### PR TITLE
fix: writeHead iterable response headers as an object, not a nested array

### DIFF
--- a/server/http.ts
+++ b/server/http.ts
@@ -17,7 +17,7 @@ import { createSecureServer } from 'node:http2';
 import { createServer as createSecureServerHttp1 } from 'node:https';
 import { createServer, IncomingMessage } from 'node:http';
 import { Request, BunRequest, isBun } from './serverHelpers/Request.ts';
-import { appendHeader, Headers } from './serverHelpers/Headers.ts';
+import { appendHeader, Headers, toWriteHeadHeaders } from './serverHelpers/Headers.ts';
 import { Blob } from '../resources/blob.ts';
 import { recordAction, recordActionBinary } from '../resources/analytics/write.ts';
 import { Readable, Writable } from 'node:stream';
@@ -439,16 +439,9 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 								}
 							}
 						} // else the fast path, if we don't have to defer
-						// For iterable headers (a Map/Headers of [name, value] pairs) hand writeHead an object.
-						// `Array.from` yields nested `[[name, value], ...]` tuples, but writeHead's array form
-						// expects a flat `[name, value, name, value]` list — so it reads a tuple as a header name
-						// and throws `TypeError: "name" must be of type string`. An object matches the deferred
-						// path's setHeader loop (preserves array values, last-wins on duplicate names).
-						else
-							nodeResponse.writeHead(
-								status,
-								headers && (headers[Symbol.iterator] ? Object.fromEntries(headers) : headers)
-							);
+						// toWriteHeadHeaders converts iterable headers to an object writeHead accepts (a flat
+						// array form is required otherwise, and `Array.from` would pass invalid nested tuples).
+						else nodeResponse.writeHead(status, toWriteHeadHeaders(headers));
 					}
 					if (sentBody) nodeResponse.end(body);
 				}
@@ -498,8 +491,7 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 				const headers = error.headers;
 				const status = error.statusCode || 500;
 				try {
-					// Iterable headers must become an object, not a nested array — see the success path above.
-					nodeResponse.writeHead(status, headers && (headers[Symbol.iterator] ? Object.fromEntries(headers) : headers));
+					nodeResponse.writeHead(status, toWriteHeadHeaders(headers));
 				} catch {} // silently ignore errors writing headers, because they may have been set already
 				nodeResponse.end(errorToString(error));
 				logRequest(nodeRequest, status, requestId, performance.now() - startTime);

--- a/server/http.ts
+++ b/server/http.ts
@@ -439,7 +439,16 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 								}
 							}
 						} // else the fast path, if we don't have to defer
-						else nodeResponse.writeHead(status, headers && (headers[Symbol.iterator] ? Array.from(headers) : headers));
+						// For iterable headers (a Map/Headers of [name, value] pairs) hand writeHead an object.
+						// `Array.from` yields nested `[[name, value], ...]` tuples, but writeHead's array form
+						// expects a flat `[name, value, name, value]` list — so it reads a tuple as a header name
+						// and throws `TypeError: "name" must be of type string`. An object matches the deferred
+						// path's setHeader loop (preserves array values, last-wins on duplicate names).
+						else
+							nodeResponse.writeHead(
+								status,
+								headers && (headers[Symbol.iterator] ? Object.fromEntries(headers) : headers)
+							);
 					}
 					if (sentBody) nodeResponse.end(body);
 				}
@@ -489,7 +498,8 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 				const headers = error.headers;
 				const status = error.statusCode || 500;
 				try {
-					nodeResponse.writeHead(status, headers && (headers[Symbol.iterator] ? Array.from(headers) : headers));
+					// Iterable headers must become an object, not a nested array — see the success path above.
+					nodeResponse.writeHead(status, headers && (headers[Symbol.iterator] ? Object.fromEntries(headers) : headers));
 				} catch {} // silently ignore errors writing headers, because they may have been set already
 				nodeResponse.end(errorToString(error));
 				logRequest(nodeRequest, status, requestId, performance.now() - startTime);

--- a/server/serverHelpers/Headers.ts
+++ b/server/serverHelpers/Headers.ts
@@ -108,3 +108,17 @@ export function mergeHeaders(target: any, source: Headers) {
 	}
 	return target;
 }
+
+/**
+ * Normalize a response's headers into the form `ServerResponse.writeHead` accepts.
+ *
+ * `writeHead`'s array form is a FLAT `[name, value, name, value]` list, not a list of tuples — so an
+ * iterable of `[name, value]` pairs (a `Headers`/`Map`) must be turned into an object. Passing
+ * `Array.from(headers)` (nested `[[name, value], …]`) makes Node read a tuple as a header name and throw
+ * `TypeError: The "name" argument must be of type string. Received an instance of Array`. A plain object
+ * (or a falsy value, e.g. when there are no headers) is returned unchanged.
+ */
+export function toWriteHeadHeaders(headers: any): any {
+	if (!headers) return headers;
+	return headers[Symbol.iterator] ? Object.fromEntries(headers) : headers;
+}

--- a/unitTests/server/serverHelpers/Headers.test.js
+++ b/unitTests/server/serverHelpers/Headers.test.js
@@ -1,7 +1,7 @@
 'use strict';
 const assert = require('assert');
 
