### PR TITLE
Skip recovery-replay of put/patch entries whose record body failed to decode

### DIFF
--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -6,7 +6,7 @@ import { DatabaseTransaction } from './DatabaseTransaction.ts';
 import { RocksTransactionLogStore } from './RocksTransactionLogStore.ts';
 import { isMainThread } from 'node:worker_threads';
 import { RequestTarget } from './RequestTarget.ts';
-import { classifyAuditEntryForReplay } from './replayLogsGuards.ts';
+import { classifyAuditEntryForReplay, isUndecodableValidatedWrite } from './replayLogsGuards.ts';
 import { purgeAgedLogs } from './auditStore.ts';
 
 let warnedReplayHappening = false;
@@ -99,7 +99,10 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 					skipped++;
 					continue;
 				}
-				if (classifyAuditEntryForReplay(extendedType, tableId, record !== undefined) === 'missing-record') {
+				if (
+					classifyAuditEntryForReplay(extendedType, tableId, record !== undefined) === 'missing-record' ||
+					isUndecodableValidatedWrite(type, record)
+				) {
 					skipped++;
 					continue;
 				}

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -42,6 +42,25 @@ export function classifyAuditEntryForReplay(
 }
 
 /**
+ * Whether an audit entry is a validated write (`put`/`patch`) whose record body failed to
+ * decode, and so must be skipped during replay.
+ *
+ * `RecordEncoder.decode` returns `null` (not `undefined`, and it does not throw) when a value
+ * fails to decode — e.g. structure-dictionary divergence, which surfaces as msgpackr's
+ * "Data read, but end of buffer not reached". `classifyAuditEntryForReplay` only catches a
+ * `undefined` body, so a `null` slips through; for `put`/`patch` the replay path then calls
+ * `save()` → `validate()`, which dereferences the record and crashes on the missing body.
+ *
+ * This is deliberately scoped to `put`/`patch` (the only replay actions that run `validate()`).
+ * Other record-bearing actions must NOT be skipped on a `null` body — notably `invalidate`,
+ * which legitimately stores a `null` partial record on a table with no index fields and never
+ * reaches `validate()`. See harper#1255.
+ */
+export function isUndecodableValidatedWrite(type: string | undefined, record: unknown): boolean {
+	return record == null && (type === 'put' || type === 'patch');
+}
+
+/**
  * Wraps a transaction-log query iterator so a corrupt/torn frame ends that log's iteration
  * cleanly instead of escaping as an uncaughtException. rocksdb-js throws a bounded RangeError
  * when an entry's framing is broken; framing loss means the next entry can't be located, so the

--- a/unitTests/resources/replayLogs.test.js
+++ b/unitTests/resources/replayLogs.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert');
 // the full Resource/RocksDB module graph (which has a circular require chain).
 const {
 	classifyAuditEntryForReplay,
+	isUndecodableValidatedWrite,
 	RECORD_BEARING_FLAGS,
 	endIteratorOnCorruptFrame,
 } = require('#src/resources/replayLogsGuards');
@@ -61,6 +62,42 @@ describe('classifyAuditEntryForReplay', () => {
 		// Lock the mask: the audit writer in auditStore.ts uses these exact bit values.
 		// Silent drift here would re-introduce the crash.
 		assert.strictEqual(RECORD_BEARING_FLAGS, HAS_RECORD | HAS_PARTIAL_RECORD);
+	});
+});
+
+describe('isUndecodableValidatedWrite', () => {
+	// Regression for harper#1255: RecordEncoder.decode returns `null` (not `undefined`) on a
+	// failed value decode (e.g. structure-dictionary divergence), so classify() — which only
+	// catches `undefined` — lets it through. For put/patch the replay then calls save() ->
+	// validate(), which crashes on the null body ("Cannot read properties of undefined
+	// (reading 'id')"). This guard skips exactly those, and ONLY those.
+	it('skips put/patch whose body failed to decode (null or undefined)', () => {
+		assert.strictEqual(isUndecodableValidatedWrite('put', null), true);
+		assert.strictEqual(isUndecodableValidatedWrite('put', undefined), true);
+		assert.strictEqual(isUndecodableValidatedWrite('patch', null), true);
+		assert.strictEqual(isUndecodableValidatedWrite('patch', undefined), true);
+	});
+
+	it('does not skip put/patch with a decoded body, including falsy primitives', () => {
+		assert.strictEqual(isUndecodableValidatedWrite('put', { id: 1 }), false);
+		assert.strictEqual(isUndecodableValidatedWrite('patch', 0), false);
+		assert.strictEqual(isUndecodableValidatedWrite('put', ''), false);
+		assert.strictEqual(isUndecodableValidatedWrite('patch', false), false);
+	});
+
+	it('never skips invalidate on a null body — a no-index table stores a legitimate null partial record', () => {
+		// invalidate carries HAS_PARTIAL_RECORD but never reaches validate(); skipping it would
+		// leave the record un-invalidated/stale after recovery.
+		assert.strictEqual(isUndecodableValidatedWrite('invalidate', null), false);
+		assert.strictEqual(isUndecodableValidatedWrite('invalidate', undefined), false);
+	});
+
+	it('does not skip other record-bearing / non-validated actions on a null body', () => {
+		// Only put/patch run validate(); message/relocate/delete must pass through untouched.
+		assert.strictEqual(isUndecodableValidatedWrite('message', null), false);
+		assert.strictEqual(isUndecodableValidatedWrite('relocate', null), false);
+		assert.strictEqual(isUndecodableValidatedWrite('delete', null), false);
+		assert.strictEqual(isUndecodableValidatedWrite(undefined, null), false);
 	});
 });
 


### PR DESCRIPTION
Closes #1255

## Summary
During unclean-shutdown recovery, `resources/replayLogs.ts` replays audit entries. `RecordEncoder.decode` returns **`null`** (not `undefined`, and it does not throw) when a value fails to decode — e.g. msgpackr typed-structure-dictionary divergence, which surfaces as `Data read, but end of buffer not reached`. The guard `classifyAuditEntryForReplay` only treats an `undefined` body as missing, so a `null` slips through; for `put`/`patch` the replay then calls `save()` → `validate()`, which dereferences the record and crashes (`Cannot read properties of undefined (reading 'id')`), aborting recovery.

This adds `isUndecodableValidatedWrite(type, record)` and ORs it into the existing skip condition.

## Why this scope (where to look)
The guard is **deliberately scoped to `put`/`patch`** — the only replay actions that run `validate()`. Other record-bearing actions must *not* be skipped on a `null` body: `invalidate` carries `HAS_PARTIAL_RECORD` but `_writeInvalidate` legitimately stores a `null` partial record on tables with no index fields (`partialRecord ??= null`) and never reaches `validate()`. Skipping those would leave records un-invalidated/stale after recovery. The reviewer-worthy judgment is this scoping decision — please sanity-check that `put`/`patch` are the only replay switch cases that reach `validate()` (via `save()`).

## Context
Confirmed in production on a 5.1.0-beta.2 Fabric cluster: the same structure-divergent audit records (present since well before the upgrade) crashed startup replay on the beta. The prior fix (#526cf44fd) guards `undefined` but not `null`; this closes that gap. Note the underlying *structure divergence* is a separate, pre-existing problem (tracked under the #1163 family) — this PR only prevents the replay crash, it does not heal divergent records.

## Tests
Added `isUndecodableValidatedWrite` unit tests (put/patch null/undefined → skip; decoded/falsy bodies → keep; invalidate/message/relocate null → keep). `unitTests/resources/replayLogs.test.js` passes (15 tests). Full `test:unit:main`/`test:integration:all` rely on CI (worktree lacks the storage-path env).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: Claude Opus 4.7). Reviewed pre-PR by Codex (caught the invalidate scoping).