### PR TITLE
fix(table): reject non-object record roots; guard scan freeze (#1298)

### DIFF
--- a/integrationTests/fixtures/bytes-scan-crash/config.yaml
+++ b/integrationTests/fixtures/bytes-scan-crash/config.yaml
@@ -1,0 +1,5 @@
+# Regression fixture for HarperFast/harper#1298 — octet-stream sub-attribute write
+# stores a bare-TypedArray-root record that must not crash table scans.
+graphqlSchema:
+  files: '*.graphql'
+rest: true

--- a/integrationTests/fixtures/bytes-scan-crash/schema.graphql
+++ b/integrationTests/fixtures/bytes-scan-crash/schema.graphql
@@ -1,0 +1,11 @@
+# Regression schema for HarperFast/harper#1298.
+#
+# A Bytes column plus an open table so an `application/octet-stream` PUT to a
+# sub-attribute (PUT /Item/<id>/<attr>) can store a record whose materialized root
+# value is a bare TypedArray — the value that used to throw on Object.freeze and
+# permanently wedge every scan over the table.
+type Item @table @export {
+	id: ID @primaryKey
+	bytes: Bytes
+	note: String
+}

--- a/integrationTests/resources/bytes-scan-crash.test.ts
+++ b/integrationTests/resources/bytes-scan-crash.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Regression: non-object record roots are rejected on write, so they can never wedge
+ * a table's scans (#1298).
+ *
+ * Background: `application/octet-stream` deserializes to the raw Buffer, and a path like
+ * `/Item/<id>/bytes` is just a record whose primary key is the compound string "<id>/bytes"
+ * (slashes are not attribute paths — only `id.attr` dot syntax is). So an octet-stream PUT
+ * stored a record whose entire value was a bare TypedArray. V8 refuses to Object.freeze a
+ * non-empty TypedArray, so every unfiltered scan over the table then 500'd — and because the
+ * key was the compound string, a point GET/DELETE by the plain id never matched it, leaving the
+ * table permanently wedged.
+ *
+ * Fix: the record-write path (Table._writeUpdate) rejects any non-object record root (primitive,
+ * string/number, or bare binary) with a 400 — binary belongs in a Bytes/Blob attribute, not as
+ * the whole record. Messages (MQTT/topic publish, via _writePublish) are a separate path and may
+ * still carry raw payloads. This
+ * test asserts the bad writes are blocked, a legitimate binary-in-attribute record round-trips
+ * and scans cleanly, and no poison can be created. (The read-side freeze guard that lets an
+ * already-poisoned table recover after upgrade is covered by unitTests/resources/freeze-record.test.js.)
+ *
+ * Skipped on Windows (restart_service http_workers crashes the instance — harper#549).
+ *
+ * Implements HarperFast/harper#1298.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok } from 'node:assert/strict';
+import { resolve } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import request from 'supertest';
+import { encode as cborEncode } from 'cbor-x';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
+import { createApiClient } from '../apiTests/utils/client.mjs';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, '../fixtures/bytes-scan-crash');
+const skipSuite = process.platform === 'win32';
+const SCHEMA = 'data';
+const TABLE = 'Item';
+const BLOB_BYTES = Buffer.from([0, 1, 2, 253, 254, 255, 0x89, 0x50, 0x4e, 0x47]);
+
+suite('non-object record roots rejected on write (#1298)', { skip: skipSuite }, (ctx: ContextWithHarper) => {
+	let client: ReturnType<typeof createApiClient>;
+	let restURL: string;
+	let authHeaders: Record<string, string>;
+
+	before(async () => {
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: {}, env: {} });
+		client = createApiClient(ctx.harper);
+		restURL = client.restURL;
+		authHeaders = { Authorization: client.headers.Authorization, Connection: 'close' };
+
+		// Wait for the REST route to come up.
+		const deadline = Date.now() + 30_000;
+		while (Date.now() < deadline) {
+			try {
+				const probe = await client.reqRest(`/${TABLE}/`).timeout(3_000);
+				if (probe.status !== 404) break;
+			} catch {
+				/* not ready */
+			}
+			await sleep(250);
+		}
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	// The original repro: octet-stream PUT whose body becomes a bare-TypedArray record root.
+	// Must be rejected with a 400, not stored (and never a 500).
+	test('octet-stream bare-buffer PUT is rejected with 400', async () => {
+		const r = await request(restURL)
+			.put(`/${TABLE}/poison/bytes`)
+			.set(authHeaders)
+			.set('Content-Type', 'application/octet-stream')
+			.send(BLOB_BYTES)
+			.timeout(10_000);
+		ok(r.status === 400, `expected 400, got ${r.status}: ${r.text}`);
+	});
+
+	// A plain octet-stream PUT to a record id (no slash) is the same bare-root shape.
+	test('octet-stream bare-buffer PUT to a plain id is rejected with 400', async () => {
+		const r = await request(restURL)
+			.put(`/${TABLE}/blobby`)
+			.set(authHeaders)
+			.set('Content-Type', 'application/octet-stream')
+			.send(BLOB_BYTES)
+			.timeout(10_000);
+		ok(r.status === 400, `expected 400, got ${r.status}: ${r.text}`);
+	});
+
+	// String / number JSON bodies are non-object roots too.
+	test('primitive (string/number) record roots are rejected with 400', async () => {
+		const asString = await request(restURL)
+			.put(`/${TABLE}/str`)
+			.set(authHeaders)
+			.set('Content-Type', 'application/json')
+			.send('"just a string"')
+			.timeout(10_000);
+		ok(asString.status === 400, `string root: expected 400, got ${asString.status}: ${asString.text}`);
+
+		const asNumber = await request(restURL)
+			.put(`/${TABLE}/num`)
+			.set(authHeaders)
+			.set('Content-Type', 'application/json')
+			.send('42')
+			.timeout(10_000);
+		ok(asNumber.status === 400, `number root: expected 400, got ${asNumber.status}: ${asNumber.text}`);
+	});
+
+	// The supported way to store binary: a Bytes attribute inside an object record. Round-trips
+	// and scans cleanly.
+	test('binary inside a Bytes attribute writes and scans cleanly', async () => {
+		const put = await request(restURL)
+			.put(`/${TABLE}/good`)
+			.set(authHeaders)
+			.set('Content-Type', 'application/cbor')
+			.send(cborEncode({ id: 'good', bytes: BLOB_BYTES, note: 'object-root' }))
+			.timeout(10_000);
+		ok(put.status >= 200 && put.status < 300, `Bytes-attribute PUT should succeed, got ${put.status}: ${put.text}`);
+
+		const sql = await client
+			.req()
+			.send({ operation: 'sql', sql: `SELECT * FROM ${SCHEMA}.${TABLE}` })
+			.timeout(10_000);
+		ok(sql.status === 200, `SELECT * expected 200, got ${sql.status}: ${JSON.stringify(sql.body)}`);
+		ok(
+			Array.isArray(sql.body) && sql.body.some((r: any) => r.id === 'good'),
+			`expected the 'good' row, got ${JSON.stringify(sql.body)}`
+		);
+
+		const scan = await request(restURL)
+			.get(`/${TABLE}/`)
+			.set(authHeaders)
+			.set('Accept', 'application/json')
+			.timeout(10_000);
+		ok(scan.status === 200, `REST scan expected 200, got ${scan.status}: ${scan.text}`);
+	});
+
+	// Belt-and-suspenders: after all the rejected writes, the table is still fully scannable —
+	// no poison record slipped through.
+	test('no poison was created — table remains scannable', async () => {
+		const sql = await client
+			.req()
+			.send({ operation: 'sql', sql: `SELECT * FROM ${SCHEMA}.${TABLE}` })
+			.timeout(10_000);
+		ok(sql.status === 200, `expected 200, got ${sql.status}: ${JSON.stringify(sql.body)}`);
+	});
+});

--- a/integrationTests/resources/bytes-scan-crash.test.ts
+++ b/integrationTests/resources/bytes-scan-crash.test.ts
@@ -89,6 +89,17 @@ suite('non-object record roots rejected on write (#1298)', { skip: skipSuite }, 
 		ok(r.status === 400, `expected 400, got ${r.status}: ${r.text}`);
 	});
 
