### PR TITLE
test(embed-directive): poll for async embed count before asserting

### DIFF
--- a/integrationTests/apiTests/northwind.test.mjs
+++ b/integrationTests/apiTests/northwind.test.mjs
@@ -2160,7 +2160,7 @@ suite('Northwind operations', { skip: skipSuite }, (ctx) => {
 		// Use awaitJob + manual assertions so we can return job.message as a raw
 		// object — awaitJobCompleted would stringify it, breaking callers that
 		// access errorMsg.unauthorized_access / errorMsg.invalid_schema_items.
-		const jobResp = await awaitJob(client, getJobId(r.body), isBunRuntime ? 60 : 30);
+		const jobResp = await awaitJob(client, getJobId(r.body), isBunRuntime ? 120 : 30);
 		const job = jobResp.body[0];
 		assert.ok(job, `No job found in response: ${jobResp.text}`);
 		if (_expectedError) {

--- a/integrationTests/server/embed-directive.test.ts
+++ b/integrationTests/server/embed-directive.test.ts
@@ -420,7 +420,14 @@ suite('@embed directive end-to-end with fake Ollama', (ctx: any) => {
 		strictEqual(firstBody.id, id);
 		strictEqual(firstBody.content, expectedContent, 'cache should reflect the source-returned content');
 
-		// The embedder must have run exactly once during the cache write.
+		// The cache write fires the embed hook asynchronously — the GET response is
+		// returned before the write's txn commits (see Table.ts:~4275 design note),
+		// so the embed call may land on a later event-loop tick. Poll up to ~500ms
+		// (same approach used below for search_by_hash) before asserting.
+		for (let attempt = 0; attempt < 20; attempt++) {
+			if (fake.embedCallCount() > baselineEmbedCalls) break;
+			await new Promise((resolve) => setTimeout(resolve, 25));
+		}
 		strictEqual(
 			fake.embedCallCount(),
 			baselineEmbedCalls + 1,


### PR DESCRIPTION
## Summary

Two shard-2 CI failures, both fixed here:

1. **Node.js v26 embed-directive race** (`integrationTests/server/embed-directive.test.ts`): The caching-table test asserted `embedCallCount` immediately after a GET, but the GET returns before the cache-write txn commits (fire-and-forget path in `Table.ts`). The embed hook fires on a later event-loop tick. `88c94e67e` changed event-loop scheduling, making the race reliable on Node.js v26. Fix: poll up to ~500ms before asserting (same pattern already used in the `search_by_hash` assertion in the same test).

2. **Bun csvDataLoad timeout** (`integrationTests/apiTests/northwind.test.mjs`): In shard 2, the embed-directive suite tears down its Harper instance (flushing HNSW index data to disk) concurrently with northwind's `csvDataLoad` background job. The CPU-intensive HNSW flush under Bun starves the job processor, causing it to still be `IN_PROGRESS` at the 60s polling deadline. Fix: increase Bun timeout from 60s → 120s.

Both are test-only changes; no production code modified.

_Generated with Claude Sonnet 4.6_