### PR TITLE
feat(models): Phase 3 — openai backend + toolMode: 'return'

### DIFF
--- a/components/openai/index.ts
+++ b/components/openai/index.ts
@@ -1,0 +1,606 @@
+/**
+ * OpenAI backend (#630, Phase 3 of #510).
+ *
+ * Implements `ModelBackend` against the OpenAI HTTP API (or any
+ * OpenAI-compatible endpoint via `baseUrl` override — Azure OpenAI,
+ * Together AI, OpenRouter, vLLM's OpenAI shim, etc.). Exports `OpenAIBackend`
+ * directly for tests and `registerOpenAIBackend(...)` for the YAML→registry
+ * boot bridge in `resources/models/bootstrap.ts`.
+ *
+ * Component shape matches the pattern in `components/mcp/index.ts` (PR #649)
+ * and `components/ollama/index.ts` (PR #651): core imports a register helper
+ * and calls it during boot; not a `handleApplication(scope)` self-loader.
+ *
+ * Native fetch is used directly — no SDK dependency. The OpenAI wire format
+ * we touch (`POST /embeddings`, `POST /chat/completions` with SSE streaming
+ * + tool calls) has been stable for 2+ years on the fields we read; the
+ * mapping is mechanical.
+ */
+import { setEmbedding, setGenerative } from '../../resources/models/backendRegistry.ts';
+import { ServerError } from '../../utility/errors/hdbError.ts';
+import { isUnresolvedEnvVarPlaceholder } from '../../utility/expandEnvVar.ts';
+import harperLogger from '../../utility/logging/harper_logger.ts';
+import type {
+	BackendOpts,
+	EmbedOpts,
+	GenerateChunk,
+	GenerateInput,
+	GenerateOpts,
+	GenerateResult,
+	Message,
+	ModelBackend,
+	ModelCallResult,
+	ModelCapabilities,
+	ToolCall,
+	ToolDef,
+	TokenUsage,
+} from '../../resources/models/types.ts';
+
+const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
+// SSE accumulator buffer cap. Measured in JS string length (UTF-16 code units),
+// not bytes — for ASCII content the two are equal; for non-ASCII the check is
+// conservative (trips sooner than a true byte cap would). OpenAI chunks are
+// sub-KiB; anything larger is pathological.
+const MAX_SSE_BUFFER_CHARS = 1 << 20;
+// Per-tool-call argument-buffer cap during streaming. OpenAI's largest real
+// tool-call argument payloads are a few KiB; capping at 1 MiB defends against
+// a malicious or buggy OpenAI-compatible upstream emitting unbounded argument
+// deltas (which the per-event SSE cap doesn't catch on its own — each event
+// can be sub-MiB while the cumulative accumulator grows).
+const MAX_TOOL_CALL_ARGS_CHARS = 1 << 20;
+// Cap on the upstream `error.message` we pull into our thrown error for
+// operator debugging. OpenAI's real error messages are well under this; the
+// cap defends against a misbehaving compat shim that returns megabytes of
+// "error" prose.
+const MAX_UPSTREAM_ERROR_MESSAGE_CHARS = 500;
+
+const log = harperLogger.forComponent('openai').conditional;
+
+export type OpenAIBackendKind = 'embedding' | 'generative';
+
+export interface OpenAIBackendConfig {
+	/** Bearer token for the upstream API. Required. */
+	apiKey?: string;
+	/** Default model when the caller doesn't pass `opts.model`. */
+	model?: string;
+	/** Base URL of the OpenAI-compatible endpoint (default `https://api.openai.com/v1`). */
+	baseUrl?: string;
+	/** Per-request timeout. When set, combined with `opts.signal` via `AbortSignal.any`. */
+	requestTimeoutMs?: number;
+	/** Forwarded as `OpenAI-Organization` header when set. */
+	organization?: string;
+}
+
+/**
+ * `ModelBackend` implementation talking to OpenAI's HTTP API (or any
+ * OpenAI-compatible endpoint).
+ *
+ * - `embed` → `POST {baseUrl}/embeddings`
+ * - `generate` → `POST {baseUrl}/chat/completions` (always chat shape)
+ * - `generateStream` → same with `stream: true`; consumes SSE wire format and
+ *   yields `GenerateChunk` per delta.
+ *
+ * Capabilities advertise `tools: true` — first backend with native tool-call
+ * support. `adapters: false` — OpenAI doesn't expose LoRA adapter selection
+ * externally. `toolMode: 'return'` (Phase 1 default) is supported end-to-end;
+ * `toolMode: 'auto'` is reserved for #612.
+ */
+export class OpenAIBackend implements ModelBackend {
+	readonly name = 'openai';
+	readonly #baseUrl: string;
+	readonly #defaultModel?: string;
+	readonly #apiKey: string;
+	readonly #organization?: string;
+	readonly #requestTimeoutMs?: number;
+	readonly #fetch: typeof fetch;
+
+	constructor(config: OpenAIBackendConfig = {}, fetchImpl: typeof fetch = fetch) {
+		this.#apiKey = requireApiKey(config.apiKey);
+		this.#baseUrl = normalizeBaseUrl(config.baseUrl);
+		this.#defaultModel = config.model;
+		this.#organization = config.organization;
+		this.#requestTimeoutMs = config.requestTimeoutMs;
+		this.#fetch = fetchImpl;
+	}
+
+	capabilities(): ModelCapabilities {
+		return { embed: true, generate: true, stream: true, tools: true, adapters: false };
+	}
+
+	async embed(input: string | string[], opts: BackendOpts<EmbedOpts>): Promise<ModelCallResult<Float32Array[]>> {
+		const model = opts.model ?? this.#defaultModel;
+		requireModel(model, 'embed');
+		// inputType is honored as a hint but OpenAI's embedding models don't
+		// currently differentiate by it on the wire — pass through unchanged.
+		const texts = Array.isArray(input) ? input : [input];
+		const body: Record<string, unknown> = { model, input: texts };
+		const res = await this.#post('/embeddings', body, opts.signal);
+		const data = await parseJsonResponse<OpenAIEmbedResponse>(res, '/embeddings');
+		if (!Array.isArray(data.data)) {
+			throw new OpenAIBackendError("OpenAI /embeddings response missing 'data' array");
+		}
+		if (data.data.length !== texts.length) {
+			throw new OpenAIBackendError(
+				`OpenAI /embeddings returned ${data.data.length} vectors for ${texts.length} inputs`
+			);
+		}
+		// OpenAI sorts data by `index` in practice, but defend explicitly.
+		const sorted = [...data.data].sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+		const output = sorted.map((entry, i) => {
+			if (!Array.isArray(entry.embedding) || !entry.embedding.every(Number.isFinite)) {
+				throw new OpenAIBackendError(`OpenAI /embeddings vector at index ${i} is not an array of finite numbers`);
+			}
+			return Float32Array.from(entry.embedding);
+		});
+		const usage: TokenUsage = {};
+		assignFiniteTokenCount(usage, 'embeddingTokens', data.usage?.prompt_tokens);
+		return { status: 'completed', output, usage };
+	}
+
+	async generate(input: GenerateInput, opts: BackendOpts<GenerateOpts>): Promise<ModelCallResult<GenerateResult>> {
+		const model = opts.model ?? this.#defaultModel;
+		requireModel(model, 'generate');
+		const body = buildChatRequest(model, input, opts, false);
+		const res = await this.#post('/chat/completions', body, opts.signal);
+		const data = await parseJsonResponse<OpenAIChatResponse>(res, '/chat/completions');
+		const choice = data.choices?.[0];
+		if (!choice) {
+			throw new OpenAIBackendError('OpenAI /chat/completions response missing choices[0]');
+		}
+		const rawContent = choice.message?.content;
+		if (rawContent != null && typeof rawContent !== 'string') {
+			throw new OpenAIBackendError('OpenAI /chat/completions content is not a string');
+		}
+		const toolCalls = parseToolCalls(choice.message?.tool_calls);
+		const usage: TokenUsage = {};
+		assignFiniteTokenCount(usage, 'promptTokens', data.usage?.prompt_tokens);
+		assignFiniteTokenCount(usage, 'completionTokens', data.usage?.completion_tokens);
+		const result: GenerateResult = {
+			content: rawContent ?? '',
+			finishReason: mapFinishReason(choice.finish_reason),
+		};
+		if (toolCalls && toolCalls.length > 0) result.toolCalls = toolCalls;
+		return { status: 'completed', output: result, usage };
+	}
+
+	async *generateStream(input: GenerateInput, opts: BackendOpts<GenerateOpts>): AsyncIterable<GenerateChunk> {
+		const model = opts.model ?? this.#defaultModel;
+		requireModel(model, 'generateStream');
+		const body = buildChatRequest(model, input, opts, true);
+		const res = await this.#post('/chat/completions', body, opts.signal);
+		if (!res.body) throw new OpenAIBackendError('OpenAI /chat/completions returned no body for streaming');
+
+		// Tool calls arrive as `index`-keyed deltas across many SSE events; we
+		// accumulate internally and yield each call exactly once when its
+		// `arguments` field parses cleanly (or on stream termination). This
+		// preserves Phase 1's contract that `ToolCall.arguments` is `object`,
+		// never a partial string.
+		const toolBuf = new Map<number, ToolCallAccumulator>();
+		let finalFinishReason: GenerateResult['finishReason'] | undefined;
+
+		for await (const event of readSse(res.body)) {
+			const choice = event.choices?.[0];
+			if (!choice) continue;
+			const delta = choice.delta;
+			const chunk: GenerateChunk = {};
+			if (typeof delta?.content === 'string' && delta.content.length > 0) {
+				chunk.deltaContent = delta.content;
+			}
+			if (Array.isArray(delta?.tool_calls)) {
+				for (const tcDelta of delta.tool_calls) {
+					accumulateToolCallDelta(toolBuf, tcDelta);
+				}
+			}
+			if (choice.finish_reason) {
+				finalFinishReason = mapFinishReason(choice.finish_reason);
+				// On stream termination, surface any accumulated tool calls in a
+				// single yield. Skipping malformed entries (arguments that fail
+				// JSON.parse) — they get dropped with a sanitized error.
+				const finalCalls = flushToolCallBuffer(toolBuf);
+				if (finalCalls.length > 0) chunk.deltaToolCalls = finalCalls;
+				chunk.finishReason = finalFinishReason;
+			}
+			if (chunk.deltaContent || chunk.deltaToolCalls || chunk.finishReason) {
+				yield chunk;
+			}
+		}
+
+		// If the stream ended without an explicit finish_reason (rare; some
+		// proxies cut the connection), flush any buffered tool calls so the
+		// caller doesn't lose them silently.
+		if (!finalFinishReason && toolBuf.size > 0) {
+			const tail = flushToolCallBuffer(toolBuf);
+			if (tail.length > 0) yield { deltaToolCalls: tail };
+		}
+	}
+
+	async #post(path: string, body: object, callerSignal?: AbortSignal): Promise<Response> {
+		const signal = composeSignal(callerSignal, this.#requestTimeoutMs);
+		const headers: Record<string, string> = {
+			'Content-Type': 'application/json',
+			'Authorization': `Bearer ${this.#apiKey}`,
+		};
+		if (this.#organization) headers['OpenAI-Organization'] = this.#organization;
+		const res = await this.#fetch(`${this.#baseUrl}${path}`, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify(body),
+			signal,
+		});
+		if (!res.ok) {
+			// Read OpenAI's well-defined error envelope (`{ error: { message,
+			// type, code, param } }`) for operator-facing detail. `error.message`
+			// is model/service-side text, not user-input echo, so including it
+			// doesn't leak request content. Cap length defensively against a
+			// misbehaving compat shim. Falls back to status-only if the body
+			// isn't JSON or doesn't have the envelope.
+			throw new OpenAIBackendError(`OpenAI ${path} returned HTTP ${res.status}${await readErrorSuffix(res)}`);
+		}
+		return res;
+	}
+}
+
+async function readErrorSuffix(res: Response): Promise<string> {
+	try {
+		const body = (await res.json()) as { error?: { message?: unknown; type?: unknown } };
+		const message = body?.error?.message;
+		if (typeof message === 'string' && message.length > 0) {
+			const truncated =
+				message.length > MAX_UPSTREAM_ERROR_MESSAGE_CHARS
+					? message.slice(0, MAX_UPSTREAM_ERROR_MESSAGE_CHARS) + '…'
+					: message;
+			return `: ${truncated}`;
+		}
+		return '';
+	} catch {
+		return '';
+	}
+}
+
+/**
+ * Boot-bridge helper. Called from `resources/models/bootstrap.ts` for each
+ * `models.embedding.<name>` / `models.generative.<name>` entry whose
+ * `backend: openai`.
+ */
+export function registerOpenAIBackend(args: {
+	logicalName: string;
+	kind: OpenAIBackendKind;
+	config: OpenAIBackendConfig;
+}): void {
+	const backend = new OpenAIBackend(args.config);
+	if (args.kind === 'embedding') setEmbedding(args.logicalName, backend);
+	else setGenerative(args.logicalName, backend);
+}
+
+export class OpenAIBackendError extends ServerError {
+	constructor(message: string) {
+		super(message);
+		this.name = 'OpenAIBackendError';
+	}
+}
+
+// ---------- internals ----------
+
+function normalizeBaseUrl(baseUrl?: string): string {
+	const value = baseUrl?.trim() || DEFAULT_BASE_URL;
+	const withScheme = /^https?:\/\//i.test(value) ? value : `https://${value}`;
+	return withScheme.replace(/\/+$/, '');
+}
+
+function requireApiKey(apiKey: string | undefined): string {
+	if (!apiKey || apiKey.length === 0) {
+		throw new OpenAIBackendError('OpenAI backend requires an apiKey');
+	}
+	if (isUnresolvedEnvVarPlaceholder(apiKey)) {
+		// Bootstrap ran `expandEnvVarsDeep` but the env var was unset, so the
+		// literal `${VAR_NAME}` survived. Tell the operator exactly what they
+		// need to set — much better than a 401 from upstream.
+		throw new OpenAIBackendError(
+			`OpenAI apiKey is the literal placeholder ${apiKey}; set the matching env var before starting Harper`
+		);
+	}
+	return apiKey;
+}
+
+function requireModel(model: string | undefined, op: string): asserts model is string {
+	if (!model) throw new OpenAIBackendError(`No model specified for ${op}; set 'model' in config or pass opts.model`);
+}
+
+function composeSignal(caller?: AbortSignal, timeoutMs?: number): AbortSignal | undefined {
+	if (!timeoutMs) return caller;
+	const timeout = AbortSignal.timeout(timeoutMs);
+	if (!caller) return timeout;
+	return AbortSignal.any([caller, timeout]);
+}
+
+function buildChatRequest(
+	model: string,
+	input: GenerateInput,
+	opts: BackendOpts<GenerateOpts>,
+	stream: boolean
+): Record<string, unknown> {
+	const messages = normalizeMessages(input);
+	const tools = extractTools(input);
+	const body: Record<string, unknown> = {
+		model,
+		messages,
+		stream,
+	};
+	if (tools && tools.length > 0) {
+		body.tools = tools.map(toOpenAITool);
+		// tool_choice defaults to 'auto' on OpenAI when `tools` is set, which is
+		// the right behavior for `toolMode: 'return'` — the model decides whether
+		// to call; the caller decides what to do with the call.
+	}
+	if (typeof opts.temperature === 'number') body.temperature = opts.temperature;
+	if (typeof opts.maxTokens === 'number') {
+		// `max_tokens` is broadly supported across OpenAI and OpenAI-compatible
+		// endpoints. OpenAI is migrating to `max_completion_tokens` for o1/o3+
+		// models but still accepts `max_tokens` on chat completions. Compat
+		// endpoints (Azure, vLLM, Together, OpenRouter) mostly accept the older
+		// field. Switch to `max_completion_tokens` when v1 models we ship
+		// against require it.
+		body.max_tokens = opts.maxTokens;
+	}
+	const responseFormat = mapResponseFormat(opts.responseFormat);
+	if (responseFormat) body.response_format = responseFormat;
+	return body;
+}
+
+function normalizeMessages(
+	input: GenerateInput
+): Array<{ role: string; content: string; tool_call_id?: string; tool_calls?: object[] }> {
+	if (typeof input === 'string') {
+		return [{ role: 'user', content: input }];
+	}
+	if (Array.isArray(input)) {
+		return input.map(toOpenAIMessage);
+	}
+	const messages = input.messages.map(toOpenAIMessage);
+	if (input.system) {
+		return [{ role: 'system', content: input.system }, ...messages];
+	}
+	return messages;
+}
+
+function extractTools(input: GenerateInput): ToolDef[] | undefined {
+	if (typeof input === 'string' || Array.isArray(input)) return undefined;
+	return input.tools;
+}
+
+function toOpenAIMessage(m: Message): { role: string; content: string; tool_call_id?: string; tool_calls?: object[] } {
+	const out: { role: string; content: string; tool_call_id?: string; tool_calls?: object[] } = {
+		role: m.role,
+		content: m.content,
+	};
+	if (m.toolCallId) out.tool_call_id = m.toolCallId;
+	if (m.toolCalls && m.toolCalls.length > 0) {
+		out.tool_calls = m.toolCalls.map((tc) => ({
+			id: tc.id,
+			type: 'function',
+			function: { name: tc.name, arguments: JSON.stringify(tc.arguments ?? {}) },
+		}));
+	}
+	return out;
+}
+
+function toOpenAITool(t: ToolDef): {
+	type: 'function';
+	function: { name: string; description: string; parameters: object };
+} {
+	return {
+		type: 'function',
+		function: {
+			name: t.name,
+			description: t.description,
+			parameters: t.parameters,
+		},
+	};
+}
+
+function mapResponseFormat(responseFormat: GenerateOpts['responseFormat']): object | undefined {
+	if (!responseFormat) return undefined;
+	if (responseFormat === 'text') return { type: 'text' };
+	if (responseFormat === 'json') return { type: 'json_object' };
+	if (typeof responseFormat === 'object' && 'schema' in responseFormat) {
+		return {
+			type: 'json_schema',
+			json_schema: { name: 'output', schema: responseFormat.schema, strict: true },
+		};
+	}
+	return undefined;
+}
+
+function mapFinishReason(reason?: string | null): GenerateResult['finishReason'] {
+	switch (reason) {
+		case 'length':
+			return 'length';
+		case 'tool_calls':
+		case 'function_call':
+			return 'tool_calls';
+		case 'content_filter':
+			return 'content_filter';
+		case 'stop':
+		default:
+			return 'stop';
+	}
+}
+
+function parseToolCalls(raw: OpenAIToolCall[] | undefined): ToolCall[] | undefined {
+	if (!raw || raw.length === 0) return undefined;
+	const out: ToolCall[] = [];
+	for (const tc of raw) {
+		if (!tc.id || !tc.function?.name) continue;
+		try {
+			const args = tc.function.arguments ? JSON.parse(tc.function.arguments) : {};
+			out.push({ id: tc.id, name: tc.function.name, arguments: args });
+		} catch {
+			// Drop tool calls whose arguments aren't valid JSON. OpenAI almost
+			// always returns valid JSON; a malformed argument is a real model
+			// failure the caller should treat as "no tool call" rather than
+			// crash the whole response. Log at warn so the silent drop is
+			// auditable — name + id only, never the malformed argument bytes.
+			log.warn?.(`OpenAI tool call dropped: malformed arguments (id=${tc.id}, name=${tc.function.name})`);
+			continue;
+		}
+	}
+	return out.length > 0 ? out : undefined;
+}
+
+interface ToolCallAccumulator {
+	id?: string;
+	name?: string;
+	argumentsBuf: string;
+}
+
+function accumulateToolCallDelta(buf: Map<number, ToolCallAccumulator>, delta: OpenAIToolCallDelta): void {
+	const index = typeof delta.index === 'number' ? delta.index : 0;
+	let acc = buf.get(index);
+	if (!acc) {
+		acc = { argumentsBuf: '' };
+		buf.set(index, acc);
+	}
+	if (delta.id) acc.id = delta.id;
+	if (delta.function?.name) acc.name = delta.function.name;
+	if (typeof delta.function?.arguments === 'string') {
+		// Defend against an unbounded accumulator: the per-event SSE buffer cap
+		// stops a single oversize event, but tool-call arguments are *built up*
+		// across many sub-cap events. Throw before V8 hits string-length limits.
+		if (acc.argumentsBuf.length + delta.function.arguments.length > MAX_TOOL_CALL_ARGS_CHARS) {
+			throw new OpenAIBackendError(
+				`OpenAI tool-call arguments exceed ${MAX_TOOL_CALL_ARGS_CHARS} chars (index ${index})`
+			);
+		}
+		acc.argumentsBuf += delta.function.arguments;
+	}
+}
+
+function flushToolCallBuffer(buf: Map<number, ToolCallAccumulator>): Partial<ToolCall>[] {
+	const out: Partial<ToolCall>[] = [];
+	// Stable order by index for deterministic output.
+	const indices = [...buf.keys()].sort((a, b) => a - b);
+	for (const idx of indices) {
+		const acc = buf.get(idx)!;
+		if (!acc.id || !acc.name) continue;
+		try {
+			const args = acc.argumentsBuf.length > 0 ? JSON.parse(acc.argumentsBuf) : {};
+			out.push({ id: acc.id, name: acc.name, arguments: args });
+		} catch {
+			// Same posture as non-streaming: malformed arguments → drop the
+			// call but log so the silent drop is auditable. Name + id only.
+			log.warn?.(`OpenAI tool call dropped: malformed arguments (id=${acc.id}, name=${acc.name})`);
+			continue;
+		}
+	}
+	buf.clear();
+	return out;
+}
+
+/**
+ * Read OpenAI's SSE wire format. Each event is `data: <json>\n\n`; the stream
+ * terminates on `data: [DONE]\n\n`. Comment lines (`:`) and any non-`data:`
+ * field are ignored.
+ */
+async function* readSse(body: ReadableStream<Uint8Array>): AsyncGenerator<OpenAIStreamEvent> {
+	const decoder = new TextDecoder('utf-8');
+	let buf = '';
+	for await (const chunk of body as unknown as AsyncIterable<Uint8Array>) {
+		buf += decoder.decode(chunk, { stream: true });
+		if (buf.length > MAX_SSE_BUFFER_CHARS) {
+			throw new OpenAIBackendError(`OpenAI SSE buffer exceeds ${MAX_SSE_BUFFER_CHARS} chars without a complete event`);
+		}
+		let boundary: number;
+		while ((boundary = buf.indexOf('\n\n')) >= 0) {
+			const eventBlock = buf.slice(0, boundary);
+			buf = buf.slice(boundary + 2);
+			const parsed = parseSseEvent(eventBlock);
+			if (parsed === 'done') return;
+			if (parsed) yield parsed;
+		}
+	}
+	buf += decoder.decode();
+	const tail = buf.trim();
+	if (tail) {
+		const parsed = parseSseEvent(tail);
+		if (parsed && parsed !== 'done') yield parsed;
+	}
+}
+
+function parseSseEvent(block: string): OpenAIStreamEvent | 'done' | null {
+	// Each block is one or more lines. Concatenate `data:` line payloads per
+	// SSE rules (multi-line data fields are joined with `\n`).
+	let data = '';
+	for (const rawLine of block.split('\n')) {
+		const line = rawLine.replace(/\r$/, '');
+		if (!line || line.startsWith(':')) continue;
+		if (!line.startsWith('data:')) continue;
+		const payload = line.slice(5).replace(/^ /, ''); // strip "data:" + optional leading space
+		data = data ? data + '\n' + payload : payload;
+	}
+	if (!data) return null;
+	if (data === '[DONE]') return 'done';
+	try {
+		return JSON.parse(data) as OpenAIStreamEvent;
+	} catch {
+		// Static message — JSON parser echoes the offending bytes which can be
+		// upstream-derived content.
+		throw new OpenAIBackendError('Invalid SSE data line from OpenAI');
+	}
+}
+
+async function parseJsonResponse<T>(res: Response, endpoint: string): Promise<T> {
+	try {
+		return (await res.json()) as T;
+	} catch {
+		throw new OpenAIBackendError(`OpenAI ${endpoint} returned a non-JSON response body`);
+	}
+}
+
+function assignFiniteTokenCount(
+	usage: TokenUsage,
+	key: 'promptTokens' | 'completionTokens' | 'embeddingTokens',
+	value: unknown
+): void {
+	if (typeof value !== 'number') return;
+	if (!Number.isFinite(value) || value < 0 || !Number.isInteger(value)) return;
+	usage[key] = value;
+}
+
+// ---------- OpenAI wire types (subset we actually read) ----------
+
+interface OpenAIEmbedResponse {
+	data: Array<{ embedding: number[]; index?: number; object?: string }>;
+	usage?: { prompt_tokens?: number; total_tokens?: number };
+}
+
+interface OpenAIChatResponse {
+	choices?: Array<{
+		message?: { role: string; content?: string | null; tool_calls?: OpenAIToolCall[] };
+		finish_reason?: string | null;
+	}>;
+	usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+}
+
+interface OpenAIToolCall {
+	id?: string;
+	type?: 'function';
+	function?: { name?: string; arguments?: string };
+}
+
+interface OpenAIStreamEvent {
+	choices?: Array<{
+		delta?: {
+			role?: string;
+			content?: string | null;
+			tool_calls?: OpenAIToolCallDelta[];
+		};
+		finish_reason?: string | null;
+	}>;
+}
+
+interface OpenAIToolCallDelta {
+	index?: number;
+	id?: string;
+	type?: 'function';
+	function?: { name?: string; arguments?: string };
+}

