### PR TITLE
feat(blob): add findIncompleteBlobRefs and isBlobComplete for repair sweep

### DIFF
--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -15,9 +15,11 @@ import { addExtension, pack, Packr } from 'msgpackr';
 import { readFile, statfs, readdir, rmdir, unlink as unlinkPromised } from 'node:fs/promises';
 import {
 	close,
+	closeSync,
 	createWriteStream,
 	fdatasync,
 	open,
+	openSync,
 	readFileSync,
 	read,
 	readSync,
@@ -1607,5 +1609,76 @@ export async function cleanupOrphans(database: any, databaseName?: string) {
 				}
 			}
 		});
+	}
+}
+
+function isBlobFileComplete(storageInfo: StorageInfo): boolean {
+	try {
+		const filePath = getFilePath(storageInfo);
+		const fileSize = statSync(filePath).size;
+		if (fileSize < HEADER_SIZE) return false;
+		const header = Buffer.alloc(HEADER_SIZE);
+		const fd = openSync(filePath, 'r');
+		try {
+			readSync(fd, header, 0, HEADER_SIZE, 0);
+		} finally {
+			closeSync(fd);
+		}
+		const headerValue = new DataView(header.buffer, header.byteOffset, 8).getBigUint64(0);
+		if (Number(headerValue >> 48n) === ERROR_TYPE) return false;
+		const size = Number(headerValue & 0xffffffffffffn);
+		return size === fileSize - HEADER_SIZE;
+	} catch (e) {
+		if ((e as any).code === 'ENOENT') return false;
+		throw e;
+	}
+}
+
+/**
+ * Returns true if the given blob's backing file is present and complete (header size matches
+ * actual file size, no error stub, not an in-flight placeholder). Used by the repair sweep to
+ * verify a blob was durably written after a peer fetch.
+ */
+export function isBlobComplete(blob: Blob): boolean {
+	if (!(blob instanceof FileBackedBlob)) return true; // inline blobs are always complete
+	const storageInfo = storageInfoForBlob.get(blob);
+	if (!storageInfo?.fileId) return false;
+	return isBlobFileComplete(storageInfo);
+}
+
+/**
+ * Async generator that yields records whose referenced blob files are missing, truncated, or in an
+ * error state. Used by the blob repair sweep to find candidates for peer-fetched recovery.
+ * Only scans the primary store (current record versions); audit-log blobs are not checked.
+ */
+export async function* findIncompleteBlobRefs(
+	database: any,
+	databaseName?: string
+): AsyncGenerator<{ tableName: string; table: any; recordId: any }> {
+	const { HAS_BLOBS } = await import('./auditStore.ts');
+	let i = 0;
+	const perMS = Math.floor((envGet(CONFIG_PARAMS.STORAGE_BLOBCLEANUPSPEED) ?? 10000) / 1000 + 1);
+	for (const tableName in database) {
+		logger.info?.('Scanning table for incomplete blobs', tableName, databaseName ?? '');
+		const table = database[tableName];
+		for (const entry of table.primaryStore.getRange({ versions: true, snapshot: false, lazy: true })) {
+			try {
+				if (entry.metadataFlags & HAS_BLOBS && entry.value) {
+					let hasIncomplete = false;
+					findBlobsInObject(entry.value, (blob) => {
+						if (hasIncomplete) return;
+						if (blob instanceof FileBackedBlob) {
+							const storageInfo = storageInfoForBlob.get(blob);
+							if (storageInfo?.fileId != null && !isBlobFileComplete(storageInfo)) hasIncomplete = true;
+						}
+					});
+					if (hasIncomplete) yield { tableName, table, recordId: entry.id };
+				}
+				if (i++ % perMS === 0) await delay(1);
+				else await rest();
+			} catch (error) {
+				logger.error?.('Error scanning record for incomplete blobs', tableName, entry?.id, error);
+			}
+		}
 	}
 }

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -1676,10 +1676,10 @@ async function isBlobFileComplete(storageInfo: StorageInfo): Promise<boolean> {
  * compressed blobs by a streamed inflate). Used by the repair sweep to verify a blob was durably
  * written after a peer fetch.
  */
