### PR TITLE
chore(format): fix prettier drift in Models.test.js

### DIFF
--- a/unitTests/resources/models/Models.test.js
+++ b/unitTests/resources/models/Models.test.js
@@ -8,7 +8,12 @@ require('#src/resources/databases');
 const { contextStorage } = require('#src/resources/transaction');
 const { setEmbedding, setGenerative, clearRegistry } = require('#src/resources/models/backendRegistry');
 const { TestBackend } = require('#src/resources/models/TestBackend');
-const { Models, ModelCapabilityError, ModelPendingNotSupportedError, models: modelsSingleton } = require('#src/resources/models/Models');
+const {
+	Models,
+	ModelCapabilityError,
+	ModelPendingNotSupportedError,
+	models: modelsSingleton,
+} = require('#src/resources/models/Models');
 
 function makeMockWriter() {
 	const records = [];


### PR DESCRIPTION
## Summary

`prettier --check .` is red on `main` for a single file — `unitTests/resources/models/Models.test.js`. A long `require(...)` destructure exceeds the configured print width and needs to wrap. This reformats it.

Formatting-only — no logic change (6 insertions, 1 deletion: the import line wrapped across multiple lines).

## Why a standalone PR

The drift is on `main` itself, so it surfaces as a **Format Check failure on the merge ref of any open PR** that CI re-evaluates against current `main` (e.g. #848). Fixing it here clears the repo-wide check once and unblocks those PRs on rebase/merge, rather than each feature branch carrying an unrelated formatting commit.

## Test plan

- [x] `prettier --check .` passes clean repo-wide after the change
- [ ] CI: Format Check green

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
