### PR TITLE
fix(install): don't leak DEV_MODE from installer into the run process

### DIFF
--- a/unitTests/install/installer.test.js
+++ b/unitTests/install/installer.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('node:assert/strict');
 const chai = require('chai');
 const sinon = require('sinon');
 const { expect } = chai;
@@ -518,5 +519,38 @@ describe.skip('Test installer module', () => {
 			const configPath = path.join(testRoot, 'harperdb-config.yaml');
 			expect(fs.existsSync(configPath)).to.be.true;
 		});
+	});
+});
+
+// Regression guard for applyInstallModeDefaults: a 'dev' install must persist the dev config defaults but
+// must NOT set process.env.DEV_MODE. That env var is set only by the `harper dev` command and is the sole
+// source of truth for dev-only runtime behavior (component auto-reload watcher, dev-only components). When
+// install runs in-process from `harper run .` (first-run install), leaking it would make a plain `run`
+// behave like `dev` until the next restart. Tested against the real exported helper (no sinon/rewire).
+describe('applyInstallModeDefaults', () => {
+	const { applyInstallModeDefaults } = require('#js/utility/install/installer');
+
+	const readDevMode = () =>
+		Object.prototype.hasOwnProperty.call(process.env, 'DEV_MODE') ? process.env.DEV_MODE : undefined;
+
+	it('persists the dev config defaults for a dev install', () => {
+		const args = applyInstallModeDefaults({}, 'dev');
+		// Representative dev defaults that must survive into the persisted config.
+		assert.equal(args.threads_count, 1);
+		assert.equal(args.authentication_authorizeLocal, true);
+		assert.equal(args.http_cors, true);
+	});
+
+	it('does not mutate process.env.DEV_MODE for a dev install', () => {
+		const before = readDevMode();
+		applyInstallModeDefaults({}, 'dev');
+		assert.equal(readDevMode(), before);
+	});
+
+	it('does not apply dev defaults for a prod install', () => {
+		const args = applyInstallModeDefaults({}, 'prod');
+		assert.equal(args.threads_count, undefined);
+		assert.equal(args.authentication_authorizeLocal, undefined);
+		assert.equal(args.http_cors, undefined);
 	});
 });

--- a/utility/install/installer.ts
+++ b/utility/install/installer.ts
@@ -487,19 +487,22 @@ async function createBootPropertiesFile() {
 }
 
 /**
- * Calls the util function that creates the Harper config file.
- * If an error occurs during the create install is rolled backed.
- * @param installParams
- * @returns {Promise<void>}
+ * Applies the install-mode ('dev' | anything else => prod) config defaults to the given config args and
+ * returns them.
+ *
+ * Pure: it does not read or mutate process.env, touch the filesystem, or log — the returned args are simply
+ * what gets persisted to the config file. In particular a 'dev' install must NOT set process.env.DEV_MODE:
+ * that flag is owned solely by the `harper dev` command (bin/harper.ts) and is the source of truth for
+ * dev-only runtime behavior such as the component auto-reload watcher. Because install can run in-process
+ * from `harper run .` (first-run install), setting it here would leak dev runtime behavior into a plain
+ * `run` until the next restart. The dev defaults are still persisted to the config file regardless.
+ *
+ * @param args - config args (cmd/env values already merged with install params)
+ * @param defaultsMode - the resolved DEFAULTS_MODE install param ('dev' or 'prod')
+ * @returns the same args object, mutated in place, for convenience
  */
