### PR TITLE
fix(logging): scope logRotator state per instance

### DIFF
--- a/utility/logging/logRotator.ts
+++ b/utility/logging/logRotator.ts
@@ -18,9 +18,6 @@ const LOG_AUDIT_INTERVAL = 60000;
 const INT_SIZE_UNDEFINED_MSG =
 	"'interval' and 'maxSize' are both undefined, to enable logging rotation at least one of these values must be defined in harperdb-config.yaml";
 
-let lastRotationTime;
-let setIntervalId;
-
 export { logRotator };
 
 /**
@@ -67,9 +64,9 @@ function logRotator({ logger, maxSize, interval, retention, enabled, path: rotat
 
 	let lastRotatedLogPath;
 	// convert date.now to minutes
-	lastRotationTime = Date.now();
+	let lastRotationTime = Date.now();
 	hdbLogger.trace('Log rotate enabled, maxSize:', maxSize, 'interval:', interval);
-	setIntervalId = setInterval(async () => {
+	const setIntervalId = setInterval(async () => {
 		if (maxBytes) {
 			let fileStats;
 			try {


### PR DESCRIPTION
## Summary

`utility/logging/logRotator.ts` declared `lastRotationTime` and `setIntervalId` at module scope, so every `logRotator()` call overwrote the shared id. Once #1111 fixed the broken `require` and `harper_logger.getFileLogger` started creating real rotators, multiple instances (hdb, http, external) could coexist and any `rotator.end()` would `clearInterval` the most-recently-created interval instead of its own.

Move both into the function closure so each rotator owns its state.

## Regression context

Before #1111, `harper_logger.getFileLogger`'s internal `require('./logRotator')()` threw a TypeError (it was getting the CJS namespace object, not the function) and was swallowed by a `catch`, so log rotation was silently disabled and the module-level state was only ever touched by direct callers (e.g. the unit test). #1111 fixed the require, exposing the latent state-sharing bug.

The unit-test failure mode after #1111: `harper_logger.test.js` HTTP/global-logger `after()` hooks reassign `httpLogger.path`/`externalLogger.path`, which schedules a 100ms `setTimeout` in `getFileLogger` that calls `logger.rotator?.end()`. That `end()` resolves to `clearInterval(module-level setIntervalId)` — clobbering the logRotator unit test's own interval that was just created, so rotation never fires and `getLastRotatedLogPath()` returns `undefined`.

## Verification

- `npm run test:unit:logging` -> 49 passing (was 1 failing).
- `npm run test:unit:main` -> the 5 remaining failures are pre-existing SQL Engine / analytics serialization / scopedImport issues unrelated to logging.
- Codex review: no regressions identified.

Generated by Claude Opus 4.7.