### PR TITLE
fix(audit): report entries_deleted for delete_transaction/audit_logs_before (#1294)

### DIFF
--- a/dataLayer/delete.ts
+++ b/dataLayer/delete.ts
@@ -109,7 +109,8 @@ export async function deleteAuditLogsBefore(deleteObj: any) {
 	await pGlobalSchema(deleteObj.schema, deleteObj.table);
 	harperLogger.info(`Finished deleting audit logs before ${deleteObj.timestamp}`);
 
-	return new DeleteAuditLogsBeforeResults(results.start_timestamp, results.end_timestamp, results.transactions_deleted);
+	// `deleteTransactionLogsBefore` returns `entries_deleted`; the legacy result exposes it as `transactions_deleted`.
+	return new DeleteAuditLogsBeforeResults(results.start_timestamp, results.end_timestamp, results.entries_deleted);
 }
 
 /**

--- a/dataLayer/harperBridge/DeleteTransactionLogsBeforeResults.ts
+++ b/dataLayer/harperBridge/DeleteTransactionLogsBeforeResults.ts
@@ -4,16 +4,19 @@
 export class DeleteTransactionLogsBeforeResults {
 	start_timestamp?: number;
 	end_timestamp?: number;
+	entries_deleted: number;
 	log_files_deleted: number;
 
 	/**
 	 * @param {number} startTimestamp
 	 * @param {number} endTimestamp
+	 * @param {number} entriesDeleted
 	 * @param {number} logFilesDeleted
 	 */
-	constructor(startTimestamp?: number, endTimestamp?: number, logFilesDeleted = 0) {
+	constructor(startTimestamp?: number, endTimestamp?: number, entriesDeleted = 0, logFilesDeleted = 0) {
 		this.start_timestamp = startTimestamp;
 		this.end_timestamp = endTimestamp;
+		this.entries_deleted = entriesDeleted;
 		this.log_files_deleted = logFilesDeleted;
 	}
 }

--- a/dataLayer/harperBridge/ResourceBridge.ts
+++ b/dataLayer/harperBridge/ResourceBridge.ts
@@ -493,16 +493,19 @@ export class ResourceBridge extends BridgeMethods {
 			if (tables) {
 				for (const table of Object.values(tables)) {
 					if (table.primaryStore instanceof RocksDatabase) {
-						const deleted = table.primaryStore.purgeLogs({ before });
+						const deleted = table.primaryStore.purgeLogs({ before, includeEntryCounts: true });
 						totalResults.log_files_deleted += deleted.length;
+						totalResults.entries_deleted += deleted.reduce((acc, file) => acc + file.entries, 0);
 						break;
 					}
 				}
 			}
 		} else if (table.primaryStore instanceof RocksDatabase) {
-			totalResults.log_files_deleted += table.primaryStore.purgeLogs({ before }).length;
+			const deleted = table.primaryStore.purgeLogs({ before, includeEntryCounts: true });
+			totalResults.log_files_deleted += deleted.length;
+			totalResults.entries_deleted += deleted.reduce((acc, file) => acc + file.entries, 0);
 		} else {
-			await table.deleteHistory(before, deleteObj.cleanup_deleted_records);
+			totalResults.entries_deleted += await table.deleteHistory(before, deleteObj.cleanup_deleted_records);
 		}
 		return totalResults;
 	}

