### PR TITLE
fix: watch dotfile parent directories in static file watcher

### DIFF
--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -190,6 +190,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 				cwd: this.#component.directory,
 				persistent: false,
 				followSymlinks: false,
+				dot: true,
 				ignored: (path) => {
 					const normalizedPath = path.replace(/\\/g, '/');
 					const normalizedBases = allowedBases.map((base) => base.replace(/\\/g, '/'));


### PR DESCRIPTION
## Summary

- Add `dot: true` to chokidar options in `EntryHandler.ts`
- Without this, chokidar silently skips traversing parent directories that start with a dot (e.g. `.claude/worktrees/`), so the static extension's file map is never populated and every static request returns 404

## Purpose

Fixes #196 — `harper dev` fails to serve static files when the app path contains a dotfile directory (e.g. git worktrees under `.claude/worktrees/`, a common Claude Code pattern). Other extensions were unaffected because they don't rely on chokidar for their initial file discovery.

## Test plan

- [ ] Run `harper dev .` from a path containing a dotfile directory (e.g. `/path/.hidden/my-app/`) with a `static` extension configured
- [ ] Verify static files are served correctly at the configured `urlPath`
- [ ] Verify existing static serving still works from non-dotfile paths
- [ ] Verify dotfiles within the watched directory are still excluded (the custom `ignored` function handles exclusions, `dot: true` only affects parent-path traversal)

## Attention

The change is minimal (one line). The main question is whether `dot: true` has any unintended side effects — specifically, whether it could cause the watcher to pick up dotfiles within the `files` glob that should remain ignored. The custom `ignored` function already correctly gates on `allowedBases`, so only paths matching the configured `files` pattern will be watched regardless of `dot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)