### PR TITLE
feat(models): Phase 1 — scope.models foundation

### DIFF
--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -6,6 +6,7 @@ import { server, type Server } from '../server/Server.ts';
 import { EntryHandler, type EntryHandlerEventMap, type onEntryEventHandler } from './EntryHandler.ts';
 import { OptionsWatcher, OptionsWatcherEventMap } from './OptionsWatcher.ts';
 import { resources, type Resources } from '../resources/Resources.ts';
+import { Models } from '../resources/models/Models.ts';
 import type { FileAndURLPathConfig } from './Component.ts';
 import { FilesOption } from './deriveGlobOptions.ts';
 import { requestRestart } from './requestRestart.ts';
@@ -49,6 +50,7 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 	server?: Server;
 	ready: Promise<any[]>;
 	databaseEvents: typeof databaseEventsEmitter;
+	models: Models;
 
 	constructor(
 		appName: string,
@@ -68,6 +70,7 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 		this.databaseEvents = databaseEventsEmitter;
 		this.applicationScope = applicationScope;
 		this.resources = applicationScope?.resources ?? resources;
+		this.models = new Models();
 
 		const baseServer = applicationScope?.server ?? server;
 		const scopeRef = this;

--- a/resources/ResourceInterface.ts
+++ b/resources/ResourceInterface.ts
@@ -98,6 +98,19 @@ export interface Context {
 	_freezeRecords?: boolean; // until v5, we conditionally freeze records for back-compat
 	timestamp?: number;
 	includeExpensiveRecordCountEstimates?: boolean;
+	/**
+	 * Matched route path of the calling Resource, populated by the HTTP/WS entry points
+	 * before they hand the request into `transaction()`. Populated on the Request that
+	 * becomes the ALS-bound Context for that path; absent for ops-API, internal jobs,
+	 * and replication-driven contexts.
+	 */
+	handlerPath?: string;
+	/**
+	 * Abort signal carried through ALS so generator bodies can forward cancellation to
+	 * external work (e.g. `scope.models.generateStream({ signal })`). Populated on the
+	 * Request that becomes the ALS-bound Context for HTTP/WS paths via #513.
+	 */
+	signal?: AbortSignal;
 }
 
 export interface SourceContext<TRequestContext = Context, Record extends object = any> {

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -78,6 +78,7 @@ export const NON_REPLICATING_SYSTEM_TABLES = [
 	'hdb_temp',
 	'hdb_certificate',
 	'hdb_raw_analytics',
+	'hdb_model_calls',
 	'hdb_session_will',
 	'hdb_job',
 	'hdb_info',

--- a/resources/models/Models.ts
+++ b/resources/models/Models.ts
@@ -1,0 +1,215 @@
+import { contextStorage } from '../transaction.ts';
+import { resolveEmbedding, resolveGenerative } from './backendRegistry.ts';
+import { getModelCallAnalyticsWriter, type ModelCallAnalyticsWriter, type ModelCallRecord } from './analyticsTable.ts';
+import { ServerError } from '../../utility/errors/hdbError.ts';
+import type {
+	AccountingContext,
+	BackendOpts,
+	EmbedOpts,
+	GenerateChunk,
+	GenerateInput,
+	GenerateOpts,
+	GenerateResult,
+	ModelBackend,
+	ModelCallResult,
+	Models as ModelsContract,
+	TokenUsage,
+} from './types.ts';
+
+type CallMethod = ModelCallRecord['method'];
+
+/**
+ * Public `scope.models` facade. One instance per `Scope`.
+ *
+ * On every call:
+ * - Resolves the configured backend via `backendRegistry` (config-driven).
+ * - Reads the ALS-bound request `Context` to extract accounting context
+ *   (tenantId, handlerPath) and an `AbortSignal`. Outside an ALS scope
+ *   (app-init, internal jobs), accounting is empty and signal is undefined.
+ * - Records the call to `hdb_model_calls` via the buffered writer — both
+ *   successful and failed calls land in the table for billing visibility.
+ *
+ * The ALS pattern matches `resources/Table.ts:3517` and is rooted at
+ * `resources/transaction.ts:6`.
+ */
+export class Models implements ModelsContract {
+	#analyticsWriter: ModelCallAnalyticsWriter;
+
+	constructor(analyticsWriter: ModelCallAnalyticsWriter = getModelCallAnalyticsWriter()) {
+		this.#analyticsWriter = analyticsWriter;
+	}
+
+	async embed(input: string | string[], opts: EmbedOpts = {}): Promise<Float32Array[]> {
+		const backend = resolveEmbedding(opts.model);
+		requireCapability(backend, 'embed');
+		const { accounting, signal } = resolveCallContext(opts.signal);
+		const backendOpts: BackendOpts<EmbedOpts> = { ...opts, signal, accounting };
+		const startedAt = performance.now();
+		try {
+			const result = await backend.embed!(input, backendOpts);
+			this.#record(backend, 'embed', opts.model, accounting, undefined, result, startedAt);
+			return unwrap(backend, result);
+		} catch (err) {
+			this.#recordFailure(backend, 'embed', opts.model, accounting, undefined, startedAt, err);
+			throw err;
+		}
+	}
+
+	async generate(input: GenerateInput, opts: GenerateOpts = {}): Promise<GenerateResult> {
+		const backend = resolveGenerative(opts.model);
+		requireCapability(backend, 'generate');
+		const { accounting, signal } = resolveCallContext(opts.signal);
+		const backendOpts: BackendOpts<GenerateOpts> = { ...opts, signal, accounting };
+		const startedAt = performance.now();
+		try {
+			const result = await backend.generate!(input, backendOpts);
+			this.#record(backend, 'generate', opts.model, accounting, opts, result, startedAt);
+			return unwrap(backend, result);
+		} catch (err) {
+			this.#recordFailure(backend, 'generate', opts.model, accounting, opts, startedAt, err);
+			throw err;
+		}
+	}
+
+	generateStream(input: GenerateInput, opts: GenerateOpts = {}): AsyncIterable<GenerateChunk> {
+		const backend = resolveGenerative(opts.model);
+		requireCapability(backend, 'stream');
+		const { accounting, signal } = resolveCallContext(opts.signal);
+		const backendOpts: BackendOpts<GenerateOpts> = { ...opts, signal, accounting };
+		return this.#wrapStream(backend, input, backendOpts, opts, accounting);
+	}
+
+	async *#wrapStream(
+		backend: ModelBackend,
+		input: GenerateInput,
+		backendOpts: BackendOpts<GenerateOpts>,
+		opts: GenerateOpts,
+		accounting: AccountingContext
+	): AsyncIterable<GenerateChunk> {
+		const startedAt = performance.now();
+		let success = true;
+		let caught: unknown;
+		try {
+			for await (const chunk of backend.generateStream!(input, backendOpts)) {
+				yield chunk;
+			}
+		} catch (err) {
+			success = false;
+			caught = err;
+			throw err;
+		} finally {
+			if (success) {
+				this.#record(backend, 'generateStream', opts.model, accounting, opts, undefined, startedAt);
+			} else {
+				this.#recordFailure(backend, 'generateStream', opts.model, accounting, opts, startedAt, caught);
+			}
+		}
+	}
+
+	#record(
+		backend: ModelBackend,
+		method: CallMethod,
+		model: string | undefined,
+		accounting: AccountingContext,
+		opts: GenerateOpts | undefined,
+		result: ModelCallResult<unknown> | undefined,
+		startedAt: number
+	): void {
+		const usage = result?.status === 'completed' ? result.usage : undefined;
+		this.#analyticsWriter.write(buildRecord(backend, method, model, accounting, opts, usage, startedAt, true));
+	}
+
+	#recordFailure(
+		backend: ModelBackend,
+		method: CallMethod,
+		model: string | undefined,
+		accounting: AccountingContext,
+		opts: GenerateOpts | undefined,
+		startedAt: number,
+		err: unknown
+	): void {
+		this.#analyticsWriter.write({
+			...buildRecord(backend, method, model, accounting, opts, undefined, startedAt, false),
+			error_code: classifyError(err),
+		});
+	}
+}
+
+function buildRecord(
+	backend: ModelBackend,
+	method: CallMethod,
+	model: string | undefined,
+	accounting: AccountingContext,
+	opts: GenerateOpts | undefined,
+	usage: TokenUsage | undefined,
+	startedAt: number,
+	success: boolean
+): ModelCallRecord {
+	const record: ModelCallRecord = {
+		backend: backend.name,
+		method,
+		model,
+		tenant: accounting.tenantId,
+		app: accounting.app,
+		adapter: opts?.adapter,
+		conversation_id: opts?.conversationId,
+		latency_ms: performance.now() - startedAt,
+		success,
+	};
+	if (usage) {
+		if (usage.promptTokens !== undefined) record.prompt_tokens = usage.promptTokens;
+		if (usage.completionTokens !== undefined) record.completion_tokens = usage.completionTokens;
+		if (usage.embeddingTokens !== undefined) record.embedding_tokens = usage.embeddingTokens;
+		if (usage.gpuMs !== undefined) record.gpu_ms = usage.gpuMs;
+	}
+	return record;
+}
+
+function resolveCallContext(callerSignal?: AbortSignal): { accounting: AccountingContext; signal?: AbortSignal } {
+	const ctx = contextStorage.getStore() as any;
+	return {
+		accounting: {
+			tenantId: extractTenantId(ctx?.user),
+			app: ctx?.handlerPath,
+		},
+		signal: callerSignal ?? ctx?.signal,
+	};
+}
+
+function extractTenantId(user: any): string | undefined {
+	return user?.tenant ?? user?.tenantId ?? undefined;
+}
+
+function requireCapability(backend: ModelBackend, capability: 'embed' | 'generate' | 'stream'): void {
+	if (!backend.capabilities()[capability]) throw new ModelCapabilityError(backend.name, capability);
+}
+
+function unwrap<T>(backend: ModelBackend, result: ModelCallResult<T>): T {
+	if (result.status === 'completed') return result.output;
+	throw new ModelPendingNotSupportedError(backend.name);
+}
+
+function classifyError(err: unknown): string {
+	if (err && typeof err === 'object') {
+		const e = err as { name?: string; code?: string };
+		if (e.name === 'AbortError' || e.code === 'ABORT_ERR') return 'aborted';
+		if (e.name === 'ModelCapabilityError') return 'capability_unsupported';
+	}
+	return 'backend_error';
+}
+
+export class ModelCapabilityError extends ServerError {
+	// Deliberately does not name the requested capability beyond what was asked for —
+	// avoids enumerating what the backend *does* support in error responses.
+	constructor(backendName: string, capability: 'embed' | 'generate' | 'stream') {
+		super(`Backend '${backendName}' does not support '${capability}'`);
+		this.name = 'ModelCapabilityError';
+	}
+}
+
+export class ModelPendingNotSupportedError extends ServerError {
+	constructor(backendName: string) {
+		super(`Backend '${backendName}' returned 'pending'; long-running operations are not yet supported`);
+		this.name = 'ModelPendingNotSupportedError';
+	}
+}

--- a/resources/models/Models.ts
+++ b/resources/models/Models.ts
@@ -22,12 +22,13 @@ type CallMethod = ModelCallRecord['method'];
  * Public `scope.models` facade. One instance per `Scope`.
  *
  * On every call:
- * - Resolves the configured backend via `backendRegistry` (config-driven).
+ * - Resolves the configured backend via `backendRegistry`.
  * - Reads the ALS-bound request `Context` to extract accounting context
  *   (tenantId, handlerPath) and an `AbortSignal`. Outside an ALS scope
  *   (app-init, internal jobs), accounting is empty and signal is undefined.
  * - Records the call to `hdb_model_calls` via the buffered writer — both
  *   successful and failed calls land in the table for billing visibility.
