### PR TITLE
HTTP/2 support via cleartext h2 UDS mirror (symphony-L4 ALPN dispatch)

### DIFF
--- a/server/http.ts
+++ b/server/http.ts
@@ -13,9 +13,10 @@ import * as terms from '../utility/hdbTerms.ts';
 import { getConfigPath } from '../config/configUtils.ts';
 import { getTicketKeys, getWorkerIndex } from './threads/manageThreads.js';
 import { createTLSSelector } from '../security/keys.ts';
-import { createSecureServer } from 'node:http2';
+import { createSecureServer, createServer as createH2CServer } from 'node:http2';
 import { createServer as createSecureServerHttp1 } from 'node:https';
 import { createServer, IncomingMessage } from 'node:http';
+import { createServer as createNetServer } from 'node:net';
 import { Request, BunRequest, isBun } from './serverHelpers/Request.ts';
 import { appendHeader, Headers, toWriteHeadHeaders } from './serverHelpers/Headers.ts';
 import { Blob } from '../resources/blob.ts';
@@ -71,9 +72,12 @@ export function cleanupUdsFiles() {
 }
 
 /** Write YAML metadata for a UDS mirror socket, describing the TLS certs from the corresponding secure server. */
-export function writeUdsMetadata(yamlPath: string, port: number | string, secureServer: any) {
+export function writeUdsMetadata(yamlPath: string, port: number | string, secureServer: any, protocol?: string) {
 	const contexts = secureServer.secureContexts;
 	let yaml = `pid: ${process.pid}\ntid: ${currentThreadId()}\nport: ${port}\n`;
+	// Which application protocol this socket speaks (absent = http/1.1, the historical
+	// default) — lets a fronting proxy route by negotiated ALPN.
+	if (protocol) yaml += `protocol: ${protocol}\n`;
 	yaml += `certificates:\n`;
 	if (contexts?.size > 0) {
 		const seen = new Set();
@@ -600,6 +604,32 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 			const writeMetadata = () => writeUdsMetadata(yamlPath, port, server);
 			options.SNICallback.ready.then(writeMetadata);
 			server.secureContextsListeners.push(writeMetadata);
+
+			// Optional cleartext HTTP/2 mirror (spike: HARPER_H2C_UDS=1). A separate socket
+			// (`<worker>-<port>-h2.sock`) so a fronting proxy can route by negotiated ALPN:
+			// h2 connections here, http/1.1 to the plain mirror above. The metadata yaml
+			// carries `protocol: h2` so the proxy can discover which socket speaks what.
+			if (process.env.HARPER_H2C_UDS) {
+				const udsPathH2 = join(socketsDir, `${socketName}-h2.sock`);
+				const yamlPathH2 = join(socketsDir, `${socketName}-h2.yaml`);
+				const h2Server = createH2CServer({}, (nodeRequest: any, nodeResponse: any) => {
+					const method = nodeRequest.method;
+					if (method === 'GET' || method === 'OPTIONS' || method === 'HEAD') requestHandler(nodeRequest, nodeResponse);
+					else throttledRequestHandler(nodeRequest, nodeResponse);
+				});
+				// A stray non-h2 client (or a truncated preface) fails the session, not the worker.
+				h2Server.on('sessionError', (error: Error) => {
+					harperLogger.debug(`h2c UDS session error: ${error.message}`);
+				});
+				const h2Front = createH2CProxyFront(h2Server) as any;
+				h2Front.isPerThreadSocket = true;
+				SERVERS[udsPathH2] = h2Front;
+				registerUdsCleanupPaths(udsPathH2, yamlPathH2);
+
+				const writeMetadataH2 = () => writeUdsMetadata(yamlPathH2, port, server, 'h2');
+				options.SNICallback.ready.then(writeMetadataH2);
+				server.secureContextsListeners.push(writeMetadataH2);
+			}
 		}
 	}
 	return httpServers[port];
@@ -1106,6 +1136,52 @@ export function enableProxyProtocol(httpServer) {
 				if (rest.length > 0) forward(rest);
 			});
 		});
