### PR TITLE
fix: use getSync for system-table point reads (RocksDB MaybePromise)

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -482,7 +482,10 @@ export function makeTable(options) {
 											updateRecordedSequenceId = () => {
 												// the key for tracking the sequence ids and txn times received from this node
 												const seqKey = [Symbol.for('seq'), event.remoteNodeIds[0]];
-												const existingSeq = dbisDb.get(seqKey);
+												// getSync (not get): dbisDb is the raw __dbis__ store, so on RocksDB get() returns a
+												// Promise on a block-cache miss; `Promise?.nodes` is undefined and per-peer sequence
+												// tracking would silently reset. The seq keyspace grows with peer count, so it evicts.
+												const existingSeq = (dbisDb as any).getSync(seqKey);
 												let nodeStates = existingSeq?.nodes;
 												if (!nodeStates) {
 													// if we don't have a list of nodes, we need to create one, with the main one using the existing seqId
@@ -966,7 +969,10 @@ export function makeTable(options) {
 		}
 
 		static getResidencyRecord(id: Id) {
-			return dbisDb.get([Symbol.for('residency_by_id'), id]);
+			// getSync (not get): callers consume the result synchronously (e.g. residency.includes(...) in a
+			// commit callback, or store it as context.previousResidency). On RocksDB get() would return a
+			// Promise on a cache miss, breaking those sync consumers once __dbis__ grows past the block cache.
+			return (dbisDb as any).getSync([Symbol.for('residency_by_id'), id]);
 		}
 
 		static setResidency(getResidency?: (record: object, context: Context) => ResidencyDefinition) {
@@ -5302,7 +5308,9 @@ export function makeTable(options) {
 	function getResidencyId(ownerNodeNames) {
 		if (ownerNodeNames) {
 			const setKey = ownerNodeNames.join(',');
-			let residencyId = dbisDb.get([Symbol.for('residency_by_set'), setKey]);
+			// getSync (not get): a get() Promise on a RocksDB cache miss is always truthy, so this would
+			// return the Promise as the residencyId and skip minting a new one, corrupting the mapping.
+			let residencyId = (dbisDb as any).getSync([Symbol.for('residency_by_set'), setKey]);
 			if (residencyId) return residencyId;
 			dbisDb.put(
 				[Symbol.for('residency_by_set'), setKey],

--- a/resources/nodeIdMapping.ts
+++ b/resources/nodeIdMapping.ts
@@ -38,7 +38,9 @@ function getIdMappingRecord(auditStore) {
 			// we need to update the sequence id for the previous host name, and have it start from our last sequence id
 			const seqKey = [Symbol.for('seq'), lastId];
 			auditStore.rootStore.dbisDb.transactionSync(() => {
-				if (!auditStore.rootStore.dbisDb.get(seqKey))
+				// getSync (not get): a get() Promise on a RocksDB cache miss is truthy, so `!...get(seqKey)`
+				// would be false and skip initializing the seq record for the reassigned node id.
+				if (!(auditStore.rootStore.dbisDb as any).getSync(seqKey))
 					auditStore.rootStore.dbisDb.putSync(seqKey, {
 						seqId: lastTimeInAuditStore(auditStore) ?? 1,
 						nodes: [],

--- a/security/keys.ts
+++ b/security/keys.ts
@@ -240,7 +240,11 @@ export function loadCertificates() {
 
 								// If a record already exists for cert check to see who is newer, cert record or cert file.
 								// If cert file is newer, add it to table
-								const certRecord = certificateTable.primaryStore.get(certCn);
+								// getSync (not get): this runs in a synchronous loadAndWatch callback. On RocksDB get()
+								// returns a Promise on a block-cache miss, which is truthy but has no timestamp fields,
+								// so the staleness guard below is bypassed and a stale on-disk cert can overwrite a
+								// newer replicated record (TLS churn / downgrade) once hdb_certificate evicts.
+								const certRecord = certificateTable.primaryStore.getSync(certCn);
 								let fileTimestamp = statSync(path).mtimeMs;
 								let recordTimestamp =
 									!certRecord || certRecord.is_self_signed


### PR DESCRIPTION
Fixes a class of RocksDB `store.get()` misuse. On RocksDB `store.get()` returns a `MaybePromise` — the record synchronously when it's in the block cache/memtable, but a **Promise** on a cache miss. So point reads whose result is consumed synchronously work while the data is cached, then break once the table grows past the block cache (or right after a cold-cache restart, when the cache is empty). LMDB is always synchronous, so this is RocksDB-only.

## Summary

Switch four system-table point reads from `get()` to the synchronous `getSync()`:

- **`Table.ts`** — the `__dbis__` per-peer seq-tracking read in the replication apply path (`existingSeq?.nodes`), and the `residency_by_id` / `residency_by_set` lookups (`getResidencyRecord` + `getResidencyId`). A Promise here silently reset sequence tracking or returned a Promise *as* a residency id.
- **`nodeIdMapping.ts`** — the seq-init existence check on a node-id reassignment (a truthy Promise skipped the init).
- **`security/keys.ts`** — the `hdb_certificate` staleness comparison in the synchronous `loadAndWatch` callback (a Promise bypassed the timestamp guard, allowing a stale on-disk cert to overwrite a newer replicated record).

## Where to look

- The raw `dbisDb` reads use `(dbisDb as any).getSync(...)` to match the existing precedent in this file (`Table.ts:1064`). The lmdb type doesn't declare `getSync`, but it exists at runtime (`lmdb/read.js` aliases it to the sync `get`). A properly typed `Store<V>` surface is a planned follow-up that would let the compiler flag this whole class.
- `getResidencyRecord` is changed once and covers all four call sites (a sync `.includes(...)` in a commit callback plus three `context.previousResidency` consumers).

Paired with the harper-pro PR, which bumps the `core` submodule to this commit and carries the replication-side fixes plus unit/integration tests.

_Generated by Claude Code (Claude Opus 4.8)._
