### PR TITLE
Created time handling

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -4130,6 +4130,27 @@ export function makeTable(options) {
 								let auditRecord: any;
 								let omitLocalRecord = false;
 								let residencyId: number;
+								if (updatedTimeProperty) {
+									updatedRecord[updatedTimeProperty.name] =
+										updatedTimeProperty.type === 'Date'
+											? new Date(txnTime)
+											: updatedTimeProperty.type === 'String'
+												? new Date(txnTime).toISOString()
+												: txnTime;
+								}
+								if (createdTimeProperty && updatedRecord[createdTimeProperty.name] == null) {
+									const existingCreatedTime = existingEntry?.value?.[createdTimeProperty.name];
+									if (existingCreatedTime != null) {
+										updatedRecord[createdTimeProperty.name] = existingCreatedTime;
+									} else {
+										updatedRecord[createdTimeProperty.name] =
+											createdTimeProperty.type === 'Date'
+												? new Date(txnTime)
+												: createdTimeProperty.type === 'String'
+													? new Date(txnTime).toISOString()
+													: txnTime;
+									}
+								}
 								const residency = residencyFromFunction(TableResource.getResidency(updatedRecord, context));
 								if (residency) {
 									if (!residency.includes(server.hostname)) {
@@ -4148,6 +4169,11 @@ export function makeTable(options) {
 												}
 												// if there are any indices, we need to preserve a partial invalidated record to ensure we can still do searches
 												updatedRecord[name] = auditRecord[name];
+											}
+											if (createdTimeProperty && auditRecord[createdTimeProperty.name] != null) {
+												// preserve the created timestamp in the partial record so it isn't lost when we don't have residency
+												if (!updatedRecord) updatedRecord = {};
+												updatedRecord[createdTimeProperty.name] = auditRecord[createdTimeProperty.name];
 											}
 										}
 									}

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1433,18 +1433,6 @@ export function makeTable(options) {
 			if (hasSourceGet) {
 				// if there is a resolution in-progress, abandon the eviction
 				if (primaryStore.hasLock(id, entry.version)) return;
-				// if there is a source, we are not "deleting" the record, just removing our local copy, but preserving what we need for indexing
-				let partialRecord;
-				for (const name in indices) {
-					// if there are any indices, we need to preserve a partial evicted record to ensure we can still do searches
-					if (!partialRecord) partialRecord = {};
-					partialRecord[name] = existingRecord[name];
-				}
-				// if we are evicting and not deleting, need to preserve the partial record
-				if (partialRecord) {
-					// treat this as a record resolution (so previous version is checked) with no audit record
-					return updateRecord(id, partialRecord, entry, existingVersion, EVICTED, null, null, null, true);
-				}
 			}
 			primaryStore.ifVersion?.(id, existingVersion, () => {
 				updateIndices(id, existingRecord, null);
@@ -1845,6 +1833,11 @@ export function makeTable(options) {
 										}
 										// if there are any indices, we need to preserve a partial invalidated record to ensure we can still do searches
 										recordToStore[name] = auditRecordToStore[name];
+									}
+									if (createdTimeProperty && auditRecordToStore[createdTimeProperty.name] != null) {
+										// preserve the created timestamp in the partial record so it isn't lost when we don't have residency
+										if (!recordToStore) recordToStore = {};
+										recordToStore[createdTimeProperty.name] = auditRecordToStore[createdTimeProperty.name];
 									}
 								}
 							}
