### PR TITLE
fix(components): close deploy-validation Scopes to stop deployLifecycle listener leak

### DIFF
--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -309,6 +309,11 @@ export interface LoadComponentOptions {
 	autoReload?: boolean;
 	providedLoadedComponents?: Map<any, any>;
 	appName?: string;
+	// When provided, every Scope created during this load is added to this set instead of being
+	// auto-closed on worker shutdown. The caller then owns closing them. Used by transient loads
+	// (e.g. the deploy pre-flight validation) so their deploy-lifecycle listeners don't accumulate
+	// across deploys (#1462).
+	collectScopes?: Set<Scope>;
 }
 
 /**
@@ -477,6 +482,7 @@ export async function loadComponent(
 								applicationScope: subApplicationScope,
 								autoReload: false,
 								appName: appName || componentName,
+								collectScopes: options.collectScopes,
 							});
 							componentFunctionality[componentName] = true;
 						}
@@ -545,9 +551,17 @@ export async function loadComponent(
 						origin
 					);
 
-					// Track the close so the worker's shutdown path waits for it (and thus for any async
-					// native-runtime disposal, e.g. @harperfast/vite's dev server) before calling realExit.
-					onMessageByType(ITC_EVENT_TYPES.SHUTDOWN, () => trackScopeClose(scope.close()));
+					if (options.collectScopes) {
+						// A transient/validation load owns these scopes and closes them itself once the
+						// load is validated (see operations.js deploy pre-flight). Skip the worker-shutdown
+						// auto-close so their deploy-lifecycle listeners — and this SHUTDOWN handler — don't
+						// accumulate across deploys (#1462).
+						options.collectScopes.add(scope);
+					} else {
+						// Track the close so the worker's shutdown path waits for it (and thus for any async
+						// native-runtime disposal, e.g. @harperfast/vite's dev server) before calling realExit.
+						onMessageByType(ITC_EVENT_TYPES.SHUTDOWN, () => trackScopeClose(scope.close()));
+					}
 
 					await sequentiallyHandleApplication(scope, extensionModule);
 

--- a/components/operations.js
+++ b/components/operations.js
@@ -536,7 +536,10 @@ async function deployComponent(req) {
 						collectScopes: validationScopes,
 					});
 				} finally {
-					await Promise.allSettled(Array.from(validationScopes, (scope) => scope.close()));
+					const closeResults = await Promise.allSettled(Array.from(validationScopes, (scope) => scope.close()));
+					for (const result of closeResults) {
+						if (result.status === 'rejected') log.warn('Failed to close a deploy-validation Scope', result.reason);
+					}
 				}
 			})();
 			// Track the load+close so a concurrent worker shutdown waits for these scopes to finish

--- a/components/operations.js
+++ b/components/operations.js
@@ -520,18 +520,29 @@ async function deployComponent(req) {
 			pseudoResources.isWorker = true;
 
 			const componentLoader = require('./componentLoader.ts').default || require('./componentLoader.ts');
+			const { trackScopeClose } = require('./scopeShutdown.ts');
 			let lastError;
 			componentLoader.setErrorReporter((error) => (lastError = error));
 			emit('phase', { phase: 'load', status: 'start' });
-			await componentLoader.loadComponent(
-				application.dirPath,
-				pseudoResources,
-				undefined,
-				false,
-				undefined,
-				false,
-				req.project
-			);
+			// This load exists only to surface load-time errors early; the Scopes it creates are
+			// throwaway. They are collected (instead of registered for worker-shutdown auto-close) so we
+			// can close them here once validation completes — otherwise each deploy leaks the Scope's
+			// deploy-lifecycle listeners on this worker, eventually tripping MaxListenersExceededWarning
+			// (#1462).
+			const validationScopes = new Set();
+			const validation = (async () => {
+				try {
+					await componentLoader.loadComponent(application.dirPath, pseudoResources, undefined, {
+						collectScopes: validationScopes,
+					});
+				} finally {
+					await Promise.allSettled(Array.from(validationScopes, (scope) => scope.close()));
+				}
+			})();
+			// Track the load+close so a concurrent worker shutdown waits for these scopes to finish
+			// disposing — a plugin may start a native runtime in handleApplication — before realExit.
+			trackScopeClose(validation);
+			await validation;
 			emit('phase', { phase: 'load', status: 'done' });
 
 			if (lastError) throw lastError;

--- a/unitTests/components/componentLoader.test.js
+++ b/unitTests/components/componentLoader.test.js
@@ -315,4 +315,88 @@ describe('ComponentLoader Status Integration', function () {
 			dataLoaderModule.handleApplication = originalhandleApplication;
 		});
 	});
+
+	describe('deploy lifecycle listener lifecycle (#1462)', function () {
+		const { deployLifecycle } = require('#src/components/deployLifecycle');
+
+		// Each Scope created for a handleApplication component registers a deploy:start /
+		// deploy:end listener on the shared deployLifecycle emitter and only removes them in
+		// close(). The deploy operation's pre-flight validation load (operations.js) creates
+		// such Scopes purely to surface load errors; if they are never closed, their listeners
+		// accumulate across deploys and eventually trip MaxListenersExceededWarning.
+		function makeProbeComponent(pluginName, onScope) {
+			const componentDir = path.join(tempDir, `leak-probe-${pluginName}`);
+			if (!existsSync(componentDir)) mkdirSync(componentDir);
+			writeFileSync(path.join(componentDir, 'harperdb-config.yaml'), `${pluginName}: {}`);
+			componentLoader.TRUSTED_RESOURCE_PLUGINS[pluginName] = {
+				handleApplication(scope) {
+					onScope?.(scope);
+				},
+			};
+			return componentDir;
+		}
+
+		it('leaks a deploy:start listener per load when validation scopes are never closed', async function () {
+			const pluginName = 'leakProbeUnclosed';
+			const createdScopes = [];
+			const componentDir = makeProbeComponent(pluginName, (scope) => createdScopes.push(scope));
+
+			const baseline = deployLifecycle.listenerCount('deploy:start');
+			const loads = 5;
+			try {
+				for (let i = 0; i < loads; i++) {
+					componentLoader.loadedPaths.clear(); // a fresh deploy re-validates past the path-load guard
+					await componentLoader.loadComponent(componentDir, { isWorker: true, set: sinon.stub() }, 'test-origin');
+				}
+
+				assert.equal(
+					deployLifecycle.listenerCount('deploy:start') - baseline,
+					loads,
+					'each unclosed validation load leaks one deploy:start listener'
+				);
+			} finally {
+				// Remove the leaked listeners so the shared emitter does not affect other tests.
+				await Promise.allSettled(createdScopes.map((scope) => scope.close()));
+				delete componentLoader.TRUSTED_RESOURCE_PLUGINS[pluginName];
+				componentLoader.loadedPaths.clear();
+			}
+
+			assert.equal(
+				deployLifecycle.listenerCount('deploy:start'),
+				baseline,
+				'closing the scopes removes their deploy:start listeners'
+			);
+		});
+
+		it('stays bounded across repeated loads when collectScopes is closed after each load', async function () {
+			const pluginName = 'leakProbeCollected';
+			const componentDir = makeProbeComponent(pluginName);
+
+			const baseline = deployLifecycle.listenerCount('deploy:start');
+			const loads = 12; // exceed the default maxListeners (10) to mirror the reported warning
+			try {
+				for (let i = 0; i < loads; i++) {
+					componentLoader.loadedPaths.clear();
+					const collectScopes = new Set();
+					await componentLoader.loadComponent(componentDir, { isWorker: true, set: sinon.stub() }, 'test-origin', {
+						collectScopes,
+					});
+
+					assert.ok(collectScopes.size >= 1, 'collectScopes should capture the validation scope(s)');
+
+					// The deploy operation closes these throwaway scopes once validation completes.
+					await Promise.allSettled([...collectScopes].map((scope) => scope.close()));
+				}
+
+				assert.equal(
+					deployLifecycle.listenerCount('deploy:start'),
+					baseline,
+					'deploy:start listeners return to baseline after each validation load is closed'
+				);
+			} finally {
+				delete componentLoader.TRUSTED_RESOURCE_PLUGINS[pluginName];
+				componentLoader.loadedPaths.clear();
+			}
+		});
+	});
 });


### PR DESCRIPTION
Fixes #1462

## Summary

`deploy_component`'s pre-flight validation load (`components/operations.js`, `deployComponent`) loads the freshly-prepared component on a worker — with `pseudoResources.isWorker = true` — purely to surface load-time errors early. Because `isWorker` is set, `loadComponent` creates real `Scope`s, each of which registers `deploy:start` / `deploy:end` listeners on the shared `deployLifecycle` emitter (`components/Scope.ts:138-139`). These throwaway validation Scopes were never closed — `Scope.close()` only ran via the per-Scope worker-`SHUTDOWN` handler — so their listeners accumulated on the worker across deploys, eventually tripping `MaxListenersExceededWarning` (`11 deploy:start listeners`). This is the leak in #1462.

The invariant the rest of the system relies on is stated in `components/scopeShutdown.ts`: *"scopes are created once at load and closed once at shutdown, so nothing accumulates."* The validation load violated it.

## Changes

- **`components/componentLoader.ts`** — added a `collectScopes?: Set<Scope>` option to `loadComponent`. When provided, each Scope created during the load is added to the set **instead of** being registered for worker-shutdown auto-close; the caller then owns closing them. Threaded through the sub-component recursion so packaged sub-components are collected too.
- **`components/operations.js`** (`deployComponent`) — the validation load now collects its Scopes and closes them in a `finally` once validation completes, so their `deployLifecycle` listeners are removed immediately. The load+close is wrapped in `trackScopeClose(...)` so a concurrent worker shutdown still waits for these Scopes to dispose (a plugin may start a native runtime in `handleApplication`) before `realExit`. Also dropped the stale trailing positional args to `loadComponent` (the 4th+ args were already ignored by the current `(dir, resources, origin, options)` signature).
- **`unitTests/components/componentLoader.test.js`** — a characterization test (each unclosed validation load leaks exactly one `deploy:start` listener) and a regression test (with `collectScopes` closed after each load, the listener count stays at baseline across 12 loads — past the default `maxListeners` of 10).

## Where to look

- **Shutdown safety (operations.js).** Skipping the per-Scope `SHUTDOWN` auto-close for collected Scopes would otherwise drop them from the worker's `whenScopesClosed()` wait. The `trackScopeClose(validation)` wrapping restores that guarantee — worth a look that this is the right mechanism. (Raised by the Codex cross-model review and addressed here.)
- This is **distinct** from harper-pro#460/#461 (replicator node-update watcher accumulation) and from the in-flight `startOnMainThread`-once core fix (branch `kris/start-on-main-thread-once`). No overlap: that fix gates main-thread init; this fixes worker-side validation-load Scope cleanup.

Local validation: `unitTests/components/componentLoader.test.js` and `unitTests/components/Scope.test.js` pass; the deploy integration suite is left to CI.

🤖 Generated by an LLM (Claude Opus 4.8).
