### PR TITLE
fix(serialization): surface @computed scalars on default reads + guard cyclic @enumerable serialization (#1484)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -8,8 +8,9 @@ Design notes and non-obvious internals for the harper-pro/core codebase. Complem
 
 Records stored in tables are plain objects given a `RecordObject` prototype, which provides `getExpiresAt()` and `getUpdatedTime()`. These methods read from `entryMap` (a `WeakMap` in `RecordEncoder.ts`), which maps each record object to its storage entry.
 
-- The prototype is set automatically by the msgpack decoder via `structPrototype` (per-table, defined inside `RecordEncoder`).
-- `entryMap.set(record, entry)` is called whenever a record is read from the store.
+- `RecordObject` is a shared runtime base class; every encoder creates an isolated `StoreRecordObject` subclass for its `structPrototype`, so table-specific computed getters do not leak across tables. Structon records inherit that prototype during decode. Classic msgpackr records decode as plain objects and are promoted by the store read wrappers before Harper exposes them.
+- Use `record instanceof RecordObject` when behavior must apply to either exposed representation. Do not use `entryMap.has(record)` as a record-type test: `entryMap` exists for storage metadata, and some range-read paths can prototype-promote a record without registering that mapping.
+- Point reads and other paths that need storage metadata call `entryMap.set(record, entry)` when exposing a record.
 - To give a plain JS object the RecordObject prototype without copying it (preserving mutability), use `Object.setPrototypeOf(obj, primaryStore.encoder.structPrototype)` then `entryMap.set(obj, entry)`.
 - Do **not** copy the object (e.g. via `Object.assign` into a new instance) if any code still holds a reference to the original and expects to mutate it — see below.
 

--- a/integrationTests/resources/computed-and-cyclic-serialization.test.ts
+++ b/integrationTests/resources/computed-and-cyclic-serialization.test.ts
@@ -1,0 +1,175 @@
+/**
+ * harper#1484 — computed-scalar default surfacing (Fix A) + cyclic-enumerable serialization guard (Fix B).
+ *
+ *  Fix A: REST GET with no explicit select must include @computed *scalar* attributes (their getters are
+ *         non-enumerable, so JSON.stringify used to silently drop them). Table-typed computeds/relationships
+ *         stay lazy by default.
+ *  Fix B: @enumerable relationships that form a cycle (Author<->Book, and the Category self-loop) must
+ *         serialize as { <primaryKey> } reference stubs rather than overflowing the stack / 500ing.
+ *
+ * Reproduction:
+ *   npm run test:integration -- "integrationTests/resources/computed-and-cyclic-serialization.test.ts"
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual, deepStrictEqual } from 'node:assert';
+import { resolve } from 'node:path';
+import { encode as encodeCbor, decode as decodeCbor } from 'cbor-x';
+import { unpack } from 'msgpackr';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
+import { createApiClient } from '../apiTests/utils/client.mjs';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'computed-and-cyclic-serialization');
+const skipSuite = process.platform === 'win32';
+const ENGINE = process.env.HARPER_STORAGE_ENGINE || 'rocksdb(default)';
+const NATIVE_DATE = new Date('1843-01-01T00:00:00.000Z');
+const NATIVE_BYTES = Buffer.from([0, 1, 127, 128, 255]);
+
+suite(
+	`harper#1484 computed + cyclic serialization [engine=${ENGINE}]`,
+	{ skip: skipSuite },
+	(ctx: ContextWithHarper) => {
+		let httpURL: string;
+		let auth: string;
+		let client: ReturnType<typeof createApiClient>;
+
+		async function rest(method: string, path: string, body?: unknown): Promise<{ status: number; body: any }> {
+			const r = await fetch(`${httpURL}${path}`, {
+				method,
+				headers: { 'Content-Type': 'application/json', 'Authorization': auth },
+				body: body == null ? undefined : JSON.stringify(body),
+			});
+			let parsed: any = null;
+			try {
+				parsed = await r.json();
+			} catch {
+				/* ignore */
+			}
+			return { status: r.status, body: parsed };
+		}
+
+		async function putCbor(path: string, body: unknown): Promise<number> {
+			const response = await fetch(`${httpURL}${path}`, {
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/cbor', 'Authorization': auth },
+				// @ts-expect-error Node's fetch BodyInit type does not accept Buffer<ArrayBufferLike>.
+				body: encodeCbor(body),
+			});
+			return response.status;
+		}
+
+		async function getEncoded(path: string, mediaType: 'application/cbor' | 'application/x-msgpack') {
+			const response = await fetch(`${httpURL}${path}`, {
+				headers: { Accept: mediaType, Authorization: auth },
+			});
+			const encoded = Buffer.from(await response.arrayBuffer());
+			return {
+				status: response.status,
+				body: mediaType === 'application/cbor' ? decodeCbor(encoded) : unpack(encoded),
+			};
+		}
+
+		function assertNativeValues(body: any, tableName: string, mediaType: string) {
+			strictEqual(body?.displayName, tableName, `${mediaType} must include the computed field`);
+			ok(body?.details?.createdAt instanceof Date, `${mediaType} must preserve Date as a native timestamp`);
+			ok(ArrayBuffer.isView(body?.details?.bytes), `${mediaType} must preserve Bytes as a binary view`);
+			deepStrictEqual(
+				Array.from(body.details.bytes),
+				Array.from(NATIVE_BYTES),
+				`${mediaType} must preserve the original bytes`
+			);
+		}
+
+		before(async () => {
+			await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: {}, env: {} });
+			client = createApiClient(ctx.harper);
+			httpURL = ctx.harper.httpURL;
+			auth = client.headers.Authorization;
+
+			await rest('PUT', '/Author/1', { id: '1', name: 'Ada' });
+			await rest('PUT', '/Book/10', { id: '10', authorId: '1', title: 'Analytical Engine' });
+			// Category self-loop: 1 -> 2 -> 1
+			await rest('PUT', '/Category/1', { id: '1', name: 'root', parentId: '2' });
+			await rest('PUT', '/Category/2', { id: '2', name: 'child', parentId: '1' });
+			// Node link cycle via an unconstrained (`Any`) @computed resolver: A -> B -> A
+			await rest('PUT', '/Node/A', { id: 'A', linkId: 'B' });
+			await rest('PUT', '/Node/B', { id: 'B', linkId: 'A' });
+			// Ref link cycle via a *typed-scalar* (`String`) @computed resolver that returns a live entity: X -> Y -> X
+			await rest('PUT', '/Ref/X', { id: 'X', linkId: 'Y' });
+			await rest('PUT', '/Ref/Y', { id: 'Y', linkId: 'X' });
+			for (const tableName of ['NativeValues', 'NativeStructValues']) {
+				strictEqual(
+					await putCbor(`/${tableName}/1`, {
+						id: '1',
+						name: tableName,
+						details: { createdAt: NATIVE_DATE, bytes: NATIVE_BYTES },
+					}),
+					204
+				);
+			}
+		});
+
+		after(async () => {
+			await teardownHarper(ctx);
+		});
+
+		// ---- Fix A: computed scalar on the default read path ----
+
+		test('A1: default GET includes @computed scalar (displayName)', async () => {
+			const { status, body } = await rest('GET', '/Author/1');
+			strictEqual(status, 200);
+			strictEqual(body?.name, 'Ada');
+			strictEqual(body?.displayName, 'Ada', 'computed scalar must be surfaced without an explicit select');
+		});
+
+		// ---- Fix B: cyclic @enumerable serialization does not overflow ----
+
+		test('B1: mutual enumerable cycle (Author<->Book) serializes with a reference stub', async () => {
+			const { status, body } = await rest('GET', '/Author/1');
+			strictEqual(status, 200, 'must not 500/overflow on a cyclic-enumerable read');
+			// Author.books is enumerable -> each Book.author is enumerable -> back to this Author = cycle.
+			const book = Array.isArray(body?.books) ? body.books[0] : undefined;
+			ok(book, 'enumerable books should be present in serialization');
+			deepStrictEqual(book?.author, { id: '1' }, 'cyclic back-edge collapses to a { id } reference stub');
+		});
+
+		test('B2: self-referential tree (Category.parent) does not overflow', async () => {
+			const { status, body } = await rest('GET', '/Category/1');
+			strictEqual(status, 200, 'self-loop must not overflow');
+			strictEqual(body?.parent?.id, '2');
+			deepStrictEqual(body?.parent?.parent, { id: '1' }, 'tree cycle collapses to a reference stub');
+		});
+
+		test('B3: unconstrained @computed returning a live entity cycle does not overflow', async () => {
+			const { status, body } = await rest('GET', '/Node/A');
+			strictEqual(status, 200, 'untyped-computed runtime cycle must not overflow (guarded, not fast path)');
+			strictEqual(body?.linked?.id, 'B', 'the computed live entity is surfaced');
+			deepStrictEqual(body?.linked?.linked, { id: 'A' }, 'runtime cycle collapses to a reference stub');
+		});
+
+		test('B4: typed-scalar @computed returning a live entity cycle does not overflow (guarded path)', async () => {
+			// Regression for the review follow-up: a `String`-typed @computed whose resolver returns a live
+			// struct took the raw fast path before the fix (only `Any`/untyped computeds were guarded) and
+			// overflowed. It must now route through the guarded path regardless of the declared type.
+			const { status, body } = await rest('GET', '/Ref/X');
+			strictEqual(status, 200, 'a typed-scalar computed returning a live struct must be guarded, not fast-path');
+			strictEqual(body?.linked?.id, 'Y', 'the computed live entity is surfaced');
+			deepStrictEqual(body?.linked?.linked, { id: 'X' }, 'runtime cycle collapses to a reference stub');
+		});
+
+		// ---- Fix C: guarded traversal preserves native values for binary encoders ----
+
+		for (const [label, mediaType] of [
+			['CBOR', 'application/cbor'],
+			['MessagePack', 'application/x-msgpack'],
+		] as const) {
+			test(`C: ${label} preserves nested Date/Bytes for msgpackr and structon records`, async () => {
+				for (const tableName of ['NativeValues', 'NativeStructValues']) {
+					const { status, body } = await getEncoded(`/${tableName}/1`, mediaType);
+					strictEqual(status, 200);
+					assertNativeValues(body, tableName, mediaType);
+				}
+			});
+		}
+	}
+);

