### PR TITLE
feat(replication): LOCAL_ONLY record-metadata flag for non-replicating writes

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -15,6 +15,7 @@ import {
 	HAS_BLOBS,
 	ACTION_32_BIT,
 	HAS_ADDITIONAL_AUDIT_REFS as HAS_ADDITIONAL_AUDIT_REFS_AUDIT,
+	LOCAL_ONLY,
 } from './auditStore.ts';
 import * as harperLogger from '../utility/logging/harper_logger.ts';
 import './blob.ts';
@@ -662,6 +663,13 @@ export function recordUpdater(store, tableId, auditStore) {
 			const previousAdditionalAuditRefs = existingEntry?.additionalAuditRefs;
 			if (previousAdditionalAuditRefs && previousAdditionalAuditRefs.length > 0) {
 				extendedType |= HAS_ADDITIONAL_AUDIT_REFS_AUDIT;
+			}
+			if (options?.localOnly) {
+				// Mark this write as local-only: set the bit in BOTH the persisted record metadata
+				// (so the full-copy send loop, which reads entry.metadataFlags, skips it) AND the audit
+				// entry's extendedType (so the audit-forward send path skips it by bitmask without decode).
+				metadataInNextEncoding |= LOCAL_ONLY;
+				extendedType |= LOCAL_ONLY;
 			}
 			if (previousResidencyId !== residencyId) {
 				extendedType |= HAS_PREVIOUS_RESIDENCY_ID;

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -2081,6 +2081,8 @@ export function makeTable(options) {
 								transaction,
 								tableToTrack: databaseName === 'system' ? null : options?.replay ? null : tableName, // don't track analytics on system tables
 								additionalAuditRefs: additionalAuditRefs.length > 0 ? additionalAuditRefs : undefined,
+								// local-only marks the record so the replication send path skips it (see LOCAL_ONLY)
+								localOnly: options?.localOnly,
 							},
 							type,
 							false,

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -301,6 +301,16 @@ export const HAS_ORIGINATING_OPERATION = 2048;
 export const HAS_EXPIRATION_EXTENDED_TYPE = 0x1000;
 export const HAS_BLOBS = 0x2000;
 export const HAS_ADDITIONAL_AUDIT_REFS = 0x4000;
+/**
+ * Marks a record (and its audit entry) as local-only: it is persisted on this node but must
+ * never be forwarded to replication peers. The bit lives in the record metadata bitmap (and is
+ * mirrored into the audit entry's extendedType) so the replication send path can skip it by a
+ * bitmask test on the already-decoded metadataFlags/extendedType integer — without decoding the
+ * record value (a critical send-path throughput optimization). Bit 15 (0x8000) was confirmed
+ * unused across the record metadata bitmap and the audit extendedType space; it sits below the
+ * lower-byte action region (which extendedType forbids) and within the always-32-bit metadata form.
+ */
+export const LOCAL_ONLY = 0x8000;
 const EVENT_TYPES = {
 	put: PUT | HAS_RECORD,
 	[PUT]: 'put',


### PR DESCRIPTION
## Summary

Adds a generic record-metadata bit — `LOCAL_ONLY = 0x8000` (`resources/auditStore.ts`) — that marks a write as **node-local: persisted here, never forwarded to replication peers.** Internal primitive (no public `put`/`patch` surface yet — see Notes); used by harper-pro to fix the v4→v5 bridge leak ([harper-pro#246](https://github.com/HarperFast/harper-pro/issues/246)).

## How it works

- `RecordEncoder.recordUpdater`: on the internal `localOnly` write option, sets the bit on **both** the persisted record metadata header (`metadataInNextEncoding`) and the audit entry's `extendedType`.
- `Table.ts`: threads `localOnly` from the write options into `recordUpdater`.
- The replication send path skips `LOCAL_ONLY` records via a pure bitmask test on the already-available `metadataFlags` / `extendedType` integer — **no record value decode is added to the throughput-critical send path** (the harper-pro side does the skipping; this PR just defines + sets the bit).

## What to check

- **Bit choice `0x8000` (bit 15):** confirmed unused in the record-metadata bitmap and the audit `extendedType` space (tops out at `0x4000`; framing is `0xc0000000`), sits below the action byte, and round-trips through the always-32-bit metadata encode/decode. Verified by review against `auditStore.ts` + `RecordEncoder.ts`.
- Both bits are set together unconditionally — no path sets only one (which would leak via the unset channel).
- Deep-reviewed (data-integrity + concurrency): the bit persists and round-trips; no decode added.

## Notes

`LOCAL_ONLY` is intentionally **internal-only** for now. A public API (per-write option and/or table-level config) is deferred to a planned **residency-scoped metadata visibility** feature, where this becomes the residency = {self} case. Tracked in the harper-pro follow-up issue.

🤖 Generated with Claude Opus 4.7 (implementation by Claude Sonnet 4.6).