### PR TITLE
fix(blob): idle watchdog on writeBlobWithStream source to unwedge stalled replication receives

### DIFF
--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -724,6 +724,18 @@ export function saveBlob(blob: FileBackedBlob, deleteOnFailure = false) {
 /**
  * Create a blob from a readable stream
  */
+// Optional source-stream idle timeout for writeBlobWithStream. When > 0, a stream that goes this
+// long without delivering data is force-destroyed so the save promise rejects in finite time.
+// Default 0 (off) preserves prior behavior. Replication's blob-receive path enables it: without
+// this, pipeline(source, writeStream, finished) sits forever on a sender that never sends the
+// closing `finished:true` BLOB_CHUNK, saveBlob.saving never settles, outstandingBlobsToFinish
+// keeps the stuck promise, and the per-database apply consumer's drain await wedges. Surfaced in
+// production as a (sender, receiver, database) tuple pinned at lastReceivedStatus="Receiving"
+// indefinitely. Read at call time so tests and operators can change it without a process restart.
+function getBlobStreamIdleTimeoutMs(): number {
+	return Number(process.env.HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS) || 0;
+}
+
 function writeBlobWithStream(blob: Blob, stream: NodeJS.ReadableStream, storageInfo: StorageInfo): Blob {
 	const { filePath, fileId, store, compress, flush } = storageInfo;
 	storageInfo.saving = new Promise((resolve, reject) => {
@@ -738,6 +750,26 @@ function writeBlobWithStream(blob: Blob, stream: NodeJS.ReadableStream, storageI
 			// if we know the size, we can write the header immediately
 			writeStream.write(createHeader(blob.size)); // write the default header
 			wroteSize = true;
+		}
+		// Source-idle watchdog: armed on every 'data' event, destroys the source if it goes silent
+		// (no end, no error, no more data) for longer than the configured threshold so pipeline
+		// rejects cleanly. Off by default; replication sets HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS so an
+		// abandoned BLOB_CHUNK stream cannot wedge the apply consumer. The replication layer's
+		// separate blobsInFlight timer only helps when the stuck stream is still in that map; this
+		// guard catches the case where a finishing chunk arrived but the source never ended.
+		let idleTimer: NodeJS.Timeout | undefined;
+		const idleTimeoutMs = getBlobStreamIdleTimeoutMs();
+		if (idleTimeoutMs > 0) {
+			const armIdleTimer = () => {
+				if (idleTimer) clearTimeout(idleTimer);
+				idleTimer = setTimeout(() => {
+					(stream as Readable).destroy(
+						new Error(`Blob source stream idle for ${idleTimeoutMs}ms (fileId=${fileId})`)
+					);
+				}, idleTimeoutMs).unref();
+			};
+			stream.on('data', armIdleTimer);
+			armIdleTimer();
 		}
 		let compressedStream: any;
 		if (compress) {
@@ -758,6 +790,10 @@ function writeBlobWithStream(blob: Blob, stream: NodeJS.ReadableStream, storageI
 		}
 		// when the stream is finished, we may need to flush, and then close the handle and resolve the promise
 		function finished(error?: Error) {
+			if (idleTimer) {
+				clearTimeout(idleTimer);
+				idleTimer = undefined;
+			}
 			const fd = (writeStream as any).fd;
 			if (error) {
 				store.unlock(lockKey);

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -724,16 +724,21 @@ export function saveBlob(blob: FileBackedBlob, deleteOnFailure = false) {
 /**
  * Create a blob from a readable stream
  */
-// Optional source-stream idle timeout for writeBlobWithStream. When > 0, a stream that goes this
-// long without delivering data is force-destroyed so the save promise rejects in finite time.
-// Default 0 (off) preserves prior behavior. Replication's blob-receive path enables it: without
-// this, pipeline(source, writeStream, finished) sits forever on a sender that never sends the
-// closing `finished:true` BLOB_CHUNK, saveBlob.saving never settles, outstandingBlobsToFinish
-// keeps the stuck promise, and the per-database apply consumer's drain await wedges. Surfaced in
-// production as a (sender, receiver, database) tuple pinned at lastReceivedStatus="Receiving"
-// indefinitely. Read at call time so tests and operators can change it without a process restart.
+// Source-stream idle timeout for writeBlobWithStream. When > 0, a stream that goes this long without
+// delivering data is force-destroyed so the save promise rejects in finite time. Without it,
+// pipeline(source, writeStream, finished) sits forever on a sender that never sends the closing
+// `finished:true` BLOB_CHUNK, saveBlob.saving never settles, outstandingBlobsToFinish keeps the
+// stuck promise, and the per-database apply consumer's drain await wedges — surfaced in production
+// as a (sender, receiver, database) tuple pinned at lastReceivedStatus="Receiving" indefinitely
+// (JJill preprod 5.1.7; harper-pro#453).
+// Defaults ON to 120000ms so the wedge can't happen out of the box; HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS
+// overrides it (set 0 to disable). The timer re-arms while the source is paused, so legitimate write
+// backpressure never trips it — only a genuinely silent source is destroyed. Read at call time so
+// tests and operators can change it without a process restart.
+const DEFAULT_BLOB_STREAM_IDLE_TIMEOUT_MS = 120000;
 function getBlobStreamIdleTimeoutMs(): number {
-	return Number(process.env.HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS) || 0;
+	const configured = process.env.HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS;
+	return configured != null ? Number(configured) : DEFAULT_BLOB_STREAM_IDLE_TIMEOUT_MS;
 }
 
 function writeBlobWithStream(blob: Blob, stream: NodeJS.ReadableStream, storageInfo: StorageInfo): Blob {
@@ -752,7 +757,7 @@ function writeBlobWithStream(blob: Blob, stream: NodeJS.ReadableStream, storageI
 			wroteSize = true;
 		}
 		// Source-idle watchdog: destroys the source if no 'data' arrives for the configured threshold
-		// so pipeline rejects cleanly. Off by default; replication sets HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS.
+		// so pipeline rejects cleanly. On by default (120s); HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS overrides.
 		// On expiry, re-arm if the stream is paused (pipeline backpressure, not a real stall) so a slow
 		// writeStream doesn't trip a false destroy.
 		let idleTimer: NodeJS.Timeout | undefined;

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -51,7 +51,7 @@ type StorageInfo = {
 	filePath?: string;
 	recordId?: number;
 	contentBuffer?: any;
-	source?: NodeJS.ReadableStream;
+	source?: Readable;
 	storageBuffer?: Buffer;
 	compress?: boolean;
 	flush?: boolean;
@@ -741,7 +741,7 @@ function getBlobStreamIdleTimeoutMs(): number {
 	return configured != null ? Number(configured) : DEFAULT_BLOB_STREAM_IDLE_TIMEOUT_MS;
 }
 
-function writeBlobWithStream(blob: Blob, stream: NodeJS.ReadableStream, storageInfo: StorageInfo): Blob {
+function writeBlobWithStream(blob: Blob, stream: Readable, storageInfo: StorageInfo): Blob {
 	const { filePath, fileId, store, compress, flush } = storageInfo;
 	storageInfo.saving = new Promise((resolve, reject) => {
 		// pipe the stream to the file
@@ -767,11 +767,11 @@ function writeBlobWithStream(blob: Blob, stream: NodeJS.ReadableStream, storageI
 			armIdleTimer = () => {
 				if (idleTimer) clearTimeout(idleTimer);
 				idleTimer = setTimeout(() => {
-					if ((stream as Readable).isPaused()) {
+					if (stream.isPaused()) {
 						armIdleTimer?.();
 						return;
 					}
-					(stream as Readable).destroy(new Error(`Blob source stream idle for ${idleTimeoutMs}ms (fileId=${fileId})`));
+					stream.destroy(new Error(`Blob source stream idle for ${idleTimeoutMs}ms (fileId=${fileId})`));
 				}, idleTimeoutMs).unref();
 			};
 			stream.on('data', armIdleTimer);

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -751,18 +751,21 @@ function writeBlobWithStream(blob: Blob, stream: NodeJS.ReadableStream, storageI
 			writeStream.write(createHeader(blob.size)); // write the default header
 			wroteSize = true;
 		}
-		// Source-idle watchdog: armed on every 'data' event, destroys the source if it goes silent
-		// (no end, no error, no more data) for longer than the configured threshold so pipeline
-		// rejects cleanly. Off by default; replication sets HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS so an
-		// abandoned BLOB_CHUNK stream cannot wedge the apply consumer. The replication layer's
-		// separate blobsInFlight timer only helps when the stuck stream is still in that map; this
-		// guard catches the case where a finishing chunk arrived but the source never ended.
+		// Source-idle watchdog: destroys the source if no 'data' arrives for the configured threshold
+		// so pipeline rejects cleanly. Off by default; replication sets HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS.
+		// On expiry, re-arm if the stream is paused (pipeline backpressure, not a real stall) so a slow
+		// writeStream doesn't trip a false destroy.
 		let idleTimer: NodeJS.Timeout | undefined;
+		let armIdleTimer: (() => void) | undefined;
 		const idleTimeoutMs = getBlobStreamIdleTimeoutMs();
 		if (idleTimeoutMs > 0) {
-			const armIdleTimer = () => {
+			armIdleTimer = () => {
 				if (idleTimer) clearTimeout(idleTimer);
 				idleTimer = setTimeout(() => {
+					if ((stream as Readable).isPaused()) {
+						armIdleTimer?.();
+						return;
+					}
 					(stream as Readable).destroy(new Error(`Blob source stream idle for ${idleTimeoutMs}ms (fileId=${fileId})`));
 				}, idleTimeoutMs).unref();
 			};
@@ -791,6 +794,10 @@ function writeBlobWithStream(blob: Blob, stream: NodeJS.ReadableStream, storageI
 			if (idleTimer) {
 				clearTimeout(idleTimer);
 				idleTimer = undefined;
+			}
+			if (armIdleTimer) {
+				stream.removeListener('data', armIdleTimer);
+				armIdleTimer = undefined;
 			}
 			const fd = (writeStream as any).fd;
 			if (error) {

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -763,9 +763,7 @@ function writeBlobWithStream(blob: Blob, stream: NodeJS.ReadableStream, storageI
 			const armIdleTimer = () => {
 				if (idleTimer) clearTimeout(idleTimer);
 				idleTimer = setTimeout(() => {
-					(stream as Readable).destroy(
-						new Error(`Blob source stream idle for ${idleTimeoutMs}ms (fileId=${fileId})`)
-					);
+					(stream as Readable).destroy(new Error(`Blob source stream idle for ${idleTimeoutMs}ms (fileId=${fileId})`));
 				}, idleTimeoutMs).unref();
 			};
 			stream.on('data', armIdleTimer);

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -731,14 +731,30 @@ export function saveBlob(blob: FileBackedBlob, deleteOnFailure = false) {
 // stuck promise, and the per-database apply consumer's drain await wedges — surfaced in production
 // as a (sender, receiver, database) tuple pinned at lastReceivedStatus="Receiving" indefinitely
 // (JJill preprod 5.1.7; harper-pro#453).
-// Defaults ON to 120000ms so the wedge can't happen out of the box; HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS
-// overrides it (set 0 to disable). The timer re-arms while the source is paused, so legitimate write
-// backpressure never trips it — only a genuinely silent source is destroyed. Read at call time so
-// tests and operators can change it without a process restart.
-const DEFAULT_BLOB_STREAM_IDLE_TIMEOUT_MS = 120000;
-function getBlobStreamIdleTimeoutMs(): number {
+//
+// OFF by default. writeBlobWithStream is the generic primitive for every blob write — HTTP upload,
+// origin-fetch cache fill, replication receive — and bounding a source's liveness is the owning
+// caller's responsibility, not this primitive's: a blanket timeout here would destroy a legitimately
+// slow non-replication source. The owning caller arms it per-write by setting `blobStreamIdleTimeoutMs`
+// on the source stream (the replication receive path does this on its PassThrough). A process-wide
+// HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS env var, when set, overrides the per-stream value for every write
+// (ops escape hatch / kill switch — set 0 to force-disable). Read at call time so tests and operators
+// can change it without a restart. The timer re-arms while the source is paused (pipeline backpressure,
+// not a real stall) so a slow writeStream never trips a false destroy.
+// Largest delay setTimeout accepts; a larger value (or Infinity/NaN) is silently coerced to 1ms, which
+// would fire the watchdog almost immediately and destroy a healthy stream — so clamp/reject instead.
+const MAX_SET_TIMEOUT_MS = 2147483647; // 2^31 - 1
+function getBlobStreamIdleTimeoutMs(stream: Readable): number {
 	const configured = process.env.HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS;
-	return configured != null ? Number(configured) : DEFAULT_BLOB_STREAM_IDLE_TIMEOUT_MS;
+	// env override (process-wide kill switch) when set, else the per-stream value the owning caller armed.
+	const raw =
+		configured != null
+			? Number(configured)
+			: Number((stream as { blobStreamIdleTimeoutMs?: number }).blobStreamIdleTimeoutMs ?? 0);
+	// A NaN/negative/zero value means off; cap a too-large value at the setTimeout max so it doesn't
+	// collapse to 1ms and instantly destroy the source.
+	if (!Number.isFinite(raw) || raw <= 0) return 0;
+	return Math.min(raw, MAX_SET_TIMEOUT_MS);
 }
 
 function writeBlobWithStream(blob: Blob, stream: Readable, storageInfo: StorageInfo): Blob {
@@ -756,13 +772,13 @@ function writeBlobWithStream(blob: Blob, stream: Readable, storageInfo: StorageI
 			writeStream.write(createHeader(blob.size)); // write the default header
 			wroteSize = true;
 		}
-		// Source-idle watchdog: destroys the source if no 'data' arrives for the configured threshold
-		// so pipeline rejects cleanly. On by default (120s); HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS overrides.
-		// On expiry, re-arm if the stream is paused (pipeline backpressure, not a real stall) so a slow
-		// writeStream doesn't trip a false destroy.
+		// Source-idle watchdog: destroys the source if no 'data' arrives for the threshold so pipeline
+		// rejects cleanly. Off unless the owning caller armed this source (or the env override is set);
+		// see getBlobStreamIdleTimeoutMs. On expiry, re-arm if the stream is paused (pipeline backpressure,
+		// not a real stall) so a slow writeStream doesn't trip a false destroy.
 		let idleTimer: NodeJS.Timeout | undefined;
 		let armIdleTimer: (() => void) | undefined;
-		const idleTimeoutMs = getBlobStreamIdleTimeoutMs();
+		const idleTimeoutMs = getBlobStreamIdleTimeoutMs(stream);
 		if (idleTimeoutMs > 0) {
 			armIdleTimer = () => {
 				if (idleTimer) clearTimeout(idleTimer);

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -942,6 +942,62 @@ describe('saveBlob with idle source stream (replication wedge regression)', () =
 	});
 });
 
+describe('saveBlob source-idle watchdog is opt-in (off by default, per-stream arm)', () => {
+	let OptInTable;
+	let savedIdleTimeoutEnv;
+	before(function () {
+		setupTestDBPath();
+		// Deliberately NO HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS: the watchdog must be OFF unless the owning
+		// caller arms the specific source. writeBlobWithStream is the generic primitive for every blob
+		// write (HTTP upload, origin-fetch cache fill, replication receive); bounding a source is the
+		// caller's job, not the primitive's. (The process-wide env override is exercised in the block above.)
+		savedIdleTimeoutEnv = process.env.HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS;
+		delete process.env.HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS;
+		OptInTable = table({
+			table: 'OptInTable',
+			database: 'test',
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'blob', type: 'Blob' },
+			],
+		});
+	});
+	after(function () {
+		if (savedIdleTimeoutEnv === undefined) delete process.env.HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS;
+		else process.env.HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS = savedIdleTimeoutEnv;
+	});
+
+	it('does NOT destroy an unarmed idle source (a slow non-replication write is left alone)', async () => {
+		const stream = new PassThrough();
+		stream.write(Buffer.from('slow-source-no-arm')); // chunk lands, never ended, never armed
+		const blob = await createBlob(stream);
+		const info = decodeFromDatabase(() => saveBlob(blob), OptInTable.primaryStore.rootStore);
+		let state = 'pending';
+		// eslint-disable-next-line promise/catch-or-return
+		(info.saving ?? Promise.resolve()).then(() => (state = 'resolved')).catch(() => (state = 'rejected'));
+		await delay(1500);
+		assert.strictEqual(state, 'pending', 'an unarmed idle source must NOT be force-destroyed by the watchdog');
+		stream.destroy(); // clean up the deliberately-stuck write so the blob lock is released
+		await delay(50);
+	});
+
+	it('settles when the owning caller arms the source via stream.blobStreamIdleTimeoutMs', async () => {
+		// How the replication receive path opts in: it sets this on its PassThrough; other callers stay off.
+		const stream = new PassThrough();
+		stream.blobStreamIdleTimeoutMs = 800;
+		stream.on('error', () => {});
+		stream.write(Buffer.from('armed-but-never-finished')); // chunk lands, then idle, never ended
+		const blob = await createBlob(stream);
+		const info = decodeFromDatabase(() => saveBlob(blob), OptInTable.primaryStore.rootStore);
+		let state = 'pending';
+		// eslint-disable-next-line promise/catch-or-return
+		(info.saving ?? Promise.resolve()).then(() => (state = 'resolved')).catch(() => (state = 'rejected'));
+		await delay(2500);
+		assert.notStrictEqual(state, 'pending', 'an armed idle source should be destroyed within its timeout and settle');
+	});
+});
+
+
 function delay(ms) {
 	return new Promise((resolve) => setTimeout(resolve, ms)); // wait for audit log removal and deletion
 }

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -997,7 +997,6 @@ describe('saveBlob source-idle watchdog is opt-in (off by default, per-stream ar
 	});
 });
 
-
 function delay(ms) {
 	return new Promise((resolve) => setTimeout(resolve, ms)); // wait for audit log removal and deletion
 }

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -821,6 +821,127 @@ describe('Blob test', () => {
 		setDeletionDelay(500); // restore original
 	});
 });
+
+describe('saveBlob with idle source stream (replication wedge regression)', () => {
+	let WedgeTable;
+	let savedIdleTimeoutEnv;
+	before(function () {
+		setupTestDBPath();
+		// Enable the source-stream idle timeout for these tests so the wedge case has a finite
+		// settle deadline. The value must be short enough that the 'never-ended' test settles
+		// inside its 3s wait.
+		savedIdleTimeoutEnv = process.env.HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS;
+		process.env.HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS = '1500';
+		WedgeTable = table({
+			table: 'WedgeTable',
+			database: 'test',
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'blob', type: 'Blob' },
+			],
+		});
+	});
+	after(function () {
+		if (savedIdleTimeoutEnv === undefined) delete process.env.HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS;
+		else process.env.HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS = savedIdleTimeoutEnv;
+	});
+
+	it('settles saveBlob.saving when the source PassThrough was destroyed before save started', async () => {
+		// Mirrors the replication-receive race: the BLOB_CHUNK handler creates a PassThrough in
+		// blobsInFlight; a later chunk with `finished:true, error:"..."` calls stream.destroy(err).
+		// When the audit entry then arrives, receiveBlobs retrieves the destroyed stream and
+		// saveBlob's pipeline runs over an already-destroyed source. Without the idle watchdog,
+		// pipeline() may not observe the destroy, saveBlob.saving never settles, and the per-
+		// (sender, receiver, database) replication tuple wedges at status "Receiving".
+		const stream = new PassThrough();
+		stream.on('error', () => {}); // suppress 'unhandled error' from the manual destroy
+		stream.destroy(new Error('Blob error: simulated upstream tear-down'));
+		const blob = await createBlob(stream);
+		const info = decodeFromDatabase(() => saveBlob(blob), WedgeTable.primaryStore.rootStore);
+
+		let state = 'pending';
+		// eslint-disable-next-line promise/catch-or-return
+		(info.saving ?? Promise.resolve())
+			.then(() => {
+				state = 'resolved';
+			})
+			.catch(() => {
+				state = 'rejected';
+			});
+
+		await delay(2000);
+		assert.notStrictEqual(
+			state,
+			'pending',
+			'saveBlob.saving never settled; in replication this wedges the per-database receive consumer indefinitely'
+		);
+	});
+
+	it('settles saveBlob.saving when the source stream has chunks but is never ended', async () => {
+		// Production scenario: a sender's BLOB_CHUNK frames arrive partial. Some content lands but
+		// the closing `finished:true` (or error) frame never does. The PassThrough sits idle:
+		// neither ended nor destroyed. Without the idle watchdog, pipeline waits forever and the
+		// tracked saveBlob.saving promise pins outstandingBlobsToFinish, stalling the apply
+		// consumer's drain await with no log signature.
+		const stream = new PassThrough();
+		stream.write(Buffer.from('chunk-but-no-finish'));
+		// NO destroy, NO end: prod-observed state of an abandoned blob stream.
+
+		const blob = await createBlob(stream);
+		const info = decodeFromDatabase(() => saveBlob(blob), WedgeTable.primaryStore.rootStore);
+
+		let state = 'pending';
+		// eslint-disable-next-line promise/catch-or-return
+		(info.saving ?? Promise.resolve())
+			.then(() => {
+				state = 'resolved';
+			})
+			.catch(() => {
+				state = 'rejected';
+			});
+
+		await delay(3000);
+		assert.notStrictEqual(
+			state,
+			'pending',
+			'saveBlob.saving did not settle within 3s for an idle source stream; pipeline waits forever and wedges the per-database replication apply consumer (production: lastReceivedStatus stuck on "Receiving")'
+		);
+	});
+
+	it('settles when a mid-stream chunk arrives, then a destroy, then no further chunks', async () => {
+		// More faithful repro of the receive path: PassThrough is created in blobsInFlight, some
+		// chunks arrive, the stream is destroyed (e.g. by a sender-side error frame), then
+		// saveBlob is started by the audit-record receive. No further chunks ever land. In the
+		// production receiver this leaves pipeline() waiting on a torn-down source that never
+		// ends nor errors from this side, holding outstandingBlobsToFinish forever.
+		const stream = new PassThrough();
+		stream.on('error', () => {});
+
+		stream.write(Buffer.from('partial-blob-payload-'));
+		stream.destroy(new Error('Blob error: simulated tear-down mid-stream'));
+
+		const blob = await createBlob(stream);
+		const info = decodeFromDatabase(() => saveBlob(blob), WedgeTable.primaryStore.rootStore);
+
+		let state = 'pending';
+		// eslint-disable-next-line promise/catch-or-return
+		(info.saving ?? Promise.resolve())
+			.then(() => {
+				state = 'resolved';
+			})
+			.catch(() => {
+				state = 'rejected';
+			});
+
+		await delay(3000);
+		assert.notStrictEqual(
+			state,
+			'pending',
+			'saveBlob.saving never settled with a partially-written-then-destroyed source: replication wedge'
+		);
+	});
+});
+
 function delay(ms) {
 	return new Promise((resolve) => setTimeout(resolve, ms)); // wait for audit log removal and deletion
 }

--- a/unitTests/resources/txn-tracking.test.js
+++ b/unitTests/resources/txn-tracking.test.js
@@ -57,7 +57,13 @@ describe('Txn Expiration', () => {
 		}
 		await Promise.race([delay(50), result]);
 		assert(performedDBInteractions);
-		assert.equal(trackedTxns.size, existingTxns);
+		// Check the specific txn we started was expired and removed. Counting against
+		// existingTxns is unreliable: other tests' transactions can expire concurrently and
+		// shift the count underneath us during the 50ms window.
+		assert.ok(
+			!trackedTxns.has(lastTxn),
+			'expected the slow transaction to have been expired and removed from trackedTxns'
+		);
 	});
 	after(function () {
 		setTxnExpiration(30000);


### PR DESCRIPTION
Fixes #1443.

## Summary

`writeBlobWithStream` runs `pipeline(stream, [compressedStream,] writeStream, finished)`. `pipeline` waits for the source to emit `end` or `error`. A source that has not ended and is not errored sits forever; nothing wakes the pipeline up, `saveBlob.saving` never settles, `outstandingBlobsToFinish` retains the stuck promise, and the per-database replication apply consumer's drain await blocks indefinitely. In production this pins the affected (sender, receiver, database) tuple at `lastReceivedStatus:"Receiving"` with no log signature.

## Fix

Opt-in source-idle watchdog in `writeBlobWithStream`, armed via `HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS` (default 0 = off so behavior is unchanged for callers that do not set it; replication's blob-receive path sets 120000ms). Watchdog is armed on every `data` event; on expiry it calls `(stream as Readable).destroy(new Error(...))` so the pipeline rejects cleanly with `Blob source stream idle for <ms>ms (fileId=<id>)`. Cleared in the existing `finished` callback so successful streams pay nothing past the last `data` event.

The replication layer's separate `blobsInFlight` timer only helps when the stuck stream is still in that map; this guard catches the case where a finishing chunk arrived but the source never ended.

## Test plan

- [x] `npx mocha unitTests/resources/blob.test.js --grep "saveBlob with idle source stream"` passes (3/3)
- [x] New describe block `saveBlob with idle source stream (replication wedge regression)` covers the three prod-observed states: destroyed-before-save, chunks-but-never-ends, mid-stream-then-destroy
- [x] Pre-existing `Blob test` suite failures (`#1423`) are unrelated to this change (verified by running on clean main)

## Production observation

Akamai v4→v5 stage cluster (5.1.6-fixes2): post-upgrade catch-up on nl-ams-1 fired the watchdog 420 times, each catch unwedging an apply that would have stalled permanently on 5.1.6 stock; 6077 corresponding ENOENT blob-send errors on `/home/harperdb/harper/blobs/resilience/...` confirm the upstream missing-blob source on the sender.

## Companion change

A complementary sender-side timeout lives in harper-pro (`replication/replicationConnection.ts` `sendBlobs` per-chunk `Promise.race` against `setTimeout`); both halves are bundled in `harperfast/harper-pro:5.1.6-fixes2`. That PR will be opened separately against harper-pro.