### PR TITLE
Log notify message at startup when HARPER_SAFE_MODE is set

### DIFF
--- a/bin/run.ts
+++ b/bin/run.ts
@@ -39,6 +39,8 @@ const UPGRADE_ERR = 'Got an error while trying to upgrade your Harper instance. 
 const HDB_NOT_FOUND_MSG = 'Harper not found, starting install process.';
 const INSTALL_ERR = 'There was an error during install. Exiting.';
 const HDB_STARTED = 'Harper successfully started.';
+const SAFE_MODE_MSG =
+	'Harper is running in safe mode (HARPER_SAFE_MODE); user applications and components will not be loaded.';
 
 function addUnhandleRejectionListener() {
 	process.on('unhandledRejection', (reason, promise) => {
@@ -198,6 +200,8 @@ async function main(calledByInstall = false) {
 			configUtils.updateConfigObject('settings_path', harperConfigPath);
 		}
 		await initialize(calledByInstall, true);
+
+		if (process.env.HARPER_SAFE_MODE) hdbLogger.notify(SAFE_MODE_MSG);
 
 		if (env.get(terms.CONFIG_PARAMS.STORAGE_COMPACTONSTART)) await compactOnStart();
 		if (env.get(terms.CONFIG_PARAMS.STORAGE_MIGRATEONSTART)) await migrateOnStart();


### PR DESCRIPTION
## Summary
Adds a single `notify`-level log in the main-process startup path (`bin/run.ts`) when Harper is launched with `HARPER_SAFE_MODE` set. Message:

> `Harper is running in safe mode (HARPER_SAFE_MODE); user applications and components will not be loaded.`

## Purpose
In safe mode Harper skips loading user applications and components. There was previously no log line announcing this, so an operator inspecting logs couldn't tell whether an instance came up in safe mode. This makes it visible.

## Where to look
- `bin/run.ts` — `main()`, immediately after `initialize()`. Placed here (rather than in `loadRootComponents`/`componentLoader`, which run per worker thread) so it fires **exactly once** in the main process, and before `startHTTPThreads` so it's emitted even if a later startup step fails. `notify` matches the level of the other startup lifecycle messages (`HDB_STARTED`, install/restart).

## Notes
- Not user-facing in the docs sense (no public API/config/CLI/schema change) — just an internal log line — so no documentation PR.
- We considered also surfacing safe mode in `harper status`, but `status` runs as its own CLI process and can only read `HARPER_SAFE_MODE` from the *invoking* shell, not the running server (safe mode isn't persisted), so it would be misleading. Left out by design.
- Generated by an LLM (Claude Opus 4.8).