### PR TITLE
test(crud): poll for analytics-recording instead of a fixed sleep (deflake Node v24)

### DIFF
--- a/unitTests/resources/crud.test.js
+++ b/unitTests/resources/crud.test.js
@@ -126,7 +126,8 @@ describe('CRUD operations with the Resource API', () => {
 					conditions: [{ attribute: 'id', comparator: 'greater_than_equal', value: start }],
 				});
 				for await (let { metrics } of analyticsResults) {
-					const found = metrics.find((entry) => entry.metric === metric && entry.path === 'CRUDTable');
+					if (!Array.isArray(metrics)) continue;
+					const found = metrics.find((entry) => entry?.metric === metric && entry?.path === 'CRUDTable');
 					if (found) return found;
 				}
 			},

--- a/unitTests/resources/crud.test.js
+++ b/unitTests/resources/crud.test.js
@@ -6,6 +6,7 @@ const { transaction } = require('#src/resources/transaction');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { RequestTarget } = require('#src/resources/RequestTarget');
 const analytics = require('#src/resources/analytics/write');
+const { waitFor } = require('../waitFor.js');
 
 // might want to enable an iteration with NATS being assigned as a source
 describe('CRUD operations with the Resource API', () => {
@@ -117,6 +118,21 @@ describe('CRUD operations with the Resource API', () => {
 		});
 		registerTests();
 	});
+	async function waitForAnalyticsMetric(metric, start) {
+		return waitFor(
+			async () => {
+				if (!databases.system?.hdb_raw_analytics) return undefined;
+				const analyticsResults = await databases.system.hdb_raw_analytics.search({
+					conditions: [{ attribute: 'id', comparator: 'greater_than_equal', value: start }],
+				});
+				for await (let { metrics } of analyticsResults) {
+					const found = metrics.find((entry) => entry.metric === metric && entry.path === 'CRUDTable');
+					if (found) return found;
+				}
+			},
+			{ message: `${metric} was recorded in analytics` }
+		);
+	}
 	function registerTests() {
 		it('puts', async function () {
 			const start = Date.now();
@@ -137,31 +153,13 @@ describe('CRUD operations with the Resource API', () => {
 				nestedData: { id: 'some-id', name: 'nested name ' },
 			});
 			assert.equal((await CRUDTable.get('two')).name, 'Two');
-			await new Promise((resolve) => setTimeout(resolve, 100));
-			const analyticsResults = await databases.system.hdb_raw_analytics.search({
-				conditions: [{ attribute: 'id', comparator: 'greater_than_equal', value: start }],
-			});
-			let analyticRecorded;
-			for await (let { metrics } of analyticsResults) {
-				analyticRecorded = metrics.find(({ metric, path }) => metric === 'db-write' && path === 'CRUDTable');
-				if (analyticRecorded) break;
-			}
-			assert(analyticRecorded, 'db-write was recorded in analytics');
+			const analyticRecorded = await waitForAnalyticsMetric('db-write', start);
 			assert(analyticRecorded.mean > 2, 'db-write bytes count were recorded in analytics');
 		});
 		it('get is recorded in analytics', async function () {
 			const start = Date.now();
 			assert.equal((await CRUDTable.get('two')).name, 'Two');
-			await new Promise((resolve) => setTimeout(resolve, 100));
-			const analyticsResults = await databases.system.hdb_raw_analytics.search({
-				conditions: [{ attribute: 'id', comparator: 'greater_than_equal', value: start }],
-			});
-			let analyticRecorded;
-			for await (let { metrics } of analyticsResults) {
-				analyticRecorded = metrics.find(({ metric, path }) => metric === 'db-read' && path === 'CRUDTable');
-				if (analyticRecorded) break;
-			}
-			assert(analyticRecorded, 'db-read was recorded in analytics');
+			const analyticRecorded = await waitForAnalyticsMetric('db-read', start);
 			assert(analyticRecorded.mean > 20, 'db-read bytes count were recorded in analytics');
 		});
 		it('gets', async function () {


### PR DESCRIPTION
## Summary

`unitTests/resources/crud.test.js`'s "puts" and "get is recorded in analytics" tests slept a fixed 100ms and then asserted the corresponding write/read had already landed in `hdb_raw_analytics`. On Node v24 CI runners specifically (not v22/v26), the async analytics-flush pipeline occasionally takes longer than 100ms, so the assertion fired against an empty/incomplete result — a timing race in the test, not a functional break in analytics recording.

Replaces the fixed-sleep-then-assert with the existing `waitFor` poll-with-deadline helper (`unitTests/waitFor.js`, already used elsewhere, e.g. `caching.test.js`), deduped into a small `waitForAnalyticsMetric(metric, start)` helper shared by both assertions. Also guards against `databases.system` being transiently unpopulated the very first time these tests run in the suite — without the guard, the poll condition threw on its first synchronous check instead of retrying.

## Why

Recurring flake, always this same shape, always resolved by re-running the job — has never indicated a real product bug. Most recent occurrence: [run 29333666804, job 87087503643](https://github.com/HarperFast/harper/actions/runs/29333666804/job/87087503643). No tracking issue exists yet — found during routine CI triage, this PR is the tracker.

## Test notes

No changes to non-test source files. `unitTests/resources/crud.test.js` (35 tests) run clean, repeatedly, on Node v22.23.1, v24.10.0, and v26.2.0 locally; the full `unitTests/resources/**` suite (1090 tests) passes with the change in place.

---
Generated by Claude Sonnet 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)