### PR TITLE
fix(transaction): retry ERR_TRY_AGAIN commits instead of dropping them silently

### DIFF
--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -336,7 +336,13 @@ export class DatabaseTransaction implements Transaction {
 							});
 						},
 						(error) => {
-							if (error.code === 'ERR_BUSY') {
+							// ERR_BUSY: optimistic-transaction write conflict. ERR_TRY_AGAIN: RocksDB kTryAgain —
+							// the transaction's snapshot sequence fell outside the memtable conflict-check window
+							// (max_write_buffer_size_to_maintain), which happens under bulk-ingest bursts such as a
+							// migration full-table copy. Both are transient and retryable. Before ERR_TRY_AGAIN was
+							// retried here, the rejection propagated out of the unawaited onCommit() handler as an
+							// unhandled rejection and the write was silently dropped — records lost mid-copy (#308).
+							if (error.code === 'ERR_BUSY' || error.code === 'ERR_TRY_AGAIN') {
 								// if the transaction failed due to concurrent changes, we need to retry. First record this as an increased risk of contention/retry
 								// for future transactions
 								this.retries++;


### PR DESCRIPTION
## Summary

Under bulk-ingest bursts (notably a v4→v5 migration full-table copy into a RocksDB receiver), RocksDB returns `kTryAgain` (rocksdb-js code `ERR_TRY_AGAIN`) when a transaction's snapshot sequence falls outside the memtable conflict-check window (`max_write_buffer_size_to_maintain`). The commit error handler in `DatabaseTransaction.ts` only retried `ERR_BUSY`; `ERR_TRY_AGAIN` fell through to `throw`. Because the commit is driven from an **unawaited** `onCommit().then()`, that rejection became an unhandled promise rejection in the worker — logged but the **write was silently dropped**. Copied tables froze short of their source counts with no error surfaced anywhere.

This is the data-loss mechanism behind [harper-pro#308](https://github.com/HarperFast/harper-pro/issues/308), reproduced deterministically twice in our internal migration test bench (the internal migration-bench repro).

## Change

One clause: treat `ERR_TRY_AGAIN` like `ERR_BUSY` in the commit retry — retry with the existing backoff, and after `MAX_RETRIES` throw a `ServerError` (loud) rather than losing the write. Both are transient, retryable conflict conditions. Reuses the already-exercised `ERR_BUSY` retry/backoff path; no new control flow.

## What to check

- `resources/DatabaseTransaction.ts` — the retry condition + comment.
- The `ERR_TRY_AGAIN` code string is confirmed against rocksdb-js (`src/binding/napi/helpers.cpp:264/300`, `kTryAgain → "ERR_TRY_AGAIN"`).
- Note: rocksdb-js was already bumped to `^2.0.0` (retuned memtable defaults — `maxWriteBufferSizeToMaintain: -1`, `dbWriteBufferSize: 0`) which *reduces the frequency* of this conflict; this PR handles the residual transient occurrences so they retry instead of silently dropping. The two are complementary.

## Validation

Core `tsc` build clean. End-to-end acceptance is the internal migration-bench repro re-run (it deterministically reproduced the silent drop; per-table count parity is the signal). A focused unit test for this internal retry path needs significant transaction-harness mocking and mirrors the already-tested `ERR_BUSY` branch — happy to add one if reviewers want it.

🤖 Generated with Claude Opus 4.7.
