### PR TITLE
feat(models): Phase 6 — anthropic + bedrock backends

### DIFF
--- a/components/anthropic/index.ts
+++ b/components/anthropic/index.ts
@@ -1,0 +1,547 @@
+/**
+ * Anthropic backend (#633, Phase 6 of #510).
+ *
+ * Implements `ModelBackend` against the Anthropic HTTP API. Native `fetch` —
+ * no SDK dependency, consistent with `components/openai/`. Exports
+ * `AnthropicBackend` directly for tests and `registerAnthropicBackend(...)`
+ * for the YAML→registry boot bridge.
+ *
+ * `embed` is not implemented (Anthropic doesn't ship an embedding API);
+ * `capabilities()` advertises `embed: false` and Phase 1's `Models.embed`
+ * throws `ModelCapabilityError` before reaching this backend.
+ *
+ * Key differences from OpenAI:
+ * - Auth header is `x-api-key`, not `Authorization: Bearer`.
+ * - `system` is a top-level request field, not a message role.
+ * - `max_tokens` is required (not optional); defaults to 4096 when caller
+ *   doesn't supply `opts.maxTokens`.
+ * - Tool calls arrive as content blocks (`type: 'tool_use'`) inline with
+ *   text blocks, not in a separate `tool_calls` field.
+ * - Streaming uses named SSE events (`message_start`, `content_block_delta`,
+ *   `message_delta`, etc.); we dispatch on `data.type` rather than the
+ *   `event:` line header.
+ */
+import { setGenerative } from '../../resources/models/backendRegistry.ts';
+import {
+	assignFiniteTokenCount,
+	composeSignal,
+	normalizeOrigin,
+	parseJsonResponse,
+	requireCredential,
+	requireModel,
+} from '../../resources/models/backendHelpers.ts';
+import { ServerError } from '../../utility/errors/hdbError.ts';
+import harperLogger from '../../utility/logging/harper_logger.ts';
+import type {
+	BackendOpts,
+	GenerateChunk,
+	GenerateInput,
+	GenerateOpts,
+	GenerateResult,
+	Message,
+	ModelBackend,
+	ModelCallResult,
+	ModelCapabilities,
+	ToolCall,
+	ToolDef,
+	TokenUsage,
+} from '../../resources/models/types.ts';
+
+const DEFAULT_BASE_URL = 'https://api.anthropic.com';
+const ANTHROPIC_API_VERSION = '2023-06-01';
+// Default `max_tokens` when caller doesn't supply one. Anthropic requires this
+// field on every request; 4096 is a reasonable upper bound for typical chat
+// responses (well under Claude 3.x's per-model limit of 8192–32768).
+const DEFAULT_MAX_TOKENS = 4096;
+// Per-event SSE buffer cap. Same shape as `components/openai/index.ts`.
+const MAX_SSE_BUFFER_CHARS = 1 << 20;
+// Per-tool-call accumulator cap during streaming.
+const MAX_TOOL_CALL_ARGS_CHARS = 1 << 20;
+// Cap for upstream `error.message` we surface to operators.
+const MAX_UPSTREAM_ERROR_MESSAGE_CHARS = 500;
+
+const log = harperLogger.forComponent('anthropic').conditional;
+
+export type AnthropicBackendKind = 'generative';
+
+export interface AnthropicBackendConfig {
+	apiKey?: string;
+	model?: string;
+	baseUrl?: string;
+	requestTimeoutMs?: number;
+}
+
+/**
+ * `ModelBackend` for Anthropic's Messages API.
+ *
+ * - `generate` → `POST {baseUrl}/v1/messages` (non-streaming)
+ * - `generateStream` → same with `stream: true`; SSE wire format
+ * - `embed` → not implemented; capability negotiation rejects the call
+ *
+ * `tools: true` — Anthropic has first-class tool-use support via
+ * `tool_use` / `tool_result` content blocks.
+ */
+export class AnthropicBackend implements ModelBackend {
+	readonly name = 'anthropic';
+	readonly #baseUrl: string;
+	readonly #defaultModel?: string;
+	readonly #apiKey: string;
+	readonly #requestTimeoutMs?: number;
+	readonly #fetch: typeof fetch;
+
+	constructor(config: AnthropicBackendConfig = {}, fetchImpl: typeof fetch = fetch) {
+		this.#apiKey = requireCredential(config.apiKey, 'Anthropic', 'apiKey', AnthropicBackendError);
+		this.#baseUrl = normalizeOrigin(config.baseUrl, { host: DEFAULT_BASE_URL, secure: true });
+		this.#defaultModel = config.model;
+		this.#requestTimeoutMs = config.requestTimeoutMs;
+		this.#fetch = fetchImpl;
+	}
+
+	capabilities(): ModelCapabilities {
+		return { embed: false, generate: true, stream: true, tools: true, adapters: false };
+	}
+
+	async generate(input: GenerateInput, opts: BackendOpts<GenerateOpts>): Promise<ModelCallResult<GenerateResult>> {
+		const model = opts.model ?? this.#defaultModel;
+		requireModel(model, 'generate', AnthropicBackendError);
+		const body = buildMessagesRequest(model, input, opts, false);
+		const res = await this.#post('/v1/messages', body, opts.signal);
+		const data = await parseJsonResponse<AnthropicMessagesResponse>(
+			res,
+			'Anthropic /v1/messages',
+			AnthropicBackendError
+		);
+		const { content, toolCalls } = extractContent(data.content);
+		const usage: TokenUsage = {};
+		assignFiniteTokenCount(usage, 'promptTokens', data.usage?.input_tokens);
+		assignFiniteTokenCount(usage, 'completionTokens', data.usage?.output_tokens);
+		const result: GenerateResult = {
+			content,
+			finishReason: mapStopReason(data.stop_reason),
+		};
+		if (toolCalls && toolCalls.length > 0) result.toolCalls = toolCalls;
+		return { status: 'completed', output: result, usage };
+	}
+
+	async *generateStream(input: GenerateInput, opts: BackendOpts<GenerateOpts>): AsyncIterable<GenerateChunk> {
+		const model = opts.model ?? this.#defaultModel;
+		requireModel(model, 'generateStream', AnthropicBackendError);
+		const body = buildMessagesRequest(model, input, opts, true);
+		const res = await this.#post('/v1/messages', body, opts.signal);
+		if (!res.body) throw new AnthropicBackendError('Anthropic /v1/messages returned no body for streaming');
+
+		// Tool-call deltas arrive as `input_json_delta` strings inside
+		// `content_block_delta` events, keyed by `index`. We accumulate per
+		// content-block index and yield each tool call once at its
+		// `content_block_stop`, when the full JSON is available. Phase 1's
+		// contract requires `ToolCall.arguments: object`, so we never expose
+		// partial strings.
+		const toolBuf = new Map<number, AnthropicToolCallAccumulator>();
+		let finalFinishReason: GenerateResult['finishReason'] | undefined;
+
+		for await (const event of readSse(res.body)) {
+			const chunk: GenerateChunk = {};
+
+			// Mid-stream upstream errors (`overloaded_error`, `rate_limit_error`,
+			// etc.) arrive as `event: error` / `data.type === 'error'`. Anthropic
+			// closes the stream after these — silently swallowing them would
+			// leave callers unable to distinguish a clean end from an aborted
+			// one. Throw the backend's error, bounding any included upstream
+			// message through the same cap used by `readErrorSuffix`.
+			if (event.type === 'error') {
+				const upstream = (event as { error?: { message?: unknown } }).error?.message;
+				if (typeof upstream === 'string' && upstream.length > 0) {
+					const truncated =
+						upstream.length > MAX_UPSTREAM_ERROR_MESSAGE_CHARS
+							? upstream.slice(0, MAX_UPSTREAM_ERROR_MESSAGE_CHARS) + '…'
+							: upstream;
+					throw new AnthropicBackendError(`Anthropic stream aborted by upstream error: ${truncated}`);
+				}
+				throw new AnthropicBackendError('Anthropic stream aborted by upstream error');
+			}
+
+			if (
+				event.type === 'content_block_start' &&
+				event.index !== undefined &&
+				event.content_block?.type === 'tool_use'
+			) {
+				toolBuf.set(event.index, {
+					id: event.content_block.id,
+					name: event.content_block.name,
+					argumentsBuf: '',
+				});
+			}
+
+			if (event.type === 'content_block_delta' && event.index !== undefined && event.delta) {
+				if (event.delta.type === 'text_delta' && typeof event.delta.text === 'string' && event.delta.text.length > 0) {
+					chunk.deltaContent = event.delta.text;
+				} else if (event.delta.type === 'input_json_delta' && typeof event.delta.partial_json === 'string') {
+					const acc = toolBuf.get(event.index);
+					if (acc) {
+						if (acc.argumentsBuf.length + event.delta.partial_json.length > MAX_TOOL_CALL_ARGS_CHARS) {
+							throw new AnthropicBackendError(
+								`Anthropic tool-call arguments exceed ${MAX_TOOL_CALL_ARGS_CHARS} chars (index ${event.index})`
+							);
+						}
+						acc.argumentsBuf += event.delta.partial_json;
+					}
+				}
+			}
+
+			if (event.type === 'content_block_stop' && event.index !== undefined) {
+				const acc = toolBuf.get(event.index);
+				if (acc && acc.id && acc.name) {
+					const finalized = finalizeToolCall(acc);
+					toolBuf.delete(event.index);
+					if (finalized) chunk.deltaToolCalls = [finalized];
+				}
+			}
+
+			if (event.type === 'message_delta' && event.delta?.stop_reason) {
+				finalFinishReason = mapStopReason(event.delta.stop_reason);
+				chunk.finishReason = finalFinishReason;
+			}
+
+			if (chunk.deltaContent || chunk.deltaToolCalls || chunk.finishReason) {
+				yield chunk;
+			}
+		}
+
+		// If the stream closed without a `message_delta` (rare; proxy hiccup),
+		// flush any orphan tool calls so the caller doesn't lose them.
+		if (!finalFinishReason && toolBuf.size > 0) {
+			const tail: Partial<ToolCall>[] = [];
+			for (const acc of toolBuf.values()) {
+				if (!acc.id || !acc.name) continue;
+				const finalized = finalizeToolCall(acc);
+				if (finalized) tail.push(finalized);
+			}
+			toolBuf.clear();
+			if (tail.length > 0) yield { deltaToolCalls: tail };
+		}
+	}
+
+	async #post(path: string, body: object, callerSignal?: AbortSignal): Promise<Response> {
+		const signal = composeSignal(callerSignal, this.#requestTimeoutMs);
+		const headers: Record<string, string> = {
+			'Content-Type': 'application/json',
+			'x-api-key': this.#apiKey,
+			'anthropic-version': ANTHROPIC_API_VERSION,
+		};
+		const res = await this.#fetch(`${this.#baseUrl}${path}`, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify(body),
+			signal,
+		});
+		if (!res.ok) {
+			throw new AnthropicBackendError(`Anthropic ${path} returned HTTP ${res.status}${await readErrorSuffix(res)}`);
+		}
+		return res;
+	}
+}
+
+/**
+ * Boot-bridge helper. Anthropic only registers as a generative backend
+ * (`embed: false`); the `kind` field would only ever be `'generative'` —
+ * surface a clear error if a config block ever tries `embedding`.
+ */
+export function registerAnthropicBackend(args: {
+	logicalName: string;
+	kind: 'embedding' | 'generative';
+	config: AnthropicBackendConfig;
+}): void {
+	if (args.kind === 'embedding') {
+		throw new AnthropicBackendError(
+			'Anthropic does not provide an embedding API; remove the embedding entry or use a different backend'
+		);
+	}
+	const backend = new AnthropicBackend(args.config);
+	setGenerative(args.logicalName, backend);
+}
+
+export class AnthropicBackendError extends ServerError {
+	constructor(message: string) {
+		super(message);
+		this.name = 'AnthropicBackendError';
+	}
+}
+
+// ---------- internals ----------
+
+async function readErrorSuffix(res: Response): Promise<string> {
+	try {
+		const body = (await res.json()) as { error?: { message?: unknown; type?: unknown } };
+		const message = body?.error?.message;
+		if (typeof message === 'string' && message.length > 0) {
+			const truncated =
+				message.length > MAX_UPSTREAM_ERROR_MESSAGE_CHARS
+					? message.slice(0, MAX_UPSTREAM_ERROR_MESSAGE_CHARS) + '…'
+					: message;
+			return `: ${truncated}`;
+		}
+		return '';
+	} catch {
+		return '';
+	}
+}
+
+interface BuiltMessagesRequest extends Record<string, unknown> {
+	model: string;
+	messages: AnthropicMessage[];
+	max_tokens: number;
+	stream: boolean;
+	system?: string;
+	tools?: AnthropicTool[];
+	temperature?: number;
+}
+
+function buildMessagesRequest(
+	model: string,
+	input: GenerateInput,
+	opts: BackendOpts<GenerateOpts>,
+	stream: boolean
+): BuiltMessagesRequest {
+	const { messages, system } = normalizeMessages(input);
+	const tools = extractTools(input);
+	const body: BuiltMessagesRequest = {
+		model,
+		messages: messages.map(toAnthropicMessage),
+		max_tokens: typeof opts.maxTokens === 'number' && opts.maxTokens > 0 ? opts.maxTokens : DEFAULT_MAX_TOKENS,
+		stream,
+	};
+	if (system) body.system = system;
+	if (tools && tools.length > 0) body.tools = tools.map(toAnthropicTool);
+	if (typeof opts.temperature === 'number') body.temperature = opts.temperature;
+	// `responseFormat` is not directly supported by Anthropic's Messages API
+	// (no equivalent of OpenAI's `response_format`); callers wanting JSON
+	// must instruct the model via the prompt. Document and ignore.
+	return body;
+}
+
+function normalizeMessages(input: GenerateInput): { messages: Message[]; system?: string } {
+	if (typeof input === 'string') {
+		return { messages: [{ role: 'user', content: input }] };
+	}
+	if (Array.isArray(input)) {
+		// Extract any 'system' role messages and consolidate into top-level
+		// `system` field; Anthropic forbids a 'system' role in `messages[]`.
+		const system: string[] = [];
+		const rest: Message[] = [];
+		for (const m of input) {
+			if (m.role === 'system') system.push(m.content);
+			else rest.push(m);
+		}
+		return system.length > 0 ? { messages: rest, system: system.join('\n\n') } : { messages: rest };
+	}
+	const explicit = input.system;
+	const inlineSystems: string[] = [];
+	const rest: Message[] = [];
+	for (const m of input.messages) {
+		if (m.role === 'system') inlineSystems.push(m.content);
+		else rest.push(m);
+	}
+	const combined = [explicit, ...inlineSystems]
+		.filter((s): s is string => typeof s === 'string' && s.length > 0)
+		.join('\n\n');
+	return combined.length > 0 ? { messages: rest, system: combined } : { messages: rest };
+}
+
+function extractTools(input: GenerateInput): ToolDef[] | undefined {
+	if (typeof input === 'string' || Array.isArray(input)) return undefined;
+	return input.tools;
+}
+
+interface AnthropicMessage {
+	role: 'user' | 'assistant';
+	content: string | AnthropicContentBlock[];
+}
+
+interface AnthropicContentBlock {
+	type: 'text' | 'tool_use' | 'tool_result';
+	text?: string;
+	id?: string;
+	name?: string;
+	input?: object;
+	tool_use_id?: string;
+	content?: string | AnthropicContentBlock[];
+}
+
+function toAnthropicMessage(m: Message): AnthropicMessage {
+	if (m.role !== 'user' && m.role !== 'assistant' && m.role !== 'tool') {
+		// 'system' is normalized out above; anything unexpected goes through
+		// as 'user' for safety. Anthropic will reject invalid roles.
+		return { role: 'user', content: m.content };
+	}
+	if (m.role === 'tool') {
+		// Tool result message: Anthropic represents these as `tool_result`
+		// content blocks inside a `user` role message, referenced by
+		// `tool_use_id` (matches Phase 1's `Message.toolCallId`).
+		return {
+			role: 'user',
+			content: [
+				{
+					type: 'tool_result',
+					tool_use_id: m.toolCallId ?? '',
+					content: m.content,
+				},
+			],
+		};
+	}
+	if (m.role === 'assistant' && m.toolCalls && m.toolCalls.length > 0) {
+		// Mixed assistant message: text + tool_use blocks. Phase 1 keeps
+		// `Message.content` separate from `Message.toolCalls`; Anthropic
+		// represents both as a content blocks array.
+		const blocks: AnthropicContentBlock[] = [];
+		if (m.content) blocks.push({ type: 'text', text: m.content });
+		for (const tc of m.toolCalls) {
+			blocks.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.arguments ?? {} });
+		}
+		return { role: 'assistant', content: blocks };
+	}
+	return { role: m.role, content: m.content };
+}
+
+interface AnthropicTool {
+	name: string;
+	description: string;
+	input_schema: object;
+}
+
+function toAnthropicTool(t: ToolDef): AnthropicTool {
+	return { name: t.name, description: t.description, input_schema: t.parameters };
+}
+
+function mapStopReason(reason?: string | null): GenerateResult['finishReason'] {
+	switch (reason) {
+		case 'max_tokens':
+			return 'length';
+		case 'tool_use':
+			return 'tool_calls';
+		case 'end_turn':
+		case 'stop_sequence':
+		default:
+			return 'stop';
+	}
+}
+
+function extractContent(blocks: AnthropicContentBlock[] | undefined): { content: string; toolCalls?: ToolCall[] } {
+	if (!blocks || blocks.length === 0) return { content: '' };
+	const text: string[] = [];
+	const toolCalls: ToolCall[] = [];
+	for (const block of blocks) {
+		if (block.type === 'text' && typeof block.text === 'string') {
+			text.push(block.text);
+		} else if (block.type === 'tool_use' && block.id && block.name) {
+			// Anthropic returns `input` as a parsed object — no JSON.parse needed.
+			const input = block.input && typeof block.input === 'object' ? block.input : {};
+			toolCalls.push({ id: block.id, name: block.name, arguments: input });
+		}
+	}
+	const result: { content: string; toolCalls?: ToolCall[] } = { content: text.join('') };
+	if (toolCalls.length > 0) result.toolCalls = toolCalls;
+	return result;
+}
+
+interface AnthropicToolCallAccumulator {
+	id: string;
+	name: string;
+	argumentsBuf: string;
+}
+
+function finalizeToolCall(acc: AnthropicToolCallAccumulator): Partial<ToolCall> | undefined {
+	try {
+		const args = acc.argumentsBuf.length > 0 ? JSON.parse(acc.argumentsBuf) : {};
+		return { id: acc.id, name: acc.name, arguments: args };
+	} catch {
+		// Static-message log on malformed JSON; matches the openai backend's
+		// posture. Drop the call rather than crash the stream.
+		log.warn?.(`Anthropic tool call dropped: malformed arguments (id=${acc.id}, name=${acc.name})`);
+		return undefined;
+	}
+}
+
+/**
+ * Read Anthropic's SSE wire format. Same framing as OpenAI's (events
+ * separated by `\n\n`, `data:` lines carry JSON). Anthropic adds named
+ * `event:` lines but we dispatch off `data.type` which is more reliable.
+ * `event: ping` and any non-`data:` line are skipped naturally.
+ *
+ * No explicit `[DONE]` terminator — the stream ends when the server closes
+ * the connection after `message_stop`.
+ */
+async function* readSse(body: ReadableStream<Uint8Array>): AsyncGenerator<AnthropicStreamEvent> {
+	const decoder = new TextDecoder('utf-8');
+	let buf = '';
+	for await (const chunk of body as unknown as AsyncIterable<Uint8Array>) {
+		buf += decoder.decode(chunk, { stream: true });
+		if (buf.length > MAX_SSE_BUFFER_CHARS) {
+			throw new AnthropicBackendError(
+				`Anthropic SSE buffer exceeds ${MAX_SSE_BUFFER_CHARS} chars without a complete event`
+			);
+		}
+		let boundary: number;
+		while ((boundary = buf.indexOf('\n\n')) >= 0) {
+			const eventBlock = buf.slice(0, boundary);
+			buf = buf.slice(boundary + 2);
+			const parsed = parseSseEvent(eventBlock);
+			if (parsed) yield parsed;
+		}
+	}
+	buf += decoder.decode();
+	const tail = buf.trim();
+	if (tail) {
+		const parsed = parseSseEvent(tail);
+		if (parsed) yield parsed;
+	}
+}
+
+function parseSseEvent(block: string): AnthropicStreamEvent | null {
+	let data = '';
+	for (const rawLine of block.split('\n')) {
+		const line = rawLine.replace(/\r$/, '');
+		if (!line || line.startsWith(':') || !line.startsWith('data:')) continue;
+		const payload = line.slice(5).replace(/^ /, '');
+		data = data ? data + '\n' + payload : payload;
+	}
+	if (!data) return null;
+	try {
+		return JSON.parse(data) as AnthropicStreamEvent;
+	} catch {
+		throw new AnthropicBackendError('Invalid SSE data line from Anthropic');
+	}
+}
+
+// ---------- Anthropic wire types (subset we actually read) ----------
+
+interface AnthropicMessagesResponse {
+	id?: string;
+	type?: string;
+	role?: string;
+	content?: AnthropicContentBlock[];
+	model?: string;
+	stop_reason?: string | null;
+	usage?: { input_tokens?: number; output_tokens?: number };
+}
+
+interface AnthropicStreamEvent {
+	type:
+		| 'message_start'
+		| 'content_block_start'
+		| 'content_block_delta'
+		| 'content_block_stop'
+		| 'message_delta'
+		| 'message_stop'
+		| 'ping'
+		| 'error';
+	index?: number;
+	content_block?: AnthropicContentBlock;
+	delta?: {
+		type?: 'text_delta' | 'input_json_delta';
+		text?: string;
+		partial_json?: string;
+		stop_reason?: string | null;
+		stop_sequence?: string | null;
+	};
+	usage?: { output_tokens?: number };
+}

