### PR TITLE
[MCP] v1 CLI + E2E + PR-1 follow-ups (consolidated: #621, #623)

### DIFF
--- a/bin/harper.ts
+++ b/bin/harper.ts
@@ -27,6 +27,7 @@ install                         - Install harperdb
 <api-operation> <param>=<value> - Run an API operation and return result to the CLI, not all operations are supported
 login [target] [username]       - Login to a remote or local Harper instance
 logout [target]                 - Logout from Harper and clear saved JWT
+mcp [subcommand]                - MCP stdio bridge / print-config / doctor (see 'harper mcp help')
 register                        - Register harperdb
 renew-certs                     - Generate a new set of self-signed certificates
 restart                         - Restart the harperdb background process
@@ -94,6 +95,12 @@ async function harper() {
 			const { logout } = require('./logout');
 			return logout(target);
 		}
+		case SERVICE_ACTIONS_ENUM.MCP: {
+			const { runMcpCli } = require('./mcp');
+			const code = await runMcpCli(process.argv.slice(3));
+			process.exit(code);
+		}
+		// eslint-disable-next-line no-fallthrough
 		case SERVICE_ACTIONS_ENUM.RENEWCERTS:
 			return require('../security/keys')
 				.renewSelfSigned()

--- a/bin/mcp/client.ts
+++ b/bin/mcp/client.ts
@@ -1,0 +1,340 @@
+/**
+ * Streamable HTTP MCP client over stdio. Implements the MCP rev 2025-06-18
+ * transport from the client side: each line on stdin is a JSON-RPC frame,
+ * POSTed to the server's `/mcp` endpoint; the response (JSON or SSE) is
+ * parsed and emitted to stdout as line-delimited JSON-RPC. After the
+ * `initialize` handshake completes, a long-lived GET request opens the
+ * server-push SSE channel and forwards each notification to stdout.
+ *
+ * Sits between an MCP host (Claude Desktop, Cursor, Zed) and a running
+ * Harper instance. The host treats this as a stdio-transport MCP server;
+ * Harper sees a Streamable HTTP client. v1 keeps it simple — no
+ * `Last-Event-ID` resumability, no multi-process session coordination.
+ */
+import * as http from 'node:http';
+import * as https from 'node:https';
+import * as readline from 'node:readline';
+import { URL } from 'node:url';
+import type { McpCliOptions } from './options.ts';
+
+interface HttpOptions {
+	hostname?: string;
+	port?: number | string;
+	protocol: 'http:' | 'https:';
+	socketPath?: string;
+	rejectUnauthorized: boolean;
+	authHeader?: string;
+}
+
+interface PostResult {
+	statusCode: number;
+	contentType: string;
+	headers: http.IncomingHttpHeaders;
+	bodyText: string; // for application/json
+	sse?: AsyncIterable<SseFrame>;
+}
+
+interface SseFrame {
+	event?: string;
+	data: string;
+	id?: string;
+}
+
+const SESSION_HEADER = 'mcp-session-id';
+const PROTOCOL_HEADER = 'mcp-protocol-version';
+
+export interface BridgeOptions {
+	connection: HttpOptions;
+	mountPath: string;
+	stdin?: NodeJS.ReadableStream;
+	stdout?: NodeJS.WritableStream;
+	stderr?: NodeJS.WritableStream;
+}
+
+/**
+ * Run the bridge until stdin closes (host disconnects) or the GET stream
+ * errors. Returns a promise that resolves on graceful shutdown.
+ */
+export async function runBridge(opts: BridgeOptions): Promise<void> {
+	const stdin = opts.stdin ?? process.stdin;
+	const stdout = opts.stdout ?? process.stdout;
+	const stderr = opts.stderr ?? process.stderr;
+	const log = (msg: string): void => {
+		stderr.write(`harper mcp: ${msg}\n`);
+	};
+
+	let sessionId: string | undefined;
+	let protocolVersion: string | undefined;
+	let getController: AbortController | undefined;
+
+	const rl = readline.createInterface({ input: stdin, crlfDelay: Infinity });
+	const writeFrame = (frame: object): void => {
+		stdout.write(JSON.stringify(frame) + '\n');
+	};
+
+	// stdin lines → POST /mcp
+	const stdinDone: Promise<void> = (async () => {
+		for await (const line of rl) {
+			const trimmed = line.trim();
+			if (!trimmed) continue;
+			let message: unknown;
+			try {
+				message = JSON.parse(trimmed);
+			} catch (err) {
+				log(`stdin line is not valid JSON, ignoring: ${(err as Error).message}`);
+				continue;
+			}
+			try {
+				const result = await postMessage(opts.connection, opts.mountPath, message, sessionId, protocolVersion);
+				// Capture session id from initialize response.
+				const newSid = headerString(result.headers, SESSION_HEADER);
+				if (newSid && !sessionId) {
+					sessionId = newSid;
+					// If this is an initialize response, capture the protocol version
+					// the server picked, then open the GET stream.
+					const parsed = safeParse(result.bodyText);
+					if (parsed && typeof parsed === 'object' && 'result' in (parsed as Record<string, unknown>)) {
+						const r = (parsed as { result?: { protocolVersion?: unknown } }).result;
+						if (r && typeof r.protocolVersion === 'string') protocolVersion = r.protocolVersion;
+					}
+					getController = openGetStream(opts.connection, opts.mountPath, sessionId, protocolVersion, writeFrame, log);
+				}
+				if (result.sse) {
+					// Streaming POST response: each `message` event maps to a JSON-RPC frame.
+					for await (const frame of result.sse) {
+						if (frame.event && frame.event !== 'message') continue;
+						const parsed = safeParse(frame.data);
+						if (parsed) writeFrame(parsed as object);
+					}
+				} else if (result.bodyText) {
+					const parsed = safeParse(result.bodyText);
+					if (parsed) writeFrame(parsed as object);
+				}
+			} catch (err) {
+				log(`POST failed: ${(err as Error).message}`);
+				// Best-effort: emit a JSON-RPC error keyed to the original id so the
+				// host doesn't hang waiting for a response.
+				const id = (message as { id?: unknown })?.id ?? null;
+				writeFrame({
+					jsonrpc: '2.0',
+					id,
+					error: { code: -32603, message: (err as Error).message },
+				});
+			}
+		}
+	})();
+
+	await stdinDone;
+	getController?.abort();
+}
+
+function openGetStream(
+	connection: HttpOptions,
+	mountPath: string,
+	sessionId: string,
+	protocolVersion: string | undefined,
+	writeFrame: (frame: object) => void,
+	log: (msg: string) => void
+): AbortController {
+	const controller = new AbortController();
+	(async () => {
+		try {
+			const { req, res } = await openRequest(connection, mountPath, 'GET', {
+				accept: 'text/event-stream',
+				[SESSION_HEADER]: sessionId,
+				...(protocolVersion ? { [PROTOCOL_HEADER]: protocolVersion } : {}),
+			});
+			controller.signal.addEventListener('abort', () => {
+				req.destroy();
+			});
+			if (res.statusCode !== 200) {
+				log(`GET /mcp returned ${res.statusCode}; server-push notifications will not arrive`);
+				res.resume();
+				return;
+			}
+			for await (const frame of parseSseStream(res)) {
+				if (frame.event && frame.event !== 'message') continue;
+				const parsed = safeParse(frame.data);
+				if (parsed) writeFrame(parsed as object);
+			}
+		} catch (err) {
+			if ((err as { code?: string }).code === 'ABORT_ERR') return;
+			log(`GET stream error: ${(err as Error).message}`);
+		}
+	})();
+	return controller;
+}
+
+async function postMessage(
+	connection: HttpOptions,
+	mountPath: string,
+	body: unknown,
+	sessionId: string | undefined,
+	protocolVersion: string | undefined
+): Promise<PostResult> {
+	const headers: Record<string, string> = {
+		'content-type': 'application/json',
+		'accept': 'application/json, text/event-stream',
+	};
+	if (sessionId) headers[SESSION_HEADER] = sessionId;
+	if (protocolVersion) headers[PROTOCOL_HEADER] = protocolVersion;
+	const { req, res } = await openRequest(connection, mountPath, 'POST', headers, JSON.stringify(body));
+	const contentType = (res.headers['content-type'] ?? '').toString();
+	if (contentType.startsWith('text/event-stream')) {
+		return {
+			statusCode: res.statusCode ?? 0,
+			contentType,
+			headers: res.headers,
+			bodyText: '',
+			sse: parseSseStream(res),
+		};
+	}
+	const bodyText = await collectBody(res);
+	req.destroy();
+	return { statusCode: res.statusCode ?? 0, contentType, headers: res.headers, bodyText };
+}
+
+interface OpenedRequest {
+	req: http.ClientRequest;
+	res: http.IncomingMessage;
+}
+
+function openRequest(
+	connection: HttpOptions,
+	mountPath: string,
+	method: 'GET' | 'POST',
+	headers: Record<string, string>,
+	body?: string
+): Promise<OpenedRequest> {
+	return new Promise((resolve, reject) => {
+		const isHttps = connection.protocol === 'https:';
+		const lib = isHttps ? https : http;
+		const reqHeaders: Record<string, string> = { ...headers };
+		if (connection.authHeader) reqHeaders.authorization = connection.authHeader;
+		const reqOptions: http.RequestOptions = {
+			method,
+			path: mountPath,
+			headers: reqHeaders,
+		};
+		if (connection.socketPath) {
+			reqOptions.socketPath = connection.socketPath;
+		} else {
+			reqOptions.hostname = connection.hostname;
+			reqOptions.port = connection.port;
+		}
+		if (isHttps) {
+			(reqOptions as https.RequestOptions).rejectUnauthorized = connection.rejectUnauthorized;
+		}
+		const req = lib.request(reqOptions, (res) => {
+			resolve({ req, res });
+		});
+		req.on('error', (err) => reject(err));
+		if (body !== undefined) req.write(body);
+		req.end();
+	});
+}
+
+async function collectBody(res: http.IncomingMessage): Promise<string> {
+	const chunks: Buffer[] = [];
+	for await (const chunk of res) {
+		chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk);
+	}
+	return Buffer.concat(chunks).toString('utf8');
+}
+
+/**
+ * Minimal SSE stream parser per WHATWG (server-sent events). MCP uses only
+ * the `event`, `data`, and `id` fields; we ignore `retry` and comments.
+ * Multi-line `data:` blocks are joined with `\n`.
+ */
+async function* parseSseStream(stream: NodeJS.ReadableStream): AsyncIterable<SseFrame> {
+	let buffer = '';
+	for await (const chunk of stream) {
+		buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+		let idx: number;
+		while ((idx = buffer.indexOf('\n\n')) !== -1) {
+			const raw = buffer.slice(0, idx);
+			buffer = buffer.slice(idx + 2);
+			const frame = parseSseFrame(raw);
+			if (frame) yield frame;
+		}
+	}
+	if (buffer.trim().length > 0) {
+		const frame = parseSseFrame(buffer);
+		if (frame) yield frame;
+	}
+}
+
+function parseSseFrame(raw: string): SseFrame | null {
+	const lines = raw.split(/\r?\n/);
+	let event: string | undefined;
+	let dataLines: string[] = [];
+	let id: string | undefined;
+	for (const line of lines) {
+		if (!line || line.startsWith(':')) continue;
+		const colon = line.indexOf(':');
+		const field = colon === -1 ? line : line.slice(0, colon);
+		let value = colon === -1 ? '' : line.slice(colon + 1);
+		if (value.startsWith(' ')) value = value.slice(1);
+		if (field === 'event') event = value;
+		else if (field === 'data') dataLines.push(value);
+		else if (field === 'id') id = value;
+	}
+	if (dataLines.length === 0) return null;
+	return { event, data: dataLines.join('\n'), id };
+}
+
+function headerString(headers: http.IncomingHttpHeaders, key: string): string | undefined {
+	const v = headers[key.toLowerCase()];
+	if (Array.isArray(v)) return v[0];
+	return v;
+}
+
+function safeParse(text: string): unknown {
+	try {
+		return JSON.parse(text);
+	} catch {
+		return undefined;
+	}
+}
+
+/** Resolve `--target` / UDS path + creds → HttpOptions. */
+export function resolveConnection(opts: McpCliOptions): HttpOptions {
+	// `--target` wins. Else fall back to local UDS via the operationsApi
+	// domain socket — same path cliOperations uses.
+	if (opts.target) {
+		let parsed: URL;
+		try {
+			parsed = new URL(opts.target);
+		} catch {
+			parsed = new URL(`https://${opts.target}`);
+		}
+		const proto = parsed.protocol === 'http:' ? 'http:' : 'https:';
+		const authHeader = computeAuthHeader(opts, parsed);
+		return {
+			protocol: proto,
+			hostname: parsed.hostname,
+			port: parsed.port || (proto === 'https:' ? 443 : 80),
+			rejectUnauthorized: opts.rejectUnauthorized,
+			authHeader,
+		};
+	}
+	// UDS path resolution mirrors bin/cliOperations.ts:150.
+	const { getConfigPath } = require('../../config/configUtils');
+	const terms = require('../../utility/hdbTerms');
+	const socketPath = getConfigPath(terms.CONFIG_PARAMS.OPERATIONSAPI_NETWORK_DOMAINSOCKET);
+	return {
+		protocol: 'http:',
+		socketPath,
+		rejectUnauthorized: true,
+		authHeader: undefined,
+	};
+}
+
+function computeAuthHeader(opts: McpCliOptions, parsed: URL): string | undefined {
+	if (opts.bearer) return `Bearer ${opts.bearer}`;
+	const u = opts.username ?? parsed.username;
+	const p = opts.password ?? parsed.password;
+	if (u) return `Basic ${Buffer.from(`${u}:${p ?? ''}`).toString('base64')}`;
+	return undefined;
+}

--- a/bin/mcp/client.ts
+++ b/bin/mcp/client.ts
@@ -327,10 +327,18 @@ function safeParse(text: string): unknown {
 	}
 }
 
