### PR TITLE
fix(databases): rebind table store after in-place engine migration

### DIFF
--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -546,6 +546,9 @@ function initStores(
 		}
 		// if the table has already been defined, use that class, don't create a new one
 		let table = tables[tableName];
+		// unless its store was migrated to a different engine (e.g. LMDB to RocksDB on startup)
+		const recreateForEngineChange =
+			!!table && (table as any).primaryStore?.rootStore instanceof RocksDatabase !== rootStore instanceof RocksDatabase;
 		let indices = {},
 			existingAttributes = [];
 		let tableId;
@@ -558,7 +561,7 @@ function initStores(
 		const sealed = primaryAttribute.sealed;
 		const splitSegments = primaryAttribute.splitSegments;
 		const replicate = primaryAttribute.replicate;
-		if (table) {
+		if (table && !recreateForEngineChange) {
 			indices = table.indices;
 			existingAttributes = table.attributes;
 			table.schemaVersion++;
@@ -644,7 +647,7 @@ function initStores(
 				}
 			}
 		}
-		if (table) {
+		if (table && !recreateForEngineChange) {
 			if (attributesUpdated) {
 				table.schemaVersion++;
 				table.updatedAttributes();
@@ -691,12 +694,6 @@ export function resetDatabases() {
 		if (store.needsDeletion && !path.endsWith('system.mdb')) {
 			store.close();
 			lmdbDatabaseEnvs.delete(path);
-			// Remove the database entry so that the next getDatabases() call re-creates it
-			// with the current storage engine (e.g. RocksDB after migrateOnStart).
-			if (store.databaseName && databases[store.databaseName]) {
-				delete databases[store.databaseName];
-				databaseEventsEmitter.emit('dropDatabase', store.databaseName);
-			}
 		}
 	}
 	return databases;

--- a/unitTests/resources/schemaMigrationFragility.test.js
+++ b/unitTests/resources/schemaMigrationFragility.test.js
@@ -25,8 +25,13 @@
 require('../testUtils');
 const assert = require('node:assert/strict');
 const { setupTestDBPath } = require('../testUtils');
-const { table, resetDatabases } = require('#src/resources/databases');
+const { table, resetDatabases, getDatabases } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const fs = require('fs-extra');
+const path = require('node:path');
+const env = require('#src/utility/environment/environmentManager');
+const terms = require('#src/utility/hdbTerms');
+const { RocksDatabase } = require('@harperfast/rocksdb-js');
 
 async function collect(iter) {
 	const out = [];
@@ -302,5 +307,68 @@ describe('schema-migration fragility: stale `changed` reused after re-fetch unde
 			!redundant,
 			'F1 fingerprint: second table() call triggered a redundant runIndexing — stale `changed` reused after re-fetch under lock.'
 		);
+	});
+});
+
+describe('schema-migration fragility: stale store reused after LMDB to RocksDB engine migration (F4)', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+
+	const DB = 'F4EngineRebind';
+	const TABLE = 'Widget';
+	const testRoot = path.resolve(__dirname, '../envDir/f4EngineRebind');
+	const dbDir = path.join(testRoot, terms.DATABASES_DIR_NAME);
+	const attributes = [{ name: 'id', isPrimaryKey: true }, { name: 'name' }];
+	const originalEngine = process.env.HARPER_STORAGE_ENGINE;
+	let preReloadStore;
+
+	before(async () => {
+		setMainIsWorker(true);
+		await fs.remove(testRoot);
+		await fs.mkdirp(dbDir);
+		env.setProperty(terms.HDB_SETTINGS_NAMES.HDB_ROOT_KEY, testRoot);
+		env.setProperty(terms.CONFIG_PARAMS.ROOTPATH, testRoot);
+		env.setProperty(terms.CONFIG_PARAMS.STORAGE_PATH, dbDir);
+		env.setProperty(terms.CONFIG_PARAMS.DATABASES, {});
+
+		process.env.HARPER_STORAGE_ENGINE = 'lmdb';
+		resetDatabases();
+		const lmdbTable = table({ table: TABLE, database: DB, attributes });
+		await lmdbTable.put({ id: 'k', name: 'from-lmdb' });
+		const staleTable = getDatabases()[DB][TABLE];
+
+		// post-migration state: RocksDB on disk, stale LMDB table still in the registry
+		process.env.HARPER_STORAGE_ENGINE = 'rocksdb';
+		delete getDatabases()[DB];
+		await fs.remove(path.join(dbDir, `${DB}.mdb`));
+		await fs.remove(path.join(dbDir, `${DB}.mdb-lock`));
+		const rocksTable = table({ table: TABLE, database: DB, attributes });
+		await rocksTable.put({ id: 'k', name: 'from-rocks' });
+		getDatabases()[DB][TABLE] = staleTable;
+		preReloadStore = getDatabases()[DB][TABLE].primaryStore;
+
+		resetDatabases();
+	});
+
+	after(async () => {
+		if (originalEngine === undefined) delete process.env.HARPER_STORAGE_ENGINE;
+		else process.env.HARPER_STORAGE_ENGINE = originalEngine;
+		await fs.remove(testRoot);
+	});
+
+	it('starts from a stale LMDB-backed table while the data on disk is RocksDB', () => {
+		assert.ok(!(preReloadStore.rootStore instanceof RocksDatabase), 'pre-reload table should be LMDB-backed');
+		assert.ok(preReloadStore.path.endsWith('.mdb'), `pre-reload path should be .mdb, got ${preReloadStore.path}`);
+	});
+
+	it('rebinds the registry table to the RocksDB store on reload', () => {
+		const reloaded = getDatabases()[DB]?.[TABLE];
+		assert.ok(reloaded, `${DB}.${TABLE} should still be registered after reload`);
+		assert.ok(
+			reloaded.primaryStore.rootStore instanceof RocksDatabase,
+			'primaryStore should be backed by RocksDatabase'
+		);
+		const p = reloaded.primaryStore.path;
+		assert.ok(!p.endsWith('.mdb'), `primaryStore.path should be a RocksDB directory, got ${p}`);
+		assert.ok(fs.statSync(p).isDirectory(), `${p} should be a directory`);
 	});
 });


