### PR TITLE
fix(encoder): cap maxOwnStructures at 32 to avoid two-byte over-cap corruption

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -119,10 +119,19 @@ export class RecordEncoder extends StructonEncoder {
 	name: string;
 	constructor(options) {
 		options.useBigIntExtension = true;
-		// Bound the per-encoder typed-structure dictionary. It is append-only and pinned on the
-		// long-lived primary store, so a wide/sparse schema (whose records vary by per-field value
-		// width) can grow it unbounded and exhaust memory. Caller-overridable; default caps it.
-		options.maxOwnStructures ??= 256;
+		// Bound the per-encoder structure dictionary. It is append-only and pinned on the long-lived
+		// primary store, so a wide/sparse schema (whose records vary by per-field value width) can grow
+		// it unbounded and exhaust memory. Caller-overridable; default caps it.
+		//
+		// Must stay <= 32: with msgpackr's default maxSharedStructures (32), maxOwnStructures + 32 > 64
+		// flips on the two-byte record-id encoding, which mis-serializes over-cap "own" structures when a
+		// shared-structures store is present (the primary store always has one). The mis-read consumes
+		// an extra byte as a phantom high byte of the record id, leaving the structure decoder offset by
+		// one and surfacing as "Data read, but end of buffer not reached <N>" or "Record id is not
+		// defined for N" — observed in v4 to v5 migration on records with custom-type embedded fields
+		// (harper#1260). The one-byte path (<= 32) inlines over-cap shapes correctly and bounds memory
+		// at least as tightly.
+		options.maxOwnStructures ??= 32;
 		/**
 		 * The base class for records that provides the read-only methods for accessing
 		 * metadata and will be assigned computed property getters. On its own, these instances


### PR DESCRIPTION
## Summary

Caps `RecordEncoder`'s default `maxOwnStructures` at 32. Combined with msgpackr's default `maxSharedStructures` of 32, this keeps the encoder on the one-byte record-id path. The two-byte path (triggered when `maxOwnStructures + maxSharedStructures > 64`) mis-serializes over-cap "own" structures in the structon-backed typed path, producing records that fail to decode on subsequent reads with `Error: Data read, but end of buffer not reached <N>`.

Fixes #1260. Observed in v4-to-v5 migration where the migration process's in-memory state masks the on-disk corruption until a restart re-reads the records cold, then crashes `initStores` and the node won't boot.

## Trade-off

Moderate-cardinality tables get less compact shared-structure encoding. Memory is bounded at least as tightly. Caller-overridable.

## Why not just bump structon

The structon-side fix for the typed two-byte path does not exist yet (no released version, no merged PR, no filed issue). Once it lands, the cap can be raised back to 256 in a one-line revert. The Harper-side cap is the only protection in flight for customers upgrading from v4 with custom-type embedded fields.

The companion msgpackr 2.0.4 bump (`7dbab67dd`) addresses the classic two-byte path on the msgpackr side; the structon typed path is still vulnerable, which is why this cap is needed independently.

## Test

`unitTests/resources/recordEncoder.test.js` (9 cases) passes against the cap. Verification on staging: nl-ams-1 re-migrated against this build survives a subsequent restart without crashing `initStores`.