### PR TITLE
test(blob): correct complete() fault contract for track-only vs needs-saving blobs (#1353/#1376)

### DIFF
--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -563,27 +563,69 @@ describe('Blob test', () => {
 		assert.equal(isSourceBlobUnavailable(null), false);
 		assert.equal(isSourceBlobUnavailable(undefined), false);
 	});
-	it('startPreCommitBlobsForRecord.complete() tolerates a source-missing blob but still rejects a transient fault', async () => {
-		// harper-pro#403/#388: a replicated record whose blob is gone at the source must still commit (blob
-		// diverged, backfilled later) rather than aborting the apply and wedging the copy stream. A genuine
-		// local/transient save fault must still abort the write so it is retried (no silent data loss).
+	it('complete() fault contract: needs-saving aborts on a transient fault, track-only never aborts (#1353/#1376)', async () => {
+		// CONTRACT HISTORY — do not "restore" the old all-blobs-abort assertion:
+		//   #1353 introduced complete() awaiting EVERY pre-commit blob, so any save fault (even on an
+		//     already-saving, replication-received blob) aborted the commit.
+		//   #1376 then split pre-commit blobs into two sets and changed the contract:
+		//     - blobsNeedingSaving (saveInRecord / saveBeforeCommit): complete() awaits these. A
+		//       transient/local fault MUST still reject → the write aborts and retries (no silent loss).
+		//       A replication source-missing blob (sourceBlobUnavailable marker) is tolerated so the
+		//       record still commits with a diverged reference, backfilled later (harper-pro#403/#388).
+		//     - blobsToTrackOnly (already-saving, replication-received): complete() deliberately does
+		//       NOT await these — awaiting a paused/back-pressured copy stream's blob would deadlock the
+		//       WS (commit fails → onCommit never fires → outstandingCommits never decrements →
+		//       WS paused forever, harper-pro#414). Their durability is NOT enforced by commit-abort
+		//       anymore; it moved to the replication resume cursor: a fault sets hasBlobGap=true and
+		//       pins lastDurableSequenceId so the blob is re-streamed on reconnect
+		//       (harper-pro replication/replicationConnection.ts).
+		// So a transient fault aborts ONLY on the needs-saving path; on the track-only path complete()
+		// must NOT reject. The pre-#1376 assertion drove the fault through the track-only path, which is
+		// why it became stale: complete() no longer awaits that set.
 		const store = BlobTest.primaryStore.rootStore;
 
-		// source-unavailable: destroy the receive stream with the replication marker → saving rejects → tolerated
-		const goneStream = new PassThrough();
-		const goneBlob = await createBlob(goneStream);
-		decodeFromDatabase(() => saveBlob(goneBlob, true), store); // start the save (assigns fileId, begins the pipeline)
-		const toleratePc = startPreCommitBlobsForRecord({ id: 1, blob: goneBlob }, store, false, true);
-		goneStream.destroy(Object.assign(new Error('Blob error: ENOENT'), { sourceBlobUnavailable: true }));
-		await assert.doesNotReject(toleratePc.complete(), 'source-unavailable blob must not abort the commit');
+		// --- needs-saving path (saveBeforeCommit) ---
 
-		// transient/local fault: unmarked rejection must still propagate so the write aborts and retries
+		// transient/local fault → complete() awaits the save and the unmarked rejection MUST propagate so
+		// the write aborts and retries.
 		const failStream = new PassThrough();
-		const failBlob = await createBlob(failStream);
-		decodeFromDatabase(() => saveBlob(failBlob, true), store);
-		const rejectPc = startPreCommitBlobsForRecord({ id: 2, blob: failBlob }, store, false, true);
+		const failBlob = await createBlob(failStream, { saveBeforeCommit: true });
+		const rejectPc = startPreCommitBlobsForRecord({ id: 1, blob: failBlob }, store, false, true);
 		failStream.destroy(new Error('disk full')); // no sourceBlobUnavailable marker
-		await assert.rejects(rejectPc.complete(), 'a local/transient save fault must still abort the commit');
+		await assert.rejects(
+			rejectPc.complete(),
+			'a local/transient save fault on a needs-saving blob must still abort the commit'
+		);
+
+		// source-unavailable → the replication marker is tolerated even on the awaited needs-saving path,
+		// so the record still commits with a diverged reference.
+		const goneStream = new PassThrough();
+		const goneBlob = await createBlob(goneStream, { saveBeforeCommit: true });
+		const toleratePc = startPreCommitBlobsForRecord({ id: 2, blob: goneBlob }, store, false, true);
+		goneStream.destroy(Object.assign(new Error('Blob error: ENOENT'), { sourceBlobUnavailable: true }));
+		await assert.doesNotReject(toleratePc.complete(), 'a source-unavailable blob must not abort the commit');
+
+		// --- track-only path (already-saving replication-received blob) ---
+
+		// A replication-received blob is saved out-of-band before the apply (fileId already set, no
+		// saveBeforeCommit), so startPreCommitBlobsForRecord(trackPersistedBlobs=true) puts it in
+		// blobsToTrackOnly. complete() must NOT await it: a transient fault here does NOT abort the commit
+		// (durability is the resume cursor's job via hasBlobGap — see comment above). Without this, a
+		// paused copy stream would deadlock the WS (harper-pro#414).
+		const trackOnlyStream = new PassThrough();
+		const trackOnlyBlob = await createBlob(trackOnlyStream);
+		decodeFromDatabase(() => saveBlob(trackOnlyBlob, true), store); // out-of-band save: assigns fileId, begins the pipeline
+		isSaving(trackOnlyBlob)?.catch(() => {}); // complete() won't await this save, so absorb its rejection ourselves
+		const trackOnlyPc = startPreCommitBlobsForRecord({ id: 3, blob: trackOnlyBlob }, store, false, true);
+		assert(
+			trackOnlyPc && trackOnlyPc.blobs.includes(trackOnlyBlob),
+			'an already-saved replication blob is tracked for cleanup'
+		);
+		trackOnlyStream.destroy(new Error('disk full')); // unmarked transient fault on the track-only blob
+		await assert.doesNotReject(
+			trackOnlyPc.complete(),
+			'a transient fault on a track-only blob must NOT abort the commit (durability handled by the resume cursor)'
+		);
 	});
 	it('#406: cleanupUnusedBlobs deletes non-retained blobs but keeps retained ones', async () => {
 		// The retained-fileId guard: a skipped/aborted write may carry a blob whose fileId the surviving


### PR DESCRIPTION
## Summary
Fixes the RED unit test on `main` in `unitTests/resources/blob.test.js`: the case asserting `startPreCommitBlobsForRecord().complete()` "tolerates a source-missing blob but still rejects a transient fault." This is a **stale test assertion**, not a code regression — `resources/blob.ts` is unchanged.

## Why it was red
- **#1353** made `complete()` await **every** pre-commit blob, so any save fault aborted the commit. The test was written against that behavior.
- **#1376** then split pre-commit blobs into:
  - `blobsNeedingSaving` (`saveInRecord` / `saveBeforeCommit`) — still awaited by `complete()`; a transient fault must still reject (abort + retry), while a replication source-missing blob (`sourceBlobUnavailable`) is tolerated.
  - `blobsToTrackOnly` (already-saving, replication-received) — **deliberately not awaited**, to avoid a WS deadlock when a back-pressured copy stream can't supply more chunks (harper-pro#414). Their durability moved to the replication **resume cursor** (`hasBlobGap` pins `lastDurableSequenceId` → blob re-streamed on reconnect).

The old test drove the transient-fault blob through the **track-only** path, which `complete()` no longer awaits, so the expected rejection never fired → `Missing expected rejection`.

## What changed (test-only)
- The "transient fault must still abort" assertion now targets a **needs-saving** (`saveBeforeCommit`) blob, where abort remains the contract.
- A **new** case asserts a transient fault on a **track-only** blob does **not** abort the commit (durability is the resume cursor's job).
- The **source-unavailable → tolerated** case is kept and moved onto the awaited needs-saving path, so it now genuinely exercises the `isSourceBlobUnavailable` tolerance in `complete()` (previously it passed vacuously, since track-only blobs aren't awaited).
- A `CONTRACT HISTORY` comment records the #1353→#1376 change so the next reader doesn't "fix" it back.

## Impact
- **Not** a v5.1.5 data-loss regression; no 5.1.6 code patch is needed.
- Merging turns `main`'s unit suite green again — it's currently blocking clean unit signal on every PR, so it should land promptly.

## Where to look
`unitTests/resources/blob.test.js` — the single rewritten `it(...)` block. No production code touched.

## Verification
- `blob.test.js`: 28 pass / 1 fail → **29 pass / 0 fail** (stable across repeated runs).
- `test:unit:resources`: 841 passing, 14 pending, 0 failing.
- `test:unit:main`: 2755 passing, 188 pending, 0 failing.
- Codex cross-model review: no regression found.

---
_Generated by Claude (Opus 4.8)._