### PR TITLE
[MCP] Streamable HTTP transport

### DIFF
--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -41,6 +41,7 @@ import { Scope } from './Scope.ts';
 import { ApplicationScope } from './ApplicationScope.ts';
 import { ComponentV1, processResourceExtensionComponent } from './ComponentV1.ts';
 import * as httpComponent from '../server/http.ts';
+import * as mcpComponent from './mcp/index.ts';
 import { Status } from '../server/status/index.ts';
 import { lifecycle as componentLifecycle } from './status/index.ts';
 import { DEFAULT_CONFIG } from './DEFAULT_CONFIG.ts';
@@ -108,6 +109,7 @@ export const TRUSTED_RESOURCE_PLUGINS: any = {
 	loadEnv,
 	logging: harperLogger,
 	dataLoader,
+	mcp: mcpComponent,
 	/*
 	static: ...
 	login: ...

--- a/components/mcp/adapters/fastify.ts
+++ b/components/mcp/adapters/fastify.ts
@@ -1,0 +1,81 @@
+/**
+ * Fastify adapter for the MCP transport core (operations port, #614).
+ *
+ * Maps Fastify's `(request, reply)` ↔ the transport's normalized
+ * Request/Response shape. The route is registered with the
+ * `authAndEnsureUserOnRequest` preValidation hook, so the authenticated
+ * user lands on `request.hdb_user` before this handler runs.
+ *
+ * Fastify auto-parses JSON request bodies; we re-stringify so the core's
+ * `parseMessage` sees the raw envelope it expects. The round-trip is
+ * cheap for the small JSON-RPC frames in the MCP wire format and keeps
+ * the core framework-agnostic.
+ */
+import { handleMcpRequest, type McpProfile, type NormRequest } from '../transport.ts';
+
+interface FastifyLikeRequest {
+	method: string;
+	headers: Record<string, string | string[] | undefined>;
+	body: unknown;
+	hdb_user?: { username?: string } | null;
+}
+
+interface FastifyLikeReply {
+	code: (status: number) => FastifyLikeReply;
+	header: (name: string, value: string) => FastifyLikeReply;
+	send: (body?: unknown) => unknown;
+}
+
+export function createFastifyHandler(profile: McpProfile) {
+	return async function mcpFastifyHandler(request: FastifyLikeRequest, reply: FastifyLikeReply): Promise<void> {
+		const norm: NormRequest = {
+			method: request.method,
+			headers: normalizeHeaders(request.headers),
+			// Fastify has already parsed the JSON body into an object via its
+			// preParsing pipeline. Pass it through directly — the transport
+			// core's parseMessage accepts both strings and parsed values, so we
+			// avoid an unnecessary stringify/re-parse round trip on the hot path.
+			body: request.body,
+			user: request.hdb_user?.username ?? '',
+			profile,
+		};
+
+		const res = await handleMcpRequest(norm);
+
+		reply.code(res.status);
+		for (const [name, value] of Object.entries(res.headers)) {
+			reply.header(name, value);
+		}
+
+		if (res.jsonBody !== undefined) {
+			if (!res.headers['Content-Type'] && !res.headers['content-type']) {
+				reply.header('Content-Type', 'application/json');
+			}
+			reply.send(res.jsonBody);
+			return;
+		}
+
+		if (res.sseIterable !== undefined) {
+			// Reserved for #619 (server-push GET stream). Fastify will iterate
+			// the async iterable and write SSE frames via the contentTypes
+			// serializer at `server/serverHelpers/contentTypes.ts:128-162`.
+			if (!res.headers['Content-Type'] && !res.headers['content-type']) {
+				reply.header('Content-Type', 'text/event-stream');
+			}
+			reply.header('Cache-Control', 'no-store');
+			reply.send(res.sseIterable);
+			return;
+		}
+
+		// 202/204/4xx with empty body.
+		reply.send();
+	};
+}
+
+function normalizeHeaders(headers: Record<string, string | string[] | undefined>): Record<string, string | undefined> {
+	const out: Record<string, string | undefined> = {};
+	for (const [name, value] of Object.entries(headers)) {
+		out[name.toLowerCase()] = Array.isArray(value) ? value[0] : value;
+	}
+	return out;
+}

--- a/components/mcp/adapters/harperHttp.ts
+++ b/components/mcp/adapters/harperHttp.ts
@@ -1,0 +1,97 @@
+/**
+ * Harper-HTTP adapter for the MCP transport core (application port, #614).
+ *
+ * Maps Harper's HTTP handler signature `(request, nextHandler) => { status,
+ * headers, body }` to/from the transport's normalized Request/Response.
+ * Auth runs upstream via `{ after: 'authentication' }` on the registration,
+ * so `request.user` is already populated when this handler fires.
+ *
+ * SSE responses (reserved for #619) are returned as `{ body: iterable,
+ * headers: { 'content-type': 'text/event-stream' } }`. Harper's serializer
+ * at `server/serverHelpers/contentTypes.ts:128-162` picks the SSE writer
+ * automatically and pipes the iterable to the wire.
+ */
+import { handleMcpRequest, type McpProfile, type NormRequest, type NormResponse } from '../transport.ts';
+
+interface HarperHttpRequest {
+	method: string;
+	headers: Iterable<[string, string | string[]]> & { get?: (name: string) => string | undefined };
+	body?: AsyncIterable<Buffer | string>;
+	user?: { username?: string };
+	isWebSocket?: boolean;
+}
+
+interface HarperHttpResponse {
+	status: number;
+	headers: Record<string, string>;
+	body?: unknown;
+}
+
+export function createHarperHttpHandler(profile: McpProfile) {
+	return async function mcpHarperHttpHandler(
+		request: HarperHttpRequest,
+		nextHandler: (req: HarperHttpRequest) => unknown
+	): Promise<HarperHttpResponse | unknown> {
+		// WebSocket upgrades aren't ours — let the next handler take it.
+		if (request.isWebSocket) return nextHandler(request);
+
+		const norm: NormRequest = {
+			method: request.method,
+			headers: normalizeHeaders(request.headers),
+			body: await readBody(request.body),
+			user: request.user?.username ?? '',
+			profile,
+		};
+
+		const res = await handleMcpRequest(norm);
+		return toHarperResponse(res);
+	};
+}
+
+function normalizeHeaders(headers: HarperHttpRequest['headers']): Record<string, string | undefined> {
+	const out: Record<string, string | undefined> = {};
+	for (const [name, value] of headers) {
+		out[name.toLowerCase()] = Array.isArray(value) ? value[0] : value;
+	}
+	return out;
+}
+
+async function readBody(body: AsyncIterable<Buffer | string> | undefined): Promise<string> {
+	if (!body) return '';
+	const chunks: Buffer[] = [];
+	for await (const chunk of body) {
+		chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk);
+	}
+	return Buffer.concat(chunks).toString('utf8');
+}
+
+function toHarperResponse(res: NormResponse): HarperHttpResponse {
+	const headers = { ...res.headers };
+
+	if (res.jsonBody !== undefined) {
+		if (!headers['Content-Type'] && !headers['content-type']) {
+			headers['Content-Type'] = 'application/json';
+		}
+		return {
+			status: res.status,
+			headers,
+			body: JSON.stringify(res.jsonBody),
+		};
+	}
+
+	if (res.sseIterable !== undefined) {
+		if (!headers['Content-Type'] && !headers['content-type']) {
+			headers['Content-Type'] = 'text/event-stream';
+		}
+		if (!headers['Cache-Control'] && !headers['cache-control']) {
+			headers['Cache-Control'] = 'no-store';
+		}
+		return {
+			status: res.status,
+			headers,
+			body: res.sseIterable,
+		};
+	}
+
+	return { status: res.status, headers };
+}

