### PR TITLE
Add RocksDB transaction log stats to analytics

### DIFF
--- a/components/mcp/tools/schemas/operations.ts
+++ b/components/mcp/tools/schemas/operations.ts
@@ -265,6 +265,10 @@ export const OPERATION_INPUT_SCHEMAS: Record<string, object> = {
 				description: 'ISO 8601 timestamp or epoch ms — inclusive window start.',
 			},
 			end_time: { type: ['number', 'string'], description: 'ISO 8601 timestamp or epoch ms — exclusive window end.' },
+			log: {
+				type: 'string',
+				description: 'Transaction log name to filter on (rocksdb-txnlog-stats metric).',
+			},
 		},
 		required: ['metric'],
 	},

--- a/components/mcp/tools/schemas/operations.ts
+++ b/components/mcp/tools/schemas/operations.ts
@@ -299,6 +299,10 @@ export const OPERATION_INPUT_SCHEMAS: Record<string, object> = {
 				description: 'ISO 8601 timestamp or epoch ms — inclusive window start.',
 			},
 			end_time: { type: ['number', 'string'], description: 'ISO 8601 timestamp or epoch ms — exclusive window end.' },
+			log: {
+				type: 'string',
+				description: 'Transaction log name to filter on (rocksdb-txnlog-stats metric).',
+			},
 		},
 		required: ['metric'],
 	},

--- a/resources/analytics/metadata.ts
+++ b/resources/analytics/metadata.ts
@@ -7,6 +7,7 @@ export const METRIC = {
 	UTILIZATION: 'utilization',
 	NODE_STORAGE: 'node-storage',
 	ROCKSDB_STATS: 'rocksdb-stats',
+	ROCKSDB_TXNLOG_STATS: 'rocksdb-txnlog-stats',
 } as const;
 
 export type BuiltInMetricName = (typeof METRIC)[keyof typeof METRIC];

--- a/resources/analytics/read.ts
+++ b/resources/analytics/read.ts
@@ -35,6 +35,9 @@ interface GetAnalyticsRequest {
 	get_attributes?: string[];
 	coalesce_time?: boolean;
 	conditions?: Conditions;
+	// Convenience filter for the rocksdb-txnlog-stats metric: restrict results to a single
+	// transaction log by name (equivalent to a `log` equals condition).
+	log?: string;
 	// When true, fan the query out to every peer node and merge the results into one
 	// cluster-wide response. Cleared before forwarding so peers only return their own.
 	replicated?: boolean;
@@ -85,6 +88,7 @@ export async function getOp(req: GetAnalyticsRequest): Promise<GetAnalyticsRespo
 		endTime: req.end_time,
 		coalesceTime: req.coalesce_time,
 		additionalConditions: req.conditions,
+		log: req.log,
 	});
 
 	if (!peers) return localResults;
@@ -171,11 +175,15 @@ interface GetAnalyticsOpts {
 	endTime?: number;
 	coalesceTime?: boolean;
 	additionalConditions?: Conditions;
+	log?: string;
 }
 
 export async function get(metric: string, opts?: GetAnalyticsOpts): Promise<Metric[]> {
-	const { getAttributes, startTime, endTime, additionalConditions } = opts ?? {};
+	const { getAttributes, startTime, endTime, additionalConditions, log: logName } = opts ?? {};
 	const conditions: Conditions = [{ attribute: 'metric', comparator: 'equals', value: metric }];
+	if (logName !== undefined) {
+		conditions.push({ attribute: 'log', comparator: 'equals', value: logName });
+	}
 	if (additionalConditions) {
 		conditions.push(...additionalConditions.map(conformCondition));
 	}

--- a/resources/analytics/read.ts
+++ b/resources/analytics/read.ts
@@ -63,6 +63,18 @@ export async function getOp(req: GetAnalyticsRequest): Promise<GetAnalyticsRespo
 			true
 		);
 	}
+	// `log` only identifies a row on the per-log rocksdb-txnlog-stats metric. Reject it for any
+	// other metric rather than silently returning zero rows (no other metric has a `log` attribute).
+	if (req.log !== undefined && req.metric !== METRIC.ROCKSDB_TXNLOG_STATS) {
+		throw handleHDBError(
+			new Error('invalid get_analytics request'),
+			`The 'log' filter is only supported for the '${METRIC.ROCKSDB_TXNLOG_STATS}' metric`,
+			hdbErrors.HTTP_STATUS_CODES.BAD_REQUEST,
+			undefined,
+			undefined,
+			true
+		);
+	}
 	// `replicated` fans the query out to every peer node and merges each node's
 	// analytics into one cluster-wide result set. Fan-out is skipped when:
 	//  - the request did not ask for it;

--- a/resources/analytics/write.ts
+++ b/resources/analytics/write.ts
@@ -421,17 +421,17 @@ const ROCKSDB_DB_COUNTERS = [
 	'stallMicros',
 	'memtableHit',
 	'memtableMiss',
+	// Transaction log counters, summed across all of a database's logs by getStats(). The summed
+	// roll-up rides on the db-level rocksdb-stats row; per-log detail lives on rocksdb-txnlog-stats.
+	'txnlogBytesWritten',
+	'txnlogTransactionsWritten',
 ] as const;
 // Gauges are scalar values that are not cumulative. They go up and down over time.
