### PR TITLE
chore(ci): bump ai-review-prompts to 1bbc562 (week-of-06-15 calibration + log-count fix)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,7 +33,7 @@ jobs:
     # Note: the `claude-review` label name is matched there too —
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@9eb635a9221ffcc1e467016b525a7655277d2d6c # main 2026-06-15 (post #59 — week-of-06-08 calibration: mechanical-diff no-log gate, setup/teardown-leak + undefined-context robustness, commit/replication atomicity)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@1bbc562d57d131363586fdde3e893380381f455e # main 2026-06-24 (#67 week-of-06-15 calibration: error/abort-path rule + throwaway/inert-CI-config ignore; #69 log finding-count fix)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (layer files + bash
@@ -44,7 +44,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 9eb635a9221ffcc1e467016b525a7655277d2d6c
+      ai-review-prompts-ref: 1bbc562d57d131363586fdde3e893380381f455e
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -52,7 +52,7 @@ jobs:
     # Note: the `gemini-review` label name is matched there too —
     # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@9eb635a9221ffcc1e467016b525a7655277d2d6c # main 2026-06-15 (post #59 — week-of-06-08 calibration: mechanical-diff no-log gate, setup/teardown-leak + undefined-context robustness, commit/replication atomicity)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@1bbc562d57d131363586fdde3e893380381f455e # main 2026-06-24 (#67 week-of-06-15 calibration: error/abort-path rule + throwaway/inert-CI-config ignore; #69 log finding-count fix)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -70,7 +70,7 @@ jobs:
       # duplication is unavoidable: reusable workflows can't introspect
       # their own ref (`github.workflow_ref` resolves to the CALLER's
       # ref in workflow_call context), and `uses: …@<ref>` is literal.
-      ai-review-prompts-ref: 9eb635a9221ffcc1e467016b525a7655277d2d6c
+      ai-review-prompts-ref: 1bbc562d57d131363586fdde3e893380381f455e
       review-layers: |
         universal
         harper/common


### PR DESCRIPTION
## What

Bumps the **claude-review** and **gemini-review** caller workflows from `9eb635a` (week-of-06-08 prompts) to ai-review-prompts main **`1bbc562`** — two calibrations in one move:

- **[#67](https://github.com/HarperFast/ai-review-prompts/pull/67)** — week-of-06-15 calibration: a new **"error/abort paths that crash or leak"** Robustness rule; an **"explicitly-throwaway / empty-diff PRs"** ignore bullet; and the mechanical-diff ignore narrowed to **inert** CI-config with a workflow-security carve-out (permissions / triggers / secrets / job-structure stay reviewable).
- **[#69](https://github.com/HarperFast/ai-review-prompts/pull/69)** — log-review **finding-count fix**: a finding-bearing review is no longer recorded in ai-review-log as "no blockers" when the count is spelled out (`One blocker found.`) or delivered inline (ai-review-log #683), plus the symmetric no-blockers-guard hardening.

`uses:` and `ai-review-prompts-ref:` move in lockstep to the same immutable SHA. Only the two review callers change; the mention / issue-to-pr / validate callers are unrelated and untouched.

## Why now / canary

harper is the **canary** for this batch — highest review traffic, so the count-fix and the new rules get exercised fastest — before rolling the same bump to harper-pro / oauth / nextjs. Conveniently, **this PR's own review run executes the newly-pinned workflow**, so the Claude + Gemini reviews on this PR are themselves the first live test of `1bbc562`.

## Check after merge

- The review comments on this PR ran against the new prompts.
- The corresponding ai-review-log entries carry the correct title (no finding-bearing review mislabeled "no blockers").

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
