### PR TITLE
fix: prevent LMDBTransaction leak in evict() causing repeated transaction errors

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1426,7 +1426,8 @@ export function makeTable(options) {
 		 */
 		static evict(id, existingRecord, existingVersion) {
 			let entry;
-			let transaction = txnForContext({ transaction: new DatabaseTransaction() }).getReadTxn();
+			const lmdbTransaction = txnForContext({ transaction: new DatabaseTransaction() });
+			let transaction = lmdbTransaction.getReadTxn();
 			let options = { transaction };
 			try {
 				if (hasSourceGet || audit) {
@@ -1453,7 +1454,7 @@ export function makeTable(options) {
 					return removeEntry(primaryStore, entry ?? primaryStore.getEntry(id), options);
 				}
 			} finally {
-				return transaction.commit();
+				return lmdbTransaction.commit();
 			}
 		}
 		/**

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1454,7 +1454,13 @@ export function makeTable(options) {
 					return removeEntry(primaryStore, entry ?? primaryStore.getEntry(id), options);
 				}
 			} finally {
-				return lmdbTransaction.commit();
+				if (primaryStore.ifVersion) {
+					// LMDB: committing the wrapper calls doneReadTxn(), removing it from trackedTxns
+					return lmdbTransaction.commit();
+				}
+				// RocksDB: eviction writes went directly into the raw transaction via options;
+				// commit it directly, as DatabaseTransaction.commit() would abort it (no tracked writes)
+				return transaction?.commit();
 			}
 		}
 		/**


### PR DESCRIPTION
## Summary

- `evict()` discarded the `LMDBTransaction` wrapper returned by `txnForContext()`, keeping only the raw LMDB Txn from `getReadTxn()`
- The wrapper was added to `trackedTxns` but never removed, since `doneReadTxn()` was never called
- The monitoring timer then repeatedly called `commit()` on the already-finished raw Txn, throwing "Can not finish a transaction more times than it was used" every 60 seconds per leaked transaction
- Every ContentCache eviction during the cleanup scan (worker `getWorkerCount() - 1` only) leaked one transaction, so errors appeared immediately after restart and fired continuously

Fix: retain the `LMDBTransaction` wrapper and commit it instead of the raw Txn, so `doneReadTxn()` properly cleans up `trackedTxns`.

## Test plan

- [ ] Start a node with ContentCache entries that have TTLs set to expire shortly after startup
- [ ] Confirm cleanup scan runs without "Can not finish a transaction more times than it was used" errors in logs
- [ ] Confirm no growth in `trackedTxns` over repeated eviction cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)