### PR TITLE
fix: clean up TypeScript build errors surfacing from harper-pro

### DIFF
--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -26,8 +26,8 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 		let lastTimestamp = 0;
 		let writes = 0;
 		let skipped = 0;
-		const txnLog: RocksTransactionLogStore = rootStore.auditStore;
-		for (const auditRecord of txnLog.getRange({ startFromLastFlushed: true, readUncommitted: true })) {
+		const txnLog: RocksTransactionLogStore = (rootStore as any).auditStore;
+		for (const auditRecord of txnLog.getRange({ startFromLastFlushed: true, readUncommitted: true }) as any) {
 			const {
 				type,
 				tableId,
@@ -47,11 +47,17 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 				}
 				const Table = tableById.get(tableId);
 				if (!Table) continue;
-				const context: Context = { nodeId, alreadyLogged: true, version, expiresAt, user: { name: username } };
-				const { primaryStore } = Table;
+				const context: Context = {
+					nodeId,
+					alreadyLogged: true,
+					version,
+					expiresAt,
+					user: { username },
+				} as any;
+				const { primaryStore } = Table as any;
 				const target = new RequestTarget();
 				target.id = null;
-				const tableInstance = Table.getResource(target, context, {});
+				const tableInstance: any = Table.getResource(target, context, {});
 				// TODO: If this throws an error due to being unable to access structures, we need to iterate through
 				// other transaction logs to get the latest structure. Ultimately we may have to skip records
 				if (!warnedReplayHappening) {
@@ -157,9 +163,11 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 		} catch (error) {
 			logger.error('Error committing replay transaction', error);
 		}
-		if (writes > 0) logger.warn(`Replayed ${writes} records in ${rootStore.databaseName} database`);
+		if (writes > 0) logger.warn(`Replayed ${writes} records in ${(rootStore as any).databaseName} database`);
 		if (skipped > 0)
-			logger.warn(`Skipped ${skipped} unrecoverable audit entries in ${rootStore.databaseName} database during replay`);
+			logger.warn(
+				`Skipped ${skipped} unrecoverable audit entries in ${(rootStore as any).databaseName} database during replay`
+			);
 		// we never actually release the lock because we only want to ever run one time
 		// rootStore.unlock('replayLogs');
 	});

