### PR TITLE
feat: harper login and logout

### DIFF
--- a/bin/cliCredentials.ts
+++ b/bin/cliCredentials.ts
@@ -1,0 +1,133 @@
+import { getHomeDir } from '../utility/common_utils.ts';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ownerRWDenyAllOthers = 0o600;
+
+interface TargetedCredentials {
+	last_target: string | null;
+	targets: {
+		[target: string]: Tokens;
+	};
+}
+
+interface Tokens {
+	operation_token: string;
+	refresh_token: string;
+}
+
+/**
+ * Normalizes a target operations API URL to a canonical form (with trailing slash).
+ */
+export function normalizeTarget(target: string): string {
+	if (!target) return target;
+	let normalized = target;
+	if (!normalized.startsWith('http://') && !normalized.startsWith('https://')) {
+		normalized = 'https://' + normalized;
+	}
+	try {
+		const url = new URL(normalized);
+		if (!url.port && !normalized.includes(':', normalized.indexOf('://') + 3)) {
+			url.port = '9925';
+		}
+		normalized = url.toString();
+	} catch {
+		// If it's not a valid URL yet, we'll let it be handled later or it will fail
+	}
+	if (!normalized.endsWith('/')) {
+		normalized += '/';
+	}
+	return normalized;
+}
+
+/**
+ * Loads the JWT credentials from the ~/.harperdb/credentials.json file.
+ */
+export function loadCredentials(): TargetedCredentials {
+	const credentialsFile = getCredentialsFile();
+	try {
+		return JSON.parse(fs.readFileSync(credentialsFile, 'utf8'));
+	} catch (err) {
+		if (err.code !== 'ENOENT') {
+			throw new Error(`Error reading credentials file: ${err.message}`);
+		}
+	}
+	return {
+		last_target: null,
+		targets: {},
+	};
+}
+
+/**
+ * Saves the JWT credentials to the ~/.harperdb/credentials.json file.
+ */
+export function saveCredentials(target: string, tokens: Tokens): void {
+	if (!target) {
+		throw new Error('Target is required to save credentials.');
+	}
+
+	target = normalizeTarget(target);
+	const allCredentials = loadCredentials();
+
+	allCredentials.targets ||= {};
+	allCredentials.targets[target] = tokens;
+	allCredentials.last_target = target;
+
+	try {
+		fs.mkdirSync(getCredentialsDir(), { recursive: true });
+		fs.writeFileSync(getCredentialsFile(), JSON.stringify(allCredentials, null, 2), { mode: ownerRWDenyAllOthers });
+	} catch (err) {
+		throw new Error(`Error saving credentials file: ${err.message}`);
+	}
+}
+
+/**
+ * Deletes the credentials for a specific target or all if no target provided.
+ */
+export function clearCredentials(target: string): void {
+	const credentialsFile = getCredentialsFile();
+	if (target) {
+		target = normalizeTarget(target);
+		const allCredentials = loadCredentials();
+		if (allCredentials && allCredentials.targets) {
+			if (allCredentials.targets[target]) {
+				delete allCredentials.targets[target];
+			} else {
+				console.error(`No credentials found for ${target}`);
+				process.exit(1);
+			}
+
+			if (allCredentials.last_target === target) {
+				allCredentials.last_target = null;
+			}
+			try {
+				fs.writeFileSync(credentialsFile, JSON.stringify(allCredentials, null, 2), {
+					mode: ownerRWDenyAllOthers,
+				});
+				console.log(`Logged out from ${target}`);
+			} catch (err) {
+				throw new Error(`Error clearing credentials file: ${err.message}`);
+			}
+		} else {
+			console.error(`No credentials found for ${target}`);
+			process.exit(1);
+		}
+	} else if (fs.existsSync(credentialsFile)) {
+		try {
+			fs.unlinkSync(credentialsFile);
+			console.log('Logged out from all targets');
+		} catch (err) {
+			throw new Error(`Error clearing credentials file: ${err.message}`);
+		}
+	} else {
+		console.log('No credentials found to clear.');
+	}
+}
+
+function getCredentialsFile(): string {
+	return path.join(getHomeDir(), '.harperdb', 'credentials.json');
+}
+
+function getCredentialsDir(): string {
+	return path.join(getHomeDir(), '.harperdb');
+}

--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+import { loadCredentials, saveCredentials, normalizeTarget } from './cliCredentials.ts';
+import { isJWTExpired } from '../security/tokenAuthentication.ts';
 import * as envMgr from '../utility/environment/environmentManager.ts';
 envMgr.initSync();
 import * as terms from '../utility/hdbTerms.ts';
@@ -57,14 +59,31 @@ function buildRequest(): any {
 }
 
 /**
+ * Resolves the target URL from various sources.
+ * @param {Object} req The request object.
+ * @param {Object} allCredentials Stored credentials.
+ * @returns {string|null} The resolved target URL.
+ */
+function resolveTarget(req, allCredentials) {
+	return (
+		req.target ||
+		process.env.HARPER_CLI_TARGET ||
+		process.env.CLI_TARGET ||
+		(allCredentials && allCredentials.last_target)
+	);
+}
+
+/**
  * Using a unix domain socket will send a request to hdb operations API server
  * @param req
+ * @param skipResponseLog By default, the response is logged to the console. Set this to true to skip logging it, which can be useful for sensitive responses like login calls!
  * @returns {Promise<void>}
  */
