### PR TITLE
Improve integration test settings

### DIFF
--- a/integrationTests/utils/harperLifecycle.ts
+++ b/integrationTests/utils/harperLifecycle.ts
@@ -251,7 +251,7 @@ export async function startHarper(ctx: ContextWithHarper, options?: SetupHarperO
 	const harperProcess = await runHarperCommand({
 		args: [
 			`--ROOTPATH=${installDir}`,
-			'--DEFAULTS_MODE=prod',
+			'--DEFAULTS_MODE=dev',
 			`--HDB_ADMIN_USERNAME=${DEFAULT_ADMIN_USERNAME}`,
 			`--HDB_ADMIN_PASSWORD=${DEFAULT_ADMIN_PASSWORD}`,
 			'--THREADS_COUNT=1',
@@ -260,6 +260,7 @@ export async function startHarper(ctx: ContextWithHarper, options?: SetupHarperO
 			`--HTTP_PORT=${loopbackAddress}:${HTTP_PORT}`,
 			`--OPERATIONSAPI_NETWORK_PORT=${loopbackAddress}:${OPERATIONS_API_PORT}`,
 			'--LOGGING_LEVEL=debug',
+			'--LOGGING_STDSTREAMS=false',
 			'--HARPER_SET_CONFIG=' + JSON.stringify(config),
 		],
 		env: options?.env || {},


### PR DESCRIPTION
Consolidate the exit handler, log non-zero exit codes, and don't double log stderr (in hdb.log and stderr.log).