--- a/integrationTests/server/openai-backend.test.ts
+++ b/integrationTests/server/openai-backend.test.ts
@@ -1,0 +1,232 @@
+/**
+ * OpenAI backend integration test (#630, Phase 3 of #510).
+ *
+ * Exercises `OpenAIBackend` end-to-end against the real OpenAI HTTP API to
+ * validate that the mocked wire format used in unit tests matches what
+ * OpenAI actually produces.
+ *
+ * The suite SKIPS when `OPENAI_API_KEY` is unset. Set:
+ *   - `OPENAI_API_KEY`           (required to run)
+ *   - `OPENAI_EMBED_MODEL`       (default `text-embedding-3-small`)
+ *   - `OPENAI_GENERATE_MODEL`    (default `gpt-4o-mini`)
+ *   - `OPENAI_BASE_URL`          (default `https://api.openai.com/v1`)
+ *
+ * The full app→Resource→harper.models path is covered by the unit-test
+ * suites for jsLoader (`harper.models` export, from Phase 2), bootstrap
+ * (registry wiring), and OpenAIBackend (call dispatch). This file is the
+ * contract check against the real OpenAI HTTP surface.
+ */
+import { suite, test, before } from 'node:test';
+import { strictEqual, ok } from 'node:assert/strict';
+
+// NOTE: `OpenAIBackend` is imported dynamically inside `before()` rather than
+// at the top of the file. Statically importing it from `components/openai/`
+// triggers a pre-existing require cycle in Harper's CommonJS graph
+// (`utility/common_utils.ts` ↔ `utility/logging/harper_logger.ts`) when this
+// test file is loaded by `node --test`, fatal on Node 22+ (ERR_REQUIRE_CYCLE_MODULE).
+// Same workaround as `integrationTests/server/ollama-backend.test.ts`.
+
+type OpenAIBackendCtor = new (
+	config: { apiKey: string; model?: string; baseUrl?: string; requestTimeoutMs?: number; organization?: string },
+	fetchImpl?: typeof fetch
+) => {
+	embed: (
+		input: string | string[],
+		opts: object
+	) => Promise<{ status: string; output: Float32Array[]; usage: { embeddingTokens?: number } }>;
+	generate: (
+		input: unknown,
+		opts: object
+	) => Promise<{
+		status: string;
+		output: { content: string; finishReason: string; toolCalls?: unknown[] };
+		usage: object;
+	}>;
+	generateStream: (
+		input: unknown,
+		opts: object
+	) => AsyncIterable<{ deltaContent?: string; deltaToolCalls?: unknown[]; finishReason?: string }>;
+};
+
+const API_KEY = process.env.OPENAI_API_KEY;
+const EMBED_MODEL = process.env.OPENAI_EMBED_MODEL ?? 'text-embedding-3-small';
+const GENERATE_MODEL = process.env.OPENAI_GENERATE_MODEL ?? 'gpt-4o-mini';
+const BASE_URL = process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1';
+
+const ACCOUNTING = { tenantId: 'integration', app: '/integration' };
+
+const skip = !API_KEY;
+
+suite('OpenAIBackend against the real OpenAI API', { skip }, () => {
+	let backend: InstanceType<OpenAIBackendCtor>;
+
+	before(async () => {
+		const mod = (await import('../../components/openai/index.ts')) as { OpenAIBackend: OpenAIBackendCtor };
+		backend = new mod.OpenAIBackend({
+			apiKey: API_KEY!,
+			baseUrl: BASE_URL,
+		});
+	});
+
+	test('embed returns a non-empty Float32Array vector', async () => {
+		const result = await backend.embed('integration test', {
+			accounting: ACCOUNTING,
+			model: EMBED_MODEL,
+		});
+		strictEqual(result.status, 'completed');
+		ok(Array.isArray(result.output));
+		strictEqual(result.output.length, 1);
+		ok(result.output[0] instanceof Float32Array);
+		ok(result.output[0].length > 0, 'expected non-empty vector');
+		ok(typeof result.usage.embeddingTokens === 'number' && result.usage.embeddingTokens > 0);
+	});
+
+	test('embed returns multiple vectors for an array input', async () => {
+		const result = await backend.embed(['one', 'two'], {
+			accounting: ACCOUNTING,
+			model: EMBED_MODEL,
+		});
+		strictEqual(result.status, 'completed');
+		strictEqual(result.output.length, 2);
+	});
+
+	test('generate produces non-empty content', async () => {
+		const result = await backend.generate('Reply with the single word OK.', {
+			accounting: ACCOUNTING,
+			model: GENERATE_MODEL,
+			maxTokens: 10,
+			temperature: 0,
+		});
+		strictEqual(result.status, 'completed');
+		ok(typeof result.output.content === 'string' && result.output.content.length > 0);
+		ok(['stop', 'length'].includes(result.output.finishReason));
+	});
+
+	test('generate via messages-array shape produces non-empty content', async () => {
+		const result = await backend.generate([{ role: 'user', content: 'Reply with the single word OK.' }], {
+			accounting: ACCOUNTING,
+			model: GENERATE_MODEL,
+			maxTokens: 10,
+			temperature: 0,
+		});
+		strictEqual(result.status, 'completed');
+		ok(typeof result.output.content === 'string' && result.output.content.length > 0);
+	});
+
+	test('generate with tools (toolMode: return) surfaces a tool_calls response', async () => {
+		const tools = [
+			{
+				name: 'get_weather',
+				description: 'Get the current weather for a location',
+				parameters: {
+					type: 'object',
+					properties: { location: { type: 'string', description: 'City name' } },
+					required: ['location'],
+				},
+			},
+		];
+		const result = await backend.generate(
+			{
+				messages: [{ role: 'user', content: 'What is the weather in San Francisco? Use the tool.' }],
+				tools,
+			},
+			{ accounting: ACCOUNTING, model: GENERATE_MODEL, temperature: 0, toolMode: 'return' }
+		);
+		strictEqual(result.status, 'completed');
+		// The model SHOULD call the tool given the directive. If it didn't,
+		// finishReason will be 'stop' instead of 'tool_calls' — that's a model
+		// decision, not a contract failure. We assert structure when present.
+		if (result.output.finishReason === 'tool_calls') {
+			ok(Array.isArray(result.output.toolCalls));
+			ok((result.output.toolCalls?.length ?? 0) > 0);
+			const tc = result.output.toolCalls![0] as { id: string; name: string; arguments: object };
+			strictEqual(tc.name, 'get_weather');
+			ok(typeof tc.arguments === 'object' && tc.arguments !== null);
+		}
+	});
+
+	test('generateStream yields content chunks and a terminating finishReason', async () => {
+		const chunks: { deltaContent?: string; finishReason?: string }[] = [];
+		for await (const chunk of backend.generateStream('Count: 1 2 3.', {
+			accounting: ACCOUNTING,
+			model: GENERATE_MODEL,
+			maxTokens: 20,
+			temperature: 0,
+		})) {
+			chunks.push(chunk);
+		}
+		ok(chunks.length > 0, 'expected at least one chunk');
+		const hasContent = chunks.some((c) => typeof c.deltaContent === 'string' && c.deltaContent.length > 0);
+		ok(hasContent, 'expected at least one chunk with deltaContent');
+		const terminal = chunks[chunks.length - 1];
+		ok(['stop', 'length'].includes(terminal.finishReason ?? ''));
+	});
+
+	test('generateStream with tools accumulates and surfaces a fully-assembled tool call', async () => {
+		const tools = [
+			{
+				name: 'get_weather',
+				description: 'Get the current weather for a location',
+				parameters: {
+					type: 'object',
+					properties: { location: { type: 'string' } },
+					required: ['location'],
+				},
+			},
+		];
+		const chunks: { deltaContent?: string; deltaToolCalls?: unknown[]; finishReason?: string }[] = [];
+		for await (const chunk of backend.generateStream(
+			{
+				messages: [{ role: 'user', content: 'Weather in Tokyo? Use the tool.' }],
+				tools,
+			},
+			{ accounting: ACCOUNTING, model: GENERATE_MODEL, temperature: 0 }
+		)) {
+			chunks.push(chunk);
+		}
+		ok(chunks.length > 0);
+		const terminal = chunks[chunks.length - 1];
+		if (terminal.finishReason === 'tool_calls') {
+			ok(Array.isArray(terminal.deltaToolCalls));
+			ok((terminal.deltaToolCalls?.length ?? 0) > 0);
+		}
+	});
+
+	test('AbortSignal cancels an in-flight stream', async () => {
+		const ctrl = new AbortController();
+		const iter = backend
+			.generateStream('Write a long paragraph about the ocean and waves and tides.', {
+				accounting: ACCOUNTING,
+				model: GENERATE_MODEL,
+				signal: ctrl.signal,
+				maxTokens: 1000,
+				temperature: 0.5,
+			})
+			[Symbol.asyncIterator]();
+		// Get one chunk to confirm the stream started, then abort.
+		await iter.next();
+		ctrl.abort();
+		// After abort, the iterator must terminate — either by rejecting
+		// (AbortError) or by reaching `done`. The real failure mode this
+		// guards against is the stream hanging. Race a 5 s deadline.
+		const drain = (async () => {
+			try {
+				while (true) {
+					const next = await iter.next();
+					if (next.done) return 'done' as const;
+				}
+			} catch (err) {
+				const name = (err as Error).name;
+				const isAbort = name === 'AbortError' || /abort/i.test(String(err));
+				return isAbort ? ('aborted' as const) : ('errored' as const);
+			}
+		})();
+		const HANG = Symbol('hang');
+		const deadline = new Promise<typeof HANG>((resolve) => setTimeout(() => resolve(HANG), 5000));
+		const outcome = await Promise.race([drain, deadline]);
+		ok(
+			outcome === 'done' || outcome === 'aborted',
+			`expected abort to terminate stream (done or AbortError); got ${String(outcome)}`
+		);
+	});
+});

