### PR TITLE
cherry-pick: fix: prevent silent index gaps when per-record puts fail during schema migration (PR #529)

### DIFF
--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1087,7 +1087,6 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 							attribute.lastIndexedKey = attributeDescriptor?.lastIndexedKey ?? undefined;
 							attribute.indexingPID = process.pid;
 							delete attribute.indexingFailed; // clear failure flag for the new run
-							delete attribute.indexingAttempt; // reset attempt counter
 							dbi.isIndexing = true;
 							Object.defineProperty(attribute, 'dbi', { value: dbi, configurable: true, enumerable: false });
 							// we only set indexing nulls to true if new or reindexing, we can't have partial indexing of null
@@ -1257,7 +1256,13 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 				else if (outstanding > MIN_OUTSTANDING_INDEXING) await new Promise((resolve) => setImmediate(resolve)); // yield event turn, don't want to use all computation
 			}
 		}
-		// Await the last pending put. If it rejects, that's also an indexing error.
+		// Await the last pending put. If it rejects, that is also an indexing error.
+		// Note: the when() calls above already attach rejection handlers to each record's
+		// last-put promise; this try-catch specifically handles the case where lastResolution
+		// itself rejects (i.e. the very last put in the loop failed) which would otherwise
+		// throw past the hadIndexingErrors check to the outer catch. The broader issue of
+		// unhandled rejections from non-last puts in multi-value attributes is pre-existing
+		// and out of scope for this fix.
 		try {
 			await lastResolution;
 		} catch (error) {
@@ -1288,7 +1293,7 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 			}
 			await lastResolution;
 			logger.warn(
-				`Indexing of ${Table.tableName} encountered errors on some records — index will remain incomplete. ` +
+				`Indexing of ${Table.tableName} encountered errors on some records - index will remain incomplete. ` +
 					`On next restart the migration will be retried from the last checkpoint (indexingFailed=true). ` +
 					`Affected attributes: ${attributes.map((a) => a.name).join(', ')}`
 			);
@@ -1298,7 +1303,6 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 				delete attribute.lastIndexedKey;
 				delete attribute.indexingPID;
 				delete attribute.indexingFailed;
-				delete attribute.indexingAttempt;
 				attribute.dbi.isIndexing = false;
 				// Also clear isIndexing on the currently-active dbi in Table.indices, which may
 				// differ from attribute.dbi if a resetDatabases() call during this migration

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1063,6 +1063,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 				const dbi = openIndex(dbiKey, rootStore, attribute);
 				if (
 					changed ||
+					attributeDescriptor.indexingFailed ||
 					(attributeDescriptor.indexingPID && attributeDescriptor.indexingPID !== process.pid) ||
 					attributeDescriptor.restartNumber < workerData?.restartNumber
 				) {
@@ -1071,6 +1072,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 					attributeDescriptor = attributesDbi.getSync(dbiKey);
 					if (
 						changed ||
+						attributeDescriptor.indexingFailed ||
 						(attributeDescriptor.indexingPID && attributeDescriptor.indexingPID !== process.pid) ||
 						attributeDescriptor.restartNumber < workerData?.restartNumber
 					) {
@@ -1084,14 +1086,21 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 						if (hasExistingData) {
 							attribute.lastIndexedKey = attributeDescriptor?.lastIndexedKey ?? undefined;
 							attribute.indexingPID = process.pid;
+							delete attribute.indexingFailed; // clear failure flag for the new run
+							delete attribute.indexingAttempt; // reset attempt counter
 							dbi.isIndexing = true;
-							Object.defineProperty(attribute, 'dbi', { value: dbi });
+							Object.defineProperty(attribute, 'dbi', { value: dbi, configurable: true, enumerable: false });
 							// we only set indexing nulls to true if new or reindexing, we can't have partial indexing of null
 							attributesToIndex.push(attribute);
 						}
 					}
 					attributesDbi.put(dbiKey, attribute);
 				}
+				// If a migration is in progress (indexingPID set), any newly opened dbi must also
+				// reflect isIndexing = true. A resetDatabases() during an active runIndexing creates
+				// a new dbi object; without this, queries could use the new dbi (isIndexing = false)
+				// and return incomplete results while the backfill is still running.
+				if (attributeDescriptor?.indexingPID) dbi.isIndexing = true;
 				if (attributeDescriptor?.indexNulls && attribute.indexNulls === undefined) attribute.indexNulls = true;
 				dbi.indexNulls = attribute.indexNulls;
 				indices[attribute.name] = dbi;
@@ -1162,6 +1171,7 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 			lastResolution = index.drop();
 		}
 		let interrupted;
