### PR TITLE
fixes types for the server.upgrade method and adds `request.__harperRequestUpgraded`

### DIFF
--- a/server/Server.ts
+++ b/server/Server.ts
@@ -3,22 +3,30 @@ import { _assignPackageExport } from '../globals.js';
 import type { Value } from '../resources/analytics/write.ts';
 import type { Resources } from '../resources/Resources.ts';
 import { OperationDefinition } from './serverHelpers/serverUtilities.ts';
+import { Duplex } from 'stream';
+import { Request } from './serverHelpers/Request.ts';
 
+export type HttpListener = (request: Request, nextLayer: (request: Request) => Response) => void;
+// based on `upgrade` event in Node.js http server: https://nodejs.org/docs/latest/api/http.html#event-upgrade-1
+export type UpgradeListener = (
+	request: Request,
+	socket: Duplex,
+	head: Buffer,
+	nextLayer: (request: Request, socket: Duplex, head: Buffer) => Promise<void>
+) => Promise<void>;
 /**
  * This is the central interface by which we define entry points for different server protocol plugins to listen for
  * incoming connections and requests.
  */
 export interface Server {
 	socket?(listener: (socket: Socket) => void, options: ServerOptions): void;
-	http?(listener: (request: Request, nextLayer: (request: Request) => Response) => void, options?: HttpOptions): void;
-	request?(
-		listener: (request: Request, nextLayer: (request: Request) => Response) => void,
-		options?: HttpOptions
-	): void;
+	http?(listener: HttpListener, options?: HttpOptions): void;
+	request?(listener: HttpListener, options?: HttpOptions): void;
 	ws?(
 		listener: (ws: WebSocket, request: Request, requestCompletion: Promise<any>) => any,
 		options?: WebSocketOptions
 	): void;
+	upgrade?(listener: UpgradeListener, options?: UpgradeOptions): void;
 	contentTypes: Map<string, ContentTypeHandler>;
 	getUser(username: string, password: string | null, request: Request): any;
 	authenticateUser(username: string, password: string, request: Request): any;
@@ -55,6 +63,12 @@ export interface ServerOptions {
 interface WebSocketOptions extends ServerOptions {
 	subProtocol: string;
 }
+export interface UpgradeOptions {
+	port?: number;
+	securePort?: number;
+	runFirst?: boolean;
+}
+
 export interface HttpOptions extends ServerOptions {
 	runFirst?: boolean;
 }

--- a/server/http.ts
+++ b/server/http.ts
@@ -19,7 +19,14 @@ import { appendHeader, Headers } from './serverHelpers/Headers.ts';
 import { Blob } from '../resources/blob.ts';
 import { recordAction, recordActionBinary } from '../resources/analytics/write.ts';
 import { Readable } from 'node:stream';
-import { server, type ServerOptions, type HttpOptions } from './Server.ts';
+import {
+	server,
+	type ServerOptions,
+	type HttpOptions,
+	type HttpListener,
+	type UpgradeOptions,
+	UpgradeListener,
+} from './Server.ts';
 import { setPortServerMap, SERVERS } from './serverRegistry.ts';
 import { getComponentName } from '../components/componentLoader.ts';
 import { throttle } from './throttle.ts';
@@ -490,29 +497,10 @@ Object.defineProperty(IncomingMessage.prototype, 'upgrade', {
 	set(_v) {},
 });
 
-type OnUpgradeOptions = {
-	port?: number;
-	securePort?: number;
-	runFirst?: boolean;
-};
-
-/**
- * @typedef {(request: unknown, next: Listener) => void | Promise<void>} Listener
- */
-
 const upgradeListeners = [],
 	upgradeChains = {};
 
-/**
- *
- * @param {Listener} listener
- * @param {OnUpgradeOptions} options
- * @returns
- */
-function onUpgrade(
-	listener: (request: Request, next: (request: Request) => Response) => void,
-	options: OnUpgradeOptions
-) {
+function onUpgrade(listener: UpgradeListener, options: UpgradeOptions) {
 	for (const { port } of getPorts(options)) {
 		upgradeListeners[options?.runFirst ? 'unshift' : 'push']({ listener, port });
 		upgradeChains[port] = makeCallbackChain(upgradeListeners, port);
@@ -568,13 +556,14 @@ function onWebSocket(listener: (ws: WebSocket) => void, options: OnWebSocketOpti
 			onUpgrade(
 				(request, socket, head, next) => {
 					// If the request has already been upgraded, continue without upgrading
-					if (request.__harperdbRequestUpgraded) {
+					if (request.__harperdbRequestUpgraded || request.__harperRequestUpgraded) {
 						return next(request, socket, head);
 					}
 
 					// Otherwise, upgrade the socket and then continue
 					return websocketServers[port].handleUpgrade(request, socket, head, (ws) => {
 						request.__harperdbRequestUpgraded = true;
+						request.__harperRequestUpgraded = true;
 						next(request, socket, head);
 						websocketServers[port].emit('connection', ws, request);
 					});

--- a/server/http.ts
+++ b/server/http.ts
@@ -19,14 +19,7 @@ import { appendHeader, Headers } from './serverHelpers/Headers.ts';
 import { Blob } from '../resources/blob.ts';
 import { recordAction, recordActionBinary } from '../resources/analytics/write.ts';
 import { Readable } from 'node:stream';
-import {
-	server,
-	type ServerOptions,
-	type HttpOptions,
-	type HttpListener,
-	type UpgradeOptions,
-	UpgradeListener,
-} from './Server.ts';
+import { server, type ServerOptions, type HttpOptions, type UpgradeOptions, UpgradeListener } from './Server.ts';
 import { setPortServerMap, SERVERS } from './serverRegistry.ts';
 import { getComponentName } from '../components/componentLoader.ts';
 import { throttle } from './throttle.ts';

--- a/server/serverHelpers/Request.ts
+++ b/server/serverHelpers/Request.ts
@@ -24,8 +24,8 @@ interface IncomingMessage extends NodeIncomingMessage {
 export class Request {
 	#body: RequestBody | undefined;
 	#peerCertificate: any;
-	private _nodeRequest: IncomingMessage;
-	private _nodeResponse: NodeServerResponse;
+	public _nodeRequest: IncomingMessage;
+	public _nodeResponse?: NodeServerResponse;
 	public method: string;
 	public url: string;
 	public headers: Headers;
@@ -35,6 +35,7 @@ export class Request {
 		status?: number;
 		headers: ResponseHeaders;
 	};
+	public __harperRequestUpgraded: boolean;
 
 	constructor(nodeRequest: IncomingMessage, nodeResponse: NodeServerResponse) {
 		this.method = nodeRequest.method;
@@ -43,6 +44,7 @@ export class Request {
 		this._nodeResponse = nodeResponse;
 		this.url = url;
 		this.headers = new Headers(nodeRequest.headers);
+		this.__harperRequestUpgraded = false;
 	}
 	get absoluteURL() {
 		return this.protocol + '://' + this.host + this.url;


### PR DESCRIPTION
This is mainly for the upcoming `@harperfast/nextjs` plugin implementation so there are less type errors. These core files could still use some serious Typescript attention. I kept the old `__harperdbRequestUpgraded` boolean alongside the new `__harperRequestUpgraded` so that the `@harperdb/nextjs` (v1) extension can still work in v5.... but I'd be happy to remove it too 👀 