### PR TITLE
Fix describe_table record_count over-estimate on large RocksDB tables

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -3609,7 +3609,10 @@ export function makeTable(options) {
 					await rest();
 					if (reverseScanned >= limit) break;
 				}
-				const sampleSize = limit * 2;
+				// Use the actual entries sampled, not limit*2: the reverse scan can yield fewer than `limit`
+				// (concurrent deletions under snapshot:false, or an overestimated entryCount), and counting
+				// those un-scanned slots would inflate the denominator and underestimate the rate.
+				const sampleSize = limit + reverseScanned;
 				const recordRate = (recordCount + firstRecordCount) / sampleSize;
 				const variance =
 					Math.pow((recordCount - firstRecordCount + 1) / limit / 2, 2) + // variance between samples

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -3591,6 +3591,12 @@ export function makeTable(options) {
 				// entries and last thousand entries
 				const firstRecordCount = recordCount;
 				recordCount = 0;
+				// Bound the reverse scan explicitly. The getRange `limit` option is honored by lmdb-js but
+				// ignored by rocksdb-js; without this break the scan reads the whole table, so `recordRate`
+				// blows up to ~entryCount/(2*limit) and the estimate scales with entryCount^2 -- the source
+				// of the wildly inflated `record_count` (e.g. 20,000,000 for ~105k rows) on large RocksDB
+				// tables. The early-exit above guarantees limit < entryCount/2, so the two samples stay disjoint.
+				let reverseScanned = 0;
 				for (const { value } of primaryStore.getRange({
 					start: '\uffff',
 					reverse: true,
@@ -3599,7 +3605,9 @@ export function makeTable(options) {
 					snapshot: false,
 				})) {
 					if (value != null) recordCount++;
+					reverseScanned++;
 					await rest();
+					if (reverseScanned >= limit) break;
 				}
 				const sampleSize = limit * 2;
 				const recordRate = (recordCount + firstRecordCount) / sampleSize;

--- a/unitTests/resources/getRecordCount.test.js
+++ b/unitTests/resources/getRecordCount.test.js
@@ -31,14 +31,14 @@ describe('Table.getRecordCount', () => {
 	});
 
 	it('switches to the sampling estimator when the time budget is exhausted', async function () {
-		// Force the early-exit branch by giving the loop a 0ms time budget.
-		// This is the regression guard for the RocksDB entryCount bug: when
-		// `entryCount` was undefined on RocksDB stores, `halfway` became NaN
-		// and `entriesScanned < halfway` was always false, so the early-exit
-		// never fired and getRecordCount silently full-scanned every table.
-		// With a working entryCount we should drop into the sampling path
-		// after the first iteration and return an `estimatedRange`.
-		const result = await RecordCountTable.getRecordCount({ timeLimit: 0 });
+		// Force the early-exit branch. A negative time budget makes `now - start > TIME_LIMIT` true on
+		// the first iteration deterministically (a 0ms budget is racy: a tiny table can finish before
+		// the monotonic clock advances past the start, completing exactly instead of estimating).
+		// This is the regression guard for the RocksDB entryCount bug: when `entryCount` was undefined
+		// on RocksDB stores, `halfway` became NaN and `entriesScanned < halfway` was always false, so
+		// the early-exit never fired and getRecordCount silently full-scanned every table. With a working
+		// entryCount we should drop into the sampling path after the first iteration and return an `estimatedRange`.
+		const result = await RecordCountTable.getRecordCount({ timeLimit: -1 });
 		assert.ok(
 			Array.isArray(result.estimatedRange),
 			'expected getRecordCount to engage the sampling estimator (estimatedRange should be set)'
@@ -47,11 +47,11 @@ describe('Table.getRecordCount', () => {
 	});
 
 	it('keeps the sampling estimate within a sane factor of the true record count', async function () {
-		// Guards the reverse-sample bound. With `timeLimit: 0` the forward pass yields after one entry
-		// (limit=1) and the estimator runs. If the reverse loop is unbounded (rocksdb-js ignores the
+		// Guards the reverse-sample bound. With a negative time budget the forward pass yields after one
+		// entry (limit=1) and the estimator runs. If the reverse loop is unbounded (rocksdb-js ignores the
 		// getRange `limit`), it counts every live row, so `recordRate = (1 + entryCount)/2` and the
 		// estimate scales with entryCount^2 -- the `record_count=20,000,000`-for-~105K-rows bug.
-		const result = await RecordCountTable.getRecordCount({ timeLimit: 0 });
+		const result = await RecordCountTable.getRecordCount({ timeLimit: -1 });
 		assert.ok(
 			result.recordCount > 0 && result.recordCount <= 30 * 4,
 			`estimate ${result.recordCount} should track the ~30 live records, not an inflated key count`
@@ -89,17 +89,18 @@ describe('Table.getRecordCount', () => {
 			);
 		}
 
-		const result = await InflationTable.getRecordCount({ timeLimit: 0 });
+		const result = await InflationTable.getRecordCount({ timeLimit: -1 });
 		assert.ok(
 			result.recordCount <= N * 2,
 			`estimate ${result.recordCount} should track ${N} live records, not the inflated physical key count (${physicalEstimate})`
 		);
 	});
 
-	it('returns a valid record count and range for a tiny table under a 0ms budget', async function () {
-		// Edge case: a 1-row table with `timeLimit: 0`. `halfway` is 0, so the early-exit can't fire
-		// (entriesScanned is never < 0) and the loop completes to an exact count rather than estimating
-		// from a sample that would otherwise overlap its own tail. Guards against an inverted/!valid range.
+	it('returns a valid record count and range for a tiny table under an exhausted budget', async function () {
+		// Edge case: a 1-row table with a negative (always-exhausted) budget. `halfway` is 0, so the
+		// early-exit can't fire (entriesScanned is never < 0) and the loop completes to an exact count
+		// rather than estimating from a sample that would otherwise overlap its own tail. Guards against
+		// an inverted/invalid range.
 		const TinyTable = table({
 			table: 'RecordCountTinyTable',
 			database: 'test',
@@ -107,7 +108,7 @@ describe('Table.getRecordCount', () => {
 		});
 		await TinyTable.put({ id: 'solo', name: 'only-row' });
 
-		const result = await TinyTable.getRecordCount({ timeLimit: 0 });
+		const result = await TinyTable.getRecordCount({ timeLimit: -1 });
 		const [lower, upper] = result.estimatedRange ?? [result.recordCount, result.recordCount];
 		assert.ok(lower <= upper, `estimated range must be valid (got [${lower}, ${upper}])`);
 		assert.ok(

--- a/unitTests/resources/getRecordCount.test.js
+++ b/unitTests/resources/getRecordCount.test.js
@@ -45,4 +45,74 @@ describe('Table.getRecordCount', () => {
 		);
 		assert.equal(result.estimatedRange.length, 2);
 	});
+
+	it('keeps the sampling estimate within a sane factor of the true record count', async function () {
+		// Guards the reverse-sample bound. With `timeLimit: 0` the forward pass yields after one entry
+		// (limit=1) and the estimator runs. If the reverse loop is unbounded (rocksdb-js ignores the
+		// getRange `limit`), it counts every live row, so `recordRate = (1 + entryCount)/2` and the
+		// estimate scales with entryCount^2 -- the `record_count=20,000,000`-for-~105K-rows bug.
+		const result = await RecordCountTable.getRecordCount({ timeLimit: 0 });
+		assert.ok(
+			result.recordCount > 0 && result.recordCount <= 30 * 4,
+			`estimate ${result.recordCount} should track the ~30 live records, not an inflated key count`
+		);
+	});
+
+	it('does not inflate the estimate when keys are repeatedly overwritten', async function () {
+		// Defense-in-depth for the extrapolation *base* (distinct from the reverse-sample bound above).
+		// Re-write the same keys many times so superseded versions accumulate across (mostly) uncompacted
+		// SST files, driving rocksdb `estimate-num-keys` well above the live count. record_count must still
+		// track the live rows, i.e. `entryCount` must stay the exact `getKeysCount`, not `getEstimatedKeyCount`.
+		const InflationTable = table({
+			table: 'RecordCountInflationTable',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+		});
+		const N = 40;
+		const ROUNDS = 30;
+		for (let r = 0; r < ROUNDS; r++) {
+			let last;
+			for (let i = 0; i < N; i++) {
+				last = InflationTable.put({ id: 'k-' + i, name: 'v-' + r + '-' + i });
+			}
+			await last;
+			InflationTable.primaryStore.flushSync?.();
+		}
+
+		// Precondition sanity: this test only discriminates when the physical estimate is actually
+		// inflated above the live count. Surface when it can't (e.g. LMDB, or compaction kept up) so a
+		// green run isn't over-read.
+		const physicalEstimate = InflationTable.primaryStore.getEstimatedKeyCount?.() ?? N;
+		if (physicalEstimate < N * 1.5) {
+			console.warn(
+				`getRecordCount inflation guard: estimate ${physicalEstimate} not meaningfully inflated vs ${N} live; assertion still valid but less discriminating`
+			);
+		}
+
+		const result = await InflationTable.getRecordCount({ timeLimit: 0 });
+		assert.ok(
+			result.recordCount <= N * 2,
+			`estimate ${result.recordCount} should track ${N} live records, not the inflated physical key count (${physicalEstimate})`
+		);
+	});
+
+	it('returns a valid record count and range for a tiny table under a 0ms budget', async function () {
+		// Edge case: a 1-row table with `timeLimit: 0`. `halfway` is 0, so the early-exit can't fire
+		// (entriesScanned is never < 0) and the loop completes to an exact count rather than estimating
+		// from a sample that would otherwise overlap its own tail. Guards against an inverted/!valid range.
+		const TinyTable = table({
+			table: 'RecordCountTinyTable',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+		});
+		await TinyTable.put({ id: 'solo', name: 'only-row' });
+
+		const result = await TinyTable.getRecordCount({ timeLimit: 0 });
+		const [lower, upper] = result.estimatedRange ?? [result.recordCount, result.recordCount];
+		assert.ok(lower <= upper, `estimated range must be valid (got [${lower}, ${upper}])`);
+		assert.ok(
+			result.recordCount >= 1 && result.recordCount <= 10,
+			`estimate ${result.recordCount} should track the single live row`
+		);
+	});
 });


### PR DESCRIPTION
## Summary

`Table.getRecordCount()` (the `describe_table.record_count` estimator) reported wildly inflated, non-monotonic counts on large RocksDB tables — e.g. `record_count=20,000,000` for ~104,958 actual rows, bouncing between values in the millions across successive calls. This bounds the reverse-sample loop so the estimate tracks reality.

## Root cause

When the forward value-scan exceeds the time budget, the estimator samples the first `limit` and last `limit` entries and extrapolates. The reverse-sample loop passed `limit` to `getRange({ ..., limit })`:

- **lmdb-js honors** the `getRange` `limit` option.
- **rocksdb-js ignores it** (its `getRange` has no `limit` handling).

So on RocksDB the reverse loop scanned the **entire table** instead of `limit` entries. That made `recordRate = (firstRecordCount + reverseRecordCount) / (2 * limit) ≈ entryCount / (2 * limit)`, so `estimatedRecordCount = recordRate * entryCount` scaled with **entryCount²**. For ~105K rows with `limit ≈ 300` (≈ number of 100 KB-value reads that fit in 500 ms), that lands at ~18–20M, and bounces as `limit`/`entryCount` vary per call. It also meant `describe_table` read the whole table's values on every call.

This is independent of `getKeysCount` (which is exact on rocksdb-js ≥ 1.2.0); `entryCount` was never the inflated term.

## Change

- Bound the reverse-sample loop with an explicit `reverseScanned >= limit` break (`resources/Table.ts`). The existing `halfway` guard keeps `limit < entryCount / 2`, so the forward and reverse sample windows stay disjoint.
- Added regression tests in `unitTests/resources/getRecordCount.test.js`: the sampling estimate stays within a sane factor of the true count; the count isn't inflated by uncompacted overwrites; and a tiny-table edge case returns a valid range.

## Where to look

- `resources/Table.ts` `getRecordCount()` — the new `reverseScanned` bound is the whole fix. Confirm the disjointness reasoning (the `halfway` early-exit guarantees `limit < entryCount/2`).
- The fix relies on the empirical fact that rocksdb-js silently ignores `getRange({ limit })`. A separate rocksdb-js fix to honor `limit` is being filed/opened as a follow-up; the manual break here is correct regardless and stays as defense-in-depth (and for lmdb tables).

## Follow-up (not in this PR)

`getRecordCount()` still takes the exact `getKeysCount()` (full key-only scan) up front on every call. A follow-up will defer that — escape to the full count only when the time-bounded value scan can't finish — without reintroducing sample overlap.

## Review notes

- Cross-model review: Codex flagged a sample-overlap regression in an earlier draft (which dropped the `halfway` guard); that draft was reverted to this minimal form. The Gemini (`agy`) leg timed out and produced no output — no second-model coverage from Gemini, flagging so a reviewer's eyes substitute.

Generated by an LLM (Claude Opus 4.8).
