### PR TITLE
Add option to freeze intrinsics after applications are loaded

### DIFF
--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -355,7 +355,20 @@ class FileBackedBlob extends InstanceOfBlobWithNoConstructor {
 										} else {
 											// set a timer for the watcher too
 											timer = setTimeout(() => {
-												onError(new Error(`File read timed out reading from ${filePath}`));
+												if (readSync(fd, buffer, 0, buffer.length, position) > 0) {
+													// finally try to read one more time to see if it was a watcher failure
+													onError(
+														new Error(
+															`File read timed out reading from ${filePath} due to the watcher failing to notify of updates, read ${totalContentRead} bytes, but size is supposed to be ${size} bytes`
+														)
+													);
+												} else {
+													onError(
+														new Error(
+															`File read timed out reading from ${filePath}, read ${totalContentRead} bytes, but size is supposed to be ${size} bytes`
+														)
+													);
+												}
 											}, FILE_READ_TIMEOUT).unref();
 										}
 									} else {
@@ -952,7 +965,7 @@ export function deleteBlobsInObject(object) {
  */
 export function findBlobsInObject(object: any, callback: (blob: Blob) => void) {
 	if (object instanceof Blob) {
-		// eslint-disable-next-line
+		//
 		// @ts-ignore
 		callback(object);
 	} else if (Array.isArray(object)) {

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -908,6 +908,7 @@ export function preventFunctionConstructor() {
 function freezeIntrinsics() {
 	overridableProperty(Object.prototype, 'toString');
 	overridableProperty(Object.prototype, 'valueOf');
+	overridableProperty(Object.prototype, 'hasOwnProperty');
 	overridableProperty(Object.prototype, 'constructor');
 	overridableProperty(Promise.prototype, 'then');
 	overridableProperty(Date, 'now');

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -17,8 +17,9 @@ import type { CompartmentOptions } from 'ses';
 import { mkdirSync, readFileSync, writeFileSync, unlinkSync, openSync, closeSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { EventEmitter } from 'node:events';
+import { whenComponentsLoaded } from '../server/threads/threadServer.js';
 
-type Lockdown = 'none' | 'freeze' | 'ses';
+type Lockdown = 'none' | 'freeze' | 'ses' | 'freeze-after-load';
 const APPLICATIONS_LOCKDOWN: Lockdown = env.get(CONFIG_PARAMS.APPLICATIONS_LOCKDOWN);
 const HARPER_MODULE_IDS = new Set([
 	'harper',
@@ -50,42 +51,11 @@ export async function scopedImport(filePath: string | URL, scope?: ApplicationSc
 			});
 		} else {
 			preventFunctionConstructor();
-			for (let name of Object.getOwnPropertyNames(Object.prototype)) {
-				if (name === '__proto__') continue;
-				overridableProperty(Object.prototype, name);
+			if (APPLICATIONS_LOCKDOWN === 'freeze-after-load') {
+				whenComponentsLoaded.then(freezeIntrinsics);
+			} else {
+				freezeIntrinsics();
 			}
-			overridableProperty(Promise.prototype, 'then');
-			overridableProperty(Date, 'now');
-			for (let name of ['get', 'set', 'has', 'delete', 'clear', 'forEach', 'entries', 'keys', 'values']) {
-				overridableProperty(Map.prototype, name);
-			}
-			for (let Intrinsic of [
-				Object,
-				Array,
-				Promise,
-				BigInt,
-				String,
-				Number,
-				Boolean,
-				Symbol,
-				RegExp,
-				Date,
-				Map,
-				Set,
-				WeakMap,
-				WeakSet,
-				Math,
-				JSON,
-				Reflect,
-				Atomics,
-				SharedArrayBuffer,
-				WeakRef,
-				FinalizationRegistry,
-			]) {
-				Object.freeze(Intrinsic);
-				Object.freeze(Intrinsic.prototype);
-			}
-			Object.freeze(Function);
 		}
 	}
 	const moduleUrl = (filePath instanceof URL ? filePath : pathToFileURL(filePath)).toString();
@@ -933,6 +903,44 @@ function getResponse() {
 
 export function preventFunctionConstructor() {
 	Function.prototype.constructor = function () {}; // prevent this from being used to eval data in a parent context
+}
+
+function freezeIntrinsics() {
+	overridableProperty(Object.prototype, 'toString');
+	overridableProperty(Object.prototype, 'valueOf');
+	overridableProperty(Object.prototype, 'constructor');
+	overridableProperty(Promise.prototype, 'then');
+	overridableProperty(Date, 'now');
+	for (let name of ['get', 'set', 'has', 'delete', 'clear', 'forEach', 'entries', 'keys', 'values']) {
+		overridableProperty(Map.prototype, name);
+	}
+	for (let Intrinsic of [
+		Object,
+		Array,
+		Promise,
+		BigInt,
+		String,
+		Number,
+		Boolean,
+		Symbol,
+		RegExp,
+		Date,
+		Map,
+		Set,
+		WeakMap,
+		WeakSet,
+		Math,
+		JSON,
+		Reflect,
+		Atomics,
+		SharedArrayBuffer,
+		WeakRef,
+		FinalizationRegistry,
+	]) {
+		Object.freeze(Intrinsic);
+		Object.freeze(Intrinsic.prototype);
+	}
+	Object.freeze(Function);
 }
 
 /**


### PR DESCRIPTION
Most packages that modify intrinsics, do so when the module is loaded, not later at run time, which is when intrinsic modification is more likely to be a malicious (triggered by an exploit).
(I tested this with the `reflect-metadata` package which had caused errors for the host manager, and this avoids those errors).