### PR TITLE
chore(deps): bump @harperfast/integration-testing to ^0.6.2 (loopback canary HTTP-port fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
 			},
 			"devDependencies": {
 				"@harperdb/code-guidelines": "^0.0.6",
-				"@harperfast/integration-testing": "^0.5.2",
+				"@harperfast/integration-testing": "^0.6.2",
 				"@modelcontextprotocol/sdk": "^1.29.0",
 				"@types/busboy": "^1.5.4",
 				"@types/fs-extra": "^11.0.4",
@@ -2897,9 +2897,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@harperfast/integration-testing": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@harperfast/integration-testing/-/integration-testing-0.5.2.tgz",
-			"integrity": "sha512-d+UAcpRUYYyL5KKvGEMA2GfOTPimo3uVBxUK1VnVB+lFI8snwhN77V7C5Rhu4dLyOZvpNvdU8xpx3ajTS0QeUA==",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/integration-testing/-/integration-testing-0.6.2.tgz",
+			"integrity": "sha512-N/uTy9hQt3GNuBPlVTBpJ75ONNRn2rrZadDvC9vyMI7Y8kaFxGzQgyeW0IFSxYTh23wqkJT2aQ+ofQoo5pQCSA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -3732,13 +3732,11 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
 			"version": "3.0.4",
@@ -3747,13 +3745,11 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
 			"version": "3.0.4",
@@ -3762,13 +3758,11 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
 			"version": "3.0.4",
@@ -3777,13 +3771,11 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
 			"version": "3.0.4",
@@ -3792,13 +3784,11 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
 			"version": "3.0.4",
@@ -3807,13 +3797,11 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@noble/hashes": {
 			"version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
 	},
 	"devDependencies": {
 		"@harperdb/code-guidelines": "^0.0.6",
-		"@harperfast/integration-testing": "^0.5.2",
+		"@harperfast/integration-testing": "^0.6.2",
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"@types/busboy": "^1.5.4",
 		"@types/fs-extra": "^11.0.4",


### PR DESCRIPTION
Bumps the integration-test harness to **0.6.2**, which carries the loopback conflict-canary HTTP-port probe (integration-testing#20).

## Why
Under CI sharding, integration shards hit cascading `ECONNREFUSED :9926` failures: a test whose main thread had exited but whose HTTP **worker** threads still held its loopback address (via SO_REUSEPORT) had that address recycled to the next test, which then silently co-bound it. The old canary only probed the operations port (main-thread, exclusive) and missed this. 0.6.2's canary probes **both** the operations port and the HTTP port, detecting the lingering worker and skipping the address.

This is the framework half of the fix that unblocks the held test-promotion PR #1427 (which reproduced the contamination on non-crash tests too).

## Safety
`0.5.2 → 0.6.2` has **no breaking API changes**. Runtime deltas: `fix: Prevent global state smashing` (0.5.4) + the canary (0.6.2). The 0.6.0 *minor* is purely the semantic-release CI-automation `feat`, not an API change. devDependency only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)