### PR TITLE
fix(blob): mark a retriable source-stream write-abort PENDING (503) not incomplete (500) (harper-pro#481)

### DIFF
--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -70,6 +70,12 @@ const HEADER_SIZE = 8;
 const UNCOMPRESSED_TYPE = 0;
 const DEFLATE_TYPE = 1;
 const ERROR_TYPE = 0xff;
+// A write that aborted on a re-streamable external source (replication receive / origin fetch) stamps the
+// file with this type so a downstream read returns 503 (retry) rather than 500 (confidently incomplete).
+// The bytes are still expected — the receive side holds a blob gap and re-streams on reconnect, which
+// overwrites this stub; a terminal give-up unlinks the file (→ 404). Distinct from ERROR_TYPE (a permanent
+// corrupt/error stub, replicated as-is). See harper-pro#481.
+const PENDING_TYPE = 0xfe;
 const DEFAULT_HEADER = new Uint8Array([0, UNCOMPRESSED_TYPE, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
 const COMPRESS_HEADER = new Uint8Array([0, DEFLATE_TYPE, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
 const UNKNOWN_SIZE = 0xffffffffffff;
@@ -212,6 +218,10 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 					const headerValue = new DataView(rawBytes.buffer, rawBytes.byteOffset, 8).getBigUint64(0);
 					if (Number(headerValue >> 48n) === ERROR_TYPE) {
 						throw new BlobReadError('Error in blob: ' + rawBytes.subarray(HEADER_SIZE), BLOB_CORRUPT_STATUS);
+					}
+					if (Number(headerValue >> 48n) === PENDING_TYPE) {
+						// half-replicated blob whose source stream aborted; the bytes are still expected — retry (harper-pro#481)
+						throw new BlobReadError('Blob pending replication for ' + filePath, BLOB_UNAVAILABLE_STATUS);
 					}
 
 					size = Number(headerValue & 0xffffffffffffn);
@@ -432,6 +442,10 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 								return onError(
 									new BlobReadError('Error in blob: ' + buffer.subarray(HEADER_SIZE, bytesRead), BLOB_CORRUPT_STATUS)
 								);
+							}
+							if (Number(headerValue >> 48n) === PENDING_TYPE) {
+								// half-replicated blob whose source stream aborted; the bytes are still expected — retry (harper-pro#481)
+								return onError(new BlobReadError('Blob pending replication for ' + filePath, BLOB_UNAVAILABLE_STATUS));
 							}
 							size = Number(headerValue & 0xffffffffffffn);
 							if (size < UNKNOWN_SIZE) {
@@ -854,16 +868,38 @@ function writeBlobWithStream(blob: Blob, stream: Readable, storageInfo: StorageI
 			}
 			const fd = (writeStream as any).fd;
 			if (error) {
-				store.unlock(lockKey);
 				if (fd) {
 					close(fd);
 					(writeStream as any).fd = null; // do not close the same fd twice, that is very dangerous because it might represent a new fd
 				}
 				if (storageInfo.deleteOnFailure) {
+					store.unlock(lockKey);
 					unlink(filePath, (error) => {
 						if (error) logger.debug?.('Error while deleting aborted blob file', error);
 					});
+				} else if (idleTimeoutMs > 0 && !(error as { sourceBlobUnavailable?: boolean }).sourceBlobUnavailable) {
+					// The write was fed by a re-streamable replication/origin source — the owning caller armed the
+					// source-idle watchdog (idleTimeoutMs > 0), which only the replication receive path does, never an
+					// app-supplied one-shot stream — and it aborted for a retriable reason: the source stalled or
+					// dropped, NOT a source-reported permanent absence (sourceBlobUnavailable, which the receive loop
+					// sets and then advances past + unlinks). The bytes are still expected: the receiver holds a blob
+					// gap and re-streams on reconnect. Stamp the file PENDING so a downstream read of this
+					// half-replicated blob returns 503 (retry) instead of 500 (confidently incomplete → the peer
+					// advances its resume cursor past it = silent loss, harper-pro#481). Hold the write lock until the
+					// marker is durable so no concurrent read/send observes the bare partial file (lock-free + short =
+					// classified 500 = the very loss this prevents). The re-stream overwrites this stub
+					// (createWriteStream flags 'w'); a terminal give-up on the receive side unlinks it (→ 404). Build
+					// the header directly rather than via createHeader so its compress-type OR can't collide with the
+					// PENDING type bits.
+					const messageBuffer = Buffer.from(error.toString());
+					const header = new Uint8Array(HEADER_SIZE);
+					new DataView(header.buffer).setBigInt64(0, BigInt(messageBuffer.length) | (BigInt(PENDING_TYPE) << 48n));
+					writeFile(filePath, Buffer.concat([header, messageBuffer]), (writeError: Error) => {
+						if (writeError) logger.debug?.('Error writing pending marker to blob file', writeError);
+						store.unlock(lockKey);
+					});
 				} else {
+					store.unlock(lockKey);
 					try {
 						if (statSync(filePath).size === 0) {
 							// if there was an error in the stream, nothing may have been written, so we can write the error message instead
@@ -1510,7 +1546,10 @@ addExtension({
 					// slice size, which legitimately differs from the full on-disk header size).
 					const isSlice = storageInfo.start !== undefined || storageInfo.end !== undefined;
 					const sizeMatchesDescriptor = type === ERROR_TYPE || isSlice || options.size == null || options.size === size;
-					if (size === buffer.length - HEADER_SIZE && sizeMatchesDescriptor) {
+					// A PENDING stub (half-replicated, bytes still expected) must never inline as complete — its
+					// header size is the abort-message length, which can coincide with the body length. Stay uncoded
+					// so the receiver holds the gap and retries rather than replicating the stub (harper-pro#481/#429).
+					if (type !== PENDING_TYPE && size === buffer.length - HEADER_SIZE && sizeMatchesDescriptor) {
 						// the file is there and complete, we can return the encoding
 						return Buffer.concat([pack([options]), buffer]);
 					}
@@ -1728,6 +1767,7 @@ async function isBlobFileComplete(storageInfo: StorageInfo): Promise<boolean> {
 	}
 	const headerValue = new DataView(header.buffer, header.byteOffset, 8).getBigUint64(0);
 	if (Number(headerValue >> 48n) === ERROR_TYPE) return false;
+	if (Number(headerValue >> 48n) === PENDING_TYPE) return false; // half-replicated, bytes still expected (harper-pro#481)
 	// The header size field holds the *uncompressed* content length for both compressed and
 	// uncompressed blobs (writeBlobWithStream stores deflate.bytesWritten, which is the input/
 	// uncompressed byte count). For an uncompressed blob that equals the on-disk body length;

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -861,6 +861,109 @@ describe('Blob test', () => {
 		const result = Buffer.isBuffer(encoded) ? encoded : await encoded;
 		assert(Buffer.isBuffer(result), 'a slice should pack without being rejected as incomplete');
 	});
+
+	// harper-pro#481: a blob write fed by a re-streamable external source (replication receive / origin
+	// fetch) that aborts mid-stream stamps the file with a PENDING_TYPE (0xfe) header. The bytes are
+	// still expected — the receiver holds a blob gap and re-streams on reconnect — so a downstream read
+	// must return 503 (retry), NOT 500 (confidently incomplete), which the peer would treat as permanent
+	// and advance its resume cursor past = silent loss. Distinct from an ERROR_TYPE (0xff) stub, which is
+	// a permanent error replicated as-is.
+	const PENDING_TYPE = 0xfe;
+	// Stamp a disk-backed blob's file with a PENDING stub the way the write-abort path does: an 8-byte
+	// header (type=PENDING_TYPE, size=message length) followed by the abort message. The record descriptor
+	// still records the full size, so descriptor cross-checks would mismatch — the PENDING type must be
+	// what routes the read to 503.
+	function writePendingStub(filePath) {
+		const message = Buffer.from('Blob source stream idle for 120000ms');
+		const stub = Buffer.concat([makeBlobHeader(message.length, PENDING_TYPE), message]);
+		const fd = openSync(filePath, 'r+');
+		try {
+			writeSync(fd, stub, 0, stub.length, 0);
+			ftruncateSync(fd, stub.length);
+		} finally {
+			closeSync(fd);
+		}
+	}
+	it('#481: bytes() rejects a PENDING (half-replicated) blob with 503, not 500', async () => {
+		const { blob, filePath } = await makeDiskBackedBlob();
+		writePendingStub(filePath);
+		await assert.rejects(blob.bytes(), (error) => {
+			assert.equal(error.statusCode, 503, 'a pending blob must read as retryable (503), not corrupt (500)');
+			return true;
+		});
+	});
+	it('#481: stream() rejects a PENDING (half-replicated) blob with 503, not 500', async () => {
+		const { blob, filePath } = await makeDiskBackedBlob();
+		writePendingStub(filePath);
+		await assert.rejects(streamToBuffer(blob.stream()), (error) => {
+			assert.equal(error.statusCode, 503);
+			return true;
+		});
+	});
+	it('#481: isBlobComplete is false for a PENDING blob (repair sweep treats it as incomplete)', async () => {
+		const { blob, filePath } = await makeDiskBackedBlob();
+		writePendingStub(filePath);
+		assert.equal(await isBlobComplete(blob), false);
+	});
+	it('#481: replication-send does not pack a PENDING blob as complete (holds and retries)', async () => {
+		const { blob, filePath } = await makeDiskBackedBlob();
+		writePendingStub(filePath);
+		// Unlike an error stub (replicated as-is), a PENDING stub must not inline: the encode re-reads via
+		// blob.bytes(), which rejects 503, so the sender holds the gap rather than propagating the stub.
+		await assert.rejects(Promise.resolve(encodeBlobsAsBuffers(() => pack({ blob }))), (error) => {
+			assert.equal(error.statusCode, 503);
+			return true;
+		});
+	});
+	it('#481: a source-stream write that aborts leaves a PENDING (503) blob, not a 500 incomplete', async () => {
+		// Drive the real write-abort path: createBlob from a PassThrough armed with blobStreamIdleTimeoutMs
+		// the way the replication receive path arms its source (this is what the abort branch gates on, so an
+		// app-supplied one-shot stream is NOT mis-marked PENDING). Start the save, deliver a partial body, then
+		// destroy the source with an error. writeBlobWithStream's abort branch must stamp the file PENDING
+		// because the bytes are still expected.
+		const store = BlobTest.primaryStore.rootStore;
+		const source = new PassThrough();
+		source.blobStreamIdleTimeoutMs = 60000; // arm the source-idle watchdog (won't fire during the test)
+		const blob = await createBlob(source, { size: 20000 });
+		const saving = decodeFromDatabase(() => saveBlob(blob).saving, store);
+		source.write(randomBytes(4000)); // a partial body lands before the abort
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		source.destroy(new Error('Blob source stream idle for 120000ms'));
+		await assert.rejects(Promise.resolve(saving), 'the aborted save rejects');
+		// the PENDING stub is written asynchronously in the abort callback; wait for the read to flip to 503
+		await waitFor(
+			async () => {
+				try {
+					await blob.bytes();
+					return false;
+				} catch (error) {
+					return error.statusCode === 503;
+				}
+			},
+			{ timeout: 2000, message: 'aborted source write should leave a PENDING (503) blob' }
+		);
+		unlinkSync(getFilePathForBlob(blob));
+	});
+	it('#481: an app-supplied (unarmed) source-stream abort is NOT marked PENDING (gate excludes one-shot streams)', async () => {
+		// Same abort shape, but the source is NOT armed with blobStreamIdleTimeoutMs — an ordinary app write,
+		// not a replication receive. The abort branch must NOT stamp it PENDING: nothing will ever re-stream
+		// those bytes, so a 503 (retry) read would hold forever (the #429 wedge). It stays the prior behavior.
+		const store = BlobTest.primaryStore.rootStore;
+		const source = new PassThrough();
+		const blob = await createBlob(source, { size: 20000 });
+		const saving = decodeFromDatabase(() => saveBlob(blob).saving, store);
+		source.write(randomBytes(4000));
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		source.destroy(new Error('connection reset'));
+		await assert.rejects(Promise.resolve(saving));
+		await new Promise((resolve) => setTimeout(resolve, 50)); // let any async abort-path write land
+		await assert.rejects(blob.bytes(), (error) => {
+			assert.notEqual(error.statusCode, 503, 'an unarmed app-stream abort must not become a retriable 503');
+			return true;
+		});
+		const filePath = getFilePathForBlob(blob);
+		if (existsSync(filePath)) unlinkSync(filePath);
+	});
 	it('#1424: bytes() rejects a file corrupted below the header rather than returning garbage (T3)', async () => {
 		const { blob, filePath } = await makeDiskBackedBlob();
 		// overwrite with fewer than HEADER_SIZE bytes, with byte[1] = DEFLATE_TYPE — the case that


### PR DESCRIPTION
## Problem (harper-pro#481)

A blob write fed by a **re-streamable replication/origin source** that aborts mid-stream (the source stalled — idle watchdog — or the connection dropped) left a short file with a normal header. A downstream read then classified it `BlobReadError('Blob is incomplete', 500)`. The replication receiver treats **500 as permanent**: it advances its resume cursor **past** the record and, with proactive blob backfill (harper-pro#388) unimplemented, the blob is **silently lost**.

In a catch-up (two nodes converging from a complete peer), both sides serve 500 for blobs the other is still pulling, and the cluster **stops converging even after writes stop** — the field symptom on the Akamai v4→v5 stage cluster (5.1.11).

This is the flip side of harper-pro#429: the *same* `'Blob is incomplete'` error wants the *opposite* response depending on whether the bytes are still coming. The on-disk file can't tell them apart (both are just short), so a blanket reclassify would reopen #429's connection wedge.

## Fix

The **write-abort path still holds the abort reason** and knows whether the source was a re-streamable replication/origin feed: the owning caller armed the source-idle watchdog (`idleTimeoutMs > 0`) — which only the replication receive path does, never an app one-shot stream — and the failure is not a source-reported permanent absence (`sourceBlobUnavailable`, which the receive loop already advances past + unlinks).

Such a file is stamped with a new `PENDING_TYPE` (0xfe) header. The read paths return **503** (transient → the receiver holds the gap and re-streams on reconnect) instead of 500. The re-stream overwrites the stub; a terminal give-up unlinks it (→ 404). This resolves the #481/#429 tension without reopening the #429 wedge.

- `bytes()` / `stream()` return `BLOB_UNAVAILABLE_STATUS` (503) for a PENDING stub
- `isBlobFileComplete` returns false (the #388 repair sweep still treats it as incomplete)
- the inline replication-encode path never inlines a PENDING stub as complete (its header size can coincide with the body length) — stays uncoded so the sender holds and retries rather than propagating the stub
- the marker is written **under the still-held blob lock** (unlock moved into the `writeFile` callback, unconditional) so no concurrent read/send observes the bare partial file and classifies 500 in the gap
- gated on the **armed idle watchdog**, not `storageInfo.source`, so an app `put`-from-stream abort is never mis-marked PENDING (which would read 503 forever)
- header built directly (not via `createHeader`) so the compress-type OR can't collide with the PENDING type bits

**Receiver side needs no change** — 503 already routes to hold-and-retry via `isPermanentSourceBlobErrorCode` (only 404/500 are permanent).

## Tests

`unitTests/resources/blob.test.js` (52 passing): PENDING reads → 503 (`bytes()`/`stream()`), `isBlobComplete` false, replication-encode holds, the real armed-source abort → PENDING via `writeBlobWithStream`, and a negative guard (unarmed app-stream abort stays non-503).

## Cross-model review

Codex flagged two issues, both fixed + regression-tested before this PR:
1. **Marker-write race** — was fire-and-forget after `unlock`; now the lock is held until the marker is durable.
2. **Over-broad gate** — was `storageInfo.source != null` (caught app `put`-from-stream → permanent 503 wedge); now `idleTimeoutMs > 0`.

(Gemini leg was unavailable — `agy` timed out.)

## Release

Targets `main`; the BlobReadError statusCode taxonomy it builds on is already on main. Not in the in-flight 5.1.13 — queue for **5.1.14**. Follow-up: harper-pro#388 (repair-sweep peer backfill) as the durable convergence fix; the `findIncompleteBlobRefs` machinery this relies on already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)