### PR TITLE
Default applications.moduleLoader to vm-current-context

### DIFF
--- a/components/ApplicationScope.ts
+++ b/components/ApplicationScope.ts
@@ -30,7 +30,7 @@ export class ApplicationScope {
 		this.resources = resources;
 		this.server = server;
 
-		this.mode = env.get(CONFIG_PARAMS.APPLICATIONS_MODULELOADER) ?? 'vm';
+		this.mode = env.get(CONFIG_PARAMS.APPLICATIONS_MODULELOADER) ?? 'vm-current-context';
 		this.dependencyLoader = env.get(CONFIG_PARAMS.APPLICATIONS_DEPENDENCYLOADER);
 		if (env.get(CONFIG_PARAMS.APPLICATIONS_ALLOWEDDIRECTORY) !== 'app') this.allowedPath = ''; // this is used to match paths by startsWith, so empty string matches everything
 	}

--- a/static/defaultConfig.yaml
+++ b/static/defaultConfig.yaml
@@ -25,7 +25,7 @@ analytics:
   replicate: false
 applications:
   lockdown: freeze-after-load
-  moduleLoader: vm
+  moduleLoader: vm-current-context
   dependencyLoader: auto
   allowedSpawnCommands:
     - npm


### PR DESCRIPTION
## Summary

Flip the default `applications.moduleLoader` from `vm` to `vm-current-context`.

- `components/ApplicationScope.ts` — fallback when the config param is unset is now `vm-current-context`.
- `static/defaultConfig.yaml` — shipped default updated to match.

## Purpose

Under `vm` mode each application gets its own context with **separate JavaScript intrinsics** (`Object`, `Array`, `Promise`, …). That is a recurring source of subtle cross-realm bugs — most commonly `instanceof` and other identity checks failing for values that cross the application/Harper boundary. `vm-current-context` runs the VM loader in Harper's own context, so intrinsics are shared, while still giving each application its own module cache and a scoped `harper` module (tagged `logger`, per-app `config`, etc.).

Application-specific values remain available exactly as before via `import ... from 'harper'` / `require('harper')` — only the realm changes, not the scoped-export mechanism.

## Where to look

- The behavioral surface is just the default; `vm` remains fully available for anyone who needs separate intrinsics or the SES-constrained `fetch` (which only applies in `vm` mode).
- No loader code paths change — an earlier idea to inject scoped globals into the CJS wrapper was dropped because `require('harper')` already resolves to the scoped exports, and wrapper-param injection collides with the canonical `const harper = require('harperdb')` pattern.

_Generated with assistance from Claude (Opus 4.7); reviewed by Kris._