### PR TITLE
fix(migration): preserve records with file-backed blobs during v4→v5 migration

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -38,6 +38,8 @@ When `migrateOnStart` opens a source LMDB primary store to read records out for 
 
 Harper's normal `databases.ts` path already does this (search for `dbiInit.compression = primaryKeyAttribute.compression`); the migration path in `bin/copyDb.ts` has to match.
 
+The same source-dbi open has a second non-obvious requirement: assign `sourceDbi.encoder.rootStore = sourceRootStore` for the primary store. The primary dbi decodes through a `RecordEncoder`, and decoding a record that holds a file-backed blob reference resolves that reference against `rootStore` (it locates the blob file). With `rootStore` unset, the `Blob` msgpackr extension throws `No store specified, cannot load blob from storage`; `RecordEncoder.decode` swallows the error and yields `null`, and `copyDbToRocks` then skips the `null` value — so every record with a file-backed blob is silently dropped from the migration. The runtime path gets `rootStore` from `handleLocalTimeForGets`; the migration path opens the source dbi raw and must set it explicitly (issue #857).
+
 ## Schema migration and `runIndexing` internals (`databases.ts`)
 
 When `table()` is called with an attribute newly marked `indexed: true` (or with any change that requires re-building the secondary index), `runIndexing` is launched asynchronously and `Table.indexingOperation` is set to its promise. While running:

--- a/bin/copyDb.ts
+++ b/bin/copyDb.ts
@@ -376,7 +376,7 @@ export async function migrateOnStart() {
 	}
 }
 
