### PR TITLE
Update defaultConfig.yaml docs link to v5 configuration options

### DIFF
--- a/static/defaultConfig.yaml
+++ b/static/defaultConfig.yaml
@@ -1,4 +1,4 @@
-# Harper configuration file. Refer to https://docs.harperdb.io/docs/deployments/configuration
+# Harper configuration file. Refer to https://docs.harperdb.io/reference/v5/configuration/options
 ---
 http:
   compressionThreshold: 0


### PR DESCRIPTION
## Summary

Updates the doc link in the comment at the top of `static/defaultConfig.yaml` from the stale `https://docs.harperdb.io/docs/deployments/configuration` to the current configuration reference, `https://docs.harperdb.io/reference/v5/configuration/options`.

## Purpose

The old `/docs/deployments/configuration` path no longer points to the configuration options reference. The new URL is the current v5 docs page (verified live; matches `reference/configuration/options.md` in the documentation repo).

## Notes

- One-line comment change in a static YAML file; no behavior change. `defaultConfig.yaml` is read at runtime (not generated).
- The `HarperDB` → `Harper` wording in the original request was already current in this repo, so the net diff is the URL only.
- No companion docs PR needed — the target page already exists.

_Generated by an LLM (Claude Opus 4.8)._