### PR TITLE
fix: use getDatabases() in role validation to avoid startup crash

### DIFF
--- a/validation/role_validation.ts
+++ b/validation/role_validation.ts
@@ -3,6 +3,7 @@ const validator = require('./validationWrapper');
 import * as terms from '../utility/hdbTerms.ts';
 import { validateOperations } from '../utility/operationPermissions.ts';
 import { handleHDBError, hdbErrors } from '../utility/errors/hdbError.ts';
+import { getDatabases } from '../resources/databases.ts';
 
 const { HDB_ERROR_MSGS, HTTP_STATUS_CODES } = hdbErrors;
 
@@ -66,6 +67,10 @@ function customValidate(object, constraints) {
 		schema_permissions: {},
 	};
 
+	// getDatabases() is self-initializing; global.hdb_schema is set lazily and is undefined when a
+	// component's roles.yaml is validated during startup.
+	const hdb_schema: any = getDatabases();
+
 	const jsonMsgKeys = Object.keys(object);
 
 	//Check to confirm that keys in JSON body are valid
@@ -116,7 +121,7 @@ function customValidate(object, constraints) {
 				if (Array.isArray(structureUserPerm)) {
 					for (let k = 0, length = structureUserPerm.length; k < length; k++) {
 						let schemaPerm = structureUserPerm[k];
-						if (!(global as any).hdb_schema[schemaPerm]) {
+						if (!hdb_schema[schemaPerm]) {
 							addPermError(HDB_ERROR_MSGS.SCHEMA_NOT_FOUND(schemaPerm), validationErrors, undefined, undefined);
 						}
 					}
@@ -146,7 +151,7 @@ function customValidate(object, constraints) {
 
 			let schema = object.permission[item];
 			//validate that schema exists
-			if (!item || !(global as any).hdb_schema[item]) {
+			if (!item || !hdb_schema[item]) {
 				addPermError(HDB_ERROR_MSGS.SCHEMA_NOT_FOUND(item), validationErrors, undefined, undefined);
 				continue;
 			}
@@ -154,7 +159,7 @@ function customValidate(object, constraints) {
 				for (let t in schema.tables) {
 					let table = schema.tables[t];
 					//validate that table exists in schema
-					if (!t || !(global as any).hdb_schema[item][t]) {
+					if (!t || !hdb_schema[item][t]) {
 						addPermError(HDB_ERROR_MSGS.TABLE_NOT_FOUND(item, t), validationErrors, undefined, undefined);
 						continue;
 					}
@@ -186,7 +191,7 @@ function customValidate(object, constraints) {
 
 					//need this check here to ensure no unexpected errors if key is missing in table perms obj
 					if (table.attribute_permissions) {
-						let tableAttributeNames = (global as any).hdb_schema[item][t].attributes.map(({ attribute }) => attribute);
+						let tableAttributeNames = hdb_schema[item][t].attributes.map(({ attribute }) => attribute);
 						const attrPermsCheck = {
 							read: false,
 							insert: false,


### PR DESCRIPTION
## Problem

Starting Harper with a component that declares a `roles.yaml` granting database/table permissions crashes during startup:

```
[http/8] [error] [central-manager]: Error in async entry handler: TypeError: Cannot read properties of undefined (reading 'data')
    at customValidate (core/validation/role_validation.ts:149)
    at addRoleValidation (core/validation/role_validation.ts:42)
    at addRole (core/security/role.ts:43)
    at ensureRole (core/resources/roles.ts:92)
    at handleFile (core/resources/roles.ts:77)
```

It also escalates to an `unhandledRejection` in the http worker thread.

## Root cause

`customValidate` reads the legacy global `global.hdb_schema` to verify that the databases/tables a role references exist. That global is populated lazily by `setSchemaDataToGlobal()` (operations-server `setUp`, schema-mutating ops). When a component's `roles.yaml` is loaded during startup on the http worker threads, the global hasn't been set yet, so it's `undefined`. A role granting permissions on a real database (e.g. `data`) then evaluates `undefined['data']` and throws.

## Fix

Use `getDatabases()` directly instead of the lazily-set global. `getDatabases()` is self-initializing and is exactly what `global.hdb_schema` is assigned from, so it works both at startup and afterward. Typed `any` locally to preserve the previous untyped indexing behavior.

## Verification

Reproduced locally with a central-manager component whose `read_only` role grants table permissions on `data` (14 errors per boot). After the fix + rebuild + restart: **0** errors, roles load cleanly, `Harper successfully started.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)