### PR TITLE
Upgrade rocksdb-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
 		"@fastify/cors": "^11.2.0",
 		"@fastify/static": "^9.0.0",
 		"@harperfast/extended-iterable": "^1.0.1",
-		"@harperfast/rocksdb-js": "^1.0.1",
+		"@harperfast/rocksdb-js": "^1.1.0",
 		"@turf/area": "6.5.0",
 		"@turf/boolean-contains": "6.5.0",
 		"@turf/boolean-disjoint": "6.5.0",


### PR DESCRIPTION
Kind of a bizarre PR: package-lock.json is already on rocks 1.10.0. And we are upgrading package.json to match. Because merging package locks is [my favorite thing](https://github.com/HarperFast/harper/pull/422) (humans were not meant for this).