### PR TITLE
Fix loadedFromSource being unobservable on string-id gets on caching tables

### DIFF
--- a/resources/RequestTarget.ts
+++ b/resources/RequestTarget.ts
@@ -56,6 +56,7 @@ export class RequestTarget extends URLSearchParams {
 	declare previousResidency?: string[];
 
 	// Action tracking
+	/** Cache disposition of a get on a caching table; also mirrored onto the request Context. */
 	declare loadedFromSource?: boolean;
 	declare createdNewId?: string;
 

--- a/resources/Resource.ts
+++ b/resources/Resource.ts
@@ -68,10 +68,6 @@ export class Resource<Record extends object = any> implements ResourceInterface<
 		return true; // Subclasses should override if needed
 	}
 
-	wasLoadedFromSource(): boolean | void {
-		// Subclasses should override if needed
-	}
-
 	addTo(_property: keyof Record, _value: Record[keyof Record]): void {
 		throw new Error('Not implemented');
 	}

--- a/resources/ResourceInterface.ts
+++ b/resources/ResourceInterface.ts
@@ -95,10 +95,11 @@ export interface Context {
 	sourceApply?: boolean;
 	originatingOperation?: OperationFunctionName;
 	previousResidency?: string[];
-	/** Cache disposition of the most recent get on a caching table in this context: true if the
-	 * request initiated a fetch from source (including when a stale cached value is returned while
-	 * revalidating in the background), false if served from cache — including after waiting on
-	 * another request's in-flight source fetch. Subsequent gets in the same context overwrite it. */
+	/** Cache disposition of the most recent get on a caching table in this context: true if the get
+	 * fetched from source — including when a source error fell back to a stale record (staleIfError);
+	 * false if served from cache — including stale-while-revalidate responses (the source fetch
+	 * continues in the background) and waits on another request's in-flight source fetch.
+	 * Subsequent gets in the same context overwrite it. */
 	loadedFromSource?: boolean;
 	nodeName?: string;
 	resourceCache?: Map<Id, any>;

--- a/resources/ResourceInterface.ts
+++ b/resources/ResourceInterface.ts
@@ -95,6 +95,10 @@ export interface Context {
 	sourceApply?: boolean;
 	originatingOperation?: OperationFunctionName;
 	previousResidency?: string[];
+	/** Cache disposition of the most recent get on a caching table in this context: true if the
+	 * request initiated a fetch from source (including when a stale cached value is returned while
+	 * revalidating in the background), false if served from cache — including after waiting on
+	 * another request's in-flight source fetch. Subsequent gets in the same context overwrite it. */
 	loadedFromSource?: boolean;
 	nodeName?: string;
 	resourceCache?: Map<Id, any>;

--- a/resources/ResourceInterface.ts
+++ b/resources/ResourceInterface.ts
@@ -49,7 +49,6 @@ export interface ResourceInterface<Record extends object = any>
 	subscribe?(request: SubscriptionRequest): AsyncIterable<Record> | Promise<AsyncIterable<Record>>;
 
 	doesExist(): boolean;
-	wasLoadedFromSource(): boolean | void;
 
 	getCurrentUser(): User | undefined;
 }

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -776,7 +776,7 @@ export function makeTable(options) {
 					this.#record = entry.value;
 					this.#version = entry.version;
 				});
