### PR TITLE
fix(replay): bound skip-dominated boot replay so it can't grind forever (#1266) [5.0 patch]

### DIFF
--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -6,7 +6,7 @@ import { DatabaseTransaction } from './DatabaseTransaction.ts';
 import { RocksTransactionLogStore } from './RocksTransactionLogStore.ts';
 import { isMainThread } from 'node:worker_threads';
 import { RequestTarget } from './RequestTarget.ts';
-import { classifyAuditEntryForReplay } from './replayLogsGuards.ts';
+import { classifyAuditEntryForReplay, shouldAbortStalledReplay } from './replayLogsGuards.ts';
 import { purgeAgedLogs } from './auditStore.ts';
 
 let warnedReplayHappening = false;
@@ -46,8 +46,21 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 		let lastTimestamp = 0;
 		let writes = 0;
 		let skipped = 0;
+		// Track forward progress so a backlog of unwritable entries can't grind the boot thread
+		// forever (harper#1266). `noProgressRun` counts every entry processed without a successful
+		// write since the last one — undecodable/corrupt skips AND entries for a dropped table — and
+		// is reset to 0 the moment a write succeeds, so the stall bound only fires on a genuinely
+		// write-free run.
+		let noProgressRun = 0;
+		let lastProgressTime = Date.now();
 		const txnLog: RocksTransactionLogStore = rootStore.auditStore;
 		for (const auditRecord of txnLog.getRange({ startFromLastFlushed: true, readUncommitted: true })) {
+			if (noProgressRun > 0 && shouldAbortStalledReplay(noProgressRun, Date.now() - lastProgressTime)) {
+				logger.fatal(
+					`Aborting transaction-log replay in ${rootStore.databaseName} database: ${noProgressRun} consecutive audit entries with no successful write (${skipped} skipped as unrecoverable, ${writes} replayed so far). This backlog is making no forward progress and was blocking startup (harper#1266) — typically a peer transaction log whose values reference unresolvable shared structures (harper#1163), or a backlog for a dropped table. Continuing boot without replaying the remainder; shed or relocate the oversized/undecodable peer transaction log(s), or re-clone this node, to recover the unreplayed data.`
+				);
+				break;
+			}
 			const {
 				type,
 				tableId,
@@ -63,10 +76,17 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 			try {
 				if (classifyAuditEntryForReplay(extendedType, tableId, true) === 'corrupt-header') {
 					skipped++;
+					noProgressRun++;
 					continue;
 				}
 				const Table = tableById.get(tableId);
-				if (!Table) continue;
+				if (!Table) {
+					// Entry for a table this node no longer has (dropped/foreign). Not an
+					// unrecoverable skip, but still a no-progress entry — a large backlog of them
+					// must trip the stall bound rather than grind the boot thread.
+					noProgressRun++;
+					continue;
+				}
 				const context: Context = { nodeId, alreadyLogged: true, version, expiresAt, user: { name: username } };
 				const { primaryStore } = Table;
 				const target = new RequestTarget();
@@ -88,10 +108,12 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 					// (millions of these were observed in prod). The total skip count is logged
 					// once at the end of replay.
 					skipped++;
+					noProgressRun++;
 					continue;
 				}
 				if (classifyAuditEntryForReplay(extendedType, tableId, record !== undefined) === 'missing-record') {
 					skipped++;
+					noProgressRun++;
 					continue;
 				}
 				if (lastTimestamp !== version) {
@@ -166,6 +188,11 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 						primaryStore.decoder.structure = updatedStructures;
 					}
 				}
+				// Forward progress: a write was staged successfully, so reset the no-progress
+				// trackers. Doing this AFTER the switch (not before) means a slow or throwing
+				// write is neither counted as progress nor charged to the stall bound (harper#1266).
+				noProgressRun = 0;
+				lastProgressTime = Date.now();
 			} catch (err) {
 				logger.error(`Error writing from replay of log`, err, {
 					version,

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -52,10 +52,10 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 		// is reset to 0 the moment a write succeeds, so the stall bound only fires on a genuinely
 		// write-free run.
 		let noProgressRun = 0;
-		let lastProgressTime = Date.now();
+		let lastProgressTime = performance.now();
 		const txnLog: RocksTransactionLogStore = rootStore.auditStore;
 		for (const auditRecord of txnLog.getRange({ startFromLastFlushed: true, readUncommitted: true })) {
-			if (noProgressRun > 0 && shouldAbortStalledReplay(noProgressRun, Date.now() - lastProgressTime)) {
+			if (noProgressRun > 0 && shouldAbortStalledReplay(noProgressRun, performance.now() - lastProgressTime)) {
 				logger.fatal(
 					`Aborting transaction-log replay in ${rootStore.databaseName} database: ${noProgressRun} consecutive audit entries with no successful write (${skipped} skipped as unrecoverable, ${writes} replayed so far). This backlog is making no forward progress and was blocking startup (harper#1266) — typically a peer transaction log whose values reference unresolvable shared structures (harper#1163), or a backlog for a dropped table. Continuing boot without replaying the remainder; shed or relocate the oversized/undecodable peer transaction log(s), or re-clone this node, to recover the unreplayed data.`
 				);
@@ -192,8 +192,12 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 				// trackers. Doing this AFTER the switch (not before) means a slow or throwing
 				// write is neither counted as progress nor charged to the stall bound (harper#1266).
 				noProgressRun = 0;
-				lastProgressTime = Date.now();
+				lastProgressTime = performance.now();
 			} catch (err) {
+				// A write that threw made no forward progress either — count it toward the stall
+				// bound so a continuous stream of throwing writes can't grind the boot thread
+				// indefinitely (and the per-entry error log below can't spam unboundedly). harper#1266
+				noProgressRun++;
 				logger.error(`Error writing from replay of log`, err, {
 					version,
 				});

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -40,3 +40,50 @@ export function classifyAuditEntryForReplay(
 	if ((action & RECORD_BEARING_FLAGS) !== 0 && !hasRecord) return 'missing-record';
 	return null;
 }
+
+// A node that crashed unclean replays its unflushed audit backlog on boot. When that backlog is
+// dominated by entries that can't be written — undecodable values (the #1163 structure-dictionary
+// divergence), corrupt headers, or entries for a dropped table — every iteration makes no forward
+// progress. A large enough backlog then grinds the main thread for minutes with zero progress,
+// blocking startup entirely (harper#1266). These bounds let replay give up on a run that is making
+// no progress so boot can proceed; the operator then sheds/relocates the offending peer log (or
+// re-clones). They are deliberately conservative: a healthy replay produces writes, which reset
+// the progress tracking, so neither bound can trip on it.
+
+// Max consecutive no-progress entries (since the last successful write) before the replay is
+// treated as stalled. ~100k contiguous unwritable entries is unambiguously degenerate and caps the
+// wasted grind well below the multi-minute hangs observed in prod.
+export const REPLAY_NO_PROGRESS_COUNT_LIMIT = 100_000;
+
+// Max wall-clock time (ms) since the last successful write before the replay is treated as stalled.
+// Belt-and-suspenders for the count bound: if individual entries are slow enough that fewer than the
+// count limit still burns minutes, this still bounds the hang.
+export const REPLAY_NO_PROGRESS_TIME_LIMIT_MS = 60_000;
+
+// The time bound only applies once a substantial no-progress run has built up. Without this floor a
+// single skipped entry followed by an unrelated latency spike (a GC pause, disk throttling, one
+// slow write) would trip the time bound and abort an otherwise-healthy replay; requiring a real run
+// of no-progress entries keeps the time bound a signal of a genuine grind, not a transient stall.
+export const REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR = 1_000;
+
+/**
+ * Whether boot replay should abort because it is making no forward progress — a backlog of
+ * unwritable entries (undecodable/corrupt, or for a dropped table) that produces no writes
+ * (harper#1266). Returns `true` once the contiguous run of no-progress entries since the last
+ * successful write crosses the count bound, or once it has both built up past the time-skip floor
+ * AND burned the time bound. All inputs are measured since the last write, so a productive replay
+ * (which keeps resetting them) never trips this; only a genuinely stalled, write-free grind does.
+ *
+ * @param noProgressRun   consecutive entries processed without a successful write
+ * @param msSinceProgress wall-clock ms elapsed since the last successful write
+ */
+export function shouldAbortStalledReplay(
+	noProgressRun: number,
+	msSinceProgress: number,
+	countLimit = REPLAY_NO_PROGRESS_COUNT_LIMIT,
+	timeLimitMs = REPLAY_NO_PROGRESS_TIME_LIMIT_MS,
+	timeSkipFloor = REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR
+): boolean {
+	if (noProgressRun >= countLimit) return true;
+	return noProgressRun >= timeSkipFloor && msSinceProgress >= timeLimitMs;
+}

--- a/unitTests/resources/replayLogs.test.js
+++ b/unitTests/resources/replayLogs.test.js
@@ -2,7 +2,14 @@ const assert = require('node:assert');
 
 // The helper lives in a dependency-free module so the test doesn't need to bootstrap
 // the full Resource/RocksDB module graph (which has a circular require chain).
-const { classifyAuditEntryForReplay, RECORD_BEARING_FLAGS } = require('#src/resources/replayLogsGuards');
+const {
+	classifyAuditEntryForReplay,
+	RECORD_BEARING_FLAGS,
+	shouldAbortStalledReplay,
+	REPLAY_NO_PROGRESS_COUNT_LIMIT,
+	REPLAY_NO_PROGRESS_TIME_LIMIT_MS,
+	REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR,
+} = require('#src/resources/replayLogsGuards');
 
 // Regression tests for the unclean-shutdown replay guards. Without these, an audit log
 // containing entries with corrupt MessagePack values caused replayLogs to write
@@ -57,5 +64,58 @@ describe('classifyAuditEntryForReplay', () => {
 		// Lock the mask: the audit writer in auditStore.ts uses these exact bit values.
 		// Silent drift here would re-introduce the crash.
 		assert.strictEqual(RECORD_BEARING_FLAGS, HAS_RECORD | HAS_PARTIAL_RECORD);
+	});
+});
+
+// Regression tests for HarperFast/harper#1266: a boot replay over a backlog of unwritable entries
+// (undecodable peer-log entries, or entries for a dropped table) must give up once it is making no
+// forward progress, instead of grinding the main thread for minutes. A healthy replay (which keeps
+// producing writes that reset the no-progress counters) must never trip the bound, and neither must
+// a single skip followed by an unrelated latency spike.
+describe('shouldAbortStalledReplay', () => {
+	it('exposes conservative default bounds', () => {
+		assert.strictEqual(REPLAY_NO_PROGRESS_COUNT_LIMIT, 100_000);
+		assert.strictEqual(REPLAY_NO_PROGRESS_TIME_LIMIT_MS, 60_000);
+		assert.strictEqual(REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR, 1_000);
+	});
+
+	it('does not abort while the no-progress run is below both bounds', () => {
+		assert.strictEqual(shouldAbortStalledReplay(0, 0), false);
+		assert.strictEqual(shouldAbortStalledReplay(1, 0), false);
+		assert.strictEqual(shouldAbortStalledReplay(REPLAY_NO_PROGRESS_COUNT_LIMIT - 1, 0), false);
+		assert.strictEqual(shouldAbortStalledReplay(50_000, REPLAY_NO_PROGRESS_TIME_LIMIT_MS - 1), false);
+	});
+
+	it('aborts once the no-progress count reaches the limit', () => {
+		assert.strictEqual(shouldAbortStalledReplay(REPLAY_NO_PROGRESS_COUNT_LIMIT, 0), true);
+		assert.strictEqual(shouldAbortStalledReplay(REPLAY_NO_PROGRESS_COUNT_LIMIT + 1, 0), true);
+	});
+
+	it('does NOT trip the time bound on a tiny no-progress run (a single skip + a latency spike)', () => {
+		assert.strictEqual(shouldAbortStalledReplay(1, REPLAY_NO_PROGRESS_TIME_LIMIT_MS), false);
+		assert.strictEqual(
+			shouldAbortStalledReplay(REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR - 1, 10 * REPLAY_NO_PROGRESS_TIME_LIMIT_MS),
+			false
+		);
+	});
+
+	it('aborts once a substantial slow no-progress run crosses the time bound below the count limit', () => {
+		assert.strictEqual(
+			shouldAbortStalledReplay(REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR, REPLAY_NO_PROGRESS_TIME_LIMIT_MS),
+			true
+		);
+		assert.strictEqual(
+			shouldAbortStalledReplay(REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR, REPLAY_NO_PROGRESS_TIME_LIMIT_MS - 1),
+			false
+		);
+	});
+
+	it('honors caller-supplied bounds (used to keep unit tests fast/deterministic)', () => {
+		// signature: (noProgressRun, msSinceProgress, countLimit, timeLimitMs, timeSkipFloor)
+		assert.strictEqual(shouldAbortStalledReplay(3, 0, 5, 1000, 2), false);
+		assert.strictEqual(shouldAbortStalledReplay(5, 0, 5, 1000, 2), true);
+		assert.strictEqual(shouldAbortStalledReplay(2, 1000, 5, 1000, 2), true);
+		assert.strictEqual(shouldAbortStalledReplay(1, 1000, 5, 1000, 2), false);
+		assert.strictEqual(shouldAbortStalledReplay(2, 999, 5, 1000, 2), false);
 	});
 });


### PR DESCRIPTION
**5.0 patch of #1266** — companion to the main-branch PR #1271. Targets `v5.0` directly because the main fix sits on top of helpers (`isUndecodableValidatedWrite`, #1257) that aren't on 5.0, so the `patch` label's auto-cherry-pick would conflict; this is the manually-adapted equivalent.

## Summary

On boot after an unclean shutdown, `resources/replayLogs.ts` replays the database's unflushed audit/txn-log backlog. When that backlog is dominated by entries that can't be written — undecodable values (the #1163 shared-structure divergence family), corrupt headers, or entries for a dropped table — every loop iteration makes no forward progress. A large enough backlog (the live incident had ~1.2 GB on the `system` DB) grinds the main thread for minutes with zero progress, blocking startup. Confirmed wedging on **5.0.30/31/32** (eh-prod.gend `us-west-1`); profiles placed the spin in the V8 JIT heap, i.e. a pure-JS no-progress loop.

This adds a **no-progress bound**: abort the replay once the contiguous run of entries processed *without a successful write* crosses **100k** (`REPLAY_NO_PROGRESS_COUNT_LIMIT`), or once that run has both built past a **1k floor** (`REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR`) **and** burned **60s** (`REPLAY_NO_PROGRESS_TIME_LIMIT_MS`). On trip it logs a loud `logger.fatal` with actionable guidance and continues boot. A healthy replay produces writes that reset the trackers, so it can never trip the bound.

## Where to look / judgment calls

- **Data-loss tradeoff (sign off on this):** aborting mid-backlog means decodable entries *after* the abort point aren't replayed this boot — deliberate, accepted; recovery is shedding/re-cloning, which the live box needs anyway. The abort is a `break`; the post-loop `directCommitSync()` still commits the progress made.
- **No-progress accounting:** `noProgressRun` increments at all four no-progress sites (corrupt-header, `!Table`, decode-fail, missing-record) and resets to `0` **only after the `switch` stages a write** (not before), so a slow/throwing write isn't mis-accounted.
- **Scope vs. main (#1271):** this patch is intentionally the hang-fix only. The main PR additionally moves per-entry `context`/`getResource` allocation off the skip path — omitted here to keep the patch minimal/low-risk for the release line.

## Differences from #1271 (why this isn't a clean cherry-pick)

5.0 lacks `isUndecodableValidatedWrite` (#1257) and the getResource reorder, so the surrounding loop differs. The stall-bound logic and the `shouldAbortStalledReplay` helper are identical to #1271 (same constants, same semantics).

## Testing

Unit tests for `shouldAbortStalledReplay` in `unitTests/resources/replayLogs.test.js` (12 passing). Reviewed cross-model (Codex + Gemini) on the main PR; both findings — reset-before-write and single-skip-plus-latency false-abort — are already incorporated here. Multi-node integration repro is blocked locally; CI is the gate.

_Generated with assistance from Claude (Opus 4.7); reviewed by Kris._