### PR TITLE
Clarify upgrade migration log: show the data→software transition and migration purpose

### DIFF
--- a/unitTests/upgrade/directivesController.test.js
+++ b/unitTests/upgrade/directivesController.test.js
@@ -34,6 +34,9 @@ describe('directivesController — hdb_deployment table-creation directive', () 
 		const directive = directivesController.getDirectiveByVersion('5.1.0');
 		expect(directive, 'expected a directive registered for version 5.1.0').to.exist;
 		expect(directive.version).to.equal('5.1.0');
+		expect(directive.description, 'directive should carry a human-readable description for the upgrade log').to.be.a(
+			'string'
+		).that.is.not.empty;
 		expect(directive.async_functions).to.be.an('array').that.is.not.empty;
 		expect(directive.async_functions[0].name).to.equal('createHdbDeploymentIfMissing');
 	});

--- a/unitTests/upgrade/directivesManager.test.js
+++ b/unitTests/upgrade/directivesManager.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const sinon = require('sinon');
+const chai = require('chai');
+const { expect } = chai;
+
+const directivesManager = require('#src/upgrade/directivesManager');
+const directivesController = require('#src/upgrade/directives/directivesController');
+const { UpgradeObject } = require('#src/upgrade/UpgradeObjects');
+
+// Coverage for the upgrade log wording: the per-migration line must describe the actual
+// data -> software transition and what each migration does, rather than printing the bare
+// directive version (which is the release that *introduced* the migration, not the version
+// being installed — e.g. "Running upgrade for version 5.1.0" while installing 5.1.7).
+describe('directivesManager.processDirectives — upgrade log output', () => {
+	const sandbox = sinon.createSandbox();
+	let consoleLog_stub;
+	let getVersions_stub;
+	let getDirective_stub;
+
+	const fakeDirective = {
+		version: '5.1.0',
+		description: 'create system.hdb_deployment table for deployment tracking',
+		sync_functions: [],
+		async_functions: [async function noop() {}],
+	};
+
+	beforeEach(() => {
+		consoleLog_stub = sandbox.stub(console, 'log').returns();
+		// log.notify receives the same text as console.log; stub best-effort to keep test output quiet.
+		const loggerModule = require('#src/utility/logging/harper_logger');
+		const logger = loggerModule.default ?? loggerModule;
+		if (typeof logger.notify === 'function') sandbox.stub(logger, 'notify').returns();
+		getVersions_stub = sandbox.stub(directivesController, 'getVersionsForUpgrade');
+		getDirective_stub = sandbox.stub(directivesController, 'getDirectiveByVersion');
+	});
+
+	afterEach(() => sandbox.restore());
+
+	const loggedLines = () => consoleLog_stub.getCalls().map((call) => call.args[0]);
+
+	it('headers with the real data -> software transition, not the directive version', async () => {
+		getVersions_stub.returns(['5.1.0']);
+		getDirective_stub.withArgs('5.1.0').returns(fakeDirective);
+
+		await directivesManager.processDirectives(new UpgradeObject('5.0.22', '5.1.7'));
+
+		const lines = loggedLines();
+		const header = lines.find((line) => line.startsWith('Starting upgrade process'));
+		expect(header, 'expected a header line').to.exist;
+		expect(header).to.include('5.0.22');
+		expect(header).to.include('5.1.7');
+		// the old, misleading bare-version line must be gone
+		expect(lines).to.not.include('Running upgrade for version 5.1.0');
+	});
+
+	it('describes each migration as "introduced in <version>" with its description', async () => {
+		getVersions_stub.returns(['5.1.0']);
+		getDirective_stub.withArgs('5.1.0').returns(fakeDirective);
+
+		await directivesManager.processDirectives(new UpgradeObject('5.0.22', '5.1.7'));
+
+		const line = loggedLines().find((logged) => logged.startsWith('Applying migration'));
+		expect(line, 'expected an "Applying migration" line').to.exist;
+		expect(line).to.include('introduced in 5.1.0');
+		expect(line).to.include('create system.hdb_deployment table for deployment tracking');
+	});
+
+	it('reports when there are no migrations to apply', async () => {
+		getVersions_stub.returns([]);
+
+		await directivesManager.processDirectives(new UpgradeObject('5.1.7', '5.1.7'));
+
+		const lines = loggedLines();
+		expect(lines.some((line) => line.includes('no data migrations to apply'))).to.be.true;
+		expect(getDirective_stub.called, 'no directive should be looked up when none apply').to.be.false;
+	});
+});

