### PR TITLE
De-flake drop suite: tolerate already-dropped column family and serialize dropTable

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -111,6 +111,15 @@ const CACHEABLE_STATUS_CODES = new Set([200, 203, 204, 206, 300, 301, 308, 404, 
 envMngr.initSync();
 const LMDB_PREFETCH_WRITES = envMngr.get(CONFIG_PARAMS.STORAGE_PREFETCHWRITES);
 const LOCK_TIMEOUT = 10000;
+// Tolerate a redundant column family drop. Drops are broadcast to every worker
+// thread and each holds its own handle to the same underlying family, so a
+// concurrent worker may already have dropped it; the storage engine reports
+// that as "Column family already dropped!". The family being gone is the
+// intended outcome, so swallow that specific error and rethrow anything else.
+function ignoreAlreadyDropped(error: any): void {
+	if (error?.message?.includes('Column family already dropped')) return;
+	throw error;
+}
 // A frozen record we may need to copy-on-mutate before stamping it (records are immutable — decoded
 // records are frozen and 5.2 record caching relies on it). Only plain/record objects qualify: never
 // a Buffer/typed-array (spreading would corrupt the binary into a {0:.., 1:..} object) or a primitive
@@ -1057,28 +1066,73 @@ export function makeTable(options) {
 			}
 			if (databaseName === databasePath) {
 				// part of a database.
-				// Drop the column families and AWAIT them. Previously the catalog
-				// metadata was removed (synchronous removeSync) before primaryStore.drop(),
-				// and the drops were fire-and-forget (their rejections swallowed). If a
-				// column family was corrupt/half-initialized the drop would fail, yet the
-				// catalog entry was already gone - an orphaned "ghost" column family that
-				// poisons same-name recreates. By awaiting the drops before touching the
-				// catalog, a failed drop surfaces as the operation's error and the
-				// tombstoned catalog rows survive for the startup reconcile.
-				const drops = [];
-				for (const attribute of attributes) {
-					const index = indices[attribute.name];
-					if (index) drops.push(index.drop());
+				// Drop the column families, then remove the catalog metadata - never
+				// the reverse: a removed-then-failed drop orphans a "ghost" column
+				// family that poisons same-name recreates, so a genuine drop failure
+				// must surface and leave the tombstoned catalog rows for the reconcile.
+				//
+				// A drop is broadcast to every worker thread, and each holds its own
+				// handle to the same underlying column family, so a concurrent worker
+				// (or completeInterruptedDrop) may already have dropped it - surfaced
+				// as "Column family already dropped!". That is the intended end state,
+				// not a failure, so tolerate it. The catalog rows are removed only if
+				// this drop's tombstone is still the live primary row: a concurrent
+				// same-name create completes the interrupted drop and writes fresh
+				// catalog rows, and clobbering those would orphan the new table.
+				const removeTombstonedCatalog = () => {
+					const currentPrimary = (dbisDb as any).getSync(TableResource.tableName + '/');
+					if (!currentPrimary?.dropping) return false;
+					for (const attribute of attributes) {
+						dbisDb.remove(TableResource.tableName + '/' + attribute.name);
+					}
+					dbisDb.remove(TableResource.tableName + '/');
+					return true;
+				};
+				const rootStore = primaryStore.rootStore;
+				if (rootStore instanceof RocksDatabase) {
+					// Serialize the drops + catalog removal against a concurrent
+					// same-name create (and completeInterruptedDrop) under the database's
+					// 'update-attributes' exclusive lock - the same lock the create path
+					// holds. It is a synchronous spin lock that blocks the event loop, so
+					// the locked section MUST stay synchronous: drop with dropSync (as
+					// completeInterruptedDrop does), never an awaited drop(), or a
+					// concurrent create's spin would deadlock waiting on a drop that the
+					// blocked event loop can never resolve.
+					while (!rootStore.tryLock('update-attributes')) {}
+					let removed = false;
+					try {
+						for (const attribute of attributes) {
+							const index = indices[attribute.name];
+							if (index)
+								try {
+									index.dropSync();
+								} catch (error) {
+									ignoreAlreadyDropped(error);
+								}
+						}
+						try {
+							primaryStore.dropSync();
+						} catch (error) {
+							ignoreAlreadyDropped(error);
+						}
+						removed = removeTombstonedCatalog();
+					} finally {
+						rootStore.unlock('update-attributes');
+					}
+					if (removed) await dbisDb.committed;
+				} else {
+					// LMDB: no shared column-family double-drop, and its engine lock is
+					// transactional rather than this spin lock, so keep the awaited drop
+					// plus the same tombstone-guarded catalog removal.
+					const drops = [];
+					for (const attribute of attributes) {
+						const index = indices[attribute.name];
+						if (index) drops.push(index.drop().catch(ignoreAlreadyDropped));
+					}
+					drops.push(primaryStore.drop().catch(ignoreAlreadyDropped));
+					await Promise.all(drops);
+					if (removeTombstonedCatalog()) await dbisDb.committed;
 				}
-				drops.push(primaryStore.drop());
-				await Promise.all(drops);
-				// Column families are gone; remove the catalog metadata (including
-				// the tombstoned primary entry).
-				for (const attribute of attributes) {
-					dbisDb.remove(TableResource.tableName + '/' + attribute.name);
-				}
-				dbisDb.remove(TableResource.tableName + '/');
-				await dbisDb.committed;
 			} else {
 				// legacy table per database
 				await primaryStore.close();

--- a/unitTests/resources/dropTableGhost.test.js
+++ b/unitTests/resources/dropTableGhost.test.js
@@ -21,6 +21,19 @@ function getDbisDb() {
 	return database({ database: TEST_DB, table: null }).dbisDb;
 }
 
+// dropTable drops column families with dropSync() on RocksDB (under the
+// exclusive lock) and with the awaited drop() on LMDB, so stub both to make a
+// test engine-agnostic under `test:unit` and `test:unit:lmdb`. Returns a
+// restore function.
+function stubFailingDrop(store, error) {
+	const original = { drop: store.drop, dropSync: store.dropSync };
+	store.dropSync = () => {
+		throw error;
+	};
+	store.drop = () => Promise.reject(error);
+	return () => Object.assign(store, original);
+}
+
 describe('dropTable ghost regression', () => {
 	before(() => {
 		setupTestDBPath();
@@ -77,12 +90,11 @@ describe('dropTable ghost regression', () => {
 	it('surfaces a failed column family drop and completes the drop on recreate', async function () {
 		const Doomed = defineTable('GhostFailDrop');
 		await Doomed.put({ id: 1, str: 'data' });
-		const originalDrop = Doomed.primaryStore.drop;
-		Doomed.primaryStore.drop = () => Promise.reject(new Error('injected drop failure'));
+		const restore = stubFailingDrop(Doomed.primaryStore, new Error('injected drop failure'));
 		try {
 			await assert.rejects(() => Doomed.dropTable(), /injected drop failure/);
 		} finally {
-			Doomed.primaryStore.drop = originalDrop;
+			restore();
 		}
 		// the table is gone from the live schema (no half-alive table)...
 		assert.equal(databases[TEST_DB]?.GhostFailDrop, undefined, 'failed drop must still remove the table from memory');
@@ -95,5 +107,64 @@ describe('dropTable ghost regression', () => {
 		assert.equal((await Fresh.get(2)).str, 'fresh');
 		assert.equal(await Fresh.get(1), undefined, 'old data must not resurrect');
 		await Fresh.dropTable();
+	});
+
+	it('tolerates an already-dropped column family and completes the drop', async function () {
+		const Raced = defineTable('GhostAlreadyDropped');
+		await Raced.put({ id: 1, str: 'data' });
+		// A concurrent worker already dropped the shared column family (drops are
+		// broadcast to every thread), so the storage engine reports the redundant
+		// drop as "Column family already dropped!". The family being gone is the
+		// intended outcome, so the drop operation must succeed rather than fail.
+		const restore = stubFailingDrop(Raced.primaryStore, new Error('Invalid argument: Column family already dropped!'));
+		try {
+			await Raced.dropTable();
+		} finally {
+			restore();
+		}
+		// the table is removed from the live schema...
+		assert.equal(
+			databases[TEST_DB]?.GhostAlreadyDropped,
+			undefined,
+			'tolerated drop must remove the table from memory'
+		);
+		// ...and because the drop is treated as success, the catalog rows (and any
+		// tombstone) are removed too - no ghost left behind for the reconcile.
+		assert.equal(
+			getDbisDb().getSync('GhostAlreadyDropped/'),
+			undefined,
+			'catalog rows must be removed on a tolerated drop'
+		);
+	});
+
+	it('does not clobber a same-name table created during a tolerated drop race', async function () {
+		// Exercises the RocksDB drop path (synchronous dropSync under the exclusive
+		// lock) and its tombstone-guarded catalog removal; the LMDB path keeps the
+		// awaited drop() and is covered by the create-over-tombstone case above.
+		if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return this.skip();
+		const Raced = defineTable('GhostDropRaceCreate');
+		await Raced.put({ id: 1, str: 'data' });
+		const dbisDb = getDbisDb();
+		const originalDrop = Raced.primaryStore.dropSync;
+		// Simulate the race: while this drop holds the lock, the catalog already
+		// carries a fresh, non-tombstoned row for a same-name table (as a concurrent
+		// create's completeInterruptedDrop would have left it). The guard must see
+		// the fresh row on its re-read and skip removal so it is not clobbered.
+		Raced.primaryStore.dropSync = () => {
+			const fresh = { ...dbisDb.getSync('GhostDropRaceCreate/') };
+			delete fresh.dropping;
+			dbisDb.putSync('GhostDropRaceCreate/', fresh);
+			throw new Error('Column family already dropped!');
+		};
+		try {
+			await Raced.dropTable();
+		} finally {
+			Raced.primaryStore.dropSync = originalDrop;
+		}
+		// the new table's catalog row must survive - cleanup only runs when this
+		// drop's own tombstone is still the live primary row
+		const survived = dbisDb.getSync('GhostDropRaceCreate/');
+		assert.ok(survived, 'a same-name table created during the drop must keep its catalog row');
+		assert.ok(!survived.dropping, 'the surviving row must be the fresh (non-tombstoned) create');
 	});
 });


### PR DESCRIPTION
## Summary
De-flakes the intermittent `Drop number table` failure in `Integration Tests 1/6` (`AssertionError: Drop failed: ... Column family already dropped!`, usually followed by a cascading `Database not open` / `Delete operations` timeout). `Table.dropTable()` now (1) tolerates a column-family drop that reports "Column family already dropped!", and (2) on RocksDB runs the drops + catalog removal under the database's `update-attributes` exclusive lock to close a drop/same-name-create race.

## Purpose / root cause
A `drop` is broadcast to every worker thread, and each thread holds its own handle to the same underlying column family. A concurrent worker (or `completeInterruptedDrop`) can drop a shared family first, so the originating `drop_table` then hits "Column family already dropped!" and fails the operation — intermittently, depending on thread scheduling (hence cross-platform / cross-Node flakiness). The family being gone is the intended end state, so the drop tolerates it. Genuine drop failures still surface and leave the tombstone for the reconcile.

## Where to look
- **Spin lock across the drop (please sanity-check the deadlock reasoning).** The RocksDB path serializes the drops + catalog removal under the same `update-attributes` lock the create path / `completeInterruptedDrop` hold. That lock is the synchronous spin lock (CORE-3064); like the create path, it is held **only across synchronous work** — the drops use `dropSync()` (as `completeInterruptedDrop` does) and `await dbisDb.committed` runs *after* the lock is released. Holding the spin lock across an `await` would deadlock, so the locked section is deliberately await-free.
- **Tombstone-guarded catalog removal.** Catalog rows are removed only when this drop's own tombstone is still the live primary row, so a concurrent same-name create's fresh rows are never clobbered. Under the lock this check+remove is atomic w.r.t. the create path.
- **LMDB path** keeps the awaited `drop()` + guarded removal (transactional locking, no shared-CF double-drop). The new clobber-guard unit test is RocksDB-scoped; the LMDB guard path is covered by the existing create-over-tombstone test.

## Pairing
Pairs with **HarperFast/rocksdb-js#656**, which makes the column-family drop idempotent at the source. This harper-side change de-flakes independently and does **not** require the rocksdb-js release/bump to land.

## Tests
`unitTests/resources/dropTableGhost.test.js`: tolerance + the drop/create clobber guard; run under both `test:unit` and `test:unit:lmdb`.

---
Generated by an LLM (Claude Opus 4.8). Cross-model reviewed (Codex + Harper deep-review): the catalog-clobber and the cross-thread drop/create race were both raised and are addressed here (the latter via the lock); the one item left for a human is verifying the spin-lock deadlock reasoning called out above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)