### PR TITLE
test(blob): fix "sensor schema missing" flake in per-device-type sharding suite

### DIFF
--- a/integrationTests/apiTests/blob.test.mjs
+++ b/integrationTests/apiTests/blob.test.mjs
@@ -455,6 +455,25 @@ const DEVICE_RESOURCES_JS =
 	'doorlockblob.sourcedFrom(DoorlockBlobSource);\n' +
 	'sensorblob.sourcedFrom(SensorBlobSource);\n\n';
 
+// `restart_service http_workers` (and the /openapi readiness probe it waits on)
+// only guarantees the workers are back up — NOT that the component's
+// schema.graphql has been parsed and all three device tables registered and
+// propagated to the metadata that describe_all / REST reads. Poll describe_all
+// until every device schema is visible so the assertions below don't race
+// component load (fixes the intermittent "sensor schema missing" flake).
+async function waitForDeviceSchemas(client, timeoutMs) {
+	const required = ['"thermostat":{"ThermostatBlob"', '"doorlock":{"DoorlockBlob"', '"sensor":{"SensorBlob"'];
+	const deadline = Date.now() + timeoutMs;
+	let body = '';
+	while (Date.now() < deadline) {
+		const r = await client.req().send({ operation: 'describe_all' });
+		body = JSON.stringify(r.body);
+		if (required.every((frag) => body.includes(frag))) return;
+		await setTimeout(250);
+	}
+	throw new Error(`device schemas not all visible within ${timeoutMs}ms\n` + body);
+}
+
 suite('Per-device-type LMDB database sharding', { skip: skipSuite }, (ctx) => {
 	let client;
 	const thermostatId = randomInt(1000000);
@@ -500,6 +519,7 @@ suite('Per-device-type LMDB database sharding', { skip: skipSuite }, (ctx) => {
 			.expect(200);
 
 		await restartHttpWorkers(client, '/openapi', 120000);
+		await waitForDeviceSchemas(client, 30000);
 
 		const configResp = await client.req().send({ operation: 'get_configuration' }).expect(200);
 		rootPath = configResp.body.rootPath;


### PR DESCRIPTION
## Problem

The **Per-device-type LMDB database sharding** suite in `integrationTests/apiTests/blob.test.mjs` intermittently fails in CI with:

```
AssertionError [ERR_ASSERTION]: sensor schema missing
```

followed by cascading `Table 'sensor.SensorBlob' does not exist` / `expected 200 "OK", got 404` failures. Observed most recently on **Integration Tests 3/6 (Node.js v22)** — a single shard/runtime out of ~24, while every other shard and runtime passed, which is the classic flake signature.

## Root cause

All three device schemas (`thermostat`, `doorlock`, `sensor`) are declared in one `schema.graphql` loaded by a single component, then `before()` does:

```js
await restartHttpWorkers(client, '/openapi', 120000);
```

`restartHttpWorkers` only waits on the `/openapi` readiness probe, which returns `200` the moment a worker is back up — that does **not** guarantee the component's `schema.graphql` has been parsed and all three tables registered and propagated to the metadata that `describe_all` / REST read. The first test then asserts all three schemas in a single shot and races the tail of component load. `sensor` — the last of the three declared — is the one that loses the race, and the subsequent `sensorblob` REST calls 404 for the same reason.

## Fix

After the restart, poll `describe_all` until all three device schemas are visible before running the assertions (30s budget, 250ms interval). Returns immediately in the happy path, so it adds no meaningful cost to normal runs — it only absorbs the propagation window that was previously assumed to be zero. Test-only change; no product code touched.

This is the same "readiness poll instead of assumed timing" approach as #1091.

## Verification

- `prettier@3.9` clean, `node --check` clean.
- Not run through the full local integration suite: reproducing the race is nondeterministic, so a single green run wouldn't prove the fix — the change is a poll-until-ready that cannot break the already-passing case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)