### PR TITLE
fix(replay): contain rocksdb-js corrupt-entry throws to a single log

### DIFF
--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -199,6 +199,30 @@ export class RocksTransactionLogStore extends EventEmitter {
 			let nextEntries: any[];
 			let latestUpdates: number;
 			const iterators: IterableIterator<TransactionEntry>[] = [];
+			// Iterators that have permanently failed (corrupt entry stuck at the same
+			// position). Tracked by identity so the retry-poll path in next() and
+			// updateIterators() never calls .next() on them again — otherwise every
+			// subsequent drain cycle would re-throw the same RangeError, spamming logs
+			// and burning CPU.
+			const failedIterators = new WeakSet<IterableIterator<TransactionEntry>>();
+			// Per-log advance that converts a thrown corrupt-entry error from rocksdb-js
+			// into a clean `done: true` for that iterator. The reader's RangeError leaves
+			// `position` at the bad entry; re-calling next() would re-throw indefinitely.
+			// Terminating just this log lets the aggregate keep draining the other peers'
+			// logs and prevents the throw from escaping into setImmediate-scheduled
+			// consumers (notifyFromTransactionData) where it becomes an uncaughtException.
+			const safeNext = (iterator: IterableIterator<TransactionEntry>, log?: TransactionLog) => {
+				if (failedIterators.has(iterator)) return { value: undefined, done: true };
+				try {
+					return iterator.next();
+				} catch (error) {
+					failedIterators.add(iterator);
+					harperLogger.error('Transaction log iterator failed; terminating this log', error, {
+						log: log?.name,
+					});
+					return { value: undefined, done: true };
+				}
+			};
 			const updateIterators = () => {
 				if (latestUpdates !== this.updates) {
 					const latestLogs = (this.nodeLogs || this.loadLogs()).filter(
@@ -231,7 +255,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 						}
 					}
 				}
-				nextEntries = iterators.map((iterator) => iterator.next());
+				nextEntries = iterators.map((iterator, i) => safeNext(iterator, logs[i]));
 			};
 			updateIterators();
 
