### PR TITLE
fix(models): retry transient backend failures with backoff; actionable @embed errors (#1594)

### DIFF
--- a/components/anthropic/index.ts
+++ b/components/anthropic/index.ts
@@ -78,12 +78,18 @@ export interface AnthropicBackendConfig {
 	apiKey?: string;
 	model?: string;
 	baseUrl?: string;
+	/**
+	 * Overall deadline for a backend call — spans ALL retry attempts and backoff
+	 * sleeps, not one request. Combined with `opts.signal` via `AbortSignal.any`.
+	 */
 	requestTimeoutMs?: number;
 	/**
 	 * Retries after the initial attempt for retriable failures — HTTP 408/429/5xx
 	 * (including Anthropic's 529 overloaded) and transient network errors (#1594).
 	 * Honors `Retry-After`; jittered exponential backoff otherwise. All attempts
-	 * share the `requestTimeoutMs` / caller-signal budget. `0` disables. Default 2.
+	 * share the `requestTimeoutMs` / caller-signal budget. `0` disables. Default 2,
+	 * clamped to 10. Note: a retried `generate` is not exactly-once — a request
+	 * that succeeded upstream but failed in transit may re-execute.
 	 */
 	maxRetries?: number;
 	/** Initial retry backoff in ms (default 500); doubles per attempt with jitter. */

--- a/components/anthropic/index.ts
+++ b/components/anthropic/index.ts
@@ -25,12 +25,14 @@ import { setGenerative } from '../../resources/models/backendRegistry.ts';
 import {
 	assignFiniteTokenCount,
 	composeSignal,
+	fetchWithRetry,
 	MAX_ERROR_BODY_BYTES,
 	normalizeOrigin,
 	parseJsonResponse,
 	readBoundedJson,
 	requireCredential,
 	requireModel,
+	resolveRetryConfig,
 } from '../../resources/models/backendHelpers.ts';
 import { ServerError } from '../../utility/errors/hdbError.ts';
 import harperLogger from '../../utility/logging/harper_logger.ts';
@@ -77,6 +79,15 @@ export interface AnthropicBackendConfig {
 	model?: string;
 	baseUrl?: string;
 	requestTimeoutMs?: number;
+	/**
+	 * Retries after the initial attempt for retriable failures — HTTP 408/429/5xx
+	 * (including Anthropic's 529 overloaded) and transient network errors (#1594).
+	 * Honors `Retry-After`; jittered exponential backoff otherwise. All attempts
+	 * share the `requestTimeoutMs` / caller-signal budget. `0` disables. Default 2.
+	 */
+	maxRetries?: number;
+	/** Initial retry backoff in ms (default 500); doubles per attempt with jitter. */
+	retryBackoffMs?: number;
 }
 
 /**
@@ -95,6 +106,8 @@ export class AnthropicBackend implements ModelBackend {
 	readonly #defaultModel?: string;
 	readonly #apiKey: string;
 	readonly #requestTimeoutMs?: number;
+	readonly #maxRetries: number;
+	readonly #retryBackoffMs: number;
 	readonly #fetch: typeof fetch;
 
 	constructor(config: AnthropicBackendConfig = {}, fetchImpl: typeof fetch = fetch) {
@@ -102,6 +115,7 @@ export class AnthropicBackend implements ModelBackend {
 		this.#baseUrl = normalizeOrigin(config.baseUrl, { host: DEFAULT_BASE_URL, secure: true });
 		this.#defaultModel = config.model;
 		this.#requestTimeoutMs = config.requestTimeoutMs;
+		({ maxRetries: this.#maxRetries, retryBackoffMs: this.#retryBackoffMs } = resolveRetryConfig(config));
 		this.#fetch = fetchImpl;
 	}
 
@@ -250,12 +264,12 @@ export class AnthropicBackend implements ModelBackend {
 			'x-api-key': this.#apiKey,
 			'anthropic-version': ANTHROPIC_API_VERSION,
 		};
-		const res = await this.#fetch(`${this.#baseUrl}${path}`, {
-			method: 'POST',
-			headers,
-			body: JSON.stringify(body),
-			signal,
-		});
+		const res = await fetchWithRetry(
+			this.#fetch,
+			`${this.#baseUrl}${path}`,
+			{ method: 'POST', headers, body: JSON.stringify(body), signal },
+			{ maxRetries: this.#maxRetries, retryBackoffMs: this.#retryBackoffMs }
+		);
 		if (!res.ok) {
 			throw new AnthropicBackendError(
 				`Anthropic ${path} returned HTTP ${res.status}${await readErrorSuffix(res)}`,

--- a/components/bedrock/index.ts
+++ b/components/bedrock/index.ts
@@ -21,7 +21,12 @@
  * helpers below.
  */
 import { setEmbedding, setGenerative } from '../../resources/models/backendRegistry.ts';
-import { assignFiniteTokenCount, composeSignal, requireModel } from '../../resources/models/backendHelpers.ts';
+import {
+	assignFiniteTokenCount,
+	composeSignal,
+	requireModel,
+	resolveRetryConfig,
+} from '../../resources/models/backendHelpers.ts';
 import { ServerError } from '../../utility/errors/hdbError.ts';
 import harperLogger from '../../utility/logging/harper_logger.ts';
 import type {
@@ -68,6 +73,14 @@ export interface BedrockBackendConfig {
 	 */
 	model?: string;
 	requestTimeoutMs?: number;
+	/**
+	 * Retries after the initial attempt for retriable failures (#1594). Plumbed
+	 * to the AWS SDK's `maxAttempts` (`maxRetries + 1`) — the SDK owns the retry
+	 * loop and backoff for Bedrock, unlike the fetch-based backends. `0` disables.
+	 * Default 2, matching both the other backends and the SDK's own default.
+	 * There is no `retryBackoffMs` here; the SDK's retry strategy manages delays.
+	 */
+	maxRetries?: number;
 }
 
 /**
@@ -76,7 +89,7 @@ export interface BedrockBackendConfig {
  * compile doesn't depend on the SDK either.
  */
 type SdkLike = {
-	BedrockRuntimeClient: new (config: { region?: string }) => {
+	BedrockRuntimeClient: new (config: { region?: string; maxAttempts?: number }) => {
 		send: (cmd: object) => Promise<unknown>;
 	};
 	InvokeModelCommand: new (input: { modelId: string; body: string; contentType?: string; accept?: string }) => object;
@@ -150,12 +163,14 @@ export class BedrockBackend implements ModelBackend {
 	readonly #region?: string;
 	readonly #defaultModel?: string;
 	readonly #requestTimeoutMs?: number;
+	readonly #maxRetries: number;
 	#client?: { send: (cmd: object) => Promise<unknown> };
 
 	constructor(config: BedrockBackendConfig = {}) {
 		this.#region = config.region;
 		this.#defaultModel = config.model;
 		this.#requestTimeoutMs = config.requestTimeoutMs;
+		this.#maxRetries = resolveRetryConfig(config).maxRetries;
 	}
 
 	capabilities(): ModelCapabilities {
@@ -248,7 +263,7 @@ export class BedrockBackend implements ModelBackend {
 	async #getClient(): Promise<{ send: (cmd: object) => Promise<unknown> }> {
 		if (this.#client) return this.#client;
 		const sdk = await loadSdk();
-		this.#client = new sdk.BedrockRuntimeClient({ region: this.#region });
+		this.#client = new sdk.BedrockRuntimeClient({ region: this.#region, maxAttempts: this.#maxRetries + 1 });
 		return this.#client;
 	}
 

--- a/components/bedrock/index.ts
+++ b/components/bedrock/index.ts
@@ -77,8 +77,12 @@ export interface BedrockBackendConfig {
 	 * Retries after the initial attempt for retriable failures (#1594). Plumbed
 	 * to the AWS SDK's `maxAttempts` (`maxRetries + 1`) — the SDK owns the retry
 	 * loop and backoff for Bedrock, unlike the fetch-based backends. `0` disables.
-	 * Default 2, matching both the other backends and the SDK's own default.
-	 * There is no `retryBackoffMs` here; the SDK's retry strategy manages delays.
+	 * Default 2 (clamped to 10), matching both the other backends and the SDK's
+	 * own default. There is no `retryBackoffMs` here; the SDK's retry strategy
+	 * manages delays. `requestTimeoutMs` spans all SDK attempts (the composed
+	 * abort signal wraps the whole `send`). Note: a retried `generate` is not
+	 * exactly-once — a request that succeeded upstream but failed in transit may
+	 * re-execute.
 	 */
 	maxRetries?: number;
 }

--- a/components/ollama/index.ts
+++ b/components/ollama/index.ts
@@ -44,13 +44,18 @@ export interface OllamaBackendConfig {
 	host?: string;
 	/** Default model when the caller doesn't pass `opts.model`. */
 	model?: string;
-	/** Per-request timeout. When set, combined with `opts.signal` via `AbortSignal.any`. */
+	/**
+	 * Overall deadline for a backend call — spans ALL retry attempts and backoff
+	 * sleeps, not one request. Combined with `opts.signal` via `AbortSignal.any`.
+	 */
 	requestTimeoutMs?: number;
 	/**
 	 * Retries after the initial attempt for retriable failures — HTTP 408/429/5xx
 	 * and transient network errors (#1594). Honors `Retry-After`; jittered
 	 * exponential backoff otherwise. All attempts share the `requestTimeoutMs` /
-	 * caller-signal budget. `0` disables. Default 2.
+	 * caller-signal budget. `0` disables. Default 2, clamped to 10. Note: a
+	 * retried `generate` is not exactly-once — a request that succeeded upstream
+	 * but failed in transit may re-execute.
 	 */
 	maxRetries?: number;
 	/** Initial retry backoff in ms (default 500); doubles per attempt with jitter. */

--- a/components/ollama/index.ts
+++ b/components/ollama/index.ts
@@ -13,9 +13,11 @@ import { setEmbedding, setGenerative } from '../../resources/models/backendRegis
 import {
 	assignFiniteTokenCount,
 	composeSignal,
+	fetchWithRetry,
 	normalizeOrigin,
 	parseJsonResponse,
 	requireModel,
+	resolveRetryConfig,
 } from '../../resources/models/backendHelpers.ts';
 import { ServerError } from '../../utility/errors/hdbError.ts';
 import type {
@@ -44,6 +46,15 @@ export interface OllamaBackendConfig {
 	model?: string;
 	/** Per-request timeout. When set, combined with `opts.signal` via `AbortSignal.any`. */
 	requestTimeoutMs?: number;
+	/**
+	 * Retries after the initial attempt for retriable failures — HTTP 408/429/5xx
+	 * and transient network errors (#1594). Honors `Retry-After`; jittered
+	 * exponential backoff otherwise. All attempts share the `requestTimeoutMs` /
+	 * caller-signal budget. `0` disables. Default 2.
+	 */
+	maxRetries?: number;
+	/** Initial retry backoff in ms (default 500); doubles per attempt with jitter. */
+	retryBackoffMs?: number;
 }
 
 /**
@@ -64,12 +75,15 @@ export class OllamaBackend implements ModelBackend {
 	readonly #origin: string;
 	readonly #defaultModel?: string;
 	readonly #requestTimeoutMs?: number;
+	readonly #maxRetries: number;
+	readonly #retryBackoffMs: number;
 	readonly #fetch: typeof fetch;
 
 	constructor(config: OllamaBackendConfig = {}, fetchImpl: typeof fetch = fetch) {
 		this.#origin = normalizeOrigin(config.host, { host: DEFAULT_HOST, secure: false });
 		this.#defaultModel = config.model;
 		this.#requestTimeoutMs = config.requestTimeoutMs;
+		({ maxRetries: this.#maxRetries, retryBackoffMs: this.#retryBackoffMs } = resolveRetryConfig(config));
 		this.#fetch = fetchImpl;
 	}
 
@@ -140,12 +154,12 @@ export class OllamaBackend implements ModelBackend {
 
 	async #post(path: string, body: object, callerSignal?: AbortSignal): Promise<Response> {
 		const signal = composeSignal(callerSignal, this.#requestTimeoutMs);
-		const res = await this.#fetch(`${this.#origin}${path}`, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify(body),
-			signal,
-		});
+		const res = await fetchWithRetry(
+			this.#fetch,
+			`${this.#origin}${path}`,
+			{ method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body), signal },
+			{ maxRetries: this.#maxRetries, retryBackoffMs: this.#retryBackoffMs }
+		);
 		if (!res.ok) {
 			throw new OllamaBackendError(`Ollama ${path} returned HTTP ${res.status}`, res.status);
 		}

--- a/components/openai/index.ts
+++ b/components/openai/index.ts
@@ -20,12 +20,14 @@ import { setEmbedding, setGenerative } from '../../resources/models/backendRegis
 import {
 	assignFiniteTokenCount,
 	composeSignal,
+	fetchWithRetry,
 	MAX_ERROR_BODY_BYTES,
 	normalizeOrigin,
 	parseJsonResponse,
 	readBoundedJson,
 	requireCredential,
 	requireModel,
+	resolveRetryConfig,
 } from '../../resources/models/backendHelpers.ts';
 import { ServerError } from '../../utility/errors/hdbError.ts';
 import harperLogger from '../../utility/logging/harper_logger.ts';
@@ -87,6 +89,15 @@ export interface OpenAIBackendConfig {
 	requestTimeoutMs?: number;
 	/** Forwarded as `OpenAI-Organization` header when set. */
 	organization?: string;
+	/**
+	 * Retries after the initial attempt for retriable failures — HTTP 408/429/5xx
+	 * and transient network errors (#1594). Honors `Retry-After`; jittered
+	 * exponential backoff otherwise. All attempts share the `requestTimeoutMs` /
+	 * caller-signal budget. `0` disables. Default 2.
+	 */
+	maxRetries?: number;
+	/** Initial retry backoff in ms (default 500); doubles per attempt with jitter. */
+	retryBackoffMs?: number;
 }
 
 /**
@@ -110,6 +121,8 @@ export class OpenAIBackend implements ModelBackend {
 	readonly #apiKey: string;
 	readonly #organization?: string;
 	readonly #requestTimeoutMs?: number;
+	readonly #maxRetries: number;
+	readonly #retryBackoffMs: number;
 	readonly #fetch: typeof fetch;
 	// True only when talking to api.openai.com itself. OpenAI's reasoning models
 	// (o-series, gpt-5 family) reject `max_tokens` in favour of `max_completion_tokens`;
@@ -127,6 +140,7 @@ export class OpenAIBackend implements ModelBackend {
 		this.#defaultModel = config.model;
 		this.#organization = config.organization;
 		this.#requestTimeoutMs = config.requestTimeoutMs;
+		({ maxRetries: this.#maxRetries, retryBackoffMs: this.#retryBackoffMs } = resolveRetryConfig(config));
 		this.#fetch = fetchImpl;
 	}
 
@@ -249,12 +263,12 @@ export class OpenAIBackend implements ModelBackend {
 			'Authorization': `Bearer ${this.#apiKey}`,
 		};
 		if (this.#organization) headers['OpenAI-Organization'] = this.#organization;
-		const res = await this.#fetch(`${this.#baseUrl}${path}`, {
-			method: 'POST',
-			headers,
-			body: JSON.stringify(body),
-			signal,
-		});
+		const res = await fetchWithRetry(
+			this.#fetch,
+			`${this.#baseUrl}${path}`,
+			{ method: 'POST', headers, body: JSON.stringify(body), signal },
+			{ maxRetries: this.#maxRetries, retryBackoffMs: this.#retryBackoffMs }
+		);
 		if (!res.ok) {
 			// Read OpenAI's well-defined error envelope (`{ error: { message,
 			// type, code, param } }`) for operator-facing detail. `error.message`

--- a/components/openai/index.ts
+++ b/components/openai/index.ts
@@ -85,7 +85,10 @@ export interface OpenAIBackendConfig {
 	model?: string;
 	/** Base URL of the OpenAI-compatible endpoint (default `https://api.openai.com/v1`). */
 	baseUrl?: string;
-	/** Per-request timeout. When set, combined with `opts.signal` via `AbortSignal.any`. */
+	/**
+	 * Overall deadline for a backend call — spans ALL retry attempts and backoff
+	 * sleeps, not one request. Combined with `opts.signal` via `AbortSignal.any`.
+	 */
 	requestTimeoutMs?: number;
 	/** Forwarded as `OpenAI-Organization` header when set. */
 	organization?: string;
@@ -93,7 +96,9 @@ export interface OpenAIBackendConfig {
 	 * Retries after the initial attempt for retriable failures — HTTP 408/429/5xx
 	 * and transient network errors (#1594). Honors `Retry-After`; jittered
 	 * exponential backoff otherwise. All attempts share the `requestTimeoutMs` /
-	 * caller-signal budget. `0` disables. Default 2.
+	 * caller-signal budget. `0` disables. Default 2, clamped to 10. Note: a
+	 * retried `generate` is not exactly-once — a request that succeeded upstream
+	 * but failed in transit may re-execute.
 	 */
 	maxRetries?: number;
 	/** Initial retry backoff in ms (default 500); doubles per attempt with jitter. */

--- a/resources/models/backendHelpers.ts
+++ b/resources/models/backendHelpers.ts
@@ -83,7 +83,9 @@ export function isRetriableStatus(status: number): boolean {
  * clamps a past HTTP-date to 0.
  */
 export function parseRetryAfterMs(header: string | null): number | undefined {
-	if (!header) return undefined;
+	// Whitespace-only must be unparseable, not Number(' ') === 0 — a 0ms "retry after"
+	// would skip the computed backoff entirely.
+	if (!header?.trim()) return undefined;
 	const seconds = Number(header);
 	if (Number.isFinite(seconds)) return seconds >= 0 ? seconds * 1000 : undefined;
 	const date = Date.parse(header);

--- a/resources/models/backendHelpers.ts
+++ b/resources/models/backendHelpers.ts
@@ -43,6 +43,14 @@ export const MAX_RETRY_DELAY_MS = 10_000;
  * server's request) or held open (which would stall the caller's write).
  */
 export const MAX_RETRY_AFTER_MS = 30_000;
+/**
+ * Sanity clamp on configured `maxRetries`. A fat-fingered large value with no
+ * `requestTimeoutMs`/caller signal would otherwise wedge the embed/write path
+ * for minutes (backoff caps at 10s and `Retry-After` at 30s PER ATTEMPT) —
+ * and on the cache-from-source path that time is spent under a per-record
+ * store lock.
+ */
+export const MAX_CONFIG_RETRIES = 10;
 
 /** Config fields shared by every backend that supports retry. */
 export interface RetryConfig {
@@ -54,13 +62,15 @@ export interface RetryConfig {
  * Validate the retry knobs from a backend config entry, falling back to the
  * defaults on missing or malformed values (negative, non-integer `maxRetries`;
  * non-positive or non-finite `retryBackoffMs`). `maxRetries: 0` is a valid,
- * deliberate "no retries" setting.
+ * deliberate "no retries" setting; values above `MAX_CONFIG_RETRIES` clamp.
  */
 export function resolveRetryConfig(config: RetryConfig): { maxRetries: number; retryBackoffMs: number } {
 	const { maxRetries, retryBackoffMs } = config;
 	return {
 		maxRetries:
-			Number.isInteger(maxRetries) && (maxRetries as number) >= 0 ? (maxRetries as number) : DEFAULT_MAX_RETRIES,
+			Number.isInteger(maxRetries) && (maxRetries as number) >= 0
+				? Math.min(maxRetries as number, MAX_CONFIG_RETRIES)
+				: DEFAULT_MAX_RETRIES,
 		retryBackoffMs:
 			typeof retryBackoffMs === 'number' && Number.isFinite(retryBackoffMs) && retryBackoffMs > 0
 				? retryBackoffMs

--- a/resources/models/backendHelpers.ts
+++ b/resources/models/backendHelpers.ts
@@ -29,6 +29,161 @@ export function composeSignal(caller?: AbortSignal, timeoutMs?: number): AbortSi
 	return AbortSignal.any([caller, timeout]);
 }
 
+// ---------- retry (#1594) ----------
+
+/** Retries after the initial attempt when the backend doesn't configure `maxRetries`. */
+export const DEFAULT_MAX_RETRIES = 2;
+/** Initial backoff when the backend doesn't configure `retryBackoffMs`; doubles per attempt. */
+export const DEFAULT_RETRY_BACKOFF_MS = 500;
+/** Upper bound on any single computed backoff sleep. */
+export const MAX_RETRY_DELAY_MS = 10_000;
+/**
+ * Upper bound on an honored `Retry-After`. A server demanding a longer wait
+ * is surfaced immediately rather than retried early (which would ignore the
+ * server's request) or held open (which would stall the caller's write).
+ */
+export const MAX_RETRY_AFTER_MS = 30_000;
+
+/** Config fields shared by every backend that supports retry. */
+export interface RetryConfig {
+	maxRetries?: number;
+	retryBackoffMs?: number;
+}
+
+/**
+ * Validate the retry knobs from a backend config entry, falling back to the
+ * defaults on missing or malformed values (negative, non-integer `maxRetries`;
+ * non-positive or non-finite `retryBackoffMs`). `maxRetries: 0` is a valid,
+ * deliberate "no retries" setting.
+ */
+export function resolveRetryConfig(config: RetryConfig): { maxRetries: number; retryBackoffMs: number } {
+	const { maxRetries, retryBackoffMs } = config;
+	return {
+		maxRetries:
+			Number.isInteger(maxRetries) && (maxRetries as number) >= 0 ? (maxRetries as number) : DEFAULT_MAX_RETRIES,
+		retryBackoffMs:
+			typeof retryBackoffMs === 'number' && Number.isFinite(retryBackoffMs) && retryBackoffMs > 0
+				? retryBackoffMs
+				: DEFAULT_RETRY_BACKOFF_MS,
+	};
+}
+
+/**
+ * Statuses worth a same-backend retry: request timeout, rate limit, and server
+ * errors (including Anthropic's 529 overloaded). Everything else — auth,
+ * validation, not-found — is deterministic and re-attempting it just burns quota.
+ */
+export function isRetriableStatus(status: number): boolean {
+	return status === 408 || status === 429 || (status >= 500 && status < 600);
+}
+
+/**
+ * Parse a `Retry-After` response header (delta-seconds or HTTP-date form) into
+ * milliseconds from now. Returns `undefined` for absent/unparseable values;
+ * clamps a past HTTP-date to 0.
+ */
+export function parseRetryAfterMs(header: string | null): number | undefined {
+	if (!header) return undefined;
+	const seconds = Number(header);
+	if (Number.isFinite(seconds)) return seconds >= 0 ? seconds * 1000 : undefined;
+	const date = Date.parse(header);
+	if (!Number.isNaN(date)) return Math.max(0, date - Date.now());
+	return undefined;
+}
+
+/**
+ * Jittered exponential backoff: `baseMs * 2^attempt`, capped at
+ * `MAX_RETRY_DELAY_MS`, scaled by a random factor in [0.5, 1). The half floor
+ * keeps the backoff meaningful under jitter; the cap bounds the tail. `random`
+ * is injectable for deterministic tests.
+ */
+export function computeRetryDelayMs(attempt: number, baseMs: number, random: () => number = Math.random): number {
+	const exponential = Math.min(MAX_RETRY_DELAY_MS, baseMs * 2 ** attempt);
+	return exponential * (0.5 + random() * 0.5);
+}
+
+/** Abort-driven rejections (caller abort or `AbortSignal.timeout`) — deliberate deadlines, never retried. */
+function isAbortError(err: unknown): boolean {
+	const name = (err as { name?: string } | null)?.name;
+	return name === 'AbortError' || name === 'TimeoutError';
+}
+
+/**
+ * `setTimeout` as a promise that rejects immediately with the signal's reason
+ * when `signal` aborts, so a backoff sleep never outlives the caller's deadline.
+ */
+export function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(signal.reason ?? new DOMException('This operation was aborted', 'AbortError'));
+			return;
+		}
+		const onAbort = () => {
+			clearTimeout(timer);
+			reject(signal!.reason ?? new DOMException('This operation was aborted', 'AbortError'));
+		};
+		const timer = setTimeout(() => {
+			signal?.removeEventListener('abort', onAbort);
+			resolve();
+		}, ms);
+		signal?.addEventListener('abort', onAbort, { once: true });
+	});
+}
+
+export interface FetchRetryOpts {
+	/** Retries after the initial attempt. 0 = single attempt. */
+	maxRetries: number;
+	/** Initial backoff in ms; doubles per attempt with jitter. */
+	retryBackoffMs: number;
+	/** Test seam — replaces `abortableSleep`. */
+	sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+	/** Test seam — replaces `Math.random` in the jitter computation. */
+	random?: () => number;
+}
+
+/**
+ * `fetch` with bounded same-endpoint retries (#1594): retriable HTTP statuses
+ * (`isRetriableStatus`) and transient network rejections re-attempt with
+ * jittered exponential backoff, honoring `Retry-After` when present (up to
+ * `MAX_RETRY_AFTER_MS` — a longer server-requested wait surfaces the response
+ * instead). Every attempt and backoff sleep runs under `init.signal`, so a
+ * composed caller-abort/`requestTimeoutMs` signal remains the overall deadline
+ * for the whole call — retries fit inside the existing budget rather than
+ * extending it — and aborts are never retried. The final attempt's response is
+ * returned unread (ok or not) so the caller's error path can consume the body;
+ * earlier retriable responses have their bodies cancelled to release the
+ * connection. Mid-stream failures after a returned `ok` response are the
+ * caller's concern — a partially consumed stream is not retriable here.
+ */
+export async function fetchWithRetry(
+	fetchImpl: typeof fetch,
+	url: string,
+	init: RequestInit,
+	opts: FetchRetryOpts
+): Promise<Response> {
+	const sleep = opts.sleep ?? abortableSleep;
+	const signal = init.signal ?? undefined;
+	for (let attempt = 0; ; attempt++) {
+		let res: Response;
+		try {
+			res = await fetchImpl(url, init);
+		} catch (err) {
+			if (attempt >= opts.maxRetries || signal?.aborted || isAbortError(err)) throw err;
+			await sleep(computeRetryDelayMs(attempt, opts.retryBackoffMs, opts.random), signal);
+			continue;
+		}
+		if (res.ok || !isRetriableStatus(res.status) || attempt >= opts.maxRetries) return res;
+		const retryAfterMs = parseRetryAfterMs(res.headers?.get?.('retry-after') ?? null);
+		if (retryAfterMs !== undefined && retryAfterMs > MAX_RETRY_AFTER_MS) return res;
+		try {
+			res.body?.cancel?.()?.catch?.(() => {});
+		} catch {
+			// A locked or already-disturbed body can't be cancelled; the retry proceeds regardless.
+		}
+		await sleep(retryAfterMs ?? computeRetryDelayMs(attempt, opts.retryBackoffMs, opts.random), signal);
+	}
+}
+
 /**
  * Write a token count to `usage` only when the value is a finite, non-negative
  * integer. Drops `NaN`, `Infinity`, negatives, and non-integers silently —

--- a/resources/models/embedHook.ts
+++ b/resources/models/embedHook.ts
@@ -15,6 +15,17 @@ function getLogger(): { error?: (...args: any[]) => void } {
 	}
 }
 
+// Lazy for the same reason as getLogger (hdbError imports the logger); only needed on failure.
+// Returning undefined fails closed: an unverifiable error stays behind the sanitized message.
+function getServerErrorClass(): (new (...args: any[]) => Error) | undefined {
+	try {
+		// eslint-disable-next-line @typescript-eslint/no-var-requires
+		return require('#src/utility/errors/hdbError').ServerError;
+	} catch {
+		return undefined;
+	}
+}
+
 export type EmbedConfig = {
 	source: string;
 	model: string;
@@ -118,19 +129,37 @@ export function buildEmbedBefore(
 				try {
 					vector = await embedder(record);
 				} catch (err) {
-					// Backend errors can carry URLs / key tails; log raw, rethrow sanitized. Include
-					// only safe identifiers (error class name, upstream HTTP status) so the failure is
-					// diagnosable without hunting through server logs (#1593). upstreamStatus is the
-					// provider's status — NOT ServerError's statusCode, which is Harper's own response
-					// status and would misleadingly read 500 here.
+					// Embedder errors can carry URLs / key tails; log raw, rethrow sanitized (#1593).
+					// One exception (#1594): errors from our own backend classes' HTTP paths —
+					// `ServerError` subclasses carrying `upstreamStatus` — have deliberately
+					// sanitized, length-capped messages (no request content), so surfacing them
+					// verbatim makes the failure actionable without grepping server logs. A bare
+					// `upstreamStatus` on a non-ServerError is NOT proof of sanitization; custom
+					// embedder errors stay behind safe identifiers only (class name, status).
+					// upstreamStatus is the provider's status — NOT ServerError's statusCode,
+					// which is Harper's own response status and would misleadingly read 500 here.
 					getLogger().error?.(`Embedder for attribute "${attr.name}" failed:`, err);
 					const status = (err as any)?.upstreamStatus;
 					const errName = (err as any)?.name;
+					const model = attr.embed?.model;
+					const modelPart = model ? ` (model "${model}")` : '';
+					const ServerErrorClass = getServerErrorClass();
+					if (
+						typeof status === 'number' &&
+						ServerErrorClass !== undefined &&
+						err instanceof ServerErrorClass &&
+						typeof (err as any).message === 'string'
+					) {
+						throw new Error(
+							`Failed to compute embedding for attribute "${attr.name}"${modelPart} ` +
+								`[${errName}] (backend HTTP ${status}): ${(err as any).message}`
+						);
+					}
 					const detail =
 						(errName && errName !== 'Error' ? ` [${errName}]` : '') +
 						(typeof status === 'number' ? ` (backend HTTP ${status})` : '');
 					throw new Error(
-						`Failed to compute embedding for attribute "${attr.name}"${detail} — see server log for details`
+						`Failed to compute embedding for attribute "${attr.name}"${modelPart}${detail} — see server log for details`
 					);
 				}
 				record[attr.name] = normalizeVector(vector);

--- a/unitTests/components/bedrock/index.test.js
+++ b/unitTests/components/bedrock/index.test.js
@@ -16,9 +16,11 @@ const ACCOUNTING = { tenantId: 'tid', app: '/test' };
 // Each test wires its own responder to control what `client.send(command)` resolves to.
 function fakeSdk(responder) {
 	const sent = [];
+	const constructed = [];
 	class FakeClient {
 		constructor(config) {
 			this.config = config;
+			constructed.push(config);
 		}
 		async send(command, options) {
 			sent.push({ command, options });
@@ -44,6 +46,7 @@ function fakeSdk(responder) {
 			InvokeModelWithResponseStreamCommand,
 		},
 		sent,
+		constructed,
 	};
 }
 
@@ -544,5 +547,28 @@ describe('Bedrock Anthropic-stream tool-call accumulator cardinality cap', () =>
 				/* drain */
 			}
 		}, /tool-call accumulator exceeded 128/);
+	});
+});
+
+describe('BedrockBackend retry plumbing (#1594)', () => {
+	it('constructs the SDK client with maxAttempts = maxRetries + 1 (default 2 retries)', async () => {
+		const { sdk, constructed } = fakeSdk(() =>
+			jsonBodyResponse({ content: [{ type: 'text', text: 'hi' }], stop_reason: 'end_turn' })
+		);
+		_injectSdkForTests(sdk);
+		const b = new BedrockBackend({ region: 'us-east-1', model: 'anthropic.claude-opus-4-v1:0' });
+		await b.generate('hello', { accounting: ACCOUNTING });
+		assert.strictEqual(constructed.length, 1);
+		assert.strictEqual(constructed[0].maxAttempts, 3);
+	});
+
+	it('maxRetries: 0 maps to a single SDK attempt', async () => {
+		const { sdk, constructed } = fakeSdk(() =>
+			jsonBodyResponse({ content: [{ type: 'text', text: 'hi' }], stop_reason: 'end_turn' })
+		);
+		_injectSdkForTests(sdk);
+		const b = new BedrockBackend({ region: 'us-east-1', model: 'anthropic.claude-opus-4-v1:0', maxRetries: 0 });
+		await b.generate('hello', { accounting: ACCOUNTING });
+		assert.strictEqual(constructed[0].maxAttempts, 1);
 	});
 });

--- a/unitTests/components/openai/index.test.js
+++ b/unitTests/components/openai/index.test.js
@@ -934,3 +934,38 @@ describe('registerOpenAIBackend', () => {
 		assert.strictEqual(b.name, 'openai');
 	});
 });
+
+describe('OpenAIBackend retry (#1594)', () => {
+	it('retries a 429 through #post and succeeds', async () => {
+		const fetch = mockFetch(({ callIndex }) =>
+			callIndex === 0
+				? new Response(JSON.stringify({ error: { message: 'rate limited' } }), {
+						status: 429,
+						headers: { 'retry-after': '0' }, // real sleep of 0ms keeps the test instant
+					})
+				: jsonResponse({ data: [{ embedding: [0.1] }] })
+		);
+		const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+		const result = await b.embed('x', { accounting: ACCOUNTING });
+		assert.strictEqual(result.status, 'completed');
+		assert.strictEqual(fetch.calls.length, 2);
+	});
+
+	it('maxRetries: 0 disables retry and surfaces the upstream status', async () => {
+		const fetch = mockFetch(() => jsonResponse({ error: { message: 'rate limited' } }, { status: 429 }));
+		const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm', maxRetries: 0 }, fetch);
+		await assert.rejects(b.embed('x', { accounting: ACCOUNTING }), (err) => {
+			assert.ok(err instanceof OpenAIBackendError);
+			assert.strictEqual(err.upstreamStatus, 429);
+			return true;
+		});
+		assert.strictEqual(fetch.calls.length, 1);
+	});
+
+	it('does not retry a non-retriable status', async () => {
+		const fetch = mockFetch(() => jsonResponse({ error: { message: 'bad request' } }, { status: 400 }));
+		const b = new OpenAIBackend({ apiKey: API_KEY, model: 'm' }, fetch);
+		await assert.rejects(b.embed('x', { accounting: ACCOUNTING }), OpenAIBackendError);
+		assert.strictEqual(fetch.calls.length, 1);
+	});
+});

--- a/unitTests/resources/models/backendHelpers.test.js
+++ b/unitTests/resources/models/backendHelpers.test.js
@@ -411,6 +411,12 @@ describe('backendHelpers retry (#1594)', () => {
 			assert.strictEqual(parseRetryAfterMs('-5'), undefined);
 			assert.strictEqual(parseRetryAfterMs('soon'), undefined);
 		});
+
+		it('treats empty and whitespace-only headers as unparseable, not 0', () => {
+			assert.strictEqual(parseRetryAfterMs(''), undefined);
+			assert.strictEqual(parseRetryAfterMs(' '), undefined);
+			assert.strictEqual(parseRetryAfterMs('\t'), undefined);
+		});
 	});
 
 	describe('computeRetryDelayMs', () => {

--- a/unitTests/resources/models/backendHelpers.test.js
+++ b/unitTests/resources/models/backendHelpers.test.js
@@ -21,6 +21,7 @@ const {
 	computeRetryDelayMs,
 	abortableSleep,
 	fetchWithRetry,
+	MAX_CONFIG_RETRIES,
 } = require('#src/resources/models/backendHelpers');
 
 // Backend-specific error class used to verify the helpers route the thrown
@@ -374,6 +375,11 @@ describe('backendHelpers retry (#1594)', () => {
 			for (const retryBackoffMs of [0, -100, NaN, Infinity, '500']) {
 				assert.strictEqual(resolveRetryConfig({ retryBackoffMs }).retryBackoffMs, DEFAULT_RETRY_BACKOFF_MS);
 			}
+		});
+
+		it('clamps oversized maxRetries to MAX_CONFIG_RETRIES', () => {
+			assert.strictEqual(resolveRetryConfig({ maxRetries: 10_000 }).maxRetries, MAX_CONFIG_RETRIES);
+			assert.strictEqual(resolveRetryConfig({ maxRetries: MAX_CONFIG_RETRIES }).maxRetries, MAX_CONFIG_RETRIES);
 		});
 	});
 

--- a/unitTests/resources/models/backendHelpers.test.js
+++ b/unitTests/resources/models/backendHelpers.test.js
@@ -11,6 +11,16 @@ const {
 	requireModel,
 	requireCredential,
 	normalizeOrigin,
+	DEFAULT_MAX_RETRIES,
+	DEFAULT_RETRY_BACKOFF_MS,
+	MAX_RETRY_DELAY_MS,
+	MAX_RETRY_AFTER_MS,
+	resolveRetryConfig,
+	isRetriableStatus,
+	parseRetryAfterMs,
+	computeRetryDelayMs,
+	abortableSleep,
+	fetchWithRetry,
 } = require('#src/resources/models/backendHelpers');
 
 // Backend-specific error class used to verify the helpers route the thrown
@@ -318,5 +328,251 @@ describe('readBoundedJson', () => {
 
 	it('MAX_ERROR_BODY_BYTES is 256 KiB', () => {
 		assert.strictEqual(MAX_ERROR_BODY_BYTES, 256 * 1024);
+	});
+});
+
+describe('backendHelpers retry (#1594)', () => {
+	// Records requested sleep durations without actually sleeping — keeps the
+	// backoff paths deterministic and instant.
+	function sleepRecorder() {
+		const sleeps = [];
+		return {
+			sleeps,
+			sleep: async (ms) => {
+				sleeps.push(ms);
+			},
+		};
+	}
+
+	function retryOpts(overrides = {}) {
+		return { maxRetries: 2, retryBackoffMs: 500, random: () => 0, ...overrides };
+	}
+
+	describe('resolveRetryConfig', () => {
+		it('falls back to defaults on an empty config', () => {
+			assert.deepStrictEqual(resolveRetryConfig({}), {
+				maxRetries: DEFAULT_MAX_RETRIES,
+				retryBackoffMs: DEFAULT_RETRY_BACKOFF_MS,
+			});
+		});
+
+		it('respects an explicit maxRetries of 0', () => {
+			assert.strictEqual(resolveRetryConfig({ maxRetries: 0 }).maxRetries, 0);
+		});
+
+		it('passes through valid values', () => {
+			assert.deepStrictEqual(resolveRetryConfig({ maxRetries: 5, retryBackoffMs: 100 }), {
+				maxRetries: 5,
+				retryBackoffMs: 100,
+			});
+		});
+
+		it('rejects malformed values back to defaults', () => {
+			for (const maxRetries of [-1, 1.5, NaN, Infinity, '2']) {
+				assert.strictEqual(resolveRetryConfig({ maxRetries }).maxRetries, DEFAULT_MAX_RETRIES);
+			}
+			for (const retryBackoffMs of [0, -100, NaN, Infinity, '500']) {
+				assert.strictEqual(resolveRetryConfig({ retryBackoffMs }).retryBackoffMs, DEFAULT_RETRY_BACKOFF_MS);
+			}
+		});
+	});
+
+	describe('isRetriableStatus', () => {
+		it('retries timeout, rate limit, and server errors', () => {
+			for (const status of [408, 429, 500, 502, 503, 504, 529, 599]) {
+				assert.strictEqual(isRetriableStatus(status), true, `expected ${status} retriable`);
+			}
+		});
+
+		it('does not retry deterministic client errors or success', () => {
+			for (const status of [200, 201, 301, 400, 401, 403, 404, 409, 422]) {
+				assert.strictEqual(isRetriableStatus(status), false, `expected ${status} non-retriable`);
+			}
+		});
+	});
+
+	describe('parseRetryAfterMs', () => {
+		it('parses delta-seconds', () => {
+			assert.strictEqual(parseRetryAfterMs('2'), 2000);
+			assert.strictEqual(parseRetryAfterMs('0'), 0);
+		});
+
+		it('parses an HTTP-date into a forward delay', () => {
+			const ms = parseRetryAfterMs(new Date(Date.now() + 5000).toUTCString());
+			assert.ok(ms > 0 && ms <= 5000, `expected 0 < ms <= 5000, got ${ms}`);
+		});
+
+		it('clamps a past HTTP-date to 0', () => {
+			assert.strictEqual(parseRetryAfterMs(new Date(Date.now() - 60_000).toUTCString()), 0);
+		});
+
+		it('returns undefined for absent, negative, or garbage values', () => {
+			assert.strictEqual(parseRetryAfterMs(null), undefined);
+			assert.strictEqual(parseRetryAfterMs('-5'), undefined);
+			assert.strictEqual(parseRetryAfterMs('soon'), undefined);
+		});
+	});
+
+	describe('computeRetryDelayMs', () => {
+		it('doubles per attempt with the jitter floor at half the exponential', () => {
+			assert.strictEqual(
+				computeRetryDelayMs(0, 500, () => 0),
+				250
+			);
+			assert.strictEqual(
+				computeRetryDelayMs(1, 500, () => 0),
+				500
+			);
+			assert.strictEqual(
+				computeRetryDelayMs(2, 500, () => 0),
+				1000
+			);
+		});
+
+		it('never exceeds the exponential value', () => {
+			const delay = computeRetryDelayMs(1, 500, () => 0.999999);
+			assert.ok(delay < 1000, `expected < 1000, got ${delay}`);
+		});
+
+		it('caps the exponential at MAX_RETRY_DELAY_MS', () => {
+			const delay = computeRetryDelayMs(30, 500, () => 0.999999);
+			assert.ok(delay <= MAX_RETRY_DELAY_MS, `expected <= ${MAX_RETRY_DELAY_MS}, got ${delay}`);
+		});
+	});
+
+	describe('abortableSleep', () => {
+		it('resolves after the given duration', async () => {
+			await abortableSleep(5);
+		});
+
+		it('rejects with the abort reason when the signal fires mid-sleep', async () => {
+			const ctrl = new AbortController();
+			const reason = new Error('deadline');
+			setTimeout(() => ctrl.abort(reason), 5);
+			await assert.rejects(abortableSleep(60_000, ctrl.signal), (err) => err === reason);
+		});
+
+		it('rejects immediately on an already-aborted signal', async () => {
+			const ctrl = new AbortController();
+			ctrl.abort();
+			await assert.rejects(abortableSleep(60_000, ctrl.signal));
+		});
+	});
+
+	describe('fetchWithRetry', () => {
+		function mockFetch(responders) {
+			const calls = [];
+			const fn = async (url, init) => {
+				calls.push({ url, init });
+				const responder = responders[Math.min(calls.length - 1, responders.length - 1)];
+				if (responder instanceof Error) throw responder;
+				return responder();
+			};
+			fn.calls = calls;
+			return fn;
+		}
+
+		it('retries a retriable status and returns the eventual success', async () => {
+			const { sleeps, sleep } = sleepRecorder();
+			const fetchImpl = mockFetch([() => new Response('', { status: 503 }), () => new Response('ok', { status: 200 })]);
+			const res = await fetchWithRetry(fetchImpl, 'http://u', {}, retryOpts({ sleep }));
+			assert.strictEqual(res.status, 200);
+			assert.strictEqual(fetchImpl.calls.length, 2);
+			assert.deepStrictEqual(sleeps, [250]); // 500 * 2^0 * 0.5 (random pinned to 0)
+		});
+
+		it('honors Retry-After delta-seconds over the computed backoff', async () => {
+			const { sleeps, sleep } = sleepRecorder();
+			const fetchImpl = mockFetch([
+				() => new Response('', { status: 429, headers: { 'retry-after': '1' } }),
+				() => new Response('ok', { status: 200 }),
+			]);
+			const res = await fetchWithRetry(fetchImpl, 'http://u', {}, retryOpts({ sleep }));
+			assert.strictEqual(res.status, 200);
+			assert.deepStrictEqual(sleeps, [1000]);
+		});
+
+		it('surfaces the response instead of honoring a Retry-After beyond the cap', async () => {
+			const { sleeps, sleep } = sleepRecorder();
+			const fetchImpl = mockFetch([
+				() => new Response('', { status: 429, headers: { 'retry-after': String(MAX_RETRY_AFTER_MS / 1000 + 1) } }),
+			]);
+			const res = await fetchWithRetry(fetchImpl, 'http://u', {}, retryOpts({ sleep }));
+			assert.strictEqual(res.status, 429);
+			assert.strictEqual(fetchImpl.calls.length, 1);
+			assert.deepStrictEqual(sleeps, []);
+		});
+
+		it('does not retry a non-retriable status', async () => {
+			const { sleeps, sleep } = sleepRecorder();
+			const fetchImpl = mockFetch([() => new Response('', { status: 400 })]);
+			const res = await fetchWithRetry(fetchImpl, 'http://u', {}, retryOpts({ sleep }));
+			assert.strictEqual(res.status, 400);
+			assert.strictEqual(fetchImpl.calls.length, 1);
+			assert.deepStrictEqual(sleeps, []);
+		});
+
+		it('returns the final retriable response once maxRetries is exhausted', async () => {
+			const { sleeps, sleep } = sleepRecorder();
+			const fetchImpl = mockFetch([() => new Response('', { status: 503 })]);
+			const res = await fetchWithRetry(fetchImpl, 'http://u', {}, retryOpts({ sleep }));
+			assert.strictEqual(res.status, 503);
+			assert.strictEqual(fetchImpl.calls.length, 3); // initial + 2 retries
+			assert.deepStrictEqual(sleeps, [250, 500]);
+		});
+
+		it('makes a single attempt when maxRetries is 0', async () => {
+			const fetchImpl = mockFetch([() => new Response('', { status: 503 })]);
+			const res = await fetchWithRetry(fetchImpl, 'http://u', {}, retryOpts({ maxRetries: 0 }));
+			assert.strictEqual(res.status, 503);
+			assert.strictEqual(fetchImpl.calls.length, 1);
+		});
+
+		it('retries a transient network rejection', async () => {
+			const { sleep } = sleepRecorder();
+			const fetchImpl = mockFetch([new TypeError('fetch failed'), () => new Response('ok', { status: 200 })]);
+			const res = await fetchWithRetry(fetchImpl, 'http://u', {}, retryOpts({ sleep }));
+			assert.strictEqual(res.status, 200);
+			assert.strictEqual(fetchImpl.calls.length, 2);
+		});
+
+		it('rethrows the network error once maxRetries is exhausted', async () => {
+			const { sleep } = sleepRecorder();
+			const boom = new TypeError('fetch failed');
+			const fetchImpl = mockFetch([boom]);
+			await assert.rejects(fetchWithRetry(fetchImpl, 'http://u', {}, retryOpts({ maxRetries: 1, sleep })), boom);
+			assert.strictEqual(fetchImpl.calls.length, 2);
+		});
+
+		it('never retries an abort', async () => {
+			const { sleep } = sleepRecorder();
+			const fetchImpl = mockFetch([new DOMException('This operation was aborted', 'AbortError')]);
+			await assert.rejects(fetchWithRetry(fetchImpl, 'http://u', {}, retryOpts({ sleep })), /aborted/i);
+			assert.strictEqual(fetchImpl.calls.length, 1);
+		});
+
+		it('never retries a timeout abort', async () => {
+			const { sleep } = sleepRecorder();
+			const fetchImpl = mockFetch([new DOMException('The operation timed out', 'TimeoutError')]);
+			await assert.rejects(fetchWithRetry(fetchImpl, 'http://u', {}, retryOpts({ sleep })), /timed out/i);
+			assert.strictEqual(fetchImpl.calls.length, 1);
+		});
+
+		it('a signal abort during backoff stops the retry loop promptly', async () => {
+			const ctrl = new AbortController();
+			const reason = new Error('caller gave up');
+			const fetchImpl = mockFetch([
+				() => {
+					setTimeout(() => ctrl.abort(reason), 5);
+					return new Response('', { status: 503 });
+				},
+			]);
+			// Real abortableSleep + a long backoff: only the abort can end the test quickly.
+			await assert.rejects(
+				fetchWithRetry(fetchImpl, 'http://u', { signal: ctrl.signal }, retryOpts({ retryBackoffMs: 60_000 })),
+				(err) => err === reason
+			);
+			assert.strictEqual(fetchImpl.calls.length, 1);
+		});
 	});
 });

--- a/unitTests/resources/models/embedHook.test.js
+++ b/unitTests/resources/models/embedHook.test.js
@@ -262,3 +262,61 @@ describe('embedHook', () => {
 		});
 	});
 });
