### PR TITLE
Detect operationsApi/http port collisions during config validation

### DIFF
--- a/config/configUtils.js
+++ b/config/configUtils.js
@@ -466,6 +466,40 @@ function validateConfig(configDoc, skipFsValidation = false) {
 		);
 	}
 
+	// The operations API and the REST/http servers are distinct servers that cannot share a port. The operations API
+	// runs on the main thread without SO_REUSEPORT while the http servers run on the workers with it, so a shared port is
+	// silently claimed by whichever binds first (the operations server), leaving the http server — and its WebSocket
+	// upgrade handler — unable to bind. That presents as secure-port WebSocket upgrades hanging. Fail loudly here rather
+	// than letting the collision go undetected. (mqtt websocket intentionally shares http.port and replication defaults
+	// to the operations port, so only the http/operationsApi pairing is checked.) See issue #1412.
+	const configuredPorts = [
+		['http.port', configJson.http?.port],
+		['http.securePort', configJson.http?.securePort],
+		['operationsApi.network.port', configJson.operationsApi?.network?.port],
+		['operationsApi.network.securePort', configJson.operationsApi?.network?.securePort],
+	];
+	const portLabels = new Map();
+	for (const [label, value] of configuredPorts) {
+		// Normalize to a number so a string env-var port (e.g. "9926") still matches a numeric YAML port, and skip
+		// unset/ephemeral values: 0 (and NaN from a non-numeric value) requests an OS-assigned port, so distinct
+		// sections configured that way won't actually collide at bind time.
+		const port = Number(value);
+		if (!port) continue;
+		const collidingLabel = portLabels.get(port);
+		// Skip http-internal and operationsApi-internal collisions; those are reported with dedicated messages above.
+		if (collidingLabel && collidingLabel.split('.')[0] !== label.split('.')[0]) {
+			throw handleHDBError(
+				new Error(),
+				HDB_ERROR_MSGS.CONFIG_VALIDATION(`${collidingLabel} and ${label} cannot be the same value (${port})`),
+				HTTP_STATUS_CODES.BAD_REQUEST,
+				undefined,
+				undefined,
+				true
+			);
+		}
+		portLabels.set(port, label);
+	}
+
 	const validation = configValidator(configJson, skipFsValidation);
 	if (validation.error) {
 		throw handleHDBError(

--- a/config/configUtils.js
+++ b/config/configUtils.js
@@ -480,11 +480,12 @@ function validateConfig(configDoc, skipFsValidation = false) {
 	];
 	const portLabels = new Map();
 	for (const [label, value] of configuredPorts) {
-		// Normalize to a number so a string env-var port (e.g. "9926") still matches a numeric YAML port, and skip
-		// unset/ephemeral values: 0 (and NaN from a non-numeric value) requests an OS-assigned port, so distinct
-		// sections configured that way won't actually collide at bind time.
+		// Skip non-numeric values (unset, or a malformed boolean/array/object) — those are caught by the schema
+		// validator below. Numeric strings pass (isNumber('9926') === true) so a string env-var port still matches a
+		// numeric YAML port. Skip 0: it requests an OS-assigned port, so distinct sections set that way won't collide.
+		if (!isNumber(value)) continue;
 		const port = Number(value);
-		if (!port) continue;
+		if (port === 0) continue;
 		const collidingLabel = portLabels.get(port);
 		// Skip http-internal and operationsApi-internal collisions; those are reported with dedicated messages above.
 		if (collidingLabel && collidingLabel.split('.')[0] !== label.split('.')[0]) {

--- a/unitTests/config/configUtils.test.js
+++ b/unitTests/config/configUtils.test.js
@@ -522,6 +522,132 @@ describe('Test configUtils module', () => {
 			expect(set_in_stub.args[3][1]).to.equal('path/to/storage');
 			expect(set_in_stub.args[4][1]).to.equal('path/for/rotated/logs');
 		});
+
+		it('Test error is thrown if operationsApi securePort collides with http securePort', () => {
+			const fake_config_doc = {
+				toJSON: () => ({
+					http: { securePort: 9926 },
+					operationsApi: { network: { port: 9925, securePort: 9926 } },
+				}),
+				setIn: () => {},
+			};
+
+			let error;
+			try {
+				validate_config(fake_config_doc);
+			} catch (err) {
+				error = err;
+			}
+
+			expect(error?.message, `Error was: ${error}`).to.equal(
+				'Harper config file validation error: http.securePort and operationsApi.network.securePort cannot be the same value (9926)'
+			);
+		});
+
+		it('Test error is thrown if operationsApi port collides with http port', () => {
+			const fake_config_doc = {
+				toJSON: () => ({
+					http: { port: 9926 },
+					operationsApi: { network: { port: 9926 } },
+				}),
+				setIn: () => {},
+			};
+
+			let error;
+			try {
+				validate_config(fake_config_doc);
+			} catch (err) {
+				error = err;
+			}
+
+			expect(error?.message, `Error was: ${error}`).to.equal(
+				'Harper config file validation error: http.port and operationsApi.network.port cannot be the same value (9926)'
+			);
+		});
+
+		it('Test collision is detected when one port is a string and the other a number', () => {
+			const fake_config_doc = {
+				toJSON: () => ({
+					http: { securePort: 9926 },
+					operationsApi: { network: { securePort: '9926' } },
+				}),
+				setIn: () => {},
+			};
+
+			let error;
+			try {
+				validate_config(fake_config_doc);
+			} catch (err) {
+				error = err;
+			}
+
+			expect(error?.message, `Error was: ${error}`).to.equal(
+				'Harper config file validation error: http.securePort and operationsApi.network.securePort cannot be the same value (9926)'
+			);
+		});
+
+		it('Test port 0 (OS-assigned) does not trigger a collision error', () => {
+			const fake_validation = {
+				value: {
+					threads: { count: 1 },
+					componentsRoot: '/yaml/components',
+					logging: { root: '/yaml/log', rotation: { path: '/yaml/log/rotated' } },
+					storage: { path: '/yaml/storage' },
+					operationsApi: { network: { domainSocket: null } },
+				},
+			};
+			config_validator_stub = sandbox.stub().returns(fake_validation);
+			config_utils_rw.__set__('configValidator', config_validator_stub);
+
+			const fake_config_doc = {
+				toJSON: () => ({
+					http: { port: 0 },
+					operationsApi: { network: { port: 0 } },
+				}),
+				setIn: () => {},
+			};
+
+			let error;
+			try {
+				validate_config(fake_config_doc);
+			} catch (err) {
+				error = err;
+			}
+
+			expect(error, `Error was: ${error}`).to.not.exist;
+		});
+
+		it('Test no collision error is thrown when http and operationsApi ports are distinct', () => {
+			const fake_validation = {
+				value: {
+					threads: { count: 1 },
+					componentsRoot: '/yaml/components',
+					logging: { root: '/yaml/log', rotation: { path: '/yaml/log/rotated' } },
+					storage: { path: '/yaml/storage' },
+					operationsApi: { network: { domainSocket: null } },
+				},
+			};
+			config_validator_stub = sandbox.stub().returns(fake_validation);
+			config_utils_rw.__set__('configValidator', config_validator_stub);
+
+			const fake_config_doc = {
+				toJSON: () => ({
+					http: { port: 9926, securePort: 9927 },
+					operationsApi: { network: { port: 9925, securePort: 9928 } },
+				}),
+				setIn: () => {},
+			};
+
+			let error;
+			try {
+				validate_config(fake_config_doc);
+			} catch (err) {
+				error = err;
+			}
+
+			expect(error, `Error was: ${error}`).to.not.exist;
+			expect(config_validator_stub.called).to.be.true;
+		});
 	});
 
 	describe('Test updateConfigObject function', () => {

--- a/unitTests/config/configUtils.test.js
+++ b/unitTests/config/configUtils.test.js
@@ -617,6 +617,39 @@ describe('Test configUtils module', () => {
 			expect(error, `Error was: ${error}`).to.not.exist;
 		});
 
+		it('Test non-numeric port values do not trigger a collision error', () => {
+			const fake_validation = {
+				value: {
+					threads: { count: 1 },
+					componentsRoot: '/yaml/components',
+					logging: { root: '/yaml/log', rotation: { path: '/yaml/log/rotated' } },
+					storage: { path: '/yaml/storage' },
+					operationsApi: { network: { domainSocket: null } },
+				},
+			};
+			config_validator_stub = sandbox.stub().returns(fake_validation);
+			config_utils_rw.__set__('configValidator', config_validator_stub);
+
+			// Malformed values (e.g. boolean true, which Number() would coerce to 1) must not be treated as ports here;
+			// the schema validator reports them.
+			const fake_config_doc = {
+				toJSON: () => ({
+					http: { port: true },
+					operationsApi: { network: { port: true } },
+				}),
+				setIn: () => {},
+			};
+
+			let error;
+			try {
+				validate_config(fake_config_doc);
+			} catch (err) {
+				error = err;
+			}
+
+			expect(error, `Error was: ${error}`).to.not.exist;
+		});
+
 		it('Test no collision error is thrown when http and operationsApi ports are distinct', () => {
 			const fake_validation = {
 				value: {


### PR DESCRIPTION
Fixes #1412.

## Summary
Adds a cross-section port-collision check to `validateConfig` (`config/configUtils.js`) so a config where the operations-API and REST/http servers are pointed at the same port fails loudly at startup instead of silently breaking the secure-port WebSocket path.

## Why
Issue #1412 reports secure-port (`wss`) WebSocket upgrades hanging on 5.1.x while the insecure port works. Root cause (confirmed by live + local repro on the issue) is a **config port collision**, not the 5.1.0 middleware rewrite it first looked like:

- In 5.1 the operations API binds on the **main thread without `SO_REUSEPORT`**; the REST/http servers bind on the **workers with it**.
- When a config collides another server onto the REST `securePort` (e.g. `operationsApi.network.securePort` == `http.securePort`), the single non-reusePort ops socket claims the port **exclusively**. The reusePort REST workers then hit `EADDRINUSE`, which is swallowed in `threadServer.js` (that swallow is load-bearing on macOS/Windows, where every server is non-reusePort, so it can't simply be made loud).
- The lone surviving listener is the ops server, which has no REST WebSocket upgrade handler → `wss` upgrades reset/hang. 5.0 didn't break because the ops API also used reusePort.

`validateConfig` already hard-errors on *within-section* collisions (`http.port === http.securePort`, same for ops). This just closes the missing *cross-section* case at the right layer.

## Where to put attention
- **Behavior change (deliberate):** this is a hard error, consistent with the existing within-section checks. A deployment currently running with this collision (one server silently shadowed) will now **refuse to start** until the config is fixed. That's the intended fail-loud trade vs. silent WS breakage, but it's the thing to weigh — especially re: whether this should be cherry-picked to 5.1 (happy to, via /patch-pr, if we want it released; see open question below).
- **Scope of the check** (`config/configUtils.js`): limited to the `http` ↔ `operationsApi.network` pairing on purpose. `mqtt.websocket` *intentionally* shares `http.port`, and `replication.port` defaults to the operations port, so a blanket "all ports distinct" check would false-positive. Worth a sanity check that this scoping matches your mental model of which servers can legitimately co-bind.
- Ports are normalized via `Number()` (string env-var port vs numeric YAML port) and `0`/ephemeral is skipped — see the two edge-case unit tests.

## Not in this PR (open follow-ups)
- The **`wss`-upgrade test gap** the issue flags (a regression test driving a TLS WebSocket upgrade against `securePort`) is real but orthogonal to this config-layer fix and needs net-new integration-test infrastructure — recommend a separate PR.
- Detecting a **component-declared `http.port`** colliding with the REST secure port (the 4th repro permutation in the issue) — components load after main-config validation, so it'd need a different hook; deferred.

## Open question
Should this be cherry-picked to the 5.1 release branch as a patch? It's safe and well-contained, but it's a startup-refusal behavior change (see above).

🤖 Generated by Claude (Opus 4.8). Cross-model review: Gemini (`agy`) leg run; two edge cases it surfaced (string-vs-number port equality, port-0 ephemeral false-positive) are fixed in this PR with tests. Codex leg unavailable in this environment.