### PR TITLE
fix(jobs): unref parentPort after job completes to prevent Bun NAPI crash

### DIFF
--- a/server/jobs/jobProcess.ts
+++ b/server/jobs/jobProcess.ts
@@ -15,6 +15,7 @@ import { cloneDeep } from 'lodash';
 
 import { pathToFileURL } from 'node:url';
 import { join } from 'node:path';
+import { parentPort } from 'node:worker_threads';
 import { getEnvBuiltInComponents } from './../../components/Application.ts';
 import { PACKAGE_ROOT } from '../../utility/packageUtils.js';
 const JOB_NAME = process.env[(hdbTerms as any).PROCESS_NAME_ENV_PROP] as string;
@@ -26,12 +27,6 @@ const JOB_ID = JOB_NAME.substring(4);
  * @returns {Promise<void>}
  */
 (async function job() {
-	// Bun's event loop does not keep the loop alive for pending NAPI async callbacks
-	// (e.g. RocksDB transaction commit passing resolve/reject into native code). Job
-	// workers have no other ref'd work (HTTP server, ref'd ports), so Bun exits the
-	// loop before the callback fires. A ref'd interval prevents that.
-	const bunEventLoopKeepAlive =
-		typeof (globalThis as any).Bun !== 'undefined' ? setInterval(() => {}, 1000) : undefined;
 	// The request value could potentially be quite large so it's set to undefined to clear it out after being processed.
 	let jobObj: any = { id: JOB_ID, request: undefined };
 	let exitCode = 0;
@@ -83,7 +78,11 @@ const JOB_ID = JOB_NAME.substring(4);
 		jobObj.end_datetime = moment().valueOf();
 	} finally {
 		await jobs.updateJob(jobObj);
-		if (bunEventLoopKeepAlive) clearInterval(bunEventLoopKeepAlive);
+		// On Bun 1.3.13, calling process.exit() in a worker thread with lmdb-js loaded
+		// while sibling workers are running causes a NAPI fatal error crash. Unref
+		// parentPort (which broadcastWithAcknowledgement may have ref'd during schema
+		// changes) so the event loop drains naturally without calling process.exit().
+		parentPort?.unref();
 		setTimeout(() => {
 			realExit(exitCode);
 		}, 3000).unref();

--- a/server/jobs/jobProcess.ts
+++ b/server/jobs/jobProcess.ts
@@ -26,6 +26,12 @@ const JOB_ID = JOB_NAME.substring(4);
  * @returns {Promise<void>}
  */
 (async function job() {
+	// Bun's event loop does not keep the loop alive for pending NAPI async callbacks
+	// (e.g. RocksDB transaction commit passing resolve/reject into native code). Job
+	// workers have no other ref'd work (HTTP server, ref'd ports), so Bun exits the
+	// loop before the callback fires. A ref'd interval prevents that.
+	const bunEventLoopKeepAlive =
+		typeof (globalThis as any).Bun !== 'undefined' ? setInterval(() => {}, 1000) : undefined;
 	// The request value could potentially be quite large so it's set to undefined to clear it out after being processed.
 	let jobObj: any = { id: JOB_ID, request: undefined };
 	let exitCode = 0;
@@ -77,6 +83,7 @@ const JOB_ID = JOB_NAME.substring(4);
 		jobObj.end_datetime = moment().valueOf();
 	} finally {
 		await jobs.updateJob(jobObj);
+		if (bunEventLoopKeepAlive) clearInterval(bunEventLoopKeepAlive);
 		setTimeout(() => {
 			realExit(exitCode);
 		}, 3000).unref();


### PR DESCRIPTION
## Summary

Fixes the `csv_data_load` hang/crash on Bun (#1222). Companion to test-side PR #1225.

### Root cause

A Bun 1.3.13 bug: calling `process.exit()` in a `worker_threads.Worker` that has loaded `lmdb-js`, while sibling workers are running, triggers a NAPI fatal error:

```
panic: NAPI FATAL ERROR: Error::New napi_create_error
```

This crashes the entire Bun process (all workers, including HTTP workers), which is why the integration test sees a connection failure and times out.

**Crash chain for the CSV upsert test:**

1. `northnwd.suppliers` has `schemaDefined = false` — the table was created with `create_table` without an `attributes` array, so `Boolean(attributes) = false`
2. A CSV upsert introducing a new column triggers `addAttributes` → `runIndexing` → `signalSchemaChange` → `broadcastWithAcknowledgement`
3. `broadcastWithAcknowledgement` calls `port.ref()` on **all** connected ports — including `parentPort`
4. After ACKs are received, the ack handler unref's sibling ports but **never unref's `parentPort`** (intentional for regular workers, but wrong for job workers)
5. The ref'd `parentPort` keeps the event loop alive until the 3-second unref'd `realExit` timer fires
6. `realExit(exitCode)` → `process.exit()` in the lmdb-bearing job worker → Bun crash

The previous commit on this branch had the wrong premise (blamed NAPI event-loop ref counting for RocksDB callbacks) and its keepalive `setInterval` actually made things worse by ensuring `realExit` was always called.

### Fix

Unref `parentPort` in `jobProcess.ts` after `updateJob` completes. This lets the event loop drain naturally — no more `process.exit()` call, no Bun crash.

```diff
 } finally {
     await jobs.updateJob(jobObj);
+    // On Bun 1.3.13, calling process.exit() in a worker thread with lmdb-js loaded
+    // while sibling workers are running causes a NAPI fatal error crash. Unref
+    // parentPort (which broadcastWithAcknowledgement may have ref'd during schema
+    // changes) so the event loop drains naturally without calling process.exit().
+    parentPort?.unref();
     setTimeout(() => {
         realExit(exitCode);
     }, 3000).unref();
 }
```

The `?.` is defensive — `parentPort` is `null` if the file runs as the main thread (it never does, but avoids a TypeScript complaint).

## Test plan

- [ ] Run northwind Bun integration tests (shard 2/4) — "CSV Data Load upsert to table w/ full perms" (line 8733) should complete without a crash
- [ ] Verify no regression on Node shards (the unref is a no-op there — `parentPort` is either already unref'd or ref-count is unaffected)
- [ ] Pair with #1225 (test-side polling) for a clean pass

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-sonnet-4-6)