### PR TITLE
Add workload descriptions to YCSB benchmark series names

### DIFF
--- a/benchmarks/ycsb/README.md
+++ b/benchmarks/ycsb/README.md
@@ -70,9 +70,13 @@ node benchmarks/ycsb/run-single-node.mts --engine=lmdb --threads=4
 ### Flags
 
 `--scale` `--records` `--ops` `--concurrency` `--load-concurrency` `--fields`
-`--field-length` `--scan-max` `--warmup` `--workloads` `--distribution`
+`--field-length` `--scan-max` `--warmup` `--reps` `--workloads` `--distribution`
 `--engine` (`rocksdb`|`lmdb`) `--threads` `--out` `--startup-timeout`.
 Individual flags override the scale preset.
+
+`--reps` (default 1) runs each workload N times and reports the **median rep by
+throughput** — robust to a single degenerate rep. Warmup runs once per workload,
+not per rep. The cluster runner defaults this to 3 to dampen its higher variance.
 
 ## Output
 

--- a/benchmarks/ycsb/harness.mts
+++ b/benchmarks/ycsb/harness.mts
@@ -30,6 +30,7 @@ export interface BenchmarkConfig {
 	maxScanLength: number;
 	warmupOps: number;
 	workloads: string[];
+	reps: number;
 	distribution?: DistributionName;
 	table: string;
 }
