### PR TITLE
Suggest admin instead of HDB_ADMIN for admin username

### DIFF
--- a/integrationTests/utils/README.md
+++ b/integrationTests/utils/README.md
@@ -166,7 +166,7 @@ interface ContextWithHarper extends SuiteContext, TestContext {
 - **`harper`** - `object` - The Harper instance details
   - **`installDir`** - `string` - The absolute path to the Harper installation directory
   - **`admin`** - `object` - Admin credentials
-    - **`username`** - `string` - The Harper Admin Username (default: `'HDB_ADMIN'`)
+    - **`username`** - `string` - The Harper Admin Username (default: `'admin'`)
     - **`password`** - `string` - The Harper Admin Password (default: `'abc123'`)
   - **`httpURL`** - `string` - The HTTP URL for the Harper instance (e.g., `'http://127.0.0.2:9926'`)
   - **`operationsAPIURL`** - `string` - The Operations API URL (e.g., `'http://127.0.0.2:9925'`)

--- a/integrationTests/utils/harperLifecycle.ts
+++ b/integrationTests/utils/harperLifecycle.ts
@@ -12,7 +12,7 @@ import { getNextAvailableLoopbackAddress, releaseLoopbackAddress } from './loopb
 // Constants
 const HTTP_PORT = 9926;
 const OPERATIONS_API_PORT = 9925;
-const DEFAULT_ADMIN_USERNAME = 'HDB_ADMIN';
+const DEFAULT_ADMIN_USERNAME = 'admin';
 const DEFAULT_ADMIN_PASSWORD = 'abc123';
 const DEFAULT_STARTUP_DELAY_MS = parseInt(process.env.HARPER_INTEGRATION_TEST_STARTUP_DELAY_MS, 10) || 5000;
 
@@ -39,7 +39,7 @@ export interface ContextWithHarper extends SuiteContext, TestContext {
 		installDir: string;
 		/** Admin credentials for the Harper instance */
 		admin: {
-			/** Admin username (default: 'HDB_ADMIN') */
+			/** Admin username (default: 'admin') */
 			username: string;
 			/** Admin password (default: 'abc123') */
 			password: string;

--- a/utility/install/installer.js
+++ b/utility/install/installer.js
@@ -40,7 +40,7 @@ const HDB_EXISTS_MSG = 'It appears that HarperDB is already installed. Exiting i
 const ABORT_MSG = 'Aborting install';
 const PROCESS_HOME = os.homedir();
 const DEFAULT_HDB_ROOT = path.join(PROCESS_HOME, hdbTerms.HDB_ROOT_DIR_NAME);
-const DEFAULT_ADMIN_USERNAME = 'HDB_ADMIN';
+const DEFAULT_ADMIN_USERNAME = 'admin';
 const DEFAULT_NODE_HOSTNAME = 'localhost';
 const DEFAULT_CONFIG_MODE = 'dev';
 


### PR DESCRIPTION
For the reasons discussed here: https://harperdb.slack.com/archives/C3Z2T1QAZ/p1748884583690689

Since it's just a suggestion offered during installation we could safely make this change in 4.x too, but it seemed like something we should definitely do for 5.x+.