### PR TITLE
fix(logging): default rotation path to <log dir>/rotated when unset

### DIFF
--- a/unitTests/utility/logging/logRotator.test.js
+++ b/unitTests/utility/logging/logRotator.test.js
@@ -94,15 +94,10 @@ describe('Test logRotator module', () => {
 		);
 	});
 
-	it('Test error logged if rotation path is undefined', async () => {
-		let error;
-		try {
-			await runRotator({ maxSize: '1K', path: null });
-		} catch (e) {
-			error = e;
-		}
-		expect(error.message).to.equal(
-			"'logging.rotation.path' is undefined, to enable logging rotation set this value in harperdb-config.yaml"
-		);
+	it('Defaults rotation path to <log dir>/rotated when path is not set', async () => {
+		const rotated_log_path = await runRotator({ maxSize: '1K', path: null });
+		const expectedDir = path.join(LOG_DIR_TEST, 'rotated');
+		expect(rotated_log_path.startsWith(expectedDir)).to.be.true;
+		expect(fs.pathExistsSync(rotated_log_path)).to.be.true;
 	});
 });

--- a/utility/logging/logRotator.ts
+++ b/utility/logging/logRotator.ts
@@ -45,11 +45,8 @@ function logRotator({ logger, maxSize, interval, retention, enabled, path: rotat
 	}
 
 	if (!rotatedLogDir) {
-		// Default to <log file dir>/rotated when path is not explicitly set in config,
-		// so rotation works out of the box when only LOGGING_ROTATION_MAXSIZE is set.
 		rotatedLogDir = path.join(path.dirname(logger.path), 'rotated');
 	}
-	// Ensure the directory exists; moveLogFile's rename would otherwise ENOENT on first rotation.
 	mkdirSync(rotatedLogDir, { recursive: true });
 
 	// Convert maxSize param to bytes.

--- a/utility/logging/logRotator.ts
+++ b/utility/logging/logRotator.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { promises as fsProm, createReadStream, createWriteStream } from 'fs';
+import { promises as fsProm, createReadStream, createWriteStream, mkdirSync } from 'fs';
 import { createGzip } from 'zlib';
 import { promisify } from 'util';
 import { pipeline } from 'stream';
@@ -17,8 +17,6 @@ import { onStorageReclamation } from '../../server/storageReclamation.ts';
 const LOG_AUDIT_INTERVAL = 60000;
 const INT_SIZE_UNDEFINED_MSG =
 	"'interval' and 'maxSize' are both undefined, to enable logging rotation at least one of these values must be defined in harperdb-config.yaml";
-const PATH_UNDEFINED_MSG =
-	"'logging.rotation.path' is undefined, to enable logging rotation set this value in harperdb-config.yaml";
 
 let lastRotationTime;
 let setIntervalId;
@@ -47,8 +45,12 @@ function logRotator({ logger, maxSize, interval, retention, enabled, path: rotat
 	}
 
 	if (!rotatedLogDir) {
-		throw new Error(PATH_UNDEFINED_MSG);
+		// Default to <log file dir>/rotated when path is not explicitly set in config,
+		// so rotation works out of the box when only LOGGING_ROTATION_MAXSIZE is set.
+		rotatedLogDir = path.join(path.dirname(logger.path), 'rotated');
 	}
+	// Ensure the directory exists; moveLogFile's rename would otherwise ENOENT on first rotation.
+	mkdirSync(rotatedLogDir, { recursive: true });
 
 	// Convert maxSize param to bytes.
 	let maxBytes;


### PR DESCRIPTION
closes #1088 

## Summary

- Default `rotation.path` to `<dirname(logger.path)>/rotated` inside `logRotator` when not explicitly set, so rotation works out of the box when only `LOGGING_ROTATION_MAXSIZE` (or `LOGGING_ROTATION_INTERVAL`) is configured.
- `mkdirSync(rotatedLogDir, { recursive: true })` at init so the first rotation's rename doesn't ENOENT on the freshly defaulted dir.
- Drop the now-unused `PATH_UNDEFINED_MSG` constant.

## Context

Today the default config ships with `logging.rotation.enabled: true, maxSize: 64M, path: null`. The rotator at [`utility/logging/logRotator.ts:48-50`](utility/logging/logRotator.ts#L48) throws `'logging.rotation.path' is undefined, ...` when `path` is null, and [`harper_logger.ts:638-640`](utility/logging/harper_logger.ts#L638) catches the throw silently and re-emits it through the file logger we're trying to rotate. End result: an operator setting only `LOGGING_ROTATION_MAXSIZE=512M` gets no rotation and no actionable signal until the disk or quota fills.

Three fix shapes were considered in #1088: surface the catch to stderr, default the path, or fail config validation when `enabled: true` and `path: null`. This PR takes "default the path" because the other two either don't actually fix the broken default (just make it noisier) or break every existing deploy on upgrade.

The default lives in `logRotator` rather than in `defaultConfig.yaml` so it stays adjacent to whatever the actual log file path resolves to at runtime. An explicit `LOGGING_ROTATION_PATH` continues to override the default, and `LOGGING_ROTATION_ENABLED=false` continues to disable rotation entirely.

## Test

[`unitTests/utility/logging/logRotator.test.js`](unitTests/utility/logging/logRotator.test.js): the existing "Test error logged if rotation path is undefined" is replaced with "Defaults rotation path to <log dir>/rotated when path is not set", which calls the rotator with `path: null` and asserts the rotated file lands under `<LOG_DIR_TEST>/rotated/`.