### PR TITLE
fix(rocks-audit-iterator): retry done iterators before returning done

### DIFF
--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -263,7 +263,37 @@ export class RocksTransactionLogStore extends EventEmitter {
 							value: onlyKeys ? earliest.timestamp : earliest,
 							done: false,
 						};
-					} // else we are done
+					}
+					// Every entry in nextEntries is done. Before declaring "no more data", give the
+					// iterators one fresh round: each per-log iterator picks up new entries when its
+					// log file has grown since the last `.next()` returned done, and updateIterators
+					// also picks up any new logs (e.g. a peer's log created by replication). Without
+					// this retry, a `{ done: true }` slot in nextEntries carried over from a previous
+					// call can persist across a burst of commits that all coalesce into a single
+					// notifyFromTransactionData wake-up — the loop above keeps skipping the stale
+					// done slot, never re-polls the underlying iterator, and the entire burst is
+					// silently dropped (no further 'committed' arrives to unstick us). This was the
+					// fingerprint of the cloneNode topology bug where peer rows landed in hdb_nodes
+					// via system-DB replication but subscribeToNodeUpdates never received the events,
+					// so onNodeUpdate never opened replication connections to those peers.
+					nextEntries.length = 0;
+					updateIterators();
+					for (let i = 0; i < nextEntries.length; i++) {
+						const result = nextEntries[i];
+						if (result.done) continue;
+						const next = result.value;
+						if (!earliest || earliest.timestamp > next.timestamp) {
+							earliest = next;
+							earliestIndex = i;
+						}
+					}
+					if (earliestIndex >= 0) {
+						nextEntries[earliestIndex] = iterators[earliestIndex].next();
+						return {
+							value: onlyKeys ? earliest.timestamp : earliest,
+							done: false,
+						};
+					}
 					nextEntries.length = 0; // reset so if this iterator is restarted, we can re-query
 					return { value: undefined, done: true };
 				},

