### PR TITLE
test: closed transaction in ALS context still reads latest committed state

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -52,6 +52,7 @@
 		"server": "readonly",
 		"databases": "readonly",
 		"tables": "readonly",
+		"transaction": "readonly",
 		"createBlob": "readonly",
 		"lockdown": "readonly",
 		"threads": "readonly",

--- a/integrationTests/fixtures/transaction-context-reads/config.yaml
+++ b/integrationTests/fixtures/transaction-context-reads/config.yaml
@@ -1,0 +1,6 @@
+# REPRO component for the "closed transaction in ALS -> empty search" diagnosis.
+graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/fixtures/transaction-context-reads/resources.js
+++ b/integrationTests/fixtures/transaction-context-reads/resources.js
@@ -1,0 +1,99 @@
+// Fixture for transaction-context-reads.test.ts.
+//
+// Each Dash* GET reads ScoreSnapshot rows for a company and reports how many it saw.
+// All variants query the SAME seeded data; the only thing that varies is the
+// transaction state of the ALS context at the moment ScoreSnapshot.search() runs —
+// exercising the contract that a closed transaction reads latest committed state.
+//
+// `tables`, `Resource`, `transaction` are Harper globals.
+
+function paramId(query) {
+	return query && query.get ? (query.get('company') ?? query.company) : query && query.company;
+}
+
+async function searchSnapshots(companyId) {
+	const out = [];
+	for await (const rec of tables.ScoreSnapshot.search({
+		conditions: [{ attribute: 'companyId', comparator: 'equals', value: companyId }],
+	})) {
+		out.push(rec.id);
+	}
+	out.sort();
+	return out;
+}
+
+// CONTROL — ScoreSnapshot.search is the FIRST table op in the request, so no closed
+// transaction exists in the ALS context yet.
+export class DashControl extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const companyId = paramId(query);
+		const snapshots = await searchSnapshots(companyId);
+		return { variant: 'control', companyId, count: snapshots.length, snapshots };
+	}
+}
+
+// NORMAL — Company.get() then ScoreSnapshot.search(), both inside the single OPEN
+// per-request transaction (REST wraps the handler in transaction(request, ...)).
+export class DashGetThenSearch extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const companyId = paramId(query);
+		const company = await tables.Company.get(companyId);
+		const snapshots = await searchSnapshots(companyId);
+		return { variant: 'get-then-search', companyId, company: company?.id ?? null, count: snapshots.length, snapshots };
+	}
+}
+
+// FORCED-CLOSED — read Company, then explicitly COMMIT the per-request transaction
+// (closing it but leaving the closed DatabaseTransaction on context.transaction in
+// ALS), THEN run ScoreSnapshot.search(). The closed slot must still read latest.
+export class DashCommitThenSearch extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const companyId = paramId(query);
+		const company = await tables.Company.get(companyId);
+		const ctx = this.getContext();
+		const stateBefore = ctx?.transaction?.open;
+		await transaction.commit(this); // commit + close the request txn; it stays in ALS
+		const stateAfter = ctx?.transaction?.open;
+		const snapshots = await searchSnapshots(companyId);
+		return {
+			variant: 'commit-then-search',
+			companyId,
+			company: company?.id ?? null,
+			txnOpenBefore: stateBefore,
+			txnOpenAfter: stateAfter,
+			count: snapshots.length,
+			snapshots,
+		};
+	}
+}
+
+// LAZY-ITERABLE — Company.get() first, then RETURN the ScoreSnapshot.search() iterable
+// without consuming it. REST awaits the handler return, commits the request txn, THEN
+// serializes the response by iterating — so the iteration happens against a committed/
+// closed transaction. This is the most realistic "dashboard returns a query" pattern.
+export class DashLazyIterable extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const companyId = paramId(query);
+		await tables.Company.get(companyId); // first op opens/uses the request txn
+		return tables.ScoreSnapshot.search({
+			conditions: [{ attribute: 'companyId', comparator: 'equals', value: companyId }],
+		});
+	}
+}
+
+// FORCED-CLOSED via a write — same as above but the first op is a write whose commit
+// closes the txn, closer to a real handler that writes then reads.
+export class DashWriteThenSearch extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const companyId = paramId(query);
+		await tables.Company.put({ id: companyId, name: 'touched' });
+		await transaction.commit(this);
+		const snapshots = await searchSnapshots(companyId);
+		return { variant: 'write-then-search', companyId, count: snapshots.length, snapshots };
+	}
+}

--- a/integrationTests/fixtures/transaction-context-reads/schema.graphql
+++ b/integrationTests/fixtures/transaction-context-reads/schema.graphql
@@ -1,0 +1,14 @@
+# Fixture for transaction-context-reads.test.ts: a Company read followed by an indexed
+# ScoreSnapshot search, used to verify a closed transaction in the ALS context still
+# reads the latest committed state for the second table.
+
+type Company @table @export {
+	id: ID @primaryKey
+	name: String
+}
+
+type ScoreSnapshot @table @export {
+	id: ID @primaryKey
+	companyId: String @indexed
+	score: Int
+}