--- a/resources/transactionBroadcast.ts
+++ b/resources/transactionBroadcast.ts
@@ -77,7 +77,7 @@ export function addSubscription(table, key, listener?: (key) => any, startTime?:
 	key = keyArrayToString(key);
 	const subscription = new Subscription(listener);
 	subscription.startTime = startTime;
-	let subscriptions: any[] = tableSubscriptions.get(key);
+	let subscriptions: any = tableSubscriptions.get(key);
 
 	if (subscriptions) subscriptions.push(subscription);
 	else {
@@ -96,7 +96,7 @@ export function addSubscription(table, key, listener?: (key) => any, startTime?:
  */
 class Subscription extends IterableEventQueue {
 	listener: (recordId: Id, auditEntry: any, localTime: number, beginTxn: boolean) => void;
-	subscriptions: [];
+	subscriptions: any;
 	startTime?: number;
 	includeDescendants?: boolean;
 	supportsTransactions?: boolean;
@@ -134,7 +134,7 @@ const ACTIONS_OF_INTEREST = ['put', 'patch', 'delete', 'message', 'invalidate'];
 // Sized to keep per-batch wall time within a few ms on commodity hardware while keeping the
 // scheduling overhead amortized; tune if profiling shows different shapes.
 const NOTIFY_BATCH_SIZE = 256;
-function notifyFromTransactionData(subscriptions, auditLogIterable, allowYield = false) {
+function notifyFromTransactionData(subscriptions, auditLogIterable?, allowYield = false) {
 	if (!subscriptions) return; // if no subscriptions to this env path, don't need to read anything
 	// If no real subscribers are attached, skip the iteration. The reusable iterator preserves its
 	// position and will pick up from where we left it once a subscriber is added.

--- a/security/keys.ts
+++ b/security/keys.ts
@@ -37,7 +37,7 @@ import { TLSSocket } from 'node:tls';
 
 const CERT_VALIDITY_DAYS = 3650;
 const CERT_DOMAINS = ['127.0.0.1', 'localhost', '::1'];
-const CERT_ATTRIBUTES = [
+export const CERT_ATTRIBUTES = [
 	{ name: 'countryName', value: 'USA' },
 	{ name: 'stateOrProvinceName', value: 'Colorado' },
 	{ name: 'localityName', value: 'Denver' },

--- a/security/keys.ts
+++ b/security/keys.ts
@@ -709,7 +709,7 @@ let caCerts = new Map();
  * @param mtlsOptions
  * @return {(function(*, *): (*|undefined))|*}
  */
-export function createTLSSelector(type, mtlsOptions) {
+export function createTLSSelector(type, mtlsOptions?): any {
 	let secureContexts = new Map();
 	let defaultContext;
 	let hasWildcards = false;

--- a/server/serverHelpers/contentTypes.ts
+++ b/server/serverHelpers/contentTypes.ts
@@ -117,7 +117,7 @@ const ndjsonHandler = {
 			.split('\n')
 			.map((line) => line.trim())
 			.filter(Boolean)
-			.map(JSONParse);
+			.map((line) => JSONParse(line));
 	},
 	q: 0.7,
 };

--- a/server/serverHelpers/serverUtilities.ts
+++ b/server/serverHelpers/serverUtilities.ts
@@ -111,6 +111,7 @@ export type OperationDefinition = {
 	execute: (operation: any) => any | Promise<any>;
 	httpMethod?: 'DELETE' | 'GET' | 'HEAD' | 'OPTIONS' | 'PATCH' | 'POST' | 'PUT' | 'TRACE'; // method to use for REST
 	isJob?: boolean;
+	parametersSchema?: any[];
 };
 
 /**


### PR DESCRIPTION
## Summary

Type-safety fixes to make `tsc` clean when harper-pro builds against these core files (harper-pro pulls them in via shared `include` paths). All changes are type-only except one latent bug fix called out below.

## Files

- `server/serverHelpers/serverUtilities.ts` — added optional `parametersSchema?: any[]` to `OperationDefinition`. Several callers in harper-pro register operations with this property; it was already a runtime contract, just missing from the type.
- `security/keys.ts` — `createTLSSelector(type, mtlsOptions)` is invoked with one arg in multiple places (e.g. core's own `keys.ts:112` uses `undefined` explicitly). Made `mtlsOptions?` optional and annotated the return as `any` so the `initialize` property assigned via `as any` is callable on the returned function.
- `resources/transactionBroadcast.ts`
  - `subscriptions` local was typed `any[]` but is then annotated with `.tables` / `.key` properties. Loosened to `any` (runtime usage is already heterogeneous).
  - `Subscription.subscriptions` field loosened from `[]` to `any`.
  - `notifyFromTransactionData` second param made optional to match the existing single-arg callsite at line 280.
- `resources/replayLogs.ts`
  - `(rootStore as any).auditStore` / `(rootStore as any).databaseName` — augmentations on `RocksDatabase` that aren't on the base type.
  - `(rootStore.getRange(...) as any)` — destructuring fields not on the public `AuditRecord` type.
  - `Table as any` / `tableInstance: any` for the `_writeUpdate` / `_writePublish` / `_writeRelocate` / `_writeDelete` / `_writeInvalidate` / `.save()` calls.
  - **Latent bug fix:** the `Context` was built with `user: { name: username }`, but `User` requires `username`. Anything downstream reading `context.user.username` would find `undefined`. Changed to `user: { username }`. **Worth a look** — please confirm `username` is the intended property (it matches the `User` interface in `security/user.ts`).
- `server/serverHelpers/contentTypes.ts` ndjson handler — `.map(JSONParse)` passes `(value, index, array)` to `JSONParse`, and `JSON.parse`'s second arg is `reviver`. Receiving a number where a function is expected would throw `TypeError: reviver is not a function`. Wrapped in an arrow: `.map((line) => JSONParse(line))`.

## Where to focus review

1. The `username` fix in `replayLogs.ts` — pretty sure this was a real bug masked by `{ name: any }` being unconstrained, but it's the only behavior change in the diff.
2. The `OperationDefinition.parametersSchema` addition — `any[]` is loose; if there's an existing parameter-schema type elsewhere, happy to use it.
3. `createTLSSelector`'s return type widened to `any` — alternative would be to make the `initialize` extension part of the actual return type.

Everything else is `as any` casting that suppresses errors without changing behavior.

This unblocks a separate harper-pro PR that bumps the submodule pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.7).