### PR TITLE
fix(test): eliminate race in Txn Expiration flaky test

### DIFF
--- a/unitTests/resources/txn-tracking.test.js
+++ b/unitTests/resources/txn-tracking.test.js
@@ -60,7 +60,10 @@ describe('Txn Expiration', () => {
 		// Check the specific txn we started was expired and removed. Counting against
 		// existingTxns is unreliable: other tests' transactions can expire concurrently and
 		// shift the count underneath us during the 50ms window.
-		assert.ok(!trackedTxns.has(lastTxn), 'expected the slow transaction to have been expired and removed from trackedTxns');
+		assert.ok(
+			!trackedTxns.has(lastTxn),
+			'expected the slow transaction to have been expired and removed from trackedTxns'
+		);
 	});
 	after(function () {
 		setTxnExpiration(30000);

--- a/unitTests/resources/txn-tracking.test.js
+++ b/unitTests/resources/txn-tracking.test.js
@@ -57,7 +57,10 @@ describe('Txn Expiration', () => {
 		}
 		await Promise.race([delay(50), result]);
 		assert(performedDBInteractions);
-		assert.equal(trackedTxns.size, existingTxns);
+		// Check the specific txn we started was expired and removed. Counting against
+		// existingTxns is unreliable: other tests' transactions can expire concurrently and
+		// shift the count underneath us during the 50ms window.
+		assert.ok(!trackedTxns.has(lastTxn), 'expected the slow transaction to have been expired and removed from trackedTxns');
 	});
 	after(function () {
 		setTxnExpiration(30000);


### PR DESCRIPTION
## Root cause

The `Slow txn will expire` test asserts `trackedTxns.size === existingTxns` at the end, where `existingTxns` was sampled before the `SlowResource.get` call. The problem: `trackedTxns` is a module-level singleton Set shared across the whole test suite. The 5 «existing» transactions sampled as the baseline are leftover open txns from earlier tests — and they can expire (and be removed from the Set by the 20ms timer) **during** the 50ms `Promise.race` window that follows, causing the count to fall below `existingTxns`. This produces the `0 == 5` `AssertionError` seen on Node v26.

The polling loop added to stabilize the baseline only checks for a 5ms quiet window; a txn whose countdown hits zero just after that window still fires in the next tick.

## Fix

Replace the aggregate-count assertion with a direct membership check on `lastTxn` — the specific `DatabaseTransaction` object added by `SlowResource.get(3)`. This is immune to other tests' txns expiring concurrently.

```js
// before
assert.equal(trackedTxns.size, existingTxns);

// after
assert.ok(!trackedTxns.has(lastTxn), 'expected the slow transaction to have been expired and removed from trackedTxns');
```

## Test plan

- [x] CI passes on all three Node versions (v22, v24, v26) — the assertion is now independent of background txn churn
- The `lastTxn` reference was already captured unconditionally on line 52; only the final assertion changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)