### PR TITLE
fix(mqtt): share the MQTT port across workers except on macOS

### DIFF
--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -484,7 +484,12 @@ function onSocket(listener, options) {
 			listener
 		);
 		SNICallback.initialize(socketServer);
-		socketServer.noReusePort = true;
+		// Only opt out of reusePort on macOS, which doesn't reliably support SO_REUSEPORT on all
+		// socket types (ENOTSUP). Everywhere else, sharing the port lets every worker accept
+		// connections for this listener (e.g. MQTT), matching how HTTP servers are bound; without
+		// it only the first worker to bind serves the port and every sibling's listen() fails with
+		// a silently-swallowed EADDRINUSE.
+		if (process.platform === 'darwin') socketServer.noReusePort = true;
 		SERVERS[options.securePort] = socketServer;
 
 		// Create a corresponding Unix Domain Socket mirror for the secure socket
@@ -521,7 +526,9 @@ function onSocket(listener, options) {
 			keepAlive: true,
 			keepAliveInitialDelay: 600,
 		});
-		socketServer.noReusePort = true;
+		// See the securePort path above: opt out of reusePort only on macOS so every worker can
+		// accept connections for this listener elsewhere.
+		if (process.platform === 'darwin') socketServer.noReusePort = true;
 		SERVERS[options.port] = socketServer;
 	}
 	return socketServer;

--- a/unitTests/apiTests/mqtt-test.mjs
+++ b/unitTests/apiTests/mqtt-test.mjs
@@ -12,6 +12,7 @@ const { get: env_get, setProperty } = environmentManager;
 import { connect, connectAsync } from 'mqtt';
 import { readFileSync } from 'fs';
 import { handleApplication as handleMQTTApplication } from '#src/server/mqtt';
+import { SERVERS, portServer } from '#src/server/serverRegistry';
 
 // Adapter: creates a minimal scope and delegates to the new plugin API,
 // capturing socket/ws server instances so callers can call .listen() on them.
@@ -1060,6 +1061,52 @@ describe('test MQTT connections and commands', function () {
 				}
 			});
 		});
+	});
+
+	it('socket listeners only opt out of reusePort on macOS (so every worker shares the port elsewhere)', function () {
+		// server.socket() (onSocket in threadServer.js) is what the MQTT component uses to create
+		// its TCP and TLS listeners. On every platform except macOS these listeners must share the
+		// port via SO_REUSEPORT so all workers accept connections; macOS opts out because it does
+		// not reliably support SO_REUSEPORT on these socket types. Stub process.platform so both
+		// branches are exercised regardless of the host/CI OS, and cover both the TCP and TLS paths
+		// since the guard has to be applied to each.
+		const originalPlatform = process.platform;
+		// Snapshot both registries by value so cleanup restores them exactly — dropping keys these
+		// calls add (incl. any UDS-mirror entry) and undoing any array append setPortServerMap()
+		// would make on a port-key collision. SERVERS is a plain object; portServer is a Map of
+		// port -> server[], so deep-copy each array.
+		const preexistingServers = { ...SERVERS };
+		const preexistingPortServer = new Map([...portServer.entries()].map(([key, servers]) => [key, [...servers]]));
+		const makeListener = (platform, options) => {
+			Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+			return global.server.socket(() => {}, options);
+		};
+		try {
+			assert.equal(!!makeListener('linux', { port: 21883 }).noReusePort, false, 'TCP should share the port on Linux');
+			assert.equal(
+				makeListener('darwin', { port: 21884 }).noReusePort,
+				true,
+				'TCP should opt out of reusePort on macOS'
+			);
+			assert.equal(
+				!!makeListener('linux', { securePort: 28883 }).noReusePort,
+				false,
+				'TLS should share the port on Linux'
+			);
+			assert.equal(
+				makeListener('darwin', { securePort: 28884 }).noReusePort,
+				true,
+				'TLS should opt out of reusePort on macOS'
+			);
+		} finally {
+			Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+			// These listeners were never bound (no listen()); restore both registries to their exact
+			// pre-test state so nothing leaks into other tests.
+			for (const key of Object.keys(SERVERS)) delete SERVERS[key];
+			Object.assign(SERVERS, preexistingServers);
+			portServer.clear();
+			for (const [key, servers] of preexistingPortServer) portServer.set(key, servers);
+		}
 	});
 
 	after(() => {


### PR DESCRIPTION
## Summary

`onSocket()` in `server/threads/threadServer.js` (exposed as `server.socket()`, used by the MQTT component for its TCP and TLS listeners) set `socketServer.noReusePort = true` **unconditionally** on both paths. That opt-out was meant to be macOS-only — macOS doesn't reliably support `SO_REUSEPORT` on these socket types (ENOTSUP). The sibling HTTP fix in the original commit (`219e52bec`) correctly guarded on `process.platform === 'darwin'`, but the `onSocket` path was left unconditional.

This guards the opt-out on `darwin` for both paths, matching how HTTP servers are bound.

## Why

With `noReusePort` always on, MQTT never shares its port across workers on Linux. With `threads.count > 1`, only the first worker to bind the MQTT port actually serves it; every other worker's `listen()` fails with `EADDRINUSE`, which `listenOnPorts()` silently swallows (a workaround for the Node <20.11.1 reusePort bug). Net effect: all MQTT traffic funnels through a single worker instead of being kernel-load-balanced across all of them. This restores per-worker MQTT scaling on Linux; macOS/Windows behavior is unchanged.

## Where to look

- **Multi-worker MQTT correctness (pre-existing, now more reachable).** MQTT has no duplicate-`clientId` session takeover today (`getSession()` doesn't disconnect a prior live connection) — true even single-worker. Sharing the port across workers makes a reconnecting client more likely to land on a *different* worker than its prior (half-open) connection, widening two existing races on the shared `hdb_session*` tables: (1) the old connection's delayed keepalive-close can publish/delete the *new* connection's will, and (2) two live connections' `DurableSubscriptionsSession` instances can overwrite each other's `startTime`/`subscriptions`. Not introduced here and not a blocker for this fix, but worth a follow-up (#1604). (Retained messages and cross-worker delivery via `transactionBroadcast` are handled correctly by the DB layer.)
- **Verification is Linux-only.** The reusePort path can't be exercised on macOS (which correctly keeps `noReusePort`); the unit test stubs `process.platform` so both branches run on any CI OS, but true multi-worker port-sharing is being validated separately on a Linux host.

## Test

Adds a unit test in `mqtt-test.mjs` asserting `server.socket()` sets `noReusePort` only on `darwin`, covering both the TCP and TLS paths (stubs `process.platform` so the darwin branch is exercised on Linux CI and vice-versa).

---
🤖 Generated by Claude (Opus 4.8). Cross-model review: Codex (clean) + Gemini (surfaced the pre-existing session-takeover concern noted above; test-cleanup suggestion applied).
