### PR TITLE
fix(lint): unbreak main — node:assert/strict → node:assert in bytes-scan-crash test

### DIFF
--- a/integrationTests/resources/bytes-scan-crash.test.ts
+++ b/integrationTests/resources/bytes-scan-crash.test.ts
@@ -23,7 +23,7 @@
  * Implements HarperFast/harper#1298.
  */
 import { suite, test, before, after } from 'node:test';
-import { ok } from 'node:assert/strict';
+import { ok } from 'node:assert';
 import { resolve } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 import request from 'supertest';


### PR DESCRIPTION
## Summary

`integrationTests/resources/bytes-scan-crash.test.ts:26` imports `{ ok } from 'node:assert/strict'`, which the `no-restricted-imports` eslint rule forbids. That left `lint:required` (`runLinter`) **red on `main`** — `1 problem (1 error)` — which surfaces on every downstream PR's CI.

The import was added in 7945918e6 (`fix(table): reject bare-array roots…`). `ok` is identical when imported from `node:assert`, which is the form all sibling integration tests already use.

```diff
-import { ok } from 'node:assert/strict';
+import { ok } from 'node:assert';
```

## Test plan
- [x] `npm run lint:required` passes locally (was `exit 1`, now `exit 0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)