### PR TITLE
Add live secret change subscription and live scoped accessor (#1776)

### DIFF
--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -12,7 +12,11 @@ import { FilesOption } from './deriveGlobOptions.ts';
 import { requestRestart } from './requestRestart.ts';
 import { resolveBaseURLPath } from './resolveBaseURLPath.ts';
 import { ApplicationScope } from './ApplicationScope.ts';
-import { getSecretsForComponent, closeComponentSubscriptions } from './componentSecrets.ts';
+import {
+	getSecretsForComponent,
+	retainComponentSubscriptions,
+	releaseComponentSubscriptions,
+} from './componentSecrets.ts';
 import type { SecretsView } from './componentSecrets.ts';
 import { deployLifecycle } from './deployLifecycle.ts';
 
@@ -55,6 +59,7 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 	#entryHandler?: EntryHandler;
 	#entryHandlers: EntryHandler[];
 	#logger: Logger;
+	#secretsReleased = false;
 	#pendingInitialLoads: Set<Promise<void>>;
 	#deployStartHandler: (name: string) => void;
 	#deployEndHandler: (name: string) => void;
@@ -91,6 +96,9 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 
 		this.databaseEvents = databaseEventsEmitter;
 		this.applicationScope = applicationScope;
+		// Hold this identity's live secret subscriptions (#1776) for as long as this Scope is open, so a
+		// throwaway deploy-validation Scope closing can't tear down a sibling/running Scope's streams.
+		retainComponentSubscriptions(applicationScope?.name ?? appName);
 		this.resources = applicationScope?.resources ?? resources;
 		this.models = modelsSingleton;
 
@@ -225,11 +233,14 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 
 		this.removeAllListeners();
 
-		// End any live secret subscriptions (#1776) this scope's code opened, AFTER the close listeners
-		// (so a subscription a close listener created is torn down too). Keyed by the same identity
-		// `scope.secrets` uses; scopes sharing an application identity share their subscriptions, so this
-		// runs at application-teardown granularity — that identity's streams are ended together.
-		closeComponentSubscriptions(this.applicationScope?.name ?? this.#appName);
+		// Release this identity's subscription hold (#1776), AFTER the close listeners (so a subscription a
+		// close listener created is still accounted for). Streams end only when the LAST holder of the
+		// identity releases — so a discarded validation-load Scope can't kill a still-running app's streams.
+		// Guarded so a double close() can't underflow the refcount.
+		if (!this.#secretsReleased) {
+			this.#secretsReleased = true;
+			releaseComponentSubscriptions(this.applicationScope?.name ?? this.#appName);
+		}
 
 		return this;
 	}

--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -12,7 +12,7 @@ import { FilesOption } from './deriveGlobOptions.ts';
 import { requestRestart } from './requestRestart.ts';
 import { resolveBaseURLPath } from './resolveBaseURLPath.ts';
 import { ApplicationScope } from './ApplicationScope.ts';
-import { getSecretsForComponent } from './componentSecrets.ts';
+import { getSecretsForComponent, closeComponentSubscriptions } from './componentSecrets.ts';
 import type { SecretsView } from './componentSecrets.ts';
 import { deployLifecycle } from './deployLifecycle.ts';
 
@@ -224,6 +224,12 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 		);
 
 		this.removeAllListeners();
+
+		// End any live secret subscriptions (#1776) this scope's code opened, AFTER the close listeners
+		// (so a subscription a close listener created is torn down too). Keyed by the same identity
+		// `scope.secrets` uses; scopes sharing an application identity share their subscriptions, so this
+		// runs at application-teardown granularity — that identity's streams are ended together.
+		closeComponentSubscriptions(this.applicationScope?.name ?? this.#appName);
 
 		return this;
 	}

--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -13,6 +13,7 @@ import { requestRestart } from './requestRestart.ts';
 import { resolveBaseURLPath } from './resolveBaseURLPath.ts';
 import { ApplicationScope } from './ApplicationScope.ts';
 import { getSecretsForComponent } from './componentSecrets.ts';
+import type { SecretsView } from './componentSecrets.ts';
 import { deployLifecycle } from './deployLifecycle.ts';
 
 export class MissingDefaultFilesOptionError extends Error {
@@ -149,12 +150,13 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 
 	/**
 	 * The application's secrets view (#1550): hdb_secret rows granted to this application plus its
-	 * declared global-tier env names. Frozen, enumerable, values decrypted at component load.
-	 * Keyed by the ApplicationScope's name (the application directory name — the identity grants
-	 * and env declarations use, and the same binding `import { secrets } from 'harper'` resolves);
-	 * `#appName` can differ on paths like RUN_HDB_APP, where it is the full directory path.
+	 * declared global-tier env names. A live, read-only view (#1776) — scoped values reflect the latest
+	 * store state on each read and it carries the reserved `subscribe(name)` method. Keyed by the
+	 * ApplicationScope's name (the application directory name — the identity grants and env declarations
+	 * use, and the same binding `import { secrets } from 'harper'` resolves); `#appName` can differ on
+	 * paths like RUN_HDB_APP, where it is the full directory path.
 	 */
-	get secrets(): Readonly<Record<string, string>> {
+	get secrets(): SecretsView {
 		return getSecretsForComponent(this.applicationScope?.name ?? this.#appName);
 	}
 

--- a/components/componentSecrets.ts
+++ b/components/componentSecrets.ts
@@ -687,9 +687,13 @@ function subscribeSecret(componentName: string, name: string): AsyncIterableIter
 
 /** Close every live subscription owned by a component (component reload/unload). */
 export function closeComponentSubscriptions(componentName: string): void {
+	// Collect first, then close: stream.end() → unregisterStream() mutates secretSubscribers, so we must
+	// not close while iterating it.
+	const toClose: SecretChangeStream[] = [];
 	for (const streams of secretSubscribers.values()) {
-		for (const stream of [...streams]) if (stream.componentName === componentName) stream.end();
+		for (const stream of streams) if (stream.componentName === componentName) toClose.push(stream);
 	}
+	for (const stream of toClose) stream.end();
 }
 
 /** The component's current effective value for one name (scoped-granted live, else declared→process.env). */
@@ -870,8 +874,9 @@ export function resetComponentSecrets(): void {
 	unsatisfiedEnv.clear();
 	accessorCache.clear();
 	warnedSubscribeShadow.clear();
-	for (const streams of secretSubscribers.values()) for (const stream of [...streams]) stream.end();
+	const openStreams = [...secretSubscribers.values()].flatMap((streams) => [...streams]);
 	secretSubscribers.clear();
+	for (const stream of openStreams) stream.end();
 	// Tear down the shared table watcher too, so a reset doesn't leak an audit-log listener.
 	secretWatcherSubscription?.emit?.('close');
 	secretWatcherSubscription?.end?.();

--- a/components/componentSecrets.ts
+++ b/components/componentSecrets.ts
@@ -696,6 +696,30 @@ export function closeComponentSubscriptions(componentName: string): void {
 	for (const stream of toClose) stream.end();
 }
 
+// Subscriptions are keyed by component IDENTITY (applicationScope.name), which several concurrently-open
+// Scopes legitimately share — most notably a throwaway deploy-validation Scope loads the SAME directory
+// as the running app and closes in a `finally` before the real restart. Tearing down on any one Scope's
+// close would kill the running app's live streams. So teardown is reference-counted per identity: a Scope
+// retains on construction and releases on close, and streams are ended only when the LAST holder of that
+// identity releases (i.e. the app is truly unloading, not merely a validation load being discarded).
+const subscriptionHolders = new Map<string, number>();
+
+/** A Scope of this identity is now open — hold its live secret subscriptions until it releases. */
+export function retainComponentSubscriptions(componentName: string): void {
+	subscriptionHolders.set(componentName, (subscriptionHolders.get(componentName) ?? 0) + 1);
+}
+
+/** A Scope of this identity closed — end the identity's subscriptions once the last holder is gone. */
+export function releaseComponentSubscriptions(componentName: string): void {
+	const remaining = (subscriptionHolders.get(componentName) ?? 0) - 1;
+	if (remaining > 0) {
+		subscriptionHolders.set(componentName, remaining);
+	} else {
+		subscriptionHolders.delete(componentName);
+		closeComponentSubscriptions(componentName);
+	}
+}
+
 /** The component's current effective value for one name (scoped-granted live, else declared→process.env). */
 function currentSecretValue(componentName: string, name: string): string | undefined {
 	const { available, value } = resolveSubscribedSecret(componentName, name, secretRows.get(name));
@@ -876,6 +900,7 @@ export function resetComponentSecrets(): void {
 	warnedSubscribeShadow.clear();
 	const openStreams = [...secretSubscribers.values()].flatMap((streams) => [...streams]);
 	secretSubscribers.clear();
+	subscriptionHolders.clear();
 	for (const stream of openStreams) stream.end();
 	// Tear down the shared table watcher too, so a reset doesn't leak an audit-log listener.
 	secretWatcherSubscription?.emit?.('close');

--- a/components/componentSecrets.ts
+++ b/components/componentSecrets.ts
@@ -34,8 +34,12 @@
  * rather than guessing. The recommended idiom is a module-top-level destructure
  * (`const { MY_KEY } = secrets;`), where binding is exact in every mode.
  *
- * Late custody / changed secrets heal on restart or component reload (each load cycle re-reads the
- * store) — there is no live re-materialization.
+ * Liveness (#1776): a change watcher on the store keeps the SCOPED tier live — the per-component
+ * accessor (`secrets.NAME`) and `secrets.subscribe(name)` reflect a later set_secret/grant/revoke/delete
+ * without a reload. The GLOBAL (`process.env`) tier stays reload-only: a live change never re-mutates
+ * `process.env` under already-running code (child processes have inherited it; arbitrary code has cached
+ * it), so materialized env values still heal only on restart or component reload. Late custody likewise
+ * heals on reload (each load cycle re-reads and re-decrypts the store).
  */
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { databases } from '../resources/databases.ts';
@@ -47,8 +51,19 @@ import { _assignPackageExport } from '../globals.js';
 
 const SECRET_TABLE = SYSTEM_TABLE_NAMES.SECRET_TABLE_NAME;
 
-/** A per-component secrets view: read-only name→value map exposed as `import { secrets } from 'harper'`. */
-export type SecretsView = Readonly<Record<string, string>>;
+/**
+ * Subscribe to a secret's current value and any subsequent changes (#1776). Yields the current value
+ * first, then on each change; `undefined` means the component has no access right now (never granted,
+ * revoked, or deleted) — the same thing `secrets[name]` reads as. The stream stays open across that,
+ * so a re-grant/re-add resumes on the same iterator.
+ */
+export type SecretSubscribe = (name: string) => AsyncIterableIterator<string | undefined>;
+
+/**
+ * A per-component secrets view: read-only name→value map exposed as `import { secrets } from 'harper'`,
+ * plus the reserved, non-enumerable `subscribe(name)` method for live change subscription.
+ */
+export type SecretsView = Readonly<Record<string, string>> & { readonly subscribe: SecretSubscribe };
 
 export type UnsatisfiedReason = 'missing' | 'ungranted' | 'custody-unavailable';
 
@@ -89,7 +104,40 @@ const ownedEnvKeys = new Set<string>();
 // Per-component registries, rebuilt as each component's env block is processed.
 const declaredEnvNames = new Map<string, Set<string>>();
 const unsatisfiedEnv = new Map<string, UnsatisfiedDeclaration[]>();
+// Cached LIVE per-component view proxies (stable per component; they resolve values on each read, so
+// they never need invalidating on a secret change — only on reset).
 const accessorCache = new Map<string, SecretsView>();
+// Components already warned about a secret named `subscribe` shadowing the reserved method.
+const warnedSubscribeShadow = new Set<string>();
+
+/**
+ * Build the in-memory state for one hdb_secret row: normalize grants, read the tier flag, and
+ * decrypt the envelope with this node's custody. The single source of truth for turning a stored
+ * record into a {grants, processEnv, value?, failure?} — shared by the load-cycle scan
+ * (doMaterializeGlobalSecrets) and the live change watcher (dispatchSecretChange), so both paths
+ * apply identical decrypt/failure semantics.
+ */
+function rowStateFromRecord(record: any): SecretRowState {
+	const state: SecretRowState = {
+		grants: Array.isArray(record.grants) ? [...new Set(record.grants as string[])] : [],
+		processEnv: record.processEnv === true,
+	};
+	if (typeof record.envelope === 'string') {
+		const decryptor = getSecretDecryptor();
+		if (!decryptor) {
+			state.failure = 'no secrets custody is registered on this node';
+		} else {
+			try {
+				state.value = decryptor(record.envelope);
+			} catch (error) {
+				state.failure = `decrypt failed: ${(error as Error).message}`;
+			}
+		}
+	} else {
+		state.failure = 'stored row has no envelope';
+	}
+	return state;
+}
 
 /**
  * Read the hdb_secret store, decrypt what this node's custody allows, materialize the global tier
@@ -130,29 +178,11 @@ async function doMaterializeGlobalSecrets(): Promise<void> {
 		return;
 	}
 	const rows = new Map<string, SecretRowState>();
-	const decryptor = getSecretDecryptor();
 	try {
 		for await (const row of table.search([])) {
 			const name = row.name;
 			if (typeof name !== 'string' || !name) continue;
-			const state: SecretRowState = {
-				grants: Array.isArray(row.grants) ? [...new Set(row.grants as string[])] : [],
-				processEnv: row.processEnv === true,
-			};
-			if (typeof row.envelope === 'string') {
-				if (!decryptor) {
-					state.failure = 'no secrets custody is registered on this node';
-				} else {
-					try {
-						state.value = decryptor(row.envelope);
-					} catch (error) {
-						state.failure = `decrypt failed: ${(error as Error).message}`;
-					}
-				}
-			} else {
-				state.failure = 'stored row has no envelope';
-			}
-			rows.set(name, state);
+			rows.set(name, rowStateFromRecord(row));
 		}
 	} catch (error) {
 		// Leave the previous snapshot (and process.env) untouched rather than acting on a partial read.
@@ -194,6 +224,17 @@ async function doMaterializeGlobalSecrets(): Promise<void> {
 	}
 	secretRows = rows;
 	accessorCache.clear();
+	// Start (once) the live change watcher so the scoped-tier accessor and any subscriptions reflect
+	// later set_secret/grant/revoke/delete without a reload. Runs on whichever thread materializes
+	// secrets — the same thread that serves the accessor. Never fatal: a subscribe failure leaves the
+	// node bootable with reload-only secrets.
+	try {
+		await ensureSecretWatcher(table);
+	} catch (error) {
+		logger.warn(
+			`Could not start the live secrets change watcher (secrets will be reload-only): ${(error as Error).message}`
+		);
+	}
 }
 
 function parseDeclaration(componentName: string, name: string, spec: unknown): EnvDeclaration {
@@ -337,33 +378,327 @@ export function getUnsatisfiedEnv(componentName: string): UnsatisfiedDeclaration
 	return unsatisfiedEnv.get(componentName) ?? [];
 }
 
+// ── Live secret change subscription (#1776) ────────────────────────────────────────────────────
+//
+// `secrets.subscribe(name)` returns an async iterable that yields the secret's current effective
+// value (if the component has access now) and then a new value on every change — so an app can
+// hot-swap an API key without a restart. It is a decrypted, grant-filtered PROJECTION over the
+// replicated `system.hdb_secret` table's own subscription: a `set_secret`/`grant_secret` on ANY
+// node replicates the row, the one shared table watcher observes the commit, and the change fans
+// out to the subscribers of that name. Change authority is re-evaluated per event through the SAME
+// resolver as the read accessor (continuous re-authorization, the property #1414 enforces), so a
+// `revoke_secret`/`delete_secret` that removes the component's access hands the stream `undefined`
+// (and retains no plaintext) rather than the last value — the app can never keep receiving a secret
+// it has lost rights to. The stream stays open across that, so a later re-grant/re-add resumes on it.
+//
+// Tier semantics: the SCOPED tier is fully live (value resolved from the freshly decrypted row).
+// The global (processEnv) tier stays reload-only for `process.env` itself — a live change never
+// silently re-mutates process.env under already-running code — but a subscriber to a declared
+// global name still receives the fresh decrypted value through this channel.
+
 /**
- * The secrets view for a component: scoped-tier rows granted to it, plus its DECLARED names
- * resolved from process.env (global-tier materialized values, env literals, or real env vars).
- * The superset lets app code use `secrets.FOO` uniformly, and lets ops later tighten a secret from
- * global to granted without breaking the app. Values are decrypted eagerly at load; the object is
- * frozen and enumerable (`Object.keys`, spread).
+ * A single (component, secret-name) live subscription: a minimal push async-iterator that yields the
+ * secret's current effective value and then a new value on every change. A value of `undefined` means
+ * the component has no access right now (never granted, revoked, or the secret was deleted) — the same
+ * thing `secrets[name]` reads as. The stream stays open across that transition, so a delete-then-re-add
+ * or revoke-then-re-grant resumes on the SAME iterator with no re-subscribe. It ends only when the
+ * consumer breaks out, the component is unloaded, or the store is unavailable.
+ */
+type SecretValue = string | undefined;
+class SecretChangeStream implements AsyncIterableIterator<SecretValue> {
+	// At most one undelivered value: this is a current-state stream, so a newer value COALESCES over an
+	// unconsumed older one. That also means a revoke (deliver `undefined`) drops any queued plaintext a
+	// slow consumer had not yet read — no stale secret is handed out after access is lost.
+	#queued: { value: SecretValue } | null = null;
+	// FIFO of parked next() resolvers, so concurrent next() calls each settle (a single slot would drop
+	// all but the last).
+	#waiters: Array<(result: IteratorResult<SecretValue>) => void> = [];
+	#closed = false;
+	/** Whether any value has been delivered yet, so the first (possibly `undefined`) value always emits. */
+	#hasEmitted = false;
+	/** Last value delivered, so an unrelated row change doesn't re-emit an unchanged value. */
+	lastValue: SecretValue;
+	readonly componentName: string;
+	readonly name: string;
+
+	constructor(componentName: string, name: string) {
+		this.componentName = componentName;
+		this.name = name;
+	}
+
+	get closed(): boolean {
+		return this.#closed;
+	}
+
+	[Symbol.asyncIterator](): AsyncIterableIterator<SecretValue> {
+		return this;
+	}
+
+	next(): Promise<IteratorResult<SecretValue>> {
+		if (this.#queued) {
+			const { value } = this.#queued;
+			this.#queued = null;
+			return Promise.resolve({ value, done: false });
+		}
+		if (this.#closed) return Promise.resolve({ value: undefined, done: true });
+		return new Promise((resolve) => this.#waiters.push(resolve));
+	}
+
+	// Consumer breaking out of `for await` — tear down and stop tracking this stream.
+	return(): Promise<IteratorResult<SecretValue>> {
+		this.#close();
+		return Promise.resolve({ value: undefined, done: true });
+	}
+
+	// Producer side: deliver the current effective value (bespoke iterator rather than IterableEventQueue
+	// so an `undefined`/empty-string value can't be misread as an empty queue). Dedups so an unrelated
+	// row change doesn't re-emit an unchanged value; the first value always emits so a currently-absent
+	// secret yields `undefined` up front.
+	deliver(value: SecretValue): void {
+		if (this.#closed) return;
+		if (this.#hasEmitted && value === this.lastValue) return;
+		this.#hasEmitted = true;
+		this.lastValue = value;
+		const waiter = this.#waiters.shift();
+		if (waiter) waiter({ value, done: false });
+		else this.#queued = { value }; // replace: coalesce to the latest, dropping any stale queued value
+	}
+
+	// Producer side: end the stream (consumer/component gone, or the store is unavailable). Access loss
+	// is NOT an end — it is delivered as an `undefined` value via deliver().
+	end(): void {
+		this.#close();
+	}
+
+	#close(): void {
+		if (this.#closed) return;
+		this.#closed = true;
+		// Drop any queued plaintext and the retained last value so nothing is readable after close.
+		this.#queued = null;
+		this.lastValue = undefined;
+		unregisterStream(this);
+		const waiters = this.#waiters;
+		this.#waiters = [];
+		for (const waiter of waiters) waiter({ value: undefined, done: true });
+	}
+}
+
+// name → active streams for that name. Keyed by secret name so a change dispatches only to the
+// streams that care, without every stream filtering every commit.
+const secretSubscribers = new Map<string, Set<SecretChangeStream>>();
+
+function registerStream(stream: SecretChangeStream): void {
+	let streams = secretSubscribers.get(stream.name);
+	if (!streams) secretSubscribers.set(stream.name, (streams = new Set()));
+	streams.add(stream);
+}
+
+function unregisterStream(stream: SecretChangeStream): void {
+	const streams = secretSubscribers.get(stream.name);
+	if (!streams) return;
+	streams.delete(stream);
+	if (streams.size === 0) secretSubscribers.delete(stream.name);
+}
+
+/**
+ * Resolve a component's effective view of one secret from a freshly-decrypted row state — the SAME
+ * authority the read accessor applies (scoped rows require a grant; global/absent rows require a
+ * declaration), so the subscription can never widen access. Returns the value when available.
+ */
+function resolveSubscribedSecret(
+	componentName: string,
+	name: string,
+	row: SecretRowState | undefined
+): { available: boolean; value?: string } {
+	// Exactly the read accessor's authority (getSecretsForComponent), so a subscription can never
+	// widen access beyond a fresh `secrets[name]` read:
+	//  1. a scoped row granted to this component and decryptable → its live decrypted value;
+	//  2. otherwise, a name this component DECLARED → its process.env value (global-materialized,
+	//     literal, or a real env var — reload-only, precedence already resolved in process.env).
+	// The process.env fallback is gated on declaration: an undeclared, ungranted component must never
+	// read a still-materialized global value out of process.env (that would bypass the grant model).
+	if (row && !row.processEnv && row.value !== undefined && row.grants.includes(componentName)) {
+		return { available: true, value: row.value };
+	}
+	if (declaredEnvNames.get(componentName)?.has(name)) {
+		const envValue = process.env[name];
+		if (envValue !== undefined) return { available: true, value: envValue };
+	}
+	return { available: false };
+}
+
+// The one shared subscription to system.hdb_secret. Lazily started on the first subscribe; a
+// single watcher feeds every stream.
+let secretWatcher: Promise<void> | undefined;
+let secretWatcherSubscription: { emit?: (event: string) => void; end?: () => void } | undefined;
+
+function ensureSecretWatcher(table: any): Promise<void> {
+	// Reset the memo on failure so a transient table.subscribe() error doesn't permanently disable live
+	// secrets — the next caller retries instead of reusing a rejected promise.
+	return (secretWatcher ??= (async () => {
+		// No omitCurrent: on attach the watcher replays the current rows, re-syncing `secretRows` and
+		// closing any gap between the load-time scan and the subscription attach point. Subsequent
+		// commits (local or replicated) keep the snapshot live.
+		secretWatcherSubscription = await table.subscribe({ listener: onSecretEvent });
+	})().catch((error) => {
+		secretWatcher = undefined;
+		throw error;
+	}));
+}
+
+// Fired for every commit to system.hdb_secret (local or replicated). event.value is the full record
+// on put; null-valued on delete. Keeps `secretRows` (the live view's source) current and fans the
+// change out to any subscribers, WITHOUT touching process.env — the global tier stays reload-only.
+function onSecretEvent(event: any): void {
+	try {
+		// Base-copy replication of a system table delivers a single `{type:'reload', id:null}` marker
+		// instead of per-row events (harper-pro#495): the whole table was reseeded, so re-scan to resync
+		// adds AND removals rather than silently keeping stale rows/grants.
+		if (event?.type === 'reload') {
+			void materializeGlobalSecrets();
+			return;
+		}
+		const name = (event?.value?.name ?? event?.id) as unknown;
+		if (typeof name !== 'string' || !name) return;
+		const record = event?.type === 'delete' ? null : (event?.value ?? null);
+		const row = record ? rowStateFromRecord(record) : undefined;
+		if (row) secretRows.set(name, row);
+		else secretRows.delete(name);
+		// The cached views are live proxies (they read secretRows on each access), so no invalidation is
+		// needed here — a fresh `secrets[name]` read already reflects this update.
+		dispatchSecretChange(name, row);
+	} catch (error) {
+		logger.warn(`secrets change subscription failed to dispatch an event: ${(error as Error).message}`);
+	}
+}
+
+function dispatchSecretChange(name: string, row: SecretRowState | undefined): void {
+	const streams = secretSubscribers.get(name);
+	if (!streams || streams.size === 0) return;
+	for (const stream of [...streams]) {
+		// Authority is re-evaluated on EVERY event (continuous re-authorization, the property #1414
+		// enforces): a revoke/delete/custody-loss resolves to unavailable → the stream is handed
+		// `undefined` (no plaintext retained), not the last value. A later re-grant/re-add resolves to a
+		// value again and resumes on the same stream. deliver() dedups unchanged values.
+		const { available, value } = resolveSubscribedSecret(stream.componentName, name, row);
+		stream.deliver(available ? value : undefined);
+	}
+}
+
+/**
+ * `secrets.subscribe(name)` for a component: the current effective value (matching `secrets[name]`)
+ * then a stream of changes. Returned synchronously for direct use in `for await`. The initial value is
+ * delivered SYNCHRONOUSLY from the live snapshot before the watcher is (re)started, so no change event
+ * can interleave ahead of it and a stale value can never land after a newer one.
+ */
+function subscribeSecret(componentName: string, name: string): AsyncIterableIterator<SecretValue> {
+	const stream = new SecretChangeStream(componentName, name);
+	registerStream(stream);
+	// Initial value from the current snapshot (scoped-granted live, or a declared name's process.env
+	// value even when the store is unavailable — accessor-equivalent).
+	const initial = resolveSubscribedSecret(componentName, name, secretRows.get(name));
+	stream.deliver(initial.available ? initial.value : undefined);
+	const table = (databases as { system?: Record<string, any> }).system?.[SECRET_TABLE];
+	if (table) {
+		// Start (or reuse) the one shared watcher so subsequent changes flow to this stream.
+		ensureSecretWatcher(table).catch((error) => {
+			logger.warn(`secrets.subscribe('${name}'): live change watcher unavailable: ${(error as Error).message}`);
+		});
+	} else {
+		// No store to watch: the stream keeps its initial value and simply won't receive live updates
+		// (nothing can change without the store); a reload/restart re-establishes it.
+		logger.debug?.(
+			`secrets.subscribe('${name}'): secrets store (system.${SECRET_TABLE}) is unavailable; no live updates`
+		);
+	}
+	return stream;
+}
+
+/** Close every live subscription owned by a component (component reload/unload). */
+export function closeComponentSubscriptions(componentName: string): void {
+	for (const streams of secretSubscribers.values()) {
+		for (const stream of [...streams]) if (stream.componentName === componentName) stream.end();
+	}
+}
+
+/** The component's current effective value for one name (scoped-granted live, else declared→process.env). */
+function currentSecretValue(componentName: string, name: string): string | undefined {
+	const { available, value } = resolveSubscribedSecret(componentName, name, secretRows.get(name));
+	return available ? value : undefined;
+}
+
+/** The names currently visible to a component (granted scoped rows + declared names present in env). */
+function currentSecretNames(componentName: string): string[] {
+	const names = new Set<string>();
+	const declared = declaredEnvNames.get(componentName);
+	if (declared) for (const name of declared) if (process.env[name] !== undefined) names.add(name);
+	for (const [name, row] of secretRows) {
+		if (row.value !== undefined && !row.processEnv && row.grants.includes(componentName)) names.add(name);
+	}
+	return [...names];
+}
+
+/**
+ * The secrets view for a component: scoped-tier rows granted to it, plus its DECLARED names resolved
+ * from process.env (global-tier materialized values, env literals, or real env vars). The superset
+ * lets app code use `secrets.FOO` uniformly, and lets ops later tighten a secret from global to
+ * granted without breaking the app.
+ *
+ * It is a LIVE view (#1776): a Proxy that resolves each read from the current snapshot, so a scoped
+ * secret's rotation/revoke is reflected by a fresh `secrets.FOO` read under every loader — including a
+ * view captured once by the vm/compartment loader or held as `const v = scope.secrets` (only a
+ * value destructured out, `const { FOO } = secrets`, is a point-in-time copy). Declared global names
+ * still resolve from `process.env` (reload-only). Read-only and null-prototype, so Object.prototype
+ * members can't masquerade as secrets and the view can't be mutated. `subscribe` is a reserved,
+ * non-enumerable method (skipped by Object.keys/spread); a secret literally named `subscribe` is
+ * shadowed by it — logged once when observed.
  */
 export function getSecretsForComponent(componentName: string): SecretsView {
 	let view = accessorCache.get(componentName);
 	if (view) return view;
-	// Null prototype so inherited Object.prototype members (toString, hasOwnProperty, constructor)
-	// can never masquerade as secret values under dynamic access like `secrets[key]`.
-	const entries: Record<string, string> = Object.create(null);
-	const declared = declaredEnvNames.get(componentName);
-	if (declared) {
-		for (const name of declared) {
-			const value = process.env[name];
-			if (value !== undefined) entries[name] = value;
-		}
-	}
-	// Scoped rows granted to this component; on a name collision the scoped value wins.
-	for (const [name, row] of secretRows) {
-		if (row.value !== undefined && !row.processEnv && row.grants.includes(componentName)) {
-			entries[name] = row.value;
-		}
-	}
-	view = Object.freeze(entries);
+	const subscribe: SecretSubscribe = (name: string) => subscribeSecret(componentName, name);
+	view = new Proxy(Object.create(null) as Record<string, string>, {
+		get(_target, property) {
+			if (property === 'subscribe') {
+				// Advisory: warn once per component if a real secret named `subscribe` is shadowed by the
+				// reserved method (it is then unreadable via dot/bracket access — an accepted #1776 tradeoff).
+				if (!warnedSubscribeShadow.has(componentName)) {
+					warnedSubscribeShadow.add(componentName);
+					if (currentSecretValue(componentName, 'subscribe') !== undefined) {
+						logger.warn(
+							`Component '${componentName}' has a secret named 'subscribe'; it is shadowed by the reserved secrets.subscribe() method and is not readable through the secrets accessor`
+						);
+					}
+				}
+				return subscribe;
+			}
+			if (typeof property === 'symbol') return undefined;
+			return currentSecretValue(componentName, property);
+		},
+		has(_target, property) {
+			if (property === 'subscribe') return true;
+			if (typeof property === 'symbol') return false;
+			return currentSecretValue(componentName, property) !== undefined;
+		},
+		ownKeys() {
+			// `subscribe` is intentionally omitted (non-enumerable), so spread/Object.keys never surface it.
+			return currentSecretNames(componentName);
+		},
+		getOwnPropertyDescriptor(_target, property) {
+			if (property === 'subscribe') {
+				return { value: subscribe, writable: false, enumerable: false, configurable: true };
+			}
+			if (typeof property === 'symbol') return undefined;
+			const value = currentSecretValue(componentName, property);
+			if (value === undefined) return undefined;
+			return { value, writable: false, enumerable: true, configurable: true };
+		},
+		set: readOnly,
+		defineProperty: readOnly,
+		deleteProperty: readOnly,
+		preventExtensions: readOnly,
+		setPrototypeOf: readOnly,
+	}) as unknown as SecretsView;
 	accessorCache.set(componentName, view);
 	return view;
 }
@@ -407,6 +742,9 @@ function readOnly(): never {
 export const secrets: SecretsView = new Proxy(
 	{},
 	{
+		// `subscribe` resolves like any other own property of the bound view (it is a non-enumerable
+		// method there); it therefore reads through here, appears in ownKeys as non-enumerable, and is
+		// skipped by spread/Object.keys — no special-casing needed in the traps.
 		get(_target, property) {
 			if (typeof property === 'symbol' || property === 'then') return undefined;
 			return resolveBoundSecrets()[property];
@@ -423,8 +761,7 @@ export const secrets: SecretsView = new Proxy(
 		getOwnPropertyDescriptor(_target, property) {
 			if (typeof property === 'symbol' || componentBinding.getStore() === undefined) return undefined;
 			const descriptor = Object.getOwnPropertyDescriptor(resolveBoundSecrets(), property);
-			// The views are frozen; report configurable so the proxy invariant against its (extensible,
-			// empty) target holds.
+			// Report configurable so the proxy invariant against this (extensible, empty) target holds.
 			return descriptor && { ...descriptor, configurable: true };
 		},
 		set: readOnly,
@@ -436,7 +773,8 @@ export const secrets: SecretsView = new Proxy(
 		preventExtensions: readOnly,
 		setPrototypeOf: readOnly,
 	}
-);
+	// The empty target can't carry the reserved `subscribe` member statically; the get trap supplies it.
+) as unknown as SecretsView;
 _assignPackageExport('secrets', secrets);
 
 /** Reset all module state and retract materialized env values. Intended for tests. */
@@ -448,4 +786,12 @@ export function resetComponentSecrets(): void {
 	declaredEnvNames.clear();
 	unsatisfiedEnv.clear();
 	accessorCache.clear();
+	warnedSubscribeShadow.clear();
+	for (const streams of secretSubscribers.values()) for (const stream of [...streams]) stream.end();
+	secretSubscribers.clear();
+	// Tear down the shared table watcher too, so a reset doesn't leak an audit-log listener.
+	secretWatcherSubscription?.emit?.('close');
+	secretWatcherSubscription?.end?.();
+	secretWatcher = undefined;
+	secretWatcherSubscription = undefined;
 }

--- a/components/componentSecrets.ts
+++ b/components/componentSecrets.ts
@@ -166,30 +166,74 @@ export function materializeGlobalSecrets(): Promise<void> {
 }
 let materializeInFlight: Promise<void> | undefined;
 
+// Bump on every applied live change, so a full rescan can detect that its stable-snapshot view raced
+// a newer watcher update and retry rather than clobber it (see scanIntoSecretRows).
+let secretEventSeq = 0;
+const SCAN_RETRY_LIMIT = 5;
+
+/**
+ * Rebuild `secretRows` (the live snapshot behind the scoped accessor and subscriptions) from a full
+ * table scan, then re-deliver current values to every open stream. `table.search` uses a stable
+ * snapshot, so a scan that started before a revoke could otherwise complete afterward and re-authorize
+ * the just-revoked secret; to prevent that we retry the scan when a live change was applied while it
+ * ran, and the final assignment is synchronous (no await) so no event can interleave between the guard
+ * check and the assignment. Does NOT touch process.env — callers that must (re)materialize the global
+ * tier do that separately (it stays reload-only).
+ */
+async function scanIntoSecretRows(table: any): Promise<Map<string, SecretRowState>> {
+	let rows: Map<string, SecretRowState>;
+	let before: number;
+	let attempts = 0;
+	do {
+		before = secretEventSeq;
+		rows = new Map();
+		for await (const record of table.search([])) {
+			const name = record.name;
+			if (typeof name !== 'string' || !name) continue;
+			rows.set(name, rowStateFromRecord(record));
+		}
+	} while (before !== secretEventSeq && ++attempts < SCAN_RETRY_LIMIT);
+	if (before !== secretEventSeq) {
+		logger.warn(
+			'Secrets store changed repeatedly during a rescan; applying the latest scan (heals on the next change)'
+		);
+	}
+	secretRows = rows;
+	storeAvailable = true;
+	redispatchAllStreams();
+	return rows;
+}
+
 async function doMaterializeGlobalSecrets(): Promise<void> {
 	const table = (databases as { system?: Record<string, any> }).system?.[SECRET_TABLE];
 	if (!table) {
 		storeAvailable = false;
 		secretRows = new Map();
 		accessorCache.clear();
+		redispatchAllStreams(); // reflect the store going away to any open streams
 		logger.debug?.(
 			`Secrets store not initialized (system.${SECRET_TABLE} missing); component env declarations can only be satisfied from process.env`
 		);
 		return;
 	}
-	const rows = new Map<string, SecretRowState>();
+	// Start the watcher BEFORE the scan so a change committed during the scan bumps secretEventSeq and
+	// forces a retry (closing the scan→attach gap where a deletion would otherwise be lost). Non-fatal:
+	// a subscribe failure leaves the node bootable with reload-only secrets.
 	try {
-		for await (const row of table.search([])) {
-			const name = row.name;
-			if (typeof name !== 'string' || !name) continue;
-			rows.set(name, rowStateFromRecord(row));
-		}
+		await ensureSecretWatcher(table);
+	} catch (error) {
+		logger.warn(
+			`Could not start the live secrets change watcher (secrets will be reload-only): ${(error as Error).message}`
+		);
+	}
+	let rows: Map<string, SecretRowState>;
+	try {
+		rows = await scanIntoSecretRows(table);
 	} catch (error) {
 		// Leave the previous snapshot (and process.env) untouched rather than acting on a partial read.
 		logger.error(`Failed to read the secrets store (system.${SECRET_TABLE}): ${(error as Error).message}`);
 		return;
 	}
-	storeAvailable = true;
 
 	for (const [name, state] of rows) {
 		if (!state.processEnv) {
@@ -221,19 +265,6 @@ async function doMaterializeGlobalSecrets(): Promise<void> {
 			delete process.env[name];
 			ownedEnvKeys.delete(name);
 		}
-	}
-	secretRows = rows;
-	accessorCache.clear();
-	// Start (once) the live change watcher so the scoped-tier accessor and any subscriptions reflect
-	// later set_secret/grant/revoke/delete without a reload. Runs on whichever thread materializes
-	// secrets — the same thread that serves the accessor. Never fatal: a subscribe failure leaves the
-	// node bootable with reload-only secrets.
-	try {
-		await ensureSecretWatcher(table);
-	} catch (error) {
-		logger.warn(
-			`Could not start the live secrets change watcher (secrets will be reload-only): ${(error as Error).message}`
-		);
 	}
 }
 
@@ -510,6 +541,10 @@ function resolveSubscribedSecret(
 	name: string,
 	row: SecretRowState | undefined
 ): { available: boolean; value?: string } {
+	// `subscribe` is the reserved accessor method, never a readable secret (it is shadowed on the view),
+	// so it must be uniformly invisible as a value here too — otherwise subscribe('subscribe') would leak
+	// the plaintext of a secret literally named `subscribe` that the accessor hides.
+	if (name === 'subscribe') return { available: false };
 	// Exactly the read accessor's authority (getSecretsForComponent), so a subscription can never
 	// widen access beyond a fresh `secrets[name]` read:
 	//  1. a scoped row granted to this component and decryptable → its live decrypted value;
@@ -532,14 +567,23 @@ function resolveSubscribedSecret(
 let secretWatcher: Promise<void> | undefined;
 let secretWatcherSubscription: { emit?: (event: string) => void; end?: () => void } | undefined;
 
+function restartSecretWatcher(): void {
+	// Drop the memo (and any live subscription) so the next ensureSecretWatcher() re-attaches.
+	const sub = secretWatcherSubscription;
+	secretWatcher = undefined;
+	secretWatcherSubscription = undefined;
+	sub?.emit?.('close');
+	sub?.end?.();
+}
+
 function ensureSecretWatcher(table: any): Promise<void> {
 	// Reset the memo on failure so a transient table.subscribe() error doesn't permanently disable live
 	// secrets — the next caller retries instead of reusing a rejected promise.
 	return (secretWatcher ??= (async () => {
-		// No omitCurrent: on attach the watcher replays the current rows, re-syncing `secretRows` and
-		// closing any gap between the load-time scan and the subscription attach point. Subsequent
-		// commits (local or replicated) keep the snapshot live.
-		secretWatcherSubscription = await table.subscribe({ listener: onSecretEvent });
+		// omitCurrent: the load-cycle scan (scanIntoSecretRows) seeds and re-syncs the snapshot, and the
+		// watcher is attached BEFORE that scan, so it need not (and should not) replay current rows here —
+		// it only needs subsequent commits, local or replicated.
+		secretWatcherSubscription = await table.subscribe({ omitCurrent: true, listener: onSecretEvent });
 	})().catch((error) => {
 		secretWatcher = undefined;
 		throw error;
@@ -551,15 +595,29 @@ function ensureSecretWatcher(table: any): Promise<void> {
 // change out to any subscribers, WITHOUT touching process.env — the global tier stays reload-only.
 function onSecretEvent(event: any): void {
 	try {
+		// Table.subscribe surfaces an async retained-state/replay failure by delivering the Error THROUGH
+		// the listener (not by rejecting subscribe()), so detect it here and restart the watcher —
+		// otherwise the memo stays fulfilled and every future ensureSecretWatcher reuses a dead subscription.
+		if (event instanceof Error) {
+			logger.warn(`secrets change watcher errored; restarting it: ${event.message}`);
+			restartSecretWatcher();
+			return;
+		}
 		// Base-copy replication of a system table delivers a single `{type:'reload', id:null}` marker
-		// instead of per-row events (harper-pro#495): the whole table was reseeded, so re-scan to resync
-		// adds AND removals rather than silently keeping stale rows/grants.
+		// instead of per-row events (harper-pro#495): the whole table was reseeded, so re-scan the LIVE
+		// snapshot to resync adds AND removals (and re-deliver to streams). It does NOT re-materialize
+		// process.env — the global tier stays reload-only even under replicated reloads.
 		if (event?.type === 'reload') {
-			void materializeGlobalSecrets();
+			const table = (databases as { system?: Record<string, any> }).system?.[SECRET_TABLE];
+			if (table)
+				scanIntoSecretRows(table).catch((error) =>
+					logger.warn(`secrets store rescan after a reload marker failed: ${(error as Error).message}`)
+				);
 			return;
 		}
 		const name = (event?.value?.name ?? event?.id) as unknown;
 		if (typeof name !== 'string' || !name) return;
+		secretEventSeq++; // let a concurrent rescan know its snapshot is now stale
 		const record = event?.type === 'delete' ? null : (event?.value ?? null);
 		const row = record ? rowStateFromRecord(record) : undefined;
 		if (row) secretRows.set(name, row);
@@ -582,6 +640,19 @@ function dispatchSecretChange(name: string, row: SecretRowState | undefined): vo
 		// value again and resumes on the same stream. deliver() dedups unchanged values.
 		const { available, value } = resolveSubscribedSecret(stream.componentName, name, row);
 		stream.deliver(available ? value : undefined);
+	}
+}
+
+// Re-deliver the current effective value to every open stream from the present `secretRows` — used
+// after a full rescan (reload marker or load cycle), where individual per-row events were not seen so
+// a removed row's subscribers would otherwise keep their stale value.
+function redispatchAllStreams(): void {
+	for (const [name, streams] of secretSubscribers) {
+		const row = secretRows.get(name);
+		for (const stream of [...streams]) {
+			const { available, value } = resolveSubscribedSecret(stream.componentName, name, row);
+			stream.deliver(available ? value : undefined);
+		}
 	}
 }
 
@@ -627,6 +698,16 @@ function currentSecretValue(componentName: string, name: string): string | undef
 	return available ? value : undefined;
 }
 
+/**
+ * Whether a secret named exactly `name` WOULD be readable to the component if it weren't reserved —
+ * used only to detect (and warn about) a secret named `subscribe` shadowed by the reserved method.
+ */
+function hasRawSecretNamed(componentName: string, name: string): boolean {
+	const row = secretRows.get(name);
+	if (row && !row.processEnv && row.value !== undefined && row.grants.includes(componentName)) return true;
+	return (declaredEnvNames.get(componentName)?.has(name) ?? false) && process.env[name] !== undefined;
+}
+
 /** The names currently visible to a component (granted scoped rows + declared names present in env). */
 function currentSecretNames(componentName: string): string[] {
 	const names = new Set<string>();
@@ -635,6 +716,7 @@ function currentSecretNames(componentName: string): string[] {
 	for (const [name, row] of secretRows) {
 		if (row.value !== undefined && !row.processEnv && row.grants.includes(componentName)) names.add(name);
 	}
+	names.delete('subscribe'); // reserved for the method — never surfaced as a value key
 	return [...names];
 }
 
@@ -664,7 +746,7 @@ export function getSecretsForComponent(componentName: string): SecretsView {
 				// reserved method (it is then unreadable via dot/bracket access — an accepted #1776 tradeoff).
 				if (!warnedSubscribeShadow.has(componentName)) {
 					warnedSubscribeShadow.add(componentName);
-					if (currentSecretValue(componentName, 'subscribe') !== undefined) {
+					if (hasRawSecretNamed(componentName, 'subscribe')) {
 						logger.warn(
 							`Component '${componentName}' has a secret named 'subscribe'; it is shadowed by the reserved secrets.subscribe() method and is not readable through the secrets accessor`
 						);
@@ -681,8 +763,9 @@ export function getSecretsForComponent(componentName: string): SecretsView {
 			return currentSecretValue(componentName, property) !== undefined;
 		},
 		ownKeys() {
-			// `subscribe` is intentionally omitted (non-enumerable), so spread/Object.keys never surface it.
-			return currentSecretNames(componentName);
+			// Include `subscribe` so own-property reflection is consistent (getOwnPropertyDescriptor
+			// reports it); it is non-enumerable, so spread/Object.keys still skip it.
+			return [...currentSecretNames(componentName), 'subscribe'];
 		},
 		getOwnPropertyDescriptor(_target, property) {
 			if (property === 'subscribe') {

--- a/unitTests/components/componentSecrets.test.js
+++ b/unitTests/components/componentSecrets.test.js
@@ -25,6 +25,7 @@ const {
 	runWithComponentBinding,
 	secrets,
 	resetComponentSecrets,
+	closeComponentSubscriptions,
 } = require('#src/components/componentSecrets');
 const { databases } = require('#src/resources/databases');
 const terms = require('#src/utility/hdbTerms');
@@ -52,15 +53,35 @@ function seal(plaintext) {
 	return PREFIX + encryptEnvelope(plaintext, publicKey, fp);
 }
 
-// Minimal mock table: rows keyed by name with the search() subset materialization uses.
+// Minimal mock table: rows keyed by name with the search() subset materialization uses, plus the
+// get()/subscribe() surface the live change watcher (#1776) needs. `emit()` drives the captured
+// subscription listener the way a committed put/delete would.
 function installMockSecretTable() {
 	const rows = new Map();
+	let listener;
 	const mock = {
 		rows,
 		search() {
 			return (async function* () {
 				yield* rows.values();
 			})();
+		},
+		async get(name) {
+			return rows.get(name) ?? null;
+		},
+		async subscribe(request) {
+			listener = request?.listener;
+			return { emit() {}, end() {} };
+		},
+		// Simulate a committed change to `name`: `record === null` is a delete.
+		emit(name, record) {
+			if (record) rows.set(name, record);
+			else rows.delete(name);
+			listener?.({ id: name, type: record ? 'put' : 'delete', value: record ?? null });
+		},
+		// Simulate a base-copy reload marker (the whole table was reseeded; no per-row events).
+		emitReload() {
+			listener?.({ id: null, type: 'reload', value: null });
 		},
 	};
 	if (!databases.system) databases.system = {};
@@ -389,7 +410,13 @@ describe('componentSecrets', () => {
 			const view = getSecretsForComponent('app-a');
 			assert.deepEqual(Object.keys(view), ['CS_SCOPED']);
 			assert.deepEqual({ ...view }, { CS_SCOPED: 's-value' });
-			assert.equal(Object.isFrozen(view), true);
+			// The live view is read-only (a Proxy, not a frozen object — frozen would preclude live values).
+			assert.throws(() => {
+				view.CS_SCOPED = 'nope';
+			}, TypeError);
+			assert.throws(() => {
+				delete view.CS_SCOPED;
+			}, TypeError);
 		});
 
 		it('a granted scoped row wins over an env var of the same name', async () => {
@@ -535,6 +562,234 @@ export const afterTopLevelAwait = secrets.CS_SCOPED;
 			await runWithComponentBinding('app-a', async () => {
 				assert.deepEqual(Object.keys(secrets), ['CS_SCOPED']); // still enumerable afterward
 			});
+		});
+	});
+
+	describe('live change subscription (secrets.subscribe, #1776)', () => {
+		// The initial value is served synchronously from the live snapshot, so tests seed it via
+		// materializeGlobalSecrets() (which also starts the watcher on the mock).
+		it('yields the current value then each subsequent change for a granted scoped secret', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['app']));
+			await materializeGlobalSecrets();
+			const iter = getSecretsForComponent('app').subscribe('CS_SCOPED');
+			assert.equal((await iter.next()).value, 'v1'); // current value first
+			table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v2', ['app']));
+			assert.equal((await iter.next()).value, 'v2');
+			table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v3', ['app']));
+			assert.equal((await iter.next()).value, 'v3');
+			await iter.return();
+		});
+
+		it('yields undefined (not a close) when the grant is revoked, and resumes on re-grant', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['app']));
+			await materializeGlobalSecrets();
+			const iter = getSecretsForComponent('app').subscribe('CS_SCOPED');
+			assert.equal((await iter.next()).value, 'v1');
+			table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v1', [])); // grant removed → access lost
+			const revoked = await iter.next();
+			assert.equal(revoked.done, false); // stream stays open
+			assert.equal(revoked.value, undefined); // value is now absent
+			table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v2', ['app'])); // re-granted with a new value
+			assert.equal((await iter.next()).value, 'v2'); // same iterator, no re-subscribe
+			await iter.return();
+		});
+
+		it('yields undefined on delete and resumes with the new value on re-add (no restart)', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['app']));
+			await materializeGlobalSecrets();
+			const iter = getSecretsForComponent('app').subscribe('CS_SCOPED');
+			assert.equal((await iter.next()).value, 'v1');
+			table.mock.emit('CS_SCOPED', null); // deleted
+			assert.equal((await iter.next()).value, undefined);
+			table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v2', ['app'])); // re-added
+			assert.equal((await iter.next()).value, 'v2');
+			await iter.return();
+		});
+
+		it('yields undefined up front for a secret the component cannot currently read', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['other-app']));
+			await materializeGlobalSecrets();
+			const iter = getSecretsForComponent('app').subscribe('CS_SCOPED');
+			const first = await iter.next();
+			assert.equal(first.done, false);
+			assert.equal(first.value, undefined);
+			await iter.return();
+		});
+
+		it('does not re-emit an unchanged value', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['app']));
+			await materializeGlobalSecrets();
+			const iter = getSecretsForComponent('app').subscribe('CS_SCOPED');
+			assert.equal((await iter.next()).value, 'v1');
+			const pending = iter.next();
+			table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v1', ['app'])); // same value → suppressed
+			table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v2', ['app'])); // real change
+			assert.equal((await pending).value, 'v2'); // never saw a duplicate v1
+			await iter.return();
+		});
+
+		it('never widens access: silent (undefined) until this component is granted, then resumes', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['other-app']));
+			await materializeGlobalSecrets();
+			const iter = getSecretsForComponent('app').subscribe('CS_SCOPED');
+			assert.equal((await iter.next()).value, undefined); // not granted to app → no value
+			table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v2', ['other-app'])); // change for another app only
+			table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v2', ['other-app', 'app'])); // now granted to app
+			assert.equal((await iter.next()).value, 'v2'); // the change for another app was never delivered
+			await iter.return();
+		});
+
+		it('does not leak a globally-materialized value to an undeclared, ungranted component', async () => {
+			// CS_GLOBAL is materialized into process.env, but app-b neither declares nor is granted it.
+			table.mock.rows.set('CS_GLOBAL', envRow('CS_GLOBAL', 'g1'));
+			await materializeGlobalSecrets();
+			assert.equal(process.env.CS_GLOBAL, 'g1'); // present in process.env
+			const iter = getSecretsForComponent('app-b').subscribe('CS_GLOBAL');
+			assert.equal((await iter.next()).value, undefined); // not visible to app-b (no ungated env fallback)
+			await iter.return();
+		});
+
+		it('drops a queued value on revoke (no stale plaintext delivered after access loss)', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['app']));
+			await materializeGlobalSecrets();
+			const iter = getSecretsForComponent('app').subscribe('CS_SCOPED');
+			assert.equal((await iter.next()).value, 'v1');
+			// No consumer parked: v2 is queued, then a revoke coalesces over it before it is read.
+			table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v2', ['app'])); // queued
+			table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v2', [])); // revoked before consume
+			assert.equal((await iter.next()).value, undefined); // stale v2 dropped; only the revoke is seen
+			await iter.return();
+		});
+
+		it('does not expose a queued value after the stream is closed', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['app']));
+			await materializeGlobalSecrets();
+			const iter = getSecretsForComponent('app').subscribe('CS_SCOPED');
+			assert.equal((await iter.next()).value, 'v1');
+			table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v2', ['app'])); // queued, no waiter
+			await iter.return(); // close: drops the queued plaintext
+			assert.equal((await iter.next()).done, true); // not v2
+		});
+
+		it('settles concurrent next() calls independently', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['app']));
+			await materializeGlobalSecrets();
+			const iter = getSecretsForComponent('app').subscribe('CS_SCOPED');
+			assert.equal((await iter.next()).value, 'v1');
+			const a = iter.next();
+			const b = iter.next(); // second concurrent waiter must not orphan the first
+			table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v2', ['app']));
+			assert.equal((await a).value, 'v2'); // first waiter settles (would hang if overwritten)
+			await iter.return(); // closes; remaining waiter settles as done
+			assert.equal((await b).done, true);
+		});
+
+		it('delivers a declared global secret from process.env (reload-only tier)', async () => {
+			table.mock.rows.set('CS_GLOBAL', envRow('CS_GLOBAL', 'g1'));
+			await materializeGlobalSecrets();
+			processComponentEnv('app', { CS_GLOBAL: { required: true } });
+			const iter = getSecretsForComponent('app').subscribe('CS_GLOBAL');
+			assert.equal((await iter.next()).value, 'g1'); // current process.env value
+			table.mock.emit('CS_GLOBAL', envRow('CS_GLOBAL', 'g2'));
+			assert.equal(process.env.CS_GLOBAL, 'g1'); // global tier is not re-mutated live
+			await iter.return();
+		});
+
+		it('exposes subscribe as a reserved, non-enumerable method on the view and the proxy', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['app']));
+			await materializeGlobalSecrets();
+			const view = getSecretsForComponent('app');
+			assert.equal(typeof view.subscribe, 'function');
+			assert.ok(!Object.keys(view).includes('subscribe')); // skipped by Object.keys/spread
+			assert.equal(Object.getOwnPropertyDescriptor(view, 'subscribe').enumerable, false);
+			await runWithComponentBinding('app', () => {
+				assert.equal(typeof secrets.subscribe, 'function');
+				assert.deepEqual(Object.keys(secrets), ['CS_SCOPED']); // subscribe not enumerated
+			});
+		});
+
+		it('with no store, still delivers a declared process.env value (accessor-equivalent)', async () => {
+			table.restore();
+			delete databases.system[SECRET_TABLE];
+			process.env.CS_DECLARED = 'from-env';
+			processComponentEnv('app', { CS_DECLARED: { required: false } });
+			const iter = getSecretsForComponent('app').subscribe('CS_DECLARED');
+			assert.equal((await iter.next()).value, 'from-env'); // readable even with no store
+			await iter.return();
+		});
+
+		it('closeComponentSubscriptions ends the streams a component opened', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['app']));
+			await materializeGlobalSecrets();
+			const iter = getSecretsForComponent('app').subscribe('CS_SCOPED');
+			assert.equal((await iter.next()).value, 'v1');
+			closeComponentSubscriptions('other-app'); // unrelated component: no effect
+			const stillPending = iter.next();
+			closeComponentSubscriptions('app');
+			assert.equal((await stillPending).done, true);
+		});
+	});
+
+	describe('live accessor (scoped tier reflects changes without reload, #1776)', () => {
+		it('a scoped secret value change is reflected by a fresh secrets read', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['app']));
+			await materializeGlobalSecrets(); // seeds the snapshot and starts the watcher
+			assert.equal(getSecretsForComponent('app').CS_SCOPED, 'v1');
+			table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v2', ['app']));
+			assert.equal(getSecretsForComponent('app').CS_SCOPED, 'v2'); // live, no reload
+		});
+
+		it('is live through the context-bound process-wide secrets proxy too', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['app']));
+			await materializeGlobalSecrets();
+			await runWithComponentBinding('app', async () => {
+				assert.equal(secrets.CS_SCOPED, 'v1');
+				table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v2', ['app']));
+				assert.equal(secrets.CS_SCOPED, 'v2');
+			});
+		});
+
+		it('a revoked grant removes the value from the accessor; a re-grant restores it', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['app']));
+			await materializeGlobalSecrets();
+			assert.equal(getSecretsForComponent('app').CS_SCOPED, 'v1');
+			table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v1', [])); // revoked
+			assert.equal(getSecretsForComponent('app').CS_SCOPED, undefined);
+			table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v1', ['app'])); // re-granted
+			assert.equal(getSecretsForComponent('app').CS_SCOPED, 'v1');
+		});
+
+		it('a global (processEnv) secret change stays reload-only in the accessor and process.env', async () => {
+			table.mock.rows.set('CS_GLOBAL', envRow('CS_GLOBAL', 'g1'));
+			await materializeGlobalSecrets();
+			processComponentEnv('app', { CS_GLOBAL: { required: true } });
+			assert.equal(getSecretsForComponent('app').CS_GLOBAL, 'g1');
+			table.mock.emit('CS_GLOBAL', envRow('CS_GLOBAL', 'g2'));
+			assert.equal(getSecretsForComponent('app').CS_GLOBAL, 'g1'); // unchanged until reload
+			assert.equal(process.env.CS_GLOBAL, 'g1');
+		});
+
+		it('a retained view reference reflects live changes (Proxy, not a captured snapshot)', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['app']));
+			await materializeGlobalSecrets();
+			const view = getSecretsForComponent('app'); // capture once (mirrors vm/compartment injection)
+			assert.equal(view.CS_SCOPED, 'v1');
+			table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v2', ['app']));
+			assert.equal(view.CS_SCOPED, 'v2'); // same object, live
+		});
+
+		it('re-scans on a base-copy reload marker (imports new rows, drops removed ones)', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['app']));
+			table.mock.rows.set('CS_GLOBAL', row('CS_GLOBAL', 'gone', ['app']));
+			await materializeGlobalSecrets();
+			assert.equal(getSecretsForComponent('app').CS_SCOPED, 'v1');
+			// Base copy reseeds the table wholesale and emits only a reload marker (no per-row events).
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v2', ['app']));
+			table.mock.rows.delete('CS_GLOBAL');
+			table.mock.emitReload();
+			await new Promise((resolve) => setImmediate(resolve)); // the re-scan is async
+			assert.equal(getSecretsForComponent('app').CS_SCOPED, 'v2'); // updated
+			assert.equal(getSecretsForComponent('app').CS_GLOBAL, undefined); // removed
 		});
 	});
 });

