### PR TITLE
Wrap source-resolved records in RecordObject with entryMap registration

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,20 @@
+# DESIGN.md
+
+Design notes and non-obvious internals for the harper-pro/core codebase. Complements AGENTS.md (architecture overview) and CONTRIBUTING.md. Grows incrementally as agents encounter non-obvious things.
+
+---
+
+## RecordObject prototype and entryMap
+
+Records stored in tables are plain objects given a `RecordObject` prototype, which provides `getExpiresAt()` and `getUpdatedTime()`. These methods read from `entryMap` (a `WeakMap` in `RecordEncoder.ts`), which maps each record object to its storage entry.
+
+- The prototype is set automatically by the msgpack decoder via `structPrototype` (per-table, defined inside `RecordEncoder`).
+- `entryMap.set(record, entry)` is called whenever a record is read from the store.
+- To give a plain JS object the RecordObject prototype without copying it (preserving mutability), use `Object.setPrototypeOf(obj, primaryStore.encoder.structPrototype)` then `entryMap.set(obj, entry)`.
+- Do **not** copy the object (e.g. via `Object.assign` into a new instance) if any code still holds a reference to the original and expects to mutate it — see below.
+
+## getFromSource() timing: promise resolves before commit runs
+
+In `getFromSource()` (`Table.ts`), the promise that callers await resolves with the entry **before** the `dbTxn.addWrite` commit callback runs. The commit callback mutates `updatedRecord` in-place to set fields like `createdAt` and `updatedAt`. Since the resolved entry's `.value` is the same reference as `updatedRecord`, those mutations are visible to the caller after resolution.
+
+Consequence: never replace `entry.value` with a copy of `updatedRecord` in this path — the copy won't receive the commit callback's mutations.

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -4090,6 +4090,11 @@ export function makeTable(options) {
 							version,
 							value: updatedRecord,
 							expiresAt: sourceContext.expiresAt,
+							metadataFlags: 0,
+							size: 0,
+							localTime: 0,
+							nodeId: 0,
+							residencyId: 0,
 						};
 						// Give the plain object the RecordObject prototype so getExpiresAt/getUpdatedTime
 						// are available on the immediately-resolved entry. We mutate the prototype
@@ -4097,8 +4102,6 @@ export function makeTable(options) {
 						// createdAt/updatedAt to updatedRecord) is still reflected in the entry value.
 						if (updatedRecord && updatedRecord.constructor === Object) {
 							Object.setPrototypeOf(updatedRecord, primaryStore.encoder.structPrototype);
-							resolvedEntry.metadataFlags ??= 0;
-							resolvedEntry.size ??= 0;
 							entryMap.set(updatedRecord, resolvedEntry);
 						}
 						resolve(resolvedEntry);

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -4091,17 +4091,15 @@ export function makeTable(options) {
 							value: updatedRecord,
 							expiresAt: sourceContext.expiresAt,
 						};
-						// Convert plain object to RecordObject so that getExpiresAt/getUpdatedTime
-						// methods are available on the immediately-resolved entry before it is written
-						// to and re-read from the store with proper deserialization.
+						// Give the plain object the RecordObject prototype so getExpiresAt/getUpdatedTime
+						// are available on the immediately-resolved entry. We mutate the prototype
+						// in-place rather than copying so that the commit callback (which adds
+						// createdAt/updatedAt to updatedRecord) is still reflected in the entry value.
 						if (updatedRecord && updatedRecord.constructor === Object) {
-							const recordObject = new primaryStore.encoder.structPrototype.constructor();
-							Object.assign(recordObject, updatedRecord);
-							Object.freeze(recordObject);
-							resolvedEntry.value = recordObject;
+							Object.setPrototypeOf(updatedRecord, primaryStore.encoder.structPrototype);
 							resolvedEntry.metadataFlags ??= 0;
 							resolvedEntry.size ??= 0;
-							entryMap.set(recordObject, resolvedEntry);
+							entryMap.set(updatedRecord, resolvedEntry);
 						}
 						resolve(resolvedEntry);
 					} catch (error) {

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -4085,11 +4085,25 @@ export function makeTable(options) {
 							if (primaryKey && updatedRecord[primaryKey] !== id) updatedRecord[primaryKey] = id;
 						}
 						resolved = true;
-						resolve({
+						const resolvedEntry: Entry = {
 							key: id,
 							version,
 							value: updatedRecord,
-						});
+							expiresAt: sourceContext.expiresAt,
+						};
+						// Convert plain object to RecordObject so that getExpiresAt/getUpdatedTime
+						// methods are available on the immediately-resolved entry before it is written
+						// to and re-read from the store with proper deserialization.
+						if (updatedRecord && updatedRecord.constructor === Object) {
+							const recordObject = new primaryStore.encoder.structPrototype.constructor();
+							Object.assign(recordObject, updatedRecord);
+							Object.freeze(recordObject);
+							resolvedEntry.value = recordObject;
+							resolvedEntry.metadataFlags ??= 0;
+							resolvedEntry.size ??= 0;
+							entryMap.set(recordObject, resolvedEntry);
+						}
+						resolve(resolvedEntry);
 					} catch (error) {
 						error.message += ` while resolving record ${id} for ${tableName}`;
 						if (

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -336,9 +336,8 @@ describe('Caching', () => {
 		assert.equal(sourceRequests, 1);
 		assert.equal(events.length, 0);
 		result = await IndexedCachingTable.get(23);
-		// TODO: This should always be there, per https://github.com/HarperFast/harper/issues/239
 		await delay(10); // give the lock a chance to be released
-		//assert(result.getExpiresAt());
+		assert(result.getExpiresAt());
 		result = IndexedCachingTable.primaryStore.getEntry(23);
 		await IndexedCachingTable.evict(23, result, result.version);
 		await delay(10);


### PR DESCRIPTION
## Summary

- When `Table.get(id)` resolved a record from an external source (`sourcedFrom`), the plain JS object from the source was returned directly without being converted to a `RecordObject`
- This meant the record lacked `getExpiresAt()` and `getUpdatedTime()` methods and wasn't registered in `entryMap` (which those methods rely on)
- Fix uses `Object.setPrototypeOf(updatedRecord, primaryStore.encoder.structPrototype)` to give the plain object the RecordObject prototype in-place, then registers it in `entryMap` with the resolved entry (including `expiresAt`)
- The record is intentionally **not** frozen: the `commit` callback in `addWrite` mutates `updatedRecord` in-place after resolution to set `createdAt`/`updatedAt`, so the entry value must remain mutable

Closes #239

## Changes

**`resources/Table.ts`** — In `getFromSource()`, after resolving the entry from source, set the RecordObject prototype on the plain object in-place via `Object.setPrototypeOf` and register it in `entryMap`. Include `expiresAt` and zero-valued defaults for all required `Entry` fields in the resolved entry.

**`unitTests/resources/caching.test.js`** — Uncomment the previously-disabled `assert(result.getExpiresAt())` assertion in "Can load cached indexed data" that tracked this issue.

**`DESIGN.md`** — New file documenting the RecordObject/entryMap pattern and the `getFromSource()` timing invariant (promise resolves before commit callback runs).

## Areas of attention

- `Object.setPrototypeOf` mutates the source-returned object rather than copying it — necessary to preserve the commit callback's mutations, but means the caller receives a prototype-modified version of whatever the source returned
- The zero defaults for `localTime`, `nodeId`, `residencyId` on the resolved entry are placeholders; these fields are only meaningful after the record is written to and re-read from the store

## Test results

12 tests passing, 0 failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)