### PR TITLE
fix(security): report OCSP/CRL cache disposition via target.loadedFromSource

### DIFF
--- a/security/certificateVerification/certificateVerificationSource.ts
+++ b/security/certificateVerification/certificateVerificationSource.ts
@@ -6,20 +6,25 @@ import { Resource } from '../../resources/Resource.ts';
 import type { SourceContext, Query } from '../../resources/ResourceInterface.ts';
 import type { CertificateVerificationContext } from './types.ts';
 
-// Import verification functions
-let performCRLCheck: any;
-let performOCSPCheck: any;
+// Lazy, memoized imports to avoid circular dependencies without re-hitting the module loader on
+// every cache miss, loading only the module the request needs. We cache the module *promises*, not
+// the resolved functions, and read each function off the live module object (`default` is the CJS
+// module.exports) on every call: a CJS module's named exports are snapshotted into the ESM namespace
+// at first import, so a cached function reference (or namespace binding) would honor a stale
+// implementation forever — e.g. a test double pinned past its restore.
+let crlModulePromise: Promise<any> | null = null;
+let ocspModulePromise: Promise<any> | null = null;
 
-// Lazy load to avoid circular dependencies
-async function loadVerificationFunctions() {
-	if (!performCRLCheck) {
-		const crlModule = await import('./crlVerification.js');
-		performCRLCheck = (crlModule as any).performCRLCheck;
-	}
-	if (!performOCSPCheck) {
-		const ocspModule = await import('./ocspVerification.js');
-		performOCSPCheck = (ocspModule as any).performOCSPCheck;
-	}
+async function loadVerificationFunctions(method?: string) {
+	const crlPromise = !method || method === 'crl' ? (crlModulePromise ??= import('./crlVerification.js')) : null;
+	const ocspPromise = !method || method === 'ocsp' ? (ocspModulePromise ??= import('./ocspVerification.js')) : null;
+	const [crlModule, ocspModule] = await Promise.all([crlPromise, ocspPromise]);
+	const crl = crlModule ? ((crlModule as any).default ?? crlModule) : null;
+	const ocsp = ocspModule ? ((ocspModule as any).default ?? ocspModule) : null;
+	return {
+		performCRLCheck: crl?.performCRLCheck,
+		performOCSPCheck: ocsp?.performOCSPCheck,
+	};
 }
 
 /**
@@ -51,7 +56,7 @@ export class CertificateVerificationSource extends Resource {
 		}
 
 		// Load verification functions
-		await loadVerificationFunctions();
+		const { performCRLCheck, performOCSPCheck } = await loadVerificationFunctions(method);
 
 		// Perform verification based on method
 		let result;

--- a/security/certificateVerification/crlVerification.ts
+++ b/security/certificateVerification/crlVerification.ts
@@ -2,10 +2,14 @@
  * CRL (Certificate Revocation List) verification
  */
 
+// Apply the PKI.js Ed25519/Ed448 patch before using PKI.js for CRL signature verification.
+// CRL must not depend on the OCSP module being loaded to get this patch (they load independently).
+import './pkijs-ed25519-patch.ts';
 import * as pkijs from 'pkijs';
 import { loggerWithTag } from '../../utility/logging/logger.ts';
 import { table } from '../../resources/databases.ts';
 import { Resource } from '../../resources/Resource.ts';
+import { RequestTarget } from '../../resources/RequestTarget.ts';
 import type { SourceContext } from '../../resources/ResourceInterface.ts';
 import {
 	extractCRLDistributionPoints,
@@ -20,6 +24,7 @@ import {
 import { ERROR_CACHE_TTL, CRL_DEFAULT_VALIDITY_PERIOD, CRL_USER_AGENT } from './verificationConfig.ts';
 import type {
 	CertificateVerificationResult,
+	CertificateVerificationContext,
 	CertificateCacheEntry,
 	CRLCheckResult,
 	CRLConfig,
@@ -230,13 +235,18 @@ export async function verifyCRL(
 		// Create a cache key that includes all verification parameters
 		const cacheKey = createCacheKey(certPemStr, issuerPemStr, 'crl');
 
-		// Pass certificate data as context - Harper will make it available as requestContext in the source
-		const cacheEntry = await (getCertificateCacheTable() as any).get(cacheKey, undefined, {
+		// Pass a RequestTarget as the id so Harper records the cache disposition on it
+		// (target.loadedFromSource); the cert data goes in the context arg, which the source
+		// reads as requestContext. Set target.id directly to avoid URL-parsing the cache key.
+		const target = new RequestTarget();
+		target.id = cacheKey;
+		const context: CertificateVerificationContext = {
 			certPem: certPemStr,
 			issuerPem: issuerPemStr,
 			distributionPoint: distributionPoints[0], // Use first distribution point for CRL fetch
 			config: { crl: config ?? {} },
-		} as any);
+		};
+		const cacheEntry = await (getCertificateCacheTable() as any).get(target, context);
 
 		if (!cacheEntry) {
 			// This should not happen if the source is configured correctly but handle it gracefully
@@ -250,13 +260,13 @@ export async function verifyCRL(
 		}
 
 		const cached = cacheEntry as unknown as CertificateCacheEntry;
-		const wasLoadedFromSource = (cacheEntry as any).wasLoadedFromSource?.();
-		logger.trace?.(`CRL ${wasLoadedFromSource ? 'source fetch' : 'cache hit'} for certificate`);
+		const loadedFromSource = target.loadedFromSource;
+		logger.trace?.(`CRL ${loadedFromSource ? 'source fetch' : 'cache hit'} for certificate`);
 
 		return {
 			valid: cached.status === 'good',
 			status: cached.status,
-			cached: !wasLoadedFromSource,
+			cached: !loadedFromSource,
 			method: cached.method || 'crl',
 		};
 	} catch (error) {

--- a/security/certificateVerification/ocspVerification.ts
+++ b/security/certificateVerification/ocspVerification.ts
@@ -6,6 +6,7 @@
 import './pkijs-ed25519-patch.ts';
 import { getCertStatus } from 'easy-ocsp';
 import { loggerWithTag } from '../../utility/logging/logger.ts';
+import { RequestTarget } from '../../resources/RequestTarget.ts';
 import {
 	bufferToPem,
 	createCacheKey,
@@ -64,14 +65,19 @@ export async function verifyOCSP(
 		const cacheKey = createCacheKey(certPemStr, issuerPemStr, 'ocsp');
 
 		// Get the cache table - Harper will automatically handle
-		// concurrent requests and cache stampede prevention
-		// Pass certificate data as context - Harper will make it available as requestContext in the source
-		const cacheEntry = await (getCertificateCacheTable() as any).get(cacheKey, {
+		// concurrent requests and cache stampede prevention.
+		// Pass a RequestTarget as the id so Harper records the cache disposition on it
+		// (target.loadedFromSource); the cert data goes in the context arg, which the source
+		// reads as requestContext. Set target.id directly to avoid URL-parsing the cache key.
+		const target = new RequestTarget();
+		target.id = cacheKey;
+		const context: CertificateVerificationContext = {
 			certPem: certPemStr,
 			issuerPem: issuerPemStr,
 			ocspUrls,
 			config: { ocsp: config ?? {} },
-		} as CertificateVerificationContext);
+		};
+		const cacheEntry = await (getCertificateCacheTable() as any).get(target, context);
 
 		if (!cacheEntry) {
 			// This should not happen if the source is configured correctly
@@ -85,13 +91,13 @@ export async function verifyOCSP(
 		}
 
 		const cached = cacheEntry as unknown as CertificateCacheEntry;
-		const wasLoadedFromSource = (cacheEntry as any).wasLoadedFromSource?.();
-		logger.trace?.(`OCSP ${wasLoadedFromSource ? 'source fetch' : 'cache hit'} for certificate`);
+		const loadedFromSource = target.loadedFromSource;
+		logger.trace?.(`OCSP ${loadedFromSource ? 'source fetch' : 'cache hit'} for certificate`);
 
 		return {
 			valid: cached.status === 'good',
 			status: cached.status,
-			cached: !wasLoadedFromSource,
+			cached: !loadedFromSource,
 			method: cached.method || 'ocsp',
 		};
 	} catch (error) {

--- a/unitTests/security/certificateVerification/crlVerification.test.js
+++ b/unitTests/security/certificateVerification/crlVerification.test.js
@@ -197,6 +197,32 @@ describe('certificateVerification/crlVerification.ts', function () {
 				assert.ok(typeof result.cached === 'boolean');
 			}
 		});
+
+		it('reports cached:false on a fresh source fetch and cached:true on a subsequent cached read', async function () {
+			// Stub the CRL check so the source resolves deterministically without any network.
+			// The source reads performCRLCheck off the live module, so this stub is honored.
+			sinon.stub(crlModule, 'performCRLCheck').resolves({ status: 'good' });
+
+			// Unique cert bytes keep the cache key fresh regardless of test ordering.
+			const unique = `disposition-${process.pid}-${Date.now()}`;
+			const cert = Buffer.from(`cert-${unique}`);
+			const issuer = Buffer.from(`issuer-${unique}`);
+			const config = {
+				enabled: true,
+				failureMode: 'fail-open',
+				timeout: 10000,
+				cacheTtl: 86400000,
+				gracePeriod: 86400000,
+			};
+			// Provide the distribution point explicitly so the get reaches the cache/source.
+			const crlUrls = [`http://crl.example.com/${unique}.crl`];
+
+			const first = await crlModule.verifyCRL(cert, issuer, config, crlUrls);
+			assert.strictEqual(first.cached, false, 'first get should load from source');
+
+			const second = await crlModule.verifyCRL(cert, issuer, config, crlUrls);
+			assert.strictEqual(second.cached, true, 'second get should be served from cache');
+		});
 	});
 
 	describe('CRL signature verification', function () {

--- a/unitTests/security/certificateVerification/ocspVerification.test.js
+++ b/unitTests/security/certificateVerification/ocspVerification.test.js
@@ -145,6 +145,28 @@ describe('certificateVerification/ocspVerification.ts', function () {
 			}
 		});
 
+		it('reports cached:false on a fresh source fetch and cached:true on a subsequent cached read', async function () {
+			// Use unique cert bytes so the cache key is fresh regardless of test ordering.
+			// Invalid certs resolve to status 'unknown' (ocsp-error) without any network, and the
+			// source still caches that result, so the second get is served from cache.
+			const unique = `disposition-${process.pid}-${Date.now()}`;
+			const cert = Buffer.from(`cert-${unique}`);
+			const issuer = Buffer.from(`issuer-${unique}`);
+			const config = {
+				enabled: true,
+				failureMode: 'fail-open',
+				timeout: 5000,
+				cacheTtl: 3600000,
+				errorCacheTtl: 300000,
+			};
+
+			const first = await ocspModule.verifyOCSP(cert, issuer, config);
+			assert.strictEqual(first.cached, false, 'first get should load from source');
+
+			const second = await ocspModule.verifyOCSP(cert, issuer, config);
+			assert.strictEqual(second.cached, true, 'second get should be served from cache');
+		});
+
 		it('should handle provided OCSP URLs', async function () {
 			const providedUrls = ['http://ocsp.example.com'];
 


### PR DESCRIPTION
## Summary

The OCSP and CRL certificate-verification paths reported the `cached` result field (and the trace log line) by calling `wasLoadedFromSource?.()` on the record returned by the caching table's `get()`. That value is a plain frozen record with no resource methods, so the call was always `undefined` and `cached` was hard-wired to `true` — every check logged/reported "cache hit" regardless of whether the certificate status was actually fetched from source. `wasLoadedFromSource()` was removed from the `Resource` base class in #1576, and the `Context.loadedFromSource` mirror is removed in #1590.

This observes cache disposition on the **RequestTarget** of the get, which #1590 makes the sole disposition signal.

## Changes

- **`ocspVerification.ts` / `crlVerification.ts`** — pass a `RequestTarget` as the get id and read `target.loadedFromSource` after the get. The target is built with the empty ctor + `target.id = cacheKey` to avoid URL-parsing cache keys that may contain `/` or `?`. Cert data still travels in the context (2nd) arg, which the source reads as `requestContext`, so the source fetch is unchanged. CRL is aligned to the same 2-arg `get(target, context)` convention as OCSP.
- **`certificateVerificationSource.ts`** — read `performCRLCheck`/`performOCSPCheck` off the live module object (`.default`) with memoized, per-method dynamic imports. See "Where to look".
- **`crlVerification.ts`** — import the PKI.js Ed25519/Ed448 patch directly (see "Where to look").
- Unit tests for both OCSP and CRL: `cached:false` on a fresh source fetch, `cached:true` on the subsequent cached read.

## Where to look

- **`loadAsInstance` mode (the subtle correctness point).** The cert cache table is left in the default **instance mode** (`loadAsInstance` is unset, i.e. `!== false`), not `loadAsInstance=false`. Verified empirically that `target.loadedFromSource` is set `true` on a miss / `false` on a hit anyway: `getResource` routes `loadAsInstance !== false` tables through `_loadRecord`, which calls `setLoadedFromSource(target, false)` on a cache hit and `setLoadedFromSource(target, true)` on a source fetch (via `getFromSource`). I did **not** set `loadAsInstance:false` — it isn't needed here.
- **`certificateVerificationSource.ts` — live `.default` read + memoized imports.** A CJS module's ESM-import namespace snapshots its named exports at first `import()`, so caching the resolved function reference would pin a stale implementation (e.g. a test double past its restore — which leaked across test files and broke the OCSP source before this). Reading off `.default` (live `module.exports`) each call fixes it; the memoized per-method import avoids re-hitting the module loader on cache misses.
- **`crlVerification.ts` — PKI.js Ed25519 patch import (from cross-model review).** CRL signature verification uses PKI.js but previously received the Ed25519/Ed448 patch only as a *side effect* of loading the OCSP module. With the per-method import above, a CRL-only path no longer loads OCSP, so the CRL module now imports the patch itself — otherwise Ed25519/Ed448 issuers would degrade to unknown/failure. Verified that loading only the CRL module applies the patch.

## Dependency / base

Stacked on **#1590** (`kris/loadedfromsource-target-only`), which makes `target.loadedFromSource` the sole cache-disposition signal and removes the `Context` mirror. Base is set to that branch; once #1590 lands on v5.1 this rebases onto v5.1. Both #1590 and this target **v5.1**, not main — needs a forward-port to main later.

## Notes

- OCSP and CRL keep their own small cache-read blocks rather than a shared helper (they differ in method/log-tag/config-shape). Deliberate.
- Cross-model review: **Codex** flagged the Ed25519 patch coupling (fixed here); **Gemini/agy** validated the approach — including that instance-mode is correct and `loadAsInstance:false` was unnecessary — with no blockers.

> Note: earlier revisions of this PR read `context.loadedFromSource`; it was reworked to `target.loadedFromSource` after the plan changed to #1590 (dropping the Context mirror). Force-pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: Claude Opus 4.8)