### PR TITLE
perf(commit): early-out the out-of-order audit walk when a write is fully superseded

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -2028,8 +2028,11 @@ export function makeTable(options) {
 											// KEEPS commutative ops (and, for a full update, every field) — so whether the residual
 											// empties is order-independent, and a commutative op never triggers the early-out.
 											// Supersession is monotonic, so once empty stop folding (an unscanned branch may still
-											// be deferring the early-out below). RocksDB only — see the early-out below.
-											if (isRocksDB && !fullySuperseded) {
+											// be deferring the early-out below). RocksDB only — see the early-out below. Guard on
+											// newerPatch: a corrupt/undecodable audit value can be undefined, and folding it would
+											// throw in rebuildUpdateBefore's `in` check; it supersedes nothing, so skip it (the
+											// pre-existing fold below already tolerates this case by returning earlier).
+											if (isRocksDB && !fullySuperseded && newerPatch) {
 												earlyOutResidual = rebuildUpdateBefore(
 													earlyOutResidual ?? recordUpdate,
 													newerPatch,

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1956,6 +1956,30 @@ export function makeTable(options) {
 							let nextRef: { localTime: number; nodeId: number };
 							let walkSteps = 0;
 							let auditWalkCapped = false;
+							// Early-out residual: as we walk the chain newest-first, fold each succeeding patch into a
+							// throwaway copy of this write purely to detect when every field has been overwritten by
+							// newer writes. When it empties — and there is no alternate audit branch — the write is
+							// fully superseded and the rest of the O(depth) walk can be skipped; this is equivalent to
+							// walking to the end and taking the `writeCommit(false)` escape after the fold below
+							// (#1114/#1316). It is NOT used as the applied value: the sorted fold still computes that for
+							// the non-empty (legit merge) case, so merge correctness is unchanged.
+							let earlyOutResidual: any;
+							let fullySuperseded = false;
+							// A re-delivered write whose exact (version, nodeId) is already in the audit log was already
+							// applied; drop it rather than re-applying it (double-applying commutative ops) or writing a
+							// duplicate audit-only record. Used by the early-out and the depth-cap block below.
+							const isReDeliveredDuplicate = () => {
+								const duplicate = auditStore.get(txnTime, tableId, id, options?.nodeId);
+								return (
+									duplicate &&
+									duplicate.version === txnTime &&
+									precedesExistingVersion(
+										txnTime,
+										{ version: txnTime, localTime: txnTime, key: id, nodeId: duplicate.nodeId },
+										options?.nodeId
+									) === 0
+								);
+							};
 							do {
 								while (localTime > txnTime || (auditedVersion >= txnTime && localTime > 0)) {
 									// Bound the walk only for RocksDB, where the OOM was observed (issue #1114): each step
@@ -1997,8 +2021,22 @@ export function makeTable(options) {
 											// audit record itself, so its backing transaction-log buffer and decoders can be
 											// reclaimed immediately. Only these two fields are needed for the ordered fold below;
 											// retaining the full records is what pins the heap on a deep chain (issue #1114).
-											succeedingUpdates.push({ version: auditedVersion, value: auditRecord.getValue(primaryStore) });
+											const newerPatch = auditRecord.getValue(primaryStore);
+											succeedingUpdates.push({ version: auditedVersion, value: newerPatch });
 											auditRecordToStore = recordUpdate; // use the original update for the audit record
+											// rebuildUpdateBefore only ever DROPS plain fields the newer patch overwrites and
+											// KEEPS commutative ops (and, for a full update, every field) — so whether the residual
+											// empties is order-independent, and a commutative op never triggers the early-out.
+											// Supersession is monotonic, so once empty stop folding (an unscanned branch may still
+											// be deferring the early-out below). RocksDB only — see the early-out below.
+											if (isRocksDB && !fullySuperseded) {
+												earlyOutResidual = rebuildUpdateBefore(
+													earlyOutResidual ?? recordUpdate,
+													newerPatch,
+													fullUpdate
+												);
+												if (!earlyOutResidual) fullySuperseded = true;
+											}
 										} else if (auditRecord.type === 'put' || auditRecord.type === 'delete') {
 											// There is newer full record update, so this incremental update is completely superseded
 											write.skipped = true;
@@ -2023,6 +2061,24 @@ export function makeTable(options) {
 												nodeId: ref.nodeId,
 											});
 										}
+									}
+
+									// Every field of this write is overwritten by newer writes, and there is no alternate
+									// audit branch left to scan, so it is fully superseded — the same outcome as walking to
+									// the end and taking the `writeCommit(false)` escape below, reached without paying the rest
+									// of the deep walk (#1114/#1316). additionalAuditRefs is already final here (the out-of-order
+									// ref is pushed once, above), so the audit record written is identical. RocksDB only: LMDB has
+									// no up-front keyed dedup, so it must keep walking until inline duplicate detection reaches the
+									// matching entry. A re-delivered duplicate is dropped via the keyed lookup (as the depth-cap
+									// block does) rather than written as a duplicate audit-only record; a genuine first delivery
+									// writes the audit record. (A newer full put/delete on this single chain is caught above before
+									// the residual could empty, so it cannot be reached here.)
+									if (isRocksDB && fullySuperseded && auditRefsToVisit.length === 0) {
+										if (isReDeliveredDuplicate()) {
+											write.skipped = true;
+											return; // re-delivered duplicate already applied
+										}
+										return writeCommit(false);
 									}
 
 									localTime = auditRecord.previousVersion;
@@ -2069,16 +2125,7 @@ export function makeTable(options) {
 										depth: walkSteps,
 									}
 								);
-								const duplicate = auditStore.get(txnTime, tableId, id, options?.nodeId);
-								if (
-									duplicate &&
-									duplicate.version === txnTime &&
-									precedesExistingVersion(
-										txnTime,
-										{ version: txnTime, localTime: txnTime, key: id, nodeId: duplicate.nodeId },
-										options?.nodeId
-									) === 0
-								) {
+								if (isReDeliveredDuplicate()) {
 									write.skipped = true;
 									return; // duplicate write already applied
 								}

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -393,7 +393,11 @@ describe('Transactions', () => {
 			if (isLMDB) return; // RocksDB-only bounded path (LMDB keeps the exact unbounded walk)
 			const { logger } = require('#src/utility/logging/logger');
 			const id = 1114000;
-			const base = Date.now();
+			// Each #1114 test writes a chain ~10k ms wide of timestamps into the shared TxnTest table. A
+			// distinct, far-future per-test base keeps those ranges disjoint from each other AND from the
+			// other tests' Date.now() writes, so audit entries can't collide at the same version (which made
+			// re-delivery dedup timing-fragile across tests).
+			const base = Date.now() + 400_000_000;
 			// Oldest version: a seed put with count = 0.
 			await TxnTest.put(id, { name: 'seed', count: 0 }, { timestamp: base });
 			// A chain of in-order patches deeper than MAX_OUT_OF_ORDER_AUDIT_DEPTH (1000). None is a full
@@ -434,7 +438,7 @@ describe('Transactions', () => {
 		it('does not double-apply a re-delivered commutative op in the bounded path (#1114)', async function () {
 			if (isLMDB) return; // RocksDB-only bounded path (LMDB keeps the exact unbounded walk)
 			const id = 1114001;
-			const base = Date.now();
+			const base = Date.now() + 100_000_000; // disjoint range — see the #1114 base note above
 			await TxnTest.put(id, { name: 'seed', count: 0 }, { timestamp: base });
 			const depth = 1010;
 			for (let i = 1; i <= depth; i++) {
@@ -460,7 +464,7 @@ describe('Transactions', () => {
 			if (isLMDB) return; // RocksDB-only up-front keyed dedup (LMDB keeps the exact unbounded walk)
 			const { logger } = require('#src/utility/logging/logger');
 			const id = 1114002;
-			const base = Date.now();
+			const base = Date.now() + 200_000_000; // disjoint range — see the #1114 base note above
 			await TxnTest.put(id, { name: 'seed', count: 0 }, { timestamp: base });
 			const depth = 1010; // deeper than MAX_OUT_OF_ORDER_AUDIT_DEPTH so an unguarded walk would cap
 			for (let i = 1; i <= depth; i++) await TxnTest.patch(id, { seq: i }, { timestamp: base + 10 * i });
@@ -482,6 +486,41 @@ describe('Transactions', () => {
 			}
 			assert.equal((await TxnTest.get(id)).count, 7, 're-delivered duplicate must not double-apply');
 			assert.equal(capWarned, false, 're-delivery should be deduped up front, not via the deep walk');
+		});
+
+		// #1114/#1316: an out-of-order write whose every field is overwritten by newer in-order patches is
+		// fully superseded. The fold at the end of the walk already drops it (writeCommit(false)) — but only
+		// after walking the whole chain. The early-out folds as it walks and escapes the moment the residual
+		// empties, so a fully-superseded write past the depth cap never takes the deep walk. This is the bulk
+		// of the transitive re-delivery / crash-recovery-replay traffic that pegged the event loop.
+		it('escapes the deep walk when an out-of-order write is fully superseded by newer patches (#1114)', async function () {
+			if (isLMDB) return; // RocksDB-only: the depth-cap walk is bounded for RocksDB
+			const { logger } = require('#src/utility/logging/logger');
+			const id = 1114003;
+			const base = Date.now() + 300_000_000; // disjoint range — see the #1114 base note above
+			await TxnTest.put(id, { name: 'seed', val: 0 }, { timestamp: base });
+			// A linear chain of in-order patches deeper than MAX_OUT_OF_ORDER_AUDIT_DEPTH (1000), each
+			// overwriting the same field. In-order patches add no audit branches, so the early-out's
+			// no-branch guard holds.
+			const depth = 1010;
+			for (let i = 1; i <= depth; i++) await TxnTest.patch(id, { val: i }, { timestamp: base + 10 * i });
+			const originalWarn = logger.warn;
+			let capWarned = false;
+			logger.warn = (msg) => {
+				if (typeof msg === 'string' && msg.includes('exceeded depth cap')) capWarned = true;
+			};
+			try {
+				// Older than every patch and touching only `val`, which every newer patch overwrites → fully
+				// superseded. Without the early-out this walks the whole chain and hits the cap; with it, the
+				// residual empties on the first (newest) patch folded and the walk is abandoned.
+				await TxnTest.patch(id, { val: 'stale' }, { timestamp: base + 5 });
+			} finally {
+				logger.warn = originalWarn;
+			}
+			assert.equal(capWarned, false, 'a fully-superseded write should escape before the depth-cap walk');
+			const record = await TxnTest.get(id);
+			assert.equal(record.val, depth, 'newest last-writer-wins value survives; the stale older write is dropped');
+			assert.equal(record.name, 'seed');
 		});
 
 		it('Can merge replication updates', async function () {


### PR DESCRIPTION
## Summary

Adds an early-out to the out-of-order audit-chain reconciliation in `Table.commit()`. Today the walk (the `do { while (localTime > txnTime …) }` loop) scans **every** succeeding update into `succeedingUpdates` — each step a transaction-log range scan + msgpackr decode, up to the depth cap (1000) — and only **after** the walk completes folds them (`rebuildUpdateBefore`) and drops a fully-superseded older write at `if (!incrementalUpdateToApply) return writeCommit(false)`. So a re-delivered / out-of-order patch whose fields are all overwritten by newer writes — the bulk of transitive re-delivery and crash-recovery replay traffic on hot records (#1114 / #1316) — pays the **whole** O(depth) deep walk before being discarded.

This folds each succeeding patch into a throwaway residual **as we walk** (newest-first), purely to detect full supersession; when it empties (and no alternate audit branch remains) it returns immediately. For a fully-superseded write on a deep chain this turns O(depth) into O(few).

This is the core-side optimization discussed as a better complement to #1310 (the up-front *exact-duplicate* dedup) — it absorbs the broader *fully-superseded* case, not just exact dupes — and is the candidate fix for #1316's facet-a (deep-walk replay). It does **not** replace #1310/#1316/#399; it reduces the per-write cost they each work around.

## Where to look

- **`resources/Table.ts`** — the early-out. The residual is **never** used as the applied value: the existing sorted fold still computes that for the non-empty (legit-merge) case, so merge correctness is unchanged. This is purely a fast path for the dropped case.
- **`unitTests/resources/transaction.test.js`** — new regression test (a fully-superseded out-of-order write escapes before the depth-cap walk: `capWarned === false`), plus disjoint timestamp bases for the existing #1114 tests (see below).

## Correctness boundary worth a careful look

1. **`auditRefsToVisit.length === 0` guard.** The early-out only fires when the residual empties *and* there is no pending audit branch. On a single `previousVersion` chain a newer full `put`/`delete` is caught at the existing `else if (type === 'put' || 'delete')` branch **before** the residual could empty (the walk is newest-first), so the early-out can only fire in the all-patches-superseded case — provably the same outcome as walking to the end and hitting `writeCommit(false)`. When branches exist, we fall through to the exact existing walk (no behavior change).
2. **RocksDB only.** Gated to `isRocksDB`, matching the depth cap and #1310. LMDB has no up-front keyed dedup and relies on the exact walk's *inline* duplicate detection reaching the matching entry, so firing the early-out there could convert a re-delivered duplicate into a duplicate audit-only record. (Caught in cross-model review — see below.)
3. **Duplicate handling.** On RocksDB a re-delivered duplicate reaching the early-out is dropped via the keyed `(version, nodeId)` lookup — factored into a shared `isReDeliveredDuplicate()` helper now used by both the early-out and the depth-cap block. This is a best-effort backstop (same as the cap block); the primary catch remains #1310's up-front lookup.
4. **`additionalAuditRefs` is already final** at the early-out point (the out-of-order ref is pushed once, gated by `addedAuditRef`), so the audit record written by `writeCommit(false)` here is identical to the end-of-walk escape.

## Open items for the reviewer

- **The LMDB exclusion (point 2)** — please sanity-check the reasoning. Codex flagged the original (un-gated) version as turning an LMDB duplicate into a duplicate audit event; the fix is to gate to RocksDB. I'd value a second opinion that RocksDB-only is the right boundary (vs. also adding an LMDB-safe path).
- **Test-robustness change bundled in:** the existing #1114 tests share the `TxnTest` table and used `Date.now()` bases whose ~10k-ms-wide chains overlapped, making cross-test audit collisions (and re-delivery dedup) timing-fragile. My fold perturbs timing enough to expose this (the #1114 group flaked ~10%, and was already in the flaky set on `main`). Giving each #1114 test a disjoint, far-future base makes the group deterministic (0/20 stress runs). Flagging because it touches tests I didn't author.

## Verification

- `test:unit:resources` (RocksDB + LMDB): new test passes; existing OOO/#1114 tests pass; no new failures vs `main` baseline. The pre-existing `Can run txn with three tables and two databases` failure reproduces on clean `main` (unrelated, environmental).
- Cross-model review: **Codex** (found the LMDB issue + a node_modules-symlink hygiene note, both addressed). **Gemini** could not run in this environment (`gemini`/`agy` unavailable in the worktree — same as #1310); compensated with the documented correctness argument above and a careful self-review. A second model pass on the correctness boundary is welcome.
- Not yet bench-validated against the captured production node (mil) — that deterministic replay bench is the next step and will be posted to #1316.

<sub>Generated by Claude (Opus 4.8).</sub>
