### PR TITLE
ci: run Next.js adapter integration suite against harper PRs (downstream gate)

### DIFF
--- a/.github/workflows/integration-tests-nextjs.yml
+++ b/.github/workflows/integration-tests-nextjs.yml
@@ -5,14 +5,13 @@ name: Next.js Integration Tests (downstream)
 # integration (HTTP server, REST, ISR/`use cache` backed by Harper tables) is
 # caught here rather than in the downstream adapter repo.
 #
-# It calls the reusable workflow in HarperFast/nextjs, passing this PR's head SHA
-# as `harper_ref`; the reusable workflow checks out + builds harper at that ref and
-# resolves it as the `harper` the test harness and fixtures run against.
+# It checks out HarperFast/nextjs explicitly, then checks out + builds harper at this
+# PR's head SHA and resolves that tarball as the `harper` used by the adapter's test
+# harness and fixtures.
 #
-# Advisory, non-blocking: this is pinned to the nextjs reusable-workflow fix from
-# HarperFast/nextjs#50. That revision explicitly checks out the adapter repository;
-# without it, workflow_call inherits this caller's checkout context and runs the
-# adapter's package scripts against harper instead.
+# Advisory, non-blocking: this deliberately tracks nextjs `main`, so a regression on
+# nextjs main against harper surfaces here instead of silently drifting. That means
+# this check's outcome depends on nextjs main's health, not just this PR's diff.
 
 on:
   pull_request:
@@ -56,9 +55,74 @@ jobs:
   # Heavy path: only when relevant files changed. Runs and reports informationally --
   # this is not wired to a required gate job, so it never blocks a harper merge.
   nextjs-integration:
