### PR TITLE
chore: bump version to 5.1.0-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "harper",
-	"version": "5.1.0-beta.1",
+	"version": "5.1.0-beta.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "harper",
-			"version": "5.1.0-beta.1",
+			"version": "5.1.0-beta.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/client-s3": "^3.1012.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "harper",
 	"description": "Harper is an open-source Node.js performance platform that unifies database, cache, application, and messaging layers into one in-memory process.",
-	"version": "5.1.0-beta.1",
+	"version": "5.1.0-beta.2",
 	"license": "Apache-2.0",
 	"homepage": "https://harper.fast",
 	"bugs": {


### PR DESCRIPTION
Version bump to `5.1.0-beta.2`.

Pair with: HarperFast/harper-pro (version bump PR, same branch name)

**Do not merge until:**
- [x] #1147 merged (commutative op double-apply fix)
- [ ] #1154 merged (shared-structure not-saved fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)