--- a/components/bedrock/index.ts
+++ b/components/bedrock/index.ts
@@ -1,0 +1,823 @@
+/**
+ * AWS Bedrock backend (#633, Phase 6 of #510).
+ *
+ * Implements `ModelBackend` against AWS Bedrock via the official AWS SDK.
+ * Unlike Ollama / OpenAI / Anthropic, Bedrock requires SigV4-signed
+ * requests against region-specific endpoints; rolling that ourselves is
+ * not worth it. `@aws-sdk/client-bedrock-runtime` is declared as an
+ * **optional `peerDependency`** in Harper's `package.json`. Users who
+ * want the bedrock backend add the SDK to their own project's
+ * `package.json`; we dynamic-import on first use and throw a pointed
+ * error if it's missing.
+ *
+ * AWS credentials resolve via the SDK's standard chain (env / shared
+ * credentials file / EC2 / ECS / IAM roles for service accounts). No
+ * `apiKey` field on the Harper config — credential handling is the
+ * SDK's job, not ours.
+ *
+ * Bedrock has multiple model invocation shapes per family (Claude vs
+ * Llama vs Titan vs Cohere). The backend dispatches on the `model`
+ * field's prefix; per-family request/response translation lives in
+ * helpers below.
+ */
+import { setEmbedding, setGenerative } from '../../resources/models/backendRegistry.ts';
+import { assignFiniteTokenCount, composeSignal, requireModel } from '../../resources/models/backendHelpers.ts';
+import { ServerError } from '../../utility/errors/hdbError.ts';
+import harperLogger from '../../utility/logging/harper_logger.ts';
+import type {
+	BackendOpts,
+	EmbedOpts,
+	GenerateChunk,
+	GenerateInput,
+	GenerateOpts,
+	GenerateResult,
+	Message,
+	ModelBackend,
+	ModelCallResult,
+	ModelCapabilities,
+	ToolCall,
+	ToolDef,
+	TokenUsage,
+} from '../../resources/models/types.ts';
+
+// Defaults matching Anthropic's expectation when Claude is invoked via
+// Bedrock — Anthropic requires `max_tokens` on every request.
+const DEFAULT_MAX_TOKENS = 4096;
+// Max accumulated `bytes` from streamed Claude tool-use input_json_delta;
+// matches the cap in `components/anthropic/index.ts`.
+const MAX_TOOL_CALL_ARGS_CHARS = 1 << 20;
+
+const log = harperLogger.forComponent('bedrock').conditional;
+
+export type BedrockBackendKind = 'embedding' | 'generative';
+
+export interface BedrockBackendConfig {
+	/** AWS region (e.g. `us-east-1`). Required — Bedrock is regional. */
+	region?: string;
+	/**
+	 * Model ID per Bedrock conventions, e.g. `anthropic.claude-opus-4-v1:0`
+	 * for Claude, `meta.llama3-70b-instruct-v1:0` for Llama,
+	 * `amazon.titan-embed-text-v2:0` for Titan embed. The leading vendor
+	 * prefix is how the backend dispatches to the right per-family shape.
+	 */
+	model?: string;
+	requestTimeoutMs?: number;
+}
+
+/**
+ * SDK type-erased shape we use. We don't import `@aws-sdk/client-bedrock-runtime`
+ * at module init (it's an optional peerDep); types are kept loose so the
+ * compile doesn't depend on the SDK either.
+ */
+type SdkLike = {
+	BedrockRuntimeClient: new (config: { region?: string }) => {
+		send: (cmd: object) => Promise<unknown>;
+	};
+	InvokeModelCommand: new (input: { modelId: string; body: string; contentType?: string; accept?: string }) => object;
+	InvokeModelWithResponseStreamCommand: new (input: {
+		modelId: string;
+		body: string;
+		contentType?: string;
+		accept?: string;
+	}) => object;
+};
+
+let sdkPromise: Promise<SdkLike> | undefined;
+
+/**
+ * Load the AWS SDK on demand. Memoized — the SDK is module-scope state once
+ * loaded. Throws `BedrockBackendError` with a clear "add to your
+ * package.json" message if the SDK isn't installed.
+ */
+async function loadSdk(): Promise<SdkLike> {
+	if (!sdkPromise) {
+		sdkPromise = (async () => {
+			try {
+				// `@aws-sdk/client-bedrock-runtime` is declared as an optional
+				// peerDependency in Harper's `package.json` — it is not present
+				// in Harper's `node_modules` by design, so TypeScript can't
+				// resolve it at compile time. The runtime import resolves
+				// against the user's project tree.
+				// @ts-expect-error optional peerDependency, not resolvable at build time
+				const mod = (await import('@aws-sdk/client-bedrock-runtime')) as unknown as SdkLike;
+				return mod;
+			} catch (err) {
+				// Wipe the cached rejection so a follow-up install + retry works
+				// without restart. The thrown error is still propagated for this call.
+				sdkPromise = undefined;
+				throw new BedrockBackendError(
+					'@aws-sdk/client-bedrock-runtime is not installed. Add it to your project ' +
+						'(`npm install @aws-sdk/client-bedrock-runtime`) — Harper declares it as an optional peerDependency, ' +
+						'not a direct dependency, so applications that do not use the bedrock backend never pay the install cost. ' +
+						`Underlying error: ${(err as Error)?.message ?? err}`
+				);
+			}
+		})();
+	}
+	return sdkPromise;
+}
+
+/** Test-only hook to reset the memoized SDK promise between cases. */
+export function _resetSdkCacheForTests(): void {
+	sdkPromise = undefined;
+}
+
+/** Test-only hook to inject a fake SDK. */
+export function _injectSdkForTests(sdk: SdkLike): void {
+	sdkPromise = Promise.resolve(sdk);
+}
+
+/**
+ * `ModelBackend` for AWS Bedrock.
+ *
+ * - `embed` → `InvokeModel` against an embedding model (Titan, Cohere, etc.)
+ * - `generate` → `InvokeModel` against a generative model, per-family body shape
+ * - `generateStream` → `InvokeModelWithResponseStream`, per-family event parsing
+ *
+ * Tool support varies per model family — `capabilities()` advertises
+ * `tools: true` at the capability level; calls against models that don't
+ * support tools (or that haven't been wired into the per-family dispatcher
+ * yet) raise structured errors.
+ */
+export class BedrockBackend implements ModelBackend {
+	readonly name = 'bedrock';
+	readonly #region?: string;
+	readonly #defaultModel?: string;
+	readonly #requestTimeoutMs?: number;
+	#client?: { send: (cmd: object) => Promise<unknown> };
+
+	constructor(config: BedrockBackendConfig = {}) {
+		this.#region = config.region;
+		this.#defaultModel = config.model;
+		this.#requestTimeoutMs = config.requestTimeoutMs;
+	}
+
+	capabilities(): ModelCapabilities {
+		return { embed: true, generate: true, stream: true, tools: true, adapters: false };
+	}
+
+	async embed(input: string | string[], opts: BackendOpts<EmbedOpts>): Promise<ModelCallResult<Float32Array[]>> {
+		const model = opts.model ?? this.#defaultModel;
+		requireModel(model, 'embed', BedrockBackendError);
+		const family = familyOf(model);
+		const texts = Array.isArray(input) ? input : [input];
+
+		const client = await this.#getClient();
+		const sdk = await loadSdk();
+		const vectors: Float32Array[] = [];
+		let totalPromptTokens = 0;
+		let sawAnyTokens = false;
+
+		// Bedrock embedding APIs (Titan, Cohere) accept one text per call.
+		// Loop to honor the multi-input contract; concurrent dispatch would
+		// trip the SDK's request budget on larger batches without bounded
+		// concurrency, which is overkill for v1.
+		for (const text of texts) {
+			const body = buildEmbedBody(family, text, opts.inputType);
+			const command = new sdk.InvokeModelCommand({
+				modelId: model,
+				body: JSON.stringify(body),
+				contentType: 'application/json',
+				accept: 'application/json',
+			});
+			const response = (await this.#sendWithAbort(client, command, opts.signal)) as { body?: Uint8Array | string };
+			const parsed = parseInvokeModelResponse(response);
+			const { embedding, promptTokens } = extractEmbedResult(family, parsed);
+			vectors.push(Float32Array.from(embedding));
+			if (typeof promptTokens === 'number') {
+				totalPromptTokens += promptTokens;
+				sawAnyTokens = true;
+			}
+		}
+
+		const usage: TokenUsage = {};
+		if (sawAnyTokens) assignFiniteTokenCount(usage, 'embeddingTokens', totalPromptTokens);
+		return { status: 'completed', output: vectors, usage };
+	}
+
+	async generate(input: GenerateInput, opts: BackendOpts<GenerateOpts>): Promise<ModelCallResult<GenerateResult>> {
+		const model = opts.model ?? this.#defaultModel;
+		requireModel(model, 'generate', BedrockBackendError);
+		const family = familyOf(model);
+		const body = buildGenerateBody(family, input, opts);
+
+		const client = await this.#getClient();
+		const sdk = await loadSdk();
+		const command = new sdk.InvokeModelCommand({
+			modelId: model,
+			body: JSON.stringify(body),
+			contentType: 'application/json',
+			accept: 'application/json',
+		});
+		const response = (await this.#sendWithAbort(client, command, opts.signal)) as { body?: Uint8Array | string };
+		const parsed = parseInvokeModelResponse(response);
+		const result = extractGenerateResult(family, parsed);
+		return { status: 'completed', output: result.output, usage: result.usage };
+	}
+
+	async *generateStream(input: GenerateInput, opts: BackendOpts<GenerateOpts>): AsyncIterable<GenerateChunk> {
+		const model = opts.model ?? this.#defaultModel;
+		requireModel(model, 'generateStream', BedrockBackendError);
+		const family = familyOf(model);
+		const body = buildGenerateBody(family, input, opts);
+
+		const client = await this.#getClient();
+		const sdk = await loadSdk();
+		const command = new sdk.InvokeModelWithResponseStreamCommand({
+			modelId: model,
+			body: JSON.stringify(body),
+			contentType: 'application/json',
+			accept: 'application/json',
+		});
+		const response = (await this.#sendWithAbort(client, command, opts.signal)) as {
+			body?: AsyncIterable<{ chunk?: { bytes?: Uint8Array } }>;
+		};
+		if (!response.body) {
+			throw new BedrockBackendError(`Bedrock InvokeModelWithResponseStream returned no body for model ${model}`);
+		}
+
+		yield* parseStream(family, response.body);
+	}
+
+	async #getClient(): Promise<{ send: (cmd: object) => Promise<unknown> }> {
+		if (this.#client) return this.#client;
+		const sdk = await loadSdk();
+		this.#client = new sdk.BedrockRuntimeClient({ region: this.#region });
+		return this.#client;
+	}
+
+	/**
+	 * Send a command with caller-supplied AbortSignal + optional per-call
+	 * timeout composed via `AbortSignal.any`. The SDK accepts `abortSignal`
+	 * in the request options bag.
+	 */
+	async #sendWithAbort(
+		client: { send: (cmd: object, options?: { abortSignal?: AbortSignal }) => Promise<unknown> },
+		command: object,
+		callerSignal?: AbortSignal
+	): Promise<unknown> {
+		const abortSignal = composeSignal(callerSignal, this.#requestTimeoutMs);
+		return client.send(command, abortSignal ? { abortSignal } : undefined);
+	}
+}
+
+/**
+ * Boot-bridge helper. Called from `resources/models/bootstrap.ts` for each
+ * `models.embedding.<name>` / `models.generative.<name>` entry whose
+ * `backend: bedrock`. Construction is cheap (no SDK load) — the SDK loads
+ * lazily on first call.
+ */
+export function registerBedrockBackend(args: {
+	logicalName: string;
+	kind: BedrockBackendKind;
+	config: BedrockBackendConfig;
+}): void {
+	const backend = new BedrockBackend(args.config);
+	if (args.kind === 'embedding') setEmbedding(args.logicalName, backend);
+	else setGenerative(args.logicalName, backend);
+}
+
+export class BedrockBackendError extends ServerError {
+	constructor(message: string) {
+		super(message);
+		this.name = 'BedrockBackendError';
+	}
+}
+
+// ---------- per-family dispatch ----------
+
+type Family = 'anthropic' | 'amazon' | 'meta' | 'cohere' | 'mistral' | 'unknown';
+
+function familyOf(modelId: string): Family {
+	const prefix = modelId.split('.', 1)[0]?.toLowerCase() ?? '';
+	if (prefix === 'anthropic') return 'anthropic';
+	if (prefix === 'amazon') return 'amazon';
+	if (prefix === 'meta') return 'meta';
+	if (prefix === 'cohere') return 'cohere';
+	if (prefix === 'mistral') return 'mistral';
+	return 'unknown';
+}
+
+// ---------- embed body / result extraction ----------
+
+function buildEmbedBody(family: Family, text: string, inputType?: 'document' | 'query'): object {
+	if (family === 'amazon') {
+		// Titan embed v2: { inputText, dimensions?, normalize? }. Titan does
+		// not currently differentiate document vs query at the wire level.
+		return { inputText: text };
+	}
+	if (family === 'cohere') {
+		// Cohere embed-v3: `input_type` materially affects the produced vector
+		// — `search_document` and `search_query` produce different embeddings
+		// for the same text. Honor the caller's `inputType`; default to
+		// `search_document` when unset (matches Cohere's recommended default
+		// for indexing).
+		const cohereInputType = inputType === 'query' ? 'search_query' : 'search_document';
+		return { texts: [text], input_type: cohereInputType };
+	}
+	throw new BedrockBackendError(`Bedrock embed not supported for model family '${family}'`);
+}
+
+function extractEmbedResult(
+	family: Family,
+	parsed: Record<string, unknown>
+): { embedding: number[]; promptTokens?: number } {
+	if (family === 'amazon') {
+		const embedding = parsed.embedding;
+		if (!Array.isArray(embedding) || !embedding.every((n) => typeof n === 'number' && Number.isFinite(n))) {
+			throw new BedrockBackendError("Bedrock Titan response missing 'embedding' as a finite-number array");
+		}
+		const inputTextTokenCount = parsed.inputTextTokenCount;
+		return {
+			embedding: embedding as number[],
+			promptTokens: typeof inputTextTokenCount === 'number' ? inputTextTokenCount : undefined,
+		};
+	}
+	if (family === 'cohere') {
+		const embeddings = parsed.embeddings;
+		if (!Array.isArray(embeddings) || embeddings.length === 0) {
+			throw new BedrockBackendError("Bedrock Cohere response missing 'embeddings' array");
+		}
+		const first = embeddings[0];
+		if (!Array.isArray(first) || !first.every((n) => typeof n === 'number' && Number.isFinite(n))) {
+			throw new BedrockBackendError('Bedrock Cohere embedding vector is not an array of finite numbers');
+		}
+		return { embedding: first as number[] };
+	}
+	throw new BedrockBackendError(`Bedrock embed result extraction not implemented for family '${family}'`);
+}
+
+// ---------- generate body / result extraction ----------
+
+function buildGenerateBody(family: Family, input: GenerateInput, opts: BackendOpts<GenerateOpts>): object {
+	if (family === 'anthropic') return buildAnthropicBody(input, opts);
+	if (family === 'meta') return buildLlamaBody(input, opts);
+	if (family === 'amazon') return buildTitanGenerateBody(input, opts);
+	if (family === 'mistral') return buildMistralBody(input, opts);
+	if (family === 'cohere') return buildCohereGenerateBody(input, opts);
+	throw new BedrockBackendError(`Bedrock generate not supported for model family '${family}'`);
+}
+
+function extractGenerateResult(
+	family: Family,
+	parsed: Record<string, unknown>
+): { output: GenerateResult; usage: TokenUsage } {
+	if (family === 'anthropic') return extractAnthropicResult(parsed);
+	if (family === 'meta') return extractLlamaResult(parsed);
+	if (family === 'amazon') return extractTitanResult(parsed);
+	if (family === 'mistral') return extractMistralResult(parsed);
+	if (family === 'cohere') return extractCohereResult(parsed);
+	throw new BedrockBackendError(`Bedrock generate result extraction not implemented for family '${family}'`);
+}
+
+// Claude via Bedrock uses Anthropic's Messages API shape verbatim. Reuse the
+// translation patterns from `components/anthropic/index.ts` but keep the
+// code self-contained here — duplicated shape, different transport.
+function buildAnthropicBody(input: GenerateInput, opts: BackendOpts<GenerateOpts>): object {
+	const { messages, system } = normalizeMessages(input);
+	const tools = extractTools(input);
+	const body: Record<string, unknown> = {
+		anthropic_version: 'bedrock-2023-05-31',
+		messages: messages.map(toAnthropicMessage),
+		max_tokens: typeof opts.maxTokens === 'number' && opts.maxTokens > 0 ? opts.maxTokens : DEFAULT_MAX_TOKENS,
+	};
+	if (system) body.system = system;
+	if (tools && tools.length > 0) {
+		body.tools = tools.map((t) => ({ name: t.name, description: t.description, input_schema: t.parameters }));
+	}
+	if (typeof opts.temperature === 'number') body.temperature = opts.temperature;
+	return body;
+}
+
+function extractAnthropicResult(parsed: Record<string, unknown>): { output: GenerateResult; usage: TokenUsage } {
+	const content = Array.isArray(parsed.content) ? (parsed.content as AnthropicContentBlock[]) : [];
+	const text: string[] = [];
+	const toolCalls: ToolCall[] = [];
+	for (const block of content) {
+		if (block.type === 'text' && typeof block.text === 'string') text.push(block.text);
+		else if (block.type === 'tool_use' && block.id && block.name) {
+			const input = block.input && typeof block.input === 'object' ? block.input : {};
+			toolCalls.push({ id: block.id, name: block.name, arguments: input });
+		}
+	}
+	const usage: TokenUsage = {};
+	const usageObj = parsed.usage as { input_tokens?: unknown; output_tokens?: unknown } | undefined;
+	assignFiniteTokenCount(usage, 'promptTokens', usageObj?.input_tokens);
+	assignFiniteTokenCount(usage, 'completionTokens', usageObj?.output_tokens);
+	const output: GenerateResult = {
+		content: text.join(''),
+		finishReason: mapAnthropicStopReason(parsed.stop_reason as string | undefined),
+	};
+	if (toolCalls.length > 0) output.toolCalls = toolCalls;
+	return { output, usage };
+}
+
+function buildLlamaBody(input: GenerateInput, opts: BackendOpts<GenerateOpts>): object {
+	// Llama on Bedrock uses a flat `prompt` string. Caller's structured
+	// messages are flattened with role tags; not as expressive as native chat,
+	// but matches what AWS documents.
+	rejectToolsForFamily(input, 'meta');
+	const prompt = flattenToLlamaPrompt(input);
+	const body: Record<string, unknown> = { prompt };
+	if (typeof opts.maxTokens === 'number') body.max_gen_len = opts.maxTokens;
+	if (typeof opts.temperature === 'number') body.temperature = opts.temperature;
+	return body;
+}
+
+function extractLlamaResult(parsed: Record<string, unknown>): { output: GenerateResult; usage: TokenUsage } {
+	const generation = typeof parsed.generation === 'string' ? parsed.generation : '';
+	const usage: TokenUsage = {};
+	assignFiniteTokenCount(usage, 'promptTokens', parsed.prompt_token_count);
+	assignFiniteTokenCount(usage, 'completionTokens', parsed.generation_token_count);
+	const output: GenerateResult = {
+		content: generation,
+		finishReason: mapGenericStopReason(parsed.stop_reason as string | undefined),
+	};
+	return { output, usage };
+}
+
+function buildTitanGenerateBody(input: GenerateInput, opts: BackendOpts<GenerateOpts>): object {
+	rejectToolsForFamily(input, 'amazon');
+	const inputText = flattenToFlatPrompt(input);
+	const body: Record<string, unknown> = { inputText };
+	const textGenerationConfig: Record<string, unknown> = {};
+	if (typeof opts.maxTokens === 'number') textGenerationConfig.maxTokenCount = opts.maxTokens;
+	if (typeof opts.temperature === 'number') textGenerationConfig.temperature = opts.temperature;
+	if (Object.keys(textGenerationConfig).length > 0) body.textGenerationConfig = textGenerationConfig;
+	return body;
+}
+
+function extractTitanResult(parsed: Record<string, unknown>): { output: GenerateResult; usage: TokenUsage } {
+	const results = Array.isArray(parsed.results) ? parsed.results : [];
+	const first = (results[0] as Record<string, unknown>) ?? {};
+	const outputText = typeof first.outputText === 'string' ? first.outputText : '';
+	const usage: TokenUsage = {};
+	assignFiniteTokenCount(usage, 'promptTokens', parsed.inputTextTokenCount);
+	assignFiniteTokenCount(usage, 'completionTokens', first.tokenCount);
+	const output: GenerateResult = {
+		content: outputText,
+		finishReason: mapGenericStopReason(first.completionReason as string | undefined),
+	};
+	return { output, usage };
+}
+
+function buildMistralBody(input: GenerateInput, opts: BackendOpts<GenerateOpts>): object {
+	rejectToolsForFamily(input, 'mistral');
+	const prompt = flattenToFlatPrompt(input);
+	const body: Record<string, unknown> = { prompt };
+	if (typeof opts.maxTokens === 'number') body.max_tokens = opts.maxTokens;
+	if (typeof opts.temperature === 'number') body.temperature = opts.temperature;
+	return body;
+}
+
+function extractMistralResult(parsed: Record<string, unknown>): { output: GenerateResult; usage: TokenUsage } {
+	const outputs = Array.isArray(parsed.outputs) ? parsed.outputs : [];
+	const first = (outputs[0] as Record<string, unknown>) ?? {};
+	const text = typeof first.text === 'string' ? first.text : '';
+	const output: GenerateResult = {
+		content: text,
+		finishReason: mapGenericStopReason(first.stop_reason as string | undefined),
+	};
+	// Mistral via Bedrock doesn't currently return per-call token counts in a
+	// stable shape — leave usage empty.
+	return { output, usage: {} };
+}
+
+function buildCohereGenerateBody(input: GenerateInput, opts: BackendOpts<GenerateOpts>): object {
+	rejectToolsForFamily(input, 'cohere');
+	const prompt = flattenToFlatPrompt(input);
+	const body: Record<string, unknown> = { prompt };
+	if (typeof opts.maxTokens === 'number') body.max_tokens = opts.maxTokens;
+	if (typeof opts.temperature === 'number') body.temperature = opts.temperature;
+	return body;
+}
+
+function extractCohereResult(parsed: Record<string, unknown>): { output: GenerateResult; usage: TokenUsage } {
+	const generations = Array.isArray(parsed.generations) ? parsed.generations : [];
+	const first = (generations[0] as Record<string, unknown>) ?? {};
+	const text = typeof first.text === 'string' ? first.text : '';
+	const output: GenerateResult = {
+		content: text,
+		finishReason: mapGenericStopReason(first.finish_reason as string | undefined),
+	};
+	return { output, usage: {} };
+}
+
+// ---------- streaming dispatch ----------
+
+async function* parseStream(
+	family: Family,
+	body: AsyncIterable<{ chunk?: { bytes?: Uint8Array } }>
+): AsyncGenerator<GenerateChunk> {
+	if (family === 'anthropic') {
+		yield* parseAnthropicStream(body);
+		return;
+	}
+	if (family === 'meta' || family === 'amazon' || family === 'mistral' || family === 'cohere') {
+		yield* parseFlatStream(family, body);
+		return;
+	}
+	throw new BedrockBackendError(`Bedrock streaming not supported for model family '${family}'`);
+}
+
+async function* parseAnthropicStream(
+	body: AsyncIterable<{ chunk?: { bytes?: Uint8Array } }>
+): AsyncGenerator<GenerateChunk> {
+	const decoder = new TextDecoder('utf-8');
+	const toolBuf = new Map<number, { id: string; name: string; argumentsBuf: string }>();
+	let finalFinishReason: GenerateResult['finishReason'] | undefined;
+
+	for await (const event of body) {
+		if (!event.chunk?.bytes) continue;
+		const text = decoder.decode(event.chunk.bytes);
+		let parsed: Record<string, unknown>;
+		try {
+			parsed = JSON.parse(text) as Record<string, unknown>;
+		} catch {
+			throw new BedrockBackendError('Invalid JSON in Bedrock Anthropic stream chunk');
+		}
+		const chunk: GenerateChunk = {};
+		const type = parsed.type as string | undefined;
+		const index = parsed.index as number | undefined;
+		const contentBlock = parsed.content_block as AnthropicContentBlock | undefined;
+		const delta = parsed.delta as
+			| {
+					type?: string;
+					text?: string;
+					partial_json?: string;
+					stop_reason?: string | null;
+			  }
+			| undefined;
+
+		// Mid-stream upstream errors from Anthropic-via-Bedrock arrive as a
+		// `type: 'error'` chunk; without explicit handling the stream ends
+		// silently and the caller can't distinguish a clean end from an
+		// aborted one. Same posture as the direct Anthropic backend.
+		if (type === 'error') {
+			const upstream = (parsed as { error?: { message?: unknown } }).error?.message;
+			if (typeof upstream === 'string' && upstream.length > 0) {
+				const truncated = upstream.length > 500 ? upstream.slice(0, 500) + '…' : upstream;
+				throw new BedrockBackendError(`Bedrock Anthropic stream aborted by upstream error: ${truncated}`);
+			}
+			throw new BedrockBackendError('Bedrock Anthropic stream aborted by upstream error');
+		}
+
+		if (type === 'content_block_start' && index !== undefined && contentBlock?.type === 'tool_use') {
+			toolBuf.set(index, { id: contentBlock.id ?? '', name: contentBlock.name ?? '', argumentsBuf: '' });
+		}
+		if (type === 'content_block_delta' && index !== undefined && delta) {
+			if (delta.type === 'text_delta' && typeof delta.text === 'string' && delta.text.length > 0) {
+				chunk.deltaContent = delta.text;
+			} else if (delta.type === 'input_json_delta' && typeof delta.partial_json === 'string') {
+				const acc = toolBuf.get(index);
+				if (acc) {
+					if (acc.argumentsBuf.length + delta.partial_json.length > MAX_TOOL_CALL_ARGS_CHARS) {
+						throw new BedrockBackendError(
+							`Bedrock tool-call arguments exceed ${MAX_TOOL_CALL_ARGS_CHARS} chars (index ${index})`
+						);
+					}
+					acc.argumentsBuf += delta.partial_json;
+				}
+			}
+		}
+		if (type === 'content_block_stop' && index !== undefined) {
+			const acc = toolBuf.get(index);
+			if (acc?.id && acc.name) {
+				try {
+					const args = acc.argumentsBuf.length > 0 ? JSON.parse(acc.argumentsBuf) : {};
+					chunk.deltaToolCalls = [{ id: acc.id, name: acc.name, arguments: args }];
+				} catch {
+					log.warn?.(`Bedrock tool call dropped: malformed arguments (id=${acc.id}, name=${acc.name})`);
+				}
+				toolBuf.delete(index);
+			}
+		}
+		if (type === 'message_delta' && delta?.stop_reason) {
+			finalFinishReason = mapAnthropicStopReason(delta.stop_reason);
+			chunk.finishReason = finalFinishReason;
+		}
+		if (chunk.deltaContent || chunk.deltaToolCalls || chunk.finishReason) yield chunk;
+	}
+
+	if (!finalFinishReason && toolBuf.size > 0) {
+		const tail: Partial<ToolCall>[] = [];
+		for (const acc of toolBuf.values()) {
+			if (!acc.id || !acc.name) continue;
+			try {
+				const args = acc.argumentsBuf.length > 0 ? JSON.parse(acc.argumentsBuf) : {};
+				tail.push({ id: acc.id, name: acc.name, arguments: args });
+			} catch {
+				log.warn?.(`Bedrock tool call dropped on flush (id=${acc.id}, name=${acc.name})`);
+			}
+		}
+		toolBuf.clear();
+		if (tail.length > 0) yield { deltaToolCalls: tail };
+	}
+}
+
+async function* parseFlatStream(
+	family: Family,
+	body: AsyncIterable<{ chunk?: { bytes?: Uint8Array } }>
+): AsyncGenerator<GenerateChunk> {
+	// Llama / Titan / Mistral / Cohere via Bedrock all emit one JSON object
+	// per stream chunk with a family-specific "delta-content" field. We yield
+	// each as a GenerateChunk and rely on the final chunk's stop_reason
+	// (or family equivalent) to terminate.
+	const decoder = new TextDecoder('utf-8');
+	for await (const event of body) {
+		if (!event.chunk?.bytes) continue;
+		const text = decoder.decode(event.chunk.bytes);
+		let parsed: Record<string, unknown>;
+		try {
+			parsed = JSON.parse(text) as Record<string, unknown>;
+		} catch {
+			throw new BedrockBackendError('Invalid JSON in Bedrock stream chunk');
+		}
+		const chunk: GenerateChunk = {};
+		const deltaContent = extractFlatDeltaContent(family, parsed);
+		if (deltaContent && deltaContent.length > 0) chunk.deltaContent = deltaContent;
+		const stopReason = extractFlatStopReason(family, parsed);
+		if (stopReason) chunk.finishReason = mapGenericStopReason(stopReason);
+		if (chunk.deltaContent || chunk.finishReason) yield chunk;
+	}
+}
+
+function extractFlatDeltaContent(family: Family, parsed: Record<string, unknown>): string | undefined {
+	if (family === 'meta') return typeof parsed.generation === 'string' ? parsed.generation : undefined;
+	if (family === 'amazon') return typeof parsed.outputText === 'string' ? parsed.outputText : undefined;
+	if (family === 'mistral') {
+		const outputs = Array.isArray(parsed.outputs) ? parsed.outputs : [];
+		const first = (outputs[0] as Record<string, unknown>) ?? {};
+		return typeof first.text === 'string' ? first.text : undefined;
+	}
+	if (family === 'cohere') {
+		const generations = Array.isArray(parsed.generations) ? parsed.generations : [];
+		const first = (generations[0] as Record<string, unknown>) ?? {};
+		return typeof first.text === 'string' ? first.text : undefined;
+	}
+	return undefined;
+}
+
+function extractFlatStopReason(family: Family, parsed: Record<string, unknown>): string | undefined {
+	if (family === 'meta') return parsed.stop_reason as string | undefined;
+	if (family === 'amazon') return parsed.completionReason as string | undefined;
+	if (family === 'mistral') {
+		const outputs = Array.isArray(parsed.outputs) ? parsed.outputs : [];
+		const first = (outputs[0] as Record<string, unknown>) ?? {};
+		return first.stop_reason as string | undefined;
+	}
+	if (family === 'cohere') {
+		const generations = Array.isArray(parsed.generations) ? parsed.generations : [];
+		const first = (generations[0] as Record<string, unknown>) ?? {};
+		return first.finish_reason as string | undefined;
+	}
+	return undefined;
+}
+
+// ---------- message translation (shared by Claude-on-Bedrock body) ----------
+
+interface AnthropicContentBlock {
+	type: 'text' | 'tool_use' | 'tool_result';
+	text?: string;
+	id?: string;
+	name?: string;
+	input?: object;
+	tool_use_id?: string;
+	content?: string | AnthropicContentBlock[];
+}
+
+interface AnthropicMessage {
+	role: 'user' | 'assistant';
+	content: string | AnthropicContentBlock[];
+}
+
+function normalizeMessages(input: GenerateInput): { messages: Message[]; system?: string } {
+	if (typeof input === 'string') return { messages: [{ role: 'user', content: input }] };
+	if (Array.isArray(input)) {
+		const system: string[] = [];
+		const rest: Message[] = [];
+		for (const m of input) {
+			if (m.role === 'system') system.push(m.content);
+			else rest.push(m);
+		}
+		return system.length > 0 ? { messages: rest, system: system.join('\n\n') } : { messages: rest };
+	}
+	const explicit = input.system;
+	const inlineSystems: string[] = [];
+	const rest: Message[] = [];
+	for (const m of input.messages) {
+		if (m.role === 'system') inlineSystems.push(m.content);
+		else rest.push(m);
+	}
+	const combined = [explicit, ...inlineSystems]
+		.filter((s): s is string => typeof s === 'string' && s.length > 0)
+		.join('\n\n');
+	return combined.length > 0 ? { messages: rest, system: combined } : { messages: rest };
+}
+
+function extractTools(input: GenerateInput): ToolDef[] | undefined {
+	if (typeof input === 'string' || Array.isArray(input)) return undefined;
+	return input.tools;
+}
+
+/**
+ * Throw if the caller supplied `tools` on a Bedrock model family that this
+ * backend doesn't route them to. `capabilities()` advertises `tools: true`
+ * at the backend level, but only Anthropic-via-Bedrock actually consumes
+ * them in this PR — other families' body builders would silently drop
+ * the tools, leaving the caller unable to distinguish "model chose not to
+ * call" from "model never saw the tool". Loud error makes the
+ * unsupported-family case unambiguous; capability negotiation should
+ * eventually become model-aware (follow-up).
+ */
+function rejectToolsForFamily(input: GenerateInput, family: Family): void {
+	const tools = extractTools(input);
+	if (tools && tools.length > 0) {
+		throw new BedrockBackendError(
+			`Bedrock tool calls are not supported for model family '${family}' (only 'anthropic' models route tools in this version)`
+		);
+	}
+}
+
+function toAnthropicMessage(m: Message): AnthropicMessage {
+	if (m.role !== 'user' && m.role !== 'assistant' && m.role !== 'tool') {
+		return { role: 'user', content: m.content };
+	}
+	if (m.role === 'tool') {
+		return {
+			role: 'user',
+			content: [{ type: 'tool_result', tool_use_id: m.toolCallId ?? '', content: m.content }],
+		};
+	}
+	if (m.role === 'assistant' && m.toolCalls && m.toolCalls.length > 0) {
+		const blocks: AnthropicContentBlock[] = [];
+		if (m.content) blocks.push({ type: 'text', text: m.content });
+		for (const tc of m.toolCalls) {
+			blocks.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.arguments ?? {} });
+		}
+		return { role: 'assistant', content: blocks };
+	}
+	return { role: m.role, content: m.content };
+}
+
+function flattenToLlamaPrompt(input: GenerateInput): string {
+	if (typeof input === 'string') return input;
+	const messages = Array.isArray(input) ? input : input.messages;
+	const system = !Array.isArray(input) && typeof input.system === 'string' ? input.system : undefined;
+	const parts: string[] = [];
+	if (system) parts.push(`<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n${system}<|eot_id|>`);
+	for (const m of messages) {
+		parts.push(`<|start_header_id|>${m.role}<|end_header_id|>\n\n${m.content}<|eot_id|>`);
+	}
+	parts.push('<|start_header_id|>assistant<|end_header_id|>\n\n');
+	return parts.join('');
+}
+
+function flattenToFlatPrompt(input: GenerateInput): string {
+	if (typeof input === 'string') return input;
+	const messages = Array.isArray(input) ? input : input.messages;
+	const system = !Array.isArray(input) && typeof input.system === 'string' ? input.system : undefined;
+	const parts: string[] = [];
+	if (system) parts.push(`System: ${system}`);
+	for (const m of messages) parts.push(`${m.role[0].toUpperCase()}${m.role.slice(1)}: ${m.content}`);
+	parts.push('Assistant:');
+	return parts.join('\n\n');
+}
+
+// ---------- finish-reason mapping ----------
+
+function mapAnthropicStopReason(reason: string | null | undefined): GenerateResult['finishReason'] {
+	switch (reason) {
+		case 'max_tokens':
+			return 'length';
+		case 'tool_use':
+			return 'tool_calls';
+		case 'end_turn':
+		case 'stop_sequence':
+		default:
+			return 'stop';
+	}
+}
+
+function mapGenericStopReason(reason: string | null | undefined): GenerateResult['finishReason'] {
+	const r = (reason ?? '').toLowerCase();
+	if (r === 'length' || r === 'max_tokens' || r === 'max_token' || r === 'truncated') return 'length';
+	if (r === 'tool_calls' || r === 'tool_use' || r === 'function_call') return 'tool_calls';
+	if (r === 'content_filter' || r === 'content_filtered') return 'content_filter';
+	return 'stop';
+}
+
+// ---------- response parsing ----------
+
+function parseInvokeModelResponse(response: { body?: Uint8Array | string }): Record<string, unknown> {
+	if (!response.body) {
+		throw new BedrockBackendError('Bedrock InvokeModel response missing body');
+	}
+	const text =
+		typeof response.body === 'string' ? response.body : new TextDecoder('utf-8').decode(response.body as Uint8Array);
+	try {
+		return JSON.parse(text) as Record<string, unknown>;
+	} catch {
+		throw new BedrockBackendError('Bedrock InvokeModel response body is not valid JSON');
+	}
+}

--- a/components/ollama/index.ts
+++ b/components/ollama/index.ts
@@ -10,6 +10,13 @@
  * `handleApplication(scope)` self-loader.
  */
 import { setEmbedding, setGenerative } from '../../resources/models/backendRegistry.ts';