--- a/unitTests/components/componentSecrets.test.js
+++ b/unitTests/components/componentSecrets.test.js
@@ -61,17 +61,34 @@ function installMockSecretTable() {
 	let listener;
 	const mock = {
 		rows,
+		subscribeCount: 0,
+		// Optional async hook invoked between rows during a scan, so a test can inject a concurrent change
+		// mid-scan (exercises the stale-rescan retry guard).
+		scanHook: null,
 		search() {
+			// Stable snapshot at scan start, like a real table.search — a mid-scan mutation to `rows` is
+			// NOT reflected in this scan's yields.
+			const snapshot = [...rows.values()];
+			const hook = mock.scanHook;
 			return (async function* () {
-				yield* rows.values();
+				for (const record of snapshot) {
+					yield record;
+					if (hook) await hook();
+				}
 			})();
 		},
 		async get(name) {
 			return rows.get(name) ?? null;
 		},
 		async subscribe(request) {
+			mock.subscribeCount++;
 			listener = request?.listener;
-			return { emit() {}, end() {} };
+			return {
+				emit() {},
+				end() {
+					if (listener === request?.listener) listener = undefined;
+				},
+			};
 		},
 		// Simulate a committed change to `name`: `record === null` is a delete.
 		emit(name, record) {
@@ -82,6 +99,10 @@ function installMockSecretTable() {
 		// Simulate a base-copy reload marker (the whole table was reseeded; no per-row events).
 		emitReload() {
 			listener?.({ id: null, type: 'reload', value: null });
+		},
+		// Simulate Table.subscribe surfacing an async replay failure through the listener.
+		emitError(error) {
+			listener?.(error);
 		},
 	};
 	if (!databases.system) databases.system = {};
@@ -790,6 +811,77 @@ export const afterTopLevelAwait = secrets.CS_SCOPED;
 			await new Promise((resolve) => setImmediate(resolve)); // the re-scan is async
 			assert.equal(getSecretsForComponent('app').CS_SCOPED, 'v2'); // updated
 			assert.equal(getSecretsForComponent('app').CS_GLOBAL, undefined); // removed
+		});
+	});
+
+	describe('hardening (review findings, #1776)', () => {
+		it('a stale rescan cannot re-authorize a secret revoked while it ran', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['app']));
+			await materializeGlobalSecrets();
+			assert.equal(getSecretsForComponent('app').CS_SCOPED, 'v1');
+			// Revoke the grant mid-scan: the scan's stable snapshot still shows it granted, but the retry
+			// guard must re-scan and end up with the revoked state rather than clobbering the live update.
+			table.mock.scanHook = async () => {
+				table.mock.scanHook = null; // fire once
+				table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v1', [])); // revoke lands during the scan
+			};
+			await materializeGlobalSecrets();
+			assert.equal(getSecretsForComponent('app').CS_SCOPED, undefined); // NOT re-authorized
+		});
+
+		it('a secret named "subscribe" is not readable via the accessor or subscribe (reserved)', async () => {
+			table.mock.rows.set('subscribe', row('subscribe', 'plaintext', ['app']));
+			await materializeGlobalSecrets();
+			const view = getSecretsForComponent('app');
+			assert.equal(typeof view.subscribe, 'function'); // the reserved method, not the value
+			assert.ok(!Object.keys(view).includes('subscribe'));
+			const iter = view.subscribe('subscribe');
+			assert.equal((await iter.next()).value, undefined); // never leaks the plaintext
+			await iter.return();
+		});
+
+		it('subscribe is an own, non-enumerable key (consistent reflection)', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['app']));
+			await materializeGlobalSecrets();
+			const view = getSecretsForComponent('app');
+			assert.ok(Reflect.ownKeys(view).includes('subscribe')); // present for reflection
+			assert.ok(Object.hasOwn(view, 'subscribe'));
+			assert.ok(!Object.keys(view).includes('subscribe')); // but non-enumerable
+		});
+
+		it('a reload marker re-delivers undefined to a subscriber whose secret was removed', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['app']));
+			await materializeGlobalSecrets();
+			const iter = getSecretsForComponent('app').subscribe('CS_SCOPED');
+			assert.equal((await iter.next()).value, 'v1');
+			table.mock.rows.delete('CS_SCOPED'); // base copy removed it
+			table.mock.emitReload();
+			assert.equal((await iter.next()).value, undefined); // stream re-dispatched, not left stale
+			await iter.return();
+		});
+
+		it('a reload marker does not re-materialize the global tier into process.env', async () => {
+			table.mock.rows.set('CS_GLOBAL', envRow('CS_GLOBAL', 'g1'));
+			await materializeGlobalSecrets();
+			assert.equal(process.env.CS_GLOBAL, 'g1');
+			table.mock.rows.set('CS_GLOBAL', envRow('CS_GLOBAL', 'g2')); // changed at the source
+			table.mock.emitReload();
+			await new Promise((resolve) => setImmediate(resolve));
+			assert.equal(process.env.CS_GLOBAL, 'g1'); // reload-only: not re-mutated under running code
+		});
+
+		it('restarts the watcher when the subscription surfaces an error through the listener', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['app']));
+			await materializeGlobalSecrets();
+			const before = table.mock.subscribeCount;
+			table.mock.emitError(new Error('replay failed')); // resets the watcher memo
+			const iter = getSecretsForComponent('app').subscribe('CS_SCOPED');
+			assert.equal((await iter.next()).value, 'v1'); // initial from the snapshot
+			await new Promise((resolve) => setImmediate(resolve)); // let ensureSecretWatcher re-attach
+			assert.ok(table.mock.subscribeCount > before, 're-subscribed after the error');
+			table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v2', ['app'])); // live changes flow again
+			assert.equal((await iter.next()).value, 'v2');
+			await iter.return();
 		});
 	});
 });