-async function copyDbToRocks(sourceRootStore, sourceDatabase: string, targetPath: string) {
+export async function copyDbToRocks(sourceRootStore, sourceDatabase: string, targetPath: string) {
 	console.log(`Migrating database ${sourceDatabase} to RocksDB at ${targetPath}`);
 	const sourceDbisDb = sourceRootStore.dbisDb;
 
@@ -413,6 +413,11 @@ async function copyDbToRocks(sourceRootStore, sourceDatabase: string, targetPath
 			const dbiInit = new OpenDBIObject(!isPrimary, isPrimary);
 			dbiInit.compression = attribute.compression;
 			const sourceDbi = sourceRootStore.openDB(key, dbiInit);
+			// The primary dbi uses a RecordEncoder, whose decode resolves file-backed blob references
+			// against `rootStore`. Without it, decoding any record that holds a blob throws "No store
+			// specified, cannot load blob from storage", the error is swallowed (record decodes to null),
+			// and the record is silently dropped from the migration (HarperFast/harper#857).
+			if (isPrimary && sourceDbi.encoder) sourceDbi.encoder.rootStore = sourceRootStore;
 
 			let targetDbi;
 			if (!isPrimary) {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"test:unit": "mocha",
 		"test:unit:main": "mocha \"unitTests/**/*test.*js\" --exclude \"unitTests/apiTests/**/*\" --exclude \"unitTests/dataLayer/harperBridge/**/*\" --exclude \"unitTests/resources/**/*\"",
 		"test:unit:all": "npm run test:unit:main && npm run test:unit:apitests && npm run test:unit:resources && npm run test:unit:lmdb",
-		"test:unit:lmdb": "HARPER_STORAGE_ENGINE=lmdb npm run test:unit:resources && HARPER_STORAGE_ENGINE=lmdb npm run test:unit:apitests",
+		"test:unit:lmdb": "HARPER_STORAGE_ENGINE=lmdb npm run test:unit:resources && HARPER_STORAGE_ENGINE=lmdb npm run test:unit:apitests && HARPER_STORAGE_ENGINE=lmdb npm run test:unit:bin",
 		"test:unit:components": "mocha \"unitTests/components/**/*.js\"",
 		"test:unit:resources": "mocha \"unitTests/resources/**/*.js\"",
 		"test:unit:bin": "mocha \"unitTests/bin/**/*.js\"",

--- a/unitTests/bin/blobMigration.test.js
+++ b/unitTests/bin/blobMigration.test.js
@@ -1,0 +1,84 @@
+// Regression test for HarperFast/harper#857.
+//
+// copyDbToRocks (the v4 LMDB -> v5 RocksDB migration) opens the source LMDB primary dbi with a
+// RecordEncoder but never assigns `rootStore` to that encoder. Decoding a source record that holds a
+// file-backed blob reference therefore runs with no store context, the Blob msgpackr extension throws
+// "No store specified, cannot load blob from storage", RecordEncoder.decode swallows the error and
+// yields null, and the record is silently skipped during migration -- so every record with a
+// file-backed blob is lost on upgrade.
+const fs = require('fs-extra');
+const assert = require('assert');
+const path = require('path');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const { get: envGet } = require('#src/utility/environment/environmentManager');
+const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
+const { getFilePathForBlob } = require('#src/resources/blob');
+const { randomBytes } = require('crypto');
+
+// Migration only applies to LMDB sources, so this only runs under the lmdb engine.
+describe('Blob migration LMDB -> RocksDB (#857)', function () {
+	// Match the engine resolution in resources/databases.ts (env var wins over config).
+	if ((process.env.HARPER_STORAGE_ENGINE || envGet(CONFIG_PARAMS.STORAGE_ENGINE)) !== 'lmdb') return;
+	const { setupTestDBPath } = require('../testUtils');
+	const copyDB = require('#src/bin/copyDb');
+	const { RocksDatabase } = require('@harperfast/rocksdb-js');
+
+	let BlobMig;
+	let rootPath;
+	let targetPath;
+	let fileBackedBlobPath;
+	const blobBytes = randomBytes(25000); // > FILE_STORAGE_THRESHOLD so the blob is stored as a file reference
+	const plainBytes = randomBytes(100); // < threshold so it is inlined in the record (control)
+
+	before(async function () {
+		rootPath = setupTestDBPath();
+		setMainIsWorker(true);
+		BlobMig = table({
+			table: 'BlobMig',
+			database: 'test',
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'blob', type: 'Blob' },
+			],
+		});
+		const fileBackedBlob = await createBlob(blobBytes);
+		await BlobMig.put({ id: 1, blob: fileBackedBlob }); // file-backed blob (stored as a separate file)
+		await BlobMig.put({ id: 2, blob: await createBlob(plainBytes) }); // inlined blob
+		await BlobMig.put({ id: 3, blob: null }); // no blob (control)
+		await fileBackedBlob.written; // the blob file is written asynchronously; wait so the on-disk content assertion is deterministic
+		// Blob file paths are derived from <hdbBasePath>/blobs/<databaseName>, independent of the storage
+		// engine, so the migrated RocksDB record reuses this exact file and reads the same content.
+		fileBackedBlobPath = getFilePathForBlob(fileBackedBlob);
+
+		targetPath = path.join(rootPath, 'rocks-migrated', 'test');
+		await fs.remove(targetPath);
+		await copyDB.copyDbToRocks(BlobMig.primaryStore.rootStore, 'test', targetPath);
+	});
+
+	after(async function () {
+		await fs.remove(path.join(rootPath, 'rocks-migrated'));
+	});
+
+	it('migrates records that contain a file-backed blob instead of dropping them', function () {
+		const primaryCF = RocksDatabase.open(targetPath, {
+			name: 'BlobMig/',
+			sharedStructuresKey: Symbol.for('structures'),
+		});
+		try {
+			const keys = [...primaryCF.getKeys()].filter((k) => typeof k !== 'symbol');
+			assert(keys.includes(1), `record 1 (file-backed blob) must survive migration; migrated keys: ${keys}`);
+			assert(keys.includes(2), `record 2 (inlined blob) must survive migration; migrated keys: ${keys}`);
+			assert(keys.includes(3), `record 3 (no blob) must survive migration; migrated keys: ${keys}`);
+		} finally {
+			primaryCF.close();
+		}
+	});
+
+	it('preserves the file-backed blob content the migrated record points at', function () {
+		assert(fs.existsSync(fileBackedBlobPath), `blob file ${fileBackedBlobPath} must still exist after migration`);
+		const HEADER_SIZE = 8; // blob files are prefixed with an 8-byte size/type header
+		const stored = fs.readFileSync(fileBackedBlobPath).subarray(HEADER_SIZE);
+		assert(stored.equals(blobBytes), 'migrated blob content must match the original bytes');
+	});
+});

--- a/unitTests/resources/models/Models.test.js
+++ b/unitTests/resources/models/Models.test.js
@@ -8,7 +8,12 @@ require('#src/resources/databases');
 const { contextStorage } = require('#src/resources/transaction');
 const { setEmbedding, setGenerative, clearRegistry } = require('#src/resources/models/backendRegistry');
 const { TestBackend } = require('#src/resources/models/TestBackend');
-const { Models, ModelCapabilityError, ModelPendingNotSupportedError, models: modelsSingleton } = require('#src/resources/models/Models');
+const {
+	Models,
+	ModelCapabilityError,
+	ModelPendingNotSupportedError,
+	models: modelsSingleton,
+} = require('#src/resources/models/Models');
 
 function makeMockWriter() {
 	const records = [];


### PR DESCRIPTION
## Summary

During the v4 (LMDB) → v5 (RocksDB) startup migration, `copyDbToRocks` opened each source LMDB primary dbi with a `RecordEncoder` but never set its `rootStore`. Decoding any record holding a **file-backed** blob reference then ran with no store context, so the `Blob` msgpackr extension threw `No store specified, cannot load blob from storage`. `RecordEncoder.decode` swallows that error and returns `null`, and `copyDbToRocks` skips `null` values — so **every record containing a file-backed blob was silently dropped on upgrade** (small/inlined blobs and blob-less records were unaffected).

Fix: set `sourceDbi.encoder.rootStore = sourceRootStore` for the primary source dbi so blob references resolve against the source store during migration (the runtime read path gets this via `handleLocalTimeForGets`; the migration opens the source dbi raw).

Resolves [#857](https://github.com/HarperFast/harper/issues/857).

## Changes
- `bin/copyDb.ts`: set `rootStore` on the source primary encoder; export `copyDbToRocks` so the regression test can drive it directly.
- `unitTests/bin/blobMigration.test.js`: new regression test (LMDB engine) — migrates a file-backed blob, an inlined blob, and a no-blob record, asserts all survive and the blob content is intact.
- `DESIGN.md`: documents the `rootStore` requirement next to the existing source-dbi `compression` note.

## Where to look
- The one-line behavioral change is `if (isPrimary && sourceDbi.encoder) sourceDbi.encoder.rootStore = sourceRootStore;`. Confirm `rootStore` is the correct store for resolving source blob references (it mirrors what `handleLocalTimeForGets` assigns at runtime).
- Scope check: only the primary dbi decodes records (and thus blobs); index dbis copy ordered-binary values and the LMDB→LMDB `copyDb` compaction copies raw bytes (`decoder`/`encoder` nulled), so neither needs this. The fix is intentionally guarded to `isPrimary`.

## Notes
- Generated by Claude (Opus 4.7). An outside-model review (Codex) found no code-level concerns.
- Open item for the reviewer: the unit test verifies the migrated record survives and the on-disk blob file content matches (source and target share the `<hdbBasePath>/blobs/<databaseName>` path and the same `fileId` is re-emitted). It does **not** decode the migrated record back through a v5 RocksDB store to confirm the reference resolves end-to-end — that full read-through belongs in the `integrationTests/upgrade` path. Flagging in case you'd prefer a stronger unit assertion.