### PR TITLE
fix(replication): propagate per-event expiresAt to record writes

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -311,6 +311,8 @@ export function makeTable(options) {
 						ensureLoaded: false,
 						nodeId: event.nodeId,
 						viaNodeId: event.viaNodeId,
+						// use per-event expiresAt: batched txn context only holds the first event's expiration
+						expiresAt: event.expiresAt,
 						async: true,
 					};
 					const id = event.id;
@@ -1685,7 +1687,8 @@ export function makeTable(options) {
 					const type = fullUpdate ? 'put' : 'patch';
 					let residencyId: number | undefined;
 					if (options?.residencyId != undefined) residencyId = options.residencyId;
-					const expiresAt: number = context?.expiresAt ?? (expirationMs ? expirationMs + Date.now() : -1);
+					const expiresAt: number =
+						options?.expiresAt ?? context?.expiresAt ?? (expirationMs ? expirationMs + Date.now() : -1);
 					const additionalAuditRefs: Array<{ version: number; nodeId: number }> = []; // track additional audit refs to store
 
 					if (precedesExisting <= 0) {
@@ -1902,7 +1905,7 @@ export function makeTable(options) {
 					updateIndices(id, existingRecord, recordToStore, transaction && { transaction });
 
 					writeCommit(true);
-					if (context.expiresAt) scheduleCleanup();
+					if (expiresAt >= 0) scheduleCleanup(); // arm for replicated writes too, not just local-context writes
 					function writeCommit(storeRecord: boolean) {
 						// we need to write the commit. if storeRecord then we need to store the record, otherwise we just need to store the audit record
 						updateRecord(


### PR DESCRIPTION
## Problem

Records received via replication were not being evicted by the cleanup scanner even when they carried an `expiresAt` value. Three issues:

**1. `expiresAt` missing from options passed to `_writeUpdate`**

In a multi-record transaction batch, every event after the first is processed with `txnInProgress` (the first event) as `context`. Subsequent events had no `expiresAt` in their `options`, so `_writeUpdate` saw `context.expiresAt` from the *first* record applied to all records — or saw nothing if the first record had no expiration.

**2. `_writeUpdate` didn't read `expiresAt` from options**

```ts
// before
const expiresAt: number = context?.expiresAt ?? (expirationMs ? expirationMs + Date.now() : -1);

// after
const expiresAt: number = options?.expiresAt ?? context?.expiresAt ?? (expirationMs ? expirationMs + Date.now() : -1);
```

**3. `scheduleCleanup()` not armed for replicated writes**

```ts
// before — only fired when context carried expiresAt (local writes)
if (context.expiresAt) scheduleCleanup();

// after — fires whenever the computed expiresAt is valid
if (expiresAt >= 0) scheduleCleanup();
```

## Relationship to v4 cross-version replication

When receiving a table copy from a v4 peer, `auditRecord.expiresAt` may be `undefined` due to a separate encoding bug in v4's table copy path (see harperdb/harperdb#3120). The fallback `expirationMs + Date.now()` in point 2 above handles this case: if the v5 table is pre-configured with an `expiration` value before connecting to the v4 cluster, the receiver computes a fresh `expiresAt` at receipt time.

## Test plan

Integration test `replicationTopology.test.mjs` covers both cases:
- v5→v5: multi-record batch TTL eviction across all nodes
- v4→v5: cross-version TTL eviction (requires harper-pro change, see below)

---
*Signed-off by Claude*