### PR TITLE
Add retry backoff and fix index removal in transactions

### DIFF
--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -95,6 +95,8 @@ export class DatabaseTransaction implements Transaction {
 		if (this.open !== TRANSACTION_STATE.OPEN) return; // can not start a new read transaction as there is no future commit that will take place, just have to allow the read to latest database state
 
 		this.transaction = new RocksTransaction(this.db.store);
+		harperLogger.warn('Created new transaction to read', this.transaction.id);
+
 		if (this.timestamp) {
 			this.transaction.setTimestamp(this.timestamp);
 		}
@@ -123,6 +125,7 @@ export class DatabaseTransaction implements Transaction {
 				// if we have lingering writes, we have to call commit to finish them
 				this.commit();
 			} else {
+				harperLogger.warn('Aborting finished read txn', this.transaction.id);
 				this.transaction?.abort();
 				this.transaction = null;
 			}
@@ -161,6 +164,7 @@ export class DatabaseTransaction implements Transaction {
 		let immediateCommit = false;
 		if (!transaction) {
 			transaction = new RocksTransaction(this.db.store as RocksStore);
+			harperLogger.warn('Created new transaction in save', transaction.id);
 			if (this.open === TRANSACTION_STATE.OPEN) {
 				this.transaction = transaction;
 			} else {
@@ -170,6 +174,8 @@ export class DatabaseTransaction implements Transaction {
 			if (txnTime) {
 				transaction.setTimestamp(txnTime);
 			}
+		} else {
+			harperLogger.warn('existing transaction in save', transaction.id);
 		}
 		if (this.retries > 0) {
 			// this is marks the rocks transaction as a retry so we don't write the transaction log again
@@ -177,6 +183,7 @@ export class DatabaseTransaction implements Transaction {
 		}
 		if (!txnTime) txnTime = this.timestamp = transaction.getTimestamp();
 		if (reloadEntry || operation.entry === undefined) {
+			if (transaction.id == 15) console.log('loading entry');
 			operation.entry = operation.store.getEntry(operation.key, { transaction });
 		}
 		if (!operation.saved) {
@@ -191,8 +198,11 @@ export class DatabaseTransaction implements Transaction {
 			result = operation.beforeIntermediate?.() as Promise<void>;
 			if (result?.then) this.completions.push(result);
 		}
+		if (transaction.id == 15) console.log('operation.commit');
 		operation.commit(txnTime, operation.entry, this.retries > 0, transaction);
+		if (transaction.id == 15) console.log('operation.commit completed');
 		if (immediateCommit) {
+			if (transaction.id == 15) console.log('commit immediately');
 			return this.commit({ transaction }); // immediately commit if the harper transaction is closed
 		}
 	}
@@ -240,8 +250,10 @@ export class DatabaseTransaction implements Transaction {
 				this.transaction = null; // clear transaction so any further operations operate immediately
 				if (transaction) {
 					if (this.writes.length > 0) {
+						harperLogger.warn('Committing txn', transaction.id);
 						commitResolution = transaction.commit();
 					} else {
+						harperLogger.warn('aborting txn', transaction.id);
 						commitResolution = transaction.abort();
 					}
 				}
@@ -297,6 +309,7 @@ export class DatabaseTransaction implements Transaction {
 							// if the transaction failed due to concurrent changes, we need to retry. First record this as an increased risk of contention/retry
 							// for future transactions
 							this.retries++;
+							harperLogger.warn('retrying', transaction.id, this.retries);
 							if (this.retries > 2) {
 								if (this.retries > MAX_RETRIES) {
 									throw new ServerError(
@@ -397,6 +410,7 @@ function startMonitoringTxns() {
 				);
 				// reset the transaction
 				try {
+					harperLogger.warn('timeout txn', txn.id);
 					const result = txn.commit();
 					if (result?.then) {
 						result.catch((error) => {

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -95,7 +95,6 @@ export class DatabaseTransaction implements Transaction {
 		if (this.open !== TRANSACTION_STATE.OPEN) return; // can not start a new read transaction as there is no future commit that will take place, just have to allow the read to latest database state
 
 		this.transaction = new RocksTransaction(this.db.store);
-		if (this.transaction.id < 20) harperLogger.warn('Created new transaction to read', this.transaction.id);
 
 		if (this.timestamp) {
 			this.transaction.setTimestamp(this.timestamp);
@@ -123,10 +122,8 @@ export class DatabaseTransaction implements Transaction {
 			trackedTxns.delete(this);
 			if (this.open === TRANSACTION_STATE.LINGERING) {
 				// if we have lingering writes, we have to call commit to finish them
-				if (this.transaction.id < 20) harperLogger.warn('Commiting lingering txn', this.transaction.id);
 				this.commit();
 			} else {
-				if (this.transaction.id < 20) harperLogger.warn('Aborting finished read txn', this.transaction.id);
 				this.transaction?.abort();
 				this.transaction = null;
 			}
@@ -166,9 +163,8 @@ export class DatabaseTransaction implements Transaction {
 		if (!transaction) {
 			transaction = new RocksTransaction(operation.store.store as RocksStore);
 			if (operation.store.rootStore !== this.db.rootStore) {
-				harperLogger.warn('Created new transaction in save, but the store does match existing store', transaction.id);
+				harperLogger.warn?.('Created new transaction in save, but the store does match existing store', transaction.id);
 			}
-			if (transaction.id < 20) harperLogger.warn('Created new transaction in save', transaction.id);
 			if (this.open === TRANSACTION_STATE.OPEN) {
 				this.transaction = transaction;
 			} else {
@@ -179,7 +175,6 @@ export class DatabaseTransaction implements Transaction {
 				transaction.setTimestamp(txnTime);
 			}
 		} else {
-			if (transaction.id < 20) harperLogger.warn('existing transaction in save', transaction.id);
 		}
 		if (this.retries > 0) {
 			// This marks the Rocks transaction as a retry so we don't write the transaction log again
@@ -187,7 +182,6 @@ export class DatabaseTransaction implements Transaction {
 		}
 		if (!txnTime) txnTime = this.timestamp = transaction.getTimestamp();
 		if (reloadEntry || operation.entry === undefined) {
-			if (transaction.id == 15) console.log('loading entry');
 			operation.entry = operation.store.getEntry(operation.key, { transaction });
 		}
 		if (!operation.saved) {
@@ -202,11 +196,8 @@ export class DatabaseTransaction implements Transaction {
 			result = operation.beforeIntermediate?.() as Promise<void>;
 			if (result?.then) this.completions.push(result);
 		}
-		if (transaction.id == 15) console.log('operation.commit');
 		operation.commit(txnTime, operation.entry, this.retries > 0, transaction);
-		if (transaction.id == 15) console.log('operation.commit completed');
 		if (immediateCommit) {
-			if (transaction.id == 15) console.log('commit immediately');
 			return this.commit({ transaction }); // immediately commit if the harper transaction is closed
 		}
 	}
@@ -254,10 +245,8 @@ export class DatabaseTransaction implements Transaction {
 				this.transaction = null; // clear transaction so any further operations operate immediately
 				if (transaction) {
 					if (this.writes.length > 0) {
-						if (transaction.id < 20) harperLogger.warn('Committing txn', transaction.id);
 						commitResolution = transaction.commit();
 					} else {
-						if (transaction.id < 20) harperLogger.warn('aborting txn', transaction.id);
 						commitResolution = transaction.abort();
 					}
 				}
@@ -414,7 +403,6 @@ function startMonitoringTxns() {
 				);
 				// reset the transaction
 				try {
-					harperLogger.warn('timeout txn', txn.id);
 					const result = txn.commit();
 					if (result?.then) {
 						result.catch((error) => {

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -20,7 +20,7 @@ export const TRANSACTION_STATE = {
 	OPEN: 1, // the transaction is open and can be used for reads and writes
 	LINGERING: 2, // the transaction has completed a read, but can be used for immediate writes
 };
-const MAX_RETRIES = 100;
+const MAX_RETRIES = 40;
 let outstandingCommit, outstandingCommitStart;
 let confirmReplication;
 export function replicationConfirmation(callback) {
@@ -313,7 +313,7 @@ export class DatabaseTransaction implements Transaction {
 							// if the transaction failed due to concurrent changes, we need to retry. First record this as an increased risk of contention/retry
 							// for future transactions
 							this.retries++;
-							harperLogger.warn('retrying', transaction.id, this.retries);
+							harperLogger.debug?.('retrying', transaction.id, this.retries);
 							if (this.retries > 2) {
 								if (this.retries > MAX_RETRIES) {
 									throw new ServerError(
@@ -321,7 +321,7 @@ export class DatabaseTransaction implements Transaction {
 									);
 								}
 								// start delaying, back off to try to space out transactions and avoid excessive conflicts
-								return delay(this.retries).then(() => this.commit({ transaction }));
+								return delay(this.retries * this.retries).then(() => this.commit({ transaction }));
 							}
 							return this.commit({ transaction }); // try again
 						} else throw error;

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -7,6 +7,7 @@ import * as envMngr from '../utility/environment/environmentManager.js';
 import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 import { convertToMS } from '../utility/common_utils.js';
 import { when } from '../utility/when.ts';
+import { setTimeout as delay } from 'node:timers/promises';
 import { Transaction as RocksTransaction, type Store as RocksStore } from '@harperfast/rocksdb-js';
 import type { RootDatabaseKind } from './databases.ts';
 import type { Entry } from './RecordEncoder.ts';
@@ -19,6 +20,7 @@ export const TRANSACTION_STATE = {
 	OPEN: 1, // the transaction is open and can be used for reads and writes
 	LINGERING: 2, // the transaction has completed a read, but can be used for immediate writes
 };
+const MAX_RETRIES = 100;
 let outstandingCommit, outstandingCommitStart;
 let confirmReplication;
 export function replicationConfirmation(callback) {
@@ -295,6 +297,15 @@ export class DatabaseTransaction implements Transaction {
 							// if the transaction failed due to concurrent changes, we need to retry. First record this as an increased risk of contention/retry
 							// for future transactions
 							this.retries++;
+							if (this.retries > 2) {
+								if (this.retries > MAX_RETRIES) {
+									throw new ServerError(
+										`After ${MAX_RETRIES} retries, unable to commit transaction, transaction is in conflict with ongoing writes`
+									);
+								}
+								// start delaying, back off to try to space out transactions and avoid excessive conflicts
+								return delay(this.retries).then(() => this.commit({ transaction }));
+							}
 							return this.commit({ transaction }); // try again
 						} else throw error;
 					}

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -95,7 +95,7 @@ export class DatabaseTransaction implements Transaction {
 		if (this.open !== TRANSACTION_STATE.OPEN) return; // can not start a new read transaction as there is no future commit that will take place, just have to allow the read to latest database state
 
 		this.transaction = new RocksTransaction(this.db.store);
-		harperLogger.warn('Created new transaction to read', this.transaction.id);
+		if (this.transaction.id < 20) harperLogger.warn('Created new transaction to read', this.transaction.id);
 
 		if (this.timestamp) {
 			this.transaction.setTimestamp(this.timestamp);
@@ -123,9 +123,10 @@ export class DatabaseTransaction implements Transaction {
 			trackedTxns.delete(this);
 			if (this.open === TRANSACTION_STATE.LINGERING) {
 				// if we have lingering writes, we have to call commit to finish them
+				if (this.transaction.id < 20) harperLogger.warn('Commiting lingering txn', this.transaction.id);
 				this.commit();
 			} else {
-				harperLogger.warn('Aborting finished read txn', this.transaction.id);
+				if (this.transaction.id < 20) harperLogger.warn('Aborting finished read txn', this.transaction.id);
 				this.transaction?.abort();
 				this.transaction = null;
 			}
@@ -163,8 +164,11 @@ export class DatabaseTransaction implements Transaction {
 		transaction ??= this.transaction;
 		let immediateCommit = false;
 		if (!transaction) {
-			transaction = new RocksTransaction(this.db.store as RocksStore);
-			harperLogger.warn('Created new transaction in save', transaction.id);
+			transaction = new RocksTransaction(operation.store.store as RocksStore);
+			if (operation.store.rootStore !== this.db.rootStore) {
+				harperLogger.warn('Created new transaction in save, but the store does match existing store', transaction.id);
+			}
+			if (transaction.id < 20) harperLogger.warn('Created new transaction in save', transaction.id);
 			if (this.open === TRANSACTION_STATE.OPEN) {
 				this.transaction = transaction;
 			} else {
@@ -175,10 +179,10 @@ export class DatabaseTransaction implements Transaction {
 				transaction.setTimestamp(txnTime);
 			}
 		} else {
-			harperLogger.warn('existing transaction in save', transaction.id);
+			if (transaction.id < 20) harperLogger.warn('existing transaction in save', transaction.id);
 		}
 		if (this.retries > 0) {
-			// this is marks the rocks transaction as a retry so we don't write the transaction log again
+			// This marks the Rocks transaction as a retry so we don't write the transaction log again
 			transaction.isRetry = true;
 		}
 		if (!txnTime) txnTime = this.timestamp = transaction.getTimestamp();
@@ -250,10 +254,10 @@ export class DatabaseTransaction implements Transaction {
 				this.transaction = null; // clear transaction so any further operations operate immediately
 				if (transaction) {
 					if (this.writes.length > 0) {
-						harperLogger.warn('Committing txn', transaction.id);
+						if (transaction.id < 20) harperLogger.warn('Committing txn', transaction.id);
 						commitResolution = transaction.commit();
 					} else {
-						harperLogger.warn('aborting txn', transaction.id);
+						if (transaction.id < 20) harperLogger.warn('aborting txn', transaction.id);
 						commitResolution = transaction.abort();
 					}
 				}

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -688,13 +688,13 @@ export function recordUpdater(store, tableId, auditStore) {
 export function setAdditionalAuditRefs(refs: Array<{ version: number; nodeId: number }> | undefined) {
 	additionalAuditRefsNextEncoding = refs;
 }
-export function removeEntry(store: any, entry: any, existingVersion?: number) {
+export function removeEntry(store: any, entry: any, options?: any) {
 	if (!entry) return;
 	if (entry.value && entry.metadataFlags & HAS_BLOBS) {
 		// if it used to have blobs, we need to delete the old blobs
 		deleteBlobsInObject(entry.value);
 	}
-	return store.remove(entry.key, existingVersion);
+	return store.remove(entry.key, options);
 }
 export interface RecordObject {
 	getUpdatedTime(): number;

--- a/resources/ResourceInterface.ts
+++ b/resources/ResourceInterface.ts
@@ -69,7 +69,7 @@ export interface Context {
 	/**	 The user making the request */
 	user?: User;
 	/** Check the username and password against the core user table to verify user identity */
-	login: (username: string, password: string) => Promise<string>;
+	login?: (username: string, password: string) => Promise<string>;
 	/** Describes the current cookie-based session if it is present and grants the capacity to delete it. authentication.enableSessions must be turned on in the harperdb-config.yaml  */
 	session?: Session;
 	/**	 The database transaction object */

--- a/resources/RocksIndexStore.ts
+++ b/resources/RocksIndexStore.ts
@@ -16,6 +16,13 @@ declare module '@harperfast/rocksdb-js' {
 	}
 }
 
+/**
+ * A specialized RocksDB-based index store that maintains indexed references to primary keys.
+ * This store uses composite keys consisting of indexed values and primary keys, enabling
+ * efficient range queries over indexed data. The actual data values are stored as null since
+ * this is purely an index structure pointing to primary records elsewhere. This extends
+ * RocksDatabase rather than a store because it actually alters the interface
+ */
 export class RocksIndexStore extends RocksDatabase {
 	/**
 	 * Get all entries matching the range

--- a/resources/RocksIndexStore.ts
+++ b/resources/RocksIndexStore.ts
@@ -5,6 +5,7 @@ import {
 	type StoreIteratorOptions,
 	type StorePutOptions,
 	type StoreRemoveOptions,
+	RocksDatabase,
 } from '@harperfast/rocksdb-js';
 import { Id } from './ResourceInterface.ts';
 import { MAXIMUM_KEY } from 'ordered-binary';
@@ -15,12 +16,12 @@ declare module '@harperfast/rocksdb-js' {
 	}
 }
 
-export class RocksIndexStore extends Store {
+export class RocksIndexStore extends RocksDatabase {
 	/**
 	 * Get all entries matching the range
 	 * @param options
 	 */
-	getRange(context: StoreContext, options: StoreIteratorOptions): Iterable<any> {
+	getRange(options: StoreIteratorOptions): Iterable<any> {
 		let { start, end, exclusiveStart, inclusiveEnd, reverse } = options;
 		if ((reverse ? !exclusiveStart : exclusiveStart) && start !== undefined) {
 			start = [start, MAXIMUM_KEY];
@@ -29,7 +30,7 @@ export class RocksIndexStore extends Store {
 			end = [end, MAXIMUM_KEY];
 		}
 		const translatedOptions = { ...options, start, end };
-		return super.getRange(context, translatedOptions).map(({ key }) => {
+		return super.getRange(translatedOptions).map(({ key }) => {
 			return { key: key[0], value: key.length > 2 ? key.slice(1) : key[1] };
 		});
 	}
@@ -40,23 +41,20 @@ export class RocksIndexStore extends Store {
 	 * @param primaryKey
 	 * @param txnId
 	 */
-	put(context: StoreContext, indexedValue: any, primaryKey: Id, options: StorePutOptions) {
-		return super.putSync(context, [indexedValue, primaryKey], null, options);
+	put(indexedValue: any, primaryKey: Id, options: StorePutOptions) {
+		return super.putSync([indexedValue, primaryKey], null, options);
 	}
 
-	putSync(context: StoreContext, indexedValue: any, primaryKey: Id, options: StorePutOptions) {
-		return super.putSync(context, [indexedValue, primaryKey], null, options);
+	putSync(indexedValue: any, primaryKey: Id, options: StorePutOptions) {
+		return super.putSync([indexedValue, primaryKey], null, options);
 	}
 
-	remove(context: StoreContext, indexedValue: any, primaryKey: Id, options?: StoreRemoveOptions) {
-		return super.removeSync(context, [indexedValue, primaryKey], options);
+	remove(indexedValue: any, primaryKey: Id, options?: StoreRemoveOptions) {
+		return super.removeSync([indexedValue, primaryKey], options);
 	}
 
-	removeSync(context: StoreContext, indexedValue: any, options?: StoreRemoveOptions) {
-		// the removeSync operation only takes 2 arguments, and we are stuck inside the store interface, so we need to pass
-		// the removed primary key in the options
-		let primaryKey = options.primaryKey;
-		super.removeSync(context, [indexedValue, primaryKey], options);
+	removeSync(indexedValue: any, primaryKey: Id, options?: StoreRemoveOptions) {
+		super.removeSync([indexedValue, primaryKey], options);
 	}
 }
 
@@ -65,7 +63,7 @@ export class RocksIndexStore extends Store {
  * classes.
  */
 DBI.prototype.getValuesCount = function getValuesCount(indexedValue: any) {
-	if (this.store instanceof RocksIndexStore) {
+	if (this instanceof RocksIndexStore) {
 		return this.store.getCount(this._context, { start: indexedValue, end: [indexedValue, MAXIMUM_KEY] });
 	}
 	throw new Error('getValuesCount is only supported if dupSort=true');

--- a/resources/RocksIndexStore.ts
+++ b/resources/RocksIndexStore.ts
@@ -1,7 +1,5 @@
 import {
 	DBI,
-	Store,
-	type StoreContext,
 	type StoreIteratorOptions,
 	type StorePutOptions,
 	type StoreRemoveOptions,

--- a/resources/RocksIndexStore.ts
+++ b/resources/RocksIndexStore.ts
@@ -10,7 +10,6 @@ import { Id } from './ResourceInterface.ts';
 import { MAXIMUM_KEY } from 'ordered-binary';
 
 declare module '@harperfast/rocksdb-js' {
-	// eslint-disable-next-line no-unused-vars
 	interface DBI<T> {
 		getValuesCount(indexedValue: any): number;
 	}
@@ -53,7 +52,10 @@ export class RocksIndexStore extends Store {
 		return super.removeSync(context, [indexedValue, primaryKey], options);
 	}
 
-	removeSync(context: StoreContext, indexedValue: any, primaryKey: Id, options?: StoreRemoveOptions) {
+	removeSync(context: StoreContext, indexedValue: any, options?: StoreRemoveOptions) {
+		// the removeSync operation only takes 2 arguments, and we are stuck inside the store interface, so we need to pass
+		// the removed primary key in the options
+		let primaryKey = options.primaryKey;
 		super.removeSync(context, [indexedValue, primaryKey], options);
 	}
 }

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1434,13 +1434,23 @@ export function makeTable(options) {
 				// if there is a resolution in-progress, abandon the eviction
 				if (primaryStore.hasLock(id, entry.version)) return;
 			}
-			primaryStore.ifVersion?.(id, existingVersion, () => {
-				updateIndices(id, existingRecord, null);
-			});
 			// evictions never go in the audit log, so we can not record a deletion entry for the eviction
 			// as there is no corresponding audit entry and it would never get cleaned up. So we must simply
-			// removed the entry entirely
-			return removeEntry(primaryStore, entry ?? primaryStore.getEntry(id), existingVersion);
+			// removed the entry entirely, but first cleanup indices
+			if (primaryStore.ifVersion) {
+				// lmdb
+				primaryStore.ifVersion?.(id, existingVersion, () => {
+					updateIndices(id, existingRecord, null);
+				});
+				return removeEntry(primaryStore, entry ?? primaryStore.getEntry(id), existingVersion);
+			} else {
+				let context = {};
+				return transaction(context, () => {
+					let txn = txnForContext(context);
+					updateIndices(id, existingRecord, null);
+					return removeEntry(primaryStore, entry ?? primaryStore.getEntry(id), { transaction: txn.getReadTxn() });
+				});
+			}
 		}
 		/**
 		 * This is intended to acquire a lock on a record from the whole cluster.
@@ -1951,9 +1961,10 @@ export function makeTable(options) {
 							context.lastModified = existingEntry.version;
 						TableResource._updateResource(this, existingEntry);
 					}
-					if (precedesExistingVersion(txnTime, existingEntry, options?.nodeId) <= 0) return; // a newer record exists locally
-					updateIndices(id, existingRecord);
-					logger.trace?.(`Deleting record with id: ${id}, txn timestamp: ${new Date(txnTime).toISOString()}`);
+					if (precedesExistingVersion(txnTime, existingEntry, options?.nodeId) < 0) {
+						return;
+					} // a newer record exists locally
+					updateIndices(id, existingRecord, null, transaction && { transaction });
 					if (audit || trackDeletes) {
 						updateRecord(
 							id,
@@ -3534,7 +3545,8 @@ export function makeTable(options) {
 				}
 				//if the update cleared out the attribute value we need to delete it from the index
 				for (let i = 0, l = valuesToRemove.length; i < l; i++) {
-					index.remove(valuesToRemove[i], id, options);
+					if (options) options.primaryKey = id; // we have to pass the primary key in through the options, because the DBI interface only takes two args
+					index.remove(valuesToRemove[i], options);
 				}
 			} else if (valuesToAdd?.length > 0 && LMDB_PREFETCH_WRITES) {
 				// no old values, just new
@@ -4124,7 +4136,7 @@ export function makeTable(options) {
 								// don't do anything if the version has changed
 								return;
 							}
-							updateIndices(id, existingRecord, updatedRecord);
+							updateIndices(id, existingRecord, updatedRecord, dbTxn && { transaction: dbTxn });
 							if (updatedRecord) {
 								if (existingEntry) {
 									context.previousResidency = TableResource.getResidencyRecord(existingEntry.residencyId);

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -3547,12 +3547,7 @@ export function makeTable(options) {
 				}
 				//if the update cleared out the attribute value we need to delete it from the index
 				for (let i = 0, l = valuesToRemove.length; i < l; i++) {
-					if (isLMDB) {
-						index.remove(valuesToRemove[i], id);
-					} else {
-						if (options) options.primaryKey = id; // we have to pass the primary key in through the options, because the DBI interface only takes two args
-						index.removeSync(valuesToRemove[i], options);
-					}
+					index.remove(valuesToRemove[i], id, options);
 				}
 			} else if (isLMDB && valuesToAdd?.length > 0 && LMDB_PREFETCH_WRITES) {
 				// no old values, just new
@@ -3563,11 +3558,7 @@ export function makeTable(options) {
 			}
 			if (valuesToAdd) {
 				for (let i = 0, l = valuesToAdd.length; i < l; i++) {
-					if (isLMDB) {
-						index.put(valuesToAdd[i], id);
-					} else {
-						index.putSync(valuesToAdd[i], id, options);
-					}
+					index.put(valuesToAdd[i], id, options);
 				}
 			}
 		}

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1876,7 +1876,7 @@ export function makeTable(options) {
 							}
 						})()
 					);
-					updateIndices(id, existingRecord, recordToStore, { transaction });
+					updateIndices(id, existingRecord, recordToStore, transaction && { transaction });
 
 					writeCommit(true);
 					if (context.expiresAt) scheduleCleanup();
@@ -1966,7 +1966,7 @@ export function makeTable(options) {
 					if (precedesExistingVersion(txnTime, existingEntry, options?.nodeId) < 0) {
 						return;
 					} // a newer record exists locally
-					updateIndices(id, existingRecord, null, { transaction });
+					updateIndices(id, existingRecord, null, transaction && { transaction });
 					if (audit || trackDeletes) {
 						updateRecord(
 							id,
@@ -4138,7 +4138,7 @@ export function makeTable(options) {
 								// don't do anything if the version has changed
 								return;
 							}
-							updateIndices(id, existingRecord, updatedRecord, { transaction });
+							updateIndices(id, existingRecord, updatedRecord, transaction && { transaction });
 							if (updatedRecord) {
 								if (existingEntry) {
 									context.previousResidency = TableResource.getResidencyRecord(existingEntry.residencyId);

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1424,33 +1424,34 @@ export function makeTable(options) {
 		 */
 		static evict(id, existingRecord, existingVersion) {
 			let entry;
-			if (hasSourceGet || audit) {
-				if (!existingRecord) return;
-				entry = primaryStore.getEntry(id);
-				if (!entry || !existingRecord) return;
-				if (entry.version !== existingVersion) return;
-			}
-			if (hasSourceGet) {
-				// if there is a resolution in-progress, abandon the eviction
-				if (primaryStore.hasLock(id, entry.version)) return;
-			}
-			// evictions never go in the audit log, so we can not record a deletion entry for the eviction
-			// as there is no corresponding audit entry and it would never get cleaned up. So we must simply
-			// removed the entry entirely, but first cleanup indices
-			if (primaryStore.ifVersion) {
-				// lmdb
-				primaryStore.ifVersion?.(id, existingVersion, () => {
-					updateIndices(id, existingRecord, null);
-				});
-				return removeEntry(primaryStore, entry ?? primaryStore.getEntry(id), existingVersion);
-			} else {
-				let context = {};
-				return transaction(context, () => {
-					let txn = txnForContext(context);
-					let options = { transaction: txn.getReadTxn() };
+			let transaction = txnForContext({ transaction: new DatabaseTransaction() }).getReadTxn();
+			let options = { transaction };
+			try {
+				if (hasSourceGet || audit) {
+					if (!existingRecord) return;
+					entry = primaryStore.getEntry(id, options);
+					if (!entry || !existingRecord) return;
+					if (entry.version !== existingVersion) return;
+				}
+				if (hasSourceGet) {
+					// if there is a resolution in-progress, abandon the eviction
+					if (primaryStore.hasLock(id, entry.version)) return;
+				}
+				// evictions never go in the audit log, so we can not record a deletion entry for the eviction
+				// as there is no corresponding audit entry and it would never get cleaned up. So we must simply
+				// removed the entry entirely, but first cleanup indices
+				if (primaryStore.ifVersion) {
+					// lmdb
+					primaryStore.ifVersion?.(id, existingVersion, () => {
+						updateIndices(id, existingRecord, null);
+					});
+					return removeEntry(primaryStore, entry ?? primaryStore.getEntry(id), existingVersion);
+				} else {
 					updateIndices(id, existingRecord, null, options);
 					return removeEntry(primaryStore, entry ?? primaryStore.getEntry(id), options);
-				});
+				}
+			} finally {
+				return transaction.commit();
 			}
 		}
 		/**

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1447,8 +1447,9 @@ export function makeTable(options) {
 				let context = {};
 				return transaction(context, () => {
 					let txn = txnForContext(context);
-					updateIndices(id, existingRecord, null);
-					return removeEntry(primaryStore, entry ?? primaryStore.getEntry(id), { transaction: txn.getReadTxn() });
+					let options = { transaction: txn.getReadTxn() };
+					updateIndices(id, existingRecord, null, options);
+					return removeEntry(primaryStore, entry ?? primaryStore.getEntry(id), options);
 				});
 			}
 		}

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1874,7 +1874,7 @@ export function makeTable(options) {
 							}
 						})()
 					);
-					updateIndices(id, existingRecord, recordToStore, transaction && { transaction });
+					updateIndices(id, existingRecord, recordToStore, { transaction });
 
 					writeCommit(true);
 					if (context.expiresAt) scheduleCleanup();
@@ -1964,7 +1964,7 @@ export function makeTable(options) {
 					if (precedesExistingVersion(txnTime, existingEntry, options?.nodeId) < 0) {
 						return;
 					} // a newer record exists locally
-					updateIndices(id, existingRecord, null, transaction && { transaction });
+					updateIndices(id, existingRecord, null, { transaction });
 					if (audit || trackDeletes) {
 						updateRecord(
 							id,
@@ -4136,7 +4136,7 @@ export function makeTable(options) {
 								// don't do anything if the version has changed
 								return;
 							}
-							updateIndices(id, existingRecord, updatedRecord, dbTxn && { transaction: dbTxn });
+							updateIndices(id, existingRecord, updatedRecord, { transaction });
 							if (updatedRecord) {
 								if (existingEntry) {
 									context.previousResidency = TableResource.getResidencyRecord(existingEntry.residencyId);

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -3522,6 +3522,7 @@ export function makeTable(options) {
 			// determine what index values need to be removed and added
 			let valuesToAdd = getIndexedValues(value, indexNulls) as any[];
 			let valuesToRemove = getIndexedValues(existingValue, indexNulls) as any[];
+			let isLMDB = !!index.prefetch;
 			if (valuesToRemove?.length > 0) {
 				// put this in a conditional so we can do a faster version for new records
 				// determine the changes/diff from new values and old values
@@ -3538,26 +3539,34 @@ export function makeTable(options) {
 						})
 					: [];
 				valuesToRemove = Array.from(setToRemove);
-				if ((valuesToRemove.length > 0 || valuesToAdd.length > 0) && LMDB_PREFETCH_WRITES) {
+				if (isLMDB && (valuesToRemove.length > 0 || valuesToAdd.length > 0) && LMDB_PREFETCH_WRITES) {
 					// prefetch any values that have been removed or added
 					const valuesToPrefetch = valuesToRemove.concat(valuesToAdd).map((v) => ({ key: v, value: id }));
-					index.prefetch?.(valuesToPrefetch, noop);
+					index.prefetch(valuesToPrefetch, noop);
 				}
 				//if the update cleared out the attribute value we need to delete it from the index
 				for (let i = 0, l = valuesToRemove.length; i < l; i++) {
-					if (options) options.primaryKey = id; // we have to pass the primary key in through the options, because the DBI interface only takes two args
-					index.remove(valuesToRemove[i], options);
+					if (isLMDB) {
+						index.remove(valuesToRemove[i], id);
+					} else {
+						if (options) options.primaryKey = id; // we have to pass the primary key in through the options, because the DBI interface only takes two args
+						index.removeSync(valuesToRemove[i], options);
+					}
 				}
-			} else if (valuesToAdd?.length > 0 && LMDB_PREFETCH_WRITES) {
+			} else if (isLMDB && valuesToAdd?.length > 0 && LMDB_PREFETCH_WRITES) {
 				// no old values, just new
-				index.prefetch?.(
+				index.prefetch(
 					valuesToAdd.map((v) => ({ key: v, value: id })),
 					noop
 				);
 			}
 			if (valuesToAdd) {
 				for (let i = 0, l = valuesToAdd.length; i < l; i++) {
-					index.put(valuesToAdd[i], id, options);
+					if (isLMDB) {
+						index.put(valuesToAdd[i], id);
+					} else {
+						index.putSync(valuesToAdd[i], id, options);
+					}
 				}
 			}
 		}

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -120,9 +120,13 @@ function openRocksDatabase(path: string, options: RocksDatabaseOptions & { dupSo
 	}
 	let db: RocksRootDatabase;
 	if (options.dupSort) {
-		db = RocksDatabase.open(new RocksIndexStore(path, options)) as RocksDatabaseEx;
+		db = new RocksIndexStore(path, options).open() as RocksDatabaseEx;
 	} else {
 		db = RocksDatabase.open(path, options) as RocksDatabaseEx;
+		// the RocksDB put and remove return promises, which masks thrown errors in non-awaiting calls to put/remove,
+		// making them unsafe to replace LMDB methods, which will synchronously throw errors if there is a problem
+		db.put = db.putSync;
+		db.remove = db.removeSync;
 		db.encoder.name = options.name;
 	}
 	db.env = {};
@@ -549,7 +553,10 @@ function initStores(
 						existingAttribute,
 						'from attributes',
 						existingAttributes,
-						tableName
+						'in',
+						tableName,
+						'requesting new attribute list',
+						attributes
 					);
 					continue;
 				}

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -544,7 +544,13 @@ function initStores(
 			const attribute = attributes.find((attribute) => attribute.name === existingAttribute.name);
 			if (!attribute) {
 				if (existingAttribute.isPrimaryKey) {
-					logger.error('Unable to remove existing primary key attribute', existingAttribute);
+					logger.error(
+						'Unable to remove existing primary key attribute',
+						existingAttribute,
+						'from attributes',
+						existingAttributes,
+						tableName
+					);
 					continue;
 				}
 				if (existingAttribute.indexed) {

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -432,13 +432,6 @@ function initStores(
 	definedTables.rootStore = rootStore;
 	const tablesToLoad = new Map<string, any>();
 
-	console.log(
-		'loading attributes from ',
-		rootStore.path,
-		attributesDbi.path,
-		'checking hdb_raw_analytics',
-		attributesDbi.getSync('hdb_raw_analytics/')
-	);
 	for (const result of attributesDbi.getRange({ start: false })) {
 		const { key, value } = result as { key: string; value: any };
 		let [tableName, attribute_name] = key.toString().split('/');
@@ -1051,7 +1044,6 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 					if (attribute.type) updatedPrimaryAttribute.type = attribute.type;
 					hasChanges = true; // send out notification of the change
 					exclusiveLock();
-					console.log('setting attribute', dbiKey, updatedPrimaryAttribute);
 					attributesDbi.put(dbiKey, updatedPrimaryAttribute);
 				}
 
@@ -1100,7 +1092,6 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 							attributesToIndex.push(attribute);
 						}
 					}
-					console.log('setting attribute', dbiKey, attribute);
 					attributesDbi.put(dbiKey, attribute);
 				}
 				if (attributeDescriptor?.indexNulls && attribute.indexNulls === undefined) attribute.indexNulls = true;
@@ -1109,7 +1100,6 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 			} else if (changed) {
 				hasChanges = true;
 				exclusiveLock();
-				console.log('setting attribute', dbiKey, attribute);
 				attributesDbi.put(dbiKey, attribute);
 			}
 		}
@@ -1280,7 +1270,6 @@ export function dropTableMeta({ table: tableName, database: databaseName }) {
 	const removals = [];
 	const dbisDb = rootStore.dbisDb;
 	for (const key of dbisDb.getKeys({ start: tableName + '/', end: tableName + '0' })) {
-		console.log('removing attribute', key);
 		removals.push(dbisDb.remove(key));
 	}
 	databaseEventsEmitter.emit('dropTable', tableName, databaseName);

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -549,7 +549,7 @@ function initStores(
 			if (!attribute) {
 				if (existingAttribute.isPrimaryKey) {
 					logger.error(
-						'Unable to remove existing primary key attribute',
+						new Error('Unable to remove existing primary key attribute'),
 						existingAttribute,
 						'from attributes',
 						existingAttributes,

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -556,7 +556,9 @@ function initStores(
 						'in',
 						tableName,
 						'requesting new attribute list',
-						attributes
+						attributes,
+						'full metadata list',
+						Array.from(dbisStore.getRange({ start: false }))
 					);
 					continue;
 				}

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -390,18 +390,18 @@ function initStores(
 ) {
 	const envInit = new OpenEnvironmentObject(path, false);
 	const internalDbiInit = createOpenDBIObject(false);
-	let dbisStore = rootStore.dbisDb;
-	if (!dbisStore) {
+	let attributesDbi = rootStore.dbisDb;
+	if (!attributesDbi) {
 		if (rootStore instanceof RocksDatabase) {
-			dbisStore = openRocksDatabase(rootStore.path, {
+			attributesDbi = openRocksDatabase(rootStore.path, {
 				...internalDbiInit,
 				disableWAL: false,
 				name: INTERNAL_DBIS_NAME,
 			}) as RocksDatabaseEx;
 		} else {
-			dbisStore = rootStore.openDB(INTERNAL_DBIS_NAME, internalDbiInit);
+			attributesDbi = rootStore.openDB(INTERNAL_DBIS_NAME, internalDbiInit);
 		}
-		rootStore.dbisDb = dbisStore;
+		rootStore.dbisDb = attributesDbi;
 	}
 
 	let auditStore = rootStore.auditStore;
@@ -432,7 +432,14 @@ function initStores(
 	definedTables.rootStore = rootStore;
 	const tablesToLoad = new Map<string, any>();
 
-	for (const result of dbisStore.getRange({ start: false })) {
+	console.log(
+		'loading attributes from ',
+		rootStore.path,
+		attributesDbi.path,
+		'checking hdb_raw_analytics',
+		attributesDbi.getSync('hdb_raw_analytics/')
+	);
+	for (const result of attributesDbi.getRange({ start: false })) {
 		const { key, value } = result as { key: string; value: any };
 		let [tableName, attribute_name] = key.toString().split('/');
 		if (attribute_name === '') {
@@ -493,16 +500,16 @@ function initStores(
 		} else {
 			tableId = primaryAttribute.tableId;
 			if (tableId) {
-				if (tableId >= (dbisStore.getSync(NEXT_TABLE_ID) || 0)) {
-					dbisStore.putSync(NEXT_TABLE_ID, tableId + 1);
+				if (tableId >= (attributesDbi.getSync(NEXT_TABLE_ID) || 0)) {
+					attributesDbi.putSync(NEXT_TABLE_ID, tableId + 1);
 					logger.info(`Updating next table id (it was out of sync) to ${tableId + 1} for ${tableName}`);
 				}
 			} else {
-				primaryAttribute.tableId = tableId = dbisStore.getSync(NEXT_TABLE_ID);
+				primaryAttribute.tableId = tableId = attributesDbi.getSync(NEXT_TABLE_ID);
 				if (!tableId) tableId = 1;
 				logger.debug(`Table {tableName} missing an id, assigning {tableId}`);
-				dbisStore.putSync(NEXT_TABLE_ID, tableId + 1);
-				dbisStore.putSync(primaryAttribute.key, primaryAttribute);
+				attributesDbi.putSync(NEXT_TABLE_ID, tableId + 1);
+				attributesDbi.putSync(primaryAttribute.key, primaryAttribute);
 			}
 			const dbiInit = createOpenDBIObject(!primaryAttribute.isPrimaryKey, primaryAttribute.isPrimaryKey);
 			dbiInit.compression = primaryAttribute.compression;
@@ -558,7 +565,7 @@ function initStores(
 						'requesting new attribute list',
 						attributes,
 						'full metadata list',
-						Array.from(dbisStore.getRange({ start: false }))
+						Array.from(attributesDbi.getRange({ start: false }))
 					);
 					continue;
 				}
@@ -596,7 +603,7 @@ function initStores(
 					indices,
 					attributes,
 					schemaDefined: primaryAttribute.schemaDefined,
-					dbisDB: dbisStore,
+					dbisDB: attributesDbi,
 				})
 			);
 			table.schemaVersion = 1;
@@ -1044,6 +1051,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 					if (attribute.type) updatedPrimaryAttribute.type = attribute.type;
 					hasChanges = true; // send out notification of the change
 					exclusiveLock();
+					console.log('setting attribute', dbiKey, updatedPrimaryAttribute);
 					attributesDbi.put(dbiKey, updatedPrimaryAttribute);
 				}
 
@@ -1092,6 +1100,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 							attributesToIndex.push(attribute);
 						}
 					}
+					console.log('setting attribute', dbiKey, attribute);
 					attributesDbi.put(dbiKey, attribute);
 				}
 				if (attributeDescriptor?.indexNulls && attribute.indexNulls === undefined) attribute.indexNulls = true;
@@ -1100,6 +1109,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 			} else if (changed) {
 				hasChanges = true;
 				exclusiveLock();
+				console.log('setting attribute', dbiKey, attribute);
 				attributesDbi.put(dbiKey, attribute);
 			}
 		}
@@ -1270,6 +1280,7 @@ export function dropTableMeta({ table: tableName, database: databaseName }) {
 	const removals = [];
 	const dbisDb = rootStore.dbisDb;
 	for (const key of dbisDb.getKeys({ start: tableName + '/', end: tableName + '0' })) {
+		console.log('removing attribute', key);
 		removals.push(dbisDb.remove(key));
 	}
 	databaseEventsEmitter.emit('dropTable', tableName, databaseName);

--- a/resources/indexes/HierarchicalNavigableSmallWorld.ts
+++ b/resources/indexes/HierarchicalNavigableSmallWorld.ts
@@ -142,7 +142,14 @@ export class HierarchicalNavigableSmallWorld {
 			// For each level from top to bottom
 			while (currentLevel > level) {
 				// Search for closest neighbors at current level
-				const neighbors = this.searchLayer(vector, entryPointId, entryPoint, this.efConstruction, currentLevel);
+				const neighbors = this.searchLayer(
+					vector,
+					entryPointId,
+					entryPoint,
+					this.efConstruction,
+					currentLevel,
+					options
+				);
 
 				if (neighbors.length > 0) {
 					entryPointId = neighbors[0].id; // closest neighbor becomes new entry point
@@ -157,7 +164,7 @@ export class HierarchicalNavigableSmallWorld {
 
 			// Connect the new element to neighbors at its level and below
 			for (let l = Math.min(level, currentLevel); l >= 0; l--) {
-				let neighbors = this.searchLayer(vector, entryPointId, entryPoint, this.efConstruction, l);
+				let neighbors = this.searchLayer(vector, entryPointId, entryPoint, this.efConstruction, l, options);
 				neighbors = neighbors.slice(0, this.M << 1) as SearchResults;
 
 				if (neighbors.length === 0 && l === 0) {
@@ -336,16 +343,16 @@ export class HierarchicalNavigableSmallWorld {
 			this.indexStore.put(id, updatedNode, options);
 		}
 		for (const [key, vector] of needsReindexing) {
-			this.index(key, vector, vector);
+			this.index(key, vector, vector, options);
 		}
 		this.checkSymmetry(nodeId, this.indexStore.getSync(nodeId, options), options);
 	}
 
-	private getEntryPoint() {
+	private getEntryPoint(options: { transaction?: any } = {}) {
 		// Get entry point
-		const entryPointId = this.indexStore.getSync(ENTRY_POINT);
+		const entryPointId = this.indexStore.getSync(ENTRY_POINT, options);
 		if (entryPointId === undefined) return;
-		const node = this.indexStore.getSync(entryPointId);
+		const node = this.indexStore.getSync(entryPointId, options);
 		return { id: entryPointId, ...node };
 	}
 
@@ -359,6 +366,7 @@ export class HierarchicalNavigableSmallWorld {
 	 * @param ef
 	 * @param level
 	 * @param distanceFunction
+	 * @param options
 	 * @private
 	 */
 	private searchLayer(
@@ -367,6 +375,7 @@ export class HierarchicalNavigableSmallWorld {
 		entryPoint: any,
 		ef: number,
 		level: number,
+		options: { transaction?: any } = {},
 		distanceFunction = this.distance
 	): SearchResults {
 		const visited = new Set([entryPointId]);
@@ -396,7 +405,7 @@ export class HierarchicalNavigableSmallWorld {
 				if (visited.has(neighborId) || neighborId === undefined) continue;
 				visited.add(neighborId);
 
-				const neighbor = this.indexStore.getSync(neighborId);
+				const neighbor = this.indexStore.getSync(neighborId, options);
 				if (!neighbor) continue;
 				this.nodesVisitedCount++;
 				const distance = distanceFunction(queryVector, neighbor.vector);
@@ -429,19 +438,22 @@ export class HierarchicalNavigableSmallWorld {
 	 * @param comparator
 	 * @param context
 	 */
-	search({
-		target,
-		value,
-		descending,
-		distance,
-		comparator,
-	}: {
-		target: number[];
-		value: number;
-		descending: boolean;
-		distance: string;
-		comparator: string;
-	}) {
+	search(
+		{
+			target,
+			value,
+			descending,
+			distance,
+			comparator,
+		}: {
+			target: number[];
+			value: number;
+			descending: boolean;
+			distance: string;
+			comparator: string;
+		},
+		context: any
+	) {
 		let limit = 0; // zero is ignored, only used if set below
 		switch (comparator) {
 			case 'lt':
@@ -462,14 +474,23 @@ export class HierarchicalNavigableSmallWorld {
 		if (!target) throw new ClientError('A target vector must be provided for an HNSW query');
 		if (!Array.isArray(target)) throw new ClientError('The target vector must be an array');
 
-		let entryPoint = this.getEntryPoint();
+		const options = context.transaction; // should have a nested RocksDB transaction
+		let entryPoint = this.getEntryPoint(options);
 		if (!entryPoint) return [];
 		let entryPointId = entryPoint.id;
 		let results: Candidate[] = [];
 		// For each level from top to bottom
 		for (let l = entryPoint.level; l >= 0; l--) {
 			// Search for closest neighbors at current level
-			results = this.searchLayer(target, entryPointId, entryPoint, this.efConstructionSearch, l, distanceFunction);
+			results = this.searchLayer(
+				target,
+				entryPointId,
+				entryPoint,
+				this.efConstructionSearch,
+				l,
+				options,
+				distanceFunction
+			);
 
 			if (results.length > 0) {
 				const neighbor = results[0]; // closest neighbor becomes new entry point
@@ -500,7 +521,7 @@ export class HierarchicalNavigableSmallWorld {
 				// verify that the connection is symmetrical
 				const symmetrical = neighborNode[l]?.find(({ id: nid }) => nid == id);
 				if (!symmetrical) {
-					logger.info?.('asymmetry detected', neighborNode[l]);
+					logger.info?.('asymmetry detected', neighborNode[l], 'does not have', id);
 				}
 			}
 			l++;

--- a/security/certificateVerification/ocspVerification.ts
+++ b/security/certificateVerification/ocspVerification.ts
@@ -95,7 +95,7 @@ export async function verifyOCSP(
 			method: cached.method || 'ocsp',
 		};
 	} catch (error) {
-		logger.error?.(`OCSP verification error: ${error}`);
+		logger.error?.(`OCSP verification error:`, error);
 
 		// Check failure mode
 		if (config.failureMode === 'fail-closed') {

--- a/server/itc/serverHandlers.js
+++ b/server/itc/serverHandlers.js
@@ -46,10 +46,6 @@ async function schemaHandler(event) {
  */
 async function syncSchemaMetadata(msg) {
 	try {
-		// reset current read transactions to ensure that we are getting the very latest data
-		harperBridge.resetReadTxn(hdbTerms.SYSTEM_SCHEMA_NAME, hdbTerms.SYSTEM_TABLE_NAMES.TABLE_TABLE_NAME);
-		harperBridge.resetReadTxn(hdbTerms.SYSTEM_SCHEMA_NAME, hdbTerms.SYSTEM_TABLE_NAMES.ATTRIBUTE_TABLE_NAME);
-		harperBridge.resetReadTxn(hdbTerms.SYSTEM_SCHEMA_NAME, hdbTerms.SYSTEM_TABLE_NAMES.SCHEMA_TABLE_NAME);
 		// TODO: Eventually should indicate which database/table changed so we don't have to scan everything
 		let databases = resetDatabases();
 		if (msg.table && msg.database)

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -7,6 +7,7 @@ const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { transaction } = require('#src/resources/transaction');
 const { IterableEventQueue } = require('#js/resources/IterableEventQueue');
 const { RocksDatabase } = require('@harperfast/rocksdb-js');
+const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
 
 describe('Transactions', () => {
 	let TxnTest, TxnTest2, TxnTest3;
@@ -216,6 +217,7 @@ describe('Transactions', () => {
 		});
 
 		it('Write after read after delete', async function () {
+			if (isLMDB) return;
 			const context = {};
 			await transaction(context, async () => {
 				await TxnTest.put(71, { name: 'before delete' });
@@ -236,6 +238,7 @@ describe('Transactions', () => {
 		});
 
 		it('Successive patches, concurrently', async function () {
+			if (isLMDB) return;
 			await TxnTest.put(71, { name: 'original', count: 0 });
 			let txns = [];
 			for (let i = 0; i < 4; i++) {

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -26,6 +26,7 @@ describe('Transactions', () => {
 				{ name: 'countInt', type: 'Int' },
 				{ name: 'computed', computed: true, indexed: true },
 			],
+			audit: true,
 		});
 		TxnTest.sourcedFrom({
 			subscribe() {
@@ -212,6 +213,43 @@ describe('Transactions', () => {
 			let record = await TxnTest.get(61);
 			assert.equal(record.name, 'newer');
 			assert.equal(record.count, 3);
+		});
+
+		it('Write after read after delete', async function () {
+			const context = {};
+			await transaction(context, async () => {
+				await TxnTest.put(71, { name: 'before delete' });
+				await TxnTest.delete(71);
+				let rawRecord = TxnTest.primaryStore.getSync(71);
+				console.log({ rawRecord });
+				let record = await TxnTest.get(71);
+				assert(!record);
+				await TxnTest.put(71, { name: 'after delete' });
+				record = await TxnTest.get(71);
+				assert.equal(record.name, 'after delete');
+				await TxnTest.put(71, { name: 'after delete 2' });
+				record = await TxnTest.get(71);
+				assert.equal(record.name, 'after delete 2');
+			});
+			let record = await TxnTest.get(71);
+			assert.equal(record.name, 'after delete 2');
+		});
+
+		it('Successive patches, concurrently', async function () {
+			await TxnTest.put(71, { name: 'original', count: 0 });
+			let txns = [];
+			for (let i = 0; i < 4; i++) {
+				txns.push(
+					transaction({}, async (txn) => {
+						await TxnTest.patch(71, { count: 1 });
+						console.log('id', txn.transaction?.id);
+						await TxnTest.patch(71, { count: 2 });
+					})
+				);
+			}
+			await Promise.all(txns);
+			let record = await TxnTest.get(71);
+			assert.equal(record.count, 2);
 		});
 
 		it('Store additional audit refs on out-of-order writes', async function () {

--- a/unitTests/security/certificateVerification/crlVerification.test.js
+++ b/unitTests/security/certificateVerification/crlVerification.test.js
@@ -228,9 +228,7 @@ describe('certificateVerification/crlVerification.ts', function () {
 			const certFromBERStub = sinon.stub(pkijs.Certificate, 'fromBER').returns(mockIssuerCert);
 
 			// Mock fetch to return CRL data
-			//
 			const originalFetch = globalThis.fetch;
-			//
 			globalThis.fetch = sinon.stub().resolves({
 				ok: true,
 				status: 200,
@@ -264,7 +262,6 @@ describe('certificateVerification/crlVerification.ts', function () {
 			} finally {
 				fromBERStub.restore();
 				certFromBERStub.restore();
-				//
 				globalThis.fetch = originalFetch;
 			}
 		});
@@ -295,9 +292,7 @@ describe('certificateVerification/crlVerification.ts', function () {
 			const certFromBERStub = sinon.stub(pkijs.Certificate, 'fromBER').returns(mockIssuerCert);
 
 			// Mock fetch to return CRL data
-			//
 			const originalFetch = globalThis.fetch;
-			//
 			globalThis.fetch = sinon.stub().resolves({
 				ok: true,
 				status: 200,
@@ -331,7 +326,6 @@ describe('certificateVerification/crlVerification.ts', function () {
 			} finally {
 				fromBERStub.restore();
 				certFromBERStub.restore();
-				//
 				globalThis.fetch = originalFetch;
 			}
 		});

--- a/unitTests/security/certificateVerification/crlVerification.test.js
+++ b/unitTests/security/certificateVerification/crlVerification.test.js
@@ -33,12 +33,12 @@ describe('certificateVerification/crlVerification.ts', function () {
 			for await (const entry of entries) {
 				try {
 					await certCacheTable.delete(entry.certificate_id);
-					// eslint-disable-next-line sonarjs/no-ignored-exceptions
+					//
 				} catch {
 					// Ignore delete errors
 				}
 			}
-			// eslint-disable-next-line sonarjs/no-ignored-exceptions
+			//
 		} catch {
 			// Ignore if cache doesn't exist yet
 		}
@@ -228,9 +228,9 @@ describe('certificateVerification/crlVerification.ts', function () {
 			const certFromBERStub = sinon.stub(pkijs.Certificate, 'fromBER').returns(mockIssuerCert);
 
 			// Mock fetch to return CRL data
-			// eslint-disable-next-line no-undef
+			//
 			const originalFetch = globalThis.fetch;
-			// eslint-disable-next-line no-undef
+			//
 			globalThis.fetch = sinon.stub().resolves({
 				ok: true,
 				status: 200,
@@ -264,7 +264,7 @@ describe('certificateVerification/crlVerification.ts', function () {
 			} finally {
 				fromBERStub.restore();
 				certFromBERStub.restore();
-				// eslint-disable-next-line no-undef
+				//
 				globalThis.fetch = originalFetch;
 			}
 		});
@@ -295,9 +295,9 @@ describe('certificateVerification/crlVerification.ts', function () {
 			const certFromBERStub = sinon.stub(pkijs.Certificate, 'fromBER').returns(mockIssuerCert);
 
 			// Mock fetch to return CRL data
-			// eslint-disable-next-line no-undef
+			//
 			const originalFetch = globalThis.fetch;
-			// eslint-disable-next-line no-undef
+			//
 			globalThis.fetch = sinon.stub().resolves({
 				ok: true,
 				status: 200,
@@ -331,7 +331,7 @@ describe('certificateVerification/crlVerification.ts', function () {
 			} finally {
 				fromBERStub.restore();
 				certFromBERStub.restore();
-				// eslint-disable-next-line no-undef
+				//
 				globalThis.fetch = originalFetch;
 			}
 		});

--- a/unitTests/testUtils.js
+++ b/unitTests/testUtils.js
@@ -202,7 +202,7 @@ async function tearDownMockDB(envs = undefined, partial_teardown = false) {
 
 		delete global.hdb_schema;
 		global.lmdb_map = undefined;
-		//if (!partial_teardown) await fs.remove(ENV_DIR_PATH);
+		if (!partial_teardown) await fs.remove(ENV_DIR_PATH);
 	} catch (err) {
 		console.error('Error tearing down mock DB used for unit tests');
 		console.error(err);

--- a/unitTests/testUtils.js
+++ b/unitTests/testUtils.js
@@ -202,7 +202,7 @@ async function tearDownMockDB(envs = undefined, partial_teardown = false) {
 
 		delete global.hdb_schema;
 		global.lmdb_map = undefined;
-		if (!partial_teardown) await fs.remove(ENV_DIR_PATH);
+		//if (!partial_teardown) await fs.remove(ENV_DIR_PATH);
 	} catch (err) {
 		console.error('Error tearing down mock DB used for unit tests');
 		console.error(err);


### PR DESCRIPTION
Implements exponential backoff for transaction retries (up to 100 attempts) to reduce contention conflicts. Fixes index removal to pass primary key through options due to DBI interface constraints. Updates eviction logic to use transactions for RocksDB index cleanup instead of ifVersion.