### PR TITLE
fix: prevent silent index gaps when per-record puts fail during schema migration

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -31,3 +31,25 @@ The mitigations live in three places:
 - `LMDBTransaction.abort` and `DatabaseTransaction.abort` walk all writes and run the same cleanup unconditionally (regardless of `skipped`), since nothing was committed. `DatabaseTransaction.commit` adds an explicit reject handler so a `Promise.all` failure on `completions` (e.g. a blob save errored) aborts the underlying transaction instead of leaking it _and_ the blob files.
 
 When adding a new commit-handler early-return path: reset `write.skipped = false` at the top of the handler if you don't already, then set `write.skipped = true` immediately before the `return`. Decide first whether the audit log will reference the blob (via `auditRecordToStore`) — if it does, leave `skipped` unset. `cleanupOrphans` is the periodic safety net; don't rely on it for transactional correctness.
+
+## Schema migration and `runIndexing` internals (`databases.ts`)
+
+When `table()` is called with an attribute newly marked `indexed: true` (or with any change that requires re-building the secondary index), `runIndexing` is launched asynchronously and `Table.indexingOperation` is set to its promise. While running:
+
+**In-flight state tracking (persisted to `attributesDbi`):**
+- `attribute.indexingPID = process.pid` — set at migration start; cleared on clean completion. On restart with a different PID, `indexingPID !== process.pid` triggers a re-migration.
+- `attribute.lastIndexedKey` — updated every 100 records as a resumable checkpoint. Cleared on clean completion; preserved on error so a retry starts from this key.
+- `attribute.indexingFailed = true` — set if any record's `index.put` errors during the backfill. `table()` checks this flag: a fresh call in the same or a new process re-triggers the backfill from `lastIndexedKey`.
+- `dbi.isIndexing = true` — in-memory flag on the index dbi. Prevents `searchByIndex` from serving partial results (returns 503 "not indexed yet" instead). Cleared only when backfill completes cleanly.
+
+**`isIndexing` propagation across `resetDatabases()` calls:**
+When `signalSchemaChange('schema-change')` fires at the start of `runIndexing`, `syncSchemaMetadata` calls `resetDatabases()` which re-opens all tables via `table()`. This creates a _new_ dbi object and assigns it to `Table.indices[attribute.name]`. The condition `if (attributeDescriptor?.indexingPID) dbi.isIndexing = true` (just before `indices[name] = dbi` in the migration-detection block) ensures any dbi created while a migration is in progress also has `isIndexing = true`. Without this, a concurrent `resetDatabases()` would replace the in-progress dbi with a fresh one where `isIndexing` is false, allowing queries to read partial index results.
+
+**Error handling:**
+- Per-record sync errors: caught by the inner try-catch. Set `hadIndexingErrors = true`.
+- Per-record async rejections (`index.put` returning a rejected Promise): caught by the `when()` error handler. Set `hadIndexingErrors = true`.
+- The final `await lastResolution` is wrapped in its own try-catch because if the very last put in the loop was rejected, an unguarded `await lastResolution` would throw past the `hadIndexingErrors` check to the outer catch, silently bypassing the error path.
+- On any error: `indexingFailed = true` is persisted; `indexingPID`, `isIndexing`, and `lastIndexedKey` are kept. This leaves the index in 503 "incomplete" state rather than silently serving partial results.
+
+**`Object.defineProperty(attribute, 'dbi', ...)` must use `configurable: true`:**
+`attribute.dbi` is defined as a non-enumerable property (to prevent serialization to `attributesDbi`). It is defined with `configurable: true` so it can be re-assigned if the attribute participates in a retry cycle in the same process.

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1103,6 +1103,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 				const dbi = openIndex(dbiKey, rootStore, attribute);
 				if (
 					changed ||
+					attributeDescriptor.indexingFailed ||
 					(attributeDescriptor.indexingPID && attributeDescriptor.indexingPID !== process.pid) ||
 					attributeDescriptor.restartNumber < workerData?.restartNumber
 				) {
@@ -1111,6 +1112,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 					attributeDescriptor = attributesDbi.getSync(dbiKey);
 					if (
 						changed ||
+						attributeDescriptor.indexingFailed ||
 						(attributeDescriptor.indexingPID && attributeDescriptor.indexingPID !== process.pid) ||
 						attributeDescriptor.restartNumber < workerData?.restartNumber
 					) {
@@ -1124,14 +1126,21 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 						if (hasExistingData) {
 							attribute.lastIndexedKey = attributeDescriptor?.lastIndexedKey ?? undefined;
 							attribute.indexingPID = process.pid;
+							delete attribute.indexingFailed; // clear failure flag for the new run
+							delete attribute.indexingAttempt; // reset attempt counter
 							dbi.isIndexing = true;
-							Object.defineProperty(attribute, 'dbi', { value: dbi });
+							Object.defineProperty(attribute, 'dbi', { value: dbi, configurable: true, enumerable: false });
 							// we only set indexing nulls to true if new or reindexing, we can't have partial indexing of null
 							attributesToIndex.push(attribute);
 						}
 					}
 					attributesDbi.put(dbiKey, attribute);
 				}
