### PR TITLE
chore: update engines.node to ^22.18.0 || >=24.0.0 for rocksdb-js 2.0.0

### DIFF
--- a/launchServiceScripts/utility/checkNodeVersion.js
+++ b/launchServiceScripts/utility/checkNodeVersion.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const semverMajor = require('semver/functions/major');
+const semver = require('semver');
 const { packageJson } = require('../../utility/packageUtils.js');
 const INSTALLED_NODE_VERSION = process.versions && process.versions.node ? process.versions.node : undefined;
 
@@ -9,9 +9,9 @@ module.exports = checkNodeVersion;
 function checkNodeVersion() {
 	// Skip Node version check when running on Bun
 	if (typeof globalThis.Bun !== 'undefined') return;
-	const minimumHdbNodeVersion = packageJson.engines['minimum-node'];
-	if (INSTALLED_NODE_VERSION && semverMajor(INSTALLED_NODE_VERSION) < semverMajor(minimumHdbNodeVersion)) {
-		const versionError = `The minimum version of Node.js Harper supports is: ${minimumHdbNodeVersion}, the currently installed Node.js version is: ${INSTALLED_NODE_VERSION}. Please install a version of Node.js that is withing the defined range.`;
+	const requiredRange = packageJson.engines.node;
+	if (INSTALLED_NODE_VERSION && !semver.satisfies(INSTALLED_NODE_VERSION, requiredRange)) {
+		const versionError = `Harper requires Node.js ${requiredRange}, but the currently installed version is ${INSTALLED_NODE_VERSION}. Please install a compatible version.`;
 		return { error: versionError };
 	}
 }

--- a/package.json
+++ b/package.json
@@ -103,8 +103,7 @@
 		}
 	},
 	"engines": {
-		"node": "^22.18.0 || >=24.0.0",
-		"minimum-node": "22.18.0"
+		"node": "^22.18.0 || >=24.0.0"
 	},
 	"devEngines": {
 		"runtime": {

--- a/package.json
+++ b/package.json
@@ -103,8 +103,8 @@
 		}
 	},
 	"engines": {
-		"node": ">=20",
-		"minimum-node": "20.0.0"
+		"node": "^22.18.0 || >=24.0.0",
+		"minimum-node": "22.18.0"
 	},
 	"devEngines": {
 		"runtime": {


### PR DESCRIPTION
Follow-up to #1220 (`@harperfast/rocksdb-js` 2.0.0 bump).

`rocksdb-js@2.0.0` requires `^22.18.0 || >=24.0.0`. Harper's `engines.node` still said `>=20`, meaning Node 20 / Node 22.0–22.17 users would install successfully but hit a runtime failure when RocksDB (the default storage engine) loads.

**Change:** `engines.node` `>=20` → `^22.18.0 || >=24.0.0`; `minimum-node` `20.0.0` → `22.18.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)