### PR TITLE
ci: add always-on toggle + opt-in Gemini review caller

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,7 +30,7 @@ jobs:
     # always-on toggle". CLAUDE_ALWAYS_ON=true (repo/org variable) → auto-
     # review trusted-author PRs; unset → opt-in via the claude-review
     # label. The reusable's authorize job still owns WHO is admitted.
-    # NB: the `claude-review` label name is matched there too —
+    # Note: the `claude-review` label name is matched there too —
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
     uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@2be0f702b114e39b90eed90962922ef64df58482 # main 2026-06-03 (post #52 — week-of-05-25 calibration: Harper-aware best-practices wiring, skills-ref v1.7.0, surface-findings rule, access-control blocker guidance, public-skill dedup)

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,6 +30,8 @@ jobs:
     # always-on toggle". CLAUDE_ALWAYS_ON=true (repo/org variable) → auto-
     # review trusted-author PRs; unset → opt-in via the claude-review
     # label. The reusable's authorize job still owns WHO is admitted.
+    # NB: the `claude-review` label name is matched there too —
+    # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
     uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@2be0f702b114e39b90eed90962922ef64df58482 # main 2026-06-03 (post #52 — week-of-05-25 calibration: Harper-aware best-practices wiring, skills-ref v1.7.0, surface-findings rule, access-control blocker guidance, public-skill dedup)
     with:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -26,6 +26,11 @@ concurrency:
 
 jobs:
   review:
+    # Always-on toggle — see ai-review-prompts USAGE.md "Reviewers & the
+    # always-on toggle". CLAUDE_ALWAYS_ON=true (repo/org variable) → auto-
+    # review trusted-author PRs; unset → opt-in via the claude-review
+    # label. The reusable's authorize job still owns WHO is admitted.
+    if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
     uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@f22bf7dcb7d22d5de94c938daa9d790f2b5c776b # main 2026-05-18 (post #37 + #38 + #40 — calibration layer update + label-gated bot-PR review; #39's workflow-level `permissions: {}` reverted in #40 because it broke reusable callers via the GH Actions calling-workflow-caps-reusable rule)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -49,7 +49,7 @@ jobs:
     # review trusted-author PRs; unset → opt-in via the gemini-review
     # label. The reusable's authorize job still owns WHO is admitted
     # (CODEOWNERS trust set; the labeler, not the author, on `labeled`).
-    # NB: the `gemini-review` label name is matched there too —
+    # Note: the `gemini-review` label name is matched there too —
     # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
     uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@2be0f702b114e39b90eed90962922ef64df58482 # main 2026-06-03 (post #52 — calibration: Harper-aware wiring for the Gemini leg, skills-ref v1.7.0, surface-findings rule, access-control blocker guidance, public-skill dedup)

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -49,6 +49,8 @@ jobs:
     # review trusted-author PRs; unset → opt-in via the gemini-review
     # label. The reusable's authorize job still owns WHO is admitted
     # (CODEOWNERS trust set; the labeler, not the author, on `labeled`).
