### PR TITLE
chore(deps): disable Renovate updates for sinon (keep 21.0.3)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,8 @@
 		},
 		{
 			"matchPackageNames": ["sinon"],
-			"groupName": "sinon"
+			"groupName": "sinon",
+			"enabled": false
 		},
 		{
 			"groupName": "all non-major dependencies",


### PR DESCRIPTION
## Summary

Adds `"enabled": false` to the existing `sinon` entry in `renovate.json` so Renovate stops re-proposing `sinon@21.1.2`.

## Why

`sinon@21.1.2` changed the stub/spy property shape, which deterministically breaks **5 deep-equal assertions on `Select` AST objects** in `unitTests/dataLayer/update.test.js` across all Node legs. `main` is green at `sinon@21.0.3`.

The non-major batch PR #1514 ("fix(deps): update all non-major dependencies") keeps re-proposing the 21.1.2 bump and failing CI on those 5 asserts. This unblocks it: once this lands, #1514 should drop its sinon bump (or it will rebase clean, since Renovate will no longer include sinon in the group).

## Note for the reviewer

The task that prompted this asked to *pin* `package.json` to an exact `21.0.3` — but that pin **already exists on `main`** (`devDependencies.sinon: "21.0.3"`, landed in commit `e728987e2` "chore: Revert sinon update"), and the lockfile already resolves to `21.0.3`. A literal pin alone does **not** stop Renovate, because Renovate updates pinned versions too. So the only effective and necessary change is this one-line Renovate rule. That's why this diff touches only `renovate.json` and not `package.json`/`package-lock.json`.

Ordering check: the dedicated `sinon` rule precedes the broad `all non-major dependencies` rule; the latter does not set `enabled`, so it does not re-enable sinon. `enabled: false` on the sinon rule is sufficient.

Generated by an LLM (Claude Opus 4.8).

— 🤖 KrAIs (Kris's review assistant)