+ *   Pre-call resolution / capability errors land too, with `backend: 'unknown'`.
  *
  * The ALS pattern matches `resources/Table.ts:3517` and is rooted at
  * `resources/transaction.ts:6`.
@@ -40,15 +41,19 @@ export class Models implements ModelsContract {
 	}
 
 	async embed(input: string | string[], opts: EmbedOpts = {}): Promise<Float32Array[]> {
-		const backend = resolveEmbedding(opts.model);
-		requireCapability(backend, 'embed');
 		const { accounting, signal } = resolveCallContext(opts.signal);
-		const backendOpts: BackendOpts<EmbedOpts> = { ...opts, signal, accounting };
 		const startedAt = performance.now();
+		let backend: ModelBackend | undefined;
 		try {
+			backend = resolveEmbedding(opts.model);
+			requireCapability(backend, 'embed');
+			const backendOpts: BackendOpts<EmbedOpts> = { ...opts, signal, accounting };
 			const result = await backend.embed!(input, backendOpts);
+			// Throw on `pending` BEFORE recording success — otherwise we'd write a
+			// success row followed by a failure row from the catch (duplicate).
+			if (result.status !== 'completed') throw new ModelPendingNotSupportedError(backend.name);
 			this.#record(backend, 'embed', opts.model, accounting, undefined, result, startedAt);
-			return unwrap(backend, result);
+			return result.output;
 		} catch (err) {
 			this.#recordFailure(backend, 'embed', opts.model, accounting, undefined, startedAt, err);
 			throw err;
@@ -56,15 +61,17 @@ export class Models implements ModelsContract {
 	}
 
 	async generate(input: GenerateInput, opts: GenerateOpts = {}): Promise<GenerateResult> {
-		const backend = resolveGenerative(opts.model);
-		requireCapability(backend, 'generate');
 		const { accounting, signal } = resolveCallContext(opts.signal);
-		const backendOpts: BackendOpts<GenerateOpts> = { ...opts, signal, accounting };
 		const startedAt = performance.now();
+		let backend: ModelBackend | undefined;
 		try {
+			backend = resolveGenerative(opts.model);
+			requireCapability(backend, 'generate');
+			const backendOpts: BackendOpts<GenerateOpts> = { ...opts, signal, accounting };
 			const result = await backend.generate!(input, backendOpts);
+			if (result.status !== 'completed') throw new ModelPendingNotSupportedError(backend.name);
 			this.#record(backend, 'generate', opts.model, accounting, opts, result, startedAt);
-			return unwrap(backend, result);
+			return result.output;
 		} catch (err) {
 			this.#recordFailure(backend, 'generate', opts.model, accounting, opts, startedAt, err);
 			throw err;
@@ -72,11 +79,20 @@ export class Models implements ModelsContract {
 	}
 
 	generateStream(input: GenerateInput, opts: GenerateOpts = {}): AsyncIterable<GenerateChunk> {
-		const backend = resolveGenerative(opts.model);
-		requireCapability(backend, 'stream');
 		const { accounting, signal } = resolveCallContext(opts.signal);
+		const startedAt = performance.now();
+		let backend: ModelBackend;
+		try {
+			backend = resolveGenerative(opts.model);
+			requireCapability(backend, 'stream');
+		} catch (err) {
+			// Record pre-call failure synchronously so callers that hold but never
+			// iterate the returned iterable still produce a billing row, then rethrow.
+			this.#recordFailure(undefined, 'generateStream', opts.model, accounting, opts, startedAt, err);
+			throw err;
+		}
 		const backendOpts: BackendOpts<GenerateOpts> = { ...opts, signal, accounting };
-		return this.#wrapStream(backend, input, backendOpts, opts, accounting);
+		return this.#wrapStream(backend, input, backendOpts, opts, accounting, startedAt);
 	}
 
 	async *#wrapStream(
@@ -84,24 +100,29 @@ export class Models implements ModelsContract {
 		input: GenerateInput,
 		backendOpts: BackendOpts<GenerateOpts>,
 		opts: GenerateOpts,
-		accounting: AccountingContext
+		accounting: AccountingContext,
+		startedAt: number
 	): AsyncIterable<GenerateChunk> {
-		const startedAt = performance.now();
-		let success = true;
 		let caught: unknown;
+		let completed = false;
 		try {
 			for await (const chunk of backend.generateStream!(input, backendOpts)) {
 				yield chunk;
 			}
+			completed = true;
 		} catch (err) {
-			success = false;
 			caught = err;
 			throw err;
 		} finally {
-			if (success) {
+			if (completed) {
 				this.#record(backend, 'generateStream', opts.model, accounting, opts, undefined, startedAt);
-			} else {
+			} else if (caught) {
 				this.#recordFailure(backend, 'generateStream', opts.model, accounting, opts, startedAt, caught);
+			} else {
+				// Stream terminated by the consumer (break / iter.return()) without an error
+				// from the backend. Treat as an aborted call rather than success — the model
+				// did real work that the caller didn't consume.
+				this.#recordFailure(backend, 'generateStream', opts.model, accounting, opts, startedAt, 'aborted');
 			}
 		}
 	}
@@ -120,23 +141,24 @@ export class Models implements ModelsContract {
 	}
 
 	#recordFailure(
-		backend: ModelBackend,
+		backend: ModelBackend | undefined,
 		method: CallMethod,
 		model: string | undefined,
 		accounting: AccountingContext,
 		opts: GenerateOpts | undefined,
 		startedAt: number,
-		err: unknown
+		errOrCode: unknown
 	): void {
+		const error_code = typeof errOrCode === 'string' ? errOrCode : classifyError(errOrCode);
 		this.#analyticsWriter.write({
 			...buildRecord(backend, method, model, accounting, opts, undefined, startedAt, false),
-			error_code: classifyError(err),
+			error_code,
 		});
 	}
 }
 
 function buildRecord(
-	backend: ModelBackend,
+	backend: ModelBackend | undefined,
 	method: CallMethod,
 	model: string | undefined,
 	accounting: AccountingContext,
@@ -146,7 +168,7 @@ function buildRecord(
 	success: boolean
 ): ModelCallRecord {
 	const record: ModelCallRecord = {
-		backend: backend.name,
+		backend: backend?.name ?? 'unknown',
 		method,
 		model,
 		tenant: accounting.tenantId,
@@ -166,7 +188,7 @@ function buildRecord(
 }
 
 function resolveCallContext(callerSignal?: AbortSignal): { accounting: AccountingContext; signal?: AbortSignal } {
-	const ctx = contextStorage.getStore() as any;
+	const ctx = contextStorage.getStore();
 	return {
 		accounting: {
 			tenantId: extractTenantId(ctx?.user),
@@ -184,16 +206,13 @@ function requireCapability(backend: ModelBackend, capability: 'embed' | 'generat
 	if (!backend.capabilities()[capability]) throw new ModelCapabilityError(backend.name, capability);
 }
 
-function unwrap<T>(backend: ModelBackend, result: ModelCallResult<T>): T {
-	if (result.status === 'completed') return result.output;
-	throw new ModelPendingNotSupportedError(backend.name);
-}
-
 function classifyError(err: unknown): string {
 	if (err && typeof err === 'object') {
 		const e = err as { name?: string; code?: string };
 		if (e.name === 'AbortError' || e.code === 'ABORT_ERR') return 'aborted';
 		if (e.name === 'ModelCapabilityError') return 'capability_unsupported';
+		if (e.name === 'ModelBackendNotFoundError') return 'backend_not_found';
+		if (e.name === 'ModelPendingNotSupportedError') return 'pending_unsupported';
 	}
 	return 'backend_error';
 }

--- a/resources/models/Models.ts
+++ b/resources/models/Models.ts
@@ -81,14 +81,17 @@ export class Models implements ModelsContract {
 	generateStream(input: GenerateInput, opts: GenerateOpts = {}): AsyncIterable<GenerateChunk> {
 		const { accounting, signal } = resolveCallContext(opts.signal);
 		const startedAt = performance.now();
-		let backend: ModelBackend;
+		let backend: ModelBackend | undefined;
 		try {
 			backend = resolveGenerative(opts.model);
 			requireCapability(backend, 'stream');
 		} catch (err) {
 			// Record pre-call failure synchronously so callers that hold but never
 			// iterate the returned iterable still produce a billing row, then rethrow.
-			this.#recordFailure(undefined, 'generateStream', opts.model, accounting, opts, startedAt, err);
+			// Pass `backend` (not `undefined`): when the registry hit but the capability
+			// check failed, `backend` is the resolved instance and its name belongs in
+			// the row. Only registry misses leave `backend` undefined → 'unknown'.
+			this.#recordFailure(backend, 'generateStream', opts.model, accounting, opts, startedAt, err);
 			throw err;
 		}
 		const backendOpts: BackendOpts<GenerateOpts> = { ...opts, signal, accounting };

--- a/resources/models/TestBackend.ts
+++ b/resources/models/TestBackend.ts
@@ -1,0 +1,83 @@
+import type {
+	BackendOpts,
+	EmbedOpts,
+	GenerateChunk,
+	GenerateInput,
+	GenerateOpts,
+	GenerateResult,
+	ModelBackend,
+	ModelCallResult,
+	ModelCapabilities,
+} from './types.ts';
+
+/**
+ * Deterministic in-memory backend for Phase 1 tests.
+ *
+ * Same input always produces the same output — no external services, no model
+ * files, no network. Lets the facade, registry, accounting, and analytics
+ * paths be exercised end-to-end without an Ollama / OpenAI / fabric backend.
+ */
+export class TestBackend implements ModelBackend {
+	readonly name = 'test';
+
+	capabilities(): ModelCapabilities {
+		return { embed: true, generate: true, stream: true, tools: false, adapters: false };
+	}
+
+	async embed(input: string | string[], _opts: BackendOpts<EmbedOpts>): Promise<ModelCallResult<Float32Array[]>> {
+		const texts = Array.isArray(input) ? input : [input];
+		const vectors = texts.map((t) => deterministicVector(t, 16));
+		const embeddingTokens = texts.reduce((sum, t) => sum + t.length, 0);
+		return { status: 'completed', output: vectors, usage: { embeddingTokens, latencyMs: 0 } };
+	}
+
+	async generate(input: GenerateInput, _opts: BackendOpts<GenerateOpts>): Promise<ModelCallResult<GenerateResult>> {
+		const text = stringFromInput(input);
+		const content = `[TestBackend echoed]: ${text}`;
+		return {
+			status: 'completed',
+			output: { content, finishReason: 'stop' },
+			usage: { promptTokens: text.length, completionTokens: content.length, latencyMs: 0 },
+		};
+	}
+
+	async *generateStream(input: GenerateInput, _opts: BackendOpts<GenerateOpts>): AsyncIterable<GenerateChunk> {
+		const text = stringFromInput(input);
+		const words = `[TestBackend stream]: ${text}`.split(' ');
+		for (const word of words) {
+			yield { deltaContent: word + ' ' };
+		}
+		yield { finishReason: 'stop' };
+	}
+}
+
+function stringFromInput(input: GenerateInput): string {
+	if (typeof input === 'string') return input;
+	const messages = Array.isArray(input) ? input : input.messages;
+	return messages.map((m) => m.content).join(' ');
+}
+
+/**
+ * Hash text into a deterministic Float32Array of the given dimension.
+ *
+ * Uses FNV-1a to seed a Mulberry32 PRNG; values are mapped to [-1, 1).
+ * Same input → same vector across runs and platforms; not a cryptographic hash.
+ */
+function deterministicVector(text: string, dim: number): Float32Array {
+	let seed = 2166136261 >>> 0; // FNV-1a 32-bit offset basis
+	for (let i = 0; i < text.length; i++) {
+		seed ^= text.charCodeAt(i);
+		seed = Math.imul(seed, 16777619) >>> 0;
+	}
+	const vec = new Float32Array(dim);
+	let state = seed;
+	for (let i = 0; i < dim; i++) {
+		state = (state + 0x6d2b79f5) >>> 0;
+		let t = state;
+		t = Math.imul(t ^ (t >>> 15), t | 1) >>> 0;
+		t = (t + Math.imul(t ^ (t >>> 7), t | 61)) >>> 0;
+		const r = ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+		vec[i] = r * 2 - 1; // map [0, 1) → [-1, 1)
+	}
+	return vec;
+}

--- a/resources/models/analyticsTable.ts
+++ b/resources/models/analyticsTable.ts
@@ -1,5 +1,4 @@
-import { table } from '../databases.ts';
-import { get as envGet } from '../../utility/environment/environmentManager.ts';
+import { table, isReadOnlyMode } from '../databases.ts';
 import { getNextMonotonicTime } from '../../utility/lmdb/commonUtility.ts';
 import harperLogger from '../../utility/logging/harper_logger.ts';
 
@@ -8,7 +7,11 @@ const log = harperLogger.forComponent('models').conditional;
 const DEFAULT_FLUSH_INTERVAL_MS = 10_000; // 10s
 const DEFAULT_MAX_BUFFER_SIZE = 1000;
 const DEFAULT_CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // 1h
-const DEFAULT_RETENTION_DAYS = 90;
+// 90-day default tuned for billing windows. Operator-tunable config key will land
+// in Phase 2 alongside the YAML→registry bootstrapper (Harper's `getConfigValue`
+// only reads keys registered in `CONFIG_PARAM_MAP`, so we defer config plumbing
+// until the first real backend ships and the key has a documented owner).
+const DEFAULT_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
 
 /**
  * One row in `hdb_model_calls`. Field names are snake_case to match the table
@@ -109,7 +112,7 @@ export class ModelCallAnalyticsWriter {
 		const flushIntervalMs = opts.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS;
 		const cleanupIntervalMs = opts.cleanupIntervalMs ?? DEFAULT_CLEANUP_INTERVAL_MS;
 		this.#maxBufferSize = opts.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE;
-		this.#retentionMs = opts.retentionMs ?? resolveRetentionMs();
+		this.#retentionMs = opts.retentionMs ?? DEFAULT_RETENTION_MS;
 		this.#getTable = opts.getTable ?? getModelCallsTable;
 		this.#flushTimer = setInterval(() => {
 			this.flush().catch((err) => log.warn?.(`Model-call analytics flush failed: ${err?.message ?? err}`));
@@ -123,7 +126,9 @@ export class ModelCallAnalyticsWriter {
 
 	write(record: ModelCallRecord): void {
 		if (this.#stopped) return;
-		this.#buffer.push({ id: getNextMonotonicTime(), ...record });
+		// id last so a record that accidentally carries an `id` field can't override
+		// the monotonic primary key.
+		this.#buffer.push({ ...record, id: getNextMonotonicTime() });
 		if (this.#buffer.length >= this.#maxBufferSize) {
 			// Out-of-cadence flush; swallow errors so a failing flush doesn't escape into the caller.
 			this.flush().catch((err) => log.warn?.(`Model-call analytics flush failed: ${err?.message ?? err}`));
@@ -132,26 +137,40 @@ export class ModelCallAnalyticsWriter {
 
 	async flush(): Promise<void> {
 		if (this.#buffer.length === 0) return;
+		// Read-only nodes (followers, recovery mode) shouldn't accumulate doomed writes —
+		// drop the buffer and skip. Matches `resources/analytics/write.ts:643-650`.
+		if (isReadOnlyMode()) {
+			this.#buffer = [];
+			return;
+		}
 		const batch = this.#buffer;
 		this.#buffer = [];
 		const tbl = this.#getTable();
-		const puts: Promise<unknown>[] = [];
+		const puts: Array<{ id: number; promise: Promise<unknown> }> = [];
 		for (const record of batch) {
 			try {
 				const result = tbl.primaryStore.put(record.id, record);
 				if (result && typeof (result as { then?: unknown }).then === 'function') {
-					puts.push(result as Promise<unknown>);
+					puts.push({ id: record.id, promise: result as Promise<unknown> });
 				}
 			} catch (err) {
 				log.warn?.(`Model-call analytics put failed for id=${record.id}: ${(err as Error)?.message ?? err}`);
 			}
 		}
 		if (puts.length > 0) {
-			await Promise.allSettled(puts);
+			const results = await Promise.allSettled(puts.map((p) => p.promise));
+			for (let i = 0; i < results.length; i++) {
+				const r = results[i];
+				if (r.status === 'rejected') {
+					const reason = r.reason as { message?: string } | undefined;
+					log.warn?.(`Model-call analytics async put failed for id=${puts[i].id}: ${reason?.message ?? r.reason}`);
+				}
+			}
 		}
 	}
 
 	async cleanup(): Promise<void> {
+		if (isReadOnlyMode()) return;
 		const end = Date.now() - this.#retentionMs;
 		const tbl = this.#getTable();
 		for (const key of tbl.primaryStore.getKeys({ start: false, end })) {
@@ -170,12 +189,6 @@ export class ModelCallAnalyticsWriter {
 	get bufferSize(): number {
 		return this.#buffer.length;
 	}
-}
-
-function resolveRetentionMs(): number {
-	const days = envGet('analytics.modelCallRetentionDays');
-	const n = typeof days === 'number' && days > 0 ? days : DEFAULT_RETENTION_DAYS;
-	return n * 24 * 60 * 60 * 1000;
 }
 
 let _writer: ModelCallAnalyticsWriter | undefined;

--- a/resources/models/analyticsTable.ts
+++ b/resources/models/analyticsTable.ts
@@ -81,6 +81,8 @@ export interface ModelCallAnalyticsWriterOpts {
 	cleanupIntervalMs?: number;
 	/** Default 90d. Rows older than this are removed by `cleanup()`. */
 	retentionMs?: number;
+	/** Override the table accessor. Tests inject a mock to avoid touching real LMDB. */
+	getTable?: () => any;
 }
 
 /**
@@ -100,6 +102,7 @@ export class ModelCallAnalyticsWriter {
 	#cleanupTimer?: NodeJS.Timeout;
 	#maxBufferSize: number;
 	#retentionMs: number;
+	#getTable: () => any;
 	#stopped = false;
 
 	constructor(opts: ModelCallAnalyticsWriterOpts = {}) {
@@ -107,6 +110,7 @@ export class ModelCallAnalyticsWriter {
 		const cleanupIntervalMs = opts.cleanupIntervalMs ?? DEFAULT_CLEANUP_INTERVAL_MS;
 		this.#maxBufferSize = opts.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE;
 		this.#retentionMs = opts.retentionMs ?? resolveRetentionMs();
+		this.#getTable = opts.getTable ?? getModelCallsTable;
 		this.#flushTimer = setInterval(() => {
 			this.flush().catch((err) => log.warn?.(`Model-call analytics flush failed: ${err?.message ?? err}`));
 		}, flushIntervalMs);
@@ -130,19 +134,26 @@ export class ModelCallAnalyticsWriter {
 		if (this.#buffer.length === 0) return;
 		const batch = this.#buffer;
 		this.#buffer = [];
-		const tbl = getModelCallsTable();
+		const tbl = this.#getTable();
+		const puts: Promise<unknown>[] = [];
 		for (const record of batch) {
 			try {
-				tbl.primaryStore.put(record.id, record);
+				const result = tbl.primaryStore.put(record.id, record);
+				if (result && typeof (result as { then?: unknown }).then === 'function') {
+					puts.push(result as Promise<unknown>);
+				}
 			} catch (err) {
 				log.warn?.(`Model-call analytics put failed for id=${record.id}: ${(err as Error)?.message ?? err}`);
 			}
+		}
+		if (puts.length > 0) {
+			await Promise.allSettled(puts);
 		}
 	}
 
 	async cleanup(): Promise<void> {
 		const end = Date.now() - this.#retentionMs;
-		const tbl = getModelCallsTable();
+		const tbl = this.#getTable();
 		for (const key of tbl.primaryStore.getKeys({ start: false, end })) {
 			tbl.primaryStore.remove(key);
 		}

--- a/resources/models/analyticsTable.ts
+++ b/resources/models/analyticsTable.ts
@@ -1,0 +1,175 @@
+import { table } from '../databases.ts';
+import { get as envGet } from '../../utility/environment/environmentManager.ts';
+import { getNextMonotonicTime } from '../../utility/lmdb/commonUtility.ts';
+import harperLogger from '../../utility/logging/harper_logger.ts';
+
+const log = harperLogger.forComponent('models').conditional;
+
+const DEFAULT_FLUSH_INTERVAL_MS = 10_000; // 10s
+const DEFAULT_MAX_BUFFER_SIZE = 1000;
+const DEFAULT_CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // 1h
+const DEFAULT_RETENTION_DAYS = 90;
+
+/**
+ * One row in `hdb_model_calls`. Field names are snake_case to match the table
+ * schema. Numeric token counts are optional because not every backend reports
+ * every metric.
+ */
+export interface ModelCallRecord {
+	tenant?: string;
+	app?: string;
+	model?: string;
+	backend: string;
+	method: 'embed' | 'generate' | 'generateStream';
+	adapter?: string;
+	conversation_id?: string;
+	prompt_tokens?: number;
+	completion_tokens?: number;
+	embedding_tokens?: number;
+	gpu_ms?: number;
+	latency_ms: number;
+	success: boolean;
+	/** Sanitized code (e.g. 'backend_error', 'aborted', 'capability_unsupported'). Never a raw upstream message. */
+	error_code?: string;
+}
+
+interface BufferedRecord extends ModelCallRecord {
+	id: number;
+}
+
+let _table: any;
+/**
+ * Lazy-getter for `hdb_model_calls`. Matches the convention used by
+ * `getRawAnalyticsTable()` / `getAnalyticsTable()` in
+ * `resources/analytics/write.ts:656-700` and the system-table declarations in
+ * `server/DurableSubscriptionsSession.ts:14-50`.
+ */
+export function getModelCallsTable(): any {
+	if (_table) return _table;
+	_table = table({
+		table: 'hdb_model_calls',
+		database: 'system',
+		audit: true,
+		trackDeletes: false,
+		attributes: [
+			{ name: 'id', isPrimaryKey: true },
+			{ name: 'tenant', type: 'string', indexed: true },
+			{ name: 'app', type: 'string', indexed: true },
+			{ name: 'model', type: 'string', indexed: true },
+			{ name: 'backend', type: 'string', indexed: true },
+			{ name: 'method', type: 'string', indexed: true },
+			{ name: 'adapter', type: 'string', indexed: true },
+			{ name: 'conversation_id', type: 'string', indexed: true },
+			{ name: 'prompt_tokens', type: 'number' },
+			{ name: 'completion_tokens', type: 'number' },
+			{ name: 'embedding_tokens', type: 'number' },
+			{ name: 'gpu_ms', type: 'number' },
+			{ name: 'latency_ms', type: 'number', indexed: true },
+			{ name: 'success', type: 'boolean', indexed: true },
+			{ name: 'error_code', type: 'string' },
+		],
+	});
+	return _table;
+}
+
+export interface ModelCallAnalyticsWriterOpts {
+	/** Default 10s. Buffer is flushed at this cadence regardless of size. */
+	flushIntervalMs?: number;
+	/** Default 1000. Reaching this size triggers an out-of-cadence flush. */
+	maxBufferSize?: number;
+	/** Default 1h. How often `cleanup()` runs to remove expired rows. */
+	cleanupIntervalMs?: number;
+	/** Default 90d. Rows older than this are removed by `cleanup()`. */
+	retentionMs?: number;
+}
+
+/**
+ * In-memory buffered writer for per-call model analytics. Rows are batched and
+ * flushed periodically (or when the buffer is full) to keep the analytics path
+ * off the hot model-call path. Shape mirrors the pattern in
+ * `resources/analytics/write.ts` but writes per-call rows rather than
+ * aggregating counters.
+ *
+ * The intervals are `.unref()`ed so they never hold the process open during
+ * shutdown; rows buffered at shutdown are dropped (best-effort, same posture
+ * as the existing analytics writer).
+ */
+export class ModelCallAnalyticsWriter {
+	#buffer: BufferedRecord[] = [];
+	#flushTimer?: NodeJS.Timeout;
+	#cleanupTimer?: NodeJS.Timeout;
+	#maxBufferSize: number;
+	#retentionMs: number;
+	#stopped = false;
+
+	constructor(opts: ModelCallAnalyticsWriterOpts = {}) {
+		const flushIntervalMs = opts.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS;
+		const cleanupIntervalMs = opts.cleanupIntervalMs ?? DEFAULT_CLEANUP_INTERVAL_MS;
+		this.#maxBufferSize = opts.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE;
+		this.#retentionMs = opts.retentionMs ?? resolveRetentionMs();
+		this.#flushTimer = setInterval(() => {
+			this.flush().catch((err) => log.warn?.(`Model-call analytics flush failed: ${err?.message ?? err}`));
+		}, flushIntervalMs);
+		this.#flushTimer.unref?.();
+		this.#cleanupTimer = setInterval(() => {
+			this.cleanup().catch((err) => log.warn?.(`Model-call analytics cleanup failed: ${err?.message ?? err}`));
+		}, cleanupIntervalMs);
+		this.#cleanupTimer.unref?.();
+	}
+
+	write(record: ModelCallRecord): void {
+		if (this.#stopped) return;
+		this.#buffer.push({ id: getNextMonotonicTime(), ...record });
+		if (this.#buffer.length >= this.#maxBufferSize) {
+			// Out-of-cadence flush; swallow errors so a failing flush doesn't escape into the caller.
+			this.flush().catch((err) => log.warn?.(`Model-call analytics flush failed: ${err?.message ?? err}`));
+		}
+	}
+
+	async flush(): Promise<void> {
+		if (this.#buffer.length === 0) return;
+		const batch = this.#buffer;
+		this.#buffer = [];
+		const tbl = getModelCallsTable();
+		for (const record of batch) {
+			try {
+				tbl.primaryStore.put(record.id, record);
+			} catch (err) {
+				log.warn?.(`Model-call analytics put failed for id=${record.id}: ${(err as Error)?.message ?? err}`);
+			}
+		}
+	}
+
+	async cleanup(): Promise<void> {
+		const end = Date.now() - this.#retentionMs;
+		const tbl = getModelCallsTable();
+		for (const key of tbl.primaryStore.getKeys({ start: false, end })) {
+			tbl.primaryStore.remove(key);
+		}
+	}
+
+	/** Stop the periodic timers. After stop, `write()` is a no-op and `flush()` still works. */
+	stop(): void {
+		this.#stopped = true;
+		if (this.#flushTimer) clearInterval(this.#flushTimer);
+		if (this.#cleanupTimer) clearInterval(this.#cleanupTimer);
+	}
+
+	/** Test-only: inspect current buffer size without flushing. */
+	get bufferSize(): number {
+		return this.#buffer.length;
+	}
+}
+
+function resolveRetentionMs(): number {
+	const days = envGet('analytics.modelCallRetentionDays');
+	const n = typeof days === 'number' && days > 0 ? days : DEFAULT_RETENTION_DAYS;
+	return n * 24 * 60 * 60 * 1000;
+}
+
+let _writer: ModelCallAnalyticsWriter | undefined;
+/** Process-wide singleton writer. Constructed on first access. */
+export function getModelCallAnalyticsWriter(): ModelCallAnalyticsWriter {
+	if (!_writer) _writer = new ModelCallAnalyticsWriter();
+	return _writer;
+}

--- a/resources/models/backendRegistry.ts
+++ b/resources/models/backendRegistry.ts
@@ -1,76 +1,66 @@
-import { get as envGet } from '../../utility/environment/environmentManager.ts';
 import { ServerError } from '../../utility/errors/hdbError.ts';
 import type { ModelBackend } from './types.ts';
 
 /**
  * Process-wide model backend registry.
  *
- * Backends register themselves by `backend.name` (e.g. `'test'`, `'ollama'`,
- * `'ollama:fast'`). Per-kind logical-name resolution is config-driven:
- * `resolveEmbedding('default')` reads `models.embedding.default.backend` from
- * config and returns the registered backend with that name.
+ * Stores logical-name → backend-instance mappings for embedding and
+ * generative kinds. App code or boot wiring populates the registry via
+ * `setEmbedding(...)` / `setGenerative(...)`; the `Models` facade reads it
+ * via `resolveEmbedding(...)` / `resolveGenerative(...)`.
  *
  * Module-scope state is intentional — one registry per Harper process,
- * mirroring `contextStorage` at `resources/transaction.ts:6`.
+ * mirroring `contextStorage` at `resources/transaction.ts:6`. Translating
+ * a YAML `models:` config block into registry entries (the bootstrapper
+ * step) lands in Phase 2 alongside the first real backend.
  */
 
 type ModelKind = 'embedding' | 'generative';
 
-const byName: Map<string, ModelBackend> = new Map();
+const embedding: Map<string, ModelBackend> = new Map();
+const generative: Map<string, ModelBackend> = new Map();
 
-/**
- * Register a backend instance. Idempotent on `backend.name` — re-registering
- * with the same name replaces the prior instance (convenient for tests).
- */
-export function registerBackend(backend: ModelBackend): void {
-	byName.set(backend.name, backend);
+/** Map `logicalName` to a backend for embedding calls. Re-set replaces. */
+export function setEmbedding(logicalName: string, backend: ModelBackend): void {
+	embedding.set(logicalName, backend);
+}
+
+/** Map `logicalName` to a backend for generative calls. Re-set replaces. */
+export function setGenerative(logicalName: string, backend: ModelBackend): void {
+	generative.set(logicalName, backend);
 }
 
 /**
- * Resolve the backend configured as the embedding provider for `logicalName`
- * (default: `'default'`). Throws if no config entry exists or the named
- * backend is not registered.
+ * Resolve the embedding backend mapped to `logicalName` (default: `'default'`).
+ * Throws `ModelBackendNotFoundError` if no backend is mapped.
  */
 export function resolveEmbedding(logicalName: string = 'default'): ModelBackend {
-	return resolve('embedding', logicalName);
-}
-
-/**
- * Resolve the backend configured as the generative provider for `logicalName`
- * (default: `'default'`). Throws if no config entry exists or the named
- * backend is not registered.
- */
-export function resolveGenerative(logicalName: string = 'default'): ModelBackend {
-	return resolve('generative', logicalName);
-}
-
-/** Remove all registered backends. Test-only hygiene. */
-export function clearRegistry(): void {
-	byName.clear();
-}
-
-function resolve(kind: ModelKind, logicalName: string): ModelBackend {
-	const backendName = envGet(`models.${kind}.${logicalName}.backend`);
-	if (typeof backendName !== 'string' || !backendName) {
-		throw new ModelBackendNotConfiguredError(kind, logicalName);
-	}
-	const backend = byName.get(backendName);
-	if (!backend) throw new ModelBackendNotRegisteredError(kind, logicalName);
+	const backend = embedding.get(logicalName);
+	if (!backend) throw new ModelBackendNotFoundError('embedding', logicalName);
 	return backend;
 }
 
-export class ModelBackendNotConfiguredError extends ServerError {
-	constructor(kind: ModelKind, logicalName: string) {
-		super(`No '${kind}.${logicalName}.backend' configured`);
-		this.name = 'ModelBackendNotConfiguredError';
-	}
+/**
+ * Resolve the generative backend mapped to `logicalName` (default: `'default'`).
+ * Throws `ModelBackendNotFoundError` if no backend is mapped.
+ */
+export function resolveGenerative(logicalName: string = 'default'): ModelBackend {
+	const backend = generative.get(logicalName);
+	if (!backend) throw new ModelBackendNotFoundError('generative', logicalName);
+	return backend;
 }
 
-export class ModelBackendNotRegisteredError extends ServerError {
-	// Deliberately does not name which backend was configured — avoids leaking
-	// the set of registered backend identifiers in error responses.
+/** Remove all registrations. Test-only hygiene. */
+export function clearRegistry(): void {
+	embedding.clear();
+	generative.clear();
+}
+
+export class ModelBackendNotFoundError extends ServerError {
+	// Message identifies the kind + logical name only; never enumerates other
+	// registered names to avoid leaking the registry shape in error responses.
 	constructor(kind: ModelKind, logicalName: string) {
-		super(`Backend configured for '${kind}.${logicalName}' is not registered`);
-		this.name = 'ModelBackendNotRegisteredError';
+		super(`No backend registered for '${kind}.${logicalName}'`);
+		this.name = 'ModelBackendNotFoundError';
 	}
 }

--- a/resources/models/backendRegistry.ts
+++ b/resources/models/backendRegistry.ts
@@ -1,0 +1,76 @@
+import { get as envGet } from '../../utility/environment/environmentManager.ts';
+import { ServerError } from '../../utility/errors/hdbError.ts';
+import type { ModelBackend } from './types.ts';
+
+/**
+ * Process-wide model backend registry.
+ *
+ * Backends register themselves by `backend.name` (e.g. `'test'`, `'ollama'`,
+ * `'ollama:fast'`). Per-kind logical-name resolution is config-driven:
+ * `resolveEmbedding('default')` reads `models.embedding.default.backend` from
+ * config and returns the registered backend with that name.
+ *
+ * Module-scope state is intentional — one registry per Harper process,
+ * mirroring `contextStorage` at `resources/transaction.ts:6`.
+ */
+
+type ModelKind = 'embedding' | 'generative';
+
+const byName: Map<string, ModelBackend> = new Map();
+
+/**
+ * Register a backend instance. Idempotent on `backend.name` — re-registering
+ * with the same name replaces the prior instance (convenient for tests).
+ */
+export function registerBackend(backend: ModelBackend): void {
+	byName.set(backend.name, backend);
+}
+
+/**
+ * Resolve the backend configured as the embedding provider for `logicalName`
+ * (default: `'default'`). Throws if no config entry exists or the named
+ * backend is not registered.
+ */
+export function resolveEmbedding(logicalName: string = 'default'): ModelBackend {
+	return resolve('embedding', logicalName);
+}
+
+/**
+ * Resolve the backend configured as the generative provider for `logicalName`
+ * (default: `'default'`). Throws if no config entry exists or the named
+ * backend is not registered.
+ */
+export function resolveGenerative(logicalName: string = 'default'): ModelBackend {
+	return resolve('generative', logicalName);
+}
+
+/** Remove all registered backends. Test-only hygiene. */
+export function clearRegistry(): void {
+	byName.clear();
+}
+
+function resolve(kind: ModelKind, logicalName: string): ModelBackend {
+	const backendName = envGet(`models.${kind}.${logicalName}.backend`);
+	if (typeof backendName !== 'string' || !backendName) {
+		throw new ModelBackendNotConfiguredError(kind, logicalName);
+	}
+	const backend = byName.get(backendName);
+	if (!backend) throw new ModelBackendNotRegisteredError(kind, logicalName);
+	return backend;
+}
+
+export class ModelBackendNotConfiguredError extends ServerError {
+	constructor(kind: ModelKind, logicalName: string) {
+		super(`No '${kind}.${logicalName}.backend' configured`);
+		this.name = 'ModelBackendNotConfiguredError';
+	}
+}
+
+export class ModelBackendNotRegisteredError extends ServerError {
+	// Deliberately does not name which backend was configured — avoids leaking
+	// the set of registered backend identifiers in error responses.
+	constructor(kind: ModelKind, logicalName: string) {
+		super(`Backend configured for '${kind}.${logicalName}' is not registered`);
+		this.name = 'ModelBackendNotRegisteredError';
+	}
+}

--- a/resources/models/backendRegistry.ts
+++ b/resources/models/backendRegistry.ts
@@ -5,7 +5,7 @@ import type { ModelBackend } from './types.ts';
  * Process-wide model backend registry.
  *
  * Stores logical-name → backend-instance mappings for embedding and
- * generative kinds. App code or boot wiring populates the registry via
+ * generative kinds. Boot wiring populates the registry via
  * `setEmbedding(...)` / `setGenerative(...)`; the `Models` facade reads it
  * via `resolveEmbedding(...)` / `resolveGenerative(...)`.
  *

--- a/resources/models/types.ts
+++ b/resources/models/types.ts
@@ -1,0 +1,124 @@
+/**
+ * Public type surface for the model-access API (`scope.models`).
+ *
+ * Phase 1 foundation of #510. Other phases (ollama, openai, gateway, @embed,
+ * anthropic, bedrock) consume these types; changes here cascade.
+ *
+ * Reference: planning artifact `tmp/harper-510-phase-1-detail.md` (canonical shapes).
+ */
+
+export interface Models {
+	embed(input: string | string[], opts?: EmbedOpts): Promise<Float32Array[]>;
+	generate(input: GenerateInput, opts?: GenerateOpts): Promise<GenerateResult>;
+	generateStream(input: GenerateInput, opts?: GenerateOpts): AsyncIterable<GenerateChunk>;
+}
+
+export interface ModelBackend {
+	readonly name: string;
+	capabilities(): ModelCapabilities;
+	embed?(input: string | string[], opts: BackendOpts<EmbedOpts>): Promise<ModelCallResult<Float32Array[]>>;
+	generate?(input: GenerateInput, opts: BackendOpts<GenerateOpts>): Promise<ModelCallResult<GenerateResult>>;
+	generateStream?(input: GenerateInput, opts: BackendOpts<GenerateOpts>): AsyncIterable<GenerateChunk>;
+}
+
+export interface ModelCapabilities {
+	embed: boolean;
+	generate: boolean;
+	stream: boolean;
+	tools: boolean;
+	adapters: boolean;
+}
+
+export type EmbedOpts = {
+	model?: string;
+	/** For models that distinguish document-vs-query embeddings (e.g. nomic-embed-text); ignored otherwise. */
+	inputType?: 'document' | 'query';
+	signal?: AbortSignal;
+};
+
+export type GenerateOpts = {
+	model?: string;
+	adapter?: string;
+	temperature?: number;
+	maxTokens?: number;
+	responseFormat?: 'text' | 'json' | { schema: object };
+	tools?: ToolDef[];
+	toolMode?: 'return' | 'auto';
+	/** Accepted in Phase 1; activates with #511 (ConversationResource). */
+	conversationId?: string;
+	signal?: AbortSignal;
+};
+
+export type GenerateInput = string | Message[] | { messages: Message[]; tools?: ToolDef[]; system?: string };
+
+/** Options handed to a backend: caller-supplied opts plus runtime accounting context. */
+export type BackendOpts<TOpts> = TOpts & { accounting: AccountingContext };
+
+export interface AccountingContext {
+	/** Free-form tenant identifier (v1). Pending canonical model from #510 comment thread. */
+	tenantId?: string;
+	/** Resource path (e.g. matched route) of the calling Resource, if any. */
+	app?: string;
+}
+
+/**
+ * Backend call result.
+ *
+ * `pending` is reserved for future long-running operations (Bedrock batch, fabric LROs);
+ * no Phase 1 backend emits it. The public `Models` facade unwraps `completed` and
+ * matches #510's `Promise<Float32Array[]>` / `Promise<GenerateResult>` signatures,
+ * throwing if a backend returns `pending` until the LRO surface is added.
+ */
+export type ModelCallResult<T> =
+	| { status: 'completed'; output: T; usage?: TokenUsage }
+	| { status: 'pending'; operationId: string; resumeAfter?: number };
+
+export interface TokenUsage {
+	promptTokens?: number;
+	completionTokens?: number;
+	embeddingTokens?: number;
+	gpuMs?: number;
+	latencyMs?: number;
+}
+
+export interface Message {
+	role: 'system' | 'user' | 'assistant' | 'tool';
+	content: string;
+	/** When `role === 'assistant'`: tool calls the model requested. */
+	toolCalls?: ToolCall[];
+	/** When `role === 'tool'`: id of the tool call this message responds to. */
+	toolCallId?: string;
+}
+
+export interface ToolDef {
+	name: string;
+	description: string;
+	/** JSON Schema for the tool's input. */
+	parameters: object;
+}
+
+export interface ToolCall {
+	id: string;
+	name: string;
+	/** Parsed tool input. Backends that deliver stringified JSON (OpenAI) normalize before yielding. */
+	arguments: object;
+}
+
+export interface GenerateResult {
+	content: string;
+	toolCalls?: ToolCall[];
+	/** Why generation stopped. Backend-agnostic; backends map their native reasons. */
+	finishReason: 'stop' | 'length' | 'tool_calls' | 'content_filter';
+}
+
+export interface GenerateChunk {
+	/** Incremental text appended since the previous chunk. */
+	deltaContent?: string;
+	/**
+	 * Tool-call deltas accumulating across chunks. A streaming backend may deliver
+	 * the same tool-call id multiple times with partial fields as it builds up.
+	 */
+	deltaToolCalls?: Partial<ToolCall>[];
+	/** Set on the final chunk. */
+	finishReason?: GenerateResult['finishReason'];
+}

--- a/resources/models/types.ts
+++ b/resources/models/types.ts
@@ -42,13 +42,23 @@ export type GenerateOpts = {
 	temperature?: number;
 	maxTokens?: number;
 	responseFormat?: 'text' | 'json' | { schema: object };
-	tools?: ToolDef[];
+	/**
+	 * How to handle tool calls the model emits. `'return'` (default) hands tool-call
+	 * requests back to the caller; `'auto'` resolves them in-process to completion.
+	 * The tool definitions themselves live on `GenerateInput`'s object variant
+	 * (alongside `messages` and `system`) — they're content, not strategy.
+	 */
 	toolMode?: 'return' | 'auto';
 	/** Accepted in Phase 1; activates with #511 (ConversationResource). */
 	conversationId?: string;
 	signal?: AbortSignal;
 };
 
+/**
+ * Generation input. Tools and system prompt live here (with `messages`) because
+ * they are model-facing content. Caller must use the object form to supply tools:
+ * `{ messages, tools, system }`.
+ */
 export type GenerateInput = string | Message[] | { messages: Message[]; tools?: ToolDef[]; system?: string };
 
 /** Options handed to a backend: caller-supplied opts plus runtime accounting context. */

--- a/unitTests/components/Scope.test.js
+++ b/unitTests/components/Scope.test.js
@@ -1,4 +1,5 @@
 const { Scope, MissingDefaultFilesOptionError } = require('#src/components/Scope');
+const { Models } = require('#src/resources/models/Models');
 const { EventEmitter } = require('node:events');
 const assert = require('node:assert/strict');
 const { join, basename } = require('node:path');
@@ -59,6 +60,14 @@ describe('Scope', () => {
 		assert.ok(scope.options instanceof OptionsWatcher, 'Scope should have an OptionsWatcher instance');
 		assert.ok(scope.resources instanceof Resources, 'Scope should have a resources property of type Map');
 		assert.ok(scope.server !== undefined, 'Scope should have a server property');
+		assert.ok(scope.models instanceof Models, 'Scope should expose a Models facade as scope.models');
+		assert.strictEqual(typeof scope.models.embed, 'function', 'scope.models.embed should be callable');
+		assert.strictEqual(typeof scope.models.generate, 'function', 'scope.models.generate should be callable');
+		assert.strictEqual(
+			typeof scope.models.generateStream,
+			'function',
+			'scope.models.generateStream should be callable'
+		);
 
 		// Even though scope is ready, we haven't provided an entry handler yet so modifying a file matched by files option should not request a restart
 		await writeFile(this.testFilePath, '"bar";');

--- a/unitTests/resources/models/Models.test.js
+++ b/unitTests/resources/models/Models.test.js
@@ -1,0 +1,229 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+// Importing databases first primes Harper's module graph in the order other unit tests
+// (e.g. Resource-get-context.test.js) load it; otherwise the transaction.ts ↔
+// DatabaseTransaction/blob require chain hits a cycle when loaded ESM-first by mocha.
+require('#src/resources/databases');
+const { contextStorage } = require('#src/resources/transaction');
+const { setEmbedding, setGenerative, clearRegistry } = require('#src/resources/models/backendRegistry');
+const { TestBackend } = require('#src/resources/models/TestBackend');
+const { Models, ModelCapabilityError, ModelPendingNotSupportedError } = require('#src/resources/models/Models');
+
+function makeMockWriter() {
+	const records = [];
+	return {
+		records,
+		write(record) {
+			records.push(record);
+		},
+	};
+}
+
+describe('Models facade', () => {
+	let writer;
+	let models;
+
+	beforeEach(() => {
+		clearRegistry();
+		writer = makeMockWriter();
+		models = new Models(writer);
+		const test = new TestBackend();
+		setEmbedding('default', test);
+		setGenerative('default', test);
+	});
+
+	afterEach(() => {
+		clearRegistry();
+	});
+
+	describe('embed', () => {
+		it('returns the unwrapped vector array (not a ModelCallResult)', async () => {
+			const vectors = await models.embed('hello');
+			assert.ok(Array.isArray(vectors));
+			assert.ok(vectors[0] instanceof Float32Array);
+		});
+
+		it('writes an analytics record with backend=test, method=embed, success=true', async () => {
+			await models.embed('hello');
+			assert.strictEqual(writer.records.length, 1);
+			const r = writer.records[0];
+			assert.strictEqual(r.backend, 'test');
+			assert.strictEqual(r.method, 'embed');
+			assert.strictEqual(r.success, true);
+			assert.ok(r.latency_ms >= 0);
+		});
+
+		it('with no ALS context, accounting tenant/app are undefined and no error is thrown', async () => {
+			await models.embed('hello');
+			const r = writer.records[0];
+			assert.strictEqual(r.tenant, undefined);
+			assert.strictEqual(r.app, undefined);
+		});
+
+		it('inside an ALS-bound context, accounting picks up tenant + handlerPath', async () => {
+			const ctx = { user: { tenant: 't-42' }, handlerPath: '/MyResource' };
+			await contextStorage.run(ctx, async () => {
+				await models.embed('hello');
+			});
+			const r = writer.records[0];
+			assert.strictEqual(r.tenant, 't-42');
+			assert.strictEqual(r.app, '/MyResource');
+		});
+
+		it('extractTenantId prefers user.tenant, falls back to user.tenantId', async () => {
+			await contextStorage.run({ user: { tenantId: 'fallback' }, handlerPath: '/x' }, async () => {
+				await models.embed('hello');
+			});
+			assert.strictEqual(writer.records[0].tenant, 'fallback');
+		});
+
+		it('forwards opts.signal to the backend over the ctx signal when both present', async () => {
+			let seenSignal;
+			setEmbedding('default', {
+				name: 'spy',
+				capabilities: () => ({ embed: true, generate: false, stream: false, tools: false, adapters: false }),
+				async embed(_input, opts) {
+					seenSignal = opts.signal;
+					return { status: 'completed', output: [new Float32Array(1)] };
+				},
+			});
+			const callerSignal = new AbortController().signal;
+			const ctxSignal = new AbortController().signal;
+			await contextStorage.run({ signal: ctxSignal }, async () => {
+				await models.embed('x', { signal: callerSignal });
+			});
+			assert.strictEqual(seenSignal, callerSignal);
+		});
+
+		it('forwards ctx.signal to the backend when opts.signal is absent', async () => {
+			let seenSignal;
+			setEmbedding('default', {
+				name: 'spy',
+				capabilities: () => ({ embed: true, generate: false, stream: false, tools: false, adapters: false }),
+				async embed(_input, opts) {
+					seenSignal = opts.signal;
+					return { status: 'completed', output: [new Float32Array(1)] };
+				},
+			});
+			const ctxSignal = new AbortController().signal;
+			await contextStorage.run({ signal: ctxSignal }, async () => {
+				await models.embed('x');
+			});
+			assert.strictEqual(seenSignal, ctxSignal);
+		});
+
+		it('throws ModelCapabilityError when the backend does not support embed', async () => {
+			setEmbedding('default', {
+				name: 'no-embed',
+				capabilities: () => ({ embed: false, generate: true, stream: false, tools: false, adapters: false }),
+			});
+			await assert.rejects(() => models.embed('x'), ModelCapabilityError);
+		});
+
+		it('throws ModelPendingNotSupportedError when backend returns pending', async () => {
+			setEmbedding('default', {
+				name: 'pending',
+				capabilities: () => ({ embed: true, generate: false, stream: false, tools: false, adapters: false }),
+				async embed() {
+					return { status: 'pending', operationId: 'op-1' };
+				},
+			});
+			await assert.rejects(() => models.embed('x'), ModelPendingNotSupportedError);
+		});
+
+		it('writes an analytics record with success=false and sanitized error_code on backend failure', async () => {
+			setEmbedding('default', {
+				name: 'failing',
+				capabilities: () => ({ embed: true, generate: false, stream: false, tools: false, adapters: false }),
+				async embed() {
+					throw new Error('upstream boom');
+				},
+			});
+			await assert.rejects(() => models.embed('x'));
+			const r = writer.records[0];
+			assert.strictEqual(r.success, false);
+			assert.strictEqual(r.error_code, 'backend_error');
+			for (const value of Object.values(r)) {
+				if (typeof value === 'string') {
+					assert.ok(!value.includes('upstream boom'), 'raw upstream message should not leak into the record');
+				}
+			}
+		});
+
+		it("classifies AbortError as error_code = 'aborted'", async () => {
+			setEmbedding('default', {
+				name: 'aborter',
+				capabilities: () => ({ embed: true, generate: false, stream: false, tools: false, adapters: false }),
+				async embed() {
+					const err = new Error('aborted');
+					err.name = 'AbortError';
+					throw err;
+				},
+			});
+			await assert.rejects(() => models.embed('x'));
+			assert.strictEqual(writer.records[0].error_code, 'aborted');
+		});
+	});
+
+	describe('generate', () => {
+		it('returns unwrapped GenerateResult with content', async () => {
+			const result = await models.generate('hello');
+			assert.strictEqual(typeof result.content, 'string');
+			assert.strictEqual(result.finishReason, 'stop');
+		});
+
+		it('records adapter and conversation_id when provided on GenerateOpts', async () => {
+			await models.generate('hello', { adapter: 'lora-1', conversationId: 'conv-99' });
+			const r = writer.records[0];
+			assert.strictEqual(r.adapter, 'lora-1');
+			assert.strictEqual(r.conversation_id, 'conv-99');
+		});
+
+		it('writes a failure record and rethrows when the generative backend throws', async () => {
+			setGenerative('default', {
+				name: 'failing-gen',
+				capabilities: () => ({ embed: false, generate: true, stream: false, tools: false, adapters: false }),
+				async generate() {
+					throw new Error('generate boom');
+				},
+			});
+			await assert.rejects(() => models.generate('x'), /generate boom/);
+			const r = writer.records[0];
+			assert.strictEqual(r.method, 'generate');
+			assert.strictEqual(r.success, false);
+			assert.strictEqual(r.error_code, 'backend_error');
+		});
+	});
+
+	describe('generateStream', () => {
+		it('yields chunks and writes one analytics record at stream end', async () => {
+			const chunks = [];
+			for await (const chunk of models.generateStream('hello')) {
+				chunks.push(chunk);
+			}
+			assert.ok(chunks.length > 1);
+			assert.strictEqual(writer.records.length, 1);
+			assert.strictEqual(writer.records[0].method, 'generateStream');
+			assert.strictEqual(writer.records[0].success, true);
+		});
+
+		it('records success=false when the stream throws mid-iteration', async () => {
+			setGenerative('default', {
+				name: 'stream-err',
+				capabilities: () => ({ embed: false, generate: true, stream: true, tools: false, adapters: false }),
+				async *generateStream() {
+					yield { deltaContent: 'partial ' };
+					throw new Error('stream boom');
+				},
+			});
+			await assert.rejects(async () => {
+				for await (const _chunk of models.generateStream('x')) {
+					// drain
+				}
+			});
+			assert.strictEqual(writer.records[0].success, false);
+			assert.strictEqual(writer.records[0].error_code, 'backend_error');
+		});
+	});
+});

--- a/unitTests/resources/models/Models.test.js
+++ b/unitTests/resources/models/Models.test.js
@@ -275,5 +275,22 @@ describe('Models facade', () => {
 			assert.strictEqual(writer.records[0].error_code, 'backend_not_found');
 			assert.strictEqual(writer.records[0].method, 'generateStream');
 		});
+
+		it('records capability-mismatch on generateStream with the resolved backend name (not "unknown")', async () => {
+			setGenerative('default', {
+				name: 'no-stream',
+				capabilities: () => ({ embed: false, generate: true, stream: false, tools: false, adapters: false }),
+			});
+			await assert.rejects(async () => {
+				// eslint-disable-next-line no-unused-vars
+				for await (const _ of models.generateStream('x')) {
+					// will not iterate — requireCapability throws first
+				}
+			});
+			assert.strictEqual(writer.records.length, 1);
+			assert.strictEqual(writer.records[0].backend, 'no-stream');
+			assert.strictEqual(writer.records[0].error_code, 'capability_unsupported');
+			assert.strictEqual(writer.records[0].method, 'generateStream');
+		});
 	});
 });

--- a/unitTests/resources/models/Models.test.js
+++ b/unitTests/resources/models/Models.test.js
@@ -113,15 +113,19 @@ describe('Models facade', () => {
 			assert.strictEqual(seenSignal, ctxSignal);
 		});
 
-		it('throws ModelCapabilityError when the backend does not support embed', async () => {
+		it('throws ModelCapabilityError when the backend does not support embed AND records the failure', async () => {
 			setEmbedding('default', {
 				name: 'no-embed',
 				capabilities: () => ({ embed: false, generate: true, stream: false, tools: false, adapters: false }),
 			});
 			await assert.rejects(() => models.embed('x'), ModelCapabilityError);
+			assert.strictEqual(writer.records.length, 1);
+			assert.strictEqual(writer.records[0].backend, 'no-embed');
+			assert.strictEqual(writer.records[0].success, false);
+			assert.strictEqual(writer.records[0].error_code, 'capability_unsupported');
 		});
 
-		it('throws ModelPendingNotSupportedError when backend returns pending', async () => {
+		it('writes ONE record with success=false on pending result (not duplicate from unwrap+catch)', async () => {
 			setEmbedding('default', {
 				name: 'pending',
 				capabilities: () => ({ embed: true, generate: false, stream: false, tools: false, adapters: false }),
@@ -130,6 +134,19 @@ describe('Models facade', () => {
 				},
 			});
 			await assert.rejects(() => models.embed('x'), ModelPendingNotSupportedError);
+			assert.strictEqual(writer.records.length, 1, 'pending result must not produce duplicate rows');
+			assert.strictEqual(writer.records[0].success, false);
+			assert.strictEqual(writer.records[0].error_code, 'pending_unsupported');
+		});
+
+		it("records pre-call ModelBackendNotFoundError with backend='unknown' and error_code='backend_not_found'", async () => {
+			// No backend mapped for the requested logical name.
+			await assert.rejects(() => models.embed('x', { model: 'no-such-name' }));
+			assert.strictEqual(writer.records.length, 1);
+			assert.strictEqual(writer.records[0].backend, 'unknown');
+			assert.strictEqual(writer.records[0].model, 'no-such-name');
+			assert.strictEqual(writer.records[0].success, false);
+			assert.strictEqual(writer.records[0].error_code, 'backend_not_found');
 		});
 
 		it('writes an analytics record with success=false and sanitized error_code on backend failure', async () => {
@@ -224,6 +241,39 @@ describe('Models facade', () => {
 			});
 			assert.strictEqual(writer.records[0].success, false);
 			assert.strictEqual(writer.records[0].error_code, 'backend_error');
+		});
+
+		it("records success=false with error_code='aborted' when the consumer breaks early", async () => {
+			setGenerative('default', {
+				name: 'long-stream',
+				capabilities: () => ({ embed: false, generate: true, stream: true, tools: false, adapters: false }),
+				async *generateStream() {
+					yield { deltaContent: 'one ' };
+					yield { deltaContent: 'two ' };
+					yield { deltaContent: 'three ' };
+					yield { finishReason: 'stop' };
+				},
+			});
+			let count = 0;
+			for await (const _chunk of models.generateStream('x')) {
+				if (++count === 2) break;
+			}
+			assert.strictEqual(writer.records.length, 1);
+			assert.strictEqual(writer.records[0].success, false);
+			assert.strictEqual(writer.records[0].error_code, 'aborted');
+		});
+
+		it("records pre-call failure with backend='unknown' when the generative backend isn't registered", async () => {
+			await assert.rejects(async () => {
+				// eslint-disable-next-line no-unused-vars
+				for await (const _ of models.generateStream('x', { model: 'no-such-name' })) {
+					// will not iterate — resolve throws first
+				}
+			});
+			assert.strictEqual(writer.records.length, 1);
+			assert.strictEqual(writer.records[0].backend, 'unknown');
+			assert.strictEqual(writer.records[0].error_code, 'backend_not_found');
+			assert.strictEqual(writer.records[0].method, 'generateStream');
 		});
 	});
 });

--- a/unitTests/resources/models/TestBackend.test.js
+++ b/unitTests/resources/models/TestBackend.test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { TestBackend } = require('#src/resources/models/TestBackend');
+
+describe('TestBackend', () => {
+	let backend;
+	beforeEach(() => {
+		backend = new TestBackend();
+	});
+
+	describe('capabilities', () => {
+		it('returns the Phase 1 capability shape', () => {
+			assert.deepStrictEqual(backend.capabilities(), {
+				embed: true,
+				generate: true,
+				stream: true,
+				tools: false,
+				adapters: false,
+			});
+		});
+
+		it('reports name = "test"', () => {
+			assert.strictEqual(backend.name, 'test');
+		});
+	});
+
+	describe('embed', () => {
+		const accounting = { tenantId: 'tid', app: '/test' };
+
+		it('returns a Float32Array per input string', async () => {
+			const result = await backend.embed(['a', 'b'], { accounting });
+			assert.strictEqual(result.status, 'completed');
+			assert.strictEqual(result.output.length, 2);
+			assert.ok(result.output[0] instanceof Float32Array);
+			assert.strictEqual(result.output[0].length, 16);
+		});
+
+		it('accepts a single string and returns one vector', async () => {
+			const result = await backend.embed('hello', { accounting });
+			assert.strictEqual(result.output.length, 1);
+			assert.strictEqual(result.output[0].length, 16);
+		});
+
+		it('is deterministic — same input yields the same vector across calls', async () => {
+			const a = await backend.embed('hello', { accounting });
+			const b = await backend.embed('hello', { accounting });
+			assert.deepStrictEqual(Array.from(a.output[0]), Array.from(b.output[0]));
+		});
+
+		it('produces different vectors for different inputs', async () => {
+			const a = await backend.embed('hello', { accounting });
+			const b = await backend.embed('world', { accounting });
+			assert.notDeepStrictEqual(Array.from(a.output[0]), Array.from(b.output[0]));
+		});
+
+		it('reports embeddingTokens equal to total input length', async () => {
+			const result = await backend.embed(['ab', 'cde'], { accounting });
+			assert.strictEqual(result.usage.embeddingTokens, 5);
+		});
+	});
+
+	describe('generate', () => {
+		const accounting = { tenantId: 'tid', app: '/test' };
+
+		it('echoes a string input with the TestBackend prefix', async () => {
+			const result = await backend.generate('hi', { accounting });
+			assert.strictEqual(result.status, 'completed');
+			assert.strictEqual(result.output.content, '[TestBackend echoed]: hi');
+			assert.strictEqual(result.output.finishReason, 'stop');
+		});
+
+		it('joins messages into content when given a Message[] input', async () => {
+			const result = await backend.generate(
+				[
+					{ role: 'user', content: 'one' },
+					{ role: 'assistant', content: 'two' },
+				],
+				{ accounting }
+			);
+			assert.ok(result.output.content.includes('one two'));
+		});
+
+		it('joins messages into content when given a { messages, system, tools } object input', async () => {
+			const result = await backend.generate(
+				{
+					system: 'sys',
+					messages: [
+						{ role: 'user', content: 'alpha' },
+						{ role: 'assistant', content: 'beta' },
+					],
+				},
+				{ accounting }
+			);
+			assert.ok(result.output.content.includes('alpha beta'));
+		});
+
+		it('reports promptTokens and completionTokens in usage', async () => {
+			const result = await backend.generate('hi', { accounting });
+			assert.strictEqual(result.usage.promptTokens, 2);
+			assert.ok(result.usage.completionTokens > 0);
+		});
+	});
+
+	describe('generateStream', () => {
+		const accounting = { tenantId: 'tid', app: '/test' };
+
+		it('yields chunks then a finishReason chunk', async () => {
+			const chunks = [];
+			for await (const chunk of backend.generateStream('hello', { accounting })) {
+				chunks.push(chunk);
+			}
+			const lastChunk = chunks[chunks.length - 1];
+			assert.strictEqual(lastChunk.finishReason, 'stop');
+			const concatenated = chunks
+				.map((c) => c.deltaContent ?? '')
+				.join('')
+				.trim();
+			assert.ok(concatenated.startsWith('[TestBackend stream]:'));
+		});
+	});
+});

--- a/unitTests/resources/models/analyticsTable.test.js
+++ b/unitTests/resources/models/analyticsTable.test.js
@@ -1,0 +1,219 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { setTimeout: delay } = require('node:timers/promises');
+const { ModelCallAnalyticsWriter } = require('#src/resources/models/analyticsTable');
+
+/**
+ * Mock primaryStore that records put/remove operations in an in-memory Map.
+ * Mirrors only the API surface the writer uses (`put`, `remove`, `getKeys`).
+ *
+ * Database-touching coverage for hdb_model_calls is left to a separate
+ * integration test — same posture as `resources/analytics/write.ts`'s
+ * unit test (`unitTests/resources/analytics/write.test.js`), which only
+ * exercises its pure helper functions and leaves the table interactions
+ * for end-to-end coverage.
+ */
+function makeMockTable() {
+	const store = new Map();
+	return {
+		store,
+		primaryStore: {
+			put(id, record) {
+				store.set(id, record);
+			},
+			remove(id) {
+				store.delete(id);
+			},
+			getKeys({ start, end } = {}) {
+				const keys = Array.from(store.keys()).sort((a, b) => a - b);
+				return keys.filter(
+					(k) => (start === false || start === undefined || k >= start) && (end === undefined || k < end)
+				);
+			},
+		},
+	};
+}
+
+function makeRecord(overrides = {}) {
+	return {
+		backend: 'test',
+		method: 'embed',
+		latency_ms: 10,
+		success: true,
+		...overrides,
+	};
+}
+
+describe('ModelCallAnalyticsWriter', () => {
+	let table;
+	let writer;
+
+	beforeEach(() => {
+		table = makeMockTable();
+		writer = new ModelCallAnalyticsWriter({
+			flushIntervalMs: 60_000,
+			cleanupIntervalMs: 60_000,
+			getTable: () => table,
+		});
+	});
+
+	afterEach(async () => {
+		writer.stop();
+		await writer.flush();
+	});
+
+	describe('write + buffering', () => {
+		it('buffers a record without writing immediately', () => {
+			writer.write(makeRecord());
+			assert.strictEqual(writer.bufferSize, 1);
+			assert.strictEqual(table.store.size, 0);
+		});
+
+		it('multiple writes grow the buffer in order', () => {
+			writer.write(makeRecord({ backend: 'a' }));
+			writer.write(makeRecord({ backend: 'b' }));
+			writer.write(makeRecord({ backend: 'c' }));
+			assert.strictEqual(writer.bufferSize, 3);
+			assert.strictEqual(table.store.size, 0);
+		});
+
+		it('write() is a no-op after stop()', () => {
+			writer.stop();
+			writer.write(makeRecord());
+			assert.strictEqual(writer.bufferSize, 0);
+		});
+	});
+
+	describe('flush', () => {
+		it('writes buffered records to the table and clears the buffer', async () => {
+			writer.write(makeRecord({ backend: 'a' }));
+			writer.write(makeRecord({ backend: 'b' }));
+			await writer.flush();
+			assert.strictEqual(writer.bufferSize, 0);
+			assert.strictEqual(table.store.size, 2);
+		});
+
+		it('is a no-op when the buffer is empty', async () => {
+			await writer.flush();
+			assert.strictEqual(table.store.size, 0);
+		});
+
+		it('still works after stop() to drain any pre-stop buffer', async () => {
+			writer.write(makeRecord());
+			writer.stop();
+			await writer.flush();
+			assert.strictEqual(table.store.size, 1);
+		});
+
+		it('writes records with all the schema fields the facade builds', async () => {
+			const record = makeRecord({
+				backend: 'test',
+				method: 'generate',
+				tenant: 't-1',
+				app: '/Resource',
+				model: 'm-1',
+				adapter: 'lora',
+				conversation_id: 'conv',
+				prompt_tokens: 12,
+				completion_tokens: 7,
+				latency_ms: 42,
+				success: true,
+			});
+			writer.write(record);
+			await writer.flush();
+			const stored = Array.from(table.store.values())[0];
+			assert.strictEqual(stored.backend, 'test');
+			assert.strictEqual(stored.method, 'generate');
+			assert.strictEqual(stored.tenant, 't-1');
+			assert.strictEqual(stored.app, '/Resource');
+			assert.strictEqual(stored.model, 'm-1');
+			assert.strictEqual(stored.adapter, 'lora');
+			assert.strictEqual(stored.conversation_id, 'conv');
+			assert.strictEqual(stored.prompt_tokens, 12);
+			assert.strictEqual(stored.completion_tokens, 7);
+			assert.strictEqual(stored.latency_ms, 42);
+			assert.strictEqual(stored.success, true);
+			assert.ok(typeof stored.id === 'number', 'id should be a numeric monotonic timestamp');
+		});
+
+		it('continues writing remaining records when one put throws', async () => {
+			let callCount = 0;
+			const throwingTable = {
+				store: new Map(),
+				primaryStore: {
+					put(id, record) {
+						callCount++;
+						if (callCount === 2) throw new Error('simulated put failure');
+						this.store.set(id, record);
+					},
+					remove() {},
+					getKeys: () => [],
+				},
+			};
+			throwingTable.primaryStore.store = throwingTable.store;
+			const w = new ModelCallAnalyticsWriter({
+				flushIntervalMs: 60_000,
+				cleanupIntervalMs: 60_000,
+				getTable: () => throwingTable,
+			});
+			w.write(makeRecord({ backend: 'a' }));
+			w.write(makeRecord({ backend: 'b' }));
+			w.write(makeRecord({ backend: 'c' }));
+			await w.flush();
+			w.stop();
+			// Records 1 and 3 wrote; record 2 threw and was logged + dropped.
+			assert.strictEqual(throwingTable.store.size, 2);
+		});
+	});
+
+	describe('maxBufferSize triggers flush', () => {
+		it('reaching the cap schedules an out-of-cadence flush', async () => {
+			const small = new ModelCallAnalyticsWriter({
+				flushIntervalMs: 60_000,
+				cleanupIntervalMs: 60_000,
+				maxBufferSize: 2,
+				getTable: () => table,
+			});
+			small.write(makeRecord());
+			small.write(makeRecord());
+			// The size-cap flush is fire-and-forget; give microtasks a turn.
+			await delay(5);
+			assert.strictEqual(small.bufferSize, 0);
+			assert.strictEqual(table.store.size, 2);
+			small.stop();
+		});
+	});
+
+	describe('cleanup', () => {
+		it('removes rows whose ids are older than retentionMs', async () => {
+			const oldId = Date.now() - 1_000_000;
+			const newId = Date.now();
+			table.store.set(oldId, makeRecord({ backend: 'old' }));
+			table.store.set(newId, makeRecord({ backend: 'new' }));
+			const w = new ModelCallAnalyticsWriter({
+				flushIntervalMs: 60_000,
+				cleanupIntervalMs: 60_000,
+				retentionMs: 1000,
+				getTable: () => table,
+			});
+			await w.cleanup();
+			w.stop();
+			assert.strictEqual(table.store.has(oldId), false);
+			assert.strictEqual(table.store.has(newId), true);
+		});
+
+		it('is a no-op when no rows are older than retentionMs', async () => {
+			table.store.set(Date.now(), makeRecord());
+			const w = new ModelCallAnalyticsWriter({
+				flushIntervalMs: 60_000,
+				cleanupIntervalMs: 60_000,
+				retentionMs: 60_000,
+				getTable: () => table,
+			});
+			await w.cleanup();
+			w.stop();
+			assert.strictEqual(table.store.size, 1);
+		});
+	});
+});

--- a/unitTests/resources/models/analyticsTable.test.js
+++ b/unitTests/resources/models/analyticsTable.test.js
@@ -137,6 +137,44 @@ describe('ModelCallAnalyticsWriter', () => {
 			assert.ok(typeof stored.id === 'number', 'id should be a numeric monotonic timestamp');
 		});
 
+		it('continues writing remaining records when one put rejects asynchronously (no silent loss)', async () => {
+			let callCount = 0;
+			const rejections = [];
+			const asyncTable = {
+				store: new Map(),
+				primaryStore: {
+					put(id, record) {
+						callCount++;
+						if (callCount === 2) {
+							const p = Promise.reject(new Error('async LMDB rejection'));
+							rejections.push(p);
+							// Avoid unhandled-rejection warnings if the writer doesn't await fast.
+							p.catch(() => {});
+							return p;
+						}
+						this.store.set(id, record);
+						return Promise.resolve();
+					},
+					remove() {},
+					getKeys: () => [],
+				},
+			};
+			asyncTable.primaryStore.store = asyncTable.store;
+			const w = new ModelCallAnalyticsWriter({
+				flushIntervalMs: 60_000,
+				cleanupIntervalMs: 60_000,
+				getTable: () => asyncTable,
+			});
+			w.write(makeRecord({ backend: 'a' }));
+			w.write(makeRecord({ backend: 'b' }));
+			w.write(makeRecord({ backend: 'c' }));
+			await w.flush();
+			w.stop();
+			// Records 1 and 3 wrote; record 2's async rejection was awaited (no unhandled rejection).
+			assert.strictEqual(asyncTable.store.size, 2);
+			assert.strictEqual(rejections.length, 1);
+		});
+
 		it('continues writing remaining records when one put throws', async () => {
 			let callCount = 0;
 			const throwingTable = {

--- a/unitTests/resources/models/backendRegistry.test.js
+++ b/unitTests/resources/models/backendRegistry.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const {
+	setEmbedding,
+	setGenerative,
+	resolveEmbedding,
+	resolveGenerative,
+	clearRegistry,
+	ModelBackendNotFoundError,
+} = require('#src/resources/models/backendRegistry');
+
+function fakeBackend(name) {
+	return {
+		name,
+		capabilities: () => ({ embed: true, generate: true, stream: true, tools: false, adapters: false }),
+	};
+}
+
+describe('backendRegistry', () => {
+	beforeEach(() => {
+		clearRegistry();
+	});
+
+	it('resolves an embedding backend by logical name', () => {
+		const backend = fakeBackend('test');
+		setEmbedding('default', backend);
+		assert.strictEqual(resolveEmbedding('default'), backend);
+	});
+
+	it("defaults logicalName to 'default' when omitted", () => {
+		const backend = fakeBackend('test');
+		setEmbedding('default', backend);
+		assert.strictEqual(resolveEmbedding(), backend);
+	});
+
+	it('resolves multiple logical names to different backends', () => {
+		const a = fakeBackend('a');
+		const b = fakeBackend('b');
+		setEmbedding('default', a);
+		setEmbedding('fast', b);
+		assert.strictEqual(resolveEmbedding('default'), a);
+		assert.strictEqual(resolveEmbedding('fast'), b);
+	});
+
+	it('resolves generative independently from embedding', () => {
+		const e = fakeBackend('emb');
+		const g = fakeBackend('gen');
+		setEmbedding('default', e);
+		setGenerative('default', g);
+		assert.strictEqual(resolveEmbedding('default'), e);
+		assert.strictEqual(resolveGenerative('default'), g);
+	});
+
+	it('throws ModelBackendNotFoundError when no backend is registered for the name', () => {
+		assert.throws(
+			() => resolveEmbedding('missing'),
+			(err) => err instanceof ModelBackendNotFoundError && err.statusCode === 500
+		);
+	});
+
+	it('re-mapping the same logical name replaces the prior backend', () => {
+		const first = fakeBackend('first');
+		const second = fakeBackend('second');
+		setEmbedding('default', first);
+		setEmbedding('default', second);
+		assert.strictEqual(resolveEmbedding('default'), second);
+	});
+
+	it('clearRegistry() removes all mappings', () => {
+		setEmbedding('default', fakeBackend('test'));
+		setGenerative('default', fakeBackend('test'));
+		clearRegistry();
+		assert.throws(() => resolveEmbedding('default'), ModelBackendNotFoundError);
+		assert.throws(() => resolveGenerative('default'), ModelBackendNotFoundError);
+	});
+
+	it('error message identifies kind + logical name but never enumerates other registrations', () => {
+		setEmbedding('default', fakeBackend('secret-backend-name'));
+		try {
+			resolveEmbedding('other');
+			assert.fail('expected error');
+		} catch (err) {
+			assert.ok(!err.message.includes('secret-backend-name'), 'error should not enumerate registered backend names');
+			assert.ok(err.message.includes('embedding.other'));
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Closes #628. Tracking #510 (Phase 1 of 6).

Lands the runtime foundation for the model-access API: TypeScript interfaces, the `scope.models` facade with ALS-bound per-request accounting context, a process-wide backend registry, the `hdb_model_calls` system table with a buffered per-call writer, and an in-memory `TestBackend`. No real backends ship here — phases 2 (#629 ollama), 3 (#630 openai), 4 (#631 /v1/* gateway), 5 (#632 @embed), and 6 (#633 anthropic+bedrock) consume this contract.

## What ships

| File | Purpose |
|---|---|
| `resources/models/types.ts` | All Phase 1 TypeScript interfaces. Canonical shapes pulled from the planning artifact (`tmp/harper-510-phase-1-detail.md`). |
| `resources/models/backendRegistry.ts` | Module-scope `setEmbedding(logicalName, backend)` / `setGenerative(...)` / `resolveEmbedding(...)` / `resolveGenerative(...)`. Direct logical-name → backend mapping. YAML-to-registry bootstrapping lands in Phase 2. |
| `resources/models/TestBackend.ts` | Deterministic in-memory backend (FNV-1a seeded Mulberry32 → 16-dim Float32Array embeddings; echo-with-prefix generate; word-by-word stream). |
| `resources/models/analyticsTable.ts` | `hdb_model_calls` table declaration (lazy-getter, matching `analytics/write.ts:656-700` pattern) + buffered writer (10s/1000-row flush, hourly cleanup, 90-day retention). |
| `resources/models/Models.ts` | The `scope.models` facade. Reads ALS on every call, populates accounting, classifies errors, records to the analytics writer on both success and failure. |
| `components/Scope.ts` | Adds `models: Models` property; `new Models()` in the constructor. |

## Decisions worth a look

1. **Out-of-scope LRO methods.** The planning artifact stubs `getOperation` / `cancelOperation` on the public `Models` interface; the #628 issue body explicitly excludes them. Followed the issue body — `ModelCallResult.pending` is reserved in the type, but no facade methods land until a real LRO-capable backend ships.

2. **Tenant identity is a free-form string.** `extractTenantId(user)` returns `user?.tenant ?? user?.tenantId ?? undefined`. Canonical model still pending on #510's comment thread; Phase 1 doesn't block on it.

3. **Registry refactor mid-stream.** First draft of the registry used `envGet('models.embedding.<n>.backend')` for config-driven resolution. Discovered late that Harper's `getConfigValue` only reads keys in `CONFIG_PARAM_MAP`, so dynamic config paths silently returned undefined. Refactored to direct `setEmbedding(name, backend)`; the YAML-config → registry bootstrapper is now a Phase 2 concern (Phase 2 ships the first real backend constructor anyway).

4. **Capability + LRO error classes are sanitized.** `ModelBackendNotFoundError` doesn't enumerate other registered backends. `ModelCapabilityError` names the requested capability but not the backend's full capability set. `error_code` on `hdb_model_calls` rows is a small enum (`aborted`, `capability_unsupported`, `backend_error`) — no raw upstream message ever lands in the table. This matters for Phases 2/3 where real network errors will start flowing.

5. **AbortSignal source precedence.** `opts.signal` overrides `ctx.signal`. Now reachable since #513 (the precursor PR #635) landed earlier today.

6. **`scope.models.embed()` outside a Resource scope.** No-ALS fallback: accounting is empty (`tenant`/`app` undefined), the call still runs, and a row still lands in the table with both fields null. Covers the init-code and internal-job paths the acceptance criteria call out.

7. **`tools` moved off `GenerateOpts` onto `GenerateInput` (cross-model review fix).** Surfaced by a Gemini review of this diff: `tools?: ToolDef[]` originally appeared in both `GenerateOpts` AND `GenerateInput`'s object variant. Both came from the original #510 API surface — appears unresolved. Phase 2-6 backends (#629–#633) would have had to merge from two sources when building request bodies. Removed from `GenerateOpts`; tools now live only with `messages`/`system` on `GenerateInput`. `toolMode` stays in `GenerateOpts` (it's strategy, not content). Callers that want tools use the object form: `models.generate({ messages, tools }, { toolMode: 'auto' })`. Flag if this is the wrong call and I'll revert.

## Deferred to Phase 2 (and known gap relative to issue body)

The #628 issue body's smoke test shows a Resource calling `await scope.models.embed('hello world')` directly. **That code does not yet work as written** — `scope.models` is reachable inside Harper internals but is not exposed to user-deployed code. `security/jsLoader.ts`'s `getHarperExports` doesn't include `models` (only `Resource`, `tables`, `databases`, etc.), and there's no `scope` global available to user modules.

The spec only added `models: Models` to the per-component `Scope` class; it did not mandate how user code would reach that property. Three reasonable exposure paths exist (`harper.models`, top-level `models` global, or a literal `scope` global); none was selected in #628. Deferring this API decision to Phase 2, where #629 (ollama) will be the first phase to actually need a user-callable path. The decision affects what every subsequent phase's example code looks like, so it's worth resolving with #629's PR rather than rushed here.

In the meantime, internal Harper code (and any future built-in operation that wants to use the facade) can construct `new Models()` directly and call its methods — that part fully works and is unit-tested.

## Test coverage

47 new unit tests + 1 addition to `Scope.test.js`. **Coverage on `resources/models/`: 94% statements, 92.6% branches.**

| File | Stmts | Branch | Funcs |
|---|---|---|---|
| `Models.ts` | 100% | 95.9% | 100% |
| `TestBackend.ts` | 100% | 100% | 100% |
| `backendRegistry.ts` | 100% | 100% | 100% |
| `analyticsTable.ts` | 82% | 80% | 90% |

`analyticsTable.ts`'s uncovered region is the lazy-getter for the real `table({...})` call (lines 47-73). Database-touching coverage is intentionally not in unit tests — mirrors `unitTests/resources/analytics/write.test.js`'s posture (only pure helpers; LMDB writes are end-to-end). When Phase 2 (#629) ships a real backend, that PR will naturally exercise this path through HTTP → Resource → `models.embed()` → flush → `hdb_model_calls`.

`Scope.test.js` extension asserts the wiring point: `new Scope(...).models` is a `Models` instance with all three callable methods.

**No integration test file in this PR.** A smoke test was scoped, but writing it surfaced the user-exposure question above. Since the exposure decision is the right gate for an integration test (you'd want to test the actual user-facing access pattern), the integration test follows that decision into Phase 2.

## Cross-model review

Diff was run through Gemini CLI pre-PR per `harper-engineering-guidelines` #9. Gemini flagged one real concern (tools redundancy — addressed in decision #7 above). The other six focus areas (ALS correctness, concurrency, resource leaks, security, boot timing, `#wrapStream`) came back clean.

## Where to look

- `resources/models/types.ts` — the contract every downstream phase implements against. Sub-issues #629-#633 all depend on these shapes.
- `resources/models/Models.ts` — most reviewer-worthy file. The `#wrapStream` async-generator + per-call analytics recording is the non-trivial bit.
- `resources/models/analyticsTable.ts` — the `getTable` constructor option is a test-injection seam; default still resolves to the real LMDB table.

## Test plan

- [x] Unit tests pass: `npx mocha unitTests/resources/models/ unitTests/components/Scope.test.js` (54 passing)
- [x] Coverage: 94% stmts / 92.6% branches via `npx c8`
- [x] Lint clean: `oxlint resources/models/ unitTests/resources/models/`
- [x] Format clean: `prettier --check`
- [x] TypeScript build: no new errors in changed files
- [x] Cross-model review (Gemini): one finding addressed, six focus areas clean
- [x] CI green (will monitor)
- [ ] User-facing exposure of `models` decided in Phase 2 (#629) PR
- [ ] Integration smoke test follows that decision into Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)