### PR TITLE
fix(indexing): treat shutdown-closed store during backfill as benign; de-flake reindex test

### DIFF
--- a/integrationTests/server/vector-index-integrity.test.ts
+++ b/integrationTests/server/vector-index-integrity.test.ts
@@ -151,7 +151,7 @@ async function vectorSearchStable(
 		} catch (err: any) {
 			const transient = /INDEX_REBUILDING|is not indexed yet/.test(err?.message ?? '');
 			if (transient && Date.now() < deadline) {
-				await new Promise((resolve) => setTimeout(resolve, 250));
+				await sleep(250);
 				continue;
 			}
 			throw err;

--- a/integrationTests/server/vector-index-integrity.test.ts
+++ b/integrationTests/server/vector-index-integrity.test.ts
@@ -127,6 +127,39 @@ async function vectorSearch(
 }
 
 /**
+ * Like vectorSearch, but tolerant of a *transient* INDEX_REBUILDING (503).
+ *
+ * `restart_service http_workers` can tear a worker down mid-backfill; the surviving
+ * generation re-runs the backfill via crash-recovery, during which `isIndexing` is briefly
+ * true again and searches legitimately return 503 before the index settles. A single
+ * post-gate search can therefore land in that window even though the index does converge.
+ * Retry until it is stably searchable. A 503 that never clears within the budget still
+ * surfaces — so a genuinely-stuck index (no recovery) is still caught as a failure.
+ */
+async function vectorSearchStable(
+	httpURL: string,
+	headers: Record<string, string>,
+	resourcePath: string,
+	target: number[],
+	opts: { limit?: number; select?: string[] } = {},
+	timeoutMs = 30_000
+): Promise<any[]> {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		try {
+			return await vectorSearch(httpURL, headers, resourcePath, target, opts);
+		} catch (err: any) {
+			const transient = /INDEX_REBUILDING|is not indexed yet/.test(err?.message ?? '');
+			if (transient && Date.now() < deadline) {
+				await new Promise((resolve) => setTimeout(resolve, 250));
+				continue;
+			}
+			throw err;
+		}
+	}
+}
+
+/**
  * Issue an HTTP QUERY request via fetch — supertest/superagent has no API for
  * non-standard verbs, while undici's fetch passes custom method tokens through.
  */
