### PR TITLE
load extensionModule via native import instead of vm sandbox

### DIFF
--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -513,7 +513,7 @@ export async function loadComponent(
 		if ((config.extensionModule || config.pluginModule) && (!isMainThread || config.runOnMainThread)) {
 			const extensionModule = await scopedImport(
 				join(componentDirectory, config.extensionModule || config.pluginModule),
-				applicationScope
+				config.pluginModule ? applicationScope : undefined
 			);
 			loadedPaths.set(resolvedFolder, extensionModule);
 			return extensionModule;


### PR DESCRIPTION
fixes the following error when running ecommerce template:

`TypeError: Could not load application due to logger.loggerWithTag is not a function`