### PR TITLE
Add input validation to `get_analytics` operation

### DIFF
--- a/resources/ResourceInterface.ts
+++ b/resources/ResourceInterface.ts
@@ -138,24 +138,27 @@ export interface SourceContext<TRequestContext = Context, Record extends object 
 
 export type Operator = 'and' | 'or';
 
-export type Comparator =
-	| 'between'
-	| 'contains'
-	| 'ends_with'
-	| 'eq'
-	| 'equals'
-	| 'gt'
-	| 'ge'
-	| 'lt'
-	| 'le'
-	| 'greater_than'
-	| 'greater_than_equal'
-	| 'in'
-	| 'less_than'
-	| 'less_than_equal'
-	| 'ne'
-	| 'not_equal'
-	| 'starts_with';
+export const COMPARATORS = [
+	'between',
+	'contains',
+	'ends_with',
+	'eq',
+	'equals',
+	'gt',
+	'ge',
+	'lt',
+	'le',
+	'greater_than',
+	'greater_than_equal',
+	'in',
+	'less_than',
+	'less_than_equal',
+	'ne',
+	'not_equal',
+	'starts_with',
+] as const;
+
+export type Comparator = (typeof COMPARATORS)[number];
 
 export type DirectCondition<Record extends object = any> = TypedDirectCondition<Record, keyof Record>;
 

--- a/resources/analytics/read.ts
+++ b/resources/analytics/read.ts
@@ -6,6 +6,8 @@ import type { Condition, Conditions } from '../ResourceInterface.ts';
 import { METRIC, type BuiltInMetricName } from './metadata.ts';
 import { CONFIG_PARAMS } from '../../utility/hdbTerms.ts';
 import { get as envGet } from '../../utility/environment/environmentManager.ts';
+import { validateGetAnalytics } from '../../validation/analyticsValidator.ts';
+import { handleHDBError, hdbErrors } from '../../utility/errors/hdbError.ts';
 
 // default to one week time window for finding custom metrics
 const defaultCustomMetricWindow = 1000 * 60 * 60 * 24 * 7;
