### PR TITLE
feat(analytics): make retention windows configurable

### DIFF
--- a/config-root.schema.json
+++ b/config-root.schema.json
@@ -585,7 +585,7 @@
 				"aggregateRetentionMs": {
 					"type": "number",
 					"minimum": 0,
-					"description": "Milliseconds to retain aggregated analytics. Default: 31536000000 (1 year)"
+					"description": "Milliseconds to retain aggregated analytics. 0 disables cleanup (keep forever). Default: 31536000000 (1 year)"
 				},
 				"logging": { "$ref": "#/definitions/loggerConfig" }
 			}

--- a/config-root.schema.json
+++ b/config-root.schema.json
@@ -577,6 +577,16 @@
 					"type": "number",
 					"description": "Number of aggregation cycles between node storage measurements. 0 to disable. Default: 10"
 				},
+				"rawRetentionMs": {
+					"type": "number",
+					"minimum": 0,
+					"description": "Milliseconds to retain raw (pre-aggregation) analytics. Clamped to at least aggregatePeriod to prevent data loss. Default: 3600000 (1 hour)"
+				},
+				"aggregateRetentionMs": {
+					"type": "number",
+					"minimum": 0,
+					"description": "Milliseconds to retain aggregated analytics. Default: 31536000000 (1 year)"
+				},
 				"logging": { "$ref": "#/definitions/loggerConfig" }
 			}
 		}

--- a/resources/analytics/write.ts
+++ b/resources/analytics/write.ts
@@ -715,11 +715,15 @@ function startScheduledTasks() {
 	nodeStorageInterval = envGet(CONFIG_PARAMS.ANALYTICS_STORAGEINTERVAL) ?? DEFAULT_STORAGE_INTERVAL;
 	const AGGREGATE_PERIOD = envGet(CONFIG_PARAMS.ANALYTICS_AGGREGATEPERIOD) * 1000;
 	if (AGGREGATE_PERIOD) {
+		// Clamp raw retention to at least one full aggregation period so raw records
+		// are never deleted before they can be rolled up.
+		const rawRetentionMs = Math.max(envGet(CONFIG_PARAMS.ANALYTICS_RAWRETENTIONMS) ?? RAW_EXPIRATION, AGGREGATE_PERIOD);
+		const aggregateRetentionMs = envGet(CONFIG_PARAMS.ANALYTICS_AGGREGATERETENTIONMS) ?? AGGREGATE_EXPIRATION;
 		setInterval(
 			async () => {
 				await aggregation(analyticsDelay, AGGREGATE_PERIOD);
-				await cleanup(getRawAnalyticsTable(), RAW_EXPIRATION);
-				await cleanup(getAnalyticsTable(), AGGREGATE_EXPIRATION);
+				await cleanup(getRawAnalyticsTable(), rawRetentionMs);
+				await cleanup(getAnalyticsTable(), aggregateRetentionMs);
 			},
 			Math.min(AGGREGATE_PERIOD / 2, 0x7fffffff)
 		).unref();

--- a/resources/analytics/write.ts
+++ b/resources/analytics/write.ts
@@ -723,7 +723,8 @@ function startScheduledTasks() {
 			async () => {
 				await aggregation(analyticsDelay, AGGREGATE_PERIOD);
 				await cleanup(getRawAnalyticsTable(), rawRetentionMs);
-				await cleanup(getAnalyticsTable(), aggregateRetentionMs);
+				// 0 means "keep forever" — skip aggregate cleanup, matching storageInterval: 0 convention
+				if (aggregateRetentionMs) await cleanup(getAnalyticsTable(), aggregateRetentionMs);
 			},
 			Math.min(AGGREGATE_PERIOD / 2, 0x7fffffff)
 		).unref();

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -426,6 +426,8 @@ export const LEGACY_CONFIG_PARAMS = {
  */
 export const CONFIG_PARAMS = {
 	ANALYTICS_AGGREGATEPERIOD: 'analytics_aggregatePeriod',
+	ANALYTICS_AGGREGATERETENTIONMS: 'analytics_aggregateRetentionMs',
+	ANALYTICS_RAWRETENTIONMS: 'analytics_rawRetentionMs',
 	ANALYTICS_REPLICATE: 'analytics_replicate',
 	ANALYTICS_STORAGEINTERVAL: 'analytics_storageInterval',
 	AUTHENTICATION_AUTHORIZELOCAL: 'authentication_authorizeLocal',


### PR DESCRIPTION
## Summary

- Add `analytics.rawRetentionMs` and `analytics.aggregateRetentionMs` config params
- Register them in `CONFIG_PARAMS` (`hdbTerms.ts`) and document in `config-root.schema.json`
- `startScheduledTasks()` in `resources/analytics/write.ts` reads configured values (with existing constants as defaults)
- Defaults unchanged — no behavior change on upgrade

## Purpose

Closes [#566](https://github.com/HarperFast/harper/issues/566) / Jira [CORE-3074](https://harperdb.atlassian.net/browse/CORE-3074). A customer's `system.mdb` reached ~5 GB of analytics data (31M rows / 1 year of aggregates). Operators previously couldn't shorten the window without a code change.

## Notable design decision

Raw retention is clamped to `Math.max(configured, AGGREGATE_PERIOD)` at startup. If the configured value is shorter than the aggregation cadence, raw records could be deleted before `aggregation()` rolls them up — a silent data loss path flagged in cross-model review. The schema description notes this behavior.

🤖 Generated by Claude on behalf of Kris.