### PR TITLE
Fix crash when CJS module uses dynamic import() via VM loader

### DIFF
--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -246,7 +246,7 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 		const runOptions = {
 			filename: url,
 			async importModuleDynamically(specifier: string, script) {
-				const resolvedUrl = resolveModule(specifier, script.sourceURL);
+				const resolvedUrl = resolveModule(specifier, script?.sourceURL ?? url);
 				const useApplicationLoader = shouldUseApplicationLoader(specifier, resolvedUrl);
 				const dynamicModule = await loadModuleWithCache(resolvedUrl, useApplicationLoader);
 				return dynamicModule;

--- a/unitTests/security/jsLoader/fixtures/uses-dynamic-import.cjs
+++ b/unitTests/security/jsLoader/fixtures/uses-dynamic-import.cjs
@@ -1,0 +1,4 @@
+module.exports.load = async function () {
+	const lib = await import('./libgood.cjs');
+	return lib.default || lib;
+};

--- a/unitTests/security/jsLoader/jsLoader.test.js
+++ b/unitTests/security/jsLoader/jsLoader.test.js
@@ -78,6 +78,12 @@ describe('scopedImport', () => {
 			);
 		}
 	});
+
+	it('should handle dynamic import() from a CJS module', async () => {
+		const result = await scopedImport(join(__dirname, 'fixtures', 'uses-dynamic-import.cjs'), vmScope());
+		const lib = await result.load();
+		expect(lib.baz).to.equal('pow');
+	});
 });
 
 describe('symlinked module resolution', () => {


### PR DESCRIPTION
## Summary

- `script.sourceURL` is `undefined` in `importModuleDynamically` when a CJS module loaded via the VM loader calls `import()` dynamically
- Added `script?.sourceURL ?? url` fallback so `resolveModule` always receives a valid referrer string (the enclosing module's own URL is the correct semantic fallback)

## Cause

Node.js does not guarantee `script.sourceURL` is set on `vm.Script` objects passed to the `importModuleDynamically` callback. The crash was observed when `proxyTransform/index.js` called `import()`.

## Test

Added a fixture (`uses-dynamic-import.cjs`) and a unit test exercising the `importModuleDynamically` path via `vmScope()`, which was the missing coverage.

## Attention

One-line change: `script.sourceURL` → `script?.sourceURL ?? url`. The only judgment call is using `url` (the CJS module's own file URL) as the fallback referrer, which is semantically correct since relative imports in a CJS module should resolve against that module's location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)