### PR TITLE
Warn users if they are running Harper in an application folder (or root folder)

### DIFF
--- a/bin/harper.js
+++ b/bin/harper.js
@@ -118,8 +118,14 @@ async function harper() {
 					process.env.RUN_HDB_APP = appFolder;
 				}
 			} else if (fs.existsSync(hdbTerms.HDB_COMPONENT_CONFIG_FILE) || fs.existsSync('schema.graphql')) {
+				console.warn(
+					`It appears you are running Harper in an application directory, but did not specify the path. I'll go ahead and run the application for you since that's probably what you meant. But to avoid this warning in the future, run applications in the current directory like this: "harper ${service} ."`
+				);
 				process.env.RUN_HDB_APP = '.';
 			} else if (fs.existsSync(hdbTerms.HARPER_CONFIG_FILE) || fs.existsSync(hdbTerms.HDB_CONFIG_FILE)) {
+				console.warn(
+					`It appears you are running Harper in a root data directory, but did not specify the path. I'll go ahead and run Harper with its root path set to "." for you since that's probably what you meant. But to avoid this warning in the future, run it like this: "harper ${service} ."`
+				);
 				process.env.ROOTPATH = '.';
 			}
 		}


### PR DESCRIPTION
Brings https://github.com/HarperFast/harperdb/commit/01b98b344f266ba5336d1fab556e24ac9e5c7582 to this repo, but slightly modified because we now go ahead and do what the user probably meant but just warn them that there's a better way.