### PR TITLE
fix(deploy): restore CLI deploy compatibility with pre-5.1 servers

### DIFF
--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -9,7 +9,8 @@ import { httpRequest } from '../utility/common_utils.ts';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as YAML from 'yaml';
-import { streamPackagedDirectory, getPackagedDirectorySize } from '../components/packageComponent.ts';
+import { streamPackagedDirectory, getPackagedDirectorySize, packageDirectory } from '../components/packageComponent.ts';
+import { encode as encodeCbor } from 'cbor-x';
 import { buildMultipartBody } from './multipartBuilder.ts';
 import { parseSSE } from './sseConsumer.ts';
 import { DeployRenderer } from './deployRenderer.ts';
@@ -36,6 +37,64 @@ const TRANSPORT_ONLY_FIELDS = new Set([
 	'skip_node_modules',
 	'skip_symlinks',
 ]);
+
+// Streaming (multipart upload + SSE progress) deploy was introduced in 5.1.0. A CLI at >=
+// 5.1 talking to a server < 5.1 must not use it: the older server has no multipart body
+// parser (the upload is rejected) and its generic text/event-stream serializer emits a bare
+// `data:` frame with no `done` event (so the CLI reads no result — "Deploy completed (no
+// result payload)."). For those targets we fall back to the legacy deploy transport: the
+// tarball rides as a native binary `payload` in a CBOR-encoded body — exactly what the
+// pre-5.1 CLI sent (Content-Type: application/cbor) — so it stays compact (~1x) instead of
+// ballooning as a base64 string (~1.33x) or a {type,data} JSON byte array (~5x).
+const STREAMING_DEPLOY_MIN_MAJOR = 5;
+const STREAMING_DEPLOY_MIN_MINOR = 1;
+
+/**
+ * Parses a Harper version string (e.g. "5.0.31", "5.1.0-beta.2") and reports whether the
+ * server is new enough to accept the multipart + SSE streaming deploy. Unparseable input
+ * returns true so we never downgrade a deploy against a server we simply can't classify.
+ */
+function versionSupportsStreamingDeploy(version: unknown): boolean {
+	if (typeof version !== 'string') return true;
+	const match = version.match(/^(\d+)\.(\d+)/);
+	if (!match) return true;
+	const major = Number(match[1]);
+	const minor = Number(match[2]);
+	if (major !== STREAMING_DEPLOY_MIN_MAJOR) return major > STREAMING_DEPLOY_MIN_MAJOR;
+	return minor >= STREAMING_DEPLOY_MIN_MINOR;
+}
+
+/**
+ * Probes a remote target's Harper version via `registration_info` (a lightweight, long-lived
+ * operation present on both < 5.1 and >= 5.1 servers that returns `{ version }`) to decide
+ * whether the streaming deploy protocol is supported. Any probe failure — non-200, missing
+ * version, network error — resolves to `true` (assume modern) so we never break a deploy
+ * that would otherwise have worked; we only downgrade on a positive "older than 5.1" reading.
+ */
+async function targetSupportsStreamingDeploy(options: any): Promise<boolean> {
+	try {
+		const probeOptions = { ...options, headers: { ...options.headers, Accept: 'application/json' } };
+		delete probeOptions.streamResponse;
+		const response = await httpRequest(probeOptions, { operation: 'registration_info' });
+		if (response.statusCode !== 200 || !response.body) return true;
+		const version = JSON.parse(response.body)?.version;
+		return versionSupportsStreamingDeploy(version);
+	} catch {
+		return true;
+	}
+}
+
+// Build the JSON operation-field set from `req`, dropping the CLI's internal (`_`-prefixed)
+// and transport-only fields so neither the CLI internals nor credentials leak into the
+// request body. Shared by the multipart and legacy-JSON deploy body builders.
+function operationFields(req: any): any {
+	const fields: any = {};
+	for (const [key, value] of Object.entries(req)) {
+		if (key.startsWith('_') || TRANSPORT_ONLY_FIELDS.has(key)) continue;
+		fields[key] = value;
+	}
+	return fields;
+}
 
 export { cliOperations, buildRequest };
 const PREPARE_OPERATION: any = {
@@ -204,7 +263,24 @@ async function cliOperations(req: any, skipResponseLog = false) {
 				options.headers.Authorization = `Bearer ${tokens.operation_token}`;
 			}
 		}