--- a/resources/models/bootstrap.ts
+++ b/resources/models/bootstrap.ts
@@ -1,5 +1,5 @@
 /**
- * YAML→registry boot bridge (#629, Phase 2 of #510).
+ * YAML→registry boot bridge (#629 / #630 of #510).
  *
  * Reads the top-level `models` block from the root config and dispatches each
  * `models.embedding.<name>` / `models.generative.<name>` entry to the matching
@@ -10,11 +10,26 @@
  * returns the root config and before per-component iteration, so that
  * `scope.models.embed(...)` works from `handleApplication(scope)`.
  *
+ * Env-var expansion: each entry's string leaves are run through
+ * `expandEnvVarsDeep` before dispatch — `apiKey: ${OPENAI_API_KEY}` in YAML
+ * becomes the resolved process.env value at the backend. Matches the
+ * convention from `@harperfast/oauth`'s config loader.
+ *
  * Errors per entry are logged and skipped, not thrown — one misconfigured
  * backend should not block Harper boot.
  */
 import harperLogger from '../../utility/logging/harper_logger.ts';
+import { expandEnvVarsDeep, isUnresolvedEnvVarPlaceholder } from '../../utility/expandEnvVar.ts';
 import { registerOllamaBackend, type OllamaBackendConfig } from '../../components/ollama/index.ts';
+import { registerOpenAIBackend, type OpenAIBackendConfig } from '../../components/openai/index.ts';
+
+/**
+ * Field names treated as credentials. When present in config as a literal
+ * value (not a `${VAR}` placeholder), bootstrap warns the operator at boot
+ * — `harperdb-config.yaml` on disk in plaintext is a real anti-pattern.
+ * Extend this list as future backends add credential fields.
+ */
+const CREDENTIAL_FIELDS = new Set(['apiKey']);
 
 type ModelKind = 'embedding' | 'generative';
 
