### PR TITLE
Fix relative require resolution for symlinked modules

### DIFF
--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -181,7 +181,13 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 		if (parts[0] === 'file:') {
 			return specifier;
 		}
-		const resolved = createRequire(referrer).resolve(specifier);
+		let resolveReferrer = referrer;
+		if (referrer.startsWith('file:')) {
+			try {
+				resolveReferrer = pathToFileURL(realpathSync(fileURLToPath(referrer))).toString();
+			} catch {}
+		}
+		const resolved = createRequire(resolveReferrer).resolve(specifier);
 		if (isAbsolute(resolved)) {
 			return pathToFileURL(resolved).toString();
 		}
@@ -206,7 +212,13 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 			cjsModule.exports = parseJsonModule(source, url);
 			return cjsModule;
 		}
-		const require = createRequire(url);
+		let requireUrl = url;
+		if (url.startsWith('file://')) {
+			try {
+				requireUrl = pathToFileURL(realpathSync(fileURLToPath(url))).toString();
+			} catch {}
+		}
+		const require = createRequire(requireUrl);
 
 		const cjsRequire = (spec: string) => {
 			const resolvedPath = require.resolve(spec);

--- a/unitTests/security/jsLoader/fixtures/symlink-test/harper-modules/cache.cjs
+++ b/unitTests/security/jsLoader/fixtures/symlink-test/harper-modules/cache.cjs
@@ -1,0 +1,1 @@
+module.exports = { value: 'hit' };

--- a/unitTests/security/jsLoader/fixtures/symlink-test/harper-modules/cache.mjs
+++ b/unitTests/security/jsLoader/fixtures/symlink-test/harper-modules/cache.mjs
@@ -1,0 +1,1 @@
+export default { value: 'hit' };

--- a/unitTests/security/jsLoader/fixtures/symlink-test/harper-modules/proxy-transform-module/index.cjs
+++ b/unitTests/security/jsLoader/fixtures/symlink-test/harper-modules/proxy-transform-module/index.cjs
@@ -1,0 +1,2 @@
+const cache = require('../cache.cjs');
+module.exports = { cached: cache.value };

--- a/unitTests/security/jsLoader/fixtures/symlink-test/harper-modules/proxy-transform-module/index.mjs
+++ b/unitTests/security/jsLoader/fixtures/symlink-test/harper-modules/proxy-transform-module/index.mjs
@@ -1,0 +1,2 @@
+import cache from '../cache.mjs';
+export const cached = cache.value;

--- a/unitTests/security/jsLoader/fixtures/symlink-test/node_modules/proxyTransform
+++ b/unitTests/security/jsLoader/fixtures/symlink-test/node_modules/proxyTransform
@@ -1,0 +1,1 @@
+../harper-modules/proxy-transform-module

--- a/unitTests/security/jsLoader/jsLoader.test.js
+++ b/unitTests/security/jsLoader/jsLoader.test.js
@@ -4,6 +4,10 @@ const { join } = require('node:path');
 const { scopedImport } = require('#src/security/jsLoader');
 const { expect } = require('chai');
 
+const SYMLINK_FIXTURE = join(__dirname, 'fixtures', 'symlink-test', 'node_modules', 'proxyTransform');
+// Minimal scope that routes through the VM loader without requiring a full Harper server context
+const vmScope = () => ({ mode: 'vm-current-context' });
+
 describe('scopedImport', () => {
 	it('should import a module', async () => {
 		const result = await scopedImport(join(__dirname, 'fixtures', 'good.cjs'));
@@ -58,5 +62,21 @@ describe('scopedImport', () => {
 				/libbad\.mjs:1\nexport const baz ====\n +\^\^\^\n+SyntaxError: Missing initializer in const declaration/
 			);
 		}
+	});
+});
+
+describe('symlinked module resolution', () => {
+	it('should resolve relative CJS require through a symlinked module', async () => {
+		// proxyTransform is a symlink to ../harper-modules/proxy-transform-module
+		// index.cjs does require('../cache.cjs') which must resolve via the real path,
+		// not the symlink path (node_modules/proxyTransform/../cache.cjs would not exist)
+		const result = await scopedImport(join(SYMLINK_FIXTURE, 'index.cjs'), vmScope());
+		expect(result.default.cached).to.equal('hit');
+	});
+
+	it('should resolve relative ESM import through a symlinked module', async () => {
+		// Same scenario for ESM: import cache from '../cache.mjs' must resolve via realpath
+		const result = await scopedImport(join(SYMLINK_FIXTURE, 'index.mjs'), vmScope());
+		expect(result.cached).to.equal('hit');
 	});
 });


### PR DESCRIPTION
## Summary

- When a module is loaded via a symlink (e.g. `node_modules/proxyTransform -> ../harper-modules/proxy-transform-module`), relative requires like `../cache.js` were resolved relative to the **symlink path** rather than the **real path**, causing `Cannot find module` errors.
- Fixed by calling `realpathSync` on the referrer in `resolveModule` (ESM/VM linker) and on the URL in `loadCJS` (CJS `require`) before passing to `createRequire`.

## Test plan

- [ ] Load a component that uses a symlinked `harper-modules` entry point with relative requires to sibling files (e.g. `proxyTransform` requiring `../cache.js`)
- [ ] Verify the module loads without `Cannot find module` errors
- [ ] Verify non-symlinked modules still resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)