### PR TITLE
fix: write Harper config files atomically

### DIFF
--- a/config/configUtils.js
+++ b/config/configUtils.js
@@ -88,6 +88,14 @@ function getConfigPath(param) {
 	if (!rootPath) return value;
 	return path.resolve(rootPath, value);
 }
+
+// Write atomically via temp file + rename so readers don't observe a truncated/empty file
+function atomicWriteFile(filePath, content) {
+	const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+	fs.writeFileSync(tempPath, content);
+	fs.renameSync(tempPath, filePath);
+}
+
 /**
  * Builds the Harper config file using user inputs and default values from defaultConfig.yaml
  * @param args - any args that the user provided.
@@ -164,7 +172,7 @@ function createConfigFile(args, skipFsValidation = false) {
 			true
 		);
 	}
-	fs.writeFileSync(configFilePath, String(configDoc));
+	atomicWriteFile(configFilePath, String(configDoc));
 	logger.trace(`Config file written to ${configFilePath}`);
 }
 
@@ -389,7 +397,7 @@ function checkForUpdatedConfig(configDoc, configFilePath) {
 				HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR
 			);
 		}
-		fs.writeFileSync(configFilePath, String(configDoc));
+		atomicWriteFile(configFilePath, String(configDoc));
 	}
 }
 
@@ -633,7 +641,7 @@ function updateConfigValue(
 			HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR
 		);
 	}
-	fs.writeFileSync(configFileLocation, String(configDoc));
+	atomicWriteFile(configFileLocation, String(configDoc));
 	if (update_config_obj) {
 		flatConfigObj = flattenConfig(configDoc.toJSON());
 	}
@@ -895,7 +903,7 @@ function applyRuntimeEnvVarConfig(configDoc, configFilePath, options = {}) {
 				HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR
 			);
 		}
-		fs.writeFileSync(configFilePath, String(configDoc));
+		atomicWriteFile(configFilePath, String(configDoc));
 		logger.debug('Config file updated with runtime env var values');
 	} catch (error) {
 		logger.error(`Failed to write config file after applying runtime env vars: ${error.message}`);
@@ -956,7 +964,7 @@ async function addConfig(topLevelElement, values) {
 			HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR
 		);
 	}
-	await fs.writeFile(getConfigFilePath(), String(configDoc));
+	atomicWriteFile(getConfigFilePath(), String(configDoc));
 }
 
 function deleteConfigFromFile(param) {
@@ -965,7 +973,7 @@ function deleteConfigFromFile(param) {
 	configDoc.deleteIn(param);
 	const hdbRoot = configDoc.getIn(['rootPath']);
 	const configFileLocation = path.join(hdbRoot, hdbTerms.HARPER_CONFIG_FILE);
-	fs.writeFileSync(configFileLocation, String(configDoc));
+	atomicWriteFile(configFileLocation, String(configDoc));
 }
 
 function getConfigObj() {

--- a/unitTests/config/configUtils-runtimeEnvVars.test.js
+++ b/unitTests/config/configUtils-runtimeEnvVars.test.js
@@ -11,6 +11,7 @@ describe('configUtils - applyRuntimeEnvVarConfig', function () {
 	let mockConfigDoc;
 	let applyRuntimeEnvConfigStub;
 	let fsWriteFileSyncStub;
+	let fsRenameSyncStub;
 	let loggerStub;
 	let YAMLStub;
 
@@ -18,6 +19,7 @@ describe('configUtils - applyRuntimeEnvVarConfig', function () {
 		// Create stubs for dependencies
 		applyRuntimeEnvConfigStub = sinon.stub();
 		fsWriteFileSyncStub = sinon.stub();
+		fsRenameSyncStub = sinon.stub();
 		loggerStub = {
 			debug: sinon.stub(),
 			warn: sinon.stub(),
@@ -32,7 +34,7 @@ describe('configUtils - applyRuntimeEnvVarConfig', function () {
 
 		// Inject stubs
 		configUtils.__set__('logger', loggerStub);
-		configUtils.__set__('fs', { writeFileSync: fsWriteFileSyncStub });
+		configUtils.__set__('fs', { writeFileSync: fsWriteFileSyncStub, renameSync: fsRenameSyncStub });
 		configUtils.__set__('YAML', YAMLStub);
 
 		// Mock harperConfigEnvVars module
@@ -48,6 +50,7 @@ describe('configUtils - applyRuntimeEnvVarConfig', function () {
 		// Reset stubs
 		applyRuntimeEnvConfigStub.reset();
 		fsWriteFileSyncStub.reset();
+		fsRenameSyncStub.reset();
 		loggerStub.debug.reset();
 		loggerStub.warn.reset();
 		loggerStub.error.reset();
@@ -140,8 +143,13 @@ describe('configUtils - applyRuntimeEnvVarConfig', function () {
 
 		applyRuntimeEnvVarConfig(mockConfigDoc, '/test/config.yaml');
 
+		// Atomic write: writeFileSync writes to a temp path, then renameSync moves it over the target
 		assert.strictEqual(fsWriteFileSyncStub.called, true);
-		assert.strictEqual(fsWriteFileSyncStub.firstCall.args[0], '/test/config.yaml');
+		const writeTarget = fsWriteFileSyncStub.firstCall.args[0];
+		assert.ok(writeTarget.startsWith('/test/config.yaml.'), `expected temp path, got ${writeTarget}`);
+		assert.ok(writeTarget.endsWith('.tmp'), `expected .tmp suffix, got ${writeTarget}`);
+		assert.strictEqual(fsRenameSyncStub.calledOnce, true);
+		assert.deepStrictEqual(fsRenameSyncStub.firstCall.args, [writeTarget, '/test/config.yaml']);
 		assert.strictEqual(loggerStub.debug.called, true);
 		assert.match(loggerStub.debug.firstCall.args[0], /Config file updated/);
 

--- a/unitTests/config/configUtils.test.js
+++ b/unitTests/config/configUtils.test.js
@@ -136,6 +136,67 @@ describe('Test configUtils module', () => {
 		});
 	});
 
+	describe('Test atomicWriteFile function', () => {
+		const atomicWriteFile = config_utils_rw.__get__('atomicWriteFile');
+		const ATOMIC_TEST_DIR = path.join(DIRNAME, 'yaml');
+		const ATOMIC_TEST_PATH = path.join(ATOMIC_TEST_DIR, 'atomic-write-test.yaml');
+
+		before(() => {
+			fs.ensureDirSync(ATOMIC_TEST_DIR);
+		});
+
+		afterEach(() => {
+			try {
+				fs.unlinkSync(ATOMIC_TEST_PATH);
+			} catch {}
+			// Clean up any stray temp files from a failed run
+			for (const entry of fs.readdirSync(ATOMIC_TEST_DIR)) {
+				if (entry.startsWith('atomic-write-test.yaml.') && entry.endsWith('.tmp')) {
+					fs.unlinkSync(path.join(ATOMIC_TEST_DIR, entry));
+				}
+			}
+		});
+
+		it('writes content to the target path', () => {
+			atomicWriteFile(ATOMIC_TEST_PATH, 'rootPath: /tmp/hdb');
+			expect(fs.readFileSync(ATOMIC_TEST_PATH, 'utf8')).to.equal('rootPath: /tmp/hdb');
+		});
+
+		it('overwrites an existing file', () => {
+			fs.writeFileSync(ATOMIC_TEST_PATH, 'rootPath: /old');
+			atomicWriteFile(ATOMIC_TEST_PATH, 'rootPath: /new');
+			expect(fs.readFileSync(ATOMIC_TEST_PATH, 'utf8')).to.equal('rootPath: /new');
+		});
+
+		it('writes via temp file then rename so target is never truncated mid-write', () => {
+			const writeStub = sandbox.stub(fs, 'writeFileSync');
+			const renameStub = sandbox.stub(fs, 'renameSync');
+			try {
+				atomicWriteFile(ATOMIC_TEST_PATH, 'content');
+				expect(writeStub.calledOnce).to.be.true;
+				expect(renameStub.calledOnce).to.be.true;
+				const tempPath = writeStub.firstCall.args[0];
+				expect(tempPath).to.not.equal(ATOMIC_TEST_PATH);
+				expect(tempPath.startsWith(`${ATOMIC_TEST_PATH}.`)).to.be.true;
+				expect(tempPath.endsWith('.tmp')).to.be.true;
+				expect(path.dirname(tempPath)).to.equal(path.dirname(ATOMIC_TEST_PATH));
+				expect(renameStub.firstCall.args).to.deep.equal([tempPath, ATOMIC_TEST_PATH]);
+				expect(writeStub.calledBefore(renameStub)).to.be.true;
+			} finally {
+				writeStub.restore();
+				renameStub.restore();
+			}
+		});
+
+		it('leaves no temp file behind after a successful write', () => {
+			atomicWriteFile(ATOMIC_TEST_PATH, 'content');
+			const stragglers = fs
+				.readdirSync(path.dirname(ATOMIC_TEST_PATH))
+				.filter((e) => e.startsWith('atomic-write-test.yaml.') && e.endsWith('.tmp'));
+			expect(stragglers).to.be.empty;
+		});
+	});
+
 	describe('Test getDefaultConfig function', () => {
 		const expected_flat_default_config_obj = {
 			analytics_aggregateperiod: 60,

--- a/unitTests/config/rootConfigWatcher.test.js
+++ b/unitTests/config/rootConfigWatcher.test.js
@@ -3,7 +3,7 @@ const { RootConfigWatcher } = require('#src/config/RootConfigWatcher');
 const { tmpdir } = require('node:os');
 const { once } = require('node:events');
 const { join } = require('node:path');
-const { writeFileSync, mkdtempSync, rmSync } = require('node:fs');
+const { writeFileSync, mkdtempSync, rmSync, renameSync } = require('node:fs');
 const { writeFile } = require('node:fs/promises');
 const { replace, fake, restore, spy } = require('sinon');
 const configUtils = require('#js/config/configUtils');
@@ -55,5 +55,24 @@ describe('RootConfigWatcher', () => {
 			undefined,
 			'RootConfigWatcher should not have a config property after close() is called'
 		);
+	});
+
+	it('should detect changes written via temp-file + rename (atomic write)', async () => {
+		const initial = { foo: 'bar' };
+		writeFileSync(this.configFilePath, stringify(initial));
+		const configWatcher = new RootConfigWatcher();
+
+		const [readyValue] = await configWatcher.ready;
+		assert.deepEqual(readyValue, initial, 'watcher should pick up initial config');
+
+		const updated = { foo: 'baz' };
+		const tempPath = `${this.configFilePath}.${process.pid}.${Date.now()}.tmp`;
+		writeFileSync(tempPath, stringify(updated));
+		renameSync(tempPath, this.configFilePath);
+
+		const [changeValue] = await once(configWatcher, 'change');
+		assert.deepEqual(changeValue, updated, 'watcher should fire change after atomic rename');
+
+		configWatcher.close();
 	});
 });


### PR DESCRIPTION
## Summary

Replaces direct `fs.writeFileSync` in `config/configUtils.js` with a temp-file + `fs.renameSync` helper so concurrent readers never observe a truncated or empty file during a rewrite.

## Why

`fs.writeFileSync` opens the target with `O_TRUNC` and then writes — between those two calls the file is zero-length. If a reader reads in that window it gets an empty buffer; `YAML.parseDocument('')` returns a document with no top-level keys, and downstream `configValidator` then throws `rootPath config parameter is undefined` and the worker calls `process.exit(1)`.

This was hit in the field on a six-node cluster: one node's clone wedged with the worker logs:

```
[http/4] [warn]: Cannot apply runtime env config: rootPath not found in config
[http/4] [error]: Error initializing environment manager
[http/4] [error]: rootPath config parameter is undefined
```

The race window is opened by `cloneNode/cloneNode.ts` calling `cloneConfig()` (which rewrites the config file via `createConfigFile`) **after** `main()` has already started spawning HTTP workers — workers running `env.initSync()` can land their `readFileSync` exactly during the truncate-to-write interval. Since `process.exit` from a worker only kills that worker (not the parent), the clone process continued running but in a wedged state with no exit code, so the container never restarted.

## What changed

- New internal helper `atomicWriteFile(filePath, content)` in `config/configUtils.js` that writes to `<filePath>.<pid>.<timestamp>.tmp` and `fs.renameSync`s over the target.
- Replaced six writers: `createConfigFile`, `checkForUpdatedConfig`, `updateConfigValue`, `applyRuntimeEnvVarConfig`, `addConfig`, `deleteConfigFromFile`. The race exists for any concurrent reader, not only clone.
- Test coverage: 4 new unit tests for the helper itself; updated the existing `applyRuntimeEnvVarConfig` write test to verify the temp+rename pair.

## Areas to look at

- **Helper placement and signature.** Single internal function in `configUtils.js`, not exported. If you'd prefer it lives in a shared utility instead, easy to move.
- **Temp file naming** (`<filePath>.<pid>.<Date.now()>.tmp`). Same directory as target so the rename is atomic on the same filesystem. Pid+timestamp avoids collisions across processes/threads. Worth confirming this is acceptable on the deployment filesystems we care about.
- **The `addConfig` async → sync conversion.** Line 966 was `await fs.writeFile(...)`; now uses the sync helper. `addConfig` is in an async function but called rarely (config-add ops API), so blocking briefly is fine. Flag if you'd rather an async variant.
- **Out of scope, intentionally.** Did NOT touch `cloneNode.ts` ordering or `environmentManager.initSync`'s `process.exit`. The atomic write closes the actual race; reordering clone vs `main()` is a structural change with broader risk surface, and `process.exit` from a worker is a separate footgun worth its own PR.

## Test plan

- [ ] `npm run test:unit:config` passes locally (51 passing)
- [ ] Manually verify a fresh clone on a multi-node cluster no longer wedges