### PR TITLE
When loading a sub-component/plugin, don't override the verifyPath if…

### DIFF
--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -333,7 +333,7 @@ export async function loadComponent(
 						}
 					}
 					if (componentPath) {
-						subApplicationScope.verifyPath = componentPath;
+						subApplicationScope.verifyPath ??= componentPath;
 						if (!process.env.HARPER_SAFE_MODE) {
 							extensionModule = await loadComponent(componentPath, resources, origin, {
 								isRoot: false,


### PR DESCRIPTION
… it has already been set