### PR TITLE
test(Scope): drain in-flight watcher events before rmSync to fix flake

### DIFF
--- a/unitTests/components/Scope.test.js
+++ b/unitTests/components/Scope.test.js
@@ -29,8 +29,17 @@ describe('Scope', () => {
 		resetRestartNeeded();
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		resetRestartNeeded();
+		// Yield to the event loop so any in-flight chokidar watcher teardown
+		// (from scope.close() in the test body) and any pending readFile
+		// promises inside EntryHandler can settle before we remove the
+		// temp directory. Otherwise, deleting test.js while a watcher event
+		// is in flight surfaces a benign ENOENT through the watcher's error
+		// path after the EntryHandler/OptionsWatcher have already removed
+		// their listeners, which mocha sees as a duplicate done() with an
+		// error. Observed flake on Node v24/v26 (tighter watcher timing).
+		await new Promise((resolve) => setImmediate(resolve));
 		try {
 			rmSync(this.directory, { recursive: true, force: true });
 			// eslint-disable-next-line sonarjs/no-ignored-exceptions


### PR DESCRIPTION
## Summary

- Make the outer `afterEach` in `Scope.test.js` async and add a single `await new Promise(r => setImmediate(r))` before `rmSync` to yield one macrotask cycle before the temp directory is deleted.

## Root cause

`Scope.close()` → `EntryHandler.close()` → `OptionsWatcher.close()` call `this.#watcher.close()` (chokidar) without awaiting the returned Promise and without draining pending `readFile` chains. After `scope.close()` returns, in-flight watcher callbacks can still fire. The `afterEach` deletes the temp directory immediately, triggering an ENOENT on `test.js` in the still-live watcher — which hits mocha's `done()` a second time.

Symptoms on Node v24/v26 (tighter scheduler timing than v22):
```
Error: done() called multiple times in hook <Scope "after each" hook>
in addition, done() received error: Error: ENOENT: no such file or directory, open '...test.js'
```

## Fix

One `setImmediate` yield in `afterEach` gives chokidar's async close and any pending `readFile` promises a chance to settle before the directory is removed. Test-only change — no production code touched.

The underlying production fix (making `EntryHandler.close()` / `OptionsWatcher.close()` return an awaitable Promise) is tracked separately.

## Test plan

- [ ] `npm run test:unit:main` passes consistently on Node v24 and v26
- [ ] No change to test semantics — `scope.close()` is still called by each test body; afterEach only adds a drain step

🤖 Generated with [Claude Code](https://claude.com/claude-code)