### PR TITLE
fix: enforce row-level allowRead during subscription delivery (#1419)

### DIFF
--- a/integrationTests/security/fixtures/subscription-row-allowread/config.yaml
+++ b/integrationTests/security/fixtures/subscription-row-allowread/config.yaml
@@ -1,0 +1,6 @@
+# Regression fixture for #1419 — per-row allowRead must filter subscription delivery.
+graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/security/fixtures/subscription-row-allowread/resources.js
+++ b/integrationTests/security/fixtures/subscription-row-allowread/resources.js
@@ -1,0 +1,36 @@
+// Regression fixture for #1419 — per-row allowRead must filter subscription delivery.
+//
+// allowRead is designed so that:
+//   - When `this` is a loaded record (a specific row), allow only if the row's owner
+//     matches the requesting user.
+//   - When `this` is the collection (no specific record loaded, this.owner undefined/null),
+//     allow the subscription to open. This is the permissive side that lets a non-owner open
+//     a whole-table subscription — the scenario where the pre-#1419 delivery loop leaked every
+//     row's events because it never re-evaluated allowRead per record.
+//
+// Super users always pass so that seed writes and setup ops succeed.
+
+function isSuper(user) {
+	return !!user?.role?.permission?.super_user;
+}
+
+export class Vault extends tables.Vault {
+	allowRead(user, _target, _context) {
+		if (isSuper(user)) return true;
+		const owner = this?.owner;
+		// Collection subscribe / no loaded record: allow the connection to open.
+		if (owner === undefined || owner === null) return true;
+		// Per-row: only the owner can read this specific record.
+		return owner === user?.username;
+	}
+
+	allowUpdate(user, _record, _context) {
+		return isSuper(user);
+	}
+	allowCreate(user, _record, _context) {
+		return isSuper(user);
+	}
+	allowDelete(user, _target, _context) {
+		return isSuper(user);
+	}
+}

--- a/integrationTests/security/fixtures/subscription-row-allowread/schema.graphql
+++ b/integrationTests/security/fixtures/subscription-row-allowread/schema.graphql
@@ -1,0 +1,11 @@
+# Regression fixture for #1419 — per-row allowRead must filter subscription delivery.
+#
+# Vault rows are owned by a specific user (`owner` field). The allowRead override in
+# resources.js permits a read only when the record's owner matches the requesting user,
+# while still allowing the collection-level subscription to open. The test verifies that a
+# whole-table SSE subscription no longer leaks other owners' row events.
+type Vault @table @export {
+	id: ID @primaryKey
+	owner: String
+	secret: String
+}

--- a/integrationTests/security/subscription-row-allowread.test.ts
+++ b/integrationTests/security/subscription-row-allowread.test.ts
@@ -1,0 +1,249 @@
+/**
+ * #1419 — Row-level `allowRead` must filter subscription delivery.
+ *
+ * Before the fix, `Table.subscribe` evaluated `allowRead` once at connect time with `this`
+ * bound to the collection (no loaded record), so a row-level override always passed and every
+ * row's change events were delivered to any collection subscriber. The fix re-evaluates
+ * `allowRead` per record-bearing event, binding a resource instance to that row's record.
+ *
+ * Fixture: a `Vault` table whose `allowRead` allows the collection subscription to open but
+ * permits per-row reads only for the row's owner (see fixtures/subscription-row-allowread).
+ * Alice and Bob are non-admin users owning different rows.
+ *
+ *   CONTROL  — Alice's REST GET of Bob's row is denied (proves allowRead is real and the
+ *              AUTHENTICATION_AUTHORIZELOCAL loopback escape is not in play — real bearer auth).
+ *   PROBE    — Alice opens a whole-table `/Vault/` SSE subscription. Writes land on Alice's
+ *              rows, Bob's rows, and a neutral row. Alice's stream must receive ONLY her own
+ *              rows' events; Bob's and the neutral row's events must be filtered out.
+ *
+ * Reproduction:
+ *   npm run test:integration -- "integrationTests/security/subscription-row-allowread.test.ts"
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok } from 'node:assert/strict';
+import { resolve } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import http from 'node:http';
+import https from 'node:https';
+import { URL } from 'node:url';
+
+import request from 'supertest';
+
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
+import { createApiClient, createHeaders } from '../apiTests/utils/client.mjs';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'fixtures/subscription-row-allowread');
+const skipSuite = process.env.HARPER_RUNTIME === 'bun' || process.platform === 'win32';
+
+const ALICE = { username: 'sub_allowread_alice', password: 'Alice-pw-1419!' };
+const BOB = { username: 'sub_allowread_bob', password: 'Bobby-pw-1419!' };
+const ROLE = 'sub_allowread_role';
+
+const ALICE_ROWS = ['row-a1', 'row-a2', 'row-a3'];
+const BOB_ROWS = ['row-b1', 'row-b2', 'row-b3'];
+const NEUTRAL_ROW = 'row-neutral';
+
+// ---------------------------------------------------------------- SSE helpers --
+interface SseEvent {
+	data?: string;
+	id?: string;
+}
+interface SseStream {
+	events: SseEvent[];
+	status: number;
+	destroy: () => void;
+}
+
+function openSse(urlStr: string, headers: Record<string, string>): Promise<SseStream> {
+	const url = new URL(urlStr);
+	const lib = url.protocol === 'https:' ? https : http;
+	const events: SseEvent[] = [];
+	let buffer = '';
+	const parseFrame = (frame: string) => {
+		if (!frame.trim()) return;
+		const ev: SseEvent = {};
+		for (const line of frame.split('\n')) {
+			const idx = line.indexOf(':');
+			if (idx < 0) continue;
+			const field = line.slice(0, idx);
+			const val = line.slice(idx + 1).replace(/^ /, '');
+			if (field === 'data') ev.data = (ev.data ? ev.data + '\n' : '') + val;
+			else if (field === 'id') ev.id = val;
+		}
+		events.push(ev);
+	};
+	return new Promise<SseStream>((resolvePromise, reject) => {
+		const req = lib.request(
+			url,
+			{ method: 'GET', headers: { ...headers, Accept: 'text/event-stream' }, rejectUnauthorized: false } as any,
+			(res) => {
+				const stream: SseStream = {
+					events,
+					status: res.statusCode ?? 0,
+					destroy: () => {
+						res.destroy();
+						req.destroy();
+					},
+				};
+				res.setEncoding('utf8');
+				res.on('data', (chunk: string) => {
+					buffer += chunk;
+					let sep: number;
+					while ((sep = buffer.indexOf('\n\n')) >= 0) {
+						parseFrame(buffer.slice(0, sep));
+						buffer = buffer.slice(sep + 2);
+					}
+				});
+				res.on('error', () => {});
+				resolvePromise(stream);
+			}
+		);
+		req.on('error', reject);
+		req.end();
+	});
+}
+
+function streamMentions(stream: SseStream, text: string): boolean {
+	return stream.events.some((e) => (e.data ?? '').includes(text));
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 8000, intervalMs = 50): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return true;
+		await sleep(intervalMs);
+	}
+	return predicate();
+}
+
+suite('#1419 row-level allowRead filters subscription delivery', { skip: skipSuite }, (ctx: ContextWithHarper) => {
+	let client: ReturnType<typeof createApiClient>;
+	let restURL = '';
+	let aliceBearer = '';
+
+	const openStreams = new Set<SseStream>();
+
+	const adminPut = (id: string, body: object) => request(restURL).put(`/Vault/${id}`).set(client.headers).send(body);
+
+	before(async () => {
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: {}, env: {} });
+		client = createApiClient(ctx.harper);
+		restURL = ctx.harper.httpURL;
+
+		// Poll until the Vault route is ready.
+		const deadline = Date.now() + 30_000;
+		while (Date.now() < deadline) {
+			try {
+				const probe = await client.reqRest('/Vault/').timeout(3000);
+				if (probe.status !== 404) break;
+			} catch {
+				/* not ready */
+			}
+			await sleep(250);
+		}
+
+		// Non-super role with full table-level READ/WRITE on Vault → the allowRead override is the
+		// only remaining read gate.
+		await client
+			.req()
+			.send({
+				operation: 'add_role',
+				role: ROLE,
+				permission: {
+					super_user: false,
+					data: {
+						tables: {
+							Vault: { read: true, insert: true, update: true, delete: true, attribute_permissions: [] },
+						},
+					},
+				},
+			})
+			.expect(200);
+
+		for (const u of [ALICE, BOB]) {
+			await client
+				.req()
+				.send({ operation: 'add_user', role: ROLE, username: u.username, password: u.password, active: true })
+				.expect(200);
+		}
+
+		// Seed rows via the ops API (super, bypasses allowCreate).
+		const records = [
+			...ALICE_ROWS.map((id) => ({ id, owner: ALICE.username, secret: `alice-secret-${id}` })),
+			...BOB_ROWS.map((id) => ({ id, owner: BOB.username, secret: `bob-secret-${id}` })),
+			{ id: NEUTRAL_ROW, owner: 'nobody', secret: 'neutral-secret' },
+		];
+		await client.req().send({ operation: 'insert', schema: 'data', table: 'Vault', records }).expect(200);
+
+		// Obtain Alice's bearer token so the SSE Authorization header uses real auth (not the
+		// header-less AUTHORIZELOCAL loopback escape).
+		const tokenResp = await client
+			.req()
+			.send({ operation: 'create_authentication_tokens', username: ALICE.username, password: ALICE.password });
+		aliceBearer =
+			tokenResp.status === 200 && tokenResp.body?.operation_token
+				? `Bearer ${tokenResp.body.operation_token}`
+				: createHeaders(ALICE.username, ALICE.password).Authorization;
+	});
+
+	after(async () => {
+		for (const s of openStreams) {
+			try {
+				s.destroy();
+			} catch {
+				/* ignore */
+			}
+		}
+		openStreams.clear();
+		await teardownHarper(ctx);
+	});
+
+	test('CONTROL: row-level allowRead is enforced on REST (Alice denied Bob row, allowed own)', async () => {
+		const ownGet = await request(restURL).get(`/Vault/${ALICE_ROWS[0]}`).set({ Authorization: aliceBearer });
+		ok(ownGet.status === 200, `Alice must read her own row, got ${ownGet.status}: ${ownGet.text}`);
+
+		const bobGet = await request(restURL).get(`/Vault/${BOB_ROWS[0]}`).set({ Authorization: aliceBearer });
+		ok([401, 403, 404].includes(bobGet.status), `Alice GET Bob row should be denied, got ${bobGet.status}`);
+
+		// Wrong password must not auto-authorize (would indicate an AUTHORIZELOCAL escape).
+		const badGet = await request(restURL)
+			.get(`/Vault/${ALICE_ROWS[0]}`)
+			.set(createHeaders(ALICE.username, 'wrong-pw-1419'));
+		ok([401, 403].includes(badGet.status), `wrong password was accepted (status ${badGet.status})`);
+	});
+
+	test('PROBE: whole-table SSE delivers only Alice rows; Bob/neutral events are filtered', async () => {
+		const stream = await openSse(`${restURL}/Vault/`, { Authorization: aliceBearer });
+		openStreams.add(stream);
+
+		ok(stream.status >= 200 && stream.status < 300, `Alice's collection SSE should open, got ${stream.status}`);
+
+		await sleep(400); // let the subscription attach
+
+		for (const id of ALICE_ROWS) {
+			await adminPut(id, { id, owner: ALICE.username, secret: `alice-secret-${id}`, updated: true }).expect(204);
+		}
+		for (const id of BOB_ROWS) {
+			await adminPut(id, { id, owner: BOB.username, secret: `bob-secret-${id}`, updated: true }).expect(204);
+		}
+		await adminPut(NEUTRAL_ROW, { id: NEUTRAL_ROW, owner: 'nobody', secret: 'neutral-secret', updated: true }).expect(204);
+
+		// Positive control: at least one of Alice's events must arrive.
+		const gotAlice = await waitFor(() => ALICE_ROWS.some((id) => streamMentions(stream, id)), 8000);
+
+		// Give denied rows equal opportunity to leak.
+		await sleep(1500);
+
+		const bobLeak =
+			BOB_ROWS.some((id) => streamMentions(stream, id)) ||
+			streamMentions(stream, BOB.username) ||
+			streamMentions(stream, 'bob-secret');
+		const neutralLeak =
+			streamMentions(stream, NEUTRAL_ROW) || streamMentions(stream, 'neutral-secret') || streamMentions(stream, 'nobody');
+
+		ok(gotAlice, "POSITIVE CONTROL FAILED: Alice did not receive updates to her own rows on the collection subscription");
+		ok(!bobLeak, "ROW-LEVEL LEAK (#1419): Bob's row events arrived on Alice's collection subscription stream");
+		ok(!neutralLeak, "ROW-LEVEL LEAK (#1419): the neutral row's events arrived on Alice's collection subscription stream");
+	});
+});

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -3231,6 +3231,62 @@ export function makeTable(options) {
 			// listener avoids duplicate delivery.
 			let dropDuringReplay = false;
 			const thisId = requestTargetToId(request) ?? null; // treat undefined and null as the root
+			// #1419: Row-level `allowRead` is enforced on the REST read path but was historically NOT
+			// re-evaluated per event during subscription delivery. The connect-time check runs with `this`
+			// bound to the collection (no loaded record), so a row-level override always passes and every
+			// row's changes leak to any collection subscriber. Re-evaluate `allowRead` per record-bearing
+			// event below, binding a resource instance to that row's record — the delivery-path analog of
+			// the per-event value filter already applied downstream.
+			//
+			// Scope, to keep this a minimal, low-blast-radius shim:
+			//   1. Only when the resource OVERRIDES `allowRead`. The default is table/attribute-level RBAC
+			//      (record-independent) and is already enforced at connect, so re-running it per event is a
+			//      no-op — skipping it keeps zero overhead for the common case and confines this to the
+			//      legacy row-level-override pattern.
+			//   2. Only when the subscription has a user principal (`context.user`). Row-level `allowRead`
+			//      is a per-user decision, and the connect-time authorization that opened this subscription
+			//      already consumes the request's `checkPermission`/`authorize` flags before we get here, so
+			//      `context.user` is the persistent signal that this is an authorization-checked (external)
+			//      subscription. Internal subscribers — the only one today is the system `hdb_certificate`
+			//      watcher (no override, so already excluded by (1)) — and replication (which doesn't use
+			//      `subscribe` at all) have no user, so the cluster keeps replicating every row between nodes.
+			const subContext = this.getContext() as any;
+			const subUser = subContext?.user;
+			const RecordResource: any = this.constructor;
+			const filterRowReads = this.allowRead !== TableResource.prototype.allowRead && subUser != null;
+			// Returns false when the subscriber may not read this event's record. `end_txn` is a
+			// transaction-boundary control marker (no record) and always passes. Fails closed: if the
+			// override throws, the event is dropped rather than leaked.
+			//
+			// Known limitation (tracked as a follow-up): the event's `value` is the authoritative record
+			// only for `put`/`invalidate` (full-record) events. For `delete` (tombstone, null value),
+			// `message` (a published message payload, not a row), and `rawEvents` (compact/partial audit
+			// value) the bound record is not the full row, so an override that keys off row fields may
+			// mis-decide those event types. This fix closes the primary leak (record updates); authorizing
+			// those non-record-bearing event types against the full row is deferred.
+			const allowsEvent = filterRowReads
+				? (event: any): boolean => {
+						if (event.type === 'end_txn') return true;
+						try {
+							const recordResource = new RecordResource(event.id, subContext);
+							recordResource.setRecord(event.value ?? null);
+							const decision = recordResource.allowRead(subUser, { id: event.id }, subContext);
+							// Table `allowRead` is synchronous by contract, but nothing enforces it at runtime.
+							// `Boolean(promise)` is always true, so an async override would silently bypass this
+							// filter — fail closed on a thenable rather than leak the event.
+							if (decision != null && typeof decision.then === 'function') {
+								logger.error?.(
+									'Subscription row-level allowRead returned a Promise; Table allowRead must be synchronous — dropping event to avoid an authorization bypass'
+								);
+								return false;
+							}
+							return Boolean(decision);
+						} catch (error) {
+							logger.error?.('Error evaluating allowRead for subscription event; dropping event', error);
+							return false;
+						}
+					}
+				: null;
 			const subscription = addSubscription(
 				TableResource,
 				thisId,
@@ -3266,8 +3322,11 @@ export function makeTable(options) {
 							type,
 							beginTxn,
 						};
+						// Queued events are filtered when the queue is drained through send() below; events
+						// sent directly (queue already drained) are filtered here. Each event is filtered once.
 						if (pendingRealTimeQueue) pendingRealTimeQueue.push(event);
 						else {
+							if (allowsEvent && !allowsEvent(event)) return;
 							if (databaseName !== 'system') {
 								recordAction(auditRecord.size ?? 1, 'db-message', tableName, null);
 							}
@@ -3353,13 +3412,18 @@ export function makeTable(options) {
 								const id = auditRecord.recordId;
 								if (thisId == null || isDescendantId(thisId, id)) {
 									const value = auditRecord.getValue(primaryStore, getFullRecord, auditRecord.localTime);
-									history.push({
+									const historyEntry = {
 										id,
 										localTime: auditRecord.localTime,
 										value,
 										version: auditRecord.version,
 										type: auditRecord.type,
-									});
+									};
+									// Filter denied rows BEFORE they consume a previousCount slot, so an authorized
+									// subscriber still receives up to `count` readable history events rather than a
+									// short count when newer rows belong to other owners (#1419).
+									if (allowsEvent && !allowsEvent(historyEntry)) continue;
+									history.push(historyEntry);
 									if (--count <= 0) break;
 								}
 							} catch (error) {
@@ -3501,6 +3565,7 @@ export function makeTable(options) {
 				subscription.send(error);
 			});
 			function send(event: any) {
+				if (allowsEvent && !allowsEvent(event)) return;
 				if (databaseName !== 'system') {
 					recordAction(event.size ?? 1, 'db-message', tableName, null);
 				}


### PR DESCRIPTION
## Summary
Row-level `allowRead` overrides are enforced on the REST point-read path but were **not** re-evaluated per event during subscription delivery (SSE, WebSocket, MQTT). The connect-time check runs with `this` bound to the collection and no loaded record, so a row-level override always passes — and **every row's changes leaked to any collection subscriber** (a multi-tenant isolation bypass).

This re-evaluates `allowRead` per record-bearing event, binding a resource instance to that row's record (the delivery-path analog of the per-event value filter already applied downstream).

## Scope / gating (kept minimal)
1. Only when the resource **overrides** `allowRead` — default table/attribute RBAC is record-independent and already enforced at connect, so this is zero-overhead for the common case.
2. Only when the subscription has a `context.user` principal — internal watchers (e.g. `hdb_certificate`) and replication have no user and keep delivering every row.

Applied at all delivery sinks: direct `send`, drained-queue `send`, and the `previousCount` history backfill. Denied rows are filtered **before** consuming a `previousCount` slot, so authorized subscribers still receive their full requested history. An async `allowRead` (thenable) **fails closed**.

## Known limitation (deferred follow-up)
`delete` / `message` / `rawEvents` events aren't authorized against the full row, since their event value isn't the full record. Tracked separately.

## Testing
- New `integrationTests/security/subscription-row-allowread` — CONTROL (REST `allowRead` enforced) + PROBE (whole-table SSE delivers only the authorized owner's rows). 2/2 pass.
- `tsc` clean.

## Related
Part of the `allowRead` consolidation (#1487). The REST collection-scan per-record enforcement and the throw→fail-closed hardening (#1422 gaps 1 & 2) live in #1489; this PR is scoped to the subscription-delivery path only and does not overlap its diff.

Closes #1419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)