### PR TITLE
fix(rest): don't mutate live cache records in finalizeResponse (persisted headers corruption)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -29,6 +29,8 @@ In `getFromSource()` (`Table.ts`), the promise that callers await resolves with 
 
 Consequence: never replace `entry.value` with a copy of `updatedRecord` in this path — the copy won't receive the commit callback's mutations.
 
+The sharing cuts both ways: the caller's mutations are visible to the **commit**, which encodes whatever the object holds at commit time. A downstream consumer that mutates the resolved record before the deferred commit runs corrupts what gets persisted — `finalizeResponse` (`server/REST.ts`) did exactly this, overwriting `.headers` with a web `Headers` (no enumerable own keys → stored as `{}`) and stamping `.status` (#1702; LMDB-only because RocksDB commits encode synchronously). Consumers must copy before mutating; `finalizeResponse` now copies any `entryMap`-tracked record.
+
 ## Blob orphan cleanup: pre-saved files outlive cancelled commits
 
 Blobs flagged with `saveBeforeCommit` (or `saveInRecord`) are written to disk in the `beforeIntermediate` phase of a `TransactionWrite`, _before_ the LMDB/RocksDB write commits. The write's commit callback can still skip the actual record write — for older versions, supersedence by future updates, residency mismatches, or full transaction abort. In every such path the file is on disk but no record references it.

--- a/server/REST.ts
+++ b/server/REST.ts
@@ -11,6 +11,7 @@ import { generateJsonApi } from '../resources/openApi.ts';
 
 import { Request } from '../server/serverHelpers/Request.ts';
 import { RequestTarget } from '../resources/RequestTarget';
+import { entryMap } from '../resources/RecordEncoder.ts';
 
 const { errorToString } = harperLogger;
 const etagBytes = new Uint8Array(8);
