### PR TITLE
fix(databases): complete the dead restartNumber reindex-recovery trigger

### DIFF
--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1287,12 +1287,20 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 				JSON.stringify(stripSearchOnly(attributeDescriptor?.indexed)) !==
 					JSON.stringify(stripSearchOnly(attribute.indexed));
 			if (attribute.indexed) {
+				// The restart generation that owns any in-progress build of this index. Use the
+				// worker's stable startup generation (workerData.restartNumber), NOT the mutable
+				// manageThreads counter: during a worker's shutdown/drain the global counter has
+				// already advanced to the replacement generation, so stamping that would make the
+				// replacement worker see an equal generation (and a possibly-reused PID) and skip
+				// crash-recovery, leaving the index stuck. Falls back to manageThreads.restartNumber
+				// on the main thread, where workerData is undefined (and it is initialized to 1).
+				const currentRestartGeneration = workerData?.restartNumber ?? manageThreads.restartNumber;
 				const dbi = openIndex(dbiKey, rootStore, attribute);
 				if (
 					changed ||
 					attributeDescriptor?.indexingFailed ||
 					(attributeDescriptor?.indexingPID && attributeDescriptor?.indexingPID !== process.pid) ||
-					attributeDescriptor?.restartNumber < workerData?.restartNumber
+					attributeDescriptor?.restartNumber < currentRestartGeneration
 				) {
 					hasChanges = true;
 					exclusiveLock();
@@ -1301,7 +1309,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 						structurallyChanged ||
 						attributeDescriptor?.indexingFailed ||
 						(attributeDescriptor?.indexingPID && attributeDescriptor?.indexingPID !== process.pid) ||
-						attributeDescriptor?.restartNumber < workerData?.restartNumber
+						attributeDescriptor?.restartNumber < currentRestartGeneration
 					) {
 						hasChanges = true;
 						if (attribute.indexNulls === undefined) attribute.indexNulls = true;
@@ -1325,6 +1333,11 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 								? undefined
 								: (attributeDescriptor?.lastIndexedKey ?? undefined);
 							attribute.indexingPID = process.pid;
+							// Persist the owning restart generation (see currentRestartGeneration above) so
+							// the trigger can re-detect an incomplete index after a worker restart even when
+							// the new process reuses the old PID. Cleared on clean completion; left in place
+							// on failure/crash so the next, higher-numbered restart re-triggers the backfill.
+							attribute.restartNumber = currentRestartGeneration;
 							delete attribute.indexingFailed; // clear failure flag for the new run
 							dbi.isIndexing = true;
 							Object.defineProperty(attribute, 'dbi', { value: dbi, configurable: true, enumerable: false });
@@ -1338,6 +1351,9 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 						// workers / a reload would treat the still-partial index as ready and return incomplete results.
 						attribute.indexingPID = attributeDescriptor.indexingPID;
 						attribute.lastIndexedKey = attributeDescriptor.lastIndexedKey;
+						// Carry the in-progress restart generation too, so persisting this metadata-only
+						// change doesn't drop it and break the crash-recovery trigger for the running backfill.
+						attribute.restartNumber = attributeDescriptor.restartNumber;
 						if (attributeDescriptor.indexingFailed) attribute.indexingFailed = attributeDescriptor.indexingFailed;
 					}
 					attributesDbi.put(dbiKey, attribute);
@@ -1557,6 +1573,7 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 				delete attribute.lastIndexedKey;
 				delete attribute.indexingPID;
 				delete attribute.indexingFailed;
+				delete attribute.restartNumber;
 				attribute.dbi.isIndexing = false;
 				// Also clear isIndexing on the currently-active dbi in Table.indices, which may
 				// differ from attribute.dbi if a resetDatabases() call during this migration

--- a/unitTests/resources/indexRestartNumber.test.js
+++ b/unitTests/resources/indexRestartNumber.test.js
@@ -1,0 +1,209 @@
+/**
+ * Regression coverage for the previously-dead `restartNumber` reindex trigger in
+ * resources/databases.ts (issue #1359).
+ *
+ * table() re-triggers an index backfill when the persisted attribute descriptor's
+ * `restartNumber` is older than the current restart generation
+ * (`attributeDescriptor.restartNumber < manageThreads.restartNumber`). This is the
+ * PID-reuse-robust crash detector: if a worker dies mid-index and the replacement
+ * worker happens to reuse the old PID, the `indexingPID !== process.pid` check can't
+ * tell them apart, but the monotonically-increasing restart generation can.
+ *
+ * Before this fix `restartNumber` was never persisted onto the descriptor, so the
+ * comparison was always `undefined < N` (false) and the trigger never fired. These
+ * tests assert the value is now (a) persisted while indexing is incomplete, (b)
+ * cleared on clean completion, and (c) actually drives a re-trigger.
+ */
+require('../testUtils');
+const assert = require('node:assert/strict');
+const { setupTestDBPath } = require('../testUtils');
+const { table, resetDatabases } = require('#src/resources/databases');
+const manageThreads = require('#js/server/threads/manageThreads');
+const { setMainIsWorker } = manageThreads;
+
+async function collect(iter) {
+	const out = [];
+	for await (const x of iter) out.push(x);
+	return out;
+}
+
+// The per-attribute descriptor is persisted in Table.dbisDB keyed by the attribute's
+// internal key; find it by name rather than reconstructing the key format.
+function findDescriptor(Tbl, attrName) {
+	for (const { key, value } of Tbl.dbisDB.getRange({ start: false })) {
+		if (value && value.name === attrName) return { key, value };
+	}
+	return null;
+}
+
+describe('indexing crash-recovery: restartNumber re-trigger (#1359)', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+
+	const DB = 'test';
+	const N = 20;
+	let savedRestart;
+
+	beforeEach(() => {
+		savedRestart = manageThreads.restartNumber;
+	});
+	afterEach(() => {
+		manageThreads.restartNumber = savedRestart;
+	});
+
+	it('persists restartNumber on an incomplete (parked) index and clears it after a clean run', async () => {
+		const TABLE = 'RN_SetThenClear';
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) last = Tbl.put({ id: 'k-' + i, tag: i % 2 ? 'odd' : 'even' });
+		await last;
+
+		// Add @indexed and force the backfill to PARK by rejecting some index puts with a permanent
+		// (non-retryable) error. The park path preserves the in-progress markers, so the descriptor
+		// should retain restartNumber set to the current generation.
+		resetDatabases();
+		Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		const tagIndex = Tbl.indices?.tag;
+		if (tagIndex && typeof tagIndex.put === 'function') {
+			const origPut = tagIndex.put.bind(tagIndex);
+			let opCount = 0;
+			tagIndex.put = function (indexedValue, primaryKey, options) {
+				if (++opCount % 7 === 0) return Promise.reject(new Error('simulated permanent index put failure'));
+				return origPut(indexedValue, primaryKey, options);
+			};
+		}
+		if (Tbl.indexingOperation) await Tbl.indexingOperation;
+
+		const parked = findDescriptor(Tbl, 'tag');
+		assert.ok(parked, 'tag descriptor should exist after a parked backfill');
+		assert.equal(parked.value.indexingFailed, true, 'a parked index should be marked indexingFailed');
+		assert.equal(
+			parked.value.restartNumber,
+			manageThreads.restartNumber,
+			'restartNumber must be persisted (== current generation) while the index is incomplete'
+		);
+
+		// Simulate a clean restart: re-open without the failing mock. indexingFailed re-triggers the
+		// backfill, which now completes cleanly and must CLEAR restartNumber.
+		resetDatabases();
+		const Tbl2 = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		assert.ok(Tbl2.indexingOperation, 'parked index should re-trigger on restart');
+		await Tbl2.indexingOperation;
+
+		const done = findDescriptor(Tbl2, 'tag');
+		assert.equal(done.value.restartNumber, undefined, 'restartNumber must be cleared after a clean completion');
+		assert.equal(done.value.indexingFailed, undefined, 'indexingFailed must be cleared after a clean completion');
+		const evens = await collect(Tbl2.search({ conditions: [{ attribute: 'tag', value: 'even' }] }));
+		assert.equal(evens.length, N / 2, 'all rows should be indexed after the clean re-run');
+	});
+
+	it('re-triggers a backfill when persisted restartNumber is older than the current generation (and not when equal)', async () => {
+		const TABLE = 'RN_Retrigger';
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) last = Tbl.put({ id: 'r-' + i, tag: 'v-' + (i % 3) });
+		await last;
+
+		resetDatabases();
+		Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		const buildOp = Tbl.indexingOperation;
+		if (buildOp) await buildOp;
+
+		// Simulate an index whose descriptor was last written by an OLDER restart generation, with no
+		// other trigger flags set, so restartNumber is the ONLY thing that can re-trigger. A re-trigger
+		// is detected by table() installing a NEW indexingOperation promise (the promise carries across
+		// resetDatabases, so identity — not truthiness — is the reliable signal; cf. the F1 test).
+		const oldGen = manageThreads.restartNumber;
+		const desc = findDescriptor(Tbl, 'tag');
+		assert.ok(desc, 'tag descriptor should exist');
+		desc.value.restartNumber = oldGen;
+		delete desc.value.indexingFailed;
+		delete desc.value.indexingPID;
+		Tbl.dbisDB.putSync(desc.key, desc.value);
+
+		// Control: current generation == persisted generation -> NO re-trigger (same promise).
+		manageThreads.restartNumber = oldGen;
+		resetDatabases();
+		const TblSame = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		assert.equal(
+			TblSame.indexingOperation,
+			buildOp,
+			'must NOT re-trigger when persisted restartNumber equals the current generation'
+		);
+
+		// Re-assert the stale descriptor (the no-trigger path above does not rewrite it) and advance the
+		// restart generation: persisted(oldGen) < current -> re-trigger (a new indexingOperation promise).
+		const desc2 = findDescriptor(TblSame, 'tag');
+		desc2.value.restartNumber = oldGen;
+		delete desc2.value.indexingFailed;
+		delete desc2.value.indexingPID;
+		TblSame.dbisDB.putSync(desc2.key, desc2.value);
+
+		manageThreads.restartNumber = oldGen + 1;
+		resetDatabases();
+		const TblNewGen = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		assert.notEqual(
+			TblNewGen.indexingOperation,
+			buildOp,
+			'must re-trigger (new indexingOperation) when persisted restartNumber is older than the current generation'
+		);
+		assert.ok(TblNewGen.indexingOperation, 're-trigger should install an indexingOperation');
+		await TblNewGen.indexingOperation;
+
+		const after = findDescriptor(TblNewGen, 'tag');
+		assert.equal(after.value.restartNumber, undefined, 'restartNumber cleared after the re-run completes');
+		let total = 0;
+		for (const v of ['v-0', 'v-1', 'v-2']) {
+			total += (await collect(TblNewGen.search({ conditions: [{ attribute: 'tag', value: v }] }))).length;
+		}
+		assert.equal(total, N, 'all rows should be indexed after the restartNumber-triggered re-run');
+	});
+});


