### PR TITLE
fix(blob): decompress (inflate) compressed blobs on read instead of re-deflating

### DIFF
--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -34,7 +34,7 @@ import {
 	type FSWatcher,
 } from 'node:fs';
 import type { StatsFs } from 'node:fs';
-import { createDeflate, createInflate, deflate } from 'node:zlib';
+import { createDeflate, createInflate, inflate } from 'node:zlib';
 import { Readable, pipeline } from 'node:stream';
 import { ensureDirSync } from 'fs-extra';
 import { get as envGet, getHdbBasePath } from '../utility/environment/environmentManager.ts';
@@ -293,11 +293,17 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 				rawBytes = Buffer.alloc(0);
 				fileMissing = true;
 			}
-			function checkCompletion(rawBytes: Buffer): Buffer | Promise<Buffer> {
-				if (size > rawBytes.length) {
-					// the file is not finished being written, wait for the write lock to complete
-					const store = storageInfo.store;
-					const lockKey = storageInfo.fileId + ':blob';
+			// The file may still be mid-write. Wait for the writer's `:blob` lock to release, then re-read.
+			// `incomplete` is the caller's "definitely not done yet" signal: for an uncompressed blob the
+			// on-disk body length must reach the (uncompressed) header size. For a compressed blob the body
+			// is shorter than the uncompressed size AND the header size is finalized up front when the size
+			// is known, so neither is a reliable completeness signal — the writer's lock is. The caller
+			// passes `mustVerifyViaLock` for compressed blobs so we probe the lock even when the bytes look
+			// plausible, and only treat the file as complete once the writer is confirmed done.
+			function waitForCompletion(incomplete: boolean, mustVerifyViaLock = false): Promise<Buffer> | undefined {
+				const store = storageInfo.store;
+				const lockKey = storageInfo.fileId + ':blob';
+				if (incomplete) {
 					if (writeFinished) {
 						// the writer released its lock but the content is still short: the file is cleanly gone
 						// (404) or confidently incomplete/corrupt (500) — not merely mid-write (#1423/#1424).
@@ -336,24 +342,77 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 							resolve(readContents());
 						}
 					});
+				} else if (mustVerifyViaLock && !writeFinished) {
+					// Bytes look complete but we can't prove it for a compressed body; probe whether the writer
+					// still holds the lock. If we acquire it, the write has finished, but the bytes we read may
+					// predate the final flush, so re-read once to get the complete body. Otherwise fall through
+					// to wait for the lock to release.
+					const acquiredImmediately = store.tryLock(lockKey);
+					if (acquiredImmediately) {
+						writeFinished = true;
+						store.unlock(lockKey);
+						return readContents(); // writer done — re-read to ensure we have the final bytes
+					}
+				} else {
+					return undefined; // confirmed complete (uncompressed exact-size match)
 				}
+				return new Promise((resolve, reject) => {
+					let settled = false;
+					const timer = setTimeout(() => {
+						if (settled) return;
+						settled = true;
+						reject(
+							new BlobReadError(
+								`Blob ${storageInfo.fileId} is unavailable; the in-progress write did not complete in time`,
+								BLOB_UNAVAILABLE_STATUS
+							)
+						);
+					}, getBlobReadTimeout());
+					timer.unref();
+					const callback = () => {
+						if (settled) return;
+						settled = true;
+						clearTimeout(timer);
+						writeFinished = true;
+						resolve(readContents());
+					};
+					const lockAcquired = store.tryLock(lockKey, callback);
+					if (lockAcquired) {
+						settled = true;
+						clearTimeout(timer);
+						writeFinished = true;
+						store.unlock(lockKey);
+						resolve(readContents());
+					}
+				});
+			}
+			function sliceContent(bytes: Buffer): Buffer {
 				if (end != undefined || start != undefined) {
-					rawBytes = rawBytes.subarray(start ?? 0, end ?? rawBytes.length);
+					bytes = bytes.subarray(start ?? 0, end ?? bytes.length);
 				}
-				return rawBytes;
+				return bytes;
 			}
 			// Only sniff the storage-type byte and take the decompress branch when a full header is present.
 			// A file shorter than the header (truncated/corrupted, #1424) would otherwise be mis-read as a
 			// deflate body and yield garbage; instead it falls through to checkCompletion as incomplete.
 			if (rawBytes.length >= HEADER_SIZE && rawBytes[1] === DEFLATE_TYPE) {
+				// An in-flight compressed file still carrying the UNKNOWN_SIZE placeholder is definitely
+				// incomplete; otherwise the size is finalized but the compressed body may still be streaming,
+				// so verify via the write lock before inflating (inflating a partial deflate stream errors).
+				const pending = waitForCompletion(size === UNKNOWN_SIZE, true);
+				if (pending) return pending;
 				return new Promise<Buffer>((resolve, reject) => {
-					deflate(rawBytes.subarray(HEADER_SIZE), (error, result) => {
+					// start/end index into the UNCOMPRESSED content, so inflate first, then slice
+					inflate(rawBytes.subarray(HEADER_SIZE), (error, result) => {
 						if (error) reject(error);
-						else resolve(checkCompletion(result));
+						else resolve(sliceContent(result));
 					});
 				});
 			}
-			return checkCompletion(rawBytes.subarray(HEADER_SIZE));
+			const body = rawBytes.subarray(HEADER_SIZE);
+			const pending = waitForCompletion(size > body.length);
+			if (pending) return pending;
+			return sliceContent(body);
 		};
 		return readContents();
 	}
