### PR TITLE
fix: retain blob files on record invalidate (#1302)

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -736,6 +736,22 @@ export function recordUpdater(store, tableId, auditStore) {
 						if (fileId) (retainedFileIds ??= new Set()).add(fileId);
 					});
 				}
+				if (type === 'invalidate') {
+					// An invalidate rewrites the row to an index-only partial record (Table._writeInvalidate);
+					// a blob attribute is never an index, so `record` carries no blob and the still-live
+					// record's blob would be unlinked ~deletionDelay ms later, leaving the row pointing at a
+					// missing file. Invalidation is a staleness marker, not a data mutation, so retain every
+					// blob the existing row referenced. The #641 retention (above) keyed off the new record,
+					// which the invalidate's partial never carries — hence the gap. See HarperFast/harper#1302.
+					// Note: the invalidated row no longer references the blob (and loses HAS_BLOBS), so a later
+					// delete/overwrite won't synchronously reclaim it — that falls to the orphan sweeper
+					// (cleanupOrphans, #708/#595). We trade prompt reclamation for never unlinking a live blob;
+					// refcount-driven deletion (track any live version referencing the fileId) is the robust fix.
+					findBlobsInObject(existingEntry.value, (blob) => {
+						const fileId = getFileId(blob);
+						if (fileId) (retainedFileIds ??= new Set()).add(fileId);
+					});
+				}
 				deleteBlobsInObject(existingEntry.value, retainedFileIds);
 			}
 			let result: Promise<void>;

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -281,6 +281,52 @@ describe('Blob test', () => {
 		});
 		setDeletionDelay(500); // restore the default
 	});
+	it('invalidating a record does not unlink a still-referenced blob', async () => {
+		// Regression (HarperFast/harper#1302): invalidate rewrites the row to an index-only
+		// partial record, which never carries the blob attribute. The #641 retention keys off
+		// the *new* record's blobs, so on invalidate retainedFileIds was empty and the live
+		// record's blob was unlinked ~deletionDelay ms later, leaving the row pointing at a
+		// missing file. Invalidates are generated automatically and repeatedly (replication
+		// revalidation, TTL eviction, peer invalidate events), so this caused progressive,
+		// silent blob data loss on caching/replicated deployments.
+		setAuditRetention(10);
+		setDeletionDelay(0);
+		const InvalidateTest = table({
+			table: 'BlobInvalidateTest',
+			database: 'test',
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'blob', type: 'Blob' },
+				{ name: 'category', type: 'String', indexed: true },
+			],
+		});
+		const payload = randomBytes(20000); // > FILE_STORAGE_THRESHOLD so it goes file-backed
+		const blob = await createBlob(payload);
+		await InvalidateTest.put({ id: 300, blob, category: 'docs' });
+		const filePath = getFilePathForBlob(blob);
+		assert(filePath, 'expected file-backed blob');
+		assert(existsSync(filePath), 'blob file should exist after initial put');
+
+		// Invalidate the record. Pre-fix: the blob file was unlinked ~deletionDelay ms later
+		// even though the record persists (now flagged INVALIDATED).
+		await InvalidateTest.invalidate(300);
+		await delay(50);
+		assert(existsSync(filePath), 'blob file must survive invalidate of a record that referenced it');
+
+		// Repeated invalidates (as replication/eviction would generate) must not shed it either.
+		for (let i = 0; i < 3; i++) {
+			await InvalidateTest.invalidate(300);
+			await delay(20);
+			assert(existsSync(filePath), `blob file must survive repeated invalidate #${i}`);
+		}
+
+		// The invalidated row is now an index-only partial that no longer references the blob,
+		// so it is no longer reachable through the record. Reclamation of the now-unreferenced
+		// file is left to the orphan sweeper (cleanupOrphans / HarperFast/harper#708, #595) rather
+		// than the write path — the targeted fix here prioritizes never unlinking a live record's
+		// blob over promptly reclaiming one that has become unreferenced.
+		setDeletionDelay(500); // restore the default
+	});
 	it('slowly create a blob and save it before it is done', async () => {
 		let testString = 'this is a test string'.repeat(256);
 		let expectedResults = '';


### PR DESCRIPTION
Fixes #1302.

## Summary
On `type === 'invalidate'`, seed `retainedFileIds` from the existing row's value (`resources/RecordEncoder.ts`) so an invalidate no longer unlinks a still-referenced file-backed blob.

## Why
`invalidate` rewrites a row to an **index-only** partial record (`Table._writeInvalidate`); a blob attribute is never an index, so that partial carries no blob. The #641 retention keyed off the *new* record's blobs, so on invalidate `retainedFileIds` was empty and `deleteBlobsInObject(existingEntry.value)` unlinked the live record's blob ~`deletionDelay` ms later, leaving the row pointing at a missing file (`ENOENT` / "Blob is incomplete").

Invalidates are generated automatically and repeatedly (replication revalidation, TTL eviction, peer invalidate events), so this caused **silent, progressive blob data loss** on any file-backed-blob deployment using caching/invalidation or replication. It is the root cause of the canopy.serent incident (~344/345 `CompanyDocument.fileData` attachments lost while the records stayed intact).

## Where to look
- `resources/RecordEncoder.ts` — the new `type === 'invalidate'` retention block. The change is small; the comment carries the rationale.
- Regression test in `unitTests/resources/blob.test.js` — "invalidating a record does not unlink a still-referenced blob" (file-backed blob survives an invalidate + repeated invalidates). Confirmed it fails on `main` and passes with the fix.

## `_writeRelocate` and other partial-record writers (the requested check)
`_writeRelocate`'s residency-excludes-this-host branch hits the **same** encoder deletion site with an index-only partial and `INVALIDATED` metadata — but with `type === 'relocate'`, so it is deliberately **not** covered here. Unlinking the local blob there is intended: the record's data is relocating off this node (the residency set excludes us), reads route to the residency node, and freeing the local file prevents a storage leak on a non-hosting node. The other relocate branches (`_writeRelocate` resident-here, `_recordRelocate`) pass the full record, so the #641 retention already preserves their blobs. No other writer puts a partial/index-only record over a `HAS_BLOBS` row with a different type. *(Confidence: high — corroborated by both cross-model legs below.)*

## Open tradeoff for the reviewer
After invalidate the row's value is index-only and `HAS_BLOBS` is cleared, so a subsequent delete/overwrite of that row does **not** synchronously reclaim the now-unreferenced blob — reclamation falls to the orphan sweeper (`cleanupOrphans`, #708/#595). This is the explicit scope tradeoff from the issue ("more robustly, blob deletion should be driven by whether any live record version still references the fileId" — refcounting, deferred): we prioritize **never unlinking a live blob** over prompt reclamation. The post-fix orphan is recoverable; the pre-fix loss was not. Both Codex and Gemini independently flagged this same tradeoff and agreed the relocate-path unlink is correct.

🤖 Generated by Claude (claude-opus-4-8, 1M context). Cross-model reviewed (Codex + Gemini).