### PR TITLE
fix(ci): keep YCSB nightly working tree clean before benchmark auto-push

### DIFF
--- a/.github/workflows/ycsb-nightly.yml
+++ b/.github/workflows/ycsb-nightly.yml
@@ -55,6 +55,13 @@ jobs:
       - name: Verify build output
         run: test -f dist/bin/harper.js || { echo "dist/bin/harper.js missing — build failed"; exit 1; }
 
+      # `npm install` above can rewrite package-lock.json (e.g. when it lags a version
+      # bump in package.json), dirtying the working tree. The auto-push benchmark steps
+      # below `git checkout gh-pages`, which aborts on a dirty tree. Discard the lockfile
+      # churn so the checkout succeeds.
+      - name: Restore lockfile churn
+        run: git checkout -- package-lock.json
+
       - name: Run YCSB load test
         # Pass dispatch inputs via env, not direct ${{ }} interpolation into the shell,
         # so a free-form input value can't inject shell commands on the runner.


### PR DESCRIPTION
## Summary

The "YCSB Nightly Load Test" workflow has been failing on `main` since 2026-06-11 (06-10 passed → 06-11/06-12 failed). The failing job is "YCSB single-node (Node.js v24)".

**Root cause:** the `Install dependencies` step runs `npm install --ignore-scripts`, which rewrites `package-lock.json` and leaves the working tree dirty. Later, the two `github-action-benchmark` steps ("Track throughput trend" / "Track latency (p99) trend") run with `auto-push: ${{ github.ref == 'refs/heads/main' }}`. On `main` that action does `git checkout gh-pages` to push trend history, and git aborts:

```
package-lock.json
Please commit your changes or stash them before you switch branches.
Aborting
Error: The process '/usr/bin/git' failed with exit code 1
```

It only fails on `main` (where `auto-push` is true), which is why branch dispatches were unaffected.

## Why the lockfile churns (separate latent issue)

I reproduced this locally: on a clean checkout of `main`, `npm install --ignore-scripts` dirties `package-lock.json` (3 ins / 4 del). The committed lockfile is **stale** — the `chore: bump version to 5.1.0-beta.3` commit bumped `package.json` (`version` 5.1.0-beta.2 → -beta.3, plus an `engines` change) but did not regenerate `package-lock.json`, so the lockfile still records `5.1.0-beta.2` and the old `engines` block. `npm install` reconciles it on every run.

## Fix chosen

Approach: add a `Restore lockfile churn` step (`git checkout -- package-lock.json`) after `Verify build output` and before the first trend step.

I considered switching to `npm ci`, but since the committed lockfile is genuinely out of sync with `package.json`, `npm ci` would fail hard. The `git checkout` approach is robust regardless of lockfile staleness, so it's the right minimal fix here. The stale lockfile is worth fixing separately (regenerate + commit `package-lock.json`), but that's out of scope for unblocking the nightly.

Single-line workflow change; security comment about not interpolating dispatch inputs is untouched.

_Generated by Claude (Opus 4.7)._