### PR TITLE
Fix fastifyRoutes 404 by deriving route prefix from urlPath config

### DIFF
--- a/server/fastifyRoutes.ts
+++ b/server/fastifyRoutes.ts
@@ -1,5 +1,6 @@
 import { dirname, basename } from 'path';
 import { existsSync } from 'fs';
+import { deriveRoutePrefix } from './fastifyRoutes/helpers/deriveRoutePrefix.ts';
 import fastify from 'fastify';
 import fastifyCors from '@fastify/cors';
 import requestTimePlugin from './serverHelpers/requestTimePlugin.js';
@@ -47,8 +48,12 @@ export function handleApplication(scope: import('../components/Scope.ts').Scope)
 		}
 		const resolvedServer = await fastifyServer;
 		const routeFolder = dirname(entry.absolutePath);
-		let prefix = basename(scope.appName);
-		if (prefix.startsWith('/')) prefix = prefix.slice(1);
+		// Derive the prefix from the component's own `urlPath`/`path` config rather than
+		// `entry.urlPath`: the EntryHandler resolves the entry path against the plugin name and
+		// ignores the deprecated `path` alias, so it can't express the app-name namespace.
+		// `appName` may be an absolute path (loaded via RUN_HDB_APP), hence basename().
+		const config = (scope.options.getAll() as { urlPath?: string; path?: string }) ?? {};
+		const prefix = deriveRoutePrefix(basename(scope.appName), config.urlPath ?? config.path);
 		if (!routeFolders.has(routeFolder)) {
 			routeFolders.add(routeFolder);
 			try {

--- a/server/fastifyRoutes/helpers/deriveRoutePrefix.ts
+++ b/server/fastifyRoutes/helpers/deriveRoutePrefix.ts
@@ -1,0 +1,13 @@
+import { resolveBaseURLPath } from '../../../components/resolveBaseURLPath.ts';
+
+/**
+ * Derives the Fastify autoload route prefix for a component's routes from its app name and the
+ * component's `urlPath` (or deprecated `path`) config, honoring the documented contract: no config
+ * serves routes at the root, `urlPath: .` namespaces them under the app name (`/app-name/...`), and
+ * an explicit `urlPath` uses that path. This mirrors `resolveBaseURLPath` (used for REST/static
+ * routing) so fastifyRoutes stays consistent, but with the leading/trailing slashes stripped since
+ * Fastify's autoload `prefix` is later re-prefixed with a single slash.
+ */
+export function deriveRoutePrefix(appName: string, urlPath: string | undefined): string {
+	return resolveBaseURLPath(appName, urlPath).replace(/^\/+|\/+$/g, '');
+}

--- a/server/fastifyRoutes/helpers/getServerOptions.js
+++ b/server/fastifyRoutes/helpers/getServerOptions.js
@@ -21,8 +21,12 @@ function getServerOptions(isHttps) {
 		keepAliveTimeout: keep_alive_timeout,
 		return503OnClosing: false,
 		forceCloseConnections: true,
-		ignoreTrailingSlash: true,
-		maxParamLength: env.get(CONFIG_PARAMS.HTTP_MAXPARAMLENGTH) ?? 1000,
+		// Router options must be nested under `routerOptions` in Fastify v5; passing them as
+		// top-level options still works but emits the FSTDEP022 deprecation warning.
+		routerOptions: {
+			ignoreTrailingSlash: true,
+			maxParamLength: env.get(CONFIG_PARAMS.HTTP_MAXPARAMLENGTH) ?? 1000,
+		},
 		// http2: isHttps, // for now we are not enabling HTTP/2 since it seems to show slower performance
 		https: isHttps /* && {
 			allowHTTP1: true,

--- a/unitTests/apiTests/fastifyRoutes-test.mjs
+++ b/unitTests/apiTests/fastifyRoutes-test.mjs
@@ -1,0 +1,34 @@
+import { assert } from 'chai';
+import axios from 'axios';
+import { setupTestApp, baseUrl } from './setupTestApp.mjs';
+
+// Regression coverage for #1254: fastifyRoutes-registered HTTP routes returned 404 (registered but
+// never dispatched) on 5.1.0-beta.2. The testApp configures fastifyRoutes with `path: .`, so its
+// routes are namespaced under the app name (`/testApp`). This asserts the route actually dispatches.
+describe('fastifyRoutes dispatch', () => {
+	before(async function () {
+		this.timeout(100000);
+		await setupTestApp();
+	});
+
+	it('dispatches a fastifyRoutes GET route (200, not 404)', async () => {
+		const response = await axios({
+			url: `${baseUrl}/testApp/ping`,
+			method: 'GET',
+			responseType: 'text',
+		});
+		assert.equal(response.status, 200);
+		assert.equal(response.data, 'pong');
+	});
+
+	it('still serves REST resources on the same component', async () => {
+		const response = await axios({
+			url: `${baseUrl}/FourProp/0`,
+			method: 'GET',
+			responseType: 'json',
+			headers: { accept: 'application/json' },
+		});
+		assert.equal(response.status, 200);
+		assert.equal(response.data.id, '0');
+	});
+});

--- a/unitTests/server/fastifyRoutes/deriveRoutePrefix.test.js
+++ b/unitTests/server/fastifyRoutes/deriveRoutePrefix.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const assert = require('assert');
+const { deriveRoutePrefix } = require('#src/server/fastifyRoutes/helpers/deriveRoutePrefix');
+
+// Regression coverage for #1254: the route prefix must honor the component's `urlPath`/`path`
+// config rather than always namespacing under the app name. With no config, routes register at the
+// root (empty prefix); the prior code forced a `/<appName>` prefix, moving default-config routes
+// off the root and returning 404.
+describe('deriveRoutePrefix', () => {
+	it('returns an empty (root) prefix when no urlPath is configured (default config)', () => {
+		assert.strictEqual(deriveRoutePrefix('my-app', undefined), '');
+	});
+
+	it('namespaces under the app name for the relative `.` urlPath (path: .)', () => {
+		assert.strictEqual(deriveRoutePrefix('my-app', '.'), 'my-app');
+	});
+
+	it('uses an explicit urlPath as the prefix', () => {
+		assert.strictEqual(deriveRoutePrefix('my-app', 'custom'), 'custom');
+	});
+
+	it('namespaces a relative sub-path under the app name', () => {
+		assert.strictEqual(deriveRoutePrefix('my-app', './v1'), 'my-app/v1');
+	});
+});

--- a/unitTests/testApp/routes/simple-routes.js
+++ b/unitTests/testApp/routes/simple-routes.js
@@ -20,6 +20,15 @@ export default async (server, { hdbCore, logger }) => {
 			resp.code(302).header('Location', 'login.html');
 		}
 	};
+	// Unauthenticated route used to assert fastifyRoutes dispatch end-to-end (see #1254).
+	server.route({
+		url: '/ping',
+		method: 'GET',
+		handler: (request, reply) => {
+			reply.send('pong');
+		},
+	});
+
 	server.route({
 		url: '/',
 		method: 'GET',


### PR DESCRIPTION
## Summary
- Derive the fastifyRoutes autoload prefix from the component's `urlPath`/`path` config instead of always using `basename(scope.appName)`, restoring pre-5.1 routing (root by default, `/<appName>` for `path: .`, explicit `urlPath` otherwise).
- Nest `ignoreTrailingSlash`/`maxParamLength` under `routerOptions` in `getServerOptions.js` to clear the Fastify v5 `FSTDEP022` deprecation warning.

## Why
Fixes #1254. Commit 87df71547 forced the route prefix to `basename(scope.appName)`, so default-config apps that previously served routes at the root were silently moved under `/<appName>`. Requests to the original paths then fell through Fastify's not-found handler → **404**. REST resources on the same component were unaffected because they use a different dispatch path.

## Where to look
- `entry.urlPath` **cannot** be used to derive the prefix: the `EntryHandler` builds its `Component` with the **plugin** name (`fastifyRoutes`, `Scope.ts`) and the new plugin system does not map the deprecated `path` alias to `urlPath` (only the old `ComponentV1` did). So the fix reads the config directly off the scope and computes the prefix via `resolveBaseURLPath(basename(scope.appName), config.urlPath ?? config.path)` — `appName` may be an absolute path when loaded via `RUN_HDB_APP`, hence `basename()`.

## Open consideration (cross-model review — unresolved)
- A Codex review flagged a P2: a **runtime** edit of `fastifyRoutes.urlPath` won't re-prefix already-registered routes. `Scope` treats a `urlPath` change as an `EntryHandler` update (not a restart), and `routeFolders` is keyed by folder, so the rescan's `add` events are skipped and routes stay at the old prefix until a manual restart. This is an inherent Fastify live-reload limitation (the loader already warns a restart may be required for fastify routes), so I left it out of scope — flagging it for your call on whether a restart-on-prefix-change is worth adding.

## Testing
- Unit test for the prefix derivation: root (default), `.` (namespaced under app), explicit `urlPath`, and nested relative paths.
- e2e dispatch test asserting a `fastifyRoutes` route returns 200 (not 404), plus a check that REST resources on the same component still respond.
- Note: the e2e (apiTests) could not run in my local environment (boot properties point at a deleted temp dir, so all apiTests fail at module load) — relying on CI for that gate. Unit tests, build, lint, and format pass locally.

Generated by Claude (Opus 4.7).