### PR TITLE
Exclude transient npm/git artifacts from component file watcher

### DIFF
--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -255,20 +255,28 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 					const normalizedBases = allowedBases.map((base) => base.replace(/\\/g, '/'));
 					const normalizedDirectory = this.#component.directory.replace(/\\/g, '/');
 
-					// Check for nested node_modules relative to the component directory
-					// This allows plugins loaded from node_modules to watch their own files
-					// while still ignoring their nested node_modules dependencies
-					const relativePath = normalizedPath.startsWith(normalizedDirectory + '/')
+					// Determine the path relative to the component directory. Leading '/' is preserved
+					// (or empty when the path *is* the component directory) so the regex anchors below
+					// can use `(?:^|/)` to match the first segment without false positives on names
+					// that merely contain the same substring (e.g. `mynode_modules`, `notgit`).
+					const relativePath = normalizedPath.startsWith(normalizedDirectory)
 						? normalizedPath.slice(normalizedDirectory.length)
-						: normalizedPath.startsWith(normalizedDirectory)
-							? normalizedPath.slice(normalizedDirectory.length)
-							: normalizedPath;
-					const hasNestedNodeModules = relativePath.includes('/node_modules');
+						: normalizedPath;
+
+					// Skip node_modules at any depth. This allows plugins loaded from node_modules
+					// to still watch their own component files while ignoring their dependencies.
+					if (/(?:^|\/)node_modules(?:\/|$)/.test(relativePath)) return true;
+
+					// Skip transient package manager and VCS artifacts. Without these, an in-place
+					// `npm install` during a component deploy writes log files and atomic-rename
+					// temp directories that fire change events and drive an auto-reload restart
+					// storm — see harper#488.
+					if (/(?:^|\/)\.git(?:\/|$)/.test(relativePath)) return true;
+					if (/(?:^|\/)\.tmp-/.test(relativePath)) return true;
+					if (/(?:^|\/)(?:npm-debug|yarn-error|yarn-debug|pnpm-debug)\.log(?:\/|$)/.test(relativePath)) return true;
 
 					return (
-						hasNestedNodeModules ||
-						(normalizedPath !== normalizedDirectory &&
-							normalizedBases.every((base) => !normalizedPath.startsWith(base)))
+						normalizedPath !== normalizedDirectory && normalizedBases.every((base) => !normalizedPath.startsWith(base))
 					);
 				},
 			})

--- a/unitTests/components/EntryHandler.test.js
+++ b/unitTests/components/EntryHandler.test.js
@@ -684,4 +684,154 @@ describe('EntryHandler', () => {
 			rmSync(directory, { recursive: true, force: true });
 		}).timeout(2000);
 	});
