### PR TITLE
fix: atomically swap component dir on deploy to avoid ENOTEMPTY on live apps

### DIFF
--- a/components/Application.ts
+++ b/components/Application.ts
@@ -126,6 +126,11 @@ export function isSSHAuthFailure(stderr: string): boolean {
 	);
 }
 
+// Hidden directory under the components root holding component versions renamed aside
+// during a deploy swap (see extractApplication). The leading dot keeps
+// loadComponentDirectories from loading its contents as components.
+export const ASIDE_STAGING_DIR = '.deploy-aside';
+
 /**
  * Extract an application given payload (content of the application) or package (npm-compatible identifier to the application).
  *
@@ -244,13 +249,19 @@ export async function extractApplication(application: Application) {
 	// anyway.) Renaming the old directory aside is atomic and immune to the race: the
 	// still-running worker keeps writing into the renamed inode harmlessly until it's
 	// replaced on restart, and the aside copy is removed best-effort below.
-	const dirName = basename(application.dirPath);
-	const asideSuffix = '.old-';
-	let previousDirPath: string | undefined;
+	//
+	// The aside lives under a hidden, component-scoped staging directory inside the
+	// components root: same filesystem as the source so the rename stays atomic, the
+	// leading dot keeps loadComponentDirectories from picking it up as a phantom
+	// component, and the per-component path means a sibling component never collides
+	// with (or sweeps) another's aside.
+	const asideStagingDir = join(dirname(application.dirPath), ASIDE_STAGING_DIR, basename(application.dirPath));
+	let didRenameAside = false;
 	try {
 		await access(application.dirPath, constants.F_OK);
-		previousDirPath = join(dirname(application.dirPath), `${dirName}${asideSuffix}${process.pid}-${Date.now()}`);
-		await rename(application.dirPath, previousDirPath);
+		await mkdir(asideStagingDir, { recursive: true });
+		await rename(application.dirPath, join(asideStagingDir, `${process.pid}-${Date.now()}`));
+		didRenameAside = true;
 	} catch (err) {
 		// Ignore does not exist error
 		if (err.code !== 'ENOENT') {
@@ -287,38 +298,17 @@ export async function extractApplication(application: Application) {
 		await rm(tarballPath, { force: true });
 	}
 
-	// Remove the renamed-aside previous version. The old worker may still hold files
-	// open in it (the live writer that motivated the rename), so this is best-effort:
-	// tolerate failure, and sweep any leftovers from earlier deploys whose workers
-	// have since exited. The unique suffix means a lingering aside dir never blocks a
-	// future deploy.
-	if (previousDirPath) {
-		await sweepAsideDirs(dirname(application.dirPath), dirName, asideSuffix);
+	// Remove this component's aside copies. The old worker may still hold files open
+	// in the just-renamed copy (the live writer that motivated the rename), so this is
+	// best-effort: removing the whole staging subdirectory also clears leftovers from
+	// earlier deploys whose workers have since exited, and a copy that survives because
+	// its worker is still live is swept by the next deploy. The failure is expected in
+	// the live-worker case, so it's logged at trace rather than as a warning.
+	if (didRenameAside) {
+		rm(asideStagingDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }).catch((err) =>
+			logger.trace?.(`Deferred cleanup of previous ${application.name} component directory: ${err.message}`)
+		);
 	}
-}
-
-/**
- * Best-effort removal of `<dirName>.old-*` directories left behind by extractApplication's
- * atomic swap. A still-running worker can keep an aside dir non-empty, so failures are
- * logged and ignored — the next deploy retries once that worker has exited.
- */
-async function sweepAsideDirs(parentDirPath: string, dirName: string, asideSuffix: string) {
-	const prefix = `${dirName}${asideSuffix}`;
-	let entries: string[];
-	try {
-		entries = await readdir(parentDirPath);
-	} catch {
-		return;
-	}
-	await Promise.all(
-		entries
-			.filter((entry) => entry.startsWith(prefix))
-			.map((entry) =>
-				rm(join(parentDirPath, entry), { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }).catch((err) =>
-					logger.warn?.(`Could not remove previous component directory ${entry}: ${err.message}`)
-				)
-			)
-	);
 }
 
 /**

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -4,7 +4,7 @@ import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 import logger from '../utility/logging/harper_logger.ts';
 import { broadcastDeployStart, broadcastDeployEnd } from './deployLifecycle.ts';
 
-import { dirname, extname, join } from 'node:path';
+import { basename, dirname, extname, join } from 'node:path';
 import {
 	access,
 	constants,
@@ -13,6 +13,7 @@ import {
 	mkdtemp,
 	readdir,
 	readFile,
+	rename,
 	rm,
 	stat,
 	symlink,
@@ -233,11 +234,23 @@ export async function extractApplication(application: Application) {
 		}
 	}
 
-	// Create the application directory
+	// Replace any existing component directory atomically instead of clearing it in
+	// place. A previous version's worker can still be running and actively writing
+	// into this directory — e.g. a live Next.js app writing into `.next/cache` — and
+	// an in-place recursive rm races that writer: rm empties `.next`, then its leaf
+	// `rmdir('.next')` fails with ENOTEMPTY because the worker just re-created a cache
+	// entry. (`force: true` only suppresses ENOENT; ENOTEMPTY is not retried unless
+	// `maxRetries` is set, and a continuously-writing app would outlast retries
+	// anyway.) Renaming the old directory aside is atomic and immune to the race: the
+	// still-running worker keeps writing into the renamed inode harmlessly until it's
+	// replaced on restart, and the aside copy is removed best-effort below.
+	const dirName = basename(application.dirPath);
+	const asideSuffix = '.old-';
+	let previousDirPath: string | undefined;
 	try {
 		await access(application.dirPath, constants.F_OK);
-		// directory already exists; clear it
-		await rm(application.dirPath, { recursive: true, force: true });
+		previousDirPath = join(dirname(application.dirPath), `${dirName}${asideSuffix}${process.pid}-${Date.now()}`);
+		await rename(application.dirPath, previousDirPath);
 	} catch (err) {
 		// Ignore does not exist error
 		if (err.code !== 'ENOENT') {
@@ -273,6 +286,39 @@ export async function extractApplication(application: Application) {
 	if (shouldDeleteTarball && tarballPath) {
 		await rm(tarballPath, { force: true });
 	}
+
+	// Remove the renamed-aside previous version. The old worker may still hold files
+	// open in it (the live writer that motivated the rename), so this is best-effort:
+	// tolerate failure, and sweep any leftovers from earlier deploys whose workers
+	// have since exited. The unique suffix means a lingering aside dir never blocks a
+	// future deploy.
+	if (previousDirPath) {
+		await sweepAsideDirs(dirname(application.dirPath), dirName, asideSuffix);
+	}
+}
+
+/**
+ * Best-effort removal of `<dirName>.old-*` directories left behind by extractApplication's
+ * atomic swap. A still-running worker can keep an aside dir non-empty, so failures are
+ * logged and ignored — the next deploy retries once that worker has exited.
+ */
+async function sweepAsideDirs(parentDirPath: string, dirName: string, asideSuffix: string) {
+	const prefix = `${dirName}${asideSuffix}`;
+	let entries: string[];
+	try {
+		entries = await readdir(parentDirPath);
+	} catch {
+		return;
+	}
+	await Promise.all(
+		entries
+			.filter((entry) => entry.startsWith(prefix))
+			.map((entry) =>
+				rm(join(parentDirPath, entry), { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }).catch((err) =>
+					logger.warn?.(`Could not remove previous component directory ${entry}: ${err.message}`)
+				)
+			)
+	);
 }
 
 /**

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -20,6 +20,7 @@ import {
 	writeFile,
 } from 'node:fs/promises';
 import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { createReadStream, existsSync, readdirSync } from 'node:fs';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
@@ -260,7 +261,7 @@ export async function extractApplication(application: Application) {
 	try {
 		await access(application.dirPath, constants.F_OK);
 		await mkdir(asideStagingDir, { recursive: true });
-		await rename(application.dirPath, join(asideStagingDir, `${process.pid}-${Date.now()}`));
+		await rename(application.dirPath, join(asideStagingDir, `${process.pid}-${Date.now()}-${randomUUID()}`));
 		didRenameAside = true;
 	} catch (err) {
 		// Ignore does not exist error

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -69,6 +69,9 @@ export function loadComponentDirectories(loadedPluginModules?: Map<any, any>, lo
 		const cfFolders = readdirSync(CF_ROUTES_DIR, { withFileTypes: true });
 		for (const appEntry of cfFolders) {
 			if (!appEntry.isDirectory() && !appEntry.isSymbolicLink()) continue;
+			// Skip hidden entries: component names are never dot-prefixed, and this keeps
+			// Harper's own staging dirs (e.g. deploy aside copies) from loading as components.
+			if (appEntry.name.startsWith('.')) continue;
 			const appName = appEntry.name;
 			const appFolder = join(CF_ROUTES_DIR, appName);
 			cfsLoaded.push(

--- a/components/operations.js
+++ b/components/operations.js
@@ -16,7 +16,7 @@ const { HDB_ERROR_MSGS, HTTP_STATUS_CODES } = hdbErrors;
 const manageThreads = require('../server/threads/manageThreads.js');
 const { packageDirectory } = require('../components/packageComponent.ts');
 const { Resources } = require('../resources/Resources.ts');
-const { Application, prepareApplication } = require('./Application.ts');
+const { Application, prepareApplication, ASIDE_STAGING_DIR } = require('./Application.ts');
 const { server } = require('../server/Server.ts');
 const { DeploymentRecorder, awaitDeploymentRow } = require('./deploymentRecorder.ts');
 const { ProgressEmitter } = require('../server/serverHelpers/progressEmitter.ts');
@@ -732,7 +732,7 @@ async function getComponents() {
 			const list = await fs.readdir(dir, { withFileTypes: true });
 			for (let item of list) {
 				const itemName = item.name;
-				if (itemName === 'node_modules') continue;
+				if (itemName === 'node_modules' || itemName === ASIDE_STAGING_DIR) continue;
 				const itemPath = path.join(dir, itemName);
 				if (item.isDirectory() || item.isSymbolicLink()) {
 					let res = {

--- a/unitTests/components/extractApplicationSwap.test.js
+++ b/unitTests/components/extractApplicationSwap.test.js
@@ -80,6 +80,16 @@ describe('extractApplication directory swap', () => {
 		assert.strictEqual(await fs.readFile(path.join(dirPath, 'index.js'), 'utf8'), 'module.exports = () => 2;\n');
 		assert.ok(writes > 0, 'writer should have run during the swap');
 
+		// The renamed-aside copy must stay hidden: the only non-dot entry under the
+		// components root is the live component, so loadComponentDirectories (which loads
+		// every visible dir as a component) can't pick up an aside as a phantom component.
+		const rootEntries = await fs.readdir(componentsRoot);
+		assert.deepStrictEqual(
+			rootEntries.filter((entry) => !entry.startsWith('.')),
+			['web'],
+			`unexpected non-hidden entries under components root: ${rootEntries.join(', ')}`
+		);
+
 		await fs.rm(componentsRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 		await fs.rm(sourceDir, { recursive: true, force: true });
 	});

--- a/unitTests/components/extractApplicationSwap.test.js
+++ b/unitTests/components/extractApplicationSwap.test.js
@@ -93,4 +93,54 @@ describe('extractApplication directory swap', () => {
 		await fs.rm(componentsRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 		await fs.rm(sourceDir, { recursive: true, force: true });
 	});
+
+	it('reclaims a stale aside copy left by an earlier deploy', async function () {
+		this.timeout(20000);
+
+		const componentsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'extract-swap-reclaim-'));
+		const dirPath = path.join(componentsRoot, 'web');
+		await fs.mkdir(dirPath, { recursive: true });
+		await fs.writeFile(path.join(dirPath, 'package.json'), '{"name":"web","version":"1.0.0"}\n');
+
+		// A leftover aside from a previous deploy whose worker has since exited — the kind
+		// of residue the best-effort cleanup tolerates, to be reclaimed by the next deploy.
+		const staleAside = path.join(componentsRoot, '.deploy-aside', 'web', 'stale-from-last-deploy');
+		await fs.mkdir(staleAside, { recursive: true });
+		await fs.writeFile(path.join(staleAside, 'leftover'), 'x');
+
+		const sourceDir = await makeFixture({
+			'package.json': '{"name":"web","version":"2.0.0"}\n',
+			'index.js': 'module.exports = () => 2;\n',
+		});
+		const app = new Application({
+			name: 'web',
+			payload: await packageDirectory(sourceDir, { skip_node_modules: true }),
+		});
+		app.dirPath = dirPath;
+
+		await extractApplication(app);
+
+		// Cleanup is fire-and-forget; with no live worker holding it, the staging dir is
+		// reclaimed promptly. Poll briefly so the assertion isn't racing the deferred rm.
+		const asideRoot = path.join(componentsRoot, '.deploy-aside', 'web');
+		const deadline = Date.now() + 5000;
+		let asideGone = false;
+		while (Date.now() < deadline) {
+			if (
+				!(await fs
+					.stat(asideRoot)
+					.then(() => true)
+					.catch(() => false))
+			) {
+				asideGone = true;
+				break;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 25));
+		}
+		assert.ok(asideGone, 'stale aside staging dir should be reclaimed by the deploy');
+		assert.strictEqual(JSON.parse(await fs.readFile(path.join(dirPath, 'package.json'), 'utf8')).version, '2.0.0');
+
+		await fs.rm(componentsRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+		await fs.rm(sourceDir, { recursive: true, force: true });
+	});
 });

--- a/unitTests/components/extractApplicationSwap.test.js
+++ b/unitTests/components/extractApplicationSwap.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const assert = require('node:assert');
+const path = require('node:path');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+
+const testUtils = require('../testUtils.js');
+testUtils.preTestPrep();
+
+const { extractApplication, Application } = require('#src/components/Application');
+const { packageDirectory } = require('#src/components/packageComponent');
+
+async function makeFixture(files) {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'extract-swap-src-'));
+	for (const [rel, content] of Object.entries(files)) {
+		const full = path.join(dir, rel);
+		await fs.mkdir(path.dirname(full), { recursive: true });
+		await fs.writeFile(full, content);
+	}
+	return dir;
+}
+
+describe('extractApplication directory swap', () => {
+	// Regression for the replicate-phase failure on a live Next.js peer:
+	//   ENOTEMPTY: directory not empty, rmdir '<component>/.next'
+	// The old worker keeps writing into .next/cache while the deploy replaces the
+	// component directory. Clearing the dir in place with a recursive rm raced that
+	// writer (its leaf rmdir of a just-repopulated .next threw ENOTEMPTY). The fix
+	// renames the old dir aside atomically, so a concurrent writer can't break it.
+	it('replaces a component dir while a worker is actively writing into .next/cache', async function () {
+		this.timeout(20000);
+
+		// Stand up a "currently deployed" component dir with a live .next/cache.
+		const componentsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'extract-swap-root-'));
+		const dirPath = path.join(componentsRoot, 'web');
+		const cacheDir = path.join(dirPath, '.next', 'cache');
+		await fs.mkdir(cacheDir, { recursive: true });
+		await fs.writeFile(path.join(dirPath, 'package.json'), '{"name":"web","version":"1.0.0"}\n');
+		// Seed many cache files so the (old) recursive rm has a wide window to lose the race.
+		for (let i = 0; i < 200; i++) await fs.writeFile(path.join(cacheDir, `seed-${i}`), 'x');
+
+		// The new version we're deploying — two top-level entries so the single-folder
+		// normalization path is skipped and we exercise the swap directly.
+		const sourceDir = await makeFixture({
+			'package.json': '{"name":"web","version":"2.0.0"}\n',
+			'index.js': 'module.exports = () => 2;\n',
+		});
+		const payload = await packageDirectory(sourceDir, { skip_node_modules: true });
+
+		// Live writer: hammers .next/cache the whole time the swap runs. Every fs error
+		// (ENOENT once the dir is renamed away, etc.) is swallowed so it can't surface as
+		// an unhandledRejection — it models a process that just keeps writing.
+		let writing = true;
+		let writes = 0;
+		const writer = (async () => {
+			while (writing) {
+				try {
+					await fs.mkdir(cacheDir, { recursive: true });
+					await fs.writeFile(path.join(cacheDir, `live-${writes++}`), 'data');
+				} catch {
+					/* directory swapped out from under us — keep going */
+				}
+			}
+		})();
+
+		const app = new Application({ name: 'web', payload });
+		app.dirPath = dirPath;
+
+		try {
+			// The assertion: this resolves instead of throwing ENOTEMPTY.
+			await extractApplication(app);
+		} finally {
+			writing = false;
+			await writer;
+		}
+
+		// The deployed payload is in place at the live path.
+		assert.strictEqual(JSON.parse(await fs.readFile(path.join(dirPath, 'package.json'), 'utf8')).version, '2.0.0');
+		assert.strictEqual(await fs.readFile(path.join(dirPath, 'index.js'), 'utf8'), 'module.exports = () => 2;\n');
+		assert.ok(writes > 0, 'writer should have run during the swap');
+
+		await fs.rm(componentsRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+		await fs.rm(sourceDir, { recursive: true, force: true });
+	});
+});


