### PR TITLE
fix: register operations in worker threads so replication WS can dispatch them

### DIFF
--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -116,6 +116,16 @@ export const TRUSTED_RESOURCE_PLUGINS = {
 };
 if (isMainThread) {
 	TRUSTED_RESOURCE_PLUGINS.operationsApi = require('../server/operationsServer');
+} else {
+	// The HTTP operations API itself only binds in the main thread, but worker threads still
+	// dispatch operations — most notably, the replication WebSocket handler in workers receives
+	// inter-node operations like `add_node_back` and calls `server.operation(...)`. That requires
+	// `server.operation` / `server.registerOperation` to be wired up here too, and the operation
+	// function map to be initialized, BEFORE component plugins (replication, etc.) load and call
+	// `server.registerOperation?.({...})` at their module top level. Requiring serverUtilities
+	// directly (rather than the full operationsServer) avoids binding the fastify HTTP layer in
+	// workers while still installing the dispatch machinery.
+	require('../server/serverHelpers/serverUtilities');
 }
 
 for (const { name, packageIdentifier } of getEnvBuiltInComponents()) {


### PR DESCRIPTION
## Summary

Re-enable `server.registerOperation` and the operation function map in worker threads so plugin operations (e.g. replication's `add_node_back`) are actually registered. After 40600bfc4 moved the HTTP operations API to main-thread-only, `server.registerOperation` was no longer set up in worker threads — module-level calls like `server.registerOperation?.({...})` in `setNode.ts` silently no-op'd because the optional-chain short-circuits when the method is undefined.

This broke inter-node cluster setup. `add_node` opens a WebSocket to the target node's replication port (9933) and sends `add_node_back`. The WS handler runs in a worker thread and dispatches via `server.operation()`, which looks up in the operation function map. Since `add_node_back` was never registered in the worker, every cluster setup attempt fails with:

> Operation 'add_node_back' not found and connection was required to sign certificate

This blocks `fullyConnectedReplication.test.mjs`, `replicationLoad.test.mjs`, and anything else exercising multi-node clustering.

## Fix

In `components/componentLoader.ts`, when not on the main thread, eagerly require `serverHelpers/serverUtilities` (which installs `server.operation`, `server.registerOperation`, and initializes the operation function map). This does NOT load the fastify HTTP layer — that stays main-thread-only per 40600bfc4.

## Verification

Verified locally:
- `fullyConnectedReplication.test.mjs` — 12/12 pass (6 RocksDB + 6 LMDB; previously 0/12).
- `replicationLoad.test.mjs` `connect nodes` and `Deploy app and test replication` now pass; remaining failures are unrelated concurrency / many-database issues.
- New `issue135-replicated-search-after-restart.test.mjs` in harper-pro (Scenario B) now runs successfully.

## Review attention

The conditional require approach mirrors the existing main-thread-only operationsServer require. It's a minimal change but the failure mode (silent no-op via `?.`) is exactly the same class of issue, so the same fix shape should be considered for any future plugin that uses `server.registerOperation` from a worker-loaded module.

🤖 Generated with Claude Sonnet 4.6 (1M context)