--- a/integrationTests/resources/transaction-context-reads.test.ts
+++ b/integrationTests/resources/transaction-context-reads.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Transaction context read semantics — a closed per-request transaction left in the
+ * AsyncLocalStorage context must NOT cause subsequent table reads to return empty.
+ *
+ * Regression guard for a misdiagnosis: a dashboard that read one table and then searched
+ * another in the same request was reported to return empty results on the second search,
+ * attributed to txnForContext() propagating CLOSED state into the second table's
+ * transaction slot (Table.ts) — with a proposed fix to start a fresh ImmediateTransaction
+ * instead of inheriting CLOSED.
+ *
+ * That mechanism does not hold: a closed transaction slot returns `undefined` from
+ * getReadTxn() (DatabaseTransaction.ts), which by design reads the latest committed state
+ * rather than an empty snapshot. This test pins that contract across the access patterns
+ * that were suspected, including one that deterministically commits (and thus closes) the
+ * per-request transaction before the second search, and one that returns the search
+ * iterable lazily so it is consumed during response serialization after the commit.
+ *
+ * Component fixture: integrationTests/fixtures/transaction-context-reads/.
+ * Skipped on Windows (restart_service http_workers crashes the Harper instance on
+ * Windows — see HarperFast/harper#549).
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert/strict';
+import { resolve } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
+import { createApiClient } from '../apiTests/utils/client.mjs';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, '../fixtures/transaction-context-reads');
+const skipSuite = process.platform === 'win32';
+
+suite('Transaction context: closed txn in ALS still reads latest', { skip: skipSuite }, (ctx: ContextWithHarper) => {
+	let client: ReturnType<typeof createApiClient>;
+	let httpURL: string;
+	let auth: string;
+
+	const COMPANY = 'c1';
+	const SNAP_IDS = ['s1', 's2', 's3'];
+
+	before(async () => {
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: {}, env: {} });
+		client = createApiClient(ctx.harper);
+		httpURL = ctx.harper.httpURL;
+		auth = client.headers.Authorization;
+
+		const deadline = Date.now() + 30_000;
+		while (Date.now() < deadline) {
+			try {
+				const probe = await client.reqRest('/Company/').timeout(3_000);
+				if (probe.status !== 404) break;
+			} catch {
+				/* not ready */
+			}
+			await sleep(250);
+		}
+
+		await putJSON(`/Company/${COMPANY}`, { id: COMPANY, name: 'Acme' });
+		for (const id of SNAP_IDS) {
+			await putJSON(`/ScoreSnapshot/${id}`, { id, companyId: COMPANY, score: 10 });
+		}
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	function putJSON(path: string, body: unknown): Promise<Response> {
+		return fetch(`${httpURL}${path}`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json', 'Authorization': auth },
+			body: JSON.stringify(body),
+		});
+	}
+
+	async function dashCount(variantPath: string): Promise<any> {
+		const r = await fetch(`${httpURL}${variantPath}?company=${COMPANY}`, { headers: { Authorization: auth } });
+		ok(r.status < 300, `${variantPath} expected 2xx, got ${r.status}`);
+		return r.json();
+	}
+
+	test('direct indexed search returns all seeded rows', async () => {
+		const r = await fetch(`${httpURL}/ScoreSnapshot/?companyId=${COMPANY}`, { headers: { Authorization: auth } });
+		const body = await r.json();
+		const ids = (Array.isArray(body) ? body : (body?.records ?? [])).map((x: any) => x.id).sort();
+		strictEqual(ids.length, SNAP_IDS.length, 'seeded snapshots are present');
+	});
+
+	test('search-first (no prior txn) returns all rows', async () => {
+		const body = await dashCount('/DashControl/');
+		strictEqual(body.count, SNAP_IDS.length);
+	});
+
+	test('get-then-search within one open txn returns all rows', async () => {
+		const body = await dashCount('/DashGetThenSearch/');
+		strictEqual(body.count, SNAP_IDS.length);
+	});
+
+	test('commit-then-search (txn closed in ALS) still returns all rows', async () => {
+		const body = await dashCount('/DashCommitThenSearch/');
+		// Guards the misdiagnosis: the request txn is genuinely closed before the search
+		// (open: 1 -> 0), yet the closed slot reads latest committed state, not empty.
+		strictEqual(body.txnOpenBefore, 1, 'txn was open before the explicit commit');
+		strictEqual(body.txnOpenAfter, 0, 'txn is closed in ALS before the search');
+		strictEqual(body.count, SNAP_IDS.length, 'closed-txn-in-ALS must still see all snapshots');
+	});
+
+	test('lazily-returned search iterated during post-commit serialization returns all rows', async () => {
+		const r = await fetch(`${httpURL}/DashLazyIterable/?company=${COMPANY}`, { headers: { Authorization: auth } });
+		ok(r.status < 300, `DashLazyIterable expected 2xx, got ${r.status}`);
+		const body = await r.json();
+		const ids = (Array.isArray(body) ? body : (body?.records ?? [])).map((x: any) => x.id).sort();
+		strictEqual(ids.length, SNAP_IDS.length, 'lazily-returned search must serialize all snapshots');
+	});
+
+	test('write-then-search (txn closed after write) still returns all rows', async () => {
+		const body = await dashCount('/DashWriteThenSearch/');
+		strictEqual(body.count, SNAP_IDS.length);
+	});
+});

