### PR TITLE
test(integration): port transaction-log + audit-log suites to harperLifecycle

### DIFF
--- a/integrationTests/apiTests/transaction-logs.test.mjs
+++ b/integrationTests/apiTests/transaction-logs.test.mjs
@@ -1,0 +1,135 @@
+/**
+ * Transaction Logs integration tests.
+ *
+ * Ported from legacy `apiTests/tests/28_transactionLogs.mjs`. Verifies
+ * `read_transaction_log` returns one entry per insert batch and that
+ * `delete_transaction_logs_before` runs to completion as a job. Self-contained:
+ * each suite owns its own `test_delete_before.test_logs` table on a throwaway
+ * Harper instance.
+ */
+import { suite, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { setTimeout } from 'node:timers/promises';
+import { startHarper, teardownHarper } from '@harperfast/integration-testing';
+import { createApiClient } from './utils/client.mjs';
+import { awaitJob, getJobId } from './utils/operations.mjs';
+
+const SCHEMA = 'test_delete_before';
+const TABLE = 'test_logs';
+
+suite('Transaction Logs', (ctx) => {
+	let client;
+	const suiteStart = Date.now();
+
+	before(async () => {
+		await startHarper(ctx, { config: {}, env: {} });
+		client = createApiClient(ctx.harper);
+
+		await client
+			.req()
+			.send({ operation: 'create_table', schema: SCHEMA, table: TABLE, primary_key: 'id' })
+			.expect((r) => assert.ok(r.body.message.includes('successfully created'), r.text))
+			.expect(200);
+		// Give the table time to settle before the first read_transaction_log.
+		await setTimeout(500);
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	test('Read transaction logs before any inserts is empty', async () => {
+		await client
+			.req()
+			.send({ operation: 'read_transaction_log', schema: SCHEMA, table: TABLE })
+			.expect((r) => assert.equal(r.body.length, 0, r.text))
+			.expect(200);
+	});
+
+	test('Insert first batch of records', async () => {
+		await client
+			.req()
+			.send({
+				operation: 'insert',
+				schema: SCHEMA,
+				table: TABLE,
+				records: [
+					{ id: 1, color: 'red' },
+					{ id: 2, color: 'blue' },
+					{ id: 3, color: 'green' },
+					{ id: 4, color: 'yellow' },
+					{ id: 5, color: 'purple' },
+					{ id: 6, color: 'orange' },
+				],
+			})
+			.expect((r) => assert.equal(r.body.inserted_hashes.length, 6, r.text))
+			.expect(200);
+		// Allow the transaction log to flush so the subsequent read sees the batch.
+		await setTimeout(1000);
+	});
+
+	test('Read transaction logs after first batch', async () => {
+		await client
+			.req()
+			.send({ operation: 'read_transaction_log', schema: SCHEMA, table: TABLE })
+			.expect((r) => {
+				assert.equal(r.body.length, 1, r.text);
+				assert.equal(r.body[0].operation, 'insert', r.text);
+				assert.equal(r.body[0].records.length, 6, r.text);
+			})
+			.expect(200);
+	});
+
+	test('Insert second batch of records', async () => {
+		await client
+			.req()
+			.send({
+				operation: 'insert',
+				schema: SCHEMA,
+				table: TABLE,
+				records: [
+					{ id: 11, color: 'brown' },
+					{ id: 12, color: 'gray' },
+					{ id: 13, color: 'black' },
+				],
+			})
+			.expect((r) => assert.equal(r.body.inserted_hashes.length, 3, r.text))
+			.expect(200);
+		await setTimeout(1000);
+	});
+
+	test('Read transaction logs after second batch', async () => {
+		await client
+			.req()
+			.send({ operation: 'read_transaction_log', schema: SCHEMA, table: TABLE })
+			.expect((r) => {
+				assert.equal(r.body.length, 2, r.text);
+				assert.equal(r.body[1].operation, 'insert', r.text);
+				assert.equal(r.body[1].records.length, 3, r.text);
+			})
+			.expect(200);
+	});
+
+	test('delete_transaction_logs_before suiteStart deletes no files', async () => {
+		// `suiteStart` is from before any inserts happened — no log files should
+		// have been rotated out yet, so the job should run to completion with
+		// `log_files_deleted: 0`.
+		const response = await client
+			.req()
+			.send({
+				operation: 'delete_transaction_logs_before',
+				timestamp: `${suiteStart}`,
+				schema: SCHEMA,
+				table: TABLE,
+			})
+			.expect(200);
+
+		const jobId = getJobId(response.body);
+		const jobResponse = await awaitJob(client, jobId, 15);
+		assert.equal(jobResponse.body[0].result.log_files_deleted, 0, jobResponse.text);
+	});
+
+	test('drop test_logs table', async () => {
+		await client.req().send({ operation: 'drop_table', schema: SCHEMA, table: TABLE }).expect(200);
+	});
+});

--- a/integrationTests/apiTests/transactions.test.mjs
+++ b/integrationTests/apiTests/transactions.test.mjs
@@ -1,0 +1,336 @@
+/**
+ * Transactions / audit-log integration tests.
+ *
+ * Ported from legacy `apiTests/tests/9_transactions.mjs`. Verifies that
+ * `read_audit_log` reflects insert/update/delete/upsert mutations and supports
+ * filtering by timestamp / username / hash_value, plus that the deprecated
+ * `delete_audit_logs_before` still returns the deprecation hint.
+ *
+ * Self-contained: each suite creates its own `test_delete_before.testerama`
+ * and `test_delete_before.test_read` tables. Audit logging must be enabled
+ * for `read_audit_log` to surface entries; the legacy run flipped this on
+ * via the runtime `8a_restartHdbToUpdateConfig` step. In the new framework
+ * we just pass `logging.auditLog: true` to `startHarper` at boot.
+ */
+import { suite, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { setTimeout } from 'node:timers/promises';
+import { startHarper, teardownHarper } from '@harperfast/integration-testing';
+import { createApiClient } from './utils/client.mjs';
+import { awaitJob, getJobId } from './utils/operations.mjs';
+
+const SCHEMA = 'test_delete_before';
+const TABLE_DEPRECATED = 'testerama';
+const TABLE_AUDIT = 'test_read';
+
+suite('Transactions / audit log', (ctx) => {
+	let client;
+	let username;
+	let insertTimestamp;
+
+	before(async () => {
+		await startHarper(ctx, {
+			config: { logging: { auditLog: true } },
+			env: {},
+		});
+		client = createApiClient(ctx.harper);
+		username = ctx.harper.admin.username;
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	test('create testerama table', async () => {
+		await client
+			.req()
+			.send({ operation: 'create_table', schema: SCHEMA, table: TABLE_DEPRECATED, primary_key: 'id' })
+			.expect((r) => assert.ok(r.body.message.includes('successfully created'), r.text))
+			.expect(200);
+		await setTimeout(500);
+	});
+
+	test('Insert first batch into testerama', async () => {
+		await client
+			.req()
+			.send({
+				operation: 'insert',
+				schema: SCHEMA,
+				table: TABLE_DEPRECATED,
+				records: [
+					{ id: 1, address: '24 South st' },
+					{ id: 2, address: '6 Truck Lane' },
+					{ id: 3, address: '19 Broadway' },
+					{ id: 4, address: '34A Mountain View' },
+					{ id: 5, address: '234 Curtis St' },
+					{ id: 6, address: '115 Way Rd' },
+				],
+			})
+			.expect((r) => assert.equal(r.body.inserted_hashes.length, 6, r.text))
+			.expect(200);
+		await setTimeout(1000);
+	});
+
+	test('Insert second batch into testerama (capture pre-insert timestamp)', async () => {
+		insertTimestamp = Date.now();
+		await client
+			.req()
+			.send({
+				operation: 'insert',
+				schema: SCHEMA,
+				table: TABLE_DEPRECATED,
+				records: [
+					{ id: 11, address: '24 South st' },
+					{ id: 12, address: '6 Truck Lane' },
+					{ id: 13, address: '19 Broadway' },
+				],
+			})
+			.expect((r) => assert.equal(r.body.inserted_hashes.length, 3, r.text))
+			.expect(200);
+	});
+
+	test('delete_audit_logs_before returns deprecation hint', async () => {
+		const response = await client
+			.req()
+			.send({
+				operation: 'delete_audit_logs_before',
+				timestamp: `${insertTimestamp}`,
+				schema: SCHEMA,
+				table: TABLE_DEPRECATED,
+			})
+			.expect(200);
+
+		const jobId = getJobId(response.body);
+		const jobResponse = await awaitJob(client, jobId, 15);
+		assert.ok(jobResponse.body[0].message.includes('Successfully completed'), jobResponse.text);
+		assert.equal(
+			jobResponse.body[0].result?.deprecated,
+			'Please use delete_transaction_logs_before instead',
+			jobResponse.text
+		);
+	});
+
+	test('create test_read table', async () => {
+		await client
+			.req()
+			.send({ operation: 'create_table', schema: SCHEMA, table: TABLE_AUDIT, primary_key: 'id' })
+			.expect((r) => assert.ok(r.body.message.includes('successfully created'), r.text))
+			.expect(200);
+		await setTimeout(500);
+	});
+
+	test('Insert two records into test_read', async () => {
+		await client
+			.req()
+			.send({
+				operation: 'insert',
+				schema: SCHEMA,
+				table: TABLE_AUDIT,
+				records: [
+					{ id: 1, name: 'Penny' },
+					{ id: 2, name: 'Kato', age: 6 },
+				],
+			})
+			.expect((r) => assert.equal(r.body.inserted_hashes.length, 2, r.text))
+			.expect(200);
+		await setTimeout(100);
+	});
+
+	test('Insert one more record into test_read', async () => {
+		await client
+			.req()
+			.send({
+				operation: 'insert',
+				schema: SCHEMA,
+				table: TABLE_AUDIT,
+				records: [{ id: 3, name: 'Riley', age: 7 }],
+			})
+			.expect((r) => assert.equal(r.body.inserted_hashes.length, 1, r.text))
+			.expect(200);
+		await setTimeout(100);
+	});
+
+	test('Update two records', async () => {
+		await client
+			.req()
+			.send({
+				operation: 'update',
+				schema: SCHEMA,
+				table: TABLE_AUDIT,
+				records: [
+					{ id: 1, name: 'Penny B', age: 8 },
+					{ id: 2, name: 'Kato B' },
+				],
+			})
+			.expect((r) => assert.equal(r.body.update_hashes.length, 2, r.text))
+			.expect(200);
+		await setTimeout(100);
+	});
+
+	test('Insert record with string id', async () => {
+		await client
+			.req()
+			.send({
+				operation: 'insert',
+				schema: SCHEMA,
+				table: TABLE_AUDIT,
+				records: [{ id: 'blerrrrr', name: 'Rosco' }],
+			})
+			.expect((r) => assert.equal(r.body.inserted_hashes.length, 1, r.text))
+			.expect(200);
+		await setTimeout(100);
+	});
+
+	test('Update string-id record', async () => {
+		await client
+			.req()
+			.send({
+				operation: 'update',
+				schema: SCHEMA,
+				table: TABLE_AUDIT,
+				records: [{ id: 'blerrrrr', breed: 'Mutt' }],
+			})
+			.expect((r) => assert.equal(r.body.update_hashes.length, 1, r.text))
+			.expect(200);
+		await setTimeout(100);
+	});
+
+	test('Delete two records', async () => {
+		await client
+			.req()
+			.send({ operation: 'delete', schema: SCHEMA, table: TABLE_AUDIT, hash_values: [3, 1] })
+			.expect((r) => assert.equal(r.body.deleted_hashes.length, 2, r.text))
+			.expect(200);
+		await setTimeout(100);
+	});
+
+	test('Insert id=4 record', async () => {
+		await client
+			.req()
+			.send({
+				operation: 'insert',
+				schema: SCHEMA,
+				table: TABLE_AUDIT,
+				records: [{ id: 4, name: 'Griff' }],
+			})
+			.expect((r) => assert.equal(r.body.inserted_hashes.length, 1, r.text))
+			.expect(200);
+		await setTimeout(100);
+	});
+
+	test('Upsert records (one with no id)', async () => {
+		await client
+			.req()
+			.send({
+				operation: 'upsert',
+				schema: SCHEMA,
+				table: TABLE_AUDIT,
+				records: [
+					{ id: 4, name: 'Griffy Jr.' },
+					{ id: 5, name: 'Gizmo', age: 10 },
+					{ name: 'Moe', age: 11 },
+				],
+			})
+			.expect((r) => assert.equal(r.body.upserted_hashes.length, 3, r.text))
+			.expect(200);
+		await setTimeout(100);
+	});
+
+	test('read_audit_log records upsert transaction by hash_value=5', async () => {
+		await client
+			.req()
+			.send({
+				operation: 'read_audit_log',
+				schema: SCHEMA,
+				table: TABLE_AUDIT,
+				search_type: 'hash_value',
+				search_values: [5],
+			})
+			.expect((r) => {
+				assert.equal(r.body['5'].length, 1, r.text);
+				const transaction = r.body['5'][0];
+				assert.equal(transaction.operation, 'upsert', r.text);
+				assert.equal(transaction.records.length, 1, r.text);
+				for (const key of Object.keys(transaction.records[0])) {
+					assert.ok(['id', 'name', 'age', '__updatedtime__', '__createdtime__'].includes(key), r.text);
+				}
+			})
+			.expect(200);
+	});
+
+	test('read_audit_log returns all 8 transactions in order', async () => {
+		await client
+			.req()
+			.send({ operation: 'read_audit_log', schema: SCHEMA, table: TABLE_AUDIT })
+			.expect((r) => {
+				assert.equal(r.body.length, 8, r.text);
+
+				const expectedAttrs = ['id', 'name', '__updatedtime__'];
+				const otherAttrs = ['age', '__createdtime__'];
+
+				const upsertTrans = r.body[7];
+				assert.equal(upsertTrans.operation, 'upsert', r.text);
+				assert.equal(upsertTrans.records.length, 3, r.text);
+
+				assert.equal(upsertTrans.records[0].id, 4, r.text);
+				assert.equal(upsertTrans.records[1].id, 5, r.text);
+				assert.equal(typeof upsertTrans.records[2].id, 'number', r.text);
+
+				for (const record of upsertTrans.records) {
+					for (const key of Object.keys(record)) {
+						assert.ok([...expectedAttrs, ...otherAttrs].includes(key), r.text);
+					}
+				}
+			})
+			.expect(200);
+	});
+
+	test('read_audit_log by timestamp returns 8 transactions', async () => {
+		await client
+			.req()
+			.send({
+				operation: 'read_audit_log',
+				schema: SCHEMA,
+				table: TABLE_AUDIT,
+				search_type: 'timestamp',
+				search_values: [],
+			})
+			.expect((r) => assert.equal(r.body.length, 8, r.text))
+			.expect(200);
+	});
+
+	test('read_audit_log by username returns 8 transactions for admin', async () => {
+		await client
+			.req()
+			.send({
+				operation: 'read_audit_log',
+				schema: SCHEMA,
+				table: TABLE_AUDIT,
+				search_type: 'username',
+				search_values: [username],
+			})
+			.expect((r) => assert.equal(r.body[username].length, 8, r.text))
+			.expect(200);
+	});
+
+	test('read_audit_log by hash_value returns history per record', async () => {
+		await client
+			.req()
+			.send({
+				operation: 'read_audit_log',
+				schema: SCHEMA,
+				table: TABLE_AUDIT,
+				search_type: 'hash_value',
+				search_values: [1, 'blerrrrr'],
+			})
+			.expect((r) => {
+				assert.equal(r.body['1'].length, 3, r.text);
+				assert.equal(r.body['blerrrrr'].length, 2, r.text);
+			})
+			.expect(200);
+	});
+
+	test('drop test_read table', async () => {
+		await client.req().send({ operation: 'drop_table', schema: SCHEMA, table: TABLE_AUDIT }).expect(200);
+	});
+});

--- a/integrationTests/apiTests/utils/operations.mjs
+++ b/integrationTests/apiTests/utils/operations.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { setTimeout } from 'node:timers/promises';
+
+/**
+ * Pull the job ID out of a Harper async-operation response body. Asserts that
+ * the `job_id` field is present and that the human-readable message agrees
+ * (the message is of the form `"Started job with id <uuid>"`).
+ *
+ * @param {{ job_id?: string, message?: string }} body
+ */
+export function getJobId(body) {
+	assert.ok(body.hasOwnProperty('job_id'), JSON.stringify(body));
+	assert.equal(body.message.split(' ')[4], body.job_id, JSON.stringify(body));
+	return body.job_id;
+}
+
+/**
+ * Poll `get_job` until the job leaves `IN_PROGRESS` or the timeout expires.
+ * Returns the final supertest response so callers can assert against the
+ * job body shape.
+ *
+ * @param {ReturnType<import('./client.mjs').createApiClient>} client
+ * @param {string} jobId
+ * @param {number} [timeoutSeconds]
+ */
+export async function awaitJob(client, jobId, timeoutSeconds = 15) {
+	let response = null;
+	let elapsed = 0;
+	do {
+		response = await client.req().send({ operation: 'get_job', id: jobId }).expect(200);
+		if (response.body[0]?.status !== 'IN_PROGRESS') break;
+		await setTimeout(1000);
+		elapsed++;
+	} while (elapsed < timeoutSeconds);
+	return response;
+}
+
+/**
+ * Poll `get_job` and assert the job reached `COMPLETE` (or `ERROR` if an
+ * `expectedError` substring is given). Returns the job message.
+ *
+ * @param {ReturnType<import('./client.mjs').createApiClient>} client
+ * @param {string} jobId
+ * @param {{ expectedError?: string, expectedMessage?: string, timeoutSeconds?: number }} [options]
+ */
+export async function awaitJobCompleted(client, jobId, options = {}) {
+	const { expectedError, expectedMessage, timeoutSeconds = 30 } = options;
+
+	const response = await awaitJob(client, jobId, timeoutSeconds);
+	const job = response.body[0];
+	assert.ok(job, `expected job body, got: ${response.text}`);
+	assert.ok(job.hasOwnProperty('status'), response.text);
+
+	if (job.status === 'ERROR') {
+		if (!expectedError) {
+			assert.fail(`Job ${jobId} ERRORed unexpectedly: ${response.text}`);
+		}
+		const message = typeof job.message === 'string' ? job.message : (job.message?.error ?? '');
+		assert.ok(
+			message.includes(expectedError),
+			`Job ${jobId} ERROR message "${message}" did not include "${expectedError}": ${response.text}`
+		);
+		return message;
+	}
+
+	assert.equal(job.status, 'COMPLETE', `Job ${jobId} did not complete: ${response.text}`);
+	if (expectedMessage) {
+		assert.ok(
+			job.message.includes(expectedMessage),
+			`Job ${jobId} COMPLETE message "${job.message}" did not include "${expectedMessage}": ${response.text}`
+		);
+	}
+	return job.message;
+}


### PR DESCRIPTION
## Summary

Second slice of the api-tests migration on top of #555. Ports two more legacy suites that are fully self-contained — no Northwind data dependency — and adds a shared job-polling helper.

- `integrationTests/apiTests/transaction-logs.test.mjs` (was `tests/28_transactionLogs.mjs`) — \`read_transaction_log\` per insert batch + \`delete_transaction_logs_before\` as an async job.
- `integrationTests/apiTests/transactions.test.mjs` (was `tests/9_transactions.mjs`) — \`read_audit_log\` exercised by insert/update/delete/upsert. Audit logging used to be flipped on by the runtime \`8a_restartHdbToUpdateConfig\` step in the legacy sequential flow; this suite just passes \`logging.auditLog: true\` to \`startHarper\` at boot.
- `integrationTests/apiTests/utils/operations.mjs` — \`getJobId(body)\` + \`awaitJob(client, id, timeout)\` + \`awaitJobCompleted(client, id, {expectedError, expectedMessage})\`. Mirrors the legacy \`utils/jobs.mjs\` but bound to a per-test client.

## Purpose

Continues the migration off the monolithic sequential api-tests runner onto \`@harperfast/integration-testing\`. Each ported file owns a throwaway Harper instance on its own loopback IP, so the suites parallelize cleanly.

These two were good follow-ups to #555 because:
- Both are fully self-contained (own their own \`test_delete_before\` schema), so no Northwind fixture needed.
- Together they prove out the async-job polling pattern, which the heavier suites (csv load, etc.) will reuse.
- They demonstrate the \`config\` knob on \`startHarper\` for the runtime-config-mutating legacy modules.

## Where to look

- \`utils/operations.mjs\` — small new helper surface. Future job-polling tests will use this. \`getJobId\` returns \`body.job_id\` directly after asserting parity with the message string (rather than re-parsing the message), per Gemini's review suggestion.
- \`transactions.test.mjs\` — note the audit-log enable via \`startHarper({ config: { logging: { auditLog: true } } })\`. This pattern replaces the legacy \`set_configuration + restart\` dance for all the config-driven suites.
- The mutation→read \`setTimeout(100)\`/\`setTimeout(1000)\` delays are carried over from legacy. They may need to become a poll-until-present helper if CI shows flakiness, but I'd rather not change behavior speculatively.

## Testing

All 37 tests across the 5 ported suites pass in parallel locally:

\`\`\`
npm run test:integration -- "integrationTests/apiTests/*.test.mjs"
# ▶ System Information ✔ (2/2)
# ▶ Alter User ✔ (7/7)
# ▶ HTTP Header / Set-Cookie handling ✔ (2/2)
# ▶ Transaction Logs ✔ (7/7)
# ▶ Transactions / audit log ✔ (19/19)
# ℹ pass 37 fail 0  duration_ms ~11400
\`\`\`

Gemini cross-review surfaced the \`getJobId\` redundancy (fixed in 3eeba12). No other blockers.

---

🤖 Generated by Claude (Opus 4.7), see commit Co-Authored-By tag.