### PR TITLE
ci(claude): bump max-turns 24→48 + sharpen anti-pattern in Tools section

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -158,7 +158,7 @@ jobs:
           show_full_output: true # TEMP: keep on during calibration so tool denials are visible
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 24
+            --max-turns 48
             # This workflow is READ-ONLY by design — the agent reviews and
             # comments, it does not modify the repo. Git subcommands are
             # scoped individually to strictly read-only operations.
@@ -224,9 +224,25 @@ jobs:
 
             ## Tools
 
-            For file inspection use the `Read`, `Grep`, and `Glob` tools.
+            **Turn budget:** you have 48 turns total per review. Plan
+            accordingly: 1–2 turns to read agent context files, 1 turn
+            to identify changed files, ~1 turn per changed file via
+            `Read`, the rest for targeted searches and posting
+            findings. Most reviews finish well under that. Running
+            out of turns means no review gets posted at all — the
+            log step skips when no marker'd review comment exists.
+
+            **The single biggest turn-burner is repo-wide search.**
+            Use the dedicated `Grep` tool with a tight `path` parameter
+            scoping to the changed files or the specific subdirectory
+            you need. Do NOT do `grep -rn …` (or `Bash(grep …)`) over
+            the whole repo — that pattern returned ~20 hits per call
+            in a recent run that timed out before posting anything.
+            For file inspection use `Read`, `Grep`, and `Glob` tools.
+
             Do NOT use `cat`, `head`, `tail`, `grep`, `ls`, or `find`
-            via Bash — those commands are not allowed and waste turns.
+            via Bash. The Bash allowlist below excludes them on
+            purpose, and the equivalent dedicated tools are faster.
             Do NOT run `npm test`, `npm run test:unit`, or any other
             script that executes PR code — the PR's tests are already
             checked separately.


### PR DESCRIPTION
## Summary

Fixes the immediate symptom from harper PR #450's failed review (run [25234303343](https://github.com/HarperFast/harper/actions/runs/25234303343)): agent burned ~20 turns on \`Bash(grep -rn …)\` repo-wide searches, hit \`--max-turns 24\`, posted no review comment, log step skipped. Diff was 5 files / +83/−8 — exploration pattern, not diff size, drove the cost.

## What changes

1. **\`--max-turns 24 → 48\`** — band-aid. Doubles worst-case budget; ends the immediate dropouts on PRs with non-trivial cross-symbol exploration.
2. **\`## Tools\` section** rewrite:
   - Adds a **turn budget** hint (1–2 turns context, 1 turn diff, ~1 per file, rest for searches + posting).
   - Names **repo-wide search as THE biggest turn-burner** with a concrete failure-mode citation ("recent run that timed out before posting anything").
   - Points at \`Grep\` tool with \`path\` parameter scoping as the right tool for the job.

## Open question (followup)

In the failed run, the agent's \`Bash(grep -rn …)\` calls all came back with \`is_error: false\` — they ran. But \`Bash(grep …)\` shouldn't match any of the existing allowlist patterns (\`Bash(git diff:*)\`, \`Bash(git log:*)\`, \`Bash(git blame:*)\`, \`Bash(git show:*)\`, \`Bash(gh ...:*)\`).

Either:
- claude-code-action permits any \`Bash(...)\` once the tool is enabled at all, or
- there's a matching gotcha in our patterns.

Worth digging into so the prompt instruction is backed by an actual deny at the action level. Not blocking this PR.

## Test plan

- [ ] Push to a PR after this lands → confirm review completes and posts a marker'd comment.
- [ ] Confirm the agent's tool-call pattern: prefers \`Grep\` over \`Bash(grep)\`, doesn't do repo-wide recursive searches.
- [ ] Re-trigger PR #450's review (or wait for next push) → confirm review now lands.

## Followup

oauth mirror once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)