### PR TITLE
copyApply write mode for non-system base copies (harper-pro#480)

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -402,6 +402,10 @@ export function makeTable(options) {
 						viaNodeId: event.viaNodeId,
 						// use per-event expiresAt: batched txn context only holds the first event's expiration
 						expiresAt: event.expiresAt,
+						// bulk base-copy snapshot frame: apply current-state directly, without an audit/transaction-log
+						// entry or out-of-order resequencing (harper-pro#480). Only set for copy frames (between
+						// COPY_START and COPY_COMPLETE); post-copy audit-replay frames apply normally.
+						isCopyApply: event.isCopyApply,
 						async: true,
 					};
 					const id = event.id;
@@ -1966,8 +1970,25 @@ export function makeTable(options) {
 					const expiresAt: number =
 						options?.expiresAt ?? context?.expiresAt ?? (expirationMs ? expirationMs + Date.now() : -1);
 					const additionalAuditRefs: Array<{ version: number; nodeId: number }> = []; // track additional audit refs to store
+					// Bulk base-copy snapshot apply: store current-state directly with no audit/transaction-log entry
+					// and no out-of-order resequencing/dedup (the source of the O(n) keyed-lookup spin in
+					// harper-pro#480). Durability for these (WAL-off) rows comes from an explicit RocksDB flush that
+					// gates the copy resume cursor on the receiver, not from an audit entry.
+					// RocksDB-only: with the singular version/localTime, a copied row's stored version === its replay
+					// sequence, so `version < copyStartTime` (the receiver's gate) reliably means "not re-delivered by
+					// the post-copy replay". On LMDB, localTime is stored separately from version and audit=false would
+					// drop it (breaking a later downstream full copy) and the replay cursor can diverge from version
+					// (risking a missed dedup), so LMDB falls back to the normal audited apply. Replication targets
+					// RocksDB anyway. (harper-pro#480)
+					const isCopyApply = options?.isCopyApply === true && isRocksDB;
 
 					if (precedesExisting <= 0) {
+						if (isCopyApply) {
+							// A base-copy snapshot row must never regress a newer-or-equal live write that landed
+							// during the copy; those are re-delivered by the post-copy audit replay from copyStartTime.
+							write.skipped = true;
+							return;
+						}
 						// This block is to handle the case of saving an update where the transaction timestamp is older than the
 						// existing timestamp, which means that we received updates out of order, and must resequence the application
 						// of the updates to the record to ensure consistency across the cluster
@@ -2372,7 +2393,8 @@ export function makeTable(options) {
 								? Math.max(txnTime, existingEntry?.version ?? 0) // RocksDB uses a singular version/local time, so it must be most recent
 								: txnTime,
 							omitLocalRecord ? INVALIDATED : 0,
-							audit,
+							// copy-apply rows are snapshots, not transactions: write the record + indices but no audit entry
+							isCopyApply ? false : audit,
 							{
 								omitLocalRecord,
 								user: (context as any)?.user,
@@ -2382,7 +2404,8 @@ export function makeTable(options) {
 								viaNodeId: options?.viaNodeId,
 								originatingOperation: (context as any)?.originatingOperation,
 								transaction,
-								tableToTrack: databaseName === 'system' ? null : options?.replay ? null : tableName, // don't track analytics on system tables
+								// no per-row db-write analytics for a bulk copy; system tables never track
+								tableToTrack: isCopyApply || databaseName === 'system' ? null : options?.replay ? null : tableName,
 								additionalAuditRefs: additionalAuditRefs.length > 0 ? additionalAuditRefs : undefined,
 								// local-only marks the record so the replication send path skips it (see LOCAL_ONLY)
 								localOnly: options?.localOnly,

--- a/unitTests/resources/copyApply.test.js
+++ b/unitTests/resources/copyApply.test.js
@@ -1,0 +1,119 @@
+const assert = require('assert');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const { setTimeout: delay } = require('node:timers/promises');
+require('#src/server/serverHelpers/serverUtilities');
+
+// Bulk base-copy frames are applied as snapshots (harper-pro#480): the record + indices are written
+// but NO audit/transaction-log entry is created, and the out-of-order resequencing/dedup is skipped.
+// These tests exercise the core apply branch via an intermediate (replication) source, which is how
+// replication feeds writes through _writeUpdate; `isCopyApply` on the event is set by harper-pro's
+// replicationConnection for frames received between COPY_START and COPY_COMPLETE.
+describe('copy-apply snapshot writes (harper-pro#480)', () => {
+	before(function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		server.replication.mockRemoteMap = new Map([['local', 0]]);
+		server.replication.getIdOfRemoteNode = function (name) {
+			let id = server.replication.mockRemoteMap.get(name);
+			if (id === undefined) {
+				id = server.replication.mockRemoteMap.size;
+				server.replication.mockRemoteMap.set(name, id);
+			}
+			return id;
+		};
+	});
+
+	async function waitFor(predicate, message, timeout = 5000) {
+		const start = Date.now();
+		while (Date.now() - start < timeout) {
+			if (await predicate()) return;
+			await delay(20);
+		}
+		throw new Error('waitFor timed out: ' + message);
+	}
+
+	// A table fed only by an intermediate (replication) source that yields `events` in order, then
+	// holds the subscription open until `held` resolves (so the apply loop stays alive for assertions).
+	function makeReplicatedTable(name, events, held) {
+		const ReplicatedTable = table({
+			table: name,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+		});
+		ReplicatedTable.sourcedFrom(
+			{
+				subscribeOnThisThread() {
+					return true;
+				},
+				async *subscribe() {
+					for (const event of events) yield event;
+					await held;
+				},
+			},
+			{ intermediateSource: true }
+		);
+		return ReplicatedTable;
+	}
+
+	it('writes the record but no audit entry, while a normal replicated put does write one', async function () {
+		// copy-apply suppresses the audit entry on RocksDB only; on LMDB it falls back to the normal audited
+		// apply (LMDB stores localTime separately and audit=false would drop it), so this RocksDB-specific
+		// assertion does not hold under HARPER_STORAGE_ENGINE=lmdb (harper-pro#480).
+		if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') this.skip();
+		let release;
+		const held = new Promise((resolve) => (release = resolve));
+		const now = Date.now();
+		const ReplicatedTable = makeReplicatedTable(
+			'CopyApplyAudit',
+			[
+				{ type: 'put', id: 1, value: { id: 1, name: 'copied' }, timestamp: now, isCopyApply: true },
+				{ type: 'put', id: 2, value: { id: 2, name: 'replicated' }, timestamp: now + 1 },
+			],
+			held
+		);
+		try {
+			await waitFor(
+				async () =>
+					(await ReplicatedTable.get(1))?.name === 'copied' && (await ReplicatedTable.get(2))?.name === 'replicated',
+				'both records applied'
+			);
+			// the snapshot record is durably stored
+			assert.equal(ReplicatedTable.primaryStore.getEntry(1)?.value?.name, 'copied');
+			// copy-apply rows carry no audit/transaction-log entry; the normal replicated row does
+			assert.equal((await ReplicatedTable.getHistoryOfRecord(1)).length, 0, 'copy-apply row must have no audit entry');
+			assert.ok(
+				(await ReplicatedTable.getHistoryOfRecord(2)).length >= 1,
+				'normal replicated row must have an audit entry'
+			);
+		} finally {
+			release();
+		}
+	});
+
+	it('is put-if-newer-or-absent: an older snapshot must not regress a newer row', async function () {
+		let release;
+		const held = new Promise((resolve) => (release = resolve));
+		const now = Date.now();
+		const ReplicatedTable = makeReplicatedTable(
+			'CopyApplyNewer',
+			[
+				{ type: 'put', id: 1, value: { id: 1, name: 'newer' }, timestamp: now + 100, isCopyApply: true },
+				{ type: 'put', id: 1, value: { id: 1, name: 'older' }, timestamp: now, isCopyApply: true },
+				// sentinel applied last so we can wait for the whole batch to drain
+				{ type: 'put', id: 9, value: { id: 9, name: 'marker' }, timestamp: now + 200, isCopyApply: true },
+			],
+			held
+		);
+		try {
+			await waitFor(async () => (await ReplicatedTable.get(9))?.name === 'marker', 'sentinel applied');
+			assert.equal(
+				(await ReplicatedTable.get(1))?.name,
+				'newer',
+				'older copy-apply snapshot must not overwrite the newer row'
+			);
+		} finally {
+			release();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Adds a **copyApply** write mode for bulk base-copy frames: the record + secondary indices are written, but **no audit/transaction-log entry** is created and the out-of-order resequencing/dedup is skipped. Engaged via `options.isCopyApply` (set by the harper-pro receive path for frames between `COPY_START` and `COPY_COMPLETE`).

## Purpose

A full base-copy of an analytics-laden table re-streams millions of old records; each one's keyed audit-dedup (`RocksTransactionLogStore.getSync`) looks up a version older than transaction-log retention → absent → `exactStart` scans to end-of-log → a worker spins ~100% CPU with no forward progress, and the copied rows are re-fabricated as transactions that amplify the per-peer transaction logs (harper-pro#480). copyApply removes both: copied rows are snapshots, not transactions.

## Where to look

- `resources/Table.ts` commit path — `isCopyApply` is **RocksDB-gated** (`&& isRocksDB`). On RocksDB the singular version === localTime === replay sequence, so the receiver's `version < copyStartTime` gate reliably means "not re-delivered by the post-copy audit replay." On LMDB, `localTime` is stored separately and `audit=false` would drop it (breaking a later downstream copy) and the replay cursor can diverge from version, so **LMDB falls back to the normal audited apply**.
- **Put-if-newer-or-absent**: the `precedesExisting <= 0` early-skip reuses `precedesExistingVersion` so a snapshot never regresses a newer live write that landed during the copy (those are re-delivered by the post-copy audit replay from `copyStartTime`).
- Audit suppression flows through `recordUpdater` (`audit=false` → primary + indices written, no audit entry).

## Pairing

Coordinated with **harper-pro** (the `isCopyApply` signal + the C2 `version < copyStartTime` gate + the WAL-off durability flush that gates the resume/sequence cursors). This core PR is the write-mode half; the harper-pro PR carries the receive-side gating and durability.

## Review notes

Cross-model reviewed (Codex, 4 rounds — surfaced & fixed: CRDT redelivery double-apply → the C2 gate; LMDB localTime/replay-cursor divergence → RocksDB-gating; async COPY_COMPLETE interleaving → latched copy-frame status on the harper-pro side). No open findings. Unit test (`copyApply.test.js`) covers no-audit-entry, record-stored, and put-if-newer; it skips the no-audit assertion under `HARPER_STORAGE_ENGINE=lmdb` (where copyApply intentionally falls back).

Generated by an LLM (Claude Opus 4.8).