### PR TITLE
fix(ci): add registry-url to setup-node in publish-harper-npm-package job

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.node-version'
+          registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
       - name: Get release build
         env:


### PR DESCRIPTION
## Summary
- Adds `registry-url: 'https://registry.npmjs.org'` to the `setup-node` step in `publish-harper-npm-package`
- Without this, `setup-node` does not write an `.npmrc` configured with `NODE_AUTH_TOKEN`, so `npm publish` fails with `ENEEDAUTH` even though the secret is set
- The `publish-harperfast-npm-package` job already had `registry-url` correctly configured — this brings the harper job in line

## Root cause
`setup-node` only creates the auth-configured `.npmrc` when `registry-url` is specified. The `NODE_AUTH_TOKEN` env var is a no-op without it.

## Test plan
- [ ] After merge, trigger `workflow_dispatch` for `v5.1.0-beta.1` — `publish-harper-npm-package` should succeed and land `harper@5.1.0-beta.1` on NPM

🤖 Generated with [Claude Code](https://claude.com/claude-code)