### PR TITLE
ci(claude): run caller-workflow validator on every PR

### DIFF
--- a/.github/workflows/validate-caller-workflows.yml
+++ b/.github/workflows/validate-caller-workflows.yml
@@ -11,24 +11,19 @@ name: Validate caller workflows
 #   * Mutable refs in `uses:` or `with.ai-review-prompts-ref` —
 #     both must pin to a 40-char SHA.
 #
-# Replaces the local `auth-gate-invariants.yml` here. After the
-# Day 2 caller migration, no inline-pattern claude-*.yml workflows
-# remain in this repo, so the centralized caller validator is the
-# single source of truth.
+# Runs on every PR and every push to `main` — no `paths:` filter.
+# A required status check that only fires on workflow-touching PRs
+# stays permanently pending on every other PR (GitHub has no
+# "required if it runs" semantic). The validator's runtime is
+# trivial (yq-parses a few caller files), so unconditional firing
+# is the right trade-off for satisfiability.
 #
-# Make this `validate` job a REQUIRED status check on `main`
-# (defense in depth alongside CODEOWNERS review on `.github/`).
+# Make this `validate` job a REQUIRED status check on `main`.
 
 on:
   pull_request:
-    paths:
-      - '.github/workflows/claude-*.yml'
-      - '.github/workflows/validate-caller-workflows.yml'
   push:
     branches: [main]
-    paths:
-      - '.github/workflows/claude-*.yml'
-      - '.github/workflows/validate-caller-workflows.yml'
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary

Drop the \`paths:\` filter from \`validate-caller-workflows.yml\`. The validator now runs on every PR (and every push to \`main\`) instead of only on PRs touching \`claude-*.yml\` or itself.

## Why

A required status check that only fires on a subset of PRs stays permanently pending on every other PR — GitHub has no "required if it runs" semantic. Path-filtered + required = unsatisfiable for any PR that doesn't touch the workflow files. (Confirmed today on PR #481, a README-only change that hung on \`validate / validate\`.)

The validator runtime is trivial (yq-parses a handful of caller files), so the unconditional firing cost is rounding error against the benefit of being able to make the check required.

## Test plan

- [x] After merge: confirm the \`validate / validate\` check now reports on a PR that doesn't touch any \`.github/workflows/claude-*.yml\` file.
- [ ] Re-enable as a required status check on \`main\` once verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)