### PR TITLE
ci(claude): fix yq expression in auth-gate-invariants validator

### DIFF
--- a/.github/scripts/validate-auth-gate-invariants.sh
+++ b/.github/scripts/validate-auth-gate-invariants.sh
@@ -74,7 +74,15 @@ for f in "${files[@]}"; do
   #    error rather than a silent runtime denial. Defense in depth
   #    against a PR that drops the env var thinking the script will
   #    "do the right thing".
-  users_to_check=$(yq -r '[.jobs.authorize.steps[].env.USERS_TO_CHECK // empty] | .[0] // ""' "$f" 2>/dev/null)
+  #
+  # NOTE: yq on ubuntu-latest is mikefarah/yq (Go), not jq. It does
+  # NOT support jq's `empty` keyword, and an earlier version of this
+  # check using `// empty` lexer-erred silently (`2>/dev/null` ate it)
+  # and produced a false fail on workflows that DID set the env var.
+  # `select(. != null)` is the idiomatic yq filter for "skip steps
+  # without this env var"; `head -1` collapses the per-step stream to
+  # a single value (or empty).
+  users_to_check=$(yq -r '.jobs.authorize.steps[].env.USERS_TO_CHECK | select(. != null)' "$f" 2>/dev/null | head -1)
   [ -n "$users_to_check" ] \
     || fail "$f: authorize job has no step setting USERS_TO_CHECK env var — the auth script needs at least one login to check (PR author, commenter, labeler, etc.)"
 


### PR DESCRIPTION
## Summary

Every PR has been failing \`Auth gate invariants / validate\` with:

\`\`\`
=== Validating .github/workflows/claude-issue-to-pr.yml ===
Error: .github/workflows/claude-issue-to-pr.yml: authorize job has no step setting USERS_TO_CHECK env var ...
Error: Process completed with exit code 1.
\`\`\`

…even on workflows that clearly set \`USERS_TO_CHECK\`. Reproduced locally — the validator's check uses jq's \`// empty\` keyword, but the runner's yq is mikefarah/yq (Go), which doesn't have it. yq's lexer rejects the expression; \`2>/dev/null\` swallowed the error; the variable came back empty; the existence check tripped on every workflow.

## Fix

Rewrite the yq expression in idiomatic mikefarah/yq syntax:

- **before:** \`yq -r '[.jobs.authorize.steps[].env.USERS_TO_CHECK // empty] | .[0] // ""' "$f" 2>/dev/null\`
- **after:** \`yq -r '.jobs.authorize.steps[].env.USERS_TO_CHECK | select(. != null)' "$f" 2>/dev/null | head -1\`

\`select(. != null)\` skips steps without the env var; \`head -1\` collapses the per-step stream to a single value (or empty) for the \`[ -n ]\` check.

Verified locally with mikefarah/yq v4.53.2 against all three harper \`claude-*.yml\` workflows — all pass.

## Out of scope (followups)

- The \`2>/dev/null\` swallowed a real yq error. Worth either dropping the suppression or capturing stderr for diagnostics when the expression returns empty.
- \`HarperFast/oauth#68\` (mirror) carries the same bug; needs a copy of this fix.

## Test plan

- [ ] Push to a PR after this lands → confirm \`Auth gate invariants / validate\` passes.
- [ ] Merge oauth#68 with the same fix mirrored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)