-/** Resolve `--target` / UDS path + creds → HttpOptions. */
+/**
+ * Resolve `--target` / UDS path + creds → HttpOptions.
+ *
+ * UDS-mode caveat: only the **operations** profile is reachable via the
+ * local Unix Domain Socket. The application profile is mounted on the
+ * application HTTP server (the same listener that serves your REST
+ * endpoints), which doesn't expose a UDS in v1. Selecting
+ * `--profile application` without `--target` is a user error — we throw
+ * here rather than silently routing to the operations UDS (which would
+ * misleadingly return the operations tool list under super_user auth).
+ */
 export function resolveConnection(opts: McpCliOptions): HttpOptions {
-	// `--target` wins. Else fall back to local UDS via the operationsApi
-	// domain socket — same path cliOperations uses.
 	if (opts.target) {
 		let parsed: URL;
 		try {
@@ -347,6 +355,13 @@ export function resolveConnection(opts: McpCliOptions): HttpOptions {
 			rejectUnauthorized: opts.rejectUnauthorized,
 			authHeader,
 		};
+	}
+	if (opts.profile === 'application') {
+		throw new Error(
+			'harper mcp: --profile application requires --target https://<host>:<port>. ' +
+				'The application MCP endpoint is mounted on the application HTTP server, which ' +
+				'does not expose a local UDS in v1.'
+		);
 	}
 	// UDS path resolution mirrors bin/cliOperations.ts:150.
 	const { getConfigPath } = require('../../config/configUtils');

--- a/bin/mcp/client.ts
+++ b/bin/mcp/client.ts
@@ -14,8 +14,14 @@
 import * as http from 'node:http';
 import * as https from 'node:https';
 import * as readline from 'node:readline';
+import { StringDecoder } from 'node:string_decoder';
 import { URL } from 'node:url';
+import { loadCredentials, normalizeTarget } from '../cliCredentials.ts';
 import type { McpCliOptions } from './options.ts';
+
+function isJwtish(token: string | undefined): token is string {
+	return typeof token === 'string' && token.split('.').length === 3;
+}
 
 interface HttpOptions {
 	hostname?: string;
@@ -124,8 +130,11 @@ export async function runBridge(opts: BridgeOptions): Promise<void> {
 		}
 	})();
 
-	await stdinDone;
-	getController?.abort();
+	try {
+		await stdinDone;
+	} finally {
+		getController?.abort();
+	}
 }
 
 function openGetStream(
@@ -139,14 +148,21 @@ function openGetStream(
 	const controller = new AbortController();
 	(async () => {
 		try {
-			const { req, res } = await openRequest(connection, mountPath, 'GET', {
-				accept: 'text/event-stream',
-				[SESSION_HEADER]: sessionId,
-				...(protocolVersion ? { [PROTOCOL_HEADER]: protocolVersion } : {}),
-			});
-			controller.signal.addEventListener('abort', () => {
-				req.destroy();
-			});
+			// Pass `signal` straight into the underlying http.request so an
+			// abort fired before/during connect-handshake terminates cleanly —
+			// adding the listener post-await would miss that race.
+			const { res } = await openRequest(
+				connection,
+				mountPath,
+				'GET',
+				{
+					accept: 'text/event-stream',
+					[SESSION_HEADER]: sessionId,
+					...(protocolVersion ? { [PROTOCOL_HEADER]: protocolVersion } : {}),
+				},
+				undefined,
+				controller.signal
+			);
 			if (res.statusCode !== 200) {
 				log(`GET /mcp returned ${res.statusCode}; server-push notifications will not arrive`);
 				res.resume();
@@ -204,7 +220,8 @@ function openRequest(
 	mountPath: string,
 	method: 'GET' | 'POST',
 	headers: Record<string, string>,
-	body?: string
+	body?: string,
+	signal?: AbortSignal
 ): Promise<OpenedRequest> {
 	return new Promise((resolve, reject) => {
 		const isHttps = connection.protocol === 'https:';
@@ -215,6 +232,7 @@ function openRequest(
 			method,
 			path: mountPath,
 			headers: reqHeaders,
+			signal,
 		};
 		if (connection.socketPath) {
 			reqOptions.socketPath = connection.socketPath;
@@ -246,11 +264,20 @@ async function collectBody(res: http.IncomingMessage): Promise<string> {
  * Minimal SSE stream parser per WHATWG (server-sent events). MCP uses only
  * the `event`, `data`, and `id` fields; we ignore `retry` and comments.
  * Multi-line `data:` blocks are joined with `\n`.
+ *
+ * Two correctness details:
+ *   - `StringDecoder` preserves multi-byte UTF-8 sequences that straddle
+ *     chunk boundaries — naive `chunk.toString('utf8')` would corrupt
+ *     them.
+ *   - Strip `\r` so the `\n\n` event delimiter matches whether the server
+ *     emits LF or CRLF line endings (HTTP/SSE often uses CRLF).
  */
 async function* parseSseStream(stream: NodeJS.ReadableStream): AsyncIterable<SseFrame> {
 	let buffer = '';
+	const decoder = new StringDecoder('utf8');
 	for await (const chunk of stream) {
-		buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+		const text = typeof chunk === 'string' ? chunk : decoder.write(chunk);
+		buffer += text.replace(/\r/g, '');
 		let idx: number;
 		while ((idx = buffer.indexOf('\n\n')) !== -1) {
 			const raw = buffer.slice(0, idx);
@@ -259,6 +286,8 @@ async function* parseSseStream(stream: NodeJS.ReadableStream): AsyncIterable<Sse
 			if (frame) yield frame;
 		}
 	}
+	const tail = decoder.end();
+	if (tail) buffer += tail.replace(/\r/g, '');
 	if (buffer.trim().length > 0) {
 		const frame = parseSseFrame(buffer);
 		if (frame) yield frame;
@@ -331,10 +360,33 @@ export function resolveConnection(opts: McpCliOptions): HttpOptions {
 	};
 }
 
+/**
+ * Precedence (highest first):
+ *   1. --bearer <token>
+ *   2. --username + --password
+ *   3. URL embedded user/pass (https://user:pw@host)
+ *   4. Saved JWT from `~/.harperdb/credentials.json` for the resolved target
+ *      (populated by `harper login` — same flow `bin/cliOperations.ts` uses).
+ *
+ * Returning undefined here means "no creds in scope"; the request goes out
+ * unauthenticated and the server gates accordingly.
+ */
 function computeAuthHeader(opts: McpCliOptions, parsed: URL): string | undefined {
 	if (opts.bearer) return `Bearer ${opts.bearer}`;
 	const u = opts.username ?? parsed.username;
 	const p = opts.password ?? parsed.password;
 	if (u) return `Basic ${Buffer.from(`${u}:${p ?? ''}`).toString('base64')}`;
+	try {
+		const all = loadCredentials();
+		// Same lookup key shape `harper login` / cliOperations writes/reads:
+		// `normalizeTarget(<user-supplied URL>)`.
+		const lookup = normalizeTarget(opts.target!);
+		const tokens = all.targets?.[lookup];
+		if (tokens?.operation_token && isJwtish(tokens.operation_token)) {
+			return `Bearer ${tokens.operation_token}`;
+		}
+	} catch {
+		// Missing / unreadable credentials file is non-fatal — fall through to anonymous.
+	}
 	return undefined;
 }

--- a/bin/mcp/doctor.ts
+++ b/bin/mcp/doctor.ts
@@ -1,0 +1,189 @@
+/**
+ * `harper mcp doctor` — quick connectivity + handshake smoke check.
+ *
+ * Steps:
+ *   1. Resolve connection (UDS or network).
+ *   2. POST an `initialize` request.
+ *   3. Read the response, capture Mcp-Session-Id.
+ *   4. POST a `tools/list` and confirm a JSON-RPC result comes back.
+ *   5. DELETE the session (if allowed) for cleanup.
+ *
+ * Each step prints a line to stdout (one line = one OK/FAIL). Exit code
+ * is 0 on full success, 1 if any step fails.
+ */
+import * as http from 'node:http';
+import * as https from 'node:https';
+import type { McpCliOptions } from './options.ts';
+import { resolveConnection } from './client.ts';
+
+const SESSION_HEADER = 'mcp-session-id';
+const PROTOCOL_VERSION = '2025-06-18';
+
+export interface DoctorResult {
+	ok: boolean;
+	steps: ReadonlyArray<{ name: string; ok: boolean; detail?: string }>;
+}
+
+export async function runDoctor(opts: McpCliOptions): Promise<DoctorResult> {
+	const connection = resolveConnection(opts);
+	const steps: Array<{ name: string; ok: boolean; detail?: string }> = [];
+
+	// Step 1: initialize.
+	let sessionId: string | undefined;
+	let protocolVersion = PROTOCOL_VERSION;
+	try {
+		const res = await postJson(connection, opts.mountPath, {
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'initialize',
+			params: {
+				protocolVersion: PROTOCOL_VERSION,
+				capabilities: {},
+				clientInfo: { name: 'harper-mcp-doctor', version: '1.0.0' },
+			},
+		});
+		if (res.statusCode !== 200) {
+			steps.push({ name: 'initialize', ok: false, detail: `HTTP ${res.statusCode}: ${res.body.slice(0, 200)}` });
+			return finalize(steps);
+		}
+		const sid = res.headers[SESSION_HEADER];
+		sessionId = Array.isArray(sid) ? sid[0] : sid;
+		const parsed = JSON.parse(res.body);
+		if (parsed?.error) {
+			steps.push({ name: 'initialize', ok: false, detail: `JSON-RPC error: ${parsed.error.message}` });
+			return finalize(steps);
+		}
+		if (typeof parsed?.result?.protocolVersion === 'string') protocolVersion = parsed.result.protocolVersion;
+		steps.push({ name: 'initialize', ok: true, detail: `session=${sessionId} protocol=${protocolVersion}` });
+	} catch (err) {
+		steps.push({ name: 'initialize', ok: false, detail: (err as Error).message });
+		return finalize(steps);
+	}
+
+	// Step 2: tools/list (validates the session works for real dispatch).
+	try {
+		const res = await postJson(
+			connection,
+			opts.mountPath,
+			{ jsonrpc: '2.0', id: 2, method: 'tools/list' },
+			sessionId,
+			protocolVersion
+		);
+		if (res.statusCode !== 200) {
+			steps.push({ name: 'tools/list', ok: false, detail: `HTTP ${res.statusCode}` });
+			return finalize(steps);
+		}
+		const parsed = JSON.parse(res.body);
+		if (parsed?.error) {
+			steps.push({ name: 'tools/list', ok: false, detail: `JSON-RPC error: ${parsed.error.message}` });
+			return finalize(steps);
+		}
+		const count = Array.isArray(parsed?.result?.tools) ? parsed.result.tools.length : 0;
+		steps.push({ name: 'tools/list', ok: true, detail: `${count} tool(s) visible` });
+	} catch (err) {
+		steps.push({ name: 'tools/list', ok: false, detail: (err as Error).message });
+		return finalize(steps);
+	}
+
+	// Step 3: DELETE the session. Tolerated to fail (some configs disable it
+	// with allowClientDelete=false → 405). Either way the doctor overall is
+	// still OK if initialize + tools/list passed.
+	try {
+		const del = await sendDelete(connection, opts.mountPath, sessionId!, protocolVersion);
+		if (del.statusCode >= 200 && del.statusCode < 300) {
+			steps.push({ name: 'session cleanup', ok: true });
+		} else {
+			steps.push({ name: 'session cleanup', ok: false, detail: `HTTP ${del.statusCode}` });
+		}
+	} catch (err) {
+		steps.push({ name: 'session cleanup', ok: false, detail: (err as Error).message });
+	}
+
+	return finalize(steps);
+}
+
+function finalize(steps: ReadonlyArray<{ name: string; ok: boolean; detail?: string }>): DoctorResult {
+	const ok = steps.every((s) => s.ok || s.name === 'session cleanup');
+	return { ok, steps };
+}
+
+interface SimpleResponse {
+	statusCode: number;
+	headers: http.IncomingHttpHeaders;
+	body: string;
+}
+
+function postJson(
+	connection: ReturnType<typeof resolveConnection>,
+	mountPath: string,
+	body: object,
+	sessionId?: string,
+	protocolVersion?: string
+): Promise<SimpleResponse> {
+	const headers: Record<string, string> = {
+		'content-type': 'application/json',
+		'accept': 'application/json, text/event-stream',
+	};
+	if (sessionId) headers[SESSION_HEADER] = sessionId;
+	if (protocolVersion) headers['mcp-protocol-version'] = protocolVersion;
+	return rawRequest(connection, mountPath, 'POST', headers, JSON.stringify(body));
+}
+
+function sendDelete(
+	connection: ReturnType<typeof resolveConnection>,
+	mountPath: string,
+	sessionId: string,
+	protocolVersion: string
+): Promise<SimpleResponse> {
+	return rawRequest(connection, mountPath, 'DELETE', {
+		[SESSION_HEADER]: sessionId,
+		'mcp-protocol-version': protocolVersion,
+	});
+}
+
+function rawRequest(
+	connection: ReturnType<typeof resolveConnection>,
+	mountPath: string,
+	method: 'POST' | 'DELETE',
+	headers: Record<string, string>,
+	body?: string
+): Promise<SimpleResponse> {
+	return new Promise((resolve, reject) => {
+		const isHttps = connection.protocol === 'https:';
+		const lib = isHttps ? https : http;
+		const reqHeaders: Record<string, string> = { ...headers };
+		if (connection.authHeader) reqHeaders.authorization = connection.authHeader;
+		const reqOpts: http.RequestOptions = {
+			method,
+			path: mountPath,
+			headers: reqHeaders,
+		};
+		if (connection.socketPath) {
+			reqOpts.socketPath = connection.socketPath;
+		} else {
+			reqOpts.hostname = connection.hostname;
+			reqOpts.port = connection.port;
+		}
+		if (isHttps) (reqOpts as https.RequestOptions).rejectUnauthorized = connection.rejectUnauthorized;
+		const req = lib.request(reqOpts, async (res) => {
+			const chunks: Buffer[] = [];
+			for await (const chunk of res) chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk);
+			resolve({
+				statusCode: res.statusCode ?? 0,
+				headers: res.headers,
+				body: Buffer.concat(chunks).toString('utf8'),
+			});
+		});
+		req.on('error', reject);
+		if (body !== undefined) req.write(body);
+		req.end();
+	});
+}
+
+export function formatDoctorReport(result: DoctorResult, stdout: NodeJS.WritableStream = process.stdout): void {
+	for (const s of result.steps) {
+		const tag = s.ok ? 'OK  ' : 'FAIL';
+		stdout.write(`[${tag}] ${s.name}${s.detail ? ' — ' + s.detail : ''}\n`);
+	}
+	stdout.write(result.ok ? '\nAll checks passed.\n' : '\nDoctor reported failures; see above.\n');
+}

--- a/bin/mcp/index.ts
+++ b/bin/mcp/index.ts
@@ -24,7 +24,9 @@ Subcommands:
   help              This message.
 
 Connection flags:
-  --profile <p>     'operations' or 'application' (default: application).
+  --profile <p>     'operations' or 'application' (default: operations).
+                    --profile application requires --target (the application
+                    HTTP server doesn't expose a local UDS).
   --target <url>    Connect over the network instead of local UDS. Example:
                     --target https://node.example.com:9926
   --mount-path <p>  Override the MCP route mount path (default: /mcp).
@@ -66,6 +68,10 @@ export async function runMcpCli(argv: readonly string[]): Promise<number> {
 			const result = await runDoctor(opts);
 			formatDoctorReport(result);
 			return result.ok ? 0 : 1;
+		}
+		default: {
+			process.stderr.write(`harper mcp: unknown subcommand '${opts.subcommand as string}'\n`);
+			return 1;
 		}
 	}
 }

--- a/bin/mcp/index.ts
+++ b/bin/mcp/index.ts
@@ -1,0 +1,74 @@
+/**
+ * `harper mcp` — stdio CLI for connecting an MCP host (Claude Desktop,
+ * Cursor, Zed) to a running Harper instance. Dispatches to one of three
+ * subcommands (bridge, print-config, doctor). With no subcommand the
+ * bridge runs and stays alive until stdin closes.
+ */
+import { parseArgs, type McpCliOptions } from './options.ts';
+import { runBridge, resolveConnection } from './client.ts';
+import { emit as emitPrintConfig } from './printConfig.ts';
+import { runDoctor, formatDoctorReport } from './doctor.ts';
+
+const HELP = `
+Usage: harper mcp [subcommand] [flags]
+
+Connects an MCP host (Claude Desktop, Cursor, Zed) to a Harper instance over
+the Streamable HTTP MCP transport. By default the CLI runs as a stdio bridge:
+host JSON-RPC frames in on stdin, Harper responses out on stdout.
+
+Subcommands:
+  (default)         Run the stdio bridge until stdin closes.
+  print-config      Emit a paste-ready config block for an MCP host.
+                    Required: --client {claude-desktop,cursor,zed}.
+  doctor            Connect, handshake, list tools; report OK/FAIL per step.
+  help              This message.
+
+Connection flags:
+  --profile <p>     'operations' or 'application' (default: application).
+  --target <url>    Connect over the network instead of local UDS. Example:
+                    --target https://node.example.com:9926
+  --mount-path <p>  Override the MCP route mount path (default: /mcp).
+  --username <u>    Basic auth username (network mode).
+  --password <p>    Basic auth password (network mode).
+  --bearer <token>  Bearer token (network mode). Wins over username/password.
+  --insecure        Skip TLS certificate validation (network mode only).
+
+print-config flags:
+  --client <name>   claude-desktop | cursor | zed
+
+Examples:
+  harper mcp
+  harper mcp doctor --target https://node.example.com:9926
+  harper mcp print-config --client claude-desktop
+`;
+
+export async function runMcpCli(argv: readonly string[]): Promise<number> {
+	const opts = parseArgs(argv);
+	if (opts.help || opts.subcommand === 'help') {
+		process.stdout.write(HELP.trim() + '\n');
+		return 0;
+	}
+	switch (opts.subcommand) {
+		case 'bridge': {
+			const connection = resolveConnection(opts);
+			await runBridge({ connection, mountPath: opts.mountPath });
+			return 0;
+		}
+		case 'print-config': {
+			if (!opts.client) {
+				process.stderr.write('harper mcp print-config: --client is required (claude-desktop | cursor | zed)\n');
+				return 1;
+			}
+			emitPrintConfig(opts);
+			return 0;
+		}
+		case 'doctor': {
+			const result = await runDoctor(opts);
+			formatDoctorReport(result);
+			return result.ok ? 0 : 1;
+		}
+	}
+}
+
+export { parseArgs };
+export type { McpCliOptions };

--- a/bin/mcp/options.ts
+++ b/bin/mcp/options.ts
@@ -6,12 +6,14 @@
  *
  * Two connection modes:
  *   - **UDS** (default): connects to the locally-running Harper instance via
- *     the operationsApi domain socket. No credentials — filesystem
- *     permissions on the socket are the gate. Harper rejects MCP requests
- *     on UDS unless the request is for the operations profile or the
- *     application server has explicitly enabled MCP on UDS.
+ *     the operationsApi domain socket. **Only the operations profile is
+ *     reachable this way** — the application profile is mounted on the
+ *     application HTTP server, which doesn't expose a UDS in v1. Filesystem
+ *     permissions on the operations socket are the access gate; no
+ *     credentials are required or sent.
  *   - **HTTPS**: `--target https://host:port` connects over the network.
- *     Credential precedence (highest first):
+ *     Required for `--profile application`. Credential precedence
+ *     (highest first):
  *       `--bearer` > `--username` + `--password` > URL-embedded user/pass
  *       > saved JWT from `~/.harperdb/credentials.json` (populated by
  *       `harper login` and looked up via `cliCredentials.normalizeTarget`).
@@ -33,7 +35,11 @@ export interface McpCliOptions {
 export function parseArgs(argv: readonly string[]): McpCliOptions {
 	const opts: McpCliOptions = {
 		subcommand: 'bridge',
-		profile: 'application',
+		// Operations is the safer default: the typical zero-config path
+		// (`harper mcp` / `harper mcp doctor` on the local machine, no
+		// --target) connects over the operations UDS, which only routes
+		// to the operations MCP endpoint in v1.
+		profile: 'operations',
 		mountPath: '/mcp',
 		rejectUnauthorized: true,
 		help: false,

--- a/bin/mcp/options.ts
+++ b/bin/mcp/options.ts
@@ -11,8 +11,10 @@
  *     on UDS unless the request is for the operations profile or the
  *     application server has explicitly enabled MCP on UDS.
  *   - **HTTPS**: `--target https://host:port` connects over the network.
- *     Credentials come from `~/.harper/credentials` (per `cliCredentials`)
- *     or `--username/--password` flags.
+ *     Credential precedence (highest first):
+ *       `--bearer` > `--username` + `--password` > URL-embedded user/pass
+ *       > saved JWT from `~/.harperdb/credentials.json` (populated by
+ *       `harper login` and looked up via `cliCredentials.normalizeTarget`).
  */
 
 export interface McpCliOptions {

--- a/bin/mcp/options.ts
+++ b/bin/mcp/options.ts
@@ -1,0 +1,114 @@
+/**
+ * Argument and environment resolution for `harper mcp`. The CLI deliberately
+ * avoids pulling in a flag-parsing dep (Harper's no-new-deps policy) — a few
+ * `--key=value` and `--key value` arguments plus a positional subcommand is
+ * the entire vocabulary.
+ *
+ * Two connection modes:
+ *   - **UDS** (default): connects to the locally-running Harper instance via
+ *     the operationsApi domain socket. No credentials — filesystem
+ *     permissions on the socket are the gate. Harper rejects MCP requests
+ *     on UDS unless the request is for the operations profile or the
+ *     application server has explicitly enabled MCP on UDS.
+ *   - **HTTPS**: `--target https://host:port` connects over the network.
+ *     Credentials come from `~/.harper/credentials` (per `cliCredentials`)
+ *     or `--username/--password` flags.
+ */
+
+export interface McpCliOptions {
+	subcommand: 'bridge' | 'print-config' | 'doctor' | 'help';
+	profile: 'operations' | 'application';
+	target?: string;
+	mountPath: string;
+	username?: string;
+	password?: string;
+	bearer?: string;
+	rejectUnauthorized: boolean;
+	client?: 'claude-desktop' | 'cursor' | 'zed';
+	help: boolean;
+}
+
+export function parseArgs(argv: readonly string[]): McpCliOptions {
+	const opts: McpCliOptions = {
+		subcommand: 'bridge',
+		profile: 'application',
+		mountPath: '/mcp',
+		rejectUnauthorized: true,
+		help: false,
+	};
+
+	// argv begins after `harper mcp`, i.e. process.argv.slice(3).
+	let i = 0;
+	if (argv[0] && !argv[0].startsWith('-')) {
+		const sub = argv[0];
+		if (sub === 'print-config' || sub === 'doctor' || sub === 'help') {
+			opts.subcommand = sub;
+			i = 1;
+		} else if (sub === 'bridge') {
+			opts.subcommand = 'bridge';
+			i = 1;
+		}
+		// anything else: assume it's a flag-style arg or noise; leave i=0.
+	}
+
+	for (; i < argv.length; i++) {
+		const arg = argv[i];
+		const eq = arg.indexOf('=');
+		const isLong = arg.startsWith('--');
+		const key = isLong ? (eq === -1 ? arg.slice(2) : arg.slice(2, eq)) : arg;
+		const valueInline = eq === -1 ? undefined : arg.slice(eq + 1);
+		const consumeNext = (): string | undefined => {
+			if (valueInline !== undefined) return valueInline;
+			const next = argv[i + 1];
+			if (next === undefined || next.startsWith('-')) return undefined;
+			i++;
+			return next;
+		};
+
+		switch (key) {
+			case '--profile':
+			case 'profile': {
+				const v = consumeNext();
+				if (v === 'operations' || v === 'application') opts.profile = v;
+				break;
+			}
+			case '--target':
+			case 'target':
+				opts.target = consumeNext();
+				break;
+			case '--mount-path':
+			case 'mount-path':
+				opts.mountPath = consumeNext() ?? opts.mountPath;
+				break;
+			case '--username':
+			case 'username':
+				opts.username = consumeNext();
+				break;
+			case '--password':
+			case 'password':
+				opts.password = consumeNext();
+				break;
+			case '--bearer':
+			case 'bearer':
+				opts.bearer = consumeNext();
+				break;
+			case '--insecure':
+			case 'insecure':
+				opts.rejectUnauthorized = false;
+				break;
+			case '--client':
+			case 'client': {
+				const v = consumeNext();
+				if (v === 'claude-desktop' || v === 'cursor' || v === 'zed') opts.client = v;
+				break;
+			}
+			case '--help':
+			case 'help':
+			case '-h':
+				opts.help = true;
+				break;
+		}
+	}
+
+	return opts;
+}

--- a/bin/mcp/printConfig.ts
+++ b/bin/mcp/printConfig.ts
@@ -14,7 +14,8 @@ interface ConfigBlock {
 export function renderConfig(opts: McpCliOptions): ConfigBlock {
 	const client = opts.client ?? 'claude-desktop';
 	const args = ['mcp'];
-	if (opts.profile !== 'application') args.push('--profile', opts.profile);
+	// Default is 'operations'; only emit the flag when overriding to 'application'.
+	if (opts.profile !== 'operations') args.push('--profile', opts.profile);
 	if (opts.target) args.push('--target', opts.target);
 	if (opts.mountPath !== '/mcp') args.push('--mount-path', opts.mountPath);
 	if (opts.username) args.push('--username', opts.username);
@@ -72,6 +73,8 @@ export function renderConfig(opts: McpCliOptions): ConfigBlock {
 				notes: ["Zed's MCP support is behind a feature flag — see the Zed docs for activation."],
 			};
 		}
+		default:
+			throw new Error(`harper mcp print-config: unknown --client '${client as string}'`);
 	}
 }
 

--- a/bin/mcp/printConfig.ts
+++ b/bin/mcp/printConfig.ts
@@ -1,0 +1,86 @@
+/**
+ * Emit a paste-ready config block for each supported MCP client. Output
+ * goes to stdout so the user can pipe or copy directly into their
+ * client's config file.
+ */
+import type { McpCliOptions } from './options.ts';
+
+interface ConfigBlock {
+	target: string;
+	body: object;
+	notes: readonly string[];
+}
+
+export function renderConfig(opts: McpCliOptions): ConfigBlock {
+	const client = opts.client ?? 'claude-desktop';
+	const args = ['mcp'];
+	if (opts.profile !== 'application') args.push('--profile', opts.profile);
+	if (opts.target) args.push('--target', opts.target);
+	if (opts.mountPath !== '/mcp') args.push('--mount-path', opts.mountPath);
+	if (opts.username) args.push('--username', opts.username);
+	if (opts.password) args.push('--password', opts.password);
+	if (opts.bearer) args.push('--bearer', opts.bearer);
+	if (!opts.rejectUnauthorized) args.push('--insecure');
+
+	switch (client) {
+		case 'claude-desktop': {
+			return {
+				target:
+					'~/Library/Application Support/Claude/claude_desktop_config.json (macOS) or %APPDATA%\\Claude\\claude_desktop_config.json (Windows)',
+				body: {
+					mcpServers: {
+						harper: {
+							command: 'harper',
+							args,
+						},
+					},
+				},
+				notes: [
+					'Restart Claude Desktop after editing the file.',
+					'Merge into an existing `mcpServers` block if you already have one.',
+				],
+			};
+		}
+		case 'cursor': {
+			return {
+				target: '~/.cursor/mcp.json',
+				body: {
+					mcpServers: {
+						harper: {
+							command: 'harper',
+							args,
+						},
+					},
+				},
+				notes: ['Cursor reads this file at startup; restart after editing.'],
+			};
+		}
+		case 'zed': {
+			return {
+				target: 'Zed settings.json',
+				body: {
+					context_servers: {
+						harper: {
+							command: {
+								path: 'harper',
+								args,
+								env: {},
+							},
+						},
+					},
+				},
+				notes: ["Zed's MCP support is behind a feature flag — see the Zed docs for activation."],
+			};
+		}
+	}
+}
+
+export function emit(opts: McpCliOptions, stdout: NodeJS.WritableStream = process.stdout): void {
+	const block = renderConfig(opts);
+	stdout.write(`# Target file: ${block.target}\n`);
+	stdout.write(JSON.stringify(block.body, null, 2));
+	stdout.write('\n');
+	for (const note of block.notes) {
+		stdout.write(`# Note: ${note}\n`);
+	}
+}

--- a/components/mcp/lifecycle.ts
+++ b/components/mcp/lifecycle.ts
@@ -55,6 +55,13 @@ export interface InitializeFailure {
  * Negotiate protocol version, create a session, and return the JSON-RPC
  * result body. The caller (transport core) maps `ok: false` to HTTP 400.
  *
+ * Per the MCP spec: if the client requests a version the server does not
+ * support, the server MUST respond with a version it does support (so the
+ * client can decide whether to downgrade or disconnect) — NOT fail. We
+ * pick `PROTOCOL_VERSION_PREFERRED` for any unknown version. The only
+ * `ok: false` cases are a missing or non-string `protocolVersion` field,
+ * which is a protocol-level violation rather than version negotiation.
+ *
  * `instructions` is optional per spec; we omit it in v1 (it can be wired
  * later when tools land in #617 and we know which profile is active).
  */
@@ -63,22 +70,22 @@ export async function handleInitialize(
 	user: string
 ): Promise<InitializeOutcome | InitializeFailure> {
 	const requested = params?.protocolVersion;
-	if (
-		typeof requested !== 'string' ||
-		!SUPPORTED_PROTOCOL_VERSIONS.includes(requested as (typeof SUPPORTED_PROTOCOL_VERSIONS)[number])
-	) {
+	if (typeof requested !== 'string') {
 		return {
 			ok: false,
-			reason: `unsupported protocolVersion${typeof requested === 'string' ? `: ${requested}` : ''}`,
+			reason: `protocolVersion is required and must be a string`,
 			supportedVersions: SUPPORTED_PROTOCOL_VERSIONS,
 		};
 	}
-	const session = await createSession({ user, protocolVersion: requested });
+	const negotiated = SUPPORTED_PROTOCOL_VERSIONS.includes(requested as (typeof SUPPORTED_PROTOCOL_VERSIONS)[number])
+		? requested
+		: PROTOCOL_VERSION_PREFERRED;
+	const session = await createSession({ user, protocolVersion: negotiated });
 	return {
 		ok: true,
 		session,
 		result: {
-			protocolVersion: requested,
+			protocolVersion: negotiated,
 			serverInfo: SERVER_INFO,
 			capabilities: SERVER_CAPABILITIES,
 		},

--- a/components/mcp/listChanged.ts
+++ b/components/mcp/listChanged.ts
@@ -6,16 +6,18 @@
  * SSE streams.
  *
  * Per-session computation only — never broadcast. For each event, we
- * walk the per-worker session registry, recompute that session's
- * tools/list (or resources/list) under its bound user, diff against the
- * snapshot from the prior emission, and push a notification iff the
- * visible set actually changed. Sessions whose visible surface is
- * unchanged see nothing.
+ * walk the per-worker session registry, re-resolve the session's user
+ * (so the diff sees the freshly-mutated permission set, not the snapshot
+ * captured at GET-stream open), recompute that session's tools/list (or
+ * resources/list) under the fresh user, diff against the snapshot from
+ * the prior emission, and push a notification iff the visible set
+ * actually changed. Sessions whose visible surface is unchanged see
+ * nothing.
  */
 import harperLogger from '../../utility/logging/harper_logger.ts';
 import { listResources } from './resources.ts';
 import { type RegisteredSession, forEachSessionByProfile, getRegisteredSession } from './sessionRegistry.ts';
-import { listTools } from './toolRegistry.ts';
+import { listTools, type AuthedUser } from './toolRegistry.ts';
 import type { McpProfile } from './transport.ts';
 
 const MAX_TOOLS_PAGE = 1000;
@@ -61,6 +63,27 @@ function loadItcHandlers():
 		return require('../../server/itc/serverHandlers');
 	} catch (err) {
 		harperLogger.trace(`MCP listChanged: ITC handlers unavailable (${(err as Error).message})`);
+		return undefined;
+	}
+}
+
+// Test seam: lets unit tests stub the user re-resolution without pulling in
+// security/user.ts (which initializes the system catalogs at module-load).
+let _userResolverOverride: ((username: string) => Promise<AuthedUser | undefined>) | undefined;
+
+export function _setUserResolverForTest(fn: ((username: string) => Promise<AuthedUser | undefined>) | undefined): void {
+	_userResolverOverride = fn;
+}
+
+async function resolveUser(username: string | undefined): Promise<AuthedUser | undefined> {
+	if (!username) return undefined;
+	if (_userResolverOverride) return _userResolverOverride(username);
+	try {
+		const { findAndValidateUser } = require('../../security/user');
+		const fresh = await findAndValidateUser(username, null, false);
+		return fresh as AuthedUser;
+	} catch (err) {
+		harperLogger.trace(`MCP listChanged: user re-resolve failed for ${username}: ${(err as Error).message}`);
 		return undefined;
 	}
 }
@@ -127,39 +150,64 @@ function maybeNotifyResourcesChanged(record: RegisteredSession): void {
 }
 
 /**
+ * Snapshot the current registry as a flat list so re-resolves can happen
+ * sequentially without re-walking the live map (which a concurrent
+ * registerSession could mutate mid-iteration).
+ */
+function snapshotSessions(profile: McpProfile): RegisteredSession[] {
+	const out: RegisteredSession[] = [];
+	forEachSessionByProfile(profile, (r) => out.push(r));
+	return out;
+}
+
+async function refreshSessionUser(record: RegisteredSession): Promise<void> {
+	const fresh = await resolveUser(record.user?.username);
+	if (fresh) record.user = fresh;
+}
+
+/**
  * Fan out a user/role change: for each session on either profile,
+ * re-resolve the user (so a role-perm mutation is visible to the diff —
+ * the captured `record.user` at GET-stream open is otherwise frozen),
  * recompute the tools list and notify if changed. Resources may also
  * change visibility (table-perm-gated schema URIs), so we re-check
  * those too.
  */
-function onUserChange(): void {
-	forEachSessionByProfile('operations', (r) => {
+async function onUserChange(): Promise<void> {
+	for (const r of snapshotSessions('operations')) {
+		await refreshSessionUser(r);
 		maybeNotifyToolsChanged(r);
 		maybeNotifyResourcesChanged(r);
-	});
-	forEachSessionByProfile('application', (r) => {
+	}
+	for (const r of snapshotSessions('application')) {
+		await refreshSessionUser(r);
 		maybeNotifyToolsChanged(r);
 		maybeNotifyResourcesChanged(r);
-	});
+	}
 }
 
 /**
  * Schema changes touch both surfaces — application-profile tools are
  * generated from the Resources registry, and operations-profile
  * resources include the OPERATION list (unchanged) plus harper://schema
- * URIs (changed). Application sessions need the bigger refresh.
+ * URIs (changed). Application sessions need the bigger refresh. We also
+ * re-resolve the user here in case the schema change coincided with a
+ * role mutation (Harper sometimes fires both channels on database-level
+ * grants).
  */
-function onSchemaChange(): void {
-	forEachSessionByProfile('application', (r) => {
+async function onSchemaChange(): Promise<void> {
+	for (const r of snapshotSessions('application')) {
+		await refreshSessionUser(r);
 		maybeNotifyToolsChanged(r);
 		maybeNotifyResourcesChanged(r);
-	});
+	}
 	// Operations sessions only need resources/list refresh — there are no
 	// schema-derived operations tools, but `harper://schema/...` URIs may
 	// shift if a new table appears under a database the user can describe.
-	forEachSessionByProfile('operations', (r) => {
+	for (const r of snapshotSessions('operations')) {
+		await refreshSessionUser(r);
 		maybeNotifyResourcesChanged(r);
-	});
+	}
 }
 
 /**
@@ -173,12 +221,19 @@ export function initListChanged(): boolean {
 	if (!handlers) return false;
 	let installed = 0;
 	if (handlers.userHandler?.addListener) {
-		onUserChangeBound = onUserChange;
+		// Harper's ITC handler treats listeners as `() => void`. Our handler is
+		// async (re-resolves users); fire-and-forget with a swallow so a rejection
+		// can never escape the event emitter as an UnhandledPromiseRejection.
+		onUserChangeBound = () => {
+			onUserChange().catch((err) => harperLogger.trace(`MCP listChanged onUserChange: ${(err as Error).message}`));
+		};
 		handlers.userHandler.addListener(onUserChangeBound);
 		installed++;
 	}
 	if (handlers.schemaHandler?.addListener) {
-		onSchemaChangeBound = onSchemaChange;
+		onSchemaChangeBound = () => {
+			onSchemaChange().catch((err) => harperLogger.trace(`MCP listChanged onSchemaChange: ${(err as Error).message}`));
+		};
 		handlers.schemaHandler.addListener(onSchemaChangeBound);
 		installed++;
 	}

--- a/components/mcp/sessionRegistry.ts
+++ b/components/mcp/sessionRegistry.ts
@@ -79,13 +79,14 @@ export function registerSession(sessionId: string, profile: McpProfile, user: Au
 	registry.set(sessionId, record);
 	// On-close hook: when the consumer's async-iterator returns/throws (or
 	// supersede emits 'close' above), drop the entry so it doesn't leak past
-	// the underlying HTTP stream's lifetime. `once` so the recursive emit
-	// inside `unregisterSession` is a no-op.
+	// the underlying HTTP stream's lifetime. We delete directly rather than
+	// calling unregisterSession() — the latter would re-emit 'close', firing
+	// any other user-registered 'close' listeners a second time.
 	queue.once('close', () => {
-		// Only unregister if we're still the live record. A racing supersede
+		// Only delete if we're still the live record. A racing supersede
 		// could have already replaced us in the map.
 		if (registry.get(sessionId) === record) {
-			unregisterSession(sessionId);
+			registry.delete(sessionId);
 		}
 	});
 	return record;

--- a/components/mcp/sessionRegistry.ts
+++ b/components/mcp/sessionRegistry.ts
@@ -8,6 +8,13 @@
  *
  * Per-worker only. A session's GET stream is bound to the worker that
  * accepted the GET; cross-worker fan-out isn't attempted in v1.
+ *
+ * Lifecycle: an entry is created on GET-SSE open and removed via three
+ * paths — explicit DELETE (transport calls `deleteSession`), the on-close
+ * hook fired when the consumer's async-iterator returns/throws (e.g.
+ * client drop), or the idle-prune sweep that catches zombies the close
+ * hook missed (e.g. a proxy holding the connection after the client died
+ * without a graceful close).
  */
 import { IterableEventQueue } from '../../resources/IterableEventQueue.ts';
 import type { AuthedUser } from './toolRegistry.ts';
@@ -28,11 +35,39 @@ export interface RegisteredSession {
 	lastTools?: ReadonlyArray<{ name: string }>;
 	/** Most recent resources/list payload sent on this session — used for diffing. */
 	lastResources?: ReadonlyArray<{ uri: string }>;
+	/** Wall-clock ms of last activity. Bumped by registerSession + touchSession. */
+	lastSeen: number;
 }
 
 const registry: Map<string, RegisteredSession> = new Map();
 
+const IDLE_PRUNE_MS = 60 * 60 * 1000;
+const PRUNE_INTERVAL_MS = 5 * 60 * 1000;
+let lastPruneAt = 0;
+
+let now: () => number = () => Date.now();
+export function _setClockForTest(fn: (() => number) | undefined): void {
+	now = fn ?? (() => Date.now());
+}
+
+function pruneIdleSessions(): void {
+	const t = now();
+	if (t - lastPruneAt < PRUNE_INTERVAL_MS) return;
+	lastPruneAt = t;
+	const cutoff = t - IDLE_PRUNE_MS;
+	for (const [id, record] of registry) {
+		// Don't prune sessions whose iterator is actively awaiting data; that
+		// signals a live consumer mid-stream. Belt-and-braces around lastSeen.
+		if (record.queue.resolveNext !== null) continue;
+		if (record.lastSeen < cutoff) {
+			record.queue.emit('close');
+			registry.delete(id);
+		}
+	}
+}
+
 export function registerSession(sessionId: string, profile: McpProfile, user: AuthedUser): RegisteredSession {
+	pruneIdleSessions();
 	const existing = registry.get(sessionId);
 	if (existing) {
 		// A client that opens a second GET on the same session id supersedes
@@ -40,20 +75,43 @@ export function registerSession(sessionId: string, profile: McpProfile, user: Au
 		existing.queue.emit('close');
 	}
 	const queue = new IterableEventQueue<SseEvent>();
-	const record: RegisteredSession = { sessionId, profile, user, queue };
+	const record: RegisteredSession = { sessionId, profile, user, queue, lastSeen: now() };
 	registry.set(sessionId, record);
+	// On-close hook: when the consumer's async-iterator returns/throws (or
+	// supersede emits 'close' above), drop the entry so it doesn't leak past
+	// the underlying HTTP stream's lifetime. `once` so the recursive emit
+	// inside `unregisterSession` is a no-op.
+	queue.once('close', () => {
+		// Only unregister if we're still the live record. A racing supersede
+		// could have already replaced us in the map.
+		if (registry.get(sessionId) === record) {
+			unregisterSession(sessionId);
+		}
+	});
 	return record;
 }
 
 export function unregisterSession(sessionId: string): void {
 	const record = registry.get(sessionId);
 	if (!record) return;
-	record.queue.emit('close');
 	registry.delete(sessionId);
+	record.queue.emit('close');
 }
 
 export function getRegisteredSession(sessionId: string): RegisteredSession | undefined {
 	return registry.get(sessionId);
+}
+
+/**
+ * Mark a session as having activity right now (e.g. a `tools/call` came in).
+ * Keeps idle-prune from sweeping live sessions whose GET stream is dormant
+ * between server-push events. Distinct from `session.touchSession` — that
+ * one updates the persistent RocksDB record's `lastActivity`; this one
+ * updates the in-memory registry's `lastSeen` (used only by the idle-prune).
+ */
+export function touchRegisteredSession(sessionId: string): void {
+	const record = registry.get(sessionId);
+	if (record) record.lastSeen = now();
 }
 
 /**
@@ -72,6 +130,7 @@ export function _resetSessionRegistryForTest(): void {
 		r.queue.emit('close');
 	}
 	registry.clear();
+	lastPruneAt = 0;
 }
 
 /** Test seam — peek count. */

--- a/components/mcp/tools/operations.ts
+++ b/components/mcp/tools/operations.ts
@@ -3,11 +3,19 @@
  * and registers one MCP tool per operation that survives the
  * `mcp.operations.allow` / `deny` filter.
  *
- * The default v1 allow list is read-only: `describe_*`, `list_*`, `search_*`,
- * `get_*`, `system_information`, `read_log`, `read_audit_log`. Operators
- * who want destructive operations on the wire opt in by adding them to
- * `mcp.operations.allow`. Destructive ops carry `destructiveHint: true`
- * so well-behaved MCP clients can surface a confirmation prompt.
+ * The default v1 allow list is read-only and intentionally narrow:
+ * `describe_*`, `list_*`, `search_*`, plus an explicit set of safe
+ * getters (`get_job`, `get_status`, `get_analytics`, `get_metrics`),
+ * `system_information`, `read_log`, `read_audit_log`. A `get_*` glob
+ * was rejected because it would have matched `get_configuration`
+ * (TLS/S3/auth secrets), `get_components` + `get_component_file` +
+ * `get_custom_function*` (component source code, which can embed
+ * secrets), `get_backup`, and `get_deployment{,_payload}` — none of
+ * which should default into the MCP surface even though
+ * `verifyPerms` still gates the actual call. Operators who want any
+ * of those opt in via `mcp.operations.allow`. Destructive ops carry
+ * `destructiveHint: true` so well-behaved MCP clients can surface a
+ * confirmation prompt.
  *
  * Tool dispatch delegates to `chooseOperation` + `processLocalTransaction`
  * — the same path Harper's REST `/operation` endpoint uses. That means
@@ -93,7 +101,14 @@ export const DEFAULT_ALLOW: readonly string[] = [
 	'describe_*',
 	'list_*',
 	'search_*',
-	'get_*',
+	// Explicit safe getters only — see file-header rationale. `get_*` would
+	// pull in `get_configuration`, `get_components`, `get_custom_function*`,
+	// `get_backup`, and `get_deployment*`, all of which can leak secrets or
+	// source code into the LLM context even with `verifyPerms` enforcing.
+	'get_job',
+	'get_status',
+	'get_analytics',
+	'get_metrics',
 	'system_information',
 	'read_log',
 	'read_audit_log',

--- a/components/mcp/transport.ts
+++ b/components/mcp/transport.ts
@@ -36,7 +36,7 @@ import { seedSessionSnapshot } from './listChanged.ts';
 import { tryAdmit } from './rateLimit.ts';
 import { deleteSession, loadSession, touchSession, type McpSessionRecord } from './session.ts';
 import { listResources, listResourceTemplates, readResource } from './resources.ts';
-import { registerSession } from './sessionRegistry.ts';
+import { registerSession, touchRegisteredSession } from './sessionRegistry.ts';
 import { getTool, listTools, type AuthedUser, type ToolResult } from './toolRegistry.ts';
 
 export type McpProfile = 'operations' | 'application';
@@ -303,6 +303,10 @@ async function dispatchToolsCall(
 	const args = params?.arguments ?? {};
 	const callStartedAt = Date.now();
 	const user = effectiveUser(request);
+	// Keep the SSE registry's idle-prune from sweeping this session: tools/call
+	// activity counts as "alive" even if the GET stream is dormant between
+	// listChanged events.
+	touchRegisteredSession(session.id);
 
 	// Rate limit check — admit-or-deny BEFORE invoking the handler. Failures
 	// surface as `isError: true` with `kind: 'rate_limited'` (NOT a JSON-RPC

--- a/integrationTests/mcp/sdk.test.ts
+++ b/integrationTests/mcp/sdk.test.ts
@@ -1,0 +1,124 @@
+/**
+ * MCP v1 — conformance against the official @modelcontextprotocol/sdk client.
+ *
+ * Boots a real Harper with `mcp.operations` enabled, then exercises the
+ * Streamable HTTP transport from the SDK side. The point of this suite
+ * (separate from the inline `integrationTests/server/mcp.test.ts` which
+ * crafts raw HTTP) is to validate spec conformance against the upstream
+ * reference implementation — if the SDK can't talk to us, no real MCP
+ * host can either.
+ *
+ * Scope:
+ *   - initialize handshake + capability surface
+ *   - tools/list returns the default-allow operations
+ *   - tools/call dispatches and returns a structured result
+ *   - tools/list pagination round-trip (cursor)
+ *   - unknown-tool / parameter-validation error surfaces
+ *
+ * The application-profile flows + listChanged cross-session delivery
+ * tests live alongside; they require booting Harper with both profiles
+ * configured and registering a sample Resource.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual, equal } from 'node:assert/strict';
+
+import { startHarper, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+function mcpUrl(ctx: ContextWithHarper): URL {
+	return new URL('/mcp', ctx.harper.operationsAPIURL);
+}
+
+function authHeader(ctx: ContextWithHarper): string {
+	return `Basic ${Buffer.from(`${ctx.harper.admin.username}:${ctx.harper.admin.password}`).toString('base64')}`;
+}
+
+async function newConnectedClient(ctx: ContextWithHarper): Promise<{ client: Client; transport: StreamableHTTPClientTransport }> {
+	const transport = new StreamableHTTPClientTransport(mcpUrl(ctx), {
+		requestInit: { headers: { Authorization: authHeader(ctx) } },
+	});
+	const client = new Client({ name: 'harper-e2e', version: '1.0.0' }, { capabilities: {} });
+	await client.connect(transport);
+	return { client, transport };
+}
+
+suite('MCP v1 conformance against @modelcontextprotocol/sdk (operations profile)', (ctx: ContextWithHarper) => {
+	before(async () => {
+		// mountPath set explicitly: flattenObject skips empty profile objects
+		// (see the equivalent note in server/mcp.test.ts).
+		await startHarper(ctx, {
+			config: {
+				mcp: { operations: { mountPath: '/mcp' } },
+			},
+			env: {},
+		});
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	test('SDK client completes the initialize handshake', async () => {
+		const { client, transport } = await newConnectedClient(ctx);
+		// The SDK exposes server capabilities/info after connect().
+		const info = client.getServerVersion();
+		ok(info?.name, 'serverInfo.name present');
+		const caps = client.getServerCapabilities();
+		ok(caps && typeof caps === 'object', 'server capabilities returned');
+		await transport.close();
+	});
+
+	test('tools/list returns the default-allow operations as MCP tools', async () => {
+		const { client, transport } = await newConnectedClient(ctx);
+		const list = await client.listTools();
+		ok(Array.isArray(list.tools));
+		const names = list.tools.map((t) => t.name);
+		// describe_all + describe_table + system_information should always
+		// be present on a clean Harper boot under the default-allow list.
+		ok(names.includes('describe_all'), 'describe_all should be in default-allow');
+		ok(names.includes('system_information'), 'system_information should be in default-allow');
+		// Sensitive getters tightened in PR-2 follow-ups must NOT be there
+		// by default — verifyPerms gates them too, but the surface itself
+		// should not advertise them.
+		ok(!names.includes('get_configuration'), 'get_configuration must NOT be default-allowed');
+		await transport.close();
+	});
+
+	test('tools/call describe_all dispatches end-to-end and returns structured content', async () => {
+		const { client, transport } = await newConnectedClient(ctx);
+		const result = await client.callTool({ name: 'describe_all', arguments: {} });
+		ok(Array.isArray(result.content), 'result.content is an array');
+		ok(result.content.length > 0, 'at least one content frame');
+		const text = result.content.find((c: { type: string }) => c.type === 'text') as { type: string; text: string } | undefined;
+		ok(text, 'a text content frame is present');
+		// describe_all returns a database/table tree under the admin user.
+		// We don't assert specific contents — just that it parses as JSON
+		// (the tool wraps the JSON object in a text frame per MCP convention).
+		const parsed = JSON.parse(text.text);
+		ok(typeof parsed === 'object', 'tool result text parses as JSON');
+		await transport.close();
+	});
+
+	test('tools/list paginates when the visible surface exceeds a configured max', async () => {
+		const { client, transport } = await newConnectedClient(ctx);
+		// Default cap is 200; we don't have 200 tools by default but the
+		// pagination contract (nextCursor undefined when exhausted) is the
+		// spec-conformance bit we actually want.
+		const page1 = await client.listTools();
+		strictEqual(page1.nextCursor, undefined, 'single page when under the cap');
+		await transport.close();
+	});
+
+	test('an unknown tool returns a JSON-RPC error frame, not a transport failure', async () => {
+		const { client, transport } = await newConnectedClient(ctx);
+		try {
+			await client.callTool({ name: 'definitely_not_a_tool', arguments: {} });
+			ok(false, 'expected callTool to throw');
+		} catch (err) {
+			// The SDK surfaces JSON-RPC errors by rejecting the call promise.
+			ok(err instanceof Error);
+		}
+		await transport.close();
+	});
+});

--- a/integrationTests/mcp/sdk.test.ts
+++ b/integrationTests/mcp/sdk.test.ts
@@ -20,7 +20,7 @@
  * configured and registering a sample Resource.
  */
 import { suite, test, before, after } from 'node:test';
-import { ok, strictEqual, equal } from 'node:assert/strict';
+import { ok, strictEqual } from 'node:assert/strict';
 
 import { startHarper, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -34,7 +34,9 @@ function authHeader(ctx: ContextWithHarper): string {
 	return `Basic ${Buffer.from(`${ctx.harper.admin.username}:${ctx.harper.admin.password}`).toString('base64')}`;
 }
 
-async function newConnectedClient(ctx: ContextWithHarper): Promise<{ client: Client; transport: StreamableHTTPClientTransport }> {
+async function newConnectedClient(
+	ctx: ContextWithHarper
+): Promise<{ client: Client; transport: StreamableHTTPClientTransport }> {
 	const transport = new StreamableHTTPClientTransport(mcpUrl(ctx), {
 		requestInit: { headers: { Authorization: authHeader(ctx) } },
 	});
@@ -90,7 +92,9 @@ suite('MCP v1 conformance against @modelcontextprotocol/sdk (operations profile)
 		const result = await client.callTool({ name: 'describe_all', arguments: {} });
 		ok(Array.isArray(result.content), 'result.content is an array');
 		ok(result.content.length > 0, 'at least one content frame');
-		const text = result.content.find((c: { type: string }) => c.type === 'text') as { type: string; text: string } | undefined;
+		const text = result.content.find((c: { type: string }) => c.type === 'text') as
+			| { type: string; text: string }
+			| undefined;
 		ok(text, 'a text content frame is present');
 		// describe_all returns a database/table tree under the admin user.
 		// We don't assert specific contents — just that it parses as JSON

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
 			"devDependencies": {
 				"@harperdb/code-guidelines": "^0.0.6",
 				"@harperfast/integration-testing": "^0.3.1",
+				"@modelcontextprotocol/sdk": "^1.29.0",
 				"@types/busboy": "^1.5.4",
 				"@types/fs-extra": "^11.0.4",
 				"@types/gunzip-maybe": "^1.4.3",
@@ -3088,6 +3089,19 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@hono/node-server": {
+			"version": "1.19.14",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+			"integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.14.1"
+			},
+			"peerDependencies": {
+				"hono": "^4"
+			}
+		},
 		"node_modules/@humanfs/core": {
 			"version": "0.19.1",
 			"dev": true,
@@ -3658,6 +3672,71 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/@modelcontextprotocol/sdk": {
+			"version": "1.29.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+			"integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@hono/node-server": "^1.19.9",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"content-type": "^1.0.5",
+				"cors": "^2.8.5",
+				"cross-spawn": "^7.0.5",
+				"eventsource": "^3.0.2",
+				"eventsource-parser": "^3.0.0",
+				"express": "^5.2.1",
+				"express-rate-limit": "^8.2.1",
+				"hono": "^4.11.4",
+				"jose": "^6.1.3",
+				"json-schema-typed": "^8.0.2",
+				"pkce-challenge": "^5.0.0",
+				"raw-body": "^3.0.0",
+				"zod": "^3.25 || ^4.0",
+				"zod-to-json-schema": "^3.25.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@cfworker/json-schema": "^4.1.1",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"@cfworker/json-schema": {
+					"optional": true
+				},
+				"zod": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
 			"version": "3.0.4",
@@ -5982,9 +6061,8 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
 			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+			"devOptional": true,
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"mime-types": "^3.0.0",
 				"negotiator": "^1.0.0"
@@ -5997,9 +6075,8 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
 			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"devOptional": true,
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"mime-db": "^1.54.0"
 			},
@@ -6613,6 +6690,31 @@
 				"safe-buffer": "~5.2.0"
 			}
 		},
+		"node_modules/body-parser": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "^3.1.2",
+				"content-type": "^1.0.5",
+				"debug": "^4.4.3",
+				"http-errors": "^2.0.0",
+				"iconv-lite": "^0.7.0",
+				"on-finished": "^2.4.1",
+				"qs": "^6.14.1",
+				"raw-body": "^3.0.1",
+				"type-is": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/bowser": {
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
@@ -6761,6 +6863,16 @@
 			},
 			"engines": {
 				"node": ">=10.16.0"
+			}
+		},
+		"node_modules/bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/bytestreamjs": {
@@ -7230,6 +7342,16 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
+		"node_modules/content-type": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -7265,6 +7387,24 @@
 		"node_modules/core-util-is": {
 			"version": "1.0.3",
 			"license": "MIT"
+		},
+		"node_modules/cors": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
 		},
 		"node_modules/cross-env": {
 			"version": "10.1.0",
@@ -7991,6 +8131,138 @@
 			"optional": true,
 			"peer": true
 		},
+		"node_modules/express": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "^2.0.0",
+				"body-parser": "^2.2.1",
+				"content-disposition": "^1.0.0",
+				"content-type": "^1.0.5",
+				"cookie": "^0.7.1",
+				"cookie-signature": "^1.2.1",
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"finalhandler": "^2.1.0",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.0",
+				"merge-descriptors": "^2.0.0",
+				"mime-types": "^3.0.0",
+				"on-finished": "^2.4.1",
+				"once": "^1.4.0",
+				"parseurl": "^1.3.3",
+				"proxy-addr": "^2.0.7",
+				"qs": "^6.14.0",
+				"range-parser": "^1.2.1",
+				"router": "^2.2.0",
+				"send": "^1.1.0",
+				"serve-static": "^2.2.0",
+				"statuses": "^2.0.1",
+				"type-is": "^2.0.1",
+				"vary": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/express-rate-limit": {
+			"version": "8.5.2",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+			"integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "^10.2.0"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/express-rate-limit"
+			},
+			"peerDependencies": {
+				"express": ">= 4.11"
+			}
+		},
+		"node_modules/express/node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/express/node_modules/finalhandler": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"on-finished": "^2.4.1",
+				"parseurl": "^1.3.3",
+				"statuses": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/express/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/express/node_modules/serve-static": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"parseurl": "^1.3.3",
+				"send": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/eyes": {
 			"version": "0.1.8",
 			"engines": {
@@ -8551,6 +8823,16 @@
 			},
 			"funding": {
 				"url": "https://ko-fi.com/tunnckoCore/commissions"
+			}
+		},
+		"node_modules/forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/fraction.js": {
@@ -9734,6 +10016,16 @@
 				"hermes-estree": "0.32.0"
 			}
 		},
+		"node_modules/hono": {
+			"version": "4.12.23",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+			"integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
 		"node_modules/http-errors": {
 			"version": "2.0.1",
 			"license": "MIT",
@@ -10108,6 +10400,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/is-regex": {
 			"version": "1.2.1",
 			"license": "MIT",
@@ -10431,6 +10730,16 @@
 				"@sideway/pinpoint": "^2.0.0"
 			}
 		},
+		"node_modules/jose": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+			"integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
 		"node_modules/js-sdsl": {
 			"version": "4.3.0",
 			"dev": true,
@@ -10506,6 +10815,13 @@
 			"version": "0.4.1",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/json-schema-typed": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+			"dev": true,
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -10921,6 +11237,16 @@
 				"node": ">= 14"
 			}
 		},
+		"node_modules/media-typer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/memoize-one": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
@@ -10928,6 +11254,19 @@
 			"license": "MIT",
 			"optional": true,
 			"peer": true
+		},
+		"node_modules/merge-descriptors": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
@@ -11860,9 +12199,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
 			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+			"devOptional": true,
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -12172,6 +12510,16 @@
 			},
 			"engines": {
 				"node": ">=20.19.4"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/object-inspect": {
@@ -12569,9 +12917,8 @@
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
 			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"devOptional": true,
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -12670,6 +13017,17 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/path-to-regexp": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/pause": {
@@ -12807,6 +13165,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/pkce-challenge": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+			"integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.20.0"
 			}
 		},
 		"node_modules/pkijs": {
@@ -12977,6 +13345,30 @@
 				"url": "https://github.com/steveukx/properties?sponsor=1"
 			}
 		},
+		"node_modules/proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/proxy-addr/node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
 		"node_modules/proxy-from-env": {
 			"version": "2.1.0",
 			"dev": true,
@@ -13088,6 +13480,22 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/raw-body": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.7.0",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/rbush": {
@@ -13616,6 +14024,23 @@
 		"node_modules/robust-predicates": {
 			"version": "3.0.2",
 			"license": "Unlicense"
+		},
+		"node_modules/router": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"is-promise": "^4.0.0",
+				"parseurl": "^1.3.3",
+				"path-to-regexp": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
 		},
 		"node_modules/run-async": {
 			"version": "2.4.1",
@@ -14845,6 +15270,56 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/type-is": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+			"integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"content-type": "^2.0.0",
+				"media-typer": "^1.1.0",
+				"mime-types": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/type-is/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/type-is/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/typed-function": {
 			"version": "4.2.2",
 			"license": "MIT",
@@ -14925,9 +15400,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"devOptional": true,
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -15032,6 +15506,16 @@
 		"node_modules/validate.js": {
 			"version": "0.13.1",
 			"license": "MIT"
+		},
+		"node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/vlq": {
 			"version": "1.0.1",
@@ -15353,6 +15837,26 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"dev": true,
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"test:integration:api-tests": "node --test integrationTests/apiTests/tests/testSuite.mjs",
 		"test:integration": "harper-integration-test-run",
 		"test:integration:all": "npm run test:integration -- \"integrationTests/**/*.test.ts\" \"integrationTests/**/*.test.mjs\"",
+		"test:integration:mcp": "npm run test:integration -- \"integrationTests/mcp/**/*.test.ts\"",
 		"test:integration:bun": "HARPER_RUNTIME=bun harper-integration-test-run",
 		"test:unit": "mocha",
 		"test:unit:main": "mocha \"unitTests/**/*test.*js\" --exclude \"unitTests/apiTests/**/*\" --exclude \"unitTests/dataLayer/harperBridge/**/*\" --exclude \"unitTests/resources/**/*\"",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
 	"devDependencies": {
 		"@harperdb/code-guidelines": "^0.0.6",
 		"@harperfast/integration-testing": "^0.3.1",
+		"@modelcontextprotocol/sdk": "^1.29.0",
 		"@types/busboy": "^1.5.4",
 		"@types/fs-extra": "^11.0.4",
 		"@types/gunzip-maybe": "^1.4.3",

--- a/unitTests/bin/mcp/client.test.js
+++ b/unitTests/bin/mcp/client.test.js
@@ -1,0 +1,173 @@
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { Readable, Writable } = require('node:stream');
+const { runBridge } = require('#src/bin/mcp/client');
+
+class ChunkSink extends Writable {
+	constructor() {
+		super();
+		this.chunks = [];
+	}
+	_write(chunk, _enc, cb) {
+		this.chunks.push(Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk));
+		cb();
+	}
+	get text() {
+		return this.chunks.join('');
+	}
+}
+
+function stdinFromLines(lines) {
+	const s = new Readable({ read() {} });
+	for (const l of lines) s.push(l + '\n');
+	s.push(null);
+	return s;
+}
+
+function startFakeServer(handler) {
+	return new Promise((resolve) => {
+		const server = http.createServer(handler);
+		server.listen(0, '127.0.0.1', () => {
+			const addr = server.address();
+			resolve({ server, port: addr.port });
+		});
+	});
+}
+
+describe('bin/mcp/client.runBridge', () => {
+	let fake;
+	afterEach(() => {
+		fake?.server.close();
+	});
+
+	it('POSTs each stdin frame and writes the JSON response to stdout', async () => {
+		const recvRequests = [];
+		fake = await startFakeServer((req, res) => {
+			let body = '';
+			req.on('data', (c) => (body += c));
+			req.on('end', () => {
+				recvRequests.push({ method: req.method, headers: req.headers, body });
+				if (req.method === 'GET') {
+					// Held-open SSE channel — keep alive briefly then end.
+					res.writeHead(200, { 'content-type': 'text/event-stream' });
+					setTimeout(() => res.end(), 10);
+					return;
+				}
+				const parsed = JSON.parse(body);
+				const isInit = parsed.method === 'initialize';
+				res.writeHead(200, {
+					'content-type': 'application/json',
+					...(isInit ? { 'mcp-session-id': 'sid-1' } : {}),
+				});
+				res.end(
+					JSON.stringify({
+						jsonrpc: '2.0',
+						id: parsed.id,
+						result: isInit ? { protocolVersion: '2025-06-18' } : { tools: [] },
+					})
+				);
+			});
+		});
+
+		const stdin = stdinFromLines([
+			JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18' } }),
+			JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }),
+		]);
+		const stdout = new ChunkSink();
+		const stderr = new ChunkSink();
+
+		await runBridge({
+			connection: { protocol: 'http:', hostname: '127.0.0.1', port: fake.port, rejectUnauthorized: false },
+			mountPath: '/mcp',
+			stdin,
+			stdout,
+			stderr,
+		});
+
+		const lines = stdout.text.split('\n').filter(Boolean);
+		assert.equal(lines.length, 2, 'two responses written to stdout');
+		const r1 = JSON.parse(lines[0]);
+		const r2 = JSON.parse(lines[1]);
+		assert.equal(r1.id, 1);
+		assert.equal(r1.result.protocolVersion, '2025-06-18');
+		assert.equal(r2.id, 2);
+		assert.deepEqual(r2.result.tools, []);
+
+		// Second POST should carry the captured session id.
+		const posts = recvRequests.filter((r) => r.method === 'POST');
+		assert.equal(posts[1].headers['mcp-session-id'], 'sid-1');
+	});
+
+	it('parses an SSE response and emits each message frame to stdout', async () => {
+		fake = await startFakeServer((req, res) => {
+			if (req.method === 'GET') {
+				res.writeHead(200, { 'content-type': 'text/event-stream' });
+				setTimeout(() => res.end(), 10);
+				return;
+			}
+			res.writeHead(200, { 'content-type': 'text/event-stream', 'mcp-session-id': 'sid-2' });
+			res.write('event: message\ndata: ' + JSON.stringify({ jsonrpc: '2.0', id: 1, result: { ok: true } }) + '\n\n');
+			res.end();
+		});
+		const stdin = stdinFromLines([JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' })]);
+		const stdout = new ChunkSink();
+		const stderr = new ChunkSink();
+		await runBridge({
+			connection: { protocol: 'http:', hostname: '127.0.0.1', port: fake.port, rejectUnauthorized: false },
+			mountPath: '/mcp',
+			stdin,
+			stdout,
+			stderr,
+		});
+		const frame = JSON.parse(stdout.text.split('\n').filter(Boolean)[0]);
+		assert.equal(frame.result.ok, true);
+	});
+
+	it('returns a JSON-RPC error frame when the POST fails outright', async () => {
+		// No fake server bound — connection refused.
+		const stdin = stdinFromLines([JSON.stringify({ jsonrpc: '2.0', id: 42, method: 'initialize' })]);
+		const stdout = new ChunkSink();
+		const stderr = new ChunkSink();
+		await runBridge({
+			connection: { protocol: 'http:', hostname: '127.0.0.1', port: 1, rejectUnauthorized: false },
+			mountPath: '/mcp',
+			stdin,
+			stdout,
+			stderr,
+		});
+		const frame = JSON.parse(stdout.text.split('\n').filter(Boolean)[0]);
+		assert.equal(frame.id, 42);
+		assert.equal(frame.error.code, -32603);
+		assert.ok(stderr.text.includes('POST failed'));
+	});
+
+	it('skips blank lines and logs (but does not crash on) malformed JSON', async () => {
+		fake = await startFakeServer((req, res) => {
+			if (req.method === 'GET') {
+				res.writeHead(200, { 'content-type': 'text/event-stream' });
+				setTimeout(() => res.end(), 10);
+				return;
+			}
+			res.writeHead(200, { 'content-type': 'application/json', 'mcp-session-id': 'sid' });
+			res.end(JSON.stringify({ jsonrpc: '2.0', id: 1, result: {} }));
+		});
+		const stdin = stdinFromLines([
+			'',
+			'   ',
+			'not json',
+			JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' }),
+		]);
+		const stdout = new ChunkSink();
+		const stderr = new ChunkSink();
+		await runBridge({
+			connection: { protocol: 'http:', hostname: '127.0.0.1', port: fake.port, rejectUnauthorized: false },
+			mountPath: '/mcp',
+			stdin,
+			stdout,
+			stderr,
+		});
+		const lines = stdout.text.split('\n').filter(Boolean);
+		assert.equal(lines.length, 1, 'only the valid request produced a response');
+		assert.ok(stderr.text.includes('not valid JSON'));
+	});
+});

--- a/unitTests/bin/mcp/client.test.js
+++ b/unitTests/bin/mcp/client.test.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const http = require('node:http');
 const { Readable, Writable } = require('node:stream');
-const { runBridge } = require('#src/bin/mcp/client');
+const { runBridge, resolveConnection } = require('#src/bin/mcp/client');
 
 class ChunkSink extends Writable {
 	constructor() {
@@ -169,5 +169,66 @@ describe('bin/mcp/client.runBridge', () => {
 		const lines = stdout.text.split('\n').filter(Boolean);
 		assert.equal(lines.length, 1, 'only the valid request produced a response');
 		assert.ok(stderr.text.includes('not valid JSON'));
+	});
+});
+
+describe('bin/mcp/client.resolveConnection', () => {
+	it('throws a helpful error when --profile application is selected without --target', () => {
+		assert.throws(
+			() =>
+				resolveConnection({
+					subcommand: 'bridge',
+					profile: 'application',
+					mountPath: '/mcp',
+					rejectUnauthorized: true,
+					help: false,
+				}),
+			/application MCP endpoint is mounted on the application HTTP server/
+		);
+	});
+
+	it('honors --target https://... in network mode regardless of profile', () => {
+		const conn = resolveConnection({
+			subcommand: 'bridge',
+			profile: 'application',
+			mountPath: '/mcp',
+			target: 'https://node:9926',
+			rejectUnauthorized: true,
+			help: false,
+		});
+		assert.equal(conn.protocol, 'https:');
+		assert.equal(conn.hostname, 'node');
+		assert.equal(conn.port, '9926');
+		assert.equal(conn.socketPath, undefined);
+	});
+
+	it('builds a Basic auth header from --username + --password', () => {
+		const conn = resolveConnection({
+			subcommand: 'bridge',
+			profile: 'application',
+			mountPath: '/mcp',
+			target: 'https://node:9926',
+			username: 'alice',
+			password: 'pw',
+			rejectUnauthorized: true,
+			help: false,
+		});
+		const expected = `Basic ${Buffer.from('alice:pw').toString('base64')}`;
+		assert.equal(conn.authHeader, expected);
+	});
+
+	it('--bearer wins over --username + --password', () => {
+		const conn = resolveConnection({
+			subcommand: 'bridge',
+			profile: 'application',
+			mountPath: '/mcp',
+			target: 'https://node:9926',
+			username: 'alice',
+			password: 'pw',
+			bearer: 'token-xyz',
+			rejectUnauthorized: true,
+			help: false,
+		});
+		assert.equal(conn.authHeader, 'Bearer token-xyz');
 	});
 });

--- a/unitTests/bin/mcp/doctor.test.js
+++ b/unitTests/bin/mcp/doctor.test.js
@@ -1,0 +1,116 @@
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { runDoctor } = require('#src/bin/mcp/doctor');
+
+function startFakeServer(handler) {
+	return new Promise((resolve) => {
+		const server = http.createServer(handler);
+		server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port }));
+	});
+}
+
+function readBody(req) {
+	return new Promise((resolve) => {
+		let body = '';
+		req.on('data', (c) => (body += c));
+		req.on('end', () => resolve(body));
+	});
+}
+
+const BASE = {
+	subcommand: 'doctor',
+	profile: 'application',
+	mountPath: '/mcp',
+	rejectUnauthorized: false,
+	help: false,
+};
+
+describe('bin/mcp/doctor.runDoctor', () => {
+	let fake;
+	afterEach(() => fake?.server.close());
+
+	it('reports OK on all steps for a well-behaved Harper instance', async () => {
+		fake = await startFakeServer(async (req, res) => {
+			const body = await readBody(req);
+			if (req.method === 'POST') {
+				const parsed = JSON.parse(body);
+				if (parsed.method === 'initialize') {
+					res.writeHead(200, { 'content-type': 'application/json', 'mcp-session-id': 'sid-3' });
+					res.end(JSON.stringify({ jsonrpc: '2.0', id: parsed.id, result: { protocolVersion: '2025-06-18' } }));
+					return;
+				}
+				if (parsed.method === 'tools/list') {
+					res.writeHead(200, { 'content-type': 'application/json' });
+					res.end(JSON.stringify({ jsonrpc: '2.0', id: parsed.id, result: { tools: [{ name: 'x' }] } }));
+					return;
+				}
+			}
+			if (req.method === 'DELETE') {
+				res.writeHead(204);
+				res.end();
+				return;
+			}
+			res.writeHead(404);
+			res.end();
+		});
+		const result = await runDoctor({ ...BASE, target: `http://127.0.0.1:${fake.port}` });
+		assert.equal(result.ok, true);
+		assert.equal(result.steps.length, 3);
+		assert.deepEqual(
+			result.steps.map((s) => s.name),
+			['initialize', 'tools/list', 'session cleanup']
+		);
+		const ttl = result.steps.find((s) => s.name === 'tools/list');
+		assert.match(ttl.detail, /1 tool\(s\) visible/);
+	});
+
+	it('reports FAIL when initialize HTTP-errors', async () => {
+		fake = await startFakeServer((req, res) => {
+			res.writeHead(500, { 'content-type': 'text/plain' });
+			res.end('boom');
+		});
+		const result = await runDoctor({ ...BASE, target: `http://127.0.0.1:${fake.port}` });
+		assert.equal(result.ok, false);
+		assert.equal(result.steps[0].ok, false);
+		assert.match(result.steps[0].detail, /HTTP 500/);
+	});
+
+	it('reports FAIL when initialize returns a JSON-RPC error', async () => {
+		fake = await startFakeServer(async (req, res) => {
+			const body = await readBody(req);
+			res.writeHead(200, { 'content-type': 'application/json' });
+			res.end(JSON.stringify({ jsonrpc: '2.0', id: JSON.parse(body).id, error: { code: -32600, message: 'nope' } }));
+		});
+		const result = await runDoctor({ ...BASE, target: `http://127.0.0.1:${fake.port}` });
+		assert.equal(result.ok, false);
+		assert.match(result.steps[0].detail, /JSON-RPC error: nope/);
+	});
+
+	it('tolerates session-cleanup failure (still reports overall OK)', async () => {
+		fake = await startFakeServer(async (req, res) => {
+			const body = await readBody(req);
+			if (req.method === 'POST') {
+				const parsed = JSON.parse(body);
+				res.writeHead(200, {
+					'content-type': 'application/json',
+					...(parsed.method === 'initialize' ? { 'mcp-session-id': 'sid-4' } : {}),
+				});
+				res.end(
+					JSON.stringify({
+						jsonrpc: '2.0',
+						id: parsed.id,
+						result: parsed.method === 'initialize' ? { protocolVersion: '2025-06-18' } : { tools: [] },
+					})
+				);
+				return;
+			}
+			// DELETE returns 405 — allowClientDelete disabled.
+			res.writeHead(405);
+			res.end();
+		});
+		const result = await runDoctor({ ...BASE, target: `http://127.0.0.1:${fake.port}` });
+		// initialize + tools/list pass; cleanup fails but doesn't tank overall OK.
+		assert.equal(result.ok, true);
+		assert.equal(result.steps.find((s) => s.name === 'session cleanup').ok, false);
+	});
+});

--- a/unitTests/bin/mcp/options.test.js
+++ b/unitTests/bin/mcp/options.test.js
@@ -1,0 +1,64 @@
+const assert = require('node:assert/strict');
+const { parseArgs } = require('#src/bin/mcp/options');
+
+describe('bin/mcp/options.parseArgs', () => {
+	it('defaults to bridge + application + UDS + /mcp', () => {
+		const o = parseArgs([]);
+		assert.equal(o.subcommand, 'bridge');
+		assert.equal(o.profile, 'application');
+		assert.equal(o.target, undefined);
+		assert.equal(o.mountPath, '/mcp');
+		assert.equal(o.rejectUnauthorized, true);
+	});
+
+	it('parses a positional subcommand', () => {
+		assert.equal(parseArgs(['doctor']).subcommand, 'doctor');
+		assert.equal(parseArgs(['print-config']).subcommand, 'print-config');
+		assert.equal(parseArgs(['help']).subcommand, 'help');
+		assert.equal(parseArgs(['bridge']).subcommand, 'bridge');
+	});
+
+	it('accepts --flag value and --flag=value forms', () => {
+		const o1 = parseArgs(['--profile', 'operations']);
+		assert.equal(o1.profile, 'operations');
+		const o2 = parseArgs(['--profile=operations']);
+		assert.equal(o2.profile, 'operations');
+	});
+
+	it('parses --target as a network endpoint', () => {
+		const o = parseArgs(['--target', 'https://host:9926']);
+		assert.equal(o.target, 'https://host:9926');
+	});
+
+	it('parses creds', () => {
+		const o = parseArgs(['--username', 'alice', '--password', 'pw']);
+		assert.equal(o.username, 'alice');
+		assert.equal(o.password, 'pw');
+	});
+
+	it('--insecure flips rejectUnauthorized', () => {
+		const o = parseArgs(['--insecure']);
+		assert.equal(o.rejectUnauthorized, false);
+	});
+
+	it('rejects unknown profile values silently (default stays)', () => {
+		const o = parseArgs(['--profile', 'bogus']);
+		assert.equal(o.profile, 'application');
+	});
+
+	it('print-config respects --client', () => {
+		const o = parseArgs(['print-config', '--client', 'cursor']);
+		assert.equal(o.subcommand, 'print-config');
+		assert.equal(o.client, 'cursor');
+	});
+
+	it('--help / -h sets help', () => {
+		assert.equal(parseArgs(['--help']).help, true);
+		assert.equal(parseArgs(['-h']).help, true);
+	});
+
+	it('--bearer overrides username/password later', () => {
+		const o = parseArgs(['--username', 'a', '--bearer', 'token']);
+		assert.equal(o.bearer, 'token');
+	});
+});

--- a/unitTests/bin/mcp/options.test.js
+++ b/unitTests/bin/mcp/options.test.js
@@ -2,10 +2,10 @@ const assert = require('node:assert/strict');
 const { parseArgs } = require('#src/bin/mcp/options');
 
 describe('bin/mcp/options.parseArgs', () => {
-	it('defaults to bridge + application + UDS + /mcp', () => {
+	it('defaults to bridge + operations + UDS + /mcp', () => {
 		const o = parseArgs([]);
 		assert.equal(o.subcommand, 'bridge');
-		assert.equal(o.profile, 'application');
+		assert.equal(o.profile, 'operations');
 		assert.equal(o.target, undefined);
 		assert.equal(o.mountPath, '/mcp');
 		assert.equal(o.rejectUnauthorized, true);
@@ -43,7 +43,7 @@ describe('bin/mcp/options.parseArgs', () => {
 
 	it('rejects unknown profile values silently (default stays)', () => {
 		const o = parseArgs(['--profile', 'bogus']);
-		assert.equal(o.profile, 'application');
+		assert.equal(o.profile, 'operations');
 	});
 
 	it('print-config respects --client', () => {

--- a/unitTests/bin/mcp/printConfig.test.js
+++ b/unitTests/bin/mcp/printConfig.test.js
@@ -3,7 +3,7 @@ const { renderConfig } = require('#src/bin/mcp/printConfig');
 
 const BASE = {
 	subcommand: 'print-config',
-	profile: 'application',
+	profile: 'operations',
 	mountPath: '/mcp',
 	rejectUnauthorized: true,
 	help: false,
@@ -34,7 +34,7 @@ describe('bin/mcp/printConfig.renderConfig', () => {
 		const block = renderConfig({
 			...BASE,
 			client: 'claude-desktop',
-			profile: 'operations',
+			profile: 'application',
 			target: 'https://node:9926',
 			mountPath: '/mcp2',
 			username: 'alice',
@@ -44,7 +44,7 @@ describe('bin/mcp/printConfig.renderConfig', () => {
 		assert.deepEqual(args, [
 			'mcp',
 			'--profile',
-			'operations',
+			'application',
 			'--target',
 			'https://node:9926',
 			'--mount-path',
@@ -53,5 +53,10 @@ describe('bin/mcp/printConfig.renderConfig', () => {
 			'alice',
 			'--insecure',
 		]);
+	});
+
+	it('omits --profile when it matches the default (operations)', () => {
+		const block = renderConfig({ ...BASE, client: 'claude-desktop' });
+		assert.deepEqual(block.body.mcpServers.harper.args, ['mcp']);
 	});
 });

--- a/unitTests/bin/mcp/printConfig.test.js
+++ b/unitTests/bin/mcp/printConfig.test.js
@@ -1,0 +1,57 @@
+const assert = require('node:assert/strict');
+const { renderConfig } = require('#src/bin/mcp/printConfig');
+
+const BASE = {
+	subcommand: 'print-config',
+	profile: 'application',
+	mountPath: '/mcp',
+	rejectUnauthorized: true,
+	help: false,
+};
+
+describe('bin/mcp/printConfig.renderConfig', () => {
+	it('claude-desktop emits an mcpServers entry calling `harper mcp`', () => {
+		const block = renderConfig({ ...BASE, client: 'claude-desktop' });
+		const harper = block.body.mcpServers.harper;
+		assert.equal(harper.command, 'harper');
+		assert.deepEqual(harper.args, ['mcp']);
+		assert.match(block.target, /claude_desktop_config\.json/);
+	});
+
+	it('cursor emits mcpServers under ~/.cursor/mcp.json', () => {
+		const block = renderConfig({ ...BASE, client: 'cursor' });
+		assert.ok(block.body.mcpServers.harper);
+		assert.match(block.target, /\.cursor\/mcp\.json/);
+	});
+
+	it('zed emits context_servers entry', () => {
+		const block = renderConfig({ ...BASE, client: 'zed' });
+		assert.ok(block.body.context_servers.harper);
+		assert.equal(block.body.context_servers.harper.command.path, 'harper');
+	});
+
+	it('forwards non-default flags into args', () => {
+		const block = renderConfig({
+			...BASE,
+			client: 'claude-desktop',
+			profile: 'operations',
+			target: 'https://node:9926',
+			mountPath: '/mcp2',
+			username: 'alice',
+			rejectUnauthorized: false,
+		});
+		const args = block.body.mcpServers.harper.args;
+		assert.deepEqual(args, [
+			'mcp',
+			'--profile',
+			'operations',
+			'--target',
+			'https://node:9926',
+			'--mount-path',
+			'/mcp2',
+			'--username',
+			'alice',
+			'--insecure',
+		]);
+	});
+});

--- a/unitTests/components/mcp/lifecycle.test.js
+++ b/unitTests/components/mcp/lifecycle.test.js
@@ -66,11 +66,20 @@ describe('mcp/lifecycle', () => {
 			assert.equal(outcome.result.protocolVersion, '2025-03-26');
 		});
 
-		it('rejects an unsupported protocol version with the supported list', async () => {
+		it('negotiates an unsupported version down to the preferred one (spec: server MUST respond with a supported version)', async () => {
 			const outcome = await handleInitialize({ protocolVersion: '2024-01-01' }, 'alice');
-			assert.equal(outcome.ok, false);
-			assert.match(outcome.reason, /2024-01-01/);
-			assert.deepEqual([...outcome.supportedVersions], [...SUPPORTED_PROTOCOL_VERSIONS]);
+			// Spec quote: "If the server does not support the requested version,
+			// the server MUST respond with a value it does support" — so we
+			// downgrade to the preferred version rather than failing the call.
+			assert.equal(outcome.ok, true);
+			assert.equal(outcome.result.protocolVersion, SUPPORTED_PROTOCOL_VERSIONS[0]);
+			assert.equal(outcome.session.protocolVersion, SUPPORTED_PROTOCOL_VERSIONS[0]);
+		});
+
+		it('also negotiates down for a newer-than-supported version (e.g. 2025-11-25 from SDK 1.29)', async () => {
+			const outcome = await handleInitialize({ protocolVersion: '2025-11-25' }, 'alice');
+			assert.equal(outcome.ok, true);
+			assert.equal(outcome.result.protocolVersion, SUPPORTED_PROTOCOL_VERSIONS[0]);
 		});
 
 		it('rejects missing protocolVersion', async () => {

--- a/unitTests/components/mcp/listChanged.test.js
+++ b/unitTests/components/mcp/listChanged.test.js
@@ -3,6 +3,7 @@ const {
 	initListChanged,
 	seedSessionSnapshot,
 	_setItcHandlersForTest,
+	_setUserResolverForTest,
 	_resetListChangedForTest,
 } = require('#src/components/mcp/listChanged');
 const { registerSession, _resetSessionRegistryForTest } = require('#src/components/mcp/sessionRegistry');
@@ -56,6 +57,7 @@ describe('mcp/listChanged', () => {
 		_resetRegistryForTest();
 		_resetListChangedForTest();
 		_setItcHandlersForTest(undefined);
+		_setUserResolverForTest(undefined);
 	});
 
 	it('subscribes to both userHandler and schemaHandler on init', () => {
@@ -140,6 +142,47 @@ describe('mcp/listChanged', () => {
 	it('init returns false when ITC handlers are unavailable', () => {
 		_setItcHandlersForTest({}); // empty — no addListener methods
 		assert.equal(initListChanged(), false);
+	});
+
+	it('re-resolves the user inside the handler so a role-perm grant fires the notification', async () => {
+		// The scenario: a tool only visible to users with a `foo.read` perm.
+		// Alice starts WITHOUT it. Some external mutation grants her the perm
+		// AND fires the user-cache invalidation. The notification dispatcher
+		// must see the FRESH alice (with foo.read), recompute the visible set,
+		// notice the diff, and emit. Without re-resolution, the diff runs
+		// against the frozen no-foo alice and silently suppresses the event.
+		const aliceWithoutFoo = {
+			username: 'alice',
+			role: { permission: {} },
+		};
+		const aliceWithFoo = {
+			username: 'alice',
+			role: { permission: { foo: { tables: { bar: { read: true } } } } },
+		};
+		addTool({
+			name: 'get_foo_bar',
+			description: 'x',
+			inputSchema: { type: 'object' },
+			profile: 'application',
+			visibleTo: (u) => u?.role?.permission?.foo?.tables?.bar?.read === true,
+			handler: async () => ({ content: [{ type: 'text', text: '' }] }),
+		});
+
+		initListChanged();
+		const rec = registerSession('sid', 'application', aliceWithoutFoo);
+		seedSessionSnapshot('sid');
+		assert.deepEqual(rec.lastTools, [], 'before the grant, alice sees no tools');
+
+		// Now the grant lands externally; the user cache is invalidated. The
+		// test seam resolver returns the fresh alice with the new perms.
+		_setUserResolverForTest(async (username) => (username === 'alice' ? aliceWithFoo : undefined));
+
+		fakeItc._fireUser();
+		const evt = await readNextEvent(rec.queue);
+		assert.equal(evt.data.method, 'notifications/tools/list_changed');
+		// The session's user reference should have been swapped in-place so
+		// subsequent diffs run against current perms too.
+		assert.equal(rec.user, aliceWithFoo, 'record.user updated to the freshly-resolved user');
 	});
 
 	it('schema events also fan out (application profile)', async () => {

--- a/unitTests/components/mcp/sessionRegistry.test.js
+++ b/unitTests/components/mcp/sessionRegistry.test.js
@@ -4,15 +4,23 @@ const {
 	unregisterSession,
 	getRegisteredSession,
 	forEachSessionByProfile,
+	touchRegisteredSession,
 	_resetSessionRegistryForTest,
 	_sessionRegistrySize,
+	_setClockForTest,
 } = require('#src/components/mcp/sessionRegistry');
 
 const SUPER = { username: 'admin', role: { permission: { super_user: true } } };
 
 describe('mcp/sessionRegistry', () => {
+	let clock = 0;
+	beforeEach(() => {
+		clock = 0;
+		_setClockForTest(() => clock);
+	});
 	afterEach(() => {
 		_resetSessionRegistryForTest();
+		_setClockForTest(undefined);
 	});
 
 	it('registers and retrieves a session', () => {
@@ -65,5 +73,92 @@ describe('mcp/sessionRegistry', () => {
 		assert.equal(_sessionRegistrySize(), 2);
 		_resetSessionRegistryForTest();
 		assert.equal(_sessionRegistrySize(), 0);
+	});
+
+	describe('on-close hook (dropped SSE connection)', () => {
+		it('emitting "close" on the queue unregisters the session', () => {
+			const rec = registerSession('drop-1', 'application', SUPER);
+			assert.equal(_sessionRegistrySize(), 1);
+			// Simulate the iterator return/throw path: emit 'close' on the queue,
+			// which is what EventQueueIterator.return() does when the consumer
+			// stops iterating (HTTP server detects client disconnect).
+			rec.queue.emit('close');
+			assert.equal(_sessionRegistrySize(), 0);
+			assert.equal(getRegisteredSession('drop-1'), undefined);
+		});
+
+		it('explicit unregisterSession does not loop via the on-close listener', () => {
+			const rec = registerSession('drop-2', 'application', SUPER);
+			// unregisterSession itself emits 'close', which would re-enter
+			// unregisterSession via the listener. The "once" listener + the
+			// registry.get check above guard against a recursive loop.
+			let emitCount = 0;
+			rec.queue.on('close', () => emitCount++);
+			unregisterSession('drop-2');
+			assert.equal(_sessionRegistrySize(), 0);
+			// The user-added 'close' listener should have fired exactly once.
+			assert.equal(emitCount, 1);
+		});
+	});
+
+	describe('idle-session prune (backstop for missed on-close)', () => {
+		it('drops sessions whose lastSeen is past the idle window', () => {
+			registerSession('idle-1', 'application', SUPER);
+			assert.equal(_sessionRegistrySize(), 1);
+			// Past prune-interval AND past idle window. Pruning runs on
+			// register, so registering a different session triggers the sweep.
+			clock += 61 * 60 * 1000;
+			registerSession('idle-2', 'application', SUPER);
+			// 'idle-1' is past the idle window and has no active iterator —
+			// should have been pruned. Only 'idle-2' remains.
+			assert.equal(_sessionRegistrySize(), 1);
+			assert.equal(getRegisteredSession('idle-1'), undefined);
+			assert.ok(getRegisteredSession('idle-2'));
+		});
+
+		it('does not prune a session whose iterator is actively awaiting data', () => {
+			const rec = registerSession('live-1', 'application', SUPER);
+			// Force the queue into an "iterator awaiting" state by reading
+			// from it. The async iterator's next() sets resolveNext.
+			const iter = rec.queue[Symbol.asyncIterator]();
+			const pending = iter.next();
+			assert.notEqual(rec.queue.resolveNext, null, 'iterator should be awaiting');
+			clock += 61 * 60 * 1000;
+			registerSession('live-2', 'application', SUPER);
+			// 'live-1' has an active iterator — even past the idle window
+			// it should survive the prune.
+			assert.ok(getRegisteredSession('live-1'), 'active session survives prune');
+			// Cleanup: resolve the pending iter by emitting close.
+			rec.queue.emit('close');
+			pending.catch(() => {});
+		});
+
+		it('touchRegisteredSession bumps lastSeen so a busy session escapes the prune window', () => {
+			registerSession('busy-1', 'application', SUPER);
+			// Half-way through the idle window, simulate tools/call activity.
+			clock += 30 * 60 * 1000;
+			touchRegisteredSession('busy-1');
+			// Another 40 minutes — would normally be past 60-minute idle.
+			clock += 40 * 60 * 1000;
+			registerSession('busy-2', 'application', SUPER);
+			// Without touchSession, busy-1 would be pruned (70 > 60). With
+			// the touch at t=30min, last-seen is 70-40 = 30min ago, under 60.
+			assert.ok(getRegisteredSession('busy-1'), 'touched session survives');
+		});
+
+		it('prune is throttled — a second sweep within PRUNE_INTERVAL_MS is a no-op', () => {
+			// First prune fires when we register past the idle window.
+			registerSession('throttle-a', 'application', SUPER);
+			clock += 61 * 60 * 1000;
+			registerSession('throttle-b', 'application', SUPER);
+			assert.equal(getRegisteredSession('throttle-a'), undefined, 'first prune ran');
+			// Now make throttle-b artificially "idle" by jumping <5 min into
+			// the future (still within the prune-interval cooldown) but
+			// >IDLE_PRUNE_MS old by lastSeen accounting. The prune should
+			// SKIP entirely, so throttle-b survives.
+			clock += 1 * 60 * 1000;
+			registerSession('throttle-c', 'application', SUPER);
+			assert.ok(getRegisteredSession('throttle-b'), 'prune throttled, b survives');
+		});
 	});
 });

--- a/unitTests/components/mcp/tools/operations.test.js
+++ b/unitTests/components/mcp/tools/operations.test.js
@@ -77,6 +77,70 @@ describe('mcp/tools/operations — registration', () => {
 		assert.equal(getTool('delete'), undefined);
 	});
 
+	it('excludes sensitive get_* operations from the default-allow set', () => {
+		// The DEFAULT_ALLOW list MUST NOT pull in operations that can leak
+		// secrets or source code into the LLM context. verifyPerms still
+		// gates the actual dispatch, but defaulting to "expose secrets to
+		// LLM if super_user calls it" is the wrong default. Operators who
+		// genuinely want any of these can opt in via mcp.operations.allow.
+		_setOperationFunctionMapForTest(
+			makeOpMap([
+				['get_configuration', async () => ({ secrets: 'inside' })],
+				['get_custom_function', async () => ({ source: 'fn body' })],
+				['get_custom_functions', async () => ({ functions: [] })],
+				['get_components', async () => ({ components: [] })],
+				['get_component_file', async () => ({ contents: '' })],
+				['get_backup', async () => ({ backup: '' })],
+				['get_deployment', async () => ({})],
+				['get_deployment_payload', async () => ({})],
+				// These four ARE in the explicit safe list.
+				['get_job', async () => ({})],
+				['get_status', async () => ({})],
+				['get_analytics', async () => ({})],
+				['get_metrics', async () => ({})],
+			])
+		);
+
+		registerOperationsTools();
+
+		const { tools } = listTools({ user: SUPER, profile: 'operations', sessionId: 's', limit: 200 });
+		const names = new Set(tools.map((t) => t.name));
+		// Sensitive getters: NOT in the default surface.
+		for (const sensitive of [
+			'get_configuration',
+			'get_custom_function',
+			'get_custom_functions',
+			'get_components',
+			'get_component_file',
+			'get_backup',
+			'get_deployment',
+			'get_deployment_payload',
+		]) {
+			assert.ok(!names.has(sensitive), `${sensitive} must not be default-allowed`);
+		}
+		// Safe getters: IN the default surface.
+		for (const safe of ['get_job', 'get_status', 'get_analytics', 'get_metrics']) {
+			assert.ok(names.has(safe), `${safe} should be default-allowed`);
+		}
+	});
+
+	it('an operator can still opt sensitive getters into the surface via mcp.operations.allow', () => {
+		envOverrides.mcp_operations_allow = ['get_configuration', 'get_components'];
+		_setOperationFunctionMapForTest(
+			makeOpMap([
+				['get_configuration', async () => ({})],
+				['get_components', async () => ({})],
+				['get_job', async () => ({})], // not on the explicit allow → excluded
+			])
+		);
+		registerOperationsTools();
+		const { tools } = listTools({ user: SUPER, profile: 'operations', sessionId: 's', limit: 200 });
+		const names = new Set(tools.map((t) => t.name));
+		assert.ok(names.has('get_configuration'));
+		assert.ok(names.has('get_components'));
+		assert.ok(!names.has('get_job'), 'when allow is set, DEFAULT_ALLOW is replaced not merged');
+	});
+
 	it('honors a user-defined allow list', () => {
 		envOverrides.mcp_operations_allow = ['describe_*', 'insert'];
 		_setOperationFunctionMapForTest(
@@ -156,7 +220,18 @@ describe('mcp/tools/operations — registration', () => {
 	it('DEFAULT_ALLOW is exposed and matches the documented v1 surface', () => {
 		assert.deepEqual(
 			[...DEFAULT_ALLOW],
-			['describe_*', 'list_*', 'search_*', 'get_*', 'system_information', 'read_log', 'read_audit_log']
+			[
+				'describe_*',
+				'list_*',
+				'search_*',
+				'get_job',
+				'get_status',
+				'get_analytics',
+				'get_metrics',
+				'system_information',
+				'read_log',
+				'read_audit_log',
+			]
 		);
 	});
 

--- a/unitTests/components/mcp/transport.test.js
+++ b/unitTests/components/mcp/transport.test.js
@@ -103,15 +103,15 @@ describe('mcp/transport', () => {
 			assert.equal(res.jsonBody.result.capabilities.tools.listChanged, true);
 		});
 
-		it('rejects unsupported protocolVersion with 400 and the supported list', async () => {
+		it('negotiates an unsupported protocolVersion down to the preferred one (spec: MUST respond with a supported version)', async () => {
 			const res = await handleMcpRequest(
 				makeReq({
 					body: jsonRpc(1, 'initialize', { protocolVersion: '1999-01-01' }),
 				})
 			);
-			assert.equal(res.status, 400);
-			assert.equal(res.jsonBody.error.code, -32602);
-			assert.deepEqual([...res.jsonBody.error.data.supportedVersions], ['2025-06-18', '2025-03-26']);
+			assert.equal(res.status, 200);
+			assert.equal(res.jsonBody.result.protocolVersion, '2025-06-18');
+			assert.ok(res.headers['Mcp-Session-Id'], 'session created on negotiated version');
 		});
 
 		it('rejects missing protocolVersion with 400', async () => {

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -347,6 +347,7 @@ export const SERVICE_ACTIONS_ENUM = {
 	OPERATION: 'operation',
 	RENEWCERTS: 'renew-certs',
 	COPYDB: 'copy-db',
+	MCP: 'mcp',
 } as const;
 
 /** describes the Geo Conversion types */


### PR DESCRIPTION
## Summary

PR-2 of the consolidated MCP v1 rollout (sequel to PR #856). Closes **#621** and **#623** and folds in the three non-blocking medium follow-ups @kriszyp flagged on PR #856's approval review.

- **`harper mcp` stdio CLI** (#621): bridge / print-config / doctor subcommands. UDS-first connect (no creds, filesystem-perm-gated) with HTTPS fallback. Full Streamable HTTP MCP client over stdin/stdout including SSE-response parsing, Mcp-Session-Id persistence, and a long-lived GET stream for `notifications/*`.
- **SDK-driven E2E suite** (#623): `integrationTests/mcp/sdk.test.ts` runs against a real Harper boot via `@modelcontextprotocol/sdk@^1.29` (added as devDep). Validates spec conformance from the reference client.
- **PR-1 follow-ups** carried forward (#856 review):
  - `sessionRegistry`: idle-prune sweep + SSE on-close hook so dropped GET connections don't leak `IterableEventQueue` records. `touchRegisteredSession` from `dispatchToolsCall` keeps live sessions out of the prune sweep.
  - `listChanged`: re-resolves the session's user inside the change handler (via a `findAndValidateUser` test seam) so a role-perm mutation between handshake and the cache-invalidation event is correctly diffed against the *current* permission set — previously diffed against the frozen snapshot and suppressed notifications.
  - `tools/operations.ts`: replaced the broad `get_*` default-allow glob with an explicit safe-getters list (`get_job`, `get_status`, `get_analytics`, `get_metrics`). The glob had been pulling in `get_configuration` (secrets), `get_components`/`get_component_file`/`get_custom_function*` (source code that can embed secrets), `get_backup`, and `get_deployment*`. Operators who want any of those opt in via `mcp.operations.allow`.
- **Spec-conformance fix surfaced by the SDK test**: `handleInitialize` now negotiates down to the preferred supported version on an unknown `protocolVersion` instead of erroring with -32602 — per MCP spec, the server MUST respond with a supported version, not fail. This is what let SDK 1.29 (which sends `2025-11-25` by default, newer than Harper's `2025-06-18`) connect at all.

## Where to look

- `components/mcp/lifecycle.ts:61-101` — the spec-conformance fix is small but behavior-changing. Worth a careful read.
- `components/mcp/sessionRegistry.ts` (full file) — new idle-prune + close-listener logic. The recursion-safety argument for the `once('close')` listener is in a comment above `queue.once(...)`; please check the reasoning.
- `components/mcp/listChanged.ts:78-89, 169-211` — the user re-resolve seam and the async handler shim. The bound listener is a sync wrapper that swallows the resulting promise rejection; happy to make this an explicit pattern elsewhere if you'd rather.
- `bin/mcp/client.ts` (full file) — the Streamable HTTP client. Notable: SSE parser is hand-rolled (lightweight, MCP only needs `event`/`data`/`id`); the GET stream uses `AbortController` for cleanup on bridge shutdown. No new deps.
- `integrationTests/mcp/sdk.test.ts` — the conformance suite. Currently failing locally with 401 (admin user not provisioned in this fresh worktree environment) but should be exercised by GH Actions CI.

## Cross-model review

Neither `codex` nor `gemini`/`agy` is available in the environment this branch was prepared from, so the standard step-9 cross-model review was skipped. Would appreciate a manual second-model pass if either is convenient before merge — none of the changes are large-blast-radius but the spec fix touches handshake behavior that other clients depend on.

## Open follow-ups (out of scope for this PR)

- `harper/documentation` MCP section (separate-repo PR, deferred to a follow-up).
- `HarperFast/mcp-server` external addon: deprecation README + archive on merge (separate repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)