+import {
+	assignFiniteTokenCount,
+	composeSignal,
+	normalizeOrigin,
+	parseJsonResponse,
+	requireModel,
+} from '../../resources/models/backendHelpers.ts';
 import { ServerError } from '../../utility/errors/hdbError.ts';
 import type {
 	BackendOpts,
@@ -60,7 +67,7 @@ export class OllamaBackend implements ModelBackend {
 	readonly #fetch: typeof fetch;
 
 	constructor(config: OllamaBackendConfig = {}, fetchImpl: typeof fetch = fetch) {
-		this.#origin = normalizeOrigin(config.host);
+		this.#origin = normalizeOrigin(config.host, { host: DEFAULT_HOST, secure: false });
 		this.#defaultModel = config.model;
 		this.#requestTimeoutMs = config.requestTimeoutMs;
 		this.#fetch = fetchImpl;
@@ -72,11 +79,11 @@ export class OllamaBackend implements ModelBackend {
 
 	async embed(input: string | string[], opts: BackendOpts<EmbedOpts>): Promise<ModelCallResult<Float32Array[]>> {
 		const model = opts.model ?? this.#defaultModel;
-		requireModel(model, 'embed');
+		requireModel(model, 'embed', OllamaBackendError);
 		const texts = Array.isArray(input) ? input : [input];
 		const prepared = texts.map((t) => applyEmbedPrefix(model, t, opts.inputType));
 		const res = await this.#post('/api/embed', { model, input: prepared }, opts.signal);
-		const data = await parseJsonResponse<OllamaEmbedResponse>(res, '/api/embed');
+		const data = await parseJsonResponse<OllamaEmbedResponse>(res, 'Ollama /api/embed', OllamaBackendError);
 		if (!Array.isArray(data.embeddings)) {
 			throw new OllamaBackendError("Ollama /api/embed response missing 'embeddings' array");
 		}
@@ -98,10 +105,14 @@ export class OllamaBackend implements ModelBackend {
 
 	async generate(input: GenerateInput, opts: BackendOpts<GenerateOpts>): Promise<ModelCallResult<GenerateResult>> {
 		const model = opts.model ?? this.#defaultModel;
-		requireModel(model, 'generate');
+		requireModel(model, 'generate', OllamaBackendError);
 		const { endpoint, body } = buildGenerateRequest(model, input, opts, false);
 		const res = await this.#post(endpoint, body, opts.signal);
-		const data = await parseJsonResponse<OllamaGenerateResponse & OllamaChatResponse>(res, endpoint);
+		const data = await parseJsonResponse<OllamaGenerateResponse & OllamaChatResponse>(
+			res,
+			`Ollama ${endpoint}`,
+			OllamaBackendError
+		);
 		const rawContent = endpoint === '/api/chat' ? data.message?.content : data.response;
 		if (rawContent !== undefined && typeof rawContent !== 'string') {
 			throw new OllamaBackendError(`Ollama ${endpoint} response content is not a string`);
@@ -118,7 +129,7 @@ export class OllamaBackend implements ModelBackend {
 
 	async *generateStream(input: GenerateInput, opts: BackendOpts<GenerateOpts>): AsyncIterable<GenerateChunk> {
 		const model = opts.model ?? this.#defaultModel;
-		requireModel(model, 'generateStream');
+		requireModel(model, 'generateStream', OllamaBackendError);
 		const { endpoint, body } = buildGenerateRequest(model, input, opts, true);
 		const res = await this.#post(endpoint, body, opts.signal);
 		if (!res.body) throw new OllamaBackendError(`Ollama ${endpoint} returned no body for streaming`);
@@ -165,23 +176,6 @@ export class OllamaBackendError extends ServerError {
 }
 
 // ---------- internals ----------
-
-function normalizeOrigin(host?: string): string {
-	const value = host?.trim() || DEFAULT_HOST;
-	const withScheme = /^https?:\/\//i.test(value) ? value : `http://${value}`;
-	return withScheme.replace(/\/+$/, '');
-}
-
-function requireModel(model: string | undefined, op: string): asserts model is string {
-	if (!model) throw new OllamaBackendError(`No model specified for ${op}; set 'model' in config or pass opts.model`);
-}
-
-function composeSignal(caller?: AbortSignal, timeoutMs?: number): AbortSignal | undefined {
-	if (!timeoutMs) return caller;
-	const timeout = AbortSignal.timeout(timeoutMs);
-	if (!caller) return timeout;
-	return AbortSignal.any([caller, timeout]);
-}
 
 function applyEmbedPrefix(model: string, text: string, inputType?: 'document' | 'query'): string {
 	if (!inputType) return text;
@@ -291,35 +285,6 @@ function parseJsonLine(line: string): OllamaStreamChunk {
 		// of `hdb_model_calls.error_code` (analyticsTable.ts:35).
 		throw new OllamaBackendError('Invalid NDJSON line from Ollama');
 	}
-}
-
-/**
- * Read a JSON response body and throw `OllamaBackendError` on parse failure
- * instead of leaking the raw `SyntaxError` (whose message can include
- * upstream-derived bytes). Mirrors `parseJsonLine`'s sanitization posture.
- */
-async function parseJsonResponse<T>(res: Response, endpoint: string): Promise<T> {
-	try {
-		return (await res.json()) as T;
-	} catch {
-		throw new OllamaBackendError(`Ollama ${endpoint} returned a non-JSON response body`);
-	}
-}
-
-/**
- * Write a token count to `usage` only when the value is a finite, non-negative
- * integer. Rejects `NaN`, `Infinity`, `-Infinity`, negatives, and non-integers —
- * any of which would poison `SUM(prompt_tokens)`-style aggregates over
- * `hdb_model_calls`.
- */
-function assignFiniteTokenCount(
-	usage: TokenUsage,
-	key: 'promptTokens' | 'completionTokens' | 'embeddingTokens',
-	value: unknown
-): void {
-	if (typeof value !== 'number') return;
-	if (!Number.isFinite(value) || value < 0 || !Number.isInteger(value)) return;
-	usage[key] = value;
 }
 
 interface OllamaEmbedResponse {

--- a/components/openai/index.ts
+++ b/components/openai/index.ts
@@ -17,8 +17,15 @@
  * mapping is mechanical.
  */
 import { setEmbedding, setGenerative } from '../../resources/models/backendRegistry.ts';
+import {
+	assignFiniteTokenCount,
+	composeSignal,
+	normalizeOrigin,
+	parseJsonResponse,
+	requireCredential,
+	requireModel,
+} from '../../resources/models/backendHelpers.ts';
 import { ServerError } from '../../utility/errors/hdbError.ts';
-import { isUnresolvedEnvVarPlaceholder } from '../../utility/expandEnvVar.ts';
 import harperLogger from '../../utility/logging/harper_logger.ts';
 import type {
 	BackendOpts,
@@ -95,8 +102,8 @@ export class OpenAIBackend implements ModelBackend {
 	readonly #fetch: typeof fetch;
 
 	constructor(config: OpenAIBackendConfig = {}, fetchImpl: typeof fetch = fetch) {
-		this.#apiKey = requireApiKey(config.apiKey);
-		this.#baseUrl = normalizeBaseUrl(config.baseUrl);
+		this.#apiKey = requireCredential(config.apiKey, 'OpenAI', 'apiKey', OpenAIBackendError);
+		this.#baseUrl = normalizeOrigin(config.baseUrl, { host: DEFAULT_BASE_URL, secure: true });
 		this.#defaultModel = config.model;
 		this.#organization = config.organization;
 		this.#requestTimeoutMs = config.requestTimeoutMs;
@@ -109,13 +116,13 @@ export class OpenAIBackend implements ModelBackend {
 
 	async embed(input: string | string[], opts: BackendOpts<EmbedOpts>): Promise<ModelCallResult<Float32Array[]>> {
 		const model = opts.model ?? this.#defaultModel;
-		requireModel(model, 'embed');
+		requireModel(model, 'embed', OpenAIBackendError);
 		// inputType is honored as a hint but OpenAI's embedding models don't
 		// currently differentiate by it on the wire — pass through unchanged.
 		const texts = Array.isArray(input) ? input : [input];
 		const body: Record<string, unknown> = { model, input: texts };
 		const res = await this.#post('/embeddings', body, opts.signal);
-		const data = await parseJsonResponse<OpenAIEmbedResponse>(res, '/embeddings');
+		const data = await parseJsonResponse<OpenAIEmbedResponse>(res, 'OpenAI /embeddings', OpenAIBackendError);
 		if (!Array.isArray(data.data)) {
 			throw new OpenAIBackendError("OpenAI /embeddings response missing 'data' array");
 		}
@@ -139,10 +146,10 @@ export class OpenAIBackend implements ModelBackend {
 
 	async generate(input: GenerateInput, opts: BackendOpts<GenerateOpts>): Promise<ModelCallResult<GenerateResult>> {
 		const model = opts.model ?? this.#defaultModel;
-		requireModel(model, 'generate');
+		requireModel(model, 'generate', OpenAIBackendError);
 		const body = buildChatRequest(model, input, opts, false);
 		const res = await this.#post('/chat/completions', body, opts.signal);
-		const data = await parseJsonResponse<OpenAIChatResponse>(res, '/chat/completions');
+		const data = await parseJsonResponse<OpenAIChatResponse>(res, 'OpenAI /chat/completions', OpenAIBackendError);
 		const choice = data.choices?.[0];
 		if (!choice) {
 			throw new OpenAIBackendError('OpenAI /chat/completions response missing choices[0]');
@@ -165,7 +172,7 @@ export class OpenAIBackend implements ModelBackend {
 
 	async *generateStream(input: GenerateInput, opts: BackendOpts<GenerateOpts>): AsyncIterable<GenerateChunk> {
 		const model = opts.model ?? this.#defaultModel;
-		requireModel(model, 'generateStream');
+		requireModel(model, 'generateStream', OpenAIBackendError);
 		const body = buildChatRequest(model, input, opts, true);
 		const res = await this.#post('/chat/completions', body, opts.signal);
 		if (!res.body) throw new OpenAIBackendError('OpenAI /chat/completions returned no body for streaming');
@@ -280,38 +287,6 @@ export class OpenAIBackendError extends ServerError {
 }
 
 // ---------- internals ----------
-
-function normalizeBaseUrl(baseUrl?: string): string {
-	const value = baseUrl?.trim() || DEFAULT_BASE_URL;
-	const withScheme = /^https?:\/\//i.test(value) ? value : `https://${value}`;
-	return withScheme.replace(/\/+$/, '');
-}
-
-function requireApiKey(apiKey: string | undefined): string {
-	if (!apiKey || apiKey.length === 0) {
-		throw new OpenAIBackendError('OpenAI backend requires an apiKey');
-	}
-	if (isUnresolvedEnvVarPlaceholder(apiKey)) {
-		// Bootstrap ran `expandEnvVarsDeep` but the env var was unset, so the
-		// literal `${VAR_NAME}` survived. Tell the operator exactly what they
-		// need to set — much better than a 401 from upstream.
-		throw new OpenAIBackendError(
-			`OpenAI apiKey is the literal placeholder ${apiKey}; set the matching env var before starting Harper`
-		);
-	}
-	return apiKey;
-}
-
-function requireModel(model: string | undefined, op: string): asserts model is string {
-	if (!model) throw new OpenAIBackendError(`No model specified for ${op}; set 'model' in config or pass opts.model`);
-}
-
-function composeSignal(caller?: AbortSignal, timeoutMs?: number): AbortSignal | undefined {
-	if (!timeoutMs) return caller;
-	const timeout = AbortSignal.timeout(timeoutMs);
-	if (!caller) return timeout;
-	return AbortSignal.any([caller, timeout]);
-}
 
 function buildChatRequest(
 	model: string,
@@ -546,24 +521,6 @@ function parseSseEvent(block: string): OpenAIStreamEvent | 'done' | null {
 		// upstream-derived content.
 		throw new OpenAIBackendError('Invalid SSE data line from OpenAI');
 	}
-}
-
-async function parseJsonResponse<T>(res: Response, endpoint: string): Promise<T> {
-	try {
-		return (await res.json()) as T;
-	} catch {
-		throw new OpenAIBackendError(`OpenAI ${endpoint} returned a non-JSON response body`);
-	}
-}
-
-function assignFiniteTokenCount(
-	usage: TokenUsage,
-	key: 'promptTokens' | 'completionTokens' | 'embeddingTokens',
-	value: unknown
-): void {
-	if (typeof value !== 'number') return;
-	if (!Number.isFinite(value) || value < 0 || !Number.isInteger(value)) return;
-	usage[key] = value;
 }
 
 // ---------- OpenAI wire types (subset we actually read) ----------

--- a/dependencies.md
+++ b/dependencies.md
@@ -160,6 +160,19 @@ Generally, dependencies are added by simply adding them to the dependencies list
 - Binary compilation: No
 - Eventual removal: Required as long as we use pkijs. Could be replaced if Node.js adds native ASN.1 parsing or if we implement our own X.509 parser.
 
+## @aws-sdk/client-bedrock-runtime (optional peerDependency)
+
+- Need for usage: AWS Bedrock backend for `scope.models` (#510 Phase 6 / #633). Bedrock requires SigV4-signed requests against region-specific endpoints; rolling SigV4 ourselves is non-trivial and the AWS SDK does it correctly. The SDK also handles the standard AWS credential chain (env vars, shared profile, IAM roles, IRSA) which is exactly what we want.
+- Classification: **optional `peerDependency`**, not a direct dependency. Harper itself does not install the SDK — `package.json` declares it in `peerDependenciesMeta.@aws-sdk/client-bedrock-runtime.optional: true`. Modern npm / pnpm / yarn skip the auto-install and do not warn. The backend dynamic-imports the SDK on first call and throws `BedrockBackendError('@aws-sdk/client-bedrock-runtime is not installed. Add it to your project ...')` if it's missing. Customers that don't use the Bedrock backend pay zero install or runtime cost.
+- Size/memory cost: ~5 MB unpacked including transitive `@smithy/*`, `@aws-sdk/*` packages. Only loaded for users who explicitly opt in by adding the SDK to their own project's `package.json`.
+- Security: AWS-maintained, weekly-cadence releases. CVE history is in the standard AWS SDK channel; Harper does not freeze the patch range — operators install the version their project pins.
+- Environment interaction: None at Harper load time (dynamic import only fires when a Bedrock backend is registered AND a `scope.models` call is made). At runtime, the SDK uses the standard AWS credential chain.
+- Overlap: None. The other model backends (`ollama`, `openai`, `anthropic`) use native `fetch` directly; SigV4 is the genuine reason we use an SDK here and not on the other three.
+- Transitive dependencies: Large `@smithy/*` set required by the SDK runtime. Acceptable because installation is opt-in via peerDep.
+- Can be deferred: Yes, by design — dynamic-imported on first Bedrock call. Customers without Bedrock never load it.
+- Binary compilation: No.
+- Eventual removal: We could implement SigV4 ourselves (~300 lines) and call Bedrock's HTTP endpoint with native `fetch`, matching the pattern used by the other three backends. Worth revisiting if SDK version churn becomes a maintenance burden or if the optional-peerDep pattern proves operator-unfriendly. The dynamic-import boundary means the swap is contained to `components/bedrock/index.ts`.
+
 ## busboy
 
 - Need for usage: Streaming multipart/form-data parser for the operations API. Required so `deploy_component` payloads can exceed the Node.js 2 GB Buffer cap by being piped straight into extraction (gunzip + tar-fs) instead of buffered. Used only on the operations API ingest path; outbound multipart bodies on the CLI are formatted inline in `bin/multipartBuilder.ts` and do not depend on busboy.

--- a/integrationTests/server/anthropic-backend.test.ts
+++ b/integrationTests/server/anthropic-backend.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Anthropic backend integration test (#633, Phase 6 of #510).
+ *
+ * Exercises `AnthropicBackend` against the real Anthropic API to validate
+ * that the mocked wire format used in unit tests matches what the API
+ * actually produces. SKIPS when `ANTHROPIC_API_KEY` is unset.
+ *
+ * Override defaults via env:
+ *   - `ANTHROPIC_API_KEY`        (required to run)
+ *   - `ANTHROPIC_MODEL`          (default `claude-opus-4-7`)
+ *   - `ANTHROPIC_BASE_URL`       (default `https://api.anthropic.com`)
+ *
+ * Dynamic import inside before() — same workaround as openai for the
+ * pre-existing CJS require cycle (`harper_logger` ↔ `common_utils`).
+ */
+import { suite, test, before } from 'node:test';
+import { strictEqual, ok } from 'node:assert/strict';
+
+type AnthropicBackendCtor = new (
+	config: { apiKey: string; model?: string; baseUrl?: string; requestTimeoutMs?: number },
+	fetchImpl?: typeof fetch
+) => {
+	generate: (
+		input: unknown,
+		opts: object
+	) => Promise<{
+		status: string;
+		output: { content: string; finishReason: string; toolCalls?: unknown[] };
+		usage: object;
+	}>;
+	generateStream: (
+		input: unknown,
+		opts: object
+	) => AsyncIterable<{ deltaContent?: string; deltaToolCalls?: unknown[]; finishReason?: string }>;
+};
+
+const API_KEY = process.env.ANTHROPIC_API_KEY;
+const MODEL = process.env.ANTHROPIC_MODEL ?? 'claude-opus-4-7';
+const BASE_URL = process.env.ANTHROPIC_BASE_URL ?? 'https://api.anthropic.com';
+
+const ACCOUNTING = { tenantId: 'integration', app: '/integration' };
+
+const skip = !API_KEY;
+
+suite('AnthropicBackend against the real Anthropic API', { skip }, () => {
+	let backend: InstanceType<AnthropicBackendCtor>;
+
+	before(async () => {
+		const mod = (await import('../../components/anthropic/index.ts')) as { AnthropicBackend: AnthropicBackendCtor };
+		backend = new mod.AnthropicBackend({ apiKey: API_KEY!, baseUrl: BASE_URL });
+	});
+
+	test('generate produces non-empty content', async () => {
+		const result = await backend.generate('Reply with just OK.', {
+			accounting: ACCOUNTING,
+			model: MODEL,
+			maxTokens: 10,
+			temperature: 0,
+		});
+		strictEqual(result.status, 'completed');
+		ok(typeof result.output.content === 'string' && result.output.content.length > 0);
+		ok(['stop', 'length', 'tool_calls'].includes(result.output.finishReason));
+	});
+
+	test('generate via messages-array with system prompt', async () => {
+		const result = await backend.generate(
+			{
+				messages: [{ role: 'user', content: 'reply OK' }],
+				system: 'be brief',
+			},
+			{ accounting: ACCOUNTING, model: MODEL, maxTokens: 10, temperature: 0 }
+		);
+		strictEqual(result.status, 'completed');
+		ok(typeof result.output.content === 'string' && result.output.content.length > 0);
+	});
+
+	test('generate with tools (toolMode: return) surfaces tool_use blocks', async () => {
+		const tools = [
+			{
+				name: 'get_weather',
+				description: 'Get current weather for a location',
+				parameters: {
+					type: 'object',
+					properties: { location: { type: 'string' } },
+					required: ['location'],
+				},
+			},
+		];
+		const result = await backend.generate(
+			{
+				messages: [{ role: 'user', content: 'Weather in Tokyo? Call the tool.' }],
+				tools,
+			},
+			{ accounting: ACCOUNTING, model: MODEL, maxTokens: 256, temperature: 0 }
+		);
+		strictEqual(result.status, 'completed');
+		if (result.output.finishReason === 'tool_calls') {
+			ok(Array.isArray(result.output.toolCalls));
+			ok((result.output.toolCalls?.length ?? 0) > 0);
+			const tc = result.output.toolCalls![0] as { name: string; arguments: object };
+			strictEqual(tc.name, 'get_weather');
+		}
+	});
+
+	test('generateStream yields content + finishReason', async () => {
+		const chunks: { deltaContent?: string; finishReason?: string }[] = [];
+		for await (const chunk of backend.generateStream('Count: 1 2 3.', {
+			accounting: ACCOUNTING,
+			model: MODEL,
+			maxTokens: 30,
+			temperature: 0,
+		})) {
+			chunks.push(chunk);
+		}
+		ok(chunks.length > 0);
+		const hasContent = chunks.some((c) => typeof c.deltaContent === 'string' && c.deltaContent.length > 0);
+		ok(hasContent);
+		const terminal = chunks[chunks.length - 1];
+		ok(['stop', 'length', 'tool_calls'].includes(terminal.finishReason ?? ''));
+	});
+});

--- a/integrationTests/server/bedrock-backend.test.ts
+++ b/integrationTests/server/bedrock-backend.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Bedrock backend integration test (#633, Phase 6 of #510).
+ *
+ * Exercises `BedrockBackend` against the real AWS Bedrock API. SKIPS when:
+ *   - `RUN_BEDROCK_INTEGRATION` env is not set (opt-in — AWS calls cost money), OR
+ *   - `@aws-sdk/client-bedrock-runtime` is not installed locally (it's an
+ *     optional peerDependency, not a Harper direct dep).
+ *
+ * AWS credentials resolve via the SDK chain (env vars, IAM roles, shared
+ * profile, etc.). Set the standard `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and
+ * `AWS_SECRET_ACCESS_KEY` (or use a profile) in the calling shell.
+ *
+ * Override defaults via env:
+ *   - `BEDROCK_REGION`           (default `us-east-1`)
+ *   - `BEDROCK_GENERATE_MODEL`   (default `anthropic.claude-3-haiku-20240307-v1:0`)
+ *   - `BEDROCK_EMBED_MODEL`      (default `amazon.titan-embed-text-v2:0`)
+ */
+import { suite, test, before } from 'node:test';
+import { strictEqual, ok } from 'node:assert/strict';
+
+type BedrockBackendCtor = new (config: { region?: string; model?: string; requestTimeoutMs?: number }) => {
+	embed: (input: string | string[], opts: object) => Promise<{ status: string; output: Float32Array[]; usage: object }>;
+	generate: (
+		input: unknown,
+		opts: object
+	) => Promise<{ status: string; output: { content: string; finishReason: string }; usage: object }>;
+	generateStream: (input: unknown, opts: object) => AsyncIterable<{ deltaContent?: string; finishReason?: string }>;
+};
+
+const OPT_IN = process.env.RUN_BEDROCK_INTEGRATION === '1';
+const REGION = process.env.BEDROCK_REGION ?? 'us-east-1';
+const GEN_MODEL = process.env.BEDROCK_GENERATE_MODEL ?? 'anthropic.claude-3-haiku-20240307-v1:0';
+const EMBED_MODEL = process.env.BEDROCK_EMBED_MODEL ?? 'amazon.titan-embed-text-v2:0';
+
+const ACCOUNTING = { tenantId: 'integration', app: '/integration' };
+
+async function sdkInstalled(): Promise<boolean> {
+	try {
+		// @ts-expect-error optional peerDependency
+		await import('@aws-sdk/client-bedrock-runtime');
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+const skip = !OPT_IN || !(await sdkInstalled());
+
+suite('BedrockBackend against the real AWS Bedrock API', { skip }, () => {
+	let Ctor: BedrockBackendCtor;
+
+	before(async () => {
+		const mod = (await import('../../components/bedrock/index.ts')) as { BedrockBackend: BedrockBackendCtor };
+		Ctor = mod.BedrockBackend;
+	});
+
+	test('generate against an Anthropic-on-Bedrock model', async () => {
+		const backend = new Ctor({ region: REGION, model: GEN_MODEL });
+		const result = await backend.generate('Reply with just OK.', {
+			accounting: ACCOUNTING,
+			maxTokens: 20,
+			temperature: 0,
+		});
+		strictEqual(result.status, 'completed');
+		ok(typeof result.output.content === 'string' && result.output.content.length > 0);
+	});
+
+	test('generateStream against an Anthropic-on-Bedrock model', async () => {
+		const backend = new Ctor({ region: REGION, model: GEN_MODEL });
+		const chunks: { deltaContent?: string; finishReason?: string }[] = [];
+		for await (const c of backend.generateStream('Count: 1 2 3.', {
+			accounting: ACCOUNTING,
+			maxTokens: 30,
+			temperature: 0,
+		})) {
+			chunks.push(c);
+		}
+		ok(chunks.length > 0);
+		const hasContent = chunks.some((c) => typeof c.deltaContent === 'string' && c.deltaContent.length > 0);
+		ok(hasContent);
+		const terminal = chunks[chunks.length - 1];
+		ok(['stop', 'length', 'tool_calls'].includes(terminal.finishReason ?? ''));
+	});
+
+	test('embed against a Titan embedding model', async () => {
+		const backend = new Ctor({ region: REGION, model: EMBED_MODEL });
+		const result = await backend.embed('integration test', { accounting: ACCOUNTING });
+		strictEqual(result.status, 'completed');
+		strictEqual(result.output.length, 1);
+		ok(result.output[0] instanceof Float32Array);
+		ok(result.output[0].length > 0);
+	});
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,6 +136,14 @@
 				"bufferutil": "^4.0.9",
 				"segfault-handler": "^1.3.0",
 				"utf-8-validate": "^5.0.10"
+			},
+			"peerDependencies": {
+				"@aws-sdk/client-bedrock-runtime": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@aws-sdk/client-bedrock-runtime": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@agoric/babel-generator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,14 +136,6 @@
 				"bufferutil": "^4.0.9",
 				"segfault-handler": "^1.3.0",
 				"utf-8-validate": "^5.0.10"
-			},
-			"peerDependencies": {
-				"@aws-sdk/client-bedrock-runtime": "^3.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@aws-sdk/client-bedrock-runtime": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@agoric/babel-generator": {
@@ -354,7 +346,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1045.0.tgz",
 			"integrity": "sha512-fsuO3Y6t+3Ro9Bsg41DKj4Sfy53CGSrhnMldNplWmG8Tx0UbYk+YDa4RD1hVlJpERw4JBmPkl0+J9qlxMh1pcA==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha1-browser": "5.2.0",
 				"@aws-crypto/sha256-browser": "5.2.0",
@@ -1040,8 +1031,52 @@
 			"integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/core": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
+				"@babel/helper-compilation-targets": "^7.28.6",
+				"@babel/helper-module-transforms": "^7.28.6",
+				"@babel/helpers": "^7.28.6",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/traverse": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"@jridgewell/remapping": "^2.3.5",
+				"convert-source-map": "^2.0.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"node_modules/@babel/core/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@babel/generator": {
@@ -1074,6 +1109,7 @@
 			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.28.6",
 				"@babel/helper-validator-option": "^7.27.1",
@@ -1091,6 +1127,7 @@
 			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 			"license": "ISC",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"yallist": "^3.0.2"
 			}
@@ -1101,6 +1138,7 @@
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"license": "ISC",
 			"optional": true,
+			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -1118,6 +1156,7 @@
 			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/traverse": "^7.28.6",
 				"@babel/types": "^7.28.6"
@@ -1132,6 +1171,7 @@
 			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.28.6",
 				"@babel/helper-validator-identifier": "^7.28.5",
@@ -1150,6 +1190,7 @@
 			"integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -1174,6 +1215,7 @@
 			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -1184,6 +1226,7 @@
 			"integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/template": "^7.28.6",
 				"@babel/types": "^7.29.0"
@@ -1211,6 +1254,7 @@
 			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1224,6 +1268,7 @@
 			"integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1237,6 +1282,7 @@
 			"integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.12.13"
 			},
@@ -1250,6 +1296,7 @@
 			"integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.14.5"
 			},
@@ -1266,6 +1313,7 @@
 			"integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.28.6"
 			},
@@ -1282,6 +1330,7 @@
 			"integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			},
@@ -1295,6 +1344,7 @@
 			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1308,6 +1358,7 @@
 			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			},
@@ -1321,6 +1372,7 @@
 			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1334,6 +1386,7 @@
 			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			},
@@ -1347,6 +1400,7 @@
 			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1360,6 +1414,7 @@
 			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1373,6 +1428,7 @@
 			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1386,6 +1442,7 @@
 			"integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.14.5"
 			},
@@ -1402,6 +1459,7 @@
 			"integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.14.5"
 			},
@@ -2586,7 +2644,6 @@
 			"version": "8.44.0",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.44.0",
 				"@typescript-eslint/types": "8.44.0",
@@ -2919,6 +2976,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2934,6 +2994,9 @@
 			"integrity": "sha512-f5Myta9ke0DBF901ehckMflm1DIOTNaKWMfzoJVuQIHwW8QT1+ZFUBz2dLKnoveIKWuE8r4TVW29YDW/oo6m2g==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -2951,6 +3014,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2966,6 +3032,9 @@
 			"integrity": "sha512-u0LN3maKDemGDGfA77aYr2HSpLl9ilOhQOFcLSjAtYrZlquxvNRGQR60aE0VIC/quui6Xdu7zHOVY9aLZpqW3g==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -3175,6 +3244,7 @@
 			"integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
 			"license": "ISC",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -3185,6 +3255,7 @@
 			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
 			"license": "ISC",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"camelcase": "^5.3.1",
 				"find-up": "^4.1.0",
@@ -3202,6 +3273,7 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -3212,6 +3284,7 @@
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -3222,6 +3295,7 @@
 			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"locate-path": "^5.0.0",
 				"path-exists": "^4.0.0"
@@ -3236,6 +3310,7 @@
 			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -3250,6 +3325,7 @@
 			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"p-locate": "^4.1.0"
 			},
@@ -3263,6 +3339,7 @@
 			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"p-try": "^2.0.0"
 			},
@@ -3279,6 +3356,7 @@
 			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"p-limit": "^2.2.0"
 			},
@@ -3292,6 +3370,7 @@
 			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3302,6 +3381,7 @@
 			"integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3312,6 +3392,7 @@
 			"integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jest/types": "^29.6.3"
 			},
@@ -3325,6 +3406,7 @@
 			"integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jest/fake-timers": "^29.7.0",
 				"@jest/types": "^29.6.3",
@@ -3341,6 +3423,7 @@
 			"integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jest/types": "^29.6.3",
 				"@sinonjs/fake-timers": "^10.0.2",
@@ -3359,6 +3442,7 @@
 			"integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
 			"license": "BSD-3-Clause",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@sinonjs/commons": "^3.0.0"
 			}
@@ -3369,6 +3453,7 @@
 			"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@sinclair/typebox": "^0.27.8"
 			},
@@ -3382,6 +3467,7 @@
 			"integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.11.6",
 				"@jest/types": "^29.6.3",
@@ -3409,6 +3495,7 @@
 			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jest/schemas": "^29.6.3",
 				"@types/istanbul-lib-coverage": "^2.0.0",
@@ -3435,6 +3522,7 @@
 			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.24"
@@ -3453,6 +3541,7 @@
 			"integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25"
@@ -3575,7 +3664,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3589,7 +3677,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3603,7 +3690,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3617,7 +3703,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3631,7 +3716,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3645,7 +3729,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3831,6 +3914,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3848,6 +3934,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3865,6 +3954,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3882,6 +3974,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3899,6 +3994,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3916,6 +4014,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3933,6 +4034,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3950,6 +4054,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4072,6 +4179,7 @@
 			"integrity": "sha512-B1SRwpntaAcckiatxbjzylvNK562Ayza05gdJCjDQHTiDafa1OABmyB5LHt7qWDOpNkaluD+w11vHF7pBmTpzQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 20.19.4"
 			}
@@ -4082,6 +4190,7 @@
 			"integrity": "sha512-ezXTN70ygVm9l2m0i+pAlct0RntoV4afftWMGUIeAWLgaca9qItQ54uOt32I/9dBJvzBibT33luIR/pBG0dQvg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.25.2",
 				"@babel/parser": "^7.25.3",
@@ -4103,7 +4212,8 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@react-native/codegen/node_modules/brace-expansion": {
 			"version": "1.1.14",
@@ -4111,6 +4221,7 @@
 			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -4122,6 +4233,7 @@
 			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
 			"license": "ISC",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.1",
@@ -4138,6 +4250,7 @@
 			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"license": "ISC",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -4159,6 +4272,7 @@
 			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"license": "ISC",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -4172,6 +4286,7 @@
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -4190,6 +4305,7 @@
 			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
@@ -4209,6 +4325,7 @@
 			"integrity": "sha512-H/eMdtOy9nEeX7YVeEG1N2vyCoifw3dr9OV8++xfUElNYV7LtSmJ6AqxZUUfxGJRDFPQvaU/8enmJlM/l11VxQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-native/dev-middleware": "0.82.1",
 				"debug": "^4.4.0",
@@ -4240,6 +4357,7 @@
 			"integrity": "sha512-a2O6M7/OZ2V9rdavOHyCQ+10z54JX8+B+apYKCQ6a9zoEChGTxUMG2YzzJ8zZJVvYf1ByWSNxv9Se0dca1hO9A==",
 			"license": "BSD-3-Clause",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 20.19.4"
 			}
@@ -4250,6 +4368,7 @@
 			"integrity": "sha512-fdRHAeqqPT93bSrxfX+JHPpCXHApfDUdrXMXhoxlPgSzgXQXJDykIViKhtpu0M6slX6xU/+duq+AtP/qWJRpBw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"cross-spawn": "^7.0.6",
 				"fb-dotslash": "0.5.8"
@@ -4264,6 +4383,7 @@
 			"integrity": "sha512-wuOIzms/Qg5raBV6Ctf2LmgzEOCqdP3p1AYN4zdhMT110c39TVMbunpBaJxm0Kbt2HQ762MQViF9naxk7SBo4w==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@isaacs/ttlcache": "^1.4.1",
 				"@react-native/debugger-frontend": "0.82.1",
@@ -4288,6 +4408,7 @@
 			"integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"async-limiter": "~1.0.0"
 			}
@@ -4298,6 +4419,7 @@
 			"integrity": "sha512-KkF/2T1NSn6EJ5ALNT/gx0MHlrntFHv8YdooH9OOGl9HQn5NM0ZmQSr86o5utJsGc7ME3R6p3SaQuzlsFDrn8Q==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 20.19.4"
 			}
@@ -4308,6 +4430,7 @@
 			"integrity": "sha512-tf70X7pUodslOBdLN37J57JmDPB/yiZcNDzS2m+4bbQzo8fhx3eG9QEBv5n4fmzqfGAgSB4BWRHgDMXmmlDSVA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 20.19.4"
 			}
@@ -4317,7 +4440,8 @@
 			"resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.82.1.tgz",
 			"integrity": "sha512-CCfTR1uX+Z7zJTdt3DNX9LUXr2zWXsNOyLbwupW2wmRzrxlHRYfmLgTABzRL/cKhh0Ubuwn15o72MQChvCRaHw==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@react-native/virtualized-lists": {
 			"version": "0.82.1",
@@ -4325,6 +4449,7 @@
 			"integrity": "sha512-f5zpJg9gzh7JtCbsIwV+4kP3eI0QBuA93JGmwFRd4onQ3DnCjV2J5pYqdWtM95sjSKK1dyik59Gj01lLeKqs1Q==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"invariant": "^2.2.4",
 				"nullthrows": "^1.1.1"
@@ -4363,7 +4488,8 @@
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
 			"integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@sinonjs/commons": {
 			"version": "3.0.1",
@@ -4408,6 +4534,7 @@
 			"integrity": "sha512-GW2yqqOTzdz3K6z0XpPO1EjLzOw0kclmAcLeW6cBt0DYM7ZNLRKanpzXxaSXkePpo4ZYMWhddE4WpSWG8e/QaQ==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
@@ -5356,6 +5483,7 @@
 			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/parser": "^7.20.7",
 				"@babel/types": "^7.20.7",
@@ -5370,6 +5498,7 @@
 			"integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/types": "^7.0.0"
 			}
@@ -5380,6 +5509,7 @@
 			"integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/parser": "^7.1.0",
 				"@babel/types": "^7.0.0"
@@ -5391,6 +5521,7 @@
 			"integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/types": "^7.28.2"
 			}
@@ -5434,6 +5565,7 @@
 			"integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -5451,7 +5583,8 @@
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
 			"integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@types/istanbul-lib-report": {
 			"version": "3.0.3",
@@ -5459,6 +5592,7 @@
 			"integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@types/istanbul-lib-coverage": "*"
 			}
@@ -5469,6 +5603,7 @@
 			"integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@types/istanbul-lib-report": "*"
 			}
@@ -5521,7 +5656,6 @@
 		"node_modules/@types/node": {
 			"version": "25.4.0",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.18.0"
 			}
@@ -5551,7 +5685,8 @@
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
 			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@types/tar-fs": {
 			"version": "2.0.4",
@@ -5586,6 +5721,7 @@
 			"integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@types/yargs-parser": "*"
 			}
@@ -5595,7 +5731,8 @@
 			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
 			"integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "8.59.2",
@@ -5640,7 +5777,6 @@
 			"integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.59.2",
 				"@typescript-eslint/types": "8.59.2",
@@ -5846,6 +5982,7 @@
 			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"mime-types": "^3.0.0",
 				"negotiator": "^1.0.0"
@@ -5860,6 +5997,7 @@
 			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"mime-db": "^1.54.0"
 			},
@@ -5875,7 +6013,6 @@
 			"version": "8.16.0",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -5897,6 +6034,7 @@
 			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 14"
 			}
@@ -5982,7 +6120,8 @@
 			"resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
 			"integrity": "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/ansi-escapes": {
 			"version": "4.3.2",
@@ -6023,6 +6162,7 @@
 			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
 			"license": "ISC",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
@@ -6066,6 +6206,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6077,6 +6218,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6109,7 +6251,8 @@
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
 			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
@@ -6171,6 +6314,7 @@
 			"integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jest/transform": "^29.7.0",
 				"@types/babel__core": "^7.1.14",
@@ -6193,6 +6337,7 @@
 			"integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
 			"license": "BSD-3-Clause",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@istanbuljs/load-nyc-config": "^1.0.0",
@@ -6210,6 +6355,7 @@
 			"integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/template": "^7.3.3",
 				"@babel/types": "^7.3.3",
@@ -6226,6 +6372,7 @@
 			"integrity": "sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"hermes-parser": "0.32.0"
 			}
@@ -6236,6 +6383,7 @@
 			"integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-bigint": "^7.8.3",
@@ -6263,6 +6411,7 @@
 			"integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"babel-plugin-jest-hoist": "^29.6.3",
 				"babel-preset-current-node-syntax": "^1.0.0"
@@ -6386,6 +6535,7 @@
 			"integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"bin": {
 				"baseline-browser-mapping": "dist/cli.cjs"
 			},
@@ -6512,12 +6662,48 @@
 				"pako": "~0.2.0"
 			}
 		},
+		"node_modules/browserslist": {
+			"version": "4.28.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"baseline-browser-mapping": "^2.10.12",
+				"caniuse-lite": "^1.0.30001782",
+				"electron-to-chromium": "^1.5.328",
+				"node-releases": "^2.0.36",
+				"update-browserslist-db": "^1.2.3"
+			},
+			"bin": {
+				"browserslist": "cli.js"
+			},
+			"engines": {
+				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			}
+		},
 		"node_modules/bser": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
 			"integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"node-int64": "^0.4.0"
 			}
@@ -6537,6 +6723,32 @@
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
 			"license": "MIT"
+		},
+		"node_modules/bufferutil": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+			"integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"node-gyp-build": "^4.3.0"
+			},
+			"engines": {
+				"node": ">=6.14.2"
+			}
+		},
+		"node_modules/bufferutil/node_modules/node-gyp-build": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+			"license": "MIT",
+			"optional": true,
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
+			}
 		},
 		"node_modules/busboy": {
 			"version": "1.6.0",
@@ -6635,7 +6847,8 @@
 				}
 			],
 			"license": "CC-BY-4.0",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/cbor-extract": {
 			"version": "2.2.2",
@@ -6668,7 +6881,6 @@
 			"version": "6.2.2",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -6737,6 +6949,7 @@
 			"integrity": "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@types/node": "*",
 				"escape-string-regexp": "^4.0.0",
@@ -6756,6 +6969,7 @@
 			"integrity": "sha512-JfJjUnq25y9yg4FABRRVPmBGWPZZi+AQXT4mxupb67766/0UlhG8PAZCz6xzEMXTbW3CsSoE8PcCWA49n35mKg==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@types/node": "*",
 				"escape-string-regexp": "^4.0.0",
@@ -6777,6 +6991,7 @@
 			],
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -6856,6 +7071,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"is-regexp": "^1.0.0",
 				"is-supported-regexp-flag": "^1.0.0"
@@ -6902,6 +7118,7 @@
 			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -6970,6 +7187,7 @@
 			"integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"debug": "2.6.9",
 				"finalhandler": "1.1.2",
@@ -6986,6 +7204,7 @@
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"ms": "2.0.0"
 			}
@@ -6995,7 +7214,8 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/content-disposition": {
 			"version": "1.0.1",
@@ -7013,7 +7233,8 @@
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/cookie": {
 			"version": "1.1.1",
@@ -7211,6 +7432,7 @@
 			"integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8",
 				"npm": "1.2.8000 || >= 1.4.16"
@@ -7316,7 +7538,8 @@
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz",
 			"integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
 			"license": "ISC",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -7342,6 +7565,7 @@
 			"integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"stackframe": "^1.3.4"
 			}
@@ -7454,7 +7678,6 @@
 			"version": "9.39.4",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -7513,7 +7736,6 @@
 			"version": "10.1.8",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -7650,6 +7872,7 @@
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
 			"license": "BSD-2-Clause",
 			"optional": true,
+			"peer": true,
 			"bin": {
 				"esparse": "bin/esparse.js",
 				"esvalidate": "bin/esvalidate.js"
@@ -7750,6 +7973,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"clone-regexp": "^1.0.0"
 			},
@@ -7762,7 +7986,8 @@
 			"resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
 			"integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
 			"license": "Apache-2.0",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/eyes": {
 			"version": "0.1.8",
@@ -8059,6 +8284,7 @@
 			"integrity": "sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==",
 			"license": "(MIT OR Apache-2.0)",
 			"optional": true,
+			"peer": true,
 			"bin": {
 				"dotslash": "bin/dotslash"
 			},
@@ -8072,6 +8298,7 @@
 			"integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"bser": "2.1.1"
 			}
@@ -8128,6 +8355,7 @@
 			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"debug": "2.6.9",
 				"encodeurl": "~1.0.2",
@@ -8147,6 +8375,7 @@
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"ms": "2.0.0"
 			}
@@ -8157,6 +8386,7 @@
 			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -8166,7 +8396,8 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/finalhandler/node_modules/on-finished": {
 			"version": "2.3.0",
@@ -8174,6 +8405,7 @@
 			"integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"ee-first": "1.1.1"
 			},
@@ -8187,6 +8419,7 @@
 			"integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -8248,7 +8481,8 @@
 			"resolved": "https://registry.npmjs.org/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz",
 			"integrity": "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/follow-redirects": {
 			"version": "1.16.0",
@@ -8354,7 +8588,8 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"license": "ISC",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
@@ -8390,6 +8625,7 @@
 			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -8457,6 +8693,7 @@
 			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -8575,7 +8812,6 @@
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
 			"integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
 			}
@@ -8641,6 +8877,7 @@
 			"integrity": "sha512-RRXMLbbdymiZsHOeg5b+DShzsMvVvkgsG9690BBCc7tzIpDb0CT7EgWEQo+rwCICr35EwZoLjtfwF6mMiCOenA==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@aws-sdk/client-s3": "^3.1012.0",
 				"@aws-sdk/lib-storage": "3.964.0",
@@ -8743,6 +8980,7 @@
 			"integrity": "sha512-ro6B04Q5TjPgIKdSWGJ+tj2ordVF1IfZJERwGpYkrwhboNEoXBXuzpfnh2LYBPvMmFJQ+8UXSFw1jkLLgxM+ig==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@smithy/abort-controller": "^4.2.7",
 				"@smithy/middleware-endpoint": "^4.4.1",
@@ -8765,6 +9003,7 @@
 			"integrity": "sha512-gipd/g0USN8ncvRMdoaru8PxYNUSEJp//+XbLf+3VNDQ6gcSsTcYqyNa3f+oEKIyV0clpOkxzautkN7hVPsn/g==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@harperfast/extended-iterable": "1.0.3",
 				"msgpackr": "1.11.9",
@@ -8797,6 +9036,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8814,6 +9054,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8826,11 +9067,15 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8843,11 +9088,15 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8860,11 +9109,15 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8877,11 +9130,15 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8899,6 +9156,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8916,6 +9174,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8932,7 +9191,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/harper/node_modules/@lmdb/lmdb-darwin-x64": {
 			"version": "3.5.3",
@@ -8946,7 +9206,8 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/harper/node_modules/@lmdb/lmdb-linux-arm": {
 			"version": "3.5.3",
@@ -8960,7 +9221,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/harper/node_modules/@lmdb/lmdb-linux-arm64": {
 			"version": "3.5.3",
@@ -8974,7 +9236,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/harper/node_modules/@lmdb/lmdb-linux-x64": {
 			"version": "3.5.3",
@@ -8988,7 +9251,8 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/harper/node_modules/@lmdb/lmdb-win32-arm64": {
 			"version": "3.5.3",
@@ -9002,7 +9266,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/harper/node_modules/@lmdb/lmdb-win32-x64": {
 			"version": "3.5.3",
@@ -9016,7 +9281,8 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/harper/node_modules/alasql": {
 			"version": "4.6.6",
@@ -9024,6 +9290,7 @@
 			"integrity": "sha512-kuRnDciFgtWSR2tpgraFwE6Q19PmeY9d2O2JzXdpEd38xoBrbp3qKDiGhzBvKfrxpuimwn+6w94FXE9NT3hJsg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cross-fetch": "4.1.0",
 				"yargs": "16"
@@ -9041,6 +9308,7 @@
 			"integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"pvtsutils": "^1.3.6",
 				"pvutils": "^1.1.3",
@@ -9056,6 +9324,7 @@
 			"integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
@@ -9071,6 +9340,7 @@
 			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			},
@@ -9085,6 +9355,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@harperfast/extended-iterable": "^1.0.3",
 				"msgpackr": "^1.11.2",
@@ -9112,6 +9383,7 @@
 			"integrity": "sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"optionalDependencies": {
 				"msgpackr-extract": "^3.0.2"
 			}
@@ -9122,6 +9394,7 @@
 			"integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"iconv-lite": "^0.6.3",
 				"sax": "^1.2.4"
@@ -9138,7 +9411,8 @@
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
 			"integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/harper/node_modules/node-gyp-build-optional-packages": {
 			"version": "5.2.2",
@@ -9146,6 +9420,7 @@
 			"integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"detect-libc": "^2.0.1"
 			},
@@ -9161,6 +9436,7 @@
 			"integrity": "sha512-UUmvQ/7KTZt/vHjhRrnyS7h+J7qPBQnpG80V56xmIC+o9IqYmQOw/UIny9S9zYDfRBR0ClouCr464EkBMIT7Fw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"atomic-sleep": "^1.0.0",
 				"fast-redact": "^3.1.1",
@@ -9184,6 +9460,7 @@
 			"integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"readable-stream": "^4.0.0",
 				"split2": "^4.0.0"
@@ -9195,6 +9472,7 @@
 			"integrity": "sha512-WX0la7n7CbnguuaIQoT4Fc0IJckPDOUldzOwlZ0nwpOcySS+Six/tXBdc0RX17J5o1To0SAr3xDJjDLsOfDFQA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"@noble/hashes": "^1.4.0",
 				"asn1js": "^3.0.5",
@@ -9212,7 +9490,8 @@
 			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.3.2.tgz",
 			"integrity": "sha512-n9wh8tvBe5sFmsqlg+XQhaQLumwpqoAUruLwjCopgTmUBjJ/fjtBsJzKleCaIGBOMXYEhp1YfKl4d7rJ5ZKJGA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/harper/node_modules/readable-stream": {
 			"version": "4.7.0",
@@ -9220,6 +9499,7 @@
 			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"abort-controller": "^3.0.0",
 				"buffer": "^6.0.3",
@@ -9251,6 +9531,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.2.1"
@@ -9262,6 +9543,7 @@
 			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -9275,6 +9557,7 @@
 			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"engines": {
 				"node": ">= 10.x"
 			}
@@ -9285,6 +9568,7 @@
 			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
 			}
@@ -9299,6 +9583,7 @@
 				"https://github.com/sponsors/ctavan"
 			],
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"uuid": "dist/esm/bin/uuid"
 			}
@@ -9309,6 +9594,7 @@
 			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -9331,6 +9617,7 @@
 			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"bin": {
 				"yaml": "bin.mjs"
 			},
@@ -9398,6 +9685,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"parse-columns": "git+https://github.com/int0h/parse-columns.git"
 			}
@@ -9422,14 +9710,16 @@
 			"resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-0.0.0.tgz",
 			"integrity": "sha512-boVFutx6ME/Km2mB6vvsQcdnazEYYI/jV1pomx1wcFUG/EVqTkr5CU0CW9bKipOA/8Hyu3NYwW3THg2Q1kNCfA==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/hermes-estree": {
 			"version": "0.32.0",
 			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
 			"integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/hermes-parser": {
 			"version": "0.32.0",
@@ -9437,6 +9727,7 @@
 			"integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"hermes-estree": "0.32.0"
 			}
@@ -9465,6 +9756,7 @@
 			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"agent-base": "^7.1.2",
 				"debug": "4"
@@ -9526,6 +9818,7 @@
 			"integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"queue": "6.0.2"
 			},
@@ -9566,6 +9859,7 @@
 			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
 			"license": "ISC",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -9662,6 +9956,7 @@
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.0.0"
 			}
@@ -9721,6 +10016,7 @@
 			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"bin": {
 				"is-docker": "cli.js"
 			},
@@ -9745,6 +10041,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			},
@@ -9832,6 +10129,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -9843,6 +10141,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -9863,6 +10162,7 @@
 			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"is-docker": "^2.0.0"
 			},
@@ -9888,6 +10188,7 @@
 			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
 			"license": "BSD-3-Clause",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -9898,6 +10199,7 @@
 			"integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
 			"license": "BSD-3-Clause",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.12.3",
 				"@babel/parser": "^7.14.7",
@@ -9915,6 +10217,7 @@
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"license": "ISC",
 			"optional": true,
+			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -9943,6 +10246,7 @@
 			"integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jest/environment": "^29.7.0",
 				"@jest/fake-timers": "^29.7.0",
@@ -9961,6 +10265,7 @@
 			"integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
@@ -9971,6 +10276,7 @@
 			"integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jest/types": "^29.6.3",
 				"@types/graceful-fs": "^4.1.3",
@@ -9997,6 +10303,7 @@
 			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.12.13",
 				"@jest/types": "^29.6.3",
@@ -10018,6 +10325,7 @@
 			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jest/types": "^29.6.3",
 				"@types/node": "*",
@@ -10033,6 +10341,7 @@
 			"integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
@@ -10043,6 +10352,7 @@
 			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jest/types": "^29.6.3",
 				"@types/node": "*",
@@ -10061,6 +10371,7 @@
 			"integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jest/types": "^29.6.3",
 				"camelcase": "^6.2.0",
@@ -10079,6 +10390,7 @@
 			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -10089,6 +10401,7 @@
 			"integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@types/node": "*",
 				"jest-util": "^29.7.0",
@@ -10105,6 +10418,7 @@
 			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -10155,7 +10469,8 @@
 			"resolved": "https://registry.npmjs.org/jsc-safe-url/-/jsc-safe-url-0.2.4.tgz",
 			"integrity": "sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==",
 			"license": "0BSD",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/jsesc": {
 			"version": "2.5.2",
@@ -10212,6 +10527,7 @@
 			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"bin": {
 				"json5": "lib/cli.js"
 			},
@@ -10340,6 +10656,7 @@
 			"integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"debug": "^2.6.9",
 				"marky": "^1.2.2"
@@ -10351,6 +10668,7 @@
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"ms": "2.0.0"
 			}
@@ -10360,7 +10678,8 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/lmdb": {
 			"version": "3.5.4",
@@ -10496,7 +10815,8 @@
 			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
 			"integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/lodash.toarray": {
 			"version": "3.0.2",
@@ -10528,6 +10848,7 @@
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			},
@@ -10548,6 +10869,7 @@
 			"integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
 			"license": "BSD-3-Clause",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tmpl": "1.0.5"
 			}
@@ -10557,7 +10879,8 @@
 			"resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
 			"integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
 			"license": "Apache-2.0",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
@@ -10592,14 +10915,16 @@
 			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
 			"integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -10622,6 +10947,7 @@
 			"integrity": "sha512-SPaPEyvTsTmd0LpT7RaZciQyDw2i/JB7+iY9L5VfBo72+psescFxBqpI1TL9dnL+pmnfkU+l/J1mEEGLeF65EQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/core": "^7.25.2",
@@ -10676,6 +11002,7 @@
 			"integrity": "sha512-sBqBkt6kNut/88bv+Ucvm4yqdPetbvAEsHzi3MAgJEifOSYYzX5Z5Kgw3TFOrwf/mHJTOBG2ONlaMHoyfP15TA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.25.2",
 				"flow-enums-runtime": "^0.0.6",
@@ -10692,7 +11019,8 @@
 			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
 			"integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/metro-babel-transformer/node_modules/hermes-parser": {
 			"version": "0.35.0",
@@ -10700,6 +11028,7 @@
 			"integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"hermes-estree": "0.35.0"
 			}
@@ -10710,6 +11039,7 @@
 			"integrity": "sha512-E9SRePXQ1Zvlj79VcOk57q7VC7rMHMFQ+jhmPHBiq+dJ0bJB5BL87lWZF6oh5X76Cci5tpDuQNaDwwuSCToEeg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"exponential-backoff": "^3.1.1",
 				"flow-enums-runtime": "^0.0.6",
@@ -10726,6 +11056,7 @@
 			"integrity": "sha512-W1c2Nmx8MiJTJt+eWhMO08z9VKi3kZOaz99IYGdqeqDgY9j+yZjXl62rUav4Di0heZfh4/n2s722PqRL1OODeg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"flow-enums-runtime": "^0.0.6"
 			},
@@ -10739,6 +11070,7 @@
 			"integrity": "sha512-83mjWFbFOt2GeJ6pFIum5mSnc1uTsZJAtD8o4ej0s4NVsYsA7fB+pHvTfHhFrpeMONaobu2riKavkPei05Er/Q==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"connect": "^3.6.5",
 				"flow-enums-runtime": "^0.0.6",
@@ -10759,6 +11091,7 @@
 			"integrity": "sha512-6yn3w1wnltT6RQl7p7YES2l95ArC+mWrOssEiH8p5/DDrJS65/szf9LsC9JrBv8c5DdvSY3V3f0GRYg0Ox7hCg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"flow-enums-runtime": "^0.0.6",
 				"lodash.throttle": "^4.1.1",
@@ -10774,6 +11107,7 @@
 			"integrity": "sha512-+j0F1m+FQYVAQ6syf+mwhIPV5GoFQrkInX8bppuc50IzNsZbMrp8R5H/Sx/K2daQ3YEa9F/XwkeZT8gzJfgeCw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"debug": "^4.4.0",
 				"fb-watchman": "^2.0.0",
@@ -10795,6 +11129,7 @@
 			"integrity": "sha512-MfJar2IS4tBRuLb9svwb0Gu5l9BsH+pcRm8eGcEi/wy8MzZinfinh5dFLt2nWkocnulIgtGB5NkFDdbXqMXKhQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"flow-enums-runtime": "^0.0.6",
 				"terser": "^5.15.0"
@@ -10809,6 +11144,7 @@
 			"integrity": "sha512-WSJIENlMcoSsuz66IfBHOkgfp3KJt2UW2TnEHPf1b8pIG2eEXNOVmo2+03A0H17WY2XGXWgxL0CG7FAopqgB1A==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"flow-enums-runtime": "^0.0.6"
 			},
@@ -10822,6 +11158,7 @@
 			"integrity": "sha512-9GKkJURaB2iyYoEExKnedzAHzxmKtSi+k0tsZUvMoU27tBZJElchYt7JH/Ai/XzYAI9lCAaV7u5HZSI8J5Z+wQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.25.0",
 				"flow-enums-runtime": "^0.0.6"
@@ -10836,6 +11173,7 @@
 			"integrity": "sha512-JgA1h7oc1a1jydBe1GhVFsUoMYo3wLPk7oRA32rjlDsq+sP2JLt9x2p2lWbNSxTm/u8NV4VRid3hvEJgcX8tKw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/traverse": "^7.29.0",
 				"@babel/types": "^7.29.0",
@@ -10857,6 +11195,7 @@
 			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
 			"license": "BSD-3-Clause",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -10867,6 +11206,7 @@
 			"integrity": "sha512-g4suyxw20WOHWI680c+Kq4wC/NF+Hx5pRH9afrMp+sMTxqLeKcPR1Xf4wMhsjlbvx7LbIREdke6q928jEjvJWw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"flow-enums-runtime": "^0.0.6",
 				"invariant": "^2.2.4",
@@ -10888,6 +11228,7 @@
 			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
 			"license": "BSD-3-Clause",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -10898,6 +11239,7 @@
 			"integrity": "sha512-Ss0FpBiZDjX2kwhukMDl5sNdYK8T/06IPqxNE4H6PTlRlfs9q11cef13c/xESY/Pm4VCkp1yJUZO3kXzvMxQFA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.25.2",
 				"@babel/generator": "^7.29.1",
@@ -10916,6 +11258,7 @@
 			"integrity": "sha512-UegCo7ygB2fT64mRK2nbAjQVJ1zSwIIHy8d96jJv2nKZFDaViYBiughEdu5HM/Ceq0WN3LZrZk3zhl9aoiLYFw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.25.2",
 				"@babel/generator": "^7.29.1",
@@ -10940,7 +11283,8 @@
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
 			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/metro/node_modules/cliui": {
 			"version": "8.0.1",
@@ -10948,6 +11292,7 @@
 			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
 			"license": "ISC",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.1",
@@ -10962,7 +11307,8 @@
 			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
 			"integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/metro/node_modules/hermes-parser": {
 			"version": "0.35.0",
@@ -10970,6 +11316,7 @@
 			"integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"hermes-estree": "0.35.0"
 			}
@@ -10980,6 +11327,7 @@
 			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"mime-db": "^1.54.0"
 			},
@@ -10997,6 +11345,7 @@
 			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
 			"license": "BSD-3-Clause",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -11007,6 +11356,7 @@
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -11025,6 +11375,7 @@
 			"integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8.3.0"
 			},
@@ -11047,6 +11398,7 @@
 			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
@@ -11497,6 +11849,7 @@
 			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -11560,14 +11913,16 @@
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
 			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.38",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
 			"integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/node-stream-zip": {
 			"version": "1.15.0",
@@ -11584,6 +11939,7 @@
 			"version": "0.2.7",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			},
@@ -11610,6 +11966,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -11627,6 +11984,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -11644,6 +12002,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -11656,11 +12015,15 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -11673,11 +12036,15 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -11690,11 +12057,15 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -11707,11 +12078,15 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -11728,7 +12103,8 @@
 			"resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
 			"integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/num-sort": {
 			"version": "1.0.0",
@@ -11737,6 +12113,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"number-is-nan": "^1.0.0"
 			},
@@ -11760,6 +12137,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -11770,6 +12148,7 @@
 			"integrity": "sha512-9M5kpuOLyTPogMtZiQUIxdAZxl7Dxs6tVBbJErSumsqGMuhVSoUbkfeZ3XNPpLpwBBtqY5QDUzGwggLHX3slQg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"flow-enums-runtime": "^0.0.6"
 			},
@@ -11852,6 +12231,7 @@
 			"integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"is-docker": "^2.0.0",
 				"is-wsl": "^2.1.1"
@@ -12109,6 +12489,7 @@
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -12143,6 +12524,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"escape-string-regexp": "^1.0.3",
 				"execall": "^1.0.0",
@@ -12160,6 +12542,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.8.0"
 			}
@@ -12170,6 +12553,7 @@
 			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -12243,6 +12627,7 @@
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -12457,7 +12842,6 @@
 			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -12485,6 +12869,7 @@
 			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jest/schemas": "^29.6.3",
 				"ansi-styles": "^5.0.0",
@@ -12500,6 +12885,7 @@
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -12538,6 +12924,7 @@
 			"integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"asap": "~2.0.6"
 			}
@@ -12637,6 +13024,7 @@
 			"integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"inherits": "~2.0.3"
 			}
@@ -12689,12 +13077,24 @@
 				"quickselect": "^2.0.0"
 			}
 		},
+		"node_modules/react": {
+			"version": "19.2.6",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+			"integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/react-devtools-core": {
 			"version": "6.1.5",
 			"resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.5.tgz",
 			"integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"shell-quote": "^1.6.1",
 				"ws": "^7"
@@ -12706,6 +13106,7 @@
 			"integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8.3.0"
 			},
@@ -12727,7 +13128,68 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
 			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/react-native": {
+			"version": "0.82.1",
+			"resolved": "https://registry.npmjs.org/react-native/-/react-native-0.82.1.tgz",
+			"integrity": "sha512-tFAqcU7Z4g49xf/KnyCEzI4nRTu1Opcx05Ov2helr8ZTg1z7AJR/3sr2rZ+AAVlAs2IXk+B0WOxXGmdD3+4czA==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jest/create-cache-key-function": "^29.7.0",
+				"@react-native/assets-registry": "0.82.1",
+				"@react-native/codegen": "0.82.1",
+				"@react-native/community-cli-plugin": "0.82.1",
+				"@react-native/gradle-plugin": "0.82.1",
+				"@react-native/js-polyfills": "0.82.1",
+				"@react-native/normalize-colors": "0.82.1",
+				"@react-native/virtualized-lists": "0.82.1",
+				"abort-controller": "^3.0.0",
+				"anser": "^1.4.9",
+				"ansi-regex": "^5.0.0",
+				"babel-jest": "^29.7.0",
+				"babel-plugin-syntax-hermes-parser": "0.32.0",
+				"base64-js": "^1.5.1",
+				"commander": "^12.0.0",
+				"flow-enums-runtime": "^0.0.6",
+				"glob": "^7.1.1",
+				"hermes-compiler": "0.0.0",
+				"invariant": "^2.2.4",
+				"jest-environment-node": "^29.7.0",
+				"memoize-one": "^5.0.0",
+				"metro-runtime": "^0.83.1",
+				"metro-source-map": "^0.83.1",
+				"nullthrows": "^1.1.1",
+				"pretty-format": "^29.7.0",
+				"promise": "^8.3.0",
+				"react-devtools-core": "^6.1.5",
+				"react-refresh": "^0.14.0",
+				"regenerator-runtime": "^0.13.2",
+				"scheduler": "0.26.0",
+				"semver": "^7.1.3",
+				"stacktrace-parser": "^0.1.10",
+				"whatwg-fetch": "^3.0.0",
+				"ws": "^6.2.3",
+				"yargs": "^17.6.2"
+			},
+			"bin": {
+				"react-native": "cli.js"
+			},
+			"engines": {
+				"node": ">= 20.19.4"
+			},
+			"peerDependencies": {
+				"@types/react": "^19.1.1",
+				"react": "^19.1.1"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/react-native-fs": {
 			"version": "2.20.0",
@@ -12749,12 +13211,136 @@
 				}
 			}
 		},
+		"node_modules/react-native/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/react-native/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/react-native/node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/react-native/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/react-native/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/react-native/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/react-native/node_modules/ws": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+			"integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"async-limiter": "~1.0.0"
+			}
+		},
+		"node_modules/react-native/node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/react-refresh": {
 			"version": "0.14.2",
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
 			"integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -12816,7 +13402,8 @@
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
 			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/regexp.prototype.flags": {
 			"version": "1.5.4",
@@ -12843,6 +13430,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"is-finite": "^1.0.0"
 			},
@@ -12937,6 +13525,7 @@
 			"deprecated": "Rimraf versions prior to v4 are no longer supported",
 			"license": "ISC",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -12952,7 +13541,8 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/rimraf/node_modules/brace-expansion": {
 			"version": "1.1.14",
@@ -12960,6 +13550,7 @@
 			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -12972,6 +13563,7 @@
 			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"license": "ISC",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -12993,6 +13585,7 @@
 			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"license": "ISC",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -13100,7 +13693,8 @@
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
 			"integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/secure-json-parse": {
 			"version": "4.1.0",
@@ -13186,6 +13780,7 @@
 			"integrity": "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -13204,6 +13799,7 @@
 			"integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
@@ -13220,6 +13816,7 @@
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"ms": "2.0.0"
 			}
@@ -13229,7 +13826,8 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/serve-static/node_modules/fresh": {
 			"version": "0.5.2",
@@ -13237,6 +13835,7 @@
 			"integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -13247,6 +13846,7 @@
 			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"bin": {
 				"mime": "cli.js"
 			},
@@ -13260,6 +13860,7 @@
 			"integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"debug": "2.6.9",
 				"depd": "2.0.0",
@@ -13347,6 +13948,7 @@
 			"integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -13475,6 +14077,7 @@
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -13525,6 +14128,7 @@
 			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -13536,6 +14140,7 @@
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"license": "BSD-3-Clause",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -13554,6 +14159,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"array-uniq": "^1.0.2",
 				"arrify": "^1.0.0",
@@ -13577,7 +14183,8 @@
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
 			"license": "BSD-3-Clause",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/stack-trace": {
 			"version": "0.0.10",
@@ -13592,6 +14199,7 @@
 			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"escape-string-regexp": "^2.0.0"
 			},
@@ -13605,6 +14213,7 @@
 			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -13614,7 +14223,8 @@
 			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
 			"integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/stacktrace-parser": {
 			"version": "0.1.11",
@@ -13622,6 +14232,7 @@
 			"integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"type-fest": "^0.7.1"
 			},
@@ -13635,6 +14246,7 @@
 			"integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
 			"license": "(MIT OR CC0-1.0)",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -13918,6 +14530,7 @@
 			"integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
 			"license": "BSD-2-Clause",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
 				"acorn": "^8.15.0",
@@ -13936,7 +14549,8 @@
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/test-exclude": {
 			"version": "6.0.0",
@@ -13944,6 +14558,7 @@
 			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
 			"license": "ISC",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@istanbuljs/schema": "^0.1.2",
 				"glob": "^7.1.4",
@@ -13958,7 +14573,8 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/test-exclude/node_modules/brace-expansion": {
 			"version": "1.1.14",
@@ -13966,6 +14582,7 @@
 			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -13978,6 +14595,7 @@
 			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"license": "ISC",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -13999,6 +14617,7 @@
 			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"license": "ISC",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -14025,7 +14644,8 @@
 			"resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
 			"integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/through": {
 			"version": "2.3.8",
@@ -14084,7 +14704,6 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -14097,7 +14716,8 @@
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
 			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
 			"license": "BSD-3-Clause",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -14205,7 +14825,6 @@
 			"version": "5.9.3",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -14272,6 +14891,7 @@
 			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -14296,6 +14916,7 @@
 			],
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"escalade": "^3.2.0",
 				"picocolors": "^1.1.1"
@@ -14313,6 +14934,32 @@
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/utf-8-validate": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+			"integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"node-gyp-build": "^4.3.0"
+			},
+			"engines": {
+				"node": ">=6.14.2"
+			}
+		},
+		"node_modules/utf-8-validate/node_modules/node-gyp-build": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+			"license": "MIT",
+			"optional": true,
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
 			}
 		},
 		"node_modules/utf8": {
@@ -14355,7 +15002,8 @@
 			"resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
 			"integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/walker": {
 			"version": "1.0.8",
@@ -14363,6 +15011,7 @@
 			"integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"makeerror": "1.0.12"
 			}
@@ -14387,7 +15036,8 @@
 			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
 			"integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/whatwg-url": {
 			"version": "5.0.0",
@@ -14540,6 +15190,7 @@
 			"integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
 			"license": "ISC",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"imurmurhash": "^0.1.4",
 				"signal-exit": "^3.0.7"
@@ -14553,7 +15204,8 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"license": "ISC",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/ws": {
 			"version": "8.20.0",
@@ -14593,7 +15245,8 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"license": "ISC",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/yaml": {
 			"version": "2.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -346,6 +346,7 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1045.0.tgz",
 			"integrity": "sha512-fsuO3Y6t+3Ro9Bsg41DKj4Sfy53CGSrhnMldNplWmG8Tx0UbYk+YDa4RD1hVlJpERw4JBmPkl0+J9qlxMh1pcA==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha1-browser": "5.2.0",
 				"@aws-crypto/sha256-browser": "5.2.0",
@@ -1031,52 +1032,8 @@
 			"integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/core": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-compilation-targets": "^7.28.6",
-				"@babel/helper-module-transforms": "^7.28.6",
-				"@babel/helpers": "^7.28.6",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/traverse": "^7.29.0",
-				"@babel/types": "^7.29.0",
-				"@jridgewell/remapping": "^2.3.5",
-				"convert-source-map": "^2.0.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.3",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/babel"
-			}
-		},
-		"node_modules/@babel/core/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@babel/generator": {
@@ -1109,7 +1066,6 @@
 			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.28.6",
 				"@babel/helper-validator-option": "^7.27.1",
@@ -1127,7 +1083,6 @@
 			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 			"license": "ISC",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"yallist": "^3.0.2"
 			}
@@ -1138,7 +1093,6 @@
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"license": "ISC",
 			"optional": true,
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -1156,7 +1110,6 @@
 			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/traverse": "^7.28.6",
 				"@babel/types": "^7.28.6"
@@ -1171,7 +1124,6 @@
 			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.28.6",
 				"@babel/helper-validator-identifier": "^7.28.5",
@@ -1190,7 +1142,6 @@
 			"integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -1215,7 +1166,6 @@
 			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -1226,7 +1176,6 @@
 			"integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/template": "^7.28.6",
 				"@babel/types": "^7.29.0"
@@ -1254,7 +1203,6 @@
 			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1268,7 +1216,6 @@
 			"integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1282,7 +1229,6 @@
 			"integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.12.13"
 			},
@@ -1296,7 +1242,6 @@
 			"integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.14.5"
 			},
@@ -1313,7 +1258,6 @@
 			"integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.28.6"
 			},
@@ -1330,7 +1274,6 @@
 			"integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			},
@@ -1344,7 +1287,6 @@
 			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1358,7 +1300,6 @@
 			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			},
@@ -1372,7 +1313,6 @@
 			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1386,7 +1326,6 @@
 			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			},
@@ -1400,7 +1339,6 @@
 			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1414,7 +1352,6 @@
 			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1428,7 +1365,6 @@
 			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -1442,7 +1378,6 @@
 			"integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.14.5"
 			},
@@ -1459,7 +1394,6 @@
 			"integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.14.5"
 			},
@@ -2644,6 +2578,7 @@
 			"version": "8.44.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.44.0",
 				"@typescript-eslint/types": "8.44.0",
@@ -2976,9 +2911,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2994,9 +2926,6 @@
 			"integrity": "sha512-f5Myta9ke0DBF901ehckMflm1DIOTNaKWMfzoJVuQIHwW8QT1+ZFUBz2dLKnoveIKWuE8r4TVW29YDW/oo6m2g==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -3014,9 +2943,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3032,9 +2958,6 @@
 			"integrity": "sha512-u0LN3maKDemGDGfA77aYr2HSpLl9ilOhQOFcLSjAtYrZlquxvNRGQR60aE0VIC/quui6Xdu7zHOVY9aLZpqW3g==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -3244,7 +3167,6 @@
 			"integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
 			"license": "ISC",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -3255,7 +3177,6 @@
 			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
 			"license": "ISC",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"camelcase": "^5.3.1",
 				"find-up": "^4.1.0",
@@ -3273,7 +3194,6 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -3284,7 +3204,6 @@
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -3295,7 +3214,6 @@
 			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"locate-path": "^5.0.0",
 				"path-exists": "^4.0.0"
@@ -3310,7 +3228,6 @@
 			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -3325,7 +3242,6 @@
 			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"p-locate": "^4.1.0"
 			},
@@ -3339,7 +3255,6 @@
 			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"p-try": "^2.0.0"
 			},
@@ -3356,7 +3271,6 @@
 			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"p-limit": "^2.2.0"
 			},
@@ -3370,7 +3284,6 @@
 			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3381,7 +3294,6 @@
 			"integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3392,7 +3304,6 @@
 			"integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@jest/types": "^29.6.3"
 			},
@@ -3406,7 +3317,6 @@
 			"integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@jest/fake-timers": "^29.7.0",
 				"@jest/types": "^29.6.3",
@@ -3423,7 +3333,6 @@
 			"integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@jest/types": "^29.6.3",
 				"@sinonjs/fake-timers": "^10.0.2",
@@ -3442,7 +3351,6 @@
 			"integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
 			"license": "BSD-3-Clause",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@sinonjs/commons": "^3.0.0"
 			}
@@ -3453,7 +3361,6 @@
 			"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@sinclair/typebox": "^0.27.8"
 			},
@@ -3467,7 +3374,6 @@
 			"integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.11.6",
 				"@jest/types": "^29.6.3",
@@ -3495,7 +3401,6 @@
 			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@jest/schemas": "^29.6.3",
 				"@types/istanbul-lib-coverage": "^2.0.0",
@@ -3522,7 +3427,6 @@
 			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.24"
@@ -3541,7 +3445,6 @@
 			"integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25"
@@ -3664,6 +3567,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3677,6 +3581,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3690,6 +3595,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3703,6 +3609,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3716,6 +3623,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3729,6 +3637,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3914,9 +3823,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3934,9 +3840,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3954,9 +3857,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3974,9 +3874,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3994,9 +3891,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4014,9 +3908,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4034,9 +3925,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4054,9 +3942,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4179,7 +4064,6 @@
 			"integrity": "sha512-B1SRwpntaAcckiatxbjzylvNK562Ayza05gdJCjDQHTiDafa1OABmyB5LHt7qWDOpNkaluD+w11vHF7pBmTpzQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 20.19.4"
 			}
@@ -4190,7 +4074,6 @@
 			"integrity": "sha512-ezXTN70ygVm9l2m0i+pAlct0RntoV4afftWMGUIeAWLgaca9qItQ54uOt32I/9dBJvzBibT33luIR/pBG0dQvg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.25.2",
 				"@babel/parser": "^7.25.3",
@@ -4212,8 +4095,7 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/@react-native/codegen/node_modules/brace-expansion": {
 			"version": "1.1.14",
@@ -4221,7 +4103,6 @@
 			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -4233,7 +4114,6 @@
 			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
 			"license": "ISC",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.1",
@@ -4250,7 +4130,6 @@
 			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"license": "ISC",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -4272,7 +4151,6 @@
 			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"license": "ISC",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -4286,7 +4164,6 @@
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -4305,7 +4182,6 @@
 			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
@@ -4325,7 +4201,6 @@
 			"integrity": "sha512-H/eMdtOy9nEeX7YVeEG1N2vyCoifw3dr9OV8++xfUElNYV7LtSmJ6AqxZUUfxGJRDFPQvaU/8enmJlM/l11VxQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@react-native/dev-middleware": "0.82.1",
 				"debug": "^4.4.0",
@@ -4357,7 +4232,6 @@
 			"integrity": "sha512-a2O6M7/OZ2V9rdavOHyCQ+10z54JX8+B+apYKCQ6a9zoEChGTxUMG2YzzJ8zZJVvYf1ByWSNxv9Se0dca1hO9A==",
 			"license": "BSD-3-Clause",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 20.19.4"
 			}
@@ -4368,7 +4242,6 @@
 			"integrity": "sha512-fdRHAeqqPT93bSrxfX+JHPpCXHApfDUdrXMXhoxlPgSzgXQXJDykIViKhtpu0M6slX6xU/+duq+AtP/qWJRpBw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"cross-spawn": "^7.0.6",
 				"fb-dotslash": "0.5.8"
@@ -4383,7 +4256,6 @@
 			"integrity": "sha512-wuOIzms/Qg5raBV6Ctf2LmgzEOCqdP3p1AYN4zdhMT110c39TVMbunpBaJxm0Kbt2HQ762MQViF9naxk7SBo4w==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@isaacs/ttlcache": "^1.4.1",
 				"@react-native/debugger-frontend": "0.82.1",
@@ -4408,7 +4280,6 @@
 			"integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"async-limiter": "~1.0.0"
 			}
@@ -4419,7 +4290,6 @@
 			"integrity": "sha512-KkF/2T1NSn6EJ5ALNT/gx0MHlrntFHv8YdooH9OOGl9HQn5NM0ZmQSr86o5utJsGc7ME3R6p3SaQuzlsFDrn8Q==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 20.19.4"
 			}
@@ -4430,7 +4300,6 @@
 			"integrity": "sha512-tf70X7pUodslOBdLN37J57JmDPB/yiZcNDzS2m+4bbQzo8fhx3eG9QEBv5n4fmzqfGAgSB4BWRHgDMXmmlDSVA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 20.19.4"
 			}
@@ -4440,8 +4309,7 @@
 			"resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.82.1.tgz",
 			"integrity": "sha512-CCfTR1uX+Z7zJTdt3DNX9LUXr2zWXsNOyLbwupW2wmRzrxlHRYfmLgTABzRL/cKhh0Ubuwn15o72MQChvCRaHw==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/@react-native/virtualized-lists": {
 			"version": "0.82.1",
@@ -4449,7 +4317,6 @@
 			"integrity": "sha512-f5zpJg9gzh7JtCbsIwV+4kP3eI0QBuA93JGmwFRd4onQ3DnCjV2J5pYqdWtM95sjSKK1dyik59Gj01lLeKqs1Q==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"invariant": "^2.2.4",
 				"nullthrows": "^1.1.1"
@@ -4488,8 +4355,7 @@
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
 			"integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/@sinonjs/commons": {
 			"version": "3.0.1",
@@ -4534,7 +4400,6 @@
 			"integrity": "sha512-GW2yqqOTzdz3K6z0XpPO1EjLzOw0kclmAcLeW6cBt0DYM7ZNLRKanpzXxaSXkePpo4ZYMWhddE4WpSWG8e/QaQ==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
@@ -5483,7 +5348,6 @@
 			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/parser": "^7.20.7",
 				"@babel/types": "^7.20.7",
@@ -5498,7 +5362,6 @@
 			"integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/types": "^7.0.0"
 			}
@@ -5509,7 +5372,6 @@
 			"integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/parser": "^7.1.0",
 				"@babel/types": "^7.0.0"
@@ -5521,7 +5383,6 @@
 			"integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/types": "^7.28.2"
 			}
@@ -5565,7 +5426,6 @@
 			"integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -5583,8 +5443,7 @@
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
 			"integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/@types/istanbul-lib-report": {
 			"version": "3.0.3",
@@ -5592,7 +5451,6 @@
 			"integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@types/istanbul-lib-coverage": "*"
 			}
@@ -5603,7 +5461,6 @@
 			"integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@types/istanbul-lib-report": "*"
 			}
@@ -5656,6 +5513,7 @@
 		"node_modules/@types/node": {
 			"version": "25.4.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.18.0"
 			}
@@ -5685,8 +5543,7 @@
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
 			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/@types/tar-fs": {
 			"version": "2.0.4",
@@ -5721,7 +5578,6 @@
 			"integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@types/yargs-parser": "*"
 			}
@@ -5731,8 +5587,7 @@
 			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
 			"integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "8.59.2",
@@ -5777,6 +5632,7 @@
 			"integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.59.2",
 				"@typescript-eslint/types": "8.59.2",
@@ -5982,7 +5838,6 @@
 			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"mime-types": "^3.0.0",
 				"negotiator": "^1.0.0"
@@ -5997,7 +5852,6 @@
 			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"mime-db": "^1.54.0"
 			},
@@ -6013,6 +5867,7 @@
 			"version": "8.16.0",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -6034,7 +5889,6 @@
 			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 14"
 			}
@@ -6120,8 +5974,7 @@
 			"resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
 			"integrity": "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/ansi-escapes": {
 			"version": "4.3.2",
@@ -6162,7 +6015,6 @@
 			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
 			"license": "ISC",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
@@ -6206,7 +6058,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6218,7 +6069,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6251,8 +6101,7 @@
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
 			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
@@ -6314,7 +6163,6 @@
 			"integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@jest/transform": "^29.7.0",
 				"@types/babel__core": "^7.1.14",
@@ -6337,7 +6185,6 @@
 			"integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
 			"license": "BSD-3-Clause",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@istanbuljs/load-nyc-config": "^1.0.0",
@@ -6355,7 +6202,6 @@
 			"integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/template": "^7.3.3",
 				"@babel/types": "^7.3.3",
@@ -6372,7 +6218,6 @@
 			"integrity": "sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"hermes-parser": "0.32.0"
 			}
@@ -6383,7 +6228,6 @@
 			"integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-bigint": "^7.8.3",
@@ -6411,7 +6255,6 @@
 			"integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"babel-plugin-jest-hoist": "^29.6.3",
 				"babel-preset-current-node-syntax": "^1.0.0"
@@ -6535,7 +6378,6 @@
 			"integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
 			"license": "Apache-2.0",
 			"optional": true,
-			"peer": true,
 			"bin": {
 				"baseline-browser-mapping": "dist/cli.cjs"
 			},
@@ -6662,48 +6504,12 @@
 				"pako": "~0.2.0"
 			}
 		},
-		"node_modules/browserslist": {
-			"version": "4.28.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/browserslist"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/funding/github/npm/browserslist"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"baseline-browser-mapping": "^2.10.12",
-				"caniuse-lite": "^1.0.30001782",
-				"electron-to-chromium": "^1.5.328",
-				"node-releases": "^2.0.36",
-				"update-browserslist-db": "^1.2.3"
-			},
-			"bin": {
-				"browserslist": "cli.js"
-			},
-			"engines": {
-				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-			}
-		},
 		"node_modules/bser": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
 			"integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
 			"license": "Apache-2.0",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"node-int64": "^0.4.0"
 			}
@@ -6723,32 +6529,6 @@
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
 			"license": "MIT"
-		},
-		"node_modules/bufferutil": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
-			"integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"node-gyp-build": "^4.3.0"
-			},
-			"engines": {
-				"node": ">=6.14.2"
-			}
-		},
-		"node_modules/bufferutil/node_modules/node-gyp-build": {
-			"version": "4.8.4",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-			"license": "MIT",
-			"optional": true,
-			"bin": {
-				"node-gyp-build": "bin.js",
-				"node-gyp-build-optional": "optional.js",
-				"node-gyp-build-test": "build-test.js"
-			}
 		},
 		"node_modules/busboy": {
 			"version": "1.6.0",
@@ -6847,8 +6627,7 @@
 				}
 			],
 			"license": "CC-BY-4.0",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/cbor-extract": {
 			"version": "2.2.2",
@@ -6881,6 +6660,7 @@
 			"version": "6.2.2",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -6949,7 +6729,6 @@
 			"integrity": "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==",
 			"license": "Apache-2.0",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@types/node": "*",
 				"escape-string-regexp": "^4.0.0",
@@ -6969,7 +6748,6 @@
 			"integrity": "sha512-JfJjUnq25y9yg4FABRRVPmBGWPZZi+AQXT4mxupb67766/0UlhG8PAZCz6xzEMXTbW3CsSoE8PcCWA49n35mKg==",
 			"license": "Apache-2.0",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@types/node": "*",
 				"escape-string-regexp": "^4.0.0",
@@ -6991,7 +6769,6 @@
 			],
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -7071,7 +6848,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"is-regexp": "^1.0.0",
 				"is-supported-regexp-flag": "^1.0.0"
@@ -7118,7 +6894,6 @@
 			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -7187,7 +6962,6 @@
 			"integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"debug": "2.6.9",
 				"finalhandler": "1.1.2",
@@ -7204,7 +6978,6 @@
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"ms": "2.0.0"
 			}
@@ -7214,8 +6987,7 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/content-disposition": {
 			"version": "1.0.1",
@@ -7233,8 +7005,7 @@
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/cookie": {
 			"version": "1.1.1",
@@ -7432,7 +7203,6 @@
 			"integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8",
 				"npm": "1.2.8000 || >= 1.4.16"
@@ -7538,8 +7308,7 @@
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz",
 			"integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
 			"license": "ISC",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -7565,7 +7334,6 @@
 			"integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"stackframe": "^1.3.4"
 			}
@@ -7678,6 +7446,7 @@
 			"version": "9.39.4",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -7736,6 +7505,7 @@
 			"version": "10.1.8",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -7872,7 +7642,6 @@
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
 			"license": "BSD-2-Clause",
 			"optional": true,
-			"peer": true,
 			"bin": {
 				"esparse": "bin/esparse.js",
 				"esvalidate": "bin/esvalidate.js"
@@ -7973,7 +7742,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"clone-regexp": "^1.0.0"
 			},
@@ -7986,8 +7754,7 @@
 			"resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
 			"integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
 			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/eyes": {
 			"version": "0.1.8",
@@ -8284,7 +8051,6 @@
 			"integrity": "sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==",
 			"license": "(MIT OR Apache-2.0)",
 			"optional": true,
-			"peer": true,
 			"bin": {
 				"dotslash": "bin/dotslash"
 			},
@@ -8298,7 +8064,6 @@
 			"integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
 			"license": "Apache-2.0",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"bser": "2.1.1"
 			}
@@ -8355,7 +8120,6 @@
 			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"debug": "2.6.9",
 				"encodeurl": "~1.0.2",
@@ -8375,7 +8139,6 @@
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"ms": "2.0.0"
 			}
@@ -8386,7 +8149,6 @@
 			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -8396,8 +8158,7 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/finalhandler/node_modules/on-finished": {
 			"version": "2.3.0",
@@ -8405,7 +8166,6 @@
 			"integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"ee-first": "1.1.1"
 			},
@@ -8419,7 +8179,6 @@
 			"integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -8481,8 +8240,7 @@
 			"resolved": "https://registry.npmjs.org/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz",
 			"integrity": "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/follow-redirects": {
 			"version": "1.16.0",
@@ -8588,8 +8346,7 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"license": "ISC",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
@@ -8625,7 +8382,6 @@
 			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -8693,7 +8449,6 @@
 			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -8812,6 +8567,7 @@
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
 			"integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
 			}
@@ -8877,7 +8633,6 @@
 			"integrity": "sha512-RRXMLbbdymiZsHOeg5b+DShzsMvVvkgsG9690BBCc7tzIpDb0CT7EgWEQo+rwCICr35EwZoLjtfwF6mMiCOenA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/client-s3": "^3.1012.0",
 				"@aws-sdk/lib-storage": "3.964.0",
@@ -8980,7 +8735,6 @@
 			"integrity": "sha512-ro6B04Q5TjPgIKdSWGJ+tj2ordVF1IfZJERwGpYkrwhboNEoXBXuzpfnh2LYBPvMmFJQ+8UXSFw1jkLLgxM+ig==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@smithy/abort-controller": "^4.2.7",
 				"@smithy/middleware-endpoint": "^4.4.1",
@@ -9003,7 +8757,6 @@
 			"integrity": "sha512-gipd/g0USN8ncvRMdoaru8PxYNUSEJp//+XbLf+3VNDQ6gcSsTcYqyNa3f+oEKIyV0clpOkxzautkN7hVPsn/g==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@harperfast/extended-iterable": "1.0.3",
 				"msgpackr": "1.11.9",
@@ -9036,7 +8789,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -9054,7 +8806,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -9067,15 +8818,11 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -9088,15 +8835,11 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -9109,15 +8852,11 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -9130,15 +8869,11 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -9156,7 +8891,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -9174,7 +8908,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -9191,8 +8924,7 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/harper/node_modules/@lmdb/lmdb-darwin-x64": {
 			"version": "3.5.3",
@@ -9206,8 +8938,7 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/harper/node_modules/@lmdb/lmdb-linux-arm": {
 			"version": "3.5.3",
@@ -9221,8 +8952,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/harper/node_modules/@lmdb/lmdb-linux-arm64": {
 			"version": "3.5.3",
@@ -9236,8 +8966,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/harper/node_modules/@lmdb/lmdb-linux-x64": {
 			"version": "3.5.3",
@@ -9251,8 +8980,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/harper/node_modules/@lmdb/lmdb-win32-arm64": {
 			"version": "3.5.3",
@@ -9266,8 +8994,7 @@
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/harper/node_modules/@lmdb/lmdb-win32-x64": {
 			"version": "3.5.3",
@@ -9281,8 +9008,7 @@
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/harper/node_modules/alasql": {
 			"version": "4.6.6",
@@ -9290,7 +9016,6 @@
 			"integrity": "sha512-kuRnDciFgtWSR2tpgraFwE6Q19PmeY9d2O2JzXdpEd38xoBrbp3qKDiGhzBvKfrxpuimwn+6w94FXE9NT3hJsg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cross-fetch": "4.1.0",
 				"yargs": "16"
@@ -9308,7 +9033,6 @@
 			"integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"pvtsutils": "^1.3.6",
 				"pvutils": "^1.1.3",
@@ -9324,7 +9048,6 @@
 			"integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
@@ -9340,7 +9063,6 @@
 			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			},
@@ -9355,7 +9077,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@harperfast/extended-iterable": "^1.0.3",
 				"msgpackr": "^1.11.2",
@@ -9383,7 +9104,6 @@
 			"integrity": "sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"optionalDependencies": {
 				"msgpackr-extract": "^3.0.2"
 			}
@@ -9394,7 +9114,6 @@
 			"integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"iconv-lite": "^0.6.3",
 				"sax": "^1.2.4"
@@ -9411,8 +9130,7 @@
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
 			"integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/harper/node_modules/node-gyp-build-optional-packages": {
 			"version": "5.2.2",
@@ -9420,7 +9138,6 @@
 			"integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"detect-libc": "^2.0.1"
 			},
@@ -9436,7 +9153,6 @@
 			"integrity": "sha512-UUmvQ/7KTZt/vHjhRrnyS7h+J7qPBQnpG80V56xmIC+o9IqYmQOw/UIny9S9zYDfRBR0ClouCr464EkBMIT7Fw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"atomic-sleep": "^1.0.0",
 				"fast-redact": "^3.1.1",
@@ -9460,7 +9176,6 @@
 			"integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"readable-stream": "^4.0.0",
 				"split2": "^4.0.0"
@@ -9472,7 +9187,6 @@
 			"integrity": "sha512-WX0la7n7CbnguuaIQoT4Fc0IJckPDOUldzOwlZ0nwpOcySS+Six/tXBdc0RX17J5o1To0SAr3xDJjDLsOfDFQA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"@noble/hashes": "^1.4.0",
 				"asn1js": "^3.0.5",
@@ -9490,8 +9204,7 @@
 			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.3.2.tgz",
 			"integrity": "sha512-n9wh8tvBe5sFmsqlg+XQhaQLumwpqoAUruLwjCopgTmUBjJ/fjtBsJzKleCaIGBOMXYEhp1YfKl4d7rJ5ZKJGA==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/harper/node_modules/readable-stream": {
 			"version": "4.7.0",
@@ -9499,7 +9212,6 @@
 			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"abort-controller": "^3.0.0",
 				"buffer": "^6.0.3",
@@ -9531,7 +9243,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.2.1"
@@ -9543,7 +9254,6 @@
 			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -9557,7 +9267,6 @@
 			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"engines": {
 				"node": ">= 10.x"
 			}
@@ -9568,7 +9277,6 @@
 			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
 			}
@@ -9583,7 +9291,6 @@
 				"https://github.com/sponsors/ctavan"
 			],
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"uuid": "dist/esm/bin/uuid"
 			}
@@ -9594,7 +9301,6 @@
 			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -9617,7 +9323,6 @@
 			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"yaml": "bin.mjs"
 			},
@@ -9685,7 +9390,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"parse-columns": "git+https://github.com/int0h/parse-columns.git"
 			}
@@ -9710,16 +9414,14 @@
 			"resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-0.0.0.tgz",
 			"integrity": "sha512-boVFutx6ME/Km2mB6vvsQcdnazEYYI/jV1pomx1wcFUG/EVqTkr5CU0CW9bKipOA/8Hyu3NYwW3THg2Q1kNCfA==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/hermes-estree": {
 			"version": "0.32.0",
 			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
 			"integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/hermes-parser": {
 			"version": "0.32.0",
@@ -9727,7 +9429,6 @@
 			"integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"hermes-estree": "0.32.0"
 			}
@@ -9756,7 +9457,6 @@
 			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"agent-base": "^7.1.2",
 				"debug": "4"
@@ -9818,7 +9518,6 @@
 			"integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"queue": "6.0.2"
 			},
@@ -9859,7 +9558,6 @@
 			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
 			"license": "ISC",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -9956,7 +9654,6 @@
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.0.0"
 			}
@@ -10016,7 +9713,6 @@
 			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"bin": {
 				"is-docker": "cli.js"
 			},
@@ -10041,7 +9737,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			},
@@ -10129,7 +9824,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -10141,7 +9835,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -10162,7 +9855,6 @@
 			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"is-docker": "^2.0.0"
 			},
@@ -10188,7 +9880,6 @@
 			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
 			"license": "BSD-3-Clause",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -10199,7 +9890,6 @@
 			"integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
 			"license": "BSD-3-Clause",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.12.3",
 				"@babel/parser": "^7.14.7",
@@ -10217,7 +9907,6 @@
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"license": "ISC",
 			"optional": true,
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -10246,7 +9935,6 @@
 			"integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@jest/environment": "^29.7.0",
 				"@jest/fake-timers": "^29.7.0",
@@ -10265,7 +9953,6 @@
 			"integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
@@ -10276,7 +9963,6 @@
 			"integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@jest/types": "^29.6.3",
 				"@types/graceful-fs": "^4.1.3",
@@ -10303,7 +9989,6 @@
 			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.12.13",
 				"@jest/types": "^29.6.3",
@@ -10325,7 +10010,6 @@
 			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@jest/types": "^29.6.3",
 				"@types/node": "*",
@@ -10341,7 +10025,6 @@
 			"integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
@@ -10352,7 +10035,6 @@
 			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@jest/types": "^29.6.3",
 				"@types/node": "*",
@@ -10371,7 +10053,6 @@
 			"integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@jest/types": "^29.6.3",
 				"camelcase": "^6.2.0",
@@ -10390,7 +10071,6 @@
 			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -10401,7 +10081,6 @@
 			"integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@types/node": "*",
 				"jest-util": "^29.7.0",
@@ -10418,7 +10097,6 @@
 			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -10469,8 +10147,7 @@
 			"resolved": "https://registry.npmjs.org/jsc-safe-url/-/jsc-safe-url-0.2.4.tgz",
 			"integrity": "sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==",
 			"license": "0BSD",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/jsesc": {
 			"version": "2.5.2",
@@ -10527,7 +10204,6 @@
 			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"bin": {
 				"json5": "lib/cli.js"
 			},
@@ -10656,7 +10332,6 @@
 			"integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
 			"license": "Apache-2.0",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"debug": "^2.6.9",
 				"marky": "^1.2.2"
@@ -10668,7 +10343,6 @@
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"ms": "2.0.0"
 			}
@@ -10678,8 +10352,7 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/lmdb": {
 			"version": "3.5.4",
@@ -10815,8 +10488,7 @@
 			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
 			"integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/lodash.toarray": {
 			"version": "3.0.2",
@@ -10848,7 +10520,6 @@
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			},
@@ -10869,7 +10540,6 @@
 			"integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
 			"license": "BSD-3-Clause",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"tmpl": "1.0.5"
 			}
@@ -10879,8 +10549,7 @@
 			"resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
 			"integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
 			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
@@ -10915,16 +10584,14 @@
 			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
 			"integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -10947,7 +10614,6 @@
 			"integrity": "sha512-SPaPEyvTsTmd0LpT7RaZciQyDw2i/JB7+iY9L5VfBo72+psescFxBqpI1TL9dnL+pmnfkU+l/J1mEEGLeF65EQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/core": "^7.25.2",
@@ -11002,7 +10668,6 @@
 			"integrity": "sha512-sBqBkt6kNut/88bv+Ucvm4yqdPetbvAEsHzi3MAgJEifOSYYzX5Z5Kgw3TFOrwf/mHJTOBG2ONlaMHoyfP15TA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.25.2",
 				"flow-enums-runtime": "^0.0.6",
@@ -11019,8 +10684,7 @@
 			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
 			"integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/metro-babel-transformer/node_modules/hermes-parser": {
 			"version": "0.35.0",
@@ -11028,7 +10692,6 @@
 			"integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"hermes-estree": "0.35.0"
 			}
@@ -11039,7 +10702,6 @@
 			"integrity": "sha512-E9SRePXQ1Zvlj79VcOk57q7VC7rMHMFQ+jhmPHBiq+dJ0bJB5BL87lWZF6oh5X76Cci5tpDuQNaDwwuSCToEeg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"exponential-backoff": "^3.1.1",
 				"flow-enums-runtime": "^0.0.6",
@@ -11056,7 +10718,6 @@
 			"integrity": "sha512-W1c2Nmx8MiJTJt+eWhMO08z9VKi3kZOaz99IYGdqeqDgY9j+yZjXl62rUav4Di0heZfh4/n2s722PqRL1OODeg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"flow-enums-runtime": "^0.0.6"
 			},
@@ -11070,7 +10731,6 @@
 			"integrity": "sha512-83mjWFbFOt2GeJ6pFIum5mSnc1uTsZJAtD8o4ej0s4NVsYsA7fB+pHvTfHhFrpeMONaobu2riKavkPei05Er/Q==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"connect": "^3.6.5",
 				"flow-enums-runtime": "^0.0.6",
@@ -11091,7 +10751,6 @@
 			"integrity": "sha512-6yn3w1wnltT6RQl7p7YES2l95ArC+mWrOssEiH8p5/DDrJS65/szf9LsC9JrBv8c5DdvSY3V3f0GRYg0Ox7hCg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"flow-enums-runtime": "^0.0.6",
 				"lodash.throttle": "^4.1.1",
@@ -11107,7 +10766,6 @@
 			"integrity": "sha512-+j0F1m+FQYVAQ6syf+mwhIPV5GoFQrkInX8bppuc50IzNsZbMrp8R5H/Sx/K2daQ3YEa9F/XwkeZT8gzJfgeCw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"debug": "^4.4.0",
 				"fb-watchman": "^2.0.0",
@@ -11129,7 +10787,6 @@
 			"integrity": "sha512-MfJar2IS4tBRuLb9svwb0Gu5l9BsH+pcRm8eGcEi/wy8MzZinfinh5dFLt2nWkocnulIgtGB5NkFDdbXqMXKhQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"flow-enums-runtime": "^0.0.6",
 				"terser": "^5.15.0"
@@ -11144,7 +10801,6 @@
 			"integrity": "sha512-WSJIENlMcoSsuz66IfBHOkgfp3KJt2UW2TnEHPf1b8pIG2eEXNOVmo2+03A0H17WY2XGXWgxL0CG7FAopqgB1A==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"flow-enums-runtime": "^0.0.6"
 			},
@@ -11158,7 +10814,6 @@
 			"integrity": "sha512-9GKkJURaB2iyYoEExKnedzAHzxmKtSi+k0tsZUvMoU27tBZJElchYt7JH/Ai/XzYAI9lCAaV7u5HZSI8J5Z+wQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.25.0",
 				"flow-enums-runtime": "^0.0.6"
@@ -11173,7 +10828,6 @@
 			"integrity": "sha512-JgA1h7oc1a1jydBe1GhVFsUoMYo3wLPk7oRA32rjlDsq+sP2JLt9x2p2lWbNSxTm/u8NV4VRid3hvEJgcX8tKw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/traverse": "^7.29.0",
 				"@babel/types": "^7.29.0",
@@ -11195,7 +10849,6 @@
 			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
 			"license": "BSD-3-Clause",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -11206,7 +10859,6 @@
 			"integrity": "sha512-g4suyxw20WOHWI680c+Kq4wC/NF+Hx5pRH9afrMp+sMTxqLeKcPR1Xf4wMhsjlbvx7LbIREdke6q928jEjvJWw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"flow-enums-runtime": "^0.0.6",
 				"invariant": "^2.2.4",
@@ -11228,7 +10880,6 @@
 			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
 			"license": "BSD-3-Clause",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -11239,7 +10890,6 @@
 			"integrity": "sha512-Ss0FpBiZDjX2kwhukMDl5sNdYK8T/06IPqxNE4H6PTlRlfs9q11cef13c/xESY/Pm4VCkp1yJUZO3kXzvMxQFA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.25.2",
 				"@babel/generator": "^7.29.1",
@@ -11258,7 +10908,6 @@
 			"integrity": "sha512-UegCo7ygB2fT64mRK2nbAjQVJ1zSwIIHy8d96jJv2nKZFDaViYBiughEdu5HM/Ceq0WN3LZrZk3zhl9aoiLYFw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.25.2",
 				"@babel/generator": "^7.29.1",
@@ -11283,8 +10932,7 @@
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
 			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/metro/node_modules/cliui": {
 			"version": "8.0.1",
@@ -11292,7 +10940,6 @@
 			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
 			"license": "ISC",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.1",
@@ -11307,8 +10954,7 @@
 			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
 			"integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/metro/node_modules/hermes-parser": {
 			"version": "0.35.0",
@@ -11316,7 +10962,6 @@
 			"integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"hermes-estree": "0.35.0"
 			}
@@ -11327,7 +10972,6 @@
 			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"mime-db": "^1.54.0"
 			},
@@ -11345,7 +10989,6 @@
 			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
 			"license": "BSD-3-Clause",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -11356,7 +10999,6 @@
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -11375,7 +11017,6 @@
 			"integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8.3.0"
 			},
@@ -11398,7 +11039,6 @@
 			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
@@ -11849,7 +11489,6 @@
 			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -11913,16 +11552,14 @@
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
 			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.38",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
 			"integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/node-stream-zip": {
 			"version": "1.15.0",
@@ -11939,7 +11576,6 @@
 			"version": "0.2.7",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			},
@@ -11966,7 +11602,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -11984,7 +11619,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -12002,7 +11636,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -12015,15 +11648,11 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -12036,15 +11665,11 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -12057,15 +11682,11 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -12078,15 +11699,11 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -12103,8 +11720,7 @@
 			"resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
 			"integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/num-sort": {
 			"version": "1.0.0",
@@ -12113,7 +11729,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"number-is-nan": "^1.0.0"
 			},
@@ -12137,7 +11752,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -12148,7 +11762,6 @@
 			"integrity": "sha512-9M5kpuOLyTPogMtZiQUIxdAZxl7Dxs6tVBbJErSumsqGMuhVSoUbkfeZ3XNPpLpwBBtqY5QDUzGwggLHX3slQg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"flow-enums-runtime": "^0.0.6"
 			},
@@ -12231,7 +11844,6 @@
 			"integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"is-docker": "^2.0.0",
 				"is-wsl": "^2.1.1"
@@ -12489,7 +12101,6 @@
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -12524,7 +12135,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"escape-string-regexp": "^1.0.3",
 				"execall": "^1.0.0",
@@ -12542,7 +12152,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.8.0"
 			}
@@ -12553,7 +12162,6 @@
 			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -12627,7 +12235,6 @@
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -12842,6 +12449,7 @@
 			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -12869,7 +12477,6 @@
 			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@jest/schemas": "^29.6.3",
 				"ansi-styles": "^5.0.0",
@@ -12885,7 +12492,6 @@
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -12924,7 +12530,6 @@
 			"integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"asap": "~2.0.6"
 			}
@@ -13024,7 +12629,6 @@
 			"integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"inherits": "~2.0.3"
 			}
@@ -13077,24 +12681,12 @@
 				"quickselect": "^2.0.0"
 			}
 		},
-		"node_modules/react": {
-			"version": "19.2.6",
-			"resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-			"integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/react-devtools-core": {
 			"version": "6.1.5",
 			"resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.5.tgz",
 			"integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"shell-quote": "^1.6.1",
 				"ws": "^7"
@@ -13106,7 +12698,6 @@
 			"integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8.3.0"
 			},
@@ -13128,68 +12719,7 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
 			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/react-native": {
-			"version": "0.82.1",
-			"resolved": "https://registry.npmjs.org/react-native/-/react-native-0.82.1.tgz",
-			"integrity": "sha512-tFAqcU7Z4g49xf/KnyCEzI4nRTu1Opcx05Ov2helr8ZTg1z7AJR/3sr2rZ+AAVlAs2IXk+B0WOxXGmdD3+4czA==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@jest/create-cache-key-function": "^29.7.0",
-				"@react-native/assets-registry": "0.82.1",
-				"@react-native/codegen": "0.82.1",
-				"@react-native/community-cli-plugin": "0.82.1",
-				"@react-native/gradle-plugin": "0.82.1",
-				"@react-native/js-polyfills": "0.82.1",
-				"@react-native/normalize-colors": "0.82.1",
-				"@react-native/virtualized-lists": "0.82.1",
-				"abort-controller": "^3.0.0",
-				"anser": "^1.4.9",
-				"ansi-regex": "^5.0.0",
-				"babel-jest": "^29.7.0",
-				"babel-plugin-syntax-hermes-parser": "0.32.0",
-				"base64-js": "^1.5.1",
-				"commander": "^12.0.0",
-				"flow-enums-runtime": "^0.0.6",
-				"glob": "^7.1.1",
-				"hermes-compiler": "0.0.0",
-				"invariant": "^2.2.4",
-				"jest-environment-node": "^29.7.0",
-				"memoize-one": "^5.0.0",
-				"metro-runtime": "^0.83.1",
-				"metro-source-map": "^0.83.1",
-				"nullthrows": "^1.1.1",
-				"pretty-format": "^29.7.0",
-				"promise": "^8.3.0",
-				"react-devtools-core": "^6.1.5",
-				"react-refresh": "^0.14.0",
-				"regenerator-runtime": "^0.13.2",
-				"scheduler": "0.26.0",
-				"semver": "^7.1.3",
-				"stacktrace-parser": "^0.1.10",
-				"whatwg-fetch": "^3.0.0",
-				"ws": "^6.2.3",
-				"yargs": "^17.6.2"
-			},
-			"bin": {
-				"react-native": "cli.js"
-			},
-			"engines": {
-				"node": ">= 20.19.4"
-			},
-			"peerDependencies": {
-				"@types/react": "^19.1.1",
-				"react": "^19.1.1"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
+			"optional": true
 		},
 		"node_modules/react-native-fs": {
 			"version": "2.20.0",
@@ -13211,136 +12741,12 @@
 				}
 			}
 		},
-		"node_modules/react-native/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/react-native/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/react-native/node_modules/cliui": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.1",
-				"wrap-ansi": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/react-native/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/react-native/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/react-native/node_modules/wrap-ansi": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/react-native/node_modules/ws": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-			"integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"async-limiter": "~1.0.0"
-			}
-		},
-		"node_modules/react-native/node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"cliui": "^8.0.1",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^21.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/react-refresh": {
 			"version": "0.14.2",
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
 			"integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -13402,8 +12808,7 @@
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
 			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/regexp.prototype.flags": {
 			"version": "1.5.4",
@@ -13430,7 +12835,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"is-finite": "^1.0.0"
 			},
@@ -13525,7 +12929,6 @@
 			"deprecated": "Rimraf versions prior to v4 are no longer supported",
 			"license": "ISC",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -13541,8 +12944,7 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/rimraf/node_modules/brace-expansion": {
 			"version": "1.1.14",
@@ -13550,7 +12952,6 @@
 			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -13563,7 +12964,6 @@
 			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"license": "ISC",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -13585,7 +12985,6 @@
 			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"license": "ISC",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -13693,8 +13092,7 @@
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
 			"integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/secure-json-parse": {
 			"version": "4.1.0",
@@ -13780,7 +13178,6 @@
 			"integrity": "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -13799,7 +13196,6 @@
 			"integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
@@ -13816,7 +13212,6 @@
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"ms": "2.0.0"
 			}
@@ -13826,8 +13221,7 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/serve-static/node_modules/fresh": {
 			"version": "0.5.2",
@@ -13835,7 +13229,6 @@
 			"integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -13846,7 +13239,6 @@
 			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"bin": {
 				"mime": "cli.js"
 			},
@@ -13860,7 +13252,6 @@
 			"integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"debug": "2.6.9",
 				"depd": "2.0.0",
@@ -13948,7 +13339,6 @@
 			"integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -14077,7 +13467,6 @@
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -14128,7 +13517,6 @@
 			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -14140,7 +13528,6 @@
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"license": "BSD-3-Clause",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -14159,7 +13546,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"array-uniq": "^1.0.2",
 				"arrify": "^1.0.0",
@@ -14183,8 +13569,7 @@
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
 			"license": "BSD-3-Clause",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/stack-trace": {
 			"version": "0.0.10",
@@ -14199,7 +13584,6 @@
 			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"escape-string-regexp": "^2.0.0"
 			},
@@ -14213,7 +13597,6 @@
 			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -14223,8 +13606,7 @@
 			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
 			"integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/stacktrace-parser": {
 			"version": "0.1.11",
@@ -14232,7 +13614,6 @@
 			"integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"type-fest": "^0.7.1"
 			},
@@ -14246,7 +13627,6 @@
 			"integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
 			"license": "(MIT OR CC0-1.0)",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -14530,7 +13910,6 @@
 			"integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
 			"license": "BSD-2-Clause",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
 				"acorn": "^8.15.0",
@@ -14549,8 +13928,7 @@
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/test-exclude": {
 			"version": "6.0.0",
@@ -14558,7 +13936,6 @@
 			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
 			"license": "ISC",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@istanbuljs/schema": "^0.1.2",
 				"glob": "^7.1.4",
@@ -14573,8 +13950,7 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/test-exclude/node_modules/brace-expansion": {
 			"version": "1.1.14",
@@ -14582,7 +13958,6 @@
 			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -14595,7 +13970,6 @@
 			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"license": "ISC",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -14617,7 +13991,6 @@
 			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"license": "ISC",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -14644,8 +14017,7 @@
 			"resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
 			"integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/through": {
 			"version": "2.3.8",
@@ -14704,6 +14076,7 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -14716,8 +14089,7 @@
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
 			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
 			"license": "BSD-3-Clause",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -14825,6 +14197,7 @@
 			"version": "5.9.3",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -14891,7 +14264,6 @@
 			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -14916,7 +14288,6 @@
 			],
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"escalade": "^3.2.0",
 				"picocolors": "^1.1.1"
@@ -14934,32 +14305,6 @@
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
-			}
-		},
-		"node_modules/utf-8-validate": {
-			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-			"integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"node-gyp-build": "^4.3.0"
-			},
-			"engines": {
-				"node": ">=6.14.2"
-			}
-		},
-		"node_modules/utf-8-validate/node_modules/node-gyp-build": {
-			"version": "4.8.4",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-			"license": "MIT",
-			"optional": true,
-			"bin": {
-				"node-gyp-build": "bin.js",
-				"node-gyp-build-optional": "optional.js",
-				"node-gyp-build-test": "build-test.js"
 			}
 		},
 		"node_modules/utf8": {
@@ -15002,8 +14347,7 @@
 			"resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
 			"integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/walker": {
 			"version": "1.0.8",
@@ -15011,7 +14355,6 @@
 			"integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
 			"license": "Apache-2.0",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"makeerror": "1.0.12"
 			}
@@ -15036,8 +14379,7 @@
 			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
 			"integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/whatwg-url": {
 			"version": "5.0.0",
@@ -15190,7 +14532,6 @@
 			"integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
 			"license": "ISC",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"imurmurhash": "^0.1.4",
 				"signal-exit": "^3.0.7"
@@ -15204,8 +14545,7 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"license": "ISC",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/ws": {
 			"version": "8.20.0",
@@ -15245,8 +14585,7 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"license": "ISC",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/yaml": {
 			"version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -248,5 +248,13 @@
 		"bufferutil": "^4.0.9",
 		"segfault-handler": "^1.3.0",
 		"utf-8-validate": "^5.0.10"
+	},
+	"peerDependencies": {
+		"@aws-sdk/client-bedrock-runtime": "^3.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@aws-sdk/client-bedrock-runtime": {
+			"optional": true
+		}
 	}
 }

--- a/resources/models/backendHelpers.ts
+++ b/resources/models/backendHelpers.ts
@@ -1,0 +1,116 @@
+/**
+ * Shared helpers for `ModelBackend` implementations.
+ *
+ * Phase 6 of #510 extracted these from the ollama and openai backends after
+ * landing the openai PR — Kris flagged the similarity, and with anthropic +
+ * bedrock adding a third and fourth use the duplication crossed the
+ * "extract" threshold.
+ *
+ * Each helper is provider-agnostic; backend-specific error classes are passed
+ * in via a constructor type so the thrown errors carry the backend's name
+ * for `instanceof` matching in tests.
+ */
+import { isUnresolvedEnvVarPlaceholder } from '../../utility/expandEnvVar.ts';
+import type { TokenUsage } from './types.ts';
+
+/** Constructor signature for backend-specific error classes. */
+export type BackendErrorCtor = new (message: string) => Error;
+
+/**
+ * Combine a caller-supplied AbortSignal with a per-call timeout via
+ * `AbortSignal.any`. Returns the caller signal directly when no timeout is
+ * configured; the timeout signal alone when no caller signal exists; a
+ * composed signal when both apply.
+ */
+export function composeSignal(caller?: AbortSignal, timeoutMs?: number): AbortSignal | undefined {
+	if (!timeoutMs) return caller;
+	const timeout = AbortSignal.timeout(timeoutMs);
+	if (!caller) return timeout;
+	return AbortSignal.any([caller, timeout]);
+}
+
+/**
+ * Write a token count to `usage` only when the value is a finite, non-negative
+ * integer. Drops `NaN`, `Infinity`, negatives, and non-integers silently —
+ * upstream-supplied bad counts would otherwise poison aggregates over
+ * `hdb_model_calls` (`SUM(prompt_tokens)` returns `NaN` for the whole window
+ * if any row carries `NaN`).
+ */
+export function assignFiniteTokenCount(
+	usage: TokenUsage,
+	key: 'promptTokens' | 'completionTokens' | 'embeddingTokens',
+	value: unknown
+): void {
+	if (typeof value !== 'number') return;
+	if (!Number.isFinite(value) || value < 0 || !Number.isInteger(value)) return;
+	usage[key] = value;
+}
+
+/**
+ * Read a JSON response body and throw the backend's error class on parse
+ * failure rather than leaking the raw `SyntaxError` (whose message can
+ * include upstream-derived bytes). Matches the sanitization posture from
+ * `analyticsTable.ts:35` ("Sanitized code (...). Never a raw upstream
+ * message.").
+ */
+export async function parseJsonResponse<T>(res: Response, endpoint: string, Err: BackendErrorCtor): Promise<T> {
+	try {
+		return (await res.json()) as T;
+	} catch {
+		throw new Err(`${endpoint} returned a non-JSON response body`);
+	}
+}
+
+/**
+ * Assert that a model name was specified — either via `opts.model` (per-call
+ * override) or the backend's configured default.
+ */
+export function requireModel(model: string | undefined, op: string, Err: BackendErrorCtor): asserts model is string {
+	if (!model) {
+		throw new Err(`No model specified for ${op}; set 'model' in config or pass opts.model`);
+	}
+}
+
+/**
+ * Validate a configured credential field (typically `apiKey`):
+ * - must be present and non-empty
+ * - must NOT be a literal `${VAR_NAME}` placeholder that survived because the
+ *   env var was unset at boot (the `bootstrap.ts` expansion runs through
+ *   `expandEnvVarsDeep`, but unresolved placeholders pass through unchanged)
+ *
+ * Returns the validated value or throws. The `backendLabel` prefixes the
+ * error message so operators see which backend's config failed.
+ */
+export function requireCredential(
+	value: string | undefined,
+	backendLabel: string,
+	fieldName: string,
+	Err: BackendErrorCtor
+): string {
+	if (!value || value.length === 0) {
+		throw new Err(`${backendLabel} backend requires ${fieldName}`);
+	}
+	if (isUnresolvedEnvVarPlaceholder(value)) {
+		throw new Err(
+			`${backendLabel} ${fieldName} is the literal placeholder ${value}; set the matching env var before starting Harper`
+		);
+	}
+	return value;
+}
+
+/**
+ * Normalize a config-supplied host/origin into a fully-qualified base URL.
+ *
+ * - Falls back to `defaults.host` when value is empty
+ * - Prepends `http://` or `https://` (per `defaults.secure`) when no scheme present
+ * - Strips trailing slashes so callers can `${origin}${path}` cleanly
+ *
+ * Backend-specific behavior collapses to choosing the right `defaults`:
+ * Ollama → `{ host: 'localhost:11434', secure: false }`; OpenAI →
+ * `{ host: 'api.openai.com/v1', secure: true }`; etc.
+ */
+export function normalizeOrigin(value: string | undefined, defaults: { host: string; secure: boolean }): string {
+	const v = value?.trim() || defaults.host;
+	const withScheme = /^https?:\/\//i.test(v) ? v : (defaults.secure ? 'https://' : 'http://') + v;
+	return withScheme.replace(/\/+$/, '');
+}

--- a/resources/models/bootstrap.ts
+++ b/resources/models/bootstrap.ts
@@ -22,6 +22,8 @@ import harperLogger from '../../utility/logging/harper_logger.ts';
 import { expandEnvVarsDeep, isUnresolvedEnvVarPlaceholder } from '../../utility/expandEnvVar.ts';
 import { registerOllamaBackend, type OllamaBackendConfig } from '../../components/ollama/index.ts';
 import { registerOpenAIBackend, type OpenAIBackendConfig } from '../../components/openai/index.ts';
+import { registerAnthropicBackend, type AnthropicBackendConfig } from '../../components/anthropic/index.ts';
+import { registerBedrockBackend, type BedrockBackendConfig } from '../../components/bedrock/index.ts';
 
 /**
  * Field names treated as credentials. When present in config as a literal
@@ -38,9 +40,12 @@ interface ModelEntry {
 	host?: string;
 	model?: string;
 	requestTimeoutMs?: number;
-	// openai-specific fields
+	// openai + anthropic credentials
 	apiKey?: string;
 	baseUrl?: string;
+	organization?: string;
+	// bedrock
+	region?: string;
 }
 
 interface ModelsConfig {
@@ -57,6 +62,8 @@ type BackendRegisterFn = (args: { logicalName: string; kind: ModelKind; config: 
 const FACTORIES: Record<string, BackendRegisterFn> = {
 	ollama: (args) => registerOllamaBackend({ ...args, config: args.config as OllamaBackendConfig }),
 	openai: (args) => registerOpenAIBackend({ ...args, config: args.config as OpenAIBackendConfig }),
+	anthropic: (args) => registerAnthropicBackend({ ...args, config: args.config as AnthropicBackendConfig }),
+	bedrock: (args) => registerBedrockBackend({ ...args, config: args.config as BedrockBackendConfig }),
 };
 
 /**

--- a/unitTests/components/anthropic/index.test.js
+++ b/unitTests/components/anthropic/index.test.js
@@ -1,0 +1,402 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const {
+	AnthropicBackend,
+	AnthropicBackendError,
+	registerAnthropicBackend,
+} = require('#src/components/anthropic/index');
+const { clearRegistry, resolveGenerative } = require('#src/resources/models/backendRegistry');
+
+const ACCOUNTING = { tenantId: 'tid', app: '/test' };
+const API_KEY = 'sk-ant-test';
+
+function mockFetch(responder) {
+	const calls = [];
+	const fn = async (url, init) => {
+		calls.push({ url, init });
+		const res = await responder({ url, init, callIndex: calls.length - 1 });
+		return res;
+	};
+	fn.calls = calls;
+	return fn;
+}
+
+function jsonResponse(body, { status = 200 } = {}) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}
+
+function sseResponse(events) {
+	const body = new ReadableStream({
+		start(controller) {
+			const enc = new TextEncoder();
+			for (const event of events) {
+				const payload = typeof event === 'string' ? event : JSON.stringify(event);
+				const line = `event: ${typeof event === 'object' && event.type ? event.type : 'message'}\ndata: ${payload}\n\n`;
+				controller.enqueue(enc.encode(line));
+			}
+			controller.close();
+		},
+	});
+	return new Response(body, { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+}
+
+describe('AnthropicBackend', () => {
+	describe('construction + shape', () => {
+		it('reports name = "anthropic"', () => {
+			const b = new AnthropicBackend({ apiKey: API_KEY });
+			assert.strictEqual(b.name, 'anthropic');
+		});
+
+		it('advertises capabilities: embed=false, tools=true (per issue body)', () => {
+			const b = new AnthropicBackend({ apiKey: API_KEY });
+			assert.deepStrictEqual(b.capabilities(), {
+				embed: false,
+				generate: true,
+				stream: true,
+				tools: true,
+				adapters: false,
+			});
+		});
+
+		it('throws when apiKey is missing', () => {
+			assert.throws(() => new AnthropicBackend({}), AnthropicBackendError);
+		});
+
+		it('throws when apiKey is the literal ${VAR} placeholder (env var unset)', () => {
+			assert.throws(() => new AnthropicBackend({ apiKey: '${ANTHROPIC_API_KEY_NOT_SET}' }), /literal placeholder/);
+		});
+
+		it('defaults baseUrl to https://api.anthropic.com', async () => {
+			const fetch = mockFetch(() => jsonResponse({ content: [], stop_reason: 'end_turn', usage: {} }));
+			const b = new AnthropicBackend({ apiKey: API_KEY, model: 'claude-opus-4-7' }, fetch);
+			await b.generate('hi', { accounting: ACCOUNTING });
+			assert.strictEqual(fetch.calls[0].url, 'https://api.anthropic.com/v1/messages');
+		});
+
+		it('respects baseUrl override', async () => {
+			const fetch = mockFetch(() => jsonResponse({ content: [], stop_reason: 'end_turn', usage: {} }));
+			const b = new AnthropicBackend(
+				{ apiKey: API_KEY, model: 'claude-opus-4-7', baseUrl: 'https://my-proxy.example.com' },
+				fetch
+			);
+			await b.generate('hi', { accounting: ACCOUNTING });
+			assert.strictEqual(fetch.calls[0].url, 'https://my-proxy.example.com/v1/messages');
+		});
+
+		it('sends x-api-key and anthropic-version headers', async () => {
+			const fetch = mockFetch(() => jsonResponse({ content: [], stop_reason: 'end_turn', usage: {} }));
+			const b = new AnthropicBackend({ apiKey: 'sk-ant-secret', model: 'claude' }, fetch);
+			await b.generate('hi', { accounting: ACCOUNTING });
+			assert.strictEqual(fetch.calls[0].init.headers['x-api-key'], 'sk-ant-secret');
+			assert.strictEqual(fetch.calls[0].init.headers['anthropic-version'], '2023-06-01');
+			// Specifically NOT the OpenAI Bearer pattern.
+			assert.strictEqual(fetch.calls[0].init.headers.Authorization, undefined);
+		});
+	});
+
+	describe('generate (non-streaming)', () => {
+		function messagesResponse({
+			contentBlocks = [{ type: 'text', text: 'hi there' }],
+			stopReason = 'end_turn',
+			usage,
+		} = {}) {
+			return jsonResponse({
+				id: 'msg_x',
+				type: 'message',
+				role: 'assistant',
+				content: contentBlocks,
+				stop_reason: stopReason,
+				usage: usage ?? { input_tokens: 5, output_tokens: 2 },
+			});
+		}
+
+		it('POSTs /v1/messages with a string input wrapped as a single user message', async () => {
+			const fetch = mockFetch(() => messagesResponse());
+			const b = new AnthropicBackend({ apiKey: API_KEY, model: 'claude' }, fetch);
+			const result = await b.generate('hello', { accounting: ACCOUNTING });
+			assert.strictEqual(result.output.content, 'hi there');
+			assert.strictEqual(result.output.finishReason, 'stop');
+			assert.strictEqual(result.usage.promptTokens, 5);
+			assert.strictEqual(result.usage.completionTokens, 2);
+			const sent = JSON.parse(fetch.calls[0].init.body);
+			assert.deepStrictEqual(sent.messages, [{ role: 'user', content: 'hello' }]);
+			assert.strictEqual(sent.stream, false);
+			// max_tokens is required by Anthropic; we default it.
+			assert.strictEqual(typeof sent.max_tokens, 'number');
+			assert.ok(sent.max_tokens > 0);
+		});
+
+		it('extracts system messages to the top-level system field', async () => {
+			const fetch = mockFetch(() => messagesResponse());
+			const b = new AnthropicBackend({ apiKey: API_KEY, model: 'claude' }, fetch);
+			await b.generate(
+				[
+					{ role: 'system', content: 'be brief' },
+					{ role: 'user', content: 'q' },
+				],
+				{ accounting: ACCOUNTING }
+			);
+			const sent = JSON.parse(fetch.calls[0].init.body);
+			assert.strictEqual(sent.system, 'be brief');
+			assert.deepStrictEqual(sent.messages, [{ role: 'user', content: 'q' }]);
+		});
+
+		it('combines explicit system field with inline system messages', async () => {
+			const fetch = mockFetch(() => messagesResponse());
+			const b = new AnthropicBackend({ apiKey: API_KEY, model: 'claude' }, fetch);
+			await b.generate(
+				{
+					messages: [
+						{ role: 'system', content: 'B' },
+						{ role: 'user', content: 'q' },
+					],
+					system: 'A',
+				},
+				{ accounting: ACCOUNTING }
+			);
+			const sent = JSON.parse(fetch.calls[0].init.body);
+			assert.strictEqual(sent.system, 'A\n\nB');
+		});
+
+		it("translates tool definitions to Anthropic's input_schema shape", async () => {
+			const fetch = mockFetch(() => messagesResponse());
+			const b = new AnthropicBackend({ apiKey: API_KEY, model: 'claude' }, fetch);
+			const tools = [
+				{ name: 'get_weather', description: 'weather lookup', parameters: { type: 'object', properties: {} } },
+			];
+			await b.generate({ messages: [{ role: 'user', content: 'q' }], tools }, { accounting: ACCOUNTING });
+			const sent = JSON.parse(fetch.calls[0].init.body);
+			assert.deepStrictEqual(sent.tools, [
+				{ name: 'get_weather', description: 'weather lookup', input_schema: { type: 'object', properties: {} } },
+			]);
+		});
+
+		it('parses tool_use content blocks into GenerateResult.toolCalls', async () => {
+			const fetch = mockFetch(() =>
+				messagesResponse({
+					contentBlocks: [
+						{ type: 'text', text: '' },
+						{ type: 'tool_use', id: 'tu_1', name: 'get_weather', input: { location: 'SF' } },
+					],
+					stopReason: 'tool_use',
+				})
+			);
+			const b = new AnthropicBackend({ apiKey: API_KEY, model: 'claude' }, fetch);
+			const result = await b.generate('q', { accounting: ACCOUNTING });
+			assert.strictEqual(result.output.finishReason, 'tool_calls');
+			assert.deepStrictEqual(result.output.toolCalls, [
+				{ id: 'tu_1', name: 'get_weather', arguments: { location: 'SF' } },
+			]);
+		});
+
+		it("maps stop_reason='max_tokens' to finishReason='length'", async () => {
+			const fetch = mockFetch(() => messagesResponse({ stopReason: 'max_tokens' }));
+			const b = new AnthropicBackend({ apiKey: API_KEY, model: 'claude' }, fetch);
+			const result = await b.generate('q', { accounting: ACCOUNTING });
+			assert.strictEqual(result.output.finishReason, 'length');
+		});
+
+		it('honors opts.maxTokens', async () => {
+			const fetch = mockFetch(() => messagesResponse());
+			const b = new AnthropicBackend({ apiKey: API_KEY, model: 'claude' }, fetch);
+			await b.generate('q', { accounting: ACCOUNTING, maxTokens: 256 });
+			const sent = JSON.parse(fetch.calls[0].init.body);
+			assert.strictEqual(sent.max_tokens, 256);
+		});
+
+		it('includes upstream error.message in HTTP-error', async () => {
+			const fetch = mockFetch(
+				() =>
+					new Response(JSON.stringify({ error: { message: 'Invalid model: foo', type: 'invalid_request' } }), {
+						status: 400,
+						headers: { 'Content-Type': 'application/json' },
+					})
+			);
+			const b = new AnthropicBackend({ apiKey: API_KEY, model: 'claude' }, fetch);
+			await assert.rejects(() => b.generate('q', { accounting: ACCOUNTING }), /returned HTTP 400: Invalid model: foo/);
+		});
+	});
+
+	describe('generateStream', () => {
+		it('yields content deltas and a terminating finishReason', async () => {
+			const fetch = mockFetch(() =>
+				sseResponse([
+					{ type: 'message_start', message: { id: 'x' } },
+					{ type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+					{ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'hi' } },
+					{ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: ' there' } },
+					{ type: 'content_block_stop', index: 0 },
+					{ type: 'message_delta', delta: { stop_reason: 'end_turn' } },
+					{ type: 'message_stop' },
+				])
+			);
+			const b = new AnthropicBackend({ apiKey: API_KEY, model: 'claude' }, fetch);
+			const chunks = [];
+			for await (const c of b.generateStream('q', { accounting: ACCOUNTING })) chunks.push(c);
+			assert.strictEqual(chunks[0].deltaContent, 'hi');
+			assert.strictEqual(chunks[1].deltaContent, ' there');
+			assert.strictEqual(chunks[chunks.length - 1].finishReason, 'stop');
+		});
+
+		it('assembles streaming tool calls from content_block_delta input_json_delta events', async () => {
+			const fetch = mockFetch(() =>
+				sseResponse([
+					{ type: 'message_start', message: { id: 'x' } },
+					{
+						type: 'content_block_start',
+						index: 0,
+						content_block: { type: 'tool_use', id: 'tu_1', name: 'get_weather' },
+					},
+					{
+						type: 'content_block_delta',
+						index: 0,
+						delta: { type: 'input_json_delta', partial_json: '{"loc' },
+					},
+					{
+						type: 'content_block_delta',
+						index: 0,
+						delta: { type: 'input_json_delta', partial_json: 'ation":"SF"}' },
+					},
+					{ type: 'content_block_stop', index: 0 },
+					{ type: 'message_delta', delta: { stop_reason: 'tool_use' } },
+				])
+			);
+			const b = new AnthropicBackend({ apiKey: API_KEY, model: 'claude' }, fetch);
+			const chunks = [];
+			for await (const c of b.generateStream(
+				{ messages: [{ role: 'user', content: 'q' }] },
+				{ accounting: ACCOUNTING }
+			)) {
+				chunks.push(c);
+			}
+			const withToolCall = chunks.find((c) => c.deltaToolCalls);
+			assert.ok(withToolCall);
+			assert.deepStrictEqual(withToolCall.deltaToolCalls, [
+				{ id: 'tu_1', name: 'get_weather', arguments: { location: 'SF' } },
+			]);
+			const terminal = chunks[chunks.length - 1];
+			assert.strictEqual(terminal.finishReason, 'tool_calls');
+		});
+
+		it('caps tool-call arguments accumulator at 1 MiB', async () => {
+			const half = 'x'.repeat(1 << 19);
+			const fetch = mockFetch(() =>
+				sseResponse([
+					{ type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'a', name: 'fn' } },
+					{ type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: half } },
+					{ type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: half } },
+					{ type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: half } },
+				])
+			);
+			const b = new AnthropicBackend({ apiKey: API_KEY, model: 'claude' }, fetch);
+			await assert.rejects(async () => {
+				for await (const _c of b.generateStream(
+					{ messages: [{ role: 'user', content: 'q' }] },
+					{ accounting: ACCOUNTING }
+				)) {
+					/* drain */
+				}
+			}, /tool-call arguments exceed/);
+		});
+
+		it('drops streamed tool calls with malformed JSON arguments', async () => {
+			const fetch = mockFetch(() =>
+				sseResponse([
+					{ type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'bad', name: 'fn' } },
+					{ type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: 'not-json' } },
+					{ type: 'content_block_stop', index: 0 },
+					{ type: 'message_delta', delta: { stop_reason: 'tool_use' } },
+				])
+			);
+			const b = new AnthropicBackend({ apiKey: API_KEY, model: 'claude' }, fetch);
+			const chunks = [];
+			for await (const c of b.generateStream(
+				{ messages: [{ role: 'user', content: 'q' }] },
+				{ accounting: ACCOUNTING }
+			)) {
+				chunks.push(c);
+			}
+			// Only the finishReason chunk should survive.
+			const withToolCall = chunks.find((c) => c.deltaToolCalls);
+			assert.strictEqual(withToolCall, undefined);
+		});
+
+		it('throws AnthropicBackendError on mid-stream upstream error events', async () => {
+			const fetch = mockFetch(() =>
+				sseResponse([
+					{ type: 'message_start', message: { id: 'x' } },
+					{ type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+					{ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'partial' } },
+					{ type: 'error', error: { type: 'overloaded_error', message: 'Anthropic is overloaded' } },
+				])
+			);
+			const b = new AnthropicBackend({ apiKey: API_KEY, model: 'claude' }, fetch);
+			await assert.rejects(async () => {
+				for await (const _c of b.generateStream('q', { accounting: ACCOUNTING })) {
+					/* drain */
+				}
+			}, /stream aborted by upstream error: Anthropic is overloaded/);
+		});
+
+		it('caps SSE buffer at 1 MiB without an event boundary', async () => {
+			const huge = 'x'.repeat((1 << 20) + 1);
+			const body = new ReadableStream({
+				start(controller) {
+					controller.enqueue(new TextEncoder().encode(huge));
+					controller.close();
+				},
+			});
+			const fetch = mockFetch(() => new Response(body, { status: 200 }));
+			const b = new AnthropicBackend({ apiKey: API_KEY, model: 'claude' }, fetch);
+			await assert.rejects(async () => {
+				for await (const _c of b.generateStream('q', { accounting: ACCOUNTING })) {
+					/* no-op */
+				}
+			}, /SSE buffer exceeds/);
+		});
+	});
+
+	describe('AbortSignal', () => {
+		it('passes caller signal through when no timeout configured', async () => {
+			const ctrl = new AbortController();
+			let seen;
+			const fetch = mockFetch(({ init }) => {
+				seen = init.signal;
+				return jsonResponse({ content: [], stop_reason: 'end_turn', usage: {} });
+			});
+			const b = new AnthropicBackend({ apiKey: API_KEY, model: 'claude' }, fetch);
+			await b.generate('q', { accounting: ACCOUNTING, signal: ctrl.signal });
+			assert.strictEqual(seen, ctrl.signal);
+		});
+	});
+});
+
+describe('registerAnthropicBackend', () => {
+	beforeEach(() => clearRegistry());
+
+	it('registers as a generative backend', () => {
+		registerAnthropicBackend({
+			logicalName: 'claude',
+			kind: 'generative',
+			config: { apiKey: API_KEY, model: 'claude-opus-4-7' },
+		});
+		const b = resolveGenerative('claude');
+		assert.strictEqual(b.name, 'anthropic');
+	});
+
+	it('throws on embedding kind (Anthropic has no embedding API)', () => {
+		assert.throws(
+			() =>
+				registerAnthropicBackend({
+					logicalName: 'whatever',
+					kind: 'embedding',
+					config: { apiKey: API_KEY, model: 'foo' },
+				}),
+			AnthropicBackendError
+		);
+	});
+});

--- a/unitTests/components/bedrock/index.test.js
+++ b/unitTests/components/bedrock/index.test.js
@@ -1,0 +1,368 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const {
+	BedrockBackend,
+	registerBedrockBackend,
+	_resetSdkCacheForTests,
+	_injectSdkForTests,
+} = require('#src/components/bedrock/index');
+const { clearRegistry, resolveEmbedding, resolveGenerative } = require('#src/resources/models/backendRegistry');
+
+const ACCOUNTING = { tenantId: 'tid', app: '/test' };
+
+// A fake AWS SDK shape that mirrors the loose types in `components/bedrock/index.ts`.
+// Each test wires its own responder to control what `client.send(command)` resolves to.
+function fakeSdk(responder) {
+	const sent = [];
+	class FakeClient {
+		constructor(config) {
+			this.config = config;
+		}
+		async send(command, options) {
+			sent.push({ command, options });
+			return responder(command, options);
+		}
+	}
+	class InvokeModelCommand {
+		constructor(input) {
+			this.kind = 'InvokeModel';
+			Object.assign(this, input);
+		}
+	}
+	class InvokeModelWithResponseStreamCommand {
+		constructor(input) {
+			this.kind = 'InvokeModelWithResponseStream';
+			Object.assign(this, input);
+		}
+	}
+	return {
+		sdk: {
+			BedrockRuntimeClient: FakeClient,
+			InvokeModelCommand,
+			InvokeModelWithResponseStreamCommand,
+		},
+		sent,
+	};
+}
+
+function jsonBodyResponse(obj) {
+	return { body: new TextEncoder().encode(JSON.stringify(obj)) };
+}
+
+async function* streamFromChunks(chunks) {
+	for (const c of chunks) {
+		yield { chunk: { bytes: new TextEncoder().encode(JSON.stringify(c)) } };
+	}
+}
+
+describe('BedrockBackend', () => {
+	beforeEach(() => _resetSdkCacheForTests());
+
+	describe('shape', () => {
+		it('reports name = "bedrock"', () => {
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'anthropic.claude' });
+			assert.strictEqual(b.name, 'bedrock');
+		});
+
+		it('advertises capabilities matching the issue body', () => {
+			const b = new BedrockBackend({ region: 'us-east-1' });
+			assert.deepStrictEqual(b.capabilities(), {
+				embed: true,
+				generate: true,
+				stream: true,
+				tools: true,
+				adapters: false,
+			});
+		});
+
+		it('throws BedrockBackendError with install instructions when SDK is missing', async () => {
+			// Default: no SDK injected → the lazy loader tries the real import
+			// which fails because Harper does not depend on the SDK directly.
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'anthropic.claude' });
+			await assert.rejects(
+				() => b.generate('q', { accounting: ACCOUNTING }),
+				/@aws-sdk\/client-bedrock-runtime is not installed/
+			);
+		});
+	});
+
+	describe('per-family generate dispatch', () => {
+		it('dispatches anthropic.* models to the Anthropic Messages body shape', async () => {
+			const { sdk, sent } = fakeSdk(() =>
+				jsonBodyResponse({
+					content: [{ type: 'text', text: 'hi' }],
+					stop_reason: 'end_turn',
+					usage: { input_tokens: 3, output_tokens: 1 },
+				})
+			);
+			_injectSdkForTests(sdk);
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'anthropic.claude-opus-4-v1:0' });
+			const result = await b.generate('hello', { accounting: ACCOUNTING });
+			assert.strictEqual(result.output.content, 'hi');
+			assert.strictEqual(result.output.finishReason, 'stop');
+			assert.strictEqual(result.usage.promptTokens, 3);
+			assert.strictEqual(result.usage.completionTokens, 1);
+			const body = JSON.parse(sent[0].command.body);
+			assert.strictEqual(body.anthropic_version, 'bedrock-2023-05-31');
+			assert.deepStrictEqual(body.messages, [{ role: 'user', content: 'hello' }]);
+			assert.ok(body.max_tokens > 0);
+		});
+
+		it('dispatches meta.* models to Llama prompt shape', async () => {
+			const { sdk, sent } = fakeSdk(() =>
+				jsonBodyResponse({
+					generation: 'llama says hi',
+					stop_reason: 'stop',
+					prompt_token_count: 10,
+					generation_token_count: 4,
+				})
+			);
+			_injectSdkForTests(sdk);
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'meta.llama3-70b-instruct-v1:0' });
+			const result = await b.generate('hi', { accounting: ACCOUNTING });
+			assert.strictEqual(result.output.content, 'llama says hi');
+			assert.strictEqual(result.usage.promptTokens, 10);
+			assert.strictEqual(result.usage.completionTokens, 4);
+			const body = JSON.parse(sent[0].command.body);
+			assert.ok(typeof body.prompt === 'string');
+			assert.ok(body.prompt.includes('hi'));
+		});
+
+		it('dispatches amazon.titan-* generate to Titan body shape', async () => {
+			const { sdk } = fakeSdk(() =>
+				jsonBodyResponse({
+					inputTextTokenCount: 5,
+					results: [{ outputText: 'titan says hi', tokenCount: 3, completionReason: 'FINISH' }],
+				})
+			);
+			_injectSdkForTests(sdk);
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'amazon.titan-text-express-v1' });
+			const result = await b.generate('q', { accounting: ACCOUNTING });
+			assert.strictEqual(result.output.content, 'titan says hi');
+			assert.strictEqual(result.usage.promptTokens, 5);
+			assert.strictEqual(result.usage.completionTokens, 3);
+		});
+
+		it('rejects tools on a non-anthropic family with a structured error', async () => {
+			const { sdk } = fakeSdk(() => jsonBodyResponse({ generation: 'x', stop_reason: 'stop' }));
+			_injectSdkForTests(sdk);
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'meta.llama3-70b-instruct-v1:0' });
+			const tools = [{ name: 'fn', description: 'd', parameters: { type: 'object', properties: {} } }];
+			await assert.rejects(
+				() => b.generate({ messages: [{ role: 'user', content: 'q' }], tools }, { accounting: ACCOUNTING }),
+				/tool calls are not supported for model family 'meta'/
+			);
+		});
+
+		it('still routes tools through anthropic.* models (no rejection)', async () => {
+			const { sdk } = fakeSdk(() =>
+				jsonBodyResponse({
+					content: [{ type: 'text', text: 'hi' }],
+					stop_reason: 'end_turn',
+					usage: {},
+				})
+			);
+			_injectSdkForTests(sdk);
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'anthropic.claude' });
+			const tools = [{ name: 'fn', description: 'd', parameters: { type: 'object', properties: {} } }];
+			// Doesn't throw.
+			await b.generate({ messages: [{ role: 'user', content: 'q' }], tools }, { accounting: ACCOUNTING });
+		});
+
+		it('throws on unknown model family', async () => {
+			const { sdk } = fakeSdk(() => jsonBodyResponse({}));
+			_injectSdkForTests(sdk);
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'unknownvendor.foo-v1' });
+			await assert.rejects(
+				() => b.generate('q', { accounting: ACCOUNTING }),
+				/not supported for model family 'unknown'/
+			);
+		});
+	});
+
+	describe('embed', () => {
+		it('dispatches Titan embed model', async () => {
+			const { sdk } = fakeSdk(() => jsonBodyResponse({ embedding: [0.1, 0.2, 0.3], inputTextTokenCount: 2 }));
+			_injectSdkForTests(sdk);
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'amazon.titan-embed-text-v2:0' });
+			const result = await b.embed('hello', { accounting: ACCOUNTING });
+			assert.strictEqual(result.status, 'completed');
+			assert.strictEqual(result.output.length, 1);
+			assert.ok(result.output[0] instanceof Float32Array);
+			assert.strictEqual(result.usage.embeddingTokens, 2);
+		});
+
+		it('dispatches Cohere embed model', async () => {
+			const { sdk } = fakeSdk(() => jsonBodyResponse({ embeddings: [[0.4, 0.5]] }));
+			_injectSdkForTests(sdk);
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'cohere.embed-english-v3' });
+			const result = await b.embed('hi', { accounting: ACCOUNTING });
+			assert.strictEqual(result.output.length, 1);
+			assert.ok(result.output[0] instanceof Float32Array);
+		});
+
+		it("Cohere embed defaults input_type to 'search_document'", async () => {
+			const { sdk, sent } = fakeSdk(() => jsonBodyResponse({ embeddings: [[0.4]] }));
+			_injectSdkForTests(sdk);
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'cohere.embed-english-v3' });
+			await b.embed('hi', { accounting: ACCOUNTING });
+			const body = JSON.parse(sent[0].command.body);
+			assert.strictEqual(body.input_type, 'search_document');
+		});
+
+		it("Cohere embed maps inputType='query' to input_type='search_query'", async () => {
+			const { sdk, sent } = fakeSdk(() => jsonBodyResponse({ embeddings: [[0.4]] }));
+			_injectSdkForTests(sdk);
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'cohere.embed-english-v3' });
+			await b.embed('hi', { accounting: ACCOUNTING, inputType: 'query' });
+			const body = JSON.parse(sent[0].command.body);
+			assert.strictEqual(body.input_type, 'search_query');
+		});
+
+		it("Cohere embed maps inputType='document' to input_type='search_document'", async () => {
+			const { sdk, sent } = fakeSdk(() => jsonBodyResponse({ embeddings: [[0.4]] }));
+			_injectSdkForTests(sdk);
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'cohere.embed-english-v3' });
+			await b.embed('hi', { accounting: ACCOUNTING, inputType: 'document' });
+			const body = JSON.parse(sent[0].command.body);
+			assert.strictEqual(body.input_type, 'search_document');
+		});
+
+		it('throws on a generative-only family asked to embed', async () => {
+			const { sdk } = fakeSdk(() => jsonBodyResponse({}));
+			_injectSdkForTests(sdk);
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'anthropic.claude-opus-4-v1:0' });
+			await assert.rejects(
+				() => b.embed('hi', { accounting: ACCOUNTING }),
+				/embed not supported for model family 'anthropic'/
+			);
+		});
+	});
+
+	describe('generateStream', () => {
+		it('streams Anthropic content_block_delta + finishReason', async () => {
+			const { sdk } = fakeSdk(() => ({
+				body: streamFromChunks([
+					{ type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+					{ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'hello' } },
+					{ type: 'content_block_stop', index: 0 },
+					{ type: 'message_delta', delta: { stop_reason: 'end_turn' } },
+				]),
+			}));
+			_injectSdkForTests(sdk);
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'anthropic.claude' });
+			const chunks = [];
+			for await (const c of b.generateStream('q', { accounting: ACCOUNTING })) chunks.push(c);
+			assert.strictEqual(chunks[0].deltaContent, 'hello');
+			assert.strictEqual(chunks[chunks.length - 1].finishReason, 'stop');
+		});
+
+		it('streams Llama generation chunks via flat parser', async () => {
+			const { sdk } = fakeSdk(() => ({
+				body: streamFromChunks([
+					{ generation: 'one ' },
+					{ generation: 'two' },
+					{ generation: '', stop_reason: 'stop' },
+				]),
+			}));
+			_injectSdkForTests(sdk);
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'meta.llama3-70b-instruct-v1:0' });
+			const chunks = [];
+			for await (const c of b.generateStream('q', { accounting: ACCOUNTING })) chunks.push(c);
+			const contents = chunks.filter((c) => c.deltaContent).map((c) => c.deltaContent);
+			assert.deepStrictEqual(contents, ['one ', 'two']);
+			assert.strictEqual(chunks[chunks.length - 1].finishReason, 'stop');
+		});
+
+		it('throws BedrockBackendError on mid-stream Anthropic upstream error events', async () => {
+			const { sdk } = fakeSdk(() => ({
+				body: streamFromChunks([
+					{ type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+					{ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'partial' } },
+					{ type: 'error', error: { type: 'overloaded_error', message: 'Bedrock is overloaded' } },
+				]),
+			}));
+			_injectSdkForTests(sdk);
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'anthropic.claude' });
+			await assert.rejects(async () => {
+				for await (const _c of b.generateStream('q', { accounting: ACCOUNTING })) {
+					/* drain */
+				}
+			}, /stream aborted by upstream error: Bedrock is overloaded/);
+		});
+
+		it('caps Anthropic streaming tool-call arguments at 1 MiB', async () => {
+			const half = 'x'.repeat(1 << 19);
+			const { sdk } = fakeSdk(() => ({
+				body: streamFromChunks([
+					{ type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'a', name: 'fn' } },
+					{ type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: half } },
+					{ type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: half } },
+					{ type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: half } },
+				]),
+			}));
+			_injectSdkForTests(sdk);
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'anthropic.claude' });
+			await assert.rejects(async () => {
+				for await (const _c of b.generateStream(
+					{ messages: [{ role: 'user', content: 'q' }] },
+					{ accounting: ACCOUNTING }
+				)) {
+					/* drain */
+				}
+			}, /tool-call arguments exceed/);
+		});
+	});
+
+	describe('AbortSignal', () => {
+		it('passes caller signal into SDK send() abortSignal option', async () => {
+			const ctrl = new AbortController();
+			let seenOptions;
+			const { sdk } = fakeSdk((_cmd, options) => {
+				seenOptions = options;
+				return jsonBodyResponse({ content: [{ type: 'text', text: '' }], stop_reason: 'end_turn', usage: {} });
+			});
+			_injectSdkForTests(sdk);
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'anthropic.claude' });
+			await b.generate('q', { accounting: ACCOUNTING, signal: ctrl.signal });
+			assert.strictEqual(seenOptions?.abortSignal, ctrl.signal);
+		});
+
+		it('composes caller signal with timeout via AbortSignal.any', async () => {
+			const ctrl = new AbortController();
+			let seenSignal;
+			const { sdk } = fakeSdk((_cmd, options) => {
+				seenSignal = options?.abortSignal;
+				return jsonBodyResponse({ content: [{ type: 'text', text: '' }], stop_reason: 'end_turn', usage: {} });
+			});
+			_injectSdkForTests(sdk);
+			const b = new BedrockBackend({ region: 'us-east-1', model: 'anthropic.claude', requestTimeoutMs: 10000 });
+			await b.generate('q', { accounting: ACCOUNTING, signal: ctrl.signal });
+			assert.ok(seenSignal instanceof AbortSignal);
+			assert.notStrictEqual(seenSignal, ctrl.signal);
+		});
+	});
+});
+
+describe('registerBedrockBackend', () => {
+	beforeEach(() => clearRegistry());
+
+	it('registers as a generative backend', () => {
+		registerBedrockBackend({
+			logicalName: 'claude',
+			kind: 'generative',
+			config: { region: 'us-east-1', model: 'anthropic.claude-opus-4-v1:0' },
+		});
+		assert.strictEqual(resolveGenerative('claude').name, 'bedrock');
+	});
+
+	it('registers as an embedding backend', () => {
+		registerBedrockBackend({
+			logicalName: 'titan',
+			kind: 'embedding',
+			config: { region: 'us-east-1', model: 'amazon.titan-embed-text-v2:0' },
+		});
+		assert.strictEqual(resolveEmbedding('titan').name, 'bedrock');
+	});
+});

