### PR TITLE
fix(downgrade): store is_hash_attribute in __dbis__ for harperdb@4.x compat

### DIFF
--- a/integrationTests/upgrade/4.x-upgrade.test.ts
+++ b/integrationTests/upgrade/4.x-upgrade.test.ts
@@ -105,19 +105,7 @@ suite(
 			ok(response.length > 10);
 		});
 
-		test(
-			'downgrade and start',
-			{
-				// The 5.1.0 upgrade directive adds the hdb_deployment table as a named DBI within
-				// schema/system.mdb (the shared LMDB env used by both harper@5 in legacy mode and
-				// harperdb@4). harperdb@4's initStores iterates __dbis__ alphabetically and fails
-				// when it encounters hdb_deployment (which precedes hdb_info alphabetically), so
-				// databases.system.hdb_info is never populated and checkIfInstallIsSupported throws.
-				// Downgrade from harper 5.1.x back to harperdb 4.x is therefore not supported after
-				// an upgrade that runs the 5.1.0 directive.
-				skip: 'downgrade from harper 5.1.x to harperdb 4.x is not supported after 5.1.0 upgrade directive runs (hdb_deployment DBI incompatible with harperdb@4)',
-			},
-			async () => {
+		test('downgrade and start', async () => {
 				// can we downgrade?
 				await killHarper(ctx); // kill 5.x harper
 				await startHarper(ctx, {

--- a/integrationTests/upgrade/4.x-upgrade.test.ts
+++ b/integrationTests/upgrade/4.x-upgrade.test.ts
@@ -105,29 +105,42 @@ suite(
 			ok(response.length > 10);
 		});
 
-		test('downgrade and start', async () => {
-			// can we downgrade?
-			await killHarper(ctx); // kill 5.x harper
-			await startHarper(ctx, {
-				config: {},
-				env: {
-					CONFIRM_DOWNGRADE: 'yes',
-				},
-				harperBinPath: join(legacyPath, 'bin', 'harperdb.js'),
-			}); // start on 4.x again
-			let response = await sendOperation(ctx.harper, {
-				operation: 'search_by_conditions',
-				table: 'test',
-				conditions: [{ attribute: 'id', comparator: 'greater_than', value: 'id-4' }],
-			});
-			ok(response.length > 4);
-			response = await sendOperation(ctx.harper, {
-				operation: 'read_audit_log',
-				schema: 'data',
-				table: 'test',
-			});
-			ok(response.length > 10);
-		});
+		test(
+			'downgrade and start',
+			{
+				// The 5.1.0 upgrade directive adds the hdb_deployment table as a named DBI within
+				// schema/system.mdb (the shared LMDB env used by both harper@5 in legacy mode and
+				// harperdb@4). harperdb@4's initStores iterates __dbis__ alphabetically and fails
+				// when it encounters hdb_deployment (which precedes hdb_info alphabetically), so
+				// databases.system.hdb_info is never populated and checkIfInstallIsSupported throws.
+				// Downgrade from harper 5.1.x back to harperdb 4.x is therefore not supported after
+				// an upgrade that runs the 5.1.0 directive.
+				skip: 'downgrade from harper 5.1.x to harperdb 4.x is not supported after 5.1.0 upgrade directive runs (hdb_deployment DBI incompatible with harperdb@4)',
+			},
+			async () => {
+				// can we downgrade?
+				await killHarper(ctx); // kill 5.x harper
+				await startHarper(ctx, {
+					config: {},
+					env: {
+						CONFIRM_DOWNGRADE: 'yes',
+					},
+					harperBinPath: join(legacyPath, 'bin', 'harperdb.js'),
+				}); // start on 4.x again
+				let response = await sendOperation(ctx.harper, {
+					operation: 'search_by_conditions',
+					table: 'test',
+					conditions: [{ attribute: 'id', comparator: 'greater_than', value: 'id-4' }],
+				});
+				ok(response.length > 4);
+				response = await sendOperation(ctx.harper, {
+					operation: 'read_audit_log',
+					schema: 'data',
+					table: 'test',
+				});
+				ok(response.length > 10);
+			}
+		);
 
 		test('upgrade and migrate LMDB to RocksDB', async () => {
 			await killHarper(ctx);

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -970,6 +970,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 		primaryKeyAttribute = attributes.find((attribute) => attribute.isPrimaryKey) || {};
 		primaryKey = primaryKeyAttribute.name;
 		primaryKeyAttribute.isPrimaryKey = true;
+		primaryKeyAttribute.is_hash_attribute = true; // backward-compat: harperdb@4.x reads this field to open the DBI with correct flags
 		primaryKeyAttribute.schemaDefined = schemaDefined;
 		// can't change compression after the fact (except threshold), so save only when we create the table
 		primaryKeyAttribute.compression = getDefaultCompression();

--- a/upgrade/directives/5-1-0.ts
+++ b/upgrade/directives/5-1-0.ts
@@ -26,6 +26,11 @@ const DEPLOYMENT_TABLE = terms.SYSTEM_TABLE_NAMES.DEPLOYMENT_TABLE_NAME;
 async function createHdbDeploymentIfMissing() {
 	if (databases.system?.[DEPLOYMENT_TABLE]) {
 		hdbLogger.info(`system.${DEPLOYMENT_TABLE} already exists; skipping create.`);
+		// Still run the patch — installs that created hdb_deployment before the is_hash_attribute
+		// fix was introduced have an __dbis__ entry without that field. harperdb@4.x uses
+		// is_hash_attribute to determine LMDB DBI open flags; without it the DBI is opened with
+		// wrong flags (DUPSORT set) and LMDB throws MDB_INCOMPATIBLE, breaking downgrade.
+		await patchHdbDeploymentIsHashAttribute();
 		return;
 	}
 
@@ -46,6 +51,31 @@ async function createHdbDeploymentIfMissing() {
 	createTable.audit = true;
 
 	await bridge.createTable(DEPLOYMENT_TABLE, createTable);
+}
+
+/**
+ * Patch the hdb_deployment __dbis__ primary-key entry to include is_hash_attribute: true.
+ *
+ * harperdb@4.x reads is_hash_attribute from __dbis__ to derive the LMDB DBI open flags
+ * (DBIDefinition(dup_sort, is_hash_attribute)). If the field is absent it opens the DBI
+ * with dup_sort=true / useVersions=false — the opposite of how harper@5 created it — which
+ * causes LMDB to throw MDB_INCOMPATIBLE and prevents harperdb@4 from starting after a
+ * 5.1.x downgrade.
+ *
+ * This is safe to call when the table already exists: it is a no-op if is_hash_attribute is
+ * already set, and writing it back is idempotent (lmdb upsert).
+ */
+async function patchHdbDeploymentIsHashAttribute() {
+	const systemTable = (databases as any).system?.[DEPLOYMENT_TABLE];
+	if (!systemTable?.dbisDB) return;
+
+	const dbiName = `${DEPLOYMENT_TABLE}/`;
+	const primaryAttr = systemTable.dbisDB.getSync(dbiName);
+	if (!primaryAttr || primaryAttr.is_hash_attribute) return; // already correct
+
+	primaryAttr.is_hash_attribute = true;
+	await systemTable.dbisDB.put(dbiName, primaryAttr);
+	hdbLogger.info(`Patched system.${DEPLOYMENT_TABLE} __dbis__ entry with is_hash_attribute=true for harperdb@4.x downgrade compatibility.`);
 }
 
 const directive510 = {


### PR DESCRIPTION
## Root cause

harperdb@4.7.x uses `is_hash_attribute` from the `__dbis__` primary-key entry to compute LMDB DBI open flags:

```js
new DBIDefinition(!attr.is_hash_attribute, attr.is_hash_attribute)
// → {dup_sort: !is_hash_attribute, useVersions: is_hash_attribute}
```

harper@5 only stored `isPrimaryKey: true`, so harperdb@4 opened `hdb_deployment` with `dup_sort=true / useVersions=false` instead of the `dup_sort=false / useVersions=true` it was created with. LMDB throws `MDB_INCOMPATIBLE`. This propagates up through `initStores` before `hdb_info` is loaded, so `checkIfInstallIsSupported` fatals with "You are attempting to upgrade from an old instance."

## Fix

Three changes:

1. **`resources/databases.ts`** — set `is_hash_attribute = true` alongside `isPrimaryKey` when writing the primary-key attribute to `__dbis__`. All new tables (including those created by the 5.1.0 directive going forward) will carry the backward-compat field.

2. **`upgrade/directives/5-1-0.ts`** — add `patchHdbDeploymentIsHashAttribute()` that updates the existing `__dbis__` entry for installs that created `hdb_deployment` before this fix landed. Called every time the directive runs (idempotent: no-op if already correct).

3. **`integrationTests/upgrade/4.x-upgrade.test.ts`** — re-enable the `downgrade and start` subtest (previously skipped in 5e16d00).

## Test plan

- [ ] CI passes on `upgrade` shard (4.x-upgrade test suite: upgrade→downgrade→re-upgrade→migrate all pass)
- [ ] Verify harperdb@4 starts cleanly after a 5.1.x upgrade on a local data dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)