### PR TITLE
Register authentication middleware on the operations API port

### DIFF
--- a/integrationTests/apiTests/authentication.test.mjs
+++ b/integrationTests/apiTests/authentication.test.mjs
@@ -112,7 +112,12 @@ suite('Authentication', (ctx) => {
 		}
 	});
 
-	test('login operation establishes a session (Studio bootstrap path)', async () => {
+	// Skipped on Bun: the operations API on Bun is served by delegating to Fastify via
+	// inject() and auth is applied through fastifyAuth's Bun shim, which does not wire up
+	// `baseRequest.login` for the session-establishing `login` op — so this op is a known
+	// pre-existing gap on Bun (login never worked there), separate from the Node regression
+	// this test guards.
+	test('login operation establishes a session (Studio bootstrap path)', { skip: skipOnBun }, async () => {
 		// Studio calls the `login` operation to set up the admin user on a new cluster. This
 		// exercises auth's session middleware on the operations-API port; that middleware runs
 		// only on the main thread, so if it is not registered there the operation fails with

--- a/integrationTests/apiTests/authentication.test.mjs
+++ b/integrationTests/apiTests/authentication.test.mjs
@@ -112,6 +112,27 @@ suite('Authentication', (ctx) => {
 		}
 	});
 
+	test('login operation establishes a session (Studio bootstrap path)', async () => {
+		// Studio calls the `login` operation to set up the admin user on a new cluster. This
+		// exercises auth's session middleware on the operations-API port; that middleware runs
+		// only on the main thread, so if it is not registered there the operation fails with
+		// "No session for login". Guards the regression from removing auth's main-thread
+		// registration.
+		const response = await request(client.operationsURL)
+			.post('')
+			.set('Content-Type', 'application/json')
+			.send({ operation: 'login', username: admin.username, password: admin.password })
+			.expect((r) => assert.ok(r.text.includes('Login successful'), r.text))
+			.expect(200);
+
+		// A successful login must establish a session cookie — Studio relies on it.
+		const setCookie = response.headers['set-cookie'];
+		assert.ok(
+			Array.isArray(setCookie) && setCookie.some((c) => c.includes('hdb-session=')),
+			`expected an hdb-session cookie, got ${JSON.stringify(setCookie)}`
+		);
+	});
+
 	test('create_authentication_tokens with valid credentials returns operation token', async () => {
 		const response = await request(client.operationsURL)
 			.post('')

--- a/server/operationsServer.ts
+++ b/server/operationsServer.ts
@@ -16,6 +16,7 @@ import { PACKAGE_ROOT } from '../utility/packageUtils.js';
 import * as globalSchema from '../utility/globalSchema.ts';
 import * as commonUtils from '../utility/common_utils.ts';
 import * as userSchema from '../security/user.ts';
+import { authentication } from '../security/auth.ts';
 import { server as serverRegistration, type ServerOptions } from '../server/Server.ts';
 import {
 	authHandler,
@@ -74,6 +75,17 @@ async function operationsServer(options: ServerOptions & { resources?: Resources
 			// now that server is fully loaded/ready, start listening on port provided in config settings or just use
 			// zero to wait for sockets from the main thread
 			serverRegistration.http(server.server, options);
+			// The operations API runs only on the main thread, where auth's worker-only
+			// handleApplication never registers the authentication middleware. Register it here
+			// (after the node server, so its port already exists) so operations requests get
+			// `request.login`/`session`/`user` set up — without it the `login` operation that
+			// Studio uses to bootstrap a new instance fails with "No session for login".
+			// Register per port: `http()` tags each responder entry with `options.port || port`,
+			// so passing both ports in one call would mis-tag the secure entry with the plain
+			// port and leave the secure listener's chain without authentication.
+			if (options.port) serverRegistration.http(authentication, { port: options.port });
+			if (options.securePort) serverRegistration.http(authentication, { securePort: options.securePort });
+			if (!options.port && !options.securePort) serverRegistration.http(authentication, { port: 'all' });
 			// On Bun, register the Fastify instance so requests can be delegated via inject()
 			if (typeof globalThis.Bun !== 'undefined') {
 				const port = options.port || options.securePort || env.get(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_PORT);

--- a/server/operationsServer.ts
+++ b/server/operationsServer.ts
@@ -80,12 +80,17 @@ async function operationsServer(options: ServerOptions & { resources?: Resources
 			// (after the node server, so its port already exists) so operations requests get
 			// `request.login`/`session`/`user` set up — without it the `login` operation that
 			// Studio uses to bootstrap a new instance fails with "No session for login".
-			// Register per port: `http()` tags each responder entry with `options.port || port`,
-			// so passing both ports in one call would mis-tag the secure entry with the plain
-			// port and leave the secure listener's chain without authentication.
-			if (options.port) serverRegistration.http(authentication, { port: options.port });
-			if (options.securePort) serverRegistration.http(authentication, { securePort: options.securePort });
-			if (!options.port && !options.securePort) serverRegistration.http(authentication, { port: 'all' });
+			// Node only: on Bun the ops API is served by delegating to Fastify via inject(), and
+			// auth is applied through fastifyAuth's Bun shim (there is no `_nodeRequest` for the
+			// auth middleware to attach the resolved user to). Register per port because `http()`
+			// tags each responder entry with `options.port || port`, so passing both ports in one
+			// call would mis-tag the secure entry with the plain port and leave the secure
+			// listener's chain without authentication.
+			if (typeof globalThis.Bun === 'undefined') {
+				if (options.port) serverRegistration.http(authentication, { port: options.port });
+				if (options.securePort) serverRegistration.http(authentication, { securePort: options.securePort });
+				if (!options.port && !options.securePort) serverRegistration.http(authentication, { port: 'all' });
+			}
 			// On Bun, register the Fastify instance so requests can be delegated via inject()
 			if (typeof globalThis.Bun !== 'undefined') {
 				const port = options.port || options.securePort || env.get(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_PORT);


### PR DESCRIPTION
## Summary
Re-registers auth's `authentication` middleware on the operations-API port so the `login` operation works again. Adds an integration test that reproduces the failure.

## Purpose
`5.1.0-beta.3` (and beta.2) fail with `Error: No session for login` when the `login` operation is called — the operation Studio uses to set up the admin user on a new cluster, so **you cannot build a new instance from Studio**. (Reported by David in Slack.)

Root cause: the operations API runs only on the main thread, but auth's `authentication` middleware is registered via `handleApplication`, which the component loader invokes **workers-only** (`components/componentLoader.ts:462`). The ops-API port therefore never gets the responder that assigns `request.login`/`session`/`user`, and `login()` throws at `security/auth.ts:372`. This was introduced when commit `c993d42fd` removed the `startOnMainThread` export from `security/auth.ts`, whose explicit job was *"start on the main thread too so we can auth the operations API."* The fix restores that registration, located in `operationsServer.ts` (the legitimate main-thread component) since the new plugin API forbids a module exporting both `handleApplication` and `startOnMainThread`.

Authenticated operations kept working because `fastifyAuth.authorize` falls back to passport Basic/Bearer — only the session-establishing `login` path (which needs `baseRequest.login`) was broken.

## Where to look
- `server/operationsServer.ts` — the new registration. **Registered per port on purpose**: `http()` tags each responder entry with `options.port || port` (`server/http.ts:288`), so passing both ports in one call mis-tags the secure entry with the plain port and leaves the HTTPS listener's chain without auth. The three-branch form covers plain-only, secure-only, dual, and the no-port (`'all'`) case.
- `integrationTests/apiTests/authentication.test.mjs` — new `login`-operation test. Verified it fails without the fix with exactly `{"error":"No session for login"}` and passes with it (13/13 in the suite).

## For the reviewer to weigh in on (open item)
Cross-model review (Codex) flagged that with `authentication` in front of Fastify, a **no-auth** operation (`login` / `logout` / `create_authentication_tokens`) that *also* carries an **expired/invalid `Authorization` header** is rejected with 401 inside `authentication()` (`security/auth.ts:230`) before Fastify's `NO_AUTH_OPERATIONS` bypass can apply. I assess this as **pre-existing, not introduced** — the removed `startOnMainThread` registered the identical middleware, so this is the restored prior behavior — and the Studio bootstrap path sends **no** auth header, so it is unaffected. Flagging it because if we want no-auth ops to ignore stale headers, that is a separate, broader change to auth semantics. Happy to follow up if you'd prefer that hardening.

## Notes
- The secure-port gap (also flagged by Codex) is addressed by the per-port registration described above.
- Cross-model review caveats: the Gemini/`agy` leg degraded and produced no findings; the domain-adjudicator subagent could not start in this environment, so Harper-domain adjudication was done in-session.
- Generated with assistance from Claude (Opus 4.7).

## Update (2nd commit): Bun runtime
- The registration is **Node-only**. On Bun the ops API is served by delegating to Fastify via `inject()` and auth runs through `fastifyAuth`'s Bun shim; there is no `_nodeRequest` for the auth middleware to attach the user to, so registering on the Bun ops port crashed every request (`null is not an object (request._nodeRequest.user = ...)`). Caught by the Bun integration shards in CI.
- The session-establishing `login` op is a **pre-existing gap on Bun** (the shim never wired `baseRequest.login`; login never worked on Bun, independent of this regression). The new test is `skipOnBun`, matching the existing pattern. Wiring Bun ops-login is a reasonable follow-up if we want Studio against a Bun-runtime instance.
