### PR TITLE
fix: guard against corrupt __dbis__ entries crashing startup

### DIFF
--- a/dataLayer/hdbInfoController.ts
+++ b/dataLayer/hdbInfoController.ts
@@ -237,7 +237,12 @@ function checkIfInstallIsSupported(dataVNum) {
 		'In order to upgrade to this version, you must do a fresh install. If you need support, ' +
 		`please contact ${hdbTerms.HDB_SUPPORT_ADDRESS}`;
 
-	if (!tableLoader.databases.system || !('hdb_info' in tableLoader.databases.system)) {
+	if (!tableLoader.databases.system) {
+		const loadErrMsg = 'The system database failed to load. Harper cannot start.';
+		console.log(loadErrMsg);
+		throw new Error(loadErrMsg);
+	}
+	if (!('hdb_info' in tableLoader.databases.system)) {
 		console.log(errMsg);
 		throw new Error(errMsg);
 	}

--- a/dataLayer/hdbInfoController.ts
+++ b/dataLayer/hdbInfoController.ts
@@ -237,7 +237,7 @@ function checkIfInstallIsSupported(dataVNum) {
 		'In order to upgrade to this version, you must do a fresh install. If you need support, ' +
 		`please contact ${hdbTerms.HDB_SUPPORT_ADDRESS}`;
 
-	if (!('hdb_info' in tableLoader.databases.system)) {
+	if (!tableLoader.databases.system || !('hdb_info' in tableLoader.databases.system)) {
 		console.log(errMsg);
 		throw new Error(errMsg);
 	}

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -506,6 +506,7 @@ function initStores(
 
 	for (const result of attributesDbi.getRange({ start: false })) {
 		const { key, value } = result as { key: string; value: any };
+		if (value == null) continue;
 		let [tableName, attribute_name] = key.toString().split('/');
 		if (attribute_name === '') {
 			// primary key
@@ -1104,6 +1105,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 	Table.dbisDB = attributesDbi;
 	const indicesToRemove = [];
 	for (const { key, value } of attributesDbi.getRange({ start: true })) {
+		if (value == null) continue;
 		let [attributeTableName, attribute_name] = key.toString().split('/');
 		if (attribute_name === '') attribute_name = value.name; // primary key
 		if (attribute_name) {


### PR DESCRIPTION
Two null-safety guards for cases where `__dbis__` (table/attribute metadata DBI) contains entries that can't be decoded.

**What breaks without this:** When `RecordEncoder.decode` fails on a `__dbis__` entry (returns `null`), startup crashes accessing `value.name` or `value.isPrimaryKey`. Separately, if `getDatabases()` throws mid-scan, `loadedDatabases` is already `true` but `databases.system` is never populated, causing `TypeError: Cannot use 'in' operator to search for 'hdb_info' in undefined` in `checkIfInstallIsSupported`.

**Changes:**
- `resources/databases.ts`: Added `if (value == null) continue;` in both `getRange` loops (`initStores` and `table()`). `RecordEncoder.decode` already logs the decode error; corrupt entries are skipped.
- `dataLayer/hdbInfoController.ts`: Added `!tableLoader.databases.system ||` before the `'in'` check.

**Root cause context:** Observed after a v5.1.0-beta.1 → v5.0.x → v5.1.0-beta.1 upgrade/downgrade/upgrade cycle. beta.1 included the bug from #1160 (struct encoding applied to all DBIs, not just primary), so it wrote `__dbis__` entries in struct mode with `typedStructs` stored under `Symbol(structures)`. When v5.0 then ran, it had no struct read hook for `__dbis__`, silently decoded those entries as null, and on any DBI write overwrote `Symbol(structures)` with a plain array — discarding the `typed` key and wiping the typedStructs mapping. When beta.1 came back up, the struct read hook was present but typedStructs were gone, so struct-encoded entries decode to null.

The root fix is #1160 (now on main/beta.2). These null guards are defense-in-depth so a future version mismatch or data corruption doesn't hard-crash startup.

Generated by Claude Sonnet 4.6