@@ -502,11 +535,14 @@ suite('HNSW vector-index data-integrity (integration)', (ctx: ContextWithHarper)
 		// indexed". Either state makes a record look like a miss, so poll the full
 		// recall check (bounded-concurrency read-back) until it converges rather than
 		// asserting on a single burst fired the instant one worker happens to be ready.
+		// Use vectorSearchStable so a transient INDEX_REBUILDING from a recovery-reindex
+		// window (a restart-interrupted backfill resuming) doesn't get counted as a miss;
+		// a permanently-stuck index still never converges and fails below.
 		const allowed = Math.ceil(N * 0.1);
 		let misses = N;
 		await waitFor(async () => {
 			const reindexResults = await mapConcurrent(N, 10, (i) =>
-				vectorSearch(httpURL, headers, path, seedVector(i, DIMS), { limit: 5 }).catch(() => [] as any[])
+				vectorSearchStable(httpURL, headers, path, seedVector(i, DIMS), { limit: 5 }).catch(() => [] as any[])
 			);
 			misses = 0;
 			for (let i = 0; i < N; i++) {
@@ -529,7 +565,7 @@ suite('HNSW vector-index data-integrity (integration)', (ctx: ContextWithHarper)
 
 		// reindex-0's new vector (seed 1000) must be near the top; deleted records absent.
 		const updatedVec = seedVector(1000, DIMS);
-		const afterResults = await vectorSearch(httpURL, headers, path, updatedVec, { limit: 15 });
+		const afterResults = await vectorSearchStable(httpURL, headers, path, updatedVec, { limit: 15 });
 		const afterIds = new Set(afterResults.map((r: any) => r.id));
 
 		ok(afterIds.has('reindex-0'), 'updated reindex-0 must appear near its new vector');

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1548,7 +1548,7 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 							// it as an error — the outer catch returns quietly once the iterator also throws.
 							attributeErrorReported[property] = true;
 							if (Table.primaryStore?.rootStore?.status === 'closed')
-								logger.debug(`Indexing attribute ${property} interrupted by store shutdown`);
+								logger.debug(`Indexing attribute ${property} interrupted by store shutdown`, error);
 							else logger.error(`Error indexing attribute ${property}`, error);
 						}
 					}
@@ -1651,7 +1651,8 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 		// interruption instead of logging a misleading error and a "failed to persist" warning.
 		if (Table.primaryStore?.rootStore?.status === 'closed') {
 			logger.debug(
-				`Indexing of ${Table.tableName} interrupted by store shutdown; recovery resumes on the next worker generation`
+				`Indexing of ${Table.tableName} interrupted by store shutdown; recovery resumes on the next worker generation`,
+				error
 			);
 			return;
 		}

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1542,9 +1542,14 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 					} catch (error) {
 						hadIndexingErrors = true;
 						if (!attributeErrorReported[property]) {
-							// just report an indexing error once per attribute so we don't spam the logs
+							// just report an indexing error once per attribute so we don't spam the logs.
+							// A store closed by worker shutdown surfaces here as "Database not open"; that is
+							// a benign interruption (the next generation re-runs the backfill), so don't log
+							// it as an error — the outer catch returns quietly once the iterator also throws.
 							attributeErrorReported[property] = true;
-							logger.error(`Error indexing attribute ${property}`, error);
+							if (Table.primaryStore?.rootStore?.status === 'closed')
+								logger.debug(`Indexing attribute ${property} interrupted by store shutdown`);
+							else logger.error(`Error indexing attribute ${property}`, error);
 						}
 					}
 				}
@@ -1638,6 +1643,18 @@ async function runIndexing(Table, attributes, indicesToRemove) {
 			logger.info(`Finished indexing ${Table.tableName} attributes`, attributes);
 		}
 	} catch (error) {
+		// A worker shutting down closes its stores mid-backfill, so the range iterator or a
+		// put throws (e.g. "Database not open" / "Iterator not initialized"). This is an
+		// interruption, not a data error: the next worker generation re-runs the backfill via
+		// the crash-recovery trigger (indexingPID / restartNumber mismatch), and persisting
+		// indexingFailed here would fail anyway against the closed store. Treat it as a benign
+		// interruption instead of logging a misleading error and a "failed to persist" warning.
+		if (Table.primaryStore?.rootStore?.status === 'closed') {
+			logger.debug(
+				`Indexing of ${Table.tableName} interrupted by store shutdown; recovery resumes on the next worker generation`
+			);
+			return;
+		}
 		logger.error('Error in indexing', error);
 		// Persist indexingFailed so the next restart re-triggers the rebuild from an
 		// explicitly failed state rather than silently looping. Without this,

--- a/unitTests/resources/indexRestartNumber.test.js
+++ b/unitTests/resources/indexRestartNumber.test.js
@@ -206,4 +206,79 @@ describe('indexing crash-recovery: restartNumber re-trigger (#1359)', () => {
 		}
 		assert.equal(total, N, 'all rows should be indexed after the restartNumber-triggered re-run');
 	});
