### PR TITLE
fix(mcp): deliver server-push SSE on both profiles (GET establish + list_changed)

### DIFF
--- a/components/mcp/adapters/fastify.ts
+++ b/components/mcp/adapters/fastify.ts
@@ -13,7 +13,9 @@
  * Streamable HTTP transport; the application profile reads the raw body and
  * returns a JSON-RPC `-32700` frame instead. See #1317 S1.)
  */
+import type { ServerResponse } from 'node:http';
 import { handleMcpRequest, type McpProfile, type NormRequest } from '../transport.ts';
+import { toSseStream, type SseFrameSource } from '../sse.ts';
 
 interface FastifyLikeRequest {
 	method: string;
@@ -31,6 +33,12 @@ interface FastifyLikeReply {
 	code: (status: number) => FastifyLikeReply;
 	header: (name: string, value: string) => FastifyLikeReply;
 	send: (body?: unknown) => unknown;
+	/** Headers accumulated so far (e.g. CORS headers set by `@fastify/cors`). */
+	getHeaders: () => Record<string, number | string | string[] | undefined>;
+	/** Take ownership of the response; Fastify will not send it. Used for SSE. */
+	hijack: () => void;
+	/** The underlying Node response, written to directly for SSE streaming. */
+	raw: ServerResponse;
 }
 
 export function createFastifyHandler(profile: McpProfile) {
@@ -49,6 +57,38 @@ export function createFastifyHandler(profile: McpProfile) {
 
 		const res = await handleMcpRequest(norm);
 
+		if (res.sseIterable !== undefined) {
+			// Server-push GET stream (#619). `reply.send(stream)` does not reliably
+			// stream SSE on the operations Fastify — it pulls one chunk then stalls,
+			// so frames pushed onto the queue are never flushed. Take over the raw
+			// socket instead: write + flush headers immediately, then pipe the framed
+			// SSE Readable directly. `hijack()` stops Fastify from touching the
+			// response. (The Harper-HTTP adapter pipes a stream fine, so this divergence
+			// is Fastify-specific.)
+			//
+			// Tradeoff: hijack bypasses Fastify's onSend/onResponse hooks for this
+			// request, so per-request completion logging/metrics don't fire until the
+			// long-lived stream closes. Acceptable for an SSE channel (auth + the MCP
+			// handler already ran above); this is the standard Fastify SSE pattern.
+			const raw = reply.raw;
+			// Start from the headers Fastify hooks already accumulated (e.g.
+			// `@fastify/cors` adds Access-Control-Allow-Origin / Vary on the reply
+			// before this handler runs). Hijacking bypasses Fastify's send path, so
+			// these must be copied onto the raw response or a CORS-allowed browser
+			// client gets its SSE GET blocked.
+			const sseHeaders: Record<string, number | string | string[] | undefined> = { ...reply.getHeaders() };
+			for (const [name, value] of Object.entries(res.headers)) sseHeaders[name] = value;
+			sseHeaders['Content-Type'] = res.headers['Content-Type'] ?? res.headers['content-type'] ?? 'text/event-stream';
+			sseHeaders['Cache-Control'] = res.headers['Cache-Control'] ?? res.headers['cache-control'] ?? 'no-store';
+			reply.hijack();
+			raw.writeHead(res.status, sseHeaders);
+			raw.flushHeaders?.();
+			const stream = toSseStream(res.sseIterable as unknown as SseFrameSource);
+			stream.pipe(raw);
+			raw.on('close', () => stream.destroy());
+			return;
+		}
+
 		reply.code(res.status);
 		for (const [name, value] of Object.entries(res.headers)) {
 			reply.header(name, value);
@@ -59,18 +99,6 @@ export function createFastifyHandler(profile: McpProfile) {
 				reply.header('Content-Type', 'application/json');
 			}
 			reply.send(res.jsonBody);
-			return;
-		}
-
-		if (res.sseIterable !== undefined) {
-			// Reserved for #619 (server-push GET stream). Fastify will iterate
-			// the async iterable and write SSE frames via the contentTypes
-			// serializer at `server/serverHelpers/contentTypes.ts:128-162`.
-			if (!res.headers['Content-Type'] && !res.headers['content-type']) {
-				reply.header('Content-Type', 'text/event-stream');
-			}
-			reply.header('Cache-Control', 'no-store');
-			reply.send(res.sseIterable);
 			return;
 		}
 

--- a/components/mcp/adapters/fastify.ts
+++ b/components/mcp/adapters/fastify.ts
@@ -84,10 +84,12 @@ export function createFastifyHandler(profile: McpProfile) {
 			raw.writeHead(res.status, sseHeaders);
 			raw.flushHeaders?.();
 			const stream = toSseStream(res.sseIterable as unknown as SseFrameSource);
-			// An unhandled `'error'` on the piped Readable would crash the worker.
-			// `pipe()` does not forward source errors to the destination, so destroy
-			// the raw socket ourselves to tear the response down cleanly.
+			// An unhandled `'error'` on either side of the pipe would crash the worker.
+			// `pipe()` does not forward errors in either direction, so guard both: a
+			// source error destroys the raw socket, and a socket error (e.g. the client
+			// resetting the connection mid-write) destroys the stream.
 			stream.on('error', () => raw.destroy());
+			raw.on('error', () => stream.destroy());
 			stream.pipe(raw);
 			raw.on('close', () => stream.destroy());
 			return;

--- a/components/mcp/adapters/fastify.ts
+++ b/components/mcp/adapters/fastify.ts
@@ -84,6 +84,10 @@ export function createFastifyHandler(profile: McpProfile) {
 			raw.writeHead(res.status, sseHeaders);
 			raw.flushHeaders?.();
 			const stream = toSseStream(res.sseIterable as unknown as SseFrameSource);
+			// An unhandled `'error'` on the piped Readable would crash the worker.
+			// `pipe()` does not forward source errors to the destination, so destroy
+			// the raw socket ourselves to tear the response down cleanly.
+			stream.on('error', () => raw.destroy());
 			stream.pipe(raw);
 			raw.on('close', () => stream.destroy());
 			return;

--- a/components/mcp/adapters/harperHttp.ts
+++ b/components/mcp/adapters/harperHttp.ts
@@ -12,6 +12,7 @@
  * automatically and pipes the iterable to the wire.
  */
 import { handleMcpRequest, type McpProfile, type NormRequest, type NormResponse } from '../transport.ts';
+import { toSseStream, type SseFrameSource } from '../sse.ts';
 
 /**
  * The inbound body as Harper hands it to a custom HTTP handler: a Node-stream
@@ -134,10 +135,15 @@ function toHarperResponse(res: NormResponse): HarperHttpResponse {
 		if (!headers['Cache-Control'] && !headers['cache-control']) {
 			headers['Cache-Control'] = 'no-store';
 		}
+		// Frame the raw IterableEventQueue into a primed SSE Readable. Harper's
+		// HTTP server pipes a Readable directly but (a) won't serialize the
+		// queue's objects to SSE text and (b) defers header transmission until the
+		// first body byte — so without the primed comment the GET hangs with
+		// headers unsent until a push fires. See `sse.ts`.
 		return {
 			status: res.status,
 			headers,
-			body: res.sseIterable,
+			body: toSseStream(res.sseIterable as unknown as SseFrameSource),
 		};
 	}
 

--- a/components/mcp/sessionRegistry.ts
+++ b/components/mcp/sessionRegistry.ts
@@ -59,9 +59,12 @@ function pruneIdleSessions(): void {
 	lastPruneAt = t;
 	const cutoff = t - IDLE_PRUNE_MS;
 	for (const [id, record] of registry) {
-		// Don't prune sessions whose iterator is actively awaiting data; that
-		// signals a live consumer mid-stream. Belt-and-braces around lastSeen.
-		if (record.queue.resolveNext !== null) continue;
+		// Don't prune sessions with a live SSE consumer. The consumer is either
+		// awaiting via the async iterator (`resolveNext`) or subscribed via the
+		// queue's `'data'` event (`hasDataListeners`, how the MCP SSE stream
+		// consumes) — either way the GET stream is open, even if no `tools/call`
+		// has refreshed `lastSeen` within the idle window.
+		if (record.queue.resolveNext !== null || record.queue.hasDataListeners) continue;
 		if (record.lastSeen < cutoff) {
 			record.queue.emit('close');
 			registry.delete(id);

--- a/components/mcp/sse.ts
+++ b/components/mcp/sse.ts
@@ -85,22 +85,26 @@ export function toSseStream(frames: SseFrameSource): Readable {
 	const onData = (frame: SseFrame): void => {
 		stream.write(serializeSseFrame(frame));
 	};
-	// Session teardown (DELETE / supersede / prune) → end the response.
+	// Server-side teardown (DELETE / supersede / prune): the queue emits `'close'`,
+	// so end the response. Mark it so the stream-`'close'` handler below does NOT
+	// re-emit `'close'` on the queue — the source already emitted it, and a second
+	// emit would show up as duplicate teardown to any `on('close')` listener.
+	let sourceClosed = false;
 	const onClose = (): void => {
+		sourceClosed = true;
 		stream.end();
 	};
 	frames.on?.('data', onData);
 	frames.once?.('close', onClose);
 
-	// Client/proxy disconnect → the server destroys this stream. Unsubscribe and
-	// signal the queue so the session registry (which listens for the queue's
-	// `'close'`) drops the entry. Idempotent if the queue closed first.
+	// Client/proxy disconnect → the server destroys this stream. Always unsubscribe
+	// the data listener. If the source has not already closed (i.e. this is a
+	// client-side teardown, not a reaction to the queue's own `'close'`), remove our
+	// `onClose` listener and signal the queue so the session registry (which listens
+	// for the queue's `'close'`) drops the entry.
 	stream.once('close', () => {
 		frames.off?.('data', onData);
-		// Drop our own `'close'` listener explicitly. If the stream tears down
-		// before the queue ever emits `'close'`, relying on `emit('close')` below
-		// to fire-and-remove `onClose` (via `once`) leaves it attached whenever the
-		// source has no working `emit` (e.g. a stub). Removing it here can't leak.
+		if (sourceClosed) return;
 		if (frames.off) frames.off('close', onClose);
 		else frames.removeListener?.('close', onClose);
 		frames.emit?.('close');

--- a/components/mcp/sse.ts
+++ b/components/mcp/sse.ts
@@ -1,0 +1,94 @@
+/**
+ * SSE framing for the MCP server-push (GET) channel.
+ *
+ * The transport core hands the GET handler a semantic frame queue (an
+ * `IterableEventQueue` of `{ event, data, id }` frames that also emits `'data'`
+ * per push and `'close'` on teardown). Both HTTP servers Harper runs — Fastify
+ * on the operations port, Harper's own HTTP server on the application port —
+ * need that turned into a real Node `Readable` of SSE wire text before they will
+ * stream it:
+ *
+ *   - Neither server drives a raw `IterableEventQueue`: Fastify sends headers
+ *     then never pulls from it, so frames sit in the queue undelivered;
+ *     Harper-HTTP would `Readable.from()` it and pipe unserialized objects.
+ *   - Node also defers transmitting response headers (after `writeHead`) until
+ *     the first body byte. An SSE channel yields nothing until a push fires, so
+ *     a GET would hang with headers unsent until the first notification.
+ *
+ * `toSseStream` returns a primed `Readable` of SSE text. It is **event-driven**
+ * (subscribes to the queue's `'data'`/`'close'` events), deliberately NOT an
+ * async generator over the queue's async iterator: a generator suspended at an
+ * `await` for the next frame cannot be torn down on client disconnect (Node
+ * defers the generator's `.return()` until the pending await settles, which
+ * never happens), which would leak the socket and the session-registry entry.
+ * The `PassThrough` + subscribe + teardown shape mirrors the operations progress
+ * stream (`server/serverHelpers/progressEmitter.ts` `createSSEResponseStream`).
+ */
+import { PassThrough, type Readable } from 'node:stream';
+
+export interface SseFrame {
+	event?: string;
+	data?: unknown;
+	id?: string;
+}
+
+/**
+ * The MCP server-push source — the session's `IterableEventQueue` viewed as an
+ * event emitter: `'data'` per pushed frame (subscribing also drains any frames
+ * already buffered), `'close'` on session teardown (DELETE / superseding GET /
+ * idle prune). All methods optional so a plain emitter/stub works in tests.
+ */
+export interface SseFrameSource {
+	on?(event: 'data', listener: (frame: SseFrame) => void): unknown;
+	off?(event: 'data', listener: (frame: SseFrame) => void): unknown;
+	once?(event: 'close', listener: () => void): unknown;
+	emit?(event: 'close'): unknown;
+}
+
+/** Serialize one frame to SSE wire format (`event:`/`data:`/`id:` lines + blank line). */
+export function serializeSseFrame(frame: SseFrame): string {
+	let out = '';
+	if (frame.event) out += `event: ${frame.event}\n`;
+	if (frame.data !== undefined) {
+		const data = typeof frame.data === 'string' ? frame.data : JSON.stringify(frame.data);
+		// SSE requires each line of a multi-line payload to carry its own `data:`
+		// prefix. MCP frames are single-line JSON in practice, but split defensively
+		// so a payload containing a literal newline can't break the framing.
+		for (const line of data.split('\n')) out += `data: ${line}\n`;
+	}
+	if (frame.id) out += `id: ${frame.id}\n`;
+	return `${out}\n`;
+}
+
+/**
+ * Build a primed SSE `Readable` that streams the queue's frames and flushes per
+ * frame. The leading comment forces response headers out immediately so the GET
+ * establishes before any push; teardown is event-driven so a client disconnect
+ * (stream destroy) unsubscribes and signals the queue's `'close'` for the
+ * session registry, and a session `'close'` ends the stream.
+ */
+export function toSseStream(frames: SseFrameSource): Readable {
+	const stream = new PassThrough();
+	// Prime: a comment line (clients ignore `:`-prefixed lines) makes the body
+	// non-empty immediately so the HTTP server flushes headers and the GET opens.
+	stream.write(': mcp stream open\n\n');
+
+	const onData = (frame: SseFrame): void => {
+		stream.write(serializeSseFrame(frame));
+	};
+	// Session teardown (DELETE / supersede / prune) → end the response.
+	const onClose = (): void => {
+		stream.end();
+	};
+	frames.on?.('data', onData);
+	frames.once?.('close', onClose);
+
+	// Client/proxy disconnect → the server destroys this stream. Unsubscribe and
+	// signal the queue so the session registry (which listens for the queue's
+	// `'close'`) drops the entry. Idempotent if the queue closed first.
+	stream.once('close', () => {
+		frames.off?.('data', onData);
+		frames.emit?.('close');
+	});
+	return stream;
+}

--- a/components/mcp/sse.ts
+++ b/components/mcp/sse.ts
@@ -41,6 +41,8 @@ export interface SseFrame {
 export interface SseFrameSource {
 	on?(event: 'data', listener: (frame: SseFrame) => void): unknown;
 	off?(event: 'data', listener: (frame: SseFrame) => void): unknown;
+	off?(event: 'close', listener: () => void): unknown;
+	removeListener?(event: 'close', listener: () => void): unknown;
 	once?(event: 'close', listener: () => void): unknown;
 	emit?(event: 'close'): unknown;
 }
@@ -69,6 +71,13 @@ export function serializeSseFrame(frame: SseFrame): string {
  */
 export function toSseStream(frames: SseFrameSource): Readable {
 	const stream = new PassThrough();
+	// A `Readable` with no `'error'` listener throws on `'error'`, crashing the
+	// worker. The operations adapter pipes this stream manually and Harper's own
+	// HTTP server (`server/http.ts`) pipes it for the application profile; neither
+	// pipe forwards a source error to a handler. Attach a default guard here so an
+	// error on either profile tears the stream down instead of crashing. The
+	// operations adapter additionally destroys its raw socket on this event.
+	stream.on('error', () => stream.destroy());
 	// Prime: a comment line (clients ignore `:`-prefixed lines) makes the body
 	// non-empty immediately so the HTTP server flushes headers and the GET opens.
 	stream.write(': mcp stream open\n\n');
@@ -88,6 +97,12 @@ export function toSseStream(frames: SseFrameSource): Readable {
 	// `'close'`) drops the entry. Idempotent if the queue closed first.
 	stream.once('close', () => {
 		frames.off?.('data', onData);
+		// Drop our own `'close'` listener explicitly. If the stream tears down
+		// before the queue ever emits `'close'`, relying on `emit('close')` below
+		// to fire-and-remove `onClose` (via `once`) leaves it attached whenever the
+		// source has no working `emit` (e.g. a stub). Removing it here can't leak.
+		if (frames.off) frames.off('close', onClose);
+		else frames.removeListener?.('close', onClose);
 		frames.emit?.('close');
 	});
 	return stream;

--- a/integrationTests/mcp/sse-listchanged.test.ts
+++ b/integrationTests/mcp/sse-listchanged.test.ts
@@ -59,10 +59,15 @@ async function initialize(baseUrl: string, auth: string): Promise<{ sessionId: s
 			params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'sse-it', version: '0' } },
 		}),
 	});
-	strictEqual(res.status, 200, `initialize should 200: ${await res.text()}`);
+	// Read the body exactly once: an `await res.text()` inside the assertion
+	// message is evaluated eagerly (template args run before `strictEqual`), so it
+	// consumes the body even on a 200 and a later `res.json()` then throws
+	// "Body has already been read". Read the text up front and parse it.
+	const text = await res.text();
+	strictEqual(res.status, 200, `initialize should 200: ${text}`);
 	const sessionId = res.headers.get('mcp-session-id');
 	ok(sessionId, 'initialize returned an Mcp-Session-Id');
-	const json: any = await res.json();
+	const json: any = JSON.parse(text);
 	return { sessionId: sessionId!, protocolVersion: json.result.protocolVersion };
 }
 

--- a/integrationTests/mcp/sse-listchanged.test.ts
+++ b/integrationTests/mcp/sse-listchanged.test.ts
@@ -1,0 +1,240 @@
+/**
+ * MCP v1 — server-push SSE channel + list_changed delivery over real HTTP.
+ *
+ * Regression coverage for two bugs found on `main`:
+ *
+ *  - N1: the application-profile GET (Harper's own HTTP server) never flushed
+ *    response headers — the SSE stream's queue yields nothing until a push, and
+ *    Node defers header transmission until the first body byte, so the GET hung
+ *    until the client gave up. The fix frames the queue into a primed SSE
+ *    Readable (an initial comment flushes headers immediately).
+ *
+ *  - N2: `listChanged` was advertised and the dispatcher fired, but the
+ *    operations-profile SSE never streamed the pushed frames — `reply.send(queue)`
+ *    on Fastify sent headers then stopped draining, so `tools/list_changed` sat
+ *    in the queue undelivered. The fix hijacks the reply and pipes a framed SSE
+ *    stream to the raw socket.
+ *
+ * Both profiles are exercised end-to-end against a real booted Harper.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert/strict';
+import { resolve } from 'node:path';
+
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, '../fixtures/custom-resources');
+
+function basicAuth(user: string, pass: string): string {
+	return `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`;
+}
+
+function adminAuth(ctx: ContextWithHarper): string {
+	return basicAuth(ctx.harper.admin.username, ctx.harper.admin.password);
+}
+
+/** Call the operations API as admin (add_role / add_user / alter_user). */
+async function op(ctx: ContextWithHarper, operation: Record<string, unknown>): Promise<void> {
+	const res = await fetch(new URL('/', ctx.harper.operationsAPIURL), {
+		method: 'POST',
+		headers: { 'content-type': 'application/json', 'authorization': adminAuth(ctx) },
+		body: JSON.stringify(operation),
+	});
+	ok(res.ok, `operation ${operation.operation} failed: ${res.status} ${await res.text()}`);
+}
+
+/** POST an MCP `initialize` and return the negotiated session. */
+async function initialize(baseUrl: string, auth: string): Promise<{ sessionId: string; protocolVersion: string }> {
+	const res = await fetch(new URL('/mcp', baseUrl), {
+		method: 'POST',
+		headers: {
+			'content-type': 'application/json',
+			'accept': 'application/json, text/event-stream',
+			'authorization': auth,
+		},
+		body: JSON.stringify({
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'initialize',
+			params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'sse-it', version: '0' } },
+		}),
+	});
+	strictEqual(res.status, 200, `initialize should 200: ${await res.text()}`);
+	const sessionId = res.headers.get('mcp-session-id');
+	ok(sessionId, 'initialize returned an Mcp-Session-Id');
+	const json: any = await res.json();
+	return { sessionId: sessionId!, protocolVersion: json.result.protocolVersion };
+}
+
+async function toolsCount(
+	baseUrl: string,
+	auth: string,
+	session: { sessionId: string; protocolVersion: string }
+): Promise<number> {
+	const res = await fetch(new URL('/mcp', baseUrl), {
+		method: 'POST',
+		headers: {
+			'content-type': 'application/json',
+			'accept': 'application/json, text/event-stream',
+			'authorization': auth,
+			'mcp-session-id': session.sessionId,
+			'mcp-protocol-version': session.protocolVersion,
+		},
+		body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }),
+	});
+	const json: any = await res.json();
+	return json?.result?.tools?.length ?? -1;
+}
+
+/**
+ * Open a GET SSE stream and resolve with `{ status, contentType }` once headers
+ * arrive (rejecting if they never flush — the N1 hang), plus a
+ * `next(predicate, timeoutMs)` that resolves to the first parsed JSON-RPC frame
+ * matching the predicate (or undefined on timeout).
+ */
+async function openSse(
+	url: string,
+	auth: string,
+	session: { sessionId: string; protocolVersion: string },
+	headerTimeoutMs = 2500
+): Promise<{
+	status: number;
+	contentType: string | null;
+	next: (predicate: (msg: any) => boolean, timeoutMs: number) => Promise<any | undefined>;
+	close: () => void;
+}> {
+	const ac = new AbortController();
+	const resP = fetch(new URL('/mcp', url), {
+		method: 'GET',
+		headers: {
+			'accept': 'text/event-stream',
+			'authorization': auth,
+			'mcp-session-id': session.sessionId,
+			'mcp-protocol-version': session.protocolVersion,
+		},
+		signal: ac.signal,
+	});
+	// Guard against the N1 hang: if headers never arrive, fail fast rather than
+	// hang the whole test run.
+	const res = (await Promise.race([
+		resP,
+		new Promise((_, reject) =>
+			setTimeout(() => reject(new Error('SSE headers never flushed (hung)')), headerTimeoutMs)
+		),
+	])) as Response;
+
+	const reader = res.body!.getReader();
+	const decoder = new TextDecoder();
+	let buffer = '';
+	const parsed: any[] = [];
+	const waiters: Array<{ predicate: (m: any) => boolean; resolve: (m: any) => void }> = [];
+
+	function dispatch(frame: string): void {
+		const dataLine = frame.split('\n').find((l) => l.startsWith('data:'));
+		if (!dataLine) return;
+		let msg: any;
+		try {
+			msg = JSON.parse(dataLine.slice(5).trim());
+		} catch {
+			return;
+		}
+		parsed.push(msg);
+		for (let i = waiters.length - 1; i >= 0; i--) {
+			if (waiters[i].predicate(msg)) {
+				waiters[i].resolve(msg);
+				waiters.splice(i, 1);
+			}
+		}
+	}
+
+	(async () => {
+		try {
+			for (;;) {
+				const { value, done } = await reader.read();
+				if (done) break;
+				buffer += decoder.decode(value, { stream: true });
+				let idx;
+				while ((idx = buffer.indexOf('\n\n')) !== -1) {
+					dispatch(buffer.slice(0, idx));
+					buffer = buffer.slice(idx + 2);
+				}
+			}
+		} catch {
+			/* aborted on close */
+		}
+	})();
+
+	return {
+		status: res.status,
+		contentType: res.headers.get('content-type'),
+		next(predicate, timeoutMs) {
+			const existing = parsed.find(predicate);
+			if (existing) return Promise.resolve(existing);
+			return new Promise((resolve) => {
+				const t = setTimeout(() => resolve(undefined), timeoutMs);
+				waiters.push({
+					predicate,
+					resolve: (m) => {
+						clearTimeout(t);
+						resolve(m);
+					},
+				});
+			});
+		},
+		close: () => ac.abort(),
+	};
+}
+
+suite('MCP v1 SSE channel + list_changed delivery', (ctx: ContextWithHarper) => {
+	before(async () => {
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+			config: { mcp: { operations: { mountPath: '/mcp' }, application: { mountPath: '/mcp' } } },
+			env: {},
+		});
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	test('N1: application-profile GET opens an SSE stream with headers flushed immediately', async () => {
+		const session = await initialize(ctx.harper.httpURL, adminAuth(ctx));
+		const sse = await openSse(ctx.harper.httpURL, adminAuth(ctx), session, 2500);
+		try {
+			strictEqual(sse.status, 200, 'application GET SSE establishes (was: hung, headers never flushed)');
+			ok((sse.contentType ?? '').includes('text/event-stream'), `expected text/event-stream, got ${sse.contentType}`);
+		} finally {
+			sse.close();
+		}
+	});
+
+	test('N2: operations-profile delivers tools/list_changed when the visible surface changes', async () => {
+		const suffix = Date.now().toString(36);
+		const loRole = `sse_lo_${suffix}`;
+		const hiRole = `sse_hi_${suffix}`;
+		const username = `sse_user_${suffix}`;
+		const password = 'Abc1234!';
+		await op(ctx, { operation: 'add_role', role: loRole, permission: { super_user: false } });
+		await op(ctx, { operation: 'add_role', role: hiRole, permission: { super_user: true } });
+		await op(ctx, { operation: 'add_user', role: loRole, username, password, active: true });
+
+		const auth = basicAuth(username, password);
+		const session = await initialize(ctx.harper.operationsAPIURL, auth);
+		const before = await toolsCount(ctx.harper.operationsAPIURL, auth, session);
+		strictEqual(before, 0, 'restricted user starts with no operations tools (valid trigger)');
+
+		const sse = await openSse(ctx.harper.operationsAPIURL, auth, session, 2500);
+		try {
+			strictEqual(sse.status, 200, 'operations GET SSE establishes');
+			// Flip the user to a super_user role — changes its visible tool surface.
+			await op(ctx, { operation: 'alter_user', username, role: hiRole });
+			const evt = await sse.next((m) => m?.method === 'notifications/tools/list_changed', 5000);
+			ok(evt, 'tools/list_changed delivered on the SSE stream after the surface changed');
+
+			const after = await toolsCount(ctx.harper.operationsAPIURL, auth, session);
+			ok(after > 0, `surface actually changed (tools ${before} → ${after})`);
+		} finally {
+			sse.close();
+		}
+	});
+});

