### PR TITLE
Don't separately listen for exit signals which exit anyways

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -48,18 +48,8 @@ function addExitListeners() {
 	if (!skipExitListeners) {
 		const removeHdbPid = () => {
 			fs.removeSync(path.join(env.get(terms.CONFIG_PARAMS.ROOTPATH), terms.HDB_PID_FILE));
-			process.exit(0);
 		};
 		process.on('exit', () => {
-			removeHdbPid();
-		});
-		process.on('SIGINT', () => {
-			removeHdbPid();
-		});
-		process.on('SIGQUIT', () => {
-			removeHdbPid();
-		});
-		process.on('SIGTERM', () => {
 			removeHdbPid();
 		});
 	}

--- a/integrationTests/utils/harperLifecycle.ts
+++ b/integrationTests/utils/harperLifecycle.ts
@@ -110,6 +110,7 @@ function runHarperCommand(args: string[], env: any, completionMessage?: string):
 		});
 
 		proc.stderr?.on('data', (data: Buffer) => {
+			console.error('error from', proc.pid, data.toString());
 			stderr += data.toString();
 		});
 		proc.on('error', (error) => {

--- a/utility/processManagement/processManagement.js
+++ b/utility/processManagement/processManagement.js
@@ -65,9 +65,6 @@ function start(procConfig, noKill = false) {
 	if (childProcesses.length === 0) {
 		if (!noKill) {
 			process.on('exit', cleanupChildrenProcesses);
-			process.on('SIGINT', cleanupChildrenProcesses);
-			process.on('SIGQUIT', cleanupChildrenProcesses);
-			process.on('SIGTERM', cleanupChildrenProcesses);
 		}
 	}
 	childProcesses.push(subprocess);


### PR DESCRIPTION
I have been having a lot of problems with integration tests never finishing because the `ctx.harper.process.kill()` signal doesn't seem to successfully terminate the process. I believe the signal is getting to the process, but somehow isn't leading to termination. Removing these signal listeners seems to fix the problem, I believe. I don't really understand why though.
Also, this PR is suggesting that stderr from the child process really should be output at the test level. Currently it is only displayed if the process actually dies with a non-zero exit code, which is very rare and not when most errors actually occur.