### PR TITLE
Also skip recovery-replay of message entries whose record body failed to decode

### DIFF
--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -42,22 +42,24 @@ export function classifyAuditEntryForReplay(
 }
 
 /**
- * Whether an audit entry is a validated write (`put`/`patch`) whose record body failed to
- * decode, and so must be skipped during replay.
+ * Whether an audit entry runs `validate()` during replay but its record body failed to decode,
+ * and so must be skipped.
  *
  * `RecordEncoder.decode` returns `null` (not `undefined`, and it does not throw) when a value
  * fails to decode — e.g. structure-dictionary divergence, which surfaces as msgpackr's
  * "Data read, but end of buffer not reached". `classifyAuditEntryForReplay` only catches a
- * `undefined` body, so a `null` slips through; for `put`/`patch` the replay path then calls
- * `save()` → `validate()`, which dereferences the record and crashes on the missing body.
+ * `undefined` body, so a `null` slips through; the replay path then calls `validate()`, which
+ * dereferences the record and crashes on the missing body.
  *
- * This is deliberately scoped to `put`/`patch` (the only replay actions that run `validate()`).
- * Other record-bearing actions must NOT be skipped on a `null` body — notably `invalidate`,
- * which legitimately stores a `null` partial record on a table with no index fields and never
- * reaches `validate()`. See harper#1255.
+ * Scoped to the actions whose replay reaches `validate()`: `put`/`patch` (via `_writeUpdate` →
+ * `save()`) and `message` (via `_writePublish` → `transaction.addWrite` → `save()`; the publish
+ * `validate` hook fires whenever the replay context has no `source`, which it never does). Other
+ * record-bearing actions must NOT be skipped on a `null` body — notably `invalidate`, which
+ * legitimately stores a `null` partial record on a table with no index fields and never reaches
+ * `validate()`; `relocate`/`delete` ignore the body entirely. See harper#1255.
  */
 export function isUndecodableValidatedWrite(type: string | undefined, record: unknown): boolean {
-	return record == null && (type === 'put' || type === 'patch');
+	return record == null && (type === 'put' || type === 'patch' || type === 'message');
 }
 
 /**

--- a/unitTests/resources/replayLogs.test.js
+++ b/unitTests/resources/replayLogs.test.js
@@ -68,21 +68,25 @@ describe('classifyAuditEntryForReplay', () => {
 describe('isUndecodableValidatedWrite', () => {
 	// Regression for harper#1255: RecordEncoder.decode returns `null` (not `undefined`) on a
 	// failed value decode (e.g. structure-dictionary divergence), so classify() — which only
-	// catches `undefined` — lets it through. For put/patch the replay then calls save() ->
-	// validate(), which crashes on the null body ("Cannot read properties of undefined
-	// (reading 'id')"). This guard skips exactly those, and ONLY those.
-	it('skips put/patch whose body failed to decode (null or undefined)', () => {
+	// catches `undefined` — lets it through. The replay then calls validate() on the null body
+	// and crashes ("Cannot read properties of undefined (reading 'id')"). This guard skips the
+	// actions whose replay reaches validate(): put/patch (via _writeUpdate) and message (via
+	// _writePublish -> addWrite -> save) — and ONLY those.
+	it('skips put/patch/message whose body failed to decode (null or undefined)', () => {
 		assert.strictEqual(isUndecodableValidatedWrite('put', null), true);
 		assert.strictEqual(isUndecodableValidatedWrite('put', undefined), true);
 		assert.strictEqual(isUndecodableValidatedWrite('patch', null), true);
 		assert.strictEqual(isUndecodableValidatedWrite('patch', undefined), true);
+		assert.strictEqual(isUndecodableValidatedWrite('message', null), true);
+		assert.strictEqual(isUndecodableValidatedWrite('message', undefined), true);
 	});
 
-	it('does not skip put/patch with a decoded body, including falsy primitives', () => {
+	it('does not skip put/patch/message with a decoded body, including falsy primitives', () => {
 		assert.strictEqual(isUndecodableValidatedWrite('put', { id: 1 }), false);
 		assert.strictEqual(isUndecodableValidatedWrite('patch', 0), false);
 		assert.strictEqual(isUndecodableValidatedWrite('put', ''), false);
 		assert.strictEqual(isUndecodableValidatedWrite('patch', false), false);
+		assert.strictEqual(isUndecodableValidatedWrite('message', 0), false);
 	});
 
 	it('never skips invalidate on a null body — a no-index table stores a legitimate null partial record', () => {
@@ -92,9 +96,8 @@ describe('isUndecodableValidatedWrite', () => {
 		assert.strictEqual(isUndecodableValidatedWrite('invalidate', undefined), false);
 	});
 
-	it('does not skip other record-bearing / non-validated actions on a null body', () => {
-		// Only put/patch run validate(); message/relocate/delete must pass through untouched.
-		assert.strictEqual(isUndecodableValidatedWrite('message', null), false);
+	it('does not skip non-validated actions on a null body', () => {
+		// relocate/delete ignore the body and never call validate(), so they pass through untouched.
 		assert.strictEqual(isUndecodableValidatedWrite('relocate', null), false);
 		assert.strictEqual(isUndecodableValidatedWrite('delete', null), false);
 		assert.strictEqual(isUndecodableValidatedWrite(undefined, null), false);


### PR DESCRIPTION
Follow-up to #1257. Refs #1255.

## Summary
#1257 scoped the undecodable-record skip to `put`/`patch`, on the assumption those are the only replay actions that reach `validate()`. A cross-model review (Gemini) caught that **`message` also reaches `validate()` during replay**, so a `message` whose body decoded to `null` still crashes recovery.

This adds `message` to `isUndecodableValidatedWrite`.

## Why message reaches validate() (verified)
- `_writePublish` (`resources/Table.ts`) registers a `validate` hook that calls `this.validate(message)`, guarded by `if (!context.source)` — and the recovery-replay context has no `source`, so the hook fires.
- `_writePublish` ends in `transaction.addWrite(write)`, and `addWrite` → `save()` (`resources/DatabaseTransaction.ts`) synchronously invokes `operation.validate()`.
- So `validate(null)` runs for an undecodable `message` body and throws `Cannot read properties of undefined`, aborting startup replay.

`_writeUpdate` (put/patch) and `_writePublish` (message) are the only replay write paths that call `this.validate()`. `invalidate` (legitimate `null` partial record on no-index tables), `relocate`, and `delete` do not — they remain un-skipped.

## Where to look
Confirm the validate-reaching replay set is exactly {put, patch, message}: grep `this.validate(` in `resources/Table.ts` (only `_writeUpdate` and `_writePublish`).

## Note
This is an incomplete-fix gap in #1257, not a regression — `message`+null crashed before #1257 too. Real-world impact: any 5.1 cluster replaying structure-divergent `message` audit entries during recovery.

## Tests
Updated `isUndecodableValidatedWrite` unit tests: put/patch/message + null/undefined → skip; decoded/falsy bodies → keep; invalidate/relocate/delete null → keep. `unitTests/resources/replayLogs.test.js` passes (15 tests). Full suites rely on CI (worktree lacks storage-path env).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: Claude Opus 4.7). Pre-PR cross-model review: Codex + Gemini (Gemini caught the message gap that prompted this follow-up).