--- a/unitTests/components/componentSecrets.test.js
+++ b/unitTests/components/componentSecrets.test.js
@@ -26,6 +26,8 @@ const {
 	secrets,
 	resetComponentSecrets,
 	closeComponentSubscriptions,
+	retainComponentSubscriptions,
+	releaseComponentSubscriptions,
 } = require('#src/components/componentSecrets');
 const { databases } = require('#src/resources/databases');
 const terms = require('#src/utility/hdbTerms');
@@ -868,6 +870,21 @@ export const afterTopLevelAwait = secrets.CS_SCOPED;
 			table.mock.emitReload();
 			await new Promise((resolve) => setImmediate(resolve));
 			assert.equal(process.env.CS_GLOBAL, 'g1'); // reload-only: not re-mutated under running code
+		});
+
+		it('reference-counts teardown by identity: a sibling scope closing does not kill live streams', async () => {
+			table.mock.rows.set('CS_SCOPED', row('CS_SCOPED', 'v1', ['app']));
+			await materializeGlobalSecrets();
+			retainComponentSubscriptions('app'); // the running app scope
+			retainComponentSubscriptions('app'); // a throwaway deploy-validation scope, same identity
+			const iter = getSecretsForComponent('app').subscribe('CS_SCOPED');
+			assert.equal((await iter.next()).value, 'v1');
+			releaseComponentSubscriptions('app'); // validation scope closes → must NOT tear down
+			const stillOpen = iter.next(); // parks; the stream is still live
+			table.mock.emit('CS_SCOPED', row('CS_SCOPED', 'v2', ['app']));
+			assert.equal((await stillOpen).value, 'v2'); // still delivering
+			releaseComponentSubscriptions('app'); // last holder (the app) closes → now tear down
+			assert.equal((await iter.next()).done, true);
 		});
 
 		it('restarts the watcher when the subscription surfaces an error through the listener', async () => {


### PR DESCRIPTION
Implements #1776 — live secret change detection so an app can hot-swap a rotated secret without a restart.

## What it adds
- **`secrets.subscribe(name)`** — a Resource-idiomatic async iterable that yields a secret's current value, then a new value on every change:
  ```js
  import { secrets } from 'harper';
  let stripe;
  for await (const key of secrets.subscribe('STRIPE_KEY')) stripe = Stripe(key);
  ```
- **Live scoped-tier accessor** — `secrets.NAME` now reflects the latest value on a fresh read (no reload). A `const v = scope.secrets` reference or a vm/compartment-injected view is live too; only a destructured `const { NAME } = secrets` is a point-in-time copy.

## How it works
The store (`system.hdb_secret`) is a real replicated table, so this is a decrypted, grant-filtered **projection over that table's own change stream** — no bespoke event bus. One shared watcher keeps the `secretRows` snapshot live and fans changes out to subscribers; the per-component view is a live `Proxy`.

Authority is re-evaluated **per event** through the same resolver as the read accessor, so a revoke/delete resolves to `undefined` (no plaintext retained) while the stream stays **open** — a re-grant/re-add resumes on the same iterator (no restart).

### Tier semantics (deliberate)
| | scoped tier (`grants`) | global tier (`processEnv`) |
|---|---|---|
| `secrets.NAME` accessor | **live** | reload-only |
| `secrets.subscribe('NAME')` | **live** | current value, reload-only |
| `process.env.NAME` | n/a | never re-mutated under running code |

The global tier stays reload-only on purpose: child processes have inherited `process.env` and the "pre-existing real env wins" precedence must hold.

## Where to look
- `resolveSubscribedSecret` mirrors the read accessor exactly — the `process.env` fallback is **gated on declaration**, so an undeclared/ungranted component can't read a globally-materialized value; `subscribe` is a reserved name and never resolves to a secret value.
- `SecretChangeStream` — single-slot coalescing buffer + FIFO waiter queue; `#close()` purges the queued value and `lastValue` so no plaintext is readable after revoke/close.
- `getSecretsForComponent` returns a live `Proxy` (read-only, null-proto; `subscribe` is a consistent own non-enumerable key) — worth a look at the trap invariants.
- `scanIntoSecretRows` — the watcher attaches **before** the scan and the scan **retries** if a change lands during it, so a stable-snapshot scan can't clobber a newer live update.
- `onSecretEvent` — restarts the watcher on an error delivered through the listener, and re-scans (without touching `process.env`) on a base-copy `reload` marker (base copies emit no per-row events — cf. harper-pro#495).

## Review
Two cross-model (Codex) rounds; the Gemini leg was unavailable both runs. The first round found a grant-bypass via an ungated `process.env` fallback and plaintext-retention paths; the second found scan/watcher races and reload/reserved-name gaps. **All are addressed in the commits** — flagging here only what remains for your judgment:

- **Scan/watcher race — residual window.** The retry guard closes the race down to a few microtasks between the scan's final read and the synchronous assignment (was: the entire scan duration). Bounded to `SCAN_RETRY_LIMIT` retries; heals on the next event. I did **not** add per-row version-vector merging — flag if you want it fully closed.
- **Subscription teardown granularity (resolved, noting the design).** `Scope.close()` teardown is **reference-counted per identity** (each Scope retains on construction, releases on close; streams end only when the last holder releases). This is deliberately not per-`Scope`-instance — `secrets.subscribe` is called by app code through the identity-shared view with no `Scope` reference — but it correctly prevents a throwaway deploy-validation Scope from tearing down the running app's streams. Flagging the granularity choice in case you'd prefer instance-level keying via a threaded token.

## Testing
`unitTests/components/componentSecrets.test.js` covers the accessor, subscription lifecycle, revoke/delete→`undefined`→resume, grant-bypass prevention, plaintext-purge-on-close, concurrent `next()`, the stale-rescan retry, reload-marker re-dispatch + reload-only global tier, watcher restart on error, and the reserved-name guard.

🤖 Generated by KrAIs (Claude Opus 4.8). Not written by a human — please review accordingly.
