### PR TITLE
fix(table): reliably skip a re-delivered out-of-order commutative op (#1137)

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1891,8 +1891,7 @@ export function makeTable(options) {
 								// retained window are not layered in — but the authoritative full-copy record restores exact
 								// convergence. Because we stopped before reaching txnTime, the inline duplicate detection in
 								// the walk never ran; full-copy audit-replay re-delivers writes, and re-applying one would
-								// double-apply its commutative ops, so rule that out here with a single O(1) lookup at txnTime
-								// (RocksDB audit logs are keyed by version, and the cap is RocksDB-only).
+								// double-apply its commutative ops, so rule that out here before folding.
 								logger.warn?.(
 									'Out-of-order audit reconciliation exceeded depth cap; reconciling against most recent updates only',
 									{
@@ -1901,16 +1900,24 @@ export function makeTable(options) {
 										depth: walkSteps,
 									}
 								);
-								const duplicate = auditStore.get(txnTime, tableId, id, options?.nodeId);
-								if (
-									duplicate &&
-									duplicate.version === txnTime &&
-									precedesExistingVersion(
-										txnTime,
-										{ version: txnTime, localTime: txnTime, key: id, nodeId: duplicate.nodeId },
-										options?.nodeId
-									) === 0
-								) {
+								// Detect a re-delivered duplicate via the record's own additionalAuditRefs rather than an
+								// audit-log lookup at txnTime. Every out-of-order write folded into this record records its
+								// {version, nodeId} ref (added in the walk above, RocksDB-only — the same condition as this
+								// cap), and the record is read with read-your-writes consistency. The transaction-log query
+								// that a keyed audit lookup would use can lag a back-to-back re-delivery — the just-committed
+								// entry is not yet visible — which silently double-applied the commutative op (#1137).
+								// precedesExistingVersion(...) === 0 is the identity tie: same version AND same node (the
+								// local node is id 0, so an undefined options?.nodeId resolves to the same 0 the ref stored).
+								const alreadyApplied = existingEntry?.additionalAuditRefs?.some(
+									(ref) =>
+										ref.version === txnTime &&
+										precedesExistingVersion(
+											txnTime,
+											{ version: txnTime, localTime: txnTime, key: id, nodeId: ref.nodeId },
+											options?.nodeId
+										) === 0
+								);
+								if (alreadyApplied) {
 									write.skipped = true;
 									return; // duplicate write already applied
 								}

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1760,6 +1760,32 @@ export function makeTable(options) {
 						// of the updates to the record to ensure consistency across the cluster
 						// TODO: can the previous version be older, but even more previous version be newer?
 						if (audit) {
+							// A re-delivered out-of-order write (full-copy audit-replay re-delivers writes) must not have
+							// its commutative ops re-folded. additionalAuditRefs is the record's own list of folded
+							// out-of-order versions, read with read-your-writes consistency, so this skips the duplicate up
+							// front — before the audit-log walk below, which can miss it: the walk stops at the depth cap, or
+							// breaks early on a not-yet-visible audit entry, before reaching txnTime, and the keyed
+							// transaction-log lookup it would otherwise use can lag a back-to-back re-delivery (that lag
+							// silently double-applied the increment — #1137). This covers the re-delivery while the ref is
+							// still on the record; a later in-order write rewrites the record and drops the ref (it survives
+							// only as previousAdditionalAuditRefs on the audit log), so that case falls back to the
+							// best-effort keyed lookup in the capped block below — see #1148. precedesExistingVersion(...)
+							// === 0 is the identity tie: same version AND same node (the local node is id 0, so an undefined
+							// options?.nodeId resolves to the same 0 the ref stored).
+							if (
+								existingEntry.additionalAuditRefs?.some(
+									(ref) =>
+										ref.version === txnTime &&
+										precedesExistingVersion(
+											txnTime,
+											{ version: txnTime, localTime: txnTime, key: id, nodeId: ref.nodeId },
+											options?.nodeId
+										) === 0
+								)
+							) {
+								write.skipped = true;
+								return; // out-of-order write already folded into this record
+							}
 							// incremental CRDT updates are only available with audit logging on
 							let localTime = existingEntry.localTime;
 							let auditedVersion = existingEntry.version;
@@ -1891,7 +1917,12 @@ export function makeTable(options) {
 								// retained window are not layered in — but the authoritative full-copy record restores exact
 								// convergence. Because we stopped before reaching txnTime, the inline duplicate detection in
 								// the walk never ran; full-copy audit-replay re-delivers writes, and re-applying one would
-								// double-apply its commutative ops, so rule that out here before folding.
+								// double-apply its commutative ops. A re-delivered out-of-order write is already ruled out by
+								// the additionalAuditRefs check at the top of this block; this keyed lookup is the best-effort
+								// guard for the remaining case — a re-delivered write that was originally in-order (so it left
+								// no ref) and is now deeper than the cap. It is best-effort because the transaction-log lookup
+								// can intermittently miss an entry under load (tracked separately); the authoritative full-copy
+								// record still restores exact convergence.
 								logger.warn?.(
 									'Out-of-order audit reconciliation exceeded depth cap; reconciling against most recent updates only',
 									{
@@ -1900,24 +1931,16 @@ export function makeTable(options) {
 										depth: walkSteps,
 									}
 								);
-								// Detect a re-delivered duplicate via the record's own additionalAuditRefs rather than an
-								// audit-log lookup at txnTime. Every out-of-order write folded into this record records its
-								// {version, nodeId} ref (added in the walk above, RocksDB-only — the same condition as this
-								// cap), and the record is read with read-your-writes consistency. The transaction-log query
-								// that a keyed audit lookup would use can lag a back-to-back re-delivery — the just-committed
-								// entry is not yet visible — which silently double-applied the commutative op (#1137).
-								// precedesExistingVersion(...) === 0 is the identity tie: same version AND same node (the
-								// local node is id 0, so an undefined options?.nodeId resolves to the same 0 the ref stored).
-								const alreadyApplied = existingEntry?.additionalAuditRefs?.some(
-									(ref) =>
-										ref.version === txnTime &&
-										precedesExistingVersion(
-											txnTime,
-											{ version: txnTime, localTime: txnTime, key: id, nodeId: ref.nodeId },
-											options?.nodeId
-										) === 0
-								);
-								if (alreadyApplied) {
+								const duplicate = auditStore.get(txnTime, tableId, id, options?.nodeId);
+								if (
+									duplicate &&
+									duplicate.version === txnTime &&
+									precedesExistingVersion(
+										txnTime,
+										{ version: txnTime, localTime: txnTime, key: id, nodeId: duplicate.nodeId },
+										options?.nodeId
+									) === 0
+								) {
 									write.skipped = true;
 									return; // duplicate write already applied
 								}


### PR DESCRIPTION
## Summary

Fixes #1137. A re-delivered write could have its commutative ops folded in **twice** during the out-of-order audit reconciliation in `commit()` — surfacing as the red unit test `does not double-apply a re-delivered commutative op in the bounded path (#1114)` (count `3` → `6`).

## Root cause

Out-of-order duplicate detection relied on the audit-log walk reaching the re-delivered write's audit record (or, past the #1114 depth cap, a keyed `auditStore.get(txnTime)` lookup). Both are unreliable under load:
- the walk **stops before reaching `txnTime`** — at the depth cap, or by breaking early on a transaction-log entry that isn't visible yet — so the inline duplicate check never runs;
- the keyed `auditStore.get(txnTime)` fallback can **lag a back-to-back re-delivery** (the just-committed entry isn't visible yet).

Result: the re-delivered increment is applied a second time. Timing-sensitive — green in isolation, red under load, and masked by any added latency (a Heisenbug).

## Fix

Add an up-front duplicate check against the record's own `additionalAuditRefs` (its list of already-folded out-of-order versions), read with **read-your-writes** consistency, at the top of the out-of-order block — *before* the walk. A re-delivered out-of-order write is skipped reliably, independent of the cap, an early walk break, or transaction-log read lag.

The capped-path keyed `auditStore.get(txnTime)` lookup is **retained unchanged** as the best-effort guard for the remaining case — a re-delivered write that was originally *in-order* (so it left no ref) and is now deeper than the cap.

Verified by @kriszyp via a local-link loop (this branch against stock rocksdb-js 1.4.2): the #1137 double-apply went from ~8–17% on `main` to **0/31** on this branch.

## Residual case + complementary hardening

The early check covers a re-delivery only while the ref is still on the record. A later in-order write rewrites the record and drops `additionalAuditRefs` (kept only as `previousAdditionalAuditRefs` on the audit log), so that re-delivery — and the originally-in-order deep case — fall back to the capped-path keyed lookup, which shares a transaction-log point-read unreliability (filed as #1148). **rocksdb-js#637** (being cherry-picked to 1.4.x) makes that point lookup reliable, so #637 + this PR cover the residual together, with the full-copy backstop underneath. (#637 is complementary hardening, not a replacement — it does not fix #1137 on its own; this PR is the harper-side fix.) This PR does not regress the residual cases — same fallback as before — and makes the common back-to-back re-delivery reliable.

## Testing

- The previously-failing regression test is now green **25/25** full-file loops (was deterministically red under load); independently corroborated by @kriszyp at 0/31.
- Full `npm run test:unit:resources` passes except one **unrelated, pre-existing** failure (`auditLog.test.js:502`, tracked in #1141).
- The non-duplicate depth-cap reconcile path (`bounds the out-of-order audit-chain walk … (#1114)`) still passes — no regression.
- `lint:required` + `format:write` clean.

## Cross-model review

- **Codex** (2 rounds): first flagged that replacing the keyed lookup with refs dropped main-chain duplicate coverage (P1) — addressed by moving to the up-front check **and** retaining the keyed lookup. Second round flagged the cleared-ref edge (P2) — the residual covered above.
- **Gemini** (bot + local leg): suggested replacing `precedesExistingVersion(...) === 0` with a direct node-id comparison. Keeping `precedesExistingVersion` — the `&& ref.version === txnTime` guard short-circuits, so it only runs on an exact version match (never per-ref on normal writes), it's the canonical comparison in `commit()`, and it preserves exact tie semantics (the direct form diverges when `getThisNodeId()` is undefined).
- **Harper domain pass:** no blockers; LMDB unaffected (the cap is RocksDB-gated).

## Commits

1. Initial fix (replace keyed lookup with `additionalAuditRefs`).
2. Rework per the Codex review — move the `additionalAuditRefs` check up front and retain the keyed lookup as the best-effort main-chain guard.

## CI note

The red **Integration Tests** check(s) are **flaky/pre-existing on `main`**, not introduced here — the failing shard varies run-to-run (upgrade-fixture server-startup fatals on one run; CSV data-load / Northwind / role-testing timeouts on another), and `main`'s own Integration Tests workflow is red independently. The **Unit Test** workflow — the relevant gate for #1137 — passes on all three runtimes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
