### PR TITLE
fix(models): surface the primary error when the fallback chain fails (#1537)

### DIFF
--- a/resources/models/Models.ts
+++ b/resources/models/Models.ts
@@ -98,8 +98,14 @@ export class Models implements ModelsContract {
 			this.#recordFailure(resolved.backend, 'embed', opts.model, accounting, undefined, startedAt, resolved.error);
 			throw resolved.error;
 		}
-		// Try candidates in order; record each attempt and fall through on failure.
-		let lastError: unknown;
+		// Try candidates in order, recording each attempt. Fall through to the next on
+		// ANY backend error — candidates are heterogeneous, so a limit/input error on
+		// one may still succeed on another; treating an error as "not worth a fallback"
+		// is a router/caller policy, not a facade default (#1537). If every candidate
+		// fails, surface the FIRST (primary) error: the caller asked for that backend,
+		// so it is the most diagnostic. A caller abort short-circuits.
+		let firstError: unknown = undefined;
+		let hasError = false;
 		for (const backend of resolved.candidates) {
 			// Don't spend a backend call on an already-cancelled request — between
 			// candidates the caller may have aborted (and at entry it may already be).
@@ -115,13 +121,14 @@ export class Models implements ModelsContract {
 				return result.output;
 			} catch (err) {
 				this.#recordFailure(backend, 'embed', opts.model, accounting, undefined, attemptStart, err);
-				lastError = err;
-				// Caller cancelled — stop. Any other failure (incl. a backend `pending`
-				// result or a backend-internal abort) falls through to the next candidate.
-				if (signal?.aborted) throw err;
+				if (!hasError) {
+					firstError = err;
+					hasError = true;
+				}
+				if (signal?.aborted) throw err; // caller cancelled — stop, surface the abort
 			}
 		}
-		throw lastError;
+		throw firstError;
 	}
 
 	async generate(input: GenerateInput, opts: GenerateOpts = {}): Promise<GenerateResult> {
@@ -148,7 +155,11 @@ export class Models implements ModelsContract {
 			this.#recordFailure(resolved.backend, 'generate', opts.model, accounting, opts, startedAt, resolved.error);
 			throw resolved.error;
 		}
-		let lastError: unknown;
+		// See embed(): fall through on any backend error (heterogeneous candidates;
+		// skip-policy is a router/caller concern, #1537), surface the FIRST error if all
+		// fail, abort short-circuits.
+		let firstError: unknown = undefined;
+		let hasError = false;
 		for (const backend of resolved.candidates) {
 			// Don't spend a backend call on an already-cancelled request — between
 			// candidates the caller may have aborted (and at entry it may already be).
@@ -165,13 +176,14 @@ export class Models implements ModelsContract {
 				return result.usage ? { ...result.output, usage: result.usage } : result.output;
 			} catch (err) {
 				this.#recordFailure(backend, 'generate', opts.model, accounting, opts, attemptStart, err);
-				lastError = err;
-				// Caller cancelled — stop. Any other failure (incl. a backend `pending`
-				// result or a backend-internal abort) falls through to the next candidate.
-				if (signal?.aborted) throw err;
+				if (!hasError) {
+					firstError = err;
+					hasError = true;
+				}
+				if (signal?.aborted) throw err; // caller cancelled — stop, surface the abort
 			}
 		}
-		throw lastError;
+		throw firstError;
 	}
 
 	generateStream(input: GenerateInput, opts: GenerateOpts = {}): AsyncIterable<GenerateChunk> {

--- a/unitTests/resources/models/routing.test.js
+++ b/unitTests/resources/models/routing.test.js
@@ -108,6 +108,35 @@ describe('Models routing (end-to-end)', () => {
 		assert.strictEqual(writer.records[1].backend, 'backup');
 	});
 
+	it('surfaces the primary (first) error, not the last candidate, when the whole chain fails (#1537)', async () => {
+		setGenerative(
+			'default',
+			defineBackend({
+				name: 'primary',
+				generate: async () => {
+					throw new Error('primary boom');
+				},
+			})
+		);
+		setGenerative(
+			'backup',
+			defineBackend({
+				name: 'backup',
+				generate: async () => {
+					throw new Error('backup boom');
+				},
+			})
+		);
+		setFallbackGroup('generative', 'default', ['backup']);
+		const writer = makeWriter();
+		// The primary is what the caller asked for, so its error is the most diagnostic.
+		await assert.rejects(() => new Models(writer, () => {}).generate('hi'), /primary boom/);
+		// Every candidate is still attempted and recorded — only the surfaced error changed.
+		assert.strictEqual(writer.records.length, 2);
+		assert.strictEqual(writer.records[0].backend, 'primary');
+		assert.strictEqual(writer.records[1].backend, 'backup');
+	});
+
 	it('generateStream throws synchronously for an unknown model (regression guard)', () => {
 		const models = new Models(makeWriter(), () => {});
 		assert.throws(() => models.generateStream('hi', { model: 'missing' }), { name: 'ModelBackendNotFoundError' });


### PR DESCRIPTION
> **Stacked on #1533** (base `feat/models-routing`). Review the 2-file diff here; this rebases onto `main` once #1533 merges.

## Summary

Follow-up from the #1326 routing review (kris). When every candidate in a fallback group fails, the facade threw the **last** candidate's error — usually the least diagnostic. Now it surfaces the **first (primary)** error: the caller asked for that backend, so its error is the most useful. `embed` / `generate` track the first failure and throw it after the chain is exhausted (`lastError` → `firstError`); each candidate is still attempted and recorded, and a caller abort still short-circuits with the abort error.

## Why not "skip non-retryable errors" (the other half of the review note)

Investigated and **deliberately deferred to router/caller policy**, not a facade default:

- **No reliable structured status to classify on** — backend errors put the HTTP status in the *message string* only; Bedrock uses `$metadata.httpStatusCode` + named SDK exceptions; network errors bubble raw. Facade-side classification would mean brittle cross-shape message parsing.
- **Candidates are heterogeneous** — a limit/input error (oversized context, unsupported param) on the primary may *succeed* on a fallback with a bigger window or different constraints. Blanket "don't retry input errors" would defeat the point of a fallback group.
- **A backend can't know if its error is fallback-terminal** — it doesn't know the alternatives. "Is this error worth a fallback?" is a *policy* decision, which the #1326 routing seam already lets a custom router (or a caller `try/catch`) own.

So the facade keeps falling through on any backend error and documents this; smarter skip-logic belongs in a router. (`IndexRebuildingError.retryable` exists, but its "retry the same op" semantics are the inverse of "try a different backend", so it isn't the right signal here.)

`toolMode:'auto'`'s up-front candidate probe is an intentional fail-loud guard; its sync-map-lookup cost doesn't warrant threading the result through the agent loop's public dispatch.

## Tests

`283 model unit tests pass`, incl. a new case asserting the **primary** error surfaces (`/primary boom/`) while both candidates are still attempted + recorded.

Closes #1537. Part of #510.

## Cross-model review (standard)

Codex + Harper-domain adjudication. **No blockers, no significant concerns.** Verified: `throw firstError` can never be `undefined` (the loop only runs on the non-empty-candidates branch); abort still records-then-surfaces the abort error (capture happens before the abort check); analytics call sites are byte-identical — only the surfaced error changed. The no-auto-skip decision was confirmed sound for Harper's threat model.

_Caveats:_ the Gemini (`agy`) leg timed out — partial second-model coverage (Codex + domain pass only). Pre-existing, out of scope here: `resolveCandidates` doesn't guard a *custom* router returning nullish array elements (app-dev-as-admin misuse of the #1326 seam) — flag if hardening the router contract is ever in scope.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
