### PR TITLE
chore: bump @harperfast/rocksdb-js to 1.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@fastify/cors": "^11.2.0",
 				"@fastify/static": "^9.1.3",
 				"@harperfast/extended-iterable": "^1.0.1",
-				"@harperfast/rocksdb-js": "^1.4.0",
+				"@harperfast/rocksdb-js": "^1.4.1",
 				"@turf/area": "6.5.0",
 				"@turf/boolean-contains": "6.5.0",
 				"@turf/boolean-disjoint": "6.5.0",
@@ -2923,9 +2923,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js/-/rocksdb-js-1.4.0.tgz",
-			"integrity": "sha512-Qa62jWYG5GO+OI3gEHJI3WyhzgA6OdFLthbmB7TRJJMa2Zu8s3psKuAnM0t2v963ohRFF4UbyRw24zt5PX3k3A==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js/-/rocksdb-js-1.4.1.tgz",
+			"integrity": "sha512-AZuIqtDiiSrnVvbupDsNlRGpJSpsONCVDKZYgXGREUTH5OzKuZ22i9elNeL6D05bXOXDaexptn2LVyDd/kUAAA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@harperfast/extended-iterable": "1.0.3",
@@ -2939,20 +2939,20 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@harperfast/rocksdb-js-darwin-arm64": "1.4.0",
-				"@harperfast/rocksdb-js-darwin-x64": "1.4.0",
-				"@harperfast/rocksdb-js-linux-arm64-glibc": "1.4.0",
-				"@harperfast/rocksdb-js-linux-arm64-musl": "1.4.0",
-				"@harperfast/rocksdb-js-linux-x64-glibc": "1.4.0",
-				"@harperfast/rocksdb-js-linux-x64-musl": "1.4.0",
-				"@harperfast/rocksdb-js-win32-arm64": "1.4.0",
-				"@harperfast/rocksdb-js-win32-x64": "1.4.0"
+				"@harperfast/rocksdb-js-darwin-arm64": "1.4.1",
+				"@harperfast/rocksdb-js-darwin-x64": "1.4.1",
+				"@harperfast/rocksdb-js-linux-arm64-glibc": "1.4.1",
+				"@harperfast/rocksdb-js-linux-arm64-musl": "1.4.1",
+				"@harperfast/rocksdb-js-linux-x64-glibc": "1.4.1",
+				"@harperfast/rocksdb-js-linux-x64-musl": "1.4.1",
+				"@harperfast/rocksdb-js-win32-arm64": "1.4.1",
+				"@harperfast/rocksdb-js-win32-x64": "1.4.1"
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-darwin-arm64": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-arm64/-/rocksdb-js-darwin-arm64-1.4.0.tgz",
-			"integrity": "sha512-78nT13T3P0Am0UfppPkMgUcTqS5Xx2ftXGl9IsmjWfrDawM1HOJt00n0GtPLoqOqrs80QVGbH9qgBZ22Bpty6Q==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-arm64/-/rocksdb-js-darwin-arm64-1.4.1.tgz",
+			"integrity": "sha512-915APRLAUVO6g0eHvhsYJwhciUZS2R+/eNcvB3FxCenrdAzhnsvC5R3luHkrsv3BUAuvDG7xV0PSy9fb/IrHCQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2966,9 +2966,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-darwin-x64": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-x64/-/rocksdb-js-darwin-x64-1.4.0.tgz",
-			"integrity": "sha512-Ck+m4bfaiGikq1I0IAHS8AELnRL+GeKB99hR8ASR7DRAvQqYGYbPtUQQUKIQk9/8S8LviKUfto/cla1nRAcslg==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-x64/-/rocksdb-js-darwin-x64-1.4.1.tgz",
+			"integrity": "sha512-6BUhuYh2bPcRAWbxbWnbKtQwJkzTq7XRa5uVLYxyTG/1VtbmI7zq4ScQl1rn0Q6tRlkoEjPY66fKLlygAPJT3w==",
 			"cpu": [
 				"x64"
 			],
@@ -2982,9 +2982,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-arm64-glibc": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-glibc/-/rocksdb-js-linux-arm64-glibc-1.4.0.tgz",
-			"integrity": "sha512-1yJkGMYR5Zh45j6joCu0cgQ+LPlsU0hjiPfv0f0cmXdjPiccXu7TemADjf3fnLz6p4p2VLP46s1fwJL7W+4lFw==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-glibc/-/rocksdb-js-linux-arm64-glibc-1.4.1.tgz",
+			"integrity": "sha512-eG7HO/PgOZeqy2yj9AKl4asGHQCNoGTqn83uK2z/Ek26oYp7Boa8jv4gmjneYXY3stKq2GQlUtfJiKXpgkIOYg==",
 			"cpu": [
 				"arm64"
 			],
