### PR TITLE
Update `tar-fs` to resolve high-severity vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
 		"stream-chain": "2.2.5",
 		"stream-json": "1.9.1",
 		"systeminformation": "5.27.11",
-		"tar-fs": "3.0.9",
+		"tar-fs": "^3.1.2",
 		"ulidx": "0.5.0",
 		"uuid": "11.1.0",
 		"validate.js": "0.13.1",


### PR DESCRIPTION
`tar-fs` 3.0.0 - 3.1.0 have a **high** severity vulnerability:

- tar-fs has a symlink validation bypass if destination directory is predictable with a specific tarball - https://github.com/advisories/GHSA-vj76-c3g6-qr5v
fix available via `npm audit fix --force`