### PR TITLE
Report a non-committed shared-structure save as not-saved

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -246,12 +246,18 @@ export class RecordEncoder extends StructonEncoder {
 							return false;
 						}
 						txn.putSync(sharedStructuresKey, structures);
-						this.structureUpdate = structures;
 						return true;
 					},
 					{ retryOnBusy: true }
 				);
-				return committed === true ? true : false;
+				// Only record the structure update once the txn has actually committed. Setting it
+				// inside the callback would leave it dangling on an aborted txn and could flag a
+				// HAS_STRUCTURE_UPDATE in the audit log for a structure that was never persisted.
+				if (committed === true) {
+					this.structureUpdate = structures;
+					return true;
+				}
+				return false;
 			} else {
 				const result = superSaveStructures.call(this, structures, isCompatible);
 				this.structureUpdate = structures;

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -222,7 +222,18 @@ export class RecordEncoder extends StructonEncoder {
 		const superGetStructures = this.getStructures;
 		this.saveStructures = function (structures, isCompatible): boolean | undefined {
 			if (this.isRocksDB) {
-				return this.rootStore.transactionSync(
+				// transactionSync returns the callback's value on commit, but returns `undefined`
+				// when the txn was aborted (it swallows ERR_ALREADY_ABORTED). The success path here
+				// returns an explicit `true`; anything else means the shared structures were NOT
+				// durably committed (a CAS conflict → `false`, or a swallowed abort → `undefined`).
+				//
+				// We must report a non-commit as `false` (not the buggy `undefined`, which msgpackr
+				// reads as success and then writes a record referencing a structure that was never
+				// saved → later "Record id is not defined" on decode). Returning `false` makes msgpackr
+				// re-pack; paired with the msgpackr fix that marks structures uninitialized on
+				// save-failure, the re-pack reloads the durable structures, rebuilds the transition
+				// trie, re-mints, and re-saves — so the record always references a persisted structure.
+				const committed = this.rootStore.transactionSync(
 					(txn) => {
 						const sharedStructuresKey = [Symbol.for('structures'), this.name];
 						const existingStructuresBuffer = txn.getBinarySync(sharedStructuresKey);
@@ -236,9 +247,11 @@ export class RecordEncoder extends StructonEncoder {
 						}
 						txn.putSync(sharedStructuresKey, structures);
 						this.structureUpdate = structures;
+						return true;
 					},
 					{ retryOnBusy: true }
 				);
+				return committed === true ? true : false;
 			} else {
 				const result = superSaveStructures.call(this, structures, isCompatible);
 				this.structureUpdate = structures;


### PR DESCRIPTION
## Summary

`RecordEncoder.saveStructures` (RocksDB path) wraps `rootStore.transactionSync`, which returns `undefined` when the structure-save txn was aborted (`ERR_ALREADY_ABORTED` is swallowed) — and the success path also fell through to `undefined`. msgpackr only re-packs on a `=== false` return, so a swallowed abort looked like success: the already-encoded record (referencing the new structure id) was written even though the structure was never persisted → later **`Record id is not defined for N`** on decode (the dominant CDI rt-dev error, ~1991/10min, on local reads).

This returns `true` only on a committed save and `false` otherwise (CAS conflict or aborted txn).

## Why this is the real fix for the desync

A concurrent-writer harness showed msgpackr's CAS coordination is sound; the bug is in the RocksDB save reporting. The existing `retryOnBusy: true` is necessary-but-insufficient (it caps at 3 busy retries, then throws; and the abort path returns `undefined`, never re-packing).

## Pairing (must land together)

This is **half** the fix and depends on **[kriszyp/msgpackr#186](https://github.com/kriszyp/msgpackr/pull/186)**: returning `false` alone doesn't recover, because msgpackr's re-pack reused the cached transition and re-emitted the same unpersisted-structure record. #186 marks structures uninitialized on save-failure so the re-pack reloads durable structures, rebuilds the trie, and re-mints + re-saves. **Blocked on msgpackr 1.11.14 publish + dep bump.**

Verified end-to-end (repro `~/dev/scripts/savestructures-abort-repro.cjs`): with both fixes, a declined/aborted save → re-pack → reload + re-mint + re-save → no dangling record.

## Note

Independent of the typed-structs default ([#1152](https://github.com/HarperFast/harper/pull/1152)) — this is the **classic** shared-structure path, so it's needed regardless. Should cherry-pick to `v5.0` (the deployed line where the error occurs).

🤖 Generated by Claude (Opus 4.7).