### PR TITLE
fix(ci): unbreak claude-review.yml — remove caller-side permissions: {}

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,16 +24,9 @@ concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-# Default-deny at the caller's workflow level. The reusable's per-job
-# `permissions:` blocks declare what each job actually needs and take
-# effect via GH Actions' per-job override semantics. See
-# ai-review-prompts#39 for the symmetric workflow-level deny on the
-# reusable side.
-permissions: {}
-
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@13cdfabde987db713e68986831d0b78d2e418b2f # main 2026-05-18 (post #37 + #38 + #39 — calibration layer update in harper/common.md (meta-checks + reuse/CI/lockfile rules) + label-gated review for bot-authored PRs via the `claude-review` label + workflow-level `permissions: {}` on all reusables)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@f22bf7dcb7d22d5de94c938daa9d790f2b5c776b # main 2026-05-18 (post #37 + #38 + #40 — calibration layer update + label-gated bot-PR review; #39's workflow-level `permissions: {}` reverted in #40 because it broke reusable callers via the GH Actions calling-workflow-caps-reusable rule)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (layer files + bash
@@ -44,7 +37,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 13cdfabde987db713e68986831d0b78d2e418b2f
+      ai-review-prompts-ref: f22bf7dcb7d22d5de94c938daa9d790f2b5c776b
       review-layers: |
         universal
         harper/common


### PR DESCRIPTION
**Unbreaks main.** Claude PR Review has been failing at \`startup_failure\` on every run since #561 merged (CI history: last green run \`26050013871\`, every run since is startup_failure).

## Root cause

#561 added \`permissions: {}\` at the caller's workflow level (adopting the recommendation from ai-review-prompts#39). For reusable workflows, the calling workflow's permissions **cap** the reusable's per-job grants — they can be downgraded but not escalated per [GitHub's docs](https://docs.github.com/en/actions/using-workflows/reusing-workflows#access-and-permissions). With caller's \`{}\` and reusable's \`review\` job requesting \`contents: read + pull-requests: write + id-token: write\`, the workflow can't start.

The original framing of "per-job grants override" applies within a single workflow, NOT across the \`workflow_call\` boundary. I conflated those two cases; this PR walks it back.

## Changes

- Remove the \`permissions: {}\` block from \`claude-review.yml\` (the immediate cause of the break)
- Bump \`ai-review-prompts-ref\` from \`13cdfab\` → \`f22bf7d\` to pick up [HarperFast/ai-review-prompts#40](https://github.com/HarperFast/ai-review-prompts/pull/40) which removes the symmetric \`permissions: {}\` from the reusables

## What stays

- **#38** (label-gated review for bot-authored PRs, the \`claude-review\` label) ✓
- **#37** (harper/common.md calibration update — meta-checks + reuse / CI / lockfile rules) ✓
- **Per-job \`permissions:\` blocks** in the reusable — unchanged, still the effective protection

## What goes

- Only #39's workflow-level hardening attempt. It was a rational-not-empirical change ("should be no-op via override semantics") that turned out to be load-bearing in the wrong direction.

## Followup

[HarperFast/harper#568](https://github.com/HarperFast/harper/issues/568) remains the right framing for tightening \`GITHUB_TOKEN\` permissions repo-wide. The retry should be empirical (find a working precedent of caller workflow with scoped permissions calling a reusable, validate against it, then propose) rather than rational. Not in scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)