@@ -3492,7 +3485,7 @@ export function makeTable(options) {
 	if (expirationMs) TableResource.setTTLExpiration(expirationMs / 1000);
 	if (expiresAtProperty) runRecordExpirationEviction();
 	return TableResource;
-	function updateIndices(id: any, existingRecord: any, record: any, options: any) {
+	function updateIndices(id: any, existingRecord: any, record: any, options?: any) {
 		let hasChanges;
 		// iterate the entries from the record
 		// for-in is about 5x as fast as for-of Object.entries, and this is extremely time sensitive since it can be

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -24,7 +24,12 @@ describe('Caching', () => {
 		CachingTable = table({
 			table: 'CachingTable',
 			database: 'test',
-			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'name' },
+				{ name: 'createdAt', type: 'Date', assignCreatedTime: true },
+				{ name: 'updatedAt', type: 'Date', assignUpdatedTime: true },
+			],
 		});
 		IndexedCachingTable = table({
 			table: 'IndexedCachingTable',
@@ -94,11 +99,14 @@ describe('Caching', () => {
 	it('Can load cached data', async function () {
 		sourceRequests = 0;
 		events = [];
+		const start = new Date();
 		CachingTable.setTTLExpiration(0.01);
 		await CachingTable.invalidate(23);
 		let result = await CachingTable.get(23);
 		assert.equal(result.id, 23);
 		assert.equal(result.name, 'name ' + 23);
+		assert(result.createdAt >= start);
+		assert(result.updatedAt >= start);
 		assert.equal(sourceRequests, 1);
 		await delay(5);
 		let target23 = new RequestTarget();
@@ -117,6 +125,8 @@ describe('Caching', () => {
 		//assert.equal(events.length, 0);
 		await CachingTable.put(23, { name: 'expires in past' }, { expiresAt: 0 });
 		result = await CachingTable.get(target23);
+		assert(result.createdAt >= start);
+		assert(result.updatedAt >= start);
 		assert.equal(sourceRequests, 3);
 		assert.equal(target23.loadedFromSource, true);
 	});

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -1,5 +1,6 @@
 require('../testUtils');
 const assert = require('assert');
+const { setTimeout: delay } = require('timers/promises');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { Resource } = require('#src/resources/Resource');
@@ -99,7 +100,7 @@ describe('Caching', () => {
 		assert.equal(result.id, 23);
 		assert.equal(result.name, 'name ' + 23);
 		assert.equal(sourceRequests, 1);
-		await new Promise((resolve) => setTimeout(resolve, 5));
+		await delay(5);
 		let target23 = new RequestTarget();
 		target23.id = 23;
 		result = await CachingTable.get(target23);
@@ -107,7 +108,7 @@ describe('Caching', () => {
 		assert.equal(result.id, 23);
 		assert.equal(sourceRequests, 1);
 		// let it expire
-		await new Promise((resolve) => setTimeout(resolve, 10));
+		await delay(10);
 		result = await CachingTable.get(target23);
 		assert.equal(result.id, 23);
 		assert.equal(result.name, 'name ' + 23);
@@ -316,7 +317,7 @@ describe('Caching', () => {
 		assert.equal(result.id, 23);
 		sourceRequests = 0;
 		// let it expire
-		await new Promise((resolve) => setTimeout(resolve, 10));
+		await delay(10);
 		result = await IndexedCachingTable.get(23);
 		assert.equal(result.id, 23);
 		assert.equal(result.name, 'name ' + 23);
@@ -324,7 +325,14 @@ describe('Caching', () => {
 		assert.equal(events.length, 0);
 		result = await IndexedCachingTable.get(23);
 		// TODO: This should always be there, per https://github.com/HarperFast/harper/issues/239
+		await delay(10); // give the lock a chance to be released
 		//assert(result.getExpiresAt());
+		result = IndexedCachingTable.primaryStore.getEntry(23);
+		await IndexedCachingTable.evict(23, result, result.version);
+		await delay(10);
+		// evict should completely eliminate the record
+		result = IndexedCachingTable.primaryStore.getSync(23); // verify that the record is evicted
+		assert.strictEqual(result, undefined);
 	});
 
 	it('Bigger stampede is handled', async function () {

--- a/unitTests/resources/crud.test.js
+++ b/unitTests/resources/crud.test.js
@@ -40,6 +40,8 @@ describe('CRUD operations with the Resource API', () => {
 						{ name: 'name', type: 'String' },
 					],
 				},
+				{ name: 'createdAt', type: 'Date', assignCreatedTime: true },
+				{ name: 'updatedAt', type: 'Date', assignUpdatedTime: true },
 			],
 		});
 		CRUDTable.loadAsInstance = false;
@@ -231,10 +233,15 @@ describe('CRUD operations with the Resource API', () => {
 			let retrieved = await CRUDTable.get(created.id);
 			assert.equal(retrieved.name, 'constructed with auto-id');
 		});
-		it('create via post with auto-id', async function () {
-			let createdId = await CRUDTable.post({ relatedId: 1, name: 'constructed via post with auto-id' });
-			let retrieved = await CRUDTable.get(createdId);
-			assert.equal(retrieved.name, 'constructed via post with auto-id');
+		it('create via post with auto-id, check timestamps', async function () {
+			let start = new Date();
+			for (let i = 0; i < 20; i++) {
+				let createdId = await CRUDTable.post({ relatedId: 1, name: 'constructed via post with auto-id' });
+				let retrieved = await CRUDTable.get(createdId);
+				assert.equal(retrieved.name, 'constructed via post with auto-id');
+				assert(retrieved.createdAt >= start);
+				assert(retrieved.updatedAt >= start);
+			}
 		});
 		it('create in transaction', async function () {
 			let context = {};

--- a/unitTests/resources/crud.test.js
+++ b/unitTests/resources/crud.test.js
@@ -239,8 +239,14 @@ describe('CRUD operations with the Resource API', () => {
 				let createdId = await CRUDTable.post({ relatedId: 1, name: 'constructed via post with auto-id' });
 				let retrieved = await CRUDTable.get(createdId);
 				assert.equal(retrieved.name, 'constructed via post with auto-id');
-				assert(retrieved.createdAt >= start);
-				assert(retrieved.updatedAt >= start);
+				assert(
+					retrieved.createdAt >= start,
+					`Expected createdAt to be >= ${start.toISOString()}, got ${retrieved.createdAt.toISOString()}`
+				);
+				assert(
+					retrieved.updatedAt >= start,
+					`Expected updatedAt to be >= ${start.toISOString()}, got ${retrieved.updatedAt.toISOString()}`
+				);
 			}
 		});
 		it('create in transaction', async function () {

--- a/unitTests/resources/crud.test.js
+++ b/unitTests/resources/crud.test.js
@@ -234,7 +234,7 @@ describe('CRUD operations with the Resource API', () => {
 			assert.equal(retrieved.name, 'constructed with auto-id');
 		});
 		it('create via post with auto-id, check timestamps', async function () {
-			let start = new Date();
+			let start = new Date(Date.now() - 100);
 			for (let i = 0; i < 20; i++) {
 				let createdId = await CRUDTable.post({ relatedId: 1, name: 'constructed via post with auto-id' });
 				let retrieved = await CRUDTable.get(createdId);


### PR DESCRIPTION
This PR preserves the created time for partial records so the creation timestamp is preserved. This also eliminates using partial records for eviction. I think that behavior just doesn't match expectations, and ensures that the created timestamp is recreated when the record is created again.
May address #329.