### PR TITLE
fix(replication): skip keyed audit-dedup lookup for versions older than txn-log retention

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1999,6 +1999,39 @@ export function makeTable(options) {
 								write.skipped = true;
 								return; // out-of-order write already folded into this record
 							}
+							// The keyed dedup lookups in this block (the up-front check below, and the depth-cap /
+							// fully-superseded `isReDeliveredDuplicate` checks later) read the per-node transaction log
+							// by version. That log has time-based retention — auditRetention purges whole log files — so a
+							// lookup for a version older than the log's oldest retained entry has (essentially always)
+							// been purged. On RocksDB an exactStart miss scans the whole log to end-of-log (~17ms each in
+							// the field, all 100% misses while applying aged hdb_analytics during a system-DB copy,
+							// pegging the worker at ~100% CPU — harper-pro#480). Both of these lookups are already
+							// documented as best-effort-may-miss: a miss at the up-front check falls through to the walk
+							// (the additionalAuditRefs read-your-writes check above is the real duplicate guard, #1137),
+							// and the depth-cap check notes the lookup "can intermittently miss under load" with the
+							// authoritative full-copy record restoring exact convergence (#1148). This guard turns that
+							// tolerated miss into a deliberate skip for pre-retention versions — staying within the
+							// existing contract. (oldestRetainedAuditTime is the first physical/in-order entry's version;
+							// a transaction log appended out of timestamp order could in theory retain a smaller-versioned
+							// entry below it — but the same best-effort contract and full-copy convergence cover that.)
+							// Resolve the oldest retained entry once, for the same log the dedup reads.
+							let oldestRetainedAuditTime: number | undefined;
+							let oldestRetainedAuditTimeResolved = false;
+							const dedupVersionCouldBeRetained = (version: number): boolean => {
+								if (!isRocksDB) return true; // LMDB keeps its exact, unbounded lookup (keyed by local audit time)
+								if (!oldestRetainedAuditTimeResolved) {
+									oldestRetainedAuditTimeResolved = true;
+									// getRange yields ascending by audit-log key, so the first entry is the oldest retained.
+									// Mirror replicationConnection's retention check and the cleanup key basis (localTime ??
+									// version). Fall back to the nominal time-based purge floor when the log is empty/unavailable.
+									for (const entry of auditStore.getRange({ start: 1, log: options?.nodeId })) {
+										oldestRetainedAuditTime = entry.localTime ?? entry.version;
+										break;
+									}
+									oldestRetainedAuditTime ??= Date.now() - auditRetention;
+								}
+								return version >= oldestRetainedAuditTime!;
+							};
 							// Up-front keyed dedup (RocksDB): a re-delivered out-of-order write whose exact
 							// (version, nodeId) is already in the audit log is a duplicate that was already applied — skip
 							// it here instead of paying the O(depth) resequencing walk below only to discard it in the
