### PR TITLE
feat(terminal): super_user PTY-over-WebSocket prototype (Studio terminal)

### DIFF
--- a/components/terminal/README.md
+++ b/components/terminal/README.md
@@ -1,0 +1,96 @@
+# Interactive terminal component (PROTOTYPE)
+
+A super_user-only PTY exposed over a WebSocket on the instance's **operations
+API port**, so Studio can render an `xterm.js` terminal that runs _inside_ the
+instance container.
+
+> **Status: prototype for team discussion.** Ships alongside the Studio
+> prototype on `claude/instance-terminal-prototype`. Not wired into any release
+> config, off by default, and carries deliberate scoping shortcuts (see
+> Security below).
+
+## Why this exists
+
+It's the first, smallest slice of the "Claude in the container" direction: a
+live shell in Studio. More importantly it establishes the **authenticated,
+super_user-gated WebSocket channel** that the planned live-log-stream and
+Node-inspector-bridge features will reuse.
+
+## How to enable
+
+Add a `terminal:` block to the instance's root config:
+
+```yaml
+terminal:
+  enabled: true # required — off by default
+  # shell: /bin/bash     # default: $SHELL, else bash
+  # cwd: /path            # default: instance root
+  # idleTimeoutMs: 600000 # default: 10 minutes
+  # maxSessions: 10       # default: 10 concurrent PTYs
+```
+
+`node-pty` is an optional native dependency — install it in the instance image
+(declared in `optionalDependencies`).
+
+## Architecture
+
+- **Operations port, main thread.** `server/operationsServer.ts` calls
+  `registerTerminalWebSocket({ nodeServer: app.server, config })` while building
+  the operations Fastify server — the same place the MCP operations profile is
+  registered — gated on `terminal.enabled`. This attaches a `/terminal` upgrade
+  handler to the operations node server. There is no `handleApplication` and no
+  worker-thread/app-port registration: the terminal lives on the operations
+  security boundary, deliberately separate from the application data port.
+- A dedicated `ws` `WebSocketServer({ noServer: true })` owns subprotocol
+  negotiation (`handleProtocols` → `harper-terminal`) and the handshake; we drive
+  `handleUpgrade` from the node server's `upgrade` event for the `/terminal` path
+  only, leaving any other upgrade untouched.
+
+## Authentication — first-message auth (no `security/auth.ts` change)
+
+Browsers can't set an `Authorization` header on `new WebSocket()`, and a token
+in the handshake subprotocol leaks into request headers that intermediaries may
+log. So the socket is accepted **unauthenticated**, and the client's **first
+frame** carries the credential:
+
+```
+a{"token":"<operation-token-jwt>"}      // or
+a{"username":"...","password":"..."}
+```
+
+The upgrade handler validates it (`validateOperationToken`, or
+`server.authenticateUser` for basic), asserts `super_user`, and only then spawns
+the PTY. A 5s timer closes the socket if no valid auth arrives. Because auth is
+handled here, the shared auth middleware is untouched — smaller blast radius than
+the subprotocol-bearer approach.
+
+## Wire protocol
+
+Kept in sync with `studio/src/features/instance/terminal/wire.ts`.
+
+Client → server (text frames, first char is an opcode):
+
+| Frame     | Meaning                                                           |
+| --------- | ----------------------------------------------------------------- |
+| `a<json>` | auth — **must be first**. `{ token }` or `{ username, password }` |
+| `i<data>` | stdin — bytes after the opcode are written to the PTY             |
+| `r<json>` | resize — JSON `{ "cols": <int>, "rows": <int> }`                  |
+
+Server → client: raw PTY output as text frames (no opcode); `close(code, reason)`
+on shell exit, idle, or a policy rejection.
+
+Close codes: `4401` unauthenticated, `4403` not super_user, `4408` idle/auth
+timeout, `4429` session limit, `4500` backend error, `1000` shell exit.
+
+## Security notes (for review — deliberately unfinished)
+
+- **First-message auth** keeps the token out of handshake headers, but the token
+  still travels over the (TLS-encrypted) socket. Fine over `wss`.
+- **Direct connections only.** The Fabric Connect proxy buffers streamed
+  responses and can't carry a WebSocket, so this only works when Studio has a
+  _direct_ connection to the instance — the same limitation as the existing
+  log/deploy SSE tails. Studio gates the UI on `isDirectConnection`.
+- **Privilege.** The shell runs on the operations (main) thread and inherits its
+  user and environment. No cgroup/user-namespace confinement, no per-user quota
+  beyond `maxSessions`. Production wants real sandboxing and a durable audit
+  trail (today: notify-level open/close/deny log lines tagged `terminal`).

