### PR TITLE
fix: bind related-table allowRead to a proper resource instance

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1300,7 +1300,10 @@ export function makeTable(options) {
 										if (!property.name) property = { name: property };
 										if (!property.checkPermission && (target as any).checkPermission)
 											property.checkPermission = (target as any).checkPermission;
-										if (!relatedTable.prototype.allowRead.call(null, user, property, context)) return false;
+										// Invoke the related table's allowRead on a properly-bound instance rather than
+										// `.call(null, ...)` so `this` is a valid resource of the related type.
+										const relatedResource = new relatedTable(undefined, context);
+										if (!relatedResource.allowRead(user, property, context)) return false;
 										if (!property.select) return property.name; // no select was applied, just return the name
 									}
 									return property;


### PR DESCRIPTION
## Summary

The related-table read check inside the built-in `allowRead` invoked `relatedTable.prototype.allowRead.call(null, user, property, context)` — binding `this` to `null`. It's harmless today because the built-in `allowRead` is closure-based and never reads `this`, but `null` is an improper binding that would break if the base hook ever referenced instance state.

This constructs a related-type resource instance and invokes `allowRead` on it, so `this` is a valid resource of the related type.

## Scope (deliberately narrow)

- **Behavior-preserving.** The same base table-level RBAC check runs (`relatedTable` is the base table class, so the resolved method is identical), only with a correct `this`.
- **Does not** consult a related-table `allowRead` *override*. Per the `allowRead` design, it is a **grant** hook over RBAC, default RBAC has no per-record granularity, and overrides are evaluated on their own read paths. Propagating overrides to related-table reads would be a behavior change and is intentionally out of scope here.

This is the safe "signature/binding correction" slice of the #1422 / #1487 `allowRead` review — the fail-closed hardening is in #1489.

## Testing

- `tsc --noEmit` clean.
- `integrationTests/server/operation-user-rbac.test.ts` — **30/30** (table/attribute read-permission paths unaffected).

No new test: the change is behavior-preserving, so existing relationship + RBAC coverage applies. Happy to add a dedicated relationship-with-attribute-permission regression if preferred.

Refs #1487, #1422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)