### PR TITLE
fix(dev): graphql schema changes trigger worker restart in dev mode

### DIFF
--- a/resources/graphql.ts
+++ b/resources/graphql.ts
@@ -41,16 +41,17 @@ server.knownGraphQLDirectives.push(
 export function handleApplication(scope: import('../components/Scope.ts').Scope) {
 	let initialLoadComplete = false;
 	const entryHandler = scope.handleEntry(async (entry) => {
+		if (initialLoadComplete) {
+			scope.requestRestart();
+			return;
+		}
+
 		if (entry.eventType === 'unlink') return;
 		if (entry.entryType === 'directory') {
 			scope.logger.warn?.('graphqlSchema currently does not handle directories. Specify file patterns only.');
 			return;
 		}
 
-		if (initialLoadComplete) {
-			scope.requestRestart();
-			return;
-		}
 		await processGraphQLSchema((entry as any).contents, entry.urlPath, entry.absolutePath, scope.resources);
 	});
 	const initialLoadPromise = once(entryHandler, 'initialLoadComplete');

--- a/resources/graphql.ts
+++ b/resources/graphql.ts
@@ -39,6 +39,7 @@ server.knownGraphQLDirectives.push(
  * @param resources
  */
 export function handleApplication(scope: import('../components/Scope.ts').Scope) {
+	let initialLoadComplete = false;
 	const entryHandler = scope.handleEntry(async (entry) => {
 		if (entry.eventType === 'unlink') return;
 		if (entry.entryType === 'directory') {
@@ -46,9 +47,17 @@ export function handleApplication(scope: import('../components/Scope.ts').Scope)
 			return;
 		}
 
+		if (initialLoadComplete) {
+			scope.requestRestart();
+			return;
+		}
 		await processGraphQLSchema((entry as any).contents, entry.urlPath, entry.absolutePath, scope.resources);
 	});
-	return once(entryHandler, 'initialLoadComplete');
+	const initialLoadPromise = once(entryHandler, 'initialLoadComplete');
+	initialLoadPromise.then(() => {
+		initialLoadComplete = true;
+	});
+	return initialLoadPromise;
 }
 
 async function processGraphQLSchema(gqlContent, urlPath, filePath, resources) {


### PR DESCRIPTION
## Summary

`graphqlSchema`'s `handleApplication` was processing `schema.graphql` changes **in-place** on every file event, which suppressed the default `requestRestart()` call — the `Scope` default listener skips `requestRestart()` whenever an `all` handler is attached to the `EntryHandler`. Schema changes silently reprocessed in-place but workers never restarted, so other in-memory state (routing, indexes, etc.) stayed stale.

**Fix**: after the initial load completes, any subsequent file event (`add`, `change`, or `unlink`) calls `scope.requestRestart()` and returns early. Initial startup is unaffected.

`jsResource.ts` already uses this exact pattern — `graphql.ts` was the outlier.

## Notes for reviewers

- Cross-model review (Gemini) confirmed correctness and caught one bug in the first draft: the `unlink` early-return was above the `initialLoadComplete` check, so deleting a schema file post-startup would not have triggered a restart. Fixed in the second commit by hoisting the flag check to the top of the callback.
- No changes to the promise return type or startup timing.
- All CI checks pass (Node.js v22/v24/v26, Bun, Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)