--- a/unitTests/resources/models/backendHelpers.test.js
+++ b/unitTests/resources/models/backendHelpers.test.js
@@ -1,0 +1,240 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const {
+	composeSignal,
+	assignFiniteTokenCount,
+	parseJsonResponse,
+	requireModel,
+	requireCredential,
+	normalizeOrigin,
+} = require('#src/resources/models/backendHelpers');
+
+// Backend-specific error class used to verify the helpers route the thrown
+// error through the caller's constructor, not a generic `Error`.
+class FakeBackendError extends Error {
+	constructor(message) {
+		super(message);
+		this.name = 'FakeBackendError';
+	}
+}
+
+describe('backendHelpers', () => {
+	describe('composeSignal', () => {
+		it('returns undefined when neither input is provided', () => {
+			assert.strictEqual(composeSignal(undefined, undefined), undefined);
+		});
+
+		it('returns the caller signal unchanged when no timeout', () => {
+			const ctrl = new AbortController();
+			assert.strictEqual(composeSignal(ctrl.signal, undefined), ctrl.signal);
+		});
+
+		it('returns a timeout-only signal when caller is undefined', () => {
+			const s = composeSignal(undefined, 5000);
+			assert.ok(s instanceof AbortSignal);
+		});
+
+		it('composes both inputs via AbortSignal.any', () => {
+			const ctrl = new AbortController();
+			const s = composeSignal(ctrl.signal, 5000);
+			assert.ok(s instanceof AbortSignal);
+			assert.notStrictEqual(s, ctrl.signal); // distinct composed signal
+		});
+
+		it('composed signal aborts when caller aborts', async () => {
+			const ctrl = new AbortController();
+			const s = composeSignal(ctrl.signal, 60_000);
+			let fired = false;
+			s.addEventListener('abort', () => {
+				fired = true;
+			});
+			ctrl.abort();
+			// abort listeners fire synchronously
+			assert.strictEqual(fired, true);
+		});
+	});
+
+	describe('assignFiniteTokenCount', () => {
+		it('assigns a positive integer', () => {
+			const usage = {};
+			assignFiniteTokenCount(usage, 'promptTokens', 7);
+			assert.strictEqual(usage.promptTokens, 7);
+		});
+
+		it('assigns 0', () => {
+			const usage = {};
+			assignFiniteTokenCount(usage, 'completionTokens', 0);
+			assert.strictEqual(usage.completionTokens, 0);
+		});
+
+		it('drops NaN', () => {
+			const usage = {};
+			assignFiniteTokenCount(usage, 'promptTokens', NaN);
+			assert.strictEqual(usage.promptTokens, undefined);
+		});
+
+		it('drops Infinity', () => {
+			const usage = {};
+			assignFiniteTokenCount(usage, 'promptTokens', Infinity);
+			assert.strictEqual(usage.promptTokens, undefined);
+		});
+
+		it('drops negatives', () => {
+			const usage = {};
+			assignFiniteTokenCount(usage, 'promptTokens', -1);
+			assert.strictEqual(usage.promptTokens, undefined);
+		});
+
+		it('drops non-integer floats', () => {
+			const usage = {};
+			assignFiniteTokenCount(usage, 'promptTokens', 1.5);
+			assert.strictEqual(usage.promptTokens, undefined);
+		});
+
+		it('drops non-number values', () => {
+			const usage = {};
+			assignFiniteTokenCount(usage, 'promptTokens', '7');
+			assert.strictEqual(usage.promptTokens, undefined);
+			assignFiniteTokenCount(usage, 'promptTokens', null);
+			assert.strictEqual(usage.promptTokens, undefined);
+			assignFiniteTokenCount(usage, 'promptTokens', undefined);
+			assert.strictEqual(usage.promptTokens, undefined);
+		});
+	});
+
+	describe('parseJsonResponse', () => {
+		it('returns the parsed body on success', async () => {
+			const res = new Response(JSON.stringify({ ok: true }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			});
+			const body = await parseJsonResponse(res, '/test', FakeBackendError);
+			assert.deepStrictEqual(body, { ok: true });
+		});
+
+		it('throws the supplied error class on invalid JSON', async () => {
+			const res = new Response('<html>oops</html>', { status: 200 });
+			await assert.rejects(() => parseJsonResponse(res, '/test', FakeBackendError), FakeBackendError);
+		});
+
+		it('error message includes the endpoint path (not raw upstream bytes)', async () => {
+			const res = new Response('<script>alert(1)</script>', { status: 200 });
+			try {
+				await parseJsonResponse(res, '/api/embed', FakeBackendError);
+				assert.fail('expected throw');
+			} catch (err) {
+				assert.ok(err.message.includes('/api/embed'));
+				assert.ok(!err.message.includes('<script>'));
+			}
+		});
+	});
+
+	describe('requireModel', () => {
+		it('passes when model is a non-empty string', () => {
+			requireModel('gpt-4o', 'generate', FakeBackendError); // does not throw
+		});
+
+		it('throws when model is undefined', () => {
+			assert.throws(() => requireModel(undefined, 'embed', FakeBackendError), FakeBackendError);
+		});
+
+		it('throws when model is empty string', () => {
+			assert.throws(() => requireModel('', 'generate', FakeBackendError), FakeBackendError);
+		});
+
+		it('error message names the operation', () => {
+			try {
+				requireModel(undefined, 'generateStream', FakeBackendError);
+				assert.fail('expected throw');
+			} catch (err) {
+				assert.ok(err.message.includes('generateStream'));
+			}
+		});
+	});
+
+	describe('requireCredential', () => {
+		it('returns the value when non-empty and not a placeholder', () => {
+			const v = requireCredential('sk-real', 'OpenAI', 'apiKey', FakeBackendError);
+			assert.strictEqual(v, 'sk-real');
+		});
+
+		it('throws when undefined', () => {
+			assert.throws(
+				() => requireCredential(undefined, 'OpenAI', 'apiKey', FakeBackendError),
+				/OpenAI backend requires apiKey/
+			);
+		});
+
+		it('throws when empty string', () => {
+			assert.throws(
+				() => requireCredential('', 'Anthropic', 'apiKey', FakeBackendError),
+				/Anthropic backend requires apiKey/
+			);
+		});
+
+		it('throws when value is an unresolved ${VAR} placeholder', () => {
+			assert.throws(
+				() => requireCredential('${SOMETHING_UNSET}', 'OpenAI', 'apiKey', FakeBackendError),
+				/literal placeholder/
+			);
+		});
+
+		it('error message echoes the placeholder string (env var name is not sensitive)', () => {
+			try {
+				requireCredential('${UNSET_FOR_TEST}', 'Anthropic', 'apiKey', FakeBackendError);
+				assert.fail('expected throw');
+			} catch (err) {
+				assert.ok(err.message.includes('${UNSET_FOR_TEST}'));
+			}
+		});
+	});
+
+	describe('normalizeOrigin', () => {
+		it('defaults to the configured host when value is empty', () => {
+			assert.strictEqual(
+				normalizeOrigin(undefined, { host: 'localhost:11434', secure: false }),
+				'http://localhost:11434'
+			);
+		});
+
+		it('uses https scheme when defaults.secure is true', () => {
+			assert.strictEqual(
+				normalizeOrigin(undefined, { host: 'api.openai.com/v1', secure: true }),
+				'https://api.openai.com/v1'
+			);
+		});
+
+		it('respects an explicit http:// scheme on the value', () => {
+			assert.strictEqual(
+				normalizeOrigin('http://my-local', { host: 'localhost:11434', secure: false }),
+				'http://my-local'
+			);
+		});
+
+		it('respects an explicit https:// scheme on the value', () => {
+			assert.strictEqual(
+				normalizeOrigin('https://my-azure.openai.azure.com/openai/v1', {
+					host: 'api.openai.com/v1',
+					secure: true,
+				}),
+				'https://my-azure.openai.azure.com/openai/v1'
+			);
+		});
+
+		it('strips trailing slashes', () => {
+			assert.strictEqual(
+				normalizeOrigin('https://api.openai.com/v1/', { host: 'x', secure: true }),
+				'https://api.openai.com/v1'
+			);
+			assert.strictEqual(normalizeOrigin('localhost:11434///', { host: 'x', secure: false }), 'http://localhost:11434');
+		});
+
+		it('trims whitespace from the value', () => {
+			assert.strictEqual(
+				normalizeOrigin('  localhost:11434  ', { host: 'x', secure: false }),
+				'http://localhost:11434'
+			);
+		});
+	});
+});