### PR DESCRIPTION
## Summary

`deploy_component` fails on a peer that is currently running the component, ~3s into the replicate phase:

```
ENOTEMPTY: directory not empty, rmdir '/home/harperdb/harper/components/<component>/.next'
```

`extractApplication` (`components/Application.ts`) cleared the existing component directory **in place** — `rm(dirPath, { recursive: true, force: true })` then `mkdir` + extract. When a previous version's worker is still running and writing into that directory (a live Next.js app continuously writing `.next/cache` under traffic), the recursive `rm` races that writer: Node empties `.next`, then its internal leaf `rmdir('.next')` throws `ENOTEMPTY` because the worker just re-created a cache entry. (`force: true` only suppresses `ENOENT`; `ENOTEMPTY` is retried only with `maxRetries > 0`, and a continuously-writing app would outlast retries anyway.)

Matches the field report exactly: only the **web** (Next.js) component fails — agent + schema in the same deploy replicate fine; only the **live peer** fails (origin/just-restarted nodes have no active writer); restarting the node clears it.

## Fix

Replace the in-place destruction with an **atomic swap**: rename the existing directory aside into a hidden, component-scoped staging dir `<componentsRoot>/.deploy-aside/<name>/<pid>-<ts>-<uuid>` (same parent → same filesystem → atomic `rename`) before `mkdir` + extract. The still-running worker keeps writing into the renamed inode harmlessly until it's replaced on restart. The staging subdir is then removed best-effort (fire-and-forget, logged at trace since failure is expected while the worker is live); leftovers are reclaimed by the next deploy.

