### PR TITLE
chore(deps): bump @harperfast/rocksdb-js 1.4.2 → 1.5.0 on v5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2218,9 +2218,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@harperfast/rocksdb-js": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js/-/rocksdb-js-1.4.2.tgz",
-			"integrity": "sha512-wQ0buhmNVcw6jPn5VOoYDsGmO1IAmtithcSgaKrnBRicf+ATvQSCB1I7ljEBuqqzWG6HcJXeCgPhFpas3kRwOw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js/-/rocksdb-js-1.5.0.tgz",
+			"integrity": "sha512-NyH8Nr+jOclzzFzPmN9aC58lvl7X7Gf94E/laJqIeWP7/dsrdbDgNPHBueBdh1JnAq5Fxd+qvEDf/PCGaA/cgw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@harperfast/extended-iterable": "1.0.3",
@@ -2234,20 +2234,20 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@harperfast/rocksdb-js-darwin-arm64": "1.4.2",
-				"@harperfast/rocksdb-js-darwin-x64": "1.4.2",
-				"@harperfast/rocksdb-js-linux-arm64-glibc": "1.4.2",
-				"@harperfast/rocksdb-js-linux-arm64-musl": "1.4.2",
-				"@harperfast/rocksdb-js-linux-x64-glibc": "1.4.2",
-				"@harperfast/rocksdb-js-linux-x64-musl": "1.4.2",
-				"@harperfast/rocksdb-js-win32-arm64": "1.4.2",
-				"@harperfast/rocksdb-js-win32-x64": "1.4.2"
+				"@harperfast/rocksdb-js-darwin-arm64": "1.5.0",
+				"@harperfast/rocksdb-js-darwin-x64": "1.5.0",
+				"@harperfast/rocksdb-js-linux-arm64-glibc": "1.5.0",
+				"@harperfast/rocksdb-js-linux-arm64-musl": "1.5.0",
+				"@harperfast/rocksdb-js-linux-x64-glibc": "1.5.0",
+				"@harperfast/rocksdb-js-linux-x64-musl": "1.5.0",
+				"@harperfast/rocksdb-js-win32-arm64": "1.5.0",
+				"@harperfast/rocksdb-js-win32-x64": "1.5.0"
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-darwin-arm64": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-arm64/-/rocksdb-js-darwin-arm64-1.4.2.tgz",
-			"integrity": "sha512-qQyv8BNCjvZQayhoTd7iqt1CLNEFHfqe8/SDZk8ztAR0ZAIyHIFkmNnaQ/Izn6p3HrNCRp6lNdwO4TKPWHj4SQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-arm64/-/rocksdb-js-darwin-arm64-1.5.0.tgz",
+			"integrity": "sha512-g8P4H/imnxn/AoGp+R5TZjHbwezdcMJCyIqo+2F1bLm3lGGaqTMrrmXK7vXxLj/COUMbooJ04QlGei7+nGShhA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2261,9 +2261,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-darwin-x64": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-x64/-/rocksdb-js-darwin-x64-1.4.2.tgz",
-			"integrity": "sha512-cPCsB7IVeuDhNjFcb/nqUkwtBI9BlaFNecJ/OjkG8hUpYAhd5rdNHFMt1vpu4sAYFaorFrMZoNKGbq43v14+hQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-x64/-/rocksdb-js-darwin-x64-1.5.0.tgz",
+			"integrity": "sha512-62g7+n0G/QV2iBPFGV8ihCi6ZFW/4cxfe+SqQAOQ7p+YtA8/68o3X7b9j2+/fEixAC0ktLp/5mUie5hQVSmZrg==",
 			"cpu": [
 				"x64"
 			],
