### PR TITLE
fix(migration): reuse copied structures during LMDB→RocksDB re-encode

### DIFF
--- a/bin/copyDb.ts
+++ b/bin/copyDb.ts
@@ -430,9 +430,23 @@ export async function copyDbToRocks(sourceRootStore, sourceDatabase: string, tar
 				existingEncoder.isRocksDB = true;
 				existingEncoder.rootStore = targetRootStore;
 				const tempEncoder = new RecordEncoder({ name: key }) as any;
+				// msgpackr's pack closure captures `packr = this` at construction, so during
+				// re-encoding the structure callbacks resolve to tempEncoder's getStructures/
+				// saveStructures (invoked with this === tempEncoder), not existingEncoder's.
+				// tempEncoder must therefore carry the RocksDB wiring too, or getStructures hits
+				// the non-RocksDB branch where the captured super is undefined and throws.
+				tempEncoder.name = key;
+				tempEncoder.isRocksDB = true;
+				tempEncoder.rootStore = targetRootStore;
 				existingEncoder.encode = tempEncoder.encode;
-				existingEncoder.saveStructures = tempEncoder.saveStructures;
 				existingEncoder.getStructures = tempEncoder.getStructures;
+				// The shared structures dictionary is copied verbatim from the source by
+				// copyStructures() below, so re-encoding never needs to persist new structures.
+				// A no-op saveStructures avoids opening a targetRootStore.transactionSync() in the
+				// middle of each record's encode, which otherwise discards the targetDbi record writes.
+				const noopSaveStructures = () => true;
+				existingEncoder.saveStructures = noopSaveStructures;
+				tempEncoder.saveStructures = noopSaveStructures;
 			}
 
 			copyStructures(sourceDbi, key);


### PR DESCRIPTION
## Summary

`main`'s integration tests were red — shard 2 specifically, on every Linux Node version (the `upgrade/4.x-upgrade.test.ts` suite is skipped on Bun/Windows). The single failure was **"upgrade and migrate LMDB to RocksDB"**, which had recently shifted from shard 1 into shard 2 when new test files were added (sharding is by file). The migrate test passed at the last green run (`11d19b898`) and regressed afterward.

### Root cause

In `copyDbToRocks` the target RocksDB store's encoder is patched with a throwaway `tempEncoder`'s methods so metadata headers (timestamps, `HAS_BLOBS`) are written. But msgpackr captures `packr = this` at construction, so during re-encoding the structure callbacks resolve to **`tempEncoder`'s** `getStructures`/`saveStructures` (invoked with `this === tempEncoder`) — which had none of the RocksDB wiring. `getStructures` fell into the non-RocksDB branch where the captured `super` is `undefined`:

```
TypeError: Cannot read properties of undefined (reading 'call')
    at RecordEncoder.saveStructures (dist/resources/RecordEncoder.js:231:52)
```

Shared structures were therefore never available → migrated records failed to decode (`Data read, but end of buffer not reached`) → the system database's users/roles were unreadable → every post-migration login returned **401 "Must login"**.

### Fix

- Wire `tempEncoder` with `name`/`isRocksDB`/`rootStore` so `getStructures` reads the structures dictionary that `copyStructures()` already copies verbatim from the source.
- Make `saveStructures` a **no-op**: re-encoding already-structured source data never needs to persist new structures. (The prior path routed `saveStructures` through `rootStore.transactionSync()` *in the middle of each record's encode*, which silently discarded the `targetDbi` record writes — a second failure mode this avoids.)

## Test plan

- [x] Full **shard 2/4: 108/108 pass** (was 1 failure)
- [x] `upgrade/4.x-upgrade.test.ts` — 3/3; validates roles/users + all 60 widgets via `deepStrictEqual`, index lookups, and the post-migration symbol-key check
- [x] `unitTests/resources/schemaMigrationFragility.test.js` (the rebind commit's tests) — 7/7
- [x] `unitTests/bin/blobMigration.test.js` under `HARPER_STORAGE_ENGINE=lmdb` (exercises `copyDbToRocks` directly) — 2/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)