### PR TITLE
Add integrated logger-status system with .status() API, health checks and hierarchical view

### DIFF
--- a/components/status/ComponentStatus.ts
+++ b/components/status/ComponentStatus.ts
@@ -5,7 +5,7 @@
  * component's status with methods for status management.
  */
 
-import { type ComponentStatusLevel, COMPONENT_STATUS_LEVELS } from './types.ts';
+import { type ComponentStatusLevel, type ComponentStatusSource, COMPONENT_STATUS_LEVELS } from './types.ts';
 
 /**
  * Component status information class
@@ -19,12 +19,23 @@ export class ComponentStatus {
 	public message?: string;
 	/** Error information if status is 'error' */
 	public error?: Error | string;
+	/** How the status was set */
+	public source?: ComponentStatusSource;
+	/** Epoch ms when this status should auto-clear */
+	public expiresAt?: number;
+	/** Number of times this status has been reported */
+	public occurrenceCount: number;
+	/** When this status was first reported */
+	public firstOccurrence: Date;
 
-	constructor(status: ComponentStatusLevel, message?: string, error?: Error | string) {
+	constructor(status: ComponentStatusLevel, message?: string, error?: Error | string, source?: ComponentStatusSource) {
 		this.lastChecked = new Date();
 		this.status = status;
 		this.message = message;
 		this.error = error;
+		this.source = source;
+		this.occurrenceCount = 1;
+		this.firstOccurrence = this.lastChecked;
 	}
 
 	/**

--- a/components/status/ComponentStatusRegistry.ts
+++ b/components/status/ComponentStatusRegistry.ts
@@ -8,6 +8,7 @@
 import { ComponentStatus } from './ComponentStatus.ts';
 import {
 	type ComponentStatusLevel,
+	type ComponentStatusSource,
 	COMPONENT_STATUS_LEVELS,
 	type AggregatedComponentStatus,
 	type ComponentApplicationStatus,
@@ -43,7 +44,8 @@ export class ComponentStatusRegistry {
 		componentName: string,
 		status: ComponentStatusLevel,
 		message?: string,
-		error?: Error | string
+		error?: Error | string,
+		source?: ComponentStatusSource
 	): void {
 		if (!componentName || typeof componentName !== 'string') {
 			throw new ComponentStatusOperationError(
@@ -61,7 +63,16 @@ export class ComponentStatusRegistry {
 			);
 		}
 
-		this.statusMap.set(componentName, new ComponentStatus(status, message, error));
+		const existing = this.statusMap.get(componentName);
+		if (existing && existing.status === status) {
+			existing.lastChecked = new Date();
+			existing.message = message;
+			if (error !== undefined) existing.error = error;
+			if (source !== undefined) existing.source = source;
+			existing.occurrenceCount++;
+		} else {
+			this.statusMap.set(componentName, new ComponentStatus(status, message, error, source));
+		}
 	}
 
 	/**

--- a/components/status/api.ts
+++ b/components/status/api.ts
@@ -28,7 +28,13 @@ export class ComponentStatusBuilder {
 	 * @returns this for chaining
 	 */
 	healthy(message?: string): this {
-		componentStatusRegistry.setStatus(this.componentName, COMPONENT_STATUS_LEVELS.HEALTHY, message, undefined, this.source);
+		componentStatusRegistry.setStatus(
+			this.componentName,
+			COMPONENT_STATUS_LEVELS.HEALTHY,
+			message,
+			undefined,
+			this.source
+		);
 		return this;
 	}
 
@@ -38,7 +44,13 @@ export class ComponentStatusBuilder {
 	 * @returns this for chaining
 	 */
 	warning(message: string): this {
-		componentStatusRegistry.setStatus(this.componentName, COMPONENT_STATUS_LEVELS.WARNING, message, undefined, this.source);
+		componentStatusRegistry.setStatus(
+			this.componentName,
+			COMPONENT_STATUS_LEVELS.WARNING,
+			message,
+			undefined,
+			this.source
+		);
 		return this;
 	}
 
@@ -59,7 +71,13 @@ export class ComponentStatusBuilder {
 	 * @returns this for chaining
 	 */
 	loading(message?: string): this {
-		componentStatusRegistry.setStatus(this.componentName, COMPONENT_STATUS_LEVELS.LOADING, message || 'Loading...', undefined, this.source);
+		componentStatusRegistry.setStatus(
+			this.componentName,
+			COMPONENT_STATUS_LEVELS.LOADING,
+			message || 'Loading...',
+			undefined,
+			this.source
+		);
 		return this;
 	}
 
@@ -69,7 +87,13 @@ export class ComponentStatusBuilder {
 	 * @returns this for chaining
 	 */
 	unknown(message?: string): this {
-		componentStatusRegistry.setStatus(this.componentName, COMPONENT_STATUS_LEVELS.UNKNOWN, message, undefined, this.source);
+		componentStatusRegistry.setStatus(
+			this.componentName,
+			COMPONENT_STATUS_LEVELS.UNKNOWN,
+			message,
+			undefined,
+			this.source
+		);
 		return this;
 	}
 

--- a/components/status/api.ts
+++ b/components/status/api.ts
@@ -7,7 +7,7 @@
 
 import { componentStatusRegistry } from './registry.ts';
 import { ComponentStatus } from './ComponentStatus.ts';
-import { COMPONENT_STATUS_LEVELS } from './types.ts';
+import { COMPONENT_STATUS_LEVELS, type ComponentStatusSource } from './types.ts';
 
 /**
  * Component Status Builder
@@ -15,9 +15,11 @@ import { COMPONENT_STATUS_LEVELS } from './types.ts';
  */
 export class ComponentStatusBuilder {
 	private componentName: string;
+	private source: ComponentStatusSource;
 
-	constructor(componentName: string) {
+	constructor(componentName: string, source: ComponentStatusSource = 'explicit') {
 		this.componentName = componentName;
+		this.source = source;
 	}
 
 	/**
@@ -26,7 +28,7 @@ export class ComponentStatusBuilder {
 	 * @returns this for chaining
 	 */
 	healthy(message?: string): this {
-		componentStatusRegistry.setStatus(this.componentName, COMPONENT_STATUS_LEVELS.HEALTHY, message);
+		componentStatusRegistry.setStatus(this.componentName, COMPONENT_STATUS_LEVELS.HEALTHY, message, undefined, this.source);
 		return this;
 	}
 
@@ -36,7 +38,7 @@ export class ComponentStatusBuilder {
 	 * @returns this for chaining
 	 */
 	warning(message: string): this {
-		componentStatusRegistry.setStatus(this.componentName, COMPONENT_STATUS_LEVELS.WARNING, message);
+		componentStatusRegistry.setStatus(this.componentName, COMPONENT_STATUS_LEVELS.WARNING, message, undefined, this.source);
 		return this;
 	}
 
@@ -47,7 +49,7 @@ export class ComponentStatusBuilder {
 	 * @returns this for chaining
 	 */
 	error(message: string, error?: Error): this {
-		componentStatusRegistry.setStatus(this.componentName, COMPONENT_STATUS_LEVELS.ERROR, message, error);
+		componentStatusRegistry.setStatus(this.componentName, COMPONENT_STATUS_LEVELS.ERROR, message, error, this.source);
 		return this;
 	}
 
@@ -57,7 +59,7 @@ export class ComponentStatusBuilder {
 	 * @returns this for chaining
 	 */
 	loading(message?: string): this {
-		componentStatusRegistry.setStatus(this.componentName, COMPONENT_STATUS_LEVELS.LOADING, message || 'Loading...');
+		componentStatusRegistry.setStatus(this.componentName, COMPONENT_STATUS_LEVELS.LOADING, message || 'Loading...', undefined, this.source);
 		return this;
 	}
 
@@ -67,7 +69,7 @@ export class ComponentStatusBuilder {
 	 * @returns this for chaining
 	 */
 	unknown(message?: string): this {
-		componentStatusRegistry.setStatus(this.componentName, COMPONENT_STATUS_LEVELS.UNKNOWN, message);
+		componentStatusRegistry.setStatus(this.componentName, COMPONENT_STATUS_LEVELS.UNKNOWN, message, undefined, this.source);
 		return this;
 	}
 

--- a/components/status/crossThread.ts
+++ b/components/status/crossThread.ts
@@ -312,6 +312,8 @@ export class StatusAggregator {
 		let mostRecentCheckTime = 0;
 		let latestMessage: string | undefined;
 		let error: Error | string | undefined;
+		let source: string | undefined;
+		let totalOccurrenceCount = 0;
 		const statusCounts = new Map<ComponentStatusLevel, number>();
 		const abnormalities = new Map<string, ComponentStatusAbnormality>();
 
@@ -349,6 +351,10 @@ export class StatusAggregator {
 			if (status.error && !error) {
 				error = status.error;
 			}
+
+			// Track source and occurrence count
+			if (status.source) source = status.source;
+			if (status.occurrenceCount) totalOccurrenceCount += status.occurrenceCount;
 		}
 
 		// Determine overall status (priority: error > warning > loading > unknown > healthy)
@@ -377,6 +383,8 @@ export class StatusAggregator {
 			lastChecked: lastCheckedTimes,
 			latestMessage,
 			error,
+			source: source as any,
+			occurrenceCount: totalOccurrenceCount || undefined,
 		};
 
 		// Only add abnormalities if there are any

--- a/components/status/healthChecks.ts
+++ b/components/status/healthChecks.ts
@@ -1,0 +1,127 @@
+/**
+ * System Health Checks
+ *
+ * Periodic monitoring of system resources (disk, memory, CPU) that reports
+ * status via the component status system. Health check statuses self-heal:
+ * when the metric returns to normal, status reverts to healthy.
+ *
+ * Runs on the main thread only.
+ */
+
+import { componentStatusRegistry } from './registry.ts';
+import { COMPONENT_STATUS_LEVELS } from './types.ts';
+
+interface ThresholdConfig {
+	warning: number;
+	error: number;
+}
+
+interface HealthCheckConfig {
+	enabled?: boolean;
+	intervalSeconds?: number;
+	thresholds?: {
+		disk?: ThresholdConfig;
+		memory?: ThresholdConfig;
+		cpu?: ThresholdConfig;
+	};
+}
+
+const DEFAULT_THRESHOLDS: Record<string, ThresholdConfig> = {
+	disk: { warning: 80, error: 95 },
+	memory: { warning: 80, error: 95 },
+	cpu: { warning: 85, error: 95 },
+};
+
+const DEFAULT_INTERVAL_SECONDS = 60;
+
+function setHealthStatus(name: string, percent: number, thresholds: ThresholdConfig, label: string) {
+	const key = `system.${name}`;
+	if (percent >= thresholds.error) {
+		componentStatusRegistry.setStatus(
+			key, COMPONENT_STATUS_LEVELS.ERROR,
+			`${label} at ${percent.toFixed(1)}% utilization`, undefined, 'health-check'
+		);
+	} else if (percent >= thresholds.warning) {
+		componentStatusRegistry.setStatus(
+			key, COMPONENT_STATUS_LEVELS.WARNING,
+			`${label} at ${percent.toFixed(1)}% utilization`, undefined, 'health-check'
+		);
+	} else {
+		componentStatusRegistry.setStatus(
+			key, COMPONENT_STATUS_LEVELS.HEALTHY,
+			`${label} at ${percent.toFixed(1)}% utilization`, undefined, 'health-check'
+		);
+	}
+}
+
+async function checkDisk(thresholds: ThresholdConfig) {
+	try {
+		const si = await import('systeminformation');
+		const fsSizes = await si.fsSize();
+		// Check the filesystem with the highest usage
+		let worstPercent = 0;
+		let worstMount = '';
+		for (const fs of fsSizes) {
+			if (fs.use > worstPercent) {
+				worstPercent = fs.use;
+				worstMount = fs.mount;
+			}
+		}
+		if (worstPercent > 0) {
+			setHealthStatus('disk', worstPercent, thresholds, `Disk (${worstMount})`);
+		}
+	} catch {
+		// systeminformation may not be available in all environments
+	}
+}
+
+async function checkMemory(thresholds: ThresholdConfig) {
+	try {
+		const si = await import('systeminformation');
+		const mem = await si.mem();
+		if (mem.total > 0) {
+			const usedPercent = ((mem.total - mem.available) / mem.total) * 100;
+			setHealthStatus('memory', usedPercent, thresholds, 'Memory');
+		}
+	} catch {
+		// systeminformation may not be available in all environments
+	}
+}
+
+async function checkCPU(thresholds: ThresholdConfig) {
+	try {
+		const si = await import('systeminformation');
+		const load = await si.currentLoad();
+		if (load.currentLoad !== undefined) {
+			setHealthStatus('cpu', load.currentLoad, thresholds, 'CPU');
+		}
+	} catch {
+		// systeminformation may not be available in all environments
+	}
+}
+
+async function runChecks(thresholds: Record<string, ThresholdConfig>) {
+	await Promise.all([
+		checkDisk(thresholds.disk),
+		checkMemory(thresholds.memory),
+		checkCPU(thresholds.cpu),
+	]);
+}
+
+export function startHealthChecks(config?: HealthCheckConfig) {
+	if (config?.enabled === false) return;
+
+	const thresholds = {
+		disk: config?.thresholds?.disk || DEFAULT_THRESHOLDS.disk,
+		memory: config?.thresholds?.memory || DEFAULT_THRESHOLDS.memory,
+		cpu: config?.thresholds?.cpu || DEFAULT_THRESHOLDS.cpu,
+	};
+	const intervalMs = (config?.intervalSeconds || DEFAULT_INTERVAL_SECONDS) * 1000;
+
+	// Run immediately
+	runChecks(thresholds);
+
+	// Then periodically
+	const timer = setInterval(() => runChecks(thresholds), intervalMs);
+	timer.unref();
+}

--- a/components/status/healthChecks.ts
+++ b/components/status/healthChecks.ts
@@ -38,18 +38,27 @@ function setHealthStatus(name: string, percent: number, thresholds: ThresholdCon
 	const key = `system.${name}`;
 	if (percent >= thresholds.error) {
 		componentStatusRegistry.setStatus(
-			key, COMPONENT_STATUS_LEVELS.ERROR,
-			`${label} at ${percent.toFixed(1)}% utilization`, undefined, 'health-check'
+			key,
+			COMPONENT_STATUS_LEVELS.ERROR,
+			`${label} at ${percent.toFixed(1)}% utilization`,
+			undefined,
+			'health-check'
 		);
 	} else if (percent >= thresholds.warning) {
 		componentStatusRegistry.setStatus(
-			key, COMPONENT_STATUS_LEVELS.WARNING,
-			`${label} at ${percent.toFixed(1)}% utilization`, undefined, 'health-check'
+			key,
+			COMPONENT_STATUS_LEVELS.WARNING,
+			`${label} at ${percent.toFixed(1)}% utilization`,
+			undefined,
+			'health-check'
 		);
 	} else {
 		componentStatusRegistry.setStatus(
-			key, COMPONENT_STATUS_LEVELS.HEALTHY,
-			`${label} at ${percent.toFixed(1)}% utilization`, undefined, 'health-check'
+			key,
+			COMPONENT_STATUS_LEVELS.HEALTHY,
+			`${label} at ${percent.toFixed(1)}% utilization`,
+			undefined,
+			'health-check'
 		);
 	}
 }
@@ -101,11 +110,7 @@ async function checkCPU(thresholds: ThresholdConfig) {
 }
 
 async function runChecks(thresholds: Record<string, ThresholdConfig>) {
-	await Promise.all([
-		checkDisk(thresholds.disk),
-		checkMemory(thresholds.memory),
-		checkCPU(thresholds.cpu),
-	]);
+	await Promise.all([checkDisk(thresholds.disk), checkMemory(thresholds.memory), checkCPU(thresholds.cpu)]);
 }
 
 export function startHealthChecks(config?: HealthCheckConfig) {

--- a/components/status/hierarchy.ts
+++ b/components/status/hierarchy.ts
@@ -39,9 +39,7 @@ const STATUS_PRIORITY: Record<ComponentStatusLevel, number> = {
  *   'system.disk' -> { system: { children: { disk: { status: 'warning', ... } } } }
  *   'replication' -> { replication: { status: 'error', ... } }
  */
-export function buildHierarchy(
-	statuses: Map<string, AggregatedComponentStatus>
-): Record<string, StatusNode> {
+export function buildHierarchy(statuses: Map<string, AggregatedComponentStatus>): Record<string, StatusNode> {
 	const root: Record<string, StatusNode> = {};
 
 	for (const [name, status] of statuses) {

--- a/components/status/hierarchy.ts
+++ b/components/status/hierarchy.ts
@@ -1,0 +1,105 @@
+/**
+ * Status Hierarchy Builder
+ *
+ * Builds a tree-structured view of component status from the flat status map.
+ * Component names are split on '.' to create parent-child relationships.
+ * Parent status rolls up from children (worst status wins).
+ */
+
+import {
+	type ComponentStatusLevel,
+	type ComponentStatusSource,
+	type AggregatedComponentStatus,
+	COMPONENT_STATUS_LEVELS,
+} from './types.ts';
+
+export interface StatusNode {
+	status: ComponentStatusLevel;
+	message?: string;
+	source?: ComponentStatusSource;
+	lastChecked?: { main?: number; workers: Record<number, number> };
+	occurrenceCount?: number;
+	error?: Error | string;
+	children?: Record<string, StatusNode>;
+}
+
+const STATUS_PRIORITY: Record<ComponentStatusLevel, number> = {
+	[COMPONENT_STATUS_LEVELS.ERROR]: 4,
+	[COMPONENT_STATUS_LEVELS.WARNING]: 3,
+	[COMPONENT_STATUS_LEVELS.LOADING]: 2,
+	[COMPONENT_STATUS_LEVELS.UNKNOWN]: 1,
+	[COMPONENT_STATUS_LEVELS.HEALTHY]: 0,
+};
+
+/**
+ * Build a hierarchical status tree from a flat map of aggregated statuses.
+ * Names are split on '.' to create parent/child structure.
+ *
+ * Example:
+ *   'system.disk' -> { system: { children: { disk: { status: 'warning', ... } } } }
+ *   'replication' -> { replication: { status: 'error', ... } }
+ */
+export function buildHierarchy(
+	statuses: Map<string, AggregatedComponentStatus>
+): Record<string, StatusNode> {
+	const root: Record<string, StatusNode> = {};
+
+	for (const [name, status] of statuses) {
+		const parts = name.split('.');
+		let currentLevel = root;
+
+		for (let i = 0; i < parts.length; i++) {
+			const part = parts[i];
+			if (!currentLevel[part]) {
+				currentLevel[part] = {
+					status: COMPONENT_STATUS_LEVELS.HEALTHY,
+				};
+			}
+			const node = currentLevel[part];
+
+			if (i === parts.length - 1) {
+				// Leaf node -- set actual status from aggregated data
+				node.status = status.status;
+				node.message = status.latestMessage;
+				node.source = status.source;
+				node.lastChecked = status.lastChecked;
+				node.occurrenceCount = status.occurrenceCount;
+				if (status.error) node.error = status.error;
+			} else {
+				// Intermediate node -- ensure children map exists
+				if (!node.children) node.children = {};
+				currentLevel = node.children;
+			}
+		}
+	}
+
+	rollUpStatus(root);
+	return root;
+}
+
+/**
+ * Roll up status from children to parents.
+ * A parent's status is the worst (highest priority) status among its children.
+ */
+function rollUpStatus(nodes: Record<string, StatusNode>): ComponentStatusLevel {
+	let worstStatus: ComponentStatusLevel = COMPONENT_STATUS_LEVELS.HEALTHY;
+
+	for (const node of Object.values(nodes)) {
+		let nodeStatus = node.status;
+
+		if (node.children) {
+			const childWorst = rollUpStatus(node.children);
+			// Parent status = worst of own status and children's worst
+			if (STATUS_PRIORITY[childWorst] > STATUS_PRIORITY[nodeStatus]) {
+				nodeStatus = childWorst;
+				node.status = nodeStatus;
+			}
+		}
+
+		if (STATUS_PRIORITY[nodeStatus] > STATUS_PRIORITY[worstStatus]) {
+			worstStatus = nodeStatus;
+		}
+	}
+
+	return worstStatus;
+}

--- a/components/status/internal.ts
+++ b/components/status/internal.ts
@@ -9,6 +9,8 @@
 import type { ComponentStatusLevel } from './types.ts';
 import { componentStatusRegistry } from './registry.ts';
 import { ComponentStatusRegistry } from './ComponentStatusRegistry.ts';
+import { initLogBridge } from './logBridge.ts';
+import { isMainThread } from 'node:worker_threads';
 
 // Internal classes and types
 export { ComponentStatus } from './ComponentStatus.ts';
@@ -24,6 +26,18 @@ export * from './errors.ts';
 
 // All type definitions
 export * from './types.ts';
+
+// Log bridge and health checks
+export { initLogBridge } from './logBridge.ts';
+export { startHealthChecks } from './healthChecks.ts';
+
+// Initialize the log-to-status bridge immediately so logger.status() calls work
+initLogBridge();
+
+// Start health checks on the main thread only
+if (isMainThread) {
+	startHealthChecks();
+}
 
 // Internal query functions for Harper core
 export const query = {

--- a/components/status/internal.ts
+++ b/components/status/internal.ts
@@ -10,6 +10,7 @@ import type { ComponentStatusLevel } from './types.ts';
 import { componentStatusRegistry } from './registry.ts';
 import { ComponentStatusRegistry } from './ComponentStatusRegistry.ts';
 import { initLogBridge } from './logBridge.ts';
+import { startHealthChecks } from './healthChecks.ts';
 import { isMainThread } from 'node:worker_threads';
 
 // Internal classes and types

--- a/components/status/logBridge.ts
+++ b/components/status/logBridge.ts
@@ -57,10 +57,16 @@ export function handleStatusLog(
 		if (options.resolves) {
 			clearExpiry(options.resolves);
 			componentStatusRegistry.setStatus(
-				options.resolves, COMPONENT_STATUS_LEVELS.HEALTHY, 'Resolved', undefined, 'log'
+				options.resolves,
+				COMPONENT_STATUS_LEVELS.HEALTHY,
+				'Resolved',
+				undefined,
+				'log'
 			);
 		} else if (options.problem) {
-			const statusLevel = options.level ? (LOG_TO_STATUS_LEVEL[options.level] || COMPONENT_STATUS_LEVELS.WARNING) : COMPONENT_STATUS_LEVELS.ERROR;
+			const statusLevel = options.level
+				? LOG_TO_STATUS_LEVEL[options.level] || COMPONENT_STATUS_LEVELS.WARNING
+				: COMPONENT_STATUS_LEVELS.ERROR;
 			componentStatusRegistry.setStatus(options.problem, statusLevel, undefined, undefined, 'log');
 			if (options.expires) {
 				scheduleExpiry(options.problem, options.expires * 1000);
@@ -74,7 +80,11 @@ export function handleStatusLog(
 	if (options.resolves) {
 		clearExpiry(options.resolves);
 		componentStatusRegistry.setStatus(
-			options.resolves, COMPONENT_STATUS_LEVELS.HEALTHY, message || 'Resolved', undefined, 'log'
+			options.resolves,
+			COMPONENT_STATUS_LEVELS.HEALTHY,
+			message || 'Resolved',
+			undefined,
+			'log'
 		);
 		return;
 	}

--- a/components/status/logBridge.ts
+++ b/components/status/logBridge.ts
@@ -1,0 +1,100 @@
+/**
+ * Log-to-Status Bridge
+ *
+ * Handles the connection between logger.status() calls and the component status system.
+ * When code uses logger.status({ problem: 'key' }).error('message'), this module
+ * receives the call and updates the ComponentStatusRegistry accordingly.
+ */
+
+import { componentStatusRegistry } from './registry.ts';
+import { COMPONENT_STATUS_LEVELS } from './types.ts';
+import type { StatusOptions } from '../../utility/logging/logger.ts';
+import { setStatusHandler } from '../../utility/logging/harper_logger.js';
+
+const LOG_TO_STATUS_LEVEL = {
+	fatal: COMPONENT_STATUS_LEVELS.ERROR,
+	error: COMPONENT_STATUS_LEVELS.ERROR,
+	warn: COMPONENT_STATUS_LEVELS.WARNING,
+	notify: COMPONENT_STATUS_LEVELS.WARNING,
+	info: COMPONENT_STATUS_LEVELS.WARNING,
+	debug: COMPONENT_STATUS_LEVELS.WARNING,
+	trace: COMPONENT_STATUS_LEVELS.WARNING,
+} as const;
+
+const expiryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function formatMessage(args: any[]): string {
+	return args
+		.map((a) => {
+			if (typeof a === 'string') return a;
+			if (a instanceof Error) return a.message;
+			try {
+				return String(a);
+			} catch {
+				return '[unserializable]';
+			}
+		})
+		.join(' ')
+		.substring(0, 500);
+}
+
+/**
+ * Status handler called by the logger's .status() wrapper.
+ * This is registered with harper_logger.js via setStatusHandler().
+ */
+export function handleStatusLog(
+	options: StatusOptions,
+	level: string,
+	componentTag: string | undefined,
+	args: any[]
+) {
+	const message = formatMessage(args);
+
+	if (options.resolves) {
+		clearExpiry(options.resolves);
+		componentStatusRegistry.setStatus(
+			options.resolves, COMPONENT_STATUS_LEVELS.HEALTHY, message || 'Resolved', undefined, 'log'
+		);
+		return;
+	}
+
+	if (options.problem) {
+		const key = options.problem;
+		const statusLevel = LOG_TO_STATUS_LEVEL[level] || COMPONENT_STATUS_LEVELS.WARNING;
+		const errorArg = args.find((a) => a instanceof Error);
+
+		componentStatusRegistry.setStatus(key, statusLevel, message, errorArg, 'log');
+
+		if (options.expires) {
+			scheduleExpiry(key, options.expires * 1000);
+		} else {
+			clearExpiry(key);
+		}
+	}
+}
+
+function scheduleExpiry(key: string, ms: number) {
+	clearExpiry(key);
+	const timer = setTimeout(() => {
+		componentStatusRegistry.setStatus(key, COMPONENT_STATUS_LEVELS.HEALTHY, 'Auto-expired', undefined, 'log');
+		expiryTimers.delete(key);
+	}, ms);
+	timer.unref();
+	expiryTimers.set(key, timer);
+}
+
+function clearExpiry(key: string) {
+	const existing = expiryTimers.get(key);
+	if (existing) {
+		clearTimeout(existing);
+		expiryTimers.delete(key);
+	}
+}
+
+/**
+ * Initialize the log-to-status bridge by registering handleStatusLog
+ * with the harper logger's setStatusHandler.
+ */
+export function initLogBridge() {
+	setStatusHandler(handleStatusLog);
+}

--- a/components/status/logBridge.ts
+++ b/components/status/logBridge.ts
@@ -44,10 +44,31 @@ function formatMessage(args: any[]): string {
  */
 export function handleStatusLog(
 	options: StatusOptions,
-	level: string,
+	level: string | null,
 	componentTag: string | undefined,
 	args: any[]
 ) {
+	// When level is null, this is a status-only call (no chained log method).
+	// If a chained method follows, it will call again with level set — skip the
+	// initial status-only call in that case by deferring: the chained call will
+	// provide the actual level and message.
+	if (level === null) {
+		// Immediate status-only registration (no log output)
+		if (options.resolves) {
+			clearExpiry(options.resolves);
+			componentStatusRegistry.setStatus(
+				options.resolves, COMPONENT_STATUS_LEVELS.HEALTHY, 'Resolved', undefined, 'log'
+			);
+		} else if (options.problem) {
+			const statusLevel = options.level ? (LOG_TO_STATUS_LEVEL[options.level] || COMPONENT_STATUS_LEVELS.WARNING) : COMPONENT_STATUS_LEVELS.ERROR;
+			componentStatusRegistry.setStatus(options.problem, statusLevel, undefined, undefined, 'log');
+			if (options.expires) {
+				scheduleExpiry(options.problem, options.expires * 1000);
+			}
+		}
+		return;
+	}
+
 	const message = formatMessage(args);
 
 	if (options.resolves) {

--- a/components/status/types.ts
+++ b/components/status/types.ts
@@ -18,6 +18,8 @@ export const COMPONENT_STATUS_LEVELS = {
 
 export type ComponentStatusLevel = (typeof COMPONENT_STATUS_LEVELS)[keyof typeof COMPONENT_STATUS_LEVELS];
 
+export type ComponentStatusSource = 'log' | 'explicit' | 'health-check';
+
 /**
  * Component status information as a plain object
  */
@@ -32,6 +34,10 @@ export interface ComponentStatusSummary {
 	error?: Error | string;
 	/** Worker index for cross-thread tracking */
 	workerIndex?: number;
+	/** How the status was set */
+	source?: ComponentStatusSource;
+	/** Number of times this status has been reported */
+	occurrenceCount?: number;
 }
 
 /**
@@ -69,6 +75,10 @@ export interface AggregatedComponentStatus {
 	latestMessage?: string;
 	/** Any error from any thread */
 	error?: Error | string;
+	/** How the status was set */
+	source?: ComponentStatusSource;
+	/** Number of times this status has been reported (across all threads) */
+	occurrenceCount?: number;
 }
 
 /**

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -665,13 +665,17 @@ function startMonitoringTxns() {
 					// replay are excluded: they have no resubscribe/resume path, so aborting a write would drop
 					// it while the resume cursor advances past it — a permanent divergence (harper-pro#348). For
 					// those, keep the prior force-commit behavior below.
-					harperLogger.status({ problem: 'database.txn-open-too-long' }).error(
-						`Transaction was open too long and has been aborted after exceeding the open-transaction limit, from table: ${
-							(txn.db as any)?.name + (url ? ' path: ' + url : '')
-						}`,
-						...(txn.startedFrom ? [`was started from ${txn.startedFrom.resourceName}.${txn.startedFrom.method}`] : []),
-						...(DEBUG_LONG_TXNS ? ['starting stack trace', txn.stackTraces] : [])
-					);
+					harperLogger
+						.status({ problem: 'database.txn-open-too-long' })
+						.error(
+							`Transaction was open too long and has been aborted after exceeding the open-transaction limit, from table: ${
+								(txn.db as any)?.name + (url ? ' path: ' + url : '')
+							}`,
+							...(txn.startedFrom
+								? [`was started from ${txn.startedFrom.resourceName}.${txn.startedFrom.method}`]
+								: []),
+							...(DEBUG_LONG_TXNS ? ['starting stack trace', txn.stackTraces] : [])
+						);
 					try {
 						txn.abortDueToTimeout();
 					} catch (error) {
@@ -681,13 +685,17 @@ function startMonitoringTxns() {
 					// Read-only long transaction (no atomicity/index risk — e.g. a large scan or export), or a
 					// canonical-source apply/replay that must never drop a write: preserve the prior behavior of
 					// committing to close out the snapshot without poisoning the transaction.
-					harperLogger.status({ problem: 'database.txn-open-too-long' }).error(
-						`Transaction was open too long and has been committed, from table: ${
-							(txn.db as any)?.name + (url ? ' path: ' + url : '')
-						}`,
-						...(txn.startedFrom ? [`was started from ${txn.startedFrom.resourceName}.${txn.startedFrom.method}`] : []),
-						...(DEBUG_LONG_TXNS ? ['starting stack trace', txn.stackTraces] : [])
-					);
+					harperLogger
+						.status({ problem: 'database.txn-open-too-long' })
+						.error(
+							`Transaction was open too long and has been committed, from table: ${
+								(txn.db as any)?.name + (url ? ' path: ' + url : '')
+							}`,
+							...(txn.startedFrom
+								? [`was started from ${txn.startedFrom.resourceName}.${txn.startedFrom.method}`]
+								: []),
+							...(DEBUG_LONG_TXNS ? ['starting stack trace', txn.stackTraces] : [])
+						);
 					try {
 						const result = txn.commit();
 						if ((result as any)?.then) {

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -197,6 +197,7 @@ export class DatabaseTransaction implements Transaction {
 			!this.overloadChecked &&
 			performance.now() - outstandingCommitStart > MAX_OUTSTANDING_TXN_DURATION
 		) {
+			harperLogger.status({ problem: 'database.write-queue-overloaded' }).error('Outstanding write transactions have too long of queue');
 			throw new ServerError('Outstanding write transactions have too long of queue, please try again later', 503);
 		}
 		this.overloadChecked = true; // only check this once, don't interrupt ongoing transactions that have already made writes
@@ -664,7 +665,7 @@ function startMonitoringTxns() {
 					// replay are excluded: they have no resubscribe/resume path, so aborting a write would drop
 					// it while the resume cursor advances past it — a permanent divergence (harper-pro#348). For
 					// those, keep the prior force-commit behavior below.
-					harperLogger.error(
+					harperLogger.status({ problem: 'database.txn-open-too-long' }).error(
 						`Transaction was open too long and has been aborted after exceeding the open-transaction limit, from table: ${
 							(txn.db as any)?.name + (url ? ' path: ' + url : '')
 						}`,
@@ -680,6 +681,13 @@ function startMonitoringTxns() {
 					// Read-only long transaction (no atomicity/index risk — e.g. a large scan or export), or a
 					// canonical-source apply/replay that must never drop a write: preserve the prior behavior of
 					// committing to close out the snapshot without poisoning the transaction.
+					harperLogger.status({ problem: 'database.txn-open-too-long' }).error(
+						`Transaction was open too long and has been committed, from table: ${
+							(txn.db as any)?.name + (url ? ' path: ' + url : '')
+						}`,
+						...(txn.startedFrom ? [`was started from ${txn.startedFrom.resourceName}.${txn.startedFrom.method}`] : []),
+						...(DEBUG_LONG_TXNS ? ['starting stack trace', txn.stackTraces] : [])
+					);
 					try {
 						const result = txn.commit();
 						if ((result as any)?.then) {

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -197,7 +197,7 @@ export class DatabaseTransaction implements Transaction {
 			!this.overloadChecked &&
 			performance.now() - outstandingCommitStart > MAX_OUTSTANDING_TXN_DURATION
 		) {
-			harperLogger.status({ problem: 'database.write-queue-overloaded' }).error('Outstanding write transactions have too long of queue');
+			harperLogger.status({ problem: 'database.write-queue-overloaded', expires: 60 });
 			throw new ServerError('Outstanding write transactions have too long of queue, please try again later', 503);
 		}
 		this.overloadChecked = true; // only check this once, don't interrupt ongoing transactions that have already made writes

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -480,7 +480,7 @@ export class RecordEncoder extends StructonEncoder {
 				);
 				return null;
 			}
-			harperLogger.error('Error decoding record', error, 'data: ' + hexPreview);
+			harperLogger.status({ problem: 'database.record-decode' }).error('Error decoding record', error, 'data: ' + hexPreview);
 			return null;
 		}
 	}
@@ -632,7 +632,7 @@ export function checkReadTxnTimeouts() {
 			if (txn.openTimer) {
 				if (txn.openTimer > 3) {
 					if (txn.openTimer > READ_TXN_TIMEOUT_TICKS) {
-						harperLogger.error(
+						harperLogger.status({ problem: 'database.read-txn-critical' }).error(
 							`Read transaction detected that has been open too long (over ${Math.round(READ_TXN_TIMEOUT_TICKS * 15)} seconds), ending transaction`,
 							txn
 						);
@@ -645,7 +645,7 @@ export function checkReadTxnTimeouts() {
 							harperLogger.warn('Unexpected error force-closing stale LMDB read transaction', error);
 						}
 					} else
-						harperLogger.error(
+						harperLogger.status({ problem: 'database.read-txn-long', expires: 60 }).error(
 							'Read transaction detected that has been open too long (over one minute), make sure read transactions are quickly closed',
 							txn
 						);

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -480,7 +480,9 @@ export class RecordEncoder extends StructonEncoder {
 				);
 				return null;
 			}
-			harperLogger.status({ problem: 'database.record-decode' }).error('Error decoding record', error, 'data: ' + hexPreview);
+			harperLogger
+				.status({ problem: 'database.record-decode' })
+				.error('Error decoding record', error, 'data: ' + hexPreview);
 			return null;
 		}
 	}
@@ -632,10 +634,12 @@ export function checkReadTxnTimeouts() {
 			if (txn.openTimer) {
 				if (txn.openTimer > 3) {
 					if (txn.openTimer > READ_TXN_TIMEOUT_TICKS) {
-						harperLogger.status({ problem: 'database.read-txn-critical' }).error(
-							`Read transaction detected that has been open too long (over ${Math.round(READ_TXN_TIMEOUT_TICKS * 15)} seconds), ending transaction`,
-							txn
-						);
+						harperLogger
+							.status({ problem: 'database.read-txn-critical' })
+							.error(
+								`Read transaction detected that has been open too long (over ${Math.round(READ_TXN_TIMEOUT_TICKS * 15)} seconds), ending transaction`,
+								txn
+							);
 						trackedTxns.splice(i--, 1);
 						txn.timerTracked = false;
 						txn.openTimer = 0;
@@ -645,10 +649,12 @@ export function checkReadTxnTimeouts() {
 							harperLogger.warn('Unexpected error force-closing stale LMDB read transaction', error);
 						}
 					} else
-						harperLogger.status({ problem: 'database.read-txn-long', expires: 60 }).error(
-							'Read transaction detected that has been open too long (over one minute), make sure read transactions are quickly closed',
-							txn
-						);
+						harperLogger
+							.status({ problem: 'database.read-txn-long', expires: 60 })
+							.error(
+								'Read transaction detected that has been open too long (over one minute), make sure read transactions are quickly closed',
+								txn
+							);
 				}
 				txn.openTimer++;
 			} else txn.openTimer = 1;

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -229,7 +229,7 @@ export function openAuditStore(rootStore) {
 		for (const time of auditStore.getKeys({ reverse: true, limit: 1 })) {
 			if (time > Date.now()) {
 				timestampErrored = true;
-				harperLogger.error(
+				harperLogger.status({ problem: 'system.time-reversal' }).error(
 					'The current time is before the last recorded entry in the audit log. Time reversal can undermine the integrity of data tracking and certificate validation and the time must be corrected.'
 				);
 			}

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -229,9 +229,11 @@ export function openAuditStore(rootStore) {
 		for (const time of auditStore.getKeys({ reverse: true, limit: 1 })) {
 			if (time > Date.now()) {
 				timestampErrored = true;
-				harperLogger.status({ problem: 'system.time-reversal' }).error(
-					'The current time is before the last recorded entry in the audit log. Time reversal can undermine the integrity of data tracking and certificate validation and the time must be corrected.'
-				);
+				harperLogger
+					.status({ problem: 'system.time-reversal' })
+					.error(
+						'The current time is before the last recorded entry in the audit log. Time reversal can undermine the integrity of data tracking and certificate validation and the time must be corrected.'
+					);
 			}
 		}
 	}

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -661,7 +661,7 @@ function initStores(
 					}
 				}
 			} catch (error) {
-				logger.error(`Error trying to update attribute`, attribute, existingAttributes, indices, error);
+				logger.status({ problem: 'database.attribute-update' }).error(`Error trying to update attribute`, attribute, existingAttributes, indices, error);
 			}
 		}
 		// Collect removals first; splicing while iterating `existingAttributes` skips adjacent
@@ -672,7 +672,7 @@ function initStores(
 			const attribute = attributes.find((attribute) => attribute.name === existingAttribute.name);
 			if (!attribute) {
 				if (existingAttribute.isPrimaryKey) {
-					logger.error(
+					logger.status({ problem: 'database.primary-key' }).error(
 						new Error('Unable to remove existing primary key attribute'),
 						existingAttribute,
 						'from attributes',

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -661,7 +661,9 @@ function initStores(
 					}
 				}
 			} catch (error) {
-				logger.status({ problem: 'database.attribute-update' }).error(`Error trying to update attribute`, attribute, existingAttributes, indices, error);
+				logger
+					.status({ problem: 'database.attribute-update' })
+					.error(`Error trying to update attribute`, attribute, existingAttributes, indices, error);
 			}
 		}
 		// Collect removals first; splicing while iterating `existingAttributes` skips adjacent
@@ -672,18 +674,20 @@ function initStores(
 			const attribute = attributes.find((attribute) => attribute.name === existingAttribute.name);
 			if (!attribute) {
 				if (existingAttribute.isPrimaryKey) {
-					logger.status({ problem: 'database.primary-key' }).error(
-						new Error('Unable to remove existing primary key attribute'),
-						existingAttribute,
-						'from attributes',
-						existingAttributes,
-						'in',
-						tableName,
-						'requesting new attribute list',
-						attributes,
-						'full metadata list',
-						Array.from(attributesDbi.getRange({ start: false }))
-					);
+					logger
+						.status({ problem: 'database.primary-key' })
+						.error(
+							new Error('Unable to remove existing primary key attribute'),
+							existingAttribute,
+							'from attributes',
+							existingAttributes,
+							'in',
+							tableName,
+							'requesting new attribute list',
+							attributes,
+							'full metadata list',
+							Array.from(attributesDbi.getRange({ start: false }))
+						);
 					continue;
 				}
 				if (existingAttribute.indexed) {

--- a/server/fastifyRoutes.ts
+++ b/server/fastifyRoutes.ts
@@ -100,7 +100,7 @@ export async function customFunctionsServer() {
 			//generate a Fastify server instance
 			server = fastifyServer = await buildServer(isHttps);
 		} catch (err) {
-			harperLogger.error(`Custom Functions buildServer error: ${err}`);
+			harperLogger.status({ problem: 'custom-functions.build' }).error(`Custom Functions buildServer error: ${err}`);
 			throw err;
 		}
 
@@ -108,13 +108,13 @@ export async function customFunctionsServer() {
 			//make sure the process waits for the server to be fully instantiated before moving forward
 			await server.ready();
 		} catch (err) {
-			harperLogger.error(`Custom Functions server.ready() error: ${err}`);
+			harperLogger.status({ problem: 'custom-functions.ready' }).error(`Custom Functions server.ready() error: ${err}`);
 			throw err;
 		}
 		// fastify can't clean up properly
 		server.server.cantCleanupProperly = true;
 	} catch (err) {
-		harperLogger.error(`Custom Functions ${process.pid} Error: ${err}`);
+		harperLogger.status({ problem: 'custom-functions.init' }).error(`Custom Functions ${process.pid} Error: ${err}`);
 		harperLogger.error(err);
 		// Use realExit so this fatal worker bootstrap failure still terminates
 		// the worker even with the worker process guard installed.
@@ -159,9 +159,9 @@ function buildRouteFolder(routesFolder, projectName) {
 					}))
 					.after((err, instance, next) => {
 						if (err?.message) {
-							harperLogger.error(err.message);
+							harperLogger.status({ problem: 'custom-functions.routes' }).error(err.message);
 						} else if (err) {
-							harperLogger.error(err);
+							harperLogger.status({ problem: 'custom-functions.routes' }).error(err);
 						}
 						next();
 					});

--- a/server/http.ts
+++ b/server/http.ts
@@ -173,7 +173,9 @@ export function deliverSocket(fdOrSocket, port, data) {
 					if (data) socket.emit('data', data);
 				} else if (retries < 5) retry(retries + 1);
 				else {
-					harperLogger.status({ problem: 'server.port-registration' }).error(`Server on port ${port} was not registered`);
+					harperLogger
+						.status({ problem: 'server.port-registration' })
+						.error(`Server on port ${port} was not registered`);
 					socket.destroy();
 				}
 			}, 1000);

--- a/server/http.ts
+++ b/server/http.ts
@@ -173,7 +173,7 @@ export function deliverSocket(fdOrSocket, port, data) {
 					if (data) socket.emit('data', data);
 				} else if (retries < 5) retry(retries + 1);
 				else {
-					harperLogger.error(`Server on port ${port} was not registered`);
+					harperLogger.status({ problem: 'server.port-registration' }).error(`Server on port ${port} was not registered`);
 					socket.destroy();
 				}
 			}, 1000);

--- a/server/operationsServer.ts
+++ b/server/operationsServer.ts
@@ -103,13 +103,13 @@ async function operationsServer(options: ServerOptions & { resources?: Resources
 			}
 		} catch (err) {
 			server.close();
-			harperLogger.error(err);
+			harperLogger.status({ problem: 'operations-server.config' }).error(err);
 			harperLogger.error(`Error configuring operations server`);
 			throw err;
 		}
 	} catch (err) {
 		console.error(`Failed to build server on ${process.pid}`, err);
-		harperLogger.fatal(err);
+		harperLogger.status({ problem: 'operations-server.fatal' }).fatal(err);
 		// Use realExit so this fatal worker bootstrap failure still terminates
 		// the worker even with the worker process guard installed.
 		realExit(1);

--- a/server/serverHelpers/serverHandlers.js
+++ b/server/serverHelpers/serverHandlers.js
@@ -48,7 +48,7 @@ function handleServerUncaughtException(err) {
 		os.EOL
 	}Terminating ${isMainThread ? 'HDB' : 'thread'}.`;
 	console.error(message);
-	harperLogger.fatal(message);
+	harperLogger.status({ problem: 'system.uncaught-exception' }).fatal(message);
 	// Harper-intentional fatal termination on uncaught exception. Use realExit
 	// so the worker process guard does not intercept it.
 	realExit(1);

--- a/server/status/index.ts
+++ b/server/status/index.ts
@@ -4,6 +4,7 @@ import { loggerWithTag } from '../../utility/logging/logger.ts';
 import { validateStatus } from '../../validation/statusValidator.ts';
 import { type StatusId, type StatusValueMap, type StatusRecord, DEFAULT_STATUS_ID } from './definitions.ts';
 import { internal as statusInternal, type AggregatedComponentStatus } from '../../components/status/index.ts';
+import { buildHierarchy, type StatusNode } from '../../components/status/hierarchy.ts';
 import { restartNeeded } from '../../components/requestRestart.ts';
 import { sendItcEvent } from '../threads/itc.js';
 import { onMessageByType, workers } from '../threads/manageThreads.js';
@@ -81,6 +82,7 @@ interface AggregatedComponentStatusWithName extends AggregatedComponentStatus {
 interface AllStatusSummary {
 	systemStatus: Promise<AsyncIterable<StatusRecord>>;
 	componentStatus: AggregatedComponentStatusWithName[];
+	hierarchy: Record<string, StatusNode>;
 	restartRequired: boolean;
 	// Only present when the request opts in with `middleware: true`.
 	middlewareChains?: MiddlewareChainsSummary | null;
@@ -157,12 +159,16 @@ async function getAllStatus(includeMiddleware = false): Promise<AllStatusSummary
 		})
 	);
 
+	// Build hierarchical view
+	const hierarchy = buildHierarchy(aggregatedStatuses);
+
 	// Get restart flag status
 	const restartRequired = restartNeeded();
 
 	const summary: AllStatusSummary = {
 		systemStatus: statusRecords as Promise<AsyncIterable<StatusRecord>>,
 		componentStatus: componentStatusArray,
+		hierarchy,
 		restartRequired,
 	};
 	if (includeMiddleware) summary.middlewareChains = await getMiddlewareChains();

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -377,7 +377,7 @@ function startWorker(path, options = {}) {
 	worker.on('error', (error) => {
 		// log errors, and it also important that we catch errors so we can recover if a thread dies (in a recoverable
 		// way)
-		harperLogger.error(`Worker index ${options.workerIndex} error:`, error);
+		harperLogger.status({ problem: 'threads.worker-error', expires: 120 }).error(`Worker index ${options.workerIndex} error:`, error);
 	});
 	worker.on('exit', (_code) => {
 		workers.splice(workers.indexOf(worker), 1);
@@ -386,7 +386,7 @@ function startWorker(path, options = {}) {
 			if (worker.unexpectedRestarts < MAX_UNEXPECTED_RESTARTS) {
 				options.unexpectedRestarts = worker.unexpectedRestarts + 1;
 				startWorker(path, options);
-			} else harperLogger.error(`Thread has been restarted ${worker.restarts} times and will not be restarted`);
+			} else harperLogger.status({ problem: 'threads.restart-limit' }).error(`Thread has been restarted ${worker.restarts} times and will not be restarted`);
 		}
 	});
 	workers.push(worker);
@@ -421,7 +421,7 @@ async function restartWorkers(
 			// some reason, so we need to reset it to the correct path.
 			process.chdir(process.cwd());
 		} catch (e) {
-			harperLogger.error('Unable to reestablish current working directory', e);
+			harperLogger.status({ problem: 'threads.cwd' }).error('Unable to reestablish current working directory', e);
 		}
 		// problematic cyclic dependency, bind late
 		const { resetRestartNeeded } = require('../../components/requestRestart.ts');

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -377,7 +377,9 @@ function startWorker(path, options = {}) {
 	worker.on('error', (error) => {
 		// log errors, and it also important that we catch errors so we can recover if a thread dies (in a recoverable
 		// way)
-		harperLogger.status({ problem: 'threads.worker-error', expires: 120 }).error(`Worker index ${options.workerIndex} error:`, error);
+		harperLogger
+			.status({ problem: 'threads.worker-error', expires: 120 })
+			.error(`Worker index ${options.workerIndex} error:`, error);
 	});
 	worker.on('exit', (_code) => {
 		workers.splice(workers.indexOf(worker), 1);
@@ -386,7 +388,10 @@ function startWorker(path, options = {}) {
 			if (worker.unexpectedRestarts < MAX_UNEXPECTED_RESTARTS) {
 				options.unexpectedRestarts = worker.unexpectedRestarts + 1;
 				startWorker(path, options);
-			} else harperLogger.status({ problem: 'threads.restart-limit' }).error(`Thread has been restarted ${worker.restarts} times and will not be restarted`);
+			} else
+				harperLogger
+					.status({ problem: 'threads.restart-limit' })
+					.error(`Thread has been restarted ${worker.restarts} times and will not be restarted`);
 		}
 	});
 	workers.push(worker);

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -82,7 +82,7 @@ process.on('uncaughtException', (error) => {
 	if (error.isHandled) return;
 	if (error.code === 'ECONNRESET' || error.code === 'ECONNREFUSED') return; // that's what network connections do
 	if (error.message === 'write EIO') return; // that means the terminal is closed
-	harperLogger.error('uncaughtException', error);
+	harperLogger.status({ problem: 'threads.uncaught-exception' }).error('uncaughtException', error);
 });
 // In both Node.js 15+ and Bun, an unhandled promise rejection exits the worker unless a
 // handler is registered. Without this, any async path that rejects without being caught
@@ -498,7 +498,7 @@ async function listenOnPortsBun() {
 				harperLogger.info('Domain socket listening on ' + udsPath);
 			}
 		} catch (error) {
-			harperLogger.error(`Unable to start Bun server on port ${port}`, error);
+			harperLogger.status({ problem: 'server.port-bind' }).error(`Unable to start Bun server on port ${port}`, error);
 		}
 	}
 	// Also start any non-HTTP servers (raw socket servers) that were registered in SERVERS

--- a/unitTests/components/status/hierarchy.test.js
+++ b/unitTests/components/status/hierarchy.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const assert = require('node:assert');
+const { buildHierarchy } = require('#src/components/status/hierarchy');
+const { COMPONENT_STATUS_LEVELS } = require('#src/components/status/types');
+
+function agg(status, extra = {}) {
+	return { componentName: 'unused', status, lastChecked: { workers: {} }, ...extra };
+}
+
+describe('buildHierarchy', function () {
+	it('builds a single-level leaf node for a name with no dots', function () {
+		const statuses = new Map([['replication', agg(COMPONENT_STATUS_LEVELS.ERROR, { latestMessage: 'down' })]]);
+
+		const tree = buildHierarchy(statuses);
+
+		assert.equal(tree.replication.status, COMPONENT_STATUS_LEVELS.ERROR);
+		assert.equal(tree.replication.message, 'down');
+		assert.equal(tree.replication.children, undefined);
+	});
+
+	it('splits a dotted name into parent/child nodes', function () {
+		const statuses = new Map([['system.disk', agg(COMPONENT_STATUS_LEVELS.WARNING, { latestMessage: '85% full' })]]);
+
+		const tree = buildHierarchy(statuses);
+
+		assert.ok(tree.system, 'parent node should exist');
+		assert.ok(tree.system.children, 'parent should have children');
+		assert.equal(tree.system.children.disk.status, COMPONENT_STATUS_LEVELS.WARNING);
+		assert.equal(tree.system.children.disk.message, '85% full');
+	});
+
+	it('rolls up the worst child status to the parent (error beats warning/healthy)', function () {
+		const statuses = new Map([
+			['system.disk', agg(COMPONENT_STATUS_LEVELS.HEALTHY)],
+			['system.memory', agg(COMPONENT_STATUS_LEVELS.WARNING)],
+			['system.cpu', agg(COMPONENT_STATUS_LEVELS.ERROR)],
+		]);
+
+		const tree = buildHierarchy(statuses);
+
+		assert.equal(tree.system.status, COMPONENT_STATUS_LEVELS.ERROR, 'parent should roll up to the worst child');
+	});
+
+	it('rolls up through multiple levels of nesting', function () {
+		const statuses = new Map([
+			['application.rest.orders', agg(COMPONENT_STATUS_LEVELS.HEALTHY)],
+			['application.rest.users', agg(COMPONENT_STATUS_LEVELS.ERROR)],
+		]);
+
+		const tree = buildHierarchy(statuses);
+
+		assert.equal(tree.application.status, COMPONENT_STATUS_LEVELS.ERROR);
+		assert.equal(tree.application.children.rest.status, COMPONENT_STATUS_LEVELS.ERROR);
+		assert.equal(tree.application.children.rest.children.orders.status, COMPONENT_STATUS_LEVELS.HEALTHY);
+		assert.equal(tree.application.children.rest.children.users.status, COMPONENT_STATUS_LEVELS.ERROR);
+	});
+
+	it('defaults an intermediate node with no own status entry to healthy before roll-up', function () {
+		// 'system' itself never appears as a key -- only 'system.disk' does.
+		const statuses = new Map([['system.disk', agg(COMPONENT_STATUS_LEVELS.HEALTHY)]]);
+
+		const tree = buildHierarchy(statuses);
+
+		assert.equal(tree.system.status, COMPONENT_STATUS_LEVELS.HEALTHY);
+	});
+
+	it('returns an empty tree for an empty status map', function () {
+		const tree = buildHierarchy(new Map());
+		assert.deepStrictEqual(tree, {});
+	});
+
+	it('carries occurrenceCount and error through to the leaf node', function () {
+		const error = new Error('boom');
+		const statuses = new Map([
+			['database.write-queue-overloaded', agg(COMPONENT_STATUS_LEVELS.ERROR, { occurrenceCount: 3, error })],
+		]);
+
+		const tree = buildHierarchy(statuses);
+
+		assert.equal(tree.database.children['write-queue-overloaded'].occurrenceCount, 3);
+		assert.equal(tree.database.children['write-queue-overloaded'].error, error);
+	});
+});

--- a/unitTests/components/status/logBridge.test.js
+++ b/unitTests/components/status/logBridge.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const assert = require('node:assert');
+const { handleStatusLog, initLogBridge } = require('#src/components/status/logBridge');
+const { componentStatusRegistry } = require('#src/components/status/registry');
+const { COMPONENT_STATUS_LEVELS } = require('#src/components/status/types');
+const { setStatusHandler, createLogger } = require('#src/utility/logging/harper_logger');
+
+describe('logBridge', function () {
+	beforeEach(function () {
+		componentStatusRegistry.reset();
+		initLogBridge();
+	});
+
+	afterEach(function () {
+		setStatusHandler(undefined);
+		componentStatusRegistry.reset();
+	});
+
+	// Regression for #372: statusLogger() used to fire the level===null (status-only) dispatch
+	// immediately and unconditionally, so a chained call like .status({problem}).error(msg) always
+	// dispatched twice, doubling occurrenceCount for nearly every problem key this feature reports.
+	it('logger.status({problem}).error(msg) registers exactly one occurrence', async function () {
+		const logger = createLogger({ level: 'trace', writeToLog: () => {} });
+		logger.status({ problem: 'test.harper-372-chained' }).error('boom');
+
+		// the options-only dispatch (if any) is deferred to a microtask; let it flush
+		await new Promise((resolve) => setImmediate(resolve));
+
+		const status = componentStatusRegistry.getStatus('test.harper-372-chained');
+		assert.ok(status, 'status should be registered');
+		assert.equal(status.status, COMPONENT_STATUS_LEVELS.ERROR);
+		assert.equal(status.message, 'boom');
+		assert.equal(status.occurrenceCount, 1, 'occurrenceCount must not be inflated by a double dispatch');
+	});
+
+	it('a status-only call with no chained method still registers once', async function () {
+		const logger = createLogger({ level: 'trace', writeToLog: () => {} });
+		logger.status({ problem: 'test.harper-372-status-only' });
+
+		await new Promise((resolve) => setImmediate(resolve));
+
+		const status = componentStatusRegistry.getStatus('test.harper-372-status-only');
+		assert.ok(status, 'status should be registered');
+		assert.equal(status.status, COMPONENT_STATUS_LEVELS.ERROR);
+		assert.equal(status.occurrenceCount, 1);
+	});
+
+	it('handleStatusLog(level=null) registers a problem directly against the registry', function () {
+		handleStatusLog({ problem: 'test.status-only-direct' }, null, undefined, []);
+
+		const status = componentStatusRegistry.getStatus('test.status-only-direct');
+		assert.ok(status);
+		assert.equal(status.status, COMPONENT_STATUS_LEVELS.ERROR);
+	});
+
+	it('handleStatusLog(level=null) with resolves clears the target status to healthy', function () {
+		componentStatusRegistry.setStatus('test.to-resolve', COMPONENT_STATUS_LEVELS.ERROR, 'broken');
+
+		handleStatusLog({ resolves: 'test.to-resolve' }, null, undefined, []);
+
+		const status = componentStatusRegistry.getStatus('test.to-resolve');
+		assert.equal(status.status, COMPONENT_STATUS_LEVELS.HEALTHY);
+	});
+});

--- a/unitTests/server/status/status.test.js
+++ b/unitTests/server/status/status.test.js
@@ -275,6 +275,12 @@ describe('server.status', function () {
 
 			// Check restart flag
 			assert.equal(result.restartRequired, true);
+
+			// Check hierarchy - built from the same aggregated statuses as componentStatus
+			assert.ok(result.hierarchy, 'hierarchy should be defined');
+			assert.equal(result.hierarchy['test-component'].status, 'healthy');
+			assert.equal(result.hierarchy['another-component'].status, 'error');
+			assert.equal(result.hierarchy['another-component'].message, 'Failed to start');
 		});
 
 		it('includes middlewareChains only when middleware:true is requested (#1573)', async function () {
@@ -309,6 +315,9 @@ describe('server.status', function () {
 
 			// Restart should be false
 			assert.equal(result.restartRequired, false);
+
+			// Hierarchy should be an empty object, not undefined
+			assert.deepStrictEqual(result.hierarchy, {});
 		});
 
 		it('should continue working if component status functions are unavailable', async function () {

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -87,6 +87,9 @@ export let externalLogger: any = {
 	forComponent(name: string) {
 		return externalLogger.forComponent(name);
 	},
+	status(options) {
+		return externalLogger.status(options);
+	},
 };
 _assignPackageExport('logger', externalLogger);
 // default logger used for the global used by external components
@@ -304,6 +307,9 @@ class HarperLogger extends Console {
 	withTag(tag) {
 		return loggerWithTag(tag, true, this);
 	}
+	status(options) {
+		return statusLogger(options, this);
+	}
 	forComponent(_name) {
 		// to be replaced
 		return this;
@@ -346,6 +352,8 @@ module.exports = {
 	errorForLog,
 	disableStdio,
 	externalLogger,
+	setStatusHandler,
+	status: (options) => statusLogger(options, mainLogger),
 };
 
 /**
@@ -501,9 +509,26 @@ function stdioLogging() {
 	}
 }
 
+let statusHandler: any;
+export function setStatusHandler(handler: any) {
+	statusHandler = handler;
+}
+function statusLogger(options: any, logger: any) {
+	const wrapper: any = {};
+	for (const level of ['notify', 'fatal', 'error', 'warn', 'info', 'debug', 'trace']) {
+		wrapper[level] = function (...args: any[]) {
+			logger[level](...args);
+			if (statusHandler) {
+				statusHandler(options, level, logger.tag || currentTag, args);
+			}
+		};
+	}
+	return wrapper;
+}
+
 export function loggerWithTag(tag: string, conditional?: boolean, logger: any = mainLogger) {
 	tag = tag.replace(/ /g, '-'); // tag can't have spaces
-	return {
+	const taggedLogger = {
 		notify: logWithTag(logger.notify, 'notify'),
 		fatal: logWithTag(logger.fatal, 'fatal'),
 		error: logWithTag(logger.error, 'error'),
@@ -511,7 +536,11 @@ export function loggerWithTag(tag: string, conditional?: boolean, logger: any = 
 		info: logWithTag(logger.info, 'info'),
 		debug: logWithTag(logger.debug, 'debug'),
 		trace: logWithTag(logger.trace, 'trace'),
+		status(options) {
+			return statusLogger(options, logger);
+		},
 	};
+	return taggedLogger;
 	function logWithTag(loggerMethod, level) {
 		return !conditional || logger.level <= LOG_LEVEL_HIERARCHY[level]
 			? function (...args) {

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -353,7 +353,7 @@ module.exports = {
 	disableStdio,
 	externalLogger,
 	setStatusHandler,
-	status: (options) => statusLogger(options, mainLogger),
+	status,
 };
 
 /**
@@ -361,6 +361,12 @@ module.exports = {
  */
 export function disableStdio(_unused?: any) {
 	nativeStdWrite = function () {}; // make this a noop
+}
+
+export function status(options: any) {
+	// Route through module.exports (not mainLogger directly) so callers/tests that stub the
+	// exported notify/fatal/error/... functions still see calls made via .status().
+	return statusLogger(options, module.exports);
 }
 
 /**
@@ -540,10 +546,14 @@ export function loggerWithTag(tag: string, conditional?: boolean, logger: any = 
 		info: logWithTag(logger.info, 'info'),
 		debug: logWithTag(logger.debug, 'debug'),
 		trace: logWithTag(logger.trace, 'trace'),
-		status(options) {
+	};
+	// non-enumerable so `for...in` over taggedLogger (used to derive the active log levels) doesn't
+	// pick this up as a level
+	Object.defineProperty(taggedLogger, 'status', {
+		value(options) {
 			return statusLogger(options, logger);
 		},
-	};
+	});
 	return taggedLogger;
 	function logWithTag(loggerMethod, level) {
 		return !conditional || logger.level <= LOG_LEVEL_HIERARCHY[level]
@@ -1134,4 +1144,6 @@ export default {
 	AuthAuditLog,
 	errorToString,
 	errorForLog,
+	setStatusHandler,
+	status,
 };

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -514,6 +514,10 @@ export function setStatusHandler(handler: any) {
 	statusHandler = handler;
 }
 function statusLogger(options: any, logger: any) {
+	// If called with just options (no chained log method), register status immediately
+	if (statusHandler) {
+		statusHandler(options, null, logger.tag || currentTag, []);
+	}
 	const wrapper: any = {};
 	for (const level of ['notify', 'fatal', 'error', 'warn', 'info', 'debug', 'trace']) {
 		wrapper[level] = function (...args: any[]) {

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -520,13 +520,21 @@ export function setStatusHandler(handler: any) {
 	statusHandler = handler;
 }
 function statusLogger(options: any, logger: any) {
-	// If called with just options (no chained log method), register status immediately
+	// A chained log method (.error(), .warn(), etc.) fires synchronously if the caller chains
+	// one, before this microtask runs. Deferring the options-only dispatch lets us skip it when
+	// a chained call already reported the same logical event, avoiding a double dispatch.
+	let chained = false;
 	if (statusHandler) {
-		statusHandler(options, null, logger.tag || currentTag, []);
+		queueMicrotask(() => {
+			if (!chained && statusHandler) {
+				statusHandler(options, null, logger.tag || currentTag, []);
+			}
+		});
 	}
 	const wrapper: any = {};
 	for (const level of ['notify', 'fatal', 'error', 'warn', 'info', 'debug', 'trace']) {
 		wrapper[level] = function (...args: any[]) {
+			chained = true;
 			logger[level](...args);
 			if (statusHandler) {
 				statusHandler(options, level, logger.tag || currentTag, args);

--- a/utility/logging/logger.ts
+++ b/utility/logging/logger.ts
@@ -8,9 +8,29 @@ for (let level of ['trace', 'debug', 'info', 'warn', 'error', 'fatal', 'notify']
 		logger[level] = harperLogger[level];
 	}
 }
+logger.status = harperLogger.status;
 
 export function loggerWithTag(tag: string): Logger {
 	return harperLogger.loggerWithTag(tag, true) as Logger;
+}
+
+export interface StatusOptions {
+	/** A key identifying the problem. Sets/updates a status entry at this key. */
+	problem?: string;
+	/** A key to resolve. Clears the status entry at this key back to healthy. */
+	resolves?: string;
+	/** Seconds until the status auto-clears. Only valid with `problem`. */
+	expires?: number;
+}
+
+export interface StatusLogger {
+	notify: (...args: any[]) => void;
+	fatal: (...args: any[]) => void;
+	error: (...args: any[]) => void;
+	warn: (...args: any[]) => void;
+	info: (...args: any[]) => void;
+	debug: (...args: any[]) => void;
+	trace: (...args: any[]) => void;
 }
 
 export interface Logger {
@@ -21,4 +41,5 @@ export interface Logger {
 	info?: (...args: any[]) => void;
 	debug?: (...args: any[]) => void;
 	trace?: (...args: any[]) => void;
+	status?: (options: StatusOptions) => StatusLogger;
 }

--- a/utility/logging/logger.ts
+++ b/utility/logging/logger.ts
@@ -21,6 +21,8 @@ export interface StatusOptions {
 	resolves?: string;
 	/** Seconds until the status auto-clears. Only valid with `problem`. */
 	expires?: number;
+	/** Status level for status-only calls (no chained log method). Defaults to 'error'. */
+	level?: string;
 }
 
 export interface StatusLogger {


### PR DESCRIPTION
Introduces logger.status({ problem: 'key' }).error('msg') API that both logs and updates component status, enabling real-time health monitoring without relying on external log shipping to DataDog.

New modules:
- logBridge.ts: bridges logger.status() calls to ComponentStatusRegistry
- hierarchy.ts: builds tree-structured status view from flat component map
- healthChecks.ts: periodic disk/memory/CPU monitoring via status system

Key changes:
- HarperLogger gains .status() method returning a logger-like wrapper
- ComponentStatus extended with source, expiresAt, occurrenceCount fields
- get_status operation now returns hierarchical status tree
- Status API adopted across replication, threads, server, and database code

The longer design document that Claude is working from:

# Integrated Status System: Explicit Logger-Status API + System Health + Hierarchical View

## Context

Harper relies on shipping log files to DataDog for problem detection -- expensive and high overhead. Harper already has a component status system (`core/components/status/`) used only by the component loader. The goal: let developers explicitly connect log calls to the status system via a `.status()` API on the logger, add system health monitoring, and expose everything through `get_status` as a hierarchical status tree a front-end can display.

## Part 1: Logger `.status()` API

### Design

Add a `.status()` method to the logger that returns a logger-like object. When you log through it, the message is both logged normally AND updates component status:

```javascript
// Report a problem -- sets status to error/warning for the given key
logger.status({ problem: 'replication-connection' }).error('Connection failed to node-1');
logger.status({ problem: 'replication-connection', expires: 300 }).warn('Connection unstable');

// Resolve a problem -- clears the status for that key
logger.status({ resolves: 'replication-connection' }).info('Connected to node-1');
```

- `problem: string` -- A status key identifying this problem. Sets/updates a status entry.
- `resolves: string` -- A status key to clear. Marks the problem as resolved (sets healthy).
- `expires: number` -- Optional seconds until the status auto-clears. Only valid with `problem`.
- The log level determines the status severity: `fatal`/`error` -> error status, `warn` -> warning status.
- `info`/`debug`/`trace` with `problem` would set warning (since they're lower severity). With `resolves`, any level works.

### Implementation

**File: `core/utility/logging/harper_logger.js`**

Add a `status()` method to `HarperLogger`:

```javascript
status(options) {
    return statusLogger(options, this);
}
```

Add a `statusLogger` function (similar pattern to `loggerWithTag`):

```javascript
let statusHandler; // injected from TS side to avoid circular deps

function statusLogger(options, logger) {
    // Returns an object with all log methods that both log AND update status
    const wrapper = {};
    for (const level of ['notify', 'fatal', 'error', 'warn', 'info', 'debug', 'trace']) {
        wrapper[level] = function (...args) {
            // First, log normally
            logger[level](...args);
            // Then, update status if handler is set
            if (statusHandler) {
                statusHandler(options, level, logger.tag || currentTag, args);
            }
        };
    }
    return wrapper;
}

function setStatusHandler(handler) {
    statusHandler = handler;
}
```

Export `setStatusHandler` from the module. The `statusHandler` is a function injected from the TS status bridge module at startup, avoiding circular dependency (JS logger cannot import TS status modules directly).

Also add `.status()` to:
- The `loggerWithTag` return object
- The `externalLogger` facade (so user code can use it)
- The module-level exports (`module.exports.status = ...`)

### Status Handler Module

**New file: `core/components/status/logBridge.ts`**

```typescript
import { statusForComponent } from './api.ts';
import { componentStatusRegistry } from './registry.ts';

const LOG_TO_STATUS_LEVEL = {
    fatal: 'error',
    error: 'error',
    warn: 'warning',
    notify: 'warning',
    info: 'warning',   // unusual to use info with problem, but treat as warning
    debug: 'warning',
    trace: 'warning',
};

// Track expiry timers
const expiryTimers = new Map<string, ReturnType<typeof setTimeout>>();

export function handleStatusLog(
    options: { problem?: string; resolves?: string; expires?: number },
    level: string,
    componentTag: string | undefined,
    args: any[]
) {
    const message = args.map(a => typeof a === 'string' ? a : String(a)).join(' ');

    if (options.resolves) {
        // Clear the status
        const key = options.resolves;
        clearExpiry(key);
        statusForComponent(key).healthy('Resolved: ' + message.substring(0, 200));
        return;
    }

    if (options.problem) {
        const key = options.problem;
        const statusLevel = LOG_TO_STATUS_LEVEL[level] || 'warning';

        if (statusLevel === 'error') {
            const errorArg = args.find(a => a instanceof Error);
            statusForComponent(key).error(message.substring(0, 500), errorArg);
        } else {
            statusForComponent(key).warning(message.substring(0, 500));
        }

        // Handle expiry
        if (options.expires) {
            scheduleExpiry(key, options.expires * 1000);
        }
    }
}

function scheduleExpiry(key: string, ms: number) {
    clearExpiry(key);
    const timer = setTimeout(() => {
        statusForComponent(key).healthy('Auto-expired');
        expiryTimers.delete(key);
    }, ms);
    timer.unref();
    expiryTimers.set(key, timer);
}

function clearExpiry(key: string) {
    const existing = expiryTimers.get(key);
    if (existing) {
        clearTimeout(existing);
        expiryTimers.delete(key);
    }
}
```

### Initialization

In the component startup path (likely `componentLoader.ts` or a dedicated status start hook), after the status system is ready:

```typescript
import { setStatusHandler } from '../../utility/logging/harper_logger.js';
import { handleStatusLog } from './logBridge.ts';

setStatusHandler(handleStatusLog);
```

### External/User Code

The external logger facade already delegates to the internal logger. Add `.status()` to the facade:

```javascript
// In module.exports.externalLogger
module.exports.externalLogger.status = function(options) {
    return externalLogger.status(options);
};
```

This is also exposed via `_assignPackageExport('logger', ...)`, so user application code gets it automatically:

```javascript
// User code in a Harper application
const { logger } = require('harperdb');
logger.status({ problem: 'my-api.upstream' }).error('Upstream API returned 503');
logger.status({ resolves: 'my-api.upstream' }).info('Upstream API recovered');
```

## Part 2: Status Lifecycle Extensions

### Extend `ComponentStatus` (`core/components/status/ComponentStatus.ts`)

Add optional fields for richer status tracking:

- `source?: 'log' | 'explicit' | 'health-check'` -- how the status was set
- `expiresAt?: number` -- epoch ms for auto-clear
- `occurrenceCount?: number` -- incremented on repeated reports of same problem

### Extend `ComponentStatusRegistry` (`core/components/status/ComponentStatusRegistry.ts`)

Add to `setStatus`:
- Accept optional `source` and `expiresAt` parameters
- If setting status for a key that already exists at the same level, increment `occurrenceCount`

No acknowledge/dismiss/adjustSeverity for now (deferred to later phase).

### Extend `ComponentStatusBuilder` (`core/components/status/api.ts`)

Add `source` tracking -- when called from the log bridge, pass `source: 'log'`; when called from health checks, pass `source: 'health-check'`; direct calls default to `source: 'explicit'`.

## Part 3: System Health Monitoring

### New Module: `core/components/status/healthChecks.ts`

Periodic checks using existing `systemInformation.js` functions:

```typescript
import { statusForComponent } from './api.ts';
// Import existing system info functions
import { getDiskInfo, getMemoryInfo, getCPUInfo } from '../../utility/environment/systemInformation.js';
```

**Checks:**
- **Disk:** filesystem usage percent -> `statusForComponent('system.disk')`
- **Memory:** used/total percent -> `statusForComponent('system.memory')`
- **CPU:** load average vs core count -> `statusForComponent('system.cpu')`

**Thresholds (configurable via `harperdb-config.yaml`):**
- Warning: 80% utilization
- Error: 95% utilization
- Check interval: 60 seconds

Health checks self-heal: when the metric drops below the threshold, status reverts to healthy. No expiry needed.

Runs on main thread only. Uses `.unref()` on interval timer.

```typescript
export function startHealthChecks(config?) {
    const thresholds = { ...DEFAULT_THRESHOLDS, ...config?.thresholds };
    const interval = (config?.intervalSeconds || 60) * 1000;

    const timer = setInterval(async () => {
        await checkDisk(thresholds.disk);
        await checkMemory(thresholds.memory);
        await checkCPU(thresholds.cpu);
    }, interval);
    timer.unref();

    // Run immediately
    checkDisk(thresholds.disk);
    checkMemory(thresholds.memory);
    checkCPU(thresholds.cpu);
}
```

## Part 4: Hierarchical Status View

### New Module: `core/components/status/hierarchy.ts`

Builds a tree from the flat component status map by splitting names on `.`:

```typescript
interface StatusNode {
    status: ComponentStatusLevel;
    message?: string;
    source?: string;
    lastChecked?: { main?: number; workers: Record<number, number> };
    children?: Record<string, StatusNode>;
}

export function buildHierarchy(
    statuses: Map<string, AggregatedComponentStatus>
): Record<string, StatusNode> {
    const root: Record<string, StatusNode> = {};

    for (const [name, status] of statuses) {
        const parts = name.split('.');
        let current = root;

        for (let i = 0; i < parts.length; i++) {
            const part = parts[i];
            if (!current[part]) {
                current[part] = {
                    status: 'healthy',
                    children: {},
                };
            }
            if (i === parts.length - 1) {
                // Leaf node -- set actual status
                current[part].status = status.status;
                current[part].message = status.latestMessage;
                current[part].lastChecked = status.lastChecked;
            }
            current = current[part].children!;
        }
    }

    // Roll up: each parent's status = worst of its children
    rollUpStatus(root);
    return root;
}
```

Parent status = worst child status (error > warning > loading > unknown > healthy).

### Extend `GET_STATUS` Response

**File: `core/server/status/index.ts`**

Modify `getAllStatus()` to include the hierarchy:

```typescript
import { buildHierarchy } from '../../components/status/hierarchy.ts';

async function getAllStatus(): Promise<AllStatusSummary> {
    const statusRecords = getStatusTable().search([]);
    const aggregatedStatuses = await statusInternal.query.allThreads();

    const componentStatusArray = Array.from(aggregatedStatuses.entries()).map(
        ([name, status]) => ({ name, ...status })
    );

    return {
        systemStatus: statusRecords,
        componentStatus: componentStatusArray,
        hierarchy: buildHierarchy(aggregatedStatuses),  // NEW
        restartRequired: restartNeeded(),
    };
}
```

## Part 5: Configuration

**Add to `harperdb-config.yaml` schema:**

```yaml
status:
  healthChecks:
    enabled: true
    intervalSeconds: 60
    thresholds:
      disk: { warning: 80, error: 95 }
      memory: { warning: 80, error: 95 }
      cpu: { warning: 85, error: 95 }
```

The log bridge itself needs no configuration -- it's explicitly opted into per log call via `.status()`.

## Implementation Phases

### Phase 1: Logger `.status()` API + Bridge
1. Add `status()` method to `HarperLogger` class
2. Add `statusLogger()` function (returns logger-like wrapper)
3. Add `setStatusHandler` export and module-level variable
4. Add `.status()` to `loggerWithTag` return objects
5. Add `.status()` to `externalLogger` facade
6. Create `core/components/status/logBridge.ts` with `handleStatusLog`
7. Wire up: call `setStatusHandler(handleStatusLog)` during component startup

### Phase 2: Status Lifecycle Extensions
1. Add `source`, `expiresAt`, `occurrenceCount` to `ComponentStatus`
2. Update `ComponentStatusRegistry.setStatus` to handle these fields
3. Implement expiry timer management in the registry

### Phase 3: Hierarchical Status View
1. Create `core/components/status/hierarchy.ts`
2. Extend `getAllStatus()` in `core/server/status/index.ts` to include hierarchy
3. Update `AllStatusSummary` type

### Phase 4: System Health Checks
1. Create `core/components/status/healthChecks.ts`
2. Add configuration support (config schema)
3. Start health checks during server startup (main thread only)

### Phase 5: Testing
1. Unit tests for `.status()` logger wrapper
2. Unit tests for `handleStatusLog` (problem, resolves, expires)
3. Unit tests for `buildHierarchy` (tree construction, status rollup)
4. Unit tests for health check threshold evaluation

## Files to Modify

| File | Changes |
|---|---|
| `core/utility/logging/harper_logger.js` | Add `status()` to HarperLogger, `statusLogger()`, `setStatusHandler`, update exports and facades |
| `core/components/status/ComponentStatus.ts` | Add `source`, `expiresAt`, `occurrenceCount` fields |
| `core/components/status/ComponentStatusRegistry.ts` | Handle new fields in `setStatus`, expiry timer mgmt |
| `core/components/status/api.ts` | Pass `source` through builder methods |
| `core/server/status/index.ts` | Add hierarchy to `getAllStatus()` response |

## New Files

| File | Purpose |
|---|---|
| `core/components/status/logBridge.ts` | `handleStatusLog` -- bridges `.status()` calls to component status |
| `core/components/status/hierarchy.ts` | `buildHierarchy` -- builds tree from flat status map |
| `core/components/status/healthChecks.ts` | Periodic system health monitoring (disk, memory, CPU) |

## Verification

1. Use `.status({ problem: 'test' }).error('test error')` -> verify it appears in `get_status` response under `componentStatus` and `hierarchy`
2. Use `.status({ resolves: 'test' }).info('resolved')` -> verify status clears to healthy
3. Use `.status({ problem: 'temp', expires: 5 }).warn('temporary')` -> verify it auto-clears after 5 seconds
4. Verify `hierarchy` in `get_status` response groups `system.disk`, `system.memory`, `system.cpu` under a `system` parent
5. Verify parent nodes in hierarchy roll up worst-case status from children
6. Verify external logger (user code) can use `.status()` API