@@ -29,6 +30,21 @@ function finalizeResponse(responseData, headers, status, request) {
 	if (Object.isFrozen(responseData)) {
 		// make a copy if it is a frozen record
 		responseData = Object.assign({}, responseData);
+	} else if (entryMap.has(responseData)) {
+		// A table/cache record handed to us for the response is also the live object that the
+		// resolving read queued for its store commit (see getFromSource in Table.ts, which shares
+		// one object so the response reflects commit-stamped timestamps). Mutating it below —
+		// reassigning `.headers` to a web `Headers` (whose entries are not own-enumerable, so it
+		// encodes as `{}`) or defaulting `.status` — writes straight through to what gets persisted,
+		// silently emptying the stored headers on the next read. On RocksDB the commit encodes before
+		// this runs so it goes unnoticed; on LMDB the commit is deferred (async txn + the blob
+		// durability gate widened in #1641) and encodes the corrupted object. Copy so response
+		// mutations never reach the stored record. Preserving the prototype keeps computed-attribute
+		// getters resolving (entryMap-backed methods like getUpdatedTime() return undefined on the
+		// copy, but nothing on this path reads them); it also means a stored field that shadows a
+		// same-named computed attribute would hit the prototype's setter here rather than becoming an
+		// own property — a schema shape that shouldn't exist. See HarperFast/harper#1702.
+		responseData = Object.assign(Object.create(Object.getPrototypeOf(responseData)), responseData);
 	}
 	// merge headers from response
 	const responseHeaders = mergeHeaders(responseData.headers, headers);

--- a/unitTests/apiTests/cache-test.mjs
+++ b/unitTests/apiTests/cache-test.mjs
@@ -84,6 +84,19 @@ describe('test REST calls with cache table', () => {
 			assert.equal(response.headers.get('cache-control'), 'max-age=10, s-maxage=20');
 			assert.equal(response.headers.get('x-custom-header'), 'custom value');
 		});
+		it('stored record headers survive the response path (#1702)', async () => {
+			// finalizeResponse must not mutate the live record queued for the deferred cache commit
+			// (it previously overwrote `headers` with a web Headers, persisting `{}` under LMDB).
+			// The second get is a cache hit served from the persisted record, so it fails if the
+			// stored headers were corrupted by the first request's response handling.
+			await axios.get(`${baseUrl}/CacheOfHttp/created-response`);
+			await delay(20); // let the background cache commit land before reading it back
+			let response = await axios.get(`${baseUrl}/CacheOfHttp/created-response`);
+			assert.equal(response.status, 200);
+			assert.equal(response.data, 'test');
+			assert.equal(response.headers.get('cache-control'), 'max-age=10, s-maxage=20');
+			assert.equal(response.headers.get('x-custom-header'), 'custom value');
+		});
 		it('get resolved with fetch body as text', async () => {
 			let response = await axios.get(`${baseUrl}/CacheOfHttp/fetch-body`);
 			assert.equal(response.status, 200);

--- a/unitTests/apiTests/cache-test.mjs
+++ b/unitTests/apiTests/cache-test.mjs
@@ -4,6 +4,7 @@ import { assert } from 'chai';
 import axios from 'axios';
 import { setupTestApp, baseUrl } from './setupTestApp.mjs';
 import { setTimeout as delay } from 'node:timers/promises';
+import { waitFor } from '../waitFor.js';
 
 describe('test REST calls with cache table', () => {
 	before(async () => {
@@ -87,14 +88,20 @@ describe('test REST calls with cache table', () => {
 		it('stored record headers survive the response path (#1702)', async () => {
 			// finalizeResponse must not mutate the live record queued for the deferred cache commit
 			// (it previously overwrote `headers` with a web Headers, persisting `{}` under LMDB).
-			// The second get is a cache hit served from the persisted record, so it fails if the
-			// stored headers were corrupted by the first request's response handling.
+			// The first get warms the cache and queues the async commit; subsequent gets are cache
+			// hits served from the persisted record, so they fail if the stored headers were
+			// corrupted by the first request's response handling. Poll rather than fixed-delay so the
+			// deferred-commit wait doesn't race a loaded runner (AGENTS.md #1138).
 			await axios.get(`${baseUrl}/CacheOfHttp/created-response`);
-			await delay(20); // let the background cache commit land before reading it back
-			let response = await axios.get(`${baseUrl}/CacheOfHttp/created-response`);
+			const response = await waitFor(
+				async () => {
+					const r = await axios.get(`${baseUrl}/CacheOfHttp/created-response`);
+					return r.headers.get('cache-control') === 'max-age=10, s-maxage=20' ? r : false;
+				},
+				{ timeout: 2000, interval: 20, message: 'stored cache headers did not survive the response path (#1702)' }
+			);
 			assert.equal(response.status, 200);
 			assert.equal(response.data, 'test');
-			assert.equal(response.headers.get('cache-control'), 'max-age=10, s-maxage=20');
 			assert.equal(response.headers.get('x-custom-header'), 'custom value');
 		});
 		it('get resolved with fetch body as text', async () => {


### PR DESCRIPTION
## Summary

`finalizeResponse` (server/REST.ts) mutates the response object in place — reassigning `.headers` to a web `Headers` instance (via `mergeHeaders`) and defaulting `.status`. For a `sourcedFrom` cache fill, that object is the **same live record** `getFromSource` queued for the deferred store commit. A `Headers` instance has no enumerable own keys, so when the commit later encodes the mutated record, its `headers` persist as `{}` — silent corruption of the stored cache row.

This is the actual root cause behind #1702: instrumented tracing showed the structon/msgpackr structure dictionaries are intact (typed structs are off by default; no classic-structure mint/save divergence) — the stored **value** itself was mutated by the response path before the commit encoded it. It only surfaces under LMDB because LMDB's cache-fill commit is deferred past the response handling (a window #1641 widened); RocksDB encodes synchronously in `putSync` before `finalizeResponse` runs, masking the same aliasing.

## Fix

Extend `finalizeResponse`'s existing frozen-record copy guard: also copy when the object is a live entry-mapped record (`entryMap.has`), preserving the record prototype. Response mutations then never reach the stored record, regardless of commit timing — so this holds even if a future change re-introduces an await between commit preparation and execution (the fragility #1702 worried about).

## Testing

- New regression test in `cache-test.mjs` (`stored record headers survive the response path (#1702)`): second GET is a cache hit served from the persisted record. Verified red without the fix, green with it, under `HARPER_STORAGE_ENGINE=lmdb`.
- `unitTests/apiTests/**` both engines: all passing (LMDB was 1 failing on main since #1641).
- `test:unit:main` (2992) / `test:unit:resources` (1017): passing (unit:main verified on the main checkout; the worktree's symlinked node_modules breaks 10 jsLoader sandbox tests identically with and without this change).

## Where to look

- The copy is `Object.assign(Object.create(Object.getPrototypeOf(responseData)), responseData)` — prototype-preserving so enumerable computed-attribute getters still resolve for serialization, unlike the frozen branch's bare `{}`. The code comment documents the two accepted edges (entryMap-backed `getUpdatedTime()` returns `undefined` on the copy; a stored field shadowing a same-named computed attribute would hit the prototype setter).
- Relationship to #1703: that PR avoids the corruption by restoring pre-#1641 commit timing for the cache-fill path (and adds blob orphan-cleanup). This fix removes the aliasing hazard itself, so the timing-avoidance aspect stops being load-bearing; #1703's blob tracking/cleanup remains independently useful.

Cross-model reviewed (Gemini via agy + Harper domain adjudication); the one substantive finding (missing regression test) is addressed in this PR.

Root-caused and generated with Claude Opus 4.8.