### PR TITLE
ci(claude): bump ai-review-prompts pin to 6463b3da

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -22,11 +22,11 @@ concurrency:
 
 jobs:
   work:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@f6daed301f8a7ece74593506de38c6e80820b00b # main 2026-05-06 (post #11/#12/#14)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@6463b3da6326f0ca4646fb6b5139c2ecf92130f6 # main 2026-05-06 (post #11/#12/#14)
     with:
       # Same SHA as the `uses:` ref above. See the comment in
       # claude-mention.yml for why the duplication is unavoidable.
-      ai-review-prompts-ref: f6daed301f8a7ece74593506de38c6e80820b00b
+      ai-review-prompts-ref: 6463b3da6326f0ca4646fb6b5139c2ecf92130f6
       repo-specific-conventions: |
         ## Harper core notes
 

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   mention:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-mention.yml@f6daed301f8a7ece74593506de38c6e80820b00b # main 2026-05-06 (post #11/#12/#14)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-mention.yml@6463b3da6326f0ca4646fb6b5139c2ecf92130f6 # main 2026-05-06 (post #11/#12/#14)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (parse + auth scripts)
@@ -34,7 +34,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to
       # the CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: f6daed301f8a7ece74593506de38c6e80820b00b
+      ai-review-prompts-ref: 6463b3da6326f0ca4646fb6b5139c2ecf92130f6
       repo-specific-conventions: |
         ## Harper core notes
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@f6daed301f8a7ece74593506de38c6e80820b00b # main 2026-05-06 (post #11/#12/#14 — Day 2 reusables)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@6463b3da6326f0ca4646fb6b5139c2ecf92130f6 # main 2026-05-06 (post #11/#12/#14 — Day 2 reusables)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (layer files + bash
@@ -35,7 +35,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: f6daed301f8a7ece74593506de38c6e80820b00b
+      ai-review-prompts-ref: 6463b3da6326f0ca4646fb6b5139c2ecf92130f6
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/validate-caller-workflows.yml
+++ b/.github/workflows/validate-caller-workflows.yml
@@ -27,9 +27,9 @@ on:
 
 jobs:
   validate:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@f6daed301f8a7ece74593506de38c6e80820b00b # main 2026-05-06 (post #11/#12/#14)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@6463b3da6326f0ca4646fb6b5139c2ecf92130f6 # main 2026-05-06 (post #11/#12/#14)
     with:
       # Same SHA as the `uses:` ref above — the reusable uses this
       # to check out the validator script at the matching version.
       # Same SHA-twice pattern as the other caller workflows.
-      ai-review-prompts-ref: f6daed301f8a7ece74593506de38c6e80820b00b
+      ai-review-prompts-ref: 6463b3da6326f0ca4646fb6b5139c2ecf92130f6


### PR DESCRIPTION
## Summary

Bumps all four caller workflow files to ai-review-prompts \`6463b3da\` (post-#19). Picks up:

- **\`:test\` validation now runs \`npm run format:check\`** (parity with the other label scopes — \`:test\` was the only one missing it). The first \`:test\` PR on this repo (#490) hit a Format Check failure the agent didn't catch before pushing; this fixes that gap for the retry.

ai-review-prompts \`#18\` (App-token push so bot-authored commits retrigger downstream CI) intentionally **not** included — that's gated on adding \`Contents: Write\` + \`Pull requests: Write\` to the \`HarperFast AI Workflows\` App's installation permissions, and we're parking it on the side. Without that fix, bot commits still won't retrigger CI; close + reopen remains the workaround.

## Test plan

- [x] Caller-validator script (from ai-review-prompts main) dry-runs cleanly.
- [x] All four caller files reference \`6463b3da6326f0ca4646fb6b5139c2ecf92130f6\` in both \`uses:\` and \`with.ai-review-prompts-ref\`.
- [ ] After merge: re-label the test issue with \`claude-fix:test\` and verify the agent format-checks before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)