### PR TITLE
fix(headers): group multi-valued Set-Cookie for writeHead

### DIFF
--- a/server/serverHelpers/Headers.ts
+++ b/server/serverHelpers/Headers.ts
@@ -115,10 +115,23 @@ export function mergeHeaders(target: any, source: Headers) {
  * `writeHead`'s array form is a FLAT `[name, value, name, value]` list, not a list of tuples — so an
  * iterable of `[name, value]` pairs (a `Headers`/`Map`) must be turned into an object. Passing
  * `Array.from(headers)` (nested `[[name, value], …]`) makes Node read a tuple as a header name and throw
- * `TypeError: The "name" argument must be of type string. Received an instance of Array`. A plain object
- * (or a falsy value, e.g. when there are no headers) is returned unchanged.
+ * `TypeError: The "name" argument must be of type string. Received an instance of Array`.
+ *
+ * Multi-valued headers (notably `Set-Cookie`, which by spec retains its multiple values when iterating
+ * a `Headers` object instead of being comma-joined) must be grouped into arrays rather than collapsed
+ * via `Object.fromEntries` last-wins. `writeHead` accepts `{name: ['value1', 'value2']}` for that, and
+ * emits the values as separate header lines on the wire. A plain object (or a falsy value, e.g. when
+ * there are no headers) is returned unchanged.
  */
 export function toWriteHeadHeaders(headers: any): any {
 	if (!headers) return headers;
-	return headers[Symbol.iterator] ? Object.fromEntries(headers) : headers;
+	if (!headers[Symbol.iterator]) return headers;
+	const result: Record<string, string | string[]> = {};
+	for (const [name, value] of headers) {
+		const existing = result[name];
+		if (existing === undefined) result[name] = value;
+		else if (Array.isArray(existing)) existing.push(value);
+		else result[name] = [existing, value];
+	}
+	return result;
 }

--- a/unitTests/server/serverHelpers/Headers.test.js
+++ b/unitTests/server/serverHelpers/Headers.test.js
@@ -380,6 +380,43 @@ describe('toWriteHeadHeaders', () => {
 		assert.deepEqual(toWriteHeadHeaders(headers), { 'X-A': '1' });
 	});
 
+	it('groups multi-valued headers (Set-Cookie) into arrays rather than last-wins', () => {
+		// Headers iteration yields one entry per Set-Cookie value. Object.fromEntries collapses
+		// duplicate keys last-wins, which broke `mergeHeaders preserves multiple Set-Cookie headers`.
+		const headers = new Headers();
+		headers.append('Set-Cookie', 'hdb-session=mock-session-id; Path=/; HttpOnly');
+		headers.append('Set-Cookie', 'hdb-tracking=track123; Path=/; HttpOnly');
+		headers.append('Set-Cookie', 'app-cookie1=value1; Path=/; HttpOnly');
+		const out = toWriteHeadHeaders(headers);
+		assert.ok(Array.isArray(out['Set-Cookie']), 'Set-Cookie value should be an array');
+		assert.equal(out['Set-Cookie'].length, 3, `expected 3 Set-Cookie values, got ${out['Set-Cookie']?.length}`);
+	});
+
+	it('Set-Cookie array reaches the wire as separate header lines (round-trip)', async () => {
+		// What the failing integration tests assert: every cookie shows up as its own header line.
+		const http = require('node:http');
+		const headers = new Headers();
+		headers.append('Set-Cookie', 'a=1; Path=/');
+		headers.append('Set-Cookie', 'b=2; Path=/');
+		headers.append('Set-Cookie', 'c=3; Path=/');
+		const server = http.createServer((req, res) => {
+			res.writeHead(200, toWriteHeadHeaders(headers));
+			res.end('ok');
+		});
+		try {
+			await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+			const { port } = server.address();
+			const res = await fetch(`http://127.0.0.1:${port}/`);
+			const setCookies = res.headers.getSetCookie();
+			assert.equal(setCookies.length, 3, `expected 3 Set-Cookie lines on the wire, got ${setCookies.length}`);
+			assert.ok(setCookies.some((c) => c.includes('a=1')));
+			assert.ok(setCookies.some((c) => c.includes('b=2')));
+			assert.ok(setCookies.some((c) => c.includes('c=3')));
+		} finally {
+			await new Promise((resolve) => server.close(resolve));
+		}
+	});
+
 	it("its output is accepted by a live response's writeHead (round-trip)", async () => {
 		const http = require('node:http');
 		const headers = new Headers();


### PR DESCRIPTION
`toWriteHeadHeaders` (introduced in fc5e5f3 / PR #1344) used `Object.fromEntries` to convert iterable Headers into a writeHead-compatible object, but `Object.fromEntries` is last-wins on duplicate keys. The Headers iterator yields one `[name, value]` pair per Set-Cookie value (per spec), so three appended Set-Cookies collapsed to one on the wire — which is what's failing in `integrationTests/apiTests/headers.test.mjs` (`mergeHeaders preserves multiple Set-Cookie headers`: expected 5, got 1). Replaced the shortcut with an explicit loop that groups duplicate keys into arrays, which `writeHead` already accepts (`{name: ['v1', 'v2']}` → separate header lines). Two unit tests added in `Headers.test.js` cover the grouping and the round-trip through a real `http.createServer`.