--- a/resources/IterableEventQueue.ts
+++ b/resources/IterableEventQueue.ts
@@ -57,6 +57,21 @@ export class IterableEventQueue<Event extends object = any> extends EventEmitter
 		}
 		return super.on(eventName, listener);
 	}
+	// `hasDataListeners` gates whether `send()` emits 'data' or buffers; keep it in
+	// step with reality when a 'data' listener is removed (e.g. an MCP SSE stream
+	// torn down on disconnect). Without this it stayed stuck on `true` for the life
+	// of the queue once any 'data' listener had ever attached.
+	removeListener(eventName: 'data' | string, listener: (...args: any[]) => void) {
+		const result = super.removeListener(eventName, listener);
+		if (eventName === 'data') this.hasDataListeners = this.listenerCount('data') > 0;
+		return result;
+	}
+	// `EventEmitter.off` is a direct alias of the *base* `removeListener`, so it
+	// would bypass the override above (and SSE teardown unsubscribes via `off`).
+	// Route it through our `removeListener` so the flag is recomputed either way.
+	off(eventName: 'data' | string, listener: (...args: any[]) => void) {
+		return this.removeListener(eventName, listener);
+	}
 }
 
 class EventQueueIterator<Event extends object = any> implements AsyncIterator<Event> {

--- a/server/http.ts
+++ b/server/http.ts
@@ -813,11 +813,17 @@ async function bunDelegateToNodeServer(
 			if (bunRequest?.user && !headers['authorization']) {
 				headers[INTERNAL_USER_HEADER] = JSON.stringify(bunRequest.user);
 			}
+			// `payloadAsStream` makes inject() resolve as soon as the response headers are
+			// written and exposes the body as a Readable, instead of buffering the whole
+			// payload and resolving only on response end. Without it a long-lived SSE
+			// response (the MCP server-push GET) never ends, so `await inject()` would
+			// hang forever and the client would never receive headers.
 			const injectResult = await fastify.inject({
 				method: webRequest.method,
 				url: url.pathname + url.search,
 				headers,
 				payload: body,
+				payloadAsStream: true,
 			});
 			const webHeaders = new globalThis.Headers();
 			for (const [k, v] of Object.entries(injectResult.headers)) {
@@ -828,7 +834,25 @@ async function bunDelegateToNodeServer(
 			if (webRequest.headers.get('connection')?.toLowerCase() === 'close') {
 				webHeaders.set('connection', 'close');
 			}
-			return new Response(injectResult.rawPayload?.length > 0 ? injectResult.rawPayload : null, {
+			const responseStream = injectResult.stream();
+			// Event-stream responses (MCP SSE) must reach the client incrementally — return
+			// the body as a stream. Everything else keeps the prior buffered behavior:
+			// drain to a single payload so Content-Length stays set and callers see no change.
+			// Note: on a Bun client disconnect this inject-bridged stream is not torn down
+			// eagerly (no real socket 'close' propagates back to the hijacked Fastify reply),
+			// so a dropped SSE session is reclaimed by the registry's idle-prune backstop
+			// rather than immediately as on the Node/application path.
+			const contentType = String(injectResult.headers['content-type'] ?? '');
+			if (contentType.includes('text/event-stream')) {
+				return new Response(Readable.toWeb(responseStream) as unknown as BodyInit, {
+					status: injectResult.statusCode,
+					headers: webHeaders,
+				});
+			}
+			const chunks: Buffer[] = [];
+			for await (const chunk of responseStream) chunks.push(Buffer.from(chunk));
+			const payload = Buffer.concat(chunks);
+			return new Response(payload.length > 0 ? payload : null, {
 				status: injectResult.statusCode,
 				headers: webHeaders,
 			});

--- a/server/http.ts
+++ b/server/http.ts
@@ -459,7 +459,13 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 				logRequest(nodeRequest, status, requestId, executionTime);
 				if (!sentBody) {
 					if (body instanceof ReadableStream) body = Readable.fromWeb(body);
-					if (body[Symbol.iterator] || body[Symbol.asyncIterator]) body = Readable.from(body);
+					// Only wrap non-stream iterables. Re-wrapping an existing Node stream in
+					// `Readable.from()` is redundant and breaks destroy propagation: on client
+					// disconnect we destroy the wrapper, which does NOT close the wrapped stream
+					// (so e.g. an SSE PassThrough never sees 'close' and its session leaks). A
+					// real stream already has `.pipe`, so it flows through the branch below.
+					else if (!(body instanceof Readable) && (body[Symbol.iterator] || body[Symbol.asyncIterator]))
+						body = Readable.from(body);
 
 					// if it is a stream, pipe it
 					if (body?.pipe) {

--- a/server/http.ts
+++ b/server/http.ts
@@ -838,12 +838,19 @@ async function bunDelegateToNodeServer(
 			// Event-stream responses (MCP SSE) must reach the client incrementally — return
 			// the body as a stream. Everything else keeps the prior buffered behavior:
 			// drain to a single payload so Content-Length stays set and callers see no change.
-			// Note: on a Bun client disconnect this inject-bridged stream is not torn down
-			// eagerly (no real socket 'close' propagates back to the hijacked Fastify reply),
-			// so a dropped SSE session is reclaimed by the registry's idle-prune backstop
-			// rather than immediately as on the Node/application path.
 			const contentType = String(injectResult.headers['content-type'] ?? '');
 			if (contentType.includes('text/event-stream')) {
+				// Propagate client disconnect back to the hijacked Fastify reply. When Bun
+				// cancels the response body it destroys this stream; destroying the inject
+				// response (the same object the SSE adapter listens on for 'close') runs the
+				// adapter's teardown, which unsubscribes the session's queue 'data' listener
+				// and drops the registry entry. Without this the inject bridge would never
+				// signal disconnect and the session would leak — its attached data listener
+				// keeps the registry's idle-prune backstop from ever reclaiming it.
+				const injectResponse = injectResult.raw?.res;
+				if (injectResponse && typeof injectResponse.destroy === 'function') {
+					responseStream.once('close', () => injectResponse.destroy());
+				}
 				return new Response(Readable.toWeb(responseStream) as unknown as BodyInit, {
 					status: injectResult.statusCode,
 					headers: webHeaders,

--- a/unitTests/components/mcp/sessionRegistry.test.js
+++ b/unitTests/components/mcp/sessionRegistry.test.js
@@ -133,6 +133,18 @@ describe('mcp/sessionRegistry', () => {
 			pending.catch(() => {});
 		});
 
+		it('does not prune a session consumed via the queue "data" event (MCP SSE stream)', () => {
+			const rec = registerSession('live-data-1', 'application', SUPER);
+			// The MCP SSE stream subscribes via `on('data')` (not the async
+			// iterator), which sets hasDataListeners but leaves resolveNext null.
+			rec.queue.on('data', () => {});
+			assert.equal(rec.queue.resolveNext, null, 'data-event consumer does not set resolveNext');
+			assert.equal(rec.queue.hasDataListeners, true, 'data-event consumer sets hasDataListeners');
+			clock += 61 * 60 * 1000;
+			registerSession('live-data-2', 'application', SUPER);
+			assert.ok(getRegisteredSession('live-data-1'), 'live event-driven SSE session survives the prune');
+		});
+
 		it('touchRegisteredSession bumps lastSeen so a busy session escapes the prune window', () => {
 			registerSession('busy-1', 'application', SUPER);
 			// Half-way through the idle window, simulate tools/call activity.

--- a/unitTests/components/mcp/sse.test.js
+++ b/unitTests/components/mcp/sse.test.js
@@ -1,0 +1,98 @@
+const assert = require('node:assert/strict');
+const { serializeSseFrame, toSseStream } = require('#src/components/mcp/sse');
+const { IterableEventQueue } = require('#src/resources/IterableEventQueue');
+
+async function collect(stream) {
+	let out = '';
+	for await (const chunk of stream) out += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+	return out;
+}
+
+describe('mcp/sse', () => {
+	describe('serializeSseFrame', () => {
+		it('serializes event + object data as event:/data: lines + blank terminator', () => {
+			const out = serializeSseFrame({
+				event: 'message',
+				data: { jsonrpc: '2.0', method: 'notifications/tools/list_changed' },
+			});
+			assert.equal(out, 'event: message\ndata: {"jsonrpc":"2.0","method":"notifications/tools/list_changed"}\n\n');
+		});
+
+		it('passes string data through without JSON-encoding', () => {
+			assert.equal(serializeSseFrame({ event: 'message', data: 'hello' }), 'event: message\ndata: hello\n\n');
+		});
+
+		it('includes an id line when present', () => {
+			assert.equal(serializeSseFrame({ event: 'message', data: 'x', id: '7' }), 'event: message\ndata: x\nid: 7\n\n');
+		});
+
+		it('omits absent fields (a frame with no data is just a terminator)', () => {
+			assert.equal(serializeSseFrame({}), '\n');
+		});
+
+		it('prefixes every line of multi-line string data with data: (SSE robustness)', () => {
+			assert.equal(serializeSseFrame({ event: 'message', data: 'a\nb' }), 'event: message\ndata: a\ndata: b\n\n');
+		});
+	});
+
+	describe('toSseStream', () => {
+		it('primes with an SSE comment so headers flush before any push', async () => {
+			const queue = new IterableEventQueue();
+			const collected = collect(toSseStream(queue));
+			queue.emit('close'); // no frames ever pushed → just the prime, then end
+			assert.equal(await collected, ': mcp stream open\n\n');
+		});
+
+		it('emits the prime, then a serialized frame for each pushed event in order', async () => {
+			const queue = new IterableEventQueue();
+			const collected = collect(toSseStream(queue));
+			await new Promise((r) => setImmediate(r));
+			queue.send({ event: 'message', data: { method: 'notifications/tools/list_changed' } });
+			queue.send({ event: 'message', data: { method: 'notifications/resources/list_changed' } });
+			await new Promise((r) => setImmediate(r));
+			queue.emit('close');
+			assert.equal(
+				await collected,
+				': mcp stream open\n\n' +
+					'event: message\ndata: {"method":"notifications/tools/list_changed"}\n\n' +
+					'event: message\ndata: {"method":"notifications/resources/list_changed"}\n\n'
+			);
+		});
+
+		it('produces a real Node Readable (has pipe)', () => {
+			const stream = toSseStream(new IterableEventQueue());
+			assert.equal(typeof stream.pipe, 'function');
+		});
+
+		it('signals the source queue when the piped stream is destroyed (disconnect → no registry leak)', async () => {
+			// Client/proxy disconnect: the server destroys the piped stream. The
+			// stream's 'close' must signal the queue so the session registry (which
+			// listens for the queue's 'close') drops the dead entry.
+			const { PassThrough } = require('node:stream');
+			const queue = new IterableEventQueue();
+			let closed = false;
+			queue.once('close', () => {
+				closed = true;
+			});
+			const stream = toSseStream(queue);
+			stream.pipe(new PassThrough()); // mirrors stream.pipe(reply.raw)
+			await new Promise((r) => setImmediate(r)); // let the prime flow
+			stream.destroy(); // server tears down on response close
+			await new Promise((r) => setTimeout(r, 30));
+			assert.equal(closed, true, 'queue close emitted so the registry can drop the dead session');
+		});
+
+		it('streams pushed frames and ENDS when the source queue emits close (no socket leak)', async () => {
+			const queue = new IterableEventQueue();
+			const collected = collect(toSseStream(queue));
+			await new Promise((r) => setImmediate(r));
+			queue.send({ event: 'message', data: { method: 'notifications/tools/list_changed' } });
+			await new Promise((r) => setImmediate(r));
+			queue.emit('close'); // sessionRegistry signals teardown this way
+			// Must resolve (stream ended), not hang.
+			const out = await collected;
+			assert.match(out, /^: mcp stream open\n\n/);
+			assert.match(out, /notifications\/tools\/list_changed/);
+		});
+	});
+});

--- a/unitTests/components/mcp/sse.test.js
+++ b/unitTests/components/mcp/sse.test.js
@@ -82,6 +82,35 @@ describe('mcp/sse', () => {
 			assert.equal(closed, true, 'queue close emitted so the registry can drop the dead session');
 		});
 
+		it('removes its queue listeners when the stream is destroyed before the queue closes (no listener leak)', async () => {
+			// Client disconnect while the session lives on: the stream tears down
+			// first. Both the 'data' and 'close' listeners it put on the long-lived
+			// queue must come off, or the queue accumulates dead listeners per
+			// reconnect.
+			const { PassThrough } = require('node:stream');
+			const queue = new IterableEventQueue();
+			const stream = toSseStream(queue);
+			stream.pipe(new PassThrough());
+			await new Promise((r) => setImmediate(r));
+			assert.ok(queue.listenerCount('close') >= 1, 'close listener attached while live');
+			stream.destroy();
+			await new Promise((r) => setTimeout(r, 30));
+			assert.equal(queue.listenerCount('data'), 0, 'data listener removed on stream teardown');
+			assert.equal(queue.listenerCount('close'), 0, 'close listener removed on stream teardown');
+		});
+
+		it('an error on the stream is handled (does not throw an unhandled error / crash)', async () => {
+			// A Readable with no 'error' listener throws on 'error', crashing the
+			// worker. toSseStream must attach a default guard so neither the piped
+			// operations socket nor Harper-HTTP can crash the process.
+			const stream = toSseStream(new IterableEventQueue());
+			assert.ok(stream.listenerCount('error') >= 1, 'default error guard attached');
+			// Emitting 'error' must not throw now that a listener exists.
+			assert.doesNotThrow(() => stream.emit('error', new Error('boom')));
+			await new Promise((r) => setImmediate(r));
+			assert.equal(stream.destroyed, true, 'stream torn down by the error guard');
+		});
+
 		it('streams pushed frames and ENDS when the source queue emits close (no socket leak)', async () => {
 			const queue = new IterableEventQueue();
 			const collected = collect(toSseStream(queue));

--- a/unitTests/components/mcp/sse.test.js
+++ b/unitTests/components/mcp/sse.test.js
@@ -107,6 +107,24 @@ describe('mcp/sse', () => {
 			assert.equal(queue.listenerCount('close'), 0, 'close listener removed on stream teardown');
 		});
 
+		it('does not re-emit close on the queue when the source closed first (no duplicate teardown)', async () => {
+			// Server-side teardown (DELETE / supersede / idle-prune) emits the queue's
+			// 'close'. That ends the stream; the stream's own 'close' handler must NOT
+			// emit 'close' on the queue again, or an on('close') listener sees teardown twice.
+			const { PassThrough } = require('node:stream');
+			const queue = new IterableEventQueue();
+			let closeCount = 0;
+			queue.on('close', () => closeCount++);
+			const stream = toSseStream(queue);
+			stream.pipe(new PassThrough());
+			const streamClosed = new Promise((resolve) => stream.once('close', resolve));
+			await new Promise((r) => setImmediate(r));
+			queue.emit('close'); // server-side teardown
+			await streamClosed; // stream-close handler has now run
+			await new Promise((r) => setImmediate(r)); // let any (erroneous) re-emit flush
+			assert.equal(closeCount, 1, 'queue close emitted exactly once (no duplicate from the stream close handler)');
+		});
+
 		it('an error on the stream is handled (does not throw an unhandled error / crash)', async () => {
 			// A Readable with no 'error' listener throws on 'error', crashing the
 			// worker. toSseStream must attach a default guard so neither the piped

--- a/unitTests/components/mcp/sse.test.js
+++ b/unitTests/components/mcp/sse.test.js
@@ -71,14 +71,19 @@ describe('mcp/sse', () => {
 			const { PassThrough } = require('node:stream');
 			const queue = new IterableEventQueue();
 			let closed = false;
-			queue.once('close', () => {
-				closed = true;
-			});
+			// Wait on the close condition rather than a fixed sleep (avoids CI flakes
+			// when teardown propagation is delayed on a loaded runner).
+			const closeReceived = new Promise((resolve) =>
+				queue.once('close', () => {
+					closed = true;
+					resolve();
+				})
+			);
 			const stream = toSseStream(queue);
 			stream.pipe(new PassThrough()); // mirrors stream.pipe(reply.raw)
 			await new Promise((r) => setImmediate(r)); // let the prime flow
 			stream.destroy(); // server tears down on response close
-			await new Promise((r) => setTimeout(r, 30));
+			await closeReceived;
 			assert.equal(closed, true, 'queue close emitted so the registry can drop the dead session');
 		});
 
@@ -93,8 +98,11 @@ describe('mcp/sse', () => {
 			stream.pipe(new PassThrough());
 			await new Promise((r) => setImmediate(r));
 			assert.ok(queue.listenerCount('close') >= 1, 'close listener attached while live');
+			// Teardown emits the queue's 'close' after removing the stream's listeners;
+			// wait on that condition (not a fixed sleep) before asserting the counts.
+			const torndown = new Promise((resolve) => queue.once('close', resolve));
 			stream.destroy();
-			await new Promise((r) => setTimeout(r, 30));
+			await torndown;
 			assert.equal(queue.listenerCount('data'), 0, 'data listener removed on stream teardown');
 			assert.equal(queue.listenerCount('close'), 0, 'close listener removed on stream teardown');
 		});

--- a/unitTests/resources/IterableEventQueue.test.js
+++ b/unitTests/resources/IterableEventQueue.test.js
@@ -1,0 +1,52 @@
+const assert = require('node:assert/strict');
+const { IterableEventQueue } = require('#src/resources/IterableEventQueue');
+
+describe('IterableEventQueue', () => {
+	it('buffers sends with no consumer, then drains them when a data listener attaches', () => {
+		const q = new IterableEventQueue();
+		q.send({ n: 1 });
+		q.send({ n: 2 });
+		const seen = [];
+		q.on('data', (e) => seen.push(e));
+		assert.equal(q.hasDataListeners, true);
+		assert.deepEqual(seen, [{ n: 1 }, { n: 2 }], 'buffered events drained on attach');
+		q.send({ n: 3 });
+		assert.deepEqual(seen, [{ n: 1 }, { n: 2 }, { n: 3 }], 'subsequent sends emit live');
+	});
+
+	it('clears hasDataListeners when the last data listener is removed (not sticky)', () => {
+		const q = new IterableEventQueue();
+		const listener = () => {};
+		q.on('data', listener);
+		assert.equal(q.hasDataListeners, true);
+		q.off('data', listener);
+		assert.equal(q.hasDataListeners, false, 'recomputed false after the last data listener is removed');
+		// With no live listener, a send buffers again instead of emitting into the void.
+		q.send({ n: 9 });
+		const seen = [];
+		q.on('data', (e) => seen.push(e));
+		assert.deepEqual(seen, [{ n: 9 }], 're-attaching drains the re-buffered event');
+	});
+
+	it('keeps hasDataListeners true while at least one data listener remains', () => {
+		const q = new IterableEventQueue();
+		const a = () => {};
+		const b = () => {};
+		q.on('data', a);
+		q.on('data', b);
+		q.removeListener('data', a);
+		assert.equal(q.hasDataListeners, true, 'listener b still attached');
+		q.removeListener('data', b);
+		assert.equal(q.hasDataListeners, false, 'no data listeners left');
+	});
+
+	it('removing a non-data listener does not disturb hasDataListeners', () => {
+		const q = new IterableEventQueue();
+		const data = () => {};
+		const close = () => {};
+		q.on('data', data);
+		q.on('close', close);
+		q.off('close', close);
+		assert.equal(q.hasDataListeners, true, "removing a 'close' listener leaves data state intact");
+	});
+});


### PR DESCRIPTION
Fixes the native MCP server's GET server-push (SSE) channel, which never delivered server→client push on either profile despite advertising `tools/list_changed`/`resources/list_changed` and the `listChanged` dispatcher firing. The first two bugs were found by an external conformance suite and confirmed on `main` by instrumentation; a Bun-only operations-profile hang was then found and fixed via CI.

## Bugs

- **Application profile (Harper HTTP server) — GET never establishes.** Node defers transmitting response headers (after `writeHead`) until the first body byte; the SSE queue yields nothing until a push, so the GET hung with headers unsent until the client gave up. (The raw queue objects were never serialized to SSE text either.)
- **Operations profile (Fastify) — `list_changed` never delivered.** The GET established headers but `reply.send(IterableEventQueue)` sends headers then stalls after one chunk, so a dispatched `tools/list_changed` sat in the queue undelivered. Instrumentation confirmed the dispatcher fired and called `queue.send()`, but at send time the queue had **no consumer** (`resolveNext=false`).
- **Operations profile on Bun — GET hangs.** On Bun the operations API is bridged to Fastify via `fastify.inject()`, which resolves only when the response *ends* and buffers the payload. A long-lived SSE response never ends, so `await inject()` hung forever and headers never reached the client. Bun-only — the application profile uses Harper's own HTTP server and was unaffected (it establishes in ~97ms on Bun).

Root cause (first two): the adapters handed the raw `IterableEventQueue` to their server assuming it would SSE-frame + stream + flush it; neither does. The `listChanged` logic itself was correct.

## Fix

New `components/mcp/sse.ts` `toSseStream(queue)` — wraps the queue in a **primed, event-driven** Node `Readable` of SSE wire text:
- leading `:` comment makes the body non-empty so headers flush immediately (fixes the application hang);
- each frame serialized to `event:`/`data:`/`id:` (multi-line `data` split per the SSE spec);
- **event-driven teardown:** subscribes to the queue's `'data'`/`'close'` (not an async generator — a generator suspended at `await next()` can't be torn down on disconnect). On stream close (client disconnect) it unsubscribes and signals the queue so the session registry drops the entry; a server-side close (DELETE / superseding GET / idle-prune) ends the stream **without** re-emitting the queue's `'close'`; a default `'error'` guard keeps an unhandled stream error from crashing the worker.

Adapters / servers:
- **harperHttp** (application): returns the framed Readable as the body. `server/http.ts` no longer re-wraps an existing Node stream in `Readable.from()` — that wrapper swallowed `.destroy()`, leaking the socket/session on disconnect. Shared HTTP path; output behavior unchanged, only teardown improved.
- **fastify** (operations): `reply.hijack()` + write/flush headers on `reply.raw` + pipe the framed Readable, with an `'error'` handler that destroys the raw socket.
- **Bun bridge** (`server/http.ts` `bunDelegateToNodeServer`): `inject()` now uses `payloadAsStream` so it resolves at `writeHead` and exposes the body as a stream. `text/event-stream` responses stream to the client; everything else is drained to a single buffered payload (Content-Length preserved — equivalent to before). Client disconnect is propagated back to the hijacked reply so the session is cleaned up immediately. Bun-only.
- **sessionRegistry**: idle-prune skips sessions with a live SSE consumer (`hasDataListeners`), so a connected-but-idle stream isn't reaped.

## Where to look / things to weigh

- **`fastify.ts` hijack path** — the main correctness surface. It merges Fastify-accumulated headers (`reply.getHeaders()`, e.g. `@fastify/cors`) onto the raw response so a CORS-allowed browser isn't blocked. **Tradeoff (deliberate):** `hijack()` skips Fastify's `onSend`/`onResponse` hooks for this long-lived request, so per-request completion logging/metrics don't fire until the stream closes. Auth + the MCP handler already ran; this is the standard Fastify SSE pattern. Flagging for a reviewer who knows the operations-server telemetry expectations.
- **`server/http.ts` — two changes on shared, non-MCP paths.** (1) The Node body handler no longer re-wraps an existing `Readable` (affects every streaming HTTP response; output identical, only `.destroy()` propagation fixed). (2) The Bun inject bridge now reads every operations response as a stream via `payloadAsStream` (non-SSE responses drained to a buffer, equivalent to the prior behavior). Both are the areas most worth a careful look.

## Tests
- Integration `integrationTests/mcp/sse-listchanged.test.ts`: boots both profiles; asserts the application GET establishes (200, `text/event-stream`, no hang) and the operations profile delivers `tools/list_changed` after a role flip. Green on all runtimes in CI, including all six Bun shards (the Bun fix is validated end-to-end there).
- Unit `unitTests/components/mcp/sse.test.ts`: framing, priming, multi-line `data`, event-driven teardown, listener cleanup on disconnect, the `'error'` guard, and no-duplicate-`'close'` on server-side teardown.
- External MCP conformance suite: 164 pass; its two known-issue `it.fails` tests for these bugs were promoted to passing positive `it`s.

## Reviews
Codex + Gemini cross-model review across several passes. Findings, all fixed with tests: multi-line-`data` robustness, CORS-header drop, stream-close socket leak, flaky fixed-sleep tests, the Bun disconnect session-leak (added disconnect propagation), and the duplicate `'close'` emit. One Codex concern — application SSE hanging on Bun — was adjudicated a false positive: N1 establishes in ~97ms on Bun, which is incompatible with the buffering path.

## Not in scope (deliberately deferred)
Two minor conformance gaps the external suite documents are left for a follow-up — they're orthogonal to the SSE channel: no `WWW-Authenticate` header on a 401 handshake (`security/auth.ts`), and lenient JSON-RPC `id` shapes (`{}`/`[]` accepted; `jsonrpc.ts`).

Related: corrects #1349 §1 (the "GET-SSE push Implemented" claim).

🤖 Generated by an LLM (Claude Opus 4.8).
