### PR TITLE
Retry saveStructures transaction on busy

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -199,20 +199,23 @@ export class RecordEncoder extends Encoder {
 		const superGetStructures = this.getStructures;
 		this.saveStructures = function (structures, isCompatible): boolean | undefined {
 			if (this.isRocksDB) {
-				return this.rootStore.transactionSync((txn) => {
-					const sharedStructuresKey = [Symbol.for('structures'), this.name];
-					const existingStructuresBuffer = txn.getBinarySync(sharedStructuresKey);
-					const existingStructures = existingStructuresBuffer ? this.decode(existingStructuresBuffer) : undefined;
-					if (typeof isCompatible == 'function') {
-						if (!isCompatible(existingStructures)) {
+				return this.rootStore.transactionSync(
+					(txn) => {
+						const sharedStructuresKey = [Symbol.for('structures'), this.name];
+						const existingStructuresBuffer = txn.getBinarySync(sharedStructuresKey);
+						const existingStructures = existingStructuresBuffer ? this.decode(existingStructuresBuffer) : undefined;
+						if (typeof isCompatible == 'function') {
+							if (!isCompatible(existingStructures)) {
+								return false;
+							}
+						} else if (existingStructures && existingStructures.length !== isCompatible) {
 							return false;
 						}
-					} else if (existingStructures && existingStructures.length !== isCompatible) {
-						return false;
-					}
-					txn.putSync(sharedStructuresKey, structures);
-					this.structureUpdate = structures;
-				});
+						txn.putSync(sharedStructuresKey, structures);
+						this.structureUpdate = structures;
+					},
+					{ retryOnBusy: true }
+				);
 			} else {
 				const result = superSaveStructures.call(this, structures, isCompatible);
 				this.structureUpdate = structures;


### PR DESCRIPTION
## Summary

One-line fix in [`resources/RecordEncoder.ts`](https://github.com/HarperFast/harper/blob/fix/save-structures-retry-on-busy/resources/RecordEncoder.ts#L202-L218): pass `{ retryOnBusy: true }` to the `transactionSync` call inside `RecordEncoder.saveStructures`.

## Purpose

CI surfaced a flake in the `HNSW concurrent PUT race condition (issue #386)` unit test (see [run 26045518727](https://github.com/HarperFast/harper/actions/runs/26045518727/job/76568521740)):

```
TransactionIsBusyError: Transaction commit failed: Resource busy id: 4
  at RecordEncoder.saveStructures (resources/RecordEncoder.ts:202:27)
```

In `rocksdb-js` the retry condition in `database.ts` is `(options?.retryOnBusy ?? err.hasLog) && attempt <= maxRetries`. The busy error from the shared-structures key has `hasLog: false`, so without an explicit `retryOnBusy: true`, the commit failure is never retried and propagates out of the worker. `maxRetries` defaults to 3, which is appropriate for this short read-check-write of the structures key.

## Where to look

- The single behavioral change is at [`resources/RecordEncoder.ts:217`](https://github.com/HarperFast/harper/blob/fix/save-structures-retry-on-busy/resources/RecordEncoder.ts#L217) — adding `{ retryOnBusy: true }` as the second arg. The rest of the diff is prettier reflow of the same callback.
- Worth confirming: that retrying `saveStructures` under contention is always safe. The transaction body re-reads `existingStructures` from inside the txn and re-evaluates `isCompatible` on each attempt, so a second attempt sees the committed state from the winning concurrent writer and either coalesces or returns `false`. No external side effects happen before commit.

## Testing

Regression coverage already exists — `unitTests/resources/vectorIndex.test.js` `HNSW concurrent PUT race condition (issue #386) > handles concurrent multi-worker PUTs without race conditions` is the test that was failing in CI; this PR is expected to make it pass.

---

🤖 Generated by Claude (Opus 4.7)