### PR TITLE
Never drop source-applied writes on conflict; backpressure the apply loop

### DIFF
--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -304,11 +304,15 @@ export class DatabaseTransaction implements Transaction {
 					return commitResolution.then(
 						() => {
 							// onCommit may be async (e.g. RocksTransactionLogStore emits 'aftercommit'). Surface a
-							// rejection via logging rather than letting it become a silent unhandled rejection — but
-							// don't fail the commit on it, the write is already durable.
-							const onCommitResult = (transaction as any).onCommit?.();
-							if (onCommitResult?.then)
-								onCommitResult.catch((error) => harperLogger.warn?.('onCommit handler failed after commit', error));
+							// rejection — or a synchronous throw — via logging rather than failing the commit, since
+							// the write is already durable.
+							try {
+								const onCommitResult = (transaction as any).onCommit?.();
+								if (onCommitResult?.then)
+									onCommitResult.catch((error) => harperLogger.warn?.('onCommit handler failed after commit', error));
+							} catch (error) {
+								harperLogger.warn?.('onCommit handler failed after commit', error);
+							}
 							if (this.next) {
 								completions.push(this.next.commit(options));
 							}
@@ -367,10 +371,19 @@ export class DatabaseTransaction implements Transaction {
 									// apply loop serializes commits (backpressure), so contention clears rather than
 									// compounding. Request-path transactions keep the MAX_RETRIES cap and surface a loud error.
 									const neverDropOnConflict = this.sourceApply;
-									if (this.retries > MAX_RETRIES && !neverDropOnConflict) {
-										throw new ServerError(
-											`After ${MAX_RETRIES} retries, unable to commit transaction, transaction is in conflict with ongoing writes`
-										);
+									if (this.retries > MAX_RETRIES) {
+										if (!neverDropOnConflict) {
+											throw new ServerError(
+												`After ${MAX_RETRIES} retries, unable to commit transaction, transaction is in conflict with ongoing writes`
+											);
+										}
+										// Uncapped retry can otherwise stall silently (debug logging is off in production);
+										// surface periodic visibility into a stalled source-apply commit.
+										if (this.retries % MAX_RETRIES === 0) {
+											harperLogger.warn?.(
+												`Source-applied transaction ${transaction.id} still in conflict after ${this.retries} retries; continuing to retry`
+											);
+										}
 									}
 									// start delaying, back off to try to space out transactions and avoid excessive conflicts
 									return delay(Math.min(this.retries * this.retries, MAX_RETRY_DELAY_MS)).then(() =>

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -99,6 +99,10 @@ export class DatabaseTransaction implements Transaction {
 	overloadChecked: boolean;
 	open = TRANSACTION_STATE.OPEN;
 	replicatedConfirmation: number;
+	// Set when this transaction is applying data from a canonical source of truth (replication peer
+	// or external caching source); its commits retry transient conflicts without the request-path
+	// retry cap. Propagated to chained (multi-store) transactions in txnForContext.
+	declare sourceApply?: boolean;
 
 	getReadTxn(): ReadTransaction {
 		this.readTxnRefCount = (this.readTxnRefCount || 0) + 1;
@@ -362,7 +366,7 @@ export class DatabaseTransaction implements Transaction {
 									// permanently diverged (harper-pro#348). Such transactions retry without a cap; the source
 									// apply loop serializes commits (backpressure), so contention clears rather than
 									// compounding. Request-path transactions keep the MAX_RETRIES cap and surface a loud error.
-									const neverDropOnConflict = (this.#context as any)?.sourceApply;
+									const neverDropOnConflict = this.sourceApply;
 									if (this.retries > MAX_RETRIES && !neverDropOnConflict) {
 										throw new ServerError(
 											`After ${MAX_RETRIES} retries, unable to commit transaction, transaction is in conflict with ongoing writes`

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -22,6 +22,9 @@ export const TRANSACTION_STATE = {
 	LINGERING: 2, // the transaction has completed a read, but can be used for immediate writes
 };
 const MAX_RETRIES = 40;
+// Cap the per-retry backoff so replication-applied transactions, which retry conflicts without a
+// cap (see the commit rejection handler), don't grow the delay unbounded.
+const MAX_RETRY_DELAY_MS = 1000;
 let outstandingCommit, outstandingCommitStart;
 let confirmReplication;
 export function replicationConfirmation(callback) {
@@ -296,7 +299,11 @@ export class DatabaseTransaction implements Transaction {
 					const completions = [];
 					return commitResolution.then(
 						() => {
-							(transaction as any).onCommit?.();
+							// onCommit may be async (e.g. RocksTransactionLogStore emits 'aftercommit'); fold its
+							// result into the commit completions so a rejection propagates instead of becoming a
+							// silent unhandled rejection.
+							const onCommitResult = (transaction as any).onCommit?.();
+							if (onCommitResult?.then) completions.push(onCommitResult);
 							if (this.next) {
 								completions.push(this.next.commit(options));
 							}
@@ -348,13 +355,22 @@ export class DatabaseTransaction implements Transaction {
 								this.retries++;
 								harperLogger.debug?.('retrying', transaction.id, this.retries);
 								if (this.retries > 2) {
-									if (this.retries > MAX_RETRIES) {
+									// Transactions applying data from a canonical source of truth (replication peer or
+									// external caching source) must never drop a write on a transient conflict: there is no
+									// re-subscribe / sequence-id-resume path, so a dropped write would leave this node
+									// permanently diverged (harper-pro#348). Such transactions retry without a cap; the source
+									// apply loop serializes commits (backpressure), so contention clears rather than
+									// compounding. Request-path transactions keep the MAX_RETRIES cap and surface a loud error.
+									const neverDropOnConflict = (this.#context as any)?.sourceApply;
+									if (this.retries > MAX_RETRIES && !neverDropOnConflict) {
 										throw new ServerError(
 											`After ${MAX_RETRIES} retries, unable to commit transaction, transaction is in conflict with ongoing writes`
 										);
 									}
 									// start delaying, back off to try to space out transactions and avoid excessive conflicts
-									return delay(this.retries * this.retries).then(() => this.commit({ transaction }));
+									return delay(Math.min(this.retries * this.retries, MAX_RETRY_DELAY_MS)).then(() =>
+										this.commit({ transaction })
+									);
 								}
 								return this.commit({ transaction }); // try again
 							} else throw error;

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -299,11 +299,12 @@ export class DatabaseTransaction implements Transaction {
 					const completions = [];
 					return commitResolution.then(
 						() => {
-							// onCommit may be async (e.g. RocksTransactionLogStore emits 'aftercommit'); fold its
-							// result into the commit completions so a rejection propagates instead of becoming a
-							// silent unhandled rejection.
+							// onCommit may be async (e.g. RocksTransactionLogStore emits 'aftercommit'). Surface a
+							// rejection via logging rather than letting it become a silent unhandled rejection — but
+							// don't fail the commit on it, the write is already durable.
 							const onCommitResult = (transaction as any).onCommit?.();
-							if (onCommitResult?.then) completions.push(onCommitResult);
+							if (onCommitResult?.then)
+								onCommitResult.catch((error) => harperLogger.warn?.('onCommit handler failed after commit', error));
 							if (this.next) {
 								completions.push(this.next.commit(options));
 							}

--- a/resources/ResourceInterface.ts
+++ b/resources/ResourceInterface.ts
@@ -90,6 +90,9 @@ export interface Context {
 	replicateTo?: string[];
 	replicateFrom?: boolean;
 	replicatedConfirmation?: number;
+	/** Set when applying a write from a canonical source of truth (replication peer or external
+	 * caching source); such commits retry transient conflicts without the request-path retry cap. */
+	sourceApply?: boolean;
 	originatingOperation?: OperationFunctionName;
 	previousResidency?: string[];
 	loadedFromSource?: boolean;

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -436,6 +436,11 @@ export function makeTable(options) {
 									continue;
 								}
 								event.source = source;
+								// Writes applied here come from the canonical source of truth (a replication peer or an
+								// external caching source), so a transient write conflict must never drop the write —
+								// there is no re-subscribe / sequence-id-resume path to recover it. Mark the context so the
+								// commit retries such conflicts without a cap (see DatabaseTransaction commit).
+								event.sourceApply = true;
 								if (event.type === 'end_txn') {
 									txnInProgress?.resolve();
 									let updateRecordedSequenceId: () => void;
@@ -486,18 +491,17 @@ export function makeTable(options) {
 											lastSequenceId = event.localTime;
 										}
 									}
+									// Backpressure: wait for the transaction's commit to land before recording the sequence
+									// id or pulling the next event. This serializes the apply loop so bulk ingest can't
+									// outrun the commit/conflict-check window, and guarantees the sequence id never
+									// advances past an uncommitted write (which would diverge this node from its peers).
+									if (txnInProgress) await txnInProgress.committed;
 									if (event.onCommit) {
-										// if there was an onCommit callback, call that. This function can be async
-										// and if so, we want to delay the recording of the sequence id until it finished
-										// (as it can be used to indicate more associated actions, like blob transfer, are in flight)
-										const onCommitFinished = txnInProgress
-											? txnInProgress.committed.then(event.onCommit)
-											: event.onCommit();
-										if (updateRecordedSequenceId) {
-											if (onCommitFinished?.then) onCommitFinished.then(updateRecordedSequenceId);
-											else updateRecordedSequenceId();
-										}
-									} else if (updateRecordedSequenceId) updateRecordedSequenceId();
+										// the onCommit callback can be async and carry associated work (e.g. blob transfer);
+										// wait for it too before recording the sequence id.
+										await event.onCommit();
+									}
+									if (updateRecordedSequenceId) updateRecordedSequenceId();
 									continue;
 								}
 								if (txnInProgress) {
@@ -570,8 +574,19 @@ export function makeTable(options) {
 								}
 
 								if (event.onCommit) {
-									if (commitResolution) commitResolution.then(event.onCommit);
-									else event.onCommit();
+									if (txnInProgress) {
+										// begin_txn: commitResolution stays pending until the matching end_txn, so it
+										// can't be awaited here; onCommit is awaited at end_txn once the commit lands.
+										if (commitResolution) commitResolution.then(event.onCommit);
+										else event.onCommit();
+									} else {
+										// standalone write: backpressure on the commit before pulling the next event.
+										if (commitResolution) await commitResolution;
+										await event.onCommit();
+									}
+								} else if (commitResolution && !txnInProgress) {
+									// standalone write with no onCommit: still backpressure on the commit.
+									await commitResolution;
 								}
 							} catch (error) {
 								logger.error?.('error in subscription handler', error);

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -442,7 +442,11 @@ export function makeTable(options) {
 								// commit retries such conflicts without a cap (see DatabaseTransaction commit).
 								event.sourceApply = true;
 								if (event.type === 'end_txn') {
-									txnInProgress?.resolve();
+									// Capture the in-progress transaction in a stable local: the loop variable is reset
+									// once this transaction completes (below), but the seq-id closure and the commit await
+									// still need to reference it afterward.
+									const committingTxn = txnInProgress;
+									committingTxn?.resolve();
 									let updateRecordedSequenceId: () => void;
 									if (event.localTime && lastSequenceId !== event.localTime) {
 										if (event.remoteNodeIds?.length > 0) {
@@ -469,7 +473,7 @@ export function makeTable(options) {
 														nodeStates.push(nodeState);
 													}
 													nodeState.seqId = Math.max(existingSeq?.seqId ?? 1, event.localTime);
-													if (nodeId === txnInProgress?.nodeId) {
+													if (nodeId === committingTxn?.nodeId) {
 														nodeState.lastTxnTime = event.timestamp;
 													}
 												}
@@ -497,7 +501,7 @@ export function makeTable(options) {
 									// advances past an uncommitted write (which would diverge this node from its peers).
 									let committed;
 									try {
-										committed = txnInProgress ? await txnInProgress.committed : undefined;
+										committed = committingTxn ? await committingTxn.committed : undefined;
 										if (event.onCommit) {
 											// the onCommit callback can be async and carry associated work (e.g. blob
 											// transfer); wait for it too before recording the sequence id. Pass the commit

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -529,6 +529,12 @@ export function makeTable(options) {
 										txnInProgress.resolve();
 										try {
 											await txnInProgress.committed;
+										} catch (error) {
+											// Transient conflicts retry without limit and never reach here, so this is a
+											// non-retryable commit failure on the prior transaction. Log and continue (rather
+											// than rethrow) so the current beginTxn still starts a fresh transaction with
+											// correct boundaries instead of having its writes applied as standalone ones.
+											logger.error?.('source-applied transaction commit failed during apply', error);
 										} finally {
 											// Clear it regardless of outcome so a rejected commit isn't re-awaited on the
 											// next beginTxn (which would brick the apply loop).
@@ -4244,6 +4250,9 @@ export function makeTable(options) {
 				if (!nextTxn) {
 					// no next one, then add our database
 					transaction.next = isRocksDB ? new DatabaseTransaction() : new LMDBTransaction();
+					// Inherit never-drop-on-conflict so a source-applied multi-store transaction doesn't
+					// drop the canonical write when a secondary store hits a transient conflict.
+					transaction.next.sourceApply = transaction.sourceApply;
 					if (transaction.open === TRANSACTION_STATE.CLOSED) {
 						// if the current transaction is already closed, we need to retain that state on new databases we work with
 						transaction.next.open = TRANSACTION_STATE.CLOSED;

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -495,19 +495,25 @@ export function makeTable(options) {
 									// id or pulling the next event. This serializes the apply loop so bulk ingest can't
 									// outrun the commit/conflict-check window, and guarantees the sequence id never
 									// advances past an uncommitted write (which would diverge this node from its peers).
-									if (txnInProgress) await txnInProgress.committed;
+									const committed = txnInProgress ? await txnInProgress.committed : undefined;
 									if (event.onCommit) {
 										// the onCommit callback can be async and carry associated work (e.g. blob transfer);
-										// wait for it too before recording the sequence id.
-										await event.onCommit();
+										// wait for it too before recording the sequence id. Pass the commit resolution
+										// through, as callbacks may use the committed txn time.
+										await event.onCommit(committed);
 									}
 									if (updateRecordedSequenceId) updateRecordedSequenceId();
 									continue;
 								}
 								if (txnInProgress) {
 									if (event.beginTxn) {
-										// if we are starting a new transaction, finish the existing one
+										// Starting a new transaction closes the existing one. When transactions are
+										// delimited by consecutive beginTxn events (end_txn only arrives after the final
+										// one), this is the backpressure point for all but the last transaction: wait for
+										// the prior commit to land before applying the next so the sequence id can't
+										// advance past an uncommitted write.
 										txnInProgress.resolve();
+										await txnInProgress.committed;
 									} else {
 										// write in the current transaction if one is in progress
 										txnInProgress.writePromises.push(writeUpdate(event, txnInProgress));
@@ -580,9 +586,10 @@ export function makeTable(options) {
 										if (commitResolution) commitResolution.then(event.onCommit);
 										else event.onCommit();
 									} else {
-										// standalone write: backpressure on the commit before pulling the next event.
-										if (commitResolution) await commitResolution;
-										await event.onCommit();
+										// standalone write: backpressure on the commit before pulling the next event,
+										// and pass the commit resolution through to the callback.
+										const committed = commitResolution ? await commitResolution : undefined;
+										await event.onCommit(committed);
 									}
 								} else if (commitResolution && !txnInProgress) {
 									// standalone write with no onCommit: still backpressure on the commit.

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -495,13 +495,23 @@ export function makeTable(options) {
 									// id or pulling the next event. This serializes the apply loop so bulk ingest can't
 									// outrun the commit/conflict-check window, and guarantees the sequence id never
 									// advances past an uncommitted write (which would diverge this node from its peers).
-									const committed = txnInProgress ? await txnInProgress.committed : undefined;
-									if (event.onCommit) {
-										// the onCommit callback can be async and carry associated work (e.g. blob transfer);
-										// wait for it too before recording the sequence id. Pass the commit resolution
-										// through, as callbacks may use the committed txn time.
-										await event.onCommit(committed);
+									let committed;
+									try {
+										committed = txnInProgress ? await txnInProgress.committed : undefined;
+										if (event.onCommit) {
+											// the onCommit callback can be async and carry associated work (e.g. blob
+											// transfer); wait for it too before recording the sequence id. Pass the commit
+											// resolution through, as callbacks may use the committed txn time.
+											await event.onCommit(committed);
+										}
+									} finally {
+										// Always clear the completed transaction so a later standalone write isn't appended
+										// to it (and lost), and a failed commit's rejected promise isn't re-awaited on the
+										// next beginTxn (which would brick the apply loop).
+										txnInProgress = undefined;
 									}
+									// Only reached when the commit succeeded; a failure propagates to the handler's catch
+									// and the sequence id is intentionally not advanced past the unapplied write.
 									if (updateRecordedSequenceId) updateRecordedSequenceId();
 									continue;
 								}
@@ -513,7 +523,13 @@ export function makeTable(options) {
 										// the prior commit to land before applying the next so the sequence id can't
 										// advance past an uncommitted write.
 										txnInProgress.resolve();
-										await txnInProgress.committed;
+										try {
+											await txnInProgress.committed;
+										} finally {
+											// Clear it regardless of outcome so a rejected commit isn't re-awaited on the
+											// next beginTxn (which would brick the apply loop).
+											txnInProgress = undefined;
+										}
 									} else {
 										// write in the current transaction if one is in progress
 										txnInProgress.writePromises.push(writeUpdate(event, txnInProgress));

--- a/resources/transaction.ts
+++ b/resources/transaction.ts
@@ -40,6 +40,7 @@ export function transaction<T>(
 	context.transaction = transaction;
 	if (context.timestamp) transaction.timestamp = context.timestamp;
 	if (context.replicatedConfirmation) transaction.replicatedConfirmation = context.replicatedConfirmation;
+	if (context.sourceApply) transaction.sourceApply = true;
 	transaction.setContext(context);
 
 	// create a resource cache so that multiple requests to the same resource return the same resource


### PR DESCRIPTION
## Summary
Writes applied from a canonical source of truth — a replication peer or an external caching source — flow through `Table.sourcedFrom`'s subscription apply loop, which committed them fire-and-forget. Under sustained write conflict a commit could exhaust the `MAX_RETRIES` cap and its rejection was swallowed as an unhandled rejection, so the write was **silently dropped**. Because there is no re-subscribe / sequence-id-resume path, the node then diverged permanently from its peers.

This makes two coordinated changes:
- **Never drop on transient conflict.** Transactions applying source-of-truth data are flagged (`context.sourceApply`); their commits retry `ERR_BUSY` / `ERR_TRY_AGAIN` **without** the `MAX_RETRIES` cap (with a capped backoff). Request-path transactions are unchanged — they keep the cap and surface a loud error.
- **Backpressure the apply loop.** The loop now `await`s each commit before recording the sequence id / pulling the next event (at `end_txn`, at a `beginTxn` that closes a prior transaction, and for standalone writes). This removes the fire-and-forget pipelining that *creates* the conflict storm and guarantees the sequence id never advances past an uncommitted write.

Also: an async success-path `onCommit` rejection is now logged instead of becoming a silent unhandled rejection.

## Purpose
The data-safety + throughput halves of HarperFast/harper-pro#348 (bulk full-copy / v4→v5 migration losing records at scale). Companion to #1251 (WBM defaults), which provides the memtable backpressure on the producer side.

## Where to look
- `resources/Table.ts` — the apply-loop backpressure awaits and the `txnInProgress` lifecycle (reset via `try/finally` after each transaction completes).
- `resources/DatabaseTransaction.ts` — the uncapped-retry-for-`sourceApply` branch and the `onCommit` rejection handling.

## Reviewer attention (open items / deliberate trade-offs)
- **Full serialization is a real throughput change** for normal replication and caching-source apply, not just the pathological case. This is the intended backpressure but warrants a perf sanity check.
- **Validation gate:** the actual #348 acceptance test is the harper-fabric-lab repro (`MIG_RECORDS=80000 …`). This has **not** been run yet — it should gate the merge. Local full `transaction.test.js` is pre-existing-flaky (RocksDB-lock/state); relevant suites pass in isolation (caching, subscriptionReplay, transaction merge).
- **Uncapped retry semantics:** a *transient* conflict that never clears (e.g. a sustained external write storm on the same key) will retry that table's apply indefinitely at a bounded ~1/s rate rather than dropping — deliberate ("truth can't be skipped"), but it means a single hot key can stall a table's replication apply. A genuinely non-transient commit error still propagates (logged) and does not advance the sequence id.
- **Scope:** applies to *all* source-of-truth apply (caching + replication), per the principle that a source is canonical and its writes can't be skipped.

Cross-model reviewed (Codex + Gemini/agy) pre-PR; a couple of backpressure/lifecycle bugs they caught are fixed in the commit history.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Sonnet 4.6

## Known limitation
A genuinely **non-transient** commit failure during source-apply (not a transient conflict — those now retry without a cap) is logged and the loop continues; a later successful transaction's `end_txn` can then advance the recorded sequence id past the failed one, so on restart that write is skipped. This is pre-existing behavior and out of scope for #348 (whose scenario is transient conflict, now fully covered). Hardening it (freeze the checkpoint or halt-loud on non-transient apply failure, so a restart re-delivers) is a possible defense-in-depth follow-up that depends on the re-subscribe/restart-resume path. The new periodic warn log surfaces a stalled apply loop in the meantime.