### PR TITLE
test(integration): add component-install helper, port REST query suite

### DIFF
--- a/integrationTests/apiTests/rest.test.mjs
+++ b/integrationTests/apiTests/rest.test.mjs
@@ -1,0 +1,195 @@
+/**
+ * REST API integration tests against the `appGraphQL` component schema.
+ *
+ * Ported from legacy `apiTests/tests/20_restTests.mjs`. Exercises the REST
+ * query syntax (`?key==value&select(...)`, nested attribute paths, etc.)
+ * against the `Related` + `SubObject` types from the appGraphQL test schema.
+ *
+ * Self-contained: each suite installs its own `appGraphQL` component
+ * (subset of the legacy 17a_addComponents schema — only the types this
+ * suite reads) and seeds the canonical Related/SubObject rows the legacy
+ * 19_graphQlTests inserted, then exercises the REST endpoints.
+ *
+ * Skipped on Windows: depends on `restart_service http_workers` after
+ * component install, which crashes the Harper instance on Windows
+ * (HarperFast/harper#549). Matches the per-suite skip pattern in
+ * `headers.test.mjs`.
+ */
+import { suite, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import request from 'supertest';
+import { startHarper, teardownHarper } from '@harperfast/integration-testing';
+import { createApiClient } from './utils/client.mjs';
+import { installAppComponent } from './utils/components.mjs';
+
+const SCHEMA_GRAPHQL = `
+type Related @table @export(rest: true, mqtt: false) {
+	id: ID @primaryKey
+	name: String @indexed
+	otherTable: [SubObject] @relationship(to: relatedId)
+	subObject: SubObject @relationship(from: "subObjectId")
+	subObjectId: ID @indexed
+}
+
+type SomeObject {
+	name: String
+}
+
+type SubObject @table(audit: false) @export {
+	id: ID @primaryKey
+	subObject: SomeObject
+	subArray: [SomeObject]
+	any: Any
+	relatedId: ID @indexed
+	related: Related @relationship(from: "relatedId")
+}
+`;
+
+const CONFIG_YAML = `rest: true
+graphqlSchema:
+  files: '*.graphql'
+graphql: true
+`;
+
+const RELATED_ROWS = [
+	{ id: '1', name: 'name-1', subObjectId: '1' },
+	{ id: '2', name: 'name-2', subObjectId: '2' },
+	{ id: '3', name: 'name-3', subObjectId: '3' },
+	{ id: '4', name: 'name-4', subObjectId: '4' },
+	{ id: '5', name: 'name-5', subObjectId: '5' },
+];
+
+const SUBOBJECT_ROWS = [
+	{ id: '0', relatedId: '1', any: null },
+	{ id: '1', relatedId: '1', any: 'any-1' },
+	{ id: '2', relatedId: '2', any: 'any-2' },
+	{ id: '3', relatedId: '3', any: 'any-3' },
+	{ id: '4', relatedId: '4', any: 'any-4' },
+	{ id: '5', relatedId: '5', any: 'any-5' },
+];
+
+const skipSuite = process.platform === 'win32';
+
+suite('REST query syntax', { skip: skipSuite }, (ctx) => {
+	let client;
+
+	before(async () => {
+		await startHarper(ctx, { config: {}, env: {} });
+		client = createApiClient(ctx.harper);
+
+		await installAppComponent(client, {
+			project: 'appGraphQL',
+			files: { 'schema.graphql': SCHEMA_GRAPHQL, 'config.yaml': CONFIG_YAML },
+			probePath: '/Related/',
+		});
+
+		await client
+			.req()
+			.send({ operation: 'insert', table: 'Related', records: RELATED_ROWS })
+			.expect((r) => assert.ok(r.body.message.includes('inserted 5 of 5 records'), r.text))
+			.expect(200);
+
+		await client
+			.req()
+			.send({ operation: 'insert', table: 'SubObject', records: SUBOBJECT_ROWS })
+			.expect((r) => assert.ok(r.body.message.includes('inserted 6 of 6 records'), r.text))
+			.expect(200);
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	test('[rest] Named query Get Related', () => {
+		return client
+			.reqRest('/Related/?select(id,name)')
+			.expect((r) => assert.equal(r.body.length, 5, r.text))
+			.expect((r) => {
+				r.body.forEach((row, i) => {
+					assert.equal(row.id, (i + 1).toString(), r.text);
+				});
+			})
+			.expect(200);
+	});
+
+	test('[rest] Named query Get SubObject', () => {
+		return client
+			.reqRest('/SubObject/?select(id,relatedId)')
+			.expect((r) => assert.equal(r.body.length, 6, r.text))
+			.expect((r) => {
+				r.body.forEach((row, i) => {
+					assert.equal(row.id, i.toString(), r.text);
+				});
+			})
+			.expect(200);
+	});
+
+	test('[rest] Query by primary key field', () => {
+		return client
+			.reqRest('/Related/?id==1&select(id,name)')
+			.expect((r) => assert.equal(r.body[0].id, '1', r.text))
+			.expect(200);
+	});
+
+	test('[rest] Query by variable non null', () => {
+		return client
+			.reqRest('/Related/?id==2&select(id,name)')
+			.expect((r) => assert.equal(r.body[0].id, '2', r.text))
+			.expect(200);
+	});
+
+	test('[rest] Query by var nullable', () => {
+		return client
+			.reqRest('/SubObject/?any==any-2&select(id,any)')
+			.expect((r) => assert.equal(r.body[0].id, '2', r.text))
+			.expect(200);
+	});
+
+	test('[rest] Query by var with null var', () => {
+		return client
+			.reqRest('/SubObject/?any==null&select(id,any)')
+			.expect((r) => assert.equal(r.body[0].id, '0', r.text))
+			.expect((r) => assert.equal(r.body[0].any, null, r.text))
+			.expect(200);
+	});
+
+	test('[rest] Query by nested attribute', () => {
+		return client
+			.reqRest('/SubObject/?related.name==name-2&select(id,any)')
+			.expect((r) => assert.equal(r.body[0].id, '2', r.text))
+			.expect(200);
+	});
+
+	test('[rest] Query by multiple nested attributes', () => {
+		return client
+			.reqRest('/SubObject/?any==any-2&related.name==name-2&select(id,any)')
+			.expect((r) => assert.equal(r.body[0].id, '2', r.text))
+			.expect(200);
+	});
+
+	test('[rest] Query by nested attribute primary key', () => {
+		return client
+			.reqRest('/SubObject/?related.id==2&select(id,any)')
+			.expect((r) => assert.equal(r.body[0].id, '2', r.text))
+			.expect(200);
+	});
+
+	test('[rest] Query by doubly nested attribute', () => {
+		return client
+			.reqRest('/SubObject/?related.subObject.any==any-2&select(id,any)')
+			.expect((r) => assert.equal(r.body[0].id, '2', r.text))
+			.expect(200);
+	});
+
+	test('[rest] Query with nested fragments', () => {
+		return client
+			.reqRest('/Related/?id==3')
+			.expect((r) => assert.equal(r.body[0].id, '3', r.text))
+			.expect(200);
+	});
+
+	test('[rest] Request POST with too large of body returns 413', () => {
+		const bigProperty = Array(1000000).fill('this is a test');
+		return request(client.restURL).post('/Related/').set(client.headers).send({ bigProperty }).expect(413);
+	});
+});

--- a/integrationTests/apiTests/utils/components.mjs
+++ b/integrationTests/apiTests/utils/components.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { restartHttpWorkers } from './lifecycle.mjs';
+
+/**
+ * Deploy a Harper component via the operations API by issuing `add_component`
+ * followed by `set_component_file` for each file in `files`, then restart
+ * http workers and wait for the component's routes to register. Returns once
+ * `probePath` returns a non-404 response.
+ *
+ * Mirrors the inline component-install dance used throughout the legacy
+ * api-tests (1_envSetup → 17a → individual suites), but bound to a per-test
+ * client so each suite can drive its own throwaway instance.
+ *
+ * @param {ReturnType<import('./client.mjs').createApiClient>} client
+ * @param {object} options
+ * @param {string} options.project — component name (used as the route prefix)
+ * @param {Record<string, string>} options.files — map of file name → contents
+ *   (e.g. `{ 'schema.graphql': '...', 'config.yaml': '...' }`)
+ * @param {string} options.probePath — REST path the test will exercise; used
+ *   to poll for route registration after the http_workers restart
+ * @param {number} [options.restartTimeoutMs]
+ */
+export async function installAppComponent(client, { project, files, probePath, restartTimeoutMs }) {
+	assert.ok(project, 'installAppComponent: project is required');
+	assert.ok(files && typeof files === 'object', 'installAppComponent: files is required');
+	assert.ok(probePath, 'installAppComponent: probePath is required');
+
+	await client
+		.req()
+		.send({ operation: 'add_component', project })
+		.expect((r) => {
+			const body = JSON.stringify(r.body);
+			assert.ok(
+				body.includes('Successfully added project') || body.includes('Project already exists'),
+				`add_component(${project}) failed: ${r.text}`
+			);
+		});
+
+	for (const [file, payload] of Object.entries(files)) {
+		await client
+			.req()
+			.send({ operation: 'set_component_file', project, file, payload })
+			.expect((r) =>
+				assert.ok(
+					r.body.message.includes(`Successfully set component: ${file}`),
+					`set_component_file(${project}/${file}) failed: ${r.text}`
+				)
+			)
+			.expect(200);
+	}
+
+	await restartHttpWorkers(client, probePath, restartTimeoutMs);
+}


### PR DESCRIPTION
## Summary

Third slice of the api-tests migration on top of #597.

- \`integrationTests/apiTests/utils/components.mjs\` — \`installAppComponent(client, { project, files, probePath, restartTimeoutMs })\`. Issues \`add_component\`, \`set_component_file\` per file, then \`restartHttpWorkers\` polling \`probePath\` until the route registers. Idempotent w.r.t. \"Project already exists\".
- \`integrationTests/apiTests/rest.test.mjs\` (was \`tests/20_restTests.mjs\`) — exercises Harper's REST query syntax against the \`appGraphQL\` test schema. Self-contained: installs its own trimmed \`appGraphQL\` schema (\`Related\` + \`SubObject\` only — the types this suite reads) plus the canonical seed rows that the legacy \`19_graphQlTests\` step inserted.

Skipped on Windows — depends on \`restart_service http_workers\`, which crashes the Harper instance on Windows (#549). Matches the existing skip pattern in \`headers.test.mjs\`.

## Purpose

Unlocks the remaining component-dependent suites. The legacy \`17a_addComponents.mjs\` step installed \`computed\`, \`appGraphQL\`, and \`myApp111\` components once for the whole sequential run; suites 18 (computed indexed props), 19 (graphQL), 20 (rest), and 22 (openapi) all assumed those components were present. With \`installAppComponent\` in place, each of those can be ported as a self-contained file with its own component install.

## Where to look

- \`utils/components.mjs\` — small new helper. Designed for reuse by the next ports; takes a generic \`files\` map so callers control schema + config + resources files. \`probePath\` is the route the test will exercise; \`restartHttpWorkers\` (#555) polls it until non-404, which is how we sidestep the race between workers coming back online and route registration.
- \`rest.test.mjs\` schema — trimmed down from the original 10-type schema in legacy \`17a\` to just \`Related\` + \`SomeObject\` + \`SubObject\`. Future ports of 19 will likely need the full schema; that can grow into a shared \`appGraphQLFixture\` helper if it's worth the abstraction.

## Testing

All 49 tests across the 6 ported suites pass in parallel locally:

\`\`\`
npm run test:integration -- \"integrationTests/apiTests/*.test.mjs\"
# ▶ System Information ✔ (2/2)
# ▶ Alter User ✔ (7/7)
# ▶ HTTP Header / Set-Cookie handling ✔ (2/2)
# ▶ Transaction Logs ✔ (7/7)
# ▶ Transactions / audit log ✔ (19/19)
# ▶ REST query syntax ✔ (12/12)
# ℹ pass 49 fail 0  duration_ms ~12300
\`\`\`

Gemini cross-review flagged two issues — both were hallucinations (claimed a long invented directive path and a leading space in an import that don't exist in the actual file). Substantive findings (faithful port, correct helper, correct Windows skip) check out.

---

🤖 Generated by Claude (Opus 4.7), see commit Co-Authored-By tag.