### PR TITLE
test(integration): retry early-hints deploy on transient npm/network errors

### DIFF
--- a/integrationTests/components/early-hints.test.ts
+++ b/integrationTests/components/early-hints.test.ts
@@ -20,23 +20,46 @@ suite('Component: early-hints', (ctx: ContextWithHarper) => {
 	before(async () => {
 		await startHarper(ctx);
 
-		// `restart: true` makes Harper restart right after accepting the deploy, which on a slow
-		// runner can delay or drop the HTTP response to this call — surfacing as a fetch
-		// `HeadersTimeoutError`. That is not a deploy failure: the readiness polling below (which
-		// waits for the /hints endpoint + seed data) is the authoritative success check. So
-		// tolerate a missing/failed response here instead of failing the whole suite in `before`.
+		// Deploying the component runs its `npm install`, which on CI intermittently hits transient
+		// registry network errors (ECONNRESET / ETIMEDOUT / "Failed to install dependencies"). Retry
+		// the deploy a few times on such transient failures before giving up.
+		//
+		// Separately, `restart: true` makes Harper restart right after accepting the deploy, which on
+		// a slow runner can delay or drop the HTTP *response* — surfacing as a fetch
+		// `HeadersTimeoutError`. That is not a deploy failure: the readiness polling below (which waits
+		// for the /hints endpoint + seed data) is the authoritative success check. So after retries are
+		// exhausted we tolerate a missing/failed response and let the poll decide, rather than failing
+		// the whole suite in `before`.
+		const isTransientDeployError = (e: unknown) =>
+			/ECONNRESET|ETIMEDOUT|EAI_AGAIN|fetch failed|Failed to install dependencies|network/i.test(
+				String((e as any)?.message ?? e)
+			);
+		const DEPLOY_ATTEMPTS = 3;
 		let deployBody: any;
-		try {
-			deployBody = await sendOperation(ctx.harper, {
-				operation: 'deploy_component',
-				project: 'early-hints',
-				package: join(__dirname, '../fixtures/template-early-hints-2.0.0.tgz'),
-				restart: true,
-			});
-		} catch (e: any) {
-			// Log the full error (not just the message) so a genuine deploy failure — bad
-			// package, invalid operation — is debuggable when the readiness poll below times out.
-			console.log('[early-hints] deploy response not received; relying on readiness poll', e);
+		for (let attempt = 1; attempt <= DEPLOY_ATTEMPTS; attempt++) {
+			try {
+				deployBody = await sendOperation(ctx.harper, {
+					operation: 'deploy_component',
+					project: 'early-hints',
+					package: join(__dirname, '../fixtures/template-early-hints-2.0.0.tgz'),
+					restart: true,
+				});
+				break;
+			} catch (e: any) {
+				if (attempt < DEPLOY_ATTEMPTS && isTransientDeployError(e)) {
+					console.log(
+						`[early-hints] deploy attempt ${attempt}/${DEPLOY_ATTEMPTS} hit a transient install/network error; retrying`,
+						e
+					);
+					await new Promise((resolve) => setTimeout(resolve, 3000 * attempt));
+					continue;
+				}
+				// Non-transient, or retries exhausted: log the full error (so a genuine failure — bad
+				// package, invalid operation, sustained registry outage — is debuggable when the
+				// readiness poll later times out) and fall through to the poll.
+				console.log('[early-hints] deploy response not received; relying on readiness poll', e);
+				break;
+			}
 		}
 		if (deployBody) {
 			strictEqual(deployBody.message, 'Successfully deployed: early-hints, restarting Harper');

--- a/integrationTests/components/early-hints.test.ts
+++ b/integrationTests/components/early-hints.test.ts
@@ -30,10 +30,17 @@ suite('Component: early-hints', (ctx: ContextWithHarper) => {
 		// for the /hints endpoint + seed data) is the authoritative success check. So after retries are
 		// exhausted we tolerate a missing/failed response and let the poll decide, rather than failing
 		// the whole suite in `before`.
-		const isTransientDeployError = (e: unknown) =>
-			/ECONNRESET|ETIMEDOUT|EAI_AGAIN|fetch failed|Failed to install dependencies|network/i.test(
-				String((e as any)?.message ?? e)
-			);
+		const isTransientDeployError = (e: unknown) => {
+			const err = e as any;
+			// Check message + code, the nested `cause` (undici fetch errors wrap the real
+			// ECONNRESET/timeout there), and the stringified error — a code-only error whose
+			// message omits the code, or an undefined message (String(e) === "[object Object]"),
+			// would otherwise slip past a message-only check.
+			const haystack = [err?.message, err?.code, err?.cause?.message, err?.cause?.code, String(err)]
+				.filter(Boolean)
+				.join(' ');
+			return /ECONNRESET|ETIMEDOUT|EAI_AGAIN|fetch failed|Failed to install dependencies|network/i.test(haystack);
+		};
 		const DEPLOY_ATTEMPTS = 3;
 		let deployBody: any;
 		for (let attempt = 1; attempt <= DEPLOY_ATTEMPTS; attempt++) {


### PR DESCRIPTION
**Status: Draft** — one of the focused follow-ups for the remaining shard-5/6 flakes. **Stacked on #1504.**

## Flake

`deploy_component` runs the early-hints component's `npm install`, which on CI intermittently hits a transient registry error:

```
Failed to install dependencies for early-hints using npm default. Exit code: 1
npm error code ECONNRESET ... fetch https://registry.npmjs.org/@graphql-codegen%2ftypescript-operations: aborted
```

When that happens, the deploy fails, the readiness poll then 404s for 60s, and the whole `early-hints` suite fails in `before`. (Same registry flake also took out a v22 build.) This is genuinely transient — the correct response is to retry.

## Fix

Retry the deploy up to 3× (with backoff) on transient install/network errors (`ECONNRESET`/`ETIMEDOUT`/`EAI_AGAIN`/`fetch failed`/`Failed to install dependencies`). On exhaustion, keep the existing behavior from #1504 (log the full error, fall through to the readiness poll). So a single transient `ECONNRESET` no longer fails the suite; only a sustained registry outage does.

This composes with the #1504 deploy guard: the retry handles the transient-npm case; the guard still handles the slow-restart `HeadersTimeoutError` case.

## Validation

CI-only — transient network errors aren't reproducible on demand, and local `restart_service` is flaky. The retry path is exercised whenever the registry hiccups.

## Scope note
This is the **genuine-fix** subset of the remaining flakes. Not addressed here (separate, by design): the `drop_database` ENOLCK (infra/engine — better as an investigation issue) and the terminology job-starvation timeout (band-aid over engine-side starvation). The HNSW reindex-tolerance fix is a separate PR stacked on #1505 (same file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)