@@ -275,7 +299,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 						}
 						if (earliestIndex >= 0) {
 							// replace the entry with the next one from the iterator we pulled from
-							nextEntries[earliestIndex] = iterators[earliestIndex].next();
+							nextEntries[earliestIndex] = safeNext(iterators[earliestIndex], logs[earliestIndex]);
 							return {
 								value: onlyKeys ? earliest.timestamp : earliest,
 								done: false,

--- a/resources/transactionBroadcast.ts
+++ b/resources/transactionBroadcast.ts
@@ -161,7 +161,19 @@ function notifyFromTransactionData(subscriptions, auditLogIterable?, allowYield 
 	let yielded = false;
 	try {
 		while (true) {
-			const result = iterator.next();
+			let result;
+			try {
+				result = iterator.next();
+			} catch (error) {
+				// We run from setImmediate, so an iterator throw here becomes an
+				// uncaughtException that kills the worker (RocksTransactionLogStore's
+				// own safeNext should already prevent this for the corrupt-entry case,
+				// but defense in depth — a stale crash here permanently silences this
+				// subscription set on every commit). Stop draining this pass; the next
+				// commit reschedules another notify cycle.
+				warn('Audit log iterator failed during broadcast; stopping this pass', error);
+				break;
+			}
 			if (result.done) break;
 			const auditRecord = result.value;
 			const timestamp: number = auditRecord.localTime ?? auditRecord.version;

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -452,6 +452,98 @@ describe('Audit log', () => {
 			assert.strictEqual(sentinel.type, undefined);
 			assert.strictEqual(sentinel.version, 42, 'timestamp from the log entry is preserved so lastTxnTime advances');
 		});
+
+		// rocksdb-js >=1.4.1 hardened transaction-log readers throw a bounded
+		// RangeError ("Corrupt transaction log entry at position …: declared length …
+		// overruns the log") when an entry's length header overshoots the committed
+		// (or mapped) bound. That throw originates inside the underlying iterator's
+		// next() — upstream of the .map() callback's per-entry try/catch — so without
+		// safeNext() it escaped through the aggregate iterator into setImmediate-
+		// scheduled consumers (notifyFromTransactionData) as an uncaughtException
+		// that crashed the worker on every commit after a SIGKILL-induced torn write.
+		it('terminates the failing log iterator instead of propagating a corrupt-entry throw out of the aggregate', () => {
+			const fakeLog = { query: () => null, addEntry: () => null, on: () => null };
+			const fakeRoot = { useLog: () => fakeLog, on: () => null, listLogs: () => [] };
+			const store = new RocksTransactionLogStore(fakeRoot);
+
+			// First log: yields one good entry, then throws (mirrors a torn entry past
+			// a committed boundary). Track call count so we can confirm the failed
+			// iterator is not re-polled on later drain cycles (otherwise every commit
+			// re-throws the same RangeError, spamming logs and burning CPU).
+			let corruptNextCalls = 0;
+			const corruptLog = {
+				name: 'corrupt',
+				query: () => {
+					let calls = 0;
+					return {
+						next() {
+							corruptNextCalls++;
+							calls++;
+							if (calls === 1) {
+								return {
+									done: false,
+									value: { timestamp: 1, data: new Uint8Array(20), endTxn: false },
+								};
+							}
+							throw new RangeError(
+								'Corrupt transaction log entry at position 14fd of log 1: declared length 2046820352 overruns the log (limit=5439)'
+							);
+						},
+						[Symbol.iterator]() {
+							return this;
+						},
+					};
+				},
+				addEntry: () => null,
+				on: () => null,
+			};
+			// Second log: drains cleanly with two entries past the corrupt one's
+			// timestamp. The aggregate must keep delivering these after the first log
+			// terminates.
+			const healthyLog = {
+				name: 'healthy',
+				query: () => {
+					let i = 0;
+					const entries = [
+						{ timestamp: 2, data: new Uint8Array(20), endTxn: false },
+						{ timestamp: 3, data: new Uint8Array(20), endTxn: false },
+					];
+					return {
+						next() {
+							return i < entries.length ? { done: false, value: entries[i++] } : { done: true, value: undefined };
+						},
+						[Symbol.iterator]() {
+							return this;
+						},
+					};
+				},
+				addEntry: () => null,
+				on: () => null,
+			};
+
+			store.nodeLogs = [corruptLog, healthyLog];
+
+			const timestamps = [];
+			assert.doesNotThrow(() => {
+				for (const record of store.getRange({})) {
+					timestamps.push(record.version);
+				}
+			}, 'aggregate iteration must not propagate the corrupt-entry RangeError');
+
+			assert.deepStrictEqual(
+				timestamps,
+				[1, 2, 3],
+				'good entries from the corrupt log (before the throw) and all entries from healthy peer logs must drain'
+			);
+			// 2 = the one good entry + the call that threw. Anything higher means the
+			// retry-poll path is calling .next() on a known-bad iterator and we'll spam
+			// the log on every subsequent commit.
+			assert.strictEqual(
+				corruptNextCalls,
+				2,
+				`failed corrupt iterator must not be re-polled after it throws (next() called ${corruptNextCalls} times)`
+			);
+		});
 	});
 
 	it('addLogToMaps assigns nodeId 0 to the local log and populates nodeLogs[0]', () => {


### PR DESCRIPTION
## Summary

Run \`/harper-engineering-skill\` at the top of your review.

Main has been red since #1117 + the rocksdb-js@1.4.2 bump landed: Integration Tests shard 2 fails on every platform (Bun, Node 22/24/26). The replay-stress integration test SIGKILLs Harper, the next start replays, and then `notifyFromTransactionData` (scheduled via `setImmediate`) hits an audit-log iterator that throws a bounded `RangeError` from the new rocksdb-js corrupt-entry-length hardening (HarperFast/rocksdb-js#612). Because the throw originates **inside the iterator's `next()`** — upstream of the `.map()` callback's per-entry try/catch — it escapes through the aggregate, becomes an uncaughtException, and crashes the worker on every commit after the torn write. Confirmed identical stack trace on shard 2 across all node versions in run 26924517619.

```
[error]: uncaughtException RangeError: Corrupt transaction log entry at position 14fd of log 1: declared length 2046820352 overruns the log (limit=5439)
    at Object.next (rocksdb-js/dist/index.cjs:2044)
    at Object.next (resources/RocksTransactionLogStore.js:296)
    at notifyFromTransactionData (resources/transactionBroadcast.js:172)
    at Immediate.<anonymous> (resources/transactionBroadcast.js:64)
```

## Changes

1. **`RocksTransactionLogStore.getRange` (primary fix).** Wrap each `iterators[i].next()` call at the aggregate boundary in `safeNext()` — logs once, marks the iterator failed (WeakSet), returns `{done: true}`. Subsequent retry-polls skip the failed iterator so a single corrupt log doesn't re-throw and log-spam on every commit while healthy peer logs keep draining.
2. **`transactionBroadcast.notifyFromTransactionData` (defense in depth).** A try/catch around the bare `iterator.next()` inside the drain loop. Step 1 should prevent this, but a `setImmediate`-scheduled consumer should never be a one-line patch away from an uncaughtException that kills the worker.
3. Unit test in `unitTests/resources/auditLog.test.js` asserting iteration completes without throwing, good entries before the throw drain, healthy peer logs continue, and the failed iterator is **not** re-polled on later drain cycles (Codex review caught the missing not-re-polled assertion).

## Where to look

- The WeakSet-based "stop re-polling failed iterators" path — Codex's review correctly flagged that a one-off `{done:true}` without tracking would still get re-polled on every retry pass via `updateIterators`. The added assertion (`corruptNextCalls === 2`) locks that in.
- I left the single-log path (`options.log !== undefined`) untouched — that's used by `getSync(timestamp, …)` for historical lookups and a thrown error there should surface to the caller, not be silently swallowed. Worth a second opinion.

## Local verification

- `replay-stress.test.ts` (the trigger): 3/3 pass.
- `npm run test:integration:all -- --shard=2/4`: 83/83 pass.
- `npm run test:integration:all -- --shard=4/4`: 140/140 pass.
- `npm run test:unit:main`: 2556 pass.
- `npm run test:unit:resources`: 688 pass.

Generated by Claude (Opus 4.7); Codex CLI cross-model review applied (WeakSet tracking + test assertion).