### PR TITLE
Scope the blob idle-watchdog: opt-in per-stream, not default-on for all writers (#1444 review)

### DIFF
--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -731,14 +731,21 @@ export function saveBlob(blob: FileBackedBlob, deleteOnFailure = false) {
 // stuck promise, and the per-database apply consumer's drain await wedges — surfaced in production
 // as a (sender, receiver, database) tuple pinned at lastReceivedStatus="Receiving" indefinitely
 // (JJill preprod 5.1.7; harper-pro#453).
-// Defaults ON to 120000ms so the wedge can't happen out of the box; HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS
-// overrides it (set 0 to disable). The timer re-arms while the source is paused, so legitimate write
-// backpressure never trips it — only a genuinely silent source is destroyed. Read at call time so
-// tests and operators can change it without a process restart.
-const DEFAULT_BLOB_STREAM_IDLE_TIMEOUT_MS = 120000;
-function getBlobStreamIdleTimeoutMs(): number {
+//
+// OFF by default. writeBlobWithStream is the generic primitive for every blob write — HTTP upload,
+// origin-fetch cache fill, replication receive — and bounding a source's liveness is the owning
+// caller's responsibility, not this primitive's: a blanket timeout here would destroy a legitimately
+// slow non-replication source. The owning caller arms it per-write by setting `blobStreamIdleTimeoutMs`
+// on the source stream (the replication receive path does this on its PassThrough). A process-wide
+// HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS env var, when set, overrides the per-stream value for every write
+// (ops escape hatch / kill switch — set 0 to force-disable). Read at call time so tests and operators
+// can change it without a restart. The timer re-arms while the source is paused (pipeline backpressure,
+// not a real stall) so a slow writeStream never trips a false destroy.
+function getBlobStreamIdleTimeoutMs(stream: Readable): number {
 	const configured = process.env.HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS;
-	return configured != null ? Number(configured) : DEFAULT_BLOB_STREAM_IDLE_TIMEOUT_MS;
+	if (configured != null) return Number(configured); // process-wide ops override / kill switch
+	const armed = (stream as { blobStreamIdleTimeoutMs?: number }).blobStreamIdleTimeoutMs;
+	return armed != null ? Number(armed) : 0; // off unless the owning caller armed this source
 }
 
 function writeBlobWithStream(blob: Blob, stream: Readable, storageInfo: StorageInfo): Blob {
@@ -756,13 +763,13 @@ function writeBlobWithStream(blob: Blob, stream: Readable, storageInfo: StorageI
 			writeStream.write(createHeader(blob.size)); // write the default header
 			wroteSize = true;
 		}
-		// Source-idle watchdog: destroys the source if no 'data' arrives for the configured threshold
-		// so pipeline rejects cleanly. On by default (120s); HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS overrides.
-		// On expiry, re-arm if the stream is paused (pipeline backpressure, not a real stall) so a slow
-		// writeStream doesn't trip a false destroy.
+		// Source-idle watchdog: destroys the source if no 'data' arrives for the threshold so pipeline
+		// rejects cleanly. Off unless the owning caller armed this source (or the env override is set);
+		// see getBlobStreamIdleTimeoutMs. On expiry, re-arm if the stream is paused (pipeline backpressure,
+		// not a real stall) so a slow writeStream doesn't trip a false destroy.
 		let idleTimer: NodeJS.Timeout | undefined;
 		let armIdleTimer: (() => void) | undefined;
-		const idleTimeoutMs = getBlobStreamIdleTimeoutMs();
+		const idleTimeoutMs = getBlobStreamIdleTimeoutMs(stream);
 		if (idleTimeoutMs > 0) {
 			armIdleTimer = () => {
 				if (idleTimer) clearTimeout(idleTimer);

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -741,11 +741,20 @@ export function saveBlob(blob: FileBackedBlob, deleteOnFailure = false) {
 // (ops escape hatch / kill switch — set 0 to force-disable). Read at call time so tests and operators
 // can change it without a restart. The timer re-arms while the source is paused (pipeline backpressure,
 // not a real stall) so a slow writeStream never trips a false destroy.
+// Largest delay setTimeout accepts; a larger value (or Infinity/NaN) is silently coerced to 1ms, which
+// would fire the watchdog almost immediately and destroy a healthy stream — so clamp/reject instead.
+const MAX_SET_TIMEOUT_MS = 2147483647; // 2^31 - 1
 function getBlobStreamIdleTimeoutMs(stream: Readable): number {
 	const configured = process.env.HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS;
-	if (configured != null) return Number(configured); // process-wide ops override / kill switch
-	const armed = (stream as { blobStreamIdleTimeoutMs?: number }).blobStreamIdleTimeoutMs;
-	return armed != null ? Number(armed) : 0; // off unless the owning caller armed this source
+	// env override (process-wide kill switch) when set, else the per-stream value the owning caller armed.
+	const raw =
+		configured != null
+			? Number(configured)
+			: Number((stream as { blobStreamIdleTimeoutMs?: number }).blobStreamIdleTimeoutMs ?? 0);
+	// A NaN/negative/zero value means off; cap a too-large value at the setTimeout max so it doesn't
+	// collapse to 1ms and instantly destroy the source.
+	if (!Number.isFinite(raw) || raw <= 0) return 0;
+	return Math.min(raw, MAX_SET_TIMEOUT_MS);
 }
 
 function writeBlobWithStream(blob: Blob, stream: Readable, storageInfo: StorageInfo): Blob {

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -944,12 +944,14 @@ describe('saveBlob with idle source stream (replication wedge regression)', () =
 
 describe('saveBlob source-idle watchdog is opt-in (off by default, per-stream arm)', () => {
 	let OptInTable;
+	let savedIdleTimeoutEnv;
 	before(function () {
 		setupTestDBPath();
 		// Deliberately NO HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS: the watchdog must be OFF unless the owning
 		// caller arms the specific source. writeBlobWithStream is the generic primitive for every blob
 		// write (HTTP upload, origin-fetch cache fill, replication receive); bounding a source is the
 		// caller's job, not the primitive's. (The process-wide env override is exercised in the block above.)
+		savedIdleTimeoutEnv = process.env.HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS;
 		delete process.env.HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS;
 		OptInTable = table({
 			table: 'OptInTable',
@@ -959,6 +961,10 @@ describe('saveBlob source-idle watchdog is opt-in (off by default, per-stream ar
 				{ name: 'blob', type: 'Blob' },
 			],
 		});
+	});
+	after(function () {
+		if (savedIdleTimeoutEnv === undefined) delete process.env.HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS;
+		else process.env.HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS = savedIdleTimeoutEnv;
 	});
 
 	it('does NOT destroy an unarmed idle source (a slow non-replication write is left alone)', async () => {

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -942,6 +942,56 @@ describe('saveBlob with idle source stream (replication wedge regression)', () =
 	});
 });
 
+describe('saveBlob source-idle watchdog is opt-in (off by default, per-stream arm)', () => {
+	let OptInTable;
+	before(function () {
+		setupTestDBPath();
+		// Deliberately NO HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS: the watchdog must be OFF unless the owning
+		// caller arms the specific source. writeBlobWithStream is the generic primitive for every blob
+		// write (HTTP upload, origin-fetch cache fill, replication receive); bounding a source is the
+		// caller's job, not the primitive's. (The process-wide env override is exercised in the block above.)
+		delete process.env.HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS;
+		OptInTable = table({
+			table: 'OptInTable',
+			database: 'test',
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'blob', type: 'Blob' },
+			],
+		});
+	});
+
+	it('does NOT destroy an unarmed idle source (a slow non-replication write is left alone)', async () => {
+		const stream = new PassThrough();
+		stream.write(Buffer.from('slow-source-no-arm')); // chunk lands, never ended, never armed
+		const blob = await createBlob(stream);
+		const info = decodeFromDatabase(() => saveBlob(blob), OptInTable.primaryStore.rootStore);
+		let state = 'pending';
+		// eslint-disable-next-line promise/catch-or-return
+		(info.saving ?? Promise.resolve()).then(() => (state = 'resolved')).catch(() => (state = 'rejected'));
+		await delay(1500);
+		assert.strictEqual(state, 'pending', 'an unarmed idle source must NOT be force-destroyed by the watchdog');
+		stream.destroy(); // clean up the deliberately-stuck write so the blob lock is released
+		await delay(50);
+	});
+
+	it('settles when the owning caller arms the source via stream.blobStreamIdleTimeoutMs', async () => {
+		// How the replication receive path opts in: it sets this on its PassThrough; other callers stay off.
+		const stream = new PassThrough();
+		stream.blobStreamIdleTimeoutMs = 800;
+		stream.on('error', () => {});
+		stream.write(Buffer.from('armed-but-never-finished')); // chunk lands, then idle, never ended
+		const blob = await createBlob(stream);
+		const info = decodeFromDatabase(() => saveBlob(blob), OptInTable.primaryStore.rootStore);
+		let state = 'pending';
+		// eslint-disable-next-line promise/catch-or-return
+		(info.saving ?? Promise.resolve()).then(() => (state = 'resolved')).catch(() => (state = 'rejected'));
+		await delay(2500);
+		assert.notStrictEqual(state, 'pending', 'an armed idle source should be destroyed within its timeout and settle');
+	});
+});
+
+
 function delay(ms) {
 	return new Promise((resolve) => setTimeout(resolve, ms)); // wait for audit log removal and deletion
 }


### PR DESCRIPTION
Stacks on #1444. Addresses the review concern that #1444 timed out **every** blob write.

## Why
`writeBlobWithStream` is the generic primitive for all blob writes — HTTP upload, origin-fetch cache fill, replication receive. A default-on 120s idle-destroy would force-destroy a legitimately slow *non-replication* source. Bounding a source's liveness is the **owning caller's** responsibility, not the primitive's.

## Change
- Core watchdog is now **off by default**. The owning caller arms it per-write via `blobStreamIdleTimeoutMs` on the source stream.
- `HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS`, when set, still overrides every write (ops kill switch — `=0` force-disables).
- The replication receiver arms it (REPLICATION_BLOBTIMEOUT, 120s) — companion harper-pro PR: HarperFast/harper-pro#459.

## Tests
- #1444's env-armed wedge regression tests unchanged (env override still works).
- Added: an **unarmed** idle source is NOT destroyed (regression-safety for slow non-replication writes); the **per-stream arm** settles. 5/5 pass.

_LLM-authored (Claude Opus 4.8)._