+		let hadIndexingErrors = false;
 		const attributeErrorReported = {};
 		let indexed = 0;
 		const attributesLength = attributes.length;
@@ -1215,6 +1225,7 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 							}
 						}
 					} catch (error) {
+						hadIndexingErrors = true;
 						if (!attributeErrorReported[property]) {
 							// just report an indexing error once per attribute so we don't spam the logs
 							attributeErrorReported[property] = true;
@@ -1227,6 +1238,7 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 					() => outstanding--,
 					(error) => {
 						outstanding--;
+						hadIndexingErrors = true;
 						logger.error(error);
 					}
 				);
@@ -1244,20 +1256,64 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 				if (outstanding > MAX_OUTSTANDING_INDEXING) await lastResolution;
 				else if (outstanding > MIN_OUTSTANDING_INDEXING) await new Promise((resolve) => setImmediate(resolve)); // yield event turn, don't want to use all computation
 			}
+		}
+		// Await the last pending put. If it rejects, that's also an indexing error.
+		try {
+			await lastResolution;
+		} catch (error) {
+			hadIndexingErrors = true;
+			logger.error(error);
+		}
+		// Yield one more event turn so any queued when() error callbacks (which fire as
+		// microtasks when their tracked promise settles) have a chance to set hadIndexingErrors
+		// before we decide whether to mark indexing as complete.
+		await new Promise((resolve) => setImmediate(resolve));
+		if (hadIndexingErrors) {
+			// Some records failed to index. Persist the failure marker in the descriptor so
+			// the next call to table() (including after a restart with a fresh PID) re-triggers
+			// the backfill from the last checkpoint. Do NOT clear indexingPID or isIndexing —
+			// leave the index in its incomplete state so queries return 503 "not indexed yet"
+			// rather than silently returning partial results. This is the key fix for the
+			// serent-canopy issue #135 fingerprint: a completed migration with transient errors
+			// (e.g. ERR_BUSY from RocksDB under load) leaving gaps while appearing successful.
+			for (const attribute of attributes) {
+				attribute.indexingFailed = true;
+				// Preserve lastIndexedKey so the retry resumes from the last checkpoint.
+				lastResolution = Table.dbisDB.put(attribute.key, attribute);
+				// Keep isIndexing = true on both the attribute.dbi and the currently-active dbi
+				// in Table.indices (which may differ if resetDatabases() ran during this pass).
+				attribute.dbi.isIndexing = true;
+				const activeDbi = Table.indices[attribute.name];
+				if (activeDbi) activeDbi.isIndexing = true;
+			}
+			await lastResolution;
+			logger.warn(
+				`Indexing of ${Table.tableName} encountered errors on some records — index will remain incomplete. ` +
+					`On next restart the migration will be retried from the last checkpoint (indexingFailed=true). ` +
+					`Affected attributes: ${attributes.map((a) => a.name).join(', ')}`
+			);
+		} else {
 			// update the attributes to indicate that we are finished
 			for (const attribute of attributes) {
 				delete attribute.lastIndexedKey;
 				delete attribute.indexingPID;
+				delete attribute.indexingFailed;
+				delete attribute.indexingAttempt;
 				attribute.dbi.isIndexing = false;
+				// Also clear isIndexing on the currently-active dbi in Table.indices, which may
+				// differ from attribute.dbi if a resetDatabases() call during this migration
+				// opened a new dbi and registered it there.
+				const activeDbi = Table.indices[attribute.name];
+				if (activeDbi) activeDbi.isIndexing = false;
 				lastResolution = Table.dbisDB.put(attribute.key, attribute);
 			}
+			await lastResolution;
+			// now notify all the threads that we are done and the index is ready to use
+			await signalling.signalSchemaChange(
+				new SchemaEventMsg(process.pid, 'indexing-finished', Table.databaseName, Table.tableName)
+			);
+			logger.info(`Finished indexing ${Table.tableName} attributes`, attributes);
 		}
-		await lastResolution;
-		// now notify all the threads that we are done and the index is ready to use
-		await signalling.signalSchemaChange(
-			new SchemaEventMsg(process.pid, 'indexing-finished', Table.databaseName, Table.tableName)
-		);
-		logger.info(`Finished indexing ${Table.tableName} attributes`, attributes);
 	} catch (error) {
 		logger.error('Error in indexing', error);
 	}

--- a/unitTests/resources/schemaMigrationFragility.test.js
+++ b/unitTests/resources/schemaMigrationFragility.test.js
@@ -123,24 +123,55 @@ describe('schema-migration fragility: silent gaps when per-record indexing error
 		}
 		if (Tbl.indexingOperation) await Tbl.indexingOperation;
 
