### PR TITLE
fix(databases): sync non-indexed attributes on worker-restart schema reload (RE-7)

### DIFF
--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -629,6 +629,7 @@ function initStores(
 					const existingIdx = existingAttributes.findIndex((ea) => ea.name === attribute.attribute);
 					if (existingIdx >= 0) {
 						existingAttributes.splice(existingIdx, 1, attribute);
+						attributesUpdated = true;
 					} else {
 						existingAttributes.push(attribute);
 						attributesUpdated = true;

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -638,6 +638,10 @@ function initStores(
 				logger.error(`Error trying to update attribute`, attribute, existingAttributes, indices, error);
 			}
 		}
+		// Collect removals first; splicing while iterating `existingAttributes` skips adjacent
+		// elements, which would silently leave stale fields behind when two or more were dropped
+		// in the same reload.
+		const toRemove = [];
 		for (const existingAttribute of existingAttributes) {
 			const attribute = attributes.find((attribute) => attribute.name === existingAttribute.name);
 			if (!attribute) {
@@ -658,14 +662,21 @@ function initStores(
 				}
 				if (existingAttribute.indexed) {
 					// we only remove attributes if they were indexed, in order to support dropAttribute that removes dynamic indexed attributes
-					existingAttributes.splice(existingAttributes.indexOf(existingAttribute), 1);
-					attributesUpdated = true;
+					toRemove.push(existingAttribute);
 				} else if (!existingAttribute.isPrimaryKey) {
-					// Remove non-indexed attributes that are no longer present in the persisted schema.
-					existingAttributes.splice(existingAttributes.indexOf(existingAttribute), 1);
-					attributesUpdated = true;
+					// Skip runtime-only attributes (e.g. relationship attrs — table()'s persistence loop
+					// `continue`s past them at line 1138). They are present in `existingAttributes` but
+					// never in the `attributes` list rebuilt from attributesDbi; removing them would drop
+					// the resolver/search support added by updatedAttributes(). Computed attrs ARE
+					// persisted, so only `relationship` is excluded here.
+					if (existingAttribute.relationship) continue;
+					toRemove.push(existingAttribute);
 				}
 			}
+		}
+		for (const existingAttribute of toRemove) {
+			existingAttributes.splice(existingAttributes.indexOf(existingAttribute), 1);
+			attributesUpdated = true;
 		}
 		if (table && !recreateForEngineChange) {
 			if (attributesUpdated) {

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -626,7 +626,7 @@ function initStores(
 					// hot-reload / worker restart. Without this, resetDatabases() re-reads these attributes
 					// from attributesDbi but never merges them back into table.attributes — causing stale
 					// schema metadata until a full kill+restart. (RE-7)
-					const existingIdx = existingAttributes.findIndex((ea) => ea.name === attribute.name);
+					const existingIdx = existingAttributes.findIndex((ea) => ea.name === attribute.attribute);
 					if (existingIdx >= 0) {
 						existingAttributes.splice(existingIdx, 1, attribute);
 					} else {

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -620,6 +620,19 @@ function initStores(
 					if (existingAttribute) existingAttributes.splice(existingAttributes.indexOf(existingAttribute), 1, attribute);
 					else existingAttributes.push(attribute);
 					attributesUpdated = true;
+				} else if (!attribute.isPrimaryKey) {
+					// Non-indexed, non-primary-key attributes (e.g. plain schema fields like `name: String`)
+					// must also be kept in sync so that describe_database reflects schema changes after a
+					// hot-reload / worker restart. Without this, resetDatabases() re-reads these attributes
+					// from attributesDbi but never merges them back into table.attributes — causing stale
+					// schema metadata until a full kill+restart. (RE-7)
+					const existingIdx = existingAttributes.findIndex((ea) => ea.name === attribute.name);
+					if (existingIdx >= 0) {
+						existingAttributes.splice(existingIdx, 1, attribute);
+					} else {
+						existingAttributes.push(attribute);
+						attributesUpdated = true;
+					}
 				}
 			} catch (error) {
 				logger.error(`Error trying to update attribute`, attribute, existingAttributes, indices, error);
@@ -645,6 +658,10 @@ function initStores(
 				}
 				if (existingAttribute.indexed) {
 					// we only remove attributes if they were indexed, in order to support dropAttribute that removes dynamic indexed attributes
+					existingAttributes.splice(existingAttributes.indexOf(existingAttribute), 1);
+					attributesUpdated = true;
+				} else if (!existingAttribute.isPrimaryKey) {
+					// Remove non-indexed attributes that are no longer present in the persisted schema.
 					existingAttributes.splice(existingAttributes.indexOf(existingAttribute), 1);
 					attributesUpdated = true;
 				}

--- a/unitTests/resources/schemaMigrationFragility.test.js
+++ b/unitTests/resources/schemaMigrationFragility.test.js
@@ -413,12 +413,7 @@ describe('schema-migration fragility: non-indexed attributes missing from table.
 		table({
 			table: TABLE,
 			database: DB,
-			attributes: [
-				{ name: 'id', isPrimaryKey: true },
-				{ name: 'name' },
-				{ name: 'breed' },
-				{ name: 'age' },
-			],
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }, { name: 'breed' }, { name: 'age' }],
 		});
 		// Re-create the stale main-thread state: reset in-memory Table.attributes back to
 		// [id] only, while attributesDbi still has all four.  This is exactly the mismatch
@@ -450,21 +445,20 @@ describe('schema-migration fragility: non-indexed attributes missing from table.
 		table({
 			table: TABLE,
 			database: DB,
-			attributes: [
-				{ name: 'id', isPrimaryKey: true },
-				{ name: 'name' },
-			],
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
 		});
 		// table() updates in-memory Table.attributes directly (databases.ts:997), so after the
 		// call above the in-memory state is already [id, name].  Re-create the stale main-thread
 		// view — still holding the old [id, name, breed, age] — so that the removal loop in
 		// initStores() actually needs to drop breed and age.
 		const tblForRemoval = getDatabases()[DB]?.[TABLE];
-		tblForRemoval.attributes.splice(0, tblForRemoval.attributes.length,
+		tblForRemoval.attributes.splice(
+			0,
+			tblForRemoval.attributes.length,
 			{ name: 'id', isPrimaryKey: true },
 			{ name: 'name' },
 			{ name: 'breed' },
-			{ name: 'age' },
+			{ name: 'age' }
 		);
 		resetDatabases();
 		const tbl = getDatabases()[DB]?.[TABLE];

--- a/unitTests/resources/schemaMigrationFragility.test.js
+++ b/unitTests/resources/schemaMigrationFragility.test.js
@@ -450,7 +450,10 @@ describe('schema-migration fragility: non-indexed attributes missing from table.
 		// table() updates in-memory Table.attributes directly (databases.ts:997), so after the
 		// call above the in-memory state is already [id, name].  Re-create the stale main-thread
 		// view — still holding the old [id, name, breed, age] — so that the removal loop in
-		// initStores() actually needs to drop breed and age.
+		// initStores() actually needs to drop breed and age.  Two adjacent removals (breed AND
+		// age) also guard against a regression of the splice-while-iterating bug: splicing the
+		// array being iterated by `for...of` skipped the next element, so the loop must collect
+		// removals first and apply them after the iteration.
 		const tblForRemoval = getDatabases()[DB]?.[TABLE];
 		tblForRemoval.attributes.splice(
 			0,
@@ -466,6 +469,33 @@ describe('schema-migration fragility: non-indexed attributes missing from table.
 		assert.ok(attrNames.includes('name'), `expected "name" in attributes`);
 		assert.ok(!attrNames.includes('breed'), `"breed" should be removed, got: ${attrNames}`);
 		assert.ok(!attrNames.includes('age'), `"age" should be removed, got: ${attrNames}`);
+	});
+
+	it('preserves runtime-only relationship attributes across resetDatabases()', () => {
+		// Relationship attrs are runtime-only — table()'s persistence loop skips them
+		// (databases.ts:1138, `if (attribute.relationship) continue`), so they are present in
+		// table.attributes but never written to attributesDbi.  After resetDatabases(),
+		// initStores() rebuilds `attributes` from attributesDbi only — so the relationship attr
+		// won't appear there.  The removal loop must not drop it; otherwise updatedAttributes()
+		// would strip the resolver/search support and downstream GraphQL nested queries return
+		// undefined (the integration symptom: graphql-querying-test "handles query by nested
+		// attribute" assertions).
+		table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+		});
+		const tblWithRel = getDatabases()[DB]?.[TABLE];
+		// Inject a runtime-only relationship attribute, mirroring what graphql.ts does after
+		// parsing a `@relationship` directive — these never round-trip through attributesDbi.
+		tblWithRel.attributes.push({ name: 'related', relationship: { from: 'relatedId' } });
+		resetDatabases();
+		const tbl = getDatabases()[DB]?.[TABLE];
+		const attrNames = tbl.attributes.map((a) => a.name);
+		assert.ok(
+			attrNames.includes('related'),
+			`relationship attribute "related" should survive resetDatabases() but was dropped — got: ${attrNames}`
+		);
 	});
 });
 

--- a/unitTests/resources/schemaMigrationFragility.test.js
+++ b/unitTests/resources/schemaMigrationFragility.test.js
@@ -455,6 +455,17 @@ describe('schema-migration fragility: non-indexed attributes missing from table.
 				{ name: 'name' },
 			],
 		});
+		// table() updates in-memory Table.attributes directly (databases.ts:997), so after the
+		// call above the in-memory state is already [id, name].  Re-create the stale main-thread
+		// view — still holding the old [id, name, breed, age] — so that the removal loop in
+		// initStores() actually needs to drop breed and age.
+		const tblForRemoval = getDatabases()[DB]?.[TABLE];
+		tblForRemoval.attributes.splice(0, tblForRemoval.attributes.length,
+			{ name: 'id', isPrimaryKey: true },
+			{ name: 'name' },
+			{ name: 'breed' },
+			{ name: 'age' },
+		);
 		resetDatabases();
 		const tbl = getDatabases()[DB]?.[TABLE];
 		const attrNames = tbl.attributes.map((a) => a.name);

--- a/unitTests/resources/schemaMigrationFragility.test.js
+++ b/unitTests/resources/schemaMigrationFragility.test.js
@@ -382,6 +382,79 @@ describe('schema-migration fragility: stale `changed` reused after re-fetch unde
 	});
 });
 
