### PR TITLE
test(integration): raise per-query HNSW ef so small-graph recall is reliable

### DIFF
--- a/integrationTests/server/vector-index-integrity.test.ts
+++ b/integrationTests/server/vector-index-integrity.test.ts
@@ -226,29 +226,33 @@ async function waitFor(predicate: () => Promise<boolean>, timeoutMs = 60_000, in
 suite('HNSW vector-index data-integrity (integration)', (ctx: ContextWithHarper) => {
 	let client: any;
 
+	// All four tables are deployed by a SINGLE component with ONE worker restart in `before`.
+	// Previously every test deployed its own component and restarted the HTTP workers (~5 restarts
+	// across the suite); on slow runners that restart is the dominant per-test cost (a test doing
+	// 3 inserts still took ~265s on Windows — almost entirely restart/setup). Consolidating to one
+	// shared restart here — plus the single restart `reindex` needs for its mid-test index-add — is
+	// the bulk of this suite's wall-time. The tables use distinct names/databases so the tests stay
+	// isolated despite sharing one component; `reindex` runs last and is the only test that mutates
+	// the schema afterward, so re-asserting the others on its redeploy is a harmless no-op.
+	const PROJECT = 'vecintegsuite';
+	// ReindexTable starts WITHOUT an index — the reindex test adds it mid-test to exercise backfill.
+	const SCHEMA_INITIAL = [
+		makeSchemaWithIndex('DelEPTable', 'vecinteg1'),
+		makeSchemaWithIndex('ChurnTable', 'vecinteg2'),
+		makeSchemaWithIndex('ThreshTable', 'vecinteg3'),
+		makeSchemaWithoutIndex('ReindexTable', 'vecinteg4'),
+	].join('\n');
+	// Same schema with ReindexTable now indexed — redeployed by the reindex test to trigger backfill.
+	const SCHEMA_REINDEX_INDEXED = [
+		makeSchemaWithIndex('DelEPTable', 'vecinteg1'),
+		makeSchemaWithIndex('ChurnTable', 'vecinteg2'),
+		makeSchemaWithIndex('ThreshTable', 'vecinteg3'),
+		makeSchemaWithIndex('ReindexTable', 'vecinteg4'),
+	].join('\n');
+
 	before(async () => {
 		await startHarper(ctx, { config: {}, env: {} });
 		client = createApiClient(ctx.harper);
-	});
-
-	after(async () => {
-		await teardownHarper(ctx);
-	});
-
-	// ── Test 1: Delete-entry-point survival ─────────────────────────────────
-	test('delete-entry-point: bulk-delete including entry point leaves survivors findable', async () => {
-		// Guards fix #2: entry-point replacement scan now passes the transaction to
-		// getRange and skips the node being deleted.
-		// Pre-fix: getRange ran outside the write-set → re-elected the deleted node
-		// as EP → dangling entry point → subsequent searches returned [].
-		const DB = 'vecinteg1';
-		const TABLE = 'DelEPTable';
-		const PROJECT = 'vecintegsuite1';
-		const DIMS = 8;
-		const N = 50;
-		const SURVIVORS = 10;
-		const deleteCount = N - SURVIVORS;
-
 		await client
 			.req()
 			.send({ operation: 'add_component', project: PROJECT })
@@ -261,19 +265,29 @@ suite('HNSW vector-index data-integrity (integration)', (ctx: ContextWithHarper)
 			});
 		await client
 			.req()
-			.send({
-				operation: 'set_component_file',
-				project: PROJECT,
-				file: 'schema.graphql',
-				payload: makeSchemaWithIndex(TABLE, DB),
-			})
+			.send({ operation: 'set_component_file', project: PROJECT, file: 'schema.graphql', payload: SCHEMA_INITIAL })
 			.expect(200);
+		// One restart loads all four tables; probing one ready endpoint confirms the workers are back.
+		await restartHttpWorkers(client, '/DelEPTable/');
+	});
 
-		await restartHttpWorkers(client, `/${TABLE}/`);
+	after(async () => {
+		await teardownHarper(ctx);
+	});
 
+	// ── Test 1: Delete-entry-point survival ─────────────────────────────────
+	test('delete-entry-point: bulk-delete including entry point leaves survivors findable', async () => {
+		// Guards fix #2: entry-point replacement scan now passes the transaction to
+		// getRange and skips the node being deleted.
+		// Pre-fix: getRange ran outside the write-set → re-elected the deleted node
+		// as EP → dangling entry point → subsequent searches returned [].
+		const DIMS = 8;
+		const N = 50;
+		const SURVIVORS = 10;
+		const deleteCount = N - SURVIVORS;
 		const httpURL = ctx.harper.httpURL;
 		const headers = client.headers;
-		const path = `/${TABLE}/`;
+		const path = '/DelEPTable/';
 
 		// Insert N records — the first-inserted node becomes the initial entry point.
 		for (let i = 0; i < N; i++) {
@@ -312,38 +326,12 @@ suite('HNSW vector-index data-integrity (integration)', (ctx: ContextWithHarper)
 		// where the old connection existed, not the full 0..l sweep (correct for DELETE).
 		// The broader sweep destroyed reverse edges that addConnection had just re-added,
 		// accumulating asymmetry with every re-embed round.
-		const DB = 'vecinteg2';
-		const TABLE = 'ChurnTable';
-		const PROJECT = 'vecintegsuite2';
 		const DIMS = 8;
 		const N = 30;
 		const ROUNDS = 5;
-
-		await client
-			.req()
-			.send({ operation: 'add_component', project: PROJECT })
-			.expect((r: any) => {
-				ok(
-					JSON.stringify(r.body).includes('Successfully added project') ||
-						JSON.stringify(r.body).includes('Project already exists'),
-					r.text
-				);
-			});
-		await client
-			.req()
-			.send({
-				operation: 'set_component_file',
-				project: PROJECT,
-				file: 'schema.graphql',
-				payload: makeSchemaWithIndex(TABLE, DB),
-			})
-			.expect(200);
-
-		await restartHttpWorkers(client, `/${TABLE}/`);
-
 		const httpURL = ctx.harper.httpURL;
 		const headers = client.headers;
-		const path = `/${TABLE}/`;
+		const path = '/ChurnTable/';
 
 		for (let i = 0; i < N; i++) {
 			await insertRecord(httpURL, headers, path, { id: `churn-${i}`, embedding: seedVector(i, DIMS) });
@@ -380,35 +368,9 @@ suite('HNSW vector-index data-integrity (integration)', (ctx: ContextWithHarper)
 	test('threshold queries: le includes exact boundary; le(~0) returns exact-match only', async () => {
 		// Guards fix #6b: le comparator now uses <= (was <).
 		// Pre-fix: records at exactly the threshold distance were excluded by le.
-		const DB = 'vecinteg3';
-		const TABLE = 'ThreshTable';
-		const PROJECT = 'vecintegsuite3';
-
-		await client
-			.req()
-			.send({ operation: 'add_component', project: PROJECT })
-			.expect((r: any) => {
-				ok(
-					JSON.stringify(r.body).includes('Successfully added project') ||
-						JSON.stringify(r.body).includes('Project already exists'),
-					r.text
-				);
-			});
-		await client
-			.req()
-			.send({
-				operation: 'set_component_file',
-				project: PROJECT,
-				file: 'schema.graphql',
-				payload: makeSchemaWithIndex(TABLE, DB),
-			})
-			.expect(200);
-
-		await restartHttpWorkers(client, `/${TABLE}/`);
-
 		const httpURL = ctx.harper.httpURL;
 		const headers = client.headers;
-		const path = `/${TABLE}/`;
+		const path = '/ThreshTable/';
 
 		// 2-D vectors at three well-separated cosine distances from [1,0]:
 		//   [1,0]            → distance 0      (exact; representable in float32, so exactly 0)
@@ -469,37 +431,13 @@ suite('HNSW vector-index data-integrity (integration)', (ctx: ContextWithHarper)
 		// on structural index change so runIndexing starts clean).
 		const DB = 'vecinteg4';
 		const TABLE = 'ReindexTable';
-		const PROJECT = 'vecintegsuite4';
 		const DIMS = 8;
 		const N = 40;
-
-		// Step 1: Deploy schema WITHOUT the HNSW index.
-		await client
-			.req()
-			.send({ operation: 'add_component', project: PROJECT })
-			.expect((r: any) => {
-				ok(
-					JSON.stringify(r.body).includes('Successfully added project') ||
-						JSON.stringify(r.body).includes('Project already exists'),
-					r.text
-				);
-			});
-		await client
-			.req()
-			.send({
-				operation: 'set_component_file',
-				project: PROJECT,
-				file: 'schema.graphql',
-				payload: makeSchemaWithoutIndex(TABLE, DB),
-			})
-			.expect(200);
-
-		await restartHttpWorkers(client, `/${TABLE}/`);
-
 		const httpURL = ctx.harper.httpURL;
 		const headers = client.headers;
-		const path = `/${TABLE}/`;
+		const path = '/ReindexTable/';
 
+		// Step 1: ReindexTable was deployed WITHOUT an HNSW index by the shared `before` setup.
 		// Step 2: Insert N records (plain [Float], no HNSW index yet). Bulk-insert in a
 		// single request — there is no index during insert, so per-record ordering is
 		// irrelevant here; the backfill (Step 3) builds the index from the stored rows.
@@ -526,14 +464,16 @@ suite('HNSW vector-index data-integrity (integration)', (ctx: ContextWithHarper)
 			.expect(200);
 		ok(Array.isArray(hashCheck.body) && hashCheck.body.length === 1, 'reindex-0 must exist before reindex');
 
-		// Step 3: Alter schema to ADD the HNSW index → triggers runIndexing backfill.
+		// Step 3: Alter schema to ADD the HNSW index on ReindexTable → triggers runIndexing
+		// backfill. Redeploy the full schema (the other three tables are unchanged, so this is
+		// a no-op re-assert for them); reindex runs last, so restarting them here is harmless.
 		await client
 			.req()
 			.send({
 				operation: 'set_component_file',
 				project: PROJECT,
 				file: 'schema.graphql',
-				payload: makeSchemaWithIndex(TABLE, DB),
+				payload: SCHEMA_REINDEX_INDEXED,
 			})
 			.expect(200);
 

--- a/integrationTests/server/vector-index-integrity.test.ts
+++ b/integrationTests/server/vector-index-integrity.test.ts
@@ -125,10 +125,17 @@ async function vectorSearch(
 	headers: Record<string, string>,
 	resourcePath: string,
 	target: number[],
-	opts: { limit?: number; select?: string[]; ef?: number } = {}
+	opts: { limit?: number; select?: string[]; ef?: number | null } = {}
 ): Promise<any[]> {
 	const body: any = {
-		sort: { attribute: 'embedding', target, distance: 'cosine', ef: opts.ef ?? SEARCH_EF },
+		// ef defaults to SEARCH_EF (reliable recall on the small test graphs); pass `ef: null`
+		// to omit it and exercise Harper's default auto-scaling behavior.
+		sort: {
+			attribute: 'embedding',
+			target,
+			distance: 'cosine',
+			...(opts.ef !== null ? { ef: opts.ef ?? SEARCH_EF } : {}),
+		},
 	};
 	if (opts.limit !== undefined) body.limit = opts.limit;
 	if (opts.select !== undefined) body.select = opts.select;

--- a/integrationTests/server/vector-index-integrity.test.ts
+++ b/integrationTests/server/vector-index-integrity.test.ts
@@ -360,12 +360,17 @@ suite('HNSW vector-index data-integrity (integration)', (ctx: ContextWithHarper)
 		}
 
 		// Each record's final vector is seedVector(i*100 + ROUNDS, dims).
-		// Searching for that exact vector must return it in the top-5.
+		// Searching for that exact vector must return it in the top-5. These are
+		// independent read-only searches, so run them concurrently rather than
+		// serializing N round-trips.
+		const churnResults = await Promise.all(
+			Array.from({ length: N }, (_, i) =>
+				vectorSearch(httpURL, headers, path, seedVector(i * 100 + ROUNDS, DIMS), { limit: 5 })
+			)
+		);
 		let misses = 0;
 		for (let i = 0; i < N; i++) {
-			const finalVec = seedVector(i * 100 + ROUNDS, DIMS);
-			const results = await vectorSearch(httpURL, headers, path, finalVec, { limit: 5 });
-			if (!results.some((r: any) => r.id === `churn-${i}`)) misses++;
+			if (!churnResults[i].some((r: any) => r.id === `churn-${i}`)) misses++;
 		}
 		const allowed = Math.ceil(N * 0.1);
 		ok(misses <= allowed, `expected ≤${allowed} misses after ${ROUNDS} churn rounds; got ${misses}/${N}`);
@@ -495,10 +500,18 @@ suite('HNSW vector-index data-integrity (integration)', (ctx: ContextWithHarper)
 		const headers = client.headers;
 		const path = `/${TABLE}/`;
 
-		// Step 2: Insert N records (plain [Float], no HNSW index yet).
-		for (let i = 0; i < N; i++) {
-			await insertRecord(httpURL, headers, path, { id: `reindex-${i}`, embedding: seedVector(i, DIMS) });
-		}
+		// Step 2: Insert N records (plain [Float], no HNSW index yet). Bulk-insert in a
+		// single request — there is no index during insert, so per-record ordering is
+		// irrelevant here; the backfill (Step 3) builds the index from the stored rows.
+		await client
+			.req()
+			.send({
+				operation: 'insert',
+				database: DB,
+				table: TABLE,
+				records: Array.from({ length: N }, (_, i) => ({ id: `reindex-${i}`, embedding: seedVector(i, DIMS) })),
+			})
+			.expect(200);
 
 		// Sanity-check: records exist.
 		const hashCheck = await client
@@ -537,12 +550,14 @@ suite('HNSW vector-index data-integrity (integration)', (ctx: ContextWithHarper)
 			}
 		}, 60_000);
 
-		// Step 5: All N pre-existing records must be reachable.
+		// Step 5: All N pre-existing records must be reachable. Independent read-only
+		// searches — run them concurrently rather than serializing N round-trips.
+		const reindexResults = await Promise.all(
+			Array.from({ length: N }, (_, i) => vectorSearch(httpURL, headers, path, seedVector(i, DIMS), { limit: 5 }))
+		);
 		let misses = 0;
 		for (let i = 0; i < N; i++) {
-			const vec = seedVector(i, DIMS);
-			const results = await vectorSearch(httpURL, headers, path, vec, { limit: 5 });
-			if (!results.some((r: any) => r.id === `reindex-${i}`)) misses++;
+			if (!reindexResults[i].some((r: any) => r.id === `reindex-${i}`)) misses++;
 		}
 		const allowed = Math.ceil(N * 0.1);
 		ok(misses <= allowed, `expected ≤${allowed} misses after backfill; got ${misses}/${N}`);

--- a/integrationTests/server/vector-index-integrity.test.ts
+++ b/integrationTests/server/vector-index-integrity.test.ts
@@ -104,6 +104,15 @@ function seedVector(seed: number, dims: number = 8): number[] {
 // HTTP helpers
 // ---------------------------------------------------------------------------
 
+// Per-query HNSW search ef for these tests. Harper's search ef auto-scales with √N, tuned for
+// 5K–30K-node graphs (resources/indexes/HierarchicalNavigableSmallWorld.ts); on these tiny 40–50-node
+// test graphs that auto-scaled ef under-explores, so exact-match self-vector searches intermittently
+// miss records that ARE correctly indexed — flaking the recall assertions. A per-query ef wins over the
+// auto-scale (search() resolves "per-query ef first"); sizing it above the working set makes recall
+// reliable on the small graph without weakening the tolerances. A genuinely unindexed/disconnected
+// record (a real backfill bug) is still missed regardless of ef, so the integrity guards stand.
+const SEARCH_EF = 64;
+
 /**
  * Execute a vector sort search via the HTTP QUERY method.
  * Returns an array of records sorted by ascending cosine distance.
@@ -116,10 +125,10 @@ async function vectorSearch(
 	headers: Record<string, string>,
 	resourcePath: string,
 	target: number[],
-	opts: { limit?: number; select?: string[] } = {}
+	opts: { limit?: number; select?: string[]; ef?: number } = {}
 ): Promise<any[]> {
 	const body: any = {
-		sort: { attribute: 'embedding', target, distance: 'cosine' },
+		sort: { attribute: 'embedding', target, distance: 'cosine', ef: opts.ef ?? SEARCH_EF },
 	};
 	if (opts.limit !== undefined) body.limit = opts.limit;
 	if (opts.select !== undefined) body.select = opts.select;
@@ -165,7 +174,7 @@ async function vectorThresholdSearch(
 	value: number
 ): Promise<any[]> {
 	const body = {
-		conditions: [{ attribute: 'embedding', comparator, value, target }],
+		conditions: [{ attribute: 'embedding', comparator, value, target, ef: SEARCH_EF }],
 	};
 	return queryResource(httpURL, headers, resourcePath, body);
 }


### PR DESCRIPTION
**Status: Draft** — focused fix for the HNSW recall flake in shard 5/6. **Stacked on #1505** (same file).

## Flake

The `reindex backfill` (and occasionally `delete-entry-point` / `update-churn`) recall assertions intermittently failed — e.g. on PR #1504's run, `reindex backfill` failed on v24+v26 with too many misses, even though the test is unmodified there. An exact-match self-vector search would miss records that **are** correctly indexed.

## Root cause

Harper's HNSW search `ef` **auto-scales with √N**, deliberately tuned for 5K–30K-node graphs (`resources/indexes/HierarchicalNavigableSmallWorld.ts`). On these tiny **40–50-node** test graphs the auto-scaled ef under-explores, so approximate recall drops below the tolerance — nondeterministically, depending on the graph the backfill happened to build.

## Fix

A **per-query `ef` wins** over the auto-scale (`search()` resolves per-query ef first). The vector-search helpers now pass `ef = 64` (above the working set) so the search explores essentially the whole small graph → reliable recall.

**Tolerances are left unchanged.** A genuinely unindexed/disconnected record (a real backfill bug — what these tests guard) is still missed regardless of ef, so the data-integrity assertions stand. This only removes the small-graph approximate-recall *noise*, not the guard.

## Validation

CI-only (local `restart_service` is flaky). If CI shows the `ef` field doesn't thread through the sort/condition query path, the fallback is an explicit `efConstructionSearch` on the index schema — but note that path currently stores the value as a *string* (the `@indexed` arg parser uses a string cast, not the numeric coercer), which is a separate latent bug worth its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)