### PR TITLE
test: establish docs-mirrored directory structure for integration tests (database/, resources/, mqtt/)

### DIFF
--- a/integrationTests/README.md
+++ b/integrationTests/README.md
@@ -4,17 +4,17 @@
 
 Directory structure mirrors the [Harper v5 reference docs](https://docs.harperdb.io/reference/v5):
 
-| Directory | Coverage |
-|---|---|
-| `database/` | Schema types, TTL, blob, scale |
-| `resources/` | Custom resources, REST API patterns |
-| `mqtt/` | MQTT broker, JWT auth, ACL, topic patterns |
-| `server/` | Caching (sourcedFrom, SWR), thread management, crash recovery |
-| `components/` | Component deployment, lifecycle, fixtures |
-| `security/` | TLS, certificates, auth |
-| `operations-api/` | Operations API, CLI commands |
-| `upgrade/` | v4→v5 upgrade / migration tests |
-| `apiTests/` | Legacy bucket — being migrated to the above (see #1215) |
+| Directory         | Coverage                                                      |
+| ----------------- | ------------------------------------------------------------- |
+| `database/`       | Schema types, TTL, blob, scale                                |
+| `resources/`      | Custom resources, REST API patterns                           |
+| `mqtt/`           | MQTT broker, JWT auth, ACL, topic patterns                    |
+| `server/`         | Caching (sourcedFrom, SWR), thread management, crash recovery |
+| `components/`     | Component deployment, lifecycle, fixtures                     |
+| `security/`       | TLS, certificates, auth                                       |
+| `operations-api/` | Operations API, CLI commands                                  |
+| `upgrade/`        | v4→v5 upgrade / migration tests                               |
+| `apiTests/`       | Legacy bucket — being migrated to the above (see #1215)       |
 
 New tests should go in the appropriate subdirectory, not `apiTests/`.
 

--- a/integrationTests/README.md
+++ b/integrationTests/README.md
@@ -1,5 +1,25 @@
 # Harper Integration Tests
 
+## Directory Structure
+
+Directory structure mirrors the [Harper v5 reference docs](https://docs.harperdb.io/reference/v5):
+
+| Directory | Coverage |
+|---|---|
+| `database/` | Schema types, TTL, blob, scale |
+| `resources/` | Custom resources, REST API patterns |
+| `mqtt/` | MQTT broker, JWT auth, ACL, topic patterns |
+| `server/` | Caching (sourcedFrom, SWR), thread management, crash recovery |
+| `components/` | Component deployment, lifecycle, fixtures |
+| `security/` | TLS, certificates, auth |
+| `operations-api/` | Operations API, CLI commands |
+| `upgrade/` | v4→v5 upgrade / migration tests |
+| `apiTests/` | Legacy bucket — being migrated to the above (see #1215) |
+
+New tests should go in the appropriate subdirectory, not `apiTests/`.
+
+---
+
 This directory contains the integration tests for Harper. They run against the built Harper distribution using the [`@harperfast/integration-testing`](https://github.com/HarperFast/integration-testing-framework) framework and the included Node.js test runner script.
 
 For full background on the testing philosophy, framework APIs, and runner configuration, see the **[`@harperfast/integration-testing` documentation](https://github.com/HarperFast/integration-testing-framework#readme)**. This document covers what is specific to running and writing tests in this repository.

--- a/integrationTests/database/README.md
+++ b/integrationTests/database/README.md
@@ -1,4 +1,5 @@
 # database/
+
 Integration tests for Harper database features: schema types, TTL/expiration, blob storage, and large-scale data patterns.
 
 Incoming: `ttl.test.ts` from HarperFast/harper#1210.

--- a/integrationTests/database/README.md
+++ b/integrationTests/database/README.md
@@ -1,0 +1,6 @@
+# database/
+Integration tests for Harper database features: schema types, TTL/expiration, blob storage, and large-scale data patterns.
+
+Incoming: `ttl.test.ts` from HarperFast/harper#1210.
+
+See also: `unitTests/resources/` for unit-level coverage of the same features.

--- a/integrationTests/mqtt/README.md
+++ b/integrationTests/mqtt/README.md
@@ -1,4 +1,5 @@
 # mqtt/
+
 Integration tests for the MQTT broker: JWT auth, ACL enforcement, and topic patterns.
 
 Incoming: `mqtt.test.ts` from HarperFast/harper#1211.

--- a/integrationTests/mqtt/README.md
+++ b/integrationTests/mqtt/README.md
@@ -1,0 +1,6 @@
+# mqtt/
+Integration tests for the MQTT broker: JWT auth, ACL enforcement, and topic patterns.
+
+Incoming: `mqtt.test.ts` from HarperFast/harper#1211.
+
+See also: `unitTests/` for unit-level coverage of the same features.

--- a/integrationTests/resources/README.md
+++ b/integrationTests/resources/README.md
@@ -1,0 +1,6 @@
+# resources/
+Integration tests for custom resources, REST API patterns, and routing.
+
+Incoming: `custom-resources.test.ts` from HarperFast/harper#1209.
+
+See also: `unitTests/resources/` for unit-level coverage of the same features.

--- a/integrationTests/resources/README.md
+++ b/integrationTests/resources/README.md
@@ -1,4 +1,5 @@
 # resources/
+
 Integration tests for custom resources, REST API patterns, and routing.
 
 Incoming: `custom-resources.test.ts` from HarperFast/harper#1209.


### PR DESCRIPTION
## Summary

Scaffold PR that establishes the docs-mirrored directory structure for `integrationTests/` **before** the feature PRs merge (no test files moved yet — the incoming PRs will land their files in the right place).

- Creates `integrationTests/database/`, `integrationTests/resources/`, and `integrationTests/mqtt/` with brief README.md placeholders referencing the incoming PRs
- Updates `integrationTests/README.md` with a directory map mirroring the [Harper v5 reference docs](https://docs.harperdb.io/reference/v5), directing new tests away from the legacy `apiTests/` bucket

Addresses the structural concern raised in #1211 review (thanks @Ethan-Arrowood). Tracking issue: #1215.

### Incoming PRs and their target directories

| PR | File | Target directory |
|---|---|---|
| #1210 | `ttl.test.ts` | `integrationTests/database/` |
| #1209 | `custom-resources.test.ts` | `integrationTests/resources/` |
| #1211 | `mqtt.test.ts` | `integrationTests/mqtt/` |
| #1208 | `caching.test.ts` | `integrationTests/server/` (already reasonable) |

## Test plan

- [ ] Verify new directories appear with README.md files
- [ ] Verify `integrationTests/README.md` directory table is accurate
- [ ] No existing files in `integrationTests/apiTests/` were touched (pure adds only)

---
*Signed: Claude*