### PR TITLE
fix: populate import.meta.filename, dirname, and resolve in VM loader

### DIFF
--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -499,6 +499,11 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 				context,
 				initializeImportMeta(meta) {
 					meta.url = url;
+					if (url.startsWith('file:')) {
+						meta.filename = fileURLToPath(url);
+						meta.dirname = dirname(meta.filename);
+					}
+					meta.resolve = (specifier: string) => resolveModule(specifier, url);
 				},
 				importModuleDynamically(specifier: string) {
 					const resolvedUrl = resolveModule(specifier, url);

--- a/unitTests/security/jsLoader/fixtures/import-meta.mjs
+++ b/unitTests/security/jsLoader/fixtures/import-meta.mjs
@@ -1,0 +1,4 @@
+export const metaUrl = import.meta.url;
+export const metaFilename = import.meta.filename;
+export const metaDirname = import.meta.dirname;
+export const resolvedSelf = import.meta.resolve('./import-meta.mjs');

--- a/unitTests/security/jsLoader/jsLoader.test.js
+++ b/unitTests/security/jsLoader/jsLoader.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { join } = require('node:path');
+const { pathToFileURL } = require('node:url');
 const { scopedImport } = require('#src/security/jsLoader');
 const { expect } = require('chai');
 
@@ -77,6 +78,17 @@ describe('scopedImport', () => {
 				/libbad\.mjs:1\nexport const baz ====\n +\^\^\^\n+SyntaxError: Missing initializer in const declaration/
 			);
 		}
+	});
+});
+
+describe('import.meta compatibility', () => {
+	it('should populate import.meta.url, filename, dirname, and resolve for ESM modules', async () => {
+		const fixturePath = join(__dirname, 'fixtures', 'import-meta.mjs');
+		const result = await scopedImport(fixturePath, vmScope());
+		expect(result.metaUrl).to.be.a('string').and.include('import-meta.mjs');
+		expect(result.metaFilename).to.equal(fixturePath);
+		expect(result.metaDirname).to.equal(join(__dirname, 'fixtures'));
+		expect(result.resolvedSelf).to.equal(pathToFileURL(fixturePath).toString());
 	});
 });
 


### PR DESCRIPTION
## Summary

- `vm.SourceTextModule`'s `initializeImportMeta` callback was only setting `meta.url`, leaving `meta.filename`, `meta.dirname`, and `meta.resolve` as `undefined`
- The native ESM loader populates all four automatically; this fix brings the VM loader to parity
- Added a unit test fixture (`import-meta.mjs`) and test case that verifies all four fields — including calling `meta.resolve` and checking it returns the correct `file://` URL

## Purpose

Apps loaded via the VM sandbox that use `import.meta.dirname` (common for path resolution, e.g. `new URL('../data', import.meta.url)`) or `import.meta.resolve` would silently get `undefined`. This fixes that compatibility gap.

## Attention

- `meta.resolve` delegates to the existing `resolveModule` helper, which uses `createRequire().resolve`. For Node built-in specifiers (e.g. `'fs'`) this returns the bare name rather than a `node:fs` URL — minor deviation from the spec but consistent with Harper's resolver and unlikely to matter in practice.
- The change is confined to `initializeImportMeta` inside `createModuleFromSource`; no impact on the CJS, compartment, or native loader paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)