### PR TITLE
Add periodic re-read safety net for TLS cert watcher (#586)

### DIFF
--- a/config-root.schema.json
+++ b/config-root.schema.json
@@ -682,7 +682,12 @@
 					"description": "Path to private key file. Default: <ROOTPATH>/keys/privateKey.pem"
 				},
 				"ciphers": { "type": "string", "description": "Optional explicit cipher list." },
-				"host": { "type": "string", "description": "Optional SNI host this certificate applies to." }
+				"host": { "type": "string", "description": "Optional SNI host this certificate applies to." },
+				"certificateWatchInterval": {
+					"type": "number",
+					"minimum": 0,
+					"description": "Interval in ms for the periodic re-read safety net that re-checks watched cert/key files in case an inotify change event was missed (e.g. on overlayfs/containers/network mounts). Honored on the top-level tls block. Default: 300000 (5 min). 0 disables polling, leaving only the inotify watcher."
+				}
 			}
 		}
 	},

--- a/security/keys.ts
+++ b/security/keys.ts
@@ -40,6 +40,9 @@ const CERT_VALIDITY_DAYS = 3650;
 // watcher is the fast path; this poll catches changes on filesystems where inotify is unreliable
 // (overlayfs, many container setups, network mounts). Overridable via tls.certificateWatchInterval; 0 disables.
 const DEFAULT_CERTIFICATE_WATCH_INTERVAL_MS = 300_000;
