### PR TITLE
Avoid needless secondary-index rebuilds from equivalent index-option representations; log rebuild reason

### DIFF
--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1268,6 +1268,10 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 				for (const key of searchOnlyOptions) delete copy[key];
 				return copy;
 			};
+			// Canonical key for the structural (reindex-triggering) comparison only: strip search-only
+			// options, then sort keys and coerce numeric-looking string scalars so a representation-only
+			// difference (key order, string-vs-number) does not force a needless rebuild. harper#1357
+			const canonicalIndexKey = (indexed: any) => JSON.stringify(canonicalizeIndexOptions(stripSearchOnly(indexed)));
 			const commonChanged =
 				!attributeDescriptor ||
 				attributeDescriptor.type !== attribute.type ||
@@ -1281,11 +1285,11 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 			// any metadata difference (drives persistence)
 			const changed =
 				commonChanged || JSON.stringify(attributeDescriptor?.indexed) !== JSON.stringify(attribute.indexed);
-			// structure-affecting difference (drives reindex) — ignores search-only option changes
-			const structurallyChanged =
-				commonChanged ||
-				JSON.stringify(stripSearchOnly(attributeDescriptor?.indexed)) !==
-					JSON.stringify(stripSearchOnly(attribute.indexed));
+			// structure-affecting difference (drives reindex) — ignores search-only option changes and
+			// representation-only differences (key order, string-vs-number) via canonicalIndexKey
+			const indexOptionsStructurallyChanged =
+				canonicalIndexKey(attributeDescriptor?.indexed) !== canonicalIndexKey(attribute.indexed);
+			const structurallyChanged = commonChanged || indexOptionsStructurallyChanged;
 			if (attribute.indexed) {
 				// The restart generation that owns any in-progress build of this index. Use the
 				// worker's stable startup generation (workerData.restartNumber), NOT the mutable
@@ -1324,11 +1328,11 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 							// previous lastIndexedKey checkpoint is for a graph built under the old options —
 							// resuming from it would mix two incompatible graphs. Reset to undefined so
 							// runIndexing clears the dbi and starts from scratch.
-							// For pure crash-recovery (same options, different PID/restartNumber), preserve
-							// the checkpoint so the backfill resumes rather than restarts.
+							// For pure crash-recovery (same options, different PID/restartNumber) — including a
+							// representation-only option difference — preserve the checkpoint so the backfill
+							// resumes rather than restarts. Canonicalized to match structurallyChanged above.
 							const indexOptionsChanged =
-								JSON.stringify(stripSearchOnly(attributeDescriptor?.indexed)) !==
-								JSON.stringify(stripSearchOnly(attribute.indexed));
+								canonicalIndexKey(attributeDescriptor?.indexed) !== canonicalIndexKey(attribute.indexed);
 							attribute.lastIndexedKey = indexOptionsChanged
 								? undefined
 								: (attributeDescriptor?.lastIndexedKey ?? undefined);
@@ -1341,6 +1345,19 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 							delete attribute.indexingFailed; // clear failure flag for the new run
 							dbi.isIndexing = true;
 							Object.defineProperty(attribute, 'dbi', { value: dbi, configurable: true, enumerable: false });
+							// Explainability: log which trigger fired so an unexpected rebuild is diagnosable. harper#1357
+							const reindexReasons: string[] = [];
+							if (commonChanged)
+								reindexReasons.push(attributeDescriptor ? 'attribute-definition-changed' : 'new-index');
+							if (attributeDescriptor && indexOptionsStructurallyChanged)
+								reindexReasons.push('structural-options-changed');
+							if (attributeDescriptor?.indexingFailed) reindexReasons.push('indexing-failed-retry');
+							if (attributeDescriptor?.indexingPID && attributeDescriptor.indexingPID !== process.pid)
+								reindexReasons.push(`crash-recovery(pid=${attributeDescriptor.indexingPID})`);
+							if (attributeDescriptor?.restartNumber < currentRestartGeneration) reindexReasons.push('restart-number');
+							logger.info(
+								`reindex ${databaseName}.${tableName}.${attribute.name}: reason=${reindexReasons.join(',') || 'unknown'}`
+							);
 							// we only set indexing nulls to true if new or reindexing, we can't have partial indexing of null
 							attributesToIndex.push(attribute);
 						}
@@ -1419,6 +1436,37 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 			});
 		}
 	}