-		const useSse = SSE_OPERATIONS.has(req.operation);
+		// Streaming deploy (multipart upload + SSE progress) only works against >= 5.1 servers.
+		// When deploying to a remote target, probe its version first and downgrade to the
+		// legacy JSON deploy if it predates 5.1. Local (domain-socket) deploys always
+		// hit this same Harper build, so no probe is needed there.
+		if (req.operation === 'deploy_component' && target && !(await targetSupportsStreamingDeploy(options))) {
+			req._legacyDeploy = true;
+			if (req._multipart) {
+				// Re-package the directory as a single buffered tarball. The legacy CBOR body
+				// below carries it as native binary, matching the pre-5.1 CLI.
+				req.payload = await packageDirectory(req._projectPath, req._packageOptions);
+				delete req._multipart;
+			}
+			console.error(
+				'Target Harper predates streaming deploy (< 5.1); using legacy compatibility deploy (no live progress).'
+			);
+		}
+
+		const useSse = SSE_OPERATIONS.has(req.operation) && !req._legacyDeploy;
 		if (useSse) {
 			options.headers.Accept = 'text/event-stream';
 			options.streamResponse = true;
@@ -223,11 +299,7 @@ async function cliOperations(req: any, skipResponseLog = false) {
 				req._packageOptions,
 				renderer ? (n) => renderer.countUploadBytes(n) : undefined
 			);
-			const fields = {};
-			for (const [key, value] of Object.entries(req)) {
-				if (key.startsWith('_') || TRANSPORT_ONLY_FIELDS.has(key)) continue;
-				fields[key] = value;
-			}
+			const fields = operationFields(req);
 			const multipart = buildMultipartBody(fields, {
 				name: 'payload',
 				filename: 'package.tar.gz',
@@ -241,6 +313,20 @@ async function cliOperations(req: any, skipResponseLog = false) {
 			// Tap the body so bytes flowing into the HTTP request advance the upload bar.
 			// The renderer's Transform is identity — chunks pass through unmodified.
 			body = renderer ? renderer.tapUploadStream(multipart.stream) : multipart.stream;
+		} else if (req._legacyDeploy) {
+			const fields = operationFields(req);
+			if (Buffer.isBuffer(fields.payload)) {
+				// Directory deploy: CBOR-encode so the tarball travels as a native binary
+				// byte string (the pre-5.1 transport). The pre-5.1 server's cbor parser hands
+				// the handler a real Buffer payload. Accept JSON so the buffered response
+				// parses on the existing (non-SSE) path below.
+				options.headers['Content-Type'] = 'application/cbor';
+				options.headers.Accept = 'application/json';
+				body = encodeCbor(fields);
+			} else {
+				// Package deploy (no binary payload): plain JSON, as pre-5.1 sent it.
+				body = fields;
+			}
 		} else {
 			body = req;
 		}

--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -271,8 +271,17 @@ async function cliOperations(req: any, skipResponseLog = false) {
 			req._legacyDeploy = true;
 			if (req._multipart) {
 				// Re-package the directory as a single buffered tarball. The legacy CBOR body
-				// below carries it as native binary, matching the pre-5.1 CLI.
-				req.payload = await packageDirectory(req._projectPath, req._packageOptions);
+				// below carries it as native binary, matching the pre-5.1 CLI. Wrap the
+				// packaging so a local failure (e.g. a file vanishing after the size walk)
+				// surfaces as itself rather than being mapped to "Failed to connect to Harper"
+				// by the catch below (which keys off err.code === 'ENOENT').
+				try {
+					req.payload = await packageDirectory(req._projectPath, req._packageOptions);
+				} catch (packageErr: any) {
+					throw new Error(`Failed to package component directory '${req._projectPath}': ${packageErr.message}`, {
+						cause: packageErr,
+					});
+				}
 				delete req._multipart;
 			}
 			console.error(

--- a/unitTests/bin/cliOperations.test.js
+++ b/unitTests/bin/cliOperations.test.js
@@ -4,10 +4,13 @@ const assert = require('node:assert/strict');
 const path = require('node:path');
 const fs = require('fs-extra');
 const os = require('node:os');
+const { Readable } = require('node:stream');
+const { decode: decodeCbor } = require('cbor-x');
 const { saveCredentials } = require('#src/bin/cliCredentials');
 const cliOperationsModule = require('#src/bin/cliOperations');
 const commonUtilsModule = require('#src/utility/common_utils');
 const tokenAuthModule = require('#src/security/tokenAuthentication');
+const packageComponentModule = require('#src/components/packageComponent');
 
 describe('cliOperations', () => {
 	const testDir = path.join(os.tmpdir(), `harper-test-cli-ops-${Date.now()}`);
@@ -94,5 +97,134 @@ describe('cliOperations', () => {
 		const { loadCredentials } = require('#src/bin/cliCredentials');
 		const creds = loadCredentials();
 		assert.strictEqual(creds.targets[target].operation_token, 'new-token');
+	});
+
+	describe('deploy_component cross-version compatibility', () => {
+		const target = 'https://example.com:9925/';
+		let originalPackageDirectory;
+		let originalGetSize;
+
+		beforeEach(() => {
+			saveCredentials(target, { operation_token: 'valid-token', refresh_token: 'refresh-token' });
+			tokenAuthModule.isJWTExpired = () => false;
+			originalPackageDirectory = packageComponentModule.packageDirectory;
+			originalGetSize = packageComponentModule.getPackagedDirectorySize;
+		});
+
+		afterEach(() => {
+			packageComponentModule.packageDirectory = originalPackageDirectory;
+			packageComponentModule.getPackagedDirectorySize = originalGetSize;
+		});
+
+		// Streams an SSE `done` event so the modern (>= 5.1) deploy path can read its result.
+		const sseDoneResponse = (result) =>
+			Object.assign(Readable.from([`event: done\ndata: ${JSON.stringify({ result })}\n\n`]), {
+				statusCode: 200,
+				headers: { 'content-type': 'text/event-stream' },
+			});
+
+		it('downgrades a package deploy to legacy JSON when the target is < 5.1', async () => {
+			const calls = [];
+			commonUtilsModule.httpRequest = async (options, req) => {
+				calls.push({ options, req });
+				if (req.operation === 'registration_info') {
+					return { statusCode: 200, body: JSON.stringify({ version: '5.0.31' }) };
+				}
+				return { statusCode: 200, body: JSON.stringify({ message: 'Successfully deployed', success: true }) };
+			};
+
+			const result = await cliOperationsModule.cliOperations(
+				{ operation: 'deploy_component', package: '@scope/widget', project: 'widget', target: 'example.com' },
+				true
+			);
+
+			// Probe first, then the deploy.
+			assert.strictEqual(calls[0].req.operation, 'registration_info');
+			assert.strictEqual(calls[0].options.streamResponse, undefined);
+			const deploy = calls[1];
+			// No streaming negotiation against the old server.
+			assert.strictEqual(deploy.options.headers.Accept, undefined);
+			assert.strictEqual(deploy.options.streamResponse, undefined);
+			// Body is a plain JSON object, not a multipart stream, and carries no transport-only fields.
+			assert.strictEqual(typeof deploy.req.pipe, 'undefined');
+			assert.strictEqual(deploy.req.operation, 'deploy_component');
+			assert.strictEqual(deploy.req._legacyDeploy, undefined);
+			assert.strictEqual(deploy.req._multipart, undefined);
+			assert.strictEqual(result.success, true);
+		});
+
+		it('downgrades a directory deploy to a CBOR binary payload when the target is < 5.1', async () => {
+			const fakeTarball = Buffer.from('fake-tarball-bytes');
+			packageComponentModule.getPackagedDirectorySize = async () => fakeTarball.length;
+			packageComponentModule.packageDirectory = async () => fakeTarball;
+
+			const calls = [];
+			commonUtilsModule.httpRequest = async (options, req) => {
+				calls.push({ options, req });
+				if (req.operation === 'registration_info') {
+					return { statusCode: 200, body: JSON.stringify({ version: '5.0.31' }) };
+				}
+				return { statusCode: 200, body: JSON.stringify({ message: 'Successfully deployed', success: true }) };
+			};
+
+			const result = await cliOperationsModule.cliOperations(
+				{ operation: 'deploy_component', project: 'widget', target: 'example.com' },
+				true
+			);
+
+			const deploy = calls[1];
+			assert.strictEqual(deploy.options.streamResponse, undefined);
+			// Multipart was abandoned in favor of a CBOR body carrying the tarball as a
+			// native binary Buffer — the transport pre-5.1 servers decode directly.
+			assert.strictEqual(deploy.options.headers['Content-Type'], 'application/cbor');
+			assert.ok(Buffer.isBuffer(deploy.req), 'CBOR body should be a Buffer');
+			const decoded = decodeCbor(deploy.req);
+			assert.ok(Buffer.isBuffer(decoded.payload), 'decoded payload should be a Buffer');
+			assert.strictEqual(decoded.payload.toString(), 'fake-tarball-bytes');
+			assert.strictEqual(decoded.operation, 'deploy_component');
+			assert.strictEqual(decoded._multipart, undefined);
+			assert.strictEqual(result.success, true);
+		});
+
+		it('keeps the streaming deploy path when the target is >= 5.1', async () => {
+			const calls = [];
+			commonUtilsModule.httpRequest = async (options, req) => {
+				calls.push({ options, req });
+				if (req.operation === 'registration_info') {
+					return { statusCode: 200, body: JSON.stringify({ version: '5.1.7' }) };
+				}
+				return sseDoneResponse({ message: 'Successfully deployed', success: true });
+			};
+
+			const result = await cliOperationsModule.cliOperations(
+				{ operation: 'deploy_component', package: '@scope/widget', project: 'widget', target: 'example.com' },
+				true
+			);
+
+			const deploy = calls[1];
+			assert.strictEqual(deploy.options.headers.Accept, 'text/event-stream');
+			assert.strictEqual(deploy.options.streamResponse, true);
+			assert.strictEqual(result.success, true);
+		});
+
+		it('does not downgrade when the version probe fails (assumes modern)', async () => {
+			const calls = [];
+			commonUtilsModule.httpRequest = async (options, req) => {
+				calls.push({ options, req });
+				if (req.operation === 'registration_info') {
+					return { statusCode: 404, body: 'not found' };
+				}
+				return sseDoneResponse({ message: 'Successfully deployed', success: true });
+			};
+
+			const result = await cliOperationsModule.cliOperations(
+				{ operation: 'deploy_component', package: '@scope/widget', project: 'widget', target: 'example.com' },
+				true
+			);
+
+			const deploy = calls[1];
+			assert.strictEqual(deploy.options.headers.Accept, 'text/event-stream');
+			assert.strictEqual(result.success, true);
+		});
 	});
 });


### PR DESCRIPTION
## Summary
The 5.1 `deploy_component` CLI uploads via `multipart/form-data` and consumes the response as SSE, reading its result from a `done` event. This breaks deploys against **Harper servers < 5.1**:

- Pre-5.1 servers have **no multipart body parser** → the upload is rejected.
- Their generic `text/event-stream` serializer emits a **bare `data:` frame with no `done` event** → the CLI reads no result, prints `Deploy completed (no result payload).`, and the run fails.

The 5.0.x CLI used a CBOR deploy and worked, so this is a cross-version regression (reported from Studio CI deploying to older instances).

**Fix:** for a *remote* `deploy_component`, probe the target's version via `registration_info` and, when it predates 5.1, fall back to the legacy transport — restoring exactly what the pre-5.1 CLI did. Modern targets are unchanged.

## Behavior notes
- **Probe failure ⇒ assume modern** (no downgrade), so a flaky/absent probe can never break a deploy that works today; we only downgrade on a positive "< 5.1" reading.
- **Local (domain-socket) deploys skip the probe** — same build, same protocol.
- **Legacy transport mirrors the 5.0.x CLI exactly:** a *directory* deploy is **CBOR-encoded** (`Content-Type: application/cbor`) with the tarball as a **native binary `payload`** — compact (~1×) and decoded directly by the pre-5.1 server's cbor parser (no base64/JSON-array bloat, so large components stay under the operations-API body limit). A *package* (`package=`) deploy goes as plain JSON, also as 5.0 sent it. Neither uses SSE.

## Where to look
- `bin/cliOperations.ts` — `versionSupportsStreamingDeploy` (version gate), `targetSupportsStreamingDeploy` (the probe), and the `_legacyDeploy` branch in `cliOperations` (CBOR for directory, JSON for package).
- One extra round-trip per remote deploy (the probe). Deploys are infrequent and already long-running, so this is judged negligible — flagging in case you disagree.

## Tests
4 new unit tests in `unitTests/bin/cliOperations.test.js`: old-package downgrade (JSON), old-directory downgrade (asserts the CBOR body round-trips to a binary payload), modern-server keeps streaming, probe-failure assumes modern. All pass; changed files are prettier/oxlint clean.

## Review
Cross-model review run (Codex + Harper-domain adjudication). Codex flagged the legacy payload encoding; the fallback now uses the **same CBOR binary transport as the 5.0.x CLI** (verified the pre-5.1 server's `application/cbor` parser + `Application.ts` accept it). **Caveat: the Gemini leg timed out, so there's no perf/maintainability second-model pass** — nothing here looks perf-sensitive.

**Open (non-blocking) — Gemini inline finding:** in the legacy branch, if `packageDirectory` throws `ENOENT`, it propagates to the main `catch` which maps `ENOENT` → `Failed to connect to Harper`, misreporting a local packaging error. Low-severity (the directory is already walked by `getPackagedDirectorySize` first), left open pending a decision on a small descriptive-rethrow.

Possible **patch-release candidate** for 5.1.x (safe, isolated to the CLI deploy path).

No docs change: this restores prior cross-version deploy behavior; no new user-facing API/flag/config.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Opus 4.8 (1M context).