### PR TITLE
fix(build): ship npm-shrinkwrap.json in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"index.*",
 		"json",
 		"launchServiceScripts",
+		"npm-shrinkwrap.json",
 		"README.md",
 		"resources",
 		"schema.graphql",


### PR DESCRIPTION
## Summary
Add `npm-shrinkwrap.json` to the `files` allowlist in `package.json`.

## Why
`build-tools/build.sh` already runs `npm shrinkwrap` before `npm pack`, intending to ship a pinned dependency tree. But `package.json` declares a `files` allowlist, and that list omitted `npm-shrinkwrap.json` — so `npm pack` silently dropped the generated lockfile. Result: **every** published harper release has shipped with unpinned `^` ranges, and consumers resolve native-addon deps to whatever satisfies the range at install time.

Concretely: `npm install harper@5.0.31` floats `@datadog/pprof` (`^5.11.1`) onto 5.16.0, whose tarball fails `node-gyp rebuild` (`binding.gyp not found`). `@harperfast/harper-pro@5.0.31` installs cleanly precisely because its `files` array already lists `npm-shrinkwrap.json`, so its shrinkwrap ships and pins pprof to 5.14.1.

## Effect
Future releases from this branch ship the shrinkwrap `build.sh` already generates, so consumers get the exact pinned tree (rocksdb-js, lmdb, argon2, …).

## Where to look
- One line. Verified with `npm pack --dry-run`: `npm-shrinkwrap.json` is now listed in the tarball (it was excluded before).
- Implication worth a nod: a full-tree shrinkwrap gives consumers harper's exact transitive versions (less dedup flexibility). This is the pre-existing intent (build.sh + harper-pro already do this), so it makes harper behave as designed rather than introducing new behavior.

_Generated by Claude (Opus 4.8)._