-    name: Next.js adapter integration (against this PR's harper)
+    name: Next.js adapter integration (against this PR's harper) (Node ${{ matrix.node-version }})
     needs: changes
     if: needs.changes.outputs.relevant == 'true'
-    uses: HarperFast/nextjs/.github/workflows/integration-tests.yml@8b1e950dcb1835b24a09bf4ffc0670c1d0cf9fc5 # HarperFast/nextjs#50
-    with:
-      harper_ref: ${{ github.event.pull_request.head.sha }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22, 24]
+    steps:
+      - name: Checkout Next.js adapter
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: HarperFast/nextjs
+          ref: main
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install adapter dependencies
+        run: npm ci
+
+      - name: Checkout harper override
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: HarperFast/harper
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: harper-override
+
+      - name: Build and install harper override
+        run: |
+          cd "$GITHUB_WORKSPACE/harper-override"
+          npm ci
+          npm run build
+          TARBALL=$(npm pack --json | jq -r '.[0].filename')
+          mv "$TARBALL" /tmp/harper-override.tgz
+          cd "$GITHUB_WORKSPACE"
+          npm install --save-dev /tmp/harper-override.tgz
+
+      - name: Build adapter
+        run: npm run build
+
+      - name: Install fixture dependencies
+        run: npm run install:fixtures
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run integration tests
+        run: npm run test:integration
+        timeout-minutes: 15
+        env:
+          HARPER_INTEGRATION_TEST_LOG_DIR: /tmp/harper-test-logs
+          FORCE_COLOR: '1'
+
+      - name: Upload Harper logs on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: harper-logs-node-${{ matrix.node-version }}
+          path: /tmp/harper-test-logs/
+          retention-days: 7
+
+      - name: Upload Playwright traces on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: playwright-traces-node-${{ matrix.node-version }}
+          path: integrationTests/test-results/
+          retention-days: 7

--- a/.github/workflows/integration-tests-nextjs.yml
+++ b/.github/workflows/integration-tests-nextjs.yml
@@ -37,7 +37,7 @@ jobs:
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Check changed paths

--- a/.github/workflows/integration-tests-nextjs.yml
+++ b/.github/workflows/integration-tests-nextjs.yml
@@ -62,9 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Match harper's supported runtimes; its native storage bindings do not
-        # support Node 20 (package.json requires ^22.18 or >=24).
-        node-version: [22, 24, 26]
+        node-version: [20, 22, 24]
     steps:
       - name: Checkout Next.js adapter
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -87,6 +85,19 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           path: harper-override
 
+      # The adapter supports Node 20, but current harper and rocksdb-js require
+      # Node 22.18+. Keep the adapter test on Node 20 while building and spawning
+      # its harper child process with a supported runtime.
+      - name: Set up supported Harper runtime
+        if: matrix.node-version == 20
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Pin Harper runtime
+        if: matrix.node-version == 20
+        run: echo "HARPER_RUNTIME=$(command -v node)" >> "$GITHUB_ENV"
+
       - name: Build and install harper override
         run: |
           cd "$GITHUB_WORKSPACE/harper-override"
@@ -96,6 +107,12 @@ jobs:
           mv "$TARBALL" /tmp/harper-override.tgz
           cd "$GITHUB_WORKSPACE"
           npm install --save-dev /tmp/harper-override.tgz
+
+      - name: Restore adapter Node.js
+        if: matrix.node-version == 20
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Build adapter
         run: npm run build

--- a/.github/workflows/integration-tests-nextjs.yml
+++ b/.github/workflows/integration-tests-nextjs.yml
@@ -1,0 +1,39 @@
+name: Next.js Integration Tests (downstream)
+
+# Runs the @harperfast/nextjs adapter's Playwright integration suite against THIS
+# PR's harper build, so a harper change that breaks the Next.js framework-hosting
+# integration (HTTP server, REST, ISR/`use cache` backed by Harper tables) is
+# caught here rather than in the downstream adapter repo.
+#
+# It calls the reusable workflow in HarperFast/nextjs, passing this PR's head SHA
+# as `harper_ref`; the reusable workflow checks out + builds harper at that ref and
+# resolves it as the `harper` the test harness and fixtures run against.
+#
+# Scoped to PRs that touch the HTTP / cache / resource / server code paths the
+# adapter exercises (tune the paths filter as coverage evolves).
+#
+# ── BEFORE MERGE ───────────────────────────────────────────────────────────────
+#   1. Depends on HarperFast/nextjs#49 — the `workflow_call` + `harper_ref` input
+#      must be on nextjs `main` first, or this caller has nothing to call.
+#   2. Replace the mutable `@main` ref below with the 40-char merge-commit SHA of
+#      nextjs#49 (cross-repo reusable `uses:` should pin to a SHA, matching the
+#      convention in validate-caller-workflows.yml).
+
+on:
+  pull_request:
+    paths:
+      - 'cache/**'
+      - 'resources/**'
+      - 'server/**'
+      - 'dataLayer/**'
+      - 'components/**'
+      - 'config/**'
+      - 'package.json'
+      - 'package-lock.json'
+
+jobs:
+  nextjs-integration:
+    name: Next.js adapter integration (against this PR's harper)
+    uses: HarperFast/nextjs/.github/workflows/integration-tests.yml@main # TODO: pin to nextjs#49 merge SHA before merging
+    with:
+      harper_ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/integration-tests-nextjs.yml
+++ b/.github/workflows/integration-tests-nextjs.yml
@@ -9,20 +9,13 @@ name: Next.js Integration Tests (downstream)
 # as `harper_ref`; the reusable workflow checks out + builds harper at that ref and
 # resolves it as the `harper` the test harness and fixtures run against.
 #
-# Scoped to PRs that touch the HTTP / cache / resource / server code paths the
-# adapter exercises (tune the paths filter as coverage evolves).
-#
-# ── BEFORE MERGE ───────────────────────────────────────────────────────────────
-#   1. Depends on HarperFast/nextjs#49 — the `workflow_call` + `harper_ref` input
-#      must be on nextjs `main` first, or this caller has nothing to call.
-#   2. Replace the mutable `@main` ref below with the 40-char merge-commit SHA of
-#      nextjs#49 (cross-repo reusable `uses:` should pin to a SHA, matching the
-#      convention in validate-caller-workflows.yml).
+# Scoped to PRs that touch the HTTP / resource / server code paths the adapter
+# exercises (tune the paths filter as coverage evolves; caching lives under
+# resources/**, there's no separate top-level cache/ dir).
 
 on:
   pull_request:
     paths:
-      - 'cache/**'
       - 'resources/**'
       - 'server/**'
       - 'dataLayer/**'
@@ -31,9 +24,12 @@ on:
       - 'package.json'
       - 'package-lock.json'
 
+permissions:
+  contents: read
+
 jobs:
   nextjs-integration:
     name: Next.js adapter integration (against this PR's harper)
-    uses: HarperFast/nextjs/.github/workflows/integration-tests.yml@main # TODO: pin to nextjs#49 merge SHA before merging
+    uses: HarperFast/nextjs/.github/workflows/integration-tests.yml@d4b5ac951dafaaf8c8a622434d1a09d997a32bf5 # main 2026-07 (nextjs#49 merge SHA)
     with:
       harper_ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/integration-tests-nextjs.yml
+++ b/.github/workflows/integration-tests-nextjs.yml
@@ -9,27 +9,95 @@ name: Next.js Integration Tests (downstream)
 # as `harper_ref`; the reusable workflow checks out + builds harper at that ref and
 # resolves it as the `harper` the test harness and fixtures run against.
 #
-# Scoped to PRs that touch the HTTP / resource / server code paths the adapter
-# exercises (tune the paths filter as coverage evolves; caching lives under
-# resources/**, there's no separate top-level cache/ dir).
+# Required-check design: this workflow triggers on EVERY pull_request (no `paths:`
+# filter on the trigger). A trigger-level paths filter cannot back a required status
+# check -- GitHub has no "required only if it runs" semantic, so a PR that skips the
+# workflow would wait forever for a check that never reports. Instead the workflow
+# always runs and gates INTERNALLY: the `changes` job decides whether adapter-relevant
+# paths changed, the heavy `nextjs-integration` job runs only when they did, and the
+# always-running `required` gate job reports the single stable status. Mark
+# `required` (job name: "Next.js adapter integration required") as the required check
+# in branch protection -- it reports success both when the suite passes and when it is
+# skipped as irrelevant, and fails only when the suite actually fails.
 
 on:
   pull_request:
-    paths:
-      - 'resources/**'
-      - 'server/**'
-      - 'dataLayer/**'
-      - 'components/**'
-      - 'config/**'
-      - 'package.json'
-      - 'package-lock.json'
 
 permissions:
   contents: read
 
 jobs:
+  # Decide whether this PR touches paths the Next.js adapter exercises. Keep this list
+  # in sync with the code paths the adapter depends on (caching lives under resources/**,
+  # there's no separate top-level cache/ dir). Uses a plain `git diff` against the PR
+  # base so no third-party action is pulled in for the decision.
+  changes:
+    name: Detect adapter-relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check changed paths
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
+          echo "Changed files:"
+          echo "$changed"
+          # Effective path list mirrors the paths the trigger used to filter on:
+          #   resources/** server/** dataLayer/** components/** config/**
+          #   package.json package-lock.json
+          if echo "$changed" | grep -Eq '^(resources|server|dataLayer|components|config)/|^package(-lock)?\.json$'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "Adapter-relevant paths changed -> integration suite will run."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "No adapter-relevant paths changed -> integration suite will be skipped."
+          fi
+
+  # Heavy path: only when relevant files changed. When skipped, this caller job
+  # contributes no check runs of its own -- which is exactly why the `required` gate
+  # job below exists to provide the stable, always-reporting status.
   nextjs-integration:
     name: Next.js adapter integration (against this PR's harper)
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     uses: HarperFast/nextjs/.github/workflows/integration-tests.yml@d4b5ac951dafaaf8c8a622434d1a09d997a32bf5 # main 2026-07 (nextjs#49 merge SHA)
     with:
       harper_ref: ${{ github.event.pull_request.head.sha }}
+
+  # Always runs, so it always reports -- this is the check to mark REQUIRED in branch
+  # protection. Passes when the suite passed OR was skipped as irrelevant; fails only
+  # when the suite actually failed/was cancelled, or when the filter job errored.
+  required:
+    name: Next.js adapter integration required
+    needs: [changes, nextjs-integration]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate integration result
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          INTEGRATION_RESULT: ${{ needs.nextjs-integration.result }}
+        run: |
+          echo "changes=$CHANGES_RESULT integration=$INTEGRATION_RESULT"
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "::error::path-filter job did not succeed ($CHANGES_RESULT)"
+            exit 1
+          fi
+          case "$INTEGRATION_RESULT" in
+            success)
+              echo "Next.js integration suite passed."
+              ;;
+            skipped)
+              echo "Next.js integration suite skipped (no adapter-relevant paths changed) -- required check satisfied."
+              ;;
+            *)
+              echo "::error::Next.js integration suite result: $INTEGRATION_RESULT"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/integration-tests-nextjs.yml
+++ b/.github/workflows/integration-tests-nextjs.yml
@@ -9,16 +9,12 @@ name: Next.js Integration Tests (downstream)
 # as `harper_ref`; the reusable workflow checks out + builds harper at that ref and
 # resolves it as the `harper` the test harness and fixtures run against.
 #
-# Required-check design: this workflow triggers on EVERY pull_request (no `paths:`
-# filter on the trigger). A trigger-level paths filter cannot back a required status
-# check -- GitHub has no "required only if it runs" semantic, so a PR that skips the
-# workflow would wait forever for a check that never reports. Instead the workflow
-# always runs and gates INTERNALLY: the `changes` job decides whether adapter-relevant
-# paths changed, the heavy `nextjs-integration` job runs only when they did, and the
-# always-running `required` gate job reports the single stable status. Mark
-# `required` (job name: "Next.js adapter integration required") as the required check
-# in branch protection -- it reports success both when the suite passes and when it is
-# skipped as irrelevant, and fails only when the suite actually fails.
+# Advisory, non-blocking: this is deliberately pinned to nextjs `@main` rather than a
+# fixed SHA, so a regression on nextjs main against harper surfaces here on the very
+# next harper PR instead of silently drifting. That means this check's outcome depends
+# on nextjs main's health, not just this PR's diff -- so it must NOT be added as a
+# required status check in branch protection, or an unrelated nextjs-side break would
+# block harper merges. It's a signal to act on, not a gate.
 
 on:
   pull_request:
@@ -59,45 +55,12 @@ jobs:
             echo "No adapter-relevant paths changed -> integration suite will be skipped."
           fi
 
-  # Heavy path: only when relevant files changed. When skipped, this caller job
-  # contributes no check runs of its own -- which is exactly why the `required` gate
-  # job below exists to provide the stable, always-reporting status.
+  # Heavy path: only when relevant files changed. Runs and reports informationally --
+  # this is not wired to a required gate job, so it never blocks a harper merge.
   nextjs-integration:
     name: Next.js adapter integration (against this PR's harper)
     needs: changes
     if: needs.changes.outputs.relevant == 'true'
-    uses: HarperFast/nextjs/.github/workflows/integration-tests.yml@d4b5ac951dafaaf8c8a622434d1a09d997a32bf5 # main 2026-07 (nextjs#49 merge SHA)
+    uses: HarperFast/nextjs/.github/workflows/integration-tests.yml@main # tracks nextjs main deliberately, so cross-repo drift is caught
     with:
       harper_ref: ${{ github.event.pull_request.head.sha }}
-
-  # Always runs, so it always reports -- this is the check to mark REQUIRED in branch
-  # protection. Passes when the suite passed OR was skipped as irrelevant; fails only
-  # when the suite actually failed/was cancelled, or when the filter job errored.
-  required:
-    name: Next.js adapter integration required
-    needs: [changes, nextjs-integration]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Evaluate integration result
-        env:
-          CHANGES_RESULT: ${{ needs.changes.result }}
-          INTEGRATION_RESULT: ${{ needs.nextjs-integration.result }}
-        run: |
-          echo "changes=$CHANGES_RESULT integration=$INTEGRATION_RESULT"
-          if [ "$CHANGES_RESULT" != "success" ]; then
-            echo "::error::path-filter job did not succeed ($CHANGES_RESULT)"
-            exit 1
-          fi
-          case "$INTEGRATION_RESULT" in
-            success)
-              echo "Next.js integration suite passed."
-              ;;
-            skipped)
-              echo "Next.js integration suite skipped (no adapter-relevant paths changed) -- required check satisfied."
-              ;;
-            *)
-              echo "::error::Next.js integration suite result: $INTEGRATION_RESULT"
-              exit 1
-              ;;
-          esac