@@ -23,6 +38,9 @@ interface ModelEntry {
 	host?: string;
 	model?: string;
 	requestTimeoutMs?: number;
+	// openai-specific fields
+	apiKey?: string;
+	baseUrl?: string;
 }
 
 interface ModelsConfig {
@@ -38,6 +56,7 @@ type BackendRegisterFn = (args: { logicalName: string; kind: ModelKind; config: 
 
 const FACTORIES: Record<string, BackendRegisterFn> = {
 	ollama: (args) => registerOllamaBackend({ ...args, config: args.config as OllamaBackendConfig }),
+	openai: (args) => registerOpenAIBackend({ ...args, config: args.config as OpenAIBackendConfig }),
 };
 
 /**
@@ -50,6 +69,18 @@ export function bootstrapModels(rootConfig: RootConfig | undefined | null): void
 	if (!block) return;
 	registerKind('embedding', block.embedding);
 	registerKind('generative', block.generative);
+}
+
+function warnOnLiteralCredentials(kind: ModelKind, logicalName: string, entry: ModelEntry): void {
+	for (const field of CREDENTIAL_FIELDS) {
+		const value = (entry as Record<string, unknown>)[field];
+		if (typeof value !== 'string' || value.length === 0) continue;
+		if (isUnresolvedEnvVarPlaceholder(value)) continue; // operator is using ${VAR} indirection
+		harperLogger.warn(
+			`models.${kind}.${logicalName}: '${field}' is a literal value in harperdb-config.yaml; ` +
+				`prefer \${ENV_VAR} indirection for credentials to keep them off disk`
+		);
+	}
 }
 
 function registerKind(kind: ModelKind, entries: Record<string, ModelEntry> | undefined): void {
@@ -68,12 +99,28 @@ function registerKind(kind: ModelKind, entries: Record<string, ModelEntry> | und
 			// a backend — silently registering nothing is a footgun. Schema-level
 			// typo guards (`.unknown(false)` on modelEntrySchema) catch field-name
 			// typos before this point; reaching here means `backend:` itself names
-			// a type Harper doesn't ship a factory for in this version.
-			harperLogger.error(`models.${kind}.${logicalName}: unknown backend '${entry.backend ?? '(missing)'}'; skipping`);
+			// a type Harper doesn't ship a factory for in this version. List the
+			// known backends so operators can spot value-name typos
+			// (`backend: 'openi'` instead of `'openai'`).
+			const known = Object.keys(FACTORIES).sort().join(', ');
+			harperLogger.error(
+				`models.${kind}.${logicalName}: unknown backend '${entry.backend ?? '(missing)'}'; skipping. Known backends: ${known}.`
+			);
 			continue;
 		}
+		// Warn before expansion: literal credentials in `harperdb-config.yaml`
+		// land on disk, in backups, and (depending on deployment) in replicated
+		// config tables. The `${VAR}` indirection pattern from
+		// `@harperfast/oauth` is documented but not enforced.
+		warnOnLiteralCredentials(kind, logicalName, entry);
 		try {
-			factory({ logicalName, kind, config: entry });
+			// Resolve `${VAR}` placeholders on every string leaf before handing the
+			// entry to the backend factory. Backends receive concrete values and
+			// don't need to know about env-var syntax. Unresolved placeholders
+			// (env var unset) pass through unchanged — backend's required-field
+			// validation catches them with a meaningful error.
+			const resolved = expandEnvVarsDeep(entry);
+			factory({ logicalName, kind, config: resolved });
 		} catch (err) {
 			harperLogger.error(`models.${kind}.${logicalName}: registration failed (${(err as Error)?.message ?? err})`);
 		}

--- a/unitTests/components/openai/index.test.js
+++ b/unitTests/components/openai/index.test.js
@@ -1,0 +1,794 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { OpenAIBackend, OpenAIBackendError, registerOpenAIBackend } = require('#src/components/openai/index');
+const { clearRegistry, resolveEmbedding, resolveGenerative } = require('#src/resources/models/backendRegistry');
+
+const ACCOUNTING = { tenantId: 'tid', app: '/test' };
+const API_KEY = 'sk-test';
+
+function mockFetch(responder) {
+	const calls = [];
+	const fn = async (url, init) => {
+		calls.push({ url, init });
+		const res = await responder({ url, init, callIndex: calls.length - 1 });
+		return res;
+	};
+	fn.calls = calls;
+	return fn;
+}
+
+function jsonResponse(body, { status = 200 } = {}) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}
+
+function sseResponse(events, { includeDone = true } = {}) {
+	const encoder = new TextEncoder();
+	const body = new ReadableStream({
+		start(controller) {
+			for (const event of events) {
+				const payload = typeof event === 'string' ? event : JSON.stringify(event);
+				controller.enqueue(encoder.encode(`data: ${payload}\n\n`));
+			}
+			if (includeDone) controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+			controller.close();
+		},
+	});
+	return new Response(body, { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+}
+
+describe('OpenAIBackend', () => {
+	describe('construction + shape', () => {
+		it('reports name = "openai"', () => {
+			const b = new OpenAIBackend({ apiKey: API_KEY });
+			assert.strictEqual(b.name, 'openai');
+		});
+
+		it('advertises capabilities matching the issue body (tools: true)', () => {
+			const b = new OpenAIBackend({ apiKey: API_KEY });
+			assert.deepStrictEqual(b.capabilities(), {
+				embed: true,
+				generate: true,
+				stream: true,
+				tools: true,
+				adapters: false,
+			});
+		});
+
+		it('throws OpenAIBackendError when apiKey is missing', () => {
+			assert.throws(() => new OpenAIBackend({}), OpenAIBackendError);
+		});
+
+		it('throws OpenAIBackendError when apiKey is the literal ${VAR} placeholder (env var unset)', () => {
+			assert.throws(() => new OpenAIBackend({ apiKey: '${OPENAI_API_KEY_NOT_SET}' }), /literal placeholder/);
+		});
+
+		it("defaults baseUrl to 'https://api.openai.com/v1'", async () => {
+			const fetch = mockFetch(() => jsonResponse({ data: [{ embedding: [0.1] }] }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			await b.embed('x', { accounting: ACCOUNTING });
+			assert.strictEqual(fetch.calls[0].url, 'https://api.openai.com/v1/embeddings');
+		});
+
+		it('respects a baseUrl override (Azure / Together / OpenRouter / vLLM)', async () => {
+			const fetch = mockFetch(() => jsonResponse({ data: [{ embedding: [0.1] }] }));
+			const b = new OpenAIBackend(
+				{ apiKey: API_KEY, model: 'm', baseUrl: 'https://my-azure.openai.azure.com/openai/v1' },
+				fetch
+			);
+			await b.embed('x', { accounting: ACCOUNTING });
+			assert.strictEqual(fetch.calls[0].url, 'https://my-azure.openai.azure.com/openai/v1/embeddings');
+		});
+
+		it('strips trailing slash on baseUrl', async () => {
+			const fetch = mockFetch(() => jsonResponse({ data: [{ embedding: [0.1] }] }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm', baseUrl: 'https://api.openai.com/v1/' }, fetch);
+			await b.embed('x', { accounting: ACCOUNTING });
+			assert.strictEqual(fetch.calls[0].url, 'https://api.openai.com/v1/embeddings');
+		});
+
+		it('sends Authorization: Bearer <apiKey> header', async () => {
+			const fetch = mockFetch(() => jsonResponse({ data: [{ embedding: [0.1] }] }));
+			const b = new OpenAIBackend({ apiKey: 'sk-secret', model: 'm' }, fetch);
+			await b.embed('x', { accounting: ACCOUNTING });
+			assert.strictEqual(fetch.calls[0].init.headers.Authorization, 'Bearer sk-secret');
+		});
+
+		it('sends OpenAI-Organization header when configured', async () => {
+			const fetch = mockFetch(() => jsonResponse({ data: [{ embedding: [0.1] }] }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm', organization: 'org-abc' }, fetch);
+			await b.embed('x', { accounting: ACCOUNTING });
+			assert.strictEqual(fetch.calls[0].init.headers['OpenAI-Organization'], 'org-abc');
+		});
+
+		it('omits OpenAI-Organization when not configured', async () => {
+			const fetch = mockFetch(() => jsonResponse({ data: [{ embedding: [0.1] }] }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			await b.embed('x', { accounting: ACCOUNTING });
+			assert.strictEqual(fetch.calls[0].init.headers['OpenAI-Organization'], undefined);
+		});
+	});
+
+	describe('embed', () => {
+		it('POSTs /embeddings and returns Float32Array vectors', async () => {
+			const fetch = mockFetch(() =>
+				jsonResponse({
+					data: [{ embedding: [0.1, 0.2, 0.3], index: 0 }],
+					usage: { prompt_tokens: 7, total_tokens: 7 },
+				})
+			);
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'text-embedding-3-small' }, fetch);
+			const result = await b.embed('hello', { accounting: ACCOUNTING });
+			assert.strictEqual(result.status, 'completed');
+			assert.strictEqual(result.output.length, 1);
+			assert.ok(result.output[0] instanceof Float32Array);
+			assert.strictEqual(result.usage.embeddingTokens, 7);
+			const sent = JSON.parse(fetch.calls[0].init.body);
+			assert.strictEqual(sent.model, 'text-embedding-3-small');
+			assert.deepStrictEqual(sent.input, ['hello']);
+		});
+
+		it('handles batch input with multiple vectors', async () => {
+			const fetch = mockFetch(() =>
+				jsonResponse({
+					data: [
+						{ embedding: [0.1], index: 0 },
+						{ embedding: [0.2], index: 1 },
+					],
+				})
+			);
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			const result = await b.embed(['a', 'b'], { accounting: ACCOUNTING });
+			assert.strictEqual(result.output.length, 2);
+			const sent = JSON.parse(fetch.calls[0].init.body);
+			assert.deepStrictEqual(sent.input, ['a', 'b']);
+		});
+
+		it('sorts vectors by index even when OpenAI returns them out of order', async () => {
+			const fetch = mockFetch(() =>
+				jsonResponse({
+					data: [
+						{ embedding: [0.2], index: 1 },
+						{ embedding: [0.1], index: 0 },
+					],
+				})
+			);
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			const result = await b.embed(['a', 'b'], { accounting: ACCOUNTING });
+			assert.strictEqual(result.output[0][0], new Float32Array([0.1])[0]);
+			assert.strictEqual(result.output[1][0], new Float32Array([0.2])[0]);
+		});
+
+		it('overrides the configured model with opts.model', async () => {
+			const fetch = mockFetch(() => jsonResponse({ data: [{ embedding: [0.1] }] }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'configured' }, fetch);
+			await b.embed('x', { accounting: ACCOUNTING, model: 'override' });
+			const sent = JSON.parse(fetch.calls[0].init.body);
+			assert.strictEqual(sent.model, 'override');
+		});
+
+		it('throws when no model is configured or passed', async () => {
+			const fetch = mockFetch(() => jsonResponse({}));
+			const b = new OpenAIBackend({ apiKey: API_KEY }, fetch);
+			await assert.rejects(() => b.embed('x', { accounting: ACCOUNTING }), OpenAIBackendError);
+		});
+
+		it('throws on vector-count mismatch', async () => {
+			const fetch = mockFetch(() => jsonResponse({ data: [{ embedding: [0.1], index: 0 }] }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			await assert.rejects(() => b.embed(['a', 'b'], { accounting: ACCOUNTING }), /returned 1 vectors for 2 inputs/);
+		});
+
+		it('throws when a vector contains non-finite values', async () => {
+			const fetch = mockFetch(() => jsonResponse({ data: [{ embedding: [0.1, null, 0.3], index: 0 }] }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			await assert.rejects(() => b.embed('x', { accounting: ACCOUNTING }), /not an array of finite numbers/);
+		});
+
+		it('drops non-finite prompt_tokens from usage', async () => {
+			const fetch = mockFetch(() => jsonResponse({ data: [{ embedding: [0.1] }], usage: { prompt_tokens: NaN } }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			const result = await b.embed('x', { accounting: ACCOUNTING });
+			assert.strictEqual(result.usage.embeddingTokens, undefined);
+		});
+
+		it('wraps non-JSON response bodies in OpenAIBackendError', async () => {
+			const fetch = mockFetch(() => new Response('<html>oops</html>', { status: 200 }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			await assert.rejects(() => b.embed('x', { accounting: ACCOUNTING }), /returned a non-JSON response body/);
+		});
+
+		it('throws OpenAIBackendError on non-2xx HTTP', async () => {
+			const fetch = mockFetch(() => new Response('rate-limit info', { status: 429 }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			await assert.rejects(() => b.embed('x', { accounting: ACCOUNTING }), /returned HTTP 429/);
+		});
+
+		it('includes upstream OpenAI error.message in the thrown error when available', async () => {
+			const fetch = mockFetch(
+				() =>
+					new Response(JSON.stringify({ error: { message: 'Invalid model: gpt-9000', type: 'invalid_request' } }), {
+						status: 400,
+						headers: { 'Content-Type': 'application/json' },
+					})
+			);
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			await assert.rejects(
+				() => b.embed('x', { accounting: ACCOUNTING }),
+				/returned HTTP 400: Invalid model: gpt-9000/
+			);
+		});
+
+		it('falls back to status-only when the error body is not the OpenAI envelope', async () => {
+			const fetch = mockFetch(() => new Response('not-json', { status: 500 }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			await assert.rejects(() => b.embed('x', { accounting: ACCOUNTING }), /returned HTTP 500$/);
+		});
+
+		it('truncates pathologically long upstream error messages', async () => {
+			const longMessage = 'x'.repeat(2000);
+			const fetch = mockFetch(
+				() =>
+					new Response(JSON.stringify({ error: { message: longMessage } }), {
+						status: 400,
+						headers: { 'Content-Type': 'application/json' },
+					})
+			);
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			try {
+				await b.embed('x', { accounting: ACCOUNTING });
+				assert.fail('expected OpenAIBackendError');
+			} catch (err) {
+				// 500-char cap + truncation marker + status prefix + small fixed
+				// text; total message length should be well under the raw 2000.
+				assert.ok(err.message.length < 2000);
+				assert.ok(err.message.includes('…'));
+			}
+		});
+	});
+
+	describe('generate (non-streaming)', () => {
+		function chatResponse({ content = 'hi', toolCalls, finishReason = 'stop', usage } = {}) {
+			const message = { role: 'assistant', content };
+			if (toolCalls) message.tool_calls = toolCalls;
+			return jsonResponse({
+				choices: [{ message, finish_reason: finishReason }],
+				usage: usage ?? { prompt_tokens: 5, completion_tokens: 2 },
+			});
+		}
+
+		it('POSTs /chat/completions with a string input as one user message', async () => {
+			const fetch = mockFetch(() => chatResponse({ content: 'reply' }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'gpt-4o-mini' }, fetch);
+			const result = await b.generate('hello', { accounting: ACCOUNTING });
+			assert.strictEqual(result.output.content, 'reply');
+			assert.strictEqual(result.output.finishReason, 'stop');
+			assert.strictEqual(result.usage.promptTokens, 5);
+			assert.strictEqual(result.usage.completionTokens, 2);
+			const sent = JSON.parse(fetch.calls[0].init.body);
+			assert.strictEqual(sent.stream, false);
+			assert.deepStrictEqual(sent.messages, [{ role: 'user', content: 'hello' }]);
+		});
+
+		it('uses a messages array directly', async () => {
+			const fetch = mockFetch(() => chatResponse());
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'gpt-4o-mini' }, fetch);
+			await b.generate(
+				[
+					{ role: 'system', content: 'be brief' },
+					{ role: 'user', content: 'q' },
+				],
+				{ accounting: ACCOUNTING }
+			);
+			const sent = JSON.parse(fetch.calls[0].init.body);
+			assert.deepStrictEqual(sent.messages, [
+				{ role: 'system', content: 'be brief' },
+				{ role: 'user', content: 'q' },
+			]);
+		});
+
+		it("prepends 'system' string into messages on the object input variant", async () => {
+			const fetch = mockFetch(() => chatResponse());
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'gpt-4o-mini' }, fetch);
+			await b.generate(
+				{ messages: [{ role: 'user', content: 'q' }], system: 'be helpful' },
+				{ accounting: ACCOUNTING }
+			);
+			const sent = JSON.parse(fetch.calls[0].init.body);
+			assert.deepStrictEqual(sent.messages[0], { role: 'system', content: 'be helpful' });
+			assert.deepStrictEqual(sent.messages[1], { role: 'user', content: 'q' });
+		});
+
+		it('forwards tools to OpenAI in the correct shape', async () => {
+			const fetch = mockFetch(() => chatResponse());
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'gpt-4o-mini' }, fetch);
+			const tools = [
+				{ name: 'get_weather', description: 'get weather', parameters: { type: 'object', properties: {} } },
+			];
+			await b.generate({ messages: [{ role: 'user', content: 'q' }], tools }, { accounting: ACCOUNTING });
+			const sent = JSON.parse(fetch.calls[0].init.body);
+			assert.deepStrictEqual(sent.tools, [
+				{
+					type: 'function',
+					function: { name: 'get_weather', description: 'get weather', parameters: { type: 'object', properties: {} } },
+				},
+			]);
+		});
+
+		it('parses tool_calls from the response and exposes them on GenerateResult.toolCalls', async () => {
+			const fetch = mockFetch(() =>
+				chatResponse({
+					content: null,
+					toolCalls: [
+						{
+							id: 'call_abc',
+							type: 'function',
+							function: { name: 'get_weather', arguments: '{"location":"SF"}' },
+						},
+					],
+					finishReason: 'tool_calls',
+				})
+			);
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'gpt-4o-mini' }, fetch);
+			const result = await b.generate('q', { accounting: ACCOUNTING });
+			assert.strictEqual(result.output.finishReason, 'tool_calls');
+			assert.deepStrictEqual(result.output.toolCalls, [
+				{ id: 'call_abc', name: 'get_weather', arguments: { location: 'SF' } },
+			]);
+		});
+
+		it('drops tool calls with malformed JSON arguments', async () => {
+			const fetch = mockFetch(() =>
+				chatResponse({
+					toolCalls: [
+						{ id: 'call_ok', type: 'function', function: { name: 'ok', arguments: '{"a":1}' } },
+						{ id: 'call_bad', type: 'function', function: { name: 'bad', arguments: 'not-json' } },
+					],
+					finishReason: 'tool_calls',
+				})
+			);
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			const result = await b.generate('q', { accounting: ACCOUNTING });
+			assert.strictEqual(result.output.toolCalls.length, 1);
+			assert.strictEqual(result.output.toolCalls[0].id, 'call_ok');
+		});
+
+		it("maps responseFormat='json' to OpenAI's response_format json_object", async () => {
+			const fetch = mockFetch(() => chatResponse());
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			await b.generate('q', { accounting: ACCOUNTING, responseFormat: 'json' });
+			const sent = JSON.parse(fetch.calls[0].init.body);
+			assert.deepStrictEqual(sent.response_format, { type: 'json_object' });
+		});
+
+		it("maps responseFormat={ schema } to OpenAI's json_schema form", async () => {
+			const fetch = mockFetch(() => chatResponse());
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			const schema = { type: 'object', properties: { a: { type: 'string' } } };
+			await b.generate('q', { accounting: ACCOUNTING, responseFormat: { schema } });
+			const sent = JSON.parse(fetch.calls[0].init.body);
+			assert.deepStrictEqual(sent.response_format, {
+				type: 'json_schema',
+				json_schema: { name: 'output', schema, strict: true },
+			});
+		});
+
+		it('maps temperature and maxTokens to OpenAI fields', async () => {
+			const fetch = mockFetch(() => chatResponse());
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			await b.generate('q', { accounting: ACCOUNTING, temperature: 0.5, maxTokens: 100 });
+			const sent = JSON.parse(fetch.calls[0].init.body);
+			assert.strictEqual(sent.temperature, 0.5);
+			assert.strictEqual(sent.max_tokens, 100);
+		});
+
+		it("maps finish_reason='length' to finishReason='length'", async () => {
+			const fetch = mockFetch(() => chatResponse({ finishReason: 'length' }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			const result = await b.generate('q', { accounting: ACCOUNTING });
+			assert.strictEqual(result.output.finishReason, 'length');
+		});
+
+		it("maps finish_reason='content_filter' to finishReason='content_filter'", async () => {
+			const fetch = mockFetch(() => chatResponse({ finishReason: 'content_filter' }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			const result = await b.generate('q', { accounting: ACCOUNTING });
+			assert.strictEqual(result.output.finishReason, 'content_filter');
+		});
+
+		it('drops non-integer / non-finite token counts from usage', async () => {
+			const fetch = mockFetch(() => chatResponse({ usage: { prompt_tokens: NaN, completion_tokens: -3 } }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			const result = await b.generate('q', { accounting: ACCOUNTING });
+			assert.strictEqual(result.usage.promptTokens, undefined);
+			assert.strictEqual(result.usage.completionTokens, undefined);
+		});
+
+		it('throws when choices[0] is missing', async () => {
+			const fetch = mockFetch(() => jsonResponse({}));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			await assert.rejects(() => b.generate('q', { accounting: ACCOUNTING }), /missing choices\[0\]/);
+		});
+
+		it('throws when content is non-string', async () => {
+			const fetch = mockFetch(() => jsonResponse({ choices: [{ message: { role: 'assistant', content: 42 } }] }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			await assert.rejects(() => b.generate('q', { accounting: ACCOUNTING }), /content is not a string/);
+		});
+	});
+
+	describe('generateStream', () => {
+		it('yields a chunk per SSE event with deltaContent', async () => {
+			const fetch = mockFetch(() =>
+				sseResponse([
+					{ choices: [{ delta: { role: 'assistant' } }] },
+					{ choices: [{ delta: { content: 'hello ' } }] },
+					{ choices: [{ delta: { content: 'world' } }] },
+					{ choices: [{ delta: {}, finish_reason: 'stop' }] },
+				])
+			);
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'gpt-4o-mini' }, fetch);
+			const chunks = [];
+			for await (const c of b.generateStream('q', { accounting: ACCOUNTING })) chunks.push(c);
+			assert.deepStrictEqual(chunks[0], { deltaContent: 'hello ' });
+			assert.deepStrictEqual(chunks[1], { deltaContent: 'world' });
+			assert.deepStrictEqual(chunks[2], { finishReason: 'stop' });
+		});
+
+		it('sets stream:true on the request body', async () => {
+			const fetch = mockFetch(() => sseResponse([{ choices: [{ delta: {}, finish_reason: 'stop' }] }]));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			for await (const _c of b.generateStream('q', { accounting: ACCOUNTING })) {
+				/* drain */
+			}
+			const sent = JSON.parse(fetch.calls[0].init.body);
+			assert.strictEqual(sent.stream, true);
+		});
+
+		it('handles SSE events split across HTTP chunk boundaries', async () => {
+			const body = new ReadableStream({
+				start(controller) {
+					const enc = new TextEncoder();
+					controller.enqueue(enc.encode('data: {"choices":[{"delta":{"content":"hel'));
+					controller.enqueue(
+						enc.encode('lo"}}]}\n\ndata: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n')
+					);
+					controller.close();
+				},
+			});
+			const fetch = mockFetch(() => new Response(body, { status: 200 }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			const chunks = [];
+			for await (const c of b.generateStream('q', { accounting: ACCOUNTING })) chunks.push(c);
+			assert.strictEqual(chunks[0].deltaContent, 'hello');
+			assert.strictEqual(chunks[1].finishReason, 'stop');
+		});
+
+		it('terminates cleanly on [DONE] (any events after are ignored)', async () => {
+			const body = new ReadableStream({
+				start(controller) {
+					const enc = new TextEncoder();
+					controller.enqueue(enc.encode('data: {"choices":[{"delta":{"content":"a"}}]}\n\n'));
+					controller.enqueue(enc.encode('data: [DONE]\n\n'));
+					// content after [DONE] should not be yielded
+					controller.enqueue(enc.encode('data: {"choices":[{"delta":{"content":"ghost"}}]}\n\n'));
+					controller.close();
+				},
+			});
+			const fetch = mockFetch(() => new Response(body, { status: 200 }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			const chunks = [];
+			for await (const c of b.generateStream('q', { accounting: ACCOUNTING })) chunks.push(c);
+			assert.strictEqual(chunks.length, 1);
+			assert.strictEqual(chunks[0].deltaContent, 'a');
+		});
+
+		it('ignores SSE comment lines (lines starting with :)', async () => {
+			const body = new ReadableStream({
+				start(controller) {
+					const enc = new TextEncoder();
+					controller.enqueue(enc.encode(': openai-keep-alive\n\n'));
+					controller.enqueue(enc.encode('data: {"choices":[{"delta":{"content":"a"}}]}\n\n'));
+					controller.enqueue(enc.encode('data: [DONE]\n\n'));
+					controller.close();
+				},
+			});
+			const fetch = mockFetch(() => new Response(body, { status: 200 }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			const chunks = [];
+			for await (const c of b.generateStream('q', { accounting: ACCOUNTING })) chunks.push(c);
+			assert.strictEqual(chunks.length, 1);
+			assert.strictEqual(chunks[0].deltaContent, 'a');
+		});
+
+		it('throws OpenAIBackendError when an event payload is invalid JSON (static message; no upstream content leak)', async () => {
+			const body = new ReadableStream({
+				start(controller) {
+					controller.enqueue(new TextEncoder().encode('data: <html>oops</html>\n\n'));
+					controller.close();
+				},
+			});
+			const fetch = mockFetch(() => new Response(body, { status: 200 }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			try {
+				for await (const _c of b.generateStream('q', { accounting: ACCOUNTING })) {
+					/* no-op */
+				}
+				assert.fail('expected OpenAIBackendError');
+			} catch (err) {
+				assert.ok(err instanceof OpenAIBackendError);
+				assert.ok(!err.message.includes('<html>'));
+			}
+		});
+
+		it('caps the SSE buffer at 1 MiB without a complete event boundary', async () => {
+			const huge = 'x'.repeat((1 << 20) + 1);
+			const body = new ReadableStream({
+				start(controller) {
+					controller.enqueue(new TextEncoder().encode(huge));
+					controller.close();
+				},
+			});
+			const fetch = mockFetch(() => new Response(body, { status: 200 }));
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			await assert.rejects(async () => {
+				for await (const _c of b.generateStream('q', { accounting: ACCOUNTING })) {
+					/* no-op */
+				}
+			}, /SSE buffer exceeds/);
+		});
+	});
+
+	describe('generateStream — tool-call delta accumulation', () => {
+		it('assembles index-keyed deltas into a single finalized tool call', async () => {
+			const fetch = mockFetch(() =>
+				sseResponse([
+					{
+						choices: [
+							{
+								delta: {
+									role: 'assistant',
+									tool_calls: [
+										{ index: 0, id: 'call_abc', type: 'function', function: { name: 'get_weather', arguments: '' } },
+									],
+								},
+							},
+						],
+					},
+					{ choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '{"loc' } }] } }] },
+					{ choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: 'ation":' } }] } }] },
+					{ choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '"SF"}' } }] } }] },
+					{ choices: [{ delta: {}, finish_reason: 'tool_calls' }] },
+				])
+			);
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'gpt-4o-mini' }, fetch);
+			const chunks = [];
+			for await (const c of b.generateStream(
+				{ messages: [{ role: 'user', content: 'q' }] },
+				{ accounting: ACCOUNTING }
+			)) {
+				chunks.push(c);
+			}
+			const final = chunks[chunks.length - 1];
+			assert.strictEqual(final.finishReason, 'tool_calls');
+			assert.deepStrictEqual(final.deltaToolCalls, [
+				{ id: 'call_abc', name: 'get_weather', arguments: { location: 'SF' } },
+			]);
+		});
+
+		it('handles multiple tool calls in parallel via distinct indices', async () => {
+			const fetch = mockFetch(() =>
+				sseResponse([
+					{
+						choices: [
+							{
+								delta: {
+									role: 'assistant',
+									tool_calls: [
+										{ index: 0, id: 'a', type: 'function', function: { name: 'fn_a', arguments: '' } },
+										{ index: 1, id: 'b', type: 'function', function: { name: 'fn_b', arguments: '' } },
+									],
+								},
+							},
+						],
+					},
+					{ choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '{}' } }] } }] },
+					{ choices: [{ delta: { tool_calls: [{ index: 1, function: { arguments: '{"x":1}' } }] } }] },
+					{ choices: [{ delta: {}, finish_reason: 'tool_calls' }] },
+				])
+			);
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			const chunks = [];
+			for await (const c of b.generateStream(
+				{ messages: [{ role: 'user', content: 'q' }] },
+				{ accounting: ACCOUNTING }
+			)) {
+				chunks.push(c);
+			}
+			const final = chunks[chunks.length - 1];
+			assert.strictEqual(final.deltaToolCalls.length, 2);
+			assert.deepStrictEqual(final.deltaToolCalls[0], { id: 'a', name: 'fn_a', arguments: {} });
+			assert.deepStrictEqual(final.deltaToolCalls[1], { id: 'b', name: 'fn_b', arguments: { x: 1 } });
+		});
+
+		it('caps accumulated tool-call arguments at 1 MiB across events', async () => {
+			// One delta is < 1 MiB (so per-event SSE cap doesn't trip) but
+			// many of them push the cumulative argumentsBuf past the cap.
+			const half = 'x'.repeat(1 << 19); // 512 KiB
+			const fetch = mockFetch(() =>
+				sseResponse([
+					{
+						choices: [
+							{
+								delta: {
+									tool_calls: [{ index: 0, id: 'big', type: 'function', function: { name: 'fn', arguments: half } }],
+								},
+							},
+						],
+					},
+					{ choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: half } }] } }] },
+					{ choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: half } }] } }] },
+				])
+			);
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			await assert.rejects(async () => {
+				for await (const _c of b.generateStream(
+					{ messages: [{ role: 'user', content: 'q' }] },
+					{ accounting: ACCOUNTING }
+				)) {
+					/* drain */
+				}
+			}, /tool-call arguments exceed/);
+		});
+
+		it('drops streamed tool calls with malformed JSON arguments', async () => {
+			const fetch = mockFetch(() =>
+				sseResponse([
+					{
+						choices: [
+							{
+								delta: {
+									tool_calls: [
+										{ index: 0, id: 'a', type: 'function', function: { name: 'ok', arguments: '{"x":1}' } },
+										{ index: 1, id: 'b', type: 'function', function: { name: 'bad', arguments: 'not-json' } },
+									],
+								},
+							},
+						],
+					},
+					{ choices: [{ delta: {}, finish_reason: 'tool_calls' }] },
+				])
+			);
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			const chunks = [];
+			for await (const c of b.generateStream(
+				{ messages: [{ role: 'user', content: 'q' }] },
+				{ accounting: ACCOUNTING }
+			)) {
+				chunks.push(c);
+			}
+			const final = chunks[chunks.length - 1];
+			assert.strictEqual(final.deltaToolCalls.length, 1);
+			assert.strictEqual(final.deltaToolCalls[0].id, 'a');
+		});
+
+		it("maps streaming finish_reason='tool_calls' to finishReason='tool_calls'", async () => {
+			const fetch = mockFetch(() =>
+				sseResponse([
+					{
+						choices: [
+							{
+								delta: {
+									tool_calls: [{ index: 0, id: 'a', type: 'function', function: { name: 'fn', arguments: '{}' } }],
+								},
+							},
+						],
+					},
+					{ choices: [{ delta: {}, finish_reason: 'tool_calls' }] },
+				])
+			);
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			const chunks = [];
+			for await (const c of b.generateStream(
+				{ messages: [{ role: 'user', content: 'q' }] },
+				{ accounting: ACCOUNTING }
+			)) {
+				chunks.push(c);
+			}
+			assert.strictEqual(chunks[chunks.length - 1].finishReason, 'tool_calls');
+		});
+
+		it('flushes buffered tool calls even when the stream ends without a finish_reason', async () => {
+			// Some proxies / intermediaries drop the final event. Buffered tool
+			// calls should still surface so the caller doesn't lose them.
+			const fetch = mockFetch(() =>
+				sseResponse(
+					[
+						{
+							choices: [
+								{
+									delta: {
+										tool_calls: [
+											{
+												index: 0,
+												id: 'late',
+												type: 'function',
+												function: { name: 'fn', arguments: '{"x":2}' },
+											},
+										],
+									},
+								},
+							],
+						},
+					],
+					{ includeDone: false }
+				)
+			);
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			const chunks = [];
+			for await (const c of b.generateStream(
+				{ messages: [{ role: 'user', content: 'q' }] },
+				{ accounting: ACCOUNTING }
+			)) {
+				chunks.push(c);
+			}
+			const final = chunks[chunks.length - 1];
+			assert.ok(final.deltaToolCalls);
+			assert.strictEqual(final.deltaToolCalls[0].id, 'late');
+		});
+	});
+
+	describe('AbortSignal propagation', () => {
+		it('passes caller signal straight through when no timeout configured', async () => {
+			const ctrl = new AbortController();
+			let seenSignal;
+			const fetch = mockFetch(({ init }) => {
+				seenSignal = init.signal;
+				return jsonResponse({ data: [{ embedding: [0.1] }] });
+			});
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+			await b.embed('x', { accounting: ACCOUNTING, signal: ctrl.signal });
+			assert.strictEqual(seenSignal, ctrl.signal);
+		});
+
+		it('composes caller signal with per-call timeout via AbortSignal.any', async () => {
+			const ctrl = new AbortController();
+			let seenSignal;
+			const fetch = mockFetch(({ init }) => {
+				seenSignal = init.signal;
+				return jsonResponse({ data: [{ embedding: [0.1] }] });
+			});
+			const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm', requestTimeoutMs: 10000 }, fetch);
+			await b.embed('x', { accounting: ACCOUNTING, signal: ctrl.signal });
+			assert.ok(seenSignal instanceof AbortSignal);
+			assert.notStrictEqual(seenSignal, ctrl.signal);
+		});
+	});
+});
+
+describe('registerOpenAIBackend', () => {
+	beforeEach(() => clearRegistry());
+
+	it('registers as an embedding backend under the logical name', () => {
+		registerOpenAIBackend({
+			logicalName: 'high-quality',
+			kind: 'embedding',
+			config: { apiKey: API_KEY, model: 'text-embedding-3-large' },
+		});
+		const b = resolveEmbedding('high-quality');
+		assert.strictEqual(b.name, 'openai');
+	});
+
+	it('registers as a generative backend under the logical name', () => {
+		registerOpenAIBackend({
+			logicalName: 'default',
+			kind: 'generative',
+			config: { apiKey: API_KEY, model: 'gpt-4o-mini' },
+		});
+		const b = resolveGenerative('default');
+		assert.strictEqual(b.name, 'openai');
+	});
+});

