### PR TITLE
fix(components): correct broken docs URL in Extension API deprecation warning

### DIFF
--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -493,7 +493,7 @@ export async function loadComponent(
 						'setupDirectory' in extensionModule)
 				) {
 					harperLogger.warn?.(
-						`Component ${componentName} is using deprecated extension API. Upgrade to the new Plugin API. For more information: https://docs.harperdb.io/docs/reference/components/plugins`
+						`Component ${componentName} is using deprecated extension API. Upgrade to the new Plugin API. For more information: https://docs.harperdb.io/reference/components/plugin-api`
 					);
 				}
 


### PR DESCRIPTION
## What

One-line fix to the deprecation warning logged when a component uses the old Extension API.

`components/componentLoader.ts` pointed authors at:

```
https://docs.harperdb.io/docs/reference/components/plugins
```

which 404s — it has a stray `/docs/` prefix (the site has no such prefix; e.g. the v5 migration note lives at `https://docs.harperdb.io/release-notes/v5-lincoln/v5-migration`) and the wrong slug (`plugins` — there's no such page). The Plugin API reference is published from `reference/components/plugin-api.md` in `HarperFast/documentation`. Updated the warning to:

```
https://docs.harperdb.io/reference/components/plugin-api
```

## Why

This URL is the first pointer an author gets toward the replacement API, so a dead link is high-friction at exactly the wrong moment.

## Note

Please confirm the published slug resolves before merge — the docs site is a SPA and I couldn't get a clean live check, but the path is derived from the doc source and the site's routing convention.

Fixes #1449

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