--- a/.github/workflows/integration-tests-nextjs.yml
+++ b/.github/workflows/integration-tests-nextjs.yml
@@ -59,6 +59,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration-tests-nextjs.yml
+++ b/.github/workflows/integration-tests-nextjs.yml
@@ -9,12 +9,10 @@ name: Next.js Integration Tests (downstream)
 # as `harper_ref`; the reusable workflow checks out + builds harper at that ref and
 # resolves it as the `harper` the test harness and fixtures run against.
 #
-# Advisory, non-blocking: this is deliberately pinned to nextjs `@main` rather than a
-# fixed SHA, so a regression on nextjs main against harper surfaces here on the very
-# next harper PR instead of silently drifting. That means this check's outcome depends
-# on nextjs main's health, not just this PR's diff -- so it must NOT be added as a
-# required status check in branch protection, or an unrelated nextjs-side break would
-# block harper merges. It's a signal to act on, not a gate.
+# Advisory, non-blocking: this is pinned to the nextjs reusable-workflow fix from
+# HarperFast/nextjs#50. That revision explicitly checks out the adapter repository;
+# without it, workflow_call inherits this caller's checkout context and runs the
+# adapter's package scripts against harper instead.
 
 on:
   pull_request:
@@ -61,6 +59,6 @@ jobs:
     name: Next.js adapter integration (against this PR's harper)
     needs: changes
     if: needs.changes.outputs.relevant == 'true'
-    uses: HarperFast/nextjs/.github/workflows/integration-tests.yml@main # tracks nextjs main deliberately, so cross-repo drift is caught
+    uses: HarperFast/nextjs/.github/workflows/integration-tests.yml@8b1e950dcb1835b24a09bf4ffc0670c1d0cf9fc5 # HarperFast/nextjs#50
     with:
       harper_ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/integration-tests-nextjs.yml
+++ b/.github/workflows/integration-tests-nextjs.yml
@@ -62,7 +62,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22, 24]
+        # Match harper's supported runtimes; its native storage bindings do not
+        # support Node 20 (package.json requires ^22.18 or >=24).
+        node-version: [22, 24, 26]
     steps:
       - name: Checkout Next.js adapter
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## What

