### PR TITLE
fix(analytics): continue instead of return so later dbs still get merics

### DIFF
--- a/resources/analytics/write.ts
+++ b/resources/analytics/write.ts
@@ -335,7 +335,7 @@ function storeDBSizeMetrics(analyticsTable: Table, databases: Databases) {
 			const [firstTable] = Object.values(tables);
 			const dbAuditSize = firstTable?.getAuditSize();
 			if (!dbAuditSize) {
-				return;
+				continue;
 			}
 			let metric;
 			if (firstTable.primaryStore instanceof RocksDatabase) {
@@ -380,7 +380,7 @@ function storeVolumeMetrics(analyticsTable: Table, databases: Databases) {
 			const [firstTable] = Object.values(tables);
 			const storageStats = firstTable?.getStorageStats();
 			if (!storageStats) {
-				return;
+				continue;
 			}
 			const metric = {
 				metric: METRIC.STORAGE_VOLUME,

--- a/resources/analytics/write.ts
+++ b/resources/analytics/write.ts
@@ -334,7 +334,7 @@ function storeDBSizeMetrics(analyticsTable: Table, databases: Databases) {
 		try {
 			const [firstTable] = Object.values(tables);
 			const dbAuditSize = firstTable?.getAuditSize();
-			if (!dbAuditSize) {
+			if (dbAuditSize == null) {
 				continue;
 			}
 			let metric;


### PR DESCRIPTION
## Summary

- Use `continue` instead of `return` when a database has no audit size or storage stats, so metrics for later databases still get recorded.

## Context

`storeDBSizeMetrics` and `storeVolumeMetrics` loop over all databases. When one had a falsy audit size (or no storage stats), the early `return` exited the whole loop, so every database after it was silently skipped that cycle. Switching to `continue` skips only the empty database and keeps going.
