### PR TITLE
fix: do not revalidate replicated writes on cache-sourced tables (#1302)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/kzyp/dev/harper/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/kzyp/dev/harper/node_modules

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -339,7 +339,16 @@ export function makeTable(options) {
 			}
 			hasSourceGet = hasSourceGet || (source.get && (!source.get.reliesOnPrototype || source.prototype.get));
 			sourceLoad = sourceLoad || source.load;
-			const shouldRevalidateEvents = this.source?.shouldRevalidateEvents;
+			// Revalidation down-converts incoming put/patch events to invalidate so a cache re-fetches
+			// from its source on next read. It must apply ONLY to events from the canonical caching
+			// source — never to authoritative writes arriving from a replication peer, which registers
+			// as an intermediateSource (harper-pro replication/replicator.ts). This closure is created
+			// per sourcedFrom() call, but the flag was read from this.source (the canonical caching
+			// source) regardless of which source the subscription is actually for; on a cache-sourced
+			// AND replicated table that leaked the caching source's revalidate flag onto the replication
+			// subscription, turning replicated writes into invalidates and deleting file-backed blobs no
+			// peer re-supplied. See HarperFast/harper#1302. Gate it off the intermediate source.
+			const shouldRevalidateEvents = !source.intermediateSource && this.source?.shouldRevalidateEvents;
 
 			// External data source may provide a subscribe method, allowing for real-time proactive delivery
 			// of data from the source to this caching table. This is generally greatly superior to expiration-based

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -348,7 +348,7 @@ export function makeTable(options) {
 			// AND replicated table that leaked the caching source's revalidate flag onto the replication
 			// subscription, turning replicated writes into invalidates and deleting file-backed blobs no
 			// peer re-supplied. See HarperFast/harper#1302. Gate it off the intermediate source.
-			const shouldRevalidateEvents = !source.intermediateSource && this.source?.shouldRevalidateEvents;
+			const shouldRevalidateEvents = !options?.intermediateSource && this.source?.shouldRevalidateEvents;
 
 			// External data source may provide a subscribe method, allowing for real-time proactive delivery
 			// of data from the source to this caching table. This is generally greatly superior to expiration-based

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -468,4 +468,70 @@ describe('Caching', () => {
 		assert.equal(extendedSourceCalls, 2);
 		assert.equal(anotherSourceCalls, 1); // AnotherExtendedTable source should not be called
 	});
+
+	it('intermediate (replication) source events are applied, not revalidated/invalidated (#1302)', async function () {
+		// A table that is BOTH cache-sourced (its caching source opts into event revalidation) AND
+		// fed by an intermediate source (how replication registers itself — see harper-pro
+		// replication/replicator.ts, `{ intermediateSource: true }`).
+		//
+		// Bug: shouldRevalidateEvents was read from this.source (the canonical caching source) for
+		// EVERY sourcedFrom() subscription closure, including the intermediate one. So authoritative
+		// replicated put/patch events were down-converted to invalidate — stripping the row to an
+		// index stub and (for file-backed blobs) deleting data no peer re-supplies. The fix gates
+		// revalidation off the intermediate source, so replicated writes apply via _writeUpdate.
+		// The caching source is gated: a read-miss on a cache-sourced table triggers a source load,
+		// and we must not let a poll-before-apply write a competing 'CACHE' record while we wait for
+		// the replicated event. Gating makes any premature load stall instead of polluting state.
+		let allowCacheLoad;
+		const cacheLoadGate = new Promise((resolve) => (allowCacheLoad = resolve));
+		const CacheSource = {
+			async get(id) {
+				await cacheLoadGate;
+				return { id, name: 'from-cache-source', payload: 'CACHE' };
+			},
+			// the caching source pushes change notifications it wants treated as invalidations
+			shouldRevalidateEvents: true,
+		};
+		const ReplAndCacheTable = table({
+			table: 'ReplAndCacheTable',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }, { name: 'payload' }],
+		});
+		// Order matters: the caching source is registered before the intermediate (replication)
+		// source, so this.source is already set when the intermediate subscription closure captures
+		// the flag — the exact condition that triggered the leak.
+		ReplAndCacheTable.sourcedFrom(CacheSource);
+
+		let releaseSubscription;
+		const subscriptionDone = new Promise((resolve) => (releaseSubscription = resolve));
+		const replicatedValue = { id: 500, name: 'from-peer', payload: 'PEER' };
+		const IntermediateSource = {
+			subscribeOnThisThread() {
+				return true;
+			},
+			async *subscribe() {
+				yield { type: 'put', id: 500, value: replicatedValue, version: Date.now() };
+				await subscriptionDone; // hold the subscription open until the assertions are done
+			},
+		};
+		ReplAndCacheTable.sourcedFrom(IntermediateSource, { intermediateSource: true });
+
+		try {
+			// A record that surfaces as 'PEER' proves the replicated event was applied as an update.
+			// Pre-fix it was down-converted to an invalidate, so the read would resolve to the source's
+			// 'CACHE' value instead and this would time out. The race against a short timer ensures a
+			// gated (stalled) load on a not-yet-applied record counts as "not ready", not a hang.
+			await waitFor(
+				async () =>
+					(await Promise.race([
+						ReplAndCacheTable.get(500).then((record) => record?.payload),
+						delay(20).then(() => undefined),
+					])) === 'PEER',
+				{ timeout: 5000, message: 'replicated intermediate-source put should be applied as an update, not invalidated' }
+			);
+		} finally {
+			allowCacheLoad();
+			releaseSubscription();
+		}
+	});
 });


