### PR TITLE
fix(table): re-apply @table metadata on reload + coerce directive args

### DIFF
--- a/integrationTests/apiTests/describe-metadata-upgrade-1132.test.ts
+++ b/integrationTests/apiTests/describe-metadata-upgrade-1132.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Two-phase: install a component with `@table(eviction: 300)`, capture describe_all,
+ * stop, reboot on the same data dir, assert describe_all still reflects schema_defined: true
+ * and expiration: "0s". Runs with threads.count: 2 so the operations-API worker that
+ * answers describe is distinct from the http worker that runs the schema parser, matching
+ * the cluster topology that hid the bug.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+	startHarper,
+	killHarper,
+	teardownHarper,
+	releaseLoopbackAddress,
+	type ContextWithHarper,
+} from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations
+import { createApiClient } from './utils/client.mjs';
+// @ts-expect-error utils/components.mjs has no type declarations
+import { installAppComponent } from './utils/components.mjs';
+
+const SCHEMA = `
+type PageCache @table(database: "seo", eviction: 300) @export(name: "SeoPageCache") {
+	cacheKey: ID! @primaryKey
+	htmlContent: String
+	updatedTimestamp: Long
+}
+
+type LifecycleMeta @table(database: "metadata") @export(name: "LifecycleMeta") {
+	id: ID! @primaryKey
+	value: String
+}
+`;
+
+const CONFIG = `rest: true
+graphqlSchema:
+  files: '*.graphql'
+`;
+
+const PINNED_DATA_DIR = mkdtempSync(join(tmpdir(), 'fix-1132-'));
+
+async function describeAll(client: ReturnType<typeof createApiClient>) {
+	const res = await client.req().send({ operation: 'describe_all' });
+	strictEqual(res.status, 200, 'describe_all should return 200');
+	return res.body;
+}
+
+suite('INVESTIGATION-1132 fix phase 1: install component on first boot', (ctx: ContextWithHarper) => {
+	before(async () => {
+		ctx.harper = { dataRootDir: PINNED_DATA_DIR } as any;
+		await startHarper(ctx, { config: { threads: { count: 2 } }, env: {} } as any);
+	});
+
+	after(async () => {
+		await killHarper(ctx);
+		await releaseLoopbackAddress(ctx.harper.hostname);
+	});
+
+	test('install component and capture first describe_all', async () => {
+		const client = createApiClient(ctx.harper);
+		await installAppComponent(client, {
+			project: 'fix1132',
+			files: { 'schema.graphql': SCHEMA, 'config.yaml': CONFIG },
+			probePath: '/SeoPageCache/',
+			restartTimeoutMs: 120_000,
+		});
+		const body = await describeAll(client);
+		const pc = body.seo?.PageCache ?? body.data?.seo?.PageCache;
+		const lm = body.metadata?.LifecycleMeta ?? body.data?.metadata?.LifecycleMeta;
+		ok(pc, 'seo.PageCache must be in describe_all phase 1');
+		ok(lm, 'metadata.LifecycleMeta must be in describe_all phase 1');
+		strictEqual(pc.schema_defined, true, 'PageCache.schema_defined should be true phase 1');
+		strictEqual(pc.expiration, '0s', 'PageCache.expiration should be "0s" phase 1');
+		strictEqual(lm.schema_defined, true, 'LifecycleMeta.schema_defined should be true phase 1');
+	});
+});
+
+suite('INVESTIGATION-1132 fix phase 2: reboot on same data dir, metadata must survive', (ctx: ContextWithHarper) => {
+	before(async () => {
+		ctx.harper = { dataRootDir: PINNED_DATA_DIR } as any;
+		await startHarper(ctx, { config: { threads: { count: 2 } }, env: {} } as any);
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+		try {
+			rmSync(PINNED_DATA_DIR, { recursive: true, force: true });
+		} catch {}
+	});
+
+	test('phase 2 describe_all preserves schema_defined: true and expiration: "0s"', async () => {
+		const client = createApiClient(ctx.harper);
+		const body = await describeAll(client);
+		const pc = body.seo?.PageCache ?? body.data?.seo?.PageCache;
+		const lm = body.metadata?.LifecycleMeta ?? body.data?.metadata?.LifecycleMeta;
+		ok(pc, 'seo.PageCache must be in describe_all phase 2');
+		ok(lm, 'metadata.LifecycleMeta must be in describe_all phase 2');
+		strictEqual(pc.schema_defined, true, 'PageCache.schema_defined must remain true after restart');
+		strictEqual(pc.expiration, '0s', 'PageCache.expiration must remain "0s" after restart');
+		strictEqual(lm.schema_defined, true, 'LifecycleMeta.schema_defined must remain true after restart');
+	});
+});