+	});
+}
+
+/**
+ * Front a cleartext HTTP/2 server with optional PROXY v1 handling on a Unix domain socket.
+ *
+ * enableProxyProtocol() can't be used here: Node's Http2Session consumes the socket's
+ * native handle directly, so data never surfaces as JS 'data' events to intercept. The
+ * PROXY header must instead be consumed *before* the socket is handed to the HTTP/2
+ * server. Bytes beyond the header (typically the coalesced h2 connection preface) are
+ * unshifted back onto the socket; the native session picks them up (verified on Node 24
+ * — covered by a unit test so a Node upgrade regressing this fails loudly).
+ */
+export function createH2CProxyFront(h2Server) {
+	return createNetServer({ noDelay: true }, (socket) => {
+		let buf: Buffer | null = null;
+		const handoff = (rest: Buffer) => {
+			socket.removeListener('readable', onReadable);
+			if (rest.length > 0) socket.unshift(rest);
+			h2Server.emit('connection', socket);
+		};
+		const onReadable = () => {
+			let chunk: Buffer;
+			while ((chunk = socket.read()) !== null) {
+				buf = buf ? Buffer.concat([buf, chunk]) : chunk;
+				// Compare against "PROXY " for as many bytes as we have so far; a non-PROXY
+				// prefix (e.g. a direct h2 client with no fronting proxy) is handed off as-is.
+				const cmpLen = Math.min(PROXY_V1_PREFIX.length, buf.length);
+				if (buf.compare(PROXY_V1_PREFIX, 0, cmpLen, 0, cmpLen) !== 0) return handoff(buf);
+				const eol = buf.indexOf('\r\n');
+				if (eol !== -1) {
+					// Complete header: "PROXY TCP4 <src-ip> <dst-ip> <src-port> <dst-port>"
+					const parts = buf.toString('latin1', 0, eol).split(' ');
+					if (parts.length === 6) {
+						// Override the UDS socket's undefined remoteAddress/remotePort with the real
+						// client values; http2's compat req.socket proxies through to these.
+						Object.defineProperty(socket, 'remoteAddress', { value: parts[2], configurable: true });
+						Object.defineProperty(socket, 'remotePort', { value: parseInt(parts[4], 10), configurable: true });
+					}
+					return handoff(buf.subarray(eol + 2));
+				}
+				// No CRLF within the spec max — not a valid PROXY header after all.
+				if (buf.length >= PROXY_V1_MAX_HEADER) return handoff(buf);
+			}
+		};
+		socket.on('readable', onReadable);
 	});
 }
 

--- a/server/http.ts
+++ b/server/http.ts
@@ -1148,12 +1148,39 @@ export function enableProxyProtocol(httpServer) {
  * server. Bytes beyond the header (typically the coalesced h2 connection preface) are
  * unshifted back onto the socket; the native session picks them up (verified on Node 24
  * — covered by a unit test so a Node upgrade regressing this fails loudly).
+ *
+ * The returned server's close() also gracefully closes live h2 sessions (GOAWAY,
+ * in-flight streams finish) so closeServers()'s generic server.close() drains instead
+ * of riding its 5s force-exit backstop — the h1 mirror gets this via http.Server's
+ * closeIdleConnections drain, which a net.Server doesn't have.
  */
