### PR TITLE
fix(table): bound out-of-order audit-chain walk to prevent full-copy OOM

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -114,6 +114,11 @@ const TEST_WRITE_KEY_BUFFER = Buffer.allocUnsafeSlow(8192);
 const MAX_KEY_BYTES = 1978;
 const EVENT_HIGH_WATER_MARK = 100;
 const REPLAY_YIELD_INTERVAL = 100; // yield to the event loop every N records during subscription replay
+// Cap for the out-of-order write reconciliation audit-chain walk in commit(). A pathologically deep
+// audit history (e.g. a replication full-copy of a large-history database) would otherwise walk and
+// buffer the entire backward chain per record, synchronously, on every worker — pinning the JS heap
+// until the worker OOMs (issue #1114). Beyond this depth we fall back to a bounded reconciliation.
+const MAX_OUT_OF_ORDER_AUDIT_DEPTH = 1000;
 const FULL_PERMISSIONS = {
 	read: true,
 	insert: true,
@@ -1766,8 +1771,18 @@ export function makeTable(options) {
 							}
 							let addedAuditRef = false;
 							let nextRef: { localTime: number; nodeId: number };
+							let walkSteps = 0;
+							let auditWalkCapped = false;
 							do {
 								while (localTime > txnTime || (auditedVersion >= txnTime && localTime > 0)) {
+									// Bound the walk only for RocksDB, where the OOM was observed (issue #1114): each step
+									// is a transaction-log range scan + msgpackr decode, and the per-node logs can be huge.
+									// LMDB audit entries are keyed by local audit time (not version), so the duplicate
+									// shortcut below would not apply — keep its exact, unbounded reconciliation.
+									if (isRocksDB && ++walkSteps > MAX_OUT_OF_ORDER_AUDIT_DEPTH) {
+										auditWalkCapped = true;
+										break;
+									}
 									const auditRecord = auditStore.get(localTime, tableId, id, nodeId);
 									if (!auditRecord) break;
 									auditedVersion = auditRecord.version;
@@ -1795,8 +1810,11 @@ export function makeTable(options) {
 										}
 										if (auditRecord.type === 'patch') {
 											logger.debug?.('out of order patch will be applied', id, auditRecord);
-											// record patches so we can reply in order
-											succeedingUpdates.push(auditRecord);
+											// Materialize the patch value now and keep only { version, value } rather than the
+											// audit record itself, so its backing transaction-log buffer and decoders can be
+											// reclaimed immediately. Only these two fields are needed for the ordered fold below;
+											// retaining the full records is what pins the heap on a deep chain (issue #1114).
+											succeedingUpdates.push({ version: auditedVersion, value: auditRecord.getValue(primaryStore) });
 											auditRecordToStore = recordUpdate; // use the original update for the audit record
 										} else if (auditRecord.type === 'put' || auditRecord.type === 'delete') {
 											// There is newer full record update, so this incremental update is completely superseded
@@ -1828,6 +1846,7 @@ export function makeTable(options) {
 									nodeId = auditRecord.previousNodeId;
 								}
 								// Check if we need to scan additional audit refs from this record
+								if (auditWalkCapped) break;
 								nextRef = auditRefsToVisit.shift();
 								if (nextRef) {
 									localTime = auditedVersion = nextRef.localTime;
@@ -1835,7 +1854,7 @@ export function makeTable(options) {
 									logger.debug?.('Following additional audit ref to continue scanning', { localTime, nodeId });
 								}
 							} while (nextRef);
-							if (!localTime) {
+							if (!localTime && !auditWalkCapped) {
 								// if we reached the end of the audit trail, we can just apply the update
 								logger.debug?.(
 									'No further audit history, applying incremental updates based on available history',
@@ -1844,15 +1863,45 @@ export function makeTable(options) {
 									existingEntry
 								);
 							}
-							succeedingUpdates.sort((a, b) => a.version - b.version); // order the patches
-							for (const auditRecord of succeedingUpdates) {
-								const newerUpdate = auditRecord.getValue(primaryStore);
-								logger.debug?.(
-									'Rebuilding update with future patch:',
-									new Date(auditRecord.version),
-									newerUpdate,
-									auditRecord
+							if (auditWalkCapped) {
+								// The out-of-order audit chain exceeded MAX_OUT_OF_ORDER_AUDIT_DEPTH (a pathologically deep
+								// history, seen during a replication full-copy of a large-history database — issue #1114).
+								// Walking and buffering the whole chain per record OOMs the worker, so we stopped at the cap
+								// and reconcile against only the most recent MAX_OUT_OF_ORDER_AUDIT_DEPTH updates (the fold
+								// below). That is an approximation for histories deeper than the cap — updates older than the
+								// retained window are not layered in — but the authoritative full-copy record restores exact
+								// convergence. Because we stopped before reaching txnTime, the inline duplicate detection in
+								// the walk never ran; full-copy audit-replay re-delivers writes, and re-applying one would
+								// double-apply its commutative ops, so rule that out here with a single O(1) lookup at txnTime
+								// (RocksDB audit logs are keyed by version, and the cap is RocksDB-only).
+								logger.warn?.(
+									'Out-of-order audit reconciliation exceeded depth cap; reconciling against most recent updates only',
+									{
+										table: tableName,
+										id,
+										depth: walkSteps,
+									}
 								);
+								const duplicate = auditStore.get(txnTime, tableId, id, options?.nodeId);
+								if (
+									duplicate &&
+									duplicate.version === txnTime &&
+									precedesExistingVersion(
+										txnTime,
+										{ version: txnTime, localTime: txnTime, key: id, nodeId: duplicate.nodeId },
+										options?.nodeId
+									) === 0
+								) {
+									write.skipped = true;
+									return; // duplicate write already applied
+								}
+							}
+							// Fold the retained succeeding updates (the full chain, or — when capped — the most recent
+							// window) onto this older write so newer fields win; for a capped walk this layers in only
+							// what we collected before the cap.
+							succeedingUpdates.sort((a, b) => a.version - b.version); // order the patches
+							for (const { version: patchVersion, value: newerUpdate } of succeedingUpdates) {
+								logger.debug?.('Rebuilding update with future patch:', new Date(patchVersion), newerUpdate);
 								incrementalUpdateToApply = rebuildUpdateBefore(
 									incrementalUpdateToApply ?? recordUpdate,
 									newerUpdate,

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -385,6 +385,73 @@ describe('Transactions', () => {
 			assert(auditRecord.previousAdditionalAuditRefs, 'Additional audit refs should be preserved');
 		});
 
+		// Regression for #1114: a pathologically deep audit chain (as seen during a replication
+		// full-copy of a large-history database) must not make the out-of-order reconciliation in
+		// commit() walk and buffer the whole chain — that OOMs the worker. Past the depth cap the walk
+		// is bounded and the older write is reconciled against only the most-recent retained updates.
+		it('bounds the out-of-order audit-chain walk past the depth cap and reconciles correctly (#1114)', async function () {
+			if (isLMDB) return; // RocksDB-only bounded path (LMDB keeps the exact unbounded walk)
+			const { logger } = require('#src/utility/logging/logger');
+			const id = 1114000;
+			const base = Date.now();
+			// Oldest version: a seed put with count = 0.
+			await TxnTest.put(id, { name: 'seed', count: 0 }, { timestamp: base });
+			// A chain of in-order patches deeper than MAX_OUT_OF_ORDER_AUDIT_DEPTH (1000). None is a full
+			// put, so an older out-of-order write would otherwise walk the entire chain. Each patch
+			// rewrites the same field so the chain (not the record) is what grows deep.
+			const depth = 1010;
+			for (let i = 1; i <= depth; i++) {
+				await TxnTest.patch(id, { seq: i }, { timestamp: base + 10 * i });
+			}
+			// Spy on the cap warning to assert the bounded branch actually ran (vs the normal full walk).
+			const originalWarn = logger.warn;
+			let capWarned = false;
+			logger.warn = (msg) => {
+				if (typeof msg === 'string' && msg.includes('exceeded depth cap')) capWarned = true;
+			};
+			try {
+				// A write older than every patch (newer than the seed): a commutative increment, a field
+				// that newer patches overwrite (seq), and a field no newer patch touches (fresh).
+				await TxnTest.patch(
+					id,
+					{ count: { __op__: 'add', value: 5 }, seq: 'stale', fresh: 'applied' },
+					{ timestamp: base + 5 }
+				);
+			} finally {
+				logger.warn = originalWarn;
+			}
+			assert(capWarned, 'the depth-cap bounded path should have been taken');
+			const record = await TxnTest.get(id);
+			// Commutative op is applied once, on top of the current state (count 0 -> 5).
+			assert.equal(record.count, 5, 'commutative op from the bounded out-of-order write should be applied');
+			// A newer patch overwrote seq, so the older write's stale value loses (folded against retained updates).
+			assert.equal(record.seq, depth, 'newer last-writer-wins value should survive the bounded reconciliation');
+			// A field no newer update touched is still applied from the older write.
+			assert.equal(record.fresh, 'applied', 'older field untouched by newer updates should be applied');
+			assert.equal(record.name, 'seed');
+		});
+
+		it('does not double-apply a re-delivered commutative op in the bounded path (#1114)', async function () {
+			if (isLMDB) return; // RocksDB-only bounded path (LMDB keeps the exact unbounded walk)
+			const id = 1114001;
+			const base = Date.now();
+			await TxnTest.put(id, { name: 'seed', count: 0 }, { timestamp: base });
+			const depth = 1010;
+			for (let i = 1; i <= depth; i++) {
+				await TxnTest.patch(id, { seq: i }, { timestamp: base + 10 * i });
+			}
+			const reDeliver = () => TxnTest.patch(id, { count: { __op__: 'add', value: 3 } }, { timestamp: base + 5 });
+			await reDeliver();
+			let record = await TxnTest.get(id);
+			assert.equal(record.count, 3, 'op applied once on first delivery');
+			// Full-copy audit-replay re-delivers writes; because the bounded walk stops before reaching
+			// txnTime, the inline duplicate check never runs — the explicit O(1) duplicate lookup must
+			// catch it so the increment is not applied a second time.
+			await reDeliver();
+			record = await TxnTest.get(id);
+			assert.equal(record.count, 3, 're-delivered duplicate must not double-apply the commutative op');
+		});
+
 		it('Can merge replication updates', async function () {
 			const context = {};
 			await transaction(context, async () => {


### PR DESCRIPTION
## Summary

Bounds the out-of-order-write reconciliation walk in `Table.commit` so a deep audit history can't pin the JS heap during replication full-copy catch-up.

- **Materialize-and-drop**: the backward audit-chain walk now retains only `{ version, value }` per succeeding update instead of the full audit record, releasing each entry's backing transaction-log buffer + decoders immediately. This is semantics-preserving and is the main heap reduction.
- **Depth cap (RocksDB only)**: beyond `MAX_OUT_OF_ORDER_AUDIT_DEPTH` (1000) walk steps the walk stops and reconciles the older write against the retained most-recent window via the existing `rebuildUpdateBefore` fold. A single O(1) lookup at `txnTime` rules out re-applying a duplicate (full-copy audit-replay re-delivers writes) so commutative ops aren't double-applied. LMDB keeps its exact, unbounded walk (its audit entries are keyed by local audit time, so the duplicate shortcut wouldn't apply, and the OOM was RocksDB-only).

## Purpose

Fixes the OOM in #1114: during full-copy of a large-history database, the reconciliation walked the entire backward chain for every record, synchronously, on all workers — peak heap scaled with audit depth × worker count and the cgroup OOM-killer crash-looped the container.

## Where to put attention

- **`resources/Table.ts` capped branch** — the bounded path is an *approximation* for out-of-order chains deeper than the cap: updates older than the retained 1000-window are not layered into the fold, so a stale field from the delayed write could briefly win over a newer value until the authoritative full-copy record converges it. This is the deliberate trade for a hard heap bound (discussed and chosen over a memory-only mitigation). For normal (shallow) out-of-order writes and for LMDB, behavior is unchanged. Worth a sanity check that this trade is acceptable for the non-full-copy out-of-order case.
- The duplicate check assumes RocksDB per-node audit logs are keyed by version (`auditStore.get(txnTime, …, options?.nodeId)`); it only runs on the RocksDB-scoped capped path.

## Not covered here

The issue also notes unbounded growth of the system-DB per-peer replication log (+ an `invalid user role found` storm) as a contributing factor. That's deferred to a separate investigation — this PR only makes the audit-walk memory-safe.

---
Tests: 2 regression tests in `unitTests/resources/transaction.test.js` (bounded reconciliation correctness incl. cap engagement, and no-double-apply on duplicate re-delivery). `test:unit:resources` green. Integration suite left to CI (a git worktree without local `node_modules` blocks the component-sandbox tests locally).

🤖 Generated by Claude (Opus 4.7) via Claude Code.