### PR TITLE
fix: resolve extension packages outside ROOTPATH during node_modules walk (#1507)

### DIFF
--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -9,7 +9,7 @@ import {
 	rmSync,
 	symlinkSync,
 } from 'node:fs';
-import { join, basename, dirname } from 'node:path';
+import { join, basename, dirname, sep } from 'node:path';
 import { isMainThread } from 'node:worker_threads';
 import { parseDocument } from 'yaml';
 import * as env from '../utility/environment/environmentManager.ts';
@@ -407,10 +407,23 @@ export async function loadComponent(
 						componentPath = join(componentDirectory, 'components', componentName);
 					} else {
 						let containerFolder = componentDirectory;
+						const hdbBasePath = getHdbBasePath();
+						const componentInsideHdb =
+							componentDirectory === hdbBasePath ||
+							componentDirectory.startsWith(hdbBasePath + sep);
 						componentPath = join(containerFolder, 'node_modules', componentName);
 						while (!existsSync(componentPath)) {
-							containerFolder = dirname(containerFolder);
-							if (containerFolder.length < getHdbBasePath().length) {
+							const parentFolder = dirname(containerFolder);
+							if (parentFolder === containerFolder) {
+								componentPath = null;
+								break;
+							}
+							containerFolder = parentFolder;
+							if (
+								componentInsideHdb &&
+								containerFolder !== hdbBasePath &&
+								!containerFolder.startsWith(hdbBasePath + sep)
+							) {
 								componentPath = null;
 								break;
 							}

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -409,8 +409,7 @@ export async function loadComponent(
 						let containerFolder = componentDirectory;
 						const hdbBasePath = getHdbBasePath();
 						const componentInsideHdb =
-							componentDirectory === hdbBasePath ||
-							componentDirectory.startsWith(hdbBasePath + sep);
+							componentDirectory === hdbBasePath || componentDirectory.startsWith(hdbBasePath + sep);
 						componentPath = join(containerFolder, 'node_modules', componentName);
 						while (!existsSync(componentPath)) {
 							const parentFolder = dirname(containerFolder);

--- a/unitTests/components/componentLoaderWalk.test.js
+++ b/unitTests/components/componentLoaderWalk.test.js
@@ -1,0 +1,151 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const path = require('node:path');
+const { tmpdir } = require('node:os');
+const { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } = require('node:fs');
+
+// Exercises the extension-package `node_modules` walk in loadComponent (the non-root
+// `package:` resolution path). Regression coverage for the ROOTPATH-relative walk bug
+// (#1507): an app run via RUN_HDB_APP from outside ROOTPATH must reach packages hoisted
+// to a monorepo root even when that root's path is shorter than ROOTPATH, while
+// components inside ROOTPATH must still stop at the ROOTPATH boundary.
+//
+// HARPER_SAFE_MODE is set so the walk runs and resolves componentPath, but the recursive
+// loadComponent() of the resolved package is skipped — isolating the resolution logic
+// from actually loading a (fake) package module.
+describe('ComponentLoader node_modules walk (#1507)', function () {
+	let componentLoader;
+	let lifecycle;
+	let sandbox;
+	let baseDir;
+	let originalBasePath;
+	let originalSafeMode;
+	const env = require('#src/utility/environment/environmentManager');
+
+	// One extension config key; the walk looks for node_modules/<key>, so the directory
+	// created under node_modules must match this name (key === package name, as in the
+	// real `@harperfast/nextjs` symptom).
+	const PKG = 'test-hoisted-ext';
+	const CONFIG = `${PKG}:\n  package: ${PKG}\n`;
+
+	function makeApp(appDir) {
+		mkdirSync(appDir, { recursive: true });
+		writeFileSync(path.join(appDir, 'harperdb-config.yaml'), CONFIG);
+		return appDir;
+	}
+
+	function makeHoistedPackage(nodeModulesParent) {
+		const pkgDir = path.join(nodeModulesParent, 'node_modules', PKG);
+		mkdirSync(pkgDir, { recursive: true });
+		return pkgDir;
+	}
+
+	async function load(appDir) {
+		await componentLoader.loadComponent(appDir, { isWorker: true, set: sinon.stub() }, 'test-origin');
+		return `${path.basename(appDir)}.${PKG}`;
+	}
+
+	function loadedFor(statusName) {
+		return lifecycle.loaded.getCalls().filter((c) => c.args[0] === statusName);
+	}
+	function failedFor(statusName) {
+		return lifecycle.failed.getCalls().filter((c) => c.args[0] === statusName);
+	}
+
+	before(function () {
+		sandbox = sinon.createSandbox();
+		const statusModule = require('#src/components/status/index');
+		lifecycle = statusModule.lifecycle;
+		sandbox.spy(lifecycle, 'loading');
+		sandbox.spy(lifecycle, 'loaded');
+		sandbox.spy(lifecycle, 'failed');
+
+		componentLoader = require('#src/components/componentLoader');
+
+		baseDir = mkdtempSync(path.join(tmpdir(), 'harper-walk-'));
+		originalBasePath = env.getHdbBasePath();
+		originalSafeMode = process.env.HARPER_SAFE_MODE;
+		process.env.HARPER_SAFE_MODE = '1';
+	});
+
+	after(function () {
+		sandbox.restore();
+		env.setHdbBasePath(originalBasePath);
+		if (originalSafeMode === undefined) delete process.env.HARPER_SAFE_MODE;
+		else process.env.HARPER_SAFE_MODE = originalSafeMode;
+		if (baseDir && existsSync(baseDir)) rmSync(baseDir, { recursive: true, force: true });
+	});
+
+	beforeEach(function () {
+		lifecycle.loading.resetHistory();
+		lifecycle.loaded.resetHistory();
+		lifecycle.failed.resetHistory();
+	});
+
+	it('resolves a monorepo-root hoisted package when the app runs outside ROOTPATH (the bug)', async function () {
+		// ROOTPATH is long; the monorepo checkout is short — the exact shape that tripped the
+		// old `containerFolder.length < getHdbBasePath().length` heuristic.
+		env.setHdbBasePath(path.join(baseDir, 'install', 'x'.repeat(80), 'hdb'));
+
+		const repo = path.join(baseDir, 'monorepo');
+		const appDir = makeApp(path.join(repo, 'apps', 'web'));
+		makeHoistedPackage(repo); // repo/node_modules/test-hoisted-ext
+
+		assert.ok(
+			path.join(repo, 'apps').length < env.getHdbBasePath().length,
+			'precondition: the walked-up parent is shorter than ROOTPATH (reproduces the old heuristic abort)'
+		);
+
+		const statusName = await load(appDir);
+
+		assert.equal(failedFor(statusName).length, 0, 'package outside ROOTPATH should resolve, not fail');
+		assert.equal(
+			loadedFor(statusName).length,
+			1,
+			'component should be marked loaded after resolving the hoisted package'
+		);
+	});
+
+	it('walks to the filesystem root and fails gracefully when an outside-ROOTPATH package is genuinely absent', async function () {
+		env.setHdbBasePath(path.join(baseDir, 'install2', 'y'.repeat(80), 'hdb'));
+
+		// App outside ROOTPATH, no hoisted package anywhere up the tree.
+		const appDir = makeApp(path.join(baseDir, 'monorepo2', 'apps', 'web'));
+
+		const statusName = await load(appDir);
+
+		// The new dirname()-fixpoint guard must terminate the walk at the fs root (no infinite loop)
+		// and report the missing package rather than hang.
+		const failed = failedFor(statusName);
+		assert.equal(failed.length, 1, 'missing package should mark the component failed');
+		assert.match(String(failed[0].args[1]), /Unable to find package/);
+	});
+
+	it('resolves a package hoisted within ROOTPATH for a component inside ROOTPATH', async function () {
+		const hdb = path.join(baseDir, 'hdb');
+		env.setHdbBasePath(hdb);
+
+		const appDir = makeApp(path.join(hdb, 'components', 'myapp'));
+		makeHoistedPackage(hdb); // hdb/node_modules/test-hoisted-ext
+
+		const statusName = await load(appDir);
+
+		assert.equal(failedFor(statusName).length, 0, 'in-ROOTPATH package should resolve');
+		assert.equal(loadedFor(statusName).length, 1);
+	});
+
+	it('does not walk above ROOTPATH for a component inside ROOTPATH (boundary preserved)', async function () {
+		const hdb = path.join(baseDir, 'hdb3');
+		env.setHdbBasePath(hdb);
+
+		const appDir = makeApp(path.join(hdb, 'components', 'myapp'));
+		// Package sits ABOVE ROOTPATH — the old intent was to never escape the install root.
+		makeHoistedPackage(baseDir); // baseDir/node_modules/test-hoisted-ext (parent of ROOTPATH)
+
+		const statusName = await load(appDir);
+
+		const failed = failedFor(statusName);
+		assert.equal(failed.length, 1, 'package above ROOTPATH must not be resolved by an in-ROOTPATH component');
+		assert.match(String(failed[0].args[1]), /Unable to find package/);
+	});
+});


### PR DESCRIPTION
Supersedes #1507 (by @pbrumblay), rebased onto `main` and with regression tests added so it's ready to merge.

## The bug

Extension package resolution fails when an application is run via `RUN_HDB_APP` from **outside** ROOTPATH (e.g. `harper run` from a monorepo's `apps/web`).

`loadComponent` walks up from the app directory looking for `node_modules/<package>`, but the old loop stopped climbing as soon as the parent path's **string length** dropped below `getHdbBasePath().length`. That length heuristic is a proxy for "we've left the install root" — and it breaks whenever the app's checkout path is shorter than ROOTPATH. The walk aborts before reaching packages hoisted to the monorepo root.

This is why the failure looked machine-specific despite identical Node/Harper versions: it depended purely on whether the checkout path happened to be longer or shorter than ROOTPATH.

```
Error: Could not load component '@harperfast/nextjs' for application 'web'
due to: Unable to find package @harperfast/nextjs:@harperfast/nextjs
```
`require.resolve('@harperfast/nextjs', { paths: ['apps/web'] })` succeeds on the same machine — only Harper's loader failed.

## The fix (credit: @pbrumblay)

Replace the string-length heuristic with **path-prefix** logic:

- Apps **outside** ROOTPATH (`RUN_HDB_APP`): walk up to the filesystem root.
- Components **inside** `$ROOTPATH/components/`: stop at the ROOTPATH boundary (preserves the original intent).

Also adds a `dirname()` fixpoint guard (`parentFolder === containerFolder`) that terminates the walk at the filesystem root — the old loop had no fs-root guard and would spin if `getHdbBasePath()` were ever undefined.

## Tests added

`unitTests/components/componentLoaderWalk.test.js` drives the real `loadComponent` walk (`HARPER_SAFE_MODE` isolates path resolution from actually loading a package):

1. **The bug** — outside-ROOTPATH app resolves a monorepo-root hoisted package when the repo path is shorter than ROOTPATH.
2. **Termination** — a genuinely-absent package walks to the fs root and fails gracefully (no infinite loop); covers the new guard.
3. **In-ROOTPATH resolution** still works.
4. **Boundary preserved** — an in-ROOTPATH component does not resolve a package above ROOTPATH.

Verified that reverting to the old heuristic makes test 1 fail while the other three stay green (they characterize behavior the old code also had).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