+				// If a migration is in progress (indexingPID set), any newly opened dbi must also
+				// reflect isIndexing = true. A resetDatabases() during an active runIndexing creates
+				// a new dbi object; without this, queries could use the new dbi (isIndexing = false)
+				// and return incomplete results while the backfill is still running.
+				if (attributeDescriptor?.indexingPID) dbi.isIndexing = true;
 				if (attributeDescriptor?.indexNulls && attribute.indexNulls === undefined) attribute.indexNulls = true;
 				dbi.indexNulls = attribute.indexNulls;
 				indices[attribute.name] = dbi;
@@ -1202,6 +1211,7 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 			lastResolution = index.drop();
 		}
 		let interrupted;
+		let hadIndexingErrors = false;
 		const attributeErrorReported = {};
 		let indexed = 0;
 		const attributesLength = attributes.length;
@@ -1255,6 +1265,7 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 							}
 						}
 					} catch (error) {
+						hadIndexingErrors = true;
 						if (!attributeErrorReported[property]) {
 							// just report an indexing error once per attribute so we don't spam the logs
 							attributeErrorReported[property] = true;
@@ -1267,6 +1278,7 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 					() => outstanding--,
 					(error) => {
 						outstanding--;
+						hadIndexingErrors = true;
 						logger.error(error);
 					}
 				);
@@ -1284,20 +1296,64 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 				if (outstanding > MAX_OUTSTANDING_INDEXING) await lastResolution;
 				else if (outstanding > MIN_OUTSTANDING_INDEXING) await new Promise((resolve) => setImmediate(resolve)); // yield event turn, don't want to use all computation
 			}