+
+	describe('ignored paths', () => {
+		// These cases ensure the watcher does not consume inotify handles for or fire
+		// events from transient artifacts produced by `npm install`, git operations, etc.
+		// Background: harper#488 — restart storms driven by these paths can exhaust the
+		// system file-watcher limit during component deploys.
+
+		it('should ignore top-level node_modules', async () => {
+			const { directory } = createFixture([['node_modules', [['pkg', ['index.js']]]], 'app.js']);
+
+			const allHandlerSpy = spy();
+			const entryHandler = new EntryHandler(basename(directory), directory, '**/*');
+			entryHandler.on('all', allHandlerSpy);
+
+			await entryHandler.ready;
+
+			const paths = allHandlerSpy.getCalls().map((call) => call.args[0].urlPath);
+			assert.ok(
+				paths.every((p) => !p.includes('node_modules')),
+				`no event should reference node_modules, got: ${JSON.stringify(paths)}`
+			);
+			assert.ok(
+				paths.some((p) => p === '/app.js'),
+				'app.js outside node_modules should still be emitted'
+			);
+
+			entryHandler.close();
+			rmSync(directory, { recursive: true, force: true });
+		});
+
+		it('should ignore nested node_modules', async () => {
+			const { directory } = createFixture([['plugin', [['node_modules', [['dep', ['index.js']]]], 'main.js']]]);
+
+			const allHandlerSpy = spy();
+			const entryHandler = new EntryHandler(basename(directory), directory, 'plugin/**/*');
+			entryHandler.on('all', allHandlerSpy);
+
+			await entryHandler.ready;
+
+			const paths = allHandlerSpy.getCalls().map((call) => call.args[0].urlPath);
+			assert.ok(
+				paths.every((p) => !p.includes('node_modules')),
+				`no event should reference node_modules, got: ${JSON.stringify(paths)}`
+			);
+			assert.ok(
+				paths.some((p) => p.endsWith('main.js')),
+				'plugin/main.js should still be emitted'
+			);
+
+			entryHandler.close();
+			rmSync(directory, { recursive: true, force: true });
+		});
+
+		it('should ignore .git directory', async () => {
+			const { directory } = createFixture([['.git', ['HEAD', 'config']], 'app.js']);
+
+			const allHandlerSpy = spy();
+			const entryHandler = new EntryHandler(basename(directory), directory, '**/*');
+			entryHandler.on('all', allHandlerSpy);
+
+			await entryHandler.ready;
+
+			const paths = allHandlerSpy.getCalls().map((call) => call.args[0].urlPath);
+			assert.ok(
+				paths.every((p) => !p.includes('.git')),
+				`no event should reference .git, got: ${JSON.stringify(paths)}`
+			);
+
+			entryHandler.close();
+			rmSync(directory, { recursive: true, force: true });
+		});
+
+		it('should ignore npm atomic-rename temp directories (.tmp-*)', async () => {
+			const { directory } = createFixture([['.tmp-12345', ['package.json']], 'app.js']);
+
+			const allHandlerSpy = spy();
+			const entryHandler = new EntryHandler(basename(directory), directory, '**/*');
+			entryHandler.on('all', allHandlerSpy);
+
+			await entryHandler.ready;
+
+			const paths = allHandlerSpy.getCalls().map((call) => call.args[0].urlPath);
+			assert.ok(
+				paths.every((p) => !p.includes('.tmp-')),
+				`no event should reference .tmp- dirs, got: ${JSON.stringify(paths)}`
+			);
+
+			entryHandler.close();
+			rmSync(directory, { recursive: true, force: true });
+		});
+
+		it('should ignore package-manager log files', async () => {
+			const { directory } = createFixture(['app.js', 'npm-debug.log', 'yarn-error.log', 'pnpm-debug.log']);
+
+			const allHandlerSpy = spy();
+			const entryHandler = new EntryHandler(basename(directory), directory, '**/*');
+			entryHandler.on('all', allHandlerSpy);
+
+			await entryHandler.ready;
+
+			const paths = allHandlerSpy.getCalls().map((call) => call.args[0].urlPath);
+			assert.ok(
+				paths.every((p) => !p.endsWith('.log')),
+				`no event should reference a .log file, got: ${JSON.stringify(paths)}`
+			);
+			assert.ok(
+				paths.some((p) => p === '/app.js'),
+				'app.js should still be emitted'
+			);
+
+			entryHandler.close();
+			rmSync(directory, { recursive: true, force: true });
+		});
+
+		it('should not over-match similar names (prefix and suffix)', async () => {
+			// The leading-and-trailing segment anchors in the ignored regex must not match
+			// substrings on either side. Directories like `notnode_modules` (prefix) and
+			// `node_modules_not` (suffix), and files like `npm-debug.log.txt`, are real user
+			// paths and must be watched.
+			const { directory } = createFixture([
+				['notnode_modules', ['data.json']],
+				['node_modules_not', ['data.json']],
+				'npm-debug.log.txt',
+				'app.js',
+			]);
+
+			const allHandlerSpy = spy();
+			const entryHandler = new EntryHandler(basename(directory), directory, '**/*');
+			entryHandler.on('all', allHandlerSpy);
+
+			await entryHandler.ready;
+
+			const paths = allHandlerSpy.getCalls().map((call) => call.args[0].urlPath);
+			assert.ok(
+				paths.some((p) => p.includes('notnode_modules')),
+				`event for notnode_modules should be emitted, got: ${JSON.stringify(paths)}`
+			);
+			assert.ok(
+				paths.some((p) => p.includes('node_modules_not')),
+				`event for node_modules_not should be emitted, got: ${JSON.stringify(paths)}`
+			);
+			assert.ok(
+				paths.some((p) => p === '/npm-debug.log.txt'),
+				`event for npm-debug.log.txt should be emitted, got: ${JSON.stringify(paths)}`
+			);
+
+			entryHandler.close();
+			rmSync(directory, { recursive: true, force: true });
+		});
+	});
 });