--- a/unitTests/resources/models/bootstrap.test.js
+++ b/unitTests/resources/models/bootstrap.test.js
@@ -173,4 +173,84 @@ describe('bootstrapModels', () => {
 			assert.strictEqual(resolveGenerative('default').name, 'openai');
 		});
 	});
+
+	// #633 (Phase 6): anthropic + bedrock entries.
+	describe('anthropic + bedrock backends (#633)', () => {
+		it('registers an anthropic generative entry', () => {
+			bootstrapModels({
+				models: {
+					generative: {
+						claude: { backend: 'anthropic', apiKey: 'sk-ant-test', model: 'claude-opus-4-7' },
+					},
+				},
+			});
+			assert.strictEqual(resolveGenerative('claude').name, 'anthropic');
+		});
+
+		it('registers a bedrock generative entry (SDK loads lazily; construction is cheap)', () => {
+			bootstrapModels({
+				models: {
+					generative: {
+						'bedrock-claude': {
+							backend: 'bedrock',
+							region: 'us-east-1',
+							model: 'anthropic.claude-opus-4-v1:0',
+						},
+					},
+				},
+			});
+			assert.strictEqual(resolveGenerative('bedrock-claude').name, 'bedrock');
+		});
+
+		it('registers a bedrock embedding entry', () => {
+			bootstrapModels({
+				models: {
+					embedding: {
+						titan: { backend: 'bedrock', region: 'us-east-1', model: 'amazon.titan-embed-text-v2:0' },
+					},
+				},
+			});
+			assert.strictEqual(resolveEmbedding('titan').name, 'bedrock');
+		});
+
+		it('logs error + skips when an anthropic embedding entry is configured (no Anthropic embed API)', () => {
+			bootstrapModels({
+				models: {
+					embedding: {
+						oops: { backend: 'anthropic', apiKey: 'sk-ant', model: 'claude' },
+					},
+				},
+			});
+			assert.throws(() => resolveEmbedding('oops'), { name: 'ModelBackendNotFoundError' });
+		});
+
+		it('all four backends side by side', () => {
+			bootstrapModels({
+				models: {
+					embedding: {
+						local: { backend: 'ollama', model: 'nomic-embed-text' },
+						hq: { backend: 'openai', apiKey: 'sk', model: 'text-embedding-3-large' },
+						titan: { backend: 'bedrock', region: 'us-east-1', model: 'amazon.titan-embed-text-v2:0' },
+					},
+					generative: {
+						'local-llm': { backend: 'ollama', model: 'llama3.2' },
+						'gpt': { backend: 'openai', apiKey: 'sk', model: 'gpt-4o-mini' },
+						'claude': { backend: 'anthropic', apiKey: 'sk-ant', model: 'claude-opus-4-7' },
+						'bedrock-claude': {
+							backend: 'bedrock',
+							region: 'us-east-1',
+							model: 'anthropic.claude-opus-4-v1:0',
+						},
+					},
+				},
+			});
+			assert.strictEqual(resolveEmbedding('local').name, 'ollama');
+			assert.strictEqual(resolveEmbedding('hq').name, 'openai');
+			assert.strictEqual(resolveEmbedding('titan').name, 'bedrock');
+			assert.strictEqual(resolveGenerative('local-llm').name, 'ollama');
+			assert.strictEqual(resolveGenerative('gpt').name, 'openai');
+			assert.strictEqual(resolveGenerative('claude').name, 'anthropic');
+			assert.strictEqual(resolveGenerative('bedrock-claude').name, 'bedrock');
+		});
+	});
 });

