### PR TITLE
feat(hnsw): dynamic/query-time ef, rerank, and no-reindex on search-only option change

### DIFF
--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1124,17 +1124,35 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 
 			// note that non-indexed attributes do not need a dbi
 			if (attributeDescriptor?.attribute && !attributeDescriptor.name) attributeDescriptor.indexed = true; // legacy descriptor
-			// Include `embed` so a source/model change refreshes the embed registry.
-			const changed =
+			// Some index options affect only search, not the stored structure (e.g. HNSW's
+			// efConstructionSearch). Changing those should persist the new metadata but NOT trigger a
+			// reindex. A custom index declares such keys via a static `searchOnlyOptions`.
+			const indexType = attribute.indexed && typeof attribute.indexed === 'object' ? attribute.indexed.type : undefined;
+			const searchOnlyOptions: string[] = (indexType && CUSTOM_INDEXES[indexType]?.searchOnlyOptions) || [];
+			const stripSearchOnly = (indexed: any): any => {
+				if (!indexed || typeof indexed !== 'object' || searchOnlyOptions.length === 0) return indexed;
+				const copy = { ...indexed };
+				for (const key of searchOnlyOptions) delete copy[key];
+				return copy;
+			};
+			const commonChanged =
 				!attributeDescriptor ||
 				attributeDescriptor.type !== attribute.type ||
-				JSON.stringify(attributeDescriptor.indexed) !== JSON.stringify(attribute.indexed) ||
 				attributeDescriptor.nullable !== attribute.nullable ||
 				attributeDescriptor.version !== attribute.version ||
 				attributeDescriptor.enumerable !== attribute.enumerable ||
 				JSON.stringify(attributeDescriptor.properties) !== JSON.stringify(attribute.properties) ||
 				JSON.stringify(attributeDescriptor.elements) !== JSON.stringify(attribute.elements) ||
+				// Include `embed` so a source/model change refreshes the embed registry.
 				JSON.stringify(attributeDescriptor.embed) !== JSON.stringify(attribute.embed);
+			// any metadata difference (drives persistence)
+			const changed =
+				commonChanged || JSON.stringify(attributeDescriptor?.indexed) !== JSON.stringify(attribute.indexed);
+			// structure-affecting difference (drives reindex) — ignores search-only option changes
+			const structurallyChanged =
+				commonChanged ||
+				JSON.stringify(stripSearchOnly(attributeDescriptor?.indexed)) !==
+					JSON.stringify(stripSearchOnly(attribute.indexed));
 			if (attribute.indexed) {
 				const dbi = openIndex(dbiKey, rootStore, attribute);
 				if (
@@ -1147,7 +1165,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 					exclusiveLock();
 					attributeDescriptor = attributesDbi.getSync(dbiKey);
 					if (
-						changed ||
+						structurallyChanged ||
 						attributeDescriptor.indexingFailed ||
 						(attributeDescriptor.indexingPID && attributeDescriptor.indexingPID !== process.pid) ||
 						attributeDescriptor.restartNumber < workerData?.restartNumber

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1157,18 +1157,18 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 				const dbi = openIndex(dbiKey, rootStore, attribute);
 				if (
 					changed ||
-					attributeDescriptor.indexingFailed ||
-					(attributeDescriptor.indexingPID && attributeDescriptor.indexingPID !== process.pid) ||
-					attributeDescriptor.restartNumber < workerData?.restartNumber
+					attributeDescriptor?.indexingFailed ||
+					(attributeDescriptor?.indexingPID && attributeDescriptor?.indexingPID !== process.pid) ||
+					attributeDescriptor?.restartNumber < workerData?.restartNumber
 				) {
 					hasChanges = true;
 					exclusiveLock();
 					attributeDescriptor = attributesDbi.getSync(dbiKey);
 					if (
 						structurallyChanged ||
-						attributeDescriptor.indexingFailed ||
-						(attributeDescriptor.indexingPID && attributeDescriptor.indexingPID !== process.pid) ||
-						attributeDescriptor.restartNumber < workerData?.restartNumber
+						attributeDescriptor?.indexingFailed ||
+						(attributeDescriptor?.indexingPID && attributeDescriptor?.indexingPID !== process.pid) ||
+						attributeDescriptor?.restartNumber < workerData?.restartNumber
 					) {
 						hasChanges = true;
 						if (attribute.indexNulls === undefined) attribute.indexNulls = true;

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1186,6 +1186,14 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 							// we only set indexing nulls to true if new or reindexing, we can't have partial indexing of null
 							attributesToIndex.push(attribute);
 						}
+					} else if (attributeDescriptor.indexingPID) {
+						// Metadata-only change (e.g. a search-only option like efConstructionSearch) while a
+						// backfill is in progress: we did NOT re-trigger indexing, so carry over the in-progress
+						// indexing state instead of persisting a descriptor that looks complete — otherwise other
+						// workers / a reload would treat the still-partial index as ready and return incomplete results.
+						attribute.indexingPID = attributeDescriptor.indexingPID;
+						attribute.lastIndexedKey = attributeDescriptor.lastIndexedKey;
+						if (attributeDescriptor.indexingFailed) attribute.indexingFailed = attributeDescriptor.indexingFailed;
 					}
 					attributesDbi.put(dbiKey, attribute);
 				}

--- a/resources/indexes/HierarchicalNavigableSmallWorld.ts
+++ b/resources/indexes/HierarchicalNavigableSmallWorld.ts
@@ -707,6 +707,24 @@ export class HierarchicalNavigableSmallWorld {
 			distance: candidate.distance,
 		}));
 	}