--- a/unitTests/components/EntryHandler.test.js
+++ b/unitTests/components/EntryHandler.test.js
@@ -776,7 +776,13 @@ describe('EntryHandler', () => {
 		});
 
 		it('should ignore package-manager log files', async () => {
-			const { directory } = createFixture(['app.js', 'npm-debug.log', 'yarn-error.log', 'pnpm-debug.log']);
+			const { directory } = createFixture([
+				'app.js',
+				'npm-debug.log',
+				'yarn-debug.log',
+				'yarn-error.log',
+				'pnpm-debug.log',
+			]);
 
 			const allHandlerSpy = spy();
 			const entryHandler = new EntryHandler(basename(directory), directory, '**/*');


### PR DESCRIPTION
## Summary

Tighten `EntryHandler`'s chokidar `ignored` callback so npm and git side-effects produced during a component deploy don't drive auto-reload restart storms.

## Why

Refs harper#488. Each Harper component runs a chokidar watcher over its directory, recursively. Linux `fs.watch` is non-recursive, so chokidar consumes one inotify watch per descended directory. The watcher's `ignored` callback previously only excluded `node_modules` (via a loose `includes('/node_modules')` check). When `npm install` ran inside a component during deploy, it wrote:

- `npm-debug.log`, `pnpm-debug.log`, `yarn-{error,debug}.log`
- `.tmp-*` atomic-rename temp directories
- `.git` internals (when a component is a git checkout)

These all leaked through the filter, fired `Scope.requestRestart()` events, and amplified the restart churn — which then thrashes the watcher pool during teardown/recreate and can hit `ENOSPC` (the inotify limit).

This PR is one of three independent mitigations for #488; PR 2 adds an `ENOSPC`/`EMFILE` polling fallback to all three watchers, PR 3 suppresses auto-reload entirely during a deploy.

## Where to look

- `components/EntryHandler.ts:193-220` — the new `ignored` callback. The substring check is replaced with anchored regexes (`(?:^|\/)…(?:\/|$)`) so similar-named user paths aren't false-matched.
- The `relativePath` derivation was simplified — the previous redundant `startsWith(directory + '/')` then `startsWith(directory)` ternary collapsed into a single slice. Leaves leading `/` on inner paths and an empty string when the path is the component dir itself, which the regex anchors handle correctly.
- Six new unit tests in `unitTests/components/EntryHandler.test.js` cover each excluded pattern plus a prefix/suffix over-match negative case.

## Cross-model review notes

- **Codex** flagged that `pnpm-debug.log` (not `.pnpm-debug.log`) is the actual filename pnpm writes — fixed.
- **Gemini** flagged that the log-file regex wasn't end-anchored, so `npm-debug.log.txt` and `npm-debug.log/` would have been over-matched — fixed by appending `(?:\/|$)`. Also suggested an explicit suffix-overmatch test case, added.

## Potential concerns to focus on

- Confidence that chokidar 4 passes absolute paths to `ignored` when `cwd` is set. Verified by reading chokidar's `_isIgnored` → `normalizeIgnored` (chokidar `esm/index.js:110,633`): function matchers pass through unchanged, and the upstream caller resolves to absolute via `getAbsolutePath`. The existing `node_modules` filter (which depends on this assumption) already works, so the behavior is established.
- Plugins that explicitly relied on receiving change events for an in-tree `npm-debug.log` or `.git/HEAD` will no longer see them. No such plugin is known to exist; the watcher contract has always been "files matching your glob, minus implementation-defined noise."
- Generated by an LLM (Claude Opus 4.7).