@@ -2277,9 +2277,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-arm64-glibc": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-glibc/-/rocksdb-js-linux-arm64-glibc-1.4.2.tgz",
-			"integrity": "sha512-NquwD+7Gxu3BYAIQhvSThjIRlZRBieDZKXGEmrc0gfcxcORbgOjMCdxDzhjF6l1nR4ODlfJfbKqGyF8JtmnIjA==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-glibc/-/rocksdb-js-linux-arm64-glibc-1.5.0.tgz",
+			"integrity": "sha512-hls3Hg8tHIAwBLL+3VHsHHpZO/D1BWoPkN8cjq8vnVSLEAAYS1qyJpePY1hdwEsL8TD2jBPs5YZwMGQ2EQCiWQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2296,9 +2296,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-arm64-musl": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-musl/-/rocksdb-js-linux-arm64-musl-1.4.2.tgz",
-			"integrity": "sha512-hp2IOXYBvloJEkZ/+bCI/AsQPtzza51Pkz+U+JkaAaayZ6+zsXdVp5GuGYPnCiH4O6QnOihKkgBW8msFhR0ogA==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-musl/-/rocksdb-js-linux-arm64-musl-1.5.0.tgz",
+			"integrity": "sha512-aS+/ZzoOAGiEcIfhpS0xPMMBlBKkEjZAVE9Y92yhVFaMIMhE8UhRPwu0tFyWos6BdyLQ7/Ud5ncR42ZIUh8Y1g==",
 			"cpu": [
 				"arm64"
 			],
@@ -2315,9 +2315,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-x64-glibc": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-glibc/-/rocksdb-js-linux-x64-glibc-1.4.2.tgz",
-			"integrity": "sha512-zEkBHRoLanN9MTVY1mFRGDdAGyXBUrk962xvtf0sGj/wIK2M3c2KL39FftWHgtm/BHA3uGHssWk6B7O2O/Dlig==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-glibc/-/rocksdb-js-linux-x64-glibc-1.5.0.tgz",
+			"integrity": "sha512-70kPD6KKwtRJMsBBnKm8JYP+QncIYl7xb02/dVswdv1I5AqN1UNeqJBU4+K4q6QP6FeNpK25oruz8S1iy8QkLQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2334,9 +2334,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-x64-musl": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-1.4.2.tgz",
-			"integrity": "sha512-K7y1CC+LJma2E+wEqFq67jk7+hZW+oPdKcqxyDxrIRKO3jyn0Dtr/fwQf3cFuU8cRnZBmZTAcnr5LeNJrUuYRw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-1.5.0.tgz",
+			"integrity": "sha512-jnGa96c1w9L98ioGAzAezlni6Nls9LQ3A5Z4HYnPrY+Dz7Q9SeYANVv+edLR/Xt8fEQn9Yz6DkpYpns3ykUzGA==",
 			"cpu": [
 				"x64"
 			],
@@ -2353,9 +2353,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-win32-arm64": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-1.4.2.tgz",
-			"integrity": "sha512-xc4oav0zTLfnjBIan1wlgB3g0NeWrzUPxR0Vq5HkLc4BGyAlPql+v1FwtQ4X6AwcAOHnS/QeYSGDQOZn6Ac1Ow==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-1.5.0.tgz",
+			"integrity": "sha512-a3A68UqztdRS1Ind5UK9sytOJPoE9UJKlGt3623HVIaiQPfP3me9mx6YpnddqBshK0Lojzr5+cc6G1ewSFGEBw==",
 			"cpu": [
 				"arm64"
 			],
