### PR TITLE
feat(models): toolMode 'auto' agent loop on scope.models.generate (#612)

### DIFF
--- a/integrationTests/server/openai-backend.test.ts
+++ b/integrationTests/server/openai-backend.test.ts
@@ -18,6 +18,7 @@
  */
 import { suite, test, before } from 'node:test';
 import { strictEqual, ok } from 'node:assert/strict';
+import type { GenerateChunk, GenerateOpts, GenerateResult, Models as ModelsApi } from '../../resources/models/types.ts';
 
 // NOTE: `OpenAIBackend` is imported dynamically inside `before()` rather than
 // at the top of the file. Statically importing it from `components/openai/`
@@ -228,5 +229,176 @@ suite('OpenAIBackend against the real OpenAI API', { skip }, () => {
 			outcome === 'done' || outcome === 'aborted',
 			`expected abort to terminate stream (done or AbortError); got ${String(outcome)}`
 		);
+	});
+});
+
+/**
+ * The `toolMode: 'auto'` agent loop (#612 / #851) end-to-end over the REAL OpenAI
+ * backend. The unit suite (`unitTests/resources/models/agentLoop.test.js`) proves the
+ * loop's logic against a scripted backend; this suite proves it drives a real
+ * tool-calling model — a genuine `tool_calls` round is dispatched through
+ * `opts.toolHandlers`, the result is fed back, and the model produces a terminal
+ * answer GROUNDED in that result — plus the same over the streaming path. Skipped
+ * without `OPENAI_API_KEY`, same posture as the backend-direct suite above.
+ *
+ * Wiring: we drive `runAgentLoop` / `runAgentLoopStream` directly with a thin `Models`
+ * stand-in over the real `OpenAIBackend`. The stand-in replicates exactly what
+ * `Models.generate`'s single-shot path does (unwrap `ModelCallResult`, merge `usage`
+ * onto the output) and nothing more. This is deliberate: the loop is the engine under
+ * review, and importing the full `Models` facade here pulls the `transaction → databases
+ * → Table` graph, which doesn't resolve under bare `node --test`. `Models.generate`'s
+ * two-line `toolMode === 'auto'` delegation is covered by `Models.test.js` instead.
+ */
+suite('toolMode:auto agent loop over the real OpenAI backend', { skip }, () => {
+	type AgentLoopMod = typeof import('../../resources/models/agentLoop.ts');
+	let runLoop: AgentLoopMod['runAgentLoop'];
+	let runLoopStream: AgentLoopMod['runAgentLoopStream'];
+	let models: Pick<ModelsApi, 'generate' | 'generateStream'>;
+
+	const weatherTool = {
+		name: 'get_weather',
+		description: 'Get the current weather for a location. Always use this for any weather question.',
+		parameters: {
+			type: 'object',
+			properties: { location: { type: 'string', description: 'City name' } },
+			required: ['location'],
+		},
+	};
+
+	before(async () => {
+		// Import BOTH the loop and the backend from COMPILED dist (relative `../../dist/...`,
+		// the established integration-test convention — see `integrationTests/deploy/*.test.ts`),
+		// NOT the `.ts` source. The source graph pulls `hdbError → harper_logger` and the backend
+		// pulls `common_utils → harper_logger`, hitting Harper's documented
+		// `common_utils ↔ harper_logger` require cycle that is fatal under `node --test`'s ESM
+		// loader (`ERR_REQUIRE_CYCLE_MODULE`). The CJS dist tolerates the cycle. Requires a prior
+		// `npm run build` (the integration job builds before testing); the loop's logic itself
+		// is unit-tested from source in `unitTests/resources/models/agentLoop.test.js`.
+		const loop = (await import('../../dist/resources/models/agentLoop.js')) as AgentLoopMod;
+		runLoop = loop.runAgentLoop;
+		runLoopStream = loop.runAgentLoopStream;
+		const mod = (await import('../../dist/components/openai/index.js')) as unknown as {
+			OpenAIBackend: OpenAIBackendCtor;
+		};
+		// Constructed WITH a model so the inner `toolMode: 'return'` calls need no per-call model.
+		const backend = new mod.OpenAIBackend({ apiKey: API_KEY!, baseUrl: BASE_URL, model: GENERATE_MODEL });
+		models = {
+			async generate(input, opts: GenerateOpts = {}) {
+				const r = await backend.generate(input, { ...opts, accounting: ACCOUNTING });
+				if (r.status !== 'completed') throw new Error(`backend returned status '${r.status}'`);
+				// Mirror Models.generate: surface usage on the output for the loop's budget tally.
+				return (r.usage ? { ...r.output, usage: r.usage } : r.output) as GenerateResult;
+			},
+			generateStream(input, opts: GenerateOpts = {}) {
+				return backend.generateStream(input, { ...opts, accounting: ACCOUNTING }) as AsyncIterable<GenerateChunk>;
+			},
+		};
+	});
+
+	test('resolves a real tool call and grounds the final answer in the tool result', async () => {
+		const calls: { location?: string }[] = [];
+		const result = await runLoop({
+			models: models as ModelsApi,
+			input: {
+				messages: [
+					{
+						role: 'user',
+						content:
+							'What is the current weather in San Francisco? You must call the get_weather tool, then answer in one sentence.',
+					},
+				],
+				tools: [weatherTool],
+			},
+			opts: {
+				temperature: 0,
+				includeToolTrace: true,
+				toolHandlers: {
+					get_weather: (args: { location?: string }) => {
+						calls.push(args);
+						// A sentinel the model can only surface by actually receiving the tool
+						// result back through the loop — not from its own training data.
+						return { tempF: 72, conditions: 'foggy' };
+					},
+				},
+			},
+			accounting: ACCOUNTING,
+		});
+
+		ok(calls.length >= 1, 'the loop must dispatch the real tool call');
+		ok(
+			/san|francisco/i.test(String(calls[0].location ?? '')),
+			`expected a location arg; got ${JSON.stringify(calls[0])}`
+		);
+		strictEqual(result.finishReason, 'stop');
+		ok(result.content.length > 0, 'expected a terminal answer');
+		ok(/72|fog/i.test(result.content), `final answer should reflect the tool result; got: ${result.content}`);
+		ok(Array.isArray(result.trace) && result.trace.length >= 1, 'trace populated with includeToolTrace');
+		const entry = result.trace!.find((e) => e.toolName === 'get_weather');
+		ok(entry, 'trace should include the get_weather invocation');
+		ok(/72/.test(entry!.result ?? ''), 'trace should capture the serialized tool result');
+	});
+
+	test('streaming auto loop dispatches the tool and emits one terminal finishReason after content', async () => {
+		const calls: unknown[] = [];
+		const chunks: GenerateChunk[] = [];
+		for await (const chunk of runLoopStream({
+			models: models as ModelsApi,
+			input: {
+				messages: [
+					{
+						role: 'user',
+						content: 'What is the weather in Tokyo? You must call get_weather, then answer in one sentence.',
+					},
+				],
+				tools: [weatherTool],
+			},
+			opts: {
+				temperature: 0,
+				toolHandlers: {
+					get_weather: (a: unknown) => {
+						calls.push(a);
+						return { tempF: 72, conditions: 'foggy' };
+					},
+				},
+			},
+			accounting: ACCOUNTING,
+		})) {
+			chunks.push(chunk);
+		}
+
+		ok(calls.length >= 1, 'streaming loop must dispatch the tool');
+		const text = chunks.map((c) => c.deltaContent ?? '').join('');
+		ok(text.length > 0, 'expected streamed content');
+		ok(/72|fog/i.test(text), `streamed answer should reflect the tool result; got: ${text}`);
+		// The loop strips inline finishReasons and re-emits exactly one terminal chunk
+		// AFTER any conversation append — assert that contract holds over the real wire.
+		const finals = chunks.filter((c) => c.finishReason);
+		strictEqual(finals.length, 1, 'exactly one terminal finishReason chunk');
+		strictEqual(finals[0].finishReason, 'stop');
+		strictEqual(finals[0].deltaContent, undefined, 'terminal chunk carries no content');
+	});
+
+	test('terminal-first answer (no tools needed) passes through without dispatching', async () => {
+		const calls: unknown[] = [];
+		const result = await runLoop({
+			models: models as ModelsApi,
+			input: 'Reply with exactly the single word: OK',
+			opts: {
+				temperature: 0,
+				includeToolTrace: true,
+				toolHandlers: {
+					get_weather: (a: unknown) => {
+						calls.push(a);
+						return {};
+					},
+				},
+			},
+			accounting: ACCOUNTING,
+		});
+
+		strictEqual(result.finishReason, 'stop');
+		ok(result.content.length > 0, 'expected a terminal answer');
+		strictEqual(calls.length, 0, 'no tool should be dispatched when none is needed');
+		ok(Array.isArray(result.trace) && result.trace.length === 0, 'empty trace when no tools ran');
 	});
 });

--- a/resources/models/Models.ts
+++ b/resources/models/Models.ts
@@ -68,6 +68,12 @@ export class Models implements ModelsContract {
 			// below and writes its own `hdb_model_calls` row. The outer auto call itself
 			// stays out of the analytics table — counting it would double-bill the round.
 			const { accounting, signal } = resolveCallContext(opts.signal);
+			// Fail loud, never silent: an auto loop that declares tools against a
+			// tools-incapable backend would run as a plain generation — the backend never
+			// receives the tool definitions (e.g. ollama drops them), so the model can't
+			// call anything and the loop returns a first-round answer, silently ignoring
+			// the caller's tools. Check up front rather than no-op.
+			if (inputHasTools(input)) requireCapability(resolveGenerative(opts.model), 'tools');
 			return runAgentLoop({ models: this, input, opts, accounting, signal });
 		}
 		const { accounting, signal } = resolveCallContext(opts.signal);
@@ -95,6 +101,10 @@ export class Models implements ModelsContract {
 			// Same rationale as `generate`: per-iteration analytics happen inside the loop
 			// when it dispatches to `this.generateStream(..., {toolMode: 'return'})`.
 			const { accounting, signal } = resolveCallContext(opts.signal);
+			// Same fail-loud guard as `generate` — a tools-incapable backend would silently
+			// stream a plain generation, ignoring the declared tools. Throws synchronously
+			// (before the iterable is returned), matching the capability-check posture below.
+			if (inputHasTools(input)) requireCapability(resolveGenerative(opts.model), 'tools');
 			return runAgentLoopStream({ models: this, input, opts, accounting, signal });
 		}
 		const { accounting, signal } = resolveCallContext(opts.signal);
@@ -223,7 +233,12 @@ function extractTenantId(user: any): string | undefined {
 	return user?.tenant ?? user?.tenantId ?? undefined;
 }
 
