### PR TITLE
fix(replication): propagate per-event expiresAt to record writes

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -327,6 +327,8 @@ export function makeTable(options) {
 						ensureLoaded: false,
 						nodeId: event.nodeId,
 						viaNodeId: event.viaNodeId,
+						// use per-event expiresAt: batched txn context only holds the first event's expiration
+						expiresAt: event.expiresAt,
 						async: true,
 					};
 					const id = event.id;
@@ -1699,7 +1701,8 @@ export function makeTable(options) {
 					const type = fullUpdate ? 'put' : 'patch';
 					let residencyId: number | undefined;
 					if (options?.residencyId != undefined) residencyId = options.residencyId;
-					const expiresAt: number = context?.expiresAt ?? (expirationMs ? expirationMs + Date.now() : -1);
+					const expiresAt: number =
+						options?.expiresAt ?? context?.expiresAt ?? (expirationMs ? expirationMs + Date.now() : -1);
 					const additionalAuditRefs: Array<{ version: number; nodeId: number }> = []; // track additional audit refs to store
 
 					if (precedesExisting <= 0) {
@@ -1917,7 +1920,7 @@ export function makeTable(options) {
 					updateIndices(id, existingRecord, recordToStore, transaction && { transaction });
 
 					writeCommit(true);
-					if (context.expiresAt) scheduleCleanup();
+					if (expiresAt >= 0) scheduleCleanup(); // arm for replicated writes too, not just local-context writes
 					function writeCommit(storeRecord: boolean) {
 						// we need to write the commit. if storeRecord then we need to store the record, otherwise we just need to store the audit record
 						updateRecord(


### PR DESCRIPTION
## Problem

Records received via replication were not being evicted by the cleanup scanner even when they carried an `expiresAt` value. Three issues (same as #639 which backports this to `v5.0`):

**1. `expiresAt` missing from options passed to `_writeUpdate`**

In a multi-record transaction batch, every event after the first is processed with `txnInProgress` (the first event) as `context`. Subsequent events had no `expiresAt` in their `options`, so `_writeUpdate` saw `context.expiresAt` from the *first* record applied to all records — or saw nothing if the first record had no expiration.

**2. `_writeUpdate` didn't read `expiresAt` from options**

```ts
// before
const expiresAt: number = context?.expiresAt ?? (expirationMs ? expirationMs + Date.now() : -1);

// after
const expiresAt: number = options?.expiresAt ?? context?.expiresAt ?? (expirationMs ? expirationMs + Date.now() : -1);
```

**3. `scheduleCleanup()` not armed for replicated writes**

```ts
// before
if (context.expiresAt) scheduleCleanup();

// after
if (expiresAt >= 0) scheduleCleanup();
```

## See also

- Backport to `v5.0`: #639
- Upstream v4 table copy encoding fix: harperdb/harperdb#3120

---
*Signed-off by Claude*