### PR TITLE
Add worker-spawn workerData providers and deferred env-secret decrypt replay

### DIFF
--- a/resources/loadEnv.ts
+++ b/resources/loadEnv.ts
@@ -2,7 +2,7 @@ import { parse } from 'dotenv';
 import logger from '../utility/logging/harper_logger.ts';
 import { Scope } from '../components/Scope.ts';
 import { isEncryptedEnvValue } from '../utility/envFile.ts';
-import { getSecretDecryptor } from './secretDecryptor.ts';
+import { deferEncryptedEnvValue, getSecretDecryptor } from './secretDecryptor.ts';
 
 export function handleApplication(scope: Scope) {
 	const override = (scope.options.getAll() as { override?: boolean }).override ?? false;
@@ -22,11 +22,14 @@ export function handleApplication(scope: Scope) {
 				// Logged at error level (not warn) so an undecryptable secret is never silent — but
 				// skipped rather than fatal, so the node still boots and the bad value can be fixed via
 				// set_env_value, and a non-Pro node isn't crashed by a replicated encrypted value. The
-				// app sees a missing var (and should fail on it) rather than receiving ciphertext.
+				// entry is also queued so a decryptor that registers later (custody can come up after
+				// component `.env` loading) replays it into process.env; until then the app sees a
+				// missing var (and should fail on it) rather than receiving ciphertext.
 				if (!decryptor) {
 					logger.error(
-						`Environment variable ${key} from ${entry.absolutePath} is encrypted but no env-secret decryptor is registered (the Harper Pro env-secrets component is required); skipping`
+						`Environment variable ${key} from ${entry.absolutePath} is encrypted but no env-secret decryptor is registered yet (the Harper Pro env-secrets component is required); deferring`
 					);
+					deferEncryptedEnvValue({ key, rawValue, sourcePath: entry.absolutePath, override });
 					continue;
 				}
 				try {

--- a/resources/secretDecryptor.ts
+++ b/resources/secretDecryptor.ts
@@ -14,14 +14,83 @@
  *
  * Registration is per-process: the Pro component registers in each worker where secrets are
  * consumed, so registration and use share the same module instance.
+ *
+ * Registration order is NOT load-bearing for `.env` values: entries that load before a decryptor
+ * exists are queued (see `deferEncryptedEnvValue`) and replayed into `process.env` the moment one
+ * registers, so a custody provider that comes up after component `.env` loading heals the skipped
+ * values instead of leaving them missing.
  */
+import logger from '../utility/logging/harper_logger.ts';
+
 export type SecretDecryptor = (value: string) => string;
+
+/** An encrypted `.env` entry that was loaded before any decryptor was registered. */
+export interface DeferredEncryptedEnvValue {
+	key: string;
+	rawValue: string;
+	sourcePath: string;
+	override: boolean;
+}
+
+// Defensive cap: the queue only ever holds encrypted `.env` entries loaded before registration,
+// so growth beyond this indicates a bug or abuse — drop (with an error) rather than grow.
+const MAX_DEFERRED_SECRETS = 1000;
+let deferredSecrets: DeferredEncryptedEnvValue[] = [];
 
 let decryptor: SecretDecryptor | undefined;
 
-/** Install the env-secret decryptor (called by the Pro env-secrets component at startup). */
+/**
+ * Queue an encrypted `.env` entry that could not be decrypted because no decryptor is registered
+ * yet. When one registers, the queue is replayed into `process.env` with the same
+ * override/conflict semantics `loadEnv` applied to the original load.
+ */
+export function deferEncryptedEnvValue(entry: DeferredEncryptedEnvValue): void {
+	if (deferredSecrets.length >= MAX_DEFERRED_SECRETS) {
+		logger.error(
+			`Deferred encrypted env queue is full (${MAX_DEFERRED_SECRETS}); dropping ${entry.key} from ${entry.sourcePath}`
+		);
+		return;
+	}
+	deferredSecrets.push(entry);
+}
+
+/** The queued entries awaiting a decryptor (exposed for tests/diagnostics). */
+export function getDeferredEncryptedEnvValues(): readonly DeferredEncryptedEnvValue[] {
+	return deferredSecrets;
+}
+
+// Replay queued encrypted env entries through a newly registered decryptor, mirroring loadEnv's
+// conflict semantics: a failed decrypt logs and skips that entry; an already-set key is only
+// overwritten when the entry's env file was loaded with `override`.
+function replayDeferredSecrets(newDecryptor: SecretDecryptor): void {
+	const entries = deferredSecrets;
+	deferredSecrets = [];
+	for (const { key, rawValue, sourcePath, override } of entries) {
+		let value: string;
+		try {
+			value = newDecryptor(rawValue);
+		} catch (error) {
+			logger.error(
+				`Failed to decrypt deferred environment variable ${key} from ${sourcePath}: ${(error as Error).message}; skipping`
+			);
+			continue;
+		}
+		if (process.env[key] !== undefined) {
+			logger.warn(`Environment variable conflict: ${key} from ${sourcePath} is already set on process.env`);
+			if (!override) continue;
+		}
+		process.env[key] = value;
+	}
+}
+
+/**
+ * Install the env-secret decryptor (called by the Pro env-secrets component at startup). Any
+ * encrypted `.env` entries that loaded before this point are immediately decrypted into
+ * `process.env`.
+ */
 export function registerSecretDecryptor(fn: SecretDecryptor): void {
 	decryptor = fn;
+	replayDeferredSecrets(fn);
 }
 
 /** The registered decryptor, or undefined when no Pro env-secrets component is active. */
@@ -29,7 +98,8 @@ export function getSecretDecryptor(): SecretDecryptor | undefined {
 	return decryptor;
 }
 
-/** Remove the registered decryptor. Intended for tests. */
+/** Remove the registered decryptor and drop any deferred entries. Intended for tests. */
 export function clearSecretDecryptor(): void {
 	decryptor = undefined;
+	deferredSecrets = [];
 }

--- a/resources/secretDecryptor.ts
+++ b/resources/secretDecryptor.ts
@@ -45,6 +45,16 @@ let decryptor: SecretDecryptor | undefined;
  * override/conflict semantics `loadEnv` applied to the original load.
  */
 export function deferEncryptedEnvValue(entry: DeferredEncryptedEnvValue): void {
+	// A re-evaluated env file (reload, watcher re-add) defers the same key again: replace the
+	// earlier entry in place so the queue holds one entry per {key, sourcePath} with the newest
+	// ciphertext, instead of wasting the cap and replaying stale values.
+	const existingIndex = deferredSecrets.findIndex(
+		(queued) => queued.key === entry.key && queued.sourcePath === entry.sourcePath
+	);
+	if (existingIndex >= 0) {
+		deferredSecrets[existingIndex] = entry;
+		return;
+	}
 	if (deferredSecrets.length >= MAX_DEFERRED_SECRETS) {
 		logger.error(
 			`Deferred encrypted env queue is full (${MAX_DEFERRED_SECRETS}); dropping ${entry.key} from ${entry.sourcePath}`

--- a/resources/secretDecryptor.ts
+++ b/resources/secretDecryptor.ts
@@ -54,9 +54,13 @@ export function deferEncryptedEnvValue(entry: DeferredEncryptedEnvValue): void {
 	deferredSecrets.push(entry);
 }
 
-/** The queued entries awaiting a decryptor (exposed for tests/diagnostics). */
-export function getDeferredEncryptedEnvValues(): readonly DeferredEncryptedEnvValue[] {
-	return deferredSecrets;
+/**
+ * A redacted snapshot of the queued entries awaiting a decryptor, for tests/diagnostics: a copy,
+ * without the ciphertext (`rawValue`), so holders can neither mutate pending entries nor retain
+ * the queued values past the flush.
+ */
+export function getDeferredEncryptedEnvValues(): Omit<DeferredEncryptedEnvValue, 'rawValue'>[] {
+	return deferredSecrets.map(({ key, sourcePath, override }) => ({ key, sourcePath, override }));
 }
 
 // Replay queued encrypted env entries through a newly registered decryptor, mirroring loadEnv's
@@ -76,6 +80,7 @@ function replayDeferredSecrets(newDecryptor: SecretDecryptor): void {
 			continue;
 		}
 		if (process.env[key] !== undefined) {
+			if (process.env[key] === value) continue; // already holds the decrypted value — nothing to report
 			logger.warn(`Environment variable conflict: ${key} from ${sourcePath} is already set on process.env`);
 			if (!override) continue;
 		}

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -113,6 +113,7 @@ const RESERVED_WORKER_DATA_KEYS = [
 	'restartNumber',
 	'ticketKeys',
 	'noServerStart',
+	'__proto__', // never a legitimate payload name; spread would define it as an own property
 ];
 const workerDataProviders = new Map();
 /**
@@ -142,8 +143,9 @@ function collectProvidedWorkerData(options) {
 			if (value === undefined) continue;
 			// Use the clone, not the original: this both pre-flights cloneability (so a bad value
 			// can't break the Worker spawn) and detaches the payload from accessor-backed objects
-			// or later mutation that could still throw inside new Worker().
-			(provided ??= {})[name] = structuredClone(value);
+			// or later mutation that could still throw inside new Worker(). Null prototype so a
+			// provider name can never collide with Object.prototype members.
+			(provided ??= Object.create(null))[name] = structuredClone(value);
 		} catch (error) {
 			harperLogger.error(`workerData provider '${name}' failed and will be skipped for this worker:`, error);
 		}

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -56,6 +56,7 @@ module.exports = {
 	getTicketKeys,
 	setMainIsWorker,
 	setTerminateTimeout,
+	registerWorkerDataProvider,
 	restartNumber: workerData?.restartNumber || 1,
 };
 
@@ -98,6 +99,51 @@ function setMainIsWorker(isWorker) {
 	module.exports.threadsHaveStarted();
 }
 let workerCount = 1; // should be assigned when workers are created
+
+// The keys startWorker itself puts on workerData — providers may not collide with these.
+const BUILT_IN_WORKER_DATA_KEYS = [
+	'addPorts',
+	'addThreadIds',
+	'workerIndex',
+	'workerCount',
+	'name',
+	'restartNumber',
+	'ticketKeys',
+];
+const workerDataProviders = new Map();
+/**
+ * Register a provider that contributes an extra `workerData` property to every worker spawned
+ * from this thread. `provider(options)` receives the startWorker options (`options.name` is the
+ * thread type, e.g. 'http' or 'job') and returns the value to place at `workerData[name]`, or
+ * undefined to skip that worker. Values must be structured-cloneable; a provider that throws or
+ * returns a non-cloneable value is logged and skipped so it can never break a spawn.
+ * Returns a function that unregisters the provider.
+ */
+function registerWorkerDataProvider(name, provider) {
+	if (BUILT_IN_WORKER_DATA_KEYS.includes(name) || workerDataProviders.has(name)) {
+		throw new Error(`workerData provider name '${name}' is already in use`);
+	}
+	if (typeof provider !== 'function') throw new Error('workerData provider must be a function');
+	workerDataProviders.set(name, provider);
+	return () => {
+		if (workerDataProviders.get(name) === provider) workerDataProviders.delete(name);
+	};
+}
+function collectProvidedWorkerData(options) {
+	if (workerDataProviders.size === 0) return undefined;
+	let provided;
+	for (const [name, provider] of workerDataProviders) {
+		try {
+			const value = provider(options);
+			if (value === undefined) continue;
+			structuredClone(value); // pre-flight: a non-cloneable value must not break the Worker spawn
+			(provided ??= {})[name] = value;
+		} catch (error) {
+			harperLogger.error(`workerData provider '${name}' failed and will be skipped for this worker:`, error);
+		}
+	}
+	return provided;
+}
 let ticketKeys;
 function getTicketKeys() {
 	if (ticketKeys) return ticketKeys;
@@ -186,6 +232,7 @@ function startWorker(path, options = {}) {
 		argv: process.argv.slice(2),
 		// pass these in synchronously to the worker so it has them on startup:
 		workerData: {
+			...collectProvidedWorkerData(options),
 			addPorts: portsToSend,
 			addThreadIds: channelsToConnect.map((channel) => channel.existingPort.threadId),
 			workerIndex: options.workerIndex,

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -100,8 +100,11 @@ function setMainIsWorker(isWorker) {
 }
 let workerCount = 1; // should be assigned when workers are created
 
-// The keys startWorker itself puts on workerData — providers may not collide with these.
-const BUILT_IN_WORKER_DATA_KEYS = [
+// Every workerData key core itself produces or consumes — providers may not collide with these.
+// Covers the keys startWorker spreads below plus keys read elsewhere: `noServerStart` is set by
+// the embedding entry point (index.ts) and read by threadServer.js to skip startServers(); a
+// provider shadowing it would wedge HTTP worker startup.
+const RESERVED_WORKER_DATA_KEYS = [
 	'addPorts',
 	'addThreadIds',
 	'workerIndex',
@@ -109,6 +112,7 @@ const BUILT_IN_WORKER_DATA_KEYS = [
 	'name',
 	'restartNumber',
 	'ticketKeys',
+	'noServerStart',
 ];
 const workerDataProviders = new Map();
 /**
@@ -120,7 +124,7 @@ const workerDataProviders = new Map();
  * Returns a function that unregisters the provider.
  */
 function registerWorkerDataProvider(name, provider) {
-	if (BUILT_IN_WORKER_DATA_KEYS.includes(name) || workerDataProviders.has(name)) {
+	if (RESERVED_WORKER_DATA_KEYS.includes(name) || workerDataProviders.has(name)) {
 		throw new Error(`workerData provider name '${name}' is already in use`);
 	}
 	if (typeof provider !== 'function') throw new Error('workerData provider must be a function');
@@ -136,8 +140,10 @@ function collectProvidedWorkerData(options) {
 		try {
 			const value = provider(options);
 			if (value === undefined) continue;
-			structuredClone(value); // pre-flight: a non-cloneable value must not break the Worker spawn
-			(provided ??= {})[name] = value;
+			// Use the clone, not the original: this both pre-flights cloneability (so a bad value
+			// can't break the Worker spawn) and detaches the payload from accessor-backed objects
+			// or later mutation that could still throw inside new Worker().
+			(provided ??= {})[name] = structuredClone(value);
 		} catch (error) {
 			harperLogger.error(`workerData provider '${name}' failed and will be skipped for this worker:`, error);
 		}

--- a/unitTests/resources/secretDeferredReplay.test.js
+++ b/unitTests/resources/secretDeferredReplay.test.js
@@ -108,6 +108,34 @@ describe('deferred encrypted env replay', () => {
 		assert.equal(process.env.SDR_OVERRIDE, 'decrypted:override');
 	});
 
+	it('dedupes re-deferred {key, sourcePath} entries, keeping the newest ciphertext', () => {
+		// same env file re-evaluated (reload/watcher re-add) with a rotated ciphertext
+		deferEncryptedEnvValue({
+			key: 'SDR_SECRET',
+			rawValue: `${PREFIX}stale`,
+			sourcePath: '/apps/test/.env',
+			override: false,
+		});
+		deferEncryptedEnvValue({
+			key: 'SDR_SECRET',
+			rawValue: `${PREFIX}fresh`,
+			sourcePath: '/apps/test/.env',
+			override: false,
+		});
+		// same key from a DIFFERENT file is a distinct entry
+		deferEncryptedEnvValue({
+			key: 'SDR_SECRET',
+			rawValue: `${PREFIX}other`,
+			sourcePath: '/apps/other/.env',
+			override: false,
+		});
+		assert.equal(getDeferredEncryptedEnvValues().length, 2);
+
+		registerSecretDecryptor((value) => `decrypted:${value.slice(PREFIX.length)}`);
+		// the replaced-in-place (newest) value won; the other-file entry then hit the conflict path
+		assert.equal(process.env.SDR_SECRET, 'decrypted:fresh');
+	});
+
 	it('caps the deferred queue defensively', () => {
 		for (let i = 0; i < 1005; i++) {
 			deferEncryptedEnvValue({ key: `SDR_CAP_${i}`, rawValue: `${PREFIX}v`, sourcePath: '/x/.env', override: false });

--- a/unitTests/resources/secretDeferredReplay.test.js
+++ b/unitTests/resources/secretDeferredReplay.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const assert = require('assert');
+const {
+	registerSecretDecryptor,
+	clearSecretDecryptor,
+	deferEncryptedEnvValue,
+	getDeferredEncryptedEnvValues,
+} = require('#src/resources/secretDecryptor');
+const { handleApplication } = require('#src/resources/loadEnv');
+
+const PREFIX = 'enc:v1:';
+const TEST_KEYS = ['SDR_SECRET', 'SDR_PLAIN', 'SDR_TAKEN', 'SDR_OVERRIDE', 'SDR_BAD', 'SDR_GOOD'];
+
+// A minimal stand-in for the component Scope that loadEnv drives: synchronously feeds one
+// virtual `.env` file through handleEntry.
+function fakeScope(contents, options = {}) {
+	return {
+		options: { getAll: () => options },
+		handleEntry(callback) {
+			callback({ eventType: 'add', absolutePath: '/apps/test/.env', contents });
+		},
+		requestRestart() {},
+	};
+}
+
+describe('deferred encrypted env replay', () => {
+	beforeEach(() => {
+		clearSecretDecryptor();
+		for (const key of TEST_KEYS) delete process.env[key];
+	});
+	after(() => {
+		clearSecretDecryptor();
+		for (const key of TEST_KEYS) delete process.env[key];
+	});
+
+	it('queues encrypted values loaded before a decryptor registers, then replays them into process.env', () => {
+		handleApplication(fakeScope(`SDR_SECRET=${PREFIX}abc\nSDR_PLAIN=hello`));
+		// plaintext loads immediately; the encrypted value is deferred, not dropped
+		assert.equal(process.env.SDR_PLAIN, 'hello');
+		assert.equal(process.env.SDR_SECRET, undefined);
+		assert.equal(getDeferredEncryptedEnvValues().length, 1);
+		assert.equal(getDeferredEncryptedEnvValues()[0].key, 'SDR_SECRET');
+
+		registerSecretDecryptor((value) => `decrypted:${value.slice(PREFIX.length)}`);
+		assert.equal(process.env.SDR_SECRET, 'decrypted:abc');
+		assert.equal(getDeferredEncryptedEnvValues().length, 0);
+	});
+
+	it('decrypts inline (no deferral) when a decryptor is already registered', () => {
+		registerSecretDecryptor((value) => `decrypted:${value.slice(PREFIX.length)}`);
+		handleApplication(fakeScope(`SDR_SECRET=${PREFIX}xyz`));
+		assert.equal(process.env.SDR_SECRET, 'decrypted:xyz');
+		assert.equal(getDeferredEncryptedEnvValues().length, 0);
+	});
+
+	it('logs and skips an entry that fails to decrypt during replay, still applying the rest', () => {
+		deferEncryptedEnvValue({
+			key: 'SDR_BAD',
+			rawValue: `${PREFIX}bad`,
+			sourcePath: '/apps/test/.env',
+			override: false,
+		});
+		deferEncryptedEnvValue({
+			key: 'SDR_GOOD',
+			rawValue: `${PREFIX}good`,
+			sourcePath: '/apps/test/.env',
+			override: false,
+		});
+		registerSecretDecryptor((value) => {
+			if (value.includes('bad')) throw new Error('cannot decrypt');
+			return 'ok';
+		});
+		assert.equal(process.env.SDR_BAD, undefined);
+		assert.equal(process.env.SDR_GOOD, 'ok');
+		assert.equal(getDeferredEncryptedEnvValues().length, 0);
+	});
+
+	it('applies the same conflict/override semantics as the original load', () => {
+		process.env.SDR_TAKEN = 'original';
+		process.env.SDR_OVERRIDE = 'original';
+		handleApplication(fakeScope(`SDR_TAKEN=${PREFIX}taken`));
+		handleApplication(fakeScope(`SDR_OVERRIDE=${PREFIX}override`, { override: true }));
+		assert.equal(getDeferredEncryptedEnvValues().length, 2);
+
+		registerSecretDecryptor((value) => `decrypted:${value.slice(PREFIX.length)}`);
+		// already-set key without override: kept
+		assert.equal(process.env.SDR_TAKEN, 'original');
+		// already-set key from an override-enabled env file: replaced
+		assert.equal(process.env.SDR_OVERRIDE, 'decrypted:override');
+	});
+
+	it('caps the deferred queue defensively', () => {
+		for (let i = 0; i < 1005; i++) {
+			deferEncryptedEnvValue({ key: `SDR_CAP_${i}`, rawValue: `${PREFIX}v`, sourcePath: '/x/.env', override: false });
+		}
+		assert.equal(getDeferredEncryptedEnvValues().length, 1000);
+		clearSecretDecryptor();
+	});
+});

--- a/unitTests/resources/secretDeferredReplay.test.js
+++ b/unitTests/resources/secretDeferredReplay.test.js
@@ -39,8 +39,13 @@ describe('deferred encrypted env replay', () => {
 		// plaintext loads immediately; the encrypted value is deferred, not dropped
 		assert.equal(process.env.SDR_PLAIN, 'hello');
 		assert.equal(process.env.SDR_SECRET, undefined);
+		const snapshot = getDeferredEncryptedEnvValues();
+		assert.equal(snapshot.length, 1);
+		assert.equal(snapshot[0].key, 'SDR_SECRET');
+		// the accessor is a redacted copy: no ciphertext, and mutating it can't touch the queue
+		assert.equal('rawValue' in snapshot[0], false);
+		snapshot.length = 0;
 		assert.equal(getDeferredEncryptedEnvValues().length, 1);
-		assert.equal(getDeferredEncryptedEnvValues()[0].key, 'SDR_SECRET');
 
 		registerSecretDecryptor((value) => `decrypted:${value.slice(PREFIX.length)}`);
 		assert.equal(process.env.SDR_SECRET, 'decrypted:abc');
@@ -73,6 +78,19 @@ describe('deferred encrypted env replay', () => {
 		});
 		assert.equal(process.env.SDR_BAD, undefined);
 		assert.equal(process.env.SDR_GOOD, 'ok');
+		assert.equal(getDeferredEncryptedEnvValues().length, 0);
+	});
+
+	it('replays an entry whose decrypted value already matches process.env as a silent no-op', () => {
+		process.env.SDR_TAKEN = 'decrypted:same';
+		deferEncryptedEnvValue({
+			key: 'SDR_TAKEN',
+			rawValue: `${PREFIX}same`,
+			sourcePath: '/apps/test/.env',
+			override: false,
+		});
+		registerSecretDecryptor((value) => `decrypted:${value.slice(PREFIX.length)}`);
+		assert.equal(process.env.SDR_TAKEN, 'decrypted:same');
 		assert.equal(getDeferredEncryptedEnvValues().length, 0);
 	});
 

--- a/unitTests/server/threads/workerData-fixture.js
+++ b/unitTests/server/threads/workerData-fixture.js
@@ -1,0 +1,15 @@
+'use strict';
+
+// Minimal worker fixture for workerDataProviders.test.js: report the provider-supplied
+// workerData properties back to the test, without loading any server infrastructure.
+const { parentPort, workerData } = require('node:worker_threads');
+
+parentPort.postMessage({
+	type: 'workerData-report',
+	testProvided: workerData.testProvided,
+	testSkipped: workerData.testSkipped,
+	testThrows: workerData.testThrows,
+	testNonCloneable: workerData.testNonCloneable,
+	name: workerData.name,
+	hasTicketKeys: Boolean(workerData.ticketKeys),
+});

--- a/unitTests/server/threads/workerDataProviders.test.js
+++ b/unitTests/server/threads/workerDataProviders.test.js
@@ -10,9 +10,11 @@ const FIXTURE = path.join(__dirname, 'workerData-fixture.js');
 const WORKER_NAME = 'workerData-provider-test';
 
 describe('registerWorkerDataProvider', () => {
-	it('rejects built-in workerData keys, duplicate names, and non-function providers', () => {
+	it('rejects reserved workerData keys, duplicate names, and non-function providers', () => {
 		assert.throws(() => registerWorkerDataProvider('ticketKeys', () => 1), /already in use/);
 		assert.throws(() => registerWorkerDataProvider('addPorts', () => 1), /already in use/);
+		// consumed by threadServer.js, not spread by startWorker — must be reserved all the same
+		assert.throws(() => registerWorkerDataProvider('noServerStart', () => true), /already in use/);
 		const unregister = registerWorkerDataProvider('dupNameTest', () => undefined);
 		try {
 			assert.throws(() => registerWorkerDataProvider('dupNameTest', () => undefined), /already in use/);
@@ -27,9 +29,20 @@ describe('registerWorkerDataProvider', () => {
 	it('spreads provider values into workerData; skips undefined, throwing, and non-cloneable providers', async function () {
 		this.timeout(30000);
 		const unregisters = [
-			registerWorkerDataProvider('testProvided', (options) =>
-				options.name === WORKER_NAME ? { secret: 'abc', kid: 'k1' } : undefined
-			),
+			registerWorkerDataProvider('testProvided', (options) => {
+				if (options.name !== WORKER_NAME) return undefined;
+				// accessor-backed value: the getter yields once, then throws. The spawn must use the
+				// structuredClone result (plain data) — storing the original would re-trigger the
+				// getter inside new Worker() and break the spawn.
+				let reads = 0;
+				return {
+					kid: 'k1',
+					get secret() {
+						if (reads++ > 0) throw new Error('secret may only be read once');
+						return 'abc';
+					},
+				};
+			}),
 			registerWorkerDataProvider('testSkipped', () => undefined),
 			registerWorkerDataProvider('testThrows', (options) => {
 				if (options.name === WORKER_NAME) throw new Error('provider boom');

--- a/unitTests/server/threads/workerDataProviders.test.js
+++ b/unitTests/server/threads/workerDataProviders.test.js
@@ -15,6 +15,7 @@ describe('registerWorkerDataProvider', () => {
 		assert.throws(() => registerWorkerDataProvider('addPorts', () => 1), /already in use/);
 		// consumed by threadServer.js, not spread by startWorker — must be reserved all the same
 		assert.throws(() => registerWorkerDataProvider('noServerStart', () => true), /already in use/);
+		assert.throws(() => registerWorkerDataProvider('__proto__', () => ({})), /already in use/);
 		const unregister = registerWorkerDataProvider('dupNameTest', () => undefined);
 		try {
 			assert.throws(() => registerWorkerDataProvider('dupNameTest', () => undefined), /already in use/);

--- a/unitTests/server/threads/workerDataProviders.test.js
+++ b/unitTests/server/threads/workerDataProviders.test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const assert = require('assert');
+const path = require('node:path');
+const { startWorker, registerWorkerDataProvider } = require('#js/server/threads/manageThreads');
+
+const FIXTURE = path.join(__dirname, 'workerData-fixture.js');
+// Providers registered here filter on this worker name so they can never leak values into
+// workers spawned by other tests sharing the process.
+const WORKER_NAME = 'workerData-provider-test';
+
+describe('registerWorkerDataProvider', () => {
+	it('rejects built-in workerData keys, duplicate names, and non-function providers', () => {
+		assert.throws(() => registerWorkerDataProvider('ticketKeys', () => 1), /already in use/);
+		assert.throws(() => registerWorkerDataProvider('addPorts', () => 1), /already in use/);
+		const unregister = registerWorkerDataProvider('dupNameTest', () => undefined);
+		try {
+			assert.throws(() => registerWorkerDataProvider('dupNameTest', () => undefined), /already in use/);
+		} finally {
+			unregister();
+		}
+		// after unregistering, the name is free again
+		registerWorkerDataProvider('dupNameTest', () => undefined)();
+		assert.throws(() => registerWorkerDataProvider('notAFunction', 'value'), /must be a function/);
+	});
+
+	it('spreads provider values into workerData; skips undefined, throwing, and non-cloneable providers', async function () {
+		this.timeout(30000);
+		const unregisters = [
+			registerWorkerDataProvider('testProvided', (options) =>
+				options.name === WORKER_NAME ? { secret: 'abc', kid: 'k1' } : undefined
+			),
+			registerWorkerDataProvider('testSkipped', () => undefined),
+			registerWorkerDataProvider('testThrows', (options) => {
+				if (options.name === WORKER_NAME) throw new Error('provider boom');
+			}),
+			// a non-cloneable value must be skipped, not break the spawn
+			registerWorkerDataProvider('testNonCloneable', (options) =>
+				options.name === WORKER_NAME ? () => {} : undefined
+			),
+		];
+		let worker;
+		try {
+			const report = await new Promise((resolve, reject) => {
+				worker = startWorker(FIXTURE, {
+					name: WORKER_NAME,
+					autoRestart: false,
+					onStarted(spawned) {
+						spawned.on('message', (message) => {
+							if (message.type === 'workerData-report') resolve(message);
+						});
+						spawned.once('error', reject);
+					},
+				});
+			});
+			assert.deepEqual(report.testProvided, { secret: 'abc', kid: 'k1' });
+			assert.equal(report.testSkipped, undefined);
+			assert.equal(report.testThrows, undefined);
+			assert.equal(report.testNonCloneable, undefined);
+			// built-ins are untouched
+			assert.equal(report.name, WORKER_NAME);
+			assert.equal(report.hasTicketKeys, true);
+		} finally {
+			for (const unregister of unregisters) unregister();
+			if (worker) {
+				worker.wasShutdown = true;
+				await worker.terminate();
+			}
+		}
+	});
+
+	it('passes the startWorker options to providers so they can filter by worker type', async function () {
+		this.timeout(30000);
+		const seen = [];
+		const unregister = registerWorkerDataProvider('testProvided', (options) => {
+			if (options.name !== WORKER_NAME) return undefined;
+			seen.push(options.name);
+			return undefined; // filter decision only — supply nothing
+		});
+		let worker;
+		try {
+			const report = await new Promise((resolve, reject) => {
+				worker = startWorker(FIXTURE, {
+					name: WORKER_NAME,
+					autoRestart: false,
+					onStarted(spawned) {
+						spawned.on('message', (message) => {
+							if (message.type === 'workerData-report') resolve(message);
+						});
+						spawned.once('error', reject);
+					},
+				});
+			});
+			assert.deepEqual(seen, [WORKER_NAME]);
+			assert.equal(report.testProvided, undefined);
+		} finally {
+			unregister();
+			if (worker) {
+				worker.wasShutdown = true;
+				await worker.terminate();
+			}
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Two small core extension points that the upcoming Harper Pro key-custody component (harper-pro#166) needs. Both are dormant in core — no behavior changes when nothing registers.

1. **`registerWorkerDataProvider(name, fn)`** (`server/threads/manageThreads.js`): registered providers run at each `startWorker` spawn and contribute extra `workerData` properties. A provider receives the `startWorker` options (`options.name` is the thread type, e.g. `http`/`job`) and may return `undefined` to skip that worker — this is how Pro will hand key material to request workers but never job workers. Provider errors and non-structured-cloneable values are logged and skipped (pre-flighted with `structuredClone`) so a provider can never break a spawn; names colliding with the built-in `workerData` keys (or an existing provider) are rejected. Registration returns an unregister function. `ticketKeys` intentionally stays on its existing hardcoded path — no behavior churn here.

2. **Deferred decrypt replay** (`resources/loadEnv.ts`, `resources/secretDecryptor.ts`): encrypted `enc:v1:` `.env` entries that load before any decryptor is registered were previously skipped permanently; they are now also queued (`deferEncryptedEnvValue`, capped at 1000) and replayed into `process.env` when `registerSecretDecryptor` runs, with the same override/conflict semantics as the original load (failed decrypts log and skip that entry; queue is cleared after replay). This removes the ordering constraint between custody registration and component `.env` loading: late custody registration heals rather than fails.

## Purpose

harper-pro#166 introduces custody providers (file-based and Fabric-injected keys). The injected tier delivers key material to workers via `workerData` (piece 1) and may register custody after `.env` files have loaded (piece 2). Both hooks are generic rather than secrets-specific where possible.

## Where to focus

- The provider spread happens before the built-in keys in the `workerData` literal, so built-ins always win even if a collision somehow got registered.
- Replay conflict semantics in `replayDeferredSecrets` intentionally mirror `loadEnv`'s inline path (warn on already-set, honor per-file `override`). If those two blocks drift in the future they should be refactored to share; kept inline for now since the loop shapes differ.
- The deferred queue holds ciphertext (not plaintext) in memory on nodes where no decryptor ever registers (e.g. non-Pro); capped defensively at 1000 entries.

## Testing

- New: `unitTests/server/threads/workerDataProviders.test.js` (real worker spawn via `startWorker`; provider filtering, throw-skip, non-cloneable-skip, built-in collision rejection) and `unitTests/resources/secretDeferredReplay.test.js` (defer→register→env populated, inline decrypt when registered, failed-replay skip, override/conflict semantics, queue cap).
- Existing `unitTests/server/threads/*` and `unitTests/utility/envFile.test.js` pass; oxlint clean on touched files.

Generated by Claude (Fable 5).

## Cross-model review (Codex + Gemini, adjudicated)

Found and fixed (commit e9f2e16):

- **Reserved-key audit**: providers could previously shadow `noServerStart` — set by the embedding entry point (`index.ts`), read by `threadServer.js` — which would make HTTP workers skip `startServers()` and wedge startup. The reject-list now covers every workerData key core produces *or consumes* (audited by grep across the tree), not just the ones `startWorker` spreads.
- **Clone detachment**: the spawn now uses the `structuredClone` result instead of the original provider value, so accessor-backed objects (or post-return mutation) that pass pre-flight can't throw inside `new Worker()`. Test covers a yield-once getter.
- **Redacted queue accessor**: `getDeferredEncryptedEnvValues` returned the live queue array — a holder could mutate pending entries and retained every ciphertext past the flush. It now returns a copied, `rawValue`-free snapshot.
- **Replay no-op**: identical decrypted value vs. already-set `process.env` no longer logs a conflict warning.

Dismissed after verification: `.ts` import-extension claims (repo TypeStrip/dist convention) and two speculative ReferenceError claims on the logger name / loadEnv variable naming — both paths are exercised by the passing tests.
