### PR TITLE
feat: Export serveStatic

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ if (!workerThreads.isMainThread) {
 export { RequestTarget } from './resources/RequestTarget.ts';
 export { flushDatabases } from './resources/databases.ts';
 export { getContext, getResponse, getUser } from './security/jsLoader.ts';
+export { serveStatic } from './server/static.ts';
 
 // Type only exports.
 // Anything exported here will only be available as TypeScript types, not as values.
@@ -29,6 +30,7 @@ export type { IterableEventQueue } from './resources/IterableEventQueue.ts';
 export type { Table } from './resources/databases.ts';
 export type { Attribute } from './resources/Table.ts';
 export type { Scope } from './components/Scope.ts';
+export type { ServeStaticOptions, StaticCacheOptions } from './server/static.ts';
 export type { FilesOption, FilesOptionObject } from './components/deriveGlobOptions.ts';
 export type { FileAndURLPathConfig } from './components/Component.ts';
 export type { OptionsWatcher, Config, ConfigValue } from './components/OptionsWatcher.ts';

--- a/server/static.ts
+++ b/server/static.ts
@@ -1,7 +1,64 @@
-import { realpathSync, existsSync } from 'node:fs';
+import { realpathSync, existsSync, type Stats } from 'node:fs';
 import { join } from 'node:path';
+import type { ServerResponse } from 'node:http';
 import { Scope } from '../components/Scope';
+import { EntryHandler, type FileEntryEvent, type DirectoryEntryEvent } from '../components/EntryHandler';
+import type { FilesOption } from '../components/deriveGlobOptions';
 import send from 'send';
+
+/**
+ * Cache / response-header options shared by the config-driven plugin and the programmatic
+ * `serveStatic` helper.
+ *
+ * - `maxAge` and `immutable` are forwarded directly to `send`.
+ * - `cacheControl` is a full `Cache-Control` header value that takes precedence over `send`'s
+ *   default (`send` only sets `Cache-Control` when one isn't already present).
+ * - `setHeaders` is a per-file callback (like `express.static`/`sirv`) invoked just before the
+ *   response headers are sent; it runs last and can override `cacheControl`.
+ */
+export interface StaticCacheOptions {
+	maxAge?: number | string;
+	immutable?: boolean;
+	cacheControl?: string;
+	setHeaders?: (res: ServerResponse, pathname: string, stat: Stats) => void;
+}
+
+/**
+ * Options for the programmatic {@link serveStatic} helper. All options are independent of the
+ * component's own `files`/`urlPath` config, so an extension can serve any directory without
+ * synthesizing a Scope.
+ */
+export interface ServeStaticOptions extends StaticCacheOptions {
+	/** Absolute directory to serve from. Defaults to `scope.directory`. */
+	directory?: string;
+	/** Base URL path to serve under, e.g. `'/'`. */
+	urlPath?: string;
+	/** Glob (or `FilesOptionObject`) to watch, relative to `directory`. Defaults to `'**'`. */
+	files?: FilesOption;
+	/** If enabled, serve `index.html` files from directories. Defaults to `true`. */
+	index?: boolean;
+	/** File extensions to try when a file is not found (e.g. `['html']`). Defaults to `[]`. */
+	extensions?: string[];
+	/** If `true`, fall through to the next handler when a file is not found. Defaults to `true`. */
+	fallthrough?: boolean;
+	/** Custom 404 handling: a file path, or `{ file, statusCode }`. */
+	notFound?: string | { file: string; statusCode: number };
+	/** Named middleware ordering for `scope.server.http`. Defaults to `'authentication'`. */
+	before?: string;
+}
+
+type NotFoundOption = undefined | string | { file: string; statusCode: number };
+
+/**
+ * Resolved, per-request configuration used by the shared static responder.
+ */
+interface StaticConfig {
+	index: boolean;
+	extensions: string[];
+	fallthrough: boolean;
+	notFound: NotFoundOption;
+	cache: StaticCacheOptions;
+}
 
 /**
  * The static plugin handles serving static files from the respective application directory.
@@ -12,6 +69,7 @@ import send from 'send';
  * - `extensions`: An array of file extensions to try when serving files. If a file is not found, it will try appending each extension in order. For example, if set to `['html'], and the request is `/page`, it will try `/page.html` if `/page` is not found.
  * - `fallthrough`: If true, it will fall through to the next handler if the file is not found. If false, it will return a 404 error.
  * - `notFound`: Can be specified as a string to serve a custom 404 page, or an object with `file` and `statusCode` properties to serve a custom file with a specific status code. This is useful for hosting SPAs that use client-side routing. Make sure to set `fallthrough` to `false`!
+ * - `maxAge`, `immutable`, `cacheControl`: Control the `Cache-Control` header of served files. See {@link StaticCacheOptions}.
  *
  * This plugin dynamically updates its behavior based on the current configuration file. Users can make updates and immediately see the changes reflect in the next request.
  *
@@ -35,138 +93,291 @@ export function handleApplication(scope: Scope) {
 	});
 
 	// Handle entry events for the default entry handler based on the `files` and `urlPath` options
-	scope.handleEntry((entry) => {
-		switch (entry.eventType) {
-			// Directories only matter for the `index` files
-			case 'addDir':
-			case 'unlinkDir':
-				// Handle `index.html` for directories for if/when the user enables the `index` option
-				const indexPath = join(entry.absolutePath, 'index.html');
-				if (existsSync(indexPath)) {
-					indexEntries[entry.eventType === 'addDir' ? 'set' : 'delete'](entry.urlPath, indexPath);
-				}
-				break;
-			// Otherwise, user must specify pattern to match individual files
-			case 'add':
-				// Store the file in memory for serving
-				staticFiles.set(entry.urlPath, entry.absolutePath);
-				// If the file is an index.html, also store it in the index entries
-				if (entry.urlPath.endsWith('index.html')) {
-					// Without trailing slash; null -> 301 redirect to trailing slash
-					let lastSlashIndex = entry.urlPath.lastIndexOf('/');
-					indexEntries.set(entry.urlPath.slice(0, lastSlashIndex), null);
-					// With trailing slash; serves the index.html file
-					indexEntries.set(entry.urlPath.slice(0, lastSlashIndex + 1), entry.absolutePath);
-				}
-				break;
-			case 'unlink':
-				// Remove the file from memory when it is deleted
-				staticFiles.delete(entry.urlPath);
-				// If the file is an index.html, remove it from the index entries as well
-				if (entry.urlPath.endsWith('index.html')) {
-					let lastSlashIndex = entry.urlPath.lastIndexOf('/');
-					indexEntries.delete(entry.urlPath.slice(0, lastSlashIndex));
-					indexEntries.delete(entry.urlPath.slice(0, lastSlashIndex + 1));
-				}
-				break;
-		}
-	});
+	scope.handleEntry((entry) => updateStaticMaps(entry, staticFiles, indexEntries));
 
+	// The config-driven plugin reads its options live from `scope.options` on each request so
+	// that edits to the config file take effect on the next request without a restart.
 	scope.server.http(
-		(req, next) => {
-			// TODO: Not sure if the isWebSocket check is still necessary
-			if (req.method !== 'GET' || req.isWebSocket) return next(req);
+		createStaticResponder({
+			staticFiles,
+			indexEntries,
+			directory: scope.directory,
+			getConfig: () => {
+				const fallthrough = scope.options.get(['fallthrough']) ?? true;
+				if (typeof fallthrough !== 'boolean') {
+					throw new Error(`Invalid fallthrough option: ${fallthrough}. Must be a boolean.`);
+				}
 
-			// Default fallthrough to `true`
-			const fallthrough = scope.options.get(['fallthrough']) ?? true;
-
-			if (typeof fallthrough !== 'boolean') {
-				throw new Error(`Invalid fallthrough option: ${fallthrough}. Must be a boolean.`);
-			}
-
-			// Attempt to retrieve the requested static file from memory
-			let staticFile = staticFiles.get(req.pathname);
-
-			// If the file is not found, try matching index
-			if (!staticFile) {
 				const index = scope.options.get(['index']) ?? true;
-
 				if (typeof index !== 'boolean') {
 					throw new Error(`Invalid index option: ${index}. Must be a boolean.`);
 				}
 
-				if (index) {
-					// Retrieve index entry
-					staticFile = indexEntries.get(req.pathname);
-
-					// If `null`, redirect to trailing slash
-					if (staticFile === null) {
-						return {
-							status: 301,
-							headers: {
-								Location: req.pathname + '/',
-							},
-						};
-					}
-				}
-			}
-
-			// If the file is still not found, try matching extensions
-			if (!staticFile) {
 				const extensions = scope.options.get(['extensions']) ?? [];
 				if (!Array.isArray(extensions) || extensions.some((ext) => typeof ext !== 'string')) {
 					throw new Error(`Invalid extensions option: ${extensions}. Must be an array of strings.`);
 				}
 
-				for (const ext of extensions) {
-					staticFile = staticFiles.get(`${req.pathname}.${ext}`);
-					// break on first match
-					if (staticFile) break;
-				}
-			}
-
-			// If an entry matched, serve it
-			if (staticFile) {
-				// The benefit to using `send` is that it handles a lot of edge cases and headers for us.
 				return {
-					handlesHeaders: true,
-					body: send(req, realpathSync(staticFile)),
+					index,
+					extensions: extensions as string[],
+					fallthrough,
+					// `notFound` is validated lazily in the responder (only on the not-found path)
+					// to preserve the original behavior.
+					notFound: scope.options.get(['notFound']) as NotFoundOption,
+					cache: {
+						maxAge: scope.options.get(['maxAge']) as number | string | undefined,
+						immutable: scope.options.get(['immutable']) as boolean | undefined,
+						cacheControl: scope.options.get(['cacheControl']) as string | undefined,
+					},
 				};
-			}
-
-			// If fallthrough is true pass along the request to the next handler
-			if (fallthrough) {
-				return next(req);
-			}
-
-			// Otherwise, handle not found
-
-			const notFound = scope.options.get(['notFound']);
-
-			validateNotFoundOption(notFound);
-
-			if (!notFound) {
-				return {
-					status: 404,
-					body: 'File not found',
-				};
-			}
-
-			const notFoundPath = join(scope.directory, typeof notFound === 'string' ? notFound : notFound.file);
-			const statusCode = typeof notFound === 'object' ? notFound.statusCode : 404;
-
-			if (!existsSync(notFoundPath)) {
-				throw new Error(`Not found file does not exist: ${notFoundPath}`);
-			}
-
-			return {
-				status: statusCode,
-				handlesHeaders: true,
-				body: send(req, realpathSync(notFoundPath)),
-			};
-		},
+			},
+		}),
 		{ before: (scope.options.get(['before']) as string) ?? 'authentication' }
 	);
+}
+
+/**
+ * Programmatically serve static files from a directory, independent of the component's own
+ * `files`/`urlPath` config. This is the public entry point for extensions (exported from the
+ * `harper` package) that want to reuse Harper's static serving without synthesizing a Scope.
+ *
+ * It registers its own file watcher (rooted at `options.directory`) and an HTTP responder. The
+ * returned `EntryHandler` can be awaited via its `ready` promise and is automatically closed
+ * when the scope closes.
+ *
+ * @example
+ * serveStatic(scope, {
+ *   directory: buildDir,
+ *   urlPath: '/',
+ *   setHeaders(res, pathname) {
+ *     if (pathname.includes('/assets/')) res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+ *     else if (pathname.endsWith('index.html')) res.setHeader('Cache-Control', 'no-cache');
+ *   },
+ * });
+ */
+export function serveStatic(scope: Scope, options: ServeStaticOptions = {}): EntryHandler {
+	const directory = options.directory ?? scope.directory;
+
+	// in-memory map of static files; keys are URL paths, values are absolute file paths
+	const staticFiles = new Map<string, string>();
+	const indexEntries = new Map<string, string>();
+
+	// Watch the target directory directly. Unlike `scope.handleEntry`, this is rooted at an
+	// arbitrary `directory` rather than `scope.directory`, and is independent of the
+	// component's own `files`/`urlPath` config.
+	const entryHandler = new EntryHandler(
+		scope.pluginName,
+		directory,
+		{ files: options.files ?? '**', urlPath: options.urlPath },
+		scope.logger
+	);
+	entryHandler.on('error', (error) => scope.logger.error?.('serveStatic watcher error:', error));
+	entryHandler.on('all', (entry) => updateStaticMaps(entry, staticFiles, indexEntries));
+	// Tie the watcher to the scope lifecycle so it's torn down with the component.
+	scope.on('close', () => void entryHandler.close());
+
+	validateNotFoundOption(options.notFound);
+
+	// Programmatic options are a captured snapshot (not live config reads).
+	const config: StaticConfig = {
+		index: options.index ?? true,
+		extensions: options.extensions ?? [],
+		fallthrough: options.fallthrough ?? true,
+		notFound: options.notFound,
+		cache: {
+			maxAge: options.maxAge,
+			immutable: options.immutable,
+			cacheControl: options.cacheControl,
+			setHeaders: options.setHeaders,
+		},
+	};
+
+	scope.server.http(createStaticResponder({ staticFiles, indexEntries, directory, getConfig: () => config }), {
+		before: options.before ?? 'authentication',
+		// Pass urlPath explicitly so it overrides the value the Scope proxy injects from
+		// `scope.options` — routing should match the directory we're actually serving.
+		urlPath: options.urlPath,
+	});
+
+	return entryHandler;
+}
+
+/**
+ * Maintain the in-memory `staticFiles` and `indexEntries` maps in response to entry events.
+ */
+function updateStaticMaps(
+	entry: FileEntryEvent | DirectoryEntryEvent,
+	staticFiles: Map<string, string>,
+	indexEntries: Map<string, string>
+): void {
+	switch (entry.eventType) {
+		// Directories only matter for the `index` files
+		case 'addDir':
+		case 'unlinkDir': {
+			// Handle `index.html` for directories for if/when the user enables the `index` option
+			const indexPath = join(entry.absolutePath, 'index.html');
+			if (existsSync(indexPath)) {
+				indexEntries[entry.eventType === 'addDir' ? 'set' : 'delete'](entry.urlPath, indexPath);
+			}
+			break;
+		}
+		// Otherwise, user must specify pattern to match individual files
+		case 'add':
+			// Store the file in memory for serving
+			staticFiles.set(entry.urlPath, entry.absolutePath);
+			// If the file is an index.html, also store it in the index entries
+			if (entry.urlPath.endsWith('index.html')) {
+				// Without trailing slash; null -> 301 redirect to trailing slash
+				let lastSlashIndex = entry.urlPath.lastIndexOf('/');
+				indexEntries.set(entry.urlPath.slice(0, lastSlashIndex), null);
+				// With trailing slash; serves the index.html file
+				indexEntries.set(entry.urlPath.slice(0, lastSlashIndex + 1), entry.absolutePath);
+			}
+			break;
+		case 'unlink':
+			// Remove the file from memory when it is deleted
+			staticFiles.delete(entry.urlPath);
+			// If the file is an index.html, remove it from the index entries as well
+			if (entry.urlPath.endsWith('index.html')) {
+				let lastSlashIndex = entry.urlPath.lastIndexOf('/');
+				indexEntries.delete(entry.urlPath.slice(0, lastSlashIndex));
+				indexEntries.delete(entry.urlPath.slice(0, lastSlashIndex + 1));
+			}
+			break;
+	}
+}
+
+type MatchResult = { kind: 'file'; absolutePath: string } | { kind: 'redirect'; location: string } | { kind: 'none' };
+
+/**
+ * Resolve a request pathname against the in-memory maps, honoring `index` and `extensions`.
+ */
+function matchStaticFile(
+	pathname: string,
+	{
+		staticFiles,
+		indexEntries,
+		index,
+		extensions,
+	}: { staticFiles: Map<string, string>; indexEntries: Map<string, string>; index: boolean; extensions: string[] }
+): MatchResult {
+	// Attempt to retrieve the requested static file from memory
+	let staticFile = staticFiles.get(pathname);
+
+	// If the file is not found, try matching index
+	if (!staticFile && index) {
+		// Retrieve index entry
+		staticFile = indexEntries.get(pathname);
+
+		// If `null`, redirect to trailing slash
+		if (staticFile === null) {
+			return { kind: 'redirect', location: pathname + '/' };
+		}
+	}
+
+	// If the file is still not found, try matching extensions
+	if (!staticFile) {
+		for (const ext of extensions) {
+			staticFile = staticFiles.get(`${pathname}.${ext}`);
+			// break on first match
+			if (staticFile) break;
+		}
+	}
+
+	return staticFile ? { kind: 'file', absolutePath: staticFile } : { kind: 'none' };
+}
+
+/**
+ * Serve a single file with `send`, applying cache/header options.
+ *
+ * The benefit to using `send` is that it handles a lot of edge cases and headers for us.
+ */
+function respondWithFile(req: any, absolutePath: string, cache: StaticCacheOptions) {
+	const sendOptions: { maxAge?: number | string; immutable?: boolean } = {};
+	if (cache.maxAge !== undefined) sendOptions.maxAge = cache.maxAge;
+	if (cache.immutable !== undefined) sendOptions.immutable = cache.immutable;
+
+	const body = send(req, realpathSync(absolutePath), sendOptions);
+
+	if (cache.cacheControl || cache.setHeaders) {
+		// `send` emits 'headers' before applying its own Cache-Control, and only sets
+		// Cache-Control if one isn't already present — so values set here take precedence.
+		body.on('headers', (res: ServerResponse, pathname: string, stat: Stats) => {
+			if (cache.cacheControl) res.setHeader('Cache-Control', cache.cacheControl);
+			// setHeaders runs last so it can override cacheControl for per-file control.
+			if (cache.setHeaders) cache.setHeaders(res, pathname, stat);
+		});
+	}
+
+	return { handlesHeaders: true, body };
+}
+
+/**
+ * Build the `(req, next)` HTTP handler shared by the config-driven plugin and `serveStatic`.
+ * `getConfig` resolves the current configuration (live from `scope.options` for the plugin, or
+ * a captured snapshot for `serveStatic`).
+ */
+function createStaticResponder({
+	staticFiles,
+	indexEntries,
+	directory,
+	getConfig,
+}: {
+	staticFiles: Map<string, string>;
+	indexEntries: Map<string, string>;
+	directory: string;
+	getConfig: () => StaticConfig;
+}) {
+	return (req: any, next: (req: any) => any) => {
+		// TODO: Not sure if the isWebSocket check is still necessary
+		if (req.method !== 'GET' || req.isWebSocket) return next(req);
+
+		const { index, extensions, fallthrough, notFound, cache } = getConfig();
+
+		const match = matchStaticFile(req.pathname, { staticFiles, indexEntries, index, extensions });
+
+		if (match.kind === 'redirect') {
+			return {
+				status: 301,
+				headers: {
+					Location: match.location,
+				},
+			};
+		}
+
+		// If an entry matched, serve it
+		if (match.kind === 'file') {
+			return respondWithFile(req, match.absolutePath, cache);
+		}
+
+		// If fallthrough is true pass along the request to the next handler
+		if (fallthrough) {
+			return next(req);
+		}
+
+		// Otherwise, handle not found
+		validateNotFoundOption(notFound);
+
+		if (!notFound) {
+			return {
+				status: 404,
+				body: 'File not found',
+			};
+		}
+
+		const notFoundPath = join(directory, typeof notFound === 'string' ? notFound : notFound.file);
+		const statusCode = typeof notFound === 'object' ? notFound.statusCode : 404;
+
+		if (!existsSync(notFoundPath)) {
+			throw new Error(`Not found file does not exist: ${notFoundPath}`);
+		}
+
+		return {
+			status: statusCode,
+			...respondWithFile(req, notFoundPath, cache),
+		};
+	};
 }
 
 function validateNotFoundOption(

--- a/unitTests/server/static.test.js
+++ b/unitTests/server/static.test.js
@@ -1,0 +1,282 @@
+const { serveStatic, handleApplication } = require('#src/server/static');
+const { Scope } = require('#src/components/Scope');
+const { ApplicationScope } = require('#src/components/ApplicationScope');
+const { Resources } = require('#src/resources/Resources');
+const assert = require('node:assert/strict');
+const { join, basename } = require('node:path');
+const { tmpdir } = require('node:os');
+const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = require('node:fs');
+const { stringify } = require('yaml');
+
+// Exercise the public `serveStatic` helper against a real Scope (with a fake server that
+// records http registrations) and a real on-disk directory watched by a real EntryHandler.
+// This covers matchStaticFile + respondWithFile + the cache/header wiring end-to-end without
+// standing up the HTTP server.
+describe('serveStatic', () => {
+	let directory;
+	let scope;
+	let httpCalls;
+
+	beforeEach(async () => {
+		directory = mkdtempSync(join(tmpdir(), 'harper.unit-test.serveStatic-'));
+		// A small static tree to serve.
+		writeFileSync(join(directory, 'index.html'), '<h1>home</h1>');
+		writeFileSync(join(directory, 'page.html'), '<h1>page</h1>');
+		mkdirSync(join(directory, 'assets'));
+		writeFileSync(join(directory, 'assets', 'app-abc123.js'), 'console.log(1)');
+		mkdirSync(join(directory, 'sub'));
+		writeFileSync(join(directory, 'sub', 'index.html'), '<h1>sub</h1>');
+
+		httpCalls = [];
+		const fakeServer = {
+			http: (listener, options) => {
+				httpCalls.push({ listener, options });
+			},
+		};
+
+		// serveStatic ignores scope.options, but the Scope's OptionsWatcher needs a valid
+		// config to become ready.
+		const configFilePath = join(directory, 'config.yaml');
+		writeFileSync(configFilePath, stringify({ plugin: { files: '**' } }));
+
+		const appName = basename(directory);
+		scope = new Scope(
+			appName,
+			'plugin',
+			directory,
+			configFilePath,
+			new ApplicationScope('test', new Resources(), fakeServer)
+		);
+		await scope.ready;
+	});
+
+	afterEach(async () => {
+		await scope.close();
+		// Let chokidar teardown + any pending file reads settle before removing the temp dir.
+		await new Promise((resolve) => setImmediate(resolve));
+		try {
+			rmSync(directory, { recursive: true, force: true });
+			// eslint-disable-next-line sonarjs/no-ignored-exceptions
+		} catch {
+			// best effort cleanup of a temp directory
+		}
+	});
+
+	it('registers an http responder with the configured before/urlPath and serves a matched file', async () => {
+		const entryHandler = serveStatic(scope, { directory, urlPath: '/', before: 'authentication' });
+		await entryHandler.ready;
+
+		assert.equal(httpCalls.length, 1);
+		assert.equal(httpCalls[0].options.before, 'authentication');
+		assert.equal(httpCalls[0].options.urlPath, '/');
+
+		const responder = httpCalls[0].listener;
+		const result = responder({ method: 'GET', pathname: '/assets/app-abc123.js' }, () => 'NEXT');
+		assert.equal(result.handlesHeaders, true);
+		assert.ok(result.body, 'expected a send stream body');
+	});
+
+	it('serves the directory index for the root path', async () => {
+		const entryHandler = serveStatic(scope, { directory, urlPath: '/' });
+		await entryHandler.ready;
+
+		const responder = httpCalls[0].listener;
+		const result = responder({ method: 'GET', pathname: '/' }, () => 'NEXT');
+		assert.equal(result.handlesHeaders, true);
+	});
+
+	it('301-redirects a directory request to its trailing-slash form', async () => {
+		const entryHandler = serveStatic(scope, { directory, urlPath: '/' });
+		await entryHandler.ready;
+
+		const responder = httpCalls[0].listener;
+		const result = responder({ method: 'GET', pathname: '/sub' }, () => 'NEXT');
+		assert.equal(result.status, 301);
+		assert.equal(result.headers.Location, '/sub/');
+	});
+
+	it('matches files via the extensions fallback', async () => {
+		const entryHandler = serveStatic(scope, { directory, urlPath: '/', extensions: ['html'] });
+		await entryHandler.ready;
+
+		const responder = httpCalls[0].listener;
+		const result = responder({ method: 'GET', pathname: '/page' }, () => 'NEXT');
+		assert.equal(result.handlesHeaders, true);
+	});
+
+	it('falls through to next when no file matches and fallthrough is true', async () => {
+		const entryHandler = serveStatic(scope, { directory, urlPath: '/' });
+		await entryHandler.ready;
+
+		const responder = httpCalls[0].listener;
+		let nextCalled = false;
+		const result = responder({ method: 'GET', pathname: '/missing' }, () => {
+			nextCalled = true;
+			return 'NEXT';
+		});
+		assert.equal(nextCalled, true);
+		assert.equal(result, 'NEXT');
+	});
+
+	it('returns 404 when no file matches and fallthrough is false', async () => {
+		const entryHandler = serveStatic(scope, { directory, urlPath: '/', fallthrough: false });
+		await entryHandler.ready;
+
+		const responder = httpCalls[0].listener;
+		const result = responder({ method: 'GET', pathname: '/missing' }, () => 'NEXT');
+		assert.equal(result.status, 404);
+		assert.equal(result.body, 'File not found');
+	});
+
+	it('serves a custom notFound file with the configured status code', async () => {
+		writeFileSync(join(directory, '404.html'), 'nope');
+		const entryHandler = serveStatic(scope, {
+			directory,
+			urlPath: '/',
+			fallthrough: false,
+			notFound: { file: '404.html', statusCode: 404 },
+		});
+		await entryHandler.ready;
+
+		const responder = httpCalls[0].listener;
+		const result = responder({ method: 'GET', pathname: '/missing' }, () => 'NEXT');
+		assert.equal(result.status, 404);
+		assert.equal(result.handlesHeaders, true);
+	});
+
+	it('passes non-GET requests through to the next handler', async () => {
+		const entryHandler = serveStatic(scope, { directory, urlPath: '/' });
+		await entryHandler.ready;
+
+		const responder = httpCalls[0].listener;
+		let nextCalled = false;
+		responder({ method: 'POST', pathname: '/index.html' }, () => {
+			nextCalled = true;
+		});
+		assert.equal(nextCalled, true);
+	});
+
+	it('applies a full cacheControl value, with setHeaders taking final precedence per file', async () => {
+		const entryHandler = serveStatic(scope, {
+			directory,
+			urlPath: '/',
+			cacheControl: 'public, max-age=31536000, immutable',
+			setHeaders: (res, pathname) => {
+				if (pathname.endsWith('index.html')) res.setHeader('Cache-Control', 'no-cache');
+			},
+		});
+		await entryHandler.ready;
+		const responder = httpCalls[0].listener;
+
+		// Content-hashed asset keeps the immutable cacheControl value.
+		const assetResult = responder({ method: 'GET', pathname: '/assets/app-abc123.js' }, () => 'NEXT');
+		const assetHeaders = emitHeaders(assetResult.body, join(directory, 'assets', 'app-abc123.js'));
+		assert.equal(assetHeaders['Cache-Control'], 'public, max-age=31536000, immutable');
+
+		// index.html is overridden to no-cache by setHeaders (runs last).
+		const indexResult = responder({ method: 'GET', pathname: '/' }, () => 'NEXT');
+		const indexHeaders = emitHeaders(indexResult.body, join(directory, 'index.html'));
+		assert.equal(indexHeaders['Cache-Control'], 'no-cache');
+	});
+
+	it('does not attach a headers listener when no cache options are provided', async () => {
+		const entryHandler = serveStatic(scope, { directory, urlPath: '/' });
+		await entryHandler.ready;
+		const responder = httpCalls[0].listener;
+		const result = responder({ method: 'GET', pathname: '/assets/app-abc123.js' }, () => 'NEXT');
+		// No 'headers' listener means send's own default cache-control logic is untouched.
+		assert.equal(result.body.listenerCount('headers'), 0);
+	});
+});
+
+// The config-driven plugin entry point reads its options live from `scope.options`, including
+// the additive cache options. This verifies the YAML path is unchanged and that
+// maxAge/immutable/cacheControl flow through.
+describe('static plugin (config-driven handleApplication)', () => {
+	let directory;
+	let scope;
+	let httpCalls;
+
+	function startWithConfig(staticConfig) {
+		directory = mkdtempSync(join(tmpdir(), 'harper.unit-test.static-'));
+		writeFileSync(join(directory, 'index.html'), '<h1>home</h1>');
+		mkdirSync(join(directory, 'assets'));
+		writeFileSync(join(directory, 'assets', 'app-abc123.js'), 'console.log(1)');
+
+		httpCalls = [];
+		const fakeServer = {
+			http: (listener, options) => {
+				httpCalls.push({ listener, options });
+			},
+		};
+		const configFilePath = join(directory, 'config.yaml');
+		writeFileSync(configFilePath, stringify({ plugin: { files: '**', ...staticConfig } }));
+		scope = new Scope(
+			basename(directory),
+			'plugin',
+			directory,
+			configFilePath,
+			new ApplicationScope('test', new Resources(), fakeServer)
+		);
+	}
+
+	afterEach(async () => {
+		await scope.close();
+		await new Promise((resolve) => setImmediate(resolve));
+		try {
+			rmSync(directory, { recursive: true, force: true });
+			// eslint-disable-next-line sonarjs/no-ignored-exceptions
+		} catch {
+			// best effort cleanup of a temp directory
+		}
+	});
+
+	it('serves files watched via the default (files-driven) entry handler', async () => {
+		startWithConfig({});
+		await scope.ready;
+		handleApplication(scope);
+		await scope.waitForInitialLoads();
+
+		assert.equal(httpCalls.length, 1);
+		const responder = httpCalls[0].listener;
+		const result = responder({ method: 'GET', pathname: '/assets/app-abc123.js' }, () => 'NEXT');
+		assert.equal(result.handlesHeaders, true);
+		// With no cache config, no headers listener is attached (send default preserved).
+		assert.equal(result.body.listenerCount('headers'), 0);
+	});
+
+	it('applies a cacheControl value read live from config', async () => {
+		startWithConfig({ cacheControl: 'public, max-age=31536000, immutable' });
+		await scope.ready;
+		handleApplication(scope);
+		await scope.waitForInitialLoads();
+
+		const responder = httpCalls[0].listener;
+		const result = responder({ method: 'GET', pathname: '/assets/app-abc123.js' }, () => 'NEXT');
+		const headers = emitHeaders(result.body, join(directory, 'assets', 'app-abc123.js'));
+		assert.equal(headers['Cache-Control'], 'public, max-age=31536000, immutable');
+	});
+
+	it('honors before from config when registering the http handler', async () => {
+		startWithConfig({ before: 'authentication' });
+		await scope.ready;
+		handleApplication(scope);
+		await scope.waitForInitialLoads();
+
+		assert.equal(httpCalls[0].options.before, 'authentication');
+	});
+});
+
+// Drive the send stream's 'headers' event with a fake response to observe what headers the
+// cache wiring sets. (send emits 'headers' before applying its own Cache-Control.)
+function emitHeaders(body, pathname) {
+	const headers = {};
+	const fakeRes = {
+		setHeader: (key, value) => {
+			headers[key] = value;
+		},
+		getHeader: (key) => headers[key],
+	};
+	body.emit('headers', fakeRes, pathname, {});
+	return headers;
+}


### PR DESCRIPTION
`@harperfast/vite-plugin` wants to serve a Vite build through Harper's built-in `static` plugin instead of bundling its own static server. Two things block a clean integration:

1. **No public programmatic entry.** The only entry point is `handleApplication(scope)` in [server/static.ts](server/static.ts), and the `harper` package only exports `"."` ([package.json:121](package.json)), so `harper/dist/server/static.js` can't be imported by path. The plugin currently resolves the file on disk and `require()`s it, then fakes a `Scope` — fragile across versions.
2. **No cache-header control.** The handler calls `send(req, realpathSync(file))` with no options ([server/static.ts:133](server/static.ts)), so consumers can't set `Cache-Control`. A Vite build needs content-hashed assets cached forever (`public, max-age=31536000, immutable`) while `index.html` stays `no-cache`.

Goal: add a `Scope`-free `serveStatic(scope, options)` helper, export it from the `harper` package, and add cache/header options — both to the helper and to the YAML config-driven path. All existing config behavior (`files`, `urlPath`, `index`, `extensions`, `fallthrough`, `notFound`, `before`) stays unchanged; everything here is additive.

Decisions confirmed with the user:
- Expose `serveStatic` (+ `ServeStaticOptions`) from the `harper` package via `index.ts`.
- Add `maxAge` / `immutable` / `cacheControl` to the YAML config path too (live-reloadable); `setHeaders` is programmatic-only (it's a function, can't come from YAML).

- `send` v1.2.1 ships **no types** and tsconfig has no `noImplicitAny`/`strict`, so `send` is effectively `any` — `.on('headers', …)` needs no type wrangling.
- `send`'s stream emits `'headers'(res, path, stat)` **before** it applies its own `Cache-Control`, and it only sets `Cache-Control` if not already present ([node_modules/send/index.js:730-754]). So setting the header in a `'headers'` listener wins over send's default. This is exactly how `cacheControl` (full string) and `setHeaders` are implemented. `maxAge`/`immutable` are passed natively to `send`.
- An `EntryHandler` ([components/EntryHandler.ts:98](components/EntryHandler.ts)) is rooted at an explicit `directory` and watches a `files` glob, deriving `entry.urlPath` (via `resolveBaseURLPath(name, urlPath)` + glob-base stripping) and `entry.absolutePath`. This lets `serveStatic` watch an **arbitrary absolute directory** independent of `scope.directory`, which `scope.handleEntry` can't (it hardcodes `scope.directory`).
- The static plugin is registered as `static: staticFiles` in `TRUSTED_RESOURCE_PLUGINS` ([components/componentLoader.ts:104](components/componentLoader.ts)) and invoked via `plugin.handleApplication(scope)`. This wiring is untouched.
- `index.ts` already has a "regular exports" block at the top ([index.ts:9-12](index.ts)) for value exports like `getContext` — `serveStatic` goes there. (Do NOT use the runtime-globals block lower down.)

Extract three reusable pieces (no behavior change to existing logic):

- **`updateStaticMaps(entry, staticFiles, indexEntries)`** — the `add`/`unlink`/`addDir`/ `unlinkDir` switch currently inline in `handleApplication` ([static.ts:38-73]). Maintains the `staticFiles` and `indexEntries` maps. Pure; shared by both entry points.
- **`matchStaticFile(pathname, { staticFiles, indexEntries, index, extensions })`** — the lookup currently at [static.ts:88-126]. Returns a discriminated result: `{ kind: 'file', absolutePath }` | `{ kind: 'redirect', location }` | `{ kind: 'none' }`.
- **`respondWithFile(req, absolutePath, cache)`** — wraps `send`: ```ts const sendOptions = {};
  if (cache.maxAge !== undefined) sendOptions.maxAge = cache.maxAge;       // number ms or ms-string
  if (cache.immutable !== undefined) sendOptions.immutable = cache.immutable;
  const body = send(req, realpathSync(absolutePath), sendOptions);
  if (cache.cacheControl || cache.setHeaders) {
    body.on('headers', (res, path, stat) => {
      if (cache.cacheControl) res.setHeader('Cache-Control', cache.cacheControl);
      if (cache.setHeaders) cache.setHeaders(res, path, stat);   // runs last; can override
    });
  }
  return { handlesHeaders: true, body };
  ```
  Used for both matched files and the `notFound` file.

Add a shared **`createStaticResponder({ scope, staticFiles, indexEntries, directory, getConfig })`** that returns the `(req, next)` handler. `getConfig()` returns the live config object `{ index, extensions, fallthrough, notFound, cache }`. The responder keeps the exact control flow of today: GET/non-websocket guard → `matchStaticFile` → `respondWithFile` on hit → 301 on redirect → `next(req)` on fallthrough → `notFound`/404 handling (resolving the notFound file under `directory`, reusing `validateNotFoundOption` which already exists at [static.ts:172]).

Define the public options type:
```ts
export interface ServeStaticOptions {
  directory?: string;          // absolute dir to serve from; default scope.directory
  urlPath?: string;            // base URL path, e.g. '/'
  files?: FilesOption;         // glob to watch, relative to `directory`; default '**'
  index?: boolean;             // default true
  extensions?: string[];       // default []
  fallthrough?: boolean;       // default true
  notFound?: string | { file: string; statusCode: number };
  before?: string;             // default 'authentication'
  // cache / headers:
  maxAge?: number | string;
  immutable?: boolean;
  cacheControl?: string;
  setHeaders?: (res: ServerResponse, pathname: string, stat: Stats) => void;
}
```

```ts
export function serveStatic(scope: Scope, options: ServeStaticOptions = {}): EntryHandler {
  const directory = options.directory ?? scope.directory;
  const staticFiles = new Map<string, string>();
  const indexEntries = new Map<string, string>();

  // Own EntryHandler rooted at `directory` — independent of scope.options config.
  const entryHandler = new EntryHandler(
    scope.pluginName,
    directory,
    { files: options.files ?? '**', urlPath: options.urlPath },
    scope.logger
  );
  entryHandler.on('error', (e) => scope.logger.error?.('serveStatic watcher error:', e));
  entryHandler.on('all', (entry) => updateStaticMaps(entry, staticFiles, indexEntries));
  scope.on('close', () => void entryHandler.close());   // lifecycle cleanup

  const config = {            // captured snapshot (programmatic; not live YAML)
    index: options.index ?? true,
    extensions: options.extensions ?? [],
    fallthrough: options.fallthrough ?? true,
    notFound: options.notFound,
    cache: { maxAge: options.maxAge, immutable: options.immutable,
             cacheControl: options.cacheControl, setHeaders: options.setHeaders },
  };
  scope.server.http(
    createStaticResponder({ scope, staticFiles, indexEntries, directory, getConfig: () => config }),
    { before: options.before ?? 'authentication', urlPath: options.urlPath }
  );
  return entryHandler;
}
```

Notes:
- Returns the `EntryHandler` so callers can `await ret.ready` or `ret.close()`; auto-closes on `scope` `'close'`.
- Passing `urlPath` explicitly in the http options overrides the value the `Scope` proxy injects from `scope.options` ([Scope.ts:104-110]), so routing matches `options.urlPath`.
- `directory` should exist before calling (the Vite plugin builds first); chokidar tolerates later-created files within a watched dir.

- Keep the `staticFiles`/`indexEntries` maps and the `scope.options.on('change')` clear of maps on `files`/`urlPath` change ([static.ts:27-35]).
- Keep `scope.handleEntry((entry) => updateStaticMaps(entry, …))` (default, config-driven watcher rooted at `scope.directory`).
- Register `createStaticResponder` with `getConfig()` that reads `scope.options` **live each request** (preserving today's per-request reload of `index`/`extensions`/`fallthrough`/ `notFound`), and now also reads the new `maxAge`/`immutable`/`cacheControl` keys into `cache`. `directory` = `scope.directory`; `before` read once at registration as today.

This preserves the config-driven path exactly, plus the additive YAML cache options.

In [index.ts](index.ts), in the top regular-exports block (next to the `getContext` line):
```ts
export { serveStatic } from './server/static.ts';
export type { ServeStaticOptions } from './server/static.ts';
```
Compiles to `dist/index.js` / `dist/index.d.ts`; the existing `exports["."]` ([package.json:121-126]) then makes `import { serveStatic } from 'harper'` work. No `exports`-map change needed.

- [server/static.ts](server/static.ts) — refactor: extract `updateStaticMaps`, `matchStaticFile`, `respondWithFile`, `createStaticResponder`; add `ServeStaticOptions` + `serveStatic`; rebuild `handleApplication` on the shared internals; add cache reads.
- [index.ts](index.ts) — add the two public exports.
- Imports needed in `static.ts`: `EntryHandler` from `../components/EntryHandler`, `FilesOption` (type) from `../components/deriveGlobOptions`, `Stats` / `ServerResponse` types as needed.

- **Build/lint:** `npm run build` (catches the new `index.ts` export + any circular-import surprise from `index.ts` → `static.ts` → `Scope`), then `npm run lint` and `npm run format:write`.
- **Unit tests** (`node:assert/strict`, no sinon/rewire — match `unitTests/components/*`), new `unitTests/server/static.test.js`:
  - `matchStaticFile`: file hit, index hit, `null`→redirect, extension fallback, miss.
  - cache wiring: build a `send` stream via `respondWithFile` with `cacheControl` / `setHeaders`, emit a synthetic `'headers'` event with a fake `res` (object recording `setHeader`), assert the header is set and `setHeaders` runs last.
  - `serveStatic` integration-ish: construct a real `Scope` over a temp dir with a fake `server` `{ http: (fn, opts) => recorded.push({fn, opts}) }` (pattern from [unitTests/components/Scope.test.js:18-58]), write files, `await ret.ready`, assert the responder was registered with the right `before`/`urlPath` and that a GET for a known file returns `{ handlesHeaders: true }`.
- **Integration test** (extend the static fixture pattern in [integrationTests/deploy/deploy-tracking.test.ts:77-100]): deploy a `static:` component with `cacheControl: 'public, max-age=31536000, immutable'` (or `maxAge`/`immutable`), request a served file over HTTP, assert the `Cache-Control` response header; request with no cache config and assert send's default (`public, max-age=0`) still applies.
- **Manual smoke (optional):** point the WIP `@harperfast/vite-plugin` at the rebuilt `harper`, call `serveStatic(scope, { directory: <dist>, urlPath: '/', setHeaders })`, and curl `/assets/*.js` (immutable) vs `/index.html` (no-cache).