### PR TITLE
fix: persist indexingFailed in runIndexing outer catch

### DIFF
--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1396,6 +1396,24 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 		}
 	} catch (error) {
 		logger.error('Error in indexing', error);
+		// Persist indexingFailed so the next restart re-triggers the rebuild from an
+		// explicitly failed state rather than silently looping. Without this,
+		// indexingPID (written before runIndexing was called) stays in the descriptor
+		// but indexingFailed is never set, leaving isIndexing stuck with no recovery
+		// signal. Mirrors the hadIndexingErrors path. harper#843
+		try {
+			const puts: Promise<unknown>[] = [];
+			for (const attribute of attributes) {
+				attribute.indexingFailed = true;
+				puts.push(Table.dbisDB.put(attribute.key, attribute));
+				attribute.dbi.isIndexing = true;
+				const activeDbi = Table.indices[attribute.name];
+				if (activeDbi) activeDbi.isIndexing = true;
+			}
+			await Promise.all(puts);
+		} catch (persistError) {
+			logger.warn('Failed to persist indexing failure state', persistError);
+		}
 	}
 }
 

--- a/unitTests/resources/schemaMigrationFragility.test.js
+++ b/unitTests/resources/schemaMigrationFragility.test.js
@@ -237,6 +237,78 @@ describe('schema-migration fragility: stale index entry from concurrent write du
 	});
 });
 
+describe('schema-migration fragility: outer catch does not persist indexingFailed when clear() throws (F4)', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+
+	const TABLE = 'F4OuterCatchPersistFailed';
+	const DB = 'test';
+	const N = 5;
+
+	before(async () => {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		const Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) {
+			last = Tbl.put({ id: 'f4-' + i, tag: 'v-' + i });
+		}
+		await last;
+	});
+
+	it('outer catch should persist indexingFailed when clear() throws before the record scan', async () => {
+		resetDatabases();
+		const Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+
+		// Intercept clear() on the tag index dbi to simulate ERR_COLUMN_FAMILY_DROPPED.
+		// This throws before the record scan begins, hitting the outer catch in runIndexing.
+		const tagIndex = Tbl.indices?.tag;
+		if (tagIndex && typeof tagIndex.clear === 'function') {
+			tagIndex.clear = async function () {
+				throw Object.assign(new Error('simulated clear failure: column family dropped'), {
+					code: 'ERR_COLUMN_FAMILY_DROPPED',
+				});
+			};
+		}
+
+		// Wait for runIndexing to finish (the outer catch swallows the error).
+		if (Tbl.indexingOperation) await Tbl.indexingOperation.catch(() => {});
+
+		// Verify: simulate restart by resetting and re-opening.
+		// The outer catch should have persisted indexingFailed=true in the attribute descriptor.
+		// A clean re-open should detect this and re-trigger runIndexing.
+		resetDatabases();
+		const Tbl2 = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		assert.ok(
+			Tbl2.indexingOperation,
+			'F4 fingerprint: outer catch did not persist indexingFailed — ' +
+				'table() on "restart" did not re-trigger runIndexing, so isIndexing would be stuck forever.'
+		);
+		if (Tbl2.indexingOperation) await Tbl2.indexingOperation;
+
+		// After a clean retry, all rows should be indexed.
+		const rows = await collect(Tbl2.search({ conditions: [{ attribute: 'tag', value: 'v-0' }] }));
+		assert.equal(rows.length, 1, `Expected 1 row indexed after clean re-run, got ${rows.length}`);
+	});
+});
+
 describe('schema-migration fragility: stale `changed` reused after re-fetch under lock (F1)', () => {
 	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
 


### PR DESCRIPTION
## Summary

- `runIndexing`'s outer `catch` now persists `indexingFailed = true` for each attribute before exiting
- Uses `Promise.all` over all descriptor puts to ensure all writes are awaited
- Logs a warning if the secondary persist attempt itself fails (best-effort)

## Context

When an error fires before the record scan begins (e.g. `clear()` throws `kColumnFamilyDropped` due to a concurrent `drop_table`), the outer catch previously only logged the error. `indexingPID` is written to the descriptor *before* `runIndexing` is called, so on restart the PID mismatch re-triggers `runIndexing`, which fails again — an infinite silent loop where all searches return `503 not indexed yet`.

The fix mirrors the `hadIndexingErrors` inner path: write `indexingFailed = true` into the descriptor so the next startup sees it, clears the stale PID, and triggers a fresh rebuild from a known failure state.

Closes #843

> Generated by Claude Sonnet 4.6