### PR TITLE
Decrypt SSH deploy keys to a transient file for git operations

### DIFF
--- a/components/Application.ts
+++ b/components/Application.ts
@@ -10,6 +10,8 @@ import {
 	type GitCredentialSession,
 	type ResolvedGitCredential,
 } from './gitCredentialServer.ts';
+import { getSecretDecryptor } from '../resources/secretDecryptor.ts';
+import { ENV_ENCRYPTED_PREFIX } from '../utility/envFile.ts';
 
 import { basename, dirname, extname, join } from 'node:path';
 import {
@@ -29,7 +31,7 @@ import {
 import { spawn } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
-import { createReadStream, existsSync, readdirSync } from 'node:fs';
+import { createReadStream, existsSync } from 'node:fs';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { StringDecoder } from 'node:string_decoder';
@@ -1117,16 +1119,82 @@ export async function installApplications() {
 	await writeFile(harperApplicationLockPath, JSON.stringify(harperApplicationLock, null, 2), 'utf8');
 }
 
-function getGitSSHCommand() {
+/**
+ * Materialize the SSH deploy keys for the lifetime of a single git-over-SSH spawn.
+ *
+ * Keys are sealed at rest as `enc:v1:` envelopes (Harper Pro's `add_ssh_key`), but ssh needs a key
+ * *file*, so each key is decrypted into a fresh 0700 temp dir as a 0600 file and the ssh config is
+ * copied with its `IdentityFile` paths repointed at the transient copies. The caller removes the
+ * dir as soon as the spawn settles, so the plaintext never outlives the git invocation. Legacy
+ * plaintext keys (written before sealing, or on a node with no custody) are copied through
+ * unchanged, so this is a no-op for them beyond the temp dir.
+ *
+ * A key that cannot be decrypted — no custody registered on this node, an envelope sealed under a
+ * different cluster key, or a tampered envelope — is logged and skipped rather than failing the
+ * spawn: a deploy that doesn't need that key is unaffected, and one that does fails with the usual
+ * SSH auth error (see `isSSHAuthFailure`). No log or error message here carries key material or
+ * the envelope.
+ *
+ * @returns The `GIT_SSH_COMMAND` to use plus its cleanup, or undefined when no keys are configured.
+ */
+export async function materializeGitSSH(): Promise<{ command: string; cleanup: () => Promise<void> } | undefined> {
 	const rootDir = getConfigValue(CONFIG_PARAMS.ROOTPATH);
+	if (!rootDir) return; // config not initialized (e.g. an install-time spawn) — no ssh dir to read
 	const sshDir = join(rootDir, 'ssh');
-	if (existsSync(sshDir)) {
-		for (const file of readdirSync(sshDir)) {
-			if (file.includes('.key')) {
-				return `ssh -F ${join(sshDir, 'config')} -o UserKnownHostsFile=${join(sshDir, 'known_hosts')}`;
-			}
-		}
+	let sshDirEntries: string[];
+	try {
+		sshDirEntries = await readdir(sshDir);
+	} catch {
+		return; // no ssh dir on this node
 	}
+	const keyFiles = sshDirEntries.filter((entry) => entry.endsWith('.key'));
+	if (keyFiles.length === 0) return;
+
+	const tempDir = await mkdtemp(join(tmpdir(), 'harper-ssh-'));
+	const cleanup = async () => {
+		try {
+			await rm(tempDir, { recursive: true, force: true });
+		} catch (error) {
+			// never mask the caller's error (this runs from a finally) — a leaked temp dir is the
+			// lesser failure, and it holds only 0600 files in a 0700 dir
+			logger.warn?.(`Failed to remove transient ssh dir ${tempDir}:`, error);
+		}
+	};
+
+	try {
+		const decryptor = getSecretDecryptor();
+		for (const keyFile of keyFiles) {
+			const storedKey = await readFile(join(sshDir, keyFile), 'utf8');
+			let keyMaterial = storedKey;
+			if (storedKey.startsWith(ENV_ENCRYPTED_PREFIX)) {
+				if (!decryptor) {
+					logger.error?.(
+						`SSH key ${keyFile} is encrypted but no secret custody is registered on this node; skipping it`
+					);
+					continue;
+				}
+				try {
+					keyMaterial = decryptor(storedKey);
+				} catch (error) {
+					logger.error?.(`Failed to decrypt SSH key ${keyFile}: ${(error as Error).message}; skipping it`);
+					continue;
+				}
+			}
+			await writeFile(join(tempDir, keyFile), keyMaterial, { mode: 0o600 });
+		}
+		// The config's `IdentityFile` lines are absolute paths into the durable ssh dir; repoint
+		// them at the transient copies. known_hosts holds no secrets and stays where it is.
+		const sshConfig = await readFile(join(sshDir, 'config'), 'utf8').catch(() => '');
+		await writeFile(join(tempDir, 'config'), sshConfig.split(sshDir).join(tempDir), { mode: 0o600 });
+	} catch (error) {
+		await cleanup();
+		throw error;
+	}
+
+	return {
+		command: `ssh -F ${join(tempDir, 'config')} -o UserKnownHostsFile=${join(sshDir, 'known_hosts')}`,
+		cleanup,
+	};
 }
 
 // Normalize a registry to a full URL with a scheme and trailing slash, e.g.
@@ -1219,7 +1287,12 @@ function createLineSplitter(onLine: (line: string) => void): {
 	};
 }
 
-export function nonInteractiveSpawn(
+/**
+ * Run a command with the deploy's SSH key material materialized only for the duration of the
+ * spawn. The keys are decrypted to a transient 0700 dir (see `materializeGitSSH`) and removed as
+ * soon as the process settles — on success, failure, and timeout alike.
+ */
+export async function nonInteractiveSpawn(
 	applicationName: string,
 	command: string,
 	args: string[],
@@ -1229,6 +1302,35 @@ export function nonInteractiveSpawn(
 	npmUserconfigPath?: string,
 	gitCredentialEnv?: Record<string, string>
 ): Promise<{ stdout: string; stderr: string; code: number }> {
+	const gitSSH = await materializeGitSSH();
+	try {
+		return await spawnWithEnv(
+			applicationName,
+			command,
+			args,
+			cwd,
+			timeoutMs,
+			onLine,
+			npmUserconfigPath,
+			gitSSH?.command,
+			gitCredentialEnv
+		);
+	} finally {
+		await gitSSH?.cleanup();
+	}
+}
+
+function spawnWithEnv(
+	applicationName: string,
+	command: string,
+	args: string[],
+	cwd: string,
+	timeoutMs: number,
+	onLine: ((stream: 'stdout' | 'stderr', line: string) => void) | undefined,
+	npmUserconfigPath: string | undefined,
+	gitSSHCommand: string | undefined,
+	gitCredentialEnv: Record<string, string> | undefined
+): Promise<{ stdout: string; stderr: string; code: number }> {
 	return new Promise((resolve, reject) => {
 		logger
 			.loggerWithTag(`${applicationName}:spawn:${command}`)
@@ -1236,7 +1338,6 @@ export function nonInteractiveSpawn(
 
 		const env = { ...process.env };
 
-		const gitSSHCommand = getGitSSHCommand();
 		if (gitSSHCommand) {
 			env.GIT_SSH_COMMAND = gitSSHCommand;
 		}

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -1147,7 +1147,9 @@ export function rewriteSshConfigPaths(
 	const sshDirPattern = sshDir.split(/[\\/]/).map(escapeRegExp).join(sepClass) + `(?=${sepClass}|$)`;
 	const sshDirRegex = new RegExp(sshDirPattern, platform === 'win32' ? 'gi' : 'g');
 	const normalizedTempDir = platform === 'win32' ? tempDir.replace(/\\/g, '/') : tempDir;
-	return sshConfig.replace(sshDirRegex, normalizedTempDir);
+	// Function replacer: a string replacer would treat `$` sequences in normalizedTempDir
+	// (e.g. `$&`, `$1`) as replacement patterns instead of literal characters.
+	return sshConfig.replace(sshDirRegex, () => normalizedTempDir);
 }
 
 /**

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -1120,6 +1120,37 @@ export async function installApplications() {
 }
 
 /**
+ * Rewrite every occurrence of `sshDir` in an ssh `config` file's contents to `tempDir`, matching
+ * either slash direction per path segment (and case-insensitively on `win32`) rather than relying
+ * on the two strings being byte-identical.
+ *
+ * A plain string substitution (`sshConfig.split(sshDir).join(tempDir)`) doesn't hold
+ * cross-platform: ssh config files are frequently forward-slash even on Windows, while `sshDir`
+ * (built via `path.join`) is backslash there, so the split would silently never match; Windows
+ * paths are also case-insensitive. `sshDir` is split into segments on either separator *before*
+ * escaping, so escaping a regex-special character within a segment (e.g. a literal paren in a
+ * directory name) can't interact with the separator substitution. A trailing lookahead keeps
+ * `sshDir` from partial-matching a sibling directory whose name happens to start with it (e.g.
+ * `.../ssh` vs `.../sshhh`).
+ *
+ * Exported only so unit tests can pin the Windows-path behavior (mixed slash direction, case
+ * insensitivity) directly via the `platform` override, without needing to run on Windows.
+ */
+export function rewriteSshConfigPaths(
+	sshConfig: string,
+	sshDir: string,
+	tempDir: string,
+	platform: string = process.platform
+): string {
+	const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	const sepClass = '[\\\\/]';
+	const sshDirPattern = sshDir.split(/[\\/]/).map(escapeRegExp).join(sepClass) + `(?=${sepClass}|$)`;
+	const sshDirRegex = new RegExp(sshDirPattern, platform === 'win32' ? 'gi' : 'g');
+	const normalizedTempDir = platform === 'win32' ? tempDir.replace(/\\/g, '/') : tempDir;
+	return sshConfig.replace(sshDirRegex, normalizedTempDir);
+}
+
+/**
  * Materialize the SSH deploy keys for the lifetime of a single git-over-SSH spawn.
  *
  * Keys are sealed at rest as `enc:v1:` envelopes (Harper Pro's `add_ssh_key`), but ssh needs a key
@@ -1141,13 +1172,14 @@ export async function materializeGitSSH(): Promise<{ command: string; cleanup: (
 	const rootDir = getConfigValue(CONFIG_PARAMS.ROOTPATH);
 	if (!rootDir) return; // config not initialized (e.g. an install-time spawn) — no ssh dir to read
 	const sshDir = join(rootDir, 'ssh');
-	let sshDirEntries: string[];
-	try {
-		sshDirEntries = await readdir(sshDir);
-	} catch {
-		return; // no ssh dir on this node
-	}
-	const keyFiles = sshDirEntries.filter((entry) => entry.endsWith('.key'));
+	// `withFileTypes` so a stray subdirectory in the ssh dir (e.g. one named `foo.key`) is filtered
+	// out here rather than reaching `readFile` below and throwing EISDIR, which would abort the
+	// whole spawn instead of just skipping that one entry.
+	const sshDirEntries = await readdir(sshDir, { withFileTypes: true }).catch(() => undefined);
+	if (!sshDirEntries) return; // no ssh dir on this node
+	const keyFiles = sshDirEntries
+		.filter((entry) => entry.isFile() && entry.name.endsWith('.key'))
+		.map((entry) => entry.name);
 	if (keyFiles.length === 0) return;
 
 	const tempDir = await mkdtemp(join(tmpdir(), 'harper-ssh-'));
@@ -1164,7 +1196,16 @@ export async function materializeGitSSH(): Promise<{ command: string; cleanup: (
 	try {
 		const decryptor = getSecretDecryptor();
 		for (const keyFile of keyFiles) {
-			const storedKey = await readFile(join(sshDir, keyFile), 'utf8');
+			let storedKey: string;
+			try {
+				storedKey = await readFile(join(sshDir, keyFile), 'utf8');
+			} catch (error) {
+				// Same fail-open policy as a decrypt failure below: a key that can't even be read
+				// (permission drift, deleted mid-scan by a concurrent add_ssh_key/rotation, a
+				// transient EIO) should drop that one key, not abort a spawn that may not need it.
+				logger.error?.(`Failed to read SSH key ${keyFile}: ${(error as Error).message}; skipping it`);
+				continue;
+			}
 			let keyMaterial = storedKey;
 			if (storedKey.startsWith(ENV_ENCRYPTED_PREFIX)) {
 				if (!decryptor) {
@@ -1185,7 +1226,8 @@ export async function materializeGitSSH(): Promise<{ command: string; cleanup: (
 		// The config's `IdentityFile` lines are absolute paths into the durable ssh dir; repoint
 		// them at the transient copies. known_hosts holds no secrets and stays where it is.
 		const sshConfig = await readFile(join(sshDir, 'config'), 'utf8').catch(() => '');
-		await writeFile(join(tempDir, 'config'), sshConfig.split(sshDir).join(tempDir), { mode: 0o600 });
+		const rewrittenConfig = rewriteSshConfigPaths(sshConfig, sshDir, tempDir);
+		await writeFile(join(tempDir, 'config'), rewrittenConfig, { mode: 0o600 });
 	} catch (error) {
 		await cleanup();
 		throw error;

--- a/unitTests/components/gitSSHMaterialization.test.js
+++ b/unitTests/components/gitSSHMaterialization.test.js
@@ -28,7 +28,7 @@ testUtils.preTestPrep();
 
 const env = require('#src/utility/environment/environmentManager');
 const terms = require('#src/utility/hdbTerms');
-const { materializeGitSSH, nonInteractiveSpawn } = require('#src/components/Application');
+const { materializeGitSSH, nonInteractiveSpawn, rewriteSshConfigPaths } = require('#src/components/Application');
 const secretDecryptor = require('#src/resources/secretDecryptor');
 const { encryptEnvelope, decryptEnvelope, fingerprintOf } = require('#src/utility/secretEnvelope');
 // CJS interop hands back the module namespace, which is the very object Application.ts's default
@@ -196,6 +196,56 @@ describe('materializeGitSSH', () => {
 		await materialized.cleanup();
 	});
 
+	it('skips a stray subdirectory in the ssh dir instead of throwing EISDIR', async () => {
+		writeSSHDir({ deploy: KEY_MATERIAL });
+		// A subdirectory that happens to end in `.key` used to reach `readFile` and throw EISDIR,
+		// aborting the whole materialize call (and therefore the whole spawn, including an
+		// unrelated npm install).
+		fs.mkdirSync(path.join(sshDir, 'nested.key'));
+
+		const materialized = await materializeGitSSH();
+		assert.ok(materialized, 'a stray subdirectory must not abort materialization');
+		const tempDir = path.dirname(materialized.command.match(/ssh -F (\S+)/)[1]);
+
+		assert.strictEqual(fs.readFileSync(path.join(tempDir, 'deploy.key'), 'utf8'), KEY_MATERIAL);
+		assert.ok(!fs.existsSync(path.join(tempDir, 'nested.key')), 'the directory entry must not be materialized');
+
+		await materialized.cleanup();
+	});
+
+	it('skips a key that cannot be read (permission drift) without aborting the whole materialize call', async function () {
+		if (typeof process.getuid === 'function' && process.getuid() === 0) {
+			// chmod-based permission denial is a no-op for root; there's no reliable way to force a
+			// read failure in that case, so skip rather than false-pass or false-fail.
+			this.skip();
+			return;
+		}
+
+		writeSSHDir({ readable: KEY_MATERIAL, unreadable: KEY_MATERIAL });
+		const unreadableKeyPath = path.join(sshDir, 'unreadable.key');
+		fs.chmodSync(unreadableKeyPath, 0o000);
+
+		try {
+			const materialized = await materializeGitSSH();
+			assert.ok(materialized, 'an unreadable key must not abort materialization of the others');
+			const tempDir = path.dirname(materialized.command.match(/ssh -F (\S+)/)[1]);
+
+			// the readable key still materializes; only the unreadable one drops out
+			assert.strictEqual(fs.readFileSync(path.join(tempDir, 'readable.key'), 'utf8'), KEY_MATERIAL);
+			assert.ok(!fs.existsSync(path.join(tempDir, 'unreadable.key')));
+			assert.ok(
+				logged.some((line) => line.includes('unreadable.key') && line.includes('Failed to read')),
+				`expected a read failure log for the unreadable key, got: ${JSON.stringify(logged)}`
+			);
+			for (const line of logged)
+				assert.ok(!line.includes('OPENSSH PRIVATE KEY'), 'a log must never carry key material');
+
+			await materialized.cleanup();
+		} finally {
+			fs.chmodSync(unreadableKeyPath, 0o600); // restore so afterEach's rmSync can clean up
+		}
+	});
+
 	it('skips a tampered envelope (GCM auth tag failure)', async () => {
 		secretDecryptor.registerSecretDecryptor(decryptorFor(keypair));
 		const envelope = seal(KEY_MATERIAL);
@@ -211,6 +261,68 @@ describe('materializeGitSSH', () => {
 		assert.ok(logged.some((line) => line.includes('deploy.key')));
 
 		await materialized.cleanup();
+	});
+});
+
+describe('rewriteSshConfigPaths (cross-platform IdentityFile rewrite)', () => {
+	// materializeGitSSH always calls this with process.platform, but the platform param lets us
+	// pin Windows-shaped behavior (mixed slash direction, drive-letter case-insensitivity) from
+	// any CI host — this is exactly the kind of platform-specific logic that's easy to "fix"
+	// without ever actually exercising the Windows branch.
+
+	it('rewrites an exact-match posix path (existing behavior preserved)', () => {
+		const config = 'Host gh\n\tIdentityFile /data/hdb/ssh/deploy.key\n\tIdentitiesOnly yes';
+		const rewritten = rewriteSshConfigPaths(config, '/data/hdb/ssh', '/tmp/harper-ssh-abc', 'darwin');
+		assert.strictEqual(rewritten, 'Host gh\n\tIdentityFile /tmp/harper-ssh-abc/deploy.key\n\tIdentitiesOnly yes');
+	});
+
+	it('rewrites when the config uses forward slashes but sshDir (path.join on win32) uses backslashes', () => {
+		const sshDir = 'C:\\Users\\svc\\hdb\\ssh';
+		const tempDir = 'C:\\Users\\svc\\AppData\\Local\\Temp\\harper-ssh-xyz';
+		const config = 'Host gh\n\tIdentityFile C:/Users/svc/hdb/ssh/deploy.key\n';
+		const rewritten = rewriteSshConfigPaths(config, sshDir, tempDir, 'win32');
+		assert.strictEqual(
+			rewritten,
+			'Host gh\n\tIdentityFile C:/Users/svc/AppData/Local/Temp/harper-ssh-xyz/deploy.key\n'
+		);
+	});
+
+	it('is case-insensitive on win32 for drive-letter casing', () => {
+		const sshDir = 'C:\\Users\\svc\\hdb\\ssh';
+		const tempDir = 'C:\\Users\\svc\\AppData\\Local\\Temp\\harper-ssh-xyz';
+		const config = 'Host gh\n\tIdentityFile c:\\Users\\svc\\hdb\\ssh\\deploy.key\n';
+		const rewritten = rewriteSshConfigPaths(config, sshDir, tempDir, 'win32');
+		assert.ok(
+			rewritten.includes('C:/Users/svc/AppData/Local/Temp/harper-ssh-xyz'),
+			`expected the lowercase drive-letter path to still be rewritten, got: ${rewritten}`
+		);
+		assert.ok(!rewritten.includes('hdb'), 'the durable ssh dir must not remain in the rewritten config');
+	});
+
+	it('does not case-fold on non-Windows platforms', () => {
+		// A differently-cased sshDir must NOT match on posix — case sensitivity there is real.
+		const config = 'IdentityFile /Data/HDB/ssh/deploy.key\n';
+		const rewritten = rewriteSshConfigPaths(config, '/data/hdb/ssh', '/tmp/harper-ssh-abc', 'linux');
+		assert.strictEqual(rewritten, config, 'a differently-cased path must be left untouched on posix');
+	});
+
+	it('does not partial-match a sibling directory whose name starts with sshDir', () => {
+		const config = 'IdentityFile /data/hdb/sshhh/other.key\n';
+		const rewritten = rewriteSshConfigPaths(config, '/data/hdb/ssh', '/tmp/harper-ssh-abc', 'darwin');
+		assert.strictEqual(rewritten, config, 'a sibling directory like .../sshhh must not be touched');
+	});
+
+	it('escapes regex-special characters within a path segment (e.g. parens) without breaking separator matching', () => {
+		const sshDir = '/data/hdb (prod)/ssh';
+		const config = 'IdentityFile /data/hdb (prod)/ssh/deploy.key\n';
+		const rewritten = rewriteSshConfigPaths(config, sshDir, '/tmp/harper-ssh-abc', 'linux');
+		assert.strictEqual(rewritten, 'IdentityFile /tmp/harper-ssh-abc/deploy.key\n');
+	});
+
+	it('rewrites every IdentityFile occurrence (global match)', () => {
+		const config = 'IdentityFile /data/hdb/ssh/a.key\nIdentityFile /data/hdb/ssh/b.key\n';
+		const rewritten = rewriteSshConfigPaths(config, '/data/hdb/ssh', '/tmp/harper-ssh-abc', 'darwin');
+		assert.strictEqual(rewritten, 'IdentityFile /tmp/harper-ssh-abc/a.key\nIdentityFile /tmp/harper-ssh-abc/b.key\n');
 	});
 });
 

--- a/unitTests/components/gitSSHMaterialization.test.js
+++ b/unitTests/components/gitSSHMaterialization.test.js
@@ -324,6 +324,15 @@ describe('rewriteSshConfigPaths (cross-platform IdentityFile rewrite)', () => {
 		const rewritten = rewriteSshConfigPaths(config, '/data/hdb/ssh', '/tmp/harper-ssh-abc', 'darwin');
 		assert.strictEqual(rewritten, 'IdentityFile /tmp/harper-ssh-abc/a.key\nIdentityFile /tmp/harper-ssh-abc/b.key\n');
 	});
+
+	it('treats a literal `$` in tempDir as a literal character, not a replacement pattern', () => {
+		// A string replacer would interpret `$&` here as "the whole match" and corrupt the path;
+		// a function replacer sidesteps special-token interpretation entirely.
+		const config = 'IdentityFile /data/hdb/ssh/deploy.key\n';
+		const tempDir = '/tmp/harper-ssh-$&-abc';
+		const rewritten = rewriteSshConfigPaths(config, '/data/hdb/ssh', tempDir, 'darwin');
+		assert.strictEqual(rewritten, 'IdentityFile /tmp/harper-ssh-$&-abc/deploy.key\n');
+	});
 });
 
 describe('nonInteractiveSpawn transient ssh lifetime', () => {

--- a/unitTests/components/gitSSHMaterialization.test.js
+++ b/unitTests/components/gitSSHMaterialization.test.js
@@ -1,0 +1,261 @@
+'use strict';
+
+/**
+ * Transient materialization of SSH deploy keys (harper-pro#581).
+ *
+ * git/ssh needs a key *file*, but the key is now sealed at rest as an `enc:v1:` envelope (Pro's
+ * `add_ssh_key`). `materializeGitSSH` decrypts it into a fresh 0700 temp dir as a 0600 file and
+ * repoints the ssh config's `IdentityFile` at that copy for exactly the lifetime of one spawn —
+ * the same decrypt-to-transient-file shape as the per-deploy `.npmrc` (#1717).
+ *
+ * The things that actually matter here, and that these tests pin:
+ *  - the plaintext exists only inside the temp dir, at 0600, in a 0700 dir
+ *  - it is removed when the spawn settles — including when the command FAILS
+ *  - an undecryptable key (no custody, foreign cluster key, tampered envelope) is skipped and
+ *    logged, not fatal: a deploy that doesn't need that key still works, one that does gets the
+ *    normal SSH auth error
+ *  - no log or error message ever carries key material or the envelope
+ */
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const testUtils = require('../testUtils.js');
+testUtils.preTestPrep();
+
+const env = require('#src/utility/environment/environmentManager');
+const terms = require('#src/utility/hdbTerms');
+const { materializeGitSSH, nonInteractiveSpawn } = require('#src/components/Application');
+const secretDecryptor = require('#src/resources/secretDecryptor');
+const { encryptEnvelope, decryptEnvelope, fingerprintOf } = require('#src/utility/secretEnvelope');
+// CJS interop hands back the module namespace, which is the very object Application.ts's default
+// import resolves to — so stubbing a level here is what the code under test sees.
+const logger = require('#src/utility/logging/harper_logger');
+
+const ENC_PREFIX = 'enc:v1:';
+const KEY_MATERIAL = '-----BEGIN OPENSSH PRIVATE KEY-----\nc3NoLWtleS1tYXRlcmlhbA\n-----END OPENSSH PRIVATE KEY-----\n';
+
+function makeKeypair() {
+	const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+		modulusLength: 2048,
+		publicKeyEncoding: { type: 'spki', format: 'pem' },
+		privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+	});
+	return { privateKey, publicKey, kid: fingerprintOf(publicKey) };
+}
+
+// The decryptor Pro registers: strip the marker, unwrap, AES-GCM decrypt.
+function decryptorFor({ privateKey, kid }) {
+	return (value) => decryptEnvelope(value.slice(ENC_PREFIX.length), privateKey, kid);
+}
+
+const tempSSHDirs = () => fs.readdirSync(os.tmpdir()).filter((entry) => entry.startsWith('harper-ssh-'));
+
+describe('materializeGitSSH', () => {
+	let rootDir;
+	let sshDir;
+	let keypair;
+	let logged;
+	let originalError;
+	let originalWarn;
+
+	function writeSSHDir(keyFiles) {
+		fs.mkdirSync(sshDir, { recursive: true });
+		const configBlocks = [];
+		for (const [name, contents] of Object.entries(keyFiles)) {
+			const keyPath = path.join(sshDir, `${name}.key`);
+			fs.writeFileSync(keyPath, contents, { mode: 0o600 });
+			configBlocks.push(
+				`#${name}\nHost gh-${name}\n\tHostName example.com\n\tUser git\n\tIdentityFile ${keyPath}\n\tIdentitiesOnly yes`
+			);
+		}
+		fs.writeFileSync(path.join(sshDir, 'config'), configBlocks.join('\n'));
+		fs.writeFileSync(path.join(sshDir, 'known_hosts'), '');
+	}
+
+	const seal = (plaintext, kp = keypair) => ENC_PREFIX + encryptEnvelope(plaintext, kp.publicKey, kp.kid);
+
+	beforeEach(() => {
+		rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ssh-test-'));
+		sshDir = path.join(rootDir, 'ssh');
+		env.setProperty(terms.CONFIG_PARAMS.ROOTPATH, rootDir);
+		keypair = makeKeypair();
+
+		logged = [];
+		originalError = logger.error;
+		originalWarn = logger.warn;
+		logger.error = (...args) => logged.push(args.join(' '));
+		logger.warn = (...args) => logged.push(args.join(' '));
+	});
+
+	afterEach(() => {
+		logger.error = originalError;
+		logger.warn = originalWarn;
+		secretDecryptor.clearSecretDecryptor();
+		fs.rmSync(rootDir, { recursive: true, force: true });
+		for (const leftover of tempSSHDirs()) {
+			fs.rmSync(path.join(os.tmpdir(), leftover), { recursive: true, force: true });
+		}
+	});
+
+	it('returns undefined when the node has no ssh dir', async () => {
+		assert.strictEqual(await materializeGitSSH(), undefined);
+	});
+
+	it('returns undefined when the ssh dir holds no keys', async () => {
+		fs.mkdirSync(sshDir, { recursive: true });
+		fs.writeFileSync(path.join(sshDir, 'known_hosts'), '');
+		assert.strictEqual(await materializeGitSSH(), undefined);
+	});
+
+	it('decrypts a sealed key to a 0600 file in a 0700 temp dir and repoints IdentityFile at it', async () => {
+		secretDecryptor.registerSecretDecryptor(decryptorFor(keypair));
+		writeSSHDir({ deploy: seal(KEY_MATERIAL) });
+
+		const materialized = await materializeGitSSH();
+		assert.ok(materialized, 'expected a GIT_SSH_COMMAND');
+
+		const configPath = materialized.command.match(/ssh -F (\S+)/)[1];
+		const tempDir = path.dirname(configPath);
+		assert.ok(path.basename(tempDir).startsWith('harper-ssh-'));
+
+		// the plaintext exists, but only here
+		const transientKey = path.join(tempDir, 'deploy.key');
+		assert.strictEqual(fs.readFileSync(transientKey, 'utf8'), KEY_MATERIAL);
+		assert.strictEqual(fs.statSync(transientKey).mode & 0o777, 0o600, 'key file must be 0600');
+		assert.strictEqual(fs.statSync(tempDir).mode & 0o777, 0o700, 'temp dir must be 0700');
+
+		// ssh is pointed at the transient copy, not the sealed durable one
+		const config = fs.readFileSync(configPath, 'utf8');
+		assert.ok(config.includes(`IdentityFile ${transientKey}`), `config should point at the transient key: ${config}`);
+		assert.ok(!config.includes(sshDir), 'no IdentityFile should still point into the durable ssh dir');
+
+		// the durable copy is untouched and still sealed
+		assert.ok(fs.readFileSync(path.join(sshDir, 'deploy.key'), 'utf8').startsWith(ENC_PREFIX));
+
+		// known_hosts is not secret and stays where it is
+		assert.ok(materialized.command.includes(`UserKnownHostsFile=${path.join(sshDir, 'known_hosts')}`));
+
+		await materialized.cleanup();
+		assert.ok(!fs.existsSync(tempDir), 'cleanup must remove the plaintext');
+	});
+
+	it('passes a legacy plaintext key through unchanged (pre-#581 keys keep working)', async () => {
+		writeSSHDir({ legacy: KEY_MATERIAL });
+
+		const materialized = await materializeGitSSH();
+		const tempDir = path.dirname(materialized.command.match(/ssh -F (\S+)/)[1]);
+
+		assert.strictEqual(fs.readFileSync(path.join(tempDir, 'legacy.key'), 'utf8'), KEY_MATERIAL);
+		assert.strictEqual(fs.statSync(path.join(tempDir, 'legacy.key')).mode & 0o777, 0o600);
+
+		await materialized.cleanup();
+		assert.ok(!fs.existsSync(tempDir));
+	});
+
+	it('skips a sealed key when no custody is registered, and never logs the envelope or key', async () => {
+		const envelope = seal(KEY_MATERIAL);
+		writeSSHDir({ deploy: envelope });
+
+		const materialized = await materializeGitSSH();
+		const tempDir = path.dirname(materialized.command.match(/ssh -F (\S+)/)[1]);
+
+		// no plaintext was produced — the key is simply unusable on this node
+		assert.ok(!fs.existsSync(path.join(tempDir, 'deploy.key')));
+
+		const complaint = logged.find((line) => line.includes('deploy.key'));
+		assert.ok(complaint, `expected a loud log, got: ${JSON.stringify(logged)}`);
+		assert.ok(complaint.includes('no secret custody'), complaint);
+		for (const line of logged) {
+			assert.ok(!line.includes('OPENSSH PRIVATE KEY'), 'a log must never carry key material');
+			assert.ok(!line.includes(envelope), 'a log must never carry the envelope');
+		}
+
+		await materialized.cleanup();
+	});
+
+	it('skips a key sealed under a different cluster key rather than failing the whole spawn', async () => {
+		secretDecryptor.registerSecretDecryptor(decryptorFor(keypair));
+		writeSSHDir({ ours: seal(KEY_MATERIAL), foreign: seal(KEY_MATERIAL, makeKeypair()) });
+
+		const materialized = await materializeGitSSH();
+		const tempDir = path.dirname(materialized.command.match(/ssh -F (\S+)/)[1]);
+
+		// the usable key still materializes; only the undecryptable one drops out
+		assert.strictEqual(fs.readFileSync(path.join(tempDir, 'ours.key'), 'utf8'), KEY_MATERIAL);
+		assert.ok(!fs.existsSync(path.join(tempDir, 'foreign.key')));
+		assert.ok(
+			logged.some((line) => line.includes('foreign.key') && line.includes('Failed to decrypt')),
+			`expected a decrypt failure for the foreign key, got: ${JSON.stringify(logged)}`
+		);
+		for (const line of logged) assert.ok(!line.includes('OPENSSH PRIVATE KEY'));
+
+		await materialized.cleanup();
+	});
+
+	it('skips a tampered envelope (GCM auth tag failure)', async () => {
+		secretDecryptor.registerSecretDecryptor(decryptorFor(keypair));
+		const envelope = seal(KEY_MATERIAL);
+		// flip a byte in the base64url body — the auth tag no longer verifies
+		const tampered =
+			ENC_PREFIX + (envelope.slice(-1) === 'A' ? envelope.slice(7, -1) + 'B' : envelope.slice(7, -1) + 'A');
+		writeSSHDir({ deploy: tampered });
+
+		const materialized = await materializeGitSSH();
+		const tempDir = path.dirname(materialized.command.match(/ssh -F (\S+)/)[1]);
+
+		assert.ok(!fs.existsSync(path.join(tempDir, 'deploy.key')));
+		assert.ok(logged.some((line) => line.includes('deploy.key')));
+
+		await materialized.cleanup();
+	});
+});
+
+describe('nonInteractiveSpawn transient ssh lifetime', () => {
+	let rootDir;
+	let sshDir;
+
+	beforeEach(() => {
+		rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ssh-spawn-test-'));
+		sshDir = path.join(rootDir, 'ssh');
+		env.setProperty(terms.CONFIG_PARAMS.ROOTPATH, rootDir);
+		fs.mkdirSync(sshDir, { recursive: true });
+		fs.writeFileSync(path.join(sshDir, 'deploy.key'), KEY_MATERIAL, { mode: 0o600 });
+		fs.writeFileSync(
+			path.join(sshDir, 'config'),
+			`#deploy\nHost gh\n\tIdentityFile ${path.join(sshDir, 'deploy.key')}\n\tIdentitiesOnly yes`
+		);
+		fs.writeFileSync(path.join(sshDir, 'known_hosts'), '');
+	});
+
+	afterEach(() => {
+		fs.rmSync(rootDir, { recursive: true, force: true });
+		for (const leftover of tempSSHDirs()) {
+			fs.rmSync(path.join(os.tmpdir(), leftover), { recursive: true, force: true });
+		}
+	});
+
+	it('exposes GIT_SSH_COMMAND to the child and removes the key material once it exits', async () => {
+		const { stdout, code } = await nonInteractiveSpawn('app', 'printenv', ['GIT_SSH_COMMAND'], rootDir);
+
+		assert.strictEqual(code, 0);
+		assert.match(stdout, /^ssh -F \S*harper-ssh-\S+[/\\]config /, `unexpected GIT_SSH_COMMAND: ${stdout}`);
+		assert.deepStrictEqual(tempSSHDirs(), [], 'the transient ssh dir must not outlive the spawn');
+	});
+
+	it('removes the key material when the command FAILS (cleanup-on-error)', async () => {
+		const { code } = await nonInteractiveSpawn('app', 'sh', ['-c', '"exit 3"'], rootDir);
+
+		assert.strictEqual(code, 3);
+		assert.deepStrictEqual(tempSSHDirs(), [], 'a failed git operation must still clean up the plaintext key');
+	});
+
+	it('removes the key material when the command times out', async () => {
+		await assert.rejects(nonInteractiveSpawn('app', 'sleep', ['30'], rootDir, 200), /timed out/);
+
+		assert.deepStrictEqual(tempSSHDirs(), [], 'a timed-out git operation must still clean up the plaintext key');
+	});
+});


### PR DESCRIPTION
## Summary

Harper Pro is moving SSH deploy keys to sealed-at-rest storage (harper-pro#581 — the key file and the replicated `add_ssh_key` op body become `enc:v1:` envelopes instead of plaintext). git/ssh still needs a key *file*, so core needs to decrypt one for the duration of a git invocation. This is that half.

`getGitSSHCommand()` (which just pointed `GIT_SSH_COMMAND` at the durable `<rootDir>/ssh` dir) is replaced by **`materializeGitSSH()`**, which:

- decrypts each `enc:v1:` key into a fresh **0700** temp dir as a **0600** file, via the already-registered `getSecretDecryptor()` hook;
- copies the ssh `config` with its `IdentityFile` paths repointed at the transient copies (`known_hosts` holds no secrets and stays put);
- returns a `cleanup()` that `nonInteractiveSpawn` runs in a `finally`, so the plaintext is removed on **success, non-zero exit, and timeout** alike.

This is the same decrypt-to-transient-file shape already shipped for the per-deploy `.npmrc` in #1717 — the SSH analogue of it.

Legacy plaintext keys are copied through unchanged, so nodes with pre-existing keys (or no custody) keep working exactly as before.

## Why this shape

Bracketing inside `nonInteractiveSpawn` rather than around the whole deploy (as the `.npmrc` does on `Application`) means **one** code path, cleanup guaranteed by `finally`, no call-site churn, and the `install_node_modules` spawn in `npmUtilities.ts` is covered for free. It also narrows the plaintext's lifetime from a whole deploy to a single spawn. The cost is a `readdir` per spawn, which is negligible next to `npm install`.

## Where to look

- **`materializeGitSSH`'s failure policy** is the main design call worth a second opinion. A key that can't be decrypted (no custody on this node, an envelope sealed under a different cluster key, a tampered envelope) is **logged and skipped**, not fatal. Rationale: throwing would break *every* deploy on such a node — including npm-only ones that never touch that key — whereas skipping means a deploy that doesn't need the key is unaffected, and one that does fails with the normal SSH auth error (`isSSHAuthFailure` already produces a good message). Fail-closed on the key, not on the whole node.
- **No plaintext in any error path**: no log or error message here carries key material or the envelope. There's a test asserting exactly that.
- The config rewrite is a path-prefix substitution (`sshConfig.split(sshDir).join(tempDir)`), which relies on `IdentityFile` lines holding absolute paths into the ssh dir — which is how Pro's `add_ssh_key` writes them.

## Tests

`unitTests/components/gitSSHMaterialization.test.js` — 10 tests: sealed key decrypts to a 0600 file in a 0700 dir with `IdentityFile` repointed; legacy plaintext passes through; no-custody / foreign-cluster-key / tampered-envelope keys are skipped with no plaintext and no key material in the logs; and the transient dir does not outlive the spawn on success, on failure, or on timeout.

## Companion PR

Pairs with harper-pro **[#582 — Encrypt stored SSH deploy keys at rest](https://github.com/HarperFast/harper-pro/pull/582)**, which does the sealing half. Neither is useful alone; the pro PR bumps the `core` submodule to this branch.

---
🤖 Generated by KrAIs (Claude Opus 4.8) with [Claude Code](https://claude.com/claude-code)
