### PR TITLE
fix(jobs): exclude job worker ports from schema-change broadcasts

### DIFF
--- a/server/jobs/jobRunner.ts
+++ b/server/jobs/jobRunner.ts
@@ -154,7 +154,17 @@ if (isMainThread) {
 				env: { ...process.env, [hdbTerms.PROCESS_NAME_ENV_PROP]: `JOB-${message.jobId}` },
 			});
 		} catch (e) {
-			log.error(e);
+			log.error(`Failed to start worker for job ${message.jobId}:`, e);
+			try {
+				await jobs.updateJob({
+					id: message.jobId,
+					status: hdbTerms.JOB_STATUS_ENUM.ERROR,
+					message: e.message ?? String(e),
+					end_datetime: moment().valueOf(),
+				});
+			} catch (updateErr) {
+				log.error(`Unable to mark job ${message.jobId} as failed:`, updateErr);
+			}
 		}
 	});
 }

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -199,17 +199,19 @@ function startWorker(path, options = {}) {
 	});
 	// now that we have the new thread ids, we can finishing connecting the channel and notify the existing
 	// worker of the new port with thread id.
+	const isJobWorker = options.name === hdbTerms.THREAD_TYPES.JOB;
 	for (let { port1, existingPort } of channelsToConnect) {
 		existingPort.postMessage(
 			{
 				type: ADDED_PORT,
 				port: port1,
 				threadId: worker.threadId,
+				isJobWorker,
 			},
 			[port1]
 		);
 	}
-	addPort(worker, true);
+	addPort(worker, true, isJobWorker);
 	worker.unexpectedRestarts = options.unexpectedRestarts || 0;
 	worker.startCopy = () => {
 		// in a shutdown sequence we use overlapping restarts, starting the new thread while waiting for the old thread
@@ -412,6 +414,11 @@ function broadcastWithAcknowledgement(message) {
 	return new Promise((resolve) => {
 		let waitingCount = 0;
 		for (let port of connectedPorts) {
+			// Job workers run a single isolated task and exit; they don't participate in
+			// schema-change gossip. Including them causes a deadlock: the broadcast waits for
+			// the job worker's ACK while the job worker's event loop is busy waiting for the
+			// same broadcast to complete (re-entrant schema change triggered by the job op).
+			if (port.isJobWorker) continue;
 			try {
 				let requestId = nextId++;
 				const ackHandler = () => {
@@ -573,7 +580,8 @@ function removePort(port, deadThreadId) {
 	}
 }
 
-function addPort(port, keepRef) {
+function addPort(port, keepRef, isJobWorker) {
+	if (isJobWorker) port.isJobWorker = true;
 	connectedPorts.push(port);
 	// Capture threadId now — Bun resets port.threadId to -1 by the time 'exit' fires.
 	const portThreadId = port.threadId;
@@ -581,7 +589,7 @@ function addPort(port, keepRef) {
 		.on('message', (message) => {
 			if (message.type === ADDED_PORT) {
 				message.port.threadId = message.threadId;
-				addPort(message.port);
+				addPort(message.port, false, message.isJobWorker);
 			} else if (message.type === ACKNOWLEDGEMENT) {
 				let completion = awaitingResponses.get(message.id);
 				if (completion) {

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -864,6 +864,7 @@ export const ITC_EVENT_TYPES = {
 /** Supported thread types */
 export const THREAD_TYPES = {
 	HTTP: 'http',
+	JOB: 'job',
 } as const;
 
 /** A version string for pre 4.0.0 comparison */


### PR DESCRIPTION
## Summary

- Job workers are single-task-and-exit threads that don't participate in schema-change gossip, but were being included in `broadcastWithAcknowledgement` — causing a deadlock where the broadcast waited for the job worker's ACK while that worker's event loop was itself blocked waiting for the same schema change to complete (re-entrant schema change triggered by the job operation).
- Fix: tag ports created for `JOB` thread types with `isJobWorker`, propagate the flag through `ADDED_PORT` messages to all peer ports, and skip tagged ports in `broadcastWithAcknowledgement`.
- Also adds `JOB` to `THREAD_TYPES` in `hdbTerms.ts` (previously it was only `HTTP`) and improves error handling in `jobRunner.ts` to persist an `ERROR` status on the job record if the worker thread fails to launch.

## Test plan

- [ ] Run existing job-related tests — no regressions (pre-existing 2 failures and 6 Global Variable Isolation order-dependent failures are unrelated to this change)
- [ ] Manually trigger a job that causes a schema change (e.g., creating a table inside a job) and confirm it completes without hanging
- [ ] Confirm non-job schema changes (table creation from HTTP workers) still broadcast and acknowledge correctly
- [ ] Verify a failed job-worker launch records `ERROR` status on the job record

🤖 Generated with [Claude Code](https://claude.com/claude-code)