--- a/integrationTests/apiTests/describe-metadata-upgrade.test.ts
+++ b/integrationTests/apiTests/describe-metadata-upgrade.test.ts
@@ -40,7 +40,7 @@ graphqlSchema:
   files: '*.graphql'
 `;
 
-const PINNED_DATA_DIR = mkdtempSync(join(tmpdir(), 'fix-1132-'));
+const PINNED_DATA_DIR = mkdtempSync(join(tmpdir(), 'describe-metadata-upgrade-'));
 
 async function describeAll(client: ReturnType<typeof createApiClient>) {
 	const res = await client.req().send({ operation: 'describe_all' });
@@ -48,7 +48,7 @@ async function describeAll(client: ReturnType<typeof createApiClient>) {
 	return res.body;
 }
 
-suite('INVESTIGATION-1132 fix phase 1: install component on first boot', (ctx: ContextWithHarper) => {
+suite('describe_all metadata upgrade phase 1: install component on first boot', (ctx: ContextWithHarper) => {
 	before(async () => {
 		ctx.harper = { dataRootDir: PINNED_DATA_DIR } as any;
 		await startHarper(ctx, { config: { threads: { count: 2 } }, env: {} } as any);
@@ -62,7 +62,7 @@ suite('INVESTIGATION-1132 fix phase 1: install component on first boot', (ctx: C
 	test('install component and capture first describe_all', async () => {
 		const client = createApiClient(ctx.harper);
 		await installAppComponent(client, {
-			project: 'fix1132',
+			project: 'describemetadataupgrade',
 			files: { 'schema.graphql': SCHEMA, 'config.yaml': CONFIG },
 			probePath: '/SeoPageCache/',
 			restartTimeoutMs: 120_000,
@@ -78,7 +78,7 @@ suite('INVESTIGATION-1132 fix phase 1: install component on first boot', (ctx: C
 	});
 });
 
-suite('INVESTIGATION-1132 fix phase 2: reboot on same data dir, metadata must survive', (ctx: ContextWithHarper) => {
+suite('describe_all metadata upgrade phase 2: reboot on same data dir, metadata must survive', (ctx: ContextWithHarper) => {
 	before(async () => {
 		ctx.harper = { dataRootDir: PINNED_DATA_DIR } as any;
 		await startHarper(ctx, { config: { threads: { count: 2 } }, env: {} } as any);

--- a/integrationTests/apiTests/describe-metadata-upgrade.test.ts
+++ b/integrationTests/apiTests/describe-metadata-upgrade.test.ts
@@ -88,31 +88,34 @@ suite('describe_all metadata upgrade phase 1: install component on first boot', 
 	});
 });
 
-suite('describe_all metadata upgrade phase 2: reboot on same data dir, metadata must survive', (ctx: ContextWithHarper) => {
-	before(async () => {
-		ctx.harper = { dataRootDir: PINNED_DATA_DIR } as any;
-		await startHarper(ctx, { config: { threads: { count: 2 } }, env: {} } as any);
-	});
+suite(
+	'describe_all metadata upgrade phase 2: reboot on same data dir, metadata must survive',
+	(ctx: ContextWithHarper) => {
+		before(async () => {
+			ctx.harper = { dataRootDir: PINNED_DATA_DIR } as any;
+			await startHarper(ctx, { config: { threads: { count: 2 } }, env: {} } as any);
+		});
 
-	after(async () => {
-		await teardownHarper(ctx);
-		try {
-			rmSync(PINNED_DATA_DIR, { recursive: true, force: true });
-		} catch {}
-	});
+		after(async () => {
+			await teardownHarper(ctx);
+			try {
+				rmSync(PINNED_DATA_DIR, { recursive: true, force: true });
+			} catch {}
+		});
 
-	test('phase 2 describe_all preserves schema_defined and expiration across reboot', async () => {
-		const client = createApiClient(ctx.harper);
-		const body = await describeAll(client);
-		const pc = body.seo?.PageCache ?? body.data?.seo?.PageCache;
-		const lm = body.metadata?.LifecycleMeta ?? body.data?.metadata?.LifecycleMeta;
-		const loose = body.dynamic?.Loose ?? body.data?.dynamic?.Loose;
-		ok(pc, 'seo.PageCache must be in describe_all phase 2');
-		ok(lm, 'metadata.LifecycleMeta must be in describe_all phase 2');
-		ok(loose, 'dynamic.Loose must be in describe_all phase 2');
-		strictEqual(pc.schema_defined, true, 'PageCache.schema_defined must remain true after restart');
-		strictEqual(pc.expiration, '0s', 'PageCache.expiration must remain "0s" after restart');
-		strictEqual(lm.schema_defined, true, 'LifecycleMeta.schema_defined must remain true after restart');
-		strictEqual(loose.schema_defined, false, 'dynamic.Loose.schema_defined must remain false after restart');
-	});
-});
+		test('phase 2 describe_all preserves schema_defined and expiration across reboot', async () => {
+			const client = createApiClient(ctx.harper);
+			const body = await describeAll(client);
+			const pc = body.seo?.PageCache ?? body.data?.seo?.PageCache;
+			const lm = body.metadata?.LifecycleMeta ?? body.data?.metadata?.LifecycleMeta;
+			const loose = body.dynamic?.Loose ?? body.data?.dynamic?.Loose;
+			ok(pc, 'seo.PageCache must be in describe_all phase 2');
+			ok(lm, 'metadata.LifecycleMeta must be in describe_all phase 2');
+			ok(loose, 'dynamic.Loose must be in describe_all phase 2');
+			strictEqual(pc.schema_defined, true, 'PageCache.schema_defined must remain true after restart');
+			strictEqual(pc.expiration, '0s', 'PageCache.expiration must remain "0s" after restart');
+			strictEqual(lm.schema_defined, true, 'LifecycleMeta.schema_defined must remain true after restart');
+			strictEqual(loose.schema_defined, false, 'dynamic.Loose.schema_defined must remain false after restart');
+		});
+	}
+);

--- a/integrationTests/apiTests/describe-metadata-upgrade.test.ts
+++ b/integrationTests/apiTests/describe-metadata-upgrade.test.ts
@@ -67,14 +67,24 @@ suite('describe_all metadata upgrade phase 1: install component on first boot', 
 			probePath: '/SeoPageCache/',
 			restartTimeoutMs: 120_000,
 		});
+		// Create a dynamic table via the operations API (no attributes → schema_defined: false).
+		// Asserting this stays false through the reboot guards against the existing-Table branch
+		// flipping it to true via the schemaDefined default when omitting callers re-enter table().
+		await client
+			.req()
+			.send({ operation: 'create_table', database: 'dynamic', table: 'Loose', primary_key: 'id' })
+			.expect(200);
 		const body = await describeAll(client);
 		const pc = body.seo?.PageCache ?? body.data?.seo?.PageCache;
 		const lm = body.metadata?.LifecycleMeta ?? body.data?.metadata?.LifecycleMeta;
+		const loose = body.dynamic?.Loose ?? body.data?.dynamic?.Loose;
 		ok(pc, 'seo.PageCache must be in describe_all phase 1');
 		ok(lm, 'metadata.LifecycleMeta must be in describe_all phase 1');
+		ok(loose, 'dynamic.Loose must be in describe_all phase 1');
 		strictEqual(pc.schema_defined, true, 'PageCache.schema_defined should be true phase 1');
 		strictEqual(pc.expiration, '0s', 'PageCache.expiration should be "0s" phase 1');
 		strictEqual(lm.schema_defined, true, 'LifecycleMeta.schema_defined should be true phase 1');
+		strictEqual(loose.schema_defined, false, 'dynamic.Loose.schema_defined should be false phase 1');
 	});
 });
 
@@ -91,15 +101,18 @@ suite('describe_all metadata upgrade phase 2: reboot on same data dir, metadata 
 		} catch {}
 	});
 
-	test('phase 2 describe_all preserves schema_defined: true and expiration: "0s"', async () => {
+	test('phase 2 describe_all preserves schema_defined and expiration across reboot', async () => {
 		const client = createApiClient(ctx.harper);
 		const body = await describeAll(client);
 		const pc = body.seo?.PageCache ?? body.data?.seo?.PageCache;
 		const lm = body.metadata?.LifecycleMeta ?? body.data?.metadata?.LifecycleMeta;
+		const loose = body.dynamic?.Loose ?? body.data?.dynamic?.Loose;
 		ok(pc, 'seo.PageCache must be in describe_all phase 2');
 		ok(lm, 'metadata.LifecycleMeta must be in describe_all phase 2');
+		ok(loose, 'dynamic.Loose must be in describe_all phase 2');
 		strictEqual(pc.schema_defined, true, 'PageCache.schema_defined must remain true after restart');
 		strictEqual(pc.expiration, '0s', 'PageCache.expiration must remain "0s" after restart');
 		strictEqual(lm.schema_defined, true, 'LifecycleMeta.schema_defined must remain true after restart');
+		strictEqual(loose.schema_defined, false, 'dynamic.Loose.schema_defined must remain false after restart');
 	});
 });

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -190,6 +190,9 @@ export function makeTable(options) {
 	} = options;
 	let { expirationMS: expirationMs, evictionMS: evictionMs, audit, trackDeletes } = options;
 	evictionMs ??= 0;
+	// Eviction without explicit expiration means expiration:0. Apply at construction so
+	// describe_all sees it on every worker, not just ones that ran setTTLExpiration.
+	if (evictionMs > 0 && expirationMs === undefined) expirationMs = 0;
 	let { attributes, properties }: { attributes: Attribute[]; properties?: Record<string, JsonSchemaFragment> } =
 		options;
 	if (!attributes) attributes = [];

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1014,6 +1014,9 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 		// it table already exists, get the split segments setting
 		if (splitSegments == undefined) splitSegments = Table.splitSegments;
 		Table.attributes.splice(0, Table.attributes.length, ...attributes);
+		// Re-assert from the live declaration so a stale `false` on disk (replicated event,
+		// v4-era backfill) is corrected on every reload, not stuck across the existing-Table branch.
+		Table.schemaDefined = schemaDefined;
 		// Refresh class-level schema metadata to track docstring/directive changes across reloads.
 		Table.description = description;
 		Table.properties = properties;

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -993,6 +993,10 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 	let primaryKey;
 	let primaryKeyAttribute;
 	let attributesDbi;
+	// Track whether the caller explicitly supplied schemaDefined; callers that omit it (cluster
+	// schema-replication in Table.ts, dataLoader.ts) are operating on already-live tables whose
+	// flag must be left as-is. Only an explicit value can re-assert on the existing-Table branch.
+	const schemaDefinedExplicit = tableDefinition.schemaDefined !== undefined;
 	if (schemaDefined == undefined) schemaDefined = true;
 	const internalDbiInit = createOpenDBIObject(false);
 
@@ -1014,9 +1018,11 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 		// it table already exists, get the split segments setting
 		if (splitSegments == undefined) splitSegments = Table.splitSegments;
 		Table.attributes.splice(0, Table.attributes.length, ...attributes);
-		// Re-assert from the live declaration so a stale `false` on disk (replicated event,
-		// v4-era backfill) is corrected on every reload, not stuck across the existing-Table branch.
-		Table.schemaDefined = schemaDefined;
+		// Re-assert from the live declaration so a stale value on disk (replicated event,
+		// v4-era backfill) is corrected on every reload. Gated on `schemaDefinedExplicit` so
+		// callers that omit the flag (cluster schema-replication, data loader) don't flip a
+		// dynamic table to true via the default at the top of table().
+		if (schemaDefinedExplicit) Table.schemaDefined = schemaDefined;
 		// Refresh class-level schema metadata to track docstring/directive changes across reloads.
 		Table.description = description;
 		Table.properties = properties;

--- a/resources/graphql.ts
+++ b/resources/graphql.ts
@@ -3,13 +3,33 @@ import { Script } from 'node:vm';
 import { table } from './databases.ts';
 import { getWorkerIndex } from '../server/threads/manageThreads.js';
 import { Resources } from './Resources.ts';
-import type { NamedTypeNode, StringValueNode } from 'graphql';
+import type { NamedTypeNode, StringValueNode, ValueNode } from 'graphql';
 import { once } from 'node:events';
 import { ClientError } from '../utility/errors/hdbError.ts';
 import { attributeToFragment, type JsonSchemaFragment } from './jsonSchemaTypes.ts';
 import harperLogger from '../utility/logging/harper_logger.ts';
 
 const PRIMITIVE_TYPES = ['ID', 'Int', 'Float', 'Long', 'String', 'Boolean', 'Date', 'Bytes', 'Any', 'BigInt', 'Blob'];
+
+// coerce directive arg values by their AST node kind so numbers arrive as numbers,
+// not as the string literals they're stored as on IntValue/FloatValue nodes.
+function coerceDirectiveValue(node: ValueNode): any {
+	switch (node.kind) {
+		case 'IntValue':
+		case 'FloatValue':
+			return Number((node as { value: string }).value);
+		case 'BooleanValue':
+		case 'StringValue':
+		case 'EnumValue':
+			return (node as { value: unknown }).value;
+		case 'NullValue':
+			return null;
+		case 'ListValue':
+			return node.values.map(coerceDirectiveValue);
+		default:
+			return (node as { value?: unknown }).value;
+	}
+}
 
 if (!server.knownGraphQLDirectives) {
 	server.knownGraphQLDirectives = [];
@@ -87,7 +107,7 @@ async function processGraphQLSchema(gqlContent, urlPath, filePath, resources) {
 					const directiveName = directive.name.value;
 					if (directiveName === 'table') {
 						for (const arg of directive.arguments) {
-							typeDef[arg.name.value] = (arg.value as StringValueNode).value;
+							typeDef[arg.name.value] = coerceDirectiveValue(arg.value);
 						}
 						if (typeDef.schema) typeDef.database = typeDef.schema;
 						if (!typeDef.table) typeDef.table = typeName;


### PR DESCRIPTION
## Summary

On in-place upgrades into 5.1.0-beta.2 (both v4 → v5 with LMDB → RocksDB and v5 → v5), `describe_all` shows `schema_defined: false` on every table and omits `expiration` for eviction-configured tables. Reproduced on us-lax-1 and nl-ams-1. Eviction still functionally works; the gap is metadata visibility.

## Fix

- [resources/Table.ts](../blob/main/resources/Table.ts): default `expirationMs = 0` when `evictionMs > 0 && expirationMs === undefined` so describe sees it on every worker.
- [resources/databases.ts:1017](../blob/main/resources/databases.ts#L1017): unconditionally re-assert `Table.schemaDefined = schemaDefined` on every component reload.
- [resources/graphql.ts](../blob/main/resources/graphql.ts): `coerceDirectiveValue` switches on AST node kind so Int/Float arrive as numbers.

## Test

`integrationTests/apiTests/describe-metadata-upgrade-1132.test.ts`: pinned `dataRootDir`, two-phase, `threads.count: 2`. Phase 1 installs the component and asserts `expiration: "0s"` and `schema_defined: true`. Phase 2 reboots on the same data dir and asserts both survive. Both fail without the patches.


closes #1245 