### PR TITLE
fix(table): dedup re-delivered out-of-order writes before the resequencing walk (#1114)

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1898,6 +1898,32 @@ export function makeTable(options) {
 								write.skipped = true;
 								return; // out-of-order write already folded into this record
 							}
+							// Up-front keyed dedup (RocksDB): a re-delivered out-of-order write whose exact
+							// (version, nodeId) is already in the audit log is a duplicate that was already applied — skip
+							// it here instead of paying the O(depth) resequencing walk below only to discard it in the
+							// depth-cap block. This is the same keyed lookup that block performs, hoisted ahead of the walk.
+							// It is what catches transitive/proxied re-deliveries: they arrive buried below the record head
+							// (so replication's head-tie fast-skip can't see them) yet are exact duplicates. Keyed by nodeId,
+							// so it is correct across multiple source nodes. RocksDB-only: LMDB audit entries are keyed by
+							// local audit time, not version, so this version-keyed lookup doesn't apply there (LMDB keeps the
+							// exact unbounded walk). A miss (the keyed lookup can lag a back-to-back re-delivery — #1137)
+							// simply falls through to the walk, so this never changes correctness; the additionalAuditRefs
+							// check above remains the read-your-writes guard.
+							if (isRocksDB) {
+								const priorAudit = auditStore.get(txnTime, tableId, id, options?.nodeId);
+								if (
+									priorAudit &&
+									priorAudit.version === txnTime &&
+									precedesExistingVersion(
+										txnTime,
+										{ version: txnTime, localTime: txnTime, key: id, nodeId: priorAudit.nodeId },
+										options?.nodeId
+									) === 0
+								) {
+									write.skipped = true;
+									return; // duplicate already applied; avoid the resequencing walk
+								}
+							}
 							// incremental CRDT updates are only available with audit logging on
 							let localTime = existingEntry.localTime;
 							let auditedVersion = existingEntry.version;

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -452,6 +452,38 @@ describe('Transactions', () => {
 			assert.equal(record.count, 3, 're-delivered duplicate must not double-apply the commutative op');
 		});
 
+		// #1114: once a later in-order write drops the out-of-order ref from the record, a re-delivery can no
+		// longer be caught by the additionalAuditRefs front-check. The up-front keyed audit lookup must catch
+		// it BEFORE the resequencing walk, so the deep-walk/depth-cap path is never taken (this is the case
+		// that pegged the event loop on transitive re-deliveries in production).
+		it('deduplicates a re-delivered out-of-order write up front, without the deep walk (#1114)', async function () {
+			if (isLMDB) return; // RocksDB-only up-front keyed dedup (LMDB keeps the exact unbounded walk)
+			const { logger } = require('#src/utility/logging/logger');
+			const id = 1114002;
+			const base = Date.now();
+			await TxnTest.put(id, { name: 'seed', count: 0 }, { timestamp: base });
+			const depth = 1010; // deeper than MAX_OUT_OF_ORDER_AUDIT_DEPTH so an unguarded walk would cap
+			for (let i = 1; i <= depth; i++) await TxnTest.patch(id, { seq: i }, { timestamp: base + 10 * i });
+			// Out-of-order commutative write (older than every patch); records an additionalAuditRef.
+			await TxnTest.patch(id, { count: { __op__: 'add', value: 7 } }, { timestamp: base + 5 });
+			assert.equal((await TxnTest.get(id)).count, 7, 'out-of-order op applied once');
+			// A newer in-order write rewrites the record and drops the ref, so the front-check can no longer see it.
+			await TxnTest.patch(id, { seq: depth + 1 }, { timestamp: base + 10 * (depth + 2) });
+			// Re-deliver the same out-of-order write: must be deduped up front, never reaching the depth-cap walk.
+			const originalWarn = logger.warn;
+			let capWarned = false;
+			logger.warn = (msg) => {
+				if (typeof msg === 'string' && msg.includes('exceeded depth cap')) capWarned = true;
+			};
+			try {
+				await TxnTest.patch(id, { count: { __op__: 'add', value: 7 } }, { timestamp: base + 5 });
+			} finally {
+				logger.warn = originalWarn;
+			}
+			assert.equal((await TxnTest.get(id)).count, 7, 're-delivered duplicate must not double-apply');
+			assert.equal(capWarned, false, 're-delivery should be deduped up front, not via the deep walk');
+		});
+
 		it('Can merge replication updates', async function () {
 			const context = {};
 			await transaction(context, async () => {


### PR DESCRIPTION
## Summary

Hoist the keyed audit-log duplicate lookup **ahead of** the out-of-order resequencing walk in `Table.commit`. A re-delivered out-of-order write whose exact `(version, nodeId)` is already in the audit log is now dropped in O(1) instead of walking the full audit chain (up to `MAX_OUT_OF_ORDER_AUDIT_DEPTH`) only to discard it in the depth-cap block.

## Why

On a production cluster (#1114), transitive/proxied replication (`viaNodeId`) re-delivers already-applied patches out-of-order. On high-churn records with deep pure-`patch` histories, each re-delivery drove an ~1000-step **synchronous** walk in the commit path → event-loop starvation (`JavaScript execution has taken too long`) → replication ping-timeouts → dropped subscriptions and stalled catch-up.

A live logpoint at the depth-cap site confirmed the mechanism: the capped walks were exact `(version, nodeId)` duplicates (the existing `auditStore.get(...)` matched, `dupVerMatch=true`) — i.e. the dedup the cap block already does, just reached only *after* the full walk. This hoists that lookup before the walk.

It complements the existing guards: the `additionalAuditRefs` front-check (#1137) catches a re-delivery while the ref is still on the record; this keyed lookup catches the case where a later in-order write has since **dropped** the ref, which is exactly the transitive-re-delivery case observed in production. Keyed by `nodeId`, so it's correct across multiple source nodes.

## Where to look

- `resources/Table.ts` — the new `if (isRocksDB)` keyed-dedup block at the top of the `precedesExisting <= 0` audit branch. **RocksDB-only** (LMDB audit entries are keyed by local audit time, not version, so the version-keyed lookup doesn't apply there; LMDB keeps the exact unbounded walk). A keyed-lookup miss simply falls through to the existing walk — **no correctness change**, purely a fast-path.
- `unitTests/resources/transaction.test.js` — new test: a re-delivery *after* a ref-dropping in-order write is deduped without taking the depth-cap path. Verified to fail without the change (it would take the deep walk) and that the record value is identical with or without it.

## Notes for the reviewer

- **Not a 5.1 regression** — the walk, depth cap, `additionalAuditRefs`, and transitive delivery all exist in `v5.0`; the same latent path. Good **backport/patch candidate for v5.0** (the `auditStore.get` lookup it relies on already exists in v5.0's cap block).
- **Open follow-up, not in this PR:** this *absorbs* the redundant transitive re-deliveries cheaply but does not reduce their *volume*. The proxy-resume start-time relay that generates them is a separate workstream worth its own ticket.

<sub>Generated by Claude (Opus 4.8).</sub>

## Review status (open item for the human reviewer)

- **Codex review:** clean (no actionable issues).
- **Gemini review:** attempted twice via `agy`; it failed to produce findings (workspace-resolution flakiness in the worktree; `gemini` CLI unavailable). Compensated with a careful self-review (the change is a faithful hoist of the existing depth-cap-block lookup with the identical identity-tie guard). A second human/model pass on the correctness argument is welcome.
- **`test:unit:main`** could not complete locally — it failed on a storage-path env issue (unrelated to this change; passed once `HDB_ROOT`/`STORAGE_PATH` were set) and then hung on an unrelated `ComponentLoader` integration test. The change is covered by `test:unit:resources` (passing, incl. the new regression test). CI should exercise the full suite.