+
+describe('embed error surface (#1594)', () => {
+	const { ServerError } = require('#src/utility/errors/hdbError');
+	const attrs = [{ name: 'embedding', embed: { source: 'content', model: 'default' } }];
+
+	// Mirrors the shape of the real backend error classes (OpenAIBackendError etc.):
+	// a ServerError subclass carrying `upstreamStatus`, whose message is the backend's
+	// deliberately sanitized, length-capped text.
+	class FakeBackendHttpError extends ServerError {
+		constructor(message, upstreamStatus) {
+			super(message);
+			this.name = 'OpenAIBackendError';
+			this.upstreamStatus = upstreamStatus;
+		}
+	}
+
+	it('surfaces the backend sanitized message, model, and status for ServerError + upstreamStatus', async () => {
+		const record = { content: 'hello' };
+		const backendError = new FakeBackendHttpError(
+			'OpenAI /embeddings returned HTTP 404: models/default is not found',
+			404
+		);
+		const before = buildEmbedBefore(record, {}, {}, attrs, {
+			embedding: async () => {
+				throw backendError;
+			},
+		});
+		assert.ok(before);
+		await assert.rejects(before(), (err) => {
+			assert.ok(/models\/default is not found/.test(err.message), 'backend sanitized message should be surfaced');
+			assert.ok(/model "default"/.test(err.message), 'configured model name should be included');
+			assert.ok(/backend HTTP 404/.test(err.message), 'upstream status should be included');
+			assert.ok(/OpenAIBackendError/.test(err.message), 'error class name should be included');
+			return true;
+		});
+	});
+
+	it('keeps a plain error with a spoofed upstreamStatus behind the sanitized message', async () => {
+		const record = { content: 'hello' };
+		const spoofed = new Error('https://internal-embed.svc:9000 404 key=sk-abc123 not found');
+		spoofed.name = 'OpenAIBackendError';
+		spoofed.upstreamStatus = 404;
+		const before = buildEmbedBefore(record, {}, {}, attrs, {
+			embedding: async () => {
+				throw spoofed;
+			},
+		});
+		assert.ok(before);
+		await assert.rejects(before(), (err) => {
+			assert.ok(!/sk-abc123/.test(err.message), 'API key tail leaked');
+			assert.ok(!/internal-embed\.svc/.test(err.message), 'internal hostname leaked');
+			assert.ok(/model "default"/.test(err.message), 'configured model name should be included');
+			assert.ok(/backend HTTP 404/.test(err.message), 'upstream status should still be included');
+			assert.ok(/server log/i.test(err.message), 'should point at the server log for details');
+			return true;
+		});
+	});
+});


