### PR TITLE
Audit records now attribute registered-operation writes to the authenticated user

### DIFF
--- a/server/serverHelpers/serverUtilities.ts
+++ b/server/serverHelpers/serverUtilities.ts
@@ -92,13 +92,17 @@ export async function processLocalTransaction(req: OperationRequest, operationFu
 	// (issue #1591). An explicit context passed by a handler still takes precedence (the
 	// transactional wrappers only fall back to contextStorage when no context is provided), and
 	// an existing ambient context already carrying this user (e.g. server.operation() called
-	// from within a request handler) is preserved rather than shadowed.
+	// from within a request handler) is preserved rather than shadowed. When the ambient user
+	// differs (or is absent), the ambient context is merged rather than replaced: other ambient
+	// properties (open transaction, signal, caches) are preserved so atomicity is unaffected and
+	// only the user is swapped for attribution; the outer context object itself is never mutated.
 	const hdbUser = req.body.hdb_user;
+	const currentStore = contextStorage.getStore();
 	const callOperationFunction = () =>
 		operationFunctionCaller.callOperationFunctionAsAwait(operationFunction, req.body, null);
 	let data =
-		hdbUser && contextStorage.getStore()?.user !== hdbUser
-			? await contextStorage.run({ user: hdbUser }, callOperationFunction)
+		hdbUser && currentStore?.user !== hdbUser
+			? await contextStorage.run({ ...currentStore, user: hdbUser }, callOperationFunction)
 			: await callOperationFunction();
 
 	if (typeof data !== 'object') {

--- a/server/serverHelpers/serverUtilities.ts
+++ b/server/serverHelpers/serverUtilities.ts
@@ -37,6 +37,7 @@ import type { Context } from '../../resources/ResourceInterface.ts';
 import * as status from '../status/index.ts';
 import * as regDeprecated from '../../resources/registrationDeprecated.ts';
 import * as deploymentOperations from '../../components/deploymentOperations.ts';
+import { contextStorage } from '../../resources/transaction.ts';
 
 const pSearchSearch = util.promisify(search.search);
 let pEvaluateSql: (sql: string) => Promise<any>;
@@ -86,7 +87,19 @@ export async function processLocalTransaction(req: OperationRequest, operationFu
 		operationLog.error(e);
 	}
 
-	let data = await operationFunctionCaller.callOperationFunctionAsAwait(operationFunction, req.body, null);
+	// Bridge the authenticated user into the ambient async context so static Resource API calls
+	// (e.g. table.put) inside operation handlers inherit user attribution for audit records
+	// (issue #1591). An explicit context passed by a handler still takes precedence (the
+	// transactional wrappers only fall back to contextStorage when no context is provided), and
+	// an existing ambient context already carrying this user (e.g. server.operation() called
+	// from within a request handler) is preserved rather than shadowed.
+	const hdbUser = req.body.hdb_user;
+	const callOperationFunction = () =>
+		operationFunctionCaller.callOperationFunctionAsAwait(operationFunction, req.body, null);
+	let data =
+		hdbUser && contextStorage.getStore()?.user !== hdbUser
+			? await contextStorage.run({ user: hdbUser }, callOperationFunction)
+			: await callOperationFunction();
 
 	if (typeof data !== 'object') {
 		data = { message: data };

--- a/unitTests/resources/operationContextUser.test.js
+++ b/unitTests/resources/operationContextUser.test.js
@@ -1,0 +1,58 @@
+const assert = require('assert');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const serverUtilities = require('#src/server/serverHelpers/serverUtilities');
+
+// Verifies the fix for issue #1591: writes performed by operation handlers through the static
+// Resource API without an explicit context must inherit user attribution from the operation
+// request (via the ambient context established in processLocalTransaction).
+describe('Operation ambient user context (audit attribution, issue #1591)', () => {
+	let OpAuditTable;
+
+	before(async function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		OpAuditTable = table({
+			table: 'OpAuditTable',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+		});
+	});
+
+	it('attributes a static put from an operation handler to the request user', async () => {
+		await serverUtilities.processLocalTransaction(
+			{ body: { operation: 'test_registered_op', hdb_user: { username: 'audit_user' } } },
+			async () => {
+				// simulates a registered operation handler using the static Resource API with no context
+				await OpAuditTable.put('op-write', { name: 'from-op' });
+				return { message: 'ok' };
+			}
+		);
+		const history = await OpAuditTable.getHistoryOfRecord('op-write');
+		assert.equal(history.length, 1);
+		assert.equal(history[0].user, 'audit_user');
+	});
+
+	it('an explicit context passed by the handler still wins over the ambient user', async () => {
+		await serverUtilities.processLocalTransaction(
+			{ body: { operation: 'test_registered_op', hdb_user: { username: 'ambient_user' } } },
+			async () => {
+				await OpAuditTable.put('explicit-write', { name: 'explicit' }, { user: { username: 'explicit_user' } });
+				return { message: 'ok' };
+			}
+		);
+		const history = await OpAuditTable.getHistoryOfRecord('explicit-write');
+		assert.equal(history.length, 1);
+		assert.equal(history[0].user, 'explicit_user');
+	});
+
+	it('leaves writes unattributed when the request carries no hdb_user', async () => {
+		await serverUtilities.processLocalTransaction({ body: { operation: 'test_registered_op' } }, async () => {
+			await OpAuditTable.put('no-user-write', { name: 'no-user' });
+			return { message: 'ok' };
+		});
+		const history = await OpAuditTable.getHistoryOfRecord('no-user-write');
+		assert.equal(history.length, 1);
+		assert.equal(history[0].user, undefined);
+	});
+});

--- a/unitTests/server/serverHelpers/serverUtilities.test.js
+++ b/unitTests/server/serverHelpers/serverUtilities.test.js
@@ -501,5 +501,44 @@ describe('Test serverUtilities.js module ', () => {
 			);
 			assert.equal(observedStore, outerContext);
 		});
+
+		it('Should re-wrap with a fresh minimal context when the request user differs from the ambient user', async function () {
+			// An explicitly different hdb_user must never silently ride the outer user's
+			// attribution or transaction. The fresh { user } store carries no `transaction`
+			// property, which is the mechanism that detaches the handler's writes from the
+			// outer transaction (the transactional wrappers only join context.transaction).
+			op_func_caller_stub.callThrough();
+			const userX = { username: 'outer_user' };
+			const userY = { username: 'request_user' };
+			const outerContext = { user: userX, transaction: { open: true }, someRequestState: true };
+			let observedStore;
+			await contextStorage.run(outerContext, () =>
+				serverUtilities.processLocalTransaction(
+					{ body: { operation: 'create_schema', schema: 'test', hdb_user: userY } },
+					async () => {
+						observedStore = contextStorage.getStore();
+						return test_func_data;
+					}
+				)
+			);
+			assert.notEqual(observedStore, outerContext);
+			assert.equal(observedStore.user, userY);
+			assert.deepStrictEqual(Object.keys(observedStore), ['user']);
+			assert.ok(!('transaction' in observedStore), 'outer transaction must not carry into the re-wrapped context');
+		});
+
+		it('Should not establish an ambient context when hdb_user is null', async function () {
+			// serverHandlers.js sets req.body.hdb_user = null on the unauthenticated-allowed path
+			op_func_caller_stub.callThrough();
+			let observedStore;
+			await serverUtilities.processLocalTransaction(
+				{ body: { operation: 'create_schema', schema: 'test', hdb_user: null } },
+				async () => {
+					observedStore = contextStorage.getStore();
+					return test_func_data;
+				}
+			);
+			assert.equal(observedStore, undefined);
+		});
 	});
 });

