### PR TITLE
fix: guard against undefined events in subscription handler

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -364,6 +364,10 @@ export function makeTable(options) {
 						// we listen for events by iterating through the async iterator provided by the subscription
 						for await (const event of subscription) {
 							try {
+								if (!event || typeof event !== 'object') {
+									logger.error?.('Bad subscription event', event);
+									continue;
+								}
 								const firstWrite = event.type === 'transaction' ? event.writes[0] : event;
 								if (!firstWrite) {
 									logger.error?.('Bad subscription event', event);

--- a/server/DurableSubscriptionsSession.ts
+++ b/server/DurableSubscriptionsSession.ts
@@ -257,6 +257,7 @@ class SubscriptionsSession {
 			const _result = (async () => {
 				for await (const update of subscription) {
 					try {
+						if (!update || typeof update !== 'object') continue;
 						let messageId;
 						if (
 							update.type &&


### PR DESCRIPTION
## Summary
- Added `!event || typeof event !== 'object'` guard in `resources/Table.ts` subscription loop to prevent `TypeError` when the async iterator yields `undefined`
- Applied the same guard in `server/DurableSubscriptionsSession.ts` for consistency

## Purpose
Fixes a crash (`TypeError: Cannot read properties of undefined (reading 'type')`) in the subscription handler at `Table.ts:367`. The subscription async iterator was occasionally yielding `undefined`, which crashed the handler and broke the subscription.

## Attention
- The `typeof event !== 'object'` check (beyond `!event`) guards against truthy primitives that would otherwise crash at the `event.source = source` assignment — suggested by cross-model review
- `DurableSubscriptionsSession.ts` had the same potential crash; patched for consistency but not yet observed to fail in production
- Both locations use `continue` to keep the subscription alive rather than terminating it on a bad event

🤖 Generated with [Claude Code](https://claude.com/claude-code)