### PR TITLE
test: clearer timeouts + row_count polling for northwind csv_data_load races (refs #1222)

### DIFF
--- a/integrationTests/apiTests/northwind.test.mjs
+++ b/integrationTests/apiTests/northwind.test.mjs
@@ -12217,15 +12217,17 @@ suite('Northwind operations', { skip: skipSuite }, (ctx) => {
 					records: [{ name: 'Harper', shoes: 'Nike', runner_id: '1', age: 55 }],
 				})
 				.expect(200);
-			await setTimeout(200);
 		});
 
 		test('Jobs - Validate 1 entry in runners table', async () => {
-			await client
-				.req()
-				.send({ operation: 'sql', sql: 'select * from test_job.runner' })
-				.expect((r) => assert.equal(r.body.length, 1, r.text))
-				.expect(200);
+			// Poll instead of a fixed sleep: the insert above commits asynchronously
+			// on contended Bun runners, so the SQL read can race ahead of visibility
+			// (#1222).
+			const r = await waitFor(
+				() => client.req().send({ operation: 'sql', sql: 'select * from test_job.runner' }).expect(200),
+				{ until: (res) => res.body.length === 1, timeoutSeconds: isBunRuntime ? 60 : 15 }
+			);
+			assert.equal(r.body.length, 1, r.text);
 		});
 
 		test('Jobs - Test Remove Files Before with test_user', async () => {


### PR DESCRIPTION
## Summary

Partial fix toward #1222. The northwind Bun shard 2/4 flake has two distinct
symptoms — this PR cleans up the test-side races; the underlying
`csv_data_load` upsert hang on Bun (the dominant cause) needs a separate fix.

### What this fixes

* `utils/operations.mjs`: `awaitJob()` previously *silently returned* the
  IN_PROGRESS response on timeout, which surfaced downstream as the misleading
  `[{"status":"IN_PROGRESS"}]` `AssertionError`. The new `waitForJob()`
  throws on timeout with a clear `"job <id> still IN_PROGRESS after Nms"`
  message. `awaitJob` / `awaitJobCompleted` now delegate to it.
* `northwind.test.mjs`: "Check row from Data CSV job was upserted" is now a
  bounded poll of `SELECT count(*)` instead of a one-shot read — so when the
  upsert job does complete (just before the predecessor's timeout), the
  followup test no longer races a stale read.
* `northwind.test.mjs`: "Jobs - Validate 1 entry in runners table" replaces
  its preceding `setTimeout(200)` with a count poll for the same reason.
* Polling cadence uses a small initial burst (5 polls @ 200ms) and then
  settles to 1000ms — fast jobs return promptly without piling get_job traffic
  on an already-CPU-bound runner during a long wait.

### What this does NOT fix

The "CSV Data Load upsert to table w/ full perms" test (line 8733) calls
`csv_data_load` with no primary-key column in the payload (only
`companyname, new_attr`). On Bun shard 2/4 that specific job has been
observed to hang past 120s while the rest of the server stays responsive
— see the most recent main-branch run on the same SHA:
https://github.com/HarperFast/harper/actions/runs/27252990882/job/80481389717
That looks like an upstream Bun/csv_data_load worker issue, not a test-timing
problem. With this PR the failure message is now actionable
(`waitForJob: job <id> still IN_PROGRESS after 120000ms`) rather than the
misleading status-mismatch assert, but the test will still fail when the job
genuinely doesn't complete. #1222 should stay open until the hang is
investigated.

### Where to look

* `utils/operations.mjs` — verify the burst→backoff polling and the new
  throw-on-timeout semantics. Other callers (`transactions.test.mjs`,
  `delete.test.mjs`, `transaction-logs.test.mjs`, `terminology.test.mjs`)
  all assert terminal state immediately after the await, so the explicit
  throw is strictly better than a silent IN_PROGRESS return.
* `northwind.test.mjs` — two converted test bodies. The unrelated
  `setTimeout(200|500)` calls at lines 3753 / 6748 / 12189 / 12197
  (sit at the tail of a test, no followup data assertion) are left alone to
  keep this PR surgical.

Generated by Claude (Opus 4.7).