-		// Sum the per-value search counts and compare to the primary store.
+		// With the fix, the index must NOT be silently complete when errors occurred.
+		// The fix leaves isIndexing = true and sets indexingFailed = true so:
+		//   (a) queries return 503 "not indexed yet" instead of a partial result set, and
+		//   (b) the next restart (new PID) detects indexingFailed and re-triggers from checkpoint.
+		//
+		// Verify (a): search must throw, not silently return fewer rows.
+		let caughtError;
+		try {
+			for (const v of VALUES) {
+				await collect(Tbl.search({ conditions: [{ attribute: 'tag', value: v }] }));
+			}
+		} catch (err) {
+			caughtError = err;
+		}
+		assert.ok(
+			caughtError,
+			`Expected search to throw "not indexed yet" (503) after a partial migration with errors. ` +
+				`Without the fix this returns a silent subset, making the bug invisible to callers.`
+		);
+		assert.ok(
+			caughtError.message?.includes('not indexed yet') || caughtError.statusCode === 503,
+			`Expected 503 "not indexed yet", got: ${caughtError.message}`
+		);
+
+		// Verify (b): indexingFailed is persisted so a restart-simulated re-call to table() retries.
+		resetDatabases();
+		// Re-open the same table — this time without any put mock, simulating a fresh process.
+		// The indexingFailed flag on disk triggers a re-migration from the last checkpoint.
+		const Tbl2 = table({
+			table: TABLE2,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		assert.ok(
+			Tbl2.indexingOperation,
+			`After restart, table() should have detected indexingFailed and re-triggered runIndexing`
+		);
+		if (Tbl2.indexingOperation) await Tbl2.indexingOperation;
+
+		// After the clean retry, all rows should be found.
 		let viaIndex = 0;
 		for (const v of VALUES) {
-			const rows = await collect(Tbl.search({ conditions: [{ attribute: 'tag', value: v }] }));
+			const rows = await collect(Tbl2.search({ conditions: [{ attribute: 'tag', value: v }] }));
 			viaIndex += rows.length;
 		}
-		let viaPrimary = 0;
-		for (const entry of Tbl.primaryStore.getRange({ start: true })) {
-			if (entry.value) viaPrimary++;
-		}
-		// If F2 manifests, viaIndex < viaPrimary because some records were skipped
-		// in the index when the put failed, but the records still exist in primary store.
-		assert.equal(
-			viaIndex,
-			viaPrimary,
-			`indexed search saw ${viaIndex} rows but primary store has ${viaPrimary}. ` +
-				`F2 fingerprint: per-record indexing errors leave silent gaps in the new index.`
-		);
+		assert.equal(viaIndex, N, `After restart-triggered retry, all ${N} rows should be indexed. Got ${viaIndex}.`);
 	});
 });
 

