### PR TITLE
fix(migration): persist __dbis__ structures to RocksDB CF on LMDB→RocksDB upgrade

### DIFF
--- a/bin/copyDb.ts
+++ b/bin/copyDb.ts
@@ -396,7 +396,7 @@ export async function copyDbToRocks(sourceRootStore, sourceDatabase: string, tar
 	});
 
 	const STRUCTURES_KEY = Symbol.for('structures');
-	const copyStructures = (sourceDbi, storeName: string, extraTarget?: any) => {
+	const copyStructures = (sourceDbi, storeName: string, extraTarget?: RocksDatabase) => {
 		const buffer = sourceDbi.getBinary?.(STRUCTURES_KEY);
 		if (buffer) {
 			const binaryBuffer = asBinary(buffer);

--- a/bin/copyDb.ts
+++ b/bin/copyDb.ts
@@ -381,20 +381,33 @@ export async function copyDbToRocks(sourceRootStore, sourceDatabase: string, tar
 	const sourceDbisDb = sourceRootStore.dbisDb;
 
 	const targetRootStore = openRocksDb(targetPath, { disableWAL: false });
+	// sharedStructuresKey wires the rocksdb-js getStructures/saveStructures closures
+	// so that the plain msgpackr.Encoder used here persists structures within the
+	// __dbis__ CF at Symbol.for('structures'). The runtime attributesDbi RecordEncoder
+	// takes the non-isRocksDB path (handleLocalTimeForGets is never called on it) and
+	// reads from the same CF key via superGetStructures. Without this, own structure
+	// IDs starting at 0x40 are minted in-memory and silently lost on restart →
+	// runtime decoder interprets 0x40 as fixint 64 → "Data read, but end of buffer
+	// not reached 64" (harper#1260).
 	const targetDbisDb = openRocksDb(targetPath, {
 		disableWAL: false,
 		name: INTERNAL_DBIS_NAME,
+		sharedStructuresKey: Symbol.for('structures'),
 	});
 
 	const STRUCTURES_KEY = Symbol.for('structures');
-	const copyStructures = (sourceDbi, storeName: string) => {
+	const copyStructures = (sourceDbi, storeName: string, extraTarget?: any) => {
 		const buffer = sourceDbi.getBinary?.(STRUCTURES_KEY);
 		if (buffer) {
-			targetRootStore.putSync([STRUCTURES_KEY, storeName], asBinary(buffer));
+			const binaryBuffer = asBinary(buffer);
+			targetRootStore.putSync([STRUCTURES_KEY, storeName], binaryBuffer);
+			// Also write to the extra target CF when provided (e.g. __dbis__ CF,
+			// which the runtime RecordEncoder reads via its superGetStructures path).
+			extraTarget?.putSync(STRUCTURES_KEY, binaryBuffer);
 		}
 	};
 
-	copyStructures(sourceDbisDb, INTERNAL_DBIS_NAME);
+	copyStructures(sourceDbisDb, INTERNAL_DBIS_NAME, targetDbisDb);
 
 	let written;
 	let outstandingWrites = 0;

--- a/integrationTests/upgrade/4.x-upgrade.test.ts
+++ b/integrationTests/upgrade/4.x-upgrade.test.ts
@@ -252,5 +252,42 @@ suite(
 				widgetsCF.close();
 			}
 		});
+
+		// Regression test for harper#1260: before the fix, the __dbis__ CF encoder
+		// minted own structure IDs (starting at 0x40) that were never persisted on
+		// restart → initStores crash-looped with "Data read, but end of buffer not
+		// reached 64". Verify that a cold restart after migration decodes all records.
+		test('cold restart after LMDB→RocksDB migration reads tables and records', async () => {
+			await startHarper(ctx, { config: {}, env: {} });
+
+			const testTableResponse = await sendOperation(ctx.harper, {
+				operation: 'search_by_conditions',
+				table: 'test',
+				conditions: [{ attribute: 'id', comparator: 'greater_than', value: 'id-4' }],
+			});
+			ok(testTableResponse.length > 4, 'test table must have records after cold restart post-migration');
+
+			for (const expected of widgets) {
+				const rows = await sendOperation(ctx.harper, {
+					operation: 'search_by_conditions',
+					table: 'widgets',
+					conditions: [{ attribute: 'id', comparator: 'equals', value: expected.id }],
+				});
+				ok(rows.length === 1, `expected exactly 1 row for ${expected.id} after cold restart, got ${rows.length}`);
+				const actual = rows[0];
+				deepStrictEqual(
+					{
+						id: actual.id,
+						name: actual.name,
+						category: actual.category,
+						price: actual.price,
+						inStock: actual.inStock,
+						tags: actual.tags,
+					},
+					expected,
+					`record ${expected.id} did not survive cold restart post-migration`
+				);
+			}
+		});
 	}
 );


### PR DESCRIPTION
## Summary

- Opens `targetDbisDb` (the `__dbis__` CF) with `sharedStructuresKey: Symbol.for('structures')` so the rocksdb-js `saveStructures` hook is wired up during migration
- Extends `copyStructures` with an optional `extraTarget` parameter and passes `targetDbisDb` when copying `__dbis__` structures, so they land in both the legacy root-store composite key and directly inside the CF
- Adds a regression test: cold restart after LMDB→RocksDB migration must successfully decode all records in both `test` and `widgets` tables

## Purpose

Fixes #1260. After an LMDB→RocksDB migration, a cold restart crash-looped with:

```
Data read, but end of buffer not reached 64
```

Root cause: `targetDbisDb` was opened without `sharedStructuresKey`, so the msgpackr.Encoder had no `saveStructures` hook. Own structure IDs (starting at `0x40` when `maxSharedStructures=0`) were minted in-memory during migration and silently discarded on process exit. On cold restart, the runtime `RecordEncoder`'s `superGetStructures` path reads from the `__dbis__` CF at `Symbol.for('structures')` and finds nothing, so msgpackr falls back to returning the raw token (`0x40 = 64`) as a fixint — the literal number `64` is what appears in the error string.

## Areas for attention

- The pre-existing `targetDbisDb.put()` call a few lines below the change (~line 418) is unawaited — this was flagged by Gemini but predates this diff and is not introduced by it. Worth a separate look.
- The `extraTarget?.putSync(STRUCTURES_KEY, binaryBuffer)` call is synchronous while the surrounding `copyStructures` function makes no async guarantees either way — consistent with the existing `targetRootStore.putSync` call.

_Generated by claude-sonnet-4-6_