### PR TITLE
feat(cli): add harper describe_data command

### DIFF
--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -35,6 +35,7 @@ const TRANSPORT_ONLY_FIELDS = new Set([
 	'json',
 	'skip_node_modules',
 	'skip_symlinks',
+	'preferLocal',
 ]);
 
 export { cliOperations, buildRequest };
@@ -100,7 +101,7 @@ function resolveTarget(req, allCredentials) {
 		req.target ||
 		process.env.HARPER_CLI_TARGET ||
 		process.env.CLI_TARGET ||
-		(allCredentials && allCredentials.last_target)
+		(req.preferLocal ? null : allCredentials?.last_target)
 	);
 }
 

--- a/bin/harper.ts
+++ b/bin/harper.ts
@@ -41,6 +41,7 @@ help                            - Display this output
 upgrade                         - Upgrade harperdb
 version                         - Print the version
 deploy                          - Deploy the application locally or remotely with target=<remote url>
+describe_data                   - Print the tables and attributes in the local (or remote) Harper instance
 `;
 
 async function harper() {
@@ -111,6 +112,31 @@ async function harper() {
 			let sourceDb = process.argv[3];
 			let targetDbPath = process.argv[4];
 			return require('./copyDb').copyDb(sourceDb, targetDbPath);
+		}
+		case SERVICE_ACTIONS_ENUM.DESCRIBE_DATA: {
+			const req = cliOperations.buildRequest();
+			req.operation = 'describe_all';
+			// Default to local instance; only route to remote if target= was explicitly provided
+			req.preferLocal = !process.argv.slice(3).some((arg) => arg.startsWith('target='));
+			const result = await cliOperations.cliOperations(req, true);
+			if (result && typeof result === 'object') {
+				for (const [schema, tables] of Object.entries(result as Record<string, any>)) {
+					if (schema === 'resolvedTarget') continue;
+					console.log(`Schema: ${schema}`);
+					if (!tables || typeof tables !== 'object' || Object.keys(tables).length === 0) {
+						console.log('  (no tables)');
+						continue;
+					}
+					for (const [tableName, tableInfo] of Object.entries(tables as Record<string, any>)) {
+						const pk: string = tableInfo.primary_key || 'id';
+						const attrs: string = (tableInfo.attributes || [])
+							.map((a: any) => (a.attribute === pk ? `${a.attribute}*` : a.attribute))
+							.join(', ');
+						console.log(`  ${tableName}  [${attrs}]`);
+					}
+				}
+			}
+			return;
 		}
 		case SERVICE_ACTIONS_ENUM.DEV:
 			process.env.DEV_MODE = 'true';

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -355,6 +355,7 @@ export const SERVICE_ACTIONS_ENUM = {
 	RENEWCERTS: 'renew-certs',
 	COPYDB: 'copy-db',
 	MCP: 'mcp',
+	DESCRIBE_DATA: 'describe_data',
 } as const;
 
 /** describes the Geo Conversion types */


### PR DESCRIPTION
## Summary

- Adds a new `harper describe_data` CLI command that shows tables and attributes in the local (or remote) Harper instance
- Adds `preferLocal` transport-only flag to `cliOperations` so the command defaults to the local domain socket instead of the saved `last_target`
- Updates help text to include the new command

### Output

```
$ harper describe_data
Connecting to local Harper instance
Schema: data
  Dog  [id*, name, breed, age]
```

The asterisk marks the primary key. Pass `target=<url>` to inspect a remote instance.

## Motivation

New users following the getting-started guide run `harper dev .` and then immediately move to enabling the REST API with no way to verify the Dog table was actually created from their schema. This command gives them a quick sanity check without needing `curl` or the operations API.

Also discovered that `harper <api-operation>` commands fall back to `last_target` from saved credentials, which is surprising in a local-development context. The `preferLocal` flag is the opt-out for that behavior.

## Test plan

- [ ] `harper describe_data` with Harper running locally shows correct schema
- [ ] `harper describe_data` with no Harper running prints a clear error ("Harper must be running")
- [ ] `harper describe_data target=<url>` routes to the remote instance
- [ ] `harper describe_data` with a saved `last_target` in credentials still uses local socket
- [ ] `harper help` includes the new command

🤖 Generated with [Claude Code](https://claude.com/claude-code)