@@ -67,6 +68,7 @@ export function parseOptions(argv: string[]): ParsedOptions {
 			'field-length': { type: 'string', default: '100' },
 			'scan-max': { type: 'string', default: '100' },
 			'warmup': { type: 'string' },
+			'reps': { type: 'string', default: '1' },
 			'workloads': { type: 'string', default: DEFAULT_WORKLOAD_ORDER.join(',') },
 			'distribution': { type: 'string' },
 			'engine': { type: 'string', default: 'rocksdb' },
@@ -101,6 +103,7 @@ export function parseOptions(argv: string[]): ParsedOptions {
 		maxScanLength: Number(values['scan-max']),
 		warmupOps: values.warmup ? Number(values.warmup) : Math.min(opsPerWorkload, 20_000),
 		workloads,
+		reps: Math.max(1, Number(values.reps)),
 		distribution: values.distribution as DistributionName | undefined,
 		table: 'usertable',
 	};
@@ -122,6 +125,20 @@ function keyWidth(config: BenchmarkConfig): number {
 	return Math.max(10, String(config.records + config.opsPerWorkload).length);
 }
 
+/**
+ * Picks the median run by throughput from a set of repetitions of the same
+ * workload. Returning a whole rep (rather than computing each metric's median
+ * independently) keeps the reported throughput and its latency block internally
+ * consistent — they come from one real run. Robust to a single degenerate rep:
+ * an outlier sorts to an end and is never selected. For an even count we take the
+ * lower-middle (the more conservative throughput), avoiding any averaging of two
+ * runs' incompatible latency blocks.
+ */
+function medianByThroughput(reps: PhaseResult[]): PhaseResult {
+	const sorted = [...reps].sort((a, b) => a.throughput - b.throughput);
+	return sorted[Math.floor((sorted.length - 1) / 2)];
+}
+
 export interface WorkloadResult {
 	name: string;
 	description: string;
@@ -131,6 +148,10 @@ export interface WorkloadResult {
 	elapsedMs: number;
 	throughput: number;
 	latency: Partial<Record<OperationType, LatencyStats>>;
+	// Number of repetitions run for this workload; when >1 the fields above are the
+	// median rep (by throughput) and `repThroughputs` lists every rep for transparency.
+	reps?: number;
+	repThroughputs?: number[];
 }
 
 export interface BenchmarkResults {
@@ -219,36 +240,56 @@ export async function runBenchmark(
 		}
 
 		// --- Run phase: each selected workload against the loaded dataset ---
+		// Each workload runs `config.reps` times; the reported point is the median rep
+		// (by throughput), which keeps a single degenerate rep from skewing the trend.
+		// Warmup above runs once per workload set (not per rep) — the dataset is already
+		// hot after the first rep, so re-warming each rep would only add runtime without
+		// changing what's measured.
 		const workloadResults: WorkloadResult[] = [];
 		for (const name of config.workloads) {
 			const spec = WORKLOADS[name];
 			const distribution = config.distribution ?? spec.distribution;
-			log(`\n[workload ${name}] ${spec.description} — ${distribution}, ${config.opsPerWorkload.toLocaleString()} ops`);
-			const keys = new KeyState({
-				distribution,
-				initialKeyCount: config.records,
-				keyWidth: width,
-				shape,
-				maxScanLength: config.maxScanLength,
-			});
-			const result: PhaseResult = await runOperations({
-				opCount: config.opsPerWorkload,
-				concurrency: config.concurrency,
-				mix: spec.mix,
-				executor,
-				keys,
-				onProgress: (done, total) => log(`  ${name}: ${done.toLocaleString()} / ${total.toLocaleString()}`),
-			});
-			log(`[workload ${name}] ${result.throughput.toFixed(0)} ops/sec, ${result.errors} errors`);
+			log(
+				`\n[workload ${name}] ${spec.description} — ${distribution}, ${config.opsPerWorkload.toLocaleString()} ops × ${config.reps} rep(s)`
+			);
+			const reps: PhaseResult[] = [];
+			for (let rep = 0; rep < config.reps; rep++) {
+				// Fresh KeyState per rep so each rep is an independent, reproducible draw.
+				const keys = new KeyState({
+					distribution,
+					initialKeyCount: config.records,
+					keyWidth: width,
+					shape,
+					maxScanLength: config.maxScanLength,
+				});
+				const repLabel = config.reps > 1 ? `${name} rep ${rep + 1}/${config.reps}` : name;
+				const result: PhaseResult = await runOperations({
+					opCount: config.opsPerWorkload,
+					concurrency: config.concurrency,
+					mix: spec.mix,
+					executor,
+					keys,
+					onProgress: (done, total) => log(`  ${repLabel}: ${done.toLocaleString()} / ${total.toLocaleString()}`),
+				});
+				log(`[workload ${repLabel}] ${result.throughput.toFixed(0)} ops/sec, ${result.errors} errors`);
+				reps.push(result);
+			}
+			const median = medianByThroughput(reps);
+			if (config.reps > 1) {
+				const all = reps.map((r) => r.throughput.toFixed(0)).join(', ');
+				log(`[workload ${name}] median ${median.throughput.toFixed(0)} ops/sec of [${all}]`);
+			}
 			workloadResults.push({
 				name,
 				description: spec.description,
 				distribution,
-				ops: result.ops,
-				errors: result.errors,
-				elapsedMs: result.elapsedMs,
-				throughput: result.throughput,
-				latency: result.latency,
+				ops: median.ops,
+				errors: median.errors,
+				elapsedMs: median.elapsedMs,
+				throughput: median.throughput,
+				latency: median.latency,
+				reps: config.reps,
+				repThroughputs: reps.map((r) => r.throughput),
 			});
 		}
 
@@ -303,7 +344,7 @@ export function printReport(results: BenchmarkResults): void {
 		`YCSB results — ${results.config.nodeCount} node(s), threads.count=${results.config.threads}, ${results.config.engine}`
 	);
 	lines.push(
-		`records=${results.config.records.toLocaleString()}  ops/workload=${results.config.opsPerWorkload.toLocaleString()}  concurrency=${results.config.concurrency}`
+		`records=${results.config.records.toLocaleString()}  ops/workload=${results.config.opsPerWorkload.toLocaleString()}  concurrency=${results.config.concurrency}  reps=${results.config.reps} (median)`
 	);
 	lines.push('='.repeat(78));
 	lines.push(`load: ${results.load.throughput.toFixed(0)} records/sec (${results.load.errors} errors)`);

--- a/benchmarks/ycsb/harness.mts
+++ b/benchmarks/ycsb/harness.mts
@@ -134,7 +134,7 @@ function keyWidth(config: BenchmarkConfig): number {
  * lower-middle (the more conservative throughput), avoiding any averaging of two
  * runs' incompatible latency blocks.
  */
-function medianByThroughput(reps: PhaseResult[]): PhaseResult {
+export function medianByThroughput(reps: PhaseResult[]): PhaseResult {
 	const sorted = [...reps].sort((a, b) => a.throughput - b.throughput);
 	return sorted[Math.floor((sorted.length - 1) / 2)];
 }
@@ -253,11 +253,17 @@ export async function runBenchmark(
 				`\n[workload ${name}] ${spec.description} — ${distribution}, ${config.opsPerWorkload.toLocaleString()} ops × ${config.reps} rep(s)`
 			);
 			const reps: PhaseResult[] = [];
+			// Carry the readable key count forward across reps so an insert-bearing workload
+			// (E, D) keeps allocating fresh keys each rep, mirroring one continuous run, rather
+			// than re-inserting the same keys as PUT overwrites. Read/scan-only workloads never
+			// advance this, so it stays at config.records for them.
+			let keyCount = config.records;
 			for (let rep = 0; rep < config.reps; rep++) {
-				// Fresh KeyState per rep so each rep is an independent, reproducible draw.
+				// Fresh KeyState per rep (independent, reproducible draw) seeded with the
+				// keyspace as grown by prior reps.
 				const keys = new KeyState({
 					distribution,
-					initialKeyCount: config.records,
+					initialKeyCount: keyCount,
 					keyWidth: width,
 					shape,
 					maxScanLength: config.maxScanLength,
@@ -273,6 +279,7 @@ export async function runBenchmark(
 				});
 				log(`[workload ${repLabel}] ${result.throughput.toFixed(0)} ops/sec, ${result.errors} errors`);
 				reps.push(result);
+				keyCount = keys.keyCount;
 			}
 			const median = medianByThroughput(reps);
 			if (config.reps > 1) {

--- a/benchmarks/ycsb/harness.mts
+++ b/benchmarks/ycsb/harness.mts
@@ -103,7 +103,7 @@ export function parseOptions(argv: string[]): ParsedOptions {
 		maxScanLength: Number(values['scan-max']),
 		warmupOps: values.warmup ? Number(values.warmup) : Math.min(opsPerWorkload, 20_000),
 		workloads,
-		reps: Math.max(1, Number(values.reps)),
+		reps: Math.max(1, Math.floor(Number(values.reps)) || 1),
 		distribution: values.distribution as DistributionName | undefined,
 		table: 'usertable',
 	};
@@ -122,7 +122,10 @@ export function parseOptions(argv: string[]): ParsedOptions {
 }
 
 function keyWidth(config: BenchmarkConfig): number {
-	return Math.max(10, String(config.records + config.opsPerWorkload).length);
+	// Size for the largest key index any rep can reach. With --reps the keyspace carries
+	// forward, so budget for every rep being all-inserts (the pessimistic bound) — keeps key
+	// formatting consistent even if a future workload inserts far more than today's ≤5%.
+	return Math.max(10, String(config.records + config.reps * config.opsPerWorkload).length);
 }
 
 /**

--- a/benchmarks/ycsb/harness.test.mts
+++ b/benchmarks/ycsb/harness.test.mts
@@ -1,0 +1,46 @@
+/**
+ * Unit tests for the YCSB harness helpers. Run standalone with:
+ *   node --test benchmarks/ycsb/
+ */
+import { test } from 'node:test';
+import { strictEqual } from 'node:assert/strict';
+import { medianByThroughput } from './harness.mts';
+import type { PhaseResult } from './workload.mts';
+
+function rep(throughput: number): PhaseResult {
+	// Tag latency so we can assert the WHOLE rep is returned, not a recomputed metric.
+	return {
+		ops: 0,
+		errors: 0,
+		elapsedMs: 0,
+		throughput,
+		latency: {
+			read: {
+				count: 1,
+				min: throughput,
+				max: throughput,
+				mean: throughput,
+				p50: throughput,
+				p95: throughput,
+				p99: throughput,
+				p999: throughput,
+			},
+		},
+	};
+}
+
+test('medianByThroughput returns the middle rep and ignores a single degenerate run', () => {
+	const chosen = medianByThroughput([rep(100), rep(50), rep(90)]);
+	strictEqual(chosen.throughput, 90, 'median of [100,50,90] is 90; the low outlier is never selected');
+	// The returned latency comes from that same rep, kept internally consistent.
+	strictEqual(chosen.latency.read!.p99, 90);
+});
+
+test('medianByThroughput picks the conservative lower-middle for an even count', () => {
+	strictEqual(medianByThroughput([rep(80), rep(120)]).throughput, 80);
+	strictEqual(medianByThroughput([rep(120), rep(80)]).throughput, 80, 'order-independent');
+});
+
+test('medianByThroughput is a no-op for a single rep', () => {
+	strictEqual(medianByThroughput([rep(42)]).throughput, 42);
+});

--- a/benchmarks/ycsb/harness.test.mts
+++ b/benchmarks/ycsb/harness.test.mts
@@ -4,7 +4,7 @@
  */
 import { test } from 'node:test';
 import { strictEqual } from 'node:assert/strict';
-import { medianByThroughput } from './harness.mts';
+import { medianByThroughput, parseOptions } from './harness.mts';
 import type { PhaseResult } from './workload.mts';
 
 function rep(throughput: number): PhaseResult {
@@ -43,4 +43,15 @@ test('medianByThroughput picks the conservative lower-middle for an even count',
 
 test('medianByThroughput is a no-op for a single rep', () => {
 	strictEqual(medianByThroughput([rep(42)]).throughput, 42);
+});
+
+test('parseOptions clamps --reps to a positive integer', () => {
+	strictEqual(parseOptions(['--scale=quick']).config.reps, 1, 'defaults to 1');
+	strictEqual(parseOptions(['--scale=quick', '--reps=3']).config.reps, 3);
+	// Non-numeric, zero, negative, and fractional inputs must never yield NaN/0 — that would
+	// make the rep loop never run and medianByThroughput crash on an empty set.
+	strictEqual(parseOptions(['--scale=quick', '--reps=foo']).config.reps, 1, 'NaN -> 1');
+	strictEqual(parseOptions(['--scale=quick', '--reps=0']).config.reps, 1, '0 -> 1');
+	strictEqual(parseOptions(['--scale=quick', '--reps=-2']).config.reps, 1, 'negative -> 1');
+	strictEqual(parseOptions(['--scale=quick', '--reps=2.9']).config.reps, 2, 'fractional floors');
 });

--- a/benchmarks/ycsb/to-benchmark-json.mts
+++ b/benchmarks/ycsb/to-benchmark-json.mts
@@ -10,6 +10,7 @@
  */
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
+import { WORKLOADS } from './workload.mts';
 
 interface BenchPoint {
 	name: string;
@@ -24,11 +25,28 @@ interface LatencyStats {
 
 interface Results {
 	load: { throughput: number };
-	workloads: { name: string; throughput: number; latency: Record<string, LatencyStats> }[];
+	workloads: { name: string; description?: string; throughput: number; latency: Record<string, LatencyStats> }[];
 }
 
 function round(n: number): number {
 	return Math.round(n * 100) / 100;
+}
+
+// Brief description of the load phase (no WorkloadSpec exists for it).
+const LOAD_DESCRIPTION = 'bulk insert';
+
+/** Full description for a workload, sourced from the results, falling back to the WorkloadSpec. */
+function describeWorkload(wl: { name: string; description?: string }): string {
+	return wl.description ?? WORKLOADS[wl.name]?.description ?? wl.name;
+}
+
+/**
+ * Short tag for latency series labels (chart titles get crowded with the full mix).
+ * Takes the descriptive phrase before the parenthetical op-mix, e.g.
+ * "Update heavy (50% read / 50% update)" -> "update heavy".
+ */
+function shortTag(description: string): string {
+	return description.split('(')[0].trim().toLowerCase();
 }
 
 async function main(): Promise<void> {
@@ -37,12 +55,16 @@ async function main(): Promise<void> {
 
 	const results = JSON.parse(await readFile(resultsPath, 'utf8')) as Results;
 
-	const throughput: BenchPoint[] = [{ name: 'load', unit: 'records/sec', value: round(results.load.throughput) }];
+	const throughput: BenchPoint[] = [
+		{ name: `load — ${LOAD_DESCRIPTION}`, unit: 'records/sec', value: round(results.load.throughput) },
+	];
 	const latency: BenchPoint[] = [];
 	for (const wl of results.workloads) {
-		throughput.push({ name: `workload ${wl.name}`, unit: 'ops/sec', value: round(wl.throughput) });
+		const description = describeWorkload(wl);
+		throughput.push({ name: `workload ${wl.name} — ${description}`, unit: 'ops/sec', value: round(wl.throughput) });
+		const tag = shortTag(description);
 		for (const [op, stats] of Object.entries(wl.latency)) {
-			latency.push({ name: `${wl.name} ${op} p99`, unit: 'ms', value: round(stats.p99) });
+			latency.push({ name: `${wl.name} ${op} p99 — ${tag}`, unit: 'ms', value: round(stats.p99) });
 		}
 	}
 

--- a/benchmarks/ycsb/to-benchmark-json.mts
+++ b/benchmarks/ycsb/to-benchmark-json.mts
@@ -23,8 +23,8 @@ interface LatencyStats {
 	p99: number;
 }
 
-interface Results {
-	load: { throughput: number };
+export interface Results {
+	load?: { throughput: number };
 	workloads: { name: string; description?: string; throughput: number; latency: Record<string, LatencyStats> }[];
 }
 
@@ -35,9 +35,13 @@ function round(n: number): number {
 // Brief description of the load phase (no WorkloadSpec exists for it).
 const LOAD_DESCRIPTION = 'bulk insert';
 
-/** Full description for a workload, sourced from the results, falling back to the WorkloadSpec. */
-function describeWorkload(wl: { name: string; description?: string }): string {
-	return wl.description ?? WORKLOADS[wl.name]?.description ?? wl.name;
+/**
+ * Full description for a workload, sourced from the results, falling back to the WorkloadSpec.
+ * Returns undefined when neither carries a description, so callers can omit the suffix/tag
+ * rather than echoing the bare name (which would produce "workload FOO — FOO" / a "foo" tag).
+ */
+function describeWorkload(wl: { name: string; description?: string }): string | undefined {
+	return wl.description ?? WORKLOADS[wl.name]?.description;
 }
 
 /**
@@ -49,24 +53,34 @@ function shortTag(description: string): string {
 	return description.split('(')[0].trim().toLowerCase();
 }
 
+/** Pure conversion of a results object into the two benchmark series arrays. */
+export function convert(results: Results): { throughput: BenchPoint[]; latency: BenchPoint[] } {
+	const throughput: BenchPoint[] = [];
+	// The load phase can be skipped (e.g. a run against a pre-loaded dataset); omit its
+	// series rather than throwing on the missing field.
+	if (results.load) {
+		throughput.push({ name: `load — ${LOAD_DESCRIPTION}`, unit: 'records/sec', value: round(results.load.throughput) });
+	}
+	const latency: BenchPoint[] = [];
+	for (const wl of results.workloads) {
+		const description = describeWorkload(wl);
+		const throughputName = description ? `workload ${wl.name} — ${description}` : `workload ${wl.name}`;
+		throughput.push({ name: throughputName, unit: 'ops/sec', value: round(wl.throughput) });
+		const tag = description ? shortTag(description) : undefined;
+		for (const [op, stats] of Object.entries(wl.latency)) {
+			const latencyName = tag ? `${wl.name} ${op} p99 — ${tag}` : `${wl.name} ${op} p99`;
+			latency.push({ name: latencyName, unit: 'ms', value: round(stats.p99) });
+		}
+	}
+	return { throughput, latency };
+}
+
 async function main(): Promise<void> {
 	const [resultsPath, outDir] = process.argv.slice(2);
 	if (!resultsPath || !outDir) throw new Error('usage: to-benchmark-json.mts <results.json> <out-dir>');
 
 	const results = JSON.parse(await readFile(resultsPath, 'utf8')) as Results;
-
-	const throughput: BenchPoint[] = [
-		{ name: `load — ${LOAD_DESCRIPTION}`, unit: 'records/sec', value: round(results.load.throughput) },
-	];
-	const latency: BenchPoint[] = [];
-	for (const wl of results.workloads) {
-		const description = describeWorkload(wl);
-		throughput.push({ name: `workload ${wl.name} — ${description}`, unit: 'ops/sec', value: round(wl.throughput) });
-		const tag = shortTag(description);
-		for (const [op, stats] of Object.entries(wl.latency)) {
-			latency.push({ name: `${wl.name} ${op} p99 — ${tag}`, unit: 'ms', value: round(stats.p99) });
-		}
-	}
+	const { throughput, latency } = convert(results);
 
 	await mkdir(outDir, { recursive: true });
 	await writeFile(join(outDir, 'throughput.json'), JSON.stringify(throughput, null, 2));
@@ -74,7 +88,10 @@ async function main(): Promise<void> {
 	console.log(`wrote ${throughput.length} throughput + ${latency.length} latency metrics to ${outDir}`);
 }
 
-main().catch((error) => {
-	console.error(error);
-	process.exit(1);
-});
+// Only run as a CLI; stays inert when imported (e.g. by the test module).
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main().catch((error) => {
+		console.error(error);
+		process.exit(1);
+	});
+}

--- a/benchmarks/ycsb/to-benchmark-json.test.mts
+++ b/benchmarks/ycsb/to-benchmark-json.test.mts
@@ -1,0 +1,56 @@
+/**
+ * Unit tests for the YCSB results -> github-action-benchmark converter. Run standalone with:
+ *   node --test benchmarks/ycsb/
+ */
+import { test } from 'node:test';
+import { strictEqual, deepStrictEqual } from 'node:assert/strict';
+import { convert, type Results } from './to-benchmark-json.mts';
+
+const latency = { read: { p50: 1, p99: 2 } };
+
+test('emits the load series plus per-workload throughput/latency for a normal run', () => {
+	const results: Results = {
+		load: { throughput: 1000 },
+		workloads: [{ name: 'A', throughput: 500, latency }],
+	};
+	const { throughput, latency: lat } = convert(results);
+	deepStrictEqual(
+		throughput.map((p) => p.name),
+		['load — bulk insert', 'workload A — Update heavy (50% read / 50% update)']
+	);
+	// Latency tag is the descriptive phrase before the parenthetical op-mix.
+	strictEqual(lat[0].name, 'A read p99 — update heavy');
+});
+
+test('omits the load series when the load phase is absent (does not throw)', () => {
+	const results: Results = {
+		workloads: [{ name: 'C', throughput: 700, latency }],
+	};
+	const { throughput } = convert(results);
+	strictEqual(
+		throughput.some((p) => p.name.startsWith('load')),
+		false,
+		'no load series when results.load is undefined'
+	);
+	strictEqual(throughput[0].name, 'workload C — Read only (100% read)');
+});
+
+test('omits a redundant description/tag when the workload has no known description', () => {
+	const results: Results = {
+		load: { throughput: 10 },
+		// Unknown name with no description: must not echo the name as its own description.
+		workloads: [{ name: 'FOO', throughput: 5, latency }],
+	};
+	const { throughput, latency: lat } = convert(results);
+	strictEqual(throughput[1].name, 'workload FOO', 'no "workload FOO — FOO" redundancy');
+	strictEqual(lat[0].name, 'FOO read p99', 'no redundant "— foo" tag');
+});
+
+test('uses a description carried on the result over the WorkloadSpec fallback', () => {
+	const results: Results = {
+		workloads: [{ name: 'A', description: 'Custom mix (40% read / 60% update)', throughput: 5, latency }],
+	};
+	const { throughput, latency: lat } = convert(results);
+	strictEqual(throughput[0].name, 'workload A — Custom mix (40% read / 60% update)');
+	strictEqual(lat[0].name, 'A read p99 — custom mix');
+});

--- a/benchmarks/ycsb/workload.mts
+++ b/benchmarks/ycsb/workload.mts
@@ -296,6 +296,16 @@ export class KeyState {
 		return formatKey(this.chooser.next(this.readableCount), this.width);
 	}
 
+	/**
+	 * Current readable key count, including any keys this run inserted. Used to seed a
+	 * subsequent repetition's `initialKeyCount` so reps keep growing the keyspace (each
+	 * rep's inserts allocate fresh keys) instead of re-inserting the same keys as PUT
+	 * overwrites — matching how one continuous run would evolve the dataset.
+	 */
+	get keyCount(): number {
+		return this.readableCount;
+	}
+
 	/** Allocate a new key beyond the loaded range. Not readable until acknowledged. */
 	nextInsert(): { index: number; key: string } {
 		const index = this.insertCursor++;

--- a/benchmarks/ycsb/workload.test.mts
+++ b/benchmarks/ycsb/workload.test.mts
@@ -127,6 +127,24 @@ test('KeyState allocates inserts sequentially and gates reads on acknowledgement
 	ok(sawNew, 'acknowledged key should become readable');
 });
 
+test('KeyState.keyCount tracks the acknowledged frontier so reps can carry the keyspace forward', () => {
+	const keys = new KeyState({
+		distribution: 'uniform',
+		initialKeyCount: 100,
+		keyWidth: 8,
+		shape: { fieldCount: 1, fieldLength: 4 },
+		maxScanLength: 10,
+	});
+	strictEqual(keys.keyCount, 100, 'starts at initialKeyCount');
+	const a = keys.nextInsert();
+	const b = keys.nextInsert();
+	strictEqual(keys.keyCount, 100, 'allocation alone does not advance the readable frontier');
+	keys.acknowledgeInsert(b.index);
+	strictEqual(keys.keyCount, 100, 'a gap at 100 holds the frontier despite 101 being acked');
+	keys.acknowledgeInsert(a.index);
+	strictEqual(keys.keyCount, 102, 'contiguous acks advance the frontier — next rep seeds from here');
+});
+
 test('LatencyRecorder computes ordered percentiles', () => {
 	const recorder = new LatencyRecorder();
 	for (let i = 1; i <= 1000; i++) recorder.record('read', i);


### PR DESCRIPTION
## Summary
The nightly YCSB cluster trend dashboard (github-action-benchmark) emitted bare chart-series names — `load`, `workload A`, `C read p99` — so the dashboard titles and legends weren't self-explanatory. This appends a brief workload description to each throughput and latency series name in the converter.

The description is sourced from the results JSON's per-workload `description` (written by `harness.mts`), falling back to the authoritative `WorkloadSpec.description` in `workload.mts` so labels stay accurate even for results that predate the `description` field.

Resulting names (confirmed against `workload.mts`):
- `load — bulk insert`
- `workload A — Update heavy (50% read / 50% update)`
- `workload B — Read mostly (95% read / 5% update)`
- `workload C — Read only (100% read)`
- `workload E — Short ranges (95% scan / 5% insert)`
- `workload F — Read-modify-write (50% read / 50% read-modify-write)`
- latency, e.g. `A update p99 — update heavy` (short tag = the phrase before the op-mix parenthesis)

## Attention
- **Renaming series starts new lines on the dashboard.** github-action-benchmark keys each series by name, so the old-named series stop updating and new ones begin. This is expected and intended (the cross-model review flagged the same continuity break — it's the deliberate tradeoff here).
- `to-benchmark-json.mts` is a standalone CLI invoked by the workflow (not part of the unit-test tree); verified by running it against a sample results file. The `shortTag`/`describeWorkload` helpers are exercised through that run.

## Coordination
Paired with HarperFast/harper-pro#425, which guards the publish step against partial/cancelled runs and bumps the `core` submodule pointer to this commit.

Generated by Claude (Opus 4.8).


---

## Follow-up addition (same branch) — `--reps` median-of-N in the harness

Layered on top of the series-name change above, to reduce the cluster bench's healthy-run jitter.

`harness.mts` gains a `--reps` flag (default **1**, so single-node behavior is unchanged). When `reps > 1`, each workload runs N times and the reported point is the **median rep by throughput** (`medianByThroughput`). Returning a whole rep — rather than computing each metric's median independently — keeps the reported throughput and its latency block internally consistent (they come from one real run). A single degenerate rep sorts to an end of the set and is never selected; for an even count we take the lower-middle (the more conservative throughput).

- **Warmup runs once per workload, not per rep** — the dataset is already hot after the first rep, so re-warming each rep would only add runtime.
- The cluster runner (harper-pro #425) opts into `--reps=3`.
- Results JSON gains additive per-workload `reps`/`repThroughputs` fields. `to-benchmark-json.mts` and `validate-benchmark-json.mts` only read `name`/`description`/`throughput`/`latency`, so both ignore the new fields and stay compatible (verified by round-tripping a synthetic 5-workload result through convert + validate).

## Attention
- `medianByThroughput` is not covered by `workload.test.mts` (it lives in the standalone harness CLI, like the existing convert helpers); verified via a direct round-trip script. Existing `workload.test.mts` still passes (10/10).

Generated by Claude (Opus 4.8).
