### PR TITLE
fix(logging): close rotated log fd immediately + expose logging.rotation.retention (#683)

### DIFF
--- a/config-root.schema.json
+++ b/config-root.schema.json
@@ -341,11 +341,14 @@
 					"properties": {
 						"enabled": { "type": "boolean", "description": "Enable log rotation. Default: true" },
 						"compress": { "type": "boolean", "description": "Compress rotated logs with gzip. Default: false" },
-						"interval": { "type": ["string", "null"], "description": "Time between rotations (e.g. '1D','6H','30M')." },
+						"interval": {
+							"type": ["string", "null"],
+							"description": "Time between rotations (e.g. '1D', '6H', '30m'). Units: D (days), H (hours), M (months), m (minutes)."
+						},
 						"maxSize": { "type": ["string", "null"], "description": "Max size before rotation (e.g. '100M', '1G')." },
 						"retention": {
 							"type": ["string", "null"],
-							"description": "Delete rotated logs older than this age (e.g. '30D', '12H', '1M' for one month). Units: D (days), H (hours), M (months). When unset, rotated logs are kept indefinitely."
+							"description": "Delete rotated logs older than this age (e.g. '30D', '12H', '1M' for one month). Units: D (days), H (hours), M (months), m (minutes). When unset, rotated logs are kept indefinitely."
 						},
 						"path": { "type": "string", "description": "Directory to store rotated logs. Default: <ROOTPATH>/log" }
 					}

--- a/config-root.schema.json
+++ b/config-root.schema.json
@@ -343,6 +343,10 @@
 						"compress": { "type": "boolean", "description": "Compress rotated logs with gzip. Default: false" },
 						"interval": { "type": ["string", "null"], "description": "Time between rotations (e.g. '1D','6H','30M')." },
 						"maxSize": { "type": ["string", "null"], "description": "Max size before rotation (e.g. '100M', '1G')." },
+						"retention": {
+							"type": ["string", "null"],
+							"description": "Delete rotated logs older than this age (e.g. '30D', '12H', '1M' for one month). Units: D (days), H (hours), M (months). When unset, rotated logs are kept indefinitely."
+						},
 						"path": { "type": "string", "description": "Directory to store rotated logs. Default: <ROOTPATH>/log" }
 					}
 				},

--- a/unitTests/utility/logging/logRotator.test.js
+++ b/unitTests/utility/logging/logRotator.test.js
@@ -100,4 +100,47 @@ describe('Test logRotator module', () => {
 		expect(rotated_log_path.startsWith(expectedDir)).to.be.true;
 		expect(fs.pathExistsSync(rotated_log_path)).to.be.true;
 	});
+
+	it('Reopens a fresh log file after rotation so subsequent writes do not go to the rotated file', async () => {
+		const rotated_log_path = await runRotator({ maxSize: '1K' });
+		expect(fs.pathExistsSync(LOG_FILE_PATH_TEST), 'Active log should have been rotated away').to.be.false;
+
+		// After rotation the descriptor must be closed so the next write opens a brand new hdb.log.
+		const marker = 'POST_ROTATION_MARKER_LINE';
+		logger.error(marker);
+		await hdb_utils.asyncSetTimeout(100);
+
+		expect(fs.pathExistsSync(LOG_FILE_PATH_TEST), 'A new active log file should be created on the next write').to.be
+			.true;
+		expect(readFileSync(LOG_FILE_PATH_TEST, 'utf-8')).to.include(marker);
+		// The rotated file must not receive writes made after rotation (would indicate a stale/leaked descriptor).
+		expect(readFileSync(rotated_log_path, 'utf-8')).to.not.include(marker);
+	}).timeout(TEST_TIMEOUT);
+
+	it('Deletes rotated logs older than the configured retention', async () => {
+		const retentionDir = path.join(LOG_DIR_TEST, 'retained');
+		fs.mkdirpSync(retentionDir);
+		const oldLog = path.join(retentionDir, 'HDB-old.log');
+		const newLog = path.join(retentionDir, 'HDB-new.log');
+		fs.writeFileSync(oldLog, 'old rotated log contents');
+		fs.writeFileSync(newLog, 'fresh rotated log contents');
+		// Age the old log well beyond the retention window (the fresh log stays comfortably inside it).
+		const past = new Date(Date.now() - 120000);
+		fs.utimesSync(oldLog, past, past);
+
+		// Large maxSize so the active log is not rotated; retention is what we are exercising.
+		const rotator = log_rotator({
+			logger,
+			path: retentionDir,
+			enabled: true,
+			auditInterval: 100,
+			maxSize: '1G',
+			retention: '30s',
+		});
+		await hdb_utils.asyncSetTimeout(300);
+		rotator.end();
+
+		expect(fs.pathExistsSync(oldLog), 'Rotated log older than retention should be deleted').to.be.false;
+		expect(fs.pathExistsSync(newLog), 'Rotated log within retention should be kept').to.be.true;
+	}).timeout(TEST_TIMEOUT);
 });

