### PR TITLE
fix: Restore getRecordCount sampling early-exit on RocksDB

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -3252,8 +3252,10 @@ export function makeTable(options) {
 		}
 		static async getRecordCount(options?: any) {
 			// iterate through the metadata entries to exclude their count and exclude the deletion counts
-			const entryCount = primaryStore.getStats().entryCount;
-			const TIME_LIMIT = 1000 / 2; // one second time limit, enforced by seeing if we are halfway through at 500ms
+			const entryCount = isRocksDB
+				? (primaryStore.getDBIntProperty('rocksdb.estimate-num-keys') ?? 0)
+				: primaryStore.getStats().entryCount;
+			const TIME_LIMIT = options?.timeLimit ?? 1000 / 2; // one second time limit, enforced by seeing if we are halfway through at 500ms
 			const start = performance.now();
 			const halfway = Math.floor(entryCount / 2);
 			const exactCount = options?.exactCount;

--- a/unitTests/resources/getRecordCount.test.js
+++ b/unitTests/resources/getRecordCount.test.js
@@ -1,0 +1,48 @@
+require('../testUtils');
+const assert = require('node:assert/strict');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+
+describe('Table.getRecordCount', () => {
+	let RecordCountTable;
+
+	before(async function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		RecordCountTable = table({
+			table: 'RecordCountTable',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+		});
+
+		const N = 30;
+		let last;
+		for (let i = 0; i < N; i++) {
+			last = RecordCountTable.put({ id: 'k-' + i, name: 'name-' + i });
+		}
+		await last;
+	});
+
+	it('returns the exact count when the loop completes within the time budget', async function () {
+		const result = await RecordCountTable.getRecordCount();
+		assert.equal(result.recordCount, 30);
+		assert.equal(result.estimatedRange, undefined);
+	});
+
+	it('switches to the sampling estimator when the time budget is exhausted', async function () {
+		// Force the early-exit branch by giving the loop a 0ms time budget.
+		// This is the regression guard for the RocksDB entryCount bug: when
+		// `entryCount` was undefined on RocksDB stores, `halfway` became NaN
+		// and `entriesScanned < halfway` was always false, so the early-exit
+		// never fired and getRecordCount silently full-scanned every table.
+		// With a working entryCount we should drop into the sampling path
+		// after the first iteration and return an `estimatedRange`.
+		const result = await RecordCountTable.getRecordCount({ timeLimit: 0 });
+		assert.ok(
+			Array.isArray(result.estimatedRange),
+			'expected getRecordCount to engage the sampling estimator (estimatedRange should be set)'
+		);
+		assert.equal(result.estimatedRange.length, 2);
+	});
+});


### PR DESCRIPTION
## Summary

`Table.getRecordCount` reads `entryCount` from `primaryStore.getStats()`, which is an LMDB field name. On RocksDB stores `getStats()` returns keys like `rocksdb.estimate-num-keys` instead, so on every RocksDB table the lookup was `undefined`, `halfway = Math.floor(undefined / 2) = NaN`, and the `entriesScanned < halfway` guard on the 500ms early-exit was always false. The sampling estimator never engaged — every `describe_all` / `describe_table` silently iterated and decoded the entire table.

Reproduced live on a Harper Pro 5.0.10 instance with a 1.46M-row RocksDB table: `describe_all` consistently ~18-20s, returning exact counts every time. CPU profile during the call was dominated by `rocksdb-js next` and per-record msgpackr decoding inside the `getRecordCount` loop.

The fix branches on `isRocksDB` and reads `rocksdb.estimate-num-keys` via `getDBIntProperty`, the same pattern already used by `getSize` a few lines above.

## What changed

- `resources/Table.ts` — read `entryCount` correctly on RocksDB; accept `options.timeLimit` so the early-exit path is reachable deterministically from tests.
- `unitTests/resources/getRecordCount.test.js` — new regression suite. The `timeLimit: 0` test fails without the source fix and passes with it.

## Where to look

- The `?? 0` fallback in case `getDBIntProperty` ever returns null — keeps `halfway` numeric (0 means \"loop never breaks early on an empty table,\" same effective behavior as before for a 0-row table).
- `options.timeLimit` is an undocumented escape hatch added for testability. If we'd rather keep `getRecordCount`'s public surface untouched, I can move the test to use a different mechanism, but this seemed lowest-impact.
- I did not change the estimator math itself; the `entryCount` value also feeds the variance / CI calculation downstream, which was previously NaN-poisoned in the unreachable branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)