### PR TITLE
Stop setting Server response header

### DIFF
--- a/server/http.ts
+++ b/server/http.ts
@@ -269,10 +269,6 @@ function getHTTPServer(port, secure, isOperationsServer, isMtls) {
 					response.headers = new Headers(response.headers);
 				}
 
-				if (!response.headers.has('Server')) {
-					response.headers.set('Server', 'Harper');
-				}
-
 				if (response.status === -1) {
 					// This means the HDB stack didn't handle the request, and we can then cascade the request
 					// to the server-level handler, forming the bridge to the slower legacy fastify framework that expects


### PR DESCRIPTION
So that plugins (like usageLicensing) can set it to something else.