### PR TITLE
feat(config): add `HARPER_CONFIG` as the recommended way to set config from the environment

### DIFF
--- a/config/configUtils.js
+++ b/config/configUtils.js
@@ -872,18 +872,23 @@ function applyRuntimeEnvVarConfig(configDoc, configFilePath, options = {}) {
 	const defaultEnvValue = process.env.HARPER_DEFAULT_CONFIG;
 	const configEnvValue = process.env.HARPER_CONFIG;
 	const setEnvValue = process.env.HARPER_SET_CONFIG;
+	const anyEnvValue = defaultEnvValue || configEnvValue || setEnvValue;
 
-	// No env vars set, skip entirely (zero overhead)
-	if (!defaultEnvValue && !configEnvValue && !setEnvValue) return;
-
-	const { applyRuntimeEnvConfig } = require('./harperConfigEnvVars.ts');
+	const { applyRuntimeEnvConfig, hasPersistedEnvConfigState } = require('./harperConfigEnvVars.ts');
 
 	// Get rootPath for state file location
 	const rootPath = configDoc.getIn(['rootPath']);
 	if (!rootPath) {
-		logger.warn('Cannot apply runtime env config: rootPath not found in config');
+		// Only an error if there is config to apply; otherwise there is simply nothing to do.
+		if (anyEnvValue) logger.warn('Cannot apply runtime env config: rootPath not found in config');
 		return;
 	}
+
+	// Skip entirely (zero overhead) only when nothing is set AND there is no prior state to
+	// clean up. If a var was applied on a previous boot and then removed, all three env vars
+	// are absent now but applyRuntimeEnvConfig must still run to restore originals and clear
+	// the snapshot — so don't short-circuit in that case.
+	if (!anyEnvValue && !hasPersistedEnvConfigState(rootPath)) return;
 
 	// Convert to JSON for processing
 	const configObj = configDoc.toJSON();

--- a/config/configUtils.js
+++ b/config/configUtils.js
@@ -171,7 +171,7 @@ function createConfigFile(args, skipFsValidation = false) {
 
 	if (schemasArgs) setSchemasConfig(configDoc, schemasArgs);
 
-	// Apply HARPER_DEFAULT_CONFIG and HARPER_SET_CONFIG environment variables BEFORE validation
+	// Apply HARPER_DEFAULT_CONFIG, HARPER_CONFIG and HARPER_SET_CONFIG environment variables BEFORE validation
 	// This allows runtime env vars to resolve port conflicts before validation
 	// Must be called AFTER rootPath is set in configDoc
 	// Mutates configDoc in place
@@ -352,7 +352,7 @@ function initConfig(force = false) {
 
 		checkForUpdatedConfig(configDoc, configFilePath);
 
-		// Apply HARPER_DEFAULT_CONFIG and HARPER_SET_CONFIG environment variables
+		// Apply HARPER_DEFAULT_CONFIG, HARPER_CONFIG and HARPER_SET_CONFIG environment variables
 		applyRuntimeEnvVarConfig(configDoc, configFilePath);
 
 		// Validates config doc and if required sets default values for some parameters.
@@ -848,15 +848,16 @@ function parseYamlDoc(filePath) {
 }
 
 /**
- * Apply HARPER_DEFAULT_CONFIG and HARPER_SET_CONFIG environment variables at runtime
+ * Apply HARPER_DEFAULT_CONFIG, HARPER_CONFIG and HARPER_SET_CONFIG environment variables at runtime
  *
  * This function performs the following:
  * 1. Loads configuration state to track sources
  * 2. Detects user edits (drift) to protect them from HARPER_DEFAULT_CONFIG
  * 3. Applies HARPER_DEFAULT_CONFIG (respects user edits)
- * 4. Applies HARPER_SET_CONFIG (overrides everything)
- * 5. Handles deletions when keys removed from env vars
- * 6. Saves updated state and persists changes to config file (if configFilePath provided)
+ * 4. Applies HARPER_CONFIG (merge layer: reasserts its keys, yields only to HARPER_SET_CONFIG)
+ * 5. Applies HARPER_SET_CONFIG (overrides everything)
+ * 6. Handles deletions when keys removed from env vars
+ * 7. Saves updated state and persists changes to config file (if configFilePath provided)
  *
  * NOTE: This function performs multiple conversions (YAML → JSON → YAML) which is not
  * efficient but provides clear separation of concerns. The conversions are necessary
@@ -869,10 +870,11 @@ function parseYamlDoc(filePath) {
  */
 function applyRuntimeEnvVarConfig(configDoc, configFilePath, options = {}) {
 	const defaultEnvValue = process.env.HARPER_DEFAULT_CONFIG;
+	const configEnvValue = process.env.HARPER_CONFIG;
 	const setEnvValue = process.env.HARPER_SET_CONFIG;
 
 	// No env vars set, skip entirely (zero overhead)
-	if (!defaultEnvValue && !setEnvValue) return;
+	if (!defaultEnvValue && !configEnvValue && !setEnvValue) return;
 
 	const { applyRuntimeEnvConfig } = require('./harperConfigEnvVars.ts');
 

--- a/config/harperConfigEnvVars.ts
+++ b/config/harperConfigEnvVars.ts
@@ -757,6 +757,16 @@ export function composeConfigFromEnv(base: ConfigObject = {}): ConfigObject {
 }
 
 /**
+ * True if a config-state file exists with tracked env-var snapshots. Callers use this to
+ * decide whether applyRuntimeEnvConfig must run even when no config env vars are currently
+ * set — e.g. to restore originals and clear the snapshot after a var was applied on a prior
+ * boot and then removed. Cheap: returns false without reading when no state file exists.
+ */
+export function hasPersistedEnvConfigState(rootPath: string): boolean {
+	return Object.keys(loadConfigState(rootPath).snapshots).length > 0;
+}
+
+/**
  * Apply HARPER_DEFAULT_CONFIG, HARPER_CONFIG and HARPER_SET_CONFIG (in that order —
  * later wins). Can be used for both install-time and runtime.
  */

--- a/config/harperConfigEnvVars.ts
+++ b/config/harperConfigEnvVars.ts
@@ -1,8 +1,19 @@
 /**
- * HARPER_DEFAULT_CONFIG and HARPER_SET_CONFIG environment variable support
+ * HARPER_CONFIG, HARPER_DEFAULT_CONFIG and HARPER_SET_CONFIG environment variable support
  *
  * This module provides utilities for applying configuration from environment variables
  * to Harper's configuration system with source tracking and drift detection.
+ *
+ * The three variables form a precedence ladder (later wins):
+ *   HARPER_DEFAULT_CONFIG  <  config file / user edits  <  HARPER_CONFIG  <  HARPER_SET_CONFIG
+ *
+ * - HARPER_CONFIG (recommended): merge — sets exactly the keys it names, reasserting
+ *   them on every boot (a manual edit to a named key is overwritten on restart), and
+ *   yields only to HARPER_SET_CONFIG. Individual HARPER_* env vars still win over it
+ *   for the keys they name (arg filtering remains SET-only).
+ * - HARPER_DEFAULT_CONFIG: defaults — yields to the config file, individual env vars,
+ *   and user edits.
+ * - HARPER_SET_CONFIG: force — overrides everything and locks against drift.
  *
  * Features:
  * - Install-time and runtime configuration from env vars
@@ -31,7 +42,7 @@ function getLogger(): Logger {
 
 // Type definitions
 type ConfigObject = Record<string, any>;
-type ConfigSource = 'HARPER_DEFAULT_CONFIG' | 'HARPER_SET_CONFIG' | 'user' | 'default';
+type ConfigSource = 'HARPER_DEFAULT_CONFIG' | 'HARPER_CONFIG' | 'HARPER_SET_CONFIG' | 'user' | 'default';
 
 /**
  * Configuration state tracking structure
@@ -69,6 +80,7 @@ interface ConfigState {
 	snapshots: {
 		// Snapshots of what each env var currently specifies (for detecting changes)
 		HARPER_DEFAULT_CONFIG?: { hash: string; config: ConfigObject };
+		HARPER_CONFIG?: { hash: string; config: ConfigObject };
 		HARPER_SET_CONFIG?: { hash: string; config: ConfigObject };
 	};
 }
@@ -534,9 +546,11 @@ function handleDeletions(
 	for (const path of deletedPaths) {
 		// Only handle if this path was set by this source
 		if (state.sources[path] === sourceName) {
-			// For both HARPER_DEFAULT_CONFIG and HARPER_SET_CONFIG, restore original value instead of deleting
+			// For all config env vars, restore original value instead of deleting
 			if (
-				(sourceName === 'HARPER_DEFAULT_CONFIG' || sourceName === 'HARPER_SET_CONFIG') &&
+				(sourceName === 'HARPER_DEFAULT_CONFIG' ||
+					sourceName === 'HARPER_CONFIG' ||
+					sourceName === 'HARPER_SET_CONFIG') &&
 				path in state.originalValues
 			) {
 				setNestedValue(fileConfig, path, state.originalValues[path]);
@@ -608,6 +622,14 @@ function processEnvVar(
 			respectSources: [],
 			storeOriginals: true,
 		});
+	} else if (sourceName === 'HARPER_CONFIG') {
+		// HARPER_CONFIG merges: it sets exactly the keys it names and reasserts them on
+		// every boot (winning over the config file, user edits, and DEFAULT), yielding
+		// only to HARPER_SET_CONFIG. Same behavior at install and runtime.
+		applyConfigLayer(fileConfig, state, parsedConfig, sourceName, {
+			respectSources: ['HARPER_SET_CONFIG'],
+			storeOriginals: true,
+		});
 	} else if (sourceName === 'HARPER_DEFAULT_CONFIG') {
 		// DEFAULT_CONFIG behavior depends on install vs runtime
 		if (options.isInstall) {
@@ -675,8 +697,8 @@ function cleanupRemovedEnvVar(
 
 	const logger = getLogger();
 
-	// For both HARPER_DEFAULT_CONFIG and HARPER_SET_CONFIG, restore original values
-	if (sourceName === 'HARPER_DEFAULT_CONFIG' || sourceName === 'HARPER_SET_CONFIG') {
+	// For all config env vars, restore original values
+	if (sourceName === 'HARPER_DEFAULT_CONFIG' || sourceName === 'HARPER_CONFIG' || sourceName === 'HARPER_SET_CONFIG') {
 		const pathsToCleanup = Object.keys(state.sources).filter((path) => state.sources[path] === sourceName);
 		for (const path of pathsToCleanup) {
 			if (path in state.originalValues) {
@@ -699,14 +721,15 @@ function cleanupRemovedEnvVar(
 }
 
 /**
- * Compose a merged config from HARPER_DEFAULT_CONFIG and HARPER_SET_CONFIG
- * layered with an optional base. Later layers win:
- *   HARPER_DEFAULT_CONFIG  <  base  <  HARPER_SET_CONFIG
+ * Compose a merged config from HARPER_DEFAULT_CONFIG, HARPER_CONFIG and
+ * HARPER_SET_CONFIG layered with an optional base. Later layers win:
+ *   HARPER_DEFAULT_CONFIG  <  base  <  HARPER_CONFIG  <  HARPER_SET_CONFIG
  *
  * HARPER_DEFAULT_CONFIG provides scaffolding defaults, the base (e.g., the
- * user's existing config file) is layered on top, and HARPER_SET_CONFIG
- * force-overrides everything. This matches the precedence applied by the
- * runtime pipeline in applyRuntimeEnvConfig.
+ * user's existing config file) is layered on top, HARPER_CONFIG merges its
+ * keys over that, and HARPER_SET_CONFIG force-overrides everything. This
+ * matches the precedence applied by the runtime pipeline in
+ * applyRuntimeEnvConfig.
  *
  * Unlike applyRuntimeEnvConfig, this does NOT read or write the config state
  * file and does NOT track sources — it returns a fresh object. Use when you
@@ -718,6 +741,7 @@ export function composeConfigFromEnv(base: ConfigObject = {}): ConfigObject {
 	const layers: (ConfigObject | null)[] = [
 		parseConfigEnvVar(process.env.HARPER_DEFAULT_CONFIG, 'HARPER_DEFAULT_CONFIG'),
 		cloneDeep(base),
+		parseConfigEnvVar(process.env.HARPER_CONFIG, 'HARPER_CONFIG'),
 		parseConfigEnvVar(process.env.HARPER_SET_CONFIG, 'HARPER_SET_CONFIG'),
 	];
 
@@ -733,8 +757,8 @@ export function composeConfigFromEnv(base: ConfigObject = {}): ConfigObject {
 }
 
 /**
- * Apply HARPER_DEFAULT_CONFIG and HARPER_SET_CONFIG
- * Can be used for both install-time and runtime
+ * Apply HARPER_DEFAULT_CONFIG, HARPER_CONFIG and HARPER_SET_CONFIG (in that order —
+ * later wins). Can be used for both install-time and runtime.
  */
 export function applyRuntimeEnvConfig(
 	fileConfig: ConfigObject,
@@ -742,13 +766,14 @@ export function applyRuntimeEnvConfig(
 	options: { isInstall?: boolean } = {}
 ): ConfigObject {
 	const defaultEnvValue = process.env.HARPER_DEFAULT_CONFIG;
+	const configEnvValue = process.env.HARPER_CONFIG;
 	const setEnvValue = process.env.HARPER_SET_CONFIG;
 
 	// Load existing state
 	const state = loadConfigState(rootPath);
 
 	// No env vars set and no previous state, nothing to do
-	if (!defaultEnvValue && !setEnvValue && Object.keys(state.snapshots).length === 0) {
+	if (!defaultEnvValue && !configEnvValue && !setEnvValue && Object.keys(state.snapshots).length === 0) {
 		return fileConfig;
 	}
 
@@ -760,21 +785,26 @@ export function applyRuntimeEnvConfig(
 		}
 	}
 
-	// Process HARPER_DEFAULT_CONFIG
-	processEnvVar(fileConfig, state, 'HARPER_DEFAULT_CONFIG', 'HARPER_DEFAULT_CONFIG', options);
-
-	// Clean up if HARPER_DEFAULT_CONFIG was removed
+	// Clean up any env var that was removed BEFORE applying the remaining ones. A removed
+	// var restores its paths to their stored originals and clears ownership; doing this
+	// first means a path a higher-precedence var is releasing is already un-sourced when a
+	// lower-precedence var (e.g. HARPER_CONFIG) runs, so that var reclaims it the same boot
+	// instead of leaving it at the file value for one boot.
 	if (!defaultEnvValue) {
 		cleanupRemovedEnvVar(fileConfig, state, 'HARPER_DEFAULT_CONFIG', 'HARPER_DEFAULT_CONFIG');
 	}
-
-	// Process HARPER_SET_CONFIG (always overrides everything)
-	processEnvVar(fileConfig, state, 'HARPER_SET_CONFIG', 'HARPER_SET_CONFIG', options);
-
-	// Clean up if HARPER_SET_CONFIG was removed
+	if (!configEnvValue) {
+		cleanupRemovedEnvVar(fileConfig, state, 'HARPER_CONFIG', 'HARPER_CONFIG');
+	}
 	if (!setEnvValue) {
 		cleanupRemovedEnvVar(fileConfig, state, 'HARPER_SET_CONFIG', 'HARPER_SET_CONFIG');
 	}
+
+	// Apply present vars in precedence order (later wins):
+	//   HARPER_DEFAULT_CONFIG < config file / user edits < HARPER_CONFIG < HARPER_SET_CONFIG
+	processEnvVar(fileConfig, state, 'HARPER_DEFAULT_CONFIG', 'HARPER_DEFAULT_CONFIG', options);
+	processEnvVar(fileConfig, state, 'HARPER_CONFIG', 'HARPER_CONFIG', options);
+	processEnvVar(fileConfig, state, 'HARPER_SET_CONFIG', 'HARPER_SET_CONFIG', options);
 
 	// Save updated state
 	saveConfigState(rootPath, state);

--- a/unitTests/config/configUtils-runtimeEnvVars.test.js
+++ b/unitTests/config/configUtils-runtimeEnvVars.test.js
@@ -10,6 +10,7 @@ const applyRuntimeEnvVarConfig = configUtils.__get__('applyRuntimeEnvVarConfig')
 describe('configUtils - applyRuntimeEnvVarConfig', function () {
 	let mockConfigDoc;
 	let applyRuntimeEnvConfigStub;
+	let hasPersistedEnvConfigStateStub;
 	let fsWriteFileSyncStub;
 	let fsRenameSyncStub;
 	let loggerStub;
@@ -18,6 +19,7 @@ describe('configUtils - applyRuntimeEnvVarConfig', function () {
 	before(function () {
 		// Create stubs for dependencies
 		applyRuntimeEnvConfigStub = sinon.stub();
+		hasPersistedEnvConfigStateStub = sinon.stub();
 		fsWriteFileSyncStub = sinon.stub();
 		fsRenameSyncStub = sinon.stub();
 		loggerStub = {
@@ -40,7 +42,10 @@ describe('configUtils - applyRuntimeEnvVarConfig', function () {
 		// Mock harperConfigEnvVars module
 		configUtils.__set__('require', function (modulePath) {
 			if (modulePath.startsWith('./harperConfigEnvVars')) {
-				return { applyRuntimeEnvConfig: applyRuntimeEnvConfigStub };
+				return {
+					applyRuntimeEnvConfig: applyRuntimeEnvConfigStub,
+					hasPersistedEnvConfigState: hasPersistedEnvConfigStateStub,
+				};
 			}
 			return require(modulePath);
 		});
@@ -49,6 +54,8 @@ describe('configUtils - applyRuntimeEnvVarConfig', function () {
 	beforeEach(function () {
 		// Reset stubs
 		applyRuntimeEnvConfigStub.reset();
+		hasPersistedEnvConfigStateStub.reset();
+		hasPersistedEnvConfigStateStub.returns(false); // default: no prior state
 		fsWriteFileSyncStub.reset();
 		fsRenameSyncStub.reset();
 		loggerStub.debug.reset();
@@ -77,14 +84,31 @@ describe('configUtils - applyRuntimeEnvVarConfig', function () {
 		sinon.restore();
 	});
 
-	it('should skip when no env vars set', function () {
+	it('should skip when no env vars set and no prior state', function () {
 		delete process.env.HARPER_DEFAULT_CONFIG;
+		delete process.env.HARPER_CONFIG;
 		delete process.env.HARPER_SET_CONFIG;
+		hasPersistedEnvConfigStateStub.returns(false);
 
 		applyRuntimeEnvVarConfig(mockConfigDoc, '/test/config.yaml');
 
 		assert.strictEqual(applyRuntimeEnvConfigStub.called, false);
 		assert.strictEqual(fsWriteFileSyncStub.called, false);
+	});
+
+	it('should run cleanup when no env vars set but prior state exists (var removed)', function () {
+		// All three vars were applied on a prior boot and then removed: the wrapper must NOT
+		// short-circuit — applyRuntimeEnvConfig has to restore originals and clear the snapshot.
+		delete process.env.HARPER_DEFAULT_CONFIG;
+		delete process.env.HARPER_CONFIG;
+		delete process.env.HARPER_SET_CONFIG;
+		hasPersistedEnvConfigStateStub.returns(true);
+
+		applyRuntimeEnvVarConfig(mockConfigDoc, '/test/config.yaml');
+
+		assert.strictEqual(applyRuntimeEnvConfigStub.called, true, 'cleanup must run when state exists');
+		assert.strictEqual(applyRuntimeEnvConfigStub.firstCall.args[1], '/test/root');
+		assert.strictEqual(fsWriteFileSyncStub.called, true);
 	});
 
 	it('should apply HARPER_DEFAULT_CONFIG when set', function () {

--- a/unitTests/config/harperConfigEnvVars-config.test.js
+++ b/unitTests/config/harperConfigEnvVars-config.test.js
@@ -10,6 +10,7 @@ const harperConfigEnvVars = rewire('#src/config/harperConfigEnvVars');
 const applyRuntimeEnvConfig = harperConfigEnvVars.__get__('applyRuntimeEnvConfig');
 const composeConfigFromEnv = harperConfigEnvVars.__get__('composeConfigFromEnv');
 const filterArgsAgainstRuntimeConfig = harperConfigEnvVars.__get__('filterArgsAgainstRuntimeConfig');
+const hasPersistedEnvConfigState = harperConfigEnvVars.__get__('hasPersistedEnvConfigState');
 
 const ENV_VARS = ['HARPER_CONFIG', 'HARPER_DEFAULT_CONFIG', 'HARPER_SET_CONFIG'];
 
@@ -208,6 +209,17 @@ describe('HARPER_CONFIG', function () {
 			const filtered = filterArgsAgainstRuntimeConfig(args);
 
 			assert.deepStrictEqual(filtered, args, 'individual env vars win over HARPER_CONFIG');
+		});
+	});
+
+	describe('hasPersistedEnvConfigState', function () {
+		it('is false for a fresh root and true once a var has been applied', function () {
+			assert.strictEqual(hasPersistedEnvConfigState(testRoot), false, 'no state file yet');
+
+			process.env.HARPER_CONFIG = JSON.stringify({ http: { port: 8080 } });
+			applyRuntimeEnvConfig({ http: { port: 9925 } }, testRoot);
+
+			assert.strictEqual(hasPersistedEnvConfigState(testRoot), true, 'snapshot persisted after apply');
 		});
 	});
 

--- a/unitTests/config/harperConfigEnvVars-config.test.js
+++ b/unitTests/config/harperConfigEnvVars-config.test.js
@@ -1,0 +1,228 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const rewire = require('rewire');
+const fs = require('fs-extra');
+const path = require('node:path');
+const os = require('node:os');
+
+const harperConfigEnvVars = rewire('#src/config/harperConfigEnvVars');
+const applyRuntimeEnvConfig = harperConfigEnvVars.__get__('applyRuntimeEnvConfig');
+const composeConfigFromEnv = harperConfigEnvVars.__get__('composeConfigFromEnv');
+const filterArgsAgainstRuntimeConfig = harperConfigEnvVars.__get__('filterArgsAgainstRuntimeConfig');
+
+const ENV_VARS = ['HARPER_CONFIG', 'HARPER_DEFAULT_CONFIG', 'HARPER_SET_CONFIG'];
+
+describe('HARPER_CONFIG', function () {
+	let testRoot;
+	let savedEnv;
+
+	beforeEach(function () {
+		savedEnv = {};
+		for (const name of ENV_VARS) {
+			savedEnv[name] = process.env[name];
+			delete process.env[name];
+		}
+
+		testRoot = path.join(os.tmpdir(), 'hdb-config-test-' + Date.now() + '-' + Math.floor(process.hrtime()[1]));
+		fs.mkdirpSync(path.join(testRoot, 'backup'));
+	});
+
+	afterEach(function () {
+		for (const name of ENV_VARS) {
+			if (savedEnv[name] !== undefined) process.env[name] = savedEnv[name];
+			else delete process.env[name];
+		}
+
+		try {
+			fs.removeSync(testRoot);
+			// eslint-disable-next-line sonarjs/no-ignored-exceptions
+		} catch {
+			// ignore cleanup errors
+		}
+	});
+
+	function readState() {
+		return fs.readJsonSync(path.join(testRoot, 'backup', '.harper-config-state.json'));
+	}
+
+	describe('merge behavior', function () {
+		it('sets only the keys it names, preserving siblings at any depth', function () {
+			process.env.HARPER_CONFIG = JSON.stringify({ http: { port: 8080 } });
+			const fileConfig = {
+				http: { port: 9925, securePort: 9926, cors: { enabled: true } },
+				logging: { level: 'warn' },
+			};
+
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+
+			assert.strictEqual(fileConfig.http.port, 8080);
+			assert.strictEqual(fileConfig.http.securePort, 9926, 'sibling preserved');
+			assert.strictEqual(fileConfig.http.cors.enabled, true, 'nested sibling preserved');
+			assert.strictEqual(fileConfig.logging.level, 'warn', 'unrelated section preserved');
+		});
+
+		it('tracks its paths with source HARPER_CONFIG and stores originals', function () {
+			process.env.HARPER_CONFIG = JSON.stringify({ http: { port: 8080 } });
+			const fileConfig = { http: { port: 9925 } };
+
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+
+			const state = readState();
+			assert.strictEqual(state.sources['http.port'], 'HARPER_CONFIG');
+			assert.strictEqual(state.originalValues['http.port'], 9925);
+		});
+
+		it('honors $union for arrays', function () {
+			process.env.HARPER_CONFIG = JSON.stringify({ tls: { uses: { $union: ['server'] } } });
+			const fileConfig = { tls: { uses: ['app-cert'] } };
+
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+
+			assert.deepStrictEqual(fileConfig.tls.uses, ['app-cert', 'server'], 'composes and stays idempotent');
+		});
+	});
+
+	describe('precedence', function () {
+		it('wins over an existing config-file value', function () {
+			process.env.HARPER_CONFIG = JSON.stringify({ logging: { level: 'debug' } });
+			const fileConfig = { logging: { level: 'warn' } };
+
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+
+			assert.strictEqual(fileConfig.logging.level, 'debug');
+		});
+
+		it('reasserts over a manual user edit on the next boot', function () {
+			process.env.HARPER_CONFIG = JSON.stringify({ logging: { level: 'debug' } });
+			const fileConfig = { logging: { level: 'warn' } };
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+			assert.strictEqual(fileConfig.logging.level, 'debug');
+
+			// User hand-edits the config file between boots
+			fileConfig.logging.level = 'error';
+
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+			assert.strictEqual(fileConfig.logging.level, 'debug', 'env reasserts while the var names the key');
+		});
+
+		it('wins over HARPER_DEFAULT_CONFIG', function () {
+			process.env.HARPER_DEFAULT_CONFIG = JSON.stringify({ http: { port: 7777 } });
+			process.env.HARPER_CONFIG = JSON.stringify({ http: { port: 8080 } });
+			const fileConfig = {};
+
+			applyRuntimeEnvConfig(fileConfig, testRoot, { isInstall: true });
+
+			assert.strictEqual(fileConfig.http.port, 8080);
+			assert.strictEqual(readState().sources['http.port'], 'HARPER_CONFIG');
+		});
+
+		it('yields to HARPER_SET_CONFIG', function () {
+			process.env.HARPER_CONFIG = JSON.stringify({ http: { port: 8080 } });
+			process.env.HARPER_SET_CONFIG = JSON.stringify({ http: { port: 6666 } });
+			const fileConfig = { http: { port: 9925 } };
+
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+
+			assert.strictEqual(fileConfig.http.port, 6666);
+			assert.strictEqual(readState().sources['http.port'], 'HARPER_SET_CONFIG');
+
+			// And on a later boot, CONFIG still does not steal a SET-sourced path
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+			assert.strictEqual(fileConfig.http.port, 6666);
+			assert.strictEqual(readState().sources['http.port'], 'HARPER_SET_CONFIG');
+		});
+
+		it('reclaims a path the SAME boot HARPER_SET_CONFIG is removed (no one-boot drop to file value)', function () {
+			// Boot 1: SET owns the path, CONFIG also names it
+			process.env.HARPER_CONFIG = JSON.stringify({ http: { port: 2222 } });
+			process.env.HARPER_SET_CONFIG = JSON.stringify({ http: { port: 3333 } });
+			const fileConfig = { http: { port: 9925 } };
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+			assert.strictEqual(fileConfig.http.port, 3333);
+			assert.strictEqual(readState().sources['http.port'], 'HARPER_SET_CONFIG');
+
+			// Boot 2: drop SET only — CONFIG must take the path back to 2222 THIS boot,
+			// not fall through to the file original (9925) for a boot.
+			delete process.env.HARPER_SET_CONFIG;
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+			assert.strictEqual(fileConfig.http.port, 2222, 'CONFIG reclaims same boot');
+			assert.strictEqual(readState().sources['http.port'], 'HARPER_CONFIG');
+
+			// And dropping CONFIG afterward restores the true file original
+			delete process.env.HARPER_CONFIG;
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+			assert.strictEqual(fileConfig.http.port, 9925, 'original restored after both vars gone');
+		});
+	});
+
+	describe('deletion / cleanup', function () {
+		it('restores the original value when a key is dropped between boots', function () {
+			process.env.HARPER_CONFIG = JSON.stringify({ http: { port: 8080 }, logging: { level: 'debug' } });
+			const fileConfig = { http: { port: 9925 }, logging: { level: 'warn' } };
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+			assert.strictEqual(fileConfig.http.port, 8080);
+
+			// Next boot: http.port dropped from the var
+			process.env.HARPER_CONFIG = JSON.stringify({ logging: { level: 'debug' } });
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+
+			assert.strictEqual(fileConfig.http.port, 9925, 'original restored');
+			assert.strictEqual(fileConfig.logging.level, 'debug', 'remaining key still applied');
+			assert.strictEqual(readState().sources['http.port'], undefined);
+		});
+
+		it('restores originals when the variable is removed entirely', function () {
+			process.env.HARPER_CONFIG = JSON.stringify({ http: { port: 8080 } });
+			const fileConfig = { http: { port: 9925 } };
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+			assert.strictEqual(fileConfig.http.port, 8080);
+
+			delete process.env.HARPER_CONFIG;
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+
+			assert.strictEqual(fileConfig.http.port, 9925, 'original restored after var removal');
+			const state = readState();
+			assert.strictEqual(state.snapshots.HARPER_CONFIG, undefined, 'snapshot cleaned up');
+		});
+
+		it('deletes a key it introduced (no original) when dropped', function () {
+			process.env.HARPER_CONFIG = JSON.stringify({ http: { cors: { enabled: true } } });
+			const fileConfig = { http: {} };
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+			assert.strictEqual(fileConfig.http.cors.enabled, true);
+
+			delete process.env.HARPER_CONFIG;
+			applyRuntimeEnvConfig(fileConfig, testRoot);
+
+			assert.strictEqual(fileConfig.http.cors?.enabled, undefined, 'introduced key removed');
+		});
+	});
+
+	describe('individual env var interaction', function () {
+		it('does NOT filter individual args against HARPER_CONFIG (SET-only filtering)', function () {
+			process.env.HARPER_CONFIG = JSON.stringify({ operationsApi: { network: { port: 9925 } } });
+
+			const args = { operationsapi_network_port: '9930', rootpath: '/y' };
+			const filtered = filterArgsAgainstRuntimeConfig(args);
+
+			assert.deepStrictEqual(filtered, args, 'individual env vars win over HARPER_CONFIG');
+		});
+	});
+
+	describe('composeConfigFromEnv', function () {
+		it('layers DEFAULT < base < HARPER_CONFIG < SET', function () {
+			process.env.HARPER_DEFAULT_CONFIG = JSON.stringify({ a: 1, b: 1, c: 1, d: 1 });
+			process.env.HARPER_CONFIG = JSON.stringify({ c: 3, d: 3 });
+			process.env.HARPER_SET_CONFIG = JSON.stringify({ d: 4 });
+
+			const result = composeConfigFromEnv({ b: 2, c: 2, d: 2 });
+
+			assert.strictEqual(result.a, 1, 'DEFAULT fills the gap');
+			assert.strictEqual(result.b, 2, 'base beats DEFAULT');
+			assert.strictEqual(result.c, 3, 'HARPER_CONFIG beats base');
+			assert.strictEqual(result.d, 4, 'SET beats HARPER_CONFIG');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds `HARPER_CONFIG` as the **recommended** environment variable for setting Harper configuration. It takes a JSON config object and applies it as a **merge** on top of the existing configuration: it sets exactly the keys it names (at any depth), reasserts them on every boot, and yields only to `HARPER_SET_CONFIG`.

Closes #1214 (sub-issue of #1097). Builds on the `$union` directive from #1213.

## Precedence (later wins)

```
HARPER_DEFAULT_CONFIG  <  config file / user edits  <  HARPER_CONFIG  <  HARPER_SET_CONFIG
```

| Variable | Use it when | Merge behavior |
|---|---|---|
| **`HARPER_CONFIG`** *(recommended)* | Set configuration — the normal default | Merge; only the named keys change; reasserts every boot |
| `HARPER_DEFAULT_CONFIG` | Provide overridable defaults | Merge, yields to file/user/individual vars |
| `HARPER_SET_CONFIG` | Force + lock against drift | Override (existing force semantics) |

## Behavior (the four decisions, confirmed with @heskew)

1. **Drift:** while the var names a key, the env wins — a manual config-file edit to that key is overwritten on the next restart (12-factor intuition). This is what distinguishes it from `DEFAULT`.
2. **Deletion:** dropping a key from `HARPER_CONFIG` restores the pre-override original (or deletes the key if `HARPER_CONFIG` introduced it), via the existing snapshot machinery — symmetric with `DEFAULT`/`SET`.
3. **Individual `HARPER_*` env vars win** over `HARPER_CONFIG` for the keys they name (`filterArgsAgainstRuntimeConfig` stays SET-only — unchanged).
4. **DEFAULT** stays as-is — three vars, three niches (defaults / recommended-merge / force).

## Implementation

- New `'HARPER_CONFIG'` `ConfigSource` + snapshot slot; applied via `applyConfigLayer` with `respectSources: ['HARPER_SET_CONFIG']` + `storeOriginals`, same at install and runtime.
- Added to `applyRuntimeEnvConfig`, `composeConfigFromEnv` (clone/pre-install), the `configUtils.js` early-return guard, and the restore-original deletion/cleanup paths.
- `$union` flows through `HARPER_CONFIG` for free via the shared apply path.

## Where to look

- **Cleanup-before-apply ordering (`applyRuntimeEnvConfig`)** — this PR moves all removed-var cleanups *ahead* of the applies. A domain review caught that the original apply-then-cleanup order gave a **one-boot window** where removing `HARPER_SET_CONFIG` (while `HARPER_CONFIG` still named the path) dropped the value to the file original for one boot before self-healing. Reordering makes `HARPER_CONFIG` reclaim the path the same boot. Behavior is unchanged for present-var and DEFAULT/SET-only cases (a removed var's own apply is a no-op). New regression test: "reclaims a path the SAME boot HARPER_SET_CONFIG is removed".
- **Known-benign quirk:** when `HARPER_CONFIG` and `HARPER_SET_CONFIG` name the same path in one boot, `HARPER_CONFIG`'s snapshot records the value it set before `SET` overrode it, while `sources[path]` ends up `HARPER_SET_CONFIG`. No data loss — deletion paths gate on current source ownership (verified) — but the snapshot is momentarily not authoritative for that path. Left as-is to avoid complicating `buildSnapshot`; flagging for the reviewer.

## Testing

13 new unit tests in `unitTests/config/harperConfigEnvVars-config.test.js`: merge/sibling preservation, source+original tracking, `$union`, all four precedence relationships (file, user-edit reassert, DEFAULT, SET incl. not stealing SET-owned paths), the SET→CONFIG same-boot hand-back, drop-key restore, var-removal cleanup, introduced-key deletion, SET-only arg filtering, and four-layer `composeConfigFromEnv` ordering. Full `unitTests/config/**` suite green (174 passing); build + lint + format clean.

## Review note

Cross-model review was domain-only this round: Codex hit its weekly session limit and the local Gemini (`agy`) leg hangs in this environment. The Harper-domain pass (which found the ordering issue above) ran; the GitHub Gemini Code Assist + Claude review bots will provide the outside-model legs on this PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (agent: Claude Opus 4.8)