@@ -34,8 +36,24 @@ interface GetAnalyticsRequest {
 
 type GetAnalyticsResponse = Metric[];
 
+/**
+ * Validates the `get_analytics` request and returns the analytics results.
+ * @param req
+ * @returns
+ */
 export function getOp(req: GetAnalyticsRequest): Promise<GetAnalyticsResponse> {
 	log.trace?.('get_analytics request:', req);
+	const validationError = validateGetAnalytics(req);
+	if (validationError) {
+		throw handleHDBError(
+			validationError,
+			validationError.message,
+			hdbErrors.HTTP_STATUS_CODES.BAD_REQUEST,
+			undefined,
+			undefined,
+			true
+		);
+	}
 	return get(req.metric, {
 		getAttributes: req.get_attributes,
 		startTime: req.start_time,

--- a/resources/analytics/read.ts
+++ b/resources/analytics/read.ts
@@ -41,7 +41,7 @@ type GetAnalyticsResponse = Metric[];
  * @param req
  * @returns
  */
-export function getOp(req: GetAnalyticsRequest): Promise<GetAnalyticsResponse> {
+export async function getOp(req: GetAnalyticsRequest): Promise<GetAnalyticsResponse> {
 	log.trace?.('get_analytics request:', req);
 	const validationError = validateGetAnalytics(req);
 	if (validationError) {

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -177,15 +177,9 @@ function openRocksDatabase(path: string, options: RocksDatabaseOptions & { dupSo
 	const writeBufferManagerAllowStall = envGet(CONFIG_PARAMS.STORAGE_ROCKS_WRITEBUFFERMANAGERALLOWSTALL);
 	RocksDatabase.config({
 		blockCacheSize,
-		...(typeof writeBufferManagerSize === 'number' && writeBufferManagerSize > 0
-			? { writeBufferManagerSize }
-			: {}),
-		...(typeof writeBufferManagerCostToCache === 'boolean'
-			? { writeBufferManagerCostToCache }
-			: {}),
-		...(typeof writeBufferManagerAllowStall === 'boolean'
-			? { writeBufferManagerAllowStall }
-			: {}),
+		...(typeof writeBufferManagerSize === 'number' && writeBufferManagerSize > 0 ? { writeBufferManagerSize } : {}),
+		...(typeof writeBufferManagerCostToCache === 'boolean' ? { writeBufferManagerCostToCache } : {}),
+		...(typeof writeBufferManagerAllowStall === 'boolean' ? { writeBufferManagerAllowStall } : {}),
 	});
 	if (!existsSync(path)) {
 		// Don't create directories in read-only mode

--- a/unitTests/validation/analyticsValidator.test.js
+++ b/unitTests/validation/analyticsValidator.test.js
@@ -158,4 +158,9 @@ describe('validateGetAnalytics', function () {
 		const error = validateGetAnalytics({ metric: 'cpu-usage', conditions: [{}] });
 		assert.ok(error instanceof Error);
 	});
+
+	it('should reject a condition with attribute but no comparator or value', function () {
+		const error = validateGetAnalytics({ metric: 'cpu-usage', conditions: [{ attribute: 'path' }] });
+		assert.ok(error instanceof Error);
+	});
 });

--- a/unitTests/validation/analyticsValidator.test.js
+++ b/unitTests/validation/analyticsValidator.test.js
@@ -1,0 +1,145 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { validateGetAnalytics } = require('#src/validation/analyticsValidator');
+
+describe('validateGetAnalytics', function () {
+	// ── Happy paths ──────────────────────────────────────────────────────────
+
+	it('should accept a minimal valid request (metric only)', function () {
+		assert.strictEqual(validateGetAnalytics({ metric: 'cpu-usage' }), undefined);
+	});
+
+	it('should accept a fully-specified valid request', function () {
+		assert.strictEqual(
+			validateGetAnalytics({
+				operation: 'get_analytics',
+				metric: 'cpu-usage',
+				start_time: 1779834663816,
+				end_time: 1779834763816,
+				get_attributes: ['value', 'node'],
+				coalesce_time: true,
+				conditions: [{ attribute: 'path', comparator: 'equals', value: '/api/test' }],
+			}),
+			undefined
+		);
+	});
+
+	it('should allow extra fields (operation, hdb_user, etc.) via allowUnknown', function () {
+		assert.strictEqual(
+			validateGetAnalytics({ operation: 'get_analytics', metric: 'cpu-usage', hdb_user: { username: 'admin' } }),
+			undefined
+		);
+	});
+
+	it('should accept legacy condition field names (search_attribute / search_type / search_value)', function () {
+		assert.strictEqual(
+			validateGetAnalytics({
+				metric: 'cpu-usage',
+				conditions: [{ search_attribute: 'path', search_type: 'equals', search_value: '/api/test' }],
+			}),
+			undefined
+		);
+	});
+
+	it('should accept a group condition with nested conditions array', function () {
+		assert.strictEqual(
+			validateGetAnalytics({
+				metric: 'cpu-usage',
+				conditions: [
+					{
+						operator: 'or',
+						conditions: [
+							{ attribute: 'method', comparator: 'equals', value: 'GET' },
+							{ attribute: 'method', comparator: 'equals', value: 'POST' },
+						],
+					},
+				],
+			}),
+			undefined
+		);
+	});
+
+	// ── metric field ─────────────────────────────────────────────────────────
+
+	it('should reject a request with no metric', function () {
+		const error = validateGetAnalytics({ operation: 'get_analytics' });
+		assert.ok(error instanceof Error);
+		assert.ok(error.message.includes('metric'), `expected "metric" in: ${error.message}`);
+	});
+
+	it('should reject a non-string metric', function () {
+		const error = validateGetAnalytics({ metric: 42 });
+		assert.ok(error instanceof Error);
+		assert.ok(error.message.includes('metric'), `expected "metric" in: ${error.message}`);
+	});
+
+	// ── start_time / end_time ────────────────────────────────────────────────
+
+	it('should reject start_time as a numeric string', function () {
+		const error = validateGetAnalytics({ metric: 'cpu-usage', start_time: '1779834663816' });
+		assert.ok(error instanceof Error);
+		assert.ok(error.message.includes('start_time'), `expected "start_time" in: ${error.message}`);
+	});
+
+	it('should reject end_time as a non-numeric string', function () {
+		const error = validateGetAnalytics({ metric: 'cpu-usage', end_time: 'tomorrow' });
+		assert.ok(error instanceof Error);
+		assert.ok(error.message.includes('end_time'), `expected "end_time" in: ${error.message}`);
+	});
+
+	it('should accept start_time and end_time as numbers', function () {
+		assert.strictEqual(
+			validateGetAnalytics({ metric: 'cpu-usage', start_time: 1779834663816, end_time: 1779834763816 }),
+			undefined
+		);
+	});
+
+	// ── get_attributes ───────────────────────────────────────────────────────
+
+	it('should reject get_attributes as a plain string instead of an array', function () {
+		const error = validateGetAnalytics({ metric: 'cpu-usage', get_attributes: 'value' });
+		assert.ok(error instanceof Error);
+		assert.ok(error.message.includes('get_attributes'), `expected "get_attributes" in: ${error.message}`);
+	});
+
+	it('should accept get_attributes as an array of strings', function () {
+		assert.strictEqual(
+			validateGetAnalytics({ metric: 'cpu-usage', get_attributes: ['value', 'node', 'count'] }),
+			undefined
+		);
+	});
+
+	// ── coalesce_time ────────────────────────────────────────────────────────
+
+	it('should reject coalesce_time as the string "true"', function () {
+		const error = validateGetAnalytics({ metric: 'cpu-usage', coalesce_time: 'true' });
+		assert.ok(error instanceof Error);
+		assert.ok(error.message.includes('coalesce_time'), `expected "coalesce_time" in: ${error.message}`);
+	});
+
+	it('should reject coalesce_time as the number 1', function () {
+		const error = validateGetAnalytics({ metric: 'cpu-usage', coalesce_time: 1 });
+		assert.ok(error instanceof Error);
+		assert.ok(error.message.includes('coalesce_time'), `expected "coalesce_time" in: ${error.message}`);
+	});
+
+	it('should accept coalesce_time as false', function () {
+		assert.strictEqual(validateGetAnalytics({ metric: 'cpu-usage', coalesce_time: false }), undefined);
+	});
+
+	// ── conditions ───────────────────────────────────────────────────────────
+
+	it('should reject conditions as a plain object instead of an array', function () {
+		const error = validateGetAnalytics({
+			metric: 'cpu-usage',
+			conditions: { attribute: 'path', comparator: 'equals', value: '/api' },
+		});
+		assert.ok(error instanceof Error);
+		assert.ok(error.message.includes('conditions'), `expected "conditions" in: ${error.message}`);
+	});
+
+	it('should accept an empty conditions array', function () {
+		assert.strictEqual(validateGetAnalytics({ metric: 'cpu-usage', conditions: [] }), undefined);
+	});
+});

--- a/unitTests/validation/analyticsValidator.test.js
+++ b/unitTests/validation/analyticsValidator.test.js
@@ -154,7 +154,8 @@ describe('validateGetAnalytics', function () {
 		assert.ok(error.message.includes('conditions'), `expected "conditions" in: ${error.message}`);
 	});
 
-	it('should accept a condition that is an empty object (directConditionSchema has all-optional fields)', function () {
-		assert.strictEqual(validateGetAnalytics({ metric: 'cpu-usage', conditions: [{}] }), undefined);
+	it('should reject a direct condition with no attribute, comparator, or value', function () {
+		const error = validateGetAnalytics({ metric: 'cpu-usage', conditions: [{}] });
+		assert.ok(error instanceof Error);
 	});
 });

--- a/unitTests/validation/analyticsValidator.test.js
+++ b/unitTests/validation/analyticsValidator.test.js
@@ -142,4 +142,19 @@ describe('validateGetAnalytics', function () {
 	it('should accept an empty conditions array', function () {
 		assert.strictEqual(validateGetAnalytics({ metric: 'cpu-usage', conditions: [] }), undefined);
 	});
+
+	it('should reject a condition with an invalid comparator', function () {
+		const error = validateGetAnalytics({
+			metric: 'cpu-usage',
+			conditions: [{ attribute: 'path', comparator: 'not_a_real_op', value: '/api' }],
+		});
+		assert.ok(error instanceof Error);
+		// Joi.alternatives() surfaces a top-level "doesn't match any type" error rather than
+		// the sub-schema field error, so we assert on the array path rather than the field name.
+		assert.ok(error.message.includes('conditions'), `expected "conditions" in: ${error.message}`);
+	});
+
+	it('should accept a condition that is an empty object (directConditionSchema has all-optional fields)', function () {
+		assert.strictEqual(validateGetAnalytics({ metric: 'cpu-usage', conditions: [{}] }), undefined);
+	});
 });

--- a/unitTests/validation/analyticsValidator.test.js
+++ b/unitTests/validation/analyticsValidator.test.js
@@ -95,6 +95,18 @@ describe('validateGetAnalytics', function () {
 		);
 	});
 
+	it('should reject a zero start_time', function () {
+		const error = validateGetAnalytics({ metric: 'cpu-usage', start_time: 0 });
+		assert.ok(error instanceof Error);
+		assert.ok(error.message.includes('start_time'), `expected "start_time" in: ${error.message}`);
+	});
+
+	it('should reject a negative end_time', function () {
+		const error = validateGetAnalytics({ metric: 'cpu-usage', end_time: -1 });
+		assert.ok(error instanceof Error);
+		assert.ok(error.message.includes('end_time'), `expected "end_time" in: ${error.message}`);
+	});
+
 	// ── get_attributes ───────────────────────────────────────────────────────
 
 	it('should reject get_attributes as a plain string instead of an array', function () {

--- a/validation/analyticsValidator.ts
+++ b/validation/analyticsValidator.ts
@@ -31,8 +31,8 @@ const groupConditionSchema = Joi.object({
 // silently converted. Strictness propagates to child schemas.
 const getAnalyticsSchema = Joi.object({
 	metric: Joi.string().required(),
-	start_time: Joi.number().min(0),
-	end_time: Joi.number().min(0),
+	start_time: Joi.number().greater(0),
+	end_time: Joi.number().greater(0),
 	get_attributes: Joi.array().items(Joi.string()),
 	coalesce_time: Joi.boolean(),
 	conditions: Joi.array().items(Joi.alternatives(groupConditionSchema, directConditionSchema)),

--- a/validation/analyticsValidator.ts
+++ b/validation/analyticsValidator.ts
@@ -13,7 +13,10 @@ const directConditionSchema = Joi.object({
 	search_type: Joi.string().valid(...COMPARATORS),
 	value: Joi.any(),
 	search_value: Joi.any(),
-}).or('attribute', 'search_attribute');
+})
+	.or('attribute', 'search_attribute')
+	.or('comparator', 'search_type')
+	.or('value', 'search_value');
 
 // A condition group. The nested `conditions` array is left unconstrained for
 // the same reason searchByConditionsSchema leaves it unconstrained: shallow

--- a/validation/analyticsValidator.ts
+++ b/validation/analyticsValidator.ts
@@ -1,0 +1,40 @@
+import Joi from 'joi';
+import * as validator from './validationWrapper.ts';
+import { COMPARATORS } from '../resources/ResourceInterface.ts';
+
+// A leaf condition. Both the canonical (attribute/comparator/value) and the
+// legacy (search_attribute/search_type/search_value) names are accepted —
+// `conformCondition` in resources/analytics/read.ts maps the latter onto the
+// former.
+const directConditionSchema = Joi.object({
+	attribute: Joi.string(),
+	search_attribute: Joi.string(),
+	comparator: Joi.string().valid(...COMPARATORS),
+	search_type: Joi.string().valid(...COMPARATORS),
+	value: Joi.any(),
+	search_value: Joi.any(),
+});
+
+// A condition group. The nested `conditions` array is left unconstrained for
+// the same reason searchByConditionsSchema leaves it unconstrained: shallow
+// validation here is enough to reject scalar/wrong-type inputs at the boundary.
+const groupConditionSchema = Joi.object({
+	operator: Joi.string().valid('and', 'or'),
+	conditions: Joi.array(),
+});
+
+// `.strict()` disables Joi's default type coercion so a numeric string like
+// '1779834663816' is rejected for a `Joi.number()` field instead of being
+// silently converted. Strictness propagates to child schemas.
+const getAnalyticsSchema = Joi.object({
+	metric: Joi.string().required(),
+	start_time: Joi.number(),
+	end_time: Joi.number(),
+	get_attributes: Joi.array().items(Joi.string()),
+	coalesce_time: Joi.boolean(),
+	conditions: Joi.array().items(Joi.alternatives(groupConditionSchema, directConditionSchema)),
+}).strict();
+
+export function validateGetAnalytics(req: any): Error | undefined {
+	return validator.validateBySchema(req, getAnalyticsSchema);
+}

--- a/validation/analyticsValidator.ts
+++ b/validation/analyticsValidator.ts
@@ -28,8 +28,8 @@ const groupConditionSchema = Joi.object({
 // silently converted. Strictness propagates to child schemas.
 const getAnalyticsSchema = Joi.object({
 	metric: Joi.string().required(),
-	start_time: Joi.number(),
-	end_time: Joi.number(),
+	start_time: Joi.number().min(0),
+	end_time: Joi.number().min(0),
 	get_attributes: Joi.array().items(Joi.string()),
 	coalesce_time: Joi.boolean(),
 	conditions: Joi.array().items(Joi.alternatives(groupConditionSchema, directConditionSchema)),

--- a/validation/analyticsValidator.ts
+++ b/validation/analyticsValidator.ts
@@ -13,7 +13,7 @@ const directConditionSchema = Joi.object({
 	search_type: Joi.string().valid(...COMPARATORS),
 	value: Joi.any(),
 	search_value: Joi.any(),
-});
+}).or('attribute', 'search_attribute');
 
 // A condition group. The nested `conditions` array is left unconstrained for
 // the same reason searchByConditionsSchema leaves it unconstrained: shallow

--- a/validation/analyticsValidator.ts
+++ b/validation/analyticsValidator.ts
@@ -20,7 +20,7 @@ const directConditionSchema = Joi.object({
 // validation here is enough to reject scalar/wrong-type inputs at the boundary.
 const groupConditionSchema = Joi.object({
 	operator: Joi.string().valid('and', 'or'),
-	conditions: Joi.array(),
+	conditions: Joi.array().required(),
 });
 
 // `.strict()` disables Joi's default type coercion so a numeric string like

--- a/validation/searchValidator.ts
+++ b/validation/searchValidator.ts
@@ -5,6 +5,7 @@ import * as hdbUtils from '../utility/common_utils.ts';
 import { hdbSchemaTable, checkValidTable, hdbTable, hdbDatabase } from './common_validators.ts';
 import { handleHDBError, hdbErrors } from '../utility/errors/hdbError.ts';
 import { getDatabases } from '../resources/databases.ts';
+
 const { HTTP_STATUS_CODES } = hdbErrors;
 
 const searchByValueSchema = Joi.object({


### PR DESCRIPTION
Adds Joi-based input validation to the `get_analytics` operation, rejecting malformed requests with a 400 before they reach the data layer.

## Changes

- **`ResourceInterface.ts`** — Converts the `Comparator` union type to a `COMPARATORS as const` array with a derived type, enabling runtime validation without duplication.
- **`validation/analyticsValidator.ts`** (new) — Joi schema for `get_analytics` requests. Uses `.strict()` to disable type coercion (e.g. a numeric string is rejected for `start_time`). Accepts both canonical (`attribute`/`comparator`/`value`) and legacy (`search_attribute`/`search_type`/`search_value`) condition field names.
- **`resources/analytics/read.ts`** — Wires the validator into `getOp`; throws a 400 `HdbError` on failure.
- **`unitTests/validation/analyticsValidator.test.js`** (new) — 17 unit tests covering happy paths and rejection cases for each field.
- **`validation/searchValidator.ts`** — Minor: blank line cleanup from an intermediate refactor; no behavior change.

## Notes

During development, the `COMPARATORS` array was briefly also used in `searchValidator.ts`. That was reverted because the expanded shorthand aliases (`eq`, `gt`, etc.) are supported by the Resource search path but not the LMDB data layer — using them there would silently return empty results. `searchValidator.ts` retains its original inline list.

_Generated by Claude Sonnet 4.6 (claude-code)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)