--- a/unitTests/upgrade/directivesManager.test.js
+++ b/unitTests/upgrade/directivesManager.test.js
@@ -1,78 +1,44 @@
 'use strict';
 
-const sinon = require('sinon');
-const chai = require('chai');
-const { expect } = chai;
+const assert = require('node:assert/strict');
+const { formatUpgradeHeader, formatMigrationLine } = require('#src/upgrade/directivesManager');
 
-const directivesManager = require('#src/upgrade/directivesManager');
-const directivesController = require('#src/upgrade/directives/directivesController');
-const { UpgradeObject } = require('#src/upgrade/UpgradeObjects');
+// The upgrade log must describe the real data -> software transition and what each migration does,
+// rather than printing a bare directive version (the release that *introduced* a migration, e.g.
+// "5.1.0" while installing 5.1.7), which reads like a downgrade.
+describe('directivesManager — upgrade log wording', function () {
+	describe('formatUpgradeHeader', function () {
+		it('names the real data -> software transition for a single migration', function () {
+			const header = formatUpgradeHeader('5.0.22', '5.1.7', 1);
+			assert.ok(header.includes('from 5.0.22'), header);
+			assert.ok(header.includes('software 5.1.7'), header);
+			assert.ok(header.includes('1 data migration '), `expected singular wording: ${header}`);
+			assert.ok(!header.includes('Running upgrade for version'), 'old misleading wording must be gone');
+		});
 
-// Coverage for the upgrade log wording: the per-migration line must describe the actual
-// data -> software transition and what each migration does, rather than printing the bare
-// directive version (which is the release that *introduced* the migration, not the version
-// being installed — e.g. "Running upgrade for version 5.1.0" while installing 5.1.7).
-describe('directivesManager.processDirectives — upgrade log output', () => {
-	const sandbox = sinon.createSandbox();
-	let consoleLog_stub;
-	let getVersions_stub;
-	let getDirective_stub;
+		it('pluralizes and reports the count for multiple migrations', function () {
+			const header = formatUpgradeHeader('5.0.0', '5.3.0', 3);
+			assert.ok(header.includes('applying 3 data migrations '), header);
+		});
 
-	const fakeDirective = {
-		version: '5.1.0',
-		description: 'create system.hdb_deployment table for deployment tracking',
-		sync_functions: [],
-		async_functions: [async function noop() {}],
-	};
-
-	beforeEach(() => {
-		consoleLog_stub = sandbox.stub(console, 'log').returns();
-		// log.notify receives the same text as console.log; stub best-effort to keep test output quiet.
-		const loggerModule = require('#src/utility/logging/harper_logger');
-		const logger = loggerModule.default ?? loggerModule;
-		if (typeof logger.notify === 'function') sandbox.stub(logger, 'notify').returns();
-		getVersions_stub = sandbox.stub(directivesController, 'getVersionsForUpgrade');
-		getDirective_stub = sandbox.stub(directivesController, 'getDirectiveByVersion');
+		it('reports when there are no migrations to apply', function () {
+			const header = formatUpgradeHeader('5.1.7', '5.1.7', 0);
+			assert.ok(header.includes('no data migrations to apply'), header);
+		});
 	});
 
-	afterEach(() => sandbox.restore());
+	describe('formatMigrationLine', function () {
+		it('frames the version as "introduced in" and appends the description', function () {
+			const line = formatMigrationLine(1, 1, '5.1.0', 'create system.hdb_deployment table for deployment tracking');
+			assert.equal(
+				line,
+				'Applying migration 1 of 1 (introduced in 5.1.0): create system.hdb_deployment table for deployment tracking'
+			);
+		});
 
-	const loggedLines = () => consoleLog_stub.getCalls().map((call) => call.args[0]);
-
-	it('headers with the real data -> software transition, not the directive version', async () => {
-		getVersions_stub.returns(['5.1.0']);
-		getDirective_stub.withArgs('5.1.0').returns(fakeDirective);
-
-		await directivesManager.processDirectives(new UpgradeObject('5.0.22', '5.1.7'));
-
-		const lines = loggedLines();
-		const header = lines.find((line) => line.startsWith('Starting upgrade process'));
-		expect(header, 'expected a header line').to.exist;
-		expect(header).to.include('5.0.22');
-		expect(header).to.include('5.1.7');
-		// the old, misleading bare-version line must be gone
-		expect(lines).to.not.include('Running upgrade for version 5.1.0');
-	});
-
-	it('describes each migration as "introduced in <version>" with its description', async () => {
-		getVersions_stub.returns(['5.1.0']);
-		getDirective_stub.withArgs('5.1.0').returns(fakeDirective);
-
-		await directivesManager.processDirectives(new UpgradeObject('5.0.22', '5.1.7'));
-
-		const line = loggedLines().find((logged) => logged.startsWith('Applying migration'));
-		expect(line, 'expected an "Applying migration" line').to.exist;
-		expect(line).to.include('introduced in 5.1.0');
-		expect(line).to.include('create system.hdb_deployment table for deployment tracking');
-	});
-
-	it('reports when there are no migrations to apply', async () => {
-		getVersions_stub.returns([]);
-
-		await directivesManager.processDirectives(new UpgradeObject('5.1.7', '5.1.7'));
-
-		const lines = loggedLines();
-		expect(lines.some((line) => line.includes('no data migrations to apply'))).to.be.true;
-		expect(getDirective_stub.called, 'no directive should be looked up when none apply').to.be.false;
+		it('omits the description segment when none is provided', function () {
+			const line = formatMigrationLine(2, 4, '5.4.0');
+			assert.equal(line, 'Applying migration 2 of 4 (introduced in 5.4.0)');
+		});
 	});
 });

--- a/upgrade/directives/5-1-0.ts
+++ b/upgrade/directives/5-1-0.ts
@@ -82,6 +82,7 @@ async function patchHdbDeploymentIsHashAttribute() {
 
 const directive510 = {
 	version: '5.1.0',
+	description: 'create system.hdb_deployment table for deployment tracking',
 	sync_functions: [] as Array<() => unknown>,
 	async_functions: [createHdbDeploymentIfMissing] as Array<() => Promise<unknown>>,
 };

--- a/upgrade/directivesManager.ts
+++ b/upgrade/directivesManager.ts
@@ -8,6 +8,26 @@ import * as directivesController from './directives/directivesController.ts';
 const { DATA_VERSION, UPGRADE_VERSION } = hdbTerms.UPGRADE_JSON_FIELD_NAMES_ENUM;
 
 /**
+ * Build the upgrade-process header line. Surfaces the real data -> software transition and the
+ * migration count so the per-migration directive version below isn't misread as a downgrade: a
+ * migration's version is the release that *introduced* it, not the software version being installed,
+ * so a migration tagged 5.1.0 can run while installing a later release (e.g. 5.1.7).
+ */
+export function formatUpgradeHeader(dataVersion: any, upgradeVersion: any, migrationCount: number) {
+	if (migrationCount === 0) {
+		return `Starting upgrade process: no data migrations to apply (data ${dataVersion} -> software ${upgradeVersion}).`;
+	}
+	const plural = migrationCount === 1 ? '' : 's';
+	return `Starting upgrade process: applying ${migrationCount} data migration${plural} to bring data from ${dataVersion} up to software ${upgradeVersion}.`;
+}
+
+/** Build a single migration's log line: which migration, the release that introduced it, and what it does. */
+export function formatMigrationLine(position: number, total: number, version: any, description?: any) {
+	const detail = description ? `: ${description}` : '';
+	return `Applying migration ${position} of ${total} (introduced in ${version})${detail}`;
+}
+
+/**
  * Iterates through the directives files to find uninstalled updates and runs the files.
  *
  * @param upgradeObj
@@ -22,22 +42,14 @@ export async function processDirectives(upgradeObj: any) {
 
 	const dirLength = upgradeDirectives.length;
 
-	// A migration's version is the release that *introduced* it, not the software version being
-	// installed. Migrations run once, when the data crosses their version boundary, so a migration
-	// tagged 5.1.0 can run while installing a later release (e.g. 5.1.7) and the bare version is
-	// easily misread as a downgrade. Log the actual data -> software transition for context.
-	const header =
-		dirLength === 0
-			? `Starting upgrade process: no data migrations to apply (data ${dataVersion} -> software ${upgradeVersion}).`
-			: `Starting upgrade process: applying ${dirLength} data migration${dirLength === 1 ? '' : 's'} to bring data from ${dataVersion} up to software ${upgradeVersion}.`;
+	const header = formatUpgradeHeader(dataVersion, upgradeVersion, dirLength);
 	log.notify(header);
 	console.log(header);
 
 	let allResponses = [];
 	for (let i = 0; i < dirLength; i++) {
 		const vers = upgradeDirectives[i];
-		const description = vers.description ? `: ${vers.description}` : '';
-		let notifyMsg = `Applying migration ${i + 1} of ${dirLength} (introduced in ${vers.version})${description}`;
+		let notifyMsg = formatMigrationLine(i + 1, dirLength, vers.version, vers.description);
 		log.notify(notifyMsg);
 		console.log(notifyMsg);
 

--- a/upgrade/directivesManager.ts
+++ b/upgrade/directivesManager.ts
@@ -1,8 +1,11 @@
 'use strict';
 
 import * as hdbUtil from '../utility/common_utils.ts';
+import * as hdbTerms from '../utility/hdbTerms.ts';
 import log from '../utility/logging/harper_logger.ts';
 import * as directivesController from './directives/directivesController.ts';
+
+const { DATA_VERSION, UPGRADE_VERSION } = hdbTerms.UPGRADE_JSON_FIELD_NAMES_ENUM;
 
 /**
  * Iterates through the directives files to find uninstalled updates and runs the files.
@@ -11,16 +14,30 @@ import * as directivesController from './directives/directivesController.ts';
  * @returns {Promise<*[]>}
  */
 export async function processDirectives(upgradeObj: any) {
-	console.log('Starting upgrade process...');
+	const dataVersion = upgradeObj?.[DATA_VERSION];
+	const upgradeVersion = upgradeObj?.[UPGRADE_VERSION];
 
 	let loadedDirectives = directivesController.getVersionsForUpgrade(upgradeObj);
 	let upgradeDirectives = getUpgradeDirectivesToInstall(loadedDirectives);
 
-	let allResponses = [];
 	const dirLength = upgradeDirectives.length;
+
+	// A migration's version is the release that *introduced* it, not the software version being
+	// installed. Migrations run once, when the data crosses their version boundary, so a migration
+	// tagged 5.1.0 can run while installing a later release (e.g. 5.1.7) and the bare version is
+	// easily misread as a downgrade. Log the actual data -> software transition for context.
+	const header =
+		dirLength === 0
+			? `Starting upgrade process: no data migrations to apply (data ${dataVersion} -> software ${upgradeVersion}).`
+			: `Starting upgrade process: applying ${dirLength} data migration${dirLength === 1 ? '' : 's'} to bring data from ${dataVersion} up to software ${upgradeVersion}.`;
+	log.notify(header);
+	console.log(header);
+
+	let allResponses = [];
 	for (let i = 0; i < dirLength; i++) {
 		const vers = upgradeDirectives[i];
-		let notifyMsg = `Running upgrade for version ${vers.version}`;
+		const description = vers.description ? `: ${vers.description}` : '';
+		let notifyMsg = `Applying migration ${i + 1} of ${dirLength} (introduced in ${vers.version})${description}`;
 		log.notify(notifyMsg);
 		console.log(notifyMsg);
 


### PR DESCRIPTION
## Summary

Reworks the upgrade-time log wording so each migration line says what's actually happening instead of printing a bare directive version.

Before (installing 5.1.7):

```
Starting upgrade process...
Running upgrade for version 5.1.0
```

After:

```
Starting upgrade process: applying 1 data migration to bring data from 5.0.22 up to software 5.1.7.
Applying migration 1 of 1 (introduced in 5.1.0): create system.hdb_deployment table for deployment tracking
```

## Why

`Running upgrade for version <X>` printed the version that *introduced* a migration directive, not the software version being installed. With only the 5.1.0 directive registered, it prints `5.1.0` for any upgrade that crosses it (e.g. while installing 5.1.7) — which reads like a downgrade and says nothing about what the migration does. It came up when the line surprised people watching a 5.1.7 upgrade. Fixes #1451.

## Changes

- `upgrade/directivesManager.ts` — header logs the real data → software transition and migration count; per-migration line is now `Applying migration N of M (introduced in <version>): <description>`.
- `upgrade/directives/5-1-0.ts` — added an optional `description` field (set on the 5.1.0 directive).
- Unit tests for the new wording and the empty-migrations branch.

No change to the upgrade/migration logic — `log`/`console` text only.

## Review notes

- **Where to look:** the new header/branch logic in `processDirectives` (`upgrade/directivesManager.ts`).
- **Deliberate tradeoff (flagging since the cross-model review raised it):** I did *not* add an `undefined` guard on the header's version fields. The sole caller (`bin/upgrade.js`) always supplies both, and a missing-version object already routes to `getVersionsForUpgrade → []` (the "no migrations" branch), so it can't crash — a guard would be defensive cruft.
- **Docs:** no documentation-repo change — these log strings aren't documented.

## Cross-model review

Harper-domain pass via the `cross-model-review` skill (Opus 4.8): **no blockers, no significant concerns.** Caveat: the Gemini/`agy` leg timed out this run, so there was no second-model (Gemini) coverage.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
