### PR TITLE
fix: handle scalar root config values in OptionsWatcher

### DIFF
--- a/components/OptionsWatcher.ts
+++ b/components/OptionsWatcher.ts
@@ -178,7 +178,9 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 		// First, ensure current and new config values are Config objects (not null, undefined, or a primitive)
 		if (!this.#isConfig(currentConfigValue) || !this.#isConfig(newConfigValue)) {
 			// If either is not a config, then just set as there is no need to diff/merge
-			this.#setValue(prevKeys, newConfigValue);
+			if (!isDeepStrictEqual(currentConfigValue, newConfigValue)) {
+				this.#setValue(prevKeys, newConfigValue);
+			}
 			return;
 		}
 
@@ -254,6 +256,12 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 
 		if (!['object', 'string', 'array', 'number', 'boolean', 'undefined'].includes(typeof value)) {
 			throw new InvalidValueTypeError(keys, value);
+		}
+
+		if (keys.length === 0) {
+			this.#scopedConfig = value;
+			this.emit('change', keys, value, this.#scopedConfig);
+			return;
 		}
 
 		let obj: ConfigValue = this.#scopedConfig;

--- a/unitTests/components/OptionsWatcher.test.js
+++ b/unitTests/components/OptionsWatcher.test.js
@@ -534,6 +534,66 @@ describe('OptionsWatcher', () => {
 			));
 	});
 
+	describe('change event when root config value is a scalar', () => {
+		it('should handle updating from scalar to scalar without throwing', async () => {
+			const { fixture, configFilePath } = createFixture({ [NAME]: 'initialString' });
+			const options = new OptionsWatcher(NAME, configFilePath);
+			await options.ready;
+
+			const newValue = 'updatedString';
+			await assertEvent(
+				options,
+				'change',
+				() => writeFile(configFilePath, stringify({ [NAME]: newValue }), 'utf-8'),
+				(changeSpy) => {
+					assert.equal(changeSpy.callCount, 1);
+					assert.deepEqual(changeSpy.getCall(0).args, [[], newValue, newValue]);
+					assert.equal(options.getAll(), newValue);
+				}
+			);
+
+			await teardown({ fixture, options });
+		});
+
+		it('should handle updating from scalar to object without throwing', async () => {
+			const { fixture, configFilePath } = createFixture({ [NAME]: 'initialString' });
+			const options = new OptionsWatcher(NAME, configFilePath);
+			await options.ready;
+
+			const newValue = { foo: 'bar' };
+			await assertEvent(
+				options,
+				'change',
+				() => writeFile(configFilePath, stringify({ [NAME]: newValue }), 'utf-8'),
+				(changeSpy) => {
+					assert.equal(changeSpy.callCount, 1);
+					assert.deepEqual(changeSpy.getCall(0).args, [[], newValue, newValue]);
+					assert.deepEqual(options.getAll(), newValue);
+				}
+			);
+
+			await teardown({ fixture, options });
+		});
+
+		it('should handle updating from object to scalar without throwing', async () => {
+			const { fixture, configFilePath, options } = await setup();
+
+			const newValue = 'scalar';
+			await assertEvent(
+				options,
+				'change',
+				() => writeFile(configFilePath, stringify({ [NAME]: newValue }), 'utf-8'),
+				(changeSpy) => {
+					assert.equal(changeSpy.callCount, 1);
+					assert.deepEqual(changeSpy.getCall(0).args, [[], newValue, newValue]);
+					assert.equal(options.getAll(), newValue);
+				}
+			);
+
+			await teardown({ fixture, options });
+		});
+	});
+
 	it('should handle default config resolution', async () => {
 		this.timeout = 3000;
 		const { fixture, configFilePath } = createFixture();


### PR DESCRIPTION
## Summary

- `OptionsWatcher` threw `CannotSetPropertyError` whenever a plugin's YAML config value was a scalar (string, number, boolean) at the root level and the config file changed
- Fixed `#setValue` to handle `keys=[]` (root replacement) by directly assigning `#scopedConfig` instead of trying to index into it as a parent object
- Added `isDeepStrictEqual` guard in `#merge`'s non-Config shortcut path to prevent spurious `change` events when the chokidar `ready` event re-reads an unchanged scalar

## Root Cause

Two issues combined:
1. `#merge` short-circuits at the top level when either value is not a `Config` object, calling `#setValue([], newValue)`. `#setValue` had no handling for an empty key array — it traversed nothing, then checked `typeof obj !== 'object'` on the scalar `#scopedConfig` itself, throwing `CannotSetPropertyError` with a blank property name.
2. Without the equality guard, any file-watch re-read of a scalar config would also trigger a spurious `change` event.

## Test Plan

- [x] 3 new regression tests added: scalar→scalar, scalar→object, object→scalar
- [x] All 23 unit tests passing (`npx mocha unitTests/components/OptionsWatcher.test.js`)
- [x] Cross-model review (Gemini) confirmed fix is correct and edge cases are covered
- [x] Format and lint clean on changed files

## Attention

- The `keys=[]` path in `#setValue` is new behavior — callers that pass empty keys now get root-level replacement with a `change` event emitting `([], value, value)`. Listeners expecting a non-empty key path for all changes should be verified if they handle this case.
- Object→scalar transitions now emit a single `change([], scalar)` instead of per-key `undefined` events for the old object's keys. This is consistent with how type changes (e.g., array↔object) already worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)