### PR TITLE
Copy database in binary mode

### DIFF
--- a/bin/copyDb.ts
+++ b/bin/copyDb.ts
@@ -200,9 +200,18 @@ export async function copyDb(sourceDatabase: string, targetDatabasePath: string)
 			await copyDbi(sourceDbi, targetDbi, isPrimary, transaction);
 		}
 		if (sourceAuditStore) {
-			const targetAuditStore = rootStore.openDB(AUDIT_STORE_NAME, AUDIT_STORE_OPTIONS);
+			// Copy audit store in binary mode to avoid encode/decode issues with symbol-keyed metadata entries
+			const auditBinaryOptions: any = {
+				keyEncoder: AUDIT_STORE_OPTIONS.keyEncoder,
+				encoding: 'binary',
+			};
+			const sourceAuditBinary: any = rootStore.openDB(AUDIT_STORE_NAME, auditBinaryOptions);
+			sourceAuditBinary.decoder = null;
+			sourceAuditBinary.decoderCopies = false;
+			const targetAuditStore: any = targetEnv.openDB(AUDIT_STORE_NAME, auditBinaryOptions);
+			targetAuditStore.encoder = null;
 			console.log('copying audit log for', sourceDatabase, 'to', targetDatabasePath);
-			copyDbi(sourceAuditStore, targetAuditStore, false, transaction);
+			await copyDbi(sourceAuditBinary, targetAuditStore, false, transaction);
 		}
 
 		async function copyDbi(sourceDbi, targetDbi, isPrimary, transaction) {


### PR DESCRIPTION
I created an database using LMDB storage and then inserted a bunch of rows. Next I ran `harper copy-db testdb testdb2` and it errored with:
```
[main/0] [error]: Reading audit entry error RangeError: Error reading float64: Offset is outside the bounds of the DataView at position 4
```

When opening the source and target databases, set the encoding to binary so that we completely bypass decoding/encoding and do a true byte copy.
