### PR TITLE
Expand static types

### DIFF
--- a/config-root.schema.json
+++ b/config-root.schema.json
@@ -288,7 +288,7 @@
 					"type": "boolean",
 					"description": "Attempt fail-over to different node when unreachable. Default: true"
 				},
-				"shard": { "type": "integer", "description": "Shard id for this instance." },
+				"shard": { "type": ["integer", "null"], "description": "Shard id for this instance." },
 				"logging": { "$ref": "#/definitions/loggerConfig" }
 			}
 		},

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,14 +13,19 @@ export type {
 	SubscriptionRequest,
 	RequestTargetOrId,
 } from './resources/ResourceInterface.ts';
-export { ResourceInterface } from './resources/ResourceInterface.ts';
+export type { ResourceInterface, ResourceStaticInterface } from './resources/ResourceInterface.ts';
+export type {
+	TableInterface,
+	TableInterface as Table,
+	TableStaticInterface,
+	Attribute,
+} from './resources/TableInterface.ts';
 export type { User } from './security/user.ts';
 export type { RecordObject } from './resources/RecordEncoder.ts';
 export type { IterableEventQueue } from './resources/IterableEventQueue.ts';
 export { RequestTarget } from './resources/RequestTarget.ts';
 export { server } from './server/Server';
-export { tables, databases, type Table } from './resources/databases.ts';
-export type { Attribute } from './resources/Table.ts';
+export { tables, databases } from './resources/databases.ts';
 
 export { Scope } from './components/Scope.ts';
 export type { FilesOption, FilesOptionObject } from './components/deriveGlobOptions.ts';

--- a/index.js
+++ b/index.js
@@ -22,11 +22,14 @@ exports.RequestTarget = undefined;
 exports.RequestTargetOrId = undefined;
 exports.Resource = undefined;
 exports.ResourceInterface = undefined;
+exports.ResourceStaticInterface = undefined;
 exports.Scope = undefined;
 exports.Session = undefined;
 exports.SourceContext = undefined;
 exports.SubscriptionRequest = undefined;
 exports.Table = undefined;
+exports.TableInterface = undefined;
+exports.TableStaticInterface = undefined;
 exports.User = undefined;
 
 // these are all overwritten by the globals, but need to be here so that Node's static

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
 	"bin": {
 		"harper": "./dist/bin/harper.js"
 	},
+	"exports": {
+		".": "./index.js"
+	},
+	"types": "./index.d.ts",
 	"files": [
 		"dist",
 		"bin",
@@ -110,9 +114,6 @@
 			"name": "npm",
 			"onFail": "error"
 		}
