### PR TITLE
fix: prevent uncaughtException when timer force-closes a pooled LMDB read transaction

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -504,8 +504,8 @@ setInterval(() => {
 						txn.openTimer = 0;
 						try {
 							txn.done();
-						} catch {
-							// transaction was already released; stale WeakRef from a lmdb pool renewal cycle
+						} catch (error) {
+							harperLogger.warn('Unexpected error force-closing stale LMDB read transaction', error);
 						}
 					} else
 						harperLogger.error(

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -470,6 +470,7 @@ export function handleLocalTimeForGets(store, rootStore) {
 			};
 			Txn.prototype.done = function () {
 				done.call(this);
+				this.openTimer = 0; // reset so idle pool time doesn't accumulate toward the stale-open threshold
 				if (this.isDone) {
 					for (let i = 0; i < trackedTxns.length; i++) {
 						const txn = trackedTxns[i].deref();
@@ -498,7 +499,14 @@ setInterval(() => {
 							'Read transaction detected that has been open too long (over 15 minutes), ending transaction',
 							txn
 						);
-						txn.done();
+						trackedTxns.splice(i--, 1);
+						txn.timerTracked = false;
+						txn.openTimer = 0;
+						try {
+							txn.done();
+						} catch {
+							// transaction was already released; stale WeakRef from a lmdb pool renewal cycle
+						}
 					} else
 						harperLogger.error(
 							'Read transaction detected that has been open too long (over one minute), make sure read transactions are quickly closed',


### PR DESCRIPTION
## Summary

- lmdb recycles `Txn` objects between use/done cycles. After a normal `done()`, the Txn returns to the pool with `isDone` unset, leaving a stale `WeakRef` in RecordEncoder's `trackedTxns` array.
- The 15-second stale-transaction timer accumulated `openTimer` on these idle pooled transactions (which have `notCurrent: true`) and eventually called `txn.done()` on an already-finished transaction, crashing the process with an `uncaughtException: "Can not finish a transaction more times than it was used"`.
- The smoking gun in the error output: `refCount: -5792` (the transaction object has been recycled through thousands of use/done cycles) and `openTimer: 61` (15 minutes × 4 ticks/min).

## Changes

1. **`Txn.prototype.done` patch** — reset `openTimer = 0` so idle pool time doesn't accumulate toward the 15-minute stale threshold across use/done renewal cycles.
2. **Timer force-close** — splice from `trackedTxns` and reset `timerTracked = false` before calling `done()`, then wrap in `try/catch`. This ensures cleanup happens regardless and the `uncaughtException` cannot occur.

## Attention / lower-confidence areas

- **`notCurrent` semantics**: The detection logic fires on `txn.notCurrent`, which is true for both actively-open-but-stale and idle-pooled transactions. A cross-model review (Gemini) suggested flipping the condition to `!notCurrent`, but that would break detection of genuinely stuck transactions — `notCurrent` means the snapshot is stale (new writes occurred), not that the transaction is finished. The `openTimer` reset in `done()` is the correct way to prevent pool-idle time from triggering false positives.
- **`openTimer++` still runs after force-close**: After the splice, `txn.openTimer++` at line 516 still executes on the local variable. Since `txn.openTimer = 0` is set first, it becomes 1. This is safe — if the txn is renewed via `use()`, it re-enters tracking fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)