--- a/integrationTests/resources/computed-and-cyclic-serialization/resources.js
+++ b/integrationTests/resources/computed-and-cyclic-serialization/resources.js
@@ -1,0 +1,16 @@
+// harper#1484 — resolver for the unconstrained (`Any`) @computed `Node.linked`, which returns a LIVE
+// entity (another Node). The static cycle detector can't see this edge, so the table must fall to the
+// guarded serialization path; two Nodes that link each other must serialize as reference stubs, not
+// overflow. Exercises the "new exposure" the cross-model review flagged for computed-scalar-only tables.
+// getSync returns the live decoded struct synchronously (a Promise/async get would serialize as {} and
+// never cycle) — this is what makes the runtime cycle reachable during synchronous JSON serialization.
+tables.Node.setComputedAttribute('linked', (record) =>
+	record.linkId != null ? tables.Node.primaryStore.getSync(record.linkId) : undefined
+);
+
+// Review follow-up: `Ref.linked` is declared `String` but the resolver returns a live entity (another
+// Ref). The declared scalar type made this take the raw fast path before the fix; it must now be guarded
+// so two Refs linking each other serialize as reference stubs rather than overflowing.
+tables.Ref.setComputedAttribute('linked', (record) =>
+	record.linkId != null ? tables.Ref.primaryStore.getSync(record.linkId) : undefined
+);

