### PR TITLE
fix: exclude cluster/replication topology operations from ambient user context

### DIFF
--- a/server/serverHelpers/serverUtilities.ts
+++ b/server/serverHelpers/serverUtilities.ts
@@ -132,10 +132,22 @@ export async function processLocalTransaction(req: OperationRequest, operationFu
 	const currentStore = contextStorage.getStore();
 	const callOperationFunction = () =>
 		operationFunctionCaller.callOperationFunctionAsAwait(operationFunction, req.body, null);
-	let data =
-		hdbUser && currentStore?.user !== hdbUser && !OPERATIONS_EXCLUDED_FROM_AMBIENT_USER.has(req.body.operation)
-			? await contextStorage.run({ ...currentStore, user: hdbUser }, callOperationFunction)
+	let data;
+	if (OPERATIONS_EXCLUDED_FROM_AMBIENT_USER.has(req.body.operation)) {
+		// Excluded operations must run with no ambient user principal. Strip any ambient user —
+		// whether it would come from this request's hdb_user or from an enclosing ambient context
+		// (e.g. a nested server.operation() call from within an authenticated handler) — so the
+		// long-lived background work they spawn never inherits a user. Other ambient state is
+		// preserved, and the outer context object is never mutated.
+		data = currentStore
+			? await contextStorage.run({ ...currentStore, user: undefined }, callOperationFunction)
 			: await callOperationFunction();
+	} else {
+		data =
+			hdbUser && currentStore?.user !== hdbUser
+				? await contextStorage.run({ ...currentStore, user: hdbUser }, callOperationFunction)
+				: await callOperationFunction();
+	}
 
 	if (typeof data !== 'object') {
 		data = { message: data };

--- a/server/serverHelpers/serverUtilities.ts
+++ b/server/serverHelpers/serverUtilities.ts
@@ -59,6 +59,34 @@ const GLOBAL_SCHEMA_UPDATE_OPERATIONS_ENUM = {
 	[terms.OPERATIONS_ENUM.DROP_SCHEMA]: true,
 };
 
+// Cluster/replication topology operations must NOT run under the request's ambient user context
+// (the #1591 attribution wrap below). Two reasons:
+//
+//   1. Their writes are internal node-registry bookkeeping (hdb_nodes, certificates), not
+//      user-authored data — they should not be stamped with a user principal.
+//   2. Critically, they start long-lived, non-awaited replication subscription work (a peer
+//      connection's connect/handshake/reconnect lifecycle) that outlives the handler. Because that
+//      work is constructed while this handler's AsyncLocalStorage scope is active, it keeps
+//      observing the ambient { user } for its ENTIRE life, not just the request — which corrupts
+//      the subscription's identity and produces a WebSocket 1006 reconnect storm that never meshes
+//      (regression from #1591/#1592; the pre-#1591 world gave this background work no ambient user).
+//
+// The durable fix is to detach that background work from the ambient context where it is spawned
+// (harper-pro's replication component); this core-side exclusion resolves the regression for the
+// operations that trigger it without that background work ever inheriting a user. The names span
+// core and harper-pro's replication component (registered via server.registerOperation), so this
+// set must be kept in sync if new topology-management operations are added.
+const OPERATIONS_EXCLUDED_FROM_AMBIENT_USER = new Set<string>([
+	terms.OPERATIONS_ENUM.ADD_NODE, // 'add_node'
+	terms.OPERATIONS_ENUM.UPDATE_NODE, // 'update_node'
+	terms.OPERATIONS_ENUM.SET_NODE_REPLICATION, // 'set_node_replication'
+	'add_node_back',
+	'set_node',
+	'remove_node',
+	'remove_node_back',
+	'configure_cluster',
+]);
+
 import { OperationFunctionObject } from './OperationFunctionObject.ts';
 
 type ValueOf<T> = T[keyof T];
@@ -97,12 +125,15 @@ export async function processLocalTransaction(req: OperationRequest, operationFu
 	// differs (or is absent), the ambient context is merged rather than replaced: other ambient
 	// properties (open transaction, signal, caches) are preserved so atomicity is unaffected and
 	// only the user is swapped for attribution; the outer context object itself is never mutated.
+	// Cluster/replication topology operations are excluded (see OPERATIONS_EXCLUDED_FROM_AMBIENT_USER):
+	// they spawn long-lived background work that would otherwise inherit this ambient user for its
+	// whole life.
 	const hdbUser = req.body.hdb_user;
 	const currentStore = contextStorage.getStore();
 	const callOperationFunction = () =>
 		operationFunctionCaller.callOperationFunctionAsAwait(operationFunction, req.body, null);
 	let data =
-		hdbUser && currentStore?.user !== hdbUser
+		hdbUser && currentStore?.user !== hdbUser && !OPERATIONS_EXCLUDED_FROM_AMBIENT_USER.has(req.body.operation)
 			? await contextStorage.run({ ...currentStore, user: hdbUser }, callOperationFunction)
 			: await callOperationFunction();
 

--- a/unitTests/server/serverHelpers/serverUtilities.test.js
+++ b/unitTests/server/serverHelpers/serverUtilities.test.js
@@ -563,5 +563,80 @@ describe('Test serverUtilities.js module ', () => {
 			);
 			assert.equal(observedStore, undefined);
 		});
+
+		// Regression for the #1591/#1592 follow-up: cluster/replication topology operations must not run
+		// under the ambient user context, because they spawn long-lived, non-awaited background work (a
+		// replication subscription connection's connect/handshake/reconnect lifecycle) that outlives the
+		// handler. Under AsyncLocalStorage that background work would otherwise keep observing the ambient
+		// { user } for its entire life — corrupting the subscription's identity and producing a WebSocket
+		// 1006 reconnect storm that never meshes.
+		describe('cluster/replication topology operations are excluded from the ambient user context', function () {
+			const TOPOLOGY_OPERATIONS = [
+				'add_node',
+				'add_node_back',
+				'update_node',
+				'set_node',
+				'set_node_replication',
+				'remove_node',
+				'remove_node_back',
+				'configure_cluster',
+			];
+
+			for (const operation of TOPOLOGY_OPERATIONS) {
+				it(`does not establish an ambient user context for '${operation}'`, async function () {
+					op_func_caller_stub.callThrough();
+					let observedStore;
+					await serverUtilities.processLocalTransaction(
+						{ body: { operation, hdb_user: { username: 'admin' } } },
+						async () => {
+							observedStore = contextStorage.getStore();
+							return test_func_data;
+						}
+					);
+					assert.equal(observedStore, undefined, `${operation} handler must run with no ambient user`);
+				});
+			}
+
+			it('background work spawned by a topology handler does not observe the request user after the handler returns', async function () {
+				op_func_caller_stub.callThrough();
+				let backgroundStore = 'unset';
+				let resolveBackground;
+				const backgroundRead = new Promise((resolve) => {
+					resolveBackground = resolve;
+				});
+				await serverUtilities.processLocalTransaction(
+					{ body: { operation: 'add_node', hdb_user: { username: 'admin' } } },
+					async () => {
+						// simulate the handler kicking off non-awaited long-lived work (e.g. a subscription
+						// connection) that reads the ambient context after the handler has returned
+						setTimeout(() => {
+							backgroundStore = contextStorage.getStore();
+							resolveBackground();
+						}, 5);
+						return test_func_data;
+					}
+				);
+				await backgroundRead;
+				assert.equal(
+					backgroundStore,
+					undefined,
+					'detached background work must not inherit the request user for its ongoing lifetime'
+				);
+			});
+
+			it('still establishes the ambient user for a non-topology operation (does not over-exclude)', async function () {
+				op_func_caller_stub.callThrough();
+				const hdbUser = { username: 'data_user' };
+				let observedStore;
+				await serverUtilities.processLocalTransaction(
+					{ body: { operation: 'insert', hdb_user: hdbUser } },
+					async () => {
+						observedStore = contextStorage.getStore();
+						return test_func_data;
+					}
+				);
+				assert.equal(observedStore?.user, hdbUser, 'data operations must keep #1591 audit attribution');
+			});
+		});
 	});
 });

