### PR TITLE
ci: use individual reviewers instead of developers team

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -12,18 +12,21 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
-      - name: Assign Developers team if no reviewers set
+      - name: Assign default reviewers if none set
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REVIEWERS_JSON: ${{ toJson(github.event.pull_request.requested_reviewers) }}
           TEAMS_JSON: ${{ toJson(github.event.pull_request.requested_teams) }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           reviewers=$(echo "$REVIEWERS_JSON" | jq 'length')
           teams=$(echo "$TEAMS_JSON" | jq 'length')
           if [ "$reviewers" -eq 0 ] && [ "$teams" -eq 0 ]; then
-            gh api "repos/$REPO/pulls/$PR_NUMBER/requested_reviewers" \
-              --method POST \
-              --field 'team_reviewers[]=developers'
+            echo '["cb1kenobi","heskew","Ethan-Arrowood","kriszyp"]' \
+              | jq --arg author "$PR_AUTHOR" '{"reviewers": [.[] | select(. != $author)]}' \
+              | gh api "repos/$REPO/pulls/$PR_NUMBER/requested_reviewers" \
+                --method POST \
+                --input -
           fi


### PR DESCRIPTION
## Summary

- `GITHUB_TOKEN` lacks `read:org` scope, so GitHub's GraphQL layer cannot resolve the `developers` team node when assigning reviewers, producing a 422
- Switches to individual users (`cb1kenobi`, `heskew`, `Ethan-Arrowood`, `kriszyp`) as the fallback reviewers
- Filters out the PR author from the reviewer list to avoid self-assignment

The longer-term fix is to use an org-scoped PAT (with `read:org`) as `secrets.ORG_TOKEN`, which would let us go back to assigning the team.

## Test plan

- [ ] Open a new PR with no reviewers set — confirm the four individuals are requested
- [ ] Open a PR as one of the listed reviewers — confirm that person is excluded from the request

*Signed-off-by: Claude*