### PR TITLE
Properly honor the async option

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -2239,11 +2239,12 @@ export function makeTable(options) {
 				entries = transformToEntries(entries, select, context, readTxn, null);
 				let ordered;
 				// if we are doing post-ordering, we need to get records first, then sort them
-				results.iterate = function () {
+				results.iterate = function (options: { async: boolean }) {
 					let sortedArrayIterator: IterableIterator<any>;
-					const dbIterator = entries[Symbol.asyncIterator]
-						? entries[Symbol.asyncIterator]()
-						: entries[Symbol.iterator]();
+					const dbIterator =
+						options?.async && entries[Symbol.asyncIterator]
+							? entries[Symbol.asyncIterator]()
+							: entries[Symbol.iterator]();
 					let dbDone: boolean;
 					const dbOrderedAttribute = sort.dbOrderedAttribute;
 					let enqueuedEntryForNextGroup: any;
@@ -2357,7 +2358,10 @@ export function makeTable(options) {
 				};
 				applySortingOnSelect(sort);
 			} else {
-				results.iterate = (entries[Symbol.asyncIterator] || entries[Symbol.iterator]).bind(entries);
+				results.iterate = (options: { async: boolean }) => {
+					if (options?.async && entries[Symbol.asyncIterator]) return entries[Symbol.asyncIterator]();
+					else return entries[Symbol.iterator]();
+				};
 				results = results.map(function (entry) {
 					try {
 						// because this is a part of a stream of results, we will often be continuing to iterate over the results when there are errors,

--- a/unitTests/resources/query.test.js
+++ b/unitTests/resources/query.test.js
@@ -199,6 +199,20 @@ describe('Querying through Resource API', () => {
 		}
 		assert.equal(results.length, 1);
 	});
+	it('Ensure that we are yielding when querying data in a table', async function () {
+		let results = [];
+		let yielded = false;
+		setImmediate(() => {
+			yielded = true;
+		});
+		for await (let record of QueryTable.search({
+			conditions: [{ attribute: 'id', comparator: 'less_than_equal', value: 'id-3' }],
+		})) {
+			results.push(record);
+		}
+		assert(yielded);
+		assert.equal(results.length, 24);
+	});
 	it('Query data in a table with non-indexed property', async function () {
 		let results = [];
 		for await (let record of QueryTable.search({
@@ -342,7 +356,8 @@ describe('Querying through Resource API', () => {
 
 		it('Query relational data in a table with many-to-one', async function () {
 			let results = [];
-			for await (let record of QueryTable.search({
+			// do this test with sync iteration to verify it is possible
+			for (let record of QueryTable.search({
 				conditions: [{ attribute: 'id', value: 'id-1' }],
 				select: ['id', 'related', 'name'],
 			})) {


### PR DESCRIPTION
This should properly honor the async option (or lack thereof) in iteration to maintain back-compat for sync iteration. We have previously supported sync and async iteration of query results, although we had been failing to properly do async yielding with primary key queries. This was addressed with https://github.com/HarperFast/harperdb/pull/3087, but this leads to a regression in supporting sync iteration.
(mirrors ticket in harperdb)