### PR TITLE
fix(test): await startCrlServer so the EADDRINUSE retry covers the listen

### DIFF
--- a/integrationTests/utils/securityServices.ts
+++ b/integrationTests/utils/securityServices.ts
@@ -112,7 +112,9 @@ export async function setupCrlServerWithCerts(
 		try {
 			const { generateCrlCertificates } = await import('./security/crl/generate-test-certs.ts');
 			const certs = await generateCrlCertificates(certsPath, hostname, port);
-			return startCrlServer(certsPath, port, certs);
+			// await so EADDRINUSE from server.listen() lands in the catch and triggers retry
+			// (matches setupOcspResponderWithCerts pattern)
+			return await startCrlServer(certsPath, port, certs);
 		} catch (error: any) {
 			if (error.code === 'EADDRINUSE' && attempt < maxRetries - 1) {
 				continue;


### PR DESCRIPTION
## What

One-line test-harness fix in `integrationTests/utils/securityServices.ts`. No production code changes.

## Why

`setupCrlServerWithCerts` had a 5-attempt retry loop intended to handle `EADDRINUSE` from `server.listen()`, but the call to `startCrlServer` was `return`ed without `await`. Because `startCrlServer` rejects via `server.on('error', reject)`, that rejection escapes the `try/catch` entirely — so the retry only ever guarded `generateCrlCertificates`, never the actual bind.

Ports are chosen randomly from 50000–59999, which overlaps the Linux ephemeral range (32768–60999). A collision with a kernel-assigned port causes the whole suite to fail with `EADDRINUSE` instead of retrying. This surfaced as a `crl-verification.test.ts` failure on the Node 22 shard of an unrelated PR (#1709); Node 24/26 shards happened to be clean (pure timing).

## Fix

Add `await` before `startCrlServer(...)`. This makes the bind rejection land in the `catch`, so the existing retry loop works as intended. The sibling `setupOcspResponderWithCerts` already does `const server = await startOcspServer(...)` inside its `try` — this change brings `setupCrlServerWithCerts` to the same pattern.

Generated by Claude Sonnet 4.6.