### PR TITLE
Remove undefined logger variable

### DIFF
--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -63,7 +63,7 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 		this.#pluginName = pluginName;
 		this.#directory = directory;
 		this.#configFilePath = configFilePath;
-		this.#logger = logger || loggerWithTag(this.#appName);
+		this.#logger = loggerWithTag(this.#appName);
 
 		this.databaseEvents = databaseEventsEmitter;
 		this.applicationScope = applicationScope;


### PR DESCRIPTION
I noticed this warning in the CI logs:
```
Error: components/Scope.ts(66,18): error TS2663: Cannot find name 'logger'. Did you mean the instance member 'this.logger'?
```

It seems the `logger ||` was erroneously introduced by this sync: https://github.com/HarperFast/harper/pull/232/changes#diff-3ad922b5eb54262456b7e046c62a2a69bfaa4e377953ba616fea6e4a8258d24fR66. This `logger` ref does exist in `harperdb`, but looks to be removed during the big lift.