### PR TITLE
chore(deps): bump structon to ^1.0.7 (#1163)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
 				"ses": "^1.15.0",
 				"stream-chain": "2.2.5",
 				"stream-json": "1.9.1",
-				"structon": "^1.0.6",
+				"structon": "^1.0.7",
 				"systeminformation": "^5.31.4",
 				"tar-fs": "^3.1.2",
 				"ulidx": "0.5.0",
@@ -14859,9 +14859,9 @@
 			"license": "MIT"
 		},
 		"node_modules/structon": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/structon/-/structon-1.0.6.tgz",
-			"integrity": "sha512-ulbz1oTo92EXGPp77nZjA0vXlPvaBFDUd2Ch6hfELKxYlmPM8OsjwzASizyxFIpTk1kQ5fVoQ33whvTf+aaDFQ==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/structon/-/structon-1.0.7.tgz",
+			"integrity": "sha512-/6z2LmwKXmVVQhnDo1TUHmnHm5IdZxMh6w60N28y6xAwgGapOOLvANZsCjrp4GVGL26ZXi/jM8s3D14EJpY9pA==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
 				"msgpackr": ">=2.0.1"

--- a/package.json
+++ b/package.json
@@ -231,7 +231,7 @@
 		"ses": "^1.15.0",
 		"stream-chain": "2.2.5",
 		"stream-json": "1.9.1",
-		"structon": "^1.0.6",
+		"structon": "^1.0.7",
 		"systeminformation": "^5.31.4",
 		"tar-fs": "^3.1.2",
 		"ulidx": "0.5.0",


### PR DESCRIPTION
## Summary
Bumps `structon` `^1.0.6` → `^1.0.7` (lockfile updated to 1.0.7).

structon 1.0.7 = HarperFast/structon#5: on the **standalone** decode path, typed structures now reload from durable storage when a decode hits a structure id minted after the reader's last load (previously the cache short-circuited and never refreshed — a record that exists came back undecodable, the read half of #1163). The base decoder already did this for classic shared structures; 1.0.7 brings typed structures to parity.

## Why this is safe here
On `main` this is **inert**: msgpackr `^2.0.4` uses structon's fast path, whose `readStruct` already reloads on miss, so the new standalone-path branch is never executed. The change is load-bearing only on the **standalone (msgpackr v1) path** that the v5.0 line / the affected production cluster runs — so the impactful delivery is a v5.0 backport (see below), not this PR.

## Note
The structon-level change carried its full review in HarperFast/structon#5 (incl. cross-model review); this is a mechanical dependency bump (package.json range + lockfile only, diff is structon-only). One open item flagged in structon#5: nested-struct misses via `_decodeSliceDirect` are not yet covered (re-entrancy hazard) — tracked there.

Backport: the v5.0 line is where this actually fixes #1163; that's a separate `/patch-pr` once this lands.

---
🤖 Generated by Claude (Opus 4.7).