### PR TITLE
Add version support to spawn process management

### DIFF
--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -763,7 +763,7 @@ function isProcessRunning(pid: number): boolean {
  */
 function parsePidFile(content: string): { pid: number; version: number } {
 	const lines = content.trim().split('\n');
-	const pid = parseInt(lines[0], 10);
+	const pid = Number.parseInt(lines[0], 10);
 	const version = lines.length > 1 ? parseInt(lines[1], 10) : 0;
 	return { pid, version };
 }
@@ -788,7 +788,7 @@ function acquirePidFileLock(
 					const { pid: existingPid, version: existingVersion } = parsePidFile(pidContent);
 
 					if (!isNaN(existingPid) && isProcessRunning(existingPid)) {
-						// If a higher version is requested, kill the existing process and re-acquire
+						// If the version isn't the one we want, kill the existing process and re-acquire
 						if (requestedVersion != null && requestedVersion !== existingVersion) {
 							try {
 								process.kill(existingPid);

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -789,7 +789,7 @@ function acquirePidFileLock(
 
 					if (!isNaN(existingPid) && isProcessRunning(existingPid)) {
 						// If a higher version is requested, kill the existing process and re-acquire
-						if (requestedVersion != null && requestedVersion > existingVersion) {
+						if (requestedVersion != null && requestedVersion !== existingVersion) {
 							try {
 								process.kill(existingPid);
 							} catch {

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -768,7 +768,12 @@ function parsePidFile(content: string): { pid: number; version: number } {
 	return { pid, version };
 }
 
-function acquirePidFileLock(pidFilePath: string, requestedVersion?: number, maxRetries = 100, retryDelay = 5): { pid: number; version: number } {
+function acquirePidFileLock(
+	pidFilePath: string,
+	requestedVersion?: number,
+	maxRetries = 100,
+	retryDelay = 5
+): { pid: number; version: number } {
 	for (let attempt = 0; attempt < maxRetries; attempt++) {
 		try {
 			// Try to open exclusively - 'wx' fails if file exists
@@ -870,9 +875,8 @@ function createSpawn(spawnFunction: (...args: any) => child_process.ChildProcess
 		const childProcess = spawnFunction(command, args, options, callback);
 
 		// Write PID (and version if provided) to the file we just created
-		const pidFileContent = requestedVersion != null
-			? `${childProcess.pid}\n${requestedVersion}`
-			: childProcess.pid.toString();
+		const pidFileContent =
+			requestedVersion != null ? `${childProcess.pid}\n${requestedVersion}` : childProcess.pid.toString();
 		try {
 			writeFileSync(pidFilePath, pidFileContent, 'utf-8');
 		} catch (err) {

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -761,23 +761,49 @@ function isProcessRunning(pid: number): boolean {
  * Acquires an exclusive lock using the PID file itself (synchronously with busy-wait)
  * Returns 0 if lock was acquired (need to spawn new process), or the existing PID if process is running
  */
-function acquirePidFileLock(pidFilePath: string, maxRetries = 100, retryDelay = 5): number {
+function parsePidFile(content: string): { pid: number; version: number } {
+	const lines = content.trim().split('\n');
+	const pid = parseInt(lines[0], 10);
+	const version = lines.length > 1 ? parseInt(lines[1], 10) : 0;
+	return { pid, version };
+}
+
+function acquirePidFileLock(pidFilePath: string, requestedVersion?: number, maxRetries = 100, retryDelay = 5): { pid: number; version: number } {
 	for (let attempt = 0; attempt < maxRetries; attempt++) {
 		try {
 			// Try to open exclusively - 'wx' fails if file exists
 			const fd = openSync(pidFilePath, 'wx');
 			closeSync(fd);
-			return 0; // Successfully acquired lock (file created), caller should spawn process
+			return { pid: 0, version: 0 }; // Successfully acquired lock (file created), caller should spawn process
 		} catch (err) {
 			if (err.code === 'EEXIST') {
 				// File exists - check if it contains a valid running process
 				try {
 					const pidContent = readFileSync(pidFilePath, 'utf-8');
-					const existingPid = parseInt(pidContent.trim(), 10);
+					const { pid: existingPid, version: existingVersion } = parsePidFile(pidContent);
 
 					if (!isNaN(existingPid) && isProcessRunning(existingPid)) {
-						// Valid process is running, return its PID immediately
-						return existingPid;
+						// If a higher version is requested, kill the existing process and re-acquire
+						if (requestedVersion != null && requestedVersion > existingVersion) {
+							try {
+								process.kill(existingPid);
+							} catch {
+								// Process may have already exited
+							}
+							try {
+								unlinkSync(pidFilePath);
+							} catch {
+								// Another thread may have removed it
+							}
+							// Retry to acquire the lock for the new version
+							const start = Date.now();
+							while (Date.now() - start < retryDelay) {
+								// Busy wait for process cleanup
+							}
+							continue;
+						}
+						// Valid process is running at same or higher version, return its PID
+						return { pid: existingPid, version: existingVersion };
 					}
 
 					// Invalid/empty PID - check file age to determine if it's stale or being written
@@ -824,6 +850,7 @@ function createSpawn(spawnFunction: (...args: any) => child_process.ChildProcess
 			throw new Error(
 				`Calling ${spawnFunction.name} in Harper must have a process "name" in the options to ensure that a single process is started and reused`
 			);
+		const requestedVersion = options?.version;
 
 		// Ensure PID directory exists
 		const pidDir = join(basePath, 'pids');
@@ -831,20 +858,23 @@ function createSpawn(spawnFunction: (...args: any) => child_process.ChildProcess
 
 		const pidFilePath = join(pidDir, `${processName}.pid`);
 
-		// Try to acquire lock - returns 0 if acquired, or existing PID
-		const existingPid = acquirePidFileLock(pidFilePath);
+		// Try to acquire lock - returns pid: 0 if acquired, or existing PID/version
+		const existing = acquirePidFileLock(pidFilePath, requestedVersion);
 
-		if (existingPid !== 0) {
+		if (existing.pid !== 0) {
 			// Existing process is running, return wrapper
-			return new ExistingProcessWrapper(existingPid);
+			return new ExistingProcessWrapper(existing.pid);
 		}
 
 		// We acquired the lock (file was created), spawn new process
 		const childProcess = spawnFunction(command, args, options, callback);
 
-		// Write PID to the file we just created
+		// Write PID (and version if provided) to the file we just created
+		const pidFileContent = requestedVersion != null
+			? `${childProcess.pid}\n${requestedVersion}`
+			: childProcess.pid.toString();
 		try {
-			writeFileSync(pidFilePath, childProcess.pid.toString(), 'utf-8');
+			writeFileSync(pidFilePath, pidFileContent, 'utf-8');
 		} catch (err) {
 			// Failed to write PID, clean up
 			try {

--- a/unitTests/components/fixtures/testJSWithDeps/resources.js
+++ b/unitTests/components/fixtures/testJSWithDeps/resources.js
@@ -75,4 +75,20 @@ export const processSpawnTest = {
 
 		return { child1, child2 };
 	},
+	testVersionUpgrade(childProcessPath) {
+		// First call with version 1
+		const child1 = fork(childProcessPath, [], { name: 'test-version-process', version: 1 });
+		assert(child1.pid, 'First fork should return a process with a PID');
+
+		// Second call with same version should reuse
+		const child2 = fork(childProcessPath, [], { name: 'test-version-process', version: 1 });
+		assert.equal(child1.pid, child2.pid, 'Same version should reuse existing process');
+
+		// Third call with higher version should spawn new process
+		const child3 = fork(childProcessPath, [], { name: 'test-version-process', version: 2 });
+		assert(child3.pid, 'Higher version should return a process with a PID');
+		assert.notEqual(child1.pid, child3.pid, 'Higher version should spawn a new process');
+
+		return { child1, child3 };
+	},
 };

--- a/unitTests/components/globalIsolation.test.js
+++ b/unitTests/components/globalIsolation.test.js
@@ -214,6 +214,32 @@ describe('Global Variable Isolation in testJSWithDeps', function () {
 		});
 	});
 
+	it('should restart process when version is upgraded', async function () {
+		this.timeout(10000);
+
+		let applicationScope = new ApplicationScope('test', mockResources, server);
+		Object.assign(applicationScope, {
+			mode: 'vm',
+			dependencyLoader: 'native',
+			verifyPath: PACKAGE_ROOT,
+		});
+		await loadComponent(componentDir, mockResources, 'test-origin', {
+			applicationScope,
+		});
+
+		const processSpawnTest = mockResources.get('/processSpawnTest');
+		const childProcessPath = path.join(componentDir, 'test-child-process.js');
+
+		const { child1, child3 } = processSpawnTest.testVersionUpgrade(childProcessPath);
+
+		// Verify the old process was killed and a new one spawned
+		assert(child3.pid, 'New version process should have a PID');
+		assert.notEqual(child1.pid, child3.pid, 'Higher version should have spawned a new process');
+
+		// Clean up
+		child3.kill();
+	});
+
 	it('should handle ESM circular dependencies correctly', async function () {
 		let applicationScope = new ApplicationScope('test', mockResources, server);
 		Object.assign(applicationScope, {


### PR DESCRIPTION
When a higher version number is passed in spawn options, the existing process is killed and a new one is started. The version is stored alongside the PID in the pid file. This allows callers to force a process restart when the underlying configuration or code changes.

Including this in a patch as it will likely to be important for our work on spawning local language models.