### PR TITLE
Fix EEXIST error when symlinking harper module over dangling symlink

### DIFF
--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -1,5 +1,14 @@
 import { onMessageByType } from '../server/threads/manageThreads.js';
-import { readdirSync, readFileSync, existsSync, realpathSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
+import {
+	readdirSync,
+	readFileSync,
+	existsSync,
+	lstatSync,
+	realpathSync,
+	mkdirSync,
+	rmSync,
+	symlinkSync,
+} from 'node:fs';
 import { join, basename, dirname } from 'node:path';
 import { isMainThread } from 'node:worker_threads';
 import { parseDocument } from 'yaml';
@@ -151,23 +160,26 @@ function symlinkHarperModule(componentDirectory: string) {
 
 				// validate harper module
 				const harperModule = join(nodeModulesDir, 'harper');
-				if (existsSync(harperModule)) {
-					if (realpathSync(harperModule) !== realpathSync(PACKAGE_ROOT)) {
-						// if it exists but is incorrectly linked, fix it
-						rmSync(harperModule, { recursive: true, force: true });
-						// create link to harper module
-						symlinkSync(PACKAGE_ROOT, harperModule, 'dir');
-					}
-				} else {
-					// create link to harper module
+				let harperModuleLinked = false;
+				try {
+					lstatSync(harperModule); // throws ENOENT if absent; succeeds even for dangling symlinks
+					harperModuleLinked = realpathSync(harperModule) === realpathSync(PACKAGE_ROOT);
+				} catch {}
+				if (!harperModuleLinked) {
+					rmSync(harperModule, { recursive: true, force: true });
 					symlinkSync(PACKAGE_ROOT, harperModule, 'dir');
 				}
 				// if there is a harperdb module, fix that too
 				const harperdbModule = join(nodeModulesDir, 'harperdb');
-				if (existsSync(harperdbModule) && realpathSync(harperdbModule) !== realpathSync(PACKAGE_ROOT)) {
-					// if it exists but is incorrectly linked, fix it
+				let harperdbModulePresent = false;
+				let harperdbModuleLinked = false;
+				try {
+					lstatSync(harperdbModule);
+					harperdbModulePresent = true;
+					harperdbModuleLinked = realpathSync(harperdbModule) === realpathSync(PACKAGE_ROOT);
+				} catch {}
+				if (harperdbModulePresent && !harperdbModuleLinked) {
 					rmSync(harperdbModule, { recursive: true, force: true });
-					// create link to harper module
 					symlinkSync(PACKAGE_ROOT, harperdbModule, 'dir');
 				}
 


### PR DESCRIPTION
## Summary

- `existsSync` follows symlinks and returns `false` for dangling symlinks (symlink file present, target missing)
- This caused `symlinkSync` to throw `EEXIST` in the `else` branch because the symlink file itself still exists on disk
- Replaced `existsSync` with `lstatSync` (which inspects the symlink file itself, not its target) for both `harper` and `harperdb` module checks

## Root cause

The EEXIST error surface:
```
Error: EEXIST: file already exists, symlink '.../@harperfast/harper-pro' -> '.../deploy-pkg/node_modules/harper'
```
This happens when `deploy-pkg/node_modules/harper` is a dangling symlink (e.g. after a package reinstall that removed the old target). `existsSync` returns false → falls through to the bare `symlinkSync` call → EEXIST.

## Attention

- The `harper` module fix changes behavior: previously a dangling symlink would be left in place; now it's removed and recreated correctly. This is the desired behavior.
- The `harperdb` module fix is the same pattern but lower risk — the original code never created `harperdb` from scratch, so there was no EEXIST risk, but a dangling symlink would silently go unfixed.
- The `lstatSync`/`realpathSync` pair is wrapped in a single `try/catch` — a dangling symlink causes `lstatSync` to succeed but `realpathSync` to throw, leaving `*Linked = false`, which correctly triggers the remove+recreate path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)