### PR TITLE
fix: dispose component scopes before worker exit in dev, and serialize reloads

### DIFF
--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -188,15 +188,17 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 		// e.g. @harperfast/vite disposing its Vite/rolldown dev server — and the worker shutdown path
 		// awaits this close(), so awaiting the listeners here ensures such a native runtime is fully
 		// disposed before the worker exits. That ordering matters: tearing the worker down while a native
-		// (N-API) bundler runtime is still live crashes the whole process. Listeners that return nothing
-		// (the common case) settle immediately, so existing behavior is unchanged.
+		// (N-API) bundler runtime is still live crashes the whole process. `Promise.all` (not
+		// `allSettled`) so a listener that fails surfaces its error to the caller rather than being
+		// silently swallowed; listeners that return nothing (the common case) settle immediately.
 		const closeListeners = this.listeners('close') as Array<(...args: any[]) => unknown>;
 		this.removeAllListeners('close');
-		await Promise.allSettled(
+		await Promise.all(
 			closeListeners.map((listener) => {
+				// Run every listener (so all teardown is attempted) and bind `this` to the Scope, matching
+				// how EventEmitter invokes listeners — a listener may rely on it (e.g. `this.logger`). The
+				// wrapper turns a synchronous throw into a rejection so `Promise.all` surfaces it too.
 				try {
-					// Bind `this` to the Scope, matching how EventEmitter invokes listeners — a listener may
-					// rely on it (e.g. `this.logger`).
 					return listener.call(this);
 				} catch (error) {
 					return Promise.reject(error);

--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -184,7 +184,24 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 
 		await Promise.allSettled([...this.#entryHandlers.map((h) => h.close()), this.options.close()]);
 
-		this.emit('close');
+		// Invoke `close` listeners and await any promise they return. A plugin's teardown can be async —
+		// e.g. @harperfast/vite disposing its Vite/rolldown dev server — and the worker shutdown path
+		// awaits this close(), so awaiting the listeners here ensures such a native runtime is fully
+		// disposed before the worker exits. That ordering matters: tearing the worker down while a native
+		// (N-API) bundler runtime is still live crashes the whole process. Listeners that return nothing
+		// (the common case) settle immediately, so existing behavior is unchanged.
+		const closeListeners = this.listeners('close') as Array<(...args: any[]) => unknown>;
+		this.removeAllListeners('close');
+		await Promise.allSettled(
+			closeListeners.map((listener) => {
+				try {
+					return listener();
+				} catch (error) {
+					return Promise.reject(error);
+				}
+			})
+		);
+
 		this.removeAllListeners();
 
 		return this;

--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -195,7 +195,9 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 		await Promise.allSettled(
 			closeListeners.map((listener) => {
 				try {
-					return listener();
+					// Bind `this` to the Scope, matching how EventEmitter invokes listeners — a listener may
+					// rely on it (e.g. `this.logger`).
+					return listener.call(this);
 				} catch (error) {
 					return Promise.reject(error);
 				}

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -27,6 +27,7 @@ import harperLogger from '../utility/logging/harper_logger.ts';
 import * as dataLoader from '../resources/dataLoader.ts';
 import { restartWorkers, getWorkerIndex } from '../server/threads/manageThreads.js';
 import { resetRestartNeeded, subscribeToRestartRequests } from './requestRestart.ts';
+import { trackScopeClose } from './scopeShutdown.ts';
 import { scopedImport } from '../security/jsLoader.ts';
 import { server } from '../server/Server.ts';
 import { Resources } from '../resources/Resources.ts';
@@ -469,7 +470,9 @@ export async function loadComponent(
 						origin
 					);
 
-					onMessageByType(ITC_EVENT_TYPES.SHUTDOWN, () => scope.close());
+					// Track the close so the worker's shutdown path waits for it (and thus for any async
+					// native-runtime disposal, e.g. @harperfast/vite's dev server) before calling realExit.
+					onMessageByType(ITC_EVENT_TYPES.SHUTDOWN, () => trackScopeClose(scope.close()));
 
 					await sequentiallyHandleApplication(scope, extensionModule);
 
@@ -555,13 +558,39 @@ export async function loadComponent(
 		compName = parentCompName;
 		if (isMainThread && !watchesSetup && autoReload) {
 			let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+			let restarting = false; // a reload cycle (loadComponentDirectories + restartWorkers) is in flight
+			let pending = false; // a request arrived while a cycle was running — run exactly one more afterward
+
+			// Run reload cycles strictly one at a time. Requests that arrive while a cycle is in flight are
+			// collapsed into a single follow-up cycle (not one per request), so a burst of changes — or a
+			// regenerate-on-reload loop — can't stack overlapping restarts. Overlapping restarts pile worker
+			// threads up and push them past the forced-termination grace, which crashes a worker that is
+			// mid-teardown of a native runtime (e.g. @harperfast/vite's rolldown dev server).
+			const runRestartCycle = async () => {
+				if (restarting) {
+					pending = true;
+					return;
+				}
+				restarting = true;
+				try {
+					do {
+						pending = false;
+						resetRestartNeeded();
+						await loadComponentDirectories();
+						await restartWorkers();
+					} while (pending); // a request landed mid-cycle → run once more, coalescing the rest
+				} catch (error) {
+					harperLogger.error('Error during component reload', error);
+				} finally {
+					restarting = false;
+				}
+			};
+
 			subscribeToRestartRequests(() => {
 				if (debounceTimer) clearTimeout(debounceTimer);
-				debounceTimer = setTimeout(async () => {
+				debounceTimer = setTimeout(() => {
 					debounceTimer = null;
-					resetRestartNeeded();
-					await loadComponentDirectories();
-					restartWorkers();
+					void runRestartCycle();
 				}, 500);
 			});
 		}

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -576,11 +576,15 @@ export async function loadComponent(
 					do {
 						pending = false;
 						resetRestartNeeded();
-						await loadComponentDirectories();
-						await restartWorkers();
+						// Per-cycle try/catch: a failed reload (e.g. a saved syntax error) must log and move on
+						// — not abort the loop and discard a pending follow-up, like the save that fixes it.
+						try {
+							await loadComponentDirectories();
+							await restartWorkers();
+						} catch (error) {
+							harperLogger.error('Error during component reload', error);
+						}
 					} while (pending); // a request landed mid-cycle → run once more, coalescing the rest
-				} catch (error) {
-					harperLogger.error('Error during component reload', error);
 				} finally {
 					restarting = false;
 				}

--- a/components/scopeShutdown.ts
+++ b/components/scopeShutdown.ts
@@ -1,0 +1,26 @@
+/**
+ * Per-worker registry of in-flight application-scope `close()` promises.
+ *
+ * On a `harper dev` reload (and any worker shutdown) the worker tears itself down. Some components
+ * dispose native runtimes asynchronously — notably @harperfast/vite, whose `scope.close()` awaits
+ * Vite's `server.close()` to shut down the rolldown (N-API) bundler runtime. If the worker exits or is
+ * terminated while that runtime is still live, the whole process crashes (SIGSEGV/SIGABRT). The worker's
+ * shutdown path (`threadServer`) awaits {@link whenScopesClosed} before calling `realExit`, so disposal
+ * happens *before* exit.
+ *
+ * State is module-local, so it is naturally per-worker (each worker is a fresh module realm) and resets
+ * with the worker — scopes are created once at load and closed once at shutdown, so nothing accumulates.
+ */
+const closing = new Set<Promise<unknown>>();
+
+/** Track an application scope's `close()` so the worker waits for it before exiting. Never rejects. */
+export function trackScopeClose(closePromise: Promise<unknown>): void {
+	const settled = Promise.resolve(closePromise).catch(() => {});
+	closing.add(settled);
+	void settled.finally(() => closing.delete(settled));
+}
+
+/** Resolve once every tracked scope close has settled (a no-op when none are in flight). */
+export function whenScopesClosed(): Promise<unknown> {
+	return Promise.allSettled([...closing]);
+}

--- a/components/scopeShutdown.ts
+++ b/components/scopeShutdown.ts
@@ -11,16 +11,25 @@
  * State is module-local, so it is naturally per-worker (each worker is a fresh module realm) and resets
  * with the worker — scopes are created once at load and closed once at shutdown, so nothing accumulates.
  */
+import harperLogger from '../utility/logging/harper_logger.ts';
+
 const closing = new Set<Promise<unknown>>();
 
-/** Track an application scope's `close()` so the worker waits for it before exiting. Never rejects. */
+/**
+ * Track an application scope's `close()` so the worker waits for it before exiting. A close that
+ * rejects is logged — never silently swallowed — and treated as settled, so one component's failed
+ * cleanup can't wedge shutdown: `whenScopesClosed()` still resolves and the worker exits. (This is the
+ * shutdown boundary; there's nowhere useful to propagate to without preventing the exit it must allow.)
+ */
 export function trackScopeClose(closePromise: Promise<unknown>): void {
-	const settled = Promise.resolve(closePromise).catch(() => {});
+	const settled = Promise.resolve(closePromise).catch((error) => {
+		harperLogger.error('Error closing application scope during shutdown', error);
+	});
 	closing.add(settled);
 	void settled.finally(() => closing.delete(settled));
 }
 
 /** Resolve once every tracked scope close has settled (a no-op when none are in flight). */
 export function whenScopesClosed(): Promise<unknown> {
-	return Promise.allSettled([...closing]);
+	return Promise.all([...closing]);
 }

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -22,7 +22,10 @@ const MB = 1024 * 1024;
 const workers = []; // these are our child workers that we are managing
 const connectedPorts = []; // these are all known connected worker ports (siblings, children, parents)
 const MAX_UNEXPECTED_RESTARTS = 50;
-let threadTerminationTimeout = 10000; // threads, you got 10 seconds to die
+// Threads get 10s to die before they're forced. In dev (`harper dev`) we widen this: a reload's old
+// worker may be disposing a native runtime (e.g. @harperfast/vite's rolldown dev server) and forcing it
+// down mid-disposal crashes the process, so give that teardown more room before the forced backstop.
+let threadTerminationTimeout = process.env.DEV_MODE === 'true' || process.env.DEV_MODE === '1' ? 30000 : 10000;
 const RESTART_TYPE = 'restart';
 const REQUEST_THREAD_INFO = 'request_thread_info';
 const RESOURCE_REPORT = 'resource_report';

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -22,6 +22,7 @@ const { startupLog } = require('../../bin/run.ts');
 const { SERVERS, setPortServerMap, portServer } = require('../serverRegistry.ts');
 const httpComponent = require('../http.ts');
 const globals = require('../../globals.js');
+const { whenScopesClosed } = require('../../components/scopeShutdown.ts');
 
 const debugThreads = env.get(terms.CONFIG_PARAMS.THREADS_DEBUG);
 const isWindows = process.platform === 'win32';
@@ -171,10 +172,16 @@ function startServers() {
 					if (message.type === terms.ITC_EVENT_TYPES.SHUTDOWN) {
 						harperLogger.trace('received shutdown request', threadId);
 						// shutdown (for these threads) means stop listening for incoming requests (finish what we are working) and
-						// close connections as possible, then let the event loop complete
-						closeServers().then(() => {
-							realExit(0);
-						});
+						// close connections as possible, then let the event loop complete.
+						// Wait for application scopes to finish closing before exiting — some dispose a native
+						// runtime asynchronously (e.g. @harperfast/vite's rolldown dev server), and exiting the
+						// worker while that runtime is still live crashes the process. The manageThreads backstop
+						// timers still bound this if a scope's disposal hangs.
+						closeServers()
+							.then(() => whenScopesClosed())
+							.then(() => {
+								realExit(0);
+							});
 						// Clean up per-thread UDS socket and metadata files
 						httpComponent.cleanupUdsFiles();
 						if (!isBun && (debugThreads || process.env.DEV_MODE)) {


### PR DESCRIPTION
In `harper dev`, recycling a worker that holds a component with a live native (N-API) runtime — e.g. @harperfast/vite's rolldown dev server — by forced exit or `worker.terminate()` tears the V8 isolate down while that runtime's threads are still running, which crashes the whole process (SIGSEGV/SIGABRT). The safe path is to dispose the runtime first, then exit.

- Scope.close() now invokes its `close` listeners and awaits any promise they return, so a plugin's async teardown (e.g. closing the Vite dev server) completes as part of close() instead of running unawaited after emit().
- New components/scopeShutdown.ts tracks in-flight scope close() promises; componentLoader registers each scope's close on SHUTDOWN, and threadServer awaits whenScopesClosed() between closeServers() and realExit — so the worker disposes its components before it exits.
- componentLoader serializes dev reload cycles: cycles run one at a time and a single coalesced follow-up absorbs everything that arrives mid-cycle, so a burst of file changes (or a regenerate-on-reload loop) can't stack overlapping restarts that pile workers up past the forced-termination grace.
- manageThreads widens the forced-termination grace to 30s in DEV_MODE so a slow-but-progressing disposal isn't force-killed prematurely.