### PR TITLE
fix: store local node id in record encoding for unambiguous audit log lookup

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -588,8 +588,8 @@ export function recordUpdater(store, tableId, auditStore) {
 				metadataInNextEncoding |= HAS_RESIDENCY_ID;
 				extendedType |= HAS_CURRENT_RESIDENCY_ID;
 			} else residencyIdAtNextEncoding = 0;
-			const nodeId = options?.nodeId;
-			if (nodeId >= 0) {
+			const nodeId = options?.nodeId ?? (audit ? getThisNodeId(auditStore) : undefined);
+			if (nodeId !== undefined && nodeId >= 0) {
 				nodeIdAtNextEncoding = nodeId;
 				metadataInNextEncoding |= HAS_NODE_ID;
 			} else nodeIdAtNextEncoding = -1;

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -589,7 +589,7 @@ export function recordUpdater(store, tableId, auditStore) {
 				extendedType |= HAS_CURRENT_RESIDENCY_ID;
 			} else residencyIdAtNextEncoding = 0;
 			const nodeId = options?.nodeId ?? (audit ? getThisNodeId(auditStore) : undefined);
-			if (nodeId !== undefined && nodeId >= 0) {
+			if (nodeId >= 0) {
 				nodeIdAtNextEncoding = nodeId;
 				metadataInNextEncoding |= HAS_NODE_ID;
 			} else nodeIdAtNextEncoding = -1;

--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -125,7 +125,8 @@ export class RocksTransactionLogStore extends EventEmitter {
 		throw new Error('Not implemented');
 	}
 	addLogToMaps(logName: string, log: TransactionLog) {
-		const nodeId = (getIdOfRemoteNode(logName, this) ?? 0) as number;
+		// 'local' is always the local node's log, which maps to nodeId 0
+		const nodeId = (logName === 'local' ? 0 : getIdOfRemoteNode(logName, this)) as number;
 		if (this.nodeLogs) {
 			this.nodeLogs![nodeId] ??= log;
 		}

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -454,6 +454,24 @@ describe('Audit log', () => {
 		});
 	});
 
+	it('addLogToMaps assigns nodeId 0 to the local log and populates nodeLogs[0]', () => {
+		const fakeLog = { query: () => null, addEntry: () => null, on: () => null };
+		const fakeRoot = { useLog: () => fakeLog, on: () => null, listLogs: () => [] };
+		const store = new RocksTransactionLogStore(fakeRoot);
+		store.nodeLogs = [];
+		const nodeId = store.addLogToMaps('local', fakeLog);
+		assert.strictEqual(nodeId, 0, "'local' log must map to nodeId 0");
+		assert.strictEqual(store.nodeLogs[0], fakeLog, 'nodeLogs[0] must be the local log');
+	});
+
+	it('local audited write stores nodeId 0 in the primary record', async function () {
+		const key = 9001;
+		await AuditedTable.put(key, { name: 'nodeId-test' });
+		const entry = AuditedTable.primaryStore.getEntry(key);
+		assert.strictEqual(entry.nodeId, 0, 'locally-written audited record must store nodeId 0');
+		await AuditedTable.delete(key);
+	});
+
 	it('can handle separate subscriptions on separate dbs', async function () {
 		const DB_COUNT = 3;
 		let tables = [];


### PR DESCRIPTION
## Summary

- **RecordEncoder.ts**: `recordUpdater` now falls back to `getThisNodeId(auditStore)` when `options.nodeId` is absent and the write is audited, storing explicit `nodeId=0` for locally-originated records.
- **RocksTransactionLogStore.ts**: `addLogToMaps` maps the `'local'` log directly to `nodeId=0` instead of calling `getIdOfRemoteNode('local', ...)`, which would have assigned the reserved string `'local'` a spurious id (e.g. 1), leaving `nodeLogs[0]` empty.

## Purpose

Fixes [#137](https://github.com/HarperFast/harper/issues/137). The transaction log key is `(timestamp, tableId, recordId, nodeId)`. For local writes, `nodeId` was never stored in the record because `options.nodeId` is absent — `existingEntry.nodeId` remained `undefined`. On RocksDB, this caused `auditStore.get` to search every node's log (O(N) scan) instead of targeting the local log directly. In multi-node conflict resolution it also relied on the implicit `?? 0` convention in `Table.ts:4096` rather than a stored value. Both changes together make the nodeId present and resolvable for all audited writes.

## Backward compatibility

Old records without `HAS_NODE_ID` decode as `nodeId=undefined`; every existing lookup path already handles that (`?? 0` in tie-breaking, fallback to all-log scan in `getRange`). No schema migration needed.

## Review attention

- **`addLogToMaps` special-case**: the `logName === 'local'` guard prevents `getIdOfRemoteNode` from permanently registering the string `'local'` as a remote node name in the id mapping, which would have been a minor pollution. Confirm this is the right place to break the generalisation.
- **`getThisNodeId` at write time**: called only when `audit` is truthy, so it's on the same code path that already calls it for the audit record entry (line 641). No extra cost in practice, but worth verifying the mapping is always initialised before first audited write.
- The worktree test runner has a pre-existing module-resolution issue unrelated to these changes; `npm run build` + manual dist smoke tests pass cleanly.

*Generated by Claude Sonnet 4.6*