### PR TITLE
fix(build): strip devDependencies from published shrinkwrap

### DIFF
--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -8,11 +8,11 @@ npm install --ignore-scripts
 echo -e "\n📦 Building project"
 npm run build || true
 
-echo -e "\n📦 Pruning devDependencies"
-npm prune --omit=dev
-
 echo -e "\n📦 Creating shrinkwrap"
 npm shrinkwrap
+
+echo -e "\n📦 Pruning devDependencies from shrinkwrap"
+node build-tools/prune-shrinkwrap-dev.mjs npm-shrinkwrap.json
 
 ./build-tools/build-studio.sh
 

--- a/build-tools/prune-shrinkwrap-dev.mjs
+++ b/build-tools/prune-shrinkwrap-dev.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// Remove dev-only packages from the shrinkwrap that ships in the published package.
+//
+// npm generates the lockfile from the package.json manifest, so `npm prune --omit=dev`
+// does NOT strip dev entries from it — prune only touches node_modules, not the lockfile.
+// A published npm-shrinkwrap.json therefore vendors dev-only packages, including
+// platform-specific optionals (e.g. @esbuild/* pulled in via tsx). When a consumer's
+// lockfile is generated with npm 11, npm can fold that subtree in and drop the
+// "optional" flag, so `npm ci` then fails everywhere with EBADPLATFORM. See #1780, #1782.
+//
+// This enforces the invariant that the published shrinkwrap describes only the production
+// tree a consumer installs: every package reachable solely through devDependencies is
+// marked "dev": true, so removing those (plus the root devDependencies block) leaves
+// production and prod-optional (devOptional) entries untouched.
+//
+// Usage: node build-tools/prune-shrinkwrap-dev.mjs [npm-shrinkwrap.json]
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const file = process.argv[2] ?? 'npm-shrinkwrap.json';
+const lock = JSON.parse(readFileSync(file, 'utf8'));
+
+if (lock.lockfileVersion < 2 || !lock.packages) {
+	throw new Error(`unsupported lockfileVersion ${lock.lockfileVersion}; expected >= 2 with a "packages" map`);
+}
+
+let removed = 0;
+for (const key of Object.keys(lock.packages)) {
+	if (key === '') continue; // root manifest node
+	if (lock.packages[key].dev === true) {
+		delete lock.packages[key];
+		removed++;
+	}
+}
+if (lock.packages['']?.devDependencies) delete lock.packages[''].devDependencies;
+
+writeFileSync(file, JSON.stringify(lock, null, 2) + '\n');
+console.log(`Pruned ${removed} dev-only entries from ${file}`);

--- a/build-tools/prune-shrinkwrap-dev.mjs
+++ b/build-tools/prune-shrinkwrap-dev.mjs
@@ -19,8 +19,8 @@ import { readFileSync, writeFileSync } from 'node:fs';
 const file = process.argv[2] ?? 'npm-shrinkwrap.json';
 const lock = JSON.parse(readFileSync(file, 'utf8'));
 
-if (lock.lockfileVersion < 2 || !lock.packages) {
-	throw new Error(`unsupported lockfileVersion ${lock.lockfileVersion}; expected >= 2 with a "packages" map`);
+if (lock.lockfileVersion !== 3 || !lock.packages) {
+	throw new Error(`unsupported lockfileVersion ${lock.lockfileVersion}; expected 3 with a "packages" map`);
 }
 
 let removed = 0;


### PR DESCRIPTION
Follow-up to [harper#1781 — fix(build): prune devDependencies before shrinkwrap](https://github.com/HarperFast/harper/pull/1781), which was **merged but is a no-op**.

## Why #1781 didn't work
`npm shrinkwrap` regenerates the lockfile from the `package.json` manifest, not from the physical `node_modules` tree. `npm prune --omit=dev` only removes packages from `node_modules` — it does not touch the lockfile. So every devDependency (marked `"dev": true`) survives into the published `npm-shrinkwrap.json`. Verified: the shrinkwrap produced with the prune step is byte-for-byte identical to the one produced without it. (Thanks to @cb1kenobi's Barber AI review on the harper-pro twin for flagging this.)

## The actual bug (#1780 / #1782)
The published shrinkwrap vendors the 26 `@esbuild/*` platform packages that arrive via `tsx` (a **devDependency**), each marked `{ "dev": true, "optional": true }`. When a consumer generates their lockfile with **npm 11**, npm folds harper's shrinkwrap subtree into their `package-lock.json` and **drops the `"optional": true` flag**. `npm ci` then treats `@esbuild/aix-ppc64` as required on every platform:

```
npm error code EBADPLATFORM
npm error notsup Unsupported platform for @esbuild/aix-ppc64@0.28.1:
  wanted {"os":"aix","cpu":"ppc64"} (current: {"os":"linux","cpu":"x64"})
```

## Fix
Prune the shrinkwrap *after* it is generated. `build-tools/prune-shrinkwrap-dev.mjs` (zero-dependency) removes every package marked `"dev": true` plus the root `devDependencies` block, enforcing the invariant that **the published shrinkwrap describes only the production tree a consumer installs**. No npm version can fold dev entries that aren't there.

```diff
 echo -e "\n📦 Creating shrinkwrap"
 npm shrinkwrap

+echo -e "\n📦 Pruning devDependencies from shrinkwrap"
+node build-tools/prune-shrinkwrap-dev.mjs npm-shrinkwrap.json
```

## Validation
Run against the real published `harper@5.1.19` shrinkwrap:
- 417 dev-only entries removed — **all 26 `@esbuild/*` gone**, zero `"dev": true` remaining.
- Production deps (794 packages) and prod-optional natives (`@lmdb/*`, `@harperfast/rocksdb-js-*`, `@msgpackr-extract/*`) untouched, each keeping `optional: true`.
- Stripped shrinkwrap installs cleanly and `npm ci` passes (validated via a local verdaccio registry).

Labeled `patch` to match the original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)