### PR TITLE
Run node storage tracking less often than the standard analytics inteval and make configurable

### DIFF
--- a/config-root.schema.json
+++ b/config-root.schema.json
@@ -562,6 +562,10 @@
 					"type": "boolean",
 					"description": "Replicate aggregated analytics across cluster. Default: false"
 				},
+				"storageInterval": {
+					"type": "number",
+					"description": "Number of aggregation cycles between node storage measurements. 0 to disable. Default: 10"
+				},
 				"logging": { "$ref": "#/definitions/loggerConfig" }
 			}
 		}

--- a/resources/analytics/write.ts
+++ b/resources/analytics/write.ts
@@ -402,7 +402,12 @@ export async function getDirectorySizeAsync(dirPath: string): Promise<number> {
 	}
 }
 
+const DEFAULT_STORAGE_INTERVAL = 10;
+let nodeStorageInterval = DEFAULT_STORAGE_INTERVAL;
+let nodeStorageCycleCount = 0;
+
 async function storeNodeStorageMetric(analyticsTable: Table) {
+	if (nodeStorageInterval <= 0 || ++nodeStorageCycleCount % nodeStorageInterval !== 1) return;
 	try {
 		const size = await getDirectorySizeAsync(getHdbBasePath());
 		storeMetric(analyticsTable, {
@@ -689,6 +694,7 @@ if (!parentPort) onMessageByType(ANALYTICS_REPORT_TYPE, recordAnalytics);
 let scheduledTasksRunning;
 function startScheduledTasks() {
 	scheduledTasksRunning = true;
+	nodeStorageInterval = envGet(CONFIG_PARAMS.ANALYTICS_STORAGEINTERVAL) ?? DEFAULT_STORAGE_INTERVAL;
 	const AGGREGATE_PERIOD = envGet(CONFIG_PARAMS.ANALYTICS_AGGREGATEPERIOD) * 1000;
 	if (AGGREGATE_PERIOD) {
 		setInterval(

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -426,6 +426,7 @@ export const LEGACY_CONFIG_PARAMS = {
 export const CONFIG_PARAMS = {
 	ANALYTICS_AGGREGATEPERIOD: 'analytics_aggregatePeriod',
 	ANALYTICS_REPLICATE: 'analytics_replicate',
+	ANALYTICS_STORAGEINTERVAL: 'analytics_storageInterval',
 	AUTHENTICATION_AUTHORIZELOCAL: 'authentication_authorizeLocal',
 	AUTHENTICATION_CACHETTL: 'authentication_cacheTTL',
 	AUTHENTICATION_COOKIE_DOMAINS: 'authentication_cookie_domains',


### PR DESCRIPTION
Related to #286 and CORE-2985