### PR TITLE
feat(server): surface external port conflicts on all platforms; single-worker default without SO_REUSEPORT

### DIFF
--- a/integrationTests/server/external-port-conflict.test.ts
+++ b/integrationTests/server/external-port-conflict.test.ts
@@ -15,7 +15,7 @@
  * still starts (the conflict is surfaced, not fatal).
  */
 import { suite, test, before, after } from 'node:test';
-import { ok } from 'node:assert/strict';
+import { ok } from 'node:assert';
 import { createServer, type Server } from 'node:net';
 import { mkdtemp, readFile } from 'node:fs/promises';
 import { join } from 'node:path';

--- a/integrationTests/server/external-port-conflict.test.ts
+++ b/integrationTests/server/external-port-conflict.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression test for external MQTT port-conflict detection.
+ *
+ * With reusePort (Linux), sibling workers share a port and never raise EADDRINUSE; without it
+ * (macOS/Windows), the main thread binds every port before any worker starts and never
+ * restarts. Either way an EADDRINUSE on the reusePort path or the main thread is never a
+ * benign in-process collision — it means an unrelated process already holds the port and will
+ * silently receive this listener's traffic. Harper used to swallow that EADDRINUSE
+ * unconditionally, so a squatter on the MQTT port went completely unreported (the original
+ * symptom: a developer's second Harper instance holding 8883, MQTT connections silently
+ * routed to it).
+ *
+ * This test pre-occupies the MQTT secure port with an unrelated plain socket server, boots
+ * Harper on the same address, and asserts (a) Harper logs the external conflict and (b) Harper
+ * still starts (the conflict is surfaced, not fatal).
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok } from 'node:assert/strict';
+import { createServer, type Server } from 'node:net';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import {
+	startHarper,
+	teardownHarper,
+	getNextAvailableLoopbackAddress,
+	type ContextWithHarper,
+} from '@harperfast/integration-testing';
+
+// Mirrors @harperfast/integration-testing's fixed MQTT secure port.
+const MQTTS_PORT = 8883;
+const CONFLICT_LOG = /address already in use by another process/;
+
+/** Bind a plain (non-reusePort) TCP server to simulate an unrelated process squatting the port. */
+function occupyPort(host: string, port: number): Promise<Server> {
+	return new Promise((resolve, reject) => {
+		const server = createServer();
+		server.once('error', reject);
+		server.listen({ host, port, reusePort: false }, () => {
+			server.removeListener('error', reject);
+			resolve(server);
+		});
+	});
+}
+
+function closeServer(server: Server): Promise<void> {
+	return new Promise((resolve) => server.close(() => resolve()));
+}
+
+/** Poll the instance's hdb.log until it contains `pattern` or the deadline passes. */
+async function waitForLogMatch(logDir: string, pattern: RegExp, timeoutMs = 15_000): Promise<string> {
+	const logFile = join(logDir, 'hdb.log');
+	const deadline = Date.now() + timeoutMs;
+	let contents = '';
+	while (Date.now() < deadline) {
+		try {
+			contents = await readFile(logFile, 'utf8');
+			if (pattern.test(contents)) return contents;
+		} catch {
+			// log file may not exist yet
+		}
+		await sleep(200);
+	}
+	return contents;
+}
+
+suite('external MQTT port conflict is surfaced, not swallowed', (ctx: ContextWithHarper) => {
+	let squatter: Server;
+	let hostname: string;
+
+	before(async () => {
+		hostname = await getNextAvailableLoopbackAddress();
+		// Grab the MQTT secure port before Harper boots, as an unrelated process would.
+		squatter = await occupyPort(hostname, MQTTS_PORT);
+
+		const dataRootDir = await mkdtemp(join(tmpdir(), 'harper-external-port-conflict-'));
+		// Pre-seed hostname so startHarper binds MQTT on the exact address we squatted.
+		ctx.harper = { dataRootDir, hostname } as ContextWithHarper['harper'];
+		// Must resolve despite the squatter — the conflict is surfaced, not fatal.
+		await startHarper(ctx);
+	});
+
+	after(async () => {
+		// Release the port before teardown so its port-free wait doesn't block on our squatter.
+		// teardownHarper() releases the loopback address (only once it has confirmed the ports are
+		// free), so don't release it again here — a second unconditional release could return a
+		// still-parked address to the shared pool.
+		if (squatter) await closeServer(squatter);
+		await teardownHarper(ctx);
+	});
+
+	// Detection is universal: with reusePort (Linux) siblings share the port so any EADDRINUSE is
+	// external; without it (macOS/Windows/Bun raw sockets) the main thread binds first and never
+	// restarts, so its EADDRINUSE is equally unambiguous.
+	test('Harper logs the external bind conflict for the MQTT port', async () => {
+		const logDir = ctx.harper.logDir ?? join(ctx.harper.dataRootDir, 'log');
+		const contents = await waitForLogMatch(logDir, CONFLICT_LOG);
+		ok(
+			CONFLICT_LOG.test(contents),
+			`expected an external-conflict log for the MQTT port; got:\n${contents.slice(-2000)}`
+		);
+	});
+
+	test('Harper still started despite the conflict', () => {
+		// startHarper() resolved in before() (it throws HarperStartupError otherwise), so a live
+		// process handle is the proof the squatted port did not abort boot.
+		ok(ctx.harper.process && ctx.harper.process.exitCode === null, 'Harper process should be running');
+	});
+});

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -441,10 +441,16 @@ async function restartWorkers(
 		// make a copy of the workers before iterating them, as the workers array mutates a lot during this
 		let waitingToFinish = []; // promises for workers we have shut down and are waiting to exit
 		// We can only start the replacement *before* the old worker releases its port when the OS lets
-		// both listen on the same port at once (SO_REUSEPORT). Without that — Windows (no SO_REUSEPORT)
-		// and Bun — the replacement can't bind until the old worker exits, so there we keep the original
-		// ordering: shut the old worker down first, then start the replacement (an unavoidable brief gap).
-		const canPreStartReplacement = process.platform !== 'win32' && !isBun;
+		// both listen on the same port at once (SO_REUSEPORT). Without that — Windows (no SO_REUSEPORT),
+		// macOS (unreliable SO_REUSEPORT, so workers bind exclusively), and Bun — the replacement can't
+		// bind a port the old worker still holds: its EADDRINUSE would be swallowed and the port left
+		// unbound once the old worker exits (this silently killed worker-owned listeners like MQTT on
+		// macOS after every component-reload restart). So there we keep the original ordering: shut the
+		// old worker down first (server.close() releases its ports immediately), then start the
+		// replacement — an unavoidable brief gap, but only for worker-owned listeners, since the main
+		// thread keeps serving the HTTP ports throughout. This ordering is also what lets
+		// listenOnPorts() treat a dedicated listener's EADDRINUSE as an external conflict.
+		const canPreStartReplacement = process.platform !== 'win32' && process.platform !== 'darwin' && !isBun;
 		for (let worker of workers.slice(0)) {
 			if ((name && worker.name !== name) || worker.wasShutdown) continue; // filter by type, if specified
 			const overlapping = OVERLAPPING_RESTART_TYPES.indexOf(worker.name) > -1;

--- a/server/threads/socketRouter.ts
+++ b/server/threads/socketRouter.ts
@@ -30,6 +30,10 @@ export async function startHTTPThreads(threadCount = 2, dynamicThreads?: boolean
 	startTransactionLogCooling();
 	try {
 		if (dynamicThreads) {
+			// No caller currently passes dynamicThreads. If one ever does, note that the main thread
+			// does not bind ports in this mode, so on platforms without SO_REUSEPORT (macOS/Windows)
+			// worker 0's exclusive HTTP bind would silently swallow an external EADDRINUSE — the
+			// external-conflict detection in listenOnPorts() assumes the main thread binds first.
 			startHTTPWorker(0, 1);
 		} else {
 			const { loadRootComponents } = require('../loadRootComponents.js');

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -276,6 +276,7 @@ function listenOnPorts() {
 			continue;
 		}
 		let listen_on;
+		let ownerWorkerIndex = 0; // lowest eligible worker index for this port
 		const threadRange = env.get(terms.CONFIG_PARAMS.HTTP_THREADRANGE);
 		if (threadRange) {
 			let threadRangeArray = typeof threadRange === 'string' ? threadRange.split('-') : threadRange;
@@ -283,6 +284,7 @@ function listenOnPorts() {
 			if (threadIndex < threadRangeArray[0] || threadIndex > threadRangeArray[1]) {
 				continue;
 			}
+			ownerWorkerIndex = +threadRangeArray[0];
 		}
 
 		try {
@@ -301,6 +303,13 @@ function listenOnPorts() {
 			harperLogger.error(`Unable to bind to port ${port}`, error);
 			continue;
 		}
+		// A dedicated listener (see onSocket()) with an exclusive (non-reusePort) bind is owned by a
+		// single deterministic worker — the lowest eligible index — instead of every worker racing
+		// for it. Nothing else in-process can then hold its port (the main thread doesn't bind these,
+		// and restarts of the owner are non-overlapping on non-reusePort platforms, see
+		// restartWorkers()), which is what makes the owner's EADDRINUSE below unambiguously external.
+		if (server.dedicatedListener && !listen_on.reusePort && !isMainThread && getWorkerIndex() !== ownerWorkerIndex)
+			continue;
 		listening.push(
 			new Promise((resolve, reject) => {
 				server
@@ -309,12 +318,24 @@ function listenOnPorts() {
 						harperLogger.trace('Listening on port ' + port, threadId);
 					})
 					.on('error', (err) => {
-						// Node.js before v20.11.1 does not properly support reusePort for net.Server —
-						// workers receive EADDRINUSE even though the main thread bound with reusePort: true.
-						// Resolve rather than reject so the worker can proceed, matching the same graceful
-						// handling already present in listenOnPortsBun().
-						if (err.code === 'EADDRINUSE') resolve({ port, name: server.name, protocol_name: server.protocol_name });
-						else reject(err);
+						if (err.code !== 'EADDRINUSE') return reject(err);
+						// An EADDRINUSE here is unambiguously an unrelated external process already
+						// holding the port (which will silently receive this listener's traffic) when:
+						// - the listener uses reusePort: Harper's supported Node fully supports
+						//   SO_REUSEPORT, so sibling workers share the port and never raise EADDRINUSE,
+						//   even across an overlapping restart (the replacement co-binds while the old
+						//   worker is still up); or
+						// - this is the main thread: it binds the HTTP/operations ports (awaited) before
+						//   any worker starts and never restarts, so nothing in-process can already hold
+						//   them; or
+						// - this is a dedicated listener's owner worker (gated above): no other thread
+						//   binds it, and its restarts are non-overlapping without reusePort.
+						// The remaining case — a worker's exclusive HTTP bind on macOS/Windows —
+						// deterministically loses to the main thread's earlier bind; that benign
+						// EADDRINUSE stays swallowed silently. Resolve either way so one unavailable
+						// port doesn't stall the rest of this thread's boot.
+						if (listen_on.reusePort || isMainThread || server.dedicatedListener) logExternalBindConflict(port, err);
+						resolve({ port, name: server.name, protocol_name: server.protocol_name });
 					});
 			})
 		);
@@ -347,6 +368,23 @@ function listenOnPorts() {
 		}
 	}
 	return Promise.all(listening);
+}
+
+/**
+ * Log that a port could not be bound because an unrelated process already holds it — meaning that
+ * process, not this listener, will receive the port's traffic. Only called once in-process
+ * collisions have been ruled out (reusePort sharing, or the main thread's first-bind ordering),
+ * so this is unambiguously external.
+ */
+function logExternalBindConflict(port, err) {
+	// `port` is a string key from `for..in SERVERS`, but portServer may be keyed by the numeric
+	// port setPortServerMap() was called with, so fall back to a numeric lookup.
+	const registered = portServer.get(port) ?? portServer.get(Number(port));
+	const owner = registered?.[registered.length - 1];
+	harperLogger.error(
+		`Failed to bind ${owner?.protocol_name ?? 'socket'} listener${owner?.name ? ` for component '${owner.name}'` : ''} to port ${port}: address already in use by another process`,
+		err
+	);
 }
 
 async function listenOnPortsBun() {
@@ -486,6 +524,13 @@ async function listenOnPortsBun() {
 				const lastColon = String(port).lastIndexOf(':');
 				const rawHostname = lastColon > 0 ? String(port).slice(0, lastColon).replace(/[[\]]/g, '') : null;
 				const portNum = lastColon > 0 ? +String(port).slice(lastColon + 1) : +port;
+				// These raw-socket listens bind exclusively (no reusePort), so a dedicated listener
+				// gets a single owner worker — same reasoning as listenOnPorts(). Bun restarts are
+				// already non-overlapping (see restartWorkers()).
+				if (server.dedicatedListener && !isMainThread && getWorkerIndex() !== 0) {
+					listening.push(Promise.resolve({ port }));
+					continue;
+				}
 				listening.push(
 					new Promise((resolve, reject) => {
 						server
@@ -494,9 +539,14 @@ async function listenOnPortsBun() {
 								harperLogger.trace('Listening on port ' + port, threadId);
 							})
 							.on('error', (err) => {
-								// Another worker already bound this port — that's fine
-								if (err.code === 'EADDRINUSE') resolve({ port });
-								else reject(err);
+								if (err.code !== 'EADDRINUSE') return reject(err);
+								// The main thread binds before any worker and never restarts, and a
+								// dedicated listener's owner worker is the only thread that binds it — in
+								// both cases EADDRINUSE can only come from an unrelated external process;
+								// surface it (see listenOnPorts()). Otherwise another worker already bound
+								// the port — that's fine.
+								if (isMainThread || server.dedicatedListener) logExternalBindConflict(port, err);
+								resolve({ port });
 							});
 					})
 				);
@@ -542,6 +592,11 @@ function onSocket(listener, options) {
 		// it only the first worker to bind serves the port and every sibling's listen() fails with
 		// a silently-swallowed EADDRINUSE.
 		if (process.platform === 'darwin') socketServer.noReusePort = true;
+		// Unlike HTTP/operations ports, these component listeners are never bound by the main
+		// thread (components don't run handleApplication there), so a worker owns them. Marking
+		// them lets listenOnPorts() give an exclusive (non-reusePort) one a single deterministic
+		// owner worker, which makes any EADDRINUSE on it unambiguously an external process.
+		socketServer.dedicatedListener = true;
 		SERVERS[options.securePort] = socketServer;
 
 		// Create a corresponding Unix Domain Socket mirror for the secure socket
@@ -579,8 +634,9 @@ function onSocket(listener, options) {
 			keepAliveInitialDelay: 600,
 		});
 		// See the securePort path above: opt out of reusePort only on macOS so every worker can
-		// accept connections for this listener elsewhere.
+		// accept connections for this listener elsewhere, and mark it worker-owned.
 		if (process.platform === 'darwin') socketServer.noReusePort = true;
+		socketServer.dedicatedListener = true;
 		SERVERS[options.port] = socketServer;
 	}
 	return socketServer;

--- a/unitTests/apiTests/mqtt-test.mjs
+++ b/unitTests/apiTests/mqtt-test.mjs
@@ -1120,17 +1120,17 @@ describe('test MQTT connections and commands', function () {
 			return global.server.socket(() => {}, options);
 		};
 		try {
-			assert.equal(!!makeListener('linux', { port: 21883 }).noReusePort, false, 'TCP should share the port on Linux');
+			const linuxTcp = makeListener('linux', { port: 21883 });
+			assert.equal(!!linuxTcp.noReusePort, false, 'TCP should share the port on Linux');
+			assert.equal(linuxTcp.dedicatedListener, true, 'TCP listener should be marked worker-owned/dedicated');
 			assert.equal(
 				makeListener('darwin', { port: 21884 }).noReusePort,
 				true,
 				'TCP should opt out of reusePort on macOS'
 			);
-			assert.equal(
-				!!makeListener('linux', { securePort: 28883 }).noReusePort,
-				false,
-				'TLS should share the port on Linux'
-			);
+			const linuxTls = makeListener('linux', { securePort: 28883 });
+			assert.equal(!!linuxTls.noReusePort, false, 'TLS should share the port on Linux');
+			assert.equal(linuxTls.dedicatedListener, true, 'TLS listener should be marked worker-owned/dedicated');
 			assert.equal(
 				makeListener('darwin', { securePort: 28884 }).noReusePort,
 				true,

--- a/unitTests/validation/configValidator.test.js
+++ b/unitTests/validation/configValidator.test.js
@@ -265,6 +265,8 @@ describe('Test configValidator module', () => {
 			},
 		};
 		const helpers = { state: { path: ['customFunctions', 'processes'] } };
+		const original_platform = process.platform;
+		const set_platform = (value) => Object.defineProperty(process, 'platform', { value, configurable: true });
 		let os_cpus_stub;
 		let logger_info_stub;
 
@@ -276,14 +278,25 @@ describe('Test configValidator module', () => {
 		afterEach(() => {
 			os_cpus_stub.restore();
 			logger_info_stub.restore();
+			set_platform(original_platform);
 		});
 
 		it('Test happy path, correct info message is logged and correct number of processes returned', () => {
+			// CPU-based defaulting only applies where SO_REUSEPORT lets workers share the ports
+			set_platform('linux');
 			os_cpus_stub.returns([1, 2, 3, 4, 5, 6]);
 			const result = set_default_processes(parent, helpers);
 
 			expect(result).to.equal(5);
 			expect(logger_info_stub.firstCall.args[0]).to.include(`defaulting customFunctions.processes to ${result}`);
+		});
+
+		it('Defaults to a single worker on platforms without SO_REUSEPORT (macOS, Windows)', () => {
+			os_cpus_stub.returns([1, 2, 3, 4, 5, 6]);
+			for (const platform of ['darwin', 'win32']) {
+				set_platform(platform);
+				expect(set_default_processes(parent, helpers)).to.equal(1);
+			}
 		});
 	});
 

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -442,6 +442,16 @@ function validateRotationRetention(value, helpers) {
 
 function setDefaultThreads(parent, helpers) {
 	const configParam = helpers.state.path.join('.');
+	// Without SO_REUSEPORT (macOS is unreliable, Windows lacks it) worker threads cannot share the
+	// HTTP/socket ports — the main thread binds them all first and serves alone, so extra HTTP
+	// workers never receive direct TCP traffic. Default to a single worker there; an explicit
+	// threads.count still overrides.
+	if (process.platform === 'darwin' || process.platform === 'win32') {
+		hdbLogger.info(
+			`Defaulting ${configParam} to 1 on ${process.platform}: without SO_REUSEPORT, additional HTTP workers cannot share the server ports`
+		);
+		return 1;
+	}
 	let processors = os.cpus().length;
 
 	// default to one less than the number of logical CPU/processors so we can have good concurrency with the


### PR DESCRIPTION
## Summary

Stacked on #1603 (MQTT listeners share their port via `SO_REUSEPORT` on non-macOS). This makes external port conflicts **detected and loudly logged on every platform**, and aligns two related behaviors on platforms without working `SO_REUSEPORT` (macOS/Windows).

`listenOnPorts()` used to swallow every `EADDRINUSE` — a workaround for a Node <20.11.1 reusePort bug now outside Harper's supported range (`^22.18 || >=24`). So an unrelated process squatting a Harper port (the original symptom: a second Harper instance holding 8883) silently received Harper's MQTT traffic with no error logged anywhere.

## Design

Every `EADDRINUSE` with a possible in-process explanation is structurally ruled out, so what remains is unambiguously external and gets logged (port + owning component + error):

| Case | Why EADDRINUSE must be external |
|---|---|
| `reusePort` listener (Linux) | siblings share the port, never collide — even across overlapping restarts |
| main thread (HTTP/ops ports) | binds every port (awaited) before any worker starts; never restarts |
| dedicated listener's owner worker (MQTT via `server.socket()`) | never bound by the main thread; now bound by a **single owner worker** (lowest eligible index) instead of every worker racing; restarts are non-overlapping without reusePort |

The one remaining benign case — a worker's exclusive HTTP bind losing to the main thread on macOS/Windows — stays silently swallowed. Everything still resolves, so a squatted port never stalls boot.

Supporting changes:
- **`restartWorkers()` no longer pre-starts replacements on macOS** (`canPreStartReplacement` now excludes darwin, like Windows/Bun). This also fixes a latent bug: the pre-started replacement could never bind the exclusive ports the old worker still held, its `EADDRINUSE` was swallowed, and worker-owned listeners (MQTT) were left **permanently unbound after every component-reload restart on macOS**. The main thread keeps serving HTTP throughout, so only worker-owned listeners see the brief shutdown-first gap.
- **`threads.count` defaults to 1 on macOS/Windows** (`setDefaultThreads`): without `SO_REUSEPORT`, extra HTTP workers can never share the server ports — the CPU-based default just spawned workers that serve no direct TCP traffic. Explicit `threads.count` still overrides.

## Where to look

- **The ownership claims are the crux.** Verified in code + empirically: main thread binds HTTP/ops before workers (`socketRouter.ts` awaits `listenOnPorts()` pre-spawn); component plugins don't run `handleApplication` on the main thread, so MQTT listeners exist only in workers.
- **`canPreStartReplacement` on darwin**: #1417 (rolling-restart conn-refused) was a Linux `SO_REUSEPORT`-pool fix and Linux is unchanged. `rolling-restart.test.ts` fails identically on macOS on the base branch (pre-existing), so CI/Linux remains the gating signal.
- **`threadRange`**: the dedicated-listener owner is the lowest *eligible* index, not hardcoded 0.

## Test

`integrationTests/server/external-port-conflict.test.ts` squats the MQTT secure port before boot and asserts the conflict is logged **on every platform** (skip removed) and Harper still starts. Plus platform-stubbed unit coverage for `setDefaultThreads` and the `dedicatedListener` marker.

---
🤖 Generated by Claude (Fable 5 / Opus 4.8 across revisions). Cross-model reviewed (Codex + Gemini) at each design iteration; earlier reviews drove the pivot from worker-gating → reusePort-only → this universal design.
