### PR TITLE
feat(models): public registerBackend + defineBackend for custom backends (#1325)

### DIFF
--- a/globals.js
+++ b/globals.js
@@ -2,9 +2,11 @@
 global.contentTypes = exports.contentTypes = null;
 global.createBlob = exports.createBlob = undefined;
 global.databases = exports.databases = {};
+global.defineBackend = exports.defineBackend = undefined;
 global.logger = exports.logger = {};
 global.models = exports.models = undefined;
 global.operation = exports.operation = undefined;
+global.registerBackend = exports.registerBackend = undefined;
 global.Resource = exports.Resource = undefined;
 global.server = exports.server = {};
 global.tables = exports.tables = {};

--- a/index.ts
+++ b/index.ts
@@ -29,6 +29,28 @@ export type { IterableEventQueue } from './resources/IterableEventQueue.ts';
 export type { Table } from './resources/databases.ts';
 export type { Attribute } from './resources/Table.ts';
 export type { Scope } from './components/Scope.ts';
+export type {
+	ModelBackend,
+	ModelCapabilities,
+	DefineBackendSpec,
+	EmbedOpts,
+	GenerateOpts,
+	GenerateInput,
+	GenerateResult,
+	GenerateChunk,
+	BackendOpts,
+	AccountingContext,
+	ModelCallResult,
+	TokenUsage,
+	Message,
+	ToolDef,
+	ToolCall,
+	ToolHandler,
+	ToolHandlerContext,
+	ToolTraceEntry,
+	ConversationAppender,
+	ConversationTurn,
+} from './resources/models/types.ts';
 export type { FilesOption, FilesOptionObject } from './components/deriveGlobOptions.ts';
 export type { FileAndURLPathConfig } from './components/Component.ts';
 export type { OptionsWatcher, Config, ConfigValue } from './components/OptionsWatcher.ts';
@@ -69,14 +91,20 @@ import type { server as ServerImport } from './server/Server.ts';
 import type { tables as TablesImport } from './resources/databases.ts';
 type ThreadsImport = unknown[]; // TODO: figure out actual type for this
 import type { transaction as TransactionImport } from './resources/transaction.ts';
+import type {
+	registerBackend as RegisterBackendImport,
+	defineBackend as DefineBackendImport,
+} from './resources/models/backendRegistry.ts';
 
 declare global {
 	const contentTypes: typeof ContentTypesImport;
 	const createBlob: typeof CreateBlobImport;
 	const databases: typeof DatabasesImport;
+	const defineBackend: typeof DefineBackendImport;
 	const logger: Logger;
 	const models: typeof ModelsImport;
 	const operation: typeof OperationImport;
+	const registerBackend: typeof RegisterBackendImport;
 	const Resource: typeof ResourceImport;
 	const server: typeof ServerImport;
 	const tables: typeof TablesImport;
@@ -88,9 +116,11 @@ declare global {
 export declare const contentTypes: typeof ContentTypesImport;
 export declare const createBlob: typeof CreateBlobImport;
 export declare const databases: typeof DatabasesImport;
+export declare const defineBackend: typeof DefineBackendImport;
 export declare const logger: Logger;
 export declare const models: typeof ModelsImport;
 export declare const operation: typeof OperationImport;
+export declare const registerBackend: typeof RegisterBackendImport;
 export declare const Resource: typeof ResourceImport;
 export declare const server: typeof ServerImport;
 export declare const tables: typeof TablesImport;
@@ -101,9 +131,11 @@ export declare const transaction: typeof TransactionImport;
 exports.contentTypes = null;
 exports.createBlob = undefined;
 exports.databases = {};
+exports.defineBackend = undefined;
 exports.logger = {};
 exports.models = undefined;
 exports.operation = undefined;
+exports.registerBackend = undefined;
 exports.Resource = undefined;
 exports.server = {};
 exports.tables = {};

--- a/resources/models/Models.ts
+++ b/resources/models/Models.ts
@@ -1,6 +1,11 @@
 import { _assignPackageExport } from '../../globals.js';
 import { contextStorage } from '../transaction.ts';
-import { resolveEmbedding, resolveGenerative } from './backendRegistry.ts';
+import {
+	defineBackend,
+	registerBackend as registerBackendImpl,
+	resolveEmbedding,
+	resolveGenerative,
+} from './backendRegistry.ts';
 import { getModelCallAnalyticsWriter, type ModelCallAnalyticsWriter, type ModelCallRecord } from './analyticsTable.ts';
 import { recordAction } from '../analytics/write.ts';
 import { ServerError } from '../../utility/errors/hdbError.ts';
@@ -49,6 +54,16 @@ export class Models implements ModelsContract {
 	) {
 		this.#analyticsWriter = analyticsWriter;
 		this.#emit = metricEmitter;
+	}
+
+	/**
+	 * Register a custom backend under a logical id (e.g. `'local:bge-small'`),
+	 * then select it per call with `opts.model`. The public path for components
+	 * and apps to add in-process or third-party backends; pair with
+	 * `defineBackend` to build the backend from a few methods. See #1325.
+	 */
+	registerBackend(kind: 'embedding' | 'generative', id: string, backend: ModelBackend): void {
+		registerBackendImpl(kind, id, backend);
 	}
 
 	async embed(input: string | string[], opts: EmbedOpts = {}): Promise<Float32Array[]> {
@@ -302,3 +317,6 @@ export class ModelPendingNotSupportedError extends ServerError {
  */
 export const models = new Models();
 _assignPackageExport('models', models);
+// Free-function registration API (#1325), also reachable as `models.registerBackend(...)`.
+_assignPackageExport('registerBackend', registerBackendImpl);
+_assignPackageExport('defineBackend', defineBackend);

--- a/resources/models/backendRegistry.ts
+++ b/resources/models/backendRegistry.ts
@@ -1,5 +1,5 @@
 import { ServerError } from '../../utility/errors/hdbError.ts';
-import type { ModelBackend } from './types.ts';
+import type { DefineBackendSpec, ModelBackend, ModelCapabilities } from './types.ts';
 
 /**
  * Process-wide model backend registry.
@@ -8,6 +8,10 @@ import type { ModelBackend } from './types.ts';
  * generative kinds. Boot wiring populates the registry via
  * `setEmbedding(...)` / `setGenerative(...)`; the `Models` facade reads it
  * via `resolveEmbedding(...)` / `resolveGenerative(...)`.
+ *
+ * Components and apps register their own backends — including in-process /
+ * non-HTTP ones — through the public `registerBackend(...)` / `defineBackend(...)`
+ * pair (#1325), the same primitive the built-in backends use internally.
  *
  * Module-scope state is intentional — one registry per Harper process,
  * mirroring `contextStorage` at `resources/transaction.ts:6`. Translating
@@ -50,6 +54,78 @@ export function resolveGenerative(logicalName: string = 'default'): ModelBackend
 	return backend;
 }
 
+/**
+ * Public registration API (#1325).
+ *
+ * The supported way for a component or app to add a backend — including
+ * in-process / non-HTTP ones — under a logical id. Call it during component
+ * load (e.g. `handleApplication`); the registry is process-wide, so each worker
+ * thread that loads the component registers its own instance, matching how the
+ * config-driven built-ins populate per process.
+ *
+ * `id` is the logical name callers select with `opts.model` (e.g.
+ * `models.embed(text, { model: 'local:bge-small' })`). A provider-namespaced id
+ * (`local:bge-small`, `openai:gpt-4o`) avoids collisions when multiple plugins
+ * register — convention, not enforced.
+ *
+ * A hand-rolled backend's `capabilities()` must agree with the methods it
+ * implements (the `generate` / `stream` paths gate on it); `defineBackend`
+ * derives them for you, so prefer it.
+ */
+export function registerBackend(kind: ModelKind, id: string, backend: ModelBackend): void {
+	if (kind !== 'embedding' && kind !== 'generative')
+		throw new ModelBackendRegistrationError(`kind must be 'embedding' or 'generative', got '${String(kind)}'`);
+	if (typeof id !== 'string' || id.length === 0)
+		throw new ModelBackendRegistrationError('backend id must be a non-empty string');
+	if (
+		!backend ||
+		typeof backend.capabilities !== 'function' ||
+		typeof backend.name !== 'string' ||
+		backend.name.length === 0
+	)
+		throw new ModelBackendRegistrationError(`backend '${id}' must be a ModelBackend with a name and capabilities()`);
+	if (kind === 'embedding') {
+		if (typeof backend.embed !== 'function')
+			throw new ModelBackendRegistrationError(`embedding backend '${id}' must implement embed()`);
+		setEmbedding(id, backend);
+	} else {
+		if (typeof backend.generate !== 'function' && typeof backend.generateStream !== 'function')
+			throw new ModelBackendRegistrationError(
+				`generative backend '${id}' must implement generate() or generateStream()`
+			);
+		setGenerative(id, backend);
+	}
+}
+
+/**
+ * Build a `ModelBackend` from just the methods it implements. `capabilities()`
+ * is derived from which of `embed` / `generate` / `generateStream` are present;
+ * `tools` and `adapters` aren't inferable from method presence, so pass them
+ * explicitly (both default `false`). Lowers the bar from authoring a class to
+ * supplying a function — pair with `registerBackend`. See #1325.
+ */
+export function defineBackend(spec: DefineBackendSpec): ModelBackend {
+	if (!spec || typeof spec.name !== 'string' || spec.name.length === 0)
+		throw new ModelBackendRegistrationError('defineBackend requires a non-empty name');
+	const { name, embed, generate, generateStream, tools = false, adapters = false } = spec;
+	if (!embed && !generate && !generateStream)
+		throw new ModelBackendRegistrationError(
+			`backend '${name}' must implement at least one of embed / generate / generateStream`
+		);
+	const capabilities: ModelCapabilities = Object.freeze({
+		embed: typeof embed === 'function',
+		generate: typeof generate === 'function',
+		stream: typeof generateStream === 'function',
+		tools,
+		adapters,
+	});
+	const backend: ModelBackend = { name, capabilities: () => capabilities };
+	if (embed) backend.embed = embed;
+	if (generate) backend.generate = generate;
+	if (generateStream) backend.generateStream = generateStream;
+	return backend;
+}
+
 /** Remove all registrations. Test-only hygiene. */
 export function clearRegistry(): void {
 	embedding.clear();
@@ -62,5 +138,13 @@ export class ModelBackendNotFoundError extends ServerError {
 	constructor(kind: ModelKind, logicalName: string) {
 		super(`No backend registered for '${kind}.${logicalName}'`);
 		this.name = 'ModelBackendNotFoundError';
+	}
+}
+
+/** Thrown by `registerBackend` / `defineBackend` on invalid registration input. */
+export class ModelBackendRegistrationError extends ServerError {
+	constructor(message: string) {
+		super(message);
+		this.name = 'ModelBackendRegistrationError';
 	}
 }

--- a/resources/models/backendRegistry.ts
+++ b/resources/models/backendRegistry.ts
@@ -1,5 +1,5 @@
 import { ServerError } from '../../utility/errors/hdbError.ts';
-import type { DefineBackendSpec, ModelBackend, ModelCapabilities } from './types.ts';
+import type { DefineBackendSpec, GenerateResult, ModelBackend, ModelCapabilities, ToolCall } from './types.ts';
 
 /**
  * Process-wide model backend registry.
@@ -108,22 +108,58 @@ export function defineBackend(spec: DefineBackendSpec): ModelBackend {
 	if (!spec || typeof spec.name !== 'string' || spec.name.length === 0)
 		throw new ModelBackendRegistrationError('defineBackend requires a non-empty name');
 	const { name, embed, generate, generateStream, tools = false, adapters = false } = spec;
-	if (!embed && !generate && !generateStream)
+	// Gate on function-ness, not truthiness: a non-function value (`generate: 'oops'`)
+	// must be rejected at definition time, not assigned and crash at call time.
+	const hasEmbed = typeof embed === 'function';
+	const hasGenerate = typeof generate === 'function';
+	const hasStream = typeof generateStream === 'function';
+	if (!hasEmbed && !hasGenerate && !hasStream)
 		throw new ModelBackendRegistrationError(
-			`backend '${name}' must implement at least one of embed / generate / generateStream`
+			`backend '${name}' must implement at least one of embed / generate / generateStream (as functions)`
 		);
 	const capabilities: ModelCapabilities = Object.freeze({
-		embed: typeof embed === 'function',
-		generate: typeof generate === 'function',
-		stream: typeof generateStream === 'function',
+		embed: hasEmbed,
+		// A stream-only backend gains generate() via the synthesis below.
+		generate: hasGenerate || hasStream,
+		stream: hasStream,
 		tools,
 		adapters,
 	});
 	const backend: ModelBackend = { name, capabilities: () => capabilities };
-	if (embed) backend.embed = embed;
-	if (generate) backend.generate = generate;
-	if (generateStream) backend.generateStream = generateStream;
+	if (hasEmbed) backend.embed = embed;
+	if (hasGenerate) backend.generate = generate;
+	if (hasStream) backend.generateStream = generateStream;
+	// Stream-only generative backend: synthesize generate() by draining the stream,
+	// so a plain models.generate() works without the backend implementing both.
+	if (hasStream && !hasGenerate) backend.generate = synthesizeGenerateFromStream(generateStream!);
 	return backend;
+}
+
+/**
+ * Build a `generate` from a backend's `generateStream` by draining it into a
+ * single `GenerateResult`. Accumulates text and the terminal finish reason;
+ * tool calls are forwarded best-effort (only those that arrive complete in a
+ * single chunk — the chunk type carries no call index to reassemble fragments,
+ * so a backend that streams partial tool calls should implement `generate()`).
+ */
+function synthesizeGenerateFromStream(
+	generateStream: NonNullable<ModelBackend['generateStream']>
+): NonNullable<ModelBackend['generate']> {
+	return async (input, opts) => {
+		let content = '';
+		let finishReason: GenerateResult['finishReason'] = 'stop';
+		const toolCalls: ToolCall[] = [];
+		for await (const chunk of generateStream(input, opts)) {
+			if (chunk.deltaContent) content += chunk.deltaContent;
+			if (chunk.finishReason) finishReason = chunk.finishReason;
+			for (const tc of chunk.deltaToolCalls ?? []) {
+				if (typeof tc.id === 'string' && typeof tc.name === 'string') toolCalls.push(tc as ToolCall);
+			}
+		}
+		const output: GenerateResult =
+			toolCalls.length > 0 ? { content, finishReason, toolCalls } : { content, finishReason };
+		return { status: 'completed', output };
+	};
 }
 
 /** Remove all registrations. Test-only hygiene. */

--- a/resources/models/types.ts
+++ b/resources/models/types.ts
@@ -11,6 +11,8 @@ export interface Models {
 	embed(input: string | string[], opts?: EmbedOpts): Promise<Float32Array[]>;
 	generate(input: GenerateInput, opts?: GenerateOpts): Promise<GenerateResult>;
 	generateStream(input: GenerateInput, opts?: GenerateOpts): AsyncIterable<GenerateChunk>;
+	/** Register a custom backend under a logical id, selectable via `opts.model`. See #1325. */
+	registerBackend(kind: 'embedding' | 'generative', id: string, backend: ModelBackend): void;
 }
 
 export interface ModelBackend {
@@ -27,6 +29,23 @@ export interface ModelCapabilities {
 	stream: boolean;
 	tools: boolean;
 	adapters: boolean;
+}
+
+/**
+ * Spec for `defineBackend` — supply only the methods your backend implements;
+ * `capabilities()` is derived from which are present. `tools` and `adapters`
+ * can't be inferred from method presence, so declare them explicitly (both
+ * default `false`). See #1325.
+ */
+export interface DefineBackendSpec {
+	name: string;
+	embed?: ModelBackend['embed'];
+	generate?: ModelBackend['generate'];
+	generateStream?: ModelBackend['generateStream'];
+	/** Backend supports tool calls in `generate` / `generateStream`. Default `false`. */
+	tools?: boolean;
+	/** Backend supports per-call LoRA / adapter selection. Default `false`. */
+	adapters?: boolean;
 }
 
 export type EmbedOpts = {

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -3,6 +3,7 @@ import { contextStorage, transaction } from '../resources/transaction.ts';
 import { RequestTarget } from '../resources/RequestTarget.ts';
 import { tables, databases } from '../resources/databases.ts';
 import { models as harperModelsSingleton } from '../resources/models/Models.ts';
+import { registerBackend, defineBackend } from '../resources/models/backendRegistry.ts';
 import { readFile } from 'node:fs/promises';
 import { dirname, isAbsolute } from 'node:path';
 import { pathToFileURL, fileURLToPath } from 'node:url';
@@ -788,6 +789,10 @@ function getHarperExports(scope: ApplicationScope) {
 		// registry it reads from is populated at boot by
 		// `resources/models/bootstrap.ts`.
 		models: harperModelsSingleton,
+		// Public model-backend registration API (#1325) — same functions as the
+		// top-level package exports; components register backends through these.
+		registerBackend,
+		defineBackend,
 		createBlob,
 		RequestTarget,
 		getContext,

--- a/unitTests/resources/models/Models.test.js
+++ b/unitTests/resources/models/Models.test.js
@@ -33,6 +33,11 @@ describe('models singleton', () => {
 	it('_assignPackageExport wires global.models to the same object', () => {
 		assert.strictEqual(global.models, modelsSingleton);
 	});
+
+	it('_assignPackageExport wires the registerBackend / defineBackend free functions', () => {
+		assert.strictEqual(typeof global.registerBackend, 'function');
+		assert.strictEqual(typeof global.defineBackend, 'function');
+	});
 });
 
 // Captures (value, metric, path) tuples that Models passes to recordAction.

--- a/unitTests/resources/models/backendRegistry.test.js
+++ b/unitTests/resources/models/backendRegistry.test.js
@@ -7,7 +7,10 @@ const {
 	resolveEmbedding,
 	resolveGenerative,
 	clearRegistry,
+	registerBackend,
+	defineBackend,
 	ModelBackendNotFoundError,
+	ModelBackendRegistrationError,
 } = require('#src/resources/models/backendRegistry');
 
 function fakeBackend(name) {
@@ -84,5 +87,69 @@ describe('backendRegistry', () => {
 			assert.ok(!err.message.includes('secret-backend-name'), 'error should not enumerate registered backend names');
 			assert.ok(err.message.includes('embedding.other'));
 		}
+	});
+});
+
+describe('registerBackend', () => {
+	const embedSpec = { embed: async () => ({ status: 'completed', output: [] }) };
+	const generateSpec = {
+		generate: async () => ({ status: 'completed', output: { content: '', finishReason: 'stop' } }),
+	};
+
+	beforeEach(() => clearRegistry());
+
+	it('registers and resolves an embedding backend by id', () => {
+		const backend = defineBackend({ name: 'local:e', ...embedSpec });
+		registerBackend('embedding', 'local:e', backend);
+		assert.strictEqual(resolveEmbedding('local:e'), backend);
+	});
+
+	it('registers and resolves a generative backend by id', () => {
+		const backend = defineBackend({ name: 'local:g', ...generateSpec });
+		registerBackend('generative', 'local:g', backend);
+		assert.strictEqual(resolveGenerative('local:g'), backend);
+	});
+
+	it('accepts a stream-only generative backend', () => {
+		const backend = defineBackend({ name: 'local:s', generateStream: async function* () {} });
+		registerBackend('generative', 'local:s', backend);
+		assert.strictEqual(resolveGenerative('local:s'), backend);
+	});
+
+	it('re-registering the same id replaces the prior backend', () => {
+		const a = defineBackend({ name: 'a', ...embedSpec });
+		const b = defineBackend({ name: 'b', ...embedSpec });
+		registerBackend('embedding', 'x', a);
+		registerBackend('embedding', 'x', b);
+		assert.strictEqual(resolveEmbedding('x'), b);
+	});
+
+	it('throws on an invalid kind', () => {
+		assert.throws(() => registerBackend('bogus', 'x', fakeBackend('k')), ModelBackendRegistrationError);
+	});
+
+	it('throws on an empty id', () => {
+		assert.throws(
+			() => registerBackend('embedding', '', defineBackend({ name: 'k', ...embedSpec })),
+			ModelBackendRegistrationError
+		);
+	});
+
+	it('throws when an embedding backend has no embed()', () => {
+		assert.throws(
+			() => registerBackend('embedding', 'x', defineBackend({ name: 'g-only', ...generateSpec })),
+			ModelBackendRegistrationError
+		);
+	});
+
+	it('throws when a generative backend has neither generate() nor generateStream()', () => {
+		assert.throws(
+			() => registerBackend('generative', 'x', defineBackend({ name: 'e-only', ...embedSpec })),
+			ModelBackendRegistrationError
+		);
+	});
+
+	it('throws when the backend lacks a name or capabilities()', () => {
+		assert.throws(() => registerBackend('embedding', 'x', { embed: async () => ({}) }), ModelBackendRegistrationError);
 	});
 });

--- a/unitTests/resources/models/defineBackend.test.js
+++ b/unitTests/resources/models/defineBackend.test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+// Prime Harper's module graph in the same order the other models unit tests do
+// (see Models.test.js) so the transaction.ts ↔ blob require chain resolves.
+require('#src/resources/databases');
+const {
+	registerBackend,
+	defineBackend,
+	clearRegistry,
+	ModelBackendRegistrationError,
+} = require('#src/resources/models/backendRegistry');
+const { Models } = require('#src/resources/models/Models');
+
+function makeMockWriter() {
+	const records = [];
+	return { records, write: (record) => records.push(record) };
+}
+
+const embedFn = async (input) => {
+	const texts = Array.isArray(input) ? input : [input];
+	return { status: 'completed', output: texts.map(() => Float32Array.from([0.1, 0.2, 0.3])) };
+};
+
+describe('defineBackend', () => {
+	it('derives capabilities from the methods supplied (embed-only)', () => {
+		const b = defineBackend({ name: 'local:e', embed: embedFn });
+		assert.deepStrictEqual(b.capabilities(), {
+			embed: true,
+			generate: false,
+			stream: false,
+			tools: false,
+			adapters: false,
+		});
+		assert.strictEqual(typeof b.embed, 'function');
+		assert.strictEqual(b.generate, undefined);
+		assert.strictEqual(b.generateStream, undefined);
+	});
+
+	it('derives generate + stream capabilities', () => {
+		const b = defineBackend({
+			name: 'local:g',
+			generate: async () => ({ status: 'completed', output: { content: '', finishReason: 'stop' } }),
+			generateStream: async function* () {},
+		});
+		assert.deepStrictEqual(b.capabilities(), {
+			embed: false,
+			generate: true,
+			stream: true,
+			tools: false,
+			adapters: false,
+		});
+	});
+
+	it('honors explicit tools / adapters flags (not inferable from methods)', () => {
+		const b = defineBackend({
+			name: 'local:t',
+			generate: async () => ({ status: 'completed', output: { content: '', finishReason: 'stop' } }),
+			tools: true,
+			adapters: true,
+		});
+		assert.strictEqual(b.capabilities().tools, true);
+		assert.strictEqual(b.capabilities().adapters, true);
+	});
+
+	it('returns a frozen, stable capabilities object', () => {
+		const b = defineBackend({ name: 'local:f', embed: embedFn });
+		assert.ok(Object.isFrozen(b.capabilities()));
+		assert.strictEqual(b.capabilities(), b.capabilities());
+	});
+
+	it('throws without a name', () => {
+		assert.throws(() => defineBackend({ embed: embedFn }), ModelBackendRegistrationError);
+	});
+
+	it('throws when no method is supplied', () => {
+		assert.throws(() => defineBackend({ name: 'empty' }), ModelBackendRegistrationError);
+	});
+});
+
+describe('registerBackend + defineBackend end-to-end through Models', () => {
+	beforeEach(() => clearRegistry());
+	afterEach(() => clearRegistry());
+
+	it('a registered in-process embedding backend resolves through models.embed({ model })', async () => {
+		registerBackend('embedding', 'local:test-embed', defineBackend({ name: 'local:test-embed', embed: embedFn }));
+		const models = new Models(makeMockWriter(), () => {});
+		const vectors = await models.embed('hello', { model: 'local:test-embed' });
+		assert.ok(Array.isArray(vectors));
+		assert.ok(vectors[0] instanceof Float32Array);
+		assert.strictEqual(vectors[0].length, 3);
+	});
+
+	it('models.registerBackend (the scope.models path) registers too', async () => {
+		const models = new Models(makeMockWriter(), () => {});
+		models.registerBackend(
+			'embedding',
+			'local:via-method',
+			defineBackend({ name: 'local:via-method', embed: embedFn })
+		);
+		const vectors = await models.embed('hi', { model: 'local:via-method' });
+		assert.ok(vectors[0] instanceof Float32Array);
+	});
+});

--- a/unitTests/resources/models/defineBackend.test.js
+++ b/unitTests/resources/models/defineBackend.test.js
@@ -76,6 +76,28 @@ describe('defineBackend', () => {
 	it('throws when no method is supplied', () => {
 		assert.throws(() => defineBackend({ name: 'empty' }), ModelBackendRegistrationError);
 	});
+
+	it('rejects a non-function method instead of assigning it (function-ness, not truthiness)', () => {
+		// A truthy non-function is not a method: if it's the only one, the backend has none.
+		assert.throws(() => defineBackend({ name: 'bad', generate: 'oops' }), ModelBackendRegistrationError);
+		// Alongside a valid method, the bad value is simply not attached and the
+		// capability stays false — no `backend.generate is not a function` at call time.
+		const b = defineBackend({ name: 'mixed', embed: embedFn, generate: 'oops' });
+		assert.strictEqual(b.generate, undefined);
+		assert.strictEqual(b.capabilities().generate, false);
+	});
+
+	it('synthesizes generate() for a stream-only backend (capabilities.generate = true)', () => {
+		const b = defineBackend({
+			name: 'local:stream-only',
+			generateStream: async function* () {
+				yield { deltaContent: 'hi' };
+			},
+		});
+		assert.strictEqual(b.capabilities().generate, true);
+		assert.strictEqual(b.capabilities().stream, true);
+		assert.strictEqual(typeof b.generate, 'function');
+	});
 });
 
 describe('registerBackend + defineBackend end-to-end through Models', () => {
@@ -100,5 +122,24 @@ describe('registerBackend + defineBackend end-to-end through Models', () => {
 		);
 		const vectors = await models.embed('hi', { model: 'local:via-method' });
 		assert.ok(vectors[0] instanceof Float32Array);
+	});
+
+	it('models.generate() drains a stream-only backend via the synthesized generate', async () => {
+		registerBackend(
+			'generative',
+			'local:stream-only',
+			defineBackend({
+				name: 'local:stream-only',
+				generateStream: async function* () {
+					yield { deltaContent: 'Hello, ' };
+					yield { deltaContent: 'world' };
+					yield { finishReason: 'stop' };
+				},
+			})
+		);
+		const models = new Models(makeMockWriter(), () => {});
+		const result = await models.generate('hi', { model: 'local:stream-only' });
+		assert.strictEqual(result.content, 'Hello, world');
+		assert.strictEqual(result.finishReason, 'stop');
 	});
 });

--- a/unitTests/security/jsLoader/jsLoader.test.js
+++ b/unitTests/security/jsLoader/jsLoader.test.js
@@ -66,6 +66,11 @@ describe('scopedImport', () => {
 		const result = await scopedImport(join(__dirname, 'fixtures', 'uses-harperdb.cjs'), scope);
 		expect(result.Resource).to.be.a('function');
 		expect(result.tables).to.exist;
+		// #1325: the model-backend registration API must reach components through the
+		// `require('harperdb')` path (getHarperExports), the same way `models`/`tables` do.
+		expect(result.models).to.exist;
+		expect(result.registerBackend).to.be.a('function');
+		expect(result.defineBackend).to.be.a('function');
 	});
 
 	it('should throw an error importing an ESM module with invalid dependency', async () => {


### PR DESCRIPTION
## Summary

Exposes the model-backend registry so components and apps can register their own backends — including in-process / non-HTTP ("code") ones — under a logical id, the same primitive the built-in backends use internally.

- `registerBackend(kind, id, backend)` — public registration; also `scope.models.registerBackend(...)`.
- `defineBackend(spec)` — builds a `ModelBackend`, deriving `capabilities()` from the methods supplied (`tools` / `adapters` declared explicitly, default false).
- Both reach components through every path `models` already uses: the package index, globals, **and** the component module loader (`getHarperExports`), so `import { registerBackend } from 'harperdb'` works inside a component.
- Model public types re-exported from the package; `registerBackend` added to the `Models` interface.

## Purpose

`scope.models` (5.1.0 GA) only hosts the four config-selectable backends via a closed factory map; there was no public path to register a custom or in-process backend. This unblocks that — e.g. wrapping a local node-llama-cpp embedder behind `scope.models`.

Closes #1325 (imperative-only scope; operator config-file selection is tracked separately in #1471). Part of #510.

## Where to look

- `security/jsLoader.ts` `getHarperExports` — the surface components import from `'harperdb'`; the two new functions are wired alongside `models`. A regression test in `jsLoader.test.js` asserts they resolve through `require('harperdb')`.
- `resources/models/backendRegistry.ts` — `registerBackend` validation + `defineBackend` capability derivation.
- Backward-compat: strictly additive — no change to the existing `Models` runtime surface, `ModelBackend`, the built-in backends, or `models:` config. `scope.models` stays GA-frozen (5.1.0).

## Scope / deferred

Imperative API only — register backends in code, select via `opts.model`. Operator config-file selection of a custom backend (`backend: <module>` in the `models:` YAML) is split out to #1471.

## Docs

Companion docs PR: HarperFast/documentation#554.

## Review

Cross-model reviewed (Codex + Harper domain pass). No blockers. Open coverage caveat for the human reviewer: the Gemini / perf-lens leg timed out and did not run — low cost here, since this is registration code that runs at component load, not in the embed/generate hot path.

## Status

Ready for review — scope settled (imperative-only; config split to #1471), CI green. The companion docs PR (HarperFast/documentation#554) is intentionally held in draft until the release version this lands in is known (its `<VersionBadge>` needs the real version).

---

Generated by an LLM (Claude Opus 4.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