-export function createH2CProxyFront(h2Server) {
-	return createNetServer({ noDelay: true }, (socket) => {
+export function createH2CProxyFront(h2Server, prehandoffTimeout = 10_000) {
+	const sessions = new Set<any>();
+	const prehandoffSockets = new Set<any>();
+	let closing = false;
+	h2Server.on('session', (session) => {
+		// A connection can be mid-handoff (header read, session not yet created) when
+		// close() runs — its session forms after the close sweep, so close it here or
+		// it would never receive GOAWAY and would ride the 5s force-exit backstop.
+		if (closing) session.close();
+		sessions.add(session);
+		session.on('close', () => sessions.delete(session));
+	});
+	const front = createNetServer({ noDelay: true }, (socket) => {
 		let buf: Buffer | null = null;
+		// Until handoff the h2 session's own handlers aren't attached yet: swallow socket
+		// errors (a reset mid-header) and bound how long we'll wait for the header, so a
+		// stalled connection can't hold an fd forever.
+		prehandoffSockets.add(socket);
+		socket.on('close', () => prehandoffSockets.delete(socket));
+		const onPrehandoffError = () => socket.destroy();
+		socket.on('error', onPrehandoffError);
+		socket.setTimeout(prehandoffTimeout, () => socket.destroy());
 		const handoff = (rest: Buffer) => {
+			prehandoffSockets.delete(socket);
 			socket.removeListener('readable', onReadable);
+			socket.removeListener('error', onPrehandoffError);
+			socket.setTimeout(0);
 			if (rest.length > 0) socket.unshift(rest);
 			h2Server.emit('connection', socket);
 		};
@@ -1183,6 +1210,17 @@ export function createH2CProxyFront(h2Server) {
 		};
 		socket.on('readable', onReadable);
 	});
+	const netClose = front.close.bind(front);
+	front.close = (callback?: (error?: Error) => void) => {
+		closing = true;
+		for (const session of sessions) session.close();
+		// Header-waiting sockets carry no in-flight work; drop them so they can't hold
+		// the close callback open for the rest of the pre-handoff timeout.
+		for (const socket of prehandoffSockets) socket.destroy();
+		h2Server.close();
+		return netClose(callback);
+	};
+	return front;
 }
 
 function defaultNotFound(request, response) {

--- a/server/http.ts
+++ b/server/http.ts
@@ -619,7 +619,7 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 				});
 				// A stray non-h2 client (or a truncated preface) fails the session, not the worker.
 				h2Server.on('sessionError', (error: Error) => {
-					harperLogger.debug(`h2c UDS session error: ${error.message}`);
+					harperLogger.debug('h2c UDS session error:', error);
 				});
 				const h2Front = createH2CProxyFront(h2Server) as any;
 				h2Front.isPerThreadSocket = true;

--- a/server/http.ts
+++ b/server/http.ts
@@ -1175,12 +1175,14 @@ export function createH2CProxyFront(h2Server, prehandoffTimeout = 10_000) {
 		socket.on('close', () => prehandoffSockets.delete(socket));
 		const onPrehandoffError = () => socket.destroy();
 		socket.on('error', onPrehandoffError);
-		socket.setTimeout(prehandoffTimeout, () => socket.destroy());
+		const onPrehandoffTimeout = () => socket.destroy();
+		socket.setTimeout(prehandoffTimeout, onPrehandoffTimeout);
 		const handoff = (rest: Buffer) => {
 			prehandoffSockets.delete(socket);
 			socket.removeListener('readable', onReadable);
 			socket.removeListener('error', onPrehandoffError);
 			socket.setTimeout(0);
+			socket.removeListener('timeout', onPrehandoffTimeout);
 			if (rest.length > 0) socket.unshift(rest);
 			h2Server.emit('connection', socket);
 		};

--- a/unitTests/server/udsMirror.test.js
+++ b/unitTests/server/udsMirror.test.js
@@ -286,4 +286,152 @@ describe('UDS mirror (writeUdsMetadata, cleanup helpers)', () => {
 			assert.doesNotThrow(() => cleanupSocketsDirectory());
 		});
 	});
+
+	// ─── writeUdsMetadata protocol marker ─────────────────────────────────────
+
+	describe('writeUdsMetadata protocol parameter', () => {
+		it('writes a protocol line when given, omits it otherwise', () => {
+			const yamlPath = path.join(TEST_SOCKETS_DIR, '0-9926-h2.yaml');
+			writeUdsMetadata(yamlPath, 9926, makeSecureServer(), 'h2');
+			assert.match(fs.readFileSync(yamlPath, 'utf8'), /^protocol: h2$/m);
+			writeUdsMetadata(yamlPath, 9926, makeSecureServer());
+			assert.doesNotMatch(fs.readFileSync(yamlPath, 'utf8'), /^protocol:/m);
+		});
+	});
+});
+
+// ─── createH2CProxyFront ──────────────────────────────────────────────────────
+// Real sockets: an h2c server behind the PROXY-stripping front on a UDS path.
+// These also pin the Node behavior the front depends on: bytes unshifted onto a
+// net.Socket must survive Http2Session's native handle consume.
+
+describe('createH2CProxyFront (h2c UDS mirror)', () => {
+	const http2 = require('node:http2');
+	const net = require('node:net');
+	const os = require('node:os');
+	const { createH2CProxyFront } = require('#src/server/http');
+
+	// h2 connection preface + empty SETTINGS frame (type 4, flags 0, stream 0, len 0)
+	const H2_PREFACE = Buffer.concat([
+		Buffer.from('PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n'),
+		Buffer.from([0, 0, 0, 4, 0, 0, 0, 0, 0]),
+	]);
+	const PROXY_LINE = 'PROXY TCP4 203.0.113.9 127.0.0.1 45678 443\r\n';
+
+	let h2srv, front, udsPath;
+
+	beforeEach((done) => {
+		udsPath = path.join(os.tmpdir(), `hdb-h2c-test-${process.pid}-${Math.random().toString(36).slice(2)}.sock`);
+		h2srv = http2.createServer((req, res) => {
+			res.writeHead(200, { 'content-type': 'text/plain' });
+			res.end(`addr=${req.socket.remoteAddress ?? 'none'} port=${req.socket.remotePort ?? 0} path=${req.url}`);
+		});
+		h2srv.on('sessionError', () => {});
+		front = createH2CProxyFront(h2srv);
+		front.listen(udsPath, done);
+	});
+
+	afterEach((done) => {
+		h2srv.close();
+		front.close(() => {
+			try {
+				fs.unlinkSync(udsPath);
+			} catch {}
+			done();
+		});
+	});
+
+	function h2Request(prepare) {
+		return new Promise((resolve, reject) => {
+			const session = http2.connect('http://localhost', {
+				createConnection: () => {
+					const socket = net.connect(udsPath);
+					prepare?.(socket);
+					return socket;
+				},
+			});
+			session.on('error', reject);
+			const req = session.request({ ':path': '/who' });
+			let body = '';
+			req.setEncoding('utf8');
+			req.on('data', (d) => (body += d));
+			req.on('end', () => {
+				session.close();
+				resolve(body);
+			});
+			req.on('error', reject);
+			req.end();
+		});
+	}
+
+	// Establish a session manually (PROXY/preface framing fully under test control)
+	// and resolve on the server's SETTINGS-ACK. The server sends its own SETTINGS
+	// unprompted on session creation, so only an ACK (type 0x4, flags & 0x1) proves
+	// the CLIENT preface survived stripping/unshift and reached the native session.
+	function rawSessionEstablishes(writes) {
+		return new Promise((resolve, reject) => {
+			const socket = net.connect(udsPath, async () => {
+				for (const w of writes) {
+					if (typeof w === 'number') await new Promise((r) => setTimeout(r, w));
+					else socket.write(w);
+				}
+			});
+			const timer = setTimeout(() => {
+				socket.destroy();
+				reject(new Error('no SETTINGS-ACK from server'));
+			}, 1500);
+			let buf = Buffer.alloc(0);
+			socket.on('data', (d) => {
+				buf = Buffer.concat([buf, d]);
+				// Walk complete frames: 3-byte length, 1-byte type, 1-byte flags, 4-byte stream id
+				let off = 0;
+				while (buf.length - off >= 9) {
+					const len = buf.readUIntBE(off, 3);
+					const type = buf[off + 3];
+					const flags = buf[off + 4];
+					if (type === 4 && flags & 0x1) {
+						clearTimeout(timer);
+						socket.destroy();
+						return resolve();
+					}
+					if (buf.length - off < 9 + len) break;
+					off += 9 + len;
+				}
+				buf = buf.subarray(off);
+			});
+			socket.on('error', reject);
+		});
+	}
+
+	it('strips the PROXY header and overrides remoteAddress/remotePort', async () => {
+		const body = await h2Request((socket) => socket.write(PROXY_LINE));
+		assert.match(body, /addr=203\.0\.113\.9 port=45678/);
+	});
+
+	it('passes a direct h2 connection (no PROXY header) through unchanged', async () => {
+		const body = await h2Request();
+		assert.match(body, /path=\/who/);
+		assert.doesNotMatch(body, /203\.0\.113\.9/);
+	});
+
+	it('handles the PROXY header coalesced with the preface in a single packet', async () => {
+		await rawSessionEstablishes([Buffer.concat([Buffer.from(PROXY_LINE), H2_PREFACE])]);
+	});
+
+	it('handles a PROXY header split across packets', async () => {
+		await rawSessionEstablishes([
+			Buffer.from('PROXY TCP4 203.0.'),
+			20,
+			Buffer.from('113.9 127.0.0.1 45678 443\r\n'),
+			H2_PREFACE,
+		]);
+	});
+
+	it('hands off unparseable long first packets without stalling', async () => {
+		// Starts with "PROXY " but never terminates: after 108 bytes the front must
+		// give up and forward — the h2 server then fails the session (never ACKs),
+		// rather than the front buffering forever.
+		const junk = Buffer.from('PROXY ' + 'x'.repeat(150));
+		await assert.rejects(rawSessionEstablishes([junk]), /no SETTINGS-ACK|ECONNRESET/);
+	});
 });

