### PR TITLE
ci(claude): bump ai-review-prompts pin to pick up concise-PR + within-PR memory

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: HarperFast/ai-review-prompts
-          ref: 752c5da8f1a7746e8202dba8aba4c28bd17d14c4 # main at seed merge
+          ref: 14c79a1c36565c764b68d3641c32bdadfc4d0512 # main 2026-04-30 (incl. concise-PR + within-PR-memory)
           path: .ai-review-prompts
 
       - name: Compose review scope from layers


### PR DESCRIPTION
## Summary

One-line bump of the `ai-review-prompts` ref pin in `claude-review.yml` from `752c5da` (2026-04-23 seed) to `14c79a1` (2026-04-30 main). Picks up two universal-layer changes:

- [`ai-review-prompts#6`](https://github.com/HarperFast/ai-review-prompts/pull/6) — keep PR comments concise; route calibration tracing to the workflow's log surface when one is wired.
- [`ai-review-prompts#7`](https://github.com/HarperFast/ai-review-prompts/pull/7) — read prior PR conversation before reviewing; don't re-raise dismissed findings; mark resolved findings as resolved.

## Why now (no buffer)

Internal HarperFast-owned repo. The buffer discipline (wait several days after release before bumping) applies to **third-party** actions where supply-chain compromise is the threat we're hedging against. Internal config repos that we control on both sides ship without delay.

## How it interacts with existing harper changes

- The concise-PR override in #437 was overriding a stale universal clause; that clause is now fixed at source. The override stays in-tree as documentation of the design choice, but no longer has to fight the layered scope on every run.
- The learnings-to-log channel in #438 is the structured target that the new "read prior conversation" instruction implicitly relies on — read what was learned, capture what was learned, repeat.

## Test plan

- [ ] Push to a PR with prior `claude` activity → confirm the new review reads prior comments / inline threads and doesn't re-raise dismissed findings.
- [ ] Confirm the related `ai-review-log` issue's run-notes block populates with at least the "Surfaces verified" / "Dismissals honored" sections when relevant.
- [ ] PR comment stays strictly concise — single sentence on "no blockers" runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)