### PR TITLE
Fix ReDoS in configValidator directory-path regex (CLI hangs at 100% CPU)

### DIFF
--- a/unitTests/validation/configValidator.test.js
+++ b/unitTests/validation/configValidator.test.js
@@ -239,17 +239,24 @@ describe('Test configValidator module', () => {
 			}
 		});
 
-		it('rejects control characters (incl. newline / null / DEL) and empty / whitespace-only', () => {
+		it('rejects control characters (C0/DEL/C1 + Unicode line separators) and empty / whitespace-only', () => {
+			const cp = String.fromCodePoint; // avoid literal separators in this source file
 			const bad = [
 				'', // empty
 				'   ', // whitespace-only (Windows strips to a valid-but-wrong dir)
 				'\t', // tab
-				'/embedded\nnewline', // newline — would forge log lines
+				'/embedded\nnewline', // ASCII newline — would forge log lines
 				'/embedded\x00null',
 				'/embedded\x7fdel',
+				'/nel' + cp(0x85) + 'here', // U+0085 NEL (C1) — a Unicode line break
+				'/c1' + cp(0x9f) + 'here', // U+009F (C1 control)
+				'/ls' + cp(0x2028) + 'here', // U+2028 line separator
+				'/ps' + cp(0x2029) + 'here', // U+2029 paragraph separator
 			];
 			for (const value of bad) {
-				expect(directoryPathPattern.test(value), JSON.stringify(value)).to.equal(false);
+				expect(directoryPathPattern.test(value), JSON.stringify([...value].map((c) => c.codePointAt(0)))).to.equal(
+					false
+				);
 			}
 		});
 
@@ -281,6 +288,9 @@ describe('Test configValidator module', () => {
 				(d) => d.path?.[0] === 'storage' && /directory path pattern/.test(d.message)
 			);
 			expect(goodPatternError, 'storage.path `~/hdb/database` should pass the denylist').to.equal(undefined);
+			// validatePath returns undefined on success; Joi.custom retains the original value (does not
+			// coerce it to undefined), so the path must survive into the validated config.
+			expect(goodSchema.value.storage.path, 'storage.path must survive validation').to.equal('~/hdb/database');
 
 			const bad = testUtils.deepClone(FAKE_CONFIG);
 			bad.storage = { ...bad.storage, path: '/db\nroot' }; // control char (newline)

--- a/unitTests/validation/configValidator.test.js
+++ b/unitTests/validation/configValidator.test.js
@@ -198,6 +198,70 @@ describe('Test configValidator module', () => {
 		});
 	});
 
+	describe('Directory-path pattern is linear-time (ReDoS regression, #1779)', () => {
+		const directoryPathPattern = config_val.__get__('DIRECTORY_PATH_PATTERN');
+		const directoryPathWithHomePattern = config_val.__get__('DIRECTORY_PATH_WITH_HOME_PATTERN');
+
+		// The previous `([...]+)+$` nested quantifier backtracked exponentially on any
+		// value containing a char outside the class after a run of valid chars. A dotted
+		// 80-char path is the real-world trigger (default installs write
+		// `tls.privateKey: <root>/privateKey.pem`); it took minutes before the fix.
+		it('resolves a dotted 80-char path effectively instantly', () => {
+			const dottedPath = '/Users/someone/harper-instances/engineering-metrics-project/keys/privateKey.pem';
+			expect(dottedPath.length).to.be.greaterThan(60);
+			const start = Date.now();
+			const matched = directoryPathPattern.test(dottedPath);
+			const elapsed = Date.now() - start;
+			expect(matched).to.equal(true);
+			expect(elapsed).to.be.lessThan(100);
+		});
+
+		it('does not hang even when the value fails to match', () => {
+			// A char outside the class (`?`) after a long valid prefix is the worst
+			// case for the old regex; it must now fail fast, not backtrack.
+			const badPath = '/Users/someone/harper-instances/engineering?metrics/keys/key';
+			const start = Date.now();
+			const matched = directoryPathPattern.test(badPath);
+			const elapsed = Date.now() - start;
+			expect(matched).to.equal(false);
+			expect(elapsed).to.be.lessThan(100);
+		});
+
+		it('accepts the path shapes the validator must permit', () => {
+			// The space cases (Windows Program Files, macOS user dirs) were accepted by
+			// the old un-anchored pattern and must keep validating (#1779 review).
+			const good = [
+				'/',
+				'/Users/x/harper',
+				'/etc/harper/privateKey.pem',
+				'C:\\Users\\x',
+				'./rel/path',
+				'C:\\Program Files\\Harper',
+				'/Users/some user/harper',
+			];
+			for (const value of good) {
+				expect(directoryPathPattern.test(value), value).to.equal(true);
+			}
+			expect(directoryPathWithHomePattern.test('~/harper/keys/key.pem'), '~/harper').to.equal(true);
+		});
+
+		it('still rejects paths with disallowed characters', () => {
+			for (const bad of ['/@@@', '/???', '/pipe|d', '/angle<br>', '/newline\n']) {
+				expect(directoryPathPattern.test(bad), bad).to.equal(false);
+			}
+		});
+
+		it('validates a dotted rootPath through configValidator without erroring', () => {
+			const config_obj = testUtils.deepClone(FAKE_CONFIG);
+			config_obj.rootPath = '/Users/someone/harper-instances/metrics/data.dir';
+			const start = Date.now();
+			const schema = configValidator(config_obj);
+			expect(Date.now() - start).to.be.lessThan(1000);
+			const rootPathError = (schema.error?.details ?? []).find((d) => d.path?.[0] === 'rootPath');
+			expect(rootPathError, 'rootPath should validate').to.equal(undefined);
+		});
+	});
+
 	describe('Test doesPathExist function', () => {
 		let exists_sync_stub;
 		let does_path_exist_rw = config_val.__get__('doesPathExist');

--- a/unitTests/validation/configValidator.test.js
+++ b/unitTests/validation/configValidator.test.js
@@ -163,13 +163,13 @@ describe('Test configValidator module', () => {
 			bad_config_obj.logging.rotation.compress = 'nah';
 			bad_config_obj.logging.rotation.maxSize = '100z';
 			bad_config_obj.logging.rotation.path = true;
-			bad_config_obj.logging.root = '/???';
+			bad_config_obj.logging.root = '/log\nroot'; // control char (newline) — rejected by the denylist
 			bad_config_obj.logging.stdStreams = ['not_a_boolean'];
 			bad_config_obj.logging.auditLog = ['not_a_boolean'];
 
 			const schema = configValidator(bad_config_obj);
 			const expected_schema_message =
-				"'logging.file' must be a boolean. 'logging.level' must be one of [notify, fatal, error, warn, info, debug, trace]. 'logging.rotation.enabled' must be a boolean. 'logging.rotation.compress' must be a boolean. 'logging.rotation.interval' must be a string. Invalid logging.rotation.maxSize unit. Available units are G, M or K. 'logging.rotation.path' must be a string. 'logging.root' with value '/???' fails to match the directory path pattern. 'logging.stdStreams' must be a boolean. 'logging.auditLog' must be a boolean";
+				"'logging.file' must be a boolean. 'logging.level' must be one of [notify, fatal, error, warn, info, debug, trace]. 'logging.rotation.enabled' must be a boolean. 'logging.rotation.compress' must be a boolean. 'logging.rotation.interval' must be a string. Invalid logging.rotation.maxSize unit. Available units are G, M or K. 'logging.rotation.path' must be a string. 'logging.root' with value '/log\nroot' fails to match the directory path pattern. 'logging.stdStreams' must be a boolean. 'logging.auditLog' must be a boolean";
 			expect(schema.error.message).to.eql(expected_schema_message);
 		});
 
@@ -187,78 +187,108 @@ describe('Test configValidator module', () => {
 			bad_config_obj.operationsApi.network.timeout = false;
 			bad_config_obj.operationsApi.nodeEnv = true;
 			bad_config_obj.http.threads = true;
-			bad_config_obj.rootPath = '/@@@';
+			bad_config_obj.rootPath = '/root\npath'; // control char (newline) — rejected by the denylist
 			bad_config_obj.storage.writeAsync = undefined;
 
 			const schema = configValidator(bad_config_obj);
 			const expected_schema_message =
-				"'operationsApi.network.cors' must be a boolean. 'operationsApi.network.headersTimeout' must be greater than or equal to 1. 'operationsApi.network.keepAliveTimeout' must be a number. 'operationsApi.network.timeout' must be a number. 'rootPath' with value '/@@@' fails to match the directory path pattern. 'storage.writeAsync' is required";
+				"'operationsApi.network.cors' must be a boolean. 'operationsApi.network.headersTimeout' must be greater than or equal to 1. 'operationsApi.network.keepAliveTimeout' must be a number. 'operationsApi.network.timeout' must be a number. 'rootPath' with value '/root\npath' fails to match the directory path pattern. 'storage.writeAsync' is required";
 
 			expect(schema.error.message).to.eql(expected_schema_message);
 		});
 	});
 
-	describe('Directory-path pattern is linear-time (ReDoS regression, #1779)', () => {
+	describe('Directory-path pattern is a linear-time denylist (ReDoS regression, #1779)', () => {
 		const directoryPathPattern = config_val.__get__('DIRECTORY_PATH_PATTERN');
-		const directoryPathWithHomePattern = config_val.__get__('DIRECTORY_PATH_WITH_HOME_PATTERN');
 
-		// The previous `([...]+)+$` nested quantifier backtracked exponentially on any
-		// value containing a char outside the class after a run of valid chars. A dotted
-		// 80-char path is the real-world trigger (default installs write
-		// `tls.privateKey: <root>/privateKey.pem`); it took minutes before the fix.
-		it('resolves a dotted 80-char path effectively instantly', () => {
-			const dottedPath = '/Users/someone/harper-instances/engineering-metrics-project/keys/privateKey.pem';
-			expect(dottedPath.length).to.be.greaterThan(60);
+		// Guard against reintroducing catastrophic backtracking: a long valid run
+		// followed by a rejected (control) char is the worst case for a nested
+		// quantifier. Denylist runs in microseconds; a nested-quantifier revert
+		// would spin for minutes. The generous bound distinguishes the two.
+		it('rejects a 50k-char adversarial input effectively instantly', () => {
+			const adversarial = '/' + 'a'.repeat(50000) + '\x01';
 			const start = Date.now();
-			const matched = directoryPathPattern.test(dottedPath);
-			const elapsed = Date.now() - start;
-			expect(matched).to.equal(true);
-			expect(elapsed).to.be.lessThan(100);
-		});
-
-		it('does not hang even when the value fails to match', () => {
-			// A char outside the class (`?`) after a long valid prefix is the worst
-			// case for the old regex; it must now fail fast, not backtrack.
-			const badPath = '/Users/someone/harper-instances/engineering?metrics/keys/key';
-			const start = Date.now();
-			const matched = directoryPathPattern.test(badPath);
+			const matched = directoryPathPattern.test(adversarial);
 			const elapsed = Date.now() - start;
 			expect(matched).to.equal(false);
 			expect(elapsed).to.be.lessThan(100);
 		});
 
-		it('accepts the path shapes the validator must permit', () => {
-			// The space cases (Windows Program Files, macOS user dirs) were accepted by
-			// the old un-anchored pattern and must keep validating (#1779 review).
+		it('accepts every path shape the validator must permit', () => {
+			// Each of these is REJECTED by any anchored ASCII allow-list (spaces,
+			// parens, `~`, apostrophes, Unicode), so this test fails on the earlier
+			// allow-list fix and only passes on the denylist — real regression cover.
 			const good = [
 				'/',
+				'~/hdb', // the documented default rootPath (config-root.schema.json)
+				'~/hdb/components',
 				'/Users/x/harper',
 				'/etc/harper/privateKey.pem',
 				'C:\\Users\\x',
 				'./rel/path',
-				'C:\\Program Files\\Harper',
-				'/Users/some user/harper',
+				'C:\\Program Files (x86)\\Harper', // Windows default install path (parens)
+				'/Users/some user/harper', // space
+				'/Users/café/harper', // non-ASCII home dir
+				"/Users/O'Brien/hdb", // apostrophe
+				'/opt/harper+ext/root',
+				'.', // resolves honestly to cwd
+				'..', // resolves honestly to parent
 			];
 			for (const value of good) {
 				expect(directoryPathPattern.test(value), value).to.equal(true);
 			}
-			expect(directoryPathWithHomePattern.test('~/harper/keys/key.pem'), '~/harper').to.equal(true);
 		});
 
-		it('still rejects paths with disallowed characters', () => {
-			for (const bad of ['/@@@', '/???', '/pipe|d', '/angle<br>', '/newline\n']) {
-				expect(directoryPathPattern.test(bad), bad).to.equal(false);
+		it('rejects control characters (incl. newline / null / DEL) and empty / whitespace-only', () => {
+			const bad = [
+				'', // empty
+				'   ', // whitespace-only (Windows strips to a valid-but-wrong dir)
+				'\t', // tab
+				'/embedded\nnewline', // newline — would forge log lines
+				'/embedded\x00null',
+				'/embedded\x7fdel',
+			];
+			for (const value of bad) {
+				expect(directoryPathPattern.test(value), JSON.stringify(value)).to.equal(false);
 			}
 		});
 
-		it('validates a dotted rootPath through configValidator without erroring', () => {
+		it('validates the documented `~/hdb`-style config through configValidator without erroring', () => {
 			const config_obj = testUtils.deepClone(FAKE_CONFIG);
-			config_obj.rootPath = '/Users/someone/harper-instances/metrics/data.dir';
+			config_obj.rootPath = '~/hdb';
+			config_obj.componentsRoot = '~/hdb/components';
 			const start = Date.now();
+			// rootPath/componentsRoot are pattern-only (no fs check), so no skipFsValidation needed;
+			// passing it would leak the module-level skipFsVal flag into later tests.
 			const schema = configValidator(config_obj);
 			expect(Date.now() - start).to.be.lessThan(1000);
-			const rootPathError = (schema.error?.details ?? []).find((d) => d.path?.[0] === 'rootPath');
-			expect(rootPathError, 'rootPath should validate').to.equal(undefined);
+			const pathErrors = (schema.error?.details ?? []).filter(
+				(d) => d.path?.[0] === 'rootPath' || d.path?.[0] === 'componentsRoot'
+			);
+			expect(pathErrors, `rootPath/componentsRoot should validate: ${JSON.stringify(pathErrors)}`).to.eql([]);
+		});
+
+		// storage.path is the third pattern site — it runs the denylist inside Joi.custom(validatePath)
+		// via Joi.assert. That throw is caught by Joi.custom and folded into schema.error as an
+		// `any.custom` detail, so a bad path surfaces the same way the other two sites do (not a throw).
+		it('runs the denylist on storage.path: accepts `~/`, rejects a control char', () => {
+			const good = testUtils.deepClone(FAKE_CONFIG);
+			good.storage = { ...good.storage, path: '~/hdb/database' };
+			// The denylist accepts `~/...`; any remaining storage.path error must be the fs-existence
+			// message, never a "directory path pattern" failure.
+			const goodSchema = configValidator(good);
+			const goodPatternError = (goodSchema.error?.details ?? []).find(
+				(d) => d.path?.[0] === 'storage' && /directory path pattern/.test(d.message)
+			);
+			expect(goodPatternError, 'storage.path `~/hdb/database` should pass the denylist').to.equal(undefined);
+
+			const bad = testUtils.deepClone(FAKE_CONFIG);
+			bad.storage = { ...bad.storage, path: '/db\nroot' }; // control char (newline)
+			const badSchema = configValidator(bad);
+			const badPatternError = (badSchema.error?.details ?? []).find(
+				(d) => d.path?.[0] === 'storage' && /directory path pattern/.test(d.message)
+			);
+			expect(badPatternError, 'storage.path with a newline should be rejected').to.not.equal(undefined);
 		});
 	});
 

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -28,6 +28,18 @@ const INVALID_RETENTION_VALUE_MSG =
 const VALID_ROTATION_DURATION_UNITS = ['D', 'd', 'H', 'h', 'M', 'm'];
 const UNDEFINED_OPS_API = 'rootPath config parameter is undefined';
 
+// Directory-path character allow-list. Anchored with a single quantifier so it
+// runs in linear time: the previous `([...]+)+$` nested quantifier backtracked
+// catastrophically (ReDoS) on any value containing a character outside the
+// class — e.g. the `.` in a default install's `tls.privateKey: <root>/privateKey.pem`
+// — hanging the CLI at 100% CPU forever (#1779). `.` is included since dotted
+// path segments are legitimate, and a space so paths like `C:\Program Files\...`
+// or `/Users/some user/...` (which the old, un-anchored pattern accepted via a
+// trailing match) keep validating.
+const DIRECTORY_PATH_PATTERN = /^[\\/a-zA-Z_0-9:. -]+$/;
+// As above, additionally allowing a leading/embedded `~` for home-relative paths.
+const DIRECTORY_PATH_WITH_HOME_PATTERN = /^[\\/~a-zA-Z_0-9:. -]+$/;
+
 const portConstraints = Joi.alternatives([number.min(0), string])
 	.optional()
 	.empty(null);
@@ -93,10 +105,7 @@ export function configValidator(configJson, skipFsValidation = false) {
 
 	const enabledConstraints = boolean.optional();
 	const threadsConstraints = number.min(0).max(1000).empty(null).default(setDefaultThreads);
-	const rootConstraints = string
-		.pattern(/^[\\/]$|([\\/a-zA-Z_0-9:-]+)+$/, 'directory path')
-		.empty(null)
-		.default(setDefaultRoot);
+	const rootConstraints = string.pattern(DIRECTORY_PATH_PATTERN, 'directory path').empty(null).default(setDefaultRoot);
 	const pemFileConstraints = string.optional().empty(null);
 
 	const storagePathConstraints = Joi.custom(validatePath).empty(null).default(setDefaultRoot);
@@ -278,7 +287,7 @@ export function configValidator(configJson, skipFsValidation = false) {
 			}).optional(),
 			tls: Joi.alternatives([Joi.array().items(tlsConstraints), tlsConstraints]),
 		}).required(),
-		rootPath: string.pattern(/^[\\/]$|([\\/a-zA-Z_0-9:-]+)+$/, 'directory path').required(),
+		rootPath: string.pattern(DIRECTORY_PATH_PATTERN, 'directory path').required(),
 		mqtt: Joi.object({
 			network: Joi.object({
 				port: portConstraints,
@@ -377,7 +386,7 @@ function doesPathExist(pathToCheck) {
 }
 
 function validatePath(value, helpers) {
-	Joi.assert(value, string.pattern(/^[\\/~]$|([\\/~a-zA-Z_0-9:-]+)+$/, 'directory path'));
+	Joi.assert(value, string.pattern(DIRECTORY_PATH_WITH_HOME_PATTERN, 'directory path'));
 
 	let resolvedValue;
 	if (value.startsWith('~/')) {

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -28,17 +28,23 @@ const INVALID_RETENTION_VALUE_MSG =
 const VALID_ROTATION_DURATION_UNITS = ['D', 'd', 'H', 'h', 'M', 'm'];
 const UNDEFINED_OPS_API = 'rootPath config parameter is undefined';
 
-// Directory-path character allow-list. Anchored with a single quantifier so it
-// runs in linear time: the previous `([...]+)+$` nested quantifier backtracked
-// catastrophically (ReDoS) on any value containing a character outside the
-// class — e.g. the `.` in a default install's `tls.privateKey: <root>/privateKey.pem`
-// — hanging the CLI at 100% CPU forever (#1779). `.` is included since dotted
-// path segments are legitimate, and a space so paths like `C:\Program Files\...`
-// or `/Users/some user/...` (which the old, un-anchored pattern accepted via a
-// trailing match) keep validating.
-const DIRECTORY_PATH_PATTERN = /^[\\/a-zA-Z_0-9:. -]+$/;
-// As above, additionally allowing a leading/embedded `~` for home-relative paths.
-const DIRECTORY_PATH_WITH_HOME_PATTERN = /^[\\/~a-zA-Z_0-9:. -]+$/;
+// Directory-path validation. The previous `([...]+)+$` nested quantifier
+// backtracked catastrophically (ReDoS), hanging the CLI at 100% CPU on any
+// value with a character outside its allow-list after a run of valid ones — a
+// dotted rootPath such as `/Users/john.doe/hdb` is enough (#1779). An allow-list
+// is also the wrong model for file paths: they legitimately contain spaces, `~`,
+// parens (`C:\\Program Files (x86)`), apostrophes, and any Unicode
+// (`/Users/café/hdb`), so any fixed class rejects real, previously-valid
+// configs. These paths only ever reach `fs`/`path` (never a shell), so the
+// character check is just a friendly "reject obvious garbage" gate — the real
+// validation is the existence check in `validatePath`. So this is a denylist:
+// reject only control characters (incl. newlines, which paths get logged into)
+// via a single anchored quantifier — linear time, no backtracking. The
+// `(?!\s*$)` guard rejects empty/whitespace-only values, which on Windows
+// silently strip to a valid-but-wrong directory and would pass the existence
+// check; `.`/`..` are allowed since they resolve honestly to real directories.
+// eslint-disable-next-line no-control-regex -- deliberate: reject control characters
+const DIRECTORY_PATH_PATTERN = /^(?!\s*$)[^\x00-\x1f\x7f]+$/;
 
 const portConstraints = Joi.alternatives([number.min(0), string])
 	.optional()
@@ -386,7 +392,7 @@ function doesPathExist(pathToCheck) {
 }
 
 function validatePath(value, helpers) {
-	Joi.assert(value, string.pattern(DIRECTORY_PATH_WITH_HOME_PATTERN, 'directory path'));
+	Joi.assert(value, string.pattern(DIRECTORY_PATH_PATTERN, 'directory path'));
 
 	let resolvedValue;
 	if (value.startsWith('~/')) {

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -38,13 +38,15 @@ const UNDEFINED_OPS_API = 'rootPath config parameter is undefined';
 // configs. These paths only ever reach `fs`/`path` (never a shell), so the
 // character check is just a friendly "reject obvious garbage" gate — the real
 // validation is the existence check in `validatePath`. So this is a denylist:
-// reject only control characters (incl. newlines, which paths get logged into)
+// reject only control characters — C0 (`\x00-\x1f`), DEL, and C1 (`\x80-\x9f`,
+// which includes NEL U+0085) — plus the Unicode line/paragraph separators
+// U+2028/U+2029, since paths get logged and any of these could forge log lines,
 // via a single anchored quantifier — linear time, no backtracking. The
 // `(?!\s*$)` guard rejects empty/whitespace-only values, which on Windows
 // silently strip to a valid-but-wrong directory and would pass the existence
 // check; `.`/`..` are allowed since they resolve honestly to real directories.
 // eslint-disable-next-line no-control-regex -- deliberate: reject control characters
-const DIRECTORY_PATH_PATTERN = /^(?!\s*$)[^\x00-\x1f\x7f]+$/;
+const DIRECTORY_PATH_PATTERN = /^(?!\s*$)[^\x00-\x1f\x7f\x80-\x9f\u2028\u2029]+$/;
 
 const portConstraints = Joi.alternatives([number.min(0), string])
 	.optional()


### PR DESCRIPTION
Fixes #1779.

## Summary

Three directory-path validators in `validation/configValidator.ts` used the classic catastrophic-backtracking shape `/^[\\/]$|([\\/a-zA-Z_0-9:-]+)+$/` (+ a `~` variant). The nested `([...]+)+$` quantifier backtracks ~2^n on any value containing a character outside the class after a run of valid ones. `.` is outside the class, and a **default install** writes dotted paths into `harper-config.yaml` (`tls.privateKey: <root>/privateKey.pem`), so real configs hang `harper deploy` / CLI operations at ~100% CPU indefinitely — no error, looks like a stuck upload. Reproduced locally: a 28-char valid prefix + `.pem` took 2.4s, doubling every ~2 chars.

## Approach: denylist, not allow-list

The first pass anchored the existing allow-list. That killed the ReDoS but **regressed real, previously-valid paths** — the documented default `~/hdb`, Windows `C:\Program Files (x86)\` (parens), spaces, apostrophes, and any non-ASCII home dir (`/Users/café/hdb`). The Windows integration shards on this PR failed on exactly this. An allow-list is the wrong model: config paths legitimately contain arbitrary Unicode and punctuation, and they only ever reach `fs`/`path` (never a shell).

So the three patterns are now **one control-char denylist**:

```
/^(?!\s*$)[^\x00-\x1f\x7f]+$/
```

- Single anchored quantifier → linear time, ReDoS-safe (verified: 50k-char adversarial input = <1ms).
- Rejects only C0/DEL control characters (newlines included — paths get logged, so this blocks log-line forging).
- `(?!\s*$)` rejects empty/whitespace-only values, which **Windows silently strips** to a valid-but-wrong directory that would then pass the existence check.
- Accepts everything real: `~/hdb`, spaces, parens, apostrophes, Unicode, `.`/`..` (which resolve honestly).

Applied at all three sites (`rootPath`, `rootConstraints` → `componentsRoot`/`logging.root`, and `validatePath` → `storage.path`); the two prior patterns collapse into one.

## Where to look

- **`validatePath` throw semantics:** it runs the denylist via `Joi.assert`, whose throw is *caught by `Joi.custom`* and folded into `schema.error` as an `any.custom` detail — a bad `storage.path` surfaces as a validation error, not an exception. Covered by a dedicated test.
- The regex is a *character* filter, not an existence/authorization check, so permitting `.`/`..` introduces no traversal boundary here — the real check is `validatePath`'s existence test.

## Testing

Unit tests rewritten for the denylist (`unitTests/validation/configValidator.test.js`, 58 passing): 50k-char linearity guard; an accept-set (`~/hdb`, `C:\Program Files (x86)\Harper`, `/Users/café/harper`, `/Users/O'Brien/hdb`, `.`, `..`) that **fails on any allow-list and only passes on the denylist**; control-char / empty / whitespace-only rejects; the third-site `storage.path` path; and two pre-existing fixtures updated (they used `/???` and `/@@@` as "invalid" — those are valid Unix paths the denylist correctly accepts now).

Suggested as a **patch candidate** — the hang regressed somewhere in 5.1.10–5.1.19 and bricks the CLI on default installs.

_Generated by an LLM (Claude Fable 5). Cross-model review in progress on the denylist revision._
