### PR TITLE
fix: export CERT_ATTRIBUTES from security/keys

### DIFF
--- a/security/keys.ts
+++ b/security/keys.ts
@@ -37,7 +37,7 @@ import { TLSSocket } from 'node:tls';
 
 const CERT_VALIDITY_DAYS = 3650;
 const CERT_DOMAINS = ['127.0.0.1', 'localhost', '::1'];
-const CERT_ATTRIBUTES = [
+export const CERT_ATTRIBUTES = [
 	{ name: 'countryName', value: 'USA' },
 	{ name: 'stateOrProvinceName', value: 'Colorado' },
 	{ name: 'localityName', value: 'Denver' },


### PR DESCRIPTION
## Summary

One-line fix: add the missing `export` to `CERT_ATTRIBUTES` in `security/keys.ts`.

## Why

The TS conversion of `security/keys` (formerly `keys.js`) dropped this export. The CommonJS version had `exports.CERT_ATTRIBUTES = CERT_ATTRIBUTES;` near the bottom of the file; the TS rewrite removed it from the public surface.

The only external consumer is harper-pro's `security/certificate.ts`, which named-imports `CERT_ATTRIBUTES` and spreads it into the subject array for `createCsr`. Without the export the import resolves to `undefined` at runtime, and `...CERT_ATTRIBUTES` throws `TypeError: CERT_ATTRIBUTES is not iterable`. That break currently fails every harper-pro replication integration test that exercises `create_csr` / `sign_certificate` / `add_node` — see [HarperFast/harper-pro#162](https://github.com/HarperFast/harper-pro/pull/162) for the downstream symptom.

## Test plan

- [ ] harper-pro integration tests pass once this lands and harper-pro bumps its submodule pointer

🤖 Generated by Claude (Opus 4.7).