### PR TITLE
avoid mutating cached records in `get_analytics`

### DIFF
--- a/resources/analytics/read.ts
+++ b/resources/analytics/read.ts
@@ -130,9 +130,8 @@ export async function get(metric: string, opts?: GetAnalyticsOpts): Promise<Metr
 	let results = searchResults.map(async (result: Metric) => {
 		// remove nodeId from 'id' attr and resolve it to the actual hostname and
 		// add back in as 'node' attr if selected
-		result = { ...result };
 		const nodeId = result.id[1];
-		result['id'] = result['id'][0];
+		result = { ...result, id: result.id[0] };
 		if (isSelected(select, 'node')) {
 			log.trace?.(`get_analytics lookup hostname for nodeId: ${nodeId}`);
 			const hostname = await lookupHostname(nodeId);


### PR DESCRIPTION
fixes `TypeError: Cannot assign to read only property 'id' of object` when retrieving custom component metrics 

Discovered this issue while testing the redirector component, both locally and on the testing cluster:



```
$ curl -X POST "http://localhost:9925" \
  -H "Content-Type: application/json" \
  -u "admin:password" \
  -d '{"operation": "get_analytics", "metric": "redirect-timing", "start_time": 0}'

[{"error":"TypeError","message":"Cannot assign to read only property 'id' of object '[object Object]'"}]
```