### PR TITLE
Refactor `deploy_component` to streaming payload using mutlipart request

### DIFF
--- a/bin/cliOperations.js
+++ b/bin/cliOperations.js
@@ -3,11 +3,11 @@
 const envMgr = require('../utility/environment/environmentManager.js');
 envMgr.initSync();
 const terms = require('../utility/hdbTerms.ts');
-const { httpRequest } = require('../utility/common_utils.js');
+const { httpRequest, buildMultipartRequest } = require('../utility/common_utils.js');
 const path = require('path');
 const fs = require('fs-extra');
 const YAML = require('yaml');
-const { packageDirectory } = require('../components/packageComponent.ts');
+const { packageDirectoryStream } = require('../components/packageComponent.ts');
 const { encode } = require('cbor-x');
 const { getHdbPid } = require('../utility/processManagement/processManagement.js');
 const { initConfig } = require('../config/configUtils.js');
@@ -69,6 +69,7 @@ const SUPPORTED_OPS = [
 const OP_ALIASES = { deploy: 'deploy_component', package: 'package_component' };
 
 module.exports = { cliOperations, buildRequest };
+
 const PREPARE_OPERATION = {
 	deploy_component: async (req) => {
 		if (req.package) {
@@ -76,8 +77,8 @@ const PREPARE_OPERATION = {
 		}
 
 		const projectPath = process.cwd();
-		req.payload = await packageDirectory(projectPath, { skip_node_modules: true, ...req });
-		req.cborEncode = true;
+		req.payloadStream = packageDirectoryStream(projectPath, { skip_node_modules: true, ...req });
+		req.multipartDeploy = true;
 		if (!req.project) req.project = path.basename(projectPath);
 	},
 };
@@ -162,11 +163,16 @@ async function cliOperations(req) {
 		if (target?.username) {
 			options.headers.Authorization = `Basic ${Buffer.from(`${target.username}:${target.password}`).toString('base64')}`;
 		}
-		if (req.cborEncode) {
+		let requestBody = req;
+		if (req.multipartDeploy) {
+			const { stream, contentType } = buildMultipartRequest(req);
+			options.headers['Content-Type'] = contentType;
+			requestBody = stream;
+		} else if (req.cborEncode) {
 			options.headers['Content-Type'] = 'application/cbor';
-			req = encode(req);
+			requestBody = encode(req);
 		}
-		let response = await httpRequest(options, req);
+		const response = await httpRequest(options, requestBody);
 
 		let responseData;
 		try {

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -122,9 +122,15 @@ export async function extractApplication(application: Application) {
 	let tarball: Readable;
 	if (application.payload) {
 		// Given a payload, create a Readable from the Buffer or string
-		tarball = Readable.from(
-			application.payload instanceof Buffer ? application.payload : Buffer.from(application.payload, 'base64')
-		);
+		if (application.payload instanceof Buffer) {
+			tarball = Readable.from(application.payload);
+		} else if (application.payload instanceof String) {
+			tarball = Readable.from(Buffer.from(application.payload, 'base64'));
+		} else if (application.payload instanceof Readable) {
+			tarball = application.payload;
+		} else {
+			throw new Error(`Invalid payload type: ${typeof application.payload}`);
+		}
 	} else {
 		// Given a package, there are a a couple options
 		const parentDirPath = dirname(application.dirPath);
@@ -381,14 +387,14 @@ export async function installApplication(application: Application) {
 
 interface ApplicationOptions {
 	name: string;
-	payload?: Buffer | string;
+	payload?: Buffer | string | Readable;
 	packageIdentifier?: string;
 	install?: { command?: string; timeout?: number };
 }
 
 export class Application {
 	name: string;
-	payload?: Buffer | string;
+	payload?: Buffer | string | Readable;
 	packageIdentifier?: string;
 	install?: { command?: string; timeout?: number };
 	dirPath: string;

--- a/components/operations.js
+++ b/components/operations.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import { Readable } from 'node:stream';
+
 const path = require('node:path');
 const { isMainThread } = require('node:worker_threads');
 const fs = require('fs-extra');
@@ -385,13 +387,11 @@ async function deployComponent(req /* FastifyRequest<{ Body?: OperationRequestBo
 	}
 
 	const payload /* Buffer | string | Readable | undefined */ =
-		typeof req.file === 'function'
-			? await req.file()
-			: req.payload
-				? Buffer.isBuffer(req.payload)
-					? req.payload
-					: Buffer.from(req.payload, 'base64')
-				: undefined;
+		req.payload instanceof Readable
+			? req.payload
+			: Buffer.isBuffer(req.payload)
+				? req.payload
+				: Buffer.from(req.payload, 'base64');
 
 	const application = new Application({
 		name: req.project,

--- a/components/operations.js
+++ b/components/operations.js
@@ -347,7 +347,7 @@ async function packageComponent(req) {
  * @param req
  * @returns {Promise<string>}
  */
-async function deployComponent(req) {
+async function deployComponent(req /* FastifyRequest<{ Body?: OperationRequestBody }> */) {
 	if (req.project) {
 		req.project = path.parse(req.project).name;
 	} else if (req.package) {
@@ -384,9 +384,18 @@ async function deployComponent(req) {
 		await configUtils.addConfig(req.project, applicationConfig);
 	}
 
+	const payload /* Buffer | string | Readable | undefined */ =
+		typeof req.file === 'function'
+			? await req.file()
+			: req.payload
+				? Buffer.isBuffer(req.payload)
+					? req.payload
+					: Buffer.from(req.payload, 'base64')
+				: undefined;
+
 	const application = new Application({
 		name: req.project,
-		payload: req.payload,
+		payload,
 		packageIdentifier: req.package,
 		install: {
 			command: req.install_command,

--- a/components/packageComponent.ts
+++ b/components/packageComponent.ts
@@ -1,6 +1,33 @@
 import { join } from 'path';
+import { Readable } from 'stream';
 import tar from 'tar-fs';
 import { createGzip } from 'node:zlib';
+
+/**
+ * Package a directory into a tarball stream.
+ * Use this when streaming is preferred to avoid buffering the entire archive in memory.
+ */
+export function packageDirectoryStream(
+	directory: string,
+	options: { skip_node_modules?: boolean; skip_symlinks?: boolean } = { skip_node_modules: false, skip_symlinks: false }
+): Readable {
+	return tar
+		.pack(directory, {
+			dereference: !options.skip_symlinks,
+			ignore: options.skip_node_modules
+				? (name: string) => {
+						return name.includes('node_modules') || name.includes(join('cache', 'webpack'));
+					}
+				: undefined,
+			map: (header) => {
+				if (header.type === 'directory') {
+					header.mode = 0o755;
+				}
+				return header;
+			},
+		})
+		.pipe(createGzip());
+}
 
 /**
  * Package a directory into a tarball, base64 encoded

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
 		"@datadog/pprof": "^5.11.1",
 		"@endo/static-module-record": "^1.1.2",
 		"@fastify/autoload": "5.10.0",
+		"@fastify/busboy": "^3.2.0",
 		"@fastify/compress": "~6.5.0",
 		"@fastify/cors": "~9.0.1",
 		"@fastify/static": "~7.0.4",

--- a/server/operationsServer.ts
+++ b/server/operationsServer.ts
@@ -12,7 +12,7 @@ import requestTimePlugin from './serverHelpers/requestTimePlugin.js';
 import guidePath from 'path';
 import { PACKAGE_ROOT } from '../utility/packageUtils.js';
 import globalSchema from '../utility/globalSchema.js';
-import commonUtils from '../utility/common_utils.js';
+import * as commonUtils from '../utility/common_utils.js';
 import * as userSchema from '../security/user.ts';
 import { server as serverRegistration, type ServerOptions } from '../server/Server.ts';
 import {
@@ -22,9 +22,9 @@ import {
 	serverErrorHandler,
 	reqBodyValidationHandler,
 } from './serverHelpers/serverHandlers.js';
-import { registerContentHandlers } from './serverHelpers/contentTypes.ts';
+import { registerContentHandlers, registerMultipartParser } from './serverHelpers/contentTypes.ts';
 import type { OperationFunctionName } from './serverHelpers/serverUtilities.ts';
-import type { ParsedSqlObject } from '../sqlTranslator/index.js';
+import type { ParsedSQLObject } from '../sqlTranslator/index.js';
 import { generateJsonApi } from '../resources/openApi.ts';
 import { Resources } from '../resources/Resources.ts';
 import { ServerError } from '../utility/errors/hdbError.js';
@@ -103,7 +103,7 @@ interface BaseOperationRequestBody {
 	password?: string;
 	payload?: string;
 	sql?: string;
-	parsedSqlObject?: ParsedSqlObject;
+	parsedSqlObject?: ParsedSQLObject;
 	[key: string]: unknown;
 }
 
@@ -163,6 +163,8 @@ function buildServer(isHttps: boolean, resources: Resources): FastifyInstance {
 		},
 	});
 	registerContentHandlers(app);
+
+	registerMultipartParser(app, REQ_MAX_BODY_SIZE);
 
 	// Add a simple health check
 	app.get('/health', () => 'Harper is running.');

--- a/server/serverHelpers/contentTypes.ts
+++ b/server/serverHelpers/contentTypes.ts
@@ -249,8 +249,8 @@ export function registerContentHandlers(app) {
 export function registerMultipartParser(app: FastifyInstance, maxBodySize: number = 1024 * 1024 * 1024) {
 	app.addContentTypeParser(
 		'multipart/form-data',
-		{ parseAs: 'buffer' },
-		(req: any, payload: Buffer, done: (err: Error | null, body?: any) => void) => {
+		{ bodyLimit: maxBodySize },
+		(req: any, payload: NodeJS.ReadableStream, done: (err: Error | null, body?: any) => void) => {
 			let body: any = null;
 			let payloadBuffer: Buffer | Readable | null = null;
 			let pending = 2;
@@ -305,7 +305,7 @@ export function registerMultipartParser(app: FastifyInstance, maxBodySize: numbe
 			busboy.on('error', (err: Error) => done(err));
 			busboy.on('finish', () => maybeDone());
 
-			Readable.from(payload).pipe(busboy);
+			payload.pipe(busboy);
 		}
 	);
 }

--- a/server/serverHelpers/contentTypes.ts
+++ b/server/serverHelpers/contentTypes.ts
@@ -252,7 +252,7 @@ export function registerMultipartParser(app: FastifyInstance, maxBodySize: numbe
 		{ parseAs: 'buffer' },
 		(req: any, payload: Buffer, done: (err: Error | null, body?: any) => void) => {
 			let body: any = null;
-			let payloadBuffer: Buffer | null = null;
+			let payloadBuffer: Buffer | Readable | null = null;
 			let pending = 2;
 			let completed = false;
 
@@ -268,7 +268,6 @@ export function registerMultipartParser(app: FastifyInstance, maxBodySize: numbe
 					return;
 				}
 				body.payload = payloadBuffer;
-				body.file = () => Promise.resolve(payloadBuffer);
 				done(null, body);
 			}
 
@@ -295,15 +294,8 @@ export function registerMultipartParser(app: FastifyInstance, maxBodySize: numbe
 					});
 					stream.on('error', (err: Error) => busboy.destroy(err));
 				} else if (name === 'payload') {
-					// TODO: pass the stream through as a prop on the body or possibly stream it to
-					// a temporary file instead of buffering the entire payload in memory
-					const chunks: Buffer[] = [];
-					stream.on('data', (chunk: Buffer) => chunks.push(chunk));
-					stream.on('end', () => {
-						payloadBuffer = Buffer.concat(chunks);
-						maybeDone();
-					});
-					stream.on('error', (err: Error) => busboy.destroy(err));
+					payloadBuffer = stream;
+					maybeDone();
 				} else {
 					stream.resume();
 					pending--;

--- a/server/serverHelpers/contentTypes.ts
+++ b/server/serverHelpers/contentTypes.ts
@@ -12,8 +12,11 @@ import * as YAML from 'yaml';
 import logger from '../../utility/logging/logger.js';
 import { Blob } from '../../resources/blob.ts';
 import { Transform } from 'json2csv';
+import type { FastifyInstance } from 'fastify';
 // TODO: Only load this if fastify is loaded
 import fp from 'fastify-plugin';
+import Busboy from '@fastify/busboy';
+
 const SERIALIZATION_BIGINT = envMgr.get(CONFIG_PARAMS.SERIALIZATION_BIGINT) !== false;
 const JSONStringify = SERIALIZATION_BIGINT ? stringify : JSON.stringify;
 const JSONParse = SERIALIZATION_BIGINT ? parse : JSON.parse;
@@ -228,6 +231,91 @@ export function registerContentHandlers(app) {
 			done(error);
 		}
 	});
+}
+
+/**
+ * Registers a content type parser for multipart requests with a Fastify app.
+ * Expects: Part 1 "request" = CBOR-encoded operation body, Part 2 "payload" (e.g. tar.gz file)
+ *
+ * Used by the `deploy_component` operation to handle large payloads..
+ *
+ * Uses @fastify/busboy directly rather than @fastify/multipart because we need req.body populated
+ * (from the CBOR-encoded first part) before preValidation runs—the multipart plugin defers parsing
+ * to the handler and does not set `req.body`.
+ *
+ * @param app - Fastify instance
+ * @param maxBodySize - Max request body size in bytes (default 1GB)
+ */
+export function registerMultipartParser(app: FastifyInstance, maxBodySize: number = 1024 * 1024 * 1024) {
+	app.addContentTypeParser(
+		'multipart/form-data',
+		{ parseAs: 'buffer' },
+		(req: any, payload: Buffer, done: (err: Error | null, body?: any) => void) => {
+			let body: any = null;
+			let payloadBuffer: Buffer | null = null;
+			let pending = 2;
+			let completed = false;
+
+			function finalize() {
+				if (completed) return;
+				completed = true;
+				if (!body) {
+					done(new Error('Invalid deploy multipart: missing "request" part'));
+					return;
+				}
+				if (!payloadBuffer) {
+					done(new Error('Invalid deploy multipart: missing "payload" part'));
+					return;
+				}
+				body.payload = payloadBuffer;
+				body.file = () => Promise.resolve(payloadBuffer);
+				done(null, body);
+			}
+
+			function maybeDone() {
+				if (--pending === 0) finalize();
+			}
+
+			const busboy = Busboy({
+				headers: req.headers,
+				limits: { fileSize: maxBodySize },
+			});
+
+			busboy.on('file', (name: string, stream: any) => {
+				if (name === 'request') {
+					const chunks: Buffer[] = [];
+					stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+					stream.on('end', () => {
+						try {
+							body = decode(Buffer.concat(chunks));
+						} catch (err) {
+							busboy.destroy(err as Error);
+						}
+						maybeDone();
+					});
+					stream.on('error', (err: Error) => busboy.destroy(err));
+				} else if (name === 'payload') {
+					// TODO: pass the stream through as a prop on the body or possibly stream it to
+					// a temporary file instead of buffering the entire payload in memory
+					const chunks: Buffer[] = [];
+					stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+					stream.on('end', () => {
+						payloadBuffer = Buffer.concat(chunks);
+						maybeDone();
+					});
+					stream.on('error', (err: Error) => busboy.destroy(err));
+				} else {
+					stream.resume();
+					pending--;
+				}
+			});
+
+			busboy.on('error', (err: Error) => done(err));
+			busboy.on('finish', () => maybeDone());
+
+			Readable.from(payload).pipe(busboy);
+		}
+	);
 }
 
 const registerFastifySerializers = fp(

--- a/server/serverHelpers/serverUtilities.ts
+++ b/server/serverHelpers/serverUtilities.ts
@@ -6,7 +6,7 @@ import delete_ from '../../dataLayer/delete.js';
 import readAuditLog from '../../dataLayer/readAuditLog.js';
 import * as user from '../../security/user.ts';
 import role from '../../security/role.js';
-import customFunctionOperations from '../../components/operations.js';
+import * as customFunctionOperations from '../../components/operations.js';
 import harperLogger from '../../utility/logging/harper_logger.js';
 import readLog from '../../utility/logging/readLog.js';
 import export_ from '../../dataLayer/export.js';

--- a/sqlTranslator/index.js
+++ b/sqlTranslator/index.js
@@ -29,7 +29,7 @@ alasqlFunctionImporter(alasql);
 let UNAUTHORIZED_RESPONSE = 403;
 const SQL_INSERT_ERROR_MSG = 'There was a problem performing this insert. Please check the logs and try again.';
 
-class ParsedSQLObject {
+export class ParsedSQLObject {
 	constructor() {
 		this.ast = undefined;
 		this.variant = undefined;

--- a/utility/common_utils.js
+++ b/utility/common_utils.js
@@ -14,6 +14,8 @@ const isNumber = require('is-number');
 const minimist = require('minimist');
 const https = require('https');
 const http = require('http');
+const { encode } = require('cbor-x');
+const { PassThrough } = require('stream');
 
 const ISO_DATE =
 	/^((\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)))$/;
@@ -823,8 +825,12 @@ function httpRequest(options, data) {
 			reject(err);
 		});
 
-		req.write(data instanceof Buffer ? data : JSON.stringify(data));
-		req.end();
+		if (data && typeof data.pipe === 'function') {
+			data.pipe(req);
+		} else {
+			req.write(data instanceof Buffer ? data : JSON.stringify(data));
+			req.end();
+		}
 	});
 }
 
@@ -865,3 +871,46 @@ function convertToMS(interval) {
 	return seconds * 1000;
 }
 const hdbErrors = require('./errors/commonErrors.js');
+
+/**
+ * Builds a streaming multipart/form-data request body: first part is CBOR-encoded
+ * request (without payload), second part is the raw payload stream (piped through).
+ * @param {object} req - Request object (payload will be removed)
+ * @returns {{ stream: import('stream').Readable, contentType: string }}
+ */
+export function buildMultipartRequest(req /* FastifyRequest<{ Body?: OperationRequestBody }> */) {
+	const boundary = `----harper-request-${Date.now().toString(36)}`;
+
+	// remove `payload` because you can't have a `payload` and a `payloadStream`
+	delete req.payload;
+
+	// remove `payloadStream` because we're streaming it instead of encoding it
+	const { payloadStream } = req;
+	delete req.payloadStream;
+
+	const requestPart = encode(req);
+	const preamble = Buffer.concat([
+		Buffer.from(`--${boundary}\r\n`, 'utf8'),
+		Buffer.from(`Content-Disposition: form-data; name="request"; filename="request.cbor"\r\n`, 'utf8'),
+		Buffer.from(`Content-Type: application/cbor\r\n\r\n`, 'utf8'),
+		Buffer.isBuffer(requestPart) ? requestPart : Buffer.from(requestPart),
+		Buffer.from('\r\n', 'utf8'),
+		Buffer.from(`--${boundary}\r\n`, 'utf8'),
+		Buffer.from(`Content-Disposition: form-data; name="payload"; filename="package.tar.gz"\r\n`, 'utf8'),
+		Buffer.from(`Content-Type: application/gzip\r\n\r\n`, 'utf8'),
+	]);
+
+	const multipartStream = new PassThrough();
+	multipartStream.write(preamble);
+	payloadStream.pipe(multipartStream, { end: false });
+	payloadStream.on('end', () => {
+		multipartStream.write(Buffer.from(`\r\n--${boundary}--\r\n`, 'utf8'));
+		multipartStream.end();
+	});
+	payloadStream.on('error', (err) => multipartStream.destroy(err));
+
+	return {
+		stream: multipartStream,
+		contentType: `multipart/form-data; boundary=${boundary}`,
+	};
+}


### PR DESCRIPTION
Update the `deploy_component` operation to support multipart requests enabling streaming the payload.

On the client side, the request is comprised of two parts: the cbor-encoded JSON data minus the `payload` followed by the stream the tarball bytes.

On the server side, the request is parsed and the first part is decoded into JSON containing everything except the `payload`, then the second part is the tarball bytes. The payload stream is set as the `payload` as a `Readable`. Luckily, a `Readable` is exactly what `extractApplication()` wants and we're good to go!

The server-side changes are backwards compatible with `payload` being encoded in the body.

I did some before and after tests to see the memory difference. I tested on clean install (e.g. nuked the ~/harper directory). Upon startup, Harper sits at a cool 300MB. Before, the client-side would consume around 2GB of memory packaging a 875MB website, then the server-side would jump to around 3GB of memory. After these changes, the client-side consumes around 100MB and the server-side consumes 1.2GB of memory. After garbage collection kicks in, the memory drops back down to 300MB.

I encourage the reviewers to scrutinize every line and pull the branch locally to test.

Fixes #187.