+// Lower bound (ms) for a configured poll interval; a misconfigured sub-second value is clamped up
+// to keep the safety-net poll from becoming a tight stat() loop. 0 still disables polling entirely.
+const MIN_CERTIFICATE_WATCH_INTERVAL_MS = 1000;
 const CERT_DOMAINS = ['127.0.0.1', 'localhost', '::1'];
 export const CERT_ATTRIBUTES = [
 	{ name: 'countryName', value: 'USA' },
@@ -304,7 +307,10 @@ function getCertificateWatchInterval(): number {
 	if (configured == null) return DEFAULT_CERTIFICATE_WATCH_INTERVAL_MS;
 	const interval = Number(configured);
 	if (!Number.isFinite(interval) || interval < 0) return DEFAULT_CERTIFICATE_WATCH_INTERVAL_MS;
-	return interval;
+	// 0 explicitly disables the poll; otherwise floor at MIN to keep a typo (e.g. 1ms) from
+	// spinning a stat() loop. This is a safety net, not a hot-poll path, so sub-second is never wanted.
+	if (interval === 0) return 0;
+	return Math.max(interval, MIN_CERTIFICATE_WATCH_INTERVAL_MS);
 }
 
 // Active poll timers, keyed by watched path (exposed for test cleanup).

--- a/security/keys.ts
+++ b/security/keys.ts
@@ -330,7 +330,10 @@ function loadAndWatch(path, loadCert, type) {
 	let lastModified;
 	const loadFile = (path, stats) => {
 		try {
-			let modified = stats.mtimeMs;
+			// chokidar's 'change' event omits stats unless alwaysStat is set (default off in v4), so
+			// stat the file here when it's missing — otherwise the inotify fast path would throw and
+			// silently never reload, leaving only the periodic poll to catch the change.
+			let modified = (stats ?? statSync(path)).mtimeMs;
 			if (modified && modified !== lastModified) {
 				if (lastModified && isMainThread) logger.warn?.(`Reloading ${type}:`, path);
 				lastModified = modified;

--- a/security/keys.ts
+++ b/security/keys.ts
@@ -36,6 +36,10 @@ import { isMainThread } from 'worker_threads';
 import { TLSSocket } from 'node:tls';
 
 const CERT_VALIDITY_DAYS = 3650;
+// Default interval (ms) for the periodic cert-file re-read safety net. The chokidar (inotify)
+// watcher is the fast path; this poll catches changes on filesystems where inotify is unreliable
+// (overlayfs, many container setups, network mounts). Overridable via tls.certificateWatchInterval; 0 disables.
+const DEFAULT_CERTIFICATE_WATCH_INTERVAL_MS = 300_000;
 const CERT_DOMAINS = ['127.0.0.1', 'localhost', '::1'];
 export const CERT_ATTRIBUTES = [
 	{ name: 'countryName', value: 'USA' },
@@ -288,7 +292,36 @@ export function loadCertificates() {
 }
 
 /**
- * Load the certificate file and watch for changes and reload with any changes
+ * Resolve the periodic cert-watch poll interval (ms) from config, falling back to the default.
+ * Returns 0 (polling disabled) only when explicitly configured to 0.
+ *
+ * This is a single global watcher-behavior knob, read from the top-level `tls.certificateWatchInterval`
+ * (mirrors how `tls.unixDomainSockets`/`tls.ciphers` are read globally via env.get). It is not honored
+ * per-cert inside an SNI `tls` array or under `operationsApi.tls`; those configs use the default.
+ */
+function getCertificateWatchInterval(): number {
+	const configured = envManager.get(CONFIG_PARAMS.TLS_CERTIFICATEWATCHINTERVAL);
+	if (configured == null) return DEFAULT_CERTIFICATE_WATCH_INTERVAL_MS;
+	const interval = Number(configured);
+	if (!Number.isFinite(interval) || interval < 0) return DEFAULT_CERTIFICATE_WATCH_INTERVAL_MS;
+	return interval;
+}
+
+// Active poll timers, keyed by watched path (exposed for test cleanup).
+const certificateWatchTimers = new Map<string, NodeJS.Timeout>();
+// The poll callback for each watched path, keyed by path. Exposed so tests can drive a single
+// re-read deterministically (simulating a missed inotify event) without waiting for the interval.
+const certificateWatchPollers = new Map<string, () => void>();
+
+/**
+ * Load the certificate file and watch for changes and reload with any changes.
+ *
+ * Two detection mechanisms feed the same reload path (and share the `lastModified` fingerprint,
+ * so they never double-reload for the same change):
+ *   1. chokidar inotify watcher — the fast path, reacts immediately to fs events.
+ *   2. A periodic re-read (main thread only) — a safety net for filesystems where inotify is
+ *      unreliable (overlayfs/containers/network mounts), where a real renewal can otherwise be
+ *      silently missed. Interval is tls.certificateWatchInterval (default 5m); 0 disables it.
  * @param path
  * @param loadCert
  * @param type
@@ -310,6 +343,39 @@ function loadAndWatch(path, loadCert, type) {
 	if (fs.existsSync(path)) loadFile(path, statSync(path));
 	else logger.error?.(`${type} file not found:`, path);
 	watch(path, { persistent: false }).on('change', loadFile);
+
+	// Periodic re-read safety net. For certificates, this runs on the main thread only — workers
+	// receive cert updates via the hdb_certificate table subscription, so polling the cert file on
+	// every worker would be wasteful. Private keys are different: each worker loads its own key
+	// directly from disk into its privateKeys map (no table propagation), so a renewal missed by
+	// inotify on a worker would strand the stale key — therefore the key poll must run on all
+	// threads. mtime is checked first against the last-loaded fingerprint, so an unchanged file does
+	// no PEM read and no reload (and shares the fingerprint with the chokidar watcher, so the two
+	// detection paths never double-reload the same change).
+	const pollsOnThisThread = isMainThread || type === 'private key';
+	if (pollsOnThisThread) {
+		const poll = () => {
+			let stats;
+			try {
+				stats = statSync(path);
+			} catch (error) {
+				// File may be transiently absent (e.g. atomic-rename renewal in flight); the chokidar
+				// watcher and the next poll will pick up the replacement.
+				logger.trace?.(`Watch poll could not stat ${type}:`, path, error);
+				return;
+			}
+			loadFile(path, stats);
+		};
+		certificateWatchPollers.set(path, poll);
+		const interval = getCertificateWatchInterval();
+		if (interval > 0) {
+			const existingTimer = certificateWatchTimers.get(path);
+			if (existingTimer) clearInterval(existingTimer);
+			const timer = setInterval(poll, interval);
+			timer.unref();
+			certificateWatchTimers.set(path, timer);
+		}
+	}
 }
 
 function getHost() {

--- a/static/defaultConfig.yaml
+++ b/static/defaultConfig.yaml
@@ -75,5 +75,6 @@ storage:
   prefetchWrites: true
 tls:
   privateKey: null
+  certificateWatchInterval: 300000
 node:
   hostname: null

--- a/unitTests/security/keys.test.js
+++ b/unitTests/security/keys.test.js
@@ -611,6 +611,16 @@ describe('Test keys module', () => {
 			expect(getCertificateWatchInterval()).to.equal(DEFAULT);
 		});
 
+		it('clamps a too-small configured interval up to the minimum, but 0 still disables', () => {
+			const getCertificateWatchInterval = keys.__get__('getCertificateWatchInterval');
+			const MIN = keys.__get__('MIN_CERTIFICATE_WATCH_INTERVAL_MS');
+			const stub = localSandbox.stub(env_mgr, 'get');
+			stub.callsFake(() => 1); // typo'd 1ms must not become a tight poll loop
+			expect(getCertificateWatchInterval()).to.equal(MIN);
+			stub.callsFake(() => 0); // 0 is the explicit "disable polling" sentinel
+			expect(getCertificateWatchInterval()).to.equal(0);
+		});
+
 		it('registers a poll for a private-key watch (key poll must run on all threads, including workers)', () => {
 			// Private keys are loaded per-thread directly from disk (no hdb_certificate propagation), so
 			// the poll safety net must be wired for 'private key' watches regardless of thread. On the

--- a/unitTests/security/keys.test.js
+++ b/unitTests/security/keys.test.js
@@ -500,4 +500,108 @@ describe('Test keys module', () => {
 			expect(record.certificate, 'an older file must not overwrite the stored cert').to.equal('SENTINEL-FUTURE');
 		});
 	});
+
+	describe('loadAndWatch periodic re-read safety net (#586)', () => {
+		const loadAndWatch = keys.__get__('loadAndWatch');
+		const watchTimers = keys.__get__('certificateWatchTimers');
+		const watchPollers = keys.__get__('certificateWatchPollers');
+		const localSandbox = sinon.createSandbox();
+		let watchPath;
+
+		beforeEach(() => {
+			// Stub chokidar's watch so these tests exercise only the poll path and never open a real
+			// FSWatcher (real watchers would leak fds and risk EMFILE across repeated runs).
+			const chokidar = require('chokidar');
+			localSandbox.stub(chokidar, 'watch').returns({ on: () => {} });
+			watchPath = path.join(test_dir, `watch-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.pem`);
+			fs.writeFileSync(watchPath, 'PEM-V1');
+		});
+
+		afterEach(() => {
+			localSandbox.restore();
+			const timer = watchTimers.get(watchPath);
+			if (timer) clearInterval(timer);
+			watchTimers.delete(watchPath);
+			watchPollers.delete(watchPath);
+			if (fs.existsSync(watchPath)) fs.removeSync(watchPath);
+		});
+
+		it('a cert swap missed by inotify is still picked up by the poll (mtime advanced)', () => {
+			const loaded = [];
+			loadAndWatch(watchPath, (pem) => loaded.push(pem), 'certificate');
+
+			// Initial synchronous load on registration.
+			expect(loaded).to.eql(['PEM-V1']);
+
+			// Simulate a renewal that inotify missed: new content + advanced mtime, no chokidar event.
+			fs.writeFileSync(watchPath, 'PEM-V2');
+			const future = (Date.now() + 5000) / 1000;
+			fs.utimesSync(watchPath, future, future);
+
+			// Drive a single poll (what the unref'd interval would do on its tick).
+			watchPollers.get(watchPath)();
+
+			expect(loaded).to.eql(['PEM-V1', 'PEM-V2']);
+		});
+
+		it('does not reload when the file is unchanged (mtime fingerprint dedup)', () => {
+			const loaded = [];
+			loadAndWatch(watchPath, (pem) => loaded.push(pem), 'certificate');
+			expect(loaded).to.eql(['PEM-V1']);
+
+			// Repeated polls with no on-disk change must not re-invoke the loader.
+			const poll = watchPollers.get(watchPath);
+			poll();
+			poll();
+			expect(loaded).to.eql(['PEM-V1']);
+		});
+
+		it('resolves the configured interval and registers an unref-ed poll timer', () => {
+			localSandbox.stub(env_mgr, 'get').callsFake((param) => {
+				if (param === 'tls_certificateWatchInterval') return 1234;
+				return undefined;
+			});
+
+			expect(keys.__get__('getCertificateWatchInterval')()).to.equal(1234);
+
+			loadAndWatch(watchPath, () => {}, 'certificate');
+
+			const timer = watchTimers.get(watchPath);
+			expect(timer, 'a poll timer should be registered').to.exist;
+			// .unref() prevents the timer from holding the event loop / process open.
+			expect(typeof timer.unref).to.equal('function');
+			expect(timer.hasRef()).to.be.false;
+		});
+
+		it('falls back to the default interval when unconfigured or invalid', () => {
+			const getCertificateWatchInterval = keys.__get__('getCertificateWatchInterval');
+			const DEFAULT = keys.__get__('DEFAULT_CERTIFICATE_WATCH_INTERVAL_MS');
+			const stub = localSandbox.stub(env_mgr, 'get');
+			stub.callsFake(() => undefined);
+			expect(getCertificateWatchInterval()).to.equal(DEFAULT);
+			stub.callsFake(() => 'not-a-number');
+			expect(getCertificateWatchInterval()).to.equal(DEFAULT);
+			stub.callsFake(() => -5);
+			expect(getCertificateWatchInterval()).to.equal(DEFAULT);
+		});
+
+		it('registers a poll for a private-key watch (key poll must run on all threads, including workers)', () => {
+			// Private keys are loaded per-thread directly from disk (no hdb_certificate propagation), so
+			// the poll safety net must be wired for 'private key' watches regardless of thread. On the
+			// main thread the poller is registered either way; this asserts the key path stays wired.
+			loadAndWatch(watchPath, () => {}, 'private key');
+			expect(watchPollers.get(watchPath), 'a poller should be registered for the private key').to.exist;
+		});
+
+		it('does not register a poll timer when the interval is configured to 0', () => {
+			localSandbox.stub(env_mgr, 'get').callsFake((param) => {
+				if (param === 'tls_certificateWatchInterval') return 0;
+				return undefined;
+			});
+
+			loadAndWatch(watchPath, () => {}, 'certificate');
+
+			expect(watchTimers.get(watchPath), 'no timer should be registered when polling is disabled').to.be.undefined;
+		});
+	});
 });

--- a/unitTests/security/keys.test.js
+++ b/unitTests/security/keys.test.js
@@ -544,6 +544,32 @@ describe('Test keys module', () => {
 			expect(loaded).to.eql(['PEM-V1', 'PEM-V2']);
 		});
 
+		it("chokidar's 'change' event reloads even when it emits no stats (alwaysStat off)", () => {
+			// chokidar v4 defaults alwaysStat:false, so the 'change' handler is called with undefined
+			// stats; loadFile must stat the file itself rather than throw and silently skip the reload.
+			let changeHandler;
+			localSandbox.restore();
+			const chokidar = require('chokidar');
+			localSandbox.stub(chokidar, 'watch').returns({
+				on: (event, handler) => {
+					if (event === 'change') changeHandler = handler;
+				},
+			});
+
+			const loaded = [];
+			loadAndWatch(watchPath, (pem) => loaded.push(pem), 'certificate');
+			expect(loaded).to.eql(['PEM-V1']);
+
+			fs.writeFileSync(watchPath, 'PEM-V2');
+			const future = (Date.now() + 5000) / 1000;
+			fs.utimesSync(watchPath, future, future);
+
+			// Fire the watcher's change event the way chokidar does when alwaysStat is off: no stats.
+			changeHandler(watchPath, undefined);
+
+			expect(loaded).to.eql(['PEM-V1', 'PEM-V2']);
+		});
+
 		it('does not reload when the file is unchanged (mtime fingerprint dedup)', () => {
 			const loaded = [];
 			loadAndWatch(watchPath, (pem) => loaded.push(pem), 'certificate');

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -650,6 +650,7 @@ export const CONFIG_PARAMS = {
 	TLS_CERTIFICATEAUTHORITY: 'tls_certificateAuthority',
 	TLS_CIPHERS: 'tls_ciphers',
 	TLS_UNIXDOMAINSOCKETS: 'tls_unixDomainSockets',
+	TLS_CERTIFICATEWATCHINTERVAL: 'tls_certificateWatchInterval',
 	TLS: 'tls',
 	CLONED: 'cloned',
 	NODE_HOSTNAME: 'node_hostname',

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -64,6 +64,10 @@ export function configValidator(configJson, skipFsValidation = false) {
 		certificate: pemFileConstraints,
 		certificateAuthority: pemFileConstraints,
 		privateKey: pemFileConstraints,
+		// Periodic re-read interval (ms) for the cert-file watcher's polling safety net.
+		// 0 disables polling, leaving only the inotify-based chokidar watcher. Honored on the
+		// top-level tls block (a single global setting); see getCertificateWatchInterval in security/keys.ts.
+		certificateWatchInterval: number.min(0).optional().empty(null),
 	});
 
 	// MCP — sub-issue #613 lands the config surface ahead of the transport (#614).


### PR DESCRIPTION
## Summary
The TLS cert-file watcher in `security/keys.ts` (`loadAndWatch`) relies solely on chokidar's inotify events. On filesystems where inotify is unreliable — overlayfs, many container setups, network mounts — a real certificate renewal can be **silently missed**, leaving Harper serving the old (expired) cert with no error. This is a live risk for the **July 8 2026 fleet cert rotation** (P0). A CI manifestation of exactly this — overlayfs dropping inotify events — was confirmed in #1392.

This PR hardens **detection** with a periodic re-read safety net. It does not touch worker-side propagation (the table subscription + TLS rebuild), which already works.

## What changed
- **Periodic re-read poll** added alongside the existing chokidar watcher. A per-file `setInterval` (`.unref()`'d so it never holds the process open) re-stats the watched file and routes through the **same** reload path on change. Chokidar stays the fast path; the poll is the belt-and-suspenders net for missed events.
- **De-dupe:** both detection paths share the existing `lastModified` mtime fingerprint, so an inotify event and a poll for the same change never double-reload. An unchanged file does only a cheap `statSync` (no PEM read, no reload).
- **Configurable interval:** top-level `tls.certificateWatchInterval` (ms), default **300000 (5 min)**; `0` disables polling. Registered in `hdbTerms.ts`, `static/defaultConfig.yaml`, the Joi validator (`validation/configValidator.ts`), and `config-root.schema.json` (which has `additionalProperties: false` on `tlsConfig`).

## Where to look
- `security/keys.ts` `loadAndWatch` — poll registration and thread gating.
- **Thread gating (please sanity-check):** the **certificate** poll runs on the **main thread only** (workers get cert updates via the `hdb_certificate` subscription). The **private-key** poll runs on **all threads**, because each worker loads its own key directly from disk with no table propagation — a key renewal missed by inotify on a worker would otherwise strand the stale key. This asymmetry was raised by cross-model review and is deliberate.

## Open item for reviewer (deliberately out of scope)
Cross-model review flagged a latent race: when a renewal rotates **both** cert and key, a worker's private-key poll only refreshes the in-thread `privateKeys` map — it does **not** itself trigger a `createTLSSelector`/`updateTLS` rebuild. The TLS rebuild is driven by the `hdb_certificate` subscription. **This is pre-existing behavior of the private-key chokidar watcher too** (its `loadCert` callback already just sets the map), not introduced here — this PR only adds a second trigger to the same path. Fixing worker key-rotation → immediate TLS rebuild is a separate, riskier change I deliberately kept out of this P0 patch. Flagging so it's not rediscovered.

## Testing
- New unit coverage in `unitTests/security/keys.test.js`: swap missed by inotify is picked up by the poll (chokidar stubbed so only the poll path runs); mtime-fingerprint dedup; configured-interval resolution + `.unref()`; default/invalid-interval fallback; `0` disables; private-key path stays wired.
- Existing `integrationTests/security/cert-reload.test.ts` (#586 multi-worker propagation regression) still passes.
- `test:unit:main` + `test:unit:config` green (10 pre-existing `globalIsolation.test.js` failures are unrelated — identical on clean `main`). Lint/format clean; TypeStrip `--check` clean.

## Notes
- **P0 / July 8 cert-rotation relevant**; likely a **5.1.6 patch candidate**.
- Generated by an LLM (Claude Opus 4.8).