### PR TITLE
chore(ci): bump ai-review-prompts to 9cf49d2 (calibration #70 + prompt-ref tracking #71)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,7 +33,7 @@ jobs:
     # Note: the `claude-review` label name is matched there too —
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@1bbc562d57d131363586fdde3e893380381f455e # main 2026-06-24 (#67 week-of-06-15 calibration: error/abort-path rule + throwaway/inert-CI-config ignore; #69 log finding-count fix)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@67d7611de07c5ed728c1606d51b8a1523ea094c4 # main 2026-06-29 (#71 record ai-review-prompts ref per log entry; on 1bbc562 = #67 calibration + #69 log-count fix)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (layer files + bash
@@ -44,7 +44,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 1bbc562d57d131363586fdde3e893380381f455e
+      ai-review-prompts-ref: 67d7611de07c5ed728c1606d51b8a1523ea094c4
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,7 +33,7 @@ jobs:
     # Note: the `claude-review` label name is matched there too —
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@67d7611de07c5ed728c1606d51b8a1523ea094c4 # main 2026-06-29 (#71 record ai-review-prompts ref per log entry; on 1bbc562 = #67 calibration + #69 log-count fix)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@9cf49d23cb046ecd6c87f3bba86dc3338d6998fb # main 2026-06-29 (#70 week-of-06-22 calibration + #71 prompt-ref tracking; on 1bbc562 = #67 + #69)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (layer files + bash
@@ -44,7 +44,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 67d7611de07c5ed728c1606d51b8a1523ea094c4
+      ai-review-prompts-ref: 9cf49d23cb046ecd6c87f3bba86dc3338d6998fb
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -52,7 +52,7 @@ jobs:
     # Note: the `gemini-review` label name is matched there too —
     # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@1bbc562d57d131363586fdde3e893380381f455e # main 2026-06-24 (#67 week-of-06-15 calibration: error/abort-path rule + throwaway/inert-CI-config ignore; #69 log finding-count fix)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@67d7611de07c5ed728c1606d51b8a1523ea094c4 # main 2026-06-29 (#71 record ai-review-prompts ref per log entry; on 1bbc562 = #67 calibration + #69 log-count fix)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -70,7 +70,7 @@ jobs:
       # duplication is unavoidable: reusable workflows can't introspect
       # their own ref (`github.workflow_ref` resolves to the CALLER's
       # ref in workflow_call context), and `uses: …@<ref>` is literal.
-      ai-review-prompts-ref: 1bbc562d57d131363586fdde3e893380381f455e
+      ai-review-prompts-ref: 67d7611de07c5ed728c1606d51b8a1523ea094c4
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -52,7 +52,7 @@ jobs:
     # Note: the `gemini-review` label name is matched there too —
     # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@67d7611de07c5ed728c1606d51b8a1523ea094c4 # main 2026-06-29 (#71 record ai-review-prompts ref per log entry; on 1bbc562 = #67 calibration + #69 log-count fix)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@9cf49d23cb046ecd6c87f3bba86dc3338d6998fb # main 2026-06-29 (#70 week-of-06-22 calibration + #71 prompt-ref tracking; on 1bbc562 = #67 + #69)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -70,7 +70,7 @@ jobs:
       # duplication is unavoidable: reusable workflows can't introspect
       # their own ref (`github.workflow_ref` resolves to the CALLER's
       # ref in workflow_call context), and `uses: …@<ref>` is literal.
-      ai-review-prompts-ref: 67d7611de07c5ed728c1606d51b8a1523ea094c4
+      ai-review-prompts-ref: 9cf49d23cb046ecd6c87f3bba86dc3338d6998fb
       review-layers: |
         universal
         harper/common


### PR DESCRIPTION
## What

Bumps the claude-review + gemini-review callers to ai-review-prompts main **`9cf49d2`**, landing two changes in one bump:

- **[#70](https://github.com/HarperFast/ai-review-prompts/pull/70)** — week-of-06-22 calibration: new Robustness rules (numeric coercion & range; unhandled rejection on detached async) + Harper checks (`get()` MaybePromise; worker-restart / pre-start ordering races).
- **[#71](https://github.com/HarperFast/ai-review-prompts/pull/71)** — prompt-ref tracking: each ai-review-log entry now records a `**Prompt ref:** <sha>` field + `prompt:<shortsha>` label, so calibration can attribute verdicts to a specific prompt version.

(No prompt-content change vs the already-live `1bbc562` beyond #70's calibration; `1bbc562` already carried #67 + #69.) `uses:` and `ai-review-prompts-ref:` move in lockstep. Re-pointed from the earlier `67d7611` target after #70 merged.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
