### PR TITLE
fix: only join an ambient transaction if it is genuinely still OPEN

### DIFF
--- a/resources/Resource.ts
+++ b/resources/Resource.ts
@@ -10,7 +10,7 @@ import {
 	RequestTargetOrId,
 } from './ResourceInterface.ts';
 import { randomUUID } from 'crypto';
-import { DatabaseTransaction, type Transaction } from './DatabaseTransaction.ts';
+import { DatabaseTransaction, TRANSACTION_STATE, type Transaction } from './DatabaseTransaction.ts';
 import { IterableEventQueue } from './IterableEventQueue.ts';
 import { _assignPackageExport } from '../globals.js';
 import { ClientError, AccessViolation } from '../utility/errors/hdbError.ts';
@@ -658,7 +658,21 @@ function transactional(
 			if (isCollection) resourceOptions.isCollection = true;
 		} else resourceOptions = options;
 		const loadAsInstance = this.loadAsInstance;
-		if (context?.transaction) {
+		// Only join an existing transaction if it is still genuinely OPEN (mirrors the reuse check
+		// resources/transaction.ts's transaction() helper already applies to itself). A `context`
+		// object can carry a *stale* `.transaction` left over from an earlier, unrelated call that
+		// already ran to completion: ambient contexts obtained via contextStorage.getStore() are
+		// no longer guaranteed to be fresh, one-shot objects now that processLocalTransaction (#1591/
+		// #1592) installs one shared, long-lived context for the lifetime of an entire operation
+		// handler. Without this check, a second, logically-independent static Resource API call made
+		// later in the same handler (no explicit context of its own) would see that leftover
+		// `.transaction` reference and wrongly treat it as "still open," silently folding its write
+		// into a transaction whose commit lifecycle was already driven to completion by the first
+		// call — coalescing two unrelated writes and risking the first one being dropped. See
+		// harper-pro's replication/subscriptionManager.ts ensureNode(), which is called twice in
+		// sequence (once for this node, once for a peer) from a single add_node/add_node_back
+		// operation handler and reproduced this exact loss in a live cluster-formation test.
+		if (context?.transaction?.open === TRANSACTION_STATE.OPEN) {
 			// we are already in a transaction, proceed
 			const resource = this.getResource(query, context, resourceOptions);
 			return resource.then

--- a/resources/Resource.ts
+++ b/resources/Resource.ts
@@ -672,8 +672,20 @@ function transactional(
 		// harper-pro's replication/subscriptionManager.ts ensureNode(), which is called twice in
 		// sequence (once for this node, once for a peer) from a single add_node/add_node_back
 		// operation handler and reproduced this exact loss in a live cluster-formation test.
-		if (context?.transaction?.open === TRANSACTION_STATE.OPEN) {
-			// we are already in a transaction, proceed
+		//
+		// A transaction that is no longer OPEN reached that state one of two ways, and they need
+		// opposite treatment:
+		//  - committed: the prior call ran to completion normally. Safe to silently start a fresh
+		//    transaction for this independent call (the case above).
+		//  - aborted due to exceeding storage.maxTransactionOpenTime (#1411, DatabaseTransaction.ts
+		//    abortDueToTimeout(), marked via the `timedOut` poison flag): the whole logical operation
+		//    must fail atomically, not have this write quietly land on a brand-new transaction while
+		//    the earlier write(s) were rolled back. Joining the poisoned transaction here (instead of
+		//    starting fresh) makes the write throw transactionOpenTooLongError via addWrite()/commit()'s
+		//    poison check, correctly propagating the abort to the caller. See
+		//    integrationTests/resources/txn-overtime-atomicity.test.ts.
+		if (context?.transaction?.open === TRANSACTION_STATE.OPEN || context?.transaction?.timedOut) {
+			// we are already in a transaction (or it was poisoned by a timeout abort and must fail), proceed
 			const resource = this.getResource(query, context, resourceOptions);
 			return resource.then
 				? resource.then(authorizeActionOnResource)

--- a/unitTests/resources/operationContextTransactionLeak.test.js
+++ b/unitTests/resources/operationContextTransactionLeak.test.js
@@ -60,7 +60,10 @@ describe('Ambient operation context must not couple independent writes (transact
 
 		const first = await LeakTable.get('first-record');
 		const second = await LeakTable.get('second-record');
-		assert.ok(first, 'first-record must persist: it must not be silently dropped by a leaked/shared transaction from the ambient operation context');
+		assert.ok(
+			first,
+			'first-record must persist: it must not be silently dropped by a leaked/shared transaction from the ambient operation context'
+		);
 		assert.equal(first?.name, 'first');
 		assert.ok(second, 'second-record must persist');
 		assert.equal(second?.name, 'second');

--- a/unitTests/resources/operationContextTransactionLeak.test.js
+++ b/unitTests/resources/operationContextTransactionLeak.test.js
@@ -126,4 +126,60 @@ describe('Ambient operation context must not couple independent writes (transact
 		assert.ok(afterSearch, 'write made after draining a search() iterator must persist');
 		assert.equal(afterSearch?.name, 'after-search');
 	});
+
+	// The three tests above assert final persistence, which a reviewer (cb1kenobi, PR #1720) found
+	// does not actually discriminate buggy vs. fixed code: reverting Resource.ts's fix back to the
+	// bare `if (context?.transaction)` truthiness check and re-running them still passes 3/3, because
+	// by the time a second write joins the stale, already-committed transaction from the first call,
+	// DatabaseTransaction's addWrite()/save() takes an immediate-commit path for a closed transaction,
+	// so the write still lands. That masks the actual bug in this isolated single-process unit setup,
+	// even though the same coalescing was proven to silently drop a write in the live 4-node cluster
+	// integration test (harper-pro's replicationTopology.test.mjs) that originally caught this.
+	//
+	// This test instead asserts the mechanism directly: each independent, no-explicit-context write
+	// must be serviced by its own DatabaseTransaction instance. Resource.ts's dispatcher only ever
+	// assigns a *new* transaction onto the shared ambient context via resources/transaction.ts's
+	// transaction() helper when it takes the "start a transaction" branch; the buggy bare-truthiness
+	// check instead takes the "we are already in a transaction, proceed" branch as soon as
+	// `context.transaction` is set at all, so it never calls transaction() again and the ambient
+	// context's `.transaction` reference never changes for the lifetime of the operation handler —
+	// every subsequent write is coalesced into the exact same instance. With the fix, once the prior
+	// transaction is no longer TRANSACTION_STATE.OPEN, the dispatcher takes the other branch and a
+	// fresh DatabaseTransaction is minted. This invariant fails on the pre-fix code and holds on the
+	// fix, regardless of whether an individual isolated unit test happens to still persist the data.
+	it('services each independent no-explicit-context write with its own DatabaseTransaction instance (mechanism-level)', async () => {
+		const transactionsSeenAfterEachWrite = [];
+		await serverUtilities.processLocalTransaction(
+			{ body: { operation: 'test_registered_op', hdb_user: { username: 'internal_bookkeeping' } } },
+			async () => {
+				await LeakTable.put('mech-first', { name: 'first' });
+				transactionsSeenAfterEachWrite.push(contextStorage.getStore()?.transaction);
+
+				await LeakTable.put('mech-second', { name: 'second' });
+				transactionsSeenAfterEachWrite.push(contextStorage.getStore()?.transaction);
+
+				await LeakTable.put('mech-third', { name: 'third' });
+				transactionsSeenAfterEachWrite.push(contextStorage.getStore()?.transaction);
+
+				return { message: 'ok' };
+			}
+		);
+
+		const [afterFirst, afterSecond, afterThird] = transactionsSeenAfterEachWrite;
+		assert.ok(afterFirst, 'the first write must leave a transaction attached to the ambient context');
+		assert.ok(afterSecond, 'the second write must leave a transaction attached to the ambient context');
+		assert.ok(afterThird, 'the third write must leave a transaction attached to the ambient context');
+		assert.notStrictEqual(
+			afterFirst,
+			afterSecond,
+			'the second write must not join the first write’s transaction instance: each independent, ' +
+				'no-explicit-context write must run in its own DatabaseTransaction, not a stale one left over ' +
+				'from a prior, already-completed call on the shared ambient context'
+		);
+		assert.notStrictEqual(
+			afterSecond,
+			afterThird,
+			'the third write must not join the second write’s transaction instance, for the same reason'
+		);
+	});
 });

--- a/unitTests/resources/operationContextTransactionLeak.test.js
+++ b/unitTests/resources/operationContextTransactionLeak.test.js
@@ -1,0 +1,126 @@
+const assert = require('assert');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const serverUtilities = require('#src/server/serverHelpers/serverUtilities');
+const { contextStorage } = require('#src/resources/transaction');
+const { TRANSACTION_STATE } = require('#src/resources/DatabaseTransaction');
+
+// Regression coverage for a transaction-context leak exposed by issue #1591/#1592 (ambient user
+// context for operation handlers) and confirmed against a real 2-node cluster-formation scenario
+// (harper-pro integrationTests/cluster/replicationTopology.test.mjs, bisected to core commit
+// af646222d) — see harper-pro replication/subscriptionManager.ts's ensureNode(), which is called
+// twice in sequence (once for "this node", once for a peer) from a single add_node/add_node_back
+// operation handler.
+//
+// processLocalTransaction now wraps an entire operation handler invocation in one
+// contextStorage.run({ user: hdbUser }, ...) call, installing a *single, long-lived, mutable*
+// context object as the ambient store for the whole handler. resources/transaction.ts's
+// transaction() helper mutates that shared object in place (context.transaction = <txn>) as a side
+// effect of servicing the *first* static Resource API write made with no explicit context. Because
+// the object is shared, that leftover `.transaction` reference is then visible to any *subsequent*,
+// logically-independent static Resource API write made later in the same handler — and
+// resources/Resource.ts's dispatcher decides whether to join an existing transaction purely via
+// `if (context?.transaction)` truthiness, with no check that the transaction is still meaningfully
+// open for a *fresh, unrelated* write. The two writes get folded into one transaction whose commit
+// lifecycle was only ever driven by the second call, and the first call's write is silently lost.
+//
+// Before #1591, every internal, no-explicit-context static Resource API call resolved ambient
+// context via `contextStorage.getStore() ?? {}`, and the store was always empty for operation
+// handlers (nothing ever populated it), so each call always got its own fresh, throwaway `{}` and
+// could never observe another call's transaction.
+describe('Ambient operation context must not couple independent writes (transaction leak, issue #1591 side effect)', () => {
+	let LeakTable;
+
+	before(async function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		LeakTable = table({
+			table: 'LeakTable',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+		});
+	});
+
+	it('persists two sequential no-explicit-context writes made inside one ambient-user operation', async () => {
+		await serverUtilities.processLocalTransaction(
+			{ body: { operation: 'test_registered_op', hdb_user: { username: 'internal_bookkeeping' } } },
+			async () => {
+				// Mirrors setNode()/addNodeBack(): a preceding static-API *read* (e.g.
+				// getReplicationCertAuth()'s hdb_certificate lookup) establishes the first transaction on
+				// the shared ambient context, before ensureNode() is called twice in sequence (once for
+				// "this node", once for a peer) — two logically-independent records, written through the
+				// static Resource API with no explicit context, both relying on ambient contextStorage
+				// fallback.
+				await LeakTable.get('does-not-exist-yet');
+				await LeakTable.put('first-record', { name: 'first' });
+				await LeakTable.put('second-record', { name: 'second' });
+				return { message: 'ok' };
+			}
+		);
+
+		const first = await LeakTable.get('first-record');
+		const second = await LeakTable.get('second-record');
+		assert.ok(first, 'first-record must persist: it must not be silently dropped by a leaked/shared transaction from the ambient operation context');
+		assert.equal(first?.name, 'first');
+		assert.ok(second, 'second-record must persist');
+		assert.equal(second?.name, 'second');
+	});
+
+	it('persists three sequential no-explicit-context writes made inside one ambient-user operation', async () => {
+		await serverUtilities.processLocalTransaction(
+			{ body: { operation: 'test_registered_op', hdb_user: { username: 'internal_bookkeeping' } } },
+			async () => {
+				await LeakTable.get('does-not-exist-yet-2');
+				await LeakTable.put('r1', { name: 'r1' });
+				await LeakTable.put('r2', { name: 'r2' });
+				await LeakTable.put('r3', { name: 'r3' });
+				return { message: 'ok' };
+			}
+		);
+
+		for (const id of ['r1', 'r2', 'r3']) {
+			const record = await LeakTable.get(id);
+			assert.ok(record, `${id} must persist`);
+			assert.equal(record?.name, id);
+		}
+	});
+
+	it('persists a write made after a search() iterator leaves the shared context.transaction non-OPEN', async () => {
+		// Mirrors harper-pro security/certificate.ts's signCertificate(), which does
+		// `for await (const cert of certificateTable.search([])) {...}` (a long-lived static-API read
+		// iterator) before later code in the same operation handler calls setCertTable() /
+		// ensureNode(), which write through the static API with no explicit context. A search()
+		// iterator is exactly the kind of read that can leave the shared ambient context's
+		// `.transaction` in a LINGERING (not OPEN) state once it completes, rather than a plain get().
+		await serverUtilities.processLocalTransaction(
+			{ body: { operation: 'test_registered_op', hdb_user: { username: 'internal_bookkeeping' } } },
+			async () => {
+				await LeakTable.put('pre-existing', { name: 'pre-existing' });
+				// eslint-disable-next-line no-empty
+				for await (const _record of LeakTable.search([])) {
+					// drain the iterator, as signCertificate() does
+				}
+				// At this point the shared ambient context's .transaction (if still attached at all)
+				// must not be treated as an open scope for the next, unrelated write below — assert the
+				// invariant directly so this test still documents the mechanism if the write-loss
+				// symptom is ever masked by an unrelated change.
+				const ambientTransaction = contextStorage.getStore()?.transaction;
+				if (ambientTransaction) {
+					assert.notEqual(
+						ambientTransaction.open,
+						TRANSACTION_STATE.OPEN,
+						'test setup assumption: the drained search() transaction should no longer be OPEN by the time this write runs — if it is, this test is not exercising the leak scenario'
+					);
+				}
+				await LeakTable.put('after-search', { name: 'after-search' });
+				return { message: 'ok' };
+			}
+		);
+
+		const preExisting = await LeakTable.get('pre-existing');
+		const afterSearch = await LeakTable.get('after-search');
+		assert.ok(preExisting, 'pre-existing record must still be present');
+		assert.ok(afterSearch, 'write made after draining a search() iterator must persist');
+		assert.equal(afterSearch?.name, 'after-search');
+	});
+});


### PR DESCRIPTION
## Root cause

`resources/Resource.ts`'s static-API dispatcher (backing `Table.get`/`put`/`patch`/`delete`) decides whether to join an existing transaction on the ambient context or start a fresh one purely via `if (context?.transaction)` truthiness. This is safe only when ambient contexts are fresh, one-shot objects per call — which was always true before #1591/#1592, since `context = contextStorage.getStore() ?? {}` fell back to a brand-new `{}` whenever nothing had populated `contextStorage` for the current call chain.

#1591/#1592 ("establish ambient user context for operation handlers so audit records carry attribution") changed that: `processLocalTransaction` now wraps an *entire* operation handler invocation in one `contextStorage.run({ user: hdbUser }, handler)` call, installing a single, long-lived, mutable context object as the ambient store for the whole handler. `resources/transaction.ts`'s `transaction()` helper mutates that shared object in place (`context.transaction = new DatabaseTransaction()`) as a side effect of servicing the *first* static Resource API write made with no explicit context. Because the object is shared, that leftover `.transaction` reference is then visible to any *later*, logically-independent static Resource API call made in the same handler — and `Resource.ts` wrongly joins it instead of starting its own, even though the first call's transaction may already be closing or lingering. The two writes get folded into one transaction whose commit lifecycle was only ever driven by one of the calls, and the other write can be silently dropped.

## How this was found

Flagged via `harper-pro` PR #512's CI: bumping the `core` submodule pointer past this range caused `integrationTests/cluster/replicationTopology.test.mjs` (a 4-node star-topology cluster-formation test) to fail intermittently with `Timed out waiting for cluster to connect` / `SELF_SIGNED_CERT_IN_CHAIN`. Bisecting ~87 divergent `core` commits against that test as an oracle (harper-pro code held constant, only the `core` submodule pointer changed) converged cleanly on `af646222d` ("fix: establish ambient user context for operation handlers so audit records carry attribution (#1591)") as the first-bad commit.

Root-caused by instrumenting a live 2-node cluster-formation run: harper-pro's `add_node`/`add_node_back` operation handlers (`replication/subscriptionManager.ts`'s `ensureNode()`, and `security/certificate.ts`'s `signCertificate()`) each make 2+ sequential static Resource API calls with no explicit context under one ambient-`hdb_user`-carrying operation. Tracing showed two sequential `ensureNode()` calls (once for the node's own record, once for a peer's) sharing the *identical* `DatabaseTransaction` instance — something structurally impossible before #1591, since each call always got its own throwaway `{}` context. As a result, a peer's CA cert silently failed to persist into `hdb_nodes`, so a node's TLS trust store never picked it up, producing `SELF_SIGNED_CERT_IN_CHAIN` on subsequent mesh connections.

## Fix

Only treat an ambient `.transaction` as reusable when it is still `TRANSACTION_STATE.OPEN` — the exact same self-consistency check `resources/transaction.ts`'s own `transaction()` helper already applies before deciding to reuse vs. create a transaction. This restores the pre-#1591 isolation for independent calls sharing an ambient context, while leaving genuine nested/explicit transaction chaining (a caller holding the same still-open `Context`/txn across multiple calls *within* one `transaction(...)` callback) completely unaffected, since `.open` only transitions away from `OPEN` once the transaction's owning `transaction()` call has fully completed.

This does **not** regress #1591/#1592's actual audit-attribution feature — `unitTests/resources/operationContextUser.test.js` and `unitTests/server/serverHelpers/serverUtilities.test.js` still pass unmodified.

## Testing

- New regression test: `unitTests/resources/operationContextTransactionLeak.test.js` — exercises 2 and 3 sequential no-explicit-context static-API writes, plus a write following a drained `search()` iterator, all inside one ambient-user `processLocalTransaction` scope, asserting every write persists.
- Existing suites re-run clean against this fix: `unitTests/resources/**` (1029 passing), `unitTests/server/serverHelpers/**` (200 passing, including all `#1591` audit-attribution cases), `unitTests/components/mcp/audit.test.js` (13 passing), `unitTests/dataLayer/**` (155 passing).
- Full-system validation against `harper-pro`'s `integrationTests/cluster/replicationTopology.test.mjs` ("connect nodes", 4-node star topology), with `core` pinned at `af646222d`:
  - **Without this fix**: fails consistently, 0/3 runs, timing out waiting for the cluster to connect (`SELF_SIGNED_CERT_IN_CHAIN` in node logs).
  - **With this fix** (harper-pro code otherwise unmodified): passes consistently, 3/3 runs, at the same speed (~3.2s) as a pre-`af646222d` `core` baseline run on the same machine.

## Note for harper-pro

`ensureNode()`'s own writes remain attributed to whatever ambient `hdb_user` happens to be present (e.g. the calling admin, or an inter-node connection's resolved auth principal) even with this fix — no longer a data-loss bug, but arguably still slightly wrong for audit-attribution purposes, since this is internal replication/system bookkeeping, not a user-authored write. I've prepared a small, separate defense-in-depth harper-pro change (giving `ensureNode()` an explicit, isolated context) that Kris can review/merge independently; it is not required for this fix to be effective.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>