### PR TITLE
fix: cast env-var strings before comparing in updateConfigValue

### DIFF
--- a/config/configUtils.js
+++ b/config/configUtils.js
@@ -517,11 +517,17 @@ function updateConfigValue(
 	let schemasArgs;
 
 	// Don't do the update if the values are the same.
+	// Env vars arrive as strings ('true', '9925', '["x"]'); flatConfigObj has
+	// typed values (true, 9925, ['x']). Run the env value through castConfigValue
+	// — the same coercion the write path applies below — and deep-compare. Plain
+	// loose equality (the previous approach) handled string<->number but not
+	// string<->boolean or string<->array, which made the check fire spuriously
+	// every boot for any non-string env var.
 	if (parsedArgs && flatConfigObj) {
 		let doUpdate = false;
 		for (const arg in parsedArgs) {
-			// Using no-strict here because we might need to compare string to number
-			if (parsedArgs[arg] != flatConfigObj[arg.toLowerCase()]) {
+			const castedValue = castConfigValue(arg, parsedArgs[arg]);
+			if (!_.isEqual(castedValue, flatConfigObj[arg.toLowerCase()])) {
 				doUpdate = true;
 				break;
 			}

--- a/unitTests/config/configUtils.test.js
+++ b/unitTests/config/configUtils.test.js
@@ -710,6 +710,61 @@ describe('Test configUtils module', () => {
 			expect(logger_trace_stub.called).to.be.true;
 			expect(logger_trace_stub.args[0][0]).to.equal('No changes detected in config parameters, skipping update');
 		});
+
+		it('Test string env values matching typed config values are detected as equal', () => {
+			// Env vars are always strings, but flatConfigObj has typed values.
+			// Without casting, 'true' != true would fire updates on every boot.
+			config_utils_rw.__set__('flatConfigObj', {
+				logging_stdstreams: true,
+				logging_rotation_compress: false,
+				operationsapi_network_port: 9925,
+				http_corsaccesslist: ['https://example.com'],
+			});
+
+			config_utils_rw.updateConfigValue(undefined, undefined, {
+				logging_stdstreams: 'true',
+				logging_rotation_compress: 'false',
+				operationsapi_network_port: '9925',
+				http_corsaccesslist: '["https://example.com"]',
+			});
+
+			expect(logger_trace_stub.called).to.be.true;
+			expect(logger_trace_stub.args[0][0]).to.equal('No changes detected in config parameters, skipping update');
+		});
+
+		it('Test string env value differing from typed config value triggers update', () => {
+			const set_in_stub = sandbox.stub();
+			const get_in_stub = sandbox.stub().callsFake((path) => {
+				if (Array.isArray(path) && path[0] === 'rootPath') return HDB_ROOT;
+				return undefined;
+			});
+			const fake_config_doc = { setIn: set_in_stub, getIn: get_in_stub, errors: [] };
+			const parse_yaml_doc_stub = sandbox.stub().returns(fake_config_doc);
+			const parse_yaml_doc_rw = config_utils_rw.__set__('parseYamlDoc', parse_yaml_doc_stub);
+			const get_config_value_stub = sandbox.stub().returns(HDB_ROOT);
+			const get_config_value_rw = config_utils_rw.__set__('getConfigValue', get_config_value_stub);
+			const fs_exists_stub = sandbox.stub(fs, 'existsSync').returns(true);
+			const atomic_write_stub = sandbox.stub();
+			const atomic_write_rw = config_utils_rw.__set__('atomicWriteFile', atomic_write_stub);
+
+			try {
+				config_utils_rw.__set__('flatConfigObj', { logging_stdstreams: true });
+
+				config_utils_rw.updateConfigValue(undefined, undefined, { logging_stdstreams: 'false' });
+
+				expect(
+					logger_trace_stub.args.some(
+						(callArgs) => callArgs[0] === 'No changes detected in config parameters, skipping update'
+					)
+				).to.be.false;
+				expect(set_in_stub.called).to.be.true;
+			} finally {
+				parse_yaml_doc_rw();
+				get_config_value_rw();
+				fs_exists_stub.restore();
+				atomic_write_rw();
+			}
+		});
 	});
 
 	describe('Test castConfigValue function', () => {


### PR DESCRIPTION
## Summary

Fix `updateConfigValue`'s "skip if no changes" check (`config/configUtils.js:516`) to cast env-var strings to typed values before comparing. Without this, every Harper restart rewrites the config file (and creates a backup) for any deployment that uses a boolean or array env var.

## Why

Env vars arrive in `process.env` as strings — there is no boolean/number env var at the OS level. The check was using loose equality:

```js
if (parsedArgs[arg] != flatConfigObj[arg.toLowerCase()]) {
```

Loose equality coerces string↔number cleanly (`'9925' == 9925` → true) but **not** string↔boolean (`'true' != true` because `'true'` becomes `NaN`, `true` becomes `1`, and `NaN != 1`) and **not** string↔array. Any deployment with a boolean or array config env var trips the check on every boot.

This affects the default Harper Dockerfile, which sets `LOGGING_STDSTREAMS=true`. Every Harper container is rewriting its config and creating a backup on every restart, even with no actual config change. Same md5sum across N backups — observed in the field.

This was also the trigger for the partial-config corruption fixed in #493: every restart was opening the truncate window for `fs.writeFileSync` while concurrent readers were starting up. With #493's atomic write, the corruption no longer occurs, but the spurious writes and backups still happen. This PR stops them.

## What changed

- `config/configUtils.js:511-526`: cast `parsedArgs[arg]` through `castConfigValue` (the same coercion already used by the write path 80 lines below) and deep-compare with `_.isEqual`.
- `unitTests/config/configUtils.test.js`: added two tests — one verifying string env values matching typed config values are detected as equal (the fix), one verifying genuine differences still trigger an update (no regression).

## Areas to look at

- **The cast covers all the cases loose-equal handled, plus the ones it didn't.** Walked through edge cases (`'' vs null`, `'0' vs null`, `'3d' vs '3d'`, `null vs undefined`) and didn't find a regression — the new comparison agrees with `castConfigValue`, which is what the actual write path uses anyway.
- **`castConfigValue` ignores its `param` argument** (pre-existing — there's a TS6133 diagnostic on it). Passing `arg` works because it's never read; if someone later wires `param` up, this comparison call site would need to use the canonical `CONFIG_PARAM_MAP[arg.toLowerCase()]` instead.
- **Out of scope, intentionally.** Did NOT touch the duplicate `initialize()` calls (`launch()` runs it before forking, daemon child likely runs it again). With this fix, the second call sees no diff and skips cleanly. If duplicate writes still occur after this lands, that's a separate bug.

## Test plan

- [ ] `npm run test:unit:config` passes locally (130 passing)
- [ ] Manually verify a Harper deploy with the stock Dockerfile no longer creates a new backup on every restart