-async function cliOperations(req: any) {
-	if (!req.target) {
-		req.target = process.env.HARPER_CLI_TARGET || process.env.CLI_TARGET;
-	}
+async function cliOperations(req: any, skipResponseLog = false) {
+	require('dotenv').config();
+
+	const allCredentials = loadCredentials();
+	req.target = normalizeTarget(resolveTarget(req, allCredentials));
 	let target;
 	if (req.target) {
 		try {
@@ -76,6 +95,7 @@ async function cliOperations(req: any) {
 				throw error;
 			}
 		}
+		const resolvedTarget = req.target;
 		target = {
 			protocol: target.protocol,
 			hostname: target.hostname,
@@ -83,8 +103,9 @@ async function cliOperations(req: any) {
 			username: req.username || target.username || process.env.HARPER_CLI_USERNAME || process.env.CLI_TARGET_USERNAME,
 			password: req.password || target.password || process.env.HARPER_CLI_PASSWORD || process.env.CLI_TARGET_PASSWORD,
 			rejectUnauthorized: req.rejectUnauthorized,
+			resolvedTarget,
 		};
-		console.error(`Connecting to ${target.protocol}//${target.hostname}:${target.port}`);
+		console.error(`Connecting to ${resolvedTarget}`);
 	} else {
 		// if we aren't doing a targeted operation (like deploy), we initialize the config and verify that local harper
 		// is running and that we can communicate with it.
@@ -110,6 +131,47 @@ async function cliOperations(req: any) {
 		options.headers = { 'Content-Type': 'application/json' };
 		if (target?.username) {
 			options.headers.Authorization = `Basic ${Buffer.from(`${target.username}:${target.password}`).toString('base64')}`;
+		} else if (allCredentials) {
+			let tokens = null;
+			let lookupKey = null;
+			if (target && allCredentials.targets) {
+				lookupKey = target.resolvedTarget;
+				tokens = allCredentials.targets[lookupKey] ?? null;
+			}
+
+			if (tokens?.operation_token) {
+				if (tokens.refresh_token && isJWTExpired(tokens.operation_token)) {
+					console.error('Operation token expired, attempting to refresh...');
+					try {
+						const refreshOptions = { ...options };
+						refreshOptions.headers = { ...options.headers, Authorization: `Bearer ${tokens.refresh_token}` };
+						const refreshResponse = await httpRequest(refreshOptions, {
+							operation: 'refresh_operation_token',
+						});
+						if (refreshResponse.statusCode === 200) {
+							const refreshData = JSON.parse(refreshResponse.body);
+							if (refreshData.operation_token) {
+								tokens.operation_token = refreshData.operation_token;
+								saveCredentials(lookupKey || target?.resolvedTarget, {
+									operation_token: tokens.operation_token,
+									refresh_token: tokens.refresh_token,
+								});
+								console.error('Operation token refreshed successfully.');
+								// Update the original request's authorization header with the new token
+								options.headers.Authorization = `Bearer ${tokens.operation_token}`;
+							}
+						} else if (refreshResponse.statusCode === 401) {
+							console.error('Refresh token expired or invalid. Please run harper login again.');
+							process.exit(1);
+						} else {
+							console.error(`Failed to refresh operation token: ${refreshResponse.statusCode}`);
+						}
+					} catch (refreshErr) {
+						console.error(`Error refreshing operation token: ${refreshErr.message}`);
+					}
+				}
+				options.headers.Authorization = `Bearer ${tokens.operation_token}`;
+			}
 		}
 		if (req.cborEncode) {
 			options.headers['Content-Type'] = 'application/cbor';
@@ -141,7 +203,13 @@ async function cliOperations(req: any) {
 			process.exit(1);
 		}
 
-		console.log(responseLog);
+		if (!skipResponseLog) {
+			console.log(responseLog);
+		}
+
+		if (target) {
+			responseData.resolvedTarget = target.resolvedTarget;
+		}
 
 		return responseData;
 	} catch (err) {

--- a/bin/harper.ts
+++ b/bin/harper.ts
@@ -25,6 +25,8 @@ copy-db <source> <target>       - Copies a database from source path to target p
 dev <path>                      - Run the application in dev mode with debugging, foreground logging, no auth
 install                         - Install harperdb
 <api-operation> <param>=<value> - Run an API operation and return result to the CLI, not all operations are supported
+login [target] [username]       - Login to a remote or local Harper instance
+logout [target]                 - Logout from Harper and clear saved JWT
 register                        - Register harperdb
 renew-certs                     - Generate a new set of self-signed certificates
 restart                         - Restart the harperdb background process
@@ -81,6 +83,17 @@ async function harper() {
 				.then(() => 'Your instance of Harper is up to date!');
 		case SERVICE_ACTIONS_ENUM.STATUS:
 			return (require('./status').default || require('./status'))();
+		case SERVICE_ACTIONS_ENUM.LOGIN: {
+			const target = process.argv[3];
+			const username = process.argv[4];
+			const { login } = require('./login');
+			return login(target, username);
+		}
+		case SERVICE_ACTIONS_ENUM.LOGOUT: {
+			const target = process.argv[3];
+			const { logout } = require('./logout');
+			return logout(target);
+		}
 		case SERVICE_ACTIONS_ENUM.RENEWCERTS:
 			return require('../security/keys')
 				.renewSelfSigned()

--- a/bin/login.ts
+++ b/bin/login.ts
@@ -1,0 +1,168 @@
+import chalk from 'chalk';
+import dotenv from 'dotenv';
+import fs from 'node:fs';
+import path from 'node:path';
+import readline from 'node:readline/promises';
+import { saveCredentials, normalizeTarget } from './cliCredentials.ts';
+import { cliOperations } from './cliOperations.ts';
+
+/**
+ * Executes the login command.
+ */
+export async function login(targetArg: string, usernameArg: string): Promise<void> {
+	dotenv.config();
+
+	const rl = readline.createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+
+	try {
+		console.log(chalk.cyan('\nHarper login'));
+		console.log(
+			chalk.gray(
+				'Harper apps can be deployed to Fabric for free, where one runtime can house your app, database, cache, and messaging.'
+			)
+		);
+		console.log(chalk.gray('https://fabric.harper.fast/\n'));
+		console.log(
+			chalk.gray('If you create a cluster, you can enter your credentials here. They will be exchanged for a JWT from')
+		);
+		console.log(chalk.gray('your cluster, which will be saved inside ~/.harperdb/credentials.json\n'));
+
+		const defaultTarget = process.env.HARPER_CLI_TARGET || process.env.CLI_TARGET;
+		let target = targetArg || defaultTarget;
+		let skipTargetPrompt = !!targetArg;
+
+		if (!skipTargetPrompt) {
+			if (defaultTarget) {
+				const input = await rl.question(`Cluster Target [${defaultTarget}]: `);
+				if (input.trim()) {
+					target = input.trim();
+				}
+			} else {
+				target = await rl.question(`Cluster Target URL: `);
+			}
+		}
+
+		if (!target) {
+			console.error(chalk.red('Target URL is required.'));
+			process.exit(1);
+		}
+
+		target = normalizeTarget(target);
+
+		let targetUsername = usernameArg;
+		if (!targetUsername) {
+			if (process.env.CLI_TARGET_USERNAME) {
+				targetUsername = process.env.CLI_TARGET_USERNAME;
+				console.log(chalk.gray(`Using username from CLI_TARGET_USERNAME environment variable: ${targetUsername}`));
+			} else if (process.env.HARPER_CLI_USERNAME) {
+				targetUsername = process.env.HARPER_CLI_USERNAME;
+				console.log(chalk.gray(`Using username from HARPER_CLI_USERNAME environment variable: ${targetUsername}`));
+			} else {
+				targetUsername = await rl.question(`Cluster Username: `);
+			}
+		}
+
+		let targetPassword = process.env.CLI_TARGET_PASSWORD || process.env.HARPER_CLI_PASSWORD;
+
+		if (targetPassword) {
+			const envVarName = process.env.CLI_TARGET_PASSWORD ? 'CLI_TARGET_PASSWORD' : 'HARPER_CLI_PASSWORD';
+			console.log(chalk.gray(`Using password from ${envVarName} environment variable.`));
+		} else {
+			targetPassword = await new Promise((resolve) => {
+				process.stdout.write(`Cluster Password: `);
+				process.stdin.setRawMode(true);
+				process.stdin.resume();
+				let password = '';
+				const onData = (data: Buffer) => {
+					for (let i = 0; i < data.length; i++) {
+						const char = data[i];
+						if (char === 13 || char === 10) {
+							// \r or \n
+							process.stdout.write('\n');
+							cleanup();
+							resolve(password);
+							return;
+						} else if (char === 3) {
+							// Ctrl+C
+							process.stdout.write('\n');
+							cleanup();
+							process.exit(1);
+						} else if (char === 8 || char === 127) {
+							// Backspace
+							if (password.length > 0) {
+								password = password.slice(0, -1);
+								process.stdout.write('\b \b');
+							}
+						} else {
+							password += data.toString('utf-8', i, i + 1);
+							process.stdout.write('*');
+						}
+					}
+				};
+
+				const cleanup = () => {
+					process.stdin.removeListener('data', onData);
+					process.stdin.setRawMode(false);
+					process.stdin.pause();
+				};
+
+				process.stdin.on('data', onData);
+			});
+		}
+
+		if (!targetUsername || !targetPassword) {
+			console.error('Username and password are required.');
+			process.exit(1);
+		}
+
+		const req = {
+			operation: 'create_authentication_tokens',
+			username: targetUsername,
+			password: targetPassword,
+			target,
+		};
+
+		const response = await cliOperations(req, true);
+
+		if (response && response.operation_token) {
+			const resolvedTarget = response.target || req.target || response.resolvedTarget || target;
+			try {
+				saveCredentials(resolvedTarget, {
+					operation_token: response.operation_token,
+					refresh_token: response.refresh_token,
+				});
+			} catch (err) {
+				console.error(chalk.red(err.message));
+				process.exit(1);
+			}
+
+			// If CLI_TARGET is not in process.env before we started (meaning it's not in .env or other env vars),
+			// and we just logged in with a target, let's consider adding it to .env
+			const envPath = path.join(process.cwd(), '.env');
+			if (fs.existsSync(envPath)) {
+				const envConfig = dotenv.parse(fs.readFileSync(envPath));
+
+				if (
+					!envConfig.CLI_TARGET &&
+					!envConfig.HARPER_CLI_TARGET &&
+					!process.env.CLI_TARGET &&
+					!process.env.HARPER_CLI_TARGET
+				) {
+					const envLine = `\nHARPER_CLI_TARGET=${resolvedTarget}\n`;
+					fs.appendFileSync(envPath, envLine);
+					console.log(`Added HARPER_CLI_TARGET to .env`);
+				}
+			}
+
+			console.log(`Successfully logged in to ${resolvedTarget} and saved credentials.`);
+			process.exit(0);
+		} else {
+			throw new Error('Failed to retrieve authentication tokens.');
+		}
+	} finally {
+		rl.close();
+	}
+}

--- a/bin/logout.ts
+++ b/bin/logout.ts
@@ -1,0 +1,11 @@
+import dotenv from 'dotenv';
+import { clearCredentials } from './cliCredentials.ts';
+
+/**
+ * Executes the logout command.
+ */
+export async function logout(target?: string): Promise<void> {
+	dotenv.config();
+
+	clearCredentials(target);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -344,7 +344,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1042.0.tgz",
 			"integrity": "sha512-z3Ibstr7ckDT10dz/nkk4+93LitrrO49Oq563/JoFHt30ZNodPBCfSxysKcelLyi/lNVF1MZrhZZfikUAG3iNQ==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha1-browser": "5.2.0",
 				"@aws-crypto/sha256-browser": "5.2.0",
@@ -2252,7 +2251,6 @@
 			"version": "8.44.0",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.44.0",
 				"@typescript-eslint/types": "8.44.0",
@@ -2967,7 +2965,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2981,7 +2978,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2995,7 +2991,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3009,7 +3004,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3021,7 +3015,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3035,7 +3028,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3514,6 +3506,7 @@
 			"integrity": "sha512-GW2yqqOTzdz3K6z0XpPO1EjLzOw0kclmAcLeW6cBt0DYM7ZNLRKanpzXxaSXkePpo4ZYMWhddE4WpSWG8e/QaQ==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
@@ -4535,7 +4528,6 @@
 		"node_modules/@types/node": {
 			"version": "25.4.0",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.18.0"
 			}
@@ -4630,7 +4622,6 @@
 			"integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.59.0",
 				"@typescript-eslint/types": "8.59.0",
@@ -4851,7 +4842,6 @@
 			"version": "8.16.0",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -5004,6 +4994,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5015,6 +5006,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5331,6 +5323,32 @@
 			"version": "1.1.2",
 			"license": "MIT"
 		},
+		"node_modules/bufferutil": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+			"integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"node-gyp-build": "^4.3.0"
+			},
+			"engines": {
+				"node": ">=6.14.2"
+			}
+		},
+		"node_modules/bufferutil/node_modules/node-gyp-build": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+			"license": "MIT",
+			"optional": true,
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
+			}
+		},
 		"node_modules/bytestreamjs": {
 			"version": "2.0.1",
 			"license": "BSD-3-Clause",
@@ -5429,7 +5447,6 @@
 			"version": "6.2.2",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -5567,6 +5584,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"is-regexp": "^1.0.0",
 				"is-supported-regexp-flag": "^1.0.0"
@@ -6087,7 +6105,6 @@
 			"version": "9.39.4",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -6146,7 +6163,6 @@
 			"version": "10.1.8",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -6369,6 +6385,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"clone-regexp": "^1.0.0"
 			},
@@ -7042,7 +7059,6 @@
 		"node_modules/graphql": {
 			"version": "16.13.2",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
 			}
@@ -7108,6 +7124,7 @@
 			"integrity": "sha512-RRXMLbbdymiZsHOeg5b+DShzsMvVvkgsG9690BBCc7tzIpDb0CT7EgWEQo+rwCICr35EwZoLjtfwF6mMiCOenA==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/client-s3": "^3.1012.0",
 				"@aws-sdk/lib-storage": "3.964.0",
@@ -7210,6 +7227,7 @@
 			"integrity": "sha512-ro6B04Q5TjPgIKdSWGJ+tj2ordVF1IfZJERwGpYkrwhboNEoXBXuzpfnh2LYBPvMmFJQ+8UXSFw1jkLLgxM+ig==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@smithy/abort-controller": "^4.2.7",
 				"@smithy/middleware-endpoint": "^4.4.1",
@@ -7232,6 +7250,7 @@
 			"integrity": "sha512-gipd/g0USN8ncvRMdoaru8PxYNUSEJp//+XbLf+3VNDQ6gcSsTcYqyNa3f+oEKIyV0clpOkxzautkN7hVPsn/g==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@harperfast/extended-iterable": "1.0.3",
 				"msgpackr": "1.11.9",
@@ -7264,6 +7283,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -7281,6 +7301,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -7298,6 +7319,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -7315,6 +7337,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -7332,6 +7355,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -7349,6 +7373,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -7366,6 +7391,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -7383,6 +7409,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -7399,7 +7426,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/harper/node_modules/@lmdb/lmdb-darwin-x64": {
 			"version": "3.5.3",
@@ -7413,7 +7441,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/harper/node_modules/@lmdb/lmdb-linux-arm": {
 			"version": "3.5.3",
@@ -7427,7 +7456,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/harper/node_modules/@lmdb/lmdb-linux-arm64": {
 			"version": "3.5.3",
@@ -7441,7 +7471,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/harper/node_modules/@lmdb/lmdb-linux-x64": {
 			"version": "3.5.3",
@@ -7455,7 +7486,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/harper/node_modules/@lmdb/lmdb-win32-arm64": {
 			"version": "3.5.3",
@@ -7469,7 +7501,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/harper/node_modules/@lmdb/lmdb-win32-x64": {
 			"version": "3.5.3",
@@ -7483,7 +7516,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/harper/node_modules/asn1js": {
 			"version": "3.0.7",
@@ -7491,6 +7525,7 @@
 			"integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"pvtsutils": "^1.3.6",
 				"pvutils": "^1.1.3",
@@ -7506,6 +7541,7 @@
 			"integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
@@ -7521,6 +7557,7 @@
 			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			},
@@ -7535,6 +7572,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@harperfast/extended-iterable": "^1.0.3",
 				"msgpackr": "^1.11.2",
@@ -7562,6 +7600,7 @@
 			"integrity": "sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"optionalDependencies": {
 				"msgpackr-extract": "^3.0.2"
 			}
@@ -7572,6 +7611,7 @@
 			"integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"iconv-lite": "^0.6.3",
 				"sax": "^1.2.4"
@@ -7588,7 +7628,8 @@
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
 			"integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/harper/node_modules/node-gyp-build-optional-packages": {
 			"version": "5.2.2",
@@ -7596,6 +7637,7 @@
 			"integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"detect-libc": "^2.0.1"
 			},
@@ -7611,6 +7653,7 @@
 			"integrity": "sha512-UUmvQ/7KTZt/vHjhRrnyS7h+J7qPBQnpG80V56xmIC+o9IqYmQOw/UIny9S9zYDfRBR0ClouCr464EkBMIT7Fw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"atomic-sleep": "^1.0.0",
 				"fast-redact": "^3.1.1",
@@ -7634,6 +7677,7 @@
 			"integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"readable-stream": "^4.0.0",
 				"split2": "^4.0.0"
@@ -7645,6 +7689,7 @@
 			"integrity": "sha512-WX0la7n7CbnguuaIQoT4Fc0IJckPDOUldzOwlZ0nwpOcySS+Six/tXBdc0RX17J5o1To0SAr3xDJjDLsOfDFQA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"@noble/hashes": "^1.4.0",
 				"asn1js": "^3.0.5",
@@ -7662,7 +7707,8 @@
 			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.3.2.tgz",
 			"integrity": "sha512-n9wh8tvBe5sFmsqlg+XQhaQLumwpqoAUruLwjCopgTmUBjJ/fjtBsJzKleCaIGBOMXYEhp1YfKl4d7rJ5ZKJGA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/harper/node_modules/readable-stream": {
 			"version": "4.7.0",
@@ -7670,6 +7716,7 @@
 			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"abort-controller": "^3.0.0",
 				"buffer": "^6.0.3",
@@ -7701,6 +7748,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.2.1"
@@ -7712,6 +7760,7 @@
 			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -7725,6 +7774,7 @@
 			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"engines": {
 				"node": ">= 10.x"
 			}
@@ -7735,6 +7785,7 @@
 			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
 			}
@@ -7745,6 +7796,7 @@
 			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -7767,6 +7819,7 @@
 			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"bin": {
 				"yaml": "bin.mjs"
 			},
@@ -7834,6 +7887,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"parse-columns": "git+https://github.com/int0h/parse-columns.git"
 			}
