### PR TITLE
fix: resolve extension packages outside ROOTPATH during node_modules walk

### DIFF
--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -9,7 +9,7 @@ import {
 	rmSync,
 	symlinkSync,
 } from 'node:fs';
-import { join, basename, dirname } from 'node:path';
+import { join, basename, dirname, sep } from 'node:path';
 import { isMainThread } from 'node:worker_threads';
 import { parseDocument } from 'yaml';
 import * as env from '../utility/environment/environmentManager.ts';
@@ -407,10 +407,23 @@ export async function loadComponent(
 						componentPath = join(componentDirectory, 'components', componentName);
 					} else {
 						let containerFolder = componentDirectory;
+						const hdbBasePath = getHdbBasePath();
+						const componentInsideHdb =
+							componentDirectory === hdbBasePath ||
+							componentDirectory.startsWith(hdbBasePath + sep);
 						componentPath = join(containerFolder, 'node_modules', componentName);
 						while (!existsSync(componentPath)) {
-							containerFolder = dirname(containerFolder);
-							if (containerFolder.length < getHdbBasePath().length) {
+							const parentFolder = dirname(containerFolder);
+							if (parentFolder === containerFolder) {
+								componentPath = null;
+								break;
+							}
+							containerFolder = parentFolder;
+							if (
+								componentInsideHdb &&
+								containerFolder !== hdbBasePath &&
+								!containerFolder.startsWith(hdbBasePath + sep)
+							) {
 								componentPath = null;
 								break;
 							}


### PR DESCRIPTION
Note!!! This is _UNTESTED_. For demonstration purposes only. 

Fixes extension package resolution when an application is run via RUN_HDB_APP from outside ROOTPATH (e.g. harper run from a monorepo's apps/web).

Harper walks up from the app directory looking for node_modules/<package>, but stops when the parent path's string length drops below getHdbBasePath().length. That incorrectly aborts the walk before reaching hoisted packages at the monorepo root when the checkout path is shorter than ROOTPATH.

Symptom:

Error: Could not load component '@harperfast/nextjs' for application 'web'
due to: Unable to find package @harperfast/nextjs:@harperfast/nextjs
Node's own require.resolve('@harperfast/nextjs', { paths: ['apps/web'] }) succeeds on the same machine — only Harper's loader fails.

Example (fails on v5.1.14):

App: /Users/usrna01/some-really-long-reposiotory-01/apps/web (46 chars at repo root)
ROOTPATH: /Users/usrna01/.local/share/mise/harper/674e1c5/hdb (51 chars)
Hoisted package: …/some-really-long-reposiotory-01/node_modules/@harperfast/nextjs
Walk stops at apps/ because 46 < 51 — repo root is never checked
Example (works by accident):

App: /Users/peter/src/rl/some-really-long-reposiotory-01/apps/web
Repo root length (51) ≥ ROOTPATH length (49) — walk reaches hoisted node_modules
This explains failures that appear machine-specific despite identical Node/Harper versions, branch, and package contents.

Fix
Replace the string-length heuristic with path-prefix logic:

Apps outside ROOTPATH (RUN_HDB_APP): walk up to the filesystem root
Components inside $ROOTPATH/components/: stop at the ROOTPATH boundary (preserves existing intent)