### PR TITLE
fix(blob): harden FileBackedBlob.stream() cancel/cleanup paths (#1457)

### DIFF
--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -340,7 +340,20 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 		let totalContentRead = 0;
 		let watcher: FSWatcher;
 		let timer: NodeJS.Timeout;
+		// The start() open-retry timer lives in a different scope/phase than pull()'s `timer`; track it
+		// separately so a cancel() during the file-creation wait clears it instead of leaking an fd (#1457).
+		let openTimer: NodeJS.Timeout;
 		let isBeingWritten: boolean;
+		// Close the descriptor at most once. Without nulling `fd`, a later close()/cancel() (e.g. a
+		// GC-driven cancel after a successful read) would close a descriptor the OS may have reassigned to
+		// an unrelated file/socket; and a cancel() before start()'s open() resolves would call
+		// close(undefined) and throw. Guarding on `fd != null` fixes both (#1457).
+		const closeFd = () => {
+			if (fd != null) {
+				close(fd);
+				fd = null;
+			}
+		};
 		let previouslyFinishedWriting = false;
 		const blob = this;
 		// Authoritative (uncompressed) content length from the record descriptor, captured before the
@@ -365,10 +378,11 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 								if (Date.now() < deadline) {
 									logger.debug?.('File does not exist yet, waiting for it to be created', filePath);
 									// the file doesn't exist, so we need to wait for it to be created
-									return setTimeout(() => {
+									openTimer = setTimeout(() => {
 										checkIfIsBeingWritten();
 										openFile(resolve, reject);
 									}, 20).unref();
+									return openTimer;
 								}
 							}
 							// ENOENT: the file is gone. A writer still holding the lock means we timed out waiting
@@ -400,9 +414,15 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 				// it; bounds the case where the header reports a known size but the bytes never arrive (a
 				// present-but-truncated blob whose writer lock stays held) (#1454).
 				let incompleteDeadline = 0;
+				// Settle this pull exactly once. A slow async read that completes with an error after the
+				// watcher-timeout path already called onError() (and closed the fd) would otherwise run
+				// onError twice — double close + duplicated #onError callbacks (#1457).
+				let settled = false;
 				return new Promise(function readMore(resolve: () => void, reject: (error: Error) => void) {
 					function onError(error) {
-						close(fd);
+						if (settled) return;
+						settled = true;
+						closeFd();
 						clearTimeout(timer);
 						if (watcher) watcher.close();
 						reject(error);
@@ -411,6 +431,9 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 					// allocate a buffer for reading. Note that we could do a stat to get the size, but that is a little more complicated, and might be a little extra overhead
 					const buffer = Buffer.allocUnsafe(0x40000);
 					read(fd, buffer, 0, buffer.length, position, (error, bytesRead, buffer) => {
+						// A late read completion after the pull already settled (via onError or terminal
+						// close) must not re-enter the state machine (#1457).
+						if (settled) return;
 						// TODO: Implement support for decompression
 						totalContentRead += bytesRead;
 						if (error) return onError(error);
@@ -472,6 +495,7 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 						} else if (bytesRead === 0) {
 							const buffer = Buffer.allocUnsafe(8);
 							return read(fd, buffer, 0, HEADER_SIZE, 0, (error) => {
+								if (settled) return;
 								if (error) return onError(error);
 								size = Number(new DataView(buffer.buffer, buffer.byteOffset, 8).getBigUint64(0) & 0xffffffffffffn);
 								if (size > totalContentRead) {
@@ -571,7 +595,8 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 									}
 									return;
 								}
-								close(fd);
+								settled = true;
+								closeFd();
 								controller.close();
 								resolve();
 							});
@@ -579,19 +604,26 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 							buffer = buffer.subarray(0, bytesRead);
 						}
 						if (start !== undefined || end !== undefined) {
+							// content offset of the first byte currently in `buffer`. The 8-byte header is only
+							// present in — and stripped from — the first read at file position 0; every later read
+							// starts HEADER_SIZE into the file relative to its content offset.
+							const contentStart = position === 0 ? 0 : position - HEADER_SIZE;
 							if (start && totalContentRead < start) {
-								// we are before the start of the slice, so we need to read more
-								position += bytesRead;
+								// we are before the start of the slice. Seek straight to it (HEADER_SIZE + start)
+								// instead of reading and discarding a 256KB buffer per chunk from byte 0. The header
+								// has already been validated and the size detected on the first read (#1457).
+								position = HEADER_SIZE + start;
+								totalContentRead = start;
 								return readMore(resolve, reject);
 							}
 							if (end && totalContentRead >= end) {
 								// we are past or reached the end of the slice, so we have reached the end, indicate
-								if (totalContentRead > end) buffer = buffer.subarray(0, end - position);
+								if (totalContentRead > end) buffer = buffer.subarray(0, end - contentStart);
 								totalContentRead = size = end;
 							}
-							if (start && start > position) {
-								// we need to skip ahead to the start of the slice
-								buffer = buffer.subarray(start - position);
+							if (start && start > contentStart) {
+								// we need to skip ahead to the start of the slice within this chunk
+								buffer = buffer.subarray(start - contentStart);
 							}
 						}
 						position += bytesRead;
@@ -604,7 +636,8 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 							return resolve();
 						}
 						if (totalContentRead === size) {
-							close(fd);
+							settled = true;
+							closeFd();
 							controller.close();
 						}
 						resolve();
@@ -612,8 +645,9 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 				});
 			},
 			cancel() {
-				close(fd);
+				closeFd();
 				clearTimeout(timer);
+				clearTimeout(openTimer);
 				if (watcher) watcher.close();
 			},
 		});

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -343,6 +343,10 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 		// The start() open-retry timer lives in a different scope/phase than pull()'s `timer`; track it
 		// separately so a cancel() during the file-creation wait clears it instead of leaking an fd (#1457).
 		let openTimer: NodeJS.Timeout;
