### PR TITLE
Add clearJWTRSAKeysCache to invalidate the in-memory JWT key cache

### DIFF
--- a/security/tokenAuthentication.ts
+++ b/security/tokenAuthentication.ts
@@ -77,6 +77,17 @@ export async function getJWTRSAKeys(): Promise<JWTRSAKeys> {
 }
 
 /**
+ * Drops the in-memory JWT RSA key cache so the next getJWTRSAKeys() re-reads from disk. Needed when the
+ * key files are replaced underneath a running process — e.g. node cloning overwrites .jwtPublic/.jwtPrivate/
+ * .jwtPass with the leader's keys after Harper (and thus the operations API) is already up, and an early
+ * Bearer-auth request may have already cached the pre-clone install-generated keys. The operations API runs
+ * only on the main thread, so clearing this process-local cache there is sufficient.
+ */
+export function clearJWTRSAKeysCache(): void {
+	rsaKeys = undefined;
+}
+
+/**
  * Creates a new operation token and refresh token.
  * If there is no username and password, the hdb_user making the request is used in the token.
  * An optional role can be provided which will be saved in the token payload.

--- a/security/tokenAuthentication.ts
+++ b/security/tokenAuthentication.ts
@@ -61,15 +61,24 @@ interface JWTTokens {
  * @returns {Promise<JWTRSAKeys>}
  */
 let rsaKeys: JWTRSAKeys | undefined = undefined;