--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -236,65 +236,53 @@ export class RocksTransactionLogStore extends EventEmitter {
 
 			aggregateIterator = {
 				next() {
-					if (nextEntries.length === 0) {
-						// on the first iteration and any time we finished all the iterators, we re-retrieve all
-						// the next entries (in case we are resuming after being done)
-						updateIterators();
-					}
-					let earliest: TransactionEntry;
-					let earliestIndex = -1;
-					for (let i = 0; i < nextEntries.length; i++) {
-						const result = nextEntries[i];
-						// skip any that are done
-						if (result.done) {
-							continue;
+					// We get up to two passes: the normal find-earliest pass, plus one retry that
+					// forces nextEntries.length = 0 to re-poll every per-log iterator (each picks
+					// up new entries when its log file has grown since the last `.next()` returned
+					// done) and to let updateIterators pick up any new logs added since the last
+					// call (e.g. a peer's log created by replication). Without the retry, a
+					// `{ done: true }` slot in nextEntries carried over from a previous call
+					// persists across a burst of commits that all coalesce into a single
+					// notifyFromTransactionData wake-up — the find-earliest loop keeps skipping
+					// the stale done slot, never re-polls the underlying iterator, and the entire
+					// burst is silently dropped (no further 'committed' arrives to unstick us).
+					// This was the fingerprint of the cloneNode topology bug where peer rows
+					// landed in hdb_nodes via system-DB replication but subscribeToNodeUpdates
+					// never received the events, so onNodeUpdate never opened replication
+					// connections to those peers.
+					for (let attempt = 0; attempt < 2; attempt++) {
+						if (nextEntries.length === 0) {
+							// on the first iteration and any time we finished all the iterators,
+							// we re-retrieve all the next entries (in case we are resuming after
+							// being done)
+							updateIterators();
 						}
-						// find the earliest one that is not done
-						const next = result.value;
-						if (!earliest || earliest.timestamp > next.timestamp) {
-							earliest = next;
-							earliestIndex = i;
+						let earliest: TransactionEntry;
+						let earliestIndex = -1;
+						for (let i = 0; i < nextEntries.length; i++) {
+							const result = nextEntries[i];
+							// skip any that are done
+							if (result.done) {
+								continue;
+							}
+							// find the earliest one that is not done
+							const next = result.value;
+							if (!earliest || earliest.timestamp > next.timestamp) {
+								earliest = next;
+								earliestIndex = i;
+							}
 						}
-					}
-					if (earliestIndex >= 0) {
-						// replace the entry with the next one from the iterator we pulled from
-						nextEntries[earliestIndex] = iterators[earliestIndex].next();
-						return {
-							value: onlyKeys ? earliest.timestamp : earliest,
-							done: false,
-						};
-					}
-					// Every entry in nextEntries is done. Before declaring "no more data", give the
-					// iterators one fresh round: each per-log iterator picks up new entries when its
-					// log file has grown since the last `.next()` returned done, and updateIterators
-					// also picks up any new logs (e.g. a peer's log created by replication). Without
-					// this retry, a `{ done: true }` slot in nextEntries carried over from a previous
-					// call can persist across a burst of commits that all coalesce into a single
-					// notifyFromTransactionData wake-up — the loop above keeps skipping the stale
-					// done slot, never re-polls the underlying iterator, and the entire burst is
-					// silently dropped (no further 'committed' arrives to unstick us). This was the
-					// fingerprint of the cloneNode topology bug where peer rows landed in hdb_nodes
-					// via system-DB replication but subscribeToNodeUpdates never received the events,
-					// so onNodeUpdate never opened replication connections to those peers.
-					nextEntries.length = 0;
-					updateIterators();
-					for (let i = 0; i < nextEntries.length; i++) {
-						const result = nextEntries[i];
-						if (result.done) continue;
-						const next = result.value;
-						if (!earliest || earliest.timestamp > next.timestamp) {
-							earliest = next;
-							earliestIndex = i;
+						if (earliestIndex >= 0) {
+							// replace the entry with the next one from the iterator we pulled from
+							nextEntries[earliestIndex] = iterators[earliestIndex].next();
+							return {
+								value: onlyKeys ? earliest.timestamp : earliest,
+								done: false,
+							};
 						}
+						// All current entries are done; force the retry pass to re-poll
+						nextEntries.length = 0;
 					}
-					if (earliestIndex >= 0) {
-						nextEntries[earliestIndex] = iterators[earliestIndex].next();
-						return {
-							value: onlyKeys ? earliest.timestamp : earliest,
-							done: false,
-						};
-					}
-					nextEntries.length = 0; // reset so if this iterator is restarted, we can re-query
 					return { value: undefined, done: true };
 				},
 				addLog(logName: string) {

--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -506,6 +506,36 @@ describe('Subscription replay', () => {
 			}
 		});
 
+		// Regression: subscribe to an empty table, then write a single record. Production
+		// repro: cloneNode peers not appearing in subscribeToNodeUpdates. The rocksdb-backed
+		// aggregate audit-log iterator (RocksTransactionLogStore.getRange with no specified
+		// log) was created when the only log was empty, so its initial
+		// `iterators.map(it => it.next())` populated `nextEntries` with `{ done: true }`. The
+		// inner `next()` loop kept skipping that stale done slot without re-polling the
+		// underlying iterator, so when the write's `'committed'` wake-up arrived and called
+		// `notifyFromTransactionData`, the aggregate iterator returned `done` immediately
+		// and the write was silently dropped — leaving the subscriber waiting forever.
+		it('!omitCurrent: subscribe-then-write on a fresh database delivers the write', async () => {
+			const T = table({
+				table: 'SubReplaySubThenOne',
+				database: 'subReplaySubThenOne', // fresh database — no prior subscriptions/iterator
+				attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+				audit: true,
+			});
+			const subscription = await T.subscribe({ isCollection: true });
+			const events = [];
+			subscription.on('data', (e) => events.push(e));
+			// allow subscribe's IIFE to fully complete before issuing the write — this is
+			// the production timing: subscribe is established, then a live write arrives
+			await delay(50);
+			await T.put(50000, { name: 'single' });
+			await delay(300);
+			subscription.return?.();
+
+			assert.equal(events.length, 1, `expected 1 event for the post-subscribe write, got ${events.length}`);
+			assert.equal(events[0].id, 50000);
+		});
+
 		it('count: subscribe while writes are in flight does not duplicate history', async function () {
 			if (!isLMDB) return this.skip();
 			// pre-populate so we have history to capture


### PR DESCRIPTION
## Summary

Fix a silent-drop in `RocksTransactionLogStore.getRange()`'s aggregate audit-log iterator that bites the cluster topology after `cloneNode`: peer `hdb_nodes` rows arrive correctly via system-DB replication, but the subscribe stream consumed by `replication/subscriptionManager.subscribeToNodeUpdates` never sees the `'put'` events for them — so `onNodeUpdate` never opens replication connections to those peers, and the cluster stabilizes in a star topology (everyone connected to leader, no peer-to-peer). Any process restart fixes it, because `subscribeToNodeUpdates`'s synchronous seed loop reads `primaryStore` directly without going through the audit-log iterator.

## When this regressed

Commit `c91532112` "fix: defer and yield audit-store commit notifications" (May 14, 2026, 1 day after 5.0.16) made the `'committed'` listener defer to `setImmediate` and coalesce concurrent commits via `notifyScheduled`. Before that commit, every `'committed'` ran `notifyFromTransactionData` synchronously, so even if the aggregate iterator had a stale `{ done: true }` slot from a previous call, the very next commit unstuck it. After the deferral landed, bursts of commits (e.g. a `cloneNode` full-copy of `hdb_nodes`) collapse to one notify pass — and if that pass returns done due to the stale state, no further `'committed'` arrives to recover.

5.0.16 doesn't have c91532112 → no symptom. 5.0.17+ (including the v5.0 cherry-pick in PR #544) and current main → symptom.

## Root cause

`aggregateIterator.next()` carries `nextEntries` across calls. A previous call that found no non-done entries leaves a `{ done: true }` slot in `nextEntries`; subsequent calls keep skipping that slot in the find-earliest loop **without re-calling .next() on the underlying per-log iterator**. The only path that re-polls is `updateIterators()`, which runs only when `nextEntries.length === 0` (set right before returning `done`).

With c91532112's coalescing in place: a burst of replication writes during a clone collapses into a single `setImmediate(notifyFromTransactionData)` wake-up. If the iterator was last in a "found nothing" state, that single pass returns `done` immediately, drops the entire burst, and clears `notifyScheduled`. Without another commit to fire `'committed'`, the iterator is stuck — which is the production fingerprint.

## The fix

When the find-earliest loop finds no entry, do one fresh round of `updateIterators()` before declaring done. This:

1. Re-polls every per-log iterator — rocksdb-js per-log iterators recover from `done` once their log file has grown.
2. Picks up any logs added since the last `updateIterators` (e.g. peer logs created by replication's `ensureLogExists`).

Bounded to a single retry via `for (attempt = 0; attempt < 2; attempt++)`, so no busy-loop and no perf impact on the happy path (only kicks in when we'd otherwise return `done`).

## Where reviewer attention is most valuable

- **`resources/RocksTransactionLogStore.ts`** — the retry block in `aggregateIterator.next()`. Verify the bounded-retry semantics are correct (we don't recurse, the inner `updateIterators` call re-checks `latestUpdates !== this.updates`, and we still return `done` if nothing new arrived).
- **Race-condition coverage** — the new unit test (`!omitCurrent: subscribe-then-write on a fresh database delivers the write`) is **not** a deterministic repro of the production race. It passes on `main` today without the fix because the race is timing-dependent on cross-thread `'committed'` coalescing. It's there as a smoke test for the post-subscribe live-stream path and as documentation. The real validation will come from CI integration tests (`integrationTests/cloneNode/cloneNode.test.mjs` 4-node topology + `integrationTests/cluster/replicationTopology.test.mjs`) and from harper-pro's downstream integration coverage once this lands and the submodule is bumped.
- **Secondary bug Gemini flagged**: `aggregateIterator.addLog(name)` only removes the name from `options.excludeLogs`; it doesn't bump `this.updates`, so `updateIterators` won't see it as a new log and the dynamic-include path is silently a no-op. Out of scope here, worth a follow-up.

## Test plan

- [x] `unitTests/resources/subscriptionReplay.test.js` — 27 passing, 9 skipped (rocksdb-skipped tests unrelated to this fix). No regressions.
- [x] Gemini code review — analysis sound, fix correct, placement correct. Suggested for-loop refactor applied.
- [ ] CI integration tests pass on this branch.
- [ ] Downstream: harper-pro submodule bump + verify cluster integration tests pass with the bumped core.
- [ ] Production: clone a 4+ node cluster on the bumped core and confirm full mesh forms without restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)