@@ -496,7 +555,6 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 						// re-enter the state machine — otherwise a recursive read() would hit a null fd and
 						// throw synchronously, or onError() would reject an already-cancelled stream (#1457).
 						if (settled || cancelled) return resolve();
-						// TODO: Implement support for decompression
 						totalContentRead += bytesRead;
 						if (error) return onError(error);
 						if (position === 0) {
@@ -531,6 +589,36 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 							if (Number(headerValue >> 48n) === PENDING_TYPE) {
 								// half-replicated blob whose source stream aborted; the bytes are still expected — retry (harper-pro#481)
 								return onError(new BlobReadError('Blob pending replication for ' + filePath, BLOB_UNAVAILABLE_STATUS));
+							}
+							if (buffer[1] === DEFLATE_TYPE) {
+								// We can't seek/slice a deflate stream by uncompressed offset, so hand off to the
+								// buffered inflate path (bytes() inflates then slices) and emit it as one chunk.
+								// Safe by construction: the read loop never streams the raw compressed body.
+								return blob.bytes().then(
+									(bytes: Buffer) => {
+										// bytes() resolves asynchronously; the consumer may have cancelled meanwhile.
+										// Settle exactly once and route the close through closeFd() so we never touch a
+										// reassigned/nulled descriptor (#1457).
+										if (settled || cancelled) return resolve();
+										settled = true;
+										closeFd();
+										if (bytes.length > 0) {
+											try {
+												controller.enqueue(bytes);
+											} catch (error) {
+												logger.debug?.('Error enqueuing chunk', error);
+												return resolve();
+											}
+										}
+										try {
+											controller.close();
+										} catch {
+											// controller may already be closed
+										}
+										resolve();
+									},
+									(error: Error) => onError(error)
+								);
 							}
 							size = Number(headerValue & 0xffffffffffffn);
 							if (size < UNKNOWN_SIZE) {

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -133,6 +133,32 @@ describe('Blob test', () => {
 		retrievedBytes = await sliced.bytes();
 		assert(retrievedBytes.equals(random.slice(300, 400)));
 	});
+	it('round-trips a compressed blob via bytes() and stream()', async () => {
+		// compressible payload, comfortably over FILE_STORAGE_THRESHOLD so it is file-backed
+		let original = Buffer.from('compressible blob payload '.repeat(2000));
+		assert(original.length > 8192);
+		let blob = await createBlob(original, { compress: true });
+		await BlobTest.put({ id: 1, blob });
+		let record = await BlobTest.get(1);
+		let retrievedBytes = await record.blob.bytes();
+		assert(retrievedBytes.equals(original), 'bytes() must return the decompressed original content');
+		assert.equal(record.blob.size, original.length);
+		// the streaming read path must also decompress
+		let streamed = await streamToBuffer(record.blob.stream());
+		assert.equal(streamed, original.toString(), 'stream() must return the decompressed original content');
+	});
+	it('reads a ranged slice of a compressed blob over uncompressed offsets', async () => {
+		let original = Buffer.from('compressible blob payload '.repeat(2000));
+		let blob = await createBlob(original, { compress: true });
+		await BlobTest.put({ id: 1, blob });
+		let record = await BlobTest.get(1);
+		let sliced = record.blob.slice(300, 400);
+		assert.equal(sliced.size, 100);
+		let slicedBytes = await sliced.bytes();
+		assert(slicedBytes.equals(original.slice(300, 400)), 'ranged read must slice the uncompressed content');
+		let slicedStream = await streamToBuffer(record.blob.slice(300, 400).stream());
+		assert.equal(slicedStream, original.slice(300, 400).toString());
+	});
 	it('create a blob from a buffer and save it before committing', async () => {
 		let random = randomBytes(5000 * Math.random() + 20000);
 		let blob = createBlob(random, { saveBeforeCommit: true });


### PR DESCRIPTION
## Summary
`FileBackedBlob.bytes()` read DEFLATE-compressed blobs incorrectly: for `DEFLATE_TYPE` it called `deflate()` on the already-compressed on-disk body (double-compressing) instead of decompressing, and `inflate` wasn't even imported. The streaming read path (`stream()`) had a `// TODO: Implement support for decompression` and likewise returned the raw compressed bytes. Net effect: reading any DEFLATE-compressed blob returned corrupt data.

## Why it was latent
Blob compression is exposed (`compress?: boolean` on `BlobCreationOptions`) but **off by default and unused** — nothing in harper/harper-pro sets `compress: true` for blobs. So this never fired in practice. This is a correctness fix that must be in place **before** anyone enables `compress: true`.

## The fix
**Buffered path (`bytes()`):**
- Inflate the body for `DEFLATE_TYPE` (was `deflate`). `start`/`end` ranges index into the **uncompressed** content, so we inflate first, then slice.
- Completeness of a compressed blob can't be judged from the header `size` (which is the *uncompressed* length) vs the compressed on-disk body length, and the header size is written up front when the size is known — so neither bytes nor header size is a reliable in-flight signal. Completeness is instead verified via the writer's existing `fileId + ":blob"` lock (new `mustVerifyViaLock` probe in `waitForCompletion`): if the writer still holds the lock we wait for release and re-read; otherwise we re-read once and inflate. The `ERROR_TYPE`, `UNKNOWN_SIZE`, and lock-wait semantics are preserved. The uncompressed path keeps its exact size-vs-body completeness check (refactored for clarity, behavior unchanged).

**Streaming path (`stream()`):**
- On detecting `DEFLATE_TYPE` in the header (first read), delegate to the buffered inflate path and emit the decompressed result as a single chunk. This is the **correct-or-safe** choice the task sanctioned: it never streams compressed garbage. A true streaming inflate would require reworking the position-seeking / watcher framing (you can't seek into a deflate stream by uncompressed offset), which I judged too risky for a correctness fix.

## Tests
Added to `unitTests/resources/blob.test.js`:
- Compressed round-trip via `bytes()` **and** `stream()` — asserts decompressed output equals the original.
- Ranged read (`slice(300, 400)`) over a compressed blob, via both `bytes()` and `stream()`.

Both **fail before the fix** (the double-compress produces a body shorter than the uncompressed size → "Incomplete blob" / inflate error) and pass after. `blob.test.js` (31) and the full `test:unit:resources` suite (843) are green; lint and TypeStrip (`node --experimental-strip-types --check`) clean.

## Where to look
- The `mustVerifyViaLock` lock-probe logic in `waitForCompletion` — this is the load-bearing correctness piece. The cross-model reviews (Codex, Gemini) found no deadlock / incorrect-throw issues here, but it's the part most worth a careful read.
- The `stream()` buffered-fallback decision: deliberate tradeoff (correctness over true streaming inflate). Open for discussion if a streaming inflate is wanted later — flagged as a known limitation, not a regression.

Note: this PR touches `resources/blob.ts` but only `FileBackedBlob.bytes()` and `stream()` — disjoint from PR #1387 (`isBlobFileComplete`/`findIncompleteBlobRefs`), so they should coexist cleanly.

🤖 Generated by Claude Code (model: claude-opus-4-8). Cross-reviewed by Codex and Gemini; no open blockers.