### PR TITLE
ci(review): canary Claude reviews on claude-sonnet-5 (harper only)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -45,6 +45,14 @@ jobs:
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
       ai-review-prompts-ref: 9cf49d23cb046ecd6c87f3bba86dc3338d6998fb
+      # CANARY (2026-07-11): run this repo's Claude reviews on Sonnet 5
+      # while the fleet default stays claude-sonnet-4-6. Every ai-review-log
+      # entry records `Model:`, so calibration can compare sonnet-5 vs
+      # sonnet-4-6 verdict mix directly — watch the severity-deflation rate
+      # (Sonnet 5 follows blocker-only instructions more literally; known
+      # code-review-harness effect). Promote to the reusable's default or
+      # revert based on the next calibration cycle.
+      model: claude-sonnet-5
       review-layers: |
         universal
         harper/common


### PR DESCRIPTION
## What

One-input canary: harper's Claude reviews run on **claude-sonnet-5** while the fleet default stays claude-sonnet-4-6 (the reusable's default is untouched; this is a caller-side \`model:\` override).

## Why harper, why now

- Sonnet 5's largest gains over 4.6 are coding/agentic work — our review workload. Intro pricing ($2/$10 per MTok through 2026-08-31) roughly offsets the new tokenizer (~30% more tokens per equivalent text); post-intro cost is ~1.3x.
- harper has the highest review traffic (~15 log entries/day), so the A/B converges fastest. Every ai-review-log entry records \`Model:\`, so calibration can slice sonnet-5 vs sonnet-4-6 verdict mix directly at the same prompt ref.

## Watch item (decides promote vs revert)

Sonnet 5 follows blocker-only severity instructions **more literally** — a documented code-review-harness effect where precision rises but measured recall can fall. Our dominant calibration failure is already severity deflation, so the metric to watch in the next calibration cycle is the deflation-partial rate for sonnet-5 entries vs 4.6. If it rises: add coverage-first reporting to the run-notes surface (findings with confidence/severity in the log, blocker-only on the PR) and re-measure. If clean or better: promote to the reusable default and drop this override.

Note: this PR edits the caller workflow, so its own Claude review check fails with the expected anti-tamper guard; clears on merge.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)