-const ROCKSDB_DB_GAUGES = ['blockCacheUsage', 'blockCacheCapacity', 'numRunningFlushes'] as const;
-const ROCKSDB_TABLE_GAUGES = ['numRunningCompactions', 'compactionPending'] as const;
-
-// Transaction log stats live on their own rocksdb-txnlog-stats metric, kept separate from the
-// rocksdb-stats block-cache/memtable/compaction columns. db.getStats() rolls up these txnlog.*
-// values summed across all of a database's logs; the db-level txnlog row reports that roll-up,
-// while per-log rows (below) break it down by log.
-const ROCKSDB_TXNLOG_DB_COUNTERS = ['txnlogBytesWritten', 'txnlogTransactionsWritten'] as const;
-const ROCKSDB_TXNLOG_DB_GAUGES = [
+const ROCKSDB_DB_GAUGES = [
+	'blockCacheUsage',
+	'blockCacheCapacity',
+	'numRunningFlushes',
+	// Transaction log gauges, summed across all of a database's logs by getStats().
 	'txnlogLogCount',
 	'txnlogFileCount',
 	'txnlogTotalSizeBytes',
@@ -442,9 +442,12 @@ const ROCKSDB_TXNLOG_DB_GAUGES = [
 	'txnlogUncommittedTransactions',
 	'txnlogReplayGapBytes',
 ] as const;
-// Per-transaction-log gauges, flattened from log.getStats(). Sequence numbers, positions, and
-// static config are intentionally dropped as noise (see normalizeTxnLogStats).
-const ROCKSDB_TXNLOG_LOG_GAUGES = [
+const ROCKSDB_TABLE_GAUGES = ['numRunningCompactions', 'compactionPending'] as const;
+
+// Per-transaction-log stats (rocksdb-txnlog-stats metric), flattened from log.getStats(), one
+// row per log. Sequence numbers, positions, and static config are intentionally dropped as noise
+// (see normalizeTxnLogStats).
+const ROCKSDB_TXNLOG_GAUGES = [
 	'fileCount',
 	'totalSizeBytes',
 	'currentFileSize',
@@ -459,7 +462,7 @@ const ROCKSDB_TXNLOG_LOG_GAUGES = [
 	'purgeRetainedUnflushedFiles',
 ] as const;
 // Per-transaction-log lifetime counters (diffed to per-period rates).
-const ROCKSDB_TXNLOG_LOG_COUNTERS = [
+const ROCKSDB_TXNLOG_COUNTERS = [
 	'totalsTransactionsWritten',
 	'totalsEntriesWritten',
 	'totalsBytesWritten',
@@ -597,39 +600,6 @@ export function buildRocksDBTableMetric(
 }
 
 /**
- * Gathers the database-level transaction log metric (rocksdb-txnlog-stats) from the txnlog.*
- * roll-up in db.getStats(), summed across all of a database's logs. Counters are diffed against
- * the prior sample; gauges pass through absolute. Carries a `database` dimension but no `log`,
- * distinguishing it from the per-log rows.
- * @param dbName - The name of the database.
- * @param stats - The normalized db.getStats() record (includes the txnlog* fields).
- * @param lastStats - The previous sample's normalized stats, for diffing counters.
- * @param now - The current time.
- * @param period - The period to store the metrics for.
- */
-export function buildRocksDBTxnLogDbMetric(
-	dbName: string,
-	stats: Record<string, number>,
-	lastStats: Record<string, number> | undefined,
-	now: number,
-	period: number | undefined
-): Record<string, unknown> {
-	const metric: Record<string, unknown> = {
-		metric: METRIC.ROCKSDB_TXNLOG_STATS,
-		database: dbName,
-		time: now,
-	};
-	if (period !== undefined) metric.period = period;
-	for (const field of ROCKSDB_TXNLOG_DB_COUNTERS) {
-		metric[field] = diffRocksDBCounter(stats[field] ?? 0, lastStats?.[field]);
-	}
-	for (const field of ROCKSDB_TXNLOG_DB_GAUGES) {
-		metric[field] = stats[field] ?? 0;
-	}
-	return metric;
-}
-
-/**
  * Gathers metrics for a single RocksDB transaction log (rocksdb-txnlog-stats). Counters are
  * diffed against the prior sample (like the DB-level counters); gauges pass through absolute.
  * Carries a `log` dimension alongside `database`.
@@ -655,10 +625,10 @@ export function buildRocksDBTxnLogMetric(
 		time: now,
 	};
 	if (period !== undefined) metric.period = period;
-	for (const field of ROCKSDB_TXNLOG_LOG_COUNTERS) {
+	for (const field of ROCKSDB_TXNLOG_COUNTERS) {
 		metric[field] = diffRocksDBCounter(stats[field] ?? 0, lastStats?.[field]);
 	}
-	for (const field of ROCKSDB_TXNLOG_LOG_GAUGES) {
+	for (const field of ROCKSDB_TXNLOG_GAUGES) {
 		metric[field] = stats[field] ?? 0;
 	}
 	return metric;
@@ -707,10 +677,6 @@ function storeRocksDBStatsMetrics(
 				const dbMetric = buildRocksDBDbMetric(db, firstNormalizedStats, lastDbStats, now, period);
 				storeMetric(analyticsTable, dbMetric);
 				log.trace?.(`db ${db} rocksdb stats metric: ${JSON.stringify(dbMetric)}`);
-				// The txnlog.* roll-up from the same getStats() reading goes on its own metric.
-				const txnLogDbMetric = buildRocksDBTxnLogDbMetric(db, firstNormalizedStats, lastDbStats, now, period);
-				storeMetric(analyticsTable, txnLogDbMetric);
-				log.trace?.(`db ${db} rocksdb txnlog stats metric: ${JSON.stringify(txnLogDbMetric)}`);
 			}
 			lastRocksDBDbStats.set(db, firstNormalizedStats);
 		}

--- a/resources/analytics/write.ts
+++ b/resources/analytics/write.ts
@@ -14,7 +14,7 @@ import { server } from '../../server/Server.ts';
 import * as fs from 'node:fs';
 import { getAnalyticsHostnameTable, nodeIds, stableNodeId } from './hostnames.ts';
 import { METRIC } from './metadata.ts';
-import { RocksDatabase } from '@harperfast/rocksdb-js';
+import { RocksDatabase, type TransactionLogStats } from '@harperfast/rocksdb-js';
 
 const log = forComponent('analytics').conditional;
 const isBun = typeof globalThis.Bun !== 'undefined';
@@ -421,12 +421,56 @@ const ROCKSDB_DB_COUNTERS = [
 	'stallMicros',
 	'memtableHit',
 	'memtableMiss',
+	// Transaction log counters, summed across all of a database's logs by getStats().
+	'txnlogBytesWritten',
+	'txnlogTransactionsWritten',
 ] as const;
 // Gauges are scalar values that are not cumulative. They go up and down over time.
-const ROCKSDB_DB_GAUGES = ['blockCacheUsage', 'blockCacheCapacity', 'numRunningFlushes'] as const;
+const ROCKSDB_DB_GAUGES = [
+	'blockCacheUsage',
+	'blockCacheCapacity',
+	'numRunningFlushes',
+	// Transaction log gauges, summed across all of a database's logs by getStats().
+	'txnlogLogCount',
+	'txnlogFileCount',
+	'txnlogTotalSizeBytes',
+	'txnlogMappedBytes',
+	'txnlogOverlayBytes',
+	'txnlogActiveMaps',
+	'txnlogPendingTransactions',
+	'txnlogUncommittedTransactions',
+	'txnlogReplayGapBytes',
+] as const;
 const ROCKSDB_TABLE_GAUGES = ['numRunningCompactions', 'compactionPending'] as const;
+// Per-transaction-log gauges, flattened from log.getStats(). Sequence numbers, positions, and
+// static config are intentionally dropped as noise (see normalizeTxnLogStats).
+const ROCKSDB_LOG_GAUGES = [
+	'fileCount',
+	'totalSizeBytes',
+	'currentFileSize',
+	'pendingTransactions',
+	'uncommittedTransactions',
+	'replayGapBytes',
+	'memoryMappedBytes',
+	'memoryOverlayBytes',
+	'memoryActiveMaps',
+	'purgeOldestFileAgeMs',
+	'purgePurgeableFiles',
+	'purgeRetainedUnflushedFiles',
+] as const;
+// Per-transaction-log lifetime counters (diffed to per-period rates).
+const ROCKSDB_LOG_COUNTERS = [
+	'totalsTransactionsWritten',
+	'totalsEntriesWritten',
+	'totalsBytesWritten',
+	'totalsRotations',
+	'totalsWriteFailures',
+] as const;
 
 const lastRocksDBDbStats = new Map<string, Record<string, number>>();
+// Per-log counter baselines, nested db name -> log name -> last normalized stats, so a database's
+// log baselines can be pruned together when the database is dropped.
+const lastRocksDBLogStats = new Map<string, Map<string, Record<string, number>>>();
 let lastRocksDBStatsTime = 0;
 
 export function diffRocksDBCounter(curr: number, last: number | undefined): number {
@@ -448,6 +492,47 @@ export function normalizeRocksDBStats(raw: Record<string, unknown>): Record<stri
 	if (!raw) return out;
 	for (const [key, value] of Object.entries(raw)) {
 		if (typeof value === 'number') out[toRocksDBCamelCase(key)] = value;
+	}
+	return out;
+}
+
+/**
+ * Flattens a per-log TransactionLogStats snapshot to the flat numeric record used by analytics,
+ * selecting only the performance- and resource-relevant fields. Sequence numbers, log positions,
+ * the path, and static config are intentionally dropped — they carry no analytic signal as a
+ * periodic time series (replayGapBytes already captures the meaningful flushed-vs-written gap).
+ * @param raw - The raw per-log stats from log.getStats().
+ * @returns The normalized per-log stats record.
+ */
+export function normalizeTxnLogStats(raw: TransactionLogStats): Record<string, number> {
+	const out: Record<string, number> = {};
+	if (!raw) return out;
+	const setNumber = (key: string, value: unknown) => {
+		if (typeof value === 'number') out[key] = value;
+	};
+	setNumber('fileCount', raw.fileCount);
+	setNumber('totalSizeBytes', raw.totalSizeBytes);
+	setNumber('currentFileSize', raw.currentFileSize);
+	setNumber('pendingTransactions', raw.pendingTransactions);
+	setNumber('uncommittedTransactions', raw.uncommittedTransactions);
+	setNumber('replayGapBytes', raw.replayGapBytes);
+	const { memory, purge, totals } = raw;
+	if (memory) {
+		setNumber('memoryMappedBytes', memory.mappedBytes);
+		setNumber('memoryOverlayBytes', memory.overlayBytes);
+		setNumber('memoryActiveMaps', memory.activeMaps);
+	}
+	if (purge) {
+		setNumber('purgeOldestFileAgeMs', purge.oldestFileAgeMs);
+		setNumber('purgePurgeableFiles', purge.purgeableFiles);
+		setNumber('purgeRetainedUnflushedFiles', purge.retainedUnflushedFiles);
+	}
+	if (totals) {
+		setNumber('totalsTransactionsWritten', totals.transactionsWritten);
+		setNumber('totalsEntriesWritten', totals.entriesWritten);
+		setNumber('totalsBytesWritten', totals.bytesWritten);
+		setNumber('totalsRotations', totals.rotations);
+		setNumber('totalsWriteFailures', totals.writeFailures);
 	}
 	return out;
 }
@@ -512,6 +597,41 @@ export function buildRocksDBTableMetric(
 }
 
 /**
+ * Gathers metrics for a single RocksDB transaction log. Counters are diffed against the prior
+ * sample (like the DB-level counters); gauges pass through absolute. Reuses the rocksdb-stats
+ * metric with a `log` dimension instead of `table`.
+ * @param dbName - The name of the database the log is attached to.
+ * @param logName - The name of the transaction log.
+ * @param stats - The normalized per-log stats.
+ * @param lastStats - The previous sample's normalized stats, for diffing counters.
+ * @param now - The current time.
+ * @param period - The period to store the metrics for.
+ */
+export function buildRocksDBLogMetric(
+	dbName: string,
+	logName: string,
+	stats: Record<string, number>,
+	lastStats: Record<string, number> | undefined,
+	now: number,
+	period: number | undefined
+): Record<string, unknown> {
+	const metric: Record<string, unknown> = {
+		metric: METRIC.ROCKSDB_STATS,
+		database: dbName,
+		log: logName,
+		time: now,
+	};
+	if (period !== undefined) metric.period = period;
+	for (const field of ROCKSDB_LOG_COUNTERS) {
+		metric[field] = diffRocksDBCounter(stats[field] ?? 0, lastStats?.[field]);
+	}
+	for (const field of ROCKSDB_LOG_GAUGES) {
+		metric[field] = stats[field] ?? 0;
+	}
+	return metric;
+}
+
+/**
  * Stores the RocksDB stats metrics for the given databases.
  * @param analyticsTable - The analytics table to store the metrics in.
  * @param databases - The databases to store the metrics for.
@@ -528,7 +648,9 @@ function storeRocksDBStatsMetrics(
 		if (!tables) continue; // no tables or not loaded/initialized yet
 		const tableEntries = Object.entries(tables);
 		const [, firstTable] = tableEntries[0] ?? [];
-		if (!(firstTable?.primaryStore instanceof RocksDatabase)) continue;
+		// Tables in a database share one root store; check the first to skip non-RocksDB databases.
+		const rootStore = firstTable?.primaryStore;
+		if (!(rootStore instanceof RocksDatabase)) continue;
 
 		let firstNormalizedStats: Record<string, number> | undefined;
 		for (const [tableName, tbl] of tableEntries) {
@@ -555,6 +677,49 @@ function storeRocksDBStatsMetrics(
 			}
 			lastRocksDBDbStats.set(db, firstNormalizedStats);
 		}
+
+		// Per-transaction-log stats. Logs are attached at the database (root store) level, so we
+		// enumerate them once per database rather than per table.
+		let logNames: string[];
+		try {
+			logNames = rootStore.listLogs();
+		} catch (error) {
+			// The store may have been closed/dropped mid-cycle (e.g. "Database not open"); skip this
+			// database's logs rather than letting the throw abort the whole analytics cycle.
+			log.warn?.(`Error listing RocksDB logs for ${db}`, error);
+			continue;
+		}
+		let logStatsByName = lastRocksDBLogStats.get(db);
+		const seenLogs = new Set<string>();
+		for (const logName of logNames) {
+			seenLogs.add(logName);
+			try {
+				const logStats = normalizeTxnLogStats(rootStore.useLog(logName).getStats());
+				const lastLogStats = logStatsByName?.get(logName);
+				// Skip the first sample for a log — its counters are cumulative since the log was
+				// created, so a delta-from-zero would produce a misleading spike (mirrors the
+				// DB-level skip above).
+				if (lastLogStats !== undefined) {
+					const logMetric = buildRocksDBLogMetric(db, logName, logStats, lastLogStats, now, period);
+					storeMetric(analyticsTable, logMetric);
+					log.trace?.(`db ${db} log ${logName} rocksdb txnlog metric: ${JSON.stringify(logMetric)}`);
+				}
+				if (!logStatsByName) {
+					logStatsByName = new Map();
+					lastRocksDBLogStats.set(db, logStatsByName);
+				}
+				logStatsByName.set(logName, logStats);
+			} catch (error) {
+				// A log may be removed mid-collection — keep iterating siblings.
+				log.warn?.(`Error getting RocksDB stats for log ${db}.${logName}`, error);
+			}
+		}
+		// Drop cached baselines for logs that no longer exist on this database.
+		if (logStatsByName) {
+			for (const cachedLog of logStatsByName.keys()) {
+				if (!seenLogs.has(cachedLog)) logStatsByName.delete(cachedLog);
+			}
+		}
 	}
 }
 
@@ -567,6 +732,9 @@ function pruneRocksDBStatsCache(databases: Databases) {
 	const activeDbs = new Set<string>(Object.keys(databases));
 	for (const key of lastRocksDBDbStats.keys()) {
 		if (!activeDbs.has(key)) lastRocksDBDbStats.delete(key);
+	}
+	for (const key of lastRocksDBLogStats.keys()) {
+		if (!activeDbs.has(key)) lastRocksDBLogStats.delete(key);
 	}
 }
 

--- a/resources/analytics/write.ts
+++ b/resources/analytics/write.ts
@@ -421,16 +421,17 @@ const ROCKSDB_DB_COUNTERS = [
 	'stallMicros',
 	'memtableHit',
 	'memtableMiss',
-	// Transaction log counters, summed across all of a database's logs by getStats().
-	'txnlogBytesWritten',
-	'txnlogTransactionsWritten',
 ] as const;
 // Gauges are scalar values that are not cumulative. They go up and down over time.
-const ROCKSDB_DB_GAUGES = [
-	'blockCacheUsage',
-	'blockCacheCapacity',
-	'numRunningFlushes',
-	// Transaction log gauges, summed across all of a database's logs by getStats().
+const ROCKSDB_DB_GAUGES = ['blockCacheUsage', 'blockCacheCapacity', 'numRunningFlushes'] as const;
+const ROCKSDB_TABLE_GAUGES = ['numRunningCompactions', 'compactionPending'] as const;
+
+// Transaction log stats live on their own rocksdb-txnlog-stats metric, kept separate from the
+// rocksdb-stats block-cache/memtable/compaction columns. db.getStats() rolls up these txnlog.*
+// values summed across all of a database's logs; the db-level txnlog row reports that roll-up,
+// while per-log rows (below) break it down by log.
+const ROCKSDB_TXNLOG_DB_COUNTERS = ['txnlogBytesWritten', 'txnlogTransactionsWritten'] as const;
+const ROCKSDB_TXNLOG_DB_GAUGES = [
 	'txnlogLogCount',
 	'txnlogFileCount',
 	'txnlogTotalSizeBytes',
@@ -441,10 +442,9 @@ const ROCKSDB_DB_GAUGES = [
 	'txnlogUncommittedTransactions',
 	'txnlogReplayGapBytes',
 ] as const;
-const ROCKSDB_TABLE_GAUGES = ['numRunningCompactions', 'compactionPending'] as const;
 // Per-transaction-log gauges, flattened from log.getStats(). Sequence numbers, positions, and
 // static config are intentionally dropped as noise (see normalizeTxnLogStats).
-const ROCKSDB_LOG_GAUGES = [
+const ROCKSDB_TXNLOG_LOG_GAUGES = [
 	'fileCount',
 	'totalSizeBytes',
 	'currentFileSize',
@@ -459,7 +459,7 @@ const ROCKSDB_LOG_GAUGES = [
 	'purgeRetainedUnflushedFiles',
 ] as const;
 // Per-transaction-log lifetime counters (diffed to per-period rates).
-const ROCKSDB_LOG_COUNTERS = [
+const ROCKSDB_TXNLOG_LOG_COUNTERS = [
 	'totalsTransactionsWritten',
 	'totalsEntriesWritten',
 	'totalsBytesWritten',
@@ -597,9 +597,42 @@ export function buildRocksDBTableMetric(
 }
 
 /**
- * Gathers metrics for a single RocksDB transaction log. Counters are diffed against the prior
- * sample (like the DB-level counters); gauges pass through absolute. Reuses the rocksdb-stats
- * metric with a `log` dimension instead of `table`.
+ * Gathers the database-level transaction log metric (rocksdb-txnlog-stats) from the txnlog.*
+ * roll-up in db.getStats(), summed across all of a database's logs. Counters are diffed against
+ * the prior sample; gauges pass through absolute. Carries a `database` dimension but no `log`,
+ * distinguishing it from the per-log rows.
+ * @param dbName - The name of the database.
+ * @param stats - The normalized db.getStats() record (includes the txnlog* fields).
+ * @param lastStats - The previous sample's normalized stats, for diffing counters.
+ * @param now - The current time.
+ * @param period - The period to store the metrics for.
+ */
+export function buildRocksDBTxnLogDbMetric(
+	dbName: string,
+	stats: Record<string, number>,
+	lastStats: Record<string, number> | undefined,
+	now: number,
+	period: number | undefined
+): Record<string, unknown> {
+	const metric: Record<string, unknown> = {
+		metric: METRIC.ROCKSDB_TXNLOG_STATS,
+		database: dbName,
+		time: now,
+	};
+	if (period !== undefined) metric.period = period;
+	for (const field of ROCKSDB_TXNLOG_DB_COUNTERS) {
+		metric[field] = diffRocksDBCounter(stats[field] ?? 0, lastStats?.[field]);
+	}
+	for (const field of ROCKSDB_TXNLOG_DB_GAUGES) {
+		metric[field] = stats[field] ?? 0;
+	}
+	return metric;
+}
+
+/**
+ * Gathers metrics for a single RocksDB transaction log (rocksdb-txnlog-stats). Counters are
+ * diffed against the prior sample (like the DB-level counters); gauges pass through absolute.
+ * Carries a `log` dimension alongside `database`.
  * @param dbName - The name of the database the log is attached to.
  * @param logName - The name of the transaction log.
  * @param stats - The normalized per-log stats.
@@ -607,7 +640,7 @@ export function buildRocksDBTableMetric(
  * @param now - The current time.
  * @param period - The period to store the metrics for.
  */
-export function buildRocksDBLogMetric(
+export function buildRocksDBTxnLogMetric(
 	dbName: string,
 	logName: string,
 	stats: Record<string, number>,
@@ -616,16 +649,16 @@ export function buildRocksDBLogMetric(
 	period: number | undefined
 ): Record<string, unknown> {
 	const metric: Record<string, unknown> = {
-		metric: METRIC.ROCKSDB_STATS,
+		metric: METRIC.ROCKSDB_TXNLOG_STATS,
 		database: dbName,
 		log: logName,
 		time: now,
 	};
 	if (period !== undefined) metric.period = period;
-	for (const field of ROCKSDB_LOG_COUNTERS) {
+	for (const field of ROCKSDB_TXNLOG_LOG_COUNTERS) {
 		metric[field] = diffRocksDBCounter(stats[field] ?? 0, lastStats?.[field]);
 	}
-	for (const field of ROCKSDB_LOG_GAUGES) {
+	for (const field of ROCKSDB_TXNLOG_LOG_GAUGES) {
 		metric[field] = stats[field] ?? 0;
 	}
 	return metric;
@@ -674,6 +707,10 @@ function storeRocksDBStatsMetrics(
 				const dbMetric = buildRocksDBDbMetric(db, firstNormalizedStats, lastDbStats, now, period);
 				storeMetric(analyticsTable, dbMetric);
 				log.trace?.(`db ${db} rocksdb stats metric: ${JSON.stringify(dbMetric)}`);
+				// The txnlog.* roll-up from the same getStats() reading goes on its own metric.
+				const txnLogDbMetric = buildRocksDBTxnLogDbMetric(db, firstNormalizedStats, lastDbStats, now, period);
+				storeMetric(analyticsTable, txnLogDbMetric);
+				log.trace?.(`db ${db} rocksdb txnlog stats metric: ${JSON.stringify(txnLogDbMetric)}`);
 			}
 			lastRocksDBDbStats.set(db, firstNormalizedStats);
 		}
@@ -700,7 +737,7 @@ function storeRocksDBStatsMetrics(
 				// created, so a delta-from-zero would produce a misleading spike (mirrors the
 				// DB-level skip above).
 				if (lastLogStats !== undefined) {
-					const logMetric = buildRocksDBLogMetric(db, logName, logStats, lastLogStats, now, period);
+					const logMetric = buildRocksDBTxnLogMetric(db, logName, logStats, lastLogStats, now, period);
 					storeMetric(analyticsTable, logMetric);
 					log.trace?.(`db ${db} log ${logName} rocksdb txnlog metric: ${JSON.stringify(logMetric)}`);
 				}

--- a/unitTests/resources/analytics/read.test.js
+++ b/unitTests/resources/analytics/read.test.js
@@ -524,4 +524,15 @@ describe('getOp (log filter)', () => {
 		const conditions = searchStub.firstCall.args[0].conditions;
 		expect(conditions.some((c) => c.attribute === 'log')).to.be.false;
 	});
+
+	it('rejects a `log` filter on a non-txnlog metric instead of silently returning nothing', async () => {
+		let threw = false;
+		try {
+			await getOp({ metric: 'cpu-usage', log: 'audit' });
+		} catch {
+			threw = true;
+		}
+		expect(threw).to.be.true;
+		expect(searchStub.called).to.be.false;
+	});
 });

--- a/unitTests/resources/analytics/read.test.js
+++ b/unitTests/resources/analytics/read.test.js
@@ -490,3 +490,38 @@ describe('getOp (replicated fan-out)', () => {
 		expect(result).to.deep.equal([{ id: 10, metric: 'm', total: 1 }]);
 	});
 });
+
+describe('getOp (log filter)', () => {
+	let searchStub;
+	let originalDatabases;
+	let originalServer;
+
+	beforeEach(() => {
+		originalDatabases = global.databases;
+		originalServer = global.server;
+		searchStub = sinon.stub().returns(mockSearchIterable([]));
+		global.databases = { system: { hdb_analytics: { search: searchStub, replicate: true } } };
+		global.server = { hostname: 'local-host', nodes: [] };
+	});
+
+	afterEach(() => {
+		sinon.restore();
+		global.databases = originalDatabases;
+		global.server = originalServer;
+	});
+
+	it('adds a `log` equals condition when log is provided', async () => {
+		await collect(await getOp({ metric: 'rocksdb-txnlog-stats', log: 'audit' }));
+
+		const conditions = searchStub.firstCall.args[0].conditions;
+		expect(conditions[0]).to.deep.equal({ attribute: 'metric', comparator: 'equals', value: 'rocksdb-txnlog-stats' });
+		expect(conditions).to.deep.include({ attribute: 'log', comparator: 'equals', value: 'audit' });
+	});
+
+	it('does not add a `log` condition when log is omitted', async () => {
+		await collect(await getOp({ metric: 'rocksdb-txnlog-stats' }));
+
+		const conditions = searchStub.firstCall.args[0].conditions;
+		expect(conditions.some((c) => c.attribute === 'log')).to.be.false;
+	});
+});

--- a/unitTests/resources/analytics/write.test.js
+++ b/unitTests/resources/analytics/write.test.js
@@ -7,8 +7,10 @@ const {
 	toRocksDBCamelCase,
 	diffRocksDBCounter,
 	normalizeRocksDBStats,
+	normalizeTxnLogStats,
 	buildRocksDBDbMetric,
 	buildRocksDBTableMetric,
+	buildRocksDBLogMetric,
 } = require('#src/resources/analytics/write');
 const { writeFile, mkdtemp, rm, mkdir } = require('node:fs/promises');
 const { join } = require('node:path');
@@ -251,6 +253,29 @@ describe('buildRocksDBDbMetric', () => {
 		expect(metric.blockCacheUsage).to.equal(0);
 		expect(metric.numRunningFlushes).to.equal(0);
 	});
+
+	it('diffs txnlog counters and passes txnlog gauges through (summed across the db logs)', () => {
+		const last = { txnlogBytesWritten: 1000, txnlogTransactionsWritten: 40 };
+		const stats = {
+			txnlogBytesWritten: 1500, // delta 500
+			txnlogTransactionsWritten: 55, // delta 15
+			txnlogLogCount: 2,
+			txnlogFileCount: 6,
+			txnlogTotalSizeBytes: 4096,
+			txnlogMappedBytes: 8192,
+			txnlogOverlayBytes: 256,
+			txnlogActiveMaps: 2,
+			txnlogPendingTransactions: 3,
+			txnlogUncommittedTransactions: 1,
+			txnlogReplayGapBytes: 512,
+		};
+		const metric = buildRocksDBDbMetric('mydb', stats, last, now, 5000);
+		expect(metric.txnlogBytesWritten).to.equal(500);
+		expect(metric.txnlogTransactionsWritten).to.equal(15);
+		expect(metric.txnlogLogCount).to.equal(2);
+		expect(metric.txnlogTotalSizeBytes).to.equal(4096);
+		expect(metric.txnlogReplayGapBytes).to.equal(512);
+	});
 });
 
 describe('buildRocksDBTableMetric', () => {
@@ -282,5 +307,140 @@ describe('buildRocksDBTableMetric', () => {
 		const metric = buildRocksDBTableMetric('mydb', 'mytable', stats, now, 1000);
 		expect(metric).to.not.have.property('memtableHit');
 		expect(metric).to.not.have.property('memtableMiss');
+	});
+});
+
+// A representative log.getStats() snapshot covering every nested group plus the fields we drop.
+const sampleTxnLogStats = () => ({
+	name: 'audit',
+	path: '/data/mydb/txnlog/audit',
+	fileCount: 4,
+	currentSequenceNumber: 42,
+	oldestSequenceNumber: 38,
+	totalSizeBytes: 8192,
+	currentFileSize: 2048,
+	pendingTransactions: 3,
+	uncommittedTransactions: 1,
+	replayGapBytes: 512,
+	memory: { mappedBytes: 65536, overlayBytes: 4096, activeMaps: 2 },
+	nextLogPosition: { sequence: 42, offset: 2048 },
+	lastFlushedPosition: { sequence: 42, offset: 1536 },
+	lastCommittedPosition: { sequence: 42, offset: 1024 },
+	purge: { oldestFileAgeMs: 90000, purgeableFiles: 1, retainedUnflushedFiles: 0, lastPurgeMs: 1_699_999_900_000 },
+	totals: {
+		transactionsWritten: 1000,
+		entriesWritten: 1200,
+		bytesWritten: 500000,
+		rotations: 4,
+		filesPurged: 2,
+		bytesPurged: 16384,
+		purgeRuns: 5,
+		databaseFlushes: 8,
+		writeFailures: 0,
+	},
+	config: { maxFileSize: 1048576, retentionMs: 86400000, maxAgeThreshold: 0.8 },
+});
+
+describe('normalizeTxnLogStats', () => {
+	it('flattens the selected performance and resource fields', () => {
+		const out = normalizeTxnLogStats(sampleTxnLogStats());
+		expect(out).to.deep.equal({
+			fileCount: 4,
+			totalSizeBytes: 8192,
+			currentFileSize: 2048,
+			pendingTransactions: 3,
+			uncommittedTransactions: 1,
+			replayGapBytes: 512,
+			memoryMappedBytes: 65536,
+			memoryOverlayBytes: 4096,
+			memoryActiveMaps: 2,
+			purgeOldestFileAgeMs: 90000,
+			purgePurgeableFiles: 1,
+			purgeRetainedUnflushedFiles: 0,
+			totalsTransactionsWritten: 1000,
+			totalsEntriesWritten: 1200,
+			totalsBytesWritten: 500000,
+			totalsRotations: 4,
+			totalsWriteFailures: 0,
+		});
+	});
+
+	it('drops noise fields (path, sequence numbers, positions, lastPurgeMs, config, borderline counters)', () => {
+		const out = normalizeTxnLogStats(sampleTxnLogStats());
+		for (const dropped of [
+			'name',
+			'path',
+			'currentSequenceNumber',
+			'oldestSequenceNumber',
+			'nextLogPosition',
+			'lastFlushedPosition',
+			'lastCommittedPosition',
+			'purgeLastPurgeMs',
+			'maxFileSize',
+			'retentionMs',
+			'maxAgeThreshold',
+			'totalsFilesPurged',
+			'totalsBytesPurged',
+			'totalsPurgeRuns',
+			'totalsDatabaseFlushes',
+		]) {
+			expect(out).to.not.have.property(dropped);
+		}
+	});
+
+	it('tolerates missing nested groups', () => {
+		const out = normalizeTxnLogStats({ fileCount: 1, totalSizeBytes: 10 });
+		expect(out).to.deep.equal({ fileCount: 1, totalSizeBytes: 10 });
+	});
+});
+
+describe('buildRocksDBLogMetric', () => {
+	const now = 1_700_000_000_000;
+
+	it('includes database and log dimensions (not table)', () => {
+		const metric = buildRocksDBLogMetric('mydb', 'audit', {}, undefined, now, undefined);
+		expect(metric).to.include({
+			metric: 'rocksdb-stats',
+			database: 'mydb',
+			log: 'audit',
+			time: now,
+		});
+		expect(metric).to.not.have.property('table');
+		expect(metric).to.not.have.property('period');
+	});
+
+	it('reports counters absolute on the first sample', () => {
+		const stats = normalizeTxnLogStats(sampleTxnLogStats());
+		const metric = buildRocksDBLogMetric('mydb', 'audit', stats, undefined, now, undefined);
+		expect(metric.totalsTransactionsWritten).to.equal(1000);
+		expect(metric.totalsBytesWritten).to.equal(500000);
+		// Gauges always pass through absolute.
+		expect(metric.replayGapBytes).to.equal(512);
+		expect(metric.memoryOverlayBytes).to.equal(4096);
+	});
+
+	it('diffs counters and passes gauges through on subsequent samples', () => {
+		const last = { totalsTransactionsWritten: 1000, totalsBytesWritten: 500000, totalsRotations: 4 };
+		const stats = {
+			totalsTransactionsWritten: 1250, // delta 250
+			totalsBytesWritten: 600000, // delta 100000
+			totalsRotations: 5, // delta 1
+			replayGapBytes: 1024, // gauge — absolute
+			pendingTransactions: 7,
+		};
+		const metric = buildRocksDBLogMetric('mydb', 'audit', stats, last, now, 5000);
+		expect(metric.period).to.equal(5000);
+		expect(metric.totalsTransactionsWritten).to.equal(250);
+		expect(metric.totalsBytesWritten).to.equal(100000);
+		expect(metric.totalsRotations).to.equal(1);
+		expect(metric.replayGapBytes).to.equal(1024);
+		expect(metric.pendingTransactions).to.equal(7);
+	});
+
+	it('defaults missing stats to 0', () => {
+		const metric = buildRocksDBLogMetric('mydb', 'audit', {}, undefined, now, undefined);
+		expect(metric.totalsTransactionsWritten).to.equal(0);
+		expect(metric.replayGapBytes).to.equal(0);
+		expect(metric.fileCount).to.equal(0);
 	});
 });

--- a/unitTests/resources/analytics/write.test.js
+++ b/unitTests/resources/analytics/write.test.js
@@ -10,7 +10,6 @@ const {
 	normalizeTxnLogStats,
 	buildRocksDBDbMetric,
 	buildRocksDBTableMetric,
-	buildRocksDBTxnLogDbMetric,
 	buildRocksDBTxnLogMetric,
 } = require('#src/resources/analytics/write');
 const { writeFile, mkdtemp, rm, mkdir } = require('node:fs/promises');
@@ -255,60 +254,22 @@ describe('buildRocksDBDbMetric', () => {
 		expect(metric.numRunningFlushes).to.equal(0);
 	});
 
-	it('does not emit txnlog fields (they live on rocksdb-txnlog-stats)', () => {
-		const stats = { bytesRead: 100, txnlogBytesWritten: 1500, txnlogLogCount: 2, txnlogReplayGapBytes: 512 };
-		const metric = buildRocksDBDbMetric('mydb', stats, undefined, now, undefined);
-		expect(metric).to.not.have.property('txnlogBytesWritten');
-		expect(metric).to.not.have.property('txnlogLogCount');
-		expect(metric).to.not.have.property('txnlogReplayGapBytes');
-	});
-});
-
-describe('buildRocksDBTxnLogDbMetric', () => {
-	const now = 1_700_000_000_000;
-
-	it('builds a rocksdb-txnlog-stats database row (no table/log dimension)', () => {
-		const metric = buildRocksDBTxnLogDbMetric('mydb', {}, undefined, now, undefined);
-		expect(metric).to.include({
-			metric: 'rocksdb-txnlog-stats',
-			database: 'mydb',
-			time: now,
-		});
-		expect(metric).to.not.have.property('table');
-		expect(metric).to.not.have.property('log');
-		expect(metric).to.not.have.property('period');
-	});
-
-	it('diffs txnlog counters and passes txnlog gauges through (summed across the db logs)', () => {
+	it('folds the txnlog roll-up onto the db row (counters diffed, gauges absolute)', () => {
 		const last = { txnlogBytesWritten: 1000, txnlogTransactionsWritten: 40 };
 		const stats = {
 			txnlogBytesWritten: 1500, // delta 500
 			txnlogTransactionsWritten: 55, // delta 15
 			txnlogLogCount: 2,
-			txnlogFileCount: 6,
 			txnlogTotalSizeBytes: 4096,
-			txnlogMappedBytes: 8192,
-			txnlogOverlayBytes: 256,
-			txnlogActiveMaps: 2,
-			txnlogPendingTransactions: 3,
-			txnlogUncommittedTransactions: 1,
 			txnlogReplayGapBytes: 512,
 		};
-		const metric = buildRocksDBTxnLogDbMetric('mydb', stats, last, now, 5000);
-		expect(metric.period).to.equal(5000);
+		const metric = buildRocksDBDbMetric('mydb', stats, last, now, 5000);
+		expect(metric.metric).to.equal('rocksdb-stats');
 		expect(metric.txnlogBytesWritten).to.equal(500);
 		expect(metric.txnlogTransactionsWritten).to.equal(15);
 		expect(metric.txnlogLogCount).to.equal(2);
 		expect(metric.txnlogTotalSizeBytes).to.equal(4096);
 		expect(metric.txnlogReplayGapBytes).to.equal(512);
-	});
-
-	it('does not include the rocksdb-stats block-cache columns', () => {
-		const stats = { bytesRead: 100, blockCacheHit: 5, txnlogLogCount: 2 };
-		const metric = buildRocksDBTxnLogDbMetric('mydb', stats, undefined, now, undefined);
-		expect(metric).to.not.have.property('bytesRead');
-		expect(metric).to.not.have.property('blockCacheHit');
-		expect(metric.txnlogLogCount).to.equal(2);
 	});
 });
 

--- a/unitTests/resources/analytics/write.test.js
+++ b/unitTests/resources/analytics/write.test.js
@@ -10,7 +10,8 @@ const {
 	normalizeTxnLogStats,
 	buildRocksDBDbMetric,
 	buildRocksDBTableMetric,
-	buildRocksDBLogMetric,
+	buildRocksDBTxnLogDbMetric,
+	buildRocksDBTxnLogMetric,
 } = require('#src/resources/analytics/write');
 const { writeFile, mkdtemp, rm, mkdir } = require('node:fs/promises');
 const { join } = require('node:path');
@@ -254,6 +255,30 @@ describe('buildRocksDBDbMetric', () => {
 		expect(metric.numRunningFlushes).to.equal(0);
 	});
 
+	it('does not emit txnlog fields (they live on rocksdb-txnlog-stats)', () => {
+		const stats = { bytesRead: 100, txnlogBytesWritten: 1500, txnlogLogCount: 2, txnlogReplayGapBytes: 512 };
+		const metric = buildRocksDBDbMetric('mydb', stats, undefined, now, undefined);
+		expect(metric).to.not.have.property('txnlogBytesWritten');
+		expect(metric).to.not.have.property('txnlogLogCount');
+		expect(metric).to.not.have.property('txnlogReplayGapBytes');
+	});
+});
+
+describe('buildRocksDBTxnLogDbMetric', () => {
+	const now = 1_700_000_000_000;
+
+	it('builds a rocksdb-txnlog-stats database row (no table/log dimension)', () => {
+		const metric = buildRocksDBTxnLogDbMetric('mydb', {}, undefined, now, undefined);
+		expect(metric).to.include({
+			metric: 'rocksdb-txnlog-stats',
+			database: 'mydb',
+			time: now,
+		});
+		expect(metric).to.not.have.property('table');
+		expect(metric).to.not.have.property('log');
+		expect(metric).to.not.have.property('period');
+	});
+
 	it('diffs txnlog counters and passes txnlog gauges through (summed across the db logs)', () => {
 		const last = { txnlogBytesWritten: 1000, txnlogTransactionsWritten: 40 };
 		const stats = {
@@ -269,12 +294,21 @@ describe('buildRocksDBDbMetric', () => {
 			txnlogUncommittedTransactions: 1,
 			txnlogReplayGapBytes: 512,
 		};
-		const metric = buildRocksDBDbMetric('mydb', stats, last, now, 5000);
+		const metric = buildRocksDBTxnLogDbMetric('mydb', stats, last, now, 5000);
+		expect(metric.period).to.equal(5000);
 		expect(metric.txnlogBytesWritten).to.equal(500);
 		expect(metric.txnlogTransactionsWritten).to.equal(15);
 		expect(metric.txnlogLogCount).to.equal(2);
 		expect(metric.txnlogTotalSizeBytes).to.equal(4096);
 		expect(metric.txnlogReplayGapBytes).to.equal(512);
+	});
+
+	it('does not include the rocksdb-stats block-cache columns', () => {
+		const stats = { bytesRead: 100, blockCacheHit: 5, txnlogLogCount: 2 };
+		const metric = buildRocksDBTxnLogDbMetric('mydb', stats, undefined, now, undefined);
+		expect(metric).to.not.have.property('bytesRead');
+		expect(metric).to.not.have.property('blockCacheHit');
+		expect(metric.txnlogLogCount).to.equal(2);
 	});
 });
 
@@ -394,13 +428,13 @@ describe('normalizeTxnLogStats', () => {
 	});
 });
 
-describe('buildRocksDBLogMetric', () => {
+describe('buildRocksDBTxnLogMetric', () => {
 	const now = 1_700_000_000_000;
 
-	it('includes database and log dimensions (not table)', () => {
-		const metric = buildRocksDBLogMetric('mydb', 'audit', {}, undefined, now, undefined);
+	it('includes database and log dimensions (not table) on the rocksdb-txnlog-stats metric', () => {
+		const metric = buildRocksDBTxnLogMetric('mydb', 'audit', {}, undefined, now, undefined);
 		expect(metric).to.include({
-			metric: 'rocksdb-stats',
+			metric: 'rocksdb-txnlog-stats',
 			database: 'mydb',
 			log: 'audit',
 			time: now,
@@ -411,7 +445,7 @@ describe('buildRocksDBLogMetric', () => {
 
 	it('reports counters absolute on the first sample', () => {
 		const stats = normalizeTxnLogStats(sampleTxnLogStats());
-		const metric = buildRocksDBLogMetric('mydb', 'audit', stats, undefined, now, undefined);
+		const metric = buildRocksDBTxnLogMetric('mydb', 'audit', stats, undefined, now, undefined);
 		expect(metric.totalsTransactionsWritten).to.equal(1000);
 		expect(metric.totalsBytesWritten).to.equal(500000);
 		// Gauges always pass through absolute.
@@ -428,7 +462,7 @@ describe('buildRocksDBLogMetric', () => {
 			replayGapBytes: 1024, // gauge — absolute
 			pendingTransactions: 7,
 		};
-		const metric = buildRocksDBLogMetric('mydb', 'audit', stats, last, now, 5000);
+		const metric = buildRocksDBTxnLogMetric('mydb', 'audit', stats, last, now, 5000);
 		expect(metric.period).to.equal(5000);
 		expect(metric.totalsTransactionsWritten).to.equal(250);
 		expect(metric.totalsBytesWritten).to.equal(100000);
@@ -438,7 +472,7 @@ describe('buildRocksDBLogMetric', () => {
 	});
 
 	it('defaults missing stats to 0', () => {
-		const metric = buildRocksDBLogMetric('mydb', 'audit', {}, undefined, now, undefined);
+		const metric = buildRocksDBTxnLogMetric('mydb', 'audit', {}, undefined, now, undefined);
 		expect(metric.totalsTransactionsWritten).to.equal(0);
 		expect(metric.replayGapBytes).to.equal(0);
 		expect(metric.fileCount).to.equal(0);

--- a/unitTests/validation/analyticsValidator.test.js
+++ b/unitTests/validation/analyticsValidator.test.js
@@ -10,6 +10,15 @@ describe('validateGetAnalytics', function () {
 		assert.strictEqual(validateGetAnalytics({ metric: 'cpu-usage' }), undefined);
 	});
 
+	it('should accept a string log filter', function () {
+		assert.strictEqual(validateGetAnalytics({ metric: 'rocksdb-txnlog-stats', log: 'audit' }), undefined);
+	});
+
+	it('should reject a non-string log filter', function () {
+		const error = validateGetAnalytics({ metric: 'rocksdb-txnlog-stats', log: 42 });
+		assert.ok(error instanceof Error);
+	});
+
 	it('should accept a fully-specified valid request', function () {
 		assert.strictEqual(
 			validateGetAnalytics({

--- a/validation/analyticsValidator.ts
+++ b/validation/analyticsValidator.ts
@@ -36,6 +36,7 @@ const getAnalyticsSchema = Joi.object({
 	get_attributes: Joi.array().items(Joi.string()),
 	coalesce_time: Joi.boolean(),
 	conditions: Joi.array().items(Joi.alternatives(groupConditionSchema, directConditionSchema)),
+	log: Joi.string(),
 	replicated: Joi.boolean(),
 }).strict();
 


### PR DESCRIPTION
## Summary

Records rocksdb-js transaction log (txnlog) stats in `get_analytics` (rocksdb-js@2.1.0), extending the `rocksdb-stats` metric added in #871.

- **`rocksdb-stats`** (DB row) now also carries the summed `txnlog.*` roll-up from `db.getStats()` (the `txnlog*`-prefixed columns), alongside the existing block-cache/memtable/compaction columns.
- **New `rocksdb-txnlog-stats` metric** — one row per transaction log (`database` + `log`), from `db.listLogs()` + `db.useLog(name).getStats()`. Records the performance/resource-relevant fields (backlog: `pendingTransactions`/`uncommittedTransactions`/`replayGapBytes`; footprint: `totalSizeBytes`/`memoryOverlayBytes`/file counts; throughput counters) and drops noise (sequence numbers, log positions, static config, path).
- **New optional `log` filter** on `get_analytics` to narrow `rocksdb-txnlog-stats` to a single log by name.

## Purpose

Closes #1311 — surface transaction-log performance and resource-utilization metrics for observability.

## Where to look

- **`storeRocksDBStatsMetrics`** (`resources/analytics/write.ts`): per-log collection. `listLogs()` is guarded so a store closed/dropped mid-cycle can't abort the whole analytics aggregation; per-`(db, log)` counter baselines are cached and pruned on log removal and database drop; the first sample per log is skipped (mirrors the db-level path) so cumulative counters aren't reported as a spike.
- **Column selection**: `normalizeTxnLogStats` and the `ROCKSDB_TXNLOG_*` constant lists — what's kept vs dropped.
- **`log` filter** (`resources/analytics/read.ts`): rejects `log` with a non-`rocksdb-txnlog-stats` metric (BAD_REQUEST) rather than silently returning nothing.

## Open areas for the reviewer (surfaced by a self-review pass; deliberately not addressed here)

- **Efficiency / cold path**: `useLog(name).getStats()` runs every aggregation cycle (~60s) per log, and the per-db/per-log sweep is synchronous (no `await rest()` like the surrounding aggregation loops). Cold path, but worth a rocksdb-js owner's eye on whether `useLog` can pin mmaps.
- A RocksDB database with transaction logs but **zero loaded tables** emits no txnlog rows (logs are enumerated via the first table's `primaryStore`).
- A **transient per-log `getStats()` error** can make the next period's reported rate ~2× (the log's baseline isn't advanced while the period clock is). Same class of issue exists in the pre-existing db-level path.
- Cleanup deferred: the dedicated `log` param overlaps the generic `conditions` API; the three metric builders are near-identical and could be parameterized.

## Notes

- Docs: `get_analytics` gained a user-facing `log` parameter — a companion docs PR to HarperFast/documentation will follow.
- Generated by an LLM (Claude Opus 4.8).
