### PR TITLE
fix(test): de-flake MQTT durable-session reconnect test

### DIFF
--- a/server/DurableSubscriptionsSession.ts
+++ b/server/DurableSubscriptionsSession.ts
@@ -480,8 +480,8 @@ export class DurableSubscriptionsSession extends SubscriptionsSession {
 							}
 							subscription.acks.push(update.timestamp);
 							trace('Received ack', topic, update.timestamp);
-							getDurableSession().put(this.sessionRecord, { source: true }); // add source: true context to bypass any overloaded checks, as skipping this can lead to increased load
-							return;
+							// add source: true context to bypass any overloaded checks, as skipping this can lead to increased load
+							return getDurableSession().put(this.sessionRecord, { source: true });
 						}
 					}
 				}
@@ -493,7 +493,7 @@ export class DurableSubscriptionsSession extends SubscriptionsSession {
 				subscription.startTime = update.timestamp;
 			}
 		}
-		getDurableSession().put(this.sessionRecord, { source: true });
+		return getDurableSession().put(this.sessionRecord, { source: true });
 		// TODO: Increment the timestamp for the corresponding subscription, possibly recording any interim unacked messages
 	}
 

--- a/server/mqtt.ts
+++ b/server/mqtt.ts
@@ -463,7 +463,8 @@ function onSocket(socket, send, request, user, mqttSettings) {
 					break;
 				case 'pubcomp':
 				case 'puback':
-					session.acknowledge(packet.messageId);
+					await session.acknowledge(packet.messageId);
+					emitEvent('acknowledged', session, packet);
 					break;
 				case 'pingreq':
 					sendPacket({ cmd: 'pingresp' });

--- a/unitTests/apiTests/mqtt-test.mjs
+++ b/unitTests/apiTests/mqtt-test.mjs
@@ -61,36 +61,27 @@ async function connectWithMessageListener(brokerUrl, options, listener) {
 	return client;
 }
 
-// Waits for the server to actually finish processing a client's disconnect (session/subscription
-// teardown) rather than guessing with a fixed delay. `client.endAsync()` only resolves once the
-// local socket is closed and does not wait for the broker to process the disconnect, so callers
-// that immediately reconnect with the same clientId can otherwise race the broker's teardown.
-async function endDurableSession(client, clientId) {
-	const torn_down = new Promise((resolve) => {
-		function onDisconnected(session) {
+// Waits for a server-side MQTT session event (see `server/mqtt.ts` `emitEvent`) for a specific
+// clientId, rather than guessing with a fixed delay for the broker to finish some async step.
+function waitForMqttSessionEvent(eventName, clientId) {
+	return new Promise((resolve) => {
+		function onEvent(session) {
 			if (session?.sessionId === clientId) {
-				global.server.mqtt.events.off('disconnected', onDisconnected);
+				global.server.mqtt.events.off(eventName, onEvent);
 				resolve();
 			}
 		}
-		global.server.mqtt.events.on('disconnected', onDisconnected);
+		global.server.mqtt.events.on(eventName, onEvent);
 	});
-	await client.endAsync();
-	await torn_down;
 }
 
-// Waits for the client to actually send the PUBACK for a QoS 1 message it just received, rather
-// than guessing with a fixed delay before disconnecting.
-function waitForPuback(client) {
-	return new Promise((resolve) => {
-		function onPacketSend(packet) {
-			if (packet.cmd === 'puback') {
-				client.off('packetsend', onPacketSend);
-				resolve();
-			}
-		}
-		client.on('packetsend', onPacketSend);
-	});
+// `client.endAsync()` only resolves once the local socket is closed — it does not wait for the
+// broker to process the disconnect and tear down the session — so callers that immediately
+// reconnect with the same clientId can otherwise race the broker's teardown.
+async function endDurableSession(client, clientId) {
+	const torn_down = waitForMqttSessionEvent('disconnected', clientId);
+	await client.endAsync();
+	await torn_down;
 }
 
 describe('test MQTT connections and commands', function () {
@@ -885,10 +876,12 @@ describe('test MQTT connections and commands', function () {
 			protocolVersion: 4,
 		});
 		await new Promise((resolve) => {
-			const acked = waitForPuback(client);
+			// Wait for the broker to finish processing (and durably persisting) our ack of this
+			// message, not just for the client to have sent it — see `session.acknowledge()`.
+			const acknowledged = waitForMqttSessionEvent('acknowledged', 'test-client1');
 			client.on('message', (topic, payload) => {
 				JSON.parse(payload);
-				resolve(acked);
+				resolve(acknowledged);
 			});
 
 			client.publish(

--- a/unitTests/apiTests/mqtt-test.mjs
+++ b/unitTests/apiTests/mqtt-test.mjs
@@ -79,9 +79,21 @@ function waitForMqttSessionEvent(eventName, clientId) {
 // broker to process the disconnect and tear down the session — so callers that immediately
 // reconnect with the same clientId can otherwise race the broker's teardown.
 async function endDurableSession(client, clientId) {
-	const torn_down = waitForMqttSessionEvent('disconnected', clientId);
-	await client.endAsync();
-	await torn_down;
+	let onDisconnected;
+	const torn_down = new Promise((resolve) => {
+		onDisconnected = (session) => {
+			if (session?.sessionId === clientId) resolve();
+		};
+		global.server.mqtt.events.on('disconnected', onDisconnected);
+	});
+	try {
+		await client.endAsync();
+		await torn_down;
+	} finally {
+		// Always clean up the listener, even if endAsync() rejects or the event never fires,
+		// so a failed disconnect doesn't leak a listener on the shared event emitter.
+		global.server.mqtt.events.off('disconnected', onDisconnected);
+	}
 }
 
 describe('test MQTT connections and commands', function () {

--- a/unitTests/apiTests/mqtt-test.mjs
+++ b/unitTests/apiTests/mqtt-test.mjs
@@ -61,6 +61,38 @@ async function connectWithMessageListener(brokerUrl, options, listener) {
 	return client;
 }
 
+// Waits for the server to actually finish processing a client's disconnect (session/subscription
+// teardown) rather than guessing with a fixed delay. `client.endAsync()` only resolves once the
+// local socket is closed and does not wait for the broker to process the disconnect, so callers
+// that immediately reconnect with the same clientId can otherwise race the broker's teardown.
+async function endDurableSession(client, clientId) {
+	const torn_down = new Promise((resolve) => {
+		function onDisconnected(session) {
+			if (session?.sessionId === clientId) {
+				global.server.mqtt.events.off('disconnected', onDisconnected);
+				resolve();
+			}
+		}
+		global.server.mqtt.events.on('disconnected', onDisconnected);
+	});
+	await client.endAsync();
+	await torn_down;
+}
+
+// Waits for the client to actually send the PUBACK for a QoS 1 message it just received, rather
+// than guessing with a fixed delay before disconnecting.
+function waitForPuback(client) {
+	return new Promise((resolve) => {
+		function onPacketSend(packet) {
+			if (packet.cmd === 'puback') {
+				client.off('packetsend', onPacketSend);
+				resolve();
+			}
+		}
+		client.on('packetsend', onPacketSend);
+	});
+}
+
 describe('test MQTT connections and commands', function () {
 	this.timeout(10000);
 	let available_records;
@@ -839,25 +871,24 @@ describe('test MQTT connections and commands', function () {
 			clientId: 'test-client1',
 			protocolVersion: 4,
 		});
-		await client.endAsync();
-		await delay(10);
+		await endDurableSession(client, 'test-client1');
 		client = await connectAsync(mqttUrl, {
 			clean: false,
 			clientId: 'test-client1',
 			protocolVersion: 4,
 		});
 		await client.subscribeAsync(['SimpleRecord/41', 'SimpleRecord/42'], { qos: 1 });
-		await client.endAsync();
-		await delay(10);
+		await endDurableSession(client, 'test-client1');
 		client = await connectAsync(mqttUrl, {
 			clean: false,
 			clientId: 'test-client1',
 			protocolVersion: 4,
 		});
 		await new Promise((resolve) => {
+			const acked = waitForPuback(client);
 			client.on('message', (topic, payload) => {
 				JSON.parse(payload);
-				resolve();
+				resolve(acked);
 			});
 
 			client.publish(
@@ -870,10 +901,8 @@ describe('test MQTT connections and commands', function () {
 				}
 			);
 		});
-		await delay(10);
-		await client.endAsync();
-		await delay(50);
-		clientV5.publish(
+		await endDurableSession(client, 'test-client1');
+		await clientV5.publishAsync(
 			'SimpleRecord/41',
 			JSON.stringify({
 				name: 'This is a test of publishing to a disconnected durable session',
@@ -900,7 +929,6 @@ describe('test MQTT connections and commands', function () {
 				qos: 1,
 			}
 		);
-		await delay(10);
 		let messages = [];
 		client = await connectWithMessageListener(
 			mqttUrl,


### PR DESCRIPTION
## Summary
- `subscribe with QoS=1 and reconnect with non-clean session` (`unitTests/apiTests/mqtt-test.mjs`) sequenced connect/disconnect/publish steps using hard-coded `delay(10)`/`delay(50)` calls instead of waiting for the actual server-side state to settle.
- Replaced each disconnect-then-reconnect delay with a wait on the broker's own `disconnected` event (`server.mqtt.events`, already used by another test in this file) for the matching clientId — `client.endAsync()` only resolves once the local socket closes, it does not wait for the broker to finish tearing down the durable session.
- Fixed the first of three "publish while disconnected" calls, which was fire-and-forget (`clientV5.publish(...)`) while the other two were awaited (`clientV5.publishAsync(...)`) — now all three are awaited so they're durably committed before the reconnecting client asserts on redelivery.
- **Production fix surfaced during review:** `DurableSubscriptionsSession.acknowledge()` (`server/DurableSubscriptionsSession.ts`) persisted the updated durable-session `startTime` via a fire-and-forget `getDurableSession().put(...)`, and `server/mqtt.ts`'s puback/pubcomp handler didn't await `session.acknowledge()` at all. This is a real gap, not just a test-timing issue: a client disconnecting immediately after acking a QoS≥1 message could have that message redelivered again on the next durable-session resume, since the persisted cursor might not have advanced yet. Now `acknowledge()` returns the persistence promise, mqtt.ts awaits it and emits a new `acknowledged` event (mirroring the existing `disconnected` event) so the test can wait on the real completion signal instead of a client-side proxy (the client's own PUBACK send).

## Purpose
This test flaked twice recently on unrelated PRs (#410, #1476): once with its own internal "Expected 3 queued messages ... got 0" timeout, once with a generic mocha "Timeout of 10000ms exceeded" for the file. Issue #1138 had already flagged this file as the #2-worst offender for delay-based waits (26 of them) and recommended poll-until-condition instead of guessed durations; this test's `this.timeout(20000)` override and internal 15s reject were themselves an earlier band-aid (PR from commit 211415356) for the same underlying race rather than a fix. PR #533 touched a different test in this file (a PUT/PATCH ordering race) and never addressed this one.

Root cause: `client.endAsync()` sends the MQTT DISCONNECT packet and closes the local socket without waiting for the broker to process it. The test immediately reconnects with the same clientId, so under load the new CONNECT could race the broker's still-in-flight session teardown from the previous connection. A related, previously-latent race in `acknowledge()`'s ack-persistence (see above) could independently cause a stale/duplicate redelivery.

## Where to look
- The new `waitForMqttSessionEvent()`/`endDurableSession()` helpers at the top of `unitTests/apiTests/mqtt-test.mjs` are the only new test abstractions; everything else is the existing test body with `delay(N)` calls swapped for these waits.
- The `server/mqtt.ts` / `server/DurableSubscriptionsSession.ts` change is a small, targeted production fix (not just test scaffolding) — worth a close look since it changes when the 'puback'/'pubcomp' handler resolves. The base (non-durable) `SubscriptionsSession.acknowledge()` doesn't return a promise, so `await session.acknowledge(...)` on it is `await undefined` — a safe no-op, confirmed non-blocking for clean/non-durable sessions.
- I was unable to get a clean full local run of `unitTests/apiTests/mqtt-test.mjs` to verify end-to-end: 6 of ~25 tests in this file (including this one) fail locally with `AccessViolation: Unauthorized access to resource` on a **clean, unmodified `origin/main`** checkout too — this is a pre-existing, unrelated environment issue (every test after the first one in the `describe` block fails the same way, with or without this diff — confirmed identical 19-pass/6-fail counts). I've filed this separately (not in scope here). CI should be relied on to confirm this specific fix, since it isn't reproducible for me locally right now for an unrelated reason.

Generated by Claude (Sonnet 5).