### PR TITLE
fix(itc): await cross-worker propagation for role/schema mutations (#1497)

### DIFF
--- a/dataLayer/schema.ts
+++ b/dataLayer/schema.ts
@@ -47,7 +47,9 @@ const PRIMARY_KEY_CONSTRAINTS = Joi.string()
 
 export async function createSchema(schemaCreateObject: any) {
 	let schemaStructure = await createSchemaStructure(schemaCreateObject);
-	signalling.signalSchemaChange(
+	// Await cross-worker propagation so the new schema is visible on every worker before
+	// returning success — otherwise describe_all on a lagging worker reports it missing (#1497).
+	await signalling.signalSchemaChange(
 		new SchemaEventMsg(process.pid, schemaCreateObject.operation, schemaCreateObject.schema)
 	);
 
@@ -170,7 +172,11 @@ export async function dropSchema(dropSchemaObject: any) {
 	}
 
 	await harperBridge.dropSchema(dropSchemaObject);
-	signalling.signalSchemaChange(new SchemaEventMsg(process.pid, dropSchemaObject.operation, dropSchemaObject.schema));
+	// Await cross-worker propagation before returning success so no worker keeps serving the
+	// dropped schema (#1497).
+	await signalling.signalSchemaChange(
+		new SchemaEventMsg(process.pid, dropSchemaObject.operation, dropSchemaObject.schema)
+	);
 
 	let response = await server.replication.replicateOperation(dropSchemaObject);
 	response.message = `successfully deleted '${dropSchemaObject.schema}'`;
@@ -276,7 +282,9 @@ export async function dropAttribute(dropAttributeObject: any) {
 	try {
 		await harperBridge.dropAttribute(dropAttributeObject);
 		dropAttributeFromGlobal(dropAttributeObject);
-		signalling.signalSchemaChange(
+		// Await cross-worker propagation before returning success so the dropped attribute is
+		// gone from every worker's cached schema (#1497).
+		await signalling.signalSchemaChange(
 			new SchemaEventMsg(
 				process.pid,
 				dropAttributeObject.operation,
@@ -327,7 +335,9 @@ export async function createAttribute(createAttributeObject: any) {
 	}
 
 	await harperBridge.createAttribute(createAttributeObject);
-	signalling.signalSchemaChange(
+	// Await cross-worker propagation before returning success so a query for the new attribute
+	// can't hit a lagging worker that still has the old (empty) attribute permissions (#1497).
+	await signalling.signalSchemaChange(
 		new SchemaEventMsg(
 			process.pid,
 			createAttributeObject.operation,

--- a/security/role.ts
+++ b/security/role.ts
@@ -87,7 +87,10 @@ export async function addRole(role: any) {
 
 	await insert.insert(insertObject);
 
-	signalling.signalUserChange(new UserEventMsg(process.pid));
+	// Await cross-worker propagation so the new role is in effect on every worker before
+	// returning success (matches alterRole and the user ops). Otherwise a request routed to a
+	// lagging worker can observe the old auth state — see #1497.
+	await signalling.signalUserChange(new UserEventMsg(process.pid));
 
 	role = scrubRoleDetails(role);
 	return role;
@@ -186,7 +189,9 @@ export async function dropRole(role: any) {
 
 	await pDeleteDelete(deleteObject);
 
-	signalling.signalUserChange(new UserEventMsg(process.pid));
+	// Await cross-worker propagation so the drop is in effect on every worker before returning
+	// success — otherwise a lagging worker keeps honoring the dropped role briefly (#1497).
+	await signalling.signalUserChange(new UserEventMsg(process.pid));
 	return `${roleName[0].role} successfully deleted`;
 }
 

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -470,9 +470,26 @@ async function broadcast(message, includeSelf) {
 
 const awaitingResponses = new Map();
 let nextId = 1;
-function broadcastWithAcknowledgement(message) {
+// Backstop so a wedged-but-alive worker (one whose event loop is blocked and never acks, yet
+// whose port hasn't closed) can't hang a mutating admin/DDL op forever. The durable write has
+// already succeeded by the time we broadcast, and the health monitor restarts a truly stuck
+// worker (its port close fires the same ack handlers), so on timeout we proceed best-effort.
+const DEFAULT_ACK_TIMEOUT_MS = 30000;
+function broadcastWithAcknowledgement(message, timeout = DEFAULT_ACK_TIMEOUT_MS) {
 	return new Promise((resolve) => {
 		let waitingCount = 0;
+		let timer;
+		// Tracks the handlers still awaiting an ack for THIS broadcast. Doubles as an
+		// idempotency guard: a port's handler runs at most once whether it's driven by an ack,
+		// the close listener, or the timeout below.
+		const pending = new Set();
+		const finish = () => {
+			if (timer) {
+				clearTimeout(timer);
+				timer = undefined;
+			}
+			resolve();
+		};
 		for (let port of connectedPorts) {
 			// Job workers run a single isolated task and exit; they don't participate in
 			// schema-change gossip. Including them causes a deadlock: the broadcast waits for
@@ -482,15 +499,17 @@ function broadcastWithAcknowledgement(message) {
 			try {
 				let requestId = nextId++;
 				const ackHandler = () => {
+					if (!pending.delete(ackHandler)) return; // already settled for this port
 					awaitingResponses.delete(requestId);
 					if (--waitingCount === 0) {
-						resolve();
+						finish();
 					}
 					if (port !== parentPort && --port.refCount === 0) {
 						port.unref();
 					}
 				};
 				ackHandler.port = port;
+				pending.add(ackHandler);
 				port.ref();
 				port.refCount = (port.refCount || 0) + 1;
 				awaitingResponses.set((message.requestId = requestId), ackHandler);
@@ -511,7 +530,21 @@ function broadcastWithAcknowledgement(message) {
 				harperLogger.error(`Unable to send message to worker`, error);
 			}
 		}
-		if (waitingCount === 0) resolve();
+		if (waitingCount === 0) return resolve();
+		if (timeout > 0) {
+			timer = setTimeout(() => {
+				timer = undefined;
+				const stuck = [];
+				for (let ackHandler of [...pending]) {
+					stuck.push(ackHandler.port?.threadId);
+					ackHandler(); // same cleanup path as an ack/close; drives waitingCount to 0 and resolves
+				}
+				harperLogger.warn(
+					`ITC broadcast (type ${message.type}) not acknowledged by worker thread(s) ${stuck.join(', ')} within ${timeout}ms; proceeding best-effort`
+				);
+			}, timeout);
+			timer.unref?.();
+		}
 	});
 }
 

--- a/utility/signalling.ts
+++ b/utility/signalling.ts
@@ -6,25 +6,29 @@ import ITCEventObject from '../server/itc/utility/ITCEventObject.js';
 let serverItcHandlers;
 import { sendItcEvent } from '../server/threads/itc.js';
 
-export function signalSchemaChange(message: any) {
+// Await BOTH the local handler and the cross-worker broadcast. The local handler is what
+// rebuilds THIS thread's cache; firing it un-awaited let the originating worker return success
+// before its own cache caught up, so the next request it served observed stale state even though
+// the op awaited propagation to the other workers — the originator half of #1497. Both legs
+// resolve without rejecting (each handler has its own try/catch; the broadcast always resolves),
+// so Promise.all is safe here. Callers that don't await keep their prior fire-and-forget behavior.
+export async function signalSchemaChange(message: any) {
 	try {
 		hdbLogger.debug('signalSchemaChange called with message:', message);
 		serverItcHandlers = serverItcHandlers || require('../server/itc/serverHandlers.js');
 		const itcEventSchema = new ITCEventObject(hdbTerms.ITC_EVENT_TYPES.SCHEMA, message);
-		serverItcHandlers.schema(itcEventSchema);
-		return sendItcEvent(itcEventSchema);
+		await Promise.all([serverItcHandlers.schema(itcEventSchema), sendItcEvent(itcEventSchema)]);
 	} catch (err) {
 		hdbLogger.error(err);
 	}
 }
 
-export function signalUserChange(message: any) {
+export async function signalUserChange(message: any) {
 	try {
 		hdbLogger.trace('signalUserChange called with message:', message);
 		serverItcHandlers = serverItcHandlers || require('../server/itc/serverHandlers.js');
 		const itcEventUser = new ITCEventObject(hdbTerms.ITC_EVENT_TYPES.USER, message);
-		serverItcHandlers.user(itcEventUser);
-		return sendItcEvent(itcEventUser);
+		await Promise.all([serverItcHandlers.user(itcEventUser), sendItcEvent(itcEventUser)]);
 	} catch (err) {
 		hdbLogger.error(err);
 	}


### PR DESCRIPTION
## Summary

Addresses the eventually-consistent ITC gap in #1497 across three layers:

1. **Call-site awaits** — `addRole`, `dropRole`, `createSchema`, `dropSchema`, `createAttribute`, and `dropAttribute` returned success before sibling workers had rebuilt their cached auth/schema state, because they fired `signalUserChange` / `signalSchemaChange` without awaiting the returned promise. Made consistent with siblings (`alterRole`, `add/alter/dropUser`) that already awaited.

2. **Originating-worker local rebuild** — `signalUserChange` / `signalSchemaChange` called the *local* `serverItcHandlers.user/schema()` fire-and-forget, then awaited only the cross-worker broadcast. So even if a caller awaited, the originating worker returned before *its own* `usersWithRolesMap` was rebuilt. Fixed with `async function + await Promise.all([localHandler, broadcast])` in `utility/signalling.ts`.

3. **Ack timeout backstop** — `broadcastWithAcknowledgement` had no timeout: a wedged-but-alive worker (hung ITC handler, not dead) would block admin ops forever. Added a best-effort 30 s timeout: remaining pending acks are resolved, thread IDs are logged, and the call returns so the durable write isn't rolled back.

## Root cause summary

The cross-worker ack machinery the issue proposes building **already exists**:

- `signalUserChange` / `signalSchemaChange` return `broadcastWithAcknowledgement` (`server/threads/manageThreads.js`), which resolves only after every live worker acks (a port close-listener releases the wait if a worker dies).
- Each worker acks from its ITC handler (`server/threads/itc.js`) **only after** awaiting `userHandler` / `schemaHandler` — i.e. after `setUsersWithRolesCache()` / schema reload completes.

The bugs were: (a) six entry points dropped the returned promise; (b) the signal helpers themselves fired the local rebuild fire-and-forget.

## Scope

`createTable` / `dropTable` propagate through a different layer (harperBridge → ResourceBridge → Table apply path) — they don't use these signal helpers and are intentionally untouched. `tokenAuthentication.ts` signals on every login; awaiting there would add cross-worker latency for no auth-visibility benefit.

## Validation

Cannot reproduce the flake locally — the integration harness hardcodes `THREADS_COUNT=1`, which prevents the multi-thread routing race. Using CI as the repro environment; watching whether the northwind cross-3-schema-join flake (the `alter_role` stale-partial-403 from #1497 symptom 3) resolves after the local-rebuild fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — KrAIs