### PR TITLE
Fix audit read crash and wrong value images for keys deleted then re-inserted (#1330)

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -4095,10 +4095,12 @@ export function makeTable(options) {
 					if (auditRecord.tableId === tableId && compareKeys(auditRecord.recordId, id) === 0) {
 						history.splice(insertionPoint, 0, {
 							id: auditRecord.recordId,
-							localTime: nextVersion,
+							localTime: auditRecord.version,
 							version: auditRecord.version,
 							type: auditRecord.type,
-							value: auditRecord.getValue(primaryStore, true, nextVersion),
+							// reconstruct each entry's record image as of its own version, not the audit
+							// window boundary (nextVersion), matching getHistory (issue #1330)
+							value: auditRecord.getValue(primaryStore, true, auditRecord.version),
 							user: auditRecord.user,
 							operation: auditRecord.originatingOperation,
 						});

--- a/resources/crdt.ts
+++ b/resources/crdt.ts
@@ -177,6 +177,9 @@ export function getRecordAtTime(currentEntry, timestamp, store, tableId: number,
 	// then continue to iterate back through the audit history, filling in the blanks
 	while (unknowns.size > 0 && auditTime > 0) {
 		const auditEntry = auditStore.get(auditTime, tableId, recordId);
+		// The history needed to resolve the remaining unknowns may have been pruned away; stop
+		// rather than dereferencing a missing entry (mirrors the reverse-walk guard above).
+		if (!auditEntry) break;
 		let priorRecord: any;
 		switch (auditEntry.type) {
 			case 'put':

--- a/resources/crdt.ts
+++ b/resources/crdt.ts
@@ -70,6 +70,77 @@ export function applyReverse(record, update, unknowns: Set<string>) {
 	}
 }
 
+// Apply an audit update onto a record moving forward in time (the inverse of applyReverse). Used
+// when reconstructing a record from a known-good base after the reverse walk crosses a delete.
+export function applyForward(record, update) {
+	for (const key in update) {
+		const value = update[key];
+		if (value?.__op__) {
+			const operation = operations[value.__op__];
+			if (operation) operation(record, key, { value: value.value });
+			else throw new Error(`Unsupported operation ${value.__op__}`);
+		} else {
+			record[key] = value;
+		}
+	}
+}
+
+/**
+ * Reconstruct the record state at `timestamp` by walking the audit history forward from the most
+ * recent full `put` at or before `timestamp`. Used when the reverse-from-current walk in
+ * getRecordAtTime crosses a `delete`: a delete erases the record, leaving no base to keep reversing
+ * against, and everything newer than the delete is irrelevant to a `timestamp` that precedes it (a
+ * key that was deleted then re-inserted, see issue #1330).
+ *
+ * `fromVersion` is the newest pre-delete entry (the delete's previousVersion); the walk follows the
+ * previousVersion chain from there. Entries newer than `timestamp` are skipped (the cutoff may fall
+ * between entries). Returns null if the record did not exist at `timestamp` (the nearest in-range
+ * history boundary is a delete with no surviving writes, or there is no in-range history).
+ */
+function reconstructForward(auditStore, store, tableId: number, recordId: any, fromVersion, timestamp) {
+	// Collect the in-range entries (at or before `timestamp`) back to a base boundary, newest-first.
+	// The boundary is a full `put` (snapshot) or a `delete` (everything older is erased); a record
+	// whose first write was a `patch` has no put and bottoms out at the start of history. Only
+	// `put`/`patch` contribute to the value, matching the reverse walk's switch (other partial types
+	// such as `invalidate` are ignored).
+	const entries = [];
+	let auditTime = fromVersion;
+	while (auditTime > 0) {
+		const auditEntry = auditStore.get(auditTime, tableId, recordId);
+		if (!auditEntry) break;
+		if (auditEntry.type === 'delete') {
+			// A delete at or before `timestamp` bounds the history; the record is rebuilt from the
+			// writes collected after it (an empty base). A delete newer than `timestamp` (a later
+			// delete/re-insert cycle) is irrelevant and skipped, like any other newer entry.
+			if (auditTime <= timestamp) break;
+		} else if (auditTime <= timestamp) {
+			if (auditEntry.type === 'put') {
+				entries.push(auditEntry);
+				break; // full snapshot reached; nothing older is needed
+			} else if (auditEntry.type === 'patch') {
+				entries.push(auditEntry);
+			}
+		}
+		auditTime = auditEntry.previousVersion;
+	}
+	if (entries.length === 0) return null; // record did not exist at `timestamp`
+	// Replay oldest-first. The base is the put if the chain reached one; otherwise an empty record
+	// (the first in-range write was a patch, or a delete bounds the history) onto which patches apply.
+	let record = null;
+	for (let i = entries.length - 1; i >= 0; i--) {
+		const auditEntry = entries[i];
+		const value = auditEntry.getValue(store);
+		// Copy the base put: applyForward mutates `record`, and getValue may return a cached
+		// object shared with the audit entry.
+		if (auditEntry.type === 'put') record = { ...value };
+		else {
+			if (record == null) record = {};
+			applyForward(record, value);
+		}
+	}
+	return record;
+}
+
 /**
  * Reconstruct the record state at a given timestamp by going back through the audit history and reversing any changes
  * @param currentEntry
@@ -94,7 +165,10 @@ export function getRecordAtTime(currentEntry, timestamp, store, tableId: number,
 				applyReverse(record, auditEntry.getValue(store), unknowns);
 				break;
 			case 'delete':
-				record = null;
+				// The reverse walk reached a delete that is newer than `timestamp`. There is no
+				// base record to keep reversing patches against, so reconstruct the pre-delete
+				// state forward instead (issue #1330: a key deleted then re-inserted).
+				return reconstructForward(auditStore, store, tableId, recordId, auditEntry.previousVersion, timestamp);
 		}
 		auditTime = auditEntry.previousVersion;
 	}

--- a/resources/crdt.ts
+++ b/resources/crdt.ts
@@ -172,6 +172,13 @@ export function getRecordAtTime(currentEntry, timestamp, store, tableId: number,
 		}
 		auditTime = auditEntry.previousVersion;
 	}
+	// If the most recent entry at or before `timestamp` is a delete, the record did not exist then.
+	// (A delete reached as a boundary — rather than crossed, which returns via reconstructForward —
+	// is otherwise missed, leaving `record` holding a newer re-inserted value. See issue #1330.)
+	if (auditTime > 0) {
+		const boundaryEntry = auditStore.get(auditTime, tableId, recordId);
+		if (boundaryEntry?.type === 'delete') return null;
+	}
 	// some patches may leave properties in an unknown state, so we need to fill in the blanks
 	// first we determine if there any unknown properties
 	// then continue to iterate back through the audit history, filling in the blanks

--- a/unitTests/resources/crdt.test.js
+++ b/unitTests/resources/crdt.test.js
@@ -126,6 +126,20 @@ describe('crdt getRecordAtTime', () => {
 		assert.deepStrictEqual(getRecordAtTime(current, 15, store, 1, 'G'), { id: 'G', n: 1 });
 	});
 
+	it('does not crash when older history needed to fill unknowns has been pruned', () => {
+		// patch(n:2)@10 [PRUNED] <- patch(n:3)@20 <- patch(n:4)@30 (current). Reconstructing before
+		// the pruned base leaves `n` unknown and walks into the missing @10 entry.
+		const events = [
+			// version 10 intentionally absent from the store (pruned)
+			{ version: 20, type: 'patch', value: { n: 3 }, previousVersion: 10 },
+			{ version: 30, type: 'patch', value: { n: 4 }, previousVersion: 20 },
+		];
+		const store = makeStore(events);
+		const current = currentEntry({ id: 'K', n: 4, label: 'c' }, 30);
+		// `n` cannot be resolved (its prior value was pruned), so it keeps the live value; no throw.
+		assert.deepStrictEqual(getRecordAtTime(current, 15, store, 1, 'K'), { id: 'K', n: 4, label: 'c' });
+	});
+
 	describe('records with no delete in history (reverse-walk path unchanged)', () => {
 		// put(v:1) -> patch(v:2) -> patch(v:3, current)
 		const events = [

--- a/unitTests/resources/crdt.test.js
+++ b/unitTests/resources/crdt.test.js
@@ -111,6 +111,20 @@ describe('crdt getRecordAtTime', () => {
 		assert.deepStrictEqual(getRecordAtTime(current, 35, store, 1, 'R'), { count: 7 });
 	});
 
+	it('returns null for a timestamp in the most recent deleted gap (no newer delete)', () => {
+		// put -> delete -> put(re-insert, current). A timestamp after the delete but before the
+		// re-insert is reached as the reverse-walk boundary (no newer delete triggers
+		// reconstructForward), so the boundary-delete check must return null.
+		const events = [
+			{ version: 10, type: 'put', value: { id: 'G', n: 1 }, previousVersion: 0 },
+			{ version: 20, type: 'delete', value: null, previousVersion: 10 },
+			{ version: 30, type: 'put', value: { id: 'G', n: 2 }, previousVersion: 20 },
+		];
+		const store = makeStore(events);
+		const current = currentEntry({ id: 'G', n: 2 }, 30);
+		assert.strictEqual(getRecordAtTime(current, 25, store, 1, 'G'), null);
+	});
+
 	it('reconstructs a value that existed before a later delete/re-insert cycle', () => {
 		// put -> delete -> put -> delete -> put(current). A timestamp inside the FIRST live span
 		// must skip the newer delete and find the first put as its base.

--- a/unitTests/resources/crdt.test.js
+++ b/unitTests/resources/crdt.test.js
@@ -1,0 +1,159 @@
+const assert = require('assert');
+const { getRecordAtTime, applyForward } = require('#src/resources/crdt');
+
+// Build a mock audit history and the `store` shape getRecordAtTime expects. Each event is
+// { version, type: 'put'|'patch'|'delete', value, previousVersion }. The audit store resolves an
+// entry by its exact version (matching the real store, which is only ever queried by exact
+// version via the previousVersion chain).
+function makeStore(events) {
+	const byVersion = new Map();
+	for (const event of events) byVersion.set(event.version, event);
+	const auditStore = {
+		get(version) {
+			const event = byVersion.get(version);
+			if (!event) return undefined;
+			return {
+				type: event.type,
+				previousVersion: event.previousVersion,
+				getValue: () => event.value,
+			};
+		},
+	};
+	return { rootStore: { auditStore } };
+}
+
+// currentEntry mirrors the live record entry getRecordAtTime starts the reverse walk from.
+function currentEntry(value, localTime) {
+	return { value, localTime };
+}
+
+describe('crdt getRecordAtTime', () => {
+	describe('record deleted then re-inserted under the same key (issue #1330)', () => {
+		// put(n:1) -> patch(n:2) -> patch(n:3) -> delete -> put(n:4, re-insert, current)
+		const events = [
+			{ version: 10, type: 'put', value: { id: 'K', n: 1, label: 'a' }, previousVersion: 0 },
+			{ version: 20, type: 'patch', value: { n: 2, label: 'b' }, previousVersion: 10 },
+			{ version: 30, type: 'patch', value: { n: 3, label: 'c' }, previousVersion: 20 },
+			{ version: 40, type: 'delete', value: null, previousVersion: 30 },
+			{ version: 50, type: 'put', value: { id: 'K', n: 4, label: 'd' }, previousVersion: 40 },
+		];
+		const store = makeStore(events);
+		const current = currentEntry({ id: 'K', n: 4, label: 'd' }, 50);
+
+		it('reconstructs a pre-delete patch reached after crossing the delete (the crash case)', () => {
+			// Without the fix this threw: TypeError: Cannot set properties of null (setting 'id').
+			assert.deepStrictEqual(getRecordAtTime(current, 20, store, 1, 'K'), { id: 'K', n: 2, label: 'b' });
+		});
+
+		it('reconstructs the patch immediately before the delete (no base patch reversed)', () => {
+			assert.deepStrictEqual(getRecordAtTime(current, 30, store, 1, 'K'), { id: 'K', n: 3, label: 'c' });
+		});
+
+		it('reconstructs the base put that precedes the delete', () => {
+			assert.deepStrictEqual(getRecordAtTime(current, 10, store, 1, 'K'), { id: 'K', n: 1, label: 'a' });
+		});
+	});
+
+	it('applies CRDT add operations forward when reconstructing across a delete', () => {
+		// put(count:5) -> patch(+3) -> delete -> put(count:100, current); at the patch count is 8.
+		const events = [
+			{ version: 10, type: 'put', value: { id: 'C', count: 5 }, previousVersion: 0 },
+			{ version: 20, type: 'patch', value: { count: { __op__: 'add', value: 3 } }, previousVersion: 10 },
+			{ version: 30, type: 'delete', value: null, previousVersion: 20 },
+			{ version: 40, type: 'put', value: { id: 'C', count: 100 }, previousVersion: 30 },
+		];
+		const store = makeStore(events);
+		const current = currentEntry({ id: 'C', count: 100 }, 40);
+		assert.deepStrictEqual(getRecordAtTime(current, 20, store, 1, 'C'), { id: 'C', count: 8 });
+	});
+
+	it('returns null when the record was in a deleted gap at the requested time', () => {
+		// put -> delete -> put -> delete -> put(current). A timestamp inside the first deleted
+		// gap is reached by crossing the newer delete, then finding the older delete as the
+		// in-range boundary (no surviving base put) -> the record did not exist then.
+		const events = [
+			{ version: 10, type: 'put', value: { id: 'G', n: 1 }, previousVersion: 0 },
+			{ version: 20, type: 'delete', value: null, previousVersion: 10 },
+			{ version: 30, type: 'put', value: { id: 'G', n: 2 }, previousVersion: 20 },
+			{ version: 40, type: 'delete', value: null, previousVersion: 30 },
+			{ version: 50, type: 'put', value: { id: 'G', n: 3 }, previousVersion: 40 },
+		];
+		const store = makeStore(events);
+		const current = currentEntry({ id: 'G', n: 3 }, 50);
+		assert.strictEqual(getRecordAtTime(current, 25, store, 1, 'G'), null);
+	});
+
+	it('reconstructs a record whose first write was a patch (no preceding put) across a delete', () => {
+		// A key created by an incremental update has type 'patch' with previousVersion 0 (no put).
+		// patch(+5) -> delete -> put(re-insert, current); at the patch the record was { count: 5 }.
+		const events = [
+			{ version: 10, type: 'patch', value: { count: { __op__: 'add', value: 5 } }, previousVersion: 0 },
+			{ version: 20, type: 'delete', value: null, previousVersion: 10 },
+			{ version: 30, type: 'put', value: { id: 'P', count: 99 }, previousVersion: 20 },
+		];
+		const store = makeStore(events);
+		const current = currentEntry({ id: 'P', count: 99 }, 30);
+		assert.deepStrictEqual(getRecordAtTime(current, 15, store, 1, 'P'), { count: 5 });
+	});
+
+	it('reconstructs a record re-inserted via a patch after a delete', () => {
+		// put -> delete -> patch(re-insert via add) -> delete -> put(current). At the re-insert
+		// patch the record is rebuilt from an empty base bounded by the delete before it.
+		const events = [
+			{ version: 10, type: 'put', value: { id: 'R', count: 1 }, previousVersion: 0 },
+			{ version: 20, type: 'delete', value: null, previousVersion: 10 },
+			{ version: 30, type: 'patch', value: { count: { __op__: 'add', value: 7 } }, previousVersion: 20 },
+			{ version: 40, type: 'delete', value: null, previousVersion: 30 },
+			{ version: 50, type: 'put', value: { id: 'R', count: 100 }, previousVersion: 40 },
+		];
+		const store = makeStore(events);
+		const current = currentEntry({ id: 'R', count: 100 }, 50);
+		assert.deepStrictEqual(getRecordAtTime(current, 35, store, 1, 'R'), { count: 7 });
+	});
+
+	it('reconstructs a value that existed before a later delete/re-insert cycle', () => {
+		// put -> delete -> put -> delete -> put(current). A timestamp inside the FIRST live span
+		// must skip the newer delete and find the first put as its base.
+		const events = [
+			{ version: 10, type: 'put', value: { id: 'G', n: 1 }, previousVersion: 0 },
+			{ version: 20, type: 'delete', value: null, previousVersion: 10 },
+			{ version: 30, type: 'put', value: { id: 'G', n: 2 }, previousVersion: 20 },
+			{ version: 40, type: 'delete', value: null, previousVersion: 30 },
+			{ version: 50, type: 'put', value: { id: 'G', n: 3 }, previousVersion: 40 },
+		];
+		const store = makeStore(events);
+		const current = currentEntry({ id: 'G', n: 3 }, 50);
+		assert.deepStrictEqual(getRecordAtTime(current, 15, store, 1, 'G'), { id: 'G', n: 1 });
+	});
+
+	describe('records with no delete in history (reverse-walk path unchanged)', () => {
+		// put(v:1) -> patch(v:2) -> patch(v:3, current)
+		const events = [
+			{ version: 10, type: 'put', value: { id: 'N', v: 1 }, previousVersion: 0 },
+			{ version: 20, type: 'patch', value: { v: 2 }, previousVersion: 10 },
+			{ version: 30, type: 'patch', value: { v: 3 }, previousVersion: 20 },
+		];
+		const store = makeStore(events);
+		const current = currentEntry({ id: 'N', v: 3 }, 30);
+
+		it('reverses patches back to an earlier patch state', () => {
+			assert.deepStrictEqual(getRecordAtTime(current, 20, store, 1, 'N'), { id: 'N', v: 2 });
+		});
+
+		it('reverses patches back to the original put', () => {
+			assert.deepStrictEqual(getRecordAtTime(current, 10, store, 1, 'N'), { id: 'N', v: 1 });
+		});
+	});
+});
+
+describe('crdt applyForward', () => {
+	it('overwrites plain values and applies add operations', () => {
+		const record = { id: 'A', count: 5, label: 'old' };
+		applyForward(record, { label: 'new', count: { __op__: 'add', value: 2 } });
+		assert.deepStrictEqual(record, { id: 'A', count: 7, label: 'new' });
+	});
+
+	it('throws on an unsupported operation', () => {
+		assert.throws(() => applyForward({}, { x: { __op__: 'multiply', value: 2 } }), /Unsupported operation multiply/);
+	});
+});


### PR DESCRIPTION
Fixes #1330.

## Summary
Two bugs on the `read_audit_log` / time-travel record-reconstruction path, both triggered by a key that is **deleted then re-inserted** under the same key (session/idempotency/cache re-creation, upsert-after-delete):

1. **Crash.** `getRecordAtTime` (`resources/crdt.ts`) walks history backward from the live record, reversing changes. On a `delete` entry it set `record = null`, then a subsequent patch reversal (`applyReverse` reading `record[prop]` for a CRDT op) or the unknowns-fill loop (`record[key] = …`) dereferenced null → `TypeError: Cannot set properties of null (setting 'id')`. Durable across restart.
2. **Wrong value images.** `getHistoryOfRecord` (`resources/Table.ts`) reconstructed every partial (patch) entry's value at `nextVersion` — the *audit-window high boundary*, constant across a 100-unit window batch — instead of each entry's own `version`. So a multi-version record's history returned the latest-in-window image for every entry (e.g. the `v=2` entry came back as `v=4`).

## Changes
- **`resources/crdt.ts`** — when the reverse walk crosses a `delete`, there is no base record to keep reversing against, and everything newer than the delete is irrelevant to a `timestamp` that precedes it. Switch to forward reconstruction (`reconstructForward`): walk the `previousVersion` chain back to a base boundary (the most recent `put`, or — when the first in-range write is a `patch`, or a `delete` bounds the history — an empty record), then replay `put`/`patch` entries forward via a new `applyForward` helper (mirrors `applyReverse`: overwrites plain values, applies CRDT `add` ops). Handles multiple delete/re-insert cycles; returns `null` only when the record genuinely did not exist at the requested time.
- **`resources/Table.ts`** — `getHistoryOfRecord` now uses `auditRecord.version` for both `localTime` and the `getValue` reconstruction time, matching the sibling `getHistory` generator (the timestamp-window path, which was already correct).
- **`unitTests/resources/crdt.test.js`** — new unit tests for `getRecordAtTime`/`applyForward` covering the crash case, the patch-immediately-before-delete case, base-put reconstruction, patch-first (no preceding put) history, re-insert-via-patch, multiple delete/re-insert cycles, deleted-gap → null, CRDT add forward, and the no-delete reverse-walk path (unchanged).

## Where to look
- `reconstructForward`'s boundary logic in `crdt.ts` is the substantive new code — particularly the empty-base path. A record created by an incremental `update` writes `type:'patch', previousVersion:0` with **no** preceding `put`; the cross-model review caught an earlier version of this fix returning `null` for that shape after a delete. The current version reconstructs from an empty base instead. Worth a second look that the empty-base vs put-base vs null cases are partitioned correctly.
- The `nextVersion → auditRecord.version` change in `Table.ts` affects all `getHistoryOfRecord` reads. The only consumer (`ResourceBridge.readAuditLog`) reads `.version`/`.value`/`.user`/`.operation`, not `.localTime`, so the `localTime` change is inert; the `value` change is the actual correctness fix.

## Verification
- New unit suite (`crdt.test.js`) passes; `auditLog`/`auditPurge` suites unaffected (33 passing).
- Verified end-to-end against the QA repro (`read_audit_log(K)` no longer crashes and returns correct, ordered value images across the delete+reinsert boundary; durable across restart).

## Review notes
- Cross-model review: the Codex leg was unavailable (CLI not installed) and the Gemini/`agy` leg timed out twice (intermittent backend), so the outside-model legs did not contribute. The Harper-domain `deep-review` pass ran and found the patch-first → wrong-null bug noted above, which is fixed in this PR.

🤖 Generated by Claude (Opus 4.8, 1M context). Reviewed by a human before merge.