+}
+/**
+ * Canonical form used ONLY for the structural (reindex-triggering) comparison of index options.
+ * `@indexed(...)` records options in source-argument order and as strings, while the operations API
+ * and config objects can supply them reordered or as numbers; without canonicalizing, such a
+ * representation-only difference flips the structural comparison and forces a needless full rebuild
+ * (clearing + rebuilding the index, 503-ing the attribute throughout) for a semantically identical
+ * index. Sorts object keys and coerces numeric-looking (non-zero) string scalars to numbers.
+ * Conservative by design: boolean-vs-object, absent-vs-present, and string-"0"-vs-number-0
+ * differences are all preserved, so a genuine change (`true` vs `{ type: 'HNSW' }`, an added/removed
+ * option, a changed value) still triggers a rebuild. Persistence keys off the raw form, so the stored
+ * descriptor self-heals toward this shape over time. harper#1357
+ */
+export function canonicalizeIndexOptions(value: any): any {
+	if (Array.isArray(value)) return value.map(canonicalizeIndexOptions);
+	if (value && typeof value === 'object') {
+		const canonical: Record<string, any> = {};
+		for (const key of Object.keys(value).sort()) canonical[key] = canonicalizeIndexOptions(value[key]);
+		return canonical;
+	}
+	// Coerce numeric-looking strings ("16" -> 16) so string-vs-number representations of the same
+	// option compare equal — EXCEPT zero: the string "0" is truthy while the number 0 is falsy, and
+	// index code may branch on truthiness (e.g. HNSW `if (this.optimizeRouting)` doubles maxConnections),
+	// so "0" and 0 build structurally different indexes and must still trigger a rebuild. Zero is the
+	// only finite number whose string and numeric forms diverge in truthiness, so excluding it fully
+	// closes that gap. Leave non-numeric strings, booleans, null, etc. intact.
+	if (typeof value === 'string' && value.trim() !== '') {
+		const numeric = Number(value);
+		if (numeric !== 0 && Number.isFinite(numeric)) return numeric;
+	}
+	return value;
 }
 const MAX_OUTSTANDING_INDEXING = 1000;
 const MIN_OUTSTANDING_INDEXING = 10;