+		// Stream-wide cancellation gate. cancel() can null `fd` but cannot reach pull()'s per-pull
+		// `settled` flag, so this is the cross-phase signal that stops start()/pull() from opening or
+		// reading once the consumer has cancelled (e.g. an aborted ranged response) (#1457).
+		let cancelled = false;
 		let isBeingWritten: boolean;
 		// Close the descriptor at most once. Without nulling `fd`, a later close()/cancel() (e.g. a
 		// GC-driven cancel after a successful read) would close a descriptor the OS may have reassigned to
@@ -371,6 +375,7 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 				// lookup) is computed lazily on the first miss, so a healthy read never pays for it.
 				let deadline = 0;
 				const openFile = (resolve: (value: any) => void, reject: (error: Error) => void) => {
+					if (cancelled) return resolve(undefined); // consumer cancelled before/while opening; stop retrying
 					open(filePath, 'r', (error, openedFd) => {
 						if (error) {
 							if (error.code === 'ENOENT' && isBeingWritten !== false) {
@@ -400,6 +405,9 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 							blob.#onError?.forEach((callback) => callback(readError));
 						} else {
 							fd = openedFd;
+							// the consumer cancelled while open() was in flight: pull()/cancel() will not run
+							// again, so close the descriptor we just acquired rather than leaking it (#1457)
+							if (cancelled) closeFd();
 							resolve(openedFd);
 						}
 					});
@@ -419,6 +427,9 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 				// onError twice — double close + duplicated #onError callbacks (#1457).
 				let settled = false;
 				return new Promise(function readMore(resolve: () => void, reject: (error: Error) => void) {
+					// A queued timer/watcher callback can re-enter readMore after the stream was cancelled (fd
+					// is gone); stop here so we never issue read() on a closed/nulled descriptor (#1457).
+					if (cancelled || fd == null) return resolve();
 					function onError(error) {
 						if (settled) return;
 						settled = true;
@@ -432,8 +443,10 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 					const buffer = Buffer.allocUnsafe(0x40000);
 					read(fd, buffer, 0, buffer.length, position, (error, bytesRead, buffer) => {
 						// A late read completion after the pull already settled (via onError or terminal
-						// close) must not re-enter the state machine (#1457).
-						if (settled) return;
+						// close) or after the stream was cancelled (fd nulled, EBADF/partial read) must not
+						// re-enter the state machine — otherwise a recursive read() would hit a null fd and
+						// throw synchronously, or onError() would reject an already-cancelled stream (#1457).
+						if (settled || cancelled) return resolve();
 						// TODO: Implement support for decompression
 						totalContentRead += bytesRead;
 						if (error) return onError(error);
@@ -495,7 +508,7 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 						} else if (bytesRead === 0) {
 							const buffer = Buffer.allocUnsafe(8);
 							return read(fd, buffer, 0, HEADER_SIZE, 0, (error) => {
-								if (settled) return;
+								if (settled || cancelled) return resolve();
 								if (error) return onError(error);
 								size = Number(new DataView(buffer.buffer, buffer.byteOffset, 8).getBigUint64(0) & 0xffffffffffffn);
 								if (size > totalContentRead) {
@@ -645,6 +658,7 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 				});
 			},
 			cancel() {
+				cancelled = true;
 				closeFd();
 				clearTimeout(timer);
 				clearTimeout(openTimer);

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -383,6 +383,34 @@ describe('Blob test', () => {
 		slicedStreamResults = streamToBuffer(slicedStream);
 		assert.equal(await slicedStreamResults, expectedResults.slice(1000, 11000));
 	});
+	it('slice a multi-chunk blob via stream() seeks past the read chunk size (#1457)', async () => {
+		// 0x40000 is the stream() read-buffer size. The older slice tests only cover offsets within the
+		// first chunk; exercise slices whose start and/or end land in later chunks so the seek and the
+		// content-offset accounting are covered (previously the slice would read and discard every chunk
+		// from byte 0, and the past-first-chunk trim was off by HEADER_SIZE).
+		const CHUNK = 0x40000;
+		const data = randomBytes(CHUNK * 2 + 5000);
+		const blob = await createBlob(data); // > FILE_STORAGE_THRESHOLD → file-backed
+		await BlobTest.put({ id: 50, blob });
+		const record = await BlobTest.get(50);
+		const cases = [
+			[100, 200], // within the first chunk (regression guard)
+			[0, CHUNK], // exactly the first chunk
+			[CHUNK - 100, CHUNK + 100], // straddles the first/second chunk boundary
+			[CHUNK + 1000, CHUNK + 2000], // start and end both in the second chunk (seek path)
+			[CHUNK * 2 + 100, undefined], // start in the third chunk, run to EOF
+			[5000, data.length], // start in the first chunk, run to EOF across chunks
+		];
+		for (const [start, end] of cases) {
+			const sliced = end === undefined ? record.blob.slice(start) : record.blob.slice(start, end);
+			const streamed = await streamToBytes(sliced.stream());
+			const expected = data.subarray(start, end);
+			assert(
+				streamed.equals(expected),
+				`slice(${start}, ${end}) stream mismatch: got ${streamed.length} bytes, expected ${expected.length}`
+			);
+		}
+	});
 	it('Abort reading a blob', async () => {
 		let testString = 'this is a test string for deletion'.repeat(800);
 		let blob = await createBlob(Readable.from(testString));
@@ -1266,4 +1294,12 @@ async function streamToBuffer(stream) {
 		retrievedDataFromStream.push(chunk);
 	}
 	return Buffer.concat(retrievedDataFromStream).toString();
+}
+
+async function streamToBytes(stream) {
+	const chunks = [];
+	for await (const chunk of stream) {
+		chunks.push(chunk);
+	}
+	return Buffer.concat(chunks);
 }

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -35,6 +35,7 @@ const {
 	statSync,
 	truncateSync,
 	writeFileSync,
+	readdirSync,
 } = require('fs');
 const { pack } = require('msgpackr');
 const { randomBytes } = require('crypto');
@@ -419,6 +420,53 @@ describe('Blob test', () => {
 			break;
 		}
 		// just make sure there is no error
+	});
+	it('cancel a blob stream mid-read does not throw or reject (#1457)', async () => {
+		// Cancelling while an fs.read may be in flight must not recurse into read(null) (sync throw) or
+		// reject the cancelled pull (unhandled rejection) — the cancel-race the cross-model review caught.
+		const data = randomBytes(0x40000 * 2 + 1000); // multi-chunk, file-backed
+		const blob = await createBlob(data);
+		await BlobTest.put({ id: 51, blob });
+		const record = await BlobTest.get(51);
+		const rejections = [];
+		const onRej = (e) => rejections.push(e);
+		process.on('unhandledRejection', onRej);
+		try {
+			// cancel before any chunk is pulled (start()'s open may still be in flight)
+			await record.blob.stream().getReader().cancel();
+			// cancel after the first chunk, with a second read likely in flight
+			const reader = record.blob.stream().getReader();
+			await reader.read();
+			const racing = reader.read();
+			await reader.cancel();
+			await racing.catch(() => {});
+			await new Promise((res) => setTimeout(res, 50)); // let any late fs.read callback fire
+		} finally {
+			process.off('unhandledRejection', onRej);
+		}
+		assert.deepEqual(rejections, [], 'cancel must not produce unhandled rejections');
+		// the blob is still readable afterwards (no wedged state)
+		assert((await (await BlobTest.get(51)).blob.bytes()).equals(data));
+	});
+	it('cancel before open() resolves does not leak fds (#1457)', async () => {
+		const fdDir = '/proc/self/fd';
+		if (!existsSync(fdDir)) return; // Linux-only fd accounting
+		const data = randomBytes(20000);
+		const blob = await createBlob(data);
+		await BlobTest.put({ id: 52, blob });
+		const record = await BlobTest.get(52);
+		const countFds = () => readdirSync(fdDir).length;
+		await record.blob.stream().getReader().cancel(); // warm up lazy config lookups
+		await new Promise((res) => setTimeout(res, 50));
+		const before = countFds();
+		for (let i = 0; i < 50; i++) {
+			// cancel immediately, while start()'s open() is still in flight: the descriptor it later
+			// acquires must be closed by the cancelled-guard, not leaked.
+			await record.blob.stream().getReader().cancel();
+		}
+		await new Promise((res) => setTimeout(res, 100)); // let in-flight opens resolve and self-close
+		const after = countFds();
+		assert(after - before < 10, `fd leak across 50 cancels: grew from ${before} to ${after}`);
 	});
 	it('Abort writing a blob', async () => {
 		let testString = 'this is a test string'.repeat(256);


### PR DESCRIPTION
Closes #1457.

Fixes pre-existing reliability/correctness hazards in `resources/blob.ts` `FileBackedBlob.stream()`, surfaced by the cross-model review of #1454 / PR #1456 in code those PRs do not change. None are regressions from #1456 — they predate it.

## What changed

The five hazards listed in #1457:

1. **`fd` not nulled after close → double-close on a reassigned descriptor.** All closes now route through a `closeFd()` helper that guards on `fd != null` and nulls it. A later GC-driven `cancel()` after a successful read can no longer close a descriptor the OS may have reassigned to an unrelated file/socket.
2. **`cancel()` before `open()` resolves → `close(undefined)` throw.** Same `fd != null` guard.
3. **`start()` open-retry 20ms timer was untracked** (different scope than `pull()`'s `timer`), leaking an fd if cancelled during the file-creation wait. Tracked as `openTimer` and cleared in `cancel()`.
4. **Double `onError`** — a slow async read completing with an error after the watcher-timeout path already called `onError()` ran it twice (double close + duplicated `#onError` callbacks). Added a per-pull `settled` guard.
5. **Slice read sequentially from byte 0** — `slice(start,end).stream()` read and discarded a 256KB buffer per chunk from offset 0 instead of seeking to `HEADER_SIZE + start`. Now seeks directly.

### Latent correctness bug fixed alongside #5
The slice trim used the file `position` where it needed the **content** offset (`position - HEADER_SIZE`). Any slice whose bound landed past the first `0x40000` chunk returned bytes shifted by `HEADER_SIZE`. Existing tests only sliced within the first chunk, so it was never exercised. The seek rewrite corrects the accounting; the new cross-chunk slice test fails on the old code.

## Cross-model review caught two blockers (also fixed here)

A first pass relied on a **per-pull `settled` flag**, which `cancel()` (a different scope) can't set. Codex and Gemini both flagged the gap:

- **fd leak** — `cancel()` before `start()`'s `open()` resolved couldn't close the descriptor `open()` later acquired (`pull()`/`cancel()` never run again). A realistic abort-during-open path.
- **cancel race** — a late read callback after cancel could recurse into `read(null,…)` → synchronous `ERR_INVALID_ARG_TYPE` crash, or reject the already-cancelled pull (unhandled rejection).

Both are fixed by a **stream-wide `cancelled` flag** set in `cancel()`, gating the open-retry loop, the `open()` success path (closes an fd acquired post-cancel), `readMore()` entry, and both read callbacks.

## Tests

Added to `unitTests/resources/blob.test.js`:
- **cross-chunk slice** via `stream()` (boundary-straddling, both-bounds-in-later-chunk seek path, third-chunk-to-EOF, within-first-chunk regression) — verified to fail on the old code.
- **cancel mid-read** — no throw / no unhandled rejection.
- **cancel before open() resolves** — fd accounting via `/proc/self/fd`; verified 50/50 fds leaked without the guard, flat with it.

`npm run build` clean; full blob unit file green (58 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)