### PR TITLE
fix(build): prune devDependencies before shrinkwrapping

### DIFF
--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -8,6 +8,9 @@ npm install --ignore-scripts
 echo -e "\n📦 Building project"
 npm run build || true
 
+echo -e "\n📦 Pruning devDependencies"
+npm prune --omit=dev
+
 echo -e "\n📦 Creating shrinkwrap"
 npm shrinkwrap
 


### PR DESCRIPTION
Follow-up to #1622.

npm shrinkwrap runs after a full npm install in build-tools/build.sh, so the generated npm-shrinkwrap.json captures devDependencies as well as runtime ones. Since #1622 started shipping npm-shrinkwrap.json in the published tarball, consumers now get harper's entire dev tree installed under node_modules/harper/node_modules/ -- including esbuild (pulled in transitively via tsx) and its ~30 platform-specific optional binaries.

Those nested @esbuild/<platform> entries land in the consumer's package-lock.json as "extraneous" rather than resolved-optional, because they aren't reachable from any declared dependency edge in the consumer's graph -- they're just mirrored in from harper's bundled shrinkwrap. Extraneous entries don't get the "optional": true flag written, so npm ci in consumer projects fails with EBADPLATFORM on platforms other than the shrinkwrap's original build machine (e.g. @esbuild/aix-ppc64 on darwin/arm64).

Prune devDependencies before shrinkwrapping so the pinned tree only contains what harper actually needs at runtime.