### PR TITLE
docs: clarify that tables/databases are live process-wide singletons

### DIFF
--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -161,6 +161,17 @@ export function setErrorReporter(reporter) {
 let compName: string;
 export const getComponentName = () => compName;
 
+/**
+ * Symlink a component's `node_modules/harper` (and `harperdb`) to this running Harper install,
+ * rather than letting it resolve a separately-installed npm copy.
+ *
+ * This is what makes `import { tables } from 'harper'` (or `import 'harperdb'`) inside component
+ * code — including bundler-loaded code such as a Vite SSR entry — resolve to the SAME module
+ * instance Harper is running. That instance carries the live, process-wide exports
+ * (`tables`/`databases`/`Resource`/…) populated via `_assignPackageExport` (see ../globals.js and
+ * ../index.ts), so the import yields live data, not an empty separate copy. The link is verified on
+ * every non-root component load and repaired if missing or pointing elsewhere.
+ */
 function symlinkHarperModule(componentDirectory: string) {
 	return new Promise<void>((resolve, reject) => {
 		const store = Status.primaryStore;

--- a/index.ts
+++ b/index.ts
@@ -70,6 +70,16 @@ import type { tables as TablesImport } from './resources/databases.ts';
 type ThreadsImport = unknown[]; // TODO: figure out actual type for this
 import type { transaction as TransactionImport } from './resources/transaction.ts';
 
+// These names are exposed TWO ways that resolve to the SAME live, process-wide value:
+//   1. as ambient globals (the `declare global` block below), and
+//   2. as named exports of the `harper` package (the `export declare const` block below).
+// At runtime each is populated in place by `_assignPackageExport(name, value)` (see globals.js),
+// which assigns BOTH `global[name]` and `exports[name]` to the one shared instance. So
+// `tables`/`databases`/etc. are not per-module or per-compartment copies: the bare global `tables`
+// and `import { tables } from 'harper'` are the same object, available in any module Harper loads —
+// resources, plugins, and e.g. a Vite SSR entry (whose `node_modules/harper` is symlinked to this
+// running install, see components/componentLoader.ts). Application VM compartments are *seeded* from
+// this process global, not given an alternate set (see security/jsLoader.ts `getGlobalObject`).
 declare global {
 	const contentTypes: typeof ContentTypesImport;
 	const createBlob: typeof CreateBlobImport;

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -751,6 +751,12 @@ function getDefaultJSGlobalNames() {
 
 /**
  * Get the set of global variables that should be available to modules that run in scoped compartments/contexts.
+ *
+ * The compartment global is SEEDED from the process `global` — every Harper process-global
+ * (`tables`, `databases`, `Resource`, …; see ../globals.js) is copied across as a live reference,
+ * not a per-compartment copy. A compartment is therefore not given an alternate set of these
+ * objects; it shares the same ones as the rest of the process (with only `server`/`logger`/
+ * `resources`/`config` optionally overridden per scope).
  */
 function getGlobalObject(scope: ApplicationScope, copyIntrinsics = false) {
 	const appGlobal = {};
@@ -774,6 +780,10 @@ function getGlobalObject(scope: ApplicationScope, copyIntrinsics = false) {
 	});
 	return appGlobal;
 }
+// The object exposed as the `harper` module inside compartments (`import { tables } from 'harper'`).
+// `Resource`/`tables`/`databases`/`createBlob`/… below are the live, process-wide singletons (the
+// same values surfaced as the top-level package exports and bare globals), not per-compartment
+// copies — only `server`/`logger`/`resources`/`config` are scope-overridable.
 function getHarperExports(scope: ApplicationScope) {
 	return {
 		server: scope.server ?? server,


### PR DESCRIPTION
## Why

Harper's data-access globals are easy to misread from the source, and that misreading has real downstream cost (e.g. SSR code fetching its own REST API over loopback instead of just calling `tables.X.get()`):

- A reader who finds the VM `Compartment` machinery in `security/jsLoader.ts` can conclude `tables`/`databases` are **compartment-only**.
- A reader who sees `node_modules/harper` can assume `import 'harper'` resolves a **separate, empty** npm copy.

Both are wrong. `globals.js` assigns each name to **both** `global[name]` and `exports[name]` (via `_assignPackageExport`), the component loader **symlinks** `node_modules/harper` to the running install, and compartments are **seeded** from the process `global`. But none of that code carried an explanatory comment, so the correct mental model isn't discoverable.

## What (comments only — no behavior change)

- **`index.ts`** — note that the names are exposed as ambient globals *and* as `harper` package exports that resolve to the **same live value**, available in any module Harper loads (including a Vite SSR entry whose `node_modules/harper` is symlinked here).
- **`components/componentLoader.ts`** — JSDoc on `symlinkHarperModule` explaining it exists so `import 'harper'` in component/bundler code resolves to the running install (live exports), not a separate copy.
- **`security/jsLoader.ts`** — note that `getGlobalObject` **seeds** compartments from the process `global` (live references) and `getHarperExports` returns those same singletons; compartments don't get an alternate set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)