### PR TITLE
Fix require('harperdb') in CJS modules loaded via VM

### DIFF
--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -209,15 +209,21 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 		const require = createRequire(url);
 
 		const cjsRequire = (spec: string) => {
-			const resolvedPath = require.resolve(spec);
-			if (isAbsolute(resolvedPath)) {
-				const source = readFileSync(resolvedPath, { encoding: 'utf-8' });
-				return loadCJS(resolvedPath, source).exports;
-			} else {
-				return require(spec);
+			const resolvedUrl = resolveModule(spec, url);
+			if (resolvedUrl === 'harper') {
+				return getHarperExports(scope);
 			}
+			if (resolvedUrl.startsWith('file://')) {
+				const source = readFileSync(new URL(resolvedUrl), { encoding: 'utf-8' });
+				return loadCJS(resolvedUrl, source).exports;
+			}
+			return require(resolvedUrl);
 		};
-		cjsRequire.resolve = require.resolve;
+		cjsRequire.resolve = (spec: string) => {
+			const resolvedUrl = resolveModule(spec, url);
+			if (resolvedUrl.startsWith('file://')) return fileURLToPath(resolvedUrl);
+			return resolvedUrl;
+		};
 
 		const cjsWrapper = `
 			(function(module, exports, require, __filename, __dirname) {

--- a/unitTests/security/jsLoader/fixtures/uses-harperdb.cjs
+++ b/unitTests/security/jsLoader/fixtures/uses-harperdb.cjs
@@ -1,0 +1,2 @@
+const harper = require('harperdb');
+module.exports = harper;

--- a/unitTests/security/jsLoader/jsLoader.test.js
+++ b/unitTests/security/jsLoader/jsLoader.test.js
@@ -48,6 +48,21 @@ describe('scopedImport', () => {
 		}
 	});
 
+	it('should resolve require("harperdb") to harper exports', async () => {
+		const scope = {
+			mode: 'vm-current-context',
+			allowedPath: '',
+			moduleCache: null,
+			server: { authenticateUser: null, operation: null },
+			logger: {},
+			resources: {},
+			config: {},
+		};
+		const result = await scopedImport(join(__dirname, 'fixtures', 'uses-harperdb.cjs'), scope);
+		expect(result.Resource).to.be.a('function');
+		expect(result.tables).to.exist;
+	});
+
 	it('should throw an error importing an ESM module with invalid dependency', async () => {
 		try {
 			await scopedImport(join(__dirname, 'fixtures', 'invalid4.mjs'));


### PR DESCRIPTION
## Summary
- `cjsRequire` was calling `require.resolve()` directly, bypassing `resolveModule()`, so `HARPER_MODULE_IDS` like `'harperdb'` threw `MODULE_NOT_FOUND` instead of resolving to the harper synthetic module
- Updated `cjsRequire` to call `resolveModule()` first and return `getHarperExports(scope)` when the result is `'harper'`
- Also updated `cjsRequire.resolve` to go through `resolveModule()` for consistency

## Test plan
- [ ] New fixture `uses-harperdb.cjs` that calls `require('harperdb')` and exports the result
- [ ] New test in `jsLoader.test.js`: verifies `require('harperdb')` resolves to harper exports (`Resource`, `tables`) when loaded via VM scope
- [ ] Run `npm run test:unit:security` — all `scopedImport` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)