### PR TITLE
Export lastValueEncoding for full-copy replication fix

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -71,12 +71,6 @@ let timestampNextEncoding = 0,
 	residencyIdAtNextEncoding = 0,
 	nodeIdAtNextEncoding = -1,
 	additionalAuditRefsNextEncoding: Array<{ version: number; nodeId: number }> | undefined;
-	timestampNextEncoding = 0,
-	metadataInNextEncoding = -1,
-	expiresAtNextEncoding = -1,
-	residencyIdAtNextEncoding = 0,
-	nodeIdAtNextEncoding = -1,
-	additionalAuditRefsNextEncoding: Array<{ version: number; nodeId: number }> | undefined;
 // tracking metadata with a singleton works better than trying to alter response of getEntry/get and coordinating that across caching layers
 export let lastMetadata: Entry | null = null;
 export class RecordEncoder extends Encoder {

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -64,7 +64,13 @@ const TRACKED_WRITE_TYPES = new Set(['put', 'patch', 'delete', 'message', 'publi
 // WeakMaps are definitely not the fastest form of private properties, but they are the only
 // way to do this with how the objects are frozen for now.
 export const entryMap = new WeakMap<any, Entry>();
-export let lastValueEncoding: Buffer | undefined,
+export let lastValueEncoding: Buffer | undefined;
+let timestampNextEncoding = 0,
+	metadataInNextEncoding = -1,
+	expiresAtNextEncoding = -1,
+	residencyIdAtNextEncoding = 0,
+	nodeIdAtNextEncoding = -1,
+	additionalAuditRefsNextEncoding: Array<{ version: number; nodeId: number }> | undefined;
 	timestampNextEncoding = 0,
 	metadataInNextEncoding = -1,
 	expiresAtNextEncoding = -1,

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -64,7 +64,7 @@ const TRACKED_WRITE_TYPES = new Set(['put', 'patch', 'delete', 'message', 'publi
 // WeakMaps are definitely not the fastest form of private properties, but they are the only
 // way to do this with how the objects are frozen for now.
 export const entryMap = new WeakMap<any, Entry>();
-let lastValueEncoding,
+export let lastValueEncoding: Buffer | undefined,
 	timestampNextEncoding = 0,
 	metadataInNextEncoding = -1,
 	expiresAtNextEncoding = -1,


### PR DESCRIPTION
## Summary

- Export `lastValueEncoding` from `RecordEncoder.ts` so the full-copy replication path in `harper-pro` can access the pure msgpack bytes independently of the `encode()` return value.

## Purpose

This is the core-side companion to a `harper-pro` fix for `Error decoding replication message` / `Data read, but end of buffer not reached 66` during full database copy. `RecordEncoder.encode()` in the metadata path returns bytes prefixed with an 8-byte RocksDB timestamp and 4-byte flags; `lastValueEncoding` always holds the un-prefixed msgpack bytes and is the correct value to send over the wire.

## Review notes

- The change is a one-line export promotion (`let` → `export let`) with an explicit type annotation.
- `lastValueEncoding` was already used externally in the normal (incremental) audit replication path; this just makes the same value accessible to the full-copy path.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)