--- a/unitTests/server/serverHelpers/serverUtilities.test.js
+++ b/unitTests/server/serverHelpers/serverUtilities.test.js
@@ -624,6 +624,31 @@ describe('Test serverUtilities.js module ', () => {
 				);
 			});
 
+			it('strips an inherited ambient user when a topology op runs inside an existing context (nested server.operation)', async function () {
+				// A topology op invoked via server.operation() from within an authenticated request would
+				// otherwise fall through and run under the enclosing context's user, re-leaking it into the
+				// background work it spawns. The exclusion must strip that inherited user too, while
+				// preserving other ambient state and not mutating the outer context object.
+				op_func_caller_stub.callThrough();
+				const outerUser = { username: 'outer_user' };
+				const outerTransaction = { open: true };
+				const outerContext = { user: outerUser, transaction: outerTransaction, someRequestState: true };
+				let observedStore;
+				await contextStorage.run(outerContext, () =>
+					serverUtilities.processLocalTransaction(
+						{ body: { operation: 'add_node', hdb_user: outerUser } },
+						async () => {
+							observedStore = contextStorage.getStore();
+							return test_func_data;
+						}
+					)
+				);
+				assert.equal(observedStore.user, undefined, 'inherited ambient user must be stripped for topology ops');
+				assert.equal(observedStore.transaction, outerTransaction, 'other ambient state must be preserved');
+				assert.equal(observedStore.someRequestState, true, 'other ambient state must be preserved');
+				assert.equal(outerContext.user, outerUser, 'outer context object must not be mutated');
+			});
+
 			it('still establishes the ambient user for a non-topology operation (does not over-exclude)', async function () {
 				op_func_caller_stub.callThrough();
 				const hdbUser = { username: 'data_user' };


### PR DESCRIPTION
## Summary

Excludes cluster/replication topology operations from the #1591/#1592 ambient-user context wrap in `processLocalTransaction`, and strips any inherited ambient user for those operations.

## Root cause

`af646222d` (#1591, part of #1592) made `processLocalTransaction` run every operation handler carrying `hdb_user` inside `contextStorage.run({ ...currentStore, user: hdbUser }, handler)`, so static Resource API writes inside component-registered handlers inherit user attribution for audit records.

Cluster/replication topology operations (`add_node`, `add_node_back`, `set_node`, `update_node`, `set_node_replication`, `remove_node`, …) start **long-lived, non-awaited** replication subscription work (a peer connection's connect/handshake/reconnect lifecycle). The handler returns quickly, but that background async chain keeps running — and because it was constructed while the handler's `AsyncLocalStorage` scope was active, it keeps observing the ambient `{ user }` for its **entire life**, not just the request. That corrupts the subscription's identity and produces a WebSocket **1006** reconnect storm that never meshes.

This is distinct from #1720 (a stale ambient *transaction* leaking into a later static write within one handler invocation, fixed in `resources/Resource.ts`). Both stem from #1591's design change — long-lived ambient context per handler invocation — but at different points. This fix is orthogonal to #1720 (different file, different mechanism; verified #1720's leak test passes with this change).

## Fix

`processLocalTransaction` now skips the ambient-user wrap for a documented set of topology-management operations, and — for the nested case where an ambient context already carries a user (e.g. a `server.operation()` call from within an authenticated handler) — strips that inherited user too, preserving other ambient state and never mutating the outer context object. Their writes are internal node-registry bookkeeping (`hdb_nodes`, certificates), not user-authored data, so removing user attribution is also correct, not just safe.

## Why this direction

The architecturally cleanest fix is option (b) from the investigation — detach the long-lived work from the ambient context **where it is spawned**. That spawn point lives in **harper-pro's replication component** (`subscriptionManager`/`replicationConnection`), not core, so it can't be done in a core-only change, and the deliverable requires a self-sufficient core fix (the harper-pro integration test must pass on the core change alone). The core-only variant of (b) — clearing the ambient user *after* the handler settles — is unsafe: operation handlers can return `Readable` streams that are consumed after `processLocalTransaction` returns (`serverHandlers.js`), so stripping the user mid-stream would corrupt late/streaming authorization.

This change is the safe, self-sufficient core fix (option a): it is proven-equivalent to the investigation's validated "revert the wrap" for exactly the affected operations, while preserving #1591 attribution for all data operations.

## Where to look / open items

- **`OPERATIONS_EXCLUDED_FROM_AMBIENT_USER`** (`server/serverHelpers/serverUtilities.ts`): the set spans core's `OPERATIONS_ENUM` entries and harper-pro-registered names (`add_node_back`, `set_node`, …). This cross-layer name list is the fragile part — it must be extended if new topology-management operations that spawn long-lived background work are added. **The durable fix is to detach that background work from the ambient context at the spawn point in harper-pro's replication component; recommend a coordinated follow-up.** A prior harper-pro branch (`fix/ensurenode-ambient-context`) already isolates `ensureNode`'s write context in that layer.

## Verification

- harper-pro `integrationTests/cluster/replicationReconnect.test.mjs` against this core branch: **2/3 → 3/3**, reliably (previously-failing tests dropped from ~15–17s timeouts to ~1–2s), confirmed over two runs.
- New unit coverage in `unitTests/server/serverHelpers/serverUtilities.test.js`: each topology op runs with no ambient user; background work spawned by a topology handler does not observe the request user after the handler returns; inherited ambient user is stripped for the nested case; and a non-topology op still gets #1591 attribution (no over-exclusion).
- Existing #1591 attribution tests (`operationContextUser.test.js`, `serverUtilities.test.js`) pass; #1720's leak test passes with this change overlaid.
- Full local suites green: `unitTests/resources/**` (1027), `unitTests/components/mcp/**` (479), `unitTests/server/serverHelpers/**` (211).

Generated by Claude (Opus 4.8), reviewed cross-model by Codex (one P1 addressed: strip inherited ambient user for the nested case).
