### PR TITLE
Auth: support token login in core — exchange a validated JWT for an httpOnly hdb-session cookie

### DIFF
--- a/components/mcp/tools/schemas/operationDescriptions.ts
+++ b/components/mcp/tools/schemas/operationDescriptions.ts
@@ -192,15 +192,15 @@ export const OPERATION_DESCRIPTIONS: Record<string, string> = {
 	// drop_role: security/role.ts:126 — Delete a role; refuses if assigned.
 	drop_role:
 		'Deletes a role. Refused if any active user is still assigned to the role — drop or reassign those users first.',
-	// create_authentication_tokens: security/tokenAuthentication.ts:86 — Mint operation + refresh token pair.
+	// create_authentication_tokens: security/tokenAuthentication.ts:108 — Mint operation + refresh token pair, or (purpose: 'login') a login-exchange token.
 	create_authentication_tokens:
-		'Creates a JWT operation token and a refresh token after validating credentials. Stores the refresh token on the user record.',
+		"Creates a JWT operation token and a refresh token after validating credentials. Stores the refresh token on the user record. With purpose: 'login', instead mints a single short-lived login-exchange token (not usable as a Bearer API credential) intended for the `login` operation.",
 	// refresh_operation_token: security/tokenAuthentication.ts:171 — Mint new operation token from refresh.
 	refresh_operation_token:
 		'Issues a new operation token using a valid refresh token, without re-authenticating with username/password.',
 	// login: security/auth.ts:371 — Session-based login.
 	login:
-		'Authenticates the caller and creates a session entry. Requires sessions to be enabled in Harper configuration.',
+		'Authenticates the caller and creates a session entry. Accepts username/password, or a `token` from create_authentication_tokens with purpose: "login" to exchange it for the session cookie. Requires sessions to be enabled in Harper configuration.',
 	// logout: security/auth.ts:381 — Session-based logout.
 	logout: "Clears the caller's session. Requires sessions to be enabled.",
 

--- a/integrationTests/apiTests/authentication.test.mjs
+++ b/integrationTests/apiTests/authentication.test.mjs
@@ -151,14 +151,14 @@ suite('Authentication', (ctx) => {
 				purpose: 'login',
 			})
 			.expect(200);
-		assert.ok(tokenResponse.body.login_token, tokenResponse.text);
-		assert.equal(tokenResponse.body.operation_token, undefined, tokenResponse.text);
+		// Same field as a regular operation-token mint — purpose: 'login' doesn't change the response shape.
+		assert.ok(tokenResponse.body.operation_token, tokenResponse.text);
 		assert.equal(tokenResponse.body.refresh_token, undefined, tokenResponse.text);
 
 		const loginResponse = await request(client.operationsURL)
 			.post('')
 			.set('Content-Type', 'application/json')
-			.send({ operation: 'login', token: tokenResponse.body.login_token })
+			.send({ operation: 'login', token: tokenResponse.body.operation_token })
 			.expect((r) => assert.ok(r.text.includes('Login successful'), r.text))
 			.expect(200);
 
@@ -184,7 +184,7 @@ suite('Authentication', (ctx) => {
 		await request(client.operationsURL)
 			.post('')
 			.set('Content-Type', 'application/json')
-			.set('Authorization', `Bearer ${tokenResponse.body.login_token}`)
+			.set('Authorization', `Bearer ${tokenResponse.body.operation_token}`)
 			.send({ operation: 'describe_all' })
 			.expect((r) => assert.ok(r.text.includes('"error":"invalid token"'), r.text))
 			.expect(401);

--- a/integrationTests/apiTests/authentication.test.mjs
+++ b/integrationTests/apiTests/authentication.test.mjs
@@ -138,6 +138,58 @@ suite('Authentication', (ctx) => {
 		);
 	});
 
+	// Fabric Connect flow (harper#1544): mint a purpose-scoped login token, then trade it for a
+	// session cookie via `login` — without ever sending username/password to this instance.
+	test('login operation exchanges a login-purpose token for a session cookie', { skip: skipOnBun }, async () => {
+		const tokenResponse = await request(client.operationsURL)
+			.post('')
+			.set('Content-Type', 'application/json')
+			.send({
+				operation: 'create_authentication_tokens',
+				username: admin.username,
+				password: admin.password,
+				purpose: 'login',
+			})
+			.expect(200);
+		assert.ok(tokenResponse.body.login_token, tokenResponse.text);
+		assert.equal(tokenResponse.body.operation_token, undefined, tokenResponse.text);
+		assert.equal(tokenResponse.body.refresh_token, undefined, tokenResponse.text);
+
+		const loginResponse = await request(client.operationsURL)
+			.post('')
+			.set('Content-Type', 'application/json')
+			.send({ operation: 'login', token: tokenResponse.body.login_token })
+			.expect((r) => assert.ok(r.text.includes('Login successful'), r.text))
+			.expect(200);
+
+		const setCookie = loginResponse.headers['set-cookie'];
+		assert.ok(
+			Array.isArray(setCookie) && setCookie.some((c) => c.includes('hdb-session=')),
+			`expected an hdb-session cookie, got ${JSON.stringify(setCookie)}`
+		);
+	});
+
+	test('a login-purpose token is rejected as a Bearer API credential', async () => {
+		const tokenResponse = await request(client.operationsURL)
+			.post('')
+			.set('Content-Type', 'application/json')
+			.send({
+				operation: 'create_authentication_tokens',
+				username: admin.username,
+				password: admin.password,
+				purpose: 'login',
+			})
+			.expect(200);
+
+		await request(client.operationsURL)
+			.post('')
+			.set('Content-Type', 'application/json')
+			.set('Authorization', `Bearer ${tokenResponse.body.login_token}`)
+			.send({ operation: 'describe_all' })
+			.expect((r) => assert.ok(r.text.includes('"error":"invalid token"'), r.text))
+			.expect(401);
+	});
+
 	test('create_authentication_tokens with valid credentials returns operation token', async () => {
 		const response = await request(client.operationsURL)
 			.post('')

--- a/resources/login.ts
+++ b/resources/login.ts
@@ -12,9 +12,9 @@ class Login extends Resource {
 		// TODO: Return a login page
 	}
 	static async post(_id, body, request) {
-		const { username, password } = body;
+		const { username, password, token } = body;
 		return {
-			data: await request.login(username, password),
+			data: await request.login(username, password, token),
 		};
 	}
 }

--- a/security/auth.ts
+++ b/security/auth.ts
@@ -1,7 +1,7 @@
 import { getSuperUser } from './user.ts';
 import { server } from '../server/Server.ts';
 import { resources } from '../resources/Resources.ts';
-import { validateOperationToken, validateRefreshToken } from './tokenAuthentication.ts';
+import { validateOperationToken, validateRefreshToken, validateLoginToken } from './tokenAuthentication.ts';
 import { table, type Table } from '../resources/databases.ts';
 import { v4 as uuid } from 'uuid';
 import * as env from '../utility/environment/environmentManager.ts';
@@ -315,8 +315,10 @@ export async function authentication(request, nextHandler) {
 					expiresAt: expires ? Date.now() + convertToMS(expires) : undefined,
 				});
 			};
-			request.login = async function (username: string, password: string) {
-				const user: any = (request.user = await server.authenticateUser(username, password, request));
+			request.login = async function (username: string, password?: string, token?: string) {
+				const user: any = (request.user = token
+					? await validateLoginToken(token)
+					: await server.authenticateUser(username, password, request));
 				request.session.update({ user: user && (user.getId?.() ?? user.username) });
 			};
 		}
@@ -374,7 +376,7 @@ export async function login(loginObject) {
 	loginObject.baseResponse.headers.set = (name, value) => {
 		loginObject.fastifyResponse.header(name, value);
 	};
-	await loginObject.baseRequest.login(loginObject.username, loginObject.password ?? '');
+	await loginObject.baseRequest.login(loginObject.username, loginObject.password ?? '', loginObject.token);
 	return 'Login successful';
 }
 

--- a/security/tokenAuthentication.ts
+++ b/security/tokenAuthentication.ts
@@ -25,11 +25,20 @@ env.initSync();
 type StringValue = SignOptions['expiresIn'];
 const OPERATION_TOKEN_TIMEOUT: StringValue = env.get(CONFIG_PARAMS.AUTHENTICATION_OPERATIONTOKENTIMEOUT) || '1d';
 const REFRESH_TOKEN_TIMEOUT: StringValue = env.get(CONFIG_PARAMS.AUTHENTICATION_REFRESHTOKENTIMEOUT) || '30d';
+// Default lifetime of a login-purpose token (see TOKEN_TYPE.LOGIN below). It only exists to be
+// exchanged for a session cookie, so it defaults far shorter than an operation token; callers can
+// still override via expires_in.
+const LOGIN_TOKEN_TIMEOUT: StringValue = '1m';
 const RSA_ALGORITHM: Algorithm = 'RS256';
 
 const TOKEN_TYPE = {
 	OPERATION: 'operation',
 	REFRESH: 'refresh',
+	// Purpose-scoped exchange token minted by createTokens({ purpose: 'login' }) and accepted only
+	// by validateLoginToken (the `login` operation). Its `sub` claim differs from
+	// TOKEN_TYPE.OPERATION, so validateOperationToken's Bearer-API path rejects it automatically —
+	// it can't be replayed as a general API credential the way a full operation token could.
+	LOGIN: 'login',
 };
 
 interface JWTRSAKeys {
@@ -45,6 +54,9 @@ interface AuthObject {
 	expires_in?: string | number;
 	bypass_auth?: boolean;
 	hdb_user?: User;
+	// 'login' mints a single short-lived, login-scoped token instead of an operation/refresh pair —
+	// see TOKEN_TYPE.LOGIN.
+	purpose?: 'login';
 }
 
 interface TokenObject {
@@ -52,8 +64,9 @@ interface TokenObject {
 }
 
 interface JWTTokens {
-	operation_token: string;
+	operation_token?: string;
 	refresh_token?: string;
+	login_token?: string;
 }
 
 /**
@@ -99,7 +112,8 @@ export function clearJWTRSAKeysCache(): void {
 }
 
 /**
- * Creates a new operation token and refresh token.
+ * Creates a new operation token and refresh token (or, with `purpose: 'login'`, a single
+ * login-scoped token — see TOKEN_TYPE.LOGIN).
  * If there is no username and password, the hdb_user making the request is used in the token.
  * An optional role can be provided which will be saved in the token payload.
  * The token expires in the time specified in the expires_in field or the default time.
@@ -113,6 +127,7 @@ export async function createTokens(authObj: AuthObject): Promise<JWTTokens> {
 			password: Joi.string().optional(),
 			role: Joi.string().optional(),
 			expires_in: Joi.alternatives(Joi.string(), Joi.number()).optional(),
+			purpose: Joi.string().valid('login').optional(),
 		})
 	);
 	if (validation) throw new ClientError(validation.message);
@@ -147,6 +162,22 @@ export async function createTokens(authObj: AuthObject): Promise<JWTTokens> {
 	if (authObj.role) payload.role = authObj.role;
 
 	const keys: JWTRSAKeys = await getJWTRSAKeys();
+
+	if (authObj.purpose === 'login') {
+		// Login-scoped exchange token: no refresh token, no user record update — it's a one-shot
+		// ticket for the `login` operation to trade for a session cookie, not a standing credential.
+		const loginToken = jwt.sign(
+			{ username: authObj.username },
+			{ key: keys.privateKey, passphrase: keys.passphrase } satisfies Secret,
+			{
+				expiresIn: (authObj.expires_in ?? LOGIN_TOKEN_TIMEOUT) as StringValue,
+				algorithm: RSA_ALGORITHM,
+				subject: TOKEN_TYPE.LOGIN,
+			} satisfies SignOptions
+		);
+		return { login_token: loginToken };
+	}
+
 	const operationToken = jwt.sign(
 		payload,
 		{ key: keys.privateKey, passphrase: keys.passphrase } satisfies Secret,
@@ -217,6 +248,15 @@ export async function validateOperationToken(token: string): Promise<any> {
 
 export async function validateRefreshToken(token: string): Promise<any> {
 	return validateToken(token, TOKEN_TYPE.REFRESH);
+}
+
+/**
+ * Validates a login-purpose token minted via createTokens({ purpose: 'login' }). Used solely by
+ * the `login` operation to exchange the token for an httpOnly session cookie — this is the only
+ * place a `sub: 'login'` token is accepted.
+ */
+export async function validateLoginToken(token: string): Promise<any> {
+	return validateToken(token, TOKEN_TYPE.LOGIN);
 }
 
 async function validateToken(token: string, tokenType: string): Promise<any> {

--- a/security/tokenAuthentication.ts
+++ b/security/tokenAuthentication.ts
@@ -64,9 +64,10 @@ interface TokenObject {
 }
 
 interface JWTTokens {
-	operation_token?: string;
+	// Always the mint result: an operation JWT normally, or (purpose: 'login') the login-scoped
+	// exchange JWT — same field, same response shape, callers don't need to branch on purpose.
+	operation_token: string;
 	refresh_token?: string;
-	login_token?: string;
 }
 
 /**
@@ -175,7 +176,7 @@ export async function createTokens(authObj: AuthObject): Promise<JWTTokens> {
 				subject: TOKEN_TYPE.LOGIN,
 			} satisfies SignOptions
 		);
-		return { login_token: loginToken };
+		return { operation_token: loginToken };
 	}
 
 	const operationToken = jwt.sign(

--- a/unitTests/security/tokenAuthentication.test.js
+++ b/unitTests/security/tokenAuthentication.test.js
@@ -491,11 +491,10 @@ describe('test createTokens', () => {
 		let result = await token_auth.createTokens({ username: 'HDB_USER', password: 'pass', purpose: 'login' });
 		rw_get_tokens();
 
-		assert.notDeepStrictEqual(result.login_token, undefined);
-		assert.deepStrictEqual(result.operation_token, undefined);
+		assert.notDeepStrictEqual(result.operation_token, undefined);
 		assert.deepStrictEqual(result.refresh_token, undefined);
 
-		const payload = jwt.decode(result.login_token);
+		const payload = jwt.decode(result.operation_token);
 		assert.deepStrictEqual(payload.username, 'HDB_USER');
 		assert.deepStrictEqual(payload.sub, 'login');
 		// no operation-token side effects: nothing persisted, no user-change broadcast
@@ -681,18 +680,18 @@ describe('test validateLoginToken function', () => {
 
 		const expiry_timeout = token_auth.__set__('LOGIN_TOKEN_TIMEOUT', '-1');
 		expired_login_token = (await token_auth.createTokens({ username: 'EXPIRED', password: 'cool', purpose: 'login' }))
-			.login_token;
+			.operation_token;
 		expiry_timeout();
 
 		hdb_admin_login_token = (
 			await token_auth.createTokens({ username: 'HDB_ADMIN', password: 'cool', purpose: 'login' })
-		).login_token;
+		).operation_token;
 		old_user_login_token = (
 			await token_auth.createTokens({ username: 'old_user', password: 'notcool', purpose: 'login' })
-		).login_token;
+		).operation_token;
 		non_user_login_token = (
 			await token_auth.createTokens({ username: 'non_user', password: 'notcool', purpose: 'login' })
-		).login_token;
+		).operation_token;
 		hdb_admin_operation_token = (await token_auth.createTokens({ username: 'HDB_ADMIN', password: 'cool' }))
 			.operation_token;
 

--- a/unitTests/security/tokenAuthentication.test.js
+++ b/unitTests/security/tokenAuthentication.test.js
@@ -482,6 +482,26 @@ describe('test createTokens', () => {
 		assert.deepStrictEqual(result, undefined);
 		assert.deepStrictEqual(error.message, 'unable to store refresh_token');
 	});
+
+	it("test purpose: 'login' mints a login-only token and skips refresh-token bookkeeping", async () => {
+		let rw_get_tokens = token_auth.__set__(
+			'getJWTRSAKeys',
+			async () => new JWTRSAKeys(PUBLIC_KEY_VALUE, PRIVATE_KEY_VALUE, PASSPHRASE_VALUE)
+		);
+		let result = await token_auth.createTokens({ username: 'HDB_USER', password: 'pass', purpose: 'login' });
+		rw_get_tokens();
+
+		assert.notDeepStrictEqual(result.login_token, undefined);
+		assert.deepStrictEqual(result.operation_token, undefined);
+		assert.deepStrictEqual(result.refresh_token, undefined);
+
+		const payload = jwt.decode(result.login_token);
+		assert.deepStrictEqual(payload.username, 'HDB_USER');
+		assert.deepStrictEqual(payload.sub, 'login');
+		// no operation-token side effects: nothing persisted, no user-change broadcast
+		assert(update_stub.called === false);
+		assert(signalling_stub.called === false);
+	});
 });
 
 describe('test validateOperationToken function', () => {
@@ -625,6 +645,134 @@ describe('test validateOperationToken function', () => {
 		assert(jwt_spy.callCount === 1);
 		assert(jwt_spy.threw() === true);
 		assert(validate_user_stub.callCount === 0);
+	});
+});
+
+describe('test validateLoginToken function', () => {
+	let rw_get_tokens;
+	let jwt_spy;
+	let validate_user_stub;
+	let hdb_admin_login_token;
+	let old_user_login_token;
+	let non_user_login_token;
+	let expired_login_token;
+	let hdb_admin_operation_token;
+
+	before(async () => {
+		sandbox.restore();
+
+		rw_get_tokens = token_auth.__set__(
+			'getJWTRSAKeys',
+			async () => new JWTRSAKeys(PUBLIC_KEY_VALUE, PRIVATE_KEY_VALUE, PASSPHRASE_VALUE)
+		);
+
+		let update_stub = sandbox.stub(insert, 'update').callsFake(async (_update_object) => {
+			return { message: 'updated 1 of 1', update_hashes: ['1'], skipped_hashes: [] };
+		});
+		let signalling_stub = sandbox.stub(signalling, 'signalUserChange').callsFake((_obj) => {});
+		validate_user_stub = sandbox.stub(user, 'findAndValidateUser').callsFake(async (u, _pw) => ({ username: u }));
+
+		await user.setUsersWithRolesCache(
+			new Map([
+				['HDB_ADMIN', { username: 'HDB_ADMIN', active: true }],
+				['old_user', { username: 'old_user', active: false }],
+			])
+		);
+
+		const expiry_timeout = token_auth.__set__('LOGIN_TOKEN_TIMEOUT', '-1');
+		expired_login_token = (await token_auth.createTokens({ username: 'EXPIRED', password: 'cool', purpose: 'login' }))
+			.login_token;
+		expiry_timeout();
+
+		hdb_admin_login_token = (
+			await token_auth.createTokens({ username: 'HDB_ADMIN', password: 'cool', purpose: 'login' })
+		).login_token;
+		old_user_login_token = (
+			await token_auth.createTokens({ username: 'old_user', password: 'notcool', purpose: 'login' })
+		).login_token;
+		non_user_login_token = (
+			await token_auth.createTokens({ username: 'non_user', password: 'notcool', purpose: 'login' })
+		).login_token;
+		hdb_admin_operation_token = (await token_auth.createTokens({ username: 'HDB_ADMIN', password: 'cool' }))
+			.operation_token;
+
+		validate_user_stub.restore();
+		jwt_spy = sandbox.spy(jwt, 'verify');
+		validate_user_stub = sandbox.spy(user, 'findAndValidateUser');
+
+		update_stub.restore();
+		signalling_stub.restore();
+	});
+
+	afterEach(() => {
+		jwt_spy.resetHistory();
+		validate_user_stub.resetHistory();
+	});
+
+	after(() => {
+		rw_get_tokens();
+		sandbox.restore();
+	});
+
+	it('test hdb_admin login token', async () => {
+		const result_user = await token_auth.validateLoginToken(hdb_admin_login_token);
+		assert.deepStrictEqual(result_user, { active: true, username: 'HDB_ADMIN' });
+	});
+
+	it('test old_user login token', async () => {
+		let error;
+		try {
+			await token_auth.validateLoginToken(old_user_login_token);
+		} catch (e) {
+			error = e;
+		}
+		assert.deepStrictEqual(error.message, 'invalid token');
+	});
+
+	it('test non-existent user login token', async () => {
+		const result_user = await token_auth.validateLoginToken(non_user_login_token);
+		assert.deepStrictEqual(result_user, { username: 'non_user' });
+	});
+
+	it('test bad login token', async () => {
+		let error;
+		try {
+			await token_auth.validateLoginToken('BAD_TOKEN');
+		} catch (e) {
+			error = e;
+		}
+		assert.deepStrictEqual(error.message, 'invalid token');
+	});
+
+	it('test expired login token', async () => {
+		let error;
+		try {
+			await token_auth.validateLoginToken(expired_login_token);
+		} catch (e) {
+			error = e;
+		}
+		assert.deepStrictEqual(error.message, 'token expired');
+		assert.deepStrictEqual(error.statusCode, 403);
+	});
+
+	it('rejects an operation token — a login token is not a substitute Bearer credential', async () => {
+		let error;
+		try {
+			await token_auth.validateLoginToken(hdb_admin_operation_token);
+		} catch (e) {
+			error = e;
+		}
+		assert.deepStrictEqual(error.message, 'invalid token');
+	});
+
+	it('validateOperationToken rejects a login token — cannot be replayed as a Bearer credential', async () => {
+		let error;
+		try {
+			await token_auth.validateOperationToken(hdb_admin_login_token);
+		} catch (e) {
+			error = e;
+		}
+		assert.deepStrictEqual(error.message, 'invalid token');
 	});
 });
 


### PR DESCRIPTION
## Summary

Implements #1544. Studio wants direct (non-proxied) connections to instances for SSE/streaming (studio#1398) — native `EventSource` can't send an `Authorization` header, so cookie auth is the fit. This gives core the missing bridge: turn a validated JWT into an httpOnly `hdb-session` cookie.

- `request.login()` / the `login` operation now accept a `token` alongside username/password. When given, it's validated and the resulting user is written into the session (existing `request.session.update()` — no new cookie machinery).
- `create_authentication_tokens` / `createTokens()` gains `purpose: 'login'`: mints a single short-lived (`1m` default, override via `expires_in`) token instead of an operation+refresh pair, and skips the refresh-token DB write / user-change broadcast that pair triggers.

## Design decision taken

The issue flagged one open call: reuse a full operation token for the exchange, vs. mint a **purpose-scoped token** rejected by the Bearer-API path. I went with the recommended purpose-scoped option — the login token is signed with `subject: 'login'` instead of `'operation'`, so `validateOperationToken`'s `jwt.verify(..., { subject: 'operation' })` rejects it on a `sub` mismatch with no extra code, and `validateLoginToken` is the only thing that accepts it. This means the exchange ticket can't be replayed as a general API credential even if it leaked (e.g. in a log line) — confirmed in the new tests below (log lines literally read `jwt subject invalid`).

CSRF posture (design point 3) is unchanged: the cookie is still origin-prefixed per the existing mechanism, regardless of how the session was established.

## Testing

- `unitTests/security/tokenAuthentication.test.js` — 8 new cases: `purpose: 'login'` mints a login-only token with no refresh-token side effects; `validateLoginToken` happy/inactive-user/non-existent-user/bad/expired paths; and the two cross-subject rejection cases (operation token rejected by `validateLoginToken`, login token rejected by `validateOperationToken`).
- `integrationTests/apiTests/authentication.test.mjs` — 2 new end-to-end cases: mint a login token → `login` op → session cookie set; and a login token sent as `Authorization: Bearer` → 401.
- Ran locally: `tsc --noEmit` clean, full build clean, both touched unit-test files green (39/39, 31/31), both touched integration suites green (15/15, 9/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)