### PR TITLE
fix(encoder): strict-extension CAS in sharedStructures save

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -50,6 +50,37 @@ const MISSING_STRUCTURE_METRIC = 'decode-missing-structure';
 const MISSING_TYPED_STRUCTURE_PREFIX = 'Could not find typed structure ';
 const MISSING_CLASSIC_STRUCTURE_PREFIX = 'Record id is not defined for ';
 
+// Normalize a shared-structures payload into {named, typed} arrays. Accepts the three wire forms
+// the encoder hands us: a plain Array (named only), a Map with 'named'/'typed' keys (structon's
+// typedStructs form), or a plain object with the same keys (Map round-tripped via mapsAsObjects).
+function toShape(s: any): { named: any[]; typed: any[] } {
+	if (!s) return { named: [], typed: [] };
+	if (s instanceof Map) return { named: s.get('named') || [], typed: s.get('typed') || [] };
+	if (Array.isArray(s)) return { named: s, typed: [] };
+	if (typeof s === 'object') return { named: s.named || [], typed: s.typed || [] };
+	return { named: [], typed: [] };
+}
+
+// Structural equality for the leaf shapes structures hold: primitive (named entries are strings,
+// typed entries are arrays of [type, size, key] triples). Recurses through arrays only.
+function shapeEqual(a: any, b: any): boolean {
+	if (a === b) return true;
+	if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+	for (let i = 0; i < a.length; i++) {
+		if (!shapeEqual(a[i], b[i])) return false;
+	}
+	return true;
+}
+
+// next must contain every existing entry in the same slot, in order; new slots may be appended.
+function isStrictExtension(existing: any[], next: any[]): boolean {
+	if (next.length < existing.length) return false;
+	for (let i = 0; i < existing.length; i++) {
+		if (!shapeEqual(existing[i], next[i])) return false;
+	}
+	return true;
+}
+
 export function isMissingStructureError(error: any): boolean {
 	const message = error?.message;
 	return (
@@ -290,26 +321,20 @@ export class RecordEncoder extends StructonEncoder {
 							return false;
 						}
 						// Strict-extension CAS: the length check above lets two writers with the same baseline
-						// length save different shapes at the same index, silently corrupting the loser's
-						// records (decode trips on "Data read, but end of buffer not reached"). Reject any
-						// save that would mutate an existing entry; msgpackr's pack() re-packs against the
-						// new disk state and re-mints at the next free id. See harper#1337.
-						if (existingStructures) {
-							for (let i = 0; i < existingStructures.length; i++) {
-								const existingEntry = existingStructures[i];
-								const newEntry = structures[i];
-								if (existingEntry === newEntry) continue;
-								if (
-									!Array.isArray(existingEntry) ||
-									!Array.isArray(newEntry) ||
-									existingEntry.length !== newEntry.length
-								) {
-									return false;
-								}
-								for (let j = 0; j < existingEntry.length; j++) {
-									if (existingEntry[j] !== newEntry[j]) return false;
-								}
-							}
+						// save different shapes at the same index, silently corrupting the loser's records
+						// (decode trips on "Data read, but end of buffer not reached"). Reject any save that
+						// would mutate an existing entry; msgpackr re-packs against the new disk state and
+						// re-mints at the next free id. Structures arrive as a plain Array (named-only) or a
+						// Map / plain object with 'named' and 'typed' keys (structon's typedStructs form, the
+						// latter after a mapsAsObjects round-trip); normalize both sides so an Array→Map
+						// upgrade (first typedStruct minted) isn't mistaken for mutation. See harper#1337.
+						const existingShape = toShape(existingStructures);
+						const nextShape = toShape(structures);
+						if (
+							!isStrictExtension(existingShape.named, nextShape.named) ||
+							!isStrictExtension(existingShape.typed, nextShape.typed)
+						) {
+							return false;
 						}
 						txn.putSync(sharedStructuresKey, structures);
 						return true;

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -289,13 +289,11 @@ export class RecordEncoder extends StructonEncoder {
 						} else if (existingStructures && existingStructures.length !== isCompatible) {
 							return false;
 						}
-						// Strict-extension CAS: the length check above (msgpackr default) catches the
-						// common race but lets two writers with the same baseline length save different
-						// shapes at the same index. Once disk holds one writer's shape at id N, the
-						// other writer's records on disk reference id N expecting a different shape,
-						// and decode trips on "Data read, but end of buffer not reached". Reject the
-						// save if existing entries don't match our prefix; msgpackr will re-pack
-						// against the new disk state and re-mint at the next free id. See harper#1337.
+						// Strict-extension CAS: the length check above lets two writers with the same baseline
+						// length save different shapes at the same index, silently corrupting the loser's
+						// records (decode trips on "Data read, but end of buffer not reached"). Reject any
+						// save that would mutate an existing entry; msgpackr's pack() re-packs against the
+						// new disk state and re-mints at the next free id. See harper#1337.
 						if (existingStructures) {
 							for (let i = 0; i < existingStructures.length; i++) {
 								const existingEntry = existingStructures[i];

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -289,6 +289,30 @@ export class RecordEncoder extends StructonEncoder {
 						} else if (existingStructures && existingStructures.length !== isCompatible) {
 							return false;
 						}
+						// Strict-extension CAS: the length check above (msgpackr default) catches the
+						// common race but lets two writers with the same baseline length save different
+						// shapes at the same index. Once disk holds one writer's shape at id N, the
+						// other writer's records on disk reference id N expecting a different shape,
+						// and decode trips on "Data read, but end of buffer not reached". Reject the
+						// save if existing entries don't match our prefix; msgpackr will re-pack
+						// against the new disk state and re-mint at the next free id. See harper#1337.
+						if (existingStructures) {
+							for (let i = 0; i < existingStructures.length; i++) {
+								const existingEntry = existingStructures[i];
+								const newEntry = structures[i];
+								if (existingEntry === newEntry) continue;
+								if (
+									!Array.isArray(existingEntry) ||
+									!Array.isArray(newEntry) ||
+									existingEntry.length !== newEntry.length
+								) {
+									return false;
+								}
+								for (let j = 0; j < existingEntry.length; j++) {
+									if (existingEntry[j] !== newEntry[j]) return false;
+								}
+							}
+						}
 						txn.putSync(sharedStructuresKey, structures);
 						return true;
 					},

--- a/unitTests/resources/recordEncoder-structuresMismatch.test.js
+++ b/unitTests/resources/recordEncoder-structuresMismatch.test.js
@@ -1,27 +1,10 @@
-// Regression for HarperFast/harper#1337: a record encoded against one
-// sharedStructures snapshot becomes undecodable when the dictionary on disk
-// is replaced with a different shape at the same struct id.
-//
-// In the cluster we observed records in Campaign/ CF that started with the
-// metadata-prefix + bare struct-ref byte (e.g. 0x43) and depended on an
-// in-memory sharedStructures dictionary to interpret the value bytes. When
-// the dictionary that getStructures() returns disagrees with what was used at
-// encode time, msgpackr decodes against the wrong shape and throws the exact
-// production error: "Data read, but end of buffer not reached <partial>".
-//
-// The failure mode is silent corruption: no client-side error, no operator
-// alert, no automated reconciliation. Records on disk are unreadable until
-// the dictionary is restored or each record is re-encoded with inline defs.
-//
-// See: https://github.com/HarperFast/harper/issues/1337
-
 require('../testUtils');
 const assert = require('assert');
 const { RecordEncoder } = require('#src/resources/RecordEncoder');
 const { Encoder } = require('msgpackr');
 
-// A shared, mutable "disk" for the structures buffer. Mirrors the way DBIs
-// hold the sharedStructures blob under Symbol.for('structures').
+// Shared structures persisted as an encoded buffer (mirrors how a DBI stores them under
+// Symbol.for('structures')), so struct/record structures cross between encoder instances.
 function sharedStore() {
 	let buf;
 	const meta = new Encoder();
@@ -33,286 +16,148 @@ function sharedStore() {
 		get() {
 			return buf ? meta.decode(buf) : undefined;
 		},
-		raw: () => buf,
-		setRaw: (b) => {
-			buf = b;
-		},
 	};
 }
 
 function makeEncoder(store) {
 	return new RecordEncoder({
 		structures: [],
-		// false = msgpackr named-structures path (records start in 0x40-0x5f), which is
-		// the path the failing production records take.
+		// false = msgpackr named-structures path (records start in 0x40-0x5f), which is the path
+		// the failing production records take.
 		randomAccessStructure: false,
 		getStructures: store.get,
 		saveStructures: store.save,
 	});
 }
 
+// Minimal RocksDB-ish rootStore for the saveStructures CAS path. The wrapped buffer holds the
+// encoded structures blob; CAS reads it before each save and writes through txn.putSync on commit.
+function rocksRoot() {
+	let buf;
+	const meta = new Encoder();
+	return {
+		store: {
+			transactionSync(fn) {
+				return fn({
+					getBinarySync: () => buf,
+					putSync: (_key, value) => {
+						buf = meta.encode(value);
+					},
+				});
+			},
+			getBinarySync: () => undefined,
+		},
+		get: () => (buf ? meta.decode(buf) : undefined),
+	};
+}
+
+function makeRocksEncoder(root) {
+	const enc = new RecordEncoder({
+		structures: [],
+		randomAccessStructure: false,
+		getStructures: root.get,
+		saveStructures: () => true,
+	});
+	enc.isRocksDB = true;
+	enc.rootStore = root.store;
+	return enc;
+}
+
 describe('RecordEncoder sharedStructures dictionary divergence (harper#1337)', () => {
 	it('records that reference a struct id become undecodable when the dictionary at that id is replaced', () => {
-		// Writer A encodes a record with one shape, persists its structures.
+		// Writer A persists its shape; writer B (separate store) persists a different shape at the same
+		// id; the reader loads writer B's store. Writer A's record now references the wrong shape on
+		// decode, exactly mirroring the cluster-side failure where the on-disk dictionary diverges from
+		// what some records were written against.
 		const storeA = sharedStore();
-		const writerA = makeEncoder(storeA);
-		const recordA = { runId: 'r-1', vu: 'v-1', iter: 'paused' };
-		const bytesA = Buffer.from(writerA.encode(recordA));
-
-		// Sanity: writer A actually persisted some structures, and its record bytes
-		// land in the named-struct ref range (0x40-0x5f) so they depend on the dictionary.
-		assert.ok(storeA.get()?.length > 0, 'writer A should have persisted structures');
+		const bytesA = Buffer.from(makeEncoder(storeA).encode({ runId: 'r-1', vu: 'v-1', iter: 'paused' }));
 		assert.ok(
 			bytesA[0] >= 0x40 && bytesA[0] < 0x60,
 			`expected named-struct ref byte 0x40-0x5f, got 0x${bytesA[0].toString(16)}`
 		);
 
-		// Writer B encodes a different shape against a fresh store (simulating a
-		// concurrent encoder instance that started before seeing writer A's save,
-		// or a post-restart fresh thread). Writer B's structure mints at id 0
-		// with a different shape than writer A's id 0.
 		const storeB = sharedStore();
-		const writerB = makeEncoder(storeB);
-		const recordB = { alpha: 1, beta: 2 };
-		writerB.encode(recordB);
+		makeEncoder(storeB).encode({ alpha: 1, beta: 2 });
 
-		// The "disk" then ends up holding writer B's structures (the cluster
-		// observation: post-rollout, the on-disk dictionary disagrees with what
-		// some records on disk were written against).
-		const reader = makeEncoder({
-			save: () => true,
-			get: storeB.get,
-			raw: storeB.raw,
-			setRaw: storeB.setRaw,
-		});
-
-		// Decoding writer A's record against writer B's dictionary should fail.
-		// The decoder reads the bytes as if they were the wrong shape, fills in
-		// the wrong field names, then chokes on the extra bytes.
-		let result;
-		let caught;
+		const reader = makeEncoder({ save: () => true, get: storeB.get });
+		let result, caught;
 		try {
 			result = reader.decode(bytesA);
 		} catch (e) {
 			caught = e;
 		}
-
-		// RecordEncoder.decode is non-fatal: it returns null and logs the error
-		// internally (see RecordEncoder.ts:432). The on-disk record is dropped from
-		// query results — silent data loss, which is exactly the production symptom.
-		assert.ok(
-			caught != null || result === null,
-			`expected decode to fail (return null or throw); got ${JSON.stringify(result)}`
-		);
+		// RecordEncoder.decode is non-fatal: it returns null and logs internally. The on-disk record
+		// silently drops out of query results, which is the production symptom.
+		assert.ok(caught != null || result === null, `expected decode to fail; got ${JSON.stringify(result)}`);
 	});
 
-	it('a fresh decoder finds the inline-defining record to repopulate its dictionary on iterator read', () => {
-		// Counter-case: a record that carries its own inline struct definition
-		// (the d4 72 form) decodes regardless of what's on disk, because it
-		// teaches the decoder its own shape inline. This is why the working
-		// records in production decode fine — they were emitted before the
-		// dictionary diverged and the encoder hadn't yet switched to ref-only.
+	it('decodes fine when writer and reader share the same store', () => {
 		const store = sharedStore();
-		const writer = makeEncoder(store);
 		const record = { runId: 'r-1', vu: 'v-1', iter: 'active' };
-		const bytes = Buffer.from(writer.encode(record));
-
-		// A reader that knows about the structures decodes fine.
-		const reader = makeEncoder(store);
-		const decoded = reader.decode(bytes);
-		assert.ok(decoded, 'record should decode when the structure is available');
+		const bytes = Buffer.from(makeEncoder(store).encode(record));
+		const decoded = makeEncoder(store).decode(bytes);
+		assert.ok(decoded);
 		assert.strictEqual(decoded.runId, record.runId);
 		assert.strictEqual(decoded.vu, record.vu);
 		assert.strictEqual(decoded.iter, record.iter);
 	});
 
-	it('strict-extension CAS rejects a save that would replace an existing structure at the same index', () => {
-		// Direct check of the fix: saveStructures must reject any incoming
-		// structures array that differs from existing on an index that already
-		// has content. msgpackr's pack() loop sees the false return and re-packs
-		// the record at the next free id, so the on-disk record always references
-		// a structure that's actually persisted under that id.
-		//
-		// This test uses Harper's saveStructures hook directly (the production
-		// surface for RocksDB-backed stores) rather than racing two encoders,
-		// so it stays deterministic and fast.
+	it('strict-extension CAS rejects a save that replaces an existing structure at the same index', () => {
+		// Length matches but the entry at index 0 differs. msgpackr's default length-only check would
+		// accept this and silently corrupt anything writer A's records reference; the fix must reject.
+		const root = rocksRoot();
+		const enc = makeRocksEncoder(root);
 
-		let buf;
-		const meta = new Encoder();
-		// A minimal RocksDB-ish rootStore that backs the save into a single buffer
-		// via transactionSync (synchronous, no real DB needed for the CAS logic).
-		const rootStore = {
-			transactionSync(fn) {
-				return fn({
-					getBinarySync: () => buf,
-					putSync: (_key, value) => {
-						buf = meta.encode(value);
-					},
-				});
-			},
-		};
+		assert.strictEqual(enc.saveStructures([['runId', 'vu', 'iter']], 0), true);
+		assert.strictEqual(enc.saveStructures([['alpha', 'beta', 'gamma']], 1), false);
+		assert.deepStrictEqual(root.get(), [['runId', 'vu', 'iter']], 'disk should still hold writer A structures');
 
-		const enc = new RecordEncoder({
-			structures: [],
-			randomAccessStructure: false,
-			getStructures: () => (buf ? meta.decode(buf) : undefined),
-			saveStructures: () => true, // overridden via rootStore wiring below
-		});
-		// Wire up the RocksDB code path: isRocksDB=true, rootStore set,
-		// and the saveStructures override that lives in the constructor uses these.
-		enc.isRocksDB = true;
-		enc.rootStore = rootStore;
-
-		// Writer A's first save: nothing on disk, accept.
-		const structuresA = [['runId', 'vu', 'iter']];
-		const okA = enc.saveStructures(structuresA, 0);
-		assert.strictEqual(okA, true, 'first save should be accepted (disk empty)');
-		assert.deepStrictEqual(meta.decode(buf), structuresA, 'disk should hold writer A structures');
-
-		// Writer B comes along with a DIFFERENT shape at the same index 0.
-		// Length matches (both 1), so msgpackr's length-only check would accept this
-		// and silently corrupt anything writer A's records reference. The fix must
-		// reject it.
-		const structuresB = [['alpha', 'beta', 'gamma']];
-		const okB = enc.saveStructures(structuresB, 1);
+		// Strict extension is accepted; the prefix matches and a new entry is appended.
 		assert.strictEqual(
-			okB,
-			false,
-			'save that would replace existing structure at index 0 with a different shape must be rejected'
+			enc.saveStructures(
+				[
+					['runId', 'vu', 'iter'],
+					['alpha', 'beta', 'gamma'],
+				],
+				1
+			),
+			true
 		);
-		assert.deepStrictEqual(meta.decode(buf), structuresA, 'disk should still hold writer A structures');
-
-		// A save that strictly EXTENDS the existing dictionary is accepted.
-		const structuresExtended = [
-			['runId', 'vu', 'iter'],
-			['alpha', 'beta', 'gamma'],
-		];
-		const okExt = enc.saveStructures(structuresExtended, 1);
-		assert.strictEqual(okExt, true, 'save that extends existing structures should be accepted');
-		assert.deepStrictEqual(meta.decode(buf), structuresExtended, 'disk should now hold extended structures');
 	});
 
 	it('strict-extension CAS catches replacement at a non-zero index', () => {
-		// The check loops over every existing entry, not just index 0. Catch a
-		// regression in the loop bounds where a later writer replaces a middle
+		// Guard against a regression in the comparison-loop bounds: a later writer replaces a middle
 		// entry while preserving entries 0..i-1 and i+1..N.
-		let buf;
-		const meta = new Encoder();
-		const rootStore = {
-			transactionSync(fn) {
-				return fn({
-					getBinarySync: () => buf,
-					putSync: (_key, value) => {
-						buf = meta.encode(value);
-					},
-				});
-			},
-		};
-		const enc = new RecordEncoder({
-			structures: [],
-			randomAccessStructure: false,
-			getStructures: () => (buf ? meta.decode(buf) : undefined),
-			saveStructures: () => true,
-		});
-		enc.isRocksDB = true;
-		enc.rootStore = rootStore;
-
-		const original = [['a'], ['b'], ['c']];
-		assert.strictEqual(enc.saveStructures(original, 0), true);
-
-		// Same length, same entries at index 0 and 2, DIFFERENT entry at index 1.
-		const mutated = [['a'], ['X'], ['c']];
-		assert.strictEqual(
-			enc.saveStructures(mutated, 3),
-			false,
-			'replacement at index 1 (mid-array) must be rejected even when length matches'
-		);
-		assert.deepStrictEqual(meta.decode(buf), original, 'disk should still hold the original structures');
+		const root = rocksRoot();
+		const enc = makeRocksEncoder(root);
+		assert.strictEqual(enc.saveStructures([['a'], ['b'], ['c']], 0), true);
+		assert.strictEqual(enc.saveStructures([['a'], ['X'], ['c']], 3), false);
+		assert.deepStrictEqual(root.get(), [['a'], ['b'], ['c']]);
 	});
 
 	it('strict-extension CAS accepts a strict suffix extension', () => {
-		// Belt-and-braces: an off-by-one in the comparison loop could reject
-		// legitimate extensions and break normal write throughput. Verify the
-		// happy path explicitly.
-		let buf;
-		const meta = new Encoder();
-		const rootStore = {
-			transactionSync(fn) {
-				return fn({
-					getBinarySync: () => buf,
-					putSync: (_key, value) => {
-						buf = meta.encode(value);
-					},
-				});
-			},
-		};
-		const enc = new RecordEncoder({
-			structures: [],
-			randomAccessStructure: false,
-			getStructures: () => (buf ? meta.decode(buf) : undefined),
-			saveStructures: () => true,
-		});
-		enc.isRocksDB = true;
-		enc.rootStore = rootStore;
-
-		// Establish a 3-entry baseline on disk.
+		// Belt-and-braces happy path: an off-by-one in the loop could silently reject legitimate
+		// extensions and break normal write throughput.
+		const root = rocksRoot();
+		const enc = makeRocksEncoder(root);
 		assert.strictEqual(enc.saveStructures([['a'], ['b'], ['c']], 0), true);
-
-		// Append two entries — same prefix [a, b, c], plus [d] and [e].
 		const extended = [['a'], ['b'], ['c'], ['d'], ['e']];
-		assert.strictEqual(
-			enc.saveStructures(extended, 3),
-			true,
-			'strict extension (existing prefix preserved, new entries appended) must be accepted'
-		);
-		assert.deepStrictEqual(meta.decode(buf), extended);
+		assert.strictEqual(enc.saveStructures(extended, 3), true);
+		assert.deepStrictEqual(root.get(), extended);
 	});
 
 	it('strict-extension CAS rejects a type mismatch at an existing index', () => {
-		// If an existing entry is an array (the expected shape for a structure
-		// definition) but a new save puts a non-array at the same index, that's
-		// a corruption attempt; reject. The current implementation falls into
-		// the `!Array.isArray(...)` guard rather than throwing.
-		let buf;
-		const meta = new Encoder();
-		const rootStore = {
-			transactionSync(fn) {
-				return fn({
-					getBinarySync: () => buf,
-					putSync: (_key, value) => {
-						buf = meta.encode(value);
-					},
-				});
-			},
-		};
-		const enc = new RecordEncoder({
-			structures: [],
-			randomAccessStructure: false,
-			getStructures: () => (buf ? meta.decode(buf) : undefined),
-			saveStructures: () => true,
-		});
-		enc.isRocksDB = true;
-		enc.rootStore = rootStore;
-
+		// existing entry is an array, new save puts a non-array at the same index. The !Array.isArray()
+		// guard catches it rather than throwing.
+		const root = rocksRoot();
+		const enc = makeRocksEncoder(root);
 		assert.strictEqual(enc.saveStructures([['a', 'b']], 0), true);
-		// Same length, but the new entry at index 0 is a string instead of an array.
-		const mutated = ['notAnArray'];
-		assert.strictEqual(
-			enc.saveStructures(mutated, 1),
-			false,
-			'type-mismatch save (array → non-array at same index) must be rejected'
-		);
+		assert.strictEqual(enc.saveStructures(['notAnArray'], 1), false);
 	});
 
-	// Note on end-to-end coverage: validating that msgpackr's pack() re-pack
-	// loop fires correctly on our `false` return and produces records that
-	// decode against the new disk state needs a real RocksDB-backed encoder
-	// (the decode path uses rootStore.getBinarySync to resolve blob
-	// references, which a mock doesn't satisfy without basically rebuilding
-	// the store). That validation lives in harper-pro's
-	// `integrationTests/cluster/multiShapeReplicationConvergence.test.mjs`
-	// where two-node mesh + 4-thread writers + varying optional-field
-	// combinations exercise the full encode→save→CAS→re-pack→decode loop
-	// with the actual storage layer. The four CAS tests above are the
-	// per-condition slices of that flow.
+	// End-to-end retry-flow coverage (encode → save → CAS reject → msgpackr re-pack → decode against
+	// the new disk state) lives in harper-pro's integrationTests/cluster/multiShapeReplicationConvergence.test.mjs,
+	// which exercises a real RocksDB-backed encoder with 4-thread writers and varying optional-field
+	// combinations. Mocking the rootStore well enough to satisfy both the save path and the
+	// blob-resolving decode path basically rebuilds the storage layer.
 });

--- a/unitTests/resources/recordEncoder-structuresMismatch.test.js
+++ b/unitTests/resources/recordEncoder-structuresMismatch.test.js
@@ -183,7 +183,10 @@ describe('RecordEncoder sharedStructures dictionary divergence (harper#1337)', (
 		assert.deepStrictEqual(meta.decode(buf), structuresA, 'disk should still hold writer A structures');
 
 		// A save that strictly EXTENDS the existing dictionary is accepted.
-		const structuresExtended = [['runId', 'vu', 'iter'], ['alpha', 'beta', 'gamma']];
+		const structuresExtended = [
+			['runId', 'vu', 'iter'],
+			['alpha', 'beta', 'gamma'],
+		];
 		const okExt = enc.saveStructures(structuresExtended, 1);
 		assert.strictEqual(okExt, true, 'save that extends existing structures should be accepted');
 		assert.deepStrictEqual(meta.decode(buf), structuresExtended, 'disk should now hold extended structures');

--- a/unitTests/resources/recordEncoder-structuresMismatch.test.js
+++ b/unitTests/resources/recordEncoder-structuresMismatch.test.js
@@ -155,6 +155,108 @@ describe('RecordEncoder sharedStructures dictionary divergence (harper#1337)', (
 		assert.strictEqual(enc.saveStructures(['notAnArray'], 1), false);
 	});
 
+	it('strict-extension CAS accepts Array→Map upgrade when named entries match', () => {
+		// structon switches the persisted format from plain Array (named-only) to a Map with
+		// 'named'/'typed' keys the moment the first typedStruct is minted. A naive index-into-existing
+		// loop would treat the Map's missing numeric properties as a deletion and falsely reject the
+		// receiver-side save, which is exactly the regression that left during-window markers stuck on
+		// the patched cluster.
+		const root = rocksRoot();
+		const enc = makeRocksEncoder(root);
+		assert.strictEqual(enc.saveStructures([['runId', 'vu']], 0), true);
+		const upgraded = new Map();
+		upgraded.set('named', [['runId', 'vu']]);
+		upgraded.set('typed', [[['Long', 4, 'a']]]);
+		assert.strictEqual(enc.saveStructures(upgraded, 1), true);
+		const persisted = root.get();
+		assert.deepStrictEqual(persisted.get('named'), [['runId', 'vu']]);
+		assert.deepStrictEqual(persisted.get('typed'), [[['Long', 4, 'a']]]);
+	});
+
+	it('strict-extension CAS rejects a Map upgrade that mutates an existing named entry', () => {
+		// Array→Map is fine when the named prefix matches; it must still reject when named[0]
+		// disagrees, because that is the silent-corruption case dressed up in the upgrade format.
+		const root = rocksRoot();
+		const enc = makeRocksEncoder(root);
+		assert.strictEqual(enc.saveStructures([['runId', 'vu']], 0), true);
+		const conflicting = new Map();
+		conflicting.set('named', [['alpha', 'beta']]);
+		conflicting.set('typed', [[['Long', 4, 'a']]]);
+		assert.strictEqual(enc.saveStructures(conflicting, 1), false);
+		assert.deepStrictEqual(root.get(), [['runId', 'vu']]);
+	});
+
+	it('strict-extension CAS accepts an append to typed structures in Map form', () => {
+		// Two saves in Map form where the second extends typed by one entry; identical [type,size,key]
+		// triples come from different array literals so a reference-equality element check would
+		// falsely reject. Recursive shape compare handles the nested form. structon attaches a function
+		// isCompatible when saving Map form (the numeric fallback assumes Array shape), so the test
+		// mirrors that real-world call shape.
+		const root = rocksRoot();
+		const enc = makeRocksEncoder(root);
+		const first = new Map();
+		first.set('named', [['runId']]);
+		first.set('typed', [[['Long', 4, 'a']]]);
+		assert.strictEqual(
+			enc.saveStructures(first, () => true),
+			true
+		);
+		const second = new Map();
+		second.set('named', [['runId']]);
+		second.set('typed', [[['Long', 4, 'a']], [['Long', 4, 'b']]]);
+		assert.strictEqual(
+			enc.saveStructures(second, () => true),
+			true
+		);
+	});
+
+	it('strict-extension CAS rejects a typed-structure replacement at an existing id', () => {
+		// Concurrent writers both mint a typed struct at the same nextId; one must lose so the loser's
+		// records get re-packed against the persisted shape.
+		const root = rocksRoot();
+		const enc = makeRocksEncoder(root);
+		const first = new Map();
+		first.set('named', []);
+		first.set('typed', [[['Long', 4, 'a']]]);
+		assert.strictEqual(
+			enc.saveStructures(first, () => true),
+			true
+		);
+		const conflicting = new Map();
+		conflicting.set('named', []);
+		conflicting.set('typed', [[['Long', 4, 'b']]]);
+		assert.strictEqual(
+			enc.saveStructures(conflicting, () => true),
+			false
+		);
+	});
+
+	it('strict-extension CAS handles plain-object form (Map round-tripped via mapsAsObjects)', () => {
+		// msgpackr decodes Maps as plain objects under mapsAsObjects:true. RecordEncoder uses Map-form
+		// natively, but defensive normalization keeps the check correct even if the persisted form
+		// comes back as {named, typed}.
+		const root = rocksRoot();
+		const enc = makeRocksEncoder(root);
+		const first = new Map();
+		first.set('named', [['runId']]);
+		first.set('typed', [[['Long', 4, 'a']]]);
+		assert.strictEqual(
+			enc.saveStructures(first, () => true),
+			true
+		);
+		// Replace the persisted Map with the plain-object form to simulate a mapsAsObjects round-trip.
+		root.store.transactionSync((txn) =>
+			txn.putSync([Symbol.for('structures'), enc.name], { named: [['runId']], typed: [[['Long', 4, 'a']]] })
+		);
+		const extended = new Map();
+		extended.set('named', [['runId']]);
+		extended.set('typed', [[['Long', 4, 'a']], [['Long', 4, 'b']]]);
+		assert.strictEqual(
+			enc.saveStructures(extended, () => true),
+			true
+		);
+	});
+
 	// End-to-end retry-flow coverage (encode → save → CAS reject → msgpackr re-pack → decode against
 	// the new disk state) lives in harper-pro's integrationTests/cluster/multiShapeReplicationConvergence.test.mjs,
 	// which exercises a real RocksDB-backed encoder with 4-thread writers and varying optional-field

--- a/unitTests/resources/recordEncoder-structuresMismatch.test.js
+++ b/unitTests/resources/recordEncoder-structuresMismatch.test.js
@@ -1,0 +1,191 @@
+// Regression for HarperFast/harper#1337: a record encoded against one
+// sharedStructures snapshot becomes undecodable when the dictionary on disk
+// is replaced with a different shape at the same struct id.
+//
+// In the cluster we observed records in Campaign/ CF that started with the
+// metadata-prefix + bare struct-ref byte (e.g. 0x43) and depended on an
+// in-memory sharedStructures dictionary to interpret the value bytes. When
+// the dictionary that getStructures() returns disagrees with what was used at
+// encode time, msgpackr decodes against the wrong shape and throws the exact
+// production error: "Data read, but end of buffer not reached <partial>".
+//
+// The failure mode is silent corruption: no client-side error, no operator
+// alert, no automated reconciliation. Records on disk are unreadable until
+// the dictionary is restored or each record is re-encoded with inline defs.
+//
+// See: https://github.com/HarperFast/harper/issues/1337
+
+require('../testUtils');
+const assert = require('assert');
+const { RecordEncoder } = require('#src/resources/RecordEncoder');
+const { Encoder } = require('msgpackr');
+
+// A shared, mutable "disk" for the structures buffer. Mirrors the way DBIs
+// hold the sharedStructures blob under Symbol.for('structures').
+function sharedStore() {
+	let buf;
+	const meta = new Encoder();
+	return {
+		save(s) {
+			buf = meta.encode(s);
+			return true;
+		},
+		get() {
+			return buf ? meta.decode(buf) : undefined;
+		},
+		raw: () => buf,
+		setRaw: (b) => {
+			buf = b;
+		},
+	};
+}
+
+function makeEncoder(store) {
+	return new RecordEncoder({
+		structures: [],
+		// false = msgpackr named-structures path (records start in 0x40-0x5f), which is
+		// the path the failing production records take.
+		randomAccessStructure: false,
+		getStructures: store.get,
+		saveStructures: store.save,
+	});
+}
+
+describe('RecordEncoder sharedStructures dictionary divergence (harper#1337)', () => {
+	it('records that reference a struct id become undecodable when the dictionary at that id is replaced', () => {
+		// Writer A encodes a record with one shape, persists its structures.
+		const storeA = sharedStore();
+		const writerA = makeEncoder(storeA);
+		const recordA = { runId: 'r-1', vu: 'v-1', iter: 'paused' };
+		const bytesA = Buffer.from(writerA.encode(recordA));
+
+		// Sanity: writer A actually persisted some structures, and its record bytes
+		// land in the named-struct ref range (0x40-0x5f) so they depend on the dictionary.
+		assert.ok(storeA.get()?.length > 0, 'writer A should have persisted structures');
+		assert.ok(
+			bytesA[0] >= 0x40 && bytesA[0] < 0x60,
+			`expected named-struct ref byte 0x40-0x5f, got 0x${bytesA[0].toString(16)}`
+		);
+
+		// Writer B encodes a different shape against a fresh store (simulating a
+		// concurrent encoder instance that started before seeing writer A's save,
+		// or a post-restart fresh thread). Writer B's structure mints at id 0
+		// with a different shape than writer A's id 0.
+		const storeB = sharedStore();
+		const writerB = makeEncoder(storeB);
+		const recordB = { alpha: 1, beta: 2 };
+		writerB.encode(recordB);
+
+		// The "disk" then ends up holding writer B's structures (the cluster
+		// observation: post-rollout, the on-disk dictionary disagrees with what
+		// some records on disk were written against).
+		const reader = makeEncoder({
+			save: () => true,
+			get: storeB.get,
+			raw: storeB.raw,
+			setRaw: storeB.setRaw,
+		});
+
+		// Decoding writer A's record against writer B's dictionary should fail.
+		// The decoder reads the bytes as if they were the wrong shape, fills in
+		// the wrong field names, then chokes on the extra bytes.
+		let result;
+		let caught;
+		try {
+			result = reader.decode(bytesA);
+		} catch (e) {
+			caught = e;
+		}
+
+		// RecordEncoder.decode is non-fatal: it returns null and logs the error
+		// internally (see RecordEncoder.ts:432). The on-disk record is dropped from
+		// query results — silent data loss, which is exactly the production symptom.
+		assert.ok(
+			caught != null || result === null,
+			`expected decode to fail (return null or throw); got ${JSON.stringify(result)}`
+		);
+	});
+
+	it('a fresh decoder finds the inline-defining record to repopulate its dictionary on iterator read', () => {
+		// Counter-case: a record that carries its own inline struct definition
+		// (the d4 72 form) decodes regardless of what's on disk, because it
+		// teaches the decoder its own shape inline. This is why the working
+		// records in production decode fine — they were emitted before the
+		// dictionary diverged and the encoder hadn't yet switched to ref-only.
+		const store = sharedStore();
+		const writer = makeEncoder(store);
+		const record = { runId: 'r-1', vu: 'v-1', iter: 'active' };
+		const bytes = Buffer.from(writer.encode(record));
+
+		// A reader that knows about the structures decodes fine.
+		const reader = makeEncoder(store);
+		const decoded = reader.decode(bytes);
+		assert.ok(decoded, 'record should decode when the structure is available');
+		assert.strictEqual(decoded.runId, record.runId);
+		assert.strictEqual(decoded.vu, record.vu);
+		assert.strictEqual(decoded.iter, record.iter);
+	});
+
+	it('strict-extension CAS rejects a save that would replace an existing structure at the same index', () => {
+		// Direct check of the fix: saveStructures must reject any incoming
+		// structures array that differs from existing on an index that already
+		// has content. msgpackr's pack() loop sees the false return and re-packs
+		// the record at the next free id, so the on-disk record always references
+		// a structure that's actually persisted under that id.
+		//
+		// This test uses Harper's saveStructures hook directly (the production
+		// surface for RocksDB-backed stores) rather than racing two encoders,
+		// so it stays deterministic and fast.
+
+		let buf;
+		const meta = new Encoder();
+		// A minimal RocksDB-ish rootStore that backs the save into a single buffer
+		// via transactionSync (synchronous, no real DB needed for the CAS logic).
+		const rootStore = {
+			transactionSync(fn) {
+				return fn({
+					getBinarySync: () => buf,
+					putSync: (_key, value) => {
+						buf = meta.encode(value);
+					},
+				});
+			},
+		};
+
+		const enc = new RecordEncoder({
+			structures: [],
+			randomAccessStructure: false,
+			getStructures: () => (buf ? meta.decode(buf) : undefined),
+			saveStructures: () => true, // overridden via rootStore wiring below
+		});
+		// Wire up the RocksDB code path: isRocksDB=true, rootStore set,
+		// and the saveStructures override that lives in the constructor uses these.
+		enc.isRocksDB = true;
+		enc.rootStore = rootStore;
+
+		// Writer A's first save: nothing on disk, accept.
+		const structuresA = [['runId', 'vu', 'iter']];
+		const okA = enc.saveStructures(structuresA, 0);
+		assert.strictEqual(okA, true, 'first save should be accepted (disk empty)');
+		assert.deepStrictEqual(meta.decode(buf), structuresA, 'disk should hold writer A structures');
+
+		// Writer B comes along with a DIFFERENT shape at the same index 0.
+		// Length matches (both 1), so msgpackr's length-only check would accept this
+		// and silently corrupt anything writer A's records reference. The fix must
+		// reject it.
+		const structuresB = [['alpha', 'beta', 'gamma']];
+		const okB = enc.saveStructures(structuresB, 1);
+		assert.strictEqual(
+			okB,
+			false,
+			'save that would replace existing structure at index 0 with a different shape must be rejected'
+		);
+		assert.deepStrictEqual(meta.decode(buf), structuresA, 'disk should still hold writer A structures');
+
+		// A save that strictly EXTENDS the existing dictionary is accepted.
+		const structuresExtended = [['runId', 'vu', 'iter'], ['alpha', 'beta', 'gamma']];
+		const okExt = enc.saveStructures(structuresExtended, 1);
+		assert.strictEqual(okExt, true, 'save that extends existing structures should be accepted');
+		assert.deepStrictEqual(meta.decode(buf), structuresExtended, 'disk should now hold extended structures');
+	});
+});

--- a/unitTests/resources/recordEncoder-structuresMismatch.test.js
+++ b/unitTests/resources/recordEncoder-structuresMismatch.test.js
@@ -188,4 +188,128 @@ describe('RecordEncoder sharedStructures dictionary divergence (harper#1337)', (
 		assert.strictEqual(okExt, true, 'save that extends existing structures should be accepted');
 		assert.deepStrictEqual(meta.decode(buf), structuresExtended, 'disk should now hold extended structures');
 	});
+
+	it('strict-extension CAS catches replacement at a non-zero index', () => {
+		// The check loops over every existing entry, not just index 0. Catch a
+		// regression in the loop bounds where a later writer replaces a middle
+		// entry while preserving entries 0..i-1 and i+1..N.
+		let buf;
+		const meta = new Encoder();
+		const rootStore = {
+			transactionSync(fn) {
+				return fn({
+					getBinarySync: () => buf,
+					putSync: (_key, value) => {
+						buf = meta.encode(value);
+					},
+				});
+			},
+		};
+		const enc = new RecordEncoder({
+			structures: [],
+			randomAccessStructure: false,
+			getStructures: () => (buf ? meta.decode(buf) : undefined),
+			saveStructures: () => true,
+		});
+		enc.isRocksDB = true;
+		enc.rootStore = rootStore;
+
+		const original = [['a'], ['b'], ['c']];
+		assert.strictEqual(enc.saveStructures(original, 0), true);
+
+		// Same length, same entries at index 0 and 2, DIFFERENT entry at index 1.
+		const mutated = [['a'], ['X'], ['c']];
+		assert.strictEqual(
+			enc.saveStructures(mutated, 3),
+			false,
+			'replacement at index 1 (mid-array) must be rejected even when length matches'
+		);
+		assert.deepStrictEqual(meta.decode(buf), original, 'disk should still hold the original structures');
+	});
+
+	it('strict-extension CAS accepts a strict suffix extension', () => {
+		// Belt-and-braces: an off-by-one in the comparison loop could reject
+		// legitimate extensions and break normal write throughput. Verify the
+		// happy path explicitly.
+		let buf;
+		const meta = new Encoder();
+		const rootStore = {
+			transactionSync(fn) {
+				return fn({
+					getBinarySync: () => buf,
+					putSync: (_key, value) => {
+						buf = meta.encode(value);
+					},
+				});
+			},
+		};
+		const enc = new RecordEncoder({
+			structures: [],
+			randomAccessStructure: false,
+			getStructures: () => (buf ? meta.decode(buf) : undefined),
+			saveStructures: () => true,
+		});
+		enc.isRocksDB = true;
+		enc.rootStore = rootStore;
+
+		// Establish a 3-entry baseline on disk.
+		assert.strictEqual(enc.saveStructures([['a'], ['b'], ['c']], 0), true);
+
+		// Append two entries — same prefix [a, b, c], plus [d] and [e].
+		const extended = [['a'], ['b'], ['c'], ['d'], ['e']];
+		assert.strictEqual(
+			enc.saveStructures(extended, 3),
+			true,
+			'strict extension (existing prefix preserved, new entries appended) must be accepted'
+		);
+		assert.deepStrictEqual(meta.decode(buf), extended);
+	});
+
+	it('strict-extension CAS rejects a type mismatch at an existing index', () => {
+		// If an existing entry is an array (the expected shape for a structure
+		// definition) but a new save puts a non-array at the same index, that's
+		// a corruption attempt; reject. The current implementation falls into
+		// the `!Array.isArray(...)` guard rather than throwing.
+		let buf;
+		const meta = new Encoder();
+		const rootStore = {
+			transactionSync(fn) {
+				return fn({
+					getBinarySync: () => buf,
+					putSync: (_key, value) => {
+						buf = meta.encode(value);
+					},
+				});
+			},
+		};
+		const enc = new RecordEncoder({
+			structures: [],
+			randomAccessStructure: false,
+			getStructures: () => (buf ? meta.decode(buf) : undefined),
+			saveStructures: () => true,
+		});
+		enc.isRocksDB = true;
+		enc.rootStore = rootStore;
+
+		assert.strictEqual(enc.saveStructures([['a', 'b']], 0), true);
+		// Same length, but the new entry at index 0 is a string instead of an array.
+		const mutated = ['notAnArray'];
+		assert.strictEqual(
+			enc.saveStructures(mutated, 1),
+			false,
+			'type-mismatch save (array → non-array at same index) must be rejected'
+		);
+	});
+
+	// Note on end-to-end coverage: validating that msgpackr's pack() re-pack
+	// loop fires correctly on our `false` return and produces records that
+	// decode against the new disk state needs a real RocksDB-backed encoder
+	// (the decode path uses rootStore.getBinarySync to resolve blob
+	// references, which a mock doesn't satisfy without basically rebuilding
+	// the store). That validation lives in harper-pro's
+	// `integrationTests/cluster/multiShapeReplicationConvergence.test.mjs`
+	// where two-node mesh + 4-thread writers + varying optional-field
+	// combinations exercise the full encode→save→CAS→re-pack→decode loop
+	// with the actual storage layer. The four CAS tests above are the
+	// per-condition slices of that flow.
 });


### PR DESCRIPTION
## Summary

Under concurrent encoder writes the `saveStructures` CAS check at `resources/RecordEncoder.ts` only verifies length match, so two writers with the same baseline length can independently mint different shapes at the same struct id. One save lands on disk first; the other writer's already-encoded records on disk now reference that struct id expecting a different shape. On decode msgpackr reads the bytes against the wrong shape, fills in the wrong field names from the now-current dictionary populated with values from the original record, and throws the production error `Data read, but end of buffer not reached <partial>` — byte-for-byte the call chain seen in the cluster logs for #1337.

This adds a content comparison after the existing length check: any save whose new structures array does not match the existing entries on a prefix is rejected, msgpackr's `pack()` loop sees the false return, reloads structures from disk, and re-mints the new shape at the next free id.

## Format-aware comparison (refinement, commit 7cc690ca3)

The first version of the check iterated `existingStructures.length` and indexed `structures[i]`, which is wrong as soon as structon's `prepareStructures` upgrades the wire format from a plain Array (named-only) to a `Map` with `named` and `typed` keys the moment the first typedStruct is minted. On a Map, numeric indexing returns `undefined`; the `!Array.isArray(undefined)` guard then rejected every legitimate Array→Map upgrade. Observed in a live patched cluster: decode errors stopped (good — confirms the CAS does catch the race) but during-window catchup stalled — receivers silently re-packed against the new disk state, hit the same false-reject on the next save, and never durably applied the record.

The refinement normalizes both sides through a small `toShape` helper that handles all three wire forms (Array, Map, or plain object after a `mapsAsObjects` round-trip) and runs a recursive `shapeEqual` so identical typed entries (arrays of `[type, size, key]` triples from different literals) compare equal. The strict-extension check then runs against the named and typed arrays independently.

## Test coverage

`unitTests/resources/recordEncoder-structuresMismatch.test.js` — 11 cases:

- failure mode reproduces the production error chain end-to-end
- working case still decodes when writer/reader share a store
- CAS rejects same-length replacement at index 0
- CAS catches replacement at a non-zero index
- CAS accepts strict suffix extension
- CAS rejects array→non-array type mismatch
- **CAS accepts Array→Map upgrade when named entries match** (the regression that broke during-window catchup in production)
- CAS rejects a Map upgrade that mutates an existing named entry
- CAS accepts an append to typed structures in Map form (reference-equality sub-array trap)
- CAS rejects a typed-structure replacement at an existing id (concurrent typedStruct collision)
- CAS handles plain-object form (Map round-tripped via `mapsAsObjects: true`)

End-to-end retry-flow coverage lives in harper-pro's `multiShapeReplicationConvergence.test.mjs` which exercises the full encode→save→CAS→re-pack→decode loop against a real RocksDB-backed encoder.

## Scope

This prevents future corruption. It does not address lost replication messages from the rolling upgrade window or records that are already corrupted on disk in deployed clusters; those need separate work.

## Migration path is not affected

`bin/copyDb.ts` writes structures via `targetRootStore.putSync([STRUCTURES_KEY, storeName], binaryBuffer)` directly (lines 403, 406), bypassing `saveStructures` entirely. The per-record re-encoding step explicitly installs a no-op `saveStructures` on both `existingEncoder` and `tempEncoder` (lines 458-462), so msgpackr's `pack()` does not hit the patched code during migration either. The strict-extension CAS only runs on runtime writes.

## Validated locally

- [x] `npx mocha unitTests/resources/recordEncoder-structuresMismatch.test.js` (11/11)
- [x] `npx mocha unitTests/resources/recordEncoder.test.js` (9/9)
- [x] `node --test integrationTests/cluster/multiShapeReplicationConvergence.test.mjs` in harper-pro with this branch wired as the core submodule — passes on the pre-refinement commit; needs re-run with 7cc690ca3 to confirm the format-aware comparison doesn't regress the typed-shape coverage

## Live-cluster signal (pre-refinement bundle)

Bundled the pre-refinement build to the v4→v5 mixed cluster: `Data read, but end of buffer not reached` errors stopped on the upgraded node, confirming the CAS does close the corruption race. During-window record catchup did not converge, which surfaced the Array→Map false-reject bug above. The refinement targets that gap.

## Not validated locally, needs CI

- [ ] `integrationTests/cluster/cloneFromLegacy.test.mjs` early-returns without `HARPER_LEGACY_VERSION_PATH`. CI has a v4 binary; defensive belt to confirm the post-migration runtime path also stays healthy with the strict-extension CAS in place.
- [ ] `unitTests/bin/copyDB.test.js` early-returns when `STORAGE_ENGINE !== 'lmdb'`. Same scenario, same delegation.

Refs #1337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)