### PR DESCRIPTION
## Summary

- Recreate a table's store when its engine no longer matches what's on disk (LMDB vs RocksDB), instead of reusing the stale entry from the per-thread registry.
- Stop deleting the database entry in `resetDatabases()`, which was also tearing down replication subscriptions via the `dropDatabase` event.

## Context

After an in-place v4 to v5 `migrateOnStart`, the `.mdb` files are moved to `backup/` and RocksDB directories are created in their place. The per-thread `databases` registry still holds the old table whose `primaryStore.path` points at the now-missing `.mdb` file. Anything that reads that path fails, e.g. DB size/volume analytics throw `ENOENT` on the `.mdb` every aggregation cycle.

The previous attempt to fix this in `resetDatabases()` deleted the database entry and emitted `dropDatabase` so the next `getDatabases()` would rebuild it. That also dropped the database's replication subscriptions, so it wasn't safe.

This change instead detects the engine mismatch in `initStores`: if an already-defined table's `primaryStore.rootStore` is a `RocksDatabase` but the current `rootStore` is not (or vice versa), the table is rebuilt against the current engine rather than reused. `resetDatabases()` now only closes the migrated store and clears its env entry, leaving the registry rebind to `initStores`.

## Test

`unitTests/resources/schemaMigrationFragility.test.js` adds an F4 case that:
- creates an LMDB-backed table and writes a row,
- swaps the engine to RocksDB on disk while leaving the stale LMDB table in the registry (the post-migration state),
- calls `resetDatabases()` and asserts the reloaded table's `primaryStore` is now backed by `RocksDatabase` and its path is a directory, not a `.mdb` file.

Fails on `main`, passes with this change. Skipped under `HARPER_STORAGE_ENGINE=lmdb`.
