### PR TITLE
fix(deploy): stream deploy payloads into payload_blob instead of buffering (lift 200 MB cap)

### DIFF
--- a/.github/workflows/large-deploy-test.yml
+++ b/.github/workflows/large-deploy-test.yml
@@ -1,0 +1,64 @@
+name: Large Deploy Payload Test (self-hosted)
+
+# Streams a multi-GB component through deploy_component on a self-hosted runner to prove the
+# payload path stays memory-bounded (regression guard for the 5.1.0 200 MB ingestPayload cap
+# / 2 GB Buffer ceiling). Far too heavy for the normal sharded matrix — the default 2200 MB
+# of incompressible data also exceeds Node's ~2 GB single-Buffer limit, so a buffered
+# implementation fails outright. See integrationTests/deploy/deploy-large-payload.test.ts.
+#
+# schedule + manual dispatch ONLY (never pull_request): the job runs on a self-hosted host,
+# so untrusted PR code must never execute here. Reuses the `harper-bench` host (one job at a
+# time across harper / harper-pro via the repo-scoped JIT supervisor); if it stays queued the
+# supervisor is down or can't reach this repo.
+
+on:
+  schedule:
+    - cron: '30 9 * * 1' # weekly, Monday — offset from the nightly perf/ycsb jobs
+  workflow_dispatch:
+    inputs:
+      size-mb:
+        description: 'Payload size in MB (incompressible). Default clears the old 200 MB cap and the ~2 GB Buffer ceiling.'
+        required: true
+        type: string
+        default: '2200'
+
+jobs:
+  large-deploy-test:
+    name: Large streamed deploy (Node.js v24)
+    runs-on: [self-hosted, linux, harper-bench]
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm install # plain install (builds native deps) — matches the other self-hosted jobs
+
+      - name: Build
+        run: npm run build || true # repo currently has type errors; ignore per integration-tests.yml
+
+      - name: Verify build output
+        run: test -f dist/bin/harper.js || { echo "dist/bin/harper.js missing — build failed"; exit 1; }
+
+      - name: Run large streamed deploy test
+        env:
+          HARPER_TEST_LARGE_DEPLOY_MB: ${{ github.event.inputs.size-mb || '2200' }}
+          HARPER_INTEGRATION_TEST_LOG_DIR: /tmp/harper-large-deploy-logs
+          HARPER_INTEGRATION_TEST_INSTALL_SCRIPT: dist/bin/harper.js
+        run: npm run test:integration -- "integrationTests/deploy/deploy-large-payload.test.ts"
+
+      - name: Upload Harper server logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: harper-large-deploy-logs
+          path: /tmp/harper-large-deploy-logs/
+          retention-days: 3
+          if-no-files-found: ignore

--- a/components/deploymentRecorder.ts
+++ b/components/deploymentRecorder.ts
@@ -13,9 +13,10 @@ import { randomUUID } from 'node:crypto';
 import { createHash } from 'node:crypto';
 import { Readable, Transform, pipeline } from 'node:stream';
 import { databases } from '../resources/databases.ts';
-import { createBlob, isSaving } from '../resources/blob.ts';
+import { createBlob, isSaving, deleteBlob } from '../resources/blob.ts';
 import * as terms from '../utility/hdbTerms.ts';
 import { ClientError } from '../utility/errors/hdbError.ts';
+import { logger } from '../utility/logging/logger.ts';
 import { hostname } from 'node:os';
 import { ProgressEmitter } from '../server/serverHelpers/progressEmitter.ts';
 
@@ -239,9 +240,12 @@ export class DeploymentRecorder {
 		let byteCount = 0;
 		const tap = new Transform({
 			transform(chunk, _encoding, callback) {
-				hash.update(chunk as Buffer);
-				byteCount += (chunk as Buffer).length;
-				callback(null, chunk);
+				// Normalize to a Buffer: a string chunk would otherwise hash as utf8 and count
+				// characters, not bytes — corrupting both payload_hash and payload_size.
+				const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as any);
+				hash.update(buf);
+				byteCount += buf.length;
+				callback(null, buf);
 			},
 		});
 		// `tapDone` resolves once every source byte has passed through the tap (so the hash
