### PR TITLE
fix: replay structure updates to the key the decoder reads (#362)

### DIFF
--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -10,6 +10,28 @@ import { classifyAuditEntryForReplay, isUndecodableValidatedWrite } from './repl
 import { purgeAgedLogs } from './auditStore.ts';
 
 let warnedReplayHappening = false;
+
+// True when `updated` would DROP shared structures relative to `existing` — for either the classic
+// array form or the {named, typed} Map form, and for a form change between the two. Shared
+// structures only ever grow (ids are stable and append-only), so a shorter replayed buffer is a
+// stale/older entry. Used to refuse a downgrade of the durable structures dictionary during replay:
+// since the composite key is the one RecordEncoder.getStructures reads, overwriting it with fewer
+// structures would drop ids the decoder still needs and make existing records decode to null. This
+// mirrors saveStructures' compatibility reject (RecordEncoder.ts). See harper-pro#362.
+export function structuresWouldShrink(existing: any, updated: any): boolean {
+	if (Array.isArray(existing)) {
+		return !Array.isArray(updated) || updated.length < existing.length;
+	}
+	if (existing && typeof existing.get === 'function') {
+		if (!updated || typeof updated.get !== 'function') return true;
+		return (
+			(updated.get('named')?.length ?? 0) < (existing.get('named')?.length ?? 0) ||
+			(updated.get('typed')?.length ?? 0) < (existing.get('typed')?.length ?? 0)
+		);
+	}
+	return false;
+}
+
 export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void> {
 	if (!isMainThread) return; // ideally we don't do it like this, but for now this is predictable
 	return new Promise((resolve) => {
@@ -147,50 +169,48 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 					case 'structures': {
 						const structuresAsBinary = auditRecord.getBinaryValue(primaryStore);
 						const updatedStructures = structuresAsBinary ? primaryStore.decoder.decode(structuresAsBinary) : undefined;
-						// Persist replayed structures where the decoder actually reads them. The RocksDB decode
+						// Persist replayed structures where the decoder actually reads them: the RocksDB decode
 						// path (RecordEncoder.getStructures) reads `rootStore` at the COMPOSITE key
-						// [Symbol.for('structures'), name]; this previously wrote `primaryStore` at the PLAIN key
-						// Symbol.for('structures'), which getStructures never consults. A structure delivered only
-						// via replication therefore stayed invisible to the decoder — records referencing it threw
-						// "Record id is not defined" and decoded as null — until a full-copy resync rewrote the row
-						// through saveStructures (composite key). See harper-pro#362 (and the #352 auth-path wedge).
-						// Mirror saveStructures exactly: same store, same composite key, same transaction shape.
+						// [Symbol.for('structures'), name], and saveStructures writes there. This previously wrote
+						// `primaryStore` at the PLAIN key Symbol.for('structures'), which getStructures never
+						// consults — so a structure delivered only via replication stayed invisible to the decoder
+						// (records referencing it decoded to null) until a full-copy resync rewrote the row through
+						// saveStructures. See harper-pro#362 (and the #352 auth-path wedge). Because this is now the
+						// authoritative key the decoder reads, it must carry saveStructures' guards: never poison the
+						// dictionary with an undecodable value, and never downgrade it to fewer structures.
 						const encoder = primaryStore.decoder;
 						const sharedStructuresKey = [Symbol.for('structures'), encoder.name];
 						encoder.rootStore.transactionSync(
 							(txn) => {
+								// A torn/corrupt/empty structures log value decodes to null/undefined; writing it to
+								// the key the decoder reads would poison the whole table's structure dictionary.
+								if (!updatedStructures) {
+									logger.warn(
+										`Skipping a structures replay entry that did not decode to a valid structures buffer (table ${encoder.name}).`
+									);
+									return;
+								}
 								const existingStructuresBuffer = txn.getBinarySync(sharedStructuresKey);
 								const existingStructures = existingStructuresBuffer
 									? encoder.decode(existingStructuresBuffer)
 									: undefined;
-								if (existingStructures) {
-									if (existingStructures instanceof Array) {
-										if (updatedStructures.length < existingStructures.length) {
-											logger.warn(
-												`Found ${existingStructures.length} structures in audit store, but ${updatedStructures.length} in replay log. Using ${updatedStructures.length} structures.`
-											);
-										}
-									} else {
-										if (existingStructures.get('named').length > updatedStructures.get('named').length) {
-											logger.warn(
-												`Found named ${existingStructures.length} structures in audit store, but ${updatedStructures.length} in replay log. Using named ${updatedStructures.length} structures.`
-											);
-										}
-										if (existingStructures.get('typed').length > updatedStructures.get('typed').length) {
-											logger.warn(
-												`Found named ${existingStructures.length} structures in audit store, but ${updatedStructures.length} in replay log. Using named ${updatedStructures.length} structures.`
-											);
-										}
-									}
+								// Refuse to overwrite a longer/newer durable buffer with an older/shorter replayed
+								// one — dropping ids the decoder still needs would make existing records decode to
+								// null. saveStructures rejects incompatible writes the same way (RecordEncoder.ts).
+								if (existingStructures && structuresWouldShrink(existingStructures, updatedStructures)) {
+									logger.warn(
+										`Replay log structures for table ${encoder.name} are fewer than the durable buffer; keeping the durable structures.`
+									);
+									return;
 								}
 								txn.putSync(sharedStructuresKey, asBinary(structuresAsBinary));
 							},
 							{ retryOnBusy: true }
 						);
-						// Load in-memory so the remainder of this replay can decode records that reference these
-						// structures. We deliberately do NOT route through saveStructures, which would set
-						// structureUpdate and re-log the structure as a fresh audit entry during replay.
-						primaryStore.decoder.structure = updatedStructures;
+						// No in-memory assignment is needed: the remainder of the replay decodes through
+						// getStructures/loadStructures, which re-reads this composite key (now correct) whenever a
+						// record references a not-yet-loaded structure id. We deliberately do NOT route through
+						// saveStructures, which would set structureUpdate and re-log the structure during replay.
 					}
 				}
 			} catch (err) {

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -1,4 +1,4 @@
-import { RocksDatabase, Transaction as RocksTransaction } from '@harperfast/rocksdb-js';
+import { RocksDatabase } from '@harperfast/rocksdb-js';
 import { Resource } from './Resource.ts';
 import type { Context } from './ResourceInterface.ts';
 import * as logger from '../utility/logging/harper_logger.js';
@@ -145,36 +145,51 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 						tableInstance._writeInvalidate(recordId, record, options);
 						break;
 					case 'structures': {
-						const rocksTransaction = new RocksTransaction(primaryStore.store);
 						const structuresAsBinary = auditRecord.getBinaryValue(primaryStore);
 						const updatedStructures = structuresAsBinary ? primaryStore.decoder.decode(structuresAsBinary) : undefined;
-						const existingStructures = primaryStore.getSync(Symbol.for('structures'), {
-							transaction: rocksTransaction,
-						});
-						if (existingStructures) {
-							if (existingStructures instanceof Array) {
-								if (updatedStructures.length < existingStructures.length) {
-									logger.warn(
-										`Found ${existingStructures.length} structures in audit store, but ${updatedStructures.length} in replay log. Using ${updatedStructures.length} structures.`
-									);
+						// Persist replayed structures where the decoder actually reads them. The RocksDB decode
+						// path (RecordEncoder.getStructures) reads `rootStore` at the COMPOSITE key
+						// [Symbol.for('structures'), name]; this previously wrote `primaryStore` at the PLAIN key
+						// Symbol.for('structures'), which getStructures never consults. A structure delivered only
+						// via replication therefore stayed invisible to the decoder — records referencing it threw
+						// "Record id is not defined" and decoded as null — until a full-copy resync rewrote the row
+						// through saveStructures (composite key). See harper-pro#362 (and the #352 auth-path wedge).
+						// Mirror saveStructures exactly: same store, same composite key, same transaction shape.
+						const encoder = primaryStore.decoder;
+						const sharedStructuresKey = [Symbol.for('structures'), encoder.name];
+						encoder.rootStore.transactionSync(
+							(txn) => {
+								const existingStructuresBuffer = txn.getBinarySync(sharedStructuresKey);
+								const existingStructures = existingStructuresBuffer
+									? encoder.decode(existingStructuresBuffer)
+									: undefined;
+								if (existingStructures) {
+									if (existingStructures instanceof Array) {
+										if (updatedStructures.length < existingStructures.length) {
+											logger.warn(
+												`Found ${existingStructures.length} structures in audit store, but ${updatedStructures.length} in replay log. Using ${updatedStructures.length} structures.`
+											);
+										}
+									} else {
+										if (existingStructures.get('named').length > updatedStructures.get('named').length) {
+											logger.warn(
+												`Found named ${existingStructures.length} structures in audit store, but ${updatedStructures.length} in replay log. Using named ${updatedStructures.length} structures.`
+											);
+										}
+										if (existingStructures.get('typed').length > updatedStructures.get('typed').length) {
+											logger.warn(
+												`Found named ${existingStructures.length} structures in audit store, but ${updatedStructures.length} in replay log. Using named ${updatedStructures.length} structures.`
+											);
+										}
+									}
 								}
-							} else {
-								if (existingStructures.get('named').length > updatedStructures.get('named').length) {
-									logger.warn(
-										`Found named ${existingStructures.length} structures in audit store, but ${updatedStructures.length} in replay log. Using named ${updatedStructures.length} structures.`
-									);
-								}
-								if (existingStructures.get('typed').length > updatedStructures.get('typed').length) {
-									logger.warn(
-										`Found named ${existingStructures.length} structures in audit store, but ${updatedStructures.length} in replay log. Using named ${updatedStructures.length} structures.`
-									);
-								}
-							}
-						}
-						primaryStore.putSync(Symbol.for('structures'), asBinary(structuresAsBinary), {
-							transaction: rocksTransaction,
-						});
-						rocksTransaction.commitSync();
+								txn.putSync(sharedStructuresKey, asBinary(structuresAsBinary));
+							},
+							{ retryOnBusy: true }
+						);
+						// Load in-memory so the remainder of this replay can decode records that reference these
+						// structures. We deliberately do NOT route through saveStructures, which would set
+						// structureUpdate and re-log the structure as a fresh audit entry during replay.
 						primaryStore.decoder.structure = updatedStructures;
 					}
 				}

--- a/unitTests/resources/replayStructures.test.js
+++ b/unitTests/resources/replayStructures.test.js
@@ -1,0 +1,137 @@
+require('../testUtils');
+const assert = require('node:assert');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const { RecordEncoder } = require('#src/resources/RecordEncoder');
+
+// Regression for harper-pro#362 (and the #352 auth-path wedge).
+//
+// The replayLogs `case 'structures'` apply used to persist the shared-structure buffer to the PLAIN
+// key Symbol.for('structures') on `primaryStore`. But the RocksDB decode read path
+// (RecordEncoder.getStructures) reads `rootStore` at the COMPOSITE key [Symbol.for('structures'), name].
+// So a structure delivered only via replication landed where getStructures never looks: records
+// referencing it threw "Record id is not defined" and RecordEncoder.decode returned null, until a
+// full-copy resync rewrote the row via saveStructures (composite key).
+//
+// The fix writes the replayed structures to the same composite key on the same rootStore that
+// saveStructures/getStructures use. These tests prove that at the level that matters: a structure
+// persisted at the composite key is visible to a cold decoder (and its records decode), while the
+// same structure at the old plain key stays invisible (decode -> null). The plain-key case is the
+// negative control demonstrating the fix is necessary, not cosmetic.
+
+const STRUCTURES = Symbol.for('structures');
+
+// Mirror the local `asBinary` helper in resources/replayLogs.ts: it wraps the raw structures buffer
+// in msgpackr's binary-data marker so putSync stores the exact bytes rather than re-encoding them.
+function asBinary(buffer) {
+	return { ['\x10binary-data\x02']: buffer };
+}
+
+// Only meaningful for the RocksDB engine; on LMDB getStructures/saveStructures fall back to the
+// store's own (non-composite-key) handling, so the composite-vs-plain distinction doesn't apply.
+const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
+
+describe('replay structures land where the decoder reads them (harper-pro#362)', function () {
+	if (isLMDB) return;
+
+	let primaryStore, rootStore, name, compositeKey, recordBytes, structuresBuffer;
+
+	before(function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		const ReplayStruct = table({
+			table: 'ReplayStruct362',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }, { name: 'type' }],
+		});
+		primaryStore = ReplayStruct.primaryStore;
+		const encoder = primaryStore.decoder;
+		rootStore = encoder.rootStore;
+		name = encoder.name;
+		compositeKey = [STRUCTURES, name];
+
+		// Encoding a record mints a shared structure and persists it via saveStructures (composite key).
+		// We capture both the record byte sequence and the durable structures buffer, then drive each
+		// persistence path below from this captured state to model a node that received the record but
+		// must source the structure purely from the store (no in-memory structure carried over).
+		recordBytes = Buffer.from(encoder.encode({ name: 'price', type: 'Float' }));
+		const persisted = rootStore.getBinarySync(compositeKey);
+		assert.ok(persisted, 'precondition: encoding a record must persist the shared structure at the composite key');
+		structuresBuffer = Buffer.from(persisted);
+	});
+
+	// A reader whose ONLY source of shared structures is the store at the composite key — i.e. a cold
+	// reopen / a freshly-started node, with no in-memory decoder.structure carried over. This is what
+	// getStructures resolves against, so it faithfully models the decode path that broke in #362.
+	function coldReader() {
+		const reader = new RecordEncoder({
+			structures: [],
+			getStructures() {
+				const buffer = rootStore.getBinarySync(compositeKey);
+				return buffer ? reader.decode(buffer) : undefined;
+			},
+			saveStructures() {},
+		});
+		reader.name = name;
+		reader.rootStore = rootStore;
+		reader.isRocksDB = true;
+		return reader;
+	}
+
+	function clearComposite() {
+		rootStore.removeSync(compositeKey);
+	}
+
+	it('with NO structure persisted anywhere, a cold decode yields null (the #362 symptom)', function () {
+		// A record referencing a structure this node never received throws a missing-structure error
+		// ("Record id is not defined") inside msgpackr, which RecordEncoder.decode swallows to null
+		// (see harper#1163 handling, covered by recordEncoder.test.js's isMissingStructureError tests).
+		clearComposite();
+		const reader = coldReader();
+		assert.strictEqual(reader.getStructures(), undefined, 'no structure should be visible');
+		assert.strictEqual(
+			reader.decode(Buffer.from(recordBytes)),
+			null,
+			'a record with no available structure decodes to null'
+		);
+	});
+
+	it('FIX: structures persisted at the composite key are visible to a cold decoder and its records decode', function () {
+		clearComposite();
+		// Persist exactly the way the replayLogs fix does: composite key, on rootStore, inside a
+		// retry-on-busy transaction, wrapped with asBinary.
+		rootStore.transactionSync(() => rootStore.putSync(compositeKey, asBinary(structuresBuffer)), { retryOnBusy: true });
+
+		const reader = coldReader();
+		assert.deepStrictEqual(
+			reader.getStructures(),
+			[['name', 'type']],
+			'getStructures must find the replayed structure at the composite key'
+		);
+		assert.deepStrictEqual(
+			reader.decode(Buffer.from(recordBytes)),
+			{ name: 'price', type: 'Float' },
+			'a record referencing the replayed structure must decode to the real object, not null'
+		);
+	});
+
+	it('NEGATIVE CONTROL (the bug): structures at the OLD plain key stay invisible — cold decode is null', function () {
+		// Reproduce the pre-fix behavior: write the same buffer to the plain key on primaryStore (where
+		// the old replay apply wrote it) and leave the composite key empty.
+		clearComposite();
+		primaryStore.putSync(STRUCTURES, asBinary(structuresBuffer));
+
+		const reader = coldReader();
+		assert.strictEqual(
+			reader.getStructures(),
+			undefined,
+			'getStructures never consults the plain key, so the structure stays invisible'
+		);
+		assert.strictEqual(
+			reader.decode(Buffer.from(recordBytes)),
+			null,
+			'this is the #362 wedge: the record decodes to null until a full-copy resync rewrites the composite key'
+		);
+	});
+});

--- a/unitTests/resources/replayStructures.test.js
+++ b/unitTests/resources/replayStructures.test.js
@@ -135,3 +135,38 @@ describe('replay structures land where the decoder reads them (harper-pro#362)',
 		);
 	});
 });