--- a/integrationTests/resources/transaction-context-reads.test.ts
+++ b/integrationTests/resources/transaction-context-reads.test.ts
@@ -44,16 +44,21 @@ suite('Transaction context: closed txn in ALS still reads latest', { skip: skipS
 		httpURL = ctx.harper.httpURL;
 		auth = client.headers.Authorization;
 
+		let ready = false;
 		const deadline = Date.now() + 30_000;
 		while (Date.now() < deadline) {
 			try {
 				const probe = await client.reqRest('/Company/').timeout(3_000);
-				if (probe.status !== 404) break;
+				if (probe.status !== 404) {
+					ready = true;
+					break;
+				}
 			} catch {
 				/* not ready */
 			}
 			await sleep(250);
 		}
+		ok(ready, 'Harper instance did not become ready within 30 seconds');
 
 		await putJSON(`/Company/${COMPANY}`, { id: COMPANY, name: 'Acme' });
 		for (const id of SNAP_IDS) {
@@ -65,12 +70,14 @@ suite('Transaction context: closed txn in ALS still reads latest', { skip: skipS
 		await teardownHarper(ctx);
 	});
 
-	function putJSON(path: string, body: unknown): Promise<Response> {
-		return fetch(`${httpURL}${path}`, {
+	async function putJSON(path: string, body: unknown): Promise<Response> {
+		const r = await fetch(`${httpURL}${path}`, {
 			method: 'PUT',
 			headers: { 'Content-Type': 'application/json', 'Authorization': auth },
 			body: JSON.stringify(body),
 		});
+		ok(r.status < 300, `PUT ${path} expected 2xx, got ${r.status}`);
+		return r;
 	}
 
 	async function dashCount(variantPath: string): Promise<any> {
@@ -81,6 +88,7 @@ suite('Transaction context: closed txn in ALS still reads latest', { skip: skipS
 
 	test('direct indexed search returns all seeded rows', async () => {
 		const r = await fetch(`${httpURL}/ScoreSnapshot/?companyId=${COMPANY}`, { headers: { Authorization: auth } });
+		ok(r.status < 300, `GET /ScoreSnapshot/ expected 2xx, got ${r.status}`);
 		const body = await r.json();
 		const ids = (Array.isArray(body) ? body : (body?.records ?? [])).map((x: any) => x.id).sort();
 		strictEqual(ids.length, SNAP_IDS.length, 'seeded snapshots are present');


### PR DESCRIPTION
## Summary

Adds an integration regression guard — `integrationTests/resources/transaction-context-reads.test.ts` plus a `transaction-context-reads` fixture — that pins the contract: **a closed per-request transaction left in the AsyncLocalStorage context must not cause subsequent table reads to return empty.** Also adds the real `transaction` Harper global (`globals.js`) to the oxlint `globals` list so fixture/component code can reference it without a `no-undef` error.

No production code changes.

## Purpose

A live investigation of a customer dashboard (reads `Company`, then searches `ScoreSnapshot` in the same request) reported the second search returning empty on 5.1.0, and proposed a core fix: have `txnForContext()` start a fresh `ImmediateTransaction` instead of inheriting `CLOSED` state into the second table's slot.

That mechanism does not hold against the source: a closed slot returns `undefined` from `DatabaseTransaction.getReadTxn()`, which by design "reads latest committed state" — and `ImmediateTransaction.getReadTxn()` returns `undefined` too, so the proposed change would be a no-op for reads while altering write-immediacy semantics. This test encodes that reasoning as an executable guard so the same misdiagnosis (and proposed fix) doesn't recur. The customer-facing empty-data symptom is being pursued separately as a replication/sync issue on the affected node.

## What it covers

Identical seeded data, varying only the ALS transaction state at the moment of the indexed `ScoreSnapshot.search()`:
- search-first (no prior txn); get-then-search within one open txn;
- **commit-then-search** — explicitly commits (closes) the request txn first; asserts `txn.open` went `1 → 0` and the search still returns all rows;
- **lazy-iterable** — returns the search iterable so it's iterated during response serialization *after* the request txn commits;
- write-then-search.

All assert the full row set.

## Where to look

- The `commit-then-search` and `lazy-iterable` variants are the load-bearing ones — confirm they reflect realistic request shapes.
- One-line `.oxlintrc.json` addition (`transaction` global) — flag if you'd rather scope it narrower than a global allow.

_Generated by an LLM (Claude Opus 4.8)._