### PR TITLE
test(tls): force polling for cert watcher in hot-reload test to fix CI flake (#586)

### DIFF
--- a/integrationTests/security/cert-reload.test.ts
+++ b/integrationTests/security/cert-reload.test.ts
@@ -127,6 +127,16 @@ suite('TLS certificate hot-reload propagates to all workers (#586)', { skip: ski
 					privateKey: keyPath,
 				},
 			},
+			// Force the main-thread cert file watcher (chokidar, in security/keys.ts) to poll
+			// rather than rely on native fs.watch/inotify. On the Linux CI runners' overlayfs/tmpfs,
+			// inotify silently drops change events, so the on-disk cert swap below was intermittently
+			// never detected (#586) — making this test flaky despite the worker-propagation feature
+			// itself working. CHOKIDAR_USEPOLLING is a chokidar-global override honored by every
+			// watcher in-process. This only affects how the swap is *detected* in the test; the
+			// regression assertion (every worker serves the renewed cert) is unchanged. The product
+			// itself still uses native watching by default — see the PR for the separate hardening
+			// follow-up to give the cert watcher a polling fallback like RootConfigWatcher.
+			env: { CHOKIDAR_USEPOLLING: '1' },
 		});
 	});
 


### PR DESCRIPTION
## Summary

Makes the multi-worker TLS cert hot-reload regression test (`integrationTests/security/cert-reload.test.ts`, added in #1314 for #586) spawn Harper with `CHOKIDAR_USEPOLLING=1`, so the main-thread cert-file watcher polls instead of relying on native `fs.watch`/inotify. This unblocks `main`'s integration signal.

## Why

`main`'s integration suite has been intermittently red on Linux shard 2/6 with:

```
✖ every worker serves the renewed certificate after an on-disk swap
  AssertionError: cert never reloaded — still serving 03E9 after 20s
```

I traced the failing CI job log: for the entire 20s window, **every** handshake (across both `[http/1]` and `[http/2]` workers) logged `No certificate found to match cert-reload-test.harper.local using the default certificate`, the served serial never changed from `03E9` (1001), and there was **no** "Reloading certificate" log. So the swap was never detected on the main thread and never written to the `hdb_certificate` table — the workers had nothing to propagate.

This is environmental, not a regression of the #586 worker-propagation feature. The feature works: the test is green on macOS (5/5 local) and green on CI whenever the file change is detected (one recent shard-2/6 run passed). The cert-file watcher in `security/keys.ts` uses native chokidar/inotify with no polling fallback, and the GitHub Actions Linux runner filesystem (overlayfs/tmpfs) intermittently drops inotify change events — so detection is nondeterministic.

`CHOKIDAR_USEPOLLING` is a chokidar-global override honored by every in-process watcher (the cert watcher passes no `usePolling`, so it falls through to the env check). Forcing polling makes change detection deterministic on CI. The regression assertion (every worker serves the renewed serial) is unchanged — this only affects how the swap is *detected* in the test.

## Where to look

- Single file, +10 lines: the `env: { CHOKIDAR_USEPOLLING: '1' }` option on `setupHarperWithFixture` plus an explanatory comment.

## Separate follow-up (NOT in this PR — flagging for triage)

The same gap exists in production: the cert watcher relies on native inotify with **no** polling/exhaustion fallback, while `config/RootConfigWatcher.ts`, `components/EntryHandler.ts`, and `components/OptionsWatcher.ts` all fall back to polling on `ENOSPC`/`EMFILE` (see `utility/watcherFallback.ts`, harper#488). A production host that drops or exhausts inotify could miss a real cert renewal — the exact #586 customer symptom. Recommend a separate, supervised PR to give the cert watcher the same resilience (and ideally make its `change` handler not depend on `stats.mtimeMs`, which chokidar does not always supply). This is P0-relevant (July 8 cert-expiry path) but is product behavior with a design choice, so it shouldn't ride along on a test-only unblock.

---
Generated by Claude (Opus 4.8).