### PR TITLE
ci(claude): bump ai-review-prompts pin to f6daed30

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -22,11 +22,11 @@ concurrency:
 
 jobs:
   work:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@11872cb1cc2d0e90659659ade6d8ddbbdfbf1d05 # main 2026-05-06 (post #11/#12/#14)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@f6daed301f8a7ece74593506de38c6e80820b00b # main 2026-05-06 (post #11/#12/#14)
     with:
       # Same SHA as the `uses:` ref above. See the comment in
       # claude-mention.yml for why the duplication is unavoidable.
-      ai-review-prompts-ref: 11872cb1cc2d0e90659659ade6d8ddbbdfbf1d05
+      ai-review-prompts-ref: f6daed301f8a7ece74593506de38c6e80820b00b
       repo-specific-conventions: |
         ## Harper core notes
 

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   mention:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-mention.yml@11872cb1cc2d0e90659659ade6d8ddbbdfbf1d05 # main 2026-05-06 (post #11/#12/#14)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-mention.yml@f6daed301f8a7ece74593506de38c6e80820b00b # main 2026-05-06 (post #11/#12/#14)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (parse + auth scripts)
@@ -34,7 +34,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to
       # the CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 11872cb1cc2d0e90659659ade6d8ddbbdfbf1d05
+      ai-review-prompts-ref: f6daed301f8a7ece74593506de38c6e80820b00b
       repo-specific-conventions: |
         ## Harper core notes
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@11872cb1cc2d0e90659659ade6d8ddbbdfbf1d05 # main 2026-05-06 (post #11/#12/#14 — Day 2 reusables)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@f6daed301f8a7ece74593506de38c6e80820b00b # main 2026-05-06 (post #11/#12/#14 — Day 2 reusables)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (layer files + bash
@@ -35,7 +35,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 11872cb1cc2d0e90659659ade6d8ddbbdfbf1d05
+      ai-review-prompts-ref: f6daed301f8a7ece74593506de38c6e80820b00b
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/validate-caller-workflows.yml
+++ b/.github/workflows/validate-caller-workflows.yml
@@ -27,9 +27,9 @@ on:
 
 jobs:
   validate:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@11872cb1cc2d0e90659659ade6d8ddbbdfbf1d05 # main 2026-05-06 (post #11/#12/#14)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@f6daed301f8a7ece74593506de38c6e80820b00b # main 2026-05-06 (post #11/#12/#14)
     with:
       # Same SHA as the `uses:` ref above — the reusable uses this
       # to check out the validator script at the matching version.
       # Same SHA-twice pattern as the other caller workflows.
-      ai-review-prompts-ref: 11872cb1cc2d0e90659659ade6d8ddbbdfbf1d05
+      ai-review-prompts-ref: f6daed301f8a7ece74593506de38c6e80820b00b


### PR DESCRIPTION
## Summary

Bumps all four caller workflow files to ai-review-prompts `f6daed30`. Picks up the label-expansion calibration done on harper-pro yesterday, now verified end-to-end:

- **`claude-fix:test` label** — test work that was previously stretched into `:bug` or routed through `@claude` mention. The reusable now hard-codes `:test` in its `if:`, prompt scope guidance, and default `pre-commit-validation`. Tests work (write, migrate, refactor, stabilize) under this label.
- **FS primitives in the issue-to-PR allowlist** (`mkdir`/`mv`/`cp`/`ls`/`cat`) — the agent burned half its turn budget on a real test-migration ask retrying `mkdir` against permission denials. `Bash(git:*)` was already in the allowlist (full namespace), so the new entries are not a meaningful security expansion.
- **Mention allowlist aligned with issue-to-PR's** — closes the iteration-on-PR gap. When issue-to-PR opens a PR, follow-up `@claude` mentions on that PR (the natural "please change X to Y" path) flow through the mention reusable. Without these primitives mention hit the same FS wall that issue-to-PR escaped.
- **`:test` migrations are add-only** — for migrations / relocations, the agent ADDs the new test in the target framework (via the `Write` tool, which creates parent directories automatically), leaves the original in place. The human reviewer confirms the new test runs cleanly before any deletion. Sidesteps the SDK rm-block + the still-open mkdir-allowlist mystery.

Verified end-to-end on harper-pro #125 (analytics unit test → integration framework migration).

The `claude-fix:test` label has already been created on this repo (mirroring harper-pro / harper / oauth where applicable: green `#0E8A16`, "Test work — write, migrate, refactor, or stabilize tests").

## Test plan

- [x] Caller-validator script (from ai-review-prompts main) dry-runs cleanly against the bumped tree.
- [x] All four caller files now reference `f6daed301f8a7ece74593506de38c6e80820b00b` in both `uses:` and `with.ai-review-prompts-ref`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)