### PR TITLE
fix: resolve uWebSockets.js via a tarball URL, not a github: git spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "harper",
-	"version": "5.1.15",
+	"version": "5.2.0-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "harper",
-			"version": "5.1.15",
+			"version": "5.2.0-alpha.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/client-s3": "^3.1012.0",
@@ -138,7 +138,7 @@
 				"bufferutil": "^4.0.9",
 				"segfault-handler": "^1.3.0",
 				"utf-8-validate": "^5.0.10",
-				"uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.68.0"
+				"uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js/archive/624987739d4da0acb628aaf2a10fc43e7ce27c5c.tar.gz"
 			},
 			"peerDependencies": {
 				"@aws-sdk/client-bedrock-runtime": "^3.0.0"
@@ -14868,7 +14868,8 @@
 		},
 		"node_modules/uWebSockets.js": {
 			"version": "20.68.0",
-			"resolved": "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#624987739d4da0acb628aaf2a10fc43e7ce27c5c",
+			"resolved": "https://github.com/uNetworking/uWebSockets.js/archive/624987739d4da0acb628aaf2a10fc43e7ce27c5c.tar.gz",
+			"integrity": "sha512-BcXO02DANWelQzJyMd2G875nBeZDDYHZxqE7uOH9cAsf62Ur3hl5+4crdqBWvFF+DzbUxJoswPqvE3i2aAEZ1g==",
 			"license": "Apache-2.0",
 			"optional": true
 		},

--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
 	"optionalDependencies": {
 		"bufferutil": "^4.0.9",
 		"segfault-handler": "^1.3.0",
-		"uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.68.0",
+		"uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js/archive/624987739d4da0acb628aaf2a10fc43e7ce27c5c.tar.gz",
 		"utf-8-validate": "^5.0.10"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
## Summary
Same root cause as [harper-pro#561](https://github.com/HarperFast/harper-pro/pull/561), filed against this repo since `uWebSockets.js` (added for #1096) is declared here too:

- `package.json` declared `uWebSockets.js` via the `github:` shorthand (`github:uNetworking/uWebSockets.js#v20.68.0`).
- npm/`hosted-git-info` resolves that to `git+ssh://git@github.com/...` in `package-lock.json`.
- Our Docker build stage has no SSH credentials for `github.com`. Since it's an optional dependency, `npm ci` silently skips the failed clone — no error, no warning, build succeeds without it.
- Net effect: the shipped image never bundles the native `uWebSockets.js` addon, so `HARPER_UWS_UDS`/`HARPER_UWS_HTTP` are inert even when explicitly set.

An explicit `git+https://` spec does **not** fix this — verified with a clean npm cache that `hosted-git-info` canonicalizes *any* github.com git dependency back to `git+ssh://` regardless of the requested protocol.

## Fix
Point `package.json` at a plain tarball URL (`https://github.com/uNetworking/uWebSockets.js/archive/<sha>.tar.gz`) instead of a `github:` git spec. npm treats this as a remote-tarball dependency, not hosted-git, so the ssh-canonicalization path never runs. `resolved` stays a plain https URL with a pinned integrity hash — immune to regressing on a future `npm install`.

## Verification
Ran `npm ci` in a HOME-stripped, credential-less environment (no `~/.ssh`, no SSH agent) matching the Docker build stage, both before and after a full `npm install` regenerates the lockfile from `package.json`:
- Before: `uWebSockets.js` silently absent from `node_modules` (0 native `.node` binaries).
- After: installs cleanly, all 15 platform/ABI native binaries present.

## Test plan
- [ ] CI build picks up the change; confirm downstream harper-pro build (once its `core` submodule is bumped to include this) bundles `node_modules/uWebSockets.js/*.node`
- [ ] Enable `HARPER_UWS_UDS` on a dev cluster and confirm the uWS backend actually engages