### PR TITLE
fix: invoke startOnMainThread at most once per component (harper-pro#460)

### DIFF
--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -141,6 +141,18 @@ for (const { name, packageIdentifier } of getEnvBuiltInComponents()) {
 const BUILT_INS = Object.keys(TRUSTED_RESOURCE_PLUGINS);
 
 export const loadedPaths = new Map();
+
+// Tracks which components have already had `startOnMainThread` invoked, so it runs at most once
+// per component for the life of the process (the documented one-time main-thread init contract).
+// Keyed by stable component identity (name + resolved directory) rather than the module instance
+// (`loadedComponents`) or the per-pass `loadedPaths` map — a reload re-imports the module (new
+// instance) and `loadedPaths` is cleared on the reload path, so neither dedupes across reloads.
+// The stored value is the post-`startOnMainThread` module so a reload reuses the same wiring
+// (handleFile/handleDirectory, loadedComponents) without re-running main-thread init. See #460:
+// re-invoking `startOnMainThread` on every reload accumulated watchers/routes and re-ran
+// destructive one-time scans (e.g. the replicator's hdb_nodes subscription scan).
+export const mainThreadInitialized = new Map<string, any>();
+
 let errorReporter;
 export function setErrorReporter(reporter) {
 	errorReporter = reporter;
@@ -498,15 +510,31 @@ export async function loadComponent(
 				}
 
 				if (isMainThread) {
-					extensionModule =
-						(await extensionModule.startOnMainThread?.({
-							server,
-							ensureTable,
-							port,
-							securePort,
-							resources,
-							...componentConfig,
-						})) || extensionModule;
+					// `startOnMainThread` is one-time main-thread init: run it at most once per component
+					// for the life of the process (first load / first deploy). On a reload of an
+					// already-initialized component, skip the call and reuse the previously-initialized
+					// module so downstream wiring (handleFile/handleDirectory, loadedComponents) is
+					// preserved without re-running main-thread setup. Only components that actually
+					// export `startOnMainThread` are gated — a component with only setup handlers has no
+					// one-time hook to dedupe and must keep picking up its freshly loaded module on
+					// reload. See #460.
+					if (typeof extensionModule.startOnMainThread === 'function') {
+						const mainThreadKey = `${isRoot ? '' : basename(componentDirectory)}/${componentName}@${realpathSync(componentDirectory)}`;
+						if (mainThreadInitialized.has(mainThreadKey)) {
+							extensionModule = mainThreadInitialized.get(mainThreadKey);
+						} else {
+							extensionModule =
+								(await extensionModule.startOnMainThread({
+									server,
+									ensureTable,
+									port,
+									securePort,
+									resources,
+									...componentConfig,
+								})) || extensionModule;
+							mainThreadInitialized.set(mainThreadKey, extensionModule);
+						}
+					}
 					if (isRoot && network) {
 						if (env.get(CONFIG_PARAMS.HTTP_SESSIONAFFINITY))
 							harperLogger.warn('Session affinity is not supported and will be ignored');

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -519,7 +519,9 @@ export async function loadComponent(
 					// one-time hook to dedupe and must keep picking up its freshly loaded module on
 					// reload. See #460.
 					if (typeof extensionModule.startOnMainThread === 'function') {
-						const mainThreadKey = `${isRoot ? '' : basename(componentDirectory)}/${componentName}@${realpathSync(componentDirectory)}`;
+						// Reuse the already-resolved realpath (line 308) instead of a second realpathSync —
+						// same value, avoids a redundant sync FS call (PR #1464 review).
+						const mainThreadKey = `${isRoot ? '' : basename(resolvedFolder)}/${componentName}@${resolvedFolder}`;
 						if (mainThreadInitialized.has(mainThreadKey)) {
 							extensionModule = mainThreadInitialized.get(mainThreadKey);
 						} else {

--- a/unitTests/components/startOnMainThreadOnce.test.js
+++ b/unitTests/components/startOnMainThreadOnce.test.js
@@ -1,0 +1,148 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const path = require('node:path');
+const { isMainThread } = require('node:worker_threads');
+const { tmpdir } = require('node:os');
+const { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } = require('node:fs');
+
+// #460: `startOnMainThread` must run at most once per component for the life of the process.
+// A deploy_component reload re-enters loadComponent for already-loaded components; before the fix
+// the main-thread init was re-invoked every pass, accumulating watchers/routes and re-running
+// destructive one-time scans (the replicator's hdb_nodes subscription scan). These tests assert
+// the once-only contract holds across a reload while a brand-new component still initializes.
+describe('startOnMainThread once-per-component (#460)', function () {
+	// somt only runs on the main thread; if mocha ever runs this in a worker the assertions below
+	// would be meaningless, so guard explicitly.
+	before(function () {
+		if (!isMainThread) this.skip();
+	});
+
+	let tempDir;
+	let componentLoader;
+	let sandbox;
+
+	before(function () {
+		sandbox = sinon.createSandbox();
+		tempDir = mkdtempSync(path.join(tmpdir(), 'harper-somt-once-'));
+
+		const env = require('#src/utility/environment/environmentManager');
+		sandbox.stub(env, 'get').callsFake((key) => {
+			if (key === 'COMPONENTSROOT') return tempDir;
+			if (key === 'CLUSTERING_ENABLED') return false;
+			if (key === 'MAX_HEADER_SIZE') return 8192;
+			if (key === 'HTTP_PORT') return 9925;
+			if (key === 'CUSTOM_FUNCTIONS') return false;
+			return '';
+		});
+
+		const configUtils = require('#js/config/configUtils');
+		sandbox.stub(configUtils, 'getConfigObj').returns({});
+
+		componentLoader = require('#src/components/componentLoader');
+	});
+
+	after(function () {
+		sandbox.restore();
+		if (tempDir && existsSync(tempDir)) rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	// Create a component directory whose harper-config.yaml declares a single trusted plugin we
+	// register on the fly, returning its name + dir for cleanup and assertions.
+	function makeComponent(dirName, pluginName) {
+		const componentDir = path.join(tempDir, dirName);
+		mkdirSync(componentDir, { recursive: true });
+		writeFileSync(path.join(componentDir, 'harperdb-config.yaml'), `${pluginName}: {}`);
+		return componentDir;
+	}
+
+	it('runs startOnMainThread once across a reload of an existing component, and once for a newly-added component', async function () {
+		const pluginA = 'somtOncePluginA';
+		const pluginB = 'somtOncePluginB';
+		const dirA = makeComponent('somt-once-a', pluginA);
+		const dirB = makeComponent('somt-once-b', pluginB);
+
+		let somtA = 0;
+		let somtB = 0;
+		const exportedResource = { marker: 'A-init' };
+
+		componentLoader.TRUSTED_RESOURCE_PLUGINS[pluginA] = {
+			startOnMainThread() {
+				somtA++;
+				// Return a replacement module to verify the skip reuses the post-somt result.
+				return { ...exportedResource, somtRunCount: somtA };
+			},
+		};
+		componentLoader.TRUSTED_RESOURCE_PLUGINS[pluginB] = {
+			startOnMainThread() {
+				somtB++;
+			},
+		};
+
+		const resources = { isWorker: false, set: sinon.stub() };
+
+		try {
+			// First boot: only component A exists yet.
+			await componentLoader.loadComponent(dirA, resources, 'origin');
+			assert.equal(somtA, 1, 'A.startOnMainThread should run on first load');
+
+			// Simulate the reload re-entry: the production reload path re-invokes loadComponent for
+			// already-loaded components. loadedPaths is cleared on that path (and on worker
+			// re-import), so clearing it here reproduces the field condition that previously caused
+			// startOnMainThread to re-run.
+			componentLoader.loadedPaths.clear();
+
+			// Reload of A (already initialized) AND first load of newly-added B in the same pass.
+			await componentLoader.loadComponent(dirA, resources, 'origin');
+			await componentLoader.loadComponent(dirB, resources, 'origin');
+
+			assert.equal(somtA, 1, 'A.startOnMainThread must NOT re-run on reload (once-only contract)');
+			assert.equal(somtB, 1, 'B.startOnMainThread must still run for a newly-added component');
+
+			// One more reload to confirm the gate holds across repeated reloads.
+			componentLoader.loadedPaths.clear();
+			await componentLoader.loadComponent(dirA, resources, 'origin');
+			await componentLoader.loadComponent(dirB, resources, 'origin');
+			assert.equal(somtA, 1, 'A.startOnMainThread stays at one across repeated reloads');
+			assert.equal(somtB, 1, 'B.startOnMainThread stays at one across repeated reloads');
+
+			// The skip must reuse the post-somt module (the value returned by the first somt call),
+			// so downstream wiring is preserved rather than reverting to the pre-init plugin object.
+			const keyA = `${path.basename(dirA)}/${pluginA}@${require('node:fs').realpathSync(dirA)}`;
+			const storedA = componentLoader.mainThreadInitialized.get(keyA);
+			assert.equal(storedA.marker, 'A-init', 'stored module is the post-somt result');
+			assert.equal(storedA.somtRunCount, 1, 'stored module reflects the single somt run');
+		} finally {
+			delete componentLoader.TRUSTED_RESOURCE_PLUGINS[pluginA];
+			delete componentLoader.TRUSTED_RESOURCE_PLUGINS[pluginB];
+		}
+	});
+
+	it('does not gate (cache) components that have no startOnMainThread, so they keep their fresh module on reload', async function () {
+		// A component whose plugin exports a setup handler but no startOnMainThread has no one-time
+		// main-thread hook. It must not be entered into the gate, so a reload keeps using the
+		// freshly loaded module rather than a stale cached one (Codex P2).
+		const pluginC = 'somtlessPluginC';
+		const dirC = makeComponent('somtless-c', pluginC);
+
+		componentLoader.TRUSTED_RESOURCE_PLUGINS[pluginC] = {
+			// no startOnMainThread; a setup-only handler must not be entered into the gate
+			setupDirectory() {},
+		};
+
+		const resources = { isWorker: false, set: sinon.stub() };
+		try {
+			await componentLoader.loadComponent(dirC, resources, 'origin');
+			componentLoader.loadedPaths.clear();
+			await componentLoader.loadComponent(dirC, resources, 'origin');
+
+			const keyC = `${path.basename(dirC)}/${pluginC}@${require('node:fs').realpathSync(dirC)}`;
+			assert.equal(
+				componentLoader.mainThreadInitialized.has(keyC),
+				false,
+				'a component without startOnMainThread must not be entered into the once-only gate'
+			);
+		} finally {
+			delete componentLoader.TRUSTED_RESOURCE_PLUGINS[pluginC];
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Make a component's `startOnMainThread` run **at most once per component for the life of the process** (first load / first deploy) instead of re-running on every component reload. On a subsequent reload of an already-initialized component, the call is skipped and the previously-initialized module is reused.

## Purpose

Root-cause fix for **harper-pro#460** ("deploy_component worker-reload leaves followers with zero replication subscriptions"). A `deploy_component` triggers `restartWorkers() → loadRootComponents() → loadComponentDirectories()` on the main thread, which re-iterated every component and unconditionally re-invoked `extensionModule.startOnMainThread(...)`. For the replicator this re-ran a destructive one-time `hdb_nodes` subscription scan and accumulated watchers/routes across deploys (the latent `MaxListenersExceededWarning` leak). harper-pro#461 carries the complementary decode-resilience fix (making the subscription scan tolerate an undecodable peer); this PR removes the re-invocation that the scan is run from.

## What changed (`components/componentLoader.ts`)

- New module-global `mainThreadInitialized: Map<string, any>` keyed by **stable component identity** — `${isRoot ? '' : basename(componentDirectory)}/${componentName}@${realpathSync(componentDirectory)}`. The existing maps don't dedupe across reloads: `loadedComponents` is keyed by the *module instance* (a reload re-imports the module → new instance), and `loadedPaths` is cleared on the reload path / a worker re-import.
- At the `isMainThread` `startOnMainThread` call site: only gated when the component actually exports `startOnMainThread`. If the identity is already initialized, skip the call and reuse the stored **post-`startOnMainThread`** module (so a hook that returns a replacement module, plus all downstream wiring — `loadedComponents`, the `handleFile/handleDirectory/setupFile/setupDirectory` ComponentV1 branch — is preserved). Otherwise call it and store the result.

Untouched: the first-time load of a new component, the worker `start()` path (app code still reloads in workers), the new Plugin API `handleApplication` path, and any component with no `startOnMainThread`.

## ⚠️ Behavior change for reviewers to weigh

**This changes a core contract: an app component's `startOnMainThread` no longer re-runs on redeploy/reload — it runs exactly once per process.** The documented contract is one-time main-thread init, so this aligns behavior with the contract, but it is a real change for any component that (mis)used the re-invocation to do per-reload main-thread work.

In-tree audit (no misuse found):
- `utility/logging/harper_logger.ts` `updateLogSettings` (logging somt) installs its **own** `RootConfigWatcher` `'change'` listener on first run (guarded by `if (!rootConfig)`), so log-setting changes are handled by that watcher, not by somt re-invocation — safe, and itself evidence the contract is once-only.
- `agent/agent.ts` `startOnMainThread` is documented "invoked once on the main thread."
- `server/operationsServer.ts` somt binds the ops server; re-binding on reload is not relied upon.

Note: in stock core, the `loadedPaths` guard *already* prevented somt re-running on the common reload path; this PR makes the once-only guarantee explicit and robust to the paths where `loadedPaths` is cleared (worker re-import, and the field reload path observed in harper-pro#460).

## Testing

`unitTests/components/startOnMainThreadOnce.test.js` (modeled on `componentLoader.test.js`):
- `startOnMainThread` runs once across a reload of an existing component (reload simulated by clearing `loadedPaths`, reproducing the field re-entry) **and** still runs for a newly-added component; verified the skip reuses the post-somt module.
- A component with only a setup handler (no `startOnMainThread`) is **not** entered into the gate, so it keeps its freshly loaded module on reload.

The new test fails against unmodified `main` (asserts `startOnMainThread must NOT re-run on reload`) and passes with the fix. Component unit suite: 185 passing locally (excluding `componentLoader.test.js` and `globalIsolation.test.js`, which hang / fail on `main` in an isolated worktree for environment reasons unrelated to this change — CI runs the full suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: Claude Opus 4.8)