`loadComponentDirectories` loads every visible directory under the components root as a component, so the staging dir is hidden (dot-prefixed) and the loader now skips dot-prefixed entries; `get_components`' `walkDir` skips the staging dir too.

## Where to look

- The swap block in `extractApplication` — rename-aside replaces the old `access` + in-place `rm` + `mkdir`.
- Best-effort cleanup semantics: failure is tolerated by design (a still-running worker can keep the aside non-empty); the next deploy reclaims it. Sanity-check that this best-effort-with-residue tradeoff is acceptable vs. blocking the deploy on cleanup.

## Cross-model review

Reviewed via the cross-model skill (Gemini + Harper-domain adjudication). No blockers or significant issues in the committed code. The early collision/log-noise findings drove the staging-dir redesign and are resolved.

**Open follow-ups (pre-existing, not introduced here — flagging for a reviewer call on whether to fold in or track separately):**
- The single-top-level-folder normalization right below uses `mkdtemp(application.dirPath)`, creating a **non-hidden** sibling `<componentsRoot>/<name>XXXXXX`. On a crash between `mkdtemp` and its `rm`, that leftover would load as a phantom component. Independent of this race.
- `dropCustomFunctionProject` (`components/operations.js`) deletes a component dir in place with `rmSync(..., { recursive: true })` — same live-writer `ENOTEMPTY` race is possible, though semantics differ (the component is being removed, not swapped). Lower stakes.

## Tests

`unitTests/components/extractApplicationSwap.test.js`: (1) a populated `.next/cache` + an aggressive concurrent writer during `extractApplication` — fails on the old code with the exact `ENOTEMPTY ... rmdir '.../.next/cache'`, passes on the fix, and asserts no non-hidden leftover appears under the components root; (2) a stale aside from an earlier deploy is reclaimed.

🤖 Generated by Claude (Opus 4.8).