+		}
+		// Await the last pending put. If it rejects, that's also an indexing error.
+		try {
+			await lastResolution;
+		} catch (error) {
+			hadIndexingErrors = true;
+			logger.error(error);
+		}
+		// Yield one more event turn so any queued when() error callbacks (which fire as
+		// microtasks when their tracked promise settles) have a chance to set hadIndexingErrors
+		// before we decide whether to mark indexing as complete.
+		await new Promise((resolve) => setImmediate(resolve));
+		if (hadIndexingErrors) {
+			// Some records failed to index. Persist the failure marker in the descriptor so
+			// the next call to table() (including after a restart with a fresh PID) re-triggers
+			// the backfill from the last checkpoint. Do NOT clear indexingPID or isIndexing —
+			// leave the index in its incomplete state so queries return 503 "not indexed yet"
+			// rather than silently returning partial results. This is the key fix for the
+			// serent-canopy issue #135 fingerprint: a completed migration with transient errors
+			// (e.g. ERR_BUSY from RocksDB under load) leaving gaps while appearing successful.
+			for (const attribute of attributes) {
+				attribute.indexingFailed = true;
+				// Preserve lastIndexedKey so the retry resumes from the last checkpoint.
+				lastResolution = Table.dbisDB.put(attribute.key, attribute);
+				// Keep isIndexing = true on both the attribute.dbi and the currently-active dbi
+				// in Table.indices (which may differ if resetDatabases() ran during this pass).
+				attribute.dbi.isIndexing = true;
+				const activeDbi = Table.indices[attribute.name];
+				if (activeDbi) activeDbi.isIndexing = true;
+			}
+			await lastResolution;
+			logger.warn(
+				`Indexing of ${Table.tableName} encountered errors on some records — index will remain incomplete. ` +
+					`On next restart the migration will be retried from the last checkpoint (indexingFailed=true). ` +
+					`Affected attributes: ${attributes.map((a) => a.name).join(', ')}`
+			);
+		} else {
 			// update the attributes to indicate that we are finished
 			for (const attribute of attributes) {
 				delete attribute.lastIndexedKey;
 				delete attribute.indexingPID;
+				delete attribute.indexingFailed;
+				delete attribute.indexingAttempt;
 				attribute.dbi.isIndexing = false;
+				// Also clear isIndexing on the currently-active dbi in Table.indices, which may
+				// differ from attribute.dbi if a resetDatabases() call during this migration
+				// opened a new dbi and registered it there.
+				const activeDbi = Table.indices[attribute.name];
+				if (activeDbi) activeDbi.isIndexing = false;
 				lastResolution = Table.dbisDB.put(attribute.key, attribute);
 			}
+			await lastResolution;
+			// now notify all the threads that we are done and the index is ready to use
+			await signalling.signalSchemaChange(
+				new SchemaEventMsg(process.pid, 'indexing-finished', Table.databaseName, Table.tableName)
+			);
+			logger.info(`Finished indexing ${Table.tableName} attributes`, attributes);
 		}
-		await lastResolution;
-		// now notify all the threads that we are done and the index is ready to use
-		await signalling.signalSchemaChange(
-			new SchemaEventMsg(process.pid, 'indexing-finished', Table.databaseName, Table.tableName)
-		);
-		logger.info(`Finished indexing ${Table.tableName} attributes`, attributes);
 	} catch (error) {
 		logger.error('Error in indexing', error);
 	}

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1127,7 +1127,6 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 							attribute.lastIndexedKey = attributeDescriptor?.lastIndexedKey ?? undefined;
 							attribute.indexingPID = process.pid;
 							delete attribute.indexingFailed; // clear failure flag for the new run
-							delete attribute.indexingAttempt; // reset attempt counter
 							dbi.isIndexing = true;
 							Object.defineProperty(attribute, 'dbi', { value: dbi, configurable: true, enumerable: false });
 							// we only set indexing nulls to true if new or reindexing, we can't have partial indexing of null
@@ -1297,7 +1296,13 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 				else if (outstanding > MIN_OUTSTANDING_INDEXING) await new Promise((resolve) => setImmediate(resolve)); // yield event turn, don't want to use all computation
 			}
 		}
-		// Await the last pending put. If it rejects, that's also an indexing error.
+		// Await the last pending put. If it rejects, that is also an indexing error.
+		// Note: the when() calls above already attach rejection handlers to each record's
+		// last-put promise; this try-catch specifically handles the case where lastResolution
+		// itself rejects (i.e. the very last put in the loop failed) which would otherwise
+		// throw past the hadIndexingErrors check to the outer catch. The broader issue of
+		// unhandled rejections from non-last puts in multi-value attributes is pre-existing
+		// and out of scope for this fix.
 		try {
 			await lastResolution;
 		} catch (error) {
@@ -1328,7 +1333,7 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 			}
 			await lastResolution;
 			logger.warn(
-				`Indexing of ${Table.tableName} encountered errors on some records — index will remain incomplete. ` +
+				`Indexing of ${Table.tableName} encountered errors on some records - index will remain incomplete. ` +
 					`On next restart the migration will be retried from the last checkpoint (indexingFailed=true). ` +
 					`Affected attributes: ${attributes.map((a) => a.name).join(', ')}`
 			);
