### PR TITLE
MCP: accept missing MCP-Protocol-Version as the session's negotiated version

### DIFF
--- a/components/mcp/transport.ts
+++ b/components/mcp/transport.ts
@@ -25,12 +25,7 @@ import {
 	type JsonRpcId,
 	type JsonRpcMessage,
 } from './jsonrpc.ts';
-import {
-	handleInitialize,
-	handleInitialized,
-	PROTOCOL_VERSION_BACKCOMPAT,
-	SUPPORTED_PROTOCOL_VERSIONS,
-} from './lifecycle.ts';
+import { handleInitialize, handleInitialized, SUPPORTED_PROTOCOL_VERSIONS } from './lifecycle.ts';
 import { emitAuditEntry } from './audit.ts';
 import { emitMcpLogToSession, isValidMcpLogLevel, setSessionLogLevel } from './logging.ts';
 import { decodeCursor } from './pagination.ts';
@@ -1025,15 +1020,22 @@ function validateProtocolHeader(
 	headerValue: string | undefined,
 	sessionVersion: string
 ): { ok: true } | { ok: false; reason: string } {
-	// Per spec compatibility rule: missing header is treated as 2025-03-26.
-	const effective = headerValue ?? PROTOCOL_VERSION_BACKCOMPAT;
-	if (!SUPPORTED_PROTOCOL_VERSIONS.includes(effective as (typeof SUPPORTED_PROTOCOL_VERSIONS)[number])) {
-		return { ok: false, reason: `unsupported MCP-Protocol-Version: ${effective}` };
+	// A missing header is accepted as the session's own negotiated version
+	// (#1611). The spec's assume-2025-03-26 compatibility rule exists for
+	// clients that predate the header entirely; an established session already
+	// IS the version authority, and assuming the backcompat version here made
+	// every headerless request on a 2025-06-18 session fail the mismatch check
+	// below — needlessly rejecting common clients that only send the header on
+	// some requests. A header that IS present must still name a supported
+	// version and match the negotiated one.
+	if (headerValue === undefined) return { ok: true };
+	if (!SUPPORTED_PROTOCOL_VERSIONS.includes(headerValue as (typeof SUPPORTED_PROTOCOL_VERSIONS)[number])) {
+		return { ok: false, reason: `unsupported MCP-Protocol-Version: ${headerValue}` };
 	}
-	if (effective !== sessionVersion) {
+	if (headerValue !== sessionVersion) {
 		return {
 			ok: false,
-			reason: `MCP-Protocol-Version mismatch: session negotiated ${sessionVersion}, request sent ${effective}`,
+			reason: `MCP-Protocol-Version mismatch: session negotiated ${sessionVersion}, request sent ${headerValue}`,
 		};
 	}
 	return { ok: true };

--- a/unitTests/components/mcp/transport.test.js
+++ b/unitTests/components/mcp/transport.test.js
@@ -197,16 +197,29 @@ describe('mcp/transport', () => {
 			assert.match(res.jsonBody.error.message, /mismatch/);
 		});
 
-		it('treats missing MCP-Protocol-Version as 2025-03-26 (spec compatibility rule)', async () => {
-			// Session is on 2025-06-18 from initialize above, so missing header
-			// (treated as 2025-03-26) should mismatch.
+		it('accepts a missing MCP-Protocol-Version as the session-negotiated version (#1611)', async () => {
+			// Session negotiated 2025-06-18 via initialize; the established session
+			// is the version authority, so a headerless request must NOT be
+			// rejected as a 2025-03-26 mismatch.
 			const res = await handleMcpRequest(
 				makeReq({
 					body: jsonRpc(2, 'tools/list'),
 					headers: { 'mcp-session-id': sessionId },
 				})
 			);
-			assert.equal(res.status, 400);
+			assert.equal(res.status, 200);
+			assert.ok(res.jsonBody.result, `tools/list succeeded: ${JSON.stringify(res.jsonBody)}`);
+		});
+
+		it('accepts a headerless GET SSE open on an established session (#1611)', async () => {
+			const res = await handleMcpRequest(
+				makeReq({
+					method: 'GET',
+					headers: { 'mcp-session-id': sessionId, 'accept': 'text/event-stream' },
+				})
+			);
+			assert.equal(res.status, 200, `SSE open succeeded: ${res.status}`);
+			assert.ok(res.sseIterable, 'SSE stream returned');
 		});
 
 		it('accepts a matching MCP-Protocol-Version and returns Method-not-found for unknown methods', async () => {


### PR DESCRIPTION
Fixes #1611 (as repurposed after investigation — both originally-filed items were verified unreproducible/stale on 5.1.17; see the issue comment with runtime evidence).

## Summary

Requests on an established session that omit `MCP-Protocol-Version` were treated as `2025-03-26` (the spec's backcompat assumption) and then failed the negotiated-version check — so any client that negotiated `2025-06-18` but doesn't send the header on every request got `400 MCP-Protocol-Version mismatch`. The session record already knows the negotiated version, so a missing header now validates as that version. A header that IS present must still name a supported version and match the negotiated one (both still 400).

One conditional in `validateProtocolHeader` (covers both call sites: POST dispatch and GET SSE open); `initialize` never validated the header and is unchanged.

**Spec posture** (flagging for review): the assume-2025-03-26 rule is a SHOULD aimed at clients predating the header; such clients negotiate 2025-03-26 anyway, so deferring to the session version is equivalent for them and stops penalizing modern clients that violate the MUST-send-header rule on non-critical requests. No downgrade risk — the authority is the server-side session record, not anything an attacker can strip in transit.

## Testing

Flipped the unit test that asserted the 400, added a headerless GET SSE case; verified at runtime on a live instance (headerless `tools/list` on a 2025-06-18 session → 200; `2025-03-26` header on the same session → 400; garbage version → 400). No docs companion: the docs don't document the header behavior.

_Generated by an LLM (Claude Fable 5); cross-reviewed by Codex (no findings) and Gemini (no findings; confirmed both call sites, the empty-string-header edge, and the no-downgrade posture)._