### PR TITLE
Tolerate missing methods on registered resources

### DIFF
--- a/resources/Resource.ts
+++ b/resources/Resource.ts
@@ -683,15 +683,26 @@ function transactional(
 		}
 	}
 }
-function missingMethod(resource, method) {
-	const error = new ClientError(`The ${resource.constructor.name} does not have a ${method} method implemented`, 405);
-	error.allow = [];
+const KNOWN_METHODS = ['get', 'head', 'put', 'post', 'delete', 'patch', 'query', 'move', 'copy'];
+type ClientErrorWithMethods = ClientError & { allow: string[]; method: string };
+export function missingMethod(resource: any, method: string) {
+	const error = new ClientError(
+		`The ${resource.constructor.name} does not have a ${method} method implemented`,
+		405
+	) as ClientErrorWithMethods;
+	error.allow = allowedMethods(resource);
 	error.method = method;
-	for (const method of ['get', 'put', 'post', 'delete', 'query', 'move', 'copy']) {
-		if (typeof resource[method] === 'function') error.allow.push(method);
-	}
 	throw error;
 }
+
+export function allowedMethods(resource: any) {
+	const allow = [];
+	for (const method of KNOWN_METHODS) {
+		if (typeof resource[method] === 'function') allow.push(method);
+	}
+	return allow;
+}
+
 /**
  * This is responsible for handling a select query parameter/call that selects specific
  * properties from the returned record(s).

--- a/server/REST.ts
+++ b/server/REST.ts
@@ -4,7 +4,7 @@ import * as harperLogger from '../utility/logging/harper_logger.js';
 import { ServerOptions } from 'http';
 import { ServerError, ClientError } from '../utility/errors/hdbError.js';
 import { Resources } from '../resources/Resources.ts';
-import { Resource } from '../resources/Resource.ts';
+import { Resource, missingMethod, allowedMethods } from '../resources/Resource.ts';
 import { IterableEventQueue } from '../resources/IterableEventQueue.ts';
 import { transaction } from '../resources/transaction.ts';
 import { Headers, mergeHeaders } from '../server/serverHelpers/Headers.ts';
@@ -114,29 +114,38 @@ async function http(request: Context & Request, nextHandler) {
 			switch (method) {
 				case 'GET':
 				case 'HEAD':
-					return resource.get(target, request);
+					return resource.get ? resource.get(target, request) : missingMethod(resource, 'get');
 				case 'POST':
-					return resource.post(target, request.data, request);
+					return resource.post ? resource.post(target, request.data, request) : missingMethod(resource, 'post');
 				case 'PUT':
-					return resource.put(target, request.data, request);
+					return resource.put ? resource.put(target, request.data, request) : missingMethod(resource, 'put');
 				case 'DELETE':
-					return resource.delete(target, request);
+					return resource.delete ? resource.delete(target, request) : missingMethod(resource, 'delete');
 				case 'PATCH':
-					return resource.patch(target, request.data, request);
+					return resource.patch ? resource.patch(target, request.data, request) : missingMethod(resource, 'patch');
 				case 'OPTIONS': // used primarily for CORS
-					headers.setIfNone('Allow', 'GET, HEAD, POST, PUT, DELETE, PATCH, OPTIONS, TRACE, QUERY, COPY, MOVE');
+					headers.setIfNone(
+						'Allow',
+						allowedMethods(resource)
+							.map((method) => method.toUpperCase())
+							.join(', ')
+					);
 					return;
 				case 'CONNECT':
 					// websockets? and event-stream
-					return resource.connect(target, null, request);
+					return resource.connect ? resource.connect(target, null, request) : missingMethod(resource, 'connect');
 				case 'TRACE':
 					return 'Harper is the terminating server';
 				case 'QUERY':
-					return resource.query(target, request.data, request);
+					return resource.query ? resource.query(target, request.data, request) : missingMethod(resource, 'query');
 				case 'COPY': // methods suggested from webdav RFC 4918
-					return resource.copy(target, headersObject.destination, request);
+					return resource.copy
+						? resource.copy(target, headersObject.destination, request)
+						: missingMethod(resource, 'copy');
 				case 'MOVE':
-					return resource.move(target, headersObject.destination, request);
+					return resource.move
+						? resource.move(target, headersObject.destination, request)
+						: missingMethod(resource, 'move');
 				case 'BREW': // RFC 2324
 					throw new ClientError("Harper is short and stout and can't brew coffee", 418);
 				default:

--- a/unitTests/apiTests/basicREST-test.mjs
+++ b/unitTests/apiTests/basicREST-test.mjs
@@ -601,5 +601,19 @@ describe('test REST calls', () => {
 		assert.equal(response5.data.name, 'ResourceC');
 		assert.strictEqual(response5.data.params.pathname, '/some/relative/path/');
 		assert.strictEqual(response5.data.params.search, 'with=query.property');
+
+		let badResponse = await axios.post(
+			'http://localhost:9926/api/v1/resourceA/resourceB/subPath/ResourceC/anything',
+			{},
+			{
+				customResponse: true,
+				validateStatus: function (_status) {
+					return true;
+				},
+			}
+		);
+		// expect method not implemented
+		assert.equal(badResponse.status, 405);
+		assert(badResponse.headers.allow);
 	});
 });

--- a/unitTests/testApp/resources.js
+++ b/unitTests/testApp/resources.js
@@ -52,18 +52,21 @@ export class Echo extends Resource {
 
 class ResourceA extends Resource {
 	get(params) {
+		// legacy style
 		return { name: 'ResourceA', params };
 	}
 }
 
 class ResourceB extends Resource {
-	get(params) {
+	static get(params) {
+		// modern style
 		return { name: 'ResourceB', params };
 	}
 }
 
-class ResourceC extends Resource {
-	get(params) {
+class ResourceC {
+	// without extending Resource
+	static get(params) {
 		return { name: 'ResourceC', params };
 	}
 }


### PR DESCRIPTION
With the move to more usage of static methods, it is reasonable to let (and even encourage) users to create "plain" resource classes or objects:
```javascript
export class MyResource { // look ma, no extends
  static get(target) {
    ...
  }
}
export const anotherEndpoint = {
  get(target) {
    ...
  }
}
```
However, the REST handler should properly handle missing methods.