### PR TITLE
fix(subscriptions): re-deliver current scope to live subscribers on a copyApply reload marker

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -3230,6 +3230,9 @@ export function makeTable(options) {
 			// snapshot:false, which catches any commits that land during yield points; dropping in the
 			// listener avoids duplicate delivery.
 			let dropDuringReplay = false;
+			// Coalescing guards for the reload re-snapshot (harper-pro#495), driven from the listener below.
+			let reloadResnapshotRunning = false;
+			let reloadResnapshotPending = false;
 			const thisId = requestTargetToId(request) ?? null; // treat undefined and null as the root
 			const subscription = addSubscription(
 				TableResource,
@@ -3243,9 +3246,15 @@ export function makeTable(options) {
 							// we only send the full message, this are individual messages that can be sent out of order
 							// TODO: Do we want to have a limit to how far out-of-order we are willing to send?
 							value = auditRecord.getValue?.(primaryStore, getFullRecord);
-						} else if (type !== 'end_txn' && type !== 'reload') {
-							// 'reload' is a whole-table marker with a null id and no record (harper-pro#489); pass it
-							// through verbatim so subscribers re-read the table, skipping the per-record lookup below.
+						} else if (type === 'reload') {
+							// Whole-table marker with a null id and no record (harper-pro#489): a copyApply base copy
+							// back-filled rows with no per-row audit events. For a user table, re-deliver the current
+							// scope as 'put's so MQTT/SSE/WS subscribers recover the snapshotted records, and do NOT
+							// forward the bare marker (harper-pro#495). System-DB subscribers (knownNodes etc.) instead
+							// get the raw marker and run their own bespoke whole-table rescan.
+							if (databaseName !== 'system') return scheduleReloadResnapshot();
+							// system DB: fall through to forward the bare 'reload' event verbatim.
+						} else if (type !== 'end_txn') {
 							// these are events that indicate that the primary record has changed. I believe we always want to simply
 							// send the latest value. Note that it is fine to synchronously access these records, they should have just
 							// been written, so are fresh in memory.
@@ -3506,6 +3515,78 @@ export function makeTable(options) {
 				}
 				subscription.send(event);
 			}
+			// #region reload re-snapshot (harper-pro#495)
+			// A copyApply base copy back-fills rows as snapshots with NO per-row audit entries, so the live
+			// listener above never fires for them and an already-connected subscriber would miss them until
+			// the next direct write. After the copy, a whole-table 'reload' marker is delivered here (id=null).
+			// For a user table we react by re-delivering the subscription's current scope as ordinary 'put'
+			// events — so EVERY consumer that funnels through subscribe() (MQTT, SSE, WS) recovers the records
+			// uniformly, with no per-protocol handling. System-DB reloads are NOT re-snapshotted: their
+			// subscribers (knownNodes peer-discovery, hdb_certificate CA install) run a bespoke whole-table
+			// rescan off the raw marker, which a per-row re-emit cannot express (it can't drop stale rows).
+			// Yields the latest committed value (snapshot:false) and skips tombstones, mirroring the
+			// omitCurrent initial-snapshot scan.
+			async function* currentScopeRecords() {
+				const isCollection = request.isCollection ?? thisId == null;
+				if (isCollection) {
+					let sinceYield = 0;
+					for (const { key: id, value, version, localTime, size } of primaryStore.getRange({
+						start: thisId ?? false,
+						end: thisId == null ? undefined : [thisId, MAXIMUM_KEY],
+						versions: true,
+						snapshot: false, // no need for a snapshot, just want the latest data
+					})) {
+						if (++sinceYield >= REPLAY_YIELD_INTERVAL) {
+							sinceYield = 0;
+							await rest();
+						}
+						if (!value) continue; // skip tombstones
+						yield { id, localTime, value, version, type: 'put', size };
+					}
+				} else {
+					const entry = primaryStore.getEntry(thisId);
+					if (entry?.value) yield { id: thisId, ...entry, type: 'put' };
+				}
+			}
+			// Drain the current scope into the subscription with the same back-pressure as the live path.
+			// Coalesced: a marker that arrives while a re-snapshot is running just re-arms it once more (so
+			// markers for several tables, or a marker landing mid-scan, are not lost), and we never run two
+			// scans concurrently. The first thing it does is `await rest()` (a setImmediate macrotask), so the
+			// scan never executes inside the synchronous broadcast listener — which on the same-thread
+			// aftercommit path holds an inter-thread lock that must not span event-loop turns.
+			async function runReloadResnapshot() {
+				reloadResnapshotRunning = true;
+				try {
+					await rest(); // defer off the broadcast listener's stack before scanning
+					while (reloadResnapshotPending) {
+						reloadResnapshotPending = false;
+						// Subscription.end() nulls `subscriptions`; bail the moment it closes — before, between,
+						// or mid-scan — so we never scan + send into a dead queue. pending is already cleared, so
+						// the finally re-arm won't re-loop.
+						if (!subscription.subscriptions) return;
+						for await (const record of currentScopeRecords()) {
+							if (!subscription.subscriptions) return;
+							send(record);
+							if (subscription.queue?.length > EVENT_HIGH_WATER_MARK) {
+								if ((await subscription.waitForDrain()) === false) return;
+							}
+						}
+					}
+				} catch (error) {
+					harperLogger.error?.('Error in reload re-snapshot:', error);
+				} finally {
+					reloadResnapshotRunning = false;
+					// A marker that landed after the last pending-check but before we cleared the flag would
+					// otherwise be dropped — re-arm if so (unless the subscription has since closed).
+					if (subscription.subscriptions && reloadResnapshotPending) scheduleReloadResnapshot();
+				}
+			}
+			function scheduleReloadResnapshot() {
+				if (!subscription.subscriptions) return;
+				reloadResnapshotPending = true;
+				if (!reloadResnapshotRunning) runReloadResnapshot();
+			}
+			// #endregion
 			return subscription;
 		}
 

--- a/unitTests/resources/reloadMarker.test.js
+++ b/unitTests/resources/reloadMarker.test.js
@@ -26,8 +26,13 @@ describe('table-reload marker (harper-pro#489)', () => {
 		throw new Error('waitFor timed out: ' + message);
 	}
 
-	it('delivers a reload event to every subscriber on the table', async function () {
+	it('delivers a raw reload event to every subscriber on a system table', async function () {
+		// System-DB subscribers (knownNodes peer discovery, hdb_certificate CA install) consume the raw
+		// marker and run their own bespoke whole-table rescan, so for the system DB the bare 'reload' is
+		// forwarded verbatim. (User-DB tables instead re-snapshot the current scope — see the next test,
+		// harper-pro#495.)
 		const ReloadTable = table({
+			database: 'system',
 			table: 'ReloadMarkerDeliver',
 			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
 		});
@@ -47,6 +52,34 @@ describe('table-reload marker (harper-pro#489)', () => {
 		const reload = rootEvents.find((e) => e.type === 'reload');
 		assert.equal(reload.value, undefined, 'reload carries no record value');
 		assert.ok(reload.id == null, 'reload has no record id (whole-table signal)');
+	});
+
+	it('re-snapshots the current scope (not a raw reload) to a user-table subscriber (harper-pro#495)', async function () {
+		// On a user table, a copyApply base copy back-fills rows with no per-row audit events, so the live
+		// listener never fired for them. subscribe() reacts to the reload marker by re-delivering the
+		// current scope as 'put's — recovering those rows — and suppresses the bare marker (a 'reload' typed
+		// event is meaningless to MQTT/SSE/WS clients). Subscribe with omitCurrent so the only delivery is
+		// the reload-driven re-snapshot, not the initial snapshot.
+		const ReloadTable = table({
+			table: 'ReloadMarkerResnapshot',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+		});
+		await ReloadTable.put({ id: 'r1', name: 'one' });
+
+		const events = [];
+		const sub = await ReloadTable.subscribe({ omitCurrent: true });
+		sub.on('data', (event) => events.push(event));
+
+		await ReloadTable.writeReloadMarker();
+
+		await waitFor(
+			() => events.some((e) => e.type === 'put' && e.id === 'r1'),
+			'subscriber receives the existing row as a put via the reload re-snapshot'
+		);
+		assert.ok(
+			!events.some((e) => e.type === 'reload'),
+			'the bare reload marker is suppressed on a user table (re-snapshotted instead)'
+		);
 	});
 
 	it('persists the marker as a local-only audit entry that never replicates', async function () {


### PR DESCRIPTION
## Summary
A copyApply base copy (harper#1479) writes its rows as snapshots with **no per-row audit entries**, so the live-subscription notify path never fires for them. An already-connected MQTT/SSE/WS subscriber therefore silently **misses records that land on its node via a base copy** — they are durably stored but never delivered. (Confirmed by controlled experiment: the consumer receives only a whole-table `reload` marker, never a per-record `put`; with the re-snapshot disabled the subscriber sees `[]`.)

This is the **core half** of harper-pro#495. It builds on the `reload` marker producer from harper#1491 (already merged): when a whole-table `reload` marker (id=null) is delivered for a **non-system** table, `subscribe()` suppresses the bare marker and instead re-delivers the subscription's current scope as ordinary `put` events, recovering the snapshotted rows.

## Where to look — `resources/Table.ts` `subscribe()`
- **One place covers every protocol.** MQTT, SSE, and WS all funnel through `subscribe()` (SSE/WS via `Resource.connect()` → `this.subscribe()`), so a single producer-side re-snapshot covers them — no per-protocol handling.
- **Gate = `databaseName !== 'system'`.** System-DB reloads pass through verbatim, so knownNodes (peer discovery) and hdb_certificate (CA install) keep their bespoke whole-table rescan — which a per-row `put` re-emit cannot express (it can't drop stale rows). Every internal raw-`reload` consumer is on the system DB, so no per-subscription flag is needed.
- **Off the lock.** The re-snapshot's first statement is `await rest()` (a `setImmediate` macrotask), so only two boolean assignments run inside the synchronous broadcast listener; the scan runs after the listener returns and (on the same-thread aftercommit path) releases its inter-thread lock.
- **Coalesced + back-pressured.** Reuses the same `send()` + `waitForDrain` back-pressure as the initial snapshot; a marker arriving mid-scan re-arms one more pass; a closed subscription bails.

## Companion
- harper-pro: emits the per-table `reload` markers on copy-complete (`emitCopyReloadMarkers`). Dormant on its own — without that emitter no user-table markers are produced, so this change is inert until the harper-pro side lands.

## Verification
- New integration test (harper-pro side) `aclConnectCopyReload.test.mjs`: a live subscriber on a node that base-copies pre-existing rows receives all of them — **fails** with the re-snapshot disabled (true negative control), passes with it.
- Existing `aclConnectCrossNode` cross-node delivery (3 tests): still green.

## Cross-model review
Thorough cross-model review (Codex + Gemini + Harper-domain adjudication): **no blockers** — all four outside-model "blockers" were false positives on direct source trace (the `send` closure, a no-`await`-window coalescing path, the `await rest()` deferral, `snapshot:false` convergence). Domain pass confirmed the `LOCAL_ONLY` marker is skipped by the replication send path and the system-DB gate preserves knownNodes.

Generated by an LLM (Claude Opus 4.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)