### PR TITLE
ci(claude): drop ^ anchor from no-blockers detection regex

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -403,7 +403,11 @@ jobs:
           fi
 
           # Title: count findings (lines starting with `### <digit>`). "No blockers" case has none.
-          if printf '%s' "$CLAUDE_BODY" | grep -qi '^no blockers found'; then
+          # Match the phrase anywhere in the body — the new concise prompt asks for
+          # `Reviewed; no blockers found.`, which doesn't start with "no blockers"
+          # and so wouldn't match an anchored regex. Anywhere-match is safe because
+          # `no blockers found` is a deliberate sentinel phrase from the prompt.
+          if printf '%s' "$CLAUDE_BODY" | grep -qi 'no blockers found'; then
             COUNT_PART="no blockers"
           else
             FINDING_COUNT=$(printf '%s\n' "$CLAUDE_BODY" | grep -c '^### [0-9]' || true)


### PR DESCRIPTION
## Summary

The new concise prompt (PR #437) tells the agent to use `Reviewed; no blockers found.` as the no-blockers PR comment shape. The log step's regex was anchored at start (`grep -qi '^no blockers found'`), so the new wording fell through to the finding-counter path and produced misleading titles like `[harper] PR #436: 0 finding(s) — triage pending` for clean no-blockers runs.

This drops the `^` anchor — `no blockers found` is a deliberate sentinel phrase from the prompt, so anywhere-match is safe.

## Observed on

`HarperFast/ai-review-log#87` (the log issue for harper PR #436's first review run) — caught during the post-consolidation cleanup pass.

## Test plan

- [ ] Open or push to a PR after this lands → confirm a no-blockers run produces a log issue titled `[harper] PR #N: no blockers` (not `0 finding(s) — triage pending`).
- [ ] Confirm finding runs still title correctly (`N finding(s) — triage pending`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)