### PR TITLE
test(tls): stabilize cert hot-reload test under CI overlayfs (inotify drop)

### DIFF
--- a/integrationTests/security/cert-reload.test.ts
+++ b/integrationTests/security/cert-reload.test.ts
@@ -127,6 +127,19 @@ suite('TLS certificate hot-reload propagates to all workers (#586)', { skip: ski
 					privateKey: keyPath,
 				},
 			},
+			// Force the main-thread cert-file watcher (chokidar, in security/keys.ts) to poll the
+			// file instead of relying on native fs.watch/inotify. The GitHub Actions Linux runners
+			// back the temp dir with overlayfs/tmpfs, which silently DROPS inotify change events —
+			// so the on-disk cert swap below was intermittently never detected and the reload never
+			// fired, making this test time out ("cert never reloaded ... after 20s"). chokidar reads
+			// CHOKIDAR_USEPOLLING / CHOKIDAR_INTERVAL as process-global overrides (honored by every
+			// watcher in-process regardless of dependency depth), so this swaps detection to a stat
+			// poll that is immune to the inotify drop. It only changes HOW the swap is detected — the
+			// regression assertion (every worker serves the renewed cert) is unchanged, and the
+			// product still uses native watching by default. The integration-testing harness merges
+			// `env` into the spawned Harper process (harperLifecycle.js), so the override reaches the
+			// main thread that owns the watcher. 250ms keeps detection well within the 20s budget.
+			env: { CHOKIDAR_USEPOLLING: '1', CHOKIDAR_INTERVAL: '250' },
 		});
 	});
 


### PR DESCRIPTION
## Summary
Stabilizes the TLS cert hot-reload integration test (`integrationTests/security/cert-reload.test.ts`, regression for #586) by forcing the main-thread cert-file watcher to poll instead of relying on native inotify. One-line change: adds `env: { CHOKIDAR_USEPOLLING: '1', CHOKIDAR_INTERVAL: '250' }` to the test's `setupHarperWithFixture` options.

## Why
This test is the dominant recurring flake in `HarperFast/harper` — it fails on integration **shard 1/6** across Node **v22 / v24 / v26** on many PRs, blocking clean CI signal.

Root cause: the GitHub Actions Linux runners back the temp dir with **overlayfs/tmpfs, which silently drops inotify change events**. The cert watcher in `security/keys.ts` (`watch(path, { persistent: false })`, chokidar) therefore never sees the on-disk cert swap, the reload never fires, and the test times out:

```
AssertionError: cert never reloaded — still serving 03E9 after 20s
```

The feature itself works (the watcher writes to `system.hdb_certificate`, each worker subscribes and rebuilds its TLS context) — this is purely a CI-environment detection problem. chokidar 4.0.3 reads `CHOKIDAR_USEPOLLING` / `CHOKIDAR_INTERVAL` as process-global overrides, so switching to a stat-based poll makes detection immune to the inotify drop. The integration-testing harness merges `env` into the spawned Harper process, so the override reaches the main thread that owns the watcher.

This only changes **how** the swap is detected — the regression coverage ("every worker serves the renewed cert after a swap", 40 fresh handshakes, zero stale serials) is **unchanged**. Production still uses native watching by default.

## Relationship to prior PRs
- **Supersedes the closed #1392**, which took the same polling approach but was abandoned partly because a staleness-guard field-name mismatch in `loadCertificates()` rejected the reload even once detection fired.
- That guard bug was fixed and shipped in **#1408** ("persist and read certificate `file_timestamp` for staleness guard", confirmed present at `security/keys.ts` lines ~244–269 on this base). With #1408 in, the polling path now works **end-to-end**.
- Independent of the in-flight **#1394** (production periodic re-read safety net) — that's a product-robustness fix; this is test stability only.

## Where to look / caveats
- The whole change is the `env` line + its comment.
- **Local runs cannot reproduce the overlayfs inotify drop** (local fs delivers inotify fine), so local green is necessary but not sufficient proof. The real fix is that detection no longer depends on an inotify event firing at all — it now polls. Local: **5/5 passes**, detection consistently ~4.6s (vs. the variable, sometimes-never inotify path), well inside the 20s budget.
- Candidate for the in-flight **5.1.7** release (test-only, low risk).

Generated by Claude (Opus 4.8); reviewed via cross-model (Codex) — no blockers.