### PR TITLE
ci(claude): bump ai-review-prompts pin to 53d4f501

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -22,11 +22,11 @@ concurrency:
 
 jobs:
   work:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@11872cb1cc2d0e90659659ade6d8ddbbdfbf1d05 # main 2026-05-06 (post #11/#12/#14)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@53d4f5015c8bac691fa108c5c3d0440151bd66af # main 2026-05-06
     with:
       # Same SHA as the `uses:` ref above. See the comment in
       # claude-mention.yml for why the duplication is unavoidable.
-      ai-review-prompts-ref: 11872cb1cc2d0e90659659ade6d8ddbbdfbf1d05
+      ai-review-prompts-ref: 53d4f5015c8bac691fa108c5c3d0440151bd66af
       repo-specific-conventions: |
         ## Harper core notes
 

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   mention:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-mention.yml@11872cb1cc2d0e90659659ade6d8ddbbdfbf1d05 # main 2026-05-06 (post #11/#12/#14)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-mention.yml@53d4f5015c8bac691fa108c5c3d0440151bd66af # main 2026-05-06
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (parse + auth scripts)
@@ -34,7 +34,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to
       # the CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 11872cb1cc2d0e90659659ade6d8ddbbdfbf1d05
+      ai-review-prompts-ref: 53d4f5015c8bac691fa108c5c3d0440151bd66af
       repo-specific-conventions: |
         ## Harper core notes
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@11872cb1cc2d0e90659659ade6d8ddbbdfbf1d05 # main 2026-05-06 (post #11/#12/#14 — Day 2 reusables)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@53d4f5015c8bac691fa108c5c3d0440151bd66af # main 2026-05-06
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (layer files + bash
@@ -35,7 +35,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 11872cb1cc2d0e90659659ade6d8ddbbdfbf1d05
+      ai-review-prompts-ref: 53d4f5015c8bac691fa108c5c3d0440151bd66af
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/validate-caller-workflows.yml
+++ b/.github/workflows/validate-caller-workflows.yml
@@ -27,9 +27,9 @@ on:
 
 jobs:
   validate:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@11872cb1cc2d0e90659659ade6d8ddbbdfbf1d05 # main 2026-05-06 (post #11/#12/#14)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@53d4f5015c8bac691fa108c5c3d0440151bd66af # main 2026-05-06
     with:
       # Same SHA as the `uses:` ref above — the reusable uses this
       # to check out the validator script at the matching version.
       # Same SHA-twice pattern as the other caller workflows.
-      ai-review-prompts-ref: 11872cb1cc2d0e90659659ade6d8ddbbdfbf1d05
+      ai-review-prompts-ref: 53d4f5015c8bac691fa108c5c3d0440151bd66af


### PR DESCRIPTION
## Summary

Bumps all four caller workflow files to ai-review-prompts \`53d4f501\` (post-#15). Picks up:

- **\`claude-fix:test\` label support** — added to the issue-to-PR reusable's hard-coded \`if:\` JSON list and prompt label-scope guidance. Test work (write, migrate, refactor, stabilize tests) was the missing scope between \`:bug\` and the existing labels.
- **FS primitives in the allowlist** — \`Bash(mkdir:*)\`, \`Bash(mv:*)\`, \`Bash(cp:*)\`, \`Bash(ls:*)\`, \`Bash(cat:*)\`. Surfaced when an \`@claude\` mention burned half its turn budget retrying \`mkdir\` against a denial. \`Bash(git:*)\` was already in the allowlist (full namespace), so this isn't a meaningful security expansion.

All four callers move together to the same SHA, keeping the "all pin lines match" invariant easy to eyeball.

The \`claude-fix:test\` label has already been created on this repo (mirroring oauth / harper-pro: green \`#0E8A16\`, "Test work — write, migrate, refactor, or stabilize tests").

## Test plan

- [x] Caller-validator script (from ai-review-prompts main) dry-runs cleanly against the bumped tree.
- [x] All four caller files now reference \`53d4f5015c8bac691fa108c5c3d0440151bd66af\` in both \`uses:\` and \`with.ai-review-prompts-ref\`.
- [ ] After merge: label a test issue with \`claude-fix:test\`; verify the issue-to-PR reusable picks up the new scope and the agent doesn't burn turns on \`mkdir\` denials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)