### PR TITLE
Fix SSE hang + uncaughtException on finite generator streamed to completion (#1628)

### DIFF
--- a/server/serverHelpers/contentTypes.ts
+++ b/server/serverHelpers/contentTypes.ts
@@ -623,15 +623,10 @@ function transformIterable(iterable, transform) {
 				next() {
 					const step = iterator.next();
 					if (step.then) {
-						return step.then((step) => ({
-							value: transform(step.value),
-							done: step.done,
-						}));
+						// don't transform the terminal sentinel step, whose value is undefined
+						return step.then((result) => (result.done ? result : { value: transform(result.value), done: false }));
 					}
-					return {
-						value: transform(step.value),
-						done: step.done,
-					};
+					return step.done ? step : { value: transform(step.value), done: false };
 				},
 				return(value) {
 					return iterator.return(value);

--- a/unitTests/resources/models/openaiStream.sse-http.test.js
+++ b/unitTests/resources/models/openaiStream.sse-http.test.js
@@ -38,9 +38,9 @@ async function* toolCallChunks() {
 // serializer. This mirrors Harper's actual SSE path: a request with `Accept: text/event-stream`
 // is dispatched as CONNECT (server/REST.ts:24-25,137-139) and the resulting message stream is
 // iterated and serialized per message — never the terminating `done` step. So we call the real
-// `sse.serialize` (contentTypes.ts) on each yielded message, exactly as that path does. (We do
-// NOT use `sse.serializeStream`: its `transformIterable` transforms the terminal `undefined`
-// value, which the resource-SSE path avoids by manual iteration.)
+// `sse.serialize` (contentTypes.ts) on each yielded message, exactly as that path does. (This
+// test predates #1628; `sse.serializeStream` now skips the terminal `done` step and finishes a
+// finite generator cleanly — see the serializeStream SSE coverage in contentTypes.test.js.)
 // Listens on an ephemeral loopback port so concurrent runs stay isolated.
 function serveOnce(tokens, opts) {
 	const server = http.createServer(async (_req, res) => {

--- a/unitTests/server/serverHelpers/contentTypes.test.js
+++ b/unitTests/server/serverHelpers/contentTypes.test.js
@@ -138,3 +138,36 @@ describe('contentTypes – application/x-ndjson', function () {
 		});
 	});
 });
+
+describe('contentTypes – text/event-stream (SSE)', function () {
+	const handler = contentTypes.get('text/event-stream');
+
+	// #1628: a finite async generator streamed to natural completion must close the SSE
+	// stream cleanly. transformIterable used to hand the terminal `{ value: undefined,
+	// done: true }` step to serialize(), which threw on `undefined.acknowledge` — hanging
+	// the response and raising an uncaughtException. The infinite-subscription case never
+	// reaches a terminal step, so this went unnoticed.
+	it('streams a finite async generator to completion without hanging or throwing', async function () {
+		async function* source() {
+			yield { seq: 'a' };
+			yield { seq: 'b' };
+		}
+		const readable = handler.serializeStream(source());
+		const output = await streamToString(readable);
+		const events = output
+			.split('\n\n')
+			.filter(Boolean)
+			.map((frame) => JSON.parse(frame.replace(/^data: /, '')));
+		assert.deepStrictEqual(events, [{ seq: 'a' }, { seq: 'b' }]);
+	});
+
+	it('streams a finite sync iterable to completion without hanging or throwing', async function () {
+		const readable = handler.serializeStream([{ n: 1 }, { n: 2 }]);
+		const output = await streamToString(readable);
+		const events = output
+			.split('\n\n')
+			.filter(Boolean)
+			.map((frame) => JSON.parse(frame.replace(/^data: /, '')));
+		assert.deepStrictEqual(events, [{ n: 1 }, { n: 2 }]);
+	});
+});


### PR DESCRIPTION
Closes #1628.

## Summary
`transformIterable` (`server/serverHelpers/contentTypes.ts`) applied the serializer transform to a finite iterator's terminal `{ value: undefined, done: true }` step. The SSE `serialize()` opens with `if (message.acknowledge) message.acknowledge()`, so the terminal `undefined` threw `TypeError: Cannot read properties of undefined (reading 'acknowledge')` — a process `uncaughtException` — and the HTTP response never closed. Any custom Resource that streams a **plain async generator to natural completion over `Accept: text/event-stream`** hangs.

The fix guards `transformIterable` to pass the terminal `done` step through untransformed, in both the sync and async branches. This is the root-cause fix (a transform should never see the sentinel `undefined`), so it also benefits the other consumer (ndjson) which previously ran a wasted `JSONStringify(undefined)` on the terminal step.

## Why it wasn't hit before
The common infinite-subscription SSE case (`IterableEventQueue`) never reaches a terminal `done` step; a plain generator over `application/json` closes cleanly. The bug is confined to the SSE streaming path on **finite** generators — directly on the LLM/`openaiStream` completion pattern (#631) and any bounded/export-over-SSE stream.

## Where to look
- `server/serverHelpers/contentTypes.ts` — the 5-LOC guard. On `done`, the raw step is returned as-is (its `value` is discarded by the async-iterator protocol / `Readable.from`), avoiding the transform, an extra allocation, and a redundant `step.done` read.
- `unitTests/server/serverHelpers/contentTypes.test.js` — two regression tests (async generator + sync iterable) that fail with the exact `acknowledge` error before the fix and pass after.
- `unitTests/resources/models/openaiStream.sse-http.test.js` — comment-only update: that test predates #1628 and documented this hazard as the reason it hand-iterates instead of using `serializeStream`; the note now points at the fix.

## Out of scope (pre-existing)
A non-terminal `yield undefined` (`{ value: undefined, done: false }`) still reaches `transform(undefined)` and would throw on the SSE path. That's a distinct pre-existing edge case, not introduced here.

## Review
Cross-model review (standard: Gemini + Harper-domain adjudication): no blockers, no significant concerns. The one Gemini suggestion (skip the terminal-step allocation) is folded into the fix.

Generated by an LLM (Claude Opus 4.8).