### PR TITLE
fix(blob): progress-gate the source-idle watchdog so a stalled paused receive recovers

### DIFF
--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -771,8 +771,10 @@ export function saveBlob(blob: FileBackedBlob, deleteOnFailure = false) {
 // on the source stream (the replication receive path does this on its PassThrough). A process-wide
 // HARPER_BLOB_STREAM_IDLE_TIMEOUT_MS env var, when set, overrides the per-stream value for every write
 // (ops escape hatch / kill switch — set 0 to force-disable). Read at call time so tests and operators
-// can change it without a restart. The timer re-arms while the source is paused (pipeline backpressure,
-// not a real stall) so a slow writeStream never trips a false destroy.
+// can change it without a restart. While the source is paused (pipeline backpressure) the timer re-arms
+// only if the destination is still draining (writeStream.bytesWritten advancing) so a slow writeStream
+// never trips a false destroy — but a pause with zero downstream progress for the whole interval is a
+// genuine stall the 'data' re-arm can never clear, so it is destroyed.
 // Largest delay setTimeout accepts; a larger value (or Infinity/NaN) is silently coerced to 1ms, which
 // would fire the watchdog almost immediately and destroy a healthy stream — so clamp/reject instead.
 const MAX_SET_TIMEOUT_MS = 2147483647; // 2^31 - 1
@@ -787,6 +789,17 @@ function getBlobStreamIdleTimeoutMs(stream: Readable): number {
 	// collapse to 1ms and instantly destroy the source.
 	if (!Number.isFinite(raw) || raw <= 0) return 0;
 	return Math.min(raw, MAX_SET_TIMEOUT_MS);
+}
+
+// Decision for the source-idle watchdog on timer expiry. A non-paused expiry is a true source idle (no
+// data, no end, no error) and is always destroyed. While the source is paused (pipeline backpressure) it
+// is only a real wedge when the destination made zero progress over the interval: a paused source whose
+// writeStream is still draining (bytesWritten advanced since the last arm) is a slow-but-live write that
+// must be left alone. Without the progress check a genuinely stalled-but-paused receive (the disk-write
+// pipeline that never drains, leaving the replication socket paused on backpressure forever) re-arms
+// indefinitely and never recovers — the 19h prerender blob-replication wedge.
+export function shouldDestroyIdleBlobSource(paused: boolean, bytesWritten: number, lastProgressBytes: number): boolean {
+	return !(paused && bytesWritten > lastProgressBytes);
 }
 
 function writeBlobWithStream(blob: Blob, stream: Readable, storageInfo: StorageInfo): Blob {
@@ -806,16 +819,21 @@ function writeBlobWithStream(blob: Blob, stream: Readable, storageInfo: StorageI
 		}
 		// Source-idle watchdog: destroys the source if no 'data' arrives for the threshold so pipeline
 		// rejects cleanly. Off unless the owning caller armed this source (or the env override is set);
-		// see getBlobStreamIdleTimeoutMs. On expiry, re-arm if the stream is paused (pipeline backpressure,
-		// not a real stall) so a slow writeStream doesn't trip a false destroy.
+		// see getBlobStreamIdleTimeoutMs. On expiry while the stream is paused (pipeline backpressure),
+		// re-arm only if the destination is still draining — bytesWritten advancing since the last arm
+		// means a slow-but-live writeStream, not a wedge. A pause with zero downstream progress for the
+		// whole interval is a genuine stall (disk hang / stuck pipeline) the 'data' re-arm can never
+		// clear — the receive socket stays paused on backpressure that never lifts — so destroy it.
 		let idleTimer: NodeJS.Timeout | undefined;
 		let armIdleTimer: (() => void) | undefined;
+		let lastProgressBytes = 0;
 		const idleTimeoutMs = getBlobStreamIdleTimeoutMs(stream);
 		if (idleTimeoutMs > 0) {
 			armIdleTimer = () => {
 				if (idleTimer) clearTimeout(idleTimer);
+				lastProgressBytes = writeStream.bytesWritten;
 				idleTimer = setTimeout(() => {
-					if (stream.isPaused()) {
+					if (!shouldDestroyIdleBlobSource(stream.isPaused(), writeStream.bytesWritten, lastProgressBytes)) {
 						armIdleTimer?.();
 						return;
 					}
@@ -823,6 +841,10 @@ function writeBlobWithStream(blob: Blob, stream: Readable, storageInfo: StorageI
 				}, idleTimeoutMs).unref();
 			};
 			stream.on('data', armIdleTimer);
+			// Re-arm on 'resume' too: when backpressure clears, the stream flips to flowing before the
+			// next 'data' fires, so an expiry landing in that window would see isPaused()===false and
+			// destroy a stream that just resumed — give it a fresh window instead.
+			stream.on('resume', armIdleTimer);
 			armIdleTimer();
 		}
 		let compressedStream: any;
@@ -850,6 +872,7 @@ function writeBlobWithStream(blob: Blob, stream: Readable, storageInfo: StorageI
 			}
 			if (armIdleTimer) {
 				stream.removeListener('data', armIdleTimer);
+				stream.removeListener('resume', armIdleTimer);
 				armIdleTimer = undefined;
 			}
 			const fd = (writeStream as any).fd;

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -23,6 +23,7 @@ const {
 	isSourceBlobUnavailable,
 	isBlobComplete,
 	findIncompleteBlobRefs,
+	shouldDestroyIdleBlobSource,
 } = require('#src/resources/blob');
 const {
 	existsSync,
@@ -1129,6 +1130,27 @@ describe('saveBlob source-idle watchdog is opt-in (off by default, per-stream ar
 		(info.saving ?? Promise.resolve()).then(() => (state = 'resolved')).catch(() => (state = 'rejected'));
 		await delay(2500);
 		assert.notStrictEqual(state, 'pending', 'an armed idle source should be destroyed within its timeout and settle');
+	});
+});
+
+describe('shouldDestroyIdleBlobSource (paused-source progress gate)', () => {
+	it('destroys a non-paused idle source regardless of bytes (true source idle: no data, no end)', () => {
+		assert.strictEqual(shouldDestroyIdleBlobSource(false, 100, 100), true);
+		assert.strictEqual(shouldDestroyIdleBlobSource(false, 200, 100), true);
+		assert.strictEqual(shouldDestroyIdleBlobSource(false, 0, 0), true);
+	});
+
+	it('leaves a paused source alone while the destination is still draining (slow-but-live writeStream)', () => {
+		// bytesWritten advanced since the last arm → real progress → re-arm, do not destroy.
+		assert.strictEqual(shouldDestroyIdleBlobSource(true, 4096, 1024), false);
+		assert.strictEqual(shouldDestroyIdleBlobSource(true, 1025, 1024), false);
+	});
+
+	it('destroys a paused source that made zero downstream progress over the interval (genuine wedge)', () => {
+		// Paused on backpressure but the writeStream never advanced for the whole timeout: the disk-write
+		// pipeline that never drains — the 19h prerender blob-replication wedge. Must be torn down.
+		assert.strictEqual(shouldDestroyIdleBlobSource(true, 1024, 1024), true);
+		assert.strictEqual(shouldDestroyIdleBlobSource(true, 0, 0), true);
 	});
 });
 


### PR DESCRIPTION
## Summary
Progress-gate the blob source-idle watchdog in `writeBlobWithStream` so a stalled-but-paused blob receive can recover.

Previously the idle timer re-armed *unconditionally* whenever the source stream was paused (pipeline backpressure). A genuinely stalled receive — the downstream disk-write pipeline never drains, so the replication socket stays paused on backpressure forever — therefore re-armed indefinitely and never recovered. Observed in production as a ~19h prerender (StubHub) blob-replication wedge: `connected:true`, `Receiving`, watermark frozen.

## What changed
- While paused, re-arm **only if the destination is still draining** (`writeStream.bytesWritten` advanced since the last arm). A pause with **zero** downstream progress for a whole interval is a real stall → `stream.destroy(...)`. That rejects the pipeline and, on the replication receive path, fires the PassThrough's `close` → `removePauseReason` → `ws.resume()`, lifting the very pause that was stranded.
- Re-arm on `'resume'` as well: an expiry landing in the window just after backpressure clears (`isPaused()===false` before the next `'data'`) would otherwise destroy a stream that just resumed. Both listeners are removed in `finished()`.
- Decision extracted to exported `shouldDestroyIdleBlobSource(paused, bytesWritten, lastProgressBytes)` so the branch logic is unit-tested deterministically (the wired backpressure path is hard to make deterministic).

## Context / relationship to other fixes
This is the **prevention** half of the wedge class; harper-pro#463 (reconcile-level force-reconnect, already merged → 5.1.14) is the **recovery** backstop. This fix recovers faster (~the blob timeout, default 120s, failing just the one blob) vs. #463's 15-min reconnect, and they compose. Note: harper-pro's `core` pointer must be synced to include this for `#459`'s per-stream arming to take effect.

## Where to look
- `resources/blob.ts` — the re-arm condition and the `'resume'` handling. The progress signal is `writeStream.bytesWritten` (bytes actually flushed to the fd), correct under both the plain and `deflate` pipelines since `writeStream` is the disk sink in both.

## Open item for the reviewer
- **Header first-interval delay (benign, accepted):** `lastProgressBytes` is captured as the async header write may still be buffered (`bytesWritten===0`); its later 8-byte completion can read as "progress" once, delaying destroy of a *zero-chunk* stalled stream by one extra interval. Bounded to one interval and only for a pathological no-data stream — left as-is rather than special-casing the header. Flag if you'd rather tighten it.

## Tests
`unitTests/resources/blob.test.js` — 3 predicate cases for `shouldDestroyIdleBlobSource`; the existing 5 idle-watchdog regressions remain green (49/49 in the file).

Cross-model reviewed (Codex + Gemini): Codex found no blockers; Gemini flagged the resume-window race, fixed here.

🤖 Generated by KrAIs (Claude Opus 4.8, 1M context).