--- a/unitTests/resources/models/bootstrap.test.js
+++ b/unitTests/resources/models/bootstrap.test.js
@@ -94,4 +94,83 @@ describe('bootstrapModels', () => {
 		assert.strictEqual(resolveGenerative('default').name, 'ollama');
 		assert.strictEqual(resolveGenerative('fast').name, 'ollama');
 	});
+
+	// #630 (Phase 3 of #510): openai-specific bootstrap behavior.
+	describe('openai backend (#630)', () => {
+		const ENV_VAR = '__HARPER_TEST_BOOTSTRAP_OPENAI__';
+
+		afterEach(() => {
+			delete process.env[ENV_VAR];
+		});
+
+		it('registers an openai entry under its logical name', () => {
+			bootstrapModels({
+				models: {
+					generative: {
+						default: { backend: 'openai', apiKey: 'sk-test', model: 'gpt-4o-mini' },
+					},
+				},
+			});
+			assert.strictEqual(resolveGenerative('default').name, 'openai');
+		});
+
+		it('resolves ${ENV_VAR} apiKey before constructing the backend', () => {
+			process.env[ENV_VAR] = 'sk-real-key';
+			bootstrapModels({
+				models: {
+					generative: {
+						default: { backend: 'openai', apiKey: `\${${ENV_VAR}}`, model: 'gpt-4o-mini' },
+					},
+				},
+			});
+			// Successful registration proves the env var resolved (otherwise the
+			// backend constructor's `requireApiKey` would throw on the literal
+			// placeholder).
+			assert.strictEqual(resolveGenerative('default').name, 'openai');
+		});
+
+		it('logs error + skips when ${ENV_VAR} apiKey is unset', () => {
+			// ENV_VAR is intentionally not set in this test; the placeholder
+			// stays literal and the backend constructor throws.
+			bootstrapModels({
+				models: {
+					generative: {
+						default: { backend: 'openai', apiKey: `\${${ENV_VAR}}`, model: 'gpt-4o-mini' },
+					},
+				},
+			});
+			// Backend was not registered.
+			assert.throws(() => resolveGenerative('default'), { name: 'ModelBackendNotFoundError' });
+		});
+
+		it('logs error + skips when apiKey is missing entirely', () => {
+			bootstrapModels({
+				models: {
+					generative: {
+						default: { backend: 'openai', model: 'gpt-4o-mini' },
+					},
+				},
+			});
+			assert.throws(() => resolveGenerative('default'), { name: 'ModelBackendNotFoundError' });
+		});
+
+		it('registers ollama + openai entries side by side', () => {
+			bootstrapModels({
+				models: {
+					embedding: {
+						'default': { backend: 'ollama', model: 'nomic-embed-text' },
+						'high-quality': { backend: 'openai', apiKey: 'sk-test', model: 'text-embedding-3-large' },
+					},
+					generative: {
+						fast: { backend: 'ollama', model: 'llama3.2' },
+						default: { backend: 'openai', apiKey: 'sk-test', model: 'gpt-4o-mini' },
+					},
+				},
+			});
+			assert.strictEqual(resolveEmbedding('default').name, 'ollama');
+			assert.strictEqual(resolveEmbedding('high-quality').name, 'openai');
+			assert.strictEqual(resolveGenerative('fast').name, 'ollama');
+			assert.strictEqual(resolveGenerative('default').name, 'openai');
+		});
+	});
 });

