### PR TITLE
test(resources): fix main-red subscriptionReplay flakes (fixed collect() window vs #1345 load)

### DIFF
--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -34,16 +34,27 @@ function assertChronologicalIfStrictlyOrdered(events, msg) {
 	if (isLMDB) assertChronological(events, msg);
 }
 
-// Drain a subscription into an array, returning when no new event has arrived for `quietMs`.
-async function collect(subscription, quietMs = 50) {
+// Drain a subscription into an array. Returns once at least `minEvents` have arrived AND no new
+// event has landed for `quietMs`, or once `timeout` ms elapse.
+//
+// Waiting for `minEvents` (default 1) instead of racing a fixed quiet window from t=0 is what
+// keeps these tests stable on a loaded runner: async replay delivery can start more than
+// `quietMs` late (e.g. behind a heavy preceding test in the same suite), and the old
+// unconditional quiet timer would then expire before the first event and return nothing. Tests
+// that assert *no* events must pass `{ minEvents: 0 }` to keep the original quiet-window behavior.
+// The quiet window still bounds the tail, so exact-count assertions remain valid. See
+// unitTests/waitFor.js for the same "wait for the condition, not the clock" rationale.
+async function collect(subscription, quietMs = 50, { minEvents = 1, timeout = 5000 } = {}) {
 	const events = [];
 	let lastEventAt = Date.now();
 	subscription.on('data', (event) => {
 		events.push(event);
 		lastEventAt = Date.now();
 	});
-	while (Date.now() - lastEventAt < quietMs) {
-		await delay(quietMs);
+	const deadline = Date.now() + timeout;
+	while (Date.now() < deadline) {
+		if (events.length >= minEvents && Date.now() - lastEventAt >= quietMs) break;
+		await delay(Math.min(quietMs, 20));
 	}
 	return events;
 }
@@ -706,7 +717,7 @@ describe('Subscription replay', () => {
 				audit: true,
 			});
 			const subscription = await T.subscribe({ previousCount: 10, isCollection: true });
-			const events = await collect(subscription, 150);
+			const events = await collect(subscription, 150, { minEvents: 0 });
 			subscription.return?.();
 
 			assert.equal(events.length, 0, `expected 0 events on empty table, got ${events.length}`);
@@ -817,7 +828,7 @@ describe('Subscription replay', () => {
 			// startTime well in the future — gate skips everything ≤ that
 			const futureTime = Date.now() + 10_000_000_000; // far future
 			const subscription = await T.subscribe({ startTime: futureTime, isCollection: true });
-			const events = await collect(subscription, 150);
+			const events = await collect(subscription, 150, { minEvents: 0 });
 			subscription.return?.();
 
 			// nothing delivered initially (gate skips, cursor's exclusiveStart skips)
@@ -833,7 +844,7 @@ describe('Subscription replay', () => {
 			});
 			// startTime: 1 (truthy) to force the branch
 			const subscription = await T.subscribe({ startTime: 1, isCollection: true });
-			const events = await collect(subscription, 100);
+			const events = await collect(subscription, 100, { minEvents: 0 });
 			subscription.return?.();
 
 			assert.equal(events.length, 0, `expected 0 events on empty audit log, got ${events.length}`);
@@ -849,7 +860,7 @@ describe('Subscription replay', () => {
 				audit: true,
 			});
 			const subscription = await T.subscribe({ isCollection: true });
-			const events = await collect(subscription, 100);
+			const events = await collect(subscription, 100, { minEvents: 0 });
 			subscription.return?.();
 
 			assert.equal(events.length, 0, `expected 0 events on empty store, got ${events.length}`);
@@ -884,7 +895,7 @@ describe('Subscription replay', () => {
 				audit: true,
 			});
 			const subscription = await T.subscribe({ id: 999, startTime: Date.now() - 1 });
-			const events = await collect(subscription, 100);
+			const events = await collect(subscription, 100, { minEvents: 0 });
 			subscription.return?.();
 
 			assert.equal(events.length, 0, `expected 0 events for non-existent record, got ${events.length}`);


### PR DESCRIPTION
## What

`main`'s **Unit Test** job has been red on all three Node versions since #1345, failing in `subscriptionReplay.test.js`. Two failures, same root cause:

- rocksdb resources run — `audit records of types not in ACTIONS_OF_INTEREST are still delivered by cursor` → `expected at least 1 event for id=1, got 0`
- lmdb resources run — `count: previousCount larger than total records returns all available` → `missing id 0`

The lmdb one was **masked** on main: `test:unit:all` chains `resources && lmdb`, so the rocksdb failure aborted the run before lmdb executed. Fixing only the rocksdb test uncovered the next latent one — hence the helper-level fix here rather than test-by-test.

## Root cause

`subscriptionReplay` tests drained their subscription with `collect(sub, Nms)`, which returned as soon as `N` ms passed with no event — **measured from t=0**. Async replay delivery can start later than that window on a loaded runner, so `collect()` returned too few (often zero) events and the assertion failed.

#1345 added `searchDuringActiveIndexing.test.js` — a heavyweight test that seeds **60,000 rows**, launches a background `runIndexing`, and runs 60k search/write iterations. It sorts just before `subscriptionReplay` in the resources suite (same mocha process) and leaves the event loop under load, reliably pushing replay delivery past the fixed windows. Subscription delivery itself is unchanged and correct.

This is the failure mode `unitTests/waitFor.js` documents — *"Fixed `delay(N)` waits race against loaded CI runners; waiting for the actual condition does not."*

## Fix

Fix the shared `collect()` helper instead of individual tests: wait until at least `minEvents` (default **1**) have arrived **and** the stream has gone quiet for `quietMs`, bounded by a `timeout`. The quiet window still bounds the tail, so exact-count assertions stay valid.

- All positive-assertion callers work unchanged (default `minEvents: 1`).
- The five tests that assert **no** events opt out with `{ minEvents: 0 }`, preserving the original quiet-window behavior.
- The `#1345` coverage test is intentionally **not** changed — a subscription test must be robust to a loaded runner regardless of what runs before it.

## Validation

`searchDuringActiveIndexing.test.js` + `subscriptionReplay.test.js` run green together (heavy test first) under **both** engines:
- rocksdb: 28 passing
- lmdb: 37 passing (includes the previously-failing `count:` tests)

Release branches `v5.1`/`v5.0` don't carry #1345's heavy test, so the flake can't occur there — no backport needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)