### PR TITLE
Update `lodash` to resolve moderate-severity vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
 		"jsonata": "1.8.7",
 		"jsonwebtoken": "9.0.3",
 		"lmdb": "3.5.2",
-		"lodash": "4.17.21",
+		"lodash": "^4.17.23",
 		"mathjs": "11.12.0",
 		"micromatch": "^4.0.8",
 		"minimist": "1.2.8",


### PR DESCRIPTION
`lodash` 4.0.0 - 4.17.21 have a **moderate** severity vulnerability:

- Lodash has Prototype Pollution Vulnerability in `_.unset` and `_.omit` functions - https://github.com/advisories/GHSA-xxjr-mmjv-4gpg