### PR TITLE
cherry-pick: Fix static plugin serving nothing when urlPath is configured (#1584 → v5.1)

### DIFF
--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -10,6 +10,7 @@ import { Models, models as modelsSingleton } from '../resources/models/Models.ts
 import type { FileAndURLPathConfig } from './Component.ts';
 import { FilesOption } from './deriveGlobOptions.ts';
 import { requestRestart } from './requestRestart.ts';
+import { resolveBaseURLPath } from './resolveBaseURLPath.ts';
 import { ApplicationScope } from './ApplicationScope.ts';
 import { deployLifecycle } from './deployLifecycle.ts';
 
@@ -104,7 +105,9 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 							const scopeConfig = (scopeRef.options?.getAll() as any) ?? {};
 							return method.call(target, listener, {
 								name: pluginName,
-								urlPath: scopeConfig.urlPath || undefined,
+								// resolve to the same base the entry pipeline uses ('assets' -> '/assets/',
+								// './x' -> '/<name>/x/') so route matching sees a real pathname prefix (#1583)
+								urlPath: scopeConfig.urlPath ? resolveBaseURLPath(pluginName, scopeConfig.urlPath) : undefined,
 								host: scopeConfig.host || undefined,
 								...options,
 							});

--- a/integrationTests/components/static-urlpath.test.ts
+++ b/integrationTests/components/static-urlpath.test.ts
@@ -1,0 +1,73 @@
+/**
+ * #1583 — the static plugin served nothing when `urlPath` was configured: the routing chain
+ * strips the mount prefix from req.pathname while the file map was keyed by the full entry
+ * URL path, and a slash-less `urlPath` (e.g. 'assets') never matched the route at all.
+ *
+ * The fixture is the issue's minimal repro: `static: { files: 'web/**', urlPath: 'assets' }`.
+ *
+ * Reproduction:
+ *   npm run test:integration -- "integrationTests/components/static-urlpath.test.ts"
+ */
+import { suite, test, before, after } from 'node:test';
+import { strictEqual, ok } from 'node:assert';
+import { resolve } from 'node:path';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, '../fixtures/static-urlpath');
+
+suite('static plugin with urlPath (#1583)', (ctx: ContextWithHarper) => {
+	before(async () => {
+		await setupHarperWithFixture(ctx, FIXTURE_PATH);
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	test('serves a file under the configured urlPath', async () => {
+		const res = await fetch(new URL('/assets/test.css', ctx.harper.httpURL));
+		const text = await res.text();
+		strictEqual(res.status, 200, `expected /assets/test.css to serve: ${res.status} ${text}`);
+		ok(text.includes('teal'), 'served the fixture css content');
+	});
+
+	test('does not serve the file at the unprefixed path', async () => {
+		const res = await fetch(new URL('/test.css', ctx.harper.httpURL));
+		strictEqual(res.status, 404);
+	});
+
+	test('serves a directory index under the urlPath', async () => {
+		const res = await fetch(new URL('/assets/docs/', ctx.harper.httpURL));
+		const text = await res.text();
+		strictEqual(res.status, 200, `expected /assets/docs/ to serve index.html: ${res.status} ${text}`);
+		ok(text.includes('docs index'));
+	});
+
+	test('redirects a directory request to the trailing-slash path including the mount prefix', async () => {
+		const res = await fetch(new URL('/assets/docs', ctx.harper.httpURL), { redirect: 'manual' });
+		strictEqual(res.status, 301);
+		strictEqual(res.headers.get('location'), '/assets/docs/');
+	});
+
+	test('serves the root index at the trailing-slash mount path', async () => {
+		const res = await fetch(new URL('/assets/', ctx.harper.httpURL));
+		const text = await res.text();
+		strictEqual(res.status, 200, `expected /assets/ to serve the root index: ${res.status} ${text}`);
+		ok(text.includes('root index'));
+	});
+
+	test('redirects the no-slash mount root to the trailing-slash form', async () => {
+		const res = await fetch(new URL('/assets', ctx.harper.httpURL), { redirect: 'manual' });
+		strictEqual(res.status, 301);
+		strictEqual(res.headers.get('location'), '/assets/');
+	});
+
+	test('preserves the query string on trailing-slash redirects', async () => {
+		const root = await fetch(new URL('/assets?foo=bar', ctx.harper.httpURL), { redirect: 'manual' });
+		strictEqual(root.status, 301);
+		strictEqual(root.headers.get('location'), '/assets/?foo=bar');
+		const dir = await fetch(new URL('/assets/docs?foo=bar', ctx.harper.httpURL), { redirect: 'manual' });
+		strictEqual(dir.status, 301);
+		strictEqual(dir.headers.get('location'), '/assets/docs/?foo=bar');
+	});
+});

--- a/integrationTests/fixtures/static-urlpath/config.yaml
+++ b/integrationTests/fixtures/static-urlpath/config.yaml
@@ -1,0 +1,3 @@
+static:
+  files: 'web/**'
+  urlPath: 'assets'

--- a/integrationTests/fixtures/static-urlpath/web/docs/index.html
+++ b/integrationTests/fixtures/static-urlpath/web/docs/index.html
@@ -1,0 +1,1 @@
+<!doctype html><title>docs index</title>

--- a/integrationTests/fixtures/static-urlpath/web/index.html
+++ b/integrationTests/fixtures/static-urlpath/web/index.html
@@ -1,0 +1,1 @@
+<!doctype html><title>root index</title><link rel="stylesheet" href="test.css" />

--- a/integrationTests/fixtures/static-urlpath/web/test.css
+++ b/integrationTests/fixtures/static-urlpath/web/test.css
@@ -1,0 +1,3 @@
+body {
+	color: teal;
+}

--- a/server/middlewareChain.ts
+++ b/server/middlewareChain.ts
@@ -125,11 +125,15 @@ export function resolveDeps(entries: HttpEntry[], nameToEntry: Map<string, HttpE
 }
 
 /**
- * Normalizes a urlPath by stripping a single trailing slash (except for the root '/').
- * '/api' and '/api/' are treated equivalently for routing/matching.
+ * Normalizes a urlPath by ensuring a leading slash and stripping a single trailing slash
+ * (except for the root '/'). '/api', 'api', and '/api/' are treated equivalently for
+ * routing/matching — pathnames always begin with '/', so a slash-less urlPath could
+ * otherwise never match anything (#1583).
  */
 export function normalizeUrlPath(urlPath: string | undefined): string | undefined {
-	if (!urlPath || urlPath.length <= 1) return urlPath;
+	if (!urlPath) return urlPath;
+	if (!urlPath.startsWith('/')) urlPath = '/' + urlPath;
+	if (urlPath.length <= 1) return urlPath;
 	return urlPath.endsWith('/') ? urlPath.slice(0, -1) : urlPath;
 }
 
@@ -167,6 +171,12 @@ export function stripPrefix(request: any, prefix: string): any {
 			if (prop === 'pathname') {
 				const origPathname: string = target.pathname ?? '/';
 				return origPathname === normalizedPrefix ? '/' : origPathname.slice(normalizedPrefix.length);
+			}
+			// Runtime-agnostic access to the unstripped pathname — '/mount' and '/mount/' both
+			// strip to '/', so handlers that must distinguish them (e.g. static's mount-root
+			// redirect, #1583) read this instead of runtime internals like _nodeRequest.
+			if (prop === 'originalPathname') {
+				return target.pathname ?? '/';
 			}
 			if (prop === 'url') {
 				const origPathname: string = target.pathname ?? '/';

--- a/server/static.ts
+++ b/server/static.ts
@@ -1,6 +1,7 @@
 import { realpathSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { Scope } from '../components/Scope';
+import { resolveBaseURLPath } from '../components/resolveBaseURLPath.ts';
 import send from 'send';
 
 /**
@@ -15,27 +16,44 @@ import send from 'send';
  *
  * This plugin dynamically updates its behavior based on the current configuration file. Users can make updates and immediately see the changes reflect in the next request.
  *
- * Updates to the `files` or `urlPath` options will clear the in-memory maps and allow them to regenerate based on the new configuration (since the default EntryHandler will regenerate anyways).
+ * Updates to the `files` option will clear the in-memory maps and allow them to regenerate based on the new configuration (since the default EntryHandler will regenerate anyways).
+ * Updates to `urlPath` request a restart: the HTTP route mount is registered once at load and cannot be re-registered on a live server (#1583).
  */
 export function handleApplication(scope: Scope) {
 	// in-memory map of static files
-	// keys are the URL paths, values are the absolute paths to the files
+	// keys are the URL paths relative to the mount base, values are the absolute paths to the files
 	const staticFiles = new Map<string, string>();
 	const indexEntries = new Map<string, string>();
 
-	// If the `files` or `urlPath` options change, clear the maps and let them regenerate
+	// The HTTP route below is registered once, with the urlPath in effect at load time; the mount
+	// cannot be re-registered at runtime. Capture the matching base once so map keys always agree
+	// with the registered route (#1583).
+	const baseURLPath = resolveBaseURLPath(scope.pluginName, (scope.options.getAll() as any)?.urlPath);
+
 	scope.options.on('change', (key) => {
-		if (key[0] === 'files' || key[0] === 'urlPath') {
-			// If the files or urlPath options change, we need to reinitialize the static files map
+		if (key[0] === 'files') {
+			// If the files option changes, clear the maps and let the entry handler regenerate them
 			staticFiles.clear();
 			indexEntries.clear();
 			scope.logger.info(`Static files reinitialized due to change in ${key.join('.')}`);
+			return;
+		}
+		if (key[0] === 'urlPath') {
+			// The route mount cannot be changed on a live server registration — restart to apply
+			scope.requestRestart();
 			return;
 		}
 	});
 
 	// Handle entry events for the default entry handler based on the `files` and `urlPath` options
 	scope.handleEntry((entry) => {
+		// entry.urlPath includes the component's base URL path, but when a `urlPath` is configured
+		// the routing chain strips that mount prefix from req.pathname before this plugin's handler
+		// runs — so key the maps relative to the base (#1583)
+		const urlPath =
+			baseURLPath !== '/' && entry.urlPath.startsWith(baseURLPath)
+				? entry.urlPath.slice(baseURLPath.length - 1)
+				: entry.urlPath;
 		switch (entry.eventType) {
 			// Directories only matter for the `index` files
 			case 'addDir':
@@ -43,30 +61,30 @@ export function handleApplication(scope: Scope) {
 				// Handle `index.html` for directories for if/when the user enables the `index` option
 				const indexPath = join(entry.absolutePath, 'index.html');
 				if (existsSync(indexPath)) {
-					indexEntries[entry.eventType === 'addDir' ? 'set' : 'delete'](entry.urlPath, indexPath);
+					indexEntries[entry.eventType === 'addDir' ? 'set' : 'delete'](urlPath, indexPath);
 				}
 				break;
 			// Otherwise, user must specify pattern to match individual files
 			case 'add':
 				// Store the file in memory for serving
-				staticFiles.set(entry.urlPath, entry.absolutePath);
+				staticFiles.set(urlPath, entry.absolutePath);
 				// If the file is an index.html, also store it in the index entries
-				if (entry.urlPath.endsWith('index.html')) {
+				if (urlPath.endsWith('index.html')) {
 					// Without trailing slash; null -> 301 redirect to trailing slash
-					let lastSlashIndex = entry.urlPath.lastIndexOf('/');
-					indexEntries.set(entry.urlPath.slice(0, lastSlashIndex), null);
+					let lastSlashIndex = urlPath.lastIndexOf('/');
+					indexEntries.set(urlPath.slice(0, lastSlashIndex), null);
 					// With trailing slash; serves the index.html file
-					indexEntries.set(entry.urlPath.slice(0, lastSlashIndex + 1), entry.absolutePath);
+					indexEntries.set(urlPath.slice(0, lastSlashIndex + 1), entry.absolutePath);
 				}
 				break;
 			case 'unlink':
 				// Remove the file from memory when it is deleted
-				staticFiles.delete(entry.urlPath);
+				staticFiles.delete(urlPath);
 				// If the file is an index.html, remove it from the index entries as well
-				if (entry.urlPath.endsWith('index.html')) {
-					let lastSlashIndex = entry.urlPath.lastIndexOf('/');
-					indexEntries.delete(entry.urlPath.slice(0, lastSlashIndex));
-					indexEntries.delete(entry.urlPath.slice(0, lastSlashIndex + 1));
+				if (urlPath.endsWith('index.html')) {
+					let lastSlashIndex = urlPath.lastIndexOf('/');
+					indexEntries.delete(urlPath.slice(0, lastSlashIndex));
+					indexEntries.delete(urlPath.slice(0, lastSlashIndex + 1));
 				}
 				break;
 		}
@@ -99,12 +117,35 @@ export function handleApplication(scope: Scope) {
 					// Retrieve index entry
 					staticFile = indexEntries.get(req.pathname);
 
-					// If `null`, redirect to trailing slash
+					// The router strips both '/assets' and '/assets/' down to '/', so the mount root
+					// must be disambiguated via the unstripped pathname (exposed by stripPrefix):
+					// redirect the no-slash form so relative links on the index page resolve under
+					// the mount (#1583). Query string is preserved across both redirects; compute it
+					// lazily inside each branch so the common (non-redirect) index serve stays allocation-free.
+					if (staticFile && req.pathname === '/' && baseURLPath !== '/') {
+						const originalPathname: string | undefined = (req as any).originalPathname;
+						if (originalPathname && !originalPathname.endsWith('/')) {
+							const queryIndex = (req.url as string).indexOf('?');
+							const query = queryIndex === -1 ? '' : (req.url as string).slice(queryIndex);
+							return {
+								status: 301,
+								headers: {
+									Location: baseURLPath + query,
+								},
+							};
+						}
+					}
+
+					// If `null`, redirect to trailing slash. req.pathname arrives with the mount
+					// prefix stripped, so rebuild the external path for the Location header (#1583)
 					if (staticFile === null) {
+						const externalPath = baseURLPath === '/' ? req.pathname : baseURLPath.slice(0, -1) + req.pathname;
+						const queryIndex = (req.url as string).indexOf('?');
+						const query = queryIndex === -1 ? '' : (req.url as string).slice(queryIndex);
 						return {
 							status: 301,
 							headers: {
-								Location: req.pathname + '/',
+								Location: externalPath + '/' + query,
 							},
 						};
 					}

--- a/unitTests/server/middlewareChain.test.js
+++ b/unitTests/server/middlewareChain.test.js
@@ -679,6 +679,39 @@ describe('normalizeUrlPath', () => {
 	it('leaves paths without trailing slash unchanged', () => {
 		assert.strictEqual(normalizeUrlPath('/api/v2'), '/api/v2');
 	});
+
+	it('adds a leading slash to slash-less paths (#1583)', () => {
+		assert.strictEqual(normalizeUrlPath('assets'), '/assets');
+		assert.strictEqual(normalizeUrlPath('assets/'), '/assets');
+		assert.strictEqual(normalizeUrlPath('a'), '/a');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// matchesRoute with slash-less urlPath (#1583)
+// ---------------------------------------------------------------------------
+
+describe('matchesRoute with slash-less urlPath', () => {
+	it('matches as if the leading slash were present', () => {
+		assert.strictEqual(matchesRoute(req('/assets/test.css'), { urlPath: 'assets' }), true);
+		assert.strictEqual(matchesRoute(req('/assets'), { urlPath: 'assets' }), true);
+		assert.strictEqual(matchesRoute(req('/assets2/x'), { urlPath: 'assets' }), false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// stripPrefix originalPathname passthrough (#1583)
+// ---------------------------------------------------------------------------
+
+describe('stripPrefix originalPathname', () => {
+	it('exposes the unstripped pathname so handlers can distinguish /mount from /mount/', () => {
+		const noSlash = stripPrefix(req('/assets'), '/assets');
+		assert.strictEqual(noSlash.pathname, '/');
+		assert.strictEqual(noSlash.originalPathname, '/assets');
+		const withSlash = stripPrefix(req('/assets/'), '/assets');
+		assert.strictEqual(withSlash.pathname, '/');
+		assert.strictEqual(withSlash.originalPathname, '/assets/');
+	});
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Cherry-pick of #1584 onto \`v5.1\`. **Clean cherry-pick — no conflicts.**

Fixes #1730 (\`static.urlPath\` subpath mounts return 404 in 5.1.x) on the v5.1 line. #1584 landed on \`main\` (5.2); this ships the same fix as a 5.1.18+ patch.

## What it fixes

Two stacked defects that made \`static\` with a configured \`urlPath\` serve 404 at every path:
- **\`urlPath: app\` (no leading slash)** produced a dead route mount that never matched \`/app/...\`. \`normalizeUrlPath\` now guarantees a leading slash, and the Scope proxy resolves \`urlPath\` through \`resolveBaseURLPath\` (same normalization the entry pipeline uses).
- **\`urlPath: /app\`** matched but the router stripped the prefix while \`static.ts\` kept file maps keyed by the full URL path → lookup miss. \`static.ts\` now keys relative to the mount base captured at registration.

Plus the review-driven behaviors from #1584: \`urlPath\` runtime changes request a restart (the mount can't re-register live), and the mount root disambiguates the no-slash form via \`originalPathname\` (301 \`/app\` → \`/app/\`, query string preserved).

## Provenance

Cherry-picked squash commit \`5e6d9f1\` (\`git cherry-pick -x\`); \`server/middlewareChain.ts\` auto-merged cleanly against v5.1 context. Includes the integration test \`integrationTests/components/static-urlpath.test.ts\` (file-under-mount, directory index, root index at \`/app/\`, \`/app\` → \`/app/\` 301) and the \`normalizeUrlPath\`/slash-less \`matchesRoute\` unit tests.

Once merged, #1730 ships fixed on 5.1.

— KrAIs 🤖