### PR TITLE
Set up default config for gemini PR reviews

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -11,6 +11,6 @@ code_review:
     code_review: true
     include_drafts: true
 ignore_patterns:
-  - "package-lock.json"
+  - 'package-lock.json'
 
 # Note that you can also include a styleguide.md which provides a system prompt for the AI to follow for the reviews.

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,16 @@
+# Configure Gemini PR reviews, schema at https://docs.cloud.google.com/gemini/docs/code-review/customize-repo-review#schema
+memory_config:
+  disabled: false
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: true
+    include_drafts: true
+ignore_patterns:
+  - "package-lock.json"
+
+# Note that you can also include a styleguide.md which provides a system prompt for the AI to follow for the reviews.


### PR DESCRIPTION
These are the default settings for Gemini PR reviews (well, I added package-lock.json, setting this up as a baseline for customizing and copying to other repos).