--- a/integrationTests/apiTests/transaction-logs.test.mjs
+++ b/integrationTests/apiTests/transaction-logs.test.mjs
@@ -113,7 +113,7 @@ suite('Transaction Logs', (ctx) => {
 	test('delete_transaction_logs_before suiteStart deletes no files', async () => {
 		// `suiteStart` is from before any inserts happened — no log files should
 		// have been rotated out yet, so the job should run to completion with
-		// `log_files_deleted: 0`.
+		// `log_files_deleted: 0` and `entries_deleted: 0`.
 		const response = await client
 			.req()
 			.send({
@@ -127,6 +127,7 @@ suite('Transaction Logs', (ctx) => {
 		const jobId = getJobId(response.body);
 		const jobResponse = await awaitJob(client, jobId, 15);
 		assert.equal(jobResponse.body[0].result.log_files_deleted, 0, jobResponse.text);
+		assert.equal(jobResponse.body[0].result.entries_deleted, 0, jobResponse.text);
 	});
 
 	test('drop test_logs table', async () => {

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -4090,8 +4090,9 @@ export function makeTable(options) {
 			this.userEmbedders[attribute_name] = embedder;
 			this.userSetEmbedders.add(attribute_name);
 		}
-		static async deleteHistory(endTime = 0, cleanupDeletedRecords = false) {
+		static async deleteHistory(endTime = 0, cleanupDeletedRecords = false): Promise<number> {
 			let completion: Promise<void>;
+			let entriesDeleted = 0;
 			for (const auditRecord of auditStore.getRange({
 				start: 0,
 				end: endTime,
@@ -4099,6 +4100,7 @@ export function makeTable(options) {
 				await rest(); // yield to other async operations
 				if (auditRecord.tableId !== tableId) continue;
 				completion = removeAuditEntry(auditStore, auditRecord);
+				entriesDeleted++;
 			}
 			if (cleanupDeletedRecords) {
 				// this is separate procedure we can do if the records are not being cleaned up by the audit log. This shouldn't
@@ -4112,6 +4114,7 @@ export function makeTable(options) {
 				}
 			}
 			await completion;
+			return entriesDeleted;
 		}
 		static async *getHistory(startTime = 0, endTime = Infinity) {
 			for (const auditRecord of auditStore.getRange({

--- a/unitTests/dataLayer/delete.test.js
+++ b/unitTests/dataLayer/delete.test.js
@@ -141,7 +141,8 @@ describe('Tests for delete.js', () => {
 			let bridge_delete_txns_stub = sandbox.stub(harperBridge, 'deleteTransactionLogsBefore').resolves({
 				start_timestamp: 1,
 				end_timestamp: 2,
-				transactions_deleted: 3,
+				entries_deleted: 3,
+				log_files_deleted: 1,
 			});
 
 			global.hdb_schema = {
@@ -150,12 +151,14 @@ describe('Tests for delete.js', () => {
 				},
 			};
 			let delete_obj = testUtils.deepClone(DELETE_TXN_BEFORE_OBJ);
-			await _delete.deleteAuditLogsBefore(delete_obj);
+			const result = await _delete.deleteAuditLogsBefore(delete_obj);
 
 			expect(bridge_delete_txns_stub).to.have.been.calledWith(delete_obj);
 			expect(log_info_spy).to.have.been.calledWith(
 				`Finished deleting audit logs before ${DELETE_TXN_BEFORE_OBJ.timestamp}`
 			);
+			// the bridge's `entries_deleted` is surfaced as the legacy `transactions_deleted` field
+			expect(result.transactions_deleted).to.equal(3);
 		});
 	});
 


### PR DESCRIPTION
Closes #1294.

## Summary
On the RocksDB engine, `delete_transaction_logs_before` / `delete_audit_logs_before` purge whole transaction-log files but reported no entry count, so the ops looked like silent no-ops (issue #1294). `@harperfast/rocksdb-js` 2.2.0 adds `purgeLogs({ includeEntryCounts: true })`, which returns `{ path, entries }[]`. This surfaces the purged entry count as a new `entries_deleted` response field.

- `DeleteTransactionLogsBeforeResults`: add `entries_deleted`.
- `ResourceBridge.deleteTransactionLogsBefore`: pass `includeEntryCounts: true` and sum entries for RocksDB; for LMDB, sum the count now returned by `Table.deleteHistory`.
- `Table.deleteHistory`: return the number of audit entries removed (was `void`).
- `delete.ts` (deprecated `delete_audit_logs_before`): previously mapped `results.transactions_deleted` — a field that never existed on the new bridge result, so it **always reported 0**. Now maps `entries_deleted`.

## Where to look
- **`Table.deleteHistory` signature change** (`void` → `Promise<number>`): only caller is `ResourceBridge`; return value was previously ignored. Additive/back-compat.
- **`DeleteTransactionLogsBeforeResults` constructor param order**: `entriesDeleted` inserted before `logFilesDeleted`. The class is only ever constructed with no args, so positional callers are unaffected.
- **Cross-engine symmetry**: `entries_deleted` is now populated for both RocksDB (entries in purged whole files) and LMDB (per-entry deletions). RocksDB remains whole-file/rollover-granular — a short retention window still reclaims nothing until a file fully ages past the cutoff (documented in issue #1294); this PR makes the *reported count* truthful, it does not change purge granularity.

## Testing
- `test:unit:main` (2755 passing), `test:unit:resources` (841 passing), `delete.test.js` updated to assert the deprecated-op mapping.
- Integration `transaction-logs.test.mjs` extended to assert `entries_deleted: 0` in the no-purge case.
- A positive-count integration assertion was intentionally not added: forcing a RocksDB log-file rollover in-test is fragile (purge only deletes files entirely before the flushed position).

## Notes
- New user-facing response field `entries_deleted` — a companion docs update (HarperFast/documentation) is likely warranted.
- Cross-model review: Codex (clean, no regressions). The Gemini/`agy` reviewer returned empty output across several attempts (tooling issue), so a second model review is still outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: Claude Opus 4.8)