### PR TITLE
fix(test): drain orphaned lmdb cursor wrappers after Read Txn Expiration

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -5,7 +5,7 @@
 	"recursive": true,
 	"enable-source-maps": true,
 	"exclude": ["unitTests/security/jsLoader/fixtures/**"],
-	"node-option": ["expose-internals", "enable-source-maps", "experimental-vm-modules"],
+	"node-option": ["expose-internals", "enable-source-maps", "experimental-vm-modules", "expose-gc"],
 	"require": ["unitTests/mocha.init.js"],
 	"exit": true
 }

--- a/unitTests/resources/txn-tracking.test.js
+++ b/unitTests/resources/txn-tracking.test.js
@@ -121,7 +121,15 @@ describe('Read Txn Expiration', () => {
 		assert.equal(result.name, 'two');
 	});
 
-	after(function () {
+	after(async function () {
 		setReadTxnExpiration(300000);
+		// On Node v24 the V8 exit-time finalizer order can call mdb_cursor_close on a cursor
+		// whose txn was force-aborted by checkReadTxnTimeouts above. Drain in-flight ops and
+		// reap orphaned cursor wrappers now, while the env is still in a stable state.
+		await new Promise((r) => setImmediate(r));
+		if (typeof global.gc === 'function') {
+			global.gc();
+			await new Promise((r) => setImmediate(r));
+		}
 	});
 });


### PR DESCRIPTION
The Node v24 Unit Test job has been intermittently segfaulting (~50% hit rate) in the LMDB-mode resources test pass, blocking PRs #1351 and #1352. A gdb backtrace from a core dump showed the crash is inside lmdb's `mdb_cursor_close` at process exit, called by V8's exit-time finalizer pass — lmdb-js's own source warns about this in [read.js:706](https://github.com/kriszyp/lmdb-js/blob/master/read.js#L706): "this must be closed before the transaction is aborted or it can cause a segmentation fault."

The trigger is the `Read Txn Expiration` suite in `unitTests/resources/txn-tracking.test.js`, which is LMDB-only (skips under RocksDB at the before-hook) and deliberately calls `checkReadTxnTimeouts()` to force-end in-flight read transactions. On Node v24 the exit-time finalizer order then runs `mdb_cursor_close` on a cursor wrapper whose txn was already aborted, hitting freed native memory — SIGSEGV.

This adds an explicit drain + `global.gc()` in the suite's `after()` block so orphaned cursor wrappers are reaped at the end of the suite, while the env is still healthy, rather than at process exit. Adds `--expose-gc` to mocharc so the GC call is available.

Verified by running the v24 Unit Test job 4 times in a row on this branch (1 initial + 3 reruns): 4/4 pass. Against the prior ~50% per-run failure rate the probability of 4 consecutive passes by luck is ~6%, so the fix is doing something.

This is a targeted mitigation; the underlying lmdb-js cursor-vs-txn lifecycle hazard remains and should be reported upstream.