### PR TITLE
fix: defer and yield audit-store commit notifications

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -37,6 +37,7 @@ When adding a new commit-handler early-return path: reset `write.skipped = false
 When `table()` is called with an attribute newly marked `indexed: true` (or with any change that requires re-building the secondary index), `runIndexing` is launched asynchronously and `Table.indexingOperation` is set to its promise. While running:
 
 **In-flight state tracking (persisted to `attributesDbi`):**
+
 - `attribute.indexingPID = process.pid` — set at migration start; cleared on clean completion. On restart with a different PID, `indexingPID !== process.pid` triggers a re-migration.
 - `attribute.lastIndexedKey` — updated every 100 records as a resumable checkpoint. Cleared on clean completion; preserved on error so a retry starts from this key.
 - `attribute.indexingFailed = true` — set if any record's `index.put` errors during the backfill. `table()` checks this flag: a fresh call in the same or a new process re-triggers the backfill from `lastIndexedKey`.
@@ -46,6 +47,7 @@ When `table()` is called with an attribute newly marked `indexed: true` (or with
 When `signalSchemaChange('schema-change')` fires at the start of `runIndexing`, `syncSchemaMetadata` calls `resetDatabases()` which re-opens all tables via `table()`. This creates a _new_ dbi object and assigns it to `Table.indices[attribute.name]`. The condition `if (attributeDescriptor?.indexingPID) dbi.isIndexing = true` (just before `indices[name] = dbi` in the migration-detection block) ensures any dbi created while a migration is in progress also has `isIndexing = true`. Without this, a concurrent `resetDatabases()` would replace the in-progress dbi with a fresh one where `isIndexing` is false, allowing queries to read partial index results.
 
 **Error handling:**
+
 - Per-record sync errors: caught by the inner try-catch. Set `hadIndexingErrors = true`.
 - Per-record async rejections (`index.put` returning a rejected Promise): caught by the `when()` error handler. Set `hadIndexingErrors = true`.
 - The final `await lastResolution` is wrapped in its own try-catch because if the very last put in the loop was rejected, an unguarded `await lastResolution` would throw past the `hadIndexingErrors` check to the outer catch, silently bypassing the error path.
@@ -53,3 +55,11 @@ When `signalSchemaChange('schema-change')` fires at the start of `runIndexing`, 
 
 **`Object.defineProperty(attribute, 'dbi', ...)` must use `configurable: true`:**
 `attribute.dbi` is defined as a non-enumerable property (to prevent serialization to `attributesDbi`). It is defined with `configurable: true` so it can be re-assigned if the attribute participates in a retry cycle in the same process.
+
+## Audit-store `'committed'` notification batching (`transactionBroadcast.ts`)
+
+The cross-thread subscription path (default `crossThreads`) drives every `Table.subscribe()` consumer. When the database's audit store emits `'committed'`, we walk the audit log via a reusable iterator and dispatch matching records to subscribers. Three properties of this path are easy to break and worth knowing about before changing it:
+
+- **`databaseSubscriptions.activeCount`** is the count of live `Subscription` instances on a database. It is incremented at the end of `addSubscription` (after the Subscription is created, so the `scope: 'full-database'` early-return path correctly skips counting) and decremented in `Subscription.end()`. `notifyFromTransactionData` short-circuits when this is zero — the reusable rocksdb iterator stays put and resumes from its position the next time a subscriber arrives. Without this short-circuit, an idle database with no subscribers still pays the audit-log iteration cost on every commit during replication backlog catch-up.
+- **`notifyScheduled` + `setImmediate`** in the `'committed'` listener defers the iteration off the commit microtask. Multiple `'committed'` events that land in the same event-loop turn collapse into one notify pass. `notifyScheduled` stays set for the entire drain — including across yield-and-resume turns — so a re-entry from a new `'committed'` event cannot spawn a second concurrent notify on the same iterator.
+- **Batched yielding** in `notifyFromTransactionData` (`NOTIFY_BATCH_SIZE`) is gated by `allowYield`. The `'committed'` path passes `allowYield = true`; the `listenToCommits` (same-thread `aftercommit`) path does not, because that path holds an inter-thread `'thread-local-writes'` lock that must not span event-loop turns. `subscribersWithTxns` is carried across yields via `subscriptions.pendingTxnSubscribers` so the `end_txn` signal fires exactly once when the iterator truly drains. When `activeCount` drops to zero mid-yield, the next continuation drops the carry-over to avoid invoking ended subscribers' listeners.

--- a/resources/transactionBroadcast.ts
+++ b/resources/transactionBroadcast.ts
@@ -40,8 +40,16 @@ export function addSubscription(table, key, listener?: (key) => any, startTime?:
 				auditLogIterator = auditStore.getRange({});
 			}
 			auditStore.hasSubscriptionCommitListener = true;
+			// Coalesce 'committed' bursts: instead of iterating the audit log synchronously inside the
+			// commit microtask (which pegs the event loop during replication backlog catch-up), defer
+			// to setImmediate. Multiple commits within the same turn collapse into one notify pass.
+			// notifyScheduled stays true for the full drain — including yield-and-resume — so new
+			// 'committed' events that fire mid-drain don't spawn an overlapping notify pass.
 			auditStore.on('committed', () => {
-				notifyFromTransactionData(databaseSubscriptions, auditLogIterator);
+				if (!databaseSubscriptions.activeCount) return; // no listeners; iterator advances lazily
+				if (databaseSubscriptions.notifyScheduled) return;
+				databaseSubscriptions.notifyScheduled = true;
+				setImmediate(() => notifyFromTransactionData(databaseSubscriptions, auditLogIterator, true));
 			});
 		}
 	}
@@ -72,6 +80,7 @@ export function addSubscription(table, key, listener?: (key) => any, startTime?:
 		subscriptions.key = key;
 	}
 	subscription.subscriptions = subscriptions;
+	databaseSubscriptions.activeCount = (databaseSubscriptions.activeCount || 0) + 1;
 	return subscription;
 }
 
@@ -94,20 +103,20 @@ class Subscription extends IterableEventQueue {
 	end() {
 		// cleanup
 		if (!this.subscriptions) return;
+		const tableSubscriptions = this.subscriptions.tables;
+		const envSubscriptions = tableSubscriptions?.envs;
 		this.subscriptions.splice(this.subscriptions.indexOf(this), 1);
 		if (this.subscriptions.length === 0) {
-			const tableSubscriptions = this.subscriptions.tables;
 			if (tableSubscriptions) {
 				// TODO: Handle cleanup of wildcard
 				const key = this.subscriptions.key;
 				tableSubscriptions.delete(key);
 				if (tableSubscriptions.size === 0) {
-					const envSubscriptions = tableSubscriptions.envs;
-					const dbi = tableSubscriptions.dbi;
-					delete envSubscriptions[dbi];
+					delete envSubscriptions[tableSubscriptions.tableId];
 				}
 			}
 		}
+		if (envSubscriptions?.activeCount > 0) envSubscriptions.activeCount--;
 		this.subscriptions = null;
 	}
 	toJSON() {
@@ -115,12 +124,25 @@ class Subscription extends IterableEventQueue {
 	}
 }
 const ACTIONS_OF_INTEREST = ['put', 'patch', 'delete', 'message', 'invalidate'];
-function notifyFromTransactionData(subscriptions, auditLogIterable) {
+// Maximum audit records processed per synchronous turn before yielding back to the event loop.
+// Sized to keep per-batch wall time within a few ms on commodity hardware while keeping the
+// scheduling overhead amortized; tune if profiling shows different shapes.
+const NOTIFY_BATCH_SIZE = 256;
+function notifyFromTransactionData(subscriptions, auditLogIterable, allowYield = false) {
 	if (!subscriptions) return; // if no subscriptions to this env path, don't need to read anything
+	// If no real subscribers are attached, skip the iteration. The reusable iterator preserves its
+	// position and will pick up from where we left it once a subscriber is added.
+	if (!subscriptions.activeCount) {
+		subscriptions.pendingTxnSubscribers = null; // discard any carry-over from a yielded run
+		if (allowYield) subscriptions.notifyScheduled = false;
+		return;
+	}
 	const auditStore = subscriptions.auditStore;
 	auditStore.resetReadTxn?.();
-	nextTransaction(subscriptions.auditStore);
-	let subscribersWithTxns;
+	nextTransaction(auditStore);
+	// subscribersWithTxns is carried across batches so the end_txn signal fires only once the
+	// iterator truly drains, not at each yield point.
+	let subscribersWithTxns = subscriptions.pendingTxnSubscribers;
 	if (!auditLogIterable) {
 		// rocksdb will pass this in, but with lmdb, we have to re-create the iterable
 		auditLogIterable = auditStore.getRange({
@@ -128,70 +150,97 @@ function notifyFromTransactionData(subscriptions, auditLogIterable) {
 			exclusiveStart: true,
 		});
 	}
-	for (const auditRecord of auditLogIterable) {
-		const timestamp: number = auditRecord.localTime ?? auditRecord.version;
-		subscriptions.lastTxnTime = timestamp;
-		if (!ACTIONS_OF_INTEREST.includes(auditRecord.type)) continue;
-		const tableSubscriptions = subscriptions[auditRecord.tableId];
-		if (!tableSubscriptions) continue;
-		const recordId = auditRecord.recordId;
-		// TODO: How to handle invalidation
-		let matchingKey = keyArrayToString(recordId);
-		let ancestorLevel = 0;
-		do {
-			// we iterate through the key hierarchy, notifying all subscribers for each key,
-			// so for an id like resource/foo/bar, we notify subscribers for resource/foo/bar, resource/foo/, resource/foo, resource/, and resource
-			// this allows for efficient subscriptions to children ids/topics
-			const keySubscriptions = tableSubscriptions.get(matchingKey);
-			if (keySubscriptions) {
-				for (const subscription of keySubscriptions) {
-					if (
-						ancestorLevel > 0 && // only ancestors if the subscription is for ancestors (and apply onlyChildren filtering as necessary)
-						!(subscription.includeDescendants && !(subscription.onlyChildren && ancestorLevel > 1))
-					)
-						continue;
-					if (subscription.startTime >= timestamp) {
-						continue;
-					}
-					try {
-						let beginTxn;
-						if (subscription.supportsTransactions && subscription.txnInProgress !== auditRecord.version) {
-							// if the subscriber supports transactions, we mark this as the beginning of a new transaction
-							// tracking the subscription so that we can delimit the transaction on next transaction
-							// (with a beginTxn flag, which may be on an endTxn event)
-							beginTxn = true;
-							if (!subscription.txnInProgress) {
-								// if first txn for subscriber of this cycle, add to the transactional subscribers that we are tracking
-								if (!subscribersWithTxns) subscribersWithTxns = [subscription];
-								else subscribersWithTxns.push(subscription);
+	const iterator = auditLogIterable[Symbol.iterator]?.() ?? auditLogIterable;
+	let processed = 0;
+	let yielded = false;
+	try {
+		while (true) {
+			const result = iterator.next();
+			if (result.done) break;
+			const auditRecord = result.value;
+			const timestamp: number = auditRecord.localTime ?? auditRecord.version;
+			subscriptions.lastTxnTime = timestamp;
+			if (ACTIONS_OF_INTEREST.includes(auditRecord.type)) {
+				const tableSubscriptions = subscriptions[auditRecord.tableId];
+				if (tableSubscriptions) {
+					const recordId = auditRecord.recordId;
+					// TODO: How to handle invalidation
+					let matchingKey = keyArrayToString(recordId);
+					let ancestorLevel = 0;
+					do {
+						// we iterate through the key hierarchy, notifying all subscribers for each key,
+						// so for an id like resource/foo/bar, we notify subscribers for resource/foo/bar, resource/foo/, resource/foo, resource/, and resource
+						// this allows for efficient subscriptions to children ids/topics
+						const keySubscriptions = tableSubscriptions.get(matchingKey);
+						if (keySubscriptions) {
+							for (const subscription of keySubscriptions) {
+								if (
+									ancestorLevel > 0 && // only ancestors if the subscription is for ancestors (and apply onlyChildren filtering as necessary)
+									!(subscription.includeDescendants && !(subscription.onlyChildren && ancestorLevel > 1))
+								)
+									continue;
+								if (subscription.startTime >= timestamp) {
+									continue;
+								}
+								try {
+									let beginTxn;
+									if (subscription.supportsTransactions && subscription.txnInProgress !== auditRecord.version) {
+										// if the subscriber supports transactions, we mark this as the beginning of a new transaction
+										// tracking the subscription so that we can delimit the transaction on next transaction
+										// (with a beginTxn flag, which may be on an endTxn event)
+										beginTxn = true;
+										if (!subscription.txnInProgress) {
+											// if first txn for subscriber of this cycle, add to the transactional subscribers that we are tracking
+											if (!subscribersWithTxns) subscribersWithTxns = [subscription];
+											else subscribersWithTxns.push(subscription);
+										}
+										// the version defines the extent of a transaction, all audit records with the same version
+										// are part of the same transaction, and when the version changes, we know it is a new
+										// transaction
+										subscription.txnInProgress = auditRecord.version;
+									}
+									subscription.listener(recordId, auditRecord, timestamp, beginTxn);
+								} catch (error) {
+									warn(error);
+								}
 							}
-							// the version defines the extent of a transaction, all audit records with the same version
-							// are part of the same transaction, and when the version changes, we know it is a new
-							// transaction
-							subscription.txnInProgress = auditRecord.version;
 						}
-						subscription.listener(recordId, auditRecord, timestamp, beginTxn);
-					} catch (error) {
-						warn(error);
-					}
+						if (matchingKey == null) break;
+						const lastSlash = matchingKey.lastIndexOf?.('/', matchingKey.length - 2);
+						if (lastSlash !== matchingKey.length - 1) {
+							ancestorLevel++; // don't increase the ancestor level for this going from resource/ to resource
+						}
+						if (lastSlash > -1) {
+							matchingKey = matchingKey.slice(0, lastSlash + 1);
+						} else matchingKey = null;
+					} while (true);
 				}
 			}
-			if (matchingKey == null) break;
-			const lastSlash = matchingKey.lastIndexOf?.('/', matchingKey.length - 2);
-			if (lastSlash !== matchingKey.length - 1) {
-				ancestorLevel++; // don't increase the ancestor level for this going from resource/ to resource
+			if (allowYield && ++processed >= NOTIFY_BATCH_SIZE) {
+				// Yield the event loop. Save in-progress txn state so the next batch can resume.
+				// Reusable iterables (rocksdb) can be passed back in directly; LMDB-style iterables
+				// are recreated from the advanced lastTxnTime. The same-thread aftercommit path does not
+				// set allowYield because it holds an inter-thread lock that must not span event-loop turns.
+				subscriptions.pendingTxnSubscribers = subscribersWithTxns;
+				yielded = true;
+				setImmediate(() =>
+					notifyFromTransactionData(subscriptions, auditStore.reusableIterable ? auditLogIterable : null, true)
+				);
+				return;
 			}
-			if (lastSlash > -1) {
-				matchingKey = matchingKey.slice(0, lastSlash + 1);
-			} else matchingKey = null;
-		} while (true);
-	}
-	if (subscribersWithTxns) {
-		// any subscribers with open transactions need to have an event to indicate that their transaction has been ended
-		for (const subscription of subscribersWithTxns) {
-			subscription.txnInProgress = null; // clean up
-			subscription.listener(null, { type: 'end_txn' }, subscriptions.lastTxnTime, true);
 		}
+		subscriptions.pendingTxnSubscribers = null;
+		if (subscribersWithTxns) {
+			// any subscribers with open transactions need to have an event to indicate that their transaction has been ended
+			for (const subscription of subscribersWithTxns) {
+				subscription.txnInProgress = null; // clean up
+				subscription.listener(null, { type: 'end_txn' }, subscriptions.lastTxnTime, true);
+			}
+		}
+	} finally {
+		// If we yielded, the continuation owns notifyScheduled; otherwise (drain or any throw) we
+		// must clear it here so a stuck flag doesn't permanently silence future commits.
+		if (allowYield && !yielded) subscriptions.notifyScheduled = false;
 	}
 }
 /**

--- a/resources/transactionBroadcast.ts
+++ b/resources/transactionBroadcast.ts
@@ -46,7 +46,13 @@ export function addSubscription(table, key, listener?: (key) => any, startTime?:
 			// notifyScheduled stays true for the full drain — including yield-and-resume — so new
 			// 'committed' events that fire mid-drain don't spawn an overlapping notify pass.
 			auditStore.on('committed', () => {
-				if (!databaseSubscriptions.activeCount) return; // no listeners; iterator advances lazily
+				if (!databaseSubscriptions.activeCount) {
+					// No per-key listeners; skip the expensive audit-log iteration entirely. But still
+					// rotate the nextTransaction promise so any whenNextTransaction() waiter (used by
+					// outbound replication on databases with no local subscribers) wakes up.
+					if (auditStore.nextTransaction) nextTransaction(auditStore);
+					return;
+				}
 				if (databaseSubscriptions.notifyScheduled) return;
 				databaseSubscriptions.notifyScheduled = true;
 				setImmediate(() => notifyFromTransactionData(databaseSubscriptions, auditLogIterator, true));

--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -902,6 +902,31 @@ describe('Subscription replay', () => {
 			assert.equal(new Set(pairs).size, pairs.length, 'duplicate (id,version) emitted during burst');
 		});
 
+		it('whenNextTransaction resolves on commit even when no per-key subscribers exist', async () => {
+			// Regression for the activeCount short-circuit: whenNextTransaction sets up a
+			// scope: 'full-database' subscription that intentionally does not increment activeCount.
+			// The 'committed' listener must still rotate the nextTransaction promise so the waiter
+			// wakes — otherwise outbound replication hangs whenever a database has no local
+			// per-key subscriptions.
+			const { whenNextTransaction } = require('#src/resources/transactionBroadcast');
+			const T = table({
+				table: 'WhenNextTxnIdle',
+				database: 'test',
+				attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+				audit: true,
+			});
+			// no Table.subscribe() — only the full-database waiter
+			const wake = whenNextTransaction(T.auditStore);
+			let resolved = false;
+			wake.then(() => {
+				resolved = true;
+			});
+			await T.put(40000, { name: 'wake_me' });
+			// give the committed listener + microtask a tick to resolve
+			await delay(50);
+			assert.equal(resolved, true, 'whenNextTransaction should resolve when a commit lands with no per-key subscribers');
+		});
+
 		it('resumes delivery after a subscribe/end/subscribe cycle with writes in between', async () => {
 			// regression for the activeCount short-circuit: when no subscribers exist, the audit
 			// notify loop skips iteration. A new subscription after a quiescent period must still

--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -870,6 +870,67 @@ describe('Subscription replay', () => {
 			assert.ok(events.length >= 0, `events array exists`);
 		});
 
+		it('delivers all live events when a single committed burst exceeds the notify batch size', async () => {
+			// transactionBroadcast yields back to the event loop every NOTIFY_BATCH_SIZE (256)
+			// audit records during a drain. A subscription receiving a burst larger than that must
+			// still see every event with no duplicates.
+			const T = table({
+				table: 'BurstNotify',
+				database: 'test',
+				attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+				audit: true,
+			});
+			const startTime = Date.now();
+			const subscription = await T.subscribe({ startTime: startTime - 100, isCollection: true });
+			// give the live-listener wiring a microtask to attach before we start writing
+			await delay(10);
+			// queue a burst of writes large enough to span multiple notify batches
+			const N = 600;
+			for (let i = 0; i < N; i++) {
+				await T.put(20000 + i, { name: 'burst' + i });
+			}
+			const events = await collect(subscription, 300);
+			subscription.return?.();
+
+			const ids = new Set(events.map((e) => e.id));
+			let missing = 0;
+			for (let i = 0; i < N; i++) {
+				if (!ids.has(20000 + i)) missing++;
+			}
+			assert.equal(missing, 0, `missing ${missing} of ${N} burst ids`);
+			const pairs = events.map((e) => `${e.id}:${e.version}`);
+			assert.equal(new Set(pairs).size, pairs.length, 'duplicate (id,version) emitted during burst');
+		});
+
+		it('resumes delivery after a subscribe/end/subscribe cycle with writes in between', async () => {
+			// regression for the activeCount short-circuit: when no subscribers exist, the audit
+			// notify loop skips iteration. A new subscription after a quiescent period must still
+			// pick up subsequent commits.
+			const T = table({
+				table: 'ResubscribeAfterIdle',
+				database: 'test',
+				attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+				audit: true,
+			});
+			const startTime = Date.now();
+			const s1 = await T.subscribe({ startTime: startTime - 1, isCollection: true });
+			await T.put(30000, { name: 'first' });
+			await delay(50);
+			s1.return?.();
+			// commits land while no subscriber is attached
+			await T.put(30001, { name: 'orphan_a' });
+			await T.put(30002, { name: 'orphan_b' });
+
+			const reSubStart = Date.now();
+			const s2 = await T.subscribe({ startTime: reSubStart - 1, isCollection: true });
+			await T.put(30003, { name: 'after_resub' });
+			const events = await collect(s2, 150);
+			s2.return?.();
+
+			const ids = new Set(events.map((e) => e.id));
+			assert.ok(ids.has(30003), 'event after re-subscribe was not delivered');
+		});
+
 		it('audit records of types not in ACTIONS_OF_INTEREST are still delivered by cursor', async () => {
 			// verifies pre-existing behavior: the cursor doesn't filter by audit type, but the
 			// listener does (notifyFromTransactionData has ACTIONS_OF_INTEREST gate). For


### PR DESCRIPTION
## Summary

Three targeted changes to [`resources/transactionBroadcast.ts`](resources/transactionBroadcast.ts) so that audit-store `'committed'` events no longer monopolize the worker event loop during heavy commit traffic (e.g. replication backlog catch-up):

- **`activeCount` short-circuit** — track live subscriptions on `databaseSubscriptions`. When zero, `notifyFromTransactionData` skips the iteration entirely. The reusable rocksdb iterator preserves its position and resumes once a subscriber arrives.
- **`setImmediate`-deferred notification** — the `'committed'` listener no longer runs `notifyFromTransactionData` synchronously inside the commit microtask. A `notifyScheduled` flag coalesces a burst of commits in the same turn into one notify pass and lets I/O (replication sockets, blob streams, HTTP) interleave.
- **Batched yielding mid-iteration** — every `NOTIFY_BATCH_SIZE` (256) records the drain `setImmediate`s its continuation. `pendingTxnSubscribers` carries across the yield so `end_txn` still fires exactly once when the iterator truly drains.

Yielding is gated by an `allowYield` parameter. The same-thread `listenToCommits` aftercommit path explicitly does **not** set it, because that path holds the cross-thread `'thread-local-writes'` lock and must complete in one turn.

Also cleans up a pre-existing leak in `Subscription.end()` where `delete envSubscriptions[dbi]` referenced an undefined `dbi` property instead of `tableSubscriptions.tableId`, leaving empty table Maps in place.

## Why

While investigating worker unresponsiveness on us-central-1.pb-prod.gend during replication backlog catch-up, CPU profiling on a 100%-pinned worker thread showed `>94%` of samples in `rocksdb-js` `TransactionLog.next()`, driven by the merge-sort aggregator iterator in `RocksTransactionLogStore.getRange({})` reached via `commit → save → … → next()`. That iterator is created by `transactionBroadcast` and walked synchronously on every commit's `'committed'` event. During backlog catch-up the cumulative cost saturates the event loop, CDP eval to the worker times out, and a single Receiving peer (4.9h behind on `prerender`) stalls every other subscription on that worker.

## Where to look

- **`notifyFromTransactionData`** in [`resources/transactionBroadcast.ts`](resources/transactionBroadcast.ts) — the drain loop is now wrapped in `try { … } finally { … }`, with `yielded`/`allowYield` controlling whether the finally clears `notifyScheduled` (so any throw inside the drain can't permanently freeze future notifications).
- **Re-entrance.** `notifyScheduled` stays `true` for the full drain *including* yield/resume turns. The `'committed'` listener early-returns when it's set, so a new commit during a yielded drain never spawns a second concurrent iteration on the same shared iterator. The iterator is reusable for rocksdb (`auditStore.reusableIterable`) and recreated from `lastTxnTime` for LMDB on each yield-continuation.
- **Semantics change worth a careful look.** Subscribers' listeners now fire on the *next* event-loop turn rather than synchronously inside the commit microtask. The two new tests below cover delivery; if anything downstream assumes synchronous-within-commit notification I'd appreciate flagging it.
- **`Subscription.end()`** — the `delete envSubscriptions[dbi]` fix changes behavior only for cases where the last subscription for a table is removed; the empty Map was previously kept alive. No call sites depend on the leaked Map.

## Test plan

- [x] `unitTests/resources/subscriptionReplay.test.js` — full file (25 passing, 9 pending). Adds two new tests:
  - `delivers all live events when a single committed burst exceeds the notify batch size` (N=600 sequential puts, asserts all 600 ids delivered with no duplicate `(id,version)` pairs).
  - `resumes delivery after a subscribe/end/subscribe cycle with writes in between` (regression for the `activeCount` short-circuit).
- [x] `unitTests/resources/auditLog.test.js`, `transaction.test.js`, `caching.test.js`, `crud.test.js` — all passing.
- [x] Lint (`npm run lint:required`) — 0 errors (392 pre-existing warnings).
- [x] Formatted (`npm run format:write`).
- [ ] Worth verifying on a live Fabric node before merging by watching worker `recentELU.utilization` and CDP responsiveness during a real backlog catch-up.

Cross-model review (Gemini) flagged three concerns; all addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code) by Claude Opus 4.7 (1M context)