### PR TITLE
fix(deploy): make peer deployment-row wait configurable, default 120s

### DIFF
--- a/components/deploymentRecorder.ts
+++ b/components/deploymentRecorder.ts
@@ -341,21 +341,43 @@ export class DeploymentRecorder {
 	}
 }
 
+// Default peer-wait budget for the hdb_deployment row to replicate. A deploy is a rare,
+// heavyweight, user-initiated operation, and the `system`-table replication channel can be
+// backlogged behind unrelated writes when several deploys land in succession, so the row can
+// take well over the original 30s to arrive on a peer (harper-pro#402). 120s matches the
+// blob-stream receive default and gives a loaded cluster room to converge. Override per-deploy
+// via the `deployment_timeout` operation parameter.
+const DEFAULT_AWAIT_ROW_TIMEOUT_MS = 120_000;
+
 /**
  * Peer-side helper — wait for the hdb_deployment row to arrive via table replication,
  * then return it. The row is committed on origin before `replicateOperation` is
- * called, so peers normally find it immediately; this polling loop is for the rare
- * case where the operation arrives faster than the table-replication channel.
+ * called, so peers normally find it immediately; this polling loop covers the case
+ * where the operation arrives faster than the table-replication channel, including
+ * when that channel is backlogged behind other writes.
  *
  * The payload_blob's chunks may still be in flight after the row arrives — that's
  * fine, the Blob's `stream()` / `bytes()` API blocks on incomplete writes
  * (resources/blob.ts).
+ *
+ * On timeout the thrown error distinguishes the two failure modes: the row never
+ * replicated at all (the replication channel to this peer is stalled or broken) versus
+ * the row arrived but its payload_blob has not been populated yet (the origin's
+ * ingestPayload write is still propagating) — they point at different root causes.
  */
 export async function awaitDeploymentRow(
 	deploymentId: string,
 	options: { timeoutMs?: number; pollIntervalMs?: number; initialPollIntervalMs?: number } = {}
 ): Promise<Record<string, any>> {
-	const timeoutMs = options.timeoutMs ?? 30_000;
+	// Coerce defensively: the deploy operation's `deployment_timeout` reaches us via the
+	// operation body, and the Joi validator's coerced number is discarded by validateBySchema
+	// (it returns only the error, never writes the parsed value back), so a JSON/multipart
+	// client sending `"120000"` would otherwise arrive here as a string. `Date.now() + "<n>"`
+	// concatenates into a far-future "deadline" that silently defeats the timeout. Anything
+	// non-finite or negative falls back to the default rather than producing a NaN deadline
+	// (which would never satisfy `>= deadline` and loop forever).
+	const requested = Number(options.timeoutMs);
+	const timeoutMs = Number.isFinite(requested) && requested >= 0 ? requested : DEFAULT_AWAIT_ROW_TIMEOUT_MS;
 	const maxIntervalMs = options.pollIntervalMs ?? 100;
 	// Start fast (5ms) so the common case — replication has already caught up — sees no
 	// human-noticeable latency, then back off exponentially up to maxIntervalMs for the
@@ -369,18 +391,34 @@ export async function awaitDeploymentRow(
 	}
 	const deadline = Date.now() + timeoutMs;
 	let lastError: unknown;
-	while (Date.now() < deadline) {
+	let sawRow = false;
+	// Poll at least once even when timeoutMs is 0 (the caller asked for a single check, not
+	// "skip the lookup entirely"), and re-test the deadline AFTER the lookup so we never burn
+	// an extra idle interval once it has already passed.
+	while (true) {
 		try {
 			const row = await table.get(deploymentId);
-			if (row && row.payload_blob != null) return row;
+			if (row) {
+				if (row.payload_blob != null) return row;
+				// Row replicated but its payload_blob write hasn't landed yet — replication is
+				// alive, just mid-flight. Remember this so the timeout message points at the
+				// payload write rather than a dead channel.
+				sawRow = true;
+			}
 		} catch (err) {
 			lastError = err;
 		}
-		await new Promise<void>((resolve) => setTimeout(resolve, intervalMs));
+		const remaining = deadline - Date.now();
+		if (remaining <= 0) break;
+		// Cap the sleep to the remaining budget so we don't overshoot the deadline.
+		await new Promise<void>((resolve) => setTimeout(resolve, Math.min(intervalMs, remaining)));
 		intervalMs = Math.min(intervalMs * 2, maxIntervalMs);
 	}
+	const cause = sawRow
+		? `row '${deploymentId}' replicated but its payload_blob has not arrived`
+		: `hdb_deployment row '${deploymentId}' did not replicate`;
 	throw new Error(
-		`Timed out after ${timeoutMs}ms waiting for hdb_deployment row '${deploymentId}' to replicate` +
+		`Timed out after ${timeoutMs}ms waiting for the deployment payload: ${cause}` +
 			(lastError ? ` (last error: ${(lastError as Error).message ?? lastError})` : '')
 	);
 }

--- a/components/operations.js
+++ b/components/operations.js
@@ -439,7 +439,10 @@ async function deployComponent(req) {
 			// the replicated hdb_deployment row's payload_blob. Blob.stream() blocks on
 			// in-flight BLOB_CHUNK writes until the chunks land. If the row never arrives
 			// within the timeout, peer records a failure and origin sees it in peer_results.
-			const row = await awaitDeploymentRow(req._deploymentId);
+			// The wait budget defaults to 120s but is overridable per-deploy via
+			// `deployment_timeout` (ms) for clusters where the system-table channel is
+			// heavily backlogged (harper-pro#402).
+			const row = await awaitDeploymentRow(req._deploymentId, { timeoutMs: req.deployment_timeout });
 			extractionPayload = row.payload_blob.stream();
 		}
 

--- a/components/operationsValidation.js
+++ b/components/operationsValidation.js
@@ -241,6 +241,7 @@ function deployComponentValidator(req) {
 		install_command: Joi.string().optional(),
 		install_timeout: Joi.number().optional(),
 		install_allow_scripts: Joi.boolean().optional(),
+		deployment_timeout: Joi.number().min(0).optional(),
 		force: Joi.boolean().optional(),
 		urlPath: Joi.string()
 			.min(1)

--- a/integrationTests/deploy/deploy-tracking-peer-branch.test.ts
+++ b/integrationTests/deploy/deploy-tracking-peer-branch.test.ts
@@ -173,6 +173,7 @@ suite('Deployment tracking — peer-side branch', (ctx: ContextWithHarper) => {
 	);
 
 	// Note: the bogus-_deploymentId-id timeout case isn't covered here because the
-	// awaitDeploymentRow 30s default would balloon test time. The timeout path is exercised
-	// by the unit tests for awaitDeploymentRow directly.
+	// awaitDeploymentRow 120s default would balloon test time. The timeout path (and the
+	// per-deploy deployment_timeout override) is exercised by the unit tests for
+	// awaitDeploymentRow directly.
 });

--- a/unitTests/components/deploymentRecorder.test.js
+++ b/unitTests/components/deploymentRecorder.test.js
@@ -242,15 +242,61 @@ describe('awaitDeploymentRow', () => {
 		assert.ok(result.payload_blob);
 	});
 
-	it('rejects with a timeout error when the row never arrives within timeoutMs', async () => {
+	it('rejects with a "did not replicate" timeout when the row never arrives within timeoutMs', async () => {
 		await assert.rejects(
 			() => awaitDeploymentRow('never-arrives', { timeoutMs: 100, pollIntervalMs: 25 }),
-			/Timed out after 100ms waiting for hdb_deployment row 'never-arrives'/
+			/Timed out after 100ms .*hdb_deployment row 'never-arrives' did not replicate/
+		);
+	});
+
+	it('rejects with a "payload_blob has not arrived" timeout when the row replicated but its blob has not', async () => {
+		// Distinguish the two failure modes: the row is present (replication reached its
+		// creation) but payload_blob stays null past the deadline — points at the payload
+		// write, not a dead channel.
+		const id = 'row-without-blob';
+		installed.mock.rows.set(id, { deployment_id: id, payload_blob: null });
+		await assert.rejects(
+			() => awaitDeploymentRow(id, { timeoutMs: 100, pollIntervalMs: 25 }),
+			/Timed out after 100ms .*row 'row-without-blob' replicated but its payload_blob has not arrived/
 		);
 	});
 
 	it('throws if the deployment table is missing entirely (not yet provisioned)', async () => {
 		delete databases.system[DEPLOYMENT_TABLE];
 		await assert.rejects(() => awaitDeploymentRow('d3'), /Deployment tracking is not initialized on this node/);
+	});
+
+	it('coerces a numeric-string timeoutMs so the deadline is real (not string concatenation)', async () => {
+		// `deployment_timeout` can reach awaitDeploymentRow as a string (validateBySchema
+		// discards Joi's coerced value). Date.now() + "120" would concatenate into a
+		// far-future deadline that never times out; the coercion must keep it numeric so this
+		// rejects in ~120ms rather than hanging.
+		const before = Date.now();
+		await assert.rejects(
+			() => awaitDeploymentRow('string-timeout', { timeoutMs: '120', pollIntervalMs: 25 }),
+			/Timed out after 120ms/
+		);
+		assert.ok(Date.now() - before < 5000, 'a string timeoutMs must not balloon the deadline');
+	});
+
+	it('falls back to a real deadline when timeoutMs is non-numeric (no NaN infinite loop)', async () => {
+		// Number('soon') is NaN; a NaN deadline would make `remaining <= 0` always false and
+		// loop forever. The guard must fall back to the default, so polling for an
+		// already-present row still resolves immediately.
+		const row = { deployment_id: 'nan-timeout', payload_blob: { fake: true } };
+		installed.mock.rows.set('nan-timeout', row);
+		const result = await awaitDeploymentRow('nan-timeout', { timeoutMs: 'soon' });
+		assert.strictEqual(result, row);
+	});
+
+	it('polls at least once when timeoutMs is 0 — returns an already-present row', async () => {
+		const row = { deployment_id: 'zero-present', payload_blob: { fake: true } };
+		installed.mock.rows.set('zero-present', row);
+		const result = await awaitDeploymentRow('zero-present', { timeoutMs: 0 });
+		assert.strictEqual(result, row, 'a 0 timeout must still perform a single lookup');
+	});
+
+	it('polls once then times out when timeoutMs is 0 and the row is absent', async () => {
+		await assert.rejects(() => awaitDeploymentRow('zero-absent', { timeoutMs: 0 }), /Timed out after 0ms/);
 	});
 });

--- a/unitTests/server/fastifyRoutes/operationsValidation.test.js
+++ b/unitTests/server/fastifyRoutes/operationsValidation.test.js
@@ -260,5 +260,24 @@ describe('Test operationsValidation module', () => {
 			expect(result).to.be.ok;
 			expect(result.message).to.include('project');
 		});
+
+		it('accepts a numeric deployment_timeout', () => {
+			const result = validator.deployComponentValidator({
+				project: 'my-app',
+				package: 'pkg',
+				deployment_timeout: 180000,
+			});
+			expect(result).to.be.undefined;
+		});
+
+		it('rejects a non-numeric deployment_timeout', () => {
+			const result = validator.deployComponentValidator({
+				project: 'my-app',
+				package: 'pkg',
+				deployment_timeout: 'soon',
+			});
+			expect(result).to.be.ok;
+			expect(result.message).to.include('deployment_timeout');
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the peer-side timeout in replicated `deploy_component` reported in **harper-pro#402**. Since 5.1.x the deployment-tracking feature moved the payload off the operation body into the `system.hdb_deployment` row's `payload_blob`; peers wait for that row to replicate via `awaitDeploymentRow`, which hardcoded a **30s** deadline with no way to extend it. Under `system`-table replication backlog the row arrives later than 30s, so the peer threw `Timed out … waiting for hdb_deployment row …` and the deploy failed.

- Default peer-wait `30s → 120s` (`DEFAULT_AWAIT_ROW_TIMEOUT_MS`).
- New optional **`deployment_timeout`** deploy operation parameter (ms) to extend the budget per-deploy on heavily-backlogged clusters; added to the Joi schema.
- Poll loop now runs at least once (so `deployment_timeout: 0` performs a single lookup rather than no-op'ing) and caps the final sleep to the remaining budget.
- Timeout error now distinguishes **"row never replicated"** (dead/stalled channel) from **"row arrived but payload_blob pending"** (origin's `ingestPayload` write still in flight).

## Where to look / what to weigh

- **`deploymentRecorder.ts` — the 120s default.** Rationale: a deploy is rare and heavyweight, and the issue's evidence (the *initial* deploy always succeeds because the row beats 30s; rows arrive mid-wait) shows the row replicates on a path independent of the waiting op — so the longer wait extends patience without deadlock risk. A peer that will ultimately fail now takes up to 120s (or the operator's `deployment_timeout`) to report it, instead of 30s. Worth a sanity check that 120s is the right default vs. something larger/smaller.
- **`deployment_timeout` propagation.** The param is set on the origin call and carried to peers via the replicated operation body (the origin only deletes `payload`/`progress` before replicating), which is what lets peers honor it. Confirm that's the intended delivery mechanism.
- **Defensive `Number()` coercion of `timeoutMs`.** `validateBySchema` discards Joi's coerced value, so a numeric-string `deployment_timeout` from a JSON/multipart client would otherwise reach the arithmetic as a string and concatenate into a far-future deadline. Coerced + finite/non-negative guarded in the helper (the single chokepoint where the timestamp math lives).

## Follow-up (not in this PR)

This is the pragmatic Option-1 fix from the issue. The progress-based / no-progress timeout (issue suggestion #2) is deferred — I'll file a follow-up to track it; the create()→ingestPayload() writes happen back-to-back on the origin, so the intermediate "row present, null blob" progress signal is unreliable in practice and the marginal benefit is uncertain.

## Tests

Unit coverage added for the configurable timeout, the numeric-string/NaN coercion, the `timeoutMs: 0` single-poll behavior, the two distinct timeout messages, and validator accept/reject of `deployment_timeout`.

---
🤖 Generated by Claude (Opus 4.8, 1M context). Reviewed cross-model (Codex + Gemini) before opening; the findings they surfaced are already addressed in the diff.