--- a/integrationTests/resources/computed-and-cyclic-serialization/schema.graphql
+++ b/integrationTests/resources/computed-and-cyclic-serialization/schema.graphql
@@ -1,0 +1,65 @@
+# harper#1484 — default-read computed-scalar surfacing + cyclic-enumerable serialization guard.
+#
+#  Fix A: a @computed *scalar* must appear on the default (no-select) REST read, even though its
+#         getter is non-enumerable. A @computed whose type is a table must stay lazy (edge guard).
+#  Fix B: @enumerable relationships that form a cycle must serialize as { primaryKey } reference
+#         stubs instead of overflowing the stack.
+
+type Author @table @export {
+	id: ID @primaryKey
+	name: String
+	# Fix A: computed SCALAR — surfaced by default.
+	displayName: String @computed(from: "name")
+	# Fix B: enumerable side of a mutual cycle (Author.books -> Book.author -> Author ...).
+	books: [Book] @relationship(to: authorId) @enumerable
+}
+
+type Book @table @export {
+	id: ID @primaryKey
+	authorId: ID @indexed
+	title: String
+	author: Author @relationship(from: authorId) @enumerable
+}
+
+# Self-referential tree: enumerable parent pointing back at the same table (a self-loop cycle).
+type Category @table @export {
+	id: ID @primaryKey
+	name: String
+	parentId: ID @indexed
+	parent: Category @relationship(from: parentId) @enumerable
+}
+
+# Unconstrained (`Any`) @computed whose resolver (resources.js) returns a live entity. The static edge
+# graph can't see this, so `linked` forces the guarded serialization path; two Nodes linking each other
+# must not overflow. This is the "new exposure" the cross-model review flagged for computed-scalar tables.
+type Node @table @export {
+	id: ID @primaryKey
+	linkId: ID
+	linked: Any @computed
+}
+
+# Review follow-up (cb1kenobi): a @computed declared with a concrete SCALAR type whose resolver
+# nonetheless returns a live entity. JS can't enforce the declared return type, so before the fix this
+# took the raw fast path (only `Any`/untyped computeds were guarded) and overflowed on a runtime cycle.
+# Any surfaced non-table @computed now routes through the guarded path.
+type Ref @table @export {
+	id: ID @primaryKey
+	linkId: ID
+	linked: String @computed
+}
+
+# Both record encodings must preserve nested native Date/Bytes values on the guarded path.
+# NativeValues exercises msgpackr's default classic structures; NativeStructValues opts into structon.
+type NativeValues @table @export {
+	id: ID @primaryKey
+	name: String
+	details: Any
+	displayName: String @computed(from: "name")
+}
+
+type NativeStructValues @table(randomAccessFields: true) @export {
+	id: ID @primaryKey
+	name: String
+	details: Any
+	displayName: String @computed(from: "name")
+}

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -101,6 +101,19 @@ const TRACKED_WRITE_TYPES = new Set(['put', 'patch', 'delete', 'message', 'publi
 // WeakMaps are definitely not the fastest form of private properties, but they are the only
 // way to do this with how the objects are frozen for now.
 export const entryMap = new WeakMap<any, Entry>();
+/**
+ * The shared base for decoded table records. Each encoder uses a subclass so its table-specific
+ * computed-property prototype remains isolated, while callers can identify records independently
+ * of whether msgpackr or structon decoded them.
+ */
+export class RecordObject {
+	getUpdatedTime(): number {
+		return entryMap.get(this)?.version;
+	}
+	getExpiresAt(): number {
+		return entryMap.get(this)?.expiresAt;
+	}
+}
 export let lastValueEncoding: Buffer | undefined;
 let timestampNextEncoding = 0,
 	metadataInNextEncoding = -1,
@@ -137,16 +150,9 @@ export class RecordEncoder extends StructonEncoder {
 		 * are usually frozen, but this can be extended (by the Updatable class) for providing
 		 * mutation methods.
 		 */
-		class RecordObject {
-			getUpdatedTime() {
-				return entryMap.get(this)?.version;
-			}
-			getExpiresAt() {
-				return entryMap.get(this)?.expiresAt;
-			}
-		}
+		class StoreRecordObject extends RecordObject {}
 
-		options.structPrototype = RecordObject.prototype;
+		options.structPrototype = StoreRecordObject.prototype;
 		super(options);
 		// Whether this store carries per-record version/timestamp metadata. Only versioned stores
 		// (primary table DBIs) prefix records with the metadata header; non-versioned internal DBIs
@@ -917,8 +923,4 @@ export function removeEntry(store: any, entry: any, options?: any) {
 		}
 	}
 	return removal;
-}
-export interface RecordObject {
-	getUpdatedTime(): number;
-	getExpiresAt(): number;
 }

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -62,14 +62,7 @@ import { getWorkerIndex, getWorkerCount } from '../server/threads/manageThreads.
 import { HAS_BLOBS, auditRetention, removeAuditEntry } from './auditStore.ts';
 import { buildEmbedBefore, createDefaultEmbedder, type EmbedAttribute, type Embedder } from './models/embedHook.ts';
 import { autoCast, autoCastBooleanStrict } from '../utility/common_utils.ts';
-import {
-	recordUpdater,
-	removeEntry,
-	PENDING_LOCAL_TIME,
-	type RecordObject,
-	type Entry,
-	entryMap,
-} from './RecordEncoder.ts';
+import { recordUpdater, removeEntry, PENDING_LOCAL_TIME, RecordObject, type Entry, entryMap } from './RecordEncoder.ts';
 import { recordAction, recordActionBinary } from './analytics/write.ts';
 import { rebuildUpdateBefore } from './crdt.ts';
 import { appendHeader } from '../server/serverHelpers/Headers.ts';
@@ -272,6 +265,68 @@ function cloneConditions(conditions: any[]): any[] {
 		return copy;
 	});
 }