+
+	it('treats a store closed by worker shutdown as a benign interruption (resolves, no indexingFailed)', async () => {
+		const TABLE = 'RN_ShutdownInterrupt';
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		let Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'tag' }],
+		});
+		let last;
+		for (let i = 0; i < N; i++) last = Tbl.put({ id: 's-' + i, tag: i % 2 ? 'odd' : 'even' });
+		await last;
+
+		// Add @indexed to trigger the backfill, then simulate the worker's store being closed
+		// mid-backfill: the range scan throws like a closed RocksDB handle and rootStore.status
+		// reports 'closed'. The descriptor's indexingPID/restartNumber are persisted by table()
+		// BEFORE runIndexing runs, so recovery can still re-trigger on the next generation.
+		resetDatabases();
+		Tbl = table({
+			table: TABLE,
+			database: DB,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'tag', indexed: true },
+			],
+		});
+		const rootStore = Tbl.primaryStore.rootStore;
+		const origStatusDesc = Object.getOwnPropertyDescriptor(rootStore, 'status');
+		const origGetRange = Tbl.primaryStore.getRange.bind(Tbl.primaryStore);
+		let scanIntercepted = 0;
+		Object.defineProperty(rootStore, 'status', { value: 'closed', configurable: true });
+		Tbl.primaryStore.getRange = () => ({
+			[Symbol.iterator]() {
+				return {
+					next() {
+						scanIntercepted++;
+						throw new Error('Database not open');
+					},
+				};
+			},
+		});
+		let rejected = false;
+		try {
+			// A shutdown interruption is benign: runIndexing must resolve, not reject.
+			if (Tbl.indexingOperation) await Tbl.indexingOperation;
+		} catch {
+			rejected = true;
+		} finally {
+			Tbl.primaryStore.getRange = origGetRange;
+			if (origStatusDesc) Object.defineProperty(rootStore, 'status', origStatusDesc);
+			else delete rootStore.status;
+		}
+
+		assert.ok(scanIntercepted > 0, 'sanity: the backfill scan must have been intercepted (store-closed simulation)');
+		assert.equal(
+			rejected,
+			false,
+			'a store closed by shutdown must be handled as a benign interruption, not a rejection'
+		);
+
+		// The early-return is a pure no-op on persisted state: it must NOT mark the index
+		// indexingFailed (the old path tried to persist that against the closed store, which
+		// both failed loudly and was unnecessary — recovery comes from the restartNumber/PID
+		// trigger, covered by the tests above). Recovery markers, if the trigger set them, are
+		// left untouched because the fix writes nothing.
+		const desc = findDescriptor(Tbl, 'tag');
+		assert.ok(desc, 'tag descriptor should exist after a shutdown-interrupted backfill');
+		assert.notEqual(
+			desc.value.indexingFailed,
+			true,
+			'a shutdown-interrupted backfill must NOT be marked indexingFailed'
+		);
+	});
 });


### PR DESCRIPTION
## Summary
Fixes the ~50% CI flake on `integrationTests/server/vector-index-integrity.test.ts` ("reindex backfill") and removes misleading error noise during worker shutdown.

## Root cause (investigated with instrumentation + local repro)
When `restart_service http_workers` tears a worker down mid-backfill, `runIndexing`'s range scan/puts throw against the closing store (`Database not open`). The new worker generation re-runs the backfill via the existing crash-recovery trigger (`indexingPID !== process.pid` / `restartNumber < currentRestartGeneration`). During that recovery-reindex window the index legitimately reports `isIndexing=true`, so searches transiently return `503 INDEX_REBUILDING`. The test's step-4 gate waited for a single successful search, then step 5 fired searches with no retry — a transient 503 in that window failed the test.

Instrumented/amplified local runs confirmed the index **always recovers** (no permanent stuck state); the failure is the transient 503 plus benign-but-misleading teardown logging (`Error in indexing` + `Failed to persist indexing failure state`).

## Changes
- **`resources/databases.ts`** — in `runIndexing`'s outer catch and per-attribute error catch, treat a store closed by shutdown (`primaryStore.rootStore?.status === 'closed'`) as a benign interruption: early-return without the doomed `indexingFailed` persist, log at `debug`. Recovery behavior is unchanged (handled by the pid/restartNumber trigger).
- **`integrationTests/server/vector-index-integrity.test.ts`** — `vectorSearchStable()` retries a transient `INDEX_REBUILDING` (503) up to 30s; used in steps 5/6. A permanently-stuck index (never clears) still surfaces the 503 and fails.
- **`unitTests/resources/indexRestartNumber.test.js`** — new test for the shutdown-interruption path (runIndexing resolves; `indexingFailed` not set).

## Where to look / what to verify
- The `status === 'closed'` early-return is gated so it only skips a persist that **could not have succeeded** anyway (closed store). On LMDB, `dbisDB` shares the env with `primaryStore`, so the prior `dbisDB.put` already failed there too — no recovery regression. On RocksDB (CI), `resetDatabases()` never closes the store, so `closed` only occurs on real worker teardown → recovery via a new generation.

## Cross-model review (DLC step 10 — thorough)
Codex + Gemini + Harper domain pass. **No open blockers.** Two findings surfaced, both confirmed **pre-existing / out of scope**, not introduced here:
- LMDB same-process `resetDatabases()` mid-backfill can leave an index stuck — this predates the change (the old persist already failed against the same closed env; recovery there doesn't depend on `indexingFailed`). LMDB is not the indexing/replication target path. Flagged for awareness, not fixed here.
- Non-last-`put` unhandled rejection for multi-value attributes — already documented in-code as pre-existing and out of scope.

Generated by an LLM (Claude Opus 4.8).