### PR TITLE
Add missing timeout parameter

### DIFF
--- a/components/Application.ts
+++ b/components/Application.ts
@@ -555,7 +555,7 @@ export function nonInteractiveSpawn(
 	command: string,
 	args: string[],
 	cwd: string,
-	timeoutMs: number = 5 * 60 * 1000
+	timeoutMs: number = 60 * 60 * 1000
 ): Promise<{ stdout: string; stderr: string; code: number }> {
 	return new Promise((resolve, reject) => {
 		logger


### PR DESCRIPTION
There are three different branches/calls to install packages, but for some reason this one was missing the timeout parameter.
Also increases the timeout to an hour. The current timeout is causing far more problems than it is helping/solving.