### PR TITLE
ci: bump third-party action versions across workflows

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -105,7 +105,7 @@ jobs:
           path: .harper-skills
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.node-version'
           cache: 'npm'
@@ -114,7 +114,7 @@ jobs:
 
       - name: Claude (agent mode)
         id: claude-agent
-        uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
+        uses: anthropics/claude-code-action@ef50f123a3a9be95b60040d042717517407c7256 # v1.0.110
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -123,7 +123,7 @@ jobs:
         # prompt tells the agent to run `npm ci` itself before any script
         # that needs dependencies.
         if: steps.mention.outputs.proceed == 'true'
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.node-version'
           cache: 'npm'
@@ -131,7 +131,7 @@ jobs:
       - name: Claude (agent mode)
         if: steps.mention.outputs.proceed == 'true'
         id: claude-agent
-        uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
+        uses: anthropics/claude-code-action@ef50f123a3a9be95b60040d042717517407c7256 # v1.0.110
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Claude review
         id: claude-review
-        uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
+        uses: anthropics/claude-code-action@ef50f123a3a9be95b60040d042717517407c7256 # v1.0.110
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Admit the issue-to-PR bot's PRs. Job-level `if:` gate above lets

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.node-version'
           cache: 'npm'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           package-manager-cache: false
@@ -64,7 +64,7 @@ jobs:
         run: npm run build || true # we currently have type errors so just ignore that
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: harper-build-artifacts-node-${{ matrix.node-version }}
           path: |
@@ -89,7 +89,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           package-manager-cache: false
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload Harper logs
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: harper-integration-api-test-logs-node-${{ matrix.node-version }}
           path: /tmp/hdb/log/
@@ -151,7 +151,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           package-manager-cache: false
@@ -178,7 +178,7 @@ jobs:
 
       - name: Upload Harper server logs
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: harper-server-logs-node-${{ matrix.node-version }}-shard-${{ matrix.shard }}
           path: /tmp/harper-integration-test-logs/

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           package-manager-cache: false


### PR DESCRIPTION
## Summary

Sweep of currently-pinned third-party action SHAs to latest stable releases past the 3-day buffer. Continues from #461.

| Action | Was | Now | Released | Age |
|---|---|---|---|---|
| \`actions/setup-node\` | v6.2.0 / v6.3.0 | v6.4.0 | 2026-04-20 | 14 days |
| \`actions/upload-artifact\` | v7.0.0 | v7.0.1 | 2026-04-10 | 24 days |
| \`anthropics/claude-code-action\` | v1.0.99 | v1.0.110 | 2026-04-29 | 5 days |

## Skipped (already current)

- \`actions/checkout\` v6.0.2 (2026-01-09)
- \`actions/create-github-app-token\` v3.1.1 (2026-04-11)
- \`actions/download-artifact\` v8.0.1 (2026-03-11)

## Held back

- \`anthropics/claude-code-action\` v1.0.111 (2026-05-01) — at the 3-day buffer edge today; deliberately one patch behind. Will pick up on the next sweep.

## Files touched

- \`claude-review.yml\`, \`claude-mention.yml\`, \`claude-issue-to-pr.yml\` (claude-code-action + setup-node)
- \`format-check.yml\`, \`integration-tests.yml\`, \`unit-test.yml\` (setup-node)
- \`integration-tests.yml\` (upload-artifact)

## Verified locally

- All affected workflows parse as valid YAML.
- \`bash .github/scripts/validate-auth-gate-invariants.sh\` passes against all three \`claude-*.yml\` workflows.

## oauth followup

oauth needs a parallel sweep — coming next. Includes:

1. Same three bumps as this PR.
2. Mirror of #461's \`actions/checkout\` v4.3.1 → v6.0.2 (not yet shipped to oauth).
3. \`pr-checks.yml\`'s three tag-pinned refs (\`@v4\`, \`@v4\`, \`@v2\`) get SHA pins.

## Test plan

- [ ] Push to a PR after this lands → confirm \`Auth gate invariants / validate\` still passes (it touches \`claude-*.yml\`, so the validator runs).
- [ ] Confirm a Claude review run completes end-to-end on v1.0.110.
- [ ] Confirm \`integration-tests\` workflow still uploads/downloads artifacts cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)