-			}
+			} else if (hasSourceGet) setLoadedFromSource(undefined, this.getContext(), false); // mark it as cached
 		}
 		// #section: lifecycle-admin
 		static getNewId(): any {
@@ -1224,6 +1224,7 @@ export function makeTable(options) {
 									// return 504 (rather than 404) if there is no content and the cache-control header
 									// dictates not to go to source
 									if (!entry?.value) throw new ServerError('Entry is not cached', 504);
+									if (hasSourceGet) setLoadedFromSource(target, context, false); // mark it as cached
 								} else if (ensureLoaded) {
 									const loadingFromSource = ensureLoadedFromSource(
 										constructor.source,
@@ -1236,7 +1237,7 @@ export function makeTable(options) {
 									if (loadingFromSource) {
 										txn?.disregardReadTxn(); // this could take some time, so don't keep the transaction open if possible
 										return loadingFromSource.then((entry) => entry?.value);
-									}
+									} else if (hasSourceGet) setLoadedFromSource(target, context, false); // mark it as cached
 								}
 								return entry?.value;
 							});

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -4562,7 +4562,8 @@ export function makeTable(options) {
 	) {
 		// mirror the flag onto the context: callers that pass a plain id get an internal
 		// RequestTarget they never see, so the context is their only way to observe cache disposition (#1571)
-		if (target) target.loadedFromSource = loadedFromSource;
+		// target may be a primitive id on instance-API calls, which can't hold the flag
+		if (target && typeof target === 'object') target.loadedFromSource = loadedFromSource;
 		if (context) context.loadedFromSource = loadedFromSource;
 	}
 	function ensureLoadedFromSource(source: typeof TableResource, id, entry, context, resource?, target?) {

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -727,7 +727,7 @@ export function makeTable(options) {
 							// return 504 (rather than 404) if there is no content and the cache-control header
 							// dictates not to go to source
 							if (!this.doesExist()) throw new ServerError('Entry is not cached', 504);
-							if (hasSourceGet && target) target.loadedFromSource = false; // mark it as cached
+							if (hasSourceGet) setLoadedFromSource(target, request, false); // mark it as cached
 						} else if (resourceOptions?.ensureLoaded) {
 							const loadingFromSource = ensureLoadedFromSource(
 								(this.constructor as any).source,
@@ -743,7 +743,7 @@ export function makeTable(options) {
 									TableResource._updateResource(this, entry);
 									return this;
 								});
-							} else if (hasSourceGet) target.loadedFromSource = false; // mark it as cached
+							} else if (hasSourceGet) setLoadedFromSource(target, request, false); // mark it as cached
 						}
 						return this;
 					}
@@ -4554,6 +4554,16 @@ export function makeTable(options) {
 		}
 	}
 
+	function setLoadedFromSource(
+		target: RequestTarget | undefined,
+		context: Context | undefined,
+		loadedFromSource: boolean
+	) {
+		// mirror the flag onto the context: callers that pass a plain id get an internal
+		// RequestTarget they never see, so the context is their only way to observe cache disposition (#1571)
+		if (target) target.loadedFromSource = loadedFromSource;
+		if (context) context.loadedFromSource = loadedFromSource;
+	}
 	function ensureLoadedFromSource(source: typeof TableResource, id, entry, context, resource?, target?) {
 		if (context?.onlyIfCached) {
 			if (!entry?.value) throw new ServerError('Entry is not cached', 504);
@@ -4786,7 +4796,7 @@ export function makeTable(options) {
 				whenResolved(getFromSource(source, id, primaryStore.getEntry(id), context, target));
 			else {
 				// served from cache after waiting for another request to resolve
-				if (target) target.loadedFromSource = false;
+				setLoadedFromSource(target, context, false);
 				whenResolved(entry);
 			}
 		};
@@ -4801,7 +4811,7 @@ export function makeTable(options) {
 			});
 		}
 		// lock acquired — this request will actually load from source
-		if (target) target.loadedFromSource = true;
+		setLoadedFromSource(target, context, true);
 
 		const existingRecord = existingEntry?.value;
 		// it is important to remember that this is _NOT_ part of the current transaction; nothing is changing

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -152,6 +152,25 @@ describe('Caching', () => {
 		assert.equal(context.loadedFromSource, false);
 	});
 
