### PR TITLE
Fix deploy packaging an empty component when installed under a node_modules path

### DIFF
--- a/components/packageComponent.ts
+++ b/components/packageComponent.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join, relative, sep } from 'node:path';
 import { stat, readdir } from 'node:fs/promises';
 import { Readable } from 'node:stream';
 import tar from 'tar-fs';
@@ -10,6 +10,21 @@ interface PackageOptions {
 }
 
 const DEFAULT_OPTIONS: PackageOptions = { skip_node_modules: false, skip_symlinks: false };
+
+const WEBPACK_CACHE_SEGMENT = join('cache', 'webpack');
+
+/**
+ * Whether `fullPath` (an absolute path under `directory`) should be excluded from the package when
+ * `skip_node_modules` is set. The path is first made relative to `directory`, so packaging a component
+ * that itself lives under a `node_modules/` path — i.e. any npm-installed component — does not match
+ * every entry. tar-fs invokes `ignore` with the absolute path, so a substring test on it wrongly
+ * excluded the whole tree. Shared by the stream packer and the size walk so the two cannot diverge.
+ */
+function isExcluded(directory: string, fullPath: string, options: PackageOptions): boolean {
+	if (!options.skip_node_modules) return false;
+	const rel = relative(directory, fullPath);
+	return rel.split(sep).includes('node_modules') || rel.includes(WEBPACK_CACHE_SEGMENT);
+}
 
 /**
  * Package a directory into a tar+gzip stream. The returned Readable can be
@@ -27,11 +42,7 @@ export function streamPackagedDirectory(
 ): Readable {
 	const packStream = tar.pack(directory, {
 		dereference: !options.skip_symlinks,
-		ignore: options.skip_node_modules
-			? (name: string) => {
-					return name.includes('node_modules') || name.includes(join('cache', 'webpack'));
-				}
-			: undefined,
+		ignore: (name: string) => isExcluded(directory, name, options),
 		map: (header) => {
 			if (header.type === 'directory') {
 				header.mode = 0o755;
@@ -71,7 +82,7 @@ export async function getPackagedDirectorySize(
 		}
 		for (const entry of entries) {
 			const fullPath = join(dir, entry.name);
-			if (options.skip_node_modules && (entry.name === 'node_modules' || fullPath.includes(join('cache', 'webpack')))) {
+			if (isExcluded(directory, fullPath, options)) {
 				continue;
 			}
 			if (entry.isDirectory()) {

--- a/unitTests/components/packageComponent.test.js
+++ b/unitTests/components/packageComponent.test.js
@@ -99,6 +99,40 @@ describe('streamPackagedDirectory round-trip', () => {
 			await fs.rm(sourceDir, { recursive: true, force: true });
 		}
 	});
+
+	it('packages a component that itself lives under a node_modules/ path (regression)', async function () {
+		this.timeout(15000);
+		// A component installed under node_modules — the case that made `harper deploy`
+		// of any npm-installed component ship an empty tarball (ignore matched the
+		// absolute path's `node_modules` segment for every entry).
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), 'pkg-under-nm-'));
+		const compDir = path.join(root, 'node_modules', '@scope', 'comp');
+		const compFiles = {
+			'package.json': '{"name":"comp","version":"1.0.0"}\n',
+			'dist/resources/Memory.js': 'exports.x = 1;\n',
+			'schemas/memory.graphql': 'type Memory { id: ID }\n',
+		};
+		for (const [rel, content] of Object.entries(compFiles)) {
+			const full = path.join(compDir, rel);
+			await fs.mkdir(path.dirname(full), { recursive: true });
+			await fs.writeFile(full, content);
+		}
+		// An inner node_modules that must still be excluded.
+		const innerDep = path.join(compDir, 'node_modules', 'dep', 'index.js');
+		await fs.mkdir(path.dirname(innerDep), { recursive: true });
+		await fs.writeFile(innerDep, 'module.exports = 1;\n');
+
+		const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pkg-under-nm-out-'));
+		try {
+			await pipeline(streamPackagedDirectory(compDir, { skip_node_modules: true }), gunzip(), tar.extract(extractDir));
+			// Component source survives despite compDir living under node_modules/, and the
+			// inner node_modules is excluded — deepStrictEqual asserts both at once.
+			assert.deepStrictEqual(await readDirTree(extractDir), compFiles);
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+			await fs.rm(extractDir, { recursive: true, force: true });
+		}
+	});
 });
 
 // keep eslint happy in case Readable isn't directly used in some branch


### PR DESCRIPTION
## Summary
`harper deploy` shipped an **empty** component (only deps reinstalled node-side) when packaging any component located under a `node_modules/` directory — e.g. a globally npm-installed component. `packageComponent`'s `tar-fs` `ignore` tested `name.includes('node_modules')` on the **absolute** path, so every entry of a component living under `…/node_modules/<pkg>` matched and the whole tree was excluded (1.5 KiB tarball). The size estimator (`getPackagedDirectorySize`) already used a relative segment check, so the packer and size-walk had diverged.

Fix: a shared `isExcluded()` that resolves paths **relative to the pack root** and matches `node_modules` as a path *segment* (plus the `cache/webpack` path), used by both `streamPackagedDirectory` and `getPackagedDirectorySize` so they can't diverge again. Regression test added.

## Why
Surfaced while dogfooding a Fabric deploy of a globally-installed component (it deployed empty; see tpsdev-ai/flair#513). Affects any npm-installed component deploy, not just that case.

## Where to look
- `components/packageComponent.ts` — the `isExcluded` helper and the two call sites it unifies.
- Edge cases (verified by reviewers): `fullPath === directory` → empty rel, not excluded; Windows `sep`; nested `node_modules` still excluded; substring false-positives like `some_node_modules_pkg` no longer match.

No open review concerns — Codex and Gemini both reviewed clean (one perf suggestion — hoisting the `cache/webpack` join — applied).

🤖 Generated by Claude (Opus 4.8) via Claude Code.