### PR TITLE
Cap the typed-structure dictionary in RecordEncoder (maxOwnStructures)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
 				"ses": "^1.15.0",
 				"stream-chain": "2.2.5",
 				"stream-json": "1.9.1",
-				"structon": "^1.0.5",
+				"structon": "^1.0.6",
 				"systeminformation": "^5.31.4",
 				"tar-fs": "^3.1.2",
 				"ulidx": "0.5.0",
@@ -14859,9 +14859,9 @@
 			"license": "MIT"
 		},
 		"node_modules/structon": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/structon/-/structon-1.0.5.tgz",
-			"integrity": "sha512-ncBlQTTO0Xjlsg4HanW77ROfoqKqhYg4CuKqKk0r/eJP69Ax7ysenZYO1Mx7Wt/Pga54qVN4M1c7OLvrz/hT7g==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/structon/-/structon-1.0.6.tgz",
+			"integrity": "sha512-ulbz1oTo92EXGPp77nZjA0vXlPvaBFDUd2Ch6hfELKxYlmPM8OsjwzASizyxFIpTk1kQ5fVoQ33whvTf+aaDFQ==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
 				"msgpackr": ">=2.0.1"

--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
 		"ses": "^1.15.0",
 		"stream-chain": "2.2.5",
 		"stream-json": "1.9.1",
-		"structon": "^1.0.5",
+		"structon": "^1.0.6",
 		"systeminformation": "^5.31.4",
 		"tar-fs": "^3.1.2",
 		"ulidx": "0.5.0",

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -96,6 +96,10 @@ export class RecordEncoder extends StructonEncoder {
 	name: string;
 	constructor(options) {
 		options.useBigIntExtension = true;
+		// Bound the per-encoder typed-structure dictionary. It is append-only and pinned on the
+		// long-lived primary store, so a wide/sparse schema (whose records vary by per-field value
+		// width) can grow it unbounded and exhaust memory. Caller-overridable; default caps it.
+		options.maxOwnStructures ??= 256;
 		/**
 		 * The base class for records that provides the read-only methods for accessing
 		 * metadata and will be assigned computed property getters. On its own, these instances


### PR DESCRIPTION
## Summary

Defaults `maxOwnStructures` to 256 in `RecordEncoder` and bumps `structon` to `^1.0.6` (which adds the cap). Bounds the per-encoder typed-structure dictionary that was growing unbounded and OOM-ing under shape-heterogeneous data.

## Purpose

structon's random-access typed-struct dictionary (`typedStructs` + transition trie) is append-only and pinned on the long-lived primary-store encoder/decoder. The encoder branches per field on the *value's* numeric width (num8/num32/num64, float32/float64) and string kind, so a wide/sparse schema (~hundreds of distinct key-sets) explodes into tens of thousands of structures — and per-table-per-peer dictionaries, multiplied across worker isolates, OOM-crash-looped a production cluster during replication catch-up of a bulk-loaded table.

`structon@1.0.6` adds an opt-in `maxOwnStructures` cap (uncapped by default; see HarperFast/structon#4). This wires it on: once the cap is hit, novel shapes fall back to plain msgpack encoding; the read path is untouched so existing/persisted structs stay decodable. 256 is caller-overridable (a table/DBI option can raise it).

## Where to look

- One-line change in `resources/RecordEncoder.ts` (`options.maxOwnStructures ??= 256` before `super(options)`), plus the `structon` dep bump. RecordEncoder extends structon's `createStructon(Encoder)`.

## Validation

- Builds clean (tsc); `unitTests/resources` suite passes (687 passing, 0 failing). The cap logic itself is covered by structon's 94-test suite (structon#4), which exercises exactly this `createStructon(msgpackr-v2)` + `maxOwnStructures` usage. Change is a one-line option default, so no dedicated harper unit test added (RecordEncoder isn't standalone-instantiable; the behavior is upstream-tested).
- **Companion**: the deployed 5.0.x line (msgpackr v1, no structon) gets the equivalent change on the `v5.0` branch + msgpackr `1.11.13`.

🤖 Generated by Claude (Opus 4.7).