--- a/unitTests/utility/expandEnvVar.test.js
+++ b/unitTests/utility/expandEnvVar.test.js
@@ -1,0 +1,145 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { expandEnvVar, expandEnvVarsDeep, isUnresolvedEnvVarPlaceholder } = require('#src/utility/expandEnvVar');
+
+describe('expandEnvVar', () => {
+	const SET_VAR = '__HARPER_TEST_EXPAND_SET__';
+	const UNSET_VAR = '__HARPER_TEST_EXPAND_UNSET__';
+
+	before(() => {
+		process.env[SET_VAR] = 'expanded-value';
+		delete process.env[UNSET_VAR];
+	});
+	after(() => {
+		delete process.env[SET_VAR];
+	});
+
+	describe('expandEnvVar (single value)', () => {
+		it(`resolves \${${SET_VAR}} to the env value`, () => {
+			assert.strictEqual(expandEnvVar(`\${${SET_VAR}}`), 'expanded-value');
+		});
+
+		it('returns the original string when the env var is unset', () => {
+			assert.strictEqual(expandEnvVar(`\${${UNSET_VAR}}`), `\${${UNSET_VAR}}`);
+		});
+
+		it('returns plain strings unchanged', () => {
+			assert.strictEqual(expandEnvVar('literal-string'), 'literal-string');
+		});
+
+		it('does NOT expand partial-string placeholders (whole-string only)', () => {
+			assert.strictEqual(expandEnvVar(`http://\${${SET_VAR}}:9926`), `http://\${${SET_VAR}}:9926`);
+		});
+
+		it('treats placeholders with internal whitespace as literals (not lookups)', () => {
+			// Env var names can't contain whitespace; treat such strings as
+			// literal values rather than failed lookups that confuse downstream
+			// "is this an unresolved placeholder?" checks.
+			assert.strictEqual(expandEnvVar('${MY KEY}'), '${MY KEY}');
+		});
+
+		it('returns non-string values unchanged', () => {
+			assert.strictEqual(expandEnvVar(123), 123);
+			assert.strictEqual(expandEnvVar(true), true);
+			assert.strictEqual(expandEnvVar(null), null);
+			assert.strictEqual(expandEnvVar(undefined), undefined);
+		});
+
+		it('uses env value even when it is the empty string (operator may want empty default)', () => {
+			process.env[SET_VAR] = '';
+			try {
+				assert.strictEqual(expandEnvVar(`\${${SET_VAR}}`), '');
+			} finally {
+				process.env[SET_VAR] = 'expanded-value';
+			}
+		});
+	});
+
+	describe('expandEnvVarsDeep (recursive)', () => {
+		// Helper: deep value-equal comparison that ignores prototype shape.
+		// `expandEnvVarsDeep` returns null-prototype objects (anti-pollution
+		// defense); JSON.parse(JSON.stringify(...)) round-trips to plain
+		// objects for assertion convenience without leaking prototype-pollution
+		// gadgets (JSON parses don't honor `__proto__` setters either).
+		const plain = (value) => JSON.parse(JSON.stringify(value));
+
+		it('walks plain objects, expanding string leaves', () => {
+			const input = {
+				backend: 'openai',
+				apiKey: `\${${SET_VAR}}`,
+				nested: { model: 'gpt-4o', baseUrl: 'https://api.openai.com/v1' },
+			};
+			assert.deepStrictEqual(plain(expandEnvVarsDeep(input)), {
+				backend: 'openai',
+				apiKey: 'expanded-value',
+				nested: { model: 'gpt-4o', baseUrl: 'https://api.openai.com/v1' },
+			});
+		});
+
+		it('walks arrays, expanding each element', () => {
+			const input = [`\${${SET_VAR}}`, 'literal', { a: `\${${SET_VAR}}` }];
+			assert.deepStrictEqual(plain(expandEnvVarsDeep(input)), ['expanded-value', 'literal', { a: 'expanded-value' }]);
+		});
+
+		it('leaves placeholders pointing at unset env vars unchanged', () => {
+			const input = { apiKey: `\${${UNSET_VAR}}`, model: 'gpt-4o' };
+			assert.deepStrictEqual(plain(expandEnvVarsDeep(input)), {
+				apiKey: `\${${UNSET_VAR}}`,
+				model: 'gpt-4o',
+			});
+		});
+
+		it('passes through scalars unchanged', () => {
+			assert.strictEqual(expandEnvVarsDeep(42), 42);
+			assert.strictEqual(expandEnvVarsDeep(true), true);
+			assert.strictEqual(expandEnvVarsDeep(null), null);
+		});
+
+		it('does not introduce shared references between input and output (object case)', () => {
+			const input = { apiKey: `\${${SET_VAR}}`, nested: { x: 1 } };
+			const output = expandEnvVarsDeep(input);
+			assert.notStrictEqual(output, input);
+			assert.notStrictEqual(output.nested, input.nested);
+		});
+
+		it('does not pollute Object.prototype via __proto__ keys in input', () => {
+			// The reusable framing of this util invites callers to feed it
+			// untrusted-source objects (e.g., JSON-from-HTTP). Defending here
+			// keeps that future caller safe.
+			const malicious = JSON.parse('{"__proto__": {"polluted": true}, "ok": "fine"}');
+			const output = expandEnvVarsDeep(malicious);
+			// Walk the prototype chain explicitly: nothing should have been
+			// added to Object.prototype.
+			assert.strictEqual({}.polluted, undefined);
+			// The key is still preserved as an own property on the output
+			// (since we used Object.create(null), no prototype-setter shenanigans).
+			assert.ok(Object.prototype.hasOwnProperty.call(output, '__proto__'));
+			assert.strictEqual(output.ok, 'fine');
+		});
+	});
+
+	describe('isUnresolvedEnvVarPlaceholder', () => {
+		it('returns true for a literal ${VAR_NAME} string', () => {
+			assert.strictEqual(isUnresolvedEnvVarPlaceholder('${OPENAI_API_KEY}'), true);
+		});
+
+		it('returns false for a real string value', () => {
+			assert.strictEqual(isUnresolvedEnvVarPlaceholder('sk-real-key'), false);
+		});
+
+		it('returns false for partial-string placeholders (not what expandEnvVar matches)', () => {
+			assert.strictEqual(isUnresolvedEnvVarPlaceholder('http://${HOST}:9926'), false);
+		});
+
+		it('returns false for non-string values', () => {
+			assert.strictEqual(isUnresolvedEnvVarPlaceholder(undefined), false);
+			assert.strictEqual(isUnresolvedEnvVarPlaceholder(null), false);
+			assert.strictEqual(isUnresolvedEnvVarPlaceholder(123), false);
+		});
+
+		it('returns false for placeholders containing a space (not a valid env var name)', () => {
+			assert.strictEqual(isUnresolvedEnvVarPlaceholder('${VAR NAME}'), false);
+		});
+	});
+});

