### PR TITLE
fix(blob): don't await already-saving replication blobs in preCommit.complete()

### DIFF
--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -1032,6 +1032,14 @@ export function startPreCommitBlobsForRecord(
 	trackPersistedBlobs?: boolean
 ): PreCommitBlobs | undefined {
 	const blobsNeedingSaving: Blob[] = [];
+	// Already-saving blobs tracked for cleanup only — NOT awaited in complete(). Their durability is
+	// already tracked by outstandingBlobsToFinish in replicationConnection.ts. Awaiting them here would
+	// block the commit on blob I/O; if the WS is paused for commit-backlog back-pressure, any
+	// partially-received blob stream that can't get more chunks until ws.resume() would time out — the
+	// commit would then fail, preventing onCommit() from decrementing outstandingCommits, permanently
+	// locking the WS (deadlock). Track-only keeps the skip/abort cleanup from harper-pro#406 without
+	// introducing this commit-path dependency. (harper-pro#414)
+	const blobsToTrackOnly: Blob[] = [];
 	for (const key in record) {
 		const value = record[key];
 		// Track a file-backed blob on the write when it still needs saving before commit (the local-write
@@ -1046,23 +1054,28 @@ export function startPreCommitBlobsForRecord(
 		// Already-saved blobs are not re-saved (saveBlob early-returns on an existing fileId); the
 		// retained-fileId guard in cleanupUnusedBlobs additionally protects any blob the committed record
 		// still references.
-		if (
-			value instanceof FileBackedBlob &&
-			(saveInRecord || value.saveBeforeCommit || (trackPersistedBlobs && storageInfoForBlob.get(value)?.fileId != null))
-		) {
-			currentStore = store;
-			if (saveInRecord) {
-				value.saveInRecord = true;
+		if (value instanceof FileBackedBlob) {
+			if (saveInRecord || value.saveBeforeCommit) {
+				currentStore = store;
+				if (saveInRecord) {
+					value.saveInRecord = true;
+				}
+				blobsNeedingSaving.push(value);
+			} else if (trackPersistedBlobs && storageInfoForBlob.get(value)?.fileId != null) {
+				blobsToTrackOnly.push(value);
 			}
-			blobsNeedingSaving.push(value);
 		}
 	}
-	if (blobsNeedingSaving.length > 0) {
+	const allTrackedBlobs = blobsNeedingSaving.concat(blobsToTrackOnly);
+	if (allTrackedBlobs.length > 0) {
 		// we do have blobs, start saving once complete() is called
 		return {
-			blobs: blobsNeedingSaving,
+			blobs: allTrackedBlobs,
 			complete: () => {
 				currentStore = store;
+				// Only await blobs that need saving before commit (saveInRecord / saveBeforeCommit path).
+				// Already-saving blobs (blobsToTrackOnly) are skipped here — their durability is tracked
+				// separately by outstandingBlobsToFinish; blocking the commit on them causes deadlock.
 				return Promise.all(
 					blobsNeedingSaving.map((blob) => {
 						return saveBlob(blob as any, true).saving ?? Promise.resolve();


### PR DESCRIPTION
## Summary

- `#1341` added `trackPersistedBlobs` to `startPreCommitBlobsForRecord`, which tracks already-saving out-of-band blobs (saved by `receiveBlobs` in replicationConnection.ts before the record apply runs) so they can be unlinked on skip/abort (orphan-blob cleanup, harper-pro#406).
- The same blobs were added to `blobsNeedingSaving`, so `complete()` awaited their in-flight `saving` promises **before the commit ran**. This blocks the commit on file I/O for every replication-received record that has a large blob.
- Under backlog-recovery catch-up (many records arriving quickly), `outstandingCommits` can exceed `MAX_OUTSTANDING_COMMITS` (150), causing `ws.pause()`. Blob streams that haven't received all their chunks (still in kernel/WS buffers) can't get more data while the WS is paused. After `blobTimeout` (120 s) they time out → `hasBlobGap = true` → `complete()` rejects → commit fails → `onCommit()` never fires → `outstandingCommits` never decrements → **WS permanently paused**.

## Fix

Split `startPreCommitBlobsForRecord` into two lists:
- **`blobsNeedingSaving`** — blobs that genuinely need saving before commit (`saveInRecord` / `saveBeforeCommit` path). Awaited in `complete()` as before.
- **`blobsToTrackOnly`** — already-saving (`fileId` set, `trackPersistedBlobs` path). Added to `write.savedBlobs` for skip/abort cleanup but **not awaited** in `complete()`.

Their durability is already tracked by `outstandingBlobsToFinish` / `lastDurableSequenceId` in replicationConnection.ts — the commit-level await was redundant and created the deadlock.

The orphan-blob cleanup from `#1341` is fully preserved: both lists end up in `write.savedBlobs` via `allTrackedBlobs`.

## Test plan

- [ ] Run `backlogRecovery` stress test (`HARPER_RUN_STRESS_TESTS=1 HARPER_STRESS_BACKLOG_OFFLINE_MINUTES=5`) — B should converge from 60 → 800 without stalling at ~315.
- [ ] Run `blobSaveRejectionContainment` and `blobGapDeadlock` cluster tests — orphan-blob cleanup must still fire on skip/abort (verify zero orphan markers).
- [ ] Existing blob unit tests in `unitTests/resources/blob.test.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)