### PR TITLE
fix(encoding): stop versioned-write metadata leaking into non-versioned __dbis__ records (#1307)

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -117,6 +117,7 @@ export class RecordEncoder extends StructonEncoder {
 	structureUpdate?: any;
 	isRocksDB: boolean;
 	name: string;
+	useVersions: boolean;
 	constructor(options) {
 		options.useBigIntExtension = true;
 		// Bound the per-encoder typed-structure dictionary. It is append-only and pinned on the
@@ -140,6 +141,11 @@ export class RecordEncoder extends StructonEncoder {
 
 		options.structPrototype = RecordObject.prototype;
 		super(options);
+		// Whether this store carries per-record version/timestamp metadata. Only versioned stores
+		// (primary table DBIs) prefix records with the metadata header; non-versioned internal DBIs
+		// (e.g. __dbis__, useVersions=false) must not — see the encode hook + harper#1307. Default to
+		// true when unspecified so an option that doesn't propagate can't silently strip prefixes.
+		this.useVersions = options.useVersions !== false;
 		// structon (the StructonEncoder base) always installs the struct write hook. For DBIs
 		// that don't opt into struct mode (non-primary, e.g. __dbis__), force it to bail (return
 		// 0) so objects are written in plain msgpackr records mode — decodable by readers without
@@ -155,6 +161,18 @@ export class RecordEncoder extends StructonEncoder {
 			// this handles our custom metadata encoding, prefixing the record with metadata, including the local
 			// timestamp into the audit record, invalidation status and residency information
 			if (timestampNextEncoding || metadataInNextEncoding >= 0) {
+				if (!this.useVersions) {
+					// harper#1307: this store does not carry version metadata, but the *NextEncoding globals
+					// are set — they belong to a versioned write in progress, NOT to us. We reach here when a
+					// nested write into this store (e.g. a node-id-map update via getThisNodeId) runs after
+					// recordUpdater staged the primary's metadata but before the primary encode, or when they
+					// leaked from a versioned write whose encode was skipped. Either way, encode our value
+					// plainly and LEAVE the globals untouched for their real owner: consuming/clearing them
+					// here would strip the primary record's prefix, and prefixing OUR record (e.g. a __dbis__
+					// `seq` cursor) makes it undecodable on the non-versioned read path (null → repl wedge).
+					lastValueEncoding = superEncode.call(this, record, options);
+					return lastValueEncoding;
+				}
 				let valueStart = 0;
 				const timestamp = timestampNextEncoding;
 				if (timestamp) {
@@ -638,6 +656,21 @@ export function setNextEncoding(timestamp: number, metadata: number, expiresAt =
 	nodeIdAtNextEncoding = nodeId;
 	residencyIdAtNextEncoding = residencyId;
 }
+/**
+ * Reset the module-level "next encoding" metadata to its no-metadata defaults. These globals are
+ * set just before a versioned encode and consumed (and reset) by the encode hook. If the consuming
+ * encode is skipped — e.g. a delete, whose record is never encoded — they would otherwise leak into
+ * the next encode on ANY store, including a non-versioned DBI (__dbis__) that then prefixes its
+ * record with another store's timestamp/nodeId and becomes undecodable. See harper#1307.
+ */
+export function clearNextEncoding() {
+	timestampNextEncoding = 0;
+	metadataInNextEncoding = -1;
+	expiresAtNextEncoding = -1;
+	nodeIdAtNextEncoding = -1;
+	residencyIdAtNextEncoding = 0;
+	additionalAuditRefsNextEncoding = undefined;
+}
 export function recordUpdater(store, tableId, auditStore) {
 	return function (
 		id,
@@ -830,6 +863,15 @@ export function recordUpdater(store, tableId, auditStore) {
 		} catch (error) {
 			error.message += ' id: ' + id + ' options: ' + putOptions;
 			throw error;
+		} finally {
+			// harper#1307: clear the metadata globals staged above so they cannot leak past this call
+			// into the next store's encode (notably a raw __dbis__ `seq`/residency write, which would
+			// then be prefixed and become undecodable). Unconditional is safe: a successful put encodes
+			// SYNCHRONOUSLY — rocksdb via putSync, and lmdb's put() also encodes inline at call time — so
+			// the encode hook already consumed and reset these globals before this finally runs, making
+			// the clear a no-op there. It only does work when no encode consumed them: a delete
+			// (record === undefined, never encoded) or a write that threw before its encode.
+			clearNextEncoding();
 		}
 	};
 }

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -158,21 +158,20 @@ export class RecordEncoder extends StructonEncoder {
 		if (!options.randomAccessStructure) this._writeStruct = () => 0;
 		const superEncode = this.encode;
 		this.encode = function (record, options?) {
+			if (!this.useVersions) {
+				// harper#1307: this store does not carry version metadata, so it never prefixes its records.
+				// Encode plainly and LEAVE any in-flight *NextEncoding globals untouched for their real owner:
+				// they belong to a versioned write (recordUpdater staged the primary's metadata and a nested
+				// __dbis__ write — e.g. via getThisNodeId — runs before the primary encode; or they leaked from
+				// a versioned write whose encode was skipped). Consuming/clearing them here would strip the
+				// primary record's prefix, and prefixing OUR record (e.g. a __dbis__ `seq` cursor) makes it
+				// undecodable on the non-versioned read path (null → replication wedge).
+				lastValueEncoding = superEncode.call(this, record, options);
+				return lastValueEncoding;
+			}
 			// this handles our custom metadata encoding, prefixing the record with metadata, including the local
 			// timestamp into the audit record, invalidation status and residency information
 			if (timestampNextEncoding || metadataInNextEncoding >= 0) {
-				if (!this.useVersions) {
-					// harper#1307: this store does not carry version metadata, but the *NextEncoding globals
-					// are set — they belong to a versioned write in progress, NOT to us. We reach here when a
-					// nested write into this store (e.g. a node-id-map update via getThisNodeId) runs after
-					// recordUpdater staged the primary's metadata but before the primary encode, or when they
-					// leaked from a versioned write whose encode was skipped. Either way, encode our value
-					// plainly and LEAVE the globals untouched for their real owner: consuming/clearing them
-					// here would strip the primary record's prefix, and prefixing OUR record (e.g. a __dbis__
-					// `seq` cursor) makes it undecodable on the non-versioned read path (null → repl wedge).
-					lastValueEncoding = superEncode.call(this, record, options);
-					return lastValueEncoding;
-				}
 				let valueStart = 0;
 				const timestamp = timestampNextEncoding;
 				if (timestamp) {

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -67,6 +67,14 @@ export function isReadOnlyMode(): boolean {
 function createOpenDBIObject(dupSort = false, isPrimary = false) {
 	return new OpenDBIObject(dupSort, isPrimary);
 }
+// The __dbis__ metadata DBI is non-versioned (OpenDBIObject useVersions=false); only versioned
+// primary stores carry the per-record metadata prefix. lmdb/rocksdb don't forward `useVersions` to
+// the encoder, so mark the live encoder explicitly — its encode hook uses this to write __dbis__
+// records plainly and never consume in-flight metadata staged for a primary write (harper#1307).
+function markInternalDbiNonVersioned(dbisDb: any): any {
+	if (dbisDb?.encoder) dbisDb.encoder.useVersions = false;
+	return dbisDb;
+}
 const logger = forComponent('storage');
 
 const DEFAULT_DATABASE_NAME = 'data';
@@ -466,7 +474,7 @@ function initStores(
 		} else {
 			attributesDbi = rootStore.openDB(INTERNAL_DBIS_NAME, internalDbiInit as any);
 		}
-		rootStore.dbisDb = attributesDbi;
+		rootStore.dbisDb = markInternalDbiNonVersioned(attributesDbi);
 	}
 
 	let auditStore = rootStore.auditStore;
@@ -1086,6 +1094,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 		} else {
 			attributesDbi = (rootStore as any).dbisDb = (rootStore as any).openDB(INTERNAL_DBIS_NAME, internalDbiInit as any);
 		}
+		markInternalDbiNonVersioned(attributesDbi);
 
 		exclusiveLock(); // get an exclusive lock on the database so we can verify that we are the only thread creating the table (and assigning the table id)
 		const existingTableMeta = (attributesDbi as any).getSync(dbiName);
@@ -1172,7 +1181,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 		} else {
 			(rootStore as any).dbisDb = (rootStore as any).openDB(INTERNAL_DBIS_NAME, internalDbiInit as any);
 		}
-		attributesDbi = (rootStore as any).dbisDb;
+		attributesDbi = markInternalDbiNonVersioned((rootStore as any).dbisDb);
 	}
 	Table.dbisDB = attributesDbi;
 	const indicesToRemove = [];

--- a/unitTests/resources/dbisEncodeLeak.test.js
+++ b/unitTests/resources/dbisEncodeLeak.test.js
@@ -1,0 +1,132 @@
+require('../testUtils');
+const assert = require('assert');
+const { RecordEncoder, setNextEncoding, clearNextEncoding } = require('#src/resources/RecordEncoder');
+const { Encoder } = require('msgpackr');
+
+// Shared structures persisted as an encoded buffer (mirrors how a DBI stores them under
+// Symbol.for('structures')), so structures cross between encoder instances.
+function sharedStore() {
+	let buf;
+	const meta = new Encoder();
+	return {
+		save(s) {
+			buf = meta.encode(s);
+			return true;
+		},
+		get() {
+			return buf ? meta.decode(buf) : undefined;
+		},
+	};
+}
+
+function makeEncoder(useVersions, store) {
+	return new RecordEncoder({
+		structures: [],
+		randomAccessStructure: false, // non-primary / __dbis__ style
+		useVersions,
+		getStructures: store.get,
+		saveStructures: store.save,
+	});
+}
+
+// A __dbis__ `seq` cursor value — the record at the center of harper#1307 / harper-pro#352.
+const seqRecord = { seqId: 1781538711832, nodes: [] };
+
+// The metadata a versioned delete leaves in the module-level *NextEncoding globals when its encode
+// is skipped (record === undefined): a timestamp + HAS_NODE_ID(64) + the deleted record's nodeId.
+const HAS_NODE_ID = 64;
+function simulateLeakedDelete() {
+	setNextEncoding(
+		/* timestamp */ 1781538711832,
+		/* metadata */ HAS_NODE_ID,
+		/* expiresAt */ -1,
+		/* nodeId */ 1,
+		/* residencyId */ 0
+	);
+}
+
+describe('RecordEncoder version-metadata gating (harper#1307)', () => {
+	// Defaults match clearNextEncoding(), so this guarantees a clean baseline regardless of order,
+	// and avoids leaking module state into other suites in the same mocha process.
+	beforeEach(() => clearNextEncoding());
+	afterEach(() => clearNextEncoding());
+
+	it('a non-versioned store ignores leaked metadata and encodes the record plainly (round-trips)', () => {
+		const store = sharedStore();
+		const enc = makeEncoder(false, store);
+		const clean = Buffer.from(enc.encode(seqRecord)); // baseline: no pending metadata
+
+		simulateLeakedDelete();
+		const afterLeak = Buffer.from(enc.encode(seqRecord));
+
+		assert.deepStrictEqual(
+			[...afterLeak],
+			[...clean],
+			'a useVersions:false store must not prefix its record with leaked timestamp/nodeId'
+		);
+		// The actual #352 failure mode: a prefixed __dbis__ record decodes to null on the non-versioned
+		// read path. With no prefix it round-trips cleanly.
+		const reader = makeEncoder(false, store);
+		assert.deepStrictEqual(reader.decode(afterLeak), seqRecord, 'seq record must round-trip, not decode to null');
+	});
+
+	it('does NOT consume in-flight metadata staged for a versioned write (no metadata theft)', () => {
+		// The nested-write case: recordUpdater stages the primary record's metadata, then a nested write
+		// into a non-versioned store (e.g. a node-id-map update) runs before the primary encode. The
+		// non-versioned encode must encode plainly AND leave the staged globals for the primary — if it
+		// consumed/cleared them, the primary record would lose its prefix.
+		const versioned = makeEncoder(true, sharedStore());
+		const nonVersioned = makeEncoder(false, sharedStore());
+		const cleanPrimary = Buffer.from(versioned.encode(seqRecord)); // baseline: no metadata
+
+		simulateLeakedDelete(); // the primary write's staged metadata
+		nonVersioned.encode(seqRecord); // nested non-versioned write — must not touch the globals
+		const primaryOut = Buffer.from(versioned.encode(seqRecord)); // the primary encode
+
+		assert.ok(
+			primaryOut.length > cleanPrimary.length,
+			`the primary write must still get its prefix after a nested non-versioned write (got ${primaryOut.length} vs ${cleanPrimary.length})`
+		);
+	});
+
+	it('a versioned store still applies pending metadata (no regression)', () => {
+		const store = sharedStore();
+		const enc = makeEncoder(true, store);
+		const clean = Buffer.from(enc.encode(seqRecord));
+
+		simulateLeakedDelete();
+		const withMeta = Buffer.from(enc.encode(seqRecord));
+
+		assert.ok(
+			withMeta.length > clean.length,
+			`a useVersions:true store must still apply the metadata prefix (got ${withMeta.length} vs ${clean.length})`
+		);
+	});
+
+	it('useVersions defaults to true when unspecified (option may not propagate to the encoder)', () => {
+		const store = sharedStore();
+		const enc = new RecordEncoder({
+			structures: [],
+			randomAccessStructure: false,
+			getStructures: store.get,
+			saveStructures: store.save,
+		});
+		assert.strictEqual(
+			enc.useVersions,
+			true,
+			'omitted useVersions must default to true so prefixes are never silently dropped'
+		);
+	});
+
+	it('clearNextEncoding() drops pending metadata so a later encode does not apply it', () => {
+		const store = sharedStore();
+		const enc = makeEncoder(true, store);
+		const clean = Buffer.from(enc.encode(seqRecord));
+
+		simulateLeakedDelete();
+		clearNextEncoding();
+		const after = Buffer.from(enc.encode(seqRecord));
+
+		assert.deepStrictEqual([...after], [...clean], 'clearNextEncoding must drop the pending metadata');
+	});
+});


### PR DESCRIPTION
## Summary

`RecordEncoder` stages a record's version/timestamp/nodeId metadata in **module-level `*NextEncoding` globals** just before the encode that consumes and resets them. Two paths apply those globals to the *wrong* record:

1. **Delete leak** — a delete (`record === undefined`) through `recordUpdater` stages the globals but skips the consuming `store.putSync`, so they leak into the next store's encode.
2. **Nested-write theft** — a nested write into a non-versioned store (e.g. a node-id-map update via `getThisNodeId`) runs *after* `recordUpdater` stages the primary's metadata but *before* the primary encode, and consumes them — corrupting that `__dbis__` record **and** stripping the primary record's prefix.

Either way a non-versioned `__dbis__` record (e.g. a replication `seq` cursor) is prefixed with a foreign timestamp/nodeId. The `__dbis__` read path (`useVersions=false`) can't parse that prefix, so the record **decodes to `null`** — wedging replication.

## Purpose

Root cause behind harper-pro#352. **Confirmed on a live in-place-upgraded node**: the wedged `system` DB held a single `[seq, 1]` cursor whose 27 bytes were a 16-byte metadata prefix (8-byte timestamp + 32-bit flags + `nodeId=1`, the leader) on a struct-11 `{seqId, nodes}` record; it decoded to `null` as-is and decoded cleanly once the prefix was accounted for. The structure table was fully intact — this is a metadata-framing leak, not a structure problem.

## Fix

- **Encode hook**: when the encoder is non-versioned, encode the value plainly and **leave the staged globals untouched** for their real owner. (Crucial: consuming/clearing here would strip a primary record's prefix when a nested `__dbis__` write precedes the primary encode.)
- **`recordUpdater` `finally`**: clear the globals **unconditionally**, so a skipped (delete) or aborted (throw-before-encode) write can't leak them. Safe because successful writes encode **synchronously** (rocksdb `putSync`; lmdb `put()` also encodes inline) and have already consumed+reset the globals before the `finally` runs.
- **`databases.ts`**: mark the `__dbis__` encoder `useVersions=false` at open. lmdb/rocksdb do **not** forward the store's `useVersions` to the encoder (verified), so it's set on the live encoder; the constructor defaults to `true` so a non-propagating option can never silently drop a primary prefix.

## Where to look

- `RecordEncoder.ts` encode hook (`!this.useVersions` early-out) and `recordUpdater`'s `finally`.
- `databases.ts` `markInternalDbiNonVersioned` + its three call sites (Gemini confirmed `INTERNAL_DBIS_NAME` is opened only at these three spots).

## Cross-model review (thorough; Codex + Gemini, two rounds)

The first round materially shaped the fix — surfaced and addressed:
- **Codex (confirmed empirically):** `useVersions` does **not** reach the encoder via lmdb/rocksdb option-forwarding → the gate was a no-op until I set it explicitly at open.
- **Codex:** the original `clearNextEncoding()` in the hook was too aggressive (clobbered an in-flight primary write's metadata via the nested-write path) → changed to **non-consuming**.
- **Gemini:** the original `finally` guard (`if (record === undefined)`) missed write-failures → made the clear **unconditional** (safe given synchronous encode).

A second Gemini pass on the revised diff returned no blockers (confirmed: no stale-global consumption by unrelated encodes; unconditional clear safe; all `__dbis__` open paths covered).

**Open item for a separate issue (not in this PR):** Gemini flagged that `lastValueEncoding` is stale on a delete and used unconditionally as the delete's audit-entry `encodedRecord` (`RecordEncoder.ts:838`) — a pre-existing, distinct concern from this encode-leak. Flagged for separate triage.

## Tests

`unitTests/resources/dbisEncodeLeak.test.js` (5) covers: non-versioned ignores leaked metadata + round-trips (the #352 failure mode); non-versioned does **not** consume a primary's staged metadata; versioned still applies metadata; `useVersions` default-true; `clearNextEncoding()`. No regressions across the RecordEncoder/replay/txn-tracking resource suites (44 passing). A full e2e repro is timing-dependent (per the harper-pro#352 bench); harper-pro#394 is the read-side resilience layer that lets affected nodes recover.

🤖 Generated by Claude Opus 4.8 (1M context).