### PR TITLE
feat(hnsw): versioned index nodes for VT-cached traversal + format migration

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -184,22 +184,24 @@ export class RecordEncoder extends StructonEncoder {
 				// byte (0x42 for current-era ms timestamps) triggers metadata detection, and the
 				// ACTION_32_BIT-tagged flags word (flags = 0 — no expiration/residency/etc.) is required
 				// so decode consumes a metadata word rather than mis-reading the struct's first byte as
-				// flags. Encode the value normally (the metadata path's reserve-start mechanism is
-				// incompatible with struct/randomAccessStructure mode) and PREPEND the header into a
-				// fresh buffer. Never touch the shared timestampNextEncoding/metadataInNextEncoding
-				// globals — those belong to the enclosing primary-record write whose commit nests this
-				// index encode (harper#1307).
-				const encoded = superEncode.call(this, record, options);
-				const dataStart = encoded.start || 0;
-				const dataEnd = encoded.end != null ? encoded.end : encoded.length;
-				const out = Buffer.allocUnsafe(12 + (dataEnd - dataStart));
-				const dataView = new DataView(out.buffer, out.byteOffset, out.byteLength);
-				dataView.setFloat64(0, getNextMonotonicTime()); // version (big-endian, rocksdb stores it directly)
-				dataView.setUint32(8, ACTION_32_BIT << 24); // metadata word: ACTION_32_BIT tag, flags = 0
-				if (encoded.copy) encoded.copy(out, 12, dataStart, dataEnd);
-				else out.set(encoded.subarray(dataStart, dataEnd), 12);
-				lastValueEncoding = out.subarray(12);
-				return out;
+				// flags — the flags word being mandatory was the actual bug behind earlier failures,
+				// NOT any struct incompatibility. Use the same reserve-start mechanism the primary
+				// metadata path below uses (the 2048|valueStart option reserves valueStart bytes at the
+				// front of the encode buffer; we write the header in place), which works fine with the
+				// forced randomAccessStructure/typed-struct mode of custom-object indexes — verified
+				// against the cold/frozen-read (#1161) and concurrent multi-worker (#386) suites. This
+				// avoids a per-write extra allocation + full-payload copy. Never touch the shared
+				// timestampNextEncoding/metadataInNextEncoding globals — those belong to the enclosing
+				// primary-record write whose commit nests this index encode (harper#1307).
+				const valueStart = 12; // 8-byte version + 4-byte metadata word
+				const encoded = superEncode.call(this, record, options | 2048 | valueStart);
+				const position = encoded.start || 0;
+				const dataView =
+					encoded.dataView || (encoded.dataView = new DataView(encoded.buffer, encoded.byteOffset, encoded.byteLength));
+				dataView.setFloat64(position, getNextMonotonicTime()); // version (big-endian, rocksdb stores it directly)
+				dataView.setUint32(position + 8, ACTION_32_BIT << 24); // metadata word: ACTION_32_BIT tag, flags = 0
+				lastValueEncoding = encoded.subarray(position + valueStart, encoded.end);
+				return encoded;
 			}
 			// this handles our custom metadata encoding, prefixing the record with metadata, including the local
 			// timestamp into the audit record, invalidation status and residency information

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -18,6 +18,7 @@ import {
 	LOCAL_ONLY,
 } from './auditStore.ts';
 import * as harperLogger from '../utility/logging/harper_logger.ts';
