### PR TITLE
feat: log application path and table init during startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ harper-*.tgz
 # AI
 .antigravitycli/
 .claude/
+cache/
 
 # YCSB benchmark results (generated)
 benchmarks/ycsb/results/

--- a/cache/projects.json
+++ b/cache/projects.json
@@ -1,0 +1,3 @@
+{
+	"/home/kzyp/dev/harper/.claude/worktrees/add-app-load-logging": "9f2bada4-8fbd-48ff-bd6f-369b49eff10d"
+}

--- a/cache/projects.json
+++ b/cache/projects.json
@@ -1,3 +1,0 @@
-{
-	"/home/kzyp/dev/harper/.claude/worktrees/add-app-load-logging": "9f2bada4-8fbd-48ff-bd6f-369b49eff10d"
-}

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -77,6 +77,7 @@ export function loadComponentDirectories(loadedPluginModules?: Map<any, any>, lo
 	}
 	const hdbAppFolder = process.env.RUN_HDB_APP;
 	if (hdbAppFolder) {
+		harperLogger.info('Loading application from ' + hdbAppFolder);
 		cfsLoaded.push(
 			loadComponent(hdbAppFolder, resources, hdbAppFolder, {
 				isRoot: false,

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -77,7 +77,7 @@ export function loadComponentDirectories(loadedPluginModules?: Map<any, any>, lo
 	}
 	const hdbAppFolder = process.env.RUN_HDB_APP;
 	if (hdbAppFolder) {
-		harperLogger.info('Loading application from ' + hdbAppFolder);
+		if (getWorkerIndex() === 0) harperLogger.info?.('Loading application from ' + hdbAppFolder);
 		cfsLoaded.push(
 			loadComponent(hdbAppFolder, resources, hdbAppFolder, {
 				isRoot: false,

--- a/resources/graphql.ts
+++ b/resources/graphql.ts
@@ -6,6 +6,7 @@ import { Resources } from './Resources.ts';
 import type { NamedTypeNode, StringValueNode } from 'graphql';
 import { once } from 'node:events';
 import { ClientError } from '../utility/errors/hdbError.ts';
+import harperLogger from '../utility/logging/harper_logger.ts';
 
 const PRIMITIVE_TYPES = ['ID', 'Int', 'Float', 'Long', 'String', 'Boolean', 'Date', 'Bytes', 'Any', 'BigInt', 'Blob'];
 
@@ -251,6 +252,11 @@ async function processGraphQLSchema(gqlContent, urlPath, filePath, resources) {
 		// with graphql database definitions, this is a declaration that the table should exist and that it
 		// should be created if it does not exist
 		typeDef.tableClass = table(typeDef);
+		if (getWorkerIndex() === 0) {
+			const pk = (typeDef.properties as any[]).find((p) => p.isPrimaryKey)?.name ?? 'id';
+			const schemaPart = typeDef.database ? `, schema: ${typeDef.database}` : '';
+			harperLogger.info(`Initialized table "${typeDef.table}"${schemaPart}, primaryKey: ${pk}`);
+		}
 		if (typeDef.export) {
 			// allow empty string to be used to declare a table on the root path
 			if (typeDef.export.name === '') resources.set(dirname(urlPath), typeDef.tableClass);

--- a/resources/graphql.ts
+++ b/resources/graphql.ts
@@ -253,9 +253,9 @@ async function processGraphQLSchema(gqlContent, urlPath, filePath, resources) {
 		// should be created if it does not exist
 		typeDef.tableClass = table(typeDef);
 		if (getWorkerIndex() === 0) {
-			const pk = (typeDef.properties as any[]).find((p) => p.isPrimaryKey)?.name ?? 'id';
+			const pk = (typeDef.properties as any[])?.find((p) => p.isPrimaryKey)?.name ?? 'id';
 			const schemaPart = typeDef.database ? `, schema: ${typeDef.database}` : '';
-			harperLogger.info(`Initialized table "${typeDef.table}"${schemaPart}, primaryKey: ${pk}`);
+			harperLogger.info?.(`Initialized table "${typeDef.table}"${schemaPart}, primaryKey: ${pk}`);
 		}
 		if (typeDef.export) {
 			// allow empty string to be used to declare a table on the root path


### PR DESCRIPTION
## Summary

- Logs `Loading application from <path>` at info level when `RUN_HDB_APP` is set, so users following the getting-started guide can confirm their app directory was found
- Logs `Initialized table "<Name>" (primaryKey: <field>)` for each table defined via `@table` in a GraphQL schema
- Both logs are guarded by `getWorkerIndex() === 0` so they emit exactly once even with multiple worker threads
- Together these fill the confidence gap between `harper dev /path/to/app` and `All root applications loaded`, without requiring a `describe_all` round-trip

## Example output

```
[main/0] [info]: Loading application from /home/user/first-harper-app
[main/0] [info]: Initialized table "Dog", primaryKey: id
[main/0] [info]: All root applications loaded
```

## Notes

Cross-model review (Gemini) caught a missing thread guard in `componentLoader.ts` — the initial commit only had the guard in `graphql.ts`. Fixed in the second commit along with `harperLogger.info?.()` optional chaining.

## Test plan

- [ ] Run `harper dev /path/to/app` with a schema containing one or more `@table` types — confirm each message appears once
- [ ] Run with `schema: "mydb"` on a `@table` directive — confirm `, schema: mydb` appears in the table log
- [ ] Start without `RUN_HDB_APP` set — confirm no spurious log line
- [ ] Verify no duplicate lines when running with multiple worker threads

🤖 Generated with [Claude Code](https://claude.com/claude-code) — cross-model review via Gemini