### PR TITLE
feat(audit): table-reload marker type for copyApply system-DB coverage

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -3209,7 +3209,9 @@ export function makeTable(options) {
 							// we only send the full message, this are individual messages that can be sent out of order
 							// TODO: Do we want to have a limit to how far out-of-order we are willing to send?
 							value = auditRecord.getValue?.(primaryStore, getFullRecord);
-						} else if (type !== 'end_txn') {
+						} else if (type !== 'end_txn' && type !== 'reload') {
+							// 'reload' is a whole-table marker with a null id and no record (harper-pro#489); pass it
+							// through verbatim so subscribers re-read the table, skipping the per-record lookup below.
 							// these are events that indicate that the primary record has changed. I believe we always want to simply
 							// send the latest value. Note that it is fine to synchronously access these records, they should have just
 							// been written, so are fresh in memory.
@@ -3569,6 +3571,41 @@ export function makeTable(options) {
 			// because transaction log entries can be deleted at any point, we must save the blobs in the record, there is no cleanup of them
 			write.beforeIntermediate = preCommitBlobsForRecordBefore(write, message, undefined, true);
 			transaction.addWrite(write);
+		}
+		/**
+		 * Write a single table-reload marker for this table (harper-pro#489): a LOCAL_ONLY audit entry of
+		 * type 'reload' with no record, committed in its own transaction. Subscribers driven off the audit
+		 * stream — hdb_nodes peer discovery and hdb_certificate CA install — treat it as "this table was
+		 * bulk-reloaded, re-read it". It is needed after a copyApply base copy, whose per-row snapshot rows
+		 * carry no audit entry, so the per-row events those subscribers rely on never fire. The marker is
+		 * never replicated (its LOCAL_ONLY bit makes the send path skip it without decoding the
+		 * peers-may-not-know type), and a lost marker self-heals on restart because each subscriber re-scans
+		 * the table when it (re)subscribes.
+		 */
+		static writeReloadMarker(context?: any) {
+			return transaction(context ?? {}, (txn: any) => {
+				// Bind the fresh transaction to this table's database (claims db + timestamp) exactly as the
+				// instance write paths do; a bare transaction() has no db and would fault in save().
+				const tableTxn = txnForContext({ transaction: txn } as any);
+				tableTxn.addWrite({
+					key: null,
+					store: primaryStore,
+					commit: (txnTime: number, _existingEntry: any, _retry: any, transaction: any) => {
+						updateRecord(
+							null, // recordId: null — a whole-table signal, not a per-row change
+							undefined, // no record to store: this writes the audit entry only
+							undefined,
+							txnTime,
+							0,
+							true, // audit: emit the marker to the transaction log
+							{ nodeId: getThisNodeId(auditStore) ?? 0, transaction, localOnly: true, tableToTrack: null },
+							'reload',
+							false,
+							undefined
+						);
+					},
+				});
+			});
 		}
 		// #section: validation
 		validate(record: any, patch?: boolean) {

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -291,6 +291,12 @@ const INVALIDATE = 4;
 const PATCH = 5;
 const RELOCATE = 6;
 const STRUCTURES = 7;
+// Whole-table "reload" marker: a control entry (no record) signalling that a table was bulk-reloaded
+// and subscribers should re-read it. Used after a copyApply base copy, whose per-row snapshot writes
+// carry no audit entry (harper-pro#489). The entry type lives in the low nibble of the action byte
+// (decoded via `action & 0xf`); 1–7 are the record actions above, 8 is reload, leaving 9–15 free for
+// future actions. Markers are always written LOCAL_ONLY so an unknown type never reaches a peer.
+const RELOAD = 8;
 export const ACTION_32_BIT = 14;
 export const ACTION_64_BIT = 15;
 /** Used to indicate we have received a remote local time update */
@@ -326,6 +332,8 @@ const EVENT_TYPES = {
 	[RELOCATE]: 'relocate',
 	structures: STRUCTURES,
 	[STRUCTURES]: 'structures',
+	reload: RELOAD,
+	[RELOAD]: 'reload',
 	remoteSequenceUpdate: REMOTE_SEQUENCE_UPDATE,
 	[REMOTE_SEQUENCE_UPDATE]: 'remoteSequenceUpdate',
 };
@@ -532,7 +540,10 @@ export function readAuditEntry(buffer: Uint8Array, start = 0, end = undefined): 
 		const usernameEnd = (decoder.position += length);
 		let value: any;
 		return {
-			type: EVENT_TYPES[action & 7],
+			// The entry type is the low nibble of the action byte (1–7 record actions, 8 reload, 9–15
+			// reserved); the flag bits (HAS_RECORD, HAS_PARTIAL_RECORD, …) sit above it. `& 0xf` is
+			// identical to the historical `& 7` for every pre-reload entry (bit 3 was always clear).
+			type: EVENT_TYPES[action & 0xf],
 			tableId,
 			nodeId,
 			get recordId() {

--- a/resources/transactionBroadcast.ts
+++ b/resources/transactionBroadcast.ts
@@ -233,6 +233,24 @@ function notifyFromTransactionData(subscriptions, auditLogIterable?, allowYield 
 						} else matchingKey = null;
 					} while (true);
 				}
+			} else if (auditRecord.type === 'reload') {
+				// Whole-table reload marker (harper-pro#489): a copyApply base copy back-filled this table's
+				// rows as snapshots with no per-row audit entries, so deliver one signal to EVERY subscriber on
+				// the table (regardless of key — there is no recordId to walk the key hierarchy) so each re-reads
+				// the bulk-reloaded table. hdb_nodes peer discovery and hdb_certificate CA install rely on this.
+				const tableSubscriptions = subscriptions[auditRecord.tableId];
+				if (tableSubscriptions) {
+					for (const keySubscriptions of tableSubscriptions.values()) {
+						for (const subscription of keySubscriptions) {
+							if (subscription.startTime >= timestamp) continue;
+							try {
+								subscription.listener(null, auditRecord, timestamp, false);
+							} catch (error) {
+								warn(error);
+							}
+						}
+					}
+				}
 			}
 			if (allowYield && ++processed >= NOTIFY_BATCH_SIZE) {
 				// Yield the event loop. Save in-progress txn state so the next batch can resume.

--- a/unitTests/resources/reloadMarker.test.js
+++ b/unitTests/resources/reloadMarker.test.js
@@ -1,0 +1,78 @@
+const assert = require('assert');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const { LOCAL_ONLY } = require('#src/resources/auditStore');
+const { setTimeout: delay } = require('node:timers/promises');
+require('#src/server/serverHelpers/serverUtilities');
+
+// A table-reload marker is a whole-table signal (harper-pro#489): one LOCAL_ONLY audit entry of type
+// 'reload' with no record, delivered to every subscriber on the table so they re-read it. It exists so
+// copyApply (which back-fills base-copy rows as snapshots with no per-row audit entries) can cover the
+// system DB, whose subscribers (hdb_nodes peer discovery, hdb_certificate CA install) drive off the
+// audit `aftercommit` stream.
+describe('table-reload marker (harper-pro#489)', () => {
+	before(function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+	});
+
+	async function waitFor(predicate, message, timeout = 5000) {
+		const start = Date.now();
+		while (Date.now() - start < timeout) {
+			if (await predicate()) return;
+			await delay(20);
+		}
+		throw new Error('waitFor timed out: ' + message);
+	}
+
+	it('delivers a reload event to every subscriber on the table', async function () {
+		const ReloadTable = table({
+			table: 'ReloadMarkerDeliver',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+		});
+		// Two subscribers at different keys: the reload marker has no recordId, so BOTH must be notified.
+		const rootEvents = [];
+		const keyEvents = [];
+		const rootSub = await ReloadTable.subscribe({});
+		rootSub.on('data', (event) => rootEvents.push(event));
+		const keySub = await ReloadTable.subscribe('some-key');
+		keySub.on('data', (event) => keyEvents.push(event));
+
+		await ReloadTable.writeReloadMarker();
+
+		await waitFor(() => rootEvents.some((e) => e.type === 'reload'), 'root subscriber receives reload');
+		await waitFor(() => keyEvents.some((e) => e.type === 'reload'), 'keyed subscriber receives reload');
+
+		const reload = rootEvents.find((e) => e.type === 'reload');
+		assert.equal(reload.value, undefined, 'reload carries no record value');
+		assert.ok(reload.id == null, 'reload has no record id (whole-table signal)');
+	});
+
+	it('persists the marker as a local-only audit entry that never replicates', async function () {
+		const ReloadTable = table({
+			table: 'ReloadMarkerAudit',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+		});
+		// touch the audit stream first so the table has an audit store wired up
+		await ReloadTable.put({ id: 1, name: 'row' });
+		await ReloadTable.writeReloadMarker();
+
+		// The txn-log store's empty getRange positions at the tail (for live subscription), so scan from an
+		// explicit numeric start to read the existing entries.
+		let marker;
+		for (const entry of ReloadTable.auditStore.getRange({ start: 1 })) {
+			if (entry.type === 'reload') {
+				marker = entry;
+				break;
+			}
+		}
+		assert.ok(marker, 'a reload audit entry was written');
+		// LOCAL_ONLY makes the replication send path skip it by a bitmask test (no decode of an unknown
+		// type on a peer): the marker is a local signal only.
+		assert.ok(marker.extendedType & LOCAL_ONLY, 'reload marker is LOCAL_ONLY (never forwarded to peers)');
+		assert.ok(marker.recordId == null, 'reload marker has a null recordId');
+		// the regular row keeps its own audit entry; the marker did not disturb it
+		assert.ok((await ReloadTable.getHistoryOfRecord(1)).length >= 1, 'the real row still has its audit entry');
+	});
+});


### PR DESCRIPTION
## Summary
Adds a `reload` audit entry type — a `LOCAL_ONLY`, record-less control entry that signals a whole table was bulk-reloaded so its subscribers re-read it.

- `auditStore.ts`: new `RELOAD = 8` type; the entry type is now decoded from the **low nibble** of the action byte (`action & 0xf`) instead of `action & 7`, widening the type space from 7 to 15. Identical to the old mask for every existing entry (bit 3 was always clear); flag bits (`HAS_RECORD`, …) sit above the nibble.
- `Table.writeReloadMarker()`: emits one marker in its own transaction (id `null`, no record → audit-only; `localOnly: true`).
- `transactionBroadcast.ts`: on a `reload` entry, notifies **every** subscriber on the table (no recordId hierarchy walk).
- `Table.subscribe` listener: passes `reload` through without the per-record lookup.

## Purpose
Lets harper-pro extend copyApply to the system DB (harper-pro#489). copyApply's audit-less snapshot rows otherwise suppress the `hdb_nodes` (peer discovery) and `hdb_certificate` (CA install) events that drive cluster formation; a single reload marker re-drives those subscribers after the copy.

## Where to look
- **`action & 0xf` widening** (`auditStore.ts` readAuditEntry) — the one hot-path decode change. `readAuditEntry` is the sole action-byte decoder; harper-pro reuses it.
- **`writeReloadMarker`** binds its standalone transaction to the table's db via `txnForContext` (a bare `transaction()` has no db and faults in `save()`).

## Tests
`unitTests/resources/reloadMarker.test.js` — delivery to multiple subscribers + the persisted entry is `LOCAL_ONLY` with a null recordId. Existing copyApply/auditLog/crud/recordEncoder suites pass unchanged.

Generated by an LLM (Claude Opus 4.8).
