### PR TITLE
fix(blob): validate reads/replication against descriptor size and bound read waits (#1424, #1423)

### DIFF
--- a/config-root.schema.json
+++ b/config-root.schema.json
@@ -475,6 +475,10 @@
 					"oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }],
 					"description": "Path or array of paths for blob storage. Default: <rootPath>/blobs"
 				},
+				"blobReadTimeout": {
+					"type": "number",
+					"description": "Max time (ms) a blob read will wait for an in-progress write to finish before failing with a 503, rather than holding the connection. Default: 20000"
+				},
 				"pageSize": { "type": "number", "description": "Database page size (bytes). Default: OS default" },
 				"reclamation": {
 					"type": "object",

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -102,10 +102,17 @@ const BLOB_UNAVAILABLE_STATUS = 503;
 const BLOB_CORRUPT_STATUS = 500;
 class BlobReadError extends Error {
 	statusCode: number;
+	code?: string;
 	constructor(message: string, statusCode: number) {
 		super(message);
 		this.name = 'BlobReadError';
 		this.statusCode = statusCode;
+		// A cleanly-gone blob (404) is an ENOENT at heart. Carry the fs-style `.code` so a consumer that
+		// only understands `error.code` — notably an OLDER replication receiver whose
+		// `isPermanentSourceBlobErrorCode` predates the statusCode taxonomy — still classifies a missing
+		// source blob as a PERMANENT absence and advances its resume cursor past it, rather than wedging
+		// (harper-pro#403/#405). Newer receivers key on `statusCode`; this keeps mixed-version clusters safe.
+		if (statusCode === BLOB_GONE_STATUS) this.code = 'ENOENT';
 	}
 }
 // We want FileBackedBlob instances to be an instanceof Blob, but we don't want to actually extend the class and call Blob's constructor, which is quite expensive because it has to set it up as a transferrable.

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -78,7 +78,31 @@ let promisedWrites: Array<Promise<void>>;
 let currentStore: any; // the root store of the database we are currently encoding for
 export let blobsWereEncoded = false; // keep track of whether blobs were encoded with file paths
 // the header is 8 bytes
-const FILE_READ_TIMEOUT = 60000;
+const DEFAULT_BLOB_READ_TIMEOUT = 20000;
+/**
+ * How long a blob read will wait for an in-progress write to finish before giving up. This bounds
+ * the read paths — the stream() open-retry loop and the incomplete-content waits — so a blob whose
+ * backing file is being written, truncated, or deleted returns a prompt, actionable error instead
+ * of holding the HTTP connection open until a long internal timeout fires (#1423). Configurable via
+ * storage_blobReadTimeout; defaults to 20s.
+ */
+function getBlobReadTimeout(): number {
+	return envGet(CONFIG_PARAMS.STORAGE_BLOBREADTIMEOUT) ?? DEFAULT_BLOB_READ_TIMEOUT;
+}
+// HTTP statuses attached to blob read errors so a failed read surfaces a clean response rather than a
+// hung connection: 404 when the file is cleanly gone, 503 while a write is still in progress (the
+// client can retry), 500 when the content is confidently corrupt/incomplete.
+const BLOB_GONE_STATUS = 404;
+const BLOB_UNAVAILABLE_STATUS = 503;
+const BLOB_CORRUPT_STATUS = 500;
+class BlobReadError extends Error {
+	statusCode: number;
+	constructor(message: string, statusCode: number) {
+		super(message);
+		this.name = 'BlobReadError';
+		this.statusCode = statusCode;
+	}
+}
 // We want FileBackedBlob instances to be an instanceof Blob, but we don't want to actually extend the class and call Blob's constructor, which is quite expensive because it has to set it up as a transferrable.
 function InstanceOfBlobWithNoConstructor() {}
 InstanceOfBlobWithNoConstructor.prototype = Blob.prototype;
@@ -155,21 +179,37 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 			return Promise.resolve(contentBuffer);
 		}
 		const filePath = getFilePath(storageInfo);
