### PR TITLE
feat(replication): add replication_copyTimeout config param

### DIFF
--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -597,6 +597,7 @@ export const CONFIG_PARAMS = {
 	REPLICATION_RECORDCONCURRENCY: 'replication_recordConcurrency',
 	REPLICATION_PINGINTERVAL: 'replication_pingInterval',
 	REPLICATION_PINGTIMEOUT: 'replication_pingTimeout',
+	REPLICATION_COPYTIMEOUT: 'replication_copyTimeout',
 	REPLICATION_LEADINGDUPLICATESKIP: 'replication_leadingDuplicateSkip',
 	REPLICATION_REPLAYTIMEOUT: 'replication_replayTimeout',
 	ROOTPATH: 'rootPath',

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -193,6 +193,7 @@ export function configValidator(configJson, skipFsValidation = false) {
 			copyTablesToCatchUp: boolean.optional(),
 			pingInterval: number.min(1).optional().empty(null),
 			pingTimeout: number.min(1).optional().empty(null),
+			copyTimeout: number.min(1).optional().empty(null),
 			replayTimeout: number.min(1).optional().empty(null),
 		}).optional(),
 		componentsRoot: rootConstraints.optional(),


### PR DESCRIPTION
## Summary

Registers a new replication config parameter `replication_copyTimeout` (`CONFIG_PARAMS.REPLICATION_COPYTIMEOUT`) and adds it to the replication config schema.

## Purpose

Paired with harper-pro#454 follow-up (harper-pro#460). harper-pro's replication receive path needs a separate, wider no-activity threshold *during the initial base copy*: a sender stuck in `writableNeedDrain` backpressure can keep bytes from reaching the receiver for far longer than `replication_pingTimeout` (default 60s) without the copy being unhealthy. Reusing `pingTimeout` there makes the receiver reconnect → resume the same checkpoint → stall again, starving the copy. The new param lets the copy-phase threshold be tuned independently (harper-pro defaults it to 300000ms).

This PR is core-side only: it adds the param to the registry and validator so harper-pro can consume it via `env.get(CONFIG_PARAMS.REPLICATION_COPYTIMEOUT)`. The consuming logic lives in harper-pro#454.

## Where to look

- `utility/hdbTerms.ts` — new entry next to the sibling replication timeout params.
- `validation/configValidator.ts` — `copyTimeout` added next to `pingTimeout` (min 1, optional); the schema already allows unknown keys, so this is for discoverability/validation parity.

Generated by Claude (Opus 4.8). Diff and commit history are the source of truth.