### PR TITLE
Report a non-committed shared-structure save as not-saved (v5.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
 				"minimist": "1.2.8",
 				"moment": "2.30.1",
 				"mqtt-packet": "~9.0.1",
-				"msgpackr": "1.11.13",
+				"msgpackr": "1.11.14",
 				"needle": "3.5.0",
 				"node-forge": "^1.3.1",
 				"node-stream-zip": "1.15.0",
@@ -8249,9 +8249,9 @@
 			"license": "MIT"
 		},
 		"node_modules/msgpackr": {
-			"version": "1.11.13",
-			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.13.tgz",
-			"integrity": "sha512-pWaxg0k1iiNdkAayUQ7Zlz/vYNfVefUttmHxqFcQjjtyqFa3w4x5rginOEzy/GvbWhBDD9K65/ZXyq8qz8utaQ==",
+			"version": "1.11.14",
+			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.14.tgz",
+			"integrity": "sha512-suPZQcjFtPGp0cksn70ICfLuxsO9F2/sRrbJzeNepojZ+OPwGzA0lNdLyU4SJUKAd5ZgvUWWPojzzdlVuOYcrQ==",
 			"license": "MIT",
 			"optionalDependencies": {
 				"msgpackr-extract": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
 		"minimist": "1.2.8",
 		"moment": "2.30.1",
 		"mqtt-packet": "~9.0.1",
-		"msgpackr": "1.11.13",
+		"msgpackr": "1.11.14",
 		"needle": "3.5.0",
 		"node-forge": "^1.3.1",
 		"node-stream-zip": "1.15.0",

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -230,12 +230,18 @@ export class RecordEncoder extends Encoder {
 							return false;
 						}
 						txn.putSync(sharedStructuresKey, structures);
-						this.structureUpdate = structures;
 						return true;
 					},
 					{ retryOnBusy: true }
 				);
-				return committed === true ? true : false;
+				// Only record the structure update once the txn has actually committed. Setting it
+				// inside the callback would leave it dangling on an aborted txn and could flag a
+				// HAS_STRUCTURE_UPDATE in the audit log for a structure that was never persisted.
+				if (committed === true) {
+					this.structureUpdate = structures;
+					return true;
+				}
+				return false;
 			} else {
 				const result = superSaveStructures.call(this, structures, isCompatible);
 				this.structureUpdate = structures;

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -206,7 +206,18 @@ export class RecordEncoder extends Encoder {
 		const superGetStructures = this.getStructures;
 		this.saveStructures = function (structures, isCompatible): boolean | undefined {
 			if (this.isRocksDB) {
-				return this.rootStore.transactionSync(
+				// transactionSync returns the callback's value on commit, but returns `undefined`
+				// when the txn was aborted (it swallows ERR_ALREADY_ABORTED). The success path here
+				// returns an explicit `true`; anything else means the shared structures were NOT
+				// durably committed (a CAS conflict → `false`, or a swallowed abort → `undefined`).
+				//
+				// We must report a non-commit as `false` (not the buggy `undefined`, which msgpackr
+				// reads as success and then writes a record referencing a structure that was never
+				// saved → later "Record id is not defined" on decode). Returning `false` makes msgpackr
+				// re-pack; paired with msgpackr 1.11.14's structures-rebuild-on-save-failure fix, the
+				// re-pack reloads the durable structures, rebuilds the transition trie, re-mints, and
+				// re-saves — so the record always references a persisted structure.
+				const committed = this.rootStore.transactionSync(
 					(txn) => {
 						const sharedStructuresKey = [Symbol.for('structures'), this.name];
 						const existingStructuresBuffer = txn.getBinarySync(sharedStructuresKey);
@@ -220,9 +231,11 @@ export class RecordEncoder extends Encoder {
 						}
 						txn.putSync(sharedStructuresKey, structures);
 						this.structureUpdate = structures;
+						return true;
 					},
 					{ retryOnBusy: true }
 				);
+				return committed === true ? true : false;
 			} else {
 				const result = superSaveStructures.call(this, structures, isCompatible);
 				this.structureUpdate = structures;

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -134,15 +134,9 @@ function openRocksDatabase(path: string, options: RocksDatabaseOptions & { dupSo
 	const writeBufferManagerAllowStall = envGet(CONFIG_PARAMS.STORAGE_ROCKS_WRITEBUFFERMANAGERALLOWSTALL);
 	RocksDatabase.config({
 		blockCacheSize,
-		...(typeof writeBufferManagerSize === 'number' && writeBufferManagerSize > 0
-			? { writeBufferManagerSize }
-			: {}),
-		...(typeof writeBufferManagerCostToCache === 'boolean'
-			? { writeBufferManagerCostToCache }
-			: {}),
-		...(typeof writeBufferManagerAllowStall === 'boolean'
-			? { writeBufferManagerAllowStall }
-			: {}),
+		...(typeof writeBufferManagerSize === 'number' && writeBufferManagerSize > 0 ? { writeBufferManagerSize } : {}),
+		...(typeof writeBufferManagerCostToCache === 'boolean' ? { writeBufferManagerCostToCache } : {}),
+		...(typeof writeBufferManagerAllowStall === 'boolean' ? { writeBufferManagerAllowStall } : {}),
 	});
 	if (!existsSync(path)) {
 		mkdirSync(path, { recursive: true });


### PR DESCRIPTION
## Summary

v5.0 backport of the `Record id is not defined for N` desync fix (main: [#1154](https://github.com/HarperFast/harper/pull/1154)). This is the **deployed line** where the error fires on CDI rt-dev.

`RecordEncoder.saveStructures` returned `undefined` when the structure-save txn aborted (`ERR_ALREADY_ABORTED` swallowed by `transactionSync`) — and the success path also fell through to `undefined`. msgpackr only re-packs on `=== false`, so a swallowed abort looked like success and the already-encoded record (referencing the new structure id) was persisted even though the structure was never saved → `Record id is not defined for N` on a fresh reader.

- Returns `true` only on a committed save, `false` otherwise (CAS conflict or aborted txn).
- Bumps **msgpackr 1.11.13 → 1.11.14** ([kriszyp/msgpackr#186](https://github.com/kriszyp/msgpackr/pull/186)), which marks structures uninitialized on save-failure so the re-pack reloads durable structures, rebuilds the transition trie, and re-mints + re-saves. **Both halves are required** — `return false` alone doesn't recover (the re-pack reused the cached transition).

Validated end-to-end (`~/dev/scripts/savestructures-abort-repro.cjs`). Independent of the typed-structs work — this is the classic shared-structure path. The auto-cherry-pick can't carry this cleanly (main bumps msgpackr to 2.0.3; v5.0 needs 1.11.14), hence a dedicated PR.

🤖 Generated by Claude (Opus 4.7).