@@ -8089,6 +8143,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			},
@@ -8176,6 +8231,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8187,6 +8243,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -9133,6 +9190,7 @@
 			"version": "0.2.7",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			},
@@ -9159,6 +9217,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -9176,6 +9235,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -9193,6 +9253,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -9210,6 +9271,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -9227,6 +9289,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -9242,6 +9305,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -9257,6 +9321,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -9275,6 +9340,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"number-is-nan": "^1.0.0"
 			},
@@ -9298,6 +9364,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -9641,6 +9708,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"escape-string-regexp": "^1.0.3",
 				"execall": "^1.0.0",
@@ -9658,6 +9726,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.8.0"
 			}
@@ -9935,7 +10004,6 @@
 			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -10196,6 +10264,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"is-finite": "^1.0.0"
 			},
@@ -10691,6 +10760,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"array-uniq": "^1.0.2",
 				"arrify": "^1.0.0",
@@ -11050,7 +11120,6 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -11164,7 +11233,6 @@
 			"version": "5.9.3",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -11231,6 +11299,32 @@
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/utf-8-validate": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+			"integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"node-gyp-build": "^4.3.0"
+			},
+			"engines": {
+				"node": ">=6.14.2"
+			}
+		},
+		"node_modules/utf-8-validate/node_modules/node-gyp-build": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+			"license": "MIT",
+			"optional": true,
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -11681,7 +11775,6 @@
 			"version": "3.1042.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1042.0.tgz",
 			"integrity": "sha512-z3Ibstr7ckDT10dz/nkk4+93LitrrO49Oq563/JoFHt30ZNodPBCfSxysKcelLyi/lNVF1MZrhZZfikUAG3iNQ==",
