### PR TITLE
fix(downgrade): gate struct-mode encoding to primary DBIs for v4 compat

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -13,6 +13,16 @@ Records stored in tables are plain objects given a `RecordObject` prototype, whi
 - To give a plain JS object the RecordObject prototype without copying it (preserving mutability), use `Object.setPrototypeOf(obj, primaryStore.encoder.structPrototype)` then `entryMap.set(obj, entry)`.
 - Do **not** copy the object (e.g. via `Object.assign` into a new instance) if any code still holds a reference to the original and expects to mutate it — see below.
 
+## Struct mode is gated to primary DBIs (downgrade compatibility)
+
+`RecordEncoder` extends a structon encoder, whose random-access "struct" encoding uses header bytes in `0x20–0x3f`. That range overlaps msgpack positive-fixints, so a reader without struct support (msgpackr v1, i.e. harperdb v4) decodes a struct header as an integer. harperdb v4 only enabled struct mode (its `randomAccessStructure` option) on **primary** DBIs, so non-primary DBIs — notably the `__dbis__` metadata store (table/attribute defs) — were plain records mode. If v5 writes `__dbis__` in struct mode, a v5→v4 downgrade can't decode the metadata, silently treats the instance as a fresh pre-3.0 install, and refuses to boot.
+
+To match v4: `OpenDBIObject` sets `randomAccessStructure = isPrimary`, and `RecordEncoder`, when `randomAccessStructure` is false, makes the struct **write** hook bail (`this._writeStruct = () => 0`) so objects are written in records mode. Two subtleties:
+
+- We **bail** the hook (return 0) rather than clear it (`undefined`). Clearing it shifts msgpackr's positive-fixint boundary from `0x20` to `0x40`, so top-level integers `0x20–0x3f` (e.g. a `NEXT_TABLE_ID` ≥ 32 stored in `__dbis__`) would be written as bare fixints — which the still-installed struct **read** hook misreads as struct headers. Bailing keeps the boundary at `0x20`, so those integers are written as `uint8`.
+- The struct **read** hook is left intact, so records a prior v5 already wrote in struct mode still decode (read-compat); only new writes switch to records mode.
+- Companion change in `structon`: `prepareStructures` saves the shared structures in the legacy plain-array form when there are no typed structs (instead of the `{named, typed}` Map), so the `Symbol.for('structures')` buffer for a records-mode `__dbis__` is also v4-decodable.
+
 ## getFromSource() timing: promise resolves before commit runs
 
 In `getFromSource()` (`Table.ts`), the promise that callers await resolves with the entry **before** the `dbTxn.addWrite` commit callback runs. The commit callback mutates `updatedRecord` in-place to set fields like `createdAt` and `updatedAt`. Since the resolved entry's `.value` is the same reference as `updatedRecord`, those mutations are visible to the caller after resolution.

