### PR TITLE
Cache HTTP responses based on RFC 9111 cacheable status codes

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -91,6 +91,7 @@ const NULL_WITH_TIMESTAMP = new Uint8Array(9);
 NULL_WITH_TIMESTAMP[8] = 0xc0; // null
 const UNCACHEABLE_TIMESTAMP = Infinity; // we use this when dynamic content is accessed that we can't safely cache, and this prevents earlier timestamps from change the "last" modification
 const RECORD_PRUNING_INTERVAL = 60000; // one minute
+const CACHEABLE_STATUS_CODES = new Set([200, 203, 204, 206, 300, 301, 308, 404, 405, 410, 414, 501]);
 envMngr.initSync();
 const LMDB_PREFETCH_WRITES = envMngr.get(CONFIG_PARAMS.STORAGE_PREFETCHWRITES);
 const LOCK_TIMEOUT = 10000;
@@ -4038,15 +4039,14 @@ export function makeTable(options) {
 							if (typeof updatedRecord !== 'object') throw new Error('Only objects can be cached and stored in tables');
 							if (updatedRecord.status > 0 && updatedRecord.headers) {
 								// if the source has a status code and headers, treat it as a response
-								if (updatedRecord.status >= 300) {
-									if (updatedRecord.status === 304) {
-										// revalidation of our current cached record
-										updatedRecord = existingRecord;
-										version = existingVersion;
-									} else {
-										// if the source has an error status, we need to throw an error
-										throw new ServerError(updatedRecord.body || 'Error from source', updatedRecord.status);
-									} // there are definitely more status codes to handle
+								const status = updatedRecord.status;
+								if (status === 304) {
+									// revalidation of our current cached record
+									updatedRecord = existingRecord;
+									version = existingVersion;
+								} else if (!CACHEABLE_STATUS_CODES.has(status)) {
+									// non-cacheable status - propagate to client without caching
+									throw new ServerError(updatedRecord.body || 'Error from source', status);
 								} else {
 									let headers: any;
 									const sourceHeaders = updatedRecord.headers;
@@ -4074,16 +4074,11 @@ export function makeTable(options) {
 									if (data !== undefined) {
 										// we have structured data that we have parsed
 										delete headers['content-type']; // don't store the content type if we have already parsed it
-										updatedRecord = {
-											headers,
-											data,
-										};
+										updatedRecord = { headers, data };
 									} else {
-										updatedRecord = {
-											headers,
-											body: createBlob(updatedRecord.body),
-										};
+										updatedRecord = { headers, body: createBlob(updatedRecord.body) };
 									}
+									if (status !== 200) updatedRecord.status = status;
 								}
 							}
 							if (typeof updatedRecord.toJSON === 'function') updatedRecord = updatedRecord.toJSON();

--- a/unitTests/apiTests/basicREST-test.mjs
+++ b/unitTests/apiTests/basicREST-test.mjs
@@ -457,6 +457,7 @@ describe('test REST calls', () => {
 			assert(!response2.headers['server-timing'].includes('miss'));
 		});
 		it('does not cache a non-cacheable 500 response', async () => {
+			const callsBefore = tables.CacheOfHttp.serverErrorCalls;
 			const response = await axios.get('http://localhost:9926/CacheOfHttp/server-error', {
 				validateStatus: () => true,
 			});
@@ -466,6 +467,7 @@ describe('test REST calls', () => {
 				validateStatus: () => true,
 			});
 			assert.equal(response2.status, 500);
+			assert.equal(tables.CacheOfHttp.serverErrorCalls, callsBefore + 2);
 		});
 		it('does not store status in cached record for 200 responses', async () => {
 			// The CacheOfHttp 'created-response' source returns a 200 with a custom header

--- a/unitTests/apiTests/basicREST-test.mjs
+++ b/unitTests/apiTests/basicREST-test.mjs
@@ -466,7 +466,6 @@ describe('test REST calls', () => {
 				validateStatus: () => true,
 			});
 			assert.equal(response2.status, 500);
-			assert(response2.headers['server-timing'].includes('miss'));
 		});
 		it('does not store status in cached record for 200 responses', async () => {
 			// The CacheOfHttp 'created-response' source returns a 200 with a custom header

--- a/unitTests/apiTests/basicREST-test.mjs
+++ b/unitTests/apiTests/basicREST-test.mjs
@@ -443,6 +443,40 @@ describe('test REST calls', () => {
 			req.end(body);
 		});
 	});
+	describe('HTTP response status code caching', function () {
+		it('caches a cacheable 404 response and returns it with 404 status', async () => {
+			const response = await axios.get('http://localhost:9926/CacheOfHttp/not-found', {
+				validateStatus: () => true,
+			});
+			assert.equal(response.status, 404);
+			// second request should also return 404 (served from cache)
+			const response2 = await axios.get('http://localhost:9926/CacheOfHttp/not-found', {
+				validateStatus: () => true,
+			});
+			assert.equal(response2.status, 404);
+			assert(!response2.headers['server-timing'].includes('miss'));
+		});
+		it('does not cache a non-cacheable 500 response', async () => {
+			const response = await axios.get('http://localhost:9926/CacheOfHttp/server-error', {
+				validateStatus: () => true,
+			});
+			assert.equal(response.status, 500);
+			// second request should also hit source (not cached)
+			const response2 = await axios.get('http://localhost:9926/CacheOfHttp/server-error', {
+				validateStatus: () => true,
+			});
+			assert.equal(response2.status, 500);
+			assert(response2.headers['server-timing'].includes('miss'));
+		});
+		it('does not store status in cached record for 200 responses', async () => {
+			// The CacheOfHttp 'created-response' source returns a 200 with a custom header
+			// If status 200 were stored, it would appear as a field in the raw record
+			// We verify that the 200 response is served correctly without redundantly caching status
+			const response = await axios.get('http://localhost:9926/CacheOfHttp/created-response');
+			assert.equal(response.status, 200);
+			assert.equal(response.headers.get('x-custom-header'), 'custom value');
+		});
+	});
 	it('post with custom response', async () => {
 		const response = await axios.post('http://localhost:9926/SimpleCache/35555', {
 			customResponse: true,

--- a/unitTests/testApp/resources.js
+++ b/unitTests/testApp/resources.js
@@ -194,6 +194,10 @@ tables.CacheOfHttp.sourcedFrom({
 					headers: { 'x-custom-header': 'custom value' },
 					name: 'test-sibling-to-headers',
 				};
+			case 'not-found':
+				return new Response('Not Found', { status: 404 });
+			case 'server-error':
+				return new Response('Internal Server Error', { status: 500 });
 		}
 	},
 });

--- a/unitTests/testApp/resources.js
+++ b/unitTests/testApp/resources.js
@@ -169,6 +169,7 @@ tables.CacheOfResource.sourcedFrom({
 });
 
 // test transparent HTTP caching straight through
+tables.CacheOfHttp.serverErrorCalls = 0;
 tables.CacheOfHttp.sourcedFrom({
 	async get(target) {
 		switch (target) {
@@ -197,6 +198,7 @@ tables.CacheOfHttp.sourcedFrom({
 			case 'not-found':
 				return new Response('Not Found', { status: 404 });
 			case 'server-error':
+				tables.CacheOfHttp.serverErrorCalls++;
 				return new Response('Internal Server Error', { status: 500 });
 		}
 	},


### PR DESCRIPTION
Replaces the blanket >=300 error throw with a proper cacheable-status check so that responses like 404, 405, and 410 are stored in the cache (with their status code preserved in the record) rather than being propagated as uncached errors. Status 200 is omitted from the stored record since it is the implied default. Non-cacheable codes (e.g. 500, 302) continue to propagate to the client without being cached.

Adds tests for cacheable 404, non-cacheable 500, and 200 behaviour.

Addresses #153 