### PR TITLE
Add support for defining a package manager prefix

### DIFF
--- a/components/Application.ts
+++ b/components/Application.ts
@@ -302,7 +302,7 @@ export async function installApplication(application: Application) {
 
 		const { stderr, code } = await nonInteractiveSpawn(
 			application.name,
-			packageManager.name,
+			(application.packageManagerPrefix ? application.packageManagerPrefix + ' ' : '') + packageManager.name,
 			['install'], // All of `npm`, `yarn`, and `pnpm` support the `install` command. If we need to configure options here we may have to use some other defaults though
 			application.dirPath,
 			application.install?.timeout
@@ -339,7 +339,7 @@ export async function installApplication(application: Application) {
 	// Finally, default to running `npm install`
 	const { stderr, code } = await nonInteractiveSpawn(
 		application.name,
-		'npm',
+		(application.packageManagerPrefix ? application.packageManagerPrefix + ' ' : '') + 'npm',
 		['install', '--force'],
 		application.dirPath
 	);
@@ -370,6 +370,7 @@ export class Application {
 	install?: { command?: string; timeout?: number };
 	dirPath: string;
 	logger: any;
+	packageManagerPrefix: string; // can be used to configure a package manager prefix, specifically "sfw".
 
 	constructor({ name, payload, packageIdentifier, install }: ApplicationOptions) {
 		this.name = name;
@@ -378,6 +379,7 @@ export class Application {
 		this.install = install;
 		this.dirPath = join(getConfigValue(CONFIG_PARAMS.COMPONENTSROOT), name);
 		this.logger = logger.loggerWithTag(name);
+		this.packageManagerPrefix = getConfigValue(CONFIG_PARAMS.APPLICATIONS_PACKAGEMANAGERPREFIX);
 	}
 }
 

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -433,6 +433,7 @@ export const CONFIG_PARAMS = {
 	APPLICATIONS_CONTAINMENT: 'applications_containment',
 	APPLICATIONS_LOCKDOWN: 'applications_lockdown',
 	APPLICATIONS_DEPENDENCYCONTAINMENT: 'applications_dependencyContainment',
+	APPLICATIONS_PACKAGEMANAGERPREFIX: 'applications_packageManagerPrefix',
 	THREADS: 'threads',
 	THREADS_COUNT: 'threads_count',
 	THREADS_DEBUG: 'threads_debug',


### PR DESCRIPTION
Add a prefix so that we can enable running `sfw` for all installs in fabric.