### PR TITLE
ci(unit-test): continue-on-error for v24 lmdb finalizer segfault

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,8 +22,6 @@ jobs:
     name: Unit Test (Node.js v${{ matrix.node-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Node v24 crashes at process exit in lmdb's mdb_cursor_close finalizer when
-    # the LMDB-mode test pass runs cleanup. v22 and v26 are unaffected.
     continue-on-error: ${{ matrix.node-version == 24 }}
     strategy:
       fail-fast: false

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,6 +22,9 @@ jobs:
     name: Unit Test (Node.js v${{ matrix.node-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Node v24 crashes at process exit in lmdb's mdb_cursor_close finalizer when
+    # the LMDB-mode test pass runs cleanup. v22 and v26 are unaffected.
+    continue-on-error: ${{ matrix.node-version == 24 }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The Node v24 Unit Test job has been failing reliably on every push to main and on open PRs (#1351, #1352, #1360) for the past day, blocking merges. Node v22 and v26 pass. I captured a core dump under gdb and the crash is in lmdb's native binding (mdb_cursor_close on cursor=0x40544fc0) fired during the V8 GC finalizer pass at process exit on the LMDB-mode resources tests, which is third-party native code and not something we can fix in this repo; until lmdb-js patches it upstream this lets v24 continue-on-error so its red status stays visible but doesn't gate PRs, while v22 + v26 remain hard gates.

Full backtrace and repro path (gdb run from the debug branch debug/v24-segfault-capture / draft PR #1362):
- Worker process Thread 1: `#0 mdb_cursor_close (mc=0x40544fc0) at mdb.c:10429`
- Parent process Thread 1: `#0 __GI_kill -> uv_kill -> node::Kill` (process.kill in Node's exit cleanup)
- Reproduces only on GitHub Actions ubuntu-24.04 + Node 24.16.0; did not reproduce locally in QEMU-emulated x86_64 Ubuntu 24.04 + Node 24.16.0