### PR TITLE
feat(models): config-selectable backends via backend: <module> (#1471)

### DIFF
--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -359,7 +359,9 @@ export async function loadComponent(
 		// config's `models:` block before any user `handleApplication(scope)` runs,
 		// so `scope.models.embed(...)` works from app-init code as well as Resource
 		// methods. Per-entry errors are logged and skipped by `bootstrapModels`.
-		if (isRoot) bootstrapModels(config);
+		// Awaited so module-backed entries (#1471) finish importing before the
+		// per-component iteration below; built-in entries register synchronously.
+		if (isRoot) await bootstrapModels(config);
 
 		if (!isRoot) {
 			try {

--- a/resources/models/bootstrap.ts
+++ b/resources/models/bootstrap.ts
@@ -110,8 +110,8 @@ async function registerKind(kind: ModelKind, entries: Record<string, ModelEntry>
 			harperLogger.error(`models.${kind}.${logicalName} is not an object; skipping`);
 			continue;
 		}
-		if (!entry.backend) {
-			harperLogger.error(`models.${kind}.${logicalName}: 'backend' is missing; skipping`);
+		if (typeof entry.backend !== 'string' || entry.backend.length === 0) {
+			harperLogger.error(`models.${kind}.${logicalName}: 'backend' must be a non-empty string; skipping`);
 			continue;
 		}
 		// Warn before expansion: literal credentials in `harperdb-config.yaml`

--- a/resources/models/bootstrap.ts
+++ b/resources/models/bootstrap.ts
@@ -10,6 +10,12 @@
  * returns the root config and before per-component iteration, so that
  * `scope.models.embed(...)` works from `handleApplication(scope)`.
  *
+ * A `backend` value that is not a built-in name is resolved as a module
+ * specifier (a bare package, an instance-root-relative path, or an absolute
+ * path), dynamically imported, and its exported factory invoked (#1471). This
+ * makes `bootstrapModels` async; the boot site awaits it before per-component
+ * iteration so the ordering guarantee above still holds.
+ *
  * Env-var expansion: each entry's string leaves are run through
  * `expandEnvVarsDeep` before dispatch — `apiKey: ${OPENAI_API_KEY}` in YAML
  * becomes the resolved process.env value at the backend. Matches the
@@ -24,6 +30,10 @@ import { registerOllamaBackend, type OllamaBackendConfig } from '../../component
 import { registerOpenAIBackend, type OpenAIBackendConfig } from '../../components/openai/index.ts';
 import { registerAnthropicBackend, type AnthropicBackendConfig } from '../../components/anthropic/index.ts';
 import { registerBedrockBackend, type BedrockBackendConfig } from '../../components/bedrock/index.ts';
+import { isAbsolute, resolve as resolvePath } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { createRequire } from 'node:module';
+import { getHdbBasePath } from '../../utility/environment/environmentManager.ts';
 
 /**
  * Field names treated as credentials. When present in config as a literal
@@ -57,7 +67,7 @@ interface RootConfig {
 	models?: ModelsConfig;
 }
 
-type BackendRegisterFn = (args: { logicalName: string; kind: ModelKind; config: object }) => void;
+type BackendRegisterFn = (args: { logicalName: string; kind: ModelKind; config: object }) => void | Promise<void>;
 
 const FACTORIES: Record<string, BackendRegisterFn> = {
 	ollama: (args) => registerOllamaBackend({ ...args, config: args.config as OllamaBackendConfig }),
@@ -71,11 +81,11 @@ const FACTORIES: Record<string, BackendRegisterFn> = {
  * is absent or empty. Idempotent within a process: each entry overwrites any
  * prior registration under the same logical name (registry uses `.set()`).
  */
-export function bootstrapModels(rootConfig: RootConfig | undefined | null): void {
+export async function bootstrapModels(rootConfig: RootConfig | undefined | null): Promise<void> {
 	const block = rootConfig?.models;
 	if (!block) return;
-	registerKind('embedding', block.embedding);
-	registerKind('generative', block.generative);
+	await registerKind('embedding', block.embedding);
+	await registerKind('generative', block.generative);
 }
 
 function warnOnLiteralCredentials(kind: ModelKind, logicalName: string, entry: ModelEntry): void {
@@ -90,7 +100,7 @@ function warnOnLiteralCredentials(kind: ModelKind, logicalName: string, entry: M
 	}
 }
 
-function registerKind(kind: ModelKind, entries: Record<string, ModelEntry> | undefined): void {
+async function registerKind(kind: ModelKind, entries: Record<string, ModelEntry> | undefined): Promise<void> {
 	if (!entries) return;
 	for (const [logicalName, entry] of Object.entries(entries)) {
 		if (!entry || typeof entry !== 'object') {
@@ -100,19 +110,8 @@ function registerKind(kind: ModelKind, entries: Record<string, ModelEntry> | und
 			harperLogger.error(`models.${kind}.${logicalName} is not an object; skipping`);
 			continue;
 		}
-		const factory = entry.backend ? FACTORIES[entry.backend] : undefined;
-		if (!factory) {
-			// Loud because the operator opted into `models:` specifically to enable
-			// a backend — silently registering nothing is a footgun. Schema-level
-			// typo guards (`.unknown(false)` on modelEntrySchema) catch field-name
-			// typos before this point; reaching here means `backend:` itself names
-			// a type Harper doesn't ship a factory for in this version. List the
-			// known backends so operators can spot value-name typos
-			// (`backend: 'openi'` instead of `'openai'`).
-			const known = Object.keys(FACTORIES).sort().join(', ');
-			harperLogger.error(
-				`models.${kind}.${logicalName}: unknown backend '${entry.backend ?? '(missing)'}'; skipping. Known backends: ${known}.`
-			);
+		if (!entry.backend) {
+			harperLogger.error(`models.${kind}.${logicalName}: 'backend' is missing; skipping`);
 			continue;
 		}
 		// Warn before expansion: literal credentials in `harperdb-config.yaml`
@@ -126,10 +125,86 @@ function registerKind(kind: ModelKind, entries: Record<string, ModelEntry> | und
 			// don't need to know about env-var syntax. Unresolved placeholders
 			// (env var unset) pass through unchanged — backend's required-field
 			// validation catches them with a meaningful error.
-			const resolved = expandEnvVarsDeep(entry);
-			factory({ logicalName, kind, config: resolved });
+			const config = expandEnvVarsDeep(entry);
+			const builtin = FACTORIES[entry.backend];
+			if (builtin) {
+				await builtin({ logicalName, kind, config });
+			} else {
+				// Not a built-in name: treat `backend` as a module specifier (#1471).
+				await registerFromModule(kind, logicalName, entry.backend, config);
+			}
 		} catch (err) {
 			harperLogger.error(`models.${kind}.${logicalName}: registration failed (${(err as Error)?.message ?? err})`);
 		}
 	}
+}
+
+/**
+ * Resolve a non-built-in `backend` value as a module and invoke its factory (#1471).
+ *
+ * Specifier forms: a bare package name (resolved from `node_modules` — the
+ * Fabric-friendly path: install the backend as a dependency), an instance-root-
+ * relative path (`./…`, anchored to the Harper base path), or an absolute path.
+ * The module's default export — or a `register` export — is a factory of the
+ * same shape as the built-in register functions, and may be async.
+ *
+ * A name that is neither a built-in nor an importable module throws (caught and
+ * logged by the caller), with the known built-ins listed so a value-name typo
+ * (`backend: 'openi'`) still gets a helpful message.
+ *
+ * The specifier is the raw `backend` value — unlike other config leaves it is
+ * not `${VAR}`-expanded; a module specifier is not subject to env indirection.
+ */
+async function registerFromModule(
+	kind: ModelKind,
+	logicalName: string,
+	specifier: string,
+	config: object
+): Promise<void> {
+	let mod: Record<string, unknown>;
+	try {
+		mod = (await import(resolveBackendSpecifier(specifier))) as Record<string, unknown>;
+	} catch (err) {
+		const known = Object.keys(FACTORIES).sort().join(', ');
+		throw new Error(
+			`backend '${specifier}' is neither a built-in (${known}) nor an importable module: ${(err as Error)?.message ?? err}`
+		);
+	}
+	// Probe a `register` export (named, or a static / `.register` on the default
+	// export) BEFORE treating the default export as a callable: a `default class`
+	// is `typeof === 'function'` and would throw "cannot invoke without 'new'".
+	const fromDefault = mod.default as { register?: unknown } | undefined;
+	const named = typeof mod.register === 'function' ? mod.register : fromDefault?.register;
+	const factory = (
+		typeof named === 'function' ? named : typeof mod.default === 'function' ? mod.default : undefined
+	) as BackendRegisterFn | undefined;
+	if (!factory) {
+		throw new Error(
+			`backend module '${specifier}' must export a default function (or a 'register' export) that registers the backend`
+		);
+	}
+	await factory({ logicalName, kind, config });
+}
+
+/**
+ * Resolve a backend module specifier to something `import()` accepts. Relative
+ * paths anchor to the Harper instance root; absolute paths become file URLs;
+ * bare package names pass through for Node's `node_modules` resolution.
+ */
+function resolveBackendSpecifier(specifier: string): string {
+	// Relative path (`./`, `../`, and Windows `.\` `..\`): anchor to the instance root.
+	if (specifier.startsWith('.')) {
+		const base = getHdbBasePath();
+		if (!base) throw new Error('cannot resolve a relative backend path: the Harper base path is unavailable');
+		return pathToFileURL(resolvePath(base, specifier)).href;
+	}
+	if (isAbsolute(specifier)) return pathToFileURL(specifier).href;
+	// Bare package: resolve from the instance root's `node_modules` — where the
+	// operator installs the backend — not Harper's own install tree, which
+	// diverges from the instance root under a global / Docker / Fabric install.
+	// Mirrors the `createRequire`-anchored resolution in `security/jsLoader.ts`.
+	const base = getHdbBasePath();
+	if (!base) return specifier; // unknown instance root: fall back to default resolution
+	const requireFromRoot = createRequire(pathToFileURL(resolvePath(base, 'index.js')).href);
+	return pathToFileURL(requireFromRoot.resolve(specifier)).href;
 }

--- a/unitTests/resources/models/bootstrap.test.js
+++ b/unitTests/resources/models/bootstrap.test.js
@@ -83,6 +83,11 @@ describe('bootstrapModels', () => {
 		assert.throws(() => resolveEmbedding('x'), ModelBackendNotFoundError);
 	});
 
+	it('skips an entry whose backend is not a string', async () => {
+		await bootstrapModels({ models: { embedding: { x: { backend: 123, model: 'm' } } } });
+		assert.throws(() => resolveEmbedding('x'), ModelBackendNotFoundError);
+	});
+
 	it('registers multiple logical names independently', async () => {
 		await bootstrapModels({
 			models: {

--- a/unitTests/resources/models/bootstrap.test.js
+++ b/unitTests/resources/models/bootstrap.test.js
@@ -8,23 +8,24 @@ const {
 	resolveGenerative,
 	ModelBackendNotFoundError,
 } = require('#src/resources/models/backendRegistry');
+const { join } = require('node:path');
 
 describe('bootstrapModels', () => {
 	beforeEach(() => clearRegistry());
 
-	it('is a no-op when rootConfig is undefined/null', () => {
-		bootstrapModels(undefined);
-		bootstrapModels(null);
+	it('is a no-op when rootConfig is undefined/null', async () => {
+		await bootstrapModels(undefined);
+		await bootstrapModels(null);
 		assert.throws(() => resolveEmbedding('default'), ModelBackendNotFoundError);
 	});
 
-	it('is a no-op when rootConfig.models is absent', () => {
-		bootstrapModels({});
+	it('is a no-op when rootConfig.models is absent', async () => {
+		await bootstrapModels({});
 		assert.throws(() => resolveEmbedding('default'), ModelBackendNotFoundError);
 	});
 
-	it('registers an ollama embedding entry under its logical name', () => {
-		bootstrapModels({
+	it('registers an ollama embedding entry under its logical name', async () => {
+		await bootstrapModels({
 			models: {
 				embedding: {
 					fast: { backend: 'ollama', host: 'localhost:11434', model: 'nomic-embed-text' },
@@ -35,8 +36,8 @@ describe('bootstrapModels', () => {
 		assert.strictEqual(backend.name, 'ollama');
 	});
 
-	it('registers an ollama generative entry under its logical name', () => {
-		bootstrapModels({
+	it('registers an ollama generative entry under its logical name', async () => {
+		await bootstrapModels({
 			models: {
 				generative: {
 					default: { backend: 'ollama', host: 'localhost:11434', model: 'llama3.2' },
@@ -47,8 +48,8 @@ describe('bootstrapModels', () => {
 		assert.strictEqual(backend.name, 'ollama');
 	});
 
-	it('skips entries with unknown backend without throwing', () => {
-		bootstrapModels({
+	it('skips entries with unknown backend without throwing', async () => {
+		await bootstrapModels({
 			models: {
 				embedding: {
 					default: { backend: 'magic-backend', model: 'm' },
@@ -64,8 +65,8 @@ describe('bootstrapModels', () => {
 		assert.throws(() => resolveEmbedding('default'), ModelBackendNotFoundError);
 	});
 
-	it('skips entries that are not objects', () => {
-		bootstrapModels({
+	it('skips entries that are not objects', async () => {
+		await bootstrapModels({
 			models: {
 				embedding: {
 					bad: 'just a string',
@@ -77,13 +78,13 @@ describe('bootstrapModels', () => {
 		assert.throws(() => resolveEmbedding('bad'), ModelBackendNotFoundError);
 	});
 
-	it('skips entries missing a backend field', () => {
-		bootstrapModels({ models: { embedding: { x: { model: 'm' } } } });
+	it('skips entries missing a backend field', async () => {
+		await bootstrapModels({ models: { embedding: { x: { model: 'm' } } } });
 		assert.throws(() => resolveEmbedding('x'), ModelBackendNotFoundError);
 	});
 
-	it('registers multiple logical names independently', () => {
-		bootstrapModels({
+	it('registers multiple logical names independently', async () => {
+		await bootstrapModels({
 			models: {
 				generative: {
 					default: { backend: 'ollama', host: 'a:1', model: 'mA' },
@@ -103,8 +104,8 @@ describe('bootstrapModels', () => {
 			delete process.env[ENV_VAR];
 		});
 
-		it('registers an openai entry under its logical name', () => {
-			bootstrapModels({
+		it('registers an openai entry under its logical name', async () => {
+			await bootstrapModels({
 				models: {
 					generative: {
 						default: { backend: 'openai', apiKey: 'sk-test', model: 'gpt-4o-mini' },
@@ -114,9 +115,9 @@ describe('bootstrapModels', () => {
 			assert.strictEqual(resolveGenerative('default').name, 'openai');
 		});
 
-		it('resolves ${ENV_VAR} apiKey before constructing the backend', () => {
+		it('resolves ${ENV_VAR} apiKey before constructing the backend', async () => {
 			process.env[ENV_VAR] = 'sk-real-key';
-			bootstrapModels({
+			await bootstrapModels({
 				models: {
 					generative: {
 						default: { backend: 'openai', apiKey: `\${${ENV_VAR}}`, model: 'gpt-4o-mini' },
@@ -129,10 +130,10 @@ describe('bootstrapModels', () => {
 			assert.strictEqual(resolveGenerative('default').name, 'openai');
 		});
 
-		it('logs error + skips when ${ENV_VAR} apiKey is unset', () => {
+		it('logs error + skips when ${ENV_VAR} apiKey is unset', async () => {
 			// ENV_VAR is intentionally not set in this test; the placeholder
 			// stays literal and the backend constructor throws.
-			bootstrapModels({
+			await bootstrapModels({
 				models: {
 					generative: {
 						default: { backend: 'openai', apiKey: `\${${ENV_VAR}}`, model: 'gpt-4o-mini' },
@@ -143,8 +144,8 @@ describe('bootstrapModels', () => {
 			assert.throws(() => resolveGenerative('default'), { name: 'ModelBackendNotFoundError' });
 		});
 
-		it('logs error + skips when apiKey is missing entirely', () => {
-			bootstrapModels({
+		it('logs error + skips when apiKey is missing entirely', async () => {
+			await bootstrapModels({
 				models: {
 					generative: {
 						default: { backend: 'openai', model: 'gpt-4o-mini' },
@@ -154,8 +155,8 @@ describe('bootstrapModels', () => {
 			assert.throws(() => resolveGenerative('default'), { name: 'ModelBackendNotFoundError' });
 		});
 
-		it('registers ollama + openai entries side by side', () => {
-			bootstrapModels({
+		it('registers ollama + openai entries side by side', async () => {
+			await bootstrapModels({
 				models: {
 					embedding: {
 						'default': { backend: 'ollama', model: 'nomic-embed-text' },
@@ -176,8 +177,8 @@ describe('bootstrapModels', () => {
 
 	// #633 (Phase 6): anthropic + bedrock entries.
 	describe('anthropic + bedrock backends (#633)', () => {
-		it('registers an anthropic generative entry', () => {
-			bootstrapModels({
+		it('registers an anthropic generative entry', async () => {
+			await bootstrapModels({
 				models: {
 					generative: {
 						claude: { backend: 'anthropic', apiKey: 'sk-ant-test', model: 'claude-opus-4-7' },
@@ -187,8 +188,8 @@ describe('bootstrapModels', () => {
 			assert.strictEqual(resolveGenerative('claude').name, 'anthropic');
 		});
 
-		it('registers a bedrock generative entry (SDK loads lazily; construction is cheap)', () => {
-			bootstrapModels({
+		it('registers a bedrock generative entry (SDK loads lazily; construction is cheap)', async () => {
+			await bootstrapModels({
 				models: {
 					generative: {
 						'bedrock-claude': {
@@ -202,8 +203,8 @@ describe('bootstrapModels', () => {
 			assert.strictEqual(resolveGenerative('bedrock-claude').name, 'bedrock');
 		});
 
-		it('registers a bedrock embedding entry', () => {
-			bootstrapModels({
+		it('registers a bedrock embedding entry', async () => {
+			await bootstrapModels({
 				models: {
 					embedding: {
 						titan: { backend: 'bedrock', region: 'us-east-1', model: 'amazon.titan-embed-text-v2:0' },
@@ -213,8 +214,8 @@ describe('bootstrapModels', () => {
 			assert.strictEqual(resolveEmbedding('titan').name, 'bedrock');
 		});
 
-		it('logs error + skips when an anthropic embedding entry is configured (no Anthropic embed API)', () => {
-			bootstrapModels({
+		it('logs error + skips when an anthropic embedding entry is configured (no Anthropic embed API)', async () => {
+			await bootstrapModels({
 				models: {
 					embedding: {
 						oops: { backend: 'anthropic', apiKey: 'sk-ant', model: 'claude' },
@@ -224,8 +225,8 @@ describe('bootstrapModels', () => {
 			assert.throws(() => resolveEmbedding('oops'), { name: 'ModelBackendNotFoundError' });
 		});
 
-		it('all four backends side by side', () => {
-			bootstrapModels({
+		it('all four backends side by side', async () => {
+			await bootstrapModels({
 				models: {
 					embedding: {
 						local: { backend: 'ollama', model: 'nomic-embed-text' },
@@ -251,6 +252,74 @@ describe('bootstrapModels', () => {
 			assert.strictEqual(resolveGenerative('gpt').name, 'openai');
 			assert.strictEqual(resolveGenerative('claude').name, 'anthropic');
 			assert.strictEqual(resolveGenerative('bedrock-claude').name, 'bedrock');
+		});
+	});
+
+	// #1471: a non-built-in `backend` value is resolved as a module specifier.
+	describe('module backends (#1471)', () => {
+		const FIXTURES = join(__dirname, 'fixtures');
+
+		it('registers a backend from a module specifier (default-export factory)', async () => {
+			await bootstrapModels({
+				models: {
+					embedding: {
+						local: { backend: join(FIXTURES, 'embed-backend-module.cjs'), model: 'bge-test' },
+					},
+				},
+			});
+			assert.strictEqual(resolveEmbedding('local').name, 'module:bge-test');
+		});
+
+		it('skips a module that exports no usable factory', async () => {
+			await bootstrapModels({
+				models: {
+					embedding: {
+						bad: { backend: join(FIXTURES, 'no-factory-module.cjs'), model: 'm' },
+					},
+				},
+			});
+			assert.throws(() => resolveEmbedding('bad'), ModelBackendNotFoundError);
+		});
+
+		it('skips an unimportable backend specifier; a sibling built-in still registers', async () => {
+			await bootstrapModels({
+				models: {
+					embedding: {
+						nope: { backend: '@harper-test/does-not-exist', model: 'm' },
+						good: { backend: 'ollama', model: 'nomic-embed-text' },
+					},
+				},
+			});
+			assert.throws(() => resolveEmbedding('nope'), ModelBackendNotFoundError);
+			assert.strictEqual(resolveEmbedding('good').name, 'ollama');
+		});
+
+		it('registers from a module with a named `register` export', async () => {
+			await bootstrapModels({
+				models: { embedding: { r: { backend: join(FIXTURES, 'register-export-module.cjs'), model: 'm' } } },
+			});
+			assert.strictEqual(resolveEmbedding('r').name, 'module:register-export');
+		});
+
+		it('registers from a default class with a static `register` method', async () => {
+			await bootstrapModels({
+				models: { embedding: { c: { backend: join(FIXTURES, 'class-register-module.cjs'), model: 'm' } } },
+			});
+			assert.strictEqual(resolveEmbedding('c').name, 'module:class-register');
+		});
+
+		it('resolves a relative specifier against the Harper instance root', async () => {
+			const env = require('#src/utility/environment/environmentManager');
+			const prev = env.getHdbBasePath();
+			env.setHdbBasePath(FIXTURES);
+			try {
+				await bootstrapModels({
+					models: { embedding: { rel: { backend: './embed-backend-module.cjs', model: 'rel-test' } } },
+				});
+				assert.strictEqual(resolveEmbedding('rel').name, 'module:rel-test');
+			} finally {
+				env.setHdbBasePath(prev);
+			}
 		});
 	});
 });

--- a/unitTests/resources/models/fixtures/class-register-module.cjs
+++ b/unitTests/resources/models/fixtures/class-register-module.cjs
@@ -1,0 +1,17 @@
+'use strict';
+// #1471 test fixture: a default class export with a static `register` method
+// (a `typeof === 'function'` default that must NOT be called as a plain factory).
+const { registerBackend, defineBackend } = require('#src/resources/models/backendRegistry');
+
+module.exports = class TestBackendModule {
+	static register({ logicalName, kind }) {
+		registerBackend(
+			kind,
+			logicalName,
+			defineBackend({
+				name: 'module:class-register',
+				embed: async (input) => ({ status: 'completed', output: [input].flat().map(() => Float32Array.from([1])) }),
+			})
+		);
+	}
+};

--- a/unitTests/resources/models/fixtures/embed-backend-module.cjs
+++ b/unitTests/resources/models/fixtures/embed-backend-module.cjs
@@ -1,0 +1,19 @@
+'use strict';
+// #1471 test fixture: a config-selectable backend module. The default export is
+// a factory of the built-in register-function shape; it registers an embedding
+// backend via the public registerBackend / defineBackend API.
+const { registerBackend, defineBackend } = require('#src/resources/models/backendRegistry');
+
+module.exports = function register({ logicalName, kind, config }) {
+	registerBackend(
+		kind,
+		logicalName,
+		defineBackend({
+			name: `module:${config.model ?? 'test'}`,
+			embed: async (input) => {
+				const texts = Array.isArray(input) ? input : [input];
+				return { status: 'completed', output: texts.map(() => Float32Array.from([1, 2, 3])) };
+			},
+		})
+	);
+};

--- a/unitTests/resources/models/fixtures/no-factory-module.cjs
+++ b/unitTests/resources/models/fixtures/no-factory-module.cjs
@@ -1,0 +1,4 @@
+'use strict';
+// #1471 test fixture: a module that exports no usable factory, exercising the
+// "must export a default function (or a 'register' export)" guard.
+module.exports = { notAFactory: true };

--- a/unitTests/resources/models/fixtures/register-export-module.cjs
+++ b/unitTests/resources/models/fixtures/register-export-module.cjs
@@ -1,0 +1,15 @@
+'use strict';
+// #1471 test fixture: a backend module exposing a named `register` export
+// (rather than a default-export factory).
+const { registerBackend, defineBackend } = require('#src/resources/models/backendRegistry');
+
+exports.register = function register({ logicalName, kind }) {
+	registerBackend(
+		kind,
+		logicalName,
+		defineBackend({
+			name: 'module:register-export',
+			embed: async (input) => ({ status: 'completed', output: [input].flat().map(() => Float32Array.from([1])) }),
+		})
+	);
+};


### PR DESCRIPTION
## Summary

Lets an operator select a custom backend from the `models:` config — `backend: <module>` — the same way the built-ins (`ollama` / `openai` / …) are selected. `bootstrapModels` resolves a non-built-in `backend` value as a module specifier, dynamically imports it, and invokes its exported factory.

- **Bare package** (`@me/embedder`) — the Fabric-friendly path: install the backend as an app dependency, no filesystem paths; resolved from `node_modules`.
- **Instance-root-relative path** (`./backends/x.js`, anchored to `getHdbBasePath()`) — self-hosted convenience.
- **Absolute path** — escape hatch.

Module contract: the default export (or a `register` export) is a factory `({ logicalName, kind, config }) => void | Promise<void>` that registers via `registerBackend` / `defineBackend` (#1405).

## Where to look

- `resources/models/bootstrap.ts` — `registerKind` dispatches non-built-ins to `registerFromModule` (dynamic import + factory + resolution). `bootstrapModels` / `registerKind` are now **async**.
- `components/componentLoader.ts` — `await bootstrapModels(config)` before the component loop (already an async fn; the ordering guarantee — registration before any `handleApplication` — is preserved).
- Per-entry errors are still logged-and-skipped; a name that is neither a built-in nor importable lists the known built-ins, so a value typo (`backend: 'openi'`) still gets a helpful message.

## Scope / deferred

Bare-package + root-relative + absolute resolution. **Component-relative** resolution (a path relative to a specific component) needs component-scoped model config — a separate, larger change — and is deferred to a follow-up.

## Relationship

Builds on **#1405** (`registerBackend` / `defineBackend`), now **merged** — this PR is rebased onto `main` (no longer stacked). Closes #1471; part of #510.

## Review

Cross-model reviewed (Codex + Gemini + Harper domain pass) — **no blockers**. Three significant findings fixed in this PR:

- **Bare-package resolution** now anchors to the instance root via `createRequire(getHdbBasePath())`, so an operator-installed dependency resolves under a global / Docker / Fabric install — it previously resolved against Harper's own install tree, contradicting the "install as a dependency" promise.
- **Windows relative specifiers** (`.\mod.js`) are handled (`startsWith('.')`).
- **A default class with a static `register`** is no longer called as a plain function.

The "unawaited built-in factory" finding was adjudicated as style (all built-ins are synchronous) and applied anyway for consistency. Deferred: a bare-package *end-to-end* test (can't commit a `node_modules` fixture) — the `createRequire`-from-root anchoring is exercised indirectly by the unimportable-specifier and relative-resolution tests.

## Status

Draft, rebased onto `main`. Companion docs PR: **HarperFast/documentation#556**. Remaining: review + ready-flip. (CI's one failure was the unrelated `dropTableGhost` flake — re-running.)

---

Generated by an LLM (Claude Opus 4.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