--- a/unitTests/validation/configValidator.test.js
+++ b/unitTests/validation/configValidator.test.js
@@ -487,5 +487,106 @@ describe('Test configValidator module', () => {
 			const result = configValidator(config, true);
 			expect(result.error).to.be.undefined;
 		});
+
+		// #630 (Phase 3): openai-specific discriminated schema.
+		describe('openai backend', () => {
+			it('accepts an openai entry with apiKey + model', () => {
+				const config = baseConfig();
+				config.models = {
+					generative: {
+						default: { backend: 'openai', apiKey: 'sk-test', model: 'gpt-4o-mini' },
+					},
+				};
+				const result = configValidator(config, true);
+				expect(result.error).to.be.undefined;
+			});
+
+			it('accepts a ${ENV_VAR} placeholder as the apiKey value (resolved at bootstrap)', () => {
+				const config = baseConfig();
+				config.models = {
+					generative: {
+						default: { backend: 'openai', apiKey: '${OPENAI_API_KEY}', model: 'gpt-4o-mini' },
+					},
+				};
+				const result = configValidator(config, true);
+				expect(result.error).to.be.undefined;
+			});
+
+			it('accepts baseUrl and organization on openai entries', () => {
+				const config = baseConfig();
+				config.models = {
+					generative: {
+						azure: {
+							backend: 'openai',
+							apiKey: 'sk-test',
+							model: 'gpt-4o',
+							baseUrl: 'https://my-azure.openai.azure.com/openai/v1',
+							organization: 'org-abc',
+						},
+					},
+				};
+				const result = configValidator(config, true);
+				expect(result.error).to.be.undefined;
+			});
+
+			it('rejects openai entry missing apiKey', () => {
+				const config = baseConfig();
+				config.models = {
+					generative: { default: { backend: 'openai', model: 'gpt-4o-mini' } },
+				};
+				const result = configValidator(config, true);
+				expect(result.error).to.not.be.undefined;
+				expect(result.error.message).to.include('apiKey');
+			});
+
+			it('rejects ollama-specific field (host) on an openai entry', () => {
+				const config = baseConfig();
+				config.models = {
+					generative: {
+						default: { backend: 'openai', apiKey: 'sk-test', model: 'gpt-4o-mini', host: 'oops' },
+					},
+				};
+				const result = configValidator(config, true);
+				expect(result.error).to.not.be.undefined;
+				expect(result.error.message).to.include('host');
+			});
+
+			it('rejects openai-specific field (apiKey) on an ollama entry', () => {
+				const config = baseConfig();
+				config.models = {
+					generative: {
+						default: { backend: 'ollama', model: 'm', apiKey: 'wrong-backend' },
+					},
+				};
+				const result = configValidator(config, true);
+				expect(result.error).to.not.be.undefined;
+				expect(result.error.message).to.include('apiKey');
+			});
+
+			it('allows ollama and openai entries side by side', () => {
+				const config = baseConfig();
+				config.models = {
+					embedding: {
+						'default': { backend: 'ollama', model: 'nomic-embed-text' },
+						'high-quality': { backend: 'openai', apiKey: 'sk-test', model: 'text-embedding-3-large' },
+					},
+					generative: {
+						default: { backend: 'openai', apiKey: 'sk-test', model: 'gpt-4o-mini' },
+						fast: { backend: 'ollama', model: 'llama3.2' },
+					},
+				};
+				const result = configValidator(config, true);
+				expect(result.error).to.be.undefined;
+			});
+
+			it('passes through an unknown backend (bootstrap handles at runtime)', () => {
+				const config = baseConfig();
+				config.models = {
+					generative: { default: { backend: 'future-backend', model: 'whatever', anyField: 'goes' } },
+				};
+				const result = configValidator(config, true);
+				expect(result.error).to.be.undefined;
+			});
+		});
 	});
 });

--- a/utility/expandEnvVar.ts
+++ b/utility/expandEnvVar.ts
@@ -1,0 +1,110 @@
+/**
+ * Environment-variable expansion for config-loaded values.
+ *
+ * Harper's config parser does not expand `${VAR}` placeholders itself — the
+ * `harperdb-config.yaml` value lands in memory verbatim. Component code that
+ * needs to support env-var indirection (secrets, host overrides, etc.)
+ * applies these helpers to its own config entries.
+ *
+ * The pattern matches the convention established by the OAuth component
+ * (`@harperfast/oauth`'s `src/lib/config.ts`); kept identical so operator
+ * documentation and config snippets carry over verbatim.
+ *
+ * Matching rules:
+ * - Only **whole-string** `${VAR_NAME}` placeholders match. Partial expansion
+ *   (e.g. `'http://${HOST}:9926'`) is NOT supported by design — keeps the
+ *   substitution boundary unambiguous and avoids accidental injection into
+ *   structured values.
+ * - When the env var is undefined, the **original placeholder string is
+ *   returned unchanged**. Callers detect missing values via downstream
+ *   required-field checks (a `${VAR}` literal won't satisfy "non-empty string"
+ *   contracts the same way a real key would).
+ * - Non-string values pass through unchanged.
+ */
+
+/**
+ * Single shared predicate. Both `expandEnvVar` and `isUnresolvedEnvVarPlaceholder`
+ * must agree on what counts as a placeholder — otherwise an entry can sail past
+ * one check and trip on the other, producing a confusing downstream error.
+ *
+ * A value qualifies when it's a whole-string `${VAR_NAME}` with no internal
+ * whitespace (real shell env-var names disallow whitespace; rejecting it here
+ * means `'${MY KEY}'` is treated as a literal value rather than a botched
+ * lookup that always returns undefined).
+ */
+function looksLikePlaceholder(value: unknown): value is string {
+	if (typeof value !== 'string' || !value.startsWith('${') || !value.endsWith('}')) return false;
+	return !value.slice(2, -1).includes(' ');
+}
+
+/**
+ * Expand a single value: returns `process.env[VAR_NAME]` if `value` is exactly
+ * `${VAR_NAME}` and the env var is defined; returns `value` unchanged otherwise.
+ *
+ * @example
+ * expandEnvVar('${OPENAI_API_KEY}') // process.env.OPENAI_API_KEY or '${OPENAI_API_KEY}' if unset
+ * expandEnvVar('literal')           // 'literal'
+ * expandEnvVar(123)                 // 123
+ * expandEnvVar(undefined)           // undefined
+ */
+export function expandEnvVar<T>(value: T): T {
+	if (looksLikePlaceholder(value)) {
+		const envVar = value.slice(2, -1);
+		const envValue = process.env[envVar];
+		// Use the env value when defined (even if empty string — operators may
+		// legitimately want to set an empty default).
+		return (envValue !== undefined ? envValue : value) as T;
+	}
+	return value;
+}
+
+/**
+ * Recursively expand `${VAR_NAME}` placeholders on every string leaf of a
+ * value. Walks arrays and plain objects; bails on non-plain values.
+ *
+ * Used when a structured config block (e.g. `models.generative.<name>`) has
+ * multiple string fields that may carry env-var placeholders, so callers
+ * don't have to enumerate them.
+ *
+ * @example
+ * expandEnvVarsDeep({ backend: 'openai', apiKey: '${OPENAI_API_KEY}' })
+ * // → { backend: 'openai', apiKey: 'sk-...' }   (if env var set)
+ */
+export function expandEnvVarsDeep<T>(value: T): T {
+	if (typeof value === 'string') {
+		return expandEnvVar(value);
+	}
+	if (Array.isArray(value)) {
+		return value.map(expandEnvVarsDeep) as unknown as T;
+	}
+	if (value !== null && typeof value === 'object') {
+		// `Object.create(null)` avoids prototype-pollution gadgets via a
+		// `__proto__` / `constructor` / `prototype` key. The YAML parser this
+		// helper is initially used against produces plain objects without
+		// these keys, but the helper is documented as reusable; defending
+		// here makes "feed a JSON-from-HTTP payload through this" safe.
+		const expanded = Object.create(null) as Record<string, unknown>;
+		for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+			expanded[key] = expandEnvVarsDeep(item);
+		}
+		return expanded as T;
+	}
+	return value;
+}
+
+/**
+ * Returns `true` when `value` is a literal `${VAR_NAME}` placeholder string —
+ * i.e., a value that `expandEnvVar` would have substituted if the env var
+ * were defined but didn't, leaving the original unchanged.
+ *
+ * Useful for distinguishing "operator wrote a literal placeholder by mistake"
+ * (loud, surface to logs) from "operator set the value directly" (proceed).
+ *
+ * @example
+ * isUnresolvedEnvVarPlaceholder('${OPENAI_API_KEY}') // true
+ * isUnresolvedEnvVarPlaceholder('sk-real-key')        // false
+ * isUnresolvedEnvVarPlaceholder('${FOO}-suffix')      // false (partial; not matched by expandEnvVar)
+ */
+export function isUnresolvedEnvVarPlaceholder(value: unknown): boolean {
+	return looksLikePlaceholder(value);
+}

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -66,28 +66,52 @@ export function configValidator(configJson, skipFsValidation = false) {
 		privateKey: pemFileConstraints,
 	});
 
