### PR TITLE
Use the SLACK_BOT_TOKEN to send Slack notifications

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: slackapi/slack-github-action@v2
         with:
           method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_KEY }}
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {
               "channel": "#development-ci",
@@ -106,7 +106,7 @@ jobs:
       - uses: slackapi/slack-github-action@v2
         with:
           method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_KEY }}
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {
               "channel": "#development-ci",
@@ -147,7 +147,7 @@ jobs:
       - uses: slackapi/slack-github-action@v2
         with:
           method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_KEY }}
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {
               "channel": "#development-ci",

--- a/.github/workflows/notify-release-published.yaml
+++ b/.github/workflows/notify-release-published.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: slackapi/slack-github-action@v2
         with:
           method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_KEY }}
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {
               "channel": "#development-ci",

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -99,7 +99,7 @@ jobs:
         uses: slackapi/slack-github-action@v2
         with:
           method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_KEY }}
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {
               "channel": "#development-ci",
@@ -140,7 +140,7 @@ jobs:
       - uses: slackapi/slack-github-action@v2
         with:
           method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_KEY }}
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {
               "channel": "#development-ci",

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -92,7 +92,7 @@ jobs:
         uses: slackapi/slack-github-action@v2
         with:
           method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_KEY }}
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {
               "channel": "#development-ci",
@@ -139,7 +139,7 @@ jobs:
       - uses: slackapi/slack-github-action@v2
         with:
           method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_KEY }}
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {
               "channel": "#development-ci",


### PR DESCRIPTION
Fixes `SlackError: Missing input! A token must be provided to use the method decided.` error.

Ref: https://github.com/HarperFast/harper/actions/runs/23010989936/job/66821135878