### PR TITLE
feat(ci): add workflow_dispatch to publish-npm workflow

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -3,6 +3,12 @@ name: Publish NPM Package
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag to publish (e.g. v5.1.0-beta.1)'
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,12 +28,12 @@ jobs:
       - name: Get release build
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release download ${{ github.event.release.tag_name }} --pattern "harper-*.tgz"
+        run: gh release download ${{ github.event.release.tag_name || inputs.tag_name }} --pattern "harper-*.tgz"
       - name: Get version components
         id: version-components
         uses: matt-usurp/validate-semver@7bbc9584679de1aeef57aa531504ab00438481ab # v2.1.0
         with:
-          version: ${{ github.event.release.tag_name }}
+          version: ${{ github.event.release.tag_name || inputs.tag_name }}
       - name: Set package tag
         id: package-tag
         # Once we have our first full, non-beta release, turn this back on:
@@ -58,12 +64,12 @@ jobs:
       - name: Get release build
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release download ${{ github.event.release.tag_name }} --pattern "harper-*.tgz"
+        run: gh release download ${{ github.event.release.tag_name || inputs.tag_name }} --pattern "harper-*.tgz"
       - name: Get version components
         id: version-components
         uses: matt-usurp/validate-semver@7bbc9584679de1aeef57aa531504ab00438481ab # v2.1.0
         with:
-          version: ${{ github.event.release.tag_name }}
+          version: ${{ github.event.release.tag_name || inputs.tag_name }}
       - name: Rename package to '@harperfast/harper'
         run: |
           mkdir package

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -28,7 +28,8 @@ jobs:
       - name: Get release build
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release download ${{ github.event.release.tag_name || inputs.tag_name }} --pattern "harper-*.tgz"
+          TAG_NAME: ${{ github.event.release.tag_name || inputs.tag_name }}
+        run: gh release download "$TAG_NAME" --pattern "harper-*.tgz"
       - name: Get version components
         id: version-components
         uses: matt-usurp/validate-semver@7bbc9584679de1aeef57aa531504ab00438481ab # v2.1.0
@@ -64,7 +65,8 @@ jobs:
       - name: Get release build
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release download ${{ github.event.release.tag_name || inputs.tag_name }} --pattern "harper-*.tgz"
+          TAG_NAME: ${{ github.event.release.tag_name || inputs.tag_name }}
+        run: gh release download "$TAG_NAME" --pattern "harper-*.tgz"
       - name: Get version components
         id: version-components
         uses: matt-usurp/validate-semver@7bbc9584679de1aeef57aa531504ab00438481ab # v2.1.0


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the NPM publish workflow with a `tag_name` input
- Allows manually re-triggering publishes for releases where the automated event failed (e.g. workflow was broken at tag time)
- Uses `${{ github.event.release.tag_name || inputs.tag_name }}` coalescing so both triggers work correctly

## Why
The `release:published` event uses the workflow from the tag's commit, not `main`. When the workflow had a bug at tag time, there's no way to re-run with a fixed workflow. `workflow_dispatch` lets us publish from `main`'s current (fixed) workflow for any existing release tag.

## Test plan
- [ ] After merge, manually trigger for `v5.1.0-beta.1` to publish `harper@5.1.0-beta.1` to NPM (publish-harperfast-npm-package will skip since `@harperfast/harper@5.1.0-beta.1` already exists — that's fine)
- [ ] Verify future release events still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)