### PR TITLE
fix(migration): build the v4→v5 canonical structure seed for decoded records

### DIFF
--- a/bin/copyDb.ts
+++ b/bin/copyDb.ts
@@ -15,6 +15,7 @@ import * as hdbLogger from '../utility/logging/harper_logger.ts';
 import { RocksDatabase, type RocksDatabaseOptions } from '@harperfast/rocksdb-js';
 import { RocksIndexStore } from '../resources/RocksIndexStore.ts';
 import {
+	Blob,
 	beginPendingMigrationBlobSaves,
 	encodeBlobsWithFilePath,
 	endPendingMigrationBlobSaves,
@@ -290,14 +291,30 @@ export async function copyDb(sourceDatabase: string, targetDatabasePath: string)
 
 // Returns a skeleton of `value` that produces the same classic/named structure (key list) when
 // encoded, but stubs every leaf — strings, numbers, Buffers, Blobs, Dates, etc. — to a primitive.
-// Plain objects and arrays are recursed so nested structures (e.g. a record's `headers` object) are
-// still built. Used to build the migration's canonical structure dictionary without re-reading
-// file-backed Blob payloads (which a raw encode of the real value would pull into memory).
-function shapeForStructure(value: any): any {
+// Objects (plain AND decoded records) and arrays are recursed so nested structures (e.g. a record's
+// `headers` object) are built. The migration reads source records as RecordObject instances (the
+// encoder's structPrototype), not plain Object, so gating recursion on `constructor === Object`
+// stubbed every record to a scalar — the observer then minted no structure and the canonical seed was
+// never persisted, so v5 workers fork the dictionary from an empty durable (HarperFast/harper#1508).
+// Leaf object types (Blob, Date, Buffer/typed arrays, Map, Set) stay stubbed; a Blob especially must
+// not be walked — that would pull the file-backed payload this skeleton exists to avoid.
+export function shapeForStructure(value: any): any {
 	if (Array.isArray(value)) return value.map(shapeForStructure);
-	if (value && typeof value === 'object' && value.constructor === Object) {
+	if (
+		value &&
+		typeof value === 'object' &&
+		!(value instanceof Blob) &&
+		!(value instanceof Date) &&
+		!ArrayBuffer.isView(value) &&
+		!(value instanceof ArrayBuffer) &&
+		!(value instanceof SharedArrayBuffer) &&
+		!(value instanceof Map) &&
+		!(value instanceof Set)
+	) {
 		const out: any = {};
-		for (const k in value) out[k] = shapeForStructure(value[k]);
+		// Own enumerable keys only — match the struct fields msgpackr encodes for the real record, and
+		// don't pull enumerable prototype-chain properties into the skeleton's key set.
+		for (const k of Object.keys(value)) out[k] = shapeForStructure(value[k]);
 		return out;
 	}
 	return 1;

--- a/unitTests/bin/shapeForStructure.test.js
+++ b/unitTests/bin/shapeForStructure.test.js
@@ -1,0 +1,63 @@
+// Regression guard for the v4->v5 migration canonical-seed root cause (HarperFast/harper#1508).
+//
+// copyDb's structure observer builds the canonical v5 dictionary by encoding shapeForStructure(record)
+// for each migrated record. The migration reads source records as RecordObject instances (the encoder's
+// structPrototype), NOT plain Object. shapeForStructure used to gate recursion on
+// `value.constructor === Object`, so a RecordObject fell through to the scalar stub (1): the observer
+// then minted no structure, canonicalStructures stayed undefined, the seed was never persisted, and
+// every v5 worker forked the dictionary from an empty durable. shapeForStructure must recurse decoded
+// records (any non-leaf object) while still stubbing leaf object types (Blob/Date/typed arrays).
+const assert = require('node:assert');
+const { shapeForStructure } = require('#src/bin/copyDb');
+
+describe('shapeForStructure (#1508)', function () {
+	it('recurses a decoded record (non-plain object), not just plain Object', function () {
+		// Simulate a decoded record: a class instance (constructor !== Object) with data fields, like the
+		// RecordObject the migration actually reads. The old constructor===Object gate stubbed this to 1.
+		class RecordObject {}
+		const record = new RecordObject();
+		record.id = 'a';
+		record.name = 'n';
+		record.tags = ['x', 'y'];
+		record.nested = { level: 1, child: { k: 'v' } };
+		const shape = shapeForStructure(record);
+		assert.notEqual(shape, 1, 'a decoded record was stubbed to a scalar -> observer mints no structure (#1508)');
+		assert.deepEqual(shape, { id: 1, name: 1, tags: [1, 1], nested: { level: 1, child: { k: 1 } } });
+	});
+
+	it('still recurses plain objects and arrays', function () {
+		assert.deepEqual(shapeForStructure({ a: 1, b: { c: 2 } }), { a: 1, b: { c: 1 } });
+		assert.deepEqual(shapeForStructure([{ a: 1 }, 2]), [{ a: 1 }, 1]);
+	});
+
+	it('stubs leaf values (primitives and leaf object types) to a scalar', function () {
+		const leaves = [
+			's',
+			5,
+			true,
+			null,
+			new Date(),
+			Buffer.from('x'),
+			new Uint8Array([1]),
+			new ArrayBuffer(4),
+			new Map(),
+			new Set(),
+		];
+		if (typeof SharedArrayBuffer !== 'undefined') leaves.push(new SharedArrayBuffer(4));
+		for (const leaf of leaves) {
+			assert.equal(shapeForStructure(leaf), 1, `expected ${String(leaf)} to stub to 1`);
+		}
+		// A Blob must stay a leaf — recursing it would pull the file-backed payload shapeForStructure avoids.
+		if (typeof Blob !== 'undefined') assert.equal(shapeForStructure(new Blob(['x'])), 1, 'Blob must stub to 1');
+	});
+
+	it('uses own enumerable keys only (no prototype-chain leakage)', function () {
+		// A record whose prototype carries an enumerable property must not leak it into the skeleton's
+		// key set — that would diverge from the struct fields msgpackr encodes for the record.
+		const proto = { inheritedEnumerable: 'x' };
+		const record = Object.create(proto);
+		record.id = 'a';
+		record.value = 7;
+		assert.deepEqual(shapeForStructure(record), { id: 1, value: 1 });
+	});
+});


### PR DESCRIPTION
## Summary

`copyDb`'s structure observer seeds the canonical v5 shared-structures dictionary by encoding `shapeForStructure(record)` for each migrated record. The v4→v5 migration reads source records as **`RecordObject`** instances (the encoder's `structPrototype`), not plain `Object`, so the old gate `value.constructor === Object` stubbed every record to the scalar `1`. The observer then minted **no** structure, `canonicalStructures` stayed `undefined`, the persist guard skipped, and the canonical seed was never written. v5 workers then mint the dictionary from an empty durable in their own encounter order and **fork** it — records decode against a divergent in-memory shape (`Data read, but end of buffer not reached` / silent wrong values) under v4→v5 upgrade load.

Fix: broaden `shapeForStructure` to recurse any non-leaf object (decoded records *and* plain objects) while still stubbing leaf object types (`Blob`, `Date`, `Buffer`/typed arrays, `ArrayBuffer`, `Map`, `Set`). A `Blob` must not be walked — that would pull the file-backed payload the skeleton exists to avoid. `RecordObject`'s own-enumerable keys are exactly its data fields (methods are non-enumerable, metadata rides a WeakMap), so the seeded structure matches what msgpackr encodes for the real record.

## Why this is the fix (#1508)

This is the prevention side of the v4→v5 structure-id fork family (#1453 / #1163; #1506 is the recovery side). Root cause confirmed live: a single-node `4.7.34 → 5.1.14` migration of 300 seeded nested records logged `canonicalStructures=undefined`, `WILL_PERSIST=false`, and `shapeForStructure(record) → 1` for a real `RecordObject`. With the fix the observer mints the structures and the seed persists.

## Where to look

- `bin/copyDb.ts` `shapeForStructure` — the broadened recursion gate. The risk to weigh is **shape parity**: the skeleton must encode to the *same* struct (key set + order) msgpackr produces for the real record, or it would itself fork the dictionary. It uses own-enumerable keys (matching struct fields) and stubs leaf object types so a binary/blob/date field stays a scalar leaf.

## Tests

- `unitTests/bin/shapeForStructure.test.js` — guards the recursion (record vs plain vs leaf), own-enumerable-only iteration, and the leaf stubs. **Fails on `main`** (record → `1`), passes with the fix.
- `integrationTests/upgrade/4.x-upgrade.test.ts` (real `harperdb@4` source, runs in CI) passes with the fix — migration round-trips and records decode after cold restart (no regression). Verified locally; with the fix the migrated default CF contains the `[Symbol.for('structures'), 'widgets/']` seed.
- **End-to-end validated by a live `4.7.34 → 5.1.14` migration**: with the fix the observer mints structures and the seed persists — `canonicalStructures` is a 19-entry array, `WILL_PERSIST=true` (vs `undefined`/skipped on `main`).
- Why no dedicated unit/CI seed-assertion: every unit-harness source path (warm cache, cold reopen, fixture-via-`table()`) decodes records to plain `Object`, not the cold `RecordObject`s a real v4 source yields; and at the integration layer `copyStructures` already writes a (verbatim v4) seed on `main`, so a simple "seed exists" check can't cleanly separate the fix from `main`. The multi-worker dictionary fork the seed prevents is validated by the cluster repro. The `shapeForStructure` unit test is the clean fail-without-fix guard.

## Cross-model review

Codex + Gemini (`agy`) + a Harper-domain pass. No open blockers. Two findings were addressed in this diff: raw `ArrayBuffer`/`SharedArrayBuffer` would be walked (now excluded), and `for...in` prototype-chain leakage (now own-enumerable only). Adjudicated as not-blocking for migration data (acyclic msgpack values; `Blob` resolves to the global base; a literal `__proto__` field encodes identically on both sides): cyclic-reference recursion (pre-existing; the old code recursed objects too) and the `__proto__` own-key trap.

🤖 Generated by KrAIs (Claude Opus 4.8). LLM-authored; please review with that in mind.