+// Ambient, path-scoped cycle guard for the enumerable-struct `toJSON` serialization path. A record on
+// a cyclically-enumerable table can (transitively) reference itself, which would recurse forever through
+// JSON.stringify. The struct getters resolve related records by id — and without a shared cache each
+// resolution decodes a fresh instance — so object-identity tracking is defeated; we key on (tableId, id).
+// Only cyclic tables allocate/consult this map; acyclic-enumerable tables keep a guard-free fast path.
+// Keyed by table class → set of primary keys currently on the serialization path (avoids any tableId
+// stringification/collision concern).
+let structSerializationVisited: Map<any, Set<any>> | null = null;
+// Resolve Harper records within a guarded serialization, so none escape back to an encoder that would call
+// their toJSON after our path-scoped unwind and miss the cycle. Native values (Date, Buffer/typed arrays,
+// ArrayBuffer, etc.) stay intact for CBOR/MessagePack.
+function resolveStructForJSON(value: any): any {
+	if (value == null || typeof value !== 'object') return value;
+	const isRecordObject = value instanceof RecordObject;
+	if (isRecordObject) {
+		const toJSON = (value as any).toJSON;
+		// The table-installed toJSON resolves every surfaced value through this function before returning.
+		if (typeof toJSON === 'function') return toJSON.call(value);
+	}
+	if (Array.isArray(value)) {
+		let resolvedArray: any[] | undefined;
+		for (let index = 0; index < value.length; index++) {
+			if (!(index in value)) continue;
+			const original = value[index];
+			const resolved = resolveStructForJSON(original);
+			if (resolved !== original) {
+				resolvedArray ??= value.slice();
+				resolvedArray[index] = resolved;
+			}
+		}
+		return resolvedArray ?? value;
+	}
+	const prototype = Object.getPrototypeOf(value);
+	if (!isRecordObject && prototype !== Object.prototype && prototype !== null) return value;
+	// Materialize eligible containers in one pass so accessors run exactly once. A RecordObject without a
+	// table toJSON becomes plain response data rather than a detached record-shaped object with no entryMap metadata.
+	const resolvedObject = Object.create(isRecordObject ? Object.prototype : prototype);
+	for (const key of Object.keys(value)) {
+		const original = value[key];
+		resolvedObject[key] = resolveStructForJSON(original);
+	}
+	return resolvedObject;
+}
+// Is `start` reachable from itself through @enumerable table-typed edges? (Includes self-loops, e.g. a
+// tree table with an enumerable parent/children relationship.) Walks the per-table `enumerableRelationDefs`
+// graph, resolving each definition's `.tableClass` here — this runs lazily on first serialization, by which
+// point every table class is assigned (so self/forward refs whose tableClass was unset at collection time
+// resolve correctly).
+function detectCyclicEnumerable(start: any): boolean {
+	const queue = start.enumerableRelationDefs ? [...start.enumerableRelationDefs] : [];
+	const seen = new Set();
+	while (queue.length) {
+		const target = queue.pop()?.tableClass;
+		if (!target) continue;
+		if (target === start) return true;
+		if (seen.has(target)) continue;
+		seen.add(target);
+		if (target.enumerableRelationDefs) for (const def of target.enumerableRelationDefs) queue.push(def);
+	}
+	return false;
+}
+
 // #section: setup-and-factory
 export function makeTable(options) {
 	const {
@@ -330,6 +385,19 @@ export function makeTable(options) {
 	let expirationWarningChecked = false;
 	let propertyResolvers: any;
 	let hasRelationships = false;
+	// Attribute names surfaced by the struct `toJSON` on the default (no-select) read: everything that is
+	// @enumerable, PLUS @computed attributes whose declared type is NOT a table type (scalars/objects/arrays
+	// that don't resolve to another entity — harper#1484). Table-typed computed attributes and non-enumerable
+	// relationships stay lazy, preserving the edge/cycle guard. `enumerableRelationDefs` holds the type
+	// definitions reached by an @enumerable *table-typed* attribute — the edges that can form a cycle. We store
+	// the definition (set early, during connectPropertyType) rather than its `.tableClass` (assigned later, so
+	// unset for self/forward refs at collection time); `.tableClass` is resolved lazily at detection.
+	let enumerableAttributeNames: string[] = [];
+	const enumerableRelationDefs = new Set<any>();
+	// True when the table surfaces any non-table @computed attribute. A resolver can return a live (possibly
+	// cyclic) entity at runtime regardless of its declared scalar type, and the static edge graph can't see
+	// it, so such a table takes the guarded serialization path rather than the raw fast path.
+	let hasSurfacedComputed = false;
 	let runningRecordExpiration: boolean;
 	const isRocksDB = primaryStore instanceof RocksDatabase;
 	type BigInt64ArrayAndMaxSafeId = BigInt64Array & { maxSafeId: number };
@@ -371,6 +439,75 @@ export function makeTable(options) {
 			return this.addTo(property, -value);
 		}
 	}
+	// Install the struct `toJSON` for a table that has @enumerable getters. JSON.stringify only walks own
+	// enumerable props (it skips inherited getters), so without this the enumerable getters never appear.
+	// The bounded enumeration (own keys + the known enumerable names) replaces the old whole-prototype-chain
+	// `for..in`, which cost O(inherited enumerables) per record. On a cyclically-enumerable table it also
+	// applies the path-scoped cycle guard; acyclic tables keep the cheap raw-value fast path.
+	function installEnumerableToJSON(structPrototype: any, tableClass: any, hasSurfacedComputed: boolean) {
+		const enumNames = enumerableAttributeNames;
+		let isCyclic: boolean | undefined; // lazily resolved on first serialization (once all tables loaded)
+		Object.defineProperty(structPrototype, 'toJSON', {
+			configurable: true,
+			value() {
+				if (isCyclic === undefined) {
+					isCyclic = detectCyclicEnumerable(tableClass);
+					if (isCyclic && getWorkerIndex() === 0)
+						harperLogger.warn?.(
+							`Table "${tableName}" has cyclically-enumerable relationships; cyclic references will be serialized as { ${primaryKey} } reference stubs. Consider removing @enumerable from one side of the cycle.`
+						);
+				}
+				// The fast path leaves surfaced values raw for native JSON.stringify to recurse — safe only when
+				// nothing surfaced can be a live entity that cycles. Statically-cyclic tables are excluded, and so
+				// are tables surfacing any non-table @computed: a resolver's runtime return could be a cyclic
+				// struct the static edge graph can't see, whatever its declared type. Those take the guarded path
+				// so the id-keyed guard + resolveStructForJSON catch any runtime cycle.
+				if (structSerializationVisited == null && !isCyclic && !hasSurfacedComputed) {
+					// fast path: bounded copy, values left raw (matches the previous for..in output). `name in json`
+					// treats an own stored key (already copied above) as taking precedence over its getter.
+					const json = {};
+					for (const key of Object.keys(this)) json[key] = this[key];
+					for (const name of enumNames) if (!(name in json)) json[name] = this[name];
+					return json;
+				}
+				// guarded path: track (tableClass, id) on the current serialization path and fully resolve
+				// nested structs so none escape back to native stringify after we unwind. All state setup lives
+				// inside the try so a throw from the primaryKey getter or the id-key normalization can never leak
+				// structSerializationVisited to a non-null Map for the rest of the thread's serializations.
+				const isTop = structSerializationVisited == null;
+				let ids: Set<any> | undefined;
+				let idKey: any;
+				let added = false;
+				try {
+					if (isTop) structSerializationVisited = new Map();
+					const id = this[primaryKey];
+					// Composite/array PKs and object-typed single PKs (Bytes/Uint8Array/Date/object) decode to a
+					// fresh instance each read, so identity-based membership would miss the same logical record;
+					// normalize any non-primitive id to a stable string key. The replacer keeps a BigInt component
+					// from throwing (JSON.stringify can't serialize BigInt natively); a primitive BigInt PK stays
+					// raw (Set membership is by value).
+					idKey =
+						id !== null && typeof id === 'object'
+							? JSON.stringify(id, (_, v) => (typeof v === 'bigint' ? v.toString() : v))
+							: id;
+					if (id != null) {
+						ids = structSerializationVisited!.get(tableClass);
+						if (!ids) structSerializationVisited!.set(tableClass, (ids = new Set()));
+						if (ids.has(idKey)) return { [primaryKey]: id }; // already on the path -> reference stub
+						ids.add(idKey);
+						added = true;
+					}
+					const json = {};
+					for (const key of Object.keys(this)) json[key] = resolveStructForJSON(this[key]);
+					for (const name of enumNames) if (!(name in json)) json[name] = resolveStructForJSON(this[name]);
+					return json;
+				} finally {
+					if (added) ids!.delete(idKey);
+					if (isTop) structSerializationVisited = null;
+				}
+			},
+		});
+	}
 	class TableResource<Record extends object = any> extends Resource<Record> {
 		#record: any; // the stored/frozen record from the database and stored in the cache (should not be modified directly)
 		#changes: any; // the changes to the record that have been made (should not be modified directly)
@@ -404,6 +541,7 @@ export function makeTable(options) {
 		static createdTimeProperty = createdTimeProperty;
 		static updatedTimeProperty = updatedTimeProperty;
 		static propertyResolvers;
+		static enumerableRelationDefs;
 		static userResolvers = {};
 		// `@embed` hook registry. `userSetEmbedders` records names set explicitly via
 		// `setEmbedAttribute` so a schema reload refreshes defaults without clobbering them.
@@ -4639,6 +4777,11 @@ export function makeTable(options) {
 			}
 			assignTrackedAccessors(this, this);
 			assignTrackedAccessors(Updatable, this, true);
+			// updatedAttributes() re-runs on every schema reload, so rebuild these from scratch rather than
+			// accumulating stale/duplicate entries across reloads.
+			enumerableAttributeNames = [];
+			enumerableRelationDefs.clear();
+			hasSurfacedComputed = false;
 			for (const attribute of attributes) {
 				const name = attribute.name;
 				if (attribute.resolve) {
@@ -4652,21 +4795,26 @@ export function makeTable(options) {
 						configurable: true,
 						enumerable: attribute.enumerable,
 					});
-					if (attribute.enumerable && !primaryStore.encoder.structPrototype.toJSON) {
-						Object.defineProperty(primaryStore.encoder.structPrototype, 'toJSON', {
-							configurable: true,
-							value() {
-								const json = {};
-								for (const key in this) {
-									// copy all enumerable properties, including from prototype
-									json[key] = this[key];
-								}
-								return json;
-							},
-						});
-					}
+					// The type definition (set early) marks a table-typed attribute; its `.tableClass` may not be
+					// assigned yet for self/forward refs, so key table-typedness off the definition, not tableClass.
+					const relationDef = attribute.definition || attribute.elements?.definition;
+					// Surface on the default read when @enumerable, or when a @computed attribute is NOT
+					// table-typed (harper#1484 — computed scalars). Table-typed computeds stay lazy.
+					if (attribute.enumerable || (attribute.computed && !relationDef)) enumerableAttributeNames.push(name);
+					// Only @enumerable *table-typed* attributes create a serialization edge that can cycle.
+					if (attribute.enumerable && relationDef) enumerableRelationDefs.add(relationDef);
+					// Any surfaced non-table @computed can return a live (possibly cyclic) entity at runtime,
+					// regardless of its declared scalar type — the static edge graph can't see it — so route it
+					// through the guarded serialization path.
+					if (attribute.computed && !relationDef) hasSurfacedComputed = true;
 				}
 			}
+			this.enumerableRelationDefs = enumerableRelationDefs;
+			// Re-install each reload so the toJSON closure captures the rebuilt name list; if a reload
+			// removed all enumerable/computed-scalar attributes, drop the now-unneeded toJSON.
+			if (enumerableAttributeNames.length > 0)
+				installEnumerableToJSON(primaryStore.encoder.structPrototype, this, hasSurfacedComputed);
+			else if (primaryStore.encoder.structPrototype.toJSON) delete primaryStore.encoder.structPrototype.toJSON;
 		}
 		// #section: computed-history
 		static setComputedAttribute(attribute_name, resolver) {

--- a/unitTests/apiTests/basicREST-test.mjs
+++ b/unitTests/apiTests/basicREST-test.mjs
@@ -240,7 +240,7 @@ describe('test REST calls', () => {
 			assert.equal(response.status, 200);
 			assert.equal(response.data.length, 5);
 			assert.equal(response.data[4].age, 24);
-			assert.equal(response.data[4].ageInMonths, undefined); // computed property shouldn't be returned by default
+			assert.equal(response.data[4].ageInMonths, 288); // harper#1484: computed scalars now surface on default reads
 			assert.equal(response.data[4].nameTitle, 'name4 title4'); // enumerable computed property should be returned by
 			// default
 		});

--- a/unitTests/apiTests/cache-test.mjs
+++ b/unitTests/apiTests/cache-test.mjs
@@ -32,6 +32,7 @@ describe('test REST calls with cache table', () => {
 		let data = response.data;
 		data.name = 'name change';
 		delete data.nameTitle; // don't send a computed property
+		delete data.ageInMonths; // harper#1484: computed scalars now also surface on default reads
 		response = await axios.put(`${baseUrl}/FourProp/3`, data);
 		assert.equal(response.status, 204);
 		await delay(20);

--- a/unitTests/resources/recordEncoder.test.js
+++ b/unitTests/resources/recordEncoder.test.js
@@ -1,6 +1,6 @@
 require('../testUtils');
 const assert = require('assert');
-const { RecordEncoder, isMissingStructureError } = require('#src/resources/RecordEncoder');
+const { RecordEncoder, RecordObject, isMissingStructureError } = require('#src/resources/RecordEncoder');
 const harperLogger = require('#src/utility/logging/harper_logger');
 const { Encoder } = require('msgpackr');
 
@@ -48,6 +48,23 @@ describe('RecordEncoder struct-mode gating', () => {
 		assert.notStrictEqual(enc._writeStruct, undefined, 'struct write hook should be set for primary DBIs');
 		const bytes = enc.encode(record);
 		assert.ok(bytes[0] >= 0x20 && bytes[0] < 0x40, `expected struct header byte, got 0x${bytes[0].toString(16)}`);
+	});
+
+	it('promoted classic msgpackr and structon records share the runtime base without sharing prototypes', () => {
+		const classicEncoder = makeEncoder(false, sharedStore());
+		const structEncoder = makeEncoder(true, sharedStore());
+		const classicDecoded = classicEncoder.decode(Buffer.from(classicEncoder.encode(record)));
+		const classicRecord = new classicEncoder.structPrototype.constructor();
+		Object.assign(classicRecord, classicDecoded); // getEntry promotes classic decoded objects this way
+		const structRecord = structEncoder.decode(Buffer.from(structEncoder.encode(record)));
+
+		assert.ok(classicRecord instanceof RecordObject, 'classic msgpackr records must be identifiable at runtime');
+		assert.ok(structRecord instanceof RecordObject, 'structon records must be identifiable at runtime');
+		assert.notStrictEqual(
+			classicEncoder.structPrototype,
+			structEncoder.structPrototype,
+			'per-encoder prototypes must remain isolated for table-specific computed getters'
+		);
 	});
 
 	it('records-mode output decodes on a struct-unaware msgpackr decoder (downgrade-safe)', () => {


### PR DESCRIPTION
Closes #1484.

Default reads now surface non-table `@computed` attributes, and cyclic `@enumerable` relationships serialize repeated ancestors as primary-key reference stubs instead of overflowing. The bounded per-table serializer keeps acyclic enumerable tables on a guard-free fast path and uses a path-scoped `(table, primary key)` guard only when runtime cycles are possible.

The guarded path preserves transport-native values: it identifies both promoted classic msgpackr records and structon random-access records through a shared `RecordObject` runtime base, recursively materializes only Harper records and ordinary containers, and leaves `Date`, `Buffer`/typed arrays, and `ArrayBuffer` intact for CBOR and MessagePack. Per-encoder record subclasses keep table-specific computed getters isolated.

Reviewer attention: `resources/Table.ts` owns the cycle guard and guarded materialization; `resources/RecordEncoder.ts` owns the shared runtime base. A computed resolver's declared scalar type cannot constrain its JS return value, so every surfaced non-table computed takes the guarded path.

Coverage includes mutual/self/runtime-computed cycles, classic msgpackr and structon records, CBOR and MessagePack fidelity, and RocksDB + LMDB. No documentation change is needed: this restores declared computed-field behavior and preserves the existing binary transport contract.

Generated with Claude Opus on the original implementation and Codex on the native-serialization follow-up. Final follow-up review: Gemini 3.6 Flash via direct API found no unresolved issues; the local Claude CLI review route was unavailable (execution timeout).
