### PR TITLE
fix(replication): repair dangling blob reference on identity-tie re-stream (authoritative tables)

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -61,7 +61,13 @@ import { recordAction, recordActionBinary } from './analytics/write.ts';
 import { rebuildUpdateBefore } from './crdt.ts';
 import { appendHeader } from '../server/serverHelpers/Headers.ts';
 import fs from 'node:fs';
-import { Blob, deleteBlobsInObject, findBlobsInObject, startPreCommitBlobsForRecord } from './blob.ts';
+import {
+	Blob,
+	deleteBlobsInObject,
+	findBlobsInObject,
+	getFilePathForBlob,
+	startPreCommitBlobsForRecord,
+} from './blob.ts';
 import { onStorageReclamation } from '../server/storageReclamation.ts';
 import { RequestTarget } from './RequestTarget.ts';
 import harperLogger from '../utility/logging/harper_logger.ts';
@@ -73,6 +79,24 @@ import { type JsonSchemaFragment, projectAttributesToProperties } from './jsonSc
 
 const { sortBy } = lodash;
 const { validateAttribute } = lmdbProcessRows;
+
+/**
+ * True if any file-backed blob referenced by a decoded record value points at a file that is no
+ * longer on disk. Used to detect a record whose receive-side blob save failed (the row committed
+ * referencing a fileId whose write never landed) so a re-streamed duplicate can repair it rather
+ * than being dropped. Blob-less records pay almost nothing: findBlobsInObject does a shallow walk
+ * and invokes its callback zero times, so the fs.existsSync stat only ever runs for records that
+ * actually carry file-backed blobs.
+ */
+function existingRecordHasMissingBlobFile(value: any): boolean {
+	let missing = false;
+	findBlobsInObject(value, (blob) => {
+		if (missing) return;
+		const path = getFilePathForBlob(blob as any);
+		if (path && !fs.existsSync(path)) missing = true;
+	});
+	return missing;
+}
 
 export type Attribute = {
 	name: string;
@@ -1942,6 +1966,45 @@ export function makeTable(options) {
 												options?.nodeId
 											);
 											if (precedesExisting === 0) {
+												// Identity tie: normally a duplicate to drop. But if the existing row references a
+												// blob whose file is missing — a prior receive-side blob save failed and the
+												// replication resume-cursor clamp re-streamed this record (which carries the now
+												// re-saved blob) — re-store the row onto the re-streamed value at the SAME version.
+												// This is a local-only repair (empty audit value, 'relocate' type → not replicated as a
+												// data change; a peer that receives it no-ops on the same-version guard), so there is no
+												// version bump and no cluster divergence. Without it the re-stream is dropped here and the
+												// row keeps its dangling blob reference — permanent loss on an authoritative table.
+												// Note: we do not gate on the HAS_BLOBS metadata flag here — its reliability on the
+												// existingEntry handed to this commit callback is not guaranteed, and
+												// existingRecordHasMissingBlobFile already returns immediately for blob-less records
+												// (findBlobsInObject invokes its callback zero times, so no fs.existsSync runs).
+												if (
+													recordUpdate &&
+													existingEntry?.value &&
+													existingRecordHasMissingBlobFile(existingEntry.value)
+												) {
+													logger.warn?.('Repairing a record with a missing blob file via re-streamed replication', id);
+													updateRecord(
+														id,
+														recordUpdate, // the re-streamed record, referencing the freshly re-saved blob
+														existingEntry,
+														existingEntry.version, // version number should not change — local repair, not a data change
+														0,
+														audit,
+														{
+															user: (context as any)?.user,
+															residencyId: existingEntry.residencyId,
+															nodeId: existingEntry.nodeId,
+															expiresAt: existingEntry.expiresAt,
+															transaction,
+														},
+														'relocate',
+														false,
+														null // empty audit value: there is no data change, only a storage repair
+													);
+													write.skipped = true; // the repair re-store is the write; skip the outer duplicate write
+													return;
+												}
 												logger.debug?.(
 													'The transaction time is equal to the existing version, treating as duplicate',
 													id


### PR DESCRIPTION
## Status: recommend DROP (redundant on the #368 watermark path)

This PR added a dedicated repair in `Table._writeUpdate` at the identity-tie duplicate-drop:
on an authoritative (non-caching) table, if the existing row references a blob whose file is
missing and a re-streamed duplicate arrives, re-store the row onto the re-streamed value at the
same version (a local-only `'relocate'`), so the dangling reference is replaced by the
freshly re-saved blob.

The premise was that a receive-side blob save failure commits a dangling row, and the
resume-cursor re-stream then arrives as an identity-tie duplicate and is **dropped**, stranding
the blob (caching tables self-heal via re-source; authoritative tables cannot).

### Why it's redundant now

The real blocker was a receive-path **deadlock**, which is fixed by **harper-pro #368** (an
async durability watermark). With #368 in place, the authoritative path was tested empirically
(harper-pro #371, 4 runs):

- The disrupted record's blob is **reliably re-saved by the natural same-version overwrite** of
  the re-streamed record — the follower converges with no wedge and, with the source offline,
  every authoritative blob is byte-for-byte intact.
- **This repair branch never fired.** Trace at the tie-branch / walk-break / overwrite showed
  the existing-row-has-missing-blob condition was never true at any apply-commit decision: the
  audit-walk `auditStore.get(...)` lookup that gates this repair **reliably misses** on the live
  re-stream, so the record never reaches the tie-drop. It falls through to the natural overwrite
  instead, which re-saves the blob.

The repair therefore sits behind a lookup that reliably misses, guarding a path that already
self-heals. harper-pro #371 retains the lasting value — a byte-integrity regression test that
asserts the authoritative-table blob is intact after failure + restart (no re-source masking) —
and reverts its `core` pointer to #368's base, so it no longer depends on this commit.

**Recommendation:** close or convert this PR. Kept in draft pending that decision; no code
change is needed in core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Cross-model review pending (main session)
