### PR TITLE
fix(server): never use SO_REUSEPORT for the operations API (Bun path)

### DIFF
--- a/server/http.ts
+++ b/server/http.ts
@@ -743,9 +743,13 @@ function getBunHTTPServer(port: number, secure: boolean, options: ServerOptions)
 		};
 
 		// Store the config for Bun.serve() — will be started by threadServer.js listenOnPorts()
+		// The operations API is main-thread-only and must NOT use SO_REUSEPORT — it's the one
+		// exclusive port, which lets tooling (e.g. the integration-test loopback pool) detect an
+		// address that's already in use instead of silently co-binding. Mirrors the Node path,
+		// which sets server.noReusePort for isOperationsServer (see above).
 		const config: any = {
 			fetch: fetchHandler,
-			reusePort: process.platform !== 'darwin' && process.platform !== 'win32',
+			reusePort: !isOperationsServer && process.platform !== 'darwin' && process.platform !== 'win32',
 		};
 		if (secure) {
 			// TLS config for Bun

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -316,7 +316,9 @@ async function listenOnPortsBun() {
 			}
 			const serveOptions = {
 				port: portNumber,
-				reusePort: !isWindows && !isMac,
+				// Respect the per-server reusePort decision made in http.ts (the operations API
+				// opts out so it stays exclusive); fall back to the platform default otherwise.
+				reusePort: config.reusePort ?? (!isWindows && !isMac),
 				fetch: config.fetch,
 			};
 			if (portHostname) serveOptions.hostname = portHostname;


### PR DESCRIPTION
The Node listen path already excludes the operations API from SO_REUSEPORT (`server.noReusePort` for `isOperationsServer`, `server/http.ts` ~548). The `Bun.serve()` path, however, hardcoded `reusePort: process.platform !== 'darwin' && process.platform !== 'win32'`, so under Bun the **main-thread-only operations API** would bind with SO_REUSEPORT.

This makes the two runtimes consistent: the operations API stays **exclusive** everywhere. That exclusivity is relied on by tooling — notably the integration-test loopback-address pool (HarperFast/integration-testing#17), which probes the operations port to detect an address a stale node still holds. Worker-shared ports (HTTP/WS, replication) keep `reusePort` as before.

No effect on the Node runtime (the active path for current CI); this is a consistency/correctness fix for Bun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)