### PR TITLE
Warn when a per-record expiresAt has no scheduled cleanup (#1339)

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -236,6 +236,10 @@ export function makeTable(options) {
 	let cleanupPriority = 0;
 	let lastCleanupInterval: number;
 	let cleanupTimer: NodeJS.Timeout;
+	// true once a table-level expiration/eviction/scanInterval has armed the periodic cleanup scan at setup
+	let expirationScanScheduled = false;
+	// dedup flag for the once-per-table warning about a runtime per-record expiresAt with no scheduled cleanup
+	let warnedUnscheduledExpiration = false;
 	let propertyResolvers: any;
 	let hasRelationships = false;
 	let runningRecordExpiration: boolean;
@@ -957,6 +961,7 @@ export function makeTable(options) {
 			if (expirationMs < 0) throw new Error('Expiration can not be negative');
 			// default to one quarter of the total expiration+eviction window
 			cleanupInterval = cleanupInterval || (expirationMs + evictionMs) / 4;
+			expirationScanScheduled = true;
 			scheduleCleanup();
 		}
 
@@ -2309,7 +2314,28 @@ export function makeTable(options) {
 					updateIndices(id, existingRecord, recordToStore, transaction && { transaction });
 
 					writeCommit(true);
-					if (expiresAt >= 0) scheduleCleanup(); // arm for replicated writes too, not just local-context writes
+					if (expiresAt >= 0) {
+						scheduleCleanup(); // arm for replicated writes too, not just local-context writes
+						// A runtime per-record expiresAt on a table with no table-level expiration/eviction, no expiresAt
+						// attribute, and no source has no setup-time arming of the cleanup scan: the scan is only armed
+						// best-effort from this write path, on whichever worker happened to handle the write, and is not
+						// re-armed after a restart with no further writes. Warn once per table so the misconfiguration is
+						// visible and the operator can configure reliable, setup-armed eviction. See issue #1339.
+						if (
+							// dedup first so that, once warned, every later expiring write short-circuits on one check
+							!warnedUnscheduledExpiration &&
+							!expirationMs &&
+							!evictionMs &&
+							!expirationScanScheduled &&
+							!expiresAtProperty &&
+							!hasSourceGet
+						) {
+							warnedUnscheduledExpiration = true;
+							logger.warn?.(
+								`A per-record expiresAt was set on table "${tableName}" which has no table-level expiration/eviction, no expiresAt attribute, and no source; expiration will not be reliably enforced (the eviction scan is only armed best-effort on write and does not survive a restart with no writes). Configure a table-level expiration/eviction or an indexed expiresAt attribute for reliable eviction.`
+							);
+						}
+					}
 					function writeCommit(storeRecord: boolean) {
 						// we need to write the commit. if storeRecord then we need to store the record, otherwise we just need to store the audit record
 						updateRecord(

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -238,8 +238,8 @@ export function makeTable(options) {
 	let cleanupTimer: NodeJS.Timeout;
 	// true once a table-level expiration/eviction/scanInterval has armed the periodic cleanup scan at setup
 	let expirationScanScheduled = false;
-	// dedup flag for the once-per-table warning about a runtime per-record expiresAt with no scheduled cleanup
-	let warnedUnscheduledExpiration = false;
+	// set on the first expiring write so the unscheduled-expiration warning is evaluated at most once per table
+	let expirationWarningChecked = false;
 	let propertyResolvers: any;
 	let hasRelationships = false;
 	let runningRecordExpiration: boolean;
@@ -2321,19 +2321,14 @@ export function makeTable(options) {
 						// best-effort from this write path, on whichever worker happened to handle the write, and is not
 						// re-armed after a restart with no further writes. Warn once per table so the misconfiguration is
 						// visible and the operator can configure reliable, setup-armed eviction. See issue #1339.
-						if (
-							// dedup first so that, once warned, every later expiring write short-circuits on one check
-							!warnedUnscheduledExpiration &&
-							!expirationMs &&
-							!evictionMs &&
-							!expirationScanScheduled &&
-							!expiresAtProperty &&
-							!hasSourceGet
-						) {
-							warnedUnscheduledExpiration = true;
-							logger.warn?.(
-								`A per-record expiresAt was set on table "${tableName}" which has no table-level expiration/eviction, no expiresAt attribute, and no source; expiration will not be reliably enforced (the eviction scan is only armed best-effort on write and does not survive a restart with no writes). Configure a table-level expiration/eviction or an indexed expiresAt attribute for reliable eviction.`
-							);
+						// Evaluate at most once per table (on the first expiring write); later writes short-circuit on one check.
+						if (!expirationWarningChecked) {
+							expirationWarningChecked = true;
+							if (!expirationMs && !evictionMs && !expirationScanScheduled && !expiresAtProperty && !hasSourceGet) {
+								logger.warn?.(
+									`A per-record expiresAt was set on table "${tableName}" which has no table-level expiration/eviction, no expiresAt attribute, and no source; expiration will not be reliably enforced (the eviction scan is only armed best-effort on write and does not survive a restart with no writes). Configure a table-level expiration/eviction or an indexed expiresAt attribute for reliable eviction.`
+								);
+							}
 						}
 					}
 					function writeCommit(storeRecord: boolean) {

--- a/unitTests/resources/expirationWarning.test.js
+++ b/unitTests/resources/expirationWarning.test.js
@@ -1,0 +1,100 @@
+require('../testUtils');
+const assert = require('assert');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { Resource } = require('#src/resources/Resource');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const { logger } = require('#src/utility/logging/logger');
+const { waitFor } = require('../waitFor.js');
+
+// Covers issue #1339: a runtime per-record expiresAt on a table with no table-level expiration/eviction,
+// no expiresAt attribute, and no source has no setup-time arming of the cleanup scan, so eviction is not
+// reliably enforced. Table.ts warns once per table when such a write happens; these tests assert the
+// warning fires for the unscheduled case and is suppressed when a reliable arming path is configured.
+describe('Per-record expiresAt without scheduled cleanup (#1339)', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+
+	let warnings;
+	let originalWarn;
+
+	const matchesWarning = (message) => typeof message === 'string' && message.includes('per-record expiresAt');
+	const warningsFor = (tableName) =>
+		warnings.filter(([message]) => matchesWarning(message) && message.includes(`"${tableName}"`));
+
+	before(function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+	});
+
+	beforeEach(function () {
+		warnings = [];
+		originalWarn = logger.warn;
+		logger.warn = (...args) => warnings.push(args);
+	});
+
+	afterEach(function () {
+		logger.warn = originalWarn;
+	});
+
+	it('warns once per table when a per-record expiresAt is set on an unconfigured table', async function () {
+		const UnscheduledTable = table({
+			table: 'UnscheduledExpiresAtTable',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }],
+		});
+		await UnscheduledTable.put(1, { id: 1, name: 'first' }, { expiresAt: Date.now() + 60000 });
+		await waitFor(() => warningsFor('UnscheduledExpiresAtTable').length === 1);
+		assert.strictEqual(warningsFor('UnscheduledExpiresAtTable').length, 1);
+
+		// A second expiring write must not produce a duplicate warning for the same table.
+		await UnscheduledTable.put(2, { id: 2, name: 'second' }, { expiresAt: Date.now() + 60000 });
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.strictEqual(warningsFor('UnscheduledExpiresAtTable').length, 1);
+	});
+
+	it('does not warn when the table has a table-level eviction configured', async function () {
+		const EvictionTable = table({
+			table: 'EvictionConfiguredTable',
+			database: 'test',
+			eviction: 3600,
+			attributes: [{ name: 'id', isPrimaryKey: true }],
+		});
+		await EvictionTable.put(1, { id: 1 }, { expiresAt: Date.now() + 60000 });
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.strictEqual(warningsFor('EvictionConfiguredTable').length, 0);
+	});
+
+	it('does not warn when the table has an expiresAt attribute', async function () {
+		const AttributeTable = table({
+			table: 'ExpiresAtAttributeTable',
+			database: 'test',
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'expiresAt', expiresAt: true, indexed: true },
+			],
+		});
+		await AttributeTable.put(1, { id: 1, expiresAt: Date.now() + 60000 }, { expiresAt: Date.now() + 60000 });
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		assert.strictEqual(warningsFor('ExpiresAtAttributeTable').length, 0);
+	});
+
+	it('does not warn when the table has a source', async function () {
+		const SourcedTable = table({
+			table: 'SourcedExpiresAtTable',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }],
+		});
+		SourcedTable.sourcedFrom(
+			class extends Resource {
+				get() {
+					// A source-driven per-record expiresAt: the cache-fill write goes through the same save path.
+					this.getContext().expiresAt = Date.now() + 60000;
+					return { id: this.getId(), name: 'from source' };
+				}
+			}
+		);
+		await SourcedTable.get(1);
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		assert.strictEqual(warningsFor('SourcedExpiresAtTable').length, 0);
+	});
+});