+
+// The replay apply now writes the authoritative composite key the decoder reads, so it must carry
+// saveStructures' downgrade guard: a stale/shorter replayed structures buffer must NOT overwrite a
+// longer durable one (that would drop ids and make existing records decode to null).
+// structuresWouldShrink is the predicate that refuses such a write.
+describe('structuresWouldShrink — refuse a downgrade of the durable structures dictionary (harper-pro#362)', function () {
+	const { structuresWouldShrink } = require('#src/resources/replayLogs');
+
+	it('classic array form: a shorter replayed buffer would shrink (refuse); equal/longer does not', function () {
+		assert.strictEqual(structuresWouldShrink([['a'], ['b'], ['c']], [['a'], ['b']]), true);
+		assert.strictEqual(structuresWouldShrink([['a'], ['b']], [['a'], ['b']]), false);
+		assert.strictEqual(structuresWouldShrink([['a'], ['b']], [['a'], ['b'], ['c']]), false);
+	});
+
+	it('named/typed Map form: fewer named OR fewer typed would shrink', function () {
+		const map = (named, typed) =>
+			new Map([
+				['named', new Array(named)],
+				['typed', new Array(typed)],
+			]);
+		assert.strictEqual(structuresWouldShrink(map(3, 2), map(2, 2)), true); // fewer named
+		assert.strictEqual(structuresWouldShrink(map(3, 2), map(3, 1)), true); // fewer typed
+		assert.strictEqual(structuresWouldShrink(map(3, 2), map(3, 2)), false); // equal
+		assert.strictEqual(structuresWouldShrink(map(3, 2), map(4, 3)), false); // grown
+	});
+
+	it('a form change is treated as a shrink (conservative: keep the durable buffer)', function () {
+		const emptyMap = new Map([
+			['named', []],
+			['typed', []],
+		]);
+		assert.strictEqual(structuresWouldShrink([['a']], emptyMap), true);
+		assert.strictEqual(structuresWouldShrink(emptyMap, [['a']]), true);
+	});
+});