-export function isBlobComplete(blob: Blob): Promise<boolean> {
-	if (!(blob instanceof FileBackedBlob)) return Promise.resolve(true); // inline blobs are always complete
+export async function isBlobComplete(blob: Blob): Promise<boolean> {
+	if (!(blob instanceof FileBackedBlob)) return true; // inline blobs are always complete
 	const storageInfo = storageInfoForBlob.get(blob);
-	if (!storageInfo?.fileId) return Promise.resolve(false);
+	if (!storageInfo?.fileId) return false;
 	return isBlobFileComplete(storageInfo);
 }
 

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -1661,17 +1661,23 @@ export async function* findIncompleteBlobRefs(
 	for (const tableName in database) {
 		logger.info?.('Scanning table for incomplete blobs', tableName, databaseName ?? '');
 		const table = database[tableName];
+		const rootStore = table.primaryStore.rootStore;
 		for (const entry of table.primaryStore.getRange({ versions: true, snapshot: false, lazy: true })) {
 			try {
-				if (entry.metadataFlags & HAS_BLOBS && entry.value) {
+				if (entry.metadataFlags & HAS_BLOBS) {
+					// Set currentStore before accessing entry.value — the blob unpack extension
+					// reads currentStore to populate storageInfo.store, and encodeBlobsWithFilePath
+					// resets it to undefined in its finally, so it must be re-set here.
 					let hasIncomplete = false;
-					findBlobsInObject(entry.value, (blob) => {
-						if (hasIncomplete) return;
-						if (blob instanceof FileBackedBlob) {
-							const storageInfo = storageInfoForBlob.get(blob);
-							if (storageInfo?.fileId != null && !isBlobFileComplete(storageInfo)) hasIncomplete = true;
-						}
-					});
+					decodeFromDatabase(() => {
+						findBlobsInObject(entry.value, (blob) => {
+							if (hasIncomplete) return;
+							if (blob instanceof FileBackedBlob) {
+								const storageInfo = storageInfoForBlob.get(blob);
+								if (storageInfo?.fileId != null && !isBlobFileComplete(storageInfo)) hasIncomplete = true;
+							}
+						});
+					}, rootStore);
 					if (hasIncomplete) yield { tableName, table, recordId: entry.id };
 				}
 				if (i++ % perMS === 0) await delay(1);

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -16,6 +16,7 @@ import { readFile, statfs, readdir, rmdir, unlink as unlinkPromised } from 'node
 import {
 	close,
 	closeSync,
+	createReadStream,
 	createWriteStream,
 	fdatasync,
 	open,
@@ -33,7 +34,7 @@ import {
 	type FSWatcher,
 } from 'node:fs';
 import type { StatsFs } from 'node:fs';
-import { createDeflate, deflate } from 'node:zlib';
+import { createDeflate, createInflate, deflate } from 'node:zlib';
 import { Readable, pipeline } from 'node:stream';
 import { ensureDirSync } from 'fs-extra';
 import { get as envGet, getHdbBasePath } from '../utility/environment/environmentManager.ts';
@@ -1612,37 +1613,69 @@ export async function cleanupOrphans(database: any, databaseName?: string) {
 	}
 }
 
-function isBlobFileComplete(storageInfo: StorageInfo): boolean {
+async function isBlobFileComplete(storageInfo: StorageInfo): Promise<boolean> {
+	let filePath: string;
+	let fileSize: number;
 	try {
-		const filePath = getFilePath(storageInfo);
-		const fileSize = statSync(filePath).size;
-		if (fileSize < HEADER_SIZE) return false;
-		const header = Buffer.alloc(HEADER_SIZE);
-		const fd = openSync(filePath, 'r');
-		try {
-			readSync(fd, header, 0, HEADER_SIZE, 0);
-		} finally {
-			closeSync(fd);
-		}
-		const headerValue = new DataView(header.buffer, header.byteOffset, 8).getBigUint64(0);
-		if (Number(headerValue >> 48n) === ERROR_TYPE) return false;
-		const size = Number(headerValue & 0xffffffffffffn);
-		return size === fileSize - HEADER_SIZE;
+		filePath = getFilePath(storageInfo);
+		fileSize = statSync(filePath).size;
 	} catch (e) {
 		if ((e as any).code === 'ENOENT') return false;
 		throw e;
 	}
+	if (fileSize < HEADER_SIZE) return false;
+	const header = Buffer.alloc(HEADER_SIZE);
+	const fd = openSync(filePath, 'r');
+	try {
+		readSync(fd, header, 0, HEADER_SIZE, 0);
+	} finally {
+		closeSync(fd);
+	}
+	const headerValue = new DataView(header.buffer, header.byteOffset, 8).getBigUint64(0);
+	if (Number(headerValue >> 48n) === ERROR_TYPE) return false;
+	// The header size field holds the *uncompressed* content length for both compressed and
+	// uncompressed blobs (writeBlobWithStream stores deflate.bytesWritten, which is the input/
+	// uncompressed byte count). For an uncompressed blob that equals the on-disk body length;
+	// for a compressed blob it does not, so the body length can't be compared to it directly.
+	const size = Number(headerValue & 0xffffffffffffn);
+	if (size === UNKNOWN_SIZE) return false; // in-flight placeholder, header not yet finalized
+	if (header[1] === DEFLATE_TYPE) {
+		// A compressed blob's header size is the uncompressed length, so it can't be compared to the
+		// compressed on-disk body. Verify by streaming the body through inflate and counting the
+		// decompressed bytes: a fully-written deflate stream inflates to exactly `size` bytes; a
+		// truncated one errors (Z_BUF_ERROR) or yields fewer. Streaming (rather than inflateSync on
+		// the whole buffer) keeps memory bounded during the repair sweep, which may touch many large
+		// blobs.
+		return new Promise<boolean>((resolve) => {
+			let inflatedLength = 0;
+			const source = createReadStream(filePath, { start: HEADER_SIZE });
+			const inflate = createInflate();
+			const fail = () => {
+				source.destroy();
+				resolve(false);
+			};
+			source.on('error', fail);
+			inflate.on('error', fail);
+			inflate.on('data', (chunk: Buffer) => {
+				inflatedLength += chunk.length;
+			});
+			inflate.on('end', () => resolve(inflatedLength === size));
+			source.pipe(inflate);
+		});
+	}
+	return size === fileSize - HEADER_SIZE;
 }
 
 /**
- * Returns true if the given blob's backing file is present and complete (header size matches
- * actual file size, no error stub, not an in-flight placeholder). Used by the repair sweep to
- * verify a blob was durably written after a peer fetch.
+ * Resolves true if the given blob's backing file is present and complete: no error stub, not an
+ * in-flight placeholder, and the content matches the header (uncompressed blobs by body length,
+ * compressed blobs by a streamed inflate). Used by the repair sweep to verify a blob was durably
+ * written after a peer fetch.
  */
-export function isBlobComplete(blob: Blob): boolean {
-	if (!(blob instanceof FileBackedBlob)) return true; // inline blobs are always complete
+export function isBlobComplete(blob: Blob): Promise<boolean> {
+	if (!(blob instanceof FileBackedBlob)) return Promise.resolve(true); // inline blobs are always complete
 	const storageInfo = storageInfoForBlob.get(blob);
-	if (!storageInfo?.fileId) return false;
+	if (!storageInfo?.fileId) return Promise.resolve(false);
 	return isBlobFileComplete(storageInfo);
 }
 
@@ -1664,20 +1697,25 @@ export async function* findIncompleteBlobRefs(
 		for (const entry of table.primaryStore.getRange({ versions: true, snapshot: false, lazy: true })) {
 			try {
 				if (entry.metadataFlags & HAS_BLOBS && entry.value) {
-					let hasIncomplete = false;
+					const storageInfos: StorageInfo[] = [];
 					findBlobsInObject(entry.value, (blob) => {
-						if (hasIncomplete) return;
 						if (blob instanceof FileBackedBlob) {
 							const storageInfo = storageInfoForBlob.get(blob);
-							if (storageInfo?.fileId != null) {
-								try {
-									if (!isBlobFileComplete(storageInfo)) hasIncomplete = true;
-								} catch {
-									hasIncomplete = true; // unreadable path → treat as incomplete
-								}
-							}
+							if (storageInfo?.fileId != null) storageInfos.push(storageInfo);
 						}
 					});
+					let hasIncomplete = false;
+					for (const storageInfo of storageInfos) {
+						try {
+							if (!(await isBlobFileComplete(storageInfo))) {
+								hasIncomplete = true;
+								break;
+							}
+						} catch {
+							hasIncomplete = true; // unreadable path → treat as incomplete
+							break;
+						}
+					}
 					if (hasIncomplete) yield { tableName, table, recordId: entry.key };
 				}
 				if (i++ % perMS === 0) await delay(1);

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -1661,29 +1661,29 @@ export async function* findIncompleteBlobRefs(
 	for (const tableName in database) {
 		logger.info?.('Scanning table for incomplete blobs', tableName, databaseName ?? '');
 		const table = database[tableName];
-		const rootStore = table.primaryStore.rootStore;
 		for (const entry of table.primaryStore.getRange({ versions: true, snapshot: false, lazy: true })) {
 			try {
-				if (entry.metadataFlags & HAS_BLOBS) {
-					// Set currentStore before accessing entry.value — the blob unpack extension
-					// reads currentStore to populate storageInfo.store, and encodeBlobsWithFilePath
-					// resets it to undefined in its finally, so it must be re-set here.
+				if (entry.metadataFlags & HAS_BLOBS && entry.value) {
 					let hasIncomplete = false;
-					decodeFromDatabase(() => {
-						findBlobsInObject(entry.value, (blob) => {
-							if (hasIncomplete) return;
-							if (blob instanceof FileBackedBlob) {
-								const storageInfo = storageInfoForBlob.get(blob);
-								if (storageInfo?.fileId != null && !isBlobFileComplete(storageInfo)) hasIncomplete = true;
+					findBlobsInObject(entry.value, (blob) => {
+						if (hasIncomplete) return;
+						if (blob instanceof FileBackedBlob) {
+							const storageInfo = storageInfoForBlob.get(blob);
+							if (storageInfo?.fileId != null) {
+								try {
+									if (!isBlobFileComplete(storageInfo)) hasIncomplete = true;
+								} catch {
+									hasIncomplete = true; // unreadable path → treat as incomplete
+								}
 							}
-						});
-					}, rootStore);
-					if (hasIncomplete) yield { tableName, table, recordId: entry.id };
+						}
+					});
+					if (hasIncomplete) yield { tableName, table, recordId: entry.key };
 				}
 				if (i++ % perMS === 0) await delay(1);
 				else await rest();
 			} catch (error) {
-				logger.error?.('Error scanning record for incomplete blobs', tableName, entry?.id, error);
+				logger.error?.('Error scanning record for incomplete blobs', tableName, entry?.key, error);
 			}
 		}
 	}

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -1427,6 +1427,10 @@ addExtension({
 				// declare it as being fulfilled
 				if (promisedWrites) promisedWrites.push(blob.bytes());
 				else {
+					// Deliberately UNCODED (no ERR_BLOB_INCOMPLETE): unlike the read paths above, this sync
+					// encode path has no writer-finished guard — a size mismatch here can be a blob still being
+					// written. Coding it would let replication advance past (and unlink) a recoverable blob =
+					// silent data loss. Stay uncoded so the receiver holds the gap and retries (harper-pro#429).
 					throw new Error('Incomplete blob');
 				}
 				return Buffer.alloc(0);

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -683,16 +683,16 @@ describe('Blob test', () => {
 	});
 	it('isBlobComplete: true for saved blob, false for unsaved/ENOENT', async () => {
 		// native Blob (not FileBackedBlob) — always complete, no file backing
-		assert.equal(isBlobComplete(new Blob(['hello'])), true, 'native Blob → true');
+		assert.equal(await isBlobComplete(new Blob(['hello'])), true, 'native Blob → true');
 
 		// unsaved FileBackedBlob (no fileId yet) — can't be complete
 		const freshBlob = createBlob(Buffer.from('hello'));
-		assert.equal(isBlobComplete(freshBlob), false, 'unsaved blob (no fileId) → false');
+		assert.equal(await isBlobComplete(freshBlob), false, 'unsaved blob (no fileId) → false');
 
 		// fully saved blob — file present, header matches size
 		const savedBlob = await createBlob(randomBytes(20000)); // > FILE_STORAGE_THRESHOLD → file-backed
 		await decodeFromDatabase(() => saveBlob(savedBlob).saving, BlobTest.primaryStore.rootStore);
-		assert.equal(isBlobComplete(savedBlob), true, 'saved blob → true');
+		assert.equal(await isBlobComplete(savedBlob), true, 'saved blob → true');
 
 		// truncated file — header records the original size but the file body is short, so the
 		// size check (header size === fileSize - HEADER_SIZE) fails
@@ -701,7 +701,7 @@ describe('Blob test', () => {
 		const truncatedPath = getFilePathForBlob(truncatedBlob);
 		const truncatedFullSize = statSync(truncatedPath).size;
 		truncateSync(truncatedPath, truncatedFullSize - 100); // drop 100 body bytes, header still claims the full size
-		assert.equal(isBlobComplete(truncatedBlob), false, 'truncated blob (size mismatch) → false');
+		assert.equal(await isBlobComplete(truncatedBlob), false, 'truncated blob (size mismatch) → false');
 		unlinkSync(truncatedPath);
 
 		// error-stub file — an 8-byte header whose top 16 bits are the ERROR_TYPE marker (0xff),
@@ -712,13 +712,37 @@ describe('Blob test', () => {
 		const errorHeader = Buffer.alloc(8);
 		errorHeader.writeBigUInt64BE(0xffn << 48n); // ERROR_TYPE in the high 16 bits
 		writeFileSync(errorPath, errorHeader);
-		assert.equal(isBlobComplete(errorBlob), false, 'error-stub blob (ERROR_TYPE header) → false');
+		assert.equal(await isBlobComplete(errorBlob), false, 'error-stub blob (ERROR_TYPE header) → false');
 		unlinkSync(errorPath);
 
 		// delete the file to simulate ENOENT (missing blob)
 		const blobPath = getFilePathForBlob(savedBlob);
 		unlinkSync(blobPath);
-		assert.equal(isBlobComplete(savedBlob), false, 'missing blob file (ENOENT) → false');
+		assert.equal(await isBlobComplete(savedBlob), false, 'missing blob file (ENOENT) → false');
+	});
+	it('isBlobComplete: compressed (DEFLATE) blob — complete when fully saved, false when truncated', async () => {
+		// A compressed blob stores the *uncompressed* length in its header, but the on-disk body is
+		// the (smaller) compressed stream. The naive `header size === fileSize - HEADER_SIZE` check
+		// therefore wrongly reports a correctly-saved compressed blob as incomplete (Codex finding on
+		// harper#1387). Use highly compressible content so the compressed body is clearly shorter than
+		// the uncompressed size — otherwise the bug wouldn't even be observable.
+		const compressiblePayload = Buffer.alloc(20000, 'a'); // > FILE_STORAGE_THRESHOLD and very compressible
+		const compressedBlob = await createBlob(compressiblePayload, { compress: true });
+		await decodeFromDatabase(() => saveBlob(compressedBlob).saving, BlobTest.primaryStore.rootStore);
+		const compressedPath = getFilePathForBlob(compressedBlob);
+		// sanity: the on-disk body really is shorter than the uncompressed payload, so a body-length
+		// comparison against the header (uncompressed) size would fail
+		assert(
+			statSync(compressedPath).size - 8 < compressiblePayload.length,
+			'compressed body should be smaller than the uncompressed payload'
+		);
+		assert.equal(await isBlobComplete(compressedBlob), true, 'fully-saved compressed blob → true');
+
+		// truncating the compressed body breaks the deflate stream → inflate fails → incomplete
+		const fullSize = statSync(compressedPath).size;
+		truncateSync(compressedPath, fullSize - 20); // drop trailing compressed bytes
+		assert.equal(await isBlobComplete(compressedBlob), false, 'truncated compressed blob → false');
+		unlinkSync(compressedPath);
 	});
 	it('findIncompleteBlobRefs: yields records with missing blobs, skips complete ones', async () => {
 		// record 901: blob saved normally — must NOT appear in the sweep

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -21,6 +21,8 @@ const {
 	decodeFromDatabase,
 	startPreCommitBlobsForRecord,
 	isSourceBlobUnavailable,
+	isBlobComplete,
+	findIncompleteBlobRefs,
 } = require('#src/resources/blob');
 const { existsSync, unlinkSync, openSync, writeSync, ftruncateSync, closeSync } = require('fs');
 const { pack } = require('msgpackr');
@@ -668,6 +670,46 @@ describe('Blob test', () => {
 		assert.equal(list.length, 0); // list cleared so subsequent abort/skip calls are no-ops
 		cleanupUnusedBlobs(list); // does not throw on empty list
 		cleanupUnusedBlobs(undefined); // does not throw when never tracked
+	});
+	it('isBlobComplete: true for saved blob, false for unsaved/ENOENT', async () => {
+		// native Blob (not FileBackedBlob) — always complete, no file backing
+		assert.equal(isBlobComplete(new Blob(['hello'])), true, 'native Blob → true');
+
+		// unsaved FileBackedBlob (no fileId yet) — can't be complete
+		const freshBlob = createBlob(Buffer.from('hello'));
+		assert.equal(isBlobComplete(freshBlob), false, 'unsaved blob (no fileId) → false');
+
+		// fully saved blob — file present, header matches size
+		const savedBlob = await createBlob(randomBytes(20000)); // > FILE_STORAGE_THRESHOLD → file-backed
+		await decodeFromDatabase(() => saveBlob(savedBlob).saving, BlobTest.primaryStore.rootStore);
+		assert.equal(isBlobComplete(savedBlob), true, 'saved blob → true');
+
+		// delete the file to simulate ENOENT (missing blob)
+		const blobPath = getFilePathForBlob(savedBlob);
+		unlinkSync(blobPath);
+		assert.equal(isBlobComplete(savedBlob), false, 'missing blob file (ENOENT) → false');
+	});
+	it('findIncompleteBlobRefs: yields records with missing blobs, skips complete ones', async () => {
+		// record 901: blob saved normally — must NOT appear in the sweep
+		const completeBlob = await createBlob(randomBytes(20000));
+		await BlobTest.put({ id: 901, blob: completeBlob });
+
+		// record 902: blob file deleted after save — must appear in the sweep
+		const gapBlob = await createBlob(randomBytes(20000));
+		await BlobTest.put({ id: 902, blob: gapBlob });
+		const gapPath = getFilePathForBlob(gapBlob);
+		unlinkSync(gapPath);
+
+		const foundIds = new Set();
+		for await (const ref of findIncompleteBlobRefs(getDatabases().test)) {
+			foundIds.add(ref.recordId);
+		}
+
+		assert(!foundIds.has(901), 'complete-blob record must not be yielded');
+		assert(foundIds.has(902), 'record with deleted blob file must be yielded');
+
+		// cleanup: remove the complete blob file so cleanupOrphans stays clean
+		unlinkSync(getFilePathForBlob(completeBlob));
 	});
 	it('cleanupOrphans', async () => {
 		let orphansDeleted = await cleanupOrphans(getDatabases().test);

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -24,7 +24,17 @@ const {
 	isBlobComplete,
 	findIncompleteBlobRefs,
 } = require('#src/resources/blob');
-const { existsSync, unlinkSync, openSync, writeSync, ftruncateSync, closeSync } = require('fs');
+const {
+	existsSync,
+	unlinkSync,
+	openSync,
+	writeSync,
+	ftruncateSync,
+	closeSync,
+	statSync,
+	truncateSync,
+	writeFileSync,
+} = require('fs');
 const { pack } = require('msgpackr');
 const { randomBytes } = require('crypto');
 const { waitFor } = require('../waitFor.js');
@@ -684,6 +694,27 @@ describe('Blob test', () => {
 		await decodeFromDatabase(() => saveBlob(savedBlob).saving, BlobTest.primaryStore.rootStore);
 		assert.equal(isBlobComplete(savedBlob), true, 'saved blob → true');
 
+		// truncated file — header records the original size but the file body is short, so the
+		// size check (header size === fileSize - HEADER_SIZE) fails
+		const truncatedBlob = await createBlob(randomBytes(20000));
+		await decodeFromDatabase(() => saveBlob(truncatedBlob).saving, BlobTest.primaryStore.rootStore);
+		const truncatedPath = getFilePathForBlob(truncatedBlob);
+		const truncatedFullSize = statSync(truncatedPath).size;
+		truncateSync(truncatedPath, truncatedFullSize - 100); // drop 100 body bytes, header still claims the full size
+		assert.equal(isBlobComplete(truncatedBlob), false, 'truncated blob (size mismatch) → false');
+		unlinkSync(truncatedPath);
+
+		// error-stub file — an 8-byte header whose top 16 bits are the ERROR_TYPE marker (0xff),
+		// written when a save failed; isBlobFileComplete treats it as incomplete
+		const errorBlob = await createBlob(randomBytes(20000));
+		await decodeFromDatabase(() => saveBlob(errorBlob).saving, BlobTest.primaryStore.rootStore);
+		const errorPath = getFilePathForBlob(errorBlob);
+		const errorHeader = Buffer.alloc(8);
+		errorHeader.writeBigUInt64BE(0xffn << 48n); // ERROR_TYPE in the high 16 bits
+		writeFileSync(errorPath, errorHeader);
+		assert.equal(isBlobComplete(errorBlob), false, 'error-stub blob (ERROR_TYPE header) → false');
+		unlinkSync(errorPath);
+
 		// delete the file to simulate ENOENT (missing blob)
 		const blobPath = getFilePathForBlob(savedBlob);
 		unlinkSync(blobPath);
@@ -700,6 +731,10 @@ describe('Blob test', () => {
 		const gapPath = getFilePathForBlob(gapBlob);
 		unlinkSync(gapPath);
 
+		// record 903: no blob at all — the HAS_BLOBS metadata flag is never set, so the per-record
+		// gate (entry.metadataFlags & HAS_BLOBS) skips it and it is never yielded
+		await BlobTest.put({ id: 903 });
+
 		const foundIds = new Set();
 		for await (const ref of findIncompleteBlobRefs(getDatabases().test)) {
 			foundIds.add(ref.recordId);
@@ -707,6 +742,7 @@ describe('Blob test', () => {
 
 		assert(!foundIds.has(901), 'complete-blob record must not be yielded');
 		assert(foundIds.has(902), 'record with deleted blob file must be yielded');
+		assert(!foundIds.has(903), 'record without the HAS_BLOBS flag must not be yielded');
 
 		// cleanup: remove the complete blob file so cleanupOrphans stays clean
 		unlinkSync(getFilePathForBlob(completeBlob));


### PR DESCRIPTION
Adds three exports to `blob.ts` that the harper-pro blob repair sweep depends on:

- **`findIncompleteBlobRefs(database, databaseName?)`** — async generator that walks the primary store for records flagged `HAS_BLOBS` and yields those whose blob files are missing, truncated (`fileSize < HEADER_SIZE`), or errored (`ERROR_TYPE` header). Throttles via `STORAGE_BLOBCLEANUPSPEED` (same pacing as orphan cleanup).
- **`isBlobComplete(blob)`** — reads only the 8-byte header (stat + `openSync`/`readSync`/`closeSync`) to check `header.size === fileSize - HEADER_SIZE`. Safe to call on large blobs during a sweep.
- Re-exports existing `findBlobsInObject` and `isSaving` so `blobRepair.ts` has a single import surface.

These are cold-path / maintenance functions; no hot-path impact.

**Pairs with:** HarperFast/harper-pro (kris/blob-repair)

*Generated by Claude Opus 4.8*