### PR TITLE
Fix two-byte record corruption: cap maxOwnStructures at 32 (v5.0)

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -88,10 +88,18 @@ export class RecordEncoder extends Encoder {
 	name: string;
 	constructor(options) {
 		options.useBigIntExtension = true;
-		// Bound the per-encoder typed-structure dictionary. It is append-only and pinned on the
-		// long-lived primary store, so a wide/sparse schema (whose records vary by per-field value
-		// width) can grow it unbounded and exhaust memory. Caller-overridable; default caps it.
-		options.maxOwnStructures ??= 256;
+		// Bound the per-encoder structure dictionary. It is append-only and pinned on the long-lived
+		// primary store, so a wide/sparse schema (whose records vary by per-field value width) can grow
+		// it unbounded and exhaust memory. Caller-overridable; default caps it.
+		//
+		// Must stay <= 32: with msgpackr's default maxSharedStructures (32), maxOwnStructures + 32 > 64
+		// flips on the two-byte record-id encoding, which mis-serializes over-cap "own" structures when a
+		// shared-structures store is present (the primary store always has one) — it writes an out-of-range
+		// record-id reference instead of inlining the structure, so records become undecodable
+		// ("Record id is not defined for N") once a table exceeds the shared cap. The one-byte path
+		// (<= 32) inlines over-cap shapes correctly and bounds memory at least as tightly. (A prior 256
+		// triggered this on both the typed default and the randomAccessFields=false opt-out.)
+		options.maxOwnStructures ??= 32;
 		// When random-access fields are disabled (storage.randomAccessFields=false), write records as
 		// classic shared structures instead of typed random-access structures. randomAccessStructure stays
 		// on so reads still decode either form — existing typed-struct data remains readable; only new

--- a/unitTests/resources/recordEncoder.test.js
+++ b/unitTests/resources/recordEncoder.test.js
@@ -177,3 +177,45 @@ describe('RecordEncoder random-access fields opt-out (readOnlyStructures)', () =
 		});
 	});
 });
+
+describe('RecordEncoder structure dictionary cap (no two-byte over-cap corruption)', () => {
+	// Regression: harper's default maxOwnStructures must keep msgpackr on the one-byte record path
+	// (maxOwnStructures + the default maxSharedStructures of 32 must stay <= 64). A larger value (the
+	// prior 256) flips on the two-byte path, which mis-serializes over-cap "own" structures when a
+	// shared-structures store is present — records written after a table exceeds the shared cap become
+	// undecodable ("Record id is not defined for N"), on both the typed default and the
+	// randomAccessFields=false opt-out. These write far more distinct shapes than the shared cap through
+	// a shared store and assert every record still decodes.
+	function diverseRecords(count) {
+		const records = [];
+		for (let i = 0; i < count; i++) {
+			const rec = { id: i };
+			const attrCount = 1 + (i % 6);
+			for (let a = 0; a < attrCount; a++) rec['attr_' + ((i * 7 + a) % 200)] = i % 2 ? 's' + i : i;
+			records.push(rec);
+		}
+		return records;
+	}
+
+	function assertAllDecode(extra) {
+		const store = sharedStore();
+		const writer = makeEncoder(store, extra);
+		const reader = makeEncoder(store, extra);
+		const records = diverseRecords(500); // far exceeds the 32 shared-structure cap
+		const buffers = records.map((r) => Buffer.from(writer.encode(r)));
+		let failures = 0;
+		for (let i = 0; i < buffers.length; i++) {
+			const decoded = reader.decode(buffers[i]);
+			if (!decoded || decoded.id !== records[i].id) failures++;
+		}
+		assert.strictEqual(failures, 0, `all ${records.length} records should decode after exceeding the shared cap`);
+	}
+
+	it('decodes every record past the shared cap on the typed path (default)', () => {
+		assertAllDecode(undefined);
+	});
+
+	it('decodes every record past the shared cap with randomAccessFields off (readOnlyStructures)', () => {
+		assertAllDecode({ readOnlyStructures: true });
+	});
+});


### PR DESCRIPTION
## Summary
`RecordEncoder` set `maxOwnStructures = 256`. With msgpackr's default `maxSharedStructures = 32`, `maxOwn + maxShared > 64` flips on msgpackr's **two-byte record-id encoding**, which **mis-serializes over-cap "own" structures when a shared-structures store is present** (every primary store has one): it writes an out-of-range record-id *reference* instead of inlining the structure. Once a table exceeds the shared cap, new records become **undecodable** — `Record id is not defined for N`. This fix lowers the cap to **32**, keeping msgpackr on the correct **one-byte path** (which inlines over-cap shapes and bounds memory at least as tightly).

## Why this matters (data integrity, shipped in v5.0.29)
The broken `maxOwnStructures=256` is the OOM cap from #1146, shipped in **v5.0.29**. The corruption hits **both** configs:
- **Default** (typed / `randomAccessFields=true`)
- **Opt-out** (`randomAccessFields=false`, #1169)

i.e. any high-cardinality table (e.g. CDI's `RaceEntry` with undeclared dynamic attributes) writing records past the ~32-shape shared cap produces undecodable records. This is the `Record id is not defined for N` flood reported on dev/CDI (Slack thread, and Nathan Heskew's verification on #1169) — root-caused here to the two-byte path, not the #1157/#186 save-race.

**Patch candidate for v5.0.30.**

## Repro (high confidence)
Pure-msgpackr matrix with a shared store + 3–5k distinct shapes:
- `maxOwn=256` → ~2900/3000 records undecodable
- `maxOwn=33` (just over the one-byte boundary) → also broken
- `maxOwn=32` / default → **0 errors**, dictionary bounded

## Where to look
- `resources/RecordEncoder.ts` — the one-line cap change (256 → 32) + a comment explaining the one-byte invariant (`maxOwn + maxShared ≤ 64`).
- `unitTests/resources/recordEncoder.test.js` — new regression block: writes 500 distinct shapes through a shared store and asserts every record decodes, on **both** the typed and `readOnlyStructures` paths. (Fails at 256, passes at 32.)

## Open / follow-up
- The deeper **msgpackr two-byte over-cap fix** (to make >32 shared structures correct, not just avoided) is in progress separately; this PR is the safe immediate stop-gap.
- **Already-written data**: records persisted on v5.0.29 *after* a table exceeded the shared cap may be permanently undecodable — needs a separate recovery assessment.
- Pre-existing on v5.0.29 (not from this PR): the #1169 `recordEncoder.test.js` config/byte-range tests flake under full-file ordering (config-state isolation), and the resources suite has the environmental "Data read" setup crash. The new regression tests pass in isolation and are robust to ambient config (they assert decodability, not byte ranges).

🤖 Generated by Claude (Opus 4.7). Codex review: clean — no actionable correctness issues introduced. (Gemini was daily-quota-limited on the related PRs.)