### PR TITLE
Defer getRecordCount key scan to the timeout path

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -3602,12 +3602,15 @@ export function makeTable(options) {
 		static async getRecordCount(options?: any) {
 			// iterate through the metadata entries to exclude their count and exclude the deletion counts
 			const exactCount = options?.exactCount;
-			const entryCount = isRocksDB
-				? primaryStore.getKeysCount({ start: exactCount ? null : undefined })
-				: primaryStore.getStats().entryCount;
 			const TIME_LIMIT = options?.timeLimit ?? 1000 / 2; // one second time limit, enforced by seeing if we are halfway through at 500ms
 			const start = performance.now();
-			const halfway = Math.floor(entryCount / 2);
+			// `entryCount` (the exact key count) is only needed once the scan blows the time budget --
+			// to decide whether to estimate and as the extrapolation base. On RocksDB it is a full
+			// key-only scan, so we defer it: tables that finish within budget (the common case) and
+			// `exact_count` requests never pay for it. `halfway`/`entryCount` stay 0 until first computed.
+			let entryCount = 0;
+			let halfway = 0;
+			let counted = false;
 			let recordCount = 0;
 			let entriesScanned = 0;
 			let limit: number;
@@ -3615,10 +3618,21 @@ export function makeTable(options) {
 				if (value != null) recordCount++;
 				entriesScanned++;
 				await rest();
-				if (!exactCount && entriesScanned < halfway && performance.now() - start > TIME_LIMIT) {
-					// it is taking too long, so we will just take this sample and a sample from the end to estimate
-					limit = entriesScanned;
-					break;
+				if (!exactCount && performance.now() - start > TIME_LIMIT) {
+					if (!counted) {
+						counted = true;
+						entryCount = isRocksDB
+							? primaryStore.getKeysCount({ start: undefined })
+							: primaryStore.getStats().entryCount;
+						halfway = Math.floor(entryCount / 2);
+					}
+					if (entriesScanned < halfway) {
+						// it is taking too long, so we will just take this sample and a sample from the end to estimate
+						limit = entriesScanned;
+						break;
+					}
+					// Past the halfway point already: finishing the scan for an exact count is cheaper
+					// than estimating, so fall through and keep iterating to completion.
 				}
 			}
 			if (limit) {

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -3611,6 +3611,7 @@ export function makeTable(options) {
 			let entryCount = 0;
 			let halfway = 0;
 			let counted = false;
+			let completeForExact = false;
 			let recordCount = 0;
 			let entriesScanned = 0;
 			let limit: number;
@@ -3618,7 +3619,7 @@ export function makeTable(options) {
 				if (value != null) recordCount++;
 				entriesScanned++;
 				await rest();
-				if (!exactCount && performance.now() - start > TIME_LIMIT) {
+				if (!exactCount && !completeForExact && performance.now() - start > TIME_LIMIT) {
 					if (!counted) {
 						counted = true;
 						entryCount = isRocksDB
@@ -3632,7 +3633,8 @@ export function makeTable(options) {
 						break;
 					}
 					// Past the halfway point already: finishing the scan for an exact count is cheaper
-					// than estimating, so fall through and keep iterating to completion.
+					// than estimating. Set the flag so we stop re-evaluating the budget on each remaining iteration.
+					completeForExact = true;
 				}
 			}
 			if (limit) {

--- a/unitTests/resources/getRecordCount.test.js
+++ b/unitTests/resources/getRecordCount.test.js
@@ -116,4 +116,30 @@ describe('Table.getRecordCount', () => {
 			`estimate ${result.recordCount} should track the single live row`
 		);
 	});
+
+	it('does not take a key count when the scan completes within the time budget', async function () {
+		// The entry-count source should only be consulted when the value scan blows the time budget;
+		// a within-budget scan returns the exact count directly and must not pay for it. The source is
+		// engine-dependent -- getKeysCount() (a full key scan) on RocksDB, getStats().entryCount on LMDB
+		// (the resources suite runs under both) -- so spy on whichever the store exposes.
+		const store = RecordCountTable.primaryStore;
+		let calls = 0;
+		const origKeys = typeof store.getKeysCount === 'function' ? store.getKeysCount.bind(store) : undefined;
+		const origStats = typeof store.getStats === 'function' ? store.getStats.bind(store) : undefined;
+		if (origKeys) store.getKeysCount = (...args) => (calls++, origKeys(...args));
+		if (origStats) store.getStats = (...args) => (calls++, origStats(...args));
+		try {
+			const completed = await RecordCountTable.getRecordCount(); // default budget; 30 rows finish fast
+			assert.equal(completed.recordCount, 30);
+			assert.equal(completed.estimatedRange, undefined);
+			assert.equal(calls, 0, 'entry-count source should not be consulted when the scan finishes within budget');
+
+			calls = 0;
+			await RecordCountTable.getRecordCount({ timeLimit: -1 }); // force timeout -> escape to the exact count
+			assert.ok(calls >= 1, 'entry-count source should be consulted once the scan exceeds the budget');
+		} finally {
+			if (origKeys) store.getKeysCount = origKeys;
+			if (origStats) store.getStats = origStats;
+		}
+	});
 });


### PR DESCRIPTION
## Summary

Follow-up to #1279 (**stacked on it** — base branch is `kris/getrecordcount-reverse-sample-bound`; retarget to `main` once #1279 merges). `getRecordCount()` took the exact `getKeysCount()` — a full key-only scan on RocksDB — up front on **every** `describe_table`, even though that count is only needed when the time-bounded value scan can't finish and we fall back to estimating.

This defers it: the key count is computed lazily on the **first timeout**. Tables whose value scan finishes within the budget (the common case) and `exact_count` requests no longer pay for the scan at all.

## Behavior preserved

The `halfway` guard — "once the scan is past half the table, finish for an exact count rather than estimate" — is preserved exactly; it's just evaluated against the lazily-computed count instead of an up-front one. So medium tables that previously powered through to an exact count still do. The only difference is *when* (and *whether*) the key count is taken:

| case | before | after |
|---|---|---|
| value scan finishes within budget | key scan taken, unused | **no key scan** |
| `exact_count: true` | key scan taken, unused | **no key scan** |
| times out before halfway | key scan up front → estimate | key scan on timeout → estimate (same result) |
| times out past halfway | key scan up front → exact | key scan on timeout → exact (same result) |

## Where to look

- `resources/Table.ts` `getRecordCount()` — the `counted`/`entryCount`/`halfway` lazy block inside the forward loop. Confirm the `if (limit)` branch is only reachable after `entryCount` is assigned (it is: `limit` is set only inside the `counted` block).
- New test asserts `getKeysCount` is **not** called when the scan completes within budget, and **is** called once it times out.

Generated by an LLM (Claude Opus 4.8).