### PR TITLE
fix(encoder): reload structures and retry once on dict-lag decode error

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -448,18 +448,20 @@ export class RecordEncoder extends StructonEncoder {
 				);
 				return null;
 			}
-			// Classic shared-structures dict lag: persisted structures advanced past the in-memory copy,
-			// so msgpackr decodes the known fields and leaves the tail. Reload from storage and retry
-			// once. structon does the equivalent on typed-struct misses (harper#1163).
-			if (!this._reloadingStructures && /end of buffer not reached/i.test(error?.message)) {
-				try {
-					const fresh = this.getStructures();
-					if (fresh) this._mergeStructures(fresh);
-				} catch (reloadError) {
-					harperLogger.warn?.('Failed to reload structures during decode-retry', reloadError);
-				}
+			// In-memory structures dict diverged from durable (harper#1453); reload and retry. Guard
+			// is set before getStructures() because on RocksDB it itself decodes the structures buffer.
+			if (
+				!this._reloadingStructures &&
+				/end of buffer not reached|unexpected end of messagepack data/i.test(error?.message)
+			) {
 				this._reloadingStructures = true;
 				try {
+					try {
+						const fresh = this.getStructures();
+						if (fresh) this._mergeStructures(fresh);
+					} catch (reloadError) {
+						harperLogger.warn?.('Failed to reload structures during decode-retry', reloadError);
+					}
 					return this.decode(buffer, options);
 				} finally {
 					this._reloadingStructures = false;

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -464,10 +464,7 @@ export class RecordEncoder extends StructonEncoder {
 					const fresh = this.getStructures();
 					if (fresh) this._mergeStructures(fresh);
 				} catch (reloadError) {
-					harperLogger.warn?.(
-						'Failed to reload structures during decode-retry; continuing to error path',
-						reloadError
-					);
+					harperLogger.warn?.('Failed to reload structures during decode-retry; continuing to error path', reloadError);
 				}
 				this._reloadingStructures = true;
 				try {

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -114,10 +114,12 @@ export class RecordEncoder extends StructonEncoder {
 	declare saveStructures: any;
 	declare getStructures: any;
 	declare _writeStruct: any;
+	declare _mergeStructures: any;
 	structureUpdate?: any;
 	isRocksDB: boolean;
 	name: string;
 	useVersions: boolean;
+	_reloadingStructures?: boolean;
 	constructor(options) {
 		options.useBigIntExtension = true;
 		// Bound the per-encoder typed-structure dictionary. It is append-only and pinned on the
@@ -449,11 +451,7 @@ export class RecordEncoder extends StructonEncoder {
 			// Classic shared-structures dict lag: persisted structures advanced past the in-memory copy,
 			// so msgpackr decodes the known fields and leaves the tail. Reload from storage and retry
 			// once. structon does the equivalent on typed-struct misses (harper#1163).
-			if (
-				!this._reloadingStructures &&
-				typeof this.getStructures === 'function' &&
-				/end of buffer not reached/i.test(error?.message)
-			) {
+			if (!this._reloadingStructures && /end of buffer not reached/i.test(error?.message)) {
 				try {
 					const fresh = this.getStructures();
 					if (fresh) this._mergeStructures(fresh);

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -446,6 +446,36 @@ export class RecordEncoder extends StructonEncoder {
 				);
 				return null;
 			}
+			// Reader-side classic shared-structures dictionary lag: msgpackr decoded the N fields its
+			// local dict knew about, then checkedRead flagged leftover bytes for the (N+k)-th field.
+			// The persistent structures buffer is already at N+k (the writer published it via
+			// saveStructures); the local singleton encoder just hasn't reloaded since. Force a reload
+			// and retry once. Mirrors structon's auto-reload for the typed-struct missing case
+			// (harper#1163), but for classic structures the upstream path doesn't self-recover on
+			// tail-shape mismatch, so without this the record is silently laundered as null on every
+			// read. `_reloadingStructures` guards a single retry to avoid infinite recursion if the
+			// reload doesn't actually advance the dict.
+			if (
+				!this._reloadingStructures &&
+				typeof this.getStructures === 'function' &&
+				/end of buffer not reached/i.test(error?.message)
+			) {
+				try {
+					const fresh = this.getStructures();
+					if (fresh) this._mergeStructures(fresh);
+				} catch (reloadError) {
+					harperLogger.warn?.(
+						'Failed to reload structures during decode-retry; continuing to error path',
+						reloadError
+					);
+				}
+				this._reloadingStructures = true;
+				try {
+					return this.decode(buffer, options);
+				} finally {
+					this._reloadingStructures = false;
+				}
+			}
 			harperLogger.error('Error decoding record', error, 'data: ' + hexPreview);
 			return null;
 		}

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -446,15 +446,9 @@ export class RecordEncoder extends StructonEncoder {
 				);
 				return null;
 			}
-			// Reader-side classic shared-structures dictionary lag: msgpackr decoded the N fields its
-			// local dict knew about, then checkedRead flagged leftover bytes for the (N+k)-th field.
-			// The persistent structures buffer is already at N+k (the writer published it via
-			// saveStructures); the local singleton encoder just hasn't reloaded since. Force a reload
-			// and retry once. Mirrors structon's auto-reload for the typed-struct missing case
-			// (harper#1163), but for classic structures the upstream path doesn't self-recover on
-			// tail-shape mismatch, so without this the record is silently laundered as null on every
-			// read. `_reloadingStructures` guards a single retry to avoid infinite recursion if the
-			// reload doesn't actually advance the dict.
+			// Classic shared-structures dict lag: persisted structures advanced past the in-memory copy,
+			// so msgpackr decodes the known fields and leaves the tail. Reload from storage and retry
+			// once. structon does the equivalent on typed-struct misses (harper#1163).
 			if (
 				!this._reloadingStructures &&
 				typeof this.getStructures === 'function' &&
@@ -464,7 +458,7 @@ export class RecordEncoder extends StructonEncoder {
 					const fresh = this.getStructures();
 					if (fresh) this._mergeStructures(fresh);
 				} catch (reloadError) {
-					harperLogger.warn?.('Failed to reload structures during decode-retry; continuing to error path', reloadError);
+					harperLogger.warn?.('Failed to reload structures during decode-retry', reloadError);
 				}
 				this._reloadingStructures = true;
 				try {

--- a/unitTests/resources/recordEncoder.test.js
+++ b/unitTests/resources/recordEncoder.test.js
@@ -243,9 +243,14 @@ describe('RecordEncoder structure-version drift on read', () => {
 			`expected leftover-bytes detection (null + error log, or thrown error). decoded=${JSON.stringify(decoded)} messages=${JSON.stringify(messages)}`
 		);
 		if (hitNull) {
-			assert.ok(hitLog, `decoded to null but error log did not include "end of buffer not reached": ${JSON.stringify(messages)}`);
+			assert.ok(
+				hitLog,
+				`decoded to null but error log did not include "end of buffer not reached": ${JSON.stringify(messages)}`
+			);
 		} else if (decoded !== null && JSON.stringify(decoded) === JSON.stringify(wideRecord)) {
-			assert.fail('reader recovered the full record despite a truncated dict; symptom is not reproduced by this fixture');
+			assert.fail(
+				'reader recovered the full record despite a truncated dict; symptom is not reproduced by this fixture'
+			);
 		}
 	});
 });

--- a/unitTests/resources/recordEncoder.test.js
+++ b/unitTests/resources/recordEncoder.test.js
@@ -211,4 +211,18 @@ describe('RecordEncoder structure-version drift on read', () => {
 			`expected "end of buffer not reached" error; got: ${JSON.stringify(messages)}`
 		);
 	});
+
+	it('recovers from over-read variant ("Unexpected end of MessagePack data") on the same dict drift', () => {
+		// Reader's in-memory dict has MORE fields than what the writer encoded with: over-read.
+		const writerStore = sharedStore();
+		const writer = makeEncoder(false, writerStore);
+		const bytes = Buffer.from(writer.encode({ id: 'x', payload: 'hello' }));
+
+		const reader = makeEncoder(false, writerStore);
+		const persisted = writerStore.get();
+		reader.structures = persisted.map((entry) => (Array.isArray(entry) ? [...entry, 'extra'] : entry));
+
+		assert.deepStrictEqual(reader.decode(bytes), { id: 'x', payload: 'hello' });
+		assert.strictEqual(errors.length, 0);
+	});
 });

--- a/unitTests/resources/recordEncoder.test.js
+++ b/unitTests/resources/recordEncoder.test.js
@@ -154,17 +154,6 @@ describe('RecordEncoder missing-structure handling (harper#1163)', () => {
 });
 
 describe('RecordEncoder structure-version drift on read', () => {
-	// Production symptom from the v4→v5 in-place upgrade soak (Akamai staging): a burst of
-	// records on the first upgraded node failed to decode with
-	//   "Error decoding record Error: Data read, but end of buffer not reached"
-	// All affected records carry the same classic struct ID byte and decode through msgpackr's
-	// checkedRead. Mechanism: writer encoded against shared-structures version V (N+k fields),
-	// reader's local in-memory structures buffer is at V-1 (N fields), so the decoder finishes
-	// the N declared fields successfully but k field-bytes remain in the buffer. Distinct from
-	// the CAS-clobber path (harper#1441), which surfaces as missing-structure or "Unexpected end
-	// of MessagePack data" instead; this one is reader-side dictionary lag, not writer-side
-	// overwrite.
-
 	let errors, restoreError;
 	beforeEach(() => {
 		errors = [];
@@ -176,30 +165,20 @@ describe('RecordEncoder structure-version drift on read', () => {
 	});
 
 	it('recovers via getStructures() reload when persistent dict has caught up to writer', () => {
-		// In production the persistent structures buffer in storage is at the writer's version
-		// (saveStructures wrote it); only the in-memory singleton encoder dict lags. The fix
-		// catches "end of buffer not reached" once, calls getStructures() (which reads from
-		// storage), merges, and retries decode.
 		const writerStore = sharedStore();
 		const writer = makeEncoder(false, writerStore);
 		const bytes = Buffer.from(writer.encode({ id: 'x', payload: 'hello', tag: 'extra' }));
 
+		// In-memory dict is one entry behind the persistent store; the fix should reload and retry.
 		const reader = makeEncoder(false, writerStore);
 		reader.structures = writerStore.get().map((entry) => (Array.isArray(entry) ? entry.slice(0, -1) : entry));
 
-		const decoded = reader.decode(bytes);
-		assert.deepStrictEqual(
-			decoded,
-			{ id: 'x', payload: 'hello', tag: 'extra' },
-			`fix should reload structures on "end of buffer not reached" and recover the full record; got ${JSON.stringify(decoded)}`
-		);
+		assert.deepStrictEqual(reader.decode(bytes), { id: 'x', payload: 'hello', tag: 'extra' });
 		assert.strictEqual(errors.length, 0, 'recovery must not leak to the error log');
 	});
 
 	it('falls through to null + error log when reload does not advance the dict', () => {
-		// Guards the _reloadingStructures recursion guard: if a single reload doesn't actually
-		// advance the dict, the second decode must NOT retry again. Falls through to the existing
-		// null-on-corrupt-decode contract so we don't spin or shadow real corruption.
+		// _reloadingStructures guard: when reload returns the same stale dict, do not recurse.
 		const writerStore = sharedStore();
 		const writer = makeEncoder(false, writerStore);
 		const bytes = Buffer.from(writer.encode({ id: 'x', payload: 'hello', tag: 'extra' }));
@@ -208,49 +187,28 @@ describe('RecordEncoder structure-version drift on read', () => {
 		stuckStore.save(writerStore.get().map((entry) => (Array.isArray(entry) ? entry.slice(0, -1) : entry)));
 		const reader = makeEncoder(false, stuckStore);
 
-		const decoded = reader.decode(bytes);
-		assert.strictEqual(decoded, null, 'permanent truncation must still produce null');
+		assert.strictEqual(reader.decode(bytes), null);
 		assert.ok(
 			errors.some((e) => /end of buffer not reached/i.test((e[1] && e[1].message) || e.join(' '))),
-			'permanent failure must still surface in the error log (not silent)'
+			'permanent failure must still surface in the error log'
 		);
 	});
 
 	it('reports "Data read, but end of buffer not reached" when reader’s structures are behind writer’s', () => {
-		// Pure symptom: writer uses CLASSIC shared structures (randomAccessStructure=false). Its
-		// first encoded record installs a 3-field structure at index 0. Reader uses a DIFFERENT
-		// store seeded with a TRUNCATED structures dict (same index, only the first two fields).
-		// Models the v4→v5 first-upgrade window where the v5 receiver's local encoder dict for a
-		// given struct index lagged behind the writer's by one field. The bytes for the third
-		// field are still in the buffer; msgpackr decodes the two declared fields and checkedRead
-		// then flags the leftover bytes.
 		const writerStore = sharedStore();
 		const writer = makeEncoder(false, writerStore);
-		const wideRecord = { id: 'x', payload: 'hello', tag: 'extra' };
-		const bytes = Buffer.from(writer.encode(wideRecord));
+		const bytes = Buffer.from(writer.encode({ id: 'x', payload: 'hello', tag: 'extra' }));
 
-		const fullStructures = writerStore.get();
 		const stale = sharedStore();
-		stale.save(fullStructures.map((entry) => (Array.isArray(entry) ? entry.slice(0, -1) : entry)));
+		stale.save(writerStore.get().map((entry) => (Array.isArray(entry) ? entry.slice(0, -1) : entry)));
 		const reader = makeEncoder(false, stale);
 		const decoded = reader.decode(bytes);
 
 		const messages = errors.map((e) => (e[1] && e[1].message) || e.join(' '));
-		const hitLog = messages.some((m) => /end of buffer not reached/i.test(m));
-		const hitNull = decoded === null;
+		assert.strictEqual(decoded, null);
 		assert.ok(
-			hitLog || !hitNull,
-			`expected leftover-bytes detection (null + error log, or thrown error). decoded=${JSON.stringify(decoded)} messages=${JSON.stringify(messages)}`
+			messages.some((m) => /end of buffer not reached/i.test(m)),
+			`expected "end of buffer not reached" error; got: ${JSON.stringify(messages)}`
 		);
-		if (hitNull) {
-			assert.ok(
-				hitLog,
-				`decoded to null but error log did not include "end of buffer not reached": ${JSON.stringify(messages)}`
-			);
-		} else if (decoded !== null && JSON.stringify(decoded) === JSON.stringify(wideRecord)) {
-			assert.fail(
-				'reader recovered the full record despite a truncated dict; symptom is not reproduced by this fixture'
-			);
-		}
 	});
 });

--- a/unitTests/resources/recordEncoder.test.js
+++ b/unitTests/resources/recordEncoder.test.js
@@ -152,3 +152,100 @@ describe('RecordEncoder missing-structure handling (harper#1163)', () => {
 		assert.strictEqual(warnings.length, 0, 'genuine corruption should not use the missing-structure warning');
 	});
 });
+
+describe('RecordEncoder structure-version drift on read', () => {
+	// Production symptom from the v4→v5 in-place upgrade soak (Akamai staging): a burst of
+	// records on the first upgraded node failed to decode with
+	//   "Error decoding record Error: Data read, but end of buffer not reached"
+	// All affected records carry the same classic struct ID byte and decode through msgpackr's
+	// checkedRead. Mechanism: writer encoded against shared-structures version V (N+k fields),
+	// reader's local in-memory structures buffer is at V-1 (N fields), so the decoder finishes
+	// the N declared fields successfully but k field-bytes remain in the buffer. Distinct from
+	// the CAS-clobber path (harper#1441), which surfaces as missing-structure or "Unexpected end
+	// of MessagePack data" instead; this one is reader-side dictionary lag, not writer-side
+	// overwrite.
+
+	let errors, restoreError;
+	beforeEach(() => {
+		errors = [];
+		restoreError = harperLogger.error;
+		harperLogger.error = (...args) => errors.push(args);
+	});
+	afterEach(() => {
+		harperLogger.error = restoreError;
+	});
+
+	it('recovers via getStructures() reload when persistent dict has caught up to writer', () => {
+		// In production the persistent structures buffer in storage is at the writer's version
+		// (saveStructures wrote it); only the in-memory singleton encoder dict lags. The fix
+		// catches "end of buffer not reached" once, calls getStructures() (which reads from
+		// storage), merges, and retries decode.
+		const writerStore = sharedStore();
+		const writer = makeEncoder(false, writerStore);
+		const bytes = Buffer.from(writer.encode({ id: 'x', payload: 'hello', tag: 'extra' }));
+
+		const reader = makeEncoder(false, writerStore);
+		reader.structures = writerStore.get().map((entry) => (Array.isArray(entry) ? entry.slice(0, -1) : entry));
+
+		const decoded = reader.decode(bytes);
+		assert.deepStrictEqual(
+			decoded,
+			{ id: 'x', payload: 'hello', tag: 'extra' },
+			`fix should reload structures on "end of buffer not reached" and recover the full record; got ${JSON.stringify(decoded)}`
+		);
+		assert.strictEqual(errors.length, 0, 'recovery must not leak to the error log');
+	});
+
+	it('falls through to null + error log when reload does not advance the dict', () => {
+		// Guards the _reloadingStructures recursion guard: if a single reload doesn't actually
+		// advance the dict, the second decode must NOT retry again. Falls through to the existing
+		// null-on-corrupt-decode contract so we don't spin or shadow real corruption.
+		const writerStore = sharedStore();
+		const writer = makeEncoder(false, writerStore);
+		const bytes = Buffer.from(writer.encode({ id: 'x', payload: 'hello', tag: 'extra' }));
+
+		const stuckStore = sharedStore();
+		stuckStore.save(writerStore.get().map((entry) => (Array.isArray(entry) ? entry.slice(0, -1) : entry)));
+		const reader = makeEncoder(false, stuckStore);
+
+		const decoded = reader.decode(bytes);
+		assert.strictEqual(decoded, null, 'permanent truncation must still produce null');
+		assert.ok(
+			errors.some((e) => /end of buffer not reached/i.test((e[1] && e[1].message) || e.join(' '))),
+			'permanent failure must still surface in the error log (not silent)'
+		);
+	});
+
+	it('reports "Data read, but end of buffer not reached" when reader’s structures are behind writer’s', () => {
+		// Pure symptom: writer uses CLASSIC shared structures (randomAccessStructure=false). Its
+		// first encoded record installs a 3-field structure at index 0. Reader uses a DIFFERENT
+		// store seeded with a TRUNCATED structures dict (same index, only the first two fields).
+		// Models the v4→v5 first-upgrade window where the v5 receiver's local encoder dict for a
+		// given struct index lagged behind the writer's by one field. The bytes for the third
+		// field are still in the buffer; msgpackr decodes the two declared fields and checkedRead
+		// then flags the leftover bytes.
+		const writerStore = sharedStore();
+		const writer = makeEncoder(false, writerStore);
+		const wideRecord = { id: 'x', payload: 'hello', tag: 'extra' };
+		const bytes = Buffer.from(writer.encode(wideRecord));
+
+		const fullStructures = writerStore.get();
+		const stale = sharedStore();
+		stale.save(fullStructures.map((entry) => (Array.isArray(entry) ? entry.slice(0, -1) : entry)));
+		const reader = makeEncoder(false, stale);
+		const decoded = reader.decode(bytes);
+
+		const messages = errors.map((e) => (e[1] && e[1].message) || e.join(' '));
+		const hitLog = messages.some((m) => /end of buffer not reached/i.test(m));
+		const hitNull = decoded === null;
+		assert.ok(
+			hitLog || !hitNull,
+			`expected leftover-bytes detection (null + error log, or thrown error). decoded=${JSON.stringify(decoded)} messages=${JSON.stringify(messages)}`
+		);
+		if (hitNull) {
+			assert.ok(hitLog, `decoded to null but error log did not include "end of buffer not reached": ${JSON.stringify(messages)}`);
+		} else if (decoded !== null && JSON.stringify(decoded) === JSON.stringify(wideRecord)) {
+			assert.fail('reader recovered the full record despite a truncated dict; symptom is not reproduced by this fixture');
+		}
+	});
+});


### PR DESCRIPTION
Fixes #1445.

## Summary

`RecordEncoder.decode` catch block returns null on any non-missing-structure decode error. When the local in-memory `structures` array is shorter than the persistent buffer the writer used, msgpackr's `checkedRead` flags leftover bytes for the (N+k)-th field and throws "Data read, but end of buffer not reached". The stored bytes are intact: only the in-memory singleton encoder dict has fallen behind what `saveStructures` already persisted. Without recovery, every read of that struct ID returns null until the singleton happens to refresh, silently laundering data as missing.

Typed (random-access) structures auto-reload via structon's `_readStruct` on a miss (`harper#1163`). The classic-structures path has no equivalent recovery for the tail-shape mismatch.

## Fix

In the existing catch block, when the error message matches `end of buffer not reached`, call `getStructures()` (reads the persistent buffer), `_mergeStructures()` to update the in-memory dict, then retry `decode` once. A `_reloadingStructures` instance flag guards a single retry so a reload that doesn't actually advance the dict falls straight through to the original null + error log path rather than recursing.

## Test plan

- [x] `npx mocha unitTests/resources/recordEncoder.test.js` passes (12/12, includes the 3 new dict-lag tests)
- [x] `recovers via getStructures() reload when persistent dict has caught up to writer` asserts the fix succeeds when storage has the fresh dict
- [x] `falls through to null + error log when reload does not advance the dict` asserts the recursion guard prevents infinite retry and real corruption still surfaces
- [x] `reports "Data read, but end of buffer not reached" when reader's structures are behind writer's` asserts the symptom is still detected (no regression of the existing log path)

## Production observation

Akamai v4→v5 stage cluster (5.1.6-fixes2): 23 unique HttpCache records on the first upgraded node silently lost over a 13-minute post-upgrade window. Second upgrade (with a v5 peer to sync from) lost 0, isolating the trigger to the first-upgrade base-copy resync window when the local singleton encoder ingests records before its in-memory dict reloads.

## Distinct from #1441

That bug is a writer-side CAS clobber: the persisted structures buffer itself was overwritten. This bug is a reader-side in-memory lag: the persisted buffer is fine, only the local encoder hasn't reloaded.