### PR TITLE
Honor thrown Response and `status` field for custom-resource HTTP status

### DIFF
--- a/integrationTests/resources/resource-status-contract.test.ts
+++ b/integrationTests/resources/resource-status-contract.test.ts
@@ -17,9 +17,10 @@
  * Findings are printed in `after()` as compact matrices; assertions only guard
  * server survival and known-contract expectations.
  *
- * This test documents working idioms + gaps (D-086) and is an F-039/#1421 regression
- * marker — assertions match CURRENT behavior so it is green now. When F-039/#1421 land,
- * update the expected statuses accordingly.
+ * This test documents working idioms + gaps (D-086). F-039/#1421 have landed: a thrown
+ * Response now short-circuits (status/headers/body honored) and `throw {status}` maps the
+ * `status` field as an alias for `statusCode`. A thrown Response still aborts the transaction
+ * like any throw, so a preceding write rolls back (4d). Assertions below guard that behavior.
  *
  * Reproduction:
  *   npm run test:integration -- "integrationTests/resources/resource-status-contract.test.ts"
@@ -216,7 +217,7 @@ suite('QA-195 custom-resource AUTHOR status-code + body contract', { skip: skipS
 			{ case: 'bare-string', wantStatus: 500, desc: 'throw "string"' },
 			{ case: 'bare-number', wantStatus: 500, desc: 'throw 404 (bare number)' },
 			{ case: 'obj-statusCode', wantStatus: 404, desc: 'throw {statusCode:404}', isDefectIf500: true },
-			{ case: 'obj-status', wantStatus: 500, desc: 'throw {status:400} (wrong field)' },
+			{ case: 'obj-status', wantStatus: 400, desc: 'throw {status:400}', isDefectIf500: true },
 			{ case: 'throw-response', wantStatus: 422, desc: 'throw new Response(_, {status:422})' },
 			{ case: 'reject-promise', wantStatus: 500, desc: 'Promise.reject(Error)' },
 			{ case: 'null-throw', wantStatus: 500, desc: 'throw null' },
@@ -258,15 +259,13 @@ suite('QA-195 custom-resource AUTHOR status-code + body contract', { skip: skipS
 				defectList.push(`[THROW LEAK] ${c.case}: error message "${c.msgToken}" leaked into response body`);
 			}
 
-			// throw-Response specific check
+			// throw-Response now short-circuits (F-039/#1421): status, Content-Type, body, and custom headers preserved
 			if (c.case === 'throw-response') {
-				if (r.status === 500) {
-					defectList.push(
-						`[THROW F-039] throw-Response->500: Harper does not short-circuit on thrown Response objects`
-					);
-				} else if (r.status === 422) {
-					throwMatrix.push(`  ^ GOOD: throw Response short-circuits correctly`);
-				}
+				strictEqual(r.status, 422, `throw Response should short-circuit to its status, got ${r.status}`);
+				ok(r.ct.includes('application/json'), `throw Response should preserve its Content-Type, got ${r.ct}`);
+				ok(leaks(r.text, 'shortCircuit'), `throw Response should preserve its body, got ${pfx(r.text)}`);
+				strictEqual(r.headers['x-qa195-thrown'], 'response', 'throw Response should preserve its custom headers');
+				throwMatrix.push(`  ^ GOOD: throw Response short-circuits (422, body + headers preserved)`);
 			}
 
 			// bare-number 404 — was it honored?
@@ -275,13 +274,10 @@ suite('QA-195 custom-resource AUTHOR status-code + body contract', { skip: skipS
 				throwMatrix.push(`  ^ NOTE: bare number 404 was honored as status code (unexpected)`);
 			}
 
-			// obj-status (wrong field) — was status honored despite wrong field name?
+			// obj-status now honored (F-039/#1421): `status` is read as an alias for `statusCode`
 			if (c.case === 'obj-status') {
-				if (r.status === 400) {
-					throwMatrix.push(`  ^ NOTE: throw {status:400} was honored (unexpected — this is the wrong field name)`);
-				} else {
-					throwMatrix.push(`  ^ CONFIRMED: throw {status:400} (wrong field) not honored -> ${r.status}`);
-				}
+				strictEqual(r.status, 400, `throw {status:400} should map to 400, got ${r.status}`);
+				throwMatrix.push(`  ^ GOOD: throw {status:400} honored -> 400`);
 			}
 		}
 
@@ -298,7 +294,7 @@ suite('QA-195 custom-resource AUTHOR status-code + body contract', { skip: skipS
 			{ case: 'statuscode-400', wantStatus: 400, desc: 'POST Error{.statusCode=400}', isDefectIf500: true },
 			{ case: 'client-error-def', wantStatus: 400, desc: 'POST ClientError', isDefectIf500: true },
 			{ case: 'obj-statusCode', wantStatus: 409, desc: 'POST throw {statusCode:409}', isDefectIf500: true },
-			{ case: 'obj-status', wantStatus: 500, desc: 'POST throw {status:400}' },
+			{ case: 'obj-status', wantStatus: 400, desc: 'POST throw {status:400}', isDefectIf500: true },
 		];
 
 		for (const c of postCases) {
@@ -307,11 +303,8 @@ suite('QA-195 custom-resource AUTHOR status-code + body contract', { skip: skipS
 			const row = `${c.desc.padEnd(30)} -> ${r.status} [want ${c.wantStatus}]  title=${pfx(parsed?.title ?? r.text, 50)}`;
 			postPutMatrix.push(row);
 
-			if ((c as any).isDefectIf500 && r.status === 500) {
-				defectList.push(`[POST D-070] ${c.case}: 4xx-as-500`);
-			}
-			if ((c as any).isDefectIf500 && r.status !== c.wantStatus) {
-				postPutMatrix.push(`  ^ NOTE: expected ${c.wantStatus}, got ${r.status}`);
+			if ((c as any).isDefectIf500) {
+				strictEqual(r.status, c.wantStatus, `POST ${c.case}: expected ${c.wantStatus}, got ${r.status}`);
 			}
 		}
 
@@ -320,7 +313,7 @@ suite('QA-195 custom-resource AUTHOR status-code + body contract', { skip: skipS
 			{ case: 'statuscode-400', wantStatus: 400, desc: 'PUT Error{.statusCode=400}', isDefectIf500: true },
 			{ case: 'client-error-def', wantStatus: 400, desc: 'PUT ClientError', isDefectIf500: true },
 			{ case: 'obj-statusCode', wantStatus: 422, desc: 'PUT throw {statusCode:422}', isDefectIf500: true },
-			{ case: 'obj-status', wantStatus: 500, desc: 'PUT throw {status:400}' },
+			{ case: 'obj-status', wantStatus: 400, desc: 'PUT throw {status:400}', isDefectIf500: true },
 		];
 
 		for (const c of putCases) {
@@ -329,11 +322,8 @@ suite('QA-195 custom-resource AUTHOR status-code + body contract', { skip: skipS
 			const row = `${c.desc.padEnd(30)} -> ${r.status} [want ${c.wantStatus}]  title=${pfx(parsed?.title ?? r.text, 50)}`;
 			postPutMatrix.push(row);
 
-			if ((c as any).isDefectIf500 && r.status === 500) {
-				defectList.push(`[PUT D-070] ${c.case}: 4xx-as-500`);
-			}
-			if ((c as any).isDefectIf500 && r.status !== c.wantStatus) {
-				postPutMatrix.push(`  ^ NOTE: expected ${c.wantStatus}, got ${r.status}`);
+			if ((c as any).isDefectIf500) {
+				strictEqual(r.status, c.wantStatus, `PUT ${c.case}: expected ${c.wantStatus}, got ${r.status}`);
 			}
 		}
 
@@ -378,6 +368,27 @@ suite('QA-195 custom-resource AUTHOR status-code + body contract', { skip: skipS
 		}
 
 		ok(true, 'status pattern matrix recorded');
+	});
+
+	// -------------------------------------------------------------------------
+	// 4d. THROWN RESPONSE ROLLS BACK — a thrown Response surfaces its status/body,
+	//     but (like any throw) aborts the transaction, so a preceding write must
+	//     NOT persist. Guards the "throw = rollback" contract.
+	// -------------------------------------------------------------------------
+	test('thrown Response surfaces its status but rolls back the transaction', async () => {
+		const id = `twr-${Date.now()}`;
+		const r = await rawPost('/ThrowResponseAfterWrite/', { id });
+		strictEqual(r.status, 201, `thrown Response status should surface, got ${r.status}`);
+		ok(leaks(r.text, 'thrown'), `thrown Response body should surface, got ${pfx(r.text)}`);
+
+		// the write that ran before the throw must have rolled back
+		const check = await rawGet(`/Kv/${id}`);
+		statusMatrix.push(`thrown-Response-after-write id=${id} -> ${r.status}, Kv readback=${check.status} (expect 404)`);
+		strictEqual(
+			check.status,
+			404,
+			`write before a thrown Response must roll back, but Kv/${id} returned ${check.status}`
+		);
 	});
 
 	// -------------------------------------------------------------------------

--- a/integrationTests/resources/resource-status-contract/resources.js
+++ b/integrationTests/resources/resource-status-contract/resources.js
@@ -244,6 +244,24 @@ export class StatusViaObjStatus extends Resource {
 }
 
 // ---------------------------------------------------------------------------
+// THROW-RESPONSE-AFTER-WRITE — POST writes Kv(id) then throws a Response.
+// A thrown Response surfaces its status/body, but (like any throw) ABORTS the
+// transaction, so the write must NOT persist. Documents the "throw = rollback"
+// contract for thrown Responses.
+// ---------------------------------------------------------------------------
+export class ThrowResponseAfterWrite extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		const id = (body && body.id) || 'twr';
+		await tables.Kv.put({ id, v: 'should-not-persist' });
+		throw new Response(JSON.stringify({ thrown: true, id }), {
+			status: 201,
+			headers: { 'Content-Type': 'application/json' },
+		});
+	}
+}
+
+// ---------------------------------------------------------------------------
 // LIVENESS
 // ---------------------------------------------------------------------------
 export class Liveness extends Resource {

--- a/server/REST.ts
+++ b/server/REST.ts
@@ -19,6 +19,42 @@ let httpOptions = {};
 
 const OPENAPI_DOMAIN = 'openapi';
 
+/**
+ * Finalize a Response (or a response-like envelope carrying a `headers` field) into the response object
+ * handed to the HTTP layer: merge in the accumulated headers, serialize a body from `data` or the object
+ * itself when one isn't already present, and default the status. Shared by the normal return path and the
+ * thrown-Response short-circuit so both honor status, headers, and body identically.
+ */
+function finalizeResponse(responseData, headers, status, request) {
+	if (Object.isFrozen(responseData)) {
+		// make a copy if it is a frozen record
+		responseData = Object.assign({}, responseData);
+	}
+	// merge headers from response
+	const responseHeaders = mergeHeaders(responseData.headers, headers);
+	if (responseData.headers !== responseHeaders)
+		// if we rebuilt the headers, reassign it, but we don't want to assign to a Response object (which should already
+		// have a valid Headers object) or it will throw an error
+		responseData.headers = responseHeaders;
+	// if no body, look for provided data to serialize
+	if (!responseData.body) {
+		let body: any;
+		if ('data' in responseData) {
+			// a standard Response object does not have a setter for body, so we force it
+			body = serialize(responseData.data, request, responseData);
+		} else if (responseData.body === undefined) {
+			// if there is really no body, serialize this object into the body. Note that `new Response()` creates a response
+			// with a null body, and will not fall into this branch
+			body = serialize(responseData, request, responseData);
+		}
+		if (body) {
+			responseData = { status: responseData.status, headers: responseData.headers, body };
+		}
+	}
+	responseData.status ??= status ?? 200;
+	return responseData;
+}
+
 async function http(request: Request, nextHandler) {
 	const headersObject = request.headers.asObject;
 	const isSse = headersObject.accept === 'text/event-stream';
@@ -163,34 +199,8 @@ async function http(request: Request, nextHandler) {
 			if ((httpOptions as any).lastModified && isFinite(lastModification))
 				headers.setIfNone('Last-Modified', new Date(lastModification).toUTCString());
 		} else if (responseData.headers) {
-			// if response is a Response object, use it as the response
-			if (Object.isFrozen(responseData)) {
-				// make a copy if it is a frozen record
-				responseData = Object.assign({}, responseData);
-			}
-			// merge headers from response
-			const responseHeaders = mergeHeaders(responseData.headers, headers);
-			if (responseData.headers !== responseHeaders)
-				// if we rebuilt the headers, reassign it, but we don't want to assign to a Response object (which should already
-				// have a valid Headers object) or it will throw an error
-				responseData.headers = responseHeaders;
-			// if no body, look for provided data to serialize
-			if (!responseData.body) {
-				let body: any;
-				if ('data' in responseData) {
-					// a standard Response object does not have a setter for body, so we force it
-					body = serialize(responseData.data, request, responseData);
-				} else if (responseData.body === undefined) {
-					// if there is really no body, serialize this object into the body. Note that `new Response()` creates a response
-					// with a null body, and will not fall into this branch
-					body = serialize(responseData, request, responseData);
-				}
-				if (body) {
-					responseData = { status: responseData.status, headers: responseData.headers, body };
-				}
-			}
-			responseData.status ??= status ?? 200;
-			return responseData;
+			// if response is a Response object (or response-like envelope with headers), use it as the response
+			return finalizeResponse(responseData, headers, status, request);
 		} else if (isFinite(lastModification)) {
 			etagFloat[0] = lastModification;
 			// base64 encoding of the 64-bit float encoding of the date in ms (with quotes)
@@ -244,7 +254,10 @@ async function http(request: Request, nextHandler) {
 		return responseObject;
 	} catch (error) {
 		error ??= new Error('Unknown error occurred');
-		let statusCode = error.statusCode ?? request.response.status;
+		// a thrown Response short-circuits as the response, the same as returning one
+		if (error instanceof Response) return finalizeResponse(error, headers, request.response.status, request);
+		// the HTTP status may be carried as `statusCode` (our error classes) or `status` (e.g. a thrown plain object)
+		let statusCode = error.statusCode ?? error.status ?? request.response.status;
 		if (statusCode) {
 			if (statusCode === 500) harperLogger.warn(error);
 			else harperLogger.info(error);

--- a/server/http.ts
+++ b/server/http.ts
@@ -500,15 +500,17 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 			}
 			function onError(error) {
 				const headers = error.headers;
-				const status = error.statusCode || 500;
+				// the HTTP status may be carried as `statusCode` (our error classes) or `status` (e.g. a thrown plain object)
+				const statusCode = error.statusCode ?? error.status;
+				const status = statusCode || 500;
 				try {
 					nodeResponse.writeHead(status, toWriteHeadHeaders(headers));
 				} catch {} // silently ignore errors writing headers, because they may have been set already
 				nodeResponse.end(errorToString(error));
 				logRequest(nodeRequest, status, requestId, performance.now() - startTime);
 				// a status code is interpreted as an expected error, so just info or warn, otherwise log as error
-				if (error.statusCode) {
-					if (error.statusCode === 500) harperLogger.warn(error);
+				if (statusCode) {
+					if (statusCode === 500) harperLogger.warn(error);
 					else harperLogger.info(error);
 				} else harperLogger.error(error);
 			}
@@ -745,10 +747,12 @@ function getBunHTTPServer(port: number, secure: boolean, options: ServerOptions)
 				}
 				return new Response(body, { status, headers: responseHeaders });
 			} catch (error) {
-				const status = error.statusCode || 500;
+				// the HTTP status may be carried as `statusCode` (our error classes) or `status` (e.g. a thrown plain object)
+				const statusCode = error.statusCode ?? error.status;
+				const status = statusCode || 500;
 				logBunRequest(null, status, requestId, performance.now() - startTime);
-				if (error.statusCode) {
-					if (error.statusCode === 500) harperLogger.warn(error);
+				if (statusCode) {
+					if (statusCode === 500) harperLogger.warn(error);
 					else harperLogger.info(error);
 				} else harperLogger.error(error);
 				return new Response(errorToString(error), { status });


### PR DESCRIPTION
## Summary

Three status-setting patterns from custom resource handlers silently failed (surfaced by the QA-explorer campaign and the docs work in HarperFast/documentation#534). This fixes two; the third is left as an intentional footgun.

- `throw { status: 400 }` → now **400**. The error-status read in `server/REST.ts` and both `onError` handlers in `server/http.ts` fall back to `error.status` when `error.statusCode` is absent.
- `throw new Response(body, { status: 422 })` → now **short-circuits** to that Response (status, headers, body honored) instead of a 500.
- `return { status, data }` *without* a `headers` field — **intentionally unchanged** (still 200). `status` collides with ordinary record attributes (e.g. an order's `status: 'shipped'`), so `headers` stays the disambiguator. Documented in #534.

The returned-Response handling is extracted into a shared `finalizeResponse` helper so the return path and the thrown-Response path honor status/headers/body identically.

## Where to look

- **Transaction semantics of a thrown Response** (`server/REST.ts` catch path). A thrown Response aborts the transaction like any other throw — a write before the throw **rolls back** — and the Response is surfaced from the outer catch. This is deliberate ("throw = rollback"; `return` a Response to commit). Codex's cross-model review flagged the alternative (committing a thrown Response) as the risk; we chose rollback for invariant-simplicity and zero hot-path cost. New test `4d` guards it: a POST that writes then throws a 201 Response returns 201 but the row is gone (`Kv` readback 404).
- **`error.status` aliasing** in the two `http.ts` `onError` handlers — applied for symmetry so the behavior is uniform across the REST and http error paths.

## Testing

`integrationTests/resources/resource-status-contract.test.ts` (the existing F-039 regression marker) updated to assert the new behavior + the rollback guard — 7/7 green locally. Full unit suites run in CI.

## Review notes

- Cross-model review: Codex leg ran and surfaced the transaction-rollback consideration (resolved by the rollback-guard test + the deliberate B semantic above). The Gemini/`agy` leg was unavailable in the environment (returned empty/timed out) — no second outside-model pass beyond Codex.

Refs #1402. Docs: HarperFast/documentation#534.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-4-8[1m])