### PR TITLE
Default to attempting to serve index.html for a path

### DIFF
--- a/server/static.ts
+++ b/server/static.ts
@@ -83,7 +83,7 @@ export function handleApplication(scope: Scope) {
 
 			// If the file is not found, try matching index
 			if (!staticFile) {
-				const index = scope.options.get(['index']) ?? false;
+				const index = scope.options.get(['index']) ?? true;
 
 				if (typeof index !== 'boolean') {
 					throw new Error(`Invalid index option: ${index}. Must be a boolean.`);


### PR DESCRIPTION
# Default to serving `index.html` when a static path is not found

## Summary

Flip the default behavior for static file handling so that when a requested path does not match a concrete asset, the server attempts to serve `index.html` if one exists.

## What changed

* When `scope.options['index']` is `undefined`, it now defaults to `true` (previously `false`).
    * This defaults the behavior to attempting to serve an `index.html` if it exists for the path.
* Consumers who want strict 404 behavior can explicitly set `index: false`.

## Motivation / Context

* It felt odd that I needed to navigate specifically to `://app:port/path/index.html` when playing around with Fabric at JSConf, hopefully this change updates to make it so that `://app:port/path` attempts to serve `index.html` if one exists for that path.

## Note for reviewers

At the time of this writing, I wasn't able to figure out how to test properly locally, so I wasn't able to test this change. I made this update based on conversations with the team, and chatting about it. But just to be safe, I want to explicitly call out: if this is going to land, please test it and confirm behavior! If I figure out how to test this before it lands, I'll come back and update this part of the description.