--- a/unitTests/resources/indexCanonicalOptions.test.js
+++ b/unitTests/resources/indexCanonicalOptions.test.js
@@ -1,0 +1,156 @@
+/**
+ * Coverage for the canonical index-option comparison that gates secondary-index rebuilds
+ * (issue #1357).
+ *
+ * table() decides whether to rebuild a secondary index by comparing the new attribute's index
+ * options against the persisted descriptor's. Previously that comparison used a raw JSON.stringify,
+ * which is sensitive to option key order and string-vs-number scalars — so a representation-only
+ * difference (e.g. `@indexed(...)` records options in source order as strings, while the operations
+ * API can supply them reordered or as numbers) forced a needless full rebuild, 503-ing the attribute
+ * for the duration. canonicalizeIndexOptions() sorts keys and coerces numeric-looking string scalars
+ * so a semantically-identical index is recognized as unchanged. It is deliberately conservative: it
+ * must NEVER mask a genuine change.
+ *
+ * Two layers of coverage:
+ *  - unit: canonicalizeIndexOptions() against the issue's exact test matrix + conservative edges.
+ *  - wiring: a live HNSW index reload — a reordered / string-vs-number option does not re-trigger a
+ *    backfill, while a genuine option change does.
+ */
+require('../testUtils');
+const assert = require('node:assert/strict');
+const { setupTestDBPath } = require('../testUtils');
+const { table, resetDatabases, canonicalizeIndexOptions } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+
+// Mirror how databases.ts uses the canonicalizer (canonicalIndexKey): structural equality is
+// "the canonical forms stringify identically".
+const sameStructure = (a, b) =>
+	JSON.stringify(canonicalizeIndexOptions(a)) === JSON.stringify(canonicalizeIndexOptions(b));
+
+describe('canonicalizeIndexOptions structural comparison (#1357)', () => {
+	it('treats key-order and string-vs-number differences as NOT structurally changed', () => {
+		// The issue's matrix case 1.
+		assert.equal(sameStructure({ type: 'HNSW', M: '16' }, { M: 16, type: 'HNSW' }), true);
+		// key order alone
+		assert.equal(sameStructure({ a: 1, b: 2 }, { b: 2, a: 1 }), true);
+		// string-vs-number alone
+		assert.equal(sameStructure({ M: '16' }, { M: 16 }), true);
+		// recurses into nested option objects
+		assert.equal(
+			sameStructure({ type: 'HNSW', opts: { b: '2', a: 1 } }, { opts: { a: '1', b: 2 }, type: 'HNSW' }),
+			true
+		);
+		// floats and arrays of scalars
+		assert.equal(sameStructure({ optimizeRouting: '0.6' }, { optimizeRouting: 0.6 }), true);
+		assert.equal(sameStructure({ dims: ['1', '2'] }, { dims: [1, 2] }), true);
+	});
+
+	it('treats a genuine option change as structurally changed', () => {
+		// The issue's matrix case 2.
+		assert.equal(sameStructure({ type: 'HNSW', M: 16 }, { type: 'HNSW', M: 32 }), false);
+		// The issue's matrix case 3: boolean vs object is a real change (do not collapse).
+		assert.equal(sameStructure(true, { type: 'HNSW' }), false);
+		// Conservative: absent-vs-present is NOT coalesced with defaults — adding/removing an option rebuilds.
+		assert.equal(sameStructure({ type: 'HNSW' }, { type: 'HNSW', M: 16 }), false);
+		// type value differs (non-numeric strings are compared verbatim, case-sensitive)
+		assert.equal(sameStructure({ type: 'HNSW' }, { type: 'hnsw' }), false);
+	});
+
+	it('does not over-coerce: only genuinely numeric strings become numbers', () => {
+		// "16abc" is not numeric-looking -> stays a string -> differs from the number 16
+		assert.equal(sameStructure({ M: '16abc' }, { M: 16 }), false);
+		// empty string must not coerce to 0
+		assert.equal(sameStructure({ x: '' }, { x: 0 }), false);
+		// booleans and numeric-looking strings are distinct (no boolean coercion)
+		assert.equal(sameStructure({ flag: true }, { flag: 'true' }), false);
+		// zero must NOT coerce: string "0" is truthy but number 0 is falsy, and index code branches on
+		// truthiness (e.g. HNSW `if (this.optimizeRouting)` doubles maxConnections) — so these build
+		// structurally different indexes and must remain a genuine change. (cross-model review, #1357)
+		assert.equal(sameStructure({ optimizeRouting: '0' }, { optimizeRouting: 0 }), false);
+		assert.equal(canonicalizeIndexOptions('0'), '0');
+		assert.equal(canonicalizeIndexOptions('0.0'), '0.0');
+		// non-zero numeric strings still coerce (both forms are truthy and numerically identical)
+		assert.equal(sameStructure({ optimizeRouting: '0.6' }, { optimizeRouting: 0.6 }), true);
+		// the canonical form of a scalar is the scalar; whitespace-padded numerics still coerce
+		assert.equal(canonicalizeIndexOptions('16'), 16);
+		assert.equal(canonicalizeIndexOptions(' 16 '), 16);
+		assert.equal(canonicalizeIndexOptions('HNSW'), 'HNSW');
+		assert.equal(canonicalizeIndexOptions(true), true);
+	});
+});
+
+// The per-attribute descriptor is persisted in Table.dbisDB keyed by the attribute's internal key;
+// find it by name rather than reconstructing the key format.
+function findDescriptor(Tbl, attrName) {
+	for (const { value } of Tbl.dbisDB.getRange({ start: false })) {
+		if (value && value.name === attrName) return value;
+	}
+	return null;
+}
+
+describe('index rebuild gating: representation-only options do not re-trigger a backfill (#1357)', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return; // HNSW custom index is RocksDB-only here
+
+	const DB = 'test';
+	const N = 8;
+
+	// Build an HNSW index over existing rows, then reload with various option representations. A
+	// re-trigger is detected by table() installing a NEW indexingOperation promise (the promise
+	// carries across resetDatabases, so identity — not truthiness — is the reliable signal; cf.
+	// indexRestartNumber.test.js).
+	function reload(TABLE, indexedOption) {
+		resetDatabases();
+		return table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'vector', indexed: indexedOption, type: 'Array' },
+			],
+		});
+	}
+
+	it('skips the rebuild for reordered / string-vs-number options and rebuilds on a real change', async () => {
+		const TABLE = 'CanonOpts';
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		// Seed rows with vectors, no index yet.
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'vector', type: 'Array' },
+			],
+		});
+		let last;
+		for (let i = 0; i < N; i++) last = Tbl.put({ id: i, vector: [i % 2, i % 3, i % 4] });
+		await last;
+
+		// First build of the HNSW index over the existing rows.
+		Tbl = reload(TABLE, { type: 'HNSW', M: 16 });
+		const buildOp = Tbl.indexingOperation;
+		assert.ok(buildOp, 'adding @indexed over existing rows should schedule a backfill');
+		await buildOp;
+
+		// Reordered keys: raw JSON differs, canonical form is identical -> NO rebuild.
+		const reordered = reload(TABLE, { M: 16, type: 'HNSW' });
+		assert.equal(reordered.indexingOperation, buildOp, 'reordered index options must NOT re-trigger a backfill');
+
+		// String-vs-number scalar: canonical form identical -> NO rebuild.
+		const stringly = reload(TABLE, { type: 'HNSW', M: '16' });
+		assert.equal(stringly.indexingOperation, buildOp, 'string-vs-number index options must NOT re-trigger a backfill');
+
+		// Genuine option change (M: 16 -> 32) -> rebuild.
+		const changed = reload(TABLE, { type: 'HNSW', M: 32 });
+		assert.notEqual(changed.indexingOperation, buildOp, 'a genuine option change must re-trigger a backfill');
+		assert.ok(changed.indexingOperation, 'a genuine option change should install an indexingOperation');
+		await changed.indexingOperation;
+
+		// Descriptor self-heals to the latest raw form (persistence keys off the raw value).
+		const desc = findDescriptor(changed, 'vector');
+		assert.ok(desc, 'vector descriptor should exist after the rebuild');
+		assert.equal(desc.indexed.M, 32, 'descriptor should persist the changed option');
+	});
+});


