### PR TITLE
enforce 5 MB default file-size limit on get_component_file

### DIFF
--- a/components/operations.js
+++ b/components/operations.js
@@ -551,6 +551,8 @@ async function getComponents() {
  * @param req
  * @returns {Promise<*>}
  */
+const DEFAULT_COMPONENT_FILE_MAX_SIZE = 5 * 1024 * 1024; // 5 MB
+
 async function getComponentFile(req) {
 	const validation = validator.getComponentFileValidator(req);
 	if (validation) {
@@ -558,12 +560,23 @@ async function getComponentFile(req) {
 	}
 
 	const compRoot = configUtils.getConfigPath(hdbTerms.CONFIG_PARAMS.COMPONENTSROOT);
+	const filePath = path.join(compRoot, req.project, req.file);
 	const options = req.encoding ? { encoding: req.encoding } : { encoding: 'utf8' };
+	const configuredMax = configUtils.getConfigValue(hdbTerms.CONFIG_PARAMS.OPERATIONSAPI_COMPONENTFILE_MAXSIZE);
+	const maxSize =
+		Number.isFinite(+configuredMax) && +configuredMax > 0 ? +configuredMax : DEFAULT_COMPONENT_FILE_MAX_SIZE;
 
 	try {
-		const stats = await fs.stat(path.join(compRoot, req.project, req.file));
+		const stats = await fs.stat(filePath);
+		if (stats.size > maxSize) {
+			throw handleHDBError(
+				new Error(HDB_ERROR_MSGS.COMPONENT_FILE_TOO_LARGE(stats.size, maxSize)),
+				HDB_ERROR_MSGS.COMPONENT_FILE_TOO_LARGE(stats.size, maxSize),
+				HTTP_STATUS_CODES.CONTENT_TOO_LARGE
+			);
+		}
 		return {
-			message: await fs.readFile(path.join(compRoot, req.project, req.file), options),
+			message: await fs.readFile(filePath, options),
 			size: stats.size,
 			birthtime: stats.birthtime,
 			mtime: stats.mtime,

--- a/config-root.schema.json
+++ b/config-root.schema.json
@@ -395,6 +395,17 @@
 						"timeout": { "type": "integer" }
 					}
 				},
+				"componentFile": {
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"maxSize": {
+							"type": "integer",
+							"minimum": 1,
+							"description": "Maximum size in bytes for files returned by get_component_file. Default: 5242880 (5 MB)"
+						}
+					}
+				},
 				"tls": {
 					"$ref": "#/definitions/tlsConfig",
 					"description": "TLS configuration overriding root TLS for Operations API"

--- a/unitTests/server/fastifyRoutes/operations.test.js
+++ b/unitTests/server/fastifyRoutes/operations.test.js
@@ -469,6 +469,25 @@ describe('Test custom functions operations', () => {
 			expect(updated_file.message).to.eql('im the new payload');
 			expect(result.message).to.equal('Successfully set component: config.yaml');
 		});
+
+		it('Test getComponentFile rejects files over the default 5 MB limit', async () => {
+			const largeFilePath = path.join(CF_DIR_ROOT, 'my-other-component', 'large-file.bin');
+			// Write exactly one byte over the 5 MB default limit
+			await fs.writeFile(largeFilePath, Buffer.alloc(5 * 1024 * 1024 + 1));
+			try {
+				let threw = false;
+				try {
+					await operations.getComponentFile({ project: 'my-other-component', file: 'large-file.bin' });
+				} catch (err) {
+					threw = true;
+					expect(err.statusCode).to.equal(413);
+					expect(err.message).to.match(/exceeds the configured limit/);
+				}
+				expect(threw).to.be.true;
+			} finally {
+				await fs.remove(largeFilePath);
+			}
+		});
 	});
 
 	describe('Test deployComponent force flag', () => {

--- a/utility/errors/commonErrors.ts
+++ b/utility/errors/commonErrors.ts
@@ -15,6 +15,7 @@ export const HTTP_STATUS_CODES = {
 	METHOD_NOT_ALLOWED: 405,
 	REQUEST_TIMEOUT: 408,
 	CONFLICT: 409,
+	CONTENT_TOO_LARGE: 413,
 	TOO_MANY_REQUESTS: 429,
 	INTERNAL_SERVER_ERROR: 500,
 	NOT_IMPLEMENTED: 501,
@@ -216,6 +217,8 @@ const ITC_ERRORS = {
 };
 
 const CUSTOM_FUNCTIONS_ERROR_MSGS = {
+	COMPONENT_FILE_TOO_LARGE: (size: number, limit: number) =>
+		`Component file size (${size} bytes) exceeds the configured limit of ${limit} bytes`,
 	FUNCTION_STATUS: 'Error getting custom function status, check the log for more details',
 	GET_FUNCTIONS: 'Error getting custom functions, check the log for more details',
 	GET_FUNCTION: 'Error getting custom function, check the log for more details',

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -516,6 +516,7 @@ export const CONFIG_PARAMS = {
 	OPERATIONSAPI_NETWORK_SECUREPORT: 'operationsApi_network_securePort',
 	OPERATIONSAPI_NETWORK_HTTP2: 'operationsApi_network_http2',
 	OPERATIONSAPI_NETWORK_MAXREQUESTBODYSIZE: 'operationsApi_network_maxRequestBodySize',
+	OPERATIONSAPI_COMPONENTFILE_MAXSIZE: 'operationsApi_componentFile_maxSize',
 	OPERATIONSAPI_TLS: 'operationsApi_tls',
 	OPERATIONSAPI_TLS_CERTIFICATE: 'operationsApi_tls_certificate',
 	OPERATIONSAPI_TLS_PRIVATEKEY: 'operationsApi_tls_privateKey',


### PR DESCRIPTION
Closes #600.

## Summary

- `get_component_file` now refuses files larger than a configurable limit, returning HTTP 413 with a clear error message.
- Default limit: 5 MB (`5 * 1024 * 1024` bytes).
- Operators can override via `operationsApi.componentFile.maxSize` (bytes) in `harperdb-config.yaml`.

## Changes

- `components/operations.js` — read config value, validate it (guard against non-numeric), check `stats.size` before `readFile`; compute file path once (DRY)
- `utility/errors/commonErrors.ts` — add `CONTENT_TOO_LARGE: 413` status code; add `COMPONENT_FILE_TOO_LARGE` error message
- `utility/hdbTerms.ts` — add `OPERATIONSAPI_COMPONENTFILE_MAXSIZE` config param
- `config-root.schema.json` — document `operationsApi.componentFile.maxSize`
- `unitTests/server/fastifyRoutes/operations.test.js` — add test for the 413 rejection path

## Notes for reviewer

- Cross-model review (Codex + Gemini) raised a TOCTOU concern (stat then readFile race). Risk is low here — component directories are admin-controlled — but worth a follow-up hardening issue if desired.
- Path traversal via `project` is a pre-existing gap in `getComponentFileValidator` (not introduced here); flagged separately.

Generated by Claude Sonnet 4.6.