### PR TITLE
chore: regenerate stale package-lock.json (5.1.0-beta.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "harper",
-	"version": "5.1.0-beta.2",
+	"version": "5.1.0-beta.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "harper",
-			"version": "5.1.0-beta.2",
+			"version": "5.1.0-beta.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/client-s3": "^3.1012.0",
@@ -130,8 +130,7 @@
 				"why-is-node-still-running": "^1.0.0"
 			},
 			"engines": {
-				"minimum-node": "20.0.0",
-				"node": ">=20"
+				"node": "^22.18.0 || >=24.0.0"
 			},
 			"optionalDependencies": {
 				"bufferutil": "^4.0.9",


### PR DESCRIPTION
The `package-lock.json` drifted from `package.json` after the 5.1.0-beta.3 version/engines bump commit (`6532d760e`) — that commit updated `package.json` but didn't regenerate the lockfile, leaving it recording `5.1.0-beta.2` and the old `engines` minimums.

Practically: on a clean checkout `npm install` rewrites the lockfile (which was breaking the YCSB nightly auto-push step — see #1263), and `npm ci` would fail outright.

This PR runs `npm install --package-lock-only --ignore-scripts` to resync. The diff is minimal: version bumped in two places (`5.1.0-beta.2` → `5.1.0-beta.3`) and the `engines.node` field updated to match the current `package.json`. No dependency versions changed.

_Generated by Claude Sonnet 4.6_