### PR DESCRIPTION
## Summary

`replayLogs`' `case 'structures'` persisted the shared-structure buffer to the **plain** key `Symbol.for('structures')` on `primaryStore`, but the RocksDB decode path (`RecordEncoder.getStructures`) reads `rootStore` at the **composite** key `[Symbol.for('structures'), name]` (and `saveStructures` writes there). So a structure delivered **only via replication** landed where `getStructures` never looks — records referencing it threw `"Record id is not defined"` and `RecordEncoder.decode` swallowed it to `null` — until a full-copy resync rewrote the row through `saveStructures`.

This is the candidate root cause of the harper-pro#352 in-place-upgrade auth wedge (a freshly-flipped node decodes a peer's `hdb_nodes` row to `null`, fails `isValidNodeRecord`, and rejects the peer with cycling 1008 until self-heal). Filed as harper-pro#362.

## Change

One block in `core/resources/replayLogs.ts`: write the replayed structures to the same store + composite key `getStructures`/`saveStructures` use, inside a `rootStore.transactionSync(…, { retryOnBusy: true })` mirroring `saveStructures`. The in-memory `decoder.structure` load is kept; the apply deliberately does **not** route through `saveStructures` (that sets `structureUpdate` and would re-log the structure as a fresh audit entry during replay).

