### PR TITLE
feat: expose request.signal AbortSignal, aborted on client disconnect

### DIFF
--- a/server/REST.ts
+++ b/server/REST.ts
@@ -340,6 +340,7 @@ export function handleApplication(scope: import('../components/Scope.ts').Scope)
 				recordActionBinary(!hasError, 'connection', 'ws', 'disconnect');
 				incomingMessages.emit('close');
 				if (iterator) iterator.return();
+				request._abort?.();
 			});
 			try {
 				await chainCompletion;

--- a/server/serverHelpers/Request.ts
+++ b/server/serverHelpers/Request.ts
@@ -27,6 +27,7 @@ interface IncomingMessage extends NodeIncomingMessage {
 export class Request {
 	#body: RequestBody | undefined;
 	#peerCertificate: any;
+	#abortController = new AbortController();
 	public _nodeRequest: IncomingMessage;
 	public _nodeResponse?: NodeServerResponse;
 	public method: string;
@@ -60,7 +61,7 @@ export class Request {
 	public lastModified?: number;
 	public lastRefreshed?: number;
 
-	constructor(nodeRequest: IncomingMessage, nodeResponse: NodeServerResponse) {
+	constructor(nodeRequest: IncomingMessage, nodeResponse?: NodeServerResponse) {
 		this.method = nodeRequest.method;
 		const url = nodeRequest.url;
 		this._nodeRequest = nodeRequest;
@@ -68,6 +69,26 @@ export class Request {
 		this.url = url;
 		this.headers = new RequestHeaders(nodeRequest.headers);
 		this.__harperRequestUpgraded = false;
+		// Abort the request's signal on premature client disconnect. nodeResponse 'close'
+		// also fires on clean completion; the writableFinished guard restricts to disconnect.
+		if (typeof nodeResponse?.on === 'function') {
+			nodeResponse.on('close', () => {
+				if (!nodeResponse.writableFinished) this.#abortController.abort();
+			});
+		} else if (typeof nodeRequest.socket?.once === 'function') {
+			// WebSocket-upgrade path: no response. The TCP socket is the only signal.
+			nodeRequest.socket.once('close', () => this.#abortController.abort());
+		}
+	}
+	get signal(): AbortSignal {
+		return this.#abortController.signal;
+	}
+	/**
+	 * Abort this request's signal. Used by transports (e.g. WebSocket) that need to
+	 * signal client-side cancellation independently of the Node response lifecycle.
+	 */
+	_abort(): void {
+		this.#abortController.abort();
 	}
 	get absoluteURL() {
 		return this.protocol + '://' + this.host + this.url;
@@ -119,8 +140,7 @@ export class Request {
 		return this._nodeRequest.httpVersion;
 	}
 	get isAborted() {
-		// TODO: implement this
-		return false;
+		return this.#abortController.signal.aborted;
 	}
 	// Expose node request for cases that need direct access (e.g., replication)
 	get nodeRequest() {
@@ -391,7 +411,13 @@ export class BunRequest {
 		return '1.1';
 	}
 	get isAborted() {
-		return false;
+		return this._webRequest.signal?.aborted ?? false;
+	}
+	get signal(): AbortSignal {
+		return this._webRequest.signal;
+	}
+	_abort(): void {
+		// On Bun, abort is driven by the underlying Web Request's signal; no-op for parity with Node path.
 	}
 	get nodeRequest() {
 		return null;

--- a/server/serverHelpers/Request.ts
+++ b/server/serverHelpers/Request.ts
@@ -76,7 +76,12 @@ export class Request {
 				if (!nodeResponse.writableFinished) this.#abortController.abort();
 			});
 		} else if (typeof nodeRequest.socket?.once === 'function') {
-			// WebSocket-upgrade path: no response. The TCP socket is the only signal.
+			// No response on this Request — typically the WebSocket-upgrade path
+			// (http.ts creates the Request before the ws library takes over). The TCP
+			// socket close is the fallback abort trigger; REST.ts's ws.on('close') hook
+			// also calls _abort() and is the primary signal in the WS case. The two
+			// are redundant by design (idempotent abort) so any future single-arg
+			// caller still gets disconnect semantics without relying on the WS layer.
 			nodeRequest.socket.once('close', () => this.#abortController.abort());
 		}
 	}
@@ -414,6 +419,10 @@ export class BunRequest {
 		return this._webRequest.signal?.aborted ?? false;
 	}
 	get signal(): AbortSignal {
+		// Bun.serve() aborts this signal on HTTP client disconnect. Behavior on
+		// WebSocket-upgrade is implementation-defined; if the WS path needs
+		// guaranteed abort-on-close under Bun, wire it through Bun's ws close
+		// handler with a Bun-side AbortController, similar to REST.ts on Node.
 		return this._webRequest.signal;
 	}
 	_abort(): void {

--- a/unitTests/server/serverHelpers/Request.test.js
+++ b/unitTests/server/serverHelpers/Request.test.js
@@ -260,8 +260,65 @@ describe('Request class', function () {
 		});
 
 		it('should return isAborted status', function () {
-			// Currently always returns false (TODO in implementation)
 			assert.strictEqual(request.isAborted, false);
+		});
+	});
+
+	describe('signal (AbortSignal)', function () {
+		const { EventEmitter } = require('node:events');
+
+		function makeNodeRequest() {
+			return {
+				method: 'GET',
+				url: '/test',
+				headers: {},
+				socket: Object.assign(new EventEmitter(), {
+					encrypted: true,
+					remoteAddress: '127.0.0.1',
+					getPeerCertificate: sinon.stub().returns({}),
+				}),
+			};
+		}
+
+		function makeNodeResponse({ writableFinished = false } = {}) {
+			const res = new EventEmitter();
+			res.writableFinished = writableFinished;
+			return res;
+		}
+
+		it('exposes a live AbortSignal that is not initially aborted', function () {
+			const request = new Request(makeNodeRequest(), makeNodeResponse());
+			assert.ok(request.signal instanceof AbortSignal);
+			assert.strictEqual(request.signal.aborted, false);
+			assert.strictEqual(request.isAborted, false);
+		});
+
+		it('aborts the signal on nodeResponse close before write is finished', function () {
+			const nodeResponse = makeNodeResponse({ writableFinished: false });
+			const request = new Request(makeNodeRequest(), nodeResponse);
+			nodeResponse.emit('close');
+			assert.strictEqual(request.signal.aborted, true);
+			assert.strictEqual(request.isAborted, true);
+		});
+
+		it('does NOT abort the signal on nodeResponse close after write finishes', function () {
+			const nodeResponse = makeNodeResponse({ writableFinished: true });
+			const request = new Request(makeNodeRequest(), nodeResponse);
+			nodeResponse.emit('close');
+			assert.strictEqual(request.signal.aborted, false);
+		});
+
+		it('aborts on socket close when no nodeResponse is provided (WebSocket-upgrade path)', function () {
+			const nodeRequest = makeNodeRequest();
+			const request = new Request(nodeRequest);
+			nodeRequest.socket.emit('close');
+			assert.strictEqual(request.signal.aborted, true);
+		});
+
+		it('_abort() aborts the signal explicitly', function () {
+			const request = new Request(makeNodeRequest(), makeNodeResponse());
+			request._abort();
+			assert.strictEqual(request.signal.aborted, true);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Closes #513. Constructs an `AbortController` per `Request` and exposes `request.signal` so Resource methods can forward cancellation to external work — most concretely `scope.models.generateStream(input, { signal })` planned for #510. Without a forwardable signal, a generator body whose client has already gone away keeps tokenizing upstream, wasting tokens / GPU time.

## What changed

- **Node HTTP/SSE path** (`server/serverHelpers/Request.ts`): hook `nodeResponse.on('close', ...)` from the `Request` constructor, guarded by `!writableFinished` so clean completion does NOT abort.
- **WebSocket-upgrade path** (`server/REST.ts`): the existing `ws.on('close')` hook now calls `request._abort?.()`. The `Request` is constructed with no response in `http.ts:929`, so the constructor also attaches `nodeRequest.socket.once('close')` as a defensive fallback (idempotent abort — comment in code explains).
- **Bun runtime**: `BunRequest.signal` returns the underlying Web Request's native signal, which `Bun.serve()` already aborts on HTTP client disconnect. WS-on-Bun behavior is flagged in a code comment as implementation-defined; ad-hoc plumbing can be added when a use case arrives.
- **`isAborted`** now reflects the live signal state (was a TODO returning `false`).
- **Constructor signature** loosened: `nodeResponse?` is now optional (matching the WS-upgrade call site `http.ts:929` which has always passed one argument). The duck-typed `on` guard preserves all existing test mocks that pass `{}` as the response.

## Where to look

- `server/serverHelpers/Request.ts:64-92` — the constructor wiring + `signal` / `_abort` getters. The `writableFinished` guard is the most non-trivial bit; rationale in comments.
- `server/REST.ts:340-347` — the one-line WS hook addition.
- `unitTests/server/serverHelpers/Request.test.js` (signal describe block) — 5 new unit tests covering initial state, close-before-finish, close-after-finish, WS-upgrade socket close, and explicit `_abort()`.

## Test plan

- [x] Unit tests pass: `mocha unitTests/server/serverHelpers/Request.test.js` (59 passing — 27 pre-existing + 5 new in signal describe + 27 in withNodeAdapter/etc. that pass under typestrip)
- [x] Lint clean: `oxlint server/serverHelpers/Request.ts server/REST.ts`
- [x] Format clean: `prettier --check ...`
- [x] TypeScript build: no new errors in changed files
- [ ] CI green (will monitor)

## Reviewer attention

This unblocks #628 (Phase 1 of #510's model-access API), which reads `(ctx as any)?.signal` from the ALS-bound `Request` to plumb cancellation into model backend calls. Once this merges, that cast can drop the `as any`.

The most reviewer-worthy decisions:

1. **`writableFinished` guard on close** — is this the right Node API to distinguish "client gave up" from "we finished sending"? I believe yes (standard pattern), but flagging.
2. **Dual-abort on WS path** — both the socket `once('close')` in the constructor (when no response) AND `_abort()` from `REST.ts` will fire. Intentional redundancy because abort is idempotent and the socket fallback also covers any future single-arg `new Request(...)` site. Comment in code explains.
3. **Bun WS signal** — left as "use the underlying Web Request signal" without explicit Bun-side abort plumbing. Comment flags this as implementation-defined and worth wiring if a real use case appears.

A cross-model review (Gemini CLI) was run on the diff; the two actionable comments it surfaced are now in-code documentation (no behavioral changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)