### PR TITLE
Re-enable latest/next package tagging

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -38,16 +38,12 @@ jobs:
           version: ${{ github.event.release.tag_name || inputs.tag_name }}
       - name: Set package tag
         id: package-tag
-        # Once we have our first full, non-beta release, turn this back on:
-        #        run: |
-        #          if [[ "${{ steps.version-components.outputs.prerelease }}" == '' ]]; then
-        #            echo "packageTag=latest" >> "$GITHUB_OUTPUT"
-        #          else
-        #            echo "packageTag=next" >> "$GITHUB_OUTPUT"
-        #          fi
-        # and get rid of this hard coded latest tagging:
         run: |
-          echo "packageTag=latest" >> "$GITHUB_OUTPUT"
+          if [[ "${{ steps.version-components.outputs.prerelease }}" == '' ]]; then
+            echo "packageTag=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "packageTag=next" >> "$GITHUB_OUTPUT"
+          fi
       - name: Publish package to NPM registry
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -83,16 +79,12 @@ jobs:
           tar -czvf harperfast-harper-${{ steps.version-components.outputs.version }}.tgz package
       - name: Set package tag
         id: package-tag
-        # Once we have our first full, non-beta release, turn this back on:
-        #        run: |
-        #          if [[ "${{ steps.version-components.outputs.prerelease }}" == '' ]]; then
-        #            echo "packageTag=latest" >> "$GITHUB_OUTPUT"
-        #          else
-        #            echo "packageTag=next" >> "$GITHUB_OUTPUT"
-        #          fi
-        # and get rid of this hard coded latest tagging:
         run: |
-          echo "packageTag=latest" >> "$GITHUB_OUTPUT"
+          if [[ "${{ steps.version-components.outputs.prerelease }}" == '' ]]; then
+            echo "packageTag=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "packageTag=next" >> "$GITHUB_OUTPUT"
+          fi
       - name: Publish package to NPM registry
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2988,9 +2988,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3006,9 +3003,6 @@
 			"integrity": "sha512-x3F2h7fVwH1IHYlQDFOO5YJ9NH3pPkZybjPOaV1Vo8BiE9A72BabcVbQeV98/3STcMP2k20YpoggsI8QjcdCzQ==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -3026,9 +3020,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3044,9 +3035,6 @@
 			"integrity": "sha512-gswLCyzqPUoB2HlTE+DMOd2Nr7H9uUg/pgtZpIvTpHU6ewV2O8mANT6qV/DLN9uPKWrBSp77b92PxXYtPRyPsA==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -3754,11 +3742,13 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
 			"version": "3.0.4",
@@ -3767,11 +3757,13 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
 			"version": "3.0.4",
@@ -3780,11 +3772,13 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
 			"version": "3.0.4",
@@ -3793,11 +3787,13 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
 			"version": "3.0.4",
@@ -3806,11 +3802,13 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
 			"version": "3.0.4",
@@ -3819,11 +3817,13 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@noble/hashes": {
 			"version": "1.8.0",
@@ -4004,9 +4004,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4024,9 +4021,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4044,9 +4038,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4064,9 +4055,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4084,9 +4072,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4104,9 +4089,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4124,9 +4106,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4144,9 +4123,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -9360,9 +9336,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -9381,9 +9354,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -9402,9 +9372,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -9423,9 +9390,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -12380,9 +12344,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -12401,9 +12362,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -12422,9 +12380,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -12443,9 +12398,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -2988,6 +2988,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3003,6 +3006,9 @@
 			"integrity": "sha512-x3F2h7fVwH1IHYlQDFOO5YJ9NH3pPkZybjPOaV1Vo8BiE9A72BabcVbQeV98/3STcMP2k20YpoggsI8QjcdCzQ==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -3020,6 +3026,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3035,6 +3044,9 @@
 			"integrity": "sha512-gswLCyzqPUoB2HlTE+DMOd2Nr7H9uUg/pgtZpIvTpHU6ewV2O8mANT6qV/DLN9uPKWrBSp77b92PxXYtPRyPsA==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -3742,13 +3754,11 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
 			"version": "3.0.4",
@@ -3757,13 +3767,11 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
 			"version": "3.0.4",
@@ -3772,13 +3780,11 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
 			"version": "3.0.4",
@@ -3787,13 +3793,11 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
 			"version": "3.0.4",
@@ -3802,13 +3806,11 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
 			"version": "3.0.4",
@@ -3817,13 +3819,11 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@noble/hashes": {
 			"version": "1.8.0",
@@ -4004,6 +4004,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4021,6 +4024,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4038,6 +4044,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4055,6 +4064,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4072,6 +4084,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4089,6 +4104,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4106,6 +4124,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4123,6 +4144,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -9336,6 +9360,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -9354,6 +9381,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -9372,6 +9402,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -9390,6 +9423,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -12344,6 +12380,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -12362,6 +12401,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -12380,6 +12422,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -12398,6 +12443,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [


### PR DESCRIPTION
Now that we have our first full, non-beta release, we can turn the latest/next tag logic back on.