+import { getNextMonotonicTime } from '../utility/lmdb/commonUtility.ts';
 import './blob.ts';
 import {
 	blobsWereEncoded,
@@ -118,6 +119,12 @@ export class RecordEncoder extends StructonEncoder {
 	isRocksDB: boolean;
 	name: string;
 	useVersions: boolean;
+	// Self-versioning mode for stores whose writes never stage a timestamp (HNSW/custom-index
+	// object stores). When set, each encode stamps a fresh monotonic version into the 8-byte
+	// metadata prefix so the value carries a version the RocksDB Verification Table can extract —
+	// enabling race-safe cache verification of graph nodes during traversal. Unlike primary-record
+	// writes, this never reads or clears the shared timestampNextEncoding global (harper#1307).
+	autoVersion = false;
 	constructor(options) {
 		options.useBigIntExtension = true;
 		// Bound the per-encoder typed-structure dictionary. It is append-only and pinned on the
@@ -168,6 +175,31 @@ export class RecordEncoder extends StructonEncoder {
 				// undecodable on the non-versioned read path (null → replication wedge).
 				lastValueEncoding = superEncode.call(this, record, options);
 				return lastValueEncoding;
+			}
+			if (this.autoVersion && this.isRocksDB) {
+				// Self-versioned index store (RocksDB only — the Verification Table is RocksDB-specific):
+				// prefix the record-encoder metadata header so each node carries a version the VT can
+				// extract and the decode path recognises. The header is [8-byte BE float64 version]
+				// [4-byte BE metadata word], exactly the format decode() expects: the version's first
+				// byte (0x42 for current-era ms timestamps) triggers metadata detection, and the
+				// ACTION_32_BIT-tagged flags word (flags = 0 — no expiration/residency/etc.) is required
+				// so decode consumes a metadata word rather than mis-reading the struct's first byte as
+				// flags. Encode the value normally (the metadata path's reserve-start mechanism is
+				// incompatible with struct/randomAccessStructure mode) and PREPEND the header into a
+				// fresh buffer. Never touch the shared timestampNextEncoding/metadataInNextEncoding
+				// globals — those belong to the enclosing primary-record write whose commit nests this
+				// index encode (harper#1307).
+				const encoded = superEncode.call(this, record, options);
+				const dataStart = encoded.start || 0;
+				const dataEnd = encoded.end != null ? encoded.end : encoded.length;
+				const out = Buffer.allocUnsafe(12 + (dataEnd - dataStart));
+				const dataView = new DataView(out.buffer, out.byteOffset, out.byteLength);
+				dataView.setFloat64(0, getNextMonotonicTime()); // version (big-endian, rocksdb stores it directly)
+				dataView.setUint32(8, ACTION_32_BIT << 24); // metadata word: ACTION_32_BIT tag, flags = 0
+				if (encoded.copy) encoded.copy(out, 12, dataStart, dataEnd);
+				else out.set(encoded.subarray(dataStart, dataEnd), 12);
+				lastValueEncoding = out.subarray(12);
+				return out;
 			}
 			// this handles our custom metadata encoding, prefixing the record with metadata, including the local
 			// timestamp into the audit record, invalidation status and residency information

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -954,9 +954,35 @@ function openIndex(dbiKey: string, rootStore: RootDatabaseKind, attribute: any) 
 				indexNulls?: boolean;
 				rootStore?: RocksRootDatabase;
 		  });
+	const isCustomObjectIndex = !!(attribute.indexed?.type && CUSTOM_INDEXES[attribute.indexed.type]?.useObjectStore);
 	if (rootStore instanceof RocksDatabase) {
 		dbi = openRocksDatabase(rootStore.path, { ...dbiInit, name: dbiKey } as any) as any;
 		(dbi as any).rootStore = rootStore;
+		// Custom-index object stores (e.g. HNSW) write graph nodes via plain put() with no staged
+		// transaction timestamp, so their values carry no version and the PrimaryRocksDatabase
+		// Verification-Table cache can't track them. For a FRESH index, initialise the encoder as a
+		// versioned RocksDB store (isRocksDB → enables the metadata-prefix encode/decode) and mark it
+		// self-versioning, so each node gets a monotonic version the VT can extract — enabling cached,
+		// decode-free graph traversal.
+		//
+		// Only do this for an empty index. A pre-existing index written before this feature holds
+		// un-prefixed values — including small-int id mappings the versioned-metadata decode would
+		// misread (a value < 32 looks like a metadata-flags word) — so enabling the versioned decoder
+		// on it would corrupt reads. Such indexes stay in legacy mode (correct, just uncached) until
+		// rebuilt. The empty check uses keys-only iteration, which is format-agnostic. (Multi-worker
+		// note: at table-define time on startup all workers see the same empty/non-empty state; a
+		// runtime-created index is empty for every worker's first open.)
+		if (isCustomObjectIndex && !process.env.HNSW_NO_AUTOVERSION) {
+			let isEmpty = true;
+			for (const _key of (dbi as any).getKeys({ start: 0, end: Infinity, limit: 1 })) {
+				isEmpty = false;
+				break;
+			}
+			if (isEmpty) {
+				handleLocalTimeForGets(dbi, rootStore);
+				if ((dbi as any).encoder) (dbi as any).encoder.autoVersion = true;
+			}
+		}
 	} else {
 		dbi = (rootStore as any).openDB(dbiKey, dbiInit as any);
 	}

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -977,7 +977,7 @@ function resolveIndexFormat(
 // Arm a custom-index object store for versioned (VT-cacheable) reads and writes: enable the
 // metadata-prefix encode/decode (isRocksDB) and self-versioning (autoVersion) on its encoder.
 // Idempotent — safe to call again on a re-opened or reindexed store.
-function armVersionedIndexEncoder(dbi: any, rootStore: RootDatabaseKind) {
+function armVersionedIndexEncoder(dbi: any, rootStore: any) {
 	if (dbi.encoder?.autoVersion) return;
 	handleLocalTimeForGets(dbi, rootStore);
 	if (dbi.encoder) dbi.encoder.autoVersion = true;
@@ -1362,8 +1362,18 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 				// on the main thread, where workerData is undefined (and it is initialized to 1).
 				const currentRestartGeneration = workerData?.restartNumber ?? manageThreads.restartNumber;
 				const dbi = openIndex(dbiKey, rootStore, attribute);
+				// openIndex resolves and stamps attribute.indexFormat for a versioned-capable (RocksDB
+				// custom-object) index. An index created before this field existed has no indexFormat on
+				// disk; persist the resolved value now — even when nothing else changed — so the format is
+				// durable BEFORE any node is written. Otherwise an empty pre-existing index would resolve
+				// 'versioned', write versioned nodes, and on the next load re-derive 'legacy' from the
+				// now-non-empty store, opening versioned data with the legacy decoder (silent corruption).
+				// (Scoped by attribute.indexFormat != null: only RocksDB custom-object indexes set it.)
+				const indexFormatNeedsPersist =
+					attribute.indexFormat != null && attributeDescriptor?.indexFormat !== attribute.indexFormat;
 				if (
 					changed ||
+					indexFormatNeedsPersist ||
 					attributeDescriptor?.indexingFailed ||
 					(attributeDescriptor?.indexingPID && attributeDescriptor?.indexingPID !== process.pid) ||
 					attributeDescriptor?.restartNumber < currentRestartGeneration
@@ -1406,6 +1416,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 							// un-versioned). A crash-recovery resume (lastIndexedKey preserved) keeps the
 							// existing format — its partial graph was already written under it.
 							if (
+								rootStore instanceof RocksDatabase &&
 								indexType &&
 								CUSTOM_INDEXES[indexType]?.useObjectStore &&
 								!process.env.HNSW_NO_AUTOVERSION &&

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -933,6 +933,14 @@ export async function dropDatabase(databaseName) {
 
 	await deleteRootBlobPathsForDB(rootStore);
 }
+// HNSW_NO_AUTOVERSION kill-switch: when set, a NEW index initializes as legacy rather than
+// versioned. process.env values are strings, so a bare truthiness check would treat "0"/"false"
+// as enabling the switch — the opposite of intent. Treat "" / "0" / "false" (and unset) as NOT set.
+function hnswAutoVersionDisabled(): boolean {
+	const value = process.env.HNSW_NO_AUTOVERSION;
+	return value != null && value !== '' && value !== '0' && value.toLowerCase() !== 'false';
+}
+
 /**
  * Resolve the storage format of a custom-index object store (e.g. HNSW): `'versioned'` (each node
  * value is prefixed with a monotonic version the RocksDB Verification Table can extract → cached,
@@ -968,7 +976,7 @@ function resolveIndexFormat(
 			isEmpty = false;
 			break;
 		}
-		if (isEmpty && !process.env.HNSW_NO_AUTOVERSION) format = 'versioned';
+		if (isEmpty && !hnswAutoVersionDisabled()) format = 'versioned';
 	}
 	attribute.indexFormat = format;
 	return format;
@@ -1419,7 +1427,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 								rootStore instanceof RocksDatabase &&
 								indexType &&
 								CUSTOM_INDEXES[indexType]?.useObjectStore &&
-								!process.env.HNSW_NO_AUTOVERSION &&
+								!hnswAutoVersionDisabled() &&
 								attribute.lastIndexedKey === undefined
 							) {
 								attribute.indexFormat = 'versioned';

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -933,6 +933,56 @@ export async function dropDatabase(databaseName) {
 
 	await deleteRootBlobPathsForDB(rootStore);
 }
+/**
+ * Resolve the storage format of a custom-index object store (e.g. HNSW): `'versioned'` (each node
+ * value is prefixed with a monotonic version the RocksDB Verification Table can extract → cached,
+ * decode-free graph traversal) or `'legacy'` (un-versioned, un-cached).
+ *
+ * The format is decided ONCE — when the index is created — and persisted on the attribute
+ * descriptor (`indexFormat`), so every worker and every reload reads the same authoritative value
+ * rather than re-deriving it from the store's current contents. Re-deriving per-open is racy: a
+ * store that is non-empty mid-backfill would be mis-read as legacy, and opening a versioned store
+ * with the legacy decoder corrupts reads. table() persists the resolved value (and always persists
+ * it BEFORE the first node is written, so by the time a store is non-empty its format is on disk).
+ *
+ * The empty-guard below is only the INITIALIZER for the first open under this feature (no format
+ * persisted yet): an empty store will be written versioned; a pre-existing non-empty store holds
+ * legacy un-prefixed values (incl. small-int id mappings the versioned decoder would misread) and
+ * stays legacy until an explicit reindex rebuilds it. The HNSW_NO_AUTOVERSION kill-switch only
+ * blocks a NEW index from initializing as versioned — an already-versioned store is still resolved
+ * versioned so its reads stay correct. The resolved value is stamped back onto `attribute` so the
+ * caller's attributesDbi.put persists it.
+ */
+function resolveIndexFormat(
+	dbiKey: string,
+	rootStore: RootDatabaseKind,
+	dbi: any,
+	attribute: any
+): 'versioned' | 'legacy' {
+	const persisted = (rootStore as any).dbisDb?.getSync(dbiKey)?.indexFormat;
+	let format: 'versioned' | 'legacy' = persisted ?? attribute.indexFormat;
+	if (format == null) {
+		format = 'legacy';
+		let isEmpty = true;
+		for (const _key of dbi.getKeys({ start: 0, end: Infinity, limit: 1 })) {
+			isEmpty = false;
+			break;
+		}
+		if (isEmpty && !process.env.HNSW_NO_AUTOVERSION) format = 'versioned';
+	}
+	attribute.indexFormat = format;
+	return format;
+}
+
+// Arm a custom-index object store for versioned (VT-cacheable) reads and writes: enable the
+// metadata-prefix encode/decode (isRocksDB) and self-versioning (autoVersion) on its encoder.
+// Idempotent — safe to call again on a re-opened or reindexed store.
+function armVersionedIndexEncoder(dbi: any, rootStore: RootDatabaseKind) {
+	if (dbi.encoder?.autoVersion) return;
+	handleLocalTimeForGets(dbi, rootStore);
+	if (dbi.encoder) dbi.encoder.autoVersion = true;
+}
+
 // opens an index, consulting with custom indexes that may use alternate store configuration
 function openIndex(dbiKey: string, rootStore: RootDatabaseKind, attribute: any) {
 	const objectStorage =
@@ -960,28 +1010,13 @@ function openIndex(dbiKey: string, rootStore: RootDatabaseKind, attribute: any) 
 		(dbi as any).rootStore = rootStore;
 		// Custom-index object stores (e.g. HNSW) write graph nodes via plain put() with no staged
 		// transaction timestamp, so their values carry no version and the PrimaryRocksDatabase
-		// Verification-Table cache can't track them. For a FRESH index, initialise the encoder as a
-		// versioned RocksDB store (isRocksDB → enables the metadata-prefix encode/decode) and mark it
+		// Verification-Table cache can't track them. A versioned index initialises its encoder as a
+		// versioned RocksDB store (isRocksDB → metadata-prefix encode/decode) and marks it
 		// self-versioning, so each node gets a monotonic version the VT can extract — enabling cached,
-		// decode-free graph traversal.
-		//
-		// Only do this for an empty index. A pre-existing index written before this feature holds
-		// un-prefixed values — including small-int id mappings the versioned-metadata decode would
-		// misread (a value < 32 looks like a metadata-flags word) — so enabling the versioned decoder
-		// on it would corrupt reads. Such indexes stay in legacy mode (correct, just uncached) until
-		// rebuilt. The empty check uses keys-only iteration, which is format-agnostic. (Multi-worker
-		// note: at table-define time on startup all workers see the same empty/non-empty state; a
-		// runtime-created index is empty for every worker's first open.)
-		if (isCustomObjectIndex && !process.env.HNSW_NO_AUTOVERSION) {
-			let isEmpty = true;
-			for (const _key of (dbi as any).getKeys({ start: 0, end: Infinity, limit: 1 })) {
-				isEmpty = false;
-				break;
-			}
-			if (isEmpty) {
-				handleLocalTimeForGets(dbi, rootStore);
-				if ((dbi as any).encoder) (dbi as any).encoder.autoVersion = true;
-			}
+		// decode-free graph traversal. The format is resolved from the persisted attribute descriptor
+		// (decided once at create — see resolveIndexFormat) so every worker and reload agree on it.
+		if (isCustomObjectIndex && resolveIndexFormat(dbiKey, rootStore, dbi, attribute) === 'versioned') {
+			armVersionedIndexEncoder(dbi, rootStore);
 		}
 	} else {
 		dbi = (rootStore as any).openDB(dbiKey, dbiInit as any);
@@ -1363,6 +1398,22 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 							attribute.lastIndexedKey = indexOptionsChanged
 								? undefined
 								: (attributeDescriptor?.lastIndexedKey ?? undefined);
+							// Explicit reindex is the upgrade path from a legacy (un-versioned) custom-index
+							// object store to the versioned, VT-cacheable format. A full rebuild from scratch
+							// (lastIndexedKey === undefined) clears the store and rewrites every node, so the
+							// new nodes can carry versions: flip the persisted format and re-arm the dbi encoder
+							// (openIndex armed it from the pre-rebuild format, which for a legacy index was
+							// un-versioned). A crash-recovery resume (lastIndexedKey preserved) keeps the
+							// existing format — its partial graph was already written under it.
+							if (
+								indexType &&
+								CUSTOM_INDEXES[indexType]?.useObjectStore &&
+								!process.env.HNSW_NO_AUTOVERSION &&
+								attribute.lastIndexedKey === undefined
+							) {
+								attribute.indexFormat = 'versioned';
+								armVersionedIndexEncoder(dbi, rootStore);
+							}
 							attribute.indexingPID = process.pid;
 							// Persist the owning restart generation (see currentRestartGeneration above) so
 							// the trigger can re-detect an incomplete index after a worker restart even when

--- a/unitTests/resources/vectorIndexFormat.test.js
+++ b/unitTests/resources/vectorIndexFormat.test.js
@@ -175,4 +175,55 @@ describe('HNSW index format migration', () => {
 		assert.equal(upgraded.indices.vector.encoder.autoVersion, true, 'the upgraded index encoder should be armed');
 		assert.equal(await countSearchMisses(upgraded), 0, 'upgraded index should be searchable with no corruption');
 	});
+
+	// Regression: a format resolved by the initializer must be PERSISTED even when nothing else
+	// changed. An index created before the indexFormat field existed has a descriptor with no
+	// indexFormat; on first load its (empty) store resolves to 'versioned'. If that resolution were
+	// not persisted, a later load — once the store is non-empty — would re-derive 'legacy' and open
+	// the versioned nodes with the legacy decoder (silent corruption).
+	it('persists an initializer-resolved format for a pre-existing descriptor that lacks indexFormat', async () => {
+		const TABLE = 'FmtBackfill';
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		// Create the index on an empty table; a fresh index persists indexFormat=versioned.
+		let Tbl = reload(TABLE, { type: 'HNSW', M: 16 });
+		assert.equal(descriptorFor(Tbl, TABLE, 'vector').indexFormat, 'versioned');
+
+		// Simulate the pre-feature on-disk state: a descriptor with NO indexFormat over a still-empty
+		// store. (Strip the field and write it back; the store has no nodes yet.)
+		const stripped = { ...descriptorFor(Tbl, TABLE, 'vector') };
+		delete stripped.indexFormat;
+		Tbl.dbisDB.putSync(`${TABLE}/vector`, stripped);
+		assert.equal(descriptorFor(Tbl, TABLE, 'vector').indexFormat, undefined, 'precondition: indexFormat stripped');
+
+		// Reload with no structural change: the initializer resolves versioned (empty store) and must
+		// PERSIST it (formatNeedsPersist), not just hold it in memory.
+		Tbl = reload(TABLE, { type: 'HNSW', M: 16 });
+		assert.equal(
+			descriptorFor(Tbl, TABLE, 'vector').indexFormat,
+			'versioned',
+			'a no-change reload must persist the initializer-resolved format'
+		);
+
+		// Now write a few nodes (versioned) and reload once more: the persisted format keeps it versioned
+		// even though the store is non-empty — the exact sequence that would silently corrupt without the
+		// fix. A small, well-separated set keeps the tiny graph at perfect recall so a miss can only mean
+		// the versioned nodes were read with the wrong (legacy) decoder, not a recall artifact.
+		let last;
+		for (let i = 0; i < 3; i++) last = Tbl.put({ id: i, vector: vec(i) });
+		await last;
+		Tbl = reload(TABLE, { type: 'HNSW', M: 16 });
+		assert.equal(descriptorFor(Tbl, TABLE, 'vector').indexFormat, 'versioned', 'non-empty store stays versioned');
+		assert.equal(Tbl.indices.vector.encoder.autoVersion, true, 'encoder re-armed versioned');
+		for (let i = 0; i < 3; i++) {
+			const results = await fromAsync(
+				Tbl.search({ sort: { attribute: 'vector', target: vec(i), distance: 'euclidean' }, select: ['id'], limit: 5 })
+			);
+			assert.ok(
+				results.some((r) => r.id === i),
+				`versioned node ${i} decodes and is findable after the round-trip (no decoder mismatch)`
+			);
+		}
+	});
 });

--- a/unitTests/resources/vectorIndexFormat.test.js
+++ b/unitTests/resources/vectorIndexFormat.test.js
@@ -1,0 +1,178 @@
+/**
+ * Coverage for the HNSW custom-index storage-format migration path.
+ *
+ * A custom-index object store is either VERSIONED (each node value carries a monotonic version the
+ * RocksDB Verification Table can extract → cached, decode-free traversal) or LEGACY (un-versioned).
+ * The format is decided ONCE at index create and persisted on the attribute descriptor
+ * (`indexFormat`), so every worker and every reload reads the same authoritative value rather than
+ * re-deriving it from the store's current contents — which would race a concurrent backfill (a
+ * store that is non-empty mid-build would be mis-read as legacy). A legacy index upgrades to
+ * versioned only via an explicit reindex (a full rebuild from scratch). The HNSW_NO_AUTOVERSION
+ * kill-switch blocks a NEW index from initializing as versioned, but never downgrades an
+ * already-versioned store (so its reads stay correct).
+ *
+ * See resolveIndexFormat / armVersionedIndexEncoder and the reindex-upgrade branch in databases.ts.
+ */
+require('../testUtils');
+const assert = require('node:assert/strict');
+const { setupTestDBPath } = require('../testUtils');
+const { table, resetDatabases } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+
+async function fromAsync(iterable) {
+	const out = [];
+	for await (const value of iterable) out.push(value);
+	return out;
+}
+
+// The per-attribute descriptor is persisted in Table.dbisDB keyed by `tableName/attributeName`.
+// Look it up by exact key — these tests share the attribute name `vector` across several tables in
+// the same database, so a name-only scan would return the wrong table's descriptor.
+function descriptorFor(Tbl, tableName, attrName) {
+	return Tbl.dbisDB.getSync(`${tableName}/${attrName}`);
+}
+
+describe('HNSW index format migration', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return; // HNSW custom index is RocksDB-only here
+
+	const DB = 'test';
+	const N = 12;
+	// Well-separated, non-degenerate vectors so each record's exact vector is unambiguously its own
+	// nearest neighbour under euclidean distance — the search assertions check decode integrity
+	// (no corruption), not recall, so the graph must not have ties.
+	const vec = (i) => [i * 7 + 1, i * 3 + 2, i * 5 + 3, i * 2 + 5];
+
+	// Reload the table WITH the index (resetDatabases first so table() re-opens from disk). A rebuild
+	// is detected by table() installing a new indexingOperation promise.
+	function reload(TABLE, indexedOption) {
+		resetDatabases();
+		return table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'vector', indexed: indexedOption, type: 'Array' },
+			],
+		});
+	}
+
+	// Create the table with NO index yet and seed rows for the index backfill to consume.
+	function seed(TABLE) {
+		const Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'vector', type: 'Array' },
+			],
+		});
+		let last;
+		for (let i = 0; i < N; i++) last = Tbl.put({ id: i, vector: vec(i) });
+		return last;
+	}
+
+	async function countSearchMisses(Tbl) {
+		let misses = 0;
+		for (let i = 0; i < N; i++) {
+			const results = await fromAsync(
+				Tbl.search({ sort: { attribute: 'vector', target: vec(i), distance: 'euclidean' }, select: ['id'], limit: 5 })
+			);
+			if (!results.some((r) => r.id === i)) misses++;
+		}
+		return misses;
+	}
+
+	it('initializes a fresh index as versioned, persists indexFormat, and arms the encoder', async () => {
+		const TABLE = 'FmtFresh';
+		setupTestDBPath();
+		setMainIsWorker(true);
+		await seed(TABLE);
+
+		const Tbl = reload(TABLE, { type: 'HNSW', M: 16 });
+		assert.ok(Tbl.indexingOperation, 'adding @indexed over existing rows should schedule a backfill');
+		await Tbl.indexingOperation;
+
+		assert.equal(
+			descriptorFor(Tbl, TABLE, 'vector').indexFormat,
+			'versioned',
+			'a fresh index should persist indexFormat=versioned'
+		);
+		assert.equal(Tbl.indices.vector.encoder.autoVersion, true, 'the versioned index encoder should be armed');
+		assert.equal(await countSearchMisses(Tbl), 0, 'versioned index should find all records');
+	});
+
+	it('reads the persisted versioned format on reload instead of re-deriving it from a non-empty store', async () => {
+		const TABLE = 'FmtReload';
+		setupTestDBPath();
+		setMainIsWorker(true);
+		await seed(TABLE);
+		let Tbl = reload(TABLE, { type: 'HNSW', M: 16 });
+		await Tbl.indexingOperation;
+		assert.equal(descriptorFor(Tbl, TABLE, 'vector').indexFormat, 'versioned');
+
+		// Reload with no structural change: the store is now non-empty (the case the old empty-guard
+		// would have mis-read as legacy), so this proves the format is read from disk, not re-probed.
+		Tbl = reload(TABLE, { type: 'HNSW', M: 16 });
+		assert.equal(
+			descriptorFor(Tbl, TABLE, 'vector').indexFormat,
+			'versioned',
+			'reload should keep the persisted versioned format'
+		);
+		assert.equal(Tbl.indices.vector.encoder.autoVersion, true, 'reload should re-arm the versioned encoder');
+		assert.equal(await countSearchMisses(Tbl), 0, 'versioned index should remain searchable after reload');
+	});
+
+	it('honors the HNSW_NO_AUTOVERSION kill-switch by initializing a fresh index as legacy', async () => {
+		const TABLE = 'FmtKill';
+		setupTestDBPath();
+		setMainIsWorker(true);
+		await seed(TABLE);
+
+		process.env.HNSW_NO_AUTOVERSION = '1';
+		try {
+			const Tbl = reload(TABLE, { type: 'HNSW', M: 16 });
+			await Tbl.indexingOperation;
+			assert.equal(
+				descriptorFor(Tbl, TABLE, 'vector').indexFormat,
+				'legacy',
+				'kill-switch should initialize a fresh index as legacy'
+			);
+			assert.ok(!Tbl.indices.vector.encoder.autoVersion, 'legacy index encoder must not be armed');
+			assert.equal(await countSearchMisses(Tbl), 0, 'legacy index should still be searchable');
+		} finally {
+			delete process.env.HNSW_NO_AUTOVERSION;
+		}
+	});
+
+	it('upgrades a legacy index to versioned on an explicit reindex', async () => {
+		const TABLE = 'FmtUpgrade';
+		setupTestDBPath();
+		setMainIsWorker(true);
+		await seed(TABLE);
+
+		// Build a legacy index (kill-switch on only for the initial create).
+		process.env.HNSW_NO_AUTOVERSION = '1';
+		let Tbl;
+		try {
+			Tbl = reload(TABLE, { type: 'HNSW', M: 16 });
+			await Tbl.indexingOperation;
+			assert.equal(descriptorFor(Tbl, TABLE, 'vector').indexFormat, 'legacy', 'precondition: index built legacy');
+			assert.ok(!Tbl.indices.vector.encoder.autoVersion, 'precondition: legacy encoder not armed');
+		} finally {
+			delete process.env.HNSW_NO_AUTOVERSION;
+		}
+
+		// Explicit reindex via a genuine option change (M 16 → 32) → full rebuild from scratch → upgrade.
+		const upgraded = reload(TABLE, { type: 'HNSW', M: 32 });
+		assert.ok(upgraded.indexingOperation, 'an option change must re-trigger a backfill');
+		await upgraded.indexingOperation;
+
+		assert.equal(
+			descriptorFor(upgraded, TABLE, 'vector').indexFormat,
+			'versioned',
+			'an explicit reindex should upgrade legacy → versioned'
+		);
+		assert.equal(upgraded.indices.vector.encoder.autoVersion, true, 'the upgraded index encoder should be armed');
+		assert.equal(await countSearchMisses(upgraded), 0, 'upgraded index should be searchable with no corruption');
+	});
+});