-function requireCapability(backend: ModelBackend, capability: 'embed' | 'generate' | 'stream'): void {
+/** True when `input` is the object form carrying a non-empty `tools` array. */
+function inputHasTools(input: GenerateInput): boolean {
+	return typeof input === 'object' && !Array.isArray(input) && Array.isArray(input.tools) && input.tools.length > 0;
+}
+
+function requireCapability(backend: ModelBackend, capability: 'embed' | 'generate' | 'stream' | 'tools'): void {
 	if (!backend.capabilities()[capability]) throw new ModelCapabilityError(backend.name, capability);
 }
 
@@ -241,7 +256,7 @@ function classifyError(err: unknown): string {
 export class ModelCapabilityError extends ServerError {
 	// Deliberately does not name the requested capability beyond what was asked for —
 	// avoids enumerating what the backend *does* support in error responses.
-	constructor(backendName: string, capability: 'embed' | 'generate' | 'stream') {
+	constructor(backendName: string, capability: 'embed' | 'generate' | 'stream' | 'tools') {
 		super(`Backend '${backendName}' does not support '${capability}'`);
 		this.name = 'ModelCapabilityError';
 	}

--- a/resources/models/Models.ts
+++ b/resources/models/Models.ts
@@ -80,7 +80,10 @@ export class Models implements ModelsContract {
 			const result = await backend.generate!(input, backendOpts);
 			if (result.status !== 'completed') throw new ModelPendingNotSupportedError(backend.name);
 			this.#record(backend, 'generate', opts.model, accounting, opts, result, startedAt);
-			return result.output;
+			// Propagate usage onto the returned GenerateResult so callers (notably the
+			// `toolMode: 'auto'` loop's budget tracker) can read cumulative tokens without
+			// re-querying analytics. Pure pass-through — backend usage is the source of truth.
+			return result.usage ? { ...result.output, usage: result.usage } : result.output;
 		} catch (err) {
 			this.#recordFailure(backend, 'generate', opts.model, accounting, opts, startedAt, err);
 			throw err;

--- a/resources/models/Models.ts
+++ b/resources/models/Models.ts
@@ -2,6 +2,7 @@ import { contextStorage } from '../transaction.ts';
 import { resolveEmbedding, resolveGenerative } from './backendRegistry.ts';
 import { getModelCallAnalyticsWriter, type ModelCallAnalyticsWriter, type ModelCallRecord } from './analyticsTable.ts';
 import { ServerError } from '../../utility/errors/hdbError.ts';
+import { runAgentLoop, runAgentLoopStream } from './agentLoop.ts';
 import type {
 	AccountingContext,
 	BackendOpts,
@@ -61,6 +62,14 @@ export class Models implements ModelsContract {
 	}
 
 	async generate(input: GenerateInput, opts: GenerateOpts = {}): Promise<GenerateResult> {
+		if (opts.toolMode === 'auto') {
+			// The loop calls back through `this.generate(..., {toolMode: 'return'})` per
+			// iteration, so each backend round still flows through the single-shot path
+			// below and writes its own `hdb_model_calls` row. The outer auto call itself
+			// stays out of the analytics table — counting it would double-bill the round.
+			const { accounting, signal } = resolveCallContext(opts.signal);
+			return runAgentLoop({ models: this, input, opts, accounting, signal });
+		}
 		const { accounting, signal } = resolveCallContext(opts.signal);
 		const startedAt = performance.now();
 		let backend: ModelBackend | undefined;
@@ -79,6 +88,12 @@ export class Models implements ModelsContract {
 	}
 
 	generateStream(input: GenerateInput, opts: GenerateOpts = {}): AsyncIterable<GenerateChunk> {
+		if (opts.toolMode === 'auto') {
+			// Same rationale as `generate`: per-iteration analytics happen inside the loop
+			// when it dispatches to `this.generateStream(..., {toolMode: 'return'})`.
+			const { accounting, signal } = resolveCallContext(opts.signal);
+			return runAgentLoopStream({ models: this, input, opts, accounting, signal });
+		}
 		const { accounting, signal } = resolveCallContext(opts.signal);
 		const startedAt = performance.now();
 		let backend: ModelBackend | undefined;

--- a/resources/models/agentLoop.ts
+++ b/resources/models/agentLoop.ts
@@ -1,17 +1,23 @@
 /**
  * In-process tool-call agent loop for `Models.generate({ toolMode: 'auto' })`.
  *
- * Wiring (commit 1 of #612): type surface + guarded entry point. `Models.generate`
- * branches on `opts.toolMode === 'auto'` and delegates here; both entry points
- * currently throw `ServerError(501)` so the contract is type-declared and call-site
- * wired, but the loop body lands in subsequent commits. Tests assert the throw
- * and the new option-field shapes flow through unchanged.
+ * Each iteration: (1) call `models.generate` with the running message list,
+ * (2) if the model emitted tool calls, dispatch each via `opts.toolHandlers`,
+ * (3) append the tool results to the message list, repeat. Terminate when the
+ * model returns a non-`tool_calls` finish reason or when the iteration cap trips.
  *
- * Subsequent commits fill in:
- *   commit 2 — core sequential loop (handler dispatch, result truncation, trace)
- *   commit 3 — parallel batches + abort propagation
- *   commit 4 — token/cost budgets + `toolErrorMode: 'abort'`
- *   commit 5 — streaming auto path + `opts.conversation.append`
+ * Analytics: the loop calls back through `models.generate(..., {toolMode: 'return'})`
+ * per iteration so each backend round flows the single-shot path in `Models.ts` and
+ * writes its own `hdb_model_calls` row. The outer auto call stays out of the table.
+ *
+ * Commit 2 of #612 — sequential dispatch, result truncation, includeToolTrace,
+ * recover-mode error handling. Modes deferred to later commits throw 501 at entry:
+ *   - `toolArgValidation: 'strict' | 'lenient'`  → JSON Schema validator (TBD)
+ *   - `toolErrorMode: 'abort'`                   → commit 4
+ *   - `toolParallelism: 'parallel'`              → commit 3 (this commit runs serial)
+ *   - `maxToolTokens`, `maxCostUsd`              → commit 4
+ *   - `opts.conversation.append`                 → commit 5
+ *   - `runAgentLoopStream`                       → commit 5
  *
  * Registry seam: v1 dispatches via caller-supplied `opts.toolHandlers`. #615
  * replaces that with a `scope.resources` lookup using the same call signature.
@@ -23,9 +29,15 @@ import type {
 	GenerateInput,
 	GenerateOpts,
 	GenerateResult,
+	Message,
 	Models,
+	ToolDef,
+	ToolHandlerContext,
 	ToolTraceEntry,
 } from './types.ts';
+
+const DEFAULT_MAX_ITERATIONS = 10;
+const DEFAULT_MAX_RESULT_BYTES = 65_536;
 
 export interface RunAgentLoopArgs {
 	models: Models;
@@ -35,12 +47,206 @@ export interface RunAgentLoopArgs {
 	signal?: AbortSignal;
 }
 
-export async function runAgentLoop(_args: RunAgentLoopArgs): Promise<GenerateResult> {
-	throw new ServerError("`toolMode: 'auto'` is not yet implemented", 501);
+export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResult> {
+	const { models, opts, accounting, signal } = args;
+
+	// v1 gates: surface declared on GenerateOpts, runtime fills in incrementally.
+	// Throw a clear 501 at entry rather than silently downgrading to default behavior —
+	// the alternative (ignore unsupported mode) would mask caller mistakes.
+	guardUnsupportedModes(opts);
+
+	const maxIterations = opts.maxToolIterations ?? DEFAULT_MAX_ITERATIONS;
+	const maxResultBytes = opts.toolResultMaxBytes ?? DEFAULT_MAX_RESULT_BYTES;
+	const handlers = opts.toolHandlers ?? {};
+
+	const { messages, tools, system } = normalizeInput(args.input);
+	const trace: ToolTraceEntry[] = [];
+
+	// Strip loop-only knobs from what flows back into `models.generate`. The `toolMode:
+	// 'return'` override is what prevents the outer entry point from re-entering this loop.
+	const innerOpts: GenerateOpts = { ...opts, toolMode: 'return' };
+
+	for (let iteration = 1; iteration <= maxIterations; iteration++) {
+		const result = await models.generate(buildInnerInput(messages, tools, system), innerOpts);
+
+		const calls = result.toolCalls;
+		if (result.finishReason !== 'tool_calls' || !calls || calls.length === 0) {
+			// Terminal: model produced a final answer (stop / length / content_filter), or it
+			// signaled tool_calls but emitted none. Pass the result through; attach the trace
+			// when the caller asked for it.
+			return opts.includeToolTrace ? { ...result, trace } : result;
+		}
+
+		messages.push({ role: 'assistant', content: result.content, toolCalls: calls });
+
+		// Commit 2: serial dispatch. Commit 3 swaps in Promise.all when
+		// `opts.toolParallelism !== 'serial'`.
+		for (const call of calls) {
+			const entry: ToolTraceEntry = {
+				iteration,
+				toolCallId: call.id,
+				toolName: call.name,
+				// Shallow-copy so the trace's view of "what the model emitted" doesn't
+				// shift if a handler mutates its `args` parameter (legitimate pattern).
+				// Deep mutations to nested objects can still leak — common-case flat-object
+				// args are covered; document the corner.
+				arguments: { ...call.arguments },
+				durationMs: 0,
+			};
+
+			const handler = handlers[call.name];
+			if (!handler) {
+				// No handler registered. Hard fail — there's nothing to call. (#615 swaps this
+				// branch for a `scope.resources` lookup; same call signature, same throw if
+				// unresolved.) Throw as ClientError(400) since the caller didn't supply a
+				// handler for a tool they declared, not a Harper-internal fault.
+				throw new ClientError(
+					`No handler registered for tool '${call.name}' (call id ${call.id})`,
+					400
+				);
+			}
+
+			const ctx: ToolHandlerContext = { signal, accounting };
+			const handlerStart = performance.now();
+			let toolResultContent: string;
+			// Wrap BOTH the handler call AND result serialization in the recover catch.
+			// `JSON.stringify` throws on BigInt and circular refs — both trivially produced
+			// by handlers that return raw DB rows or Resource instances. Without this, a
+			// serialization failure crashes the entire loop instead of becoming a tool
+			// error the model can react to (the `toolErrorMode: 'recover'` contract).
+			try {
+				const handlerOutput = await handler(call.arguments, ctx);
+				const serialized = serializeToolResult(handlerOutput, maxResultBytes);
+				entry.result = serialized.content;
+				if (serialized.truncated) {
+					entry.truncated = true;
+					entry.totalBytes = serialized.totalBytes;
+				}
+				toolResultContent = serialized.content;
+			} catch (err) {
+				// `toolErrorMode: 'recover'` (v1 only path): append the error message as the
+				// tool result so the model can react. Commit 4 wires 'abort' to throw early.
+				entry.error = errorInfo(err);
+				toolResultContent = JSON.stringify({ error: entry.error.message });
+			}
+			entry.durationMs = performance.now() - handlerStart;
+
+			trace.push(entry);
+			messages.push({ role: 'tool', content: toolResultContent, toolCallId: call.id });
+		}
+	}
+
+	// Hit `maxToolIterations` without a terminal finishReason — the model kept calling tools.
+	// Always include the trace on the error path (independent of `includeToolTrace`) so
+	// callers can debug an exhausted budget without re-running with tracing on.
+	throw new BudgetExceededError(
+		'iterations',
+		`agent loop exceeded maxToolIterations=${maxIterations}`,
+		trace
+	);
 }
 
 export async function* runAgentLoopStream(_args: RunAgentLoopArgs): AsyncIterable<GenerateChunk> {
 	throw new ServerError("`toolMode: 'auto'` is not yet implemented for streaming", 501);
+}
+
+function guardUnsupportedModes(opts: GenerateOpts): void {
+	const validationMode = opts.toolArgValidation ?? 'none';
+	if (validationMode !== 'none') {
+		throw new ServerError(
+			`toolArgValidation: '${validationMode}' is not yet implemented; v1 supports 'none' only`,
+			501
+		);
+	}
+	const errorMode = opts.toolErrorMode ?? 'recover';
+	if (errorMode !== 'recover') {
+		throw new ServerError(
+			`toolErrorMode: '${errorMode}' is not yet implemented; v1 supports 'recover' only`,
+			501
+		);
+	}
+	// `toolParallelism` accepts 'serial' OR 'parallel' here; commit 3 wires the parallel
+	// branch. v1 runs serial regardless of caller setting — the field is forward-looking.
+	if (opts.maxToolTokens !== undefined || opts.maxCostUsd !== undefined) {
+		throw new ServerError(
+			`maxToolTokens / maxCostUsd budgets are not yet implemented (commit 4 of #612)`,
+			501
+		);
+	}
+	if (opts.conversation !== undefined) {
+		throw new ServerError(
+			`opts.conversation is not yet implemented (commit 5 of #612)`,
+			501
+		);
+	}
+}
+
+function buildInnerInput(
+	messages: Message[],
+	tools: ToolDef[] | undefined,
+	system: string | undefined
+): { messages: Message[]; tools?: ToolDef[]; system?: string } {
+	const inner: { messages: Message[]; tools?: ToolDef[]; system?: string } = { messages };
+	if (tools) inner.tools = tools;
+	if (system) inner.system = system;
+	return inner;
+}
+
+function normalizeInput(input: GenerateInput): {
+	messages: Message[];
+	tools?: ToolDef[];
+	system?: string;
+} {
+	if (typeof input === 'string') {
+		return { messages: [{ role: 'user', content: input }] };
+	}
+	if (Array.isArray(input)) {
+		return { messages: [...input] };
+	}
+	return { messages: [...input.messages], tools: input.tools, system: input.system };
+}
+
+function errorInfo(err: unknown): { name: string; message: string } {
+	if (err instanceof Error) {
+		return { name: err.name, message: err.message };
+	}
+	// Some thrown values are plain objects with a `message` field but no Error chain —
+	// e.g. Harper's `BigInt.prototype.toJSON` throws `{message: 'Cannot serialize BigInt …'}`
+	// (server/serverHelpers/JSONStream.ts) to skip the cost of capturing a stack on a hot
+	// serialization path. Surface their message instead of String()-ing the whole object.
+	if (err && typeof err === 'object' && 'message' in err) {
+		const e = err as { name?: unknown; message?: unknown };
+		const name = typeof e.name === 'string' ? e.name : 'Error';
+		const message = typeof e.message === 'string' ? e.message : String(e.message);
+		return { name, message };
+	}
+	return { name: 'Error', message: String(err) };
+}
+
+interface SerializedResult {
+	content: string;
+	totalBytes: number;
+	truncated: boolean;
+}
+
+function serializeToolResult(value: unknown, maxBytes: number): SerializedResult {
+	const json = JSON.stringify(value ?? null);
+	const buf = Buffer.from(json, 'utf8');
+	const totalBytes = buf.length;
+	if (totalBytes <= maxBytes) {
+		return { content: json, totalBytes, truncated: false };
+	}
+	// Truncated form: head of the JSON + a marker that names the original size. The
+	// content is no longer valid JSON — that's intentional, the model reads it as text
+	// alongside the marker. Single-pass byte-level slice; `Buffer#toString('utf8')`
+	// folds a split codepoint at the boundary into a replacement char (U+FFFD).
+	// The body slice never exceeds the byte budget — no O(n²) trim loop needed for
+	// multi-byte content.
+	const marker = `…[truncated; full result is ${totalBytes} bytes]`;
+	const markerBytes = Buffer.byteLength(marker, 'utf8');
+	const headBudget = Math.max(0, maxBytes - markerBytes);
+	const body = buf.subarray(0, headBudget).toString('utf8');
+	return { content: body + marker, totalBytes, truncated: true };
 }
 
 /**
@@ -48,8 +254,12 @@ export async function* runAgentLoopStream(_args: RunAgentLoopArgs): AsyncIterabl
  * far rides along on `partialTrace` so callers can inspect what already ran. The
  * loop always populates this regardless of `opts.includeToolTrace` so debugging an
  * exhausted budget never needs a second run with tracing turned on.
+ *
+ * Extends `ClientError` — the caller set the budget, so exceeding it is a 4xx
+ * caller-bounds condition, not a Harper-internal fault. Anything that branches on
+ * `err instanceof ClientError` (e.g. "don't page on this") classifies it correctly.
  */
-export class BudgetExceededError extends ServerError {
+export class BudgetExceededError extends ClientError {
 	kind: 'iterations' | 'tokens' | 'cost';
 	partialTrace: ToolTraceEntry[];
 	constructor(kind: 'iterations' | 'tokens' | 'cost', message: string, partialTrace: ToolTraceEntry[]) {
@@ -64,7 +274,8 @@ export class BudgetExceededError extends ServerError {
 /**
  * `toolArgValidation: 'strict'` rejected a tool call's arguments against its
  * declared `parameters` JSON Schema. Surfaces as a 400 — the model produced output
- * that doesn't satisfy the contract the caller declared.
+ * that doesn't satisfy the contract the caller declared. Reserved for the
+ * validator wiring (currently the strict mode is itself gated at loop entry).
  */
 export class ToolValidationError extends ClientError {
 	toolName: string;

--- a/resources/models/agentLoop.ts
+++ b/resources/models/agentLoop.ts
@@ -10,11 +10,18 @@
  * per iteration so each backend round flows the single-shot path in `Models.ts` and
  * writes its own `hdb_model_calls` row. The outer auto call stays out of the table.
  *
- * Commit 2 of #612 — sequential dispatch, result truncation, includeToolTrace,
- * recover-mode error handling. Modes deferred to later commits throw 501 at entry:
+ * **Abort wiring** (commit 3). Each invocation creates a loop-level
+ * `AbortController` composed with the caller's signal via `AbortSignal.any`. The
+ * composed signal flows to both the inner `models.generate` call and the
+ * `ToolHandlerContext.signal` handlers receive. Today the loop-level controller is
+ * only fired externally (caller aborts → composed signal aborts); commit 4 wires
+ * it to also fire on budget trips so an in-flight LLM call cancels cleanly.
+ *
+ * Commit 3 of #612 — parallel batch dispatch (Promise.all, default) + caller-signal
+ * propagation + iteration-boundary `throwIfAborted`. Modes deferred to later
+ * commits throw 501 at entry:
  *   - `toolArgValidation: 'strict' | 'lenient'`  → JSON Schema validator (TBD)
  *   - `toolErrorMode: 'abort'`                   → commit 4
- *   - `toolParallelism: 'parallel'`              → commit 3 (this commit runs serial)
  *   - `maxToolTokens`, `maxCostUsd`              → commit 4
  *   - `opts.conversation.append`                 → commit 5
  *   - `runAgentLoopStream`                       → commit 5
@@ -31,7 +38,9 @@ import type {
 	GenerateResult,
 	Message,
 	Models,
+	ToolCall,
 	ToolDef,
+	ToolHandler,
 	ToolHandlerContext,
 	ToolTraceEntry,
 } from './types.ts';
@@ -48,7 +57,7 @@ export interface RunAgentLoopArgs {
 }
 
 export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResult> {
-	const { models, opts, accounting, signal } = args;
+	const { models, opts, accounting, signal: callerSignal } = args;
 
 	// v1 gates: surface declared on GenerateOpts, runtime fills in incrementally.
 	// Throw a clear 501 at entry rather than silently downgrading to default behavior —
@@ -58,92 +67,202 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 	const maxIterations = opts.maxToolIterations ?? DEFAULT_MAX_ITERATIONS;
 	const maxResultBytes = opts.toolResultMaxBytes ?? DEFAULT_MAX_RESULT_BYTES;
 	const handlers = opts.toolHandlers ?? {};
+	const parallelism = opts.toolParallelism ?? 'parallel';
 
 	const { messages, tools, system } = normalizeInput(args.input);
 	const trace: ToolTraceEntry[] = [];
 
+	// Loop-level abort controller — fired internally on budget trips (commit 4 wires
+	// that) and on every loop exit (success, throw, abort) via the `finally` below.
+	// Composed with the caller's signal so an external `caller.abort()` ALSO fires
+	// the loop's signal (handlers and the in-flight backend call both react). The
+	// composed signal is the only signal that flows to inner calls.
+	const loopController = new AbortController();
+	const composedSignal = composeAbortSignal(callerSignal, loopController.signal);
+
 	// Strip loop-only knobs from what flows back into `models.generate`. The `toolMode:
 	// 'return'` override is what prevents the outer entry point from re-entering this loop.
-	const innerOpts: GenerateOpts = { ...opts, toolMode: 'return' };
+	// `signal` is swapped to the composed signal so `Models.generate` (and through it,
+	// the backend) see budget-trip and caller-abort cancellations the same way.
+	const innerOpts: GenerateOpts = { ...opts, toolMode: 'return', signal: composedSignal };
 
-	for (let iteration = 1; iteration <= maxIterations; iteration++) {
-		const result = await models.generate(buildInnerInput(messages, tools, system), innerOpts);
+	try {
+		for (let iteration = 1; iteration <= maxIterations; iteration++) {
+			// Pre-iteration abort check — if the caller (or a future budget trip) fired
+			// the composed signal between rounds, bail before paying for another backend
+			// call. The inner `models.generate` would itself throw on the in-flight check,
+			// but throwing here saves the round-trip and the spurious analytics row.
+			composedSignal.throwIfAborted();
 
-		const calls = result.toolCalls;
-		if (result.finishReason !== 'tool_calls' || !calls || calls.length === 0) {
-			// Terminal: model produced a final answer (stop / length / content_filter), or it
-			// signaled tool_calls but emitted none. Pass the result through; attach the trace
-			// when the caller asked for it.
-			return opts.includeToolTrace ? { ...result, trace } : result;
-		}
+			const result = await models.generate(buildInnerInput(messages, tools, system), innerOpts);
 
-		messages.push({ role: 'assistant', content: result.content, toolCalls: calls });
+			const calls = result.toolCalls;
+			if (result.finishReason !== 'tool_calls' || !calls || calls.length === 0) {
+				// Terminal: model produced a final answer (stop / length / content_filter), or it
+				// signaled tool_calls but emitted none. Pass the result through; attach the trace
+				// when the caller asked for it.
+				return opts.includeToolTrace ? { ...result, trace } : result;
+			}
 
-		// Commit 2: serial dispatch. Commit 3 swaps in Promise.all when
-		// `opts.toolParallelism !== 'serial'`.
-		for (const call of calls) {
-			const entry: ToolTraceEntry = {
+			messages.push({ role: 'assistant', content: result.content, toolCalls: calls });
+
+			const ctx: ToolHandlerContext = { signal: composedSignal, accounting };
+			const dispatched = await dispatchToolCalls(
+				calls,
+				handlers,
+				ctx,
 				iteration,
-				toolCallId: call.id,
-				toolName: call.name,
-				// Shallow-copy so the trace's view of "what the model emitted" doesn't
-				// shift if a handler mutates its `args` parameter (legitimate pattern).
-				// Deep mutations to nested objects can still leak — common-case flat-object
-				// args are covered; document the corner.
-				arguments: { ...call.arguments },
-				durationMs: 0,
-			};
+				maxResultBytes,
+				parallelism
+			);
 
-			const handler = handlers[call.name];
-			if (!handler) {
-				// No handler registered. Hard fail — there's nothing to call. (#615 swaps this
-				// branch for a `scope.resources` lookup; same call signature, same throw if
-				// unresolved.) Throw as ClientError(400) since the caller didn't supply a
-				// handler for a tool they declared, not a Harper-internal fault.
-				throw new ClientError(
-					`No handler registered for tool '${call.name}' (call id ${call.id})`,
-					400
-				);
+			// Post-dispatch abort check — covers the LAST-iteration case: if the signal
+			// fired during this round's handlers, we'd otherwise skip the top-of-loop check
+			// and throw `BudgetExceededError` (misleading: the budget never tripped). Fire
+			// the abort here so the caller gets the correct error class. Earlier iterations
+			// pick this up on the next round's top-of-loop check.
+			composedSignal.throwIfAborted();
+
+			// Trace + tool messages append in CALL order regardless of completion order under
+			// parallel — the trace mirrors what the model emitted, not which handler finished first.
+			for (const dispatchResult of dispatched) {
+				trace.push(dispatchResult.entry);
+				messages.push({
+					role: 'tool',
+					content: dispatchResult.toolMessageContent,
+					toolCallId: dispatchResult.entry.toolCallId,
+				});
 			}
-
-			const ctx: ToolHandlerContext = { signal, accounting };
-			const handlerStart = performance.now();
-			let toolResultContent: string;
-			// Wrap BOTH the handler call AND result serialization in the recover catch.
-			// `JSON.stringify` throws on BigInt and circular refs — both trivially produced
-			// by handlers that return raw DB rows or Resource instances. Without this, a
-			// serialization failure crashes the entire loop instead of becoming a tool
-			// error the model can react to (the `toolErrorMode: 'recover'` contract).
-			try {
-				const handlerOutput = await handler(call.arguments, ctx);
-				const serialized = serializeToolResult(handlerOutput, maxResultBytes);
-				entry.result = serialized.content;
-				if (serialized.truncated) {
-					entry.truncated = true;
-					entry.totalBytes = serialized.totalBytes;
-				}
-				toolResultContent = serialized.content;
-			} catch (err) {
-				// `toolErrorMode: 'recover'` (v1 only path): append the error message as the
-				// tool result so the model can react. Commit 4 wires 'abort' to throw early.
-				entry.error = errorInfo(err);
-				toolResultContent = JSON.stringify({ error: entry.error.message });
-			}
-			entry.durationMs = performance.now() - handlerStart;
-
-			trace.push(entry);
-			messages.push({ role: 'tool', content: toolResultContent, toolCallId: call.id });
 		}
+
+		// Hit `maxToolIterations` without a terminal finishReason — the model kept calling tools.
+		// Always include the trace on the error path (independent of `includeToolTrace`) so
+		// callers can debug an exhausted budget without re-running with tracing on.
+		throw new BudgetExceededError(
+			'iterations',
+			`agent loop exceeded maxToolIterations=${maxIterations}`,
+			trace
+		);
+	} finally {
+		// Always abort the loop controller on exit (success, throw, or external abort).
+		// Cleans up `AbortSignal.any`'s listener on `callerSignal` so a session-scoped caller
+		// signal doesn't accumulate listeners across many `runAgentLoop` invocations, and
+		// signals any sibling handlers still running in the background after a Promise.all
+		// rejection (missing-handler or aborted-mid-flight) to bail out promptly.
+		loopController.abort();
+	}
+}
+
+interface DispatchedToolCall {
+	entry: ToolTraceEntry;
+	toolMessageContent: string;
+}
+
+async function dispatchToolCalls(
+	calls: ToolCall[],
+	handlers: Record<string, ToolHandler>,
+	ctx: ToolHandlerContext,
+	iteration: number,
+	maxResultBytes: number,
+	parallelism: 'parallel' | 'serial'
+): Promise<DispatchedToolCall[]> {
+	// Single-call rounds use the serial path even when 'parallel' is selected — the
+	// Promise.all path adds nothing on one element and the serial path's stack trace
+	// is more readable in errors.
+	if (parallelism === 'serial' || calls.length <= 1) {
+		const out: DispatchedToolCall[] = [];
+		for (const call of calls) {
+			out.push(await runSingleToolCall(call, handlers, ctx, iteration, maxResultBytes));
+		}
+		return out;
+	}
+	// Parallel: handlers race concurrently. If any throws (missing handler is the only
+	// path that throws out of `runSingleToolCall` — handler errors are caught and
+	// recovered), Promise.all rejects with the first error. Siblings still running keep
+	// going in the background; their results are discarded. That's acceptable because
+	// (a) handler errors are recovered inline, so siblings rarely throw, and (b) the
+	// alternative (active cancellation via loopController) would also race in the same
+	// window. The composed signal still propagates external aborts to the siblings.
+	return Promise.all(
+		calls.map((call) => runSingleToolCall(call, handlers, ctx, iteration, maxResultBytes))
+	);
+}
+
+async function runSingleToolCall(
+	call: ToolCall,
+	handlers: Record<string, ToolHandler>,
+	ctx: ToolHandlerContext,
+	iteration: number,
+	maxResultBytes: number
+): Promise<DispatchedToolCall> {
+	const entry: ToolTraceEntry = {
+		iteration,
+		toolCallId: call.id,
+		toolName: call.name,
+		// Shallow-copy so the trace's view of "what the model emitted" doesn't shift if a
+		// handler mutates its `args` parameter (legitimate pattern). Deep mutations to
+		// nested objects can still leak — common-case flat-object args are covered.
+		arguments: { ...call.arguments },
+		durationMs: 0,
+	};
+
+	const handler = handlers[call.name];
+	if (!handler) {
+		// No handler registered. Hard fail — there's nothing to call. (#615 swaps this
+		// branch for a `scope.resources` lookup; same call signature, same throw if
+		// unresolved.) Throw as ClientError(400) since the caller didn't supply a handler
+		// for a tool they declared, not a Harper-internal fault.
+		throw new ClientError(
+			`No handler registered for tool '${call.name}' (call id ${call.id})`,
+			400
+		);
 	}
 
-	// Hit `maxToolIterations` without a terminal finishReason — the model kept calling tools.
-	// Always include the trace on the error path (independent of `includeToolTrace`) so
-	// callers can debug an exhausted budget without re-running with tracing on.
-	throw new BudgetExceededError(
-		'iterations',
-		`agent loop exceeded maxToolIterations=${maxIterations}`,
-		trace
-	);
+	const handlerStart = performance.now();
+	let toolMessageContent: string;
+	// Wrap BOTH the handler call AND result serialization in the recover catch.
+	// `JSON.stringify` throws on BigInt and circular refs — both trivially produced by
+	// handlers that return raw DB rows or Resource instances. Without this, a
+	// serialization failure crashes the entire loop instead of becoming a tool error
+	// the model can react to (the `toolErrorMode: 'recover'` contract).
+	try {
+		const handlerOutput = await handler(call.arguments, ctx);
+		const serialized = serializeToolResult(handlerOutput, maxResultBytes);
+		entry.result = serialized.content;
+		if (serialized.truncated) {
+			entry.truncated = true;
+			entry.totalBytes = serialized.totalBytes;
+		}
+		toolMessageContent = serialized.content;
+	} catch (err) {
+		// Cooperative cancellation is NOT a tool error — rethrow so the loop's
+		// abort path (top-of-loop / post-dispatch `throwIfAborted`) classifies it
+		// correctly. Without this, AbortError would land in `entry.error` and the
+		// caller would see `BudgetExceededError` on the last iteration, or a
+		// bogus `{error: 'aborted'}` tool message threaded into the conversation.
+		// The trace entry is abandoned (the loop builds an aborted-path trace later).
+		if (ctx.signal?.aborted) throw err;
+		// `toolErrorMode: 'recover'` (v1 only path): append the error message as the
+		// tool result so the model can react. Commit 4 wires 'abort' to throw early.
+		entry.error = errorInfo(err);
+		toolMessageContent = JSON.stringify({ error: entry.error.message });
+	}
+	entry.durationMs = performance.now() - handlerStart;
+
+	return { entry, toolMessageContent };
+}
+
+/**
+ * Mirror of `backendHelpers.composeSignal` but composing a caller signal with an
+ * INTERNAL controller's signal (not a timeout). Returns the internal signal alone
+ * when no caller signal exists, the caller signal alone when no internal controller
+ * is needed (today never — we always create one), and a composed signal otherwise.
+ *
+ * `AbortSignal.any` requires Node 20+, which matches Harper's engines floor.
+ */
+function composeAbortSignal(caller: AbortSignal | undefined, internal: AbortSignal): AbortSignal {
+	if (!caller) return internal;
+	return AbortSignal.any([caller, internal]);
 }
 
 export async function* runAgentLoopStream(_args: RunAgentLoopArgs): AsyncIterable<GenerateChunk> {

--- a/resources/models/agentLoop.ts
+++ b/resources/models/agentLoop.ts
@@ -17,25 +17,43 @@
  * only fired externally (caller aborts → composed signal aborts); commit 4 wires
  * it to also fire on budget trips so an in-flight LLM call cancels cleanly.
  *
- * Commit 5 of #612 — streaming auto path + `opts.conversation.append` hook on
- * both sync and streaming. The streaming loop yields each round's deltas to the
- * caller as they arrive, accumulates the round's tool-call assembly internally,
- * suppresses intermediate `finishReason: 'tool_calls'` chunks (per the
- * `GenerateChunk` contract that finishReason marks the FINAL chunk only), runs
- * tools between rounds, and resumes with the next backend stream. Budget /
- * abort / error-mode semantics match the sync path, with one streaming-specific
- * gap: `maxToolTokens` / `maxCostUsd` are not yet enforced for streamed calls
- * because `GenerateChunk` doesn't expose `usage` in v1 (follow-up to extend the
- * chunk shape + backend final-chunk handling).
+ * Streaming auto path + `opts.conversation.append` hook on both sync and streaming.
+ * The streaming loop yields each round's content / tool-call deltas to the caller as
+ * they arrive, accumulates the round's tool-call assembly internally, and treats
+ * `finishReason` as an INTERNAL signal: it is stripped from every forwarded chunk and
+ * re-emitted as exactly one terminal chunk AFTER the terminal assistant turn has been
+ * persisted, so a consumer that stops on the finish-reason chunk can never race past
+ * the conversation append. Tools run between rounds; the next backend stream resumes.
+ * Budget / abort / error-mode semantics match the sync path, with one streaming-specific
+ * gap: `maxToolTokens` / `maxCostUsd` are not yet enforced for streamed calls because
+ * `GenerateChunk` doesn't expose `usage` in v1 (follow-up to extend the chunk shape +
+ * backend final-chunk handling).
+ *
+ * Resilience posture (this module is foundational infra — fail loud, never silent):
+ *   - Handler lookup uses `Object.hasOwn` + a callable check; a model-emitted tool name
+ *     that collides with an Object prototype member (`toString`, `constructor`, …) does
+ *     NOT resolve a built-in as a handler.
+ *   - Missing handler splits two ways: a name the caller DECLARED in `tools` but didn't
+ *     supply a handler for is a caller config bug (hard `ClientError(400)`); an UNdeclared
+ *     name is a model hallucination, surfaced as a recoverable tool error (`toolErrorMode`
+ *     decides recover-vs-abort).
+ *   - A token/cost budget set against a backend that reports no `usage` warns once that it
+ *     is unenforceable rather than silently no-opping.
+ *   - An incomplete streamed tool call (id without a name) is recorded in the trace + warned,
+ *     not silently dropped.
+ *   - `toolErrorMode: 'abort'` throws BEFORE the conversation sink sees the round's tool
+ *     turns, so the store never holds a recover-style error turn the model never consumed.
  *
  * Modes still deferred to follow-ups throw 501 at entry:
  *   - `toolArgValidation: 'strict' | 'lenient'`  → JSON Schema validator (TBD)
  *   - `maxToolTokens` / `maxCostUsd` (streaming) → backend `usage` on chunks (TBD)
  *
- * Registry seam: v1 dispatches via caller-supplied `opts.toolHandlers`. #615
- * replaces that with a `scope.resources` lookup using the same call signature.
+ * Registry seam: v1 dispatches via caller-supplied `opts.toolHandlers`. #615 replaces
+ * that lookup with a `scope.resources` resolution using the same call signature — the
+ * declared-vs-undeclared split maps onto resolvable-but-misconfigured vs unknown.
  */
 import { ClientError, ServerError } from '../../utility/errors/hdbError.ts';
+import { logger } from '../../utility/logging/logger.ts';
 import type {
 	AccountingContext,
 	GenerateChunk,
@@ -81,11 +99,19 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 	const conversation = opts.conversation;
 
 	const { messages, tools, system } = normalizeInput(args.input);
+	// Names the CALLER declared as tools (object-form input). Used to split the
+	// missing-handler case: a declared tool with no handler is a caller config bug
+	// (hard fail); an UNdeclared name is a model hallucination (recover). See
+	// `runSingleToolCall`.
+	const declaredToolNames = collectDeclaredToolNames(tools);
 	const trace: ToolTraceEntry[] = [];
 	// Cumulative usage tallies across all iterations of this loop invocation. Used to
 	// trip `maxToolTokens` / `maxCostUsd` after each backend round.
 	let totalTokens = 0;
 	let totalCostUsd = 0;
+	// Warn-once latch: a token/cost budget is set but the backend isn't reporting
+	// usage, so the cap can't be measured. We refuse to silently pretend it's enforced.
+	let budgetUnmeasurableWarned = false;
 
 	// `conversation` is a one-way SINK for NEW turns produced by this loop — the loop
 	// does NOT re-append the caller's input messages, even when they include user
@@ -116,6 +142,33 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 			composedSignal.throwIfAborted();
 
 			const result = await models.generate(buildInnerInput(messages, tools, system), innerOpts);
+
+			// Re-check abort the instant the backend round returns, BEFORE any budget
+			// accounting, assistant append, or tool dispatch. A well-behaved backend
+			// throws on an in-flight abort; an ill-behaved one (community backend that
+			// ignores its signal) can resolve normally after the caller aborted. Without
+			// this check the loop would run side-effecting handlers for a cancelled
+			// request and then misreport the outcome as a budget/tool error instead of
+			// an abort.
+			composedSignal.throwIfAborted();
+
+			logger.debug?.(
+				`[models] auto-loop iteration ${iteration}: finishReason=${result.finishReason} toolCalls=${result.toolCalls?.length ?? 0} cumulativeTokens=${totalTokens}`
+			);
+
+			// A token/cost budget is only as good as the backend's usage reporting. If a
+			// cap is set but this round reported no usage, the cap is unmeasurable — warn
+			// once rather than letting the caller believe spend is bounded when it isn't.
+			if (
+				(maxToolTokens !== undefined || maxCostUsd !== undefined) &&
+				result.usage === undefined &&
+				!budgetUnmeasurableWarned
+			) {
+				budgetUnmeasurableWarned = true;
+				logger.warn?.(
+					`[models] auto-loop token/cost budget set but backend '${opts.model ?? 'default'}' reported no usage; budget is unenforceable for this run (maxToolIterations still applies)`
+				);
+			}
 
 			// Tally this round's usage BEFORE deciding terminal vs continue. A round
 			// that crosses the cap trips even if it would otherwise have been the last
@@ -173,7 +226,15 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 			}
 
 			const ctx: ToolHandlerContext = { signal: composedSignal, accounting };
-			const dispatched = await dispatchToolCalls(calls, handlers, ctx, iteration, maxResultBytes, parallelism);
+			const dispatched = await dispatchToolCalls(
+				calls,
+				handlers,
+				declaredToolNames,
+				ctx,
+				iteration,
+				maxResultBytes,
+				parallelism
+			);
 
 			// Post-dispatch abort check — covers the LAST-iteration case: if the signal
 			// fired during this round's handlers, we'd otherwise skip the top-of-loop check
@@ -182,10 +243,10 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 			// pick this up on the next round's top-of-loop check.
 			composedSignal.throwIfAborted();
 
-			// Trace + tool messages append in CALL order regardless of completion order under
-			// parallel — the trace mirrors what the model emitted, not which handler finished first.
-			// Append BEFORE the abort-mode check so the failing entry is included in the
-			// partial trace surfaced via `ToolHandlerError.partialTrace`.
+			// Trace + the in-memory message list always record every tool result in CALL
+			// order (the trace mirrors what the model emitted, not which handler finished
+			// first). The EXTERNAL conversation sink is handled separately below so the
+			// abort-mode throw can run BEFORE we persist turns the model never consumes.
 			for (const dispatchResult of dispatched) {
 				trace.push(dispatchResult.entry);
 				messages.push({
@@ -193,23 +254,29 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 					content: dispatchResult.toolMessageContent,
 					toolCallId: dispatchResult.entry.toolCallId,
 				});
-				if (conversation) {
+			}
+
+			// `toolErrorMode: 'abort'`: any handler failure terminates the loop. Throw
+			// BEFORE the conversation sink sees this round's tool turns — abort mode
+			// returns the error to the caller instead of recovering, so persisting a
+			// recover-style tool-error turn the model never reads would leave the store
+			// inconsistent with what actually happened. The trace (built above) still
+			// carries the failing entry via `ToolHandlerError.partialTrace`.
+			if (errorMode === 'abort') {
+				const failed = dispatched.find((d) => d.originalError !== undefined);
+				if (failed) {
+					throw new ToolHandlerError(failed.entry.toolName, failed.entry.toolCallId, trace, failed.originalError);
+				}
+			}
+
+			// Continue path: persist this round's tool turns to the conversation sink.
+			if (conversation) {
+				for (const dispatchResult of dispatched) {
 					await conversation.append({
 						role: 'tool',
 						toolCallId: dispatchResult.entry.toolCallId,
 						content: dispatchResult.toolMessageContent,
 					});
-				}
-			}
-
-			// `toolErrorMode: 'abort'`: any handler failure terminates the loop. Trace
-			// includes the failing entry (pushed above) so the caller can see what blew
-			// up. Surfaces as `ToolHandlerError` carrying the original throw on `.cause`
-			// and the trace on `.partialTrace`.
-			if (errorMode === 'abort') {
-				const failed = dispatched.find((d) => d.originalError !== undefined);
-				if (failed) {
-					throw new ToolHandlerError(failed.entry.toolName, failed.entry.toolCallId, trace, failed.originalError);
 				}
 			}
 		}
@@ -243,6 +310,7 @@ interface DispatchedToolCall {
 async function dispatchToolCalls(
 	calls: ToolCall[],
 	handlers: Record<string, ToolHandler>,
+	declaredToolNames: Set<string>,
 	ctx: ToolHandlerContext,
 	iteration: number,
 	maxResultBytes: number,
@@ -254,7 +322,7 @@ async function dispatchToolCalls(
 	if (parallelism === 'serial' || calls.length <= 1) {
 		const out: DispatchedToolCall[] = [];
 		for (const call of calls) {
-			out.push(await runSingleToolCall(call, handlers, ctx, iteration, maxResultBytes));
+			out.push(await runSingleToolCall(call, handlers, declaredToolNames, ctx, iteration, maxResultBytes));
 		}
 		return out;
 	}
@@ -271,7 +339,9 @@ async function dispatchToolCalls(
 	// unhandled-rejection warnings (and crash under `--unhandled-rejections=throw`).
 	// Attach a no-op catch to each promise so the runtime sees every rejection as
 	// handled while still letting `Promise.all` settle on the first one.
-	const promises = calls.map((call) => runSingleToolCall(call, handlers, ctx, iteration, maxResultBytes));
+	const promises = calls.map((call) =>
+		runSingleToolCall(call, handlers, declaredToolNames, ctx, iteration, maxResultBytes)
+	);
 	for (const p of promises) p.catch(() => {});
 	return Promise.all(promises);
 }
@@ -279,6 +349,7 @@ async function dispatchToolCalls(
 async function runSingleToolCall(
 	call: ToolCall,
 	handlers: Record<string, ToolHandler>,
+	declaredToolNames: Set<string>,
 	ctx: ToolHandlerContext,
 	iteration: number,
 	maxResultBytes: number
@@ -294,13 +365,35 @@ async function runSingleToolCall(
 		durationMs: 0,
 	};
 
-	const handler = handlers[call.name];
+	// Handler resolution. Use `Object.hasOwn` + a callable check rather than a plain
+	// `handlers[call.name]` lookup: a model can emit a tool name that collides with an
+	// inherited Object prototype member (`toString`, `constructor`, `__proto__`, ...),
+	// and a bare index would resolve that built-in as a "handler" and invoke it. Model
+	// output is untrusted input at this boundary — only an own, callable property counts.
+	const handler =
+		Object.hasOwn(handlers, call.name) && typeof handlers[call.name] === 'function' ? handlers[call.name] : undefined;
 	if (!handler) {
-		// No handler registered. Hard fail — there's nothing to call. (#615 swaps this
-		// branch for a `scope.resources` lookup; same call signature, same throw if
-		// unresolved.) Throw as ClientError(400) since the caller didn't supply a handler
-		// for a tool they declared, not a Harper-internal fault.
-		throw new ClientError(`No handler registered for tool '${call.name}' (call id ${call.id})`, 400);
+		if (declaredToolNames.has(call.name)) {
+			// The caller DECLARED this tool but supplied no (callable) handler for it.
+			// That's a caller config bug, not something the model can recover from —
+			// hard fail. (#615 swaps this lookup for a `scope.resources` registry
+			// resolution; same split — resolvable-but-misconfigured stays a hard fail.)
+			throw new ClientError(`No handler registered for declared tool '${call.name}' (call id ${call.id})`, 400);
+		}
+		// Undeclared tool name: the model hallucinated a tool that doesn't exist. This is
+		// the EXPECTED failure mode for an LLM, not a caller fault — surface it as a
+		// recoverable tool error so `toolErrorMode: 'recover'` feeds it back and the model
+		// can self-correct, while `'abort'` (via `originalError`) still stops the loop.
+		logger.warn?.(
+			`[models] auto-loop: model called unknown tool '${call.name}' (call id ${call.id}); no such tool declared`
+		);
+		const unknownToolError = new ClientError(`Unknown tool '${call.name}': no such tool is available`, 400);
+		entry.error = errorInfo(unknownToolError);
+		return {
+			entry,
+			toolMessageContent: JSON.stringify({ error: entry.error.message }),
+			originalError: unknownToolError,
+		};
 	}
 
 	const handlerStart = performance.now();
@@ -378,6 +471,7 @@ export async function* runAgentLoopStream(args: RunAgentLoopArgs): AsyncIterable
 	}
 
 	const { messages, tools, system } = normalizeInput(args.input);
+	const declaredToolNames = collectDeclaredToolNames(tools);
 	const trace: ToolTraceEntry[] = [];
 
 	const loopController = new AbortController();
@@ -415,25 +509,46 @@ export async function* runAgentLoopStream(args: RunAgentLoopArgs): AsyncIterable
 				if (chunk.finishReason) {
 					finishReason = chunk.finishReason;
 				}
-				// Suppress intermediate `finishReason: 'tool_calls'` from the caller —
-				// the contract on `GenerateChunk` is "finishReason set on the FINAL chunk".
-				// Intermediate tool-pause states are an internal loop concern; the caller
-				// sees a continuous stream punctuated only by the terminal finishReason.
-				if (chunk.finishReason === 'tool_calls') {
-					if (chunk.deltaContent !== undefined || chunk.deltaToolCalls) {
-						// Carry the deltas but drop the finishReason field for the yield.
-						const cleaned: GenerateChunk = {};
-						if (chunk.deltaContent !== undefined) cleaned.deltaContent = chunk.deltaContent;
-						if (chunk.deltaToolCalls) cleaned.deltaToolCalls = chunk.deltaToolCalls;
-						yield cleaned;
-					}
-					// Pure finishReason chunk on tool_calls — drop entirely.
-					continue;
+				// `finishReason` is an INTERNAL signal — never forward it inline. We re-emit
+				// exactly one terminal chunk after the loop, AFTER the terminal turn has been
+				// appended to the conversation sink (see below). Forwarding it here would let a
+				// consumer that stops on the first finish-reason chunk close this generator at
+				// the `yield` before the append runs, delivering a response that never persists.
+				// The deltas (content / tool-call shape) still flow through untouched.
+				if (chunk.deltaContent !== undefined || chunk.deltaToolCalls) {
+					const cleaned: GenerateChunk = {};
+					if (chunk.deltaContent !== undefined) cleaned.deltaContent = chunk.deltaContent;
+					if (chunk.deltaToolCalls) cleaned.deltaToolCalls = chunk.deltaToolCalls;
+					yield cleaned;
 				}
-				yield chunk;
 			}
 
 			const finalToolCalls = completeToolCallAssembly(toolCallAssembly);
+			// Surface any assembled-but-incomplete tool calls (id arrived, name never did)
+			// instead of silently dropping them. `completeToolCallAssembly` keeps only
+			// dispatchable (id + name) calls; a missing-name partial usually means a
+			// truncated stream. Record it in the trace + warn so the drop is observable.
+			if (finalToolCalls.length < toolCallAssembly.size) {
+				for (const [id, partial] of toolCallAssembly) {
+					if (!partial.name) {
+						logger.warn?.(
+							`[models] auto-loop: dropping incomplete streamed tool call id=${id} (no tool name assembled; stream likely truncated)`
+						);
+						trace.push({
+							iteration,
+							toolCallId: id,
+							toolName: '<incomplete>',
+							arguments: partial.arguments ?? {},
+							durationMs: 0,
+							error: { name: 'IncompleteToolCall', message: 'streamed tool call missing name; dropped' },
+						});
+					}
+				}
+			}
+
+			logger.debug?.(
+				`[models] auto-loop stream iteration ${iteration}: finishReason=${finishReason ?? 'none'} toolCalls=${finalToolCalls.length}`
+			);
 
 			// Continue-vs-terminal:
 			// - Hand off to tool dispatch when calls assembled AND the backend signalled
@@ -450,14 +565,18 @@ export async function* runAgentLoopStream(args: RunAgentLoopArgs): AsyncIterable
 			const continueWithToolCalls = hasToolCalls && (finishReason === 'tool_calls' || finishReason === undefined);
 
 			if (!continueWithToolCalls) {
+				// Terminal. Persist the final assistant turn to the conversation sink FIRST,
+				// then emit exactly one terminal chunk. Because the loop suppressed every
+				// inline finishReason, this `yield` is the only finish-reason the consumer
+				// sees — and it lands after the append, so a consumer that stops on it cannot
+				// race past the persistence.
 				if (conversation && accumulatedContent) {
 					await conversation.append({ role: 'assistant', content: accumulatedContent });
 				}
-				if (finishReason === undefined || finishReason === 'tool_calls') {
-					// Synthetic terminal: backend never yielded one inline, OR we suppressed
-					// the intermediate 'tool_calls' chunk and no calls assembled to dispatch.
-					yield { finishReason: 'stop' };
-				}
+				// `tool_calls` with zero dispatchable calls can't honestly be reported as the
+				// terminal reason (there are no calls); fold it and the no-signal case to 'stop'.
+				const terminalReason = finishReason && finishReason !== 'tool_calls' ? finishReason : 'stop';
+				yield { finishReason: terminalReason };
 				return;
 			}
 
@@ -477,10 +596,21 @@ export async function* runAgentLoopStream(args: RunAgentLoopArgs): AsyncIterable
 			}
 
 			const ctx: ToolHandlerContext = { signal: composedSignal, accounting };
-			const dispatched = await dispatchToolCalls(finalToolCalls, handlers, ctx, iteration, maxResultBytes, parallelism);
+			const dispatched = await dispatchToolCalls(
+				finalToolCalls,
+				handlers,
+				declaredToolNames,
+				ctx,
+				iteration,
+				maxResultBytes,
+				parallelism
+			);
 
 			composedSignal.throwIfAborted();
 
+			// Trace + in-memory messages always record every result; the external
+			// conversation sink is deferred past the abort-mode throw (same rationale as
+			// the sync path — don't persist tool turns the model never consumes on abort).
 			for (const d of dispatched) {
 				trace.push(d.entry);
 				messages.push({
@@ -488,19 +618,22 @@ export async function* runAgentLoopStream(args: RunAgentLoopArgs): AsyncIterable
 					content: d.toolMessageContent,
 					toolCallId: d.entry.toolCallId,
 				});
-				if (conversation) {
-					await conversation.append({
-						role: 'tool',
-						toolCallId: d.entry.toolCallId,
-						content: d.toolMessageContent,
-					});
-				}
 			}
 
 			if (errorMode === 'abort') {
 				const failed = dispatched.find((d) => d.originalError !== undefined);
 				if (failed) {
 					throw new ToolHandlerError(failed.entry.toolName, failed.entry.toolCallId, trace, failed.originalError);
+				}
+			}
+
+			if (conversation) {
+				for (const d of dispatched) {
+					await conversation.append({
+						role: 'tool',
+						toolCallId: d.entry.toolCallId,
+						content: d.toolMessageContent,
+					});
 				}
 			}
 		}
@@ -578,6 +711,12 @@ function normalizeInput(input: GenerateInput): {
 		return { messages: [...input] };
 	}
 	return { messages: [...input.messages], tools: input.tools, system: input.system };
+}
+
+function collectDeclaredToolNames(tools: ToolDef[] | undefined): Set<string> {
+	const names = new Set<string>();
+	if (tools) for (const t of tools) names.add(t.name);
+	return names;
 }
 
 function errorInfo(err: unknown): { name: string; message: string } {

--- a/resources/models/agentLoop.ts
+++ b/resources/models/agentLoop.ts
@@ -213,7 +213,16 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 				if (conversation && assistantContent) {
 					await conversation.append({ role: 'assistant', content: assistantContent });
 				}
-				return opts.includeToolTrace ? { ...result, trace } : result;
+				// A `tool_calls` finishReason with no dispatchable calls (e.g. the backend
+				// dropped malformed tool-call args) is terminal — coerce it to 'stop' so an
+				// auto-mode caller never sees a `tool_calls` finishReason (auto resolves calls
+				// internally) pointing at calls that aren't there, and never a `null` content.
+				// Mirrors the streaming path's terminalReason fold.
+				const terminal: GenerateResult =
+					result.finishReason === 'tool_calls'
+						? { ...result, finishReason: 'stop', content: assistantContent }
+						: result;
+				return opts.includeToolTrace ? { ...terminal, trace } : terminal;
 			}
 
 			messages.push({ role: 'assistant', content: assistantContent, toolCalls: calls });

--- a/resources/models/agentLoop.ts
+++ b/resources/models/agentLoop.ts
@@ -148,35 +148,32 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 			}
 
 			const calls = result.toolCalls;
+			// Backends (notably OpenAI) leave `content` as `null` / undefined on tool-call
+			// rounds. `Message.content` and `ConversationTurn.content` are typed as a
+			// required string — coerce to '' at the seam.
+			const assistantContent = result.content ?? '';
 			if (result.finishReason !== 'tool_calls' || !calls || calls.length === 0) {
 				// Terminal: model produced a final answer (stop / length / content_filter), or it
 				// signaled tool_calls but emitted none. Append final assistant turn to the
 				// conversation hook (if set), then pass the result through; attach the trace
 				// when the caller asked for it.
-				if (conversation && result.content) {
-					await conversation.append({ role: 'assistant', content: result.content });
+				if (conversation && assistantContent) {
+					await conversation.append({ role: 'assistant', content: assistantContent });
 				}
 				return opts.includeToolTrace ? { ...result, trace } : result;
 			}
 
-			messages.push({ role: 'assistant', content: result.content, toolCalls: calls });
+			messages.push({ role: 'assistant', content: assistantContent, toolCalls: calls });
 			if (conversation) {
 				await conversation.append({
 					role: 'assistant',
-					content: result.content,
+					content: assistantContent,
 					toolCalls: calls,
 				});
 			}
 
 			const ctx: ToolHandlerContext = { signal: composedSignal, accounting };
-			const dispatched = await dispatchToolCalls(
-				calls,
-				handlers,
-				ctx,
-				iteration,
-				maxResultBytes,
-				parallelism
-			);
+			const dispatched = await dispatchToolCalls(calls, handlers, ctx, iteration, maxResultBytes, parallelism);
 
 			// Post-dispatch abort check — covers the LAST-iteration case: if the signal
 			// fired during this round's handlers, we'd otherwise skip the top-of-loop check
@@ -212,12 +209,7 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 			if (errorMode === 'abort') {
 				const failed = dispatched.find((d) => d.originalError !== undefined);
 				if (failed) {
-					throw new ToolHandlerError(
-						failed.entry.toolName,
-						failed.entry.toolCallId,
-						trace,
-						failed.originalError
-					);
+					throw new ToolHandlerError(failed.entry.toolName, failed.entry.toolCallId, trace, failed.originalError);
 				}
 			}
 		}
@@ -225,11 +217,7 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 		// Hit `maxToolIterations` without a terminal finishReason — the model kept calling tools.
 		// Always include the trace on the error path (independent of `includeToolTrace`) so
 		// callers can debug an exhausted budget without re-running with tracing on.
-		throw new BudgetExceededError(
-			'iterations',
-			`agent loop exceeded maxToolIterations=${maxIterations}`,
-			trace
-		);
+		throw new BudgetExceededError('iterations', `agent loop exceeded maxToolIterations=${maxIterations}`, trace);
 	} finally {
 		// Always abort the loop controller on exit (success, throw, or external abort).
 		// Cleans up `AbortSignal.any`'s listener on `callerSignal` so a session-scoped caller
@@ -283,9 +271,7 @@ async function dispatchToolCalls(
 	// unhandled-rejection warnings (and crash under `--unhandled-rejections=throw`).
 	// Attach a no-op catch to each promise so the runtime sees every rejection as
 	// handled while still letting `Promise.all` settle on the first one.
-	const promises = calls.map((call) =>
-		runSingleToolCall(call, handlers, ctx, iteration, maxResultBytes)
-	);
+	const promises = calls.map((call) => runSingleToolCall(call, handlers, ctx, iteration, maxResultBytes));
 	for (const p of promises) p.catch(() => {});
 	return Promise.all(promises);
 }
@@ -314,10 +300,7 @@ async function runSingleToolCall(
 		// branch for a `scope.resources` lookup; same call signature, same throw if
 		// unresolved.) Throw as ClientError(400) since the caller didn't supply a handler
 		// for a tool they declared, not a Harper-internal fault.
-		throw new ClientError(
-			`No handler registered for tool '${call.name}' (call id ${call.id})`,
-			400
-		);
+		throw new ClientError(`No handler registered for tool '${call.name}' (call id ${call.id})`, 400);
 	}
 
 	const handlerStart = performance.now();
@@ -464,8 +447,7 @@ export async function* runAgentLoopStream(args: RunAgentLoopArgs): AsyncIterable
 			//   receive a terminal finishReason inline (degenerate streams, or the
 			//   suppressed `tool_calls` finishReason with zero assembled calls).
 			const hasToolCalls = finalToolCalls.length > 0;
-			const continueWithToolCalls =
-				hasToolCalls && (finishReason === 'tool_calls' || finishReason === undefined);
+			const continueWithToolCalls = hasToolCalls && (finishReason === 'tool_calls' || finishReason === undefined);
 
 			if (!continueWithToolCalls) {
 				if (conversation && accumulatedContent) {
@@ -495,14 +477,7 @@ export async function* runAgentLoopStream(args: RunAgentLoopArgs): AsyncIterable
 			}
 
 			const ctx: ToolHandlerContext = { signal: composedSignal, accounting };
-			const dispatched = await dispatchToolCalls(
-				finalToolCalls,
-				handlers,
-				ctx,
-				iteration,
-				maxResultBytes,
-				parallelism
-			);
+			const dispatched = await dispatchToolCalls(finalToolCalls, handlers, ctx, iteration, maxResultBytes, parallelism);
 
 			composedSignal.throwIfAborted();
 
@@ -525,21 +500,12 @@ export async function* runAgentLoopStream(args: RunAgentLoopArgs): AsyncIterable
 			if (errorMode === 'abort') {
 				const failed = dispatched.find((d) => d.originalError !== undefined);
 				if (failed) {
-					throw new ToolHandlerError(
-						failed.entry.toolName,
-						failed.entry.toolCallId,
-						trace,
-						failed.originalError
-					);
+					throw new ToolHandlerError(failed.entry.toolName, failed.entry.toolCallId, trace, failed.originalError);
 				}
 			}
 		}
 
-		throw new BudgetExceededError(
-			'iterations',
-			`agent loop exceeded maxToolIterations=${maxIterations}`,
-			trace
-		);
+		throw new BudgetExceededError('iterations', `agent loop exceeded maxToolIterations=${maxIterations}`, trace);
 	} finally {
 		loopController.abort();
 	}
@@ -650,14 +616,17 @@ function serializeToolResult(value: unknown, maxBytes: number): SerializedResult
 	}
 	// Truncated form: head of the JSON + a marker that names the original size. The
 	// content is no longer valid JSON — that's intentional, the model reads it as text
-	// alongside the marker. Single-pass byte-level slice; `Buffer#toString('utf8')`
-	// folds a split codepoint at the boundary into a replacement char (U+FFFD).
-	// The body slice never exceeds the byte budget — no O(n²) trim loop needed for
-	// multi-byte content.
+	// alongside the marker. Pre-slice the JSON string by CHARACTERS to `headBudget`
+	// before converting to a Buffer — any character takes at least one UTF-8 byte, so
+	// the pre-sliced string already fits in (4 * headBudget) bytes worst-case. Without
+	// this, a multi-MB JSON result would materialize a multi-MB Buffer copy just to
+	// throw away >99 % of it via `subarray`. After conversion, `subarray(0, headBudget)`
+	// trims to exact byte budget; `toString('utf8')` folds a split codepoint at the
+	// boundary into U+FFFD.
 	const marker = `…[truncated; full result is ${totalBytes} bytes]`;
 	const markerBytes = Buffer.byteLength(marker, 'utf8');
 	const headBudget = Math.max(0, maxBytes - markerBytes);
-	const buf = Buffer.from(json, 'utf8');
+	const buf = Buffer.from(json.slice(0, headBudget), 'utf8');
 	const body = buf.subarray(0, headBudget).toString('utf8');
 	return { content: body + marker, totalBytes, truncated: true };
 }
@@ -707,8 +676,11 @@ export class ToolHandlerError extends ServerError {
 	constructor(toolName: string, toolCallId: string, partialTrace: ToolTraceEntry[], cause: unknown) {
 		const causeMessage = errorInfo(cause).message;
 		const causeStatus =
-			cause && typeof cause === 'object' && 'statusCode' in cause && typeof (cause as { statusCode: unknown }).statusCode === 'number'
-				? ((cause as { statusCode: number }).statusCode)
+			cause &&
+			typeof cause === 'object' &&
+			'statusCode' in cause &&
+			typeof (cause as { statusCode: unknown }).statusCode === 'number'
+				? (cause as { statusCode: number }).statusCode
 				: 500;
 		super(`Tool handler '${toolName}' (call ${toolCallId}) failed: ${causeMessage}`, causeStatus);
 		this.name = 'ToolHandlerError';

--- a/resources/models/agentLoop.ts
+++ b/resources/models/agentLoop.ts
@@ -17,15 +17,20 @@
  * only fired externally (caller aborts → composed signal aborts); commit 4 wires
  * it to also fire on budget trips so an in-flight LLM call cancels cleanly.
  *
- * Commit 4 of #612 — token + cost budgets, `toolErrorMode: 'abort'`. The cost
- * function is a stub (returns 0) until a per-model rate card is wired; the cap
- * still trips when a test overrides the function via `_setComputeCallCostUsdForTests`.
- * `toolErrorMode: 'abort'` surfaces handler errors as `ToolHandlerError` with the
- * trace attached (including the failing entry) so callers always have the full
- * picture on error paths. Modes deferred to later commits throw 501 at entry:
+ * Commit 5 of #612 — streaming auto path + `opts.conversation.append` hook on
+ * both sync and streaming. The streaming loop yields each round's deltas to the
+ * caller as they arrive, accumulates the round's tool-call assembly internally,
+ * suppresses intermediate `finishReason: 'tool_calls'` chunks (per the
+ * `GenerateChunk` contract that finishReason marks the FINAL chunk only), runs
+ * tools between rounds, and resumes with the next backend stream. Budget /
+ * abort / error-mode semantics match the sync path, with one streaming-specific
+ * gap: `maxToolTokens` / `maxCostUsd` are not yet enforced for streamed calls
+ * because `GenerateChunk` doesn't expose `usage` in v1 (follow-up to extend the
+ * chunk shape + backend final-chunk handling).
+ *
+ * Modes still deferred to follow-ups throw 501 at entry:
  *   - `toolArgValidation: 'strict' | 'lenient'`  → JSON Schema validator (TBD)
- *   - `opts.conversation.append`                 → commit 5
- *   - `runAgentLoopStream`                       → commit 5
+ *   - `maxToolTokens` / `maxCostUsd` (streaming) → backend `usage` on chunks (TBD)
  *
  * Registry seam: v1 dispatches via caller-supplied `opts.toolHandlers`. #615
  * replaces that with a `scope.resources` lookup using the same call signature.
@@ -73,6 +78,7 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 	const errorMode = opts.toolErrorMode ?? 'recover';
 	const maxToolTokens = opts.maxToolTokens;
 	const maxCostUsd = opts.maxCostUsd;
+	const conversation = opts.conversation;
 
 	const { messages, tools, system } = normalizeInput(args.input);
 	const trace: ToolTraceEntry[] = [];
@@ -80,6 +86,18 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 	// trip `maxToolTokens` / `maxCostUsd` after each backend round.
 	let totalTokens = 0;
 	let totalCostUsd = 0;
+
+	// Initial conversation turns: append the user-role messages flowing IN before the
+	// first backend round. System messages skipped — conventions vary (some hosts treat
+	// system as ambient, not turn-scoped). Awaited so caller can observe initial state
+	// before any backend round runs.
+	if (conversation) {
+		for (const m of messages) {
+			if (m.role === 'user') {
+				await conversation.append({ role: 'user', content: m.content });
+			}
+		}
+	}
 
 	// Loop-level abort controller — fired internally on budget trips (commit 4 wires
 	// that) and on every loop exit (success, throw, abort) via the `finally` below.
@@ -138,12 +156,23 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 			const calls = result.toolCalls;
 			if (result.finishReason !== 'tool_calls' || !calls || calls.length === 0) {
 				// Terminal: model produced a final answer (stop / length / content_filter), or it
-				// signaled tool_calls but emitted none. Pass the result through; attach the trace
+				// signaled tool_calls but emitted none. Append final assistant turn to the
+				// conversation hook (if set), then pass the result through; attach the trace
 				// when the caller asked for it.
+				if (conversation && result.content) {
+					await conversation.append({ role: 'assistant', content: result.content });
+				}
 				return opts.includeToolTrace ? { ...result, trace } : result;
 			}
 
 			messages.push({ role: 'assistant', content: result.content, toolCalls: calls });
+			if (conversation) {
+				await conversation.append({
+					role: 'assistant',
+					content: result.content,
+					toolCalls: calls,
+				});
+			}
 
 			const ctx: ToolHandlerContext = { signal: composedSignal, accounting };
 			const dispatched = await dispatchToolCalls(
@@ -173,6 +202,13 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 					content: dispatchResult.toolMessageContent,
 					toolCallId: dispatchResult.entry.toolCallId,
 				});
+				if (conversation) {
+					await conversation.append({
+						role: 'tool',
+						toolCallId: dispatchResult.entry.toolCallId,
+						content: dispatchResult.toolMessageContent,
+					});
+				}
 			}
 
 			// `toolErrorMode: 'abort'`: any handler failure terminates the loop. Trace
@@ -341,8 +377,208 @@ function composeAbortSignal(caller: AbortSignal | undefined, internal: AbortSign
 	return AbortSignal.any([caller, internal]);
 }
 
-export async function* runAgentLoopStream(_args: RunAgentLoopArgs): AsyncIterable<GenerateChunk> {
-	throw new ServerError("`toolMode: 'auto'` is not yet implemented for streaming", 501);
+export async function* runAgentLoopStream(args: RunAgentLoopArgs): AsyncIterable<GenerateChunk> {
+	const { models, opts, accounting, signal: callerSignal } = args;
+
+	guardUnsupportedModes(opts);
+
+	const maxIterations = opts.maxToolIterations ?? DEFAULT_MAX_ITERATIONS;
+	const maxResultBytes = opts.toolResultMaxBytes ?? DEFAULT_MAX_RESULT_BYTES;
+	const handlers = opts.toolHandlers ?? {};
+	const parallelism = opts.toolParallelism ?? 'parallel';
+	const errorMode = opts.toolErrorMode ?? 'recover';
+	const conversation = opts.conversation;
+	// Streaming + token/cost budgets: backends don't emit `usage` on `GenerateChunk`
+	// in v1 (the type has no `usage` field on chunks), so cumulative usage isn't
+	// observable from the stream. The iteration budget still applies. Wiring
+	// streaming budgets requires extending `GenerateChunk` and updating each
+	// backend's stream-final-chunk handling — a follow-up to this PR.
+	if (opts.maxToolTokens !== undefined || opts.maxCostUsd !== undefined) {
+		throw new ServerError(
+			`maxToolTokens / maxCostUsd are not yet supported for generateStream (streamed usage not exposed in v1)`,
+			501
+		);
+	}
+
+	const { messages, tools, system } = normalizeInput(args.input);
+	const trace: ToolTraceEntry[] = [];
+
+	const loopController = new AbortController();
+	const composedSignal = composeAbortSignal(callerSignal, loopController.signal);
+	const innerOpts: GenerateOpts = { ...opts, toolMode: 'return', signal: composedSignal };
+
+	// Initial conversation turns: append the user-role messages flowing IN before the
+	// first backend round. System messages skipped — conventions vary (some hosts treat
+	// system as ambient, not turn-scoped).
+	if (conversation) {
+		for (const m of messages) {
+			if (m.role === 'user') {
+				await conversation.append({ role: 'user', content: m.content });
+			}
+		}
+	}
+
+	try {
+		for (let iteration = 1; iteration <= maxIterations; iteration++) {
+			composedSignal.throwIfAborted();
+
+			// Stream this round: yield content + tool-call deltas to the caller as they
+			// arrive, while internally assembling the round's content and tool-call shape.
+			let accumulatedContent = '';
+			const toolCallAssembly = new Map<string, Partial<ToolCall>>();
+			let finishReason: GenerateResult['finishReason'] | undefined;
+
+			const stream = models.generateStream(buildInnerInput(messages, tools, system), innerOpts);
+			for await (const chunk of stream) {
+				if (chunk.deltaContent !== undefined) {
+					accumulatedContent += chunk.deltaContent;
+				}
+				if (chunk.deltaToolCalls) {
+					for (const delta of chunk.deltaToolCalls) {
+						mergeToolCallDelta(toolCallAssembly, delta);
+					}
+				}
+				if (chunk.finishReason) {
+					finishReason = chunk.finishReason;
+				}
+				// Suppress intermediate `finishReason: 'tool_calls'` from the caller —
+				// the contract on `GenerateChunk` is "finishReason set on the FINAL chunk".
+				// Intermediate tool-pause states are an internal loop concern; the caller
+				// sees a continuous stream punctuated only by the terminal finishReason.
+				if (chunk.finishReason === 'tool_calls') {
+					if (chunk.deltaContent !== undefined || chunk.deltaToolCalls) {
+						// Carry the deltas but drop the finishReason field for the yield.
+						const cleaned: GenerateChunk = {};
+						if (chunk.deltaContent !== undefined) cleaned.deltaContent = chunk.deltaContent;
+						if (chunk.deltaToolCalls) cleaned.deltaToolCalls = chunk.deltaToolCalls;
+						yield cleaned;
+					}
+					// Pure finishReason chunk on tool_calls — drop entirely.
+					continue;
+				}
+				yield chunk;
+			}
+
+			const finalToolCalls = completeToolCallAssembly(toolCallAssembly);
+			const isTerminal =
+				finishReason !== 'tool_calls' || finalToolCalls.length === 0;
+
+			if (isTerminal) {
+				// Append the assistant turn (final content) to conversation before bailing.
+				if (conversation && accumulatedContent) {
+					await conversation.append({ role: 'assistant', content: accumulatedContent });
+				}
+				// Degenerate-backend guard: if the stream finished with `tool_calls` BUT no
+				// assembled calls landed (provider misbehavior or upstream truncation), we
+				// already suppressed the 'tool_calls' chunk under the intermediate-finishReason
+				// rule above. Without a synthetic terminal chunk the consumer's `for-await`
+				// ends without ever seeing a terminal `finishReason`, violating the
+				// `GenerateChunk` contract. Reclassify to 'stop' and emit one chunk so the
+				// stream closes cleanly.
+				if (finishReason === 'tool_calls' && finalToolCalls.length === 0) {
+					yield { finishReason: 'stop' };
+				}
+				return;
+			}
+
+			// Continue the loop: dispatch tools, append messages, resume on next iteration.
+			const assistantMessage: Message = {
+				role: 'assistant',
+				content: accumulatedContent,
+				toolCalls: finalToolCalls,
+			};
+			messages.push(assistantMessage);
+			if (conversation) {
+				await conversation.append({
+					role: 'assistant',
+					content: accumulatedContent,
+					toolCalls: finalToolCalls,
+				});
+			}
+
+			const ctx: ToolHandlerContext = { signal: composedSignal, accounting };
+			const dispatched = await dispatchToolCalls(
+				finalToolCalls,
+				handlers,
+				ctx,
+				iteration,
+				maxResultBytes,
+				parallelism
+			);
+
+			composedSignal.throwIfAborted();
+
+			for (const d of dispatched) {
+				trace.push(d.entry);
+				messages.push({
+					role: 'tool',
+					content: d.toolMessageContent,
+					toolCallId: d.entry.toolCallId,
+				});
+				if (conversation) {
+					await conversation.append({
+						role: 'tool',
+						toolCallId: d.entry.toolCallId,
+						content: d.toolMessageContent,
+					});
+				}
+			}
+
+			if (errorMode === 'abort') {
+				const failed = dispatched.find((d) => d.originalError !== undefined);
+				if (failed) {
+					throw new ToolHandlerError(
+						failed.entry.toolName,
+						failed.entry.toolCallId,
+						trace,
+						failed.originalError
+					);
+				}
+			}
+		}
+
+		throw new BudgetExceededError(
+			'iterations',
+			`agent loop exceeded maxToolIterations=${maxIterations}`,
+			trace
+		);
+	} finally {
+		loopController.abort();
+	}
+}
+
+/**
+ * Update the in-flight assembly map with one streamed tool-call delta. Streaming
+ * backends may send the same `id` multiple times with partial `name` / `arguments`;
+ * we merge them in arrival order. Some backends pre-assemble and send the full
+ * call as a single delta — same code path, single update.
+ *
+ * Backends that stream `arguments` as accumulating JSON string fragments must
+ * parse before yielding (delta.arguments is typed as `object`); shape assembly
+ * lives in this loop, fragment assembly lives in the backend.
+ */
+function mergeToolCallDelta(map: Map<string, Partial<ToolCall>>, delta: Partial<ToolCall>): void {
+	if (!delta.id) return;
+	const existing: Partial<ToolCall> = map.get(delta.id) ?? { id: delta.id };
+	if (delta.name) existing.name = delta.name;
+	if (delta.arguments) {
+		existing.arguments = { ...existing.arguments, ...delta.arguments };
+	}
+	map.set(delta.id, existing);
+}
+
+function completeToolCallAssembly(map: Map<string, Partial<ToolCall>>): ToolCall[] {
+	const out: ToolCall[] = [];
+	for (const partial of map.values()) {
+		if (partial.id && partial.name) {
+			out.push({
+				id: partial.id,
+				name: partial.name,
+				arguments: partial.arguments ?? {},
+			});
+		}
+	}
+	return out;
 }
 
 function guardUnsupportedModes(opts: GenerateOpts): void {
@@ -350,12 +586,6 @@ function guardUnsupportedModes(opts: GenerateOpts): void {
 	if (validationMode !== 'none') {
 		throw new ServerError(
 			`toolArgValidation: '${validationMode}' is not yet implemented; v1 supports 'none' only`,
-			501
-		);
-	}
-	if (opts.conversation !== undefined) {
-		throw new ServerError(
-			`opts.conversation is not yet implemented (commit 5 of #612)`,
 			501
 		);
 	}

--- a/resources/models/agentLoop.ts
+++ b/resources/models/agentLoop.ts
@@ -17,12 +17,13 @@
  * only fired externally (caller aborts → composed signal aborts); commit 4 wires
  * it to also fire on budget trips so an in-flight LLM call cancels cleanly.
  *
- * Commit 3 of #612 — parallel batch dispatch (Promise.all, default) + caller-signal
- * propagation + iteration-boundary `throwIfAborted`. Modes deferred to later
- * commits throw 501 at entry:
+ * Commit 4 of #612 — token + cost budgets, `toolErrorMode: 'abort'`. The cost
+ * function is a stub (returns 0) until a per-model rate card is wired; the cap
+ * still trips when a test overrides the function via `_setComputeCallCostUsdForTests`.
+ * `toolErrorMode: 'abort'` surfaces handler errors as `ToolHandlerError` with the
+ * trace attached (including the failing entry) so callers always have the full
+ * picture on error paths. Modes deferred to later commits throw 501 at entry:
  *   - `toolArgValidation: 'strict' | 'lenient'`  → JSON Schema validator (TBD)
- *   - `toolErrorMode: 'abort'`                   → commit 4
- *   - `maxToolTokens`, `maxCostUsd`              → commit 4
  *   - `opts.conversation.append`                 → commit 5
  *   - `runAgentLoopStream`                       → commit 5
  *
@@ -38,6 +39,7 @@ import type {
 	GenerateResult,
 	Message,
 	Models,
+	TokenUsage,
 	ToolCall,
 	ToolDef,
 	ToolHandler,
@@ -68,9 +70,16 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 	const maxResultBytes = opts.toolResultMaxBytes ?? DEFAULT_MAX_RESULT_BYTES;
 	const handlers = opts.toolHandlers ?? {};
 	const parallelism = opts.toolParallelism ?? 'parallel';
+	const errorMode = opts.toolErrorMode ?? 'recover';
+	const maxToolTokens = opts.maxToolTokens;
+	const maxCostUsd = opts.maxCostUsd;
 
 	const { messages, tools, system } = normalizeInput(args.input);
 	const trace: ToolTraceEntry[] = [];
+	// Cumulative usage tallies across all iterations of this loop invocation. Used to
+	// trip `maxToolTokens` / `maxCostUsd` after each backend round.
+	let totalTokens = 0;
+	let totalCostUsd = 0;
 
 	// Loop-level abort controller — fired internally on budget trips (commit 4 wires
 	// that) and on every loop exit (success, throw, abort) via the `finally` below.
@@ -95,6 +104,36 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 			composedSignal.throwIfAborted();
 
 			const result = await models.generate(buildInnerInput(messages, tools, system), innerOpts);
+
+			// Tally this round's usage BEFORE deciding terminal vs continue. A round
+			// that crosses the cap trips even if it would otherwise have been the last
+			// one — the cap is on what we paid for, not on what we'd have paid for next.
+			// Cost trip semantics: `>= cap`, so `maxCostUsd: 0` blocks every call rather
+			// than dormantly admitting all of them until a real rate card lands and then
+			// abruptly blocking everything. Token trip uses `>=` for symmetry.
+			//
+			// Discarded-content asymmetry: a TERMINAL round that trips returns
+			// BudgetExceededError instead of the final assistant content. The content is
+			// in `messages` (the loop's running state) but neither `partialTrace` nor the
+			// thrown error surfaces it. Callers that need terminal content even on
+			// budget-trip should set `maxToolTokens` / `maxCostUsd` conservatively or read
+			// the per-iteration analytics rows (one row per round in `hdb_model_calls`).
+			totalTokens += sumTokens(result.usage);
+			totalCostUsd += computeCallCostUsd(result.usage, opts.model);
+			if (maxToolTokens !== undefined && totalTokens >= maxToolTokens) {
+				throw new BudgetExceededError(
+					'tokens',
+					`agent loop exceeded maxToolTokens=${maxToolTokens} (cumulative=${totalTokens})`,
+					trace
+				);
+			}
+			if (maxCostUsd !== undefined && totalCostUsd >= maxCostUsd) {
+				throw new BudgetExceededError(
+					'cost',
+					`agent loop exceeded maxCostUsd=${maxCostUsd} (cumulative=${totalCostUsd})`,
+					trace
+				);
+			}
 
 			const calls = result.toolCalls;
 			if (result.finishReason !== 'tool_calls' || !calls || calls.length === 0) {
@@ -125,6 +164,8 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 
 			// Trace + tool messages append in CALL order regardless of completion order under
 			// parallel — the trace mirrors what the model emitted, not which handler finished first.
+			// Append BEFORE the abort-mode check so the failing entry is included in the
+			// partial trace surfaced via `ToolHandlerError.partialTrace`.
 			for (const dispatchResult of dispatched) {
 				trace.push(dispatchResult.entry);
 				messages.push({
@@ -132,6 +173,22 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 					content: dispatchResult.toolMessageContent,
 					toolCallId: dispatchResult.entry.toolCallId,
 				});
+			}
+
+			// `toolErrorMode: 'abort'`: any handler failure terminates the loop. Trace
+			// includes the failing entry (pushed above) so the caller can see what blew
+			// up. Surfaces as `ToolHandlerError` carrying the original throw on `.cause`
+			// and the trace on `.partialTrace`.
+			if (errorMode === 'abort') {
+				const failed = dispatched.find((d) => d.originalError !== undefined);
+				if (failed) {
+					throw new ToolHandlerError(
+						failed.entry.toolName,
+						failed.entry.toolCallId,
+						trace,
+						failed.originalError
+					);
+				}
 			}
 		}
 
@@ -156,6 +213,13 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 interface DispatchedToolCall {
 	entry: ToolTraceEntry;
 	toolMessageContent: string;
+	/**
+	 * The original thrown value when the handler / serialization failed and recover
+	 * mode caught it. Preserved alongside the formatted `entry.error` so abort mode
+	 * can surface the cause unmodified via `ToolHandlerError.cause`. Undefined when
+	 * the handler succeeded.
+	 */
+	originalError?: unknown;
 }
 
 async function dispatchToolCalls(
@@ -167,8 +231,8 @@ async function dispatchToolCalls(
 	parallelism: 'parallel' | 'serial'
 ): Promise<DispatchedToolCall[]> {
 	// Single-call rounds use the serial path even when 'parallel' is selected — the
-	// Promise.all path adds nothing on one element and the serial path's stack trace
-	// is more readable in errors.
+	// settled-wrapping path adds nothing on one element and the serial path's stack
+	// trace is more readable in errors.
 	if (parallelism === 'serial' || calls.length <= 1) {
 		const out: DispatchedToolCall[] = [];
 		for (const call of calls) {
@@ -176,16 +240,24 @@ async function dispatchToolCalls(
 		}
 		return out;
 	}
-	// Parallel: handlers race concurrently. If any throws (missing handler is the only
-	// path that throws out of `runSingleToolCall` — handler errors are caught and
-	// recovered), Promise.all rejects with the first error. Siblings still running keep
-	// going in the background; their results are discarded. That's acceptable because
-	// (a) handler errors are recovered inline, so siblings rarely throw, and (b) the
-	// alternative (active cancellation via loopController) would also race in the same
-	// window. The composed signal still propagates external aborts to the siblings.
-	return Promise.all(
-		calls.map((call) => runSingleToolCall(call, handlers, ctx, iteration, maxResultBytes))
+	// Parallel: handlers race concurrently. `runSingleToolCall` only throws on missing
+	// handler or cooperative abort — handler errors are caught inline and surface via
+	// `originalError`. `Promise.all` rejects on first throw, which is what we want for
+	// those two cases: surface the throw immediately so the loop's `finally` can fire
+	// `loopController.abort` and cancel siblings still in flight, instead of waiting
+	// for every sibling to complete (which `Promise.allSettled` would force).
+	//
+	// Concurrent-rejection caveat: when MULTIPLE siblings reject at the same time
+	// (e.g. several missing handlers, or several handlers reacting to a cooperative
+	// abort), `Promise.all` only awaits the first rejection — the rest become
+	// unhandled-rejection warnings (and crash under `--unhandled-rejections=throw`).
+	// Attach a no-op catch to each promise so the runtime sees every rejection as
+	// handled while still letting `Promise.all` settle on the first one.
+	const promises = calls.map((call) =>
+		runSingleToolCall(call, handlers, ctx, iteration, maxResultBytes)
 	);
+	for (const p of promises) p.catch(() => {});
+	return Promise.all(promises);
 }
 
 async function runSingleToolCall(
@@ -220,6 +292,7 @@ async function runSingleToolCall(
 
 	const handlerStart = performance.now();
 	let toolMessageContent: string;
+	let originalError: unknown;
 	// Wrap BOTH the handler call AND result serialization in the recover catch.
 	// `JSON.stringify` throws on BigInt and circular refs — both trivially produced by
 	// handlers that return raw DB rows or Resource instances. Without this, a
@@ -242,14 +315,17 @@ async function runSingleToolCall(
 		// bogus `{error: 'aborted'}` tool message threaded into the conversation.
 		// The trace entry is abandoned (the loop builds an aborted-path trace later).
 		if (ctx.signal?.aborted) throw err;
-		// `toolErrorMode: 'recover'` (v1 only path): append the error message as the
-		// tool result so the model can react. Commit 4 wires 'abort' to throw early.
+		// Handler error. Populate entry.error so the trace records the failure, build
+		// the recover-mode tool-message envelope, and stash the original throw so
+		// `toolErrorMode: 'abort'` (checked in the main loop after dispatch) can
+		// surface the cause unmodified.
+		originalError = err;
 		entry.error = errorInfo(err);
 		toolMessageContent = JSON.stringify({ error: entry.error.message });
 	}
 	entry.durationMs = performance.now() - handlerStart;
 
-	return { entry, toolMessageContent };
+	return { entry, toolMessageContent, originalError };
 }
 
 /**
@@ -274,21 +350,6 @@ function guardUnsupportedModes(opts: GenerateOpts): void {
 	if (validationMode !== 'none') {
 		throw new ServerError(
 			`toolArgValidation: '${validationMode}' is not yet implemented; v1 supports 'none' only`,
-			501
-		);
-	}
-	const errorMode = opts.toolErrorMode ?? 'recover';
-	if (errorMode !== 'recover') {
-		throw new ServerError(
-			`toolErrorMode: '${errorMode}' is not yet implemented; v1 supports 'recover' only`,
-			501
-		);
-	}
-	// `toolParallelism` accepts 'serial' OR 'parallel' here; commit 3 wires the parallel
-	// branch. v1 runs serial regardless of caller setting — the field is forward-looking.
-	if (opts.maxToolTokens !== undefined || opts.maxCostUsd !== undefined) {
-		throw new ServerError(
-			`maxToolTokens / maxCostUsd budgets are not yet implemented (commit 4 of #612)`,
 			501
 		);
 	}
@@ -388,6 +449,77 @@ export class BudgetExceededError extends ClientError {
 		this.kind = kind;
 		this.partialTrace = partialTrace;
 	}
+}
+
+/**
+ * Surfaced under `toolErrorMode: 'abort'` when a tool handler throws (or its
+ * result fails to serialize). Carries the original throw on `.cause` and the
+ * partial trace — including the failing entry — on `.partialTrace` so callers
+ * always have the full picture on the abort path.
+ *
+ * `statusCode` mirrors the underlying error when it carries one (e.g. a handler
+ * throwing `ClientError(400)` surfaces as `ToolHandlerError(400)`), otherwise
+ * defaults to 500.
+ *
+ * **`instanceof` caveat:** extends `ServerError` regardless of `statusCode`, so a
+ * handler-thrown `ClientError(403)` becomes a `ToolHandlerError` whose `statusCode`
+ * is 403 but where `instanceof ClientError === false`. Callers that route on
+ * client-vs-server class should branch on `err.statusCode` or
+ * `err.cause instanceof ClientError`, not on `err instanceof ClientError` directly.
+ */
+export class ToolHandlerError extends ServerError {
+	toolName: string;
+	toolCallId: string;
+	partialTrace: ToolTraceEntry[];
+	constructor(toolName: string, toolCallId: string, partialTrace: ToolTraceEntry[], cause: unknown) {
+		const causeMessage = errorInfo(cause).message;
+		const causeStatus =
+			cause && typeof cause === 'object' && 'statusCode' in cause && typeof (cause as { statusCode: unknown }).statusCode === 'number'
+				? ((cause as { statusCode: number }).statusCode)
+				: 500;
+		super(`Tool handler '${toolName}' (call ${toolCallId}) failed: ${causeMessage}`, causeStatus);
+		this.name = 'ToolHandlerError';
+		this.toolName = toolName;
+		this.toolCallId = toolCallId;
+		this.partialTrace = partialTrace;
+		this.cause = cause;
+	}
+}
+
+/**
+ * Cost computation hook. v1 returns 0 — no per-model rate card is wired today —
+ * so `maxCostUsd` never trips in production. The cap, the trip path, and the
+ * `BudgetExceededError({kind: 'cost'})` shape ARE wired and exercised by tests
+ * that inject a non-zero function via `_setComputeCallCostUsdForTests`. When the
+ * rate card lands, replace this implementation; no surface change needed.
+ */
+let computeCallCostUsd: (usage: TokenUsage | undefined, model: string | undefined) => number = () => 0;
+
+/**
+ * Test-only override. Public callers must not depend on this — it exists so unit
+ * tests can prove the `maxCostUsd` trip path works end-to-end before a real rate
+ * card lands. Leading underscore marks the intent.
+ */
+export function _setComputeCallCostUsdForTests(
+	fn: (usage: TokenUsage | undefined, model: string | undefined) => number
+): void {
+	computeCallCostUsd = fn;
+}
+
+/**
+ * Reset the cost function to the v1 stub. Pair with `_setComputeCallCostUsdForTests`
+ * in test `afterEach` so suites don't leak state into each other.
+ */
+export function _resetComputeCallCostUsdForTests(): void {
+	computeCallCostUsd = () => 0;
+}
+
+function sumTokens(usage: TokenUsage | undefined): number {
+	if (!usage) return 0;
+	let total = 0;
+	if (typeof usage.promptTokens === 'number' && usage.promptTokens > 0) total += usage.promptTokens;
+	if (typeof usage.completionTokens === 'number' && usage.completionTokens > 0) total += usage.completionTokens;
+	return total;
 }
 
 /**

--- a/resources/models/agentLoop.ts
+++ b/resources/models/agentLoop.ts
@@ -87,17 +87,11 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<GenerateResu
 	let totalTokens = 0;
 	let totalCostUsd = 0;
 
-	// Initial conversation turns: append the user-role messages flowing IN before the
-	// first backend round. System messages skipped — conventions vary (some hosts treat
-	// system as ambient, not turn-scoped). Awaited so caller can observe initial state
-	// before any backend round runs.
-	if (conversation) {
-		for (const m of messages) {
-			if (m.role === 'user') {
-				await conversation.append({ role: 'user', content: m.content });
-			}
-		}
-	}
+	// `conversation` is a one-way SINK for NEW turns produced by this loop — the loop
+	// does NOT re-append the caller's input messages, even when they include user
+	// turns. Echoing input back into the caller's store would corrupt it (the caller
+	// already added their own prompt) and scramble ordering for multi-turn history.
+	// The caller owns turn 0; the loop owns whatever assistant/tool turns it produces.
 
 	// Loop-level abort controller — fired internally on budget trips (commit 4 wires
 	// that) and on every loop exit (success, throw, abort) via the `finally` below.
@@ -407,16 +401,8 @@ export async function* runAgentLoopStream(args: RunAgentLoopArgs): AsyncIterable
 	const composedSignal = composeAbortSignal(callerSignal, loopController.signal);
 	const innerOpts: GenerateOpts = { ...opts, toolMode: 'return', signal: composedSignal };
 
-	// Initial conversation turns: append the user-role messages flowing IN before the
-	// first backend round. System messages skipped — conventions vary (some hosts treat
-	// system as ambient, not turn-scoped).
-	if (conversation) {
-		for (const m of messages) {
-			if (m.role === 'user') {
-				await conversation.append({ role: 'user', content: m.content });
-			}
-		}
-	}
+	// `conversation` is a one-way SINK for NEW turns produced by this loop — see
+	// `runAgentLoop` for the rationale. Streaming path applies the same contract.
 
 	try {
 		for (let iteration = 1; iteration <= maxIterations; iteration++) {
@@ -430,6 +416,11 @@ export async function* runAgentLoopStream(args: RunAgentLoopArgs): AsyncIterable
 
 			const stream = models.generateStream(buildInnerInput(messages, tools, system), innerOpts);
 			for await (const chunk of stream) {
+				// Defense-in-depth: well-behaved backends honor `opts.signal` via the
+				// fetch they hand it to. An ill-behaved community backend that doesn't
+				// observe its signal would otherwise keep streaming after a caller abort.
+				composedSignal.throwIfAborted();
+
 				if (chunk.deltaContent !== undefined) {
 					accumulatedContent += chunk.deltaContent;
 				}
@@ -460,22 +451,29 @@ export async function* runAgentLoopStream(args: RunAgentLoopArgs): AsyncIterable
 			}
 
 			const finalToolCalls = completeToolCallAssembly(toolCallAssembly);
-			const isTerminal =
-				finishReason !== 'tool_calls' || finalToolCalls.length === 0;
 
-			if (isTerminal) {
-				// Append the assistant turn (final content) to conversation before bailing.
+			// Continue-vs-terminal:
+			// - Hand off to tool dispatch when calls assembled AND the backend signalled
+			//   tool_calls OR didn't signal anything at all. The "no finishReason" case
+			//   covers proxy-truncated streams: every in-tree backend (openai, anthropic,
+			//   bedrock) emits a tail-flush `deltaToolCalls` without a finishReason when
+			//   the upstream connection drops mid-stream. Treating that as terminal would
+			//   silently drop the assembled tool calls — the backend's recovery would be
+			//   undone by this loop.
+			// - Otherwise, terminal: yield a synthetic 'stop' chunk if the consumer didn't
+			//   receive a terminal finishReason inline (degenerate streams, or the
+			//   suppressed `tool_calls` finishReason with zero assembled calls).
+			const hasToolCalls = finalToolCalls.length > 0;
+			const continueWithToolCalls =
+				hasToolCalls && (finishReason === 'tool_calls' || finishReason === undefined);
+
+			if (!continueWithToolCalls) {
 				if (conversation && accumulatedContent) {
 					await conversation.append({ role: 'assistant', content: accumulatedContent });
 				}
-				// Degenerate-backend guard: if the stream finished with `tool_calls` BUT no
-				// assembled calls landed (provider misbehavior or upstream truncation), we
-				// already suppressed the 'tool_calls' chunk under the intermediate-finishReason
-				// rule above. Without a synthetic terminal chunk the consumer's `for-await`
-				// ends without ever seeing a terminal `finishReason`, violating the
-				// `GenerateChunk` contract. Reclassify to 'stop' and emit one chunk so the
-				// stream closes cleanly.
-				if (finishReason === 'tool_calls' && finalToolCalls.length === 0) {
+				if (finishReason === undefined || finishReason === 'tool_calls') {
+					// Synthetic terminal: backend never yielded one inline, OR we suppressed
+					// the intermediate 'tool_calls' chunk and no calls assembled to dispatch.
 					yield { finishReason: 'stop' };
 				}
 				return;
@@ -640,9 +638,13 @@ interface SerializedResult {
 }
 
 function serializeToolResult(value: unknown, maxBytes: number): SerializedResult {
-	const json = JSON.stringify(value ?? null);
-	const buf = Buffer.from(json, 'utf8');
-	const totalBytes = buf.length;
+	// `JSON.stringify(Symbol())` (and `JSON.stringify(function(){})`) return `undefined`.
+	// `value ?? null` only catches null/undefined inputs, not unsupported types — fall
+	// back to the string 'null' so downstream `Buffer.byteLength` never sees undefined.
+	const json = JSON.stringify(value ?? null) ?? 'null';
+	const totalBytes = Buffer.byteLength(json, 'utf8');
+	// Common case: result fits. Skip buffer allocation entirely — read byte length
+	// without materializing a copy.
 	if (totalBytes <= maxBytes) {
 		return { content: json, totalBytes, truncated: false };
 	}
@@ -655,6 +657,7 @@ function serializeToolResult(value: unknown, maxBytes: number): SerializedResult
 	const marker = `…[truncated; full result is ${totalBytes} bytes]`;
 	const markerBytes = Buffer.byteLength(marker, 'utf8');
 	const headBudget = Math.max(0, maxBytes - markerBytes);
+	const buf = Buffer.from(json, 'utf8');
 	const body = buf.subarray(0, headBudget).toString('utf8');
 	return { content: body + marker, totalBytes, truncated: true };
 }

--- a/resources/models/agentLoop.ts
+++ b/resources/models/agentLoop.ts
@@ -1,0 +1,80 @@
+/**
+ * In-process tool-call agent loop for `Models.generate({ toolMode: 'auto' })`.
+ *
+ * Wiring (commit 1 of #612): type surface + guarded entry point. `Models.generate`
+ * branches on `opts.toolMode === 'auto'` and delegates here; both entry points
+ * currently throw `ServerError(501)` so the contract is type-declared and call-site
+ * wired, but the loop body lands in subsequent commits. Tests assert the throw
+ * and the new option-field shapes flow through unchanged.
+ *
+ * Subsequent commits fill in:
+ *   commit 2 — core sequential loop (handler dispatch, result truncation, trace)
+ *   commit 3 — parallel batches + abort propagation
+ *   commit 4 — token/cost budgets + `toolErrorMode: 'abort'`
+ *   commit 5 — streaming auto path + `opts.conversation.append`
+ *
+ * Registry seam: v1 dispatches via caller-supplied `opts.toolHandlers`. #615
+ * replaces that with a `scope.resources` lookup using the same call signature.
+ */
+import { ClientError, ServerError } from '../../utility/errors/hdbError.ts';
+import type {
+	AccountingContext,
+	GenerateChunk,
+	GenerateInput,
+	GenerateOpts,
+	GenerateResult,
+	Models,
+	ToolTraceEntry,
+} from './types.ts';
+
+export interface RunAgentLoopArgs {
+	models: Models;
+	input: GenerateInput;
+	opts: GenerateOpts;
+	accounting: AccountingContext;
+	signal?: AbortSignal;
+}
+
+export async function runAgentLoop(_args: RunAgentLoopArgs): Promise<GenerateResult> {
+	throw new ServerError("`toolMode: 'auto'` is not yet implemented", 501);
+}
+
+export async function* runAgentLoopStream(_args: RunAgentLoopArgs): AsyncIterable<GenerateChunk> {
+	throw new ServerError("`toolMode: 'auto'` is not yet implemented for streaming", 501);
+}
+
+/**
+ * Loop tripped one of its budgets (iterations, tokens, cost). The trace built so
+ * far rides along on `partialTrace` so callers can inspect what already ran. The
+ * loop always populates this regardless of `opts.includeToolTrace` so debugging an
+ * exhausted budget never needs a second run with tracing turned on.
+ */
+export class BudgetExceededError extends ServerError {
+	kind: 'iterations' | 'tokens' | 'cost';
+	partialTrace: ToolTraceEntry[];
+	constructor(kind: 'iterations' | 'tokens' | 'cost', message: string, partialTrace: ToolTraceEntry[]) {
+		// 429 (Too Many Requests) maps cleanest to "you exceeded the budget you set".
+		super(message, 429);
+		this.name = 'BudgetExceededError';
+		this.kind = kind;
+		this.partialTrace = partialTrace;
+	}
+}
+
+/**
+ * `toolArgValidation: 'strict'` rejected a tool call's arguments against its
+ * declared `parameters` JSON Schema. Surfaces as a 400 — the model produced output
+ * that doesn't satisfy the contract the caller declared.
+ */
+export class ToolValidationError extends ClientError {
+	toolName: string;
+	toolCallId: string;
+	validationErrors: object[];
+	constructor(toolName: string, toolCallId: string, validationErrors: object[], message: string) {
+		super(message, 400);
+		this.name = 'ToolValidationError';
+		this.toolName = toolName;
+		this.toolCallId = toolCallId;
+		this.validationErrors = validationErrors;
+	}
+}

--- a/resources/models/types.ts
+++ b/resources/models/types.ts
@@ -49,6 +49,64 @@ export type GenerateOpts = {
 	 * (alongside `messages` and `system`) — they're content, not strategy.
 	 */
 	toolMode?: 'return' | 'auto';
+	/**
+	 * `toolMode: 'auto'` only. Hard cap on backend → tool → backend iterations
+	 * before the loop emits `BudgetExceededError({kind: 'iterations'})`. Default 10.
+	 */
+	maxToolIterations?: number;
+	/**
+	 * `toolMode: 'auto'` only. Cumulative prompt+completion token cap across all
+	 * iterations. Trips `BudgetExceededError({kind: 'tokens'})` when exceeded.
+	 */
+	maxToolTokens?: number;
+	/**
+	 * `toolMode: 'auto'` only. Cumulative cost cap across all iterations. The v1
+	 * cost-per-call function returns 0 (no rate card yet) so this trips only when
+	 * a test or follow-up wires a non-zero function — the seam is in place.
+	 */
+	maxCostUsd?: number;
+	/**
+	 * `toolMode: 'auto'` only. When a single backend round emits multiple tool calls,
+	 * `'parallel'` (default) runs handlers concurrently via `Promise.all`; `'serial'`
+	 * runs them in order. Each handler is its own dispatch — no shared transaction.
+	 */
+	toolParallelism?: 'parallel' | 'serial';
+	/**
+	 * `toolMode: 'auto'` only. Per-tool-result byte cap (JSON-stringified) before
+	 * truncation. The model sees only the truncated form; the trace records the
+	 * original size. Default 65_536.
+	 */
+	toolResultMaxBytes?: number;
+	/**
+	 * `toolMode: 'auto'` only. How to validate tool-call arguments against the
+	 * tool's `parameters` JSON Schema. `'strict'` (default) throws on failure;
+	 * `'lenient'` coerces / drops bad fields; `'none'` passes through unchecked.
+	 */
+	toolArgValidation?: 'strict' | 'lenient' | 'none';
+	/**
+	 * `toolMode: 'auto'` only. When a tool handler throws, `'recover'` (default)
+	 * appends the error as a tool result so the model can react; `'abort'` returns
+	 * the error to the caller with the full trace attached.
+	 */
+	toolErrorMode?: 'recover' | 'abort';
+	/**
+	 * `toolMode: 'auto'` only. When true, the resolved `GenerateResult.trace` is
+	 * populated with per-iteration entries. On error paths the trace is always
+	 * returned (via `BudgetExceededError.partialTrace`) regardless of this flag.
+	 */
+	includeToolTrace?: boolean;
+	/**
+	 * `toolMode: 'auto'` only. Caller-supplied dispatch table keyed by tool name.
+	 * The model emits a tool call → loop looks up the handler here. v1 contract;
+	 * the registry seam (#615) replaces this with a `scope.resources` lookup.
+	 */
+	toolHandlers?: Record<string, ToolHandler>;
+	/**
+	 * `toolMode: 'auto'` only. Optional hook called as turns flow through the loop
+	 * (user → assistant → tool → assistant → ...). Structural shape — not coupled
+	 * to #511's `ConversationResource` so callers can plug in their own store.
+	 */
+	conversation?: ConversationAppender;
 	/** Accepted in Phase 1; activates with #511 (ConversationResource). */
 	conversationId?: string;
 	signal?: AbortSignal;
@@ -119,7 +177,66 @@ export interface GenerateResult {
 	toolCalls?: ToolCall[];
 	/** Why generation stopped. Backend-agnostic; backends map their native reasons. */
 	finishReason: 'stop' | 'length' | 'tool_calls' | 'content_filter';
+	/**
+	 * `toolMode: 'auto'` only, and only when `includeToolTrace: true` (or when an
+	 * error path attaches `partialTrace` via `BudgetExceededError`). One entry per
+	 * tool invocation, in the order it ran.
+	 */
+	trace?: ToolTraceEntry[];
 }
+
+/**
+ * Per-tool-invocation record emitted by the `toolMode: 'auto'` loop. Entries land
+ * on `GenerateResult.trace` (success path, when `includeToolTrace`) or on
+ * `BudgetExceededError.partialTrace` (any error path). Always in invocation order.
+ */
+export interface ToolTraceEntry {
+	/** 1-based iteration index — which backend round this tool call belongs to. */
+	iteration: number;
+	toolCallId: string;
+	toolName: string;
+	arguments: object;
+	/** JSON-stringified result, possibly truncated. Absent on handler error. */
+	result?: string;
+	/** True when `result` was clipped to `toolResultMaxBytes`. */
+	truncated?: boolean;
+	/** Pre-truncation byte length of the JSON-stringified result. */
+	totalBytes?: number;
+	/** Wall-clock duration of the handler call. */
+	durationMs: number;
+	/** Set when the handler threw. The loop's `toolErrorMode` decides recovery. */
+	error?: { name: string; message: string };
+}
+
+/**
+ * Context handed to a `ToolHandler`. v1: caller-supplied dispatch table. The
+ * `signal` is the composed iteration-level signal (caller signal ∪ budget-trip
+ * cancellation), so a long-running handler stops promptly when the loop trips a cap.
+ */
+export interface ToolHandlerContext {
+	signal?: AbortSignal;
+	accounting: AccountingContext;
+}
+
+/**
+ * Caller-supplied tool implementation. Return value is JSON-serialized into a
+ * `tool`-role message and fed back to the model on the next iteration. Throws are
+ * caught by the loop and routed by `toolErrorMode` (`'recover'` | `'abort'`).
+ */
+export type ToolHandler = (args: object, ctx: ToolHandlerContext) => unknown | Promise<unknown>;
+
+/**
+ * Optional hook the loop calls as conversation turns flow. Structural so the
+ * built-in `ConversationResource` (#511) AND ad-hoc stores can satisfy it.
+ */
+export interface ConversationAppender {
+	append(turn: ConversationTurn): Promise<void>;
+}
+
+export type ConversationTurn =
+	| { role: 'user'; content: string }
+	| { role: 'assistant'; content: string; toolCalls?: ToolCall[] }
+	| { role: 'tool'; toolCallId: string; content: string };
 
 export interface GenerateChunk {
 	/** Incremental text appended since the previous chunk. */

--- a/resources/models/types.ts
+++ b/resources/models/types.ts
@@ -236,12 +236,27 @@ export interface ToolHandlerContext {
  * Caller-supplied tool implementation. Return value is JSON-serialized into a
  * `tool`-role message and fed back to the model on the next iteration. Throws are
  * caught by the loop and routed by `toolErrorMode` (`'recover'` | `'abort'`).
+ *
+ * The `args` type parameter lets typed apps assign concrete handler signatures
+ * (`const search: ToolHandler<{query: string}> = ...`) without contravariance
+ * complaints under `strictFunctionTypes`. Defaults to `any` so the unparameterized
+ * `ToolHandler` stays assignable from arbitrary handlers in untyped callers.
  */
-export type ToolHandler = (args: object, ctx: ToolHandlerContext) => unknown | Promise<unknown>;
+export type ToolHandler<T = any> = (args: T, ctx: ToolHandlerContext) => unknown | Promise<unknown>;
 
 /**
  * Optional hook the loop calls as conversation turns flow. Structural so the
  * built-in `ConversationResource` (#511) AND ad-hoc stores can satisfy it.
+ *
+ * **Contract:**
+ * - The loop appends ONLY new turns it produces (assistant + tool turns from each
+ *   round). It does NOT echo the caller's input back — the caller owns turn 0.
+ * - `append` is `await`ed inline between loop steps, giving the appender ordering
+ *   + back-pressure. Slow appenders pause the loop.
+ * - Appenders SHOULD NOT throw. A throw propagates as the loop's terminal error
+ *   (bypassing `BudgetExceededError` / `ToolHandlerError` shapes) and discards any
+ *   in-progress trace. If your appender CAN fail recoverably, catch internally and
+ *   log; only surface unrecoverable persistence failures.
  */
 export interface ConversationAppender {
 	append(turn: ConversationTurn): Promise<void>;

--- a/resources/models/types.ts
+++ b/resources/models/types.ts
@@ -79,8 +79,11 @@ export type GenerateOpts = {
 	toolResultMaxBytes?: number;
 	/**
 	 * `toolMode: 'auto'` only. How to validate tool-call arguments against the
-	 * tool's `parameters` JSON Schema. `'strict'` (default) throws on failure;
-	 * `'lenient'` coerces / drops bad fields; `'none'` passes through unchecked.
+	 * tool's `parameters` JSON Schema. v1 implements `'none'` (default); `'strict'`
+	 * and `'lenient'` are reserved on the type surface but throw `501` at the loop
+	 * entry until a JSON Schema validator is wired (Harper today uses Joi for
+	 * internal validation and passes JSON Schema through to backends; adopting
+	 * Ajv is a separate decision).
 	 */
 	toolArgValidation?: 'strict' | 'lenient' | 'none';
 	/**

--- a/resources/models/types.ts
+++ b/resources/models/types.ts
@@ -181,6 +181,17 @@ export interface GenerateResult {
 	/** Why generation stopped. Backend-agnostic; backends map their native reasons. */
 	finishReason: 'stop' | 'length' | 'tool_calls' | 'content_filter';
 	/**
+	 * Token / cost usage for this call. Pass-through from the backend's
+	 * `ModelCallResult.usage` so callers (and the `toolMode: 'auto'` loop) can
+	 * cap cumulative budgets without re-querying analytics.
+	 *
+	 * Backends MUST NOT set this field on the `output` they return — the framework
+	 * (`Models.generate`) injects it from `ModelCallResult.usage`, which is the
+	 * authoritative source. A backend that sets both gets the framework's value;
+	 * easy to miss but unambiguous: usage lives at the call-result layer.
+	 */
+	usage?: TokenUsage;
+	/**
 	 * `toolMode: 'auto'` only, and only when `includeToolTrace: true` (or when an
 	 * error path attaches `partialTrace` via `BudgetExceededError`). One entry per
 	 * tool invocation, in the order it ran.

--- a/resources/models/types.ts
+++ b/resources/models/types.ts
@@ -57,12 +57,21 @@ export type GenerateOpts = {
 	/**
 	 * `toolMode: 'auto'` only. Cumulative prompt+completion token cap across all
 	 * iterations. Trips `BudgetExceededError({kind: 'tokens'})` when exceeded.
+	 *
+	 * Best-effort: enforcement depends on the backend reporting `usage`. Against a
+	 * backend that returns no usage the cap is unmeasurable — the loop warns once and
+	 * continues (it does NOT silently pretend the cap is in force); `maxToolIterations`
+	 * remains the hard bound. Not yet supported on `generateStream` (throws 501).
 	 */
 	maxToolTokens?: number;
 	/**
 	 * `toolMode: 'auto'` only. Cumulative cost cap across all iterations. The v1
 	 * cost-per-call function returns 0 (no rate card yet) so this trips only when
 	 * a test or follow-up wires a non-zero function — the seam is in place.
+	 *
+	 * Same best-effort caveat as `maxToolTokens`: cost is derived from backend usage,
+	 * so a backend reporting no usage makes the cap unmeasurable (warn-once, continue).
+	 * Not yet supported on `generateStream` (throws 501).
 	 */
 	maxCostUsd?: number;
 	/**
@@ -102,6 +111,13 @@ export type GenerateOpts = {
 	 * `toolMode: 'auto'` only. Caller-supplied dispatch table keyed by tool name.
 	 * The model emits a tool call → loop looks up the handler here. v1 contract;
 	 * the registry seam (#615) replaces this with a `scope.resources` lookup.
+	 *
+	 * Lookup is own-property + callable only (a model-emitted name matching an Object
+	 * prototype member never resolves a built-in). Missing-handler behavior splits on
+	 * whether the name was declared in `tools`: a DECLARED name with no handler is a
+	 * caller config bug (hard `ClientError(400)`); an UNDECLARED name is treated as a
+	 * model hallucination and routed through `toolErrorMode` (recover feeds an
+	 * "unknown tool" error back to the model; abort stops the loop).
 	 */
 	toolHandlers?: Record<string, ToolHandler>;
 	/**

--- a/unitTests/resources/models/Models.test.js
+++ b/unitTests/resources/models/Models.test.js
@@ -212,25 +212,10 @@ describe('Models facade', () => {
 			assert.strictEqual(r.error_code, 'backend_error');
 		});
 
-		describe("toolMode: 'auto' (commit-1 guard)", () => {
-			it('rejects with 501 — loop body lands in commit 2', async () => {
-				// The outer auto call delegates to runAgentLoop, which currently stubs out.
-				// Asserting the throw locks in the contract: `toolMode: 'auto'` is a
-				// type-declared entry point that's wired but not yet implemented.
-				await assert.rejects(
-					() => models.generate('hello', { toolMode: 'auto' }),
-					(err) => err.statusCode === 501 && /not yet implemented/i.test(err.message)
-				);
-			});
-
-			it('writes NO analytics row for the outer auto call (per-iteration rows happen inside)', async () => {
-				await assert.rejects(() => models.generate('hello', { toolMode: 'auto' }));
-				assert.strictEqual(
-					writer.records.length,
-					0,
-					'outer auto call must not double-bill the iteration the loop performs'
-				);
-			});
+		describe("toolMode: 'auto' (entry dispatch)", () => {
+			// Loop behavior lives in `agentLoop.test.js`. Tests here cover the dispatch
+			// branch in `Models.generate` itself — that the entry point picks the right
+			// path and that `'return'` is unaffected.
 
 			it("toolMode: 'return' still flows the single-shot path", async () => {
 				const result = await models.generate('hello', { toolMode: 'return' });
@@ -240,23 +225,12 @@ describe('Models facade', () => {
 				assert.strictEqual(writer.records[0].success, true);
 			});
 
-			it('accepts all new option fields without rejecting at the type/runtime surface', async () => {
-				// Surface check: the loop options exist on GenerateOpts and a fully-populated
-				// call still hits the guard cleanly. Commits 2–5 give them runtime meaning.
-				await assert.rejects(() =>
-					models.generate('hello', {
-						toolMode: 'auto',
-						maxToolIterations: 5,
-						maxToolTokens: 1000,
-						maxCostUsd: 0.5,
-						toolParallelism: 'serial',
-						toolResultMaxBytes: 1024,
-						toolArgValidation: 'lenient',
-						toolErrorMode: 'abort',
-						includeToolTrace: true,
-						toolHandlers: { echo: (args) => args },
-						conversation: { async append() {} },
-					})
+			it('still-gated modes throw 501 at the loop entry (sanity — full matrix in agentLoop.test.js)', async () => {
+				// Spot-check that the dispatch branch reaches the guarded loop body. Each
+				// deferred mode has its own assertion in `agentLoop.test.js`.
+				await assert.rejects(
+					() => models.generate('hello', { toolMode: 'auto', toolArgValidation: 'strict' }),
+					(err) => err.statusCode === 501
 				);
 			});
 		});

--- a/unitTests/resources/models/Models.test.js
+++ b/unitTests/resources/models/Models.test.js
@@ -233,6 +233,25 @@ describe('Models facade', () => {
 					(err) => err.statusCode === 501
 				);
 			});
+
+			it('auto + tools against a tools-incapable backend fails loud (no silent no-op)', async () => {
+				// TestBackend is tools:false. Declaring tools for an auto loop against it would
+				// otherwise run as a plain generation, silently ignoring the tools.
+				await assert.rejects(
+					() =>
+						models.generate(
+							{ messages: [{ role: 'user', content: 'hi' }], tools: [{ name: 't', description: '', parameters: {} }] },
+							{ toolMode: 'auto', toolHandlers: { t: () => ({}) } }
+						),
+					(err) => err instanceof ModelCapabilityError && /tools/.test(err.message)
+				);
+			});
+
+			it('auto WITHOUT tools is unaffected by the tools guard', async () => {
+				const result = await models.generate('hi', { toolMode: 'auto' });
+				assert.strictEqual(typeof result.content, 'string');
+				assert.strictEqual(result.finishReason, 'stop');
+			});
 		});
 	});
 
@@ -329,6 +348,19 @@ describe('Models facade', () => {
 				assert.strictEqual(writer.records.length, 1);
 				assert.strictEqual(writer.records[0].method, 'generateStream');
 				assert.strictEqual(writer.records[0].success, true);
+			});
+
+			it('auto + tools against a tools-incapable backend throws synchronously (before iteration)', () => {
+				// The guard runs in the synchronous body of generateStream, before the iterable
+				// is returned — so it throws on call, not on first `next()`.
+				assert.throws(
+					() =>
+						models.generateStream(
+							{ messages: [{ role: 'user', content: 'hi' }], tools: [{ name: 't', description: '', parameters: {} }] },
+							{ toolMode: 'auto', toolHandlers: { t: () => ({}) } }
+						),
+					(err) => err instanceof ModelCapabilityError && /tools/.test(err.message)
+				);
 			});
 		});
 	});

--- a/unitTests/resources/models/Models.test.js
+++ b/unitTests/resources/models/Models.test.js
@@ -211,6 +211,55 @@ describe('Models facade', () => {
 			assert.strictEqual(r.success, false);
 			assert.strictEqual(r.error_code, 'backend_error');
 		});
+
+		describe("toolMode: 'auto' (commit-1 guard)", () => {
+			it('rejects with 501 — loop body lands in commit 2', async () => {
+				// The outer auto call delegates to runAgentLoop, which currently stubs out.
+				// Asserting the throw locks in the contract: `toolMode: 'auto'` is a
+				// type-declared entry point that's wired but not yet implemented.
+				await assert.rejects(
+					() => models.generate('hello', { toolMode: 'auto' }),
+					(err) => err.statusCode === 501 && /not yet implemented/i.test(err.message)
+				);
+			});
+
+			it('writes NO analytics row for the outer auto call (per-iteration rows happen inside)', async () => {
+				await assert.rejects(() => models.generate('hello', { toolMode: 'auto' }));
+				assert.strictEqual(
+					writer.records.length,
+					0,
+					'outer auto call must not double-bill the iteration the loop performs'
+				);
+			});
+
+			it("toolMode: 'return' still flows the single-shot path", async () => {
+				const result = await models.generate('hello', { toolMode: 'return' });
+				assert.strictEqual(typeof result.content, 'string');
+				assert.strictEqual(writer.records.length, 1);
+				assert.strictEqual(writer.records[0].method, 'generate');
+				assert.strictEqual(writer.records[0].success, true);
+			});
+
+			it('accepts all new option fields without rejecting at the type/runtime surface', async () => {
+				// Surface check: the loop options exist on GenerateOpts and a fully-populated
+				// call still hits the guard cleanly. Commits 2–5 give them runtime meaning.
+				await assert.rejects(() =>
+					models.generate('hello', {
+						toolMode: 'auto',
+						maxToolIterations: 5,
+						maxToolTokens: 1000,
+						maxCostUsd: 0.5,
+						toolParallelism: 'serial',
+						toolResultMaxBytes: 1024,
+						toolArgValidation: 'lenient',
+						toolErrorMode: 'abort',
+						includeToolTrace: true,
+						toolHandlers: { echo: (args) => args },
+						conversation: { async append() {} },
+					})
+				);
+			});
+		});
 	});
 
 	describe('generateStream', () => {
@@ -291,6 +340,33 @@ describe('Models facade', () => {
 			assert.strictEqual(writer.records[0].backend, 'no-stream');
 			assert.strictEqual(writer.records[0].error_code, 'capability_unsupported');
 			assert.strictEqual(writer.records[0].method, 'generateStream');
+		});
+
+		describe("toolMode: 'auto' (commit-1 guard)", () => {
+			it('throws on first iteration with 501 — streaming loop lands in commit 5', async () => {
+				// Async-generator stub: the throw fires on first iteration, not at the
+				// synchronous .generateStream(...) call. Matches the existing capability/
+				// resolve pattern (errors surface when the caller iterates).
+				await assert.rejects(
+					async () => {
+						// eslint-disable-next-line no-unused-vars
+						for await (const _ of models.generateStream('hello', { toolMode: 'auto' })) {
+							// will not iterate
+						}
+					},
+					(err) => err.statusCode === 501 && /not yet implemented/i.test(err.message)
+				);
+			});
+
+			it('writes NO analytics row for the outer auto-stream call', async () => {
+				await assert.rejects(async () => {
+					// eslint-disable-next-line no-unused-vars
+					for await (const _ of models.generateStream('hello', { toolMode: 'auto' })) {
+						// will not iterate
+					}
+				});
+				assert.strictEqual(writer.records.length, 0);
+			});
 		});
 	});
 });

--- a/unitTests/resources/models/Models.test.js
+++ b/unitTests/resources/models/Models.test.js
@@ -316,30 +316,19 @@ describe('Models facade', () => {
 			assert.strictEqual(writer.records[0].method, 'generateStream');
 		});
 
-		describe("toolMode: 'auto' (commit-1 guard)", () => {
-			it('throws on first iteration with 501 — streaming loop lands in commit 5', async () => {
-				// Async-generator stub: the throw fires on first iteration, not at the
-				// synchronous .generateStream(...) call. Matches the existing capability/
-				// resolve pattern (errors surface when the caller iterates).
-				await assert.rejects(
-					async () => {
-						// eslint-disable-next-line no-unused-vars
-						for await (const _ of models.generateStream('hello', { toolMode: 'auto' })) {
-							// will not iterate
-						}
-					},
-					(err) => err.statusCode === 501 && /not yet implemented/i.test(err.message)
-				);
-			});
+		describe("toolMode: 'auto' (entry dispatch)", () => {
+			// Streaming auto-loop behavior is in `agentLoop.test.js`. Tests here cover
+			// the dispatch branch in `Models.generateStream` itself.
 
-			it('writes NO analytics row for the outer auto-stream call', async () => {
-				await assert.rejects(async () => {
-					// eslint-disable-next-line no-unused-vars
-					for await (const _ of models.generateStream('hello', { toolMode: 'auto' })) {
-						// will not iterate
-					}
-				});
-				assert.strictEqual(writer.records.length, 0);
+			it("toolMode: 'return' still flows the single-shot stream", async () => {
+				const chunks = [];
+				for await (const chunk of models.generateStream('hello', { toolMode: 'return' })) {
+					chunks.push(chunk);
+				}
+				assert.ok(chunks.length > 1);
+				assert.strictEqual(writer.records.length, 1);
+				assert.strictEqual(writer.records[0].method, 'generateStream');
+				assert.strictEqual(writer.records[0].success, true);
 			});
 		});
 	});

--- a/unitTests/resources/models/agentLoop.test.js
+++ b/unitTests/resources/models/agentLoop.test.js
@@ -1605,5 +1605,19 @@ describe("agentLoop (toolMode: 'auto')", () => {
 				assert.strictEqual(chunks.at(-1).finishReason, 'stop');
 			});
 		});
+
+		describe('sync: degenerate tool_calls round (no dispatchable calls) is coerced to a terminal stop', () => {
+			it('finishReason tool_calls + empty toolCalls returns finishReason stop with coerced content (matches streaming)', async () => {
+				// OpenAI can emit finishReason: 'tool_calls' with the calls dropped if their args
+				// were malformed (parseToolCalls discards them). The streaming path already folds
+				// this to 'stop'; the sync path must too — an auto-mode caller should never see a
+				// tool_calls finishReason (calls are resolved internally) pointing at no calls.
+				backend.queue({ output: { content: null, finishReason: 'tool_calls', toolCalls: [] }, usage: {} });
+				const result = await models.generate('q', { toolMode: 'auto', includeToolTrace: true });
+				assert.strictEqual(result.finishReason, 'stop');
+				assert.strictEqual(result.content, '', 'null content coerced to empty string');
+				assert.deepStrictEqual(result.trace, [], 'no tools ran');
+			});
+		});
 	});
 });

--- a/unitTests/resources/models/agentLoop.test.js
+++ b/unitTests/resources/models/agentLoop.test.js
@@ -157,7 +157,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 			assert.strictEqual(backend.calls[1].input.messages[2].toolCallId, 'c1');
 		});
 
-		it('serial handlers run in order (no concurrent overlap in v1)', async () => {
+		it("toolParallelism: 'serial' runs handlers in order (no concurrent overlap)", async () => {
 			// Two tool calls in ONE round.
 			backend.queue(
 				toolCallRound('multi', [tc('c1', 'slow', { i: 1 }), tc('c1b', 'slow', { i: 2 })]),
@@ -166,6 +166,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 			const events = [];
 			await models.generate('go', {
 				toolMode: 'auto',
+				toolParallelism: 'serial',
 				toolHandlers: {
 					slow: async (args) => {
 						events.push(`start-${args.i}`);
@@ -363,6 +364,270 @@ describe("agentLoop (toolMode: 'auto')", () => {
 			});
 			assert.strictEqual(result.content, 'recovered');
 			assert.ok(result.trace[0].error);
+		});
+	});
+
+	describe("parallel dispatch (default, toolParallelism: 'parallel')", () => {
+		it('handlers in one round run concurrently — start events interleave', async () => {
+			backend.queue(
+				toolCallRound('multi', [tc('c1', 'slow', { i: 1 }), tc('c2', 'slow', { i: 2 })]),
+				final('done')
+			);
+			const events = [];
+			await models.generate('go', {
+				toolMode: 'auto',
+				// Default is parallel — assert behavior without explicit opt-in.
+				toolHandlers: {
+					slow: async (args) => {
+						events.push(`start-${args.i}`);
+						await new Promise((r) => setImmediate(r));
+						events.push(`end-${args.i}`);
+						return args.i;
+					},
+				},
+			});
+			// Parallel: both starts fire before either end (handlers overlap).
+			assert.deepStrictEqual(events, ['start-1', 'start-2', 'end-1', 'end-2']);
+		});
+
+		it('trace and tool messages are in CALL order, not completion order', async () => {
+			// Handler #1 sleeps longer than #2 — completion order is [#2, #1] but the
+			// trace and the tool messages fed back to the model must follow the order the
+			// model emitted them in.
+			backend.queue(
+				toolCallRound('p', [tc('c1', 'slow', { ms: 10 }), tc('c2', 'fast', { ms: 0 })]),
+				final('done')
+			);
+			const result = await models.generate('go', {
+				toolMode: 'auto',
+				includeToolTrace: true,
+				toolHandlers: {
+					slow: async (args) => {
+						await new Promise((r) => setTimeout(r, args.ms));
+						return { tag: 'slow' };
+					},
+					fast: async (args) => {
+						await new Promise((r) => setTimeout(r, args.ms));
+						return { tag: 'fast' };
+					},
+				},
+			});
+			assert.deepStrictEqual(
+				result.trace.map((e) => e.toolName),
+				['slow', 'fast']
+			);
+			// Tool messages on round 2 appear in call order too.
+			const round2 = backend.calls[1].input.messages;
+			const toolMsgs = round2.filter((m) => m.role === 'tool');
+			assert.deepStrictEqual(toolMsgs.map((m) => m.toolCallId), ['c1', 'c2']);
+		});
+
+		it('single tool call uses the serial path even under parallel default', async () => {
+			// Sanity — one call, default parallel: still runs cleanly via Promise.all bypass.
+			backend.queue(
+				toolCallRound('p', [tc('c1', 'echo', { x: 1 })]),
+				final('done')
+			);
+			const result = await models.generate('go', {
+				toolMode: 'auto',
+				includeToolTrace: true,
+				toolHandlers: { echo: (args) => args },
+			});
+			assert.strictEqual(result.trace.length, 1);
+		});
+	});
+
+	describe('abort propagation', () => {
+		it('caller aborts between rounds → next iteration throws AbortError, partial work analytics recorded', async () => {
+			backend.queue(
+				toolCallRound('p', [tc('c1', 'echo', { i: 0 })]),
+				// Second round won't be reached — caller aborts after round 1's handler runs.
+				final('unreachable')
+			);
+			const ac = new AbortController();
+			let abortedDuringHandler = false;
+			await assert.rejects(
+				() =>
+					models.generate('q', {
+						toolMode: 'auto',
+						signal: ac.signal,
+						toolHandlers: {
+							echo: async (args, ctx) => {
+								// Caller aborts as the handler runs — composed signal reflects it.
+								ac.abort();
+								abortedDuringHandler = ctx.signal && ctx.signal.aborted;
+								return args;
+							},
+						},
+					}),
+				(err) => err.name === 'AbortError'
+			);
+			assert.strictEqual(abortedDuringHandler, true, 'handler ctx.signal must reflect caller abort');
+			// One analytics row for round 1 (succeeded); round 2 never started, so no row.
+			// (`throwIfAborted` fires before the second `models.generate` is reached.)
+			assert.strictEqual(writer.records.length, 1);
+			assert.strictEqual(writer.records[0].success, true);
+		});
+
+		it('handler ctx.signal aborts when caller aborts during execution', async () => {
+			backend.queue(toolCallRound('p', [tc('c1', 'slow', {})]), final('done'));
+			const ac = new AbortController();
+			let handlerSawAbort = false;
+			await assert.rejects(
+				async () => {
+					await models.generate('q', {
+						toolMode: 'auto',
+						signal: ac.signal,
+						toolHandlers: {
+							slow: async (_args, ctx) => {
+								// Race: abort and listen on ctx.signal simultaneously.
+								await new Promise((resolve, reject) => {
+									ctx.signal.addEventListener('abort', () => {
+										handlerSawAbort = true;
+										reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+									});
+									setImmediate(() => ac.abort());
+								});
+							},
+						},
+					});
+				},
+				(err) => err.name === 'AbortError'
+			);
+			assert.strictEqual(handlerSawAbort, true);
+		});
+
+		it('composed signal flows to the inner Models.generate as a wrapper (not the caller signal directly)', async () => {
+			// Use a custom backend that observes the signal AT call time — the loop's
+			// finally aborts the composed signal on exit, so post-loop inspection would
+			// always show aborted=true. The point is: backend gets the wrapper, not the
+			// raw caller signal, and it's not aborted while the call is in flight.
+			let observedSignal;
+			let abortedDuringCall;
+			setGenerative('default', {
+				name: 'observe',
+				capabilities: () => ({ embed: false, generate: true, stream: false, tools: true, adapters: false }),
+				async generate(_input, opts) {
+					observedSignal = opts.signal;
+					abortedDuringCall = opts.signal?.aborted ?? null;
+					return { status: 'completed', output: { content: 'x', finishReason: 'stop' }, usage: {} };
+				},
+			});
+			const ac = new AbortController();
+			await models.generate('q', { toolMode: 'auto', signal: ac.signal });
+			assert.ok(observedSignal, 'inner backend call must receive a signal');
+			assert.notStrictEqual(observedSignal, ac.signal, 'must be a composed wrapper, not the caller signal');
+			assert.strictEqual(abortedDuringCall, false, 'signal is not aborted while the call is in flight');
+		});
+
+		it('caller-pre-aborted signal: first iteration throws before paying for a backend call', async () => {
+			backend.queue(final('unreachable'));
+			const ac = new AbortController();
+			ac.abort();
+			await assert.rejects(
+				() => models.generate('q', { toolMode: 'auto', signal: ac.signal }),
+				(err) => err.name === 'AbortError'
+			);
+			assert.strictEqual(backend.calls.length, 0, 'inner generate must not run when caller pre-aborted');
+		});
+
+		it('in-flight handler abort rethrows (does NOT enter recover and append a bogus tool message)', async () => {
+			// If recover swallowed AbortError, the loop would push `{error: "aborted"}`
+			// into messages and try a SECOND backend round before bailing. Pin the
+			// behavior: handler-mid-flight abort → loop throws AbortError after the
+			// post-dispatch check; no second backend call; no error envelope in trace.
+			backend.queue(
+				toolCallRound('p', [tc('c1', 'slow', {})]),
+				final('unreachable — abort happens during round 1')
+			);
+			const ac = new AbortController();
+			await assert.rejects(
+				() =>
+					models.generate('q', {
+						toolMode: 'auto',
+						includeToolTrace: true,
+						signal: ac.signal,
+						toolHandlers: {
+							slow: async (_args, ctx) => {
+								await new Promise((resolve, reject) => {
+									ctx.signal.addEventListener('abort', () => {
+										const err = new Error('aborted');
+										err.name = 'AbortError';
+										reject(err);
+									});
+									setImmediate(() => ac.abort());
+								});
+							},
+						},
+					}),
+				(err) => err.name === 'AbortError'
+			);
+			// One backend call only — the second `final(...)` never got reached.
+			assert.strictEqual(backend.calls.length, 1, 'no second round after abort');
+		});
+
+		it('last-iteration abort → AbortError, NOT BudgetExceededError (misclassification check)', async () => {
+			// `maxToolIterations: 1` would otherwise trip BudgetExceededError after one
+			// round of tool calls. If we abort mid-handler in that one round, the loop
+			// must classify the throw as AbortError (post-dispatch throwIfAborted)
+			// rather than treating the loop body as having "exhausted" iterations.
+			backend.queue(toolCallRound('p', [tc('c1', 'slow', {})]));
+			const ac = new AbortController();
+			await assert.rejects(
+				() =>
+					models.generate('q', {
+						toolMode: 'auto',
+						maxToolIterations: 1,
+						signal: ac.signal,
+						toolHandlers: {
+							slow: async (_args, ctx) => {
+								await new Promise((resolve, reject) => {
+									ctx.signal.addEventListener('abort', () => {
+										const err = new Error('aborted');
+										err.name = 'AbortError';
+										reject(err);
+									});
+									setImmediate(() => ac.abort());
+								});
+							},
+						},
+					}),
+				(err) => err.name === 'AbortError' && !(err instanceof BudgetExceededError)
+			);
+		});
+
+		it('loopController.abort fires on exit — sibling handlers still running see the signal', async () => {
+			// One round, two parallel tool calls: 'missing' has no handler (throws on
+			// dispatch), 'slow' is in flight. After the missing-handler throw propagates
+			// out, the loop's finally aborts loopController → the slow handler's
+			// ctx.signal aborts. (Test by having the slow handler check ctx.signal in a
+			// microtask after a small delay; if cleanup didn't fire, the handler would
+			// hang.)
+			backend.queue(toolCallRound('p', [tc('c1', 'missing', {}), tc('c2', 'slow', {})]));
+			let slowSawAbort = false;
+			let slowResolver;
+			const slowFinished = new Promise((resolve) => {
+				slowResolver = resolve;
+			});
+			await assert.rejects(
+				() =>
+					models.generate('q', {
+						toolMode: 'auto',
+						toolHandlers: {
+							// 'missing' is intentionally absent — throws ClientError(400).
+							slow: async (_args, ctx) => {
+								await new Promise((resolve) => setImmediate(resolve));
+								slowSawAbort = ctx.signal.aborted;
+								slowResolver();
+								return null;
+							},
+						},
+					}),
+				(err) => err.statusCode === 400 && /No handler registered/.test(err.message)
+			);
+			// Wait for the slow handler to finish (it has nothing to await on after the abort).
+			await slowFinished;
+			assert.strictEqual(slowSawAbort, true, 'sibling handler must see signal aborted after loop cleanup');
 		});
 	});
 

--- a/unitTests/resources/models/agentLoop.test.js
+++ b/unitTests/resources/models/agentLoop.test.js
@@ -160,10 +160,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 		});
 
 		it('appends assistant + tool messages onto the running message list between rounds', async () => {
-			backend.queue(
-				toolCallRound('plan', [tc('c1', 'lookup', { key: 'k1' })]),
-				final('answer')
-			);
+			backend.queue(toolCallRound('plan', [tc('c1', 'lookup', { key: 'k1' })]), final('answer'));
 			await models.generate('q', {
 				toolMode: 'auto',
 				toolHandlers: { lookup: (args) => ({ key: args.key, value: 'v1' }) },
@@ -181,10 +178,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 
 		it("toolParallelism: 'serial' runs handlers in order (no concurrent overlap)", async () => {
 			// Two tool calls in ONE round.
-			backend.queue(
-				toolCallRound('multi', [tc('c1', 'slow', { i: 1 }), tc('c1b', 'slow', { i: 2 })]),
-				final('done')
-			);
+			backend.queue(toolCallRound('multi', [tc('c1', 'slow', { i: 1 }), tc('c1b', 'slow', { i: 2 })]), final('done'));
 			const events = [];
 			await models.generate('go', {
 				toolMode: 'auto',
@@ -203,10 +197,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 		});
 
 		it('records the trace entries when includeToolTrace is set', async () => {
-			backend.queue(
-				toolCallRound('p', [tc('c1', 'echo', { text: 'a' })]),
-				final('done')
-			);
+			backend.queue(toolCallRound('p', [tc('c1', 'echo', { text: 'a' })]), final('done'));
 			const result = await models.generate('q', {
 				toolMode: 'auto',
 				includeToolTrace: true,
@@ -259,11 +250,36 @@ describe("agentLoop (toolMode: 'auto')", () => {
 	});
 
 	describe('result truncation', () => {
-		it('passes small results through untouched in the trace', async () => {
+		it('coerces null/undefined assistant content to empty string (OpenAI-style tool-call rounds)', async () => {
+			// OpenAI leaves `content` as null when the model's only output is tool_calls.
+			// `Message.content` and `ConversationTurn.content` are typed as required
+			// strings — the loop must coerce at the seam, not push null into the
+			// running message list (would corrupt downstream rounds + appender).
 			backend.queue(
-				toolCallRound('p', [tc('c1', 'small', {})]),
+				{ output: { content: null, finishReason: 'tool_calls', toolCalls: [tc('c1', 'echo', { x: 1 })] }, usage: {} },
 				final('done')
 			);
+			const turns = [];
+			await models.generate('q', {
+				toolMode: 'auto',
+				conversation: {
+					async append(t) {
+						turns.push(t);
+					},
+				},
+				toolHandlers: { echo: (args) => args },
+			});
+			// Round 2 saw the assistant message with empty-string content (not null).
+			const round2 = backend.calls[1].input.messages;
+			const assistantMsg = round2.find((m) => m.role === 'assistant');
+			assert.strictEqual(assistantMsg.content, '');
+			// Conversation appender got empty string too.
+			const assistantTurn = turns.find((t) => t.role === 'assistant' && t.toolCalls);
+			assert.strictEqual(assistantTurn.content, '');
+		});
+
+		it('passes small results through untouched in the trace', async () => {
+			backend.queue(toolCallRound('p', [tc('c1', 'small', {})]), final('done'));
 			const result = await models.generate('q', {
 				toolMode: 'auto',
 				includeToolTrace: true,
@@ -275,10 +291,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 
 		it('truncates a result that exceeds toolResultMaxBytes and tags the trace entry', async () => {
 			const huge = 'x'.repeat(10_000);
-			backend.queue(
-				toolCallRound('p', [tc('c1', 'big', {})]),
-				final('done')
-			);
+			backend.queue(toolCallRound('p', [tc('c1', 'big', {})]), final('done'));
 			const result = await models.generate('q', {
 				toolMode: 'auto',
 				toolResultMaxBytes: 256,
@@ -303,10 +316,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 			// (b) the result is valid UTF-8 even when the byte boundary splits a codepoint,
 			// (c) the trace's `totalBytes` reports the byte length, not char length.
 			const text = '漢'.repeat(10_000); // 30_000 bytes UTF-8
-			backend.queue(
-				toolCallRound('p', [tc('c1', 'cjk', {})]),
-				final('done')
-			);
+			backend.queue(toolCallRound('p', [tc('c1', 'cjk', {})]), final('done'));
 			const result = await models.generate('q', {
 				toolMode: 'auto',
 				toolResultMaxBytes: 256,
@@ -329,10 +339,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 
 	describe('handler errors (recover mode)', () => {
 		it('appends the error as a tool result and keeps looping', async () => {
-			backend.queue(
-				toolCallRound('p', [tc('c1', 'broken', {})]),
-				final('recovered')
-			);
+			backend.queue(toolCallRound('p', [tc('c1', 'broken', {})]), final('recovered'));
 			const result = await models.generate('q', {
 				toolMode: 'auto',
 				includeToolTrace: true,
@@ -354,10 +361,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 			// Handlers returning raw DB rows can include BigInt — JSON.stringify throws.
 			// The loop must catch the serialization error in the same recover path it uses
 			// for handler throws, otherwise a "real" tool result crashes the whole loop.
-			backend.queue(
-				toolCallRound('p', [tc('c1', 'bigint', {})]),
-				final('recovered')
-			);
+			backend.queue(toolCallRound('p', [tc('c1', 'bigint', {})]), final('recovered'));
 			const result = await models.generate('q', {
 				toolMode: 'auto',
 				includeToolTrace: true,
@@ -369,10 +373,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 		});
 
 		it('recovers when serialization throws on a circular result', async () => {
-			backend.queue(
-				toolCallRound('p', [tc('c1', 'cyc', {})]),
-				final('recovered')
-			);
+			backend.queue(toolCallRound('p', [tc('c1', 'cyc', {})]), final('recovered'));
 			const result = await models.generate('q', {
 				toolMode: 'auto',
 				includeToolTrace: true,
@@ -391,10 +392,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 
 	describe("parallel dispatch (default, toolParallelism: 'parallel')", () => {
 		it('handlers in one round run concurrently — start events interleave', async () => {
-			backend.queue(
-				toolCallRound('multi', [tc('c1', 'slow', { i: 1 }), tc('c2', 'slow', { i: 2 })]),
-				final('done')
-			);
+			backend.queue(toolCallRound('multi', [tc('c1', 'slow', { i: 1 }), tc('c2', 'slow', { i: 2 })]), final('done'));
 			const events = [];
 			await models.generate('go', {
 				toolMode: 'auto',
@@ -416,10 +414,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 			// Handler #1 sleeps longer than #2 — completion order is [#2, #1] but the
 			// trace and the tool messages fed back to the model must follow the order the
 			// model emitted them in.
-			backend.queue(
-				toolCallRound('p', [tc('c1', 'slow', { ms: 10 }), tc('c2', 'fast', { ms: 0 })]),
-				final('done')
-			);
+			backend.queue(toolCallRound('p', [tc('c1', 'slow', { ms: 10 }), tc('c2', 'fast', { ms: 0 })]), final('done'));
 			const result = await models.generate('go', {
 				toolMode: 'auto',
 				includeToolTrace: true,
@@ -441,15 +436,15 @@ describe("agentLoop (toolMode: 'auto')", () => {
 			// Tool messages on round 2 appear in call order too.
 			const round2 = backend.calls[1].input.messages;
 			const toolMsgs = round2.filter((m) => m.role === 'tool');
-			assert.deepStrictEqual(toolMsgs.map((m) => m.toolCallId), ['c1', 'c2']);
+			assert.deepStrictEqual(
+				toolMsgs.map((m) => m.toolCallId),
+				['c1', 'c2']
+			);
 		});
 
 		it('single tool call uses the serial path even under parallel default', async () => {
 			// Sanity — one call, default parallel: still runs cleanly via Promise.all bypass.
-			backend.queue(
-				toolCallRound('p', [tc('c1', 'echo', { x: 1 })]),
-				final('done')
-			);
+			backend.queue(toolCallRound('p', [tc('c1', 'echo', { x: 1 })]), final('done'));
 			const result = await models.generate('go', {
 				toolMode: 'auto',
 				includeToolTrace: true,
@@ -558,10 +553,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 			// into messages and try a SECOND backend round before bailing. Pin the
 			// behavior: handler-mid-flight abort → loop throws AbortError after the
 			// post-dispatch check; no second backend call; no error envelope in trace.
-			backend.queue(
-				toolCallRound('p', [tc('c1', 'slow', {})]),
-				final('unreachable — abort happens during round 1')
-			);
+			backend.queue(toolCallRound('p', [tc('c1', 'slow', {})]), final('unreachable — abort happens during round 1'));
 			const ac = new AbortController();
 			await assert.rejects(
 				() =>
@@ -655,10 +647,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 
 	describe('trace integrity', () => {
 		it("trace's `arguments` is decoupled from in-handler mutation", async () => {
-			backend.queue(
-				toolCallRound('p', [tc('c1', 'mutator', { keep: 'as-emitted' })]),
-				final('done')
-			);
+			backend.queue(toolCallRound('p', [tc('c1', 'mutator', { keep: 'as-emitted' })]), final('done'));
 			const result = await models.generate('q', {
 				toolMode: 'auto',
 				includeToolTrace: true,
@@ -754,11 +743,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 
 	describe('streaming auto path (generateStream + toolMode: auto)', () => {
 		it('terminal first-round stream: yields the inner deltas + final finishReason unchanged', async () => {
-			backend.queueStream([
-				{ deltaContent: 'hello ' },
-				{ deltaContent: 'world' },
-				{ finishReason: 'stop' },
-			]);
+			backend.queueStream([{ deltaContent: 'hello ' }, { deltaContent: 'world' }, { finishReason: 'stop' }]);
 			const chunks = [];
 			for await (const c of models.generateStream('q', { toolMode: 'auto' })) {
 				chunks.push(c);
@@ -775,10 +760,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 					{ deltaToolCalls: [{ id: 'c1', name: 'echo', arguments: { x: 1 } }] },
 					{ finishReason: 'tool_calls' },
 				],
-				[
-					{ deltaContent: 'final answer' },
-					{ finishReason: 'stop' },
-				]
+				[{ deltaContent: 'final answer' }, { finishReason: 'stop' }]
 			);
 			const chunks = [];
 			for await (const c of models.generateStream('q', {
@@ -929,10 +911,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 
 		it("toolErrorMode: 'abort' on stream surfaces ToolHandlerError with cause + trace", async () => {
 			backend.queueStream(
-				[
-					{ deltaToolCalls: [{ id: 'c1', name: 'broken', arguments: {} }] },
-					{ finishReason: 'tool_calls' },
-				],
+				[{ deltaToolCalls: [{ id: 'c1', name: 'broken', arguments: {} }] }, { finishReason: 'tool_calls' }],
 				[{ deltaContent: 'unreachable' }, { finishReason: 'stop' }]
 			);
 			const handlerErr = new Error('stream boom');
@@ -962,10 +941,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 
 		it('streaming recover-mode appends error envelope and continues (default behavior)', async () => {
 			backend.queueStream(
-				[
-					{ deltaToolCalls: [{ id: 'c1', name: 'broken', arguments: {} }] },
-					{ finishReason: 'tool_calls' },
-				],
+				[{ deltaToolCalls: [{ id: 'c1', name: 'broken', arguments: {} }] }, { finishReason: 'tool_calls' }],
 				[{ deltaContent: 'recovered' }, { finishReason: 'stop' }]
 			);
 			const chunks = [];
@@ -1045,10 +1021,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 		}
 
 		it('sync path: assistant → tool → assistant turns appended in order (input NOT echoed)', async () => {
-			backend.queue(
-				toolCallRound('thinking', [tc('c1', 'echo', { x: 1 })]),
-				final('done')
-			);
+			backend.queue(toolCallRound('thinking', [tc('c1', 'echo', { x: 1 })]), final('done'));
 			const conversation = makeConversationSpy();
 			await models.generate('hello', {
 				toolMode: 'auto',
@@ -1128,10 +1101,11 @@ describe("agentLoop (toolMode: 'auto')", () => {
 			assert.deepStrictEqual(conversation.turns, []);
 		});
 
-		it("sync path: BudgetExceededError still fires; conversation has NOT had any turn appended pre-trip", async () => {
-			backend.queue(
-				{ output: { content: 'over', finishReason: 'stop' }, usage: { promptTokens: 200, completionTokens: 0 } }
-			);
+		it('sync path: BudgetExceededError still fires; conversation has NOT had any turn appended pre-trip', async () => {
+			backend.queue({
+				output: { content: 'over', finishReason: 'stop' },
+				usage: { promptTokens: 200, completionTokens: 0 },
+			});
 			const conversation = makeConversationSpy();
 			await assert.rejects(
 				() =>
@@ -1163,7 +1137,6 @@ describe("agentLoop (toolMode: 'auto')", () => {
 				(err) => err.statusCode === 501
 			);
 		});
-
 	});
 
 	describe('token + cost budgets', () => {
@@ -1230,10 +1203,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 		it("maxCostUsd trips BudgetExceededError({kind: 'cost'}) when an injected cost function exceeds the cap", async () => {
 			// Inject a $0.01-per-call cost so two rounds = $0.02, capped at $0.015.
 			_setComputeCallCostUsdForTests(() => 0.01);
-			backend.queue(
-				tokenToolRound('p', [tc('c1', 'echo', { i: 1 })]),
-				tokenRound('done')
-			);
+			backend.queue(tokenToolRound('p', [tc('c1', 'echo', { i: 1 })]), tokenRound('done'));
 			let caught;
 			try {
 				await models.generate('q', {
@@ -1249,7 +1219,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 			assert.match(caught.message, /maxCostUsd=0.015/);
 		});
 
-		it("maxCostUsd does NOT trip with the v1 stub (computeCallCostUsd returns 0)", async () => {
+		it('maxCostUsd does NOT trip with the v1 stub (computeCallCostUsd returns 0)', async () => {
 			// Default stub: cost = 0 per call, so any cap is unreachable today. Proves
 			// the v1 contract: cap is wired but doesn't fire in production until a
 			// real rate card lands.
@@ -1332,10 +1302,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 
 	describe("toolErrorMode: 'abort'", () => {
 		it('handler throw surfaces as ToolHandlerError carrying the cause + trace (recover NOT applied)', async () => {
-			backend.queue(
-				toolCallRound('p', [tc('c1', 'broken', {})]),
-				final('unreachable — abort halts the loop')
-			);
+			backend.queue(toolCallRound('p', [tc('c1', 'broken', {})]), final('unreachable — abort halts the loop'));
 			const handlerErr = new Error('boom');
 			let caught;
 			try {
@@ -1382,11 +1349,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 
 		it('parallel: successful sibling entries are recorded in trace BEFORE the abort throw', async () => {
 			backend.queue(
-				toolCallRound('p', [
-					tc('c1', 'ok', { i: 1 }),
-					tc('c2', 'broken', { i: 2 }),
-					tc('c3', 'ok', { i: 3 }),
-				])
+				toolCallRound('p', [tc('c1', 'ok', { i: 1 }), tc('c2', 'broken', { i: 2 }), tc('c3', 'ok', { i: 3 })])
 			);
 			let caught;
 			try {
@@ -1412,10 +1375,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 		});
 
 		it("default toolErrorMode is 'recover' (unchanged behavior)", async () => {
-			backend.queue(
-				toolCallRound('p', [tc('c1', 'broken', {})]),
-				final('recovered')
-			);
+			backend.queue(toolCallRound('p', [tc('c1', 'broken', {})]), final('recovered'));
 			const result = await models.generate('q', {
 				toolMode: 'auto',
 				toolHandlers: {

--- a/unitTests/resources/models/agentLoop.test.js
+++ b/unitTests/resources/models/agentLoop.test.js
@@ -6,7 +6,12 @@ const assert = require('node:assert/strict');
 require('#src/resources/databases');
 const { setGenerative, clearRegistry } = require('#src/resources/models/backendRegistry');
 const { Models } = require('#src/resources/models/Models');
-const { BudgetExceededError } = require('#src/resources/models/agentLoop');
+const {
+	BudgetExceededError,
+	ToolHandlerError,
+	_setComputeCallCostUsdForTests,
+	_resetComputeCallCostUsdForTests,
+} = require('#src/resources/models/agentLoop');
 
 function makeMockWriter() {
 	const records = [];
@@ -747,28 +752,6 @@ describe("agentLoop (toolMode: 'auto')", () => {
 			);
 		});
 
-		it("toolErrorMode: 'abort' throws 501 at entry", async () => {
-			backend.queue(final('x'));
-			await assert.rejects(
-				() => models.generate('q', { toolMode: 'auto', toolErrorMode: 'abort' }),
-				(err) => err.statusCode === 501 && /toolErrorMode/.test(err.message)
-			);
-		});
-
-		it('maxToolTokens throws 501 at entry (commit 4)', async () => {
-			await assert.rejects(
-				() => models.generate('q', { toolMode: 'auto', maxToolTokens: 1000 }),
-				(err) => err.statusCode === 501
-			);
-		});
-
-		it('maxCostUsd throws 501 at entry (commit 4)', async () => {
-			await assert.rejects(
-				() => models.generate('q', { toolMode: 'auto', maxCostUsd: 0.1 }),
-				(err) => err.statusCode === 501
-			);
-		});
-
 		it('opts.conversation throws 501 at entry (commit 5)', async () => {
 			await assert.rejects(
 				() =>
@@ -778,6 +761,268 @@ describe("agentLoop (toolMode: 'auto')", () => {
 					}),
 				(err) => err.statusCode === 501 && /conversation/.test(err.message)
 			);
+		});
+	});
+
+	describe('token + cost budgets', () => {
+		afterEach(() => {
+			_resetComputeCallCostUsdForTests();
+		});
+
+		// The default ScriptedBackend usage helpers set tokens to 1+1 per round; for these
+		// tests we override per-call so the budget arithmetic is predictable.
+		function tokenRound(content, tokens = { promptTokens: 50, completionTokens: 50 }) {
+			return { output: { content, finishReason: 'stop' }, usage: tokens };
+		}
+		function tokenToolRound(content, toolCalls, tokens = { promptTokens: 50, completionTokens: 50 }) {
+			return {
+				output: { content, finishReason: 'tool_calls', toolCalls },
+				usage: tokens,
+			};
+		}
+
+		it("maxToolTokens trips BudgetExceededError({kind: 'tokens'}) when cumulative tokens exceed the cap", async () => {
+			// Round 1: 60 tokens. Round 2: 60 tokens. Total: 120 > cap of 100.
+			backend.queue(
+				tokenToolRound('p1', [tc('c1', 'echo', { i: 1 })], { promptTokens: 30, completionTokens: 30 }),
+				tokenRound('done', { promptTokens: 30, completionTokens: 30 })
+			);
+			let caught;
+			try {
+				await models.generate('q', {
+					toolMode: 'auto',
+					maxToolTokens: 100,
+					toolHandlers: { echo: (args) => args },
+				});
+			} catch (err) {
+				caught = err;
+			}
+			assert.ok(caught instanceof BudgetExceededError, 'expected BudgetExceededError');
+			assert.strictEqual(caught.kind, 'tokens');
+			assert.strictEqual(caught.statusCode, 429);
+			assert.match(caught.message, /maxToolTokens=100/);
+			// Trace records round 1's tool call before the budget tripped on round 2's generate.
+			assert.strictEqual(caught.partialTrace.length, 1);
+			assert.strictEqual(caught.partialTrace[0].iteration, 1);
+		});
+
+		it('first-round usage that exceeds the cap still trips — caps the round we PAID for, not the next one', async () => {
+			// One round, 150 tokens, cap 100. Trips immediately.
+			backend.queue(tokenRound('over', { promptTokens: 75, completionTokens: 75 }));
+			let caught;
+			try {
+				await models.generate('q', { toolMode: 'auto', maxToolTokens: 100 });
+			} catch (err) {
+				caught = err;
+			}
+			assert.ok(caught instanceof BudgetExceededError);
+			assert.strictEqual(caught.kind, 'tokens');
+		});
+
+		it('maxToolTokens unset → unlimited (no trip even with huge usage)', async () => {
+			backend.queue(tokenRound('over', { promptTokens: 1_000_000, completionTokens: 1_000_000 }));
+			const result = await models.generate('q', { toolMode: 'auto' });
+			assert.strictEqual(result.content, 'over');
+		});
+
+		it("maxCostUsd trips BudgetExceededError({kind: 'cost'}) when an injected cost function exceeds the cap", async () => {
+			// Inject a $0.01-per-call cost so two rounds = $0.02, capped at $0.015.
+			_setComputeCallCostUsdForTests(() => 0.01);
+			backend.queue(
+				tokenToolRound('p', [tc('c1', 'echo', { i: 1 })]),
+				tokenRound('done')
+			);
+			let caught;
+			try {
+				await models.generate('q', {
+					toolMode: 'auto',
+					maxCostUsd: 0.015,
+					toolHandlers: { echo: (args) => args },
+				});
+			} catch (err) {
+				caught = err;
+			}
+			assert.ok(caught instanceof BudgetExceededError);
+			assert.strictEqual(caught.kind, 'cost');
+			assert.match(caught.message, /maxCostUsd=0.015/);
+		});
+
+		it("maxCostUsd does NOT trip with the v1 stub (computeCallCostUsd returns 0)", async () => {
+			// Default stub: cost = 0 per call, so any cap is unreachable today. Proves
+			// the v1 contract: cap is wired but doesn't fire in production until a
+			// real rate card lands.
+			backend.queue(tokenRound('done'));
+			const result = await models.generate('q', { toolMode: 'auto', maxCostUsd: 0.0001 });
+			assert.strictEqual(result.content, 'done');
+		});
+
+		it('cost function receives the usage object and model name', async () => {
+			const observations = [];
+			_setComputeCallCostUsdForTests((usage, model) => {
+				observations.push({ usage, model });
+				return 0;
+			});
+			backend.queue(tokenRound('done', { promptTokens: 5, completionTokens: 3 }));
+			// Use the default-registered backend; the model name passed in opts is what
+			// flows to computeCallCostUsd, independent of how the backend resolves.
+			await models.generate('q', { toolMode: 'auto' });
+			assert.strictEqual(observations.length, 1);
+			assert.strictEqual(observations[0].usage.promptTokens, 5);
+			assert.strictEqual(observations[0].usage.completionTokens, 3);
+			// `opts.model` was undefined here; the cost function sees that.
+			assert.strictEqual(observations[0].model, undefined);
+		});
+
+		it('caller abort during the in-flight backend round preempts the budget tally', async () => {
+			// Round 1's usage would push us over a 100-token cap. But the caller aborts
+			// mid-call, so the inner generate rejects with AbortError BEFORE we tally —
+			// caller sees AbortError, not BudgetExceededError. Locks the ordering in
+			// `runAgentLoop` so commit 5's streaming wiring can't accidentally invert it.
+			let ac;
+			setGenerative('default', {
+				name: 'aborting-backend',
+				capabilities: () => ({ embed: false, generate: true, stream: false, tools: true, adapters: false }),
+				async generate(_input, opts) {
+					// Abort mid-call. opts.signal is the composed loop signal — firing the
+					// caller signal propagates to it.
+					ac.abort();
+					opts.signal.throwIfAborted();
+					// Unreachable, but keeps the type tidy.
+					return {
+						status: 'completed',
+						output: { content: 'unreachable', finishReason: 'stop' },
+						usage: { promptTokens: 200, completionTokens: 200 },
+					};
+				},
+			});
+			ac = new AbortController();
+			await assert.rejects(
+				() =>
+					models.generate('q', {
+						toolMode: 'auto',
+						maxToolTokens: 100,
+						signal: ac.signal,
+					}),
+				(err) => err.name === 'AbortError' && !(err instanceof BudgetExceededError)
+			);
+		});
+
+		it('partial trace on token budget trip is independent of includeToolTrace', async () => {
+			// includeToolTrace: false (default). On budget trip, partialTrace is still populated.
+			backend.queue(
+				tokenToolRound('p', [tc('c1', 'echo', { i: 1 })], { promptTokens: 60, completionTokens: 0 }),
+				tokenRound('done', { promptTokens: 60, completionTokens: 0 })
+			);
+			let caught;
+			try {
+				await models.generate('q', {
+					toolMode: 'auto',
+					maxToolTokens: 100,
+					toolHandlers: { echo: (args) => args },
+				});
+			} catch (err) {
+				caught = err;
+			}
+			assert.ok(caught instanceof BudgetExceededError);
+			assert.strictEqual(caught.partialTrace.length, 1, 'partial trace populated regardless of includeToolTrace');
+		});
+	});
+
+	describe("toolErrorMode: 'abort'", () => {
+		it('handler throw surfaces as ToolHandlerError carrying the cause + trace (recover NOT applied)', async () => {
+			backend.queue(
+				toolCallRound('p', [tc('c1', 'broken', {})]),
+				final('unreachable — abort halts the loop')
+			);
+			const handlerErr = new Error('boom');
+			let caught;
+			try {
+				await models.generate('q', {
+					toolMode: 'auto',
+					toolErrorMode: 'abort',
+					toolHandlers: {
+						broken: () => {
+							throw handlerErr;
+						},
+					},
+				});
+			} catch (err) {
+				caught = err;
+			}
+			assert.ok(caught instanceof ToolHandlerError);
+			assert.strictEqual(caught.toolName, 'broken');
+			assert.strictEqual(caught.toolCallId, 'c1');
+			assert.strictEqual(caught.cause, handlerErr, 'cause is the original throw, not a copy');
+			// Trace includes the failing entry so the caller sees the call that triggered abort.
+			assert.strictEqual(caught.partialTrace.length, 1);
+			assert.strictEqual(caught.partialTrace[0].error.message, 'boom');
+			// Loop halted — the second round's `final` was never consumed.
+			assert.strictEqual(backend.calls.length, 1);
+		});
+
+		it("ToolHandlerError statusCode mirrors a thrown ClientError's status (e.g. 400)", async () => {
+			const { ClientError } = require('#src/utility/errors/hdbError');
+			backend.queue(toolCallRound('p', [tc('c1', 'forbidden', {})]));
+			await assert.rejects(
+				() =>
+					models.generate('q', {
+						toolMode: 'auto',
+						toolErrorMode: 'abort',
+						toolHandlers: {
+							forbidden: () => {
+								throw new ClientError('nope', 403);
+							},
+						},
+					}),
+				(err) => err instanceof ToolHandlerError && err.statusCode === 403
+			);
+		});
+
+		it('parallel: successful sibling entries are recorded in trace BEFORE the abort throw', async () => {
+			backend.queue(
+				toolCallRound('p', [
+					tc('c1', 'ok', { i: 1 }),
+					tc('c2', 'broken', { i: 2 }),
+					tc('c3', 'ok', { i: 3 }),
+				])
+			);
+			let caught;
+			try {
+				await models.generate('q', {
+					toolMode: 'auto',
+					toolErrorMode: 'abort',
+					toolHandlers: {
+						ok: async (args) => ({ value: args.i }),
+						broken: () => {
+							throw new Error('boom');
+						},
+					},
+				});
+			} catch (err) {
+				caught = err;
+			}
+			assert.ok(caught instanceof ToolHandlerError);
+			// All three entries land on the trace — the successful ones AND the failed one.
+			assert.strictEqual(caught.partialTrace.length, 3);
+			assert.strictEqual(caught.partialTrace.find((e) => e.toolCallId === 'c2').error.message, 'boom');
+			assert.ok(caught.partialTrace.find((e) => e.toolCallId === 'c1').result);
+			assert.ok(caught.partialTrace.find((e) => e.toolCallId === 'c3').result);
+		});
+
+		it("default toolErrorMode is 'recover' (unchanged behavior)", async () => {
+			backend.queue(
+				toolCallRound('p', [tc('c1', 'broken', {})]),
+				final('recovered')
+			);
+			const result = await models.generate('q', {
+				toolMode: 'auto',
+				toolHandlers: {
+					broken: () => {
+						throw new Error('boom');
+					},
+				},
+			});
+			assert.strictEqual(result.content, 'recovered');
 		});
 	});
 });

--- a/unitTests/resources/models/agentLoop.test.js
+++ b/unitTests/resources/models/agentLoop.test.js
@@ -32,18 +32,23 @@ class ScriptedBackend {
 	constructor(name = 'scripted') {
 		this.name = name;
 		this.responses = [];
+		this.streamResponses = [];
 		this.calls = [];
+		this.streamCalls = [];
 	}
 	capabilities() {
-		return { embed: false, generate: true, stream: false, tools: true, adapters: false };
+		return { embed: false, generate: true, stream: true, tools: true, adapters: false };
 	}
 	queue(...results) {
 		for (const r of results) this.responses.push(r);
 		return this;
 	}
+	queueStream(...rounds) {
+		// Each `round` is an array of GenerateChunk-like objects to yield in order.
+		for (const round of rounds) this.streamResponses.push(round);
+		return this;
+	}
 	async generate(input, opts) {
-		// Snapshot the input — the loop mutates the same `messages` array across
-		// iterations, so naive reference capture would show every call as the final state.
 		const snapshot =
 			typeof input === 'string' || Array.isArray(input)
 				? input
@@ -54,6 +59,18 @@ class ScriptedBackend {
 		}
 		const next = this.responses.shift();
 		return { status: 'completed', output: next.output, usage: next.usage };
+	}
+	async *generateStream(input, opts) {
+		const snapshot =
+			typeof input === 'string' || Array.isArray(input)
+				? input
+				: { ...input, messages: input.messages.map((m) => ({ ...m })) };
+		this.streamCalls.push({ input: snapshot, opts });
+		if (this.streamResponses.length === 0) {
+			throw new Error('ScriptedBackend stream ran out of rounds');
+		}
+		const chunks = this.streamResponses.shift();
+		for (const c of chunks) yield c;
 	}
 }
 
@@ -735,6 +752,358 @@ describe("agentLoop (toolMode: 'auto')", () => {
 		});
 	});
 
+	describe('streaming auto path (generateStream + toolMode: auto)', () => {
+		it('terminal first-round stream: yields the inner deltas + final finishReason unchanged', async () => {
+			backend.queueStream([
+				{ deltaContent: 'hello ' },
+				{ deltaContent: 'world' },
+				{ finishReason: 'stop' },
+			]);
+			const chunks = [];
+			for await (const c of models.generateStream('q', { toolMode: 'auto' })) {
+				chunks.push(c);
+			}
+			assert.strictEqual(chunks.length, 3);
+			assert.strictEqual(chunks[0].deltaContent, 'hello ');
+			assert.strictEqual(chunks[2].finishReason, 'stop');
+		});
+
+		it('multi-round: streams round 1 deltas, suppresses intermediate finishReason=tool_calls, streams round 2 deltas + terminal finishReason', async () => {
+			backend.queueStream(
+				[
+					{ deltaContent: 'thinking' },
+					{ deltaToolCalls: [{ id: 'c1', name: 'echo', arguments: { x: 1 } }] },
+					{ finishReason: 'tool_calls' },
+				],
+				[
+					{ deltaContent: 'final answer' },
+					{ finishReason: 'stop' },
+				]
+			);
+			const chunks = [];
+			for await (const c of models.generateStream('q', {
+				toolMode: 'auto',
+				toolHandlers: { echo: (args) => args },
+			})) {
+				chunks.push(c);
+			}
+			// No chunk carries 'tool_calls' as a terminal finishReason — only the final 'stop'.
+			const finishReasons = chunks.map((c) => c.finishReason).filter(Boolean);
+			assert.deepStrictEqual(finishReasons, ['stop']);
+			// Deltas from BOTH rounds reached the caller.
+			const allContent = chunks.map((c) => c.deltaContent ?? '').join('');
+			assert.match(allContent, /thinking/);
+			assert.match(allContent, /final answer/);
+			// Two inner stream calls — one per iteration.
+			assert.strictEqual(backend.streamCalls.length, 2);
+		});
+
+		it('assembles deltaToolCalls across multiple chunks (id-keyed, fields merge in arrival order)', async () => {
+			backend.queueStream(
+				[
+					{ deltaToolCalls: [{ id: 'c1', name: 'echo' }] },
+					{ deltaToolCalls: [{ id: 'c1', arguments: { partial: 1 } }] },
+					{ deltaToolCalls: [{ id: 'c1', arguments: { full: 2 } }] },
+					{ finishReason: 'tool_calls' },
+				],
+				[{ deltaContent: 'done' }, { finishReason: 'stop' }]
+			);
+			const seenArgs = [];
+			for await (const _ of models.generateStream('q', {
+				toolMode: 'auto',
+				toolHandlers: {
+					echo: (args) => {
+						seenArgs.push(args);
+						return args;
+					},
+				},
+			})) {
+				// drain
+			}
+			assert.strictEqual(seenArgs.length, 1);
+			assert.deepStrictEqual(seenArgs[0], { partial: 1, full: 2 });
+		});
+
+		it('iteration cap trips on stream too — BudgetExceededError({kind: iterations}) after maxToolIterations rounds', async () => {
+			for (let i = 0; i < 4; i++) {
+				backend.queueStream([
+					{ deltaToolCalls: [{ id: `c${i}`, name: 'echo', arguments: { i } }] },
+					{ finishReason: 'tool_calls' },
+				]);
+			}
+			let caught;
+			try {
+				for await (const _ of models.generateStream('q', {
+					toolMode: 'auto',
+					maxToolIterations: 3,
+					toolHandlers: { echo: (args) => args },
+				})) {
+					// drain
+				}
+			} catch (err) {
+				caught = err;
+			}
+			assert.ok(caught instanceof BudgetExceededError);
+			assert.strictEqual(caught.kind, 'iterations');
+			assert.strictEqual(caught.partialTrace.length, 3);
+		});
+
+		it('caller-pre-aborted signal bails on stream too, before any backend round', async () => {
+			backend.queueStream([{ deltaContent: 'unreachable' }, { finishReason: 'stop' }]);
+			const ac = new AbortController();
+			ac.abort();
+			await assert.rejects(
+				async () => {
+					for await (const _ of models.generateStream('q', {
+						toolMode: 'auto',
+						signal: ac.signal,
+					})) {
+						// drain
+					}
+				},
+				(err) => err.name === 'AbortError'
+			);
+			assert.strictEqual(backend.streamCalls.length, 0);
+		});
+
+		it('degenerate backend: finishReason=tool_calls with NO assembled calls → loop reclassifies as terminal stop', async () => {
+			// Provider misbehavior or upstream truncation can yield "tool_calls" without
+			// any tool-call deltas. Without the guard, the loop would suppress the
+			// intermediate finishReason chunk AND treat the round as terminal — the
+			// consumer's `for-await` would end with zero chunks ever yielded, violating
+			// the GenerateChunk contract ("finishReason set on the FINAL chunk").
+			backend.queueStream([{ finishReason: 'tool_calls' }]);
+			const chunks = [];
+			for await (const c of models.generateStream('q', { toolMode: 'auto' })) {
+				chunks.push(c);
+			}
+			assert.strictEqual(chunks.length, 1, 'must yield exactly one terminal chunk');
+			assert.strictEqual(chunks[0].finishReason, 'stop');
+		});
+
+		it("toolErrorMode: 'abort' on stream surfaces ToolHandlerError with cause + trace", async () => {
+			backend.queueStream(
+				[
+					{ deltaToolCalls: [{ id: 'c1', name: 'broken', arguments: {} }] },
+					{ finishReason: 'tool_calls' },
+				],
+				[{ deltaContent: 'unreachable' }, { finishReason: 'stop' }]
+			);
+			const handlerErr = new Error('stream boom');
+			let caught;
+			try {
+				for await (const _ of models.generateStream('q', {
+					toolMode: 'auto',
+					toolErrorMode: 'abort',
+					toolHandlers: {
+						broken: () => {
+							throw handlerErr;
+						},
+					},
+				})) {
+					// drain
+				}
+			} catch (err) {
+				caught = err;
+			}
+			assert.ok(caught instanceof ToolHandlerError);
+			assert.strictEqual(caught.cause, handlerErr);
+			assert.strictEqual(caught.partialTrace.length, 1);
+			assert.strictEqual(caught.partialTrace[0].error.message, 'stream boom');
+			// Second round was never consumed.
+			assert.strictEqual(backend.streamCalls.length, 1);
+		});
+
+		it('streaming recover-mode appends error envelope and continues (default behavior)', async () => {
+			backend.queueStream(
+				[
+					{ deltaToolCalls: [{ id: 'c1', name: 'broken', arguments: {} }] },
+					{ finishReason: 'tool_calls' },
+				],
+				[{ deltaContent: 'recovered' }, { finishReason: 'stop' }]
+			);
+			const chunks = [];
+			for await (const c of models.generateStream('q', {
+				toolMode: 'auto',
+				toolHandlers: {
+					broken: () => {
+						throw new Error('boom');
+					},
+				},
+			})) {
+				chunks.push(c);
+			}
+			const text = chunks.map((c) => c.deltaContent ?? '').join('');
+			assert.match(text, /recovered/);
+			// Second round saw the error envelope as the tool message.
+			const round2messages = backend.streamCalls[1].input.messages;
+			const toolMsg = round2messages[round2messages.length - 1];
+			assert.strictEqual(toolMsg.role, 'tool');
+			assert.strictEqual(JSON.parse(toolMsg.content).error, 'boom');
+		});
+
+		it('streaming parallel dispatch: multi-id assembly across interleaved deltas', async () => {
+			// Realistic OpenAI-style streaming: deltas for two tool calls arrive interleaved,
+			// each id built up across multiple chunks. The Map-keyed assembler must reconcile
+			// them into two complete calls.
+			backend.queueStream(
+				[
+					{ deltaToolCalls: [{ id: 'c1', name: 'echo' }] },
+					{ deltaToolCalls: [{ id: 'c2', name: 'echo' }] },
+					{ deltaToolCalls: [{ id: 'c1', arguments: { i: 1 } }] },
+					{ deltaToolCalls: [{ id: 'c2', arguments: { i: 2 } }] },
+					{ finishReason: 'tool_calls' },
+				],
+				[{ deltaContent: 'done' }, { finishReason: 'stop' }]
+			);
+			const dispatched = [];
+			for await (const _ of models.generateStream('q', {
+				toolMode: 'auto',
+				toolHandlers: {
+					echo: (args) => {
+						dispatched.push(args.i);
+						return args;
+					},
+				},
+			})) {
+				// drain
+			}
+			assert.deepStrictEqual(dispatched.sort(), [1, 2]);
+		});
+
+		it("maxToolTokens / maxCostUsd throw 501 on stream — usage isn't exposed on GenerateChunk in v1", async () => {
+			backend.queueStream([{ finishReason: 'stop' }]);
+			await assert.rejects(
+				async () => {
+					for await (const _ of models.generateStream('q', {
+						toolMode: 'auto',
+						maxToolTokens: 100,
+					})) {
+						// drain
+					}
+				},
+				(err) => err.statusCode === 501 && /streamed usage/.test(err.message)
+			);
+		});
+	});
+
+	describe('opts.conversation hook', () => {
+		function makeConversationSpy() {
+			const turns = [];
+			return {
+				turns,
+				async append(turn) {
+					turns.push(turn);
+				},
+			};
+		}
+
+		it('sync path: user → assistant → tool → assistant turns appended in order', async () => {
+			backend.queue(
+				toolCallRound('thinking', [tc('c1', 'echo', { x: 1 })]),
+				final('done')
+			);
+			const conversation = makeConversationSpy();
+			await models.generate('hello', {
+				toolMode: 'auto',
+				conversation,
+				toolHandlers: { echo: (args) => ({ result: args.x }) },
+			});
+			assert.deepStrictEqual(
+				conversation.turns.map((t) => t.role),
+				['user', 'assistant', 'tool', 'assistant']
+			);
+			assert.strictEqual(conversation.turns[0].content, 'hello');
+			assert.ok(conversation.turns[1].toolCalls, 'mid-loop assistant turn carries toolCalls');
+			assert.strictEqual(conversation.turns[2].toolCallId, 'c1');
+			assert.strictEqual(conversation.turns[3].content, 'done');
+			assert.strictEqual(conversation.turns[3].toolCalls, undefined, 'terminal assistant turn omits toolCalls');
+		});
+
+		it('streaming path: user → assistant → tool → assistant turns appended in order', async () => {
+			backend.queueStream(
+				[
+					{ deltaContent: 'thinking' },
+					{ deltaToolCalls: [{ id: 'c1', name: 'echo', arguments: { x: 1 } }] },
+					{ finishReason: 'tool_calls' },
+				],
+				[{ deltaContent: 'final' }, { finishReason: 'stop' }]
+			);
+			const conversation = makeConversationSpy();
+			for await (const _ of models.generateStream('hello', {
+				toolMode: 'auto',
+				conversation,
+				toolHandlers: { echo: (args) => ({ result: args.x }) },
+			})) {
+				// drain
+			}
+			assert.deepStrictEqual(
+				conversation.turns.map((t) => t.role),
+				['user', 'assistant', 'tool', 'assistant']
+			);
+			assert.strictEqual(conversation.turns[0].content, 'hello');
+			assert.strictEqual(conversation.turns[1].content, 'thinking');
+			assert.ok(conversation.turns[1].toolCalls);
+			assert.strictEqual(conversation.turns[3].content, 'final');
+		});
+
+		it('sync path with Message[] input: appends EACH user turn before the first round', async () => {
+			backend.queue(final('out'));
+			const conversation = makeConversationSpy();
+			await models.generate(
+				[
+					{ role: 'system', content: 'sys (ambient — not a turn)' },
+					{ role: 'user', content: 'q1' },
+					{ role: 'user', content: 'q2' },
+				],
+				{ toolMode: 'auto', conversation }
+			);
+			// Two user turns appended before the round; one assistant turn after.
+			assert.deepStrictEqual(
+				conversation.turns.map((t) => ({ role: t.role, content: t.content })),
+				[
+					{ role: 'user', content: 'q1' },
+					{ role: 'user', content: 'q2' },
+					{ role: 'assistant', content: 'out' },
+				]
+			);
+		});
+
+		it('streaming path: empty terminal content does NOT append an empty assistant turn', async () => {
+			backend.queueStream([{ finishReason: 'stop' }]);
+			const conversation = makeConversationSpy();
+			for await (const _ of models.generateStream('hello', {
+				toolMode: 'auto',
+				conversation,
+			})) {
+				// drain
+			}
+			// Only the user turn — no assistant turn for the empty terminal.
+			assert.deepStrictEqual(
+				conversation.turns.map((t) => t.role),
+				['user']
+			);
+		});
+
+		it("sync path: BudgetExceededError still fires; conversation reflects work that completed before the trip", async () => {
+			backend.queue(
+				{ output: { content: 'over', finishReason: 'stop' }, usage: { promptTokens: 200, completionTokens: 0 } }
+			);
+			const conversation = makeConversationSpy();
+			await assert.rejects(
+				() =>
+					models.generate('q', {
+						toolMode: 'auto',
+						maxToolTokens: 100,
+						conversation,
+					}),
+				(err) => err instanceof BudgetExceededError
+			);
+			// User turn appended; assistant turn NOT (budget tripped before terminal append).
+			assert.deepStrictEqual(conversation.turns.map((t) => t.role), ['user']);
+		});
+	});
+
 	describe('gated modes (deferred to later commits)', () => {
 		it("toolArgValidation: 'strict' throws 501 at entry", async () => {
 			backend.queue(final('x'));
@@ -752,16 +1121,6 @@ describe("agentLoop (toolMode: 'auto')", () => {
 			);
 		});
 
-		it('opts.conversation throws 501 at entry (commit 5)', async () => {
-			await assert.rejects(
-				() =>
-					models.generate('q', {
-						toolMode: 'auto',
-						conversation: { async append() {} },
-					}),
-				(err) => err.statusCode === 501 && /conversation/.test(err.message)
-			);
-		});
 	});
 
 	describe('token + cost budgets', () => {

--- a/unitTests/resources/models/agentLoop.test.js
+++ b/unitTests/resources/models/agentLoop.test.js
@@ -866,6 +866,52 @@ describe("agentLoop (toolMode: 'auto')", () => {
 			assert.strictEqual(backend.streamCalls.length, 0);
 		});
 
+		it('backend tail-flushes tool calls without finishReason (proxy truncation) → loop dispatches, does NOT drop the calls', async () => {
+			// All three in-tree backends (openai, anthropic, bedrock) emit a tail-flush
+			// `{deltaToolCalls: ...}` without a `finishReason` when the upstream stream
+			// closes mid-message. The loop must treat that as a `tool_calls` round and
+			// dispatch — otherwise the backend's careful recovery is undone here.
+			backend.queueStream(
+				[
+					{ deltaContent: 'thinking' },
+					// Note: no finishReason chunk at all — backend tail-flushed.
+					{ deltaToolCalls: [{ id: 'c1', name: 'recover', arguments: { x: 1 } }] },
+				],
+				[{ deltaContent: 'recovered' }, { finishReason: 'stop' }]
+			);
+			const dispatched = [];
+			const chunks = [];
+			for await (const c of models.generateStream('q', {
+				toolMode: 'auto',
+				toolHandlers: {
+					recover: (args) => {
+						dispatched.push(args);
+						return { ok: true };
+					},
+				},
+			})) {
+				chunks.push(c);
+			}
+			assert.deepStrictEqual(dispatched, [{ x: 1 }], 'tail-flushed tool call must dispatch');
+			// Caller sees deltas from BOTH rounds + a terminal 'stop'.
+			const text = chunks.map((c) => c.deltaContent ?? '').join('');
+			assert.match(text, /thinking/);
+			assert.match(text, /recovered/);
+			const finishReasons = chunks.map((c) => c.finishReason).filter(Boolean);
+			assert.deepStrictEqual(finishReasons, ['stop']);
+		});
+
+		it('backend stream ends with no finishReason AND no tool calls → loop yields synthetic stop', async () => {
+			backend.queueStream([{ deltaContent: 'partial' }]);
+			const chunks = [];
+			for await (const c of models.generateStream('q', { toolMode: 'auto' })) {
+				chunks.push(c);
+			}
+			// Last chunk carries a synthetic terminal `stop` so consumer's for-await sees one.
+			const finishReasons = chunks.map((c) => c.finishReason).filter(Boolean);
+			assert.deepStrictEqual(finishReasons, ['stop']);
+		});
+
 		it('degenerate backend: finishReason=tool_calls with NO assembled calls → loop reclassifies as terminal stop', async () => {
 			// Provider misbehavior or upstream truncation can yield "tool_calls" without
 			// any tool-call deltas. Without the guard, the loop would suppress the
@@ -998,7 +1044,7 @@ describe("agentLoop (toolMode: 'auto')", () => {
 			};
 		}
 
-		it('sync path: user → assistant → tool → assistant turns appended in order', async () => {
+		it('sync path: assistant → tool → assistant turns appended in order (input NOT echoed)', async () => {
 			backend.queue(
 				toolCallRound('thinking', [tc('c1', 'echo', { x: 1 })]),
 				final('done')
@@ -1009,18 +1055,20 @@ describe("agentLoop (toolMode: 'auto')", () => {
 				conversation,
 				toolHandlers: { echo: (args) => ({ result: args.x }) },
 			});
+			// Loop ONLY appends new turns it produced. The caller's `hello` input is
+			// theirs to track; re-appending it would corrupt the conversation store.
 			assert.deepStrictEqual(
 				conversation.turns.map((t) => t.role),
-				['user', 'assistant', 'tool', 'assistant']
+				['assistant', 'tool', 'assistant']
 			);
-			assert.strictEqual(conversation.turns[0].content, 'hello');
-			assert.ok(conversation.turns[1].toolCalls, 'mid-loop assistant turn carries toolCalls');
-			assert.strictEqual(conversation.turns[2].toolCallId, 'c1');
-			assert.strictEqual(conversation.turns[3].content, 'done');
-			assert.strictEqual(conversation.turns[3].toolCalls, undefined, 'terminal assistant turn omits toolCalls');
+			assert.strictEqual(conversation.turns[0].content, 'thinking');
+			assert.ok(conversation.turns[0].toolCalls, 'mid-loop assistant turn carries toolCalls');
+			assert.strictEqual(conversation.turns[1].toolCallId, 'c1');
+			assert.strictEqual(conversation.turns[2].content, 'done');
+			assert.strictEqual(conversation.turns[2].toolCalls, undefined, 'terminal assistant turn omits toolCalls');
 		});
 
-		it('streaming path: user → assistant → tool → assistant turns appended in order', async () => {
+		it('streaming path: assistant → tool → assistant turns appended in order (input NOT echoed)', async () => {
 			backend.queueStream(
 				[
 					{ deltaContent: 'thinking' },
@@ -1039,33 +1087,31 @@ describe("agentLoop (toolMode: 'auto')", () => {
 			}
 			assert.deepStrictEqual(
 				conversation.turns.map((t) => t.role),
-				['user', 'assistant', 'tool', 'assistant']
+				['assistant', 'tool', 'assistant']
 			);
-			assert.strictEqual(conversation.turns[0].content, 'hello');
-			assert.strictEqual(conversation.turns[1].content, 'thinking');
-			assert.ok(conversation.turns[1].toolCalls);
-			assert.strictEqual(conversation.turns[3].content, 'final');
+			assert.strictEqual(conversation.turns[0].content, 'thinking');
+			assert.ok(conversation.turns[0].toolCalls);
+			assert.strictEqual(conversation.turns[2].content, 'final');
 		});
 
-		it('sync path with Message[] input: appends EACH user turn before the first round', async () => {
+		it('sync path with Message[] input: caller-supplied user turns are NOT echoed to the appender', async () => {
+			// Multi-turn history input: caller has already persisted these turns in their
+			// store. The loop must not echo them back.
 			backend.queue(final('out'));
 			const conversation = makeConversationSpy();
 			await models.generate(
 				[
 					{ role: 'system', content: 'sys (ambient — not a turn)' },
 					{ role: 'user', content: 'q1' },
+					{ role: 'assistant', content: 'a1' },
 					{ role: 'user', content: 'q2' },
 				],
 				{ toolMode: 'auto', conversation }
 			);
-			// Two user turns appended before the round; one assistant turn after.
+			// Only the assistant turn produced THIS call lands in the appender.
 			assert.deepStrictEqual(
 				conversation.turns.map((t) => ({ role: t.role, content: t.content })),
-				[
-					{ role: 'user', content: 'q1' },
-					{ role: 'user', content: 'q2' },
-					{ role: 'assistant', content: 'out' },
-				]
+				[{ role: 'assistant', content: 'out' }]
 			);
 		});
 
@@ -1078,14 +1124,11 @@ describe("agentLoop (toolMode: 'auto')", () => {
 			})) {
 				// drain
 			}
-			// Only the user turn — no assistant turn for the empty terminal.
-			assert.deepStrictEqual(
-				conversation.turns.map((t) => t.role),
-				['user']
-			);
+			// No assistant turn for the empty terminal; loop never echoes input either.
+			assert.deepStrictEqual(conversation.turns, []);
 		});
 
-		it("sync path: BudgetExceededError still fires; conversation reflects work that completed before the trip", async () => {
+		it("sync path: BudgetExceededError still fires; conversation has NOT had any turn appended pre-trip", async () => {
 			backend.queue(
 				{ output: { content: 'over', finishReason: 'stop' }, usage: { promptTokens: 200, completionTokens: 0 } }
 			);
@@ -1099,8 +1142,8 @@ describe("agentLoop (toolMode: 'auto')", () => {
 					}),
 				(err) => err instanceof BudgetExceededError
 			);
-			// User turn appended; assistant turn NOT (budget tripped before terminal append).
-			assert.deepStrictEqual(conversation.turns.map((t) => t.role), ['user']);
+			// Budget tripped before the terminal assistant append — zero turns total.
+			assert.deepStrictEqual(conversation.turns, []);
 		});
 	});
 

--- a/unitTests/resources/models/agentLoop.test.js
+++ b/unitTests/resources/models/agentLoop.test.js
@@ -1,0 +1,518 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+// Prime module graph in the order other unit tests load it (avoids the ESM/CJS cycle
+// when transaction.ts is loaded ESM-first).
+require('#src/resources/databases');
+const { setGenerative, clearRegistry } = require('#src/resources/models/backendRegistry');
+const { Models } = require('#src/resources/models/Models');
+const { BudgetExceededError } = require('#src/resources/models/agentLoop');
+
+function makeMockWriter() {
+	const records = [];
+	return {
+		records,
+		write(record) {
+			records.push(record);
+		},
+	};
+}
+
+/**
+ * Test-only backend that returns a queued sequence of generate results. Each entry
+ * is the GenerateResult the next `generate(...)` call should resolve with. Records
+ * every (input, opts) pair so tests can assert the loop's request shape.
+ */
+class ScriptedBackend {
+	constructor(name = 'scripted') {
+		this.name = name;
+		this.responses = [];
+		this.calls = [];
+	}
+	capabilities() {
+		return { embed: false, generate: true, stream: false, tools: true, adapters: false };
+	}
+	queue(...results) {
+		for (const r of results) this.responses.push(r);
+		return this;
+	}
+	async generate(input, opts) {
+		// Snapshot the input — the loop mutates the same `messages` array across
+		// iterations, so naive reference capture would show every call as the final state.
+		const snapshot =
+			typeof input === 'string' || Array.isArray(input)
+				? input
+				: { ...input, messages: input.messages.map((m) => ({ ...m })) };
+		this.calls.push({ input: snapshot, opts });
+		if (this.responses.length === 0) {
+			throw new Error('ScriptedBackend ran out of responses');
+		}
+		const next = this.responses.shift();
+		return { status: 'completed', output: next.output, usage: next.usage };
+	}
+}
+
+function final(content) {
+	return { output: { content, finishReason: 'stop' }, usage: { promptTokens: 1, completionTokens: 1 } };
+}
+
+function toolCallRound(content, toolCalls) {
+	return {
+		output: { content, finishReason: 'tool_calls', toolCalls },
+		usage: { promptTokens: 1, completionTokens: 1 },
+	};
+}
+
+function tc(id, name, args) {
+	return { id, name, arguments: args };
+}
+
+describe("agentLoop (toolMode: 'auto')", () => {
+	let writer;
+	let models;
+	let backend;
+
+	beforeEach(() => {
+		clearRegistry();
+		writer = makeMockWriter();
+		models = new Models(writer);
+		backend = new ScriptedBackend();
+		setGenerative('default', backend);
+	});
+
+	afterEach(() => {
+		clearRegistry();
+	});
+
+	describe('terminal-first round (passthrough equivalence)', () => {
+		it('returns the single-shot result when backend emits no tool calls', async () => {
+			backend.queue(final('hello world'));
+			const result = await models.generate('hi', { toolMode: 'auto' });
+			assert.strictEqual(result.content, 'hello world');
+			assert.strictEqual(result.finishReason, 'stop');
+			assert.strictEqual(result.trace, undefined, 'trace omitted when includeToolTrace not set');
+		});
+
+		it('returns the trace when includeToolTrace is set, even on first-round terminal', async () => {
+			backend.queue(final('done'));
+			const result = await models.generate('hi', { toolMode: 'auto', includeToolTrace: true });
+			assert.deepStrictEqual(result.trace, [], 'empty trace = no tools ran');
+		});
+
+		it('outer auto call writes ZERO analytics rows; inner round writes ONE', async () => {
+			backend.queue(final('one-shot'));
+			await models.generate('hi', { toolMode: 'auto' });
+			assert.strictEqual(writer.records.length, 1, 'one row per backend round');
+			assert.strictEqual(writer.records[0].method, 'generate');
+			assert.strictEqual(writer.records[0].success, true);
+		});
+
+		it('passes toolMode: return to the inner Models.generate (prevents loop recursion)', async () => {
+			backend.queue(final('x'));
+			await models.generate('hi', { toolMode: 'auto' });
+			assert.strictEqual(backend.calls[0].opts.toolMode, 'return');
+		});
+	});
+
+	describe('serial dispatch (multi-round)', () => {
+		it('runs N rounds: tool call → result → tool call → result → final', async () => {
+			backend.queue(
+				toolCallRound('thinking', [tc('c1', 'echo', { text: 'a' })]),
+				toolCallRound('still thinking', [tc('c2', 'echo', { text: 'b' })]),
+				final('done: a + b')
+			);
+			const seen = [];
+			const result = await models.generate('start', {
+				toolMode: 'auto',
+				toolHandlers: {
+					echo: (args) => {
+						seen.push(args.text);
+						return { echoed: args.text };
+					},
+				},
+			});
+			assert.strictEqual(result.content, 'done: a + b');
+			assert.deepStrictEqual(seen, ['a', 'b']);
+			assert.strictEqual(backend.calls.length, 3);
+			assert.strictEqual(writer.records.length, 3, 'one analytics row per iteration');
+		});
+
+		it('appends assistant + tool messages onto the running message list between rounds', async () => {
+			backend.queue(
+				toolCallRound('plan', [tc('c1', 'lookup', { key: 'k1' })]),
+				final('answer')
+			);
+			await models.generate('q', {
+				toolMode: 'auto',
+				toolHandlers: { lookup: (args) => ({ key: args.key, value: 'v1' }) },
+			});
+			// First call only sees the user message.
+			assert.strictEqual(backend.calls[0].input.messages.length, 1);
+			assert.strictEqual(backend.calls[0].input.messages[0].role, 'user');
+			// Second call sees: user, assistant(tool_calls), tool(result).
+			assert.strictEqual(backend.calls[1].input.messages.length, 3);
+			assert.strictEqual(backend.calls[1].input.messages[1].role, 'assistant');
+			assert.ok(backend.calls[1].input.messages[1].toolCalls);
+			assert.strictEqual(backend.calls[1].input.messages[2].role, 'tool');
+			assert.strictEqual(backend.calls[1].input.messages[2].toolCallId, 'c1');
+		});
+
+		it('serial handlers run in order (no concurrent overlap in v1)', async () => {
+			// Two tool calls in ONE round.
+			backend.queue(
+				toolCallRound('multi', [tc('c1', 'slow', { i: 1 }), tc('c1b', 'slow', { i: 2 })]),
+				final('done')
+			);
+			const events = [];
+			await models.generate('go', {
+				toolMode: 'auto',
+				toolHandlers: {
+					slow: async (args) => {
+						events.push(`start-${args.i}`);
+						await new Promise((r) => setImmediate(r));
+						events.push(`end-${args.i}`);
+						return args.i;
+					},
+				},
+			});
+			// Serial: each handler completes before the next starts.
+			assert.deepStrictEqual(events, ['start-1', 'end-1', 'start-2', 'end-2']);
+		});
+
+		it('records the trace entries when includeToolTrace is set', async () => {
+			backend.queue(
+				toolCallRound('p', [tc('c1', 'echo', { text: 'a' })]),
+				final('done')
+			);
+			const result = await models.generate('q', {
+				toolMode: 'auto',
+				includeToolTrace: true,
+				toolHandlers: { echo: (args) => ({ echoed: args.text }) },
+			});
+			assert.strictEqual(result.trace.length, 1);
+			const entry = result.trace[0];
+			assert.strictEqual(entry.iteration, 1);
+			assert.strictEqual(entry.toolCallId, 'c1');
+			assert.strictEqual(entry.toolName, 'echo');
+			assert.deepStrictEqual(entry.arguments, { text: 'a' });
+			assert.strictEqual(JSON.parse(entry.result).echoed, 'a');
+			assert.ok(entry.durationMs >= 0);
+			assert.strictEqual(entry.truncated, undefined);
+			assert.strictEqual(entry.error, undefined);
+		});
+	});
+
+	describe('input normalization', () => {
+		it('accepts a string input', async () => {
+			backend.queue(final('out'));
+			await models.generate('hello', { toolMode: 'auto' });
+			assert.deepStrictEqual(backend.calls[0].input.messages, [{ role: 'user', content: 'hello' }]);
+		});
+
+		it('accepts a Message[] input', async () => {
+			backend.queue(final('out'));
+			const msgs = [
+				{ role: 'system', content: 'sys' },
+				{ role: 'user', content: 'q' },
+			];
+			await models.generate(msgs, { toolMode: 'auto' });
+			assert.strictEqual(backend.calls[0].input.messages.length, 2);
+			assert.notStrictEqual(backend.calls[0].input.messages, msgs, 'must copy, not alias caller array');
+		});
+
+		it('accepts a { messages, tools, system } object and threads tools + system through', async () => {
+			backend.queue(final('out'));
+			await models.generate(
+				{
+					messages: [{ role: 'user', content: 'q' }],
+					tools: [{ name: 'echo', description: 'echoes', parameters: { type: 'object' } }],
+					system: 'be helpful',
+				},
+				{ toolMode: 'auto' }
+			);
+			assert.strictEqual(backend.calls[0].input.system, 'be helpful');
+			assert.strictEqual(backend.calls[0].input.tools[0].name, 'echo');
+		});
+	});
+
+	describe('result truncation', () => {
+		it('passes small results through untouched in the trace', async () => {
+			backend.queue(
+				toolCallRound('p', [tc('c1', 'small', {})]),
+				final('done')
+			);
+			const result = await models.generate('q', {
+				toolMode: 'auto',
+				includeToolTrace: true,
+				toolHandlers: { small: () => ({ ok: true }) },
+			});
+			assert.strictEqual(result.trace[0].result, JSON.stringify({ ok: true }));
+			assert.strictEqual(result.trace[0].truncated, undefined);
+		});
+
+		it('truncates a result that exceeds toolResultMaxBytes and tags the trace entry', async () => {
+			const huge = 'x'.repeat(10_000);
+			backend.queue(
+				toolCallRound('p', [tc('c1', 'big', {})]),
+				final('done')
+			);
+			const result = await models.generate('q', {
+				toolMode: 'auto',
+				toolResultMaxBytes: 256,
+				includeToolTrace: true,
+				toolHandlers: { big: () => huge },
+			});
+			const entry = result.trace[0];
+			assert.strictEqual(entry.truncated, true);
+			assert.ok(entry.totalBytes > 256);
+			assert.ok(entry.result.includes('[truncated;'));
+			// And the model received the truncated form, not the original.
+			const messages = backend.calls[1].input.messages;
+			const toolMsg = messages[messages.length - 1];
+			assert.strictEqual(toolMsg.role, 'tool');
+			assert.ok(toolMsg.content.length <= 256 + 80 /* slack for marker */);
+			assert.ok(toolMsg.content.includes('[truncated;'));
+		});
+
+		it('handles multi-byte UTF-8 content cleanly (single-pass slice, no O(n²) trim)', async () => {
+			// CJK characters are 3 bytes in UTF-8. With a 256-byte cap, ~85 chars worth of
+			// JSON head fits before the marker. Make sure: (a) the byte cap is respected,
+			// (b) the result is valid UTF-8 even when the byte boundary splits a codepoint,
+			// (c) the trace's `totalBytes` reports the byte length, not char length.
+			const text = '漢'.repeat(10_000); // 30_000 bytes UTF-8
+			backend.queue(
+				toolCallRound('p', [tc('c1', 'cjk', {})]),
+				final('done')
+			);
+			const result = await models.generate('q', {
+				toolMode: 'auto',
+				toolResultMaxBytes: 256,
+				includeToolTrace: true,
+				toolHandlers: { cjk: () => text },
+			});
+			const entry = result.trace[0];
+			assert.strictEqual(entry.truncated, true);
+			// totalBytes counts bytes, not characters.
+			assert.ok(entry.totalBytes >= 30_000, `totalBytes=${entry.totalBytes} should be >= 30000`);
+			// Body fits inside the cap (marker overhead may push the final string slightly
+			// past in the corner where cap < markerBytes, but the body itself must stay in).
+			const bodyBytes = Buffer.byteLength(entry.result, 'utf8');
+			assert.ok(bodyBytes <= 256 + 60 /* marker overhead */, `bodyBytes=${bodyBytes}`);
+			// The decoded string must be valid UTF-8 (replacement chars are OK at the
+			// boundary, but no invalid byte sequences).
+			assert.doesNotThrow(() => Buffer.from(entry.result, 'utf8').toString('utf8'));
+		});
+	});
+
+	describe('handler errors (recover mode)', () => {
+		it('appends the error as a tool result and keeps looping', async () => {
+			backend.queue(
+				toolCallRound('p', [tc('c1', 'broken', {})]),
+				final('recovered')
+			);
+			const result = await models.generate('q', {
+				toolMode: 'auto',
+				includeToolTrace: true,
+				toolHandlers: {
+					broken: () => {
+						throw new Error('boom');
+					},
+				},
+			});
+			assert.strictEqual(result.content, 'recovered');
+			assert.strictEqual(result.trace[0].error.message, 'boom');
+			// Model saw the error envelope in the tool message.
+			const lastMsg = backend.calls[1].input.messages[backend.calls[1].input.messages.length - 1];
+			assert.strictEqual(lastMsg.role, 'tool');
+			assert.strictEqual(JSON.parse(lastMsg.content).error, 'boom');
+		});
+
+		it('recovers when serialization throws on a BigInt return value', async () => {
+			// Handlers returning raw DB rows can include BigInt — JSON.stringify throws.
+			// The loop must catch the serialization error in the same recover path it uses
+			// for handler throws, otherwise a "real" tool result crashes the whole loop.
+			backend.queue(
+				toolCallRound('p', [tc('c1', 'bigint', {})]),
+				final('recovered')
+			);
+			const result = await models.generate('q', {
+				toolMode: 'auto',
+				includeToolTrace: true,
+				toolHandlers: { bigint: () => ({ id: 123n }) },
+			});
+			assert.strictEqual(result.content, 'recovered');
+			assert.ok(result.trace[0].error, 'serialization failure must surface on the trace');
+			assert.match(result.trace[0].error.message, /BigInt/);
+		});
+
+		it('recovers when serialization throws on a circular result', async () => {
+			backend.queue(
+				toolCallRound('p', [tc('c1', 'cyc', {})]),
+				final('recovered')
+			);
+			const result = await models.generate('q', {
+				toolMode: 'auto',
+				includeToolTrace: true,
+				toolHandlers: {
+					cyc: () => {
+						const o = {};
+						o.self = o;
+						return o;
+					},
+				},
+			});
+			assert.strictEqual(result.content, 'recovered');
+			assert.ok(result.trace[0].error);
+		});
+	});
+
+	describe('trace integrity', () => {
+		it("trace's `arguments` is decoupled from in-handler mutation", async () => {
+			backend.queue(
+				toolCallRound('p', [tc('c1', 'mutator', { keep: 'as-emitted' })]),
+				final('done')
+			);
+			const result = await models.generate('q', {
+				toolMode: 'auto',
+				includeToolTrace: true,
+				toolHandlers: {
+					mutator: (args) => {
+						// Common pattern: normalize input in place.
+						args.mutated = true;
+						args.keep = 'mutated';
+						return args;
+					},
+				},
+			});
+			// The trace must show what the MODEL emitted, not the handler's mutated view.
+			assert.strictEqual(result.trace[0].arguments.mutated, undefined);
+			assert.strictEqual(result.trace[0].arguments.keep, 'as-emitted');
+		});
+	});
+
+	describe('inner backend errors', () => {
+		it('propagates a mid-loop backend throw and records the analytics row for that round', async () => {
+			backend.queue(
+				toolCallRound('p', [tc('c1', 'echo', { i: 0 })])
+				// Second round: backend throws (no queued response → ScriptedBackend rejects).
+			);
+			await assert.rejects(
+				() =>
+					models.generate('q', {
+						toolMode: 'auto',
+						toolHandlers: { echo: (args) => args },
+					}),
+				/ran out of responses/
+			);
+			// First inner round succeeded (one analytics row); second failed (second row).
+			// Both came through the single-shot path's analytics — the outer auto call
+			// writes nothing of its own.
+			assert.strictEqual(writer.records.length, 2);
+			assert.strictEqual(writer.records[0].success, true);
+			assert.strictEqual(writer.records[1].success, false);
+		});
+	});
+
+	describe('missing handler', () => {
+		it('throws ClientError(400) — nothing to dispatch to', async () => {
+			backend.queue(toolCallRound('p', [tc('c1', 'unknown', {})]));
+			await assert.rejects(
+				() => models.generate('q', { toolMode: 'auto', toolHandlers: {} }),
+				(err) => err.statusCode === 400 && /No handler registered/.test(err.message)
+			);
+		});
+	});
+
+	describe('iteration budget', () => {
+		it("trips BudgetExceededError({kind: 'iterations'}) when the model keeps calling tools", async () => {
+			// 4 rounds of tool calls — cap is 3.
+			for (let i = 0; i < 4; i++) {
+				backend.queue(toolCallRound(`r${i}`, [tc(`c${i}`, 'echo', { i })]));
+			}
+			let caught;
+			try {
+				await models.generate('q', {
+					toolMode: 'auto',
+					maxToolIterations: 3,
+					toolHandlers: { echo: (args) => args },
+				});
+			} catch (err) {
+				caught = err;
+			}
+			assert.ok(caught instanceof BudgetExceededError);
+			assert.strictEqual(caught.kind, 'iterations');
+			assert.strictEqual(caught.statusCode, 429);
+			// Trace is always attached on the budget-error path, even without includeToolTrace.
+			assert.strictEqual(caught.partialTrace.length, 3, 'one trace entry per iteration that ran');
+		});
+
+		it('default cap is 10', async () => {
+			for (let i = 0; i < 11; i++) {
+				backend.queue(toolCallRound(`r${i}`, [tc(`c${i}`, 'echo', { i })]));
+			}
+			let caught;
+			try {
+				await models.generate('q', {
+					toolMode: 'auto',
+					toolHandlers: { echo: (args) => args },
+				});
+			} catch (err) {
+				caught = err;
+			}
+			assert.ok(caught instanceof BudgetExceededError);
+			assert.strictEqual(caught.kind, 'iterations');
+			assert.strictEqual(caught.partialTrace.length, 10);
+		});
+	});
+
+	describe('gated modes (deferred to later commits)', () => {
+		it("toolArgValidation: 'strict' throws 501 at entry", async () => {
+			backend.queue(final('x'));
+			await assert.rejects(
+				() => models.generate('q', { toolMode: 'auto', toolArgValidation: 'strict' }),
+				(err) => err.statusCode === 501 && /toolArgValidation/.test(err.message)
+			);
+		});
+
+		it("toolArgValidation: 'lenient' throws 501 at entry", async () => {
+			backend.queue(final('x'));
+			await assert.rejects(
+				() => models.generate('q', { toolMode: 'auto', toolArgValidation: 'lenient' }),
+				(err) => err.statusCode === 501
+			);
+		});
+
+		it("toolErrorMode: 'abort' throws 501 at entry", async () => {
+			backend.queue(final('x'));
+			await assert.rejects(
+				() => models.generate('q', { toolMode: 'auto', toolErrorMode: 'abort' }),
+				(err) => err.statusCode === 501 && /toolErrorMode/.test(err.message)
+			);
+		});
+
+		it('maxToolTokens throws 501 at entry (commit 4)', async () => {
+			await assert.rejects(
+				() => models.generate('q', { toolMode: 'auto', maxToolTokens: 1000 }),
+				(err) => err.statusCode === 501
+			);
+		});
+
+		it('maxCostUsd throws 501 at entry (commit 4)', async () => {
+			await assert.rejects(
+				() => models.generate('q', { toolMode: 'auto', maxCostUsd: 0.1 }),
+				(err) => err.statusCode === 501
+			);
+		});
+
+		it('opts.conversation throws 501 at entry (commit 5)', async () => {
+			await assert.rejects(
+				() =>
+					models.generate('q', {
+						toolMode: 'auto',
+						conversation: { async append() {} },
+					}),
+				(err) => err.statusCode === 501 && /conversation/.test(err.message)
+			);
+		});
+	});
+});

--- a/unitTests/resources/models/agentLoop.test.js
+++ b/unitTests/resources/models/agentLoop.test.js
@@ -12,6 +12,7 @@ const {
 	_setComputeCallCostUsdForTests,
 	_resetComputeCallCostUsdForTests,
 } = require('#src/resources/models/agentLoop');
+const { logger } = require('#src/utility/logging/logger');
 
 function makeMockWriter() {
 	const records = [];
@@ -611,12 +612,12 @@ describe("agentLoop (toolMode: 'auto')", () => {
 		});
 
 		it('loopController.abort fires on exit — sibling handlers still running see the signal', async () => {
-			// One round, two parallel tool calls: 'missing' has no handler (throws on
-			// dispatch), 'slow' is in flight. After the missing-handler throw propagates
-			// out, the loop's finally aborts loopController → the slow handler's
-			// ctx.signal aborts. (Test by having the slow handler check ctx.signal in a
-			// microtask after a small delay; if cleanup didn't fire, the handler would
-			// hang.)
+			// One round, two parallel tool calls: 'missing' is DECLARED in `tools` but has
+			// no handler (a caller config bug → hard ClientError(400) on dispatch), 'slow'
+			// is in flight. After the missing-handler throw propagates out, the loop's
+			// finally aborts loopController → the slow handler's ctx.signal aborts. (Test by
+			// having the slow handler check ctx.signal in a microtask after a small delay; if
+			// cleanup didn't fire, the handler would hang.)
 			backend.queue(toolCallRound('p', [tc('c1', 'missing', {}), tc('c2', 'slow', {})]));
 			let slowSawAbort = false;
 			let slowResolver;
@@ -625,19 +626,26 @@ describe("agentLoop (toolMode: 'auto')", () => {
 			});
 			await assert.rejects(
 				() =>
-					models.generate('q', {
-						toolMode: 'auto',
-						toolHandlers: {
-							// 'missing' is intentionally absent — throws ClientError(400).
-							slow: async (_args, ctx) => {
-								await new Promise((resolve) => setImmediate(resolve));
-								slowSawAbort = ctx.signal.aborted;
-								slowResolver();
-								return null;
-							},
+					models.generate(
+						{
+							messages: [{ role: 'user', content: 'q' }],
+							// Declaring 'missing' makes the absent handler a caller config bug → hard throw.
+							tools: [{ name: 'missing', description: '', parameters: {} }],
 						},
-					}),
-				(err) => err.statusCode === 400 && /No handler registered/.test(err.message)
+						{
+							toolMode: 'auto',
+							toolHandlers: {
+								// 'missing' is intentionally absent — declared tool w/o handler throws ClientError(400).
+								slow: async (_args, ctx) => {
+									await new Promise((resolve) => setImmediate(resolve));
+									slowSawAbort = ctx.signal.aborted;
+									slowResolver();
+									return null;
+								},
+							},
+						}
+					),
+				(err) => err.statusCode === 400 && /No handler registered for declared tool/.test(err.message)
 			);
 			// Wait for the slow handler to finish (it has nothing to await on after the abort).
 			await slowFinished;
@@ -689,12 +697,77 @@ describe("agentLoop (toolMode: 'auto')", () => {
 		});
 	});
 
-	describe('missing handler', () => {
-		it('throws ClientError(400) — nothing to dispatch to', async () => {
-			backend.queue(toolCallRound('p', [tc('c1', 'unknown', {})]));
+	describe('missing handler (split policy: declared = config bug, undeclared = hallucination)', () => {
+		it('DECLARED tool with no handler throws ClientError(400) — caller config bug', async () => {
+			backend.queue(toolCallRound('p', [tc('c1', 'configured', {})]));
 			await assert.rejects(
-				() => models.generate('q', { toolMode: 'auto', toolHandlers: {} }),
-				(err) => err.statusCode === 400 && /No handler registered/.test(err.message)
+				() =>
+					models.generate(
+						{
+							messages: [{ role: 'user', content: 'q' }],
+							tools: [{ name: 'configured', description: '', parameters: {} }],
+						},
+						{ toolMode: 'auto', toolHandlers: {} }
+					),
+				(err) => err.statusCode === 400 && /No handler registered for declared tool 'configured'/.test(err.message)
+			);
+		});
+
+		it('UNDECLARED tool name recovers: feeds an "unknown tool" error back and the model continues', async () => {
+			// Round 1: model hallucinates a tool that was never declared and has no handler.
+			// Round 2: model recovers with a terminal answer. The loop must NOT throw.
+			backend.queue(toolCallRound('p', [tc('c1', 'hallucinated', {})]), final('recovered after unknown tool'));
+			const result = await models.generate('q', {
+				toolMode: 'auto',
+				includeToolTrace: true,
+				toolHandlers: {},
+			});
+			assert.strictEqual(result.content, 'recovered after unknown tool');
+			assert.strictEqual(result.trace.length, 1);
+			assert.match(result.trace[0].error.message, /Unknown tool 'hallucinated'/);
+			// The tool message fed back to the model carried the error envelope.
+			const toolMsg = backend.calls[1].input.messages.find((m) => m.role === 'tool');
+			assert.match(toolMsg.content, /Unknown tool 'hallucinated'/);
+		});
+
+		it('UNDECLARED tool under toolErrorMode:"abort" stops the loop with ToolHandlerError', async () => {
+			backend.queue(toolCallRound('p', [tc('c1', 'hallucinated', {})]));
+			await assert.rejects(
+				() => models.generate('q', { toolMode: 'auto', toolErrorMode: 'abort', toolHandlers: {} }),
+				(err) => err instanceof ToolHandlerError && /Unknown tool 'hallucinated'/.test(err.message)
+			);
+		});
+
+		it('prototype-member tool name (toString / constructor / __proto__) does NOT dispatch a built-in', async () => {
+			// A bare `handlers[name]` lookup would resolve Object.prototype.toString as a
+			// "handler" and invoke it. Each must be treated as an undeclared unknown tool.
+			for (const evil of ['toString', 'constructor', '__proto__', 'hasOwnProperty']) {
+				clearRegistry();
+				backend = new ScriptedBackend();
+				setGenerative('default', backend);
+				backend.queue(toolCallRound('p', [tc('c1', evil, {})]), final('ok'));
+				const result = await models.generate('q', {
+					toolMode: 'auto',
+					includeToolTrace: true,
+					toolHandlers: {},
+				});
+				assert.strictEqual(result.content, 'ok', `${evil} must not dispatch a built-in`);
+				assert.strictEqual(result.trace[0].error.message, `Unknown tool '${evil}': no such tool is available`);
+			}
+		});
+
+		it('own, NON-callable handler value for a declared tool is treated as missing (hard throw)', async () => {
+			backend.queue(toolCallRound('p', [tc('c1', 'broken', {})]));
+			await assert.rejects(
+				() =>
+					models.generate(
+						{
+							messages: [{ role: 'user', content: 'q' }],
+							tools: [{ name: 'broken', description: '', parameters: {} }],
+						},
+						{ toolMode: 'auto', toolHandlers: { broken: 'not a function' } }
+					),
+				(err) => err.statusCode === 400 && /No handler registered for declared tool 'broken'/.test(err.message)
 			);
 		});
 	});
@@ -1385,6 +1458,152 @@ describe("agentLoop (toolMode: 'auto')", () => {
 				},
 			});
 			assert.strictEqual(result.content, 'recovered');
+		});
+	});
+
+	describe('resilience hardening (no silent failures, consistent side-effects)', () => {
+		function makeConversationSpy() {
+			const turns = [];
+			return {
+				turns,
+				async append(turn) {
+					turns.push(turn);
+				},
+			};
+		}
+
+		// Spy on logger.warn for the warn-once assertions, restoring the original after.
+		let warnings;
+		let origWarn;
+		beforeEach(() => {
+			warnings = [];
+			origWarn = logger.warn;
+			logger.warn = (...args) => warnings.push(args.join(' '));
+		});
+		afterEach(() => {
+			logger.warn = origWarn;
+		});
+
+		describe('budget warn-once when backend reports no usage', () => {
+			it('maxToolTokens set but no usage → warns once, does NOT trip, loop completes', async () => {
+				// Two tool rounds + terminal, all with usage: undefined.
+				backend.queue(
+					{ output: { content: 'r1', finishReason: 'tool_calls', toolCalls: [tc('c1', 'echo', { i: 1 })] } },
+					{ output: { content: 'r2', finishReason: 'tool_calls', toolCalls: [tc('c2', 'echo', { i: 2 })] } },
+					{ output: { content: 'final', finishReason: 'stop' } }
+				);
+				const result = await models.generate('q', {
+					toolMode: 'auto',
+					maxToolTokens: 1, // would trip instantly IF usage were measurable
+					toolHandlers: { echo: (a) => a },
+				});
+				assert.strictEqual(result.content, 'final', 'unmeasurable budget must not falsely trip');
+				const budgetWarns = warnings.filter((w) => /budget is unenforceable/.test(w));
+				assert.strictEqual(budgetWarns.length, 1, 'warns exactly once across the run, not per-round');
+			});
+
+			it('maxToolTokens still trips normally when the backend DOES report usage', async () => {
+				backend.queue(toolCallRound('r1', [tc('c1', 'echo', { i: 1 })]), final('unreached'));
+				await assert.rejects(
+					() => models.generate('q', { toolMode: 'auto', maxToolTokens: 1, toolHandlers: { echo: (a) => a } }),
+					(err) => err instanceof BudgetExceededError && err.kind === 'tokens'
+				);
+				assert.strictEqual(warnings.filter((w) => /budget is unenforceable/.test(w)).length, 0);
+			});
+		});
+
+		describe('abort-mode does not persist tool turns the model never consumed', () => {
+			it('sync: toolErrorMode:"abort" throws BEFORE the failed tool turn reaches the conversation sink', async () => {
+				backend.queue(toolCallRound('thinking', [tc('c1', 'boom', {})]));
+				const conversation = makeConversationSpy();
+				await assert.rejects(
+					() =>
+						models.generate('q', {
+							toolMode: 'auto',
+							toolErrorMode: 'abort',
+							conversation,
+							toolHandlers: {
+								boom: () => {
+									throw new Error('handler failed');
+								},
+							},
+						}),
+					(err) => err instanceof ToolHandlerError
+				);
+				// The assistant tool-call turn is legitimately persisted (the model DID emit it),
+				// but the recover-style tool-error turn must NOT be — abort returns the error.
+				assert.deepStrictEqual(
+					conversation.turns.map((t) => t.role),
+					['assistant'],
+					'no tool-role turn should be appended on the abort path'
+				);
+			});
+
+			it('recover mode (default) DOES persist the tool-error turn so the model can react', async () => {
+				backend.queue(toolCallRound('thinking', [tc('c1', 'boom', {})]), final('handled'));
+				const conversation = makeConversationSpy();
+				await models.generate('q', {
+					toolMode: 'auto',
+					conversation,
+					toolHandlers: {
+						boom: () => {
+							throw new Error('handler failed');
+						},
+					},
+				});
+				assert.deepStrictEqual(
+					conversation.turns.map((t) => t.role),
+					['assistant', 'tool', 'assistant']
+				);
+			});
+		});
+
+		describe('streaming: terminal turn persisted before the terminal chunk is delivered', () => {
+			it('conversation has the final assistant turn even if the consumer breaks on the finish chunk', async () => {
+				backend.queueStream([{ deltaContent: 'the answer' }, { finishReason: 'stop' }]);
+				const conversation = makeConversationSpy();
+				for await (const chunk of models.generateStream('q', { toolMode: 'auto', conversation })) {
+					if (chunk.finishReason) break; // stop the instant the terminal chunk arrives
+				}
+				assert.deepStrictEqual(
+					conversation.turns.map((t) => t.role),
+					['assistant'],
+					'terminal assistant turn must be persisted before the finish chunk is yielded'
+				);
+				assert.strictEqual(conversation.turns[0].content, 'the answer');
+			});
+
+			it('the terminal finishReason is delivered on its own final chunk (never co-located with content)', async () => {
+				backend.queueStream([{ deltaContent: 'hi', finishReason: 'stop' }]);
+				const chunks = [];
+				for await (const c of models.generateStream('q', { toolMode: 'auto' })) {
+					chunks.push(c);
+				}
+				// Content delta and the terminal finishReason arrive as separate chunks.
+				assert.strictEqual(chunks.at(-1).finishReason, 'stop');
+				assert.strictEqual(chunks.at(-1).deltaContent, undefined);
+				assert.strictEqual(chunks.map((c) => c.deltaContent ?? '').join(''), 'hi');
+				assert.strictEqual(chunks.filter((c) => c.finishReason).length, 1, 'exactly one terminal chunk');
+			});
+		});
+
+		describe('streaming: incomplete assembled tool call is surfaced, not silently dropped', () => {
+			it('a tool-call delta that never delivers a name is recorded in the trace as IncompleteToolCall', async () => {
+				// id arrives but the name fragment never does (truncated stream); the round
+				// has no other content/calls, so the loop terminates — but must surface the drop.
+				backend.queueStream([
+					{ deltaToolCalls: [{ id: 'c1', arguments: { partial: true } }] },
+					{ finishReason: 'stop' },
+				]);
+				const chunks = [];
+				for await (const c of models.generateStream('q', { toolMode: 'auto', includeToolTrace: true })) {
+					chunks.push(c);
+				}
+				assert.strictEqual(warnings.filter((w) => /dropping incomplete streamed tool call/.test(w)).length, 1);
+				// generateStream doesn't return a trace object to the caller, but the warn is the
+				// observable signal; assert the loop still terminated cleanly with a stop.
+				assert.strictEqual(chunks.at(-1).finishReason, 'stop');
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Adds `toolMode: 'auto'` to `scope.models.generate` / `.generateStream` — an in-process agent loop that, when the model emits tool calls, dispatches them via caller-supplied handlers and feeds results back in until the model produces a terminal answer. Closes HarperFast/harper#851 (the loop-engine sub-issue); part of HarperFast/harper#612 (approved by Kris; all 10 review notes folded into the body before implementation). Remaining HarperFast/harper#612 pieces are tracked in sub-issues HarperFast/harper#852 / HarperFast/harper#853 / HarperFast/harper#854 / HarperFast/harper#850. Unblocks PR HarperFast/harper#839 (Kris's built-in Agent component): its **autoApprove** path collapses to a single `generate({toolMode:'auto'})` call once this ships. The destructive-tool **approval-gated** path stays on `toolMode:'return'` by design — interposing an operator decision between the model's tool request and execution is exactly what `'return'` is for, whereas `'auto'` runs to completion without interposition.

## What's in

- **`resources/models/types.ts`** — `GenerateOpts` gains the auto-loop knobs (`maxToolIterations`, `maxToolTokens`, `maxCostUsd`, `toolParallelism`, `toolResultMaxBytes`, `toolArgValidation`, `toolErrorMode`, `includeToolTrace`, `toolHandlers`, `conversation`). New exports: `ToolHandler<T>`, `ToolHandlerContext`, `ConversationAppender`, `ConversationTurn`, `ToolTraceEntry`. `GenerateResult` gains `usage?: TokenUsage` and `trace?: ToolTraceEntry[]`.

- **`resources/models/agentLoop.ts`** (new) — `runAgentLoop` + `runAgentLoopStream`. Loop-level `AbortController` composed with caller signal via `AbortSignal.any`. Default-parallel `dispatchToolCalls` (`Promise.all` + `.catch(noop)` for concurrent-rejection safety). Shared `runSingleToolCall` helper handles serialize / truncate / recover for both serial and parallel paths. `BudgetExceededError extends ClientError(429)`; `ToolHandlerError extends ServerError` with status-mirroring from the cause. `mergeToolCallDelta` for id-keyed streaming assembly.

- **`resources/models/Models.ts`** — `generate` + `generateStream` branch on `opts.toolMode === 'auto'` to delegate to the loop. `generate` single-shot path propagates `result.usage` onto the returned output so callers can read cumulative tokens without re-querying analytics. Existing `'return'` paths unchanged.

- **`unitTests/resources/models/agentLoop.test.js`** (new) — `ScriptedBackend` helper + 70+ tests across terminal-first passthrough, multi-round serial / parallel dispatch, input normalization, trace integrity, result truncation (ASCII + CJK), recover-mode handler errors, BigInt + circular serialization recover, missing handler, iteration budget, abort propagation (caller-pre-abort, caller-mid-handler, last-iteration, sibling cleanup), token + cost budgets, `toolErrorMode: 'abort'`, streaming auto path (multi-chunk assembly, multi-id parallel, degenerate-stream guard, backend-tail-flush recovery), and conversation hook (sync + stream, no-input-echo, empty-terminal skip).

## Behavior contracts

- **Analytics:** outer auto call writes ZERO `hdb_model_calls` rows. Each inner iteration writes its own row via the single-shot path. Verified by tests.
- **Conversation hook:** appends ONLY new turns the loop produces (assistant + tool). Caller owns turn 0. `await`ed inline for ordering + back-pressure.
- **Trace:** populated on `GenerateResult.trace` when `includeToolTrace`; always populated on `BudgetExceededError.partialTrace` and `ToolHandlerError.partialTrace` regardless of `includeToolTrace`.
- **`Promise.all` + concurrent rejections:** each sibling promise gets a `.catch(() => {})` so multiple-missing-handlers and multiple-aborted-handlers don't crash under `--unhandled-rejections=throw`.

## Out of scope / known follow-ups

Still throw `501` at loop entry, documented inline:

- **`toolArgValidation: 'strict' | 'lenient'`** — Harper is Joi-internal today and passes JSON Schema through to backends; adopting Ajv is a separate decision. Default `'none'` is wired.
- **`maxToolTokens` / `maxCostUsd` on `generateStream`** — `GenerateChunk` doesn't expose `usage` in v1. Iteration budget still applies. Wiring streaming budgets needs the chunk type + per-backend final-chunk handling extended; deferred.

Other deferred work tracked in HarperFast/harper#612's body: registry-driven dispatch (replaces `opts.toolHandlers`) lands with HarperFast/harper#615 / HarperFast/harper#618 / HarperFast/harper#622; cost stub (`computeCallCostUsd` returns 0 today; the cap mechanism is wired and proven by tests with an injected non-zero function); rolling PR HarperFast/harper#839's manual loop onto `generate({toolMode:'auto'})` belongs in HarperFast/harper-pro#676's repo footprint.

## Pre-merge review

- **5 per-commit default-mode reviews** (Gemini + Harper adjudication). Findings landed before each commit (serialize-outside-recover-catch on commit 2, abort-swallow on commit 3, `Promise.all` concurrent rejections on commit 4, degenerate-stream on commit 5, etc.).
- **1 thorough-mode review** against the cumulative diff before flipping to ready. 5 significant findings: conversation echo bug, `ToolHandler` generic, orphan-tool-calls on backend tail-flush, `serializeToolResult` perf, conversation throw policy. All addressed in `131a6e57`.

## Test plan

- [ ] CI: build (`npm run build`), unit (`npm run test:unit:resources`), lint (`npm run lint`)
- [ ] Manual integration: `node --test integrationTests/server/openai-backend.test.ts` with `OPENAI_API_KEY` exported (covers the auto loop against a real backend; skips otherwise per existing posture)
- [ ] Sanity check Kris's `agent/loop.ts` in PR HarperFast/harper#839 still collapses cleanly to `generate({toolMode:'auto'})` (separate follow-up PR after this lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


