### PR TITLE
Fix update-rocksdb-js workflow push protection error

### DIFF
--- a/.github/workflows/update-rocksdb-js.yml
+++ b/.github/workflows/update-rocksdb-js.yml
@@ -87,6 +87,9 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.github-token.outputs.token }}
+          add-paths: |
+            package.json
+            package-lock.json
           title: 'chore(deps): Update rocksdb-js to ${{ steps.latest-version.outputs.latest }}'
           body: |
             Update rocksdb-js to ${{ steps.latest-version.outputs.latest }}.


### PR DESCRIPTION
Restricts `peter-evans/create-pull-request` to only stage `package.json` and `package-lock.json` via the `add-paths` parameter.

Without this, the action's internal `git add -A` picks up all files in the working tree — including the workflow file itself — which triggers GitHub's push protection requiring the `workflows` permission on the GitHub App token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)