### PR TITLE
allow module imports from component dir

### DIFF
--- a/components/Application.ts
+++ b/components/Application.ts
@@ -187,7 +187,9 @@ export async function extractApplication(application: Application) {
 			try {
 				packResult = JSON.parse(stdout.slice(stdout.indexOf('[')));
 			} catch (err) {
-				throw new Error(`Failed to parse npm pack output for ${application.packageIdentifier}: ${err.message}\nstdout: ${stdout}`);
+				throw new Error(
+					`Failed to parse npm pack output for ${application.packageIdentifier}: ${err.message}\nstdout: ${stdout}`
+				);
 			}
 			if (!Array.isArray(packResult) || typeof packResult[0]?.filename !== 'string') {
 				throw new Error(`Unexpected npm pack output for ${application.packageIdentifier}:\n${stdout}`);

--- a/components/ApplicationScope.ts
+++ b/components/ApplicationScope.ts
@@ -21,10 +21,10 @@ export class ApplicationScope {
 	server: Server;
 	mode?: 'native' | 'vm' | 'vm-current-context' | 'compartment'; // option to set this from the scope
 	dependencyLoader?: 'native' | 'app' | 'auto'; // option to set this from the scope
-	verifyPath?: string;
+	allowedPaths?: string[];
 	config: any;
 	moduleCache: any; // used by the loader to retain a cache of modules, type is an internal detail of the loader
-	constructor(name: string, resources: Resources, server: Server, isInternal = false, verifyPath?: string) {
+	constructor(name: string, resources: Resources, server: Server, isInternal = false) {
 		this.logger = forComponent(name, !isInternal);
 
 		this.resources = resources;
@@ -32,7 +32,6 @@ export class ApplicationScope {
 
 		this.mode = env.get(CONFIG_PARAMS.APPLICATIONS_MODULELOADER) ?? 'vm';
 		this.dependencyLoader = env.get(CONFIG_PARAMS.APPLICATIONS_DEPENDENCYLOADER);
-		this.verifyPath = verifyPath;
 	}
 
 	/**

--- a/components/ApplicationScope.ts
+++ b/components/ApplicationScope.ts
@@ -21,7 +21,7 @@ export class ApplicationScope {
 	server: Server;
 	mode?: 'native' | 'vm' | 'vm-current-context' | 'compartment'; // option to set this from the scope
 	dependencyLoader?: 'native' | 'app' | 'auto'; // option to set this from the scope
-	allowedPaths?: string[];
+	allowedPath?: string;
 	config: any;
 	moduleCache: any; // used by the loader to retain a cache of modules, type is an internal detail of the loader
 	constructor(name: string, resources: Resources, server: Server, isInternal = false) {

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -274,7 +274,7 @@ export async function loadComponent(
 		autoReload,
 		appName,
 	} = options;
-	applicationScope.allowedPaths ??= [realpathSync(componentDirectory), PACKAGE_ROOT];
+	applicationScope.allowedPath ??= realpathSync(componentDirectory);
 	if (providedLoadedComponents) loadedComponents = providedLoadedComponents;
 	try {
 		let config;
@@ -349,7 +349,7 @@ export async function loadComponent(
 						}
 					}
 					if (componentPath) {
-						subApplicationScope.allowedPaths ??= [realpathSync(componentPath), PACKAGE_ROOT];
+						subApplicationScope.allowedPath ??= realpathSync(componentPath);
 						if (!process.env.HARPER_SAFE_MODE) {
 							extensionModule = await loadComponent(componentPath, resources, origin, {
 								isRoot: false,

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -274,7 +274,7 @@ export async function loadComponent(
 		autoReload,
 		appName,
 	} = options;
-	applicationScope.verifyPath ??= componentDirectory;
+	applicationScope.allowedPaths ??= [realpathSync(componentDirectory), PACKAGE_ROOT];
 	if (providedLoadedComponents) loadedComponents = providedLoadedComponents;
 	try {
 		let config;
@@ -349,7 +349,7 @@ export async function loadComponent(
 						}
 					}
 					if (componentPath) {
-						subApplicationScope.verifyPath ??= componentPath;
+						subApplicationScope.allowedPaths ??= [realpathSync(componentPath), PACKAGE_ROOT];
 						if (!process.env.HARPER_SAFE_MODE) {
 							extensionModule = await loadComponent(componentPath, resources, origin, {
 								isRoot: false,

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -14,7 +14,16 @@ import * as child_process from 'node:child_process';
 import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 import { contentTypes } from '../server/serverHelpers/contentTypes.ts';
 import type { CompartmentOptions } from 'ses';
-import { mkdirSync, readFileSync, writeFileSync, unlinkSync, openSync, closeSync, statSync, realpathSync } from 'node:fs';
+import {
+	mkdirSync,
+	readFileSync,
+	writeFileSync,
+	unlinkSync,
+	openSync,
+	closeSync,
+	statSync,
+	realpathSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { EventEmitter } from 'node:events';
 import { whenComponentsLoaded } from '../server/threads/threadServer.js';
@@ -914,8 +923,10 @@ function createSpawn(spawnFunction: (...args: any) => child_process.ChildProcess
 function checkAllowedModulePath(moduleUrl: string, allowedPaths?: string[]): boolean {
 	if (moduleUrl.startsWith('file:')) {
 		let path = moduleUrl.slice(7);
-		try { path = realpathSync(path); } catch {}
-		if (!allowedPaths || allowedPaths.some(p => path.startsWith(p))) {
+		try {
+			path = realpathSync(path);
+		} catch {}
+		if (!allowedPaths || allowedPaths.some((p) => path.startsWith(p))) {
 			return;
 		}
 		throw new Error(`Can not load module outside of allowed paths`);

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -14,7 +14,7 @@ import * as child_process from 'node:child_process';
 import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 import { contentTypes } from '../server/serverHelpers/contentTypes.ts';
 import type { CompartmentOptions } from 'ses';
-import { mkdirSync, readFileSync, writeFileSync, unlinkSync, openSync, closeSync, statSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync, unlinkSync, openSync, closeSync, statSync, realpathSync } from 'node:fs';
 import { join } from 'node:path';
 import { EventEmitter } from 'node:events';
 import { whenComponentsLoaded } from '../server/threads/threadServer.js';
@@ -495,13 +495,13 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 		}
 
 		if (url.startsWith('file://') && usePrivateGlobal) {
-			checkAllowedModulePath(url, scope.verifyPath);
+			checkAllowedModulePath(url, scope.allowedPaths);
 			const source = readFileSync(new URL(url), { encoding: 'utf-8' });
 			return createModuleFromSource(url, source, usePrivateGlobal);
 		}
 
 		// For Node.js built-in modules (node:) and npm packages without application loader for dependency
-		const replacedModule = checkAllowedModulePath(url, scope.verifyPath);
+		const replacedModule = checkAllowedModulePath(url, scope.allowedPaths);
 		if (replacedModule) {
 			return createSyntheticModule(url, normalizeImportedModule(replacedModule));
 		}
@@ -570,7 +570,7 @@ async function getCompartment(scope: ApplicationScope, globals) {
 					}
 					return new StaticModuleRecord(moduleText, moduleSpecifier);
 				} else {
-					checkAllowedModulePath(moduleSpecifier, scope.verifyPath);
+					checkAllowedModulePath(moduleSpecifier, scope.allowedPaths);
 					const moduleExports = await import(moduleSpecifier);
 					return {
 						imports: [],
@@ -903,21 +903,22 @@ function createSpawn(spawnFunction: (...args: any) => child_process.ChildProcess
 
 /**
  * Validates whether a module can be loaded based on security restrictions and returns the module path or replacement.
- * For file URLs, ensures the module is within the containing folder.
+ * For file URLs, ensures the module is within the allowed paths.
  * For node built-in modules, checks against an allowlist and returns any replacements.
  *
  * @param {string} moduleUrl - The URL or identifier of the module to be loaded, which may be a file: URL, node: URL, or bare module specifier.
- * @param {string} containingFolder - The absolute path of the folder that contains the application, used to validate file: URLs are within bounds.
+ * @param {string[]} allowedPaths - Array of absolute paths that the module is allowed to load from.
  * @return {any} Returns undefined for allowed file paths, or a replacement module identifier for allowed node built-in modules.
- * @throws {Error} Throws an error if the module is outside the application folder or if the module is not in the allowed list.
+ * @throws {Error} Throws an error if the module is outside the allowed paths or if the module is not in the allowed list.
  */
-function checkAllowedModulePath(moduleUrl: string, containingFolder?: string): boolean {
+function checkAllowedModulePath(moduleUrl: string, allowedPaths?: string[]): boolean {
 	if (moduleUrl.startsWith('file:')) {
-		const path = moduleUrl.slice(7);
-		if (!containingFolder || path.startsWith(containingFolder)) {
+		let path = moduleUrl.slice(7);
+		try { path = realpathSync(path); } catch {}
+		if (!allowedPaths || allowedPaths.some(p => path.startsWith(p))) {
 			return;
 		}
-		throw new Error(`Can not load module outside of application folder ${containingFolder}`);
+		throw new Error(`Can not load module outside of allowed paths`);
 	}
 	let simpleName = moduleUrl.startsWith('node:') ? moduleUrl.slice(5) : moduleUrl;
 	simpleName = simpleName.split('/')[0];

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -504,13 +504,13 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 		}
 
 		if (url.startsWith('file://') && usePrivateGlobal) {
-			checkAllowedModulePath(url, scope.allowedPaths);
+			checkAllowedModulePath(url, scope.allowedPath);
 			const source = readFileSync(new URL(url), { encoding: 'utf-8' });
 			return createModuleFromSource(url, source, usePrivateGlobal);
 		}
 
 		// For Node.js built-in modules (node:) and npm packages without application loader for dependency
-		const replacedModule = checkAllowedModulePath(url, scope.allowedPaths);
+		const replacedModule = checkAllowedModulePath(url, scope.allowedPath);
 		if (replacedModule) {
 			return createSyntheticModule(url, normalizeImportedModule(replacedModule));
 		}
@@ -579,7 +579,7 @@ async function getCompartment(scope: ApplicationScope, globals) {
 					}
 					return new StaticModuleRecord(moduleText, moduleSpecifier);
 				} else {
-					checkAllowedModulePath(moduleSpecifier, scope.allowedPaths);
+					checkAllowedModulePath(moduleSpecifier, scope.allowedPath);
 					const moduleExports = await import(moduleSpecifier);
 					return {
 						imports: [],
@@ -912,24 +912,24 @@ function createSpawn(spawnFunction: (...args: any) => child_process.ChildProcess
 
 /**
  * Validates whether a module can be loaded based on security restrictions and returns the module path or replacement.
- * For file URLs, ensures the module is within the allowed paths.
+ * For file URLs, ensures the module is within the allowed path.
  * For node built-in modules, checks against an allowlist and returns any replacements.
  *
  * @param {string} moduleUrl - The URL or identifier of the module to be loaded, which may be a file: URL, node: URL, or bare module specifier.
- * @param {string[]} allowedPaths - Array of absolute paths that the module is allowed to load from.
+ * @param {string} allowedPath - The absolute path that the module is allowed to load from.
  * @return {any} Returns undefined for allowed file paths, or a replacement module identifier for allowed node built-in modules.
- * @throws {Error} Throws an error if the module is outside the allowed paths or if the module is not in the allowed list.
+ * @throws {Error} Throws an error if the module is outside the allowed path or if the module is not in the allowed list.
  */
-function checkAllowedModulePath(moduleUrl: string, allowedPaths?: string[]): boolean {
+function checkAllowedModulePath(moduleUrl: string, allowedPath?: string): boolean {
 	if (moduleUrl.startsWith('file:')) {
 		let path = moduleUrl.slice(7);
 		try {
 			path = realpathSync(path);
 		} catch {}
-		if (!allowedPaths || allowedPaths.some((p) => path.startsWith(p))) {
+		if (!allowedPath || path.startsWith(allowedPath)) {
 			return;
 		}
-		throw new Error(`Can not load module outside of allowed paths`);
+		throw new Error(`Can not load module outside of allowed path`);
 	}
 	let simpleName = moduleUrl.startsWith('node:') ? moduleUrl.slice(5) : moduleUrl;
 	simpleName = simpleName.split('/')[0];

--- a/unitTests/components/globalIsolation.test.js
+++ b/unitTests/components/globalIsolation.test.js
@@ -46,7 +46,7 @@ describe('Global Variable Isolation in testJSWithDeps', function () {
 		Object.assign(applicationScope, {
 			mode: 'vm',
 			dependencyLoader: 'native',
-			verifyPath: PACKAGE_ROOT,
+			allowedPath: PACKAGE_ROOT,
 		});
 		await loadComponent(componentDir, mockResources, 'test-origin', {
 			applicationScope,
@@ -77,7 +77,7 @@ describe('Global Variable Isolation in testJSWithDeps', function () {
 		Object.assign(applicationScope, {
 			mode: 'vm-current-context',
 			dependencyLoader: 'native',
-			verifyPath: PACKAGE_ROOT,
+			allowedPath: PACKAGE_ROOT,
 		});
 		await loadComponent(componentDir, mockResources, 'test-origin', {
 			applicationScope,
@@ -97,7 +97,7 @@ describe('Global Variable Isolation in testJSWithDeps', function () {
 		Object.assign(applicationScope, {
 			mode: 'vm',
 			dependencyLoader: 'app',
-			verifyPath: PACKAGE_ROOT,
+			allowedPath: PACKAGE_ROOT,
 		});
 		await loadComponent(componentDir, mockResources, 'test-origin', {
 			applicationScope,
@@ -120,7 +120,7 @@ describe('Global Variable Isolation in testJSWithDeps', function () {
 		Object.assign(applicationScope, {
 			mode: 'compartment',
 			dependencyLoader: 'app',
-			verifyPath: PACKAGE_ROOT,
+			allowedPath: PACKAGE_ROOT,
 		});
 		await loadComponent(componentDir, mockResources, 'test-origin', {
 			applicationScope,
@@ -149,7 +149,7 @@ describe('Global Variable Isolation in testJSWithDeps', function () {
 		Object.assign(applicationScope, {
 			mode: 'vm',
 			dependencyLoader: 'native',
-			verifyPath: PACKAGE_ROOT,
+			allowedPath: PACKAGE_ROOT,
 		});
 		await loadComponent(componentDir, mockResources, 'test-origin', {
 			applicationScope,
@@ -169,7 +169,7 @@ describe('Global Variable Isolation in testJSWithDeps', function () {
 		Object.assign(applicationScope, {
 			mode: 'vm',
 			dependencyLoader: 'native',
-			verifyPath: PACKAGE_ROOT,
+			allowedPath: PACKAGE_ROOT,
 		});
 		await loadComponent(componentDir, mockResources, 'test-origin', {
 			applicationScope,
@@ -192,7 +192,7 @@ describe('Global Variable Isolation in testJSWithDeps', function () {
 		Object.assign(applicationScope, {
 			mode: 'vm',
 			dependencyLoader: 'native',
-			verifyPath: PACKAGE_ROOT,
+			allowedPath: PACKAGE_ROOT,
 		});
 		await loadComponent(componentDir, mockResources, 'test-origin', {
 			applicationScope,
@@ -221,7 +221,7 @@ describe('Global Variable Isolation in testJSWithDeps', function () {
 		Object.assign(applicationScope, {
 			mode: 'vm',
 			dependencyLoader: 'native',
-			verifyPath: PACKAGE_ROOT,
+			allowedPath: PACKAGE_ROOT,
 		});
 		await loadComponent(componentDir, mockResources, 'test-origin', {
 			applicationScope,
@@ -245,7 +245,7 @@ describe('Global Variable Isolation in testJSWithDeps', function () {
 		Object.assign(applicationScope, {
 			mode: 'vm',
 			dependencyLoader: 'native',
-			verifyPath: PACKAGE_ROOT,
+			allowedPath: PACKAGE_ROOT,
 		});
 		await loadComponent(componentDir, mockResources, 'test-origin', {
 			applicationScope,
@@ -263,7 +263,7 @@ describe('Global Variable Isolation in testJSWithDeps', function () {
 		Object.assign(applicationScope, {
 			mode: 'vm',
 			dependencyLoader: 'native',
-			verifyPath: PACKAGE_ROOT,
+			allowedPath: PACKAGE_ROOT,
 		});
 
 		const cjsModuleA = await scopedImport(path.join(componentDir, 'cjs-circular-a.cjs'), applicationScope);
@@ -280,7 +280,7 @@ describe('Global Variable Isolation in testJSWithDeps', function () {
 		Object.assign(applicationScope, {
 			mode: 'vm',
 			dependencyLoader: 'native', // Default to native loading
-			verifyPath: PACKAGE_ROOT,
+			allowedPath: PACKAGE_ROOT,
 		});
 
 		// harper-dependent-package has harper in its dependencies, so should use VM
@@ -299,7 +299,7 @@ describe('Global Variable Isolation in testJSWithDeps', function () {
 		Object.assign(applicationScope, {
 			mode: 'vm',
 			dependencyLoader: 'native', // Default to native loading
-			verifyPath: PACKAGE_ROOT,
+			allowedPath: PACKAGE_ROOT,
 		});
 
 		// fake-package doesn't depend on harper, should load natively (not through VM)
@@ -318,7 +318,7 @@ describe('Global Variable Isolation in testJSWithDeps', function () {
 		Object.assign(applicationScope, {
 			mode: 'vm',
 			dependencyLoader: 'native',
-			verifyPath: PACKAGE_ROOT,
+			allowedPath: PACKAGE_ROOT,
 		});
 		await loadComponent(componentDir, mockResources, 'test-origin', {
 			applicationScope,


### PR DESCRIPTION
Module imports from components broke with `Can not load module outside
of allowed paths` when running from source.

The sandbox only checked against the component directory, but modules also need access
to `PACKAGE_ROOT`. On top of that, macOS resolves `/va`r to `/private/var` through a symlink, so the real path never matched the allowed path.