### PR TITLE
feat(deploy-component): add install_allow_scripts flag

### DIFF
--- a/components/operations.js
+++ b/components/operations.js
@@ -375,10 +375,11 @@ async function deployComponent(req) {
 
 		const applicationConfig = { package: req.package };
 		// Avoid writing an empty `install:` block
-		if (req.install_command || req.install_timeout) {
+		if (req.install_command || req.install_timeout || req.install_allow_scripts !== undefined) {
 			applicationConfig.install = {
 				command: req.install_command,
 				timeout: req.install_timeout,
+				allowInstallScripts: req.install_allow_scripts,
 			};
 		}
 		await configUtils.addConfig(req.project, applicationConfig);
@@ -391,6 +392,7 @@ async function deployComponent(req) {
 		install: {
 			command: req.install_command,
 			timeout: req.install_timeout,
+			allowInstallScripts: req.install_allow_scripts,
 		},
 	});
 

--- a/components/operations.js
+++ b/components/operations.js
@@ -217,7 +217,7 @@ async function addComponent(req) {
 
 	log.trace(`adding component`);
 	const cfDir = configUtils.getConfigPath(hdbTerms.CONFIG_PARAMS.COMPONENTSROOT);
-	const { project, install_command, install_timeout } = req;
+	const { project, install_command, install_timeout, install_allow_scripts } = req;
 
 	const template = req.template || 'https://github.com/harperdb/application-template';
 
@@ -230,6 +230,7 @@ async function addComponent(req) {
 			install: {
 				command: install_command,
 				timeout: install_timeout,
+				allowInstallScripts: install_allow_scripts,
 			},
 		});
 		await prepareApplication(application);

--- a/components/operationsValidation.js
+++ b/components/operationsValidation.js
@@ -239,6 +239,7 @@ function deployComponentValidator(req) {
 		restart: Joi.alternatives().try(Joi.boolean(), Joi.string().valid('rolling')).optional(),
 		install_command: Joi.string().optional(),
 		install_timeout: Joi.number().optional(),
+		install_allow_scripts: Joi.boolean().optional(),
 		force: Joi.boolean().optional(),
 	});
 

--- a/components/operationsValidation.js
+++ b/components/operationsValidation.js
@@ -184,6 +184,7 @@ function addComponentValidator(req) {
 		template: Joi.string().optional(),
 		install_command: Joi.string().optional(),
 		install_timeout: Joi.number().optional(),
+		install_allow_scripts: Joi.boolean().optional(),
 	});
 
 	return validator.validateBySchema(req, addFuncSchema);


### PR DESCRIPTION
## Summary

- Adds `install_allow_scripts` (boolean, optional) to both `deploy_component` and `add_component` operations
- Accepted by both validators in `operationsValidation.js`
- For `deploy_component`: persisted to application config as `install.allowInstallScripts` (picked up on restart via the existing config-load path in `Application.ts:540`)
- For both operations: passed directly to the `Application` constructor so the immediate install honors it

## Purpose

`Application.ts` already supports `install.allowInstallScripts` to toggle `--ignore-scripts` on the underlying npm/yarn/pnpm call, but there was no way to set this flag via the operation API. This wires the missing connection for both operations that perform installs.

## Default behaviour unchanged

When omitted, `allowInstallScripts` is `undefined` → falsy → `--ignore-scripts` is used, which was already the default.

## Notes

- `add_component` does not write to the root config (it clones a template directly), so only the `Application` constructor is updated there — no config-persistence block.
- Custom `install_command` users are unaffected; the flag only controls the default npm/yarn/pnpm invocation path.
- Cross-model (Gemini) review completed; the `add_component` gap was flagged by Gemini and addressed in a follow-up commit.

Generated by Claude (agent) — *@kris please review*