### PR TITLE
fix(replay): purge aged transaction logs during recovery before replay

### DIFF
--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -259,6 +259,21 @@ export function setAuditRetention(retentionTime, defaultDelay = DEFAULT_AUDIT_CL
 	DEFAULT_AUDIT_CLEANUP_DELAY = defaultDelay;
 }
 
+/**
+ * One-shot purge of transaction-log files already older than the audit retention window,
+ * intended to run during startup/recovery before transaction-log replay. The steady-state
+ * cleanup loop (scheduleAuditCleanup) only starts once a worker reaches steady state, so a node
+ * that crash-loops during recovery never purges and its aged backlog only grows, enlarging the
+ * next replay/full-copy. Safe to run before replay: the native purge only deletes log files
+ * entirely before the last-flushed-to-RocksDB position, so unflushed entries that replay still
+ * needs are never removed. Returns the names of the purged files. See harper#1115.
+ */
+export function purgeAgedLogs(rootStore: RocksDatabase): string[] {
+	// Mirror the read-only guard in scheduleAuditCleanup: never delete log files in read-only mode.
+	if (isReadOnlyMode()) return [];
+	return rootStore.purgeLogs({ before: Date.now() - auditRetention });
+}
+
 const HAS_RECORD = 16;
 const HAS_PARTIAL_RECORD = 32; // will be used for CRDTs
 const PUT = 1;

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -269,8 +269,6 @@ export function setAuditRetention(retentionTime, defaultDelay = DEFAULT_AUDIT_CL
  * needs are never removed. Returns the names of the purged files. See harper#1115.
  */
 export function purgeAgedLogs(rootStore: RocksDatabase): string[] {
-	// Mirror the read-only guard in scheduleAuditCleanup: never delete log files in read-only mode.
-	if (isReadOnlyMode()) return [];
 	return rootStore.purgeLogs({ before: Date.now() - auditRetention });
 }
 

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -7,6 +7,7 @@ import { RocksTransactionLogStore } from './RocksTransactionLogStore.ts';
 import { isMainThread } from 'node:worker_threads';
 import { RequestTarget } from './RequestTarget.ts';
 import { classifyAuditEntryForReplay } from './replayLogsGuards.ts';
+import { purgeAgedLogs } from './auditStore.ts';
 
 let warnedReplayHappening = false;
 export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void> {
@@ -16,6 +17,17 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 			resolve();
 		});
 		if (!acquired) return;
+		// Shed transaction-log files already older than the audit retention window before
+		// replaying. A node that crash-loops during recovery never reaches the steady-state
+		// cleanup loop, so without this its aged backlog only grows and enlarges each subsequent
+		// replay/full-copy. The native purge keeps any file holding unflushed entries, so this
+		// never drops data the replay below still needs. See harper#1115.
+		const purgedLogs = purgeAgedLogs(rootStore);
+		if (purgedLogs.length > 0) {
+			logger.info(
+				`Purged ${purgedLogs.length} aged transaction-log file(s) before replay in ${(rootStore as any).databaseName} database`
+			);
+		}
 		const tableById = new Map<number, typeof Resource>();
 		for (const tableName in tables) {
 			const table = tables[tableName];

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -22,7 +22,18 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 		// cleanup loop, so without this its aged backlog only grows and enlarges each subsequent
 		// replay/full-copy. The native purge keeps any file holding unflushed entries, so this
 		// never drops data the replay below still needs. See harper#1115.
-		const purgedLogs = purgeAgedLogs(rootStore);
+		// Purging is a non-critical optimization, so a purge failure (filesystem/permission/native
+		// error) must never block the critical replay path that follows — especially here, during
+		// the recovery this fix is meant to harden.
+		let purgedLogs: string[] = [];
+		try {
+			purgedLogs = purgeAgedLogs(rootStore);
+		} catch (error) {
+			logger.warn(
+				`Failed to purge aged transaction logs before replay in ${(rootStore as any).databaseName} database`,
+				error
+			);
+		}
 		if (purgedLogs.length > 0) {
 			logger.info(
 				`Purged ${purgedLogs.length} aged transaction-log file(s) before replay in ${(rootStore as any).databaseName} database`

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -29,14 +29,11 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 		try {
 			purgedLogs = purgeAgedLogs(rootStore);
 		} catch (error) {
-			logger.warn(
-				`Failed to purge aged transaction logs before replay in ${(rootStore as any).databaseName} database`,
-				error
-			);
+			logger.warn(`Failed to purge aged transaction logs before replay in ${rootStore.databaseName} database`, error);
 		}
 		if (purgedLogs.length > 0) {
 			logger.info(
-				`Purged ${purgedLogs.length} aged transaction-log file(s) before replay in ${(rootStore as any).databaseName} database`
+				`Purged ${purgedLogs.length} aged transaction-log file(s) before replay in ${rootStore.databaseName} database`
 			);
 		}
 		const tableById = new Map<number, typeof Resource>();

--- a/unitTests/resources/auditPurge.test.js
+++ b/unitTests/resources/auditPurge.test.js
@@ -1,0 +1,64 @@
+const assert = require('node:assert/strict');
+
+// Regression test for the early-recovery transaction-log purge (harper#1115).
+// scheduleAuditCleanup only runs once a worker reaches steady state, so a node that
+// crash-loops during startup replay never purges its aged backlog. purgeAgedLogs is the
+// one-shot purge wired into replayLogs so a recovering node sheds files older than the
+// retention window before replaying. These tests pin its contract: it asks the store to
+// purge everything older than `Date.now() - auditRetention` and returns the purged list.
+const auditStore = require('#src/resources/auditStore');
+const { purgeAgedLogs, setAuditRetention } = auditStore;
+
+describe('purgeAgedLogs', () => {
+	let originalRetention;
+
+	before(() => {
+		originalRetention = auditStore.auditRetention;
+	});
+
+	after(() => {
+		setAuditRetention(originalRetention);
+	});
+
+	function fakeStore(purgedFiles = ['000001.txnlog', '000002.txnlog']) {
+		const calls = [];
+		return {
+			calls,
+			purgeLogs(options) {
+				calls.push(options);
+				return purgedFiles;
+			},
+		};
+	}
+
+	it('purges log files older than the configured audit retention window', () => {
+		setAuditRetention(60_000);
+		const store = fakeStore();
+		const before = Date.now();
+		const purged = purgeAgedLogs(store);
+		const after = Date.now();
+
+		assert.equal(store.calls.length, 1, 'purgeLogs should be called exactly once');
+		assert.deepEqual(Object.keys(store.calls[0]), ['before'], 'only the time bound should be passed');
+		const cutoff = store.calls[0].before;
+		assert.ok(
+			cutoff >= before - 60_000 && cutoff <= after - 60_000,
+			`cutoff ${cutoff} should be ~Date.now() - 60000 (in [${before - 60_000}, ${after - 60_000}])`
+		);
+		assert.deepEqual(purged, ['000001.txnlog', '000002.txnlog'], 'returns the purged file list');
+	});
+
+	it('tracks the retention window when it changes', () => {
+		setAuditRetention(5_000);
+		const store = fakeStore();
+		const before = Date.now();
+		purgeAgedLogs(store);
+		const after = Date.now();
+
+		const cutoff = store.calls[0].before;
+		assert.ok(
+			cutoff >= before - 5_000 && cutoff <= after - 5_000,
+			`cutoff ${cutoff} should track the 5s retention window`
+		);
+	});
+});


### PR DESCRIPTION
Cherry-pick of #1117 for v5.0.26 patch release.