+    # NB: the `gemini-review` label name is matched there too —
+    # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
     uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@2be0f702b114e39b90eed90962922ef64df58482 # main 2026-06-03 (post #52 — calibration: Harper-aware wiring for the Gemini leg, skills-ref v1.7.0, surface-findings rule, access-control blocker guidance, public-skill dedup)
     # Caller-side permissions at the calling-job level (NOT workflow-

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -1,0 +1,106 @@
+name: Gemini PR Review
+
+# Thin caller of the Gemini reusable in HarperFast/ai-review-prompts.
+# Runs in parallel with claude-review.yml so the two reviewers can be
+# compared on the same PRs.
+#
+# Layer inputs and `repo-specific-checks:` MIRROR claude-review.yml in
+# this repo. Output comparability between the two providers depends on
+# them seeing the same review scope — keep them in sync when bumping
+# the pin or editing the checks block.
+#
+# Opt-in by default: Gemini runs only when a HarperFast org member
+# applies the `gemini-review` label, UNLESS the GEMINI_ALWAYS_ON repo
+# variable is set to 'true' (then it auto-reviews trusted-author PRs,
+# like claude-review). See ai-review-prompts USAGE.md "Reviewers & the
+# always-on toggle".
+#
+# Pre-requisites:
+#   - HARPERFAST_AI_CLIENT_ID       (org-level App Client ID)
+#   - HARPERFAST_AI_APP_PRIVATE_KEY (org-level App private key)
+#   - GEMINI_API_KEY                (per-repo; optional — a missing key
+#                                   cleanly skips the review with a
+#                                   workflow notice, so this is safe to
+#                                   merge before the key is set)
+#   - AI_REVIEW_LOG_TOKEN           (optional — threads each run into a
+#                                   per-(PR, provider) issue in
+#                                   HarperFast/ai-review-log with the
+#                                   `provider:gemini` label)
+
+on:
+  pull_request:
+    # `labeled` admits the `gemini-review` opt-in gesture. `vars.*`
+    # can't be read in `on:` (only in a job `if:`), so the trigger
+    # lists the union and the `review` job gates on GEMINI_ALWAYS_ON.
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  # Different group key from claude-review so the two providers can run
+  # in parallel on the same PR. cancel-in-progress is per-group, so a
+  # synchronize push cancels the in-flight Gemini run without touching
+  # the Claude run (and vice versa).
+  group: gemini-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Always-on toggle — see ai-review-prompts USAGE.md "Reviewers & the
+    # always-on toggle". GEMINI_ALWAYS_ON=true (repo/org variable) → auto-
+    # review trusted-author PRs; unset → opt-in via the gemini-review
+    # label. The reusable's authorize job still owns WHO is admitted
+    # (CODEOWNERS trust set; the labeler, not the author, on `labeled`).
+    if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@2be0f702b114e39b90eed90962922ef64df58482 # main 2026-06-03 (post #52 — calibration: Harper-aware wiring for the Gemini leg, skills-ref v1.7.0, surface-findings rule, access-control blocker guidance, public-skill dedup)
+    # Caller-side permissions at the calling-job level (NOT workflow-
+    # level — that placement caps the reusable's per-job grants below
+    # what they need and breaks the workflow at startup; see
+    # ai-review-prompts#39/#40). Union of what the reusable's authorize
+    # (`contents: read`) and review (`contents: read` + `pull-requests:
+    # write` + `id-token: write`) jobs declare.
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    with:
+      # Same SHA as the `uses:` ref above. The reusable uses this to
+      # check out HarperFast/ai-review-prompts (layer files + bash
+      # scripts) at the same ref as the workflow logic itself. The
+      # duplication is unavoidable: reusable workflows can't introspect
+      # their own ref (`github.workflow_ref` resolves to the CALLER's
+      # ref in workflow_call context), and `uses: …@<ref>` is literal.
+      ai-review-prompts-ref: 2be0f702b114e39b90eed90962922ef64df58482
+      review-layers: |
+        universal
+        harper/common
+        harper/v5
+      repo-specific-checks: |
+        ## Repo-specific checks (Harper core)
+
+        This repo IS Harper core itself — "defer to Harper docs"
+        guidance from the layers applies to PLUGIN / APP docs,
+        not to docs within this repo (this is where the Harper docs'
+        behavior is defined).
+
+        On top of the layered scope, these are things specific to this
+        repo that the shared layers don't cover:
+
+        - **Linter is oxlint, not eslint.** `npm run lint` runs oxlint.
+          Advice in layers that references ESLint doesn't apply here.
+        - **Build tolerance (`tsc || true`)** is NOT used here —
+          Harper core's build should pass cleanly. Flag type errors
+          as real findings.
+        - **`dependencies.md`** documents all npm packages. New
+          runtime dependencies require an entry there; flag PRs that
+          add a dep without updating the file.
+        - **TypeStrip compatibility** — Harper core uses
+          `erasableSyntaxOnly`. Flag TypeScript constructs that would
+          break typestrip (non-type-only imports of types, parameter
+          property initialization, etc.).
+        - **RocksDB is primary storage** (LMDB still supported via
+          `HARPER_STORAGE_ENGINE=lmdb`). Tests should exercise the
+          primary path; flag PRs that test only the fallback.
+    secrets:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      AI_REVIEW_LOG_TOKEN: ${{ secrets.AI_REVIEW_LOG_TOKEN }}
+      HARPERFAST_AI_CLIENT_ID: ${{ secrets.HARPERFAST_AI_CLIENT_ID }}
+      HARPERFAST_AI_APP_PRIVATE_KEY: ${{ secrets.HARPERFAST_AI_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Always-on toggle + opt-in Gemini review

Brings this repo onto the unified review-toggle model (ai-review-prompts#48, USAGE "Reviewers & the always-on toggle"). Two changes:

**1. `claude-review.yml` — add the `CLAUDE_ALWAYS_ON` toggle.** A job-level `if:` gates the auto-run path on the `CLAUDE_ALWAYS_ON` repo variable, with the `claude-review` label opt-in always on top:

```yaml
if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
```

This is **backward-compatible**: with `CLAUDE_ALWAYS_ON=true` set, behavior is exactly as today. Pin unchanged (the bump is the separate PR #1118).

**2. New `gemini-review.yml` — opt-in Gemini reviewer.** Mirrors `claude-review.yml`'s layers + Harper-core checks so the two providers are comparable on the same PR. Pinned to ai-review-prompts `2be0f70`. **Opt-in by default** — runs only when a HarperFast org member applies the `gemini-review` label (the labeler, not the PR author, satisfies the auth gate), unless `GEMINI_ALWAYS_ON=true` is set.

### Maintainer actions before merge
- **Set `CLAUDE_ALWAYS_ON=true`** (repo Settings → Secrets and variables → Actions → Variables, or `gh variable set`) so Claude keeps auto-reviewing on the transition. Without it, Claude flips to opt-in-only.
- For the Gemini leg: create a **`gemini-review`** label + a **`GEMINI_API_KEY`** secret (a missing key skips the Gemini review cleanly — safe to merge before it's set).

### Notes
- Separate from the pin-bump PR **#1118** per the agreed split. Both touch `claude-review.yml` on different lines (pin vs `if:`); whichever merges second may need a trivial rebase.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