+		// The size recorded in the record descriptor is the authoritative (uncompressed) content length;
+		// the on-disk header records the same value. We cross-validate them on full reads so a truncated
+		// file with a self-consistent-but-wrong header (#1424) is not served as valid. A slice carries a
+		// reduced descriptor size, so only a full read can be compared against the header.
+		const descriptorSize = this.size;
+		const isFullRead = start === undefined && end === undefined;
 		let writeFinished: boolean;
+		let fileMissing = false;
 		const readContents = async () => {
 			let rawBytes: Buffer;
 			let size = HEADER_SIZE;
+			fileMissing = false; // reflects this attempt; a retry after the writer finishes may find the file
 			try {
 				rawBytes = await readFile(filePath);
 				if (rawBytes.length >= HEADER_SIZE) {
 					const headerValue = new DataView(rawBytes.buffer, rawBytes.byteOffset, 8).getBigUint64(0);
 					if (Number(headerValue >> 48n) === ERROR_TYPE) {
-						throw new Error('Error in blob: ' + rawBytes.subarray(HEADER_SIZE));
+						throw new BlobReadError('Error in blob: ' + rawBytes.subarray(HEADER_SIZE), BLOB_CORRUPT_STATUS);
 					}
 
 					size = Number(headerValue & 0xffffffffffffn);
 					if (size < end) size = end;
 					if (size < UNKNOWN_SIZE) {
+						if (isFullRead && descriptorSize != null && descriptorSize < UNKNOWN_SIZE && size !== descriptorSize) {
+							// the header claims a different (uncompressed) size than the record descriptor: the file
+							// has been truncated/corrupted even though its header is internally consistent (#1424).
+							throw new BlobReadError(
+								`Blob size mismatch for ${filePath}: record descriptor expects ${descriptorSize} bytes, on-disk header reports ${size}`,
+								BLOB_CORRUPT_STATUS
+							);
+						}
 						this.size = size;
 						if (this.#onSize) {
 							for (const callback of this.#onSize) callback(size);
@@ -179,6 +219,7 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 			} catch (error) {
 				if (error.code !== 'ENOENT') throw error;
 				rawBytes = Buffer.alloc(0);
+				fileMissing = true;
 			}
 			function checkCompletion(rawBytes: Buffer): Buffer | Promise<Buffer> {
 				if (size > rawBytes.length) {
@@ -186,18 +227,41 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 					const store = storageInfo.store;
 					const lockKey = storageInfo.fileId + ':blob';
 					if (writeFinished) {
-						throw new Error(`Incomplete blob for ${filePath}`);
+						// the writer released its lock but the content is still short: the file is cleanly gone
+						// (404) or confidently incomplete/corrupt (500) — not merely mid-write (#1423/#1424).
+						throw fileMissing
+							? new BlobReadError(`Blob file not found for ${filePath}`, BLOB_GONE_STATUS)
+							: new BlobReadError(`Incomplete blob for ${filePath}`, BLOB_CORRUPT_STATUS);
 					}
-					return new Promise((resolve) => {
+					return new Promise((resolve, reject) => {
+						let settled = false;
+						// Bound the wait for the writer so a stuck or abandoned write (e.g. the file was deleted
+						// mid-write) returns a prompt 503 instead of hanging the connection (#1423).
+						const timer = setTimeout(() => {
+							if (settled) return;
+							settled = true;
+							reject(
+								new BlobReadError(
+									`Blob ${storageInfo.fileId} is unavailable; the in-progress write did not complete in time`,
+									BLOB_UNAVAILABLE_STATUS
+								)
+							);
+						}, getBlobReadTimeout());
+						timer.unref();
 						const callback = () => {
+							if (settled) return;
+							settled = true;
+							clearTimeout(timer);
 							writeFinished = true;
-							return resolve(readContents());
+							resolve(readContents());
 						};
 						const lockAcquired = store.tryLock(lockKey, callback);
 						if (lockAcquired) {
+							settled = true;
+							clearTimeout(timer);
 							writeFinished = true;
 							store.unlock(lockKey);
-							return resolve(readContents());
+							resolve(readContents());
 						}
 					});
 				}
@@ -206,7 +270,10 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 				}
 				return rawBytes;
 			}
-			if (rawBytes[1] === DEFLATE_TYPE) {
+			// Only sniff the storage-type byte and take the decompress branch when a full header is present.
+			// A file shorter than the header (truncated/corrupted, #1424) would otherwise be mis-read as a
+			// deflate body and yield garbage; instead it falls through to checkCompletion as incomplete.
+			if (rawBytes.length >= HEADER_SIZE && rawBytes[1] === DEFLATE_TYPE) {
 				return new Promise<Buffer>((resolve, reject) => {
 					deflate(rawBytes.subarray(HEADER_SIZE), (error, result) => {
 						if (error) reject(error);
@@ -251,24 +318,47 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 		let isBeingWritten: boolean;
 		let previouslyFinishedWriting = false;
 		const blob = this;
+		// Authoritative (uncompressed) content length from the record descriptor, captured before the
+		// header read below overwrites blob.size, so a full read can detect a truncated file whose header
+		// was rewritten to a self-consistent smaller size (#1424). A slice carries a reduced size, so only
+		// full reads can be compared against the header.
+		const descriptorSize = this.size;
+		const isFullRead = start === undefined && end === undefined;
 
 		return new ReadableStream({
 			start() {
-				let retries = 1000;
+				// Bound the wait for the file to appear so a write that was abandoned (e.g. the file was
+				// deleted mid-write while the writer kept the lock) returns a prompt error rather than
+				// holding the connection for the full retry budget (#1423). The deadline (and its config
+				// lookup) is computed lazily on the first miss, so a healthy read never pays for it.
+				let deadline = 0;
 				const openFile = (resolve: (value: any) => void, reject: (error: Error) => void) => {
 					open(filePath, 'r', (error, openedFd) => {
 						if (error) {
 							if (error.code === 'ENOENT' && isBeingWritten !== false) {
-								logger.debug?.('File does not exist yet, waiting for it to be created', filePath, retries);
-								// the file doesn't exist, so we need to wait for it to be created
-								if (retries-- > 0)
+								if (deadline === 0) deadline = Date.now() + getBlobReadTimeout();
+								if (Date.now() < deadline) {
+									logger.debug?.('File does not exist yet, waiting for it to be created', filePath);
+									// the file doesn't exist, so we need to wait for it to be created
 									return setTimeout(() => {
 										checkIfIsBeingWritten();
 										openFile(resolve, reject);
 									}, 20).unref();
+								}
 							}
-							reject(error);
-							blob.#onError?.forEach((callback) => callback(error));
+							// ENOENT: the file is gone. A writer still holding the lock means we timed out waiting
+							// for an in-progress write (503, retryable); otherwise it is cleanly absent (404).
+							const readError =
+								error.code === 'ENOENT'
+									? isBeingWritten
+										? new BlobReadError(
+												`Blob ${storageInfo.fileId} is unavailable; its file did not appear in time`,
+												BLOB_UNAVAILABLE_STATUS
+											)
+										: new BlobReadError(`Blob file not found for ${filePath}`, BLOB_GONE_STATUS)
+									: error;
+							reject(readError);
+							blob.#onError?.forEach((callback) => callback(readError));
 						} else {
 							fd = openedFd;
 							resolve(openedFd);
@@ -298,27 +388,49 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 							// for the first read, we need to read the header and skip it for the data
 							// but first check to see if we read anything
 							if (bytesRead < HEADER_SIZE) {
-								// didn't read any bytes, have to try again
+								// the file is too small to even hold the 8-byte header: either still being created,
+								// or truncated/corrupted below the header (#1424). Retry while a write may be in
+								// flight, otherwise fail promptly rather than mis-reading it as content.
 								if (retries-- > 0 && isBeingWritten !== false) {
 									checkIfIsBeingWritten();
 									logger.debug?.('File was empty, waiting for data to be written', filePath, retries);
 									setTimeout(() => readMore(resolve, reject), 20).unref();
 								} else {
 									logger.debug?.('File was empty, throwing error', filePath, retries);
-									onError(new Error(`Blob ${storageInfo.fileId} was empty`));
+									onError(
+										new BlobReadError(
+											`Blob ${storageInfo.fileId} was empty`,
+											isBeingWritten ? BLOB_UNAVAILABLE_STATUS : BLOB_CORRUPT_STATUS
+										)
+									);
 								}
 								// else throw new Error();
 								return;
 							}
 							const headerValue = new DataView(buffer.buffer, buffer.byteOffset, 8).getBigUint64(0);
 							if (Number(headerValue >> 48n) === ERROR_TYPE) {
-								return onError(new Error('Error in blob: ' + buffer.subarray(HEADER_SIZE, bytesRead)));
+								return onError(
+									new BlobReadError('Error in blob: ' + buffer.subarray(HEADER_SIZE, bytesRead), BLOB_CORRUPT_STATUS)
+								);
 							}
 							size = Number(headerValue & 0xffffffffffffn);
-							if (size < UNKNOWN_SIZE && blob.size !== size) {
-								(blob as any).size = size;
-								if (blob.#onSize) {
-									for (const callback of blob.#onSize) callback(size);
+							if (size < UNKNOWN_SIZE) {
+								if (isFullRead && descriptorSize != null && descriptorSize < UNKNOWN_SIZE && size !== descriptorSize) {
+									// the header claims a different (uncompressed) size than the record descriptor: the
+									// file has been truncated/corrupted even though its header is internally consistent
+									// (#1424). Fail rather than streaming the short content as if it were complete.
+									return onError(
+										new BlobReadError(
+											`Blob size mismatch for ${filePath}: record descriptor expects ${descriptorSize} bytes, on-disk header reports ${size}`,
+											BLOB_CORRUPT_STATUS
+										)
+									);
+								}
+								if (blob.size !== size) {
+									(blob as any).size = size;
+									if (blob.#onSize) {
+										for (const callback of blob.#onSize) callback(size);
+									}
 								}
 							}
 							buffer = buffer.subarray(HEADER_SIZE, bytesRead);
@@ -366,30 +478,33 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 											}
 											readMore(resolve, reject);
 										} else if (!resumeIfWriterFinished()) {
-											// set a timer for the watcher too
+											// set a timer for the watcher too. A write that stalls past the bound returns a
+											// prompt 503 (retryable) instead of holding the connection for the full 60s (#1423).
 											timer = setTimeout(() => {
 												if (!resumeIfWriterFinished()) {
 													if (readSync(fd, buffer, 0, buffer.length, position) > 0) {
 														// finally try to read one more time to see if it was a watcher failure
 														onError(
-															new Error(
-																`File read timed out reading from ${filePath} due to the watcher failing to notify of updates, read ${totalContentRead} bytes, but size is supposed to be ${size} bytes`
+															new BlobReadError(
+																`File read timed out reading from ${filePath} due to the watcher failing to notify of updates, read ${totalContentRead} bytes, but size is supposed to be ${size} bytes`,
+																BLOB_UNAVAILABLE_STATUS
 															)
 														);
 													} else {
 														onError(
-															new Error(
-																`File read timed out reading from ${filePath}, read ${totalContentRead} bytes, but size is supposed to be ${size} bytes`
+															new BlobReadError(
+																`File read timed out reading from ${filePath}, read ${totalContentRead} bytes, but size is supposed to be ${size} bytes`,
+																BLOB_UNAVAILABLE_STATUS
 															)
 														);
 													}
 												}
-											}, FILE_READ_TIMEOUT).unref();
+											}, getBlobReadTimeout()).unref();
 										}
 									} else {
 										if (previouslyFinishedWriting) {
 											// we verified that the blob was finished writing before the last read, we can confidently say it is incomplete
-											onError(new Error('Blob is incomplete'));
+											onError(new BlobReadError('Blob is incomplete', BLOB_CORRUPT_STATUS));
 										} else {
 											previouslyFinishedWriting = true;
 											readMore(resolve, reject); // try again (possibly for the last time) now that we know the status of the file writing
@@ -1278,8 +1393,18 @@ addExtension({
 			try {
 				const buffer = readFileSync(getFilePath(storageInfo));
 				if (buffer.length >= HEADER_SIZE) {
-					const size = Number(new DataView(buffer.buffer, buffer.byteOffset, 8).getBigUint64(0) & 0xffffffffffffn);
-					if (size === buffer.length - HEADER_SIZE) {
+					const headerValue = new DataView(buffer.buffer, buffer.byteOffset, 8).getBigUint64(0);
+					const type = Number(headerValue >> 48n);
+					const size = Number(headerValue & 0xffffffffffffn);
+					// The on-disk body must match the header size AND the header must match the record
+					// descriptor's recorded size — otherwise a file truncated to a self-consistent smaller
+					// header would be replicated to a fresh node as complete (#1424). Two exceptions skip the
+					// descriptor cross-check: an error stub (its header size is the message length, not the
+					// content size — error state is replicated as-is) and a slice (options.size is the reduced
+					// slice size, which legitimately differs from the full on-disk header size).
+					const isSlice = storageInfo.start !== undefined || storageInfo.end !== undefined;
+					const sizeMatchesDescriptor = type === ERROR_TYPE || isSlice || options.size == null || options.size === size;
+					if (size === buffer.length - HEADER_SIZE && sizeMatchesDescriptor) {
 						// the file is there and complete, we can return the encoding
 						return Buffer.concat([pack([options]), buffer]);
 					}

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -87,7 +87,12 @@ const DEFAULT_BLOB_READ_TIMEOUT = 20000;
  * storage_blobReadTimeout; defaults to 20s.
  */
 function getBlobReadTimeout(): number {
-	return envGet(CONFIG_PARAMS.STORAGE_BLOBREADTIMEOUT) ?? DEFAULT_BLOB_READ_TIMEOUT;
+	// Coerce to a number: env-var config overrides arrive as strings, and `Date.now() + "20000"` would
+	// concatenate into a far-future deadline that disables the timeout entirely. Fall back to the default
+	// for nullish/invalid/non-positive values.
+	const configured = envGet(CONFIG_PARAMS.STORAGE_BLOBREADTIMEOUT);
+	const timeout = configured == null ? DEFAULT_BLOB_READ_TIMEOUT : Number(configured);
+	return Number.isFinite(timeout) && timeout > 0 ? timeout : DEFAULT_BLOB_READ_TIMEOUT;
 }
 // HTTP statuses attached to blob read errors so a failed read surfaces a clean response rather than a
 // hung connection: 404 when the file is cleanly gone, 503 while a write is still in progress (the

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -793,7 +793,10 @@ describe('Blob test', () => {
 		assert(store.tryLock(lockKey), 'should be able to take the blob write lock for the test');
 		try {
 			unlinkSync(filePath); // file gone while a "writer" still holds the lock
-			env.setProperty(CONFIG_PARAMS.STORAGE_BLOBREADTIMEOUT, 150);
+			// Set as a string, the way an env-var config override arrives: getBlobReadTimeout must coerce it
+			// to a number, or `Date.now() + '150'` would concatenate into a far-future deadline (the timeout
+			// would never fire). Pre-coercion this assertion would hang instead of rejecting promptly.
+			env.setProperty(CONFIG_PARAMS.STORAGE_BLOBREADTIMEOUT, '150');
 			const started = Date.now();
 			await assert.rejects(streamToBuffer(blob.stream()), (error) => {
 				assert.equal(error.statusCode, 503);

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -22,10 +22,20 @@ const {
 	startPreCommitBlobsForRecord,
 	isSourceBlobUnavailable,
 } = require('#src/resources/blob');
-const { existsSync, unlinkSync } = require('fs');
+const { existsSync, unlinkSync, openSync, writeSync, ftruncateSync, closeSync } = require('fs');
 const { pack } = require('msgpackr');
 const { randomBytes } = require('crypto');
 const { waitFor } = require('../waitFor.js');
+const env = require('#src/utility/environment/environmentManager');
+const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
+
+const HEADER_SIZE = 8;
+// Build the 8-byte blob file header: 2-byte storage type followed by a 6-byte content size.
+function makeBlobHeader(size, type = 0) {
+	const header = Buffer.alloc(HEADER_SIZE);
+	new DataView(header.buffer).setBigInt64(0, BigInt(size) | (BigInt(type) << 48n));
+	return header;
+}
 
 describe('Blob test', () => {
 	let BlobTest;
@@ -662,6 +672,138 @@ describe('Blob test', () => {
 	it('cleanupOrphans', async () => {
 		let orphansDeleted = await cleanupOrphans(getDatabases().test);
 		assert.equal(orphansDeleted, 0);
+	});
+
+	// Helper: produce a blob backed ONLY by its on-disk file (no in-memory contentBuffer), the way a
+	// node reads a blob it didn't write itself — a fresh full-copy replica or a read after the record
+	// fell out of the in-memory cache. We save a blob to disk, encode it to its storage reference, then
+	// decode a fresh instance from that reference. The descriptor `size` rides along and is the
+	// authoritative value the read/send paths cross-validate against.
+	async function makeDiskBackedBlob(payloadSize = 20000) {
+		// Build the blob from a stream, so it is backed only by its on-disk file (no in-memory
+		// contentBuffer) — the way a node reads a blob it didn't write itself (full-copy replica, or a
+		// read after the record fell out of cache). saveBlob writes the file and records the size in both
+		// the header and the descriptor; the read/send paths cross-validate the two.
+		const store = BlobTest.primaryStore.rootStore;
+		const blob = await createBlob(Readable.from(randomBytes(payloadSize)), { size: payloadSize });
+		await decodeFromDatabase(() => saveBlob(blob).saving, store);
+		const filePath = getFilePathForBlob(blob);
+		assert(filePath && existsSync(filePath), 'expected a file-backed blob');
+		assert.equal(blob.size, payloadSize);
+		return { blob, filePath, store };
+	}
+	// Rewrite the on-disk file to a self-consistent-but-smaller state: header says `newSize`, body is
+	// `newSize` bytes. The record descriptor still says the full size, so only a descriptor cross-check
+	// (not the header's internal consistency) catches it.
+	function truncateBlobConsistently(filePath, newSize) {
+		const fd = openSync(filePath, 'r+');
+		try {
+			writeSync(fd, makeBlobHeader(newSize), 0, HEADER_SIZE, 0);
+			ftruncateSync(fd, HEADER_SIZE + newSize);
+		} finally {
+			closeSync(fd);
+		}
+	}
+
+	it('#1424: bytes() rejects a blob truncated to a self-consistent smaller size (T4)', async () => {
+		const { blob, filePath } = await makeDiskBackedBlob();
+		truncateBlobConsistently(filePath, 256);
+		await assert.rejects(blob.bytes(), (error) => {
+			assert.equal(error.statusCode, 500);
+			assert.match(error.message, /size mismatch/);
+			return true;
+		});
+	});
+	it('#1424: stream() rejects a blob truncated to a self-consistent smaller size (T4)', async () => {
+		const { blob, filePath } = await makeDiskBackedBlob();
+		truncateBlobConsistently(filePath, 256);
+		await assert.rejects(streamToBuffer(blob.stream()), (error) => {
+			assert.equal(error.statusCode, 500);
+			return true;
+		});
+	});
+	it('#1424: replication-send does not emit a truncated blob as complete (T4)', async () => {
+		const { blob, filePath } = await makeDiskBackedBlob();
+		truncateBlobConsistently(filePath, 256);
+		// encodeBlobsAsBuffers returns a promise when a blob has to be re-read; the truncated read rejects
+		// rather than packing the short file as a complete blob (which would propagate via full copy).
+		await assert.rejects(Promise.resolve(encodeBlobsAsBuffers(() => pack({ blob }))), (error) => {
+			assert.equal(error.statusCode, 500);
+			return true;
+		});
+	});
+	it('#1424: replication-send preserves an error-state blob stub (does not reject)', async () => {
+		// An error-state stub (header type 0xff, header size = error-message length) is intentionally
+		// replicated as-is so the receiver keeps the error marker. The descriptor cross-check must skip it,
+		// even though the descriptor size (20000) differs from the stub's header size.
+		const { blob, filePath } = await makeDiskBackedBlob();
+		const message = Buffer.from('disk full while writing blob');
+		const fd = openSync(filePath, 'r+');
+		try {
+			const stub = Buffer.concat([makeBlobHeader(message.length, 0xff), message]);
+			writeSync(fd, stub, 0, stub.length, 0);
+			ftruncateSync(fd, stub.length);
+		} finally {
+			closeSync(fd);
+		}
+		const encoded = encodeBlobsAsBuffers(() => pack({ blob }));
+		const result = Buffer.isBuffer(encoded) ? encoded : await encoded;
+		assert(Buffer.isBuffer(result) && result.length > message.length, 'error stub should be packed, not rejected');
+	});
+	it('#1424: replication-send packs a slice against the full file (not mis-flagged as truncated)', async () => {
+		// A slice carries a reduced descriptor size that legitimately differs from the full on-disk header
+		// size; the descriptor cross-check must skip slices so a valid slice still replicates.
+		const { blob } = await makeDiskBackedBlob();
+		const sliced = blob.slice(0, 200);
+		const encoded = encodeBlobsAsBuffers(() => pack({ blob: sliced }));
+		const result = Buffer.isBuffer(encoded) ? encoded : await encoded;
+		assert(Buffer.isBuffer(result), 'a slice should pack without being rejected as incomplete');
+	});
+	it('#1424: bytes() rejects a file corrupted below the header rather than returning garbage (T3)', async () => {
+		const { blob, filePath } = await makeDiskBackedBlob();
+		// overwrite with fewer than HEADER_SIZE bytes, with byte[1] = DEFLATE_TYPE — the case that
+		// previously decompressed an empty body into ~8 garbage bytes returned as valid content.
+		const fd = openSync(filePath, 'r+');
+		try {
+			writeSync(fd, Buffer.from([0, 1, 0]), 0, 3, 0);
+			ftruncateSync(fd, 3);
+		} finally {
+			closeSync(fd);
+		}
+		await assert.rejects(blob.bytes(), (error) => {
+			assert.equal(error.statusCode, 500);
+			return true;
+		});
+	});
+	it('#1423: reading a cleanly-missing blob file returns a prompt 404', async () => {
+		const { blob, filePath } = await makeDiskBackedBlob();
+		unlinkSync(filePath);
+		await assert.rejects(blob.bytes(), (error) => {
+			assert.equal(error.statusCode, 404);
+			return true;
+		});
+		await assert.rejects(streamToBuffer(blob.stream()), (error) => {
+			assert.equal(error.statusCode, 404);
+			return true;
+		});
+	});
+	it('#1423: a missing file with an in-progress writer times out as 503 instead of hanging', async () => {
+		const { blob, filePath, store } = await makeDiskBackedBlob();
+		const lockKey = getFileId(blob) + ':blob';
+		assert(store.tryLock(lockKey), 'should be able to take the blob write lock for the test');
+		try {
+			unlinkSync(filePath); // file gone while a "writer" still holds the lock
+			env.setProperty(CONFIG_PARAMS.STORAGE_BLOBREADTIMEOUT, 150);
+			const started = Date.now();
+			await assert.rejects(streamToBuffer(blob.stream()), (error) => {
+				assert.equal(error.statusCode, 503);
+				return true;
+			});
+			assert(Date.now() - started < 5000, 'read should fail promptly, not hang');
+		} finally {
+			store.unlock(lockKey);
+			env.setProperty(CONFIG_PARAMS.STORAGE_BLOBREADTIMEOUT, undefined);
+		}
 	});
 	afterEach(function () {
 		setAuditRetention(60000);

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -775,15 +775,20 @@ describe('Blob test', () => {
 			return true;
 		});
 	});
-	it('#1423: reading a cleanly-missing blob file returns a prompt 404', async () => {
+	it('#1423: reading a cleanly-missing blob file returns a prompt 404 (with an ENOENT code for old consumers)', async () => {
 		const { blob, filePath } = await makeDiskBackedBlob();
 		unlinkSync(filePath);
+		// The 404 also carries `code: 'ENOENT'` so a consumer that only understands `error.code` — e.g. an
+		// older replication receiver predating the statusCode taxonomy — still classifies a missing source
+		// blob as a permanent absence and advances its resume cursor (harper-pro#403/#405) instead of wedging.
 		await assert.rejects(blob.bytes(), (error) => {
 			assert.equal(error.statusCode, 404);
+			assert.equal(error.code, 'ENOENT');
 			return true;
 		});
 		await assert.rejects(streamToBuffer(blob.stream()), (error) => {
 			assert.equal(error.statusCode, 404);
+			assert.equal(error.code, 'ENOENT');
 			return true;
 		});
 	});

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -616,6 +616,7 @@ export const CONFIG_PARAMS = {
 	STORAGE_PATH: 'storage_path',
 	STORAGE_BLOBPATHS: 'storage_blobPaths',
 	STORAGE_BLOBCLEANUPSPEED: 'storage_blobCleanupSpeed',
+	STORAGE_BLOBREADTIMEOUT: 'storage_blobReadTimeout',
 	STORAGE_AUDIT_PATH: 'storage_audit_path',
 	STORAGE_MAXFREESPACETOLOAD: 'storage_maxFreeSpaceToLoad',
 	STORAGE_MAXFREESPACETORETAIN: 'storage_maxFreeSpaceToRetain',


### PR DESCRIPTION
Fixes #1424 and #1423 — two related defects in file-backed blob reads, both surfaced by exploratory QA on `resources/blob.ts`.

## #1424 — truncated/corrupt blobs served as valid and propagated to replicas
Nothing cross-validated the bytes a blob read/replicated against the size recorded in the record descriptor (`blob.size`); the read/send paths trusted the on-disk file's self-describing header. So a file truncated to a self-consistent-but-wrong state was served as short content and copied to a fresh replica as "complete".

- **Read paths** (`bytes()`, `stream()`): on a *full* read, cross-check the header's (uncompressed) size against the descriptor `blob.size`; mismatch → error. Plus a guard so a file shorter than the 8-byte header (T3) is treated as incomplete instead of being mis-decoded into garbage.
- **Replication-send** (the msgpackr `pack` extension): the "complete" fast path now also requires the header size to match the descriptor before emitting the file as complete.

## #1423 — read of an incomplete/being-written/truncated file hung the HTTP response 20–60s
The waits on the incomplete-blob path were effectively unbounded (a ~20s ENOENT open-retry loop and a 60s read timeout). They now bound to a configurable `storage_blobReadTimeout` (default 20s), and read errors carry an HTTP `statusCode`: **404** cleanly gone, **503** write-in-progress (retryable), **500** confidently corrupt.

## Where to look
- `resources/blob.ts` — the descriptor cross-check in `bytes()`/`stream()` is gated on `isFullRead` (slices carry a reduced descriptor size). In `pack`, the cross-check is skipped for **error-state stubs** (header size = error-message length, not content size — these are replicated as-is by design) and **slices**. Both exemptions were found by the cross-model review and have regression tests.
- **HTTP-layer caveat:** when `blob.size` is known the server sends `writeHead(200)` + Content-Length *before* consuming the stream, so for the streaming path the win is failing **promptly** (and aborting the connection) rather than always converting to a clean status; the `statusCode` still helps the `bytes()`/pre-writeHead paths.

## Out of scope (pre-existing, not introduced here)
The Gemini leg flagged the `deflate`-instead-of-`inflate` decompression bug (being fixed in #1393) and a potential double-close/fd-reuse race in the `stream()` retry+cancel path — both pre-date this change. Worth a follow-up for the fd race; not touched here to keep this focused.

## Testing
Unit tests added for T3, T4 (bytes/stream/replication-send), the 404 and 503 paths, and the two review-found exemptions (error-stub + slice replication). `test:unit:resources` blob + caching suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8)