### PR TITLE
chore: bump lmdb to 3.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
 				"json-bigint-fixes": "1.1.0",
 				"jsonata": "1.8.7",
 				"jsonwebtoken": "9.0.3",
-				"lmdb": "3.5.4",
+				"lmdb": "3.5.5",
 				"lodash": "^4.17.23",
 				"mathjs": "11.12.0",
 				"micromatch": "^4.0.8",
@@ -3562,9 +3562,9 @@
 			}
 		},
 		"node_modules/@lmdb/lmdb-darwin-arm64": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-3.5.4.tgz",
-			"integrity": "sha512-Kk4Kz3iyu1QiLsLZBS9Af1eSKUC8VR2T+/jyE2iAyuGw2VwK08pp5iTbZnXn6sWu0LogO/RFktMxOjiDA2sS3w==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-3.5.5.tgz",
+			"integrity": "sha512-hcSIUgSblRtwEuPzV/88cTbEPxaWfxVSrTaMIVUreyAA02ysE3S9tsiQdmT7KNmUaXlwgRGs+x+GaVDCuk7Prg==",
 			"cpu": [
 				"arm64"
 			],
@@ -3575,9 +3575,9 @@
 			]
 		},
 		"node_modules/@lmdb/lmdb-darwin-x64": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-3.5.4.tgz",
-			"integrity": "sha512-BEe5Rp3trn26oxoXOVL5HVDoiYmjUDwr8NRPkBOdUdCSBEorKI+7JrZLRKAdxO+G6cGQLgseXk0gR7qIQa7aGw==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-3.5.5.tgz",
+			"integrity": "sha512-cLlp9ypk3W9Hr4fuTYwg1kL2vPfz887v9NXiHQE1raSKtJ8/hnghekqUu62wUQdQPgThLV8Om+Ran08wWuM/3w==",
 			"cpu": [
 				"x64"
 			],
@@ -3588,9 +3588,9 @@
 			]
 		},
 		"node_modules/@lmdb/lmdb-linux-arm": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-3.5.4.tgz",
-			"integrity": "sha512-SGbFR7816uBcTHc2ZY4S6WyOkl9bICnzqTQd2Mv4V/j24cfds88xx2nC6cm/y8zGQL7Ds31YF/5NGxjgcdM5Hw==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-3.5.5.tgz",
+			"integrity": "sha512-eDeK9vZww0dIXlRCZa7pvbEXSUpUNIJKUs13FxDzazL8CRLDLggbeirm5m0hZvJcRgZzTYGESE8UUEBqHcdZ9Q==",
 			"cpu": [
 				"arm"
 			],
@@ -3601,9 +3601,9 @@
 			]
 		},
 		"node_modules/@lmdb/lmdb-linux-arm64": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-3.5.4.tgz",
-			"integrity": "sha512-cUXEengO8o60v1SWerJTH4/RH4U3+9jC0/4njp2Z9NdmvaGzhKsbRM2wpXuRYrN8tytsoJCg0SvWEWwHAwLbCA==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-3.5.5.tgz",
+			"integrity": "sha512-tn8KSYdvX5sietpuGyJJSXocvQQtWlenzquap/Mzr+wWx5jrjK5I3nEAIMFxvTtuMMrpPTGHGNuE/Hanh3o0EQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3614,9 +3614,9 @@
 			]
 		},
 		"node_modules/@lmdb/lmdb-linux-x64": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-3.5.4.tgz",
-			"integrity": "sha512-Gxq8jpgOWXwd0PUR+c9R2Ik1/uBnGd5GMIIzRRDqABCkvmjtC3KWcyhesV9jSPCz759isl0NlbsstZ2oyvk8lA==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-3.5.5.tgz",
+			"integrity": "sha512-o6VRcJjZ6Zc67MnymLEa3AtbYSreFzm6Um6LMHh4lkynlE5Qk/XUHXU2beTZBdB3QuZBiMoXO2gjPSgP0tYUKg==",
 			"cpu": [
 				"x64"
 			],
