### PR TITLE
fix(deploy): surface install output and failed phase in deploy_component error response

### DIFF
--- a/components/Application.ts
+++ b/components/Application.ts
@@ -292,13 +292,13 @@ export async function installApplication(application: Application) {
 	} catch (err) {
 		if (err.code !== 'ENOENT') throw err;
 		// If no package.json, nothing to install
-		application.logger.debug(`Application ${application.name} has no package.json; skipping install`);
+		application.logger.info(`Application ${application.name} has no package.json; skipping install`);
 		return;
 	}
 	try {
 		// Does node_modules exist?
 		await access(join(application.dirPath, 'node_modules'), constants.F_OK);
-		application.logger.debug(`Application ${application.name} already has node_modules; skipping install`);
+		application.logger.info(`Application ${application.name} already has node_modules; skipping install`);
 		return;
 	} catch (err) {
 		if (err.code !== 'ENOENT') throw err;

--- a/components/operations.js
+++ b/components/operations.js
@@ -11,7 +11,7 @@ const hdbTerms = require('../utility/hdbTerms.ts');
 const env = require('../utility/environment/environmentManager.ts');
 const configUtils = require('../config/configUtils.js');
 const hdbUtils = require('../utility/common_utils.ts');
-const { handleHDBError, hdbErrors } = require('../utility/errors/hdbError.ts');
+const { handleHDBError, ServerError, hdbErrors } = require('../utility/errors/hdbError.ts');
 const { HDB_ERROR_MSGS, HTTP_STATUS_CODES } = hdbErrors;
 const manageThreads = require('../server/threads/manageThreads.js');
 const { packageDirectory } = require('../components/packageComponent.ts');
@@ -423,6 +423,9 @@ async function deployComponent(req) {
 	const systemReplicated = isSystemDatabaseReplicated();
 
 	let extractionPayload = req.payload;
+	// Bounded ring buffer of install stdout/stderr so a non-SSE caller sees the tail
+	// in the thrown error. SSE callers still stream every line live.
+	const installCapture = createInstallCapture();
 	try {
 		// On the origin, tee the tarball (Buffer or Readable from the multipart parser)
 		// through a hash-and-size tap into the row's payload_blob, then re-source extraction
@@ -449,11 +452,13 @@ async function deployComponent(req) {
 				timeout: req.install_timeout,
 				allowInstallScripts: req.install_allow_scripts,
 			},
-			// Forward each complete line of install stdout/stderr to the SSE channel (and
-			// into the recorder's event_log via the same subscriber). Peers have no emitter
-			// — their install output goes to the local logger only; cross-node install
-			// streaming would need extra plumbing and isn't wired here.
-			onInstallLine: emitter ? (manager, stream, line) => emit('install', { manager, stream, line }) : undefined,
+			// Tee each install line into both the capture buffer (for the thrown-error
+			// fallback) and the SSE channel (when a caller is streaming). Peers have no
+			// emitter, so their install output goes to the local logger and the buffer only.
+			onInstallLine: (manager, stream, line) => {
+				installCapture.push(manager, stream, line);
+				if (emitter) emit('install', { manager, stream, line });
+			},
 		});
 
 		emit('phase', { phase: 'prepare', status: 'start' });
@@ -548,14 +553,57 @@ async function deployComponent(req) {
 		}
 		return response;
 	} catch (err) {
+		// Pack phase, install output tail, and deployment_id into http_resp_msg so the
+		// Fastify error handler forwards them verbatim (it does when http_resp_msg is an
+		// object). Non-SSE callers see structured failure detail; SSE callers already
+		// got the same data live via emit('error', ...) below.
+		const capture = installCapture.snapshot();
+		const phase = recorder?.row.phase;
+		const baseMessage = err?.message ?? String(err);
+		const structured = { error: baseMessage };
+		if (phase) structured.phase = phase;
+		if (capture.lines.length > 0) structured.install_output = capture;
+		if (recorder?.deploymentId) structured.deployment_id = recorder.deploymentId;
+
+		// Wrap as a ServerError so the Fastify error handler picks a 500 by default; preserve
+		// an upstream statusCode (e.g. a ClientError from payload validation) if present.
+		const outErr = new ServerError(baseMessage, err?.statusCode);
+		outErr.http_resp_msg = structured;
+
 		emit('error', {
-			message: err?.message ?? String(err),
-			code: err?.statusCode ?? err?.code,
-			phase: recorder?.row.phase,
+			message: baseMessage,
+			code: outErr?.statusCode ?? err?.code,
+			phase,
+			install_output: capture.lines.length > 0 ? capture : undefined,
 		});
 		if (recorder) await recorder.finish('failed', err);
-		throw err;
+		throw outErr;
 	}