## Where to look

- **`encoder.name` / `encoder.rootStore`** are the same handles `getStructures` uses (`primaryStore.decoder` is the `RecordEncoder`; `rootStore`/`isRocksDB` are set in `handleLocalTimeForGets`). Worth confirming the composite key resolves identically to `saveStructures`.
- Writing the **raw logged bytes via `asBinary`** (vs. the decoded array as `saveStructures` does) — chosen to preserve the exact logged structures buffer; the round-trip is covered by the test.
- Removing the plain-key write: replay is RocksDB-only, and nothing on the RocksDB path reads the plain key — but a reviewer who knows of a plain-key reader should flag it.

## Tests

`unitTests/resources/replayStructures.test.js` (3, passing), against a real RocksDB table with a cold reader (no in-memory structure): cold/empty → `null` (the symptom); **fix** (composite key) → `getStructures` finds it and the record decodes to the real object; **negative control** (old plain key) → invisible → `null`, proving the fix is necessary. No regressions in `recordEncoder` / `replayLogs` suites (one pre-existing, unrelated `transaction.test.js` failure, confirmed present without this change).

## Caveats for the reviewer

- Cross-model review (step 10) has **not** been run yet — opened in draft at the author's direction; I'll run it before marking Ready.
- Whether #362 is *the* #352 trigger is not yet confirmed end-to-end (the #352 instrumented repro reported "0 structures replayed" in its one reproduced run); this fixes a real decode-loss defect regardless. A decisive at-the-failing-read capture is pending on a reliably-reproducing bench.

🤖 Generated by Claude Opus 4.7 (on Kris's behalf).