### PR TITLE
fix(encoder): honor structures.isCompatible in CAS check for typed-only saves

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -277,16 +277,22 @@ export class RecordEncoder extends StructonEncoder {
 				// re-pack; paired with the msgpackr fix that marks structures uninitialized on
 				// save-failure, the re-pack reloads the durable structures, rebuilds the transition
 				// trie, re-mints, and re-saves — so the record always references a persisted structure.
+				// structon's _saveTypedStructures calls saveStructures(structures) without the second
+				// arg, but prepareStructures attaches .isCompatible on the Map itself. Fall back to it
+				// so typed-only saves keep CAS protection; otherwise the else-branch check is
+				// `Map.length(undefined) !== undefined` = false, and a conflicting same-length typed
+				// struct silently clobbers the previous one.
+				const compat = isCompatible ?? (structures as any)?.isCompatible;
 				const committed = this.rootStore.transactionSync(
 					(txn) => {
 						const sharedStructuresKey = [Symbol.for('structures'), this.name];
 						const existingStructuresBuffer = txn.getBinarySync(sharedStructuresKey);
 						const existingStructures = existingStructuresBuffer ? this.decode(existingStructuresBuffer) : undefined;
-						if (typeof isCompatible == 'function') {
-							if (!isCompatible(existingStructures)) {
+						if (typeof compat == 'function') {
+							if (!compat(existingStructures)) {
 								return false;
 							}
-						} else if (existingStructures && existingStructures.length !== isCompatible) {
+						} else if (existingStructures && existingStructures.length !== compat) {
 							return false;
 						}
 						txn.putSync(sharedStructuresKey, structures);

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -265,6 +265,13 @@ export class RecordEncoder extends StructonEncoder {
 		const superSaveStructures = this.saveStructures;
 		const superGetStructures = this.getStructures;
 		this.saveStructures = function (structures, isCompatible): boolean | undefined {
+			// structon's _saveTypedStructures calls saveStructures(structures) without the second
+			// arg, but prepareStructures attaches .isCompatible on the Map itself. Fall back to it
+			// so typed-only saves keep CAS protection on both storage paths; otherwise the LMDB
+			// branch forwards `undefined` and the RocksDB else-branch check is
+			// `Map.length(undefined) !== undefined` = false, and a conflicting same-length typed
+			// struct silently clobbers the previous one.
+			const compat = isCompatible ?? (structures as any).isCompatible;
 			if (this.isRocksDB) {
 				// transactionSync returns the callback's value on commit, but returns `undefined`
 				// when the txn was aborted (it swallows ERR_ALREADY_ABORTED). The success path here
@@ -277,12 +284,6 @@ export class RecordEncoder extends StructonEncoder {
 				// re-pack; paired with the msgpackr fix that marks structures uninitialized on
 				// save-failure, the re-pack reloads the durable structures, rebuilds the transition
 				// trie, re-mints, and re-saves — so the record always references a persisted structure.
-				// structon's _saveTypedStructures calls saveStructures(structures) without the second
-				// arg, but prepareStructures attaches .isCompatible on the Map itself. Fall back to it
-				// so typed-only saves keep CAS protection; otherwise the else-branch check is
-				// `Map.length(undefined) !== undefined` = false, and a conflicting same-length typed
-				// struct silently clobbers the previous one.
-				const compat = isCompatible ?? (structures as any)?.isCompatible;
 				const committed = this.rootStore.transactionSync(
 					(txn) => {
 						const sharedStructuresKey = [Symbol.for('structures'), this.name];
@@ -309,7 +310,7 @@ export class RecordEncoder extends StructonEncoder {
 				}
 				return false;
 			} else {
-				const result = superSaveStructures.call(this, structures, isCompatible);
+				const result = superSaveStructures.call(this, structures, compat);
 				this.structureUpdate = structures;
 				return result;
 			}

--- a/unitTests/resources/recordEncoder.test.js
+++ b/unitTests/resources/recordEncoder.test.js
@@ -152,3 +152,98 @@ describe('RecordEncoder missing-structure handling (harper#1163)', () => {
 		assert.strictEqual(warnings.length, 0, 'genuine corruption should not use the missing-structure warning');
 	});
 });
+
+describe('RecordEncoder typed-struct CAS regression', () => {
+	function mockRocksRootStore() {
+		let buffer;
+		const meta = new Encoder({ useBigIntExtension: true });
+		return {
+			transactionSync(cb) {
+				const txn = {
+					getBinarySync() {
+						return buffer;
+					},
+					putSync(_key, val) {
+						buffer = meta.encode(val);
+					},
+				};
+				return cb(txn);
+			},
+			_readDecoded() {
+				return buffer ? meta.decode(buffer) : undefined;
+			},
+		};
+	}
+
+	function makeRocksEncoder(rootStore) {
+		const enc = new RecordEncoder({
+			structures: [],
+			randomAccessStructure: true,
+			getStructures: () => undefined,
+			saveStructures: () => true,
+		});
+		enc.isRocksDB = true;
+		enc.rootStore = rootStore;
+		enc.name = 'TestTable';
+		return enc;
+	}
+
+	function makeStructures(typedEntries, lastTypedLen) {
+		const m = new Map();
+		m.set('named', []);
+		m.set('typed', typedEntries);
+		m.isCompatible = (existing) => {
+			if (!existing) return lastTypedLen === 0;
+			const t = existing instanceof Map ? existing.get('typed') || [] : existing?.typed || [];
+			return t.length === lastTypedLen;
+		};
+		return m;
+	}
+
+	it('rejects a conflicting typed-only save when isCompatible is on structures, not the parameter', () => {
+		// structon's _saveTypedStructures (node_modules/structon/index.js:165) calls
+		// this.saveStructures(structures) without forwarding the second arg, but the structures
+		// object that prepareStructures returned has .isCompatible attached. Harper's saveStructures
+		// override must consult that attached function, otherwise its else-branch CAS check is
+		// `existingStructures.length !== undefined` which is `Map.length(undefined) !== undefined` =
+		// false, and a same-length-but-different-content typed-struct save silently clobbers the
+		// previous one. Records the first writer encoded against now reference a struct whose schema
+		// has been replaced, surfacing as "Data read, but end of buffer not reached" /
+		// "Unexpected end of MessagePack data" at decode (HarperFast/harper#1441).
+		const rootStore = mockRocksRootStore();
+		const enc = makeRocksEncoder(rootStore);
+
+		const firstStructures = makeStructures([[[3, 0, 'id']]], 0);
+		assert.strictEqual(enc.saveStructures(firstStructures), true, 'initial save should succeed');
+
+		// A different encoder (or thread) mints a different typed struct at the same lastTypedLen=0.
+		const conflicting = makeStructures([[[3, 0, 'differentField']]], 0);
+		const result = enc.saveStructures(conflicting);
+		assert.strictEqual(
+			result,
+			false,
+			'conflicting same-length typed-only save must be CAS-rejected; got true → silent clobber'
+		);
+
+		const persisted = rootStore._readDecoded();
+		const typed = persisted instanceof Map ? persisted.get('typed') : persisted?.typed;
+		assert.strictEqual(typed[0][0][2], 'id', 'persisted typed struct must still be the first writer’s');
+	});
+
+	it('continues to honor the explicit-parameter form (msgpackr.pack pathway)', () => {
+		// Guards against the fix breaking msgpackr's call site (node_modules/msgpackr/pack.js:190),
+		// which DOES pass structures.isCompatible as the second argument.
+		const rootStore = mockRocksRootStore();
+		const enc = makeRocksEncoder(rootStore);
+
+		const first = makeStructures([[[3, 0, 'id']]], 0);
+		assert.strictEqual(enc.saveStructures(first, first.isCompatible), true);
+
+		const conflicting = makeStructures([[[3, 0, 'differentField']]], 0);
+		assert.strictEqual(
+			enc.saveStructures(conflicting, conflicting.isCompatible),
+			false,
+			'explicit-arg path must keep rejecting conflicts'
+		);
+	});
+});


### PR DESCRIPTION
Fixes #1441.

## Summary

structon's `_saveTypedStructures` (`node_modules/structon/index.js:165`) calls `this.saveStructures(structures)` without forwarding `isCompatible` as the second argument; the structures Map carries `.isCompatible` as an attached property. Harper's `saveStructures` override at `resources/RecordEncoder.ts` only inspected the parameter form, so the typed-only call path fell into the else branch where `existingStructures.length !== undefined` evaluates `Map.length(undefined) !== undefined` = false. A conflicting same-length typed-struct save would commit and silently clobber the previous one. Records the first writer encoded against then reference a struct whose shape has been replaced, surfacing as `Data read, but end of buffer not reached` or `Unexpected end of MessagePack data` on decode, returned as null via the existing catch path.

## Fix

Extract `compat = isCompatible ?? (structures as any)?.isCompatible` and use that in both branches of the CAS check. msgpackr's own pack call site (`node_modules/msgpackr/pack.js:190`), which already passes `structures.isCompatible` as the second arg, is unaffected.

## Test plan

- [x] `npx mocha unitTests/resources/recordEncoder.test.js` passes locally (11/11)
- [x] New describe block `RecordEncoder typed-struct CAS regression` (2 tests) reproduces the silent clobber without the fix and passes with it
- [x] First test asserts the typed-only call path is now CAS-rejected
- [x] Second test asserts the explicit-parameter (msgpackr.pack) path still works

## Production observation

Predicted symptom verified on Akamai v4→v5 stage cluster (5.1.6) during a rolling upgrade soak.