### PR TITLE
fix(integration): wait for csv_data_load completion in northwind suite (#1222)

### DIFF
--- a/integrationTests/apiTests/northwind.test.mjs
+++ b/integrationTests/apiTests/northwind.test.mjs
@@ -20,7 +20,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { startHarper, teardownHarper } from '@harperfast/integration-testing';
 import { createApiClient, createHeaders } from './utils/client.mjs';
-import { awaitJob, awaitJobCompleted, getJobId } from './utils/operations.mjs';
+import { awaitJob, awaitJobCompleted, getJobId, waitFor } from './utils/operations.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const csvPath = join(__dirname, 'data') + '/';
@@ -2160,7 +2160,10 @@ suite('Northwind operations', { skip: skipSuite }, (ctx) => {
 		// Use awaitJob + manual assertions so we can return job.message as a raw
 		// object — awaitJobCompleted would stringify it, breaking callers that
 		// access errorMsg.unauthorized_access / errorMsg.invalid_schema_items.
-		const jobResp = await awaitJob(client, getJobId(r.body), isBunRuntime ? 120 : 30);
+		// Bun under CI-runner contention can leave a small csv_data_load job
+		// IN_PROGRESS well past a minute, so the wait is bounded but generous
+		// (#1222).
+		const jobResp = await awaitJob(client, getJobId(r.body), isBunRuntime ? 300 : 30);
 		const job = jobResp.body[0];
 		assert.ok(job, `No job found in response: ${jobResp.text}`);
 		if (_expectedError) {
@@ -8742,15 +8745,22 @@ suite('Northwind operations', { skip: skipSuite }, (ctx) => {
 		});
 
 		test('Check row from Data CSV job was upserted', async () => {
-			await client
-				.req()
-				.send({
-					operation: 'sql',
-					sql: `SELECT count(*) AS row_count
+			// The upsert load above is asynchronous; poll the count until the new
+			// row is visible rather than asserting once (it can still be flushing
+			// under Bun/CI-runner contention — #1222).
+			const r = await waitFor(
+				() =>
+					client
+						.req()
+						.send({
+							operation: 'sql',
+							sql: `SELECT count(*) AS row_count
 		                                  FROM northnwd.suppliers`,
-				})
-				.expect((r) => assert.equal(r.body[0].row_count, 30, r.text))
-				.expect(200);
+						})
+						.expect(200),
+				{ until: (res) => res.body?.[0]?.row_count === 30, timeoutSeconds: isBunRuntime ? 60 : 15 }
+			);
+			assert.equal(r.body[0].row_count, 30, r.text);
 		});
 
 		test.skip('Import CSV from S3 to table w/ full attr perms - update', async () => {

--- a/integrationTests/apiTests/northwind.test.mjs
+++ b/integrationTests/apiTests/northwind.test.mjs
@@ -8760,7 +8760,7 @@ suite('Northwind operations', { skip: skipSuite }, (ctx) => {
 						.expect(200),
 				{ until: (res) => res.body?.[0]?.row_count === 30, timeoutSeconds: isBunRuntime ? 60 : 15 }
 			);
-			assert.equal(r.body[0].row_count, 30, r.text);
+			assert.equal(r.body?.[0]?.row_count, 30, r.text);
 		});
 
 		test.skip('Import CSV from S3 to table w/ full attr perms - update', async () => {

--- a/integrationTests/apiTests/utils/operations.mjs
+++ b/integrationTests/apiTests/utils/operations.mjs
@@ -28,7 +28,7 @@ export async function awaitJob(client, jobId, timeoutSeconds = 15) {
 	let elapsed = 0;
 	do {
 		response = await client.req().send({ operation: 'get_job', id: jobId }).expect(200);
-		const status = response.body[0]?.status;
+		const status = response.body?.[0]?.status;
 		// Stop only on a terminal status. A freshly-started job is briefly
 		// CREATED (queued, before the worker flips it to IN_PROGRESS) and a
 		// just-created job record can momentarily come back empty; returning on
@@ -87,6 +87,10 @@ export async function awaitJobCompleted(client, jobId, options = {}) {
  * an asynchronous side effect — the source of the fixed-delay races in #1222.
  *
  * @template T
+ * A transient failure from `produce`/`until` (e.g. a momentary non-200 under CI
+ * contention) is swallowed and retried; the error is re-thrown only if it
+ * happens on the final attempt, so a persistent failure still surfaces.
+ *
  * @param {() => Promise<T> | T} produce  Produces the current value (e.g. runs a query).
  * @param {{ until: (value: T) => boolean, timeoutSeconds?: number, intervalMs?: number }} options
  * @returns {Promise<T>} the last produced value (satisfying `until`, or the final attempt on timeout)
@@ -95,8 +99,12 @@ export async function waitFor(produce, { until, timeoutSeconds = 30, intervalMs 
 	const attempts = Math.max(1, Math.ceil((timeoutSeconds * 1000) / intervalMs));
 	let value;
 	for (let attempt = 0; attempt < attempts; attempt++) {
-		value = await produce();
-		if (until(value)) return value;
+		try {
+			value = await produce();
+			if (until(value)) return value;
+		} catch (error) {
+			if (attempt === attempts - 1) throw error;
+		}
 		if (attempt < attempts - 1) await setTimeout(intervalMs);
 	}
 	return value;

--- a/integrationTests/apiTests/utils/operations.mjs
+++ b/integrationTests/apiTests/utils/operations.mjs
@@ -28,7 +28,13 @@ export async function awaitJob(client, jobId, timeoutSeconds = 15) {
 	let elapsed = 0;
 	do {
 		response = await client.req().send({ operation: 'get_job', id: jobId }).expect(200);
-		if (response.body[0]?.status !== 'IN_PROGRESS') break;
+		const status = response.body[0]?.status;
+		// Stop only on a terminal status. A freshly-started job is briefly
+		// CREATED (queued, before the worker flips it to IN_PROGRESS) and a
+		// just-created job record can momentarily come back empty; returning on
+		// "anything that isn't IN_PROGRESS" would hand the caller a job that
+		// hasn't run yet. Keep polling until COMPLETE/ERROR or the timeout.
+		if (status === 'COMPLETE' || status === 'ERROR') break;
 		await setTimeout(1000);
 		elapsed++;
 	} while (elapsed < timeoutSeconds);
@@ -71,4 +77,27 @@ export async function awaitJobCompleted(client, jobId, options = {}) {
 		);
 	}
 	return job.message;
+}
+
+/**
+ * Poll `produce` until `until(value)` is satisfied or the timeout expires, then
+ * return the most recent produced value. The caller asserts on the returned
+ * value so a timeout still surfaces a precise failure (e.g. the wrong count).
+ * Use this in place of `await setTimeout(n)` followed by a one-shot assertion on
+ * an asynchronous side effect — the source of the fixed-delay races in #1222.
+ *
+ * @template T
+ * @param {() => Promise<T> | T} produce  Produces the current value (e.g. runs a query).
+ * @param {{ until: (value: T) => boolean, timeoutSeconds?: number, intervalMs?: number }} options
+ * @returns {Promise<T>} the last produced value (satisfying `until`, or the final attempt on timeout)
+ */
+export async function waitFor(produce, { until, timeoutSeconds = 30, intervalMs = 250 } = {}) {
+	const attempts = Math.max(1, Math.ceil((timeoutSeconds * 1000) / intervalMs));
+	let value;
+	for (let attempt = 0; attempt < attempts; attempt++) {
+		value = await produce();
+		if (until(value)) return value;
+		if (attempt < attempts - 1) await setTimeout(intervalMs);
+	}
+	return value;
 }


### PR DESCRIPTION
## Summary

Closes #1222 — flaky `csv_data_load` bulk-load races in `integrationTests/apiTests/northwind.test.mjs`, most visible on **Bun, Integration Tests shard 2/4**.

From the actual failing CI job, both reported symptoms came from **one slow job in the same run**: under Bun CPU contention a `bulk_load_user` upsert `csv_data_load` (test at `:8733`) started promptly but stayed `IN_PROGRESS` past `csvDataLoad`'s 120s cap, so its `assert COMPLETE` failed — and the dependent row-count test (`:8744`) then read **29** instead of 30 because the upsert hadn't committed.

## Changes

- **`awaitJob` (utils/operations.mjs)** — poll until a **terminal** status (`COMPLETE`/`ERROR`) instead of breaking on `status !== 'IN_PROGRESS'`. Harper's job lifecycle is `CREATED → IN_PROGRESS → COMPLETE/ERROR`; a freshly-started job is briefly `CREATED` (and its record can momentarily come back empty), so the old check could hand the caller a job that **hadn't run yet**. This is shared by the `delete` / `transactions` / `transaction-logs` suites, which all assert on completed results — so it's a strict improvement for them too.
- **`waitFor(produce, { until, timeoutSeconds, intervalMs })`** — new reusable condition-poll helper (the `waitForJob`-style helper the issue suggested), returning the last produced value so a timeout still yields a precise assertion. A transient failure from `produce`/`until` (a momentary non-200 under contention) is swallowed and retried; a persistent error re-throws on the final attempt.
- **csv_data_load wait** — bounded-but-generous Bun timeout, `120s → 300s`. It's a ceiling, not a floor: healthy runs complete in ~2s and never approach it; it only absorbs contention spikes.
- **row-count check** — polls the count until it reaches the expected value instead of asserting once after the (async) load.

## Where to look / lower-confidence spots

- **`awaitJob` semantic change** is the one with blast radius — it now also waits through `CREATED`/empty-body states for the three other suites that import it. Verified each of those callers asserts on a *completed* job (`message.includes('...deleted')`, `'Successfully completed'`, `result.log_files_deleted`), so waiting longer can only help; please sanity-check that reasoning.
- **The 300s Bun ceiling** is a judgement call. The observed bad run sat `IN_PROGRESS` ~120s+; 300s gives headroom for contention without masking a true hang (which still fails, just slower). Open to a different number.

## Deliberately not touched

The issue's "Root cause" also listed five `setTimeout` sites (`:3753, 6748, 12189, 12197, 12210`). Tracing each: they follow `create_schema` / `create_table` / `insert` / `update` (synchronous ops), are carried-over cruft from the suite-port commit, and are **not** in the failure path (CI implicated only `:8733`/`:8744`). Removing them risks new schema-propagation flakes on unimplicated code, so they're left for a trivial follow-up.

## Review

- **`claude[bot]`**: no blockers. **Harper-domain pass** (deep-review): no blockers, no significant concerns.
- **`gemini-code-assist[bot]`**: three medium suggestions — optional-chaining on response bodies (×2) and the `waitFor` try/catch — all applied in the second commit.
- Cross-model caveat: the Codex leg was unavailable this run (workspace spend cap) and the Gemini *CLI* leg is inapplicable to an all-test diff; the Gemini *bot* review above covered that lens.

## Testing

- `node --check` + oxlint clean; prettier reports both files unchanged.
- Validated the new polling control flow with a fake-client harness (waits through `CREATED`/empty/`IN_PROGRESS` → `COMPLETE`, stops on `ERROR`, returns last response on timeout; `waitFor` returns on `until`, returns last on timeout, climbs count→30).
- The Bun-under-contention flake itself only reproduces in CI — exercised by this PR's CI run.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8)
