### PR TITLE
fix(cache): consult allowStaleWhileRevalidate for query-driven revalidation (#1578)

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -3039,6 +3039,7 @@ export function makeTable(options) {
 			}
 			let transformCache;
 			const source = this.source;
+			const resourceClass = this;
 			// Transform an entry to a record. Note that *this* instance is intended to be the iterator.
 			const transform = function (entry: Entry) {
 				let record;
@@ -3076,7 +3077,17 @@ export function makeTable(options) {
 								message: 'This entry has expired',
 							};
 						}
-						const loadingFromSource = ensureLoadedFromSource(source, entry.key ?? entry, entry, context);
+						// Stale-while-revalidate is an instance method, but a query has no per-row resource
+						// instance to consult (the single-record `get` path passes `this`). Construct one for this
+						// row — via the same `new constructor(id, context)` the framework's getResource uses — so
+						// the hook sees the current row's identity (this.getId()), matching the single-record path.
+						// It must be a real instance, not the bare class prototype: every resource prototype chain
+						// ends in a tracked-property Proxy, so reading an absent property (probing for an undefined
+						// `allowStaleWhileRevalidate`, or a hook touching `this.x`) on a non-instance invokes
+						// getChanges() with no backing state and throws (harper#1578). This runs only for the
+						// expired/invalidated rows already headed to source, so the allocation is negligible.
+						const swrResource = new resourceClass(entry.key ?? entry, context);
+						const loadingFromSource = ensureLoadedFromSource(source, entry.key ?? entry, entry, context, swrResource);
 						if (loadingFromSource?.then) {
 							return loadingFromSource.then(transform);
 						}

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -3080,13 +3080,19 @@ export function makeTable(options) {
 						// Stale-while-revalidate is an instance method, but a query has no per-row resource
 						// instance to consult (the single-record `get` path passes `this`). Construct one for this
 						// row — via the same `new constructor(id, context)` the framework's getResource uses — so
-						// the hook sees the current row's identity (this.getId()), matching the single-record path.
-						// It must be a real instance, not the bare class prototype: every resource prototype chain
-						// ends in a tracked-property Proxy, so reading an absent property (probing for an undefined
-						// `allowStaleWhileRevalidate`, or a hook touching `this.x`) on a non-instance invokes
-						// getChanges() with no backing state and throws (harper#1578). This runs only for the
-						// expired/invalidated rows already headed to source, so the allocation is negligible.
+						// the hook sees the current row's identity (this.getId()) and record state, matching the
+						// single-record path. It must be a real instance, not the bare class prototype: every
+						// resource prototype chain ends in a tracked-property Proxy, so reading an absent property
+						// (probing for an undefined `allowStaleWhileRevalidate`, or a hook touching `this.x`) on a
+						// non-instance invokes getChanges() with no backing state and throws (harper#1578). We also
+						// load the stale entry into it (as the single-record path does via _updateResource) so a
+						// hook consulting this.getRecord()/this.<field> sees the stale row, not undefined. `entry`
+						// here may be lazy (its `.value` is a GC-able deref, undefined once collected), so we set the
+						// already-dereferenced `record` explicitly rather than relying on `entry.value`. This runs
+						// only for the expired/invalidated rows already headed to source, so the cost is negligible.
 						const swrResource = new resourceClass(entry.key ?? entry, context);
+						resourceClass._updateResource(swrResource, entry);
+						swrResource.setRecord(record);
 						const loadingFromSource = ensureLoadedFromSource(source, entry.key ?? entry, entry, context, swrResource);
 						if (loadingFromSource?.then) {
 							return loadingFromSource.then(transform);

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -124,6 +124,10 @@ describe('Caching', () => {
 		SwrQueryTable.prototype.allowStaleWhileRevalidate = function () {
 			// Record the identity the hook sees so a test can assert it matches the current row (harper#1578).
 			observedSwrIds.push(this.getId());
+			// The stale record must be loaded on the query-path instance, matching the single-record get path:
+			// a hook consulting this.getRecord()/this.<field> should see the stale row, not undefined (harper#1578).
+			assert.ok(this.getRecord(), 'SWR hook should see the loaded stale record, not undefined');
+			assert.equal(this.getRecord().id, this.getId());
 			return swrEnabled;
 		};
 	});

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -12,9 +12,13 @@ describe('Caching', () => {
 	let CachingTable,
 		IndexedCachingTable,
 		CachingTableStaleWhileRevalidate,
+		SwrQueryTable,
 		Source,
 		sourceRequests = 0,
 		sourceResponses = 0;
+	let swrEnabled = true;
+	let sourceGate = null; // when set, SwrQueryTable's source defers responding until the test releases it
+	let observedSwrIds = []; // ids the SwrQueryTable SWR hook saw via this.getId(), for the per-row-identity test
 	let events = [];
 	let timer = 0;
 	let return_value = true;
@@ -91,6 +95,36 @@ describe('Caching', () => {
 			allowStaleWhileRevalidate(_entry, _id) {
 				return true;
 			}
+		};
+		// Indexed, object-sourced table whose allowStaleWhileRevalidate is gated by `swrEnabled`, so the
+		// same table exercises both the SWR and non-SWR query paths (harper#1578).
+		SwrQueryTable = table({
+			table: 'SwrQueryTable',
+			database: 'test',
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'name', indexed: true },
+			],
+		});
+		SwrQueryTable.sourcedFrom({
+			get(id) {
+				sourceRequests++;
+				return new Promise((resolve) => {
+					const respond = () => {
+						sourceResponses++;
+						resolve(return_value && { id, name: 'name ' + id });
+					};
+					// A gate lets a test hold the source response open deterministically (no timing races);
+					// otherwise fall back to the shared `timer` delay.
+					if (sourceGate) sourceGate(respond);
+					else setTimeout(respond, timer);
+				});
+			},
+		});
+		SwrQueryTable.prototype.allowStaleWhileRevalidate = function () {
+			// Record the identity the hook sees so a test can assert it matches the current row (harper#1578).
+			observedSwrIds.push(this.getId());
+			return swrEnabled;
 		};
 	});
 	it('Has isCaching flag', async function () {
@@ -237,6 +271,95 @@ describe('Caching', () => {
 		result = await CachingTableStaleWhileRevalidate.primaryStore.get(23);
 		assert.equal(sourceRequests, 1); // should be cached again
 		assert(result);
+	});
+
+	// harper#1578: a query touching an expired row must consult allowStaleWhileRevalidate and serve the
+	// stale row while revalidating in the background, matching the single-record get path above.
+	it('Allows stale-while-revalidate for queries', async function () {
+		try {
+			swrEnabled = true;
+			timer = 0;
+			SwrQueryTable.setTTLExpiration({ expiration: 50, eviction: 100 }); // don't expire/evict on a timer; we force staleness explicitly
+			await SwrQueryTable.get(23); // warm the cache with a fresh entry (ungated)
+			// Force the entry stale (present but expired) deterministically, avoiding TTL timing races.
+			await SwrQueryTable.put(23, { id: 23, name: 'name 23' }, { expiresAt: 1 });
+			sourceRequests = 0;
+			sourceResponses = 0;
+			// Gate the revalidation so we can assert the query returned the stale row WITHOUT the source
+			// having responded — no timing race.
+			let releaseSource;
+			sourceGate = (respond) => (releaseSource = respond);
+			const results = [];
+			for await (const record of SwrQueryTable.search({ conditions: [{ attribute: 'name', value: 'name 23' }] })) {
+				results.push(record);
+			}
+			assert.equal(results.length, 1); // stale row served without waiting on source
+			assert.equal(results[0].id, 23);
+			assert.equal(sourceRequests, 1); // background revalidation was started
+			assert.equal(sourceResponses, 0); // and the query did NOT block on it (response still gated)
+			assert(releaseSource, 'the source revalidation should be in-flight (gated)');
+			releaseSource(); // now let the background revalidation complete
+			await waitFor(() => sourceResponses === 1);
+		} finally {
+			sourceGate = null;
+			timer = 0;
+		}
+	});
+
+	// Guard the negative: without SWR (or when it returns false), a query over an expired row must still
+	// block on the upstream fetch, so the fix does not silently change non-SWR tables.
+	it('Query over expired row blocks on source when stale-while-revalidate is not allowed', async function () {
+		try {
+			swrEnabled = false;
+			timer = 0;
+			SwrQueryTable.setTTLExpiration({ expiration: 50, eviction: 100 });
+			await SwrQueryTable.get(23); // warm the cache with a fresh entry
+			await SwrQueryTable.put(23, { id: 23, name: 'name 23' }, { expiresAt: 1 }); // force stale
+			sourceRequests = 0;
+			sourceResponses = 0;
+			const results = [];
+			for await (const record of SwrQueryTable.search({ conditions: [{ attribute: 'name', value: 'name 23' }] })) {
+				results.push(record);
+			}
+			assert.equal(results.length, 1);
+			assert.equal(results[0].id, 23);
+			assert.equal(sourceRequests, 1);
+			assert.equal(sourceResponses, 1); // the query blocked until the source responded
+		} finally {
+			timer = 0;
+			swrEnabled = true;
+		}
+	});
+
+	// Guard against a single shared SWR instance leaking one row's identity to the others: a query over
+	// several expired rows must invoke allowStaleWhileRevalidate with each row's own id (harper#1578).
+	it('Query revalidation sees each row identity for a per-row SWR policy', async function () {
+		const ids = [24, 25, 26];
+		try {
+			swrEnabled = true;
+			timer = 0;
+			SwrQueryTable.setTTLExpiration({ expiration: 50, eviction: 100 });
+			for (const id of ids) await SwrQueryTable.get(id); // warm each entry
+			// Force all three stale and give them a shared indexed name so one query returns all of them.
+			for (const id of ids) await SwrQueryTable.put(id, { id, name: 'shared-swr' }, { expiresAt: 1 });
+			observedSwrIds = [];
+			const results = [];
+			for await (const record of SwrQueryTable.search({ conditions: [{ attribute: 'name', value: 'shared-swr' }] })) {
+				results.push(record.id);
+			}
+			assert.deepEqual(
+				[...results].sort((a, b) => a - b),
+				ids
+			); // all three stale rows served
+			// The SWR hook must have seen each row's own id via this.getId(), not the first row's repeated.
+			assert.deepEqual(
+				[...observedSwrIds].sort((a, b) => a - b),
+				ids
+			);
+		} finally {
+			timer = 0;
+			observedSwrIds = [];
+		}
 	});
 
 	it('Caching directives', async function () {


### PR DESCRIPTION
## Summary

Fixes #1578. When a query/search hits an expired or invalidated entry, `transformEntryForSelect` reloads it via `ensureLoadedFromSource` — but it passed **no resource**, so the stale-while-revalidate early-return could never fire. A table implementing `allowStaleWhileRevalidate()` got stale-served single-record `get`s, yet queries touching the same expired rows always **blocked on the upstream source fetch** — serial upstream latency inside query iteration, exactly what SWR exists to avoid.

## Fix

The single-record `get` path passes its loaded resource instance as the `resource`; queries have none. Since `allowStaleWhileRevalidate` is an instance method, the query path now **constructs a resource instance per expired/invalidated row** (via the same `new constructor(id, context)` the framework's `getResource` uses) and threads it through.

Key design points:
- **Real instance, not the class prototype.** Every resource prototype chain ends in a tracked-property `Proxy`; reading an absent property on a *non-instance* (probing for an undefined hook, or a user hook touching `this.x`) invokes `getChanges()` with no backing state and throws. A real instance degrades gracefully, exactly as the single-record path does for non-SWR tables.
- **Per row, not memoized per query.** Constructing per row keeps `this.getId()` / instance state correct for row-dependent policies (matching single-record semantics). It only runs for rows already headed to source, so the allocation is negligible against the source fetch.
- **Non-SWR tables unchanged** — an absent hook resolves to `undefined` through the instance's proxy and the query still blocks on source.

## Tests

Adds query-iteration tests over expired rows (in `unitTests/resources/caching.test.js`):
- **SWR**: serves the stale row while revalidating in the background — uses a deterministic source gate (no timing race).
- **Non-SWR**: still blocks on source (guards against silent behavior change).
- **Per-row identity**: a `this.getId()`-based policy sees each row's own id across a multi-row query (verified to fail under a memoized single instance).

Local: 160 passing across the caching / query / query-tier1 / resources unit suites.

## Cross-model review

Reviewed with Codex + Gemini (thorough) before opening. Both flagged the initial approach (which passed the bare prototype guarded by a `hasResourceMethod` probe): prototype-as-`this` breaks hooks that read instance state, and the probe could invoke a shadowing accessor. Reworked to the per-row real-instance approach above, which resolves both. A Codex re-review then caught a residual **row-identity** bug in an interim memoized variant (first row's id reused for all rows) — fixed by constructing per row, now covered by the per-row-identity regression test. Gemini's remaining notes (constructor arg, test flakiness) are addressed (real id passed; deterministic gate).

Behavior predates #1575/#1577; observed on v5.1 (5.1.15) and main.

_Authored with Claude Opus 4.8 (1M context)._