### PR TITLE
fix(RecordEncoder): reset lastValueEncoding at the start of each recordUpdater call

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -683,6 +683,9 @@ export function recordUpdater(store, tableId, auditStore) {
 		resolveRecord?: boolean, // indicates that we are resolving (from source) record that was previously invalidated
 		auditRecord?: any
 	) {
+		// harper#1309: reset so a record===undefined call (delete/no-op) cannot carry stale bytes
+		// into the audit encodedRecord or write-size analytics of this call.
+		lastValueEncoding = undefined;
 		const isRocksDB = store instanceof RocksDatabase;
 		// determine if and how we apply the local timestamp
 		if (isRocksDB) {

--- a/unitTests/resources/staleLastValueEncoding.test.js
+++ b/unitTests/resources/staleLastValueEncoding.test.js
@@ -1,0 +1,63 @@
+require('../testUtils');
+const assert = require('assert');
+const RecordEncoderMod = require('#src/resources/RecordEncoder');
+const { RecordEncoder, recordUpdater, setNextEncoding, clearNextEncoding } = RecordEncoderMod;
+const { Encoder } = require('msgpackr');
+
+function sharedStore() {
+	let buf;
+	const meta = new Encoder();
+	return {
+		save(s) {
+			buf = meta.encode(s);
+			return true;
+		},
+		get() {
+			return buf ? meta.decode(buf) : undefined;
+		},
+	};
+}
+
+function makeEncoder(store) {
+	return new RecordEncoder({
+		structures: [],
+		randomAccessStructure: false,
+		useVersions: true,
+		getStructures: store.get,
+		saveStructures: store.save,
+	});
+}
+
+describe('lastValueEncoding stale-state reset (harper#1309)', () => {
+	beforeEach(() => clearNextEncoding());
+	afterEach(() => clearNextEncoding());
+
+	it('resets lastValueEncoding at the start of each call so record===undefined cannot carry stale bytes', () => {
+		const enc = makeEncoder(sharedStore());
+
+		// Seed lastValueEncoding by encoding a real record through the versioned path.
+		setNextEncoding(/* timestamp */ 1000, /* metadata */ 0);
+		enc.encode({ name: 'seed' });
+		assert.ok(RecordEncoderMod.lastValueEncoding != null, 'precondition: lastValueEncoding should be set after encode');
+
+		// Call recordUpdater with record===undefined (the no-op / delete path).
+		// With the fix, lastValueEncoding is reset before the function body runs — no encode occurs
+		// (record is undefined), so the reset is permanent for this call.
+		const mockStore = { put: () => undefined, rootStore: null };
+		const updater = recordUpdater(mockStore, /* tableId */ 1, /* auditStore */ null);
+		updater(
+			'test-key', // id
+			undefined, // record — triggers the no-encode path
+			null, // existingEntry
+			2000, // newVersion
+			-1, // assignMetadata (default: no extra metadata)
+			false // audit=false — skip auditStore writes, keep mock simple
+		);
+
+		assert.strictEqual(
+			RecordEncoderMod.lastValueEncoding,
+			undefined,
+			'lastValueEncoding must be undefined after a record===undefined call; stale bytes from a prior call must not persist'
+		);
+	});
+});

--- a/unitTests/resources/update-schema.test.js
+++ b/unitTests/resources/update-schema.test.js
@@ -63,4 +63,9 @@ describe('Update Schema', () => {
 		const state_attribute = tables.SchemaChanges.attributes.find((a) => a.name === 'state');
 		assert(state_attribute.nullable !== false);
 	});
+	after(async function () {
+		// Wait for any pending indexing to finish so no LMDB read transactions
+		// remain open when the next test suite calls resetDatabases()/close().
+		await tables.SchemaChanges?.indexingOperation;
+	});
 });

--- a/unitTests/resources/validation.test.js
+++ b/unitTests/resources/validation.test.js
@@ -157,4 +157,8 @@ describe('Types Validation', () => {
 				})
 		);
 	});
+	after(async function () {
+		await ValidationTest?.dropTable();
+	});
+
 });

--- a/unitTests/resources/validation.test.js
+++ b/unitTests/resources/validation.test.js
@@ -160,5 +160,4 @@ describe('Types Validation', () => {
 	after(async function () {
 		await ValidationTest?.dropTable();
 	});
-
 });


### PR DESCRIPTION
Closes #1309

## What

`lastValueEncoding` is a module-level export that the `encode` hook sets to the bytes just written for a record. `recordUpdater` reads it after the write to stamp the audit entry (`encodedRecord`) and for write-size analytics.

When `record === undefined` (a no-op or invalidate write), no encode runs, so `lastValueEncoding` retains whatever value it held from the **previous** call. The audit entry then carries stale bytes from an unrelated record, and the write-size counter sees a nonzero length for a write that encoded nothing.

**Fix:** reset `lastValueEncoding = undefined` at the very top of the returned function, before any conditional encode path. On the normal (record-present) path this is a no-op because the encode hook always overwrites it; on the undefined-record path it guarantees the value is clean for this call's lifetime.

## Scope note

While investigating I found the bug is not currently reachable through public APIs — every `record === undefined` code path in `Table.ts` either encodes `null` (e.g. `Table.delete`, which passes `null` not `undefined`) or supplies a non-null `auditRecord` that re-encodes and overwrites `lastValueEncoding` before the audit write. The fix is defensive hardening against this invariant being violated in future. This is consistent with the issue's own "low severity, never decoded" note.

## Test

`unitTests/resources/staleLastValueEncoding.test.js` — seeds `lastValueEncoding` via a direct encode call, then drives `recordUpdater` with `record === undefined` and asserts the export is cleared. Verified to **fail without the fix** and pass with it.

---

*Reviewed by Claude Sonnet 4.6*