### PR TITLE
fix(tls): persist and read certificate file_timestamp for staleness guard

### DIFF
--- a/security/keys.ts
+++ b/security/keys.ts
@@ -98,6 +98,9 @@ export function getCertTable() {
 						attribute: 'is_self_signed',
 					},
 					{
+						attribute: 'file_timestamp',
+					},
+					{
 						attribute: '__updatedtime__',
 					},
 				],
@@ -263,7 +266,7 @@ export function loadCertificates() {
 									private_key_name,
 									is_authority: ca,
 									hostnames,
-									fileTimestamp,
+									file_timestamp: fileTimestamp,
 									details: {
 										issuer: x509Cert.issuer.replace(/\n/g, ' '),
 										subject: x509Cert.subject?.replace(/\n/g, ' '),

--- a/unitTests/security/keys.test.js
+++ b/unitTests/security/keys.test.js
@@ -407,4 +407,81 @@ describe('Test keys module', () => {
 			}
 		});
 	});
+
+	describe('certificate file_timestamp staleness guard', () => {
+		let certTable;
+		let certCn;
+		let originalMtime;
+		let originalRecord;
+
+		// Re-run a single load cycle against the existing (seeded) certificate table.
+		async function reloadCertificates() {
+			keys.__set__('configuredCertsLoaded', false);
+			keys.__set__('certificateTable', undefined);
+			await keys.loadCertificates();
+		}
+
+		before(async () => {
+			const { databases } = require('#src/resources/databases');
+			certTable = databases.system.hdb_certificate;
+			certCn = actual_cert.name;
+			// These tests mutate the cert file mtime and the stored record; snapshot both so we
+			// can restore them and avoid polluting state for any later-added tests.
+			originalMtime = fs.statSync(test_cert_path).mtime;
+			originalRecord = { ...(await certTable.get(certCn)) };
+		});
+
+		after(async () => {
+			fs.utimesSync(test_cert_path, originalMtime, originalMtime);
+			await certTable.put(originalRecord);
+		});
+
+		it('persists file_timestamp matching the certificate file mtime on load', async () => {
+			const record = await certTable.get(certCn);
+			const mtimeMs = fs.statSync(test_cert_path).mtimeMs;
+			expect(record.file_timestamp, 'file_timestamp should be persisted on the record').to.equal(mtimeMs);
+		});
+
+		it('reloads the certificate when the file is newer than the stored record', async () => {
+			const past = Date.now() - 24 * 60 * 60 * 1000;
+			await certTable.put({
+				...(await certTable.get(certCn)),
+				name: certCn,
+				certificate: 'SENTINEL-OLD',
+				is_self_signed: false,
+				file_timestamp: past,
+			});
+			const now = new Date();
+			fs.utimesSync(test_cert_path, now, now);
+
+			await reloadCertificates();
+
+			const record = await certTable.get(certCn);
+			expect(record.certificate, 'a newer file should overwrite the stored cert').to.not.equal('SENTINEL-OLD');
+			expect(record.file_timestamp, 'file_timestamp should advance to the file mtime').to.equal(
+				fs.statSync(test_cert_path).mtimeMs
+			);
+		});
+
+		it('skips reload when the certificate file is older than the stored record', async () => {
+			// The stored record claims a file_timestamp far in the future, while the file mtime is
+			// set newer than "now" but still older than that record. This distinguishes reading
+			// file_timestamp (correct -> skip) from falling back to __updatedtime__ (~now -> reload).
+			const future = Date.now() + 24 * 60 * 60 * 1000;
+			await certTable.put({
+				...(await certTable.get(certCn)),
+				name: certCn,
+				certificate: 'SENTINEL-FUTURE',
+				is_self_signed: false,
+				file_timestamp: future,
+			});
+			const fileTime = new Date(Date.now() + 60 * 60 * 1000);
+			fs.utimesSync(test_cert_path, fileTime, fileTime);
+
+			await reloadCertificates();
+
+			const record = await certTable.get(certCn);
+			expect(record.certificate, 'an older file must not overwrite the stored cert').to.equal('SENTINEL-FUTURE');
+		});
+	});
 });

--- a/unitTests/security/keys.test.js
+++ b/unitTests/security/keys.test.js
@@ -431,6 +431,22 @@ describe('Test keys module', () => {
 			originalRecord = { ...(await certTable.get(certCn)) };
 		});
 
+		beforeEach(() => {
+			// loadCertificates() returns only the last processed cert's put promise. Drop the
+			// certificateAuthority from the config so the non-CA cert is the awaited write,
+			// guaranteeing reloadCertificates() resolves after certCn is committed.
+			sandbox.restore();
+			sandbox.stub(config_utils, 'getConfigFromFile').callsFake((key) => {
+				if (key === 'tls')
+					return {
+						certificate: test_cert_path,
+						privateKey: test_private_key_path,
+					};
+				if (key === 'rootPath') return root_path;
+				return undefined;
+			});
+		});
+
 		after(async () => {
 			fs.utimesSync(test_cert_path, originalMtime, originalMtime);
 			await certTable.put(originalRecord);


### PR DESCRIPTION
## Summary
The TLS certificate reload guard in `loadCertificates()` (`security/keys.ts`) wrote the cert file's mtime to the `hdb_certificate` record as camelCase `fileTimestamp`, but the staleness comparison read it back as snake_case `file_timestamp`. Since `file_timestamp` was never persisted, `recordTimestamp` always fell back to `__updatedtime__`, so the "is the file on disk newer than the stored record?" check never used the real file timestamp.

This aligns the **write**, the **read**, and the **table schema** on snake_case `file_timestamp` (consistent with the table's other attributes: `is_self_signed`, `is_authority`, `private_key_name`).

## Why
Latent correctness bug in the cert reload / watch path (#586 area). With the guard degraded to `__updatedtime__`, freshness decisions for renewed certs on disk (e.g. Certbot rotations) could be made on the wrong basis. Fix is intentionally minimal.

## Changes
- `security/keys.ts`: write `file_timestamp: fileTimestamp` (was `fileTimestamp`); add `file_timestamp` to the `hdb_certificate` attribute list in `getCertTable()`.
- `unitTests/security/keys.test.js`: new `certificate file_timestamp staleness guard` suite covering file-newer-than-record (reload) and file-older-than-record (skip) branches, plus a check that `file_timestamp` is actually persisted. The skip-branch test sets the file mtime newer than "now" but older than the stored record so it specifically distinguishes reading `file_timestamp` from falling back to `__updatedtime__`.

## Where to look
- The read at `security/keys.ts` (`recordTimestamp = ... certRecord.file_timestamp ?? certRecord.__updatedtime__`) was already snake_case and is unchanged; only the write and schema were brought into agreement, so no consumer of the old (never-written) field exists.
- Tests restore the cert file mtime and the original DB record in an `after` hook to avoid suite pollution.

Cross-model review: Codex (no blocking issues) and Gemini (correctness pass; flagged test isolation, addressed via the `after` cleanup hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: Claude Opus 4.8)