### PR TITLE
Register replication_leadingDuplicateSkip in CONFIG_PARAMS

### DIFF
--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -597,6 +597,7 @@ export const CONFIG_PARAMS = {
 	REPLICATION_RECORDCONCURRENCY: 'replication_recordConcurrency',
 	REPLICATION_PINGINTERVAL: 'replication_pingInterval',
 	REPLICATION_PINGTIMEOUT: 'replication_pingTimeout',
+	REPLICATION_LEADINGDUPLICATESKIP: 'replication_leadingDuplicateSkip',
 	ROOTPATH: 'rootPath',
 	SERIALIZATION_BIGINT: 'serialization_bigInt',
 	STORAGE_WRITEASYNC: 'storage_writeAsync',


### PR DESCRIPTION
Adds `REPLICATION_LEADINGDUPLICATESKIP: 'replication_leadingDuplicateSkip'` to `CONFIG_PARAMS` in `hdbTerms.ts`.

Without this registration, `env.get()` resolves `undefined` for the key, making `replication.leadingDuplicateSkip: false` a silent no-op. Companion to harper-pro#395.

*Generated by Claude Sonnet 4.6*