### PR TITLE
fix(lint): use plain node:assert import in allowread-fail-closed test

### DIFF
--- a/integrationTests/resources/allowread-fail-closed.test.ts
+++ b/integrationTests/resources/allowread-fail-closed.test.ts
@@ -11,7 +11,7 @@
  * (and the super_user bypass) keep working.
  */
 import { suite, test, before, after } from 'node:test';
-import { ok, strictEqual } from 'node:assert/strict';
+import { ok, strictEqual } from 'node:assert';
 import { resolve } from 'node:path';
 
 import request from 'supertest';


### PR DESCRIPTION
## What

Fixes the `runLinter` CI failure on `main`.

The `runLinter` job runs `npm run lint:required` (`oxlint --quiet`), which fails on a single **error**:

```
integrationTests/resources/allowread-fail-closed.test.ts
  14:1  error  'node:assert/strict' import is restricted from being used.  eslint(no-restricted-imports)
```

The repo's `.oxlintrc.json` restricts imports from `node:assert/strict` (and `assert/strict`):

> Use plain `node:assert`; call `assert.strictEqual`/`deepStrictEqual` for strict checks (AGENTS.md test style).

## Change

One line — switch the import from `node:assert/strict` to plain `node:assert`:

```diff
-import { ok, strictEqual } from 'node:assert/strict';
+import { ok, strictEqual } from 'node:assert';
```

`node:assert`'s named `ok` / `strictEqual` are already the strict variants, so behavior is unchanged. This also matches the convention used across sibling integration tests (`import { ok, strictEqual } from 'node:assert'`).

## Verification

- `npm run lint:required` (the CI command) → **0 errors** (previously 1).
- `prettier --check` on the file → clean.

Note: `main` also currently fails `Unit Test` (flaky event-ordering assertions, e.g. "expected at least 1 event for id=1, got 0"); that's a separate issue and out of scope for this lint-only fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