### PR DESCRIPTION
Fixes #1302. Root-cause fix; replaces the closed symptom-level PR #1303.

## Summary
`resources/Table.ts` — gate event *revalidation* off the intermediate (replication) source:
```js
const shouldRevalidateEvents = !options?.intermediateSource && this.source?.shouldRevalidateEvents;
```

## Why
Revalidation down-converts incoming `put`/`patch` events to `invalidate` so a cache re-fetches from its source on next read. But `shouldRevalidateEvents` was read from `this.source` — the single canonical *caching* source — for **every** `sourcedFrom()` subscription closure, regardless of which source that closure subscribes to.

Replication registers itself as an `intermediateSource` (`harper-pro/replication/replicator.ts`). On a table that is **both** cache-sourced and replicated, the replication subscription captured the caching source's revalidate flag, so authoritative replicated writes were turned into invalidates — stripping the row to an index-only stub and deleting file-backed blobs that no peer re-supplies. That is the canopy.serent signature (records intact, blobs `ENOENT` for weeks).

Deleting the blob on a *genuine* invalidate is correct (the cache re-fetches) and is unchanged. The bug was that replicated writes were being invalidated at all.

## Where to look
- `resources/Table.ts` (the one-line change + comment). For `source === this.source` (the caching registration) and any non-intermediate source, `options?.intermediateSource` is falsy → behavior unchanged. For the replication intermediate source → forced `false` → events apply via `_writeUpdate`, keeping their data/blobs.
- Test: `unitTests/resources/caching.test.js` — "intermediate (replication) source events are applied, not revalidated/invalidated". Registers a cache source (revalidate-on, registered first — the order that triggered the leak) plus an intermediate source that pushes a `put`, and asserts it is applied as an update rather than re-fetched from the caching source. Verified it fails on `main` and passes with the fix.

## Notes for the reviewer
- This is order-dependent in the wild: the leak only bites when the caching source is registered before replication (so `this.source` is set when the replication closure captures the flag). The fix removes the dependency entirely.
- A 2-node harper-pro integration test (cache-sourced + replicated blob table) is a worthwhile end-to-end follow-up; the core unit test here exercises the exact mechanism deterministically.

🤖 Generated by Claude (claude-opus-4-8, 1M context).