### PR TITLE
Update `@aws-sdk/client-s3` to resolve critical-severity vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
 		"why-is-node-still-running": "^1.0.0"
 	},
 	"dependencies": {
-		"@aws-sdk/client-s3": "3.964.0",
+		"@aws-sdk/client-s3": "^3.1012.0",
 		"@aws-sdk/lib-storage": "3.964.0",
 		"@datadog/pprof": "^5.11.1",
 		"@endo/static-module-record": "^1.1.2",


### PR DESCRIPTION
`@aws-sdk/client-s3` has several dependencies which have vulnerabilities, however the most important one is the `fast-xml-parser` dependency which has a **critical** vulnerability:

- fast-xml-parser has RangeError DoS Numeric Entities Bug - https://github.com/advisories/GHSA-37qj-frw5-hhjh
- fast-xml-parser has an entity encoding bypass via regex injection in DOCTYPE entity names - https://github.com/advisories/GHSA-m7jm-9gc2-mpf2
- fast-xml-parser affected by DoS through entity expansion in DOCTYPE (no expansion limit) - https://github.com/advisories/GHSA-jmr7-xgp7-cmfj
- fast-xml-parser has stack overflow in XMLBuilder with preserveOrder - https://github.com/advisories/GHSA-fj3w-jwp8-x2g3
- fast-xml-parser affected by numeric entity expansion bypassing all entity expansion limits (incomplete fix for CVE-2026-26278) - https://github.com/advisories/GHSA-8gc5-j5rx-235r