### PR TITLE
perf(describe): add skip_record_count to skip the per-table count scan

### DIFF
--- a/components/mcp/tools/schemas/operations.ts
+++ b/components/mcp/tools/schemas/operations.ts
@@ -34,7 +34,13 @@ export const OPERATION_INPUT_SCHEMAS: Record<string, object> = {
 	// ─── describe_* ───────────────────────────────────────────────────────
 	describe_all: {
 		type: 'object',
-		properties: {},
+		properties: {
+			skip_record_count: {
+				type: 'boolean',
+				description:
+					'Omit each table’s `record_count` (and `estimated_record_range`) to skip the per-table count scan, which dominates latency on large databases. Defaults to false.',
+			},
+		},
 		description: 'Returns the full schema tree: every database, table, and attribute the caller can describe.',
 	},
 	describe_schema: {
@@ -42,12 +48,20 @@ export const OPERATION_INPUT_SCHEMAS: Record<string, object> = {
 		properties: {
 			schema: { type: 'string', description: 'Database name (legacy: "schema"). Required.' },
 			database: { type: 'string', description: 'Database name (preferred). Required if `schema` is omitted.' },
+			skip_record_count: {
+				type: 'boolean',
+				description: 'Omit each table’s `record_count` to skip the count scan. Defaults to false.',
+			},
 		},
 	},
 	describe_database: {
 		type: 'object',
 		properties: {
 			database: { type: 'string', description: 'Database name. Required.' },
+			skip_record_count: {
+				type: 'boolean',
+				description: 'Omit each table’s `record_count` to skip the count scan. Defaults to false.',
+			},
 		},
 		required: ['database'],
 	},
@@ -57,6 +71,11 @@ export const OPERATION_INPUT_SCHEMAS: Record<string, object> = {
 			database: { type: 'string', description: 'Database name.' },
 			schema: { type: 'string', description: 'Legacy alias for `database`.' },
 			table: { type: 'string', description: 'Table name. Required.' },
+			skip_record_count: {
+				type: 'boolean',
+				description:
+					'Omit `record_count` (and `estimated_record_range`) to skip the count scan and return schema/metadata faster. Defaults to false.',
+			},
 		},
 		required: ['table'],
 	},

--- a/dataLayer/schemaDescribe.ts
+++ b/dataLayer/schemaDescribe.ts
@@ -34,6 +34,7 @@ export async function describeAll(opObj: any = {}) {
 		let schemaPerms = {};
 		let tResults = [];
 		const exact_count = opObj?.exact_count;
+		const skip_record_count = opObj?.skip_record_count;
 		const include_computed = opObj?.include_computed;
 		for (let schema in databases) {
 			schemaList[schema] = true;
@@ -43,10 +44,10 @@ export async function describeAll(opObj: any = {}) {
 				try {
 					let desc;
 					if (sysCall || isSu || bypassAuth) {
-						desc = await descTable({ schema, table, exact_count, include_computed });
+						desc = await descTable({ schema, table, exact_count, skip_record_count, include_computed });
 					} else if (rolePerms && rolePerms[schema].describe && rolePerms[schema].tables[table].describe) {
 						const tAttrPerms = rolePerms[schema].tables[table].attribute_permissions;
-						desc = await descTable({ schema, table, exact_count, include_computed }, tAttrPerms);
+						desc = await descTable({ schema, table, exact_count, skip_record_count, include_computed }, tAttrPerms);
 					}
 					if (desc) {
 						tResults.push(desc);
@@ -124,6 +125,7 @@ async function descTable(describeTableObject: any, attrPerms?: any) {
 			database: Joi.string(),
 			table: Joi.string().required(),
 			exact_count: Joi.boolean().strict(),
+			skip_record_count: Joi.boolean().strict(),
 			include_computed: Joi.boolean().strict(),
 		})
 	);
@@ -208,11 +210,17 @@ async function descTable(describeTableObject: any, attrPerms?: any) {
 			.filter((source: any) => source && source !== 'Replicator');
 
 	try {
-		const recordCount = await tableObj.getRecordCount({ exactCount: !!describeTableObject.exact_count });
-		tableResult.record_count = recordCount.recordCount;
+		// `getRecordCount` scans the table's primary store, which dominates describe latency on large
+		// tables -- and `describe_all` pays it serially for every table. Callers that only need schema
+		// /metadata can pass `skip_record_count: true` to omit the scan and fetch the count separately
+		// (e.g. asynchronously). The remaining stats below are O(1), so they are always included.
+		if (!describeTableObject.skip_record_count) {
+			const recordCount = await tableObj.getRecordCount({ exactCount: !!describeTableObject.exact_count });
+			tableResult.record_count = recordCount.recordCount;
+			tableResult.estimated_record_range = recordCount.estimatedRange;
+		}
 		tableResult.table_size = tableObj.getSize();
 		tableResult.db_audit_size = tableObj.getAuditSize();
-		tableResult.estimated_record_range = recordCount.estimatedRange;
 		let auditStore = tableObj.auditStore;
 		if (auditStore) {
 			for (let key of auditStore.getKeys({ reverse: true, limit: 1 })) {
@@ -244,6 +252,7 @@ export async function describeSchema(describeSchemaObject: any) {
 		Joi.object({
 			database: Joi.string(),
 			exact_count: Joi.boolean().strict(),
+			skip_record_count: Joi.boolean().strict(),
 			include_computed: Joi.boolean().strict(),
 		})
 	);
@@ -277,6 +286,7 @@ export async function describeSchema(describeSchemaObject: any) {
 					schema: describeSchemaObject.schema,
 					table: tableName,
 					exact_count: describeSchemaObject.exact_count,
+					skip_record_count: describeSchemaObject.skip_record_count,
 					include_computed: describeSchemaObject.include_computed,
 				},
 				table_perms ? table_perms.attribute_permissions : null

--- a/integrationTests/apiTests/northwind.test.mjs
+++ b/integrationTests/apiTests/northwind.test.mjs
@@ -12799,6 +12799,35 @@ suite('Northwind operations', { skip: skipSuite }, (ctx) => {
 				.expect(200);
 		});
 
+		test('Describe Table - skip_record_count omits the count scan', async () => {
+			await client
+				.req()
+				.send({ operation: 'describe_table', schema: 'northnwd', table: 'region', skip_record_count: true })
+				.expect((r) => {
+					// schema/metadata is still returned...
+					assert.ok(r.body.hasOwnProperty('primary_key'), r.text);
+					assert.ok(r.body.hasOwnProperty('attributes'), r.text);
+					assert.ok(r.body.hasOwnProperty('table_size'), r.text);
+					// ...but the expensive count (and its estimated range) is omitted.
+					assert.ok(!r.body.hasOwnProperty('record_count'), r.text);
+					assert.ok(!r.body.hasOwnProperty('estimated_record_range'), r.text);
+				})
+				.expect(200);
+		});
+
+		test('Describe All - skip_record_count omits the count scan', async () => {
+			await client
+				.req()
+				.send({ operation: 'describe_all', skip_record_count: true })
+				.expect((r) => {
+					const table = r.body.northnwd && r.body.northnwd.region;
+					assert.ok(table, r.text);
+					assert.ok(table.hasOwnProperty('primary_key'), r.text);
+					assert.ok(!table.hasOwnProperty('record_count'), r.text);
+				})
+				.expect(200);
+		});
+
 		test('Describe  SYSTEM schema as non-SU', async () => {
 			await client
 				.reqAs(headersTestUser)


### PR DESCRIPTION
## Summary

Adds an opt-in `skip_record_count` flag to the `describe_*` operations so callers that only need schema can avoid the expensive record-count scan.

`describe_table` / `describe_all` / `describe_schema` compute `record_count` via `getRecordCount`, which **scans each table's primary store**. That scan dominates describe latency on large tables, and `describe_all` pays it **serially, for every table** — the root cause behind the slow Databases tab in Studio ([HarperFast/studio#1367](https://github.com/HarperFast/studio/issues/1367)).

## What changed

- New boolean **`skip_record_count`** (Joi-validated) on `describe_table`, `describe_all`, `describe_schema`. When set, `record_count` and `estimated_record_range` are omitted and the count scan is skipped entirely.
- The cheap, O(1) stats (`table_size`, `db_audit_size`, `last_updated_record`) are still returned.
- Threaded through `describeAll` and `describeSchema`; documented in the MCP operation input schemas.

## Compatibility

Fully backward compatible — omitting the flag preserves today's behavior, and `validateBySchema` already passes `allowUnknown: true`, so older clients/servers tolerate the new key. The estimate-vs-exact distinction Studio relies on (`estimated_record_range` present ⇒ estimate) is unchanged.

## Pairs with

The Studio frontend change that consumes this: it fetches `describe_all` with `skip_record_count`, renders records off the count-free schema, and fetches the count separately (estimate first, exact on demand). Supports [HarperFast/studio#1367](https://github.com/HarperFast/studio/issues/1367).

## Tests

Added two cases in `integrationTests/apiTests/northwind.test.mjs` asserting `describe_table` / `describe_all` with `skip_record_count: true` return schema but omit `record_count` / `estimated_record_range`. `tsc` (build project) and `oxlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
