### PR TITLE
fix(RecordEncoder): retain blob files still referenced by the new record on update

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -18,7 +18,14 @@ import {
 } from './auditStore.ts';
 import * as harperLogger from '../utility/logging/harper_logger.ts';
 import './blob.ts';
-import { blobsWereEncoded, decodeFromDatabase, deleteBlobsInObject, encodeBlobsWithFilePath } from './blob.ts';
+import {
+	blobsWereEncoded,
+	decodeFromDatabase,
+	deleteBlobsInObject,
+	encodeBlobsWithFilePath,
+	findBlobsInObject,
+	getFileId,
+} from './blob.ts';
 import { getThisNodeId } from './nodeIdMapping.ts';
 import { recordAction } from './analytics/write.ts';
 import { RocksDatabase } from '@harperfast/rocksdb-js';
@@ -614,8 +621,19 @@ export function recordUpdater(store, tableId, auditStore) {
 			// we use resolveRecord outside of transaction, so must explicitly make it conditional
 			if (resolveRecord) putOptions.ifVersion = ifVersion = existingEntry?.version ?? null;
 			if (existingEntry && existingEntry.value && type !== 'message' && existingEntry.metadataFlags & HAS_BLOBS) {
-				// delete the old blobs
-				deleteBlobsInObject(existingEntry.value);
+				// Delete the prior row's blob files — except any the new record still references.
+				// Without the retention check, updating an unrelated attribute on a row that
+				// carries a file-backed blob unlinks the blob ~deletionDelay ms later, leaving
+				// the new (otherwise valid) row pointing at a missing file. See HarperFast/harper#641
+				// (deployment tracking) for the production repro.
+				let retainedFileIds: Set<string> | undefined;
+				if (record) {
+					findBlobsInObject(record, (blob) => {
+						const fileId = getFileId(blob);
+						if (fileId) (retainedFileIds ??= new Set()).add(fileId);
+					});
+				}
+				deleteBlobsInObject(existingEntry.value, retainedFileIds);
 			}
 			let result: Promise<void>;
 			if (record !== undefined) {

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -970,12 +970,26 @@ export function decodeFromDatabase<T>(callback: () => T, rootStore: RootDatabase
 }
 
 /**
- * Delete blobs in an object, recursively searching for blobs
+ * Delete blobs in an object, recursively searching for blobs. When `retainedFileIds`
+ * is supplied, blobs whose fileId is in that set are skipped — used by the update path
+ * to avoid deleting a blob the new record still references.
+ *
+ * Background: `RecordEncoder` calls this with the *prior* row's value on every update.
+ * If a caller updates an unrelated attribute on a row that still carries a file-backed
+ * blob, the unfiltered delete unlinks the blob file ~`deletionDelay` ms later, even
+ * though the new row still references the same fileId. The retainedFileIds set
+ * prevents that data loss.
+ *
  * @param object
+ * @param retainedFileIds optional set of fileIds the caller wants to keep on disk
  */
-export function deleteBlobsInObject(object) {
-	findBlobsInObject(object, (object) => {
-		deleteBlob(object);
+export function deleteBlobsInObject(object: any, retainedFileIds?: Set<string>): void {
+	findBlobsInObject(object, (blob) => {
+		if (retainedFileIds?.size) {
+			const fileId = getFileId(blob);
+			if (fileId && retainedFileIds.has(fileId)) return;
+		}
+		deleteBlob(blob);
 	});
 }
 

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -229,6 +229,62 @@ describe('Blob test', () => {
 		await delay(50); // wait for deletion
 		assert(!existsSync(filePath));
 	});
+	it('updating an unrelated attribute does not unlink a still-referenced blob', async () => {
+		// Regression: RecordEncoder used to call deleteBlobsInObject(existingEntry.value)
+		// unconditionally on every update, scheduling unlink() on every prior blob —
+		// even ones the new record still references. With the retention check, a put
+		// that carries the same blob (same fileId) leaves the file intact.
+		//
+		// This is the pattern the deployment-tracking recorder hits: ingestPayload
+		// stores payload_blob, then several subsequent puts update phase / event_log
+		// while keeping payload_blob on the row. Without retention the blob is unlinked
+		// mid-deploy and replication fails with ENOENT.
+		setAuditRetention(10);
+		setDeletionDelay(0);
+		const RetentionTest = table({
+			table: 'BlobRetentionTest',
+			database: 'test',
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'blob', type: 'Blob' },
+				{ name: 'phase', type: 'String' },
+			],
+		});
+		const payload = randomBytes(20000); // > FILE_STORAGE_THRESHOLD so it goes file-backed
+		const blob = await createBlob(payload);
+		await RetentionTest.put({ id: 100, blob, phase: 'pending' });
+		const filePath = getFilePathForBlob(blob);
+		assert(filePath, 'expected file-backed blob');
+		assert(existsSync(filePath), 'blob file should exist after initial put');
+
+		// Update an unrelated attribute, keeping the same blob instance on the record.
+		// Pre-fix: this unlinked the file ~deletionDelay ms later.
+		await RetentionTest.put({ id: 100, blob, phase: 'extracting' });
+		await delay(50);
+		assert(existsSync(filePath), 'blob file must survive update that retains it');
+
+		// Several more updates simulating the multi-flush pattern.
+		for (const phase of ['installing', 'loading', 'replicating', 'success']) {
+			await RetentionTest.put({ id: 100, blob, phase });
+			await delay(20);
+			assert(existsSync(filePath), `blob file must survive phase=${phase} update`);
+		}
+
+		// Also exercise the get → mutate → put path so retention is proven with a
+		// freshly-decoded blob (different JS instance, same fileId), not only the
+		// in-memory blob we created above.
+		const fetched = await RetentionTest.get(100);
+		assert(fetched.blob, 'fetched row should still carry the blob attribute');
+		await RetentionTest.put({ id: 100, blob: fetched.blob, phase: 'after-roundtrip' });
+		await delay(50);
+		assert(existsSync(filePath), 'blob file must survive update via a freshly-decoded blob');
+
+		// Now explicitly drop the blob — file should get cleaned up as before.
+		await RetentionTest.put({ id: 100, blob: null, phase: 'gone' });
+		await delay(50);
+		assert(!existsSync(filePath), 'blob file should be unlinked when the new record no longer references it');
+		setDeletionDelay(500); // restore the default
+	});
 	it('slowly create a blob and save it before it is done', async () => {
 		let testString = 'this is a test string'.repeat(256);
 		let expectedResults = '';


### PR DESCRIPTION
## Summary

- `RecordEncoder` historically called `deleteBlobsInObject(existingEntry.value)` unconditionally on every update of a row that previously carried blobs.
- `deleteBlob` schedules `unlink()` ~`deletionDelay` ms later (default 500ms). If the new record carries the *same* `FileBackedBlob` (same `fileId`), the file gets unlinked after the put and the new row points at a missing path.
- Fix: `deleteBlobsInObject` now accepts an optional `retainedFileIds: Set<string>`; the encoder collects the new record's blob fileIds and threads them through. Blobs in the retained set are skipped.

## Why this matters — staging repro

[#641 deployment tracking](https://github.com/HarperFast/harper/issues/641): `DeploymentRecorder` issues many sequential puts on the same `hdb_deployment` row while keeping `payload_blob` attached (initial create → `ingestPayload` → phase transitions → per-peer `recordPeer` → `finish`). For payloads above `FILE_STORAGE_THRESHOLD` (8 KiB), the very first follow-up put schedules an `unlink` on the just-written file. Replication's `sendBlobs` then opens the file, gets ENOENT, and forwards an error chunk to the peer. The peer surfaces `Error in blob: ENOENT ... for record <id> from <origin>` and its `deploy_component` fails.

Reproduced live on the symphony-https 2-node staging cluster with a 171 MiB component tarball — both nodes had empty `blobs/system/0/0/` directories despite the row claiming `payload_blob_present: true`.

The bug is not deploy-specific. Any flow that updates a row carrying a file-backed blob without rewriting the blob attribute hits this — `description` field change next to a stored attachment, periodic timestamp bumps on a record with an embedded image, etc.

## Test plan

Added `unitTests/resources/blob.test.js` → `'updating an unrelated attribute does not unlink a still-referenced blob'`. The test:

- [x] Creates a record with a `>FILE_STORAGE_THRESHOLD` file-backed blob.
- [x] Performs the multi-update pattern (phase = pending → extracting → installing → loading → replicating → success), asserting the file survives each one.
- [x] Round-trips via `get` and `put`s the freshly-decoded blob, asserting retention across decoder instances (not just same JS object).
- [x] Explicitly nulls the blob and asserts the file *is* cleaned up — proves the retention set doesn't leak files when the new record genuinely drops the blob.

Without the fix, the test fails at the first follow-up put with `blob file must survive update that retains it` — exactly the production failure mode.

All 23 tests in `unitTests/resources/blob.test.js` pass. Lint + format clean. Cross-model review (codex) found no blocking issues; only feedback was the round-trip-via-decoded-blob test which is included.

## Performance

The extra cost is one in-memory recursive scan of the new record's tree, gated on `existingEntry.metadataFlags & HAS_BLOBS` (so untouched for the typical no-blobs path). The pre-existing scan of the old record is unchanged. No new I/O.

🤖 Generated by Claude