### PR TITLE
test(storage): cover the isRetry leak that dropped fresh-batch audit entries

### DIFF
--- a/unitTests/resources/retryCounterAuditLeak.test.js
+++ b/unitTests/resources/retryCounterAuditLeak.test.js
@@ -1,0 +1,65 @@
+require('../testUtils');
+const assert = require('assert');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const { transaction } = require('#src/resources/transaction');
+const { setTimeout: delay } = require('node:timers/promises');
+
+// Regression for the isRetry leak: DatabaseTransaction.retries is bumped on a transient conflict and
+// never reset, and save() derives `transaction.isRetry` from `this.retries > 0`. A reused
+// DatabaseTransaction that conflicted on an earlier batch therefore stamps isRetry=true on the FRESH
+// native transaction of its next batch, and RocksTransactionLogStore.put skips the audit/transaction
+// -log append for it (`if (options.transaction.isRetry) return`). The record commits and reads back
+// locally, but no audit entry is recorded, no 'committed' wake fires, and replication has nothing to
+// send: the write is silently dropped from the change feed. Fixed by setting isRetry only on the
+// specific native transaction actually being retried and resetting retries after commit.
+describe('retries counter must not suppress a fresh write audit entry', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+	let LeakTable;
+
+	before(function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		LeakTable = table({
+			table: 'RetryLeakTable',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'v' }],
+			audit: true,
+		});
+	});
+
+	async function auditEntryCount(id) {
+		for (let i = 0; i < 200; i++) {
+			let count = 0;
+			for (const entry of LeakTable.auditStore.getRange({ start: 1 })) {
+				if (entry.recordId === id) count++;
+			}
+			if (count > 0) return count;
+			await delay(10);
+		}
+		return 0;
+	}
+
+	it('a first-attempt write on a transaction carrying retries>0 still records its audit entry', async () => {
+		const context = {};
+		await transaction(context, async (txn) => {
+			// A prior batch on this reused transaction hit a transient conflict; the counter was bumped
+			// and never reset. This write is a fresh first attempt (no conflict of its own).
+			txn.retries = 1;
+			await LeakTable.put('leaked', { id: 'leaked', v: 'kept' }, context);
+		});
+
+		assert.equal((await LeakTable.get('leaked'))?.v, 'kept', 'the record itself must commit');
+		assert.ok(
+			(await auditEntryCount('leaked')) >= 1,
+			'the fresh write must record an audit/transaction-log entry even though retries>0 (else replication silently drops it)'
+		);
+	});
+
+	it('a clean transaction (retries==0) records its audit entry (control)', async () => {
+		await LeakTable.put('clean', { id: 'clean', v: 'kept' });
+		assert.equal((await LeakTable.get('clean'))?.v, 'kept');
+		assert.ok((await auditEntryCount('clean')) >= 1, 'baseline: a normal write is audited');
+	});
+});


### PR DESCRIPTION
## What

Adds a regression test for the `isRetry` leak fixed in 643d10c68 ("DatabaseTransaction: cap coordinated-retry loop, fix isRetry leak, preserve options on retry"), which landed without a dedicated test. Test only, no source changes.

## Why

The bug: `DatabaseTransaction.retries` was bumped on every transient conflict and not reset after a successful commit, and `save()` derived `transaction.isRetry` from `this.retries > 0`. A reused `DatabaseTransaction` that conflicted on an earlier batch therefore stamped `isRetry=true` on the fresh native transaction of its next batch, and `RocksTransactionLogStore.put` skips the audit/transaction-log append when `isRetry` is set. The record committed and read back locally, but no audit entry was recorded, no `committed` event fired, and replication had nothing to send: the write was silently dropped from the change feed.

643d10c68 fixed it by setting `isRetry` only on the specific native transaction being retried and resetting `this.retries` after commit. The existing `sourceApplyConflictRetry.test.js` exercises retry convergence (that a conflicted commit settles), not this leak, so the fix currently has no test guarding the audit-entry invariant that was the actual field failure.

## The test

`retryCounterAuditLeak.test.js` asserts the invariant directly: a first-attempt write on a transaction carrying `retries > 0` must still record its audit entry. It reproduces the leaked-counter state minimally (a reused transaction whose counter was left non-zero by a prior conflicted batch), then checks both that the record commits and that its audit entry exists. A control case (`retries == 0`) pins the baseline.

## Verification

- Passes on `main` (with 643d10c68): both cases green.
- Fails on the pre-fix code (record commits, zero audit entries) - the leak signature - so it guards against a regression that re-derives `isRetry` from the lifetime counter.

*Lavinia, via Claude*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
