### PR TITLE
fix: Harper login can use inquirer for easier parsing

### DIFF
--- a/bin/login.ts
+++ b/bin/login.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import dotenv from 'dotenv';
 import fs from 'node:fs';
 import path from 'node:path';
-import readline from 'node:readline/promises';
+import inquirer from 'inquirer';
 import { saveCredentials, normalizeTarget } from './cliCredentials.ts';
 import { cliOperations } from './cliOperations.ts';
 
@@ -12,135 +12,101 @@ import { cliOperations } from './cliOperations.ts';
 export async function login(targetArg: string, usernameArg: string): Promise<void> {
 	dotenv.config();
 
-	const rl = readline.createInterface({
-		input: process.stdin,
-		output: process.stdout,
-	});
+	console.log(chalk.cyan('\nHarper login'));
+	console.log(
+		chalk.gray(
+			'Harper apps can be deployed to Fabric for free, where one runtime can house your app, database, cache, and messaging.'
+		)
+	);
+	console.log(chalk.gray('https://fabric.harper.fast/\n'));
+	console.log(
+		chalk.gray('If you create a cluster, you can enter your credentials here. They will be exchanged for a JWT from')
+	);
+	console.log(chalk.gray('your cluster, which will be saved inside ~/.harperdb/credentials.json\n'));
 
-	try {
-		console.log(chalk.cyan('\nHarper login'));
-		console.log(
-			chalk.gray(
-				'Harper apps can be deployed to Fabric for free, where one runtime can house your app, database, cache, and messaging.'
-			)
-		);
-		console.log(chalk.gray('https://fabric.harper.fast/\n'));
-		console.log(
-			chalk.gray('If you create a cluster, you can enter your credentials here. They will be exchanged for a JWT from')
-		);
-		console.log(chalk.gray('your cluster, which will be saved inside ~/.harperdb/credentials.json\n'));
+	const defaultTarget = process.env.HARPER_CLI_TARGET || process.env.CLI_TARGET;
+	let target = targetArg || defaultTarget;
 
-		const defaultTarget = process.env.HARPER_CLI_TARGET || process.env.CLI_TARGET;
-		let target = targetArg || defaultTarget;
-		let skipTargetPrompt = !!targetArg;
-
-		if (!skipTargetPrompt) {
-			if (defaultTarget) {
-				const input = await rl.question(`Cluster Target [${defaultTarget}]: `);
-				if (input.trim()) {
-					target = input.trim();
-				}
-			} else {
-				target = await rl.question(`Cluster Target URL: `);
-			}
+	if (!targetArg) {
+		const { target: input } = await inquirer.prompt({
+			type: 'input',
+			name: 'target',
+			message: 'Cluster Target URL:',
+			default: defaultTarget,
+		});
+		if (input?.trim()) {
+			target = input.trim();
 		}
+	}
 
-		if (!target) {
-			console.error(chalk.red('Target URL is required.'));
-			process.exit(1);
-		}
+	if (!target) {
+		console.error(chalk.red('Target URL is required.'));
+		process.exit(1);
+	}
 
-		target = normalizeTarget(target);
+	target = normalizeTarget(target);
 
-		let targetUsername = usernameArg;
-		if (!targetUsername) {
-			if (process.env.CLI_TARGET_USERNAME) {
-				targetUsername = process.env.CLI_TARGET_USERNAME;
-				console.log(chalk.gray(`Using username from CLI_TARGET_USERNAME environment variable: ${targetUsername}`));
-			} else if (process.env.HARPER_CLI_USERNAME) {
-				targetUsername = process.env.HARPER_CLI_USERNAME;
-				console.log(chalk.gray(`Using username from HARPER_CLI_USERNAME environment variable: ${targetUsername}`));
-			} else {
-				targetUsername = await rl.question(`Cluster Username: `);
-			}
-		}
-
-		let targetPassword = process.env.CLI_TARGET_PASSWORD || process.env.HARPER_CLI_PASSWORD;
-
-		if (targetPassword) {
-			const envVarName = process.env.CLI_TARGET_PASSWORD ? 'CLI_TARGET_PASSWORD' : 'HARPER_CLI_PASSWORD';
-			console.log(chalk.gray(`Using password from ${envVarName} environment variable.`));
+	let targetUsername = usernameArg;
+	if (!targetUsername) {
+		if (process.env.CLI_TARGET_USERNAME) {
+			targetUsername = process.env.CLI_TARGET_USERNAME;
+			console.log(chalk.gray(`Using username from CLI_TARGET_USERNAME environment variable: ${targetUsername}`));
+		} else if (process.env.HARPER_CLI_USERNAME) {
+			targetUsername = process.env.HARPER_CLI_USERNAME;
+			console.log(chalk.gray(`Using username from HARPER_CLI_USERNAME environment variable: ${targetUsername}`));
 		} else {
-			targetPassword = await new Promise((resolve) => {
-				process.stdout.write(`Cluster Password: `);
-				process.stdin.setRawMode(true);
-				process.stdin.resume();
-				let password = '';
-				const onData = (data: Buffer) => {
-					for (let i = 0; i < data.length; i++) {
-						const char = data[i];
-						if (char === 13 || char === 10) {
-							// \r or \n
-							process.stdout.write('\n');
-							cleanup();
-							resolve(password);
-							return;
-						} else if (char === 3) {
-							// Ctrl+C
-							process.stdout.write('\n');
-							cleanup();
-							process.exit(1);
-						} else if (char === 8 || char === 127) {
-							// Backspace
-							if (password.length > 0) {
-								password = password.slice(0, -1);
-								process.stdout.write('\b \b');
-							}
-						} else {
-							password += data.toString('utf-8', i, i + 1);
-							process.stdout.write('*');
-						}
-					}
-				};
-
-				const cleanup = () => {
-					process.stdin.removeListener('data', onData);
-					process.stdin.setRawMode(false);
-					process.stdin.pause();
-				};
-
-				process.stdin.on('data', onData);
-			});
+			({ username: targetUsername } = await inquirer.prompt({
+				type: 'input',
+				name: 'username',
+				message: 'Cluster Username:',
+			}));
 		}
+	}
 
-		if (!targetUsername || !targetPassword) {
-			console.error('Username and password are required.');
+	let targetPassword = process.env.CLI_TARGET_PASSWORD || process.env.HARPER_CLI_PASSWORD;
+
+	if (targetPassword) {
+		const envVarName = process.env.CLI_TARGET_PASSWORD ? 'CLI_TARGET_PASSWORD' : 'HARPER_CLI_PASSWORD';
+		console.log(chalk.gray(`Using password from ${envVarName} environment variable.`));
+	} else {
+		// `type: 'password'` with no `mask` hides input entirely — nothing is echoed until Enter.
+		({ password: targetPassword } = await inquirer.prompt({
+			type: 'password',
+			name: 'password',
+			message: 'Cluster Password:',
+		}));
+	}
+
+	if (!targetUsername || !targetPassword) {
+		console.error('Username and password are required.');
+		process.exit(1);
+	}
+
+	const req = {
+		operation: 'create_authentication_tokens',
+		username: targetUsername,
+		password: targetPassword,
+		target,
+	};
+
+	const response = await cliOperations(req, true);
+
+	if (response && response.operation_token) {
+		const resolvedTarget = response.target || req.target || response.resolvedTarget || target;
+		try {
+			saveCredentials(resolvedTarget, {
+				operation_token: response.operation_token,
+				refresh_token: response.refresh_token,
+			});
+		} catch (err) {
+			console.error(chalk.red(err instanceof Error ? err.message : String(err)));
 			process.exit(1);
 		}
 
-		const req = {
-			operation: 'create_authentication_tokens',
-			username: targetUsername,
-			password: targetPassword,
-			target,
-		};
-
-		const response = await cliOperations(req, true);
-
-		if (response && response.operation_token) {
-			const resolvedTarget = response.target || req.target || response.resolvedTarget || target;
-			try {
-				saveCredentials(resolvedTarget, {
-					operation_token: response.operation_token,
-					refresh_token: response.refresh_token,
-				});
-			} catch (err) {
-				console.error(chalk.red(err.message));
-				process.exit(1);
-			}
-
-			// If CLI_TARGET is not in process.env before we started (meaning it's not in .env or other env vars),
-			// and we just logged in with a target, let's consider adding it to .env
+		// If CLI_TARGET is not in process.env before we started (meaning it's not in .env or other env vars),
+		// and we just logged in with a target, let's consider adding it to .env. This is non-critical
+		// (credentials are already saved), so a filesystem error here must not crash the CLI.
+		try {
 			const envPath = path.join(process.cwd(), '.env');
 			if (fs.existsSync(envPath)) {
 				const envConfig = dotenv.parse(fs.readFileSync(envPath));
@@ -156,13 +122,13 @@ export async function login(targetArg: string, usernameArg: string): Promise<voi
 					console.log(`Added HARPER_CLI_TARGET to .env`);
 				}
 			}
-
-			console.log(`Successfully logged in to ${resolvedTarget} and saved credentials.`);
-			process.exit(0);
-		} else {
-			throw new Error('Failed to retrieve authentication tokens.');
+		} catch (err) {
+			console.error(chalk.yellow(`Could not update .env: ${err instanceof Error ? err.message : String(err)}`));
 		}
-	} finally {
-		rl.close();
+
+		console.log(`Successfully logged in to ${resolvedTarget} and saved credentials.`);
+		process.exit(0);
+	} else {
+		throw new Error('Failed to retrieve authentication tokens.');
 	}
 }

--- a/unitTests/bin/login.test.js
+++ b/unitTests/bin/login.test.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 const os = require('node:os');
 const { login } = require('#src/bin/login');
 const { normalizeTarget } = require('#src/bin/cliCredentials');
+const inquirer = require('inquirer');
 
 describe('Login', () => {
 	describe('url normalization', () => {
@@ -41,23 +42,19 @@ describe('Login', () => {
 	});
 
 	describe('function arguments', () => {
-		const readline = require('node:readline/promises');
-		let originalCreateInterface;
-		let questionCalls;
+		let originalPrompt;
+		let promptCalls;
 
 		beforeEach(() => {
-			questionCalls = [];
+			promptCalls = [];
 			process.env.CLI_TARGET_PASSWORD = 'mockpassword';
-			originalCreateInterface = readline.createInterface;
-			readline.createInterface = () => {
-				return {
-					question: async (query) => {
-						questionCalls.push(query);
-						if (query.includes('Username')) return 'mockuser';
-						return 'mock-response';
-					},
-					close: () => {},
-				};
+			originalPrompt = inquirer.prompt;
+			inquirer.prompt = async (questions) => {
+				const q = Array.isArray(questions) ? questions[0] : questions;
+				promptCalls.push(q);
+				if (q.name === 'username') return { username: 'mockuser' };
+				if (q.name === 'target') return { target: 'mock-target' };
+				return { [q.name]: 'mock-response' };
 			};
 
 			this.originalExit = process.exit;
@@ -68,7 +65,7 @@ describe('Login', () => {
 
 		afterEach(() => {
 			delete process.env.CLI_TARGET_PASSWORD;
-			readline.createInterface = originalCreateInterface;
+			inquirer.prompt = originalPrompt;
 			process.exit = this.originalExit;
 		});
 
@@ -78,7 +75,7 @@ describe('Login', () => {
 			} catch {
 				// Ignore errors after target check
 			}
-			const targetPrompted = questionCalls.some((q) => q.includes('Target'));
+			const targetPrompted = promptCalls.some((q) => q.name === 'target');
 			assert.strictEqual(targetPrompted, false, 'Should not have prompted for target');
 		});
 	});
@@ -88,11 +85,6 @@ describe('Login', () => {
 		let originalCwd;
 		let originalExit;
 		let originalStdoutWrite;
-		let originalStdinSetRawMode;
-		let originalStdinResume;
-		let originalStdinPause;
-		let originalStdinOn;
-		let originalStdinRemoveListener;
 
 		// Mock cliOperations
 		const cliOperationsModule = require('#src/bin/cliOperations');
@@ -115,17 +107,6 @@ describe('Login', () => {
 			originalStdoutWrite = process.stdout.write;
 			process.stdout.write = () => {};
 
-			originalStdinSetRawMode = process.stdin.setRawMode;
-			process.stdin.setRawMode = () => {};
-			originalStdinResume = process.stdin.resume;
-			process.stdin.resume = () => {};
-			originalStdinPause = process.stdin.pause;
-			process.stdin.pause = () => {};
-			originalStdinOn = process.stdin.on;
-			process.stdin.on = () => {};
-			originalStdinRemoveListener = process.stdin.removeListener;
-			process.stdin.removeListener = () => {};
-
 			originalCliOperations = cliOperationsModule.cliOperations;
 			cliOperationsModule.cliOperations = async (req) => {
 				if (req.operation === 'create_authentication_tokens') {
@@ -143,11 +124,6 @@ describe('Login', () => {
 			process.cwd = originalCwd;
 			process.exit = originalExit;
 			process.stdout.write = originalStdoutWrite;
-			process.stdin.setRawMode = originalStdinSetRawMode;
-			process.stdin.resume = originalStdinResume;
-			process.stdin.pause = originalStdinPause;
-			process.stdin.on = originalStdinOn;
-			process.stdin.removeListener = originalStdinRemoveListener;
 			cliOperationsModule.cliOperations = originalCliOperations;
 			fs.rmSync(testDir, { recursive: true, force: true });
 		});
@@ -170,22 +146,9 @@ describe('Login', () => {
 			const envPath = path.join(testDir, '.env');
 			fs.writeFileSync(envPath, 'EXISTING_VAR=value'); // No trailing newline
 
-			// Set password in env to avoid readline/stdin issues
+			// Both targetArg and usernameArg are provided, password from env — inquirer is never called.
 			process.env.HARPER_CLI_PASSWORD = 'password';
-
-			// We need to mock readline.createInterface because login uses it
-			const readline = require('node:readline/promises');
-			const originalCreateInterface = readline.createInterface;
-			readline.createInterface = () => ({
-				question: async () => 'mockuser',
-				close: () => {},
-			});
-
-			try {
-				await login('example.com', 'mockuser');
-			} finally {
-				readline.createInterface = originalCreateInterface;
-			}
+			await login('example.com', 'mockuser');
 
 			const envContent = fs.readFileSync(envPath, 'utf8');
 			// The fix added `\nHARPER_CLI_TARGET=${resolvedTarget}\n`
@@ -198,19 +161,7 @@ describe('Login', () => {
 			fs.writeFileSync(envPath, 'EXISTING_VAR=value\n'); // Has trailing newline
 
 			process.env.HARPER_CLI_PASSWORD = 'password';
-
-			const readline = require('node:readline/promises');
-			const originalCreateInterface = readline.createInterface;
-			readline.createInterface = () => ({
-				question: async () => 'mockuser',
-				close: () => {},
-			});
-
-			try {
-				await login('example.com', 'mockuser');
-			} finally {
-				readline.createInterface = originalCreateInterface;
-			}
+			await login('example.com', 'mockuser');
 
 			const envContent = fs.readFileSync(envPath, 'utf8');
 			// It will result in `EXISTING_VAR=value\n\nHARPER_CLI_TARGET=https://example.com:9925/\n`


### PR DESCRIPTION
At some point, the implementation regressed (or it never worked?) for how it masks out password entry. This fixes all that by using inquirer, which I didn't notice we had the first time around. 🤦 

The bug this fixes when typing:
```
Cluster Password: w*o*w* *s*o* *s*e*c*u*r*e*
```

Or if you paste, it's even better:
```
Cluster Password: wow so secure*************
```

becomes:
```
Cluster Password: 
```
[aka, it's masked out consistently, just like we do during the harper install cli command]