### PR TITLE
ci: bump issue-to-pr pin (Opus for :bug/:test, efficiency guidance)

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -22,11 +22,11 @@ concurrency:
 
 jobs:
   work:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@6463b3da6326f0ca4646fb6b5139c2ecf92130f6 # main 2026-05-06 (post #11/#12/#14)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@441d2a310cb360adf419d3546dd27566164f1ec2 # main 2026-06-09 (post #58: Opus for :bug/:test, efficiency guidance)
     with:
       # Same SHA as the `uses:` ref above. See the comment in
       # claude-mention.yml for why the duplication is unavoidable.
-      ai-review-prompts-ref: 6463b3da6326f0ca4646fb6b5139c2ecf92130f6
+      ai-review-prompts-ref: 441d2a310cb360adf419d3546dd27566164f1ec2
       repo-specific-conventions: |
         ## Harper core notes
 


### PR DESCRIPTION
Bumps the `claude-issue-to-pr` reusable pin to [HarperFast/ai-review-prompts#58](https://github.com/HarperFast/ai-review-prompts/pull/58) (merge commit `441d2a31`) — both the `uses:` ref and the `ai-review-prompts-ref:` input.

### What #58 changes
- **Model by label:** `:bug` / `:test` (authoring-heavy) now run on `claude-opus-4-8`; `:typo` / `:docs` / `:deps` stay on `claude-sonnet-4-6`. Sub-task agents still default to Haiku.
- **"Working efficiently" prompt guidance:** read what the ask names then write; delegate broad exploration to a sub-agent (Task tool) so reading doesn't consume the main-loop turn budget; stop-and-comment when out of scope.
- **allowlist:** read-only `gh pr list` / `gh search prs` / `gh search issues` pre-approved.
- **`max-turns` 72 → 100** (a ceiling, not a target).

### Why
Run [`27222718790`](https://github.com/HarperFast/harper/actions/runs/27222718790/job/80381556260) (issue #1215, `claude-fix:test`) hit the 72-turn cap having spent the entire budget on read-only exploration — no branch, no commit, no PR. These changes give the agent a stronger model on authoring work plus explicit guidance to delegate exploration instead of spelunking.

No-op until the next `claude-fix:*` labeled issue.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)