### PR TITLE
feat(models)!: pluggable routing + namespaced extension API (#1326, #1534)

### DIFF
--- a/globals.js
+++ b/globals.js
@@ -2,11 +2,9 @@
 global.contentTypes = exports.contentTypes = null;
 global.createBlob = exports.createBlob = undefined;
 global.databases = exports.databases = {};
-global.defineBackend = exports.defineBackend = undefined;
 global.logger = exports.logger = {};
 global.models = exports.models = undefined;
 global.operation = exports.operation = undefined;
-global.registerBackend = exports.registerBackend = undefined;
 global.Resource = exports.Resource = undefined;
 global.server = exports.server = {};
 global.tables = exports.tables = {};

--- a/index.ts
+++ b/index.ts
@@ -33,6 +33,9 @@ export type {
 	ModelBackend,
 	ModelCapabilities,
 	DefineBackendSpec,
+	Capability,
+	ModelRouter,
+	RouteRequest,
 	EmbedOpts,
 	GenerateOpts,
 	GenerateInput,
@@ -91,10 +94,6 @@ import type { server as ServerImport } from './server/Server.ts';
 import type { tables as TablesImport } from './resources/databases.ts';
 type ThreadsImport = unknown[]; // TODO: figure out actual type for this
 import type { transaction as TransactionImport } from './resources/transaction.ts';
-import type {
-	registerBackend as RegisterBackendImport,
-	defineBackend as DefineBackendImport,
-} from './resources/models/backendRegistry.ts';
 
 // These names are exposed TWO ways that resolve to the SAME live, process-wide value:
 //   1. as ambient globals (the `declare global` block below), and
@@ -110,11 +109,9 @@ declare global {
 	const contentTypes: typeof ContentTypesImport;
 	const createBlob: typeof CreateBlobImport;
 	const databases: typeof DatabasesImport;
-	const defineBackend: typeof DefineBackendImport;
 	const logger: Logger;
 	const models: typeof ModelsImport;
 	const operation: typeof OperationImport;
-	const registerBackend: typeof RegisterBackendImport;
 	const Resource: typeof ResourceImport;
 	const server: typeof ServerImport;
 	const tables: typeof TablesImport;
@@ -126,11 +123,9 @@ declare global {
 export declare const contentTypes: typeof ContentTypesImport;
 export declare const createBlob: typeof CreateBlobImport;
 export declare const databases: typeof DatabasesImport;
-export declare const defineBackend: typeof DefineBackendImport;
 export declare const logger: Logger;
 export declare const models: typeof ModelsImport;
 export declare const operation: typeof OperationImport;
-export declare const registerBackend: typeof RegisterBackendImport;
 export declare const Resource: typeof ResourceImport;
 export declare const server: typeof ServerImport;
 export declare const tables: typeof TablesImport;
@@ -141,11 +136,9 @@ export declare const transaction: typeof TransactionImport;
 exports.contentTypes = null;
 exports.createBlob = undefined;
 exports.databases = {};
-exports.defineBackend = undefined;
 exports.logger = {};
 exports.models = undefined;
 exports.operation = undefined;
-exports.registerBackend = undefined;
 exports.Resource = undefined;
 exports.server = {};
 exports.tables = {};

--- a/resources/models/Models.ts
+++ b/resources/models/Models.ts
@@ -98,8 +98,14 @@ export class Models implements ModelsContract {
 			this.#recordFailure(resolved.backend, 'embed', opts.model, accounting, undefined, startedAt, resolved.error);
 			throw resolved.error;
 		}
-		// Try candidates in order; record each attempt and fall through on failure.
-		let lastError: unknown;
+		// Try candidates in order, recording each attempt. Fall through to the next on
+		// ANY backend error — candidates are heterogeneous, so a limit/input error on
+		// one may still succeed on another; treating an error as "not worth a fallback"
+		// is a router/caller policy, not a facade default (#1537). If every candidate
+		// fails, surface the FIRST (primary) error: the caller asked for that backend,
+		// so it is the most diagnostic. A caller abort short-circuits.
+		let firstError: unknown = undefined;
+		let hasError = false;
 		for (const backend of resolved.candidates) {
 			// Don't spend a backend call on an already-cancelled request — between
 			// candidates the caller may have aborted (and at entry it may already be).
@@ -115,13 +121,14 @@ export class Models implements ModelsContract {
 				return result.output;
 			} catch (err) {
 				this.#recordFailure(backend, 'embed', opts.model, accounting, undefined, attemptStart, err);
-				lastError = err;
-				// Caller cancelled — stop. Any other failure (incl. a backend `pending`
-				// result or a backend-internal abort) falls through to the next candidate.
-				if (signal?.aborted) throw err;
+				if (!hasError) {
+					firstError = err;
+					hasError = true;
+				}
+				if (signal?.aborted) throw err; // caller cancelled — stop, surface the abort
 			}
 		}
-		throw lastError;
+		throw firstError;
 	}
 
 	async generate(input: GenerateInput, opts: GenerateOpts = {}): Promise<GenerateResult> {
@@ -148,7 +155,11 @@ export class Models implements ModelsContract {
 			this.#recordFailure(resolved.backend, 'generate', opts.model, accounting, opts, startedAt, resolved.error);
 			throw resolved.error;
 		}
-		let lastError: unknown;
+		// See embed(): fall through on any backend error (heterogeneous candidates;
+		// skip-policy is a router/caller concern, #1537), surface the FIRST error if all
+		// fail, abort short-circuits.
+		let firstError: unknown = undefined;
+		let hasError = false;
 		for (const backend of resolved.candidates) {
 			// Don't spend a backend call on an already-cancelled request — between
 			// candidates the caller may have aborted (and at entry it may already be).
@@ -165,13 +176,14 @@ export class Models implements ModelsContract {
 				return result.usage ? { ...result.output, usage: result.usage } : result.output;
 			} catch (err) {
 				this.#recordFailure(backend, 'generate', opts.model, accounting, opts, attemptStart, err);
-				lastError = err;
-				// Caller cancelled — stop. Any other failure (incl. a backend `pending`
-				// result or a backend-internal abort) falls through to the next candidate.
-				if (signal?.aborted) throw err;
+				if (!hasError) {
+					firstError = err;
+					hasError = true;
+				}
+				if (signal?.aborted) throw err; // caller cancelled — stop, surface the abort
 			}
 		}
-		throw lastError;
+		throw firstError;
 	}
 
 	generateStream(input: GenerateInput, opts: GenerateOpts = {}): AsyncIterable<GenerateChunk> {

--- a/resources/models/Models.ts
+++ b/resources/models/Models.ts
@@ -2,10 +2,11 @@ import { _assignPackageExport } from '../../globals.js';
 import { contextStorage } from '../transaction.ts';
 import {
 	defineBackend,
+	getBackend,
+	ModelBackendNotFoundError,
 	registerBackend as registerBackendImpl,
-	resolveEmbedding,
-	resolveGenerative,
 } from './backendRegistry.ts';
+import { getRouter, registerRouter as registerRouterImpl } from './routing.ts';
 import { getModelCallAnalyticsWriter, type ModelCallAnalyticsWriter, type ModelCallRecord } from './analyticsTable.ts';
 import { recordAction } from '../analytics/write.ts';
 import { ServerError } from '../../utility/errors/hdbError.ts';
@@ -13,12 +14,15 @@ import { runAgentLoop, runAgentLoopStream } from './agentLoop.ts';
 import type {
 	AccountingContext,
 	BackendOpts,
+	Capability,
+	DefineBackendSpec,
 	EmbedOpts,
 	GenerateChunk,
 	GenerateInput,
 	GenerateOpts,
 	GenerateResult,
 	ModelBackend,
+	ModelRouter,
 	ModelCallResult,
 	Models as ModelsContract,
 	TokenUsage,
@@ -60,93 +64,140 @@ export class Models implements ModelsContract {
 	 * Register a custom backend under a logical id (e.g. `'local:bge-small'`),
 	 * then select it per call with `opts.model`. The public path for components
 	 * and apps to add in-process or third-party backends; pair with
-	 * `defineBackend` to build the backend from a few methods. See #1325.
+	 * `models.defineBackend` to build the backend from a few methods. Namespaced
+	 * under `models` (`scope.models.registerBackend(...)`), not a generic global. See #1325.
 	 */
 	registerBackend(kind: 'embedding' | 'generative', id: string, backend: ModelBackend): void {
 		registerBackendImpl(kind, id, backend);
 	}
 
+	/**
+	 * Build a `ModelBackend` from a small spec — supply only the methods your
+	 * backend implements and `capabilities()` is derived. Pair with
+	 * `models.registerBackend`. Namespaced under `models`
+	 * (`scope.models.defineBackend(...)`), not a generic global. See #1325.
+	 */
+	defineBackend(spec: DefineBackendSpec): ModelBackend {
+		return defineBackend(spec);
+	}
+
+	/**
+	 * Replace the model selection policy with a custom router (#1326). Reachable as
+	 * `scope.models.registerRouter(...)` / `models.registerRouter(...)`; namespaced under
+	 * `models` rather than a generic global. See the `ModelRouter` type.
+	 */
+	registerRouter(router: ModelRouter): void {
+		registerRouterImpl(router);
+	}
+
 	async embed(input: string | string[], opts: EmbedOpts = {}): Promise<Float32Array[]> {
 		const { accounting, signal } = resolveCallContext(opts.signal);
 		const startedAt = performance.now();
-		let backend: ModelBackend | undefined;
-		try {
-			backend = resolveEmbedding(opts.model);
-			requireCapability(backend, 'embed');
-			const backendOpts: BackendOpts<EmbedOpts> = { ...opts, signal, accounting };
-			const result = await backend.embed!(input, backendOpts);
-			// Throw on `pending` BEFORE recording success — otherwise we'd write a
-			// success row followed by a failure row from the catch (duplicate).
-			if (result.status !== 'completed') throw new ModelPendingNotSupportedError(backend.name);
-			this.#record(backend, 'embed', opts.model, accounting, undefined, result, startedAt);
-			return result.output;
-		} catch (err) {
-			this.#recordFailure(backend, 'embed', opts.model, accounting, undefined, startedAt, err);
-			throw err;
+		const resolved = resolveCandidates('embedding', opts.model, buildRequires('embed', opts.requires, false));
+		if ('error' in resolved) {
+			this.#recordFailure(resolved.backend, 'embed', opts.model, accounting, undefined, startedAt, resolved.error);
+			throw resolved.error;
 		}
+		// Try candidates in order; record each attempt and fall through on failure.
+		let lastError: unknown;
+		for (const backend of resolved.candidates) {
+			// Don't spend a backend call on an already-cancelled request — between
+			// candidates the caller may have aborted (and at entry it may already be).
+			signal?.throwIfAborted();
+			const attemptStart = performance.now();
+			try {
+				const backendOpts: BackendOpts<EmbedOpts> = { ...opts, signal, accounting };
+				const result = await backend.embed!(input, backendOpts);
+				// Throw on `pending` BEFORE recording success — otherwise we'd write a
+				// success row followed by a failure row from the catch (duplicate).
+				if (result.status !== 'completed') throw new ModelPendingNotSupportedError(backend.name);
+				this.#record(backend, 'embed', opts.model, accounting, undefined, result, attemptStart);
+				return result.output;
+			} catch (err) {
+				this.#recordFailure(backend, 'embed', opts.model, accounting, undefined, attemptStart, err);
+				lastError = err;
+				// Caller cancelled — stop. Any other failure (incl. a backend `pending`
+				// result or a backend-internal abort) falls through to the next candidate.
+				if (signal?.aborted) throw err;
+			}
+		}
+		throw lastError;
 	}
 
 	async generate(input: GenerateInput, opts: GenerateOpts = {}): Promise<GenerateResult> {
+		const hasTools = inputHasTools(input);
 		if (opts.toolMode === 'auto') {
 			// The loop calls back through `this.generate(..., {toolMode: 'return'})` per
 			// iteration, so each backend round still flows through the single-shot path
 			// below and writes its own `hdb_model_calls` row. The outer auto call itself
 			// stays out of the analytics table — counting it would double-bill the round.
 			const { accounting, signal } = resolveCallContext(opts.signal);
-			// Fail loud, never silent: an auto loop that declares tools against a
-			// tools-incapable backend would run as a plain generation — the backend never
-			// receives the tool definitions (e.g. ollama drops them), so the model can't
-			// call anything and the loop returns a first-round answer, silently ignoring
-			// the caller's tools. Check up front rather than no-op.
-			if (inputHasTools(input)) requireCapability(resolveGenerative(opts.model), 'tools');
+			// Fail loud, never silent: an auto loop that declares tools against a backend
+			// with no tools-capable candidate would run as a plain generation, silently
+			// ignoring the caller's tools. Check up front (no analytics row — no call ran).
+			if (hasTools) {
+				const probe = resolveCandidates('generative', opts.model, buildRequires('generate', opts.requires, true));
+				if ('error' in probe) throw probe.error;
+			}
 			return runAgentLoop({ models: this, input, opts, accounting, signal });
 		}
 		const { accounting, signal } = resolveCallContext(opts.signal);
 		const startedAt = performance.now();
-		let backend: ModelBackend | undefined;
-		try {
-			backend = resolveGenerative(opts.model);
-			requireCapability(backend, 'generate');
-			const backendOpts: BackendOpts<GenerateOpts> = { ...opts, signal, accounting };
-			const result = await backend.generate!(input, backendOpts);
-			if (result.status !== 'completed') throw new ModelPendingNotSupportedError(backend.name);
-			this.#record(backend, 'generate', opts.model, accounting, opts, result, startedAt);
-			// Propagate usage onto the returned GenerateResult so callers (notably the
-			// `toolMode: 'auto'` loop's budget tracker) can read cumulative tokens without
-			// re-querying analytics. Pure pass-through — backend usage is the source of truth.
-			return result.usage ? { ...result.output, usage: result.usage } : result.output;
-		} catch (err) {
-			this.#recordFailure(backend, 'generate', opts.model, accounting, opts, startedAt, err);
-			throw err;
+		const resolved = resolveCandidates('generative', opts.model, buildRequires('generate', opts.requires, hasTools));
+		if ('error' in resolved) {
+			this.#recordFailure(resolved.backend, 'generate', opts.model, accounting, opts, startedAt, resolved.error);
+			throw resolved.error;
 		}
+		let lastError: unknown;
+		for (const backend of resolved.candidates) {
+			// Don't spend a backend call on an already-cancelled request — between
+			// candidates the caller may have aborted (and at entry it may already be).
+			signal?.throwIfAborted();
+			const attemptStart = performance.now();
+			try {
+				const backendOpts: BackendOpts<GenerateOpts> = { ...opts, signal, accounting };
+				const result = await backend.generate!(input, backendOpts);
+				if (result.status !== 'completed') throw new ModelPendingNotSupportedError(backend.name);
+				this.#record(backend, 'generate', opts.model, accounting, opts, result, attemptStart);
+				// Propagate usage onto the returned GenerateResult so callers (notably the
+				// `toolMode: 'auto'` loop's budget tracker) can read cumulative tokens without
+				// re-querying analytics. Pure pass-through — backend usage is the source of truth.
+				return result.usage ? { ...result.output, usage: result.usage } : result.output;
+			} catch (err) {
+				this.#recordFailure(backend, 'generate', opts.model, accounting, opts, attemptStart, err);
+				lastError = err;
+				// Caller cancelled — stop. Any other failure (incl. a backend `pending`
+				// result or a backend-internal abort) falls through to the next candidate.
+				if (signal?.aborted) throw err;
+			}
+		}
+		throw lastError;
 	}
 
 	generateStream(input: GenerateInput, opts: GenerateOpts = {}): AsyncIterable<GenerateChunk> {
+		const hasTools = inputHasTools(input);
 		if (opts.toolMode === 'auto') {
 			// Same rationale as `generate`: per-iteration analytics happen inside the loop
 			// when it dispatches to `this.generateStream(..., {toolMode: 'return'})`.
 			const { accounting, signal } = resolveCallContext(opts.signal);
-			// Same fail-loud guard as `generate` — a tools-incapable backend would silently
-			// stream a plain generation, ignoring the declared tools. Throws synchronously
-			// (before the iterable is returned), matching the capability-check posture below.
-			if (inputHasTools(input)) requireCapability(resolveGenerative(opts.model), 'tools');
+			// Same fail-loud guard as `generate`, thrown synchronously before the iterable.
+			if (hasTools) {
+				const probe = resolveCandidates('generative', opts.model, buildRequires('stream', opts.requires, true));
+				if ('error' in probe) throw probe.error;
+			}
 			return runAgentLoopStream({ models: this, input, opts, accounting, signal });
 		}
 		const { accounting, signal } = resolveCallContext(opts.signal);
 		const startedAt = performance.now();
-		let backend: ModelBackend | undefined;
-		try {
-			backend = resolveGenerative(opts.model);
-			requireCapability(backend, 'stream');
-		} catch (err) {
-			// Record pre-call failure synchronously so callers that hold but never
-			// iterate the returned iterable still produce a billing row, then rethrow.
-			// Pass `backend` (not `undefined`): when the registry hit but the capability
-			// check failed, `backend` is the resolved instance and its name belongs in
-			// the row. Only registry misses leave `backend` undefined → 'unknown'.
-			this.#recordFailure(backend, 'generateStream', opts.model, accounting, opts, startedAt, err);
-			throw err;
+		// Resolved synchronously so an unknown model / unmet capability throws up front
+		// (before the iterable is returned), and a billing row is still recorded.
+		const resolved = resolveCandidates('generative', opts.model, buildRequires('stream', opts.requires, hasTools));
+		if ('error' in resolved) {
+			this.#recordFailure(resolved.backend, 'generateStream', opts.model, accounting, opts, startedAt, resolved.error);
+			throw resolved.error;
 		}
+		// First candidate only — mid-stream fallback would mean replaying already-yielded chunks.
+		const backend = resolved.candidates[0];
 		const backendOpts: BackendOpts<GenerateOpts> = { ...opts, signal, accounting };
 		return this.#wrapStream(backend, input, backendOpts, opts, accounting, startedAt);
 	}
@@ -274,8 +325,40 @@ function inputHasTools(input: GenerateInput): boolean {
 	return typeof input === 'object' && !Array.isArray(input) && Array.isArray(input.tools) && input.tools.length > 0;
 }
 
-function requireCapability(backend: ModelBackend, capability: 'embed' | 'generate' | 'stream' | 'tools'): void {
-	if (!backend.capabilities()[capability]) throw new ModelCapabilityError(backend.name, capability);
+type ResolveKind = 'embedding' | 'generative';
+type Resolution = { candidates: ModelBackend[] } | { error: Error; backend: ModelBackend | undefined };
+
+/**
+ * Resolve a call to its ordered candidate backends via the active router (#1326),
+ * or to the error to record + throw. Preserves the facade's pre-router semantics:
+ * an unmapped logical name → `ModelBackendNotFoundError` (recorded as `unknown`);
+ * a mapped backend that can't satisfy `requires` → `ModelCapabilityError` naming
+ * that backend. The router does the capability filtering; this reconstructs the
+ * distinction for the empty case. A custom router that returns empty for a backend
+ * that *does* satisfy `requires` is a routing decision, not a capability gap, so it
+ * surfaces as a plain "no candidates" error — not a misleading `ModelCapabilityError`
+ * against a backend that actually supports the call (the default router never returns
+ * empty for a satisfying primary; it only drops on name or capability miss).
+ */
+function resolveCandidates(kind: ResolveKind, model: string | undefined, requires: Capability[]): Resolution {
+	const logicalName = model ?? 'default';
+	const candidates = getRouter().route({ kind, logicalName, requires });
+	if (candidates.length > 0) return { candidates };
+	const primary = getBackend(kind, logicalName);
+	if (!primary) return { error: new ModelBackendNotFoundError(kind, logicalName), backend: undefined };
+	// `caps?.[…]` guards a custom backend whose capabilities() returns nullish — a
+	// missing capabilities object means it satisfies nothing, so it reads as unmet.
+	const caps = primary.capabilities();
+	const unmet = requires.find((capability) => !caps?.[capability]);
+	if (unmet) return { error: new ModelCapabilityError(primary.name, unmet), backend: primary };
+	return { error: new ServerError(`No routing candidates available for model '${logicalName}'`), backend: primary };
+}
+
+/** Capabilities a call requires: its base method, the caller's `requires`, and `tools` when the input declares them. */
+function buildRequires(base: Capability, requires: Capability[] | undefined, includeTools: boolean): Capability[] {
+	const set = new Set<Capability>([base, ...(requires ?? [])]);
+	if (includeTools) set.add('tools');
+	return [...set];
 }
 
 function classifyError(err: unknown): string {
@@ -292,7 +375,7 @@ function classifyError(err: unknown): string {
 export class ModelCapabilityError extends ServerError {
 	// Deliberately does not name the requested capability beyond what was asked for —
 	// avoids enumerating what the backend *does* support in error responses.
-	constructor(backendName: string, capability: 'embed' | 'generate' | 'stream' | 'tools') {
+	constructor(backendName: string, capability: Capability) {
 		super(`Backend '${backendName}' does not support '${capability}'`);
 		this.name = 'ModelCapabilityError';
 	}
@@ -317,6 +400,6 @@ export class ModelPendingNotSupportedError extends ServerError {
  */
 export const models = new Models();
 _assignPackageExport('models', models);
-// Free-function registration API (#1325), also reachable as `models.registerBackend(...)`.
-_assignPackageExport('registerBackend', registerBackendImpl);
-_assignPackageExport('defineBackend', defineBackend);
+// The backend-registration API is reachable as `models.registerBackend(...)` /
+// `models.defineBackend(...)` — methods on the `models` singleton above, not generic
+// free globals (#1534). Custom routers install via `models.registerRouter(...)` (#1326).

--- a/resources/models/backendRegistry.ts
+++ b/resources/models/backendRegistry.ts
@@ -34,6 +34,11 @@ export function setGenerative(logicalName: string, backend: ModelBackend): void 
 	generative.set(logicalName, backend);
 }
 
+/** Non-throwing lookup of the backend mapped to `logicalName` for `kind`, or `undefined`. Used by the router to assemble + filter candidate lists without exceptions. */
+export function getBackend(kind: ModelKind, logicalName: string): ModelBackend | undefined {
+	return (kind === 'embedding' ? embedding : generative).get(logicalName);
+}
+
 /**
  * Resolve the embedding backend mapped to `logicalName` (default: `'default'`).
  * Throws `ModelBackendNotFoundError` if no backend is mapped.

--- a/resources/models/bootstrap.ts
+++ b/resources/models/bootstrap.ts
@@ -34,6 +34,7 @@ import { isAbsolute, resolve as resolvePath } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { createRequire } from 'node:module';
 import { getHdbBasePath } from '../../utility/environment/environmentManager.ts';
+import { setFallbackGroup, clearFallbackGroups } from './routing.ts';
 
 /**
  * Field names treated as credentials. When present in config as a literal
@@ -56,6 +57,8 @@ interface ModelEntry {
 	organization?: string;
 	// bedrock
 	region?: string;
+	/** Ordered fallback group: other logical names tried, in order, after this one (#1326). */
+	fallback?: string[];
 }
 
 interface ModelsConfig {
@@ -82,6 +85,9 @@ const FACTORIES: Record<string, BackendRegisterFn> = {
  * prior registration under the same logical name (registry uses `.set()`).
  */
 export async function bootstrapModels(rootConfig: RootConfig | undefined | null): Promise<void> {
+	// Rebuild fallback groups from scratch each (re)load so a removed/changed `fallback:`
+	// (or a removed `models:` block) doesn't leave stale routing behind (#1326).
+	clearFallbackGroups();
 	const block = rootConfig?.models;
 	if (!block) return;
 	await registerKind('embedding', block.embedding);
@@ -133,6 +139,8 @@ async function registerKind(kind: ModelKind, entries: Record<string, ModelEntry>
 				// Not a built-in name: treat `backend` as a module specifier (#1471).
 				await registerFromModule(kind, logicalName, entry.backend, config);
 			}
+			// Record the ordered fallback group (other logical names) for the router (#1326).
+			if (entry.fallback?.length) setFallbackGroup(kind, logicalName, entry.fallback);
 		} catch (err) {
 			harperLogger.error(`models.${kind}.${logicalName}: registration failed (${(err as Error)?.message ?? err})`);
 		}

--- a/resources/models/routing.ts
+++ b/resources/models/routing.ts
@@ -1,0 +1,82 @@
+/**
+ * Pluggable model routing (#1326).
+ *
+ * The `Models` facade resolves every call through a `ModelRouter`, which returns
+ * the ordered candidate backends for that call. The facade uses the first
+ * candidate and falls through to the next on backend failure (fallback), so
+ * both capability-aware selection and fallback are expressed by one mechanism.
+ *
+ * The default router (below) is name-lookup + capability filter over a logical
+ * name's group: it expands the logical name to `[name, ...configured fallback]`,
+ * resolves each via `getBackend`, and keeps those whose `capabilities()` satisfy
+ * the request's `requires`. `registerRouter(...)` replaces it wholesale for
+ * cost/latency/tenant policies. Module-scope state — one router per process,
+ * mirroring `backendRegistry`.
+ */
+import type { Capability, ModelBackend, ModelRouter, RouteRequest } from './types.ts';
+import { getBackend } from './backendRegistry.ts';
+
+type ModelKind = RouteRequest['kind'];
+
+// `${kind}:${logicalName}` → ordered fallback logical names (from config `fallback:`).
+const fallbackGroups: Map<string, string[]> = new Map();
+let override: ModelRouter | null = null;
+
+const groupKey = (kind: ModelKind, logicalName: string): string => `${kind}:${logicalName}`;
+
+/**
+ * Register the ordered fallback group for a logical name (boot wiring, from the
+ * config `fallback:` field). The group members are additional logical names
+ * tried, in order, after the primary.
+ */
+export function setFallbackGroup(kind: ModelKind, logicalName: string, fallbackNames: string[]): void {
+	if (fallbackNames?.length) fallbackGroups.set(groupKey(kind, logicalName), [...fallbackNames]);
+}
+
+/** Replace the default selection policy with a custom router (#1326). */
+export function registerRouter(router: ModelRouter): void {
+	override = router;
+}
+
+/** Reset router override + fallback groups. Test-only hygiene. */
+export function clearRouting(): void {
+	override = null;
+	fallbackGroups.clear();
+}
+
+/**
+ * Clear only the config-derived fallback groups (a registered router override is
+ * left intact). Called at (re)bootstrap so a removed or changed `fallback:` — or a
+ * removed `models:` block — does not leave stale routing behind on a config reload.
+ */
+export function clearFallbackGroups(): void {
+	fallbackGroups.clear();
+}
+
+/** The active router — a registered override, or the default name-lookup router. */
+export function getRouter(): ModelRouter {
+	return override ?? defaultRouter;
+}
+
+function satisfies(backend: ModelBackend, requires: Capability[]): boolean {
+	if (requires.length === 0) return true;
+	// Guard against a custom backend returning nullish from capabilities() — treat
+	// "no capabilities object" as "satisfies nothing" rather than throwing here.
+	const caps = backend.capabilities();
+	return !!caps && requires.every((capability) => caps[capability]);
+}
+
+const defaultRouter: ModelRouter = {
+	route(req: RouteRequest): ModelBackend[] {
+		const names = [req.logicalName, ...(fallbackGroups.get(groupKey(req.kind, req.logicalName)) ?? [])];
+		const seen = new Set<string>();
+		const candidates: ModelBackend[] = [];
+		for (const name of names) {
+			if (seen.has(name)) continue;
+			seen.add(name);
+			const backend = getBackend(req.kind, name);
+			if (backend && satisfies(backend, req.requires)) candidates.push(backend);
+		}
+		return candidates;
+	},
+};

--- a/resources/models/types.ts
+++ b/resources/models/types.ts
@@ -13,6 +13,10 @@ export interface Models {
 	generateStream(input: GenerateInput, opts?: GenerateOpts): AsyncIterable<GenerateChunk>;
 	/** Register a custom backend under a logical id, selectable via `opts.model`. See #1325. */
 	registerBackend(kind: 'embedding' | 'generative', id: string, backend: ModelBackend): void;
+	/** Build a `ModelBackend` from a spec; pair with `registerBackend`. See #1325. */
+	defineBackend(spec: DefineBackendSpec): ModelBackend;
+	/** Replace the model selection policy with a custom router. See #1326. */
+	registerRouter(router: ModelRouter): void;
 }
 
 export interface ModelBackend {
@@ -29,6 +33,34 @@ export interface ModelCapabilities {
 	stream: boolean;
 	tools: boolean;
 	adapters: boolean;
+}
+
+/** A capability a call can require of its backend (a key of `ModelCapabilities`). */
+export type Capability = keyof ModelCapabilities;
+
+/** What the router is asked to resolve for a single call. See #1326. */
+export interface RouteRequest {
+	kind: 'embedding' | 'generative';
+	/** Logical name from `opts.model` (a role or a concrete backend id); defaults to `'default'`. */
+	logicalName: string;
+	/** Capabilities the chosen backend must satisfy — explicit `opts.requires` plus any auto-derived (e.g. tools present in the input). */
+	requires: Capability[];
+	/** Free-form routing hints (tenant, app, prompt size, …) a custom router may use. */
+	hints?: Record<string, unknown>;
+}
+
+/**
+ * Pluggable selection policy (#1326). `route` returns the ordered candidate
+ * backends for a call: `Models` uses the first that satisfies `requires` and
+ * falls through to the next on backend failure. An empty list means no
+ * candidate (the facade throws `ModelBackendNotFoundError`).
+ *
+ * Synchronous by design so the facade preserves its synchronous resolution
+ * errors (notably `generateStream`'s up-front capability check). `registerRouter`
+ * replaces the default name-lookup router.
+ */
+export interface ModelRouter {
+	route(req: RouteRequest): ModelBackend[];
 }
 
 /**
@@ -50,6 +82,8 @@ export interface DefineBackendSpec {
 
 export type EmbedOpts = {
 	model?: string;
+	/** Capabilities the chosen backend must satisfy; the router selects/filters candidates accordingly (#1326). */
+	requires?: Capability[];
 	/** For models that distinguish document-vs-query embeddings (e.g. nomic-embed-text); ignored otherwise. */
 	inputType?: 'document' | 'query';
 	signal?: AbortSignal;
@@ -57,6 +91,8 @@ export type EmbedOpts = {
 
 export type GenerateOpts = {
 	model?: string;
+	/** Capabilities the chosen backend must satisfy (e.g. `['tools']`); the router selects/filters candidates accordingly. Tools present in the input are auto-required. (#1326) */
+	requires?: Capability[];
 	adapter?: string;
 	temperature?: number;
 	maxTokens?: number;

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -3,7 +3,6 @@ import { contextStorage, transaction } from '../resources/transaction.ts';
 import { RequestTarget } from '../resources/RequestTarget.ts';
 import { tables, databases } from '../resources/databases.ts';
 import { models as harperModelsSingleton } from '../resources/models/Models.ts';
-import { registerBackend, defineBackend } from '../resources/models/backendRegistry.ts';
 import { readFile } from 'node:fs/promises';
 import { dirname, isAbsolute } from 'node:path';
 import { pathToFileURL, fileURLToPath } from 'node:url';
@@ -797,12 +796,12 @@ function getHarperExports(scope: ApplicationScope) {
 		// `harper.models` — same singleton that's surfaced as the top-level
 		// `models` package export (see `resources/models/Models.ts`).  The
 		// registry it reads from is populated at boot by
-		// `resources/models/bootstrap.ts`.
+		// `resources/models/bootstrap.ts`. The backend-registration API
+		// (`registerBackend` / `defineBackend`) and custom routing
+		// (`registerRouter`) are methods on this singleton (#1534, #1326) —
+		// components reach them via `models.registerBackend(...)`, not as
+		// separate top-level exports.
 		models: harperModelsSingleton,
-		// Public model-backend registration API (#1325) — same functions as the
-		// top-level package exports; components register backends through these.
-		registerBackend,
-		defineBackend,
 		createBlob,
 		RequestTarget,
 		getContext,

--- a/unitTests/resources/models/Models.test.js
+++ b/unitTests/resources/models/Models.test.js
@@ -34,9 +34,13 @@ describe('models singleton', () => {
 		assert.strictEqual(global.models, modelsSingleton);
 	});
 
-	it('_assignPackageExport wires the registerBackend / defineBackend free functions', () => {
-		assert.strictEqual(typeof global.registerBackend, 'function');
-		assert.strictEqual(typeof global.defineBackend, 'function');
+	it('exposes registerBackend / defineBackend / registerRouter as methods on the singleton, not free globals (#1534)', () => {
+		assert.strictEqual(typeof modelsSingleton.registerBackend, 'function');
+		assert.strictEqual(typeof modelsSingleton.defineBackend, 'function');
+		assert.strictEqual(typeof modelsSingleton.registerRouter, 'function');
+		// The generic free globals were removed — only `models` is exported.
+		assert.strictEqual(global.registerBackend, undefined);
+		assert.strictEqual(global.defineBackend, undefined);
 	});
 });
 

--- a/unitTests/resources/models/bootstrap.test.js
+++ b/unitTests/resources/models/bootstrap.test.js
@@ -9,9 +9,13 @@ const {
 	ModelBackendNotFoundError,
 } = require('#src/resources/models/backendRegistry');
 const { join } = require('node:path');
+const { getRouter, clearRouting } = require('#src/resources/models/routing');
 
 describe('bootstrapModels', () => {
-	beforeEach(() => clearRegistry());
+	beforeEach(() => {
+		clearRegistry();
+		clearRouting();
+	});
 
 	it('is a no-op when rootConfig is undefined/null', async () => {
 		await bootstrapModels(undefined);
@@ -22,6 +26,36 @@ describe('bootstrapModels', () => {
 	it('is a no-op when rootConfig.models is absent', async () => {
 		await bootstrapModels({});
 		assert.throws(() => resolveEmbedding('default'), ModelBackendNotFoundError);
+	});
+
+	it('records a `fallback` group so the router returns the ordered candidates (#1326)', async () => {
+		await bootstrapModels({
+			models: {
+				generative: {
+					default: { backend: 'ollama', model: 'a', fallback: ['alt'] },
+					alt: { backend: 'ollama', model: 'b' },
+				},
+			},
+		});
+		const candidates = getRouter().route({ kind: 'generative', logicalName: 'default', requires: [] });
+		assert.strictEqual(candidates.length, 2);
+		assert.strictEqual(candidates[0], resolveGenerative('default'));
+		assert.strictEqual(candidates[1], resolveGenerative('alt'));
+	});
+
+	it('clears a removed fallback group on the next bootstrap, not leaving stale routing (#1326)', async () => {
+		await bootstrapModels({
+			models: {
+				generative: {
+					default: { backend: 'ollama', model: 'a', fallback: ['alt'] },
+					alt: { backend: 'ollama', model: 'b' },
+				},
+			},
+		});
+		assert.strictEqual(getRouter().route({ kind: 'generative', logicalName: 'default', requires: [] }).length, 2);
+		// Reload without the fallback — the stale group must not survive.
+		await bootstrapModels({ models: { generative: { default: { backend: 'ollama', model: 'a' } } } });
+		assert.strictEqual(getRouter().route({ kind: 'generative', logicalName: 'default', requires: [] }).length, 1);
 	});
 
 	it('registers an ollama embedding entry under its logical name', async () => {

--- a/unitTests/resources/models/defineBackend.test.js
+++ b/unitTests/resources/models/defineBackend.test.js
@@ -124,6 +124,16 @@ describe('registerBackend + defineBackend end-to-end through Models', () => {
 		assert.ok(vectors[0] instanceof Float32Array);
 	});
 
+	it('models.defineBackend + models.registerBackend: the full flow via methods only (#1534)', async () => {
+		const models = new Models(makeMockWriter(), () => {});
+		// No free globals — both define and register go through the `models` singleton.
+		const backend = models.defineBackend({ name: 'local:methods-only', embed: embedFn });
+		assert.strictEqual(backend.name, 'local:methods-only');
+		models.registerBackend('embedding', 'local:methods-only', backend);
+		const vectors = await models.embed('hi', { model: 'local:methods-only' });
+		assert.ok(vectors[0] instanceof Float32Array);
+	});
+
 	it('models.generate() drains a stream-only backend via the synthesized generate', async () => {
 		registerBackend(
 			'generative',

--- a/unitTests/resources/models/routing.test.js
+++ b/unitTests/resources/models/routing.test.js
@@ -108,6 +108,35 @@ describe('Models routing (end-to-end)', () => {
 		assert.strictEqual(writer.records[1].backend, 'backup');
 	});
 
+	it('surfaces the primary (first) error, not the last candidate, when the whole chain fails (#1537)', async () => {
+		setGenerative(
+			'default',
+			defineBackend({
+				name: 'primary',
+				generate: async () => {
+					throw new Error('primary boom');
+				},
+			})
+		);
+		setGenerative(
+			'backup',
+			defineBackend({
+				name: 'backup',
+				generate: async () => {
+					throw new Error('backup boom');
+				},
+			})
+		);
+		setFallbackGroup('generative', 'default', ['backup']);
+		const writer = makeWriter();
+		// The primary is what the caller asked for, so its error is the most diagnostic.
+		await assert.rejects(() => new Models(writer, () => {}).generate('hi'), /primary boom/);
+		// Every candidate is still attempted and recorded — only the surfaced error changed.
+		assert.strictEqual(writer.records.length, 2);
+		assert.strictEqual(writer.records[0].backend, 'primary');
+		assert.strictEqual(writer.records[1].backend, 'backup');
+	});
+
 	it('generateStream throws synchronously for an unknown model (regression guard)', () => {
 		const models = new Models(makeWriter(), () => {});
 		assert.throws(() => models.generateStream('hi', { model: 'missing' }), { name: 'ModelBackendNotFoundError' });

--- a/unitTests/resources/models/routing.test.js
+++ b/unitTests/resources/models/routing.test.js
@@ -1,0 +1,183 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+// Prime the module graph in the same order the other models unit tests do.
+require('#src/resources/databases');
+const { registerRouter, getRouter, setFallbackGroup, clearRouting } = require('#src/resources/models/routing');
+const { setGenerative, defineBackend, clearRegistry } = require('#src/resources/models/backendRegistry');
+const { Models } = require('#src/resources/models/Models');
+
+function makeWriter() {
+	const records = [];
+	return { records, write: (r) => records.push(r) };
+}
+const genOut = (content) => ({ status: 'completed', output: { content, finishReason: 'stop' } });
+const TOOLS_INPUT = {
+	messages: [{ role: 'user', content: 'hi' }],
+	tools: [{ name: 't', description: 'd', parameters: {} }],
+};
+
+describe('default router', () => {
+	beforeEach(() => {
+		clearRegistry();
+		clearRouting();
+	});
+
+	it('returns the single registered backend for a logical name', () => {
+		const b = defineBackend({ name: 'g', generate: async () => genOut('x') });
+		setGenerative('default', b);
+		assert.deepStrictEqual(getRouter().route({ kind: 'generative', logicalName: 'default', requires: ['generate'] }), [
+			b,
+		]);
+	});
+
+	it('returns empty for an unregistered name', () => {
+		assert.deepStrictEqual(getRouter().route({ kind: 'generative', logicalName: 'nope', requires: [] }), []);
+	});
+
+	it('filters out candidates lacking a required capability', () => {
+		setGenerative('default', defineBackend({ name: 'no-tools', generate: async () => genOut('x') }));
+		assert.deepStrictEqual(getRouter().route({ kind: 'generative', logicalName: 'default', requires: ['tools'] }), []);
+	});
+
+	it('expands a fallback group in order, capability-filtered', () => {
+		const a = defineBackend({ name: 'a', generate: async () => genOut('a') });
+		const b = defineBackend({ name: 'b', tools: true, generate: async () => genOut('b') });
+		setGenerative('default', a);
+		setGenerative('alt', b);
+		setFallbackGroup('generative', 'default', ['alt']);
+		assert.deepStrictEqual(getRouter().route({ kind: 'generative', logicalName: 'default', requires: [] }), [a, b]);
+		assert.deepStrictEqual(getRouter().route({ kind: 'generative', logicalName: 'default', requires: ['tools'] }), [b]);
+	});
+
+	it('registerRouter replaces the default policy', () => {
+		const sentinel = defineBackend({ name: 'sentinel', generate: async () => genOut('s') });
+		const custom = { route: () => [sentinel] };
+		registerRouter(custom);
+		assert.strictEqual(getRouter(), custom);
+		assert.deepStrictEqual(getRouter().route({ kind: 'generative', logicalName: 'anything', requires: [] }), [
+			sentinel,
+		]);
+	});
+
+	it('models.registerRouter installs a custom router (namespaced under models, not a global)', () => {
+		const sentinel = defineBackend({ name: 's', generate: async () => genOut('s') });
+		new Models(makeWriter(), () => {}).registerRouter({ route: () => [sentinel] });
+		assert.deepStrictEqual(getRouter().route({ kind: 'generative', logicalName: 'x', requires: [] }), [sentinel]);
+	});
+});
+
+describe('Models routing (end-to-end)', () => {
+	beforeEach(() => {
+		clearRegistry();
+		clearRouting();
+	});
+	afterEach(() => {
+		clearRegistry();
+		clearRouting();
+	});
+
+	it('capability-routes generate({tools}) to a tools-capable backend in the group', async () => {
+		setGenerative('default', defineBackend({ name: 'plain', generate: async () => genOut('plain') }));
+		setGenerative('tooled', defineBackend({ name: 'tooled', tools: true, generate: async () => genOut('tooled') }));
+		setFallbackGroup('generative', 'default', ['tooled']);
+		const models = new Models(makeWriter(), () => {});
+		const result = await models.generate(TOOLS_INPUT);
+		assert.strictEqual(result.content, 'tooled'); // the no-tools 'default' was filtered out
+	});
+
+	it('falls back to the next candidate on error, recording each attempt', async () => {
+		setGenerative(
+			'default',
+			defineBackend({
+				name: 'failing',
+				generate: async () => {
+					throw new Error('boom');
+				},
+			})
+		);
+		setGenerative('backup', defineBackend({ name: 'backup', generate: async () => genOut('recovered') }));
+		setFallbackGroup('generative', 'default', ['backup']);
+		const writer = makeWriter();
+		const result = await new Models(writer, () => {}).generate('hi');
+		assert.strictEqual(result.content, 'recovered');
+		assert.strictEqual(writer.records.length, 2);
+		assert.strictEqual(writer.records[0].success, false);
+		assert.strictEqual(writer.records[0].backend, 'failing');
+		assert.strictEqual(writer.records[1].success, true);
+		assert.strictEqual(writer.records[1].backend, 'backup');
+	});
+
+	it('generateStream throws synchronously for an unknown model (regression guard)', () => {
+		const models = new Models(makeWriter(), () => {});
+		assert.throws(() => models.generateStream('hi', { model: 'missing' }), { name: 'ModelBackendNotFoundError' });
+	});
+
+	it('throws ModelCapabilityError (named backend) when no candidate satisfies requires', async () => {
+		setGenerative('default', defineBackend({ name: 'no-tools', generate: async () => genOut('x') }));
+		const writer = makeWriter();
+		await assert.rejects(() => new Models(writer, () => {}).generate(TOOLS_INPUT), { name: 'ModelCapabilityError' });
+		assert.strictEqual(writer.records[0].backend, 'no-tools'); // recorded with the resolved name, not 'unknown'
+	});
+
+	it('does not fall through to the next candidate when the caller has aborted', async () => {
+		const controller = new AbortController();
+		let backupTried = false;
+		setGenerative(
+			'default',
+			defineBackend({
+				name: 'first',
+				generate: async () => {
+					controller.abort();
+					throw new Error('failed after caller abort');
+				},
+			})
+		);
+		setGenerative(
+			'backup',
+			defineBackend({
+				name: 'backup',
+				generate: async () => {
+					backupTried = true;
+					return genOut('x');
+				},
+			})
+		);
+		setFallbackGroup('generative', 'default', ['backup']);
+		await assert.rejects(() => new Models(makeWriter(), () => {}).generate('hi', { signal: controller.signal }));
+		assert.strictEqual(backupTried, false); // caller abort short-circuits the fallback loop
+	});
+
+	it('does not call any backend when the signal is already aborted on entry', async () => {
+		const controller = new AbortController();
+		controller.abort();
+		let called = false;
+		setGenerative(
+			'default',
+			defineBackend({
+				name: 'first',
+				generate: async () => {
+					called = true;
+					return genOut('x');
+				},
+			})
+		);
+		await assert.rejects(() => new Models(makeWriter(), () => {}).generate('hi', { signal: controller.signal }));
+		assert.strictEqual(called, false); // top-of-loop abort guard skips the wasted call
+	});
+
+	it('throws a plain "no candidates" error (not ModelCapabilityError) when a custom router returns empty for a satisfying backend', async () => {
+		setGenerative('default', defineBackend({ name: 'capable', generate: async () => genOut('x') }));
+		registerRouter({ route: () => [] }); // a custom router declines every candidate
+		await assert.rejects(
+			() => new Models(makeWriter(), () => {}).generate('hi'),
+			(err) => {
+				// The backend supports generate — the empty result is a routing decision,
+				// so the error must not claim a capability gap.
+				assert.notStrictEqual(err.name, 'ModelCapabilityError');
+				assert.match(err.message, /No routing candidates available/);
+				return true;
+			}
+		);
+	});
+});

--- a/unitTests/security/jsLoader/jsLoader.test.js
+++ b/unitTests/security/jsLoader/jsLoader.test.js
@@ -66,11 +66,15 @@ describe('scopedImport', () => {
 		const result = await scopedImport(join(__dirname, 'fixtures', 'uses-harperdb.cjs'), scope);
 		expect(result.Resource).to.be.a('function');
 		expect(result.tables).to.exist;
-		// #1325: the model-backend registration API must reach components through the
-		// `require('harperdb')` path (getHarperExports), the same way `models`/`tables` do.
+		// #1325/#1534: the model-backend registration API reaches components through
+		// `require('harperdb').models` (getHarperExports) — methods on the models
+		// singleton, NOT separate top-level exports (those generic globals were
+		// removed in #1534, the same way routing is `models.registerRouter`).
 		expect(result.models).to.exist;
-		expect(result.registerBackend).to.be.a('function');
-		expect(result.defineBackend).to.be.a('function');
+		expect(result.models.registerBackend).to.be.a('function');
+		expect(result.models.defineBackend).to.be.a('function');
+		expect(result.registerBackend).to.equal(undefined);
+		expect(result.defineBackend).to.equal(undefined);
 	});
 
 	it('should throw an error importing an ESM module with invalid dependency', async () => {

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -114,6 +114,8 @@ export function configValidator(configJson, skipFsValidation = false) {
 	const commonEntryFields = {
 		model: string.optional(),
 		requestTimeoutMs: number.min(1).optional(),
+		// Ordered fallback group — other logical names tried, in order, after this one (#1326).
+		fallback: Joi.array().items(string).optional(),
 	};
 	const ollamaEntrySchema = Joi.object({
 		backend: string.valid('ollama').required(),


### PR DESCRIPTION
## Summary

Two related changes that finalize the `scope.models` **extension API** as a consistent, method-based surface.

### 1. Pluggable routing (#1326)
Every `scope.models` call resolves through a `ModelRouter` that returns the ordered candidate backends; the facade uses the first that satisfies the call's required capabilities and falls through to the next on failure. **Capability-aware selection and fallback are one mechanism.**

- **Capability routing** — `opts.requires` (and auto-derived: tools in the input ⇒ a tools-capable backend). The default router picks the first candidate in the group whose `capabilities()` satisfy the requirement.
- **Fallback** — "try the next candidate on error" is the same loop. `fallback: [names]` on a model entry defines the ordered group (validator + bootstrap; stale groups cleared each reload). Settles the fallback open-decision from #510.
- **`models.registerRouter(router)`** swaps the default policy — a method on `scope.models`, not a global.

### 2. Namespaced extension API — **BREAKING** (#1534)
`registerBackend` / `defineBackend` (from #1325) shipped as both `scope.models` methods *and* generic free globals / top-level `harperdb` exports. The free-global form is too generic for a model-specific surface — the same reason routing is `models.registerRouter`, not a `registerRouter` global.

- Added `models.defineBackend(spec)` (method; `models.registerBackend` already existed).
- **Removed** the free globals + top-level `harperdb` exports `registerBackend` / `defineBackend`.
- `DefineBackendSpec` / `ModelBackend` **types** stay exported.

```js
// before
const { registerBackend, defineBackend } = require('harperdb');
registerBackend('embedding', 'local:x', defineBackend({ ... }));
// after
const { models } = require('harperdb');            // or scope.models / the `models` global
models.registerBackend('embedding', 'local:x', models.defineBackend({ ... }));
```

Taken now because `scope.models` is still pre-feature-complete — cleaner than carrying a deprecated generic global.

## Where to look

- `resources/models/routing.ts` — default capability-filtering router + fallback-group / override registries. **Synchronous** (preserves `generateStream`'s up-front throw).
- `resources/models/Models.ts` — `resolveCandidates` (reconstructs NotFound / Capability / no-candidates errors); `embed` / `generate` candidate loop with per-attempt analytics, fallback, and abort guards (before each attempt + after each failure); `registerBackend` / `defineBackend` / `registerRouter` methods.
- `index.ts`, `globals.js`, `security/jsLoader.ts` — removed the `registerBackend` / `defineBackend` free-global wiring (kept the `models` singleton + the types).

## Backward-compat

Routing is strictly additive. The registration-API change is **breaking** (see §2). All other existing behavior preserved — `ModelBackendNotFoundError` / `ModelCapabilityError` / per-call analytics / the synchronous `generateStream` throw. **282 model unit tests pass** (routing, fallback, abort, method-only flows) + the jsLoader component-import test.

## Review feedback addressed (`deaf769c`)

Gemini Code Assist findings: misleading capability error on an empty custom-router result → plain "no candidates" error; abort-before-attempt guard (`signal?.throwIfAborted()` at loop top); nullish `capabilities()` guard. (The `assert/strict` nit is left to match all 14 files in `unitTests/resources/models/`.)

## Follow-ups

- Docs: `documentation` PRs for #1325 / config backends need the `models.registerBackend` / `models.defineBackend` namespacing + the routing/`registerRouter` API.

Closes #1326. Closes #1534. Part of #510.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

