### PR TITLE
fix(encoder): heal a diverged shared-structures dictionary on decode (durable-wins reload)

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -57,6 +57,39 @@ export function isMissingStructureError(error: any): boolean {
 		(message.startsWith(MISSING_TYPED_STRUCTURE_PREFIX) || message.startsWith(MISSING_CLASSIC_STRUCTURE_PREFIX))
 	);
 }
+
+// A "present-but-wrong" decode: the record references a shared-structure id that EXISTS in this
+// encoder's in-memory dictionary but maps to a DIFFERENT shape than the one it was encoded against
+// (the in-memory dictionary diverged from the canonical durable order). msgpackr surfaces this as a
+// length/shape mismatch — NOT a missing-structure error — so it never triggers msgpackr's missing-id
+// reload, and the encoder reads garbage / over-reads forever. Distinct from isMissingStructureError.
+const STRUCTURE_MISMATCH_MESSAGES = ['Unexpected end of MessagePack data', 'Data read, but end of buffer not reached'];
+export function isStructureMismatchError(error: any): boolean {
+	const message = error?.message;
+	return typeof message === 'string' && STRUCTURE_MISMATCH_MESSAGES.some((m) => message.includes(m));
+}
+
+// Extract the classic/named shared-structures array from any durable representation: a bare array
+// (classic-only), a Map / plain object carrying a `named` entry (typed tables persist
+// `{named, typed}`), or undefined.
+function namedStructures(dict: any): any[] {
+	if (!dict) return [];
+	if (Array.isArray(dict)) return dict;
+	if (dict instanceof Map) return dict.get('named') ?? [];
+	return dict.named ?? [];
+}
+
+// True iff `next` preserves every shape `existing` already published at each shared id — i.e. the
+// append-only invariant holds. A same-length-but-reordered dictionary is NOT a faithful extension.
+export function isFaithfulExtension(existing: any, next: any): boolean {
+	const a = namedStructures(existing);
+	const b = namedStructures(next);
+	for (let i = 0; i < a.length; i++) {
+		if (a[i] && JSON.stringify(a[i]) !== JSON.stringify(b[i])) return false;
+	}
+	return true;
+}
+const STRUCTURE_RELOAD_RECOVERED_METRIC = 'decode-structure-reload-recovered';
 export type Entry = {
 	key: any;
 	value: any;
@@ -114,7 +147,10 @@ export class RecordEncoder extends StructonEncoder {
 	declare saveStructures: any;
 	declare getStructures: any;
 	declare _writeStruct: any;
+	declare _mergeStructures: any;
 	structureUpdate?: any;
+	// Reentrancy guard for the durable-wins reload-and-retry in decode() (one retry per decode).
+	_reloadingStructures?: boolean;
 	isRocksDB: boolean;
 	name: string;
 	useVersions: boolean;
@@ -280,13 +316,25 @@ export class RecordEncoder extends StructonEncoder {
 				const committed = this.rootStore.transactionSync(
 					(txn) => {
 						const sharedStructuresKey = [Symbol.for('structures'), this.name];
-						const existingStructuresBuffer = txn.getBinarySync(sharedStructuresKey);
+						// Read the LATEST committed structures (fresh), not the txn's start-snapshot. A
+						// concurrent worker may have committed since this txn began; the compatibility check
+						// below must see that, or it compares against a stale dictionary and admits a divergent
+						// write. Mirrors rocksdb-js's own saveStructures, which deliberately avoids the txn read.
+						const existingStructuresBuffer = this.rootStore.getBinarySync(sharedStructuresKey);
 						const existingStructures = existingStructuresBuffer ? this.decode(existingStructuresBuffer) : undefined;
 						if (typeof isCompatible == 'function') {
 							if (!isCompatible(existingStructures)) {
 								return false;
 							}
 						} else if (existingStructures && existingStructures.length !== isCompatible) {
+							return false;
+						}
+						// Enforce the append-only invariant. The length-only checks above admit a dictionary
+						// that is the same length as durable but assigns a shared id to a DIFFERENT shape (a
+						// divergent encounter order). Committing it would clobber a peer's published order and
+						// silently corrupt every record already referencing it. Reject so msgpackr reloads the
+						// durable dictionary and rebuilds on top instead of overwriting it.
+						if (!isFaithfulExtension(existingStructures, structures)) {
 							return false;
 						}
 						txn.putSync(sharedStructuresKey, structures);
@@ -445,6 +493,27 @@ export class RecordEncoder extends StructonEncoder {
 					'data: ' + hexPreview
 				);
 				return null;
+			}
+			// A "present-but-wrong" decode (isStructureMismatchError): this encoder's in-memory shared
+			// structures diverge from the canonical durable order — e.g. the replication-apply / full-copy
+			// re-encode path builds its own encounter-order dictionary off the saveStructures CAS, so a
+			// read-heavy worker strands a divergent dictionary. msgpackr only auto-reloads on a *missing*
+			// id (and its decode-time merge is in-memory-wins), so this never self-heals: every read of the
+			// affected ids returns null. Reload the durable dictionary AUTHORITATIVELY (durable-wins, via the
+			// one-arg _mergeStructures) and retry once. The reentrancy guard prevents looping when the
+			// reload does not resolve it (genuinely corrupt bytes), in which case we fall through to null.
+			if (!this._reloadingStructures && isStructureMismatchError(error)) {
+				this._reloadingStructures = true;
+				try {
+					this._mergeStructures(this.getStructures());
+					const recovered = this.decode(buffer, options);
+					recordAction(true, STRUCTURE_RELOAD_RECOVERED_METRIC, this.name ?? this.rootStore?.name);
+					return recovered;
+				} catch {
+					// Reload did not resolve it — fall through to the generic error path below.
+				} finally {
+					this._reloadingStructures = false;
+				}
 			}
 			harperLogger.error('Error decoding record', error, 'data: ' + hexPreview);
 			return null;

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -75,8 +75,11 @@ export function isStructureMismatchError(error: any): boolean {
 function namedStructures(dict: any): any[] {
 	if (!dict) return [];
 	if (Array.isArray(dict)) return dict;
-	if (dict instanceof Map) return dict.get('named') ?? [];
-	return dict.named ?? [];
+	if (dict instanceof Map) {
+		const named = dict.get('named');
+		return Array.isArray(named) ? named : [];
+	}
+	return Array.isArray(dict.named) ? dict.named : [];
 }
 
 // True iff `next` preserves every shape `existing` already published at each shared id — i.e. the
@@ -509,8 +512,10 @@ export class RecordEncoder extends StructonEncoder {
 					const recovered = this.decode(buffer, options);
 					recordAction(true, STRUCTURE_RELOAD_RECOVERED_METRIC, this.name ?? this.rootStore?.name);
 					return recovered;
-				} catch {
-					// Reload did not resolve it — fall through to the generic error path below.
+				} catch (recoveryError) {
+					// Reload did not resolve it (or _mergeStructures/getStructures itself failed) — log so
+					// the real cause is visible instead of being masked by the generic mismatch error below.
+					harperLogger.warn('Structure reload recovery failed', recoveryError);
 				} finally {
 					this._reloadingStructures = false;
 				}

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -319,11 +319,15 @@ export class RecordEncoder extends StructonEncoder {
 				const committed = this.rootStore.transactionSync(
 					(txn) => {
 						const sharedStructuresKey = [Symbol.for('structures'), this.name];
-						// Read the LATEST committed structures (fresh), not the txn's start-snapshot. A
-						// concurrent worker may have committed since this txn began; the compatibility check
-						// below must see that, or it compares against a stale dictionary and admits a divergent
-						// write. Mirrors rocksdb-js's own saveStructures, which deliberately avoids the txn read.
-						const existingStructuresBuffer = this.rootStore.getBinarySync(sharedStructuresKey);
+						// Read through the transaction (not this.rootStore) so this read participates in the
+						// txn's optimistic-conflict tracking: a concurrent committer of the same key then makes
+						// THIS txn's commit fail (retryOnBusy re-runs the callback with a fresh txn/read), so the
+						// compatibility check always converges on the latest durable state without ever letting
+						// two concurrent writers both believe they're appending compatibly. Reading via
+						// this.rootStore (untracked by the txn) previously let RocksDB commit both writers'
+						// CAS transactions with neither detecting the other, silently dropping one side's
+						// structure — see HarperFast/harper#1506 (lost disjoint-field PATCH updates).
+						const existingStructuresBuffer = txn.getBinarySync(sharedStructuresKey);
 						const existingStructures = existingStructuresBuffer ? this.decode(existingStructuresBuffer) : undefined;
 						if (typeof isCompatible == 'function') {
 							if (!isCompatible(existingStructures)) {

--- a/unitTests/resources/recordEncoder.test.js
+++ b/unitTests/resources/recordEncoder.test.js
@@ -1,6 +1,11 @@
 require('../testUtils');
 const assert = require('assert');
-const { RecordEncoder, isMissingStructureError } = require('#src/resources/RecordEncoder');
+const {
+	RecordEncoder,
+	isMissingStructureError,
+	isStructureMismatchError,
+	isFaithfulExtension,
+} = require('#src/resources/RecordEncoder');
 const harperLogger = require('#src/utility/logging/harper_logger');
 const { Encoder } = require('msgpackr');
 
@@ -150,5 +155,75 @@ describe('RecordEncoder missing-structure handling (harper#1163)', () => {
 		assert.strictEqual(enc.decode(truncated), null, 'corrupt (non-structure) decode should still return null');
 		assert.strictEqual(errors.length, 1, 'genuine corruption should use the generic error path');
 		assert.strictEqual(warnings.length, 0, 'genuine corruption should not use the missing-structure warning');
+	});
+});
+
+describe('RecordEncoder present-but-wrong recovery (durable-wins reload)', () => {
+	let errors, restoreError, restoreWarn;
+	beforeEach(() => {
+		errors = [];
+		restoreError = harperLogger.error;
+		restoreWarn = harperLogger.warn;
+		harperLogger.error = (...a) => errors.push(a);
+		harperLogger.warn = () => {};
+	});
+	afterEach(() => {
+		harperLogger.error = restoreError;
+		harperLogger.warn = restoreWarn;
+	});
+
+	const oneField = { a: 1 };
+	const threeField = { x: 1, y: 2, z: 3 };
+
+	it('heals a diverged in-memory dictionary by reloading durable (durable-wins) and retrying', () => {
+		// Canonical durable order: id0 = ['a'], id1 = ['x','y','z'] (the writer's encounter order).
+		const canonical = sharedStore();
+		const writer = makeEncoder(false, canonical);
+		writer.encode(oneField);
+		writer.encode(threeField);
+		const recordOneField = Buffer.from(writer.encode(oneField)); // references id0 = ['a'] (1 field)
+
+		// Reader builds its OWN divergent in-memory order from an empty store — the off-CAS minting the
+		// replication-apply path does — assigning id0 = ['x','y','z'] (the opposite order).
+		const reader = makeEncoder(false, sharedStore());
+		reader.encode(threeField); // reader in-memory id0 = ['x','y','z']
+		reader.encode(oneField); // reader in-memory id1 = ['a']
+		// Its authoritative durable, however, is the canonical order (what every other node committed).
+		reader.getStructures = canonical.get;
+
+		// Decoding a record written against the canonical order over-reads (id0 is a 3-field shape in
+		// memory vs the 1-field record) → a present-but-wrong structure-mismatch error. Without recovery
+		// this returns null forever; with it, the reader reloads canonical durable and heals.
+		const decoded = reader.decode(recordOneField);
+		assert.deepStrictEqual(decoded, oneField, 'diverged read should heal to the correct record');
+		assert.strictEqual(errors.length, 0, 'recovery should succeed without falling to the generic error path');
+	});
+
+	it('classifies present-but-wrong errors distinctly from missing-structure errors', () => {
+		assert.ok(isStructureMismatchError(new Error('Unexpected end of MessagePack data')));
+		assert.ok(isStructureMismatchError(new Error('Data read, but end of buffer not reached 64')));
+		assert.ok(!isStructureMismatchError(new Error('Could not find typed structure 1')));
+		assert.ok(!isStructureMismatchError(new Error('Record id is not defined for 42')));
+		assert.ok(!isStructureMismatchError(undefined));
+		// the two classifiers are mutually exclusive over the dependency's terminal messages
+		assert.ok(!isMissingStructureError(new Error('Unexpected end of MessagePack data')));
+	});
+
+	it('isFaithfulExtension accepts append-only growth but rejects a same-length reorder', () => {
+		const base = [['a'], ['x', 'y', 'z']];
+		assert.ok(isFaithfulExtension(base, [['a'], ['x', 'y', 'z'], ['n']]), 'appending on top is faithful');
+		assert.ok(isFaithfulExtension(undefined, [['a']]), 'seeding from empty is faithful');
+		assert.ok(!isFaithfulExtension(base, [['x', 'y', 'z'], ['a']]), 'a same-length reorder is NOT faithful');
+		assert.ok(!isFaithfulExtension(base, [['a']]), 'dropping a published id is NOT faithful');
+		// the {named, typed} Map form (typed tables) is unwrapped before comparison
+		const mapBase = new Map([
+			['named', base],
+			['typed', []],
+		]);
+		const mapNext = new Map([
+			['named', [['x', 'y', 'z'], ['a']]],
+			['typed', []],
+		]);
+		assert.ok(!isFaithfulExtension(mapBase, mapNext), 'reorder detected through the {named,typed} map form');
 	});
 });


### PR DESCRIPTION
## Status: defense-in-depth (held) — root cause now fixed by #1520

The v4→v5 structure-dictionary fork's **root cause** is the migration not persisting the canonical seed: `copyDb`'s `shapeForStructure` stubbed the `RecordObject`s the migration reads (`value.constructor === Object` gate), so the observer minted no structure and the seed was skipped — every v5 worker then minted the dictionary from an empty durable and forked it. That's fixed at the source by **#1520**. With the seed persisted, workers adopt one canonical dictionary and don't diverge.

This PR is therefore **no longer the primary fix** — it's defense-in-depth:

- **decode-heal** (durable-wins reload on a present-but-wrong decode) — recovers any *residual* in-memory divergence **in-process, without a restart**: a worker that somehow still strands a divergent dictionary self-heals on the next decode instead of returning nulls until a restart.
- The `isFaithfulExtension` `saveStructures` guard here is **not load-bearing** — the optimistic-transaction retry + durable-wins merge already converge concurrent appends (thanks @kzyp for pushing on this). It's kept only as cheap belt-and-suspenders; if this PR is promoted it should likely be trimmed to just the decode-heal.

**Holding in draft pending evidence it's needed beyond #1520.** If residual divergence shows up in the field after #1520 ships — or we want no-restart recovery as insurance — promote (and trim) this; otherwise close it.

Superseded as the primary fix by #1520. Refs #1508, #1453.

— repositioned by KrAIs (Claude Opus 4.8)