--- a/unitTests/utility/logging/logRotator.test.js
+++ b/unitTests/utility/logging/logRotator.test.js
@@ -125,7 +125,7 @@ describe('Test logRotator module', () => {
 		fs.writeFileSync(oldLog, 'old rotated log contents');
 		fs.writeFileSync(newLog, 'fresh rotated log contents');
 		// Age the old log well beyond the retention window (the fresh log stays comfortably inside it).
-		const past = new Date(Date.now() - 120000);
+		const past = new Date(Date.now() - 7200000);
 		fs.utimesSync(oldLog, past, past);
 
 		// Large maxSize so the active log is not rotated; retention is what we are exercising.
@@ -135,7 +135,7 @@ describe('Test logRotator module', () => {
 			enabled: true,
 			auditInterval: 100,
 			maxSize: '1G',
-			retention: '30s',
+			retention: '1H',
 		});
 		await hdb_utils.asyncSetTimeout(300);
 		rotator.end();

--- a/unitTests/validation/configValidator.test.js
+++ b/unitTests/validation/configValidator.test.js
@@ -413,6 +413,14 @@ describe('Test configValidator module', () => {
 		expect(helpers.message.args[0][0]).to.equal(
 			"Invalid logging.rotation.retention value. Value should be a number followed by unit e.g. '30D'"
 		);
+
+		for (const invalid of ['-5D', '0D', '', null]) {
+			message_stub.resetHistory();
+			validate_retention(invalid, helpers);
+			expect(helpers.message.args[0][0]).to.equal(
+				"Invalid logging.rotation.retention value. Value should be a number followed by unit e.g. '30D'"
+			);
+		}
 	});
 
 	it('Test validateRotationRetention valid value', () => {

--- a/unitTests/validation/configValidator.test.js
+++ b/unitTests/validation/configValidator.test.js
@@ -386,6 +386,34 @@ describe('Test configValidator module', () => {
 		);
 	});
 
+	it('Test validateRotationRetention invalid unit', () => {
+		const validate_retention = config_val.__get__('validateRotationRetention');
+		const message_stub = sinon.stub();
+		const helpers = { message: message_stub };
+		validate_retention('30B', helpers);
+		expect(helpers.message.args[0][0]).to.equal(
+			'Invalid logging.rotation.retention unit. Available units are D, H or M (months)'
+		);
+	});
+
+	it('Test validateRotationRetention invalid value', () => {
+		const validate_retention = config_val.__get__('validateRotationRetention');
+		const message_stub = sinon.stub();
+		const helpers = { message: message_stub };
+		validate_retention('THIRTYD', helpers);
+		expect(helpers.message.args[0][0]).to.equal(
+			"Invalid logging.rotation.retention value. Value should be a number followed by unit e.g. '30D'"
+		);
+	});
+
+	it('Test validateRotationRetention valid value', () => {
+		const validate_retention = config_val.__get__('validateRotationRetention');
+		const message_stub = sinon.stub();
+		const helpers = { message: message_stub };
+		expect(validate_retention('30D', helpers)).to.equal('30D');
+		expect(message_stub.called).to.be.false;
+	});
+
 	describe('mcp config', () => {
 		it('validates clean when the mcp block is absent (profile off)', () => {
 			const result = configValidator(testUtils.deepClone(FAKE_CONFIG), true);

--- a/unitTests/validation/configValidator.test.js
+++ b/unitTests/validation/configValidator.test.js
@@ -372,8 +372,17 @@ describe('Test configValidator module', () => {
 		const helpers = { message: message_stub };
 		validate_interval('10B', helpers);
 		expect(helpers.message.args[0][0]).to.equal(
-			'Invalid logging.rotation.interval unit. Available units are D, H or M (minutes)'
+			'Invalid logging.rotation.interval unit. Available units are D (days), H (hours), M (months) or m (minutes)'
 		);
+	});
+
+	it('Test validateRotationInterval accepts minutes (lowercase m) and days', () => {
+		const validate_interval = config_val.__get__('validateRotationInterval');
+		const message_stub = sinon.stub();
+		const helpers = { message: message_stub };
+		expect(validate_interval('30m', helpers)).to.equal('30m');
+		expect(validate_interval('1D', helpers)).to.equal('1D');
+		expect(message_stub.called).to.be.false;
 	});
 
 	it('Test validateRotationInterval invalid value', () => {
@@ -392,7 +401,7 @@ describe('Test configValidator module', () => {
 		const helpers = { message: message_stub };
 		validate_retention('30B', helpers);
 		expect(helpers.message.args[0][0]).to.equal(
-			'Invalid logging.rotation.retention unit. Available units are D, H or M (months)'
+			'Invalid logging.rotation.retention unit. Available units are D (days), H (hours), M (months) or m (minutes)'
 		);
 	});
 

--- a/utility/logging/logRotator.ts
+++ b/utility/logging/logRotator.ts
@@ -67,23 +67,23 @@ function logRotator({ logger, maxSize, interval, retention, enabled, path: rotat
 	let lastRotationTime = Date.now();
 	hdbLogger.trace('Log rotate enabled, maxSize:', maxSize, 'interval:', interval);
 	const setIntervalId = setInterval(async () => {
+		// A missing/relocated active log file only invalidates the rotation checks below — retention cleanup
+		// must still run. So skip the individual check on ENOENT rather than returning from the whole tick.
 		if (maxBytes) {
 			let fileStats;
 			try {
 				fileStats = await fsProm.stat(logger.path);
 			} catch (err) {
-				// If the log file doesn't exist, skip rotation check
-				if (err.code === 'ENOENT') return;
-				throw err;
+				// If the log file doesn't exist, skip the size-based rotation check
+				if (err.code !== 'ENOENT') throw err;
 			}
 
-			if (fileStats.size >= maxBytes) {
+			if (fileStats && fileStats.size >= maxBytes) {
 				try {
-					lastRotatedLogPath = await moveLogFile(logger.path, rotatedLogDir);
+					lastRotatedLogPath = await moveLogFile(logger.path, rotatedLogDir, logger);
 				} catch (err) {
 					// If the log file doesn't exist, skip rotation
-					if (err.code === 'ENOENT') return;
-					throw err;
+					if (err.code !== 'ENOENT') throw err;
 				}
 			}
 		}
@@ -92,12 +92,11 @@ function logRotator({ logger, maxSize, interval, retention, enabled, path: rotat
 			const minSinceLastRotate = Date.now() - lastRotationTime;
 			if (minSinceLastRotate >= maxInterval) {
 				try {
-					lastRotatedLogPath = await moveLogFile(logger.path, rotatedLogDir);
+					lastRotatedLogPath = await moveLogFile(logger.path, rotatedLogDir, logger);
 					lastRotationTime = Date.now();
 				} catch (err) {
 					// If the log file doesn't exist, skip rotation
-					if (err.code === 'ENOENT') return;
-					throw err;
+					if (err.code !== 'ENOENT') throw err;
 				}
 			}
 		}
@@ -106,7 +105,14 @@ function logRotator({ logger, maxSize, interval, retention, enabled, path: rotat
 			// adjust retention time if there is a reclamation priority in place
 			const retentionMs = convertToMS(retention ?? '1M') / (1 + reclamationPriority);
 			reclamationPriority = 0; // reset it after use
-			const files = await fsProm.readdir(rotatedLogDir);
+			let files;
+			try {
+				files = await fsProm.readdir(rotatedLogDir);
+			} catch (err) {
+				// The rotated log dir may not exist yet (nothing rotated so far); nothing to clean up
+				if (err.code !== 'ENOENT') hdbLogger.error('Error reading rotated log directory', rotatedLogDir, err);
+				files = [];
+			}
 			for (const file of files) {
 				try {
 					const fileStats = await fsProm.stat(path.join(rotatedLogDir, file));
@@ -129,7 +135,7 @@ function logRotator({ logger, maxSize, interval, retention, enabled, path: rotat
 	};
 }
 
-async function moveLogFile(logPath: string, rotatedLogPath: string) {
+async function moveLogFile(logPath: string, rotatedLogPath: string, logger?: any) {
 	const compress = envMgr.get(CONFIG_PARAMS.LOGGING_ROTATION_COMPRESS);
 	let fullRotateLogPath = path.join(
 		rotatedLogPath,
@@ -138,6 +144,12 @@ async function moveLogFile(logPath: string, rotatedLogPath: string) {
 	// Move log file to rotated log path first (if we crash
 	// during compression, we don't want to restart the compression with a new file)
 	await fsProm.rename(logPath, fullRotateLogPath);
+	// Close the rotating logger's own file descriptor now that the file has moved. This must be the
+	// logger's own closeLogFile (which resets its internal logFD), not the module-global one — otherwise
+	// the descriptor stays open on the moved (and, when compressing, subsequently unlinked) inode until the
+	// logger's safety timeout fires, pinning disk space and sending any writes in that window into the
+	// rotated/deleted file. Closing it here makes the next write reopen a fresh log file immediately.
+	(logger?.closeLogFile ?? hdbLogger.closeLogFile)();
 	if (compress) {
 		logPath = fullRotateLogPath;
 		fullRotateLogPath += '.gz';
@@ -145,8 +157,6 @@ async function moveLogFile(logPath: string, rotatedLogPath: string) {
 		await fsProm.unlink(logPath);
 	}
 
-	// Close old log file.
-	hdbLogger.closeLogFile();
 	// This notify log will create a new log file after the previous one has been rotated. It's important to keep this log as notify
 	hdbLogger.notify(`hdb.log rotated, old log moved to ${fullRotateLogPath}`);
 	return fullRotateLogPath;

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -378,13 +378,19 @@ function validateRotationInterval(value, helpers) {
 	return value;
 }
 function validateRotationRetention(value, helpers) {
+	if (typeof value !== 'string' || !value.trim()) {
+		return helpers.message(INVALID_RETENTION_VALUE_MSG);
+	}
+
 	const unit = value.slice(-1);
 	if (!VALID_ROTATION_DURATION_UNITS.includes(unit)) {
 		return helpers.message(INVALID_RETENTION_UNIT_MSG);
 	}
 
-	const age = value.slice(0, -1);
-	if (isNaN(parseInt(age))) {
+	// parseFloat + strictly-positive check: convertToMS accepts fractional intervals, and a zero or
+	// negative retention makes every rotated log older than the (<=0) window, deleting them immediately.
+	const age = parseFloat(value.slice(0, -1));
+	if (isNaN(age) || age <= 0) {
 		return helpers.message(INVALID_RETENTION_VALUE_MSG);
 	}
 

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -14,14 +14,18 @@ import * as validator from './validationWrapper.ts';
 const DEFAULT_LOG_FOLDER = 'log';
 const DEFAULT_COMPONENTS_FOLDER = 'components';
 const INVALID_SIZE_UNIT_MSG = 'Invalid logging.rotation.maxSize unit. Available units are G, M or K';
-const INVALID_INTERVAL_UNIT_MSG = 'Invalid logging.rotation.interval unit. Available units are D, H or M (minutes)';
+const INVALID_INTERVAL_UNIT_MSG =
+	'Invalid logging.rotation.interval unit. Available units are D (days), H (hours), M (months) or m (minutes)';
 const INVALID_MAX_SIZE_VALUE_MSG =
 	"Invalid logging.rotation.maxSize value. Value should be a number followed by unit e.g. '10M'";
 const INVALID_INTERVAL_VALUE_MSG =
 	"Invalid logging.rotation.interval value. Value should be a number followed by unit e.g. '10D'";
-const INVALID_RETENTION_UNIT_MSG = 'Invalid logging.rotation.retention unit. Available units are D, H or M (months)';
+const INVALID_RETENTION_UNIT_MSG =
+	'Invalid logging.rotation.retention unit. Available units are D (days), H (hours), M (months) or m (minutes)';
 const INVALID_RETENTION_VALUE_MSG =
 	"Invalid logging.rotation.retention value. Value should be a number followed by unit e.g. '30D'";
+// Units accepted for rotation durations, matching convertToMS: note capital M (months) vs lowercase m (minutes).
+const VALID_ROTATION_DURATION_UNITS = ['D', 'd', 'H', 'h', 'M', 'm'];
 const UNDEFINED_OPS_API = 'rootPath config parameter is undefined';
 
 const portConstraints = Joi.alternatives([number.min(0), string])
@@ -362,7 +366,7 @@ function validateRotationMaxSize(value, helpers) {
 
 function validateRotationInterval(value, helpers) {
 	const unit = value.slice(-1);
-	if (unit !== 'D' && unit !== 'H' && unit !== 'M') {
+	if (!VALID_ROTATION_DURATION_UNITS.includes(unit)) {
 		return helpers.message(INVALID_INTERVAL_UNIT_MSG);
 	}
 
@@ -375,7 +379,7 @@ function validateRotationInterval(value, helpers) {
 }
 function validateRotationRetention(value, helpers) {
 	const unit = value.slice(-1);
-	if (unit !== 'D' && unit !== 'H' && unit !== 'M') {
+	if (!VALID_ROTATION_DURATION_UNITS.includes(unit)) {
 		return helpers.message(INVALID_RETENTION_UNIT_MSG);
 	}
 

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -19,6 +19,9 @@ const INVALID_MAX_SIZE_VALUE_MSG =
 	"Invalid logging.rotation.maxSize value. Value should be a number followed by unit e.g. '10M'";
 const INVALID_INTERVAL_VALUE_MSG =
 	"Invalid logging.rotation.interval value. Value should be a number followed by unit e.g. '10D'";
+const INVALID_RETENTION_UNIT_MSG = 'Invalid logging.rotation.retention unit. Available units are D, H or M (months)';
+const INVALID_RETENTION_VALUE_MSG =
+	"Invalid logging.rotation.retention value. Value should be a number followed by unit e.g. '30D'";
 const UNDEFINED_OPS_API = 'rootPath config parameter is undefined';
 
 const portConstraints = Joi.alternatives([number.min(0), string])
@@ -214,6 +217,7 @@ export function configValidator(configJson, skipFsValidation = false) {
 				compress: boolean.optional(),
 				interval: string.custom(validateRotationInterval).optional().empty(null),
 				maxSize: string.custom(validateRotationMaxSize).optional().empty(null),
+				retention: string.custom(validateRotationRetention).optional().empty(null),
 				path: string.optional().empty(null).default(setDefaultRoot),
 			}).required(),
 			root: rootConstraints,
@@ -365,6 +369,19 @@ function validateRotationInterval(value, helpers) {
 	const size = value.slice(0, -1);
 	if (isNaN(parseInt(size))) {
 		return helpers.message(INVALID_INTERVAL_VALUE_MSG);
+	}
+
+	return value;
+}
+function validateRotationRetention(value, helpers) {
+	const unit = value.slice(-1);
+	if (unit !== 'D' && unit !== 'H' && unit !== 'M') {
+		return helpers.message(INVALID_RETENTION_UNIT_MSG);
+	}
+
+	const age = value.slice(0, -1);
+	if (isNaN(parseInt(age))) {
+		return helpers.message(INVALID_RETENTION_VALUE_MSG);
 	}
 
 	return value;


### PR DESCRIPTION
Fixes #683 — two log-management issues in the rotator.

## 1. FD handling during rotation (root cause)

`moveLogFile` closed the **module-global** descriptor (`hdbLogger.closeLogFile()`, which only touches `mainLogFd`) instead of the **rotating logger's own** descriptor. That never reset the logger's internal `logFD`, so after a rename the stale fd kept the moved file open — and with `compress` enabled, the *subsequently unlinked* inode — until the logger's 10s safety timeout fired. Effects per rotation:

- Disk space pinned on the deleted inode for up to 10s.
- Up to 10s of log writes (including the "hdb.log rotated" notify) landing in the moved/deleted file instead of the fresh `hdb.log`.

Under high write volume + small `maxSize`, this recurs continuously and presents as leaking fds / disk to `lsof`/`df`.

**Fix:** close the logger's *own* `closeLogFile` immediately after the rename (before the compress step, so the inode is released before the potentially-slow gzip). The next write then reopens a fresh log file right away.

Also fixed an over-broad early-return: the `ENOENT` handler in the size check `return`ed from the whole audit tick, so **retention cleanup was skipped** whenever the active log was momentarily absent (idle logging or mid-rotation). Now a missing active log only skips the rotation checks; retention still runs.

## 2. Old-log deletion — `logging.rotation.retention`

The rotator **already** deletes rotated logs older than `retention`, but the key was absent from both the JSON schema and the Joi validator — it only worked accidentally via Joi's `allowUnknown`, so it was undocumented and unvalidated. Exposed it in both, with a `D/H/M` duration validator mirroring the existing `interval`/`maxSize` validators, plus schema docs. (Reusing the already-wired `retention` rather than adding a new `maxAgeDays` — the "or equivalent" the issue allowed.)

## Tests
- `logRotator.test.js`: added reopen-a-fresh-file-after-rotation and retention-deletion cases (7 passing).
- `configValidator.test.js`: added retention unit/value/valid cases (49 passing).
- Full logging dir: 51 passing. `tsc` build clean.

## Cross-model review (Gemini + Harper domain adjudication)
No blockers or regressions. Gemini's two "blocker" flags were adjudicated out:
- *"nullish-coalescing drops `this`, crashes on `this.logFD`"* — **refuted**: both `closeLogFile` variants are plain closures (over `logFD` / `mainLogFd`), not instance methods; no `this`.
- *"`throw err` in the async tick crashes the process"* — **pre-existing**, unchanged reachability (branch was only inverted). Legitimate hardening follow-up, out of scope here.

Acted on the domain pass's one in-scope note: since the ENOENT change makes retention run in more ticks, wrapped the retention `readdir` in try/catch so a not-yet-created rotated dir can't throw out of the tick.

Noted for later (pre-existing, not touched): the `interval` validator message says `M (minutes)` but `convertToMS` treats capital `M` as **months**; retention's docs/message follow the actual behavior (M=months).