### PR TITLE
Detect SSH auth failure on private-repo deploy and emit clear error

### DIFF
--- a/components/Application.ts
+++ b/components/Application.ts
@@ -206,7 +206,7 @@ export async function extractApplication(application: Application) {
 			if (code !== 0) {
 				if (isSSHAuthFailure(stderr)) {
 					throw new Error(
-						`Failed to deploy private repository ${application.packageIdentifier}: SSH authentication failed. Verify the repository URL, configure an SSH key on this Harper instance, and ensure it has access to the target repository.`,
+						`Failed to deploy private repository ${application.packageIdentifier}: SSH access failed. Verify the repository URL, configure an SSH key on this Harper instance, ensure the key has access to the target repository, and confirm the host is present in the ssh/known_hosts file.`,
 						{ cause: new Error(stderr) }
 					);
 				}

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -109,6 +109,21 @@ export function assertApplicationConfig(
 }
 
 /**
+ * Returns true when npm/git stderr indicates an SSH authentication failure —
+ * git exits 128 with the standard "could not read" message, or the SSH layer
+ * reports a missing uid (no SSH daemon user), explicit publickey denial, or
+ * an unverified host key.
+ */
+export function isSSHAuthFailure(stderr: string): boolean {
+	return (
+		stderr.includes('Could not read from remote repository') ||
+		stderr.includes('Permission denied (publickey)') ||
+		stderr.includes('No user exists for uid') ||
+		stderr.includes('Host key verification failed')
+	);
+}
+
+/**
  * Extract an application given payload (content of the application) or package (npm-compatible identifier to the application).
  *
  * Only one of `application.payload` or `application.package` should be specified; otherwise, an error is thrown.
@@ -189,6 +204,12 @@ export async function extractApplication(application: Application) {
 				parentDirPath
 			);
 			if (code !== 0) {
+				if (isSSHAuthFailure(stderr)) {
+					throw new Error(
+						`Failed to deploy private repository ${application.packageIdentifier}: SSH authentication failed. Verify the repository URL, configure an SSH key on this Harper instance, and ensure it has access to the target repository.`,
+						{ cause: new Error(stderr) }
+					);
+				}
 				throw new Error(`Failed to download package ${application.packageIdentifier}: ${stderr}`);
 			}
 

--- a/unitTests/components/Application.test.js
+++ b/unitTests/components/Application.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const assert = require('node:assert');
+
+const testUtils = require('../testUtils.js');
+testUtils.preTestPrep();
+
+const { isSSHAuthFailure } = require('#src/components/Application');
+
+describe('isSSHAuthFailure', () => {
+	it('returns true for "Could not read from remote repository"', () => {
+		const stderr = `
+npm error code 128
+npm error An unknown git error occurred
+npm error command git --no-replace-objects ls-remote git@github.com:Org/repo.git
+npm error fatal: Could not read from remote repository.
+npm error Please make sure you have the correct access rights
+npm error and the repository exists.
+`;
+		assert.strictEqual(isSSHAuthFailure(stderr), true);
+	});
+
+	it('returns true for "Permission denied (publickey)"', () => {
+		const stderr = `
+npm error code 128
+npm error An unknown git error occurred
+npm error git@github.com: Permission denied (publickey).
+npm error fatal: Could not read from remote repository.
+`;
+		assert.strictEqual(isSSHAuthFailure(stderr), true);
+	});
+
+	it('returns true for "No user exists for uid"', () => {
+		const stderr = `
+npm error code 128
+npm error An unknown git error occurred
+npm error No user exists for uid 42932
+npm error fatal: Could not read from remote repository.
+npm error Please make sure you have the correct access rights
+npm error and the repository exists.
+`;
+		assert.strictEqual(isSSHAuthFailure(stderr), true);
+	});
+
+	it('returns true for "Host key verification failed"', () => {
+		const stderr = `
+npm error code 128
+npm error An unknown git error occurred
+npm error Host key verification failed.
+npm error fatal: Could not read from remote repository.
+`;
+		assert.strictEqual(isSSHAuthFailure(stderr), true);
+	});
+
+	it('returns false for unrelated npm errors', () => {
+		const stderr = `
+npm error code E404
+npm error 404 Not Found - GET https://registry.npmjs.org/nonexistent-pkg
+npm error 404 '@scope/nonexistent-pkg@latest' is not in this registry.
+`;
+		assert.strictEqual(isSSHAuthFailure(stderr), false);
+	});
+
+	it('returns false for empty stderr', () => {
+		assert.strictEqual(isSSHAuthFailure(''), false);
+	});
+});


### PR DESCRIPTION
Closes HarperFast/harper-pro#185

## Summary

When `npm pack` fails with git exit 128 due to SSH auth issues, the raw npm/git stderr was passed through as-is — leaving users to dig through error noise to find the actual cause.

This detects four SSH failure patterns in the subprocess stderr:
- `Could not read from remote repository`
- `Permission denied (publickey)`
- `No user exists for uid` (SSH daemon not configured)
- `Host key verification failed` (host not in known_hosts)

…and replaces the raw passthrough with a single actionable error:
> Failed to deploy private repository `<pkg>`: SSH authentication failed. Verify the repository URL, configure an SSH key on this Harper instance, and ensure it has access to the target repository.

Original stderr is preserved via the error `cause` chain for debugging.

## Notes

- No new dependencies; purely string matching in cold-path error handling.
- `isSSHAuthFailure` is exported for unit testing (6 cases, all passing).
- Deploy docs update (acceptance criteria item 2) should follow in the documentation repo.

Cross-model review (Gemini) suggested: adding `Host key verification failed` pattern (done), `cause` chaining (done), and URL verification language in the message (done). statusCode on the thrown error was considered but skipped — the existing validation errors in this file don't use it, and the issue only requires a clear message in the API response.

🤖 Generated by Claude Sonnet 4.6