+	// A bare JSON array is also a non-object root (typeof === 'object' but Array.isArray === true).
+	test('bare JSON array record root is rejected with 400', async () => {
+		const r = await request(restURL)
+			.put(`/${TABLE}/arr`)
+			.set(authHeaders)
+			.set('Content-Type', 'application/json')
+			.send('[1,2,3]')
+			.timeout(10_000);
+		ok(r.status === 400, `array root: expected 400, got ${r.status}: ${r.text}`);
+	});
+
 	// String / number JSON bodies are non-object roots too.
 	test('primitive (string/number) record roots are rejected with 400', async () => {
 		const asString = await request(restURL)

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1920,7 +1920,7 @@ export function makeTable(options) {
 									received = `${recordUpdate.constructor?.name ?? 'binary'} of ${recordUpdate.byteLength} bytes`;
 								} else {
 									const full = stringify(recordUpdate);
-									received = full.length > 200 ? full.slice(0, 200) + '...' : full;
+									received = full == null ? String(recordUpdate) : full.length > 200 ? full.slice(0, 200) + '...' : full;
 								}
 								throw new ClientError(
 									`A record must be an object, but received ${received}. To store binary data, put it ` +

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1900,18 +1900,28 @@ export function makeTable(options) {
 					if (fullUpdate || (recordUpdate && hasChanges(this.#changes === recordUpdate ? this : recordUpdate))) {
 						if (!(context as any)?.source) {
 							transaction.checkOverloaded();
-							// A record must be a plain object. Reject primitive, string/number, and bare-binary
-							// roots — e.g. a raw Buffer from an application/octet-stream PUT, or a JSON string/number
-							// body. Such a root carries no primary key or attributes, is meaningless to
-							// SQL/get-attributes, and a bare TypedArray root additionally throws on Object.freeze
-							// during scans (#1298). Binary data belongs in a Bytes/Blob attribute. (Messages go
-							// through _writePublish, not here, so raw publish payloads are unaffected.)
+							// A record must be a plain object. Reject primitive, string/number, bare-binary,
+							// and bare-array roots — e.g. a raw Buffer from an application/octet-stream PUT, a
+							// JSON string/number body, or a top-level JSON array. Such roots carry no primary
+							// key or attributes, are meaningless to SQL/get-attributes, and a bare TypedArray
+							// root additionally throws on Object.freeze during scans (#1298). Binary data belongs
+							// in a Bytes/Blob attribute. (Messages go through _writePublish, not here, so raw
+							// publish payloads are unaffected.)
 							const isBinaryRoot = ArrayBuffer.isView(recordUpdate) || recordUpdate instanceof ArrayBuffer;
-							if (recordUpdate === null || typeof recordUpdate !== 'object' || isBinaryRoot) {
-								// Avoid dumping every byte of a large binary body into the error.
-								const received = isBinaryRoot
-									? `${recordUpdate.constructor?.name ?? 'binary'} of ${recordUpdate.byteLength} bytes`
-									: stringify(recordUpdate);
+							if (
+								recordUpdate === null ||
+								typeof recordUpdate !== 'object' ||
+								isBinaryRoot ||
+								Array.isArray(recordUpdate)
+							) {
+								// Avoid dumping every byte of a large binary body or huge payload into the error.
+								let received: string;
+								if (isBinaryRoot) {
+									received = `${recordUpdate.constructor?.name ?? 'binary'} of ${recordUpdate.byteLength} bytes`;
+								} else {
+									const full = stringify(recordUpdate);
+									received = full.length > 200 ? full.slice(0, 200) + '...' : full;
+								}
 								throw new ClientError(
 									`A record must be an object, but received ${received}. To store binary data, put it ` +
 										`in a Bytes or Blob attribute (e.g. a record like { "${primaryKey ?? 'id'}": …, "data": <bytes> }).`

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1920,7 +1920,8 @@ export function makeTable(options) {
 									received = `${recordUpdate.constructor?.name ?? 'binary'} of ${recordUpdate.byteLength} bytes`;
 								} else {
 									const full = stringify(recordUpdate);
-									received = full == null ? String(recordUpdate) : full.length > 200 ? full.slice(0, 200) + '...' : full;
+									received =
+										full == null ? String(recordUpdate) : full.length > 200 ? full.slice(0, 200) + '...' : full;
 								}
 								throw new ClientError(
 									`A record must be an object, but received ${received}. To store binary data, put it ` +

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1919,9 +1919,8 @@ export function makeTable(options) {
 								if (isBinaryRoot) {
 									received = `${recordUpdate.constructor?.name ?? 'binary'} of ${recordUpdate.byteLength} bytes`;
 								} else {
-									const full = stringify(recordUpdate);
-									received =
-										full == null ? String(recordUpdate) : full.length > 200 ? full.slice(0, 200) + '...' : full;
+									const full = stringify(recordUpdate) ?? typeof recordUpdate;
+									received = full.length > 200 ? full.slice(0, 200) + '...' : full;
 								}
 								throw new ClientError(
 									`A record must be an object, but received ${received}. To store binary data, put it ` +

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -140,6 +140,18 @@ function isFrozenRecordObject(value: any): boolean {
 		Object.isFrozen(value)
 	);
 }
+// Freeze a decoded record value for cache integrity, guarding the bare-TypedArray-root case:
+// V8 throws "Cannot freeze array buffer views with elements" on Object.freeze of a non-empty
+// TypedArray/DataView (#1298). _writeUpdate now rejects such roots on write, but this read-side
+// guard still backstops records that bypass validation (source/cache population, replication of
+// legacy data) and lets an already-poisoned table be read again after upgrade. The freeze is
+// shallow anyway, so a typed-array root needs none. Only freeze plain objects: skip ArrayBuffer
+// views/ArrayBuffers, and short-circuit primitives/null/undefined to avoid a needless native
+// Object.freeze call on the hot read/scan path.
+export function freezeRecord(value: any): void {
+	if (value !== null && typeof value === 'object' && !ArrayBuffer.isView(value) && !(value instanceof ArrayBuffer))
+		Object.freeze(value);
+}
 export const INVALIDATED = 1;
 export const EVICTED = 8; // note that 2 is reserved for timestamps
 const TEST_WRITE_KEY_BUFFER = Buffer.allocUnsafeSlow(8192);
@@ -1888,6 +1900,23 @@ export function makeTable(options) {
 					if (fullUpdate || (recordUpdate && hasChanges(this.#changes === recordUpdate ? this : recordUpdate))) {
 						if (!(context as any)?.source) {
 							transaction.checkOverloaded();
+							// A record must be a plain object. Reject primitive, string/number, and bare-binary
+							// roots — e.g. a raw Buffer from an application/octet-stream PUT, or a JSON string/number
+							// body. Such a root carries no primary key or attributes, is meaningless to
+							// SQL/get-attributes, and a bare TypedArray root additionally throws on Object.freeze
+							// during scans (#1298). Binary data belongs in a Bytes/Blob attribute. (Messages go
+							// through _writePublish, not here, so raw publish payloads are unaffected.)
+							const isBinaryRoot = ArrayBuffer.isView(recordUpdate) || recordUpdate instanceof ArrayBuffer;
+							if (recordUpdate === null || typeof recordUpdate !== 'object' || isBinaryRoot) {
+								// Avoid dumping every byte of a large binary body into the error.
+								const received = isBinaryRoot
+									? `${recordUpdate.constructor?.name ?? 'binary'} of ${recordUpdate.byteLength} bytes`
+									: stringify(recordUpdate);
+								throw new ClientError(
+									`A record must be an object, but received ${received}. To store binary data, put it ` +
+										`in a Bytes or Blob attribute (e.g. a record like { "${primaryKey ?? 'id'}": …, "data": <bytes> }).`
+								);
+							}
 							// Records are intentionally immutable: decoded records are frozen (and 5.2 record
 							// caching relies on it), so mutating in place would corrupt cached/shared state.
 							// validate() coerces values and we stamp created/updated times + the primary key
@@ -3957,7 +3986,7 @@ export function makeTable(options) {
 										});
 										if (value?.then) hasPromises = true;
 										// for now, we shouldn't be getting promises until rocksdb
-										if (TableResource.loadAsInstance === false) Object.freeze(returnEntry ? value?.value : value);
+										if (TableResource.loadAsInstance === false) freezeRecord(returnEntry ? value?.value : value);
 										return value;
 									});
 									return relationship.filterMissing
@@ -3972,7 +4001,7 @@ export function makeTable(options) {
 									transaction: txnForContext(context).getReadTxn(),
 								});
 								// for now, we shouldn't be getting promises until rocksdb
-								if (TableResource.loadAsInstance === false) Object.freeze(returnEntry ? value?.value : value);
+								if (TableResource.loadAsInstance === false) freezeRecord(returnEntry ? value?.value : value);
 								return value;
 							};
 							attribute.set = (object, related) => {
@@ -4343,7 +4372,7 @@ export function makeTable(options) {
 			// we need to freeze entry records to ensure the integrity of the cache;
 			// but we only do this when users have opted into loadAsInstance/freezeRecords to avoid back-compat
 			// issues
-			Object.freeze(entry?.value);
+			freezeRecord(entry?.value);
 			if (
 				entry?.residencyId &&
 				entry.metadataFlags & INVALIDATED &&

--- a/resources/search.ts
+++ b/resources/search.ts
@@ -2,7 +2,7 @@ import { ClientError, IndexRebuildingError, Violation } from '../utility/errors/
 import { OVERFLOW_MARKER, MAX_SEARCH_KEY_LENGTH, SEARCH_TYPES } from '../utility/lmdb/terms.ts';
 import { compareKeys, MAXIMUM_KEY } from 'ordered-binary';
 import { SKIP } from '@harperfast/extended-iterable';
-import { INVALIDATED, EVICTED } from './Table.ts';
+import { INVALIDATED, EVICTED, freezeRecord } from './Table.ts';
 import type { DirectCondition, Id } from './ResourceInterface.ts';
 import { RequestTarget } from './RequestTarget.ts';
 import { lastMetadata } from './RecordEncoder.ts';
@@ -375,7 +375,7 @@ export function searchByIndex(
 						let result: any;
 						if (entry.value == null && !(entry.metadataFlags & (INVALIDATED | EVICTED))) result = SKIP;
 						else {
-							Object.freeze(entry.value);
+							freezeRecord(entry.value);
 							recordRead(entry);
 							result = entry;
 						}
@@ -396,7 +396,7 @@ export function searchByIndex(
 						transaction: context && Table._readTxnForContext(context),
 					});
 					if (!loadedEntry) return SKIP; // record was deleted/expired or not yet visible
-					Object.freeze(loadedEntry?.value);
+					freezeRecord(loadedEntry?.value);
 					recordRead(loadedEntry);
 					return { ...otherProps, ...loadedEntry };
 				}

--- a/unitTests/resources/freeze-record.test.js
+++ b/unitTests/resources/freeze-record.test.js
@@ -1,0 +1,37 @@
+// Read-side guard for #1298: freezeRecord() must not throw on a bare-TypedArray record root.
+// V8 throws "Cannot freeze array buffer views with elements" on Object.freeze of a non-empty
+// TypedArray/DataView, which used to 500 every scan over a table holding such a record. This
+// guard backstops records that bypass write validation (source/cache population, replication of
+// legacy data) and lets an already-poisoned table recover after upgrade.
+require('../testUtils');
+const assert = require('node:assert');
+const { freezeRecord } = require('#src/resources/Table');
+
+describe('freezeRecord (#1298 read-side guard)', () => {
+	it('does not throw on bare TypedArray / DataView / ArrayBuffer roots', () => {
+		assert.doesNotThrow(() => freezeRecord(Buffer.from([1, 2, 3])));
+		assert.doesNotThrow(() => freezeRecord(new Uint8Array([1, 2, 3])));
+		assert.doesNotThrow(() => freezeRecord(new Float64Array([1.5, 2.5])));
+		assert.doesNotThrow(() => freezeRecord(new DataView(new ArrayBuffer(8))));
+		assert.doesNotThrow(() => freezeRecord(new ArrayBuffer(8)));
+	});
+
+	it('leaves binary roots unfrozen (the freeze is shallow; they need none)', () => {
+		const buf = Buffer.from([1, 2, 3]);
+		freezeRecord(buf);
+		assert.equal(Object.isFrozen(buf), false);
+	});
+
+	it('freezes plain object records', () => {
+		const record = { id: 1, name: 'x' };
+		freezeRecord(record);
+		assert.equal(Object.isFrozen(record), true);
+	});
+
+	it('is a harmless no-op on null / undefined / primitives', () => {
+		assert.doesNotThrow(() => freezeRecord(null));
+		assert.doesNotThrow(() => freezeRecord(undefined));
+		assert.doesNotThrow(() => freezeRecord(42));
+		assert.doesNotThrow(() => freezeRecord('a string'));
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #1298. A record whose materialized **root** is a raw binary value (e.g. an `application/octet-stream` PUT that deserializes to a bare `Buffer`) wedged every unfiltered scan on the table: V8 throws `Cannot freeze array buffer views with elements` when `Object.freeze()` is called on a non-empty TypedArray, so `SELECT *`, REST collection get-attributes, and `search_by_value` all 500'd. The poison record was also effectively unrecoverable (stored under a compound key, so point GET/DELETE missed it while scans still tripped on it).

A record-root that is a primitive / string / number / bare TypedArray is an **accidental, unsupported shape** — it has no primary key in the body, no attributes for SQL or get-attributes, and breaks the records-are-documents assumptions throughout. The right answer (per discussion on the issue) is to reject it at write time and push binary into a proper `Bytes`/`Blob` **attribute**.

## Changes (two parts)

**1. Write-block (primary fix).** `Table._writeUpdate` now rejects any non-object record root — primitive, string/number, bare `TypedArray`/`ArrayBuffer` — with a `ClientError(400)` directing the caller to store binary in a `Bytes`/`Blob` attribute. Placed at `_writeUpdate` rather than the shared `validate()` **on purpose**: `validate()` is also called by `_writePublish`, and MQTT/topic publish of a raw binary or string payload is legitimate — blocking there would have broken messaging. The guard sits inside the existing `if (!context.source)` gate, so cache/source population and replication of legacy data are not rejected.

**2. Read-guard (defense-in-depth).** A shared `freezeRecord()` helper replaces the bare `Object.freeze()` at the five record-root freeze sites (3 in `Table.ts`, 2 in `search.ts`). It freezes only plain objects — skips ArrayBuffer views/buffers and short-circuits null/primitives — mirroring the existing `isFrozenRecordObject` guard. The root freeze is shallow anyway, so a typed-array root never needed freezing. This lets an already-poisoned table (created before this fix) be read again after upgrade, and backstops the validate-bypass paths above.

## Verification

- **Integration test** (`integrationTests/resources/bytes-scan-crash.test.ts`): octet-stream bare-buffer PUT (both `/id/bytes` and plain `/id`) → 400; string/number roots → 400; a CBOR object-with-`Bytes` record round-trips and scans clean; table stays scannable.
- **Unit test** (`unitTests/resources/freeze-record.test.js`): `freezeRecord` doesn't throw on TypedArray/DataView/ArrayBuffer roots, freezes plain objects, no-ops on null/primitives.
- Necessity proven: reverting the read-guard reproduced the exact `Cannot freeze array buffer views with elements` 500 on `SELECT *` and `search_by_value`; restoring it → green.
- Direct check confirmed `put(buffer/string/number)` rejected, `put(object)` ok, and `publish(buffer)` **not** blocked (messaging path untouched).
- Regression suites green: crud, create, blob, caching, subscriptionReplay, replayLogs, auditLog, validation, update-schema, resource-operation, resources, jsResource.
- Bonus: the `undefined` record case now throws a clean 400 instead of the prior `validate(undefined)` 500.
- Build, `format:write`, `lint:required` clean.

## Review

Cross-model reviewed (Gemini perf/maintainability leg + Harper-domain adjudication). Adopted Gemini's hot-path short-circuit so the helper never calls native `Object.freeze` on null/primitive roots.

## Scope note

This does **not** rework the octet-stream content-type handling itself (the special-case that returns the raw buffer rather than the `{contentType, data}` object wrapping used by other binary types). The write-block makes that moot from a data-integrity standpoint — a bare-root record can no longer be created. The SQL scan paths here will also be superseded by the 5.2 SQL engine rebuild; the fix is intentionally narrow.