+describe('schema-migration fragility: non-indexed attributes missing from table.attributes after resetDatabases() (RE-7)', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+
+	const DB = 're7NonIndexedAttrs';
+	const TABLE = 'Pet';
+	const testRoot = path.resolve(__dirname, '../envDir/re7NonIndexedAttrs');
+	const dbDir = path.join(testRoot, terms.DATABASES_DIR_NAME);
+
+	before(async () => {
+		setMainIsWorker(true);
+		await fs.remove(testRoot);
+		await fs.mkdirp(dbDir);
+		env.setProperty(terms.HDB_SETTINGS_NAMES.HDB_ROOT_KEY, testRoot);
+		env.setProperty(terms.CONFIG_PARAMS.ROOTPATH, testRoot);
+		env.setProperty(terms.CONFIG_PARAMS.STORAGE_PATH, dbDir);
+		env.setProperty(terms.CONFIG_PARAMS.DATABASES, {});
+
+		resetDatabases();
+		// Initial schema: only the primary key
+		table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }],
+		});
+		// Simulate hot-reload: call table() again with an expanded schema (non-indexed fields).
+		// This is what the graphqlSchema plugin does in a restarted worker.
+		table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'name' },
+				{ name: 'breed' },
+				{ name: 'age' },
+			],
+		});
+		// Simulate the ITC schema-change handler calling resetDatabases() in the main thread
+		// (the path that describe_database goes through).
+		resetDatabases();
+	});
+
+	after(async () => {
+		await fs.remove(testRoot);
+	});
+
+	it('table.attributes includes all non-indexed fields after resetDatabases()', () => {
+		const tbl = getDatabases()[DB]?.[TABLE];
+		assert.ok(tbl, `${DB}.${TABLE} should be registered after resetDatabases()`);
+		const attrNames = tbl.attributes.map((a) => a.name);
+		assert.ok(attrNames.includes('name'), `expected "name" in attributes, got: ${attrNames}`);
+		assert.ok(attrNames.includes('breed'), `expected "breed" in attributes, got: ${attrNames}`);
+		assert.ok(attrNames.includes('age'), `expected "age" in attributes, got: ${attrNames}`);
+	});
+
+	it('removes non-indexed attributes dropped from the schema after resetDatabases()', () => {
+		// Simulate schema shrinking (field removal), then another resetDatabases().
+		table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'name' },
+			],
+		});
+		resetDatabases();
+		const tbl = getDatabases()[DB]?.[TABLE];
+		const attrNames = tbl.attributes.map((a) => a.name);
+		assert.ok(attrNames.includes('name'), `expected "name" in attributes`);
+		assert.ok(!attrNames.includes('breed'), `"breed" should be removed, got: ${attrNames}`);
+		assert.ok(!attrNames.includes('age'), `"age" should be removed, got: ${attrNames}`);
+	});
+});
+
 describe('schema-migration fragility: stale store reused after LMDB to RocksDB engine migration (F4)', () => {
 	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
 

--- a/unitTests/resources/schemaMigrationFragility.test.js
+++ b/unitTests/resources/schemaMigrationFragility.test.js
@@ -400,14 +400,16 @@ describe('schema-migration fragility: non-indexed attributes missing from table.
 		env.setProperty(terms.CONFIG_PARAMS.DATABASES, {});
 
 		resetDatabases();
-		// Initial schema: only the primary key
+		// Initial schema: only the primary key — simulates the main thread's stale view
+		// before a worker restart expands the schema.
 		table({
 			table: TABLE,
 			database: DB,
 			attributes: [{ name: 'id', isPrimaryKey: true }],
 		});
-		// Simulate hot-reload: call table() again with an expanded schema (non-indexed fields).
-		// This is what the graphqlSchema plugin does in a restarted worker.
+		// Simulate a worker restart writing the expanded schema to attributesDbi.
+		// table() updates BOTH in-memory Table.attributes AND attributesDbi, so after
+		// this call attributesDbi has all four attributes.
 		table({
 			table: TABLE,
 			database: DB,
@@ -418,8 +420,15 @@ describe('schema-migration fragility: non-indexed attributes missing from table.
 				{ name: 'age' },
 			],
 		});
+		// Re-create the stale main-thread state: reset in-memory Table.attributes back to
+		// [id] only, while attributesDbi still has all four.  This is exactly the mismatch
+		// that exists on the main thread after a worker restarts and writes a new schema —
+		// the main thread's Table.attributes hasn't been updated yet.
+		const staleTable = getDatabases()[DB]?.[TABLE];
+		staleTable.attributes.splice(0, staleTable.attributes.length, { name: 'id', isPrimaryKey: true });
 		// Simulate the ITC schema-change handler calling resetDatabases() in the main thread
-		// (the path that describe_database goes through).
+		// (the path that describe_database goes through).  Without the fix, initStores()
+		// only re-syncs indexed/pk attributes and the non-indexed fields stay missing.
 		resetDatabases();
 	});
 


### PR DESCRIPTION
## Summary

- `describe_database` returned stale schema attributes after a hot-reload worker restart (new fields missing until full kill+restart)
- Root cause: `initStores()` in `resources/databases.ts` correctly handled the first-startup path (all attributes passed to `makeTable()`), but the existing-table update path — triggered after `resetDatabases()` on a worker restart — only merged back **indexed and primary-key** attributes; plain fields like `name: String` and `age: Int` were silently dropped
- Fix adds an `else if (!attribute.isPrimaryKey)` branch so non-indexed attributes are also updated/inserted in `existingAttributes`, plus a corresponding removal path for attributes no longer in the schema

## Test plan

- [ ] `unitTests/resources/schemaMigrationFragility.test.js` — two new regression tests added (both pass)
- [ ] Manual: `harper dev .` → edit `schema.graphql` to add fields → verify `describe_database` shows new fields without full restart

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)