### PR TITLE
fix(replay): bound skip-dominated boot replay so it can't grind forever (#1266)

### DIFF
--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -59,10 +59,10 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 		// is reset to 0 the moment a write succeeds, so the stall bound only fires on a genuinely
 		// write-free run.
 		let noProgressRun = 0;
-		let lastProgressTime = Date.now();
+		let lastProgressTime = performance.now();
 		const txnLog: RocksTransactionLogStore = (rootStore as any).auditStore;
 		for (const auditRecord of txnLog.getRange({ startFromLastFlushed: true, readUncommitted: true }) as any) {
-			if (noProgressRun > 0 && shouldAbortStalledReplay(noProgressRun, Date.now() - lastProgressTime)) {
+			if (noProgressRun > 0 && shouldAbortStalledReplay(noProgressRun, performance.now() - lastProgressTime)) {
 				logger.fatal(
 					`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: ${noProgressRun} consecutive audit entries with no successful write (${skipped} skipped as unrecoverable, ${writes} replayed so far). This backlog is making no forward progress and was blocking startup (harper#1266) — typically a peer transaction log whose values reference unresolvable shared structures (harper#1163), or a backlog for a dropped table. Continuing boot without replaying the remainder; shed or relocate the oversized/undecodable peer transaction log(s), or re-clone this node, to recover the unreplayed data.`
 				);
@@ -210,8 +210,12 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 				// trackers. Doing this AFTER the switch (not before) means a slow or throwing
 				// write is neither counted as progress nor charged to the stall bound (harper#1266).
 				noProgressRun = 0;
-				lastProgressTime = Date.now();
+				lastProgressTime = performance.now();
 			} catch (err) {
+				// A write that threw made no forward progress either — count it toward the stall
+				// bound so a continuous stream of throwing writes can't grind the boot thread
+				// indefinitely (and the per-entry error log below can't spam unboundedly). harper#1266
+				noProgressRun++;
 				logger.error(`Error writing from replay of log`, err, {
 					version,
 				});

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -53,17 +53,18 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 		let lastTimestamp = 0;
 		let writes = 0;
 		let skipped = 0;
-		// Track forward progress so a skip-dominated backlog can't grind the boot thread forever
-		// (harper#1266). `skipped` only counts undecodable/corrupt entries, so the delta since the
-		// last write is the length of the current no-progress run; a successful write resets both.
-		let skippedAtLastProgress = 0;
+		// Track forward progress so a backlog of unwritable entries can't grind the boot thread
+		// forever (harper#1266). `noProgressRun` counts every entry processed without a successful
+		// write since the last one — undecodable/corrupt skips AND entries for a dropped table — and
+		// is reset to 0 the moment a write succeeds, so the stall bound only fires on a genuinely
+		// write-free run.
+		let noProgressRun = 0;
 		let lastProgressTime = Date.now();
 		const txnLog: RocksTransactionLogStore = (rootStore as any).auditStore;
 		for (const auditRecord of txnLog.getRange({ startFromLastFlushed: true, readUncommitted: true }) as any) {
-			const skipsSinceProgress = skipped - skippedAtLastProgress;
-			if (skipsSinceProgress > 0 && shouldAbortStalledReplay(skipsSinceProgress, Date.now() - lastProgressTime)) {
+			if (noProgressRun > 0 && shouldAbortStalledReplay(noProgressRun, Date.now() - lastProgressTime)) {
 				logger.fatal(
-					`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: ${skipsSinceProgress} consecutive audit entries skipped with no successful write (${writes} replayed, ${skipped} skipped so far). This backlog is making no forward progress and was blocking startup (harper#1266) — typically a peer transaction log whose values reference unresolvable shared structures (harper#1163). Continuing boot without replaying the remainder; shed or relocate the oversized/undecodable peer transaction log(s), or re-clone this node, to recover the unreplayed data.`
+					`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: ${noProgressRun} consecutive audit entries with no successful write (${skipped} skipped as unrecoverable, ${writes} replayed so far). This backlog is making no forward progress and was blocking startup (harper#1266) — typically a peer transaction log whose values reference unresolvable shared structures (harper#1163), or a backlog for a dropped table. Continuing boot without replaying the remainder; shed or relocate the oversized/undecodable peer transaction log(s), or re-clone this node, to recover the unreplayed data.`
 				);
 				break;
 			}
@@ -82,17 +83,17 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 			try {
 				if (classifyAuditEntryForReplay(extendedType, tableId, true) === 'corrupt-header') {
 					skipped++;
+					noProgressRun++;
 					continue;
 				}
 				const Table = tableById.get(tableId);
-				if (!Table) continue;
-				const context: Context = {
-					nodeId,
-					alreadyLogged: true,
-					version,
-					expiresAt,
-					user: { username },
-				} as any;
+				if (!Table) {
+					// Entry for a table this node no longer has (dropped/foreign). Not an
+					// unrecoverable skip, but still a no-progress entry — a large backlog of them
+					// must trip the stall bound rather than grind the boot thread.
+					noProgressRun++;
+					continue;
+				}
 				const { primaryStore } = Table as any;
 				let record: any;
 				try {
@@ -104,6 +105,7 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 					// (millions of these were observed in prod). The total skip count is logged
 					// once at the end of replay.
 					skipped++;
+					noProgressRun++;
 					continue;
 				}
 				if (
@@ -111,10 +113,18 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 					isUndecodableValidatedWrite(type, record)
 				) {
 					skipped++;
+					noProgressRun++;
 					continue;
 				}
-				// Entry is replayable: instantiate the resource only now, so the skip paths above
-				// never pay a Resource instantiation per skipped entry (harper#1266).
+				// Entry is replayable: build the context and instantiate the resource only now, so
+				// the skip paths above never pay those per-entry allocations (harper#1266).
+				const context: Context = {
+					nodeId,
+					alreadyLogged: true,
+					version,
+					expiresAt,
+					user: { username },
+				} as any;
 				const target = new RequestTarget();
 				target.id = null;
 				const tableInstance: any = Table.getResource(target, context, {});
@@ -141,10 +151,6 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 				context.transaction = transaction;
 				const options = { context, residencyId, nodeId, originatingOperation };
 				writes++;
-				// Forward progress: reset the no-progress trackers so the stall bound only ever
-				// fires on an uninterrupted run of skips (harper#1266).
-				skippedAtLastProgress = skipped;
-				lastProgressTime = Date.now();
 				switch (type) {
 					case 'put':
 						tableInstance._writeUpdate(recordId, record, true, options);
@@ -200,6 +206,11 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 						primaryStore.decoder.structure = updatedStructures;
 					}
 				}
+				// Forward progress: a write was staged successfully, so reset the no-progress
+				// trackers. Doing this AFTER the switch (not before) means a slow or throwing
+				// write is neither counted as progress nor charged to the stall bound (harper#1266).
+				noProgressRun = 0;
+				lastProgressTime = Date.now();
 			} catch (err) {
 				logger.error(`Error writing from replay of log`, err, {
 					version,

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -6,7 +6,11 @@ import { DatabaseTransaction } from './DatabaseTransaction.ts';
 import { RocksTransactionLogStore } from './RocksTransactionLogStore.ts';
 import { isMainThread } from 'node:worker_threads';
 import { RequestTarget } from './RequestTarget.ts';
-import { classifyAuditEntryForReplay, isUndecodableValidatedWrite } from './replayLogsGuards.ts';
+import {
+	classifyAuditEntryForReplay,
+	isUndecodableValidatedWrite,
+	shouldAbortStalledReplay,
+} from './replayLogsGuards.ts';
 import { purgeAgedLogs } from './auditStore.ts';
 
 let warnedReplayHappening = false;
@@ -49,8 +53,20 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 		let lastTimestamp = 0;
 		let writes = 0;
 		let skipped = 0;
+		// Track forward progress so a skip-dominated backlog can't grind the boot thread forever
+		// (harper#1266). `skipped` only counts undecodable/corrupt entries, so the delta since the
+		// last write is the length of the current no-progress run; a successful write resets both.
+		let skippedAtLastProgress = 0;
+		let lastProgressTime = Date.now();
 		const txnLog: RocksTransactionLogStore = (rootStore as any).auditStore;
 		for (const auditRecord of txnLog.getRange({ startFromLastFlushed: true, readUncommitted: true }) as any) {
+			const skipsSinceProgress = skipped - skippedAtLastProgress;
+			if (skipsSinceProgress > 0 && shouldAbortStalledReplay(skipsSinceProgress, Date.now() - lastProgressTime)) {
+				logger.fatal(
+					`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: ${skipsSinceProgress} consecutive audit entries skipped with no successful write (${writes} replayed, ${skipped} skipped so far). This backlog is making no forward progress and was blocking startup (harper#1266) — typically a peer transaction log whose values reference unresolvable shared structures (harper#1163). Continuing boot without replaying the remainder; shed or relocate the oversized/undecodable peer transaction log(s), or re-clone this node, to recover the unreplayed data.`
+				);
+				break;
+			}
 			const {
 				type,
 				tableId,
@@ -78,15 +94,6 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 					user: { username },
 				} as any;
 				const { primaryStore } = Table as any;
-				const target = new RequestTarget();
-				target.id = null;
-				const tableInstance: any = Table.getResource(target, context, {});
-				// TODO: If this throws an error due to being unable to access structures, we need to iterate through
-				// other transaction logs to get the latest structure. Ultimately we may have to skip records
-				if (!warnedReplayHappening) {
-					warnedReplayHappening = true;
-					console.warn('Harper was not properly shutdown, replaying transaction logs to synchronize database');
-				}
 				let record: any;
 				try {
 					record = auditRecord.getValue(primaryStore);
@@ -106,6 +113,17 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 					skipped++;
 					continue;
 				}
+				// Entry is replayable: instantiate the resource only now, so the skip paths above
+				// never pay a Resource instantiation per skipped entry (harper#1266).
+				const target = new RequestTarget();
+				target.id = null;
+				const tableInstance: any = Table.getResource(target, context, {});
+				// TODO: If this throws an error due to being unable to access structures, we need to iterate through
+				// other transaction logs to get the latest structure. Ultimately we may have to skip records
+				if (!warnedReplayHappening) {
+					warnedReplayHappening = true;
+					console.warn('Harper was not properly shutdown, replaying transaction logs to synchronize database');
+				}
 				if (lastTimestamp !== version) {
 					lastTimestamp = version;
 					try {
@@ -123,6 +141,10 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 				context.transaction = transaction;
 				const options = { context, residencyId, nodeId, originatingOperation };
 				writes++;
+				// Forward progress: reset the no-progress trackers so the stall bound only ever
+				// fires on an uninterrupted run of skips (harper#1266).
+				skippedAtLastProgress = skipped;
+				lastProgressTime = Date.now();
 				switch (type) {
 					case 'put':
 						tableInstance._writeUpdate(recordId, record, true, options);

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -60,6 +60,44 @@ export function isUndecodableValidatedWrite(type: string | undefined, record: un
 	return record == null && (type === 'put' || type === 'patch');
 }
 
+// A node that crashed unclean replays its unflushed audit backlog on boot. When that backlog is
+// dominated by undecodable entries (e.g. the #1163 structure-dictionary divergence, whose values
+// decode to nothing and are skipped), every iteration produces a skip with no write. A large
+// enough backlog then grinds the main thread for minutes with zero forward progress, blocking
+// startup entirely (harper#1266). These bounds let replay give up on a run that is making no
+// progress so boot can proceed; the operator then sheds/relocates the offending peer log (or
+// re-clones). They are deliberately conservative: a healthy replay produces writes, which reset
+// the progress tracking, so neither bound can trip on it.
+
+// Max consecutive entries skipped since the last successful write before the replay is treated as
+// stalled. ~100k contiguous undecodable entries is unambiguously degenerate and caps the wasted
+// grind well below the multi-minute hangs observed in prod.
+export const REPLAY_NO_PROGRESS_SKIP_LIMIT = 100_000;
+
+// Max wall-clock time (ms) spent skipping since the last successful write before the replay is
+// treated as stalled. Belt-and-suspenders for the count bound: if individual entries are slow
+// enough that fewer than the skip limit still burns minutes, this still bounds the hang.
+export const REPLAY_NO_PROGRESS_TIME_LIMIT_MS = 60_000;
+
+/**
+ * Whether boot replay should abort because it is making no forward progress — a backlog of
+ * undecodable/corrupt entries that produces skips but no writes (harper#1266). Returns `true` once
+ * the contiguous run of skips since the last successful write crosses either the count or the time
+ * bound. Both inputs are measured since the last write, so a productive replay (which keeps
+ * resetting them) never trips this; only a genuinely stalled, write-free grind does.
+ *
+ * @param skipsSinceLastWrite  entries skipped since the last successful write
+ * @param msSinceLastWrite     wall-clock ms elapsed since the last successful write
+ */
+export function shouldAbortStalledReplay(
+	skipsSinceLastWrite: number,
+	msSinceLastWrite: number,
+	skipLimit = REPLAY_NO_PROGRESS_SKIP_LIMIT,
+	timeLimitMs = REPLAY_NO_PROGRESS_TIME_LIMIT_MS
+): boolean {
+	return skipsSinceLastWrite >= skipLimit || msSinceLastWrite >= timeLimitMs;
+}
+
 /**
  * Wraps a transaction-log query iterator so a corrupt/torn frame ends that log's iteration
  * cleanly instead of escaping as an uncaughtException. rocksdb-js throws a bounded RangeError

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -72,7 +72,7 @@ export function isUndecodableValidatedWrite(type: string | undefined, record: un
 // Max consecutive no-progress entries (since the last successful write) before the replay is
 // treated as stalled. ~100k contiguous unwritable entries is unambiguously degenerate and caps the
 // wasted grind well below the multi-minute hangs observed in prod.
-export const REPLAY_NO_PROGRESS_SKIP_LIMIT = 100_000;
+export const REPLAY_NO_PROGRESS_COUNT_LIMIT = 100_000;
 
 // Max wall-clock time (ms) since the last successful write before the replay is treated as stalled.
 // Belt-and-suspenders for the count bound: if individual entries are slow enough that fewer than the
@@ -99,11 +99,11 @@ export const REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR = 1_000;
 export function shouldAbortStalledReplay(
 	noProgressRun: number,
 	msSinceProgress: number,
-	skipLimit = REPLAY_NO_PROGRESS_SKIP_LIMIT,
+	countLimit = REPLAY_NO_PROGRESS_COUNT_LIMIT,
 	timeLimitMs = REPLAY_NO_PROGRESS_TIME_LIMIT_MS,
 	timeSkipFloor = REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR
 ): boolean {
-	if (noProgressRun >= skipLimit) return true;
+	if (noProgressRun >= countLimit) return true;
 	return noProgressRun >= timeSkipFloor && msSinceProgress >= timeLimitMs;
 }
 

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -61,41 +61,50 @@ export function isUndecodableValidatedWrite(type: string | undefined, record: un
 }
 
 // A node that crashed unclean replays its unflushed audit backlog on boot. When that backlog is
-// dominated by undecodable entries (e.g. the #1163 structure-dictionary divergence, whose values
-// decode to nothing and are skipped), every iteration produces a skip with no write. A large
-// enough backlog then grinds the main thread for minutes with zero forward progress, blocking
-// startup entirely (harper#1266). These bounds let replay give up on a run that is making no
-// progress so boot can proceed; the operator then sheds/relocates the offending peer log (or
+// dominated by entries that can't be written — undecodable values (the #1163 structure-dictionary
+// divergence), corrupt headers, or entries for a dropped table — every iteration makes no forward
+// progress. A large enough backlog then grinds the main thread for minutes with zero progress,
+// blocking startup entirely (harper#1266). These bounds let replay give up on a run that is making
+// no progress so boot can proceed; the operator then sheds/relocates the offending peer log (or
 // re-clones). They are deliberately conservative: a healthy replay produces writes, which reset
 // the progress tracking, so neither bound can trip on it.
 
-// Max consecutive entries skipped since the last successful write before the replay is treated as
-// stalled. ~100k contiguous undecodable entries is unambiguously degenerate and caps the wasted
-// grind well below the multi-minute hangs observed in prod.
+// Max consecutive no-progress entries (since the last successful write) before the replay is
+// treated as stalled. ~100k contiguous unwritable entries is unambiguously degenerate and caps the
+// wasted grind well below the multi-minute hangs observed in prod.
 export const REPLAY_NO_PROGRESS_SKIP_LIMIT = 100_000;
 
-// Max wall-clock time (ms) spent skipping since the last successful write before the replay is
-// treated as stalled. Belt-and-suspenders for the count bound: if individual entries are slow
-// enough that fewer than the skip limit still burns minutes, this still bounds the hang.
+// Max wall-clock time (ms) since the last successful write before the replay is treated as stalled.
+// Belt-and-suspenders for the count bound: if individual entries are slow enough that fewer than the
+// count limit still burns minutes, this still bounds the hang.
 export const REPLAY_NO_PROGRESS_TIME_LIMIT_MS = 60_000;
+
+// The time bound only applies once a substantial no-progress run has built up. Without this floor a
+// single skipped entry followed by an unrelated latency spike (a GC pause, disk throttling, one
+// slow write) would trip the time bound and abort an otherwise-healthy replay; requiring a real run
+// of no-progress entries keeps the time bound a signal of a genuine grind, not a transient stall.
+export const REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR = 1_000;
 
 /**
  * Whether boot replay should abort because it is making no forward progress — a backlog of
- * undecodable/corrupt entries that produces skips but no writes (harper#1266). Returns `true` once
- * the contiguous run of skips since the last successful write crosses either the count or the time
- * bound. Both inputs are measured since the last write, so a productive replay (which keeps
- * resetting them) never trips this; only a genuinely stalled, write-free grind does.
+ * unwritable entries (undecodable/corrupt, or for a dropped table) that produces no writes
+ * (harper#1266). Returns `true` once the contiguous run of no-progress entries since the last
+ * successful write crosses the count bound, or once it has both built up past the time-skip floor
+ * AND burned the time bound. All inputs are measured since the last write, so a productive replay
+ * (which keeps resetting them) never trips this; only a genuinely stalled, write-free grind does.
  *
- * @param skipsSinceLastWrite  entries skipped since the last successful write
- * @param msSinceLastWrite     wall-clock ms elapsed since the last successful write
+ * @param noProgressRun   consecutive entries processed without a successful write
+ * @param msSinceProgress wall-clock ms elapsed since the last successful write
  */
 export function shouldAbortStalledReplay(
-	skipsSinceLastWrite: number,
-	msSinceLastWrite: number,
+	noProgressRun: number,
+	msSinceProgress: number,
 	skipLimit = REPLAY_NO_PROGRESS_SKIP_LIMIT,
-	timeLimitMs = REPLAY_NO_PROGRESS_TIME_LIMIT_MS
+	timeLimitMs = REPLAY_NO_PROGRESS_TIME_LIMIT_MS,
+	timeSkipFloor = REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR
 ): boolean {
-	return skipsSinceLastWrite >= skipLimit || msSinceLastWrite >= timeLimitMs;
+	if (noProgressRun >= skipLimit) return true;
+	return noProgressRun >= timeSkipFloor && msSinceProgress >= timeLimitMs;
 }
 
 /**

--- a/unitTests/resources/replayLogs.test.js
+++ b/unitTests/resources/replayLogs.test.js
@@ -7,6 +7,9 @@ const {
 	isUndecodableValidatedWrite,
 	RECORD_BEARING_FLAGS,
 	endIteratorOnCorruptFrame,
+	shouldAbortStalledReplay,
+	REPLAY_NO_PROGRESS_SKIP_LIMIT,
+	REPLAY_NO_PROGRESS_TIME_LIMIT_MS,
 } = require('#src/resources/replayLogsGuards');
 
 // Regression tests for the unclean-shutdown replay guards. Without these, an audit log
@@ -203,5 +206,41 @@ describe('endIteratorOnCorruptFrame', () => {
 			() => endIteratorOnCorruptFrame({ next: source.next }, () => {}).throw(boom),
 			(error) => error === boom
 		);
+	});
+});
+
+// Regression tests for HarperFast/harper#1266: a boot replay over a skip-dominated backlog
+// (undecodable peer-log entries) must give up once it is making no forward progress, instead of
+// grinding the main thread for minutes. A healthy replay (which keeps producing writes that reset
+// the no-progress counters) must never trip the bound.
+describe('shouldAbortStalledReplay', () => {
+	it('exposes conservative default bounds', () => {
+		assert.strictEqual(REPLAY_NO_PROGRESS_SKIP_LIMIT, 100_000);
+		assert.strictEqual(REPLAY_NO_PROGRESS_TIME_LIMIT_MS, 60_000);
+	});
+
+	it('does not abort while the no-progress run is below both bounds', () => {
+		assert.strictEqual(shouldAbortStalledReplay(0, 0), false);
+		assert.strictEqual(shouldAbortStalledReplay(1, 0), false);
+		assert.strictEqual(shouldAbortStalledReplay(REPLAY_NO_PROGRESS_SKIP_LIMIT - 1, 0), false);
+		assert.strictEqual(shouldAbortStalledReplay(50_000, REPLAY_NO_PROGRESS_TIME_LIMIT_MS - 1), false);
+	});
+
+	it('aborts once the skip count reaches the limit', () => {
+		assert.strictEqual(shouldAbortStalledReplay(REPLAY_NO_PROGRESS_SKIP_LIMIT, 0), true);
+		assert.strictEqual(shouldAbortStalledReplay(REPLAY_NO_PROGRESS_SKIP_LIMIT + 1, 0), true);
+	});
+
+	it('aborts once the elapsed no-progress time reaches the limit, even with few skips', () => {
+		// Belt-and-suspenders: slow per-entry decodes can burn minutes below the count bound.
+		assert.strictEqual(shouldAbortStalledReplay(1, REPLAY_NO_PROGRESS_TIME_LIMIT_MS), true);
+		assert.strictEqual(shouldAbortStalledReplay(10, REPLAY_NO_PROGRESS_TIME_LIMIT_MS + 1), true);
+	});
+
+	it('honors caller-supplied bounds (used to keep unit tests fast/deterministic)', () => {
+		assert.strictEqual(shouldAbortStalledReplay(3, 0, 5, 1000), false);
+		assert.strictEqual(shouldAbortStalledReplay(5, 0, 5, 1000), true);
+		assert.strictEqual(shouldAbortStalledReplay(0, 1000, 5, 1000), true);
+		assert.strictEqual(shouldAbortStalledReplay(0, 999, 5, 1000), false);
 	});
 });

--- a/unitTests/resources/replayLogs.test.js
+++ b/unitTests/resources/replayLogs.test.js
@@ -8,7 +8,7 @@ const {
 	RECORD_BEARING_FLAGS,
 	endIteratorOnCorruptFrame,
 	shouldAbortStalledReplay,
-	REPLAY_NO_PROGRESS_SKIP_LIMIT,
+	REPLAY_NO_PROGRESS_COUNT_LIMIT,
 	REPLAY_NO_PROGRESS_TIME_LIMIT_MS,
 	REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR,
 } = require('#src/resources/replayLogsGuards');
@@ -217,7 +217,7 @@ describe('endIteratorOnCorruptFrame', () => {
 // a single skip followed by an unrelated latency spike.
 describe('shouldAbortStalledReplay', () => {
 	it('exposes conservative default bounds', () => {
-		assert.strictEqual(REPLAY_NO_PROGRESS_SKIP_LIMIT, 100_000);
+		assert.strictEqual(REPLAY_NO_PROGRESS_COUNT_LIMIT, 100_000);
 		assert.strictEqual(REPLAY_NO_PROGRESS_TIME_LIMIT_MS, 60_000);
 		assert.strictEqual(REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR, 1_000);
 	});
@@ -225,13 +225,13 @@ describe('shouldAbortStalledReplay', () => {
 	it('does not abort while the no-progress run is below both bounds', () => {
 		assert.strictEqual(shouldAbortStalledReplay(0, 0), false);
 		assert.strictEqual(shouldAbortStalledReplay(1, 0), false);
-		assert.strictEqual(shouldAbortStalledReplay(REPLAY_NO_PROGRESS_SKIP_LIMIT - 1, 0), false);
+		assert.strictEqual(shouldAbortStalledReplay(REPLAY_NO_PROGRESS_COUNT_LIMIT - 1, 0), false);
 		assert.strictEqual(shouldAbortStalledReplay(50_000, REPLAY_NO_PROGRESS_TIME_LIMIT_MS - 1), false);
 	});
 
 	it('aborts once the no-progress count reaches the limit', () => {
-		assert.strictEqual(shouldAbortStalledReplay(REPLAY_NO_PROGRESS_SKIP_LIMIT, 0), true);
-		assert.strictEqual(shouldAbortStalledReplay(REPLAY_NO_PROGRESS_SKIP_LIMIT + 1, 0), true);
+		assert.strictEqual(shouldAbortStalledReplay(REPLAY_NO_PROGRESS_COUNT_LIMIT, 0), true);
+		assert.strictEqual(shouldAbortStalledReplay(REPLAY_NO_PROGRESS_COUNT_LIMIT + 1, 0), true);
 	});
 
 	it('does NOT trip the time bound on a tiny no-progress run (a single skip + a latency spike)', () => {
@@ -258,7 +258,7 @@ describe('shouldAbortStalledReplay', () => {
 	});
 
 	it('honors caller-supplied bounds (used to keep unit tests fast/deterministic)', () => {
-		// signature: (noProgressRun, msSinceProgress, skipLimit, timeLimitMs, timeSkipFloor)
+		// signature: (noProgressRun, msSinceProgress, countLimit, timeLimitMs, timeSkipFloor)
 		assert.strictEqual(shouldAbortStalledReplay(3, 0, 5, 1000, 2), false);
 		assert.strictEqual(shouldAbortStalledReplay(5, 0, 5, 1000, 2), true);
 		assert.strictEqual(shouldAbortStalledReplay(2, 1000, 5, 1000, 2), true);

--- a/unitTests/resources/replayLogs.test.js
+++ b/unitTests/resources/replayLogs.test.js
@@ -10,6 +10,7 @@ const {
 	shouldAbortStalledReplay,
 	REPLAY_NO_PROGRESS_SKIP_LIMIT,
 	REPLAY_NO_PROGRESS_TIME_LIMIT_MS,
+	REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR,
 } = require('#src/resources/replayLogsGuards');
 
 // Regression tests for the unclean-shutdown replay guards. Without these, an audit log
@@ -209,14 +210,16 @@ describe('endIteratorOnCorruptFrame', () => {
 	});
 });
 
-// Regression tests for HarperFast/harper#1266: a boot replay over a skip-dominated backlog
-// (undecodable peer-log entries) must give up once it is making no forward progress, instead of
-// grinding the main thread for minutes. A healthy replay (which keeps producing writes that reset
-// the no-progress counters) must never trip the bound.
+// Regression tests for HarperFast/harper#1266: a boot replay over a backlog of unwritable entries
+// (undecodable peer-log entries, or entries for a dropped table) must give up once it is making no
+// forward progress, instead of grinding the main thread for minutes. A healthy replay (which keeps
+// producing writes that reset the no-progress counters) must never trip the bound, and neither must
+// a single skip followed by an unrelated latency spike.
 describe('shouldAbortStalledReplay', () => {
 	it('exposes conservative default bounds', () => {
 		assert.strictEqual(REPLAY_NO_PROGRESS_SKIP_LIMIT, 100_000);
 		assert.strictEqual(REPLAY_NO_PROGRESS_TIME_LIMIT_MS, 60_000);
+		assert.strictEqual(REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR, 1_000);
 	});
 
 	it('does not abort while the no-progress run is below both bounds', () => {
@@ -226,21 +229,40 @@ describe('shouldAbortStalledReplay', () => {
 		assert.strictEqual(shouldAbortStalledReplay(50_000, REPLAY_NO_PROGRESS_TIME_LIMIT_MS - 1), false);
 	});
 
-	it('aborts once the skip count reaches the limit', () => {
+	it('aborts once the no-progress count reaches the limit', () => {
 		assert.strictEqual(shouldAbortStalledReplay(REPLAY_NO_PROGRESS_SKIP_LIMIT, 0), true);
 		assert.strictEqual(shouldAbortStalledReplay(REPLAY_NO_PROGRESS_SKIP_LIMIT + 1, 0), true);
 	});
 
-	it('aborts once the elapsed no-progress time reaches the limit, even with few skips', () => {
-		// Belt-and-suspenders: slow per-entry decodes can burn minutes below the count bound.
-		assert.strictEqual(shouldAbortStalledReplay(1, REPLAY_NO_PROGRESS_TIME_LIMIT_MS), true);
-		assert.strictEqual(shouldAbortStalledReplay(10, REPLAY_NO_PROGRESS_TIME_LIMIT_MS + 1), true);
+	it('does NOT trip the time bound on a tiny no-progress run (a single skip + a latency spike)', () => {
+		// harper#1266 review (Gemini): a lone skip followed by a GC/disk-throttle pause longer than
+		// the time limit must not abort an otherwise-healthy replay — the time bound requires a real
+		// run of no-progress entries first.
+		assert.strictEqual(shouldAbortStalledReplay(1, REPLAY_NO_PROGRESS_TIME_LIMIT_MS), false);
+		assert.strictEqual(
+			shouldAbortStalledReplay(REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR - 1, 10 * REPLAY_NO_PROGRESS_TIME_LIMIT_MS),
+			false
+		);
+	});
+
+	it('aborts once a substantial slow no-progress run crosses the time bound below the count limit', () => {
+		// Belt-and-suspenders: slow per-entry decodes can burn minutes well before the count bound.
+		assert.strictEqual(
+			shouldAbortStalledReplay(REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR, REPLAY_NO_PROGRESS_TIME_LIMIT_MS),
+			true
+		);
+		assert.strictEqual(
+			shouldAbortStalledReplay(REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR, REPLAY_NO_PROGRESS_TIME_LIMIT_MS - 1),
+			false
+		);
 	});
 
 	it('honors caller-supplied bounds (used to keep unit tests fast/deterministic)', () => {
-		assert.strictEqual(shouldAbortStalledReplay(3, 0, 5, 1000), false);
-		assert.strictEqual(shouldAbortStalledReplay(5, 0, 5, 1000), true);
-		assert.strictEqual(shouldAbortStalledReplay(0, 1000, 5, 1000), true);
-		assert.strictEqual(shouldAbortStalledReplay(0, 999, 5, 1000), false);
+		// signature: (noProgressRun, msSinceProgress, skipLimit, timeLimitMs, timeSkipFloor)
+		assert.strictEqual(shouldAbortStalledReplay(3, 0, 5, 1000, 2), false);
+		assert.strictEqual(shouldAbortStalledReplay(5, 0, 5, 1000, 2), true);
+		assert.strictEqual(shouldAbortStalledReplay(2, 1000, 5, 1000, 2), true);
+		assert.strictEqual(shouldAbortStalledReplay(1, 1000, 5, 1000, 2), false);
+		assert.strictEqual(shouldAbortStalledReplay(2, 999, 5, 1000, 2), false);
 	});
 });


### PR DESCRIPTION
## Summary

On boot after an unclean shutdown, `resources/replayLogs.ts` replays the database's unflushed audit/txn-log backlog. When that backlog is dominated by entries that can't be written — undecodable values (the #1163 shared-structure divergence family), corrupt headers, or entries for a dropped table — every loop iteration makes no forward progress. A large enough backlog (the live incident had a ~1.2 GB `system`-DB peer backlog) then grinds the main thread for minutes with zero progress, blocking startup before replication/subscriptions are ever reached.

This adds a **no-progress bound** to the replay loop: it aborts once the contiguous run of entries processed *without a successful write* crosses **100k** (`REPLAY_NO_PROGRESS_COUNT_LIMIT`), or once that run has both built past a **1k floor** (`REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR`) **and** burned **60s** (`REPLAY_NO_PROGRESS_TIME_LIMIT_MS`). On trip it logs a loud `logger.fatal` with actionable guidance (shed/relocate the offending peer log, or re-clone) and continues boot. A healthy replay produces writes that reset the trackers, so it can never trip the bound.

Secondary: the per-entry `context` and `Table.getResource(...)` are now built only *after* the skip checks pass, so skipped entries don't pay those allocations.

## Why

Fixes #1266. The node wedges in `system`-DB replay (confirmed on 5.0.30/31/32, eh-prod.gend `us-west-1`); two profiles placed the spin in the V8 JIT heap, not native rocksdb/lmdb/msgpackr — a pure-JS no-progress grind. This is independent of harper-pro#342 (the node never reaches subscriptions). The undecodable entries are the #1163 structure-divergence family; this PR is the graceful-degradation half — it bounds the grind so boot proceeds rather than hanging.

## Where to look / judgment calls for the reviewer

- **Data-loss tradeoff (the main thing to sign off on):** aborting mid-backlog means any *decodable* entries *after* the abort point are not replayed this boot. This is deliberate and accepted — the pathology is millions of contiguous unwritable entries, and recovery is shedding/re-cloning anyway — but it's a real behavior change worth a human eye. The abort is a `break`; the post-loop `directCommitSync()` still commits whatever progress was made.
- **No-progress accounting** — `resources/replayLogs.ts`: `noProgressRun` is incremented at all four no-progress sites (corrupt-header, `!Table`, decode-fail, missing/undecodable) and reset to `0` **only after the `switch` stages a write successfully** (not before it), so a slow or throwing write is neither counted as progress nor charged to the time bound.
- **`!Table` now counts toward the bound** — `tables` is the full table set for the DB (`databases[databaseName]`), so a `!Table` entry is a genuinely dropped/foreign table; a large backlog of them previously bypassed the detector entirely.
- **Time-bound floor** — without the 1k floor, a single skip followed by an unrelated 60s latency spike (GC/disk throttle) would false-abort a healthy replay.

## Cross-model review

Reviewed with Codex + Gemini (thorough mode). Both findings — reset-before-write mis-accounting (Codex) and single-skip + latency-spike false-abort on the time bound (Gemini) — are addressed in this PR; the `!Table` bypass and the context-allocation micro-opt (Gemini) are also addressed. One pre-existing observation left out of scope: `replayLogs` returns `undefined` rather than a `Promise` on its non-main-thread / lock-not-acquired early returns.

## Testing

Unit tests for `shouldAbortStalledReplay` (count trip, time-floor gating, no-trip below bounds, caller-supplied bounds) in `unitTests/resources/replayLogs.test.js` — 21 passing. Multi-node integration repro is blocked locally by a replication cert-signing handshake issue; CI is the gate.

_Generated with assistance from Claude (Opus 4.7); reviewed by Kris._