--- a/unitTests/resources/schemaMigrationFragility.test.js
+++ b/unitTests/resources/schemaMigrationFragility.test.js
@@ -1,0 +1,275 @@
+/**
+ * Probes for fragility in the schema-migration / reindexing code path in
+ * resources/databases.ts. Each test targets a specific risk surface called out
+ * during analysis of serent-canopy issue #135:
+ *
+ *  F2: per-record indexing errors inside `runIndexing` are caught and logged,
+ *      but the loop CONTINUES to the next record, leaving silent gaps in the
+ *      new index. A migration appears to "complete" successfully while queries
+ *      miss records — exactly the user-observed fingerprint.
+ *
+ *  F3: a concurrent write that mutates a record AFTER `runIndexing` reads it
+ *      but BEFORE `runIndexing` writes its index entry leaves the index with
+ *      a stale (now-incorrect) composite key in addition to the correct one.
+ *
+ *  F1: the double-checked-locking in table() at databases.ts:1093-1133 reuses
+ *      the `changed` variable computed before the exclusive lock, even after
+ *      re-fetching the attribute descriptor inside the lock. A second thread
+ *      can wastefully re-trigger a migration that the first thread already did.
+ *      (Idempotent on disk, but spuriously bumps schemaVersion and re-runs the
+ *      whole index scan.)
+ *
+ * These tests are designed to FAIL if the fragility manifests, so they
+ * function as both diagnostics and regression guards.
+ */
+require('../testUtils');
+const assert = require('node:assert/strict');
+const { setupTestDBPath } = require('../testUtils');
+const { table, resetDatabases } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+
+async function collect(iter) {
+	const out = [];
+	for await (const x of iter) out.push(x);
+	return out;
+}
+
+describe('schema-migration fragility: silent gaps when per-record indexing errors occur (F2)', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+
+	const TABLE = 'F2SilentIndexGap';
+	const DB = 'test';
+	const N = 50;
+
+	before(async () => {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		// Phase 1: write rows BEFORE the attribute is indexed.
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) {
+			last = Tbl.put({ id: 'k-' + i, tag: i % 2 === 0 ? 'even' : 'odd' });
+		}
+		await last;
+	});
+
+	it('completed indexing should reflect every existing row in the new index', async () => {
+		resetDatabases();
+		const Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		if (Tbl.indexingOperation) await Tbl.indexingOperation;
+
+		const evens = await collect(Tbl.search({ conditions: [{ attribute: 'tag', value: 'even' }] }));
+		const odds = await collect(Tbl.search({ conditions: [{ attribute: 'tag', value: 'odd' }] }));
+		assert.equal(
+			evens.length + odds.length,
+			N,
+			`expected ${N} rows total across the new index, got ${evens.length + odds.length}`
+		);
+	});
+
+	it('reproduces a silent gap when a per-record index write rejects mid-flight', async () => {
+		// Force a fresh migration cycle by recreating with a DIFFERENT attribute
+		// name so a NEW index has to be backfilled.
+		const TABLE2 = TABLE + 'WithThrowingIndex';
+		resetDatabases();
+		let Tbl = table({
+			table: TABLE2,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		const VALUES = ['alpha', 'beta', 'gamma'];
+		for (let i = 0; i < N; i++) {
+			last = Tbl.put({ id: 't2-' + i, tag: VALUES[i % VALUES.length] });
+		}
+		await last;
+
+		// Now add @indexed to tag. During runIndexing, intercept dbi.put calls
+		// for some records to simulate transient errors (e.g. ERR_BUSY).
+		resetDatabases();
+		Tbl = table({
+			table: TABLE2,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		const tagIndex = Tbl.indices?.tag;
+		if (tagIndex && typeof tagIndex.put === 'function') {
+			const origPut = tagIndex.put.bind(tagIndex);
+			let opCount = 0;
+			tagIndex.put = function (indexedValue, primaryKey, options) {
+				opCount++;
+				// reject every 10th index put with a simulated transient error
+				if (opCount % 10 === 0) {
+					return Promise.reject(
+						Object.assign(new Error('simulated transient index put failure'), { code: 'ERR_BUSY' })
+					);
+				}
+				return origPut(indexedValue, primaryKey, options);
+			};
+		}
+		if (Tbl.indexingOperation) await Tbl.indexingOperation;
+
+		// Sum the per-value search counts and compare to the primary store.
+		let viaIndex = 0;
+		for (const v of VALUES) {
+			const rows = await collect(Tbl.search({ conditions: [{ attribute: 'tag', value: v }] }));
+			viaIndex += rows.length;
+		}
+		let viaPrimary = 0;
+		for (const entry of Tbl.primaryStore.getRange({ start: true })) {
+			if (entry.value) viaPrimary++;
+		}
+		// If F2 manifests, viaIndex < viaPrimary because some records were skipped
+		// in the index when the put failed, but the records still exist in primary store.
+		assert.equal(
+			viaIndex,
+			viaPrimary,
+			`indexed search saw ${viaIndex} rows but primary store has ${viaPrimary}. ` +
+				`F2 fingerprint: per-record indexing errors leave silent gaps in the new index.`
+		);
+	});
+});
+
+describe('schema-migration fragility: stale index entry from concurrent write during reindex (F3)', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+
+	const TABLE = 'F3ConcurrentWriteRace';
+	const DB = 'test';
+	const N = 200;
+
+	before(async () => {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) {
+			last = Tbl.put({ id: 'c-' + i, tag: 'old' });
+		}
+		await last;
+	});
+
+	it('search by new value should not also return rows under the old value after concurrent updates during reindex', async () => {
+		resetDatabases();
+		const Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+
+		// While runIndexing is happening, update half the rows to a new value.
+		// runIndexing started but yielded the event turn at setImmediate; we
+		// kick concurrent updates immediately to overlap with the backfill scan.
+		const updates = [];
+		for (let i = 0; i < N; i += 2) {
+			updates.push(Tbl.put({ id: 'c-' + i, tag: 'new' }));
+		}
+		await Promise.all(updates);
+		if (Tbl.indexingOperation) await Tbl.indexingOperation;
+
+		const oldRows = await collect(Tbl.search({ conditions: [{ attribute: 'tag', value: 'old' }] }));
+		const newRows = await collect(Tbl.search({ conditions: [{ attribute: 'tag', value: 'new' }] }));
+
+		// After the race: half should be 'new', half 'old'.
+		assert.equal(newRows.length, N / 2, `expected ${N / 2} rows with tag=new, got ${newRows.length}`);
+		assert.equal(oldRows.length, N / 2, `expected ${N / 2} rows with tag=old, got ${oldRows.length}`);
+
+		// Cross-check: no row should appear under BOTH values in the index.
+		const newIds = new Set(newRows.map((r) => r.id));
+		const oldIds = new Set(oldRows.map((r) => r.id));
+		const overlap = [...newIds].filter((id) => oldIds.has(id));
+		assert.equal(
+			overlap.length,
+			0,
+			`F3 fingerprint: ${overlap.length} rows appear under BOTH tag values in the index — a concurrent write left a stale composite key behind from runIndexing.`
+		);
+	});
+});
+
+describe('schema-migration fragility: stale `changed` reused after re-fetch under lock (F1)', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+
+	const TABLE = 'F1StaleChangedFlag';
+	const DB = 'test';
+
+	before(async () => {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < 5; i++) {
+			last = Tbl.put({ id: 'f1-' + i, tag: 'val-' + i });
+		}
+		await last;
+	});
+
+	it('two back-to-back table() calls with the indexed attribute should not double-trigger runIndexing', async () => {
+		resetDatabases();
+		// First call: triggers migration.
+		const Tbl1 = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		const firstIndexingOp = Tbl1.indexingOperation;
+		assert.ok(firstIndexingOp, 'first table() call should have triggered indexingOperation');
+
+		// Second call: should be a no-op since descriptor on disk already reflects the indexed=true state.
+		const Tbl2 = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+
+		// If F1 manifests, the second call sees `changed=false` BEFORE the lock (descriptor in
+		// memory may match), but after re-fetching, it'd still see no change. So this specific
+		// test case is most informative when the descriptor change isn't yet flushed. The expected
+		// invariant: indexingOperation should be the SAME promise (deduplication) or `undefined`
+		// (no new migration). A NEW promise reference indicates a redundant re-trigger.
+		const secondIndexingOp = Tbl2.indexingOperation;
+		// Allow either same-promise OR undefined; flag a new promise as redundant.
+		const redundant = secondIndexingOp && secondIndexingOp !== firstIndexingOp;
+		await firstIndexingOp;
+		if (secondIndexingOp) await secondIndexingOp;
+
+		// This assertion may pass under F1 (since the on-disk descriptor has been updated by
+		// the time the second call's re-fetch happens) — F1 is the bug shape but in practice
+		// the re-fetch races with the disk write inside the same thread. In a multi-worker
+		// scenario, two concurrent table() calls is the real repro case and is harder to
+		// exercise in a single-process unit test.
+		assert.ok(
+			!redundant,
+			'F1 fingerprint: second table() call triggered a redundant runIndexing — stale `changed` reused after re-fetch under lock.'
+		);
+	});
+});