+}
+
+// Ring buffer of install stdout/stderr lines, capped by both line count and bytes so
+// a chatty install can't unbounded-grow the error response. snapshot() reports whether
+// the head was dropped so callers can flag truncation.
+function createInstallCapture(maxLines = 200, maxBytes = 16 * 1024) {
+	const lines = [];
+	let bytes = 0;
+	let dropped = 0;
+	return {
+		push(manager, stream, line) {
+			const entry = { manager, stream, line };
+			const size = (line?.length ?? 0) + (stream?.length ?? 0) + (manager?.length ?? 0);
+			lines.push(entry);
+			bytes += size;
+			while (lines.length > 0 && (lines.length > maxLines || bytes > maxBytes)) {
+				const evicted = lines.shift();
+				bytes -= (evicted.line?.length ?? 0) + (evicted.stream?.length ?? 0) + (evicted.manager?.length ?? 0);
+				dropped += 1;
+			}
+		},
+		snapshot() {
+			return { lines: lines.slice(), truncated: dropped > 0, dropped_lines: dropped };
+		},
+	};
 }
 
 /**

--- a/integrationTests/deploy/deploy-tracking.test.ts
+++ b/integrationTests/deploy/deploy-tracking.test.ts
@@ -176,7 +176,7 @@ suite('Deployment tracking', (ctx: ContextWithHarper) => {
 					operation: 'deploy_component',
 					project,
 					restart: false,
-					install_command: 'sh -c "exit 1"',
+					install_command: `sh -c "echo simulated-install-failure; exit 1"`,
 					install_timeout: 30_000,
 				},
 				{
@@ -190,6 +190,21 @@ suite('Deployment tracking', (ctx: ContextWithHarper) => {
 			const response = await postMultipart(url, multipart.contentType, multipart.stream, ctx.harper.admin);
 			// The HTTP response will be non-200 (error), but the row must still exist.
 			ok(response.status >= 400, `expected an error response, got ${response.status}: ${response.body}`);
+
+			// Non-SSE callers must see the failure phase, install output tail, and deployment_id
+			// in the response body, not just `error: <message>`. The captured line text has to
+			// match what the install command actually printed; an empty array would pass the
+			// pre-fix code, so assert on the line content too.
+			const body = JSON.parse(response.body);
+			strictEqual(body.phase, 'prepare');
+			ok(Array.isArray(body.install_output?.lines) && body.install_output.lines.length > 0);
+			ok(
+				body.install_output.lines.some(
+					(l: any) => l.stream === 'stdout' && l.line.includes('simulated-install-failure')
+				),
+				`install_output.lines should contain the printed stdout line; got ${JSON.stringify(body.install_output.lines)}`
+			);
+			ok(typeof body.deployment_id === 'string');
 
 			await sleep(200);
 


### PR DESCRIPTION
When a `deploy_component` install or load fails, the operation response now carries the failed phase, the captured tail of install stdout/stderr, and the `deployment_id` in addition to `error: <message>`. Install output is teed into a bounded ring buffer (200 lines / 16KB cap) on every deploy regardless of whether the caller streams SSE; on a thrown error the buffer's tail is packed into `http_resp_msg` as a structured object that `serverErrorHandler` already forwards verbatim when it's an object. The thrown error is wrapped as a `ServerError` (preserving any upstream `statusCode`, defaulting to 500). SSE callers are unaffected and still receive the same `install` and `error` events live. The two `skipping install` log lines also move from `debug` to `info` so the silent-skip case lands in `hdb.log` at the default level.

Verified end-to-end against a real Harper instance: the failed-deploy integration test asserts the literal `simulated-install-failure` stdout line surfaces in `body.install_output.lines` with `stream === "stdout"` (an empty array would have passed the pre-fix code, so the assertion checks line content rather than just length). All 18 deploy integration tests and 30 component unit tests pass; lint and TS build clean. Refs #1168. This is the first visibility wedge. Component-subprocess output capture, cross-node peer install streaming, the Fabric deploy-status view, and the supported-platforms matrix each need their own design and stay tracked in the issue.