### PR TITLE
fix: keep the operations API off the app http ports (#1420)

### DIFF
--- a/integrationTests/server/fixtures/ops-port-collision-app/config.yaml
+++ b/integrationTests/server/fixtures/ops-port-collision-app/config.yaml
@@ -1,0 +1,10 @@
+# Minimal app whose config carries a port-less operationsApi block. This mirrors a real
+# customer app (paddock_pro) and is the #1420 trigger: loading it on the main thread
+# re-invokes the operations-API plugin with no port, so without the getPorts fix the ops
+# registration falls back onto the app http ports and locks the http workers out.
+rest: true
+jsResource:
+  files: resources.js
+operationsApi:
+  network:
+    cors: true

--- a/integrationTests/server/fixtures/ops-port-collision-app/package.json
+++ b/integrationTests/server/fixtures/ops-port-collision-app/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "ops-port-collision-app",
+	"version": "1.0.0",
+	"type": "module",
+	"main": "resources.js",
+	"license": "Apache-2.0"
+}

--- a/integrationTests/server/fixtures/ops-port-collision-app/resources.js
+++ b/integrationTests/server/fixtures/ops-port-collision-app/resources.js
@@ -1,0 +1,6 @@
+// Minimal resource so the app is a valid loadable component.
+export class Ping extends Resource {
+	get() {
+		return { ok: true };
+	}
+}

