### PR TITLE
fix(config): scope.options sees runtime env config before the file flush (#1618)

### DIFF
--- a/components/OptionsWatcher.ts
+++ b/components/OptionsWatcher.ts
@@ -13,21 +13,14 @@ import { composeConfigFromEnv } from '../config/harperConfigEnvVars.ts';
 import { HARPER_CONFIG_FILE, HDB_CONFIG_FILE } from '../utility/hdbTerms.ts';
 
 /**
- * True when `filePath` is THE root config file. Prefers an exact match against the
- * resolved root-config path (covers the legacy `harperdb-config.yaml` name and rules
- * out a component that happens to ship a root-named file); falls back to a filename
- * match when configUtils isn't initialized (unit tests, early boot).
+ * Filename heuristic for "is this THE root config file" — matches the current and
+ * legacy root config names. Known limitation: a component that ships its own
+ * `harper-config.yaml` (a supported loader preference) is misclassified as root and
+ * gets the env overlay; harmless unless config env vars are set AND the component's
+ * keys collide with them. Callers that know root-ness authoritatively should pass
+ * the explicit `isRootConfig` constructor argument instead.
  */
-function isRootConfigPath(filePath: string): boolean {
-	try {
-		// Lazy require: configUtils' static import graph reaches server modules and must
-		// not be pulled in at OptionsWatcher module-load time (cycle risk on node 22+).
-		const { getConfigFilePath } = require('../config/configUtils');
-		const rootPath = getConfigFilePath();
-		if (typeof rootPath === 'string' && rootPath.length > 0) return filePath === rootPath;
-	} catch {
-		// fall through to the filename heuristic
-	}
+function looksLikeRootConfigPath(filePath: string): boolean {
 	const name = basename(filePath);
 	return name === HARPER_CONFIG_FILE || name === HDB_CONFIG_FILE;
 }
@@ -123,14 +116,14 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 	#pendingReads: Set<Promise<void>> = new Set();
 	ready: Promise<any[]>;
 
-	constructor(name: string, filePath: string, logger?: Logger) {
+	constructor(name: string, filePath: string, logger?: Logger, isRootConfig?: boolean) {
 		super();
 		this.#name = name;
 		this.#filePath = filePath;
 		// Root-config watchers must see runtime env config (HARPER_SET_CONFIG et al.)
 		// even when it hasn't been flushed to disk yet — see #handleChange (#1618).
 		// Application scopes watch their own config.yaml and are never overlaid.
-		this.#isRootConfig = isRootConfigPath(filePath);
+		this.#isRootConfig = isRootConfig ?? looksLikeRootConfigPath(filePath);
 		this.#logger = logger || loggerWithTag(name);
 		this.#usingPolling = false;
 		this.#closed = false;

--- a/components/OptionsWatcher.ts
+++ b/components/OptionsWatcher.ts
@@ -8,33 +8,13 @@ import { isDeepStrictEqual } from 'util';
 import { DEFAULT_CONFIG } from './DEFAULT_CONFIG.ts';
 import { cloneDeep } from 'lodash';
 import { POLLING_FALLBACK_OPTIONS, isWatcherExhaustionError, warnWatcherFallback } from '../utility/watcherFallback.ts';
-import { basename } from 'node:path';
-import { composeConfigFromEnv } from '../config/harperConfigEnvVars.ts';
-import { HARPER_CONFIG_FILE, HDB_CONFIG_FILE } from '../utility/hdbTerms.ts';
-
-/**
- * Filename heuristic for "is this THE root config file" — matches the current and
- * legacy root config names. Known limitation: a component that ships its own
- * `harper-config.yaml` (a supported loader preference) is misclassified as root and
- * gets the env overlay; harmless unless config env vars are set AND the component's
- * keys collide with them. Callers that know root-ness authoritatively should pass
- * the explicit `isRootConfig` constructor argument instead.
- */
-function looksLikeRootConfigPath(filePath: string): boolean {
-	const name = basename(filePath);
-	return name === HARPER_CONFIG_FILE || name === HDB_CONFIG_FILE;
-}
+import { overlayRootEnvConfig, isRootConfigFilename } from '../config/harperConfigEnvVars.ts';
 
 export interface Config {
 	[key: string]: ConfigValue;
 }
 
 export type ConfigValue = undefined | null | string | number | boolean | Array<ConfigValue> | Config;
-
-/** Any of the three config-shaping env vars present in this process. */
-function hasConfigEnvVars(): boolean {
-	return Boolean(process.env.HARPER_SET_CONFIG || process.env.HARPER_CONFIG || process.env.HARPER_DEFAULT_CONFIG);
-}
 
 export type OptionsWatcherEventMap = {
 	ready: [config?: ConfigValue];
@@ -123,7 +103,7 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 		// Root-config watchers must see runtime env config (HARPER_SET_CONFIG et al.)
 		// even when it hasn't been flushed to disk yet — see #handleChange (#1618).
 		// Application scopes watch their own config.yaml and are never overlaid.
-		this.#isRootConfig = isRootConfig ?? looksLikeRootConfigPath(filePath);
+		this.#isRootConfig = isRootConfig ?? isRootConfigFilename(filePath);
 		this.#logger = logger || loggerWithTag(name);
 		this.#usingPolling = false;
 		this.#closed = false;
@@ -149,15 +129,14 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 		const read: Promise<void> = readFile(this.#filePath, 'utf-8')
 			.then((contents) => {
 				let parsed = yaml.parse(contents);
-				// The on-disk root config is not guaranteed to include runtime env config
-				// (HARPER_SET_CONFIG / HARPER_CONFIG / HARPER_DEFAULT_CONFIG) at boot: the
-				// file flush races component loading, so a scope's boot-time reads (e.g. an
-				// `enabled` gate in handleApplication) could observe pre-env values that the
-				// componentLoader itself never saw. Compose the env layers over EVERY
-				// root-config read so scope.options always matches the resolved view (#1618).
-				if (this.#isRootConfig && hasConfigEnvVars()) {
-					parsed = composeConfigFromEnv(parsed && typeof parsed === 'object' ? parsed : {});
-				}
+				// The on-disk root config is not guaranteed to include runtime env config at
+				// boot: the file flush races component loading, so a scope's boot-time reads
+				// (e.g. an `enabled` gate in handleApplication) could observe pre-env values
+				// the componentLoader itself never saw. Ask the config layer to overlay env
+				// config onto EVERY root-config read so scope.options matches the resolved
+				// view (#1618). Non-root scopes and the no-env-vars case are untouched
+				// (overlayRootEnvConfig is a no-op there).
+				if (this.#isRootConfig) parsed = overlayRootEnvConfig(parsed);
 				this.#rootConfig = parsed && typeof parsed === 'object' ? parsed : undefined;
 				// If the extension is in the config file
 				if (this.#rootConfig && this.#name in this.#rootConfig) {
@@ -185,26 +164,26 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 			.catch((error) => {
 				// If the config file does not exist
 				if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
-					// Root config missing but env config present (e.g. the install hasn't
-					// flushed the file yet): compose the env layers over an empty base so
-					// boot-time consumers still see the effective config (#1618). The
-					// composed object becomes our state ONLY when this scope's name is in
-					// it — otherwise fall through to the original ENOENT handling with
-					// #rootConfig untouched (a first read must emit `ready`, not `remove`;
-					// nothing consumes `remove` at boot and `ready` would hang forever).
-					// composeConfigFromEnv throws on malformed env JSON; route that to
-					// `error` like the file-read path does, not an unhandled rejection.
-					if (this.#isRootConfig && hasConfigEnvVars()) {
+					// Root config file missing (e.g. the install hasn't flushed it yet): ask the
+					// config layer for the env-only overlay so boot-time consumers still see the
+					// effective config (#1618). It becomes our state ONLY when this scope's name
+					// is present — otherwise fall through to the original ENOENT handling with
+					// #rootConfig untouched (a first read must emit `ready`, not `remove`; nothing
+					// consumes `remove` at boot and `ready` would hang forever). overlayRootEnvConfig
+					// returns undefined when no env vars are set, and throws on malformed env JSON —
+					// route that to `error` like the file-read path, not an unhandled rejection.
+					if (this.#isRootConfig) {
+						let composed: Config | undefined;
 						try {
-							const composed = composeConfigFromEnv({}) as Config;
-							if (this.#name in composed && !this.#scopedConfig) {
-								this.#rootConfig = composed;
-								this.#scopedConfig = composed[this.#name];
-								this.emit('ready', this.#scopedConfig);
-								return;
-							}
+							composed = overlayRootEnvConfig(undefined) as Config | undefined;
 						} catch (composeError) {
 							this.emit('error', composeError);
+							return;
+						}
+						if (composed && this.#name in composed && !this.#scopedConfig) {
+							this.#rootConfig = composed;
+							this.#scopedConfig = composed[this.#name];
+							this.emit('ready', this.#scopedConfig);
 							return;
 						}
 					}

--- a/components/OptionsWatcher.ts
+++ b/components/OptionsWatcher.ts
@@ -10,7 +10,27 @@ import { cloneDeep } from 'lodash';
 import { POLLING_FALLBACK_OPTIONS, isWatcherExhaustionError, warnWatcherFallback } from '../utility/watcherFallback.ts';
 import { basename } from 'node:path';
 import { composeConfigFromEnv } from '../config/harperConfigEnvVars.ts';
-import { HARPER_CONFIG_FILE } from '../utility/hdbTerms.ts';
+import { HARPER_CONFIG_FILE, HDB_CONFIG_FILE } from '../utility/hdbTerms.ts';
+
+/**
+ * True when `filePath` is THE root config file. Prefers an exact match against the
+ * resolved root-config path (covers the legacy `harperdb-config.yaml` name and rules
+ * out a component that happens to ship a root-named file); falls back to a filename
+ * match when configUtils isn't initialized (unit tests, early boot).
+ */
+function isRootConfigPath(filePath: string): boolean {
+	try {
+		// Lazy require: configUtils' static import graph reaches server modules and must
+		// not be pulled in at OptionsWatcher module-load time (cycle risk on node 22+).
+		const { getConfigFilePath } = require('../config/configUtils');
+		const rootPath = getConfigFilePath();
+		if (typeof rootPath === 'string' && rootPath.length > 0) return filePath === rootPath;
+	} catch {
+		// fall through to the filename heuristic
+	}
+	const name = basename(filePath);
+	return name === HARPER_CONFIG_FILE || name === HDB_CONFIG_FILE;
+}
 
 export interface Config {
 	[key: string]: ConfigValue;
@@ -110,7 +130,7 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 		// Root-config watchers must see runtime env config (HARPER_SET_CONFIG et al.)
 		// even when it hasn't been flushed to disk yet — see #handleChange (#1618).
 		// Application scopes watch their own config.yaml and are never overlaid.
-		this.#isRootConfig = basename(filePath) === HARPER_CONFIG_FILE;
+		this.#isRootConfig = isRootConfigPath(filePath);
 		this.#logger = logger || loggerWithTag(name);
 		this.#usingPolling = false;
 		this.#closed = false;
@@ -174,13 +194,24 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 				if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
 					// Root config missing but env config present (e.g. the install hasn't
 					// flushed the file yet): compose the env layers over an empty base so
-					// boot-time consumers still see the effective config (#1618).
+					// boot-time consumers still see the effective config (#1618). The
+					// composed object becomes our state ONLY when this scope's name is in
+					// it — otherwise fall through to the original ENOENT handling with
+					// #rootConfig untouched (a first read must emit `ready`, not `remove`;
+					// nothing consumes `remove` at boot and `ready` would hang forever).
+					// composeConfigFromEnv throws on malformed env JSON; route that to
+					// `error` like the file-read path does, not an unhandled rejection.
 					if (this.#isRootConfig && hasConfigEnvVars()) {
-						const composed = composeConfigFromEnv({});
-						this.#rootConfig = composed as Config;
-						if (this.#name in composed && !this.#scopedConfig) {
-							this.#scopedConfig = (composed as Config)[this.#name];
-							this.emit('ready', this.#scopedConfig);
+						try {
+							const composed = composeConfigFromEnv({}) as Config;
+							if (this.#name in composed && !this.#scopedConfig) {
+								this.#rootConfig = composed;
+								this.#scopedConfig = composed[this.#name];
+								this.emit('ready', this.#scopedConfig);
+								return;
+							}
+						} catch (composeError) {
+							this.emit('error', composeError);
 							return;
 						}
 					}

--- a/components/OptionsWatcher.ts
+++ b/components/OptionsWatcher.ts
@@ -164,14 +164,12 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 			.catch((error) => {
 				// If the config file does not exist
 				if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
-					// Root config file missing (e.g. the install hasn't flushed it yet): ask the
-					// config layer for the env-only overlay so boot-time consumers still see the
-					// effective config (#1618). It becomes our state ONLY when this scope's name
-					// is present — otherwise fall through to the original ENOENT handling with
-					// #rootConfig untouched (a first read must emit `ready`, not `remove`; nothing
-					// consumes `remove` at boot and `ready` would hang forever). overlayRootEnvConfig
-					// returns undefined when no env vars are set, and throws on malformed env JSON —
-					// route that to `error` like the file-read path, not an unhandled rejection.
+					// A readFile ENOENT here is the install window (file not written yet) or a
+					// transient read race — NOT a real deletion, which chokidar routes to
+					// `#handleUnlink`. Ask the config layer for the env-only overlay so boot-time
+					// consumers still see the effective config (#1618). overlayRootEnvConfig returns
+					// undefined when no env vars are set, and throws on malformed env JSON — route
+					// that to `error` like the file-read path, not an unhandled rejection.
 					if (this.#isRootConfig) {
 						let composed: Config | undefined;
 						try {
@@ -180,10 +178,20 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 							this.emit('error', composeError);
 							return;
 						}
-						if (composed && this.#name in composed && !this.#scopedConfig) {
+						// Env config is file-independent: if it provides this scope, a missing/
+						// unreadable file must not discard it (first read → ready; a later read with
+						// config already set → merge, never reset). When this scope is NOT in the env
+						// config, fall through to the original ENOENT handling with #rootConfig
+						// untouched, so a first boot still emits `ready` (not `remove`, which nothing
+						// consumes at boot → `ready` would hang forever).
+						if (composed && this.#name in composed) {
 							this.#rootConfig = composed;
-							this.#scopedConfig = composed[this.#name];
-							this.emit('ready', this.#scopedConfig);
+							if (!this.#scopedConfig) {
+								this.#scopedConfig = composed[this.#name];
+								this.emit('ready', this.#scopedConfig);
+							} else {
+								this.#merge(composed[this.#name], this.#scopedConfig);
+							}
 							return;
 						}
 					}

--- a/components/OptionsWatcher.ts
+++ b/components/OptionsWatcher.ts
@@ -8,12 +8,20 @@ import { isDeepStrictEqual } from 'util';
 import { DEFAULT_CONFIG } from './DEFAULT_CONFIG.ts';
 import { cloneDeep } from 'lodash';
 import { POLLING_FALLBACK_OPTIONS, isWatcherExhaustionError, warnWatcherFallback } from '../utility/watcherFallback.ts';
+import { basename } from 'node:path';
+import { composeConfigFromEnv } from '../config/harperConfigEnvVars.ts';
+import { HARPER_CONFIG_FILE } from '../utility/hdbTerms.ts';
 
 export interface Config {
 	[key: string]: ConfigValue;
 }
 
 export type ConfigValue = undefined | null | string | number | boolean | Array<ConfigValue> | Config;
+
+/** Any of the three config-shaping env vars present in this process. */
+function hasConfigEnvVars(): boolean {
+	return Boolean(process.env.HARPER_SET_CONFIG || process.env.HARPER_CONFIG || process.env.HARPER_DEFAULT_CONFIG);
+}
 
 export type OptionsWatcherEventMap = {
 	ready: [config?: ConfigValue];
@@ -86,6 +94,7 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 	#watcher!: FSWatcher;
 	#scopedConfig?: ConfigValue;
 	#rootConfig?: Config;
+	#isRootConfig: boolean;
 	#name: string;
 	#logger: Logger;
 	#usingPolling: boolean;
@@ -98,6 +107,10 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 		super();
 		this.#name = name;
 		this.#filePath = filePath;
+		// Root-config watchers must see runtime env config (HARPER_SET_CONFIG et al.)
+		// even when it hasn't been flushed to disk yet — see #handleChange (#1618).
+		// Application scopes watch their own config.yaml and are never overlaid.
+		this.#isRootConfig = basename(filePath) === HARPER_CONFIG_FILE;
 		this.#logger = logger || loggerWithTag(name);
 		this.#usingPolling = false;
 		this.#closed = false;
@@ -122,7 +135,16 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 	#handleChange() {
 		const read: Promise<void> = readFile(this.#filePath, 'utf-8')
 			.then((contents) => {
-				const parsed = yaml.parse(contents);
+				let parsed = yaml.parse(contents);
+				// The on-disk root config is not guaranteed to include runtime env config
+				// (HARPER_SET_CONFIG / HARPER_CONFIG / HARPER_DEFAULT_CONFIG) at boot: the
+				// file flush races component loading, so a scope's boot-time reads (e.g. an
+				// `enabled` gate in handleApplication) could observe pre-env values that the
+				// componentLoader itself never saw. Compose the env layers over EVERY
+				// root-config read so scope.options always matches the resolved view (#1618).
+				if (this.#isRootConfig && hasConfigEnvVars()) {
+					parsed = composeConfigFromEnv(parsed && typeof parsed === 'object' ? parsed : {});
+				}
 				this.#rootConfig = parsed && typeof parsed === 'object' ? parsed : undefined;
 				// If the extension is in the config file
 				if (this.#rootConfig && this.#name in this.#rootConfig) {
@@ -150,6 +172,18 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 			.catch((error) => {
 				// If the config file does not exist
 				if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+					// Root config missing but env config present (e.g. the install hasn't
+					// flushed the file yet): compose the env layers over an empty base so
+					// boot-time consumers still see the effective config (#1618).
+					if (this.#isRootConfig && hasConfigEnvVars()) {
+						const composed = composeConfigFromEnv({});
+						this.#rootConfig = composed as Config;
+						if (this.#name in composed && !this.#scopedConfig) {
+							this.#scopedConfig = (composed as Config)[this.#name];
+							this.emit('ready', this.#scopedConfig);
+							return;
+						}
+					}
 					// And a config already exists, reset it to the default
 					if (this.#rootConfig) {
 						this.#resetConfig();

--- a/components/OptionsWatcher.ts
+++ b/components/OptionsWatcher.ts
@@ -166,35 +166,12 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 				if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
 					// A readFile ENOENT here is the install window (file not written yet) or a
 					// transient read race — NOT a real deletion, which chokidar routes to
-					// `#handleUnlink`. Ask the config layer for the env-only overlay so boot-time
-					// consumers still see the effective config (#1618). overlayRootEnvConfig returns
-					// undefined when no env vars are set, and throws on malformed env JSON — route
-					// that to `error` like the file-read path, not an unhandled rejection.
-					if (this.#isRootConfig) {
-						let composed: Config | undefined;
-						try {
-							composed = overlayRootEnvConfig(undefined) as Config | undefined;
-						} catch (composeError) {
-							this.emit('error', composeError);
-							return;
-						}
-						// Env config is file-independent: if it provides this scope, a missing/
-						// unreadable file must not discard it (first read → ready; a later read with
-						// config already set → merge, never reset). When this scope is NOT in the env
-						// config, fall through to the original ENOENT handling with #rootConfig
-						// untouched, so a first boot still emits `ready` (not `remove`, which nothing
-						// consumes at boot → `ready` would hang forever).
-						if (composed && this.#name in composed) {
-							this.#rootConfig = composed;
-							if (!this.#scopedConfig) {
-								this.#scopedConfig = composed[this.#name];
-								this.emit('ready', this.#scopedConfig);
-							} else {
-								this.#merge(composed[this.#name], this.#scopedConfig);
-							}
-							return;
-						}
-					}
+					// `#handleUnlink`. Env config is file-independent, so when it provides this
+					// scope the missing file must not discard it (#1618). When it does not, fall
+					// through to the original ENOENT handling with #rootConfig untouched, so a
+					// first boot still emits `ready` (not `remove`, which nothing consumes at
+					// boot → `ready` would hang forever).
+					if (this.#applyEnvOnlyConfig()) return;
 					// And a config already exists, reset it to the default
 					if (this.#rootConfig) {
 						this.#resetConfig();
@@ -241,11 +218,49 @@ export class OptionsWatcher extends EventEmitter<OptionsWatcherEventMap> {
 	}
 
 	#handleUnlink(path: string) {
+		// A real deletion still leaves env-var config in force: an env-defined scope must
+		// survive it exactly as on the ENOENT read path — same fallback, same error routing
+		// (#1618, #1726 review).
+		if (this.#applyEnvOnlyConfig()) {
+			this.#logger.warn?.(
+				`Configuration file ${path} was deleted; the env-var-defined configuration for '${this.#name}' remains in effect.`
+			);
+			return;
+		}
 		this.#logger.warn?.(
 			`Configuration file ${path} was deleted. Reverting to default configuration. Recreate it to restore the options watcher.`
 		);
 		this.#resetConfig();
 		this.emit('remove');
+	}
+
+	/**
+	 * Shared fallback for the ENOENT read path and `#handleUnlink`: when config env vars
+	 * define this scope, apply the env-only overlay (first application → `ready`; already
+	 * configured → `merge`, never reset). Returns true when the event was handled —
+	 * including the malformed-env case, which routes to `error` like the file-read path
+	 * rather than an unhandled rejection. Returns false (root config untouched) when this
+	 * is not a root config or the env config does not provide the scope, so callers keep
+	 * their own reset semantics.
+	 */
+	#applyEnvOnlyConfig(): boolean {
+		if (!this.#isRootConfig) return false;
+		let composed: Config | undefined;
+		try {
+			composed = overlayRootEnvConfig(undefined) as Config | undefined;
+		} catch (composeError) {
+			this.emit('error', composeError);
+			return true;
+		}
+		if (!composed || !(this.#name in composed)) return false;
+		this.#rootConfig = composed;
+		if (!this.#scopedConfig) {
+			this.#scopedConfig = composed[this.#name];
+			this.emit('ready', this.#scopedConfig);
+		} else {
+			this.#merge(composed[this.#name], this.#scopedConfig);
+		}
+		return true;
 	}
 
 	#resetConfig() {

--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -76,7 +76,8 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 		directory: string,
 		configFilePath: string,
 		applicationScope: ApplicationScope,
-		origin: string = appName
+		origin: string = appName,
+		isRootConfig?: boolean
 	) {
 		super();
 
@@ -124,7 +125,10 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 		this.ready = once(this, 'ready');
 
 		// Create the options instance for the scope immediately
-		this.options = new OptionsWatcher(pluginName, configFilePath, this.#logger)
+		// isRootConfig is the loader's authoritative isRoot signal — it decides whether the
+		// watcher overlays runtime env config (#1618). When a caller doesn't provide it,
+		// OptionsWatcher falls back to its root-config filename heuristic.
+		this.options = new OptionsWatcher(pluginName, configFilePath, this.#logger, isRootConfig)
 			.on('error', this.#handleError.bind(this))
 			.on('change', this.#optionsWatcherChangeListener.bind(this)())
 			.on('ready', this.#handleOptionsWatcherReady.bind(this));

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -507,7 +507,11 @@ export async function loadComponent(
 						componentDirectory,
 						configPath,
 						applicationScope,
-						origin
+						origin,
+						// authoritative root-ness: only root-load scopes watch THE root config and
+						// get the runtime env-config overlay (#1618) — an app component that happens
+						// to ship a root-named config file does not
+						isRoot
 					);
 
 					// Track the close so the worker's shutdown path waits for it (and thus for any async

--- a/config/harperConfigEnvVars.ts
+++ b/config/harperConfigEnvVars.ts
@@ -305,6 +305,17 @@ export function filterArgsAgainstRuntimeConfig(args: Record<string, any>): Recor
 /**
  * Flatten nested object to dot-notation paths
  */
+// One warning per distinct path per process — flattenObject runs on every env apply.
+const warnedEmptyObjectPaths = new Set<string>();
+function warnEmptyObjectDropped(path: string): void {
+	if (warnedEmptyObjectPaths.has(path)) return;
+	warnedEmptyObjectPaths.add(path);
+	getLogger().warn?.(
+		`[env-config] '${path}' is an empty object in env-var config and carries no settings; ` +
+			`it will not appear in the resolved config. Set an explicit value (e.g. '${path}.enabled: true').`
+	);
+}
+
 function flattenObject(obj: ConfigObject, prefix = ''): Record<string, any> {
 	const result: Record<string, any> = {};
 
@@ -315,7 +326,13 @@ function flattenObject(obj: ConfigObject, prefix = ''): Record<string, any> {
 		const newKey = prefix ? `${prefix}.${key}` : key;
 
 		if (isPlainObject(value) && !isDirectiveObject(value)) {
-			// Recurse for nested objects
+			// Recurse for nested objects. An EMPTY object contributes no leaves — that is
+			// load-bearing for removal semantics (`http: {}` in SET_CONFIG means "no
+			// overrides under http", restoring originals) — but it also means a bare
+			// `componentName: {}` carries no signal at all, which has silently confused
+			// users (#1618). Warn once per path so the drop is visible; use an explicit
+			// value (e.g. `enabled: true`) to convey presence.
+			if (Object.keys(value).length === 0) warnEmptyObjectDropped(newKey);
 			Object.assign(result, flattenObject(value, newKey));
 		} else {
 			// Store primitive, array, or directive ({ $union: [...] }) as a leaf

--- a/config/harperConfigEnvVars.ts
+++ b/config/harperConfigEnvVars.ts
@@ -28,6 +28,7 @@ import * as path from 'node:path';
 import * as crypto from 'node:crypto';
 import { cloneDeep } from 'lodash';
 import { getBackupDirPath } from './configHelpers.ts';
+import * as hdbTerms from '../utility/hdbTerms.ts';
 
 const STATE_FILE_NAME = '.harper-config-state.json';
 
@@ -771,6 +772,37 @@ export function composeConfigFromEnv(base: ConfigObject = {}): ConfigObject {
 	}
 
 	return result;
+}
+
+/** True when any config-shaping env var (HARPER_DEFAULT_CONFIG / HARPER_CONFIG / HARPER_SET_CONFIG) is set. */
+export function hasConfigEnvVars(): boolean {
+	return Boolean(process.env.HARPER_DEFAULT_CONFIG || process.env.HARPER_CONFIG || process.env.HARPER_SET_CONFIG);
+}
+
+/**
+ * Overlay runtime env config onto a base root-config object, hiding the env-var names and
+ * the composition rules from callers. Returns `base` unchanged when no config env vars are
+ * set (a true no-op — callers can invoke it on every root-config read without branching).
+ * A missing/non-object `base` (e.g. the install window before the config file is written)
+ * is treated as an empty base. Throws (via composeConfigFromEnv) on malformed env-var JSON.
+ */
+export function overlayRootEnvConfig(base: ConfigObject | undefined): ConfigObject | undefined {
+	if (!hasConfigEnvVars()) return base;
+	return composeConfigFromEnv(isPlainObject(base) ? base : {});
+}
+
+/**
+ * True when `filePath` names THE root Harper config file (current or legacy name), as
+ * opposed to a component/application `config.yaml`. Filename-only by design: an exact
+ * path comparison against the resolved root-config path misclassifies watchers in any
+ * environment where a real config instance is resolved (including the unit harness).
+ * Callers that know root-ness authoritatively should pass it explicitly rather than rely
+ * on this heuristic; a component that ships its own root-named file is a known false
+ * positive (harmless unless env config is set and its keys collide).
+ */
+export function isRootConfigFilename(filePath: string): boolean {
+	const name = path.basename(filePath);
+	return name === hdbTerms.HARPER_CONFIG_FILE || name === hdbTerms.HDB_CONFIG_FILE;
 }
 
 /**

--- a/config/harperConfigEnvVars.ts
+++ b/config/harperConfigEnvVars.ts
@@ -796,9 +796,10 @@ export function overlayRootEnvConfig(base: ConfigObject | undefined): ConfigObje
  * opposed to a component/application `config.yaml`. Filename-only by design: an exact
  * path comparison against the resolved root-config path misclassifies watchers in any
  * environment where a real config instance is resolved (including the unit harness).
- * Callers that know root-ness authoritatively should pass it explicitly rather than rely
- * on this heuristic; a component that ships its own root-named file is a known false
- * positive (harmless unless env config is set and its keys collide).
+ * FALLBACK ONLY: real component loads thread the loader's authoritative `isRoot` through
+ * `Scope` → `OptionsWatcher(…, isRootConfig)`, so this heuristic applies just to direct
+ * constructions (tests, ad-hoc callers), where a root-named app config file is a known,
+ * accepted false positive.
  */
 export function isRootConfigFilename(filePath: string): boolean {
 	const name = path.basename(filePath);

--- a/config/harperConfigEnvVars.ts
+++ b/config/harperConfigEnvVars.ts
@@ -317,7 +317,7 @@ function warnEmptyObjectDropped(path: string): void {
 	);
 }
 
-function flattenObject(obj: ConfigObject, prefix = ''): Record<string, any> {
+function flattenObject(obj: ConfigObject, prefix = '', warnOnEmptyDrop = true): Record<string, any> {
 	const result: Record<string, any> = {};
 
 	for (const key in obj) {
@@ -332,9 +332,11 @@ function flattenObject(obj: ConfigObject, prefix = ''): Record<string, any> {
 			// overrides under http", restoring originals) — but it also means a bare
 			// `componentName: {}` carries no signal at all, which has silently confused
 			// users (#1618). Warn once per path so the drop is visible; use an explicit
-			// value (e.g. `enabled: true`) to convey presence.
-			if (Object.keys(value).length === 0) warnEmptyObjectDropped(newKey);
-			Object.assign(result, flattenObject(value, newKey));
+			// value (e.g. `enabled: true`) to convey presence. The base config file is
+			// exempt (warnOnEmptyDrop=false): its empty objects are user content and are
+			// restored after composition rather than dropped (#1726 review).
+			if (Object.keys(value).length === 0 && warnOnEmptyDrop) warnEmptyObjectDropped(newKey);
+			Object.assign(result, flattenObject(value, newKey, warnOnEmptyDrop));
 		} else {
 			// Store primitive, array, or directive ({ $union: [...] }) as a leaf
 			result[newKey] = value;
@@ -342,6 +344,34 @@ function flattenObject(obj: ConfigObject, prefix = ''): Record<string, any> {
 	}
 
 	return result;
+}
+
+/**
+ * Re-add empty-object paths from the base config file that `flattenObject` dropped
+ * during composition. The base file is user content, not an override layer: a bare
+ * `componentName: {}` there is a real (empty) scope declaration, unlike an env-layer
+ * `{}` which means "no overrides here". Only paths the composition did not otherwise
+ * populate are restored — an env layer that set or replaced the path wins.
+ */
+function restoreBaseEmptyObjects(source: ConfigObject, target: ConfigObject): void {
+	for (const key in source) {
+		if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+		const value = source[key];
+		if (!isPlainObject(value) || isDirectiveObject(value)) continue;
+		if (Object.keys(value).length === 0) {
+			if (!(key in target)) target[key] = {};
+		} else if (key in target) {
+			// Recurse only while the composed side is still an object; a non-object env
+			// replacement wins over the base subtree.
+			if (isPlainObject(target[key])) restoreBaseEmptyObjects(value, target[key] as ConfigObject);
+		} else {
+			// The subtree produced no leaves at all (its only content was empty objects,
+			// possibly nested) — rebuild just the empty-object skeleton.
+			const skeleton: ConfigObject = {};
+			restoreBaseEmptyObjects(value, skeleton);
+			if (Object.keys(skeleton).length > 0) target[key] = skeleton;
+		}
+	}
 }
 
 /**
@@ -756,20 +786,25 @@ function cleanupRemovedEnvVar(
  */
 export function composeConfigFromEnv(base: ConfigObject = {}): ConfigObject {
 	const result: ConfigObject = {};
+	const baseLayer = cloneDeep(base);
 	const layers: (ConfigObject | null)[] = [
 		parseConfigEnvVar(process.env.HARPER_DEFAULT_CONFIG, 'HARPER_DEFAULT_CONFIG'),
-		cloneDeep(base),
+		baseLayer,
 		parseConfigEnvVar(process.env.HARPER_CONFIG, 'HARPER_CONFIG'),
 		parseConfigEnvVar(process.env.HARPER_SET_CONFIG, 'HARPER_SET_CONFIG'),
 	];
 
 	for (const layer of layers) {
 		if (!layer) continue;
-		for (const [p, value] of Object.entries(flattenObject(layer))) {
+		for (const [p, value] of Object.entries(flattenObject(layer, '', layer !== baseLayer))) {
 			// directive leaves compose against the value accumulated by prior layers
 			setNestedValue(result, p, resolveLeafValue(getNestedValue(result, p), value, p));
 		}
 	}
+
+	// The base file's empty objects are user content (e.g. a bare `componentName: {}`
+	// scope) — restore the ones composition didn't otherwise populate (#1726 review).
+	restoreBaseEmptyObjects(baseLayer, result);
 
 	return result;
 }

--- a/unitTests/components/OptionsWatcher-envOverlay.test.js
+++ b/unitTests/components/OptionsWatcher-envOverlay.test.js
@@ -90,4 +90,23 @@ describe('OptionsWatcher env-config overlay (#1618)', () => {
 		await watcher.ready;
 		assert.strictEqual(watcher.get(['enabled']), false);
 	});
+
+	it('still emits ready when the file is absent and env config lacks this scope (no remove/hang)', async () => {
+		const filePath = join(dir, 'harper-config.yaml'); // never written
+		process.env.HARPER_SET_CONFIG = JSON.stringify({ http: { port: 12345 } }); // some OTHER scope
+
+		watcher = new OptionsWatcher(NAME, filePath);
+		const [config] = await watcher.ready; // regression guard: must resolve, not hang on 'remove'
+		assert.strictEqual(config, undefined);
+	});
+
+	it('overlays env config onto the legacy root config filename (harperdb-config.yaml)', async () => {
+		const filePath = join(dir, 'harperdb-config.yaml');
+		writeFileSync(filePath, stringify({ [NAME]: { enabled: false } }));
+		process.env.HARPER_SET_CONFIG = JSON.stringify({ [NAME]: { enabled: true } });
+
+		watcher = new OptionsWatcher(NAME, filePath);
+		await watcher.ready;
+		assert.strictEqual(watcher.get(['enabled']), true);
+	});
 });

--- a/unitTests/components/OptionsWatcher-envOverlay.test.js
+++ b/unitTests/components/OptionsWatcher-envOverlay.test.js
@@ -110,3 +110,74 @@ describe('OptionsWatcher env-config overlay (#1618)', () => {
 		assert.strictEqual(watcher.get(['enabled']), true);
 	});
 });
+
+describe('OptionsWatcher env-config resilience (#1726 review)', () => {
+	const NAME = 'modelsGateway';
+	const ENV_KEYS = ['HARPER_SET_CONFIG', 'HARPER_CONFIG', 'HARPER_DEFAULT_CONFIG'];
+	let dir;
+	let savedEnv;
+	let watcher;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), 'options-watcher-env-'));
+		savedEnv = {};
+		for (const key of ENV_KEYS) {
+			savedEnv[key] = process.env[key];
+			delete process.env[key];
+		}
+	});
+
+	afterEach(async () => {
+		await watcher?.close();
+		watcher = undefined;
+		for (const key of ENV_KEYS) {
+			if (savedEnv[key] === undefined) delete process.env[key];
+			else process.env[key] = savedEnv[key];
+		}
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it('a bare `componentName: {}` scope in the root config file survives when env vars are set', async function () {
+		// Regression guard: the base file used to be routed through the env-layer flatten,
+		// which drops empty objects — the scope vanished from the composed root config and
+		// boot hung waiting for `ready` (or an already-ready watcher got `remove`).
+		this.timeout(4000);
+		const filePath = join(dir, 'harper-config.yaml');
+		writeFileSync(filePath, stringify({ [NAME]: {} }));
+		process.env.HARPER_SET_CONFIG = JSON.stringify({ http: { port: 12345 } }); // some OTHER scope
+
+		watcher = new OptionsWatcher(NAME, filePath);
+		const [config] = await watcher.ready;
+		assert.deepStrictEqual(config, {}, 'the empty scope is user content and must reach ready');
+	});
+
+	it('deleting the root config file keeps an env-defined scope alive (merge, not remove)', async function () {
+		// #handleUnlink used to reset to DEFAULT_CONFIG unconditionally, discarding
+		// HARPER_SET_CONFIG-defined scopes — the same env-independence the ENOENT read
+		// path preserves. The unlink now applies the same env-only overlay; this also
+		// exercises the shared merge branch (config already set → merge, never reset).
+		this.timeout(4000);
+		const filePath = join(dir, 'harper-config.yaml');
+		writeFileSync(filePath, stringify({ [NAME]: { enabled: false, fileOnly: 1 } }));
+		process.env.HARPER_SET_CONFIG = JSON.stringify({ [NAME]: { enabled: true } });
+
+		watcher = new OptionsWatcher(NAME, filePath);
+		await watcher.ready;
+		assert.strictEqual(watcher.get(['enabled']), true);
+		assert.strictEqual(watcher.get(['fileOnly']), 1);
+
+		let removed = false;
+		watcher.on('remove', () => {
+			removed = true;
+		});
+		// The unlink-triggered merge drops the file-only key — an observable 'change'
+		// that marks the unlink as processed without racing chokidar's latency.
+		const changed = new Promise((resolve) => watcher.on('change', resolve));
+		rmSync(filePath, { force: true });
+		await changed;
+
+		assert.strictEqual(removed, false, 'env-defined scope must survive the file deletion');
+		assert.strictEqual(watcher.get(['enabled']), true, 'env value must remain in effect');
+		assert.strictEqual(watcher.get(['fileOnly']), undefined, 'file-contributed value goes away with the file');
+	});
+});

--- a/unitTests/components/OptionsWatcher-envOverlay.test.js
+++ b/unitTests/components/OptionsWatcher-envOverlay.test.js
@@ -1,0 +1,93 @@
+/**
+ * OptionsWatcher runtime-env-config overlay (#1618).
+ *
+ * The on-disk root config (`harper-config.yaml`) is not guaranteed to contain
+ * runtime env config (HARPER_SET_CONFIG et al.) when component scopes boot —
+ * the file flush races component loading. These tests pin the fix: every
+ * root-config read composes the env layers over the file content, so
+ * `scope.options` always matches the resolved config the componentLoader used.
+ * Application config files (`config.yaml`) are never overlaid.
+ */
+const { OptionsWatcher } = require('#src/components/OptionsWatcher');
+const assert = require('node:assert');
+const { join } = require('node:path');
+const { tmpdir } = require('node:os');
+const { mkdtempSync, writeFileSync, rmSync } = require('node:fs');
+const { stringify } = require('yaml');
+
+const NAME = 'modelsGateway';
+const ENV_KEYS = ['HARPER_SET_CONFIG', 'HARPER_CONFIG', 'HARPER_DEFAULT_CONFIG'];
+
+describe('OptionsWatcher env-config overlay (#1618)', () => {
+	let dir;
+	let savedEnv;
+	let watcher;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), 'options-watcher-env-'));
+		savedEnv = {};
+		for (const key of ENV_KEYS) {
+			savedEnv[key] = process.env[key];
+			delete process.env[key];
+		}
+	});
+
+	afterEach(async () => {
+		await watcher?.close();
+		watcher = undefined;
+		for (const key of ENV_KEYS) {
+			if (savedEnv[key] === undefined) delete process.env[key];
+			else process.env[key] = savedEnv[key];
+		}
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it('delivers env config for a key missing from the root config file', async () => {
+		const filePath = join(dir, 'harper-config.yaml');
+		writeFileSync(filePath, stringify({ http: { port: 9926 } }));
+		process.env.HARPER_SET_CONFIG = JSON.stringify({ [NAME]: { enabled: true } });
+
+		watcher = new OptionsWatcher(NAME, filePath);
+		const [config] = await watcher.ready;
+		assert.deepStrictEqual(config, { enabled: true });
+		assert.strictEqual(watcher.get(['enabled']), true);
+	});
+
+	it('env config overrides the file value on a root config read', async () => {
+		const filePath = join(dir, 'harper-config.yaml');
+		writeFileSync(filePath, stringify({ [NAME]: { enabled: false } }));
+		process.env.HARPER_SET_CONFIG = JSON.stringify({ [NAME]: { enabled: true } });
+
+		watcher = new OptionsWatcher(NAME, filePath);
+		await watcher.ready;
+		assert.strictEqual(watcher.get(['enabled']), true);
+	});
+
+	it('does NOT overlay env config onto an application config file', async () => {
+		const filePath = join(dir, 'config.yaml');
+		writeFileSync(filePath, stringify({ [NAME]: { enabled: false } }));
+		process.env.HARPER_SET_CONFIG = JSON.stringify({ [NAME]: { enabled: true } });
+
+		watcher = new OptionsWatcher(NAME, filePath);
+		await watcher.ready;
+		assert.strictEqual(watcher.get(['enabled']), false);
+	});
+
+	it('delivers env config when the root config file does not exist yet (install window)', async () => {
+		const filePath = join(dir, 'harper-config.yaml'); // never written
+		process.env.HARPER_SET_CONFIG = JSON.stringify({ [NAME]: { enabled: true } });
+
+		watcher = new OptionsWatcher(NAME, filePath);
+		const [config] = await watcher.ready;
+		assert.deepStrictEqual(config, { enabled: true });
+	});
+
+	it('reads the file verbatim when no config env vars are set', async () => {
+		const filePath = join(dir, 'harper-config.yaml');
+		writeFileSync(filePath, stringify({ [NAME]: { enabled: false } }));
+
+		watcher = new OptionsWatcher(NAME, filePath);
+		await watcher.ready;
+		assert.strictEqual(watcher.get(['enabled']), false);
+	});
+});

--- a/unitTests/config/harperConfigEnvVars-compose.test.js
+++ b/unitTests/config/harperConfigEnvVars-compose.test.js
@@ -102,3 +102,54 @@ describe('composeConfigFromEnv', function () {
 		assert.strictEqual('modelsGateway' in result, false);
 	});
 });
+
+describe('composeConfigFromEnv base empty-object preservation (#1726 review)', function () {
+	let originalDefault;
+	let originalSet;
+
+	beforeEach(function () {
+		originalDefault = process.env.HARPER_DEFAULT_CONFIG;
+		originalSet = process.env.HARPER_SET_CONFIG;
+		delete process.env.HARPER_DEFAULT_CONFIG;
+		delete process.env.HARPER_SET_CONFIG;
+	});
+
+	afterEach(function () {
+		if (originalDefault !== undefined) process.env.HARPER_DEFAULT_CONFIG = originalDefault;
+		else delete process.env.HARPER_DEFAULT_CONFIG;
+		if (originalSet !== undefined) process.env.HARPER_SET_CONFIG = originalSet;
+		else delete process.env.HARPER_SET_CONFIG;
+	});
+
+	it('a bare `componentName: {}` in the base survives composition with env vars set', function () {
+		process.env.HARPER_SET_CONFIG = JSON.stringify({ http: { port: 2 } });
+		const result = composeConfigFromEnv({ modelsGateway: {}, http: { port: 1 } });
+		assert.deepStrictEqual(result.modelsGateway, {}, 'base empty-object scope must not be dropped');
+		assert.strictEqual(result.http.port, 2, 'env layer still wins where it sets values');
+	});
+
+	it('nested base empty objects are preserved', function () {
+		process.env.HARPER_SET_CONFIG = JSON.stringify({ http: { port: 2 } });
+		const result = composeConfigFromEnv({ a: { b: {} } });
+		assert.deepStrictEqual(result.a, { b: {} });
+	});
+
+	it('an env layer that replaces the path wins over the base empty object', function () {
+		process.env.HARPER_SET_CONFIG = JSON.stringify({ modelsGateway: false });
+		const result = composeConfigFromEnv({ modelsGateway: {} });
+		assert.strictEqual(result.modelsGateway, false, 'env replacement must not be resurrected as {}');
+	});
+
+	it('an env layer that populates the path wins over the base empty object', function () {
+		process.env.HARPER_SET_CONFIG = JSON.stringify({ modelsGateway: { enabled: true } });
+		const result = composeConfigFromEnv({ modelsGateway: {} });
+		assert.deepStrictEqual(result.modelsGateway, { enabled: true });
+	});
+
+	it('empty objects in ENV layers keep their no-overrides drop semantics', function () {
+		process.env.HARPER_DEFAULT_CONFIG = JSON.stringify({ http: { port: 1 } });
+		process.env.HARPER_SET_CONFIG = JSON.stringify({ http: {} });
+		const result = composeConfigFromEnv({});
+		assert.strictEqual(result.http.port, 1, 'env-layer `http: {}` must stay a no-op, not clobber the subtree');
+	});
+});

--- a/unitTests/config/harperConfigEnvVars-compose.test.js
+++ b/unitTests/config/harperConfigEnvVars-compose.test.js
@@ -90,4 +90,15 @@ describe('composeConfigFromEnv', function () {
 
 		assert.throws(() => composeConfigFromEnv(), /HARPER_SET_CONFIG/);
 	});
+
+	it('drops an empty-object value without clobbering the base (documented no-signal semantics, #1618)', function () {
+		process.env.HARPER_SET_CONFIG = JSON.stringify({ http: {}, modelsGateway: {} });
+
+		const result = composeConfigFromEnv({ http: { port: 9925 } });
+		// `http: {}` must NOT wipe base values (it means "no overrides under http")...
+		assert.strictEqual(result.http.port, 9925);
+		// ...and a bare `componentName: {}` carries no signal — the key is dropped
+		// (a once-per-path warning is logged; presence needs an explicit value).
+		assert.strictEqual('modelsGateway' in result, false);
+	});
 });


### PR DESCRIPTION
## Summary

`scope.options` (the `OptionsWatcher` every component scope boots with) reads its state by **re-parsing the config file from disk** — while the componentLoader decides what to load from the **resolved in-memory config**, which deterministically includes runtime env config (`HARPER_SET_CONFIG` / `HARPER_CONFIG` / `HARPER_DEFAULT_CONFIG`). At boot those two views race: the env-applied values reach the file only after the first thread's runtime re-apply flushes them, so a component's boot-time `scope.options` reads (e.g. an `enabled` gate in `handleApplication`) can observe pre-env values the loader itself never saw.

Fix: for the **root config file only**, `OptionsWatcher` composes the env layers over every file read via the existing side-effect-free `composeConfigFromEnv()` (same documented precedence as the runtime pipeline), including the file-not-yet-written install window. Application scopes watch their own `config.yaml` and are untouched. Additionally, an empty-object env value (`componentName: {}`) — which `flattenObject` must drop (empty objects are load-bearing "no overrides here" markers for the restore-on-removal semantics) — now logs a once-per-path warning instead of vanishing silently.

## Evidence (from #1616's CI-only 404s)

Instrumented CI runs on the `/v1` gateway branch pinned the divergence precisely: on failing runs, **componentLoader saw `modelsGateway config={"enabled":true}` on both main/0 and http/1** (the env-merged in-memory view), yet all routes 404'd — because `handleApplication`'s `scope.options.get(['enabled'])` read the on-disk file, which only received the env values at `[http/1] Config file updated with runtime env var values`, after loading. Green/red flipped run-to-run on functionally identical code — a pure race. macOS boots consistently won the race; Linux CI lost it roughly half the time. The QA characterization on the issue (env-only `componentsRoot` registering cleanly) is consistent: that key is read by the loader from memory, never through an `OptionsWatcher`.

## Where to look

- `components/OptionsWatcher.ts` — the overlay is gated on `#isRootConfig` (an explicit constructor arg when the caller knows root-ness, else a filename heuristic matching the current + legacy root config names) **plus** env vars actually being present, so the no-env and application-scope paths are byte-identical to before. The ENOENT branch now serves env-composed config during the install window rather than resetting to defaults. Note `composeConfigFromEnv` runs on *every* root-file read (not just the first): a file-change event during the racy window would otherwise clobber the scoped config via the watcher's merge/remove path.
- `config/harperConfigEnvVars.ts` — warning only; `flattenObject` semantics unchanged (a first attempt that preserved `{}` as a leaf broke the restore-on-removal contract — `http: {}` must not wipe `http.port` — caught by the existing suite).
- Import-cycle safety: `harperConfigEnvVars` is leaf-safe (fs/path/crypto/lodash/type-only logger); the module's existing lazy `getLogger()` pattern is reused for the warning.

## Tests

- `unitTests/components/OptionsWatcher-envOverlay.test.js` (new): env key missing from file → delivered; env overrides file value; application `config.yaml` NOT overlaid; install window (file absent) → env config delivered; no env vars → file verbatim.
- `unitTests/config/harperConfigEnvVars-compose.test.js`: empty-object env value drops without clobbering the base (pins both halves of the documented semantics).
- Existing `OptionsWatcher`, `harperConfigEnvVars-*`, and `configUtils*` suites pass unchanged.

## Relationship to #1513

Same family (config composed/memoized before components run). This PR fixes the `scope.options`-vs-loader divergence for process-env-delivered config; #1513's `loadEnv`-delivered case (component sets `process.env` *during* loading) is upstream of both views and remains open.

Closes #1618

---
Generated by an LLM (Claude Fable 5, with earlier investigation by Claude Sonnet 5 workers). Review focus: the overlay-on-every-read decision and the ENOENT branch in OptionsWatcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Cross-model review (step 10) outcome

Both outside-model legs failed environmentally (agy timeouts; Codex sandbox-blocked) — Harper-domain adjudication pass only, caveat noted. It confirmed the core approach and surfaced three findings, fixed in `c4963f607`:
1. **ENOENT branch regression (would-be blocker):** the composed config clobbered `#rootConfig` before the name check, so a scope whose name wasn't in env config got `remove` instead of `ready` on first read → `Scope.ready` hang. Now the composed object becomes state only when the name is present; regression-guard test added.
2. **Legacy root config (`harperdb-config.yaml`) missed the overlay, and a component shipping a root-named file got it wrongly.** Root-ness is now determined by an explicit `isRootConfig` constructor arg for callers that know it, falling back to a filename heuristic that matches **both** the current and legacy root names (`de32bb61d`). An earlier attempt to discriminate by exact-match against `getConfigFilePath()` was reverted: in any environment where `configUtils` resolves a real instance (including the unit-test harness) it misclassified the overlay tests' temp watchers, hanging `ready` and timing out unit CI. Documented residual limitation: a component that ships its own `harper-config.yaml` is still classified as root by the heuristic — harmless unless config env vars are set *and* its keys collide with them; the explicit arg is the escape hatch.
3. **Error symmetry:** `composeConfigFromEnv` throws in the ENOENT branch now route to `error` instead of an unhandled rejection.

Verified clean by the review: no-env and application-scope paths byte-identical; the merge/remove path can't corrupt scoped config on subsequent reads (composition is a superset of file keys); no import cycles; watcher reads are cold-path.
