### PR TITLE
Fix empty release notes for patch releases

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -80,6 +80,22 @@ jobs:
             }
       - name: Package Harper
         run: npm run package
+      - name: Generate release notes from git log
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 "HEAD^" 2>/dev/null || echo "")
+          {
+            echo "## What's Changed"
+            echo ""
+            if [ -n "$PREV_TAG" ]; then
+              git log --format="- %s" "${PREV_TAG}..HEAD" | grep -v "^- Release v"
+            else
+              git log --format="- %s" | grep -v "^- Release v" | head -50
+            fi
+            echo ""
+            if [ -n "$PREV_TAG" ]; then
+              echo "**Full Changelog**: ${{ github.server_url }}/${{ github.repository }}/compare/${PREV_TAG}...${{ steps.tag-version.outputs.tagVersion }}"
+            fi
+          } > release-notes.md
       - name: Get version components
         id: version-components
         uses: matt-usurp/validate-semver@7bbc9584679de1aeef57aa531504ab00438481ab # v2.1.0
@@ -93,7 +109,7 @@ jobs:
           tag_name: ${{ steps.tag-version.outputs.tagVersion }}
           files: harper-*.tgz
           fail_on_unmatched_files: true
-          generate_release_notes: true
+          body_path: release-notes.md
           prerelease: ${{ steps.version-components.outputs.prerelease != '' }}
           draft: true
           make_latest: ${{ github.event.inputs.draft == 'false' && steps.version-components.outputs.prerelease == '' }}

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -22,6 +22,8 @@ jobs:
       draft-release-url: ${{ steps.create-release.outputs.url }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,7 +2,7 @@ name: Integration Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'v[0-9]+.[0-9]+']
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -2,7 +2,7 @@ name: Unit Test
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'v[0-9]+.[0-9]+']
   pull_request:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary

`generate_release_notes: true` uses GitHub's API to match commits between tags to PRs by SHA. For patch releases, commits are cherry-picked from `main` onto the release branch — those cherry-picked commits have different SHAs from the original PR merges, so GitHub finds no matching PRs and the release notes are empty.

Replaced with a `git log`-based step that builds notes from the actual commits between the previous tag and the new one. GitHub auto-links `(#N)` references from squash-merged commits, and the step also emits a "Full Changelog" comparison link.

## Test plan

- [ ] Push a version tag and confirm the draft release has a populated "What's Changed" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)