-const { Headers, appendHeader, mergeHeaders } = require('#src/server/serverHelpers/Headers');
+const { Headers, appendHeader, mergeHeaders, toWriteHeadHeaders } = require('#src/server/serverHelpers/Headers');
 describe('Test Headers', () => {
 	describe(`Create and modify headers`, function () {
 		it('should handle headers', async function () {
@@ -335,5 +335,71 @@ describe('Test Headers', () => {
 			assert.strictEqual(result, target, 'mergeHeaders should return the same target object');
 			assert.equal(target.get('X-New'), 'test', 'target should be modified in place');
 		});
+	});
+});
+
+describe('toWriteHeadHeaders', () => {
+	it('converts an iterable Headers into a plain object (not nested tuples)', () => {
+		const headers = new Headers();
+		headers.set('Content-Type', 'application/json');
+		headers.set('X-Custom', 'abc');
+		const out = toWriteHeadHeaders(headers);
+		assert.deepEqual(out, { 'Content-Type': 'application/json', 'X-Custom': 'abc' });
+		// The whole point: an object, NOT the nested `[[name, value], …]` that `Array.from` would yield.
+		assert.equal(Array.isArray(out), false);
+	});
+
+	it('converts a Map of [name, value] pairs into an object', () => {
+		const out = toWriteHeadHeaders(
+			new Map([
+				['X-A', '1'],
+				['X-B', '2'],
+			])
+		);
+		assert.deepEqual(out, { 'X-A': '1', 'X-B': '2' });
+	});
+
+	it('passes a plain (non-iterable) object through unchanged', () => {
+		const obj = { 'X-A': '1' };
+		assert.strictEqual(toWriteHeadHeaders(obj), obj);
+	});
+
+	it('returns falsy headers as-is (writeHead then sets no headers)', () => {
+		assert.strictEqual(toWriteHeadHeaders(undefined), undefined);
+		assert.strictEqual(toWriteHeadHeaders(null), null);
+	});
+
+	it('regression: avoids the nested-tuple shape Array.from produced', () => {
+		const headers = new Headers();
+		headers.set('X-A', '1');
+		// The previous code passed this to writeHead — a nested `[[name, value]]` list, which writeHead's
+		// flat-array form reads as a header *name*, throwing "name must be of type string".
+		const previous = Array.from(headers);
+		assert.ok(Array.isArray(previous) && Array.isArray(previous[0]), 'Array.from yields nested tuples');
+		// The fix yields a plain object instead.
+		assert.deepEqual(toWriteHeadHeaders(headers), { 'X-A': '1' });
+	});
+
+	it("its output is accepted by a live response's writeHead (round-trip)", async () => {
+		const http = require('node:http');
+		const headers = new Headers();
+		headers.set('Content-Type', 'text/plain');
+		headers.set('X-Custom', 'abc');
+		const server = http.createServer((req, res) => {
+			// Same call shape as server/http.ts; with the old Array.from form this 500s.
+			res.writeHead(200, toWriteHeadHeaders(headers));
+			res.end('ok');
+		});
+		try {
+			await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+			const { port } = server.address();
+			const res = await fetch(`http://127.0.0.1:${port}/`);
+			assert.equal(res.status, 200);
+			assert.equal(res.headers.get('content-type'), 'text/plain');
+			assert.equal(res.headers.get('x-custom'), 'abc');
+			assert.equal(await res.text(), 'ok');
+		} finally {
+			await new Promise((resolve) => server.close(resolve));
+		}
 	});
 });


### PR DESCRIPTION
## Summary

The non-deferred response path in `server/http.ts` passed `Array.from(headers)` to `ServerResponse.writeHead` when the response headers were iterable (a `Map`/`Headers` of `[name, value]` pairs). `Array.from` yields **nested** `[[name, value], …]` tuples, but `writeHead`'s array form expects a **flat** `[name, value, name, value]` list — so Node reads a tuple as a header *name* and throws:

> `TypeError [ERR_INVALID_ARG_TYPE]: The "name" argument must be of type string. Received an instance of Array`

which surfaces as a 500. Fixed by converting iterables with `Object.fromEntries`, matching the sibling `deferWriteHead` branch's `setHeader` loop (preserves array values, last-wins on duplicate names). Applied in **both** the success path and the `onError` fallback — the fallback had the same bug, so a failed primary `writeHead` couldn't even emit a proper error response.

## How it surfaced

A plain GET that the `@harperfast/vite` dev server doesn't serve is handed back to Harper (REST fall-through). That response carries iterable headers and hits the non-deferred `writeHead`, 500ing. It was previously masked by an unrelated 401 at the plugin's dev-server auth gate; once that gate was fixed, the fall-through reached this code and 500'd.

## Verification

- Repro: `GET /Build` (a trivial fall-through resource) returns **500 → 200** with this fix.
- The fall-through test in `@harperfast/vite`'s integration suite (`harper dev … falls through to Harper resources`) goes from a 500 to passing; together with the plugin's loopback-auth fix the suite is fully green (**7/7**).

## Note for reviewers (pre-existing, unrelated)

`npx tsc --project tsconfig.build.json` currently fails on `resources/analytics/write.ts` (`@harperfast/rocksdb-js` has no `TransactionLogStats` / `getStats`) on `main` with or without this change — looks like a rocksdb-js dependency that needs bumping. `server/http.ts` is `// @ts-nocheck`, so this change isn't type-checked regardless. Flagging so the red build step isn't attributed to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
