### PR TITLE
fix(ci): keep npm latest/next dist-tags on the newest release line

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -38,12 +38,45 @@ jobs:
           version: ${{ github.event.release.tag_name || inputs.tag_name }}
       - name: Set package tag
         id: package-tag
+        env:
+          PACKAGE_NAME: harper
+          VERSION: ${{ steps.version-components.outputs.version }}
+          PRERELEASE: ${{ steps.version-components.outputs.prerelease }}
+          RELEASE_LINE: ${{ steps.version-components.outputs.major }}.${{ steps.version-components.outputs.minor }}
         run: |
-          if [[ "${{ steps.version-components.outputs.prerelease }}" == '' ]]; then
-            echo "packageTag=latest" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if [[ "$PRERELEASE" == '' ]]; then
+            baseTag=latest
           else
-            echo "packageTag=next" >> "$GITHUB_OUTPUT"
+            baseTag=next
           fi
+          # Only move the base tag forward: a maintenance release (e.g. 5.0.x
+          # published after 5.1.x) must not steal `latest` from a newer line —
+          # it gets a line-scoped tag (e.g. `latest-5.0`) instead. See #1644.
+          # E404 means the tag doesn't exist yet (first publish); any other npm
+          # error must abort — treating it as "no tag" would steal the tag.
+          viewStatus=0
+          currentVersion=$(npm view "$PACKAGE_NAME@$baseTag" version 2>"$RUNNER_TEMP/npm-view.err") || viewStatus=$?
+          if [[ $viewStatus -ne 0 ]]; then
+            if grep -q 'code E404' "$RUNNER_TEMP/npm-view.err"; then
+              currentVersion=''
+            else
+              cat "$RUNNER_TEMP/npm-view.err" >&2
+              exit "$viewStatus"
+            fi
+          fi
+          if [[ -z "$currentVersion" ]]; then
+            packageTag=$baseTag
+          else
+            highest=$(npx --yes semver@7.8.5 "$VERSION" "$currentVersion" | tail -1)
+            if [[ "$highest" == "$VERSION" ]]; then
+              packageTag=$baseTag
+            else
+              packageTag=$baseTag-$RELEASE_LINE
+            fi
+          fi
+          echo "Publishing $PACKAGE_NAME@$VERSION with dist-tag '$packageTag' (current $baseTag: ${currentVersion:-none})"
+          echo "packageTag=$packageTag" >> "$GITHUB_OUTPUT"
       - name: Publish package to NPM registry
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -79,12 +112,45 @@ jobs:
           tar -czvf harperfast-harper-${{ steps.version-components.outputs.version }}.tgz package
       - name: Set package tag
         id: package-tag
+        env:
+          PACKAGE_NAME: '@harperfast/harper'
+          VERSION: ${{ steps.version-components.outputs.version }}
+          PRERELEASE: ${{ steps.version-components.outputs.prerelease }}
+          RELEASE_LINE: ${{ steps.version-components.outputs.major }}.${{ steps.version-components.outputs.minor }}
         run: |
-          if [[ "${{ steps.version-components.outputs.prerelease }}" == '' ]]; then
-            echo "packageTag=latest" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if [[ "$PRERELEASE" == '' ]]; then
+            baseTag=latest
           else
-            echo "packageTag=next" >> "$GITHUB_OUTPUT"
+            baseTag=next
           fi
+          # Only move the base tag forward: a maintenance release (e.g. 5.0.x
+          # published after 5.1.x) must not steal `latest` from a newer line —
+          # it gets a line-scoped tag (e.g. `latest-5.0`) instead. See #1644.
+          # E404 means the tag doesn't exist yet (first publish); any other npm
+          # error must abort — treating it as "no tag" would steal the tag.
+          viewStatus=0
+          currentVersion=$(npm view "$PACKAGE_NAME@$baseTag" version 2>"$RUNNER_TEMP/npm-view.err") || viewStatus=$?
+          if [[ $viewStatus -ne 0 ]]; then
+            if grep -q 'code E404' "$RUNNER_TEMP/npm-view.err"; then
+              currentVersion=''
+            else
+              cat "$RUNNER_TEMP/npm-view.err" >&2
+              exit "$viewStatus"
+            fi
+          fi
+          if [[ -z "$currentVersion" ]]; then
+            packageTag=$baseTag
+          else
+            highest=$(npx --yes semver@7.8.5 "$VERSION" "$currentVersion" | tail -1)
+            if [[ "$highest" == "$VERSION" ]]; then
+              packageTag=$baseTag
+            else
+              packageTag=$baseTag-$RELEASE_LINE
+            fi
+          fi
+          echo "Publishing $PACKAGE_NAME@$VERSION with dist-tag '$packageTag' (current $baseTag: ${currentVersion:-none})"
+          echo "packageTag=$packageTag" >> "$GITHUB_OUTPUT"
       - name: Publish package to NPM registry
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fixes #1644.

The publish workflow tagged every stable release `latest` (and every prerelease `next`), so whichever release line published last owned the tag — 5.0.32, published 9 minutes after 5.1.17 on 2026-07-06, stole `latest` from the 5.1 line. Anyone running `npm install harper` (or resolving `^5`) silently gets 5.0.x.

The "Set package tag" step now compares the publishing version against the current holder of `latest`/`next` (pinned `semver@7.8.5`) and only moves the tag forward; an older-line release gets a line-scoped tag instead (`latest-5.0`, `next-5.1`). A missing tag (E404, first publish) keeps the old behavior; any other `npm view` failure aborts the publish rather than guessing — a transient registry error that silently defaulted to `latest` would recreate #1644.

Verified by running the step body locally against the live registry: newer stable → `latest`; older-line stable → `latest-5.0`; newer prerelease → `next`; older-line prerelease → `next-5.1`; E404/first publish → `latest`; simulated registry outage → aborts.

## This PR alone doesn't fix the live registry

- `on: release` executes the workflow file at the tag's commit, and releases are cut from `v5.0`/`v5.1` — this change must land on those branches to take effect. Labeled `patch` for the automated v5.1 cherry-pick; **v5.0 needs a manual cherry-pick** (the automation only targets `RELEASE_BRANCH` = v5.1), and v5.0 is the line that actually steals the tag.
- The registry needs a one-time correction (the guard only prevents future theft):

  ```
  npm dist-tag add harper@5.1.17 latest
  npm dist-tag add @harperfast/harper@5.1.17 latest
  ```

  Without it, `latest` self-heals on the next 5.1.x release but stays on 5.0.32 until then.

## Known residuals (from cross-model review, accepted deliberately)

- A line-scoped tag can still be demoted by an out-of-order publish *within* its own line (re-releasing 5.0.4 after `latest-5.0` = 5.0.5). Guarding that needs a second registry read per publish for an opt-in tag; skipped for KISS.
- `npm view` → `npm publish` isn't atomic, so two concurrent release runs can still race the tag. The window is drastically narrowed, not eliminated.
- The step body is duplicated across the two publish jobs (pre-existing pattern); kept symmetric rather than extracting a composite action.

No docs change: `npm install harper` resolving the newest stable is the documented expectation; line-scoped tags are a safeguard artifact.

Generated by an LLM (Claude Fable 5) with human direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
