### PR TITLE
Fall back to polling-based file watching on inotify/FD exhaustion

### DIFF
--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -9,6 +9,11 @@ import { readFile } from 'node:fs/promises';
 import { FilesOption } from './deriveGlobOptions.ts';
 import { deriveURLPath } from './deriveURLPath.ts';
 import { isMatch } from 'micromatch';
+import {
+	DIRECTORY_POLLING_FALLBACK_OPTIONS,
+	isWatcherExhaustionError,
+	warnWatcherFallback,
+} from '../utility/watcherFallback.ts';
 
 export interface BaseEntry {
 	stats?: Stats;
@@ -85,6 +90,8 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	// chokidar instance — otherwise a rapid pause→resume can overlap teardown
 	// and setup, which under inotify pressure can produce spurious EMFILE.
 	#pausedClose?: Promise<void>;
+	#usingPolling: boolean = false;
+	#closed: boolean = false;
 	ready: Promise<any[]>;
 
 	constructor(name: string, directory: string, config: FilesOption | FileAndURLPathConfig, logger?: Logger) {
@@ -169,6 +176,18 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	}
 
 	#handleError(error: unknown): void {
+		if (isWatcherExhaustionError(error)) {
+			// Swallow every exhaustion error — chokidar can emit several before the
+			// failed native watcher closes, and we don't want a flurry of ENOSPC to
+			// surface to consumers in the middle of recovery.
+			if (!this.#usingPolling) {
+				warnWatcherFallback(this.#component.directory);
+				this.#usingPolling = true;
+				// Reopen with polling. #watch() itself guards against reopen-after-close.
+				void this.#watch();
+			}
+			return;
+		}
 		this.emit('error', error);
 	}
 
@@ -201,6 +220,10 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		await this.#watcher?.close();
 		this.#watcher = undefined;
 
+		// If close() landed while a previous close()/recreate was awaiting, don't
+		// install a fresh watcher — it would outlive the EntryHandler.
+		if (this.#closed) return this.ready;
+
 		// pause() may have landed in the gap before our async close resolved.
 		// If so, do not install a replacement watcher — resume() will.
 		if (this.#paused) return this.ready;
@@ -217,6 +240,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 				cwd: this.#component.directory,
 				persistent: false,
 				followSymlinks: false,
+				...(this.#usingPolling ? DIRECTORY_POLLING_FALLBACK_OPTIONS : {}),
 				ignored: (path) => {
 					const normalizedPath = path.replace(/\\/g, '/');
 					const normalizedBases = allowedBases.map((base) => base.replace(/\\/g, '/'));
@@ -247,6 +271,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	}
 
 	close(): this {
+		this.#closed = true;
 		this.#watcher?.close();
 		this.#watcher = undefined;
 

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -92,6 +92,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	#pausedClose?: Promise<void>;
 	#usingPolling: boolean = false;
 	#closed: boolean = false;
+	#openCount: number = 0;
 	ready: Promise<any[]>;
 
 	constructor(name: string, directory: string, config: FilesOption | FileAndURLPathConfig, logger?: Logger) {
@@ -242,6 +243,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 
 		const allowedBases = this.#component.patternBases.map((base) => join(this.#component.directory, base));
 
+		this.#openCount++;
 		this.#watcher = chokidar
 			.watch(this.#component.commonPatternBase, {
 				cwd: this.#component.directory,
@@ -287,6 +289,13 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	// Test-only: whether the watcher has fallen back to polling.
 	get _usingPollingForTests(): boolean {
 		return this.#usingPolling;
+	}
+
+	// Test-only: number of times the underlying watcher has been (re)opened.
+	// Used to assert that a close()-during-fallback race didn't install a
+	// replacement watcher.
+	get _openCountForTests(): number {
+		return this.#openCount;
 	}
 
 	close(): this {

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -270,6 +270,18 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		return this.ready;
 	}
 
+	// Test-only: simulate the underlying chokidar watcher emitting an error.
+	// Exposed so the polling-fallback path can be exercised without triggering a
+	// real ENOSPC/EMFILE on the host.
+	_simulateWatcherErrorForTests(error: unknown): void {
+		this.#handleError(error);
+	}
+
+	// Test-only: whether the watcher has fallen back to polling.
+	get _usingPollingForTests(): boolean {
+		return this.#usingPolling;
+	}
+
 	close(): this {
 		this.#closed = true;
 		this.#watcher?.close();

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -184,7 +184,14 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 				warnWatcherFallback(this.#component.directory);
 				this.#usingPolling = true;
 				// Reopen with polling. #watch() itself guards against reopen-after-close.
-				void this.#watch();
+				// The .catch is required because #watch() internally awaits the failed
+				// watcher's close(), which can reject under the same FD/inotify pressure
+				// that triggered this path; without it Node would treat that as an
+				// unhandled rejection (matches the .catch pattern used in
+				// OptionsWatcher / RootConfigWatcher).
+				this.#watch().catch(() => {
+					// Teardown errors on an already-failed watcher are not actionable.
+				});
 			}
 			return;
 		}

--- a/components/OptionsWatcher.ts
+++ b/components/OptionsWatcher.ts
@@ -7,6 +7,7 @@ import { readFile } from 'node:fs/promises';
 import { isDeepStrictEqual } from 'util';
 import { DEFAULT_CONFIG } from './DEFAULT_CONFIG.ts';
 import { cloneDeep } from 'lodash';
+import { POLLING_FALLBACK_OPTIONS, isWatcherExhaustionError, warnWatcherFallback } from '../utility/watcherFallback.ts';
 
 export interface Config {
 	[key: string]: ConfigValue;
@@ -82,11 +83,14 @@ export class CannotSetPropertyError extends Error {
  */
 export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 	#filePath: string;
-	#watcher: FSWatcher;
+	#watcher!: FSWatcher;
 	#scopedConfig?: ConfigValue;
 	#rootConfig?: Config;
 	#name: string;
 	#logger: Logger;
+	#usingPolling: boolean;
+	#closed: boolean;
+	#openCount: number = 0;
 	ready: Promise<any[]>;
 
 	constructor(name: string, filePath: string, logger?: Logger) {
@@ -94,9 +98,19 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 		this.#name = name;
 		this.#filePath = filePath;
 		this.#logger = logger || loggerWithTag(name);
+		this.#usingPolling = false;
+		this.#closed = false;
 		this.ready = once(this, 'ready');
+		this.#openWatcher();
+	}
+
+	#openWatcher() {
+		this.#openCount++;
 		this.#watcher = chokidar
-			.watch(filePath, { persistent: false })
+			.watch(this.#filePath, {
+				persistent: false,
+				...(this.#usingPolling ? POLLING_FALLBACK_OPTIONS : {}),
+			})
 			.on('add', this.#handleChange.bind(this))
 			.on('change', this.#handleChange.bind(this))
 			.on('error', this.#handleError.bind(this))
@@ -150,6 +164,28 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 	}
 
 	#handleError(error: unknown) {
+		if (isWatcherExhaustionError(error)) {
+			// Swallow every exhaustion error — chokidar can emit several before the
+			// failed native watcher closes, and we don't want a flurry of ENOSPC to
+			// surface to consumers in the middle of recovery.
+			if (!this.#usingPolling) {
+				warnWatcherFallback(this.#filePath);
+				this.#usingPolling = true;
+				// Close the failed native watcher and reopen with polling. Guard
+				// against reopen-after-close: the caller may have invoked close()
+				// while this teardown was in flight. The .catch is required because
+				// `finally` would re-raise a teardown rejection as an unhandled one.
+				this.#watcher
+					.close()
+					.catch(() => {
+						// Teardown errors on an already-failed watcher are not actionable.
+					})
+					.finally(() => {
+						if (!this.#closed) this.#openWatcher();
+					});
+			}
+			return;
+		}
 		this.emit('error', new OptionsWatcherConfigFileError(this.#filePath, error));
 	}
 
@@ -283,10 +319,30 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 		this.emit('change', keys, value, this.#scopedConfig);
 	}
 
+	// Test-only: simulate the underlying chokidar watcher emitting an error.
+	// Exposed so the polling-fallback path can be exercised without triggering a
+	// real ENOSPC/EMFILE on the host.
+	_simulateWatcherErrorForTests(error: unknown): void {
+		this.#handleError(error);
+	}
+
+	// Test-only: whether the watcher has fallen back to polling.
+	get _usingPollingForTests(): boolean {
+		return this.#usingPolling;
+	}
+
+	// Test-only: number of times the underlying watcher has been (re)opened.
+	// Used to assert that a close()-during-fallback race didn't install a
+	// replacement watcher.
+	get _openCountForTests(): number {
+		return this.#openCount;
+	}
+
 	/**
 	 * Closes the underlying file watcher, emits the `close` event, and removes any listeners on the OptionsWatcher instance
 	 */
 	close() {
+		this.#closed = true;
 		this.#watcher.close();
 
 		this.emit('close');

--- a/config/RootConfigWatcher.ts
+++ b/config/RootConfigWatcher.ts
@@ -3,25 +3,59 @@ import { readFile } from 'node:fs/promises';
 import { getConfigFilePath } from './configUtils.js';
 import { EventEmitter, once } from 'node:events';
 import { parse } from 'yaml';
+import { POLLING_FALLBACK_OPTIONS, isWatcherExhaustionError, warnWatcherFallback } from '../utility/watcherFallback.ts';
 
 export class RootConfigWatcher extends EventEmitter {
 	#configFilePath: string;
-	#watcher: FSWatcher;
+	#watcher!: FSWatcher;
 	#config: any;
+	#usingPolling: boolean;
+	#closed: boolean;
 	ready: Promise<any[]>;
 
 	constructor() {
 		super();
 		this.#configFilePath = getConfigFilePath();
+		this.#usingPolling = false;
+		this.#closed = false;
 		this.ready = once(this, 'ready');
+		this.#openWatcher();
+	}
+
+	#openWatcher() {
 		this.#watcher = chokidar
-			.watch(this.#configFilePath, { persistent: false })
+			.watch(this.#configFilePath, {
+				persistent: false,
+				...(this.#usingPolling ? POLLING_FALLBACK_OPTIONS : {}),
+			})
 			.on('add', this.handleChange.bind(this))
 			.on('change', this.handleChange.bind(this))
 			.on('error', this.handleError.bind(this));
 	}
 
 	handleError(error: unknown) {
+		if (isWatcherExhaustionError(error)) {
+			// Swallow every exhaustion error — chokidar can emit several before the
+			// failed native watcher closes, and we don't want a flurry of ENOSPC to
+			// surface to consumers in the middle of recovery.
+			if (!this.#usingPolling) {
+				warnWatcherFallback(this.#configFilePath);
+				this.#usingPolling = true;
+				// Guard against reopen-after-close: the caller may have invoked
+				// close() while this teardown was in flight. The .catch is required
+				// because `finally` would re-raise a teardown rejection as an
+				// unhandled one.
+				this.#watcher
+					.close()
+					.catch(() => {
+						// Teardown errors on an already-failed watcher are not actionable.
+					})
+					.finally(() => {
+						if (!this.#closed) this.#openWatcher();
+					});
+			}
+			return;
+		}
 		this.emit('error', error);
 	}
 
@@ -46,6 +80,7 @@ export class RootConfigWatcher extends EventEmitter {
 	}
 
 	close() {
+		this.#closed = true;
 		this.#watcher.close();
 		this.#config = undefined;
 		this.emit('close');

--- a/config/RootConfigWatcher.ts
+++ b/config/RootConfigWatcher.ts
@@ -11,6 +11,7 @@ export class RootConfigWatcher extends EventEmitter {
 	#config: any;
 	#usingPolling: boolean;
 	#closed: boolean;
+	#openCount: number = 0;
 	ready: Promise<any[]>;
 
 	constructor() {
@@ -23,6 +24,7 @@ export class RootConfigWatcher extends EventEmitter {
 	}
 
 	#openWatcher() {
+		this.#openCount++;
 		this.#watcher = chokidar
 			.watch(this.#configFilePath, {
 				persistent: false,
@@ -31,6 +33,23 @@ export class RootConfigWatcher extends EventEmitter {
 			.on('add', this.handleChange.bind(this))
 			.on('change', this.handleChange.bind(this))
 			.on('error', this.handleError.bind(this));
+	}
+
+	// Test-only: simulate the underlying chokidar watcher emitting an error.
+	// Exposed so the polling-fallback path can be exercised without triggering a
+	// real ENOSPC/EMFILE on the host.
+	_simulateWatcherErrorForTests(error: unknown): void {
+		this.handleError(error);
+	}
+
+	// Test-only: whether the watcher has fallen back to polling.
+	get _usingPollingForTests(): boolean {
+		return this.#usingPolling;
+	}
+
+	// Test-only: number of times the underlying watcher has been (re)opened.
+	get _openCountForTests(): number {
+		return this.#openCount;
 	}
 
 	handleError(error: unknown) {

--- a/unitTests/components/EntryHandler.test.js
+++ b/unitTests/components/EntryHandler.test.js
@@ -669,21 +669,17 @@ describe('EntryHandler', () => {
 			const entryHandler = new EntryHandler(basename(directory), directory, '**/*');
 			await entryHandler.ready;
 
+			assert.equal(entryHandler._openCountForTests, 1, 'one initial open');
+
+			// Trigger the fallback path, then immediately close before the inner
+			// `await this.#watcher.close()` resolves.
 			entryHandler._simulateWatcherErrorForTests(Object.assign(new Error('boom'), { code: 'ENOSPC' }));
 			entryHandler.close();
 
 			// Allow plenty of time for the would-be reopen to (not) happen.
 			await new Promise((r) => setTimeout(r, 200));
 
-			// After close(), no further events should fire. Subsequent file writes
-			// are the strongest signal we can observe without exposing more internals.
-			const addSpy = spy();
-			entryHandler.on('add', addSpy);
-			await writeFile(join(directory, 'b.txt'), 'b');
-			// Even with the polling interval (3s for directory watchers), we should
-			// never see events because there's no active watcher of either flavor.
-			await new Promise((r) => setTimeout(r, 500));
-			assert.equal(addSpy.callCount, 0, 'no events should fire after close()');
+			assert.equal(entryHandler._openCountForTests, 1, 'reopen must be suppressed by the close-during-fallback guard');
 
 			rmSync(directory, { recursive: true, force: true });
 		}).timeout(2000);

--- a/unitTests/components/EntryHandler.test.js
+++ b/unitTests/components/EntryHandler.test.js
@@ -584,4 +584,108 @@ describe('EntryHandler', () => {
 			rmSync(directory, { recursive: true, force: true });
 		});
 	});
+
+	describe('polling fallback on watcher exhaustion', () => {
+		// harper#488: when the underlying chokidar watcher emits ENOSPC/EMFILE,
+		// the EntryHandler should re-open with polling rather than surfacing the
+		// error to consumers. EntryHandler's recovery path uses #watch() (which
+		// awaits the old watcher's close then checks #closed), structurally
+		// different from OptionsWatcher/RootConfigWatcher's explicit
+		// close().catch().finally() chain — so it needs its own coverage.
+
+		it('falls back to polling on ENOSPC and continues to receive change events', async () => {
+			const { directory } = createFixture(['a.txt']);
+			const entryHandler = new EntryHandler(basename(directory), directory, '**/*');
+			await entryHandler.ready;
+
+			const errorSpy = spy();
+			entryHandler.on('error', errorSpy);
+
+			assert.equal(entryHandler._usingPollingForTests, false);
+
+			entryHandler._simulateWatcherErrorForTests(Object.assign(new Error('boom'), { code: 'ENOSPC' }));
+
+			// Allow the close+reopen-with-polling to settle.
+			await waitFor(() => entryHandler._usingPollingForTests === true, 2000);
+			assert.equal(entryHandler._usingPollingForTests, true);
+			assert.equal(errorSpy.callCount, 0, 'ENOSPC should be swallowed');
+
+			// The polling watcher should pick up subsequent file writes; default
+			// directory polling interval is 3s, so allow up to 5s.
+			const addSpy = spy();
+			entryHandler.on('add', addSpy);
+			await writeFile(join(directory, 'b.txt'), 'b');
+			await waitFor(() => addSpy.callCount >= 1, 5000);
+			assert.ok(addSpy.callCount >= 1, 'polling watcher should fire add');
+
+			entryHandler.close();
+			rmSync(directory, { recursive: true, force: true });
+		}).timeout(8000);
+
+		it('propagates non-exhaustion errors and does not fall back', async () => {
+			const { directory } = createFixture(['a.txt']);
+			const entryHandler = new EntryHandler(basename(directory), directory, '**/*');
+			await entryHandler.ready;
+
+			const errorSpy = spy();
+			entryHandler.on('error', errorSpy);
+
+			entryHandler._simulateWatcherErrorForTests(Object.assign(new Error('boom'), { code: 'EACCES' }));
+			await new Promise((r) => setTimeout(r, 20));
+
+			assert.equal(entryHandler._usingPollingForTests, false);
+			assert.equal(errorSpy.callCount, 1, 'non-exhaustion error should propagate');
+
+			entryHandler.close();
+			rmSync(directory, { recursive: true, force: true });
+		});
+
+		it('swallows additional exhaustion errors during recovery', async () => {
+			const { directory } = createFixture(['a.txt']);
+			const entryHandler = new EntryHandler(basename(directory), directory, '**/*');
+			await entryHandler.ready;
+
+			const errorSpy = spy();
+			entryHandler.on('error', errorSpy);
+
+			const enospc = () => Object.assign(new Error('boom'), { code: 'ENOSPC' });
+			entryHandler._simulateWatcherErrorForTests(enospc());
+			entryHandler._simulateWatcherErrorForTests(enospc());
+			entryHandler._simulateWatcherErrorForTests(Object.assign(new Error('boom'), { code: 'EMFILE' }));
+
+			await waitFor(() => entryHandler._usingPollingForTests === true, 1000);
+			assert.equal(errorSpy.callCount, 0, 'all exhaustion errors should be swallowed');
+
+			entryHandler.close();
+			rmSync(directory, { recursive: true, force: true });
+		});
+
+		it('does not reopen watcher if close() is called during recovery', async () => {
+			// EntryHandler's recovery path: #handleError calls `void this.#watch()`,
+			// which does `await this.#watcher?.close(); if (this.#closed) return`.
+			// If close() lands between the ENOSPC and #watch()'s post-await check,
+			// the new chokidar watcher must not be installed.
+			const { directory } = createFixture(['a.txt']);
+			const entryHandler = new EntryHandler(basename(directory), directory, '**/*');
+			await entryHandler.ready;
+
+			entryHandler._simulateWatcherErrorForTests(Object.assign(new Error('boom'), { code: 'ENOSPC' }));
+			entryHandler.close();
+
+			// Allow plenty of time for the would-be reopen to (not) happen.
+			await new Promise((r) => setTimeout(r, 200));
+
+			// After close(), no further events should fire. Subsequent file writes
+			// are the strongest signal we can observe without exposing more internals.
+			const addSpy = spy();
+			entryHandler.on('add', addSpy);
+			await writeFile(join(directory, 'b.txt'), 'b');
+			// Even with the polling interval (3s for directory watchers), we should
+			// never see events because there's no active watcher of either flavor.
+			await new Promise((r) => setTimeout(r, 500));
+			assert.equal(addSpy.callCount, 0, 'no events should fire after close()');
+
+			rmSync(directory, { recursive: true, force: true });
+		}).timeout(2000);
+	});
 });

--- a/unitTests/components/OptionsWatcher.test.js
+++ b/unitTests/components/OptionsWatcher.test.js
@@ -637,4 +637,109 @@ describe('OptionsWatcher', () => {
 
 		await teardown({ fixture, options });
 	});
+
+	describe('polling fallback on watcher exhaustion', () => {
+		// harper#488: when ENOSPC/EMFILE fires on the underlying chokidar watcher,
+		// the OptionsWatcher should swap to a polling watcher rather than surfacing
+		// the error to consumers.
+
+		it('falls back to polling on ENOSPC and continues to receive change events', async () => {
+			const { fixture, configFilePath, options } = await setup();
+
+			const errorSpy = spy();
+			options.on('error', errorSpy);
+
+			assert.equal(options._usingPollingForTests, false, 'should not be polling initially');
+
+			// Simulate the underlying watcher emitting ENOSPC.
+			options._simulateWatcherErrorForTests(Object.assign(new Error('boom'), { code: 'ENOSPC' }));
+
+			// Wait a tick for the close + reopen to settle.
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			assert.equal(options._usingPollingForTests, true, 'should have flipped to polling');
+			assert.equal(errorSpy.callCount, 0, 'ENOSPC should be swallowed, not propagated');
+
+			// Verify the polling watcher actually fires change events. The poll
+			// interval is 1s, so allow up to ~3s for a change event to land.
+			const updated = { ...CONFIG, [NAME]: { ...OPTIONS, str: 'after-fallback' } };
+			await assertEvent(
+				options,
+				'change',
+				() => writeFile(configFilePath, stringify(updated), 'utf-8'),
+				(changeSpy) => {
+					assert.ok(changeSpy.callCount >= 1, 'change event should fire after polling fallback');
+				}
+			);
+
+			await teardown({ fixture, options });
+		}).timeout(5000);
+
+		it('propagates non-exhaustion errors and does not fall back', async () => {
+			const { fixture, options } = await setup();
+
+			const errorSpy = spy();
+			options.on('error', errorSpy);
+
+			options._simulateWatcherErrorForTests(Object.assign(new Error('boom'), { code: 'EACCES' }));
+
+			await new Promise((resolve) => setTimeout(resolve, 20));
+
+			assert.equal(options._usingPollingForTests, false, 'should not fall back for unrelated errors');
+			assert.equal(errorSpy.callCount, 1, 'non-exhaustion error should propagate');
+
+			await teardown({ fixture, options });
+		});
+
+		it('swallows additional exhaustion errors during recovery', async () => {
+			// chokidar can fire several ENOSPC/EMFILE errors before the failed
+			// native watcher finishes closing. Only the first should trigger the
+			// fallback; subsequent ones must not be re-emitted to consumers.
+			const { fixture, options } = await setup();
+
+			const errorSpy = spy();
+			options.on('error', errorSpy);
+
+			const enospc = () => Object.assign(new Error('boom'), { code: 'ENOSPC' });
+			options._simulateWatcherErrorForTests(enospc());
+			options._simulateWatcherErrorForTests(enospc());
+			options._simulateWatcherErrorForTests(Object.assign(new Error('boom'), { code: 'EMFILE' }));
+
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			assert.equal(options._usingPollingForTests, true);
+			assert.equal(errorSpy.callCount, 0, 'all exhaustion errors should be swallowed');
+
+			await teardown({ fixture, options });
+		});
+
+		it('does not reopen watcher if close() is called during recovery', async () => {
+			// Race condition: close() lands while the failed-watcher .close() promise
+			// is still pending. The reopen-with-polling must not fire after the
+			// OptionsWatcher has been closed, otherwise the new watcher leaks.
+			const { fixture, configFilePath } = createFixture();
+			const options = new OptionsWatcher(NAME, configFilePath);
+			await options.ready;
+
+			assert.equal(options._openCountForTests, 1, 'one initial open');
+
+			// Trigger the fallback path, then immediately close before the inner
+			// `await this.#watcher.close()` resolves.
+			options._simulateWatcherErrorForTests(Object.assign(new Error('boom'), { code: 'ENOSPC' }));
+			options.close();
+
+			// Wait long enough for the failed-watcher close promise to resolve and
+			// the `finally` callback to run (which should NOT reopen).
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			assert.equal(options._openCountForTests, 1, 'reopen must be suppressed by the close-during-fallback guard');
+
+			try {
+				rmSync(fixture, { recursive: true, force: true });
+				// eslint-disable-next-line sonarjs/no-ignored-exceptions
+			} catch {
+				// best-effort cleanup
+			}
+		});
+	});
 });

--- a/unitTests/config/rootConfigWatcher.test.js
+++ b/unitTests/config/rootConfigWatcher.test.js
@@ -75,4 +75,90 @@ describe('RootConfigWatcher', () => {
 
 		configWatcher.close();
 	});
+
+	describe('polling fallback on watcher exhaustion', () => {
+		// harper#488: when ENOSPC/EMFILE fires on the underlying chokidar
+		// watcher, the RootConfigWatcher should swap to a polling watcher
+		// rather than surfacing the error to consumers.
+
+		it('falls back to polling on ENOSPC and continues to receive change events', async () => {
+			const initial = { foo: 'bar' };
+			writeFileSync(this.configFilePath, stringify(initial));
+			const configWatcher = new RootConfigWatcher();
+			await configWatcher.ready;
+
+			const errorSpy = spy();
+			configWatcher.on('error', errorSpy);
+
+			assert.equal(configWatcher._usingPollingForTests, false);
+
+			configWatcher._simulateWatcherErrorForTests(Object.assign(new Error('boom'), { code: 'ENOSPC' }));
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			assert.equal(configWatcher._usingPollingForTests, true, 'should have flipped to polling');
+			assert.equal(errorSpy.callCount, 0, 'ENOSPC should be swallowed');
+
+			// Polling watcher should pick up subsequent writes; default polling
+			// interval is 1s, so allow up to ~3s for the change event.
+			const updated = { foo: 'after-fallback' };
+			await writeFile(this.configFilePath, stringify(updated));
+			const [changeValue] = await once(configWatcher, 'change');
+			assert.deepEqual(changeValue, updated, 'polling watcher should fire change');
+
+			configWatcher.close();
+		}).timeout(5000);
+
+		it('propagates non-exhaustion errors and does not fall back', async () => {
+			writeFileSync(this.configFilePath, stringify({ foo: 'bar' }));
+			const configWatcher = new RootConfigWatcher();
+			await configWatcher.ready;
+
+			const errorSpy = spy();
+			configWatcher.on('error', errorSpy);
+
+			configWatcher._simulateWatcherErrorForTests(Object.assign(new Error('boom'), { code: 'EACCES' }));
+			await new Promise((resolve) => setTimeout(resolve, 20));
+
+			assert.equal(configWatcher._usingPollingForTests, false);
+			assert.equal(errorSpy.callCount, 1, 'non-exhaustion error should propagate');
+
+			configWatcher.close();
+		});
+
+		it('swallows additional exhaustion errors during recovery', async () => {
+			writeFileSync(this.configFilePath, stringify({ foo: 'bar' }));
+			const configWatcher = new RootConfigWatcher();
+			await configWatcher.ready;
+
+			const errorSpy = spy();
+			configWatcher.on('error', errorSpy);
+
+			const enospc = () => Object.assign(new Error('boom'), { code: 'ENOSPC' });
+			configWatcher._simulateWatcherErrorForTests(enospc());
+			configWatcher._simulateWatcherErrorForTests(enospc());
+			configWatcher._simulateWatcherErrorForTests(Object.assign(new Error('boom'), { code: 'EMFILE' }));
+
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			assert.equal(configWatcher._usingPollingForTests, true);
+			assert.equal(errorSpy.callCount, 0, 'all exhaustion errors should be swallowed');
+
+			configWatcher.close();
+		});
+
+		it('does not reopen watcher if close() is called during recovery', async () => {
+			writeFileSync(this.configFilePath, stringify({ foo: 'bar' }));
+			const configWatcher = new RootConfigWatcher();
+			await configWatcher.ready;
+
+			assert.equal(configWatcher._openCountForTests, 1, 'one initial open');
+
+			configWatcher._simulateWatcherErrorForTests(Object.assign(new Error('boom'), { code: 'ENOSPC' }));
+			configWatcher.close();
+
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			assert.equal(configWatcher._openCountForTests, 1, 'reopen must be suppressed by the close-during-fallback guard');
+		});
+	});
 });

--- a/unitTests/utility/watcherFallback.test.js
+++ b/unitTests/utility/watcherFallback.test.js
@@ -1,0 +1,60 @@
+const {
+	isWatcherExhaustionError,
+	POLLING_FALLBACK_OPTIONS,
+	warnWatcherFallback,
+	_resetForTests,
+} = require('#src/utility/watcherFallback');
+const assert = require('node:assert/strict');
+
+describe('watcherFallback', () => {
+	describe('isWatcherExhaustionError', () => {
+		it('identifies ENOSPC errors', () => {
+			assert.equal(isWatcherExhaustionError(Object.assign(new Error('boom'), { code: 'ENOSPC' })), true);
+		});
+
+		it('identifies EMFILE errors', () => {
+			assert.equal(isWatcherExhaustionError(Object.assign(new Error('boom'), { code: 'EMFILE' })), true);
+		});
+
+		it('rejects unrelated error codes', () => {
+			assert.equal(isWatcherExhaustionError(Object.assign(new Error('boom'), { code: 'EACCES' })), false);
+		});
+
+		it('rejects errors with no code', () => {
+			assert.equal(isWatcherExhaustionError(new Error('boom')), false);
+		});
+
+		it('rejects non-error values', () => {
+			assert.equal(isWatcherExhaustionError(null), false);
+			assert.equal(isWatcherExhaustionError(undefined), false);
+			assert.equal(isWatcherExhaustionError('ENOSPC'), false);
+			assert.equal(isWatcherExhaustionError(42), false);
+		});
+	});
+
+	describe('POLLING_FALLBACK_OPTIONS', () => {
+		it('enables polling with a conservative interval', () => {
+			assert.equal(POLLING_FALLBACK_OPTIONS.usePolling, true);
+			// Intervals should be >=1s to bound CPU cost when the host is already
+			// under inotify/FD pressure.
+			assert.ok(POLLING_FALLBACK_OPTIONS.interval >= 1000, 'interval should be at least 1000ms');
+			assert.ok(POLLING_FALLBACK_OPTIONS.binaryInterval >= 1000, 'binaryInterval should be at least 1000ms');
+		});
+	});
+
+	describe('warnWatcherFallback', () => {
+		// We can't easily intercept the module-tagged logger here without monkey-patching,
+		// so this case only asserts the function is idempotent and doesn't throw — a
+		// regression that re-emits the warning hundreds of times per failing watcher
+		// would still be caught by manual log inspection during the integration scenario
+		// the helper exists for.
+		afterEach(() => {
+			_resetForTests();
+		});
+
+		it('does not throw on repeated invocation', () => {
+			assert.doesNotThrow(() => warnWatcherFallback('/some/path'));
+			assert.doesNotThrow(() => warnWatcherFallback('/some/other/path'));
+		});
+	});
+});

--- a/utility/watcherFallback.ts
+++ b/utility/watcherFallback.ts
@@ -1,0 +1,74 @@
+// Polling fallback for chokidar watchers.
+//
+// When the host system runs out of inotify watches (ENOSPC) or file descriptors
+// (EMFILE), native chokidar watchers emit an error and stop firing change
+// events. Polling-based watching doesn't consume inotify handles or per-watcher
+// file descriptors, so we fall back to it once and warn — see harper#488.
+
+import { loggerWithTag } from './logging/harper_logger.ts';
+
+// One-time process-wide warning so a thundering herd of failing watchers doesn't
+// produce hundreds of identical log lines.
+let exhaustionWarned = false;
+
+const fallbackLogger = loggerWithTag('watcher');
+
+/**
+ * Returns `true` if the chokidar error indicates the OS-level watcher pool is
+ * exhausted (inotify watches on Linux, open file descriptors on macOS/Linux).
+ */
+export function isWatcherExhaustionError(error: unknown): boolean {
+	if (typeof error !== 'object' || error === null) return false;
+	const code = (error as { code?: string }).code;
+	return code === 'ENOSPC' || code === 'EMFILE';
+}
+
+/**
+ * Polling-watch options to pass through to chokidar when falling back, for
+ * watchers backed by a single file (a config.yaml etc.).
+ *
+ * Intervals are deliberately conservative — polling-based watching is
+ * fundamentally less efficient than inotify, and once we're in this mode the
+ * host is already under resource pressure. A second-scale interval keeps CPU
+ * cost bounded; the alternative is to lose change events entirely.
+ */
+export const POLLING_FALLBACK_OPTIONS = {
+	usePolling: true,
+	interval: 1000,
+	binaryInterval: 2000,
+} as const;
+
+/**
+ * Polling-watch options for directory-tree watchers (EntryHandler). Chokidar
+ * polls fs.stat on every watched file each interval, so a tree with thousands
+ * of files at 1s would burn meaningful CPU; we trade responsiveness for cost
+ * here on the assumption that the host is already strained.
+ */
+export const DIRECTORY_POLLING_FALLBACK_OPTIONS = {
+	usePolling: true,
+	interval: 3000,
+	binaryInterval: 5000,
+} as const;
+
+/**
+ * Log a one-time warning when a watcher first falls back to polling. Subsequent
+ * fallbacks in the same process are silent.
+ */
+export function warnWatcherFallback(watchedPath: string): void {
+	if (exhaustionWarned) return;
+	exhaustionWarned = true;
+	fallbackLogger.warn?.(
+		`File watcher exhaustion (ENOSPC/EMFILE) on ${watchedPath}. ` +
+			'Falling back to polling-based watching for affected watchers — ' +
+			'this will increase CPU usage proportional to the size of the watched trees ' +
+			'and may delay or miss rapid file changes. ' +
+			'To restore native watching, raise the OS limit, for example: ' +
+			'`sudo sysctl -w fs.inotify.max_user_watches=524288` ' +
+			'or `sudo sysctl -w fs.inotify.max_user_instances=10000` (Linux).'
+	);
+}
+
+// Test-only hook to reset the one-time warning gate between cases.
+export function _resetForTests(): void {
+	exhaustionWarned = false;
+}


### PR DESCRIPTION
## Summary

Closes harper#488.

When chokidar's native watchers hit `ENOSPC` (inotify limit) or `EMFILE` (file descriptor limit), they emit an error and stop firing change events. Harper's three watcher classes — `EntryHandler` (per-component file tree), `OptionsWatcher` (per-component config.yaml), `RootConfigWatcher` (root harperdb-config.yaml) — now detect those exhaustion errors and transparently re-open the affected watcher with `usePolling: true`. Polling doesn't consume per-watch inotify handles or file descriptors, so Harper continues to function (with somewhat higher CPU and longer change-detection latency) until the operator raises the OS limit.

## Why

The original symptom in #488 was an `ENOSPC` thrown from an `OptionsWatcher` trying to add a single config-file watch — the system-wide watch pool was already exhausted by the time it tried. Increasing `fs.inotify.max_user_instances` resolves the immediate failure, but Harper was effectively dead at that point: subsequent watcher activity was unrecoverable without restart. This PR makes that scenario self-healing.

This is one of three independent mitigations for #488 (alongside PR #809 which tightens the ignore list, and a forthcoming PR that suppresses auto-reload during deploy).

## Where to look

- `utility/watcherFallback.ts` — shared module: `isWatcherExhaustionError`, `POLLING_FALLBACK_OPTIONS` (1s/2s for single-file watchers), `DIRECTORY_POLLING_FALLBACK_OPTIONS` (3s/5s for tree watchers, to bound CPU), `warnWatcherFallback` (process-wide one-time warning that includes the OS sysctl knobs and notes the CPU trade-off).
- Each of the three watcher classes:
  - Splits chokidar setup into `#openWatcher()` (or reuses existing `#watch()` for `EntryHandler`)
  - Catches exhaustion errors in the existing error handler, swaps to polling
  - Tracks `#usingPolling` and `#closed` flags to make the close→reopen sequence race-safe

## Cross-model review notes

- **Codex** flagged two real bugs (both fixed):
  1. After flipping `#usingPolling`, subsequent exhaustion errors during the same recovery cycle were still being emitted to consumers. Now swallowed.
  2. If `close()` is called while the failed-watcher `close()` is still pending, the `finally` callback was reopening a watcher after teardown. Now guarded by `#closed`.
- **Gemini** flagged three findings (all addressed):
  1. EntryHandler watching deep trees at 1s polling could burn meaningful CPU — moved to a 3s/5s interval set for directory watchers.
  2. The close-during-recovery test used a 1.5s `setTimeout` to assert "no event fired" — replaced with a deterministic `_openCountForTests` getter check (test now 102ms).
  3. `void .close().finally(...)` could surface unhandled promise rejections — added `.catch(() => {})` to swallow teardown rejections (these aren't actionable on an already-failed watcher).

## Potential concerns to focus on

- **Test-only API surface**: each watcher exposes `_simulateWatcherErrorForTests` / `_usingPollingForTests` (and `_openCountForTests` on `OptionsWatcher`). They're underscore-prefixed and `*ForTests`-suffixed. Open to renaming if there's an existing Harper convention.
- **Silent EMFILE-in-polling-mode**: once we're already polling, additional exhaustion errors are swallowed. In the (rare) case the polling watcher's `fs.stat` calls themselves can't acquire an FD, we'd silently miss changes until pressure subsides. The alternative (re-emitting after first warn) seems noisier than helpful given the operator already has the actionable info from the first warning.
- **Polling-and-atomic-renames**: chokidar's polling mode can miss the brief deletion phase of an atomic save. For a config.yaml-style file that's typically written via atomic rename by editors, this can cause an occasional missed reload while in fallback mode. Acceptable for a degraded-mode behavior.
- Generated by an LLM (Claude Opus 4.7).