### PR TITLE
fix(blob): clean up replication-received blobs when a source apply is skipped (harper-pro#406)

### DIFF
--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -1,4 +1,4 @@
-import { cleanupUnusedBlobs } from './blob.ts';
+import { cleanupUnusedBlobs, collectRetainedFileIds } from './blob.ts';
 import { Transaction as LMDBTransaction } from 'lmdb';
 import { getNextMonotonicTime } from '../utility/lmdb/commonUtility.ts';
 import { ServerError } from '../utility/errors/hdbError.ts';
@@ -343,7 +343,8 @@ export class DatabaseTransaction implements Transaction {
 							// commit succeeded; clean up files for any writes whose commit-handler took an early-return.
 							// deferred until here so a retry that *would* have referenced the blob can flip skipped back to false first.
 							for (const write of this.writes) {
-								if (write?.skipped && write?.savedBlobs) cleanupUnusedBlobs(write.savedBlobs);
+								if (write?.skipped && write?.savedBlobs)
+									cleanupUnusedBlobs(write.savedBlobs, collectRetainedFileIds(write.store.getEntry(write.key)?.value));
 							}
 							// now reset transactions tracking; this transaction be reused and committed again
 							this.writes = [];
@@ -402,7 +403,8 @@ export class DatabaseTransaction implements Transaction {
 					);
 				}
 				for (const write of this.writes) {
-					if (write?.skipped && write?.savedBlobs) cleanupUnusedBlobs(write.savedBlobs);
+					if (write?.skipped && write?.savedBlobs)
+						cleanupUnusedBlobs(write.savedBlobs, collectRetainedFileIds(write.store.getEntry(write.key)?.value));
 				}
 				this.writes = [];
 				if (this.#context?.resourceCache) this.#context.resourceCache = null;
@@ -432,7 +434,8 @@ export class DatabaseTransaction implements Transaction {
 		while (this.readTxnsUsed > 0) this.doneReadTxn(); // release the read snapshot when we abort, we assume we don't need it
 		this.open = TRANSACTION_STATE.CLOSED;
 		for (const write of this.writes) {
-			if (write?.savedBlobs) cleanupUnusedBlobs(write.savedBlobs);
+			if (write?.savedBlobs)
+				cleanupUnusedBlobs(write.savedBlobs, collectRetainedFileIds(write.store.getEntry(write.key)?.value));
 		}
 		// reset the transaction
 		this.writes = [];

--- a/resources/LMDBTransaction.ts
+++ b/resources/LMDBTransaction.ts
@@ -4,7 +4,7 @@ import {
 	type TransactionWrite,
 	type CommitResolution,
 } from './DatabaseTransaction';
-import { cleanupUnusedBlobs } from './blob.ts';
+import { cleanupUnusedBlobs, collectRetainedFileIds } from './blob.ts';
 import { getNextMonotonicTime } from '../utility/lmdb/commonUtility.ts';
 import * as harperLogger from '../utility/logging/harper_logger.ts';
 import type { Context } from './ResourceInterface.ts';
@@ -262,7 +262,8 @@ export class LMDBTransaction extends DatabaseTransaction {
 					// commit succeeded; clean up files for any writes whose commit-handler took an early-return.
 					// deferred until here so a retry that *would* have referenced the blob can flip skipped back to false first.
 					for (const write of this.writes) {
-						if (write?.skipped && write?.savedBlobs) cleanupUnusedBlobs(write.savedBlobs);
+						if (write?.skipped && write?.savedBlobs)
+							cleanupUnusedBlobs(write.savedBlobs, collectRetainedFileIds(write.store.getEntry(write.key)?.value));
 					}
 					// now reset transactions tracking; this transaction be reused and committed again
 					this.writes = [];
@@ -304,8 +305,11 @@ export class LMDBTransaction extends DatabaseTransaction {
 		while (this.readTxnsUsed > 0) this.doneReadTxn(); // release the read snapshot when we abort, we assume we don't need it
 		this.open = TRANSACTION_STATE.CLOSED;
 		// any blobs that were pre-saved as part of these writes will never be referenced; schedule deletion
+		// (retaining any fileId the current on-disk record still references — an aborted write may carry an
+		// already-saved blob shared with the surviving record; see harper-pro#406).
 		for (const write of this.writes) {
-			if (write?.savedBlobs) cleanupUnusedBlobs(write.savedBlobs);
+			if (write?.savedBlobs)
+				cleanupUnusedBlobs(write.savedBlobs, collectRetainedFileIds(write.store.getEntry(write.key)?.value));
 		}
 		// reset the transaction
 		this.writes = [];

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -2360,7 +2360,15 @@ export function makeTable(options) {
 				TableResource.userEmbedders
 			);
 			const proceed = (): any => {
-				write.beforeIntermediate = preCommitBlobsForRecordBefore(write, recordUpdate);
+				// On a source/replication apply (`isNotification`), the record's already-saved blobs were
+				// received out-of-band for THIS write, so track them for skip/abort cleanup (harper-pro#406).
+				write.beforeIntermediate = preCommitBlobsForRecordBefore(
+					write,
+					recordUpdate,
+					undefined,
+					undefined,
+					options?.isNotification
+				);
 				return transaction.addWrite(write as any);
 			};
 			return embedBefore ? embedBefore().then(proceed) : proceed();
@@ -5257,9 +5265,10 @@ export function makeTable(options) {
 		write: any,
 		record: any,
 		before?: () => Promise<void> | void,
-		saveInRecord?: boolean
+		saveInRecord?: boolean,
+		trackPersistedBlobs?: boolean
 	): any {
-		const preCommit = startPreCommitBlobsForRecord(record, primaryStore.rootStore, saveInRecord);
+		const preCommit = startPreCommitBlobsForRecord(record, primaryStore.rootStore, saveInRecord, trackPersistedBlobs);
 		if (preCommit) {
 			// track the blobs on the write so abort/skip paths can clean up the files if the commit doesn't reference them
 			write.savedBlobs = preCommit.blobs;

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -1028,12 +1028,28 @@ export interface PreCommitBlobs {
 export function startPreCommitBlobsForRecord(
 	record: any,
 	store: any,
-	saveInRecord?: boolean
+	saveInRecord?: boolean,
+	trackPersistedBlobs?: boolean
 ): PreCommitBlobs | undefined {
 	const blobsNeedingSaving: Blob[] = [];
 	for (const key in record) {
 		const value = record[key];
-		if (value instanceof FileBackedBlob && (saveInRecord || value.saveBeforeCommit)) {
+		// Track a file-backed blob on the write when it still needs saving before commit (the local-write
+		// path: `saveInRecord`/`saveBeforeCommit`) OR — only when `trackPersistedBlobs` is set — when it is
+		// already saved on disk (`fileId` set). The latter covers replication/source applies, where
+		// `receiveBlobs` saved the blob out-of-band before this apply: tracking it lets the skip/abort cleanup
+		// unlink it if this write loses a version conflict and never references it (otherwise it leaks —
+		// harper-pro#406). `trackPersistedBlobs` is gated to the source-apply path on purpose: a received blob
+		// is owned by THIS write (a unique fileId saved for it), whereas a local write that carries an
+		// already-saved blob references another row's blob (cross-row reuse, which `pack` rejects, or a same-
+		// key unchanged-attribute update) — deleting those on abort/skip would corrupt the owning record.
+		// Already-saved blobs are not re-saved (saveBlob early-returns on an existing fileId); the
+		// retained-fileId guard in cleanupUnusedBlobs additionally protects any blob the committed record
+		// still references.
+		if (
+			value instanceof FileBackedBlob &&
+			(saveInRecord || value.saveBeforeCommit || (trackPersistedBlobs && storageInfoForBlob.get(value)?.fileId != null))
+		) {
 			currentStore = store;
 			if (saveInRecord) {
 				value.saveInRecord = true;
@@ -1064,13 +1080,21 @@ export function startPreCommitBlobsForRecord(
  * Waits for any in-flight save to settle before unlinking, so we don't race with the writer
  * and leave a half-written file. Errors are swallowed — the blob may have already been
  * cleaned up by deleteOnFailure on the save path.
+ *
+ * `retainedFileIds` is the set of fileIds the COMMITTED (winning) record still references — those are
+ * skipped. This matters now that already-saved blobs are tracked (see startPreCommitBlobsForRecord): a
+ * skipped/aborted write can carry a file-backed blob whose fileId is shared with the surviving record
+ * (e.g. a superseded full-record update of a row whose blob attribute is unchanged), and deleting it
+ * would corrupt that record (harper-pro#406).
  * @param blobs blobs that were registered via {@link startPreCommitBlobsForRecord}
+ * @param retainedFileIds fileIds the committed record still references; never deleted
  */
-export function cleanupUnusedBlobs(blobs: Blob[] | undefined): void {
+export function cleanupUnusedBlobs(blobs: Blob[] | undefined, retainedFileIds?: Set<string>): void {
 	if (!blobs?.length) return;
 	for (const blob of blobs) {
 		const storageInfo = storageInfoForBlob.get(blob);
 		if (!storageInfo?.fileId || (blob as FileBackedBlob).saveInRecord) continue; // no file written, nothing to clean up
+		if (retainedFileIds?.has(storageInfo.fileId)) continue; // the committed record still references this blob
 		const settle = storageInfo.saving ?? Promise.resolve();
 		settle.then(
 			() => deleteBlob(blob),
@@ -1079,6 +1103,21 @@ export function cleanupUnusedBlobs(blobs: Blob[] | undefined): void {
 	}
 	// idempotent: subsequent calls (e.g. from abort after commit-handler already cleaned up) are no-ops
 	blobs.length = 0;
+}
+
+/**
+ * Collect the fileIds of every file-backed blob referenced by `record`, for use as the
+ * `retainedFileIds` guard in {@link cleanupUnusedBlobs}. Returns undefined when there are none (so the
+ * caller can skip allocating a set on the common blob-less path). See harper-pro#406.
+ */
+export function collectRetainedFileIds(record: any): Set<string> | undefined {
+	if (!record || typeof record !== 'object') return undefined;
+	let fileIds: Set<string> | undefined;
+	findBlobsInObject(record, (blob) => {
+		const fileId = storageInfoForBlob.get(blob)?.fileId;
+		if (fileId) (fileIds ??= new Set()).add(fileId);
+	});
+	return fileIds;
 }
 
 const copyingUnpacker = new Packr({ copyBuffers: true, mapsAsObjects: true });

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -14,8 +14,13 @@ const {
 	isSaving,
 	cleanupOrphans,
 	cleanupUnusedBlobs,
+	collectRetainedFileIds,
+	getFileId,
+	saveBlob,
+	decodeFromDatabase,
+	startPreCommitBlobsForRecord,
 } = require('#src/resources/blob');
-const { existsSync } = require('fs');
+const { existsSync, unlinkSync } = require('fs');
 const { pack } = require('msgpackr');
 const { randomBytes } = require('crypto');
 const { waitFor } = require('../waitFor.js');
@@ -491,6 +496,46 @@ describe('Blob test', () => {
 		// the original record value is preserved
 		const existing = await BlobTest.get(250);
 		assert.equal(await existing.blob.text(), 'first');
+	});
+	it('#406: startPreCommitBlobsForRecord tracks an already-saved blob only when trackPersistedBlobs is set', async () => {
+		// A replication-received blob is saved out-of-band by receiveBlobs BEFORE the apply, so at pre-commit
+		// it has a fileId but no saveBeforeCommit flag. It must be tracked (so a superseded apply's cleanup
+		// can unlink it — #406), but ONLY on the source-apply path: a local write carrying an already-saved
+		// blob references another row's blob and must not be unlinked on abort/skip.
+		const receivedBlob = createBlob(Buffer.alloc(20000, 'c'));
+		await decodeFromDatabase(() => saveBlob(receivedBlob).saving, BlobTest.primaryStore.rootStore);
+		const record = { id: 1, blob: receivedBlob };
+		const store = BlobTest.primaryStore.rootStore;
+		// local write (trackPersistedBlobs falsy): an already-saved blob is NOT tracked
+		assert.equal(startPreCommitBlobsForRecord(record, store, false, false), undefined);
+		// source/replication apply (trackPersistedBlobs true): tracked for skip/abort cleanup
+		const preCommit = startPreCommitBlobsForRecord(record, store, false, true);
+		assert(preCommit && preCommit.blobs.includes(receivedBlob), 'received blob tracked on source apply');
+		unlinkSync(getFilePathForBlob(receivedBlob)); // not referenced by any record; remove so it isn't counted as an orphan
+	});
+	it('#406: cleanupUnusedBlobs deletes non-retained blobs but keeps retained ones', async () => {
+		// The retained-fileId guard: a skipped/aborted write may carry a blob whose fileId the surviving
+		// record still references; deleting it would corrupt that record.
+		setDeletionDelay(0);
+		const keep = createBlob(Buffer.alloc(20000, 'k'));
+		const drop = createBlob(Buffer.alloc(20000, 'p'));
+		await decodeFromDatabase(() => saveBlob(keep).saving, BlobTest.primaryStore.rootStore);
+		await decodeFromDatabase(() => saveBlob(drop).saving, BlobTest.primaryStore.rootStore);
+		const keepPath = getFilePathForBlob(keep);
+		const dropPath = getFilePathForBlob(drop);
+		cleanupUnusedBlobs([keep, drop], new Set([getFileId(keep)]));
+		await waitFor(() => !existsSync(dropPath), { message: `non-retained blob ${dropPath} should be deleted` });
+		assert(existsSync(keepPath), 'retained blob must NOT be deleted');
+		unlinkSync(keepPath); // not referenced by any record; remove so it isn't counted as an orphan
+	});
+	it('#406: collectRetainedFileIds returns the fileIds of saved blobs in a record', async () => {
+		const blob = createBlob(Buffer.from('x'));
+		await decodeFromDatabase(() => saveBlob(blob).saving, BlobTest.primaryStore.rootStore);
+		const ids = collectRetainedFileIds({ attr: blob, other: 5 });
+		assert(ids instanceof Set);
+		assert(ids.has(getFileId(blob)));
+		assert.equal(collectRetainedFileIds(null), undefined); // no record
+		assert.equal(collectRetainedFileIds({ no: 'blobs' }), undefined); // no blobs → no set allocated
 	});
 	it('cleanupUnusedBlobs is a no-op for unsaved blobs and clears the list', () => {
 		const unsavedBlob = createBlob(Buffer.from('not yet saved'));


### PR DESCRIPTION
## Summary

Fixes a replicated-blob **orphan leak** (harper-pro#406). On a replication/source apply, the record's blobs are saved out-of-band by `receiveBlobs` *before* the apply runs. If that apply then loses a version conflict (`precedesExistingVersion <= 0` → `write.skipped`), the received blob was never unlinked — `startPreCommitBlobsForRecord` only tracked `saveBeforeCommit` blobs in `write.savedBlobs`, so the skip/abort cleanup had nothing to remove. On an active multi-node caching cluster these accumulate: an audit-aware `cleanup_orphan_blobs` sweep on one preprod node reclaimed **1059 true-orphan blobs** (~84% of its blob files).

## Changes

- **`resources/blob.ts`**
  - `startPreCommitBlobsForRecord(record, store, saveInRecord?, trackPersistedBlobs?)`: when `trackPersistedBlobs` is set, also track an already-saved (fileId-set) blob so the skip/abort cleanup can unlink it. Gated deliberately (see below).
  - `cleanupUnusedBlobs(blobs, retainedFileIds?)`: never deletes a blob whose fileId the committed (winning) record still references.
  - new `collectRetainedFileIds(record)` helper.
- **`resources/Table.ts`**: `preCommitBlobsForRecordBefore` forwards the flag; the `_writeUpdate` call site passes `options?.isNotification`.
- **`resources/LMDBTransaction.ts` (×2)** and **`resources/DatabaseTransaction.ts` (×3)**: the skip/abort cleanup sites pass `collectRetainedFileIds(write.store.getEntry(write.key)?.value)`.

## Where to look

- **The gating decision is load-bearing for data integrity.** Already-saved blobs are tracked *only* on the source/replication apply path (`isNotification`). A received blob is owned by that one write (a unique fileId saved for it). A **local** write that carries an already-saved blob instead references *another row's* blob — and deleting that on abort/skip would corrupt the owning record. (Cross-model review caught exactly this in the first cut, where tracking was unconditional; this gating + the retained guard is the fix.) `pack()` already rejects reusing a blob across records, but the rejection throws *after* `savedBlobs` is populated, so the resulting abort would have triggered the bad delete — hence gating, not just relying on the guard.
- **Pre-existing consideration, not addressed here (worth a reviewer opinion):** cross-node fileId collision. fileIds are per-origin-node sequences, so two records from different origins can share a fileId string and thus the same on-disk blob path. That's a latent collision independent of this change (the second receive already overwrites the first). This fix's skip-delete is same-origin-safe (a received blob's fileId is unique to its record) and the retained guard covers the same-key case, but a cross-key cross-node collision is not something this PR solves. Flagging in case you want a follow-up issue.

## Tests

- `unitTests/resources/blob.test.js`: 3 new tests — `trackPersistedBlobs` gating, the `retainedFileIds` guard (deletes non-retained, keeps retained), and `collectRetainedFileIds`. Existing "updating an unrelated attribute does not unlink a still-referenced blob" still passes.
- Full `unitTests/resources/**` suite: **815 passing, 0 failing**. Lint clean.

## Review provenance / caveats

- Cross-model review ran via Codex (twice). The first pass flagged a real **data-loss blocker** (unconditional tracking would delete a cross-row-shared blob on abort) — fixed by the `isNotification` gating above; Codex re-reviewed the revision and confirmed the blocker is resolved with no new findings.
- **Caveat:** the Gemini (`agy`) leg timed out/produced no output both rounds, and the worktree-isolated `reviewer` subagent could not launch (harness `WorktreeCreate` hook error). I did the Harper-domain pass myself instead. So this change has had Codex + author domain review but **not** the Gemini or Opus-reviewer legs — worth a careful human data-integrity pass.

🤖 Generated by Claude (Opus 4.8). Fix for harper-pro#406.
