### PR TITLE
Update rocksdb-js to 0.1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
 		"@fastify/cors": "~9.0.1",
 		"@fastify/static": "~7.0.4",
 		"@harperfast/extended-iterable": "^1.0.1",
-		"@harperfast/rocksdb-js": "^0.1.11",
+		"@harperfast/rocksdb-js": "^0.1.12",
 		"@turf/area": "6.5.0",
 		"@turf/boolean-contains": "6.5.0",
 		"@turf/boolean-disjoint": "6.5.0",


### PR DESCRIPTION
Update to rocksdb-js v0.1.12. This release includes the following juicy fixes:

- Resolve transaction log data races and position tracking bugs
- Check entry before getting its descriptor
- Ensure that we do not start at position 0 in a log, always start after the WOOF header

Release notes: https://github.com/HarperFast/rocksdb-js/releases/tag/v0.1.12