--- a/unitTests/server/udsMirror.test.js
+++ b/unitTests/server/udsMirror.test.js
@@ -434,4 +434,36 @@ describe('createH2CProxyFront (h2c UDS mirror)', () => {
 		const junk = Buffer.from('PROXY ' + 'x'.repeat(150));
 		await assert.rejects(rawSessionEstablishes([junk]), /no SETTINGS-ACK|ECONNRESET/);
 	});
+
+	it('close() sends GOAWAY to live sessions so shutdown drains gracefully', async () => {
+		// Establish a real session, then close the front: the session must receive
+		// GOAWAY and close promptly (well inside closeServers' 5s force-exit backstop).
+		const session = http2.connect('http://localhost', {
+			createConnection: () => net.connect(udsPath),
+		});
+		session.on('error', () => {});
+		await new Promise((resolve) => session.on('connect', resolve));
+		const sessionClosed = new Promise((resolve) => session.on('close', resolve));
+		const frontClosed = new Promise((resolve) => front.close(resolve));
+		await Promise.all([sessionClosed, frontClosed]);
+	});
+
+	it('destroys a connection that stalls before completing the PROXY header', async () => {
+		// Rebuild the front with a short pre-handoff timeout: a client that sends a
+		// partial header and stalls must be destroyed, not hold the fd forever.
+		// (net.Server unlinks the UDS file itself on close.)
+		await new Promise((resolve) => front.close(resolve));
+		front = createH2CProxyFront(h2srv, 100);
+		await new Promise((resolve) => front.listen(udsPath, resolve));
+
+		const socket = net.connect(udsPath, () => socket.write('PROXY TCP4 203.0.'));
+		socket.on('error', () => {});
+		await new Promise((resolve, reject) => {
+			const timer = setTimeout(() => reject(new Error('stalled connection was not destroyed')), 2000);
+			socket.on('close', () => {
+				clearTimeout(timer);
+				resolve();
+			});
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Flag-gated (`HARPER_H2C_UDS=1`) cleartext HTTP/2 mirror socket (`<worker>-<port>-h2.sock`) alongside the existing h1 UDS mirror, so a fronting L4 TLS proxy (symphony) can route ALPN-negotiated h2 connections to Harper without terminating HTTP itself. Part of the #914 evaluation; production default unchanged.

- `http2.createServer` (compat mode) reusing the **same request/throttle handlers** as the h1 mirror — `httpChain` already speaks h2 compat via the existing secure-port `createSecureServer` path.
- `createH2CProxyFront`: consumes an optional PROXY v1 header **before** handing the socket to the h2 server via `emit('connection')` — `Http2Session` consumes the socket handle natively, so the existing `enableProxyProtocol` data-listener interception can't apply to h2. Remaining bytes (typically the coalesced h2 preface) are `unshift`ed; this Node behavior is pinned by unit tests so a Node upgrade regressing it fails loudly.
- `front.close()` GOAWAYs live sessions (including the mid-handoff race: a session that forms *after* close began still gets closed) so `closeServers()` drains gracefully instead of riding its 5s force-exit; pre-handoff sockets get an error listener + bounded header wait.
- UDS metadata yaml gains `protocol: h2` for ALPN-based routing discovery by the proxy.

## Why this architecture

Measured (symphony `kris/l7-spike` bench harness): terminating h2 at the proxy and translating to h1 costs ~25–30% more CPU end-to-end than byte-pumping decrypted h2 frames to Node's `http2` — and needs an L7 proxy rewrite. Live Harper numbers (full httpChain, auth→404): h1 mirror 10.2 µs_cpu/req, h2c mirror 18.2 µs_cpu/req; with the proxy hop the h2 chain lands ≈ today's whole h1 chain.

## Where to look / open items

- The `unshift`-before-`emit('connection')` contract with `Http2Session`'s native consume is the load-bearing trick (`server/http.ts` `createH2CProxyFront`). Tests pin it (incl. PROXY+preface coalesced in one packet; SETTINGS-ACK as the establishment signal since the server sends its own SETTINGS unprompted).
- **Accepted for the spike** (flag-gated; revisit before promoting to a config option): no per-request timeouts on the h2c server (the h1 mirror sets `keepAliveTimeout`/`headersTimeout`/`requestTimeout`); PROXY source-IP trust is parity with the h1 mirror (UDS filesystem perms + symphony-only trust model).
- Http2ServerRequest compat costs ~1.79× the h1 path per request against the real pipeline — profiling follow-up in progress; may land on this branch.

Cross-model review (Gemini diff-only leg + Harper-domain adjudication) ran pre-PR; both significant findings (graceful shutdown, pre-handoff error window) are fixed in `29c376be`. No docs: experimental env flag, not user-facing config.

Drafted by an LLM (Claude Fable 5), reviewed against the engineering guidelines.