-			"peer": true,
 			"requires": {
 				"@aws-crypto/sha1-browser": "5.2.0",
 				"@aws-crypto/sha256-browser": "5.2.0",
@@ -12821,7 +12914,6 @@
 				"@typescript-eslint/parser": {
 					"version": "8.44.0",
 					"dev": true,
-					"peer": true,
 					"requires": {
 						"@typescript-eslint/scope-manager": "8.44.0",
 						"@typescript-eslint/types": "8.44.0",
@@ -13174,40 +13266,34 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
 			"integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
-			"dev": true,
 			"optional": true
 		},
 		"@msgpackr-extract/msgpackr-extract-darwin-x64": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
 			"integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
-			"dev": true,
 			"optional": true
 		},
 		"@msgpackr-extract/msgpackr-extract-linux-arm": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
 			"integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
-			"dev": true,
 			"optional": true
 		},
 		"@msgpackr-extract/msgpackr-extract-linux-arm64": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
 			"integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
-			"dev": true,
 			"optional": true
 		},
 		"@msgpackr-extract/msgpackr-extract-linux-x64": {
 			"version": "3.0.3",
-			"dev": true,
 			"optional": true
 		},
 		"@msgpackr-extract/msgpackr-extract-win32-x64": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
 			"integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
-			"dev": true,
 			"optional": true
 		},
 		"@noble/hashes": {
@@ -13440,6 +13526,7 @@
 			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.14.tgz",
 			"integrity": "sha512-GW2yqqOTzdz3K6z0XpPO1EjLzOw0kclmAcLeW6cBt0DYM7ZNLRKanpzXxaSXkePpo4ZYMWhddE4WpSWG8e/QaQ==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
@@ -14167,7 +14254,6 @@
 		},
 		"@types/node": {
 			"version": "25.4.0",
-			"peer": true,
 			"requires": {
 				"undici-types": "~7.18.0"
 			}
@@ -14240,7 +14326,6 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
 			"integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@typescript-eslint/scope-manager": "8.59.0",
 				"@typescript-eslint/types": "8.59.0",
@@ -14355,8 +14440,7 @@
 		},
 		"acorn": {
 			"version": "8.16.0",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
@@ -14441,14 +14525,16 @@
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
 			"integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
 			"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"asap": {
 			"version": "2.0.6",
@@ -14634,6 +14720,23 @@
 		"buffer-from": {
 			"version": "1.1.2"
 		},
+		"bufferutil": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+			"integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+			"optional": true,
+			"requires": {
+				"node-gyp-build": "^4.3.0"
+			},
+			"dependencies": {
+				"node-gyp-build": {
+					"version": "4.8.4",
+					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+					"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+					"optional": true
+				}
+			}
+		},
 		"bytestreamjs": {
 			"version": "2.0.1"
 		},
