### PR TITLE
fix(mcp): enforce row-level RBAC on MCP application verb tools (#1487)

### DIFF
--- a/components/mcp/tools/application.ts
+++ b/components/mcp/tools/application.ts
@@ -6,11 +6,19 @@
  *   2. Implements the corresponding verb on its prototype.
  *
  * Tool dispatch delegates to the static `Resource.get/post/put/delete/search`
- * methods, which wrap `transactional()` internally. That means
- * `allowRead/allowCreate/allowUpdate/allowDelete` per-record predicates run
- * unchanged, and restricted-attribute writes are rejected at runtime by
- * `Table.allowUpdate` even when the input schema permits them — defense in
- * depth.
+ * methods, which wrap `transactional()` internally. That entry point runs the
+ * `allowRead/allowCreate/allowUpdate/allowDelete` per-record predicates and
+ * rejects restricted-attribute writes at runtime — the same authorization path
+ * REST flows through.
+ *
+ * For that authorization to be correct the handlers MUST dispatch on the *live*
+ * Resource class resolved from the registry at call time (see `liveResource`),
+ * never a class reference captured when the tools were registered: a component's
+ * `resources.js` subclass — which carries the row-level `allow*` overrides — is
+ * registered after this profile builds its tools and overwrites the base table
+ * entry at the same path. A captured reference would be the base table class,
+ * whose `allow*` only checks table-level RBAC, silently skipping the per-record
+ * guard REST enforces.
  */
 import { createHash } from 'node:crypto';
 import * as env from '../../../utility/environment/environmentManager.ts';
@@ -146,10 +154,17 @@ export function _setRequestTargetForTest(ctor: RequestTargetCtor | undefined): v
 	_requestTargetCtorOverride = ctor;
 }
 
