### PR TITLE
fix(migration): await in-flight blob saves before declaring v4→v5 migration done

### DIFF
--- a/bin/copyDb.ts
+++ b/bin/copyDb.ts
@@ -519,6 +519,11 @@ export async function copyDbToRocks(sourceRootStore, sourceDatabase: string, tar
 		console.log('migrated database ' + sourceDatabase + ' to RocksDB');
 	} finally {
 		endPendingMigrationBlobSaves();
+		// If the migration threw before we awaited pendingBlobSaves above, in-flight save
+		// promises in the list have no rejection handler attached. Attach a no-op catch so a
+		// later background failure is silently observed instead of crashing the process via
+		// Node's unhandledRejection.
+		for (const saving of pendingBlobSaves) saving.catch(() => {});
 		transaction.done();
 		targetRootStore.close();
 	}

--- a/bin/copyDb.ts
+++ b/bin/copyDb.ts
@@ -14,7 +14,11 @@ import { updateConfigValue } from '../config/configUtils.js';
 import * as hdbLogger from '../utility/logging/harper_logger.ts';
 import { RocksDatabase, type RocksDatabaseOptions } from '@harperfast/rocksdb-js';
 import { RocksIndexStore } from '../resources/RocksIndexStore.ts';
-import { encodeBlobsWithFilePath } from '../resources/blob.ts';
+import {
+	beginPendingMigrationBlobSaves,
+	encodeBlobsWithFilePath,
+	endPendingMigrationBlobSaves,
+} from '../resources/blob.ts';
 import { RecordEncoder, setNextEncoding, lastMetadata, METADATA } from '../resources/RecordEncoder.ts';
 
 export async function compactOnStart() {
@@ -411,6 +415,13 @@ export async function copyDbToRocks(sourceRootStore, sourceDatabase: string, tar
 
 	let written;
 	let outstandingWrites = 0;
+	// Open a blob-save tracking window for this database's migration. saveBlob inside
+	// encodeBlobsWithFilePath pushes every in-flight save promise into `pendingBlobSaves` so we
+	// can await them before declaring the database migrated. Without this, fire-and-forget blob
+	// writes could be left mid-pipeline at migration end, producing records in the target DB
+	// referencing fileIds whose files were never durably written — exactly the missing-blob-file
+	// state that triggers the base-copy resync wedge in harper#1337.
+	const pendingBlobSaves = beginPendingMigrationBlobSaves();
 	const transaction = sourceDbisDb.useReadTransaction();
 	try {
 		for (const { key, value: attribute } of sourceDbisDb.getRange({ transaction })) {
@@ -474,6 +485,29 @@ export async function copyDbToRocks(sourceRootStore, sourceDatabase: string, tar
 
 		await written;
 
+		// Await every blob save that was kicked off during this database's migration. The promises
+		// were pushed into pendingBlobSaves by saveBlob (see resources/blob.ts). We must do this
+		// BEFORE writing the remote-ids mapping (which signals "this DB is migrated and ready")
+		// and BEFORE closing targetRootStore — otherwise any blob whose pipeline hasn't yet
+		// flushed will be silently dropped when the store handle goes away.
+		if (pendingBlobSaves.length > 0) {
+			console.log(`awaiting ${pendingBlobSaves.length} in-flight blob save(s) for ${sourceDatabase}`);
+			const results = await Promise.allSettled(pendingBlobSaves);
+			const failed = results.filter((r) => r.status === 'rejected');
+			if (failed.length > 0) {
+				// Fail loudly so migrateOnStart leaves the migration incomplete (LMDB source still
+				// in place, migrateOnStart flag retained) and the next start retries. Silently
+				// dropping records here is what produced the production missing-blob-files state.
+				throw new Error(
+					`Migration of ${sourceDatabase} failed: ${failed.length} blob save(s) failed: ` +
+						failed
+							.slice(0, 5)
+							.map((r) => (r as PromiseRejectedResult).reason?.message ?? String((r as PromiseRejectedResult).reason))
+							.join('; ')
+				);
+			}
+		}
+
 		// Preserve the node ID mapping from the LMDB audit store so replication can resume
 		// incrementally instead of triggering a full table copy after migration.
 		const REMOTE_NODE_IDS_KEY = Symbol.for('remote-ids');
@@ -484,6 +518,7 @@ export async function copyDbToRocks(sourceRootStore, sourceDatabase: string, tar
 
 		console.log('migrated database ' + sourceDatabase + ' to RocksDB');
 	} finally {
+		endPendingMigrationBlobSaves();
 		transaction.done();
 		targetRootStore.close();
 	}

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -577,14 +577,18 @@ export function saveBlob(blob: FileBackedBlob, deleteOnFailure = false) {
 	// Track the in-flight save when a migration is collecting them. storageInfo.saving is set
 	// by writeBlobWithStream; writeBlobWithBuffer for small blobs may not produce one. The
 	// wrapping `.then(...)` removes resolved promises from the list so a long migration does not
-	// accumulate every settled save in memory; the .then has no rejection handler, so a failed
-	// save still passes through and is observable in the migration's Promise.allSettled.
+	// accumulate every settled save in memory. A side `.catch(noop)` is attached to the tracked
+	// chain so a mid-loop rejection doesn't fire Node's `unhandledRejection` before the migration
+	// reaches `Promise.allSettled(pendingBlobSaves)` — that observation is via a separate handler
+	// chain, so the original `tracked` still rejects and the migration's allSettled still detects
+	// the failure and throws the structured `Migration of … failed: …` error.
 	if (pendingMigrationBlobSaves && storageInfo.saving) {
 		const list = pendingMigrationBlobSaves;
 		const tracked: Promise<void> = storageInfo.saving.then(() => {
 			const i = list.indexOf(tracked);
 			if (i !== -1) list.splice(i, 1);
 		});
+		tracked.catch(() => {});
 		list.push(tracked);
 	}
 	return storageInfo;

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -543,6 +543,13 @@ export function createBlob(
 }
 _assignPackageExport('createBlob', createBlob);
 
+// When set (during a migration via encodeBlobsWithFilePath), saveBlob pushes the in-flight
+// writeBlob save promise here so the migration can await every blob's durable write before
+// declaring the database done. Without this, the migration's `await targetDbi.put(...)`
+// only waits for the RocksDB record commit, not the async blob file pipeline, so records
+// can be committed referencing fileIds whose blob files were never durably written.
+let pendingMigrationBlobSaves: Promise<void>[] | undefined;
+
 export function saveBlob(blob: FileBackedBlob, deleteOnFailure = false) {
 	let storageInfo = storageInfoForBlob.get(blob);
 	if (!storageInfo) {
@@ -567,6 +574,9 @@ export function saveBlob(blob: FileBackedBlob, deleteOnFailure = false) {
 		// for native blobs, we have to read them from the stream
 		writeBlobWithStream(blob as any, Readable.from(blob.stream()), storageInfo);
 	}
+	// Track the in-flight save when a migration is collecting them. storageInfo.saving is set
+	// by writeBlobWithStream; writeBlobWithBuffer for small blobs may not produce one.
+	if (pendingMigrationBlobSaves && storageInfo.saving) pendingMigrationBlobSaves.push(storageInfo.saving);
 	return storageInfo;
 }
 
@@ -896,6 +906,29 @@ export function encodeBlobsWithFilePath<T>(callback: () => T, encodingId: number
 		encodeForStorageForRecordId = undefined;
 		currentStore = undefined;
 	}
+}
+
+/**
+ * Open and close a window where saveBlob tracks every in-flight blob save promise. Used by the
+ * v4→v5 migration in copyDb.ts so the migration can await every blob file write before declaring
+ * a database done. Without this, fire-and-forget blob saves can be left mid-pipeline at migration
+ * end, producing records in the target DB that reference fileIds whose files were never durably
+ * written — exactly the "missing blob file" state behind the base-copy wedge in harper#1337.
+ *
+ * Usage:
+ *   const saves = beginPendingMigrationBlobSaves();
+ *   // ... run migration loop, encodeBlobsWithFilePath collects saves into `saves` ...
+ *   const results = await Promise.allSettled(saves);
+ *   endPendingMigrationBlobSaves();
+ *   const failed = results.filter(r => r.status === 'rejected');
+ *   if (failed.length > 0) throw ...;
+ */
+export function beginPendingMigrationBlobSaves(): Promise<void>[] {
+	pendingMigrationBlobSaves = [];
+	return pendingMigrationBlobSaves;
+}
+export function endPendingMigrationBlobSaves(): void {
+	pendingMigrationBlobSaves = undefined;
 }
 /**
  * Encode blobs as buffers, so they can be transferred remotely

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -575,8 +575,18 @@ export function saveBlob(blob: FileBackedBlob, deleteOnFailure = false) {
 		writeBlobWithStream(blob as any, Readable.from(blob.stream()), storageInfo);
 	}
 	// Track the in-flight save when a migration is collecting them. storageInfo.saving is set
-	// by writeBlobWithStream; writeBlobWithBuffer for small blobs may not produce one.
-	if (pendingMigrationBlobSaves && storageInfo.saving) pendingMigrationBlobSaves.push(storageInfo.saving);
+	// by writeBlobWithStream; writeBlobWithBuffer for small blobs may not produce one. The
+	// wrapping `.then(...)` removes resolved promises from the list so a long migration does not
+	// accumulate every settled save in memory; the .then has no rejection handler, so a failed
+	// save still passes through and is observable in the migration's Promise.allSettled.
+	if (pendingMigrationBlobSaves && storageInfo.saving) {
+		const list = pendingMigrationBlobSaves;
+		const tracked: Promise<void> = storageInfo.saving.then(() => {
+			const i = list.indexOf(tracked);
+			if (i !== -1) list.splice(i, 1);
+		});
+		list.push(tracked);
+	}
 	return storageInfo;
 }
 

--- a/unitTests/bin/copyDbBlobAwait.test.js
+++ b/unitTests/bin/copyDbBlobAwait.test.js
@@ -48,14 +48,13 @@ describe('encodeBlobsWithFilePath blob-save tracking (harper#1337)', () => {
 	});
 
 	it('collects in-flight blob save promises into the begin/end window', async () => {
-
 		const tracked = beginPendingMigrationBlobSaves();
 		assert.deepStrictEqual(tracked, [], 'window starts empty');
 
 		// Drive a tiny saveBlob through encodeBlobsWithFilePath. Use a file-backed blob whose
 		// stream is short enough that the pipeline can complete in-test.
 		const { createBlob } = require('#src/resources/blob');
-		const blob = createBlob(Buffer.from('a'.repeat(20000))); // > FILE_STORAGE_THRESHOLD (8192)
+		const blob = await createBlob(Buffer.from('a'.repeat(20000))); // > FILE_STORAGE_THRESHOLD (8192)
 
 		encodeBlobsWithFilePath(
 			() => {
@@ -86,7 +85,7 @@ describe('encodeBlobsWithFilePath blob-save tracking (harper#1337)', () => {
 				yield Buffer.from('unused');
 			})()
 		);
-		const blob = createBlob(broken);
+		const blob = await createBlob(broken);
 
 		encodeBlobsWithFilePath(
 			() => {
@@ -99,11 +98,7 @@ describe('encodeBlobsWithFilePath blob-save tracking (harper#1337)', () => {
 		assert.strictEqual(tracked.length, 1, 'one save promise tracked');
 		// Use allSettled so we observe the rejection without failing the test on the throw.
 		const [result] = await Promise.allSettled(tracked);
-		assert.strictEqual(
-			result.status,
-			'rejected',
-			`expected the broken-source save to reject; got ${result.status}`
-		);
+		assert.strictEqual(result.status, 'rejected', `expected the broken-source save to reject; got ${result.status}`);
 
 		endPendingMigrationBlobSaves();
 	});
@@ -111,14 +106,14 @@ describe('encodeBlobsWithFilePath blob-save tracking (harper#1337)', () => {
 	it('endPendingMigrationBlobSaves stops collecting; new saveBlob calls do NOT land in the prior list', async () => {
 		const { createBlob, isSaving } = require('#src/resources/blob');
 		const tracked = beginPendingMigrationBlobSaves();
-		const firstBlob = createBlob(Buffer.from('x'.repeat(20000)));
+		const firstBlob = await createBlob(Buffer.from('x'.repeat(20000)));
 		encodeBlobsWithFilePath(() => saveBlob(firstBlob), 3, store);
 		assert.strictEqual(tracked.length, 1);
 
 		endPendingMigrationBlobSaves();
 
 		// After the window closes, a subsequent encode should not append to `tracked`.
-		const secondBlob = createBlob(Buffer.from('y'.repeat(20000)));
+		const secondBlob = await createBlob(Buffer.from('y'.repeat(20000)));
 		encodeBlobsWithFilePath(() => saveBlob(secondBlob), 4, store);
 		assert.strictEqual(tracked.length, 1, 'tracked list is not appended to after end');
 

--- a/unitTests/bin/copyDbBlobAwait.test.js
+++ b/unitTests/bin/copyDbBlobAwait.test.js
@@ -1,0 +1,129 @@
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+const assert = require('node:assert');
+const { describe, it, before, after, beforeEach, afterEach } = require('node:test');
+
+require('../testUtils');
+
+const {
+	beginPendingMigrationBlobSaves,
+	endPendingMigrationBlobSaves,
+	encodeBlobsWithFilePath,
+	saveBlob,
+} = require('#src/resources/blob');
+
+// Regression for harper#1337 — the v4→v5 migration was fire-and-forget on blob file writes.
+// `encodeBlobsWithFilePath` triggers `saveBlob → writeBlobWithStream`, which sets up a
+// `pipeline()` whose promise lives on `storageInfo.saving` and was never collected. The
+// migration loop awaited only `targetDbi.put`, so it could close the target DB while blob
+// pipelines were still flushing. Failures silently dropped on the floor — producing records
+// in the target DB referencing fileIds whose blob files were never durably written.
+//
+// The fix exposes a per-migration tracking window: `beginPendingMigrationBlobSaves()` returns
+// an array that `saveBlob` pushes every `storageInfo.saving` promise into. The migration
+// awaits them before closing the target store, and fails the migration loudly on any
+// rejection.
+
+describe('encodeBlobsWithFilePath blob-save tracking (harper#1337)', () => {
+	let tmpRoot;
+	let store;
+
+	beforeEach(() => {
+		tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'harper-blob-await-'));
+		const { open } = require('lmdb');
+		const { databasePaths } = require('#src/resources/blob');
+		store = open({ path: path.join(tmpRoot, 'db') });
+		databasePaths.set(store, [path.join(tmpRoot, 'blobs')]);
+	});
+
+	afterEach(() => {
+		try {
+			store?.close();
+		} catch {}
+		try {
+			fs.rmSync(tmpRoot, { recursive: true, force: true });
+		} catch {}
+		endPendingMigrationBlobSaves();
+	});
+
+	it('collects in-flight blob save promises into the begin/end window', async () => {
+
+		const tracked = beginPendingMigrationBlobSaves();
+		assert.deepStrictEqual(tracked, [], 'window starts empty');
+
+		// Drive a tiny saveBlob through encodeBlobsWithFilePath. Use a file-backed blob whose
+		// stream is short enough that the pipeline can complete in-test.
+		const { createBlob } = require('#src/resources/blob');
+		const blob = createBlob(Buffer.from('a'.repeat(20000))); // > FILE_STORAGE_THRESHOLD (8192)
+
+		encodeBlobsWithFilePath(
+			() => {
+				saveBlob(blob);
+			},
+			1,
+			store
+		);
+
+		assert.strictEqual(tracked.length, 1, 'one save promise tracked');
+		await assert.doesNotReject(tracked[0], 'the tracked save resolves');
+
+		endPendingMigrationBlobSaves();
+	});
+
+	it('a failed blob save (source stream errors) shows up as a rejection in the tracked list', async () => {
+		const { Readable } = require('node:stream');
+
+		const tracked = beginPendingMigrationBlobSaves();
+
+		const { createBlob } = require('#src/resources/blob');
+		// Construct a blob whose source stream emits an error on first read — simulates v4 having
+		// an unreadable source file (the production scenario the migration could not previously
+		// detect).
+		const broken = Readable.from(
+			(function* () {
+				throw new Error('synthetic ENOENT during migration read');
+				yield Buffer.from('unused');
+			})()
+		);
+		const blob = createBlob(broken);
+
+		encodeBlobsWithFilePath(
+			() => {
+				saveBlob(blob);
+			},
+			2,
+			store
+		);
+
+		assert.strictEqual(tracked.length, 1, 'one save promise tracked');
+		// Use allSettled so we observe the rejection without failing the test on the throw.
+		const [result] = await Promise.allSettled(tracked);
+		assert.strictEqual(
+			result.status,
+			'rejected',
+			`expected the broken-source save to reject; got ${result.status}`
+		);
+
+		endPendingMigrationBlobSaves();
+	});
+
+	it('endPendingMigrationBlobSaves stops collecting; new saveBlob calls do NOT land in the prior list', async () => {
+		const { createBlob, isSaving } = require('#src/resources/blob');
+		const tracked = beginPendingMigrationBlobSaves();
+		const firstBlob = createBlob(Buffer.from('x'.repeat(20000)));
+		encodeBlobsWithFilePath(() => saveBlob(firstBlob), 3, store);
+		assert.strictEqual(tracked.length, 1);
+
+		endPendingMigrationBlobSaves();
+
+		// After the window closes, a subsequent encode should not append to `tracked`.
+		const secondBlob = createBlob(Buffer.from('y'.repeat(20000)));
+		encodeBlobsWithFilePath(() => saveBlob(secondBlob), 4, store);
+		assert.strictEqual(tracked.length, 1, 'tracked list is not appended to after end');
+
+		// Await both blobs' pipelines to drain so the afterEach can close the store cleanly
+		// without orphaning their write streams (would otherwise show up as uncaughtException).
+		await Promise.allSettled([tracked[0], isSaving(secondBlob)].filter(Boolean));
+	});
+});

--- a/unitTests/bin/copyDbBlobAwait.test.js
+++ b/unitTests/bin/copyDbBlobAwait.test.js
@@ -102,6 +102,55 @@ describe('encodeBlobsWithFilePath blob-save tracking (harper#1337)', () => {
 		endPendingMigrationBlobSaves();
 	});
 
+	it('a mid-loop rejection does NOT fire unhandledRejection before the migration awaits the list', async () => {
+		// Production concern: in a long migration with thousands of records and multiple `await
+		// written` checkpoints between record encodes, a blob save can reject well before the
+		// migration loop reaches its Promise.allSettled(pendingBlobSaves) gate. Without a
+		// suppression handler on the tracked chain, Node fires unhandledRejection at that point
+		// and the process aborts — short-circuiting the structured `Migration of … failed: …`
+		// throw the migration relies on for retryability.
+		const { Readable } = require('node:stream');
+		const { createBlob } = require('#src/resources/blob');
+
+		const tracked = beginPendingMigrationBlobSaves();
+
+		const broken = Readable.from(
+			(function* () {
+				throw new Error('synthetic ENOENT during migration read');
+				yield Buffer.from('unused');
+			})()
+		);
+		const blob = await createBlob(broken);
+
+		// Capture unhandledRejection events for the duration of the test.
+		const unhandled = [];
+		const listener = (reason) => unhandled.push(reason);
+		process.on('unhandledRejection', listener);
+
+		encodeBlobsWithFilePath(() => saveBlob(blob), 5, store);
+		assert.strictEqual(tracked.length, 1, 'one save promise tracked');
+
+		// Yield to the event loop long enough for the rejection to propagate and any
+		// unhandledRejection to fire. Two macrotasks plus a microtask drain is typically enough.
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		await new Promise((resolve) => setImmediate(resolve));
+
+		process.off('unhandledRejection', listener);
+
+		assert.deepStrictEqual(
+			unhandled,
+			[],
+			`expected NO unhandledRejection during the migration loop; got: ${unhandled.map(String).join('; ')}`
+		);
+
+		// The migration's later Promise.allSettled MUST still observe the rejection so the
+		// structured `Migration failed` throw can fire.
+		const [result] = await Promise.allSettled(tracked);
+		assert.strictEqual(result.status, 'rejected', 'allSettled still detects the rejection');
+
+		endPendingMigrationBlobSaves();
+	});
+
 	it('endPendingMigrationBlobSaves stops collecting; new saveBlob calls do NOT land in the prior list', async () => {
 		const { createBlob, isSaving } = require('#src/resources/blob');
 		const tracked = beginPendingMigrationBlobSaves();

--- a/unitTests/bin/copyDbBlobAwait.test.js
+++ b/unitTests/bin/copyDbBlobAwait.test.js
@@ -2,7 +2,6 @@ const path = require('node:path');
 const fs = require('node:fs');
 const os = require('node:os');
 const assert = require('node:assert');
-const { describe, it, before, after, beforeEach, afterEach } = require('node:test');
 
 require('../testUtils');
 


### PR DESCRIPTION
## Summary

In `bin/copyDb.ts`, the v4→v5 migration writes each record via `written = encodeBlobsWithFilePath(() => targetDbi.put(...), ...)`. The blob-save side effect — `saveBlob` setting up `writeBlobWithStream` whose async `pipeline()` returns a promise on `storageInfo.saving` — is fire-and-forget. Nowhere in the migration loop, the per-database scope, or the outer driver are those `storageInfo.saving` promises collected or awaited. `await written` only waits for the RocksDB record commit.

The result: records are committed to the target DB while blob pipelines are still mid-write, and when the per-database scope's `finally` calls `targetRootStore.close()`, any blob pipelines still in flight are abandoned. Failures (e.g. source stream ENOENT, write contention) are silently dropped. The contiguous ~3,815-file gap observed under `sem/0/4/` on the `v4-to-v5.akamai.stage` cluster (see #1337) matches a burst of in-flight saves at the moment the loop ended.

## Fix

This PR exposes a per-migration tracking window in `resources/blob.ts`:

- `beginPendingMigrationBlobSaves()` returns a list that `saveBlob` pushes every in-flight `storageInfo.saving` promise into
- `endPendingMigrationBlobSaves()` closes the window

In `copyDb.ts`, the per-database migration opens the window before the record-copy loop and, after the loop completes, awaits all collected promises via `Promise.allSettled` **before** writing the remote-ids mapping (the \"this DB is migrated\" signal) and **before** the `finally` calls `targetRootStore.close()`. If any blob save rejected, the migration throws — `migrateOnStart`'s outer handler catches the throw, leaves the LMDB source intact (does not move it to backup), and preserves the `migrateOnStart` flag for retry on next start. This makes the migration retryable instead of silently producing a database with missing blob files.

## Test

`unitTests/bin/copyDbBlobAwait.test.js` — three cases:

1. `encodeBlobsWithFilePath` inside a `begin/end` window collects the in-flight blob save promise
2. A blob save whose source stream errors propagates as a rejection in the tracked list (so the migration can detect and fail loudly)
3. After `endPendingMigrationBlobSaves()`, subsequent saves do NOT land in the prior list

All 3 pass.

## Scope, and what this does NOT address

This is the **upstream-cause** fix for the missing-blob-file state observed in #1337. It prevents new clusters from being produced in that state by every v4→v5 migration. It does **not**:

- **Recover existing stuck clusters** (e.g. `v4-to-v5.akamai.stage`). Those clusters already have records on disk referencing fileIds whose files were never written; this PR doesn't clean them up. They need either a separate sender-side base-copy skip (to let replication converge past the bad records) or the records to expire via TTL.
- **Address the receiver-side uncaughtException storm** from orphaned blob streams. That's covered by harper-pro#409 (Kris's receiver-side teardown hardening).

The three fixes are complementary: this PR (no new bad clusters), harper-pro#409 (process stability when bad records are encountered), and a sender-side guard (existing-cluster recovery). All three are needed for full resolution.

## Cross-references

- harper#1337 (root issue with full causal chain)
- harper-pro#409 (Kris's receiver-side hardening)
- #1340 (closed without merge; defended a separate CAS path that wasn't the cause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)