### PR TITLE
fix(analytics): bound the last-aggregation lookup to avoid main-thread full-scans (#1538)

### DIFF
--- a/resources/analytics/write.ts
+++ b/resources/analytics/write.ts
@@ -815,7 +815,8 @@ export function findLastAggregationTime(
 ): number | undefined {
 	let scanned = 0;
 	for (const entry of primaryStore.getRange({ start: Infinity, end: false, reverse: true })) {
-		if (entry.value?.time && entry.value?.id?.[1] === localNodeId) return entry.value.time;
+		if (entry.value?.time && Array.isArray(entry.value.id) && entry.value.id[1] === localNodeId)
+			return entry.value.time;
 		if (++scanned >= maxScan) break;
 	}
 	return undefined;

--- a/resources/analytics/write.ts
+++ b/resources/analytics/write.ts
@@ -792,6 +792,35 @@ async function storeNodeStorageMetric(analyticsTable: Table) {
 	}
 }
 
+// Upper bound on the cold-start reverse scan that seeds `lastAggregationTime`. A healthy node's
+// newest record matches at depth 1; this cap only engages in the pathological no-matching-record
+// case, keeping the one-time main-thread decode cost bounded instead of O(table size). See #1538.
+const MAX_LAST_AGGREGATION_SCAN = 1000;
+// Time of this node's last completed aggregation, tracked in O(1) across cycles within a process.
+let lastAggregationTime: number | undefined;
+
+/**
+ * Find the time of the local node's most recent aggregation record by scanning back from the
+ * newest entry. The scan is BOUNDED to `maxScan` records: if no composite-id record for this node
+ * sits near the top — e.g. legacy scalar ids carried across an upgrade, or a node that has never
+ * completed an aggregation — an unbounded reverse scan would decode the entire table with msgpackr
+ * on the main thread, starving TLS handshakes and other main-thread work. Returns `undefined` when
+ * no match is found within the bound, so the caller falls back to aggregating recent raw data
+ * rather than scanning to EOF. Exported for testing. See #1538.
+ */
+export function findLastAggregationTime(
+	primaryStore: { getRange(options: object): Iterable<{ value?: any }> },
+	localNodeId: number,
+	maxScan: number = MAX_LAST_AGGREGATION_SCAN
+): number | undefined {
+	let scanned = 0;
+	for (const entry of primaryStore.getRange({ start: Infinity, end: false, reverse: true })) {
+		if (entry.value?.time && entry.value?.id?.[1] === localNodeId) return entry.value.time;
+		if (++scanned >= maxScan) break;
+	}
+	return undefined;
+}
+
 async function aggregation(fromPeriod, toPeriod = 60000) {
 	const rawAnalyticsTable = getRawAnalyticsTable();
 	const analyticsTable = getAnalyticsTable();
@@ -805,20 +834,21 @@ async function aggregation(fromPeriod, toPeriod = 60000) {
 		}
 		return delay;
 	})();
-	let lastForPeriod;
 	const localNodeId = getHostNodeId(server.hostname);
