### PR TITLE
chore(deps): bump @harperfast/rocksdb-js to ^1.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@fastify/cors": "^11.2.0",
 				"@fastify/static": "^9.1.3",
 				"@harperfast/extended-iterable": "^1.0.1",
-				"@harperfast/rocksdb-js": "^1.4.1",
+				"@harperfast/rocksdb-js": "^1.4.2",
 				"@turf/area": "6.5.0",
 				"@turf/boolean-contains": "6.5.0",
 				"@turf/boolean-disjoint": "6.5.0",
@@ -2923,9 +2923,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js/-/rocksdb-js-1.4.1.tgz",
-			"integrity": "sha512-AZuIqtDiiSrnVvbupDsNlRGpJSpsONCVDKZYgXGREUTH5OzKuZ22i9elNeL6D05bXOXDaexptn2LVyDd/kUAAA==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js/-/rocksdb-js-1.4.2.tgz",
+			"integrity": "sha512-wQ0buhmNVcw6jPn5VOoYDsGmO1IAmtithcSgaKrnBRicf+ATvQSCB1I7ljEBuqqzWG6HcJXeCgPhFpas3kRwOw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@harperfast/extended-iterable": "1.0.3",
@@ -2939,20 +2939,20 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@harperfast/rocksdb-js-darwin-arm64": "1.4.1",
-				"@harperfast/rocksdb-js-darwin-x64": "1.4.1",
-				"@harperfast/rocksdb-js-linux-arm64-glibc": "1.4.1",
-				"@harperfast/rocksdb-js-linux-arm64-musl": "1.4.1",
-				"@harperfast/rocksdb-js-linux-x64-glibc": "1.4.1",
-				"@harperfast/rocksdb-js-linux-x64-musl": "1.4.1",
-				"@harperfast/rocksdb-js-win32-arm64": "1.4.1",
-				"@harperfast/rocksdb-js-win32-x64": "1.4.1"
+				"@harperfast/rocksdb-js-darwin-arm64": "1.4.2",
+				"@harperfast/rocksdb-js-darwin-x64": "1.4.2",
+				"@harperfast/rocksdb-js-linux-arm64-glibc": "1.4.2",
+				"@harperfast/rocksdb-js-linux-arm64-musl": "1.4.2",
+				"@harperfast/rocksdb-js-linux-x64-glibc": "1.4.2",
+				"@harperfast/rocksdb-js-linux-x64-musl": "1.4.2",
+				"@harperfast/rocksdb-js-win32-arm64": "1.4.2",
+				"@harperfast/rocksdb-js-win32-x64": "1.4.2"
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-darwin-arm64": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-arm64/-/rocksdb-js-darwin-arm64-1.4.1.tgz",
-			"integrity": "sha512-915APRLAUVO6g0eHvhsYJwhciUZS2R+/eNcvB3FxCenrdAzhnsvC5R3luHkrsv3BUAuvDG7xV0PSy9fb/IrHCQ==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-arm64/-/rocksdb-js-darwin-arm64-1.4.2.tgz",
+			"integrity": "sha512-qQyv8BNCjvZQayhoTd7iqt1CLNEFHfqe8/SDZk8ztAR0ZAIyHIFkmNnaQ/Izn6p3HrNCRp6lNdwO4TKPWHj4SQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2966,9 +2966,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-darwin-x64": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-x64/-/rocksdb-js-darwin-x64-1.4.1.tgz",
-			"integrity": "sha512-6BUhuYh2bPcRAWbxbWnbKtQwJkzTq7XRa5uVLYxyTG/1VtbmI7zq4ScQl1rn0Q6tRlkoEjPY66fKLlygAPJT3w==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-x64/-/rocksdb-js-darwin-x64-1.4.2.tgz",
+			"integrity": "sha512-cPCsB7IVeuDhNjFcb/nqUkwtBI9BlaFNecJ/OjkG8hUpYAhd5rdNHFMt1vpu4sAYFaorFrMZoNKGbq43v14+hQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2982,9 +2982,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-arm64-glibc": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-glibc/-/rocksdb-js-linux-arm64-glibc-1.4.1.tgz",
-			"integrity": "sha512-eG7HO/PgOZeqy2yj9AKl4asGHQCNoGTqn83uK2z/Ek26oYp7Boa8jv4gmjneYXY3stKq2GQlUtfJiKXpgkIOYg==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-glibc/-/rocksdb-js-linux-arm64-glibc-1.4.2.tgz",
+			"integrity": "sha512-NquwD+7Gxu3BYAIQhvSThjIRlZRBieDZKXGEmrc0gfcxcORbgOjMCdxDzhjF6l1nR4ODlfJfbKqGyF8JtmnIjA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3001,9 +3001,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-arm64-musl": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-musl/-/rocksdb-js-linux-arm64-musl-1.4.1.tgz",
-			"integrity": "sha512-5v4mkf31JdZ7Or6H52FuBuBLcGgLpPre5bmsxo5roBEzCYobSN8jvH3XwsrGUIgO1Rvm1ZDSjXiBQs6ZVpOlPw==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-musl/-/rocksdb-js-linux-arm64-musl-1.4.2.tgz",
+			"integrity": "sha512-hp2IOXYBvloJEkZ/+bCI/AsQPtzza51Pkz+U+JkaAaayZ6+zsXdVp5GuGYPnCiH4O6QnOihKkgBW8msFhR0ogA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3020,9 +3020,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-x64-glibc": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-glibc/-/rocksdb-js-linux-x64-glibc-1.4.1.tgz",
-			"integrity": "sha512-9yaLdOKL6ibdIHnWvahEJM0h+VWjl95mjfanF97W6+iwoFydgKgm/LamBmb7ZevrOINprMUdZDl5LgZ6QNnrVw==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-glibc/-/rocksdb-js-linux-x64-glibc-1.4.2.tgz",
+			"integrity": "sha512-zEkBHRoLanN9MTVY1mFRGDdAGyXBUrk962xvtf0sGj/wIK2M3c2KL39FftWHgtm/BHA3uGHssWk6B7O2O/Dlig==",
 			"cpu": [
 				"x64"
 			],
