### PR TITLE
fix(mcp): compute operations-profile tools lazily so late-registered ops surface (#1562)

### DIFF
--- a/components/mcp/toolRegistry.ts
+++ b/components/mcp/toolRegistry.ts
@@ -185,10 +185,27 @@ export function removeTool(name: string): boolean {
 	return existed;
 }
 
-export function getTool(name: string): ToolDef | undefined {
-	// Statically-registered tools win over provider entries on a name collision
-	// (curated tool overrides a generic same-named provider tool).
+/**
+ * Resolve a tool by name for `tools/call`. Pass the caller's `profile` so
+ * resolution is profile-scoped: the flat name→def registry is a single
+ * namespace shared by both profiles, so without scoping a static tool in one
+ * profile shadows a same-named provider tool in another — the shadowed tool
+ * then lists but is uncallable (the transport rejects the wrong-profile def).
+ *
+ * With a profile: a static registration of that profile wins over its provider
+ * entry (curated tool overrides a generic same-named provider tool), then the
+ * profile's provider, then any static registration by name (harmless — the
+ * transport re-checks `tool.profile`). Without a profile (internal/tests):
+ * static registry first, then any provider.
+ */
+export function getTool(name: string, profile?: McpProfile): ToolDef | undefined {
 	const statik = registry.get(name);
+	if (profile !== undefined) {
+		if (statik?.profile === profile) return statik;
+		const def = profileProviders.get(profile)?.get(name);
+		if (def) return def;
+		return statik;
+	}
 	if (statik) return statik;
 	for (const provider of profileProviders.values()) {
 		const def = provider.get(name);

--- a/components/mcp/toolRegistry.ts
+++ b/components/mcp/toolRegistry.ts
@@ -136,8 +136,41 @@ export interface ToolDef extends ToolDescriptor {
 
 const registry = new Map<string, ToolDef>();
 
+/**
+ * Dynamic, per-profile tool source. A profile may register a provider that
+ * computes its tool set *lazily* — walked on every `tools/list` / `tools/call`
+ * rather than snapshotted into the static registry at registration time. The
+ * operations profile uses this so component operations registered after MCP
+ * boot (`server.registerOperation`, e.g. the built-in agent's `agent_prompt`)
+ * still surface once allow-listed, instead of being missed by a one-time walk
+ * of `OPERATION_FUNCTION_MAP` — see components/mcp/tools/operations.ts (#1562).
+ *
+ * On a name collision, a statically-registered tool (`addTool`) for the same
+ * profile wins over a provider entry — a curated tool overrides a generic
+ * same-named provider tool.
+ */
+export interface ProfileToolProvider {
+	/** Every tool the provider currently exposes for its profile. */
+	list(): ToolDef[];
+	/** Resolve a single tool by name, or `undefined` if not currently exposed. */
+	get(name: string): ToolDef | undefined;
+}
+
+const profileProviders = new Map<McpProfile, ProfileToolProvider>();
+
 /** Per-session pagination cache. Invalidated when a fresh `tools/list` (no cursor) call recomputes. */
 const sessionListCache = new Map<string, { tools: ToolDescriptor[] }>();
+
+/**
+ * Install (or, with `undefined`, remove) the dynamic tool provider for a
+ * profile. Idempotent — re-installing swaps the provider. Drops the pagination
+ * caches so the next `tools/list` recomputes against the new provider.
+ */
+export function setProfileToolProvider(profile: McpProfile, provider: ProfileToolProvider | undefined): void {
+	if (provider) profileProviders.set(profile, provider);
+	else profileProviders.delete(profile);
+	sessionListCache.clear();
+}
 
 export function addTool(def: ToolDef): void {
 	if (!def?.name) throw new Error('addTool: name is required');
@@ -153,7 +186,15 @@ export function removeTool(name: string): boolean {
 }
 
 export function getTool(name: string): ToolDef | undefined {
-	return registry.get(name);
+	// Statically-registered tools win over provider entries on a name collision
+	// (curated tool overrides a generic same-named provider tool).
+	const statik = registry.get(name);
+	if (statik) return statik;
+	for (const provider of profileProviders.values()) {
+		const def = provider.get(name);
+		if (def) return def;
+	}
+	return undefined;
 }
 
 /**
@@ -199,6 +240,7 @@ export function clearSessionCache(sessionId: string): void {
 /** Test seam: drop all registrations. */
 export function _resetRegistryForTest(): void {
 	registry.clear();
+	profileProviders.clear();
 	sessionListCache.clear();
 }
 
@@ -258,9 +300,19 @@ export function listTools(args: ListToolsArgs): ListToolsResult {
 }
 
 function computeFilteredList(user: AuthedUser, profile: McpProfile): ToolDescriptor[] {
-	const out: ToolDescriptor[] = [];
+	// Merge the profile's dynamic provider (if any) with its statically-registered
+	// tools, deduping by name. Provider entries are inserted first so a static
+	// registration of the same name overrides them (curated wins — see getTool).
+	const byName = new Map<string, ToolDef>();
+	const provider = profileProviders.get(profile);
+	if (provider) {
+		for (const def of provider.list()) byName.set(def.name, def);
+	}
 	for (const def of registry.values()) {
-		if (def.profile !== profile) continue;
+		if (def.profile === profile) byName.set(def.name, def);
+	}
+	const out: ToolDescriptor[] = [];
+	for (const def of byName.values()) {
 		if (!def.visibleTo(user)) continue;
 		out.push({
 			name: def.name,

--- a/components/mcp/tools/operations.ts
+++ b/components/mcp/tools/operations.ts
@@ -1,7 +1,17 @@
 /**
- * Operations-profile tool generation. Walks Harper's `OPERATION_FUNCTION_MAP`
- * and registers one MCP tool per operation that survives the
- * `mcp.operations.allow` / `deny` filter.
+ * Operations-profile tool generation. Exposes one MCP tool per Harper
+ * operation that survives the `mcp.operations.allow` / `deny` filter, computed
+ * *lazily* by walking Harper's live `OPERATION_FUNCTION_MAP` on each
+ * `tools/list` / `tools/call`.
+ *
+ * The list is computed lazily (not snapshotted at registration) because
+ * components register their operations via `server.registerOperation` during
+ * `startOnMainThread`, which runs AFTER the MCP operations profile registers
+ * (see components/mcp/index.ts → registerMcpProfile). A one-time walk at
+ * registration time would miss every component-registered operation (e.g. the
+ * built-in agent's `agent_prompt`), so `mcp.operations.allow` listing them
+ * would silently have no effect — #1562. Walking the live map per request
+ * removes the ordering dependence and stays consistent as components load.
  *
  * The default v1 allow list is read-only and intentionally narrow:
  * `describe_*`, `list_*`, `search_*`, plus an explicit set of safe
@@ -26,12 +36,21 @@
 import * as env from '../../../utility/environment/environmentManager.ts';
 import { CONFIG_PARAMS } from '../../../utility/hdbTerms.ts';
 import harperLogger from '../../../utility/logging/harper_logger.ts';
-import { addTool, canRoleInvokeOperation, type AuthedUser, type ToolResult } from '../toolRegistry.ts';
+import {
+	canRoleInvokeOperation,
+	setProfileToolProvider,
+	type AuthedUser,
+	type ProfileToolProvider,
+	type ToolDef,
+	type ToolResult,
+} from '../toolRegistry.ts';
 import { OPERATION_INPUT_SCHEMAS, PERMISSIVE_SCHEMA } from './schemas/operations.ts';
 import { OPERATION_DESCRIPTIONS } from './schemas/operationDescriptions.ts';
 
-// Eager-resolved at module load. The map is built at Harper boot and
-// doesn't mutate, so caching here is safe.
+// Resolved from Harper's server-helpers graph on demand. The map is built at
+// Harper boot but keeps mutating as components register operations during
+// `startOnMainThread` — the provider below re-reads it per request rather than
+// snapshotting (#1562).
 type OperationFunction = (json: object) => unknown | Promise<unknown>;
 type OperationFunctionMap = Map<string, { operation_function: OperationFunction }>;
 
@@ -277,35 +296,75 @@ function makeOperationToolHandler(operationName: string) {
 }
 
 /**
- * Idempotent registration: walk the op map, register every operation that
- * passes the allow/deny filter. Safe to invoke multiple times — `addTool`
- * is `Map.set`-backed.
+ * Build the `ToolDef` for one operation. A def is a pure function of the
+ * operation name — its schema, description, annotations, RBAC predicate, and
+ * handler don't depend on the allow/deny config (that only decides *whether*
+ * the op is exposed, checked per request in the provider). So defs are cached
+ * by name and reused across `tools/list` / `tools/call` calls.
+ */
+function buildOperationToolDef(operationName: string): ToolDef {
+	const inputSchema = OPERATION_INPUT_SCHEMAS[operationName] ?? PERMISSIVE_SCHEMA;
+	const annotations: { readOnlyHint?: boolean; destructiveHint?: boolean; idempotentHint?: boolean } = {};
+	if (isReadOnly(operationName)) annotations.readOnlyHint = true;
+	if (isDestructive(operationName)) annotations.destructiveHint = true;
+	if (isIdempotent(operationName)) annotations.idempotentHint = true;
+	return {
+		name: operationName,
+		description: buildDescription(operationName, operationName in OPERATION_INPUT_SCHEMAS),
+		inputSchema,
+		profile: 'operations',
+		...(Object.keys(annotations).length > 0 ? { annotations } : {}),
+		visibleTo: (user) => canRoleInvokeOperation(user, operationName),
+		handler: makeOperationToolHandler(operationName),
+	};
+}
+
+const toolDefCache = new Map<string, ToolDef>();
+
+function getOperationToolDef(operationName: string): ToolDef {
+	let def = toolDefCache.get(operationName);
+	if (!def) {
+		def = buildOperationToolDef(operationName);
+		toolDefCache.set(operationName, def);
+	}
+	return def;
+}
+
+/**
+ * Lazy operations-profile tool provider. Consulted by the registry on every
+ * `tools/list` / `tools/call`, so it reflects the live `OPERATION_FUNCTION_MAP`
+ * — including operations registered by components after MCP boot (#1562).
+ */
+const operationsToolProvider: ProfileToolProvider = {
+	list(): ToolDef[] {
+		const opMap = getOperationFunctionMap();
+		if (!opMap) {
+			harperLogger.warn('MCP operations profile: OPERATION_FUNCTION_MAP not available; no tools listed');
+			return [];
+		}
+		const config = getOperationsConfig();
+		const defs: ToolDef[] = [];
+		for (const operationName of opMap.keys()) {
+			if (!isOperationAllowed(operationName, config)) continue;
+			defs.push(getOperationToolDef(operationName));
+		}
+		return defs;
+	},
+	get(operationName: string): ToolDef | undefined {
+		const opMap = getOperationFunctionMap();
+		if (!opMap || !opMap.has(operationName)) return undefined;
+		if (!isOperationAllowed(operationName, getOperationsConfig())) return undefined;
+		return getOperationToolDef(operationName);
+	},
+};
+
+/**
+ * Install the operations-profile tool provider. The provider is walked lazily
+ * per request rather than snapshotting the op map here, so component operations
+ * registered after this runs still surface once allow-listed (#1562).
+ * Idempotent — re-installing the provider is a no-op swap.
  */
 export function registerOperationsTools(): void {
-	const opMap = getOperationFunctionMap();
-	if (!opMap) {
-		harperLogger.warn('MCP operations profile: OPERATION_FUNCTION_MAP not available; no tools registered');
-		return;
-	}
-	const config = getOperationsConfig();
-	let registered = 0;
-	for (const operationName of opMap.keys()) {
-		if (!isOperationAllowed(operationName, config)) continue;
-		const inputSchema = OPERATION_INPUT_SCHEMAS[operationName] ?? PERMISSIVE_SCHEMA;
-		const annotations: { readOnlyHint?: boolean; destructiveHint?: boolean; idempotentHint?: boolean } = {};
-		if (isReadOnly(operationName)) annotations.readOnlyHint = true;
-		if (isDestructive(operationName)) annotations.destructiveHint = true;
-		if (isIdempotent(operationName)) annotations.idempotentHint = true;
-		addTool({
-			name: operationName,
-			description: buildDescription(operationName, operationName in OPERATION_INPUT_SCHEMAS),
-			inputSchema,
-			profile: 'operations',
-			...(Object.keys(annotations).length > 0 ? { annotations } : {}),
-			visibleTo: (user) => canRoleInvokeOperation(user, operationName),
-			handler: makeOperationToolHandler(operationName),
-		});
-		registered++;
-	}
-	harperLogger.info(`MCP operations profile: registered ${registered} tool(s)`);
+	setProfileToolProvider('operations', operationsToolProvider);
+	harperLogger.info('MCP operations profile: lazy tool provider installed');
 }

--- a/components/mcp/tools/operations.ts
+++ b/components/mcp/tools/operations.ts
@@ -296,11 +296,12 @@ function makeOperationToolHandler(operationName: string) {
 }
 
 /**
- * Build the `ToolDef` for one operation. A def is a pure function of the
- * operation name — its schema, description, annotations, RBAC predicate, and
- * handler don't depend on the allow/deny config (that only decides *whether*
- * the op is exposed, checked per request in the provider). So defs are cached
- * by name and reused across `tools/list` / `tools/call` calls.
+ * Build the `ToolDef` for one operation. Cheap and stateless — a def is a pure
+ * function of the operation name (its schema, description, annotations, RBAC
+ * predicate, and handler don't depend on the allow/deny config, which only
+ * decides *whether* the op is exposed, checked per request in the provider).
+ * `tools/list` isn't a hot path, so the provider rebuilds defs per call rather
+ * than caching (no module-level state to leak or stale-cache across tests).
  */
 function buildOperationToolDef(operationName: string): ToolDef {
 	const inputSchema = OPERATION_INPUT_SCHEMAS[operationName] ?? PERMISSIVE_SCHEMA;
@@ -319,17 +320,6 @@ function buildOperationToolDef(operationName: string): ToolDef {
 	};
 }
 
-const toolDefCache = new Map<string, ToolDef>();
-
-function getOperationToolDef(operationName: string): ToolDef {
-	let def = toolDefCache.get(operationName);
-	if (!def) {
-		def = buildOperationToolDef(operationName);
-		toolDefCache.set(operationName, def);
-	}
-	return def;
-}
-
 /**
  * Lazy operations-profile tool provider. Consulted by the registry on every
  * `tools/list` / `tools/call`, so it reflects the live `OPERATION_FUNCTION_MAP`
@@ -346,7 +336,7 @@ const operationsToolProvider: ProfileToolProvider = {
 		const defs: ToolDef[] = [];
 		for (const operationName of opMap.keys()) {
 			if (!isOperationAllowed(operationName, config)) continue;
-			defs.push(getOperationToolDef(operationName));
+			defs.push(buildOperationToolDef(operationName));
 		}
 		return defs;
 	},
@@ -354,7 +344,7 @@ const operationsToolProvider: ProfileToolProvider = {
 		const opMap = getOperationFunctionMap();
 		if (!opMap || !opMap.has(operationName)) return undefined;
 		if (!isOperationAllowed(operationName, getOperationsConfig())) return undefined;
-		return getOperationToolDef(operationName);
+		return buildOperationToolDef(operationName);
 	},
 };
 

--- a/components/mcp/transport.ts
+++ b/components/mcp/transport.ts
@@ -495,7 +495,7 @@ async function dispatchToolsCall(
 	if (!name) {
 		return jsonResponse(200, buildError(messageId, ERROR_CODES.INVALID_PARAMS, 'tools/call requires params.name'));
 	}
-	const tool = getTool(name);
+	const tool = getTool(name, request.profile);
 	if (!tool || tool.profile !== request.profile) {
 		return jsonResponse(200, buildError(messageId, ERROR_CODES.METHOD_NOT_FOUND, `Unknown tool: ${name}`));
 	}

--- a/unitTests/components/mcp/toolRegistry.test.js
+++ b/unitTests/components/mcp/toolRegistry.test.js
@@ -184,6 +184,68 @@ describe('mcp/toolRegistry', () => {
 		});
 	});
 
+	describe('setProfileToolProvider (dynamic per-profile tools)', () => {
+		const { setProfileToolProvider } = require('#src/components/mcp/toolRegistry');
+
+		function provider(defs) {
+			const byName = new Map(defs.map((d) => [d.name, d]));
+			return { list: () => defs, get: (name) => byName.get(name) };
+		}
+
+		it('lists provider tools merged with statically-registered tools', () => {
+			addTool(makeTool({ name: 'static_op', profile: 'operations' }));
+			setProfileToolProvider('operations', provider([makeTool({ name: 'dynamic_op', profile: 'operations' })]));
+			const result = listTools({ user: {}, profile: 'operations', sessionId: 's', limit: 10 });
+			assert.deepEqual(
+				result.tools.map((t) => t.name),
+				['dynamic_op', 'static_op']
+			);
+		});
+
+		it('reflects a provider whose set changes between calls (lazy walk)', () => {
+			let defs = [makeTool({ name: 'op_a', profile: 'operations' })];
+			setProfileToolProvider('operations', {
+				list: () => defs,
+				get: (name) => defs.find((d) => d.name === name),
+			});
+			assert.deepEqual(
+				listTools({ user: {}, profile: 'operations', sessionId: 's', limit: 10 }).tools.map((t) => t.name),
+				['op_a']
+			);
+			defs = [...defs, makeTool({ name: 'op_b', profile: 'operations' })];
+			assert.deepEqual(
+				listTools({ user: {}, profile: 'operations', sessionId: 's', limit: 10 }).tools.map((t) => t.name),
+				['op_a', 'op_b']
+			);
+		});
+
+		it('a statically-registered tool overrides a provider tool of the same name', () => {
+			addTool(makeTool({ name: 'dup', profile: 'operations', description: 'static wins' }));
+			setProfileToolProvider(
+				'operations',
+				provider([makeTool({ name: 'dup', profile: 'operations', description: 'provider loses' })])
+			);
+			const result = listTools({ user: {}, profile: 'operations', sessionId: 's', limit: 10 });
+			assert.equal(result.tools.length, 1);
+			assert.equal(result.tools[0].description, 'static wins');
+			assert.equal(getTool('dup').description, 'static wins');
+		});
+
+		it('getTool falls back to the provider when the registry misses', () => {
+			setProfileToolProvider('operations', provider([makeTool({ name: 'prov_only', profile: 'operations' })]));
+			assert.equal(getTool('prov_only').name, 'prov_only');
+			assert.equal(getTool('nonexistent'), undefined);
+		});
+
+		it('removing the provider drops its tools', () => {
+			setProfileToolProvider('operations', provider([makeTool({ name: 'gone', profile: 'operations' })]));
+			assert.equal(getTool('gone').name, 'gone');
+			setProfileToolProvider('operations', undefined);
+			assert.equal(getTool('gone'), undefined);
+			assert.equal(listTools({ user: {}, profile: 'operations', sessionId: 's', limit: 10 }).tools.length, 0);
+		});
+	});
+
 	describe('clearSessionCache', () => {
 		const { clearSessionCache } = require('#src/components/mcp/toolRegistry');
 

--- a/unitTests/components/mcp/toolRegistry.test.js
+++ b/unitTests/components/mcp/toolRegistry.test.js
@@ -237,6 +237,33 @@ describe('mcp/toolRegistry', () => {
 			assert.equal(getTool('nonexistent'), undefined);
 		});
 
+		it('getTool(name, profile) is profile-scoped so a cross-profile static tool cannot shadow a provider tool', () => {
+			// A static application tool and a dynamic operations tool share a name.
+			// The operations client must still resolve ITS tool (not the app one).
+			addTool(makeTool({ name: 'shared', profile: 'application', description: 'app tool' }));
+			setProfileToolProvider(
+				'operations',
+				provider([makeTool({ name: 'shared', profile: 'operations', description: 'op tool' })])
+			);
+
+			const opTool = getTool('shared', 'operations');
+			assert.equal(opTool.profile, 'operations');
+			assert.equal(opTool.description, 'op tool');
+
+			const appTool = getTool('shared', 'application');
+			assert.equal(appTool.profile, 'application');
+			assert.equal(appTool.description, 'app tool');
+		});
+
+		it('within a profile, a static tool still wins over a same-name provider tool under getTool(name, profile)', () => {
+			addTool(makeTool({ name: 'dup', profile: 'operations', description: 'static wins' }));
+			setProfileToolProvider(
+				'operations',
+				provider([makeTool({ name: 'dup', profile: 'operations', description: 'provider loses' })])
+			);
+			assert.equal(getTool('dup', 'operations').description, 'static wins');
+		});
+
 		it('removing the provider drops its tools', () => {
 			setProfileToolProvider('operations', provider([makeTool({ name: 'gone', profile: 'operations' })]));
 			assert.equal(getTool('gone').name, 'gone');

--- a/unitTests/components/mcp/tools/operations.test.js
+++ b/unitTests/components/mcp/tools/operations.test.js
@@ -249,6 +249,50 @@ describe('mcp/tools/operations — registration', () => {
 		assert.equal(tools.length, 2);
 	});
 
+	it('surfaces operations registered AFTER registration (lazy walk of the live map) — #1562', () => {
+		// Components register their operations via server.registerOperation during
+		// startOnMainThread, which runs after the MCP operations profile registers.
+		// The tool list must be computed lazily so those late ops still appear.
+		const opMap = makeOpMap([['describe_all', null]]);
+		_setOperationFunctionMapForTest(opMap);
+		registerOperationsTools();
+
+		// Only the boot-time op is present at first.
+		let names = listTools({ user: SUPER, profile: 'operations', sessionId: 's', limit: 200 }).tools.map((t) => t.name);
+		assert.deepEqual(names, ['describe_all']);
+
+		// A component registers new ops after registration ran. `list_agents` is
+		// allow-listed by default via `list_*`; `agent_prompt` is opted in explicitly.
+		opMap.set('list_agents', { operation_function: async () => ({ agents: [] }) });
+		opMap.set('agent_prompt', { operation_function: async () => ({ ok: true }) });
+		envOverrides.mcp_operations_allow = ['describe_*', 'list_*', 'agent_prompt'];
+
+		names = listTools({ user: SUPER, profile: 'operations', sessionId: 's', limit: 200 }).tools.map((t) => t.name);
+		assert.deepEqual(names.sort(), ['agent_prompt', 'describe_all', 'list_agents']);
+	});
+
+	it('resolves a late-registered op through getTool for tools/call dispatch — #1562', () => {
+		const opMap = makeOpMap([['describe_all', null]]);
+		_setOperationFunctionMapForTest(opMap);
+		registerOperationsTools();
+
+		// Not registered yet, and not allow-listed → not callable.
+		assert.equal(getTool('agent_prompt'), undefined);
+
+		// Component registers it and the operator opts it in.
+		opMap.set('agent_prompt', { operation_function: async () => ({ ok: true }) });
+		envOverrides.mcp_operations_allow = ['describe_*', 'agent_prompt'];
+
+		const tool = getTool('agent_prompt');
+		assert.ok(tool, 'late-registered allow-listed op must resolve for tools/call');
+		assert.equal(tool.profile, 'operations');
+		assert.equal(typeof tool.handler, 'function');
+
+		// A live op that is NOT allow-listed still must not be callable.
+		opMap.set('drop_table', { operation_function: async () => ({}) });
+		assert.equal(getTool('drop_table'), undefined);
+	});
+
 	it('logs a warning and registers nothing when OPERATION_FUNCTION_MAP is unavailable', () => {
 		_setOperationFunctionMapForTest(undefined);
 		// Force the lazy require to return a module-shape that has no map.


### PR DESCRIPTION
## Problem

The MCP operations profile (`components/mcp/tools/operations.ts` → `registerOperationsTools`) walked `OPERATION_FUNCTION_MAP` **once** at registration time and registered one tool per allowed op. But components register their operations via `server.registerOperation` during `startOnMainThread`, which runs **after** the profile is built. Those late-registered ops (e.g. the built-in agent's `agent_prompt`) never became MCP tools, so listing them in `mcp.operations.allow` **silently had no effect** and `tools/call` returned `-32601 Unknown tool`.

Closes #1562.

## Fix

Adopts the issue's **Option 1 (lazy)** — the most robust, order-independent choice.

- **Lazy per-profile tool provider.** Replaces the one-time snapshot with a `ProfileToolProvider` the registry consults on every `tools/list` / `tools/call`. The operations provider walks the *live* `OPERATION_FUNCTION_MAP` and applies the allow/deny filter at request time, so component-registered ops surface as soon as they exist. No boot-ordering dependence.
- **Generic mechanism** (`setProfileToolProvider`) merges provider tools with statically-registered tools, deduping by name; **static registrations win on collision** — so the built-in agent's curated MCP tools (#1561) remain a deliberate curated surface and are unaffected.
- Defs are rebuilt per call (a def is a pure function of the op name). `tools/list` isn't a hot path, so no module-level cache to leak or stale across tests/boots.

## Cross-model review fix (2nd commit)

Gemini + Codex both flagged that the flat `name→def` registry is a **single namespace shared by both profiles**, so an unscoped `getTool` let a static tool in one profile shadow a same-named provider tool in another — the shadowed tool *listed* but was uncallable (transport rejected the wrong-profile def). `getTool` now takes the caller's profile and resolves profile-scoped; `dispatchToolsCall` passes `request.profile`. Also dropped the module-level `toolDefCache` (not a hot path; avoids cross-test/boot module state).

## Tests

- `unitTests/components/mcp/toolRegistry.test.js` — provider merge, static-wins-on-collision, profile-scoped `getTool`, cache invalidation.
- `unitTests/components/mcp/tools/operations.test.js` — late-registered op surfaces after provider install; allow/deny applied per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