-	// Models — sub-issue #629 (Phase 2) lands ollama. The Joi schema asserts the
-	// common envelope (logical-name keys + required `backend` discriminator) and
-	// the v1 fields. Presence-based enablement: the registry is populated iff
-	// `models` is present in config.
+	// Models — `models:` block opts a deployment into the per-backend registry.
+	// Per-backend shape is validated by a discriminated alternative on the
+	// `backend` field. Phase 2 (#629) lands ollama; Phase 3 (#630) lands openai.
 	//
-	// `.unknown(false)` is intentional: `configValidator` calls `validate(...)`
-	// with `allowUnknown: true`, which propagates into nested schemas by default.
-	// A typo like `bakend: ollama` would otherwise pass validation and reach
-	// `bootstrapModels` as an entry with `backend: undefined` — silently skipped
-	// with a warn. Opting out here turns those typos into boot-blocking errors.
-	// Phase 3+ backends needing extra fields can switch to a per-backend
-	// discriminated schema (`Joi.alternatives().conditional('backend', ...)`).
-	const modelEntrySchema = Joi.object({
-		backend: string.required(),
-		host: string.optional(),
+	// `.unknown(false)` on each known backend's schema turns field-name typos
+	// (`bakend: ollama`, `hsot: ...`) into boot-blocking validation errors.
+	// Without it, Joi's top-level `allowUnknown: true` propagates and typos
+	// silently survive into bootstrap. Unknown backend types (anything not in
+	// the `switch` list) fall through to a permissive schema so future Harper
+	// versions or third-party components can register their own backends
+	// without core schema edits — `bootstrapModels` logs+skips at runtime.
+	//
+	// `requestTimeoutMs: min(1)` (not `min(0)`) so the meaning is unambiguous:
+	// omit the field for "no timeout". `0` would validate but `composeSignal`
+	// treats it as "no timeout" via `if (!timeoutMs)`, surprising a test that
+	// sets 0 to mean "fail immediately".
+	const commonEntryFields = {
 		model: string.optional(),
-		// `min(1)` (not `min(0)`) so the meaning is unambiguous: omit the field
-		// for "no timeout". `0` would validate but `composeSignal` treats it as
-		// "no timeout" via `if (!timeoutMs)`, surprising a test that sets 0 to
-		// mean "fail immediately".
 		requestTimeoutMs: number.min(1).optional(),
+	};
+	const ollamaEntrySchema = Joi.object({
+		backend: string.valid('ollama').required(),
+		host: string.optional(),
+		...commonEntryFields,
 	}).unknown(false);
+	const openaiEntrySchema = Joi.object({
+		backend: string.valid('openai').required(),
+		// `apiKey` may be a literal secret or a `${ENV_VAR}` placeholder; both
+		// are syntactically strings. `bootstrap.ts` runs `expandEnvVarsDeep`
+		// before construction; the backend rejects unresolved placeholders
+		// with an explicit error pointing at the env-var name.
+		apiKey: string.required(),
+		baseUrl: string.optional(),
+		organization: string.optional(),
+		...commonEntryFields,
+	}).unknown(false);
+	const unknownBackendEntrySchema = Joi.object({
+		backend: string.required(),
+	}).unknown(true);
+	const modelEntrySchema = Joi.alternatives().conditional('.backend', {
+		switch: [
+			{ is: 'ollama', then: ollamaEntrySchema },
+			{ is: 'openai', then: openaiEntrySchema },
+		],
+		otherwise: unknownBackendEntrySchema,
+	});
 	const modelsSchema = Joi.object({
 		embedding: Joi.object().pattern(Joi.string(), modelEntrySchema).optional(),
 		generative: Joi.object().pattern(Joi.string(), modelEntrySchema).optional(),


### PR DESCRIPTION
## Summary

Phase 3 of #510 — second real `ModelBackend`, against OpenAI's HTTP API
(or any OpenAI-compatible endpoint via `baseUrl` override). Validates the
Phase 1 (#628) interface against a real provider with native tool-call
support and a different streaming wire format from Ollama.

Also lands `toolMode: 'return'` end-to-end: caller passes
`tools: ToolDef[]`, OpenAI returns tool-call requests in the
`GenerateResult` or `GenerateChunk.deltaToolCalls`, caller resolves
externally. The harder half (`toolMode: 'auto'` orchestration) is
split to #612.

Closes #630
Tracking: #510

> [!NOTE]
> Opened as **Draft** until CI clears, per the engineering-guidelines
> step 16 (`harper-engineering-guidelines/SKILL.md`). Specific reviewer
> assignment from the expertise matrix after Draft → Ready.

## What ships

- `utility/expandEnvVar.ts` — new reusable env-var expansion utility
  (`expandEnvVar`, `expandEnvVarsDeep`, `isUnresolvedEnvVarPlaceholder`).
  Whole-string `${VAR_NAME}` placeholders → `process.env[VAR_NAME]`.
  Matches the convention from `@harperfast/oauth`'s config loader.
  `Object.create(null)` accumulator for prototype-pollution defense.
- `components/openai/index.ts` — `OpenAIBackend implements ModelBackend`
  over native `fetch` (no SDK dep). Embed via `/embeddings`, generate
  via `/chat/completions`, stream via SSE. Tool-call support: forwards
  `GenerateInput.tools` as OpenAI's `tools` parameter; index-keyed
  delta accumulator yields each tool call once when complete.
- `resources/models/bootstrap.ts` — adds `openai` to the factory map.
  Runs `expandEnvVarsDeep(entry)` before factory dispatch. Enumerates
  known backends in the "unknown backend, skipping" error log so
  operators can spot value-name typos (`backend: 'openi'`). Warns when
  an entry has a literal `apiKey` (not wrapped in `${VAR}`) —
  surfaces the secret-on-disk anti-pattern at boot.
- `validation/configValidator.ts` — switches `modelEntrySchema` from
  flat to discriminated `Joi.alternatives().conditional('.backend', ...)`.
  `ollama` and `openai` get tight schemas with `.unknown(false)` so
  cross-backend field typos block boot. Unknown backends fall through
  to a permissive schema so future backends pass validation; bootstrap
  logs+skips at runtime.

## Why native fetch, not the `openai` SDK

The official SDK is ~5MB with transitive dependencies that ship with
every Harper install regardless of whether anyone uses model APIs.
Native `fetch` is ~300 lines of clean translation code, the OpenAI
wire surface we touch has been stable for 2+ years, and we don't
need the SDK's auto-retry / per-request key rotation / telemetry
features. Sets the precedent for #633 anthropic (also bearer auth).
Bedrock will need an SDK for SigV4 signing — that's a Phase 6 call.

## Secrets handling (sets precedent for #633)

```yaml
models:
  generative:
    default:
      backend: openai
      model: gpt-4o-mini
      apiKey: ${OPENAI_API_KEY}     # whole-string ${VAR} placeholder
```

`bootstrapModels` runs `expandEnvVarsDeep` on the entry before passing
it to the factory. Backend constructors detect unresolved placeholders
(env var unset) and throw a pointed "set the matching env var" error
rather than waiting for a 401 from the first request.

A literal `apiKey: 'sk-...'` (not wrapped in `${VAR}`) is also accepted
but logs a `warn` at boot: secrets in `harperdb-config.yaml` land on
disk, in backups, and depending on deployment in replicated config —
the `${VAR}` indirection is the documented pattern.

## Pre-PR verifier cadence

Per the agreed cadence for this series:
- `deep-review` single-pass × 3 parallel agents (api / concurrency / config).
  Surfaced 8 findings total: 0 blockers, all Tier 4–5.
  - **5 fixed in this PR:** tool-call arguments cap, log on malformed
    tool-call drop, `MAX_SSE_*` rename, OpenAI `error.message`
    extraction with cap, `Object.create(null)` accumulator.
  - **3 also fixed:** enumerate known backends in unknown-backend log,
    align whitespace check between `expandEnvVar` and
    `isUnresolvedEnvVarPlaceholder`, warn on literal-credential at boot.
- External cross-model pass: deferred to PR-time GitHub workflow
  (`claude` + claude-bot inline). Per Phase 2 lessons (agy auth /
  print-mode + Gemini CLI both hang in non-interactive Claude
  sessions), the deep-review skill's domain agents are the productive
  substrate.

## Files

| Path | Change |
|---|---|
| `utility/expandEnvVar.ts` | new — reusable env-var expansion |
| `unitTests/utility/expandEnvVar.test.js` | new — 18 tests |
| `components/openai/index.ts` | new — `OpenAIBackend` + `registerOpenAIBackend` |
| `unitTests/components/openai/index.test.js` | new — ~50 unit tests with mocked `fetch` |
| `resources/models/bootstrap.ts` | + openai factory + `expandEnvVarsDeep` + enum-on-unknown log + literal-credential warn |
| `unitTests/resources/models/bootstrap.test.js` | + 5 openai-specific tests |
| `validation/configValidator.ts` | flat → discriminated schema (ollama / openai / unknown) |
| `unitTests/validation/configValidator.test.js` | + 7 openai-schema tests |
| `integrationTests/server/openai-backend.test.ts` | new — gated on `OPENAI_API_KEY` |

## Acceptance criteria

- [x] `OpenAIBackend` implements `ModelBackend` per Phase 1's interface
- [x] `harper.models.embed()` with `backend: openai` produces a vector
- [x] `harper.models.generate()` produces a completion
- [x] `harper.models.generateStream()` yields `GenerateChunk` per Phase 1's contract
- [x] `toolMode: 'return'` end-to-end (caller→OpenAI tools mapping; OpenAI tool-calls→`GenerateResult.toolCalls` / `GenerateChunk.deltaToolCalls`)
- [x] `responseFormat: 'text' | 'json' | { schema }` maps to OpenAI's `response_format`
- [x] Per-call accounting: `backend: 'openai'`, model, token counts, latency
- [x] `AbortSignal` cancels in-flight requests
- [x] `baseUrl` override works (verified via mock for Azure/Together/OpenRouter/vLLM shape)
- [x] Unit tests cover translation logic; integration test runs against real OpenAI behind env gate
- [ ] CI green across full matrix (Draft → wait for CI → Ready)

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint:required` clean
- [x] `npx prettier --check .` clean
- [x] 209 unit tests pass locally (Node 24)
- [x] Phase 1 + 2 model tests still pass (no regression)
- [ ] CI green across full matrix
- [ ] Manual smoke against real OpenAI with `OPENAI_API_KEY` set

## Out of scope (per #630)

- `toolMode: 'auto'` orchestration — split to #612
- Anthropic / Bedrock backends — #633
- OpenAI batch API / Assistants / Files / Audio / Images
- Prompt caching (Anthropic-style)
- Client-side retry / backoff (caller decides)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)