@@ -1338,7 +1343,6 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 				delete attribute.lastIndexedKey;
 				delete attribute.indexingPID;
 				delete attribute.indexingFailed;
-				delete attribute.indexingAttempt;
 				attribute.dbi.isIndexing = false;
 				// Also clear isIndexing on the currently-active dbi in Table.indices, which may
 				// differ from attribute.dbi if a resetDatabases() call during this migration

--- a/unitTests/resources/schemaMigrationFragility.test.js
+++ b/unitTests/resources/schemaMigrationFragility.test.js
@@ -123,24 +123,55 @@ describe('schema-migration fragility: silent gaps when per-record indexing error
 		}
 		if (Tbl.indexingOperation) await Tbl.indexingOperation;
 
-		// Sum the per-value search counts and compare to the primary store.
+		// With the fix, the index must NOT be silently complete when errors occurred.
+		// The fix leaves isIndexing = true and sets indexingFailed = true so:
+		//   (a) queries return 503 "not indexed yet" instead of a partial result set, and
+		//   (b) the next restart (new PID) detects indexingFailed and re-triggers from checkpoint.
+		//
+		// Verify (a): search must throw, not silently return fewer rows.
+		let caughtError;
+		try {
+			for (const v of VALUES) {
+				await collect(Tbl.search({ conditions: [{ attribute: 'tag', value: v }] }));
+			}
+		} catch (err) {
+			caughtError = err;
+		}
+		assert.ok(
+			caughtError,
+			`Expected search to throw "not indexed yet" (503) after a partial migration with errors. ` +
+				`Without the fix this returns a silent subset, making the bug invisible to callers.`
+		);
+		assert.ok(
+			caughtError.message?.includes('not indexed yet') || caughtError.statusCode === 503,
+			`Expected 503 "not indexed yet", got: ${caughtError.message}`
+		);
+
+		// Verify (b): indexingFailed is persisted so a restart-simulated re-call to table() retries.
+		resetDatabases();
+		// Re-open the same table — this time without any put mock, simulating a fresh process.
+		// The indexingFailed flag on disk triggers a re-migration from the last checkpoint.
+		const Tbl2 = table({
+			table: TABLE2,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		assert.ok(
+			Tbl2.indexingOperation,
+			`After restart, table() should have detected indexingFailed and re-triggered runIndexing`
+		);
+		if (Tbl2.indexingOperation) await Tbl2.indexingOperation;
+
+		// After the clean retry, all rows should be found.
 		let viaIndex = 0;
 		for (const v of VALUES) {
-			const rows = await collect(Tbl.search({ conditions: [{ attribute: 'tag', value: v }] }));
+			const rows = await collect(Tbl2.search({ conditions: [{ attribute: 'tag', value: v }] }));
 			viaIndex += rows.length;
 		}
-		let viaPrimary = 0;
-		for (const entry of Tbl.primaryStore.getRange({ start: true })) {
-			if (entry.value) viaPrimary++;
-		}
-		// If F2 manifests, viaIndex < viaPrimary because some records were skipped
-		// in the index when the put failed, but the records still exist in primary store.
-		assert.equal(
-			viaIndex,
-			viaPrimary,
-			`indexed search saw ${viaIndex} rows but primary store has ${viaPrimary}. ` +
-				`F2 fingerprint: per-record indexing errors leave silent gaps in the new index.`
-		);
+		assert.equal(viaIndex, N, `After restart-triggered retry, all ${N} rows should be indexed. Got ${viaIndex}.`);
 	});
 });
 