+	it('loadedFromSource is observable on the context with loadAsInstance = false', async function () {
+		const previousLoadAsInstance = CachingTable.loadAsInstance;
+		try {
+			CachingTable.loadAsInstance = false;
+			CachingTable.setTTLExpiration(30);
+			await CachingTable.invalidate(32);
+			let context = {};
+			let result = await CachingTable.get(32, context);
+			assert.equal(result.id, 32);
+			assert.equal(context.loadedFromSource, true);
+			context = {};
+			result = await CachingTable.get(32, context);
+			assert.equal(result.id, 32);
+			assert.equal(context.loadedFromSource, false);
+		} finally {
+			CachingTable.loadAsInstance = previousLoadAsInstance;
+		}
+	});
+
 	it('Cache stampede is handled', async function () {
 		try {
 			CachingTable.setTTLExpiration(0.01);
@@ -247,8 +266,10 @@ describe('Caching', () => {
 		events = [];
 		await new Promise((resolve) => setTimeout(resolve, 10));
 		// should be stale but not evicted
-		let result = await CachingTableStaleWhileRevalidate.get(23);
+		const swrContext = {};
+		let result = await CachingTableStaleWhileRevalidate.get(23, swrContext);
 		assert(result); // should exist in database even though it is stale
+		assert.equal(swrContext.loadedFromSource, false); // stale value served from cache while revalidating
 		assert.equal(sourceRequests, 1); // the source request should be started
 		assert.equal(sourceResponses, 0); // the source request should not be completed yet
 		// the source request should be completed

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -133,6 +133,25 @@ describe('Caching', () => {
 		assert.equal(target23.loadedFromSource, true);
 	});
 
+	it('loadedFromSource is observable on the context with a plain id', async function () {
+		// with a plain id, the static get dispatch mints an internal RequestTarget the caller
+		// never sees, so the flag must be mirrored onto the context (#1571)
+		CachingTable.setTTLExpiration(30);
+		await CachingTable.invalidate(31);
+		let context = {};
+		let result = await CachingTable.get(31, context);
+		assert.equal(result.id, 31);
+		assert.equal(context.loadedFromSource, true);
+		context = {};
+		result = await CachingTable.get(31, context);
+		assert.equal(result.id, 31);
+		assert.equal(context.loadedFromSource, false);
+		context = { onlyIfCached: true };
+		result = await CachingTable.get(31, context);
+		assert.equal(result.id, 31);
+		assert.equal(context.loadedFromSource, false);
+	});
+
 	it('Cache stampede is handled', async function () {
 		try {
 			CachingTable.setTTLExpiration(0.01);


### PR DESCRIPTION
Fixes #1571.

## Summary

On a caching table, the cache-disposition flag `loadedFromSource` was only set on the `RequestTarget` of a `get`. With a plain string id (the common calling convention), the static dispatch mints an internal `RequestTarget` the caller never sees, so the flag was unobservable — and `Context.loadedFromSource`, declared in the interface, was never assigned by any code path. Apps computing cache hit/miss from the context silently recorded every lookup as a hit.

Every site that sets the flag on the target now mirrors it onto the request context via a shared `setLoadedFromSource()` helper in `Table.ts`: the instance-load cache-hit sites, the `loadAsInstance = false` get path (which previously never wrote `false` on cache hits at all, so a stale `true` could linger on a shared context), `ensureLoaded()`, the dedupe-join after another request's in-flight fetch, and the source fetch. The semantics are documented on both `Context` and `RequestTarget`. `target` semantics are unchanged, so `server/REST.ts`'s `wasCacheMiss`/`Age` behavior is unaffected.

## Semantics (verified against the code, not just intended)

- `true` — this get fetched from source, including when a source error fell back to a stale record (`staleIfError` / connection-error fallback).
- `false` — served from cache: fresh hits, `onlyIfCached`, stale-while-revalidate responses (the background fetch briefly sets `true` synchronously, then the hit path overwrites it — the settled value a caller can observe after `await get()` is `false`), and dedupe-join waits.
- Last get in the same context wins.

## Where to look

- **Stale-served semantics are asymmetric and pre-existing:** stale-while-revalidate reads `false`, `staleIfError` fallback reads `true`. Both match the pre-existing `target`/`wasCacheMiss` behavior; this PR documents rather than changes them. If we'd rather unify (e.g. `false` for anything cache-served), that's a deliberate follow-up since it also changes REST's `wasCacheMiss`.
- For chained caches (a cache sourced from another caching table) the inner table writes to its `sourceContext`, not the outer request context, so there is no cross-contamination.
- Minor drive-by: the old cache-hit site at the instance-load path dereferenced `target` without a guard; the helper now guards it.

## Testing

New/extended unit tests in `unitTests/resources/caching.test.js`: context observability with a plain id across source fetch (`true`), cache hit (`false`), and `onlyIfCached` (`false`); the same miss/hit pair with `loadAsInstance = false`; and a disposition assertion (`false`) in the stale-while-revalidate test. Locally: `test:unit:resources` passed (979 tests); `test:unit:main` was clean through 1,103 tests then intentionally stopped to hand off to CI. Please let CI run the full suites.

_Generated by an LLM (Claude Fable 5), cross-reviewed by Codex and Gemini before opening; both reviews' findings are addressed above._

**Docs:** companion documentation PR — HarperFast/documentation#563.