@@ -261,7 +265,29 @@ export class DeploymentRecorder {
 		// correctness independent of the put()/store write timing and of isSaving() being defined.
 		const putDone = this.put();
 		const saving = isSaving(blob) ?? Promise.resolve();
-		await Promise.all([putDone, tapDone, saving]);
+		try {
+			await Promise.all([putDone, tapDone, saving]);
+		} catch (error) {
+			// Aborted/failed upload (e.g. the client disconnects mid-stream). The first put()
+			// already persisted the row's reference to a now-partial blob; since cleanupOrphans
+			// only reclaims UNreferenced blobs, leaving it would leak the file permanently. Drop
+			// the reference and delete the partial file. Cleanup is best-effort — never let it
+			// mask the original failure.
+			this.record.payload_blob = null;
+			this.record.payload_hash = null;
+			this.record.payload_size = null;
+			try {
+				// Let the first put and the blob write fully settle before re-putting: this
+				// ensures the null-reference write lands after the original reference write
+				// (so it wins) and the blob's file lock is released before we unlink it.
+				await Promise.allSettled([putDone, saving]);
+				await this.put();
+				deleteBlob(blob);
+			} catch (cleanupError) {
+				logger.warn?.('Failed to clean up partial deploy payload blob', cleanupError);
+			}
+			throw error;
+		}
 		// Bytes are fully hashed (tapDone) and the file is flushed with its size header
 		// back-patched (saving), so the digest and blob.size below are final.
 		this.record.payload_hash = hash.digest('hex');

--- a/components/deploymentRecorder.ts
+++ b/components/deploymentRecorder.ts
@@ -10,10 +10,10 @@
 // as the rollback source when that operation lands.
 
 import { randomUUID } from 'node:crypto';
-import { createHash, Hash } from 'node:crypto';
-import type { Readable } from 'node:stream';
+import { createHash } from 'node:crypto';
+import { Readable, Transform, pipeline } from 'node:stream';
 import { databases } from '../resources/databases.ts';
-import { createBlob } from '../resources/blob.ts';
+import { createBlob, isSaving } from '../resources/blob.ts';
 import * as terms from '../utility/hdbTerms.ts';
 import { ClientError } from '../utility/errors/hdbError.ts';
 import { hostname } from 'node:os';
@@ -37,11 +37,11 @@ export function getActiveEmitter(deploymentId: string): ProgressEmitter | undefi
 	return activeEmitters.get(deploymentId);
 }
 
-// Interim cap: ingestPayload currently buffers the entire payload in memory before
-// computing the hash and persisting. This cap prevents an OOM on accidentally-huge
-// uploads. A follow-up will swap this for a true streaming-hash + blob-source pattern
-// that lifts the limit back to whatever the replication path supports.
-const PAYLOAD_BUFFER_CAP_BYTES = 200 * 1024 * 1024;
+// Cap for the degraded fallback used only when the hdb_deployment table is missing (so the
+// payload can't stream into a row-backed blob and must be buffered in memory). The normal
+// streaming path is uncapped — this bound exists solely to keep a pending-upgrade window from
+// OOMing the node on a large deploy. 1 GiB comfortably covers real components.
+const UNTRACKED_PAYLOAD_BUFFER_CAP_BYTES = 1024 * 1024 * 1024;
 
 type DeploymentStatus =
 	| 'pending'
