### PR TITLE
Add configurable allowed directory for applications with 'any' option

### DIFF
--- a/components/ApplicationScope.ts
+++ b/components/ApplicationScope.ts
@@ -32,6 +32,7 @@ export class ApplicationScope {
 
 		this.mode = env.get(CONFIG_PARAMS.APPLICATIONS_MODULELOADER) ?? 'vm';
 		this.dependencyLoader = env.get(CONFIG_PARAMS.APPLICATIONS_DEPENDENCYLOADER);
+		if (env.get(CONFIG_PARAMS.APPLICATIONS_ALLOWEDDIRECTORY) !== 'app') this.allowedPath = ''; // this is used to match paths by startsWith, so empty string matches everything
 	}
 
 	/**

--- a/static/defaultConfig.yaml
+++ b/static/defaultConfig.yaml
@@ -30,6 +30,7 @@ applications:
   allowedSpawnCommands:
     - npm
     - node
+  allowedDirectory: app
 componentsRoot: null
 localStudio:
   enabled: true

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -442,6 +442,7 @@ export const CONFIG_PARAMS = {
 	APPLICATIONS_PACKAGEMANAGERPREFIX: 'applications_packageManagerPrefix',
 	APPLICATIONS_ALLOWEDBUILTINMODULES: 'applications_allowedBuiltInModules',
 	APPLICATIONS_ALLOWEDSPAWNCOMMANDS: 'applications_allowedSpawnCommands',
+	APPLICATIONS_ALLOWEDDIRECTORY: 'applications_allowedDirectory',
 	THREADS: 'threads',
 	THREADS_COUNT: 'threads_count',
 	THREADS_DEBUG: 'threads_debug',

--- a/utility/install/installer.js
+++ b/utility/install/installer.js
@@ -56,6 +56,7 @@ const DEV_MODE_CONFIG = {
 	[CONFIG_PARAMS.OPERATIONSAPI_NETWORK_PORT]: 9925,
 	[CONFIG_PARAMS.LOCALSTUDIO_ENABLED]: true,
 	[CONFIG_PARAMS.NODE_HOSTNAME]: DEFAULT_NODE_HOSTNAME,
+	[CONFIG_PARAMS.APPLICATIONS_ALLOWEDDIRECTORY]: 'any',
 };
 
 // Install prompts
@@ -110,7 +111,8 @@ async function install() {
 
 	// REPLICATION_HOSTNAME was renamed to NODE_HOSTNAME in v5, but we still support the replication value if provided
 	if (promptOverride[hdbTerms.INSTALL_PROMPTS.REPLICATION_HOSTNAME]) {
-		promptOverride[hdbTerms.INSTALL_PROMPTS.NODE_HOSTNAME] = promptOverride[hdbTerms.INSTALL_PROMPTS.REPLICATION_HOSTNAME];
+		promptOverride[hdbTerms.INSTALL_PROMPTS.NODE_HOSTNAME] =
+			promptOverride[hdbTerms.INSTALL_PROMPTS.REPLICATION_HOSTNAME];
 	}
 
 	// For backwards compatibility for a time before DEFAULTS_MODE (and host name) assume prod when these args used


### PR DESCRIPTION
This commit introduces the `APPLICATIONS_ALLOWEDDIRECTORY` configuration parameter to control application file access restrictions. The default value is set to 'app', maintaining current behavior, while 'any' allows unrestricted directory access by clearing the allowedPath check.