### PR TITLE
fix(tls): reload cert contexts on all worker threads when cert file changes

### DIFF
--- a/security/keys.ts
+++ b/security/keys.ts
@@ -32,7 +32,6 @@ export const getPrivateKeys = () => privateKeys;
 
 import { readFileSync, statSync } from 'node:fs';
 import { getTicketKeys, onMessageFromWorkers } from '../server/threads/manageThreads.js';
-import { isMainThread } from 'worker_threads';
 import { TLSSocket } from 'node:tls';
 
 const CERT_VALIDITY_DAYS = 3650;
@@ -135,6 +134,14 @@ export async function getReplicationCertAuth() {
 let configuredCertsLoaded;
 const privateKeys = new Map();
 
+// Per-thread registry of TLS selector update functions. Used to directly trigger
+// cert reloads on the current thread without relying on the cross-thread
+// subscribe mechanism (which doesn't fire for RocksDB).
+const tlsUpdateFns: Array<() => void> = [];
+function scheduleLocalTLSUpdate() {
+	for (const fn of tlsUpdateFns) fn();
+}
+
 /**
  * This is responsible for loading any certificates that are in the harperdb-config.yaml file and putting them into the hdbCertificate table.
  * @return {*}
@@ -171,7 +178,7 @@ export function loadCertificates() {
 				}
 				for (let ca of [false, true]) {
 					let path = config[ca ? 'certificateAuthority' : 'certificate'];
-					if (path && isMainThread) {
+					if (path) {
 						loadAndWatch(
 							path,
 							(certificate) => {
@@ -217,6 +224,10 @@ export function loadCertificates() {
 												recordTimestamp > 1 ? new Date(recordTimestamp) : 'only self signed certificate available'
 											})`
 										);
+									// The DB already has a current or newer cert; still schedule a reload so
+									// this thread's TLS contexts reflect whatever is in the DB (handles the
+									// case where another thread already updated the DB entry).
+									scheduleLocalTLSUpdate();
 									return;
 								}
 
@@ -238,6 +249,10 @@ export function loadCertificates() {
 										valid_to: x509Cert.validTo,
 									},
 								});
+								// Directly trigger TLS context reload on this thread. The cross-thread
+								// subscribe path (committed event) does not fire for RocksDB, so each
+								// thread must handle its own reload after detecting a file change.
+								scheduleLocalTLSUpdate();
 							},
 							ca ? 'certificate authority' : 'certificate'
 						);
@@ -261,7 +276,7 @@ function loadAndWatch(path, loadCert, type) {
 		try {
 			let modified = stats.mtimeMs;
 			if (modified && modified !== lastModified) {
-				if (lastModified && isMainThread) logger.warn?.(`Reloading ${type}:`, path);
+				if (lastModified) logger.warn?.(`Reloading ${type}:`, path);
 				lastModified = modified;
 				loadCert(readPEM(path));
 			}
@@ -841,6 +856,10 @@ export function createTLSSelector(type, mtlsOptions?): any {
 				listener: () => setTimeout(() => updateTLS(), 1500).unref(),
 				omitCurrent: true,
 			} as any);
+			// Register this selector so the per-thread cert-file watcher can trigger
+			// a reload directly, bypassing the cross-thread subscribe path that does
+			// not fire for RocksDB.
+			tlsUpdateFns.push(() => setTimeout(() => updateTLS(), 1500).unref());
 			updateTLS();
 		}));
 	};

--- a/security/keys.ts
+++ b/security/keys.ts
@@ -32,6 +32,7 @@ export const getPrivateKeys = () => privateKeys;
 
 import { readFileSync, statSync } from 'node:fs';
 import { getTicketKeys, onMessageFromWorkers } from '../server/threads/manageThreads.js';
+import { isMainThread } from 'node:worker_threads';
 import { TLSSocket } from 'node:tls';
 
 const CERT_VALIDITY_DAYS = 3650;
@@ -276,7 +277,7 @@ function loadAndWatch(path, loadCert, type) {
 		try {
 			let modified = stats.mtimeMs;
 			if (modified && modified !== lastModified) {
-				if (lastModified) logger.warn?.(`Reloading ${type}:`, path);
+				if (lastModified && isMainThread) logger.warn?.(`Reloading ${type}:`, path);
 				lastModified = modified;
 				loadCert(readPEM(path));
 			}
@@ -858,8 +859,11 @@ export function createTLSSelector(type, mtlsOptions?): any {
 			} as any);
 			// Register this selector so the per-thread cert-file watcher can trigger
 			// a reload directly, bypassing the cross-thread subscribe path that does
-			// not fire for RocksDB.
-			tlsUpdateFns.push(() => setTimeout(() => updateTLS(), 1500).unref());
+			// not fire for RocksDB. Only real servers need this — the transient
+			// secureTarget created by getReplicationCert() for one-off lookups does not.
+			if (server instanceof net.Server) {
+				tlsUpdateFns.push(() => setTimeout(() => updateTLS(), 1500).unref());
+			}
 			updateTLS();
 		}));
 	};


### PR DESCRIPTION
## Summary

Fixes #586: TLS certificates were not reloaded on worker threads when cert files changed on disk, requiring a full Harper restart after cert renewal.

**Root cause:** `loadCertificates()` had an `isMainThread` guard on the cert file watcher setup, so only the main thread watched for file changes. The intended cross-thread propagation path — `hdb_certificate.subscribe()` emitting a `committed` event — does not fire on worker threads for RocksDB (the default storage engine). Node.js worker threads each have an isolated JS heap, and RocksDB's `committed` event only fires on the thread that executed the transaction.

**Fix:** Remove the `isMainThread` guard so every thread independently watches its own cert files. Add a per-thread registry (`tlsUpdateFns`) that `createTLSSelector` populates, and call `scheduleLocalTLSUpdate()` from the file-change callback to directly reload TLS contexts on that thread — bypassing the broken cross-thread subscribe path entirely.

## Details

- Each worker thread now runs its own chokidar file watcher (N watchers total, N = thread count). This is a deliberate trade-off: increased `inotify` watch count vs. guaranteed per-thread reloads without complex ITC messaging.
- Multi-thread write races are handled: a timestamp check prevents redundant DB writes, but `scheduleLocalTLSUpdate()` fires regardless so every thread that detected the change still reloads.
- Log spam prevented: the `logger.warn` reload message is still guarded by `isMainThread` so only one log line appears per cert change.
- Memory leak avoided: `tlsUpdateFns.push()` is guarded by `server instanceof net.Server`, so the transient `secureTarget` created by `getReplicationCert()` for one-off lookups does not register a leaked closure.
- The existing `hdb_certificate.subscribe()` path is kept as a safety net for non-file cert updates (e.g., API-driven cert changes) and for LMDB where cross-thread events may work.

## Areas for review attention

- **`scheduleLocalTLSUpdate()` timing** (identified in cross-model review): the reload is scheduled immediately after `certificateTable.put()` is called, before the async write commits. `updateTLS()` reads from the DB, so on a slow `put` it could read the old cert. This is mitigated by the 1500 ms delay (same as the subscribe path), which gives the write time to commit in practice, and the subscribe path provides a follow-up reload for same-thread commits. Chaining off the put promise would be more correct but would complicate error handling; left as a follow-up.
- **N file watchers**: Each thread opens its own chokidar watcher. Acceptable for typical deployments but worth noting for very high thread counts.

Generated by Claude (claude-sonnet-4-6).