### PR DESCRIPTION
Cherry-pick of [#529](https://github.com/HarperFast/harper/pull/529) to `v5.0`.

## Summary

- `runIndexing` (in `resources/databases.ts`) no longer marks a schema-migration backfill complete when per-record `index.put` calls fail. On any error during the backfill it now persists `indexingFailed = true` and keeps `indexingPID`, `isIndexing`, and `lastIndexedKey` set, so queries get `503 "not indexed yet"` instead of silently returning a partial result set.
- Wraps the final `await lastResolution` in its own try-catch so a rejected last put cannot jump past the `hadIndexingErrors` check into the outer catch.
- A subsequent `table()` call (same process, or after restart with a different PID) detects `indexingFailed = true` and re-triggers the backfill from `lastIndexedKey`.
- `Object.defineProperty(attribute, 'dbi', ...)` is made `configurable: true` so future retry mechanisms can reassign `dbi`.
- Adds `unitTests/resources/schemaMigrationFragility.test.js` with a repro for the silent-gap fingerprint (transient `ERR_BUSY` on every 10th put), verifying (a) post-failure search throws 503 and (b) restart re-runs a clean backfill.

## Cherry-pick notes

- The DESIGN.md docs commit (`docs: document runIndexing schema-migration internals`) was a no-op on `v5.0` — those notes are already present on the branch (carried in by an earlier cherry-pick). The commit was skipped.
- `resources/databases.ts` was the only meaningful merge conflict and resolved cleanly against the v5.0 surrounding context.

## Test plan

- [ ] Integration tests pass on `cherry-pick/v5.0/pr-529`.
- [ ] `unitTests/resources/schemaMigrationFragility.test.js` runs and passes.

---
🤖 Cherry-picked by [Claude Code](https://claude.com/claude-code)