### PR TITLE
Emit aggregate analytics for scope.models.embed / generate

### DIFF
--- a/resources/models/Models.ts
+++ b/resources/models/Models.ts
@@ -2,6 +2,7 @@ import { _assignPackageExport } from '../../globals.js';
 import { contextStorage } from '../transaction.ts';
 import { resolveEmbedding, resolveGenerative } from './backendRegistry.ts';
 import { getModelCallAnalyticsWriter, type ModelCallAnalyticsWriter, type ModelCallRecord } from './analyticsTable.ts';
+import { recordAction } from '../analytics/write.ts';
 import { ServerError } from '../../utility/errors/hdbError.ts';
 import { runAgentLoop, runAgentLoopStream } from './agentLoop.ts';
 import type {
@@ -19,6 +20,7 @@ import type {
 } from './types.ts';
 
 type CallMethod = ModelCallRecord['method'];
+type MetricEmitter = (value: number, metric: string, path?: string) => void;
 
 /**
  * Process-wide singleton. One shared instance serves all Scopes — `scope.models`,
@@ -38,9 +40,15 @@ type CallMethod = ModelCallRecord['method'];
  */
 export class Models implements ModelsContract {
 	#analyticsWriter: ModelCallAnalyticsWriter;
+	#emit: MetricEmitter;
 
-	constructor(analyticsWriter: ModelCallAnalyticsWriter = getModelCallAnalyticsWriter()) {
+	constructor(
+		analyticsWriter: ModelCallAnalyticsWriter = getModelCallAnalyticsWriter(),
+		// DI'd for unit tests; production wires up the module-scope `recordAction`.
+		metricEmitter: MetricEmitter = recordAction
+	) {
 		this.#analyticsWriter = analyticsWriter;
+		this.#emit = metricEmitter;
 	}
 
 	async embed(input: string | string[], opts: EmbedOpts = {}): Promise<Float32Array[]> {
@@ -171,6 +179,17 @@ export class Models implements ModelsContract {
 	): void {
 		const usage = result?.status === 'completed' ? result.usage : undefined;
 		this.#analyticsWriter.write(buildRecord(backend, method, model, accounting, opts, usage, startedAt, true));
+		// Also emit aggregate analytics into hdb_raw_analytics so model usage rolls up
+		// into the same per-period analytics that license enforcement and admin
+		// dashboards consume — mirrors the `db-read` pattern in Table.ts. The detailed
+		// per-call row in hdb_model_calls (above) is for forensics; this is for billing.
+		// Path is the backend name (analogous to tableName for db-read) so dashboards
+		// can break usage down by backend.
+		this.#emit(1, `model-${method}`, backend.name);
+		if (usage) {
+			const tokens = (usage.embeddingTokens ?? 0) + (usage.promptTokens ?? 0) + (usage.completionTokens ?? 0);
+			if (tokens > 0) this.#emit(tokens, `model-${method}-tokens`, backend.name);
+		}
 	}
 
 	#recordFailure(

--- a/unitTests/resources/models/Models.test.js
+++ b/unitTests/resources/models/Models.test.js
@@ -35,14 +35,26 @@ describe('models singleton', () => {
 	});
 });
 
+// Captures (value, metric, path) tuples that Models passes to recordAction.
+// Production wires the module-scoped recordAction; tests pass this spy so we can
+// assert exactly which aggregate metrics are emitted without touching the global
+// analytics pipeline.
+function makeMetricSpy() {
+	const calls = [];
+	const emitter = (value, metric, path) => calls.push({ value, metric, path });
+	return { calls, emitter };
+}
+
 describe('Models facade', () => {
 	let writer;
+	let metricSpy;
 	let models;
 
 	beforeEach(() => {
 		clearRegistry();
 		writer = makeMockWriter();
-		models = new Models(writer);
+		metricSpy = makeMetricSpy();
+		models = new Models(writer, metricSpy.emitter);
 		const test = new TestBackend();
 		setEmbedding('default', test);
 		setGenerative('default', test);
@@ -195,6 +207,115 @@ describe('Models facade', () => {
 			});
 			await assert.rejects(() => models.embed('x'));
 			assert.strictEqual(writer.records[0].error_code, 'aborted');
+		});
+	});
+
+	describe('aggregate analytics emission (recordAction)', () => {
+		it('emits model-embed count=1 with backend name as path on successful embed', async () => {
+			await models.embed('hello');
+			const countCall = metricSpy.calls.find((c) => c.metric === 'model-embed');
+			assert.ok(countCall, 'expected a model-embed metric to be emitted');
+			assert.strictEqual(countCall.value, 1);
+			assert.strictEqual(countCall.path, 'test');
+		});
+
+		it('emits model-embed-tokens with the sum from usage.embeddingTokens', async () => {
+			setEmbedding('default', {
+				name: 'tokenful-embed',
+				capabilities: () => ({ embed: true, generate: false, stream: false, tools: false, adapters: false }),
+				async embed() {
+					return { status: 'completed', output: [new Float32Array(1)], usage: { embeddingTokens: 17 } };
+				},
+			});
+			await models.embed('x');
+			const tokenCall = metricSpy.calls.find((c) => c.metric === 'model-embed-tokens');
+			assert.ok(tokenCall, 'expected model-embed-tokens to be emitted');
+			assert.strictEqual(tokenCall.value, 17);
+			assert.strictEqual(tokenCall.path, 'tokenful-embed');
+		});
+
+		it('omits the tokens metric entirely when usage is absent or zero', async () => {
+			setEmbedding('default', {
+				name: 'no-usage',
+				capabilities: () => ({ embed: true, generate: false, stream: false, tools: false, adapters: false }),
+				async embed() {
+					return { status: 'completed', output: [new Float32Array(1)] };
+				},
+			});
+			await models.embed('x');
+			assert.ok(
+				!metricSpy.calls.some((c) => c.metric.endsWith('-tokens')),
+				'no -tokens metric should be emitted when backend reports no usage'
+			);
+			// Count metric should still be there though.
+			assert.ok(metricSpy.calls.some((c) => c.metric === 'model-embed'));
+		});
+
+		it('sums prompt + completion tokens for generate into a single model-generate-tokens metric', async () => {
+			setGenerative('default', {
+				name: 'tokenful-gen',
+				capabilities: () => ({ embed: false, generate: true, stream: false, tools: false, adapters: false }),
+				async generate() {
+					return {
+						status: 'completed',
+						output: { content: 'hi', finishReason: 'stop' },
+						usage: { promptTokens: 12, completionTokens: 8 },
+					};
+				},
+			});
+			await models.generate('x');
+			const tokenCall = metricSpy.calls.find((c) => c.metric === 'model-generate-tokens');
+			assert.ok(tokenCall, 'expected model-generate-tokens to be emitted');
+			assert.strictEqual(tokenCall.value, 20);
+		});
+
+		it('emits a model-generateStream count + tokens at the end of a successful stream', async () => {
+			setGenerative('default', {
+				name: 'stream-with-usage',
+				capabilities: () => ({ embed: false, generate: true, stream: true, tools: false, adapters: false }),
+				async *generateStream() {
+					yield { deltaContent: 'one ' };
+					yield { deltaContent: 'two' };
+					yield { finishReason: 'stop' };
+				},
+			});
+			for await (const _chunk of models.generateStream('x')) {
+				// drain
+			}
+			// stream backend reports no usage in this test, so only the count metric
+			assert.ok(metricSpy.calls.some((c) => c.metric === 'model-generateStream' && c.value === 1));
+		});
+
+		it('does NOT emit aggregate metrics on failed calls (forensics row still goes to hdb_model_calls)', async () => {
+			setEmbedding('default', {
+				name: 'failing',
+				capabilities: () => ({ embed: true, generate: false, stream: false, tools: false, adapters: false }),
+				async embed() {
+					throw new Error('upstream boom');
+				},
+			});
+			await assert.rejects(() => models.embed('x'));
+			assert.strictEqual(metricSpy.calls.length, 0, 'no aggregate metrics should fire on failure');
+			// But the per-call writer row IS there for forensics.
+			assert.strictEqual(writer.records.length, 1);
+			assert.strictEqual(writer.records[0].success, false);
+		});
+
+		it('does NOT emit aggregate metrics on pre-call backend-not-found (no billable work happened)', async () => {
+			await assert.rejects(() => models.embed('x', { model: 'no-such-name' }));
+			assert.strictEqual(metricSpy.calls.length, 0);
+		});
+
+		it('does NOT emit aggregate metrics when the backend returns status=pending', async () => {
+			setEmbedding('default', {
+				name: 'pending',
+				capabilities: () => ({ embed: true, generate: false, stream: false, tools: false, adapters: false }),
+				async embed() {
+					return { status: 'pending', operationId: 'op-1' };
+				},
+			});
+			await assert.rejects(() => models.embed('x'), ModelPendingNotSupportedError);
+			assert.strictEqual(metricSpy.calls.length, 0);
 		});
 	});
 


### PR DESCRIPTION
Let's track and charge for this stuff!

## Summary
- Successful `embed`/`generate`/`generateStream` calls now flow through `recordAction()` into `hdb_raw_analytics` → `hdb_analytics`, mirroring the existing `db-read` / `db-message` pattern in `Table.ts`
- Per-call rows in `hdb_model_calls` are unchanged — they remain the forensics trail; aggregate metrics fire on **success only**
- Metric emitter is constructor-injected so tests can assert on exact `(value, metric, path)` tuples without touching the global pipeline; production wires up the module-scope `recordAction`

## Why
Phase 1 of the model-usage license-enforcement chain. Phase 2 will extend the central-manager `Plan.planLimits` schema + signed license blob with the new fields, Phase 3 adds `fabric-ai-level-1..3` SKUs with embed/generate budgets. Splitting the work this way lets the Harper-side emission land independently and start populating analytics tables before the CM-side enforcement is wired up.

## Metrics emitted (path = `backend.name`)
| Metric                   | Value                                                         |
|--------------------------|---------------------------------------------------------------|
| `model-<method>`         | `1` per successful call                                       |
| `model-<method>-tokens`  | sum of `embeddingTokens + promptTokens + completionTokens`, only when > 0 |

`<method>` is `embed` / `generate` / `generateStream`. Multi-modal embeds (e.g. CLIP image patches) report a synthetic `embeddingTokens` from the backend, so the image-vs-text multiplier is baked into `TokenUsage` rather than applied here.

## Where to look
- `resources/models/Models.ts` — `#record()` now also calls the injected emitter after the per-call writer row
- `unitTests/resources/models/Models.test.js` — 8 new tests in `aggregate analytics emission` describe block

## Reviewed by
- **Codex CLI** (uncommitted diff) — *\"The changes appear consistent with the existing analytics patterns... I did not find any discrete correctness issues in the modified files.\"*
- **Gemini-3.1-pro** (git diff main) — DI justified, sync+lazy `recordAction` safe in hot path, no security concerns, confirmed no existing consumer aggregates by `model-` prefix so no regression risk. Only finding was an unrelated `package-lock.json` drift from npm install (already reverted before commit).

## Test plan
- [x] `npx mocha unitTests/resources/models/Models.test.js` — 28/28 passing (20 prior + 8 new)
- [x] `npm run test:unit:resources` — 544/544
- [x] `npm run test:unit:main` — 2130/2130
- [x] `npm run test:integration:all` — 313/313
- [x] `npx prettier --write` + `npx oxlint --quiet` — clean
- [ ] Phase 2 follow-up PR in central-manager will close the license-enforcement loop

Generated by Claude (Opus 4.7) as part of the embed-analytics integration work.