### PR TITLE
fix: overwrite stale boot props when settings_path no longer exists

### DIFF
--- a/utility/install/installer.ts
+++ b/utility/install/installer.ts
@@ -441,24 +441,28 @@ async function createBootPropertiesFile() {
 		const homeDirPath = path.join(homeDir, hdbTerms.HDB_HOME_DIR_NAME);
 		const homeDirKeysDirPath = path.join(homeDirPath, hdbTerms.LICENSE_KEY_DIR_NAME);
 		const propsFilePath = path.join(homeDirPath, hdbTerms.BOOT_PROPS_FILE_NAME);
-		// Detect a stale boot props file: exists but points to a settings_path that no longer exists.
-		// This happens when a previous install dir was deleted (e.g. a temp CI dir) but the props
-		// file was never cleaned up. A stale file would cause every `harper` invocation to trigger
-		// the interactive install wizard because isHdbInstalled() fails.
-		const bootPropsStale =
-			fs.existsSync(propsFilePath) &&
-			(() => {
-				try {
-					const content = fs.readFileSync(propsFilePath, 'utf8');
-					const match = content.match(/settings_path\s*=\s*(.+)/);
-					return match ? !fs.existsSync(match[1].trim()) : true;
-				} catch {
-					return true;
+		// Write boot props when: file doesn't exist, OR no explicit ROOTPATH was given (caller
+		// accepts whatever path this install produces), OR the existing file points to a
+		// settings_path that no longer exists (stale from a deleted previous install dir).
+		let shouldWriteBootProps = !fs.existsSync(propsFilePath) || !hdbUtils.getEnvCliRootPath();
+		if (!shouldWriteBootProps) {
+			try {
+				const content = fs.readFileSync(propsFilePath, 'utf8');
+				// Anchor to line start (with /m) to avoid matching commented-out lines.
+				const match = content.match(/^[ \t]*settings_path\s*=\s*(.+)/m);
+				if (match) {
+					const settingsPath = match[1].trim().replace(/^["']|["']$/g, '');
+					if (!fs.existsSync(settingsPath)) {
+						shouldWriteBootProps = true;
+					}
+				} else {
+					shouldWriteBootProps = true;
 				}
-			})();
-		// Write boot props when: file doesn't exist, OR it's stale, OR no explicit ROOTPATH was
-		// given (no ROOTPATH means the caller accepts whatever path this install produces).
-		if (!fs.existsSync(propsFilePath) || bootPropsStale || !hdbUtils.getEnvCliRootPath()) {
+			} catch {
+				shouldWriteBootProps = true;
+			}
+		}
+		if (shouldWriteBootProps) {
 			try {
 				fs.mkdirpSync(homeDirPath, { mode: hdbTerms.HDB_FILE_PERMISSIONS });
 				fs.mkdirpSync(homeDirKeysDirPath, { mode: hdbTerms.HDB_FILE_PERMISSIONS });

--- a/utility/install/installer.ts
+++ b/utility/install/installer.ts
@@ -441,9 +441,24 @@ async function createBootPropertiesFile() {
 		const homeDirPath = path.join(homeDir, hdbTerms.HDB_HOME_DIR_NAME);
 		const homeDirKeysDirPath = path.join(homeDirPath, hdbTerms.LICENSE_KEY_DIR_NAME);
 		const propsFilePath = path.join(homeDirPath, hdbTerms.BOOT_PROPS_FILE_NAME);
-		// if the properties file already exists, and we have an explicit ROOTPATH, we don't overwrite the existing
-		// properties file
-		if (!fs.existsSync(propsFilePath) || !hdbUtils.getEnvCliRootPath()) {
+		// Detect a stale boot props file: exists but points to a settings_path that no longer exists.
+		// This happens when a previous install dir was deleted (e.g. a temp CI dir) but the props
+		// file was never cleaned up. A stale file would cause every `harper` invocation to trigger
+		// the interactive install wizard because isHdbInstalled() fails.
+		const bootPropsStale =
+			fs.existsSync(propsFilePath) &&
+			(() => {
+				try {
+					const content = fs.readFileSync(propsFilePath, 'utf8');
+					const match = content.match(/settings_path\s*=\s*(.+)/);
+					return match ? !fs.existsSync(match[1].trim()) : true;
+				} catch {
+					return true;
+				}
+			})();
+		// Write boot props when: file doesn't exist, OR it's stale, OR no explicit ROOTPATH was
+		// given (no ROOTPATH means the caller accepts whatever path this install produces).
+		if (!fs.existsSync(propsFilePath) || bootPropsStale || !hdbUtils.getEnvCliRootPath()) {
 			try {
 				fs.mkdirpSync(homeDirPath, { mode: hdbTerms.HDB_FILE_PERMISSIONS });
 				fs.mkdirpSync(homeDirKeysDirPath, { mode: hdbTerms.HDB_FILE_PERMISSIONS });


### PR DESCRIPTION
## Problem

If a previous Harper installation directory was deleted (e.g. a temp CI dir), `~/.harperdb/hdb_boot_properties.file` persists pointing at a dead `settings_path`. A subsequent automated reinstall with `ROOTPATH` set hits the guard condition and **silently skips updating it**. Every subsequent `harper` invocation then triggers the interactive install wizard because `isHdbInstalled()` returns false against the missing path.

## Fix

Added a staleness check: if the existing boot props file's `settings_path` no longer resolves to a real directory, treat it as absent and overwrite it — regardless of whether `ROOTPATH` was provided.

The original behaviour (don't clobber a valid existing install when `ROOTPATH` is explicit) is preserved — the stale path check only fires when the path is genuinely gone.

A cross-model review (Gemini) caught a regex issue in the first pass: the pattern lacked a line-start anchor and the `/m` flag, which could have matched a commented-out `settings_path` line and falsely flagged a valid live install as stale. That was fixed in the second commit along with quote-stripping on the extracted path and flattening the IIFE into a readable `shouldWriteBootProps` flag.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)