-	// find the last entry for this period for the local node only
-	for (const entry of analyticsTable.primaryStore.getRange({
-		start: Infinity,
-		end: false,
-		reverse: true,
-	})) {
-		if (!entry.value?.time || entry.value?.id[1] !== localNodeId) continue;
-		lastForPeriod = entry.value.time;
-		break;
+	// Find the time of this node's last aggregation. In steady state this is tracked in O(1) via
+	// `lastAggregationTime` (set at the end of every completed run below), so cycles after the
+	// first never touch the table. On the first cycle after boot we seed it once from the table
+	// via a bounded reverse scan (see findLastAggregationTime). Caching the seeded value keeps
+	// the next cycle O(1) even when this run early-returns below as "too recent"; a bound-hit
+	// (no match) leaves it undefined so we don't early-return, proceed to aggregate, and set the
+	// marker to `now` at the end of the cycle instead (#1538).
+	let lastForPeriod = lastAggregationTime;
+	if (lastForPeriod === undefined) {
+		lastForPeriod = findLastAggregationTime(analyticsTable.primaryStore, localNodeId);
+		if (lastForPeriod !== undefined) lastAggregationTime = lastForPeriod;
 	}
 	// was the last aggregation too recent to calculate a whole period?
-	if (Date.now() - toPeriod < lastForPeriod) return;
+	if (lastForPeriod !== undefined && Date.now() - toPeriod < lastForPeriod) return;
 	let firstForPeriod;
 	const aggregateActions = new Map();
 	const distributions = new Map();
@@ -977,6 +1007,13 @@ async function aggregation(fromPeriod, toPeriod = 60000) {
 	};
 	storeMetric(analyticsTable, cruMetric);
 	lastResourceUsage = resourceUsage;
+	// Advance the O(1) last-aggregation marker to this cycle's time. The resource-usage metric
+	// just written is a composite-id record stamped `time: now`, so it is exactly what the
+	// reverse-scan seed would find as the newest matching record. Updating it every completed
+	// cycle — not only when there were raw updates — keeps the `Date.now() - toPeriod` period
+	// guard enforcing the configured cadence during idle stretches, matching the prior
+	// scan-based behavior rather than letting a stale marker run aggregation on every tick (#1538).
+	lastAggregationTime = now;
 
 	// `system` is set as non-enumerable on the object returned by getDatabases() so most
 	// callers skip it; for analytics we want it included, so build a view where it's enumerable.

--- a/unitTests/resources/analytics/write.test.js
+++ b/unitTests/resources/analytics/write.test.js
@@ -11,6 +11,7 @@ const {
 	buildRocksDBDbMetric,
 	buildRocksDBTableMetric,
 	buildRocksDBTxnLogMetric,
+	findLastAggregationTime,
 } = require('#src/resources/analytics/write');
 const { writeFile, mkdtemp, rm, mkdir } = require('node:fs/promises');
 const { join } = require('node:path');
@@ -437,5 +438,67 @@ describe('buildRocksDBTxnLogMetric', () => {
 		expect(metric.totalsTransactionsWritten).to.equal(0);
 		expect(metric.replayGapBytes).to.equal(0);
 		expect(metric.fileCount).to.equal(0);
+	});
+});
+
+describe('findLastAggregationTime (#1538)', () => {
+	const NODE = 1890011054; // a stableNodeId-shaped 32-bit int
+	const OTHER = 1120178829;
+
+	// Build a mock primaryStore whose getRange yields `entries` (already in reverse/newest-first
+	// order, matching `{ start: Infinity, reverse: true }`). Records how many entries were pulled
+	// so we can assert the scan is bounded.
+	function mockStore(entries) {
+		const store = { pulled: 0 };
+		store.getRange = function* () {
+			for (const value of entries) {
+				store.pulled++;
+				yield { value };
+			}
+		};
+		return store;
+	}
+
+	const composite = (time, nodeId = NODE) => ({ id: [time, nodeId], time, metric: 'aggregation' });
+	const legacyScalar = (time) => ({ id: time, time, metric: 'aggregation' }); // pre-upgrade scalar id
+
+	it('matches the newest record at depth 1 for a healthy node', () => {
+		const store = mockStore([composite(5000), composite(4000), composite(3000)]);
+		expect(findLastAggregationTime(store, NODE)).to.equal(5000);
+		expect(store.pulled).to.equal(1);
+	});
+
+	it('skips records belonging to other node ids', () => {
+		const store = mockStore([composite(5000, OTHER), composite(4000, OTHER), composite(3000, NODE)]);
+		expect(findLastAggregationTime(store, NODE)).to.equal(3000);
+		expect(store.pulled).to.equal(3);
+	});
+
+	it('skips legacy scalar-id records and finds a deeper composite match', () => {
+		const store = mockStore([legacyScalar(5000), legacyScalar(4000), composite(3000)]);
+		expect(findLastAggregationTime(store, NODE)).to.equal(3000);
+	});
+
+	it('skips records without a time', () => {
+		const store = mockStore([{ id: [5000, NODE], metric: 'aggregation' }, composite(4000)]);
+		expect(findLastAggregationTime(store, NODE)).to.equal(4000);
+	});
+
+	it('returns undefined and stays bounded when no record matches within maxScan', () => {
+		// Simulate the production wedge: a table whose top is all legacy scalar ids. Use a small
+		// maxScan with strictly more entries available so we prove the scan STOPS at the bound
+		// instead of decoding the whole table on the main thread — the whole point of #1538.
+		const maxScan = 100;
+		const entries = [];
+		for (let t = maxScan * 5; t > 0; t--) entries.push(legacyScalar(t));
+		const store = mockStore(entries);
+		expect(findLastAggregationTime(store, NODE, maxScan)).to.equal(undefined);
+		expect(store.pulled).to.equal(maxScan);
+	});
+
+	it('returns undefined on an empty table', () => {
+		const store = mockStore([]);
+		expect(findLastAggregationTime(store, NODE)).to.equal(undefined);
+		expect(store.pulled).to.equal(0);
 	});
 });