-async function createConfigFile(installParams) {
-	hdbLogger.trace('Creating Harper config file');
-	const args = assignCMDENVVariables(Object.keys(hdbTerms.CONFIG_PARAM_MAP), true);
-	Object.assign(args, installParams);
-
-	// If installing in dev mode set dev config defaults
-	if (installParams[hdbTerms.INSTALL_PROMPTS.DEFAULTS_MODE] === 'dev') {
-		process.env.DEV_MODE = 'true';
+export function applyInstallModeDefaults(args, defaultsMode) {
+	if (defaultsMode === 'dev') {
 		for (const cfg in DEV_MODE_CONFIG) {
 			// Before setting http.port check that secure port is not being passed
 			if (cfg === CONFIG_PARAMS.HTTP_PORT && args[CONFIG_PARAMS.HTTP_SECUREPORT.toLowerCase()] === undefined) {
@@ -527,16 +530,31 @@ async function createConfigFile(installParams) {
 			if (args[cfg.toLowerCase()] === undefined) args[cfg] = DEV_MODE_CONFIG[cfg];
 		}
 	} else {
-		const defaultsMode = installParams[hdbTerms.INSTALL_PROMPTS.DEFAULTS_MODE];
-		if (defaultsMode !== undefined && defaultsMode !== 'prod') {
-			const warn = `DEFAULTS_MODE value "${defaultsMode}" is not recognized (expected "dev" or "prod"). Using prod defaults.`;
-			console.error(chalk.yellow.bold(`Warning: ${warn}`));
-			hdbLogger.warn(warn);
-		}
 		if (args[CONFIG_PARAMS.OPERATIONSAPI_NETWORK_PORT.toLowerCase()])
 			args[CONFIG_PARAMS.OPERATIONSAPI_NETWORK_SECUREPORT] = null;
 		if (args[CONFIG_PARAMS.HTTP_PORT.toLowerCase()]) args[CONFIG_PARAMS.HTTP_SECUREPORT] = null;
 	}
+	return args;
+}
+
+/**
+ * Calls the util function that creates the Harper config file.
+ * If an error occurs during the create install is rolled backed.
+ * @param installParams
+ * @returns {Promise<void>}
+ */
+async function createConfigFile(installParams) {
+	hdbLogger.trace('Creating Harper config file');
+	const args = assignCMDENVVariables(Object.keys(hdbTerms.CONFIG_PARAM_MAP), true);
+	Object.assign(args, installParams);
+
+	const defaultsMode = installParams[hdbTerms.INSTALL_PROMPTS.DEFAULTS_MODE];
+	if (defaultsMode !== undefined && defaultsMode !== 'dev' && defaultsMode !== 'prod') {
+		const warn = `DEFAULTS_MODE value "${defaultsMode}" is not recognized (expected "dev" or "prod"). Using prod defaults.`;
+		console.error(chalk.yellow.bold(`Warning: ${warn}`));
+		hdbLogger.warn(warn);
+	}
+	applyInstallModeDefaults(args, defaultsMode);
 
 	try {
 		if (!cfgEnv[hdbTerms.INSTALL_PROMPTS.HDB_CONFIG]) {


### PR DESCRIPTION
## Summary
`harper run .` set up a filesystem auto-reload watcher (restarting worker threads on file edits) **only when Harper happened to install itself on startup**, and not on subsequent runs. This makes the behavior depend on install state rather than the command.

## Root cause
`createConfigFile()` set `process.env.DEV_MODE = 'true'` whenever an install defaulted to dev mode (the interactive default). Because install runs **in-process** from a first-run `harper run .` (when `~/harper` is absent), that env var leaked into the run process. Component auto-reload (`components/componentLoader.ts:84`) and other dev-only runtime behavior gate on `process.env.DEV_MODE`, so a first-run install behaved like `harper dev`; a later `harper run .` (already installed) did not.

## Fix
`process.env.DEV_MODE` is now set **only** by the `harper dev` command (`bin/harper.ts`). The command line is the source of truth: `harper dev` enables auto-reload, `harper run` never does, regardless of install state. The dev *config* defaults (cors, ports, `threads=1`, `authorizeLocal`, `stdStreams`, etc.) are still persisted to the config file via `DEV_MODE_CONFIG`, so they survive restarts exactly as before — only the transient env flag is no longer leaked.

Also extracts the dev/prod config-args derivation out of `createConfigFile()` into a pure, exported `applyInstallModeDefaults(args, defaultsMode)` helper (no `process.env`/fs/logging side effects), tested with `node:assert/strict`.

## Where to look
- `utility/install/installer.ts` — the removed `process.env.DEV_MODE` assignment and the extracted helper. The "unrecognized DEFAULTS_MODE → warn + prod defaults" path was moved out of the old `else` branch into `createConfigFile`; behavior is intended to be preserved (warn only for a defined, non-dev, non-prod value).
- Confirm no other in-process `install → run` behavior relied on the leaked flag. Config-backed behaviors (thread count `run.ts:208`, `authorizeLocal`, `stdStreams`) are persisted and unaffected; the intentionally-changed behaviors for a first-run `harper run` install are auto-reload and dev-only component loading — both should now be off under `run`, matching every subsequent run.

## Testing
- New `node:assert/strict` tests for `applyInstallModeDefaults` (install + bin unit suites pass).
- Manually verified end-to-end: with the unfixed build a first-run `harper run .` install set up the watcher (file edits restarted workers); with the fix it does not, while `harper dev .` still does.
- The full local unit suite could not be run to completion in this environment (no installed `~/harper`; `.mocharc` `timeout:0` causes an unrelated component-loader integration test to hang) — relying on CI for the full suite.

Reviewed by Codex (cross-model). Generated by an LLM (Claude Opus 4.8).