--- a/unitTests/resources/schemaMigrationFragility.test.js
+++ b/unitTests/resources/schemaMigrationFragility.test.js
@@ -1,0 +1,275 @@
+/**
+ * Probes for fragility in the schema-migration / reindexing code path in
+ * resources/databases.ts. Each test targets a specific risk surface called out
+ * during analysis of serent-canopy issue #135:
+ *
+ *  F2: per-record indexing errors inside `runIndexing` are caught and logged,
+ *      but the loop CONTINUES to the next record, leaving silent gaps in the
+ *      new index. A migration appears to "complete" successfully while queries
+ *      miss records — exactly the user-observed fingerprint.
+ *
+ *  F3: a concurrent write that mutates a record AFTER `runIndexing` reads it
+ *      but BEFORE `runIndexing` writes its index entry leaves the index with
+ *      a stale (now-incorrect) composite key in addition to the correct one.
+ *
+ *  F1: the double-checked-locking in table() at databases.ts:1093-1133 reuses
+ *      the `changed` variable computed before the exclusive lock, even after
+ *      re-fetching the attribute descriptor inside the lock. A second thread
+ *      can wastefully re-trigger a migration that the first thread already did.
+ *      (Idempotent on disk, but spuriously bumps schemaVersion and re-runs the
+ *      whole index scan.)
+ *
+ * These tests are designed to FAIL if the fragility manifests, so they
+ * function as both diagnostics and regression guards.
+ */
+require('../testUtils');
+const assert = require('node:assert/strict');
+const { setupTestDBPath } = require('../testUtils');
+const { table, resetDatabases } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+
+async function collect(iter) {
+	const out = [];
+	for await (const x of iter) out.push(x);
+	return out;
+}
+
+describe('schema-migration fragility: silent gaps when per-record indexing errors occur (F2)', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+
+	const TABLE = 'F2SilentIndexGap';
+	const DB = 'test';
+	const N = 50;
+
+	before(async () => {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		// Phase 1: write rows BEFORE the attribute is indexed.
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) {
+			last = Tbl.put({ id: 'k-' + i, tag: i % 2 === 0 ? 'even' : 'odd' });
+		}
+		await last;
+	});
+
+	it('completed indexing should reflect every existing row in the new index', async () => {
+		resetDatabases();
+		const Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		if (Tbl.indexingOperation) await Tbl.indexingOperation;
+
+		const evens = await collect(Tbl.search({ conditions: [{ attribute: 'tag', value: 'even' }] }));
+		const odds = await collect(Tbl.search({ conditions: [{ attribute: 'tag', value: 'odd' }] }));
+		assert.equal(
+			evens.length + odds.length,
+			N,
+			`expected ${N} rows total across the new index, got ${evens.length + odds.length}`
+		);
+	});
+
+	it('reproduces a silent gap when a per-record index write rejects mid-flight', async () => {
+		// Force a fresh migration cycle by recreating with a DIFFERENT attribute
+		// name so a NEW index has to be backfilled.
+		const TABLE2 = TABLE + 'WithThrowingIndex';
+		resetDatabases();
+		let Tbl = table({
+			table: TABLE2,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		const VALUES = ['alpha', 'beta', 'gamma'];
+		for (let i = 0; i < N; i++) {
+			last = Tbl.put({ id: 't2-' + i, tag: VALUES[i % VALUES.length] });
+		}
+		await last;
+
+		// Now add @indexed to tag. During runIndexing, intercept dbi.put calls
+		// for some records to simulate transient errors (e.g. ERR_BUSY).
+		resetDatabases();
+		Tbl = table({
+			table: TABLE2,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		const tagIndex = Tbl.indices?.tag;
+		if (tagIndex && typeof tagIndex.put === 'function') {
+			const origPut = tagIndex.put.bind(tagIndex);
+			let opCount = 0;
+			tagIndex.put = function (indexedValue, primaryKey, options) {
+				opCount++;
+				// reject every 10th index put with a simulated transient error
+				if (opCount % 10 === 0) {
+					return Promise.reject(
+						Object.assign(new Error('simulated transient index put failure'), { code: 'ERR_BUSY' })
+					);
+				}
+				return origPut(indexedValue, primaryKey, options);
+			};
+		}
+		if (Tbl.indexingOperation) await Tbl.indexingOperation;
+
+		// Sum the per-value search counts and compare to the primary store.
+		let viaIndex = 0;
+		for (const v of VALUES) {
+			const rows = await collect(Tbl.search({ conditions: [{ attribute: 'tag', value: v }] }));
+			viaIndex += rows.length;
+		}
+		let viaPrimary = 0;
+		for (const entry of Tbl.primaryStore.getRange({ start: true })) {
+			if (entry.value) viaPrimary++;
+		}
+		// If F2 manifests, viaIndex < viaPrimary because some records were skipped
+		// in the index when the put failed, but the records still exist in primary store.
+		assert.equal(
+			viaIndex,
+			viaPrimary,
+			`indexed search saw ${viaIndex} rows but primary store has ${viaPrimary}. ` +
+				`F2 fingerprint: per-record indexing errors leave silent gaps in the new index.`
+		);
+	});
+});
+
+describe('schema-migration fragility: stale index entry from concurrent write during reindex (F3)', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+
+	const TABLE = 'F3ConcurrentWriteRace';
+	const DB = 'test';
+	const N = 200;
+
+	before(async () => {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) {
+			last = Tbl.put({ id: 'c-' + i, tag: 'old' });
+		}
+		await last;
+	});
+
+	it('search by new value should not also return rows under the old value after concurrent updates during reindex', async () => {
+		resetDatabases();
+		const Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+
+		// While runIndexing is happening, update half the rows to a new value.
+		// runIndexing started but yielded the event turn at setImmediate; we
+		// kick concurrent updates immediately to overlap with the backfill scan.
+		const updates = [];
+		for (let i = 0; i < N; i += 2) {
+			updates.push(Tbl.put({ id: 'c-' + i, tag: 'new' }));
+		}
+		await Promise.all(updates);
+		if (Tbl.indexingOperation) await Tbl.indexingOperation;
+
+		const oldRows = await collect(Tbl.search({ conditions: [{ attribute: 'tag', value: 'old' }] }));
+		const newRows = await collect(Tbl.search({ conditions: [{ attribute: 'tag', value: 'new' }] }));
+
+		// After the race: half should be 'new', half 'old'.
+		assert.equal(newRows.length, N / 2, `expected ${N / 2} rows with tag=new, got ${newRows.length}`);
+		assert.equal(oldRows.length, N / 2, `expected ${N / 2} rows with tag=old, got ${oldRows.length}`);
+
+		// Cross-check: no row should appear under BOTH values in the index.
+		const newIds = new Set(newRows.map((r) => r.id));
+		const oldIds = new Set(oldRows.map((r) => r.id));
+		const overlap = [...newIds].filter((id) => oldIds.has(id));
+		assert.equal(
+			overlap.length,
+			0,
+			`F3 fingerprint: ${overlap.length} rows appear under BOTH tag values in the index — a concurrent write left a stale composite key behind from runIndexing.`
+		);
+	});
+});
+
+describe('schema-migration fragility: stale `changed` reused after re-fetch under lock (F1)', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+
+	const TABLE = 'F1StaleChangedFlag';
+	const DB = 'test';
+
+	before(async () => {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < 5; i++) {
+			last = Tbl.put({ id: 'f1-' + i, tag: 'val-' + i });
+		}
+		await last;
+	});
+
+	it('two back-to-back table() calls with the indexed attribute should not double-trigger runIndexing', async () => {
+		resetDatabases();
+		// First call: triggers migration.
+		const Tbl1 = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		const firstIndexingOp = Tbl1.indexingOperation;
+		assert.ok(firstIndexingOp, 'first table() call should have triggered indexingOperation');
+
+		// Second call: should be a no-op since descriptor on disk already reflects the indexed=true state.
+		const Tbl2 = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+
+		// If F1 manifests, the second call sees `changed=false` BEFORE the lock (descriptor in
+		// memory may match), but after re-fetching, it'd still see no change. So this specific
+		// test case is most informative when the descriptor change isn't yet flushed. The expected
+		// invariant: indexingOperation should be the SAME promise (deduplication) or `undefined`
+		// (no new migration). A NEW promise reference indicates a redundant re-trigger.
+		const secondIndexingOp = Tbl2.indexingOperation;
+		// Allow either same-promise OR undefined; flag a new promise as redundant.
+		const redundant = secondIndexingOp && secondIndexingOp !== firstIndexingOp;
+		await firstIndexingOp;
+		if (secondIndexingOp) await secondIndexingOp;
+
+		// This assertion may pass under F1 (since the on-disk descriptor has been updated by
+		// the time the second call's re-fetch happens) — F1 is the bug shape but in practice
+		// the re-fetch races with the disk write inside the same thread. In a multi-worker
+		// scenario, two concurrent table() calls is the real repro case and is harder to
+		// exercise in a single-process unit test.
+		assert.ok(
+			!redundant,
+			'F1 fingerprint: second table() call triggered a redundant runIndexing — stale `changed` reused after re-fetch under lock.'
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes a silent-data-loss bug in `runIndexing` (resources/databases.ts): when a per-record `index.put` fails during a schema-migration backfill, the error was caught/logged and the loop continued, eventually marking the index as _complete_ with gaps. Queries against the new index silently returned fewer rows than `primaryStore` scans (SQL / ops API), which is exactly the serent-canopy issue #135 fingerprint.

## Root causes

1. **Per-record error handling**: both sync catch (line 1257) and async `when()` error handler (line 1276) logged and continued — the migration appeared to complete successfully with dropped records.
2. **`await lastResolution` bypass**: if the last put in the loop was itself a rejected promise, it threw past the `hadIndexingErrors` check to the outer catch, so the fix code was never reached.

## Fix

- Wrap `await lastResolution` in its own try-catch that sets `hadIndexingErrors = true`.
- When `hadIndexingErrors` is true: do NOT clear `indexingPID`, `isIndexing`, or `lastIndexedKey`. Set `indexingFailed = true` on the descriptor and persist it.
- Add `indexingFailed` to the condition in `table()` so the next call (including after restart with a new PID) detects it and re-triggers the backfill from `lastIndexedKey`.
- Also ensure any dbi opened while `indexingPID` is set inherits `isIndexing = true` (companion fix for the `resetDatabases()` race during an active migration).
- Make the `Object.defineProperty(attribute, 'dbi', ...)` call `configurable: true` for forward compatibility.

## Test

`unitTests/resources/schemaMigrationFragility.test.js` — F2 test now passes:
- Simulates ERR_BUSY rejections on every 10th index put.
- Verifies search throws 503 "not indexed yet" (not silently returns 45/50 rows).
- Verifies `resetDatabases()` detects `indexingFailed` and re-triggers a clean backfill.

## Review attention

- `table()` condition change (lines 1106/1115): adding `|| attributeDescriptor.indexingFailed` — verify this doesn't fire spuriously in normal operation.
- `try { await lastResolution } catch` wrapping (line ~1298): previously the outer catch caught this; the new path correctly routes it through `hadIndexingErrors`. Low risk, but worth a second look.
- The `if (attributeDescriptor?.indexingPID) dbi.isIndexing = true` line (after the migration detection block) is new. It ensures any dbi created by a concurrent `resetDatabases()` also sees `isIndexing = true` while the migration is running. Confirm it doesn't leave indexes stuck in `isIndexing` when migration was already complete (it shouldn't, since `indexingPID` is cleared in the success path before `indexing-finished` signals).

🤖 Generated with Claude Sonnet 4.6 (1M context)