### PR TITLE
Add urlPath, host, and loadComponent to get_components response

### DIFF
--- a/components/operations.js
+++ b/components/operations.js
@@ -659,8 +659,12 @@ async function getComponents() {
 		entries: [],
 	});
 	for (let entry of results.entries) {
-		const sourcePackage = rootConfig[entry.name]?.package;
-		if (sourcePackage) entry.package = sourcePackage;
+		const componentConfig = rootConfig?.[entry.name];
+		if (!componentConfig) continue;
+		if (componentConfig.package) entry.package = componentConfig.package;
+		if (componentConfig.urlPath) entry.urlPath = componentConfig.urlPath;
+		if (componentConfig.host) entry.host = componentConfig.host;
+		if (componentConfig.loadComponent) entry.loadComponent = componentConfig.loadComponent;
 	}
 
 	const { internal: statusInternal } = require('./status/index.ts');

--- a/components/operations.js
+++ b/components/operations.js
@@ -660,7 +660,7 @@ async function getComponents() {
 	});
 	for (let entry of results.entries) {
 		const componentConfig = rootConfig?.[entry.name];
-		if (!componentConfig) continue;
+		if (!componentConfig || typeof componentConfig !== 'object') continue;
 		if (componentConfig.package) entry.package = componentConfig.package;
 		if (componentConfig.urlPath) entry.urlPath = componentConfig.urlPath;
 		if (componentConfig.host) entry.host = componentConfig.host;

--- a/unitTests/server/fastifyRoutes/operations.test.js
+++ b/unitTests/server/fastifyRoutes/operations.test.js
@@ -153,6 +153,9 @@ describe('Test custom functions operations', () => {
 			sandbox.stub(configUtils, 'getConfiguration').returns({
 				'my-other-component': {
 					package: '@my-org/my-other-component',
+					urlPath: '/other',
+					host: 'other.example.com',
+					loadComponent: 'if-installed',
 				},
 			});
 		}
@@ -170,9 +173,14 @@ describe('Test custom functions operations', () => {
 			expect(coolComponent).to.exist;
 			expect(coolComponent.entries.length).to.equal(3);
 			expect(coolComponent.package).to.be.undefined;
+			expect(coolComponent.urlPath).to.be.undefined;
+			expect(coolComponent.host).to.be.undefined;
 			expect(otherComponent).to.exist;
 			expect(otherComponent.entries.find((e) => e.name === 'config.yaml')).to.exist;
 			expect(otherComponent.package).to.equal('@my-org/my-other-component');
+			expect(otherComponent.urlPath).to.equal('/other');
+			expect(otherComponent.host).to.equal('other.example.com');
+			expect(otherComponent.loadComponent).to.equal('if-installed');
 		});
 
 		it('Test getComponents includes status information when component status exists', async () => {


### PR DESCRIPTION
## Summary

`get_components` already enriched each top-level component entry with the `package` field from its root-config entry. This change additionally exposes `urlPath`, `host`, and `loadComponent` from the same config entry, so callers (e.g. Studio) can see where a component is routed and whether it is conditionally loaded (`dev-only` / `if-installed`).

## Notes for review

- Fields are copied only when truthy, matching the existing `package` behavior — absent config keys stay absent from the response rather than appearing as `undefined`/empty values.
- These come from the root `harperdb-config.yaml` entry (the same place `deploy_component` writes `urlPath`), not from a component's own `config.yaml`. A component that only sets `urlPath`/`host` in its own config file won't have them reflected here — same limitation `package` already has. Flagging in case you'd prefer the operation to merge the component-local config too.

Cross-model reviews (Codex, Gemini) were run and came back clean; Gemini's null-safety suggestion on `rootConfig` was applied.

Generated by an LLM (Claude Fable 5) under Kris's direction.