### PR TITLE
fix(blob): bound the stream() incomplete-content wait so a truncated blob can't spin a worker at 100% CPU (#1454)

### DIFF
--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -461,8 +461,10 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 									if (checkIfIsBeingWritten()) {
 										// Bound the wait for in-progress content the same way the open-retry loop bounds the
 										// wait for the file to appear (#1423): start a no-progress deadline on the first stuck
-										// read. checkIfIsBeingWritten() caches its result, so a writer that died or stalled
-										// without releasing its lock would otherwise pin us here forever (#1454).
+										// read. checkIfIsBeingWritten() caches its result, so an in-progress write whose source
+										// stream stalled — and so never reached its unlock() — keeps the lock held and would
+										// otherwise pin us here forever (the lock is in-process and released on unlock() or
+										// handle close, so this is a live stalled write, not a dead one) (#1454, cf #1444).
 										if (incompleteDeadline === 0) incompleteDeadline = Date.now() + getBlobReadTimeout();
 										// detects the race where the writer finished between our last async read
 										// and the watcher being set up (or the watcher missing the final write event)

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -382,6 +382,11 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 			pull: (controller) => {
 				let size = 0;
 				let retries = 100;
+				// No-progress deadline for the incomplete-content wait below, mirroring the open-retry loop's
+				// deadline (#1423). Computed lazily on the first stuck read so a healthy read never pays for
+				// it; bounds the case where the header reports a known size but the bytes never arrive (a
+				// present-but-truncated blob whose writer lock stays held) (#1454).
+				let incompleteDeadline = 0;
 				return new Promise(function readMore(resolve: () => void, reject: (error: Error) => void) {
 					function onError(error) {
 						close(fd);
@@ -406,7 +411,7 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 								if (retries-- > 0 && isBeingWritten !== false) {
 									checkIfIsBeingWritten();
 									logger.debug?.('File was empty, waiting for data to be written', filePath, retries);
-									setTimeout(() => readMore(resolve, reject), 20).unref();
+									timer = setTimeout(() => readMore(resolve, reject), 20).unref();
 								} else {
 									logger.debug?.('File was empty, throwing error', filePath, retries);
 									onError(
@@ -454,6 +459,11 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 								size = Number(new DataView(buffer.buffer, buffer.byteOffset, 8).getBigUint64(0) & 0xffffffffffffn);
 								if (size > totalContentRead) {
 									if (checkIfIsBeingWritten()) {
+										// Bound the wait for in-progress content the same way the open-retry loop bounds the
+										// wait for the file to appear (#1423): start a no-progress deadline on the first stuck
+										// read. checkIfIsBeingWritten() caches its result, so a writer that died or stalled
+										// without releasing its lock would otherwise pin us here forever (#1454).
+										if (incompleteDeadline === 0) incompleteDeadline = Date.now() + getBlobReadTimeout();
 										// detects the race where the writer finished between our last async read
 										// and the watcher being set up (or the watcher missing the final write event)
 										const resumeIfWriterFinished = (): boolean => {
@@ -467,7 +477,24 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 												watcher.close();
 												watcher = null;
 											}
-											readMore(resolve, reject);
+											// The header reports a known final size but the bytes at `position` have not arrived.
+											// Re-entering readMore() synchronously here busy-spins the worker at ~100% CPU on a
+											// present-but-truncated blob (header rewritten to a self-consistent smaller size, lock
+											// still held) — the read at EOF returns 0 every time, with no backoff (#1454). Poll on
+											// the same short backoff the open-retry loop uses, and fail fast with a retryable 503
+											// once the no-progress deadline passes. The deadline is only set while we are stuck (no
+											// bytes readable), so a genuinely slow in-progress write — which makes progress and
+											// resolves the pull each chunk, starting each new pull with a fresh budget — is unaffected.
+											if (Date.now() >= incompleteDeadline) {
+												onError(
+													new BlobReadError(
+														`Blob read stalled for ${filePath}: header reports ${size} bytes but only ${totalContentRead} are readable and no further data is arriving`,
+														BLOB_UNAVAILABLE_STATUS
+													)
+												);
+											} else {
+												timer = setTimeout(() => readMore(resolve, reject), 20).unref();
+											}
 											return true;
 										};
 										// the file is not finished being written, watch the file for changes to resume reading

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -813,6 +813,37 @@ describe('Blob test', () => {
 			env.setProperty(CONFIG_PARAMS.STORAGE_BLOBREADTIMEOUT, undefined);
 		}
 	});
+	it('#1454: a present-but-truncated blob with a writer still holding the lock fails 503 instead of spinning forever', async () => {
+		// The prod-dyn/prod-gar CPU storm: a blob file is present, its header records the full descriptor
+		// size (so the #1424 cross-check passes), but the body was never fully written — and the writer's
+		// lock still reads as held (a stalled/dead replication write that never released it). The reader
+		// catches up to the short body, sees `size > totalContentRead`, and — because the header size is
+		// "known" — resumeIfWriterFinished() re-entered readMore() with no backoff and no deadline,
+		// busy-spinning the worker at ~100% CPU. Pre-fix this read never resolves and this test hangs.
+		const { blob, filePath, store } = await makeDiskBackedBlob();
+		const lockKey = getFileId(blob) + ':blob';
+		assert(store.tryLock(lockKey), 'should be able to take the blob write lock for the test');
+		try {
+			// Cut the body short but leave the header (full size, == descriptor) intact — the case the
+			// #1424 descriptor cross-check cannot catch, distinct from truncateBlobConsistently above.
+			const fd = openSync(filePath, 'r+');
+			try {
+				ftruncateSync(fd, HEADER_SIZE + 256);
+			} finally {
+				closeSync(fd);
+			}
+			env.setProperty(CONFIG_PARAMS.STORAGE_BLOBREADTIMEOUT, '150');
+			const started = Date.now();
+			await assert.rejects(streamToBuffer(blob.stream()), (error) => {
+				assert.equal(error.statusCode, 503);
+				return true;
+			});
+			assert(Date.now() - started < 5000, 'read should fail promptly, not spin');
+		} finally {
+			store.unlock(lockKey);
+			env.setProperty(CONFIG_PARAMS.STORAGE_BLOBREADTIMEOUT, undefined);
+		}
+	});
 	afterEach(function () {
 		setAuditRetention(60000);
 		setDeletionDelay(50); // restore shorter, but need to have it happen for the last test

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -816,7 +816,9 @@ describe('Blob test', () => {
 	it('#1454: a present-but-truncated blob with a writer still holding the lock fails 503 instead of spinning forever', async () => {
 		// The prod-dyn/prod-gar CPU storm: a blob file is present, its header records the full descriptor
 		// size (so the #1424 cross-check passes), but the body was never fully written — and the writer's
-		// lock still reads as held (a stalled/dead replication write that never released it). The reader
+		// lock still reads as held (a live replication write stalled on a wedged source stream, so it never
+		// reached unlock(); the lock is in-process and freed on unlock()/handle close, so a *dead* writer
+		// can't cause this — only a stalled live one). The reader
 		// catches up to the short body, sees `size > totalContentRead`, and — because the header size is
 		// "known" — resumeIfWriterFinished() re-entered readMore() with no backoff and no deadline,
 		// busy-spinning the worker at ~100% CPU. Pre-fix this read never resolves and this test hangs.


### PR DESCRIPTION
Fixes #1454.

## Summary

`FileBackedBlob.stream()` → `readMore()` busy-spun a worker thread at ~100% CPU, indefinitely, when a blob file is **present but truncated** (its 8-byte header records a known final size larger than the bytes actually on disk) **and** the write-lock reads as held. In the `bytesRead === 0` branch, `resumeIfWriterFinished()` re-entered `readMore()` synchronously with no backoff and no deadline, so a read at EOF returned 0 every iteration. `checkIfIsBeingWritten()` caches its result. The lock is in-process and released on `unlock()`/`DBHandle::close()`, so a *dead* writer can't leave it held — the pin is a **live** in-progress write whose source stream stalled and never reached `unlock()` (the `writeBlobWithStream` pipeline that #1443/#1444 watchdogs). This PR is the complementary reader-side bound.

This is the prod-dyn / prod-gar GDI CPU storm (harper-pro 5.0.28), confirmed by a 6-thread CPU profile (~73% in `readMore`: `fs.read` ~48% + `Buffer.allocUnsafe(256KB)` ~21%). The trigger is a wedged GDI blob-replication backlog (~11–12h behind) plus a 2h blob expiration: bodies evict/truncate before the backlog ships them.

## Why this isn't already fixed by #1423/#1424

The spin branch is byte-for-byte identical 5.0.28 → 5.1.8. #1423's `getBlobReadTimeout()` timer lives in the `else if (!resumeIfWriterFinished())` branch the spin never enters (resume returns `true`). #1424's descriptor cross-check is `isFullRead`-gated (HTTP serving streams a range → skipped) and only fires when header ≠ descriptor (the common truncation has header == descriptor).

## The fix

- A lazily-set no-progress deadline (`incompleteDeadline = getBlobReadTimeout()`, default 20s) + a 20ms backoff before the resume re-entry. Past the deadline, fail fast with a retryable `BlobReadError(503)`.
- The deadline is set **only while no bytes are readable**; a genuinely slow but progressing in-progress write (header written up front — the replication path) resolves the pull each chunk and starts each new pull with a fresh budget, so it is unaffected.
- Both `readMore()` 20ms backoff timers are now assigned to `timer` so `cancel()`/`onError` can clear a pending poll (the cross-model review caught that the new one wasn't tracked → a read on a closed/reused fd if a stream is aborted mid-wait).

## Where to look

- `resources/blob.ts` — the `resumeIfWriterFinished()` re-entry and the `incompleteDeadline` init in the `checkIfIsBeingWritten()` block.
- Test: `unitTests/resources/blob.test.js` (#1454) — present-but-truncated blob + held lock. Verified genuine: revert the source and it hangs (30s mocha timeout); with the fix it rejects 503 in ~165ms.

## Open items for the reviewer

The cross-model review surfaced **pre-existing** latent bugs in this file, in code this PR does not change — deliberately left out of this targeted patch and tracked separately in #1457: `fd` is not nulled after close (double-close on a reused fd), the `start()` open-retry timer is untracked, `onError` can fire twice if a slow async read completes after rejection, and slices read sequentially from byte 0.

Bound for a 5.1.x patch.

_Generated with assistance from Claude (Opus 4.8). Cross-model reviewed (Codex + Gemini + Harper-domain)._