### PR TITLE
debug(test): capture JS stack on v24 segfault

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install dependencies
         run: npm install --ignore-scripts
 
+      - name: Build segfault-handler binding (debug helper)
+        run: npm rebuild segfault-handler || true
+
       - name: Build
         run: npm run build || true # we currently have type errors so just ignore that
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -55,4 +55,19 @@ jobs:
         run: node --enable-source-maps ./dist/bin/harper.js install
 
       - name: Run tests
+        env:
+          HARPER_TEST_SEGFAULT_CAPTURE: /tmp/segfault-crash.log
         run: npm run test:unit:all
+
+      - name: Upload segfault log
+        if: failure() && matrix.node-version == 24
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: segfault-log-node${{ matrix.node-version }}
+          path: /tmp/segfault-crash.log
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Dump segfault log inline
+        if: failure() && matrix.node-version == 24
+        run: cat /tmp/segfault-crash.log 2>/dev/null || echo "(no crash log)"

--- a/unitTests/mocha.init.js
+++ b/unitTests/mocha.init.js
@@ -20,6 +20,17 @@ const fs = require('fs-extra');
 const env = require('#src/utility/environment/environmentManager');
 const terms = require('#src/utility/hdbTerms');
 
+if (process.env.HARPER_TEST_SEGFAULT_CAPTURE) {
+	try {
+		const SegfaultHandler = require('segfault-handler');
+		const crashLog = process.env.HARPER_TEST_SEGFAULT_CAPTURE;
+		SegfaultHandler.registerHandler(crashLog);
+		console.log(`[mocha.init] segfault-handler registered, dumping to ${crashLog}`);
+	} catch (e) {
+		console.error('[mocha.init] failed to register segfault-handler:', e.message);
+	}
+}
+
 const isApiTestRun = process.argv.some((arg) => typeof arg === 'string' && arg.includes('apiTests'));
 
 if (!isApiTestRun) {


### PR DESCRIPTION
Wires segfault-handler into mocha.init.js (gated on HARPER_TEST_SEGFAULT_CAPTURE env var) so when the Node v24 LMDB-pass mdb_cursor_close finalizer crashes, we get a JS stack pointing at the actual leaking cursor. Not for merge.