### PR TITLE
fix: make atomicWriteFile temp path unique across worker threads

### DIFF
--- a/config/configUtils.js
+++ b/config/configUtils.js
@@ -7,6 +7,8 @@ const { configValidator } = require('../validation/configValidator.js');
 const fs = require('fs-extra');
 const YAML = require('yaml');
 const path = require('path');
+const { threadId } = require('node:worker_threads');
+const { randomBytes } = require('node:crypto');
 const isNumber = require('is-number');
 const PropertiesReader = require('properties-reader');
 const _ = require('lodash');
@@ -89,9 +91,11 @@ function getConfigPath(param) {
 	return path.resolve(rootPath, value);
 }
 
-// Write atomically via temp file + rename so readers don't observe a truncated/empty file
+// Write atomically via temp file + rename so readers don't observe a truncated/empty file.
+// Temp path includes randomness so two worker threads in the same process (same pid) writing
+// in the same millisecond can't collide on the temp name and then race the rename.
 function atomicWriteFile(filePath, content) {
-	const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+	const tempPath = `${filePath}.${process.pid}.${threadId}.${randomBytes(4).toString('hex')}.tmp`;
 	fs.writeFileSync(tempPath, content);
 	fs.renameSync(tempPath, filePath);
 }

--- a/unitTests/config/configUtils.test.js
+++ b/unitTests/config/configUtils.test.js
@@ -195,6 +195,24 @@ describe('Test configUtils module', () => {
 				.filter((e) => e.startsWith('atomic-write-test.yaml.') && e.endsWith('.tmp'));
 			expect(stragglers).to.be.empty;
 		});
+
+		it('generates a unique temp path on every call so concurrent writers cannot collide', () => {
+			// Worker threads share process.pid, so a pid+timestamp scheme can collide within
+			// the same millisecond. This guards against that regression.
+			const writeStub = sandbox.stub(fs, 'writeFileSync');
+			const renameStub = sandbox.stub(fs, 'renameSync');
+			try {
+				const tempPaths = new Set();
+				for (let i = 0; i < 100; i++) {
+					atomicWriteFile(ATOMIC_TEST_PATH, 'content');
+					tempPaths.add(writeStub.lastCall.args[0]);
+				}
+				expect(tempPaths.size).to.equal(100);
+			} finally {
+				writeStub.restore();
+				renameStub.restore();
+			}
+		});
 	});
 
 	describe('Test getDefaultConfig function', () => {

--- a/unitTests/config/configUtils.test.js
+++ b/unitTests/config/configUtils.test.js
@@ -196,11 +196,13 @@ describe('Test configUtils module', () => {
 			expect(stragglers).to.be.empty;
 		});
 
-		it('generates a unique temp path on every call so concurrent writers cannot collide', () => {
-			// Worker threads share process.pid, so a pid+timestamp scheme can collide within
-			// the same millisecond. This guards against that regression.
+		it('generates a unique temp path even when pid and timestamp are identical', () => {
+			// Worker threads share process.pid, and worker arrivals cluster within the
+			// same millisecond — a pid+timestamp scheme would collide. Pin Date.now()
+			// so this test fails if uniqueness ever stops depending on randomness.
 			const writeStub = sandbox.stub(fs, 'writeFileSync');
 			const renameStub = sandbox.stub(fs, 'renameSync');
+			const dateStub = sandbox.stub(Date, 'now').returns(1234567890);
 			try {
 				const tempPaths = new Set();
 				for (let i = 0; i < 100; i++) {
@@ -211,6 +213,7 @@ describe('Test configUtils module', () => {
 			} finally {
 				writeStub.restore();
 				renameStub.restore();
+				dateStub.restore();
 			}
 		});
 	});


### PR DESCRIPTION
## Summary

Fix `atomicWriteFile` (introduced in #493) so the temp file name doesn't collide between concurrent worker threads in the same process.

## Why

#493's `atomicWriteFile` generated temp paths from `\${filePath}.\${process.pid}.\${Date.now()}.tmp`. That's not unique enough in Harper's deployment shape:

- In Docker, the main Harper process is pid 1.
- Harper uses `worker_threads`, not `child_process` — workers share `process.pid`.
- Multiple workers spawning together each run `env.initSync` → `applyRuntimeEnvVarConfig` → `atomicWriteFile` (when `HARPER_SET_CONFIG`/`HARPER_DEFAULT_CONFIG` is set) within the same millisecond.

Sequence that breaks:

1. Worker A: `writeFileSync(temp)` → file exists
2. Worker B: `writeFileSync(temp)` → still exists (overwrites)
3. Worker A: `renameSync(temp, target)` → renames → temp gone
4. Worker B: `renameSync(temp, target)` → **ENOENT**

Reported in the field as:

```
[http/1] [error]: Failed to write config file after applying runtime env vars:
ENOENT: no such file or directory, rename '/home/harperdb/harper/harper-config.yaml.1.1778606941110.tmp'
  -> '/home/harperdb/harper/harper-config.yaml'
```

The `.1.` in the temp name is the pid (1), confirming the diagnosis.

## What changed

- Temp path now includes `threadId` (unique per worker thread in the process) and 4 random bytes: `\${filePath}.\${process.pid}.\${threadId}.\${randomHex}.tmp`. Random bytes alone would be sufficient; pid+threadId are included for log-debuggability.
- Added a regression test asserting 100 sequential calls produce 100 distinct temp paths.
- Imports `threadId` from `node:worker_threads` and `randomBytes` from `node:crypto` — both have precedent elsewhere in the codebase (`server/threads/threadServer.js:3`, `security/keys.js:8`).

## Areas to look at

- **Out of scope, intentionally.** Did not address the upstream wastefulness: `applyRuntimeEnvVarConfig` runs once per worker on every startup if `HARPER_SET_CONFIG` is set, and each call writes the config file even when nothing changed. With this fix the writes serialize safely; the writes themselves being redundant is a separate concern (likely related to #499's comparison/skip logic, but worth investigating whether worker-context writes should happen at all).
- **Random bytes alone would suffice.** 4 bytes = 2^32 = ~4B possible suffixes; collision probability is effectively zero at our write frequency. pid+threadId are included so operators can correlate failures back to specific threads in logs.

## Test plan

- [ ] `npm run test:unit:config` passes locally (41 atomicWriteFile tests including new regression)
- [ ] Manually verify a Harper deployment with `HARPER_SET_CONFIG` and 8+ HTTP threads no longer logs `ENOENT ... rename` on startup