### PR DESCRIPTION
Closes #1339.

## Summary
Adds a once-per-table `logger.warn` at the per-record write path in `resources/Table.ts` when a record is written with a runtime per-record `expiresAt` (`>= 0`) on a table that has **no table-level expiration/eviction, no `expiresAt` schema attribute, and no source**. In that configuration the periodic eviction scan is armed only best-effort from the write path, so expired records (and their file-backed blobs) can accumulate with no eviction and no signal.

Two small supporting bits:
- `expirationScanScheduled` flag, set in `setTTLExpiration`, so a runtime `scanInterval`-only config also suppresses the warning.
- `warnedUnscheduledExpiration` dedup flag (checked first in the condition, so after the first warning every later expiring write short-circuits on one boolean).

## Purpose
Per-record `expiresAt` on such a table is enforced only by luck of worker placement, and not at all after a restart with no writes. Rather than paper over it, we surface the misconfiguration and steer the operator to a setup that arms reliably (table-level `expiration`/`eviction`, or an indexed `expiresAt` attribute).

**This is warn-only by design** (confirmed with maintainer). The scheduling itself cannot be made reliable without persistence — a restart with no subsequent writes, and non-write ingestion paths on other nodes, both still miss — so issue #1339's "fix the scheduling" ask was deliberately *not* attempted.

## Where to look
- `resources/Table.ts` save path (~2317): the warning + its suppression condition. Confirm the condition correctly excludes every reliable-arming path (`expirationMs`, `evictionMs`, `expirationScanScheduled`, `expiresAtProperty`, `hasSourceGet`).

## Open items for the reviewer (from cross-model review)
- **Residual silent case (Codex, narrow, left out of scope):** a table that *declares* an `expiresAt` attribute but a write supplies only a runtime `expiresAt` without populating the attribute field — the attribute-index scan won't catch that record, yet `!expiresAtProperty` suppresses the warning. Addressing it would require per-record field inspection on the hot path; flagged here rather than fixed. Reasonable to defer unless you want it covered.
- **Per-worker warning (accepted):** the dedup flag is per-worker, so a table written on multiple workers can warn up to once per worker. Bounded and arguably useful; cross-worker (ITC) dedup felt disproportionate for a warning.

## Tests
New `unitTests/resources/expirationWarning.test.js` (4 cases): warns once on an unconfigured table + dedups a second write; no warning when the table has table-level eviction, an `expiresAt` attribute, or a source. All passing; `caching`/`evictionBatch` suites unaffected.

_Generated by an LLM (Claude Opus 4.8)._