### PR TITLE
feat(logs): stream read_log over SSE as a live tail

### DIFF
--- a/server/serverHelpers/progressEmitter.ts
+++ b/server/serverHelpers/progressEmitter.ts
@@ -16,6 +16,13 @@ export type ProgressListener = (event: ProgressEvent) => void;
 export class ProgressEmitter {
 	private listeners: ProgressListener[] = [];
 
+	/**
+	 * Set by {@link createSSEResponseStream} to a signal that aborts when the client
+	 * disconnects. Open-ended operations (e.g. a live log tail that never returns on its own)
+	 * read this to stop producing events and resolve, instead of running until process exit.
+	 */
+	signal?: AbortSignal;
+
 	emit(event: string, data: unknown): void {
 		// Snapshot before iteration so a listener that unsubscribes itself during dispatch
 		// doesn't shift indexes underneath us.
@@ -54,6 +61,12 @@ export function createSSEResponseStream(emitter: ProgressEmitter, operation: () 
 	// that consumers ignore, so it's safe filler.
 	stream.write(`: stream open\n\n`);
 
+	// Give the operation a way to observe client disconnect. `cleanup` runs when the stream
+	// closes/ends (and after the operation settles); aborting there lets an open-ended
+	// operation like a log tail stop and resolve rather than leak until the process exits.
+	const abortController = new AbortController();
+	emitter.signal = abortController.signal;
+
 	let active = true;
 	let errorEmitted = false;
 	const unsubscribe = emitter.subscribe((event) => {
@@ -67,6 +80,7 @@ export function createSSEResponseStream(emitter: ProgressEmitter, operation: () 
 		if (active) {
 			active = false;
 			unsubscribe();
+			abortController.abort();
 		}
 	};
 

--- a/server/serverHelpers/progressEmitter.ts
+++ b/server/serverHelpers/progressEmitter.ts
@@ -23,6 +23,30 @@ export class ProgressEmitter {
 	 */
 	signal?: AbortSignal;
 
+	/**
+	 * Backpressure signal for open-ended producers. {@link createSSEResponseStream} sets this
+	 * `true` when the underlying SSE stream's write buffer is full and clears it on `drain`. A
+	 * producer that can outrun a slow client (e.g. a log tail on a busy file) should await
+	 * {@link whenWritable} before emitting more, so buffered frames can't grow without bound.
+	 * Bounded producers (deploy) simply never check it.
+	 */
+	paused = false;
+	private drainWaiters: Array<() => void> = [];
+
+	/** Resolves once the SSE stream can accept more writes (immediately when not paused). */
+	whenWritable(): Promise<void> {
+		if (!this.paused) return Promise.resolve();
+		return new Promise((resolve) => this.drainWaiters.push(resolve));
+	}
+
+	/** Called by the SSE wrapper on `drain` (and on teardown) to release awaiting producers. */
+	resume(): void {
+		this.paused = false;
+		const waiters = this.drainWaiters;
+		this.drainWaiters = [];
+		for (const waiter of waiters) waiter();
+	}
+
 	emit(event: string, data: unknown): void {
 		// Snapshot before iteration so a listener that unsubscribes itself during dispatch
 		// doesn't shift indexes underneath us.
@@ -71,16 +95,22 @@ export function createSSEResponseStream(emitter: ProgressEmitter, operation: () 
 	let errorEmitted = false;
 	const unsubscribe = emitter.subscribe((event) => {
 		if (active) {
-			writeSSE(stream, event);
+			// A `false` return means the stream's buffer is over its high-water mark; flag it so
+			// producers that check `whenWritable()` back off until the 'drain' below clears it.
+			const canWriteMore = writeSSE(stream, event);
+			if (!canWriteMore) emitter.paused = true;
 			if (event.event === 'error') errorEmitted = true;
 		}
 	});
+	stream.on('drain', () => emitter.resume());
 
 	const cleanup = () => {
 		if (active) {
 			active = false;
 			unsubscribe();
 			abortController.abort();
+			// Release any producer awaiting drain so the operation can settle instead of hanging.
+			emitter.resume();
 		}
 	};
 
@@ -114,11 +144,12 @@ export function createSSEResponseStream(emitter: ProgressEmitter, operation: () 
 	return stream;
 }
 
-function writeSSE(stream: PassThrough, event: ProgressEvent): void {
+/** Write one SSE record; returns `stream.write`'s last result (false = buffer over high-water). */
+function writeSSE(stream: PassThrough, event: ProgressEvent): boolean {
 	const data = typeof event.data === 'string' ? event.data : JSON.stringify(event.data);
 	stream.write(`event: ${event.event}\n`);
 	for (const line of data.split(/\r?\n/)) {
 		stream.write(`data: ${line}\n`);
 	}
-	stream.write('\n');
+	return stream.write('\n');
 }

--- a/server/serverHelpers/progressEmitter.ts
+++ b/server/serverHelpers/progressEmitter.ts
@@ -144,12 +144,17 @@ export function createSSEResponseStream(emitter: ProgressEmitter, operation: () 
 	return stream;
 }
 
-/** Write one SSE record; returns `stream.write`'s last result (false = buffer over high-water). */
+/**
+ * Write one SSE record; returns `false` if any of its writes pushed the buffer past its
+ * high-water mark (so a dense multi-line payload that tips the buffer on an early `data:`
+ * line is still detected, not just the final `\n`). `stream.write(...)` is always the left
+ * operand so every line is written regardless of the accumulated backpressure flag.
+ */
 function writeSSE(stream: PassThrough, event: ProgressEvent): boolean {
 	const data = typeof event.data === 'string' ? event.data : JSON.stringify(event.data);
-	stream.write(`event: ${event.event}\n`);
+	let canWrite = stream.write(`event: ${event.event}\n`);
 	for (const line of data.split(/\r?\n/)) {
-		stream.write(`data: ${line}\n`);
+		canWrite = stream.write(`data: ${line}\n`) && canWrite;
 	}
-	return stream.write('\n');
+	return stream.write('\n') && canWrite;
 }

--- a/server/serverHelpers/serverHandlers.js
+++ b/server/serverHelpers/serverHandlers.js
@@ -25,11 +25,17 @@ const { applyImpersonation } = require('../../security/impersonation.ts');
 const { createGzip, constants } = require('zlib');
 const { ProgressEmitter, createSSEResponseStream } = require('./progressEmitter.ts');
 
-// Operations that support `Accept: text/event-stream` for live progress streaming. The
-// handler attaches a ProgressEmitter as req.body.progress so the operation can emit phase
-// events; the response body is the SSE-encoded emitter output. Non-SSE clients see the
-// historical single-response shape because progress is undefined on that path.
-const SSE_PROGRESS_OPERATIONS = new Set([terms.OPERATIONS_ENUM.DEPLOY_COMPONENT, terms.OPERATIONS_ENUM.GET_DEPLOYMENT]);
+// Operations that support `Accept: text/event-stream` for live streaming. The handler
+// attaches a ProgressEmitter as req.body.progress so the operation can emit events; the
+// response body is the SSE-encoded emitter output. Non-SSE clients see the historical
+// single-response shape because progress is undefined on that path. deploy_component /
+// get_deployment stream a bounded run and end; read_log tails the log and stays open until
+// the client disconnects (the emitter's abort signal), so subscribers see new lines live.
+const SSE_PROGRESS_OPERATIONS = new Set([
+	terms.OPERATIONS_ENUM.DEPLOY_COMPONENT,
+	terms.OPERATIONS_ENUM.GET_DEPLOYMENT,
+	terms.OPERATIONS_ENUM.READ_LOG,
+]);
 
 const NO_AUTH_OPERATIONS = [
 	terms.OPERATIONS_ENUM.CREATE_AUTHENTICATION_TOKENS,

--- a/unitTests/utility/logging/readLogStream.test.js
+++ b/unitTests/utility/logging/readLogStream.test.js
@@ -1,0 +1,200 @@
+'use strict';
+
+const env_mangr = require('#src/utility/environment/environmentManager');
+env_mangr.initTestEnvironment();
+const sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+const path = require('path');
+const fs = require('fs-extra');
+const rewire = require('rewire');
+const read_log = rewire('#src/utility/logging/readLog');
+const readLogFunction = read_log.default || read_log;
+const hdb_terms = require('#src/utility/hdbTerms');
+
+const LOG_DIR_TEST = 'testLoggerStream';
+const LOG_NAME_TEST = 'log_stream_unit_test.log';
+const TEST_LOG_DIR = path.join(__dirname, LOG_DIR_TEST);
+const FULL_LOG_PATH_TEST = path.join(TEST_LOG_DIR, LOG_NAME_TEST);
+
+function line(second, level, message) {
+	return `2023-03-02T21:52:1${second}.688Z [main/0] [${level}]: ${message}\n`;
+}
+
+// Fake ProgressEmitter matching what serverHandlers attaches to request.progress: an `emit`
+// that captures events, plus a `signal` that aborts on client disconnect.
+function fakeProgress() {
+	const controller = new AbortController();
+	const events = [];
+	return {
+		events,
+		signal: controller.signal,
+		emit(event, data) {
+			events.push({ event, data });
+		},
+		disconnect() {
+			controller.abort();
+		},
+		logs() {
+			return events.filter((e) => e.event === 'log').map((e) => e.data);
+		},
+	};
+}
+
+async function waitFor(predicate, { timeout = 5000, interval = 20 } = {}) {
+	const deadline = Date.now() + timeout;
+	while (Date.now() < deadline) {
+		if (predicate()) return true;
+		await new Promise((r) => setTimeout(r, interval));
+	}
+	return false;
+}
+
+describe('Test readLog SSE tail', () => {
+	const sandbox = sinon.createSandbox();
+	const validator_stub = sandbox.stub().returns(null);
+	let validator_rw;
+	let getConfigPath_rw;
+	let progress;
+	let running;
+
+	beforeEach(() => {
+		fs.mkdirpSync(TEST_LOG_DIR);
+		fs.writeFileSync(FULL_LOG_PATH_TEST, '');
+		getConfigPath_rw = read_log.__set__('configUtils_ts_1', {
+			getConfigPath: (key) => (key === hdb_terms.HDB_SETTINGS_NAMES.LOG_PATH_KEY ? TEST_LOG_DIR : undefined),
+		});
+		validator_rw = read_log.__set__('readLogValidator_ts_1', { default: validator_stub });
+		progress = undefined;
+		running = undefined;
+	});
+
+	afterEach(async () => {
+		// Always disconnect so the file watcher/timers are torn down and the operation resolves,
+		// otherwise a leaked fs.watchFile would keep the process (and mocha) alive.
+		if (progress && running) {
+			progress.disconnect();
+			await running;
+		}
+		sandbox.resetHistory();
+		validator_rw();
+		getConfigPath_rw();
+		fs.removeSync(TEST_LOG_DIR);
+	});
+
+	it('emits the existing backlog as `log` events, then resolves on disconnect', async () => {
+		fs.appendFileSync(FULL_LOG_PATH_TEST, line(0, 'info', 'first'));
+		fs.appendFileSync(FULL_LOG_PATH_TEST, line(1, 'warn', 'second'));
+
+		progress = fakeProgress();
+		running = readLogFunction({ operation: 'read_log', log_name: LOG_NAME_TEST, progress });
+
+		const got = await waitFor(() => progress.logs().length >= 2);
+		expect(got, 'backlog entries were emitted').to.be.true;
+
+		const messages = progress.logs().map((l) => l.message);
+		expect(messages).to.include('first');
+		expect(messages).to.include('second');
+		expect(progress.events.every((e) => e.event === 'log')).to.be.true;
+
+		progress.disconnect();
+		await running; // resolves because the tail observed the abort
+	});
+
+	it('tails newly appended lines live', async () => {
+		fs.appendFileSync(FULL_LOG_PATH_TEST, line(0, 'info', 'backlog'));
+
+		progress = fakeProgress();
+		running = readLogFunction({ operation: 'read_log', log_name: LOG_NAME_TEST, progress });
+		expect(await waitFor(() => progress.logs().length >= 1)).to.be.true;
+
+		// Append three lines: the first two are finalized by the following markers and stream out
+		// without waiting on the idle flush.
+		fs.appendFileSync(FULL_LOG_PATH_TEST, line(2, 'info', 'live-a'));
+		fs.appendFileSync(FULL_LOG_PATH_TEST, line(3, 'error', 'live-b'));
+		fs.appendFileSync(FULL_LOG_PATH_TEST, line(4, 'warn', 'live-c'));
+
+		const got = await waitFor(() => {
+			const m = progress.logs().map((l) => l.message);
+			return m.includes('live-a') && m.includes('live-b');
+		});
+		expect(got, 'live-appended lines were tailed').to.be.true;
+	});
+
+	it('flushes a trailing single line once the tail goes idle', async function () {
+		this.timeout(15000);
+		progress = fakeProgress();
+		running = readLogFunction({ operation: 'read_log', log_name: LOG_NAME_TEST, progress });
+		// give the watcher a moment to arm on the empty file
+		await new Promise((r) => setTimeout(r, 100));
+
+		fs.appendFileSync(FULL_LOG_PATH_TEST, line(5, 'info', 'lonely'));
+
+		// No following marker will arrive, so this only shows up after the idle flush fires.
+		const got = await waitFor(() => progress.logs().some((l) => l.message === 'lonely'), { timeout: 6000 });
+		expect(got, 'trailing line flushed on idle').to.be.true;
+	});
+
+	it('applies level and filter to both backlog and live entries', async () => {
+		fs.appendFileSync(FULL_LOG_PATH_TEST, line(0, 'info', 'keep me'));
+		fs.appendFileSync(FULL_LOG_PATH_TEST, line(0, 'error', 'drop me'));
+
+		progress = fakeProgress();
+		running = readLogFunction({
+			operation: 'read_log',
+			log_name: LOG_NAME_TEST,
+			level: 'info',
+			filter: 'keep',
+			progress,
+		});
+
+		expect(await waitFor(() => progress.logs().length >= 1)).to.be.true;
+
+		fs.appendFileSync(FULL_LOG_PATH_TEST, line(2, 'info', 'keep this too'));
+		fs.appendFileSync(FULL_LOG_PATH_TEST, line(3, 'info', 'nope'));
+		fs.appendFileSync(FULL_LOG_PATH_TEST, line(4, 'error', 'keep but wrong level'));
+		// A trailing line whose marker finalizes 'keep this too' / 'nope'.
+		fs.appendFileSync(FULL_LOG_PATH_TEST, line(5, 'info', 'sentinel keep'));
+
+		await waitFor(() => progress.logs().some((l) => l.message === 'keep this too'));
+
+		const messages = progress.logs().map((l) => l.message);
+		expect(messages).to.include('keep me');
+		expect(messages).to.include('keep this too');
+		expect(messages).to.not.include('drop me'); // filtered by `filter`
+		expect(messages).to.not.include('nope'); // filtered by `filter`
+		expect(messages).to.not.include('keep but wrong level'); // filtered by `level`
+	});
+
+	it('caps the backlog at `limit`, keeping the newest', async () => {
+		for (let i = 0; i < 5; i++) {
+			fs.appendFileSync(FULL_LOG_PATH_TEST, line(i, 'info', `entry-${i}`));
+		}
+
+		progress = fakeProgress();
+		running = readLogFunction({ operation: 'read_log', log_name: LOG_NAME_TEST, limit: 2, progress });
+
+		expect(await waitFor(() => progress.logs().length >= 2)).to.be.true;
+		// Give any erroneous extra backlog emits a chance to land before asserting the cap.
+		await new Promise((r) => setTimeout(r, 100));
+
+		const messages = progress.logs().map((l) => l.message);
+		expect(messages).to.eql(['entry-3', 'entry-4']);
+	});
+
+	it('resolves immediately without a disconnect signal (degrades to backlog-only)', async () => {
+		fs.appendFileSync(FULL_LOG_PATH_TEST, line(0, 'info', 'only-backlog'));
+
+		const noSignal = {
+			events: [],
+			emit(event, data) {
+				this.events.push({ event, data });
+			},
+		};
+		// No `signal` → cannot safely tail forever, so it must resolve after the backlog.
+		await readLogFunction({ operation: 'read_log', log_name: LOG_NAME_TEST, progress: noSignal });
+
+		const messages = noSignal.events.filter((e) => e.event === 'log').map((e) => e.data.message);
+		expect(messages).to.eql(['only-backlog']);
+	});
+});

--- a/unitTests/utility/logging/readLogStream.test.js
+++ b/unitTests/utility/logging/readLogStream.test.js
@@ -37,6 +37,50 @@ function fakeProgress() {
 	};
 }
 
+// Variant that models the real ProgressEmitter's backpressure surface: `paused` plus a
+// `whenWritable()` that resolves on `resume()` (what createSSEResponseStream calls on stream
+// 'drain'). `disconnect()` also releases waiters, mirroring the wrapper's teardown, so the
+// tail cannot hang if the client leaves while the producer is awaiting drain.
+function fakeProgressWithBackpressure() {
+	const controller = new AbortController();
+	const events = [];
+	let paused = false;
+	let waiters = [];
+	const release = () => {
+		const pending = waiters;
+		waiters = [];
+		for (const r of pending) r();
+	};
+	return {
+		events,
+		signal: controller.signal,
+		get paused() {
+			return paused;
+		},
+		emit(event, data) {
+			events.push({ event, data });
+		},
+		whenWritable() {
+			return paused ? new Promise((r) => waiters.push(r)) : Promise.resolve();
+		},
+		pause() {
+			paused = true;
+		},
+		resume() {
+			paused = false;
+			release();
+		},
+		disconnect() {
+			controller.abort();
+			paused = false;
+			release();
+		},
+		logs() {
+			return events.filter((e) => e.event === 'log').map((e) => e.data);
+		},
+	};
+}
+
 async function waitFor(predicate, { timeout = 5000, interval = 20 } = {}) {
 	const deadline = Date.now() + timeout;
 	while (Date.now() < deadline) {
@@ -116,6 +160,35 @@ describe('Test readLog SSE tail', () => {
 			return m.includes('live-a') && m.includes('live-b');
 		});
 		assert.ok(got, 'live-appended lines were tailed');
+	});
+
+	it('pauses tailing under backpressure and resumes on drain', async function () {
+		this.timeout(15000);
+		fs.appendFileSync(LOG_PATH, line(0, 'info', 'backlog'));
+
+		progress = fakeProgressWithBackpressure();
+		running = readLog({ operation: 'read_log', log_name: LOG_NAME, progress });
+		assert.ok(await waitFor(() => progress.logs().length >= 1), 'backlog emitted');
+
+		// Simulate a slow client whose write buffer is full, then append new lines.
+		progress.pause();
+		fs.appendFileSync(LOG_PATH, line(2, 'info', 'live-a'));
+		fs.appendFileSync(LOG_PATH, line(3, 'info', 'live-b'));
+		fs.appendFileSync(LOG_PATH, line(4, 'info', 'live-c'));
+
+		const beforeDrain = progress.logs().length;
+		// The pump should reach the appended bytes but park on whenWritable() — emitting nothing
+		// more — rather than buffering frames for a client that cannot keep up.
+		await new Promise((r) => setTimeout(r, 700));
+		assert.strictEqual(progress.logs().length, beforeDrain, 'no entries emitted while paused');
+
+		// Client catches up; the tail resumes and delivers the withheld lines.
+		progress.resume();
+		const got = await waitFor(() => {
+			const m = progress.logs().map((l) => l.message);
+			return m.includes('live-a') && m.includes('live-b');
+		});
+		assert.ok(got, 'withheld entries flow once the stream drains');
 	});
 
 	it('flushes a trailing single line once the tail goes idle', async function () {

--- a/unitTests/utility/logging/readLogStream.test.js
+++ b/unitTests/utility/logging/readLogStream.test.js
@@ -1,28 +1,24 @@
 'use strict';
 
-const env_mangr = require('#src/utility/environment/environmentManager');
-env_mangr.initTestEnvironment();
-const sinon = require('sinon');
-const chai = require('chai');
-const expect = chai.expect;
-const path = require('path');
-const fs = require('fs-extra');
-const rewire = require('rewire');
-const read_log = rewire('#src/utility/logging/readLog');
-const readLogFunction = read_log.default || read_log;
-const hdb_terms = require('#src/utility/hdbTerms');
+const assert = require('node:assert');
+const path = require('node:path');
+const fs = require('node:fs');
+const env = require('#src/utility/environment/environmentManager');
+env.initTestEnvironment();
+const hdbTerms = require('#src/utility/hdbTerms');
+const readLog = require('#src/utility/logging/readLog').default;
 
-const LOG_DIR_TEST = 'testLoggerStream';
-const LOG_NAME_TEST = 'log_stream_unit_test.log';
-const TEST_LOG_DIR = path.join(__dirname, LOG_DIR_TEST);
-const FULL_LOG_PATH_TEST = path.join(TEST_LOG_DIR, LOG_NAME_TEST);
+const TEST_LOG_DIR = path.join(__dirname, 'testLoggerStream');
+const LOG_NAME = 'log_stream_unit_test.log';
+const LOG_PATH = path.join(TEST_LOG_DIR, LOG_NAME);
 
 function line(second, level, message) {
 	return `2023-03-02T21:52:1${second}.688Z [main/0] [${level}]: ${message}\n`;
 }
 
-// Fake ProgressEmitter matching what serverHandlers attaches to request.progress: an `emit`
-// that captures events, plus a `signal` that aborts on client disconnect.
+// Stand-in for the ProgressEmitter serverHandlers attaches to request.progress: an `emit`
+// that captures events plus a `signal` that aborts on client disconnect. Using a plain object
+// (rather than a mock) keeps this test on real modules per AGENTS.md.
 function fakeProgress() {
 	const controller = new AbortController();
 	const events = [];
@@ -51,139 +47,140 @@ async function waitFor(predicate, { timeout = 5000, interval = 20 } = {}) {
 }
 
 describe('Test readLog SSE tail', () => {
-	const sandbox = sinon.createSandbox();
-	const validator_stub = sandbox.stub().returns(null);
-	let validator_rw;
-	let getConfigPath_rw;
+	let originalLogPath;
 	let progress;
 	let running;
 
+	before(() => {
+		// Point read_log's configured log directory at our temp dir via the real environment
+		// manager — getConfigPath reads env.get(LOG_PATH) — so the real validator and reader
+		// operate on our file with no module stubbing.
+		originalLogPath = env.get(hdbTerms.HDB_SETTINGS_NAMES.LOG_PATH_KEY);
+		env.setProperty(hdbTerms.HDB_SETTINGS_NAMES.LOG_PATH_KEY, TEST_LOG_DIR);
+	});
+
+	after(() => {
+		env.setProperty(hdbTerms.HDB_SETTINGS_NAMES.LOG_PATH_KEY, originalLogPath);
+		fs.rmSync(TEST_LOG_DIR, { recursive: true, force: true });
+	});
+
 	beforeEach(() => {
-		fs.mkdirpSync(TEST_LOG_DIR);
-		fs.writeFileSync(FULL_LOG_PATH_TEST, '');
-		getConfigPath_rw = read_log.__set__('configUtils_ts_1', {
-			getConfigPath: (key) => (key === hdb_terms.HDB_SETTINGS_NAMES.LOG_PATH_KEY ? TEST_LOG_DIR : undefined),
-		});
-		validator_rw = read_log.__set__('readLogValidator_ts_1', { default: validator_stub });
+		fs.mkdirSync(TEST_LOG_DIR, { recursive: true });
+		fs.writeFileSync(LOG_PATH, '');
 		progress = undefined;
 		running = undefined;
 	});
 
 	afterEach(async () => {
-		// Always disconnect so the file watcher/timers are torn down and the operation resolves,
-		// otherwise a leaked fs.watchFile would keep the process (and mocha) alive.
+		// Always disconnect so the file watcher/timers are torn down and the operation resolves;
+		// a leaked fs.watchFile would otherwise keep the process (and mocha) alive.
 		if (progress && running) {
 			progress.disconnect();
 			await running;
 		}
-		sandbox.resetHistory();
-		validator_rw();
-		getConfigPath_rw();
-		fs.removeSync(TEST_LOG_DIR);
 	});
 
 	it('emits the existing backlog as `log` events, then resolves on disconnect', async () => {
-		fs.appendFileSync(FULL_LOG_PATH_TEST, line(0, 'info', 'first'));
-		fs.appendFileSync(FULL_LOG_PATH_TEST, line(1, 'warn', 'second'));
+		fs.appendFileSync(LOG_PATH, line(0, 'info', 'first'));
+		fs.appendFileSync(LOG_PATH, line(1, 'warn', 'second'));
 
 		progress = fakeProgress();
-		running = readLogFunction({ operation: 'read_log', log_name: LOG_NAME_TEST, progress });
+		running = readLog({ operation: 'read_log', log_name: LOG_NAME, progress });
 
-		const got = await waitFor(() => progress.logs().length >= 2);
-		expect(got, 'backlog entries were emitted').to.be.true;
+		assert.ok(await waitFor(() => progress.logs().length >= 2), 'backlog entries were emitted');
 
 		const messages = progress.logs().map((l) => l.message);
-		expect(messages).to.include('first');
-		expect(messages).to.include('second');
-		expect(progress.events.every((e) => e.event === 'log')).to.be.true;
+		assert.ok(messages.includes('first'));
+		assert.ok(messages.includes('second'));
+		assert.ok(progress.events.every((e) => e.event === 'log'));
 
 		progress.disconnect();
 		await running; // resolves because the tail observed the abort
 	});
 
 	it('tails newly appended lines live', async () => {
-		fs.appendFileSync(FULL_LOG_PATH_TEST, line(0, 'info', 'backlog'));
+		fs.appendFileSync(LOG_PATH, line(0, 'info', 'backlog'));
 
 		progress = fakeProgress();
-		running = readLogFunction({ operation: 'read_log', log_name: LOG_NAME_TEST, progress });
-		expect(await waitFor(() => progress.logs().length >= 1)).to.be.true;
+		running = readLog({ operation: 'read_log', log_name: LOG_NAME, progress });
+		assert.ok(await waitFor(() => progress.logs().length >= 1));
 
 		// Append three lines: the first two are finalized by the following markers and stream out
 		// without waiting on the idle flush.
-		fs.appendFileSync(FULL_LOG_PATH_TEST, line(2, 'info', 'live-a'));
-		fs.appendFileSync(FULL_LOG_PATH_TEST, line(3, 'error', 'live-b'));
-		fs.appendFileSync(FULL_LOG_PATH_TEST, line(4, 'warn', 'live-c'));
+		fs.appendFileSync(LOG_PATH, line(2, 'info', 'live-a'));
+		fs.appendFileSync(LOG_PATH, line(3, 'error', 'live-b'));
+		fs.appendFileSync(LOG_PATH, line(4, 'warn', 'live-c'));
 
 		const got = await waitFor(() => {
 			const m = progress.logs().map((l) => l.message);
 			return m.includes('live-a') && m.includes('live-b');
 		});
-		expect(got, 'live-appended lines were tailed').to.be.true;
+		assert.ok(got, 'live-appended lines were tailed');
 	});
 
 	it('flushes a trailing single line once the tail goes idle', async function () {
 		this.timeout(15000);
 		progress = fakeProgress();
-		running = readLogFunction({ operation: 'read_log', log_name: LOG_NAME_TEST, progress });
+		running = readLog({ operation: 'read_log', log_name: LOG_NAME, progress });
 		// give the watcher a moment to arm on the empty file
 		await new Promise((r) => setTimeout(r, 100));
 
-		fs.appendFileSync(FULL_LOG_PATH_TEST, line(5, 'info', 'lonely'));
+		fs.appendFileSync(LOG_PATH, line(5, 'info', 'lonely'));
 
 		// No following marker will arrive, so this only shows up after the idle flush fires.
 		const got = await waitFor(() => progress.logs().some((l) => l.message === 'lonely'), { timeout: 6000 });
-		expect(got, 'trailing line flushed on idle').to.be.true;
+		assert.ok(got, 'trailing line flushed on idle');
 	});
 
 	it('applies level and filter to both backlog and live entries', async () => {
-		fs.appendFileSync(FULL_LOG_PATH_TEST, line(0, 'info', 'keep me'));
-		fs.appendFileSync(FULL_LOG_PATH_TEST, line(0, 'error', 'drop me'));
+		fs.appendFileSync(LOG_PATH, line(0, 'info', 'keep me'));
+		fs.appendFileSync(LOG_PATH, line(0, 'error', 'drop me'));
 
 		progress = fakeProgress();
-		running = readLogFunction({
+		running = readLog({
 			operation: 'read_log',
-			log_name: LOG_NAME_TEST,
+			log_name: LOG_NAME,
 			level: 'info',
 			filter: 'keep',
 			progress,
 		});
 
-		expect(await waitFor(() => progress.logs().length >= 1)).to.be.true;
+		assert.ok(await waitFor(() => progress.logs().length >= 1));
 
-		fs.appendFileSync(FULL_LOG_PATH_TEST, line(2, 'info', 'keep this too'));
-		fs.appendFileSync(FULL_LOG_PATH_TEST, line(3, 'info', 'nope'));
-		fs.appendFileSync(FULL_LOG_PATH_TEST, line(4, 'error', 'keep but wrong level'));
+		fs.appendFileSync(LOG_PATH, line(2, 'info', 'keep this too'));
+		fs.appendFileSync(LOG_PATH, line(3, 'info', 'nope'));
+		fs.appendFileSync(LOG_PATH, line(4, 'error', 'keep but wrong level'));
 		// A trailing line whose marker finalizes 'keep this too' / 'nope'.
-		fs.appendFileSync(FULL_LOG_PATH_TEST, line(5, 'info', 'sentinel keep'));
+		fs.appendFileSync(LOG_PATH, line(5, 'info', 'sentinel keep'));
 
 		await waitFor(() => progress.logs().some((l) => l.message === 'keep this too'));
 
 		const messages = progress.logs().map((l) => l.message);
-		expect(messages).to.include('keep me');
-		expect(messages).to.include('keep this too');
-		expect(messages).to.not.include('drop me'); // filtered by `filter`
-		expect(messages).to.not.include('nope'); // filtered by `filter`
-		expect(messages).to.not.include('keep but wrong level'); // filtered by `level`
+		assert.ok(messages.includes('keep me'));
+		assert.ok(messages.includes('keep this too'));
+		assert.ok(!messages.includes('drop me'), 'filtered by `filter`');
+		assert.ok(!messages.includes('nope'), 'filtered by `filter`');
+		assert.ok(!messages.includes('keep but wrong level'), 'filtered by `level`');
 	});
 
 	it('caps the backlog at `limit`, keeping the newest', async () => {
 		for (let i = 0; i < 5; i++) {
-			fs.appendFileSync(FULL_LOG_PATH_TEST, line(i, 'info', `entry-${i}`));
+			fs.appendFileSync(LOG_PATH, line(i, 'info', `entry-${i}`));
 		}
 
 		progress = fakeProgress();
-		running = readLogFunction({ operation: 'read_log', log_name: LOG_NAME_TEST, limit: 2, progress });
+		running = readLog({ operation: 'read_log', log_name: LOG_NAME, limit: 2, progress });
 
-		expect(await waitFor(() => progress.logs().length >= 2)).to.be.true;
+		assert.ok(await waitFor(() => progress.logs().length >= 2));
 		// Give any erroneous extra backlog emits a chance to land before asserting the cap.
 		await new Promise((r) => setTimeout(r, 100));
 
 		const messages = progress.logs().map((l) => l.message);
-		expect(messages).to.eql(['entry-3', 'entry-4']);
+		assert.deepStrictEqual(messages, ['entry-3', 'entry-4']);
 	});
 
 	it('resolves immediately without a disconnect signal (degrades to backlog-only)', async () => {
-		fs.appendFileSync(FULL_LOG_PATH_TEST, line(0, 'info', 'only-backlog'));
+		fs.appendFileSync(LOG_PATH, line(0, 'info', 'only-backlog'));
 
 		const noSignal = {
 			events: [],
@@ -192,9 +189,9 @@ describe('Test readLog SSE tail', () => {
 			},
 		};
 		// No `signal` → cannot safely tail forever, so it must resolve after the backlog.
-		await readLogFunction({ operation: 'read_log', log_name: LOG_NAME_TEST, progress: noSignal });
+		await readLog({ operation: 'read_log', log_name: LOG_NAME, progress: noSignal });
 
 		const messages = noSignal.events.filter((e) => e.event === 'log').map((e) => e.data.message);
-		expect(messages).to.eql(['only-backlog']);
+		assert.deepStrictEqual(messages, ['only-backlog']);
 	});
 });

--- a/unitTests/utility/logging/readLogStream.test.js
+++ b/unitTests/utility/logging/readLogStream.test.js
@@ -191,18 +191,47 @@ describe('Test readLog SSE tail', () => {
 		assert.ok(got, 'withheld entries flow once the stream drains');
 	});
 
-	it('flushes a trailing single line once the tail goes idle', async function () {
+	it('withholds a trailing entry until the next line delimits it (no partial flush)', async () => {
+		fs.appendFileSync(LOG_PATH, line(0, 'info', 'backlog'));
+		progress = fakeProgress();
+		running = readLog({ operation: 'read_log', log_name: LOG_NAME, progress });
+		assert.ok(await waitFor(() => progress.logs().length >= 1), 'backlog emitted');
+
+		const afterBacklog = progress.logs().length;
+		// A single new line has no following marker yet — it must NOT be emitted. A multi-line
+		// message could still be mid-write; flushing early would risk a truncated/split entry.
+		fs.appendFileSync(LOG_PATH, line(2, 'info', 'pending-line'));
+		await new Promise((r) => setTimeout(r, 700));
+		assert.strictEqual(progress.logs().length, afterBacklog, 'trailing line withheld until delimited');
+
+		// The next line delimits it; now the previously-pending line is emitted.
+		fs.appendFileSync(LOG_PATH, line(3, 'info', 'delimiter'));
+		assert.ok(
+			await waitFor(() => progress.logs().some((l) => l.message === 'pending-line')),
+			'previously-pending line emitted once the next marker arrives'
+		);
+	});
+
+	it('preserves a multi-byte character split across poll windows', async function () {
 		this.timeout(15000);
 		progress = fakeProgress();
 		running = readLog({ operation: 'read_log', log_name: LOG_NAME, progress });
-		// give the watcher a moment to arm on the empty file
-		await new Promise((r) => setTimeout(r, 100));
+		await new Promise((r) => setTimeout(r, 100)); // arm the watcher on the empty file
 
-		fs.appendFileSync(LOG_PATH, line(5, 'info', 'lonely'));
+		// Split a 3-byte character (日) across two appends separated by a poll, so the tail's
+		// first read ends mid-character. A per-poll decoder reset would corrupt it to U+FFFD.
+		const kanji = Buffer.from('日', 'utf8'); // 3 bytes: E6 97 A5
+		const head = Buffer.concat([Buffer.from('2023-03-02T21:52:12.688Z [main/0] [info]: x'), kanji.subarray(0, 1)]);
+		const rest = Buffer.concat([kanji.subarray(1), Buffer.from('y\n')]);
+		fs.appendFileSync(LOG_PATH, head);
+		await new Promise((r) => setTimeout(r, 400)); // let a poll read the partial character
+		fs.appendFileSync(LOG_PATH, rest);
+		fs.appendFileSync(LOG_PATH, line(3, 'info', 'delimiter')); // marker finalizes the entry
 
-		// No following marker will arrive, so this only shows up after the idle flush fires.
-		const got = await waitFor(() => progress.logs().some((l) => l.message === 'lonely'), { timeout: 6000 });
-		assert.ok(got, 'trailing line flushed on idle');
+		assert.ok(
+			await waitFor(() => progress.logs().some((l) => l.message === 'x日y')),
+			'multi-byte character reassembled intact across the poll boundary'
+		);
 	});
 
 	it('applies level and filter to both backlog and live entries', async () => {

--- a/unitTests/utility/logging/readLogStream.test.js
+++ b/unitTests/utility/logging/readLogStream.test.js
@@ -127,6 +127,9 @@ describe('Test readLog SSE tail', () => {
 	it('emits the existing backlog as `log` events, then resolves on disconnect', async () => {
 		fs.appendFileSync(LOG_PATH, line(0, 'info', 'first'));
 		fs.appendFileSync(LOG_PATH, line(1, 'warn', 'second'));
+		// The newest line stays pending until a following marker delimits it, so add a sentinel
+		// after the entries under test (it won't itself be emitted — it's now the pending one).
+		fs.appendFileSync(LOG_PATH, line(2, 'info', 'sentinel'));
 
 		progress = fakeProgress();
 		running = readLog({ operation: 'read_log', log_name: LOG_NAME, progress });
@@ -143,14 +146,15 @@ describe('Test readLog SSE tail', () => {
 	});
 
 	it('tails newly appended lines live', async () => {
-		fs.appendFileSync(LOG_PATH, line(0, 'info', 'backlog'));
+		// Two backlog lines so the first is delimited (emitted) and the second is pending.
+		fs.appendFileSync(LOG_PATH, line(0, 'info', 'backlog-a'));
+		fs.appendFileSync(LOG_PATH, line(1, 'info', 'backlog-b'));
 
 		progress = fakeProgress();
 		running = readLog({ operation: 'read_log', log_name: LOG_NAME, progress });
 		assert.ok(await waitFor(() => progress.logs().length >= 1));
 
-		// Append three lines: the first two are finalized by the following markers and stream out
-		// without waiting on the idle flush.
+		// Each appended line delimits the previous pending one, so live-a and live-b stream out.
 		fs.appendFileSync(LOG_PATH, line(2, 'info', 'live-a'));
 		fs.appendFileSync(LOG_PATH, line(3, 'error', 'live-b'));
 		fs.appendFileSync(LOG_PATH, line(4, 'warn', 'live-c'));
@@ -164,7 +168,8 @@ describe('Test readLog SSE tail', () => {
 
 	it('pauses tailing under backpressure and resumes on drain', async function () {
 		this.timeout(15000);
-		fs.appendFileSync(LOG_PATH, line(0, 'info', 'backlog'));
+		fs.appendFileSync(LOG_PATH, line(0, 'info', 'backlog-a'));
+		fs.appendFileSync(LOG_PATH, line(1, 'info', 'backlog-b'));
 
 		progress = fakeProgressWithBackpressure();
 		running = readLog({ operation: 'read_log', log_name: LOG_NAME, progress });
@@ -192,17 +197,17 @@ describe('Test readLog SSE tail', () => {
 	});
 
 	it('withholds a trailing entry until the next line delimits it (no partial flush)', async () => {
-		fs.appendFileSync(LOG_PATH, line(0, 'info', 'backlog'));
+		fs.appendFileSync(LOG_PATH, line(0, 'info', 'backlog-a'));
+		fs.appendFileSync(LOG_PATH, line(1, 'info', 'backlog-b'));
 		progress = fakeProgress();
 		running = readLog({ operation: 'read_log', log_name: LOG_NAME, progress });
 		assert.ok(await waitFor(() => progress.logs().length >= 1), 'backlog emitted');
 
-		const afterBacklog = progress.logs().length;
-		// A single new line has no following marker yet — it must NOT be emitted. A multi-line
-		// message could still be mid-write; flushing early would risk a truncated/split entry.
+		// This line has no following marker yet, so it must NOT be emitted — a multi-line message
+		// could still be mid-write, and force-flushing would risk a truncated/split entry.
 		fs.appendFileSync(LOG_PATH, line(2, 'info', 'pending-line'));
 		await new Promise((r) => setTimeout(r, 700));
-		assert.strictEqual(progress.logs().length, afterBacklog, 'trailing line withheld until delimited');
+		assert.ok(!progress.logs().some((l) => l.message === 'pending-line'), 'trailing line withheld until delimited');
 
 		// The next line delimits it; now the previously-pending line is emitted.
 		fs.appendFileSync(LOG_PATH, line(3, 'info', 'delimiter'));
@@ -269,6 +274,8 @@ describe('Test readLog SSE tail', () => {
 		for (let i = 0; i < 5; i++) {
 			fs.appendFileSync(LOG_PATH, line(i, 'info', `entry-${i}`));
 		}
+		// Sentinel delimits entry-4 so it's part of the backlog (and is itself the pending line).
+		fs.appendFileSync(LOG_PATH, line(5, 'info', 'sentinel'));
 
 		progress = fakeProgress();
 		running = readLog({ operation: 'read_log', log_name: LOG_NAME, limit: 2, progress });
@@ -283,6 +290,7 @@ describe('Test readLog SSE tail', () => {
 
 	it('resolves immediately without a disconnect signal (degrades to backlog-only)', async () => {
 		fs.appendFileSync(LOG_PATH, line(0, 'info', 'only-backlog'));
+		fs.appendFileSync(LOG_PATH, line(1, 'info', 'sentinel')); // delimits 'only-backlog'
 
 		const noSignal = {
 			events: [],

--- a/utility/logging/readLog.ts
+++ b/utility/logging/readLog.ts
@@ -656,10 +656,18 @@ function streamLogTail(progress: any, params: TailFilterParams): Promise<void> {
 			encoding: 'utf8',
 		});
 		backlogStream.on('data', (data) => backlogParser.push(String(data)));
-		backlogStream.on('error', () => {});
-		backlogStream.on('close', () => {
+		backlogStream.on('error', (err) =>
+			hdbLogger.warn(`read_log SSE tail: failed to read backlog from ${readLogPath}: ${err?.message ?? err}`)
+		);
+		backlogStream.on('close', async () => {
 			backlogParser.flush();
-			for (const entry of backlogEntries) emit(entry);
+			// Emit the backlog under the same backpressure as the live tail: a slow client with a
+			// large (multi-line) backlog would otherwise get the whole thing buffered at once.
+			for (const entry of backlogEntries) {
+				if (signal?.aborted) break;
+				emit(entry);
+				if (progress.paused) await progress.whenWritable();
+			}
 			startTail();
 		});
 	});

--- a/utility/logging/readLog.ts
+++ b/utility/logging/readLog.ts
@@ -403,9 +403,6 @@ const TAIL_POLL_INTERVAL_MS = 250;
 // can neither seek-read a huge slice into memory nor drive an O(n·limit) eviction on connect.
 // Deeper history is the buffered read_log's job; the tail is about what happens next.
 const MAX_SSE_BACKLOG_ENTRIES = 1000;
-// Push decoded text to the parser in slices this size, yielding to backpressure between them
-// so a big burst in one poll window can't emit unbounded frames ahead of a slow client.
-const TAIL_PUSH_SLICE_BYTES = 65536;
 // A transient delta-read failure is retried this many times (with this delay) before the tail
 // gives up and emits a terminal error so the client can fall back to polling.
 const TAIL_READ_MAX_RETRIES = 3;
@@ -442,11 +439,12 @@ function matchesLogFilters(entry: LogEntry, params: TailFilterParams): boolean {
 	return true;
 }
 
-// Stateful incremental parser: fed appended chunks over time, it emits an entry as soon as
-// the next marker delimits its (possibly multi-line) message. `flush()` finalizes the last
-// pending entry and is only safe at a real end-of-input (the bounded backlog snapshot) — the
-// live tail never flushes, so a partial mid-write entry is never emitted or its continuation
-// discarded; it stays pending until the next marker delimits it.
+// Stateful incremental parser: fed appended chunks over time, it emits an entry only once the
+// next marker delimits its (possibly multi-line) message. It never force-emits a pending
+// entry — the same instance spans the backlog read and the live tail (see streamLogTail), so a
+// line torn across the snapshot boundary stays pending and is completed by the tail's next
+// read rather than emitted truncated with its continuation dropped. `reset()` clears state on
+// log rotation.
 function createIncrementalLogParser(onEntry: (entry: LogEntry) => void) {
 	let remaining = '';
 	let pending: { timestamp: string; tagsString: string } | undefined;
@@ -469,13 +467,6 @@ function createIncrementalLogParser(onEntry: (entry: LogEntry) => void) {
 			}
 			remaining = data.slice(lastPosition);
 		},
-		flush() {
-			if (pending) {
-				onEntry(makeLogEntry(pending.timestamp, pending.tagsString, remaining.trim()));
-				pending = undefined;
-				remaining = '';
-			}
-		},
 		reset() {
 			pending = undefined;
 			remaining = '';
@@ -484,10 +475,16 @@ function createIncrementalLogParser(onEntry: (entry: LogEntry) => void) {
 }
 
 /**
- * Stream the local log over SSE: emit the recent (bounded) backlog, then tail newly-appended
+ * Stream the local log over SSE: replay the recent (bounded) backlog, then tail newly-appended
  * lines until the client disconnects (the emitter's `signal` aborts) — or, if reads fail past
  * retry, emit a terminal `error` so the client falls back to polling instead of watching a
  * silently-stalled "live" stream. Resolves when the tail ends so the SSE wrapper can close.
+ *
+ * A single parser and decoder span both the backlog read and the live tail with no flush at
+ * the seam, so a line (or multi-byte character) torn across the snapshot boundary stays pending
+ * and is completed by the tail's next read — never emitted truncated with its continuation
+ * dropped. (A consequence: the newest backlog line is delivered once the following line
+ * delimits it, matching how the tail delimits every entry.)
  */
 function streamLogTail(progress: any, params: TailFilterParams): Promise<void> {
 	const { readLogPath, limit } = params;
@@ -501,14 +498,26 @@ function streamLogTail(progress: any, params: TailFilterParams): Promise<void> {
 
 		let offset = 0;
 		let pumping = false;
+		let pumpQueued = false;
 		let watching = false;
 		let finished = false;
 		let readFailures = 0;
-		// One decoder for the whole tail: a multi-byte char split across two poll windows is held
-		// until its continuing bytes arrive on the next read, instead of flushed as U+FFFD.
+		// While replaying the backlog, matching entries are collected here (capped) rather than
+		// emitted; once the boundary is passed `backlogPhase` flips and entries emit live.
+		let backlogPhase = true;
+		const backlogEntries: LogEntry[] = [];
+		// One decoder + one parser for the whole session (backlog + tail): a multi-byte char (or a
+		// line) split across the boundary is held/pending and finished by the next read, not
+		// flushed as U+FFFD or truncated. Reset together only on rotation.
 		let decoder = new StringDecoder('utf8');
 		const parser = createIncrementalLogParser((entry) => {
-			if (matchesLogFilters(entry, params)) emit(entry);
+			if (!matchesLogFilters(entry, params)) return;
+			if (backlogPhase) {
+				backlogEntries.push(entry);
+				if (backlogEntries.length > backlogLimit) backlogEntries.shift();
+			} else {
+				emit(entry);
+			}
 		});
 
 		function finish() {
@@ -534,77 +543,80 @@ function streamLogTail(progress: any, params: TailFilterParams): Promise<void> {
 				signal?.addEventListener('abort', onAbort, { once: true });
 			});
 
-		// Push decoded text to the parser in bounded slices, yielding to backpressure between
-		// slices, so a big burst in one poll window can't emit frames faster than a slow client
-		// drains them (the pump's top-level pause only gates whole polls, not within one push).
-		const pushWithBackpressure = async (text: string) => {
-			for (let i = 0; i < text.length; i += TAIL_PUSH_SLICE_BYTES) {
-				if (signal?.aborted) return;
-				parser.push(text.slice(i, i + TAIL_PUSH_SLICE_BYTES));
-				if (progress.paused) await progress.whenWritable();
+		// Stream [offset, end] inclusive through the session decoder + shared parser, decoding and
+		// pushing each fs chunk as it arrives (never materializing the whole delta) and advancing
+		// `offset` per chunk, so peak memory is one chunk and a mid-range error simply resumes from
+		// where it stopped. Yields to backpressure between chunks. Returns false if the read errored.
+		async function drainTo(end: number): Promise<boolean> {
+			const rs = fs.createReadStream(readLogPath, { start: offset, end });
+			try {
+				for await (const chunk of rs) {
+					if (signal?.aborted) {
+						rs.destroy();
+						return true;
+					}
+					parser.push(decoder.write(chunk as Buffer));
+					offset += (chunk as Buffer).length;
+					if (progress.paused) await progress.whenWritable();
+				}
+				return true;
+			} catch (err: any) {
+				hdbLogger.warn(
+					`read_log SSE tail: failed reading ${readLogPath} near offset ${offset}: ${err?.message ?? err}`
+				);
+				return false;
 			}
-		};
+		}
 
-		// Read [start, end] inclusive as raw bytes → Buffer, or `null` if the read errored
-		// (logged). Bytes are only decoded/consumed by the caller on success, so a failed read
-		// leaves the session decoder and `offset` untouched and the range can be retried cleanly.
-		const readRange = (start: number, end: number): Promise<Buffer | null> =>
-			new Promise((res) => {
-				const buffers: Buffer[] = [];
-				const rs = fs.createReadStream(readLogPath, { start, end });
-				rs.on('data', (data) => buffers.push(data as Buffer));
-				rs.on('error', (err) => {
-					hdbLogger.warn(`read_log SSE tail: failed to read ${readLogPath} [${start}, ${end}]: ${err?.message ?? err}`);
-					res(null);
-				});
-				rs.on('close', () => res(Buffer.concat(buffers)));
-			});
-
-		// Single-flight pump: drain all appended bytes into the parser. Re-entrant calls while a
-		// pump is running are no-ops; the loop re-stats each turn and picks up newly-written bytes.
+		// Single-flight pump: drain all appended bytes into the parser. A change arriving while a
+		// pump runs sets `pumpQueued` so the loop runs once more, rather than being missed in the
+		// window between "caught up" and clearing `pumping`.
 		async function pump() {
-			if (pumping) return;
+			if (pumping) {
+				pumpQueued = true;
+				return;
+			}
 			pumping = true;
 			try {
-				while (!signal?.aborted) {
-					let size: number;
-					try {
-						size = (await fs.promises.stat(readLogPath)).size;
-					} catch {
-						break;
-					}
-					if (size < offset) {
-						// Truncation or rotation: restart from the new file and reset decode/parse state.
-						offset = 0;
-						decoder = new StringDecoder('utf8');
-						parser.reset();
-					}
-					if (size <= offset) break;
-					if (progress.paused) {
-						await progress.whenWritable();
-						continue;
-					}
-					const start = offset;
-					const buffer = await readRange(start, size - 1);
-					if (signal?.aborted) break;
-					if (buffer === null) {
-						if (++readFailures > TAIL_READ_MAX_RETRIES) {
-							// Don't leave the client staring at a silently-stalled "live" stream: a
-							// terminal error is its cue to fall back to polling.
-							progress.emit('error', {
-								message: `read_log live tail could not read ${readLogPath} after ${TAIL_READ_MAX_RETRIES} retries`,
-								code: 'READ_LOG_TAIL_READ_ERROR',
-							});
-							finish();
-							return;
+				do {
+					pumpQueued = false;
+					while (!signal?.aborted) {
+						let size: number;
+						try {
+							size = (await fs.promises.stat(readLogPath)).size;
+						} catch {
+							break;
 						}
-						await abortableDelay(TAIL_READ_RETRY_MS);
-						continue; // retry the same range; offset stays put
+						if (size < offset) {
+							// Truncation or rotation: restart from the new file and reset decode/parse state.
+							offset = 0;
+							decoder = new StringDecoder('utf8');
+							parser.reset();
+						}
+						if (size <= offset) break;
+						if (progress.paused) {
+							await progress.whenWritable();
+							continue;
+						}
+						const ok = await drainTo(size - 1);
+						if (signal?.aborted) break;
+						if (!ok) {
+							if (++readFailures > TAIL_READ_MAX_RETRIES) {
+								// Don't leave the client staring at a silently-stalled "live" stream: a
+								// terminal error is its cue to fall back to polling.
+								progress.emit('error', {
+									message: `read_log live tail could not read ${readLogPath} after ${TAIL_READ_MAX_RETRIES} retries`,
+									code: 'READ_LOG_TAIL_READ_ERROR',
+								});
+								finish();
+								return;
+							}
+							await abortableDelay(TAIL_READ_RETRY_MS);
+							continue; // resume from the advanced offset
+						}
+						readFailures = 0;
 					}
-					readFailures = 0;
-					offset = size;
-					await pushWithBackpressure(decoder.write(buffer));
-				}
+				} while (pumpQueued && !signal?.aborted);
 			} finally {
 				pumping = false;
 			}
@@ -615,9 +627,9 @@ function streamLogTail(progress: any, params: TailFilterParams): Promise<void> {
 		}
 
 		const startTail = () => {
-			// `offset` is already the backlog boundary, so the tail picks up strictly from there —
-			// no line dropped or double-sent across the handoff. Without a disconnect signal we
-			// can't safely tail forever; degrade to backlog-only so the client polls instead.
+			// `offset` is already the backlog boundary, so the tail picks up strictly from there.
+			// Without a disconnect signal we can't safely tail forever; degrade to backlog-only so
+			// the client polls instead.
 			if (!signal || signal.aborted) return finish();
 			fs.watchFile(readLogPath, { interval: TAIL_POLL_INTERVAL_MS }, onChange);
 			watching = true;
@@ -626,48 +638,33 @@ function streamLogTail(progress: any, params: TailFilterParams): Promise<void> {
 			void pump();
 		};
 
-		// Emit the backlog first (newest `backlogLimit` matching entries, oldest-first), then tail.
-		let startSize = 0;
-		try {
-			startSize = fs.statSync(readLogPath).size;
-		} catch {
-			startSize = 0;
-		}
-		offset = startSize;
-		if (startSize === 0) {
-			startTail();
-			return;
-		}
-		// Bound the backlog read to roughly the last `backlogLimit` entries so a large log file
-		// can't be pulled into memory all at once (mirrors the buffered path's tail-seek). A
-		// partial first line the seek lands in is dropped by the parser, as in the buffered path.
-		const backlogStart = Math.max(startSize - (backlogLimit + 5) * ESTIMATED_AVERAGE_ENTRY_SIZE, 0);
-		// Keep only the newest `backlogLimit` matching entries as we parse, so even a window denser
-		// than estimated can't grow this array without bound (and the eviction stays O(backlogLimit)).
-		const backlogEntries: LogEntry[] = [];
-		const backlogParser = createIncrementalLogParser((entry) => {
-			if (!matchesLogFilters(entry, params)) return;
-			backlogEntries.push(entry);
-			if (backlogEntries.length > backlogLimit) backlogEntries.shift();
-		});
-		const backlogStream = fs.createReadStream(readLogPath, {
-			start: backlogStart,
-			end: startSize - 1,
-			encoding: 'utf8',
-		});
-		backlogStream.on('data', (data) => backlogParser.push(String(data)));
-		backlogStream.on('error', (err) =>
-			hdbLogger.warn(`read_log SSE tail: failed to read backlog from ${readLogPath}: ${err?.message ?? err}`)
-		);
-		backlogStream.on('close', async () => {
-			backlogParser.flush();
-			// Emit the backlog under the same backpressure as the live tail: a slow client with a
-			// large (multi-line) backlog would otherwise get the whole thing buffered at once.
+		// Replay the backlog through the shared parser/decoder, then tail from the same boundary.
+		(async () => {
+			let startSize = 0;
+			try {
+				startSize = fs.statSync(readLogPath).size;
+			} catch {
+				startSize = 0;
+			}
+			if (startSize > 0) {
+				// Bound the backlog read to roughly the last `backlogLimit` entries so a large log
+				// file can't be seek-read into memory all at once (mirrors the buffered path). A
+				// partial first line the seek lands in is dropped by the parser, as in that path.
+				offset = Math.max(startSize - (backlogLimit + 5) * ESTIMATED_AVERAGE_ENTRY_SIZE, 0);
+				await drainTo(startSize - 1); // collects into backlogEntries; read errors are logged, best-effort
+			}
+			// Hand off to the live tail: flip to emit mode and deliver the collected backlog. The
+			// parser's pending entry (the newest, possibly boundary-torn line) is deliberately left
+			// pending — the tail finishes it — so nothing is emitted truncated.
+			backlogPhase = false;
 			for (const entry of backlogEntries) {
 				if (signal?.aborted) break;
 				emit(entry);
 				if (progress.paused) await progress.whenWritable();
 			}
+			startTail();
+		})().catch((err) => {
+			hdbLogger.warn(`read_log SSE tail: backlog replay failed for ${readLogPath}: ${err?.message ?? err}`);
 			startTail();
 		});
 	});

--- a/utility/logging/readLog.ts
+++ b/utility/logging/readLog.ts
@@ -33,8 +33,10 @@ async function readLog(request: any) {
 			true
 		);
 	}
-	// start pulling logs from the other nodes now so it can be done in parallel
-	let whenReplicatedResponse = server.replication.replicateOperation(request);
+	// Start pulling logs from the other nodes now so it can be done in parallel. A live SSE
+	// tail (below) is local-only and never fans out, so skip replication on that path — the
+	// buffered read still aggregates the cluster for point-in-time queries.
+	let whenReplicatedResponse = isStreamingRequest(request) ? undefined : server.replication.replicateOperation(request);
 
 	const logPath = getConfigPath(hdbTerms.HDB_SETTINGS_NAMES.LOG_PATH_KEY);
 	const rawLogName = request.log_name === undefined ? hdbTerms.LOG_NAMES.HDB : request.log_name;
@@ -57,6 +59,26 @@ async function readLog(request: any) {
 	const start = request.start === undefined ? 0 : request.start;
 	const max = start + limit;
 	const filter = request.filter;
+
+	// SSE mode: the server attached a ProgressEmitter as `request.progress` (see
+	// serverHandlers.js) because the client sent `Accept: text/event-stream`. Instead of a
+	// one-shot array, stream the recent backlog and then tail new lines live until the client
+	// disconnects. Scoped to this node's log file; the buffered path above is what aggregates
+	// the cluster for point-in-time reads.
+	if (isStreamingRequest(request)) {
+		return streamLogTail(request.progress, {
+			readLogPath,
+			level,
+			levelDefined,
+			from,
+			fromDefined,
+			to,
+			toDefined,
+			limit,
+			filter,
+		});
+	}
+
 	let fileStart = 0;
 	if (order === 'desc' && !from && !to) {
 		fileStart = Math.max(fs.statSync(readLogPath).size - (max + 5) * ESTIMATED_AVERAGE_ENTRY_SIZE, 0);
@@ -347,4 +369,232 @@ function insertAscending(value: any, result: any[]) {
 	}
 
 	result.splice(low, 0, value);
+}
+
+interface LogEntry {
+	timestamp: string;
+	thread: string;
+	level: string;
+	tags: string[];
+	message: string;
+}
+
+interface TailFilterParams {
+	readLogPath: string;
+	level: string | undefined;
+	levelDefined: boolean;
+	from: Date | undefined;
+	fromDefined: boolean;
+	to: Date | undefined;
+	toDefined: boolean;
+	limit: number;
+	filter: string | undefined;
+}
+
+// The marker that begins every log line — `TIMESTAMP [thread] [level]...: ` — matching the
+// buffered reader's regex so the two paths parse identically.
+const LOG_ENTRY_MARKER = /(?:^|\n)(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:[\d.]+Z) \[(.+?)]: /g;
+// How often a live tail polls the log file for appended bytes. fs.watchFile is stat-poll
+// based, which is far more robust across platforms and log rotation than fs.watch's rename
+// events; sub-second latency is plenty for a human watching logs.
+const TAIL_POLL_INTERVAL_MS = 250;
+// A trailing entry can't be finalized until the next marker delimits its (possibly
+// multi-line) message, so after this long without new bytes we flush it as-is.
+const TAIL_IDLE_FLUSH_MS = 1000;
+
+function isStreamingRequest(request: any): boolean {
+	return !!request.progress && typeof request.progress.emit === 'function';
+}
+
+function makeLogEntry(timestamp: string, tagsString: string, message: string): LogEntry {
+	const tags = tagsString.split('] [');
+	const thread = tags[0];
+	const level = tags[1];
+	tags.splice(0, 2);
+	return { timestamp, thread, level, tags, message };
+}
+
+function matchesLogFilters(entry: LogEntry, params: TailFilterParams): boolean {
+	const { level, levelDefined, from, fromDefined, to, toDefined, filter } = params;
+	if (filter !== undefined) {
+		const hit = (['timestamp', 'thread', 'level', 'tags', 'message'] as const).some((attr) => {
+			const value = entry[attr];
+			if (Array.isArray(value)) return value.some((v) => v.includes(filter));
+			return typeof value === 'string' && value.includes(filter);
+		});
+		if (!hit) return false;
+	}
+	if (levelDefined && entry.level !== level) return false;
+	if (fromDefined || toDefined) {
+		const when = new Date(entry.timestamp);
+		if (fromDefined && when < (from as Date)) return false;
+		if (toDefined && when > (to as Date)) return false;
+	}
+	return true;
+}
+
+// Parse a complete blob of log text into entries, finalizing the last one — used for the
+// backlog, where we hold the whole snapshot in memory.
+function parseAllLogEntries(text: string): LogEntry[] {
+	const entries: LogEntry[] = [];
+	const reader = new RegExp(LOG_ENTRY_MARKER);
+	let lastPosition = 0;
+	let pending: { timestamp: string; tagsString: string } | undefined;
+	let parsed;
+	while ((parsed = reader.exec(text))) {
+		if (pending) {
+			entries.push(makeLogEntry(pending.timestamp, pending.tagsString, text.slice(lastPosition, parsed.index)));
+		}
+		const [intro, timestamp, tagsString] = parsed;
+		pending = { timestamp, tagsString };
+		lastPosition = parsed.index + intro.length;
+	}
+	if (pending) {
+		entries.push(makeLogEntry(pending.timestamp, pending.tagsString, text.slice(lastPosition).trim()));
+	}
+	return entries;
+}
+
+// Stateful incremental parser for the live tail: fed appended chunks over time, it emits an
+// entry as soon as the next marker delimits its message; `flush()` finalizes the last pending
+// entry (called on idle so a quiet tail still surfaces its newest line).
+function createIncrementalLogParser(onEntry: (entry: LogEntry) => void) {
+	let remaining = '';
+	let pending: { timestamp: string; tagsString: string } | undefined;
+	return {
+		push(text: string) {
+			const data = remaining + text;
+			const reader = new RegExp(LOG_ENTRY_MARKER);
+			let lastPosition = 0;
+			let parsed;
+			while ((parsed = reader.exec(data))) {
+				if (pending) {
+					onEntry(makeLogEntry(pending.timestamp, pending.tagsString, data.slice(lastPosition, parsed.index)));
+				}
+				const [intro, timestamp, tagsString] = parsed;
+				pending = { timestamp, tagsString };
+				lastPosition = parsed.index + intro.length;
+			}
+			remaining = data.slice(lastPosition);
+		},
+		flush() {
+			if (pending) {
+				onEntry(makeLogEntry(pending.timestamp, pending.tagsString, remaining.trim()));
+				pending = undefined;
+				remaining = '';
+			}
+		},
+		reset() {
+			pending = undefined;
+			remaining = '';
+		},
+	};
+}
+
+/**
+ * Stream the local log over SSE: emit the recent backlog, then tail newly-appended lines
+ * until the client disconnects (the emitter's `signal` aborts). Resolves when the tail ends
+ * so the SSE wrapper can close the response.
+ */
+function streamLogTail(progress: any, params: TailFilterParams): Promise<void> {
+	const { readLogPath, limit } = params;
+	const signal: AbortSignal | undefined = progress.signal;
+	const emit = (entry: LogEntry) => progress.emit('log', entry);
+
+	return new Promise<void>((resolve) => {
+		if (signal?.aborted) return resolve();
+
+		let offset = 0;
+		let reading = false;
+		let idleTimer: ReturnType<typeof setTimeout> | undefined;
+		const parser = createIncrementalLogParser((entry) => {
+			if (matchesLogFilters(entry, params)) emit(entry);
+		});
+
+		const scheduleIdleFlush = () => {
+			if (idleTimer) clearTimeout(idleTimer);
+			idleTimer = setTimeout(() => parser.flush(), TAIL_IDLE_FLUSH_MS);
+			idleTimer.unref?.();
+		};
+
+		// Read the newly-appended bytes [offset, size) and feed them to the incremental parser.
+		// A `reading` guard serializes overlapping reads; after each read we re-check the size so
+		// a burst that landed mid-read isn't stranded until the next write.
+		const readDelta = (size: number) => {
+			if (reading) return;
+			if (size < offset) {
+				// Truncation or rotation: start over from the new file's beginning.
+				offset = 0;
+				parser.reset();
+			}
+			if (size <= offset) return;
+			reading = true;
+			const start = offset;
+			const end = size - 1;
+			offset = size;
+			let chunk = '';
+			const deltaStream = fs.createReadStream(readLogPath, { start, end, encoding: 'utf8' });
+			deltaStream.on('data', (data) => {
+				chunk += data;
+			});
+			deltaStream.on('error', () => {
+				reading = false;
+			});
+			deltaStream.on('close', () => {
+				parser.push(chunk);
+				scheduleIdleFlush();
+				reading = false;
+				fs.stat(readLogPath, (err, stats) => {
+					if (!err && stats.size > offset) readDelta(stats.size);
+				});
+			});
+		};
+
+		const onChange = (curr: fs.Stats) => readDelta(curr.size);
+
+		const startTail = () => {
+			// `offset` is already the backlog boundary, so the tail picks up strictly from there —
+			// no line dropped or double-sent across the handoff.
+			// Without a disconnect signal we can't safely tail forever; degrade to backlog-only so
+			// the client falls back to polling for subsequent changes.
+			if (!signal) return resolve();
+			fs.watchFile(readLogPath, { interval: TAIL_POLL_INTERVAL_MS }, onChange);
+			const stop = () => {
+				fs.unwatchFile(readLogPath, onChange);
+				if (idleTimer) clearTimeout(idleTimer);
+				resolve();
+			};
+			if (signal.aborted) return stop();
+			signal.addEventListener('abort', stop, { once: true });
+			// Catch anything appended between the backlog snapshot and arming the watcher; without
+			// this a burst that lands in that window waits for the next write to be noticed.
+			fs.stat(readLogPath, (err, stats) => {
+				if (!err) readDelta(stats.size);
+			});
+		};
+
+		// Emit the backlog first (newest `limit` entries, oldest-first), then begin tailing.
+		let startSize = 0;
+		try {
+			startSize = fs.statSync(readLogPath).size;
+		} catch {
+			startSize = 0;
+		}
+		offset = startSize;
+		if (startSize === 0) {
+			startTail();
+			return;
+		}
+		let backlog = '';
+		const backlogStream = fs.createReadStream(readLogPath, { start: 0, end: startSize - 1, encoding: 'utf8' });
+		backlogStream.on('data', (data) => {
+			backlog += data;
+		});
+		backlogStream.on('error', () => {});
+		backlogStream.on('close', () => {
+			const matched = parseAllLogEntries(backlog).filter((entry) => matchesLogFilters(entry, params));
+			for (const entry of matched.slice(-limit)) emit(entry);
+			startTail();
+		});
+	});
 }

--- a/utility/logging/readLog.ts
+++ b/utility/logging/readLog.ts
@@ -433,38 +433,19 @@ function matchesLogFilters(entry: LogEntry, params: TailFilterParams): boolean {
 	return true;
 }
 
-// Parse a complete blob of log text into entries, finalizing the last one — used for the
-// backlog, where we hold the whole snapshot in memory.
-function parseAllLogEntries(text: string): LogEntry[] {
-	const entries: LogEntry[] = [];
-	const reader = new RegExp(LOG_ENTRY_MARKER);
-	let lastPosition = 0;
-	let pending: { timestamp: string; tagsString: string } | undefined;
-	let parsed;
-	while ((parsed = reader.exec(text))) {
-		if (pending) {
-			entries.push(makeLogEntry(pending.timestamp, pending.tagsString, text.slice(lastPosition, parsed.index)));
-		}
-		const [intro, timestamp, tagsString] = parsed;
-		pending = { timestamp, tagsString };
-		lastPosition = parsed.index + intro.length;
-	}
-	if (pending) {
-		entries.push(makeLogEntry(pending.timestamp, pending.tagsString, text.slice(lastPosition).trim()));
-	}
-	return entries;
-}
-
-// Stateful incremental parser for the live tail: fed appended chunks over time, it emits an
+// Stateful incremental parser: fed appended chunks over time, it emits an
 // entry as soon as the next marker delimits its message; `flush()` finalizes the last pending
 // entry (called on idle so a quiet tail still surfaces its newest line).
 function createIncrementalLogParser(onEntry: (entry: LogEntry) => void) {
 	let remaining = '';
 	let pending: { timestamp: string; tagsString: string } | undefined;
+	// One RegExp per parser instance. Each push runs `exec` to completion (until null), which
+	// resets lastIndex to 0; we also reset it explicitly at the top of push for robustness.
+	const reader = new RegExp(LOG_ENTRY_MARKER);
 	return {
 		push(text: string) {
 			const data = remaining + text;
-			const reader = new RegExp(LOG_ENTRY_MARKER);
+			reader.lastIndex = 0;
 			let lastPosition = 0;
 			let parsed;
 			while ((parsed = reader.exec(data))) {
@@ -573,7 +554,7 @@ function streamLogTail(progress: any, params: TailFilterParams): Promise<void> {
 			});
 		};
 
-		// Emit the backlog first (newest `limit` entries, oldest-first), then begin tailing.
+		// Emit the backlog first (newest `limit` matching entries, oldest-first), then begin tailing.
 		let startSize = 0;
 		try {
 			startSize = fs.statSync(readLogPath).size;
@@ -585,14 +566,23 @@ function streamLogTail(progress: any, params: TailFilterParams): Promise<void> {
 			startTail();
 			return;
 		}
-		let backlog = '';
-		const backlogStream = fs.createReadStream(readLogPath, { start: 0, end: startSize - 1, encoding: 'utf8' });
-		backlogStream.on('data', (data) => {
-			backlog += data;
+		// Bound the backlog read to roughly the last `limit` entries so a large log file can't be
+		// pulled into memory all at once (mirrors the buffered path's tail-seek). We over-read a
+		// little to avoid clipping, parse it incrementally, filter, and keep the newest `limit`. A
+		// partial first line the seek lands in is dropped by the parser, as in the buffered path.
+		const backlogStart = Math.max(startSize - (limit + 5) * ESTIMATED_AVERAGE_ENTRY_SIZE, 0);
+		const backlogEntries: LogEntry[] = [];
+		const backlogParser = createIncrementalLogParser((entry) => backlogEntries.push(entry));
+		const backlogStream = fs.createReadStream(readLogPath, {
+			start: backlogStart,
+			end: startSize - 1,
+			encoding: 'utf8',
 		});
+		backlogStream.on('data', (data) => backlogParser.push(String(data)));
 		backlogStream.on('error', () => {});
 		backlogStream.on('close', () => {
-			const matched = parseAllLogEntries(backlog).filter((entry) => matchesLogFilters(entry, params));
+			backlogParser.flush();
+			const matched = backlogEntries.filter((entry) => matchesLogFilters(entry, params));
 			for (const entry of matched.slice(-limit)) emit(entry);
 			startTail();
 		});

--- a/utility/logging/readLog.ts
+++ b/utility/logging/readLog.ts
@@ -486,7 +486,7 @@ function streamLogTail(progress: any, params: TailFilterParams): Promise<void> {
 		if (signal?.aborted) return resolve();
 
 		let offset = 0;
-		let reading = false;
+		let pumping = false;
 		let idleTimer: ReturnType<typeof setTimeout> | undefined;
 		const parser = createIncrementalLogParser((entry) => {
 			if (matchesLogFilters(entry, params)) emit(entry);
@@ -498,46 +498,69 @@ function streamLogTail(progress: any, params: TailFilterParams): Promise<void> {
 			idleTimer.unref?.();
 		};
 
-		// Read the newly-appended bytes [offset, size) and feed them to the incremental parser.
-		// A `reading` guard serializes overlapping reads; after each read we re-check the size so
-		// a burst that landed mid-read isn't stranded until the next write.
-		const readDelta = (size: number) => {
-			if (reading) return;
-			if (size < offset) {
-				// Truncation or rotation: start over from the new file's beginning.
-				offset = 0;
-				parser.reset();
-			}
-			if (size <= offset) return;
-			reading = true;
-			const start = offset;
-			const end = size - 1;
-			offset = size;
-			let chunk = '';
-			const deltaStream = fs.createReadStream(readLogPath, { start, end, encoding: 'utf8' });
-			deltaStream.on('data', (data) => {
-				chunk += data;
-			});
-			deltaStream.on('error', () => {
-				reading = false;
-			});
-			deltaStream.on('close', () => {
-				parser.push(chunk);
-				scheduleIdleFlush();
-				reading = false;
-				fs.stat(readLogPath, (err, stats) => {
-					if (!err && stats.size > offset) readDelta(stats.size);
+		// Read [start, end] inclusive, resolving to the decoded text — or `null` if the read
+		// errored. On error we log and leave `offset` unadvanced so the pump retries that exact
+		// range on the next change, rather than silently skipping it forever.
+		const readRange = (start: number, end: number): Promise<string | null> =>
+			new Promise((res) => {
+				let chunk = '';
+				const rs = fs.createReadStream(readLogPath, { start, end, encoding: 'utf8' });
+				rs.on('data', (data) => {
+					chunk += data;
 				});
+				rs.on('error', (err) => {
+					hdbLogger.warn(`read_log SSE tail: failed to read ${readLogPath} [${start}, ${end}]: ${err?.message ?? err}`);
+					res(null);
+				});
+				rs.on('close', () => res(chunk));
 			});
+
+		// Single-flight pump: drain all appended bytes into the parser, pausing on backpressure so
+		// a slow client can't make buffered SSE frames grow without bound. Re-entrant calls while a
+		// pump is running are no-ops; the loop re-stats each turn and picks up newly-written bytes.
+		const pump = async () => {
+			if (pumping) return;
+			pumping = true;
+			try {
+				while (!signal?.aborted) {
+					let size: number;
+					try {
+						size = (await fs.promises.stat(readLogPath)).size;
+					} catch {
+						break;
+					}
+					if (size < offset) {
+						// Truncation or rotation: start over from the new file's beginning.
+						offset = 0;
+						parser.reset();
+					}
+					if (size <= offset) break;
+					if (progress.paused) {
+						// Client is behind — wait for the stream to drain before emitting more.
+						await progress.whenWritable();
+						continue;
+					}
+					const start = offset;
+					const chunk = await readRange(start, size - 1);
+					if (signal?.aborted) break;
+					if (chunk === null) break; // transient read error: retry same range on next change
+					offset = size;
+					parser.push(chunk);
+					scheduleIdleFlush();
+				}
+			} finally {
+				pumping = false;
+			}
 		};
 
-		const onChange = (curr: fs.Stats) => readDelta(curr.size);
+		const onChange = () => {
+			void pump();
+		};
 
 		const startTail = () => {
 			// `offset` is already the backlog boundary, so the tail picks up strictly from there —
-			// no line dropped or double-sent across the handoff.
-			// Without a disconnect signal we can't safely tail forever; degrade to backlog-only so
-			// the client falls back to polling for subsequent changes.
+			// no line dropped or double-sent across the handoff. Without a disconnect signal we
+			// can't safely tail forever; degrade to backlog-only so the client polls instead.
 			if (!signal) return resolve();
 			fs.watchFile(readLogPath, { interval: TAIL_POLL_INTERVAL_MS }, onChange);
 			const stop = () => {
@@ -547,11 +570,8 @@ function streamLogTail(progress: any, params: TailFilterParams): Promise<void> {
 			};
 			if (signal.aborted) return stop();
 			signal.addEventListener('abort', stop, { once: true });
-			// Catch anything appended between the backlog snapshot and arming the watcher; without
-			// this a burst that lands in that window waits for the next write to be noticed.
-			fs.stat(readLogPath, (err, stats) => {
-				if (!err) readDelta(stats.size);
-			});
+			// Catch anything appended between the backlog snapshot and arming the watcher.
+			void pump();
 		};
 
 		// Emit the backlog first (newest `limit` matching entries, oldest-first), then begin tailing.
@@ -571,8 +591,14 @@ function streamLogTail(progress: any, params: TailFilterParams): Promise<void> {
 		// little to avoid clipping, parse it incrementally, filter, and keep the newest `limit`. A
 		// partial first line the seek lands in is dropped by the parser, as in the buffered path.
 		const backlogStart = Math.max(startSize - (limit + 5) * ESTIMATED_AVERAGE_ENTRY_SIZE, 0);
+		// Keep only the newest `limit` matching entries as we parse, so even a window denser than
+		// estimated can't grow this array without bound.
 		const backlogEntries: LogEntry[] = [];
-		const backlogParser = createIncrementalLogParser((entry) => backlogEntries.push(entry));
+		const backlogParser = createIncrementalLogParser((entry) => {
+			if (!matchesLogFilters(entry, params)) return;
+			backlogEntries.push(entry);
+			if (backlogEntries.length > limit) backlogEntries.shift();
+		});
 		const backlogStream = fs.createReadStream(readLogPath, {
 			start: backlogStart,
 			end: startSize - 1,
@@ -582,8 +608,7 @@ function streamLogTail(progress: any, params: TailFilterParams): Promise<void> {
 		backlogStream.on('error', () => {});
 		backlogStream.on('close', () => {
 			backlogParser.flush();
-			const matched = backlogEntries.filter((entry) => matchesLogFilters(entry, params));
-			for (const entry of matched.slice(-limit)) emit(entry);
+			for (const entry of backlogEntries) emit(entry);
 			startTail();
 		});
 	});

--- a/utility/logging/readLog.ts
+++ b/utility/logging/readLog.ts
@@ -9,6 +9,7 @@ import { once } from 'events';
 import { getConfigPath } from '../../config/configUtils.ts';
 import { handleHDBError, hdbErrors } from '../errors/hdbError.ts';
 import { server } from '../../server/Server.ts';
+import { StringDecoder } from 'string_decoder';
 
 const DEFAULT_READ_LOG_LIMIT = 1000;
 const ESTIMATED_AVERAGE_ENTRY_SIZE = 200;
@@ -398,9 +399,17 @@ const LOG_ENTRY_MARKER = /(?:^|\n)(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:[\d.]+Z) \[(.+?
 // based, which is far more robust across platforms and log rotation than fs.watch's rename
 // events; sub-second latency is plenty for a human watching logs.
 const TAIL_POLL_INTERVAL_MS = 250;
-// A trailing entry can't be finalized until the next marker delimits its (possibly
-// multi-line) message, so after this long without new bytes we flush it as-is.
-const TAIL_IDLE_FLUSH_MS = 1000;
+// Cap the live-tail backlog regardless of a caller-supplied `limit`, so an unbounded `limit`
+// can neither seek-read a huge slice into memory nor drive an O(n·limit) eviction on connect.
+// Deeper history is the buffered read_log's job; the tail is about what happens next.
+const MAX_SSE_BACKLOG_ENTRIES = 1000;
+// Push decoded text to the parser in slices this size, yielding to backpressure between them
+// so a big burst in one poll window can't emit unbounded frames ahead of a slow client.
+const TAIL_PUSH_SLICE_BYTES = 65536;
+// A transient delta-read failure is retried this many times (with this delay) before the tail
+// gives up and emits a terminal error so the client can fall back to polling.
+const TAIL_READ_MAX_RETRIES = 3;
+const TAIL_READ_RETRY_MS = 250;
 
 function isStreamingRequest(request: any): boolean {
 	return !!request.progress && typeof request.progress.emit === 'function';
@@ -433,9 +442,11 @@ function matchesLogFilters(entry: LogEntry, params: TailFilterParams): boolean {
 	return true;
 }
 
-// Stateful incremental parser: fed appended chunks over time, it emits an
-// entry as soon as the next marker delimits its message; `flush()` finalizes the last pending
-// entry (called on idle so a quiet tail still surfaces its newest line).
+// Stateful incremental parser: fed appended chunks over time, it emits an entry as soon as
+// the next marker delimits its (possibly multi-line) message. `flush()` finalizes the last
+// pending entry and is only safe at a real end-of-input (the bounded backlog snapshot) — the
+// live tail never flushes, so a partial mid-write entry is never emitted or its continuation
+// discarded; it stays pending until the next marker delimits it.
 function createIncrementalLogParser(onEntry: (entry: LogEntry) => void) {
 	let remaining = '';
 	let pending: { timestamp: string; tagsString: string } | undefined;
@@ -473,52 +484,85 @@ function createIncrementalLogParser(onEntry: (entry: LogEntry) => void) {
 }
 
 /**
- * Stream the local log over SSE: emit the recent backlog, then tail newly-appended lines
- * until the client disconnects (the emitter's `signal` aborts). Resolves when the tail ends
- * so the SSE wrapper can close the response.
+ * Stream the local log over SSE: emit the recent (bounded) backlog, then tail newly-appended
+ * lines until the client disconnects (the emitter's `signal` aborts) — or, if reads fail past
+ * retry, emit a terminal `error` so the client falls back to polling instead of watching a
+ * silently-stalled "live" stream. Resolves when the tail ends so the SSE wrapper can close.
  */
 function streamLogTail(progress: any, params: TailFilterParams): Promise<void> {
 	const { readLogPath, limit } = params;
 	const signal: AbortSignal | undefined = progress.signal;
 	const emit = (entry: LogEntry) => progress.emit('log', entry);
+	// The tail never shows more backlog than this, whatever `limit` asks for (see the constant).
+	const backlogLimit = Math.min(limit, MAX_SSE_BACKLOG_ENTRIES);
 
 	return new Promise<void>((resolve) => {
 		if (signal?.aborted) return resolve();
 
 		let offset = 0;
 		let pumping = false;
-		let idleTimer: ReturnType<typeof setTimeout> | undefined;
+		let watching = false;
+		let finished = false;
+		let readFailures = 0;
+		// One decoder for the whole tail: a multi-byte char split across two poll windows is held
+		// until its continuing bytes arrive on the next read, instead of flushed as U+FFFD.
+		let decoder = new StringDecoder('utf8');
 		const parser = createIncrementalLogParser((entry) => {
 			if (matchesLogFilters(entry, params)) emit(entry);
 		});
 
-		const scheduleIdleFlush = () => {
-			if (idleTimer) clearTimeout(idleTimer);
-			idleTimer = setTimeout(() => parser.flush(), TAIL_IDLE_FLUSH_MS);
-			idleTimer.unref?.();
+		function finish() {
+			if (finished) return;
+			finished = true;
+			if (watching) fs.unwatchFile(readLogPath, onChange);
+			resolve();
+		}
+
+		// Wait `ms`, or resolve early on disconnect so a retry delay never outlives the connection.
+		const abortableDelay = (ms: number) =>
+			new Promise<void>((res) => {
+				if (signal?.aborted) return res();
+				const timer = setTimeout(() => {
+					signal?.removeEventListener('abort', onAbort);
+					res();
+				}, ms);
+				timer.unref?.();
+				const onAbort = () => {
+					clearTimeout(timer);
+					res();
+				};
+				signal?.addEventListener('abort', onAbort, { once: true });
+			});
+
+		// Push decoded text to the parser in bounded slices, yielding to backpressure between
+		// slices, so a big burst in one poll window can't emit frames faster than a slow client
+		// drains them (the pump's top-level pause only gates whole polls, not within one push).
+		const pushWithBackpressure = async (text: string) => {
+			for (let i = 0; i < text.length; i += TAIL_PUSH_SLICE_BYTES) {
+				if (signal?.aborted) return;
+				parser.push(text.slice(i, i + TAIL_PUSH_SLICE_BYTES));
+				if (progress.paused) await progress.whenWritable();
+			}
 		};
 
-		// Read [start, end] inclusive, resolving to the decoded text — or `null` if the read
-		// errored. On error we log and leave `offset` unadvanced so the pump retries that exact
-		// range on the next change, rather than silently skipping it forever.
-		const readRange = (start: number, end: number): Promise<string | null> =>
+		// Read [start, end] inclusive as raw bytes → Buffer, or `null` if the read errored
+		// (logged). Bytes are only decoded/consumed by the caller on success, so a failed read
+		// leaves the session decoder and `offset` untouched and the range can be retried cleanly.
+		const readRange = (start: number, end: number): Promise<Buffer | null> =>
 			new Promise((res) => {
-				let chunk = '';
-				const rs = fs.createReadStream(readLogPath, { start, end, encoding: 'utf8' });
-				rs.on('data', (data) => {
-					chunk += data;
-				});
+				const buffers: Buffer[] = [];
+				const rs = fs.createReadStream(readLogPath, { start, end });
+				rs.on('data', (data) => buffers.push(data as Buffer));
 				rs.on('error', (err) => {
 					hdbLogger.warn(`read_log SSE tail: failed to read ${readLogPath} [${start}, ${end}]: ${err?.message ?? err}`);
 					res(null);
 				});
-				rs.on('close', () => res(chunk));
+				rs.on('close', () => res(Buffer.concat(buffers)));
 			});
 
-		// Single-flight pump: drain all appended bytes into the parser, pausing on backpressure so
-		// a slow client can't make buffered SSE frames grow without bound. Re-entrant calls while a
+		// Single-flight pump: drain all appended bytes into the parser. Re-entrant calls while a
 		// pump is running are no-ops; the loop re-stats each turn and picks up newly-written bytes.
-		const pump = async () => {
+		async function pump() {
 			if (pumping) return;
 			pumping = true;
 			try {
@@ -530,51 +574,59 @@ function streamLogTail(progress: any, params: TailFilterParams): Promise<void> {
 						break;
 					}
 					if (size < offset) {
-						// Truncation or rotation: start over from the new file's beginning.
+						// Truncation or rotation: restart from the new file and reset decode/parse state.
 						offset = 0;
+						decoder = new StringDecoder('utf8');
 						parser.reset();
 					}
 					if (size <= offset) break;
 					if (progress.paused) {
-						// Client is behind — wait for the stream to drain before emitting more.
 						await progress.whenWritable();
 						continue;
 					}
 					const start = offset;
-					const chunk = await readRange(start, size - 1);
+					const buffer = await readRange(start, size - 1);
 					if (signal?.aborted) break;
-					if (chunk === null) break; // transient read error: retry same range on next change
+					if (buffer === null) {
+						if (++readFailures > TAIL_READ_MAX_RETRIES) {
+							// Don't leave the client staring at a silently-stalled "live" stream: a
+							// terminal error is its cue to fall back to polling.
+							progress.emit('error', {
+								message: `read_log live tail could not read ${readLogPath} after ${TAIL_READ_MAX_RETRIES} retries`,
+								code: 'READ_LOG_TAIL_READ_ERROR',
+							});
+							finish();
+							return;
+						}
+						await abortableDelay(TAIL_READ_RETRY_MS);
+						continue; // retry the same range; offset stays put
+					}
+					readFailures = 0;
 					offset = size;
-					parser.push(chunk);
-					scheduleIdleFlush();
+					await pushWithBackpressure(decoder.write(buffer));
 				}
 			} finally {
 				pumping = false;
 			}
-		};
+		}
 
-		const onChange = () => {
+		function onChange() {
 			void pump();
-		};
+		}
 
 		const startTail = () => {
 			// `offset` is already the backlog boundary, so the tail picks up strictly from there —
 			// no line dropped or double-sent across the handoff. Without a disconnect signal we
 			// can't safely tail forever; degrade to backlog-only so the client polls instead.
-			if (!signal) return resolve();
+			if (!signal || signal.aborted) return finish();
 			fs.watchFile(readLogPath, { interval: TAIL_POLL_INTERVAL_MS }, onChange);
-			const stop = () => {
-				fs.unwatchFile(readLogPath, onChange);
-				if (idleTimer) clearTimeout(idleTimer);
-				resolve();
-			};
-			if (signal.aborted) return stop();
-			signal.addEventListener('abort', stop, { once: true });
+			watching = true;
+			signal.addEventListener('abort', finish, { once: true });
 			// Catch anything appended between the backlog snapshot and arming the watcher.
 			void pump();
 		};
 
-		// Emit the backlog first (newest `limit` matching entries, oldest-first), then begin tailing.
+		// Emit the backlog first (newest `backlogLimit` matching entries, oldest-first), then tail.
 		let startSize = 0;
 		try {
 			startSize = fs.statSync(readLogPath).size;
@@ -586,18 +638,17 @@ function streamLogTail(progress: any, params: TailFilterParams): Promise<void> {
 			startTail();
 			return;
 		}
-		// Bound the backlog read to roughly the last `limit` entries so a large log file can't be
-		// pulled into memory all at once (mirrors the buffered path's tail-seek). We over-read a
-		// little to avoid clipping, parse it incrementally, filter, and keep the newest `limit`. A
+		// Bound the backlog read to roughly the last `backlogLimit` entries so a large log file
+		// can't be pulled into memory all at once (mirrors the buffered path's tail-seek). A
 		// partial first line the seek lands in is dropped by the parser, as in the buffered path.
-		const backlogStart = Math.max(startSize - (limit + 5) * ESTIMATED_AVERAGE_ENTRY_SIZE, 0);
-		// Keep only the newest `limit` matching entries as we parse, so even a window denser than
-		// estimated can't grow this array without bound.
+		const backlogStart = Math.max(startSize - (backlogLimit + 5) * ESTIMATED_AVERAGE_ENTRY_SIZE, 0);
+		// Keep only the newest `backlogLimit` matching entries as we parse, so even a window denser
+		// than estimated can't grow this array without bound (and the eviction stays O(backlogLimit)).
 		const backlogEntries: LogEntry[] = [];
 		const backlogParser = createIncrementalLogParser((entry) => {
 			if (!matchesLogFilters(entry, params)) return;
 			backlogEntries.push(entry);
-			if (backlogEntries.length > limit) backlogEntries.shift();
+			if (backlogEntries.length > backlogLimit) backlogEntries.shift();
 		});
 		const backlogStream = fs.createReadStream(readLogPath, {
 			start: backlogStart,


### PR DESCRIPTION
## What

`read_log` now supports `Accept: text/event-stream`. Instead of a one-shot array, it emits the recent backlog as `log` events and then **tails newly-appended lines live** until the client disconnects — so clients can subscribe to log changes instead of polling.

This is the backend half of the studio "Use SSE for Logs" work; it pairs with the client PR **HarperFast/studio#1425**, which consumes these `log` events (and falls back to polling when streaming isn't available).

## How

Builds on the existing operation-SSE plumbing (`ProgressEmitter` + `createSSEResponseStream`), the same path `deploy_component` / `get_deployment` use.

- **`serverHandlers.js`** — add `READ_LOG` to `SSE_PROGRESS_OPERATIONS`. When the client sends `Accept: text/event-stream`, the handler attaches a `ProgressEmitter` as `req.body.progress` and streams the response; non-SSE callers are unaffected (`progress` is undefined → the historical array path).
- **`progressEmitter.ts`** — expose an `AbortSignal` on the emitter that aborts when the client disconnects (`createSSEResponseStream` owns the controller and aborts in its existing `cleanup`). `deploy_component` / `get_deployment` stream a *bounded* run and end on their own, so they ignore the signal and are unchanged. An *open-ended* operation like the log tail reads it to stop and resolve instead of running until process exit.
- **`readLog.ts`** — when `request.progress` is set:
  1. Emit the backlog: the newest `limit` entries (filtered by `level` / `from` / `to` / `filter`), oldest-first.
  2. Tail the file with `fs.watchFile` (stat-poll based — robust across platforms and log rotation, unlike `fs.watch` rename events), parsing appended bytes incrementally with the same marker regex as the buffered reader and applying the same filters, until the abort signal fires. A trailing (possibly multi-line) entry is flushed after a short idle so a quiet tail still surfaces its newest line.

  The buffered (non-SSE) path is **untouched**. The tail is **local-node only** — a live subscription is not fanned out to peers; the buffered path still aggregates the cluster for point-in-time reads. Replication is skipped on the SSE path.

## Wire format

Each entry is one SSE record: `event: log` + `data: {"timestamp","thread","level","tags","message"}`. No new request param — streaming is negotiated purely via the `Accept` header + the whitelist, matching the deploy precedent and the studio client.

## Testing

- New `unitTests/utility/logging/readLogStream.test.js` (6 cases): backlog emission + resolve-on-disconnect, live tailing of appended lines, idle-flush of a trailing line, `level`/`filter` applied to both backlog and live, backlog capped at `limit` (newest kept), and no-signal degrade-to-backlog.
- `test:unit:logging` (55 passing) and the `progressEmitter` / `serverHandlers` unit tests still pass; `tsc` build, `oxlint --deny-warnings`, and `prettier` are clean.

## Notes / follow-ups

- Cluster-wide live tail (fanning the subscription out to peers) is intentionally out of scope here; the buffered `read_log` remains the cluster aggregate.
- On log rotation/truncation the tail resets to the new file's start (best-effort); it does not attempt to stitch across the rotated file.