### PR TITLE
Block component process.exit from terminating Harper workers

### DIFF
--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -177,15 +177,9 @@ function openRocksDatabase(path: string, options: RocksDatabaseOptions & { dupSo
 	const writeBufferManagerAllowStall = envGet(CONFIG_PARAMS.STORAGE_ROCKS_WRITEBUFFERMANAGERALLOWSTALL);
 	RocksDatabase.config({
 		blockCacheSize,
-		...(typeof writeBufferManagerSize === 'number' && writeBufferManagerSize > 0
-			? { writeBufferManagerSize }
-			: {}),
-		...(typeof writeBufferManagerCostToCache === 'boolean'
-			? { writeBufferManagerCostToCache }
-			: {}),
-		...(typeof writeBufferManagerAllowStall === 'boolean'
-			? { writeBufferManagerAllowStall }
-			: {}),
+		...(typeof writeBufferManagerSize === 'number' && writeBufferManagerSize > 0 ? { writeBufferManagerSize } : {}),
+		...(typeof writeBufferManagerCostToCache === 'boolean' ? { writeBufferManagerCostToCache } : {}),
+		...(typeof writeBufferManagerAllowStall === 'boolean' ? { writeBufferManagerAllowStall } : {}),
 	});
 	if (!existsSync(path)) {
 		// Don't create directories in read-only mode

--- a/server/fastifyRoutes.ts
+++ b/server/fastifyRoutes.ts
@@ -7,6 +7,7 @@ import autoload from '@fastify/autoload';
 import * as env from '../utility/environment/environmentManager.ts';
 import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 import * as harperLogger from '../utility/logging/harper_logger.ts';
+import { realExit } from './threads/workerProcessGuard.ts';
 import * as hdbCore from './fastifyRoutes/plugins/hdbCore.js';
 import * as userSchema from '../security/user.ts';
 import getServerOptions from './fastifyRoutes/helpers/getServerOptions.js';
@@ -101,7 +102,9 @@ export async function customFunctionsServer() {
 	} catch (err) {
 		harperLogger.error(`Custom Functions ${process.pid} Error: ${err}`);
 		harperLogger.error(err);
-		process.exit(1);
+		// Use realExit so this fatal worker bootstrap failure still terminates
+		// the worker even with the worker process guard installed.
+		realExit(1);
 	}
 }
 

--- a/server/jobs/jobProcess.ts
+++ b/server/jobs/jobProcess.ts
@@ -1,5 +1,8 @@
 'use strict';
 
+// Install the worker process guard first so user job code cannot terminate
+// the worker via process.exit() or an unhandled rejection.
+import { realExit } from '../threads/workerProcessGuard.ts';
 import * as hdbTerms from '../../utility/hdbTerms.ts';
 import * as hdbUtils from '../../utility/common_utils.ts';
 import harperLogger from '../../utility/logging/harper_logger.ts';
@@ -75,7 +78,7 @@ const JOB_ID = JOB_NAME.substring(4);
 	} finally {
 		await jobs.updateJob(jobObj);
 		setTimeout(() => {
-			process.exit(exitCode);
+			realExit(exitCode);
 		}, 3000).unref();
 	}
 })();

--- a/server/operationsServer.ts
+++ b/server/operationsServer.ts
@@ -5,6 +5,7 @@ import * as env from '../utility/environment/environmentManager.ts';
 env.initSync();
 import * as terms from '../utility/hdbTerms.ts';
 import harperLogger from '../utility/logging/harper_logger.ts';
+import { realExit } from './threads/workerProcessGuard.ts';
 import fastify, { FastifyInstance, FastifyReply, FastifyRequest, FastifyServerOptions } from 'fastify';
 import fastifyCors, { type FastifyCorsOptions } from '@fastify/cors';
 import fastifyCompress from '@fastify/compress';
@@ -92,7 +93,9 @@ async function operationsServer(options: ServerOptions & { resources?: Resources
 	} catch (err) {
 		console.error(`Failed to build server on ${process.pid}`, err);
 		harperLogger.fatal(err);
-		process.exit(1);
+		// Use realExit so this fatal worker bootstrap failure still terminates
+		// the worker even with the worker process guard installed.
+		realExit(1);
 	}
 }
 

--- a/server/serverHelpers/serverHandlers.js
+++ b/server/serverHelpers/serverHandlers.js
@@ -3,6 +3,7 @@
 const terms = require('../../utility/hdbTerms.ts');
 const hdbUtil = require('../../utility/common_utils.ts');
 const harperLogger = require('../../utility/logging/harper_logger.ts');
