### PR TITLE
ci(claude): bump actions/checkout v4.3.1 → v6.0.2 (Node 24)

### DIFF
--- a/.github/workflows/auth-gate-invariants.yml
+++ b/.github/workflows/auth-gate-invariants.yml
@@ -30,7 +30,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Validate auth gate structure
         run: bash .github/scripts/validate-auth-gate-invariants.sh

--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -60,7 +60,7 @@ jobs:
           owner: HarperFast
 
       - name: Checkout (for CODEOWNERS read)
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: |
             .github/CODEOWNERS
@@ -93,12 +93,12 @@ jobs:
         # shallow clone; `git log` / `git blame` aren't reached for by the
         # current prompt. Bump to a deeper fetch only if we see the agent
         # blocked on history lookups.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Clone shared Harper skills
         # Pinned to a SHA so agent behavior is reproducible across runs —
         # updates require an explicit pin bump here.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: HarperFast/skills
           ref: d2db99bb37a6dde868cbc5ac81ca4146be8956fb # 1.3.0 (2026-04-16)

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -53,7 +53,7 @@ jobs:
           owner: HarperFast
 
       - name: Checkout (for CODEOWNERS read)
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: |
             .github/CODEOWNERS
@@ -89,7 +89,7 @@ jobs:
         # shallow clone; `git log` / `git blame` aren't reached for by the
         # current prompt. Bump to a deeper fetch only if we see the agent
         # blocked on history lookups.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Parse mention
         # Real precision gate (the job-level `if:` is a cheap pre-filter).
@@ -109,7 +109,7 @@ jobs:
         # Pinned to a SHA so agent behavior is reproducible across runs —
         # updates require an explicit pin bump here.
         if: steps.mention.outputs.proceed == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: HarperFast/skills
           ref: d2db99bb37a6dde868cbc5ac81ca4146be8956fb # 1.3.0 (2026-04-16)

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -61,7 +61,7 @@ jobs:
           owner: HarperFast
 
       - name: Checkout (for CODEOWNERS read)
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: |
             .github/CODEOWNERS
@@ -110,7 +110,7 @@ jobs:
         # Paired with a tightly-scoped `Bash(git <subcommand>:*)` allowlist
         # below (no `Bash(git:*)` — that would allow `git push --force`,
         # `git reset --hard`, etc.).
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -118,7 +118,7 @@ jobs:
         # Pinned to a specific SHA (not `main`) so review behavior is
         # reproducible across runs — updates to the skills repo require
         # an explicit pin bump here.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: HarperFast/skills
           ref: d2db99bb37a6dde868cbc5ac81ca4146be8956fb # 1.3.0 (2026-04-16)
@@ -127,7 +127,7 @@ jobs:
       - name: Clone review prompts
         # Layer files live in HarperFast/ai-review-prompts (public).
         # Pinned to a merge SHA — bump this deliberately to adopt updates.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: HarperFast/ai-review-prompts
           ref: 14c79a1c36565c764b68d3641c32bdadfc4d0512 # main 2026-04-30 (incl. concise-PR + within-PR-memory)


### PR DESCRIPTION
## Summary

Addresses the runner deprecation warning on the \`Auth gate invariants / validate\` job:

> Node.js 20 actions are deprecated... \`actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5\`. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

\`actions/checkout\` v5.0.0 was the Node 20 → Node 24 jump. **v6.0.2** (2026-01-09) is the latest stable, ~4 months baked, and is **already in use** elsewhere in this repo (\`format-check.yml\`, \`integration-tests.yml\`, \`unit-test.yml\`) — same SHA, no new trust surface.

## Bumped (11 instances)

| File | Instances |
|---|---|
| \`auth-gate-invariants.yml\` | 1 |
| \`claude-issue-to-pr.yml\` | 3 |
| \`claude-mention.yml\` | 3 |
| \`claude-review.yml\` | 4 |

All instances now use \`actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2\`.

## Compatibility

- v6.0.0 notable change: "persist creds to a separate file" — security improvement. We don't configure custom credential persistence, so transparent.
- v6.0.2 adds tag-handling fixes.
- v6 minimum compatible runner: \`v2.327.1\` (current ubuntu-latest is \`v2.334.0\`, comfortably above).

## Out of scope

- \`actions/setup-node@v6.2.0\` and \`actions/create-github-app-token@v3.1.1\` weren't flagged by the runner — presumed Node-24-clean. If/when their warnings appear, separate sweep.
- \`anthropics/claude-code-action@v1.0.99\` not affected.

## oauth mirror

oauth needs the same 11-instance bump — will land in a follow-up PR after this merges.

## Test plan

- [ ] Push to a PR after this lands → confirm no Node 20 deprecation warning on \`Auth gate invariants / validate\` (or any other claude-*.yml job using checkout).
- [ ] Confirm \`Auth gate invariants / validate\` still passes (validator runs on PR touching workflows; this PR touches them).
- [ ] Confirm a Claude review run completes end-to-end (no checkout regression on the layered review-prompts / harper-skills clones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)