### PR TITLE
fix(analytics): recordAction ignores invalid metric values instead of throwing

### DIFF
--- a/resources/analytics/write.ts
+++ b/resources/analytics/write.ts
@@ -40,6 +40,7 @@ let activeActions = new Map<string, Action>();
 let analyticsEnabled = envGet(CONFIG_PARAMS.ANALYTICS_AGGREGATEPERIOD) > -1;
 let analyticsReadOnlyChecked = false;
 let sendAnalyticsTimeout: NodeJS.Timeout;
+let warnedInvalidMetricValue = false;
 
 // Check read-only mode lazily to avoid circular dependency at module load time
 function checkAnalyticsEnabled(): boolean {
@@ -115,6 +116,15 @@ function recordNewAction(key: string, value: Value, metric?: string, path?: stri
  */
 export function recordAction(value: Value, metric: string, path?: string, method?: string, type?: string) {
 	if (!checkAnalyticsEnabled()) return;
+	const valueType = typeof value;
+	if (valueType !== 'number' && valueType !== 'boolean' && valueType !== 'function') {
+		// metrics are best-effort; never throw on a value we can't aggregate
+		if (!warnedInvalidMetricValue) {
+			warnedInvalidMetricValue = true;
+			log.warn?.(`Ignoring analytics value of type ${valueType} for metric ${metric}`);
+		}
+		return;
+	}
 	// TODO: May want to consider nested paths, as they may yield faster hashing of (fixed) strings that hashing concatenated strings
 	let key = metric + (path ? '-' + path : '');
 	if (method !== undefined) key += '-' + method;

--- a/unitTests/resources/analytics/write.test.js
+++ b/unitTests/resources/analytics/write.test.js
@@ -1,6 +1,13 @@
 const chai = require('chai');
 const expect = chai.expect;
-const { diffResourceUsage, calculateCPUUtilization, getDirectorySizeAsync } = require('#src/resources/analytics/write');
+const assert = require('node:assert/strict');
+const {
+	diffResourceUsage,
+	calculateCPUUtilization,
+	getDirectorySizeAsync,
+	recordAction,
+	setAnalyticsEnabled,
+} = require('#src/resources/analytics/write');
 const { writeFile, mkdtemp, rm, mkdir } = require('node:fs/promises');
 const { join } = require('node:path');
 const { tmpdir } = require('node:os');
@@ -113,5 +120,18 @@ describe('calculateCPUUtilization', () => {
 		const cpuUtilization = calculateCPUUtilization(ru, 60000);
 
 		expect(cpuUtilization).to.equal(0.5);
+	});
+});
+
+describe('recordAction does not throw on invalid value types', () => {
+	before(() => setAnalyticsEnabled(true));
+	after(() => setAnalyticsEnabled(false));
+
+	it('no-ops on an object value instead of throwing', () => {
+		assert.doesNotThrow(() => recordAction({}, 'test-invalid-object'));
+	});
+
+	it('no-ops on an undefined value instead of throwing', () => {
+		assert.doesNotThrow(() => recordAction(undefined, 'test-invalid-undefined'));
 	});
 });


### PR DESCRIPTION
## Summary

- `recordAction` now checks the value type up front and returns early instead of throwing when the value is not a number, boolean, or function
- Warns once (module-level flag) so a bad value is visible without flooding the log
- Adds a regression test that `recordAction({})` and `recordAction(undefined)` no-op instead of throwing

## Context

On a v5 node receiving replication from a v4 (4.7.32) peer, the replication receive handler calls `recordAction(data, 'bytes-received', ...)` with `data` from a `COMMITTED_UPDATE` message. From v4 that value is an object or undefined, and `recordAction` (through `recordNewAction`/`recordExistingAction`) throws `TypeError: Invalid metric value type ...` on anything that is not a number, boolean, or function. The outer `onWSMessage` catch swallowed the throw, but the handler aborted before its confirmation step ran, so the replication handshake stalled, the websocket closed with code 1006, and the node reconnected and requested a full table copy. The next `COMMITTED_UPDATE` threw again, repeating the loop every 60 to 90 seconds.

Metrics are best-effort and must never crash the caller, especially the replication receive path. This makes `recordAction` skip values it cannot aggregate instead of throwing, so the handler always completes. The call-site that passed the wrong value (a confirmation status instead of a byte count) is fixed separately in harper-pro.

Closes #858