--- a/unitTests/server/serverHelpers/serverUtilities.test.js
+++ b/unitTests/server/serverHelpers/serverUtilities.test.js
@@ -502,15 +502,16 @@ describe('Test serverUtilities.js module ', () => {
 			assert.equal(observedStore, outerContext);
 		});
 
-		it('Should re-wrap with a fresh minimal context when the request user differs from the ambient user', async function () {
+		it('Should merge ambient context, swapping only the user, when the request user differs', async function () {
 			// An explicitly different hdb_user must never silently ride the outer user's
-			// attribution or transaction. The fresh { user } store carries no `transaction`
-			// property, which is the mechanism that detaches the handler's writes from the
-			// outer transaction (the transactional wrappers only join context.transaction).
+			// attribution, but the rest of the ambient context (open transaction, request
+			// state) is preserved so atomicity is unaffected. The outer context object
+			// itself must not be mutated.
 			op_func_caller_stub.callThrough();
 			const userX = { username: 'outer_user' };
 			const userY = { username: 'request_user' };
-			const outerContext = { user: userX, transaction: { open: true }, someRequestState: true };
+			const outerTransaction = { open: true };
+			const outerContext = { user: userX, transaction: outerTransaction, someRequestState: true };
 			let observedStore;
 			await contextStorage.run(outerContext, () =>
 				serverUtilities.processLocalTransaction(
@@ -523,8 +524,30 @@ describe('Test serverUtilities.js module ', () => {
 			);
 			assert.notEqual(observedStore, outerContext);
 			assert.equal(observedStore.user, userY);
-			assert.deepStrictEqual(Object.keys(observedStore), ['user']);
-			assert.ok(!('transaction' in observedStore), 'outer transaction must not carry into the re-wrapped context');
+			assert.equal(observedStore.transaction, outerTransaction, 'outer transaction must be preserved');
+			assert.equal(observedStore.someRequestState, true, 'other request state must be preserved');
+			assert.equal(outerContext.user, userX, 'outer context object must not be mutated');
+		});
+
+		it('Should merge the user into a userless ambient context, preserving its transaction', async function () {
+			op_func_caller_stub.callThrough();
+			const hdbUser = { username: 'request_user' };
+			const outerTransaction = { open: true };
+			const outerContext = { transaction: outerTransaction };
+			let observedStore;
+			await contextStorage.run(outerContext, () =>
+				serverUtilities.processLocalTransaction(
+					{ body: { operation: 'create_schema', schema: 'test', hdb_user: hdbUser } },
+					async () => {
+						observedStore = contextStorage.getStore();
+						return test_func_data;
+					}
+				)
+			);
+			assert.notEqual(observedStore, outerContext);
+			assert.equal(observedStore.user, hdbUser);
+			assert.equal(observedStore.transaction, outerTransaction, 'outer transaction must be preserved');
+			assert.equal(outerContext.user, undefined, 'outer context object must not be mutated');
 		});
 
 		it('Should not establish an ambient context when hdb_user is null', async function () {

--- a/unitTests/server/serverHelpers/serverUtilities.test.js
+++ b/unitTests/server/serverHelpers/serverUtilities.test.js
@@ -10,6 +10,7 @@ const { TEST_JSON_SUPER_USER, TEST_JSON_NON_SU } = require('../../test_data');
 const serverUtilities = require('#src/server/serverHelpers/serverUtilities');
 const operation_function_caller = require('#src/utility/OperationFunctionCaller');
 const logger = require('#src/utility/logging/harper_logger');
+const { contextStorage } = require('#src/resources/transaction');
 
 const test_func_data = { data: 'this is data', more_data: 'this is more data' };
 const test_error = 'This is bad!';
@@ -455,6 +456,50 @@ describe('Test serverUtilities.js module ', () => {
 				assert.equal(loggedBody.operation, 'create_schema', 'operation should be preserved');
 				assert.equal(loggedBody.schema, 'test', 'schema should be preserved');
 			}
+		});
+
+		it('Should run the operation function with an ambient context carrying hdb_user', async function () {
+			op_func_caller_stub.callThrough();
+			const hdbUser = { username: 'ambient_user' };
+			let observedStore;
+			await serverUtilities.processLocalTransaction(
+				{ body: { operation: 'create_schema', schema: 'test', hdb_user: hdbUser } },
+				async () => {
+					observedStore = contextStorage.getStore();
+					return test_func_data;
+				}
+			);
+			assert.equal(observedStore?.user, hdbUser);
+		});
+
+		it('Should not establish an ambient context when hdb_user is absent', async function () {
+			op_func_caller_stub.callThrough();
+			let observedStore;
+			await serverUtilities.processLocalTransaction(
+				{ body: { operation: 'create_schema', schema: 'test' } },
+				async () => {
+					observedStore = contextStorage.getStore();
+					return test_func_data;
+				}
+			);
+			assert.equal(observedStore, undefined);
+		});
+
+		it('Should preserve an existing ambient context for the same user', async function () {
+			op_func_caller_stub.callThrough();
+			const hdbUser = { username: 'ambient_user' };
+			const outerContext = { user: hdbUser, someRequestState: true };
+			let observedStore;
+			await contextStorage.run(outerContext, () =>
+				serverUtilities.processLocalTransaction(
+					{ body: { operation: 'create_schema', schema: 'test', hdb_user: hdbUser } },
+					async () => {
+						observedStore = contextStorage.getStore();
+						return test_func_data;
+					}
+				)
+			);
+			assert.equal(observedStore, outerContext);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Operation handlers that write via the static Resource API without an explicit context (`table.put(id, record)` etc.) produced audit records with `user: undefined`, because nothing bridged the authenticated `req.body.hdb_user` into the ambient AsyncLocalStorage context the transactional wrappers fall back to. This affected `registerOperation`-based (component-registered) operations; built-in CRUD was unaffected (ResourceBridge builds explicit contexts).

Fix at the dispatch layer (invariant, not per-handler): `processLocalTransaction` now runs the operation function inside a user-bearing ambient context. Closes #1591 (full root-cause chain there).

## Semantics (where to look)

The small change in `serverUtilities.ts` has four deliberate behaviors, each pinned by a regression test:

- **Explicit contexts still win** — the transactional wrappers only consult `contextStorage` when no context argument is passed.
- **Same-user ambient context is preserved untouched** — `server.operation()` called from inside a component request handler keeps the exact request context object (open transaction, response), avoiding any semantics change on that embedded path (`currentStore?.user !== hdbUser`, object identity — the embedded path passes the same `hdb_user` reference).
- **Different-user (or user-over-userless) contexts merge** — the wrap spreads the current ambient context and swaps only the user (`{ ...currentStore, user: hdbUser }`): the ambient transaction, signal, and caches are preserved (atomicity intact), while attribution — which is captured per-write — follows the new user. The outer context object is never mutated. (This was replace-not-merge in the first revision; gemini-code-assist's review correctly flagged that replacing discards an ambient transaction, breaking atomicity for nested dispatch — adopted in `050e70c9c`.)
- **No `hdb_user` → no wrap** — both absent and the explicit `hdb_user: null` set by the unauthenticated-allowed path; internal `bypass_auth` dispatch and legacy-clustering `catchup` are unchanged (catchup writes attribute explicitly through the dataLayer anyway).

All `contextStorage.getStore()` consumers in core were audited for dependence on an empty ambient context during op execution; none found (details in #1591). Behavioral note: *overlapping* no-context writes within one handler (e.g. `Promise.all`) now share one ambient context and can join one transaction — same machinery and semantics as the REST per-request path; sequential writes still get separate transactions.

Known residual (pre-existing, out of scope): `jobProcess.ts` invokes built-in job ops bare; registered ops cannot dispatch via the job process today, but if that's ever added it needs the same wrap.

## Tests

- `unitTests/server/serverHelpers/serverUtilities.test.js` — the ambient-context seam, all quadrants: wraps with `hdb_user`; no wrap when absent; no wrap when explicitly `null`; same-user ambient preserved (exact object); different-user merge (transaction identity + request state preserved, user swapped, outer object unmutated); userless-ambient merge (transaction preserved, user added).
- `unitTests/resources/operationContextUser.test.js` (new) — end-to-end: static put inside an op is attributed in the audit record; explicit context wins; unattributed without `hdb_user`.
- Adjacent suites green locally (`auditLog`, `transaction`, MCP `operations`); full unit suites left to CI.

No docs changes needed: bug fix to existing audit behavior, no new API/config surface.

## Review

Generated by an LLM (Claude — Fable 5), reviewed by Kris. Cross-model review complete (thorough: Codex leg + Gemini leg + Harper-domain adjudication): no blockers in the adjudicated pass; gemini-code-assist's PR review then correctly identified that the first revision's different-user path replaced rather than merged the ambient context — adopted (see Semantics above; threads resolved with rationale). Remaining suggestions were applied (`hdb_user: null` contract test, merge-preservation tests) or rejected with rationale (optional chaining on `req.body` — unreachable; ALS-overhead concern — ops dispatch is not the nanosecond-hot path and `transaction()` already runs `contextStorage.run` per write).

🤖 Generated with [Claude Code](https://claude.com/claude-code)