### PR TITLE
fix: proper async close lifecycle for EntryHandler, OptionsWatcher, and Scope

### DIFF
--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -298,15 +298,16 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		return this.#openCount;
 	}
 
-	close(): this {
+	close(): Promise<this> {
 		this.#closed = true;
-		this.#watcher?.close();
+		const pendingReads = [...this.#pendingFileReads];
+		const watcherClose = this.#watcher ? Promise.resolve(this.#watcher.close()).catch(() => {}) : Promise.resolve();
 		this.#watcher = undefined;
 
 		this.emit('close');
 		this.removeAllListeners();
 
-		return this;
+		return Promise.allSettled([watcherClose, ...pendingReads]).then(() => this);
 	}
 
 	/**

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -303,11 +303,15 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		const pendingReads = [...this.#pendingFileReads];
 		const watcherClose = this.#watcher ? Promise.resolve(this.#watcher.close()).catch(() => {}) : Promise.resolve();
 		this.#watcher = undefined;
+		// If paused, there may be an in-flight close from pause() that hasn't settled yet.
+		// Include it so close() doesn't resolve while inotify handles are still releasing.
+		const pausedClose = this.#pausedClose ?? Promise.resolve();
+		this.#pausedClose = undefined;
 
 		this.emit('close');
 		this.removeAllListeners();
 
-		return Promise.allSettled([watcherClose, ...pendingReads]).then(() => this);
+		return Promise.allSettled([watcherClose, pausedClose, ...pendingReads]).then(() => this);
 	}
 
 	/**

--- a/components/OptionsWatcher.ts
+++ b/components/OptionsWatcher.ts
@@ -91,6 +91,7 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 	#usingPolling: boolean;
 	#closed: boolean;
 	#openCount: number = 0;
+	#pendingReads: Set<Promise<void>> = new Set();
 	ready: Promise<any[]>;
 
 	constructor(name: string, filePath: string, logger?: Logger) {
@@ -119,7 +120,7 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 	}
 
 	#handleChange() {
-		readFile(this.#filePath, 'utf-8')
+		const read: Promise<void> = readFile(this.#filePath, 'utf-8')
 			.then((contents) => {
 				this.#rootConfig = yaml.parse(contents);
 				// If the extension is in the config file
@@ -160,7 +161,11 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 					return;
 				}
 				this.emit('error', error);
+			})
+			.finally(() => {
+				this.#pendingReads.delete(read);
 			});
+		this.#pendingReads.add(read);
 	}
 
 	#handleError(error: unknown) {
@@ -339,17 +344,19 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 	}
 
 	/**
-	 * Closes the underlying file watcher, emits the `close` event, and removes any listeners on the OptionsWatcher instance
+	 * Closes the underlying file watcher and drains any pending config-file reads.
+	 * Emits `close` synchronously, removes all listeners, then returns a Promise that
+	 * resolves once the chokidar watcher has fully stopped and all in-flight reads settle.
 	 */
-	close() {
+	close(): Promise<this> {
 		this.#closed = true;
-		this.#watcher.close();
+		const pendingReads = [...this.#pendingReads];
+		const watcherClose = Promise.resolve(this.#watcher.close()).catch(() => {});
 
 		this.emit('close');
-
 		this.removeAllListeners();
 
-		return this;
+		return Promise.allSettled([watcherClose, ...pendingReads]).then(() => this);
 	}
 
 	/**

--- a/components/OptionsWatcher.ts
+++ b/components/OptionsWatcher.ts
@@ -122,7 +122,8 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 	#handleChange() {
 		const read: Promise<void> = readFile(this.#filePath, 'utf-8')
 			.then((contents) => {
-				this.#rootConfig = yaml.parse(contents);
+				const parsed = yaml.parse(contents);
+				this.#rootConfig = parsed && typeof parsed === 'object' ? parsed : undefined;
 				// If the extension is in the config file
 				if (this.#rootConfig && this.#name in this.#rootConfig) {
 					// If a config object does not exist

--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -178,18 +178,13 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 		this.emit('error', error);
 	}
 
-	close() {
+	async close(): Promise<this> {
 		deployLifecycle.off('deploy:start', this.#deployStartHandler);
 		deployLifecycle.off('deploy:end', this.#deployEndHandler);
 
-		for (const entryHandler of this.#entryHandlers) {
-			entryHandler.close();
-		}
-
-		this.options.close();
+		await Promise.allSettled([...this.#entryHandlers.map((h) => h.close()), this.options.close()]);
 
 		this.emit('close');
-
 		this.removeAllListeners();
 
 		return this;

--- a/unitTests/components/EntryHandler.test.js
+++ b/unitTests/components/EntryHandler.test.js
@@ -550,6 +550,21 @@ describe('EntryHandler', () => {
 			rmSync(directory, { recursive: true, force: true });
 		});
 
+		it('close() while paused awaits the paused watcher teardown', async () => {
+			// Exercises the `#pausedClose` branch in close(): pause() kicks off
+			// a watcher close, then close() lands before resume() and must await
+			// that in-flight teardown rather than resolving early.
+			const { directory } = createFixture(['a']);
+			const entryHandler = new EntryHandler(basename(directory), directory, '**/*');
+			await entryHandler.ready;
+
+			entryHandler.pause();
+			// close() called without resume() — exercises #pausedClose path
+			await entryHandler.close();
+			// if close() resolved, teardown settled without throwing
+			rmSync(directory, { recursive: true, force: true });
+		});
+
 		it('awaiting `ready` after pause() does not resolve until resume()', async () => {
 			// Contract: per pause()'s docstring, awaiting `ready` while paused must
 			// wait for resume(). Naive impl (only resetting `ready` in resume) lets

--- a/unitTests/components/EntryHandler.test.js
+++ b/unitTests/components/EntryHandler.test.js
@@ -193,9 +193,7 @@ describe('EntryHandler', () => {
 		assert.equal(unlinkDirArg.content, undefined, 'unlinkDir event argument `content` should not be defined');
 		assert.equal(unlinkDirArg.stats, undefined, 'unlinkDir event argument `stats` should not be defined');
 
-		const closeEvent = once(entryHandler, 'close');
-		entryHandler.close();
-		await closeEvent;
+		await entryHandler.close();
 		assert.equal(closeEventSpy.callCount, 1, 'close event should be triggered once');
 
 		assert.equal(entryHandler.listenerCount('ready'), 0, 'ready event listener should be removed');
@@ -215,7 +213,7 @@ describe('EntryHandler', () => {
 		await entryHandler.ready;
 		assert.equal(readyEventSpy.callCount, 1, 'ready event should be triggered once');
 
-		entryHandler.close();
+		await entryHandler.close();
 	});
 
 	it('should emit file change events', async () => {
@@ -248,7 +246,7 @@ describe('EntryHandler', () => {
 		assert.ok(changeArg.stats !== undefined, 'change event argument `stats` should be defined');
 		assert.ok(changeArg.stats.isFile(), 'change event argument `stats` should be a file');
 
-		entryHandler.close();
+		await entryHandler.close();
 	});
 
 	it('should handle updating the config', async () => {
@@ -306,9 +304,7 @@ describe('EntryHandler', () => {
 		assert.equal(addArgB.urlPath, '/b', 'add event should be triggered with the correct arguments');
 		assert.equal(addDirHandlerSpy.callCount, 0, 'addDir event should not be triggered');
 
-		const closeEvent = once(entryHandler, 'close');
-		entryHandler.close();
-		await closeEvent;
+		await entryHandler.close();
 		assert.equal(closeEventSpy.callCount, 1, 'close event should be triggered once');
 		assert.equal(entryHandler.listenerCount('ready'), 0, 'ready event listener should be removed');
 		assert.equal(entryHandler.listenerCount('close'), 0, 'close event listener should be removed');
@@ -368,8 +364,7 @@ describe('EntryHandler', () => {
 		assert.equal(addHandlerSpy.callCount, 6, 'add event should be triggered for each matching file');
 		assert.equal(addDirHandlerSpy.callCount, 0, 'addDir event should be triggered for each matching directory');
 
-		entryHandler.close();
-
+		await entryHandler.close();
 		rmSync(directory, { recursive: true, force: true });
 	});
 
@@ -415,8 +410,7 @@ describe('EntryHandler', () => {
 			'urlPath resolution should account for similarities'
 		);
 
-		entryHandler.close();
-
+		await entryHandler.close();
 		rmSync(directory, { recursive: true, force: true });
 	});
 
@@ -457,8 +451,7 @@ describe('EntryHandler', () => {
 			['/a', '/b', '/static-assets/c', '/static-assets/d']
 		);
 
-		entryHandler.close();
-
+		await entryHandler.close();
 		rmSync(directory, { recursive: true, force: true });
 	});
 
@@ -488,7 +481,7 @@ describe('EntryHandler', () => {
 			assert.ok(event.hasContents, `File ${event.path} should have contents when ready resolves`);
 		}
 
-		entryHandler.close();
+		await entryHandler.close();
 		rmSync(directory, { recursive: true, force: true });
 	});
 
@@ -518,7 +511,7 @@ describe('EntryHandler', () => {
 				`resume should re-emit add for current files, got ${addSpy.callCount} total`
 			);
 
-			entryHandler.close();
+			await entryHandler.close();
 			rmSync(directory, { recursive: true, force: true });
 		});
 
@@ -538,7 +531,7 @@ describe('EntryHandler', () => {
 
 			assert.ok(allSpy.callCount > before, 'all listener still attached after resume');
 
-			entryHandler.close();
+			await entryHandler.close();
 			rmSync(directory, { recursive: true, force: true });
 		});
 
@@ -553,7 +546,7 @@ describe('EntryHandler', () => {
 			await new Promise((r) => setTimeout(r, 100));
 			assert.equal(addSpy.callCount, 0, 'resume without pause should not re-emit');
 
-			entryHandler.close();
+			await entryHandler.close();
 			rmSync(directory, { recursive: true, force: true });
 		});
 
@@ -580,7 +573,7 @@ describe('EntryHandler', () => {
 			await readyPromise;
 			assert.equal(readyResolved, true, '`ready` resolves after resume()');
 
-			entryHandler.close();
+			await entryHandler.close();
 			rmSync(directory, { recursive: true, force: true });
 		});
 	});

--- a/unitTests/components/Scope.test.js
+++ b/unitTests/components/Scope.test.js
@@ -106,7 +106,7 @@ describe('Scope', () => {
 		const entryHandlerCloseSpy = spy();
 		entryHandlerNoArgs.on('close', entryHandlerCloseSpy);
 
-		scope.close();
+		await scope.close();
 		assert.equal(scopeCloseSpy.callCount, 1, 'close event should be emitted once');
 		assert.equal(scopeOptionsCloseSpy.callCount, 1, 'close event for options should be emitted once');
 		assert.equal(entryHandlerCloseSpy.callCount, 1, 'close event for entry handler should be emitted once');
@@ -163,7 +163,7 @@ describe('Scope', () => {
 		const entryHandlerCloseSpy = spy();
 		entryHandler.on('close', entryHandlerCloseSpy);
 
-		scope.close();
+		await scope.close();
 		assert.equal(scopeCloseSpy.callCount, 1, 'close event should be emitted once');
 		assert.equal(scopeOptionsCloseSpy.callCount, 1, 'close event for options should be emitted once');
 		assert.equal(entryHandlerCloseSpy.callCount, 1, 'close event for entry handler should be emitted once');
@@ -190,7 +190,7 @@ describe('Scope', () => {
 
 		assert.equal(restartNeeded(), true, 'requestRestart was called');
 
-		scope.close();
+		await scope.close();
 	});
 
 	it('should call requestRestart if no options handler is provided', async () => {
@@ -217,7 +217,7 @@ describe('Scope', () => {
 
 		assert.equal(restartNeeded(), true, 'requestRestart was called');
 
-		scope.close();
+		await scope.close();
 	});
 
 	it('should emit error for missing default entry handler', async () => {
@@ -258,7 +258,7 @@ describe('Scope', () => {
 
 		assert.equal(restartNeeded(), false, 'requestRestart should not be called');
 
-		scope.close();
+		await scope.close();
 	});
 
 	it('should support custom entry handlers', async () => {
@@ -292,7 +292,7 @@ describe('Scope', () => {
 		customEntryHandlerPathOnlyArg.on('close', entryHandleCloseSpy1);
 		customEntryHandlerPathAndFunctionArgs.on('close', entryHandleCloseSpy2);
 
-		scope.close();
+		await scope.close();
 
 		assert.equal(entryHandleCloseSpy1.callCount, 1, 'close event for custom entry handler should be emitted once');
 		assert.equal(entryHandleCloseSpy2.callCount, 1, 'close event for custom entry handler should be emitted once');
@@ -332,7 +332,7 @@ describe('Scope', () => {
 		await waitFor(() => handleEntrySpy.callCount > 0);
 		assert.ok(handleEntrySpy.callCount > 0, 'Entry handler should be called');
 
-		scope.close();
+		await scope.close();
 	});
 
 	describe('deploy lifecycle integration', () => {
@@ -376,7 +376,7 @@ describe('Scope', () => {
 			scope.requestRestart();
 			assert.equal(restartNeeded(), true, 'requestRestart works again after deploy:end');
 
-			scope.close();
+			await scope.close();
 		});
 
 		it('does not suppress requestRestart for an unrelated component', async () => {
@@ -400,7 +400,7 @@ describe('Scope', () => {
 				'requestRestart for this component must not be suppressed by an unrelated deploy'
 			);
 
-			scope.close();
+			await scope.close();
 		});
 
 		it('pauses entry handlers on deploy:start and resumes them on deploy:end without losing plugin listeners', async () => {
@@ -445,7 +445,7 @@ describe('Scope', () => {
 			await waitFor(() => handlerSpy.callCount > callsAfterResume);
 			assert.ok(handlerSpy.callCount > callsAfterResume, 'post-deploy change fires the plugin handler');
 
-			scope.close();
+			await scope.close();
 		});
 
 		it('re-emits deploy:start and deploy:end on the scope for plugins to observe', async () => {
@@ -473,7 +473,7 @@ describe('Scope', () => {
 			assert.equal(endSpy.callCount, 1);
 			assert.deepEqual(endSpy.getCall(0).args, [this.appName]);
 
-			scope.close();
+			await scope.close();
 		});
 
 		it('detaches deploy lifecycle listeners on scope.close()', async () => {
@@ -489,7 +489,7 @@ describe('Scope', () => {
 			await scope.ready;
 
 			const beforeClose = deployLifecycle.listenerCount('deploy:start');
-			scope.close();
+			await scope.close();
 			const afterClose = deployLifecycle.listenerCount('deploy:start');
 
 			assert.equal(


### PR DESCRIPTION
## Summary

- `EntryHandler.close()` and `OptionsWatcher.close()` were calling `this.#watcher.close()` (chokidar) fire-and-forget, not awaiting the returned Promise. `OptionsWatcher` also had no tracking of its in-flight `readFile` chains, so those could outlive `close()`.
- Root cause of flaky `done() called multiple times` errors in `Scope.test.js` on Node v24/v26: the temp directory was deleted by `afterEach` while watcher teardown and pending reads were still in flight, producing ENOENT errors that landed in already-removed listeners.
- `kris/fix-scope-test-flaky` applied a `setImmediate` drain in `afterEach` as a band-aid. This PR is the proper fix and supersedes it.

**Changes:**
- `OptionsWatcher`: add `#pendingReads: Set<Promise<void>>` and track each `readFile` chain (same pattern `EntryHandler` already used for `#pendingFileReads`)
- `EntryHandler.close()` and `OptionsWatcher.close()`: emit `'close'` synchronously (preserving existing listener contracts), then return `Promise.allSettled([watcherClose, pausedClose, ...pendingReads]).then(() => this)`
- `EntryHandler.close()` also includes `#pausedClose` in the allSettled array — a gap caught in review: when closed while paused, `#watcher` is already `undefined` but the paused watcher's inotify handles are still releasing
- `Scope.close()`: `async`, awaits all sub-closes before emitting its own `'close'` event
- Tests: all `scope.close()` and `entryHandler.close()` call sites updated to `await`

**Design choices worth a look:**
- `Promise.allSettled` (not `Promise.all`) is intentional — teardown errors aren't actionable, same rationale as `pause()` already documents
- `emit('close')` fires synchronously before the `allSettled` await in EntryHandler/OptionsWatcher, so callers that listen and immediately assert close-spy counts without awaiting still work. Scope emits its own `'close'` after the await; tests were updated accordingly.

*Generated by Claude Sonnet 4.6*