### PR TITLE
ci(claude): tighten override so concise-PR rule beats universal calibration clause

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -265,13 +265,34 @@ jobs:
               `<details>` here — the related ai-review-log issue
               keeps history across runs.
 
-            For "no blockers" runs, a single sentence on the PR is
-            enough (e.g. `Reviewed; no blockers found.`). Don't
-            restate scope, confidence, or what you checked — that's
-            noise on the PR. The next workflow step threads each
-            run's PR comment into a per-PR ai-review-log issue, so
-            cross-run history accumulates there rather than on the
-            PR itself.
+            **For "no blockers" runs, the PR comment is one sentence.**
+            This overrides the universal scope's
+            `summary is welcome during calibration` allowance — Harper
+            has a log surface (the next workflow step threads each
+            run's PR comment into a per-PR `HarperFast/ai-review-log`
+            issue), so the verbose tracing belongs there, not on the
+            PR. Concrete shape:
+
+            ✅ Right shape on the PR:
+
+            ```
+            Reviewed; no blockers found.
+            ```
+
+            ❌ Wrong shape (the recap belongs in the log surface):
+
+            ```
+            No blockers found.
+
+            Two independent fixes:
+            - **<file>:** <one-line rationale for change A>
+            - **<other file>:** <one-line rationale for change B>
+            ```
+
+            The "what I traced" recap — one line per surface verified —
+            still has value for calibration; it just lives in the
+            ai-review-log issue, where reviewers can spot-check the
+            bot's reasoning without paying that cost on every PR.
 
             Only post GitHub comments — do NOT submit review text as SDK
             messages.


### PR DESCRIPTION
## Summary

PR #432's prompt change said "single sentence on the PR for no blockers" — but the upstream universal layer still said a tight calibration summary on the PR was welcome (the `summary is welcome during calibration` clause). Sonnet weighed the earlier, broader clause higher than the later per-repo override, so PR #434's review posted a 6-line "No blockers found" comment with three bullets.

This makes the override explicit:

- Names the universal clause it overrides.
- Adds ✅/❌ examples mirroring the actual #434 comment shape, so the agent has a concrete contrast.
- Reinforces that the calibration tracing has a home: the per-PR `HarperFast/ai-review-log` issue threaded by the next workflow step.

## Paired change

[`HarperFast/ai-review-prompts#6`](https://github.com/HarperFast/ai-review-prompts/pull/6) fixes the same problem at the universal layer (concise on PR; route calibration tracing to the log surface when one is wired). After both land, harper can bump its `ai-review-prompts` ref pin in `claude-review.yml`. The ✅/❌ examples in this override still earn their keep as in-tree documentation of the design choice.

## Why both

Universal-layer change: cleanest place for the rule; benefits every consumer that wires a log surface. Harper-specific override: takes effect before harper re-pins to the new universal-layer SHA, so the next review run on harper picks up the right behavior immediately.

## Test plan

- [ ] Open / push to a PR after this lands → confirm the top-level claude comment is one sentence on a "no blockers" run, with no bullet recap of fixes.
- [ ] The matching `HarperFast/ai-review-log` issue should still receive the body as a threaded comment (preserving calibration spot-checking).
- [ ] Subsequent push on the same PR → confirm the existing claude PR comment is edited in place (carryover from #432).

🤖 Generated with [Claude Code](https://claude.com/claude-code)