-	},
-	"exports": {
-		".": "./dist/index.js"
 	},
 	"devDependencies": {
 		"@harperdb/code-guidelines": "^0.0.6",

--- a/resources/DatabaseInterface.ts
+++ b/resources/DatabaseInterface.ts
@@ -1,0 +1,42 @@
+import type { RocksDatabase } from '@harperfast/rocksdb-js';
+import type { Database, RootDatabase } from 'lmdb';
+
+export interface LMDBDatabase extends Database {
+	customIndex?: any;
+	isIndexing?: boolean;
+	indexNulls?: boolean;
+}
+
+export interface LMDBRootDatabase extends RootDatabase {
+	auditStore?: LMDBRootDatabase;
+	databaseName?: string;
+	dbisDb?: LMDBDatabase;
+	isLegacy?: boolean;
+	needsDeletion?: boolean;
+	path?: string;
+	status?: 'open' | 'closed';
+}
+
+export interface RocksDatabaseEx extends RocksDatabase {
+	customIndex?: any;
+	env: Record<string, any>;
+	isLegacy?: boolean;
+	isIndexing?: boolean;
+	indexNulls?: boolean;
+	getEntry?: (id: string | number | (string | number)[] | Buffer, options?: any) => { value: any };
+}
+
+export interface RocksRootDatabase extends RocksDatabaseEx {
+	auditStore?: RocksDatabaseEx;
+	databaseName?: string;
+	dbisDb?: RocksDatabaseEx;
+}
+
+export type DBI =
+	| LMDBDatabase
+	| (RocksDatabase & {
+			customIndex?: any;
+			isIndexing?: boolean;
+			indexNulls?: boolean;
+			rootStore?: RocksRootDatabase;
+	  });

--- a/resources/Resource.ts
+++ b/resources/Resource.ts
@@ -1,6 +1,7 @@
+import type { ExtendedIterable } from '@harperfast/extended-iterable';
 import type { User } from '../security/user.ts';
 import type { RecordObject } from './RecordEncoder.js';
-import {
+import type {
 	ResourceInterface,
 	SubscriptionRequest,
 	Id,
@@ -314,10 +315,10 @@ export class Resource<Record extends object = any> implements ResourceInterface<
 	static coerceId(id: string): number | string {
 		return id;
 	}
-	static parseQuery(search, query) {
+	static parseQuery(search: string, query: RequestTarget): RequestTarget | Query | URLSearchParams | undefined {
 		return parseQuery(search, query);
 	}
-	static parsePath(path, context, query) {
+	static parsePath(path: string, context: Context, query: URLSearchParams) {
 		const dotIndex = path.indexOf('.');
 		if (dotIndex > -1) {
 			// handle paths of the form /path/id.property
@@ -436,7 +437,7 @@ export class Resource<Record extends object = any> implements ResourceInterface<
 		| AsyncIterable<Record & Partial<RecordObject>>
 		| Promise<AsyncIterable<Record & Partial<RecordObject>>>;
 
-	search?(target: RequestTargetOrId): AsyncIterable<Record & Partial<RecordObject>>;
+	search?(target: RequestTargetOrId): ExtendedIterable<Record & Partial<RecordObject>>;
 
 	create?(
 		newRecord: Partial<Record & RecordObject>,

--- a/resources/ResourceInterface.ts
+++ b/resources/ResourceInterface.ts
@@ -1,61 +1,104 @@
+import type { ExtendedIterable } from '@harperfast/extended-iterable';
 import type { User } from '../security/user.ts';
 import type { OperationFunctionName } from '../server/serverHelpers/serverUtilities.ts';
-import { DatabaseTransaction } from './DatabaseTransaction.ts';
-import { IterableEventQueue } from './IterableEventQueue.ts';
+import type { DatabaseTransaction } from './DatabaseTransaction.ts';
+import type { IterableEventQueue } from './IterableEventQueue.ts';
 import type { Entry, RecordObject } from './RecordEncoder.ts';
-import { RequestTarget } from './RequestTarget.ts';
+import type { RequestTarget } from './RequestTarget.ts';
 
 export interface ResourceInterface<Record extends object = any>
 	extends Partial<RecordObject>, Pick<UpdatableRecord<Record>, 'addTo' | 'subtractFrom'> {
-	allowRead(user: User, target: RequestTarget, context: Context): boolean | Promise<boolean>;
-	get?(
-		target?: RequestTargetOrId
-	):
-		| (Record & Partial<RecordObject>)
-		| Promise<Record & Partial<RecordObject>>
-		| AsyncIterable<Record & Partial<RecordObject>>
-		| Promise<AsyncIterable<Record & Partial<RecordObject>>>;
-	search?(target: RequestTarget): AsyncIterable<Record & Partial<RecordObject>>;
-
 	allowCreate(user: User, record: Promise<Record & RecordObject>, context: Context): boolean | Promise<boolean>;
-	create?(
-		newRecord: Partial<Record & RecordObject>,
-		target: RequestTargetOrId
-	): void | (Record & Partial<RecordObject>) | Promise<Record & Partial<RecordObject>>;
-	post?(
-		target: RequestTargetOrId,
-		newRecord: Partial<Record & RecordObject>
-	): void | (Record & Partial<RecordObject>) | Promise<Record & Partial<RecordObject>>;
+	create(newRecord: Partial<Record & RecordObject>, target: RequestTargetOrId): Promise<Record & Partial<RecordObject>>;
+	post(target: RequestTargetOrId, newRecord: Partial<Record & RecordObject>): Promise<Record & Partial<RecordObject>>;
+
+	allowRead(user: User, target: RequestTarget, context: Context): boolean | Promise<boolean>;
+	get(
+		target?: RequestTargetOrId
+	): Promise<Record & Partial<RecordObject>> | ExtendedIterable<Record & Partial<RecordObject>>;
+	search(target: RequestTarget): ExtendedIterable<Record & Partial<RecordObject>>;
 
 	allowUpdate(user: User, record: Promise<Record & RecordObject>, context: Context): boolean | Promise<boolean>;
-	put?(
-		record: Record & RecordObject,
-		target?: RequestTargetOrId
-	): void | (Record & Partial<RecordObject>) | Promise<void | (Record & Partial<RecordObject>)>;
-	patch?(
-		record: Partial<Record & RecordObject>,
-		target: RequestTargetOrId
-	): void | (Record & Partial<RecordObject>) | Promise<void | (Record & Partial<RecordObject>)>;
-	update?(updates: Record & RecordObject, fullUpdate: true): ResourceInterface<Record & Partial<RecordObject>>;
-	update?(
+	update(updates: Record & RecordObject, fullUpdate: true): ResourceInterface<Record & Partial<RecordObject>>;
+	update(
 		updates: Partial<Record & RecordObject>,
 		fullUpdate?: boolean
 	):
 		| ResourceInterface<Record & Partial<RecordObject>>
 		| Promise<ResourceInterface<Record & Partial<RecordObject>> | UpdatableRecord<Record & Partial<RecordObject>>>;
+	put(record: Record & RecordObject, target?: RequestTargetOrId): Promise<void>;
+	patch(record: Partial<Record & RecordObject>, target: RequestTargetOrId): Promise<void>;
 
 	allowDelete(user: User, target: RequestTarget, context: Context): boolean | Promise<boolean>;
-	delete?(target: RequestTargetOrId): boolean | Promise<boolean>;
+	delete(target: RequestTargetOrId): Promise<boolean>;
 
 	invalidate(target: RequestTargetOrId): void | Promise<void>;
 
-	publish?(target: RequestTargetOrId, record: Record, options?: any): void;
-	subscribe?(request: SubscriptionRequest): AsyncIterable<Record> | Promise<AsyncIterable<Record>>;
+	subscribe(request: SubscriptionRequest): AsyncIterable<Record> | Promise<AsyncIterable<Record>>;
+	publish(target: RequestTargetOrId, record: Record, options?: any): void;
 
 	doesExist(): boolean;
 	wasLoadedFromSource(): boolean | void;
 
 	getCurrentUser(): User | undefined;
+}
+
+export interface ResourceStaticInterface<Record extends object = any> {
+	new (identifier?: Id, source?: ResourceStaticInterface<Record>): ResourceInterface<Record>;
+
+	loadAsInstance?: boolean;
+
+	getNewId(): Id;
+	coerceId(id: Id): Id;
+
+	create(idPrefix: Id, record: Record, context: Context): Promise<Id>;
+	create(record: Record, context: Context): Promise<Id>;
+	create(idPrefix: any, record: Record, context?: Context): Promise<Id>;
+	post(target: RequestTargetOrId, dataOrContext?: Record | Context, context?: Context): Promise<Record>;
+	post(target: RequestTargetOrId, dataOrContext?: Record[] | Context, context?: Context): Promise<Record>;
+	post(target: RequestTargetOrId, dataOrContext?: Record | Context, context?: Context): Promise<Record>;
+
+	get(
+		target: RequestTargetOrId,
+		dataOrContext?: Record | Context,
+		context?: Context
+	): Promise<Record> | ExtendedIterable<Record>;
+	search(target: RequestTargetOrId, dataOrContext?: Record | Context, context?: Context): ExtendedIterable<Record>;
+	query(target: RequestTargetOrId, dataOrContext?: Record | Context, context?: Context): ExtendedIterable<Record>;
+
+	update(target: RequestTargetOrId, dataOrContext?: Record | Context, context?: Context): Promise<Record>;
+	put(target: RequestTargetOrId, dataOrContext?: Record | Context, context?: Context): Promise<void>;
+	put(target: RequestTargetOrId, dataOrContext?: Record[] | Context, context?: Context): Promise<void>;
+	patch(target: RequestTargetOrId, dataOrContext?: Record | Context, context?: Context): Promise<void>;
+
+	delete(target: RequestTargetOrId, dataOrContext?: Record | Context, context?: Context): Promise<void>;
+
+	invalidate(target: RequestTargetOrId, dataOrContext?: Record | Context, context?: Context): Promise<Record> | Record;
+
+	connect(target: RequestTargetOrId, dataOrContext?: Record | Context, context?: Context): IterableEventQueue;
+	subscribe(target: RequestTargetOrId, dataOrContext?: Record | Context, context?: Context): AsyncIterable<Record>;
+	publish(target: RequestTargetOrId, dataOrContext?: Record | Context, context?: Context): void;
+
+	copy(
+		target: RequestTargetOrId,
+		dataOrContext?: Record | Context,
+		context?: Context
+	): Promise<Record> | Record | void | Promise<void>;
+	move(
+		target: RequestTargetOrId,
+		dataOrContext?: Record | Context,
+		context?: Context
+	): Promise<Record> | Record | void | Promise<void>;
+
+	parseQuery(search: string, query: RequestTarget): RequestTarget | Query | URLSearchParams | undefined;
+	parsePath(path: string, context: Context, query: URLSearchParams): string | { property: string; id: string };
+	isCollection: boolean;
+
+	getResource(
+		target: RequestTargetOrId,
+		request: Context | SourceContext,
+		resourceOptions: any
+	): Promise<ResourceInterface> | ResourceInterface;
 }
 
 export interface Session {

--- a/resources/RocksIndexStore.ts
+++ b/resources/RocksIndexStore.ts
@@ -6,7 +6,7 @@ import {
 	type StorePutOptions,
 	type StoreRemoveOptions,
 } from '@harperfast/rocksdb-js';
-import { Id } from './ResourceInterface.ts';
+import type { Id } from './ResourceInterface.ts';
 import { MAXIMUM_KEY } from 'ordered-binary';
 
 declare module '@harperfast/rocksdb-js' {

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5,12 +5,10 @@
  */
 
 import { CONFIG_PARAMS, OPERATIONS_ENUM, SYSTEM_TABLE_NAMES, SYSTEM_SCHEMA_NAME } from '../utility/hdbTerms.ts';
-import { type Database } from 'lmdb';
 import { getIndexedValues } from '../utility/lmdb/commonUtility.js';
 import lodash from 'lodash';
 import { ExtendedIterable, SKIP } from '@harperfast/extended-iterable';
 import type {
-	ResourceInterface,
 	SubscriptionRequest,
 	Id,
 	Context,
@@ -19,6 +17,14 @@ import type {
 	SubSelect,
 	RequestTargetOrId,
 } from './ResourceInterface.ts';
+import type {
+	TableInterface,
+	TableStaticInterface,
+	Attribute,
+	ExpirationOptions,
+	IntermediateSourceOptions,
+	ExpirationParam,
+} from './TableInterface.ts';
 import type { User } from '../security/user.ts';
 import lmdbProcessRows from '../dataLayer/harperBridge/lmdbBridge/lmdbUtility/lmdbProcessRows.js';
 import { Resource, transformForSelect } from './Resource.ts';
@@ -69,21 +75,6 @@ import { contentTypes } from '../server/serverHelpers/contentTypes';
 const { sortBy } = lodash;
 const { validateAttribute } = lmdbProcessRows;
 
-export type Attribute = {
-	name: string;
-	type: 'ID' | 'Int' | 'Float' | 'Long' | 'String' | 'Boolean' | 'Date' | 'Bytes' | 'Any' | 'BigInt' | 'Blob' | string;
-	assignCreatedTime?: boolean;
-	assignUpdatedTime?: boolean;
-	nullable?: boolean;
-	expiresAt?: boolean;
-	isPrimaryKey?: boolean;
-	indexed?: unknown;
-	relationship?: unknown;
-	computed?: unknown;
-	properties?: Array<Attribute>;
-	elements?: Attribute;
-};
-
 type MaybePromise<T> = T | Promise<T>;
 
 const NULL_WITH_TIMESTAMP = new Uint8Array(9);
@@ -105,23 +96,6 @@ const FULL_PERMISSIONS = {
 	delete: true,
 	isSuperUser: true,
 };
-export interface Table {
-	primaryStore: Database;
-	auditStore: Database;
-	indices: {};
-	databasePath: string;
-	tableName: string;
-	databaseName: string;
-	attributes: Attribute[];
-	primaryKey: string;
-	splitSegments?: boolean;
-	replicate?: boolean;
-	subscriptions: Map<any, Function[]>;
-	expirationMS: number;
-	indexingOperations?: Promise<void>;
-	source?: new () => ResourceInterface;
-	Transaction: ReturnType<typeof makeTable>;
-}
 type ResidencyDefinition = number | string[] | void;
 
 /**
@@ -129,7 +103,7 @@ type ResidencyDefinition = number | string[] | void;
  * Instances of the returned class are Resource instances, intended to provide a consistent view or transaction of the table
  * @param options
  */
-export function makeTable(options) {
+export function makeTable(options): TableStaticInterface {
 	const {
 		primaryKey,
 		indices,
@@ -213,7 +187,7 @@ export function makeTable(options) {
 			return this.addTo(property, -value);
 		}
 	}
-	class TableResource<Record extends object = any> extends Resource<Record> {
+	class TableResource<Record extends object = any> extends Resource<Record> implements TableInterface<Record> {
 		#record: any; // the stored/frozen record from the database and stored in the cache (should not be modified directly)
 		#changes: any; // the changes to the record that have been made (should not be modified directly)
 		#version?: number; // version of the record
@@ -256,7 +230,10 @@ export function makeTable(options) {
 		 * @param options
 		 * @returns
 		 */
-		static sourcedFrom(source, options) {
+		static sourcedFrom<Record extends object = any>(
+			source: TableInterface<Record> & TableStaticInterface<Record>,
+			options?: ExpirationOptions & IntermediateSourceOptions
+		) {
 			// define a source for retrieving invalidated entries for caching purposes
 			if (options) {
 				this.sourceOptions = options;
@@ -623,7 +600,7 @@ export function makeTable(options) {
 				});
 			}
 		}
-		static getNewId(): any {
+		static getNewId(): Id {
 			const type = primaryKeyAttribute?.type;
 			// the default Resource behavior is to return a GUID, but for a table we can return incrementing numeric keys if the type is (or can be) numeric
 			if (type === 'String' || type === 'ID') return super.getNewId();
@@ -797,7 +774,7 @@ export function makeTable(options) {
 		 * @param expirationTime Time in seconds until records expire (are stale)
 		 * @param evictionTime Time in seconds until records are evicted (removed)
 		 */
-		static setTTLExpiration(expiration: number | { expiration: number; eviction?: number; scanInterval?: number }) {
+		static setTTLExpiration(expiration: ExpirationParam) {
 			// we set up a timer to remove expired entries. we only want the timer/reaper to run in one thread,
 			// so we use the first one
 			if (typeof expiration === 'number') {
@@ -930,10 +907,15 @@ export function makeTable(options) {
 		 * This retrieves the data of this resource.
 		 * @param target - If included, is an identifier/query that specifies the requested target to retrieve and query
 		 */
-		get(target: RequestTargetOrId): Record | AsyncIterable<Record> | Promise<Record | AsyncIterable<Record>>;
+		get(target: RequestTargetOrId): ExtendedIterable<Record> | Promise<Record>;
 		get(
 			target?: RequestTargetOrId
-		): TableResource<Record> | undefined | Record | AsyncIterable<Record> | Promise<Record | AsyncIterable<Record>> {
+		):
+			| TableResource<Record>
+			| undefined
+			| Record
+			| ExtendedIterable<Record>
+			| Promise<Record | ExtendedIterable<Record>> {
 			const constructor: Resource = this.constructor;
 			if (typeof target === 'string' && constructor.loadAsInstance !== false) return this.getProperty(target);
 			if (isSearchTarget(target)) {

--- a/resources/TableInterface.ts
+++ b/resources/TableInterface.ts
@@ -1,0 +1,125 @@
+import type { Database } from 'lmdb';
+import type { Context, Id, ResourceInterface, ResourceStaticInterface } from './ResourceInterface.ts';
+import type { DBI } from './DatabaseInterface.ts';
+
+export interface TableInterface<Record extends object = any> extends ResourceInterface<Record> {
+	attributes: Attribute[];
+	auditStore: Database;
+	databaseName: string;
+	databasePath: string;
+	expirationMS: number;
+	indexingOperations?: Promise<void>;
+	indices: {};
+	origin?: string;
+	primaryKey: string;
+	primaryStore: Database;
+	replicate?: boolean;
+	schemaVersion?: number;
+	source?: new () => ResourceInterface;
+	splitSegments?: boolean;
+	tableName: string;
+	Transaction: TableInterface;
+
+	getExpiresAt(): number;
+	getUpdatedTime(): number;
+}
+
+export interface Attribute {
+	assignCreatedTime?: boolean;
+	assignUpdatedTime?: boolean;
+	computed?: unknown;
+	dbi: DBI;
+	elements?: Attribute;
+	expiresAt?: boolean;
+	indexed?: unknown;
+	indexingPID?: number;
+	isPrimaryKey?: boolean;
+	key: string;
+	lastIndexedKey: string;
+	name: string;
+	nullable?: boolean;
+	properties?: Array<Attribute>;
+	relationship?: unknown;
+	resolve?: (id: Id) => any;
+	type: 'ID' | 'Int' | 'Float' | 'Long' | 'String' | 'Boolean' | 'Date' | 'Bytes' | 'Any' | 'BigInt' | 'Blob' | string;
+}
+
+export interface Index {
+	clear: () => Promise<void>;
+	clearAsync?: () => void;
+	customIndex?: {
+		index: (id: Id, value: unknown, existingValue?: unknown, options?: unknown) => void;
+		propertyResolver: (value: unknown, context: Context, entry: unknown) => unknown;
+	};
+	drop: () => void;
+	getRange: (options: { start: boolean; values: boolean; end: number; snapshot: boolean }) => void;
+	getValues: (key: Id) => Id[];
+	indexNulls: boolean;
+	isIndexing: boolean;
+	prefetch?: (valuesToPrefetch, noop) => void;
+	put: (valueToAdd, id: Id, options?: unknown) => unknown;
+	remove: (valueToRemove, id: Id, options?: unknown) => void;
+}
+
+export interface TableStaticInterface<Record extends object = any> extends ResourceStaticInterface<Record> {
+	new (identifier?: Id, source?: TableInterface<Record> & TableStaticInterface<Record>): TableInterface<Record>;
+
+	attributes: Attribute[];
+	audit: boolean;
+	auditStore: Database;
+	createdTimeProperty: Attribute;
+	databaseName: string;
+	databasePath: string;
+	dbisDB: DBI;
+	expirationMS: number;
+	getResidencyById: (id: Id) => number | void;
+	indexingOperation?: Promise<void>;
+	indices: Map<string, Index>;
+	intermediateSource: boolean;
+	name: string;
+	origin?: string;
+	primaryKey: string;
+	primaryStore: Database;
+	propertyResolvers: any;
+	replicate: boolean;
+	schemaDefined: boolean;
+	schemaVersion?: number;
+	sealed: boolean;
+	source?: TableInterface<Record> & TableStaticInterface<Record>;
+	sourceOptions?: ExpirationOptions & IntermediateSourceOptions;
+	splitSegments: boolean;
+	tableId: number;
+	tableName: string;
+	updatedTimeProperty: Attribute;
+	userResolvers: any;
+
+	cleanup(): void;
+	clear(): unknown;
+	dropTable(): Promise<void>;
+	evict(id: Id, existingRecord: unknown, existingVersion: unknown): unknown;
+	operation(operation: unknown, context: Context): unknown;
+
+	addAttributes(attributesToAdd: Attribute[]): Promise<void>;
+	updatedAttributes(): void;
+	coerceId(id: Id): Id;
+	enableAuditing(value?: boolean): void;
+	getAuditSize(): number;
+	getRecordCount(options?: {
+		exactCount?: boolean;
+	}): Promise<number | { recordCount: number; estimatedRange: number[] }>;
+	getResource(target: any, request: Context, resourceOptions: any): Promise<TableInterface>;
+	getSize(): number;
+	getNewId(): Id;
+	isCaching(): boolean;
+	getStorageStats(): { available: number; free: number; size: number };
+	removeAttributes(names: string[]): Promise<void>;
+	setTTLExpiration(expiration: ExpirationParam): void;
+	sourcedFrom(
+		source: TableInterface<Record> & TableStaticInterface<Record>,
+		options?: ExpirationOptions & IntermediateSourceOptions
+	): void;
+}
+
+export type ExpirationParam = number | ExpirationOptions;
+export type ExpirationOptions = { expiration: number; eviction?: number; scanInterval?: number };
+export type IntermediateSourceOptions = { intermediateSource?: boolean };

--- a/resources/analytics/write.ts
+++ b/resources/analytics/write.ts
@@ -1,7 +1,8 @@
+import type { TableInterface } from '../TableInterface.ts';
 import { parentPort, threadId } from 'worker_threads';
 import { onMessageByType } from '../../server/threads/manageThreads.js';
 import { getDatabases, table } from '../databases.ts';
-import type { Databases, Table, Tables } from '../databases.ts';
+import type { Databases, Tables } from '../databases.ts';
 import harperLogger from '../../utility/logging/harper_logger.js';
 import { stat } from 'node:fs/promises';
 const { getLogFilePath, forComponent } = harperLogger;
@@ -246,7 +247,7 @@ function getHostNodeId(hostname: string) {
 	return nodeId;
 }
 
-function storeMetric(table: Table, metric: Metric) {
+function storeMetric(table: TableInterface, metric: Metric) {
 	const nodeId = getHostNodeId(server.hostname);
 	const metricValue = {
 		id: [getNextMonotonicTime(), nodeId],
@@ -297,7 +298,7 @@ export function diffResourceUsage(lastResourceUsage: ResourceUsage, resourceUsag
 
 /** storeTableSizeMetrics returns the cumulative size of the tables
  */
-function storeTableSizeMetrics(analyticsTable: Table, dbName: string, tables: Tables): number {
+function storeTableSizeMetrics(analyticsTable: TableInterface, dbName: string, tables: Tables): number {
 	let dbUsedSize = 0;
 	for (const [tableName, table] of Object.entries(tables)) {
 		const fullTableName = `${dbName}.${tableName}`;
@@ -315,7 +316,7 @@ function storeTableSizeMetrics(analyticsTable: Table, dbName: string, tables: Ta
 	return dbUsedSize;
 }
 
-function storeDBSizeMetrics(analyticsTable: Table, databases: Databases) {
+function storeDBSizeMetrics(analyticsTable: TableInterface, databases: Databases) {
 	for (const [db, tables] of Object.entries(databases)) {
 		try {
 			const [firstTable] = Object.values(tables);
@@ -360,7 +361,7 @@ function storeDBSizeMetrics(analyticsTable: Table, databases: Databases) {
 	}
 }
 
-function storeVolumeMetrics(analyticsTable: Table, databases: Databases) {
+function storeVolumeMetrics(analyticsTable: TableInterface, databases: Databases) {
 	for (const [db, tables] of Object.entries(databases)) {
 		try {
 			const [firstTable] = Object.values(tables);
@@ -594,7 +595,7 @@ async function cleanup(AnalyticsTable, expiration) {
 const RAW_EXPIRATION = 3600000;
 const AGGREGATE_EXPIRATION = 31536000000; // one year
 
-let RawAnalyticsTable: Table;
+let RawAnalyticsTable: TableInterface;
 function getRawAnalyticsTable() {
 	return (
 		RawAnalyticsTable ||
@@ -619,7 +620,7 @@ function getRawAnalyticsTable() {
 	);
 }
 
-let AnalyticsTable: Table;
+let AnalyticsTable: TableInterface;
 function getAnalyticsTable() {
 	return (
 		AnalyticsTable ||

--- a/resources/dataLoader.ts
+++ b/resources/dataLoader.ts
@@ -6,7 +6,7 @@ import { getWorkerIndex } from '../server/threads/manageThreads';
 import { HTTP_STATUS_CODES } from '../utility/errors/commonErrors.js';
 import { ClientError } from '../utility/errors/hdbError.js';
 import harperLogger from '../utility/logging/harper_logger.js';
-import { Attribute } from './Table.ts';
+import type { Attribute, TableInterface } from './TableInterface.ts';
 import { FileEntry } from '../components/EntryHandler.ts';
 
 const dataLoaderLogger = harperLogger.forComponent('dataLoader');
@@ -15,7 +15,7 @@ const dataLoaderLogger = harperLogger.forComponent('dataLoader');
 const DATA_LOADER_HASH_TABLE = 'hdb_dataloader_hash';
 
 /** Lazy-initialized cache for the hash tracking table */
-let _hashTrackingTable: ReturnType<typeof table>;
+let _hashTrackingTable: TableInterface;
 
 /**
  * Computes a deterministic hash of a record's content for tracking data file changes.
@@ -42,7 +42,7 @@ export function computeRecordHash(record: Record<string, any>): string {
  * Gets or creates the hash tracking table in the system database.
  * Lazy-initializes the table on first access.
  */
-function getHashTrackingTable(databasesRef: Databases) {
+function getHashTrackingTable(databasesRef: Databases): TableInterface {
 	// Always check databasesRef first (important for testing with mocks)
 	if (databasesRef.system && databasesRef.system[DATA_LOADER_HASH_TABLE]) {
 		return databasesRef.system[DATA_LOADER_HASH_TABLE];

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1,7 +1,8 @@
 import { EventEmitter } from 'node:events';
+import type { DBI, LMDBRootDatabase, RocksDatabaseEx, RocksRootDatabase } from './DatabaseInterface.ts';
 import { initSync, getHdbBasePath, get as envGet } from '../utility/environment/environmentManager.js';
 import { INTERNAL_DBIS_NAME } from '../utility/lmdb/terms.js';
-import { open, compareKeys, type Database, type RootDatabase } from 'lmdb';
+import { open, compareKeys } from 'lmdb';
 import { join, extname, basename } from 'path';
 import { existsSync, readdirSync, readFileSync, mkdirSync } from 'node:fs';
 import { unlink } from 'node:fs/promises';
@@ -31,6 +32,7 @@ import { totalmem } from 'node:os';
 import { RocksIndexStore } from './RocksIndexStore.ts';
 import { when } from '../utility/when.ts';
 import { isProcessRunning } from '../utility/processManagement/processManagement.js';
+import type { Attribute, TableInterface, TableStaticInterface } from './TableInterface.ts';
 
 function createOpenDBIObject(dupSort = false, isPrimary = false) {
 	return new OpenDBIObject(dupSort, isPrimary);
@@ -52,13 +54,8 @@ export const NON_REPLICATING_SYSTEM_TABLES = [
 	'hdb_info',
 ];
 
-export type Table = ReturnType<typeof makeTable> & {
-	indexingOperation?: any;
-	origin?: string;
-	schemaVersion?: number;
-};
 export interface Tables {
-	[tableName: string]: Table;
+	[tableName: string]: TableInterface & TableStaticInterface;
 	[DEFINED_TABLES]?: Set<string>;
 }
 export interface Databases {
@@ -66,35 +63,6 @@ export interface Databases {
 }
 
 // note: technically `Database` is either a `LMDBStore` or a `CachingStore`
-interface LMDBDatabase extends Database {
-	customIndex?: any;
-	isIndexing?: boolean;
-	indexNulls?: boolean;
-}
-interface LMDBRootDatabase extends RootDatabase {
-	auditStore?: LMDBRootDatabase;
-	databaseName?: string;
-	dbisDb?: LMDBDatabase;
-	isLegacy?: boolean;
-	needsDeletion?: boolean;
-	path?: string;
-	status?: 'open' | 'closed';
-}
-
-interface RocksDatabaseEx extends RocksDatabase {
-	customIndex?: any;
-	env: Record<string, any>;
-	isLegacy?: boolean;
-	isIndexing?: boolean;
-	indexNulls?: boolean;
-	getEntry?: (id: string | number | (string | number)[] | Buffer, options?: any) => { value: any };
-}
-
-interface RocksRootDatabase extends RocksDatabaseEx {
-	auditStore?: RocksDatabaseEx;
-	databaseName?: string;
-	dbisDb?: RocksDatabaseEx;
-}
 
 export type RootDatabaseKind = LMDBRootDatabase | RocksRootDatabase;
 
@@ -803,19 +771,19 @@ function openIndex(dbiKey: string, rootStore: RootDatabaseKind, attribute: any) 
 
 /**
  * This can be called to ensure that the specified table exists and if it does not exist, it should be created.
- * @param tableName
- * @param databaseName
- * @param customPath
- * @param expiration
- * @param eviction
- * @param scanInterval
- * @param attributes
- * @param audit
- * @param sealed
- * @param splitSegments
- * @param replicate
+ * @param tableDefinition.tableName
+ * @param tableDefinition.databaseName
+ * @param tableDefinition.customPath
+ * @param tableDefinition.expiration
+ * @param tableDefinition.eviction
+ * @param tableDefinition.scanInterval
+ * @param tableDefinition.attributes
+ * @param tableDefinition.audit
+ * @param tableDefinition.sealed
+ * @param tableDefinition.splitSegments
+ * @param tableDefinition.replicate
  */
-export function table<TableResourceType>(tableDefinition: TableDefinition): TableResourceType {
+export function table<TableResourceType = TableInterface>(tableDefinition: TableDefinition): TableResourceType {
 	let {
 		table: tableName,
 		database: databaseName,
@@ -1129,7 +1097,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 }
 const MAX_OUTSTANDING_INDEXING = 1000;
 const MIN_OUTSTANDING_INDEXING = 10;
-async function runIndexing(Table, attributes, indicesToRemove) {
+async function runIndexing(Table: TableStaticInterface, attributes: Attribute[], indicesToRemove: DBI[]) {
 	try {
 		logger.info(`Indexing ${Table.tableName} attributes`, attributes);
 		await signalling.signalSchemaChange(


### PR DESCRIPTION
I did a few things here:
1. I fixed the schema description for `shard` in the config-root.schema.json
2. I added interfaces describing the methods and stuff we have on tables and resources, shuffling things around a little bit to facilitate that

Why? Well, it will more easily describe our tables and resources for consumers. I shifted the `tables` and `databases` to point people at these interfaces instead of at the return value of makeTable. These are a lot easier for IDEs, agents, and humans to read as a result. It will also let people guard their types when using static methods themselves.

Here's the question, though: what _should_ be described in the interfaces for statics? What shouldn't be described, because its an internal implementation detail?