### PR TITLE
fix: stop in-place v4→v5 upgrade from planting node.hostname: localhost (#351)

### DIFF
--- a/server/nodeName.ts
+++ b/server/nodeName.ts
@@ -29,10 +29,16 @@ export function getThisNodeName(): string {
 	if (nodeName) return nodeName; // if already determined, just return
 	nodeName = env.get(CONFIG_PARAMS.NODE_HOSTNAME); // standard config
 	if (nodeName) {
-		if (env.get('replication_hostname') && env.get('replication_hostname') !== nodeName) {
-			// if these are both set, it can be very confusing, make sure to warn
+		const replicationHostname = env.get('replication_hostname');
+		if (replicationHostname && replicationHostname !== nodeName) {
+			// If these are both set and differ, the node identity is ambiguous. node.hostname
+			// wins (it is what this node identifies as), but if it doesn't match the name this
+			// node is registered under in hdb_nodes, replication for that name silently turns
+			// off (harper-pro#351). Do NOT blindly recommend cementing the already-picked
+			// node.hostname value — that's how a wrong identity (e.g. 'localhost') gets locked
+			// in. Steer the operator to reconcile against the registered node name instead.
 			logger.warn?.(
-				`The node.hostname and replication.hostname configuration values are both set and are different. It is recommended that you set the node.hostname, using node.hostname: ${nodeName})`
+				`The node.hostname (${nodeName}) and replication.hostname (${replicationHostname}) configuration values are both set and differ. This node will identify as "${nodeName}". Ensure that name matches this node's row in system.hdb_nodes; if it does not, set node.hostname (or remove it to fall back to replication.hostname) to match the registered node name, otherwise replication for this node will be disabled.`
 			);
 		}
 		return nodeName;

--- a/unitTests/install/installer.test.js
+++ b/unitTests/install/installer.test.js
@@ -553,4 +553,22 @@ describe('applyInstallModeDefaults', () => {
 		assert.equal(args.authentication_authorizeLocal, undefined);
 		assert.equal(args.http_cors, undefined);
 	});
+
+	// harper-pro#351: a dev install must NOT cement a concrete node.hostname (it used to default
+	// to 'localhost'). Persisting 'localhost' makes getThisNodeName() prefer it over
+	// replication.hostname, the node fails to find its own hdb_nodes self-row, and user-DB
+	// replication silently disables. The dev default must leave node.hostname unset (null) so the
+	// fallback chain (replication.hostname -> cert CN -> listening port) keeps the real identity.
+	it('does not cement a concrete node.hostname for a dev install (harper-pro#351)', () => {
+		const args = applyInstallModeDefaults({}, 'dev');
+		assert.notEqual(args.node_hostname, 'localhost');
+		// null is acceptable (matches defaultConfig.yaml node.hostname: null); a truthy concrete
+		// value is not.
+		assert.ok(args.node_hostname == null, `node_hostname should be unset/null, got ${args.node_hostname}`);
+	});
+
+	it('preserves an explicitly provided node.hostname for a dev install', () => {
+		const args = applyInstallModeDefaults({ node_hostname: 'real-node.example.com' }, 'dev');
+		assert.equal(args.node_hostname, 'real-node.example.com');
+	});
 });

--- a/unitTests/server/nodeName.test.js
+++ b/unitTests/server/nodeName.test.js
@@ -7,7 +7,76 @@ const assert = require('assert');
 const sinon = require('sinon');
 
 const env = require('#src/utility/environment/environmentManager');
-const { hostnameToUrl } = require('#src/server/nodeName');
+const { logger } = require('#src/utility/logging/logger');
+const { hostnameToUrl, getThisNodeName, clearThisNodeName } = require('#src/server/nodeName');
+
+describe('getThisNodeName precedence (harper-pro#351)', () => {
+	let sandbox;
+
+	beforeEach(() => {
+		sandbox = sinon.createSandbox();
+		clearThisNodeName();
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+		clearThisNodeName();
+	});
+
+	function stubEnv(values) {
+		const stub = sandbox.stub(env, 'get');
+		stub.callsFake((key) => values[key]);
+		return stub;
+	}
+
+	it('prefers node.hostname (NODE_HOSTNAME) over replication.hostname', () => {
+		stubEnv({ node_hostname: 'pinned-node', replication_hostname: 'real-node' });
+		assert.strictEqual(getThisNodeName(), 'pinned-node');
+	});
+
+	it('falls back to replication.hostname when node.hostname is unset', () => {
+		// This is the working chain harper-pro#351 protects: with node.hostname left unset
+		// (the fix stops the upgrade boot from planting 'localhost'), the node keeps its
+		// real identity from replication.hostname.
+		stubEnv({ node_hostname: undefined, replication_hostname: 'real-node' });
+		assert.strictEqual(getThisNodeName(), 'real-node');
+	});
+
+	it('warns (and does NOT recommend cementing the picked value) when both differ', () => {
+		// logger.warn is conditionally present based on log level; install a stub either way
+		// and restore the original after the test.
+		const originalWarn = logger.warn;
+		const warn = sandbox.stub();
+		logger.warn = warn;
+		try {
+			stubEnv({ node_hostname: 'localhost', replication_hostname: 'real-node' });
+			const name = getThisNodeName();
+			assert.strictEqual(name, 'localhost');
+		} finally {
+			logger.warn = originalWarn;
+		}
+		assert.ok(warn.called, 'expected a warning when the two hostnames differ');
+		const msg = warn.firstCall.args[0];
+		// Must not steer the operator to cement the already-picked (wrong) value, and must
+		// mention reconciling against hdb_nodes. Also guards against the stray trailing paren.
+		assert.ok(/hdb_nodes/.test(msg), 'warning should mention reconciling against hdb_nodes');
+		assert.ok(!/\)$/.test(msg), 'warning should not end with a stray trailing paren');
+		assert.ok(/real-node/.test(msg), 'warning should surface the differing replication.hostname');
+	});
+
+	it('does not warn when only one of the two hostnames is set', () => {
+		const originalWarn = logger.warn;
+		const warn = sandbox.stub();
+		logger.warn = warn;
+		try {
+			stubEnv({ node_hostname: 'pinned-node', replication_hostname: undefined });
+			assert.strictEqual(getThisNodeName(), 'pinned-node');
+		} finally {
+			logger.warn = originalWarn;
+		}
+		assert.ok(!warn.called, 'should not warn when replication.hostname is unset');
+	});
+});
 
 describe('hostnameToUrl', () => {
 	let sandbox;

--- a/utility/install/installer.ts
+++ b/utility/install/installer.ts
@@ -41,7 +41,13 @@ const ABORT_MSG = 'Aborting install';
 const PROCESS_HOME = os.homedir();
 const DEFAULT_HDB_ROOT = path.join(PROCESS_HOME, hdbTerms.HDB_ROOT_DIR_NAME);
 const DEFAULT_ADMIN_USERNAME = 'admin';
-const DEFAULT_NODE_HOSTNAME = 'localhost';
+// Intentionally null (not 'localhost'). Persisting a concrete node.hostname here cements a
+// wrong identity: getThisNodeName() prefers node.hostname over replication.hostname, so a
+// planted 'localhost' makes the node fail to find its own hdb_nodes self-row and silently
+// disable user-DB replication (harper-pro#351 — exposed by in-place v4->v5 upgrades, where
+// the install/migration boot would otherwise default this to 'localhost'). Leaving it unset
+// preserves the working fallback chain (replication.hostname -> cert CN -> listening port).
+const DEFAULT_NODE_HOSTNAME = null;
 const DEFAULT_CONFIG_MODE = 'dev';
 
 const DEV_MODE_CONFIG = {
@@ -270,10 +276,11 @@ async function installPrompts(promptOverride) {
 			name: hdbTerms.INSTALL_PROMPTS.NODE_HOSTNAME,
 			prefix: PROMPT_PREFIX,
 			default: DEFAULT_NODE_HOSTNAME,
-			validate: (value) => {
-				if (checkForEmptyValue(value)) return checkForEmptyValue(value);
-				return true;
-			},
+			// node.hostname is OPTIONAL — an unset value is valid and preferred when the operator
+			// hasn't got a stable name to pin (it falls back to replication.hostname / cert CN /
+			// listening port). Accept empty/unset rather than forcing a value, which is what used
+			// to cement 'localhost' (harper-pro#351).
+			validate: () => true,
 			message: HDB_PROMPT_MSG(INSTALL_PROMPTS.NODE_HOSTNAME),
 		},
 		{


### PR DESCRIPTION
## Summary

Core half of the fix for harper-pro#351 — a **silent split-brain** on self-managed in-place v4→v5 upgrades. Pairs with harper-pro PR (see below).

## Root cause

A fresh v4.7.33 install writes **no** `node:` section (only `replication.hostname`). The v5 install/upgrade boot was the planter: `utility/install/installer.ts` had `DEFAULT_NODE_HOSTNAME = 'localhost'`, feeding both the `NODE_HOSTNAME` install prompt default and `DEV_MODE_CONFIG`. When the existing guard didn't fire, `localhost` got persisted as a *set* value. `getThisNodeName()` (`server/nodeName.ts`) prefers `node.hostname` over `replication.hostname`, so the node identified as `localhost`, found no self-row in `hdb_nodes`, read its `replicates` as `undefined` → treated replication as off → silently unsubscribed from every peer for user databases. The node looked healthy (ops API fine, storage converted, sockets connected) but never received another replicated user-DB write.

Bench: 4-node 4.7.33→v5 rolling in-place, 25 w/s — without an identity pin, 61,830/61,830 writes acked with 0 client errors while the first two flipped nodes ended missing 56% / 44% of them.

## Changes

- **`utility/install/installer.ts`**: `DEFAULT_NODE_HOSTNAME` `'localhost'` → `null`; the `NODE_HOSTNAME` prompt `validate` now accepts empty/unset. Stops both the prompt default and dev-mode from cementing `localhost`; preserves the working fallback chain (`replication.hostname`).
- **`server/nodeName.ts`**: the both-set/differ warning no longer recommends cementing the picked value (which steered operators to cement `localhost`); it advises reconciling against the `hdb_nodes` name. Stray trailing paren removed.

**Fresh-install and Fabric-managed (env `NODE_HOSTNAME`) paths are unaffected** — env still wins; this only stops the upgrade boot from auto-planting `localhost`.

## Tests

Extended `unitTests/server/nodeName.test.js` (precedence + corrected warning, 8 pass) and `unitTests/install/installer.test.js` (dev install must not cement hostname, 5 pass). Config suite 176 pass; configValidator/nodeName/installer 59 pass.

End-to-end (harper-fabric-lab `incidents/inplace-upgrade-2026-06-11`, image overlaying this branch): full 4-node rolling in-place upgrade, **ledger parity exact on every node** (vs the documented 56%/44% loss), zero `Disabling replication` lines, each node kept its real identity.

🤖 Authored by Claude Opus 4.7 on Kris's behalf.