### PR TITLE
ci(review): explicit caller-job permissions on the Claude review caller

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -34,6 +34,22 @@ jobs:
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
     uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@9cf49d23cb046ecd6c87f3bba86dc3338d6998fb # main 2026-06-29 (#70 week-of-06-22 calibration + #71 prompt-ref tracking; on 1bbc562 = #67 + #69)
+    # Caller-side permissions at the calling-job level (NOT workflow-
+    # level — that placement caps the reusable's per-job grants below
+    # what they need and breaks the workflow at startup; see
+    # ai-review-prompts#39/#40). Union of what the reusable's authorize
+    # (`contents: read`) and review (`contents: read` + `pull-requests:
+    # write` + `id-token: write`) jobs declare. Without this block the
+    # grants are inherited from the repo's default-workflow-permissions
+    # setting instead (GitHub intersects the reusable's requests with
+    # the caller's ceiling — un-grantable scopes are silently dropped,
+    # and `pull-requests: write` survives only while the repo default
+    # is "write"). Explicit grants keep the caller independent of that
+    # setting, and match gemini-review.yml in this repo.
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (layer files + bash


### PR DESCRIPTION
One block: grant `contents: read` + `pull-requests: write` + `id-token: write` on the `review` calling job in `claude-review.yml` — the union of what the reusable's `authorize` and `review` jobs declare, matching `gemini-review.yml` in this repo (which has carried the block since it was added post ai-review-prompts#39/#40) and oauth's claude caller.

## Why

Without an explicit block the caller inherits the repo's default-workflow-permissions setting: GitHub silently intersects the reusable's per-job requests with that ceiling (verified on a live run — granted set was exactly `Contents: read, PullRequests: write`, with the requested `id-token: write` dropped). Reviews work today only because the repo default is "write"; flipping that setting to "read" would break review posting with unhelpful 403s. Explicit job-level grants remove the hidden dependency.

## Cross-references

- Surfaced by Barber AI review feedback on HarperFast/rocksdb-js#701 (fixed there in 2753ede1)
- Pattern now documented upstream: HarperFast/ai-review-prompts#74
- Addresses the `claude-review.yml` entry in #568 (the AI-review slice of that audit; `claude-mention.yml` / `claude-issue-to-pr.yml` remain)
- Mild overlap with #1759 (Sonnet 5 canary touches the adjacent `with:` block) — whichever merges second is a trivial rebase

Note: this PR edits the caller workflow, so its own Claude review check fails with the expected anti-tamper guard; clears on merge.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)