### PR TITLE
fix(installer): warn when DEFAULTS_MODE is set to an unrecognized value (RE-6)

### DIFF
--- a/utility/install/installer.ts
+++ b/utility/install/installer.ts
@@ -527,6 +527,12 @@ async function createConfigFile(installParams) {
 			if (args[cfg.toLowerCase()] === undefined) args[cfg] = DEV_MODE_CONFIG[cfg];
 		}
 	} else {
+		const defaultsMode = installParams[hdbTerms.INSTALL_PROMPTS.DEFAULTS_MODE];
+		if (defaultsMode !== undefined && defaultsMode !== 'prod') {
+			const warn = `DEFAULTS_MODE value "${defaultsMode}" is not recognized (expected "dev" or "prod"). Using prod defaults.`;
+			console.error(chalk.yellow.bold(`Warning: ${warn}`));
+			hdbLogger.warn(warn);
+		}
 		if (args[CONFIG_PARAMS.OPERATIONSAPI_NETWORK_PORT.toLowerCase()])
 			args[CONFIG_PARAMS.OPERATIONSAPI_NETWORK_SECUREPORT] = null;
 		if (args[CONFIG_PARAMS.HTTP_PORT.toLowerCase()]) args[CONFIG_PARAMS.HTTP_SECUREPORT] = null;


### PR DESCRIPTION
## Summary

- Setting `DEFAULTS_MODE=1` (or any value besides `"dev"` or `"prod"`) silently fell through to prod defaults — HTTPS-only, auth required — with no feedback
- Adds a yellow `Warning:` line to stderr and the log before continuing, so users know why dev mode was not applied and what the valid values are

## Behavior

Before:
```
DEFAULTS_MODE=1 harper install ...
# → installs with prod defaults, HTTPS on 9926, auth required — no indication anything was wrong
```

After:
```
DEFAULTS_MODE=1 harper install ...
# Warning: DEFAULTS_MODE value "1" is not recognized (expected "dev" or "prod"). Using prod defaults.
# → installs with prod defaults (same behavior, but now visible)
```

## Test plan

- [ ] `DEFAULTS_MODE=1 harper install ...` → warning appears on stderr, install completes with prod defaults
- [ ] `DEFAULTS_MODE=dev harper install ...` → no warning, dev defaults applied as before
- [ ] `DEFAULTS_MODE=prod harper install ...` → no warning, prod defaults applied as before

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)