### PR TITLE
Use PID-based paths consistently in unit test utilities

### DIFF
--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -184,7 +184,6 @@ export function getDatabases(): Databases {
 		getConfigPath(CONFIG_PARAMS.STORAGE_PATH) ||
 		(databasePath && (existsSync(databasePath) ? databasePath : join(getHdbBasePath(), LEGACY_DATABASES_DIR_NAME)));
 	if (!databasePath) return;
-	console.error({ databasePath });
 	if (existsSync(databasePath)) {
 		// First load all the databases from our main database folder
 		// TODO: Load any databases defined with explicit storage paths from the config
@@ -246,7 +245,6 @@ export function getDatabases(): Databases {
 		for (const dbName in schemaConfigs) {
 			const schemaConfig = schemaConfigs[dbName];
 			const databasePath = schemaConfig.path;
-			console.log('specific database path', { dbName, databasePath });
 			if (existsSync(databasePath)) {
 				for (const databaseEntry of readdirSync(databasePath, { withFileTypes: true })) {
 					if (databaseEntry.isFile() && extname(databaseEntry.name).toLowerCase() === '.mdb') {

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -184,7 +184,7 @@ export function getDatabases(): Databases {
 		getConfigPath(CONFIG_PARAMS.STORAGE_PATH) ||
 		(databasePath && (existsSync(databasePath) ? databasePath : join(getHdbBasePath(), LEGACY_DATABASES_DIR_NAME)));
 	if (!databasePath) return;
-
+	console.error({ databasePath });
 	if (existsSync(databasePath)) {
 		// First load all the databases from our main database folder
 		// TODO: Load any databases defined with explicit storage paths from the config
@@ -246,6 +246,7 @@ export function getDatabases(): Databases {
 		for (const dbName in schemaConfigs) {
 			const schemaConfig = schemaConfigs[dbName];
 			const databasePath = schemaConfig.path;
+			console.log('specific database path', { dbName, databasePath });
 			if (existsSync(databasePath)) {
 				for (const databaseEntry of readdirSync(databasePath, { withFileTypes: true })) {
 					if (databaseEntry.isFile() && extname(databaseEntry.name).toLowerCase() === '.mdb') {

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -18,6 +18,8 @@ describe('Caching', () => {
 	let timer = 0;
 	let return_value = true;
 	let return_error;
+	// skip LMDB test for now
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
 	before(async function () {
 		setupTestDBPath();
 		setMainIsWorker(true); // TODO: Should be default until changed

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -18,7 +18,7 @@ describe('Caching', () => {
 	let timer = 0;
 	let return_value = true;
 	let return_error;
-	// skip LMDB test for now
+	// skip LMDB test for now, https://github.com/HarperFast/harper/issues/414 for re-enabling
 	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
 	before(async function () {
 		setupTestDBPath();

--- a/unitTests/testUtils.js
+++ b/unitTests/testUtils.js
@@ -20,7 +20,8 @@ const MOCK_ARGS_ERROR_MSG =
 const UNIT_TEST_DIR = __dirname;
 const ENV_DIR_NAME = 'envDir';
 const ENV_DIR_PATH = path.join(UNIT_TEST_DIR, ENV_DIR_NAME);
-const BASE_SCHEMA_PATH = path.join(ENV_DIR_PATH, 'schema');
+const PID_DIR_PATH = path.join(ENV_DIR_PATH, process.pid.toString());
+const BASE_SCHEMA_PATH = path.join(PID_DIR_PATH, 'schema');
 const BASE_SYSTEM_PATH = path.join(BASE_SCHEMA_PATH, 'system');
 
 /**
@@ -202,7 +203,7 @@ async function tearDownMockDB(envs = undefined, partial_teardown = false) {
 
 		delete global.hdb_schema;
 		global.lmdb_map = undefined;
-		if (!partial_teardown) await fs.remove(ENV_DIR_PATH);
+		if (!partial_teardown) await fs.remove(PID_DIR_PATH);
 	} catch (err) {
 		console.error('Error tearing down mock DB used for unit tests');
 		console.error(err);
@@ -352,9 +353,8 @@ function setTestPath(testPath) {
  * @returns {string}
  */
 function getMockTestPath() {
-	const testPath = path.join(UNIT_TEST_DIR, ENV_DIR_NAME, process.pid.toString());
-	setTestPath(testPath);
-	return testPath;
+	setTestPath(PID_DIR_PATH);
+	return PID_DIR_PATH;
 }
 
 /**
@@ -362,7 +362,7 @@ function getMockTestPath() {
  * @returns String representing the path value to the mock lmdb system directory
  */
 function setupTestDBPath() {
-	let dbPath = path.join(UNIT_TEST_DIR, ENV_DIR_NAME, process.pid.toString());
+	let dbPath = PID_DIR_PATH;
 	if (!fs.existsSync(dbPath)) {
 		fs.mkdirSync(dbPath, { recursive: true });
 	}

--- a/unitTests/testUtils.js
+++ b/unitTests/testUtils.js
@@ -10,7 +10,7 @@ const { table: ensure_table, resetDatabases } = require('#src/resources/database
 const terms = require('#src/utility/hdbTerms');
 const harperBridge = require('#js/dataLayer/harperBridge/harperBridge');
 const { isMainThread } = require('node:worker_threads');
-const { getDatabases } = require('#src/resources/databases');
+const { getDatabases, databases } = require('#src/resources/databases');
 const { handleHDBError } = require('#js/utility/errors/hdbError');
 
 let envMgrInitSyncStub;
@@ -367,12 +367,18 @@ function setupTestDBPath() {
 		fs.mkdirSync(dbPath, { recursive: true });
 	}
 	env.setProperty(terms.HDB_SETTINGS_NAMES.HDB_ROOT_KEY, dbPath);
-	env.setProperty(terms.CONFIG_PARAMS.DATABASES, {
+	const databasePaths = {
 		data: { path: dbPath },
 		dev: { path: dbPath },
 		test: { path: dbPath },
 		test2: { path: dbPath },
-	});
+	};
+	const systemPath = databases.system?.hdb_user?.primaryStore?.path;
+	if (systemPath) {
+		// do NOT change an existing system path, really confuses the system
+		databasePaths.system = { path: path.dirname(systemPath) };
+	}
+	env.setProperty(terms.CONFIG_PARAMS.DATABASES, databasePaths);
 	resetDatabases();
 	if (isMainThread) {
 		process.on('exit', function () {

--- a/unitTests/testUtils.js
+++ b/unitTests/testUtils.js
@@ -345,6 +345,10 @@ function setTestPath(testPath) {
 	env.setProperty(terms.HDB_SETTINGS_NAMES.HDB_ROOT_KEY, testPath);
 	env.setProperty(terms.CONFIG_PARAMS.STORAGE_PATH, path.join(testPath, 'database'));
 	fs.mkdirpSync(testPath);
+	const systemPath = databases.system?.hdb_user?.primaryStore?.path;
+	if (systemPath) {
+		env.setProperty(terms.CONFIG_PARAMS.DATABASES, { system: { path: path.dirname(systemPath) } });
+	}
 	fs.writeFileSync(path.join(testPath, 'harperdb-config.yaml'), JSON.stringify({}));
 }
 

--- a/utility/environment/environmentManager.js
+++ b/utility/environment/environmentManager.js
@@ -152,16 +152,22 @@ function initTestEnvironment(testConfigObj = {}) {
 		// __dirname is dist/utility/environment when running tests, so go up 3 levels to reach project root
 		const propsPath = path.join(__dirname, '../../../', 'unitTests');
 		installProps[BOOT_PROPS_FILE_PATH] = path.join(propsPath, 'hdb_boot_properties.file');
+		const TEST_HDB_PATH = path.join(propsPath, 'envDir', process.pid.toString());
 		try {
-			mkdirSync(path.join(propsPath, 'envDir'));
+			mkdirSync(TEST_HDB_PATH, { recursive: true });
 		} catch {}
 		setProperty(hdbTerms.HDB_SETTINGS_NAMES.SETTINGS_PATH_KEY, path.join(propsPath, 'settings.test'));
 		setProperty(hdbTerms.HDB_SETTINGS_NAMES.INSTALL_USER, os.userInfo() ? os.userInfo().username : undefined);
 		setProperty(hdbTerms.HDB_SETTINGS_NAMES.LOG_LEVEL_KEY, `debug`);
-		setProperty(hdbTerms.HDB_SETTINGS_NAMES.LOG_PATH_KEY, path.join(propsPath, 'envDir', 'log'));
+		setProperty(hdbTerms.HDB_SETTINGS_NAMES.LOG_PATH_KEY, path.join(TEST_HDB_PATH, 'log'));
 		setProperty(hdbTerms.HDB_SETTINGS_NAMES.LOG_DAILY_ROTATE_KEY, false);
-		setProperty(hdbTerms.HDB_SETTINGS_NAMES.HDB_ROOT_KEY, path.join(propsPath, 'envDir'));
-		setProperty(hdbTerms.CONFIG_PARAMS.STORAGE_PATH, path.join(propsPath, 'envDir'));
+		setProperty(hdbTerms.HDB_SETTINGS_NAMES.HDB_ROOT_KEY, TEST_HDB_PATH);
+		setProperty(hdbTerms.CONFIG_PARAMS.STORAGE_PATH, TEST_HDB_PATH);
+		const systemPath = typeof databases !== 'undefined' && databases.system?.hdb_user?.primaryStore?.path;
+		if (systemPath) {
+			setProperty(hdbTerms.CONFIG_PARAMS.DATABASES, { system: { path: path.dirname(systemPath) } });
+		}
+
 		if (https_enabled) {
 			setProperty(hdbTerms.CONFIG_PARAMS.HTTP_SECUREPORT, get(hdbTerms.CONFIG_PARAMS.HTTP_PORT));
 			setProperty(hdbTerms.CONFIG_PARAMS.HTTP_PORT, null);


### PR DESCRIPTION
Previously the unit tests were spamming the logs with errors about being unable to find the primary key due to the system database changing paths mid-stream, resulting in out-of-sync system tables.

All test helpers now resolve test dbs to the same `unitTests/envDir/<pid>/` directory, preventing system database path conflicts when tests switch between the fixed envDir/schema path and the PID-scoped path. Teardown now removes only the PID directory, so concurrent test runs don't interfere with each other.

The system database path is protected.