### PR TITLE
chore(renovate): enable auto-merge for dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
 	"prConcurrentLimit": 2,
 	"minimumReleaseAge": "7 days",
 	"internalChecksFilter": "strict",
+	"automerge": true,
 	"reviewersFromCodeOwners": true,
 	"lockFileMaintenance": { "enabled": false },
 	"packageRules": [


### PR DESCRIPTION
## Summary

- Adds `"automerge": true` at the top level of `renovate.json` so Renovate will automatically merge PRs once CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)