### PR TITLE
Implement wasLoadedFromSource() cache disposition on caching-table resource instances

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+../loaded-from-source-context/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-../loaded-from-source-context/node_modules

--- a/resources/ResourceInterface.ts
+++ b/resources/ResourceInterface.ts
@@ -49,6 +49,8 @@ export interface ResourceInterface<Record extends object = any>
 	subscribe?(request: SubscriptionRequest): AsyncIterable<Record> | Promise<AsyncIterable<Record>>;
 
 	doesExist(): boolean;
+	/** For caching tables, whether this resource's record was loaded from the source; undefined
+	 * until a load resolves or when the table has no source get. See Context.loadedFromSource. */
 	wasLoadedFromSource(): boolean | void;
 
 	getCurrentUser(): User | undefined;

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -289,6 +289,7 @@ export function makeTable(options) {
 		#version?: number; // version of the record
 		#entry?: Entry; // the entry from the database
 		#savingOperation?: any; // operation for the record is currently being saved
+		#loadedFromSource?: boolean; // cache disposition of this resource's load; set via setLoadedFromSource (#1576)
 
 		declare getProperty: (name: string) => any;
 		// #section: static-config
@@ -727,7 +728,7 @@ export function makeTable(options) {
 							// return 504 (rather than 404) if there is no content and the cache-control header
 							// dictates not to go to source
 							if (!this.doesExist()) throw new ServerError('Entry is not cached', 504);
-							if (hasSourceGet) setLoadedFromSource(target, request, false); // mark it as cached
+							if (hasSourceGet) setLoadedFromSource(target, request, false, this); // mark it as cached
 						} else if (resourceOptions?.ensureLoaded) {
 							const loadingFromSource = ensureLoadedFromSource(
 								(this.constructor as any).source,
@@ -743,7 +744,7 @@ export function makeTable(options) {
 									TableResource._updateResource(this, entry);
 									return this;
 								});
-							} else if (hasSourceGet) setLoadedFromSource(target, request, false); // mark it as cached
+							} else if (hasSourceGet) setLoadedFromSource(target, request, false, this); // mark it as cached
 						}
 						return this;
 					}
@@ -768,7 +769,8 @@ export function makeTable(options) {
 				(this.constructor as any).source,
 				this.getId(),
 				this.#entry,
-				this.getContext()
+				this.getContext(),
+				this
 			);
 			if (loadedFromSource) {
 				return when(loadedFromSource as Promise<Entry>, (entry) => {
@@ -776,7 +778,18 @@ export function makeTable(options) {
 					this.#record = entry.value;
 					this.#version = entry.version;
 				});
-			} else if (hasSourceGet) setLoadedFromSource(undefined, this.getContext(), false); // mark it as cached
+			} else if (hasSourceGet) setLoadedFromSource(undefined, this.getContext(), false, this); // mark it as cached
+		}
+		/**
+		 * For caching tables, reports whether this resource's record was loaded from the source
+		 * (see Context.loadedFromSource for the settled semantics). Undefined until a load resolves,
+		 * or when the table has no source get.
+		 */
+		wasLoadedFromSource(): boolean | void {
+			return this.#loadedFromSource;
+		}
+		static _setLoadedFromSource(resource: TableResource, loadedFromSource: boolean) {
+			resource.#loadedFromSource = loadedFromSource;
 		}
 		// #section: lifecycle-admin
 		static getNewId(): any {
@@ -1224,7 +1237,7 @@ export function makeTable(options) {
 									// return 504 (rather than 404) if there is no content and the cache-control header
 									// dictates not to go to source
 									if (!entry?.value) throw new ServerError('Entry is not cached', 504);
-									if (hasSourceGet) setLoadedFromSource(target, context, false); // mark it as cached
+									if (hasSourceGet) setLoadedFromSource(target, context, false, this); // mark it as cached
 								} else if (ensureLoaded) {
 									const loadingFromSource = ensureLoadedFromSource(
 										constructor.source,
@@ -1237,7 +1250,7 @@ export function makeTable(options) {
 									if (loadingFromSource) {
 										txn?.disregardReadTxn(); // this could take some time, so don't keep the transaction open if possible
 										return loadingFromSource.then((entry) => entry?.value);
-									} else if (hasSourceGet) setLoadedFromSource(target, context, false); // mark it as cached
+									} else if (hasSourceGet) setLoadedFromSource(target, context, false, this); // mark it as cached
 								}
 								return entry?.value;
 							});
