### PR TITLE
test(integration): custom jsResource patterns (#1190)

### DIFF
--- a/integrationTests/apiTests/custom-resources.test.ts
+++ b/integrationTests/apiTests/custom-resources.test.ts
@@ -51,7 +51,7 @@ type RedirectChange @table @export {
   createdAt: Date @createdTime
 }
 
-type AbusCounter @table(expiration: 10) @export {
+type AbuseCounter @table(expiration: 10) @export {
   id: ID @primaryKey
   count: Int
 }
@@ -86,7 +86,7 @@ export class RedirectRule extends tables.RedirectRule {
     }
     if (existing.length > 0) {
       const context = this.getContext();
-      context.response.status = 409;
+      if (context?.response) context.response.status = 409;
       return { error: 'Chain redirect detected' };
     }
     const id = Math.random().toString(36).slice(2);
@@ -133,8 +133,8 @@ export class RoutingDecision extends Resource {
   }
 }
 
-// AbusCounter: atomic counter with 403 threshold (Ford PasswordResetAbuse pattern)
-export class AbusCounter extends tables.AbusCounter {
+// AbuseCounter: atomic counter with 403 threshold (Ford PasswordResetAbuse pattern)
+export class AbuseCounter extends tables.AbuseCounter {
   async put(body, ctx) {
     // this is the loaded record instance; get current count from the stored record
     const current = await this.get();
@@ -142,7 +142,7 @@ export class AbusCounter extends tables.AbusCounter {
     const newCount = ((current && current.count) || 0) + 1;
     if (newCount > 5) {
       const context = this.getContext();
-      context.response.status = 403;
+      if (context?.response) context.response.status = 403;
       return { error: 'Too many attempts' };
     }
     // Full update via single-arg super.put (legacy: update(record, true) + save)
@@ -421,25 +421,25 @@ suite('Custom resource patterns', { skip: skipSuite }, (ctx) => {
 	// 6. Abuse counter with 403 threshold (Ford PasswordResetAbuse pattern)
 	// -----------------------------------------------------------------------
 
-	suite('AbusCounter: threshold enforcement', () => {
-		test('PUT AbusCounter increments count (attempts 1–5 succeed)', async () => {
+	suite('AbuseCounter: threshold enforcement', () => {
+		test('PUT AbuseCounter increments count (attempts 1–5 succeed)', async () => {
 			for (let i = 1; i <= 5; i++) {
-				const res = await restReq(httpURL, '/AbusCounter/counter1', 'PUT', { id: 'counter1' });
+				const res = await restReq(httpURL, '/AbuseCounter/counter1', 'PUT', { id: 'counter1' });
 				strictEqual(res.status, 200, `attempt ${i} unexpected status: ${res.status}`);
 				const body = (await res.json()) as Record<string, unknown>;
 				strictEqual(body.count, i, `attempt ${i} expected count=${i}, got: ${JSON.stringify(body)}`);
 			}
 		});
 
-		test('6th PUT AbusCounter returns 403', async () => {
-			const res = await restReq(httpURL, '/AbusCounter/counter1', 'PUT', { id: 'counter1' });
+		test('6th PUT AbuseCounter returns 403', async () => {
+			const res = await restReq(httpURL, '/AbuseCounter/counter1', 'PUT', { id: 'counter1' });
 			strictEqual(res.status, 403, `expected 403 on 6th attempt, got: ${res.status}`);
 			const body = (await res.json()) as Record<string, unknown>;
 			ok(typeof body.error === 'string', `expected error message on 403, got: ${JSON.stringify(body)}`);
 		});
 
 		test('independent counters do not interfere', async () => {
-			const res = await restReq(httpURL, '/AbusCounter/counter2', 'PUT', { id: 'counter2' });
+			const res = await restReq(httpURL, '/AbuseCounter/counter2', 'PUT', { id: 'counter2' });
 			strictEqual(res.status, 200, `first attempt on counter2 unexpected status: ${res.status}`);
 			const body = (await res.json()) as Record<string, unknown>;
 			strictEqual(body.count, 1, `expected count=1 for fresh counter, got: ${JSON.stringify(body)}`);

--- a/integrationTests/apiTests/custom-resources.test.ts
+++ b/integrationTests/apiTests/custom-resources.test.ts
@@ -1,0 +1,448 @@
+/**
+ * Custom jsResource integration tests.
+ *
+ * Validates custom resource patterns observed in production:
+ * - Async write-then-patch (CDI RT: enqueue + AI-inference result attachment)
+ * - Routing-decision endpoint with time-window filtering (Walmart USGM)
+ * - Immutable audit log (RedirectChange blocks external mutations)
+ * - Chain-redirect detection (409 on A→B when B→C would chain)
+ * - Abuse-counter threshold (Ford PasswordResetAbuse: 403 after N attempts)
+ *
+ * Self-contained: deploys an inline component with schema + resources JS and
+ * restarts http_workers. Skipped on Windows (restart_service http_workers
+ * crashes the Harper instance on Windows — see HarperFast/harper#549).
+ *
+ * Implements HarperFast/harper#1190.
+ */
+import { suite, test, before, after } from 'node:test';
+import { strictEqual, ok, deepStrictEqual } from 'node:assert/strict';
+import { startHarper, teardownHarper } from '@harperfast/integration-testing';
+import { createApiClient } from './utils/client.mjs';
+import { installAppComponent } from './utils/components.mjs';
+
+// ---------------------------------------------------------------------------
+// Component definition
+// ---------------------------------------------------------------------------
+
+const SCHEMA_GRAPHQL = `
+type WorkItem @table @export {
+  id: ID @primaryKey
+  state: String @indexed
+  payload: String
+  result: String
+  resultAt: Date @updatedTime
+}
+
+type RedirectRule @table @export @sealed {
+  id: ID @primaryKey
+  matchUrl: String @indexed
+  redirectUrl: String @indexed
+  statusCode: Int
+  startTime: Date
+  endTime: Date
+  createdBy: String
+}
+
+type RedirectChange @table @export {
+  id: ID @primaryKey
+  redirectId: String @indexed
+  operation: String
+  previousState: String
+  createdAt: Date @createdTime
+}
+
+type AbusCounter @table(expiration: 10) @export {
+  id: ID @primaryKey
+  count: Int
+}
+`;
+
+const RESOURCES_JS = `
+// WorkItem: async write-then-patch pattern (CDI RT enqueueing + AI inference result attachment)
+export class WorkItem extends tables.WorkItem {
+  async post(body, ctx) {
+    const id = Math.random().toString(36).slice(2);
+    // Use static class method to create a new record by explicit id
+    await tables.WorkItem.put({ id, state: 'pending', payload: JSON.stringify(body) });
+    return { id, state: 'pending' };
+  }
+  async patch(body, ctx) {
+    // this is the loaded record instance; doesExist() tells us if it was found
+    if (!this.doesExist()) return new Response(null, { status: 404 });
+    const current = await this.get();
+    // Full update via single-arg super.put (legacy: update(record, true) + save)
+    await super.put({ ...current, state: 'completed', result: body.result, resultAt: new Date() });
+    return { state: 'completed' };
+  }
+}
+
+// RedirectRule: routing decision with audit trail (Walmart USGM pattern)
+export class RedirectRule extends tables.RedirectRule {
+  async post(body, ctx) {
+    // chain detection: check if redirectUrl matches any existing matchUrl
+    const existing = [];
+    for await (const r of tables.RedirectRule.search({ conditions: [{ attribute: 'matchUrl', value: body.redirectUrl }] })) {
+      existing.push(r);
+    }
+    if (existing.length > 0) {
+      const context = this.getContext();
+      context.response.status = 409;
+      return { error: 'Chain redirect detected' };
+    }
+    const id = Math.random().toString(36).slice(2);
+    const user = this.getContext()?.user;
+    const record = { id, ...body, createdBy: user?.username || 'anonymous' };
+    // Write the redirect rule and audit record using static methods
+    await tables.RedirectRule.put(record);
+    await tables.RedirectChange.put({
+      id: Math.random().toString(36).slice(2),
+      redirectId: id,
+      operation: 'create',
+      previousState: null,
+    });
+    return record;
+  }
+}
+
+// Block external mutations on RedirectChange (audit log is immutable from outside)
+export class RedirectChange extends tables.RedirectChange {
+  post() { return new Response(null, { status: 405 }); }
+  put() { return new Response(null, { status: 405 }); }
+  patch() { return new Response(null, { status: 405 }); }
+  delete() { return new Response(null, { status: 405 }); }
+}
+
+// RoutingDecision: POST-only routing lookup endpoint (Walmart USGM)
+export class RoutingDecision extends Resource {
+  static loadAsInstance = false;
+  async post(query, body) {
+    const { path } = body;
+    if (!path) return {};
+    const now = new Date();
+    const rules = [];
+    for await (const r of tables.RedirectRule.search({ conditions: [{ attribute: 'matchUrl', value: path }] })) {
+      rules.push(r);
+    }
+    const rule = rules.find(r => {
+      if (r.startTime && new Date(r.startTime) > now) return false;
+      if (r.endTime && new Date(r.endTime) < now) return false;
+      return true;
+    });
+    if (rule) return { shouldRedirect: true, status: rule.statusCode || 302, location: rule.redirectUrl };
+    return {};
+  }
+}
+
+// AbusCounter: atomic counter with 403 threshold (Ford PasswordResetAbuse pattern)
+export class AbusCounter extends tables.AbusCounter {
+  async put(body, ctx) {
+    // this is the loaded record instance; get current count from the stored record
+    const current = await this.get();
+    const id = this.getId();
+    const newCount = ((current && current.count) || 0) + 1;
+    if (newCount > 5) {
+      const context = this.getContext();
+      context.response.status = 403;
+      return { error: 'Too many attempts' };
+    }
+    // Full update via single-arg super.put (legacy: update(record, true) + save)
+    await super.put({ id, count: newCount });
+    return { count: newCount };
+  }
+}
+`;
+
+const CONFIG_YAML = `graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true
+`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const skipSuite = process.platform === 'win32';
+
+/** Issue a REST request against the running Harper instance. */
+function restReq(httpURL: string, path: string, method: string, body?: unknown, headers: Record<string, string> = {}) {
+	const opts: RequestInit = {
+		method,
+		headers: { 'Content-Type': 'application/json', ...headers },
+	};
+	if (body !== undefined) opts.body = JSON.stringify(body);
+	return fetch(`${httpURL}${path}`, opts);
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+suite('Custom resource patterns', { skip: skipSuite }, (ctx) => {
+	let client: ReturnType<typeof createApiClient>;
+	let httpURL: string;
+
+	before(async () => {
+		await startHarper(ctx, { config: {}, env: {} });
+		client = createApiClient(ctx.harper);
+		httpURL = ctx.harper.httpURL;
+
+		await installAppComponent(client, {
+			project: 'customResources',
+			files: {
+				'schema.graphql': SCHEMA_GRAPHQL,
+				'resources.js': RESOURCES_JS,
+				'config.yaml': CONFIG_YAML,
+			},
+			probePath: '/WorkItem/',
+			restartTimeoutMs: 120_000,
+		});
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	// -----------------------------------------------------------------------
+	// 1. Async write-then-patch (CDI RT pattern)
+	// -----------------------------------------------------------------------
+
+	suite('WorkItem: async write-then-patch', () => {
+		let workItemId: string;
+
+		test('POST WorkItem enqueues with pending state', async () => {
+			const res = await restReq(httpURL, '/WorkItem/', 'POST', { task: 'infer', input: 'hello' });
+			strictEqual(res.status, 200, `unexpected status: ${res.status}`);
+			const body = (await res.json()) as Record<string, unknown>;
+			ok(typeof body.id === 'string' && body.id.length > 0, `expected id string, got: ${JSON.stringify(body)}`);
+			strictEqual(body.state, 'pending', `expected pending state, got: ${JSON.stringify(body)}`);
+			workItemId = body.id as string;
+		});
+
+		test('PATCH WorkItem/:id attaches result and moves to completed', async () => {
+			const res = await restReq(httpURL, `/WorkItem/${workItemId}`, 'PATCH', { result: 'positive' });
+			strictEqual(res.status, 200, `unexpected status: ${res.status}`);
+			const body = (await res.json()) as Record<string, unknown>;
+			strictEqual(body.state, 'completed', `expected completed state, got: ${JSON.stringify(body)}`);
+		});
+
+		test('GET WorkItem/:id returns completed record with result', async () => {
+			const res = await restReq(httpURL, `/WorkItem/${workItemId}`, 'GET');
+			strictEqual(res.status, 200, `unexpected status: ${res.status}`);
+			const body = (await res.json()) as Record<string, unknown>;
+			strictEqual(body.state, 'completed', `expected completed state, got: ${JSON.stringify(body)}`);
+			strictEqual(body.result, 'positive', `expected result, got: ${JSON.stringify(body)}`);
+		});
+
+		test('PATCH nonexistent WorkItem returns 404', async () => {
+			const res = await restReq(httpURL, '/WorkItem/does-not-exist-xyz', 'PATCH', { result: 'nope' });
+			strictEqual(res.status, 404, `expected 404, got: ${res.status}`);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// 2. Routing decision — basic lookup (Walmart USGM pattern)
+	// -----------------------------------------------------------------------
+
+	suite('RoutingDecision: POST routing lookup', () => {
+		test('POST /RoutingDecision with unknown path returns empty object', async () => {
+			const res = await restReq(httpURL, '/RoutingDecision/', 'POST', { path: '/no-such-path' });
+			strictEqual(res.status, 200, `unexpected status: ${res.status}`);
+			const body = await res.json();
+			deepStrictEqual(body, {}, `expected empty routing result, got: ${JSON.stringify(body)}`);
+		});
+
+		test('POST /RoutingDecision with missing path returns empty object', async () => {
+			const res = await restReq(httpURL, '/RoutingDecision/', 'POST', {});
+			strictEqual(res.status, 200, `unexpected status: ${res.status}`);
+			const body = await res.json();
+			deepStrictEqual(body, {}, `expected empty routing result, got: ${JSON.stringify(body)}`);
+		});
+
+		test('POST /RoutingDecision after adding a rule returns redirect info', async () => {
+			// Create a rule for /foo → /bar
+			const ruleRes = await restReq(httpURL, '/RedirectRule/', 'POST', {
+				matchUrl: '/foo',
+				redirectUrl: '/bar',
+				statusCode: 302,
+			});
+			strictEqual(ruleRes.status, 200, `rule creation failed: ${ruleRes.status}`);
+
+			const res = await restReq(httpURL, '/RoutingDecision/', 'POST', { path: '/foo' });
+			strictEqual(res.status, 200, `unexpected status: ${res.status}`);
+			const body = (await res.json()) as Record<string, unknown>;
+			strictEqual(body.shouldRedirect, true, `expected shouldRedirect, got: ${JSON.stringify(body)}`);
+			strictEqual(body.status, 302, `expected status 302, got: ${JSON.stringify(body)}`);
+			strictEqual(body.location, '/bar', `expected location /bar, got: ${JSON.stringify(body)}`);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// 3. Time-window filtering
+	// -----------------------------------------------------------------------
+
+	suite('RoutingDecision: time-window filtering', () => {
+		test('rule with future startTime is not active', async () => {
+			const futureStart = new Date(Date.now() + 3_600_000).toISOString(); // 1 hour from now
+			await restReq(httpURL, '/RedirectRule/', 'POST', {
+				matchUrl: '/future-path',
+				redirectUrl: '/future-target',
+				statusCode: 301,
+				startTime: futureStart,
+			});
+
+			const res = await restReq(httpURL, '/RoutingDecision/', 'POST', { path: '/future-path' });
+			strictEqual(res.status, 200, `unexpected status: ${res.status}`);
+			const body = await res.json();
+			deepStrictEqual(body, {}, `rule with future startTime should not match, got: ${JSON.stringify(body)}`);
+		});
+
+		test('rule with past endTime is not active', async () => {
+			const pastEnd = new Date(Date.now() - 3_600_000).toISOString(); // 1 hour ago
+			await restReq(httpURL, '/RedirectRule/', 'POST', {
+				matchUrl: '/expired-path',
+				redirectUrl: '/expired-target',
+				statusCode: 301,
+				endTime: pastEnd,
+			});
+
+			const res = await restReq(httpURL, '/RoutingDecision/', 'POST', { path: '/expired-path' });
+			strictEqual(res.status, 200, `unexpected status: ${res.status}`);
+			const body = await res.json();
+			deepStrictEqual(body, {}, `expired rule should not match, got: ${JSON.stringify(body)}`);
+		});
+
+		test('rule with no time constraints matches immediately', async () => {
+			await restReq(httpURL, '/RedirectRule/', 'POST', {
+				matchUrl: '/always-active',
+				redirectUrl: '/always-target',
+				statusCode: 302,
+			});
+
+			const res = await restReq(httpURL, '/RoutingDecision/', 'POST', { path: '/always-active' });
+			strictEqual(res.status, 200, `unexpected status: ${res.status}`);
+			const body = (await res.json()) as Record<string, unknown>;
+			strictEqual(body.shouldRedirect, true, `expected shouldRedirect, got: ${JSON.stringify(body)}`);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// 4. Immutable audit log
+	// -----------------------------------------------------------------------
+
+	suite('RedirectChange: immutable audit log', () => {
+		test('POST /RedirectChange returns 405', async () => {
+			const res = await restReq(httpURL, '/RedirectChange/', 'POST', {
+				redirectId: 'manual',
+				operation: 'create',
+			});
+			strictEqual(res.status, 405, `expected 405 on POST, got: ${res.status}`);
+		});
+
+		test('PUT /RedirectChange/:id returns 405', async () => {
+			const res = await restReq(httpURL, '/RedirectChange/manual-id', 'PUT', {
+				redirectId: 'manual',
+				operation: 'create',
+			});
+			strictEqual(res.status, 405, `expected 405 on PUT, got: ${res.status}`);
+		});
+
+		test('PATCH /RedirectChange/:id returns 405', async () => {
+			const res = await restReq(httpURL, '/RedirectChange/manual-id', 'PATCH', { operation: 'modified' });
+			strictEqual(res.status, 405, `expected 405 on PATCH, got: ${res.status}`);
+		});
+
+		test('DELETE /RedirectChange/:id returns 405', async () => {
+			const res = await restReq(httpURL, '/RedirectChange/manual-id', 'DELETE');
+			strictEqual(res.status, 405, `expected 405 on DELETE, got: ${res.status}`);
+		});
+
+		test('creating a RedirectRule auto-writes an audit entry', async () => {
+			// Create a rule; the resource JS writes a RedirectChange entry
+			const ruleRes = await restReq(httpURL, '/RedirectRule/', 'POST', {
+				matchUrl: '/audit-test',
+				redirectUrl: '/audit-target',
+				statusCode: 302,
+			});
+			strictEqual(ruleRes.status, 200, `rule creation failed: ${ruleRes.status}`);
+			const rule = (await ruleRes.json()) as Record<string, unknown>;
+			const ruleId = rule.id as string;
+
+			// Poll the audit log until the entry appears (async write)
+			const deadline = Date.now() + 10_000;
+			let auditEntries: unknown[] = [];
+			while (Date.now() < deadline) {
+				const listRes = await restReq(httpURL, '/RedirectChange/', 'GET');
+				if (listRes.status === 200) {
+					const all = (await listRes.json()) as unknown[];
+					auditEntries = (all ?? []).filter((e: unknown) => (e as Record<string, unknown>).redirectId === ruleId);
+					if (auditEntries.length > 0) break;
+				}
+				await new Promise((resolve) => setTimeout(resolve, 200));
+			}
+
+			ok(auditEntries.length > 0, `expected audit entry for redirectId ${ruleId}, found none`);
+			const entry = auditEntries[0] as Record<string, unknown>;
+			strictEqual(entry.operation, 'create', `expected operation=create, got: ${JSON.stringify(entry)}`);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// 5. Chain-redirect detection
+	// -----------------------------------------------------------------------
+
+	suite('RedirectRule: chain detection', () => {
+		test('creating a chain redirect (A→B when B→C exists) returns 409', async () => {
+			// Create rule B→C first
+			const bcRes = await restReq(httpURL, '/RedirectRule/', 'POST', {
+				matchUrl: '/chain-b',
+				redirectUrl: '/chain-c',
+				statusCode: 302,
+			});
+			strictEqual(bcRes.status, 200, `rule B→C creation failed: ${bcRes.status}`);
+
+			// Attempt to create rule A→B (would chain since B is already a matchUrl)
+			const abRes = await restReq(httpURL, '/RedirectRule/', 'POST', {
+				matchUrl: '/chain-a',
+				redirectUrl: '/chain-b',
+				statusCode: 302,
+			});
+			strictEqual(abRes.status, 409, `expected 409 for chain redirect, got: ${abRes.status}`);
+			const body = (await abRes.json()) as Record<string, unknown>;
+			ok(
+				typeof body.error === 'string' && body.error.toLowerCase().includes('chain'),
+				`expected chain error message, got: ${JSON.stringify(body)}`
+			);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// 6. Abuse counter with 403 threshold (Ford PasswordResetAbuse pattern)
+	// -----------------------------------------------------------------------
+
+	suite('AbusCounter: threshold enforcement', () => {
+		test('PUT AbusCounter increments count (attempts 1–5 succeed)', async () => {
+			for (let i = 1; i <= 5; i++) {
+				const res = await restReq(httpURL, '/AbusCounter/counter1', 'PUT', { id: 'counter1' });
+				strictEqual(res.status, 200, `attempt ${i} unexpected status: ${res.status}`);
+				const body = (await res.json()) as Record<string, unknown>;
+				strictEqual(body.count, i, `attempt ${i} expected count=${i}, got: ${JSON.stringify(body)}`);
+			}
+		});
+
+		test('6th PUT AbusCounter returns 403', async () => {
+			const res = await restReq(httpURL, '/AbusCounter/counter1', 'PUT', { id: 'counter1' });
+			strictEqual(res.status, 403, `expected 403 on 6th attempt, got: ${res.status}`);
+			const body = (await res.json()) as Record<string, unknown>;
+			ok(typeof body.error === 'string', `expected error message on 403, got: ${JSON.stringify(body)}`);
+		});
+
+		test('independent counters do not interfere', async () => {
+			const res = await restReq(httpURL, '/AbusCounter/counter2', 'PUT', { id: 'counter2' });
+			strictEqual(res.status, 200, `first attempt on counter2 unexpected status: ${res.status}`);
+			const body = (await res.json()) as Record<string, unknown>;
+			strictEqual(body.count, 1, `expected count=1 for fresh counter, got: ${JSON.stringify(body)}`);
+		});
+	});
+});

--- a/integrationTests/fixtures/custom-resources/config.yaml
+++ b/integrationTests/fixtures/custom-resources/config.yaml
@@ -1,0 +1,5 @@
+graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/fixtures/custom-resources/resources.js
+++ b/integrationTests/fixtures/custom-resources/resources.js
@@ -1,0 +1,102 @@
+// WorkItem: async write-then-patch pattern (CDI RT enqueueing + AI inference result attachment)
+export class WorkItem extends tables.WorkItem {
+	async post(body, _ctx) {
+		const id = Math.random().toString(36).slice(2);
+		// Use static class method to create a new record by explicit id
+		await tables.WorkItem.put({ id, state: 'pending', payload: JSON.stringify(body) });
+		return { id, state: 'pending' };
+	}
+	async patch(body, _ctx) {
+		// this is the loaded record instance; doesExist() tells us if it was found
+		if (!this.doesExist()) return new Response(null, { status: 404 });
+		const current = await this.get();
+		// Full update via single-arg super.put (legacy: update(record, true) + save)
+		await super.put({ ...current, state: 'completed', result: body.result, resultAt: new Date() });
+		return { state: 'completed' };
+	}
+}
+
+// RedirectRule: routing decision with audit trail (Walmart USGM pattern)
+export class RedirectRule extends tables.RedirectRule {
+	async post(body, _ctx) {
+		// chain detection: check if redirectUrl matches any existing matchUrl
+		const existing = [];
+		for await (const r of tables.RedirectRule.search({
+			conditions: [{ attribute: 'matchUrl', value: body.redirectUrl }],
+		})) {
+			existing.push(r);
+		}
+		if (existing.length > 0) {
+			const context = this.getContext();
+			if (context?.response) context.response.status = 409;
+			return { error: 'Chain redirect detected' };
+		}
+		const id = Math.random().toString(36).slice(2);
+		const user = this.getContext()?.user;
+		const record = { id, ...body, createdBy: user?.username || 'anonymous' };
+		// Write the redirect rule and audit record using static methods
+		await tables.RedirectRule.put(record);
+		await tables.RedirectChange.put({
+			id: Math.random().toString(36).slice(2),
+			redirectId: id,
+			operation: 'create',
+			previousState: null,
+		});
+		return record;
+	}
+}
+
+// Block external mutations on RedirectChange (audit log is immutable from outside)
+export class RedirectChange extends tables.RedirectChange {
+	post() {
+		return new Response(null, { status: 405 });
+	}
+	put() {
+		return new Response(null, { status: 405 });
+	}
+	patch() {
+		return new Response(null, { status: 405 });
+	}
+	delete() {
+		return new Response(null, { status: 405 });
+	}
+}
+
+// RoutingDecision: POST-only routing lookup endpoint (Walmart USGM)
+export class RoutingDecision extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		const { path } = body;
+		if (!path) return {};
+		const now = new Date();
+		const rules = [];
+		for await (const r of tables.RedirectRule.search({ conditions: [{ attribute: 'matchUrl', value: path }] })) {
+			rules.push(r);
+		}
+		const rule = rules.find((r) => {
+			if (r.startTime && new Date(r.startTime) > now) return false;
+			if (r.endTime && new Date(r.endTime) < now) return false;
+			return true;
+		});
+		if (rule) return { shouldRedirect: true, status: rule.statusCode || 302, location: rule.redirectUrl };
+		return {};
+	}
+}
+
+// AbuseCounter: atomic counter with 403 threshold (Ford PasswordResetAbuse pattern)
+export class AbuseCounter extends tables.AbuseCounter {
+	async put(_body, _ctx) {
+		// this is the loaded record instance; get current count from the stored record
+		const current = await this.get();
+		const id = this.getId();
+		const newCount = ((current && current.count) || 0) + 1;
+		if (newCount > 5) {
+			const context = this.getContext();
+			if (context?.response) context.response.status = 403;
+			return { error: 'Too many attempts' };
+		}
+		// Full update via single-arg super.put (legacy: update(record, true) + save)
+		await super.put({ id, count: newCount });
+		return { count: newCount };
+	}
+}

--- a/integrationTests/fixtures/custom-resources/schema.graphql
+++ b/integrationTests/fixtures/custom-resources/schema.graphql
@@ -1,0 +1,30 @@
+type WorkItem @table @export {
+	id: ID @primaryKey
+	state: String @indexed
+	payload: String
+	result: String
+	resultAt: Date @updatedTime
+}
+
+type RedirectRule @table @export @sealed {
+	id: ID @primaryKey
+	matchUrl: String @indexed
+	redirectUrl: String @indexed
+	statusCode: Int
+	startTime: Date
+	endTime: Date
+	createdBy: String
+}
+
+type RedirectChange @table @export {
+	id: ID @primaryKey
+	redirectId: String @indexed
+	operation: String
+	previousState: String
+	createdAt: Date @createdTime
+}
+
+type AbuseCounter @table(expiration: 10) @export {
+	id: ID @primaryKey
+	count: Int
+}

--- a/integrationTests/resources/custom-resources.test.ts
+++ b/integrationTests/resources/custom-resources.test.ts
@@ -8,156 +8,23 @@
  * - Chain-redirect detection (409 on A→B when B→C would chain)
  * - Abuse-counter threshold (Ford PasswordResetAbuse: 403 after N attempts)
  *
- * Self-contained: deploys an inline component with schema + resources JS and
- * restarts http_workers. Skipped on Windows (restart_service http_workers
- * crashes the Harper instance on Windows — see HarperFast/harper#549).
+ * Component files live in integrationTests/fixtures/custom-resources/.
+ * Skipped on Windows (restart_service http_workers crashes the Harper instance
+ * on Windows — see HarperFast/harper#549).
  *
  * Implements HarperFast/harper#1190.
  */
 import { suite, test, before, after } from 'node:test';
 import { strictEqual, ok, deepStrictEqual } from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { startHarper, teardownHarper } from '@harperfast/integration-testing';
-import { createApiClient } from './utils/client.mjs';
-import { installAppComponent } from './utils/components.mjs';
+import { createApiClient } from '../apiTests/utils/client.mjs';
+import { installAppComponent } from '../apiTests/utils/components.mjs';
 
-// ---------------------------------------------------------------------------
-// Component definition
-// ---------------------------------------------------------------------------
-
-const SCHEMA_GRAPHQL = `
-type WorkItem @table @export {
-  id: ID @primaryKey
-  state: String @indexed
-  payload: String
-  result: String
-  resultAt: Date @updatedTime
-}
-
-type RedirectRule @table @export @sealed {
-  id: ID @primaryKey
-  matchUrl: String @indexed
-  redirectUrl: String @indexed
-  statusCode: Int
-  startTime: Date
-  endTime: Date
-  createdBy: String
-}
-
-type RedirectChange @table @export {
-  id: ID @primaryKey
-  redirectId: String @indexed
-  operation: String
-  previousState: String
-  createdAt: Date @createdTime
-}
-
-type AbuseCounter @table(expiration: 10) @export {
-  id: ID @primaryKey
-  count: Int
-}
-`;
-
-const RESOURCES_JS = `
-// WorkItem: async write-then-patch pattern (CDI RT enqueueing + AI inference result attachment)
-export class WorkItem extends tables.WorkItem {
-  async post(body, ctx) {
-    const id = Math.random().toString(36).slice(2);
-    // Use static class method to create a new record by explicit id
-    await tables.WorkItem.put({ id, state: 'pending', payload: JSON.stringify(body) });
-    return { id, state: 'pending' };
-  }
-  async patch(body, ctx) {
-    // this is the loaded record instance; doesExist() tells us if it was found
-    if (!this.doesExist()) return new Response(null, { status: 404 });
-    const current = await this.get();
-    // Full update via single-arg super.put (legacy: update(record, true) + save)
-    await super.put({ ...current, state: 'completed', result: body.result, resultAt: new Date() });
-    return { state: 'completed' };
-  }
-}
-
-// RedirectRule: routing decision with audit trail (Walmart USGM pattern)
-export class RedirectRule extends tables.RedirectRule {
-  async post(body, ctx) {
-    // chain detection: check if redirectUrl matches any existing matchUrl
-    const existing = [];
-    for await (const r of tables.RedirectRule.search({ conditions: [{ attribute: 'matchUrl', value: body.redirectUrl }] })) {
-      existing.push(r);
-    }
-    if (existing.length > 0) {
-      const context = this.getContext();
-      if (context?.response) context.response.status = 409;
-      return { error: 'Chain redirect detected' };
-    }
-    const id = Math.random().toString(36).slice(2);
-    const user = this.getContext()?.user;
-    const record = { id, ...body, createdBy: user?.username || 'anonymous' };
-    // Write the redirect rule and audit record using static methods
-    await tables.RedirectRule.put(record);
-    await tables.RedirectChange.put({
-      id: Math.random().toString(36).slice(2),
-      redirectId: id,
-      operation: 'create',
-      previousState: null,
-    });
-    return record;
-  }
-}
-
-// Block external mutations on RedirectChange (audit log is immutable from outside)
-export class RedirectChange extends tables.RedirectChange {
-  post() { return new Response(null, { status: 405 }); }
-  put() { return new Response(null, { status: 405 }); }
-  patch() { return new Response(null, { status: 405 }); }
-  delete() { return new Response(null, { status: 405 }); }
-}
-
-// RoutingDecision: POST-only routing lookup endpoint (Walmart USGM)
-export class RoutingDecision extends Resource {
-  static loadAsInstance = false;
-  async post(query, body) {
-    const { path } = body;
-    if (!path) return {};
-    const now = new Date();
-    const rules = [];
-    for await (const r of tables.RedirectRule.search({ conditions: [{ attribute: 'matchUrl', value: path }] })) {
-      rules.push(r);
-    }
-    const rule = rules.find(r => {
-      if (r.startTime && new Date(r.startTime) > now) return false;
-      if (r.endTime && new Date(r.endTime) < now) return false;
-      return true;
-    });
-    if (rule) return { shouldRedirect: true, status: rule.statusCode || 302, location: rule.redirectUrl };
-    return {};
-  }
-}
-
-// AbuseCounter: atomic counter with 403 threshold (Ford PasswordResetAbuse pattern)
-export class AbuseCounter extends tables.AbuseCounter {
-  async put(body, ctx) {
-    // this is the loaded record instance; get current count from the stored record
-    const current = await this.get();
-    const id = this.getId();
-    const newCount = ((current && current.count) || 0) + 1;
-    if (newCount > 5) {
-      const context = this.getContext();
-      if (context?.response) context.response.status = 403;
-      return { error: 'Too many attempts' };
-    }
-    // Full update via single-arg super.put (legacy: update(record, true) + save)
-    await super.put({ id, count: newCount });
-    return { count: newCount };
-  }
-}
-`;
-
-const CONFIG_YAML = `graphqlSchema:
-  files: '*.graphql'
-jsResource:
-  files: resources.js
-rest: true
-`;
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = join(__dirname, '../fixtures/custom-resources');
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -191,9 +58,9 @@ suite('Custom resource patterns', { skip: skipSuite }, (ctx) => {
 		await installAppComponent(client, {
 			project: 'customResources',
 			files: {
-				'schema.graphql': SCHEMA_GRAPHQL,
-				'resources.js': RESOURCES_JS,
-				'config.yaml': CONFIG_YAML,
+				'schema.graphql': readFileSync(join(FIXTURE_DIR, 'schema.graphql'), 'utf-8'),
+				'resources.js': readFileSync(join(FIXTURE_DIR, 'resources.js'), 'utf-8'),
+				'config.yaml': readFileSync(join(FIXTURE_DIR, 'config.yaml'), 'utf-8'),
 			},
 			probePath: '/WorkItem/',
 			restartTimeoutMs: 120_000,

--- a/integrationTests/resources/custom-resources.test.ts
+++ b/integrationTests/resources/custom-resources.test.ts
@@ -17,12 +17,10 @@
 import { suite, test, before, after } from 'node:test';
 import { strictEqual, ok, deepStrictEqual } from 'node:assert/strict';
 import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { setupHarperWithFixture, teardownHarper } from '@harperfast/integration-testing';
 import { createApiClient } from '../apiTests/utils/client.mjs';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
-const FIXTURE_PATH = resolve(__dirname, '../fixtures/custom-resources');
+const FIXTURE_PATH = resolve(import.meta.dirname, '../fixtures/custom-resources');
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/integrationTests/resources/custom-resources.test.ts
+++ b/integrationTests/resources/custom-resources.test.ts
@@ -16,15 +16,13 @@
  */
 import { suite, test, before, after } from 'node:test';
 import { strictEqual, ok, deepStrictEqual } from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { startHarper, teardownHarper } from '@harperfast/integration-testing';
+import { setupHarperWithFixture, teardownHarper } from '@harperfast/integration-testing';
 import { createApiClient } from '../apiTests/utils/client.mjs';
-import { installAppComponent } from '../apiTests/utils/components.mjs';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const FIXTURE_DIR = join(__dirname, '../fixtures/custom-resources');
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const FIXTURE_PATH = resolve(__dirname, '../fixtures/custom-resources');
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -47,24 +45,28 @@ function restReq(httpURL: string, path: string, method: string, body?: unknown, 
 // ---------------------------------------------------------------------------
 
 suite('Custom resource patterns', { skip: skipSuite }, (ctx) => {
-	let client: ReturnType<typeof createApiClient>;
+	let _client: ReturnType<typeof createApiClient>;
 	let httpURL: string;
 
 	before(async () => {
-		await startHarper(ctx, { config: {}, env: {} });
-		client = createApiClient(ctx.harper);
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: {}, env: {} });
+		_client = createApiClient(ctx.harper);
 		httpURL = ctx.harper.httpURL;
 
-		await installAppComponent(client, {
-			project: 'customResources',
-			files: {
-				'schema.graphql': readFileSync(join(FIXTURE_DIR, 'schema.graphql'), 'utf-8'),
-				'resources.js': readFileSync(join(FIXTURE_DIR, 'resources.js'), 'utf-8'),
-				'config.yaml': readFileSync(join(FIXTURE_DIR, 'config.yaml'), 'utf-8'),
-			},
-			probePath: '/WorkItem/',
-			restartTimeoutMs: 120_000,
-		});
+		// Poll until WorkItem route is ready (may take a moment after startHarper resolves)
+		const deadline = Date.now() + 30_000;
+		while (Date.now() < deadline) {
+			try {
+				const probe = await fetch(`${httpURL}/WorkItem/`, {
+					method: 'GET',
+					headers: { 'Content-Type': 'application/json' },
+				});
+				if (probe.status !== 404) break;
+			} catch {
+				// connection not yet ready
+			}
+			await new Promise((r) => setTimeout(r, 200));
+		}
 	});
 
 	after(async () => {


### PR DESCRIPTION
## Summary

Closes #1190.

Adds `integrationTests/apiTests/custom-resources.test.ts` — a self-contained integration test that deploys an inline component (schema + resources.js + config.yaml) and validates five real-world custom jsResource patterns:

- **Async write-then-patch** (CDI RT pattern): POST to enqueue with `pending` state; PATCH to attach AI-inference result and flip to `completed`.
- **Routing decision with time-window filtering** (Walmart USGM): `RoutingDecision` POST endpoint does indexed lookup + active-window guard (`startTime`/`endTime`); returns `{}` for no match or future/expired rules.
- **Immutable audit log** (`RedirectChange`): all external mutations (POST/PUT/PATCH/DELETE) return 405; creating a `RedirectRule` auto-writes a `RedirectChange` audit entry.
- **Chain-redirect detection**: creating rule A→B when B→C already exists returns 409.
- **Abuse-counter threshold** (Ford PasswordResetAbuse): atomic counter via instance `put`; 6th attempt returns 403.

All 19 tests pass. No source files changed.

## Test plan

- [x] `npm run test:integration -- "integrationTests/apiTests/custom-resources.test.ts"` → 19 pass, 0 fail
- [x] `npm run format:write` — no changes
- [x] `npm run lint:required` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)