### PR TITLE
fix(ci): clean stale Harper data dir before integration test run

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -112,6 +112,7 @@ jobs:
           THREADS_DEBUG: false
           NODE_HOSTNAME: 'localhost'
         run: |
+          rm -rf /tmp/hdb
           mkdir -p /tmp/hdb/log
           node ./dist/bin/harper.js install > /tmp/hdb/log/install-stdout.log 2> /tmp/hdb/log/install-stderr.log
           node ./dist/bin/harper.js start > /tmp/hdb/log/start-stdout.log 2> /tmp/hdb/log/start-stderr.log &
@@ -173,6 +174,7 @@ jobs:
           THREADS_DEBUG: false
           NODE_HOSTNAME: 'localhost'
         run: |
+          rm -rf /tmp/hdb
           mkdir -p /tmp/hdb/log
           node ./dist/bin/harper.js install > /tmp/hdb/log/install-stdout.log 2> /tmp/hdb/log/install-stderr.log
           sleep 10


### PR DESCRIPTION
## Summary

On reused GitHub Actions Linux runners, `/tmp/hdb` can persist from a prior workflow run carrying Harper data from an older version. When the next run calls `harper.js install`, `checkIfInstallIsSupported` detects the old data and fatally aborts:

```
Error: You are attempting to upgrade from an old instance of HarperDB that is no longer supported.
```

This causes all Linux API-test shards to fail across every Node.js version on any stale runner.

## Fix

Added `rm -rf /tmp/hdb` immediately before `mkdir -p /tmp/hdb/log` in both Linux Setup-Harper steps:
- `run-integration-apiTests` (Node.js matrix)
- `run-integration-apiTests-bun` (Bun, currently `if: false` but patched for consistency)

The Windows sections are unchanged — they use `${{ runner.temp }}/hdb` which is fresh per run by design.

---
*Generated by Claude Sonnet 4.6*