### PR TITLE
fix(windows): widen atomicWriteFile rename-retry backoff for EPERM/EACCES

### DIFF
--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -7,6 +7,7 @@ import YAML from 'yaml';
 import path from 'path';
 import { threadId } from 'node:worker_threads';
 import { randomBytes } from 'node:crypto';
+import { performance } from 'node:perf_hooks';
 import isNumber from 'is-number';
 import propertiesReaderModule from 'properties-reader';
 import _ from 'lodash';
@@ -79,10 +80,30 @@ export function getConfigPath(param: string) {
 // Write atomically via temp file + rename so readers don't observe a truncated/empty file.
 // Temp path includes randomness so two worker threads in the same process (same pid) writing
 // in the same millisecond can't collide on the temp name and then race the rename.
-function atomicWriteFile(filePath, content) {
+//
+// Windows has no POSIX-style "replace an open file" semantics: rename() fails with
+// EPERM/EACCES if another thread/process has the destination momentarily open for read.
+// Every worker thread runs its own RootConfigWatcher (chokidar), so a write on one thread
+// routinely races a hot-reload read on another; Windows Defender / AV real-time scanning can
+// hold a similar transient handle. Retry with exponential backoff to ride out the race -
+// callers are synchronous, so the wait is a synchronous busy-loop rather than a real sleep.
+const RENAME_RETRY_MAX_ATTEMPTS = 8;
+const RENAME_RETRY_INITIAL_DELAY_MS = 10;
+const RENAME_RETRY_MAX_DELAY_MS = 200;
+
+function atomicWriteFile(
+	filePath,
+	content,
+	{
+		maxRetries = RENAME_RETRY_MAX_ATTEMPTS,
+		initialDelayMs = RENAME_RETRY_INITIAL_DELAY_MS,
+		maxDelayMs = RENAME_RETRY_MAX_DELAY_MS,
+	} = {}
+) {
 	const tempPath = `${filePath}.${process.pid}.${threadId}.${randomBytes(4).toString('hex')}.tmp`;
 	fs.writeFileSync(tempPath, content);
-	let retries = 5;
+	let retries = maxRetries;
+	let delayMs = initialDelayMs;
 	while (true) {
 		try {
 			fs.renameSync(tempPath, filePath);
@@ -90,9 +111,12 @@ function atomicWriteFile(filePath, content) {
 		} catch (err) {
 			if (retries > 0 && (err.code === 'EPERM' || err.code === 'EACCES')) {
 				retries--;
-				// sleep synchronously to allow the reader to close the file
-				const start = Date.now();
-				while (Date.now() - start < 10) {}
+				// Sleep synchronously (all call sites are sync) to allow the reader to close the
+				// file. Uses performance.now() rather than Date.now(): the latter tracks wall-clock
+				// time and can jump backward (NTP sync), which would turn this into an unbounded spin.
+				const start = performance.now();
+				while (performance.now() - start < delayMs) {}
+				delayMs = Math.min(delayMs * 2, maxDelayMs);
 				continue;
 			}
 			// if it fails we should clean up the tmp file

--- a/unitTests/config/configUtils.test.js
+++ b/unitTests/config/configUtils.test.js
@@ -220,6 +220,57 @@ describe('Test configUtils module', () => {
 				dateStub.restore();
 			}
 		});
+
+		it('retries the rename on a transient Windows EPERM/EACCES and succeeds once the holder releases the file', () => {
+			// Simulates a sibling worker's RootConfigWatcher (or AV) briefly holding the
+			// destination open for read: renameSync fails a couple of times, then succeeds.
+			const renameStub = sandbox.stub(fs, 'renameSync');
+			const epermError = Object.assign(new Error('EPERM: operation not permitted, rename'), { code: 'EPERM' });
+			const eaccesError = Object.assign(new Error('EACCES: permission denied, rename'), { code: 'EACCES' });
+			renameStub.onCall(0).throws(epermError);
+			renameStub.onCall(1).throws(eaccesError);
+			renameStub.onCall(2).returns(undefined);
+			try {
+				atomicWriteFile(ATOMIC_TEST_PATH, 'content');
+				expect(renameStub.callCount).to.equal(3);
+			} finally {
+				renameStub.restore();
+			}
+		});
+
+		it('gives up after exhausting retries on a persistent EPERM, cleans up the temp file, and rethrows', () => {
+			const renameStub = sandbox.stub(fs, 'renameSync');
+			const epermError = Object.assign(new Error('EPERM: operation not permitted, rename'), { code: 'EPERM' });
+			renameStub.throws(epermError);
+			try {
+				// Use the default retry count (unspecified maxRetries) so this exercises the real
+				// production budget, but override the delay to ~0 so the backoff doesn't burn real
+				// wall-clock time (default backoff would take ~900ms for a persistent failure).
+				expect(() => atomicWriteFile(ATOMIC_TEST_PATH, 'content', { initialDelayMs: 0, maxDelayMs: 0 })).to.throw(
+					epermError
+				);
+				// 1 initial attempt + 8 retries (the production default maxRetries)
+				expect(renameStub.callCount).to.equal(9);
+				const stragglers = fs
+					.readdirSync(ATOMIC_TEST_DIR)
+					.filter((e) => e.startsWith('atomic-write-test.yaml.') && e.endsWith('.tmp'));
+				expect(stragglers).to.be.empty;
+			} finally {
+				renameStub.restore();
+			}
+		});
+
+		it('does not retry on a non-permission rename error', () => {
+			const renameStub = sandbox.stub(fs, 'renameSync');
+			const enoentError = Object.assign(new Error('ENOENT: no such file or directory, rename'), { code: 'ENOENT' });
+			renameStub.throws(enoentError);
+			try {
+				expect(() => atomicWriteFile(ATOMIC_TEST_PATH, 'content')).to.throw(enoentError);
+				expect(renameStub.callCount).to.equal(1);
+			} finally {
+				renameStub.restore();
+			}
+		});
 	});
 
 	describe('Test getDefaultConfig function', () => {


### PR DESCRIPTION
## Summary
Widens the retry-on-EPERM/EACCES loop in `config/configUtils.ts`'s `atomicWriteFile` (the write-temp-file-then-rename helper used by every config write path: `createConfigFile`, `checkForUpdatedConfig`, `updateConfigValue`, `addConfig`, `deleteConfigFromFile`, `applyRuntimeEnvVarConfig`) from a 50ms total budget to exponential backoff (~910ms worst case), switches the busy-wait clock to a monotonic source, and makes the retry parameters injectable for fast unit tests.

## Root cause
Discovered incidentally while investigating an unrelated PR (#1713, `kris/hnsw-delete-ep-flake`) — a Windows CI job failed with:
```
EPERM: operation not permitted, rename '...harper-config.yaml.9072.0.413a8514.tmp' -> '...harper-config.yaml'
```
Rerunning the same job passed clean, confirming a low-frequency flake rather than a deterministic break.

`atomicWriteFile` already had a retry-on-EPERM/EACCES loop, added in a prior commit for this exact class of Windows issue ("atomic renames on Windows will throw EPERM if the target file is momentarily held open for reading by another process or thread"). That loop was under-budgeted: 5 retries × a fixed 10ms sleep = 50ms total.

Windows has no POSIX-style "replace an open file" semantics — `rename()` fails with EPERM/EACCES if the destination is momentarily open elsewhere. Every Harper worker thread runs its own `RootConfigWatcher` (chokidar-based hot-reload watcher, see `config/RootConfigWatcher.ts`), which does an async `readFile` on the config file whenever it changes. A config write on one thread therefore routinely races a hot-reload read on a sibling thread; Windows Defender / AV real-time scanning can hold a similar transient handle. 50ms just isn't always enough for the reader to close its handle.

## Fix
- Widen the retry budget to exponential backoff: 8 retries, 10ms initial delay, doubling, capped at 200ms/attempt (~910ms worst case for a persistently-held handle).
- Switch the busy-wait clock from `Date.now()` to `performance.now()` — monotonic, so a backward wall-clock jump (e.g. NTP sync) can't turn the spin into an unbounded stall (caught in cross-model review).
- Add an options parameter (`maxRetries`/`initialDelayMs`/`maxDelayMs`, all defaulting to the production values) so unit tests can exercise the real default retry count without paying the real ~900ms wall-clock cost for the exhaustion path.
- Add unit tests: retry-then-succeed, exhaust-retries-cleans-up-temp-file-and-rethrows, non-retryable-error-does-not-retry.

## Where to look / accepted tradeoffs
- **Worst-case stall widened 50ms → ~910ms.** Under *persistent* EPERM/EACCES, the synchronous busy-loop now blocks the calling worker thread's event loop for up to ~910ms instead of ~50ms. This only affects the contended-write path (rare: admin config changes, boot-time config reconciliation) — the happy path is unaffected. Accepted as the right tradeoff to reliably ride out the Windows race; flagging so a reviewer doesn't need to rediscover it.
- **Same-thread holder is still an unresolved edge case.** If the handle is held by an async operation on the *same* thread (rather than a sibling worker thread), the busy-wait blocks that operation's own completion callback, guaranteeing all retries burn before throwing. This isn't a new regression — the synchronous-busy-wait design predates this change — and it isn't the failure mode this PR fixes (the real-world contention is cross-thread `RootConfigWatcher` reads / AV, which do ride out the wait). Worth being aware of if this flake recurs after this fix ships.

Reviewed via cross-model review (thorough mode: Gemini + Codex legs + Harper-domain adjudication) — no blockers; the two items above are the adjudicated open callouts.

Generated with Claude Sonnet 5.