--- a/integrationTests/upgrade/4.x-upgrade.test.ts
+++ b/integrationTests/upgrade/4.x-upgrade.test.ts
@@ -106,29 +106,28 @@ suite(
 		});
 
 		test('downgrade and start', async () => {
-				// can we downgrade?
-				await killHarper(ctx); // kill 5.x harper
-				await startHarper(ctx, {
-					config: {},
-					env: {
-						CONFIRM_DOWNGRADE: 'yes',
-					},
-					harperBinPath: join(legacyPath, 'bin', 'harperdb.js'),
-				}); // start on 4.x again
-				let response = await sendOperation(ctx.harper, {
-					operation: 'search_by_conditions',
-					table: 'test',
-					conditions: [{ attribute: 'id', comparator: 'greater_than', value: 'id-4' }],
-				});
-				ok(response.length > 4);
-				response = await sendOperation(ctx.harper, {
-					operation: 'read_audit_log',
-					schema: 'data',
-					table: 'test',
-				});
-				ok(response.length > 10);
-			}
-		);
+			// can we downgrade?
+			await killHarper(ctx); // kill 5.x harper
+			await startHarper(ctx, {
+				config: {},
+				env: {
+					CONFIRM_DOWNGRADE: 'yes',
+				},
+				harperBinPath: join(legacyPath, 'bin', 'harperdb.js'),
+			}); // start on 4.x again
+			let response = await sendOperation(ctx.harper, {
+				operation: 'search_by_conditions',
+				table: 'test',
+				conditions: [{ attribute: 'id', comparator: 'greater_than', value: 'id-4' }],
+			});
+			ok(response.length > 4);
+			response = await sendOperation(ctx.harper, {
+				operation: 'read_audit_log',
+				schema: 'data',
+				table: 'test',
+			});
+			ok(response.length > 10);
+		});
 
 		test('upgrade and migrate LMDB to RocksDB', async () => {
 			await killHarper(ctx);

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
 				"ses": "^1.15.0",
 				"stream-chain": "2.2.5",
 				"stream-json": "1.9.1",
-				"structon": "^1.0.4",
+				"structon": "^1.0.5",
 				"systeminformation": "^5.31.4",
 				"tar-fs": "^3.1.2",
 				"ulidx": "0.5.0",
@@ -14850,9 +14850,9 @@
 			"license": "MIT"
 		},
 		"node_modules/structon": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/structon/-/structon-1.0.4.tgz",
-			"integrity": "sha512-0gGHkHV75f+dIH8tGR/MdRm4s8NQ/5BjhCGbhtAdZ86FrQPC07NP/r00cDtYPbUgdQlzZiWqlba3smzTLpyjlQ==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/structon/-/structon-1.0.5.tgz",
+			"integrity": "sha512-ncBlQTTO0Xjlsg4HanW77ROfoqKqhYg4CuKqKk0r/eJP69Ax7ysenZYO1Mx7Wt/Pga54qVN4M1c7OLvrz/hT7g==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
 				"msgpackr": ">=2.0.1"

--- a/package.json
+++ b/package.json
@@ -233,7 +233,7 @@
 		"ses": "^1.15.0",
 		"stream-chain": "2.2.5",
 		"stream-json": "1.9.1",
-		"structon": "^1.0.4",
+		"structon": "^1.0.5",
 		"systeminformation": "^5.31.4",
 		"tar-fs": "^3.1.2",
 		"ulidx": "0.5.0",

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -90,6 +90,7 @@ export class RecordEncoder extends StructonEncoder {
 	rootStore: any;
 	declare saveStructures: any;
 	declare getStructures: any;
+	declare _writeStruct: any;
 	structureUpdate?: any;
 	isRocksDB: boolean;
 	name: string;
@@ -112,6 +113,16 @@ export class RecordEncoder extends StructonEncoder {
 
 		options.structPrototype = RecordObject.prototype;
 		super(options);
+		// structon (the StructonEncoder base) always installs the struct write hook. For DBIs
+		// that don't opt into struct mode (non-primary, e.g. __dbis__), force it to bail (return
+		// 0) so objects are written in plain msgpackr records mode — decodable by readers without
+		// struct support (msgpackr v1 / Harper v4 downgrade). We make it bail rather than clear
+		// it so msgpackr keeps the struct-safe integer boundary: top-level integers 0x20-0x3f are
+		// written as uint8 rather than bare fixints, which the retained struct READ hook would
+		// otherwise misread as struct headers (e.g. a scalar NEXT_TABLE_ID >= 32 in __dbis__).
+		// The read hook stays intact so records already written in struct mode by a prior v5 still
+		// decode.
+		if (!options.randomAccessStructure) this._writeStruct = () => 0;
 		const superEncode = this.encode;
 		this.encode = function (record, options?) {
 			// this handles our custom metadata encoding, prefixing the record with metadata, including the local

--- a/unitTests/resources/recordEncoder.test.js
+++ b/unitTests/resources/recordEncoder.test.js
@@ -1,0 +1,85 @@
+require('../testUtils');
+const assert = require('assert');
+const { RecordEncoder } = require('#src/resources/RecordEncoder');
+const { Encoder } = require('msgpackr');
+
+// Shared structures persisted as an encoded buffer (mirrors how a DBI stores them under
+// Symbol.for('structures')), so struct/record structures cross between encoder instances.
+function sharedStore() {
+	let buf;
+	const meta = new Encoder();
+	return {
+		save(s) {
+			buf = meta.encode(s);
+			return true;
+		},
+		get() {
+			return buf ? meta.decode(buf) : undefined;
+		},
+	};
+}
+
+function makeEncoder(randomAccessStructure, store) {
+	return new RecordEncoder({
+		structures: [],
+		randomAccessStructure,
+		getStructures: store.get,
+		saveStructures: store.save,
+	});
+}
+
+const record = { name: 'price', type: 'Float', indexed: true };
+
+describe('RecordEncoder struct-mode gating', () => {
+	it('non-primary (randomAccessStructure off) writes records mode and bails the struct write hook', () => {
+		const store = sharedStore();
+		const enc = makeEncoder(false, store);
+		assert.strictEqual(typeof enc._writeStruct, 'function', 'struct write hook should remain a function');
+		assert.strictEqual(enc._writeStruct(), 0, 'struct write hook should bail (return 0) so objects use records mode');
+		const bytes = enc.encode(record);
+		assert.ok(bytes[0] < 0x20 || bytes[0] >= 0x40, `expected records-mode byte, got 0x${bytes[0].toString(16)}`);
+		assert.ok(Array.isArray(store.get()), 'structures should be saved as a plain array (struct-unaware readable)');
+	});
+
+	it('primary (randomAccessStructure on) writes struct mode', () => {
+		const store = sharedStore();
+		const enc = makeEncoder(true, store);
+		assert.notStrictEqual(enc._writeStruct, undefined, 'struct write hook should be set for primary DBIs');
+		const bytes = enc.encode(record);
+		assert.ok(bytes[0] >= 0x20 && bytes[0] < 0x40, `expected struct header byte, got 0x${bytes[0].toString(16)}`);
+	});
+
+	it('records-mode output decodes on a struct-unaware msgpackr decoder (downgrade-safe)', () => {
+		const store = sharedStore();
+		const enc = makeEncoder(false, store);
+		const bytes = enc.encode(record);
+		const plain = new Encoder({ useRecords: true, structures: store.get() || [] });
+		assert.deepStrictEqual(plain.decode(Buffer.from(bytes)), record);
+	});
+
+	it('non-primary encoder round-trips top-level scalar integers in the struct-header range (0x20-0x3f)', () => {
+		// Regression: clearing the struct write hook would emit bare fixints for ints 32-63,
+		// which the retained struct read hook misreads as struct headers (e.g. NEXT_TABLE_ID
+		// in __dbis__). Bailing the write hook keeps these as uint8 so they round-trip.
+		const store = sharedStore();
+		const enc = makeEncoder(false, store);
+		for (const v of [31, 32, 50, 63, 64, 100]) {
+			assert.strictEqual(enc.decode(Buffer.from(enc.encode(v))), v, `scalar ${v} should round-trip`);
+		}
+	});
+
+	it('non-primary encoder still reads struct data written by a primary encoder', () => {
+		const store = sharedStore();
+		const writer = makeEncoder(true, store); // simulate an existing v5 that wrote struct mode
+		const structBytes = writer.encode(record);
+		assert.ok(structBytes[0] >= 0x20 && structBytes[0] < 0x40, 'precondition: struct bytes');
+
+		const reader = makeEncoder(false, store);
+		assert.notStrictEqual(reader._readStruct, undefined, 'struct read hook must be retained');
+		const decoded = reader.decode(Buffer.from(structBytes));
+		assert.ok(decoded, 'struct data should still decode (not swallowed to null)');
+		assert.strictEqual(decoded.name, record.name);
+		assert.strictEqual(decoded.type, record.type);
+		assert.strictEqual(decoded.indexed, record.indexed);
+	});
+});

--- a/upgrade/directives/5-1-0.ts
+++ b/upgrade/directives/5-1-0.ts
@@ -75,7 +75,9 @@ async function patchHdbDeploymentIsHashAttribute() {
 
 	primaryAttr.is_hash_attribute = true;
 	await systemTable.dbisDB.put(dbiName, primaryAttr);
-	hdbLogger.info(`Patched system.${DEPLOYMENT_TABLE} __dbis__ entry with is_hash_attribute=true for harperdb@4.x downgrade compatibility.`);
+	hdbLogger.info(
+		`Patched system.${DEPLOYMENT_TABLE} __dbis__ entry with is_hash_attribute=true for harperdb@4.x downgrade compatibility.`
+	);
 }
 
 const directive510 = {

--- a/utility/lmdb/OpenDBIObject.ts
+++ b/utility/lmdb/OpenDBIObject.ts
@@ -19,6 +19,7 @@ export class OpenDBIObject {
 	cache: any;
 	freezeData: boolean;
 	encoder: any;
+	randomAccessStructure: boolean;
 	/**
 	 * @param {Boolean} dupSort - if the dbi allows duplicate keys
 	 * @param {Boolean} [isPrimary] - if the dbi is the primary dbi
@@ -35,6 +36,13 @@ export class OpenDBIObject {
 		/** @type {any} */
 		this.compression = undefined;
 		this.encoder = { Encoder: RecordEncoder };
+		// Only enable struct (random-access) encoding on primary DBIs. Struct headers occupy
+		// the 0x20-0x3f range, which readers without struct support (msgpackr v1 / Harper v4)
+		// decode as positive fixints. v4 likewise gated struct mode behind is_primary, so
+		// non-primary stores (e.g. the __dbis__ metadata DBI) stay in records mode and remain
+		// decodable after a downgrade. RecordEncoder still reads struct data so existing v5
+		// struct entries decode.
+		this.randomAccessStructure = isPrimary;
 		if (isPrimary) {
 			this.cache = LMDB_CACHING && { validated: true };
 			this.freezeData = true;


### PR DESCRIPTION
## Summary

- `OpenDBIObject`: set `randomAccessStructure = isPrimary` so non-primary DBIs (e.g. `__dbis__`) opt out of struct encoding
- `RecordEncoder`: make the struct write hook bail when `randomAccessStructure` is false, writing plain msgpackr records mode instead; struct read hook left intact so prior struct-mode entries still decode
- Bump `structon` to `>=1.0.5` for the plain-array shared-structures buffer fix that keeps the structures blob v4-decodable

## Why

Harper v5 applied `RecordEncoder` (structon struct-mode encoding) to ALL DBIs after a5129cf31 (May 24 2026) moved the encoder assignment outside the `isPrimary` guard in `OpenDBIObject`. Struct headers occupy bytes `0x20-0x3f`; msgpackr v1 (harperdb v4) decodes those as positive fixints, so on a v5→v4 downgrade v4 cannot decode v5's `__dbis__` metadata, silently treats the install as pre-3.0, and refuses to boot.

This restores the v4 behavior: struct encoding only on primary DBIs. Non-primary DBIs write plain msgpackr records-mode (v4-decodable). The struct read hook stays active so entries already written by a prior v5 instance still decode correctly.

Pairs with `is_hash_attribute` fix (already on main in #dae394077).

## Areas to review

- `RecordEncoder._writeStruct` bail: we return `0` from the hook to trigger msgpackr's uint8 fallback for integers 0x20-0x3f rather than clearing the hook (which would leave NEXT_TABLE_ID >= 32 as bare fixints the active read hook misreads). Want a second set of eyes that the bail-vs-clear distinction is correct.
- `structon >= 1.0.5` requirement: needed for the plain-array structures buffer. This is a semver patch bump from 1.0.4.

*Generated by Claude Sonnet 4.6*