--- a/components/mcp/index.ts
+++ b/components/mcp/index.ts
@@ -45,6 +45,8 @@ interface FullConfig {
 
 interface FastifyLikeHost {
 	post: (path: string, ...rest: unknown[]) => unknown;
+	get: (path: string, ...rest: unknown[]) => unknown;
+	delete: (path: string, ...rest: unknown[]) => unknown;
 }
 
 export interface RegisterMcpProfileArgs {
@@ -69,10 +71,18 @@ export function registerMcpProfile({ profile, host, config, routeOptions }: Regi
 	ensureSessionTable();
 	const mountPath = profileConfig.mountPath ?? DEFAULT_MOUNT_PATH;
 	const handler = createFastifyHandler(profile);
-	if (routeOptions) {
-		host.post(mountPath, routeOptions, handler);
-	} else {
-		host.post(mountPath, handler);
+	// Register POST, GET, and DELETE on the same mount path. The transport
+	// core decides whether to handle (POST initialize / JSON-RPC dispatch),
+	// return 405 with an accurate `Allow` header (GET always in v1, DELETE
+	// when `mcp.session.allowClientDelete` is false), or process (DELETE
+	// when enabled). Without explicit GET/DELETE routes Fastify would
+	// short-circuit to its built-in 404 before the transport runs.
+	for (const method of ['post', 'get', 'delete'] as const) {
+		if (routeOptions) {
+			host[method](mountPath, routeOptions, handler);
+		} else {
+			host[method](mountPath, handler);
+		}
 	}
 	harperLogger.info(`MCP ${profile} profile registered at ${mountPath}`);
 }

--- a/components/mcp/index.ts
+++ b/components/mcp/index.ts
@@ -1,16 +1,35 @@
 /**
  * Native MCP (Model Context Protocol) server component for Harper.
  *
- * Foundation PR (#613): exports a presence-gated registration hook used by
- * the operations and HTTP host servers. The hook installs a placeholder
- * route that returns HTTP 503 with body `{ error: 'mcp_not_implemented',
- * profile }` until the Streamable HTTP transport lands in #614. A profile
- * is enabled when its sub-block exists in config (matches Harper's
- * `replication` convention — no explicit `enabled` flag). Tracking: #465.
+ * #614 replaces the foundation stub from #613 with a real Streamable HTTP
+ * transport. Two entry points:
+ *
+ *   - `registerMcpProfile({profile:'operations', host, config, routeOptions})`
+ *     called from `server/operationsServer.ts` (Fastify-side gate).
+ *
+ *   - `handleApplication(scope)` invoked by the component loader when the
+ *     root config contains a top-level `mcp:` block. Registers the
+ *     application-profile handler on the HTTP port iff `mcp.application` is
+ *     present.
+ *
+ * Profile presence drives enablement, matching Harper's `replication`
+ * convention (no `enabled` flag). See #465 for the umbrella design.
  */
 import harperLogger from '../../utility/logging/harper_logger.ts';
+import { getConfigObj as realGetConfigObj } from '../../config/configUtils.js';
+import { createFastifyHandler } from './adapters/fastify.ts';
+import { createHarperHttpHandler } from './adapters/harperHttp.ts';
+import { ensureSessionTable } from './session.ts';
+import type { McpProfile } from './transport.ts';
 
-export type McpProfile = 'operations' | 'application';
+// Indirection so tests can swap the config source.
+let getConfigObj: () => unknown = realGetConfigObj as () => unknown;
+export function _setGetConfigObjForTest(fn: () => unknown): void {
+	getConfigObj = fn;
+}
+export function _restoreGetConfigObj(): void {
+	getConfigObj = realGetConfigObj as () => unknown;
+}
 
 interface McpProfileConfig {
 	mountPath?: string;
@@ -20,28 +39,26 @@ interface FullConfig {
 	mcp?: {
 		operations?: McpProfileConfig;
 		application?: McpProfileConfig;
+		session?: unknown;
 	};
 }
 
-interface FastifyLike {
+interface FastifyLikeHost {
 	post: (path: string, ...rest: unknown[]) => unknown;
 }
 
 export interface RegisterMcpProfileArgs {
 	profile: McpProfile;
-	host: FastifyLike;
+	host: FastifyLikeHost;
 	config: FullConfig;
-	/** Route-level options forwarded to the host's `post(path, options, handler)` 3-arg form (e.g., Fastify `preValidation`). */
 	routeOptions?: Record<string, unknown>;
 }
 
 const DEFAULT_MOUNT_PATH = '/mcp';
 
 /**
- * Register the MCP profile on its host server when enabled in config.
- *
- * The stub responder is intentionally minimal — sub-issue #614 replaces it
- * with the real Streamable HTTP transport without changing this gate.
+ * Fastify-side registration. Used by `server/operationsServer.ts` for the
+ * operations profile. Idempotent through the host's own route table.
  */
 export function registerMcpProfile({ profile, host, config, routeOptions }: RegisterMcpProfileArgs): void {
 	const profileConfig = config?.mcp?.[profile];
@@ -49,9 +66,9 @@ export function registerMcpProfile({ profile, host, config, routeOptions }: Regi
 		harperLogger.trace(`MCP ${profile} profile not configured, skipping registration`);
 		return;
 	}
-
+	ensureSessionTable();
 	const mountPath = profileConfig.mountPath ?? DEFAULT_MOUNT_PATH;
-	const handler = createStubHandler(profile);
+	const handler = createFastifyHandler(profile);
 	if (routeOptions) {
 		host.post(mountPath, routeOptions, handler);
 	} else {
@@ -60,21 +77,39 @@ export function registerMcpProfile({ profile, host, config, routeOptions }: Regi
 	harperLogger.info(`MCP ${profile} profile registered at ${mountPath}`);
 }
 
-/**
- * Builds the placeholder 503 handler. Returned function is Fastify-compatible:
- * `(request, reply)` where `reply` exposes `code()`, `header()`, and `send()`.
- */
-export function createStubHandler(profile: McpProfile) {
-	return async function mcpStubHandler(_request: unknown, reply: McpReply): Promise<void> {
-		reply.code(503);
-		reply.header('Retry-After', '0');
-		reply.header('Content-Type', 'application/json');
-		reply.send({ error: 'mcp_not_implemented', profile });
+let applicationStarted = false;
+
+interface ScopeLike {
+	server: {
+		http: (handler: unknown, options: Record<string, unknown>) => unknown;
 	};
 }
 
-interface McpReply {
-	code: (status: number) => McpReply;
-	header: (name: string, value: string) => McpReply;
-	send: (body: unknown) => McpReply;
+/**
+ * Trusted-Resource-Plugin entry point for the application profile. The
+ * component loader invokes this with the runtime `Scope` when the root
+ * config contains a top-level `mcp:` block. We register the handler iff the
+ * `application` sub-block is also present.
+ *
+ * Idempotent — repeated invocations no-op via `applicationStarted`. This
+ * matches REST's pattern at `server/REST.ts:283-303`.
+ */
+export function handleApplication(scope: ScopeLike): void {
+	if (applicationStarted) return;
+	const config = getConfigObj() as FullConfig | undefined;
+	if (!config?.mcp?.application) {
+		harperLogger.trace('MCP application profile not configured, skipping registration');
+		return;
+	}
+	applicationStarted = true;
+	ensureSessionTable();
+	const mountPath = config.mcp.application.mountPath ?? DEFAULT_MOUNT_PATH;
+	const handler = createHarperHttpHandler('application');
+	scope.server.http(handler, { urlPath: mountPath, after: 'authentication' });
+	harperLogger.info(`MCP application profile registered at ${mountPath}`);
+}
+
+/** Test seam: reset the module-level guard so tests can re-invoke handleApplication. */
+export function _resetApplicationStartedForTest(): void {
+	applicationStarted = false;
 }

--- a/components/mcp/jsonrpc.ts
+++ b/components/mcp/jsonrpc.ts
@@ -1,0 +1,134 @@
+/**
+ * JSON-RPC 2.0 envelope parsing + error helpers for the MCP Streamable HTTP
+ * transport (#614). The MCP wire format is one JSON-RPC message per HTTP body
+ * (no batches in the 2025-06-18 revision — spec §transports).
+ *
+ * Spec: https://www.jsonrpc.org/specification
+ */
+
+export const JSONRPC_VERSION = '2.0';
+
+/** Standard JSON-RPC 2.0 error codes (spec §5.1). */
+export const ERROR_CODES = {
+	PARSE_ERROR: -32700,
+	INVALID_REQUEST: -32600,
+	METHOD_NOT_FOUND: -32601,
+	INVALID_PARAMS: -32602,
+	INTERNAL_ERROR: -32603,
+} as const;
+
+export type JsonRpcId = string | number | null;
+
+export interface JsonRpcRequest {
+	jsonrpc: '2.0';
+	id: JsonRpcId;
+	method: string;
+	params?: unknown;
+}
+
+export interface JsonRpcNotification {
+	jsonrpc: '2.0';
+	method: string;
+	params?: unknown;
+}
+
+export interface JsonRpcSuccessResponse {
+	jsonrpc: '2.0';
+	id: JsonRpcId;
+	result: unknown;
+}
+
+export interface JsonRpcErrorObject {
+	code: number;
+	message: string;
+	data?: unknown;
+}
+
+export interface JsonRpcErrorResponse {
+	jsonrpc: '2.0';
+	id: JsonRpcId;
+	error: JsonRpcErrorObject;
+}
+
+export type JsonRpcMessage = JsonRpcRequest | JsonRpcNotification | JsonRpcSuccessResponse | JsonRpcErrorResponse;
+
+export interface ParseSuccess {
+	ok: true;
+	message: JsonRpcMessage;
+}
+export interface ParseFailure {
+	ok: false;
+	code: number;
+	reason: string;
+}
+export type ParseResult = ParseSuccess | ParseFailure;
+
+/**
+ * Validate a JSON-RPC envelope. Accepts either a raw UTF-8 JSON string
+ * (e.g., from a streamed request body) or an already-parsed value (e.g.,
+ * Fastify hands us a parsed object via its preParsing pipeline). Returns
+ * either a typed message or a structured parse error that the caller maps
+ * to a JSON-RPC error response. Never throws.
+ */
+export function parseMessage(body: string | unknown): ParseResult {
+	let parsed: unknown;
+	if (typeof body === 'string') {
+		try {
+			parsed = JSON.parse(body);
+		} catch (err) {
+			const fail: ParseFailure = { ok: false, code: ERROR_CODES.PARSE_ERROR, reason: (err as Error).message };
+			return fail;
+		}
+	} else {
+		parsed = body;
+	}
+	if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+		// Batch requests (arrays) are not used in the MCP Streamable HTTP wire
+		// format; rejecting them keeps the transport unambiguous.
+		const fail: ParseFailure = { ok: false, code: ERROR_CODES.INVALID_REQUEST, reason: 'expected a JSON object' };
+		return fail;
+	}
+	const obj = parsed as Record<string, unknown>;
+	if (obj.jsonrpc !== JSONRPC_VERSION) {
+		const fail: ParseFailure = {
+			ok: false,
+			code: ERROR_CODES.INVALID_REQUEST,
+			reason: `jsonrpc must be "${JSONRPC_VERSION}"`,
+		};
+		return fail;
+	}
+	const hasMethod = typeof obj.method === 'string';
+	const hasResultOrError = 'result' in obj || 'error' in obj;
+	if (!hasMethod && !hasResultOrError) {
+		const fail: ParseFailure = {
+			ok: false,
+			code: ERROR_CODES.INVALID_REQUEST,
+			reason: 'missing method, result, or error field',
+		};
+		return fail;
+	}
+	const success: ParseSuccess = { ok: true, message: parsed as JsonRpcMessage };
+	return success;
+}
+
+/**
+ * True if the message is a "fire-and-forget" frame from the client's
+ * perspective — a notification (no `id`) or a response to a server-initiated
+ * request (has `result` or `error`). Per MCP §transports point 4, both yield
+ * HTTP 202 with no body.
+ */
+export function isClientFireAndForget(message: JsonRpcMessage): boolean {
+	const hasId = 'id' in message;
+	const hasResultOrError = 'result' in message || 'error' in message;
+	return !hasId || hasResultOrError;
+}
+
+export function buildSuccess(id: JsonRpcId, result: unknown): JsonRpcSuccessResponse {
+	return { jsonrpc: JSONRPC_VERSION, id, result };
+}
+
+export function buildError(id: JsonRpcId, code: number, message: string, data?: unknown): JsonRpcErrorResponse {
+	const error: JsonRpcErrorObject = { code, message };
+	if (data !== undefined) error.data = data;
+	return { jsonrpc: JSONRPC_VERSION, id, error };
+}

--- a/components/mcp/lifecycle.ts
+++ b/components/mcp/lifecycle.ts
@@ -1,0 +1,98 @@
+/**
+ * MCP lifecycle handlers — `initialize` and `notifications/initialized`.
+ *
+ * Spec: https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle
+ * v1 supports protocol version `2025-06-18` (preferred) and `2025-03-26`
+ * (backcompat). Anything else returns 400 to the client; per the spec, the
+ * server SHOULD respond with its preferred supported version so the client
+ * can decide whether to connect on the older version or disconnect.
+ */
+import { createSession, saveSession, type McpSessionRecord } from './session.ts';
+import { packageJson } from '../../utility/packageUtils.js';
+
+export const PROTOCOL_VERSION_PREFERRED = '2025-06-18';
+export const PROTOCOL_VERSION_BACKCOMPAT = '2025-03-26';
+export const SUPPORTED_PROTOCOL_VERSIONS = [PROTOCOL_VERSION_PREFERRED, PROTOCOL_VERSION_BACKCOMPAT] as const;
+
+export const SERVER_INFO = {
+	name: 'harper-mcp',
+	version: (packageJson as { version: string }).version,
+} as const;
+
+/** Server capabilities advertised on `initialize` for v1. */
+export const SERVER_CAPABILITIES = {
+	tools: { listChanged: true },
+	resources: { listChanged: true },
+	logging: {},
+} as const;
+
+export interface InitializeParams {
+	protocolVersion?: unknown;
+	capabilities?: unknown;
+	clientInfo?: unknown;
+}
+
+export interface InitializeResult {
+	protocolVersion: string;
+	serverInfo: typeof SERVER_INFO;
+	capabilities: typeof SERVER_CAPABILITIES;
+	instructions?: string;
+}
+
+export interface InitializeOutcome {
+	ok: true;
+	session: McpSessionRecord;
+	result: InitializeResult;
+}
+
+export interface InitializeFailure {
+	ok: false;
+	reason: string;
+	supportedVersions: readonly string[];
+}
+
+/**
+ * Negotiate protocol version, create a session, and return the JSON-RPC
+ * result body. The caller (transport core) maps `ok: false` to HTTP 400.
+ *
+ * `instructions` is optional per spec; we omit it in v1 (it can be wired
+ * later when tools land in #617 and we know which profile is active).
+ */
+export async function handleInitialize(
+	params: InitializeParams | undefined,
+	user: string
+): Promise<InitializeOutcome | InitializeFailure> {
+	const requested = params?.protocolVersion;
+	if (
+		typeof requested !== 'string' ||
+		!SUPPORTED_PROTOCOL_VERSIONS.includes(requested as (typeof SUPPORTED_PROTOCOL_VERSIONS)[number])
+	) {
+		return {
+			ok: false,
+			reason: `unsupported protocolVersion${typeof requested === 'string' ? `: ${requested}` : ''}`,
+			supportedVersions: SUPPORTED_PROTOCOL_VERSIONS,
+		};
+	}
+	const session = await createSession({ user, protocolVersion: requested });
+	return {
+		ok: true,
+		session,
+		result: {
+			protocolVersion: requested,
+			serverInfo: SERVER_INFO,
+			capabilities: SERVER_CAPABILITIES,
+		},
+	};
+}
+
+/**
+ * Flip the session to `initialized: true`. Called when the client posts the
+ * `notifications/initialized` JSON-RPC notification (per MCP §lifecycle).
+ * The transport returns HTTP 202 with no body regardless of outcome here.
+ */
+export async function handleInitialized(session: McpSessionRecord): Promise<McpSessionRecord> {
+	if (session.initialized) return session;
+	const updated: McpSessionRecord = { ...session, initialized: true };
+	await saveSession(updated);
+	return updated;
+}

--- a/components/mcp/session.ts
+++ b/components/mcp/session.ts
@@ -1,0 +1,141 @@
+/**
+ * MCP session store backed by the `system.mcp_session` Harper table.
+ *
+ * Eviction is delegated to Harper's native TTL (`Table.setTTLExpiration`):
+ * every write to a session record updates its `version`, which Harper uses
+ * to determine expiration. So calling `saveSession(record)` on each request
+ * gives sliding-window idle semantics for free — no custom timer, no sweep.
+ *
+ * Spec: when a request bears an `Mcp-Session-Id` the server doesn't
+ * recognize (expired, terminated, or unknown), the server MUST return HTTP
+ * 404 so the client can re-`initialize`. That decision lives in the
+ * transport core; this module only reports `null` for "not found".
+ */
+import { v4 as uuid } from 'uuid';
+import { table, type Table } from '../../resources/databases.ts';
+import * as env from '../../utility/environment/environmentManager.ts';
+import { CONFIG_PARAMS } from '../../utility/hdbTerms.ts';
+import harperLogger from '../../utility/logging/harper_logger.ts';
+
+const TABLE_NAME = 'mcp_session';
+const DATABASE_NAME = 'system';
+
+/** Default idle timeout when `mcp.session.idleTimeoutSeconds` is omitted. */
+const DEFAULT_IDLE_TIMEOUT_SECONDS = 1800;
+
+/**
+ * Window between expiration and physical eviction. Short, but long enough
+ * to absorb clock skew and let a late client request resolve to a tombstone
+ * 404 rather than a "session never existed" 404. (The client recovery path
+ * is identical either way.)
+ */
+const EVICTION_WINDOW_SECONDS = 60;
+
+export interface McpSessionRecord {
+	id: string;
+	protocolVersion: string;
+	initialized: boolean;
+	user: string;
+	createdAt: number;
+	lastActivity: number;
+}
+
+let _sessionTable: Table | undefined;
+
+/**
+ * Lazily declare the system table. Called by `ensureSessionTable()` at
+ * component-init. Declaring lazily lets unit tests that don't boot a real
+ * Harper instance skip the table entirely.
+ */
+function declareSessionTable(): Table {
+	const idleTimeoutSeconds =
+		(env.get(CONFIG_PARAMS.MCP_SESSION_IDLETIMEOUTSECONDS) as number | undefined) ?? DEFAULT_IDLE_TIMEOUT_SECONDS;
+	return table<Table>({
+		table: TABLE_NAME,
+		database: DATABASE_NAME,
+		expiration: idleTimeoutSeconds,
+		eviction: idleTimeoutSeconds + EVICTION_WINDOW_SECONDS,
+		attributes: [
+			{ name: 'id', isPrimaryKey: true },
+			{ name: 'protocolVersion' },
+			{ name: 'initialized' },
+			{ name: 'user' },
+			{ name: 'createdAt' },
+			{ name: 'lastActivity' },
+		],
+	});
+}
+
+/**
+ * Initialize the session table. Called from `handleApplication(scope)` and
+ * `registerMcpProfile()` when the MCP component boots. Idempotent.
+ */
+export function ensureSessionTable(): Table {
+	if (!_sessionTable) {
+		_sessionTable = declareSessionTable();
+		harperLogger.trace(`MCP session table system.${TABLE_NAME} initialized`);
+	}
+	return _sessionTable;
+}
+
+/** Test seam: allow tests to inject a fake table without touching Harper. */
+export function _setSessionTableForTest(fake: Table | undefined): void {
+	_sessionTable = fake;
+}
+
+function getTable(): Table {
+	if (!_sessionTable) throw new Error('MCP session table not initialized');
+	return _sessionTable;
+}
+
+export async function createSession({
+	user,
+	protocolVersion,
+}: {
+	user: string;
+	protocolVersion: string;
+}): Promise<McpSessionRecord> {
+	const now = Date.now();
+	const record: McpSessionRecord = {
+		id: uuid(),
+		protocolVersion,
+		initialized: false,
+		user,
+		createdAt: now,
+		lastActivity: now,
+	};
+	await (getTable() as any).put(record);
+	return record;
+}
+
+/**
+ * Look up a session by id. Returns the record if present and not expired,
+ * else `null`. The transport core maps `null` to HTTP 404.
+ */
+export async function loadSession(id: string): Promise<McpSessionRecord | null> {
+	const record = (await (getTable() as any).get(id)) as McpSessionRecord | undefined | null;
+	if (!record) return null;
+	return record;
+}
+
+/**
+ * Persist updated session state. Used to bump `lastActivity` (sliding-window
+ * idle reset) and to flip `initialized` after `notifications/initialized`.
+ */
+export async function saveSession(record: McpSessionRecord): Promise<void> {
+	await (getTable() as any).put(record);
+}
+
+export async function deleteSession(id: string): Promise<void> {
+	await (getTable() as any).delete(id);
+}
+
+/**
+ * Convenience: touch `lastActivity` and persist. Returns the updated
+ * record so the caller doesn't re-fetch.
+ */
+export async function touchSession(record: McpSessionRecord): Promise<McpSessionRecord> {
+	const touched: McpSessionRecord = { ...record, lastActivity: Date.now() };
+	await saveSession(touched);
+	return touched;
+}

--- a/components/mcp/transport.ts
+++ b/components/mcp/transport.ts
@@ -1,0 +1,272 @@
+/**
+ * MCP Streamable HTTP transport core — framework-agnostic.
+ *
+ * Takes a normalized request (method, headers, body, authenticated user,
+ * profile) and returns a normalized response (status, headers, optional
+ * JSON body or SSE iterable). The Fastify adapter (operations port) and
+ * Harper-HTTP adapter (application port) each translate to/from this shape.
+ *
+ * All spec MUSTs from MCP §basic/transports (rev 2025-06-18) live here:
+ *   - Origin validation
+ *   - Mcp-Session-Id lifecycle
+ *   - MCP-Protocol-Version enforcement
+ *   - HTTP status code mapping (200/202/400/403/404/405)
+ *   - JSON-RPC envelope parsing + standard error codes
+ */
+import * as env from '../../utility/environment/environmentManager.ts';
+import { CONFIG_PARAMS } from '../../utility/hdbTerms.ts';
+import harperLogger from '../../utility/logging/harper_logger.ts';
+import {
+	ERROR_CODES,
+	buildError,
+	buildSuccess,
+	isClientFireAndForget,
+	parseMessage,
+	type JsonRpcId,
+	type JsonRpcMessage,
+} from './jsonrpc.ts';
+import {
+	handleInitialize,
+	handleInitialized,
+	PROTOCOL_VERSION_BACKCOMPAT,
+	SUPPORTED_PROTOCOL_VERSIONS,
+} from './lifecycle.ts';
+import { deleteSession, loadSession, touchSession } from './session.ts';
+
+export type McpProfile = 'operations' | 'application';
+
+export interface NormRequest {
+	method: string;
+	/** Lowercased header name → value. Adapters normalize before calling. */
+	headers: Record<string, string | undefined>;
+	/**
+	 * The request body. May be a raw JSON string (Harper-HTTP adapter, which
+	 * reads from a stream) or an already-parsed value (Fastify adapter, which
+	 * receives parsed JSON via its preParsing pipeline). `parseMessage` handles
+	 * both — no JSON round-trip needed.
+	 */
+	body: string | unknown;
+	/** Authenticated username from upstream auth pipeline. */
+	user: string;
+	profile: McpProfile;
+}
+
+export interface NormResponse {
+	status: number;
+	headers: Record<string, string>;
+	jsonBody?: unknown;
+	sseIterable?: AsyncIterable<unknown>;
+}
+
+const SESSION_HEADER = 'mcp-session-id';
+const PROTOCOL_HEADER = 'mcp-protocol-version';
+const ORIGIN_HEADER = 'origin';
+
+/**
+ * Main entry. Adapters call this and map the returned shape to their
+ * native wire format. Any unhandled error from a downstream call (e.g., a
+ * RocksDB I/O failure on the session table) is caught and reported as a
+ * spec-conformant JSON-RPC Internal Error so clients see a structured
+ * error envelope instead of an opaque framework 500.
+ */
+export async function handleMcpRequest(request: NormRequest): Promise<NormResponse> {
+	try {
+		if (!isOriginAllowed(request)) {
+			return jsonResponse(403, { error: 'origin_not_allowed' });
+		}
+		if (request.method === 'POST') return await handlePost(request);
+		if (request.method === 'GET') return handleGet();
+		if (request.method === 'DELETE') return await handleDelete(request);
+		return { status: 405, headers: { Allow: 'POST, GET, DELETE' } };
+	} catch (err) {
+		harperLogger.error(`MCP transport internal error: ${(err as Error).stack ?? (err as Error).message}`);
+		return jsonRpcErrorResponse(500, null, ERROR_CODES.INTERNAL_ERROR, 'internal error');
+	}
+}
+
+/**
+ * Per-profile Origin validation. Mirrors Harper's existing auth.ts pattern
+ * (security/auth.ts:65) for parity with how the operations + HTTP ports
+ * already handle CORS:
+ *   - CORS disabled in config ⇒ accept any Origin (don't gate on it at all).
+ *   - CORS enabled with empty/unset allow-list ⇒ accept any.
+ *   - CORS enabled with allow-list ⇒ match exactly OR honor a `'*'` wildcard.
+ *   - Missing Origin header ⇒ accept (curl, server-to-server, no DNS-rebinding
+ *     vector exists when the request isn't browser-initiated).
+ */
+function isOriginAllowed(request: NormRequest): boolean {
+	const origin = request.headers[ORIGIN_HEADER];
+	if (!origin) return true;
+	const corsEnabled =
+		request.profile === 'operations'
+			? env.get(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_CORS)
+			: env.get(CONFIG_PARAMS.HTTP_CORS);
+	if (!corsEnabled) return true;
+	const list =
+		request.profile === 'operations'
+			? env.get(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_CORSACCESSLIST)
+			: env.get(CONFIG_PARAMS.HTTP_CORSACCESSLIST);
+	if (!Array.isArray(list) || list.length === 0) return true;
+	return list.includes(origin) || list.includes('*');
+}
+
+async function handlePost(request: NormRequest): Promise<NormResponse> {
+	const parsed = parseMessage(request.body);
+	if (parsed.ok !== true) {
+		// Explicit cast: tsconfig has `strict: false`, so TS can't narrow
+		// discriminated unions from `parsed.ok !== true`. Without the cast it
+		// errors TS2339 on `parsed.code` / `parsed.reason`. (Verified during
+		// review; the alternative — enabling strict mode — is repo-wide.)
+		const fail = parsed as { ok: false; code: number; reason: string };
+		return jsonRpcErrorResponse(400, null, fail.code, fail.reason);
+	}
+	const message = parsed.message;
+	const messageId: JsonRpcId = 'id' in message ? message.id : null;
+	const method = 'method' in message ? message.method : undefined;
+
+	if (method === 'initialize') return dispatchInitialize(request, message, messageId);
+
+	const sessionId = request.headers[SESSION_HEADER];
+	if (!sessionId) {
+		return jsonRpcErrorResponse(400, messageId, ERROR_CODES.INVALID_REQUEST, 'missing Mcp-Session-Id header');
+	}
+	const session = await loadSession(sessionId);
+	if (!session) {
+		// Terminated, expired, or never existed. Spec mandates 404 so the
+		// client knows to drop the id and re-initialize.
+		return { status: 404, headers: {} };
+	}
+
+	const protocolCheck = validateProtocolHeader(request.headers[PROTOCOL_HEADER], session.protocolVersion);
+	if (protocolCheck.ok !== true) {
+		const fail = protocolCheck as { ok: false; reason: string };
+		return jsonRpcErrorResponse(400, messageId, ERROR_CODES.INVALID_REQUEST, fail.reason);
+	}
+
+	if (session.user !== request.user) {
+		// Defense-in-depth against session-id leaks: id was created for a
+		// different user. Mask the session id in logs — even though it's not
+		// a credential in MCP, leaking it to an attacker with log access would
+		// enable session-jacking once paired with a valid token.
+		harperLogger.warn(
+			`MCP session ${maskSessionId(sessionId)} presented by user ${request.user} but bound to ${session.user}`
+		);
+		return { status: 403, headers: {} };
+	}
+
+	// Sliding-window idle reset. Awaited (not fire-and-forget) so a concurrent
+	// DELETE that arrives mid-request can't be resurrected by a late put.
+	await touchSession(session);
+
+	// Fire-and-forget frames (notifications + client responses) always 202.
+	if (isClientFireAndForget(message)) {
+		if (method === 'notifications/initialized') {
+			await handleInitialized(session);
+		}
+		return { status: 202, headers: {} };
+	}
+
+	// Request (has id + method, not 'initialize') — stub responder for v1.
+	// Tools/resources lands in #615/#616/#617/#618; until then, every method
+	// other than initialize gets a spec-conformant Method-not-found error.
+	return jsonResponse(
+		200,
+		buildError(messageId, ERROR_CODES.METHOD_NOT_FOUND, `Method not found: ${method ?? '<missing>'}`)
+	);
+}
+
+async function dispatchInitialize(
+	request: NormRequest,
+	message: JsonRpcMessage,
+	messageId: JsonRpcId
+): Promise<NormResponse> {
+	const params = 'params' in message ? (message.params as { protocolVersion?: unknown } | undefined) : undefined;
+	const outcome = await handleInitialize(params, request.user);
+	if (outcome.ok !== true) {
+		const fail = outcome as { ok: false; reason: string; supportedVersions: readonly string[] };
+		return jsonRpcErrorResponse(400, messageId, ERROR_CODES.INVALID_PARAMS, fail.reason, {
+			supportedVersions: fail.supportedVersions,
+		});
+	}
+	return {
+		status: 200,
+		headers: { 'Mcp-Session-Id': outcome.session.id },
+		jsonBody: buildSuccess(messageId, outcome.result),
+	};
+}
+
+function handleGet(): NormResponse {
+	// v1 does not offer a GET SSE channel. #619 will replace this with a
+	// real server-push stream for `listChanged` notifications.
+	return { status: 405, headers: { Allow: 'POST, DELETE' } };
+}
+
+async function handleDelete(request: NormRequest): Promise<NormResponse> {
+	const allow = env.get(CONFIG_PARAMS.MCP_SESSION_ALLOWCLIENTDELETE);
+	if (allow !== true) {
+		return { status: 405, headers: { Allow: 'POST, GET' } };
+	}
+	const sessionId = request.headers[SESSION_HEADER];
+	if (!sessionId) {
+		return { status: 400, headers: {} };
+	}
+	const session = await loadSession(sessionId);
+	if (!session) {
+		return { status: 404, headers: {} };
+	}
+	if (session.user !== request.user) {
+		return { status: 403, headers: {} };
+	}
+	await deleteSession(sessionId);
+	return { status: 204, headers: {} };
+}
+
+function validateProtocolHeader(
+	headerValue: string | undefined,
+	sessionVersion: string
+): { ok: true } | { ok: false; reason: string } {
+	// Per spec compatibility rule: missing header is treated as 2025-03-26.
+	const effective = headerValue ?? PROTOCOL_VERSION_BACKCOMPAT;
+	if (!SUPPORTED_PROTOCOL_VERSIONS.includes(effective as (typeof SUPPORTED_PROTOCOL_VERSIONS)[number])) {
+		return { ok: false, reason: `unsupported MCP-Protocol-Version: ${effective}` };
+	}
+	if (effective !== sessionVersion) {
+		return {
+			ok: false,
+			reason: `MCP-Protocol-Version mismatch: session negotiated ${sessionVersion}, request sent ${effective}`,
+		};
+	}
+	return { ok: true };
+}
+
+function jsonResponse(status: number, body: unknown): NormResponse {
+	return {
+		status,
+		headers: { 'Content-Type': 'application/json' },
+		jsonBody: body,
+	};
+}
+
+function jsonRpcErrorResponse(
+	status: number,
+	id: JsonRpcId,
+	code: number,
+	message: string,
+	data?: unknown
+): NormResponse {
+	return {
+		status,
+		headers: { 'Content-Type': 'application/json' },
+		jsonBody: buildError(id, code, message, data),
+	};
+}
+
+/**
+ * Mask an MCP session id for log output. Sessions aren't credentials in the
+ * strict sense, but a leaked id paired with a stolen token enables session
+ * jacking, so we don't print the full value in routine logs.
+ */
+function maskSessionId(id: string): string {
+	if (id.length <= 8) return '***';
+	return `${id.slice(0, 8)}…`;
+}

--- a/components/mcp/transport.ts
+++ b/components/mcp/transport.ts
@@ -77,7 +77,7 @@ export async function handleMcpRequest(request: NormRequest): Promise<NormRespon
 		if (request.method === 'POST') return await handlePost(request);
 		if (request.method === 'GET') return handleGet();
 		if (request.method === 'DELETE') return await handleDelete(request);
-		return { status: 405, headers: { Allow: 'POST, GET, DELETE' } };
+		return { status: 405, headers: { Allow: currentlyAllowedMethods() } };
 	} catch (err) {
 		harperLogger.error(`MCP transport internal error: ${(err as Error).stack ?? (err as Error).message}`);
 		return jsonRpcErrorResponse(500, null, ERROR_CODES.INTERNAL_ERROR, 'internal error');
@@ -198,13 +198,13 @@ async function dispatchInitialize(
 function handleGet(): NormResponse {
 	// v1 does not offer a GET SSE channel. #619 will replace this with a
 	// real server-push stream for `listChanged` notifications.
-	return { status: 405, headers: { Allow: 'POST, DELETE' } };
+	return { status: 405, headers: { Allow: currentlyAllowedMethods() } };
 }
 
 async function handleDelete(request: NormRequest): Promise<NormResponse> {
 	const allow = env.get(CONFIG_PARAMS.MCP_SESSION_ALLOWCLIENTDELETE);
 	if (allow !== true) {
-		return { status: 405, headers: { Allow: 'POST, GET' } };
+		return { status: 405, headers: { Allow: currentlyAllowedMethods() } };
 	}
 	const sessionId = request.headers[SESSION_HEADER];
 	if (!sessionId) {
@@ -269,4 +269,14 @@ function jsonRpcErrorResponse(
 function maskSessionId(id: string): string {
 	if (id.length <= 8) return '***';
 	return `${id.slice(0, 8)}…`;
+}
+
+/**
+ * Build the `Allow` header value for a 405 response. Per RFC 9110 §9.1 the
+ * server MUST list only currently-supported methods. In v1, POST is always
+ * supported; GET is never supported (no SSE channel until #619); DELETE is
+ * conditional on `mcp.session.allowClientDelete`.
+ */
+function currentlyAllowedMethods(): string {
+	return env.get(CONFIG_PARAMS.MCP_SESSION_ALLOWCLIENTDELETE) === true ? 'POST, DELETE' : 'POST';
 }

--- a/integrationTests/server/mcp.test.ts
+++ b/integrationTests/server/mcp.test.ts
@@ -1,0 +1,182 @@
+/**
+ * MCP Streamable HTTP transport — integration tests (#614).
+ *
+ * Verifies end-to-end behavior against a real Harper boot with
+ * `mcp.operations: {}` in config:
+ *   - initialize handshake (request + Mcp-Session-Id response)
+ *   - notifications/initialized → 202 empty
+ *   - GET /mcp → 405 (no SSE channel in v1)
+ *   - DELETE /mcp → 405 by default
+ *   - Unknown method → 200 + JSON-RPC -32601
+ *   - Missing/unknown session id → 400 / 404
+ *   - User binding on session
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual, match } from 'node:assert/strict';
+
+import { startHarper, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+
+function authHeader(ctx: ContextWithHarper): string {
+	return `Basic ${Buffer.from(`${ctx.harper.admin.username}:${ctx.harper.admin.password}`).toString('base64')}`;
+}
+
+function mcpUrl(ctx: ContextWithHarper): string {
+	return `${ctx.harper.operationsAPIURL}/mcp`;
+}
+
+async function jsonRpcPost(
+	ctx: ContextWithHarper,
+	body: object,
+	extraHeaders: Record<string, string> = {}
+): Promise<Response> {
+	return fetch(mcpUrl(ctx), {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			'Accept': 'application/json, text/event-stream',
+			'Authorization': authHeader(ctx),
+			...extraHeaders,
+		},
+		body: JSON.stringify(body),
+	});
+}
+
+suite('MCP Streamable HTTP transport (operations profile)', (ctx: ContextWithHarper) => {
+	before(async () => {
+		await startHarper(ctx, {
+			config: {
+				mcp: { operations: {} },
+			},
+			env: {},
+		});
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	test('initialize returns 200 with Mcp-Session-Id header and capabilities', async () => {
+		const res = await jsonRpcPost(ctx, {
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'initialize',
+			params: {
+				protocolVersion: '2025-06-18',
+				capabilities: {},
+				clientInfo: { name: 'mcp-integration-test', version: '0.0.0' },
+			},
+		});
+		strictEqual(res.status, 200);
+		const sessionId = res.headers.get('mcp-session-id');
+		ok(sessionId, 'expected Mcp-Session-Id response header');
+		match(sessionId!, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+		const body = (await res.json()) as {
+			jsonrpc: string;
+			id: number;
+			result: {
+				protocolVersion: string;
+				serverInfo: { name: string; version: string };
+				capabilities: { tools: { listChanged: boolean }; resources: { listChanged: boolean }; logging: object };
+			};
+		};
+		strictEqual(body.jsonrpc, '2.0');
+		strictEqual(body.id, 1);
+		strictEqual(body.result.protocolVersion, '2025-06-18');
+		strictEqual(body.result.serverInfo.name, 'harper-mcp');
+		strictEqual(body.result.capabilities.tools.listChanged, true);
+		strictEqual(body.result.capabilities.resources.listChanged, true);
+	});
+
+	test('full handshake: initialize → notifications/initialized → 202 empty', async () => {
+		const initRes = await jsonRpcPost(ctx, {
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'initialize',
+			params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'x', version: '0' } },
+		});
+		strictEqual(initRes.status, 200);
+		const sessionId = initRes.headers.get('mcp-session-id')!;
+		await initRes.body?.cancel();
+
+		const notifRes = await jsonRpcPost(
+			ctx,
+			{ jsonrpc: '2.0', method: 'notifications/initialized' },
+			{ 'Mcp-Session-Id': sessionId, 'MCP-Protocol-Version': '2025-06-18' }
+		);
+		strictEqual(notifRes.status, 202);
+		const text = await notifRes.text();
+		strictEqual(text, '');
+	});
+
+	test('unknown method on an active session returns 200 + JSON-RPC -32601', async () => {
+		const initRes = await jsonRpcPost(ctx, {
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'initialize',
+			params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'x', version: '0' } },
+		});
+		const sessionId = initRes.headers.get('mcp-session-id')!;
+		await initRes.body?.cancel();
+
+		const res = await jsonRpcPost(
+			ctx,
+			{ jsonrpc: '2.0', id: 2, method: 'tools/list' },
+			{ 'Mcp-Session-Id': sessionId, 'MCP-Protocol-Version': '2025-06-18' }
+		);
+		strictEqual(res.status, 200);
+		const body = (await res.json()) as { jsonrpc: string; id: number; error: { code: number; message: string } };
+		strictEqual(body.error.code, -32601);
+		match(body.error.message, /tools\/list/);
+	});
+
+	test('request without Mcp-Session-Id returns 400', async () => {
+		const res = await jsonRpcPost(
+			ctx,
+			{ jsonrpc: '2.0', id: 1, method: 'tools/list' },
+			{
+				'MCP-Protocol-Version': '2025-06-18',
+			}
+		);
+		strictEqual(res.status, 400);
+	});
+
+	test('request with unknown Mcp-Session-Id returns 404', async () => {
+		const res = await jsonRpcPost(
+			ctx,
+			{ jsonrpc: '2.0', id: 1, method: 'tools/list' },
+			{ 'Mcp-Session-Id': 'not-a-real-session', 'MCP-Protocol-Version': '2025-06-18' }
+		);
+		strictEqual(res.status, 404);
+	});
+
+	test('GET /mcp returns 405', async () => {
+		const res = await fetch(mcpUrl(ctx), {
+			method: 'GET',
+			headers: { Accept: 'text/event-stream', Authorization: authHeader(ctx) },
+		});
+		strictEqual(res.status, 405);
+		await res.body?.cancel();
+	});
+
+	test('DELETE /mcp returns 405 when allowClientDelete is not configured', async () => {
+		const res = await fetch(mcpUrl(ctx), {
+			method: 'DELETE',
+			headers: { Authorization: authHeader(ctx) },
+		});
+		strictEqual(res.status, 405);
+		await res.body?.cancel();
+	});
+
+	test('parse error returns 400 with JSON-RPC -32700', async () => {
+		const res = await fetch(mcpUrl(ctx), {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Accept': 'application/json',
+				'Authorization': authHeader(ctx),
+			},
+			body: '{not json',
+		});
+		strictEqual(res.status, 400);
+	});
+});

--- a/integrationTests/server/mcp.test.ts
+++ b/integrationTests/server/mcp.test.ts
@@ -43,9 +43,17 @@ async function jsonRpcPost(
 
 suite('MCP Streamable HTTP transport (operations profile)', (ctx: ContextWithHarper) => {
 	before(async () => {
+		// NOTE on the explicit `mountPath`: the integration-testing harness
+		// passes config via the `HARPER_SET_CONFIG` env var, which is applied
+		// via `applyConfigLayer` → `flattenObject` in
+		// `config/harperConfigEnvVars.ts:176`. `flattenObject` skips empty
+		// objects (no flat paths to set), so `mcp: { operations: {} }` would
+		// be lost entirely from the runtime override. Production YAML loading
+		// preserves empty objects, so the presence-based enablement works for
+		// real users — this is a harness-only workaround.
 		await startHarper(ctx, {
 			config: {
-				mcp: { operations: {} },
+				mcp: { operations: { mountPath: '/mcp' } },
 			},
 			env: {},
 		});

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -82,6 +82,7 @@ export const NON_REPLICATING_SYSTEM_TABLES = [
 	'hdb_session_will',
 	'hdb_job',
 	'hdb_info',
+	'mcp_session',
 ];
 
 export type Table = ReturnType<typeof makeTable> & {

--- a/server/operationsServer.ts
+++ b/server/operationsServer.ts
@@ -196,7 +196,10 @@ function buildServer(isHttps: boolean, resources: Resources): FastifyInstance {
 			profile: 'operations',
 			host: app,
 			config: fullConfig,
-			routeOptions: { preValidation: [authHandler] },
+			// Use authAndEnsureUserOnRequest (sets `req.hdb_user`) instead of
+			// authHandler (which mutates `req.body.hdb_user` — that would
+			// contaminate the JSON-RPC envelope the MCP handler reads).
+			routeOptions: { preValidation: [authAndEnsureUserOnRequest] },
 		});
 	}
 

--- a/unitTests/components/mcp/adapters/fastify.test.js
+++ b/unitTests/components/mcp/adapters/fastify.test.js
@@ -1,0 +1,130 @@
+const assert = require('node:assert/strict');
+const { createFastifyHandler } = require('#src/components/mcp/adapters/fastify');
+const { _setSessionTableForTest, loadSession } = require('#src/components/mcp/session');
+
+function makeFakeTable() {
+	const store = new Map();
+	return {
+		async put(record) {
+			store.set(record.id, { ...record });
+		},
+		async get(id) {
+			const r = store.get(id);
+			return r ? { ...r } : undefined;
+		},
+		async delete(id) {
+			store.delete(id);
+		},
+	};
+}
+
+function makeReply() {
+	const reply = {
+		statusCode: undefined,
+		headers: {},
+		body: undefined,
+		code(s) {
+			reply.statusCode = s;
+			return reply;
+		},
+		header(k, v) {
+			reply.headers[k] = v;
+			return reply;
+		},
+		send(b) {
+			reply.body = b;
+			return reply;
+		},
+	};
+	return reply;
+}
+
+describe('mcp/adapters/fastify', () => {
+	beforeEach(() => _setSessionTableForTest(makeFakeTable()));
+	afterEach(() => _setSessionTableForTest(undefined));
+
+	it('forwards an initialize request and writes 200 + JSON body back to Fastify', async () => {
+		const handler = createFastifyHandler('operations');
+		const reply = makeReply();
+		const request = {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18' } },
+			hdb_user: { username: 'alice' },
+		};
+		await handler(request, reply);
+		assert.equal(reply.statusCode, 200);
+		assert.match(reply.headers['Mcp-Session-Id'], /^[0-9a-f-]{36}$/);
+		assert.equal(reply.body.id, 1);
+		assert.equal(reply.body.result.protocolVersion, '2025-06-18');
+	});
+
+	it('uses an empty username when hdb_user is absent', async () => {
+		const handler = createFastifyHandler('operations');
+		const reply = makeReply();
+		await handler(
+			{
+				method: 'POST',
+				headers: {},
+				body: { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18' } },
+			},
+			reply
+		);
+		// Still succeeds — auth bypass is not this adapter's call to make. The
+		// session ends up bound to user `""`. Upstream auth is the gate.
+		assert.equal(reply.statusCode, 200);
+	});
+
+	it('handles a notification body (no JSON-RPC id) by sending 202 empty', async () => {
+		const handler = createFastifyHandler('operations');
+		// First, initialize a session.
+		const initReply = makeReply();
+		await handler(
+			{
+				method: 'POST',
+				headers: {},
+				body: { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18' } },
+				hdb_user: { username: 'alice' },
+			},
+			initReply
+		);
+		const sessionId = initReply.headers['Mcp-Session-Id'];
+
+		const notifReply = makeReply();
+		await handler(
+			{
+				method: 'POST',
+				headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' },
+				body: { jsonrpc: '2.0', method: 'notifications/initialized' },
+				hdb_user: { username: 'alice' },
+			},
+			notifReply
+		);
+		assert.equal(notifReply.statusCode, 202);
+		assert.equal(notifReply.body, undefined);
+		const session = await loadSession(sessionId);
+		assert.equal(session.initialized, true);
+	});
+
+	it('normalizes header arrays (Fastify may emit an array for some headers)', async () => {
+		const handler = createFastifyHandler('operations');
+		const reply = makeReply();
+		await handler(
+			{
+				method: 'POST',
+				headers: { 'mcp-session-id': ['nope'] },
+				body: { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+				hdb_user: { username: 'alice' },
+			},
+			reply
+		);
+		assert.equal(reply.statusCode, 404);
+	});
+
+	it('returns 405 on GET', async () => {
+		const handler = createFastifyHandler('operations');
+		const reply = makeReply();
+		await handler({ method: 'GET', headers: {}, hdb_user: { username: 'alice' } }, reply);
+		assert.equal(reply.statusCode, 405);
+	});
+});

--- a/unitTests/components/mcp/adapters/harperHttp.test.js
+++ b/unitTests/components/mcp/adapters/harperHttp.test.js
@@ -1,0 +1,149 @@
+const assert = require('node:assert/strict');
+const { Readable } = require('node:stream');
+const { createHarperHttpHandler } = require('#src/components/mcp/adapters/harperHttp');
+const { _setSessionTableForTest, loadSession } = require('#src/components/mcp/session');
+const { Headers } = require('#src/server/serverHelpers/Headers');
+
+function makeFakeTable() {
+	const store = new Map();
+	return {
+		async put(record) {
+			store.set(record.id, { ...record });
+		},
+		async get(id) {
+			const r = store.get(id);
+			return r ? { ...r } : undefined;
+		},
+		async delete(id) {
+			store.delete(id);
+		},
+	};
+}
+
+function makeHeaders(init = {}) {
+	const h = new Headers();
+	for (const [k, v] of Object.entries(init)) h.set(k, v);
+	return h;
+}
+
+function bodyStream(text) {
+	return Readable.from([Buffer.from(text, 'utf8')]);
+}
+
+async function next() {
+	return undefined;
+}
+
+describe('mcp/adapters/harperHttp', () => {
+	beforeEach(() => _setSessionTableForTest(makeFakeTable()));
+	afterEach(() => _setSessionTableForTest(undefined));
+
+	it('handles an initialize request and returns 200 + JSON body + Mcp-Session-Id', async () => {
+		const handler = createHarperHttpHandler('application');
+		const result = await handler(
+			{
+				method: 'POST',
+				headers: makeHeaders({ 'content-type': 'application/json' }),
+				body: bodyStream(
+					JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18' } })
+				),
+				user: { username: 'alice' },
+			},
+			next
+		);
+		assert.equal(result.status, 200);
+		assert.match(result.headers['Mcp-Session-Id'], /^[0-9a-f-]{36}$/);
+		assert.equal(result.headers['Content-Type'], 'application/json');
+		const parsed = JSON.parse(result.body);
+		assert.equal(parsed.id, 1);
+		assert.equal(parsed.result.protocolVersion, '2025-06-18');
+	});
+
+	it('hands off WebSocket-upgrade requests to the next handler', async () => {
+		const handler = createHarperHttpHandler('application');
+		const out = await handler(
+			{
+				method: 'GET',
+				headers: makeHeaders(),
+				isWebSocket: true,
+				user: { username: 'alice' },
+			},
+			() => 'next-handler-result'
+		);
+		assert.equal(out, 'next-handler-result');
+	});
+
+	it('reads chunked body streams (Buffer + string mix)', async () => {
+		const handler = createHarperHttpHandler('application');
+		const body = Readable.from([
+			Buffer.from('{"jsonrpc":"2.0",', 'utf8'),
+			'"id":1,"method":"initialize",',
+			Buffer.from('"params":{"protocolVersion":"2025-06-18"}}', 'utf8'),
+		]);
+		const result = await handler({ method: 'POST', headers: makeHeaders(), body, user: { username: 'alice' } }, next);
+		assert.equal(result.status, 200);
+	});
+
+	it('flips session.initialized via notifications/initialized', async () => {
+		const handler = createHarperHttpHandler('application');
+		const initResult = await handler(
+			{
+				method: 'POST',
+				headers: makeHeaders(),
+				body: bodyStream(
+					JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18' } })
+				),
+				user: { username: 'alice' },
+			},
+			next
+		);
+		const sessionId = initResult.headers['Mcp-Session-Id'];
+
+		const notifResult = await handler(
+			{
+				method: 'POST',
+				headers: makeHeaders({ 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' }),
+				body: bodyStream(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })),
+				user: { username: 'alice' },
+			},
+			next
+		);
+		assert.equal(notifResult.status, 202);
+		assert.equal(notifResult.body, undefined);
+		const session = await loadSession(sessionId);
+		assert.equal(session.initialized, true);
+	});
+
+	it('returns 405 on GET (no SSE channel in v1)', async () => {
+		const handler = createHarperHttpHandler('application');
+		const result = await handler({ method: 'GET', headers: makeHeaders(), user: { username: 'alice' } }, next);
+		assert.equal(result.status, 405);
+	});
+
+	it('returns empty body (no JSON.stringify) for 202/204', async () => {
+		const handler = createHarperHttpHandler('application');
+		const initResult = await handler(
+			{
+				method: 'POST',
+				headers: makeHeaders(),
+				body: bodyStream(
+					JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18' } })
+				),
+				user: { username: 'alice' },
+			},
+			next
+		);
+		const sessionId = initResult.headers['Mcp-Session-Id'];
+		const notif = await handler(
+			{
+				method: 'POST',
+				headers: makeHeaders({ 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' }),
+				body: bodyStream(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/cancelled' })),
+				user: { username: 'alice' },
+			},
+			next
+		);
+		assert.equal(notif.status, 202);
+		assert.equal(notif.body, undefined);
+	});
+});

--- a/unitTests/components/mcp/index.test.js
+++ b/unitTests/components/mcp/index.test.js
@@ -1,5 +1,13 @@
 const assert = require('node:assert/strict');
-const { registerMcpProfile, createStubHandler } = require('#src/components/mcp/index');
+const indexMod = require('#src/components/mcp/index');
+const {
+	registerMcpProfile,
+	handleApplication,
+	_resetApplicationStartedForTest,
+	_setGetConfigObjForTest,
+	_restoreGetConfigObj,
+} = indexMod;
+const { _setSessionTableForTest } = require('#src/components/mcp/session');
 
 function makeFakeFastify() {
 	const calls = [];
@@ -15,29 +23,36 @@ function makeFakeFastify() {
 	};
 }
 
-function makeFakeReply() {
-	const reply = {
-		statusCode: undefined,
-		headers: {},
-		body: undefined,
-		code(status) {
-			this.statusCode = status;
-			return this;
-		},
-		header(name, value) {
-			this.headers[name] = value;
-			return this;
-		},
-		send(payload) {
-			this.body = payload;
-			return this;
+function makeFakeScope() {
+	const calls = [];
+	return {
+		calls,
+		server: {
+			http(handler, options) {
+				calls.push({ handler, options });
+			},
 		},
 	};
-	return reply;
+}
+
+function makeFakeTable() {
+	return {
+		async put() {},
+		async get() {
+			return undefined;
+		},
+		async delete() {},
+	};
 }
 
 describe('components/mcp/index', () => {
-	describe('registerMcpProfile', () => {
+	beforeEach(() => _setSessionTableForTest(makeFakeTable()));
+	afterEach(() => {
+		_setSessionTableForTest(undefined);
+		_resetApplicationStartedForTest();
+	});
+
+	describe('registerMcpProfile (operations side, Fastify)', () => {
 		it('does nothing when the mcp config block is absent', () => {
 			const host = makeFakeFastify();
 			registerMcpProfile({ profile: 'operations', host, config: {} });
@@ -56,11 +71,7 @@ describe('components/mcp/index', () => {
 
 		it('registers POST /mcp when the operations profile block is present', () => {
 			const host = makeFakeFastify();
-			registerMcpProfile({
-				profile: 'operations',
-				host,
-				config: { mcp: { operations: {} } },
-			});
+			registerMcpProfile({ profile: 'operations', host, config: { mcp: { operations: {} } } });
 			assert.equal(host.calls.length, 1);
 			assert.equal(host.calls[0].path, '/mcp');
 			assert.equal(typeof host.calls[0].handler, 'function');
@@ -69,11 +80,10 @@ describe('components/mcp/index', () => {
 		it('honors a custom mountPath', () => {
 			const host = makeFakeFastify();
 			registerMcpProfile({
-				profile: 'application',
+				profile: 'operations',
 				host,
-				config: { mcp: { application: { mountPath: '/agent' } } },
+				config: { mcp: { operations: { mountPath: '/agent' } } },
 			});
-			assert.equal(host.calls.length, 1);
 			assert.equal(host.calls[0].path, '/agent');
 		});
 
@@ -86,29 +96,58 @@ describe('components/mcp/index', () => {
 				config: { mcp: { operations: {} } },
 				routeOptions: sentinel,
 			});
-			assert.equal(host.calls.length, 1);
 			assert.deepEqual(host.calls[0].options, sentinel);
-			assert.equal(typeof host.calls[0].handler, 'function');
 		});
 	});
 
-	describe('stub handler', () => {
-		it('returns 503 with mcp_not_implemented body for the operations profile', async () => {
-			const handler = createStubHandler('operations');
-			const reply = makeFakeReply();
-			await handler({}, reply);
-			assert.equal(reply.statusCode, 503);
-			assert.equal(reply.headers['Retry-After'], '0');
-			assert.equal(reply.headers['Content-Type'], 'application/json');
-			assert.deepEqual(reply.body, { error: 'mcp_not_implemented', profile: 'operations' });
+	describe('handleApplication (application side, Harper-HTTP)', () => {
+		let configReturn;
+		beforeEach(() => {
+			_setGetConfigObjForTest(() => configReturn);
+		});
+		afterEach(() => {
+			_restoreGetConfigObj();
 		});
 
-		it('returns 503 with mcp_not_implemented body for the application profile', async () => {
-			const handler = createStubHandler('application');
-			const reply = makeFakeReply();
-			await handler({}, reply);
-			assert.equal(reply.statusCode, 503);
-			assert.deepEqual(reply.body, { error: 'mcp_not_implemented', profile: 'application' });
+		it('does nothing when the mcp.application sub-block is absent', () => {
+			configReturn = { mcp: { operations: {} } };
+			const scope = makeFakeScope();
+			handleApplication(scope);
+			assert.equal(scope.calls.length, 0);
+		});
+
+		it('registers via scope.server.http when mcp.application is present', () => {
+			configReturn = { mcp: { application: {} } };
+			const scope = makeFakeScope();
+			handleApplication(scope);
+			assert.equal(scope.calls.length, 1);
+			assert.equal(scope.calls[0].options.urlPath, '/mcp');
+			assert.equal(scope.calls[0].options.after, 'authentication');
+			assert.equal(typeof scope.calls[0].handler, 'function');
+		});
+
+		it('honors a custom mountPath', () => {
+			configReturn = { mcp: { application: { mountPath: '/agent' } } };
+			const scope = makeFakeScope();
+			handleApplication(scope);
+			assert.equal(scope.calls[0].options.urlPath, '/agent');
+		});
+
+		it('is idempotent on repeated invocations', () => {
+			configReturn = { mcp: { application: {} } };
+			const scopeA = makeFakeScope();
+			const scopeB = makeFakeScope();
+			handleApplication(scopeA);
+			handleApplication(scopeB);
+			assert.equal(scopeA.calls.length, 1);
+			assert.equal(scopeB.calls.length, 0);
+		});
+
+		it('does nothing when getConfigObj returns undefined', () => {
+			configReturn = undefined;
+			const scope = makeFakeScope();
+			handleApplication(scope);
+			assert.equal(scope.calls.length, 0);
 		});
 	});
 });

--- a/unitTests/components/mcp/index.test.js
+++ b/unitTests/components/mcp/index.test.js
@@ -11,15 +11,20 @@ const { _setSessionTableForTest } = require('#src/components/mcp/session');
 
 function makeFakeFastify() {
 	const calls = [];
+	function record(method) {
+		return function (path, optsOrHandler, maybeHandler) {
+			if (typeof optsOrHandler === 'function') {
+				calls.push({ method, path, options: undefined, handler: optsOrHandler });
+			} else {
+				calls.push({ method, path, options: optsOrHandler, handler: maybeHandler });
+			}
+		};
+	}
 	return {
 		calls,
-		post(path, optsOrHandler, maybeHandler) {
-			if (typeof optsOrHandler === 'function') {
-				calls.push({ path, options: undefined, handler: optsOrHandler });
-			} else {
-				calls.push({ path, options: optsOrHandler, handler: maybeHandler });
-			}
-		},
+		post: record('post'),
+		get: record('get'),
+		delete: record('delete'),
 	};
 }
 
@@ -69,25 +74,31 @@ describe('components/mcp/index', () => {
 			assert.equal(host.calls.length, 0);
 		});
 
-		it('registers POST /mcp when the operations profile block is present', () => {
+		it('registers POST/GET/DELETE on /mcp when the operations profile block is present', () => {
 			const host = makeFakeFastify();
 			registerMcpProfile({ profile: 'operations', host, config: { mcp: { operations: {} } } });
-			assert.equal(host.calls.length, 1);
-			assert.equal(host.calls[0].path, '/mcp');
-			assert.equal(typeof host.calls[0].handler, 'function');
+			assert.equal(host.calls.length, 3);
+			assert.deepEqual(
+				host.calls.map((c) => c.method),
+				['post', 'get', 'delete']
+			);
+			for (const call of host.calls) {
+				assert.equal(call.path, '/mcp');
+				assert.equal(typeof call.handler, 'function');
+			}
 		});
 
-		it('honors a custom mountPath', () => {
+		it('honors a custom mountPath on all three methods', () => {
 			const host = makeFakeFastify();
 			registerMcpProfile({
 				profile: 'operations',
 				host,
 				config: { mcp: { operations: { mountPath: '/agent' } } },
 			});
-			assert.equal(host.calls[0].path, '/agent');
+			for (const call of host.calls) assert.equal(call.path, '/agent');
 		});
 
-		it('forwards routeOptions to the host as the second argument', () => {
+		it('forwards routeOptions to every method registration', () => {
 			const host = makeFakeFastify();
 			const sentinel = { preValidation: ['fake-auth-handler'] };
 			registerMcpProfile({
@@ -96,7 +107,7 @@ describe('components/mcp/index', () => {
 				config: { mcp: { operations: {} } },
 				routeOptions: sentinel,
 			});
-			assert.deepEqual(host.calls[0].options, sentinel);
+			for (const call of host.calls) assert.deepEqual(call.options, sentinel);
 		});
 	});
 

--- a/unitTests/components/mcp/jsonrpc.test.js
+++ b/unitTests/components/mcp/jsonrpc.test.js
@@ -1,0 +1,112 @@
+const assert = require('node:assert/strict');
+const {
+	JSONRPC_VERSION,
+	ERROR_CODES,
+	parseMessage,
+	isClientFireAndForget,
+	buildSuccess,
+	buildError,
+} = require('#src/components/mcp/jsonrpc');
+
+describe('mcp/jsonrpc', () => {
+	describe('parseMessage', () => {
+		it('parses a well-formed request', () => {
+			const result = parseMessage('{"jsonrpc":"2.0","id":1,"method":"foo","params":{"a":1}}');
+			assert.equal(result.ok, true);
+			assert.deepEqual(result.message, { jsonrpc: '2.0', id: 1, method: 'foo', params: { a: 1 } });
+		});
+
+		it('parses a notification (no id)', () => {
+			const result = parseMessage('{"jsonrpc":"2.0","method":"notifications/initialized"}');
+			assert.equal(result.ok, true);
+			assert.equal(result.message.method, 'notifications/initialized');
+		});
+
+		it('parses a success response', () => {
+			const result = parseMessage('{"jsonrpc":"2.0","id":2,"result":{"x":1}}');
+			assert.equal(result.ok, true);
+		});
+
+		it('parses an error response', () => {
+			const result = parseMessage('{"jsonrpc":"2.0","id":3,"error":{"code":-32601,"message":"x"}}');
+			assert.equal(result.ok, true);
+		});
+
+		it('returns PARSE_ERROR on invalid JSON', () => {
+			const result = parseMessage('{not json');
+			assert.equal(result.ok, false);
+			assert.equal(result.code, ERROR_CODES.PARSE_ERROR);
+		});
+
+		it('returns INVALID_REQUEST when body is an array (batches not supported)', () => {
+			const result = parseMessage('[{"jsonrpc":"2.0","id":1,"method":"foo"}]');
+			assert.equal(result.ok, false);
+			assert.equal(result.code, ERROR_CODES.INVALID_REQUEST);
+		});
+
+		it('returns INVALID_REQUEST when body is not an object', () => {
+			assert.equal(parseMessage('null').ok, false);
+			assert.equal(parseMessage('42').ok, false);
+			assert.equal(parseMessage('"str"').ok, false);
+		});
+
+		it('returns INVALID_REQUEST when jsonrpc field is wrong', () => {
+			const result = parseMessage('{"jsonrpc":"1.0","id":1,"method":"foo"}');
+			assert.equal(result.ok, false);
+			assert.equal(result.code, ERROR_CODES.INVALID_REQUEST);
+		});
+
+		it('returns INVALID_REQUEST when method, result, and error are all missing', () => {
+			const result = parseMessage('{"jsonrpc":"2.0","id":1}');
+			assert.equal(result.ok, false);
+			assert.equal(result.code, ERROR_CODES.INVALID_REQUEST);
+		});
+	});
+
+	describe('isClientFireAndForget', () => {
+		it('is true for a notification (no id)', () => {
+			assert.equal(isClientFireAndForget({ jsonrpc: '2.0', method: 'foo' }), true);
+		});
+
+		it('is true for a success response (has result, even with id)', () => {
+			assert.equal(isClientFireAndForget({ jsonrpc: '2.0', id: 1, result: 'ok' }), true);
+		});
+
+		it('is true for an error response', () => {
+			assert.equal(isClientFireAndForget({ jsonrpc: '2.0', id: 1, error: { code: -1, message: 'x' } }), true);
+		});
+
+		it('is false for a real request (has id and method)', () => {
+			assert.equal(isClientFireAndForget({ jsonrpc: '2.0', id: 1, method: 'foo' }), false);
+		});
+	});
+
+	describe('buildSuccess', () => {
+		it('shapes a success response', () => {
+			assert.deepEqual(buildSuccess(7, { foo: 'bar' }), {
+				jsonrpc: '2.0',
+				id: 7,
+				result: { foo: 'bar' },
+			});
+		});
+	});
+
+	describe('buildError', () => {
+		it('shapes an error response without data', () => {
+			assert.deepEqual(buildError(7, ERROR_CODES.METHOD_NOT_FOUND, 'nope'), {
+				jsonrpc: '2.0',
+				id: 7,
+				error: { code: -32601, message: 'nope' },
+			});
+		});
+
+		it('includes data when provided', () => {
+			const err = buildError(7, ERROR_CODES.INVALID_PARAMS, 'bad', { field: 'x' });
+			assert.deepEqual(err.error, { code: -32602, message: 'bad', data: { field: 'x' } });
+		});
+	});
+
+	it('exports the JSONRPC_VERSION constant', () => {
+		assert.equal(JSONRPC_VERSION, '2.0');
+	});
+});

--- a/unitTests/components/mcp/lifecycle.test.js
+++ b/unitTests/components/mcp/lifecycle.test.js
@@ -1,0 +1,104 @@
+const assert = require('node:assert/strict');
+const {
+	PROTOCOL_VERSION_PREFERRED,
+	PROTOCOL_VERSION_BACKCOMPAT,
+	SUPPORTED_PROTOCOL_VERSIONS,
+	SERVER_INFO,
+	SERVER_CAPABILITIES,
+	handleInitialize,
+	handleInitialized,
+} = require('#src/components/mcp/lifecycle');
+const { _setSessionTableForTest, loadSession } = require('#src/components/mcp/session');
+
+function makeFakeTable() {
+	const store = new Map();
+	return {
+		async put(record) {
+			store.set(record.id, { ...record });
+		},
+		async get(id) {
+			const r = store.get(id);
+			return r ? { ...r } : undefined;
+		},
+		async delete(id) {
+			store.delete(id);
+		},
+	};
+}
+
+describe('mcp/lifecycle', () => {
+	beforeEach(() => _setSessionTableForTest(makeFakeTable()));
+	afterEach(() => _setSessionTableForTest(undefined));
+
+	describe('exported constants', () => {
+		it('lists the supported protocol versions', () => {
+			assert.deepEqual([...SUPPORTED_PROTOCOL_VERSIONS], [PROTOCOL_VERSION_PREFERRED, PROTOCOL_VERSION_BACKCOMPAT]);
+		});
+
+		it('advertises tools.listChanged, resources.listChanged, logging capabilities', () => {
+			assert.equal(SERVER_CAPABILITIES.tools.listChanged, true);
+			assert.equal(SERVER_CAPABILITIES.resources.listChanged, true);
+			assert.deepEqual(SERVER_CAPABILITIES.logging, {});
+		});
+
+		it('exposes server info with name "harper-mcp" and a version string', () => {
+			assert.equal(SERVER_INFO.name, 'harper-mcp');
+			assert.equal(typeof SERVER_INFO.version, 'string');
+			assert.ok(SERVER_INFO.version.length > 0);
+		});
+	});
+
+	describe('handleInitialize', () => {
+		it('accepts the preferred protocol version and creates a session', async () => {
+			const outcome = await handleInitialize({ protocolVersion: '2025-06-18' }, 'alice');
+			assert.equal(outcome.ok, true);
+			assert.equal(outcome.session.user, 'alice');
+			assert.equal(outcome.session.protocolVersion, '2025-06-18');
+			assert.equal(outcome.session.initialized, false);
+			assert.equal(outcome.result.protocolVersion, '2025-06-18');
+			assert.deepEqual(outcome.result.capabilities, SERVER_CAPABILITIES);
+		});
+
+		it('accepts the backcompat protocol version', async () => {
+			const outcome = await handleInitialize({ protocolVersion: '2025-03-26' }, 'bob');
+			assert.equal(outcome.ok, true);
+			assert.equal(outcome.session.protocolVersion, '2025-03-26');
+			assert.equal(outcome.result.protocolVersion, '2025-03-26');
+		});
+
+		it('rejects an unsupported protocol version with the supported list', async () => {
+			const outcome = await handleInitialize({ protocolVersion: '2024-01-01' }, 'alice');
+			assert.equal(outcome.ok, false);
+			assert.match(outcome.reason, /2024-01-01/);
+			assert.deepEqual([...outcome.supportedVersions], [...SUPPORTED_PROTOCOL_VERSIONS]);
+		});
+
+		it('rejects missing protocolVersion', async () => {
+			const outcome = await handleInitialize({}, 'alice');
+			assert.equal(outcome.ok, false);
+		});
+
+		it('rejects a non-string protocolVersion', async () => {
+			const outcome = await handleInitialize({ protocolVersion: 1 }, 'alice');
+			assert.equal(outcome.ok, false);
+		});
+	});
+
+	describe('handleInitialized', () => {
+		it('flips initialized to true and persists', async () => {
+			const init = await handleInitialize({ protocolVersion: '2025-06-18' }, 'alice');
+			assert.equal(init.session.initialized, false);
+			const updated = await handleInitialized(init.session);
+			assert.equal(updated.initialized, true);
+			const reloaded = await loadSession(init.session.id);
+			assert.equal(reloaded.initialized, true);
+		});
+
+		it('is idempotent — calling on already-initialized session returns it unchanged', async () => {
+			const init = await handleInitialize({ protocolVersion: '2025-06-18' }, 'alice');
+			const first = await handleInitialized(init.session);
+			const second = await handleInitialized(first);
+			assert.equal(second.initialized, true);
+		});
+	});
+});

--- a/unitTests/components/mcp/session.test.js
+++ b/unitTests/components/mcp/session.test.js
@@ -1,0 +1,107 @@
+const assert = require('node:assert/strict');
+const {
+	createSession,
+	loadSession,
+	saveSession,
+	deleteSession,
+	touchSession,
+	_setSessionTableForTest,
+} = require('#src/components/mcp/session');
+
+function makeFakeTable() {
+	const store = new Map();
+	return {
+		store,
+		async put(record) {
+			store.set(record.id, { ...record });
+		},
+		async get(id) {
+			const r = store.get(id);
+			return r ? { ...r } : undefined;
+		},
+		async delete(id) {
+			store.delete(id);
+		},
+	};
+}
+
+describe('mcp/session', () => {
+	let fake;
+	beforeEach(() => {
+		fake = makeFakeTable();
+		_setSessionTableForTest(fake);
+	});
+	afterEach(() => {
+		_setSessionTableForTest(undefined);
+	});
+
+	describe('createSession', () => {
+		it('generates a UUID id, persists, and returns the record', async () => {
+			const record = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+			assert.match(record.id, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+			assert.equal(record.user, 'alice');
+			assert.equal(record.protocolVersion, '2025-06-18');
+			assert.equal(record.initialized, false);
+			assert.equal(typeof record.createdAt, 'number');
+			assert.equal(record.lastActivity, record.createdAt);
+			assert.deepEqual(fake.store.get(record.id), record);
+		});
+
+		it('generates distinct ids', async () => {
+			const a = await createSession({ user: 'u', protocolVersion: '2025-06-18' });
+			const b = await createSession({ user: 'u', protocolVersion: '2025-06-18' });
+			assert.notEqual(a.id, b.id);
+		});
+	});
+
+	describe('loadSession', () => {
+		it('returns the record when present', async () => {
+			const created = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+			const loaded = await loadSession(created.id);
+			assert.deepEqual(loaded, created);
+		});
+
+		it('returns null when the id is unknown', async () => {
+			const loaded = await loadSession('not-a-session');
+			assert.equal(loaded, null);
+		});
+	});
+
+	describe('saveSession', () => {
+		it('persists changes', async () => {
+			const created = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+			await saveSession({ ...created, initialized: true });
+			const reloaded = await loadSession(created.id);
+			assert.equal(reloaded.initialized, true);
+		});
+	});
+
+	describe('deleteSession', () => {
+		it('removes the record and subsequent loads return null', async () => {
+			const created = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+			await deleteSession(created.id);
+			assert.equal(await loadSession(created.id), null);
+		});
+	});
+
+	describe('touchSession', () => {
+		it('updates lastActivity and returns the new record', async () => {
+			const created = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+			// Force a measurable delta even on fast clocks.
+			await new Promise((r) => setTimeout(r, 5));
+			const touched = await touchSession(created);
+			assert.ok(touched.lastActivity > created.lastActivity);
+			const reloaded = await loadSession(created.id);
+			assert.equal(reloaded.lastActivity, touched.lastActivity);
+		});
+
+		it('preserves other fields', async () => {
+			const created = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+			const initialized = { ...created, initialized: true };
+			const touched = await touchSession(initialized);
+			assert.equal(touched.initialized, true);
+			assert.equal(touched.user, 'alice');
+			assert.equal(touched.protocolVersion, '2025-06-18');
+		});
+	});
+});

--- a/unitTests/components/mcp/transport.test.js
+++ b/unitTests/components/mcp/transport.test.js
@@ -224,12 +224,24 @@ describe('mcp/transport', () => {
 			const res = await handleMcpRequest(makeReq({ method: 'GET' }));
 			assert.equal(res.status, 405);
 		});
+
+		it('Allow header lists only POST when DELETE is disabled (RFC 9110 §9.1)', async () => {
+			const res = await handleMcpRequest(makeReq({ method: 'GET' }));
+			assert.equal(res.headers.Allow, 'POST');
+		});
+
+		it('Allow header lists POST + DELETE when DELETE is enabled', async () => {
+			envOverrides.mcp_session_allowClientDelete = true;
+			const res = await handleMcpRequest(makeReq({ method: 'GET' }));
+			assert.equal(res.headers.Allow, 'POST, DELETE');
+		});
 	});
 
 	describe('DELETE /mcp', () => {
 		it('returns 405 when allowClientDelete is not configured', async () => {
 			const res = await handleMcpRequest(makeReq({ method: 'DELETE' }));
 			assert.equal(res.status, 405);
+			assert.equal(res.headers.Allow, 'POST');
 		});
 
 		it('terminates the session and returns 204 when allowClientDelete is true', async () => {
@@ -358,9 +370,17 @@ describe('mcp/transport', () => {
 	});
 
 	describe('unsupported HTTP methods', () => {
-		it('returns 405 for PUT', async () => {
+		it('returns 405 for PUT with accurate Allow header', async () => {
 			const res = await handleMcpRequest(makeReq({ method: 'PUT' }));
 			assert.equal(res.status, 405);
+			assert.equal(res.headers.Allow, 'POST');
+		});
+
+		it('PUT 405 advertises DELETE when allowClientDelete is enabled', async () => {
+			envOverrides.mcp_session_allowClientDelete = true;
+			const res = await handleMcpRequest(makeReq({ method: 'PUT' }));
+			assert.equal(res.status, 405);
+			assert.equal(res.headers.Allow, 'POST, DELETE');
 		});
 	});
 });

--- a/unitTests/components/mcp/transport.test.js
+++ b/unitTests/components/mcp/transport.test.js
@@ -1,0 +1,366 @@
+const assert = require('node:assert/strict');
+const rewire = require('rewire');
+const transport_mod = rewire('#src/components/mcp/transport');
+const { handleMcpRequest } = transport_mod;
+const { _setSessionTableForTest, createSession, loadSession } = require('#src/components/mcp/session');
+
+function makeFakeTable() {
+	const store = new Map();
+	return {
+		store,
+		async put(record) {
+			store.set(record.id, { ...record });
+		},
+		async get(id) {
+			const r = store.get(id);
+			return r ? { ...r } : undefined;
+		},
+		async delete(id) {
+			store.delete(id);
+		},
+	};
+}
+
+function makeReq(overrides = {}) {
+	return {
+		method: 'POST',
+		headers: {},
+		body: '{}',
+		user: 'alice',
+		profile: 'application',
+		...overrides,
+	};
+}
+
+function jsonRpc(id, method, params) {
+	const msg = { jsonrpc: '2.0', method };
+	if (id !== undefined) msg.id = id;
+	if (params !== undefined) msg.params = params;
+	return JSON.stringify(msg);
+}
+
+describe('mcp/transport', () => {
+	let envOverrides;
+	const envStub = {
+		get(key) {
+			return envOverrides[key];
+		},
+	};
+
+	beforeEach(() => {
+		envOverrides = {};
+		transport_mod.__set__('env', envStub);
+		_setSessionTableForTest(makeFakeTable());
+	});
+
+	afterEach(() => {
+		_setSessionTableForTest(undefined);
+	});
+
+	describe('POST initialize', () => {
+		it('creates a session and returns 200 + Mcp-Session-Id', async () => {
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(1, 'initialize', { protocolVersion: '2025-06-18' }),
+				})
+			);
+			assert.equal(res.status, 200);
+			assert.match(res.headers['Mcp-Session-Id'], /^[0-9a-f-]{36}$/);
+			assert.equal(res.jsonBody.id, 1);
+			assert.equal(res.jsonBody.result.protocolVersion, '2025-06-18');
+			assert.equal(res.jsonBody.result.serverInfo.name, 'harper-mcp');
+			assert.equal(res.jsonBody.result.capabilities.tools.listChanged, true);
+		});
+
+		it('rejects unsupported protocolVersion with 400 and the supported list', async () => {
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(1, 'initialize', { protocolVersion: '1999-01-01' }),
+				})
+			);
+			assert.equal(res.status, 400);
+			assert.equal(res.jsonBody.error.code, -32602);
+			assert.deepEqual([...res.jsonBody.error.data.supportedVersions], ['2025-06-18', '2025-03-26']);
+		});
+
+		it('rejects missing protocolVersion with 400', async () => {
+			const res = await handleMcpRequest(makeReq({ body: jsonRpc(1, 'initialize') }));
+			assert.equal(res.status, 400);
+		});
+	});
+
+	describe('POST after initialize', () => {
+		let sessionId;
+		beforeEach(async () => {
+			const res = await handleMcpRequest(
+				makeReq({ body: jsonRpc(1, 'initialize', { protocolVersion: '2025-06-18' }) })
+			);
+			sessionId = res.headers['Mcp-Session-Id'];
+		});
+
+		it('returns 400 when Mcp-Session-Id header is missing', async () => {
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(2, 'tools/list'),
+					headers: { 'mcp-protocol-version': '2025-06-18' },
+				})
+			);
+			assert.equal(res.status, 400);
+			assert.equal(res.jsonBody.error.code, -32600);
+		});
+
+		it('returns 404 when Mcp-Session-Id is unknown', async () => {
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(2, 'tools/list'),
+					headers: { 'mcp-session-id': 'not-a-session', 'mcp-protocol-version': '2025-06-18' },
+				})
+			);
+			assert.equal(res.status, 404);
+		});
+
+		it('returns 403 when session belongs to a different user', async () => {
+			const res = await handleMcpRequest(
+				makeReq({
+					user: 'mallory',
+					body: jsonRpc(2, 'tools/list'),
+					headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' },
+				})
+			);
+			assert.equal(res.status, 403);
+		});
+
+		it('returns 400 when MCP-Protocol-Version is unsupported', async () => {
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(2, 'tools/list'),
+					headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '1999-01-01' },
+				})
+			);
+			assert.equal(res.status, 400);
+		});
+
+		it('returns 400 when MCP-Protocol-Version mismatches the session version', async () => {
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(2, 'tools/list'),
+					headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-03-26' },
+				})
+			);
+			assert.equal(res.status, 400);
+			assert.match(res.jsonBody.error.message, /mismatch/);
+		});
+
+		it('treats missing MCP-Protocol-Version as 2025-03-26 (spec compatibility rule)', async () => {
+			// Session is on 2025-06-18 from initialize above, so missing header
+			// (treated as 2025-03-26) should mismatch.
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(2, 'tools/list'),
+					headers: { 'mcp-session-id': sessionId },
+				})
+			);
+			assert.equal(res.status, 400);
+		});
+
+		it('accepts a matching MCP-Protocol-Version and returns Method-not-found for unknown methods', async () => {
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(2, 'tools/list'),
+					headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' },
+				})
+			);
+			assert.equal(res.status, 200);
+			assert.equal(res.jsonBody.error.code, -32601);
+			assert.match(res.jsonBody.error.message, /tools\/list/);
+		});
+
+		it('returns 202 on notifications/initialized and flips session.initialized', async () => {
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(undefined, 'notifications/initialized'),
+					headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' },
+				})
+			);
+			assert.equal(res.status, 202);
+			const session = await loadSession(sessionId);
+			assert.equal(session.initialized, true);
+		});
+
+		it('returns 202 on any client notification', async () => {
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(undefined, 'notifications/cancelled'),
+					headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' },
+				})
+			);
+			assert.equal(res.status, 202);
+		});
+
+		it('returns 202 on a client response frame (result envelope)', async () => {
+			const res = await handleMcpRequest(
+				makeReq({
+					body: JSON.stringify({ jsonrpc: '2.0', id: 99, result: 'ok' }),
+					headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' },
+				})
+			);
+			assert.equal(res.status, 202);
+		});
+
+		it('returns 400 PARSE_ERROR on invalid JSON', async () => {
+			const res = await handleMcpRequest(
+				makeReq({
+					body: '{not json',
+					headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' },
+				})
+			);
+			assert.equal(res.status, 400);
+			assert.equal(res.jsonBody.error.code, -32700);
+		});
+	});
+
+	describe('GET /mcp', () => {
+		it('always returns 405 in v1 (no server-push channel yet)', async () => {
+			const res = await handleMcpRequest(makeReq({ method: 'GET' }));
+			assert.equal(res.status, 405);
+		});
+	});
+
+	describe('DELETE /mcp', () => {
+		it('returns 405 when allowClientDelete is not configured', async () => {
+			const res = await handleMcpRequest(makeReq({ method: 'DELETE' }));
+			assert.equal(res.status, 405);
+		});
+
+		it('terminates the session and returns 204 when allowClientDelete is true', async () => {
+			envOverrides.mcp_session_allowClientDelete = true;
+			const session = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+			const res = await handleMcpRequest(makeReq({ method: 'DELETE', headers: { 'mcp-session-id': session.id } }));
+			assert.equal(res.status, 204);
+			assert.equal(await loadSession(session.id), null);
+		});
+
+		it('returns 400 when allowClientDelete is true but session-id is missing', async () => {
+			envOverrides.mcp_session_allowClientDelete = true;
+			const res = await handleMcpRequest(makeReq({ method: 'DELETE' }));
+			assert.equal(res.status, 400);
+		});
+
+		it('returns 404 when session-id is unknown', async () => {
+			envOverrides.mcp_session_allowClientDelete = true;
+			const res = await handleMcpRequest(makeReq({ method: 'DELETE', headers: { 'mcp-session-id': 'nope' } }));
+			assert.equal(res.status, 404);
+		});
+
+		it('returns 403 when session belongs to a different user', async () => {
+			envOverrides.mcp_session_allowClientDelete = true;
+			const session = await createSession({ user: 'alice', protocolVersion: '2025-06-18' });
+			const res = await handleMcpRequest(
+				makeReq({ method: 'DELETE', user: 'mallory', headers: { 'mcp-session-id': session.id } })
+			);
+			assert.equal(res.status, 403);
+		});
+	});
+
+	describe('Origin validation', () => {
+		it('accepts any Origin when allow-list is empty/unset', async () => {
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(1, 'initialize', { protocolVersion: '2025-06-18' }),
+					headers: { origin: 'https://anywhere.example.com' },
+				})
+			);
+			assert.equal(res.status, 200);
+		});
+
+		it('accepts when Origin is missing (curl, server-to-server)', async () => {
+			envOverrides.http_corsAccessList = ['https://app.example.com'];
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(1, 'initialize', { protocolVersion: '2025-06-18' }),
+				})
+			);
+			assert.equal(res.status, 200);
+		});
+
+		it('accepts any Origin when CORS is enabled but allow-list is empty', async () => {
+			envOverrides.http_cors = true;
+			envOverrides.http_corsAccessList = [];
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(1, 'initialize', { protocolVersion: '2025-06-18' }),
+					headers: { origin: 'https://anywhere.example.com' },
+				})
+			);
+			assert.equal(res.status, 200);
+		});
+
+		it('accepts any Origin when CORS is disabled even if allow-list is set', async () => {
+			envOverrides.http_cors = false;
+			envOverrides.http_corsAccessList = ['https://only-me.example.com'];
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(1, 'initialize', { protocolVersion: '2025-06-18' }),
+					headers: { origin: 'https://evil.example.com' },
+				})
+			);
+			assert.equal(res.status, 200);
+		});
+
+		it('returns 403 when CORS is enabled and Origin is not in the allow-list', async () => {
+			envOverrides.http_cors = true;
+			envOverrides.http_corsAccessList = ['https://app.example.com'];
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(1, 'initialize', { protocolVersion: '2025-06-18' }),
+					headers: { origin: 'https://evil.example.com' },
+				})
+			);
+			assert.equal(res.status, 403);
+		});
+
+		it('uses the operations CORS list for the operations profile', async () => {
+			envOverrides.operationsApi_network_cors = true;
+			envOverrides.operationsApi_network_corsAccessList = ['https://ops.example.com'];
+			const res = await handleMcpRequest(
+				makeReq({
+					profile: 'operations',
+					body: jsonRpc(1, 'initialize', { protocolVersion: '2025-06-18' }),
+					headers: { origin: 'https://app.example.com' }, // app list, not ops
+				})
+			);
+			assert.equal(res.status, 403);
+		});
+
+		it('accepts Origin in the allow-list', async () => {
+			envOverrides.http_cors = true;
+			envOverrides.http_corsAccessList = ['https://app.example.com'];
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(1, 'initialize', { protocolVersion: '2025-06-18' }),
+					headers: { origin: 'https://app.example.com' },
+				})
+			);
+			assert.equal(res.status, 200);
+		});
+
+		it('honors the "*" wildcard in the allow-list', async () => {
+			envOverrides.http_cors = true;
+			envOverrides.http_corsAccessList = ['*'];
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(1, 'initialize', { protocolVersion: '2025-06-18' }),
+					headers: { origin: 'https://anywhere.example.com' },
+				})
+			);
+			assert.equal(res.status, 200);
+		});
+	});
+
+	describe('unsupported HTTP methods', () => {
+		it('returns 405 for PUT', async () => {
+			const res = await handleMcpRequest(makeReq({ method: 'PUT' }));
+			assert.equal(res.status, 405);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Replaces the #613 503 stub with a real MCP Streamable HTTP transport per spec [rev 2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http). Wires the application-profile registration that #613 deferred. Transport plumbing only — tools/resources/listChanged/rate-limit/audit stay out of scope (sub-issues #615-#620). Unknown JSON-RPC methods return `-32601 Method-not-found` so the dispatcher is ready for them to plug in.

Closes #614
Tracking: #465 (sub-issue #2 of 11)

## What this PR lands

- **`components/mcp/transport.ts`** — framework-agnostic core. Single entry `handleMcpRequest(normRequest)`. Implements: Origin validation, Mcp-Session-Id lifecycle, MCP-Protocol-Version enforcement, status code mapping (200/202/400/403/404/405), JSON-RPC envelope parse + standard error codes.
- **`components/mcp/adapters/fastify.ts`** — operations-port adapter. Maps Fastify `(request, reply)` to the normalized shape. Now passes the already-parsed JSON body straight through (no stringify/re-parse).
- **`components/mcp/adapters/harperHttp.ts`** — application-port adapter. Maps Harper's HTTP handler `(request, next)` to the normalized shape. Returns `{status, headers, body}` for serialization through `server/serverHelpers/contentTypes.ts`.
- **`components/mcp/session.ts`** — wraps a new `system.mcp_session` system table. **No per-thread Map, no custom timer or sweep loop** — Harper's native `Table.setTTLExpiration({expiration, eviction})` handles idle eviction. Every `table.put` updates record `version`, which gives sliding-window idle semantics for free. Default `idleTimeoutSeconds = 1800` (30 min) when omitted.
- **`components/mcp/lifecycle.ts`** — `handleInitialize` (protocol negotiation + session create) and `handleInitialized` (sets `initialized: true`). Supports `2025-06-18` (preferred) and `2025-03-26` (backcompat).
- **`components/mcp/jsonrpc.ts`** — JSON-RPC 2.0 envelope parse + builders + error codes.
- **`components/mcp/index.ts`** — rewritten. Exports `registerMcpProfile(...)` (Fastify entry for ops) and `handleApplication(scope)` (Trusted Resource Plugin entry for app). Single module-level guard prevents the application registration from firing twice.
- **`components/componentLoader.ts`** — adds `mcp: mcpComponent` to `TRUSTED_RESOURCE_PLUGINS`.
- **`resources/databases.ts`** — adds `mcp_session` to `NON_REPLICATING_SYSTEM_TABLES`.
- **`server/operationsServer.ts`** — switches MCP route's preValidation from `authHandler` to `authAndEnsureUserOnRequest` (puts user on `req.hdb_user` instead of `req.body.hdb_user`, which would otherwise contaminate the JSON-RPC envelope).
- **85 unit tests + 8 integration tests.**

## Architecture: shared core + native streaming per adapter

The operations port runs Fastify; the application port runs Harper's own HTTP handler abstraction. Spec-critical logic lives in `transport.ts`; each adapter passes streaming through its native idiom. Both adapters route SSE through the existing serializer at `server/serverHelpers/contentTypes.ts:128-162`. No new Fastify dependency in the component (the adapter is what touches Fastify).

## Where to put attention

- **`components/mcp/transport.ts`** — every spec MUST lives here. The handler-side narrowing pattern (`if (parsed.ok !== true) { const fail = parsed as {...} }`) is intentional and commented: tsconfig is non-strict so TS can't narrow discriminated unions from `!== true` without help.
- **`components/mcp/session.ts`** — TTL is configured once at component init from `mcp.session.idleTimeoutSeconds` (default 1800s) + 60s eviction window. Live reconfig isn't supported in v1 (operator restart picks up the new value).
- **`server/operationsServer.ts` preValidation swap** — `authHandler` mutates `req.body`; for the JSON-RPC envelope we need it untouched, so we use `authAndEnsureUserOnRequest` which puts the authenticated user on `req.hdb_user` instead.

## Cross-model review (Gemini 0.42.0)

Completed. Findings applied:

| # | Finding | Disposition |
|---|---|---|
| 1 | Origin validation missed the CORS enablement flag and `'*'` wildcard | **Fixed** — now mirrors `security/auth.ts:65` pattern (check `HTTP_CORS`/`OPERATIONSAPI_NETWORK_CORS`, honor `'*'`). |
| 2 | `void touchSession()` could resurrect a concurrently-deleted session | **Fixed** — awaited. ~1ms hot-path cost vs the race risk; clear win. |
| 3 | Fastify adapter re-stringified an already-parsed JSON body | **Fixed** — `parseMessage` now accepts string or object. |
| 4 | Session id logged at full length on user-mismatch warn | **Fixed** — masked to first 8 chars. |
| 5 | No try/catch around `handleMcpRequest` (uncaught Harper-table errors → opaque 500) | **Fixed** — wrapped, returns `-32603 Internal Error` on failure. |
| 6 | Type casts on discriminated unions are noisy | **Held** — non-strict tsconfig prevents narrowing; cast is required. Commented in code. |
| 7 | Header-normalization DRY between adapters | **Held** — ~6 LOC each, different input types; extraction's overhead beats the dedup gain. |

## Verification

```bash
npm run build       # clean
npm run lint:required # clean
npx mocha unitTests/components/mcp/**/*.test.js
# Expected: 85 passing

# Manual smoke (with mcp.operations: {} in config):
curl -sS -X POST http://localhost:9925/mcp \
  -H 'Origin: http://localhost' \
  -H 'Accept: application/json, text/event-stream' \
  -H 'Authorization: Bearer ...' \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}' -i
# Expected: 200, Mcp-Session-Id response header, body with serverInfo + capabilities.
```

## Test plan

- [x] 85 targeted unit tests pass locally
- [x] Build clean for files in this PR
- [x] Lint clean
- [x] Cross-model review (Gemini) findings applied
- [ ] CI green across the full matrix (Node 20/22/24, Bun, Windows shards)
- [ ] Manual smoke against a local Harper
- [ ] Regression: operations API endpoints unchanged when `mcp:` absent

## Out of scope (deferred to other sub-issues)

- Tools (`tools/list`, `tools/call`) — #615/#617/#618
- Resources (`resources/list`, `read`) — #616
- `listChanged` notifications via GET /mcp SSE channel — #619
- Audit logging + rate limiting — #620
- Stdio CLI (`harper mcp`) — #621
- `Last-Event-ID` resumability — deferred to MCP v2

## Notes

- **Sessions are intentionally not browser-bound.** The MCP spec's 404-on-unknown-session-id mechanism is the universal recovery path: restart, idle eviction, manual termination, cross-thread miss — all spec-equivalent to the client.
- **Multi-instance deployments:** because sessions are LMDB-backed (via the Harper table), any thread can find any session — round-robin LBs without sticky affinity are fine. (This was the chief operational concern weighed against pure in-memory storage.)
- Generated by an AI agent (Claude Opus 4.7) following the Harper Engineering Process & Guidelines lifecycle.