### PR TITLE
fix(v5.0): backport subscription startTime gate fix from main

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -6,7 +6,7 @@
 
 import { CONFIG_PARAMS, OPERATIONS_ENUM, SYSTEM_TABLE_NAMES, SYSTEM_SCHEMA_NAME } from '../utility/hdbTerms.ts';
 import { type Database } from 'lmdb';
-import { getIndexedValues, getNextMonotonicTime } from '../utility/lmdb/commonUtility.js';
+import { getIndexedValues } from '../utility/lmdb/commonUtility.js';
 import { getThisNodeId, exportIdMapping } from './nodeIdMapping.ts';
 import lodash from 'lodash';
 import { ExtendedIterable, SKIP } from '@harperfast/extended-iterable';
@@ -2726,52 +2726,40 @@ export function makeTable(options) {
 						pendingRealTimeQueue = null;
 						dropDuringReplay = true;
 
-						for (const auditRecord of auditStore.getRange({
-							start: startTime,
-							exclusiveStart: true,
-							snapshot: false, // no need for a snapshot, audits don't change
-						})) {
-							if (++recordsSinceYield >= REPLAY_YIELD_INTERVAL) {
-								recordsSinceYield = 0;
-								await rest();
-							}
-							if (auditRecord.tableId !== tableId) continue;
-							const id = auditRecord.recordId;
-							if (thisId == null || isDescendantId(thisId, id)) {
-								const value = auditRecord.getValue(primaryStore, getFullRecord, auditRecord.localTime);
-								send({
-									id,
-									localTime: auditRecord.localTime,
-									value,
-									version: auditRecord.version,
-									type: auditRecord.type,
-									size: auditRecord.size,
-								});
-								if (subscription.queue?.length > EVENT_HIGH_WATER_MARK) {
-									// if we have too many messages, we need to pause and let the client catch up
-									if ((await subscription.waitForDrain()) === false) return;
+						try {
+							for (const auditRecord of auditStore.getRange({
+								start: startTime,
+								exclusiveStart: true,
+								snapshot: false, // no need for a snapshot, audits don't change
+							})) {
+								if (++recordsSinceYield >= REPLAY_YIELD_INTERVAL) {
+									recordsSinceYield = 0;
+									await rest();
 								}
+								if (auditRecord.tableId !== tableId) continue;
+								const id = auditRecord.recordId;
+								if (thisId == null || isDescendantId(thisId, id)) {
+									const value = auditRecord.getValue(primaryStore, getFullRecord, auditRecord.localTime);
+									send({
+										id,
+										localTime: auditRecord.localTime,
+										value,
+										version: auditRecord.version,
+										type: auditRecord.type,
+										size: auditRecord.size,
+									});
+									if (subscription.queue?.length > EVENT_HIGH_WATER_MARK) {
+										// if we have too many messages, we need to pause and let the client catch up
+										if ((await subscription.waitForDrain()) === false) return;
+									}
+								}
+								subscription!.startTime = auditRecord.localTime ?? auditRecord.version; // update so we don't double send
 							}
-							subscription!.startTime = auditRecord.localTime ?? auditRecord.version; // update so we don't double send
+						} finally {
+							// replay is done, we can start sending real-time messages again
+							dropDuringReplay = false;
 						}
-						// No catch-up sweep needed. With snapshot:false (lmdb), notifyFromTransactionData
-						// calls resetReadTxn before iterating, which bumps renewId; on the cursor's next
-						// .next() it renews to a fresh txn whose snapshot is at least as recent. With
-						// rocksdb, the audit-log iterator re-reads `_lastCommittedPosition` on each next()
-						// (live tail). Either way, at loop exit subscription.startTime is at or past
-						// lastTxnTime, and the gate in notifyFromTransactionData handles the handoff
-						// once dropDuringReplay flips back.
-						dropDuringReplay = false;
 					} else if (count) {
-						// Raise the listener's gate up front so that any in-flight 'committed' callbacks
-						// for records the cursor will capture in `history` get gated out of
-						// pendingRealTimeQueue rather than queued and re-emitted as duplicates after
-						// history is sent. getNextMonotonicTime() returns a strictly-greater value than
-						// any audit record's localTime issued so far — it's the same source Harper uses
-						// to assign localTimes — so this gates exactly the records the cursor's
-						// snapshot:true view can see. Anything committed strictly after this point will
-						// pass the gate and reach the queue.
-						subscription!.startTime = getNextMonotonicTime();
 						const history = [];
 						// we are collecting the history in reverse order to get the right count, then reversing to send
 						for (const auditRecord of auditStore.getRange({ start: 'z', end: false, reverse: true })) {
@@ -2800,16 +2788,29 @@ export function makeTable(options) {
 						for (let i = history.length; i > 0; ) {
 							send(history[--i]);
 						}
+						// Use the latest record cursor saw (history[0] = most recent due to reverse
+						// iteration) as the gate. This is in the audit log's own time domain (works for
+						// both lmdb's localTime and rocksdb's transaction-derived version) — a JS-side
+						// `getNextMonotonicTime()` would not be comparable to rocksdb's native
+						// transaction timestamps.
+						const cursorMaxTime = history[0]?.localTime ?? history[0]?.version ?? 0;
+						if (cursorMaxTime) subscription!.startTime = cursorMaxTime;
+						// In-flight pre-subscribe 'committed' callbacks may have queued duplicates of
+						// records the cursor saw while subscription.startTime was still 0. Filter them.
+						if (pendingRealTimeQueue && cursorMaxTime) {
+							pendingRealTimeQueue = pendingRealTimeQueue.filter(
+								(event) => (event.localTime ?? event.version) > cursorMaxTime
+							);
+						}
 					} else if (!request.omitCurrent) {
-						// Raise the listener's gate up front so that any in-flight 'committed' callbacks
-						// for pre-subscribe commits (which haven't yet advanced lastTxnTime when subscribe
-						// is called) get gated out of the queue. Otherwise the listener fires for them
-						// during cursor yields and emits stale events the cursor either covered (current
-						// state) or correctly skipped (e.g., deletes via `if (!value) continue`).
-						// getNextMonotonicTime() is the same source Harper uses to assign audit record
-						// localTimes, so the gate cuts at a precise instant in the same time domain.
-						subscription!.startTime = getNextMonotonicTime();
-
+						// Track the latest record-time the cursor saw — including deletion tombstones
+						// (entries with null value). Used after iteration to gate out any pre-subscribe
+						// 'committed' callbacks that fired during cursor yields (e.g., late
+						// notifications for deletes/updates done before subscribing). This is in the
+						// audit log's time domain — works on both backends, where a JS-side
+						// `getNextMonotonicTime()` would not be comparable to rocksdb's native
+						// transaction timestamps.
+						let cursorMaxTime = 0;
 						// Retained-message semantics: subscriber may legitimately receive a record twice
 						// if a post-subscribe write hits a key the cursor also visits. This is
 						// idempotent for "current state then live updates" — both deliveries land at
@@ -2824,12 +2825,25 @@ export function makeTable(options) {
 								recordsSinceYield = 0;
 								await rest();
 							}
+							// Update cursorMaxTime BEFORE the !value check so deletion tombstones
+							// (which have null value but a real localTime/version) still raise the gate.
+							const t = localTime ?? version;
+							if (t > cursorMaxTime) cursorMaxTime = t;
 							if (!value) continue;
 							send({ id, localTime, value, version, type: 'put', size });
 							if (subscription.queue?.length > EVENT_HIGH_WATER_MARK) {
 								// if we have too many messages, we need to pause and let the client catch up
 								if ((await subscription.waitForDrain()) === false) return;
 							}
+						}
+						if (cursorMaxTime) subscription!.startTime = cursorMaxTime;
+						// Filter the queue to drop in-flight pre-subscribe events the listener queued
+						// while subscription.startTime was still 0. Anything strictly newer than what
+						// the cursor saw is a real post-subscribe commit and is kept.
+						if (pendingRealTimeQueue && cursorMaxTime) {
+							pendingRealTimeQueue = pendingRealTimeQueue.filter(
+								(event) => (event.localTime ?? event.version) > cursorMaxTime
+							);
 						}
 					}
 				} else {

--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -147,10 +147,7 @@ describe('Subscription replay', () => {
 	});
 
 	describe('count branch (collection with previousCount)', () => {
-		// Skipped on v5.0: asserts no-duplicate (id,version) behavior fixed by main commits
-		// ad8300bec ("don't use getNextMonotonicTime") and b81ede3b5 ("toggle dropDuringReplay
-		// in finally"), which have not been cherry-picked to this release branch.
-		it.skip('delivers exactly the last N records, oldest first', async function () {
+		it('delivers exactly the last N records, oldest first', async function () {
 			if (!isLMDB) return this.skip();
 			for (let i = 0; i < 200; i++) {
 				await CountTable.put(i, { name: 'v' + i });
@@ -169,9 +166,7 @@ describe('Subscription replay', () => {
 			assertChronological(events, 'count branch out of order');
 		});
 
-		// Skipped on v5.0: asserts no-duplicate (id,version) behavior fixed by main commits
-		// ad8300bec and b81ede3b5, not cherry-picked to this release branch.
-		it.skip('queues writes that land during replay without duplicating history', async function () {
+		it('queues writes that land during replay without duplicating history', async function () {
 			if (!isLMDB) return this.skip();
 			for (let i = 0; i < 150; i++) {
 				await CountTable.put(3000 + i, { name: 'count_pre' + i });
@@ -511,9 +506,7 @@ describe('Subscription replay', () => {
 			}
 		});
 
-		// Skipped on v5.0: asserts no-duplicate (id,version) behavior fixed by main commits
-		// ad8300bec and b81ede3b5, not cherry-picked to this release branch.
-		it.skip('count: subscribe while writes are in flight does not duplicate history', async function () {
+		it('count: subscribe while writes are in flight does not duplicate history', async function () {
 			if (!isLMDB) return this.skip();
 			// pre-populate so we have history to capture
 			for (let i = 0; i < 50; i++) {
@@ -598,9 +591,7 @@ describe('Subscription replay', () => {
 	describe('edge cases', () => {
 		// ---- count branch edge cases ----
 
-		// Skipped on v5.0: asserts exact event count, fixed by main commits ad8300bec and
-		// b81ede3b5 (replay-time deduplication), not cherry-picked to this release branch.
-		it.skip('count: previousCount larger than total records returns all available', async function () {
+		it('count: previousCount larger than total records returns all available', async function () {
 			if (!isLMDB) return this.skip();
 			// fresh table to control record count
 			const T = table({
@@ -623,9 +614,7 @@ describe('Subscription replay', () => {
 			assert.equal(events.length, 7, `expected exactly 7 events, got ${events.length}`);
 		});
 
-		// Skipped on v5.0: asserts exact event count, fixed by main commits ad8300bec and
-		// b81ede3b5, not cherry-picked to this release branch.
-		it.skip('count: previousCount=1 returns only the most recent record', async function () {
+		it('count: previousCount=1 returns only the most recent record', async function () {
 			if (!isLMDB) return this.skip();
 			const T = table({
 				table: 'EdgeCountOne',
@@ -683,9 +672,7 @@ describe('Subscription replay', () => {
 			assert.deepEqual(ids, [100, 101, 102, 103, 104], `live events should arrive in commit order`);
 		});
 
-		// Skipped on v5.0: asserts exact event count, fixed by main commits ad8300bec and
-		// b81ede3b5, not cherry-picked to this release branch.
-		it.skip('count: many versions of the same record returns last N versions of it', async function () {
+		it('count: many versions of the same record returns last N versions of it', async function () {
 			if (!isLMDB) return this.skip();
 			const T = table({
 				table: 'EdgeCountSameRecord',
@@ -805,9 +792,7 @@ describe('Subscription replay', () => {
 			assert.equal(events.length, 0, `expected 0 events on empty store, got ${events.length}`);
 		});
 
-		// Skipped on v5.0: deletion-tombstone handling during current-state replay was fixed
-		// by main commit ad8300bec, not cherry-picked to this release branch.
-		it.skip('!omitCurrent: deleted keys are not delivered as current state', async () => {
+		it('!omitCurrent: deleted keys are not delivered as current state', async () => {
 			const T = table({
 				table: 'EdgeOmitCurrentDeleted',
 				database: 'test',


### PR DESCRIPTION
## Summary

Backports two main commits to fix a subscription bug introduced into v5.0 by [eea70f28e](../commit/eea70f28e) ("cherry-pick: yield every 100 entries in subscription catchup"):

- [`ad8300bec`](https://github.com/harperfast/harper/commit/ad8300bec) — "don't use getNextMonotonicTime" (the actual fix)
- [`b81ede3b5`](https://github.com/harperfast/harper/commit/b81ede3b5) — "toggle dropDuringReplay in finally" (companion robustness fix)

Also re-enables 7 `subscriptionReplay` tests that were skipped in [11a15c10e](../commit/11a15c10e) and [6d1af28db](../commit/6d1af28db) pending these fixes.

## Purpose

`eea70f28e` introduced `subscription!.startTime = getNextMonotonicTime()` in the `count` and `!omitCurrent` branches of `Table.subscribe()`. That value is a JS wall-clock-ish timestamp at subscribe time, and the gate in `notifyFromTransactionData` drops anything older:

```js
if (subscription.startTime >= timestamp) continue;
```

Replicated rows arrive with `localTime` preserved from the leader (e.g. when a peer node first joined, before a clone subscribed). Those `localTime`s are older than `getNextMonotonicTime()` at subscribe-time → the gate drops them → `onNodeUpdate` never fires for those peers → `cluster_status` shows only the leader.

This was already fixed on `main`: the wall-clock gate is replaced with a `cursorMaxTime` tracker in the audit log's own time domain (works for both LMDB `localTime` and RocksDB transaction-derived `version`). On an empty table `cursorMaxTime` stays at 0 and nothing is filtered.

## Where to focus the review

- **`resources/Table.ts:2790` ish (`count` branch) and `:2820` ish (`!omitCurrent` branch)** — these are the two places the buggy `getNextMonotonicTime()` gate was set. They now compute `cursorMaxTime` from records the cursor actually saw and filter `pendingRealTimeQueue` for events with `localTime > cursorMaxTime`. The `!omitCurrent` branch is slightly subtle: `cursorMaxTime` is updated **before** the `!value` continue so deletion tombstones still raise the gate.
- **`!omitCurrent` ordering caveat**: `primaryStore` iteration is by key, not time. There's a theoretical case where an update to a key the cursor already passed could be dropped if its `localTime` is smaller than a later key's `localTime`. This is inherent to any time-based gate over non-chronological iteration; it's strictly better than the old "now"-based gate.
- **Test resurrection**: the 7 unskipped tests in `unitTests/resources/subscriptionReplay.test.js` are the verifier. Locally on LMDB: 35/35 passing. On RocksDB default engine: 26 passing + 9 LMDB-only `this.skip()`'d.

## Verification

- LMDB: `HARPER_STORAGE_ENGINE=lmdb npx mocha unitTests/resources/subscriptionReplay.test.js` — 35 passing
- RocksDB (default): same — 26 passing, 9 LMDB-only pending
- Related: `auditLog.test.js`, `crud.test.js`, `transaction.test.js` — 69 passing
- Cross-model review (Gemini): identified the same `!omitCurrent` ordering caveat noted above; no blocking concerns.

## Notes

- Generated by an AI agent (Claude). Reviewers' sanity-check welcome on the `cursorMaxTime` filter math and the test-resurrection set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)