### PR TITLE
spike(#549): capture restart_service crash signature on Windows (DO NOT MERGE)

### DIFF
--- a/integrationTests/apiTests/tests/23_blob.mjs
+++ b/integrationTests/apiTests/tests/23_blob.mjs
@@ -17,7 +17,7 @@ import { createBlobCustom } from '../utils/blob.mjs';
 import { exec } from 'node:child_process';
 import { timestamp } from '../utils/timestamp.mjs';
 
-describe('23. Blob', { skip: process.platform === 'win32' }, () => {
+describe('23. Blob', () => {
 	beforeEach(timestamp);
 
 	const blobId = randomInt(1000000);
@@ -122,8 +122,11 @@ describe('23. Blob', { skip: process.platform === 'win32' }, () => {
 			.expect(200);
 	});
 
-	it('Restart Service: http workers and wait', function (t) {
-		if (process.platform === 'win32') return t.skip('Windows: Skipping restart_service to avoid crash');
+	it('Restart Service: http workers and wait', function () {
+		// SPIKE: per-test Windows skip removed deliberately to capture the
+		// restart_service crash signature via the existing
+		// `run-integration-apiTests-windows` CI job + log artifact upload.
+		// See issue #549. DO NOT merge — diagnostic branch only.
 		return restartServiceHttpWorkersWithTimeout(testData.restartHttpWorkersTimeout);
 	});
 
@@ -250,8 +253,11 @@ describe('23. Blob', { skip: process.platform === 'win32' }, () => {
 		await verifyFilesDoNotExist(blobsPath);
 	});
 
-	it('Restart Service: http workers and wait', function (t) {
-		if (process.platform === 'win32') return t.skip('Windows: Skipping restart_service to avoid crash');
+	it('Restart Service: http workers and wait', function () {
+		// SPIKE: per-test Windows skip removed deliberately to capture the
+		// restart_service crash signature via the existing
+		// `run-integration-apiTests-windows` CI job + log artifact upload.
+		// See issue #549. DO NOT merge — diagnostic branch only.
 		return restartServiceHttpWorkersWithTimeout(testData.restartHttpWorkersTimeout);
 	});
 


### PR DESCRIPTION
**DO NOT MERGE** — diagnostic branch only.

## Purpose

Trigger the existing \`run-integration-apiTests-windows\` CI job against an unskipped \`23_blob.mjs\` so we capture the actual crash signature for #549. The crash was documented in commit \`0751644f\` ("'restart_service' operation for 'http_workers' in 23_blob.mjs causes the HarperDB process to crash") but no stack trace was ever preserved.

## What this branch does

Removes the three Windows skips in \`integrationTests/apiTests/tests/23_blob.mjs\`:

1. Outer suite-level skip on \`describe('23. Blob', { skip: process.platform === 'win32' }, ...)\`
2. Per-test \`t.skip\` inside the first "Restart Service: http workers and wait"
3. Per-test \`t.skip\` inside the second "Restart Service: http workers and wait"

Every other Windows skip elsewhere in the apiTests suite remains untouched. No source code change.

## What happens

1. CI fires the existing \`run-integration-apiTests-windows\` job
2. The blob suite deploys its component, then hits \`restart_service { service: 'http_workers' }\` while the blob component has open file handles
3. Harper crashes (per Kris's prior documentation)
4. The existing \`harper-integration-api-test-logs-windows\` artifact upload captures hdb.log + stdouts + stderrs

## After the run

1. Download the artifact
2. Attach the crash signature to #549
3. Close this PR without merging

The production fix for the underlying crash lives in \`lmdb-js\` native binding cleanup or in Harper's worker shutdown ordering — neither involves un-skipping these tests in this manner. This is purely a diagnostic capture.

## Note re: Kris's PR #555

#555 is migrating the apiTests suite to the new \`@harperfast/integration-testing\` framework on isolated per-test-file Harper instances. It does not touch \`23_blob.mjs\` in this first slice. Spike and #555 don't conflict at the file level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)