@@ -3627,9 +3627,9 @@
 			]
 		},
 		"node_modules/@lmdb/lmdb-win32-arm64": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-arm64/-/lmdb-win32-arm64-3.5.4.tgz",
-			"integrity": "sha512-pKv1DJ1bPZAaHkdFsSz5IDfUG8x9vntgquXF9/Dm2xuupcIe/EkLzylpoBxppFVK5vzbV561Dq26jNY2fIMA7g==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-arm64/-/lmdb-win32-arm64-3.5.5.tgz",
+			"integrity": "sha512-k0k/CwywhymTAJT7Uj5PdehH31Vem2ov/Jp0rn5McuJEHgzj7vbE0cmnByhjrQv+VeHLALI8wUZNicqwocPB4Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -3640,9 +3640,9 @@
 			]
 		},
 		"node_modules/@lmdb/lmdb-win32-x64": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.5.4.tgz",
-			"integrity": "sha512-JF1BmLCm9kGEVZgYmJq43zeQVdHVgAJnTi/NURWEsy6L1ZrrlSmdltS+D17QN4LODwf+1LMXAA9auIZVXtWwzw==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.5.5.tgz",
+			"integrity": "sha512-dkV3r04ro8MfhBaPj4ZsARy0LIP3sK+rm2LAuVe2QLCepBIpSzRx8p8RLWfRfkKV5YNyJ3c0NUJxGNMqtTB6Fg==",
 			"cpu": [
 				"x64"
 			],
@@ -10684,9 +10684,9 @@
 			"peer": true
 		},
 		"node_modules/lmdb": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/lmdb/-/lmdb-3.5.4.tgz",
-			"integrity": "sha512-9FKQA6G1MMtqNxfxvSBNXD/axeG2QRjYbNh0/ykRL5xYcRbCm2vXq7B9bhc7nSuKdHzr8/BHIwfPuYYH1UsXXw==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/lmdb/-/lmdb-3.5.5.tgz",
+			"integrity": "sha512-e2q1RtHdJoDaQQNMJ55wJnD5BqpvzoJIEL3NBxfZXNBjYxY0QjCh3RSL/sqmi+y9l97cERdO4WwGFfYYVft1fA==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10701,13 +10701,13 @@
 				"download-lmdb-prebuilds": "bin/download-prebuilds.js"
 			},
 			"optionalDependencies": {
-				"@lmdb/lmdb-darwin-arm64": "3.5.4",
-				"@lmdb/lmdb-darwin-x64": "3.5.4",
-				"@lmdb/lmdb-linux-arm": "3.5.4",
-				"@lmdb/lmdb-linux-arm64": "3.5.4",
-				"@lmdb/lmdb-linux-x64": "3.5.4",
-				"@lmdb/lmdb-win32-arm64": "3.5.4",
-				"@lmdb/lmdb-win32-x64": "3.5.4"
+				"@lmdb/lmdb-darwin-arm64": "3.5.5",
+				"@lmdb/lmdb-darwin-x64": "3.5.5",
+				"@lmdb/lmdb-linux-arm": "3.5.5",
+				"@lmdb/lmdb-linux-arm64": "3.5.5",
+				"@lmdb/lmdb-linux-x64": "3.5.5",
+				"@lmdb/lmdb-win32-arm64": "3.5.5",
+				"@lmdb/lmdb-win32-x64": "3.5.5"
 			}
 		},
 		"node_modules/lmdb/node_modules/msgpackr": {

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
 		"json-bigint-fixes": "1.1.0",
 		"jsonata": "1.8.7",
 		"jsonwebtoken": "9.0.3",
-		"lmdb": "3.5.4",
+		"lmdb": "3.5.5",
 		"lodash": "^4.17.23",
 		"mathjs": "11.12.0",
 		"micromatch": "^4.0.8",


### PR DESCRIPTION
Bumps `lmdb` from 3.5.4 to 3.5.5.

> Released by @kriszyp — see [lmdb changelog](https://github.com/kriszyp/lmdb-js).