--- a/components/terminal/index.ts
+++ b/components/terminal/index.ts
@@ -234,6 +234,10 @@ async function onTerminalConnection(ws: any, req: any, opts: SessionOptions): Pr
 			}
 			authenticating = true;
 			const user = await authenticate(payload, req);
+			// The socket may have closed during the await (e.g. a second rapid auth
+			// frame triggered safeClose → teardown). Bail before reserving a slot or
+			// spawning, or we'd leak liveSessions and orphan a PTY on a dead socket.
+			if (closed) return;
 			const username = user?.username ?? 'anonymous';
 			if (!user) {
 				terminalLog.warn?.(`terminal AUTH-FAIL from ${remote}`);
@@ -262,6 +266,12 @@ async function onTerminalConnection(ws: any, req: any, opts: SessionOptions): Pr
 				liveSessions = Math.max(0, liveSessions - 1);
 				terminalLog.error?.('node-pty unavailable; install it in the instance image', error);
 				safeClose(ws, 4500, 'terminal backend (node-pty) not installed');
+				return;
+			}
+			// Socket may have closed during the loadPty() import — roll back the
+			// reserved slot and don't spawn onto a dead socket.
+			if (closed) {
+				liveSessions = Math.max(0, liveSessions - 1);
 				return;
 			}
 			try {

--- a/components/terminal/index.ts
+++ b/components/terminal/index.ts
@@ -115,8 +115,13 @@ export function registerTerminalWebSocket({ nodeServer, config }: RegisterArgs):
 	// app-port WS server. `noServer` because we drive handleUpgrade ourselves.
 	const wss = new WebSocketServer({
 		noServer: true,
+		// Bound frame size so a client can't exhaust memory with a huge frame.
+		maxPayload: 1024 * 1024,
 		handleProtocols: (protocols: Set<string>) => (protocols.has(TERMINAL_SUBPROTOCOL) ? TERMINAL_SUBPROTOCOL : false),
 	});
+	// A ws.Server is an EventEmitter: an unhandled 'error' event throws and would
+	// crash the process, so always attach a listener.
+	wss.on('error', (error) => terminalLog.error?.('terminal WebSocketServer error', error));
 
 	nodeServer.on('upgrade', (req, socket, head) => {
 		let pathname: string;
@@ -146,7 +151,7 @@ interface SessionOptions {
 	maxSessions: number;
 }
 
-async function authenticate(payload: string): Promise<any | null> {
+async function authenticate(payload: string, req: any): Promise<any | null> {
 	let auth: any;
 	try {
 		auth = JSON.parse(payload);
@@ -162,7 +167,9 @@ async function authenticate(payload: string): Promise<any | null> {
 	}
 	if (auth?.username) {
 		try {
-			return await (server as any).authenticateUser(auth.username, auth.password ?? '');
+			// server.authenticateUser expects (username, password, request) — pass req
+			// through so the auth provider gets its usual context (audit, ip, etc.).
+			return await (server as any).authenticateUser(auth.username, auth.password ?? '', req);
 		} catch {
 			return null;
 		}
@@ -173,6 +180,7 @@ async function authenticate(payload: string): Promise<any | null> {
 async function onTerminalConnection(ws: any, req: any, opts: SessionOptions): Promise<void> {
 	const remote = req?.socket?.remoteAddress ?? 'unknown';
 	let authed = false;
+	let authenticating = false;
 	let term: any = null;
 	let closed = false;
 	let idleTimer: NodeJS.Timeout | undefined;
@@ -217,11 +225,15 @@ async function onTerminalConnection(ws: any, req: any, opts: SessionOptions): Pr
 		const payload = frame.slice(1);
 
 		if (!authed) {
-			if (opcode !== OPCODE_AUTH) {
+			// The message handler is async: a client could fire several auth frames
+			// before the first resolves. `authenticating` is set synchronously (before
+			// any await) so re-entrant frames bail out instead of spawning a 2nd PTY.
+			if (authenticating || opcode !== OPCODE_AUTH) {
 				safeClose(ws, 4401, 'authentication required');
 				return;
 			}
-			const user = await authenticate(payload);
+			authenticating = true;
+			const user = await authenticate(payload, req);
 			const username = user?.username ?? 'anonymous';
 			if (!user) {
 				terminalLog.warn?.(`terminal AUTH-FAIL from ${remote}`);
@@ -233,16 +245,21 @@ async function onTerminalConnection(ws: any, req: any, opts: SessionOptions): Pr
 				safeClose(ws, 4403, 'super_user required');
 				return;
 			}
+			// Reserve the session slot synchronously (check + increment with no await
+			// between them) so concurrent connections can't both pass the check and
+			// overshoot maxSessions. Rolled back below if PTY startup fails.
 			if (liveSessions >= opts.maxSessions) {
 				terminalLog.warn?.(`terminal REJECTED for '${username}' from ${remote} (maxSessions reached)`);
 				safeClose(ws, 4429, 'terminal session limit reached');
 				return;
 			}
+			liveSessions++;
 
 			let pty: any;
 			try {
 				pty = await loadPty();
 			} catch (error) {
+				liveSessions = Math.max(0, liveSessions - 1);
 				terminalLog.error?.('node-pty unavailable; install it in the instance image', error);
 				safeClose(ws, 4500, 'terminal backend (node-pty) not installed');
 				return;
@@ -256,6 +273,7 @@ async function onTerminalConnection(ws: any, req: any, opts: SessionOptions): Pr
 					env: process.env,
 				});
 			} catch (error) {
+				liveSessions = Math.max(0, liveSessions - 1);
 				terminalLog.error?.(`failed to spawn shell '${opts.shell}'`, error);
 				safeClose(ws, 4500, 'failed to spawn shell');
 				return;
@@ -263,7 +281,6 @@ async function onTerminalConnection(ws: any, req: any, opts: SessionOptions): Pr
 
 			authed = true;
 			clearTimeout(authTimer);
-			liveSessions++;
 			resetIdle();
 			terminalLog.notify?.(`terminal OPEN for '${username}' from ${remote} (pid=${term.pid}, live=${liveSessions})`);
 
@@ -282,10 +299,16 @@ async function onTerminalConnection(ws: any, req: any, opts: SessionOptions): Pr
 			return;
 		}
 
-		// Authenticated frames.
+		// Authenticated frames. The socket can still deliver messages during the
+		// WS close handshake after the PTY exited, so bail if we're tearing down.
+		if (closed || !term) return;
 		resetIdle();
 		if (opcode === OPCODE_INPUT) {
-			term.write(payload);
+			try {
+				term.write(payload);
+			} catch {
+				teardown('write-failed');
+			}
 		} else if (opcode === OPCODE_RESIZE) {
 			try {
 				const { cols, rows } = JSON.parse(payload);

--- a/components/terminal/index.ts
+++ b/components/terminal/index.ts
@@ -1,0 +1,314 @@
+/**
+ * Built-in interactive terminal (PROTOTYPE — for team review).
+ *
+ * Exposes a super_user-only PTY over a WebSocket on the **operations API port**,
+ * so Studio can render an xterm.js terminal that runs *inside* the instance
+ * container. Living on the operations port (not the application data port) keeps
+ * the terminal on the same security boundary as the rest of the operations
+ * surface. This is the stepping-stone channel from the "Claude in the container"
+ * design; the authenticated WebSocket it establishes is the substrate the
+ * planned live-log-stream and inspector-bridge features will reuse.
+ *
+ * Wired in from `server/operationsServer.ts` (main thread), alongside the MCP
+ * operations profile: `registerTerminalWebSocket({ nodeServer, config })`
+ * attaches a `/terminal` upgrade handler to the operations Fastify server's
+ * underlying Node server. There is no `handleApplication` and no worker-thread
+ * registration — the operations port is main-thread only.
+ *
+ * AUTH is FIRST-MESSAGE (no change to `security/auth.ts`): the socket is
+ * accepted unauthenticated, and the client's first frame carries the credential
+ * (`a{"token":...}` or `a{"username":...,"password":...}`). We validate it and
+ * assert super_user before spawning anything. Nothing sensitive rides in the
+ * handshake headers/subprotocol (which intermediaries may log).
+ *
+ * WIRE PROTOCOL (mirror of studio `src/features/instance/terminal/wire.ts`):
+ *   client -> server (text frames, first char is an opcode):
+ *     'a<json>'  auth — MUST be first. `{ token }` or `{ username, password }`.
+ *     'i<data>'  stdin — bytes after the opcode are written to the PTY
+ *     'r<json>'  resize — JSON `{ cols, rows }`
+ *   server -> client:
+ *     raw PTY output as text frames (no opcode)
+ *     close(code, reason): 4401 unauth, 4403 not super_user, 4408 idle/auth
+ *     timeout, 4429 session limit, 4500 backend error, 1000 shell exit
+ *
+ * PROTOTYPE CAVEATS (call out in review):
+ *   - `node-pty` is a native addon and an optional dependency; dynamically
+ *     imported so a build without it degrades to a clear runtime error. Ships in
+ *     the trusted cloud image, so the native build is controlled by us.
+ *   - The PTY runs on the operations (main) thread and inherits its privileges;
+ *     no per-user resource accounting beyond a global session cap. Deliberate
+ *     scoping for a prototype — production wants cgroups/user-namespacing.
+ */
+import { WebSocketServer } from 'ws';
+import { forComponent as loggerForComponent } from '../../utility/logging/harper_logger.ts';
+import { validateOperationToken } from '../../security/tokenAuthentication.ts';
+import { server } from '../../server/Server.ts';
+
+const terminalLog = loggerForComponent('terminal');
+
+/** Subprotocol used to identify a terminal upgrade (carries no credential). */
+const TERMINAL_SUBPROTOCOL = 'harper-terminal';
+/** Path the terminal upgrade handler listens on. */
+const TERMINAL_WS_PATH = '/terminal';
+
+/** Client->server opcodes (first character of each text frame). */
+const OPCODE_AUTH = 'a';
+const OPCODE_INPUT = 'i';
+const OPCODE_RESIZE = 'r';
+
+/** Milliseconds to wait for the first-message auth frame before closing. */
+const AUTH_TIMEOUT_MS = 5000;
+
+interface TerminalConfig {
+	enabled?: boolean;
+	shell?: string;
+	args?: string[];
+	cwd?: string;
+	idleTimeoutMs?: number;
+	maxSessions?: number;
+}
+
+const DEFAULTS = {
+	idleTimeoutMs: 10 * 60 * 1000,
+	maxSessions: 10,
+};
+
+/** Live PTY count on this (main) thread, enforced against maxSessions. */
+let liveSessions = 0;
+
+/** Loaded lazily on first authenticated connection. */
+let ptyModule: any = null;
+async function loadPty(): Promise<any> {
+	if (!ptyModule) ptyModule = await import('node-pty');
+	return ptyModule;
+}
+
+let registered = false;
+
+interface RegisterArgs {
+	/** The operations Fastify server's underlying Node HTTP(S) server (`app.server`). */
+	nodeServer: import('node:http').Server;
+	/** The `terminal` config block from the merged root config. */
+	config: TerminalConfig;
+}
+
+/**
+ * Attach the `/terminal` WebSocket upgrade handler to the operations node
+ * server. Called once, from `server/operationsServer.ts`, only when
+ * `terminal.enabled === true`.
+ */
+export function registerTerminalWebSocket({ nodeServer, config }: RegisterArgs): void {
+	if (registered) return;
+	if (config?.enabled !== true) {
+		terminalLog.info?.('terminal.enabled !== true; not registering the terminal WebSocket');
+		return;
+	}
+	registered = true;
+
+	const shell = config.shell || process.env.SHELL || 'bash';
+	const shellArgs = config.args ?? [];
+	const cwd = config.cwd || process.env.HDB_ROOT || process.cwd();
+	const idleTimeoutMs = config.idleTimeoutMs ?? DEFAULTS.idleTimeoutMs;
+	const maxSessions = config.maxSessions ?? DEFAULTS.maxSessions;
+
+	// Dedicated WS server so we own subprotocol negotiation and don't disturb the
+	// app-port WS server. `noServer` because we drive handleUpgrade ourselves.
+	const wss = new WebSocketServer({
+		noServer: true,
+		handleProtocols: (protocols: Set<string>) => (protocols.has(TERMINAL_SUBPROTOCOL) ? TERMINAL_SUBPROTOCOL : false),
+	});
+
+	nodeServer.on('upgrade', (req, socket, head) => {
+		let pathname: string;
+		try {
+			pathname = new URL(req.url ?? '/', 'http://localhost').pathname;
+		} catch {
+			return;
+		}
+		// Only handle our path; leave any other upgrade for other listeners.
+		if (pathname !== TERMINAL_WS_PATH) return;
+
+		wss.handleUpgrade(req, socket as any, head, (ws) => {
+			void onTerminalConnection(ws, req, { shell, shellArgs, cwd, idleTimeoutMs, maxSessions });
+		});
+	});
+
+	terminalLog.info?.(
+		`terminal WebSocket registered at ${TERMINAL_WS_PATH} on the operations port (shell=${shell}, maxSessions=${maxSessions})`
+	);
+}
+
+interface SessionOptions {
+	shell: string;
+	shellArgs: string[];
+	cwd: string;
+	idleTimeoutMs: number;
+	maxSessions: number;
+}
+
+async function authenticate(payload: string): Promise<any | null> {
+	let auth: any;
+	try {
+		auth = JSON.parse(payload);
+	} catch {
+		return null;
+	}
+	if (auth?.token) {
+		try {
+			return await validateOperationToken(auth.token);
+		} catch {
+			return null;
+		}
+	}
+	if (auth?.username) {
+		try {
+			return await (server as any).authenticateUser(auth.username, auth.password ?? '');
+		} catch {
+			return null;
+		}
+	}
+	return null;
+}
+
+async function onTerminalConnection(ws: any, req: any, opts: SessionOptions): Promise<void> {
+	const remote = req?.socket?.remoteAddress ?? 'unknown';
+	let authed = false;
+	let term: any = null;
+	let closed = false;
+	let idleTimer: NodeJS.Timeout | undefined;
+
+	const authTimer = setTimeout(() => {
+		if (!authed) {
+			terminalLog.warn?.(`terminal AUTH-TIMEOUT from ${remote}`);
+			safeClose(ws, 4408, 'auth timeout');
+		}
+	}, AUTH_TIMEOUT_MS);
+	authTimer.unref?.();
+
+	const resetIdle = () => {
+		if (idleTimer) clearTimeout(idleTimer);
+		idleTimer = setTimeout(() => {
+			terminalLog.info?.(`terminal IDLE-CLOSE from ${remote}`);
+			safeClose(ws, 4408, 'idle timeout');
+		}, opts.idleTimeoutMs);
+		idleTimer.unref?.();
+	};
+
+	const teardown = (reason: string) => {
+		if (closed) return;
+		closed = true;
+		clearTimeout(authTimer);
+		if (idleTimer) clearTimeout(idleTimer);
+		if (term) {
+			try {
+				term.kill();
+			} catch {
+				/* already gone */
+			}
+			liveSessions = Math.max(0, liveSessions - 1);
+			terminalLog.notify?.(`terminal CLOSE from ${remote} (reason=${reason}, live=${liveSessions})`);
+		}
+	};
+
+	ws.on('message', async (raw: Buffer | string) => {
+		const frame = typeof raw === 'string' ? raw : raw.toString('utf8');
+		if (frame.length === 0) return;
+		const opcode = frame[0];
+		const payload = frame.slice(1);
+
+		if (!authed) {
+			if (opcode !== OPCODE_AUTH) {
+				safeClose(ws, 4401, 'authentication required');
+				return;
+			}
+			const user = await authenticate(payload);
+			const username = user?.username ?? 'anonymous';
+			if (!user) {
+				terminalLog.warn?.(`terminal AUTH-FAIL from ${remote}`);
+				safeClose(ws, 4401, 'invalid credentials');
+				return;
+			}
+			if (!user.role?.permission?.super_user) {
+				terminalLog.warn?.(`terminal DENIED for '${username}' from ${remote} (super_user required)`);
+				safeClose(ws, 4403, 'super_user required');
+				return;
+			}
+			if (liveSessions >= opts.maxSessions) {
+				terminalLog.warn?.(`terminal REJECTED for '${username}' from ${remote} (maxSessions reached)`);
+				safeClose(ws, 4429, 'terminal session limit reached');
+				return;
+			}
+
+			let pty: any;
+			try {
+				pty = await loadPty();
+			} catch (error) {
+				terminalLog.error?.('node-pty unavailable; install it in the instance image', error);
+				safeClose(ws, 4500, 'terminal backend (node-pty) not installed');
+				return;
+			}
+			try {
+				term = pty.spawn(opts.shell, opts.shellArgs, {
+					name: 'xterm-color',
+					cols: 80,
+					rows: 24,
+					cwd: opts.cwd,
+					env: process.env,
+				});
+			} catch (error) {
+				terminalLog.error?.(`failed to spawn shell '${opts.shell}'`, error);
+				safeClose(ws, 4500, 'failed to spawn shell');
+				return;
+			}
+
+			authed = true;
+			clearTimeout(authTimer);
+			liveSessions++;
+			resetIdle();
+			terminalLog.notify?.(`terminal OPEN for '${username}' from ${remote} (pid=${term.pid}, live=${liveSessions})`);
+
+			term.onData((data: string) => {
+				resetIdle();
+				try {
+					ws.send(data);
+				} catch {
+					teardown('send-failed');
+				}
+			});
+			term.onExit(({ exitCode }: { exitCode: number }) => {
+				teardown(`shell-exit(${exitCode})`);
+				safeClose(ws, 1000, `shell exited (${exitCode})`);
+			});
+			return;
+		}
+
+		// Authenticated frames.
+		resetIdle();
+		if (opcode === OPCODE_INPUT) {
+			term.write(payload);
+		} else if (opcode === OPCODE_RESIZE) {
+			try {
+				const { cols, rows } = JSON.parse(payload);
+				if (Number.isInteger(cols) && Number.isInteger(rows) && cols > 0 && rows > 0) {
+					term.resize(cols, rows);
+				}
+			} catch {
+				/* ignore malformed resize */
+			}
+		}
+	});
+
+	ws.on('close', () => teardown('ws-close'));
+	ws.on('error', (error: Error) => {
+		terminalLog.info?.(`terminal ws error from ${remote}`, error);
+		teardown('ws-error');
+	});
+}
+
+function safeClose(ws: any, code: number, reason: string): void {
+	try {
+		ws.close(code, reason);
+	} catch {
+		/* socket already gone */
+	}
+}

--- a/config-root.schema.json
+++ b/config-root.schema.json
@@ -648,7 +648,7 @@
 
 		"terminal": {
 			"type": "object",
-			"description": "Built-in interactive terminal component (PROTOTYPE). Exposes a super_user-only PTY over a WebSocket on the app HTTP port for Studio. Disabled by default — a browser-reachable shell must be explicitly opted in.",
+			"description": "Built-in interactive terminal component (PROTOTYPE). Exposes a super_user-only PTY over a WebSocket on the operations API port for Studio. Disabled by default — a browser-reachable shell must be explicitly opted in.",
 			"additionalProperties": false,
 			"properties": {
 				"enabled": { "type": "boolean", "description": "Enable the interactive terminal component. Default: false" },

--- a/config-root.schema.json
+++ b/config-root.schema.json
@@ -646,6 +646,38 @@
 			}
 		},
 
+		"terminal": {
+			"type": "object",
+			"description": "Built-in interactive terminal component (PROTOTYPE). Exposes a super_user-only PTY over a WebSocket on the app HTTP port for Studio. Disabled by default — a browser-reachable shell must be explicitly opted in.",
+			"additionalProperties": false,
+			"properties": {
+				"enabled": { "type": "boolean", "description": "Enable the interactive terminal component. Default: false" },
+				"shell": {
+					"type": "string",
+					"description": "Shell executable to spawn. Default: $SHELL, else bash."
+				},
+				"args": {
+					"type": "array",
+					"items": { "type": "string" },
+					"description": "Arguments passed to the shell. Default: none."
+				},
+				"cwd": {
+					"type": "string",
+					"description": "Working directory for spawned terminals. Default: the instance root."
+				},
+				"idleTimeoutMs": {
+					"type": "integer",
+					"minimum": 1000,
+					"description": "Close a session after this many ms with no traffic. Default: 600000 (10m)."
+				},
+				"maxSessions": {
+					"type": "integer",
+					"minimum": 1,
+					"description": "Maximum concurrent terminal sessions per worker. Default: 10."
+				}
+			}
+		},
+
 		"analytics": {
 			"type": "object",
 			"additionalProperties": false,

--- a/dependencies.md
+++ b/dependencies.md
@@ -77,6 +77,14 @@ Generally, dependencies are added by simply adding them to the dependencies list
 - Binary compilation: No
 - Eventual removal: This code could be maintained within our codebase, if necessary, as it is not very large.
 
+## node-pty
+
+- Need for usage: Provides a real pseudo-terminal (PTY) for the built-in interactive terminal component (`components/terminal`), so Studio can attach an xterm.js shell to an instance. Optional dependency; the component only loads when `terminal.enabled` is set.
+- Size/memory cost: Small (~50KB) plus a prebuilt native binary per platform.
+- Security: No reported vulnerabilities. It spawns a shell, so the terminal component gates access to super_user only.
+- Binary compilation: Yes (native addon; shipped as an optional dependency with prebuilds).
+- Eventual removal: The terminal component is opt-in and off by default; if dropped, remove the component and this dependency together.
+
 ## segfault-handler
 
 - Need for usage: Provides a way to log segfaults in native code

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,6 +136,7 @@
 			},
 			"optionalDependencies": {
 				"bufferutil": "^4.0.9",
+				"node-pty": "^1.0.0",
 				"segfault-handler": "^1.3.0",
 				"utf-8-validate": "^5.0.10"
 			},
@@ -11668,6 +11669,24 @@
 			"license": "MIT",
 			"optional": true,
 			"peer": true
+		},
+		"node_modules/node-pty": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+			"integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"node-addon-api": "^7.1.0"
+			}
+		},
+		"node_modules/node-pty/node_modules/node-addon-api": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.46",

--- a/package.json
+++ b/package.json
@@ -249,6 +249,7 @@
 	},
 	"optionalDependencies": {
 		"bufferutil": "^4.0.9",
+		"node-pty": "^1.0.0",
 		"segfault-handler": "^1.3.0",
 		"utf-8-validate": "^5.0.10"
 	},

--- a/server/operationsServer.ts
+++ b/server/operationsServer.ts
@@ -29,6 +29,7 @@ import { registerBunFastifyInstance } from './http.ts';
 import { registerContentHandlers } from './serverHelpers/contentTypes.ts';
 import { getConfigObj } from '../config/configUtils.ts';
 import { registerMcpProfile } from '../components/mcp/index.ts';
+import { registerTerminalWebSocket } from '../components/terminal/index.ts';
 import type { OperationFunctionName } from './serverHelpers/serverUtilities.ts';
 type ParsedSqlObject = any;
 import { generateJsonApi } from '../resources/openApi.ts';
@@ -221,6 +222,15 @@ function buildServer(isHttps: boolean, resources: Resources): FastifyInstance {
 			// contaminate the JSON-RPC envelope the MCP handler reads).
 			routeOptions: { preValidation: [authAndEnsureUserOnRequest] },
 		});
+	}
+
+	// Built-in interactive terminal (PROTOTYPE). Opt-in via `terminal.enabled`.
+	// Attaches a `/terminal` WebSocket upgrade handler to this operations node
+	// server, keeping the super_user PTY on the operations security boundary
+	// rather than the application data port. First-message auth (no auth-middleware
+	// change). See components/terminal/index.ts and components/terminal/README.md.
+	if (fullConfig.terminal?.enabled) {
+		registerTerminalWebSocket({ nodeServer: app.server, config: fullConfig.terminal });
 	}
 
 	// Add a simple health check


### PR DESCRIPTION
**Prototype / draft — for team discussion. Not for merge as-is.**

Adds a super_user-only interactive terminal (PTY over WebSocket) exposed from a Harper instance, so Studio can render an `xterm.js` shell running **inside the container**. This is the stepping-stone channel from the "Claude in the container" exploration; the authenticated WebSocket it establishes is the substrate the planned live-log-stream and Node-inspector-bridge features would reuse.

**Companion Studio PR:** https://github.com/HarperFast/studio/pull/1467

## Design decisions (settled with the team)
- **Operations API port.** Served from the operations Fastify server's underlying node server (`registerTerminalWebSocket` in `buildServer`, right next to the MCP operations profile), gated on `terminal.enabled`. Keeps the terminal on the same security boundary as the rest of the operations surface, not the application data port.
- **First-message auth.** The socket is accepted unauthenticated; the client's **first** WS frame carries the credential (operation token, or basic), which is validated and super_user-checked before any PTY spawns. Nothing sensitive rides in the handshake headers/subprotocol. **No change to `security/auth.ts`.**

## What's here
- `components/terminal/` — the component + README (wire protocol, close codes, security notes).
- `server/operationsServer.ts` — wires it in, gated on `terminal.enabled`.
- `config-root.schema.json` — opt-in `terminal` block (default off).
- `package.json` — `node-pty` as an `optionalDependency`.

## Enable
```yaml
terminal:
  enabled: true          # required — off by default
  # shell / cwd / idleTimeoutMs / maxSessions are optional
```

## Status / caveats
- **Off by default** (opt-in twice: `terminal` block present *and* `enabled: true`).
- **Direct-connection only** — the Fabric Connect proxy buffers streamed responses and can't carry a WebSocket (same limitation as the existing log/deploy SSE tails).
- Deliberate prototype scoping: the shell inherits the operations-thread user/privileges; only a global session cap + notify-level open/close/deny audit logging, no cgroup/user-namespace confinement. See `components/terminal/README.md`.
- **Branch is based on `main@d33f0970f`; `main` has since advanced. Rebase before merge** — expect touch-points in `server/operationsServer.ts`, `config-root.schema.json`, and `package.json`.

Verified locally end-to-end in the real Studio UI (see companion PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
