### PR TITLE
Fix flaky HNSW vector index unit test

### DIFF
--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -177,15 +177,9 @@ function openRocksDatabase(path: string, options: RocksDatabaseOptions & { dupSo
 	const writeBufferManagerAllowStall = envGet(CONFIG_PARAMS.STORAGE_ROCKS_WRITEBUFFERMANAGERALLOWSTALL);
 	RocksDatabase.config({
 		blockCacheSize,
-		...(typeof writeBufferManagerSize === 'number' && writeBufferManagerSize > 0
-			? { writeBufferManagerSize }
-			: {}),
-		...(typeof writeBufferManagerCostToCache === 'boolean'
-			? { writeBufferManagerCostToCache }
-			: {}),
-		...(typeof writeBufferManagerAllowStall === 'boolean'
-			? { writeBufferManagerAllowStall }
-			: {}),
+		...(typeof writeBufferManagerSize === 'number' && writeBufferManagerSize > 0 ? { writeBufferManagerSize } : {}),
+		...(typeof writeBufferManagerCostToCache === 'boolean' ? { writeBufferManagerCostToCache } : {}),
+		...(typeof writeBufferManagerAllowStall === 'boolean' ? { writeBufferManagerAllowStall } : {}),
 	});
 	if (!existsSync(path)) {
 		// Don't create directories in read-only mode

--- a/resources/indexes/HierarchicalNavigableSmallWorld.ts
+++ b/resources/indexes/HierarchicalNavigableSmallWorld.ts
@@ -681,20 +681,24 @@ export class HierarchicalNavigableSmallWorld {
 		if (!entryPoint) return;
 		const visited = new Set<number>();
 
-		// BFS from entry point to ensure all nodes are reachable
-		const queue = [entryPoint.id];
-		visited.add(entryPoint.id);
+		// BFS from entry point to ensure all nodes are reachable. Asymmetric stale neighbor
+		// references can survive deletes, so a referenced node may not actually exist anymore;
+		// only count a node as visited once we confirm the underlying record is present.
+		const queue: number[] = [entryPoint.id];
+		const enqueued = new Set<number>([entryPoint.id]);
 		let connections = 0;
 
 		while (queue.length > 0) {
 			const currentId = queue.shift()!;
-			const current = this.indexStore.getSync(currentId);
+			const current = this.safeGetSync(currentId);
+			if (!current) continue;
+			visited.add(currentId);
 
 			for (let level = startLevel; level <= current.level; level++) {
 				for (const { id: neighborId } of current[level] || []) {
 					connections++;
-					if (!visited.has(neighborId)) {
-						visited.add(neighborId);
+					if (!enqueued.has(neighborId)) {
+						enqueued.add(neighborId);
 						queue.push(neighborId);
 					}
 				}

--- a/unitTests/resources/vectorIndex.test.js
+++ b/unitTests/resources/vectorIndex.test.js
@@ -274,11 +274,20 @@ describe('HierarchicalNavigableSmallWorld indexing', () => {
 		// find the best matches through brute force comparison
 		let withDistance = all.map((vector) => ({ vector, distance: testInstance.distance(testVector, vector) }));
 		withDistance.sort((a, b) => a.distance - b.distance);
-		// verify the first 10 match
-		assert.deepEqual(
-			withDistance.slice(0, 5).map((obj) => obj.vector),
-			results.slice(0, 5).map((obj) => obj.vector)
-		);
+		// HNSW is an approximate algorithm; recall@K is not guaranteed to be 100%, especially with
+		// many near-duplicate vectors and after delete/update churn. Rather than asserting exact
+		// vector equality at each rank, verify that each returned result's distance is close to the
+		// brute-force optimum at that rank — close enough to be a useful neighbor.
+		const DISTANCE_TOLERANCE = 0.05;
+		assert(results.length >= 5, `expected at least 5 search results, got ${results.length}`);
+		for (let i = 0; i < 5; i++) {
+			const bruteDistance = withDistance[i].distance;
+			const hnswDistance = results[i].$distance;
+			assert(
+				hnswDistance <= bruteDistance + DISTANCE_TOLERANCE,
+				`HNSW result at position ${i} (distance ${hnswDistance}) is too far from the brute-force best at that rank (${bruteDistance})`
+			);
+		}
 		assert(results[0].$distance < 0.4);
 		results = await fromAsync(
 			HNSWTest.search({


### PR DESCRIPTION
## Summary
Fixes the flaky `HierarchicalNavigableSmallWorld indexing > can delete and update and search with vector index with one dimension` test seen on unrelated PRs (e.g. [run 26469662007](https://github.com/HarperFast/harper/actions/runs/26469662007/job/77939364890?pr=778)).

## Purpose
Two independent fragilities surfaced intermittently. HNSW level assignment uses `Math.random()`, so each run produces a different graph topology and the failure mode varied across runs (~15% local repro rate):

1. **Test asserted exact recall.** `verifySearch` used `assert.deepEqual` on HNSW top‑5 vs brute‑force top‑5. HNSW is approximate; under the test's stress sequence (200 inserts → delete 100 → upsert all 200 with many near‑duplicate modular‑arithmetic vectors), recall@5 can dip below 100%. Replaced with a per‑rank distance tolerance (HNSW distance must be within `0.05` of brute‑force best at that rank).
2. **`validateConnectivity` crashed on stale neighbor refs.** HNSW deletes only scrub the deleted node's own connection list, and asymmetric edges can survive (this is logged as `asymmetry detected` warnings). When BFS traversed a stale neighbor ID, `getSync` returned `undefined` and the BFS threw `TypeError: Cannot read properties of undefined (reading 'level')`. It also inflated `visited.size` by adding stale IDs before confirming the node existed, which broke `isFullyConnected`. BFS now uses `safeGetSync`, skips missing nodes, and tracks queue membership separately so `visited` reflects real nodes only.

## Where to focus review
- **Tolerance value (`0.05`)** in [unitTests/resources/vectorIndex.test.js](unitTests/resources/vectorIndex.test.js): chose this empirically — comfortably covers observed approximation gaps (largest delta seen was ~0.016 cosine) without masking real regressions. Open to a tighter value if reviewers prefer.
- **Underlying HNSW characteristic, not a bug per se:** asymmetric edges + delete‑only‑scrubs‑own‑list means stale refs are a known tradeoff (full symmetry on delete would require an inverted index). This PR makes the *debug utility* robust to that; it doesn't change deletion semantics. Filing a follow‑up may be worth considering if we want strong invariants here.
- **Integration tests**: skipped `test:integration:all` since no integration tests exercise HNSW (`grep` confirms zero `HNSW`/`vectorIndex` refs under `integrationTests/`). `test:unit:resources` (536 tests) all pass.

## Verification
- Before fix: 5–7 failures per 30 local mocha runs.
- After fix: 0 failures over 50 consecutive runs.
- Cross‑model review: Codex (no concerns) + Gemini 3.1 Pro (one suggestion incorporated — added `assert(results.length >= 5)` bounds check).

🤖 Generated with Claude Opus 4.7