+const { realExit } = require('../threads/workerProcessGuard.ts');
 const { handleHDBError, hdbErrors } = require('../../utility/errors/hdbError.ts');
 const { isMainThread } = require('worker_threads');
 const { Readable } = require('stream');
@@ -42,7 +43,9 @@ function handleServerUncaughtException(err) {
 	}Terminating ${isMainThread ? 'HDB' : 'thread'}.`;
 	console.error(message);
 	harperLogger.fatal(message);
-	process.exit(1);
+	// Harper-intentional fatal termination on uncaught exception. Use realExit
+	// so the worker process guard does not intercept it.
+	realExit(1);
 }
 
 function serverErrorHandler(error, req, resp) {

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -1,5 +1,10 @@
 'use strict';
 
+// Must run before any component code is loaded so that process.exit() called
+// from component code (e.g. Next.js's `unhandledRejection` handler) is
+// intercepted in workers.
+const { realExit } = require('./workerProcessGuard.ts');
+
 const { Worker, MessageChannel, parentPort, isMainThread, threadId, workerData } = require('worker_threads');
 const { join, isAbsolute, extname } = require('path');
 const { server } = require('../Server.ts');
@@ -654,12 +659,12 @@ if (isMainThread) {
 			harperLogger.warn('Thread did not voluntarily terminate', threadId);
 			// Note that if this occurs, you may want to use this to debug what is currently running:
 			// require('why-is-node-running')();
-			process.exit(0);
+			realExit(0);
 		}, threadTerminationTimeout).unref(); // don't block the shutdown
 	});
 	// In Bun, worker.terminate() triggers a NAPI segfault; the main thread sends FORCE_EXIT
 	// instead, and the worker self-exits cleanly to avoid the crash.
 	onMessageByType(FORCE_EXIT, () => {
-		process.exit(0);
+		realExit(0);
 	});
 }

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -15,6 +15,7 @@ const terms = require('../../utility/hdbTerms.ts');
 const { server } = require('../Server.ts');
 let { createServer: createSecureSocketServer } = require('node:tls');
 const { restartNumber, getWorkerIndex } = require('./manageThreads.js');
+const { realExit } = require('./workerProcessGuard.ts');
 const { isBun } = require('../serverHelpers/Request.ts');
 const { createTLSSelector } = require('../../security/keys.ts');
 const { startupLog } = require('../../bin/run.ts');
@@ -172,7 +173,7 @@ function startServers() {
 						// shutdown (for these threads) means stop listening for incoming requests (finish what we are working) and
 						// close connections as possible, then let the event loop complete
 						closeServers().then(() => {
-							process.exit(0);
+							realExit(0);
 						});
 						// Clean up per-thread UDS socket and metadata files
 						httpComponent.cleanupUdsFiles();

--- a/server/threads/workerProcessGuard.ts
+++ b/server/threads/workerProcessGuard.ts
@@ -1,0 +1,93 @@
+/**
+ * Worker thread process guard.
+ *
+ * Components loaded into Harper workers (Next.js, in particular) register
+ * their own `unhandledRejection` handler that explicitly calls
+ * `process.exit()`. That terminates the entire worker — including
+ * replication and unrelated components — for what is logically an
+ * application-level error.
+ *
+ * In worker threads, this module:
+ *   - Intercepts `process.exit()` so component code cannot terminate the
+ *     worker. The original exit is preserved as `process._realExit` (and
+ *     as the exported `realExit()` helper) for Harper internal callers
+ *     that legitimately need to terminate the worker (shutdown,
+ *     FORCE_EXIT under Bun, etc.).
+ *   - Registers an `unhandledRejection` listener so the default Node.js
+ *     terminate-on-unhandled-rejection behavior is suppressed when no
+ *     other component handler exists.
+ *
+ * On the main thread this module is a no-op except for exposing
+ * `process._realExit` so internal callers can use the same name regardless
+ * of thread.
+ *
+ * Harper-internal callers that intentionally want to terminate should use
+ * the exported `realExit()` helper. It falls back to `process.exit` when
+ * the guard has not been loaded (e.g., CLI bin scripts), so the helper is
+ * always safe to call.
+ */
+
+import { isMainThread, threadId } from 'node:worker_threads';
+import * as harperLogger from '../../utility/logging/harper_logger.ts';
+
+declare global {
+	namespace NodeJS {
+		interface Process {
+			_realExit: (code?: number) => never;
+		}
+	}
+}
+
+const realExitImpl = process.exit.bind(process) as (code?: number) => never;
+
+// Expose the real exit on every thread so internal Harper callers have a
+// stable name to use regardless of which thread they run on. Make it
+// non-writable so component code cannot accidentally reassign it, but leave
+// it configurable so test doubles (sinon, etc.) can stub it.
+if (!process._realExit) {
+	Object.defineProperty(process, '_realExit', {
+		value: realExitImpl,
+		writable: false,
+		configurable: true,
+		enumerable: false,
+	});
+}
+
+/**
+ * Terminate the current process for real, bypassing the worker process
+ * guard's `process.exit` override. Safe to call from any thread — falls
+ * back to `process.exit` when the guard has not been loaded yet (e.g.,
+ * CLI bin scripts).
+ */
+export function realExit(code?: number): never {
+	// Prefer the (non-writable) `process._realExit` so test doubles that
+	// stub `_realExit` can intercept Harper-intentional exits. Fall back
+	// to `process.exit` when the guard hasn't been loaded.
+	return (process._realExit ?? process.exit)(code);
+}
+
+if (!isMainThread) {
+	// Replace the public process.exit. Component code calling this — directly
+	// or via a framework's `unhandledRejection` handler — should not be able
+	// to terminate the worker.
+	const interceptedExit = ((code?: number): never => {
+		const callSite = new Error('process.exit() intercepted').stack;
+		harperLogger.error(
+			`process.exit(${code ?? ''}) called in worker thread ${threadId} — ignored to keep Harper alive. ` +
+				`Use process._realExit() for legitimate internal shutdown.\n${callSite}`
+		);
+		// `never` is a structural lie here; we return undefined. Callers that
+		// rely on `process.exit` being terminal (e.g. dead-code analysis after
+		// the call) will see execution continue, which is the desired
+		// resilience behavior.
+		return undefined as never;
+	}) as typeof process.exit;
+	process.exit = interceptedExit;
+
+	// Defense in depth: if no other listener is registered, Node.js terminates
+	// the process on an unhandled rejection. Register a logging listener so the
+	// worker survives even when no component handler is loaded.
+	process.on('unhandledRejection', (reason) => {
+		harperLogger.error(`unhandledRejection in worker thread ${threadId}:`, reason);
+	});
+}

--- a/unitTests/server/serverHelpers/serverHandlers.test.js
+++ b/unitTests/server/serverHelpers/serverHandlers.test.js
@@ -72,7 +72,11 @@ describe('Test serverHandlers.js module ', () => {
 
 	describe('handleServerUncaughtException()', () => {
 		it('Should send error to console and log before exiting process', () => {
+			// handleServerUncaughtException uses process._realExit when available (set
+			// by workerProcessGuard) so the worker process guard does not intercept
+			// this intentional Harper-fatal exit. Stub both names to cover either path.
 			process_exit_stub = sandbox.stub(process, 'exit').callsFake(() => {});
+			const real_exit_stub = sandbox.stub(process, '_realExit').callsFake(() => {});
 			serverHandlers_rw.handleServerUncaughtException(TEST_ERR);
 
 			assert.ok(console_stub.calledOnce === true, 'Error should be sent to console as an error');
@@ -85,10 +89,12 @@ describe('Test serverHandlers.js module ', () => {
 				fatal_log_stub.args[0][0].includes(TEST_ERR.message) === true,
 				'Error should be passed to logger.fatal()'
 			);
-			assert.ok(process_exit_stub.calledOnce === true, 'Error should cause process to exit');
-			assert.ok(process_exit_stub.args[0][0] === 1, 'Process should exit with exit code 1');
+			const exitStub = real_exit_stub.called ? real_exit_stub : process_exit_stub;
+			assert.ok(exitStub.calledOnce === true, 'Error should cause process to exit');
+			assert.ok(exitStub.args[0][0] === 1, 'Process should exit with exit code 1');
 
 			process_exit_stub.restore();
+			real_exit_stub.restore();
 		});
 	});
 

--- a/unitTests/server/threads/workerProcessGuard-fixture.js
+++ b/unitTests/server/threads/workerProcessGuard-fixture.js
@@ -1,0 +1,44 @@
+'use strict';
+
+// Fixture script executed inside a Worker thread by workerProcessGuard.test.js.
+// Loads the guard, then exercises process.exit() / unhandled rejections on
+// command from the parent.
+
+require('#src/server/threads/workerProcessGuard');
+
+const { parentPort } = require('node:worker_threads');
+
+parentPort.on('message', (msg) => {
+	if (msg === 'try-exit') {
+		const exitBeforeCall = process.exit;
+		const realExit = process._realExit;
+		// This should be intercepted; execution must continue past this line.
+		process.exit(42);
+		parentPort.postMessage({
+			type: 'survived-exit',
+			realExitIsFunction: typeof realExit === 'function',
+			exitWasOverridden: exitBeforeCall !== realExit,
+		});
+	} else if (msg === 'try-exit-from-rejection') {
+		// Simulate a framework that registers its own unhandledRejection handler
+		// and explicitly calls process.exit() from it (Next.js production mode).
+		process.on('unhandledRejection', () => {
+			process.exit(1);
+		});
+		Promise.reject(new Error('fixture: simulated framework rejection'));
+		setImmediate(() => {
+			parentPort.postMessage({ type: 'survived-framework-exit' });
+		});
+	} else if (msg === 'trigger-unhandled-rejection') {
+		Promise.reject(new Error('fixture: unhandled rejection probe'));
+		setImmediate(() => {
+			parentPort.postMessage({ type: 'survived-rejection' });
+		});
+	} else if (msg === 'shutdown') {
+		// Use the real exit to terminate the fixture worker so the test process
+		// can move on. _realExit must remain a working exit primitive.
+		process._realExit(0);
+	}
+});
+
+parentPort.postMessage({ type: 'ready' });

--- a/unitTests/server/threads/workerProcessGuard.test.js
+++ b/unitTests/server/threads/workerProcessGuard.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const { Worker } = require('node:worker_threads');
+const path = require('node:path');
+const assert = require('node:assert/strict');
+
+const FIXTURE = path.join(__dirname, 'workerProcessGuard-fixture.js');
+
+function spawnFixture() {
+	const worker = new Worker(FIXTURE);
+	const ready = new Promise((resolve, reject) => {
+		worker.once('error', reject);
+		worker.once('message', (msg) => {
+			if (msg.type === 'ready') resolve();
+			else reject(new Error(`unexpected first message: ${JSON.stringify(msg)}`));
+		});
+	});
+	return { worker, ready };
+}
+
+async function sendAndAwait(worker, signal) {
+	return new Promise((resolve, reject) => {
+		worker.once('error', reject);
+		worker.once('message', resolve);
+		worker.postMessage(signal);
+	});
+}
+
+async function shutdown(worker) {
+	worker.postMessage('shutdown');
+	await new Promise((resolve) => worker.once('exit', resolve));
+}
+
+describe('workerProcessGuard', () => {
+	describe('main thread behavior', () => {
+		it('exposes process._realExit and does not override process.exit on the main thread', () => {
+			const originalExit = process.exit;
+			// Load via the same alias the production code uses.
+			require('#src/server/threads/workerProcessGuard');
+			assert.equal(typeof process._realExit, 'function', 'process._realExit should be defined');
+			// The guard installs _realExit as a bound copy, so we cannot assert reference equality
+			// to the original. The worker-thread tests below cover real exit semantics by using
+			// `process._realExit(0)` to terminate the fixture worker.
+			assert.equal(process.exit, originalExit, 'process.exit should not be overridden on the main thread');
+		});
+	});
+
+	describe('worker thread behavior', () => {
+		it('intercepts process.exit() so the worker stays alive', async () => {
+			const { worker, ready } = spawnFixture();
+			await ready;
+			try {
+				const message = await sendAndAwait(worker, 'try-exit');
+				assert.equal(message.type, 'survived-exit');
+				assert.equal(message.exitWasOverridden, true, 'process.exit should be replaced in workers');
+				assert.equal(message.realExitIsFunction, true, 'process._realExit should be a function in workers');
+			} finally {
+				await shutdown(worker);
+			}
+		});
+
+		it('keeps the worker alive after an unhandled rejection', async () => {
+			const { worker, ready } = spawnFixture();
+			await ready;
+			try {
+				const message = await sendAndAwait(worker, 'trigger-unhandled-rejection');
+				assert.equal(message.type, 'survived-rejection');
+			} finally {
+				await shutdown(worker);
+			}
+		});
+
+		it('keeps the worker alive when a framework handler calls process.exit() from unhandledRejection', async () => {
+			const { worker, ready } = spawnFixture();
+			await ready;
+			try {
+				const message = await sendAndAwait(worker, 'try-exit-from-rejection');
+				assert.equal(message.type, 'survived-framework-exit');
+			} finally {
+				await shutdown(worker);
+			}
+		});
+	});
+});

--- a/utility/environment/environmentManager.ts
+++ b/utility/environment/environmentManager.ts
@@ -118,7 +118,11 @@ export function initSync(force: boolean = false) {
 		log.error(INIT_ERR);
 		log.error(err);
 		console.error(err);
-		process.exit(1);
+		// Use _realExit so this fatal startup error still terminates the worker
+		// even with the worker process guard installed. Inline fallback (rather
+		// than importing the helper) avoids a utility -> server layer
+		// dependency; safe because both alternatives are real exit primitives.
+		(process._realExit ?? process.exit)(1);
 	}
 }
 


### PR DESCRIPTION
## Summary

Worker thread process guard that intercepts `process.exit()` so component code (e.g., Next.js's production `unhandledRejection` handler) cannot terminate the worker. The real exit is preserved for Harper-internal callers as `process._realExit` and via the exported `realExit()` helper.

This could be exported from the `harper` synthetic module as well, but this approach seems fine.

## Why

We hit this in production on a demo Fabric cluster: a Harper version mismatch caused `@harperfast/nextjs` to fail loading `harper/dist/core/index.js`, triggering an unhandled rejection in the component. Next.js's process-level handler caught it and explicitly called `process.exit()`, killing the entire worker — replication and unrelated components included — for what is logically an application error. The peer node then entered a crash loop, which produced a constant TLS-reconnect storm on the surviving node.

## Approach

- `server/threads/workerProcessGuard.ts`: new module. In worker threads, replaces `process.exit` with a logging no-op and registers a logging `unhandledRejection` listener. Exposes `process._realExit` (set via `Object.defineProperty` with `writable: false`) and an exported `realExit(code?)` helper on every thread.
- `manageThreads.js` requires the guard at the very top so it runs before any component code in workers.
- `jobProcess.ts` imports the guard directly (job workers don't go through `manageThreads.js`).
- Harper-intentional fatal exits updated to use `realExit()` / the inline fallback: shutdown/FORCE_EXIT in `manageThreads`/`threadServer`, job completion in `jobProcess`, fatal startup failures in `operationsServer`/`fastifyRoutes`/`serverHandlers`, and config init failure in `environmentManager` (inline fallback there to avoid a `utility/` → `server/` import).

## Where to look

- **`server/threads/workerProcessGuard.ts`** — design intent and edge cases (Bun, hardening, the structural-`never` lie when execution continues after a blocked exit) are commented inline.
- **The fallback pattern** in `environmentManager.ts` — kept inline rather than importing the helper to avoid a backward layer dependency. Worth confirming that's the right call.
- **Behavioral change**: Harper's `handleServerUncaughtException` in workers no longer takes down the worker when the guard is in place unless we explicitly route it through `realExit()` (we do). The `serverHandlers.test.js` update reflects this — the test now stubs both `_realExit` and `exit`.

## Test plan

- [x] `npx mocha unitTests/server/threads/workerProcessGuard.test.js` — 4 passing (main-thread no-op, worker exit intercept, unhandled-rejection survival, framework-handler exit intercept)
- [x] `npx mocha unitTests/server/serverHelpers/serverHandlers.test.js` — 23 passing (covers the updated stub)
- [x] `npm run test:unit:main` — 2103 passing / 31 failing / 197 pending. The 31 failures are pre-existing worktree-path issues (component loader rejects `node_modules/mqtt` as "outside the allowed path" because the worktree is nested inside the repo); none touch files in this PR.
- [x] `npm run test:unit:resources` — 536 passing / 12 pending / 0 failing
- [x] Codex CLI cross-model review — fixed the three findings (require-`.ts` was a false positive; logger-import style was also a false positive consistent with existing code; the standalone-context `_realExit` undefined risk and operator-precedence concerns are addressed by the new `realExit()` helper and `Object.defineProperty` hardening)
- [x] Gemini (agy) cross-model review — same three fixes applied; added `Object.defineProperty(... writable: false, configurable: true)` so tests can still stub via sinon

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Sonnet 4.6)