### PR TITLE
fix(blob): gate blob unlink on the delete/update committing (#1364)

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -879,11 +879,29 @@ export function setAdditionalAuditRefs(refs: Array<{ version: number; nodeId: nu
 }
 export function removeEntry(store: any, entry: any, options?: any) {
 	if (!entry) return;
+	const removal = store.remove(entry.key, options);
 	if (entry.value && entry.metadataFlags & HAS_BLOBS) {
-		// if it used to have blobs, we need to delete the old blobs
-		deleteBlobsInObject(entry.value);
+		// Delete the old blobs only once the removal commits. Scheduling the unlink up front
+		// (as before) orphaned the blob when the removal didn't actually land — an expiration
+		// scan whose transaction is force-committed without this delete, or an aborted/version-
+		// conflicted removal — leaving a record that references a now-missing blob and wedges
+		// replication on ENOENT. The removal promise resolves when the write commits (false on
+		// a conditional-version miss; rejects on abort), so gate the unlink on it. See #1364.
+		const deleteOldBlobs = () => deleteBlobsInObject(entry.value);
+		if (removal && typeof removal.then === 'function') {
+			// Swallow rejections (aborted removal) — leave the blob in place in that case.
+			removal.then(
+				(committed: any) => {
+					if (committed !== false) deleteOldBlobs();
+				},
+				() => {}
+			);
+		} else {
+			// Synchronous (already-durable) removal: delete immediately.
+			deleteOldBlobs();
+		}
 	}
-	return store.remove(entry.key, options);
+	return removal;
 }
 export interface RecordObject {
 	getUpdatedTime(): number;

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -2,6 +2,7 @@ require('../testUtils');
 const assert = require('assert');
 const { setupTestDBPath } = require('../testUtils');
 const { table, getDatabases } = require('#src/resources/databases');
+const { removeEntry } = require('#src/resources/RecordEncoder');
 const { Readable, PassThrough } = require('node:stream');
 const { setAuditRetention } = require('#src/resources/auditStore');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
@@ -284,6 +285,40 @@ describe('Blob test', () => {
 		await waitFor(() => !existsSync(filePath), {
 			message: 'blob file should be unlinked when the new record no longer references it',
 		});
+		setDeletionDelay(500); // restore the default
+	});
+	it('blob unlink is gated on the removal committing (#1364)', async () => {
+		// removeEntry must only unlink the old blobs once the record removal commits. An
+		// expiration scan whose transaction is force-committed without the delete (or an
+		// aborted/version-conflicted removal) leaves the record in place; unlinking its blobs
+		// regardless would orphan the reference and wedge replication on ENOENT.
+		setDeletionDelay(0);
+		const realStore = BlobTest.primaryStore;
+		const blob = await createBlob(randomBytes(20000)); // > FILE_STORAGE_THRESHOLD → file-backed
+		await BlobTest.put({ id: 720, blob });
+		const filePath = getFilePathForBlob(blob);
+		assert(filePath, 'expected file-backed blob');
+		assert(existsSync(filePath), 'blob file should exist after put');
+
+		// Fetch a real entry (value + metadataFlags) the way the eviction scan does.
+		let entry;
+		for (const e of realStore.getRange({ start: 720, end: 721, versions: true })) {
+			if (e.key === 720) entry = e;
+		}
+		assert(entry && entry.value, 'expected a real entry carrying the blob');
+
+		// Removal that never commits (rejects): the blob must be preserved.
+		removeEntry({ remove: () => Promise.reject(new Error('aborted')) }, entry, undefined);
+		await delay(40);
+		assert(existsSync(filePath), 'blob must survive when the removal does not commit (#1364)');
+
+		// Removal that commits: the blob is unlinked.
+		removeEntry({ remove: () => Promise.resolve(true) }, entry, undefined);
+		await waitFor(() => !existsSync(filePath), {
+			message: 'blob should be unlinked once the removal commits',
+		});
+
+		await BlobTest.delete(720); // cleanup the real record (its blob file is already gone)
 		setDeletionDelay(500); // restore the default
 	});
 	it('slowly create a blob and save it before it is done', async () => {


### PR DESCRIPTION
Fixes #1364.

## Summary

`removeEntry` deleted a record's blob files up front, before (and independent of) the record removal actually committing. The fix defers the blob deletion until the removal's commit promise resolves, so the unlink only happens once the delete is durable.

## Purpose

Second of the two orphan-producing paths in the JJill preprod replication incident. When the Cache expiration scan's transaction is force-committed without a given delete — or any removal aborts/version-conflicts — the record survives while its blob files are unlinked. That orphaned **reference** makes a later copy/replication stream hit `sendBlob()` ENOENT and stall permanently. (Receiver-side tolerance for a missing blob is #1353; this stops the orphan being created.)

## Approach

`store.remove()` returns a promise that resolves when the write commits (truthy on commit, `false` on a conditional-version miss) and rejects on abort — the same promise the eviction scan already awaits. So `removeEntry` now schedules the blob unlink only after that promise resolves committed, and skips it otherwise. Falls back to immediate deletion when `remove()` is synchronous (already durable).

This can only ever *skip* an unlink, never lose data; a skipped unlink leaves a reclaimable orphaned file (swept by `cleanupOrphans`).

## Where to look

- `resources/RecordEncoder.ts` — `removeEntry`. This is the whole change. It works for both the LMDB and RocksDB eviction paths because the removal is queued into the transaction that `evict()` later commits, so its promise resolves at that commit — no change to `evict()` itself.

## Notes

- No collision with #1353 (receiver-side pre-commit) or #1361 (`Table.ts` `evict()` error-handling) — different layers/functions.
- Earlier iterations of this PR tried a post-delay re-read of the record (`getEntry` re-check). That was abandoned: it raced the commit (skipping legitimate unlinks under load) and a deferred `getEntry` could fire on a closed store and segfault. Gating on the commit promise avoids both. History squashed.
- Cross-model review: Codex flagged the re-check's commit race (P2) — which is exactly why this version gates on the commit promise instead. The Gemini (`agy`) leg hung with no output — no second outside-model coverage from Gemini.
- Patch-release candidate per #1364 discussion.

🤖 Generated by Claude (Opus 4.8, 1M context).
