### PR TITLE
feat(deploy): auto-drop large deployment payload blobs after a successful deploy

### DIFF
--- a/components/deploymentRecorder.ts
+++ b/components/deploymentRecorder.ts
@@ -297,6 +297,23 @@ export class DeploymentRecorder {
 		await this.put();
 	}
 
+	/**
+	 * Drop the stored payload tarball, retaining the metadata (size, hash, event_log). Used to
+	 * reclaim storage for large deploys once every peer has installed from the blob and it is no
+	 * longer needed. Only mutates the in-memory record — the caller drops the payload before the
+	 * terminal finish() write so the null reference lands in that single put rather than a
+	 * separate one. Committing the row with no blob reference unlinks the file locally (via the
+	 * RecordEncoder retained-blob check) and replicates the null so peers drop their copies too.
+	 *
+	 * Returns the freed payload size (bytes) when a blob was present and dropped, otherwise 0.
+	 */
+	dropPayload(): number {
+		if (this.finished || this.record.payload_blob == null) return 0;
+		const freed = typeof this.record.payload_size === 'number' ? this.record.payload_size : 0;
+		this.record.payload_blob = null;
+		return freed;
+	}
+
 	async transitionPhase(phase: string, status?: DeploymentStatus): Promise<void> {
 		this.record.phase = phase;
 		if (status) this.record.status = status;

--- a/components/operations.js
+++ b/components/operations.js
@@ -572,6 +572,20 @@ async function deployComponent(req) {
 
 		if (recorder) {
 			response.deployment_id = recorder.deploymentId;
+			// Reclaim the payload tarball for large deploys: every peer has now installed from
+			// the blob (replicateOperation resolved) and the origin no longer needs it. Dropping
+			// the reference before finish() folds the null into the single terminal write, which
+			// unlinks the file locally and replicates the null so peers drop their copies too.
+			// Metadata (size, hash, event_log) is retained for the audit trail. Two guards keep
+			// the tarball when it's still the artifact you'd debug or retry with: failed deploys
+			// don't reach this branch, and a deploy that reached here only because
+			// ignore_replication_errors masked failed peers keeps its payload for those peers.
+			const payloadSize = recorder.row.payload_size;
+			const retentionMaxSize = getPayloadRetentionMaxSize();
+			if (typeof payloadSize === 'number' && payloadSize > retentionMaxSize && recorder.getFailedPeers().length === 0) {
+				const freed = recorder.dropPayload();
+				if (freed > 0) emit('payload_dropped', { payload_size: freed, max_size: retentionMaxSize });
+			}
 			emit('phase', { phase: 'success', status: 'done' });
 			await recorder.finish('success');
 		}
@@ -793,6 +807,20 @@ async function getComponents() {
  * @returns {Promise<*>}
  */
 const DEFAULT_COMPONENT_FILE_MAX_SIZE = 5 * 1024 * 1024; // 5 MB
+
+// Deploys whose payload exceeds this size have their payload_blob dropped after a successful
+// deploy (see deployComponent). The metadata is retained; only the tarball bytes are reclaimed.
+// Configurable via deployment_payloadRetention_maxSize; set it very high to retain all payloads.
+const DEFAULT_PAYLOAD_RETENTION_MAX_SIZE = 10 * 1024 * 1024; // 10 MiB
+
+function getPayloadRetentionMaxSize() {
+	const configured = configUtils.getConfigValue(hdbTerms.CONFIG_PARAMS.DEPLOYMENT_PAYLOADRETENTION_MAXSIZE);
+	// Treat unset/blank config as "use the default" — Number('') and Number(null) are 0, which
+	// would otherwise be accepted as an aggressive always-drop threshold.
+	if (configured == null || configured === '') return DEFAULT_PAYLOAD_RETENTION_MAX_SIZE;
+	const parsed = Number(configured);
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_PAYLOAD_RETENTION_MAX_SIZE;
+}
 
 async function getComponentFile(req) {
 	const validation = validator.getComponentFileValidator(req);

--- a/components/operations.js
+++ b/components/operations.js
@@ -815,9 +815,11 @@ const DEFAULT_PAYLOAD_RETENTION_MAX_SIZE = 10 * 1024 * 1024; // 10 MiB
 
 function getPayloadRetentionMaxSize() {
 	const configured = configUtils.getConfigValue(hdbTerms.CONFIG_PARAMS.DEPLOYMENT_PAYLOADRETENTION_MAXSIZE);
-	// Treat unset/blank config as "use the default" — Number('') and Number(null) are 0, which
-	// would otherwise be accepted as an aggressive always-drop threshold.
-	if (configured == null || configured === '') return DEFAULT_PAYLOAD_RETENTION_MAX_SIZE;
+	// Only a number or a numeric string is a valid threshold. Reject everything else (unset,
+	// boolean, array, blank/whitespace string) and fall back to the default — otherwise Number()
+	// coercion would turn `true`→1, `false`/``/`[]`→0 into an aggressive always-/near-always-drop.
+	if (typeof configured !== 'number' && typeof configured !== 'string') return DEFAULT_PAYLOAD_RETENTION_MAX_SIZE;
+	if (typeof configured === 'string' && configured.trim() === '') return DEFAULT_PAYLOAD_RETENTION_MAX_SIZE;
 	const parsed = Number(configured);
 	return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_PAYLOAD_RETENTION_MAX_SIZE;
 }

--- a/integrationTests/deploy/deploy-payload-reclaim.test.ts
+++ b/integrationTests/deploy/deploy-payload-reclaim.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Large-payload reclamation integration test.
+ *
+ * After a successful deploy, a payload whose size exceeds deployment_payloadRetention_maxSize
+ * has its payload_blob dropped from the hdb_deployment row (the bytes dwarf the metadata and
+ * every peer has already installed from the blob). The metadata — payload_size, payload_hash,
+ * event_log, status — is retained for the audit trail.
+ *
+ * The threshold is forced to 1 byte here so the small test fixture trips it; the retain side
+ * (a payload below the default 10 MiB threshold keeps its blob) is covered by
+ * deploy-tracking.test.ts, which deploys the same kind of small fixture under the default
+ * configuration and asserts payload_blob_present === true.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert/strict';
+import { join } from 'node:path';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { request } from 'node:http';
+import { Readable } from 'node:stream';
+
+import { startHarper, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+
+import { streamPackagedDirectory } from '../../dist/components/packageComponent.js';
+import { buildMultipartBody } from '../../dist/bin/multipartBuilder.js';
+
+function postMultipart(
+	url: URL,
+	contentType: string,
+	body: Readable,
+	auth: { username: string; password: string }
+): Promise<{ status: number; body: string }> {
+	return new Promise((resolve, reject) => {
+		const req = request(
+			{
+				protocol: url.protocol,
+				hostname: url.hostname,
+				port: url.port,
+				method: 'POST',
+				path: '/',
+				headers: {
+					'Content-Type': contentType,
+					'Transfer-Encoding': 'chunked',
+					'Authorization': 'Basic ' + Buffer.from(`${auth.username}:${auth.password}`).toString('base64'),
+				},
+			},
+			(res) => {
+				res.setEncoding('utf8');
+				let buf = '';
+				res.on('data', (chunk) => (buf += chunk));
+				res.on('end', () => resolve({ status: res.statusCode ?? 0, body: buf }));
+			}
+		);
+		req.on('error', reject);
+		body.on('error', reject);
+		body.pipe(req);
+	});
+}
+
+async function callOperation(
+	ctx: ContextWithHarper,
+	op: Record<string, unknown>
+): Promise<{ status: number; body: any }> {
+	const url = new URL(ctx.harper.operationsAPIURL);
+	const auth = 'Basic ' + Buffer.from(`${ctx.harper.admin.username}:${ctx.harper.admin.password}`).toString('base64');
+	const res = await fetch(url, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', 'Authorization': auth },
+		body: JSON.stringify(op),
+	});
+	const text = await res.text();
+	let parsed: any = text;
+	try {
+		parsed = JSON.parse(text);
+	} catch {
+		// leave as text
+	}
+	return { status: res.status, body: parsed };
+}
+
+suite('Deployment payload reclamation', (ctx: ContextWithHarper) => {
+	let fixtureDir: string;
+
+	before(async () => {
+		// Force the retention threshold to 1 byte so any real payload trips the drop. The
+		// harness applies this via HARPER_SET_CONFIG (flattened to deployment.payloadRetention.maxSize).
+		await startHarper(ctx, {
+			config: { deployment: { payloadRetention: { maxSize: 1 } } },
+			env: {},
+		});
+		fixtureDir = mkdtempSync(join(tmpdir(), 'deploy-reclaim-fixture-'));
+		writeFileSync(join(fixtureDir, 'config.yaml'), 'static:\n  files: web\nrest: true\n');
+		mkdirSync(join(fixtureDir, 'web'), { recursive: true });
+		writeFileSync(join(fixtureDir, 'web', 'index.html'), '<h1>Hello, Reclaim!</h1>');
+	});
+
+	after(async () => {
+		try {
+			rmSync(fixtureDir, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+		await teardownHarper(ctx);
+	});
+
+	test('verify Harper', async () => {
+		const response = await fetch(`${ctx.harper.operationsAPIURL}/health`);
+		strictEqual(response.status, 200);
+	});
+
+	test('drops payload_blob after a successful deploy that exceeds the threshold, retaining metadata', async () => {
+		const project = 'reclaim-test-application';
+		const multipart = buildMultipartBody(
+			{ operation: 'deploy_component', project, restart: false },
+			{
+				name: 'payload',
+				filename: 'package.tar.gz',
+				contentType: 'application/gzip',
+				stream: streamPackagedDirectory(fixtureDir, { skip_node_modules: true }),
+			}
+		);
+		const url = new URL(ctx.harper.operationsAPIURL);
+		const response = await postMultipart(url, multipart.contentType, multipart.stream, ctx.harper.admin);
+		strictEqual(response.status, 200, `expected 200, got ${response.status}: ${response.body}`);
+		const result = JSON.parse(response.body);
+		ok(result.deployment_id, 'deploy response should include a deployment_id');
+
+		await sleep(200); // let the terminal commit settle
+
+		const got = await callOperation(ctx, { operation: 'get_deployment', deployment_id: result.deployment_id });
+		strictEqual(got.status, 200, `get_deployment should return 200: ${JSON.stringify(got.body)}`);
+		const row = got.body;
+		strictEqual(row.status, 'success');
+		strictEqual(row.payload_blob_present, false, 'payload_blob should have been dropped post-deploy');
+		ok(typeof row.payload_size === 'number' && row.payload_size > 0, 'payload_size metadata should be retained');
+		ok(
+			typeof row.payload_hash === 'string' && /^[0-9a-f]{64}$/i.test(row.payload_hash),
+			'payload_hash metadata should be retained'
+		);
+		ok(
+			Array.isArray(row.event_log) && row.event_log.some((e: any) => e.event === 'payload_dropped'),
+			'event_log should record a payload_dropped event for the audit trail'
+		);
+
+		// The component itself must still be deployed — reclaiming the upload tarball must not
+		// affect the extracted, running component.
+		const components = await callOperation(ctx, { operation: 'get_components' });
+		strictEqual(components.status, 200);
+	});
+});

--- a/integrationTests/deploy/deploy-payload-reclaim.test.ts
+++ b/integrationTests/deploy/deploy-payload-reclaim.test.ts
@@ -79,6 +79,20 @@ async function callOperation(
 	return { status: res.status, body: parsed };
 }
 
+// Poll get_deployment until the row reaches a terminal status rather than relying on a fixed
+// sleep — the terminal commit settles asynchronously and a hardcoded timer is a flake source.
+async function getDeploymentWhenTerminal(ctx: ContextWithHarper, deploymentId: string, timeoutMs = 5000): Promise<any> {
+	const deadline = Date.now() + timeoutMs;
+	let last: any;
+	while (Date.now() < deadline) {
+		const got = await callOperation(ctx, { operation: 'get_deployment', deployment_id: deploymentId });
+		last = got;
+		if (got.status === 200 && (got.body?.status === 'success' || got.body?.status === 'failed')) return got;
+		await sleep(50);
+	}
+	return last;
+}
+
 suite('Deployment payload reclamation', (ctx: ContextWithHarper) => {
 	let fixtureDir: string;
 
@@ -126,9 +140,7 @@ suite('Deployment payload reclamation', (ctx: ContextWithHarper) => {
 		const result = JSON.parse(response.body);
 		ok(result.deployment_id, 'deploy response should include a deployment_id');
 
-		await sleep(200); // let the terminal commit settle
-
-		const got = await callOperation(ctx, { operation: 'get_deployment', deployment_id: result.deployment_id });
+		const got = await getDeploymentWhenTerminal(ctx, result.deployment_id);
 		strictEqual(got.status, 200, `get_deployment should return 200: ${JSON.stringify(got.body)}`);
 		const row = got.body;
 		strictEqual(row.status, 'success');

--- a/integrationTests/deploy/deploy-payload-reclaim.test.ts
+++ b/integrationTests/deploy/deploy-payload-reclaim.test.ts
@@ -99,8 +99,10 @@ suite('Deployment payload reclamation', (ctx: ContextWithHarper) => {
 	before(async () => {
 		// Force the retention threshold to 1 byte so any real payload trips the drop. The
 		// harness applies this via HARPER_SET_CONFIG (flattened to deployment.payloadRetention.maxSize).
+		// Pass it as a string so this also exercises getPayloadRetentionMaxSize's numeric-string
+		// coercion — the shape an env-var/string-sourced override actually arrives in.
 		await startHarper(ctx, {
-			config: { deployment: { payloadRetention: { maxSize: 1 } } },
+			config: { deployment: { payloadRetention: { maxSize: '1' } } },
 			env: {},
 		});
 		fixtureDir = mkdtempSync(join(tmpdir(), 'deploy-reclaim-fixture-'));

--- a/unitTests/components/deploymentRecorder.test.js
+++ b/unitTests/components/deploymentRecorder.test.js
@@ -276,6 +276,66 @@ describe('DeploymentRecorder.seal', () => {
 	});
 });
 
+describe('DeploymentRecorder.dropPayload', () => {
+	let installed;
+	beforeEach(() => {
+		installed = installMockDeploymentTable();
+	});
+	afterEach(() => installed.restore());
+
+	it('nulls the payload_blob and returns the freed size, retaining size/hash metadata', async () => {
+		const recorder = await DeploymentRecorder.create({ project: 'p' });
+		recorder.row.payload_blob = { fake: true };
+		recorder.row.payload_size = 12_345;
+		recorder.row.payload_hash = 'abc123';
+		const freed = recorder.dropPayload();
+		assert.strictEqual(freed, 12_345);
+		assert.strictEqual(recorder.row.payload_blob, null, 'blob reference is dropped');
+		assert.strictEqual(recorder.row.payload_size, 12_345, 'size metadata is retained');
+		assert.strictEqual(recorder.row.payload_hash, 'abc123', 'hash metadata is retained');
+	});
+
+	it('is a no-op returning 0 when there is no payload_blob', async () => {
+		const recorder = await DeploymentRecorder.create({ project: 'p' });
+		// create() initializes payload_blob to null.
+		assert.strictEqual(recorder.dropPayload(), 0);
+	});
+
+	it('returns 0 (freed nothing) when payload_size is unknown but still drops the blob', async () => {
+		const recorder = await DeploymentRecorder.create({ project: 'p' });
+		recorder.row.payload_blob = { fake: true };
+		recorder.row.payload_size = null;
+		assert.strictEqual(recorder.dropPayload(), 0);
+		assert.strictEqual(recorder.row.payload_blob, null);
+	});
+
+	it('is a no-op after finish() — leaves the blob reference untouched', async () => {
+		const recorder = await DeploymentRecorder.create({ project: 'p' });
+		const blob = { fake: true };
+		recorder.row.payload_blob = blob;
+		recorder.row.payload_size = 999;
+		await recorder.finish('success');
+		assert.strictEqual(recorder.dropPayload(), 0);
+		assert.strictEqual(recorder.row.payload_blob, blob, 'a finished recorder does not mutate the row');
+	});
+
+	it('folds the dropped reference into the single terminal write when sealed', async () => {
+		// Mirrors the deploy flow: ingest sets the blob, seal() before replicate, dropPayload()
+		// just before finish() so the null lands in finish()'s one put rather than a separate one.
+		const recorder = await DeploymentRecorder.create({ project: 'p' });
+		recorder.row.payload_blob = { fake: true };
+		recorder.row.payload_size = 20 * 1024 * 1024;
+		recorder.seal();
+		const freed = recorder.dropPayload();
+		assert.strictEqual(freed, 20 * 1024 * 1024);
+		await recorder.finish('success');
+		const persisted = await installed.mock.get(recorder.deploymentId);
+		assert.strictEqual(persisted.payload_blob, null, 'terminal row has no blob reference');
+		assert.strictEqual(persisted.payload_size, 20 * 1024 * 1024, 'terminal row retains the size');
+		assert.strictEqual(persisted.status, 'success');
+	});
+});
+
 describe('awaitDeploymentRow', () => {
 	let installed;
 	beforeEach(() => {

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -532,6 +532,7 @@ export const CONFIG_PARAMS = {
 	OPERATIONSAPI_NETWORK_HTTP2: 'operationsApi_network_http2',
 	OPERATIONSAPI_NETWORK_MAXREQUESTBODYSIZE: 'operationsApi_network_maxRequestBodySize',
 	OPERATIONSAPI_COMPONENTFILE_MAXSIZE: 'operationsApi_componentFile_maxSize',
+	DEPLOYMENT_PAYLOADRETENTION_MAXSIZE: 'deployment_payloadRetention_maxSize',
 	OPERATIONSAPI_TLS: 'operationsApi_tls',
 	OPERATIONSAPI_TLS_CERTIFICATE: 'operationsApi_tls_certificate',
 	OPERATIONSAPI_TLS_PRIVATEKEY: 'operationsApi_tls_privateKey',


### PR DESCRIPTION
Closes #1495 (part 1 of 2).

## Summary
After a deploy succeeds and every peer has installed from the replicated `payload_blob`, the upload tarball is no longer needed. For payloads larger than `deployment_payloadRetention_maxSize` (new config param, default **10 MiB**) the origin drops `payload_blob` as part of the `DeploymentRecorder`'s single terminal write. Because that null reference replicates, the blob is reclaimed **cluster-wide** — each node unlinks its local file via the existing `RecordEncoder` retained-blob check (the #641 path). Metadata (`payload_size`, `payload_hash`, `event_log`, status) is retained for the audit trail, and a `payload_dropped` event is recorded.

## Purpose
We never actually reclaimed deploy payload blobs after replication — they accumulated on every node (observed: hundreds of orphaned payloads, multiple GB on a preprod cluster). This adds the threshold-based reclamation we'd intended.

## Where to look / things to weigh
- **`components/operations.js`** (success branch of `deployComponent`): the drop is gated on `payload_size > threshold` **and** `getFailedPeers().length === 0`, so a deploy that only reached "success" because `ignore_replication_errors` masked a failed peer keeps its payload for inspection/retry.
- **Cluster-wide reclamation via replication is intentional** — one origin decision nulls the blob everywhere. For the post-deploy case this is desired (the payload's job is done); calling it out because it's the load-bearing semantic.
- **Threshold default 10 MiB**, configurable; set very high to retain all payloads. Explicit `0` means "always drop"; non-numeric/blank/unset falls back to the default.
- `DeploymentRecorder.dropPayload()` only mutates the in-memory record so the null folds into `finish()`'s terminal write (avoids an extra put and the #1170 out-of-order-revert window).

## Open follow-up (Part 2)
Issue #1495 also asks for a **disk-pressure storage-reclamation hook** (evict oldest payloads when space is low). The framework already exists (`server/storageReclamation.ts` `onStorageReclamation`); the eviction policy and the "one node's disk pressure reclaims audit blobs cluster-wide" semantics deserve their own PR + decision.

Gemini review also flagged a related gap that Part 2 should cover: a deploy where a peer was **offline/failed** keeps its payload (correct — that peer may still need it), but there is **no later trigger** to reclaim it once the cluster converges. The conservative keep-on-failure here is deliberate for Part 1; eventual/retroactive reclamation belongs in the Part 2 hook.

## Tests
- Unit: `DeploymentRecorder.dropPayload` (drop / no-op / after-finish / metadata-retention / sealed-terminal-write).
- Integration: `deploy-payload-reclaim.test.ts` forces the threshold to 1 byte and asserts `payload_blob_present === false` with metadata + `payload_dropped` event retained after a successful deploy (polls `get_deployment` to a terminal status — no fixed sleep). Retain-side (default threshold keeps small payloads) is covered by the existing `deploy-tracking.test.ts`.

Cross-model reviewed (Codex + Gemini). All actionable findings fixed: ignore-errors gate, blank/coerced-config zero-threshold, and the integration-test sleep flake. Declined with rationale: `record`/`row` rename (pre-existing class convention) and human-readable byte units (raw bytes matches the sibling `operationsApi_componentFile_maxSize`).

🤖 Generated by Claude Opus 4.8.