Adds `.github/workflows/integration-tests-nextjs.yml`, an advisory downstream check that runs the `@harperfast/nextjs` Playwright suite against the harper build from the current PR whenever adapter-relevant paths change.

The workflow explicitly checks out `HarperFast/nextjs@main`, packs the current harper PR, installs that tarball into the adapter test workspace, installs fixture dependencies, and runs the suite on Node 20, 22, and 24. Keeping the checkout in this caller avoids reusable-workflow checkout context selecting the harper repository and looking for adapter scripts in the wrong `package.json`.

Current harper and `rocksdb-js` require Node 22.18 or newer. The Node 20 matrix job therefore keeps Next.js and Playwright on Node 20 while building and spawning the harper child process with Node 22 via the integration harness `HARPER_RUNTIME` override.

## Advisory, non-blocking

This deliberately tracks Next.js `main`, so a Next.js-side regression is visible on the next relevant harper PR. Because the result can depend on downstream health, this workflow must remain advisory and must not be configured as a required branch-protection check.

## Verification

- [Downstream run 29547153563](https://github.com/HarperFast/harper/actions/runs/29547153563): all Node 20/22/24 jobs passed, with 21 Playwright tests per job.
- Repository format, lint, unit, build, and caller-workflow validation checks passed on the final head.

Updated by Codex (OpenAI).
