### PR TITLE
chore: bump @harperfast/integration-testing to ^0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
 			},
 			"devDependencies": {
 				"@harperdb/code-guidelines": "^0.0.6",
-				"@harperfast/integration-testing": "^0.3.1",
+				"@harperfast/integration-testing": "^0.5.1",
 				"@modelcontextprotocol/sdk": "^1.29.0",
 				"@types/busboy": "^1.5.4",
 				"@types/fs-extra": "^11.0.4",
@@ -2897,9 +2897,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@harperfast/integration-testing": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/integration-testing/-/integration-testing-0.3.1.tgz",
-			"integrity": "sha512-hW7XsSTRWv38pK0nY4GZhGmmWAeQg/2eSSHAdwOO+niL7QORLExGjKCYxySylpKbWRdORQ7JjG5RMkFH+LQc9g==",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/integration-testing/-/integration-testing-0.5.1.tgz",
+			"integrity": "sha512-hHkDf9mgxdKFPqnlc1Dtz9je9WafUWGIofyzgfpmPWECxWqEo4NIa5CesJANtdKHSVsUtSiEt0E05y6+ZsBtPw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
 	},
 	"devDependencies": {
 		"@harperdb/code-guidelines": "^0.0.6",
-		"@harperfast/integration-testing": "^0.3.1",
+		"@harperfast/integration-testing": "^0.5.1",
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"@types/busboy": "^1.5.4",
 		"@types/fs-extra": "^11.0.4",


### PR DESCRIPTION
Bumps the `@harperfast/integration-testing` harness to **0.5.1** — the upstream fix for the Integration Tests flakiness tracked in #1139 (startup-readiness + teardown/loopback-recycle races, HarperFast/integration-testing#8).

The jump from 0.3.x crosses two behavioral changes to watch in CI:
- loopback pool now starts at `127.0.0.2` (was `127.0.0.1`)
- `startupTimeoutMs` / `…_STARTUP_TIMEOUT_MS` now means the idle / no-output window, not an absolute deadline — this repo's `120000/180000` overrides remain valid (now the idle window)

Follow-up: those `STARTUP_TIMEOUT_MS` overrides in `integration-tests.yml` can be revisited now (#1139).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
