### PR TITLE
test: restore leaked envMngr.get stub in installation.test.js

### DIFF
--- a/unitTests/utility/installation.test.js
+++ b/unitTests/utility/installation.test.js
@@ -1,5 +1,5 @@
 const { isHdbInstalled } = require('#src/utility/installation');
-const sandbox = require('sinon');
+const sinon = require('sinon');
 const { expect } = require('chai');
 const fs = require('node:fs');
 const path = require('path');
@@ -12,9 +12,11 @@ describe('Test isHdbInstalled function', () => {
 	let envStub;
 	let loggerStub;
 	let logErrorStub;
+	let sandbox;
 	const TEST_ERROR = 'I am a unit test error test';
 
 	before(() => {
+		sandbox = sinon.createSandbox();
 		fsStatStub = sandbox.stub(fs, 'statSync');
 		envStub = sandbox.stub(envMangr, 'get');
 		envStub
@@ -30,7 +32,7 @@ describe('Test isHdbInstalled function', () => {
 	});
 
 	after(() => {
-		fsStatStub.restore();
+		sandbox.restore();
 	});
 
 	it('Test two calls to fs stat with the correct arguments happy path', async () => {


### PR DESCRIPTION
## Summary
`unitTests/utility/installation.test.js` aliased the entire `sinon` module as `sandbox` (`const sandbox = require('sinon')`), stubbed `envMngr.get` in `before()`, but its `after()` only restored `fsStatStub`. The `get` stub therefore leaked into every test file that ran afterward in the full unit suite.

The fix switches the test to an isolated `sinon.createSandbox()` and tears everything down with `sandbox.restore()` in `after()`.

## Purpose
The leaked `envMngr.get` stub silently corrupts config reads in later tests, and broke `unitTests/utility/lmdb/OpenDBIObject.test.js` in CI with `TypeError: Attempted to wrap get which is already wrapped` (seen on #1152). OpenDBIObject was made defensively immune to the leak (23a0c83a), but the leaking test itself needed fixing for proper isolation.

## Where to look / verify
- The change is 4 lines in one test file; no production code is touched, so it can only *remove* a leaked stub, not change runtime behavior.
- Reproduction confirmed locally: with the original `installation.test.js`, running it followed by the pre-immune `OpenDBIObject.test.js` throws "already wrapped"; with this fix the stub setup succeeds.

> Note: the full local unit suite could not be run to completion in this environment (memory pressure + shared global-setup RocksDB lock contention from concurrent test runs), so CI is the authoritative full-suite signal here.

Generated by Claude (Opus).