### PR DESCRIPTION
## Summary

The secondary-index "structurally changed?" decision in `resources/databases.ts` compared index options with a raw `JSON.stringify`, which is sensitive to option **key order** and **string-vs-number** scalars. `@indexed(...)` records options in source order as strings while the operations API / config objects can supply them reordered or as numbers, so a representation-only difference flipped the decision and forced a **full rebuild** — clearing + rebuilding the index and `503`-ing the attribute for the whole backfill — for a semantically identical index.

This adds `canonicalizeIndexOptions()`, used **only** for the structural comparison: it sorts option keys and coerces numeric-looking string scalars to numbers. It's applied symmetrically to **both** structural comparisons — the reindex trigger (`structurallyChanged`) and the checkpoint-reset decision (`indexOptionsChanged`). Persistence still keys off the **raw** form, so a stored descriptor self-heals toward the canonical shape over time.

Second piece (explainability): one `info` line per reindexed attribute stating which trigger fired — `reindex <db>.<table>.<attr>: reason=new-index|attribute-definition-changed|structural-options-changed|indexing-failed-retry|crash-recovery(pid=N)|restart-number`.

Closes #1357 (sub-issue of #1354).

## Where to look

- **`canonicalizeIndexOptions` zero exclusion** (`databases.ts` ~:1463-1473) — the one subtle correctness edge. `0` is the only finite number whose string form (`"0"`, truthy) and numeric form (`0`, falsy) diverge in JS truthiness, and index code branches on truthiness (e.g. HNSW `if (this.optimizeRouting)` doubles `maxConnections`). So `"0"` and `0` build structurally different indexes and must **not** be collapsed. Zero is excluded from coercion; everything non-zero coerces. This was caught by the cross-model review (see below).
- **Conservative by design** — boolean-vs-object, absent-vs-present, and the zero case are all preserved as rebuild triggers; `commonChanged` (type/nullable/version/properties/elements/embed) is OR'd in unchanged. The invariant is *never skip a needed rebuild*; canonicalization only relaxes the equality test for genuinely-equivalent representations.

## Two deliberate, non-blocking choices (flagged so you don't have to rediscover them)

- **The reason-log mirrors the trigger gate's decision basis**, which mixes the pre-lock structural comparison with the under-lock re-fetched descriptor's recovery flags (PID/restartNumber/indexingFailed). Under a concurrent reload the reasons list could be momentarily inconsistent. It's diagnostic-only (nothing reads `reindexReasons`; `|| 'unknown'` covers the empty case), so I left it mirroring the gate rather than recomputing post-lock.
- **`info` level** for the reason line — consistent with the existing `Indexing/Finished indexing` `info` logs and gated behind `hasExistingData` + the rebuild decision, so it's one line per actual backfill, not hot-path chatter.

## Tests

`unitTests/resources/indexCanonicalOptions.test.js`: the issue's exact matrix + conservative edges (incl. the zero case), plus an HNSW wiring test proving a reordered / string-vs-number option does **not** re-trigger a backfill while a genuine `M:16→32` change does. The sibling `indexRestartNumber` tests were re-verified to confirm the reindex trigger is unaffected.

## Cross-model review

Ran per engineering guidelines (storage/schema → thorough). **Codex** found the zero-valued-`optimizeRouting` collapse described above — now fixed and covered by a test. The **Harper-domain adjudication** returned **no blockers / no significant concerns** and verified the zero-fix is complete and the symmetry/invariant hold. **Caveat:** the Gemini leg (`agy`) hung in this environment and produced no output, so there's no outside-model perf/maintainability pass — low residual risk here since the new code is cold-path only (schema load / reindex), not on the read/write hot path.

No docs change: no public API, config option, schema directive, or CLI surface changes (the log line is operator-facing but not a documented interface).

_Generated by an LLM (Claude Opus 4.8)._

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
