### PR TITLE
fix(ci): keep npm latest/next dist-tags on the newest release line (v5.0 backport)

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -30,16 +30,45 @@ jobs:
           version: ${{ github.event.release.tag_name }}
       - name: Set package tag
         id: package-tag
-        # Once we have our first full, non-beta release, turn this back on:
-        #        run: |
-        #          if [[ "${{ steps.version-components.outputs.prerelease }}" == '' ]]; then
-        #            echo "packageTag=latest" >> "$GITHUB_OUTPUT"
-        #          else
-        #            echo "packageTag=next" >> "$GITHUB_OUTPUT"
-        #          fi
-        # and get rid of this hard coded latest tagging:
+        env:
+          PACKAGE_NAME: harper
+          VERSION: ${{ steps.version-components.outputs.version }}
+          PRERELEASE: ${{ steps.version-components.outputs.prerelease }}
+          RELEASE_LINE: ${{ steps.version-components.outputs.major }}.${{ steps.version-components.outputs.minor }}
         run: |
-          echo "packageTag=latest" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if [[ "$PRERELEASE" == '' ]]; then
+            baseTag=latest
+          else
+            baseTag=next
+          fi
+          # Only move the base tag forward: a maintenance release (e.g. 5.0.x
+          # published after 5.1.x) must not steal `latest` from a newer line —
+          # it gets a line-scoped tag (e.g. `latest-5.0`) instead. See #1644.
+          # E404 means the tag doesn't exist yet (first publish); any other npm
+          # error must abort — treating it as "no tag" would steal the tag.
+          viewStatus=0
+          currentVersion=$(npm view "$PACKAGE_NAME@$baseTag" version 2>"$RUNNER_TEMP/npm-view.err") || viewStatus=$?
+          if [[ $viewStatus -ne 0 ]]; then
+            if grep -q 'code E404' "$RUNNER_TEMP/npm-view.err"; then
+              currentVersion=''
+            else
+              cat "$RUNNER_TEMP/npm-view.err" >&2
+              exit "$viewStatus"
+            fi
+          fi
+          if [[ -z "$currentVersion" ]]; then
+            packageTag=$baseTag
+          else
+            highest=$(npx --yes semver@7.8.5 "$VERSION" "$currentVersion" | tail -1)
+            if [[ "$highest" == "$VERSION" ]]; then
+              packageTag=$baseTag
+            else
+              packageTag=$baseTag-$RELEASE_LINE
+            fi
+          fi
+          echo "Publishing $PACKAGE_NAME@$VERSION with dist-tag '$packageTag' (current $baseTag: ${currentVersion:-none})"
+          echo "packageTag=$packageTag" >> "$GITHUB_OUTPUT"
       - name: Publish package to NPM registry
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -74,16 +103,45 @@ jobs:
           tar -czvf harperfast-harper-${{ steps.version-components.outputs.version }}.tgz package
       - name: Set package tag
         id: package-tag
-        # Once we have our first full, non-beta release, turn this back on:
-        #        run: |
-        #          if [[ "${{ steps.version-components.outputs.prerelease }}" == '' ]]; then
-        #            echo "packageTag=latest" >> "$GITHUB_OUTPUT"
-        #          else
-        #            echo "packageTag=next" >> "$GITHUB_OUTPUT"
-        #          fi
-        # and get rid of this hard coded latest tagging:
+        env:
+          PACKAGE_NAME: '@harperfast/harper'
+          VERSION: ${{ steps.version-components.outputs.version }}
+          PRERELEASE: ${{ steps.version-components.outputs.prerelease }}
+          RELEASE_LINE: ${{ steps.version-components.outputs.major }}.${{ steps.version-components.outputs.minor }}
         run: |
-          echo "packageTag=latest" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if [[ "$PRERELEASE" == '' ]]; then
+            baseTag=latest
+          else
+            baseTag=next
+          fi
+          # Only move the base tag forward: a maintenance release (e.g. 5.0.x
+          # published after 5.1.x) must not steal `latest` from a newer line —
+          # it gets a line-scoped tag (e.g. `latest-5.0`) instead. See #1644.
+          # E404 means the tag doesn't exist yet (first publish); any other npm
+          # error must abort — treating it as "no tag" would steal the tag.
+          viewStatus=0
+          currentVersion=$(npm view "$PACKAGE_NAME@$baseTag" version 2>"$RUNNER_TEMP/npm-view.err") || viewStatus=$?
+          if [[ $viewStatus -ne 0 ]]; then
+            if grep -q 'code E404' "$RUNNER_TEMP/npm-view.err"; then
+              currentVersion=''
+            else
+              cat "$RUNNER_TEMP/npm-view.err" >&2
+              exit "$viewStatus"
+            fi
+          fi
+          if [[ -z "$currentVersion" ]]; then
+            packageTag=$baseTag
+          else
+            highest=$(npx --yes semver@7.8.5 "$VERSION" "$currentVersion" | tail -1)
+            if [[ "$highest" == "$VERSION" ]]; then
+              packageTag=$baseTag
+            else
+              packageTag=$baseTag-$RELEASE_LINE
+            fi
+          fi
+          echo "Publishing $PACKAGE_NAME@$VERSION with dist-tag '$packageTag' (current $baseTag: ${currentVersion:-none})"
+          echo "packageTag=$packageTag" >> "$GITHUB_OUTPUT"
       - name: Publish package to NPM registry
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
v5.0 backport of #1690 (fixes #1644 for the line that actually steals the tag).

v5.0's publish workflow still hard-codes `packageTag=latest` on every publish — a pre-GA placeholder ("turn this back on after our first non-beta release") that main outgrew but v5.0 kept. That's the direct cause of #1644: 5.0.32, published 9 minutes after 5.1.17, unconditionally re-tagged `latest`.

Because `on: release` executes the workflow file at the tag's commit, #1690 landing on `main` does nothing for releases cut from this branch — the guard has to live here. Not a clean cherry-pick (this branch's workflow predates the main-line tagging rework), so the "Set package tag" step was transplanted; **the step body is byte-identical to #1690** (verified by diffing the step blocks across branches). See #1690 for the guard's behavior, local registry test scenarios, and accepted residuals.

Note the automated `patch` cherry-pick flow only targets `RELEASE_BRANCH` = v5.1, hence this manual backport PR.

Generated by an LLM (Claude Fable 5) with human direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
