### PR TITLE
fix: reject legacy v4 'schema' field in DDL ops with 400 error

### DIFF
--- a/dataLayer/schema.ts
+++ b/dataLayer/schema.ts
@@ -19,6 +19,12 @@ import { transformReq } from '../utility/common_utils.ts';
 import { server } from '../server/Server.ts';
 import { cleanupOrphans } from '../resources/blob.ts';
 
+function rejectLegacySchemaField(obj: any) {
+	if (obj.schema && !obj.database) {
+		throw new ClientError("'database' is required. Use 'database' instead of the deprecated 'schema' field.");
+	}
+}
+
 const DB_NAME_CONSTRAINTS = Joi.string()
 	.min(1)
 	.max(commonValidators.schema_length.maximum)
@@ -63,7 +69,7 @@ export async function createSchemaStructure(schemaCreateObject: any) {
 		})
 	);
 	if (validation) throw new ClientError(validation.message);
-
+	rejectLegacySchemaField(schemaCreateObject);
 	transformReq(schemaCreateObject);
 
 	if (!(await schemaMetadataValidator.checkSchemaExists(schemaCreateObject.schema))) {
@@ -83,6 +89,7 @@ export async function createSchemaStructure(schemaCreateObject: any) {
 }
 
 export async function createTable(createTableObject: any) {
+	rejectLegacySchemaField(createTableObject);
 	transformReq(createTableObject);
 	createTableObject.primary_key = createTableObject.primary_key ?? createTableObject.hash_attribute;
 	return await createTableStructure(createTableObject);
@@ -154,7 +161,7 @@ export async function dropSchema(dropSchemaObject: any) {
 			})
 	);
 	if (validation) throw new ClientError(validation.message);
-
+	rejectLegacySchemaField(dropSchemaObject);
 	transformReq(dropSchemaObject);
 
 	let invalidSchemaMsg = await schemaMetadataValidator.checkSchemaExists(dropSchemaObject.schema);
@@ -187,7 +194,7 @@ export async function dropTable(dropTableObject: any) {
 		})
 	);
 	if (validation) throw new ClientError(validation.message);
-
+	rejectLegacySchemaField(dropTableObject);
 	transformReq(dropTableObject);
 
 	let invalidSchemaTableMsg = await schemaMetadataValidator.checkSchemaTableExists(
@@ -230,7 +237,7 @@ export async function dropAttribute(dropAttributeObject: any) {
 		})
 	);
 	if (validation) throw new ClientError(validation.message);
-
+	rejectLegacySchemaField(dropAttributeObject);
 	transformReq(dropAttributeObject);
 
 	let invalidSchemaTableMsg = await schemaMetadataValidator.checkSchemaTableExists(
@@ -310,6 +317,7 @@ function dropAttributeFromGlobal(dropAttributeObject) {
 }
 
 export async function createAttribute(createAttributeObject: any) {
+	rejectLegacySchemaField(createAttributeObject);
 	transformReq(createAttributeObject);
 
 	const tableAttr = getDatabases()[createAttributeObject.schema][createAttributeObject.table].attributes;

--- a/unitTests/dataLayer/schema.test.js
+++ b/unitTests/dataLayer/schema.test.js
@@ -638,3 +638,53 @@ describe.skip('Test schema module', function () {
 		});
 	});
 });
+
+describe('Schema legacy field rejection', function () {
+	const LEGACY_ERROR_MSG = "Use 'database' instead of the deprecated 'schema' field";
+
+	async function expectLegacyRejection(fn, args) {
+		let error;
+		try {
+			await fn(...args);
+		} catch (err) {
+			error = err;
+		}
+		expect(error).to.be.instanceOf(Error);
+		expect(error.statusCode).to.equal(400);
+		expect(error.message).to.include(LEGACY_ERROR_MSG);
+	}
+
+	it('rejects dropTable with schema-only field', () =>
+		expectLegacyRejection(schema.dropTable, [{ operation: 'drop_table', schema: 'mydb', table: 'mytable' }]));
+
+	it('rejects dropSchema with schema-only field', () =>
+		expectLegacyRejection(schema.dropSchema, [{ operation: 'drop_schema', schema: 'mydb' }]));
+
+	it('rejects createSchemaStructure with schema-only field', () =>
+		expectLegacyRejection(schema.createSchemaStructure, [{ operation: 'create_schema', schema: 'mydb' }]));
+
+	it('rejects createTable with schema-only field', () =>
+		expectLegacyRejection(schema.createTable, [
+			{ operation: 'create_table', schema: 'mydb', table: 'mytable', primary_key: 'id' },
+		]));
+
+	it('rejects dropAttribute with schema-only field', () =>
+		expectLegacyRejection(schema.dropAttribute, [
+			{ operation: 'drop_attribute', schema: 'mydb', table: 'mytable', attribute: 'name' },
+		]));
+
+	it('rejects createAttribute with schema-only field', () =>
+		expectLegacyRejection(schema.createAttribute, [
+			{ operation: 'create_attribute', schema: 'mydb', table: 'mytable', attribute: 'name' },
+		]));
+
+	it('does not reject dropTable when both database and schema are set', async function () {
+		let error;
+		try {
+			await schema.dropTable({ operation: 'drop_table', database: 'mydb', schema: 'mydb', table: 'mytable' });
+		} catch (err) {
+			error = err;
+		}
+		expect(error?.message).to.not.include(LEGACY_ERROR_MSG);
+	});
+});


### PR DESCRIPTION
## Summary

- Adds `rejectLegacySchemaField()` helper in `dataLayer/schema.js` that throws a `400 ClientError` when `schema` is provided without `database`
- Applied to all DDL entry points: `dropTable`, `dropSchema`, `createSchemaStructure`, `createTable`, `dropAttribute`, `createAttribute`
- 7 new unit tests covering rejection behavior and replication safety

## Purpose

In v5 the `database` field replaced v4's `schema` field for identifying the database in DDL operations. A caller using the legacy `schema` field received a 200 success response but the operation failed silently cluster-wide — `Promise.allSettled` in `replicateOperation` absorbs remote failures and the success message is always written over the response. There was no signal that anything went wrong.

## Design decision worth reviewing

**Check placement:** After Joi validation, before `transformReq()`. This is intentional — `transformReq` sets `req.schema = req.database` on the originating node before replication, so replicated calls always have **both** fields set; `rejectLegacySchemaField` only fires when `schema` is present *without* `database`, which uniquely identifies the legacy external API case.

**Skipped existing tests:** The `describe.skip('Test schema module')` block contains test constants (`DROP_TABLE_OBJECT_TEST`, etc.) that use `schema` without `database`. These would fail if unskipped, but updating them is a separate cleanup. They were already skipped before this change.

## Attention

- The `dropSchema` Joi schema uses `.or('database', 'schema')` for backwards compat; `rejectLegacySchemaField` then provides the more specific error. No change to the Joi schema was needed.
- Other operations (search, insert, delete) also call `transformReq` with `schema`/`database` but are out of scope — this was a DDL-specific report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)