### PR TITLE
Bump msgpackr to 2.0.4: two-byte over-cap record decode fix (5.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
 				"minimist": "1.2.8",
 				"moment": "2.30.1",
 				"mqtt-packet": "~9.0.1",
-				"msgpackr": "^2.0.1",
+				"msgpackr": "^2.0.4",
 				"needle": "3.5.0",
 				"node-forge": "^1.3.1",
 				"node-stream-zip": "1.15.0",
@@ -3087,6 +3087,15 @@
 			],
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@harperfast/rocksdb-js/node_modules/msgpackr": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.1.tgz",
+			"integrity": "sha512-9J+tqTEsbHqY8YohazYgty7LgerFIWxvMLpUjqETSmjHojtJm2WnX2kK/2a1fLI7CO7ERP1YSEUXMucz4j+yBA==",
+			"license": "MIT",
+			"optionalDependencies": {
+				"msgpackr-extract": "^3.0.2"
 			}
 		},
 		"node_modules/@hono/node-server": {
@@ -12114,12 +12123,12 @@
 			"license": "MIT"
 		},
 		"node_modules/msgpackr": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.1.tgz",
-			"integrity": "sha512-9J+tqTEsbHqY8YohazYgty7LgerFIWxvMLpUjqETSmjHojtJm2WnX2kK/2a1fLI7CO7ERP1YSEUXMucz4j+yBA==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.4.tgz",
+			"integrity": "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==",
 			"license": "MIT",
 			"optionalDependencies": {
-				"msgpackr-extract": "^3.0.2"
+				"msgpackr-extract": "^3.0.4"
 			}
 		},
 		"node_modules/msgpackr-extract": {

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
 		"minimist": "1.2.8",
 		"moment": "2.30.1",
 		"mqtt-packet": "~9.0.1",
-		"msgpackr": "^2.0.1",
+		"msgpackr": "^2.0.4",
 		"needle": "3.5.0",
 		"node-forge": "^1.3.1",
 		"node-stream-zip": "1.15.0",


### PR DESCRIPTION
## Summary
Bumps **msgpackr 2.0.1 → 2.0.4**, the v2 counterpart of the v5.0 fix (#1179). msgpackr ≤2.0.3 mis-read self-contained two-byte over-cap record definitions (`recordDefinition` used a second-byte reader that consumed the first value byte as a phantom high byte → `Record id is not defined for N`), leaving high-cardinality records undecodable. Fixed upstream in **kriszyp/msgpackr#190** — read-path only, so it fixes decoding and recovers already-written data without an on-disk format change.

## Scope on main/5.1
The typed path goes through structon; the classic two-byte path is reached via the `randomAccessFields=false` opt-out (#1152) / `toJSON` fallback, so this is a **latent-correctness** fix for the unreleased 5.1 line (lower urgency than the v5.0/v5.0.30 patch, where it's actively hit + recovers CDI data).

## Verification
- msgpackr 2.0.4 carries the upstream regression suite (kriszyp/msgpackr#190): two-byte over-cap definitions/references round-trip, dictionary stays bounded.
- main's existing `recordEncoder.test.js` (5 tests) passes against 2.0.4; build succeeds.

## Notes
- Minimal dep bump (no harper-level test added — the encoder regression coverage lives upstream in #190 and on #1179 for v5.0).
- Counterpart PRs: harper #1179 (v5.0, msgpackr 1.12.1); msgpackr #189 (v1.12.x) / #190 (v2/master).

🤖 Generated by Claude (Opus 4.7).