@@ -3001,9 +3001,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-arm64-musl": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-musl/-/rocksdb-js-linux-arm64-musl-1.4.0.tgz",
-			"integrity": "sha512-wIUqCl95Fs7WL0Ecm2j6Lu9TAFMbeDageMn2MfzqTtjx6fcQRL9dPH9o8HfIOfQ6Q0T0HTPpRwBTAtryYLmcFA==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-musl/-/rocksdb-js-linux-arm64-musl-1.4.1.tgz",
+			"integrity": "sha512-5v4mkf31JdZ7Or6H52FuBuBLcGgLpPre5bmsxo5roBEzCYobSN8jvH3XwsrGUIgO1Rvm1ZDSjXiBQs6ZVpOlPw==",
 			"cpu": [
 				"arm64"
 			],
@@ -3020,9 +3020,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-x64-glibc": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-glibc/-/rocksdb-js-linux-x64-glibc-1.4.0.tgz",
-			"integrity": "sha512-J8anAA31Dv6+h+Uu/mDlszQOoEZiTOGqrLVbWQ7/W5cET2pKZ9IC6NJjvG3rjkkFT82G+spqJ+aESY2yuEJv5Q==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-glibc/-/rocksdb-js-linux-x64-glibc-1.4.1.tgz",
+			"integrity": "sha512-9yaLdOKL6ibdIHnWvahEJM0h+VWjl95mjfanF97W6+iwoFydgKgm/LamBmb7ZevrOINprMUdZDl5LgZ6QNnrVw==",
 			"cpu": [
 				"x64"
 			],
@@ -3039,9 +3039,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-x64-musl": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-1.4.0.tgz",
-			"integrity": "sha512-bHJvxKlx/UqeG++aLpEcm6DDzNeGvDWvBZ+LKstVmF4mNZnR/QZ8TX9dYEGHFHMB+/PVrotRzUaMA5jgjfaMFQ==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-1.4.1.tgz",
+			"integrity": "sha512-2K3jAXwozZLxsiTwMf/CtoYZ+9mWb5gXAvWMfXNKFpBGjVs5tIB9u5LvD+ShmAlQ8zkFFYImy3DKyFR0vgNGGg==",
 			"cpu": [
 				"x64"
 			],
@@ -3058,9 +3058,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-win32-arm64": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-1.4.0.tgz",
-			"integrity": "sha512-r6F+ZQWZmppu4mkuZwlyYDaXWXZ/AQldP2qdIRhICxXNfxcvQUxW0+CKmfnor3X3GNk46ThIaP7tM08fu7/Zag==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-1.4.1.tgz",
+			"integrity": "sha512-RqL7eFuqvXEof0MRbCdmLcucWWT12zbTrsAw/1Ye0rigentKKx/B3c3R2EhqDmYqsXJFQtthmLnHzhGTmJK1+A==",
 			"cpu": [
 				"arm64"
 			],
@@ -3074,9 +3074,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-win32-x64": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-x64/-/rocksdb-js-win32-x64-1.4.0.tgz",
-			"integrity": "sha512-msYlg3D2sm33sw7Uyiuxw04Jt8mrzcKOhjHFZbGAM9bqlUE0lar3txcO03oHwcKYVyoIEsnYgyddQFHdRLAU+A==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-x64/-/rocksdb-js-win32-x64-1.4.1.tgz",
+			"integrity": "sha512-SnyfEhAieoWADIzMQYKjsZrgEDOOUKA47M4ZQJWF7Y1IySpFPOfSAcokXORmMeyLuxOuABgS/RDpNqsEVIpMNw==",
 			"cpu": [
 				"x64"
 			],

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
 		"@fastify/cors": "^11.2.0",
 		"@fastify/static": "^9.1.3",
 		"@harperfast/extended-iterable": "^1.0.1",
-		"@harperfast/rocksdb-js": "^1.4.0",
+		"@harperfast/rocksdb-js": "^1.4.1",
 		"@turf/area": "6.5.0",
 		"@turf/boolean-contains": "6.5.0",
 		"@turf/boolean-disjoint": "6.5.0",


### PR DESCRIPTION
Picks up v1.4.1 of `@harperfast/rocksdb-js`: backport of the writev partial-write corruption fix (rocksdb-js#613). This is the same framing-corruption class (#573) that caused the CDI `us-lax-1.rt-ite.cdi` crash-loop today via corrupt `race_alerts` txnlog files.

**Changes:** `package.json` `^1.4.0` → `^1.4.1`, lock file resolved to `1.4.1`.

*Patch — cherry-pick candidate for v5.0.*

🤖 Co-authored by Claude Sonnet 4.6