### PR TITLE
Cap the typed-structure dictionary in RecordEncoder (v5.0, maxOwnStructures)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
 				"minimist": "1.2.8",
 				"moment": "2.30.1",
 				"mqtt-packet": "~9.0.1",
-				"msgpackr": "1.11.12",
+				"msgpackr": "1.11.13",
 				"needle": "3.5.0",
 				"node-forge": "^1.3.1",
 				"node-stream-zip": "1.15.0",
@@ -8249,9 +8249,9 @@
 			"license": "MIT"
 		},
 		"node_modules/msgpackr": {
-			"version": "1.11.12",
-			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.12.tgz",
-			"integrity": "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==",
+			"version": "1.11.13",
+			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.13.tgz",
+			"integrity": "sha512-pWaxg0k1iiNdkAayUQ7Zlz/vYNfVefUttmHxqFcQjjtyqFa3w4x5rginOEzy/GvbWhBDD9K65/ZXyq8qz8utaQ==",
 			"license": "MIT",
 			"optionalDependencies": {
 				"msgpackr-extract": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
 		"minimist": "1.2.8",
 		"moment": "2.30.1",
 		"mqtt-packet": "~9.0.1",
-		"msgpackr": "1.11.12",
+		"msgpackr": "1.11.13",
 		"needle": "3.5.0",
 		"node-forge": "^1.3.1",
 		"node-stream-zip": "1.15.0",

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -86,6 +86,10 @@ export class RecordEncoder extends Encoder {
 	name: string;
 	constructor(options) {
 		options.useBigIntExtension = true;
+		// Bound the per-encoder typed-structure dictionary. It is append-only and pinned on the
+		// long-lived primary store, so a wide/sparse schema (whose records vary by per-field value
+		// width) can grow it unbounded and exhaust memory. Caller-overridable; default caps it.
+		options.maxOwnStructures ??= 256;
 		/**
 		 * The base class for records that provides the read-only methods for accessing
 		 * metadata and will be assigned computed property getters. On its own, these instances


### PR DESCRIPTION
## Summary

v5.0 backport: defaults `maxOwnStructures` to 256 in `RecordEncoder` and bumps `msgpackr` to `1.11.13` (which adds the typed-struct cap). This is the **deployed-line fix** for the unbounded typed-structure dictionary that OOM-crash-looped a production cluster.

## Purpose

msgpackr's random-access typed-struct dictionary (`typedStructs` + transition trie) is append-only and pinned on the long-lived primary-store encoder/decoder, and branches per field on the value's numeric width / string kind — so a wide/sparse schema explodes into tens of thousands of structures and grows unbounded (per-table-per-peer dictionaries × worker isolates), OOM-ing under replication catch-up of a bulk-loaded table.

`msgpackr@1.11.13` adds an opt-in `maxOwnStructures` cap to the typed-struct path (uncapped by default; the classic shared-record cap is unchanged — see kriszyp/msgpackr#185). This wires it on at 256 (caller-overridable). Once hit, novel shapes fall back to plain msgpack; the read path is untouched so existing/persisted structs stay decodable. Mirrors the main-branch change (#1145, which uses structon for the v5.1 line).

## Where to look

- One-line change in `resources/RecordEncoder.ts` (`options.maxOwnStructures ??= 256` before `super(options)`) + the `msgpackr` patch bump.

## Validation

- Source formatted + lint-clean (oxlint). **Local build/test were not run for v5.0** (its msgpackr-v1 + v5.0-pinned native deps can't share the main checkout's env) — relying on CI here. The change is identical in spirit to #1145, which built clean + passed the resources unit suite (687 passing). The cap logic is covered by msgpackr 1.11.13's 121-test suite (kriszyp/msgpackr#185), which exercises exactly `new Packr({ randomAccessStructure: true, maxOwnStructures: N })`.
- ⚠️ Reviewer: please confirm CI build/test is green before merge, since I leaned on it for local validation.

🤖 Generated by Claude (Opus 4.7).