@@ -4558,13 +4571,16 @@ export function makeTable(options) {
 	function setLoadedFromSource(
 		target: RequestTarget | undefined,
 		context: Context | undefined,
-		loadedFromSource: boolean
+		loadedFromSource: boolean,
+		resource?: TableResource
 	) {
 		// mirror the flag onto the context: callers that pass a plain id get an internal
 		// RequestTarget they never see, so the context is their only way to observe cache disposition (#1571)
 		// target may be a primitive id on instance-API calls, which can't hold the flag
 		if (target && typeof target === 'object') target.loadedFromSource = loadedFromSource;
 		if (context) context.loadedFromSource = loadedFromSource;
+		// a #private field via the static keeps the flag out of own enumerable props (spreads, serialization)
+		if (resource) TableResource._setLoadedFromSource(resource, loadedFromSource); // backs wasLoadedFromSource() (#1576)
 	}
 	function ensureLoadedFromSource(source: typeof TableResource, id, entry, context, resource?, target?) {
 		if (context?.onlyIfCached) {
@@ -4589,7 +4605,7 @@ export function makeTable(options) {
 				recordActionBinary(!needsSourceData, 'cache-hit', tableName);
 			}
 			if (needsSourceData) {
-				const loadingFromSource = getFromSource(source, id, entry, context, target).then((entry) => {
+				const loadingFromSource = getFromSource(source, id, entry, context, target, resource).then((entry) => {
 					if (entry?.value && entry?.value.getRecord?.())
 						logger.error?.('Can not assign a record that is already a resource');
 					if (context) {
@@ -4772,7 +4788,8 @@ export function makeTable(options) {
 		id: Id,
 		existingEntry: Entry,
 		context: Context,
-		target?
+		target?,
+		resource?: TableResource
 	): Promise<Entry> {
 		const metadataFlags = existingEntry?.metadataFlags;
 
@@ -4795,10 +4812,10 @@ export function makeTable(options) {
 				(entry.expiresAt != undefined && entry.expiresAt < Date.now())
 			)
 				// try again — entry still not valid, need to actually fetch from source
-				whenResolved(getFromSource(source, id, primaryStore.getEntry(id), context, target));
+				whenResolved(getFromSource(source, id, primaryStore.getEntry(id), context, target, resource));
 			else {
 				// served from cache after waiting for another request to resolve
-				setLoadedFromSource(target, context, false);
+				setLoadedFromSource(target, context, false, resource);
 				whenResolved(entry);
 			}
 		};
@@ -4813,7 +4830,7 @@ export function makeTable(options) {
 			});
 		}
 		// lock acquired — this request will actually load from source
-		setLoadedFromSource(target, context, true);
+		setLoadedFromSource(target, context, true, resource);
 
 		const existingRecord = existingEntry?.value;
 		// it is important to remember that this is _NOT_ part of the current transaction; nothing is changing

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -171,6 +171,22 @@ describe('Caching', () => {
 		}
 	});
 
+	it('wasLoadedFromSource() reports cache disposition on resource instances (#1576)', async function () {
+		let observed;
+		class ObservingCachingTable extends CachingTable {
+			get(target) {
+				observed = this.wasLoadedFromSource();
+				return super.get(target);
+			}
+		}
+		CachingTable.setTTLExpiration(30);
+		await CachingTable.invalidate(33);
+		await ObservingCachingTable.get(33);
+		assert.equal(observed, true);
+		await ObservingCachingTable.get(33);
+		assert.equal(observed, false);
+	});
+
 	it('Cache stampede is handled', async function () {
 		try {
 			CachingTable.setTTLExpiration(0.01);


### PR DESCRIPTION
Fixes #1576. **Stacked on #1575** — do not merge before it; once #1575 merges into `v5.1`, this PR should be retargeted to `v5.1` (GitHub does this automatically if the base branch is deleted on merge).

## Summary

`wasLoadedFromSource()` is declared on the Resource interface and documented, but its only implementation was the base-class stub — it always returned `undefined`. This implements it for caching tables: `setLoadedFromSource()` (from #1575) gains an optional `resource` parameter and records the disposition in a private `#loadedFromSource` field (via a `_setLoadedFromSource` static, following the `_updateResource` precedent, so the flag stays out of own enumerable props — no leak into spreads or serialization). The resource is threaded through `ensureLoadedFromSource` → `getFromSource`, including the stampede dedupe-join callback and its retry recursion. Settled semantics match `Context.loadedFromSource` exactly (SWR = false, staleIfError fallback = true, dedupe join = false).

## Where to look

- The subscription-revalidation call site (`ensureLoadedFromSource` at ~Table.ts:3076) deliberately does not pass a resource — subscriptions yield raw records, there is no instance to record on. Cross-model review agreed this is sound; flagging it so it doesn't read as an omission.
- `_loadRecord` early-returns when the record is already loaded ("don't reload"); in that path the instance keeps its prior disposition rather than being marked a hit. This mirrors "was **this resource's record** loaded from source" semantics rather than per-access semantics — deliberate, but worth a second opinion.
- First commit accidentally included a `node_modules` symlink (the `.gitignore` directory pattern doesn't match symlinks); removed in the follow-up commit. Net diff is clean.

## Testing

New unit test in `unitTests/resources/caching.test.js` observes `this.wasLoadedFromSource()` from a subclass instance `get` across a source fetch (`true`) and a cache hit (`false`). Full resources suite passes locally (980 tests, 2 consecutive clean runs).

_Generated by an LLM (Claude Fable 5), cross-reviewed by Codex (enumerable-state finding addressed via private field) and Gemini (approved, no blockers)._