### PR DESCRIPTION
Fixes #1538.

## Problem

The analytics aggregation cycle finds this node's last-aggregation time by reverse-scanning `system.hdb_analytics` for a record whose composite id matches the local nodeId. When no such record sits near the top — legacy scalar ids carried across an upgrade, or a node that has never completed an aggregation — the scan never early-terminates and decodes the **entire** table with msgpackr **on the main thread**, every `aggregatePeriod/2`. On the ~19.7M-row production table this saturated the main thread for tens of seconds (40–74s observed), starving new mTLS/connection setup — a partial outage while data-plane workers sat ~23% idle.

It's self-perpetuating: the composite "anchor" record that makes the lookup match at depth 1 is only written *after* a scan completes, so a node whose first scan never finishes under load never writes one and full-scans forever. Same code path is live in v4.7.x (field evidence in the issue).

## Fix

- **O(1) steady state.** Track the last-aggregation time in a module-level marker advanced at the end of every *completed* cycle to `now` — the timestamp stamped on the unconditionally-written resource-usage record, i.e. exactly what the reverse scan would return as the newest matching entry. Cycles after the first never touch the table.
- **Bounded cold-start seed.** On the first cycle per process the marker is seeded via `findLastAggregationTime()`, a reverse scan capped at `MAX_LAST_AGGREGATION_SCAN` (1000). On a miss it returns `undefined` and we fall back to aggregating recent raw data rather than scanning to EOF — which also tolerates legacy non-composite ids without degrading the lookup.

The forward raw scan already self-bounds to one period, so resuming from the cached marker is equivalent to the prior table-derived value — no aggregation gap, no double-count.

## Tests

Extracted `findLastAggregationTime()` as an exported helper with 6 regression tests: depth-1 match, other-node skip, legacy-scalar skip, no-`time` skip, the bounded no-match case (proves the scan stops at `maxScan` instead of decoding the whole table), and empty-table.

## Cross-model review

Reviewed via the cross-model skill (Codex correctness/concurrency leg + Gemini perf leg + Harper-domain pass). Findings addressed before this PR:

- **[Codex, significant]** An earlier revision cached the *raw cursor* (`lastTime`) only on cycles with raw updates; when traffic stopped, the period guard compared against a frozen-past value and ran aggregation on every tick (emitting built-in metrics at 2× cadence). Fixed by advancing the marker to `now` every completed cycle — faithful to the prior scan-based behavior.
- **[Gemini, significant]** Scan-miss left the marker uncached → repeated rescans. Subsumed by the above: a miss no longer early-returns, so the cycle proceeds and sets the marker to `now`.
- **[Gemini, blocker — false positive]** `strictNullChecks` compile error on the `number | undefined` comparison. `strictNullChecks` is off in this repo (build is green); nonetheless added an explicit `!== undefined` guard for clarity/future-proofing.
- **[Gemini, suggestion]** Trimmed the bounded-scan test's mock table from 1M rows to a small `maxScan`-relative size.

## Notes

- This is the durable core fix the production field-workaround (insert one anchor + restart) stood in for. Same path ships in v4.7.x — flagging whether a v4 backport is in scope.
- `MAX_LAST_AGGREGATION_SCAN = 1000` is a judgment call: depth-1 on any healthy node, ~tens of ms one-time worst case in the pathological case. Easy to raise.