### PR TITLE
ci: replace CODEOWNERS auto-assign with conditional reviewer workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,3 @@
-# CODEOWNERS is not the most intuitive file
-# Review the docs before modifying: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-# Importantly, **the last matching pattern takes precedence**
-
-# By default, everything must be reviewed by someone in the core engineering team
-*          @HarperFast/developers
-
-# Otherwise, certain paths may require other reviewers as well
-/.github/  @HarperFast/developers @HarperFast/devops
-/upgrade/  @HarperFast/developers @HarperFast/devops
-/utility/AWS/  @HarperFast/developers @HarperFast/devops
+# Reviewer assignment is handled by the assign-reviewers workflow
+# (.github/workflows/assign-reviewers.yml), which adds @HarperFast/developers
+# when a PR is opened with no reviewers already set.

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -1,0 +1,29 @@
+name: Assign Reviewers
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign Developers team if no reviewers set
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REVIEWERS_JSON: ${{ toJson(github.event.pull_request.requested_reviewers) }}
+          TEAMS_JSON: ${{ toJson(github.event.pull_request.requested_teams) }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          reviewers=$(echo "$REVIEWERS_JSON" | jq 'length')
+          teams=$(echo "$TEAMS_JSON" | jq 'length')
+          if [ "$reviewers" -eq 0 ] && [ "$teams" -eq 0 ]; then
+            gh api "repos/$REPO/pulls/$PR_NUMBER/requested_reviewers" \
+              --method POST \
+              --field 'team_reviewers[]=developers'
+          fi


### PR DESCRIPTION
## Summary

- Removes all reviewer assignment rules from `.github/CODEOWNERS` (previously unconditionally assigned `@HarperFast/developers` and `@HarperFast/devops` on every PR)
- Adds `.github/workflows/assign-reviewers.yml` which assigns `@HarperFast/developers` **only** when a PR is opened with no reviewers already set
- Skips draft PRs; triggers on `opened` and `ready_for_review`

## Why

CODEOWNERS doesn't support conditional logic — it always fires, making it impossible to open a PR pre-assigned to a specific reviewer without also getting the team auto-added. The workflow approach preserves the "fallback to developers" behavior while respecting any reviewers already set by the author.

## Reviewer note

The old CODEOWNERS also added `@HarperFast/devops` for `.github/`, `/upgrade/`, and `/utility/AWS/` paths. That path-based logic is not replicated in the workflow — if devops coverage on those paths is still needed, we can add path-matching conditions to the workflow.

## Test plan

- [ ] Open a PR with no reviewers set → `@HarperFast/developers` should be auto-assigned
- [ ] Open a PR with a reviewer already set → team should NOT be auto-assigned
- [ ] Open a draft PR → no assignment should occur; assignment fires when marked ready

---
*— Claude*