### PR TITLE
fix: fail closed when allow* hooks throw or reject (#1422 gap 1)

### DIFF
--- a/integrationTests/fixtures/allowread-fail-closed/config.yaml
+++ b/integrationTests/fixtures/allowread-fail-closed/config.yaml
@@ -1,0 +1,5 @@
+graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/fixtures/allowread-fail-closed/resources.js
+++ b/integrationTests/fixtures/allowread-fail-closed/resources.js
@@ -1,0 +1,63 @@
+// Fail-closed enforcement when an allow* hook throws/rejects (#1422 gap 1).
+//
+// allowRead is a *grant* hook layered over the default RBAC: it can widen access, and the
+// built-in implementation defers to role/table permissions. The security property under test
+// is that a hook which throws (sync) or rejects (async) must FAIL CLOSED — the request is
+// denied rather than proceeding as if authorization was granted.
+
+function isSuper(user) {
+	return !!user?.role?.permission?.super_user;
+}
+
+// Grants read to any authenticated user — the happy path that must keep working after the
+// fail-closed wrapping.
+export class Allowed extends tables.Allowed {
+	allowRead() {
+		return true;
+	}
+	allowCreate(user) {
+		return isSuper(user);
+	}
+	allowUpdate(user) {
+		return isSuper(user);
+	}
+	allowDelete(user) {
+		return isSuper(user);
+	}
+}
+
+// allowRead throws synchronously for non-super users. Before the fix the exception was
+// swallowed upstream and the request proceeded (fail open); it must now fail closed.
+export class Throws extends tables.Throws {
+	allowRead(user) {
+		if (isSuper(user)) return true;
+		throw new Error('allowRead intentionally throws (#1422 gap 1)');
+	}
+	allowCreate(user) {
+		return isSuper(user);
+	}
+	allowUpdate(user) {
+		return isSuper(user);
+	}
+	allowDelete(user) {
+		return isSuper(user);
+	}
+}
+
+// allowRead rejects asynchronously for non-super users — exercises the async rejection
+// handler on the transactional path, which must also fail closed.
+export class ThrowsAsync extends tables.ThrowsAsync {
+	async allowRead(user) {
+		if (isSuper(user)) return true;
+		throw new Error('async allowRead intentionally rejects (#1422 gap 1)');
+	}
+	allowCreate(user) {
+		return isSuper(user);
+	}
+	allowUpdate(user) {
+		return isSuper(user);
+	}
+	allowDelete(user) {
+		return isSuper(user);
+	}
+}

--- a/integrationTests/fixtures/allowread-fail-closed/schema.graphql
+++ b/integrationTests/fixtures/allowread-fail-closed/schema.graphql
@@ -1,0 +1,23 @@
+# Fail-closed enforcement when an allow* hook throws/rejects (#1422 gap 1).
+#
+# allowRead is a *grant* hook layered over RBAC. If it throws (sync) or rejects (async),
+# the request must fail closed (deny) rather than fall through as authorized.
+
+# allowRead grants read to any authenticated user — the happy path that must keep working.
+type Allowed @table @export {
+	id: ID @primaryKey
+	value: String
+}
+
+# allowRead throws synchronously for non-super users — must fail closed (deny), not grant.
+type Throws @table @export {
+	id: ID @primaryKey
+	value: String
+}
+
+# allowRead rejects asynchronously for non-super users — exercises the async rejection
+# handler; must fail closed (deny), not grant.
+type ThrowsAsync @table @export {
+	id: ID @primaryKey
+	value: String
+}

--- a/integrationTests/resources/allowread-fail-closed.test.ts
+++ b/integrationTests/resources/allowread-fail-closed.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Fail-closed enforcement when an allow* hook throws/rejects (HarperFast/harper#1422, gap 1).
+ *
+ * `allowRead` (and its allowCreate/allowUpdate/allowDelete siblings) is a grant hook layered
+ * over RBAC. Historically a hook that threw synchronously had its exception swallowed upstream
+ * and the request proceeded as authorized (fail open); an async hook that rejected had no
+ * rejection handler on the transactional path and behaved the same way.
+ *
+ * These tests assert that a throwing/rejecting hook now fails closed — denied, not granted —
+ * on both the single-record point-read and the collection-scan path, while a hook that grants
+ * (and the super_user bypass) keep working.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert/strict';
+import { resolve } from 'node:path';
+
+import request from 'supertest';
+
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
+import { createApiClient, createHeaders } from '../apiTests/utils/client.mjs';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, '../fixtures/allowread-fail-closed');
+const skipSuite = process.env.HARPER_RUNTIME === 'bun' || process.platform === 'win32';
+
+const ALICE = { username: 'failclosed_alice', password: 'Alice-pw-1422!' };
+const ROLE = 'failclosed_role';
+
+const IDS = ['row-00', 'row-01', 'row-02'];
+const TABLES = ['Allowed', 'Throws', 'ThrowsAsync'];
+
+suite('Fail-closed when allow* throws/rejects (#1422 gap 1)', { skip: skipSuite }, (ctx: ContextWithHarper) => {
+	let client: ReturnType<typeof createApiClient>;
+	let restURL = '';
+	let aliceHeaders: Record<string, string>;
+
+	before(async () => {
+		// AUTHORIZELOCAL=false so headerless loopback requests are not auto-authorized as super_user,
+		// and Alice's Basic-auth goes through real authentication.
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: {}, env: { AUTHENTICATION_AUTHORIZELOCAL: 'false' } });
+		client = createApiClient(ctx.harper);
+		restURL = ctx.harper.httpURL;
+		aliceHeaders = createHeaders(ALICE.username, ALICE.password);
+
+		// Wait for the routes to be ready.
+		const deadline = Date.now() + 30_000;
+		while (Date.now() < deadline) {
+			try {
+				const probe = await client.reqRest('/Allowed/').timeout(3_000);
+				if (probe.status !== 404) break;
+			} catch {
+				/* not ready */
+			}
+			await new Promise((r) => setTimeout(r, 200));
+		}
+
+		await client
+			.req()
+			.send({
+				operation: 'add_role',
+				role: ROLE,
+				permission: {
+					super_user: false,
+					data: {
+						tables: Object.fromEntries(
+							TABLES.map((t) => [
+								t,
+								{ read: true, insert: false, update: false, delete: false, attribute_permissions: [] },
+							])
+						),
+					},
+				},
+			})
+			.expect(200);
+
+		await client
+			.req()
+			.send({ operation: 'add_user', role: ROLE, username: ALICE.username, password: ALICE.password, active: true })
+			.expect(200);
+
+		const records = IDS.map((id, i) => ({ id, value: `v-${i}` }));
+		for (const table of TABLES) {
+			const resp = await client.req().send({ operation: 'insert', schema: 'data', table, records });
+			ok(resp.status === 200, `Seed ${table} failed: ${resp.status} ${resp.text}`);
+		}
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	test('HAPPY PATH: a granting allowRead still authorizes — point-read and collection both 200', async () => {
+		const pointRead = await request(restURL).get(`/Allowed/${IDS[0]}`).set(aliceHeaders);
+		strictEqual(pointRead.status, 200, `granting allowRead must allow point-read: ${pointRead.status} ${pointRead.text}`);
+
+		const collection = await request(restURL).get('/Allowed/?id=ge=row-00&sort(id)').set(aliceHeaders);
+		strictEqual(collection.status, 200, `granting allowRead must allow collection: ${collection.status} ${collection.text}`);
+		const rows: any[] = Array.isArray(collection.body) ? collection.body : [];
+		strictEqual(rows.length, IDS.length, `granting allowRead should return all ${IDS.length} rows, saw ${rows.length}`);
+	});
+
+	test('SYNC THROW: allowRead that throws fails closed — point-read denied, not granted', async () => {
+		const resp = await request(restURL).get(`/Throws/${IDS[0]}`).set(aliceHeaders);
+		ok(
+			[401, 403].includes(resp.status),
+			`thrown allowRead must fail closed on point-read, got ${resp.status} ${resp.text}`
+		);
+	});
+
+	test('SYNC THROW: allowRead that throws fails closed — collection scan denied or empty', async () => {
+		const resp = await request(restURL).get('/Throws/?id=ge=row-00&sort(id)').set(aliceHeaders);
+		if (resp.status === 200) {
+			const rows: any[] = Array.isArray(resp.body) ? resp.body : [];
+			strictEqual(rows.length, 0, `thrown allowRead leaked ${rows.length} rows on collection scan`);
+		} else {
+			ok(
+				[401, 403].includes(resp.status),
+				`thrown allowRead must fail closed on collection scan, got ${resp.status} ${resp.text}`
+			);
+		}
+	});
+
+	test('ASYNC REJECT: allowRead that rejects fails closed — point-read denied, not granted', async () => {
+		const resp = await request(restURL).get(`/ThrowsAsync/${IDS[0]}`).set(aliceHeaders);
+		ok(
+			[401, 403].includes(resp.status),
+			`rejected async allowRead must fail closed on point-read, got ${resp.status} ${resp.text}`
+		);
+	});
+
+	test('ASYNC REJECT: allowRead that rejects fails closed — collection scan denied or empty', async () => {
+		const resp = await request(restURL).get('/ThrowsAsync/?id=ge=row-00&sort(id)').set(aliceHeaders);
+		if (resp.status === 200) {
+			const rows: any[] = Array.isArray(resp.body) ? resp.body : [];
+			strictEqual(rows.length, 0, `rejected async allowRead leaked ${rows.length} rows on collection scan`);
+		} else {
+			ok(
+				[401, 403].includes(resp.status),
+				`rejected async allowRead must fail closed on collection scan, got ${resp.status} ${resp.text}`
+			);
+		}
+	});
+
+	test('SUPER USER: bypasses the throwing hook — reads every row', async () => {
+		const resp = await client.reqRest('/Throws/?id=ge=row-00&sort(id)');
+		strictEqual(resp.status, 200, `super user collection GET failed: ${resp.status} ${resp.text}`);
+		const rows: any[] = Array.isArray(resp.body) ? resp.body : [];
+		strictEqual(rows.length, IDS.length, `super user should see all ${IDS.length} rows, saw ${rows.length}`);
+	});
+});

--- a/integrationTests/resources/allowread-fail-closed.test.ts
+++ b/integrationTests/resources/allowread-fail-closed.test.ts
@@ -91,10 +91,18 @@ suite('Fail-closed when allow* throws/rejects (#1422 gap 1)', { skip: skipSuite 
 
 	test('HAPPY PATH: a granting allowRead still authorizes — point-read and collection both 200', async () => {
 		const pointRead = await request(restURL).get(`/Allowed/${IDS[0]}`).set(aliceHeaders);
-		strictEqual(pointRead.status, 200, `granting allowRead must allow point-read: ${pointRead.status} ${pointRead.text}`);
+		strictEqual(
+			pointRead.status,
+			200,
+			`granting allowRead must allow point-read: ${pointRead.status} ${pointRead.text}`
+		);
 
 		const collection = await request(restURL).get('/Allowed/?id=ge=row-00&sort(id)').set(aliceHeaders);
-		strictEqual(collection.status, 200, `granting allowRead must allow collection: ${collection.status} ${collection.text}`);
+		strictEqual(
+			collection.status,
+			200,
+			`granting allowRead must allow collection: ${collection.status} ${collection.text}`
+		);
 		const rows: any[] = Array.isArray(collection.body) ? collection.body : [];
 		strictEqual(rows.length, IDS.length, `granting allowRead should return all ${IDS.length} rows, saw ${rows.length}`);
 	});

--- a/resources/Resource.ts
+++ b/resources/Resource.ts
@@ -697,26 +697,38 @@ function transactional(
 			if (checkPermission) {
 				if (loadAsInstance !== false) {
 					// do permission checks, with allow methods
-					const allowed =
-						options.type === 'read'
-							? resource.allowRead(context.user, query, context)
-							: options.type === 'update'
-								? resource.doesExist?.() === false
-									? resource.allowCreate(context.user, data, context)
-									: resource.allowUpdate(context.user, data, context)
-								: options.type === 'create'
-									? resource.allowCreate(context.user, data, context)
-									: resource.allowDelete(context.user, query, context);
+					let allowed;
+					try {
+						allowed =
+							options.type === 'read'
+								? resource.allowRead(context.user, query, context)
+								: options.type === 'update'
+									? resource.doesExist?.() === false
+										? resource.allowCreate(context.user, data, context)
+										: resource.allowUpdate(context.user, data, context)
+									: options.type === 'create'
+										? resource.allowCreate(context.user, data, context)
+										: resource.allowDelete(context.user, query, context);
+					} catch (_allowError) {
+						// allow* threw — fail closed rather than letting the request proceed
+						throw new AccessViolation(context.user);
+					}
 					if ((allowed as any)?.then) {
-						return (allowed as any).then((allowed) => {
-							query.checkPermission = false;
-							if (!allowed) {
+						return (allowed as any).then(
+							(allowed) => {
+								query.checkPermission = false;
+								if (!allowed) {
+									throw new AccessViolation(context.user);
+								}
+								return when(data, (data) => {
+									return action(resource, query, context, data);
+								});
+							},
+							() => {
+								// async allow* rejected — fail closed
 								throw new AccessViolation(context.user);
 							}
-							return when(data, (data) => {
-								return action(resource, query, context, data);
-							});
-						});
+						);
 					}
 					query.checkPermission = false;
 					if (!allowed) {

--- a/resources/Resource.ts
+++ b/resources/Resource.ts
@@ -709,7 +709,7 @@ function transactional(
 									: options.type === 'create'
 										? resource.allowCreate(context.user, data, context)
 										: resource.allowDelete(context.user, query, context);
-					} catch (_allowError) {
+					} catch {
 						// allow* threw — fail closed rather than letting the request proceed
 						throw new AccessViolation(context.user);
 					}

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1209,7 +1209,12 @@ export function makeTable(options) {
 				let allowed = true;
 				if ((target as any)?.checkPermission) {
 					// requesting authorization verification
-					allowed = this.allowRead(context.user, target, context);
+					try {
+						allowed = this.allowRead(context.user, target, context);
+					} catch (_allowError) {
+						// allow* threw — fail closed rather than letting the request proceed
+						throw new AccessViolation(context.user);
+					}
 				}
 				return promiseNormalize(
 					when(
@@ -2570,7 +2575,13 @@ export function makeTable(options) {
 			if (target.parseError) throw target.parseError; // if there was a parse error, we can throw it now
 			if (target.checkPermission) {
 				// requesting authorization verification
-				const allowed = this.allowRead((context as any).user, target, context);
+				let allowed;
+				try {
+					allowed = this.allowRead((context as any).user, target, context);
+				} catch (_allowError) {
+					// allow* threw — fail closed rather than letting the request proceed
+					throw new AccessViolation((context as any).user);
+				}
 				if (!allowed) {
 					throw new AccessViolation((context as any).user);
 				}

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1211,7 +1211,7 @@ export function makeTable(options) {
 					// requesting authorization verification
 					try {
 						allowed = this.allowRead(context.user, target, context);
-					} catch (_allowError) {
+					} catch {
 						// allow* threw — fail closed rather than letting the request proceed
 						throw new AccessViolation(context.user);
 					}
@@ -2578,7 +2578,7 @@ export function makeTable(options) {
 				let allowed;
 				try {
 					allowed = this.allowRead((context as any).user, target, context);
-				} catch (_allowError) {
+				} catch {
 					// allow* threw — fail closed rather than letting the request proceed
 					throw new AccessViolation((context as any).user);
 				}


### PR DESCRIPTION
## Summary

Closes **#1422 gap 1** (the fail-open-on-throw bug). Per Kris's design clarification, `allowRead` and its `allow*` siblings are **grant** hooks layered over RBAC — they widen access; they are not a per-record *restriction* mechanism, and default RBAC has no per-record granularity. This PR therefore implements **only** the fail-closed hardening and **drops the former gap 2** (per-record `allowRead` enforcement on collection scans), which was never an advertised capability.

## What changed

An `allow*` hook that **threw** synchronously had its exception swallowed upstream, leaving the request to proceed (fail **open**); an async hook that **rejected** had no rejection handler on the transactional path and behaved the same way. Every `allow*` invocation is now wrapped so any thrown/rejected hook throws `AccessViolation` (fail **closed**).

Call sites hardened:
- **`resources/Resource.ts`** — `authorizeActionOnResource` (primary REST + operation paths): `try/catch` around the sync compute + a rejection handler on the async `.then(...)`.
- **`resources/Table.ts`** — the `loadAsInstance === false` point-read path and the `search()` collection/subscription authorization path.

No `rowLevelAuthRequired` marker, no `enforceRowLevelAuth`, no `#filterAuthorizedRows` — the gap-2 machinery is gone. Default (non-overridden) tables are unaffected.

## Testing

`integrationTests/resources/allowread-fail-closed.test.ts` (+ fixture): a throwing (sync) and a rejecting (async) `allowRead` **fail closed** on both the point-read and the collection-scan path; a granting `allowRead` and the `super_user` bypass keep working. **6/6 pass** locally.

`tsc --noEmit` clean.

## Scope notes
- Per-record `allowRead` on **subscriptions** (was #1419 / PR #1524) is likewise dropped — closed separately.
- Live-subscription **revocation** on permission loss is the real subscription-security concern and is tracked by **#1414** (table-level periodic re-auth, not per-record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)