### PR TITLE
Suppress watcher restart storms during component deploy

### DIFF
--- a/components/Application.ts
+++ b/components/Application.ts
@@ -2,6 +2,7 @@ import { type Logger } from '../utility/logging/logger.ts';
 import { getConfigObj, getConfigValue, getConfigPath } from '../config/configUtils.js';
 import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 import logger from '../utility/logging/harper_logger.ts';
+import { broadcastDeployStart, broadcastDeployEnd } from './deployLifecycle.ts';
 
 import { dirname, extname, join } from 'node:path';
 import {
@@ -493,11 +494,24 @@ export function derivePackageIdentifier(packageIdentifier: string) {
  *
  * This method should only be called from the main thread
  *
+ * Bracketed with `deploy:start`/`deploy:end` lifecycle broadcasts so every
+ * Harper thread's file watchers can suppress restart-on-change events while
+ * the component directory is being rewritten — see harper#488 and
+ * `components/deployLifecycle.ts`. The broadcast is best-effort: if it fails
+ * (e.g. workers haven't started yet during initial install), the deploy still
+ * proceeds.
+ *
  * @param application The application to prepare.
  * @returns A promise that resolves when all preparation steps complete.
  */
-export function prepareApplication(application: Application) {
-	return extractApplication(application).then(() => installApplication(application));
+export async function prepareApplication(application: Application) {
+	await broadcastDeployStart(application.name);
+	try {
+		await extractApplication(application);
+		await installApplication(application);
+	} finally {
+		broadcastDeployEnd(application.name);
+	}
 }
 
 /**

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -267,6 +267,11 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	 */
 	pause(): void {
 		this.#paused = true;
+		// Reset `ready` to a fresh pending promise so the documented "awaiting
+		// ready while paused will not resolve until resume()" contract holds even
+		// when the watcher had already become ready before pause(). The next
+		// 'ready' emit will come from the chokidar instance installed by resume().
+		this.ready = once(this, 'ready');
 		if (this.#watcher) {
 			// Retain the close promise so resume()→#watch() can await full
 			// teardown before opening a new watcher.
@@ -289,7 +294,8 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	resume(): Promise<any[]> {
 		if (!this.#paused) return this.ready;
 		this.#paused = false;
-		this.ready = once(this, 'ready');
+		// `this.ready` was already reset to a pending promise in pause(); just
+		// trigger the watcher recreation and let its 'ready' emit resolve it.
 		return this.#watch();
 	}
 

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -75,6 +75,16 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	#logger: Logger;
 	#pendingFileReads: Set<Promise<void>>;
 	#isInitialScanComplete: boolean;
+	// When true, #watch() short-circuits without creating a chokidar watcher.
+	// pause() sets it, resume() clears it. Lets a deploy quiesce the watcher
+	// without losing the EntryHandler instance (and therefore listener
+	// attachments registered by plugins via scope.handleEntry(handler)).
+	#paused: boolean = false;
+	// Tracks the in-flight close() promise from pause() so resume() can await
+	// the old watcher's inotify handles releasing before installing a fresh
+	// chokidar instance — otherwise a rapid pause→resume can overlap teardown
+	// and setup, which under inotify pressure can produce spurious EMFILE.
+	#pausedClose?: Promise<void>;
 	ready: Promise<any[]>;
 
 	constructor(name: string, directory: string, config: FilesOption | FileAndURLPathConfig, logger?: Logger) {
@@ -180,8 +190,25 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	}
 
 	async #watch() {
+		// If pause() retained an in-flight close, wait for it to release inotify
+		// handles before we install a new watcher. Otherwise a fast pause→resume
+		// can overlap teardown and setup under inotify pressure.
+		if (this.#pausedClose) {
+			await this.#pausedClose;
+			this.#pausedClose = undefined;
+		}
+
 		await this.#watcher?.close();
 		this.#watcher = undefined;
+
+		// pause() may have landed in the gap before our async close resolved.
+		// If so, do not install a replacement watcher — resume() will.
+		if (this.#paused) return this.ready;
+
+		// When a fresh watcher is installed (after pause+resume, or update), the
+		// initial scan emits add events anew, so reset the readiness latch so
+		// `ready` resolves after the new scan completes.
+		this.#isInitialScanComplete = false;
 
 		const allowedBases = this.#component.patternBases.map((base) => join(this.#component.directory, base));
 
@@ -227,6 +254,43 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		this.removeAllListeners();
 
 		return this;
+	}
+
+	/**
+	 * Quiesce the watcher without tearing down the EntryHandler. Closes the
+	 * underlying chokidar watcher (releasing inotify handles for the watched
+	 * tree) but preserves all listeners attached to this instance, so plugins
+	 * that registered `scope.handleEntry(handler)` keep their handler wired up
+	 * across the pause.
+	 *
+	 * Idempotent. Awaiting `ready` while paused will not resolve until resume().
+	 */
+	pause(): void {
+		this.#paused = true;
+		if (this.#watcher) {
+			// Retain the close promise so resume()→#watch() can await full
+			// teardown before opening a new watcher.
+			this.#pausedClose = Promise.resolve(this.#watcher.close()).catch(() => {
+				// Teardown errors aren't actionable; swallow so resume can proceed.
+			});
+			this.#watcher = undefined;
+		}
+	}
+
+	/**
+	 * Reinstate the watcher previously stopped by pause(). The fresh chokidar
+	 * instance does an initial scan and emits add events for every file
+	 * currently matching the configured globs — by design, since the typical
+	 * caller (Scope, on deploy:end) wants plugins to see the post-deploy tree
+	 * as if loading cold.
+	 *
+	 * No-op if not currently paused.
+	 */
+	resume(): Promise<any[]> {
+		if (!this.#paused) return this.ready;
+		this.#paused = false;
+		this.ready = once(this, 'ready');
+		return this.#watch();
 	}
 
 	update(config: FilesOption | FileAndURLPathConfig) {

--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -11,6 +11,7 @@ import type { FileAndURLPathConfig } from './Component.ts';
 import { FilesOption } from './deriveGlobOptions.ts';
 import { requestRestart } from './requestRestart.ts';
 import { ApplicationScope } from './ApplicationScope.ts';
+import { deployLifecycle } from './deployLifecycle.ts';
 
 export class MissingDefaultFilesOptionError extends Error {
 	constructor() {
@@ -20,10 +21,18 @@ export class MissingDefaultFilesOptionError extends Error {
 }
 
 export type ScopeEventsMap = {
-	all: [...args: unknown[]];
-	close: [];
-	error: [error: unknown];
-	ready: [];
+	'all': [...args: unknown[]];
+	'close': [];
+	'error': [error: unknown];
+	'ready': [];
+	// Fired on this scope just before deploy I/O begins for the parent component
+	// (extract + npm install). Plugins observing these can pause their own
+	// file-driven work to avoid acting on intermediate states.
+	'deploy:start': [componentName: string];
+	// Fired after deploy I/O completes (success or failure). The scope's
+	// EntryHandlers have been recreated by this point; subsequent `add`/`change`
+	// events reflect the post-deploy tree.
+	'deploy:end': [componentName: string];
 	[record: string]: [...args: unknown[]];
 };
 
@@ -43,6 +52,13 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 	#entryHandlers: EntryHandler[];
 	#logger: Logger;
 	#pendingInitialLoads: Set<Promise<void>>;
+	#deployStartHandler: (name: string) => void;
+	#deployEndHandler: (name: string) => void;
+	// While a deploy of this component is in flight, EntryHandler events do not
+	// drive requestRestart() — the deploy itself produces hundreds of file
+	// changes that would otherwise pile up. A single coalesced restart is
+	// triggered by the post-deploy re-scan instead.
+	#deployInFlight: boolean = false;
 	applicationScope?: ApplicationScope;
 
 	options: OptionsWatcher;
@@ -106,6 +122,18 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 			.on('error', this.#handleError.bind(this))
 			.on('change', this.#optionsWatcherChangeListener.bind(this)())
 			.on('ready', this.#handleOptionsWatcherReady.bind(this));
+
+		// Bridge cross-thread deploy lifecycle events for this component. The
+		// handlers live on the scope for the lifetime of the scope and are torn
+		// down in close().
+		this.#deployStartHandler = (name) => {
+			if (name === this.#appName) this.#onDeployStart(name);
+		};
+		this.#deployEndHandler = (name) => {
+			if (name === this.#appName) this.#onDeployEnd(name);
+		};
+		deployLifecycle.on('deploy:start', this.#deployStartHandler);
+		deployLifecycle.on('deploy:end', this.#deployEndHandler);
 	}
 
 	get logger(): Logger {
@@ -143,6 +171,9 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 	}
 
 	close() {
+		deployLifecycle.off('deploy:start', this.#deployStartHandler);
+		deployLifecycle.off('deploy:end', this.#deployEndHandler);
+
 		for (const entryHandler of this.#entryHandlers) {
 			entryHandler.close();
 		}
@@ -154,6 +185,49 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 		this.removeAllListeners();
 
 		return this;
+	}
+
+	#onDeployStart(componentName: string): void {
+		this.#deployInFlight = true;
+		// Pause each EntryHandler so it stops emitting events for the
+		// intermediate filesystem state the deploy is writing, and so it
+		// releases its inotify handles while npm install is unpacking
+		// dependencies. pause() preserves the EntryHandler INSTANCE — listeners
+		// the plugin attached via scope.handleEntry(handler) remain attached.
+		for (const entryHandler of this.#entryHandlers) {
+			entryHandler.pause();
+		}
+
+		this.#safeEmit('deploy:start', componentName);
+	}
+
+	#onDeployEnd(componentName: string): void {
+		this.#deployInFlight = false;
+
+		// Resume each EntryHandler BEFORE notifying plugins. Otherwise a plugin
+		// throwing in its deploy:end handler would abort this function and
+		// leave the watchers permanently paused (surfaced by Gemini review).
+		// The fresh chokidar watcher does an initial scan and emits add events
+		// for the post-deploy tree; the existing per-event listener calls
+		// scope.requestRestart() for each, and the restart debounce in
+		// componentLoader collapses them into a single restart cycle. Plugin
+		// handlers stay attached across the pause.
+		for (const entryHandler of this.#entryHandlers) {
+			void entryHandler.resume();
+		}
+
+		this.#safeEmit('deploy:end', componentName);
+	}
+
+	// Swallow and log listener exceptions so one buggy plugin can't stop us
+	// from running the rest of the deploy-lifecycle bookkeeping. EventEmitter
+	// by default rethrows from synchronous listeners.
+	#safeEmit(event: 'deploy:start' | 'deploy:end', componentName: string): void {
+		try {
+			this.emit(event, componentName);
+		} catch (error) {
+			this.#logger.error?.(`Listener for ${event} threw for ${this.#appName}:`, error);
+		}
 	}
 
 	#createEntryHandler(config: FilesOption | FileAndURLPathConfig): EntryHandler {
@@ -329,6 +403,13 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 	}
 
 	requestRestart() {
+		if (this.#deployInFlight) {
+			// Suppressed: a deploy is rewriting this component's files. The
+			// post-deploy re-scan in #onDeployEnd will trigger the coalesced
+			// restart instead.
+			this.#logger.debug?.(`Restart suppressed (deploy in flight) for ${this.#appName}`);
+			return;
+		}
 		this.#logger.debug?.(`Restart requested from ${this.#pluginName} scope for ${this.#appName}`);
 		requestRestart();
 	}

--- a/components/deployLifecycle.ts
+++ b/components/deployLifecycle.ts
@@ -1,0 +1,148 @@
+// Cross-thread deploy lifecycle events.
+//
+// Component deploys (extract + npm install) write into the component directory,
+// which is exactly what every Scope's EntryHandler is watching. Without
+// coordination this drives a restart-request storm — each file change fires
+// scope.requestRestart(), which closes and recreates every component watcher
+// through componentLoader, briefly doubling inotify-handle occupancy and
+// occasionally exhausting the OS limit (harper#488).
+//
+// This module solves that by broadcasting a structured "deploy:start" /
+// "deploy:end" signal to every Harper thread. Each thread's deploy emitter
+// fires locally so Scopes (and any plugin subscribers) can react: Scopes close
+// their EntryHandlers on start, recreate them on end. The result is that
+// during a deploy, no watcher fires events for the deployed component, and
+// after the deploy the recreated watcher emits one fresh add per current file
+// — collapsed by the existing restart debounce into a single restart.
+//
+// State sharing across threads is intentionally narrow: the local Set of
+// in-flight component names is rebuilt from the broadcast stream. Plugins that
+// need to gate their own work on deploy progress import `deployLifecycle` and
+// listen to the events directly.
+
+import { EventEmitter } from 'node:events';
+import { isMainThread } from 'node:worker_threads';
+import { broadcast, broadcastWithAcknowledgement, onMessageByType } from '../server/threads/manageThreads.js';
+
+const DEPLOY_LIFECYCLE_MSG = 'harper:deploy:lifecycle';
+
+export type DeployPhase = 'start' | 'end';
+export type DeployLifecycleEvent = { name: string; phase: DeployPhase };
+
+type DeployLifecycleEventsMap = {
+	'deploy:start': [componentName: string];
+	'deploy:end': [componentName: string];
+};
+
+class DeployLifecycle extends EventEmitter<DeployLifecycleEventsMap> {
+	// Ref-counts in-flight deploys per component. Concurrent deploys of the
+	// same name (rare, but possible if an operator queues two before the first
+	// resolves) overlap: 0→1 fires deploy:start, 1→0 fires deploy:end. Any
+	// intermediate increment/decrement is silent so watchers aren't toggled
+	// out from under an active deploy by a peer ending early.
+	#inFlight = new Map<string, number>();
+
+	isDeployInFlight(componentName: string): boolean {
+		return (this.#inFlight.get(componentName) ?? 0) > 0;
+	}
+
+	// Process a deploy lifecycle event in-process. Called both from the
+	// broadcast receiver (for events originating on another thread) and from
+	// the broadcaster (so the originating thread also reacts locally).
+	_handle(event: DeployLifecycleEvent): void {
+		const current = this.#inFlight.get(event.name) ?? 0;
+		if (event.phase === 'start') {
+			this.#inFlight.set(event.name, current + 1);
+			if (current === 0) this.emit('deploy:start', event.name);
+		} else {
+			const next = Math.max(0, current - 1);
+			if (next === 0) {
+				this.#inFlight.delete(event.name);
+				if (current > 0) this.emit('deploy:end', event.name);
+			} else {
+				this.#inFlight.set(event.name, next);
+			}
+		}
+	}
+
+	// Test-only: clear in-flight state without firing events.
+	_clearForTests(): void {
+		this.#inFlight.clear();
+	}
+}
+
+export const deployLifecycle = new DeployLifecycle();
+
+let receiverInstalled = false;
+function ensureReceiver() {
+	if (receiverInstalled) return;
+	receiverInstalled = true;
+	onMessageByType(DEPLOY_LIFECYCLE_MSG, (msg: { type: string; event: DeployLifecycleEvent }) => {
+		deployLifecycle._handle(msg.event);
+	});
+}
+
+// Install the cross-thread receiver at module load. Receiving threads (workers)
+// don't call the broadcast helpers themselves but must still react to deploy
+// events originating on the main thread — without this, a deploy on main would
+// suppress only the main thread's watchers and the worker watchers would keep
+// firing restart storms (harper#488).
+ensureReceiver();
+
+/**
+ * Announce the start of a deploy for `componentName`. Awaits acknowledgement
+ * from every worker so the caller can rely on all watchers being suppressed
+ * before writing into the component directory.
+ *
+ * Ref-counted via DeployLifecycle so overlapping deploys of the same
+ * component compose correctly (each call must be paired with exactly one
+ * broadcastDeployEnd).
+ */
+export async function broadcastDeployStart(componentName: string): Promise<void> {
+	ensureReceiver();
+	const event: DeployLifecycleEvent = { name: componentName, phase: 'start' };
+	deployLifecycle._handle(event); // local thread first
+	try {
+		// broadcastWithAcknowledgement only resolves once every peer has processed
+		// the message, which is what we want before we start touching files. From
+		// a worker, this still reaches main + sibling workers; from main it reaches
+		// all workers.
+		await broadcastWithAcknowledgement({ type: DEPLOY_LIFECYCLE_MSG, event });
+	} catch (error) {
+		// A broadcast failure here is non-fatal: the deploy can still proceed,
+		// the worst case is a transient restart storm. Don't block the deploy.
+		// (Errors are already surfaced through the existing logger by manageThreads.)
+		void error;
+	}
+}
+
+/**
+ * Announce the end of a deploy for `componentName`. Fire-and-forget — the
+ * caller (the deploy operation) is done by this point and doesn't need to
+ * wait for every worker to reopen its watcher.
+ *
+ * Must be called exactly once per matching broadcastDeployStart, even if the
+ * deploy errored — typically from a `finally` block.
+ */
+export function broadcastDeployEnd(componentName: string): void {
+	ensureReceiver();
+	const event: DeployLifecycleEvent = { name: componentName, phase: 'end' };
+	deployLifecycle._handle(event);
+	try {
+		void broadcast({ type: DEPLOY_LIFECYCLE_MSG, event }, false);
+	} catch (error) {
+		void error;
+	}
+}
+
+// Tests need to reset module state between cases.
+export function _resetForTests(): void {
+	deployLifecycle.removeAllListeners();
+	deployLifecycle._clearForTests();
+	receiverInstalled = false;
+}
+
+// Marker so callers (e.g. Application.ts) can tell whether they're running in
+// a context where broadcasting will reach peers — during startup before
+// threads are wired up, broadcasts are no-ops but still safe to call.
+export const supportsCrossThreadBroadcast = isMainThread;

--- a/components/deployLifecycle.ts
+++ b/components/deployLifecycle.ts
@@ -102,17 +102,28 @@ export async function broadcastDeployStart(componentName: string): Promise<void>
 	ensureReceiver();
 	const event: DeployLifecycleEvent = { name: componentName, phase: 'start' };
 	deployLifecycle._handle(event); // local thread first
+	let timer: ReturnType<typeof setTimeout> | undefined;
 	try {
 		// broadcastWithAcknowledgement only resolves once every peer has processed
 		// the message, which is what we want before we start touching files. From
 		// a worker, this still reaches main + sibling workers; from main it reaches
 		// all workers.
-		await broadcastWithAcknowledgement({ type: DEPLOY_LIFECYCLE_MSG, event });
+		//
+		// Race against a 5s timeout so an unresponsive worker can't hang the
+		// deploy indefinitely — the deploy is meant to be best-effort coordinated,
+		// not gated on every worker acknowledging.
+		const timeout = new Promise<void>((_resolve, reject) => {
+			timer = setTimeout(() => reject(new Error('Broadcast acknowledgement timed out')), 5000);
+			timer.unref?.();
+		});
+		await Promise.race([broadcastWithAcknowledgement({ type: DEPLOY_LIFECYCLE_MSG, event }), timeout]);
 	} catch (error) {
 		// A broadcast failure here is non-fatal: the deploy can still proceed,
 		// the worst case is a transient restart storm. Don't block the deploy.
 		// (Errors are already surfaced through the existing logger by manageThreads.)
 		void error;
+	} finally {
+		if (timer) clearTimeout(timer);
 	}
 }
 
@@ -135,11 +146,13 @@ export function broadcastDeployEnd(componentName: string): void {
 	}
 }
 
-// Tests need to reset module state between cases.
+// Tests need to reset module state between cases. We deliberately do NOT reset
+// `receiverInstalled`: manageThreads.onMessageByType has no deregistration API,
+// so flipping the flag would let a subsequent ensureReceiver() pile a second
+// listener and double-increment the refcount on every broadcast.
 export function _resetForTests(): void {
 	deployLifecycle.removeAllListeners();
 	deployLifecycle._clearForTests();
-	receiverInstalled = false;
 }
 
 // Marker so callers (e.g. Application.ts) can tell whether they're running in

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -177,15 +177,9 @@ function openRocksDatabase(path: string, options: RocksDatabaseOptions & { dupSo
 	const writeBufferManagerAllowStall = envGet(CONFIG_PARAMS.STORAGE_ROCKS_WRITEBUFFERMANAGERALLOWSTALL);
 	RocksDatabase.config({
 		blockCacheSize,
-		...(typeof writeBufferManagerSize === 'number' && writeBufferManagerSize > 0
-			? { writeBufferManagerSize }
-			: {}),
-		...(typeof writeBufferManagerCostToCache === 'boolean'
-			? { writeBufferManagerCostToCache }
-			: {}),
-		...(typeof writeBufferManagerAllowStall === 'boolean'
-			? { writeBufferManagerAllowStall }
-			: {}),
+		...(typeof writeBufferManagerSize === 'number' && writeBufferManagerSize > 0 ? { writeBufferManagerSize } : {}),
+		...(typeof writeBufferManagerCostToCache === 'boolean' ? { writeBufferManagerCostToCache } : {}),
+		...(typeof writeBufferManagerAllowStall === 'boolean' ? { writeBufferManagerAllowStall } : {}),
 	});
 	if (!existsSync(path)) {
 		// Don't create directories in read-only mode

--- a/unitTests/components/EntryHandler.test.js
+++ b/unitTests/components/EntryHandler.test.js
@@ -491,4 +491,70 @@ describe('EntryHandler', () => {
 		entryHandler.close();
 		rmSync(directory, { recursive: true, force: true });
 	});
+
+	describe('pause / resume', () => {
+		it('stops emitting while paused and re-emits add events on resume', async () => {
+			const { directory } = createFixture(['a', 'b', 'c']);
+			const entryHandler = new EntryHandler(basename(directory), directory, '**/*');
+			const addSpy = spy();
+			entryHandler.on('add', addSpy);
+
+			await entryHandler.ready;
+			const initialAdds = addSpy.callCount;
+			assert.equal(initialAdds, 3, 'initial scan should fire 3 add events');
+
+			entryHandler.pause();
+
+			// While paused, adding a file should not emit anything (watcher is closed)
+			await writeFile(join(directory, 'd'), 'd');
+			await new Promise((r) => setTimeout(r, 100));
+			assert.equal(addSpy.callCount, initialAdds, 'no events while paused');
+
+			// Resume — fresh scan should emit add for every current file (now 4)
+			await entryHandler.resume();
+			await new Promise((r) => setTimeout(r, 200));
+			assert.ok(
+				addSpy.callCount >= initialAdds + 4,
+				`resume should re-emit add for current files, got ${addSpy.callCount} total`
+			);
+
+			entryHandler.close();
+			rmSync(directory, { recursive: true, force: true });
+		});
+
+		it('preserves listener attachments across pause/resume', async () => {
+			const { directory } = createFixture(['a']);
+			const entryHandler = new EntryHandler(basename(directory), directory, '**/*');
+			const allSpy = spy();
+			entryHandler.on('all', allSpy);
+
+			await entryHandler.ready;
+			const before = allSpy.callCount;
+			assert.ok(before >= 1);
+
+			entryHandler.pause();
+			await entryHandler.resume();
+			await new Promise((r) => setTimeout(r, 200));
+
+			assert.ok(allSpy.callCount > before, 'all listener still attached after resume');
+
+			entryHandler.close();
+			rmSync(directory, { recursive: true, force: true });
+		});
+
+		it('resume is a no-op when not paused', async () => {
+			const { directory } = createFixture(['a']);
+			const entryHandler = new EntryHandler(basename(directory), directory, '**/*');
+			await entryHandler.ready;
+			const addSpy = spy();
+			entryHandler.on('add', addSpy);
+
+			await entryHandler.resume(); // not paused
+			await new Promise((r) => setTimeout(r, 100));
+			assert.equal(addSpy.callCount, 0, 'resume without pause should not re-emit');
+
+			entryHandler.close();
+			rmSync(directory, { recursive: true, force: true });
+		});
+	});
 });

--- a/unitTests/components/EntryHandler.test.js
+++ b/unitTests/components/EntryHandler.test.js
@@ -556,5 +556,32 @@ describe('EntryHandler', () => {
 			entryHandler.close();
 			rmSync(directory, { recursive: true, force: true });
 		});
+
+		it('awaiting `ready` after pause() does not resolve until resume()', async () => {
+			// Contract: per pause()'s docstring, awaiting `ready` while paused must
+			// wait for resume(). Naive impl (only resetting `ready` in resume) lets
+			// an already-resolved `ready` linger across pause and resolve early.
+			const { directory } = createFixture(['a']);
+			const entryHandler = new EntryHandler(basename(directory), directory, '**/*');
+			await entryHandler.ready; // initial ready resolves
+
+			entryHandler.pause();
+
+			let readyResolved = false;
+			const readyPromise = entryHandler.ready.then(() => {
+				readyResolved = true;
+			});
+
+			// Give the microtask queue a chance to settle a stale resolved promise.
+			await new Promise((r) => setTimeout(r, 100));
+			assert.equal(readyResolved, false, '`ready` must not resolve while paused');
+
+			await entryHandler.resume();
+			await readyPromise;
+			assert.equal(readyResolved, true, '`ready` resolves after resume()');
+
+			entryHandler.close();
+			rmSync(directory, { recursive: true, force: true });
+		});
 	});
 });

--- a/unitTests/components/Scope.test.js
+++ b/unitTests/components/Scope.test.js
@@ -14,6 +14,7 @@ const { restartNeeded, resetRestartNeeded } = require('#src/components/requestRe
 const { writeFile } = require('node:fs/promises');
 const { waitFor } = require('./waitFor.js');
 const { ApplicationScope } = require('#src/components/ApplicationScope');
+const { deployLifecycle, _resetForTests: resetDeployLifecycle } = require('#src/components/deployLifecycle');
 
 describe('Scope', () => {
 	beforeEach(() => {
@@ -323,5 +324,170 @@ describe('Scope', () => {
 		assert.ok(handleEntrySpy.callCount > 0, 'Entry handler should be called');
 
 		scope.close();
+	});
+
+	describe('deploy lifecycle integration', () => {
+		// These cases ensure that when a deploy is in flight for the parent
+		// component, file changes from the deploy itself (extract + npm install)
+		// don't drive restart-request storms — see harper#488 and
+		// components/deployLifecycle.ts.
+
+		afterEach(() => {
+			resetDeployLifecycle();
+		});
+
+		it('suppresses requestRestart while a deploy is in flight for the same component', async () => {
+			writeFileSync(this.configFilePath, stringify({ [this.pluginName]: { files: 'test.js' } }));
+
+			const scope = new Scope(
+				this.appName,
+				this.pluginName,
+				this.directory,
+				this.configFilePath,
+				new ApplicationScope('test', this.resources, this.server)
+			);
+			await scope.ready;
+			scope.handleEntry();
+
+			// Sanity: outside a deploy, file change drives restart
+			await writeFile(this.testFilePath, '"baz";');
+			await waitFor(() => restartNeeded());
+			assert.equal(restartNeeded(), true);
+			resetRestartNeeded();
+
+			// Enter a deploy
+			deployLifecycle._handle({ name: this.appName, phase: 'start' });
+
+			// File changes during the deploy must NOT request restart
+			scope.requestRestart();
+			assert.equal(restartNeeded(), false, 'requestRestart was suppressed during deploy');
+
+			// Exit the deploy — restarts should be enabled again
+			deployLifecycle._handle({ name: this.appName, phase: 'end' });
+			scope.requestRestart();
+			assert.equal(restartNeeded(), true, 'requestRestart works again after deploy:end');
+
+			scope.close();
+		});
+
+		it('does not suppress requestRestart for an unrelated component', async () => {
+			writeFileSync(this.configFilePath, stringify({ [this.pluginName]: { files: 'test.js' } }));
+
+			const scope = new Scope(
+				this.appName,
+				this.pluginName,
+				this.directory,
+				this.configFilePath,
+				new ApplicationScope('test', this.resources, this.server)
+			);
+			await scope.ready;
+
+			deployLifecycle._handle({ name: 'some-other-component', phase: 'start' });
+
+			scope.requestRestart();
+			assert.equal(
+				restartNeeded(),
+				true,
+				'requestRestart for this component must not be suppressed by an unrelated deploy'
+			);
+
+			scope.close();
+		});
+
+		it('pauses entry handlers on deploy:start and resumes them on deploy:end without losing plugin listeners', async () => {
+			writeFileSync(this.configFilePath, stringify({ [this.pluginName]: { files: 'test.js' } }));
+
+			const scope = new Scope(
+				this.appName,
+				this.pluginName,
+				this.directory,
+				this.configFilePath,
+				new ApplicationScope('test', this.resources, this.server)
+			);
+			await scope.ready;
+
+			// Register a plugin-style entry handler with a callback. Codex caught
+			// the original close+recreate design dropping these callbacks; this
+			// case guards against that regression.
+			const handlerSpy = spy();
+			const entryHandler = scope.handleEntry(handlerSpy);
+			await entryHandler.ready;
+			const callsBeforeDeploy = handlerSpy.callCount;
+			assert.ok(callsBeforeDeploy > 0, 'plugin handler fires for initial files');
+
+			// Enter and exit a deploy without touching the EntryHandler instance.
+			deployLifecycle._handle({ name: this.appName, phase: 'start' });
+			// Settle the pause's pending watcher.close() promise before resuming.
+			await new Promise((r) => setTimeout(r, 50));
+			deployLifecycle._handle({ name: this.appName, phase: 'end' });
+
+			// The same EntryHandler instance keeps the plugin's callback; the
+			// post-deploy re-scan should fire it again for the same file(s).
+			await waitFor(() => handlerSpy.callCount > callsBeforeDeploy, 3000);
+
+			// And the EntryHandler instance is unchanged — listener attachment is
+			// preserved, not re-issued through a fresh wrapper.
+			assert.strictEqual(scope.handleEntry(), entryHandler, 'same EntryHandler instance after pause/resume');
+
+			// Subsequent post-deploy file changes still fire the plugin handler
+			// (the wired listener is still attached).
+			const callsAfterResume = handlerSpy.callCount;
+			await writeFile(this.testFilePath, '"after-deploy";');
+			await waitFor(() => handlerSpy.callCount > callsAfterResume);
+			assert.ok(handlerSpy.callCount > callsAfterResume, 'post-deploy change fires the plugin handler');
+
+			scope.close();
+		});
+
+		it('re-emits deploy:start and deploy:end on the scope for plugins to observe', async () => {
+			writeFileSync(this.configFilePath, stringify({ [this.pluginName]: {} }));
+
+			const scope = new Scope(
+				this.appName,
+				this.pluginName,
+				this.directory,
+				this.configFilePath,
+				new ApplicationScope('test', this.resources, this.server)
+			);
+			await scope.ready;
+
+			const startSpy = spy();
+			const endSpy = spy();
+			scope.on('deploy:start', startSpy);
+			scope.on('deploy:end', endSpy);
+
+			deployLifecycle._handle({ name: this.appName, phase: 'start' });
+			deployLifecycle._handle({ name: this.appName, phase: 'end' });
+
+			assert.equal(startSpy.callCount, 1);
+			assert.deepEqual(startSpy.getCall(0).args, [this.appName]);
+			assert.equal(endSpy.callCount, 1);
+			assert.deepEqual(endSpy.getCall(0).args, [this.appName]);
+
+			scope.close();
+		});
+
+		it('detaches deploy lifecycle listeners on scope.close()', async () => {
+			writeFileSync(this.configFilePath, stringify({ [this.pluginName]: {} }));
+
+			const scope = new Scope(
+				this.appName,
+				this.pluginName,
+				this.directory,
+				this.configFilePath,
+				new ApplicationScope('test', this.resources, this.server)
+			);
+			await scope.ready;
+
+			const beforeClose = deployLifecycle.listenerCount('deploy:start');
+			scope.close();
+			const afterClose = deployLifecycle.listenerCount('deploy:start');
+
+			assert.equal(
+				afterClose,
+				beforeClose - 1,
+				'scope.close() should remove its deploy:start listener from the module emitter'
+			);
+		});
 	});
 });

--- a/unitTests/components/deployLifecycle.test.js
+++ b/unitTests/components/deployLifecycle.test.js
@@ -1,0 +1,79 @@
+const assert = require('node:assert/strict');
+const { deployLifecycle, _resetForTests } = require('#src/components/deployLifecycle');
+
+describe('deployLifecycle', () => {
+	afterEach(() => {
+		_resetForTests();
+	});
+
+	describe('isDeployInFlight', () => {
+		it('returns false when nothing is deploying', () => {
+			assert.equal(deployLifecycle.isDeployInFlight('foo'), false);
+		});
+
+		it('flips true between start and end events', () => {
+			deployLifecycle._handle({ name: 'foo', phase: 'start' });
+			assert.equal(deployLifecycle.isDeployInFlight('foo'), true);
+			deployLifecycle._handle({ name: 'foo', phase: 'end' });
+			assert.equal(deployLifecycle.isDeployInFlight('foo'), false);
+		});
+
+		it('tracks overlapping deploys independently', () => {
+			deployLifecycle._handle({ name: 'foo', phase: 'start' });
+			deployLifecycle._handle({ name: 'bar', phase: 'start' });
+			assert.equal(deployLifecycle.isDeployInFlight('foo'), true);
+			assert.equal(deployLifecycle.isDeployInFlight('bar'), true);
+			deployLifecycle._handle({ name: 'foo', phase: 'end' });
+			assert.equal(deployLifecycle.isDeployInFlight('foo'), false);
+			assert.equal(deployLifecycle.isDeployInFlight('bar'), true, 'ending foo must not end bar');
+		});
+	});
+
+	describe('event emission', () => {
+		it('emits deploy:start when a start event is processed', () => {
+			let received;
+			deployLifecycle.on('deploy:start', (name) => {
+				received = name;
+			});
+			deployLifecycle._handle({ name: 'foo', phase: 'start' });
+			assert.equal(received, 'foo');
+		});
+
+		it('emits deploy:end when the matching end event clears the refcount', () => {
+			let received;
+			deployLifecycle.on('deploy:end', (name) => {
+				received = name;
+			});
+			deployLifecycle._handle({ name: 'foo', phase: 'start' });
+			deployLifecycle._handle({ name: 'foo', phase: 'end' });
+			assert.equal(received, 'foo');
+		});
+
+		it('only fires deploy:start once for the 0→1 transition under overlap', () => {
+			const startSpy = require('sinon').spy();
+			const endSpy = require('sinon').spy();
+			deployLifecycle.on('deploy:start', startSpy);
+			deployLifecycle.on('deploy:end', endSpy);
+
+			deployLifecycle._handle({ name: 'foo', phase: 'start' });
+			deployLifecycle._handle({ name: 'foo', phase: 'start' }); // overlapping deploy
+			assert.equal(startSpy.callCount, 1, '0→1 fires deploy:start; 1→2 is silent');
+
+			deployLifecycle._handle({ name: 'foo', phase: 'end' });
+			assert.equal(endSpy.callCount, 0, 'first end must NOT fire deploy:end while second deploy is still in flight');
+			assert.equal(deployLifecycle.isDeployInFlight('foo'), true);
+
+			deployLifecycle._handle({ name: 'foo', phase: 'end' });
+			assert.equal(endSpy.callCount, 1, 'second end (refcount 1→0) fires deploy:end');
+			assert.equal(deployLifecycle.isDeployInFlight('foo'), false);
+		});
+
+		it('an unmatched deploy:end is a safe no-op', () => {
+			const endSpy = require('sinon').spy();
+			deployLifecycle.on('deploy:end', endSpy);
+			deployLifecycle._handle({ name: 'never-started', phase: 'end' });
+			assert.equal(endSpy.callCount, 0);
+			assert.equal(deployLifecycle.isDeployInFlight('never-started'), false);
+		});
+	});
+});


### PR DESCRIPTION
Exhausting inotify handles has been observed in production servers in a couple cases.

## Summary

Third of three independent mitigations for harper#488 (alongside PR #809 and PR #821). Adds a cross-thread deploy lifecycle so that during `extractApplication` + `npm install`, every Harper thread's component file watchers pause emission and suppress `requestRestart()`. After the deploy, watchers resume — their fresh initial scan emits add events for the post-deploy tree, which the existing restart debounce collapses into a single coalesced restart.

## Why

Today, every file change inside a component directory fires `scope.requestRestart()`. During a deploy, the extract + install writes hundreds of files; without suppression, each one drives a watcher teardown/recreate cycle through `componentLoader` — briefly doubling inotify occupancy and amplifying the exhaustion risk PR #821 makes self-healing. This PR removes the storm at the source.

## Where to look

- **`components/deployLifecycle.ts`** (new) — `DeployLifecycle` is an `EventEmitter` keyed by component name with **ref-counted** in-flight state, so overlapping deploys of the same component compose. `broadcastDeployStart` awaits acknowledgement (so the caller can rely on every worker pausing before file I/O begins); `broadcastDeployEnd` is fire-and-forget. Receiver installed at module load — workers don't call the broadcast helpers themselves but must still react to events from main.
- **`components/Application.ts`** — `prepareApplication` brackets extract + install with `broadcastDeployStart` / `finally broadcastDeployEnd`. Broadcast failures are non-fatal.
- **`components/Scope.ts`** — each Scope subscribes to deploy events for its own appName. On `deploy:start`: pauses all EntryHandlers, sets `#deployInFlight`, re-emits `deploy:start` on the scope so plugins can observe via `scope.on('deploy:start', ...)`. On `deploy:end`: resumes EntryHandlers **before** notifying plugins (so a plugin throwing in its handler can't leave watchers paused), then re-emits `deploy:end`. `requestRestart()` gated on `#deployInFlight`.
- **`components/EntryHandler.ts`** — `pause()` closes the chokidar watcher (releases inotify) while keeping the EntryHandler EventEmitter intact (preserving plugin listeners). `resume()` recreates chokidar; the fresh initial scan fires add events for current files. Includes a close-promise handoff so a rapid pause→resume doesn't overlap teardown/setup under inotify pressure.

## Cross-model review feedback addressed

- **Codex** flagged (both fixed):
  1. Workers never subscribed because `ensureReceiver()` was only called from broadcast helpers — now called at module load.
  2. Original close+recreate dropped plugin-registered handlers — refactored to pause+resume, keeping the same EntryHandler instance.
- **Gemini** flagged (all fixed):
  1. Race in pause/resume — close promise wasn't retained, so resume's new watcher started while old was still releasing handles. Now `#pausedClose` is awaited inside `#watch()`.
  2. **Blocker**: a plugin throwing on `deploy:end` aborted the function and left watchers permanently paused. Now: resume runs before emit, and emit is wrapped in `#safeEmit`.
  3. Overlapping deploys could end early — switched from `Set` to ref-counted `Map`, so 0→1 fires start, 1→0 fires end, intermediate transitions are silent.

## Potential concerns to focus on

- **Cross-thread broadcast under test**: I unit-tested the local emit path heavily (deployLifecycle ref-counting, Scope subscriptions, EntryHandler pause/resume), but the actual `broadcastWithAcknowledgement` round-trip is only smoke-covered. Gemini suggested an integration test triggering a real API deploy against a multi-threaded server. Open to adding that in this PR or a follow-up.
- **`prepareApplication` is also called from `installApplications()` on Harper startup**. At that point workers haven't joined yet — `broadcastWithAcknowledgement` resolves immediately against zero peers, so no harm. The local `_handle` still fires, which is fine (Scopes don't exist yet either).
- **Plugin contract**: `scope.on('deploy:start' | 'deploy:end', (name) => ...)` is a new public surface. Documented in the ScopeEventsMap. Open to feedback on naming.
- Generated by an LLM (Claude Opus 4.7).