+	/**
+	 * Exact distance between a query and a record's FULL-precision vector, mirroring search()'s metric
+	 * selection. Used to rerank quantized (int8) results: graph traversal navigates on approximate
+	 * (quantized) distances, but the caller has the exact record vector and can restore exact ordering
+	 * and $distance.
+	 */
+	exactDistance(searchCondition: { target: number[]; distance?: string }, recordVector: number[] | Int8Array): number {
+		if (recordVector == null) return Infinity; // missing vector sorts last
+		const fn =
+			searchCondition.distance === 'euclidean'
+				? euclideanDistance
+				: searchCondition.distance === 'dotProduct'
+					? dotProductDistance
+					: searchCondition.distance === 'cosine'
+						? cosineDistance
+						: this.distance;
+		return fn(searchCondition.target, recordVector as number[]);
+	}
 	private checkSymmetry(id, node, options) {
 		if (!node) return;
 		let l = 0;

--- a/resources/indexes/HierarchicalNavigableSmallWorld.ts
+++ b/resources/indexes/HierarchicalNavigableSmallWorld.ts
@@ -136,6 +136,10 @@ type Node = {
  */
 export class HierarchicalNavigableSmallWorld {
 	static useObjectStore = true;
+	// Index options that only affect search, not the stored graph — changing them must not trigger a
+	// reindex (databases.ts persists the new value but skips rebuilding). efConstructionSearch is the
+	// search-time candidate-list size; the build uses efConstruction/M/distance, which are structural.
+	static searchOnlyOptions = ['efConstructionSearch'];
 	indexStore: any;
 	M: number = 16; // max number of connections per layer
 	efConstruction: number = 100; // size of dynamic candidate list

--- a/resources/indexes/HierarchicalNavigableSmallWorld.ts
+++ b/resources/indexes/HierarchicalNavigableSmallWorld.ts
@@ -682,7 +682,7 @@ export class HierarchicalNavigableSmallWorld {
 		else if (!this.efSearchConfigured) {
 			const nodeCount = this.indexStore.getKeysCount
 				? this.indexStore.getKeysCount()
-				: (this.indexStore.getStats?.().entryCount ?? 0);
+				: (this.indexStore.getStats?.()?.entryCount ?? 0);
 			effectiveEf = autoScaleEf(nodeCount);
 		}
 		let entryPoint = this.getEntryPoint(options);
@@ -715,6 +715,9 @@ export class HierarchicalNavigableSmallWorld {
 	 */
 	exactDistance(searchCondition: { target: number[]; distance?: string }, recordVector: number[] | Int8Array): number {
 		if (recordVector == null) return Infinity; // missing vector sorts last
+		// distance fns require a plain Array (they guard on Array.isArray); records normally store a
+		// float[] vector, but convert defensively in case a typed array slips through.
+		const vec = Array.isArray(recordVector) ? recordVector : Array.from(recordVector);
 		const fn =
 			searchCondition.distance === 'euclidean'
 				? euclideanDistance
@@ -723,7 +726,7 @@ export class HierarchicalNavigableSmallWorld {
 					: searchCondition.distance === 'cosine'
 						? cosineDistance
 						: this.distance;
-		return fn(searchCondition.target, recordVector as number[]);
+		return fn(searchCondition.target, vec);
 	}
 	private checkSymmetry(id, node, options) {
 		if (!node) return;

--- a/resources/indexes/HierarchicalNavigableSmallWorld.ts
+++ b/resources/indexes/HierarchicalNavigableSmallWorld.ts
@@ -41,6 +41,19 @@ function dequantizeInt8(q: Int8Array, scale: number): number[] {
 	return out;
 }
 
+// Auto-scaled search ef, used only when an index does not explicitly configure efConstructionSearch
+// and a query does not pass its own ef. A fixed ef makes recall decay as the graph grows (it explores
+// a shrinking fraction of the graph), so ef grows with the node count — capped to bound search cost.
+// These are conservative defaults; the exact curve should be calibrated from a recall/latency-vs-N
+// sweep (and high recall at large N also depends on build quality: efConstruction / M).
+const AUTO_EF_BASE = 50;
+const AUTO_EF_REF = 1000;
+const AUTO_EF_MAX = 512;
+function autoScaleEf(nodeCount: number): number {
+	const scaled = Math.round(AUTO_EF_BASE * Math.sqrt(Math.max(1, nodeCount / AUTO_EF_REF)));
+	return Math.min(AUTO_EF_MAX, Math.max(AUTO_EF_BASE, scaled));
+}
+
 class MinHeap {
 	private data: Candidate[] = [];
 	get size() {
@@ -136,6 +149,7 @@ export class HierarchicalNavigableSmallWorld {
 	idIncrementer: BigInt64Array | undefined;
 	distance: (a: number[], b: number[]) => number;
 	int8 = false; // store vectors as int8-quantized bins (set via the `quantization` index option)
+	efSearchConfigured = false; // whether the schema set an explicit search ef; if not, search ef auto-scales with N
 	constructor(indexStore: any, options: any) {
 		this.indexStore = indexStore;
 		if (indexStore) {
@@ -144,6 +158,8 @@ export class HierarchicalNavigableSmallWorld {
 			this.indexStore.encoder.useFloat32 = FLOAT32_OPTIONS.ALWAYS;
 		}
 		this.int8 = options?.quantization === 'int8';
+		// Respect an explicitly-configured search ef (or efConstruction, which seeds it); otherwise auto-scale.
+		this.efSearchConfigured = options?.efConstructionSearch !== undefined || options?.efConstruction !== undefined;
 		this.distance =
 			options?.distance === 'euclidean'
 				? euclideanDistance
@@ -620,12 +636,14 @@ export class HierarchicalNavigableSmallWorld {
 			descending,
 			distance,
 			comparator,
+			ef,
 		}: {
 			target: number[];
 			value: number;
 			descending: boolean;
 			distance: string;
 			comparator: string;
+			ef?: number;
 		},
 		context: any
 	) {
@@ -651,6 +669,16 @@ export class HierarchicalNavigableSmallWorld {
 		if (!Array.isArray(target)) throw new ClientError('The target vector must be an array');
 
 		const options = context.transaction; // should have a nested RocksDB transaction
+		// Resolve search ef: per-query ef wins; else an explicitly-configured efConstructionSearch;
+		// else auto-scale with the graph size so recall holds as the table grows.
+		let effectiveEf = this.efConstructionSearch;
+		if (ef !== undefined && ef > 0) effectiveEf = ef;
+		else if (!this.efSearchConfigured) {
+			const nodeCount = this.indexStore.getKeysCount
+				? this.indexStore.getKeysCount()
+				: (this.indexStore.getStats?.().entryCount ?? 0);
+			effectiveEf = autoScaleEf(nodeCount);
+		}
 		let entryPoint = this.getEntryPoint(options);
 		if (!entryPoint) return [];
 		let entryPointId = entryPoint.id;
@@ -658,15 +686,7 @@ export class HierarchicalNavigableSmallWorld {
 		// For each level from top to bottom
 		for (let l = entryPoint.level; l >= 0; l--) {
 			// Search for closest neighbors at current level
-			results = this.searchLayer(
-				target,
-				entryPointId,
-				entryPoint,
-				this.efConstructionSearch,
-				l,
-				options,
-				distanceFunction
-			);
+			results = this.searchLayer(target, entryPointId, entryPoint, effectiveEf, l, options, distanceFunction);
 
 			if (results.length > 0) {
 				const neighbor = results[0]; // closest neighbor becomes new entry point

--- a/resources/indexes/HierarchicalNavigableSmallWorld.ts
+++ b/resources/indexes/HierarchicalNavigableSmallWorld.ts
@@ -43,10 +43,12 @@ function dequantizeInt8(q: Int8Array, scale: number): number[] {
 
 // Auto-scaled search ef, used only when an index does not explicitly configure efConstructionSearch
 // and a query does not pass its own ef. A fixed ef makes recall decay as the graph grows (it explores
-// a shrinking fraction of the graph), so ef grows with the node count — capped to bound search cost.
-// These are conservative defaults; the exact curve should be calibrated from a recall/latency-vs-N
-// sweep (and high recall at large N also depends on build quality: efConstruction / M).
-const AUTO_EF_BASE = 50;
+// a shrinking fraction of the graph), so ef grows with sqrt(node count), capped to bound search cost.
+// Constants from a recall/latency-vs-N sweep (768-dim cosine, int8): ef≈400 holds ~0.8 recall@10 from
+// 5K–30K, and the recall/latency tradeoff is steep (ef 800 at 30K ≈ 0.92 recall but ~2s p50), so the
+// cap deliberately favors latency — apps wanting higher recall set efConstructionSearch or a per-query
+// ef. Tune as graph build quality / larger-N data improves.
+const AUTO_EF_BASE = 100;
 const AUTO_EF_REF = 1000;
 const AUTO_EF_MAX = 512;
 function autoScaleEf(nodeCount: number): number {

--- a/resources/search.ts
+++ b/resources/search.ts
@@ -387,7 +387,7 @@ export function searchByIndex(
 		return results;
 	} else if (index && !skipIndex) {
 		if (index.customIndex) {
-			return index.customIndex.search(searchCondition, context).map((entry) => {
+			const loaded = index.customIndex.search(searchCondition, context).map((entry) => {
 				// if the custom index returns an entry with metadata, merge it with the loaded entry
 				if (typeof entry === 'object' && entry) {
 					const { key, ...otherProps } = entry;
@@ -402,6 +402,24 @@ export function searchByIndex(
 				}
 				return entry;
 			});
+			// Rerank: a quantized index navigates on approximate distances, so for a nearest-neighbor
+			// (sort) query, recompute the exact distance from each loaded record's full-precision vector
+			// and re-sort — restoring exact ordering and $distance. (lt/le threshold queries still use the
+			// index's approximate distance for now; exact threshold filtering needs over-fetch — follow-up.)
+			if (
+				index.customIndex.int8 &&
+				index.customIndex.exactDistance &&
+				(comparator as any) === 'sort' &&
+				(searchCondition as any).target &&
+				typeof attribute_name === 'string'
+			) {
+				const rescored = (loaded as any[]).filter((e) => e !== SKIP && e && e.value);
+				for (const e of rescored)
+					e.distance = index.customIndex.exactDistance(searchCondition, e.value[attribute_name]);
+				rescored.sort((a, b) => a.distance - b.distance);
+				return rescored as any;
+			}
+			return loaded;
 		}
 		return index.getRange(rangeOptions).map(
 			filter

--- a/resources/search.ts
+++ b/resources/search.ts
@@ -416,7 +416,9 @@ export function searchByIndex(
 				const rescored = (loaded as any[]).filter((e) => e !== SKIP && e && e.value);
 				for (const e of rescored)
 					e.distance = index.customIndex.exactDistance(searchCondition, e.value[attribute_name]);
-				rescored.sort((a, b) => a.distance - b.distance);
+				// comparison-based (not subtraction) so Infinity sentinels for missing vectors
+				// sort last without producing NaN (Infinity - Infinity).
+				rescored.sort((a, b) => (a.distance === b.distance ? 0 : a.distance < b.distance ? -1 : 1));
 				return rescored as any;
 			}
 			return loaded;

--- a/unitTests/resources/vectorIndex.test.js
+++ b/unitTests/resources/vectorIndex.test.js
@@ -608,6 +608,33 @@ describe('HNSW int8 quantization (quantization: "int8")', () => {
 		assert.equal(await top('dotProduct'), 2, 'dotProduct should rank the max-projection first');
 		M.dropTable();
 	});
+
+	it('reranks int8 results so returned $distance is exact (recomputed from the record), sorted', async () => {
+		// The graph navigates on quantized distances, but the search layer reranks the candidates
+		// against each record's full-precision vector. So the returned $distance must equal the exact
+		// float distance to that record's own vector (within float epsilon), not the quantized value.
+		const target = vec(7);
+		const results = await fromAsync(
+			T.search({
+				sort: { attribute: 'vector', target, distance: 'cosine' },
+				select: ['id', 'vector', '$distance'],
+				limit: 8,
+			})
+		);
+		assert(results.length >= 1, 'expected results');
+		for (const r of results) {
+			const exact = testInstance.distance(target, r.vector); // exact cosine over the record's full vector
+			assert(
+				Math.abs(r.$distance - exact) < 1e-6,
+				`$distance ${r.$distance} should equal the exact full-precision distance ${exact} (reranked)`
+			);
+		}
+		for (let i = 1; i < results.length; i++)
+			assert(
+				results[i].$distance >= results[i - 1].$distance - 1e-9,
+				'results must be sorted ascending by exact distance'
+			);
+	});
 });
 
 async function fromAsync(iterable) {


### PR DESCRIPTION
Follow-up to #894 (int8 quantization, merged). Makes int8 HNSW production-quality — recall compensation + exact distances + cheap ef retuning.

## Summary
1. **Dynamic + query-time search ef** — `search()` resolves ef as: per-query `ef` > explicitly-configured `efConstructionSearch` > an auto-scaled `ef(N)` fallback (capped `sqrt(N)`, base 100). A fixed ef makes recall decay as the graph grows; this compensates. The cap favors latency — apps wanting more set `efConstructionSearch` or a per-query `ef`.
2. **No reindex on search-only option changes** (`databases.ts`) — changing `efConstructionSearch` previously forced a full reindex (and briefly 503'd the index). The change-check is split into structure-affecting (drives reindex) vs metadata-only (drives persistence); a custom index declares its search-only keys via `static searchOnlyOptions`. In-progress backfill state is preserved on metadata-only updates. Validated live: an ef change now persists + applies to the live index with no rebuild.
3. **Rerank** (`search.ts`) — a quantized index navigates on approximate distances, so for a nearest-neighbor (sort) query the search layer recomputes each candidate's distance from the record's full-precision vector and re-sorts, restoring exact `$distance` and ordering while keeping the fast int8 traversal.

## Why
From a recall/latency-vs-N sweep, int8 recall ≈ float at every scale but a fixed ef makes recall decay with N (search ef is the lever, not build quality — an A/B showed higher efConstruction barely helped while halving ingest, and `optimizeRouting=0.5` *helps* recall, so both were left alone). Rerank removes the approximate-`$distance` downside.

## Where to look
- `databases.ts` structural-vs-metadata split + the in-progress-indexing-state preservation (subtle: a metadata-only change mid-backfill must not mark a partial index complete).
- `search.ts` rerank: int8 + sort gating, the materialize/re-sort, missing-vector handling.
- ef resolution precedence in `HierarchicalNavigableSmallWorld.search()`.

## Open items / follow-ups (deliberately not here)
- **Default int8 flip** — separate deliberate compat change (a test-flip passed all 15 tests, but understand why float-assuming `verifyIntegrity` didn't break + add explicit default-int8 coverage + docs first).
- **`lt`/`le` int8 threshold queries** still use the index's approximate distance — exact threshold filtering needs over-fetch (follow-up).
- **Query-time `ef`** is accepted by the index but not yet plumbed from a query's `sort.ef` through core search — auto-scale covers the dynamic default.
- **Auto-ef cap** is conservative; the 100K calibration point is missing (box contention crashed it) — tune later.
- **Float32Array input seam** lands with #747.

## Review notes
Cross-model review run: **Codex** found one P2 (a metadata-only change mid-backfill could persist a partial index as complete) — **fixed** here. The **Gemini (agy) leg timed out** (loaded box) so no second-model coverage this round, and the worktree-isolated `reviewer` subagent was unavailable — adjudicated in-session. A Gemini re-run on a quieter box would be worthwhile. 15 unit tests pass.

_Generated with the assistance of an LLM (Claude Opus 4.8)._