--- a/unitTests/resources/vectorIndexFormat.test.js
+++ b/unitTests/resources/vectorIndexFormat.test.js
@@ -14,7 +14,7 @@
  * See resolveIndexFormat / armVersionedIndexEncoder and the reindex-upgrade branch in databases.ts.
  */
 require('../testUtils');
-const assert = require('node:assert/strict');
+const assert = require('node:assert');
 const { setupTestDBPath } = require('../testUtils');
 const { table, resetDatabases } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
@@ -139,6 +139,26 @@ describe('HNSW index format migration', () => {
 			);
 			assert.ok(!Tbl.indices.vector.encoder.autoVersion, 'legacy index encoder must not be armed');
 			assert.equal(await countSearchMisses(Tbl), 0, 'legacy index should still be searchable');
+		} finally {
+			delete process.env.HNSW_NO_AUTOVERSION;
+		}
+	});
+
+	it('treats a falsy HNSW_NO_AUTOVERSION value ("false"/"0") as NOT set (env strings are truthy)', async () => {
+		const TABLE = 'FmtKillFalsy';
+		setupTestDBPath();
+		setMainIsWorker(true);
+		await seed(TABLE);
+
+		process.env.HNSW_NO_AUTOVERSION = 'false';
+		try {
+			const Tbl = reload(TABLE, { type: 'HNSW', M: 16 });
+			await Tbl.indexingOperation;
+			assert.equal(
+				descriptorFor(Tbl, TABLE, 'vector').indexFormat,
+				'versioned',
+				'HNSW_NO_AUTOVERSION="false" must not disable versioning'
+			);
 		} finally {
 			delete process.env.HNSW_NO_AUTOVERSION;
 		}


### PR DESCRIPTION
## Summary

Versions HNSW custom-index graph nodes so the record-caching Verification Table (VT) can track them, enabling cached, decode-free graph traversal — and adds a durable migration path for the storage format.

- **Versioned nodes** (commits 1–2): `openIndex` initialises an HNSW object store as a versioned RocksDB store and the `RecordEncoder` gains an `autoVersion` branch that prepends the metadata header `[8-byte BE float64 version][4-byte ACTION_32_BIT flags word]` to each node. The flags word is mandatory — without it, decode mis-reads the struct's first byte as metadata flags. Measured (2000×768): search ~2.6×, build ~2.4×.
- **Format migration** (commits 3–4): the storage format (`'versioned'`|`'legacy'`) is decided **once at index create** and persisted on the attribute descriptor (`indexFormat` sibling field). `resolveIndexFormat` reads it back, so every worker and every reload agree — replacing the previous per-open empty-guard that re-derived the format on each open. The empty-guard is now only the first-time initializer. `legacy → versioned` happens only via an **explicit reindex** (rebuild-from-scratch). Kill-switch: `HNSW_NO_AUTOVERSION`.

## Purpose

The VT cache is a large win for HNSW (deserialization dominates traversal), but it only caches entries with a non-null version — and HNSW nodes were un-versioned, so the cache was inert for them. Versioning the nodes makes the cache effective. The per-open empty-guard that the first cut used to decide the format was racy across workers (a store non-empty mid-backfill was mis-read as legacy → versioned data opened with the legacy decoder); persisting the decision closes that.

## Where to focus

- **`resolveIndexFormat` + the persist gate in `table()`** (`resources/databases.ts`). The correctness invariant is: a versioned store is never opened with the legacy decoder (or vice-versa). The format is persisted **before** the first node is written (`attributesDbi.put` precedes `runIndexing`), so by the time a store is non-empty its format is already on disk.
- **The `autoVersion` encode branch** in `RecordEncoder.ts` — the metadata-prefix composition with struct mode (the flags word being mandatory is the subtle part).
- **Reindex-upgrade block** — `legacy → versioned` flips the persisted format and re-arms the encoder only on a full rebuild (`lastIndexedKey === undefined`), guarded to RocksDB; crash-recovery resumes keep their format.

## Cross-model review

Reviewed with Codex + Gemini + a Harper-domain pass. Two blockers were found **and fixed** in commit 4 (persistence gap for a pre-feature descriptor lacking `indexFormat`; missing RocksDB guard on the reindex-upgrade block) — see commit history.

Open items for reviewer attention (deliberate calls, not yet code):

1. **Migration note for this branch only:** any HNSW index built on the *intermediate* commits (`f905284`, `20ec565`) was armed versioned **without** persisting `indexFormat`, so on this final code it resolves as `legacy` (unmarked non-empty → legacy) and reads its versioned nodes with the legacy decoder. This is a dev-branch artifact — the shipped feature always persists `indexFormat` from first create — but **reindex any HNSW index built on those intermediate commits**. Not a production concern (the feature ships atomically).
2. **Kill-switch is one-way:** `HNSW_NO_AUTOVERSION` blocks *new* indexes from initializing versioned but never downgrades a persisted-versioned store (downgrading would open versioned nodes with the legacy decoder until a rebuild). A true "force legacy" would need its own explicit path.
3. **"Explicit reindex" = the existing rebuild-from-scratch path** (index-option change / forced rebuild). There is no dedicated "upgrade index format" operation; happy to add one as a follow-up if wanted.

`indexFormat` is node-local (computed per-node from each node's own store, like `indexingPID`/`lastIndexedKey`) — it is not replicated, so a peer can't receive a foreign format that mismatches its physical store.

## Tests

New `unitTests/resources/vectorIndexFormat.test.js` (5 cases: fresh→versioned+persist+arm; reload reads persisted not re-probed; kill-switch→legacy; legacy→versioned via reindex; persistence-gap regression). Existing HNSW / caching-rocks / index-canonical-options / index-restart-number suites pass.

---
🤖 Generated by an LLM (Claude Opus 4.8). Base is `record-caching` (#410) — this stacks on the VT caching work.
