### PR TITLE
deploy_component: fail the deploy on peer replication failures (non-zero exit)

### DIFF
--- a/components/deploymentRecorder.ts
+++ b/components/deploymentRecorder.ts
@@ -272,6 +272,17 @@ export class DeploymentRecorder {
 	}
 
 	/**
+	 * Return the recorded peer outcomes that failed to replicate (status 'failed', as
+	 * assigned by normalizePeerResult). replicateOperation does not throw on a per-peer
+	 * failure — failures surface only as 'failed' entries in peer_results — so deployComponent
+	 * uses this to decide whether to fail the overall deploy with a non-2xx status.
+	 */
+	getFailedPeers(): Array<Record<string, unknown>> {
+		const list = this.record.peer_results;
+		return Array.isArray(list) ? list.filter((peer) => peer?.status === 'failed') : [];
+	}
+
+	/**
 	 * Stop persisting intermediate row updates; accumulate them in memory so finish() writes
 	 * the terminal state in a single put. Called before the replicate phase, where the row
 	 * otherwise receives a tight burst of puts (replicate phase + per-peer + finish) within
@@ -392,12 +403,17 @@ function normalizePeerResult(raw: unknown): Record<string, unknown> {
 		return { node: null, status: 'unknown', raw: String(raw) };
 	}
 	const r = raw as Record<string, unknown>;
-	const err = r.error;
+	// Failure detail arrives in one of two shapes: `error` (a structured object/string from a
+	// remote operation response) or `reason` (a stringified message from the replicator's
+	// per-peer `.catch` shape: { status: 'failed', reason, node }). Prefer `error`; fall back to
+	// `reason` only when the peer reported failed — otherwise the audit row records a peer
+	// "failed" with no explanation and deployComponent's failure message reads "unknown error".
+	const err = r.error ?? (r.status === 'failed' ? r.reason : undefined);
 	const hasError =
 		err != null && (typeof err === 'string' ? err.length > 0 : typeof err === 'object' || typeof err === 'number');
 	return {
 		node: r.node ?? r.name ?? r.hostname ?? null,
-		status: hasError ? 'failed' : (r.status ?? 'success'),
+		status: hasError || r.status === 'failed' ? 'failed' : (r.status ?? 'success'),
 		error: hasError
 			? {
 					message: typeof err === 'object' ? ((err as any).message ?? String(err)) : String(err),

--- a/components/operations.js
+++ b/components/operations.js
@@ -606,7 +606,16 @@ async function deployComponent(req) {
 			deployment_id: recorder?.deploymentId,
 			failed_peers: failedPeers.length > 0 ? failedPeers : undefined,
 		});
-		if (recorder) await recorder.finish('failed', err);
+		// Record the terminal failure, but never let a finish() write error (full disk, lock,
+		// dropped system table) mask the actual deploy failure — outErr carries the phase,
+		// install output, and failed_peers the caller needs.
+		if (recorder) {
+			try {
+				await recorder.finish('failed', err);
+			} catch (finishErr) {
+				log.warn('Failed to record deployment failure row', finishErr);
+			}
+		}
 		throw outErr;
 	}
 }

--- a/components/operations.js
+++ b/components/operations.js
@@ -546,6 +546,27 @@ async function deployComponent(req) {
 			response.message = `Successfully deployed: ${application.name}, restarting Harper`;
 		} else response.message = `Successfully deployed: ${application.name}`;
 
+		// Replication failures don't reject replicateOperation — they surface as 'failed'
+		// entries in peer_results. By default, treat any failed peer as an overall deploy
+		// failure so the operation returns a non-2xx status (and the CLI a non-zero exit
+		// code). The component is already deployed — and, if requested, restarted — on this
+		// origin node; the failure signals that one or more peers did not receive it. Pass
+		// ignore_replication_errors: true for best-effort deploys to partially-available clusters.
+		if (recorder && !req.ignore_replication_errors) {
+			const failedPeers = recorder.getFailedPeers();
+			if (failedPeers.length > 0) {
+				const detail = failedPeers
+					.map((peer) => `${peer.node ?? 'unknown'} (${peer.error?.message ?? 'unknown error'})`)
+					.join(', ');
+				throw new ServerError(
+					`Component '${application.name}' was deployed on the origin node but failed to replicate to ` +
+						`${failedPeers.length} of ${recorder.row.peer_results.length} peer node(s): ${detail}. ` +
+						`See deployment ${recorder.deploymentId} (get_deployment) for details, or pass ` +
+						`ignore_replication_errors: true to treat replication failures as non-fatal.`
+				);
+			}
+		}
+
 		if (recorder) {
 			response.deployment_id = recorder.deploymentId;
 			emit('phase', { phase: 'success', status: 'done' });
@@ -564,6 +585,13 @@ async function deployComponent(req) {
 		if (phase) structured.phase = phase;
 		if (capture.lines.length > 0) structured.install_output = capture;
 		if (recorder?.deploymentId) structured.deployment_id = recorder.deploymentId;
+		// Surface failed peer outcomes so callers see which nodes the deploy did not reach
+		// without a second get_deployment round-trip. Populated for replication failures (the
+		// throw above) and any other failure that occurred after peers reported. Carried on
+		// both the structured non-SSE body and the SSE 'error' event below so the two transports
+		// stay symmetric (the CLI uses SSE for deploy_component).
+		const failedPeers = recorder?.getFailedPeers() ?? [];
+		if (failedPeers.length > 0) structured.failed_peers = failedPeers;
 
 		// Wrap as a ServerError so the Fastify error handler picks a 500 by default; preserve
 		// an upstream statusCode (e.g. a ClientError from payload validation) if present.
@@ -575,6 +603,8 @@ async function deployComponent(req) {
 			code: outErr?.statusCode ?? err?.code,
 			phase,
 			install_output: capture.lines.length > 0 ? capture : undefined,
+			deployment_id: recorder?.deploymentId,
+			failed_peers: failedPeers.length > 0 ? failedPeers : undefined,
 		});
 		if (recorder) await recorder.finish('failed', err);
 		throw outErr;

--- a/components/operationsValidation.js
+++ b/components/operationsValidation.js
@@ -242,6 +242,7 @@ function deployComponentValidator(req) {
 		install_timeout: Joi.number().optional(),
 		install_allow_scripts: Joi.boolean().optional(),
 		force: Joi.boolean().optional(),
+		ignore_replication_errors: Joi.boolean().optional(),
 		urlPath: Joi.string()
 			.min(1)
 			.custom((value, helpers) => {

--- a/unitTests/components/deploymentRecorder.test.js
+++ b/unitTests/components/deploymentRecorder.test.js
@@ -79,6 +79,23 @@ describe('DeploymentRecorder.recordPeer', () => {
 		assert.strictEqual(recorder.row.peer_results[0].error.message, 'connection refused');
 	});
 
+	it('captures the replicator { status: "failed", reason } shape, surfacing reason as error.message', async () => {
+		// This is the shape replicateOperation's per-peer .catch produces (replicator.ts):
+		// the failure detail lives on `reason`, not `error`. Without picking it up the audit
+		// row would record a failed peer with no explanation.
+		const recorder = await DeploymentRecorder.create({ project: 'p' });
+		recorder.recordPeer({ node: 'node-e', status: 'failed', reason: 'Error: peer connection refused' });
+		assert.strictEqual(recorder.row.peer_results[0].status, 'failed');
+		assert.strictEqual(recorder.row.peer_results[0].error.message, 'Error: peer connection refused');
+	});
+
+	it('marks a bare { status: "failed" } as failed with a null error', async () => {
+		const recorder = await DeploymentRecorder.create({ project: 'p' });
+		recorder.recordPeer({ node: 'node-f', status: 'failed' });
+		assert.strictEqual(recorder.row.peer_results[0].status, 'failed');
+		assert.strictEqual(recorder.row.peer_results[0].error, null);
+	});
+
 	it('falls back to "name"/"hostname" when "node" is missing', async () => {
 		const recorder = await DeploymentRecorder.create({ project: 'p' });
 		recorder.recordPeer({ name: 'node-by-name', status: 'success' });
@@ -158,6 +175,48 @@ describe('DeploymentRecorder.recordPeers (bulk wrapper)', () => {
 		recorder.recordPeers('not an array');
 		recorder.recordPeers({ node: 'object-not-array' });
 		assert.deepStrictEqual(recorder.row.peer_results, []);
+	});
+});
+
+describe('DeploymentRecorder.getFailedPeers', () => {
+	let installed;
+	beforeEach(() => {
+		installed = installMockDeploymentTable();
+	});
+	afterEach(() => installed.restore());
+
+	it('returns an empty array when no peers were recorded', async () => {
+		const recorder = await DeploymentRecorder.create({ project: 'p' });
+		assert.deepStrictEqual(recorder.getFailedPeers(), []);
+	});
+
+	it('returns an empty array when all peers succeeded', async () => {
+		const recorder = await DeploymentRecorder.create({ project: 'p' });
+		recorder.recordPeers([
+			{ node: 'a', status: 'success' },
+			{ node: 'b', status: 'success' },
+		]);
+		assert.deepStrictEqual(recorder.getFailedPeers(), []);
+	});
+
+	it('returns only the failed entries (status="failed")', async () => {
+		const recorder = await DeploymentRecorder.create({ project: 'p' });
+		recorder.recordPeer({ node: 'a', status: 'success' });
+		recorder.recordPeer({ node: 'b', error: { message: 'install timed out', code: 'ETIMEDOUT' } });
+		recorder.recordPeer({ node: 'c', error: 'connection refused' });
+		const failed = recorder.getFailedPeers();
+		assert.strictEqual(failed.length, 2);
+		assert.deepStrictEqual(
+			failed.map((peer) => peer.node),
+			['b', 'c']
+		);
+		assert.strictEqual(failed[0].error.message, 'install timed out');
+	});
+
+	it('does not count an uninterpretable primitive entry (status="unknown") as failed', async () => {
+		const recorder = await DeploymentRecorder.create({ project: 'p' });
+		recorder.recordPeer('some opaque marker');
+		assert.deepStrictEqual(recorder.getFailedPeers(), []);
 	});
 });
 


### PR DESCRIPTION
Closes #1333

## Summary
`deploy_component` records per-node replication status in `peer_results` but never let a peer failure change the overall outcome — the deploy finished `success`, returned 2xx (SSE `done`), and the CLI exited **0** even when the package failed to replicate to the cluster.

This treats **any failed peer as an overall deploy failure** (non-2xx → non-zero CLI exit) by default, with an `ignore_replication_errors: true` opt-out for best-effort deploys to partially-available clusters. The component is still deployed and (if requested) restarted on the origin node; the **restart runs before** the failure is reported. The failure response carries `failed_peers` + `deployment_id` on both the SSE `error` event and the non-SSE structured body, so callers see which nodes failed and why without a second `get_deployment` round-trip.

## Changes
- `components/operations.js` — after the replicate (and restart) phase, throw when `getFailedPeers()` is non-empty and `ignore_replication_errors` is not set; the existing catch wraps it as a 500, finishes the row `failed`, and surfaces `failed_peers`/`deployment_id` on both transports. Also wrap `recorder.finish('failed')` so a row-write error can't mask the real deploy error.
- `components/deploymentRecorder.ts` — new `getFailedPeers()` helper; **`normalizePeerResult` now reads the replicator's `{ status: 'failed', reason, node }` shape** (failure detail is on `reason`, not `error`).
- `components/operationsValidation.js` — `ignore_replication_errors` boolean added to the deploy validator.
- Unit tests for `getFailedPeers`, the `reason`-shaped peer result, and a bare `{ status: 'failed' }`.

## Where to look / open questions for the reviewer
- **`normalizePeerResult` change** is the highest-leverage bit: without it the failure message and `failed_peers` always read "unknown error", because `replicateOperation` (harper-pro `replicator.ts`) reports per-peer failures via `reason`, not `error`. Worth confirming the shape against the replicator you have in mind.
- **Terminal status taxonomy (deliberately not changed):** a successful-origin-but-replication-failed deploy ends with the `hdb_deployment` row `status = 'failed'`. Per-peer granularity is preserved in `peer_results`, but the aggregate `status` alone can't distinguish "origin failed" from "origin OK, one peer offline". Raised in #1333 as an open question — kept as `failed` here to match the requested "overall failure" semantics; happy to add a `replication_failed`/`partial` status if preferred.
- **Pre-existing validation quirk (not fixed here):** `validateBySchema` discards Joi's coerced value, so a raw-HTTP JSON `ignore_replication_errors: "false"` (string) would be truthy and suppress errors. Affects all boolean deploy flags (`force`, `install_allow_scripts`), not just this one; the CLI is safe (it `JSON.parse`s flag values). Fixing the wrapper is broader than this change.
- **No core integration test for the end-to-end path:** OSS core's `replicateOperation` is a stub that returns no peers, so the multi-node assertion belongs in harper-pro (alongside the existing deploy-tracking peer test). Covered here by unit tests of the detection logic.

## Review
Cross-model review (thorough): Harper-domain (`deep-review`) + Gemini (`agy`). The Codex CLI was unavailable. Domain-pass findings (the `reason`/`error` shape mismatch and the SSE-vs-non-SSE `failed_peers` asymmetry) and the Gemini finding (a `finish()` write error could mask the informative deploy error) are all fixed in this PR. Remaining open considerations are the items above.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8)