### PR DESCRIPTION
## Summary

`table()` re-triggers a secondary-index backfill when the persisted attribute descriptor's `restartNumber` is older than the current restart generation. This is the PID-reuse-robust complement to the `indexingPID` check: it recovers an index left incomplete by a worker that crashed mid-backfill, even when the replacement worker reuses the old PID. The bug: `restartNumber` was never persisted onto the descriptor, so the comparison was always `undefined < N` (false) and the trigger was dead.

This persists `restartNumber` symmetrically with `indexingPID` — set on backfill start, carried across metadata-only changes during an in-progress build, cleared on clean completion (retained on park/crash).

Resolves #1359 (part of #1354).

## Where to look

- `resources/databases.ts` — `table()` (set/carry + the two trigger sites) and `runIndexing()` (clear on clean completion).
- **Operand decision (worth a look):** the trigger compares against `workerData?.restartNumber ?? manageThreads.restartNumber` — the owning worker's *stable startup* generation, falling back to the maintained `manageThreads` counter on the main thread. Cross-model review (Codex) flagged that stamping the *mutable* `manageThreads.restartNumber` is wrong during a worker's shutdown/drain window: the global counter has already advanced to the replacement generation, so an index built then would be stamped with the replacement's generation and the replacement worker would see an equal generation (+ a possibly-reused PID) and never recover it. Using the spawn generation avoids that.

## Back-compat

Existing descriptors have no persisted `restartNumber` → `undefined < N` is `false`, so upgrading does not trigger a reindex storm. On the main thread the generation is `1`, so `1 < 1` is `false` (inert until an actual restart bumps the counter).

## Tests

`unitTests/resources/indexRestartNumber.test.js` (RocksDB-only): (1) `restartNumber` is persisted on a parked/incomplete index and cleared after a clean completion; (2) a backfill re-triggers when the persisted generation is older than the current one, and not when equal. Re-trigger is asserted via `indexingOperation` promise identity (the promise carries across `resetDatabases`, so truthiness is unreliable — mirrors the existing F1 test).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8)
