### PR TITLE
fix(rocks-audit-iterator): retry done iterators before returning done

### DIFF
--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -236,35 +236,53 @@ export class RocksTransactionLogStore extends EventEmitter {
 
 			aggregateIterator = {
 				next() {
-					if (nextEntries.length === 0) {
-						// on the first iteration and any time we finished all the iterators, we re-retrieve all
-						// the next entries (in case we are resuming after being done)
-						updateIterators();
-					}
-					let earliest: TransactionEntry;
-					let earliestIndex = -1;
-					for (let i = 0; i < nextEntries.length; i++) {
-						const result = nextEntries[i];
-						// skip any that are done
-						if (result.done) {
-							continue;
+					// We get up to two passes: the normal find-earliest pass, plus one retry that
+					// forces nextEntries.length = 0 to re-poll every per-log iterator (each picks
+					// up new entries when its log file has grown since the last `.next()` returned
+					// done) and to let updateIterators pick up any new logs added since the last
+					// call (e.g. a peer's log created by replication). Without the retry, a
+					// `{ done: true }` slot in nextEntries carried over from a previous call
+					// persists across a burst of commits that all coalesce into a single
+					// notifyFromTransactionData wake-up — the find-earliest loop keeps skipping
+					// the stale done slot, never re-polls the underlying iterator, and the entire
+					// burst is silently dropped (no further 'committed' arrives to unstick us).
+					// This was the fingerprint of the cloneNode topology bug where peer rows
+					// landed in hdb_nodes via system-DB replication but subscribeToNodeUpdates
+					// never received the events, so onNodeUpdate never opened replication
+					// connections to those peers.
+					for (let attempt = 0; attempt < 2; attempt++) {
+						if (nextEntries.length === 0) {
+							// on the first iteration and any time we finished all the iterators,
+							// we re-retrieve all the next entries (in case we are resuming after
+							// being done)
+							updateIterators();
 						}
-						// find the earliest one that is not done
-						const next = result.value;
-						if (!earliest || earliest.timestamp > next.timestamp) {
-							earliest = next;
-							earliestIndex = i;
+						let earliest: TransactionEntry;
+						let earliestIndex = -1;
+						for (let i = 0; i < nextEntries.length; i++) {
+							const result = nextEntries[i];
+							// skip any that are done
+							if (result.done) {
+								continue;
+							}
+							// find the earliest one that is not done
+							const next = result.value;
+							if (!earliest || earliest.timestamp > next.timestamp) {
+								earliest = next;
+								earliestIndex = i;
+							}
 						}
+						if (earliestIndex >= 0) {
+							// replace the entry with the next one from the iterator we pulled from
+							nextEntries[earliestIndex] = iterators[earliestIndex].next();
+							return {
+								value: onlyKeys ? earliest.timestamp : earliest,
+								done: false,
+							};
+						}
+						// All current entries are done; force the retry pass to re-poll
+						nextEntries.length = 0;
 					}
-					if (earliestIndex >= 0) {
-						// replace the entry with the next one from the iterator we pulled from
-						nextEntries[earliestIndex] = iterators[earliestIndex].next();
-						return {
-							value: onlyKeys ? earliest.timestamp : earliest,
-							done: false,
-						};
-					} // else we are done
-					nextEntries.length = 0; // reset so if this iterator is restarted, we can re-query
 					return { value: undefined, done: true };
 				},
 				addLog(logName: string) {


### PR DESCRIPTION
Cherry-pick of #624 onto `v5.0` for the v5.0.26 patch release.

## Why

`RocksTransactionLogStore`'s aggregate iterator could silently drop rows when a `{ done: true }` slot in `nextEntries` carried over from a previous call across a burst of commits that all coalesced into a single `notifyFromTransactionData` wake-up — the find-earliest loop skipped the stale done slot, never re-polled the underlying iterator, and the entire burst was dropped (no further `committed` event arrived to unstick the consumer). Affects any v5.0 cluster running aggregate audit-log queries; was the fingerprint of a `cloneNode` topology bug where peer rows landed in `hdb_nodes` via system-DB replication but `subscribeToNodeUpdates` never received the events.

## Cherry-pick details

- Original PR: #624 (merged to `main` 2026-05-19 as squash commit `9d8fad9`)
- One conflict resolved in `resources/RocksTransactionLogStore.ts`: `v5.0` had the original single-pass `next()` implementation, while the upstream squash commit assumes the open-coded two-pass intermediate state. Took the post-fix end state (the bounded `for (attempt = 0; attempt < 2; ...)` loop), which is the net result intended by the PR. Diff vs `main` in the touched region is identical aside from unrelated `removeLog` changes outside the cherry-pick scope.

Generated by Claude Opus 4.7 (1M context). Do not merge — review first.