### PR TITLE
[WIP] Enable Node.js Type Stripping

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -13,7 +13,7 @@ const path = require('path');
 const checkJwtTokens = require('../utility/install/checkJWTTokensExist.js');
 const { install } = require('../utility/install/installer.js');
 const chalk = require('chalk');
-const { packageJson } = require('../utility/packageUtils.js');
+const { packageJson, PACKAGE_ROOT } = require('../utility/packageUtils.js');
 const hdbUtils = require('../utility/common_utils.js');
 const installation = require('../utility/installation.ts');
 const configUtils = require('../config/configUtils.js');
@@ -77,7 +77,7 @@ async function initialize(calledByInstall = false, calledByMain = false) {
 	addUnhandleRejectionListener();
 
 	hdbLogger.suppressLogging?.(() => {
-		console.log(chalk.magenta('' + fs.readFileSync(path.join(__dirname, '../../static/ascii_logo.txt'))));
+		console.log(chalk.magenta('' + fs.readFileSync(path.join(PACKAGE_ROOT, 'static/ascii_logo.txt'))));
 	});
 	hdbLogger.debug('Checking to make sure hdb is installed');
 	if (installation.isHdbInstalled(env, hdbLogger) === false) {

--- a/config/RootConfigWatcher.ts
+++ b/config/RootConfigWatcher.ts
@@ -1,7 +1,7 @@
 import chokidar, { FSWatcher } from 'chokidar';
 import { readFile } from 'node:fs/promises';
 import { getConfigFilePath } from './configUtils.js';
-import { EventEmitter, once } from 'node:stream';
+import { EventEmitter, once } from 'node:events';
 import { parse } from 'yaml';
 
 export class RootConfigWatcher extends EventEmitter {

--- a/config/configUtils.js
+++ b/config/configUtils.js
@@ -13,13 +13,14 @@ const _ = require('lodash');
 const { handleHDBError } = require('../utility/errors/hdbError.js');
 const { HTTP_STATUS_CODES, HDB_ERROR_MSGS } = require('../utility/errors/commonErrors.js');
 const { server } = require('../server/Server.ts');
+const { PACKAGE_ROOT } = require('../utility/packageUtils.js');
 
 const { DATABASES_PARAM_CONFIG, CONFIG_PARAMS, CONFIG_PARAM_MAP } = hdbTerms;
 const UNINIT_GET_CONFIG_ERR = 'Unable to get config value because config is uninitialized';
 const CONFIG_INIT_MSG = 'Config successfully initialized';
 const BACKUP_ERR = 'Error backing up config file';
 const EMPTY_GET_VALUE = 'Empty parameter sent to getConfigValue';
-const DEFAULT_CONFIG_FILE_PATH = path.join(__dirname, '../../static', hdbTerms.HDB_DEFAULT_CONFIG_FILE);
+const DEFAULT_CONFIG_FILE_PATH = path.join(PACKAGE_ROOT, 'static', hdbTerms.HDB_DEFAULT_CONFIG_FILE);
 
 const CONFIGURE_SUCCESS_RESPONSE =
 	'Configuration successfully set. You must restart HarperDB for new config settings to take effect.';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "harper",
-	"version": "5.0.0-alpha.1",
+	"version": "5.0.0-unreleased",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "harper",
-			"version": "5.0.0-alpha.1",
+			"version": "5.0.0-unreleased",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/client-s3": "3.824.0",
@@ -87,7 +87,7 @@
 				"yaml": "2.8.0"
 			},
 			"bin": {
-				"harper": "dist/bin/harper.js"
+				"harper": "dist/bin/harperdb.js"
 			},
 			"devDependencies": {
 				"@harperdb/code-guidelines": "^0.0.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
 	"name": "harper",
 	"description": "Harper is an open-source Node.js performance platform that unifies database, cache, application, and messaging layers into one in-memory process.",
 	"version": "5.0.0-unreleased",
-	"type": "commonjs",
 	"private": true,
 	"license": "Apache-2.0",
 	"homepage": "https://harper.fast",

--- a/server/jobs/jobRunner.js
+++ b/server/jobs/jobRunner.js
@@ -130,7 +130,7 @@ async function runJob(runnerMessage, operation) {
 async function launchJobThread(job_id) {
 	log.trace('launching job thread:', job_id);
 	if (isMainThread) {
-		threadsStart.startWorker(join(__dirname, './jobProcess.js'), {
+		threadsStart.startWorker(join(PACKAGE_ROOT, './jobProcess.js'), {
 			autoRestart: false,
 			name: 'job',
 			env: { ...process.env, [hdbTerms.PROCESS_NAME_ENV_PROP]: `JOB-${job_id}` },

--- a/utility/logging/harper_logger.js
+++ b/utility/logging/harper_logger.js
@@ -43,7 +43,7 @@ const OUTPUTS = {
 const INSTALL_LOG_LOCATION = join(PACKAGE_ROOT, `logs`);
 
 // Location of default config YAML.
-const DEFAULT_CONFIG_FILE = join(__dirname, '../../../static', hdbTerms.HDB_DEFAULT_CONFIG_FILE);
+const DEFAULT_CONFIG_FILE = join(PACKAGE_ROOT, 'static', hdbTerms.HDB_DEFAULT_CONFIG_FILE);
 
 const CLOSE_LOG_FD_TIMEOUT = 10000;
 
@@ -886,4 +886,4 @@ function AuthAuditLog(username, status, type, originatingIp, requestMethod, path
 	this.path = path;
 }
 // we have to load this at the end to avoid circular dependencies problems
-const { RootConfigWatcher } = require('../../config/RootConfigWatcher');
+const { RootConfigWatcher } = require('../../config/RootConfigWatcher.ts');

--- a/utility/mount_hdb.js
+++ b/utility/mount_hdb.js
@@ -8,6 +8,7 @@ const bridge = require('../dataLayer/harperBridge/harperBridge.js');
 const systemSchema = require('../json/systemSchema.json');
 const initPaths = require('../dataLayer/harperBridge/lmdbBridge/lmdbUtility/initializePaths.js');
 const { NON_REPLICATING_SYSTEM_TABLES } = require('../resources/databases.ts');
+const { PACKAGE_ROOT } = require('./packageUtils.js');
 
 module.exports = mountHdb;
 
@@ -20,7 +21,7 @@ async function mountHdb(hdbPath) {
 	makeDirectory(path.join(hdbPath, 'log'));
 	makeDirectory(path.join(hdbPath, 'database'));
 	makeDirectory(path.join(hdbPath, 'components'));
-	copySync(path.resolve(__dirname, '../../static/README.md'), path.join(hdbPath, 'README.md'));
+	copySync(path.resolve(PACKAGE_ROOT, 'static/README.md'), path.join(hdbPath, 'README.md'));
 
 	await createLMDBTables();
 }

--- a/utility/processManagement/processManagement.js
+++ b/utility/processManagement/processManagement.js
@@ -7,7 +7,6 @@ const hdbLogger = require('../../utility/logging/harper_logger.js');
 const { onMessageFromWorkers } = require('../../server/threads/manageThreads.js');
 const fs = require('fs');
 const path = require('node:path');
-const terms = require('../hdbTerms');
 const { setTimeout: delay } = require('node:timers/promises');
 const { execFile, fork } = require('node:child_process');
 
@@ -123,7 +122,7 @@ function restartHdb() {
 function getHdbPid() {
 	const harperPath = envMangr.getHdbBasePath();
 	if (!harperPath) return;
-	const pidFile = path.join(harperPath, terms.HDB_PID_FILE);
+	const pidFile = path.join(harperPath, hdbTerms.HDB_PID_FILE);
 	const hdbPid = readPidFile(pidFile);
 	// If the pid file doesn't exist or the pid is the same as the current process, return.
 	// In a Docker container, the pid is usually 1, and so if a previous process crashed, there will still


### PR DESCRIPTION
Work in progress to enable Node.js type stripping by correctly configuring code.

High level list of to dos:
- [x] Remove `type: 'commonjs'` from `package.json` for less-strict module resolution
- [ ] Fix relative file paths to utilize `PACKAGE_ROOT` value
  - Consider some alternative for static files resolution such as moving values to JS strings
- [ ] Fix imports and requires to include file endings
- [ ] Fix file endings to match intended source module type
  - Pretty much all of our TS code is written using ESM syntax, but we've been transforming it to CJS anyways. Some early tests demonstrate that if we switch to ESM most of our code will continue to work fine. Maybe the easiest solution is to rename TS to `.mts` for now until we can get all the CJS converted over time 🤷‍♂️ 
- [ ] Ensure TypeScript build configuration is outputting appropriately