--- a/unitTests/validation/configValidator.test.js
+++ b/unitTests/validation/configValidator.test.js
@@ -588,5 +588,122 @@ describe('Test configValidator module', () => {
 				expect(result.error).to.be.undefined;
 			});
 		});
+
+		// #633 (Phase 6): anthropic + bedrock schemas.
+		describe('anthropic backend', () => {
+			it('accepts an anthropic entry with apiKey + model', () => {
+				const config = baseConfig();
+				config.models = {
+					generative: {
+						claude: { backend: 'anthropic', apiKey: 'sk-ant-test', model: 'claude-opus-4-7' },
+					},
+				};
+				const result = configValidator(config, true);
+				expect(result.error).to.be.undefined;
+			});
+
+			it('accepts a ${ENV_VAR} placeholder as the apiKey value', () => {
+				const config = baseConfig();
+				config.models = {
+					generative: {
+						claude: { backend: 'anthropic', apiKey: '${ANTHROPIC_API_KEY}', model: 'claude-opus-4-7' },
+					},
+				};
+				const result = configValidator(config, true);
+				expect(result.error).to.be.undefined;
+			});
+
+			it('rejects an anthropic entry missing apiKey', () => {
+				const config = baseConfig();
+				config.models = {
+					generative: { claude: { backend: 'anthropic', model: 'claude-opus-4-7' } },
+				};
+				const result = configValidator(config, true);
+				expect(result.error).to.not.be.undefined;
+				expect(result.error.message).to.include('apiKey');
+			});
+
+			it('rejects an openai-only field (organization) on an anthropic entry', () => {
+				const config = baseConfig();
+				config.models = {
+					generative: {
+						claude: { backend: 'anthropic', apiKey: 'sk-ant', model: 'claude', organization: 'oops' },
+					},
+				};
+				const result = configValidator(config, true);
+				expect(result.error).to.not.be.undefined;
+				expect(result.error.message).to.include('organization');
+			});
+		});
+
+		describe('bedrock backend', () => {
+			it('accepts a bedrock entry with region + model (no apiKey — AWS SDK chain)', () => {
+				const config = baseConfig();
+				config.models = {
+					generative: {
+						'bedrock-claude': {
+							backend: 'bedrock',
+							region: 'us-east-1',
+							model: 'anthropic.claude-opus-4-v1:0',
+						},
+					},
+				};
+				const result = configValidator(config, true);
+				expect(result.error).to.be.undefined;
+			});
+
+			it('accepts a bedrock embedding entry (Titan)', () => {
+				const config = baseConfig();
+				config.models = {
+					embedding: {
+						titan: { backend: 'bedrock', region: 'us-east-1', model: 'amazon.titan-embed-text-v2:0' },
+					},
+				};
+				const result = configValidator(config, true);
+				expect(result.error).to.be.undefined;
+			});
+
+			it('rejects an apiKey field on a bedrock entry (AWS SDK chain only)', () => {
+				const config = baseConfig();
+				config.models = {
+					generative: {
+						claude: {
+							backend: 'bedrock',
+							region: 'us-east-1',
+							model: 'anthropic.claude',
+							apiKey: 'oops',
+						},
+					},
+				};
+				const result = configValidator(config, true);
+				expect(result.error).to.not.be.undefined;
+				expect(result.error.message).to.include('apiKey');
+			});
+		});
+
+		describe('all four backends side by side', () => {
+			it('validates a config with ollama + openai + anthropic + bedrock entries', () => {
+				const config = baseConfig();
+				config.models = {
+					embedding: {
+						local: { backend: 'ollama', model: 'nomic-embed-text' },
+						hq: { backend: 'openai', apiKey: '${OPENAI_KEY}', model: 'text-embedding-3-large' },
+						titan: { backend: 'bedrock', region: 'us-east-1', model: 'amazon.titan-embed-text-v2:0' },
+					},
+					generative: {
+						'local-llm': { backend: 'ollama', model: 'llama3.2' },
+						'gpt': { backend: 'openai', apiKey: '${OPENAI_KEY}', model: 'gpt-4o-mini' },
+						'claude': { backend: 'anthropic', apiKey: '${ANTHROPIC_KEY}', model: 'claude-opus-4-7' },
+						'bedrock-claude': {
+							backend: 'bedrock',
+							region: 'us-east-1',
+							model: 'anthropic.claude-opus-4-v1:0',
+						},
+					},
+				};
+				const result = configValidator(config, true);
+				expect(result.error).to.be.undefined;
+			});
+		});
 	});
 });

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -102,6 +102,22 @@ export function configValidator(configJson, skipFsValidation = false) {
 		organization: string.optional(),
 		...commonEntryFields,
 	}).unknown(false);
