### PR TITLE
fix: hand-roll authorize promise wrapper to avoid DEP0174

### DIFF
--- a/server/serverHelpers/serverHandlers.js
+++ b/server/serverHelpers/serverHandlers.js
@@ -8,10 +8,17 @@ const { isMainThread } = require('worker_threads');
 const { Readable } = require('stream');
 
 const os = require('os');
-const util = require('util');
 
 const auth = require('../../security/fastifyAuth.ts');
-const pAuthorize = util.promisify(auth.authorize);
+
+// this is a hack to suppress a deprecation warning and can be removed once `auth.authorize`
+// is converted to an async function
+function pAuthorize(req, resp) {
+	return new Promise((resolve, reject) => {
+		auth.authorize(req, resp, (err, user) => (err ? reject(err) : resolve(user)));
+	});
+}
+
 const serverUtilities = require('./serverUtilities.ts');
 const { applyImpersonation } = require('../../security/impersonation.ts');
 const { createGzip, constants } = require('zlib');


### PR DESCRIPTION
## Summary
- Replace `util.promisify(auth.authorize)` with a small manual callback→promise wrapper to silence the Node.js `DEP0174` deprecation warning.

## Why
`auth.authorize` is a Node-style callback function (`(req, res, next)`), but some of its branches return the promise from an inner `authentication(...).then(...)` chain. Node now flags this combination as a likely misuse of `util.promisify`. The wrapper is semantically identical to what `util.promisify` was doing — it just doesn't perform the deprecation check.

The goal of this PR is to reduce warnings.

## Where to look
- [server/serverHelpers/serverHandlers.js](server/serverHelpers/serverHandlers.js#L14-L20) — new `pAuthorize` wrapper replacing the `util.promisify` call. Behavior should be unchanged for both consumers (`authHandler` and `authAndEnsureUserOnRequest`).
- Long-term fix is to convert `authorize` itself to async; a TODO-style comment is added noting this can be removed once that happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)