### PR TITLE
Flag structure updates per transaction log so replicas decode against current structures (#1348)

### DIFF
--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -2,6 +2,7 @@ import { TransactionLog, RocksDatabase, shutdown, type TransactionEntry } from '
 import { ExtendedIterable } from '@harperfast/extended-iterable';
 import { getIdOfRemoteNode } from './nodeIdMapping.ts';
 import { Decoder, readAuditEntry, ENTRY_DATAVIEW, AuditRecord, createAuditEntry } from './auditStore.ts';
+import { HAS_STRUCTURE_UPDATE } from './RecordEncoder.ts';
 import { endIteratorOnCorruptFrame } from './replayLogsGuards.ts';
 import { isMainThread } from 'node:worker_threads';
 import { EventEmitter } from 'node:events';
@@ -42,6 +43,13 @@ export class RocksTransactionLogStore extends EventEmitter {
 	updates = 0; // the number of updates to the list of logs that have occurred
 	rootStore: RocksDatabase;
 	reusableIterable = true; // flag indicating that iterable can be reused to resume iterating through audit log
+	// Highest structureVersion appended to each per-node TransactionLog, tracked per tableId. Drives the
+	// per-log HAS_STRUCTURE_UPDATE flag in put(). Keyed by (log, tableId): a per-node log interleaves entries
+	// from every table, but structureVersion is per-table (each table has its own encoder / structure
+	// dictionary), so a single log-wide watermark would let a high-version table suppress the flag for
+	// another table's first use of a new structure. In-memory only: a reset to 0 on restart at most re-flags
+	// the first entry per (log, table) — a redundant, idempotent structure resend, never an under-flag.
+	structureVersionByLogTable: WeakMap<TransactionLog, Map<number, number>> = new WeakMap();
 	constructor(rootDatabase: RocksDatabase) {
 		super();
 		this.log = rootDatabase.useLog('local');
@@ -63,6 +71,36 @@ export class RocksTransactionLogStore extends EventEmitter {
 		let entryBinary: Uint8Array;
 		if (auditRecord instanceof Uint8Array) entryBinary = auditRecord;
 		else {
+			// Make every per-node log self-describing for structure progression. HAS_STRUCTURE_UPDATE is a
+			// one-shot, process-wide-per-table flag (saveStructures sets it; the next audit write to that table
+			// consumes it), so it lands on whichever write happens to follow a mint — in whatever log that write
+			// targets. Logs are partitioned per origin node (logById), so the flag can be recorded in a different
+			// log than the one whose entries first *reference* the new structure; a linear reader of that other
+			// log (replication) then never sees the update and decodes later entries against a stale structure set,
+			// yielding undecodable records (HarperFast/harper#1348). Re-derive the flag here from the monotonic
+			// per-table structureVersion so any entry that advances this (log, table) structure count carries it,
+			// regardless of where the original one-shot flag was consumed. A new structure (count increase) is the
+			// only structure change that affects decoding; structon's one count-stable mutation — promoting a
+			// field from ascii8 to string8 — decodes identically (ASCII bytes are valid UTF-8 and both types read
+			// through the same UTF-8 path), so it needs no flag. The `|=` only adds the flag, never clearing one
+			// the encoder already set.
+			const structureVersion = auditRecord.structureVersion ?? 0;
+			let versionByTable = this.structureVersionByLogTable.get(log);
+			if (!versionByTable) this.structureVersionByLogTable.set(log, (versionByTable = new Map()));
+			if (structureVersion > (versionByTable.get(auditRecord.tableId) ?? 0)) {
+				auditRecord.extendedType = (auditRecord.extendedType ?? 0) | HAS_STRUCTURE_UPDATE;
+				// Advance the (log, table) watermark only once this entry DURABLY commits (in the commit hook
+				// below) — never here. Audit entries are pending until commit and discarded if the transaction
+				// aborts (or if serialization / addEntry throws), so a watermark raised now could suppress
+				// HAS_STRUCTURE_UPDATE on a later committed entry at the same structureVersion and re-open the gap
+				// this guards (harper#1348 review). Before commit, a same-version entry simply re-flags — a
+				// redundant, harmless structure resend.
+				(options.transaction.pendingStructureWatermarks ??= []).push([
+					versionByTable,
+					auditRecord.tableId,
+					structureVersion,
+				]);
+			}
 			const flagAndStructureVersion =
 				(auditRecord.previousVersion ? HAS_PREVIOUS_VERSION : 0) |
 				(auditRecord.previousResidencyId ? HAS_PREVIOUS_RESIDENCY_ID : 0) |
@@ -79,14 +117,25 @@ export class RocksTransactionLogStore extends EventEmitter {
 			}
 			entryBinary = createAuditEntry(auditRecord, position);
 		}
-		if (this.listenerCount('aftercommit')) {
-			if (!options.transaction.logEntries) {
-				options.transaction.logEntries = [];
-				options.transaction.onCommit = () => {
-					this.emit('aftercommit', options.transaction.logEntries);
-				};
-			}
-			options.transaction.logEntries.push(auditRecord);
+		if (this.listenerCount('aftercommit')) (options.transaction.logEntries ??= []).push(auditRecord);
+		// One commit hook per transaction handles both deferred side effects — the `aftercommit` emit and the
+		// per-(log, table) structureVersion watermark advances — so they apply only after a durable commit (never
+		// on an aborted/discarded transaction). This store is the sole setter of transaction.onCommit.
+		if (
+			!options.transaction.logStoreCommitHook &&
+			(options.transaction.logEntries || options.transaction.pendingStructureWatermarks)
+		) {
+			options.transaction.logStoreCommitHook = true;
+			options.transaction.onCommit = () => {
+				const advances = options.transaction.pendingStructureWatermarks;
+				if (advances) {
+					for (const [perTable, tableId, version] of advances) {
+						if (version > (perTable.get(tableId) ?? 0)) perTable.set(tableId, version);
+					}
+				}
+				const entries = options.transaction.logEntries;
+				if (entries) this.emit('aftercommit', entries);
+			};
 		}
 		log.addEntry(entryBinary, options.transaction.id);
 	}

--- a/unitTests/resources/transactionLogStructureUpdate.test.js
+++ b/unitTests/resources/transactionLogStructureUpdate.test.js
@@ -1,0 +1,105 @@
+const assert = require('assert');
+const { RocksTransactionLogStore } = require('#src/resources/RocksTransactionLogStore');
+const { readAuditEntry } = require('#src/resources/auditStore');
+const { HAS_STRUCTURE_UPDATE } = require('#src/resources/RecordEncoder');
+
+// A mock per-node transaction log that captures appended entry binaries. The binaries must be
+// copied because the audit encoder reuses a single ENTRY_HEADER buffer between createAuditEntry calls.
+function makeLog() {
+	return {
+		entries: [],
+		addEntry(bin) {
+			this.entries.push(Buffer.from(bin));
+		},
+	};
+}
+
+// nodeLogs is indexed by nodeId; logById() reads it directly, so we can drive put() against
+// distinct per-node logs without a real RocksDB.
+function makeStore(logs) {
+	const store = new RocksTransactionLogStore({ useLog: () => makeLog() });
+	store.nodeLogs = logs;
+	return store;
+}
+
+function put(store, nodeId, structureVersion, { tableId = 1, extendedType = 0, commit = true } = {}) {
+	// `delete` carries no record, keeping the serialized entry self-contained for decode.
+	const auditRecord = {
+		type: 'delete',
+		tableId,
+		recordId: `t${tableId}-k${nodeId}-${structureVersion}`,
+		nodeId,
+		version: 1_700_000_000_000 + structureVersion,
+		structureVersion,
+		extendedType,
+	};
+	const transaction = { id: 1, isRetry: false };
+	store.put(null, auditRecord, { nodeId, transaction });
+	// The watermark advances only on durable commit. Simulate that by default; `commit: false` models a
+	// discarded/aborted append (the entry's flag was set but the watermark must not advance).
+	if (commit) transaction.onCommit?.();
+	return auditRecord;
+}
+
+const flagged = (extendedType) => (extendedType & HAS_STRUCTURE_UPDATE) !== 0;
+
+describe('RocksTransactionLogStore per-log HAS_STRUCTURE_UPDATE (harper#1348)', () => {
+	it('flags an entry when its structureVersion advances the log, and not otherwise', () => {
+		const log0 = makeLog();
+		const store = makeStore([log0]);
+
+		assert.ok(flagged(put(store, 0, 3).extendedType), 'first higher structureVersion flags');
+		assert.ok(!flagged(put(store, 0, 3).extendedType), 'same structureVersion does not flag');
+		assert.ok(flagged(put(store, 0, 5).extendedType), 'a further increase flags again');
+		assert.ok(!flagged(put(store, 0, 5).extendedType), 'no further increase does not flag');
+
+		// The flag must survive serialization (decode skips the 4-byte structureVersion header).
+		const firstDecoded = readAuditEntry(log0.entries[0], 4, undefined);
+		assert.ok(flagged(firstDecoded.extendedType), 'flag round-trips through the serialized entry');
+	});
+
+	it('tracks structureVersion per log, so a peer log learns a structure independently', () => {
+		const log0 = makeLog();
+		const log1 = makeLog();
+		const store = makeStore([log0, log1]);
+
+		assert.ok(flagged(put(store, 0, 5).extendedType), 'log 0 first entry flags');
+		// log 1 has never been advanced; its first entry must flag even though log 0 already reached 5.
+		// This is the core fix: the flag is derived per-log, not from a single shared/one-shot signal.
+		assert.ok(flagged(put(store, 1, 4).extendedType), 'log 1 first entry flags independently of log 0');
+		assert.ok(!flagged(put(store, 1, 4).extendedType), 'log 1 same structureVersion does not flag');
+	});
+
+	it('never strips a flag the encoder already set, even when the count is unchanged', () => {
+		const store = makeStore([makeLog()]);
+		put(store, 0, 5); // advance the (log, table) watermark to 5
+		// An entry at the same count that already carries the encoder's one-shot flag must keep it (the per-log
+		// derivation only adds HAS_STRUCTURE_UPDATE, never clears it).
+		assert.ok(flagged(put(store, 0, 5, { extendedType: HAS_STRUCTURE_UPDATE }).extendedType), 'pre-set flag preserved');
+	});
+
+	it('tracks structureVersion per (log, table): a high-version table does not suppress another table', () => {
+		const store = makeStore([makeLog()]);
+		// Table 1 advances this single per-node log to version 10.
+		assert.ok(flagged(put(store, 0, 10, { tableId: 1 }).extendedType), 'table 1 advance flags');
+		// Table 2's first entry (version 1) in the SAME log must still flag — its structure is independent
+		// of table 1's. A log-wide watermark (10) would wrongly suppress this and recreate the bug for table 2.
+		assert.ok(
+			flagged(put(store, 0, 1, { tableId: 2 }).extendedType),
+			'table 2 flags despite log being at v10 for table 1'
+		);
+		assert.ok(!flagged(put(store, 0, 1, { tableId: 2 }).extendedType), 'table 2 same version does not re-flag');
+		assert.ok(flagged(put(store, 0, 2, { tableId: 2 }).extendedType), 'table 2 advance flags again');
+	});
+
+	it('advances the watermark only on durable commit, so an aborted entry does not suppress a later flag', () => {
+		const store = makeStore([makeLog()]);
+		// First entry at v7 is flagged but its transaction never commits (aborted/discarded).
+		assert.ok(flagged(put(store, 0, 7, { commit: false }).extendedType), 'aborted entry is still flagged');
+		// Because the watermark was NOT advanced by the aborted entry, the next committed entry at the same
+		// structureVersion must still carry the flag — otherwise a linear reader could miss the structure (P2).
+		assert.ok(flagged(put(store, 0, 7).extendedType), 'same-version entry after an aborted attempt still flags');
+		// Once committed, the watermark advances and a further same-version entry no longer re-flags.
+		assert.ok(!flagged(put(store, 0, 7).extendedType), 'after a committed entry, same version stops flagging');
+	});
+});


### PR DESCRIPTION
## Summary
`RocksTransactionLogStore.put()` now re-derives `HAS_STRUCTURE_UPDATE` per `(log, tableId)` from the monotonic `structureVersion`, advancing the per-`(log, table)` watermark only on durable commit.

## Purpose — fixes #1348
On a production cluster, replicated records intermittently decode to `null` with `Error decoding record: Data read, but end of buffer not reached`. The application swallows it (`Promise.allSettled` + empty fallback), so it surfaces as silent degradation — affected records serve incomplete.

Root cause: `HAS_STRUCTURE_UPDATE` is a **one-shot, process-wide-per-table** flag — `saveStructures` sets it on a structure mint and the *next* audit write to that table consumes it (`RecordEncoder.ts`). But transaction logs are partitioned **per origin node** (`logById`) and interleave entries from every table, so the flag can be recorded in a *different* per-node log than the one whose entries first **reference** the new structure. A linear reader of that other log — the replication send path, which reloads structures on the flag (`harper-pro replicationConnection.ts`) — then never resends `TABLE_FIXED_STRUCTURE`, and the peer decodes later entries against a stale structure set → undecodable / null.

The fix makes every per-node log **self-describing**: any entry advancing a `(log, table)`'s structure count carries the flag, regardless of where the one-shot flag was consumed.

## Where to put attention
- **Commit-deferred watermark** (`put()` + a unified commit hook). I folded the existing `aftercommit` block into a single per-transaction `onCommit` that does both the emit *and* the watermark advance, so the watermark rises only on a durable commit — an aborted/discarded entry must not raise it and suppress a later entry's flag. This store is the sole setter of `transaction.onCommit`. Please confirm the `aftercommit` semantics read as preserved (the resources suite, incl. `auditLog.test.js`, passes).
- **Keyed by `(log, tableId)`, not per-log.** A per-node log interleaves tables while `structureVersion` is per-table; a log-wide watermark would let a high-version table suppress another table's first use of a new structure. (Caught in review.)
- **`Uint8Array` entry branch is intentionally not re-derived** — pre-encoded entries already carry the correct flag; re-deriving would break cross-node byte parity.
- **In-memory watermark** resets to 0 on restart → at most one redundant, idempotent structure resend per `(log, table)`; never an under-flag.
- **Same-count `ascii8→string8` promotion is deliberately not flagged** — it is decode-equivalent (ASCII bytes are valid UTF-8 and both types decode via the same `readString` path in `structon`), so it needs no resend. New structures (count increases) are the only decode-relevant change.

## Validation
- New unit tests (`transactionLogStructureUpdate.test.js`): monotonic flagging, per-log independence, per-`(log,table)` independence, commit-deferred/abort-safety, flag preservation. `test:unit:resources` green.
- End-to-end replication recovery is best confirmed by the harper-pro cluster integration tests — flagging that as the place to validate the full path, since this PR is core-only.

Generated by Claude (Opus 4.8). Cross-model reviewed (Codex + Gemini); the two findings they raised (per-table keying, commit-deferral) are addressed in the diff.
