### PR TITLE
chore(deps): remove @datadog/pprof from core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
 			"dependencies": {
 				"@aws-sdk/client-s3": "^3.1012.0",
 				"@aws-sdk/lib-storage": "3.1045.0",
-				"@datadog/pprof": "^5.11.1",
 				"@endo/static-module-record": "^1.1.2",
 				"@fastify/autoload": "^6.3.1",
 				"@fastify/compress": "^8.3.1",
@@ -1614,8 +1613,10 @@
 		},
 		"node_modules/@datadog/pprof": {
 			"version": "5.14.1",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"node-gyp-build": "<4.0",
 				"pprof-format": "^2.2.1",
@@ -11909,7 +11910,9 @@
 		},
 		"node_modules/node-gyp-build": {
 			"version": "3.9.0",
+			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"node-gyp-build": "bin.js",
 				"node-gyp-build-optional": "optional.js",
@@ -12850,7 +12853,9 @@
 		},
 		"node_modules/pprof-format": {
 			"version": "2.2.1",
-			"license": "MIT"
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
@@ -14141,7 +14146,9 @@
 		},
 		"node_modules/source-map": {
 			"version": "0.7.6",
+			"dev": true,
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"engines": {
 				"node": ">= 12"
 			}

--- a/package.json
+++ b/package.json
@@ -160,7 +160,6 @@
 	"dependencies": {
 		"@aws-sdk/client-s3": "^3.1012.0",
 		"@aws-sdk/lib-storage": "3.1045.0",
-		"@datadog/pprof": "^5.11.1",
 		"@endo/static-module-record": "^1.1.2",
 		"@fastify/autoload": "^6.3.1",
 		"@fastify/compress": "^8.3.1",


### PR DESCRIPTION
## Summary
- `@datadog/pprof` is only consumed by `analytics/profile.ts`, which lives in **harper-pro**, not in core. Core has no direct `import`/`require` of it (only stale comments in test utils that guard against its native-build errors).
- Removes `@datadog/pprof` from core's direct `dependencies` in `package.json` and the top-level lockfile entry.
- It remains in `package-lock.json` only as a transitive **dev/peer** dependency of the published `harper` package, which is expected.

## Why
- pprof is being managed as a harper-pro-only dependency. Keeping it in core caused the `core:sync` job in harper-pro to overwrite/downgrade harper-pro's pinned pprof version on every sync.

## Companion change
- Paired with a harper-pro PR (#250) that updates `build-tools/sync-core.sh` to preserve harper-pro's pinned `@datadog/pprof` version across the core dependency sync.

## Test plan
- [ ] CI green (core builds and tests without the direct pprof dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)