### PR TITLE
fix(mqtt): close last-will persistence race; give retained-message test more headroom

### DIFF
--- a/server/DurableSubscriptionsSession.ts
+++ b/server/DurableSubscriptionsSession.ts
@@ -126,7 +126,11 @@ export async function getSession({
 	if (will) {
 		will.id = sessionId;
 		will.user = { username: user?.username };
-		getLastWill().put(will);
+		// Must be durably persisted before CONNACK is sent (getSession() resolving is what lets
+		// mqtt.ts send CONNACK). Otherwise a client that connects and then disconnects abruptly
+		// (no DISCONNECT packet) can race ahead of this write: SubscriptionsSession.disconnect()
+		// reads this same record back to publish the will, finds nothing, and silently drops it.
+		await getLastWill().put(will);
 	}
 	if (keepalive) {
 		// keep alive is the interval in seconds that the client will send a ping to the server

--- a/unitTests/apiTests/mqtt-test.mjs
+++ b/unitTests/apiTests/mqtt-test.mjs
@@ -123,6 +123,11 @@ describe('test MQTT connections and commands', function () {
 	});
 
 	it('subscribe to retained/persisted record', async function () {
+		// Retained delivery is async (transaction -> persisted-record read -> serialization ->
+		// setImmediate yield -> socket write -> client message event) and on a loaded CI runner
+		// this has been observed taking well over the previous 8 s budget. Give this test more
+		// room than the suite-level 10 s, same as the QoS=1 reconnect test below.
+		this.timeout(20000);
 		let path = 'VariedProps/' + available_records[1];
 		// Register the message listener before subscribing so a retained message delivered
 		// during the subscribe round-trip can't be missed.
@@ -143,16 +148,16 @@ describe('test MQTT connections and commands', function () {
 		// Await the suback so a subscribe failure surfaces immediately rather than hanging
 		// until the retained-message timeout.
 		await clientV4.subscribeAsync(path);
-		// Retained delivery is async (transaction -> persisted-record read -> serialization ->
-		// setImmediate yield -> socket write -> client message event) and can run after the suback.
-		// On loaded CI runners this routinely exceeds 1 s, so wait up to a budget under the 10 s
-		// suite timeout before failing.
+		// Wait for the actual message, bounded by a backstop derived from this test's own mocha
+		// timeout (rather than a hardcoded value) so the two can never race each other — a fixed
+		// inner timeout close to (or exceeding) the outer mocha timeout previously meant this could
+		// fail with our own message right as it also became a hairline call against mocha's timeout.
 		let timer;
 		try {
 			await Promise.race([
 				messageReceived,
 				new Promise((_, reject) => {
-					timer = setTimeout(() => reject(new Error('Timeout waiting for retained message')), 8000);
+					timer = setTimeout(() => reject(new Error('Timeout waiting for retained message')), this.timeout() - 2000);
 				}),
 			]);
 		} finally {


### PR DESCRIPTION
Fixes two distinct causes of the pre-existing, load-dependent flake in `unitTests/apiTests/mqtt-test.mjs` ("test MQTT connections and commands"), observed in CI on `main` (not introduced by any specific PR):

**1. "last will should be published on connection loss" — genuine production race, not just a flaky test.**

`getSession()` in `server/DurableSubscriptionsSession.ts` persisted the MQTT Last Will record with `getLastWill().put(will)` without awaiting it. `server/mqtt.ts` awaits `getSession()` and then immediately sends CONNACK, so CONNACK could reach the client before the will record was durably written. A client that then disconnects abruptly (no DISCONNECT packet) triggers `session.disconnect(false)`, which reads the will back by session id to publish it — if that read raced ahead of the (unawaited) write, the will was silently dropped and never published. The test then hung until mocha's timeout, matching the reported `Timeout of 10000ms exceeded` failure.

Reproduced deterministically by temporarily inserting an artificial 500ms delay before the `.put()` call — the test failed reliably with the exact reported error. Added `await` and reran the same delayed-write experiment: passes correctly, since CONNACK (and therefore the client's ability to disconnect) now waits for the write to complete. Fix is one line: `await getLastWill().put(will)`.

**2. "subscribe to retained/persisted record" — test-only timing margin.**

This test already raced the real `message` event against a backstop timer (the right pattern), but the backstop was a hardcoded 8000ms against the suite's 10000ms mocha timeout — only 2s of margin, and the existing code comments already noted retained delivery "routinely exceeds 1s" on loaded CI runners. Bumped this test's own timeout to 20000ms (same precedent already used elsewhere in this file for another load-sensitive test) and derived the inner backstop from `this.timeout() - 2000` instead of a hardcoded value, so the two timeouts can't race each other regardless of future tuning.

**Verification:** ran the two target tests 15x back-to-back locally (all passing), then 10x more under artificial full-core CPU load (all passing). Ran the full `mqtt-test.mjs` suite once — 26 passing, 1 pending (pre-existing skip), no regressions.

This is a test-only + narrow production-race fix; not requesting a patch-cherry-pick — the last-will loss window requires an abrupt disconnect immediately following connect, which is a fairly narrow production window, though a genuine correctness gap. Happy to reconsider if reviewers think it's worth a backport.

Generated with Claude Sonnet 5.
