### PR TITLE
fix: always set ITC originator from threadId; guard readerList with optional chaining

### DIFF
--- a/server/threads/itc.js
+++ b/server/threads/itc.js
@@ -31,7 +31,7 @@ onMessageFromWorkers(async (event, sender) => {
  * @param event
  */
 function sendItcEvent(event) {
-	if (!isMainThread && event.message) event.message.originator = threadId;
+	if (event.message) event.message.originator = threadId;
 	return broadcastWithAcknowledgement(event);
 }
 

--- a/unitTests/server/itc/utility/itcUtils.test.js
+++ b/unitTests/server/itc/utility/itcUtils.test.js
@@ -2,6 +2,9 @@
 
 const chai = require('chai');
 const sinon = require('sinon');
+const sinon_chai = require('sinon-chai').default;
+const rewire = require('rewire');
+chai.use(sinon_chai);
 const { expect } = chai;
 const hdb_logger = require('#js/utility/logging/harper_logger');
 const itc_utils = require('#js/server/threads/itc');
@@ -41,6 +44,42 @@ describe('Test itcUtils module', () => {
 		it('Test missing originator error returned', () => {
 			const result = itc_utils.validateEvent({ type: 'table', message: { operation: 'create_table' } });
 			expect(result).to.equal("ITC event message missing 'originator' property");
+		});
+	});
+
+	describe('Test sendItcEvent function', () => {
+		let itc_rewired;
+		let broadcast_stub;
+
+		before(() => {
+			itc_rewired = rewire('#js/server/threads/itc');
+			broadcast_stub = sinon.stub().resolves();
+			itc_rewired.__set__('broadcastWithAcknowledgement', broadcast_stub);
+		});
+
+		afterEach(() => {
+			broadcast_stub.resetHistory();
+		});
+
+		it('sets originator on message when called from main thread', () => {
+			const event = { type: 'schema', message: { operation: 'create_schema' } };
+			itc_rewired.sendItcEvent(event);
+			expect(event.message.originator).to.not.equal(undefined);
+			expect(broadcast_stub).to.have.been.calledOnce;
+		});
+
+		it('sets originator to threadId regardless of isMainThread value', () => {
+			const event = { type: 'schema', message: { operation: 'create_schema' } };
+			const { threadId } = require('node:worker_threads');
+			itc_rewired.sendItcEvent(event);
+			expect(event.message.originator).to.equal(threadId);
+		});
+
+		it('does not set originator when message is absent', () => {
+			const event = { type: 'schema' };
+			itc_rewired.sendItcEvent(event);
+			expect(event.originator).to.equal(undefined);
+			expect(broadcast_stub).to.have.been.calledOnce;
 		});
 	});
 

--- a/utility/environment/systemInformation.ts
+++ b/utility/environment/systemInformation.ts
@@ -613,8 +613,8 @@ function getLMDBStats(table: Table, dbStats: DBStats): void {
 		const { root: _root, ...stats } = table.primaryStore.rootStore.getStats();
 		Object.assign(dbStats, stats);
 		dbStats.readers = table.primaryStore.rootStore
-			.readerList()
-			.split(/\n\s+/)
+			.readerList?.()
+			?.split(/\n\s+/)
 			.slice(1)
 			.map((line) => {
 				const [pid, thread, txnid] = line.trim().split(' ');


### PR DESCRIPTION
## Summary

- **ITC originator (critical):** `sendItcEvent` had a `!isMainThread` guard that skipped stamping `originator` on outgoing messages when called from the main thread. Workers' `schemaHandler` calls `validateEvent`, which returns early on a missing originator — silently dropping the schema sync on all 8 workers. Removed the guard so `threadId` is always stamped (0 for main thread, which passes the `isEmpty` check).
- **readerList optional chaining (non-critical):** `getLMDBStats` called `.readerList()` unconditionally; some table types expose no such method, causing a recurring `[notify]`-level error during metrics collection every ~9 hours. Added `?.` to guard both the call and the subsequent `.split()`.

## Test plan

- [ ] Run `npm run test:unit:server` — all 292 tests pass including 3 new `sendItcEvent` tests
- [ ] Run `npm run test:unit:utility` — 12 systemInformation tests pass
- [ ] Verify in production that the ~9-hour `readerList is not a function` error stops appearing
- [ ] Verify that schema changes triggered from the main thread (monitoring job / scheduled schema op) are received and applied on all worker threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)