@@ -2369,9 +2369,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-win32-x64": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-x64/-/rocksdb-js-win32-x64-1.4.2.tgz",
-			"integrity": "sha512-60vqTYJdw0ysvHeFHoxZ/sHNesdfvri+jWIyU5TTua2s20LmLZ4hKLglnsa0LP7/IA5JutZsxJiyUUMCoG3PDw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-x64/-/rocksdb-js-win32-x64-1.5.0.tgz",
+			"integrity": "sha512-0PKUTon/o5TUT3XBMPGPJl6Ry4aP/1D134HDP9XGSYWqtcQwzDb0LsRQdJhF9ixJQzVPrXw9mDGMQFzasVmvcw==",
 			"cpu": [
 				"x64"
 			],

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1864,8 +1864,7 @@ export function makeTable(options) {
 								// retained window are not layered in — but the authoritative full-copy record restores exact
 								// convergence. Because we stopped before reaching txnTime, the inline duplicate detection in
 								// the walk never ran; full-copy audit-replay re-delivers writes, and re-applying one would
-								// double-apply its commutative ops, so rule that out here with a single O(1) lookup at txnTime
-								// (RocksDB audit logs are keyed by version, and the cap is RocksDB-only).
+								// double-apply its commutative ops, so rule that out here before folding.
 								logger.warn?.(
 									'Out-of-order audit reconciliation exceeded depth cap; reconciling against most recent updates only',
 									{
@@ -1874,16 +1873,24 @@ export function makeTable(options) {
 										depth: walkSteps,
 									}
 								);
-								const duplicate = auditStore.get(txnTime, tableId, id, options?.nodeId);
-								if (
-									duplicate &&
-									duplicate.version === txnTime &&
-									precedesExistingVersion(
-										txnTime,
-										{ version: txnTime, localTime: txnTime, key: id, nodeId: duplicate.nodeId },
-										options?.nodeId
-									) === 0
-								) {
+								// Detect a re-delivered duplicate via the record's own additionalAuditRefs rather than an
+								// audit-log lookup at txnTime. Every out-of-order write folded into this record records its
+								// {version, nodeId} ref (added in the walk above, RocksDB-only — the same condition as this
+								// cap), and the record is read with read-your-writes consistency. The transaction-log query
+								// that a keyed audit lookup would use can lag a back-to-back re-delivery — the just-committed
+								// entry is not yet visible — which silently double-applied the commutative op (#1137).
+								// precedesExistingVersion(...) === 0 is the identity tie: same version AND same node (the
+								// local node is id 0, so an undefined options?.nodeId resolves to the same 0 the ref stored).
+								const alreadyApplied = existingEntry?.additionalAuditRefs?.some(
+									(ref) =>
+										ref.version === txnTime &&
+										precedesExistingVersion(
+											txnTime,
+											{ version: txnTime, localTime: txnTime, key: id, nodeId: ref.nodeId },
+											options?.nodeId
+										) === 0
+								);
+								if (alreadyApplied) {
 									write.skipped = true;
 									return; // duplicate write already applied
 								}

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1733,6 +1733,32 @@ export function makeTable(options) {
 						// of the updates to the record to ensure consistency across the cluster
 						// TODO: can the previous version be older, but even more previous version be newer?
 						if (audit) {
+							// A re-delivered out-of-order write (full-copy audit-replay re-delivers writes) must not have
+							// its commutative ops re-folded. additionalAuditRefs is the record's own list of folded
+							// out-of-order versions, read with read-your-writes consistency, so this skips the duplicate up
+							// front — before the audit-log walk below, which can miss it: the walk stops at the depth cap, or
+							// breaks early on a not-yet-visible audit entry, before reaching txnTime, and the keyed
+							// transaction-log lookup it would otherwise use can lag a back-to-back re-delivery (that lag
+							// silently double-applied the increment — #1137). This covers the re-delivery while the ref is
+							// still on the record; a later in-order write rewrites the record and drops the ref (it survives
+							// only as previousAdditionalAuditRefs on the audit log), so that case falls back to the
+							// best-effort keyed lookup in the capped block below — see #1148. precedesExistingVersion(...)
+							// === 0 is the identity tie: same version AND same node (the local node is id 0, so an undefined
+							// options?.nodeId resolves to the same 0 the ref stored).
+							if (
+								existingEntry.additionalAuditRefs?.some(
+									(ref) =>
+										ref.version === txnTime &&
+										precedesExistingVersion(
+											txnTime,
+											{ version: txnTime, localTime: txnTime, key: id, nodeId: ref.nodeId },
+											options?.nodeId
+										) === 0
+								)
+							) {
+								write.skipped = true;
+								return; // out-of-order write already folded into this record
+							}
 							// incremental CRDT updates are only available with audit logging on
 							let localTime = existingEntry.localTime;
 							let auditedVersion = existingEntry.version;
@@ -1864,7 +1890,12 @@ export function makeTable(options) {
 								// retained window are not layered in — but the authoritative full-copy record restores exact
 								// convergence. Because we stopped before reaching txnTime, the inline duplicate detection in
 								// the walk never ran; full-copy audit-replay re-delivers writes, and re-applying one would
-								// double-apply its commutative ops, so rule that out here before folding.
+								// double-apply its commutative ops. A re-delivered out-of-order write is already ruled out by
+								// the additionalAuditRefs check at the top of this block; this keyed lookup is the best-effort
+								// guard for the remaining case — a re-delivered write that was originally in-order (so it left
+								// no ref) and is now deeper than the cap. It is best-effort because the transaction-log lookup
+								// can intermittently miss an entry under load (tracked separately); the authoritative full-copy
+								// record still restores exact convergence.
 								logger.warn?.(
 									'Out-of-order audit reconciliation exceeded depth cap; reconciling against most recent updates only',
 									{
@@ -1873,24 +1904,16 @@ export function makeTable(options) {
 										depth: walkSteps,
 									}
 								);
-								// Detect a re-delivered duplicate via the record's own additionalAuditRefs rather than an
-								// audit-log lookup at txnTime. Every out-of-order write folded into this record records its
-								// {version, nodeId} ref (added in the walk above, RocksDB-only — the same condition as this
-								// cap), and the record is read with read-your-writes consistency. The transaction-log query
-								// that a keyed audit lookup would use can lag a back-to-back re-delivery — the just-committed
-								// entry is not yet visible — which silently double-applied the commutative op (#1137).
-								// precedesExistingVersion(...) === 0 is the identity tie: same version AND same node (the
-								// local node is id 0, so an undefined options?.nodeId resolves to the same 0 the ref stored).
-								const alreadyApplied = existingEntry?.additionalAuditRefs?.some(
-									(ref) =>
-										ref.version === txnTime &&
-										precedesExistingVersion(
-											txnTime,
-											{ version: txnTime, localTime: txnTime, key: id, nodeId: ref.nodeId },
-											options?.nodeId
-										) === 0
-								);
-								if (alreadyApplied) {
+								const duplicate = auditStore.get(txnTime, tableId, id, options?.nodeId);
+								if (
+									duplicate &&
+									duplicate.version === txnTime &&
+									precedesExistingVersion(
+										txnTime,
+										{ version: txnTime, localTime: txnTime, key: id, nodeId: duplicate.nodeId },
+										options?.nodeId
+									) === 0
+								) {
 									write.skipped = true;
 									return; // duplicate write already applied
 								}


### PR DESCRIPTION
Bumps `@harperfast/rocksdb-js` 1.4.2 → 1.5.0 on the v5.0 patch line. Lock-file-only change; `package.json` already has `^1.4.2`.

**Key fixes in rocksdb-js 1.5.0:**
- txn-log read-path truncation fix (#1148)
- Torn-tail recovery on open
- Lock-free EventEmitter listener gate
- Cross-env EventEmitter safety
- Node 26 Windows build fix

**Companion fix: backport PR #1147 (commutative-op duplicate detection)**

The rocksdb-js 1.5.0 txn-log read-path change exposed a pre-existing reliability gap in the bounded out-of-order audit-chain walk (#1114 depth cap). When the cap is hit, the walk never reaches `txnTime`, so the inline duplicate check doesn't run. The original fallback was `auditStore.get(txnTime, ...)` — a keyed transaction-log lookup that can miss a just-committed entry under load, silently double-applying a commutative op (`+3 → +6` regression in the `#1114` test case).

Cherry-picked two commits from main's PR #1147:
1. `f469ae9b5` — initial fix: replace the keyed txn-log lookup with an `additionalAuditRefs` check (those refs are read with read-your-writes consistency, immune to the visibility lag)
2. `626f8183f` — rework: move the `additionalAuditRefs` duplicate check to the **top** of the out-of-order block (before the walk), so re-delivered duplicates are skipped before the walk — immune to both the depth cap and a not-yet-visible audit entry breaking early; restore the keyed lookup as the best-effort guard for originally-in-order re-deliveries (tracked in #1148)

The target test (`does not double-apply a re-delivered commutative op in the bounded path (#1114)`) passes reliably after this fix. It was passing in low-load local runs even without the fix (the keyed lookup finds the entry when there's no contention), which is why CI under load exposed it.

_Generated by Claude Sonnet 4.6_