### PR TITLE
Update `mocha` to resolve high-severity vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
 		"globals": "^16.5.0",
 		"intercept-stdout": "0.1.2",
 		"mkcert": "^3.2.0",
-		"mocha": "^11.7.4",
+		"mocha": "^11.7.5",
 		"mqtt": "~4.3.8",
 		"oxlint": "^1.31.0",
 		"prettier": "~3.7.3",


### PR DESCRIPTION
`mocha` has multiple dependencies with **high** severity vulnerabilities:

- diff  6.0.0 - 8.0.2
  - jsdiff has a Denial of Service vulnerability in parsePatch and applyPatch - https://github.com/advisories/GHSA-73rr-hh4g-fpgx
- serialize-javascript  <=7.0.2
  - Serialize JavaScript is Vulnerable to RCE via RegExp.flags and Date.prototype.toISOString() - https://github.com/advisories/GHSA-5c6j-r48x-rmvq