+// Bumped by every clearJWTRSAKeysCache() call. getJWTRSAKeys() captures it before its file reads and
+// refuses to commit a result whose generation is stale, so a read that started before a clear (e.g. a
+// Bearer-auth request in flight while node cloning replaces the key files) cannot resurrect the
+// pre-clear keys into the cache after the clear ran.
+let rsaKeysGeneration = 0;
 export async function getJWTRSAKeys(): Promise<JWTRSAKeys> {
 	if (rsaKeys) return rsaKeys;
+	const generation: number = rsaKeysGeneration;
 	try {
 		const keysDir: string = path.join(env.getHdbBasePath(), LICENSE_KEY_DIR_NAME);
 		const passphrase: string = await fs.readFile(path.join(keysDir, JWT_ENUM.JWT_PASSPHRASE_NAME), 'utf8');
 		const privateKey: string = await fs.readFile(path.join(keysDir, JWT_ENUM.JWT_PRIVATE_KEY_NAME), 'utf8');
 		const publicKey: string = await fs.readFile(path.join(keysDir, JWT_ENUM.JWT_PUBLIC_KEY_NAME), 'utf8');
-		rsaKeys = { publicKey, privateKey, passphrase };
-		return rsaKeys;
+		const keys: JWTRSAKeys = { publicKey, privateKey, passphrase };
+		// Only populate the cache if no clear happened while we were reading; otherwise return the freshly
+		// read keys without caching so the next call re-reads (the files may have just been replaced).
+		if (generation === rsaKeysGeneration) rsaKeys = keys;
+		return keys;
 	} catch (err) {
 		logger.error(err);
 		throw new ClientError(AUTHENTICATION_ERROR_MSGS.NO_ENCRYPTION_KEYS, HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
@@ -81,9 +90,11 @@ export async function getJWTRSAKeys(): Promise<JWTRSAKeys> {
  * key files are replaced underneath a running process — e.g. node cloning overwrites .jwtPublic/.jwtPrivate/
  * .jwtPass with the leader's keys after Harper (and thus the operations API) is already up, and an early
  * Bearer-auth request may have already cached the pre-clone install-generated keys. The operations API runs
- * only on the main thread, so clearing this process-local cache there is sufficient.
+ * only on the main thread, so clearing this process-local cache there is sufficient. Bumping the generation
+ * also invalidates any getJWTRSAKeys() read already in flight, so it can't write the pre-clear keys back.
  */
 export function clearJWTRSAKeysCache(): void {
+	rsaKeysGeneration++;
 	rsaKeys = undefined;
 }
 

--- a/unitTests/security/tokenAuthentication.test.js
+++ b/unitTests/security/tokenAuthentication.test.js
@@ -251,6 +251,61 @@ describe('test getJWTRSAKeys function', () => {
 	});
 });
 
+describe('test clearJWTRSAKeysCache function', () => {
+	let get_jwt_keys_func;
+	let clear_cache_func;
+
+	before(() => {
+		const testPath = testUtils.getMockTestPath();
+		keysPath = path.join(testPath, 'keys');
+		passphrasePath = path.join(keysPath, '.jwtPass');
+		privateKeyPath = path.join(keysPath, '.jwtPrivate.key');
+		publicKeyPath = path.join(keysPath, '.jwtPublic.key');
+		get_jwt_keys_func = token_auth.__get__('getJWTRSAKeys');
+		clear_cache_func = token_auth.__get__('clearJWTRSAKeysCache');
+	});
+
+	beforeEach(() => {
+		fs.mkdirpSync(keysPath);
+		fs.writeFileSync(passphrasePath, PASSPHRASE_VALUE);
+		fs.writeFileSync(privateKeyPath, PRIVATE_KEY_VALUE);
+		fs.writeFileSync(publicKeyPath, PUBLIC_KEY_VALUE);
+	});
+
+	afterEach(() => {
+		fs.removeSync(keysPath);
+		token_auth.__set__('rsaKeys', undefined);
+	});
+
+	// Models the node-clone race: an early Bearer-auth request caches the install-generated keys, then
+	// the clone overwrites the key files on disk. Without invalidation, getJWTRSAKeys keeps returning the
+	// stale cached set. clearJWTRSAKeysCache must drop the cache so the next read picks up the new files.
+	it('forces the next getJWTRSAKeys to re-read replaced key files from disk', async () => {
+		const stale = { publicKey: 'stale-public', privateKey: 'stale-private', passphrase: 'stale-pass' };
+		token_auth.__set__('rsaKeys', stale);
+
+		// Sanity: while cached, the stale set is returned regardless of what is on disk.
+		assert.deepStrictEqual(await get_jwt_keys_func(), stale);
+
+		clear_cache_func();
+
+		const reloaded = await get_jwt_keys_func();
+		assert.deepStrictEqual(reloaded, {
+			publicKey: PUBLIC_KEY_VALUE,
+			privateKey: PRIVATE_KEY_VALUE,
+			passphrase: PASSPHRASE_VALUE,
+		});
+	});
+
+	it('is a no-op when the cache is already empty', async () => {
+		token_auth.__set__('rsaKeys', undefined);
+		assert.doesNotThrow(() => clear_cache_func());
+		// Still reads cleanly from disk afterward.
+		const reloaded = await get_jwt_keys_func();
+		assert.deepStrictEqual(reloaded.passphrase, PASSPHRASE_VALUE);
+	});
+});
+
 describe('test createTokens', () => {
 	let validate_user_stub;
 	let update_stub;

--- a/unitTests/security/tokenAuthentication.test.js
+++ b/unitTests/security/tokenAuthentication.test.js
@@ -304,6 +304,34 @@ describe('test clearJWTRSAKeysCache function', () => {
 		const reloaded = await get_jwt_keys_func();
 		assert.deepStrictEqual(reloaded.passphrase, PASSPHRASE_VALUE);
 	});
+
+	// A clear that lands while a getJWTRSAKeys() read is in flight must not let that read repopulate the
+	// cache with the pre-clear keys — otherwise the very clone race we are fixing could resurrect the stale
+	// set. The in-flight read still returns its own result, but the cache is left empty so the next read
+	// picks up the replaced files.
+	it('does not let a read in flight when the cache is cleared repopulate it', async () => {
+		token_auth.__set__('rsaKeys', undefined);
+		const readFileStub = sandbox.stub(fs, 'readFile');
+		try {
+			let cleared = false;
+			readFileStub.callsFake(async (...args) => {
+				// Simulate the clone overwriting the files + clearing the cache partway through this read.
+				if (!cleared) {
+					cleared = true;
+					clear_cache_func();
+				}
+				return readFileStub.wrappedMethod.apply(fs, args);
+			});
+
+			const result = await get_jwt_keys_func();
+			// The in-flight call still resolves with what it read...
+			assert.deepStrictEqual(result.passphrase, PASSPHRASE_VALUE);
+			// ...but it must not have committed to the cache, since a clear happened mid-read.
+			assert.deepStrictEqual(token_auth.__get__('rsaKeys'), undefined);
+		} finally {
+			readFileStub.restore();
+		}
+	});
 });
 
 describe('test createTokens', () => {


### PR DESCRIPTION
## Summary

Exports a new `clearJWTRSAKeysCache()` from `security/tokenAuthentication.ts` that drops the process-local `rsaKeys` cache so the next `getJWTRSAKeys()` re-reads from disk.

## Why

`getJWTRSAKeys()` caches the RSA key set on first read and never re-reads. That is fine for the normal lifecycle, but the harper-pro node-clone path replaces `.jwtPublic` / `.jwtPrivate` / `.jwtPass` on disk *after* Harper (and the operations API) is already running. If an early Bearer-auth request populated the cache with the install-generated keys, the later disk writes don't invalidate it, so the clone can finish `Available` while operations auth still verifies/signs with the pre-clone key set until restart. This export gives the clone path a way to force a reload.

This is the **core** half of a coordinated two-PR change; the consumer is harper-pro [#379](https://github.com/HarperFast/harper-pro/pull/379), which calls this after writing the cloned key files.

## Where to look

- `clearJWTRSAKeysCache()` is a deliberately minimal `rsaKeys = undefined`. The operations API runs only on the main thread, so a process-local reset (no cross-thread broadcast) is sufficient — calling it from the same main-thread clone flow that did the writes.

Generated by an LLM (Claude Opus 4.8).