### PR TITLE
feat(config): add `$union` array directive for config env vars

### DIFF
--- a/config/harperConfigEnvVars.ts
+++ b/config/harperConfigEnvVars.ts
@@ -109,9 +109,11 @@ function isPlainObject(value: any): value is Record<string, any> {
  * Array-composition directive: `{ $union: [...] }`.
  *
  * A "directive" is a plain object that encodes a non-default merge operation for a
- * leaf value instead of the usual overwrite. It is recognized by a `$`-prefixed key
- * (real config keys are never `$`-prefixed), so `flattenObject` treats it as a leaf
- * rather than recursing into `tls.uses.$union`.
+ * leaf value instead of the usual overwrite. It is recognized by the presence of a
+ * supported directive key (see SUPPORTED_DIRECTIVES), so `flattenObject` treats it as
+ * a leaf rather than recursing into `tls.uses.$union`. Other `$`-prefixed keys (e.g. a
+ * JSON Schema's `$schema`/`$ref` inside component config) are NOT directives and pass
+ * through as ordinary config values.
  *
  * `$union` guarantees the listed items are present in the target array — the
  * order-preserving union of (existing ∪ listed). It is idempotent under repeated
@@ -127,12 +129,16 @@ function isPlainObject(value: any): value is Record<string, any> {
  * previously set" contract. Use HARPER_SET_CONFIG to compose at runtime.
  */
 const DIRECTIVE_UNION = '$union';
+const SUPPORTED_DIRECTIVES = [DIRECTIVE_UNION];
 
 /**
- * True if value is a plain object carrying a directive (a `$`-prefixed key).
+ * True if value is a plain object carrying a supported directive key. Detection is
+ * deliberately narrowed to the known sentinels (not any `$`-prefixed key) so ordinary
+ * config that happens to contain `$`-keys — e.g. a component config embedding a JSON
+ * Schema with `$schema`/`$ref` — keeps flattening and applying as plain values.
  */
 function isDirectiveObject(value: any): boolean {
-	return isPlainObject(value) && Object.keys(value).some((key) => key.startsWith('$'));
+	return isPlainObject(value) && SUPPORTED_DIRECTIVES.some((directive) => directive in value);
 }
 
 /**
@@ -142,10 +148,9 @@ function isDirectiveObject(value: any): boolean {
 function parseDirective(value: Record<string, any>, path: string): { items: any[] } {
 	const keys = Object.keys(value);
 	if (keys.length !== 1) {
-		throw new ConfigEnvVarError(`Config directive at "${path}" must be the only key, got: ${keys.join(', ')}`);
-	}
-	if (keys[0] !== DIRECTIVE_UNION) {
-		throw new ConfigEnvVarError(`Unknown config directive "${keys[0]}" at "${path}" (supported: ${DIRECTIVE_UNION})`);
+		throw new ConfigEnvVarError(
+			`Config directive "${DIRECTIVE_UNION}" at "${path}" must be the only key, got: ${keys.join(', ')}`
+		);
 	}
 	const items = value[DIRECTIVE_UNION];
 	if (!Array.isArray(items)) {

--- a/config/harperConfigEnvVars.ts
+++ b/config/harperConfigEnvVars.ts
@@ -106,6 +106,116 @@ function isPlainObject(value: any): value is Record<string, any> {
 }
 
 /**
+ * Array-composition directive: `{ $union: [...] }`.
+ *
+ * A "directive" is a plain object that encodes a non-default merge operation for a
+ * leaf value instead of the usual overwrite. It is recognized by a `$`-prefixed key
+ * (real config keys are never `$`-prefixed), so `flattenObject` treats it as a leaf
+ * rather than recursing into `tls.uses.$union`.
+ *
+ * `$union` guarantees the listed items are present in the target array — the
+ * order-preserving union of (existing ∪ listed). It is idempotent under repeated
+ * application and never removes entries it didn't name, which is what lets a platform
+ * layer reapply its required entries on every restart without dropping an app's
+ * additions (even on the HARPER_SET_CONFIG force/drift path). We deliberately do not
+ * add `$append` (not idempotent) or `$replace` (a bare array already replaces); the
+ * vocabulary stays open so further directives can be added non-breaking.
+ *
+ * Note on HARPER_DEFAULT_CONFIG: a `$union` there composes at install (or against a
+ * value DEFAULT previously set), but at runtime DEFAULT yields to an existing
+ * un-sourced array and the union no-ops — matching DEFAULT's "only update values we
+ * previously set" contract. Use HARPER_SET_CONFIG to compose at runtime.
+ */
+const DIRECTIVE_UNION = '$union';
+
+/**
+ * True if value is a plain object carrying a directive (a `$`-prefixed key).
+ */
+function isDirectiveObject(value: any): boolean {
+	return isPlainObject(value) && Object.keys(value).some((key) => key.startsWith('$'));
+}
+
+/**
+ * Validate a directive object and return its operands. Throws on a malformed directive
+ * so misconfiguration surfaces loudly rather than silently misbehaving.
+ */
+function parseDirective(value: Record<string, any>, path: string): { items: any[] } {
+	const keys = Object.keys(value);
+	if (keys.length !== 1) {
+		throw new ConfigEnvVarError(`Config directive at "${path}" must be the only key, got: ${keys.join(', ')}`);
+	}
+	if (keys[0] !== DIRECTIVE_UNION) {
+		throw new ConfigEnvVarError(`Unknown config directive "${keys[0]}" at "${path}" (supported: ${DIRECTIVE_UNION})`);
+	}
+	const items = value[DIRECTIVE_UNION];
+	if (!Array.isArray(items)) {
+		throw new ConfigEnvVarError(`Config directive "${DIRECTIVE_UNION}" at "${path}" requires an array value`);
+	}
+	return { items };
+}
+
+/**
+ * Deterministic JSON string with object keys sorted at every level, so two
+ * structurally-equal values compare equal regardless of property insertion order.
+ * Shared by snapshot hashing and by `$union`'s idempotent dedup of object entries.
+ */
+function stableStringify(value: any): string {
+	// Honor toJSON (e.g. Date) so values serialize the way JSON.stringify would.
+	if (value && typeof value.toJSON === 'function') {
+		value = value.toJSON();
+	}
+	if (value === null || typeof value !== 'object') {
+		// undefined/function/symbol stringify to undefined → normalize to 'null' (matches
+		// JSON.stringify of an array slot) and keep the declared string return type honest.
+		return JSON.stringify(value) ?? 'null';
+	}
+	if (Array.isArray(value)) {
+		return '[' + value.map((item) => stableStringify(item)).join(',') + ']';
+	}
+	// Match JSON.stringify, which omits keys whose value is undefined/function/symbol.
+	const pairs: string[] = [];
+	for (const key of Object.keys(value).sort()) {
+		const item = value[key];
+		if (item !== undefined && typeof item !== 'function' && typeof item !== 'symbol') {
+			pairs.push(JSON.stringify(key) + ':' + stableStringify(item));
+		}
+	}
+	return '{' + pairs.join(',') + '}';
+}
+
+/**
+ * Order-preserving union: existing entries kept in place, listed items appended only
+ * when not already present. Idempotent (re-applying is a no-op, no duplicates) and
+ * never removes entries the directive didn't name. Dedup uses key-order-insensitive
+ * equality so object entries (e.g. `{ port, host }` vs `{ host, port }`) don't
+ * re-append across boots.
+ */
+function unionArrays(current: any, items: any[]): any[] {
+	const result = Array.isArray(current) ? [...current] : [];
+	// Pre-stringify existing entries once, then stringify each candidate once (O(N+M)).
+	const seen = result.map((existing) => stableStringify(existing));
+	for (const item of items) {
+		const key = stableStringify(item);
+		if (!seen.includes(key)) {
+			result.push(item);
+			seen.push(key);
+		}
+	}
+	return result;
+}
+
+/**
+ * Resolve the value to write for a flattened leaf given the value currently at that
+ * path. Plain leaves overwrite (default); directive leaves compose against current.
+ */
+function resolveLeafValue(currentValue: any, leafValue: any, path: string): any {
+	if (isDirectiveObject(leafValue)) {
+		return unionArrays(currentValue, parseDirective(leafValue, path).items);
+	}
+	return leafValue;
+}
+
+/**
  * Filters out arguments that are already set in HARPER_SET_CONFIG.
  * This prevents individual environment variables from overriding runtime configuration.
  *
@@ -148,7 +258,12 @@ export function filterArgsAgainstRuntimeConfig(args: Record<string, any>): Recor
 		const keys = new Set<string>();
 		for (const key in obj) {
 			const newKey = prefix ? `${prefix}_${key}` : key;
-			if (obj[key] !== null && typeof obj[key] === 'object' && !Array.isArray(obj[key])) {
+			if (
+				obj[key] !== null &&
+				typeof obj[key] === 'object' &&
+				!Array.isArray(obj[key]) &&
+				!isDirectiveObject(obj[key])
+			) {
 				flattenSetConfig(obj[key], newKey).forEach((k) => keys.add(k));
 			} else {
 				keys.add(newKey.toLowerCase());
@@ -182,11 +297,11 @@ function flattenObject(obj: ConfigObject, prefix = ''): Record<string, any> {
 		const value = obj[key];
 		const newKey = prefix ? `${prefix}.${key}` : key;
 
-		if (isPlainObject(value)) {
+		if (isPlainObject(value) && !isDirectiveObject(value)) {
 			// Recurse for nested objects
 			Object.assign(result, flattenObject(value, newKey));
 		} else {
-			// Store primitive or array
+			// Store primitive, array, or directive ({ $union: [...] }) as a leaf
 			result[newKey] = value;
 		}
 	}
@@ -251,21 +366,7 @@ function deleteNestedValue(obj: ConfigObject, path: string): void {
  * Hash config object for snapshot comparison
  */
 function hashConfig(config: ConfigObject): string {
-	// Deterministic JSON stringify with sorted keys at all levels
-	const sortedStringify = (obj: any): string => {
-		if (obj === null || typeof obj !== 'object') {
-			return JSON.stringify(obj);
-		}
-		if (Array.isArray(obj)) {
-			return '[' + obj.map(sortedStringify).join(',') + ']';
-		}
-		const keys = Object.keys(obj).sort();
-		const pairs = keys.map((key) => JSON.stringify(key) + ':' + sortedStringify(obj[key]));
-		return '{' + pairs.join(',') + '}';
-	};
-
-	const json = sortedStringify(config);
-	return crypto.createHash('sha256').update(json).digest('hex');
+	return crypto.createHash('sha256').update(stableStringify(config)).digest('hex');
 }
 
 /**
@@ -402,8 +503,9 @@ function applyConfigLayer(
 			}
 		}
 
-		// Set the value and track the source
-		setNestedValue(fileConfig, path, value);
+		// Set the value and track the source (directive leaves compose against current,
+		// so a $union keeps existing/app entries instead of overwriting them)
+		setNestedValue(fileConfig, path, resolveLeafValue(currentValue, value, path));
 		state.sources[path] = sourceName;
 	}
 }
@@ -532,8 +634,8 @@ function processEnvVar(
 					}
 				}
 
-				// Set the value and track the source
-				setNestedValue(fileConfig, path, value);
+				// Set the value and track the source (directive leaves compose against current)
+				setNestedValue(fileConfig, path, resolveLeafValue(currentValue, value, path));
 				state.sources[path] = sourceName;
 			}
 		}
@@ -617,7 +719,8 @@ export function composeConfigFromEnv(base: ConfigObject = {}): ConfigObject {
 	for (const layer of layers) {
 		if (!layer) continue;
 		for (const [p, value] of Object.entries(flattenObject(layer))) {
-			setNestedValue(result, p, value);
+			// directive leaves compose against the value accumulated by prior layers
+			setNestedValue(result, p, resolveLeafValue(getNestedValue(result, p), value, p));
 		}
 	}
 

--- a/unitTests/config/harperConfigEnvVars-union.test.js
+++ b/unitTests/config/harperConfigEnvVars-union.test.js
@@ -1,0 +1,244 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const rewire = require('rewire');
+const fs = require('fs-extra');
+const path = require('node:path');
+const os = require('node:os');
+
+const harperConfigEnvVars = rewire('#src/config/harperConfigEnvVars');
+const applyRuntimeEnvConfig = harperConfigEnvVars.__get__('applyRuntimeEnvConfig');
+const composeConfigFromEnv = harperConfigEnvVars.__get__('composeConfigFromEnv');
+const filterArgsAgainstRuntimeConfig = harperConfigEnvVars.__get__('filterArgsAgainstRuntimeConfig');
+const unionArrays = harperConfigEnvVars.__get__('unionArrays');
+const isDirectiveObject = harperConfigEnvVars.__get__('isDirectiveObject');
+const flattenObject = harperConfigEnvVars.__get__('flattenObject');
+const stableStringify = harperConfigEnvVars.__get__('stableStringify');
+
+describe('$union array directive', function () {
+	let testRoot;
+	let originalSet;
+	let originalDefault;
+
+	beforeEach(function () {
+		originalSet = process.env.HARPER_SET_CONFIG;
+		originalDefault = process.env.HARPER_DEFAULT_CONFIG;
+		delete process.env.HARPER_SET_CONFIG;
+		delete process.env.HARPER_DEFAULT_CONFIG;
+
+		testRoot = path.join(os.tmpdir(), 'hdb-union-test-' + Date.now() + '-' + Math.floor(process.hrtime()[1]));
+		fs.mkdirpSync(path.join(testRoot, 'backup'));
+	});
+
+	afterEach(function () {
+		if (originalSet !== undefined) process.env.HARPER_SET_CONFIG = originalSet;
+		else delete process.env.HARPER_SET_CONFIG;
+		if (originalDefault !== undefined) process.env.HARPER_DEFAULT_CONFIG = originalDefault;
+		else delete process.env.HARPER_DEFAULT_CONFIG;
+
+		try {
+			fs.removeSync(testRoot);
+			// eslint-disable-next-line sonarjs/no-ignored-exceptions
+		} catch {
+			// ignore cleanup errors
+		}
+	});
+
+	describe('unionArrays (unit)', function () {
+		it('appends only items not already present, preserving order', function () {
+			assert.deepStrictEqual(unionArrays(['a'], ['b', 'a', 'c']), ['a', 'b', 'c']);
+		});
+
+		it('treats a missing/undefined current value as an empty array', function () {
+			assert.deepStrictEqual(unionArrays(undefined, ['x']), ['x']);
+			assert.deepStrictEqual(unionArrays(null, ['x']), ['x']);
+		});
+
+		it('is idempotent — re-applying the same items is a no-op', function () {
+			const once = unionArrays(['a'], ['a', 'b']);
+			assert.deepStrictEqual(once, ['a', 'b']);
+			assert.deepStrictEqual(unionArrays(once, ['a', 'b']), ['a', 'b']);
+		});
+
+		it('dedupes deeply-equal object entries', function () {
+			assert.deepStrictEqual(unionArrays([{ x: 1 }], [{ x: 1 }, { y: 2 }]), [{ x: 1 }, { y: 2 }]);
+		});
+
+		it('dedupes object entries regardless of property order (idempotent across boots)', function () {
+			// e.g. an existing { host, port } vs a listed { port, host } — same object, must not re-append
+			assert.deepStrictEqual(unionArrays([{ host: 'a', port: 1 }], [{ port: 1, host: 'a' }]), [{ host: 'a', port: 1 }]);
+		});
+	});
+
+	describe('stableStringify (unit)', function () {
+		it('always returns a string, even for undefined', function () {
+			assert.strictEqual(stableStringify(undefined), 'null');
+			assert.strictEqual(stableStringify(null), 'null');
+		});
+
+		it('sorts object keys so property order does not affect the result', function () {
+			assert.strictEqual(stableStringify({ b: 1, a: 2 }), stableStringify({ a: 2, b: 1 }));
+		});
+
+		it('omits undefined-valued properties (matches JSON.stringify)', function () {
+			assert.strictEqual(stableStringify({ a: 1, b: undefined }), '{"a":1}');
+		});
+
+		it('honors toJSON (Date) instead of serializing it as {}', function () {
+			const d = new Date('2026-06-09T00:00:00.000Z');
+			assert.strictEqual(stableStringify(d), JSON.stringify(d.toJSON()));
+			// two equal Dates dedupe under $union; two different Dates do not
+			assert.deepStrictEqual(
+				unionArrays([new Date('2026-01-01T00:00:00Z')], [new Date('2026-01-01T00:00:00Z')]).length,
+				1
+			);
+			assert.deepStrictEqual(
+				unionArrays([new Date('2026-01-01T00:00:00Z')], [new Date('2026-02-01T00:00:00Z')]).length,
+				2
+			);
+		});
+	});
+
+	describe('directive recognition', function () {
+		it('isDirectiveObject is true only for $-prefixed-key objects', function () {
+			assert.equal(isDirectiveObject({ $union: [] }), true);
+			assert.equal(isDirectiveObject({ uses: [] }), false);
+			assert.equal(isDirectiveObject(['a']), false);
+			assert.equal(isDirectiveObject('a'), false);
+			assert.equal(isDirectiveObject({}), false);
+		});
+
+		it('flattenObject treats a directive as a leaf (does not recurse into $union)', function () {
+			const flat = flattenObject({ tls: { uses: { $union: ['server'] } } });
+			assert.deepStrictEqual(Object.keys(flat), ['tls.uses']);
+			assert.deepStrictEqual(flat['tls.uses'], { $union: ['server'] });
+		});
+	});
+
+	describe('under HARPER_SET_CONFIG', function () {
+		it('adds listed items to an existing array, order-preserving (existing then listed)', function () {
+			process.env.HARPER_SET_CONFIG = JSON.stringify({ tls: { uses: { $union: ['server', 'operations-api'] } } });
+			const fileConfig = { tls: { uses: ['app-cert'] } };
+
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+
+			assert.deepStrictEqual(fileConfig.tls.uses, ['app-cert', 'server', 'operations-api']);
+		});
+
+		it('produces just the listed items when no array exists yet', function () {
+			process.env.HARPER_SET_CONFIG = JSON.stringify({ tls: { uses: { $union: ['server'] } } });
+			const fileConfig = {};
+
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+
+			assert.deepStrictEqual(fileConfig.tls.uses, ['server']);
+		});
+
+		it('is idempotent across repeated boots (no duplicates)', function () {
+			process.env.HARPER_SET_CONFIG = JSON.stringify({ tls: { uses: { $union: ['server', 'operations-api'] } } });
+			const fileConfig = { tls: { uses: ['app-cert'] } };
+
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+
+			assert.deepStrictEqual(fileConfig.tls.uses, ['app-cert', 'server', 'operations-api']);
+		});
+
+		it('never deletes unnamed entries — app additions survive the force/drift path', function () {
+			process.env.HARPER_SET_CONFIG = JSON.stringify({ tls: { uses: { $union: ['server'] } } });
+			const fileConfig = { tls: { uses: ['app-cert'] } };
+
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+			assert.deepStrictEqual(fileConfig.tls.uses, ['app-cert', 'server']);
+
+			// App/user adds its own entry (drift relative to the env-var snapshot)
+			fileConfig.tls.uses.push('app-extra');
+
+			// Same env var re-applied: $union must keep the drifted 'app-extra' AND 'app-cert'
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+			assert.deepStrictEqual(fileConfig.tls.uses, ['app-cert', 'server', 'app-extra']);
+		});
+
+		it('grows the union and keeps app entries when the directive list changes between boots', function () {
+			// Boot 1: forces 'server'
+			process.env.HARPER_SET_CONFIG = JSON.stringify({ tls: { uses: { $union: ['server'] } } });
+			const fileConfig = { tls: { uses: ['app-cert'] } };
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+			assert.deepStrictEqual(fileConfig.tls.uses, ['app-cert', 'server']);
+
+			// Boot 2: directive list changes (hash differs → exercises the deletion/diff path)
+			process.env.HARPER_SET_CONFIG = JSON.stringify({ tls: { uses: { $union: ['server', 'operations-api'] } } });
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+
+			// app-cert (unnamed) survives the deletion path; the new member is added
+			assert.deepStrictEqual(fileConfig.tls.uses, ['app-cert', 'server', 'operations-api']);
+		});
+
+		it('still replaces wholesale for a bare array (unchanged default)', function () {
+			process.env.HARPER_SET_CONFIG = JSON.stringify({ tls: { uses: ['server', 'operations-api'] } });
+			const fileConfig = { tls: { uses: ['app-cert'] } };
+
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+
+			assert.deepStrictEqual(fileConfig.tls.uses, ['server', 'operations-api']);
+		});
+	});
+
+	describe('under HARPER_DEFAULT_CONFIG', function () {
+		it('honors $union at install time', function () {
+			process.env.HARPER_DEFAULT_CONFIG = JSON.stringify({ tls: { uses: { $union: ['server'] } } });
+			const fileConfig = { tls: { uses: ['app-cert'] } };
+
+			applyRuntimeEnvConfig(fileConfig, testRoot, { isInstall: true });
+
+			assert.deepStrictEqual(fileConfig.tls.uses, ['app-cert', 'server']);
+		});
+	});
+
+	describe('composeConfigFromEnv', function () {
+		it('accumulates $union across DEFAULT and SET layers', function () {
+			process.env.HARPER_DEFAULT_CONFIG = JSON.stringify({ tls: { uses: { $union: ['default-cert'] } } });
+			process.env.HARPER_SET_CONFIG = JSON.stringify({ tls: { uses: { $union: ['server'] } } });
+
+			const result = composeConfigFromEnv();
+
+			assert.deepStrictEqual(result.tls.uses, ['default-cert', 'server']);
+		});
+
+		it('unions a SET $union onto a base array', function () {
+			process.env.HARPER_SET_CONFIG = JSON.stringify({ tls: { uses: { $union: ['server'] } } });
+
+			const result = composeConfigFromEnv({ tls: { uses: ['app-cert'] } });
+
+			assert.deepStrictEqual(result.tls.uses, ['app-cert', 'server']);
+		});
+	});
+
+	describe('filterArgsAgainstRuntimeConfig', function () {
+		it('filters the array path (treats the directive as a single leaf, not _$union)', function () {
+			process.env.HARPER_SET_CONFIG = JSON.stringify({ tls: { uses: { $union: ['server'] } } });
+
+			const filtered = filterArgsAgainstRuntimeConfig({ tls_uses: 'x', rootpath: '/y' });
+
+			assert.deepStrictEqual(filtered, { rootpath: '/y' });
+		});
+	});
+
+	describe('malformed directives throw', function () {
+		it('rejects a non-array $union value', function () {
+			process.env.HARPER_SET_CONFIG = JSON.stringify({ tls: { uses: { $union: 'server' } } });
+			assert.throws(() => applyRuntimeEnvConfig({}, testRoot), /requires an array value/);
+		});
+
+		it('rejects an unknown directive', function () {
+			process.env.HARPER_SET_CONFIG = JSON.stringify({ tls: { uses: { $append: ['server'] } } });
+			assert.throws(() => applyRuntimeEnvConfig({}, testRoot), /Unknown config directive/);
+		});
+
+		it('rejects a directive mixed with other keys', function () {
+			process.env.HARPER_SET_CONFIG = JSON.stringify({ tls: { uses: { $union: ['server'], extra: 1 } } });
+			assert.throws(() => applyRuntimeEnvConfig({}, testRoot), /must be the only key/);
+		});
+	});
+});

--- a/unitTests/config/harperConfigEnvVars-union.test.js
+++ b/unitTests/config/harperConfigEnvVars-union.test.js
@@ -194,6 +194,41 @@ describe('$union array directive', function () {
 
 			assert.deepStrictEqual(fileConfig.tls.uses, ['app-cert', 'server']);
 		});
+
+		it('does not union into an un-sourced array at runtime (DEFAULT no-op contract)', function () {
+			// Runtime (not install) + an existing array DEFAULT never set → DEFAULT yields, union no-ops.
+			process.env.HARPER_DEFAULT_CONFIG = JSON.stringify({ tls: { uses: { $union: ['server'] } } });
+			const fileConfig = { tls: { uses: ['app-cert'] } };
+
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+
+			assert.deepStrictEqual(
+				fileConfig.tls.uses,
+				['app-cert'],
+				'runtime DEFAULT must not compose into an un-sourced array'
+			);
+		});
+
+		it('re-applies $union idempotently at runtime on a DEFAULT-sourced path', function () {
+			// Install sources the path via DEFAULT...
+			process.env.HARPER_DEFAULT_CONFIG = JSON.stringify({ tls: { uses: { $union: ['server'] } } });
+			const fileConfig = { tls: { uses: ['app-cert'] } };
+			applyRuntimeEnvConfig(fileConfig, testRoot, { isInstall: true });
+			assert.deepStrictEqual(fileConfig.tls.uses, ['app-cert', 'server']);
+
+			// ...so a later runtime boot re-applies the directive (no-op) on that DEFAULT-sourced path,
+			// and a grown list composes rather than no-ops.
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+			assert.deepStrictEqual(fileConfig.tls.uses, ['app-cert', 'server'], 'idempotent runtime re-apply');
+
+			process.env.HARPER_DEFAULT_CONFIG = JSON.stringify({ tls: { uses: { $union: ['server', 'operations-api'] } } });
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+			assert.deepStrictEqual(
+				fileConfig.tls.uses,
+				['app-cert', 'server', 'operations-api'],
+				'runtime compose on a DEFAULT-sourced path'
+			);
+		});
 	});
 
 	describe('composeConfigFromEnv', function () {

--- a/unitTests/config/harperConfigEnvVars-union.test.js
+++ b/unitTests/config/harperConfigEnvVars-union.test.js
@@ -100,12 +100,15 @@ describe('$union array directive', function () {
 	});
 
 	describe('directive recognition', function () {
-		it('isDirectiveObject is true only for $-prefixed-key objects', function () {
+		it('isDirectiveObject is true only for supported directive keys', function () {
 			assert.equal(isDirectiveObject({ $union: [] }), true);
 			assert.equal(isDirectiveObject({ uses: [] }), false);
 			assert.equal(isDirectiveObject(['a']), false);
 			assert.equal(isDirectiveObject('a'), false);
 			assert.equal(isDirectiveObject({}), false);
+			// unsupported $-keys are NOT directives (e.g. JSON Schema keywords in component config)
+			assert.equal(isDirectiveObject({ $schema: 'https://json-schema.org/draft/2020-12/schema' }), false);
+			assert.equal(isDirectiveObject({ $append: ['x'] }), false);
 		});
 
 		it('flattenObject treats a directive as a leaf (does not recurse into $union)', function () {
@@ -266,9 +269,18 @@ describe('$union array directive', function () {
 			assert.throws(() => applyRuntimeEnvConfig({}, testRoot), /requires an array value/);
 		});
 
-		it('rejects an unknown directive', function () {
-			process.env.HARPER_SET_CONFIG = JSON.stringify({ tls: { uses: { $append: ['server'] } } });
-			assert.throws(() => applyRuntimeEnvConfig({}, testRoot), /Unknown config directive/);
+		it('passes unsupported $-keys through as plain config (forward/JSON-Schema compatibility)', function () {
+			// e.g. a component config embedding a JSON Schema — must keep flattening and applying,
+			// not throw at boot (root config is forward-compatible; app config allows arbitrary keys)
+			process.env.HARPER_SET_CONFIG = JSON.stringify({
+				'my-app': { schema: { $schema: 'https://json-schema.org/draft/2020-12/schema', type: 'object' } },
+			});
+			const fileConfig = {};
+
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+
+			assert.strictEqual(fileConfig['my-app'].schema.$schema, 'https://json-schema.org/draft/2020-12/schema');
+			assert.strictEqual(fileConfig['my-app'].schema.type, 'object');
 		});
 
 		it('rejects a directive mixed with other keys', function () {


### PR DESCRIPTION
## Summary

Adds a `$union` array-composition directive to Harper's config env-var system (`config/harperConfigEnvVars.ts`). Arrays in `HARPER_DEFAULT_CONFIG` / `HARPER_SET_CONFIG` are replaced wholesale today; `{ "tls": { "uses": { "$union": ["server", "operations-api"] } } }` instead **composes** — an order-preserving, idempotent union that guarantees the listed items are present while never removing entries it didn't name.

Closes #1213 (sub-issue of #1097).

## Purpose

Problem 2 from #1097 — *"arrays don't compose."* A deployment where the platform layer forces `tls.uses` via `HARPER_SET_CONFIG` clobbered the app's TLS entries on every restart/upgrade. `$union` lets the platform **guarantee its required entries** without dropping the app's:

- **Idempotent** — reapplied on every restart/`compose up` with no duplicate growth (this is why we add `$union`, not `$append`).
- **Never deletes unnamed entries** — honored even on `HARPER_SET_CONFIG`'s force/drift deletion path, so the app's additions survive.

This is independently shippable: it works under `HARPER_SET_CONFIG` today and fixes the motivating incident on its own, ahead of the `HARPER_CONFIG` layer (#1214).

## How it works

Directives are detected by the presence of a supported sentinel key (`SUPPORTED_DIRECTIVES`, currently `$union`) — other `$`-prefixed keys (e.g. a JSON Schema's `$schema`/`$ref` inside component config) are NOT directives and pass through as plain config values. `flattenObject` treats `{ $union: [...] }` as a leaf instead of recursing. A shared `resolveLeafValue` composes directive leaves against the current value across all four apply sites: `flattenObject`, `applyConfigLayer`, the DEFAULT runtime branch, and `composeConfigFromEnv`. Bare arrays still replace wholesale (unchanged default). Malformed directives (non-array value / mixed keys alongside `$union`) throw `ConfigEnvVarError` and fail loud at boot.

## Where to look / lower-confidence areas

- **`unionArrays` dedup (`config/harperConfigEnvVars.ts`)** — uses a key-order-insensitive `stableStringify` (factored out of `hashConfig`) so object array entries (`{host,port}` vs `{port,host}`) don't re-append across boots. The designed/primary case is `tls.uses` (string array); the object case is robustness. *(Raised by the Codex review — see below.)*
- **SET drift/deletion exemption** — `$union` composes against the resolved current value, and the path-level deletion logic (`handleDeletions`) only removes a key when the directive is dropped entirely. Worth a careful read of the snapshot/hash interaction. Tested: idempotent re-apply, drift survival, and the hash-change deletion path.
- **DEFAULT runtime no-op** — a `$union` in `HARPER_DEFAULT_CONFIG` composes at install but no-ops at runtime against an existing un-sourced array (DEFAULT's "only update values we previously set" contract). Documented in the JSDoc; use `HARPER_SET_CONFIG` to compose at runtime.

## Testing

20 unit tests in `unitTests/config/harperConfigEnvVars-union.test.js` (union semantics, idempotency, drift + hash-change deletion paths, bare-array regression, install-time DEFAULT, `composeConfigFromEnv` layering, arg-filter path, malformed-directive throws, mixed-key-order dedup). Full `unitTests/config/**` suite green (155 passing); `tsc` build clean; oxlint clean.

## Cross-model review (HEG step 9)

- **Codex** flagged the object-entry dedup being key-order-sensitive — **addressed** in this PR (shared `stableStringify`) and pinned with a mixed-key-order test. No other findings; no blockers.
- **Gemini (`agy`) leg failed** — hung at startup with no output across two attempts, so there is **no second-model (perf/maintainability) coverage from Gemini**. The change is a ~130-line cold-path config module (runs at install/boot, not a hot path), so the missing perf lens is low-stakes, but flagging it for the human reviewer.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (agent: Claude Opus 4.8)


