### PR TITLE
Make TLS (re)loading to be explicitly sync

### DIFF
--- a/security/keys.js
+++ b/security/keys.js
@@ -459,7 +459,7 @@ async function getCertAuthority() {
 	let match;
 	for (let cert of allCerts) {
 		if (!cert.is_authority) continue;
-		const matchingPrivateKey = await getPrivateKeyByName(cert.private_key_name);
+		const matchingPrivateKey = getPrivateKeyByName(cert.private_key_name);
 		if (cert.private_key_name && matchingPrivateKey) {
 			const keyCheck = new X509Certificate(cert.certificate).checkPrivateKey(createPrivateKey(matchingPrivateKey));
 			if (keyCheck) {
@@ -724,7 +724,7 @@ function createTLSSelector(type, mtlsOptions) {
 			server.secureContextsListeners = [];
 		}
 		return (SNICallback.ready = new Promise((resolve, reject) => {
-			async function updateTLS() {
+			function updateTLS() {
 				try {
 					secureContexts.clear();
 					caCerts.clear();
@@ -733,7 +733,7 @@ function createTLSSelector(type, mtlsOptions) {
 						resolve();
 						return;
 					}
-					for await (const cert of databases.system.hdb_certificate.search([])) {
+					for (const cert of databases.system.hdb_certificate.search([])) {
 						const certificate = cert.certificate;
 						const certParsed = new X509Certificate(certificate);
 						if (cert.is_authority) {
@@ -742,7 +742,7 @@ function createTLSSelector(type, mtlsOptions) {
 						}
 					}
 
-					for await (const cert of databases.system.hdb_certificate.search([])) {
+					for (const cert of databases.system.hdb_certificate.search([])) {
 						try {
 							if (cert.is_authority) {
 								continue;
@@ -751,7 +751,7 @@ function createTLSSelector(type, mtlsOptions) {
 							// prefer operations certificates for operations API
 							if (cert.uses?.includes(type)) quality += 1;
 
-							const private_key = await getPrivateKeyByName(cert.private_key_name);
+							const private_key = getPrivateKeyByName(cert.private_key_name);
 
 							let certificate = cert.certificate;
 							const certParsed = new X509Certificate(certificate);
@@ -875,10 +875,10 @@ function createTLSSelector(type, mtlsOptions) {
 	}
 }
 
-async function getPrivateKeyByName(private_key_name) {
+function getPrivateKeyByName(private_key_name) {
 	const private_key = privateKeys.get(private_key_name);
 	if (!private_key && private_key_name) {
-		return await fs.readFile(
+		return fs.readFileSync(
 			path.join(envManager.get(CONFIG_PARAMS.ROOTPATH), hdbTerms.LICENSE_KEY_DIR_NAME, private_key_name),
 			'utf8'
 		);


### PR DESCRIPTION
The change/fix to yield asynchronously on search query (https://github.com/HarperFast/harper/blob/main/resources/search.ts#L349) had ramifications for making downstream consumers actually execute across multiple macro event turns. This led to a regression in using `createTLSSelector` for replication, specifically it was possible to access the `secureContexts` _while_ it was being loaded; after the map was cleared, but before values were added to it. It would be possible to continue to do this async, and replace the map at the end, but I didn't want to continue to fight the async and this seems simpler, more deterministic, and really the TLS reloading should be fast enough that sync is probably appropraite.