@@ -14689,8 +14792,7 @@
 		},
 		"chai": {
 			"version": "6.2.2",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"chai-as-promised": {
 			"version": "8.0.2",
@@ -14768,6 +14870,7 @@
 			"integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"is-regexp": "^1.0.0",
 				"is-supported-regexp-flag": "^1.0.0"
@@ -15083,7 +15186,6 @@
 		"eslint": {
 			"version": "9.39.4",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -15149,7 +15251,6 @@
 		"eslint-config-prettier": {
 			"version": "10.1.8",
 			"dev": true,
-			"peer": true,
 			"requires": {}
 		},
 		"eslint-plugin-prettier": {
@@ -15243,6 +15344,7 @@
 			"integrity": "sha512-/J0Q8CvOvlAdpvhfkD/WnTQ4H1eU0exze2nFGPj/RSC7jpQ0NkKe2r28T5eMkhEEs+fzepMZNy1kVRKNlC04nQ==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"clone-regexp": "^1.0.0"
 			}
@@ -15647,8 +15749,7 @@
 			"dev": true
 		},
 		"graphql": {
-			"version": "16.13.2",
-			"peer": true
+			"version": "16.13.2"
 		},
 		"graphql-http": {
 			"version": "1.22.4",
@@ -15696,6 +15797,7 @@
 			"resolved": "https://registry.npmjs.org/harper/-/harper-5.0.0.tgz",
 			"integrity": "sha512-RRXMLbbdymiZsHOeg5b+DShzsMvVvkgsG9690BBCc7tzIpDb0CT7EgWEQo+rwCICr35EwZoLjtfwF6mMiCOenA==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@aws-sdk/client-s3": "^3.1012.0",
 				"@aws-sdk/lib-storage": "3.964.0",
@@ -15788,6 +15890,7 @@
 					"resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.964.0.tgz",
 					"integrity": "sha512-ro6B04Q5TjPgIKdSWGJ+tj2ordVF1IfZJERwGpYkrwhboNEoXBXuzpfnh2LYBPvMmFJQ+8UXSFw1jkLLgxM+ig==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"@smithy/abort-controller": "^4.2.7",
 						"@smithy/middleware-endpoint": "^4.4.1",
@@ -15803,6 +15906,7 @@
 					"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js/-/rocksdb-js-0.1.14.tgz",
 					"integrity": "sha512-gipd/g0USN8ncvRMdoaru8PxYNUSEJp//+XbLf+3VNDQ6gcSsTcYqyNa3f+oEKIyV0clpOkxzautkN7hVPsn/g==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"@harperfast/extended-iterable": "1.0.3",
 						"@harperfast/rocksdb-js-darwin-arm64": "0.1.14",
@@ -15822,111 +15926,127 @@
 					"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-arm64/-/rocksdb-js-darwin-arm64-0.1.14.tgz",
 					"integrity": "sha512-txWzBqg4ObTYqMBdQ/fPHXBeLjHKCGp0rfVTEoUH2H89HncbsadOPT4KjzZAJPkFGuHb1VlTX0+XmV3mQOiOog==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				},
 				"@harperfast/rocksdb-js-darwin-x64": {
 					"version": "0.1.14",
 					"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-x64/-/rocksdb-js-darwin-x64-0.1.14.tgz",
 					"integrity": "sha512-gRxXvXZjFtNXv8wQQ/aK8dV3PQRh9C621ptTR0a3S/7E1F+2+rOaaMGrT5ZmvAmxx5eHNOI/ETl85kzwPNg7MA==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				},
 				"@harperfast/rocksdb-js-linux-arm64-glibc": {
 					"version": "0.1.14",
 					"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-glibc/-/rocksdb-js-linux-arm64-glibc-0.1.14.tgz",
 					"integrity": "sha512-OAwipPhuh2Da9YtbV58KRdBJ3BM7OfabpDHe3NBhIl9eHeWXA+k1OmSrSIPplsmg/2hJcKohhR90ao5cwxk7KA==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				},
 				"@harperfast/rocksdb-js-linux-arm64-musl": {
 					"version": "0.1.14",
 					"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-musl/-/rocksdb-js-linux-arm64-musl-0.1.14.tgz",
 					"integrity": "sha512-GhnsPFU5sv2ofa7aI/E48sEwt2BGUh1HSkJY+E3Ji8xqtdAfqH3X6uNWTLD/PUz0WzhZ8VcWplN2c9ZoB6ZfeA==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				},
 				"@harperfast/rocksdb-js-linux-x64-glibc": {
 					"version": "0.1.14",
 					"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-glibc/-/rocksdb-js-linux-x64-glibc-0.1.14.tgz",
 					"integrity": "sha512-RK+3YUK8hhhYrvDacJ+v5xwbOirUrwHlcBtWKd/6yKh4a93G/mlw+hpz+kzAgshDWJhU9zfrmSECzI4YlLTYfQ==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				},
 				"@harperfast/rocksdb-js-linux-x64-musl": {
 					"version": "0.1.14",
 					"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-0.1.14.tgz",
 					"integrity": "sha512-7aKQ/u1zFSlSH/Szui6Kfw5lisvVPi/UkHnaVjSjKsfaZQ5WLVcWe7Gorq5MyzHlwhC9xiVKto0yA98CGYz6pw==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				},
 				"@harperfast/rocksdb-js-win32-arm64": {
 					"version": "0.1.14",
 					"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-0.1.14.tgz",
 					"integrity": "sha512-/kqaf0PrASoXgH3MvQPYbVkouQRXwKzS63iRyAsNYINZ5eTfoveAiuqJ3dO2sR8HuVUzuSBxNAMNKFADQySOiQ==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				},
 				"@harperfast/rocksdb-js-win32-x64": {
 					"version": "0.1.14",
 					"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-x64/-/rocksdb-js-win32-x64-0.1.14.tgz",
 					"integrity": "sha512-p10sMX23HD4NX6kiSnHvrtIZ3LYHJF8rK3SbA+t9Uj269+Ey5s3RAAvRUV2rnbEhpBZTlxOCLxHpfb5kDCTNlA==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				},
 				"@lmdb/lmdb-darwin-arm64": {
 					"version": "3.5.3",
 					"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-3.5.3.tgz",
 					"integrity": "sha512-Ob379nnG6FpfVi9WUVupUVsMFa0+jbkelilrBAdJgNlg6dDtXKeTi+pzL+G3f1z3SNdXXWUAL5N8LTp7szXEVw==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				},
 				"@lmdb/lmdb-darwin-x64": {
 					"version": "3.5.3",
 					"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-3.5.3.tgz",
 					"integrity": "sha512-fbKZ6gonDCWENiXiRoDC4KdBBXi2rlDr1uYj/SErpIAHuTfnLo0Il1hvmbDLeiCPLaPjbXlvcMiR3vLnrNnWMw==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				},
 				"@lmdb/lmdb-linux-arm": {
 					"version": "3.5.3",
 					"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-3.5.3.tgz",
 					"integrity": "sha512-A80EUIRBiKA+0iMc5DxT2u8msgY+K05Lok133IKb3eJVlJkmJie4+LM0MjNyV+mREnu8UwhlNFupSikPy/eTPw==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				},
 				"@lmdb/lmdb-linux-arm64": {
 					"version": "3.5.3",
 					"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-3.5.3.tgz",
 					"integrity": "sha512-VYWkuWS8uQSyszMe5KGVJPD3YSkaXVrUz/6hbg3zkBvhfOTyrIVMN9M3cZjpU4yxVRBmGViZ5kgjoKz7n3sw2w==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				},
 				"@lmdb/lmdb-linux-x64": {
 					"version": "3.5.3",
 					"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-3.5.3.tgz",
 					"integrity": "sha512-JAeG8rJaL1klzg+VKyRqp0wPSbuPo1ZuNmO/IBRs8QRrSIPxF9r3r1TcIVVRLaaJmI0+2KOjbFRjtvFWFH6cMQ==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				},
 				"@lmdb/lmdb-win32-arm64": {
 					"version": "3.5.3",
 					"resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-arm64/-/lmdb-win32-arm64-3.5.3.tgz",
 					"integrity": "sha512-9QdgjU5VW0MJ3wy94h4fQ+cNkxeJ0KasjvisOhLuvlCep2KSOzr1i65Js3ElHBRQX8N+jVD8/+LWIM7flfGZ4w==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				},
 				"@lmdb/lmdb-win32-x64": {
 					"version": "3.5.3",
 					"resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.5.3.tgz",
 					"integrity": "sha512-0nd13c9ypIDkdsJbHv1PMvk6MZrwHLQP05AXZdxvv8lklxRrZxPK2d8nSo8HLoMXyLt0hA2yQ3fydQaSRrkz0g==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				},
 				"asn1js": {
 					"version": "3.0.7",
 					"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
 					"integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"pvtsutils": "^1.3.6",
 						"pvutils": "^1.1.3",
@@ -15938,6 +16058,7 @@
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
 					"integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"graceful-fs": "^4.2.0",
 						"jsonfile": "^6.0.1",
@@ -15949,6 +16070,7 @@
 					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
 					"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"safer-buffer": ">= 2.1.2 < 3.0.0"
 					}
@@ -15958,6 +16080,7 @@
 					"resolved": "https://registry.npmjs.org/lmdb/-/lmdb-3.5.3.tgz",
 					"integrity": "sha512-6A0iRKOv/N62P1vU8qhBr32tHQIY6pQMe8b6zqI4VLELqV8fWHUMdnfNjMR+Kyh7ZeRCo8PDzAnW2g+SJSoP1A==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"@harperfast/extended-iterable": "^1.0.3",
 						"@lmdb/lmdb-darwin-arm64": "3.5.3",
@@ -15979,6 +16102,7 @@
 					"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.9.tgz",
 					"integrity": "sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"msgpackr-extract": "^3.0.2"
 					}
@@ -15988,6 +16112,7 @@
 					"resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
 					"integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"iconv-lite": "^0.6.3",
 						"sax": "^1.2.4"
@@ -15997,13 +16122,15 @@
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
 					"integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
-					"dev": true
+					"dev": true,
+					"peer": true
 				},
 				"node-gyp-build-optional-packages": {
 					"version": "5.2.2",
 					"resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
 					"integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"detect-libc": "^2.0.1"
 					}
@@ -16013,6 +16140,7 @@
 					"resolved": "https://registry.npmjs.org/pino/-/pino-8.16.0.tgz",
 					"integrity": "sha512-UUmvQ/7KTZt/vHjhRrnyS7h+J7qPBQnpG80V56xmIC+o9IqYmQOw/UIny9S9zYDfRBR0ClouCr464EkBMIT7Fw==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"atomic-sleep": "^1.0.0",
 						"fast-redact": "^3.1.1",
@@ -16032,6 +16160,7 @@
 					"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz",
 					"integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"readable-stream": "^4.0.0",
 						"split2": "^4.0.0"
@@ -16042,6 +16171,7 @@
 					"resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.2.5.tgz",
 					"integrity": "sha512-WX0la7n7CbnguuaIQoT4Fc0IJckPDOUldzOwlZ0nwpOcySS+Six/tXBdc0RX17J5o1To0SAr3xDJjDLsOfDFQA==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"@noble/hashes": "^1.4.0",
 						"asn1js": "^3.0.5",
@@ -16055,13 +16185,15 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.3.2.tgz",
 					"integrity": "sha512-n9wh8tvBe5sFmsqlg+XQhaQLumwpqoAUruLwjCopgTmUBjJ/fjtBsJzKleCaIGBOMXYEhp1YfKl4d7rJ5ZKJGA==",
-					"dev": true
+					"dev": true,
+					"peer": true
 				},
 				"readable-stream": {
 					"version": "4.7.0",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
 					"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"abort-controller": "^3.0.0",
 						"buffer": "^6.0.3",
@@ -16075,6 +16207,7 @@
 							"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
 							"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
 							"dev": true,
+							"peer": true,
 							"requires": {
 								"base64-js": "^1.3.1",
 								"ieee754": "^1.2.1"
@@ -16086,19 +16219,22 @@
 					"version": "7.7.3",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
 					"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-					"dev": true
+					"dev": true,
+					"peer": true
 				},
 				"split2": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
 					"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-					"dev": true
+					"dev": true,
+					"peer": true
 				},
 				"string_decoder": {
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
 					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"safe-buffer": "~5.2.0"
 					}
@@ -16108,13 +16244,15 @@
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
 					"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
 					"dev": true,
+					"peer": true,
 					"requires": {}
 				},
 				"yaml": {
 					"version": "2.8.2",
 					"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
 					"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-					"dev": true
+					"dev": true,
+					"peer": true
 				}
 			}
 		},
@@ -16148,6 +16286,7 @@
 			"integrity": "sha512-7m3tHCNg44BIRozpqaFthaKXoPhEv9F63yjFIjhhjoNlF2uFYlu72TAUo6ynlx/JN31BRKHUnwd7Ysox2s+cgQ==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"parse-columns": "git+https://github.com/int0h/parse-columns.git"
 			}
@@ -16302,7 +16441,8 @@
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
 			"integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"is-fullwidth-code-point": {
 			"version": "3.0.0"
@@ -16344,14 +16484,16 @@
 			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
 			"integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"is-supported-regexp-flag": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
 			"integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"is-unicode-supported": {
 			"version": "0.1.0"
@@ -16944,6 +17086,7 @@
 		"node-unix-socket": {
 			"version": "0.2.7",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"node-unix-socket-darwin-arm64": "0.2.7",
 				"node-unix-socket-darwin-x64": "0.2.7",
@@ -16959,45 +17102,52 @@
 			"resolved": "https://registry.npmjs.org/node-unix-socket-darwin-arm64/-/node-unix-socket-darwin-arm64-0.2.7.tgz",
 			"integrity": "sha512-6wSB386fFnWADWVpAlDq87lZI/0jzLEA7BsRc6QwmMwHonZ/ZbejwEI79iRKnHqFB6wh3TZdHHiKu4csMH1c3w==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node-unix-socket-darwin-x64": {
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/node-unix-socket-darwin-x64/-/node-unix-socket-darwin-x64-0.2.7.tgz",
 			"integrity": "sha512-eO8pVbchCy7TOvbc8DlIytsSeX6MWPmDVLnSQ8dvAUmsHRGKgJdmO74gr2NwjNmh1h974iW8IpAJfovL+DffHA==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node-unix-socket-linux-arm-gnueabihf": {
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/node-unix-socket-linux-arm-gnueabihf/-/node-unix-socket-linux-arm-gnueabihf-0.2.7.tgz",
 			"integrity": "sha512-BcC2tGf+Mfs94khO6PWK2a4dJ2wX7HBOuVKxTVqfXZxcrJXplZa0NYn2H9+il4fgIJMb6EbeUo2L3iXpTDJk7w==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node-unix-socket-linux-arm64-gnu": {
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/node-unix-socket-linux-arm64-gnu/-/node-unix-socket-linux-arm64-gnu-0.2.7.tgz",
 			"integrity": "sha512-HB4mOFic2u/6KjGHlMJY2q2eAz6btWxzJ0tMYOll+K2WOIuMwT5moZRToc3rjOI6h8bSBMf8ZMwvCz5On9fdoQ==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node-unix-socket-linux-arm64-musl": {
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/node-unix-socket-linux-arm64-musl/-/node-unix-socket-linux-arm64-musl-0.2.7.tgz",
 			"integrity": "sha512-sLuUyCBRWEqBA+EHbhMYgKhEg6zNhiD7nDIJt0zJhWoF7bIrJaRAgBWsdSK/EK8d0a6FYpWIMVVe9CcsApb+lA==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node-unix-socket-linux-x64-gnu": {
 			"version": "0.2.7",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node-unix-socket-linux-x64-musl": {
 			"version": "0.2.7",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"normalize-path": {
 			"version": "3.0.0"
@@ -17008,6 +17158,7 @@
 			"integrity": "sha512-rlgHFHwHtMw93TwRpcPanY83xaSrVzAnKRJCp5yXylFGNObD2tRm+HjtvinLnqM0mHXx6I1+/7SeEcbQeV73OQ==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -17025,7 +17176,8 @@
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"object-inspect": {
 			"version": "1.13.4",
@@ -17213,6 +17365,7 @@
 			"dev": true,
 			"from": "parse-columns@git+https://github.com/int0h/parse-columns.git",
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.3",
 				"execall": "^1.0.0",
@@ -17225,7 +17378,8 @@
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"peer": true
 				}
 			}
 		},
@@ -17401,8 +17555,7 @@
 			"version": "3.8.2",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
 			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"prettier-linter-helpers": {
 			"version": "1.0.1",
@@ -17549,6 +17702,7 @@
 			"integrity": "sha512-ZqtSMuVybkISo2OWvqvm7iHSWngvdaW3IpsT9/uP8v4gMi591LY6h35wdOfvQdWCKFWZWm2Y1Opp4kV7vQKT6A==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"is-finite": "^1.0.0"
 			}
@@ -17827,6 +17981,7 @@
 			"integrity": "sha512-hTyZobArNQZhG6jp5crQEtIBRNbP3kPqPuEjqiv4xcABvqTS3ov3xfnPL9fw+3qfg5eDI4sXwk+eReZNVG6VCA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"array-uniq": "^1.0.2",
 				"arrify": "^1.0.0",
@@ -18050,8 +18205,7 @@
 					"version": "4.0.4",
 					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
 					"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-					"dev": true,
-					"peer": true
+					"dev": true
 				}
 			}
 		},
@@ -18110,8 +18264,7 @@
 		},
 		"typescript": {
 			"version": "5.9.3",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"typescript-eslint": {
 			"version": "8.58.0",
@@ -18148,6 +18301,23 @@
 			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
+			}
+		},
+		"utf-8-validate": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+			"integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+			"optional": true,
+			"requires": {
+				"node-gyp-build": "^4.3.0"
+			},
+			"dependencies": {
+				"node-gyp-build": {
+					"version": "4.8.4",
+					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+					"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+					"optional": true
+				}
 			}
 		},
 		"util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"build:watch": "npm run build -- --watch --incremental",
 		"package": "./build-tools/build.sh",
 		"lint": "oxlint --format stylish --deny-warnings .",
-		"lint:required": "oxlint --quiet .",
+		"lint:required": "oxlint --format stylish --quiet .",
 		"lint:fix": "npm run lint -- --fix",
 		"format:check": "prettier --check .",
 		"format:write": "prettier --write .",

--- a/security/tokenAuthentication.ts
+++ b/security/tokenAuthentication.ts
@@ -226,3 +226,30 @@ async function validateToken(token: string, tokenType: string): Promise<any> {
 		throw new ClientError(AUTHENTICATION_ERROR_MSGS.INVALID_TOKEN, HTTP_STATUS_CODES.UNAUTHORIZED);
 	}
 }
+
+/**
+ * Decodes a JWT and returns its payload.
+ * @param {string} token The JWT token to decode.
+ * @returns {Object|null} The decoded payload or null if invalid.
+ */
+export function decodeJWT(token: string): null | { exp: number; iat: number } {
+	try {
+		const parts = token.split('.');
+		if (parts.length !== 3) return null;
+		const payload = parts[1];
+		const decoded = Buffer.from(payload, 'base64').toString('utf8');
+		return JSON.parse(decoded);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Decodes a JWT and checks if it has expired or is going to expire soon (based on the buffer seconds).
+ */
+export function isJWTExpired(token: string, bufferSeconds = 300): boolean {
+	const payload = decodeJWT(token);
+	if (!payload || !payload.exp) return true;
+	const now = Math.floor(Date.now() / 1000);
+	return payload.exp < now + bufferSeconds;
+}

--- a/unitTests/bin/cliCredentials.test.js
+++ b/unitTests/bin/cliCredentials.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('fs-extra');
+const os = require('node:os');
+const { loadCredentials, saveCredentials, clearCredentials } = require('#src/bin/cliCredentials');
+
+describe('CLI Credentials', () => {
+	const testDir = path.join(os.tmpdir(), `harper-test-creds-${Date.now()}`);
+	const credentialsFile = path.join(testDir, '.harperdb', 'credentials.json');
+	let originalHome;
+
+	before(() => {
+		originalHome = process.env.HOME;
+		process.env.HOME = testDir;
+		fs.ensureDirSync(testDir);
+	});
+
+	after(() => {
+		process.env.HOME = originalHome;
+		fs.removeSync(testDir);
+	});
+
+	beforeEach(() => {
+		fs.removeSync(credentialsFile);
+	});
+
+	it('should return empty targets when no credentials file exists', () => {
+		const creds = loadCredentials();
+		assert.deepStrictEqual(creds, { last_target: null, targets: {} });
+	});
+
+	it('should save and load credentials with target', () => {
+		const target = 'https://example.com:9925/';
+		const tokens = {
+			operation_token: 'op-token-123',
+			refresh_token: 'ref-token-456',
+		};
+		saveCredentials(target, tokens);
+
+		const loaded = loadCredentials();
+		assert.ok(loaded);
+		assert.strictEqual(loaded.last_target, 'https://example.com:9925/');
+		assert.ok(loaded.targets['https://example.com:9925/']);
+		assert.strictEqual(loaded.targets['https://example.com:9925/'].operation_token, 'op-token-123');
+	});
+
+	it('should support multiple targets', () => {
+		saveCredentials('https://cluster1.com:9925/', {
+			operation_token: 'token1',
+			refresh_token: 'refresh1',
+		});
+		saveCredentials('https://cluster2.com:9925/', {
+			operation_token: 'token2',
+			refresh_token: 'refresh2',
+		});
+
+		const loaded = loadCredentials();
+		assert.strictEqual(loaded.last_target, 'https://cluster2.com:9925/');
+		assert.strictEqual(loaded.targets['https://cluster1.com:9925/'].operation_token, 'token1');
+		assert.strictEqual(loaded.targets['https://cluster2.com:9925/'].operation_token, 'token2');
+	});
+
+	it('should clear specific target', () => {
+		saveCredentials('https://cluster1.com:9925/', {
+			operation_token: 'token1',
+			refresh_token: 'refresh1',
+		});
+		saveCredentials('https://cluster2.com:9925/', {
+			operation_token: 'token2',
+			refresh_token: 'refresh2',
+		});
+
+		clearCredentials('https://cluster1.com:9925/');
+		const loaded = loadCredentials();
+		assert.strictEqual(loaded.targets['https://cluster1.com:9925/'], undefined);
+		assert.ok(loaded.targets['https://cluster2.com:9925/']);
+		assert.strictEqual(loaded.last_target, 'https://cluster2.com:9925/');
+	});
+
+	it('should clear all credentials when no target provided', () => {
+		saveCredentials('https://cluster1.com:9925/', {
+			operation_token: 'token1',
+			refresh_token: 'refresh1',
+		});
+
+		clearCredentials();
+		assert.deepStrictEqual(loadCredentials(), { last_target: null, targets: {} });
+		assert.strictEqual(fs.existsSync(credentialsFile), false);
+	});
+	it('should normalize target with trailing slash when saving and clearing', () => {
+		saveCredentials('https://no-slash.com:9925', {
+			operation_token: 'token-no-slash',
+			refresh_token: 'refresh-no-slash',
+		});
+
+		const loaded = loadCredentials();
+		assert.strictEqual(loaded.last_target, 'https://no-slash.com:9925/');
+		assert.ok(loaded.targets['https://no-slash.com:9925/']);
+		assert.strictEqual(loaded.targets['https://no-slash.com:9925/'].operation_token, 'token-no-slash');
+
+		clearCredentials('https://no-slash.com:9925');
+		const loadedAfterClear = loadCredentials();
+		assert.strictEqual(loadedAfterClear.targets['https://no-slash.com:9925/'], undefined);
+	});
+});

--- a/unitTests/bin/cliOperations.test.js
+++ b/unitTests/bin/cliOperations.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('fs-extra');
+const os = require('node:os');
+const { saveCredentials } = require('#src/bin/cliCredentials');
+const cliOperationsModule = require('#src/bin/cliOperations');
+const commonUtilsModule = require('#src/utility/common_utils');
+const tokenAuthModule = require('#src/security/tokenAuthentication');
+
+describe('cliOperations', () => {
+	const testDir = path.join(os.tmpdir(), `harper-test-cli-ops-${Date.now()}`);
+	let originalHome;
+	let originalHttpRequest;
+	let originalIsJWTExpired;
+
+	before(() => {
+		originalHome = process.env.HOME;
+		process.env.HOME = testDir;
+		fs.ensureDirSync(testDir);
+
+		originalHttpRequest = commonUtilsModule.httpRequest;
+		originalIsJWTExpired = tokenAuthModule.isJWTExpired;
+	});
+
+	after(() => {
+		process.env.HOME = originalHome;
+		fs.removeSync(testDir);
+
+		commonUtilsModule.httpRequest = originalHttpRequest;
+		tokenAuthModule.isJWTExpired = originalIsJWTExpired;
+	});
+
+	beforeEach(() => {
+		fs.removeSync(path.join(testDir, '.harperdb'));
+		fs.ensureDirSync(testDir);
+	});
+
+	it('Leg 1: should use non-expired token directly', async () => {
+		const target = 'https://example.com:9925/';
+		saveCredentials(target, {
+			operation_token: 'valid-token',
+			refresh_token: 'refresh-token',
+		});
+
+		tokenAuthModule.isJWTExpired = () => false;
+
+		let httpRequestCalled = false;
+		commonUtilsModule.httpRequest = async (options, _req) => {
+			httpRequestCalled = true;
+			assert.strictEqual(options.headers.Authorization, 'Bearer valid-token');
+			return { statusCode: 200, body: JSON.stringify({ success: true }) };
+		};
+
+		const result = await cliOperationsModule.cliOperations({ operation: 'test', target: 'example.com' }, true);
+		assert.strictEqual(httpRequestCalled, true);
+		assert.strictEqual(result.success, true);
+	});
+
+	it('Leg 2: should refresh expired token and save it', async () => {
+		const target = 'https://example.com:9925/';
+		saveCredentials(target, {
+			operation_token: 'expired-token',
+			refresh_token: 'refresh-token',
+		});
+
+		tokenAuthModule.isJWTExpired = (token) => token === 'expired-token';
+
+		let httpRequestCalls = [];
+		commonUtilsModule.httpRequest = async (options, req) => {
+			httpRequestCalls.push({ options, req });
+			if (req.operation === 'refresh_operation_token') {
+				assert.strictEqual(options.headers.Authorization, 'Bearer refresh-token');
+				return {
+					statusCode: 200,
+					body: JSON.stringify({ operation_token: 'new-token' }),
+				};
+			}
+			return { statusCode: 200, body: JSON.stringify({ success: true }) };
+		};
+
+		const result = await cliOperationsModule.cliOperations({ operation: 'test', target: 'example.com' }, true);
+
+		// Verify refresh call
+		assert.strictEqual(httpRequestCalls.length, 2);
+		assert.strictEqual(httpRequestCalls[0].req.operation, 'refresh_operation_token');
+
+		// Verify original request with new token
+		assert.strictEqual(httpRequestCalls[1].options.headers.Authorization, 'Bearer new-token');
+		assert.strictEqual(result.success, true);
+
+		// Verify new token was saved to disk by reloading credentials
+		const { loadCredentials } = require('#src/bin/cliCredentials');
+		const creds = loadCredentials();
+		assert.strictEqual(creds.targets[target].operation_token, 'new-token');
+	});
+});

--- a/unitTests/bin/login.test.js
+++ b/unitTests/bin/login.test.js
@@ -1,0 +1,221 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { login } = require('#src/bin/login');
+const { normalizeTarget } = require('#src/bin/cliCredentials');
+
+describe('Login', () => {
+	describe('url normalization', () => {
+		it('should add https:// and port 9925 to a domain', () => {
+			assert.strictEqual(normalizeTarget('example.com'), 'https://example.com:9925/');
+		});
+
+		it('should add port 9925 if missing but protocol is present', () => {
+			assert.strictEqual(normalizeTarget('http://example.com'), 'http://example.com:9925/');
+			assert.strictEqual(normalizeTarget('https://example.com'), 'https://example.com:9925/');
+		});
+
+		it('should preserve existing port', () => {
+			assert.strictEqual(normalizeTarget('example.com:1234'), 'https://example.com:1234/');
+			assert.strictEqual(normalizeTarget('http://example.com:1234'), 'http://example.com:1234/');
+		});
+
+		it('should add trailing slash', () => {
+			assert.strictEqual(normalizeTarget('https://example.com:9925'), 'https://example.com:9925/');
+		});
+
+		it('should handle IP addresses', () => {
+			assert.strictEqual(normalizeTarget('127.0.0.1'), 'https://127.0.0.1:9925/');
+		});
+
+		it('should handle localhost', () => {
+			assert.strictEqual(normalizeTarget('localhost'), 'https://localhost:9925/');
+		});
+
+		it('should handle existing paths', () => {
+			assert.strictEqual(normalizeTarget('example.com/api'), 'https://example.com:9925/api/');
+		});
+	});
+
+	describe('function arguments', () => {
+		const readline = require('node:readline/promises');
+		let originalCreateInterface;
+		let questionCalls;
+
+		beforeEach(() => {
+			questionCalls = [];
+			process.env.CLI_TARGET_PASSWORD = 'mockpassword';
+			originalCreateInterface = readline.createInterface;
+			readline.createInterface = () => {
+				return {
+					question: async (query) => {
+						questionCalls.push(query);
+						if (query.includes('Username')) return 'mockuser';
+						return 'mock-response';
+					},
+					close: () => {},
+				};
+			};
+
+			this.originalExit = process.exit;
+			process.exit = (code) => {
+				throw new Error('process.exit:' + code);
+			};
+		});
+
+		afterEach(() => {
+			delete process.env.CLI_TARGET_PASSWORD;
+			readline.createInterface = originalCreateInterface;
+			process.exit = this.originalExit;
+		});
+
+		it('should NOT prompt for target when targetArg is provided', async () => {
+			try {
+				await login('cluster.example.com');
+			} catch {
+				// Ignore errors after target check
+			}
+			const targetPrompted = questionCalls.some((q) => q.includes('Target'));
+			assert.strictEqual(targetPrompted, false, 'Should not have prompted for target');
+		});
+	});
+
+	describe('.env modifications', () => {
+		const testDir = path.join(os.tmpdir(), `harper-test-env-${Date.now()}`);
+		let originalCwd;
+		let originalExit;
+		let originalStdoutWrite;
+		let originalStdinSetRawMode;
+		let originalStdinResume;
+		let originalStdinPause;
+		let originalStdinOn;
+		let originalStdinRemoveListener;
+
+		// Mock cliOperations
+		const cliOperationsModule = require('#src/bin/cliOperations');
+		let originalCliOperations;
+
+		before(() => {
+			if (!fs.existsSync(testDir)) {
+				fs.mkdirSync(testDir, { recursive: true });
+			}
+			originalCwd = process.cwd;
+			process.cwd = () => testDir;
+
+			originalExit = process.exit;
+			process.exit = (code) => {
+				if (code !== 0) {
+					throw new Error('process.exit:' + code);
+				}
+			};
+
+			originalStdoutWrite = process.stdout.write;
+			process.stdout.write = () => {};
+
+			originalStdinSetRawMode = process.stdin.setRawMode;
+			process.stdin.setRawMode = () => {};
+			originalStdinResume = process.stdin.resume;
+			process.stdin.resume = () => {};
+			originalStdinPause = process.stdin.pause;
+			process.stdin.pause = () => {};
+			originalStdinOn = process.stdin.on;
+			process.stdin.on = () => {};
+			originalStdinRemoveListener = process.stdin.removeListener;
+			process.stdin.removeListener = () => {};
+
+			originalCliOperations = cliOperationsModule.cliOperations;
+			cliOperationsModule.cliOperations = async (req) => {
+				if (req.operation === 'create_authentication_tokens') {
+					return {
+						operation_token: 'mock-token',
+						refresh_token: 'mock-refresh',
+						target: req.target,
+					};
+				}
+				return {};
+			};
+		});
+
+		after(() => {
+			process.cwd = originalCwd;
+			process.exit = originalExit;
+			process.stdout.write = originalStdoutWrite;
+			process.stdin.setRawMode = originalStdinSetRawMode;
+			process.stdin.resume = originalStdinResume;
+			process.stdin.pause = originalStdinPause;
+			process.stdin.on = originalStdinOn;
+			process.stdin.removeListener = originalStdinRemoveListener;
+			cliOperationsModule.cliOperations = originalCliOperations;
+			fs.rmSync(testDir, { recursive: true, force: true });
+		});
+
+		beforeEach(() => {
+			const envPath = path.join(testDir, '.env');
+			if (fs.existsSync(envPath)) {
+				fs.unlinkSync(envPath);
+			}
+			// Clear relevant env vars
+			delete process.env.CLI_TARGET;
+			delete process.env.HARPER_CLI_TARGET;
+			delete process.env.CLI_TARGET_PASSWORD;
+			delete process.env.HARPER_CLI_PASSWORD;
+			delete process.env.CLI_TARGET_USERNAME;
+			delete process.env.HARPER_CLI_USERNAME;
+		});
+
+		it('should append HARPER_CLI_TARGET with a leading newline if .env does not end with one', async () => {
+			const envPath = path.join(testDir, '.env');
+			fs.writeFileSync(envPath, 'EXISTING_VAR=value'); // No trailing newline
+
+			// Set password in env to avoid readline/stdin issues
+			process.env.HARPER_CLI_PASSWORD = 'password';
+
+			// We need to mock readline.createInterface because login uses it
+			const readline = require('node:readline/promises');
+			const originalCreateInterface = readline.createInterface;
+			readline.createInterface = () => ({
+				question: async () => 'mockuser',
+				close: () => {},
+			});
+
+			try {
+				await login('example.com', 'mockuser');
+			} finally {
+				readline.createInterface = originalCreateInterface;
+			}
+
+			const envContent = fs.readFileSync(envPath, 'utf8');
+			// The fix added `\nHARPER_CLI_TARGET=${resolvedTarget}\n`
+			// So it should be `EXISTING_VAR=value\nHARPER_CLI_TARGET=https://example.com:9925/\n`
+			assert.strictEqual(envContent, 'EXISTING_VAR=value\nHARPER_CLI_TARGET=https://example.com:9925/\n');
+		});
+
+		it('should append HARPER_CLI_TARGET normally if .env ends with a newline', async () => {
+			const envPath = path.join(testDir, '.env');
+			fs.writeFileSync(envPath, 'EXISTING_VAR=value\n'); // Has trailing newline
+
+			process.env.HARPER_CLI_PASSWORD = 'password';
+
+			const readline = require('node:readline/promises');
+			const originalCreateInterface = readline.createInterface;
+			readline.createInterface = () => ({
+				question: async () => 'mockuser',
+				close: () => {},
+			});
+
+			try {
+				await login('example.com', 'mockuser');
+			} finally {
+				readline.createInterface = originalCreateInterface;
+			}
+
+			const envContent = fs.readFileSync(envPath, 'utf8');
+			// It will result in `EXISTING_VAR=value\n\nHARPER_CLI_TARGET=https://example.com:9925/\n`
+			// This is acceptable as it ensures the new entry is on its own line.
+			assert.strictEqual(envContent, 'EXISTING_VAR=value\n\nHARPER_CLI_TARGET=https://example.com:9925/\n');
+		});
+	});
+});

--- a/unitTests/bin/logout.test.js
+++ b/unitTests/bin/logout.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('fs-extra');
+const os = require('node:os');
+const { loadCredentials, saveCredentials } = require('#src/bin/cliCredentials');
+const { logout } = require('#src/bin/logout');
+
+describe('Logout command', () => {
+	const testDir = path.join(os.tmpdir(), `harper-test-logout-${Date.now()}`);
+	const credentialsFile = path.join(testDir, '.harperdb', 'credentials.json');
+	let originalHome;
+
+	before(() => {
+		originalHome = process.env.HOME;
+		process.env.HOME = testDir;
+		fs.ensureDirSync(testDir);
+	});
+
+	after(() => {
+		process.env.HOME = originalHome;
+		fs.removeSync(testDir);
+	});
+
+	beforeEach(() => {
+		fs.removeSync(credentialsFile);
+	});
+
+	it('should clear all credentials on global logout', async () => {
+		saveCredentials('https://example.com:9925/', {
+			operation_token: 'token1',
+			refresh_token: 'refresh1',
+		});
+		assert.ok(loadCredentials().targets['https://example.com:9925/'], 'Credentials should be loaded after saving');
+
+		await logout();
+
+		assert.deepStrictEqual(
+			loadCredentials(),
+			{ last_target: null, targets: {} },
+			'Credentials should be empty after logout'
+		);
+	});
+
+	it('should clear specific target', async () => {
+		saveCredentials('https://cluster1.com:9925/', {
+			operation_token: 'token1',
+			refresh_token: 'refresh1',
+		});
+		saveCredentials('https://cluster2.com:9925/', {
+			operation_token: 'token2',
+			refresh_token: 'refresh2',
+		});
+
+		await logout('https://cluster1.com:9925/');
+
+		const loaded = loadCredentials();
+		assert.strictEqual(loaded.targets['https://cluster1.com:9925/'], undefined);
+		assert.ok(loaded.targets['https://cluster2.com:9925/']);
+	});
+});

--- a/unitTests/security/tokenAuthentication.test.js
+++ b/unitTests/security/tokenAuthentication.test.js
@@ -878,3 +878,33 @@ describe('test refreshOperationToken function', () => {
 		assert(validate_error === undefined);
 	});
 });
+
+describe('isJWTExpired', () => {
+	const createToken = (exp) => {
+		const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64');
+		const payload = Buffer.from(JSON.stringify({ exp })).toString('base64');
+		return `${header}.${payload}.signature`;
+	};
+
+	it('should return true for invalid token', () => {
+		assert.strictEqual(token_auth.isJWTExpired('invalid'), true);
+	});
+
+	it('should return true for expired token', () => {
+		const expiredTime = Math.floor(Date.now() / 1000) - 60;
+		const token = createToken(expiredTime);
+		assert.strictEqual(token_auth.isJWTExpired(token), true);
+	});
+
+	it('should return true for token expiring soon (within buffer)', () => {
+		const soonExpTime = Math.floor(Date.now() / 1000) + 60; // 1 minute from now
+		const token = createToken(soonExpTime);
+		assert.strictEqual(token_auth.isJWTExpired(token, 300), true); // 5 minute buffer
+	});
+
+	it('should return false for long-lived token', () => {
+		const farExpTime = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
+		const token = createToken(farExpTime);
+		assert.strictEqual(token_auth.isJWTExpired(token, 300), false);
+	});
+});

--- a/utility/common_utils.ts
+++ b/utility/common_utils.ts
@@ -752,12 +752,12 @@ export function noBootFile() {
 	}
 }
 
-export function httpRequest(options: any, data: any) {
+export function httpRequest(options: any, data: any): Promise<http.IncomingMessage & { body?: string }> {
 	let client;
 	if (options.protocol === 'http:') client = http;
 	else client = https;
 	return new Promise((resolve, reject) => {
-		const req = client.request(options, (response) => {
+		const req = client.request(options, (response: http.IncomingMessage & { body?: string }) => {
 			response.setEncoding('utf8');
 			response.body = '';
 			response.on('data', (chunk) => {

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -337,6 +337,8 @@ export const SERVICE_ACTIONS_ENUM = {
 	UPGRADE: 'upgrade',
 	HELP: 'help',
 	STATUS: 'status',
+	LOGIN: 'login',
+	LOGOUT: 'logout',
 	OPERATION: 'operation',
 	RENEWCERTS: 'renew-certs',
 	COPYDB: 'copy-db',


### PR DESCRIPTION
This saves jwts, per target, in your ~/.harper directory under credentials.json. There are likely common bits that are already implemented that Junie missed, and wasted time recreating. It got a bit creative with the readline stuff too, I think that could be tighter, but the experience is decent.

Will follow up with a documentation PR and adjustments to create-harper if we like this pattern.

To verify this, I `npm link`'d harper, and went through various use cases.

```
git clone git@github.com:HarperFast/local-inference.git
cd local-inference
harper login
harper deploy
harper logout
```