### PR TITLE
Add `--experimental-vm-modules` flag to `bin/harper`

### DIFF
--- a/bin/harper.js
+++ b/bin/harper.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-vm-modules
+#!/usr/bin/env -S node --disable-warning=ExperimentalWarning --experimental-vm-modules
 'use strict';
 
 const fs = require('node:fs');


### PR DESCRIPTION
When running `harper dev` from an app, it throws the following:

```
Error: node_vm_1.SourceTextModule is not a constructor
    at createModule (/Users/chris/projects/harper/security/jsLoader.ts:285:14)
    at async getOrCreateModule (/Users/chris/projects/harper/security/jsLoader.ts:235:18)
    at async loadModuleWithCache (/Users/chris/projects/harper/security/jsLoader.ts:245:18)
    at async loadModuleWithVM (/Users/chris/projects/harper/security/jsLoader.ts:349:22)
    at async scopedImport (/Users/chris/projects/harper/security/jsLoader.ts:93:11)
    at async loadComponent (/Users/chris/projects/harper/components/componentLoader.ts:498:28)
    at async loadComponent (/Users/chris/projects/harper/components/componentLoader.ts:337:26)
    at async Promise.all (index 0)
    at async loadRootComponents (/Users/chris/projects/harper/server/loadRootComponents.js:36:3)
    at async startHTTPThreads (/Users/chris/projects/harper/server/threads/socketRouter.ts:49:4)
```

The problem is `vm.SourceTextModule` is only available when `--experimental-vm-modules` is set. This flag is set when the worker is started, however the components (e.g. my app) is loaded on the main thread before start worker is called.