+// Cache the Resources module object (not the `resources` registry itself):
+// `liveResource` calls `loadResources()` on every verb-tool invocation, so we
+// avoid repeating `require`'s path resolution on the hot path. `resources` is a
+// live binding, so reading it off the cached module each call still reflects the
+// current registry.
+let _resourcesModule: { resources?: ResourcesRegistry } | undefined;
 function loadResources(): ResourcesRegistry | undefined {
 	if (_resourcesOverride) return _resourcesOverride;
 	try {
-		return require('../../../resources/Resources').resources as ResourcesRegistry;
+		_resourcesModule ??= require('../../../resources/Resources');
+		return _resourcesModule!.resources as ResourcesRegistry;
 	} catch (err) {
 		harperLogger.trace(`MCP application tools: Resources registry unavailable (${(err as Error).message})`);
 		return undefined;
@@ -164,6 +179,29 @@ function loadRequestTarget(): RequestTargetCtor | undefined {
 		// Tests that don't use the real RequestTarget can supply a fake.
 		return undefined;
 	}
+}
+
+/**
+ * Resolve the Resource class to dispatch on for `path` from the LIVE registry at
+ * call time — never a reference captured at registration time.
+ *
+ * Why this matters for authorization: a component's `resources.js` can export a
+ * Resource subclass (`class Doc extends tables.Doc`) that overrides the row-level
+ * `allowRead/allowCreate/allowUpdate/allowDelete` predicates. That subclass is
+ * registered (overwriting the auto-generated base table entry at the same path)
+ * AFTER the MCP profile registers its tools, and its registration does not
+ * re-trigger `refreshApplicationTools`. A class reference captured at tool-build
+ * time is therefore the *base table* class, whose `allow*` only checks
+ * table-level RBAC — so a low-privilege user with table-level grants would pass
+ * while the subclass's per-record guard (which REST honors) is silently skipped.
+ * Resolving live keeps MCP dispatch in lockstep with the class REST resolves.
+ *
+ * Falls back to the registration-time class only if the registry lookup fails
+ * (e.g. the entry was removed), so a stale tool still dispatches *something*.
+ */
+function liveResource(path: string, fallback: ResourceClassLike): ResourceClassLike {
+	const entry = loadResources()?.get(path);
+	return (entry?.Resource as ResourceClassLike | undefined) ?? fallback;
 }
 
 const DEFAULT_SEARCH_LIMIT = 100;
@@ -278,10 +316,11 @@ function wrapError(toolName: string, err: unknown): ToolResult {
 
 // ─── Verb-specific handler factories ───────────────────────────────────────
 
-function makeGetHandler(toolName: string, ResourceClass: ResourceClassLike) {
+function makeGetHandler(toolName: string, path: string, capturedClass: ResourceClassLike) {
 	return async function (args: unknown, context: { user: AuthedUser }): Promise<ToolResult> {
 		const a = (args ?? {}) as Record<string, unknown>;
 		try {
+			const ResourceClass = liveResource(path, capturedClass);
 			const target = makeTarget();
 			target.id = a.id;
 			if (Array.isArray(a.get_attributes)) target.select = a.get_attributes as string[];
@@ -293,10 +332,11 @@ function makeGetHandler(toolName: string, ResourceClass: ResourceClassLike) {
 	};
 }
 
-function makeSearchHandler(toolName: string, ResourceClass: ResourceClassLike) {
+function makeSearchHandler(toolName: string, path: string, capturedClass: ResourceClassLike) {
 	return async function (args: unknown, context: { user: AuthedUser }): Promise<ToolResult> {
 		const a = (args ?? {}) as Record<string, unknown>;
 		try {
+			const ResourceClass = liveResource(path, capturedClass);
 			const target = makeTarget();
 			if (Array.isArray(a.conditions)) target.conditions = a.conditions as unknown[];
 			if (typeof a.operator === 'string') target.operator = a.operator;
@@ -341,10 +381,11 @@ async function collectRows(rawData: unknown): Promise<unknown[]> {
 	return [rawData];
 }
 
-function makeCreateHandler(toolName: string, ResourceClass: ResourceClassLike) {
+function makeCreateHandler(toolName: string, path: string, capturedClass: ResourceClassLike) {
 	return async function (args: unknown, context: { user: AuthedUser }): Promise<ToolResult> {
 		const a = (args ?? {}) as Record<string, unknown>;
 		try {
+			const ResourceClass = liveResource(path, capturedClass);
 			const target = makeTarget();
 			// Mark the target as a collection so `Resource.post` resolves the table
 			// (not a single record) and routes to `create()` — without this, the
@@ -365,11 +406,12 @@ function makeCreateHandler(toolName: string, ResourceClass: ResourceClassLike) {
 	};
 }
 
-function makeUpdateHandler(toolName: string, ResourceClass: ResourceClassLike, verb: 'put' | 'patch') {
+function makeUpdateHandler(toolName: string, path: string, capturedClass: ResourceClassLike, verb: 'put' | 'patch') {
 	return async function (args: unknown, context: { user: AuthedUser }): Promise<ToolResult> {
 		const a = (args ?? {}) as Record<string, unknown>;
 		const { id, ...rest } = a;
 		try {
+			const ResourceClass = liveResource(path, capturedClass);
 			const target = makeTarget();
 			target.id = id;
 			// Call the verb method *on* ResourceClass so `this` stays bound to the
@@ -391,10 +433,11 @@ function makeUpdateHandler(toolName: string, ResourceClass: ResourceClassLike, v
 	};
 }
 
-function makeDeleteHandler(toolName: string, ResourceClass: ResourceClassLike) {
+function makeDeleteHandler(toolName: string, path: string, capturedClass: ResourceClassLike) {
 	return async function (args: unknown, context: { user: AuthedUser }): Promise<ToolResult> {
 		const a = (args ?? {}) as Record<string, unknown>;
 		try {
+			const ResourceClass = liveResource(path, capturedClass);
 			const target = makeTarget();
 			target.id = a.id;
 			const data = await ResourceClass.delete!(target, buildContext(context.user));
@@ -576,7 +619,7 @@ function registerVerbTools(ctx: ResourceContext): number {
 			profile: 'application',
 			annotations: mergeAnnotations('get', { readOnlyHint: true }, ResourceClass),
 			visibleTo: makeVisibleTo(databaseName, tableName, 'read'),
-			handler: makeGetHandler(name, ResourceClass),
+			handler: makeGetHandler(name, path, ResourceClass),
 		});
 		count++;
 	}
@@ -591,7 +634,7 @@ function registerVerbTools(ctx: ResourceContext): number {
 			profile: 'application',
 			annotations: mergeAnnotations('search', { readOnlyHint: true }, ResourceClass),
 			visibleTo: makeVisibleTo(databaseName, tableName, 'read'),
-			handler: makeSearchHandler(name, ResourceClass),
+			handler: makeSearchHandler(name, path, ResourceClass),
 		});
 		count++;
 	}
@@ -605,7 +648,7 @@ function registerVerbTools(ctx: ResourceContext): number {
 			profile: 'application',
 			annotations: mergeAnnotations('create', {}, ResourceClass),
 			visibleTo: makeVisibleTo(databaseName, tableName, 'insert'),
-			handler: makeCreateHandler(name, ResourceClass),
+			handler: makeCreateHandler(name, path, ResourceClass),
 		});
 		count++;
 	}
@@ -621,7 +664,7 @@ function registerVerbTools(ctx: ResourceContext): number {
 			// so the observable outcome on repeat call is identical.
 			annotations: mergeAnnotations('update', { idempotentHint: true }, ResourceClass),
 			visibleTo: makeVisibleTo(databaseName, tableName, 'update'),
-			handler: makeUpdateHandler(name, ResourceClass, 'put'),
+			handler: makeUpdateHandler(name, path, ResourceClass, 'put'),
 		});
 		count++;
 	} else if (verbs.updatePatch) {
@@ -636,7 +679,7 @@ function registerVerbTools(ctx: ResourceContext): number {
 			// omitted, opt-in via static mcp.annotations.patch.idempotentHint.
 			annotations: mergeAnnotations('patch', {}, ResourceClass),
 			visibleTo: makeVisibleTo(databaseName, tableName, 'update'),
-			handler: makeUpdateHandler(name, ResourceClass, 'patch'),
+			handler: makeUpdateHandler(name, path, ResourceClass, 'patch'),
 		});
 		count++;
 	}
@@ -656,7 +699,7 @@ function registerVerbTools(ctx: ResourceContext): number {
 			// omits idempotentHint until verified end-to-end.
 			annotations: mergeAnnotations('delete', { destructiveHint: true }, ResourceClass),
 			visibleTo: makeVisibleTo(databaseName, tableName, 'delete'),
-			handler: makeDeleteHandler(name, ResourceClass),
+			handler: makeDeleteHandler(name, path, ResourceClass),
 		});
 		count++;
 	}
@@ -745,7 +788,7 @@ function registerCustomMcpTools(ResourceClass: ResourceClassLike, path: string):
 			// visibleTo filter beyond "the user is authenticated" — the runtime
 			// rejects unauthorized calls naturally.
 			visibleTo: () => true,
-			handler: makeCustomMethodHandler(def.name, ResourceClass, methodName),
+			handler: makeCustomMethodHandler(def.name, path, ResourceClass, methodName),
 		});
 		count++;
 	}
@@ -783,12 +826,15 @@ function registerCustomMcpPrompts(ResourceClass: ResourceClassLike, path: string
 	return count;
 }
 
-function makeCustomMethodHandler(toolName: string, ResourceClass: ResourceClassLike, methodName: string) {
+function makeCustomMethodHandler(toolName: string, path: string, capturedClass: ResourceClassLike, methodName: string) {
 	return async function (args: unknown, context: ToolCallContext): Promise<ToolResult> {
 		try {
 			// Instantiate per call. Component authors define custom methods on
 			// the instance side; the Harper context carries the user so any
 			// internal Resource calls the method makes pick up RBAC naturally.
+			// Resolve the live registry class (see `liveResource`) so the exported
+			// subclass's method runs, in parity with the verb tools and REST.
+			const ResourceClass = liveResource(path, capturedClass);
 			const Ctor = ResourceClass as unknown as new (id: unknown, ctx: unknown) => Record<string, unknown>;
 			const instance = new Ctor(undefined, buildContext(context.user));
 			const method = instance[methodName] as ((a: unknown, ctx: unknown) => unknown) | undefined;

--- a/integrationTests/fixtures/mcp-row-authz/config.yaml
+++ b/integrationTests/fixtures/mcp-row-authz/config.yaml
@@ -1,0 +1,11 @@
+# Fixture for MCP application-profile row-level RBAC enforcement (#1487).
+# The Doc table's resources.js subclass overrides allowRead/allowCreate/
+# allowUpdate/allowDelete to enforce owner-only access; the MCP verb tools must
+# honor those overrides (parity with REST), not just table-level RBAC.
+graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true
+databases:
+  - name: data

--- a/integrationTests/fixtures/mcp-row-authz/resources.js
+++ b/integrationTests/fixtures/mcp-row-authz/resources.js
@@ -1,0 +1,32 @@
+// Row-level RBAC overrides for the Doc table. A non-super user may only read or
+// mutate rows they own (owner === username). These are the exact per-record
+// guards REST honors; the MCP application profile must honor them too (#1487).
+
+function isSuper(user) {
+	return !!user?.role?.permission?.super_user;
+}
+
+function ownsThisRow(self, user) {
+	return self?.owner != null && user?.username != null && self.owner === user.username;
+}
+
+export class Doc extends tables.Doc {
+	allowRead(user, _target, _context) {
+		return isSuper(user) || ownsThisRow(this, user);
+	}
+
+	allowUpdate(user, _record, _context) {
+		return isSuper(user) || ownsThisRow(this, user);
+	}
+
+	allowDelete(user, _target, _context) {
+		return isSuper(user) || ownsThisRow(this, user);
+	}
+
+	// `record` may arrive as a Promise for the streamed body; resolve before use.
+	async allowCreate(user, record, _context) {
+		if (isSuper(user)) return true;
+		const body = record && typeof record.then === 'function' ? await record : record;
+		return body?.owner != null && user?.username != null && body.owner === user.username;
+	}
+}

--- a/integrationTests/fixtures/mcp-row-authz/schema.graphql
+++ b/integrationTests/fixtures/mcp-row-authz/schema.graphql
@@ -1,0 +1,8 @@
+# Doc rows carry an `owner`; the resources.js subclass restricts every verb to
+# the owner (super users always pass). @export auto-generates the MCP CRUD verb
+# tools (get_/search_/create_/update_/delete_Doc).
+type Doc @table @export {
+	id: ID @primaryKey
+	owner: String
+	payload: String
+}

--- a/integrationTests/mcp/application.test.ts
+++ b/integrationTests/mcp/application.test.ts
@@ -126,7 +126,12 @@ suite('MCP v1 application profile + operations error framing (#1317)', (ctx: Con
 
 		const got = await client.callTool({ name: 'get_WorkItem', arguments: { id: newId } });
 		ok(!got.isError, `get should succeed: ${JSON.stringify(got)}`);
-		strictEqual((got.structuredContent as { payload?: string } | undefined)?.payload, 'hello-1324');
+		// WorkItem's custom `post` stores `payload: JSON.stringify(body)`, so the
+		// round-tripped payload is the stringified create body — the same value REST
+		// returns. (MCP verb tools dispatch on the exported Resource subclass, so its
+		// custom verb methods run, in parity with REST.)
+		const gotPayload = (got.structuredContent as { payload?: string } | undefined)?.payload;
+		strictEqual(JSON.parse(gotPayload ?? '{}').payload, 'hello-1324');
 
 		const updated = await client.callTool({
 			name: 'update_WorkItem',

--- a/integrationTests/mcp/row-authz.test.ts
+++ b/integrationTests/mcp/row-authz.test.ts
@@ -1,0 +1,235 @@
+/**
+ * MCP application profile — row-level RBAC enforcement (#1487).
+ *
+ * Regression coverage for two authorization bypasses on the MCP CRUD verb tools:
+ *
+ *   - WRITE fail-open: a low-privilege user calling create_/update_/delete_<T>
+ *     succeeded and the mutation persisted even though the Resource's
+ *     allowCreate/allowUpdate/allowDelete row-level guard denied it.
+ *   - READ row-level bypass: get_/search_<T> returned rows the Resource's
+ *     allowRead guard should hide.
+ *
+ * Root cause (both): the verb-tool handlers dispatched on a Resource class
+ * captured at tool-registration time, which was the base generated table class
+ * (table-level RBAC only) rather than the component's exported subclass that
+ * carries the per-record allow* overrides. The handlers now resolve the live
+ * registry class at call time, matching what REST resolves.
+ *
+ * The fixture's `Doc` subclass restricts every verb to `owner === username`
+ * (super users pass). A `qa_writer` role grants table-level CRUD so the only
+ * thing standing between `lowuser` and another user's row is the per-record
+ * guard — exactly what must hold.
+ *
+ * MCP mounted via the config object (not .env): HARPER_SET_CONFIG's
+ * flattenObject drops empty profile objects, so a non-empty mountPath is needed.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert/strict';
+import { resolve } from 'node:path';
+
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, '../fixtures/mcp-row-authz');
+
+const LOWUSER = { username: 'mcp_authz_lowuser', password: 'LowPw-1487!' };
+const ROLE = 'mcp_authz_writer';
+
+const ADMIN_ROW = 'admin-row';
+const LOWUSER_ROW = 'lowuser-row';
+
+function basicAuth(username: string, password: string): string {
+	return `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+}
+
+interface ToolResult {
+	isError?: boolean;
+	content?: Array<{ type: string; text: string }>;
+}
+
+/** Open an MCP application-profile client authenticated as the given user. */
+async function appClient(
+	ctx: ContextWithHarper,
+	username: string,
+	password: string
+): Promise<{ client: Client; transport: StreamableHTTPClientTransport }> {
+	const transport = new StreamableHTTPClientTransport(new URL('/mcp', ctx.harper.httpURL), {
+		requestInit: { headers: { Authorization: basicAuth(username, password) } },
+	});
+	const client = new Client({ name: 'mcp-row-authz', version: '1.0.0' }, { capabilities: {} });
+	await client.connect(transport);
+	return { client, transport };
+}
+
+async function callTool(client: Client, name: string, args: Record<string, unknown>): Promise<ToolResult> {
+	return (await client.callTool({ name, arguments: args })) as ToolResult;
+}
+
+function resultText(result: ToolResult): string {
+	return result.content?.map((c) => c.text ?? '').join('') ?? '';
+}
+
+/** Operations-API call as admin (super user) — the persistence oracle. */
+async function opsAsAdmin(ctx: ContextWithHarper, body: object): Promise<any> {
+	const res = await fetch(new URL('', ctx.harper.operationsAPIURL), {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			'Authorization': basicAuth(ctx.harper.admin.username, ctx.harper.admin.password),
+		},
+		body: JSON.stringify(body),
+	});
+	const text = await res.text();
+	try {
+		return JSON.parse(text);
+	} catch {
+		return text;
+	}
+}
+
+/** Read a Doc row via the operations API (super user bypasses row-level guards). */
+async function readDoc(ctx: ContextWithHarper, id: string): Promise<any | null> {
+	const rows = await opsAsAdmin(ctx, {
+		operation: 'search_by_value',
+		schema: 'data',
+		table: 'Doc',
+		search_attribute: 'id',
+		search_value: id,
+		get_attributes: ['*'],
+	});
+	return Array.isArray(rows) && rows.length > 0 ? rows[0] : null;
+}
+
+suite('MCP application profile row-level RBAC (#1487)', (ctx: ContextWithHarper) => {
+	let admin: { client: Client; transport: StreamableHTTPClientTransport };
+	let low: { client: Client; transport: StreamableHTTPClientTransport };
+
+	before(async () => {
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+			config: { mcp: { application: { mountPath: '/mcp' } } },
+			env: {},
+		});
+
+		// Grant table-level CRUD so the only barrier is the per-record allow* guard.
+		await opsAsAdmin(ctx, {
+			operation: 'add_role',
+			role: ROLE,
+			permission: {
+				super_user: false,
+				data: {
+					tables: {
+						Doc: { read: true, insert: true, update: true, delete: true, attribute_permissions: [] },
+					},
+				},
+			},
+		});
+		await opsAsAdmin(ctx, {
+			operation: 'add_user',
+			role: ROLE,
+			username: LOWUSER.username,
+			password: LOWUSER.password,
+			active: true,
+		});
+
+		await opsAsAdmin(ctx, {
+			operation: 'insert',
+			schema: 'data',
+			table: 'Doc',
+			records: [
+				{ id: ADMIN_ROW, owner: ctx.harper.admin.username, payload: 'admin-original' },
+				{ id: LOWUSER_ROW, owner: LOWUSER.username, payload: 'lowuser-original' },
+			],
+		});
+
+		admin = await appClient(ctx, ctx.harper.admin.username, ctx.harper.admin.password);
+		low = await appClient(ctx, LOWUSER.username, LOWUSER.password);
+	});
+
+	after(async () => {
+		await admin?.transport.close();
+		await low?.transport.close();
+		await teardownHarper(ctx);
+	});
+
+	// ── WRITE: positive control — super user writes work and persist ──────────
+	test('admin create/update/delete persist (write wiring works)', async () => {
+		const id = 'admin-ctrl-row';
+		const created = await callTool(admin.client, 'create_Doc', {
+			id,
+			owner: ctx.harper.admin.username,
+			payload: 'ctrl',
+		});
+		ok(!created.isError, `admin create_Doc errored: ${resultText(created)}`);
+		ok(await readDoc(ctx, id), 'admin create_Doc did not persist');
+
+		const updated = await callTool(admin.client, 'update_Doc', {
+			id,
+			owner: ctx.harper.admin.username,
+			payload: 'ctrl-updated',
+		});
+		ok(!updated.isError, `admin update_Doc errored: ${resultText(updated)}`);
+		strictEqual((await readDoc(ctx, id))?.payload, 'ctrl-updated', 'admin update_Doc did not persist');
+
+		const deleted = await callTool(admin.client, 'delete_Doc', { id });
+		ok(!deleted.isError, `admin delete_Doc errored: ${resultText(deleted)}`);
+		strictEqual(await readDoc(ctx, id), null, 'admin delete_Doc did not persist');
+	});
+
+	// ── WRITE: low-priv user is denied and nothing persists ───────────────────
+	test('lowuser update_Doc on admin row is denied and does not persist', async () => {
+		const result = await callTool(low.client, 'update_Doc', {
+			id: ADMIN_ROW,
+			owner: ctx.harper.admin.username,
+			payload: 'LOWUSER-OVERWRITE',
+		});
+		ok(result.isError, 'lowuser update_Doc on admin row should return an MCP error');
+		strictEqual((await readDoc(ctx, ADMIN_ROW))?.payload, 'admin-original', 'denied update must not persist');
+	});
+
+	test('lowuser delete_Doc on admin row is denied and does not persist', async () => {
+		const result = await callTool(low.client, 'delete_Doc', { id: ADMIN_ROW });
+		ok(result.isError, 'lowuser delete_Doc on admin row should return an MCP error');
+		ok(await readDoc(ctx, ADMIN_ROW), 'denied delete must not remove the row');
+	});
+
+	test('lowuser create_Doc for a row owned by admin is denied and does not persist', async () => {
+		const id = 'lowuser-creates-for-admin';
+		const result = await callTool(low.client, 'create_Doc', {
+			id,
+			owner: ctx.harper.admin.username,
+			payload: 'LOWUSER-CREATE-FOR-ADMIN',
+		});
+		ok(result.isError, 'lowuser create_Doc owned-by-admin should return an MCP error');
+		strictEqual(await readDoc(ctx, id), null, 'denied create must not insert a row');
+	});
+
+	// ── WRITE: low-priv user CAN write rows it owns (guards are selective) ─────
+	test('lowuser update_Doc on its own row succeeds and persists', async () => {
+		const result = await callTool(low.client, 'update_Doc', {
+			id: LOWUSER_ROW,
+			owner: LOWUSER.username,
+			payload: 'lowuser-self-update',
+		});
+		ok(!result.isError, `lowuser update of own row should succeed: ${resultText(result)}`);
+		strictEqual((await readDoc(ctx, LOWUSER_ROW))?.payload, 'lowuser-self-update', 'own-row update must persist');
+	});
+
+	// ── READ: positive control — low-priv user reads its own row ──────────────
+	test('lowuser get_Doc on its own row returns the row', async () => {
+		const result = await callTool(low.client, 'get_Doc', { id: LOWUSER_ROW });
+		ok(!result.isError, `lowuser get of own row should succeed: ${resultText(result)}`);
+		ok(resultText(result).includes('lowuser'), 'own row should be returned');
+	});
+
+	// ── READ: low-priv user cannot read or scan rows it does not own ──────────
+	test('lowuser get_Doc on admin row leaks nothing', async () => {
+		const result = await callTool(low.client, 'get_Doc', { id: ADMIN_ROW });
+		ok(!resultText(result).includes('admin-original'), 'get_Doc must not leak a denied row');
+	});
+
+	test('lowuser search_Doc does not leak rows it does not own', async () => {
+		const result = await callTool(low.client, 'search_Doc', {});
+		ok(!resultText(result).includes('admin-original'), 'search_Doc must not leak a denied row');
+	});
+});


### PR DESCRIPTION
## Summary

The MCP application-profile CRUD verb tools (`get_`/`search_`/`create_`/`update_`/`delete_<Table>`) did not honor a Resource's **row-level** RBAC predicates (`allowRead`/`allowCreate`/`allowUpdate`/`allowDelete`). A low-privilege user with table-level grants could write rows a per-record guard denied (mutations persisted) and read rows `allowRead` should hide — while the same operations over REST were correctly rejected. This brings the MCP path into parity with REST. Fixes #1487 (write fail-open + point-read bypass; see "Known residual" for the collection-scan piece).

## Root cause

Each verb-tool handler closed over the Resource class **captured at tool-registration time**. For an `@export`ed `@table`, that captured reference is the auto-generated *base table* class, whose `allow*` predicates only evaluate **table-level** RBAC. A component's `resources.js` subclass (`class Doc extends tables.Doc`) — which carries the **row-level** `allow*` overrides — registers at the same path *after* the MCP profile builds its tools, overwriting the base entry, and that registration does not re-trigger tool refresh. So MCP kept dispatching the base class forever; no `AccessViolation` was ever raised because the base table-level guard returned `true`. REST was unaffected because it resolves the live registry entry per request.

## Fix

Resolve the **live** Resource class from the registry at call time (`liveResource(path, fallback)`) and dispatch on it, so the same authorizing path REST uses runs for every MCP verb. The fallback to the registration-time class is taken only if the registry entry is gone (graceful degradation, not a weaker guard).

## Where to look

- `components/mcp/tools/application.ts` — `liveResource` + the five verb handlers resolving it at call time; the same treatment applied to `makeCustomMethodHandler` for `mcpTools` parity.
- `integrationTests/mcp/row-authz.test.ts` + `integrationTests/fixtures/mcp-row-authz/` — new regression suite: denied create/update/delete return an MCP error **and** leave the store unchanged (verified by admin read-back); denied get/search leak nothing; admin positive controls persist; a low-priv user can still write rows it owns (guards are selective). Passes under both RocksDB and LMDB.

## Points worth a reviewer's eye

- **Behavior change beyond RBAC (intended):** because MCP now dispatches the exported subclass, a custom Resource's overridden verb methods (`post`/`put`/etc.) run for MCP calls too — this is correct REST parity, but it is a behavior change for custom resources. It surfaced as one existing assertion in `integrationTests/mcp/application.test.ts` (`#1324`): the fixture's custom `WorkItem.post` stores `payload: JSON.stringify(body)`, so the round-tripped payload now matches what REST returns; the assertion was updated to reflect that (it was previously pinning the base-table dispatch).
- **Known residual (scoped to #1487 family):** per-row `allowRead` *filtering* on collection scans depends on the shared lower-layer enforcement in #1422 / #1489 (not yet on `main`). Until that lands, `search_<T>` on a row-restricted table returns an authorization error rather than a filtered result — it does **not** leak. Routing MCP through the live authorizing dispatch means it inherits the per-row filtering automatically once #1489 merges, rather than a parallel MCP-only check.

## Cross-model review

Codex and Gemini (via the cross-model-review skill) plus a Harper-domain pass. No in-scope blockers. Two suggestions adopted: caching the `Resources` module to keep the new per-call lookup off `require`'s resolution path, and applying the same live-resolution to `makeCustomMethodHandler` for symmetry.

Generated with assistance from Claude (Opus 4.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