+	const anthropicEntrySchema = Joi.object({
+		backend: string.valid('anthropic').required(),
+		// Same secret-handling posture as openai's `apiKey`.
+		apiKey: string.required(),
+		baseUrl: string.optional(),
+		...commonEntryFields,
+	}).unknown(false);
+	const bedrockEntrySchema = Joi.object({
+		backend: string.valid('bedrock').required(),
+		// AWS credentials resolve via the SDK chain (env / shared file / IAM
+		// roles for service accounts) — no apiKey field. `region` is
+		// effectively required (Bedrock is regional) but the backend can
+		// fall back to AWS_REGION env, so we leave it optional here.
+		region: string.optional(),
+		...commonEntryFields,
+	}).unknown(false);
 	const unknownBackendEntrySchema = Joi.object({
 		backend: string.required(),
 	}).unknown(true);
@@ -109,6 +125,8 @@ export function configValidator(configJson, skipFsValidation = false) {
 		switch: [
 			{ is: 'ollama', then: ollamaEntrySchema },
 			{ is: 'openai', then: openaiEntrySchema },
+			{ is: 'anthropic', then: anthropicEntrySchema },
+			{ is: 'bedrock', then: bedrockEntrySchema },
 		],
 		otherwise: unknownBackendEntrySchema,
 	});


