### PR TITLE
Don't duplicate deps in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,8 +109,6 @@
 		"chai": "^6.2.0",
 		"chai-as-promised": "^8.0.2",
 		"chai-integer": "^0.1.0",
-		"fast-glob": "^3.3.3",
-		"fs-extra": "^11.3.2",
 		"eventsource": "^3.0.5",
 		"globals": "^16.5.0",
 		"intercept-stdout": "0.1.2",


### PR DESCRIPTION
...or running `npm install --omit dev` will omit those deps, even though they're also listed in `dependencies`!

I ran a set intersection on the keys of both objects and these were the only two.