### PR TITLE
fix(replay): bound slow-but-progressing replay and bypass validation during crash recovery

### DIFF
--- a/config-root.schema.json
+++ b/config-root.schema.json
@@ -294,6 +294,11 @@
 					"minimum": 1,
 					"description": "Time (ms) without socket activity before a replication connection is considered dead and terminated. Default: 2x pingInterval"
 				},
+				"replayTimeout": {
+					"type": "number",
+					"minimum": 1,
+					"description": "Max total wall-clock time (ms) that crash-recovery transaction-log replay may run before it is aborted so the node can finish booting. Default: 600000 (10 minutes)."
+				},
 				"failOver": {
 					"type": "boolean",
 					"description": "Attempt fail-over to different node when unreachable. Default: true"

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -103,6 +103,12 @@ export class DatabaseTransaction implements Transaction {
 	// or external caching source); its commits retry transient conflicts without the request-path
 	// retry cap. Propagated to chained (multi-store) transactions in txnForContext.
 	declare sourceApply?: boolean;
+	// Set when this transaction replays the local audit log during crash recovery (replayLogs.ts).
+	// Replayed records were valid when first written, so schema validation is skipped — a schema
+	// that has since added required fields must not block replaying older records (harper#1316).
+	// An explicit marker rather than overloading `retries`, which is also bumped by transient
+	// conflict retries and never reset, so it cannot reliably signal "this is a replay".
+	declare isReplay?: boolean;
 
 	getReadTxn(): ReadTransaction {
 		this.readTxnRefCount = (this.readTxnRefCount || 0) + 1;

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1858,11 +1858,11 @@ export function makeTable(options) {
 							// below, so copy-on-mutate when recordUpdate is frozen (e.g. a record decoded during
 							// log replay) instead of writing through the frozen object.
 							if (isFrozenRecordObject(recordUpdate)) recordUpdate = { ...recordUpdate };
-							// Skip schema validation during crash-recovery replay (transaction.retries = 1
-							// is set by replayLogs to mark replayed writes). Records were valid when
-							// originally written; post-crash schema evolution (e.g. newly required fields)
-							// must not prevent replaying them (harper#1316, facet b).
-							if (transaction.retries === 0) this.validate(recordUpdate, !fullUpdate);
+							// Skip schema validation during crash-recovery replay (transaction.isReplay is set
+							// by replayLogs). Records were valid when originally written; post-crash schema
+							// evolution (e.g. newly required fields) must not prevent replaying them
+							// (harper#1316, facet b).
+							if (!transaction.isReplay) this.validate(recordUpdate, !fullUpdate);
 							if (updatedTimeProperty) {
 								recordUpdate[updatedTimeProperty.name] =
 									updatedTimeProperty.type === 'Date'
@@ -3443,7 +3443,7 @@ export function makeTable(options) {
 					if (!(context as any)?.source) {
 						transaction.checkOverloaded();
 						// Skip schema validation during crash-recovery replay (see _writeUpdate; harper#1316).
-						if (transaction.retries === 0) this.validate(message);
+						if (!transaction.isReplay) this.validate(message);
 					}
 				},
 				before:
@@ -4468,6 +4468,9 @@ export function makeTable(options) {
 					// Inherit never-drop-on-conflict so a source-applied multi-store transaction doesn't
 					// drop the canonical write when a secondary store hits a transient conflict.
 					transaction.next.sourceApply = transaction.sourceApply;
+					// Inherit the replay marker so a multi-table replay transaction skips validation on
+					// every store, not just the first (harper#1316).
+					transaction.next.isReplay = transaction.isReplay;
 					if (transaction.open === TRANSACTION_STATE.CLOSED) {
 						// if the current transaction is already closed, we need to retain that state on new databases we work with
 						transaction.next.open = TRANSACTION_STATE.CLOSED;

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1858,7 +1858,11 @@ export function makeTable(options) {
 							// below, so copy-on-mutate when recordUpdate is frozen (e.g. a record decoded during
 							// log replay) instead of writing through the frozen object.
 							if (isFrozenRecordObject(recordUpdate)) recordUpdate = { ...recordUpdate };
-							this.validate(recordUpdate, !fullUpdate);
+							// Skip schema validation during crash-recovery replay (transaction.retries = 1
+							// is set by replayLogs to mark replayed writes). Records were valid when
+							// originally written; post-crash schema evolution (e.g. newly required fields)
+							// must not prevent replaying them (harper#1316, facet b).
+							if (transaction.retries === 0) this.validate(recordUpdate, !fullUpdate);
 							if (updatedTimeProperty) {
 								recordUpdate[updatedTimeProperty.name] =
 									updatedTimeProperty.type === 'Date'
@@ -3438,7 +3442,8 @@ export function makeTable(options) {
 				validate: () => {
 					if (!(context as any)?.source) {
 						transaction.checkOverloaded();
-						this.validate(message);
+						// Skip schema validation during crash-recovery replay (see _writeUpdate; harper#1316).
+						if (transaction.retries === 0) this.validate(message);
 					}
 				},
 				before:

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -179,8 +179,11 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 					transaction = new DatabaseTransaction();
 					transaction.db = primaryStore;
 					transaction.timestamp = version;
-					// we treat this as a retry, because it is (and we want to skip validation and writing to the transaction log)
+					// we treat this as a retry, because it is (and we want to skip writing to the transaction log)
 					transaction.retries = 1;
+					// Explicit replay marker so the write path skips schema validation (harper#1316). Keyed
+					// off this rather than `retries`, which conflict retries also bump and never reset.
+					transaction.isReplay = true;
 				}
 				context.transaction = transaction;
 				const options = { context, residencyId, nodeId, originatingOperation };

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -10,6 +10,7 @@ import {
 	classifyAuditEntryForReplay,
 	isUndecodableValidatedWrite,
 	shouldAbortStalledReplay,
+	shouldAbortSlowReplay,
 } from './replayLogsGuards.ts';
 import { purgeAgedLogs } from './auditStore.ts';
 
@@ -81,12 +82,23 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 		// is reset to 0 the moment a write succeeds, so the stall bound only fires on a genuinely
 		// write-free run.
 		let noProgressRun = 0;
-		let lastProgressTime = performance.now();
+		const replayStartTime = performance.now();
+		let lastProgressTime = replayStartTime;
 		const txnLog: RocksTransactionLogStore = (rootStore as any).auditStore;
 		for (const auditRecord of txnLog.getRange({ startFromLastFlushed: true, readUncommitted: true }) as any) {
 			if (noProgressRun > 0 && shouldAbortStalledReplay(noProgressRun, performance.now() - lastProgressTime)) {
 				logger.fatal(
 					`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: ${noProgressRun} consecutive audit entries with no successful write (${skipped} skipped as unrecoverable, ${writes} replayed so far). This backlog is making no forward progress and was blocking startup (harper#1266) — typically a peer transaction log whose values reference unresolvable shared structures (harper#1163), or a backlog for a dropped table. Continuing boot without replaying the remainder; shed or relocate the oversized/undecodable peer transaction log(s), or re-clone this node, to recover the unreplayed data.`
+				);
+				break;
+			}
+			// Abort if replay has exceeded the total wall-clock budget even while making progress
+			// (harper#1316, facet a). shouldAbortStalledReplay resets its counters on every write,
+			// so a slow-but-progressing replay (deep out-of-order audit chain walk per entry) can
+			// peg the boot thread indefinitely without tripping it. Re-clone to recover.
+			if (shouldAbortSlowReplay(performance.now() - replayStartTime)) {
+				logger.fatal(
+					`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: replay has exceeded the wall-clock time limit (${writes} written, ${skipped} skipped). The transaction log contains a pathologically deep out-of-order write history that is too expensive to reconcile during boot (harper#1316). Re-clone this node from a healthy leader to recover the unreplayed data.`
 				);
 				break;
 			}

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -92,16 +92,6 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 				);
 				break;
 			}
-			// Abort if replay has exceeded the total wall-clock budget even while making progress
-			// (harper#1316, facet a). shouldAbortStalledReplay resets its counters on every write,
-			// so a slow-but-progressing replay (deep out-of-order audit chain walk per entry) can
-			// peg the boot thread indefinitely without tripping it. Re-clone to recover.
-			if (shouldAbortSlowReplay(performance.now() - replayStartTime)) {
-				logger.fatal(
-					`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: replay has exceeded the wall-clock time limit (${writes} written, ${skipped} skipped). The transaction log contains a pathologically deep out-of-order write history that is too expensive to reconcile during boot (harper#1316). Re-clone this node from a healthy leader to recover the unreplayed data.`
-				);
-				break;
-			}
 			const {
 				type,
 				tableId,
@@ -175,6 +165,20 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 						transaction?.directCommitSync();
 					} catch (error) {
 						logger.error('Error committing replay transaction', error);
+					}
+					// Abort if replay has exceeded the total wall-clock budget even while making progress
+					// (harper#1316, facet a). shouldAbortStalledReplay resets its counters on every write,
+					// so a slow-but-progressing replay (deep out-of-order audit chain walk per entry) can
+					// peg the boot thread indefinitely without tripping it. Checked only here, at a version
+					// boundary: the prior version's transaction was just committed in full and the new one
+					// is not yet staged, so aborting never tears a same-version (same source-transaction)
+					// write batch in half. Re-clone to recover the unreplayed remainder.
+					if (shouldAbortSlowReplay(performance.now() - replayStartTime)) {
+						logger.fatal(
+							`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: replay has exceeded the wall-clock time limit (${writes} written, ${skipped} skipped). The transaction log contains a pathologically deep out-of-order write history that is too expensive to reconcile during boot (harper#1316). Re-clone this node from a healthy leader to recover the unreplayed data.`
+						);
+						transaction = undefined as any; // already committed above; nothing staged for the new version
+						break;
 					}
 					transaction = new DatabaseTransaction();
 					transaction.db = primaryStore;

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -11,8 +11,11 @@ import {
 	isUndecodableValidatedWrite,
 	shouldAbortStalledReplay,
 	shouldAbortSlowReplay,
+	REPLAY_WALL_CLOCK_LIMIT_MS,
 } from './replayLogsGuards.ts';
 import { purgeAgedLogs } from './auditStore.ts';
+import { get as envGet } from '../utility/environment/environmentManager.ts';
+import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 
 let warnedReplayHappening = false;
 
@@ -84,6 +87,10 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 		let noProgressRun = 0;
 		const replayStartTime = performance.now();
 		let lastProgressTime = replayStartTime;
+		// Total wall-clock budget (ms) for replay, configurable via `replication.replayTimeout`;
+		// falls back to the 10-minute default (harper#1316).
+		const configuredReplayTimeout = Number(envGet(CONFIG_PARAMS.REPLICATION_REPLAYTIMEOUT));
+		const replayTimeoutMs = configuredReplayTimeout > 0 ? configuredReplayTimeout : REPLAY_WALL_CLOCK_LIMIT_MS;
 		const txnLog: RocksTransactionLogStore = (rootStore as any).auditStore;
 		for (const auditRecord of txnLog.getRange({ startFromLastFlushed: true, readUncommitted: true }) as any) {
 			if (noProgressRun > 0 && shouldAbortStalledReplay(noProgressRun, performance.now() - lastProgressTime)) {
@@ -173,7 +180,7 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 					// boundary: the prior version's transaction was just committed in full and the new one
 					// is not yet staged, so aborting never tears a same-version (same source-transaction)
 					// write batch in half. Re-clone to recover the unreplayed remainder.
-					if (shouldAbortSlowReplay(performance.now() - replayStartTime)) {
+					if (shouldAbortSlowReplay(performance.now() - replayStartTime, replayTimeoutMs)) {
 						logger.fatal(
 							`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: replay has exceeded the wall-clock time limit (${writes} written, ${skipped} skipped). The transaction log contains a pathologically deep out-of-order write history that is too expensive to reconcile during boot (harper#1316). Re-clone this node from a healthy leader to recover the unreplayed data.`
 						);

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -109,6 +109,28 @@ export function shouldAbortStalledReplay(
 	return noProgressRun >= timeSkipFloor && msSinceProgress >= timeLimitMs;
 }
 
+// Maximum total wall-clock time (ms) that replay is allowed to run, even when individual writes
+// are succeeding. A slow-but-progressing replay (issue #1316, facet a) can peg the boot thread
+// for an unbounded time without tripping shouldAbortStalledReplay, which resets its counters on
+// every successful write. This bound fires regardless of progress once the total elapsed time is
+// hit. Ten minutes is deliberately generous — a healthy replay of a large backlog completes in
+// seconds to low minutes; anything exceeding this is a pathological replay that the operator must
+// resolve by re-cloning the node.
+export const REPLAY_WALL_CLOCK_LIMIT_MS = 10 * 60 * 1000;
+
+/**
+ * Whether boot replay should abort because it has exceeded the total wall-clock time limit, even
+ * if individual writes are succeeding (issue #1316, facet a). Unlike shouldAbortStalledReplay,
+ * this fires regardless of forward progress — it is the safety net for a slow-but-progressing
+ * replay (e.g. a deep out-of-order audit chain walk per entry) that would otherwise peg the boot
+ * thread indefinitely.
+ *
+ * @param totalElapsedMs wall-clock ms elapsed since replay began
+ */
+export function shouldAbortSlowReplay(totalElapsedMs: number, timeLimitMs = REPLAY_WALL_CLOCK_LIMIT_MS): boolean {
+	return totalElapsedMs >= timeLimitMs;
+}
+
 /**
  * Wraps a transaction-log query iterator so a corrupt/torn frame ends that log's iteration
  * cleanly instead of escaping as an uncaughtException. rocksdb-js throws a bounded RangeError

--- a/unitTests/resources/replayLogs.test.js
+++ b/unitTests/resources/replayLogs.test.js
@@ -11,6 +11,8 @@ const {
 	REPLAY_NO_PROGRESS_COUNT_LIMIT,
 	REPLAY_NO_PROGRESS_TIME_LIMIT_MS,
 	REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR,
+	shouldAbortSlowReplay,
+	REPLAY_WALL_CLOCK_LIMIT_MS,
 } = require('#src/resources/replayLogsGuards');
 
 // Regression tests for the unclean-shutdown replay guards. Without these, an audit log
@@ -267,5 +269,38 @@ describe('shouldAbortStalledReplay', () => {
 		assert.strictEqual(shouldAbortStalledReplay(2, 1000, 5, 1000, 2), true);
 		assert.strictEqual(shouldAbortStalledReplay(1, 1000, 5, 1000, 2), false);
 		assert.strictEqual(shouldAbortStalledReplay(2, 999, 5, 1000, 2), false);
+	});
+});
+
+// Regression tests for HarperFast/harper#1316 (facet a): a slow-but-progressing replay (e.g.
+// deep out-of-order audit chain walks per entry) resets noProgressRun on every write, so
+// shouldAbortStalledReplay never fires — the boot thread can be pegged indefinitely. This guard
+// fires on total elapsed time regardless of forward progress.
+describe('shouldAbortSlowReplay', () => {
+	it('exposes a conservative default wall-clock limit', () => {
+		assert.strictEqual(REPLAY_WALL_CLOCK_LIMIT_MS, 10 * 60 * 1000);
+	});
+
+	it('does not abort while the elapsed time is below the limit', () => {
+		assert.strictEqual(shouldAbortSlowReplay(0), false);
+		assert.strictEqual(shouldAbortSlowReplay(REPLAY_WALL_CLOCK_LIMIT_MS - 1), false);
+	});
+
+	it('aborts once the elapsed time meets or exceeds the limit', () => {
+		assert.strictEqual(shouldAbortSlowReplay(REPLAY_WALL_CLOCK_LIMIT_MS), true);
+		assert.strictEqual(shouldAbortSlowReplay(REPLAY_WALL_CLOCK_LIMIT_MS + 1), true);
+	});
+
+	it('honors a caller-supplied limit (used to keep unit tests fast/deterministic)', () => {
+		assert.strictEqual(shouldAbortSlowReplay(999, 1000), false);
+		assert.strictEqual(shouldAbortSlowReplay(1000, 1000), true);
+		assert.strictEqual(shouldAbortSlowReplay(1001, 1000), true);
+	});
+
+	it('fires even when writes are succeeding (unlike shouldAbortStalledReplay)', () => {
+		// The key difference: shouldAbortStalledReplay only fires on no-progress runs.
+		// shouldAbortSlowReplay fires purely on total elapsed time — writes or not.
+		assert.strictEqual(shouldAbortSlowReplay(5000, 1000), true);
+		assert.strictEqual(shouldAbortSlowReplay(500, 1000), false);
 	});
 });

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -598,6 +598,7 @@ export const CONFIG_PARAMS = {
 	REPLICATION_PINGINTERVAL: 'replication_pingInterval',
 	REPLICATION_PINGTIMEOUT: 'replication_pingTimeout',
 	REPLICATION_LEADINGDUPLICATESKIP: 'replication_leadingDuplicateSkip',
+	REPLICATION_REPLAYTIMEOUT: 'replication_replayTimeout',
 	ROOTPATH: 'rootPath',
 	SERIALIZATION_BIGINT: 'serialization_bigInt',
 	STORAGE_WRITEASYNC: 'storage_writeAsync',

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -193,6 +193,7 @@ export function configValidator(configJson, skipFsValidation = false) {
 			copyTablesToCatchUp: boolean.optional(),
 			pingInterval: number.min(1).optional().empty(null),
 			pingTimeout: number.min(1).optional().empty(null),
+			replayTimeout: number.min(1).optional().empty(null),
 		}).optional(),
 		componentsRoot: rootConstraints.optional(),
 		localStudio: Joi.object({


### PR DESCRIPTION
## Summary

Fixes two distinct defects in boot-time transaction-log replay ([#1316](https://github.com/HarperFast/harper/issues/1316)), both observed in production on `eh-prod.gend` (node `it-mil-1`, 5.1.2):

**Facet (a) — Slow-but-progressing replay pegs the boot thread indefinitely**

`shouldAbortStalledReplay` (#1266) resets its counters on every successful write. A node with a deep out-of-order audit chain per entry makes forward progress (each deep walk eventually succeeds) so the guard never fires — but the boot thread can be pegged for 80+ minutes and the node never finishes booting. Adds `shouldAbortSlowReplay` + `REPLAY_WALL_CLOCK_LIMIT_MS = 10 min` to bound total replay time regardless of per-entry progress.

**Facet (b) — Required-field validation throws during replay, silently losing records**

`replayLogs.ts` set `transaction.retries = 1` with the stated intent of skipping both audit re-logging *and* validation. It correctly prevented re-logging (via `isRetry`), but the `validate()` callback in `_writeUpdate`/`_writePublish` ran unconditionally on the first `save()`. Records written before a schema evolution that added required fields then threw on replay and were skipped — data loss. Fixed with an explicit `transaction.isReplay` marker, checked before `this.validate()` in both write paths.

## Where to focus

- **`isReplay` marker, not `retries`.** The validation skip is keyed off an explicit `isReplay` flag set only by `replayLogs`, propagated to chained multi-store transactions alongside `sourceApply` (`txnForContext`). Cross-model review flagged that `retries` is also bumped by transient conflict retries and never reset, so it could not safely signal "this is a replay" — hence the dedicated flag.
- **Slow-abort fires only at a version boundary.** The wall-clock guard is checked in the version-boundary block, *after* the prior version's transaction is committed in full and *before* the next is staged, so aborting never tears a same-version (same source-transaction) write batch in half. The in-flight transaction is nulled so the post-loop commit is a no-op.
  - *Known tradeoff:* a single pathological version large enough to exceed the budget on its own would not be interrupted (the boundary check can't fire mid-version). This is not the #1316 failure mode (deep per-record histories span many timestamps, and each entry's walk is already capped at `MAX_OUT_OF_ORDER_AUDIT_DEPTH`), and version-atomicity is the more important property here.
- **Is skipping `validate()` safe?** `validate()` also coerces values (Date strings → Date, BigInt, etc.). Replayed records are decoded from the audit log, which stored them *post-validation* at original write time, so they are already coerced. The created/updated-time stamping and primary-key assignment live *outside* the skipped `validate()` call and still run.
- **`REPLAY_WALL_CLOCK_LIMIT_MS = 10 min`** — confirm this is the right balance between a healthy large replay (seconds to low minutes) and a pathological one.

## Testing

5 new `shouldAbortSlowReplay` unit tests in `unitTests/resources/replayLogs.test.js`; full resources suite passes. `test:unit:main`/integration could not be exercised in my local env (pre-existing storage-path setup issue, fails identically on `main`) — relying on CI for those.

## Review

Both cross-model reviews are complete with no open required changes:
- **Codex** (3 rounds) — surfaced the `retries`-overloading risk and the mid-version partial-commit risk; both fixed (the `isReplay` marker and the version-boundary abort came out of it). Final pass clean.
- **Gemini** (3.5 Flash, via agy) — no required changes. Confirmed the coercion-skip is safe and the single-huge-version timeout tradeoff is correct. Its findings on "first batch skips isReplay", "other write entry points", and optional-chaining were checked against the code and are non-issues; its note that an aborted replay boots with incomplete data is the **pre-existing #1266 re-clone remediation** (same `fatal`+`break`+resolve path), not introduced here.

*Generated by Claude Sonnet 4.6.*
