### PR TITLE
fix(table): complete the @table metadata re-apply (continuation of #1247)

### DIFF
--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1175,8 +1175,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 				// a stale `false` (from a v4-era write or replicated event) survives every reload: the
 				// in-memory re-assert in the existing-Table branch only fixes the worker that ran @table,
 				// but other workers' next disk-load re-reads the stale value.
-				const schemaDefinedMismatch =
-					schemaDefinedExplicit && attributeDescriptor.schemaDefined !== schemaDefined;
+				const schemaDefinedMismatch = schemaDefinedExplicit && attributeDescriptor.schemaDefined !== schemaDefined;
 				// primary key can't change indexing, but settings can change
 				if (
 					schemaDefinedMismatch ||

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1171,8 +1171,15 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 			let attributeDescriptor = attributesDbi.getSync(dbiKey);
 			if (attribute.isPrimaryKey) {
 				attributeDescriptor = attributeDescriptor || attributesDbi.getSync((dbiKey = tableName + '/')) || {};
+				// Persist schemaDefined when the explicit live value disagrees with disk. Without this,
+				// a stale `false` (from a v4-era write or replicated event) survives every reload: the
+				// in-memory re-assert in the existing-Table branch only fixes the worker that ran @table,
+				// but other workers' next disk-load re-reads the stale value.
+				const schemaDefinedMismatch =
+					schemaDefinedExplicit && attributeDescriptor.schemaDefined !== schemaDefined;
 				// primary key can't change indexing, but settings can change
 				if (
+					schemaDefinedMismatch ||
 					(audit !== undefined && audit !== Table.audit) ||
 					(sealed !== undefined && sealed !== Table.sealed) ||
 					(replicate !== undefined && replicate !== Table.replicate) ||
@@ -1190,6 +1197,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 					if (sealed !== undefined) updatedPrimaryAttribute.sealed = sealed;
 					if (replicate !== undefined) updatedPrimaryAttribute.replicate = replicate;
 					if (attribute.type) updatedPrimaryAttribute.type = attribute.type;
+					if (schemaDefinedMismatch) updatedPrimaryAttribute.schemaDefined = schemaDefined;
 					hasChanges = true; // send out notification of the change
 					exclusiveLock();
 					attributesDbi.put(dbiKey, updatedPrimaryAttribute);

--- a/resources/graphql.ts
+++ b/resources/graphql.ts
@@ -109,6 +109,9 @@ async function processGraphQLSchema(gqlContent, urlPath, filePath, resources) {
 						for (const arg of directive.arguments) {
 							typeDef[arg.name.value] = coerceDirectiveValue(arg.value);
 						}
+						// @table is the canonical schema-defined declaration; pass the flag explicitly so
+						// the existing-Table re-assert in databases.ts::table() fires on every reload.
+						typeDef.schemaDefined = true;
 						if (typeDef.schema) typeDef.database = typeDef.schema;
 						if (!typeDef.table) typeDef.table = typeName;
 						if (typeDef.audit) typeDef.audit = typeDef.audit !== 'false';


### PR DESCRIPTION
## Summary

Continuation of #1247. After deploying #1247 to a staging cluster, two gaps surfaced that meant `schema_defined: false` was still sticky for upgraded GraphQL `@table` tables. This PR closes both.

Verified on `us-lax-1.v4-to-v5.akamai.stage` (in-place v5.0.27 to 5.1.0-beta.2 upgrade): with this PR's compiled output deployed on top of #1247, `describe_all` returns `schema_defined: true` for upgraded `@table`-declared tables after a restart.

## What #1247 alone missed

1. The gate added per Kris's review (`if (schemaDefinedExplicit) Table.schemaDefined = schemaDefined`) only fires when the caller of `table()` explicitly passes `schemaDefined`. The GraphQL parser does not — `typeDef.schemaDefined` stayed undefined, the gate never fired, the stale `false` from disk persisted.
2. The re-assert is in-memory only, scoped to the worker that runs the GraphQL parser. Other workers (specifically main/0 serving `describe_all`) still read the stale value from disk on their own boot.

## Fix

Two small changes:

- `resources/graphql.ts`: set `typeDef.schemaDefined = true` in the `@table` directive handler. `@table` is the canonical schema-defined declaration, so the flag is explicitly true and the gate from #1247 fires.
- `resources/databases.ts`: when `schemaDefinedExplicit && attributeDescriptor.schemaDefined !== schemaDefined`, persist the corrected value to the attribute descriptor and signal the change. Other workers' next disk-load picks it up. Same shape as the existing `needsSchemaDefinedBackfill` path, just triggered on explicit mismatch in addition to disk-undefined.

## Test

`integrationTests/apiTests/describe-metadata-upgrade.test.ts` (added in #1247) already asserts `schema_defined: true` survives a reboot on a pinned data dir with `THREADS_COUNT=2`. Both phases pass on this branch. Without the two changes here, phase 2 fails because the operations-API worker reads the stale disk value.

## History note

This branch was previously opened, closed without merging during the cluster verification cycle, and is now re-opened with the cluster-verification result attached. The fix is currently deployed via a hot-patched dist bundle on the staging cluster.

🤖 Drafted by Claude (Opus 4.7)