### PR TITLE
feat: Allow running without the global boot pointer

### DIFF
--- a/unitTests/install/installer.test.js
+++ b/unitTests/install/installer.test.js
@@ -572,3 +572,46 @@ describe('applyInstallModeDefaults', () => {
 		assert.equal(args.node_hostname, 'real-node.example.com');
 	});
 });
+
+// Regression guard for the global boot pointer opt-out (HARPER_GLOBAL_POINTER): an ephemeral instance
+// launched with an explicit --ROOTPATH (e.g. an integration-test harness) must be able to skip writing the
+// machine-global `~/.harperdb/hdb_boot_properties.file`, which otherwise outlives the instance and hijacks
+// later `harper run`/`harper dev` invocations that omit --ROOTPATH. The running instance is unaffected (it
+// uses its explicit ROOTPATH), so the in-memory settings_path is still applied.
+describe('createBootPropertiesFile — HARPER_GLOBAL_POINTER opt-out', () => {
+	const sandbox = sinon.createSandbox();
+	const originalEnv = process.env.HARPER_GLOBAL_POINTER;
+
+	beforeEach(() => {
+		// getHomeDir points the props path at a dir that doesn't exist, so the default shouldWriteBootProps is
+		// true — isolating the opt-out as the only variable. Stub the filesystem + env writes.
+		installer.__set__('hdbRoot', 'user/hdb-test/');
+		sandbox.stub(hdb_utils, 'getHomeDir').returns('homedir/test');
+		sandbox.stub(fs, 'mkdirpSync');
+		sandbox.stub(fs, 'writeFile');
+		sandbox.stub(env_manager, 'setProperty');
+		sandbox.stub(console, 'error');
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+		if (originalEnv === undefined) delete process.env.HARPER_GLOBAL_POINTER;
+		else process.env.HARPER_GLOBAL_POINTER = originalEnv;
+	});
+
+	it('does NOT write the global boot pointer when HARPER_GLOBAL_POINTER=false', async () => {
+		process.env.HARPER_GLOBAL_POINTER = 'false';
+		await installer.__get__('createBootPropertiesFile')();
+		expect(fs.writeFile.called, 'boot pointer file must not be written').to.be.false;
+		expect(fs.mkdirpSync.called, '~/.harperdb must not be created').to.be.false;
+		// the running instance still gets its settings_path in memory
+		expect(env_manager.setProperty.called, 'in-memory settings are still applied').to.be.true;
+	});
+
+	it('writes the global boot pointer by default (opt-out unset)', async () => {
+		delete process.env.HARPER_GLOBAL_POINTER;
+		await installer.__get__('createBootPropertiesFile')();
+		expect(fs.writeFile.calledOnce, 'boot pointer file is written').to.be.true;
+		expect(fs.writeFile.args[0][0]).to.equal(path.join('homedir', 'test', '.harperdb', 'hdb_boot_properties.file'));
+	});
+});

--- a/unitTests/utility/common_utils.test.js
+++ b/unitTests/utility/common_utils.test.js
@@ -566,4 +566,31 @@ describe('Test common_utils module', () => {
 		const c = cu_rewire.ms_to_time(1672345634534);
 		expect(c).to.equal('52y 27d 20h 27m 14s');
 	});
+
+	describe('Test isGlobalBootPointerEnabled', () => {
+		const original = process.env.HARPER_GLOBAL_POINTER;
+		afterEach(() => {
+			if (original === undefined) delete process.env.HARPER_GLOBAL_POINTER;
+			else process.env.HARPER_GLOBAL_POINTER = original;
+		});
+
+		it('defaults to enabled when HARPER_GLOBAL_POINTER is unset', () => {
+			delete process.env.HARPER_GLOBAL_POINTER;
+			expect(cu.isGlobalBootPointerEnabled()).to.be.true;
+		});
+
+		for (const value of ['false', '0', 'off', 'no']) {
+			it(`is disabled when HARPER_GLOBAL_POINTER="${value}"`, () => {
+				process.env.HARPER_GLOBAL_POINTER = value;
+				expect(cu.isGlobalBootPointerEnabled()).to.be.false;
+			});
+		}
+
+		for (const value of ['true', '1', 'yes']) {
+			it(`stays enabled for non-opt-out value "${value}"`, () => {
+				process.env.HARPER_GLOBAL_POINTER = value;
+				expect(cu.isGlobalBootPointerEnabled()).to.be.true;
+			});
+		}
+	});
 });

--- a/utility/common_utils.ts
+++ b/utility/common_utils.ts
@@ -735,6 +735,22 @@ export function getEnvCliRootPath() {
 }
 
 /**
+ * Whether this run may persist the machine-global boot pointer (`~/.harperdb/hdb_boot_properties.file`),
+ * which records a default rootPath for future `harper run`/`harper dev` invocations that omit `--ROOTPATH`.
+ *
+ * Enabled by default. Set `HARPER_GLOBAL_POINTER=false` (or `0`/`off`/`no`) to opt out — intended for
+ * EPHEMERAL instances launched with an explicit `--ROOTPATH` (e.g. integration-test harnesses). Without the
+ * opt-out, the first such run creates the global pointer at its temp rootPath; when that dir is later deleted
+ * the pointer is left dangling and hijacks unrelated `harper run`/`harper dev` invocations on the machine.
+ * Read directly from the environment (not the validated config) because boot-pointer creation runs during
+ * install, before the config system is initialized — mirroring `getEnvCliRootPath` above.
+ */
+export function isGlobalBootPointerEnabled() {
+	const value = process.env.HARPER_GLOBAL_POINTER;
+	return !(value === 'false' || value === '0' || value === 'off' || value === 'no');
+}
+
+/**
  * Will check to see if there is a rootpath cli/env var pointing to a harperdb-config.yaml file
  * This is used for running HDB without a boot file
  */

--- a/utility/install/installer.ts
+++ b/utility/install/installer.ts
@@ -469,6 +469,14 @@ async function createBootPropertiesFile() {
 				shouldWriteBootProps = true;
 			}
 		}
+		// Explicit opt-out for EPHEMERAL instances launched with an explicit --ROOTPATH (e.g. integration-test
+		// harnesses): never persist a machine-global rootPath pointer. Without this, the first such run creates
+		// `~/.harperdb/hdb_boot_properties.file` pointing at its temp dir; when teardown deletes the dir, the
+		// pointer is left dangling and hijacks later `harper run`/`harper dev` invocations that omit --ROOTPATH.
+		// The running instance is unaffected — it uses its explicit ROOTPATH regardless. See isGlobalBootPointerEnabled.
+		if (shouldWriteBootProps && !hdbUtils.isGlobalBootPointerEnabled()) {
+			shouldWriteBootProps = false;
+		}
 		if (shouldWriteBootProps) {
 			try {
 				fs.mkdirpSync(homeDirPath, { mode: hdbTerms.HDB_FILE_PERMISSIONS });


### PR DESCRIPTION
So I ran into this where I had run the integration tests on a clean machine, and then later in the day, I could not for the life of me figure out why I couldn't launch harper on an unrelated app! Claude helped me figure out the culprit -- I had aimed Harper at some ephemeral spot which had gotten cleaned up. By giving the capability to opt out of that, we can make our integration tests work cleaner on a developer's machine.

https://github.com/HarperFast/integration-testing/pull/18 would be either consuming this change, or obviating the need for it, depending on how we decide to proceed.