### PR TITLE
Expose ensureTable on plugin scope

### DIFF
--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -1,7 +1,7 @@
 import { type Logger } from '../utility/logging/logger.ts';
 import { loggerWithTag } from '../utility/logging/harper_logger.ts';
 import { EventEmitter, once } from 'node:events';
-import { databaseEventsEmitter } from '../resources/databases.ts';
+import { databaseEventsEmitter, table } from '../resources/databases.ts';
 import { server, type Server } from '../server/Server.ts';
 import { EntryHandler, type EntryHandlerEventMap, type onEntryEventHandler } from './EntryHandler.ts';
 import { OptionsWatcher, OptionsWatcherEventMap } from './OptionsWatcher.ts';
@@ -39,6 +39,7 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 	#directory: string;
 	#appName: string;
 	#pluginName: string;
+	#origin: string;
 	#entryHandler?: EntryHandler;
 	#entryHandlers: EntryHandler[];
 	#logger: Logger;
@@ -57,12 +58,14 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 		pluginName: string,
 		directory: string,
 		configFilePath: string,
-		applicationScope: ApplicationScope
+		applicationScope: ApplicationScope,
+		origin: string = appName
 	) {
 		super();
 
 		this.#appName = appName;
 		this.#pluginName = pluginName;
+		this.#origin = typeof origin === 'string' ? origin : appName;
 		this.#directory = directory;
 		this.#configFilePath = configFilePath;
 		this.#logger = loggerWithTag(this.#appName);
@@ -126,6 +129,11 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 
 	get configFilePath(): string {
 		return this.#configFilePath;
+	}
+
+	ensureTable<TableResourceType = unknown>(options: any): TableResourceType {
+		options.origin = this.#origin;
+		return table<TableResourceType>(options);
 	}
 
 	#handleOptionsWatcherReady(): void {

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -444,7 +444,14 @@ export async function loadComponent(
 
 				// New Plugin API (`handleApplication`)
 				if (resources.isWorker && extensionModule.handleApplication) {
-					const scope = new Scope(appName || 'harper', componentName, componentDirectory, configPath, applicationScope);
+					const scope = new Scope(
+						appName || 'harper',
+						componentName,
+						componentDirectory,
+						configPath,
+						applicationScope,
+						origin
+					);
 
 					onMessageByType(ITC_EVENT_TYPES.SHUTDOWN, () => scope.close());
 

--- a/unitTests/components/componentLoader.test.js
+++ b/unitTests/components/componentLoader.test.js
@@ -156,6 +156,55 @@ describe('ComponentLoader Status Integration', function () {
 			assert.match(loadedCalls[0].args[1], /loaded successfully/);
 		});
 
+		it('should expose ensureTable on handleApplication scope with component origin', async function () {
+			const componentDirName = 'scope-ensure-table-component';
+			const componentDir = path.join(tempDir, componentDirName);
+			const pluginName = 'scopeEnsureTablePlugin';
+			const origin = 'test-origin';
+			let capturedScope;
+
+			mkdirSync(componentDir);
+			writeFileSync(path.join(componentDir, 'harperdb-config.yaml'), `${pluginName}: {}`);
+
+			componentLoader.TRUSTED_RESOURCE_PLUGINS[pluginName] = {
+				handleApplication(scope) {
+					capturedScope = scope;
+				},
+			};
+
+			try {
+				await componentLoader.loadComponent(
+					componentDir,
+					{
+						isWorker: true,
+						set: sinon.stub(),
+					},
+					origin
+				);
+			} finally {
+				delete componentLoader.TRUSTED_RESOURCE_PLUGINS[pluginName];
+			}
+
+			assert.equal(typeof capturedScope?.ensureTable, 'function', 'scope.ensureTable should be exposed');
+
+			let assignedOrigin;
+			const options = new Proxy(
+				{},
+				{
+					set(target, property, value) {
+						if (property === 'origin') {
+							assignedOrigin = value;
+							throw new Error('stop before table call');
+						}
+						return Reflect.set(target, property, value);
+					},
+				}
+			);
+
+			assert.throws(() => capturedScope.ensureTable(options), /stop before table call/);
+			assert.equal(assignedOrigin, origin, 'scope.ensureTable should preserve the component origin');
+		});
+
 		// TODO: Does the plugin API have an equivalent mechanism?
 		it.skip('should mark component as failed when it loads no functionality', async function () {
 			// Create a component directory without config


### PR DESCRIPTION
## Summary

- add `scope.ensureTable(options)` for the new `handleApplication(scope)` plugin API
- preserve the legacy `ensureTable` behavior of stamping the component `origin` before delegating to `table(options)`
- pass the loader's `origin` into `Scope` and cover it with a component-loader unit test

## Why

Issue #607 notes that plugins migrating from the old `start` / `startOnMainThread` API lose access to the legacy `ensureTable` helper. The old helper did:

```ts
options.origin = origin;
return table(options);
```

This keeps that same behavior available from `handleApplication(scope)` as `scope.ensureTable(options)`.

## Verification

- `npm_config_cache=/tmp/npm-cache-harper-ensuretable npm ci --ignore-scripts`
- `npm run build`
- `node --expose-internals --enable-source-maps --experimental-vm-modules - <<'NODE' ... NODE` running `unitTests/components/componentLoader.test.js` with grep `/ensureTable/` after `initTestEnvironment()`
- `npm run lint:required -- components/Scope.ts components/componentLoader.ts unitTests/components/componentLoader.test.js`
- `git diff --check`

Note: running `./node_modules/.bin/mocha unitTests/components/componentLoader.test.js --grep ensureTable` directly failed before the test loaded because the component loader imports modules that expect the unit-test environment to be initialized. The programmatic Mocha run initializes `environmentManager.initTestEnvironment()` first and the new test passes.

I used an AI coding assistant to prepare this patch.

Fixes #607
