### PR TITLE
feat(mcp): implement ping + logging/setLevel + notifications/message

### DIFF
--- a/components/mcp/logging.ts
+++ b/components/mcp/logging.ts
@@ -52,7 +52,13 @@ export function getSessionLogLevel(sessionId: string): McpLogLevel | undefined {
 function admits(record: RegisteredSession, recordLevel: McpLogLevel): boolean {
 	const min = record.logLevel;
 	if (min === undefined) return false;
-	return (LEVEL_RANK.get(recordLevel) ?? 0) >= (LEVEL_RANK.get(min) ?? 0);
+	const recordRank = LEVEL_RANK.get(recordLevel);
+	const minRank = LEVEL_RANK.get(min);
+	// An unrecognized level (shouldn't reach here given the typed callers, but be
+	// defensive) is not admitted rather than defaulting to rank 0 and slipping
+	// past a `debug` minimum.
+	if (recordRank === undefined || minRank === undefined) return false;
+	return recordRank >= minRank;
 }
 
 interface LogMessageParams {

--- a/components/mcp/logging.ts
+++ b/components/mcp/logging.ts
@@ -1,0 +1,88 @@
+/**
+ * MCP logging utility (`logging/setLevel` + `notifications/message`).
+ *
+ * The MCP spec models logging on RFC 5424 syslog severities. A client raises
+ * or lowers the minimum severity it wants via `logging/setLevel`; the server
+ * then emits `notifications/message` frames at or above that severity over the
+ * session's SSE channel.
+ *
+ * Scope (see the MCP design doc issue): we deliberately emit only Harper
+ * *MCP-layer* events here — not the global `harperLogger` stream. Harper's
+ * logger has no subscription hook (only a `writeToLog` injected at
+ * `createLogger` time), and its records are process-wide and cross-worker:
+ * forwarding them to an authenticated MCP client would be both a confidentiality
+ * leak and an unbounded firehose. So this module is a small, explicit emitter
+ * the MCP code calls for noteworthy, session-scoped, non-sensitive events.
+ */
+import { forEachSessionByProfile, getRegisteredSession, type RegisteredSession } from './sessionRegistry.ts';
+import type { McpProfile } from './transport.ts';
+
+// RFC 5424 severities, ordered least → most severe (index === rank).
+const MCP_LOG_LEVELS = ['debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency'] as const;
+
+export type McpLogLevel = (typeof MCP_LOG_LEVELS)[number];
+
+const LEVEL_RANK = new Map<string, number>(MCP_LOG_LEVELS.map((level, i) => [level, i]));
+
+export function isValidMcpLogLevel(value: unknown): value is McpLogLevel {
+	return typeof value === 'string' && LEVEL_RANK.has(value);
+}
+
+/**
+ * Apply the minimum level to the session's *live* in-memory `RegisteredSession`
+ * (the SSE delivery point), if its GET stream is open on this worker. No-op
+ * otherwise. The durable source of truth is `McpSessionRecord.logLevel`
+ * (persisted by the `logging/setLevel` handler and used to seed this live value
+ * when the stream (re)connects), so a pre-stream `setLevel` is not lost.
+ */
+export function setSessionLogLevel(sessionId: string, level: McpLogLevel): void {
+	const record = getRegisteredSession(sessionId);
+	if (record) record.logLevel = level;
+}
+
+export function getSessionLogLevel(sessionId: string): McpLogLevel | undefined {
+	return getRegisteredSession(sessionId)?.logLevel;
+}
+
+/**
+ * A session admits a record only once it has set a level (no unsolicited
+ * messages before `logging/setLevel`), and only when the record's severity is
+ * at or above the session's configured minimum.
+ */
+function admits(record: RegisteredSession, recordLevel: McpLogLevel): boolean {
+	const min = record.logLevel;
+	if (min === undefined) return false;
+	return (LEVEL_RANK.get(recordLevel) ?? 0) >= (LEVEL_RANK.get(min) ?? 0);
+}
+
+interface LogMessageParams {
+	level: McpLogLevel;
+	logger?: string;
+	data: unknown;
+}
+
+function logFrame(params: LogMessageParams): { event: string; data: object } {
+	return { event: 'message', data: { jsonrpc: '2.0', method: 'notifications/message', params } };
+}
+
+/**
+ * Emit a `notifications/message` to a single session, if it has an open SSE
+ * stream and its level admits this severity. No-op otherwise.
+ */
+export function emitMcpLogToSession(sessionId: string, level: McpLogLevel, data: unknown, logger?: string): void {
+	const record = getRegisteredSession(sessionId);
+	if (!record || !admits(record, level)) return;
+	record.queue.send(logFrame({ level, logger, data }));
+}
+
+/**
+ * Emit a `notifications/message` to every session on a profile whose level
+ * admits this severity.
+ */
+export function emitMcpLogToProfile(profile: McpProfile, level: McpLogLevel, data: unknown, logger?: string): void {
+	forEachSessionByProfile(profile, (record) => {
+		if (admits(record, level)) {
+			record.queue.send(logFrame({ level, logger, data }));
+		}
+	});
+}

--- a/components/mcp/session.ts
+++ b/components/mcp/session.ts
@@ -16,6 +16,7 @@ import { table, type Table } from '../../resources/databases.ts';
 import * as env from '../../utility/environment/environmentManager.ts';
 import { CONFIG_PARAMS } from '../../utility/hdbTerms.ts';
 import harperLogger from '../../utility/logging/harper_logger.ts';
+import type { McpLogLevel } from './logging.ts';
 import { clearSessionRateState } from './rateLimit.ts';
 import { unregisterSession } from './sessionRegistry.ts';
 import { clearSessionCache } from './toolRegistry.ts';
@@ -41,6 +42,14 @@ export interface McpSessionRecord {
 	user: string;
 	createdAt: number;
 	lastActivity: number;
+	/**
+	 * Minimum `notifications/message` severity set via `logging/setLevel`.
+	 * Persisted here (not just on the in-memory SSE record) so it survives an
+	 * SSE reconnect and is order-independent of GET-stream open; the live
+	 * RegisteredSession is seeded from it. Expires with the session's TTL, so no
+	 * separate cache to prune. Undefined = the client hasn't opted into logging.
+	 */
+	logLevel?: McpLogLevel;
 }
 
 let _sessionTable: Table | undefined;
@@ -65,6 +74,7 @@ function declareSessionTable(): Table {
 			{ name: 'user' },
 			{ name: 'createdAt' },
 			{ name: 'lastActivity' },
+			{ name: 'logLevel' },
 		],
 	});
 }

