### PR TITLE
chore(deps): bump @harperfast/rocksdb-js to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@fastify/cors": "^11.2.0",
 				"@fastify/static": "^9.1.3",
 				"@harperfast/extended-iterable": "^1.0.1",
-				"@harperfast/rocksdb-js": "^1.4.2",
+				"@harperfast/rocksdb-js": "^2.0.0",
 				"@turf/area": "6.5.0",
 				"@turf/boolean-contains": "6.5.0",
 				"@turf/boolean-disjoint": "6.5.0",
@@ -2923,36 +2923,36 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js/-/rocksdb-js-1.4.2.tgz",
-			"integrity": "sha512-wQ0buhmNVcw6jPn5VOoYDsGmO1IAmtithcSgaKrnBRicf+ATvQSCB1I7ljEBuqqzWG6HcJXeCgPhFpas3kRwOw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js/-/rocksdb-js-2.0.0.tgz",
+			"integrity": "sha512-70ibZ4bg1kWaGnftsI/yRxPMzdwgLNJcryz3NtiZTywtlwpqcd9Q3wedXbQooayE7PYJmDJXIRDQj3KYkvud9w==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@harperfast/extended-iterable": "1.0.3",
-				"msgpackr": "2.0.1",
+				"msgpackr": "2.0.2",
 				"ordered-binary": "1.6.1"
 			},
 			"bin": {
 				"rocksdb-js": "bin/rocksdb-js.mjs"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^22.18.0 || >=24.0.0"
 			},
 			"optionalDependencies": {
-				"@harperfast/rocksdb-js-darwin-arm64": "1.4.2",
-				"@harperfast/rocksdb-js-darwin-x64": "1.4.2",
-				"@harperfast/rocksdb-js-linux-arm64-glibc": "1.4.2",
-				"@harperfast/rocksdb-js-linux-arm64-musl": "1.4.2",
-				"@harperfast/rocksdb-js-linux-x64-glibc": "1.4.2",
-				"@harperfast/rocksdb-js-linux-x64-musl": "1.4.2",
-				"@harperfast/rocksdb-js-win32-arm64": "1.4.2",
-				"@harperfast/rocksdb-js-win32-x64": "1.4.2"
+				"@harperfast/rocksdb-js-darwin-arm64": "2.0.0",
+				"@harperfast/rocksdb-js-darwin-x64": "2.0.0",
+				"@harperfast/rocksdb-js-linux-arm64-glibc": "2.0.0",
+				"@harperfast/rocksdb-js-linux-arm64-musl": "2.0.0",
+				"@harperfast/rocksdb-js-linux-x64-glibc": "2.0.0",
+				"@harperfast/rocksdb-js-linux-x64-musl": "2.0.0",
+				"@harperfast/rocksdb-js-win32-arm64": "2.0.0",
+				"@harperfast/rocksdb-js-win32-x64": "2.0.0"
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-darwin-arm64": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-arm64/-/rocksdb-js-darwin-arm64-1.4.2.tgz",
-			"integrity": "sha512-qQyv8BNCjvZQayhoTd7iqt1CLNEFHfqe8/SDZk8ztAR0ZAIyHIFkmNnaQ/Izn6p3HrNCRp6lNdwO4TKPWHj4SQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-arm64/-/rocksdb-js-darwin-arm64-2.0.0.tgz",
+			"integrity": "sha512-1Ed3XVekAFdoJJfDsrjBYJT1B85Zj91gQcC7fQq/CnhRdEk/D1ZdCsg7q9cg++mpZ5Ksnx+BsfiyqO67bTmKpQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2962,13 +2962,13 @@
 				"darwin"
 			],
 			"engines": {
-				"node": ">=18"
+				"node": "^22.18.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-darwin-x64": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-x64/-/rocksdb-js-darwin-x64-1.4.2.tgz",
-			"integrity": "sha512-cPCsB7IVeuDhNjFcb/nqUkwtBI9BlaFNecJ/OjkG8hUpYAhd5rdNHFMt1vpu4sAYFaorFrMZoNKGbq43v14+hQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-x64/-/rocksdb-js-darwin-x64-2.0.0.tgz",
+			"integrity": "sha512-dK85CtR9RXhN5GF7Ndpt7krO5zImAl5pGyrx3QmepI72uT8ncppYurDEPZZ0z/A3LrBidXbaznUp2iGFVdYUYg==",
 			"cpu": [
 				"x64"
 			],
@@ -2978,13 +2978,13 @@
 				"darwin"
 			],
 			"engines": {
-				"node": ">=18"
+				"node": "^22.18.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-arm64-glibc": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-glibc/-/rocksdb-js-linux-arm64-glibc-1.4.2.tgz",
-			"integrity": "sha512-NquwD+7Gxu3BYAIQhvSThjIRlZRBieDZKXGEmrc0gfcxcORbgOjMCdxDzhjF6l1nR4ODlfJfbKqGyF8JtmnIjA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-glibc/-/rocksdb-js-linux-arm64-glibc-2.0.0.tgz",
+			"integrity": "sha512-au7qK8VCkc6uU2lp2cRcO7HLML0ehfKFBimFYnxdwIHo6wZ1lPW5YVxKnuKIBKThMxdV6Dn2XJ3pu3ub8KtPrA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2997,13 +2997,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=18"
+				"node": "^22.18.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-arm64-musl": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-musl/-/rocksdb-js-linux-arm64-musl-1.4.2.tgz",
-			"integrity": "sha512-hp2IOXYBvloJEkZ/+bCI/AsQPtzza51Pkz+U+JkaAaayZ6+zsXdVp5GuGYPnCiH4O6QnOihKkgBW8msFhR0ogA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-musl/-/rocksdb-js-linux-arm64-musl-2.0.0.tgz",
+			"integrity": "sha512-x3F2h7fVwH1IHYlQDFOO5YJ9NH3pPkZybjPOaV1Vo8BiE9A72BabcVbQeV98/3STcMP2k20YpoggsI8QjcdCzQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3016,13 +3016,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=18"
+				"node": "^22.18.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-x64-glibc": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-glibc/-/rocksdb-js-linux-x64-glibc-1.4.2.tgz",
-			"integrity": "sha512-zEkBHRoLanN9MTVY1mFRGDdAGyXBUrk962xvtf0sGj/wIK2M3c2KL39FftWHgtm/BHA3uGHssWk6B7O2O/Dlig==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-glibc/-/rocksdb-js-linux-x64-glibc-2.0.0.tgz",
+			"integrity": "sha512-RDinS/7loqA7WuKQvfB73yc5dveTrOpdP/pXlFepWG1P586/0kpp0abRgCpkuSZyhmqIoWX9n9ooZvh03pvZ3A==",
 			"cpu": [
 				"x64"
 			],
@@ -3035,13 +3035,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=18"
+				"node": "^22.18.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-x64-musl": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-1.4.2.tgz",
-			"integrity": "sha512-K7y1CC+LJma2E+wEqFq67jk7+hZW+oPdKcqxyDxrIRKO3jyn0Dtr/fwQf3cFuU8cRnZBmZTAcnr5LeNJrUuYRw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-2.0.0.tgz",
+			"integrity": "sha512-gswLCyzqPUoB2HlTE+DMOd2Nr7H9uUg/pgtZpIvTpHU6ewV2O8mANT6qV/DLN9uPKWrBSp77b92PxXYtPRyPsA==",
 			"cpu": [
 				"x64"
 			],
@@ -3054,13 +3054,13 @@
 				"linux"
 			],
 			"engines": {
-				"node": ">=18"
+				"node": "^22.18.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-win32-arm64": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-1.4.2.tgz",
-			"integrity": "sha512-xc4oav0zTLfnjBIan1wlgB3g0NeWrzUPxR0Vq5HkLc4BGyAlPql+v1FwtQ4X6AwcAOHnS/QeYSGDQOZn6Ac1Ow==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-2.0.0.tgz",
+			"integrity": "sha512-vwVMVS/Nw5Mw17whMVQG7eJfBXqS2NeABiCxgsd2SoV6ovvm0TbSg9D8z2hsJlSJGy8BSYxK8i+xgqf1oh1ogA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3070,13 +3070,13 @@
 				"win32"
 			],
 			"engines": {
-				"node": ">=18"
+				"node": "^22.18.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-win32-x64": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-x64/-/rocksdb-js-win32-x64-1.4.2.tgz",
-			"integrity": "sha512-60vqTYJdw0ysvHeFHoxZ/sHNesdfvri+jWIyU5TTua2s20LmLZ4hKLglnsa0LP7/IA5JutZsxJiyUUMCoG3PDw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-x64/-/rocksdb-js-win32-x64-2.0.0.tgz",
+			"integrity": "sha512-WzaatIsLBjWrmRHHCcOeQ3TqUpBiEoaKBI6SbG6UQRO41gI7Ts0LVHtYF195Luldc8XsibSic1VztEPh2ubVAQ==",
 			"cpu": [
 				"x64"
 			],
@@ -3086,16 +3086,16 @@
 				"win32"
 			],
 			"engines": {
-				"node": ">=18"
+				"node": "^22.18.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js/node_modules/msgpackr": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.1.tgz",
-			"integrity": "sha512-9J+tqTEsbHqY8YohazYgty7LgerFIWxvMLpUjqETSmjHojtJm2WnX2kK/2a1fLI7CO7ERP1YSEUXMucz4j+yBA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.2.tgz",
+			"integrity": "sha512-c5hYOXFbP79Slh6Dzd2wzk+jnV7mX1UxfMYtilnY1NmalXPqG8DGb5cYCMBrW4AsH3zekBBZd4QrKz9NhtvYLQ==",
 			"license": "MIT",
 			"optionalDependencies": {
-				"msgpackr-extract": "^3.0.2"
+				"msgpackr-extract": "^3.0.4"
 			}
 		},
 		"node_modules/@hono/node-server": {

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
 		"@fastify/cors": "^11.2.0",
 		"@fastify/static": "^9.1.3",
 		"@harperfast/extended-iterable": "^1.0.1",
-		"@harperfast/rocksdb-js": "^1.4.2",
+		"@harperfast/rocksdb-js": "^2.0.0",
 		"@turf/area": "6.5.0",
 		"@turf/boolean-contains": "6.5.0",
 		"@turf/boolean-disjoint": "6.5.0",


### PR DESCRIPTION
Bumps `@harperfast/rocksdb-js` from `^1.4.2` to `^2.0.0`.

Contains the critical fixes merged today:
- #629 — use-after-free in `getUserSharedBuffer()`
- #637 — txn-log truncation fix
- #639 — lock-free EventEmitter listener gate
- #640 — JSON-escape helper + `ListenerData::fromStrings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)