@@ -66,8 +66,6 @@ interface CreateOptions {
 export class DeploymentRecorder {
 	readonly deploymentId: string;
 	private readonly record: Record<string, any>;
-	private hash: Hash | null = null;
-	private byteCount = 0;
 	private finished = false;
 	private unsubscribe: (() => void) | null = null;
 	private pendingPut: Promise<void> | null = null;
@@ -172,57 +170,104 @@ export class DeploymentRecorder {
 	}
 
 	/**
-	 * Drain a payload source (Buffer or Readable) into the row's payload_blob attribute,
-	 * computing sha256 and byte count alongside. After this resolves the row has been
-	 * committed once with the final hash and size, and `this.row.payload_blob.stream()`
-	 * yields a fresh Readable that callers can pass to extraction.
+	 * Drain a payload source (Buffer, base64 string, or Readable) into the row's
+	 * payload_blob attribute, computing sha256 and byte count alongside. After this
+	 * resolves the row has been committed with the final hash and size, and
+	 * `this.row.payload_blob.stream()` yields a fresh Readable callers pass to extraction.
 	 *
-	 * Buffers the payload in memory (subject to PAYLOAD_BUFFER_CAP_BYTES) so the
-	 * hash/size are known synchronously before we commit and so the blob's `saveBlob`
-	 * lifecycle doesn't race with our digest() call. A streaming variant is a planned
-	 * follow-up that uses the unused `hash`/`byteCount` instance fields below.
+	 * The Readable path (the multipart file part) is fully streaming: the tarball is teed
+	 * through a hash/size tap straight into the blob's file-backed storage, so a multi-GB
+	 * component is bounded by disk, not memory. No payload size cap is imposed — the
+	 * deployment system is explicitly designed to carry arbitrarily large components.
+	 * In-memory sources (a Buffer, or the legacy base64-in-JSON/CBOR body) are already
+	 * materialized by the time they reach us, so they take the simpler buffer path.
 	 */
 	async ingestPayload(source: Readable | Buffer | string): Promise<void> {
 		const hash = createHash('sha256');
-		let byteCount = 0;
-		let buffer: Buffer;
-		if (Buffer.isBuffer(source)) {
-			buffer = source;
-		} else if (typeof source === 'string') {
-			// Legacy CBOR/JSON path: payload arrives as a base64-encoded string.
-			buffer = Buffer.from(source, 'base64');
-		} else {
+
+		// In-memory sources: the bytes are already resident, so hashing them and creating a
+		// buffer-backed blob is both simplest and no worse for memory than what the caller
+		// already holds. No cap — a large base64-in-JSON body is the caller's choice.
+		if (Buffer.isBuffer(source) || typeof source === 'string') {
+			const buffer = Buffer.isBuffer(source) ? source : Buffer.from(source, 'base64');
+			hash.update(buffer);
+			this.record.payload_blob = createBlob(buffer, { type: 'application/gzip' });
+			this.record.payload_hash = hash.digest('hex');
+			this.record.payload_size = buffer.length;
+			await this.put();
+			return;
+		}
+
+		// Streaming source. If the hdb_deployment table is missing (upgrade directive hasn't
+		// run, or it was dropped) there is no row to attach the blob to, and a file-backed
+		// blob would never be persisted for extraction to re-read. Fall back to buffering in
+		// that degraded case so the deploy still works. Unlike the streaming path below, this
+		// buffer is held in memory, so it carries a cap: without it a multi-GB deploy during the
+		// upgrade window would OOM the node (or throw on Node's ~2 GB Buffer limit). We fail fast
+		// with a clear error instead. The cap applies ONLY to this degraded path — once the
+		// table exists, deploys stream to disk with no size limit.
+		const tableMissing = !(databases as any).system?.[terms.SYSTEM_TABLE_NAMES.DEPLOYMENT_TABLE_NAME];
+		if (tableMissing) {
 			const chunks: Buffer[] = [];
 			let collected = 0;
 			for await (const chunk of source as AsyncIterable<Buffer | string>) {
 				const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as any);
 				collected += buf.length;
-				if (collected > PAYLOAD_BUFFER_CAP_BYTES) {
+				if (collected > UNTRACKED_PAYLOAD_BUFFER_CAP_BYTES) {
 					(source as Readable).destroy?.();
 					throw new ClientError(
-						`Deploy payload exceeds the ${PAYLOAD_BUFFER_CAP_BYTES} byte buffer cap. ` +
-							`Use a package identifier (npm:/file:/git:) for larger components.`
+						`Deploy payload exceeds the ${UNTRACKED_PAYLOAD_BUFFER_CAP_BYTES}-byte limit that applies while ` +
+							`deployment tracking is unavailable (the system.${terms.SYSTEM_TABLE_NAMES.DEPLOYMENT_TABLE_NAME} ` +
+							`table is missing — likely a pending upgrade). Retry once the upgrade completes, or use a ` +
+							`package identifier (npm:/file:/git:) for larger components.`
 					);
 				}
 				chunks.push(buf);
 			}
-			buffer = Buffer.concat(chunks);
+			const buffer = Buffer.concat(chunks);
+			hash.update(buffer);
+			this.record.payload_blob = createBlob(buffer, { type: 'application/gzip' });
+			this.record.payload_hash = hash.digest('hex');
+			this.record.payload_size = buffer.length;
+			await this.put();
+			return;
 		}
-		if (buffer.length > PAYLOAD_BUFFER_CAP_BYTES) {
-			throw new ClientError(
-				`Deploy payload (${buffer.length} bytes) exceeds the ${PAYLOAD_BUFFER_CAP_BYTES} byte buffer cap. ` +
-					`Use a package identifier (npm:/file:/git:) for larger components.`
-			);
-		}
-		hash.update(buffer);
-		byteCount = buffer.length;
-		this.record.payload_blob = createBlob(buffer, { type: 'application/gzip' });
+
+		// Tee the source through a hash/size tap into a file-backed blob. The blob's
+		// saveBlob (driven by the put() below, via encodeBlobsWithFilePath) reads from the
+		// tap's output side; we pump the source into its input side. Memory stays O(chunk).
+		let byteCount = 0;
+		const tap = new Transform({
+			transform(chunk, _encoding, callback) {
+				hash.update(chunk as Buffer);
+				byteCount += (chunk as Buffer).length;
+				callback(null, chunk);
+			},
+		});
+		// `tapDone` resolves once every source byte has passed through the tap (so the hash
+		// and byteCount are final) and rejects if the source or the downstream blob write
+		// errors — a destroyed tap fails the pipeline.
+		const tapDone = new Promise<void>((resolve, reject) => {
+			pipeline(source, tap, (error) => (error ? reject(error) : resolve()));
+		});
+		const blob = createBlob(tap, { type: 'application/gzip' });
+		this.record.payload_blob = blob;
+		// Persisting the row encodes the blob, which synchronously starts the file write that
+		// drains the tap, so `isSaving(blob)` is set as soon as put() is *called*. Await the put,
+		// the source draining (tapDone), and the file flush (saving) together: handing all three
+		// to Promise.all subscribes a rejection handler to each up front, so a client that aborts
+		// a large upload mid-stream (which rejects both tapDone and the blob write) fails the
+		// deploy loudly here instead of leaking an unhandledRejection. This also makes hash/size
+		// correctness independent of the put()/store write timing and of isSaving() being defined.
+		const putDone = this.put();
+		const saving = isSaving(blob) ?? Promise.resolve();
+		await Promise.all([putDone, tapDone, saving]);
+		// Bytes are fully hashed (tapDone) and the file is flushed with its size header
+		// back-patched (saving), so the digest and blob.size below are final.
 		this.record.payload_hash = hash.digest('hex');
-		this.record.payload_size = byteCount;
-		// Touch the unused private fields so the type system stays happy when a streaming
-		// variant lands that uses them.
-		this.hash = hash;
-		this.byteCount = byteCount;
+		this.record.payload_size = blob.size ?? byteCount;
+		// Persist the now-known hash + size. The blob is already saved, so this re-put does
+		// not re-stream — saveBlob short-circuits on the existing fileId.
 		await this.put();
 	}
 

--- a/integrationTests/deploy/deploy-large-payload.test.ts
+++ b/integrationTests/deploy/deploy-large-payload.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Large-payload streaming deploy_component regression test.
+ *
+ * Guards against the regression where `ingestPayload` buffered the whole deploy payload
+ * in memory and rejected anything over a 200 MB cap (introduced in 5.1.0-beta.1, fixed by
+ * making ingestPayload stream the tarball straight into the file-backed payload_blob).
+ *
+ * The default size (2200 MB of incompressible data) is chosen to clear BOTH ceilings at
+ * once: the old 200 MB cap AND Node's ~2 GB single-Buffer limit (0x7fffffff bytes). A
+ * buffered implementation fails this test two different ways — a 400 from the cap, or a
+ * `Buffer.concat` "Cannot create a Buffer larger than 0x7fffffff bytes" 500. A streaming
+ * implementation extracts the component intact with memory bounded by chunk size.
+ *
+ * Gated behind HARPER_TEST_LARGE_DEPLOY_MB because pushing multi-GB through a deploy is
+ * far too heavy for the normal sharded matrix — it runs only on the dedicated self-hosted
+ * job (see .github/workflows/large-deploy-test.yml) or when a developer sets the env var
+ * locally. Without the env var the suite registers a single skipped test and returns fast.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert/strict';
+import { join } from 'node:path';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, statSync, createWriteStream } from 'node:fs';
+import { once } from 'node:events';
+import { randomFillSync } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { request } from 'node:http';
+import { Readable } from 'node:stream';
+
+import { startHarper, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+
+// Reach into built dist directly — the integrationTests/ package has no `#src/*` import map.
+import { streamPackagedDirectory } from '../../dist/components/packageComponent.js';
+import { buildMultipartBody } from '../../dist/bin/multipartBuilder.js';
+
+const LARGE_MB = Number(process.env.HARPER_TEST_LARGE_DEPLOY_MB ?? 0);
+const LARGE_BYTES = LARGE_MB * 1024 * 1024;
+
+/**
+ * Post a multipart deploy_component request, piping the body stream into node:http so the
+ * bytes flow with Transfer-Encoding: chunked (undici would materialize a Readable body into
+ * a Buffer, defeating the test). Mirrors deploy-multipart-stream.test.ts.
+ */
+function postMultipart(
+	url: URL,
+	contentType: string,
+	body: Readable,
+	auth: { username: string; password: string }
+): Promise<{ status: number; body: string }> {
+	return new Promise((resolve, reject) => {
+		const req = request(
+			{
+				protocol: url.protocol,
+				hostname: url.hostname,
+				port: url.port,
+				method: 'POST',
+				path: '/',
+				headers: {
+					'Content-Type': contentType,
+					'Transfer-Encoding': 'chunked',
+					'Authorization': 'Basic ' + Buffer.from(`${auth.username}:${auth.password}`).toString('base64'),
+				},
+			},
+			(res) => {
+				res.setEncoding('utf8');
+				let buf = '';
+				res.on('data', (chunk) => (buf += chunk));
+				res.on('end', () => resolve({ status: res.statusCode ?? 0, body: buf }));
+			}
+		);
+		req.on('error', reject);
+		body.on('error', reject);
+		body.pipe(req);
+	});
+}
+
+/**
+ * Write `bytes` of incompressible pseudo-random data to `path` in bounded-memory chunks, so
+ * generating a multi-GB fixture never itself allocates a multi-GB Buffer. Incompressible is
+ * essential: the bytes that flow through ingestPayload are the *gzipped* tarball, so a
+ * compressible fixture would shrink to nothing and never exercise the large-stream path.
+ */
+async function writeIncompressibleFile(path: string, bytes: number): Promise<void> {
+	const CHUNK = 8 * 1024 * 1024; // 8 MB
+	const scratch = Buffer.allocUnsafe(CHUNK);
+	const stream = createWriteStream(path);
+	let remaining = bytes;
+	while (remaining > 0) {
+		const n = Math.min(CHUNK, remaining);
+		randomFillSync(scratch, 0, n);
+		if (!stream.write(n === CHUNK ? scratch : scratch.subarray(0, n))) {
+			await once(stream, 'drain');
+		}
+		remaining -= n;
+	}
+	stream.end();
+	await once(stream, 'finish');
+}
+
+suite('Large-payload streaming deploy_component', (ctx: ContextWithHarper) => {
+	if (!LARGE_MB) {
+		test(
+			'skipped (set HARPER_TEST_LARGE_DEPLOY_MB to enable multi-GB deploy regression test)',
+			{ skip: true },
+			() => {}
+		);
+		return;
+	}
+
+	let fixtureDir: string;
+
+	before(async () => {
+		await startHarper(ctx);
+		fixtureDir = mkdtempSync(join(tmpdir(), 'large-deploy-fixture-'));
+		writeFileSync(join(fixtureDir, 'config.yaml'), 'static:\n  files: web\nrest: true\n');
+		mkdirSync(join(fixtureDir, 'web'), { recursive: true });
+		writeFileSync(join(fixtureDir, 'web', 'index.html'), '<h1>Hello, Large!</h1>');
+		await writeIncompressibleFile(join(fixtureDir, 'web', 'large.bin'), LARGE_BYTES);
+	});
+
+	after(async () => {
+		try {
+			rmSync(fixtureDir, { recursive: true, force: true });
+		} catch {
+			// best-effort cleanup
+		}
+		await teardownHarper(ctx);
+	});
+
+	test('verify Harper', async () => {
+		const response = await fetch(`${ctx.harper.operationsAPIURL}/health`);
+		strictEqual(response.status, 200);
+		strictEqual(await response.text(), 'Harper is running.');
+	});
+
+	test(
+		`deploys a ${LARGE_MB} MB streamed payload without buffering it whole`,
+		{ timeout: 30 * 60 * 1000 },
+		async () => {
+			const project = 'large-payload-application';
+			const multipart = buildMultipartBody(
+				{ operation: 'deploy_component', project, restart: true },
+				{
+					name: 'payload',
+					filename: 'package.tar.gz',
+					contentType: 'application/gzip',
+					stream: streamPackagedDirectory(fixtureDir, { skip_node_modules: true }),
+				}
+			);
+			const url = new URL(ctx.harper.operationsAPIURL);
+			const response = await postMultipart(url, multipart.contentType, multipart.stream, ctx.harper.admin);
+			strictEqual(response.status, 200, `expected 200, got ${response.status}: ${response.body}`);
+			const result = JSON.parse(response.body);
+			strictEqual(result.message, `Successfully deployed: ${project}, restarting Harper`);
+
+			// Wait for the restart + extraction of a multi-GB component to settle.
+			await sleep(15000);
+			const extracted = join(ctx.harper.dataRootDir, 'components', project, 'web', 'large.bin');
+			ok(existsSync(extracted), 'large file part should have been extracted');
+			strictEqual(
+				statSync(extracted).size,
+				LARGE_BYTES,
+				'extracted large file should be byte-for-byte the same size as the source'
+			);
+		}
+	);
+});


### PR DESCRIPTION
## Summary

`DeploymentRecorder.ingestPayload` buffered the **entire** deploy tarball in memory and threw a `ClientError` past a 200 MB cap. This rewrites the `Readable` (multipart) path to stream the tarball through a hash/size `Transform` tap straight into the file-backed `payload_blob` (`createBlob(tap)`), so memory stays O(chunk) and payload size is bounded by disk, not memory. The cap is gone for the normal path.

- In-memory `Buffer`/base64 sources keep the simple buffer path (also uncapped — the bytes are already resident).
- The degraded **table-missing** fallback (no `hdb_deployment` row to attach a blob to → must buffer) keeps a **1 GiB cap** purely to avoid OOMing the node during an upgrade window.
- Adds a gated multi-GB regression test (`HARPER_TEST_LARGE_DEPLOY_MB`) + a self-hosted weekly CI job to run it (too heavy for the normal sharded matrix; the default 2200 MB also clears Node's ~2 GB single-`Buffer` ceiling).

## Purpose

The deployment system is meant to carry multi-GB components (1 GB app deploys worked before). The 200 MB cap is a **regression introduced in 5.1.0-beta.1** by the deployment-tracking feature (commit `64d4ec48c`): tracking inserted `ingestPayload` between the multipart transport (which already streams to exceed the 2 GB `Buffer` ceiling) and extraction, but implemented it as buffer-everything with a cap as crude OOM protection. The streaming rewrite was deferred at the time; this is that follow-up.

## Where to put attention

- **`components/deploymentRecorder.ts` — `ingestPayload` streaming branch.** The blob's file write is driven by `this.put()` (→ `table.put` → `encodeBlobsWithFilePath` → `saveBlob`); the code awaits the source-drain (`tapDone`), the blob flush (`isSaving`), and the put together via `Promise.all` before reading `sha256`/`blob.size`, then a second `put()` persists hash+size. Worth confirming the two-put ordering and the `Promise.all` rejection handling read correctly to you.
- **Deliberate tradeoff — the 1 GiB fallback cap.** Only the *degraded* table-missing path is capped (an in-memory buffer that would otherwise OOM the node). The normal streaming path has no limit. Flagging in case you'd prefer a different bound or want the fallback to spool to disk instead (deferred as more invasive).
- **Pre-existing, not changed here:** `payload_hash` is computed and stored but no consumer verifies it (peers re-read the blob via the file header, not the hash) — it's observability/audit-only, same as before this change. Noting in case wiring up peer-side verification is wanted as a follow-up.

## Review / testing

Cross-model review run (Codex + a 3-domain Harper pass: data-integrity / replication / concurrency). Findings it surfaced — an unhandled-rejection on mid-upload abort and `isSaving`/store-timing correctness — are **resolved in the diff**. Gemini leg was unavailable this run (tooling). Locally green: `deploy-multipart-stream`, `deploy-tracking`, `deploy-from-source`, `deploy-tracking-peer-branch`, and the new large-payload test at 256 MB; full suite relies on CI.

---
🤖 Generated by Claude (Opus 4.8, 1M context). Review accordingly.