--- a/components/mcp/sessionRegistry.ts
+++ b/components/mcp/sessionRegistry.ts
@@ -17,6 +17,7 @@
  * without a graceful close).
  */
 import { IterableEventQueue } from '../../resources/IterableEventQueue.ts';
+import type { McpLogLevel } from './logging.ts';
 import type { AuthedUser } from './toolRegistry.ts';
 import type { McpProfile } from './transport.ts';
 
@@ -35,6 +36,8 @@ export interface RegisteredSession {
 	lastTools?: ReadonlyArray<{ name: string }>;
 	/** Most recent resources/list payload sent on this session — used for diffing. */
 	lastResources?: ReadonlyArray<{ uri: string }>;
+	/** Minimum `notifications/message` severity set via `logging/setLevel`; undefined = none. */
+	logLevel?: McpLogLevel;
 	/** Wall-clock ms of last activity. Bumped by registerSession + touchSession. */
 	lastSeen: number;
 }

--- a/components/mcp/transport.ts
+++ b/components/mcp/transport.ts
@@ -346,7 +346,8 @@ async function handleGet(request: NormRequest): Promise<NormResponse> {
 	const record = registerSession(sessionId, request.profile, effectiveUser(request));
 	// Seed the live record with any previously-set logging level so a reconnect
 	// (or a setLevel that preceded this stream) keeps delivering notifications/message.
-	if (session.logLevel) record.logLevel = session.logLevel;
+	// (A fresh record's logLevel is already undefined, so a direct assign is safe.)
+	record.logLevel = session.logLevel;
 	seedSessionSnapshot(sessionId);
 	return {
 		status: 200,

--- a/components/mcp/transport.ts
+++ b/components/mcp/transport.ts
@@ -200,7 +200,7 @@ async function handlePost(request: NormRequest): Promise<NormResponse> {
 	if (!sessionId) {
 		return jsonRpcErrorResponse(400, messageId, ERROR_CODES.INVALID_REQUEST, 'missing Mcp-Session-Id header');
 	}
-	const session = await loadSession(sessionId);
+	let session = await loadSession(sessionId);
 	if (!session) {
 		// Terminated, expired, or never existed. Spec mandates 404 so the
 		// client knows to drop the id and re-initialize.
@@ -225,8 +225,11 @@ async function handlePost(request: NormRequest): Promise<NormResponse> {
 	}
 
 	// Sliding-window idle reset. Awaited (not fire-and-forget) so a concurrent
-	// DELETE that arrives mid-request can't be resurrected by a late put.
-	await touchSession(session);
+	// DELETE that arrives mid-request can't be resurrected by a late put. Adopt
+	// the touched copy (fresh `lastActivity`) so any later save in this request
+	// — `handleInitialized`, `dispatchSetLevel` — persists the current activity
+	// time instead of rolling it back to the load-time value.
+	session = await touchSession(session);
 
 	// Fire-and-forget frames (notifications + client responses) always 202.
 	if (isClientFireAndForget(message)) {

--- a/components/mcp/transport.ts
+++ b/components/mcp/transport.ts
@@ -32,10 +32,11 @@ import {
 	SUPPORTED_PROTOCOL_VERSIONS,
 } from './lifecycle.ts';
 import { emitAuditEntry } from './audit.ts';
+import { emitMcpLogToSession, isValidMcpLogLevel, setSessionLogLevel } from './logging.ts';
 import { decodeCursor } from './pagination.ts';
 import { seedSessionSnapshot } from './listChanged.ts';
 import { tryAdmit } from './rateLimit.ts';
-import { deleteSession, loadSession, touchSession, type McpSessionRecord } from './session.ts';
+import { deleteSession, loadSession, saveSession, touchSession, type McpSessionRecord } from './session.ts';
 import { listResources, listResourceTemplates, readResource } from './resources.ts';
 import { registerSession, touchRegisteredSession } from './sessionRegistry.ts';
 import { getTool, listTools, type AuthedUser, type ToolResult } from './toolRegistry.ts';
@@ -243,6 +244,12 @@ async function handlePost(request: NormRequest): Promise<NormResponse> {
 	if (method === 'resources/list') return dispatchResourcesList(request, message, messageId);
 	if (method === 'resources/templates/list') return dispatchResourceTemplatesList(request, messageId);
 	if (method === 'resources/read') return dispatchResourcesRead(request, message, messageId);
+	if (method === 'logging/setLevel') return dispatchSetLevel(session, message, messageId);
+	// `ping` (base-protocol liveness) → empty result. Routed here, after session
+	// validation, so a stale/expired/wrong-user session surfaces the normal
+	// 404/403 rather than being masked by an unconditional success. A ping sent
+	// as a notification is handled by the fire-and-forget 202 path above.
+	if (method === 'ping') return jsonResponse(200, buildSuccess(messageId, {}));
 	return jsonResponse(
 		200,
 		buildError(messageId, ERROR_CODES.METHOD_NOT_FOUND, `Method not found: ${method ?? '<missing>'}`)
@@ -267,6 +274,46 @@ async function dispatchInitialize(
 		headers: { 'Mcp-Session-Id': outcome.session.id },
 		jsonBody: buildSuccess(messageId, outcome.result),
 	};
+}
+
+/**
+ * `logging/setLevel` — record the session's minimum severity for
+ * `notifications/message`. Returns an empty result on success. Backs the
+ * advertised `logging` capability (previously advertised but unimplemented).
+ */
+async function dispatchSetLevel(
+	session: McpSessionRecord,
+	message: JsonRpcMessage,
+	messageId: JsonRpcId
+): Promise<NormResponse> {
+	const params = 'params' in message ? (message.params as { level?: unknown } | undefined) : undefined;
+	const level = params?.level;
+	if (!isValidMcpLogLevel(level)) {
+		return jsonResponse(
+			200,
+			buildError(
+				messageId,
+				ERROR_CODES.INVALID_PARAMS,
+				'logging/setLevel requires params.level to be an RFC 5424 level'
+			)
+		);
+	}
+	// Persist on the durable session record (survives an SSE reconnect, expires
+	// with the session TTL) AND apply to the live SSE record if the stream is
+	// already open so it takes effect immediately.
+	//
+	// Per-worker caveat (v1): if this POST landed on a different worker than the
+	// one holding the session's GET/SSE stream, only the durable record is
+	// updated now; the SSE-owning worker picks the level up the next time it
+	// seeds from the record (reconnect). This matches the existing per-worker
+	// limitation of the whole MCP server-push channel — listChanged's
+	// tools/resources list_changed notifications only reach sessions registered
+	// on the worker where the change fires. Cross-worker push is a separate,
+	// subsystem-wide design item (tracked in the MCP design-doc issue).
+	session.logLevel = level;
+	await saveSession(session);
+	setSessionLogLevel(session.id, level);
+	return jsonResponse(200, buildSuccess(messageId, {}));
 }
 
 async function handleGet(request: NormRequest): Promise<NormResponse> {
@@ -297,6 +344,9 @@ async function handleGet(request: NormRequest): Promise<NormResponse> {
 		};
 	}
 	const record = registerSession(sessionId, request.profile, effectiveUser(request));
+	// Seed the live record with any previously-set logging level so a reconnect
+	// (or a setLevel that preceded this stream) keeps delivering notifications/message.
+	if (session.logLevel) record.logLevel = session.logLevel;
 	seedSessionSnapshot(sessionId);
 	return {
 		status: 200,
@@ -416,6 +466,14 @@ async function dispatchToolsCall(
 			status: 'rate_limited',
 			durationMs: 0,
 		});
+		// Surface the throttle to a client that opted into logging, so it can
+		// back off rather than only inferring from the isError tool result.
+		emitMcpLogToSession(
+			session.id,
+			'notice',
+			{ kind: 'rate_limited', tool: name, scope: denied.reason },
+			'mcp.rateLimit'
+		);
 		return jsonResponse(200, buildSuccess(messageId, toolResult));
 	}
 

--- a/unitTests/components/mcp/logging.test.js
+++ b/unitTests/components/mcp/logging.test.js
@@ -1,0 +1,109 @@
+const assert = require('node:assert/strict');
+const {
+	isValidMcpLogLevel,
+	setSessionLogLevel,
+	getSessionLogLevel,
+	emitMcpLogToSession,
+	emitMcpLogToProfile,
+} = require('#src/components/mcp/logging');
+const {
+	registerSession,
+	unregisterSession,
+	_resetSessionRegistryForTest,
+} = require('#src/components/mcp/sessionRegistry');
+
+const SUPER = { username: 'admin', role: { permission: { super_user: true } } };
+
+// Attach a 'data' listener immediately so the queue routes sends to us
+// (IterableEventQueue only emits 'data' once it has a listener).
+function capture(record) {
+	const frames = [];
+	record.queue.on('data', (f) => frames.push(f));
+	return frames;
+}
+
+describe('mcp/logging', () => {
+	afterEach(() => {
+		_resetSessionRegistryForTest();
+	});
+
+	it('validates RFC 5424 levels and rejects everything else', () => {
+		for (const level of ['debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency']) {
+			assert.equal(isValidMcpLogLevel(level), true, level);
+		}
+		for (const bad of ['verbose', 'trace', 'warn', 'fatal', '', 5, null, undefined, {}]) {
+			assert.equal(isValidMcpLogLevel(bad), false, String(bad));
+		}
+	});
+
+	it('stores the level on the registered session and clears it when the session unregisters', () => {
+		registerSession('s1', 'application', SUPER);
+		setSessionLogLevel('s1', 'warning');
+		assert.equal(getSessionLogLevel('s1'), 'warning');
+		unregisterSession('s1');
+		assert.equal(getSessionLogLevel('s1'), undefined);
+	});
+
+	it('setSessionLogLevel is a no-op for a session with no open SSE stream', () => {
+		setSessionLogLevel('ghost', 'debug'); // never registered → nowhere to store
+		assert.equal(getSessionLogLevel('ghost'), undefined);
+	});
+
+	it('emits nothing until the session has set a level (no unsolicited messages)', () => {
+		const rec = registerSession('s1', 'application', SUPER);
+		const frames = capture(rec);
+		emitMcpLogToSession('s1', 'error', { msg: 'x' });
+		assert.equal(frames.length, 0);
+	});
+
+	it('delivers a notifications/message at or above the session level', () => {
+		const rec = registerSession('s1', 'application', SUPER);
+		const frames = capture(rec);
+		setSessionLogLevel('s1', 'warning');
+		emitMcpLogToSession('s1', 'error', { code: 1 }, 'mcp.test'); // error >= warning
+		assert.equal(frames.length, 1);
+		assert.equal(frames[0].event, 'message');
+		assert.deepEqual(frames[0].data, {
+			jsonrpc: '2.0',
+			method: 'notifications/message',
+			params: { level: 'error', logger: 'mcp.test', data: { code: 1 } },
+		});
+	});
+
+	it('suppresses a record below the session level', () => {
+		const rec = registerSession('s1', 'application', SUPER);
+		const frames = capture(rec);
+		setSessionLogLevel('s1', 'error');
+		emitMcpLogToSession('s1', 'info', { msg: 'low' }); // info < error
+		assert.equal(frames.length, 0);
+	});
+
+	it('admits a record exactly at the session level', () => {
+		const rec = registerSession('s1', 'application', SUPER);
+		const frames = capture(rec);
+		setSessionLogLevel('s1', 'notice');
+		emitMcpLogToSession('s1', 'notice', { at: 'boundary' });
+		assert.equal(frames.length, 1);
+	});
+
+	it('no-ops when the session has a level but no open SSE stream', () => {
+		setSessionLogLevel('ghost', 'debug');
+		assert.doesNotThrow(() => emitMcpLogToSession('ghost', 'error', {}));
+	});
+
+	it('emitMcpLogToProfile fans out only to admitting sessions on the matching profile', () => {
+		const a = registerSession('a', 'application', SUPER);
+		const b = registerSession('b', 'application', SUPER);
+		const c = registerSession('c', 'operations', SUPER);
+		const fa = capture(a);
+		const fb = capture(b);
+		const fc = capture(c);
+		setSessionLogLevel('a', 'info'); // admits info
+		setSessionLogLevel('b', 'error'); // suppresses info
+		setSessionLogLevel('c', 'debug'); // different profile, not targeted
+		emitMcpLogToProfile('application', 'info', { hello: true });
+		assert.equal(fa.length, 1);
+		assert.equal(fb.length, 0);
+		assert.equal(fc.length, 0);
+	});
+});

--- a/unitTests/components/mcp/logging.test.js
+++ b/unitTests/components/mcp/logging.test.js
@@ -78,6 +78,16 @@ describe('mcp/logging', () => {
 		assert.equal(frames.length, 0);
 	});
 
+	it('does not admit an unrecognized level even when the session minimum is debug (rank 0)', () => {
+		// Defensive: an invalid recordLevel must not slip past a `debug` minimum by
+		// defaulting to rank 0 (Gemini review).
+		const rec = registerSession('s1', 'application', SUPER);
+		const frames = capture(rec);
+		setSessionLogLevel('s1', 'debug');
+		emitMcpLogToSession('s1', 'bogus', { msg: 'invalid level' });
+		assert.equal(frames.length, 0);
+	});
+
 	it('admits a record exactly at the session level', () => {
 		const rec = registerSession('s1', 'application', SUPER);
 		const frames = capture(rec);

--- a/unitTests/components/mcp/transport.test.js
+++ b/unitTests/components/mcp/transport.test.js
@@ -2,7 +2,7 @@ const assert = require('node:assert/strict');
 const rewire = require('rewire');
 const transport_mod = rewire('#src/components/mcp/transport');
 const { handleMcpRequest } = transport_mod;
-const { _setSessionTableForTest, createSession, loadSession } = require('#src/components/mcp/session');
+const { _setSessionTableForTest, createSession, loadSession, saveSession } = require('#src/components/mcp/session');
 const { getRegisteredSession } = require('#src/components/mcp/sessionRegistry');
 const { addTool, _resetRegistryForTest } = require('#src/components/mcp/toolRegistry');
 const {
@@ -242,6 +242,23 @@ describe('mcp/transport', () => {
 			// Persisted durably so it survives an SSE reconnect (#1349 logging design).
 			const session = await loadSession(sessionId);
 			assert.equal(session.logLevel, 'warning');
+		});
+
+		it('does not roll back lastActivity when persisting the level (touchSession adopted)', async () => {
+			// Force a known-old lastActivity, then setLevel: the request's touchSession
+			// must advance it, and the level-persisting saveSession must NOT write the
+			// stale load-time value back (root fix — handlePost adopts the touched copy).
+			const stale = await loadSession(sessionId);
+			await saveSession({ ...stale, lastActivity: 1 });
+			await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(2, 'logging/setLevel', { level: 'info' }),
+					headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' },
+				})
+			);
+			const after = await loadSession(sessionId);
+			assert.ok(after.lastActivity > 1, `lastActivity should advance, not roll back; got ${after.lastActivity}`);
+			assert.equal(after.logLevel, 'info', 'level still persisted');
 		});
 
 		it('seeds the live SSE record from a level set before the GET stream opened', async () => {

--- a/unitTests/components/mcp/transport.test.js
+++ b/unitTests/components/mcp/transport.test.js
@@ -3,6 +3,7 @@ const rewire = require('rewire');
 const transport_mod = rewire('#src/components/mcp/transport');
 const { handleMcpRequest } = transport_mod;
 const { _setSessionTableForTest, createSession, loadSession } = require('#src/components/mcp/session');
+const { getRegisteredSession } = require('#src/components/mcp/sessionRegistry');
 const { addTool, _resetRegistryForTest } = require('#src/components/mcp/toolRegistry');
 const {
 	_setResourcesForTest,
@@ -226,6 +227,107 @@ describe('mcp/transport', () => {
 				})
 			);
 			assert.equal(res.status, 202);
+		});
+
+		it('logging/setLevel accepts a valid level, returns {}, and persists it on the session record', async () => {
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(2, 'logging/setLevel', { level: 'warning' }),
+					headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' },
+				})
+			);
+			assert.equal(res.status, 200);
+			assert.equal(res.jsonBody.error, undefined);
+			assert.deepEqual(res.jsonBody.result, {});
+			// Persisted durably so it survives an SSE reconnect (#1349 logging design).
+			const session = await loadSession(sessionId);
+			assert.equal(session.logLevel, 'warning');
+		});
+
+		it('seeds the live SSE record from a level set before the GET stream opened', async () => {
+			// setLevel arrives with no open GET stream → persisted only. Opening the
+			// stream afterward must seed the live record from the persisted level so
+			// notifications/message are not silently suppressed (Codex review).
+			await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(2, 'logging/setLevel', { level: 'error' }),
+					headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' },
+				})
+			);
+			assert.equal(getRegisteredSession(sessionId), undefined, 'no live record before GET');
+			const get = await handleMcpRequest(
+				makeReq({
+					method: 'GET',
+					headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' },
+				})
+			);
+			assert.equal(get.status, 200);
+			assert.equal(getRegisteredSession(sessionId).logLevel, 'error', 'live record seeded from persisted level');
+		});
+
+		it('logging/setLevel rejects an invalid level with -32602', async () => {
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(2, 'logging/setLevel', { level: 'verbose' }),
+					headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' },
+				})
+			);
+			assert.equal(res.status, 200);
+			assert.equal(res.jsonBody.error.code, -32602);
+		});
+	});
+
+	describe('POST ping', () => {
+		let sessionId;
+		beforeEach(async () => {
+			const res = await handleMcpRequest(
+				makeReq({ body: jsonRpc(1, 'initialize', { protocolVersion: '2025-06-18' }) })
+			);
+			sessionId = res.headers['Mcp-Session-Id'];
+		});
+
+		it('answers ping with an empty result on a valid session', async () => {
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(7, 'ping'),
+					headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' },
+				})
+			);
+			assert.equal(res.status, 200);
+			assert.equal(res.jsonBody.error, undefined);
+			assert.deepEqual(res.jsonBody.result, {});
+			assert.equal(res.jsonBody.id, 7);
+		});
+
+		it('does not mask an unknown/expired session — ping returns 404, not success', async () => {
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(7, 'ping'),
+					headers: { 'mcp-session-id': 'not-a-session', 'mcp-protocol-version': '2025-06-18' },
+				})
+			);
+			assert.equal(res.status, 404);
+		});
+
+		it('returns 202 (no response) for a ping sent as a notification', async () => {
+			const res = await handleMcpRequest(
+				makeReq({
+					body: jsonRpc(undefined, 'ping'),
+					headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-06-18' },
+				})
+			);
+			assert.equal(res.status, 202);
+			assert.equal(res.jsonBody, undefined);
+		});
+	});
+
+	describe('POST after initialize (continued)', () => {
+		let sessionId;
+		beforeEach(async () => {
+			const res = await handleMcpRequest(
+				makeReq({ body: jsonRpc(1, 'initialize', { protocolVersion: '2025-06-18' }) })
+			);
+			sessionId = res.headers['Mcp-Session-Id'];
 		});
 
 		it('returns 202 on a client response frame (result envelope)', async () => {


### PR DESCRIPTION
Implements the two MCP conformance items from the design-doc issue #1349: `ping` and the `logging` capability (`logging/setLevel` + `notifications/message`).

## Why

`initialize` advertised `logging: {}`, but `logging/setLevel` returned `-32601` — an advertise-but-don't-implement mismatch a conformant client (e.g. Claude Desktop) trips on. `ping`, a base-protocol liveness utility, was likewise unanswered. This reconciles the advertised capability with real behavior.

## What

- **`ping`** → empty result. Routed *after* session validation so a stale/expired/wrong-user session gets the normal 404/403 (not a success that masks an invalid session); a ping *notification* gets the standard 202.
- **`logging/setLevel`** → validates an RFC 5424 level; persists it on the durable session record (`system.mcp_session`). Persisting (vs. an in-memory map) means it survives an SSE reconnect, is order-independent of GET-stream open, and expires with the session TTL — no separate cache to leak. The live SSE record is seeded from it on (re)connect.
- **`notifications/message`** → new `logging.ts` emitter; per-session level filtering (nothing before `setLevel`); delivered over the session's SSE queue. One call site wired: `tools/call` rate-limit rejections emit a `notice`.

## Where to look

- **`components/mcp/logging.ts`** (new) — level taxonomy + emitter. **Deliberately scoped to MCP-layer events, NOT the global `harperLogger` stream** — Harper's logger has no subscription hook and its records are process-wide/cross-worker, so forwarding them to an authenticated client would be a confidentiality leak + unbounded firehose. Rationale in #1349 §3.
- **`components/mcp/session.ts`** — new persisted `logLevel` field (+ table attribute).
- **`components/mcp/transport.ts`** — `ping`/`setLevel` dispatch + seeding the live record on GET.

## Open item for the reviewer

**Per-worker push (v1 limitation, not introduced here):** server push is per-worker — a `setLevel` POST handled on a different worker than the session's SSE stream only takes effect on that stream at the next reconnect (the durable level is updated immediately). This is the **same** constraint the existing `listChanged` channel operates under ("cross-worker fan-out isn't attempted in v1"). Cross-worker push is a subsystem-wide design item tracked in #1349. Flagging since Codex raised it — it's a documented, deliberate scope boundary, not a regression.

## Reviews

Codex + Gemini cross-model review per the guidelines. Codex surfaced three P2s across passes (ping session-validation; in-memory level-map leak; pre-stream level loss) — all addressed (the persist-on-record design resolves the latter two). Gemini approved.

## Docs

No docs change: `logging`/`ping` are protocol capabilities, not user-facing config/CLI/schema. The broader feature roadmap lives in #1349.

🤖 Generated by an LLM (Claude Opus 4.8).