@@ -3039,9 +3039,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-x64-musl": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-1.4.1.tgz",
-			"integrity": "sha512-2K3jAXwozZLxsiTwMf/CtoYZ+9mWb5gXAvWMfXNKFpBGjVs5tIB9u5LvD+ShmAlQ8zkFFYImy3DKyFR0vgNGGg==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-1.4.2.tgz",
+			"integrity": "sha512-K7y1CC+LJma2E+wEqFq67jk7+hZW+oPdKcqxyDxrIRKO3jyn0Dtr/fwQf3cFuU8cRnZBmZTAcnr5LeNJrUuYRw==",
 			"cpu": [
 				"x64"
 			],
@@ -3058,9 +3058,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-win32-arm64": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-1.4.1.tgz",
-			"integrity": "sha512-RqL7eFuqvXEof0MRbCdmLcucWWT12zbTrsAw/1Ye0rigentKKx/B3c3R2EhqDmYqsXJFQtthmLnHzhGTmJK1+A==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-1.4.2.tgz",
+			"integrity": "sha512-xc4oav0zTLfnjBIan1wlgB3g0NeWrzUPxR0Vq5HkLc4BGyAlPql+v1FwtQ4X6AwcAOHnS/QeYSGDQOZn6Ac1Ow==",
 			"cpu": [
 				"arm64"
 			],
@@ -3074,9 +3074,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-win32-x64": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-x64/-/rocksdb-js-win32-x64-1.4.1.tgz",
-			"integrity": "sha512-SnyfEhAieoWADIzMQYKjsZrgEDOOUKA47M4ZQJWF7Y1IySpFPOfSAcokXORmMeyLuxOuABgS/RDpNqsEVIpMNw==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-x64/-/rocksdb-js-win32-x64-1.4.2.tgz",
+			"integrity": "sha512-60vqTYJdw0ysvHeFHoxZ/sHNesdfvri+jWIyU5TTua2s20LmLZ4hKLglnsa0LP7/IA5JutZsxJiyUUMCoG3PDw==",
 			"cpu": [
 				"x64"
 			],

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
 		"@fastify/cors": "^11.2.0",
 		"@fastify/static": "^9.1.3",
 		"@harperfast/extended-iterable": "^1.0.1",
-		"@harperfast/rocksdb-js": "^1.4.1",
+		"@harperfast/rocksdb-js": "^1.4.2",
 		"@turf/area": "6.5.0",
 		"@turf/boolean-contains": "6.5.0",
 		"@turf/boolean-disjoint": "6.5.0",


### PR DESCRIPTION
Bumps rocksdb-js to 1.4.2 (released 2026-06-03). Includes txnlog reader hardening. For v5.0.26 patch.

_Generated by claude-sonnet-4-6._