### PR TITLE
fix(ci): checkout before setup-node in harper publish job

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -14,11 +14,11 @@ jobs:
     outputs:
       harper-version: ${{ steps.version-components.outputs.version }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.node-version'
           cache: 'npm'
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get release build
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The `publish-harper-npm-package` job ran `actions/setup-node` with `node-version-file: '.node-version'` before `actions/checkout`, so the file didn't exist yet on the runner → `harper@5.1.0-beta.1` publish failed.\n\nFix: swap the step order so checkout comes first.\n\n🤖 Co-authored by Claude Sonnet 4.6