### PR DESCRIPTION
## Summary

Phase 6 of #510 — adds the **anthropic** + **bedrock** backends, the
third and fourth real `ModelBackend` implementations. Also extracts
shared helpers out of ollama+openai now that the duplication crossed
the threshold Kris flagged on #698.

Closes #633
Tracking: #510

> [!NOTE]
> Opened as **Draft** until CI clears, per the engineering-guidelines
> step 18. Will flip to Ready when green.

## What ships

### Shared helper extraction (`resources/models/backendHelpers.ts`)

`composeSignal`, `assignFiniteTokenCount`, `parseJsonResponse`,
`requireModel`, `requireCredential`, `normalizeOrigin`. Backends pass
their error class as a constructor arg so per-backend names are
preserved for `instanceof` matching in tests. Ollama + OpenAI
migrated; local duplicates removed (~140 LOC deleted across the two).

### `components/anthropic/index.ts` (native fetch)

Native fetch (no SDK dep) against the Anthropic Messages API. SSE
streaming. `embed: false` (Anthropic has no embed API), `tools: true`.
- `x-api-key` + `anthropic-version` headers.
- `system` extracted from `Message[]` or the object form's `system` and
  combined into Anthropic's top-level field (Anthropic forbids `system`
  as a message role).
- Tool-use content-block parsing in non-streaming responses.
- Tool-call delta accumulator for streaming (input_json_delta keyed by
  content_block_index; yields each call once at `content_block_stop`).
- Mid-stream upstream errors (overloaded, rate_limit) raised as
  `AnthropicBackendError`, not silently swallowed.

### `components/bedrock/index.ts` (AWS SDK via optional peerDependency)

`@aws-sdk/client-bedrock-runtime` is declared as an **optional
`peerDependency`** in `package.json`. Harper doesn't depend on it
directly — users who want the bedrock backend add the SDK to their
own project's `package.json`. `BedrockBackend` dynamic-imports the
SDK on first call with a clear "add to your project" error if missing.

AWS credentials resolve via the SDK chain (env / shared profile /
IAM / IRSA). No `apiKey` field in config.

Per-family request dispatch on the model id prefix:
- `anthropic.*` → Anthropic Messages body (Claude on Bedrock)
- `meta.*` → Llama flat-prompt body with Llama 3 header tags
- `amazon.*` → Titan body (chat + embed v2)
- `mistral.*`, `cohere.*` → flat-prompt body

Streaming: per-family dispatch — Anthropic event-block parser for
Claude, flat per-chunk parser for the others.

Cohere embed honors `EmbedOpts.inputType`:
`'query' → search_query`, `'document' → search_document`.

Non-Anthropic generative families REJECT `GenerateInput.tools` rather
than silently dropping them. Without that guard the caller couldn't
distinguish "model chose not to call" from "model never saw the tool".
Phase 1's capability negotiation is backend-level not model-level;
model-aware capabilities is a follow-up.

Mid-stream upstream errors from Claude-on-Bedrock surface as
`BedrockBackendError`.

### Config schema + bootstrap

`validation/configValidator.ts` — discriminated schema extended with
anthropic + bedrock branches, both `.unknown(false)` so cross-backend
field typos block boot.

`resources/models/bootstrap.ts` — factory map adds anthropic + bedrock.
`expandEnvVarsDeep` already handled `${VAR}` placeholders.

### `package.json`

```json
"peerDependencies": {
  "@aws-sdk/client-bedrock-runtime": "^3.0.0"
},
"peerDependenciesMeta": {
  "@aws-sdk/client-bedrock-runtime": { "optional": true }
}
```

## Pre-PR verifier cadence

Per the agreed cadence (Phase 6 = `deep-review` single-pass per the
Flair memory): invoked `Skill({ skill: 'deep-review', args: ... })`
this time — NOT hand-rolled Agent calls.

- **api**: 3 Tier-3 findings, all confirmed, all fixed before commit:
  1. Anthropic + Bedrock-Claude streams silently swallowed upstream
     `error` events. Fixed: both parsers now throw on `type: 'error'`
     with the upstream message capped at 500 chars.
  2. Bedrock Cohere embed hardcoded `input_type: 'search_document'`,
     ignoring `EmbedOpts.inputType`. Fixed: maps `'query'` →
     `search_query`, defaults to `search_document`.
  3. Bedrock advertised `tools: true` but silently dropped tools on
     Llama/Titan/Mistral/Cohere. Fixed: non-Anthropic body builders
     throw with a structured error when tools are present.
- **concurrency**: No blockers.
- **config**: No blockers.

## What to put attention on

- The **dynamic-import + optional peerDep** pattern in
  `components/bedrock/index.ts`. New shape for Harper; happy to discuss
  if it's not the right precedent.
- **Per-family dispatch on `model` prefix** in bedrock. Will fragment
  as new Bedrock model families land; could become a registry pattern
  later. v1 is mechanical.
- **Tool-call rejection on non-anthropic Bedrock families** — option
  (b) from the deep-review recommendation. Option (a) would make
  `capabilities()` model-aware, which is a Phase 1 contract change.

## Files

| Path | Change |
|---|---|
| `resources/models/backendHelpers.ts` | new — extracted shared helpers |
| `components/anthropic/index.ts` | new — native fetch |
| `components/bedrock/index.ts` | new — SDK via dynamic-import peerDep |
| `resources/models/bootstrap.ts` | + anthropic + bedrock factory entries |
| `validation/configValidator.ts` | + anthropic + bedrock schema branches |
| `package.json` | + optional peerDep |
| `components/ollama/index.ts` | migrated to extracted helpers |
| `components/openai/index.ts` | migrated to extracted helpers |
| `unitTests/components/anthropic/index.test.js` | new |
| `unitTests/components/bedrock/index.test.js` | new — with fake-SDK injection |
| `unitTests/resources/models/backendHelpers.test.js` | new |
| `unitTests/resources/models/bootstrap.test.js` | + anthropic + bedrock cases |
| `unitTests/validation/configValidator.test.js` | + anthropic + bedrock schema cases |
| `integrationTests/server/anthropic-backend.test.ts` | new — gated on ANTHROPIC_API_KEY |
| `integrationTests/server/bedrock-backend.test.ts` | new — gated on RUN_BEDROCK_INTEGRATION + SDK installed |

## Acceptance criteria

- [x] `AnthropicBackend` + `BedrockBackend` implement `ModelBackend` per Phase 1
- [x] Bedrock dispatches on `model` field prefix to per-family request shape
- [x] `harper.models.generate()` produces completions from each provider
- [x] `harper.models.generateStream()` yields content + tool-call deltas per Phase 1 contract
- [x] Tool calls in `'return'` mode work on Anthropic + Anthropic-on-Bedrock
- [x] `harper.models.embed()` via Bedrock embedding models (Titan / Cohere)
- [x] `embed: false` on anthropic → capability negotiation rejects
- [x] Per-call accounting records `backend: 'anthropic'` / `'bedrock'`
- [x] `AbortSignal` cancels in-flight calls for both
- [x] AWS credentials resolved via SDK chain for Bedrock
- [x] SDK declared as optional peerDep; documented bump cadence in commit messages
- [x] Unit tests cover translation logic + the optional-SDK path
- [x] Integration tests gated on real creds
- [ ] CI green across full matrix (Draft → wait → Ready)

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint:required` clean
- [x] `npx prettier --check .` clean (PR files)
- [x] 299 unit tests pass locally
- [x] Phase 1-3 model tests still pass (no regression)
- [ ] CI green across full matrix
- [ ] Manual smoke against real Anthropic + Bedrock with creds set

## Out of scope (per #633)

- `toolMode: 'auto'` orchestration — #612
- Per-model fine-tuning / LoRA adapters
- Anthropic Files / Batch / prompt caching as first-class Harper APIs
- Bedrock Knowledge Bases / Agents
- Model-aware capability negotiation (would change Phase 1 contract)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)