--- a/integrationTests/server/ops-port-isolation.test.ts
+++ b/integrationTests/server/ops-port-isolation.test.ts
@@ -34,6 +34,8 @@ function wsUpgradeStatus(url: string): Promise<number> {
 		req.setTimeout(8000, () => req.destroy(new Error('ws upgrade timed out')));
 		// A successful upgrade emits 'upgrade'; a handler-less server answers as a normal response.
 		req.on('upgrade', (res, socket) => {
+			// Avoid an unhandled 'error' crashing the test process if the socket faults on teardown.
+			socket.on('error', () => {});
 			socket.destroy();
 			resolve(res.statusCode ?? 0);
 		});

--- a/integrationTests/server/ops-port-isolation.test.ts
+++ b/integrationTests/server/ops-port-isolation.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression test for #1420.
+ *
+ * When an application config carries a port-less `operationsApi` block, loading it on the
+ * main thread re-invokes the operations-API plugin with no port. Before the fix, `getPorts`
+ * fell back to the app http ports, so the main thread bound them as operations-api servers
+ * (noReusePort, no WebSocket upgrade handler). That locked the http worker threads out of
+ * those ports (silently swallowed EADDRINUSE), leaving only the main thread's handler-less
+ * socket — so every WebSocket upgrade was reset while plain HTTP kept working.
+ *
+ * This test boots Harper with such an app and asserts that a WebSocket upgrade on the app
+ * http port still completes (HTTP 101). Without the fix the upgrade never completes.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert/strict';
+import { request } from 'node:http';
+import { join } from 'node:path';
+
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+
+const FIXTURE = join(import.meta.dirname, 'fixtures', 'ops-port-collision-app');
+
+/** Attempt a WebSocket upgrade and resolve with the HTTP status code (101 on success). */
+function wsUpgradeStatus(url: string): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const req = request(url, {
+			headers: {
+				'Connection': 'Upgrade',
+				'Upgrade': 'websocket',
+				'Sec-WebSocket-Version': '13',
+				'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
+			},
+		});
+		req.setTimeout(8000, () => req.destroy(new Error('ws upgrade timed out')));
+		// A successful upgrade emits 'upgrade'; a handler-less server answers as a normal response.
+		req.on('upgrade', (res, socket) => {
+			socket.destroy();
+			resolve(res.statusCode ?? 0);
+		});
+		req.on('response', (res) => {
+			res.destroy();
+			resolve(res.statusCode ?? 0);
+		});
+		req.on('error', reject);
+		req.end();
+	});
+}
+
+suite('REST WebSocket upgrade with a port-less app operationsApi block (#1420)', (ctx: ContextWithHarper) => {
+	before(async () => {
+		await setupHarperWithFixture(ctx, FIXTURE, {
+			config: {
+				threads: { count: 2 },
+				mqtt: { webSocket: true },
+			},
+			env: {},
+		});
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	test('WebSocket upgrade on the app http port completes (101)', async () => {
+		const status = await wsUpgradeStatus(ctx.harper.httpURL);
+		strictEqual(status, 101, `expected WS upgrade to return 101, got ${status}`);
+	});
+
+	test('plain HTTP still responds on the app http port', async () => {
+		// The bug's signature was "HTTP works, WS breaks"; assert HTTP is unaffected.
+		const res = await fetch(ctx.harper.httpURL);
+		ok(res.status > 0, 'expected an HTTP response on the app port');
+	});
+
+	test('operations API remains reachable on its own port', async () => {
+		// Guards against an over-broad guard that would stop the ops API from binding.
+		const res = await fetch(`${ctx.harper.operationsAPIURL}/health`);
+		strictEqual(res.status, 200);
+	});
+});

--- a/server/http.ts
+++ b/server/http.ts
@@ -256,7 +256,12 @@ function getPorts(options) {
 	if (port) ports.push({ port, secure: true });
 	port = options?.port;
 	if (port) ports.push({ port, secure: false });
-	if (ports.length === 0) {
+	// The operations API must never fall back to the app http ports: it binds on its own
+	// configured port(s)/domain socket only. Falling back here lets a port-less operations-api
+	// registration (e.g. an app config that carries an `operationsApi` block with no port)
+	// claim http.port/http.securePort on the main thread with noReusePort and no upgrade
+	// handler, which locks the http workers out of those ports and breaks all WebSockets (#1420).
+	if (ports.length === 0 && options?.usageType !== 'operations-api') {
 		// if no port is provided, default to http port
 		ports = [];
 		if (env.get(terms.CONFIG_PARAMS.HTTP_PORT) != null)


### PR DESCRIPTION
Fixes #1420.

## Summary
`getPorts()` no longer falls back to the app `http.port`/`http.securePort` for `operations-api` registrations. The operations API now binds only on its own configured port / domain socket.

## Root cause (confirmed on a live instance, not inferred)
An application config that carries a **port-less `operationsApi` block** (e.g. `operationsApi: { network: { cors: true } }` — no `port`/`securePort`) causes `loadComponentDirectories` to re-invoke the operations-API plugin on the **main thread** with port-less options. Before this change, `getPorts` fell back to the app `http.port`/`http.securePort`, so `getHTTPServer` created `operations-api`-tagged servers (`noReusePort`, **no WebSocket upgrade handler**) on the app ports. The main thread binds them first (`socketRouter` calls `listenOnPorts()` on main before workers start), so the http worker threads then hit `EADDRINUSE` (silently swallowed in `threadServer.js`) and never bind those ports. Only the main thread's handler-less socket survives → plain HTTP works, every WebSocket upgrade resets.

This matches the issue's fingerprint exactly: multi-component instances only, "after restart", not on stock images, no errors logged.

## Where to look
- `server/http.ts` `getPorts()` — the one-line guard (`&& options?.usageType !== 'operations-api'`) is the whole fix. The default config always gives the ops API its own port (9925), and the root ops registration receives a concrete port via config-flatten (`configUtils.js`), so the fallback was only ever reachable for the buggy port-less app-component case — i.e. the guard changes nothing for any valid config. The domain-socket push below the fallback is independent, so the ops API stays reachable.
- `integrationTests/server/ops-port-isolation.test.ts` + `fixtures/ops-port-collision-app/` — regression test. Boots Harper with an app carrying a port-less `operationsApi` block and asserts the app-port WebSocket upgrade returns 101 (plus that plain HTTP and the ops API are unaffected). Verified to **fail without** the fix and **pass with** it.

## Validation
- Regression test: fails on unpatched code, passes with the fix.
- Hot-patched + restarted two affected live instances: app-port listeners went 1 → 4 (workers reclaimed the ports) and WS/WSS upgrades returned 101. The instances were then permanently recovered by removing the offending app's port-less `operationsApi` block (a separate, app-side config fix on the persistent volume).

## Related
Complementary to #1430 (config-time http/ops port-**collision** detection). #1430 catches an explicit same-port collision; this case has no explicit collision — the ops registration *expands* onto the app ports via the fallback — so #1430 would not catch it.

## Notes for the reviewer
- The cross-model review legs (Codex/Gemini) were unavailable in this environment; the Harper-domain `deep-review` pass ran and found no blockers or significant concerns (it confirmed there is no valid config where an ops registration should bind on the app ports).
- Not a user-facing API/config change, so no docs PR. Worth a separate follow-up: app configs should not carry an `operationsApi` block at all (apps don't run the ops API) — surfacing/validating that is out of scope here.
- Generated by an LLM (Claude Opus 4.8).