@@ -2010,7 +2043,7 @@ export function makeTable(options) {
 							// exact unbounded walk). A miss (the keyed lookup can lag a back-to-back re-delivery — #1137)
 							// simply falls through to the walk, so this never changes correctness; the additionalAuditRefs
 							// check above remains the read-your-writes guard.
-							if (isRocksDB) {
+							if (isRocksDB && dedupVersionCouldBeRetained(txnTime)) {
 								const priorAudit = auditStore.get(txnTime, tableId, id, options?.nodeId);
 								if (
 									priorAudit &&
@@ -2070,6 +2103,7 @@ export function makeTable(options) {
 							// applied; drop it rather than re-applying it (double-applying commutative ops) or writing a
 							// duplicate audit-only record. Used by the early-out and the depth-cap block below.
 							const isReDeliveredDuplicate = () => {
+								if (!dedupVersionCouldBeRetained(txnTime)) return false; // pre-retention version — skip the end-of-log scan (best-effort; see above)
 								const duplicate = auditStore.get(txnTime, tableId, id, options?.nodeId);
 								return (
 									duplicate &&

--- a/unitTests/resources/auditDedupRetention.test.js
+++ b/unitTests/resources/auditDedupRetention.test.js
@@ -1,0 +1,126 @@
+require('../testUtils');
+const assert = require('assert');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const { transaction } = require('#src/resources/transaction');
+
+const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
+const DAY = 86400 * 1000;
+
+// harper-pro#480: on the out-of-order apply path, the keyed audit dedup looks up a version in the
+// per-node transaction log. That log has time-based retention, so a lookup for a version older than
+// the log's oldest retained entry can never hit — its entry was purged — and on RocksDB the exactStart
+// miss scans the whole log to end-of-log. The guard skips the lookup for such versions (it is allowed
+// to miss: it falls through to the resequencing walk). These tests assert the keyed lookup is skipped
+// for a pre-retention version, performed for an in-retention version, and that convergence is unchanged.
+describe('Audit dedup retention guard (harper-pro#480)', () => {
+	let Guarded;
+	// Records every `key` (first arg) the keyed dedup / walk looks up, and whether the guard's
+	// oldest-retained probe (getRange start:1) ran. Installed per-test around the apply under test.
+	function spyAuditStore(auditStore) {
+		const getSyncKeys = [];
+		let oldestRetainedProbeCount = 0;
+		const origGetSync = auditStore.getSync.bind(auditStore);
+		const origGetRange = auditStore.getRange.bind(auditStore);
+		auditStore.getSync = function (key, ...rest) {
+			getSyncKeys.push(key);
+			return origGetSync(key, ...rest);
+		};
+		auditStore.getRange = function (options, ...rest) {
+			if (options && options.start === 1) oldestRetainedProbeCount++;
+			return origGetRange(options, ...rest);
+		};
+		return {
+			getSyncKeys,
+			get oldestRetainedProbeCount() {
+				return oldestRetainedProbeCount;
+			},
+			restore() {
+				auditStore.getSync = origGetSync;
+				auditStore.getRange = origGetRange;
+			},
+		};
+	}
+
+	before(async function () {
+		if (isLMDB) return; // guard is RocksDB-only; LMDB keeps its exact unbounded lookup
+		setupTestDBPath();
+		setMainIsWorker(true);
+		Guarded = table({
+			table: 'GuardedDedup',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }, { name: 'count' }],
+			audit: true,
+		});
+	});
+
+	it('skips the keyed dedup lookup for a version older than the oldest retained log entry', async function () {
+		if (isLMDB) return this.skip();
+		const id = 'pre-retention';
+		// Establish an existing, newer record. The oldest retained audit entry is now ~Date.now().
+		const context = {};
+		await transaction(context, () => {
+			Guarded.put(id, { name: 'original' }, context);
+		});
+		const now = Date.now();
+		await Guarded.patch(id, { name: 'newer' }, { timestamp: now + 10 });
+
+		// Apply an out-of-order write whose version predates retention by ~30 days. Its keyed dedup
+		// lookup is a guaranteed miss (its log entry was purged), so the guard must skip it.
+		const oldVersion = now - 30 * DAY;
+		const spy = spyAuditStore(Guarded.auditStore);
+		try {
+			await Guarded.patch(id, { name: 'should-lose', count: 3 }, { timestamp: oldVersion });
+		} finally {
+			spy.restore();
+		}
+
+		// The keyed dedup (auditStore.get → getSync) for the pre-retention version must NOT run...
+		assert(
+			!spy.getSyncKeys.includes(oldVersion),
+			`keyed dedup must be skipped for pre-retention version; got lookups for keys: ${spy.getSyncKeys}`
+		);
+		// ...and the guard must have resolved the oldest retained entry once.
+		assert(spy.oldestRetainedProbeCount >= 1, 'guard should probe the oldest retained audit entry');
+		// ...while the resequencing walk still ran (it looks up the existing chain by its recent
+		// localTime / previousVersion keys — proving we fell through to the walk, not short-circuited it).
+		assert(spy.getSyncKeys.length >= 1, 'resequencing walk should still look up the existing audit chain');
+
+		// Correctness unchanged: a write that predates the record's own initial put is fully superseded by
+		// that newer full put, so the walk correctly drops it — same outcome as without the guard.
+		const record = await Guarded.get(id);
+		assert.equal(record.name, 'newer', 'newer write still wins');
+		assert.equal(record.count, undefined, 'stale pre-creation write is superseded, not folded in');
+	});
+
+	it('performs the keyed dedup lookup for a version within retention', async function () {
+		if (isLMDB) return this.skip();
+		const id = 'in-retention';
+		const context = {};
+		await transaction(context, () => {
+			Guarded.put(id, { name: 'original' }, context);
+		});
+		const now = Date.now();
+		await Guarded.patch(id, { name: 'newer' }, { timestamp: now + 100 });
+
+		// An out-of-order write only ~10ms older than the head is well within retention (newer than the
+		// oldest retained entry), so the keyed dedup lookup must still be performed.
+		const recentOlderVersion = now + 10;
+		const spy = spyAuditStore(Guarded.auditStore);
+		try {
+			await Guarded.patch(id, { name: 'should-lose', count: 7 }, { timestamp: recentOlderVersion });
+		} finally {
+			spy.restore();
+		}
+
+		assert(
+			spy.getSyncKeys.includes(recentOlderVersion),
+			`keyed dedup must run for an in-retention version; got lookups for keys: ${spy.getSyncKeys}`
+		);
+
+		const record = await Guarded.get(id);
+		assert.equal(record.name, 'newer');
+		assert.equal(record.count, 7);
+	});
+});


### PR DESCRIPTION
## Problem

On the out-of-order apply path, `Table.ts` commit does a keyed audit dedup `auditStore.get(txnTime, tableId, id, nodeId)` via `RocksTransactionLogStore.getSync`. A cache miss in RocksDB's `exactStart` mode scans the per-node transaction log to end-of-log before returning empty. Since log retention is **time-based**, a lookup for a version older than the oldest retained entry is a **guaranteed miss** that performs a full scan (~17ms per call).

Measured live on 5.1.12 / rocksdb-js 2.2.0: 1,132 dedup calls in 23s, 100% miss, average ~17ms each (~83% of a core), all looking up versions ~21.5 days old. This is the root cause of the CPU storm in harper-pro#480 during `hdb_analytics` base-copy.

## Fix

`dedupVersionCouldBeRetained(version)` — lazily resolves the oldest retained entry for the same log (`getRange({start:1, log: nodeId})`; falls back to `Date.now() - auditRetention` when log is empty), mirroring the retention check already used in `replicationConnection`. Skips the keyed lookup when `version < oldestRetained`.

Gates both keyed-dedup sites:
- Up-front check in `commit()` before calling `auditStore.get()`
- `isReDeliveredDuplicate()` guard

The `previousVersion` audit-chain walk and all LMDB paths are untouched (LMDB's exact lookup is O(log n), not a log scan).

### Ordering note (from cross-model review)

The transaction log is *append*-ordered; `findPositionByTimestamp` builds a **monotonic** index (lower-bound on write timestamps), meaning an entry appended out of timestamp order could sit below `oldestRetained`. However, both guarded lookups are already documented best-effort / may-miss:
- The up-front lookup falls through to the resequencing walk + `additionalAuditRefs` read-your-writes guard on miss.
- `isReDeliveredDuplicate` is documented as "can intermittently miss under load" — the authoritative full-copy record restores convergence.

The guard converts a *tolerated* miss into a *deliberate* skip for pre-retention versions, fully within the existing contract.

## Test

`unitTests/resources/auditDedupRetention.test.js` — exercises a real RocksDB audited table:
- Asserts keyed lookup is **skipped** for a pre-retention version (spies `getSync`/`getRange`) while the resequencing walk still runs and converges.
- Asserts keyed lookup is **performed** for an in-retention version.
- Verified regression-sensitive: fails without the guard.

Existing `transaction`, `auditLog`, `crdt`, and `replayLogs` suites pass. Build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — reviewed by Kris, Codex

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>