### PR TITLE
fix type exports to actually include the root index.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,10 @@
 		}
 	},
 	"exports": {
-		".": "./dist/index.js"
+		".": {
+			"types": "./index.d.ts",
+			"default": "./dist/index.js"
+		}
 	},
 	"devDependencies": {
 		"@harperdb/code-guidelines": "^0.0.6",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,6 @@
 {
 	"extends": "./tsconfig.json",
+	"exclude": ["index.d.ts"],
 	"compilerOptions": {
 		"noEmit": false,
 		"rewriteRelativeImportExtensions": true,


### PR DESCRIPTION
TypeScript basically strips `*.d.ts` files at build time so we should exclude the root `index.d.ts` from the build and since its already included in the package `files` list, we can reference it in the `exports` as the designated `"."["types"]` entry.