### PR TITLE
fix(table): return 400 from checkValidId on invalid primary keys

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -3739,30 +3739,31 @@ export function makeTable(options) {
 	function checkValidId(id) {
 		switch (typeof id) {
 			case 'number':
+				if (isNaN(id)) throw new ClientError('Invalid primary key of NaN', 400);
 				return true;
 			case 'string':
 				if (id.length < 659) return true; // max number of characters that can't expand our key size limit
 				if (id.length > MAX_KEY_BYTES) {
 					// we can quickly determine this is too big
-					throw new Error('Primary key size is too large: ' + id.length);
+					throw new ClientError('Primary key size is too large: ' + id.length, 400);
 				}
 				// TODO: We could potentially have a faster test here, Buffer.byteLength is close, but we have to handle characters < 4 that are escaped in ordered-binary
 				break; // otherwise we have to test it, in this range, unicode characters could put it over the limit
 			case 'object':
 				if (id === null) {
-					throw new Error('Invalid primary key of null');
+					throw new ClientError('Invalid primary key of null', 400);
 				}
 				break; // otherwise we have to test it
 			case 'bigint':
 				if (id < 2n ** 64n && id > -(2n ** 64n)) return true;
 				break; // otherwise we have to test it
 			default:
-				throw new Error('Invalid primary key type: ' + typeof id);
+				throw new ClientError('Invalid primary key type: ' + typeof id, 400);
 		}
 		// otherwise it is difficult to determine if the key size is too large
 		// without actually attempting to serialize it
 		const length = writeKey(id, TEST_WRITE_KEY_BUFFER, 0);
-		if (length > MAX_KEY_BYTES) throw new Error('Primary key size is too large: ' + id.length);
+		if (length > MAX_KEY_BYTES) throw new ClientError('Primary key size is too large: ' + id.length, 400);
 		return true;
 	}
 	function requestTargetToId(target: RequestTargetOrId): Id {

--- a/unitTests/apiTests/undefinedIdInUrl-test.mjs
+++ b/unitTests/apiTests/undefinedIdInUrl-test.mjs
@@ -1,0 +1,90 @@
+'use strict';
+
+import { assert } from 'chai';
+import axios from 'axios';
+import { setupTestApp } from './setupTestApp.mjs';
+
+// A common client bug is template-stringifying an `undefined` value into a URL
+// path: PATCH /<Resource>/undefined. Pre-fix behavior depended on the PK type:
+//   • numeric PK: "undefined"/"NaN"/"true" → 400 via coerceType regex (OK),
+//                 but "null" silently coerced to null and surfaced as 500.
+//   • Any PK:     "undefined"/"null"/"true" → 500 (autoCast then checkValidId).
+//                 "NaN" was even saved with NaN id (data corruption).
+//   • String PK:  all literals are valid string ids and remain accepted.
+//
+// Fix: checkValidId now throws ClientError(400) instead of Error, and also
+// rejects NaN.
+describe('Invalid primary keys from URL paths return 400', () => {
+	before(async function () {
+		this.timeout(5000);
+		await setupTestApp();
+	});
+
+	const request = (method, path, body) =>
+		axios.request({
+			method,
+			url: `http://localhost:9926${path}`,
+			data: body,
+			validateStatus: () => true,
+		});
+
+	describe('numeric primary keys', () => {
+		// DogIntPK: id: Int @primaryKey
+		for (const literal of ['undefined', 'null', 'NaN', 'true']) {
+			it(`PATCH /DogIntPK/${literal} → 400`, async function () {
+				const response = await request('patch', `/DogIntPK/${literal}`, { name: 'Fido' });
+				assert.equal(response.status, 400);
+				assert.notExists(
+					await request('get', `/DogIntPK/${literal}`).then((r) => (r.status === 200 ? r.data : undefined)),
+					'no record should have been persisted'
+				);
+			});
+
+			it(`PUT /DogIntPK/${literal} → 400`, async function () {
+				const response = await request('put', `/DogIntPK/${literal}`, { name: 'Fido' });
+				assert.equal(response.status, 400);
+			});
+		}
+
+		it('PUT /DogIntPK/42 still works (sanity check)', async function () {
+			const response = await request('put', '/DogIntPK/42', { name: 'Rex' });
+			assert.equal(response.status, 204);
+			const fetched = await request('get', '/DogIntPK/42');
+			assert.equal(fetched.status, 200);
+			assert.equal(fetched.data.name, 'Rex');
+		});
+	});
+
+	describe('Any-typed primary keys', () => {
+		// DogAnyPK: id: Any @primaryKey — autoCast can turn "undefined"/"null" into
+		// null and "true" into a boolean; without the fix, all surfaced as 500.
+		// "NaN" was even silently persisted as a record keyed by NaN.
+		for (const literal of ['undefined', 'null', 'NaN', 'true']) {
+			it(`PATCH /DogAnyPK/${literal} → 400`, async function () {
+				const response = await request('patch', `/DogAnyPK/${literal}`, { name: 'Fido' });
+				assert.equal(response.status, 400);
+			});
+		}
+
+		it('no records were persisted to DogAnyPK', async function () {
+			// All literal-id requests above should have rejected before any write.
+			const list = await request('get', '/DogAnyPK/');
+			assert.equal(list.status, 200);
+			assert.deepEqual(list.data, []);
+		});
+	});
+
+	describe('String-typed primary keys still accept literal strings', () => {
+		// DogStringPK: id: String @primaryKey — "undefined"/"null"/etc. are
+		// legitimate string ids and should round-trip.
+		for (const literal of ['undefined', 'null', 'NaN', 'true']) {
+			it(`PUT /DogStringPK/${literal} round-trips`, async function () {
+				const put = await request('put', `/DogStringPK/${literal}`, { name: `Fido-${literal}` });
+				assert.equal(put.status, 204);
+				const fetched = await request('get', `/DogStringPK/${literal}`);
+				assert.equal(fetched.status, 200);
+				assert.equal(fetched.data.name, `Fido-${literal}`);
+			});
+		}
+	});
+});

--- a/unitTests/testApp/schema.graphql
+++ b/unitTests/testApp/schema.graphql
@@ -67,6 +67,21 @@ type HasBigInt @table @export {
 	name: String @indexed
 	anotherBigint: BigInt
 }
+
+type DogIntPK @table @export {
+	id: Int @primaryKey
+	name: String
+}
+
+type DogStringPK @table @export {
+	id: String @primaryKey
+	name: String
+}
+
+type DogAnyPK @table @export {
+	id: Any @primaryKey
+	name: String
+}
 type Conflicted1 @table @export(name: "Conflicted") {
 	id: ID @primaryKey
 }


### PR DESCRIPTION
## Summary

A client `PATCH`/`PUT` to `/<Resource>/<literal>` (where `<literal>` is `undefined`, `null`, `NaN`, `true`, etc. — common artifacts of template-stringifying a missing value into a URL) used to surface inconsistently depending on the primary key type:

| PK type | Pre-fix |
|---|---|
| Numeric (`Int`/`Long`/`Float`/`BigInt`) | `/undefined`, `/NaN`, `/true` → 400 (via `coerceType` regex). **`/null` → 500** — `coerceType` silently returned `null`, `checkValidId` then threw a plain `Error`. |
| `Any` | **All of `/undefined`, `/null`, `/true` → 500** (`autoCast` produces `null`/boolean; `checkValidId` rejects). **`/NaN` → 204, silently persisted with `NaN` id** — data corruption. |
| `String` | Accepts all literals as legitimate string ids (correct — unchanged). |

Per @kriszyp's review on the previous approach, the right boundary to fix this is `checkValidId` itself: convert all throws to `ClientError(400)` and explicitly reject `NaN`. That turns every invalid-PK code path into a clean 400 regardless of how the bad value arrived (URL, autoCast, direct API call).

## Diff in one place

[`resources/Table.ts`'s `checkValidId`](resources/Table.ts) — five `throw new Error(...)` → `throw new ClientError(..., 400)`, plus `if (isNaN(id)) throw ...` added to the `number` branch.

## Behavior matrix after this PR

| PK type | `/undefined` | `/null` | `/NaN` | `/true` |
|---|---|---|---|---|
| Numeric | 400 | **400 (was 500)** | 400 | 400 |
| `Any` | **400 (was 500)** | **400 (was 500)** | **400 (was 204 — corruption!)** | **400 (was 500)** |
| `String` | 204 (round-trips) | 204 | 204 | 204 |

## Test plan

- [x] New `unitTests/apiTests/undefinedIdInUrl-test.mjs` — 18 integration tests via real HTTP server, covering all combinations above. Includes a sanity test that `PUT /DogIntPK/42` still works and an explicit non-regression for `String` PKs.
- [x] New tables `DogIntPK`, `DogStringPK`, `DogAnyPK` in the test schema.
- [x] `npm run test:unit:resources` — 501 passing, no regressions.
- [x] `npm run lint:required` and `npm run format:write` — clean.
- [x] No associated ticket — discovered during user's hands-on testing.

> Generated by Claude (Opus 4.7, 1M context). Force-push replaces the rejected previous approach (broad coerceId rejection) with the targeted fix at the right boundary.