### PR DESCRIPTION
Closes #1594 (consolidates #1595, closed as duplicate).

Two resilience/DX gaps in the `@embed` / model-backend path, both found while dogfooding bulk embedding: a single transient provider error failed the whole write (no retry anywhere in the stack), and the surfaced error gave no hint of provider, model, or cause.

## Retry with backoff (all model callers benefit: `@embed`, `scope.models`, the `/v1` gateway)

New shared `fetchWithRetry` in `resources/models/backendHelpers.ts`, wired into the `#post` path of the **ollama**, **openai**, and **anthropic** backends:

- **Retriable:** HTTP `408`/`429`/`5xx` (includes Anthropic's `529` overloaded) and transient network rejections. Deterministic client errors (400/401/404/…) are never retried.
- **`Retry-After`** (delta-seconds or HTTP-date) is honored up to a 30s cap — a server demanding a longer wait gets its response surfaced immediately rather than retried early (impolite) or held open (stalls the write).
- **Backoff:** jittered exponential — `retryBackoffMs` base (default 500ms), doubling per attempt, 10s per-sleep cap, jitter factor in [0.5, 1).
- **Budget:** every attempt and backoff sleep runs under the existing composed signal, so `requestTimeoutMs` keeps its documented meaning as the overall per-call deadline — retries fit inside the budget rather than extending it. Aborts (caller or timeout) cancel a pending backoff sleep immediately and are never retried.
- **Config (per model entry):** `maxRetries` (default 2, `0` disables) and `retryBackoffMs`. Malformed values fall back to defaults.

**bedrock** goes through the AWS SDK, which owns its retry loop — the same `maxRetries` knob is plumbed to the SDK's `maxAttempts` (`maxRetries + 1`) instead of double-wrapping. Default matches the SDK's own (3 attempts). No `retryBackoffMs` there; the SDK's retry strategy manages delays.

### Design decisions (answering the questions consolidated from #1595)

- **Layer:** backend layer, not `Models` dispatch — so every caller benefits and per-backend semantics (SDK-managed vs fetch) stay local.
- **Failover interaction:** a backend exhausts its own retry budget first, then `Models.ts` multi-candidate failover proceeds to the next candidate exactly as today.
- **Streaming:** retry covers connection/status failures before the body is handed over. A mid-stream failure after chunks have been yielded is deliberately not retried (partial results were already delivered).
- **Batching/queueing `@embed` bulk writes:** out of scope; separate design if pursued.

## Actionable `@embed` error surface

#1593 already added the error class name + upstream HTTP status to the sanitized rethrow. This completes it:

- The **configured model name** is now always included.
- The **backend's message is surfaced verbatim** — but only when the error is a `ServerError` subclass carrying `upstreamStatus`, which is exactly our backend classes' HTTP-error path whose messages are deliberately sanitized and length-capped (no request content, capped upstream text). Example:

  `Failed to compute embedding for attribute "embedding" (model "default") [OpenAIBackendError] (backend HTTP 404): OpenAI /embeddings returned HTTP 404: models/default is not found`

- A bare `upstreamStatus` on a non-`ServerError` is **not** proof of sanitization (custom embedder errors can carry anything): those keep the #1593 posture — safe identifiers only, `— see server log for details`. There's a regression test pinning this.
- The `ServerError` check is lazily required in the failure path only, mirroring the existing `getLogger` pattern (hdbError imports the logger; fail-closed to the sanitized message if the require fails).

## Tests

- `backendHelpers.test.js`: 30+ new cases — `resolveRetryConfig` validation, retriable-status matrix, `Retry-After` parsing (delta/date/garbage/past), jitter bounds + cap, `abortableSleep` abort semantics, and `fetchWithRetry` scenarios (retry-then-success, `Retry-After` honored/over-cap, non-retriable passthrough, exhaustion, `maxRetries: 0`, network-error retry/exhaustion, abort-never-retried, abort-during-backoff).
- `openai/index.test.js`: retry through the real `#post` (429 → success), `maxRetries: 0` surfaces `upstreamStatus`, non-retriable 400 single-attempt.
- `bedrock/index.test.js`: `maxAttempts` plumbing (default → 3, `maxRetries: 0` → 1).
- `embedHook.test.js`: verbatim surface for real backend-shaped errors (message + model + status + class), spoofed `upstreamStatus` on a plain `Error` stays sanitized.

All 249 tests across the six affected suites pass; oxlint and prettier clean; build shows only the known pre-existing TS errors in unrelated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BdbdepRFuyUWoEmNN1pSVQ


---

## Review notes (HEG step 10 — cross-model review, 2026-07-17)

Harper-domain pass (deep-review + adjudication): **no blockers**. Direction-fit verified: aligns with the bounded-backoff precedents (`DatabaseTransaction` commit retry, #1371 index-backfill retry), preserves the `composeSignal`/`requestTimeoutMs` contract, extends the #1593 sanitized-error posture deliberately (fail-closed gate; provider text capped at 500 chars), and is orthogonal to the uWS/h2c/h3 server-side networking work (outbound fetch only).

**Open items for the human reviewer** (found by the review, not resolved in-PR):

1. **Lock-hold amplification on the cache-from-source path.** `Table.ts` holds the per-record store lock while `embedBefore()` runs; that path's `sourceContext` need not carry a signal, and with no `requestTimeoutMs` configured the retry budget can stretch the hold (worst case ~60s+ under a rate-limited provider honoring `Retry-After`). Pre-existing exposure — the network call already ran under that lock unbounded — but retries amplify the worst case. In-PR mitigations: `maxRetries` is now clamped at 10, and setting `requestTimeoutMs` per model entry bounds it fully. A structural fix (bounding total embed time on the lock-held refresh path in `Table.ts`) is out of this PR's scope — flag if you want it here or as a follow-up.
2. **Network-error retry is broader than "transient"** — any non-abort rejection retries, including deterministic ones (down endpoint, NXDOMAIN), adding `maxRetries × backoff` latency before a clear misconfiguration surfaces. Deliberate: distinguishing transient from permanent rejection shapes across undici versions is fragile, and the cost is bounded (~1.5s at defaults).

**Docs decision (HEG step 16):** `maxRetries`/`retryBackoffMs` are user-facing model-entry config, but models config has no docs pages yet anywhere — documentation lands wholesale with the #510 docs arc, so no companion docs PR here.

**Caveats:** both outside-model review legs failed this run (codex CLI init error; agy degraded then timed out) — this was a domain-pass-only review. Re-run the outside legs if you want second-model corroboration before merge.
