### PR TITLE
Fix release notes step failing when grep filters out all commits

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -89,9 +89,9 @@ jobs:
             echo "## What's Changed"
             echo ""
             if [ -n "$PREV_TAG" ]; then
-              git log --format="- %s" "${PREV_TAG}..HEAD" | grep -v "^- Release v"
+              git log --format="- %s" "${PREV_TAG}..HEAD" | { grep -v "^- Release v" || true; }
             else
-              git log --format="- %s" | grep -v "^- Release v" | head -50
+              git log --format="- %s" | { grep -v "^- Release v" || true; } | head -50
             fi
             echo ""
             if [ -n "$PREV_TAG" ]; then


### PR DESCRIPTION
## Summary

`grep -v` exits 1 when no lines match — e.g. when the only commit between two release tags is the `Release vX.Y.Z` version bump (which the filter removes). Under `bash -e` the release notes step aborts with exit code 1, breaking the GitHub release.

Wrap the grep in `{ grep -v ... || true; }` so an all-filtered result is treated as empty rather than failure.

This was hit by harper-pro v5.0.14 release (https://github.com/HarperFast/harper-pro/actions/runs/25703350736/job/75468586450); applying the same fix here for symmetry.

## Test plan
- [ ] Tag a release where the only commit since the previous tag is the version bump and confirm the workflow succeeds with empty notes (just the Full Changelog link)