### PR TITLE
fix: auto-wrap Error args in the logger + diagnostic property allowlist (#1734)

### DIFF
--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -23,7 +23,7 @@ import * as login from '../resources/login.ts';
 import * as REST from '../server/REST.ts';
 import * as staticFiles from '../server/static.ts';
 import * as loadEnv from '../resources/loadEnv.ts';
-import harperLogger from '../utility/logging/harper_logger.ts';
+import harperLogger, { errorForLog } from '../utility/logging/harper_logger.ts';
 import * as dataLoader from '../resources/dataLoader.ts';
 import { restartWorkers, getWorkerIndex } from '../server/threads/manageThreads.js';
 import { resetRestartNeeded, subscribeToRestartRequests } from './requestRestart.ts';
@@ -607,7 +607,7 @@ export async function loadComponent(
 					error.message
 				}`;
 				errorReporter?.(error);
-				(getWorkerIndex() === 0 ? console : harperLogger).error(error);
+				(getWorkerIndex() === 0 ? console : harperLogger).error(errorForLog(error));
 				resources.set(componentConfig.path || '/', new ErrorResource(error), null, true);
 				componentLifecycle.failed(componentStatusName, error, `Could not load component '${componentStatusName}'`);
 			}
@@ -683,7 +683,7 @@ export async function loadComponent(
 				);
 		}
 	} catch (error) {
-		console.error(`Could not load application directory ${componentDirectory}`, error);
+		console.error(`Could not load application directory ${componentDirectory}`, errorForLog(error));
 		error.message = `Could not load application due to ${error.message}`;
 		errorReporter?.(error);
 		resources.set('', new ErrorResource(error));

--- a/server/loadRootComponents.js
+++ b/server/loadRootComponents.js
@@ -6,6 +6,7 @@ const configUtils = require('../config/configUtils.ts');
 const { dirname } = require('path');
 const { loadCertificates } = require('../security/keys.ts');
 const { installApplications } = require('../components/Application.ts');
+const { errorForLog } = require('../utility/logging/harper_logger.ts');
 
 let loadedComponents = new Map();
 /**
@@ -16,7 +17,7 @@ async function loadRootComponents(isWorkerThread = false) {
 	try {
 		if (isMainThread && !process.env.HARPER_SAFE_MODE) await installApplications();
 	} catch (error) {
-		console.error(error);
+		console.error(errorForLog(error));
 	}
 
 	let resources = resetResources();

--- a/server/serverHelpers/JSONStream.ts
+++ b/server/serverHelpers/JSONStream.ts
@@ -129,7 +129,7 @@ class JSONStream extends Readable {
 				}
 			},
 			(error) => {
-				console.error(error);
+				console.error(harperLogger.errorForLog(error));
 				this.done = true;
 				this.push(errorToString(error));
 				this.push(null);
@@ -201,7 +201,7 @@ class JSONStream extends Readable {
 				}
 			} while (this.push(nextString));
 		} catch (error) {
-			console.error(error);
+			console.error(harperLogger.errorForLog(error));
 			this.push(errorToString(error));
 			this.push(null);
 			return true;
@@ -218,7 +218,7 @@ class JSONStream extends Readable {
 }
 
 function handleError(error) {
-	console.error(error);
+	console.error(harperLogger.errorForLog(error));
 	return JSON.stringify(errorToString(error));
 }
 

--- a/server/threads/socketRouter.ts
+++ b/server/threads/socketRouter.ts
@@ -18,7 +18,7 @@ if (isMainThread) {
 			harperLogger.disableStdio();
 			return;
 		}
-		console.error('uncaughtException', error);
+		console.error('uncaughtException', harperLogger.errorForLog(error));
 	});
 }
 

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -1098,5 +1098,27 @@ describe('Test harper_logger module', () => {
 			expect(() => logger.error('operation failed', proxy)).to.not.throw();
 			expect(lines.join('\n')).to.include('operation failed');
 		});
+
+		it('does not throw when a revoked Proxy appears as a cause', () => {
+			const { logger, lines } = createCapturingLogger();
+			const { proxy, revoke } = Proxy.revocable(new Error('root cause'), {});
+			revoke();
+			const error = new Error('origin fetch failed', { cause: proxy });
+			expect(() => logger.error(error)).to.not.throw();
+			expect(lines.join('\n')).to.include('Error: origin fetch failed');
+		});
+
+		it('does not throw when a cause has a throwing getter', () => {
+			const { logger, lines } = createCapturingLogger();
+			const hostileCause = {};
+			Object.defineProperty(hostileCause, 'stack', {
+				get() {
+					throw new Error('getter boom');
+				},
+			});
+			const error = new Error('origin fetch failed', { cause: hostileCause });
+			expect(() => logger.error(error)).to.not.throw();
+			expect(lines.join('\n')).to.include('Error: origin fetch failed');
+		});
 	});
 });

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -923,7 +923,43 @@ describe('Test harper_logger module', () => {
 		it('falls back to "ClassName: message" when there is no stack', () => {
 			// A thrown plain object carrying an HTTP status but no stack.
 			const thrown = { message: 'not found', status: 404 };
-			expect(render(thrown)).to.equal('Object: not found');
+			expect(render(thrown)).to.equal('Object: not found status=404');
+		});
+
+		it('surfaces the allowlisted diagnostic properties (code/status/statusCode/errno/syscall)', () => {
+			const error = new Error('ENOENT: no such file or directory');
+			error.code = 'ENOENT';
+			error.errno = -2;
+			error.syscall = 'open';
+			error.path = '/home/harperdb/hdb/schema/internal.mdb';
+			const result = render(error);
+			expect(result).to.include('code=ENOENT');
+			expect(result).to.include('errno=-2');
+			expect(result).to.include('syscall=open');
+			// path is deliberately excluded — it can reveal internal filesystem layout.
+			expect(result).to.not.include('/home/harperdb');
+		});
+
+		it('surfaces status/statusCode without leaking sibling secret properties', () => {
+			const error = new Error('request failed');
+			error.status = 401;
+			error.statusCode = 401;
+			error.authorization = 'Bearer super-secret-token';
+			const result = render(error);
+			expect(result).to.include('status=401');
+			expect(result).to.include('statusCode=401');
+			expect(result).to.not.include('super-secret-token');
+		});
+
+		it('surfaces allowlisted properties on a cause without leaking the cause’s secrets', () => {
+			const root = new Error('connection refused');
+			root.code = 'ECONNREFUSED';
+			root.secret = 'Bearer super-secret-token';
+			const error = new Error('origin fetch failed', { cause: root });
+			const result = render(error);
+			expect(result).to.include('caused by:');
+			expect(result).to.include('code=ECONNREFUSED');
+			expect(result).to.not.include('super-secret-token');
 		});
 
 		it('handles a thrown string', () => {

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -936,5 +936,131 @@ describe('Test harper_logger module', () => {
 			expect(() => render(undefined)).to.not.throw();
 			expect(render(undefined)).to.equal('undefined');
 		});
+
+		// The sweep for #1734 routes the error arg of two-/multi-arg logger calls
+		// (`logger.warn('msg', errorForLog(error))`) through errorForLog too. Node's Console
+		// formats its arguments with util.format, applying util.inspect to the wrapper — so
+		// util.format reproduces exactly what lands in hdb.log for those call shapes.
+		it('does not leak secrets in the two-arg logger form (message + error)', () => {
+			const error = new Error('WS connection failed');
+			error.hdb_secret = 'Bearer super-secret-token';
+			error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
+			const rendered = util.format('Error in handling WS connection', errorForLog(error));
+			expect(rendered).to.include('Error in handling WS connection');
+			expect(rendered).to.include('Error: WS connection failed');
+			expect(rendered).to.not.include('super-secret-token');
+			expect(rendered).to.not.include('hdb_secret');
+		});
+
+		it('does not leak secrets in the multi-arg logger form (message + error + trailing data)', () => {
+			const error = new Error('decode failed');
+			error.authorization = 'Bearer super-secret-token';
+			const rendered = util.format('Error decoding record', errorForLog(error), 'data: deadbeef');
+			expect(rendered).to.include('Error decoding record');
+			expect(rendered).to.include('Error: decode failed');
+			expect(rendered).to.include('data: deadbeef');
+			expect(rendered).to.not.include('super-secret-token');
+			expect(rendered).to.not.include('authorization');
+		});
+	});
+
+	describe('Test logger auto-wrap of Error args (#1734)', () => {
+		// The HarperLogger level methods route every Error argument through errorForLog before
+		// Console formatting, so raw `logger.error(error)` calls anywhere in the codebase (or in
+		// component/app code) cannot leak own-enumerable props into the log.
+		function createCapturingLogger(level = 'trace') {
+			const lines = [];
+			const logger = harperLoggerModule.createLogger({ level, writeToLog: (line) => lines.push(line) });
+			return { logger, lines };
+		}
+
+		it('wraps a raw Error passed as the sole argument', () => {
+			const { logger, lines } = createCapturingLogger();
+			const error = new Error('origin fetch failed');
+			error.hdb_secret = 'Bearer super-secret-token';
+			error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
+			logger.error(error);
+			const output = lines.join('\n');
+			expect(output).to.include('Error: origin fetch failed');
+			expect(output).to.not.include('super-secret-token');
+			expect(output).to.not.include('hdb_secret');
+		});
+
+		it('wraps a raw Error in any argument position, leaving other args intact', () => {
+			const { logger, lines } = createCapturingLogger();
+			const error = new Error('WS connection failed');
+			error.authorization = 'Bearer super-secret-token';
+			logger.warn('Error in handling WS connection', error, 'port: 9926');
+			const output = lines.join('\n');
+			expect(output).to.include('Error in handling WS connection');
+			expect(output).to.include('Error: WS connection failed');
+			expect(output).to.include('port: 9926');
+			expect(output).to.not.include('super-secret-token');
+		});
+
+		it('preserves the cause chain of an auto-wrapped Error', () => {
+			const { logger, lines } = createCapturingLogger();
+			const root = new Error('connection refused');
+			root.secret = 'Bearer super-secret-token';
+			logger.error(new Error('origin fetch failed', { cause: root }));
+			const output = lines.join('\n');
+			expect(output).to.include('caused by:');
+			expect(output).to.include('Error: connection refused');
+			expect(output).to.not.include('super-secret-token');
+		});
+
+		it('does not alter non-Error object arguments', () => {
+			const { logger, lines } = createCapturingLogger();
+			logger.info('operation summary', { operation: 'insert', records: 3 });
+			const output = lines.join('\n');
+			expect(output).to.include('operation summary');
+			expect(output).to.include('insert');
+			expect(output).to.include('records');
+		});
+
+		it('applies on every level method, including below-gate no-ops', () => {
+			const { logger, lines } = createCapturingLogger('error');
+			const error = new Error('quiet');
+			error.secret = 'Bearer super-secret-token';
+			logger.trace(error); // gated out - must not write at all
+			expect(lines).to.have.length(0);
+			for (const level of ['error', 'fatal', 'notify']) {
+				logger[level](error);
+			}
+			const output = lines.join('\n');
+			expect(output).to.include('Error: quiet');
+			expect(output).to.not.include('super-secret-token');
+		});
+
+		it('covers loggerWithTag-derived loggers', () => {
+			const { logger, lines } = createCapturingLogger();
+			const tagged = harperLoggerModule.loggerWithTag('operation', false, logger);
+			const error = new Error('op failed');
+			error.hdb_secret = 'Bearer super-secret-token';
+			tagged.error(error);
+			const output = lines.join('\n');
+			expect(output).to.include('Error: op failed');
+			expect(output).to.not.include('super-secret-token');
+		});
+
+		it('covers the inherited Console methods (log/dir/table)', () => {
+			const { logger, lines } = createCapturingLogger();
+			const error = new Error('bypass attempt');
+			error.hdb_secret = 'Bearer super-secret-token';
+			logger.log(error);
+			logger.dir(error);
+			logger.table([error]);
+			const output = lines.join('\n');
+			expect(output).to.include('Error: bypass attempt');
+			expect(output).to.not.include('super-secret-token');
+		});
+
+		it('does not throw on a revoked Proxy argument', () => {
+			const { logger, lines } = createCapturingLogger();
+			const { proxy, revoke } = Proxy.revocable(new Error('gone'), {});
+			revoke();
+			expect(() => logger.error('operation failed', proxy)).to.not.throw();
+			expect(lines.join('\n')).to.include('operation failed');
+		});
 	});
 });

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -12,7 +12,7 @@ import * as os from 'os';
 import { PACKAGE_ROOT } from '../../utility/packageUtils.js';
 import { _assignPackageExport } from '../../globals.js';
 import { Console } from 'console';
-import { inspect, types } from 'util';
+import { inspect, types } from 'node:util';
 
 const { isNativeError } = types;
 // store the native write function so we can call it after we write to the log file (and store it on process.stdout
@@ -945,21 +945,46 @@ function getDefaultConfig() {
  * @return {string|string}
  */
 export function errorToString(error: any) {
+	if (error == null) return String(error);
 	return typeof error.message === 'string' ? `${error.constructor.name}: ${error.message}` : error.toString();
 }
 
+// Own-enumerable Error properties considered safe to surface in logs — common diagnostic fields
+// (HTTP status, Node error codes) that libraries and app code don't use to carry secrets, unlike
+// arbitrary properties (axios' `config`/`request` with an Authorization header), which stay
+// excluded. `path` is deliberately omitted: it can reveal internal filesystem layout, and the
+// message/stack already names the failing operation.
+const LOGGABLE_ERROR_PROPS = ['code', 'status', 'statusCode', 'errno', 'syscall'];
+
+function loggablePropsSuffix(error: any): string {
+	if (typeof error !== 'object' || error === null) return '';
+	let suffix = '';
+	for (const key of LOGGABLE_ERROR_PROPS) {
+		const value = error[key];
+		if (value !== undefined) suffix += ` ${key}=${value}`;
+	}
+	return suffix;
+}
+
+function renderErrorLine(error: any): string {
+	const base = typeof error?.stack === 'string' ? error.stack : errorToString(error);
+	return base + loggablePropsSuffix(error);
+}
+
 /**
- * Renders an error to its stack (class name + message + frames), then appends the stack of each
- * error in its `cause` chain. Deliberately excludes own-enumerable properties — those are exactly
+ * Renders an error to its stack (class name + message + frames) plus a small allowlist of
+ * diagnostic properties (see `LOGGABLE_ERROR_PROPS`), then appends the same for each error in its
+ * `cause` chain. Deliberately excludes every OTHER own-enumerable property — those are exactly
  * what leaks secrets in #1734 (see `errorForLog`).
  */
 function errorToLogString(error: any) {
-	let output = typeof error?.stack === 'string' ? error.stack : error == null ? String(error) : errorToString(error);
+	if (error == null) return String(error);
+	let output = renderErrorLine(error);
 	const seen = new Set([error]);
-	let cause = error?.cause;
+	let cause = error.cause;
 	while (cause != null && !seen.has(cause)) {
 		seen.add(cause);
-		output += `\ncaused by: ${typeof cause.stack === 'string' ? cause.stack : errorToString(cause)}`;
+		output += `\ncaused by: ${renderErrorLine(cause)}`;
 		cause = cause.cause;
 	}
 	return output;

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -12,7 +12,9 @@ import * as os from 'os';
 import { PACKAGE_ROOT } from '../../utility/packageUtils.js';
 import { _assignPackageExport } from '../../globals.js';
 import { Console } from 'console';
-import { inspect } from 'util';
+import { inspect, types } from 'util';
+
+const { isNativeError } = types;
 // store the native write function so we can call it after we write to the log file (and store it on process.stdout
 // because unit tests will create multiple instances of this module)
 let nativeStdWrite = process.env.IS_SCRIPTED_SERVICE
@@ -181,6 +183,43 @@ async function updateLogSettings() {
 	}
 }
 
+/**
+ * True when the argument is an Error (same-realm or native cross-realm). The try/catch guards
+ * exotic objects whose prototype is unreachable (e.g. a revoked Proxy, where `instanceof`
+ * throws) — the logger must never throw on any input, and util.format renders those fine raw.
+ */
+function isErrorLike(arg: any): boolean {
+	try {
+		return arg instanceof Error || isNativeError(arg);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Replaces every Error argument with its log-safe errorForLog wrapper before the args reach
+ * Console's util.inspect formatting, which would otherwise dump the error's own-enumerable
+ * properties — where libraries and app code stash credentials (axios config headers, an
+ * hdb_secret for an outbound Authorization header) — into hdb.log (see #1734 and errorForLog).
+ * Called inside each level gate so filtered-out log calls pay nothing beyond the arg scan,
+ * and only allocates when an Error is actually present. Deliberately shallow: an Error nested
+ * inside a logged object/array is not rewritten (deep-walking every logged structure is not
+ * worth the per-call cost, and the #1734 threat is raw thrown errors).
+ */
+function sanitizeErrorArgs(args: any[]) {
+	for (let i = 0; i < args.length; i++) {
+		if (isErrorLike(args[i])) {
+			const sanitized = args.slice(0, i);
+			for (let j = i; j < args.length; j++) {
+				const arg = args[j];
+				sanitized[j] = isErrorLike(arg) ? errorForLog(arg) : arg;
+			}
+			return sanitized;
+		}
+	}
+	return args;
+}
+
 class HarperLogger extends Console {
 	[key: string]: any;
 	constructor(streams, level) {
@@ -194,35 +233,35 @@ class HarperLogger extends Console {
 	trace(...args) {
 		currentLevel = 'trace';
 		if (this.level <= LOG_LEVEL_HIERARCHY.trace) {
-			super.info(...args);
+			super.info(...sanitizeErrorArgs(args));
 		}
 		currentLevel = 'info';
 	}
 	debug(...args) {
 		currentLevel = 'debug';
 		if (this.level <= LOG_LEVEL_HIERARCHY.debug) {
-			super.info(...args);
+			super.info(...sanitizeErrorArgs(args));
 		}
 		currentLevel = 'info';
 	}
 	info(...args) {
 		currentLevel = 'info';
 		if (this.level <= LOG_LEVEL_HIERARCHY.info) {
-			super.info(...args);
+			super.info(...sanitizeErrorArgs(args));
 		}
 		currentLevel = 'info';
 	}
 	warn(...args) {
 		currentLevel = 'warn';
 		if (this.level <= LOG_LEVEL_HIERARCHY.warn) {
-			super.warn(...args);
+			super.warn(...sanitizeErrorArgs(args));
 		}
 		currentLevel = 'info';
 	}
 	error(...args) {
 		currentLevel = 'error';
 		if (this.level <= LOG_LEVEL_HIERARCHY.error) {
-			super.error(...args);
+			super.error(...sanitizeErrorArgs(args));
 		}
 		currentLevel = 'info';
 	}
@@ -231,7 +270,7 @@ class HarperLogger extends Console {
 		try {
 			currentLevel = 'fatal';
 			if (this.level <= LOG_LEVEL_HIERARCHY.fatal) {
-				super.error(...args);
+				super.error(...sanitizeErrorArgs(args));
 			}
 			currentLevel = 'info';
 		} finally {
@@ -243,12 +282,24 @@ class HarperLogger extends Console {
 		try {
 			currentLevel = 'notify';
 			if (this.level <= LOG_LEVEL_HIERARCHY.notify) {
-				super.info(...args);
+				super.info(...sanitizeErrorArgs(args));
 			}
 			currentLevel = 'info';
 		} finally {
 			logImmediately = false;
 		}
+	}
+	// Inherited Console methods that format arbitrary values would bypass sanitizeErrorArgs —
+	// guard them too so logger.log(error) / dir / table can't leak either (#1734). Their
+	// existing semantics (no level gate) are preserved; only the Error args are wrapped.
+	log(...args) {
+		super.log(...sanitizeErrorArgs(args));
+	}
+	dir(item, options?) {
+		super.dir(isErrorLike(item) ? errorForLog(item) : item, options);
+	}
+	table(data, columns?) {
+		super.table(Array.isArray(data) ? sanitizeErrorArgs(data) : isErrorLike(data) ? errorForLog(data) : data, columns);
 	}
 	withTag(tag) {
 		return loggerWithTag(tag, true, this);

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -946,7 +946,17 @@ function getDefaultConfig() {
  */
 export function errorToString(error: any) {
 	if (error == null) return String(error);
-	return typeof error.message === 'string' ? `${error.constructor.name}: ${error.message}` : error.toString();
+	try {
+		return typeof error.message === 'string' ? `${error.constructor.name}: ${error.message}` : error.toString();
+	} catch {
+		// error is hostile (e.g. a revoked Proxy, or a getter that throws) - this must never throw,
+		// since it's called directly for response bodies (REST.ts/http.ts/JSONStream) as well as here.
+		try {
+			return Object.prototype.toString.call(error);
+		} catch {
+			return '[Unrenderable Object]';
+		}
+	}
 }
 
 // Own-enumerable Error properties considered safe to surface in logs — common diagnostic fields
@@ -960,15 +970,24 @@ function loggablePropsSuffix(error: any): string {
 	if (typeof error !== 'object' || error === null) return '';
 	let suffix = '';
 	for (const key of LOGGABLE_ERROR_PROPS) {
-		const value = error[key];
-		if (value !== undefined) suffix += ` ${key}=${value}`;
+		try {
+			const value = error[key];
+			if (value !== undefined) suffix += ` ${key}=${value}`;
+		} catch {
+			// A hostile property (revoked Proxy, throwing getter) must not crash the logger - skip it.
+		}
 	}
 	return suffix;
 }
 
 function renderErrorLine(error: any): string {
-	const base = typeof error?.stack === 'string' ? error.stack : errorToString(error);
-	return base + loggablePropsSuffix(error);
+	try {
+		const base = typeof error?.stack === 'string' ? error.stack : errorToString(error);
+		return base + loggablePropsSuffix(error);
+	} catch (err) {
+		// error?.stack itself can throw on a hostile object even though errorToString cannot.
+		return `[Unrenderable Error: ${err instanceof Error ? err.message : String(err)}]`;
+	}
 }
 
 /**
@@ -976,16 +995,29 @@ function renderErrorLine(error: any): string {
  * diagnostic properties (see `LOGGABLE_ERROR_PROPS`), then appends the same for each error in its
  * `cause` chain. Deliberately excludes every OTHER own-enumerable property — those are exactly
  * what leaks secrets in #1734 (see `errorForLog`).
+ *
+ * The `cause` chain is not under this module's control (any code that threw the outer error could
+ * have attached a hostile `cause` - a revoked Proxy, an object with a throwing getter), so every
+ * step of the walk is defensive: this function must never throw regardless of what it's given.
  */
 function errorToLogString(error: any) {
 	if (error == null) return String(error);
 	let output = renderErrorLine(error);
 	const seen = new Set([error]);
-	let cause = error.cause;
+	let cause: any;
+	try {
+		cause = error.cause;
+	} catch {
+		return output;
+	}
 	while (cause != null && !seen.has(cause)) {
 		seen.add(cause);
 		output += `\ncaused by: ${renderErrorLine(cause)}`;
-		cause = cause.cause;
+		try {
+			cause = cause.cause;
+		} catch {
+			break;
+		}
 	}
 	return output;
 }


### PR DESCRIPTION
## Summary
Fixes the raw-`Error` logging leak class (#1734) at its root. Harper's logger extends Node's `Console`; passing a raw `Error` to a Console method formats it with `util.inspect`, which dumps **every own-enumerable property** after the stack. Libraries/app code stash secrets on thrown Errors (axios `config`/`request` headers, an `hdb_secret` used for an outbound `Authorization` header), so `logger.<level>(error)` landed those credentials verbatim in `hdb.log` at default level — retrievable via `read_log`.

Two mechanisms, matched to the two leak surfaces:

1. **Logger auto-wrap (the invariant).** The `HarperLogger` level methods — plus the inherited `log`/`dir`/`table`, which also bypass `util.inspect`'s guard otherwise — now route every `Error` argument through `errorForLog()` (`sanitizeErrorArgs`) inside the level gate. This covers **every** logger call — all first-party code, future code, and component/app code holding a `server.logger` — with no per-site changes needed. Gated-out calls pay nothing beyond an arg scan; allocation only happens when an Error is present; a revoked-Proxy arg can't make the logger throw (`isErrorLike` try/catch).
2. **Explicit wraps on `console.*` calls, scoped by error provenance (4 sites).** `harper_logger` captures both stdout and stderr into `hdb.log`, but Node's Console runs `util.inspect` *before* the capture hook — so `console.error(rawError)` leaks identically. A sanitizing console subclass was rejected (overriding console methods makes the inspector report the override frame instead of the real call site), so wrapping is per-site — and scoped to where the error can actually originate in app/library code: `JSONStream` (serializes resource iterator output — the origin-fetch axios scenario of #1734 flows through here), `socketRouter`'s generic `uncaughtException`, `componentLoader` app-load failures, `loadRootComponents`' `npm`/`pacote` install of user packages. Sites with a closed error set (fs/LMDB/pm2/config/our own code) stay raw — those errors cannot carry stashed credentials.

Additionally, a small **allowlist of diagnostic Error properties** — `code`, `status`, `statusCode`, `errno`, `syscall` — is now rendered alongside the stack/cause chain. These are common triage fields (Node error codes, HTTP status) that libraries don't use to carry secrets, unlike arbitrary properties (axios' `config`/`request`), which stay excluded. `path` is deliberately **not** included — it can reveal internal filesystem layout and the message/stack already names the failing operation.

## History
This is a clean transplant of `kris/log-error-leak-sweep` (formerly #1744) onto current `main`. #1744's base branch (`kris/rest-log-error-leak-1734`, the primitive-adding PR #1737) was **squash-merged**, so the original branch's commit history no longer rebases cleanly against `main` — reopening #1744 as-is would show `REST.ts`/`http.ts`/`graphqlQuerying.ts` as changed again, redundantly re-diffing #1737's already-merged content. This PR reapplies the sweep's net diff directly on top of the squashed `main`; **#1744 is closed as superseded**. It also folds in two `#1737` review comments that were left unresolved when that PR merged (`node:util` import scope; move `errorToString`'s null-guard into `errorToString` itself — see commit messages) and adds the diagnostic-property allowlist per a follow-up request after #1744 was mistakenly closed instead of merged.

## Where to look
- **`utility/logging/harper_logger.ts`** — `sanitizeErrorArgs`/`isErrorLike` (the auto-wrap) and `errorToLogString`/`loggablePropsSuffix` (the allowlist) are the load-bearing changes. Detection is `instanceof Error || util.types.isNativeError` (cross-realm safe), wrapped in try/catch for exotic objects (revoked Proxy) where even `instanceof` can throw.
- **The console-site wraps** (`JSONStream.ts`, `socketRouter.ts`, `componentLoader.ts`, `loadRootComponents.js`) — mechanical; only the error arg gets `errorForLog(...)`/`harperLogger.errorForLog(...)`, message strings/data args untouched. `JSONStream`'s `errorToString` response pushes stay raw (client-facing body, not a log line) and are unaffected by the allowlist (allowlist only applies inside `errorToLogString`, used for log lines).
- Sanitization is deliberately **shallow**: an Error nested inside a logged object/array (`logger.error({ err })`) is not rewritten — deep-walking every logged structure isn't worth the per-call cost, and the #1734 threat is raw thrown errors escaping directly to the logger.

## Known gap (accepted)
Component/app code calling **global `console.error(err)`** directly (not through Harper's logger) still leaks via the stdio capture — only our own console sites are wrapped. Fixing that class requires the console subclass rejected above for inspector-ergonomics reasons, or an upstream-Node-level answer.

## Testing
44 unit tests (was 9 before this work started): auto-wrap (sole-arg/any-position/cause-chain secret exclusion, non-Error objects untouched, level gating preserved, `loggerWithTag` coverage, `log`/`dir`/`table` bypass closed, revoked-Proxy no-throw) + the diagnostic-property allowlist (code/status/statusCode/errno/syscall surfaced, `path` excluded, siblings-still-excluded, cause-chain coverage). Built to `dist` and ran against it (mocha's `--conditions=typestrip` path can silently fall back to stale `dist`): **44 passing**. `oxlint` + `prettier` clean.

## Cross-model review
Thorough mode ran on an earlier iteration of this sweep (Codex found 3 missed sites + the `log`/`dir`/`table`/revoked-Proxy issues fixed in the auto-wrap design here; the Harper domain pass found the console-capture surface and non-standard logger bindings that informed this design). Gemini (`agy`) leg timed out on both attempts — no second-model coverage from Gemini on this iteration.

_Generated by an LLM (Claude Sonnet 5 / Opus 4.8 / Fable 5 — multi-session)._
