### PR TITLE
feat: expose urlPath in deploy_component operation and CLI

### DIFF
--- a/components/operations.js
+++ b/components/operations.js
@@ -384,6 +384,7 @@ async function deployComponent(req) {
 				allowInstallScripts: req.install_allow_scripts,
 			};
 		}
+		if (req.urlPath !== undefined) applicationConfig.urlPath = req.urlPath;
 		await configUtils.addConfig(req.project, applicationConfig);
 	}
 

--- a/components/operationsValidation.js
+++ b/components/operationsValidation.js
@@ -242,6 +242,7 @@ function deployComponentValidator(req) {
 		install_timeout: Joi.number().optional(),
 		install_allow_scripts: Joi.boolean().optional(),
 		force: Joi.boolean().optional(),
+		urlPath: Joi.string().optional(),
 	});
 
 	return validator.validateBySchema(req, deployProjSchema);

--- a/components/operationsValidation.js
+++ b/components/operationsValidation.js
@@ -242,8 +242,15 @@ function deployComponentValidator(req) {
 		install_timeout: Joi.number().optional(),
 		install_allow_scripts: Joi.boolean().optional(),
 		force: Joi.boolean().optional(),
-		urlPath: Joi.string().optional(),
-	});
+		urlPath: Joi.string()
+			.min(1)
+			.custom((value, helpers) => {
+				if (value.includes('..')) return helpers.error('any.invalid');
+				return value;
+			})
+			.optional()
+			.messages({ 'any.invalid': 'urlPath must not contain ".."' }),
+	}).with('urlPath', 'package');
 
 	return validator.validateBySchema(req, deployProjSchema);
 }

--- a/unitTests/server/fastifyRoutes/operationsValidation.test.js
+++ b/unitTests/server/fastifyRoutes/operationsValidation.test.js
@@ -236,24 +236,24 @@ describe('Test operationsValidation module', () => {
 
 		it('rejects urlPath without package', () => {
 			const result = validator.deployComponentValidator({ project: 'my-app', urlPath: '/api' });
-			expect(result).to.not.be.null;
+			expect(result).to.be.ok;
 			expect(result.message).to.include('urlPath');
 		});
 
 		it('rejects urlPath containing ..', () => {
 			const result = validator.deployComponentValidator({ project: 'my-app', package: 'pkg', urlPath: '../etc/passwd' });
-			expect(result).to.not.be.null;
-			expect(result.message).to.include('"');
+			expect(result).to.be.ok;
+			expect(result.message).to.include('urlPath');
 		});
 
 		it('rejects empty urlPath', () => {
 			const result = validator.deployComponentValidator({ project: 'my-app', package: 'pkg', urlPath: '' });
-			expect(result).to.not.be.null;
+			expect(result).to.be.ok;
 		});
 
 		it('rejects missing project', () => {
 			const result = validator.deployComponentValidator({ package: 'pkg' });
-			expect(result).to.not.be.null;
+			expect(result).to.be.ok;
 			expect(result.message).to.include('project');
 		});
 	});

--- a/unitTests/server/fastifyRoutes/operationsValidation.test.js
+++ b/unitTests/server/fastifyRoutes/operationsValidation.test.js
@@ -241,7 +241,11 @@ describe('Test operationsValidation module', () => {
 		});
 
 		it('rejects urlPath containing ..', () => {
-			const result = validator.deployComponentValidator({ project: 'my-app', package: 'pkg', urlPath: '../etc/passwd' });
+			const result = validator.deployComponentValidator({
+				project: 'my-app',
+				package: 'pkg',
+				urlPath: '../etc/passwd',
+			});
 			expect(result).to.be.ok;
 			expect(result.message).to.include('urlPath');
 		});

--- a/unitTests/server/fastifyRoutes/operationsValidation.test.js
+++ b/unitTests/server/fastifyRoutes/operationsValidation.test.js
@@ -222,4 +222,39 @@ describe('Test operationsValidation module', () => {
 			expect(result.message).to.equal('Project name can only contain alphanumeric, dash and underscores characters');
 		});
 	});
+
+	describe('Test deployComponentValidator function', () => {
+		it('accepts valid package-based deploy request', () => {
+			const result = validator.deployComponentValidator({ project: 'my-app', package: '@scope/pkg' });
+			expect(result).to.be.undefined;
+		});
+
+		it('accepts urlPath alongside package', () => {
+			const result = validator.deployComponentValidator({ project: 'my-app', package: '@scope/pkg', urlPath: '/api' });
+			expect(result).to.be.undefined;
+		});
+
+		it('rejects urlPath without package', () => {
+			const result = validator.deployComponentValidator({ project: 'my-app', urlPath: '/api' });
+			expect(result).to.not.be.null;
+			expect(result.message).to.include('urlPath');
+		});
+
+		it('rejects urlPath containing ..', () => {
+			const result = validator.deployComponentValidator({ project: 'my-app', package: 'pkg', urlPath: '../etc/passwd' });
+			expect(result).to.not.be.null;
+			expect(result.message).to.include('"');
+		});
+
+		it('rejects empty urlPath', () => {
+			const result = validator.deployComponentValidator({ project: 'my-app', package: 'pkg', urlPath: '' });
+			expect(result).to.not.be.null;
+		});
+
+		it('rejects missing project', () => {
+			const result = validator.deployComponentValidator({ package: 'pkg' });
+			expect(result).to.not.be.null;
+			expect(result.message).to.include('project');
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Exposes the `urlPath` component config option (added in #397) as a first-class parameter of the `deploy_component` operation and CLI.

- `urlPath` is accepted by the operation validator and persisted in `harperdb-config.yaml` alongside `package` for package-based component deployments
- CLI works for free via the existing generic `key=value` argument parser: `harper deploy project=my-app package=@my/pkg urlPath=/api`
- `urlPath` is rejected without `package` (it's only meaningful in the package-based config path; payload-deployed components configure `urlPath` in their own `harper-config.yaml`)
- `urlPath` containing `..` or empty strings are rejected at the API boundary before reaching disk

## How it flows

For package-based components the root `harperdb-config.yaml` entry (e.g. `my-app: { package: "...", urlPath: "/api" }`) is what `OptionsWatcher` reads and scopes on. That value then flows into `scope.options.getAll().urlPath` and into the per-route middleware chain from #397.

## Known limitation (pre-existing, not introduced here)

`addConfig` does a full `setIn` replace on the component's config block. Re-deploying without specifying `urlPath` will overwrite the existing value — the same behaviour applies today for `install_command` and other persisted fields.

## Tests

Added `deployComponentValidator` unit tests covering the accept, reject-without-package, path-traversal, empty-string, and missing-project cases.

_Generated by Claude Sonnet 4.6_ 🤖