### PR TITLE
Reshape deploy_component registryAuth into a general-purpose credentials array

### DIFF
--- a/components/Application.ts
+++ b/components/Application.ts
@@ -3,6 +3,7 @@ import { getConfigObj, getConfigValue, getConfigPath } from '../config/configUti
 import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 import logger from '../utility/logging/harper_logger.ts';
 import { broadcastDeployStart, broadcastDeployEnd } from './deployLifecycle.ts';
+import type { RegistryCredentialReference, ResolvedRegistryCredential } from './secretOperations.ts';
 
 import { basename, dirname, extname, join } from 'node:path';
 import {
@@ -38,10 +39,10 @@ interface ApplicationConfig {
 		timeout?: number;
 		allowInstallScripts?: boolean;
 	};
-	// Private-registry auth in reference form only — each entry names an hdb_secret row, never a
-	// token. Recorded by deploy_component so every (cold) install — reboot, new peer, rollback —
-	// re-resolves the credential from the store rather than needing it re-supplied.
-	registryAuth?: { registry: string; secret: string; scope?: string }[];
+	// Deploy credentials in reference form only — each entry names an hdb_secret row, never a token.
+	// Recorded by deploy_component so every (cold) install — reboot, new peer, rollback — re-resolves
+	// the credential from the store rather than needing it re-supplied.
+	credentials?: RegistryCredentialReference[];
 	// an application config can have other arbitrary properties
 	[key: string]: unknown;
 }
@@ -78,18 +79,18 @@ export class InvalidInstallTimeoutError extends TypeError {
 	}
 }
 
-export class InvalidRegistryAuthPropertyError extends TypeError {
-	constructor(applicationName: string, registryAuth: unknown) {
+export class InvalidCredentialsPropertyError extends TypeError {
+	constructor(applicationName: string, credentials: unknown) {
 		super(
-			`Invalid 'registryAuth' property for application ${applicationName}: expected array, got ${typeof registryAuth}`
+			`Invalid 'credentials' property for application ${applicationName}: expected array, got ${typeof credentials}`
 		);
 	}
 }
 
-export class InvalidRegistryAuthEntryError extends TypeError {
+export class InvalidCredentialEntryError extends TypeError {
 	constructor(applicationName: string) {
 		super(
-			`Invalid 'registryAuth' entry for application ${applicationName}: expected { registry, secret, scope? } reference`
+			`Invalid 'credentials' entry for application ${applicationName}: expected { registry, secret, scope? } reference`
 		);
 	}
 }
@@ -131,10 +132,10 @@ export function assertApplicationConfig(
 			);
 		}
 	}
-	if ('registryAuth' in applicationConfig && applicationConfig.registryAuth !== undefined) {
-		const entries = applicationConfig.registryAuth;
+	if ('credentials' in applicationConfig && applicationConfig.credentials !== undefined) {
+		const entries = applicationConfig.credentials;
 		if (!Array.isArray(entries)) {
-			throw new InvalidRegistryAuthPropertyError(applicationName, entries);
+			throw new InvalidCredentialsPropertyError(applicationName, entries);
 		}
 		for (const entry of entries) {
 			// Config carries references only — a literal `token` here would mean a plaintext credential
@@ -145,7 +146,7 @@ export function assertApplicationConfig(
 				typeof (entry as any).registry !== 'string' ||
 				typeof (entry as any).secret !== 'string'
 			) {
-				throw new InvalidRegistryAuthEntryError(applicationName);
+				throw new InvalidCredentialEntryError(applicationName);
 			}
 		}
 	}
@@ -551,7 +552,7 @@ interface ApplicationOptions {
 	packageIdentifier?: string;
 	install?: { command?: string; timeout?: number; allowInstallScripts?: boolean };
 	onInstallLine?: OnInstallLine;
-	registryAuth?: RegistryAuthEntry[];
+	registryCredentials?: ResolvedRegistryCredential[];
 }
 
 export class Application {
@@ -563,21 +564,22 @@ export class Application {
 	dirPath: string;
 	logger: Logger;
 	packageManagerPrefix: string; // can be used to configure a package manager prefix, specifically "sfw".
-	// Transient registry auth provided by a deploy. The token is held only in memory and a
-	// per-deploy `.npmrc`; it is never persisted to config, hdb_deployment, or replicated.
-	registryAuth?: RegistryAuthEntry[];
+	// Transient registry credentials provided by a deploy, already resolved to literal tokens. The
+	// token is held only in memory and a per-deploy `.npmrc`; it is never persisted to config,
+	// hdb_deployment, or replicated.
+	registryCredentials?: ResolvedRegistryCredential[];
 	// Path to the per-deploy `.npmrc`, set by writeTransientNpmrc() during prepareApplication and
-	// passed to the spawn calls; undefined when no registry auth was provided.
+	// passed to the spawn calls; undefined when no registry credentials were provided.
 	npmUserconfigPath?: string;
 	#npmrcTempDir?: string;
 
-	constructor({ name, payload, packageIdentifier, install, onInstallLine, registryAuth }: ApplicationOptions) {
+	constructor({ name, payload, packageIdentifier, install, onInstallLine, registryCredentials }: ApplicationOptions) {
 		this.name = name;
 		this.payload = payload;
 		this.packageIdentifier = packageIdentifier && derivePackageIdentifier(packageIdentifier);
 		this.install = install;
 		this.onInstallLine = onInstallLine;
-		this.registryAuth = registryAuth;
+		this.registryCredentials = registryCredentials;
 		const componentsRoot = getConfigPath(CONFIG_PARAMS.COMPONENTSROOT);
 		if (!componentsRoot) throw new Error('componentsRoot is not configured');
 		this.dirPath = join(componentsRoot, name);
@@ -586,7 +588,8 @@ export class Application {
 	}
 
 	// Write the transient `.npmrc` into a fresh 0700 temp dir (file mode 0600) and record its path
-	// so the deploy's npm spawns authenticate against the private registry. No-op without registry auth.
+	// so the deploy's npm spawns authenticate against the private registry. No-op without registry
+	// credentials.
 	//
 	// Because `nonInteractiveSpawn` points npm at this single file (replacing any inherited
 	// npm_config_userconfig), prepend the contents of an already-configured userconfig — e.g. a
@@ -594,7 +597,7 @@ export class Application {
 	// survive. The transient auth is appended last so it wins on conflict (npm honors the last
 	// value for a given key).
 	async writeTransientNpmrc(): Promise<void> {
-		if (!this.registryAuth?.length) return;
+		if (!this.registryCredentials?.length) return;
 		// Defensive: if called more than once, remove the prior temp dir first so it isn't leaked.
 		if (this.#npmrcTempDir) await this.cleanupTransientNpmrc();
 		this.#npmrcTempDir = await mkdtemp(join(tmpdir(), 'harper-npmrc-'));
@@ -610,7 +613,7 @@ export class Application {
 				if (error?.code !== 'ENOENT') throw error;
 			}
 		}
-		content += buildNpmrcContent(this.registryAuth);
+		content += buildNpmrcContent(this.registryCredentials);
 		await writeFile(npmrcPath, content, { mode: 0o600 });
 		this.npmUserconfigPath = npmrcPath;
 	}
@@ -629,7 +632,7 @@ export class Application {
 			this.npmUserconfigPath = undefined;
 			// Drop the in-memory token array too, so it can't surface in a later heap dump or error
 			// serialization of this Application instance.
-			this.registryAuth = undefined;
+			this.registryCredentials = undefined;
 		}
 	}
 }
@@ -737,20 +740,19 @@ export async function installApplications() {
 			// This will throw if the config is invalid
 			assertApplicationConfig(name, applicationConfig);
 
-			// Resolve any private-registry auth references from the store so a cold install (fresh
-			// node, wiped components dir, new peer that never installed) can authenticate without the
-			// token being re-supplied. Best-effort: if custody isn't available yet or a referenced
-			// secret is missing, log and install without it (a truly private package then fails in
-			// npm with its own error) rather than blocking boot.
-			let resolvedRegistryAuth: RegistryAuthEntry[] | undefined;
-			if (applicationConfig.registryAuth?.length) {
+			// Resolve any credential references from the store so a cold install (fresh node, wiped
+			// components dir, new peer that never installed) can authenticate without the token being
+			// re-supplied. Best-effort: if custody isn't available yet or a referenced secret is
+			// missing, log and install without it (a truly private package then fails in npm with its
+			// own error) rather than blocking boot.
+			let registryCredentials: ResolvedRegistryCredential[] | undefined;
+			if (applicationConfig.credentials?.length) {
 				try {
-					const { resolveRegistryAuth } = await import('./secretOperations.ts');
-					resolvedRegistryAuth = (await resolveRegistryAuth(applicationConfig.registryAuth, name)) as
-						RegistryAuthEntry[] | undefined;
+					const { resolveCredentials } = await import('./secretOperations.ts');
+					registryCredentials = await resolveCredentials(applicationConfig.credentials, name);
 				} catch (error) {
 					logger.warn?.(
-						`Could not resolve registryAuth for application ${name} at install time: ${(error as Error).message}`
+						`Could not resolve credentials for application ${name} at install time: ${(error as Error).message}`
 					);
 				}
 			}
@@ -759,7 +761,7 @@ export async function installApplications() {
 				name,
 				packageIdentifier: applicationConfig.package,
 				install: applicationConfig.install,
-				registryAuth: resolvedRegistryAuth,
+				registryCredentials,
 			});
 
 			// Lock check: only install if not already installed with matching configuration
@@ -800,12 +802,6 @@ function getGitSSHCommand() {
 	}
 }
 
-export interface RegistryAuthEntry {
-	registry: string;
-	token: string;
-	scope?: string;
-}
-
 // Normalize a registry to a full URL with a scheme and trailing slash, e.g.
 // `npm.pkg.github.com` or `//npm.pkg.github.com` → `https://npm.pkg.github.com/`.
 function normalizeRegistryUrl(registry: string): string {
@@ -817,16 +813,16 @@ function normalizeRegistryUrl(registry: string): string {
 	return url;
 }
 
-// Build the contents of a transient `.npmrc` from registry auth entries: an auth-token line keyed
+// Build the contents of a transient `.npmrc` from resolved registry credentials: an auth-token line keyed
 // by npm's registry auth key (scheme stripped, leading `//`, trailing `/`) plus a registry-routing
 // line. A scope routes only that `@scope` to the registry (`@scope:registry=…`); without a scope
 // the entry sets npm's default `registry=…` so an unscoped package spec (e.g. `npm:my-private-app`)
 // or its transitive deps actually resolve against this registry rather than the public default.
 // A scope-less entry therefore requires its registry to serve/proxy whatever npm needs to install;
 // with multiple scope-less entries npm's last-value-wins applies to the default `registry`.
-export function buildNpmrcContent(registryAuth: RegistryAuthEntry[]): string {
+export function buildNpmrcContent(registryCredentials: ResolvedRegistryCredential[]): string {
 	const lines: string[] = [];
-	for (const { registry, token, scope } of registryAuth) {
+	for (const { registry, token, scope } of registryCredentials) {
 		// Enforce the no-newline invariant at the injection point so it holds for every source. The
 		// ops validator already rejects CR/LF in a literal `token`, but a token resolved from an
 		// hdb_secret row bypasses that guard; without this a `\n` in a secret value would inject

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -579,7 +579,10 @@ export class Application {
 		this.packageIdentifier = packageIdentifier && derivePackageIdentifier(packageIdentifier);
 		this.install = install;
 		this.onInstallLine = onInstallLine;
-		this.registryCredentials = registryCredentials;
+		// `credentials` is kind-heterogeneous (registry today, a planned git-host kind later — see
+		// secretOperations.ts); filter to registry-shaped entries so buildNpmrcContent (which assumes
+		// `.registry` on every entry) never sees a non-registry kind once one exists.
+		this.registryCredentials = registryCredentials?.filter((entry) => entry && 'registry' in entry);
 		const componentsRoot = getConfigPath(CONFIG_PARAMS.COMPONENTSROOT);
 		if (!componentsRoot) throw new Error('componentsRoot is not configured');
 		this.dirPath = join(componentsRoot, name);

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -36,6 +36,7 @@ import { StringDecoder } from 'node:string_decoder';
 
 import { extract } from 'tar-fs';
 import gunzip from 'gunzip-maybe';
+import semver from 'semver';
 
 interface ApplicationConfig {
 	// define known config properties
@@ -234,6 +235,66 @@ export function parseGitReference(packageIdentifier: string): GitReference | nul
 
 const NEUTRALIZED_LIFECYCLE_SCRIPTS = ['preinstall', 'install', 'postinstall', 'prepack', 'prepare'];
 
+// npm's hosted-git-info convention (documented in #1799's own worked example, `github:my-org/my-app#semver:v1.2.3`)
+// for a committish that names a semver range instead of a literal ref. `git checkout` has no notion
+// of this syntax, so it must be resolved to a concrete tag before checkout.
+const SEMVER_COMMITTISH_PREFIX = /^semver:/i;
+
+// Matches npm's own git-tag-to-version extraction (@npmcli/git's lines-to-revs.js): a trailing
+// `1.2.3`-shaped suffix, optionally `v`-prefixed, with anything ahead of it ignored — so a tag like
+// `release-v1.2.3` resolves the same way npm's own git-dependency installer treats it.
+const TAG_VERSION_SUFFIX = /v?(\d+\.\d+\.\d+(?:[-+].+)?)$/;
+
+/**
+ * Resolves a `semver:<range>` committish (e.g. `semver:v1.2.3`, `semver:^1.2.3`) against the tags of
+ * the given clone to a concrete, unambiguous tag ref. Returns the committish unchanged if it isn't a
+ * semver-range committish.
+ */
+async function resolveCommittish(application: Application, committish: string, cloneDir: string): Promise<string> {
+	if (!SEMVER_COMMITTISH_PREFIX.test(committish)) return committish;
+	// npm's own package-arg parser URL-decodes the value after `semver:` (a range containing `^`/`~`
+	// can arrive percent-encoded, e.g. `#semver:%5E1.0.0`); do the same rather than evaluating it raw.
+	const rawRange = committish.slice('semver:'.length);
+	let range: string;
+	try {
+		range = decodeURIComponent(rawRange);
+	} catch {
+		range = rawRange;
+	}
+
+	// `git tag --list` rather than `for-each-ref --format=...`: nonInteractiveSpawn runs through a
+	// shell, and a `%(...)` format string is unsafe to pass through one.
+	const { code, stdout, stderr } = await nonInteractiveSpawn(application.name, 'git', ['tag', '--list'], cloneDir);
+	if (code !== 0) {
+		throw new Error(`Failed to list tags to resolve '${committish}' for ${application.packageIdentifier}: ${stderr}`);
+	}
+	const tags = stdout
+		.split('\n')
+		.map((tag) => tag.trim())
+		.filter(Boolean);
+
+	// A tag can be a bare version (`v1.2.3`) or carry a prefix ahead of one (`release-v1.2.3`); only
+	// the trailing version-shaped suffix is evaluated against the range, but the ORIGINAL tag name is
+	// what gets checked out.
+	const versionToTag = new Map<string, string>();
+	for (const tag of tags) {
+		const match = tag.match(TAG_VERSION_SUFFIX);
+		const version = match && semver.valid(match[1], { loose: true });
+		if (version) versionToTag.set(semver.clean(match[1], { loose: true }) as string, tag);
+	}
+
+	const resolvedVersion = semver.maxSatisfying([...versionToTag.keys()], range, { loose: true });
+	if (!resolvedVersion) {
+		throw new Error(
+			`Failed to resolve '${committish}' for ${application.packageIdentifier}: no tag satisfies range '${range}'. ` +
+				(tags.length ? `Tags found: ${tags.join(', ')}` : 'No tags were found in the repository.')
+		);
+	}
+	// refs/tags/<name> rather than the bare name: an unqualified `git checkout <name>` resolves to a
+	// same-named branch first if one exists, which would silently package the wrong commit.
+	return `refs/tags/${versionToTag.get(resolvedVersion)}`;
+}
+
 /**
  * Clones a git reference ourselves — with the credential session's env, so the clone itself can
  * still authenticate — and packs the checkout with its lifecycle scripts stripped, instead of
@@ -275,16 +336,15 @@ async function packGitReferenceWithoutScripts(
 		}
 
 		if (gitRef.committish) {
+			const committish = await resolveCommittish(application, gitRef.committish, cloneDir);
 			const { code: checkoutCode, stderr: checkoutStderr } = await nonInteractiveSpawn(
 				application.name,
 				'git',
-				['checkout', '--quiet', gitRef.committish],
+				['checkout', '--quiet', committish],
 				cloneDir
 			);
 			if (checkoutCode !== 0) {
-				throw new Error(
-					`Failed to check out '${gitRef.committish}' for ${application.packageIdentifier}: ${checkoutStderr}`
-				);
+				throw new Error(`Failed to check out '${committish}' for ${application.packageIdentifier}: ${checkoutStderr}`);
 			}
 		}
 

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -245,6 +245,16 @@ const SEMVER_COMMITTISH_PREFIX = /^semver:/i;
 // `release-v1.2.3` resolves the same way npm's own git-dependency installer treats it.
 const TAG_VERSION_SUFFIX = /v?(\d+\.\d+\.\d+(?:[-+].+)?)$/;
 
+// A conservative safe-charset check on the FULL tag name — not just the version-shaped suffix
+// TAG_VERSION_SUFFIX matches. git's own ref-name rules (`check-ref-format`) permit shell
+// metacharacters like `$`, backticks, `;`, `&`, `|`, `(`, `)` in a tag name; a prefix ahead of the
+// matched suffix (e.g. the `release-` in `release-v1.2.3`) is otherwise unconstrained. The resolved
+// name is later checked out via `nonInteractiveSpawn`, which runs through a shell with no argument
+// escaping, so a tag such as `$(id)v1.2.3` in the cloned repo would otherwise execute on checkout.
+// A tag failing this check is excluded from resolution entirely rather than sanitized or escaped —
+// this only has to reject shell metacharacters, not accept every ref git itself would allow.
+const SAFE_TAG_NAME = /^[\w][\w.-]*$/;
+
 /**
  * Resolves a `semver:<range>` committish (e.g. `semver:v1.2.3`, `semver:^1.2.3`) against the tags of
  * the given clone to a concrete, unambiguous tag ref. Returns the committish unchanged if it isn't a
@@ -278,6 +288,7 @@ async function resolveCommittish(application: Application, committish: string, c
 	// what gets checked out.
 	const versionToTag = new Map<string, string>();
 	for (const tag of tags) {
+		if (!SAFE_TAG_NAME.test(tag)) continue;
 		const match = tag.match(TAG_VERSION_SUFFIX);
 		const version = match && semver.valid(match[1], { loose: true });
 		if (version) versionToTag.set(semver.clean(match[1], { loose: true }) as string, tag);

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -3,7 +3,13 @@ import { getConfigObj, getConfigValue, getConfigPath } from '../config/configUti
 import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 import logger from '../utility/logging/harper_logger.ts';
 import { broadcastDeployStart, broadcastDeployEnd } from './deployLifecycle.ts';
-import type { RegistryCredentialReference, ResolvedRegistryCredential } from './secretOperations.ts';
+import type { CredentialReference, ResolvedCredential, ResolvedRegistryCredential } from './secretOperations.ts';
+import {
+	GIT_CREDENTIAL_SOCKET_ENV,
+	startGitCredentialSession,
+	type GitCredentialSession,
+	type ResolvedGitCredential,
+} from './gitCredentialServer.ts';
 
 import { basename, dirname, extname, join } from 'node:path';
 import {
@@ -42,7 +48,7 @@ interface ApplicationConfig {
 	// Deploy credentials in reference form only — each entry names an hdb_secret row, never a token.
 	// Recorded by deploy_component so every (cold) install — reboot, new peer, rollback — re-resolves
 	// the credential from the store rather than needing it re-supplied.
-	credentials?: RegistryCredentialReference[];
+	credentials?: CredentialReference[];
 	// an application config can have other arbitrary properties
 	[key: string]: unknown;
 }
@@ -90,7 +96,8 @@ export class InvalidCredentialsPropertyError extends TypeError {
 export class InvalidCredentialEntryError extends TypeError {
 	constructor(applicationName: string) {
 		super(
-			`Invalid 'credentials' entry for application ${applicationName}: expected { registry, secret, scope? } reference`
+			`Invalid 'credentials' entry for application ${applicationName}: expected a { registry, secret, scope? } ` +
+				`or { host, secret, username? } reference`
 		);
 	}
 }
@@ -139,12 +146,19 @@ export function assertApplicationConfig(
 		}
 		for (const entry of entries) {
 			// Config carries references only — a literal `token` here would mean a plaintext credential
-			// was persisted to disk, which the deploy path is designed to prevent.
+			// was persisted to disk, which the deploy path is designed to prevent. An entry is npm
+			// registry auth (`registry`) XOR git host auth (`host`); anything else is not a credential we
+			// know how to resolve, so reject it rather than install without it. An entry carrying both
+			// discriminators, or a stray `token`, is rejected rather than coerced into a single kind.
+			const record = entry as any;
+			const hasRegistry = typeof record?.registry === 'string';
+			const hasHost = typeof record?.host === 'string';
 			if (
 				typeof entry !== 'object' ||
 				entry === null ||
-				typeof (entry as any).registry !== 'string' ||
-				typeof (entry as any).secret !== 'string'
+				hasRegistry === hasHost || // neither, or both
+				typeof record.secret !== 'string' ||
+				record.token !== undefined
 			) {
 				throw new InvalidCredentialEntryError(applicationName);
 			}
@@ -167,10 +181,160 @@ export function isSSHAuthFailure(stderr: string): boolean {
 	);
 }
 
+// Git-reference package identifier forms recognized below for the credentialed-clone path: the
+// npm git-url spec forms this repo's own derivePackageIdentifier can produce for a git host
+// credential. An identifier that doesn't match falls back to `npm pack --ignore-scripts` (best
+// effort, same as before this fix — not a regression for a form this can't safely reclone).
+const GIT_URL_PREFIX = /^git\+(ssh|https?|file):\/\//i;
+const GIT_PROTOCOL_PREFIX = /^git:\/\//i;
+
+// Hosted-git shorthand prefixes: the same table derivePackageIdentifier implicitly relies on when it
+// defaults a bare `owner/repo` to `github:owner/repo`, plus the other hosts npm's own shorthand spec
+// recognizes. A bare `owner/repo` never reaches parseGitReference directly — the Application
+// constructor always runs packageIdentifier through derivePackageIdentifier first, which turns it
+// into `github:owner/repo` — so only the prefixed forms need handling here.
+const HOSTED_GIT_HOSTS: Record<string, string> = {
+	github: 'github.com',
+	gitlab: 'gitlab.com',
+	bitbucket: 'bitbucket.org',
+	gist: 'gist.github.com',
+};
+const HOSTED_GIT_PREFIX = /^(github|gitlab|bitbucket|gist):(.+)$/i;
+
+interface GitReference {
+	cloneUrl: string;
+	committish?: string;
+}
+
+/**
+ * Parses a `git+ssh://…`/`git+https://…`/`git+http://…`/`git+file://…`/`git://…`, or hosted-git
+ * shorthand (`github:owner/repo`, `gitlab:owner/repo`, `bitbucket:owner/repo`, `gist:id`) package
+ * identifier into a plain clone URL and optional committish, without depending on npm's own git-spec
+ * parser (npm-package-arg/hosted-git-info aren't dependencies of this repo). Returns null for any
+ * other form.
+ */
+export function parseGitReference(packageIdentifier: string): GitReference | null {
+	const hashIndex = packageIdentifier.indexOf('#');
+	const committish = hashIndex === -1 ? undefined : packageIdentifier.slice(hashIndex + 1);
+	const spec = hashIndex === -1 ? packageIdentifier : packageIdentifier.slice(0, hashIndex);
+	if (GIT_URL_PREFIX.test(spec)) return { cloneUrl: spec.slice('git+'.length), committish };
+	if (GIT_PROTOCOL_PREFIX.test(spec)) return { cloneUrl: spec, committish };
+	const hostedMatch = HOSTED_GIT_PREFIX.exec(spec);
+	if (hostedMatch) {
+		const [, prefix, path] = hostedMatch;
+		const host = HOSTED_GIT_HOSTS[prefix.toLowerCase()];
+		// A gist clone URL is keyed by id alone; an optional `owner/` in the shorthand (npm accepts
+		// `gist:[owner/]id`) has no place in the URL and is dropped.
+		const urlPath =
+			prefix.toLowerCase() === 'gist' && path.includes('/') ? path.slice(path.lastIndexOf('/') + 1) : path;
+		return { cloneUrl: `https://${host}/${urlPath}.git`, committish };
+	}
+	return null;
+}
+
+const NEUTRALIZED_LIFECYCLE_SCRIPTS = ['preinstall', 'install', 'postinstall', 'prepack', 'prepare'];
+
+/**
+ * Clones a git reference ourselves — with the credential session's env, so the clone itself can
+ * still authenticate — and packs the checkout with its lifecycle scripts stripped, instead of
+ * letting `npm pack <git-url>` clone and pack it directly.
+ *
+ * `--ignore-scripts` is not a reliable suppression for a git source's own `prepare` script: pacote's
+ * DirFetcher runs it unconditionally on npm versions before 11.0.0 (the
+ * `if (this.opts.ignoreScripts) return` guard was only added upstream in npm 11) — which is exactly
+ * what Node 22's bundled npm (10.9.x) ships. A credentialed clone can't depend on which npm version
+ * happens to be on PATH, since a script running while the credential socket is reachable is exactly
+ * what this feature exists to prevent — so the script is removed from the checkout before packing,
+ * which works regardless of npm version.
+ */
+async function packGitReferenceWithoutScripts(
+	application: Application,
+	gitRef: GitReference,
+	parentDirPath: string
+): Promise<string> {
+	const cloneDir = await mkdtemp(join(tmpdir(), 'harper-git-clone-'));
+	try {
+		const { code: cloneCode, stderr: cloneStderr } = await nonInteractiveSpawn(
+			application.name,
+			'git',
+			['clone', '--quiet', gitRef.cloneUrl, cloneDir],
+			parentDirPath,
+			undefined,
+			undefined,
+			undefined,
+			application.gitCredentialEnv
+		);
+		if (cloneCode !== 0) {
+			if (isSSHAuthFailure(cloneStderr)) {
+				throw new Error(
+					`Failed to deploy private repository ${application.packageIdentifier}: SSH access failed. Verify the repository URL, configure an SSH key on this Harper instance, ensure the key has access to the target repository, and confirm the host is present in the ssh/known_hosts file.`,
+					{ cause: new Error(cloneStderr) }
+				);
+			}
+			throw new Error(`Failed to clone package ${application.packageIdentifier}: ${cloneStderr}`);
+		}
+
+		if (gitRef.committish) {
+			const { code: checkoutCode, stderr: checkoutStderr } = await nonInteractiveSpawn(
+				application.name,
+				'git',
+				['checkout', '--quiet', gitRef.committish],
+				cloneDir
+			);
+			if (checkoutCode !== 0) {
+				throw new Error(
+					`Failed to check out '${gitRef.committish}' for ${application.packageIdentifier}: ${checkoutStderr}`
+				);
+			}
+		}
+
+		// Strip the checkout's own lifecycle scripts before packing — the mechanism above only
+		// suppresses npm's git-clone behavior; a plain `npm pack <local-dir>` still runs `prepare`
+		// unless it's gone from the manifest.
+		const manifestPath = join(cloneDir, 'package.json');
+		const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+		if (manifest.scripts) {
+			for (const scriptName of NEUTRALIZED_LIFECYCLE_SCRIPTS) delete manifest.scripts[scriptName];
+			await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+		}
+
+		const { stdout, code, stderr } = await nonInteractiveSpawn(
+			application.name,
+			'npm',
+			['pack', '--json', '--ignore-scripts', cloneDir],
+			parentDirPath,
+			undefined,
+			undefined,
+			application.npmUserconfigPath
+		);
+		if (code !== 0) {
+			throw new Error(`Failed to pack package ${application.packageIdentifier}: ${stderr}`);
+		}
+		let packResult: Array<{ filename: string }>;
+		try {
+			packResult = JSON.parse(stdout.slice(stdout.indexOf('[')));
+		} catch (err) {
+			throw new Error(
+				`Failed to parse npm pack output for ${application.packageIdentifier}: ${err.message}\nstdout: ${stdout}`
+			);
+		}
+		if (!Array.isArray(packResult) || typeof packResult[0]?.filename !== 'string') {
+			throw new Error(`Unexpected npm pack output for ${application.packageIdentifier}:\n${stdout}`);
+		}
+		return join(parentDirPath, packResult[0].filename);
+	} finally {
+		await rm(cloneDir, { recursive: true, force: true });
+	}
+}
+
 // Hidden directory under the components root holding component versions renamed aside
 // during a deploy swap (see extractApplication). The leading dot keeps
 // loadComponentDirectories from loading its contents as components.
 export const ASIDE_STAGING_DIR = '.deploy-aside';
+
+// The credential helper git executes for a private git-reference deploy. It ships alongside this
+// module (both in source and in dist), holds no secret, and is inert without a live session.
+export const GIT_CREDENTIAL_HELPER_PATH = join(__dirname, 'gitCredentialHelper.js');
 
 /**
  * Extract an application given payload (content of the application) or package (npm-compatible identifier to the application).
@@ -245,39 +409,72 @@ export async function extractApplication(application: Application) {
 				}
 			}
 		} else {
-			// `npm pack --json` writes a JSON array describing the packed tarball(s).
-			const { stdout, code, stderr } = await nonInteractiveSpawn(
-				application.name,
-				'npm',
-				['pack', '--json', application.packageIdentifier],
-				parentDirPath,
-				undefined,
-				undefined,
-				application.npmUserconfigPath
-			);
-			if (code !== 0) {
-				if (isSSHAuthFailure(stderr)) {
-					throw new Error(
-						`Failed to deploy private repository ${application.packageIdentifier}: SSH access failed. Verify the repository URL, configure an SSH key on this Harper instance, ensure the key has access to the target repository, and confirm the host is present in the ssh/known_hosts file.`,
-						{ cause: new Error(stderr) }
+			// `npm pack --json` writes a JSON array describing the packed tarball(s). This is also the
+			// spawn that clones a git-reference package, so it is the only one given the git credential
+			// environment.
+			//
+			// Packing a git reference is not just a download: npm clones the repo and, if its manifest
+			// has a prepare/build/install script, runs `npm install` inside the clone and then that
+			// script — so the repo's own code AND its dependencies' install scripts execute on this node,
+			// inheriting this spawn's environment. With a credential session live, that is exactly the
+			// reach the credential must not have (a transitive dependency's postinstall could ask the
+			// socket for a token granted for the top-level repository), so scripts are off for a
+			// credentialed clone unless the deploy explicitly opted into them.
+			const scriptsDisallowed = application.gitCredentialEnv && !application.install?.allowInstallScripts;
+			// `--ignore-scripts` alone isn't a reliable way to enforce that: pacote's DirFetcher runs a
+			// git source's `prepare` unconditionally on npm versions before 11.0.0 (see
+			// packGitReferenceWithoutScripts), which is exactly what Node 22's bundled npm ships. For a
+			// recognized git-reference identifier, clone and pack it ourselves with scripts stripped
+			// instead, sidestepping that npm code path entirely.
+			const gitRef = scriptsDisallowed ? parseGitReference(application.packageIdentifier) : null;
+
+			if (gitRef) {
+				tarballPath = await packGitReferenceWithoutScripts(application, gitRef, parentDirPath);
+			} else {
+				const packArgs = ['pack', '--json', application.packageIdentifier];
+				if (scriptsDisallowed) {
+					packArgs.push('--ignore-scripts');
+				} else if (application.gitCredentialEnv) {
+					application.logger.warn(
+						`Deploying ${application.name} from a git reference with install scripts enabled: the repository's ` +
+							`prepare/build scripts and its dependencies' install scripts run on this node during the clone and ` +
+							`can read the git credential. Unset install_allow_scripts to keep the credential out of their reach.`
 					);
 				}
-				throw new Error(`Failed to download package ${application.packageIdentifier}: ${stderr}`);
-			}
-
-			let packResult: Array<{ filename: string }>;
-			try {
-				packResult = JSON.parse(stdout.slice(stdout.indexOf('[')));
-			} catch (err) {
-				throw new Error(
-					`Failed to parse npm pack output for ${application.packageIdentifier}: ${err.message}\nstdout: ${stdout}`
+				const { stdout, code, stderr } = await nonInteractiveSpawn(
+					application.name,
+					'npm',
+					packArgs,
+					parentDirPath,
+					undefined,
+					undefined,
+					application.npmUserconfigPath,
+					application.gitCredentialEnv
 				);
-			}
-			if (!Array.isArray(packResult) || typeof packResult[0]?.filename !== 'string') {
-				throw new Error(`Unexpected npm pack output for ${application.packageIdentifier}:\n${stdout}`);
-			}
+				if (code !== 0) {
+					if (isSSHAuthFailure(stderr)) {
+						throw new Error(
+							`Failed to deploy private repository ${application.packageIdentifier}: SSH access failed. Verify the repository URL, configure an SSH key on this Harper instance, ensure the key has access to the target repository, and confirm the host is present in the ssh/known_hosts file.`,
+							{ cause: new Error(stderr) }
+						);
+					}
+					throw new Error(`Failed to download package ${application.packageIdentifier}: ${stderr}`);
+				}
 
-			tarballPath = join(parentDirPath, packResult[0].filename);
+				let packResult: Array<{ filename: string }>;
+				try {
+					packResult = JSON.parse(stdout.slice(stdout.indexOf('[')));
+				} catch (err) {
+					throw new Error(
+						`Failed to parse npm pack output for ${application.packageIdentifier}: ${err.message}\nstdout: ${stdout}`
+					);
+				}
+				if (!Array.isArray(packResult) || typeof packResult[0]?.filename !== 'string') {
+					throw new Error(`Unexpected npm pack output for ${application.packageIdentifier}:\n${stdout}`);
+				}
+
+				tarballPath = join(parentDirPath, packResult[0].filename);
+			}
 			shouldDeleteTarball = true;
 			tarball = createReadStream(tarballPath);
 		}
@@ -552,7 +749,9 @@ interface ApplicationOptions {
 	packageIdentifier?: string;
 	install?: { command?: string; timeout?: number; allowInstallScripts?: boolean };
 	onInstallLine?: OnInstallLine;
-	registryCredentials?: ResolvedRegistryCredential[];
+	// Deploy credentials already resolved to literal tokens, of any kind; partitioned by the
+	// constructor into the npm and git halves, which are injected by entirely different mechanisms.
+	credentials?: ResolvedCredential[];
 }
 
 export class Application {
@@ -568,21 +767,35 @@ export class Application {
 	// token is held only in memory and a per-deploy `.npmrc`; it is never persisted to config,
 	// hdb_deployment, or replicated.
 	registryCredentials?: ResolvedRegistryCredential[];
+	// Transient git-host credentials, likewise resolved to literal tokens and held only in memory:
+	// they are served to git over a per-deploy socket (gitCredentialServer.ts), never written anywhere.
+	gitCredentials?: ResolvedGitCredential[];
 	// Path to the per-deploy `.npmrc`, set by writeTransientNpmrc() during prepareApplication and
 	// passed to the spawn calls; undefined when no registry credentials were provided.
 	npmUserconfigPath?: string;
 	#npmrcTempDir?: string;
+	#gitCredentialSession?: GitCredentialSession;
 
-	constructor({ name, payload, packageIdentifier, install, onInstallLine, registryCredentials }: ApplicationOptions) {
+	constructor({ name, payload, packageIdentifier, install, onInstallLine, credentials }: ApplicationOptions) {
 		this.name = name;
 		this.payload = payload;
 		this.packageIdentifier = packageIdentifier && derivePackageIdentifier(packageIdentifier);
 		this.install = install;
 		this.onInstallLine = onInstallLine;
-		// `credentials` is kind-heterogeneous (registry today, a planned git-host kind later — see
-		// secretOperations.ts); filter to registry-shaped entries so buildNpmrcContent (which assumes
-		// `.registry` on every entry) never sees a non-registry kind once one exists.
-		this.registryCredentials = registryCredentials?.filter((entry) => entry && 'registry' in entry);
+		// Split by kind: registry credentials go into the transient .npmrc, git credentials into the
+		// credential socket. An entry belongs to exactly one of them (the op schema is an xor).
+		// secretOperations owns the same predicate, but it is only ever imported from here lazily (it
+		// pulls in the datastore), so this stays a local check rather than a boot-time import.
+		if (credentials?.length) {
+			const registryCredentials = credentials.filter(
+				(entry): entry is ResolvedRegistryCredential => (entry as any).registry !== undefined
+			);
+			const gitCredentials = credentials.filter(
+				(entry): entry is ResolvedGitCredential => (entry as any).registry === undefined
+			);
+			if (registryCredentials.length) this.registryCredentials = registryCredentials;
+			if (gitCredentials.length) this.gitCredentials = gitCredentials;
+		}
 		const componentsRoot = getConfigPath(CONFIG_PARAMS.COMPONENTSROOT);
 		if (!componentsRoot) throw new Error('componentsRoot is not configured');
 		this.dirPath = join(componentsRoot, name);
@@ -619,6 +832,37 @@ export class Application {
 		content += buildNpmrcContent(this.registryCredentials);
 		await writeFile(npmrcPath, content, { mode: 0o600 });
 		this.npmUserconfigPath = npmrcPath;
+	}
+
+	// Environment that lets git reach this deploy's credential socket. Applied ONLY to the spawn that
+	// clones the git reference (`npm pack`) — see prepareApplication.
+	get gitCredentialEnv(): Record<string, string> | undefined {
+		return this.#gitCredentialSession?.env;
+	}
+
+	// Start serving this deploy's git-host credentials from memory. No-op without git credentials.
+	async startGitCredentialSession(): Promise<void> {
+		if (!this.gitCredentials?.length) return;
+		if (this.#gitCredentialSession) await this.cleanupGitCredentialSession();
+		this.#gitCredentialSession = await startGitCredentialSession(this.gitCredentials, GIT_CREDENTIAL_HELPER_PATH);
+	}
+
+	// Tear the socket down as soon as the clone is done, so nothing later in the deploy — including
+	// the component's own install scripts — can still ask for the credential.
+	async cleanupGitCredentialSession(): Promise<void> {
+		const session = this.#gitCredentialSession;
+		if (!session) return;
+		this.#gitCredentialSession = undefined;
+		try {
+			await session.close();
+		} catch (error) {
+			// Called from prepareApplication's finally; a throw here would mask the deploy's own error.
+			this.logger.warn(`Failed to close git credential session:`, error);
+		} finally {
+			// Drop the in-memory tokens too, so they can't surface in a later heap dump or error
+			// serialization of this Application instance.
+			this.gitCredentials = undefined;
+		}
 	}
 
 	// Remove the transient `.npmrc` (and its temp dir) once the deploy's npm work is done.
@@ -680,7 +924,16 @@ export async function prepareApplication(application: Application) {
 		// Materialize the per-deploy `.npmrc` before extraction so both `npm pack` (extract) and
 		// `npm install` authenticate against the private registry; always remove it afterward.
 		await application.writeTransientNpmrc();
-		await extractApplication(application);
+		try {
+			// The git credential socket only has to be up for extraction — that is where npm resolves and
+			// clones a git-reference package. Closing it before installApplication means the credential is
+			// already gone by the time the component's dependency tree (and any install script it is
+			// allowed to run) executes.
+			await application.startGitCredentialSession();
+			await extractApplication(application);
+		} finally {
+			await application.cleanupGitCredentialSession();
+		}
 		await installApplication(application);
 	} finally {
 		await application.cleanupTransientNpmrc();
@@ -748,11 +1001,11 @@ export async function installApplications() {
 			// re-supplied. Best-effort: if custody isn't available yet or a referenced secret is
 			// missing, log and install without it (a truly private package then fails in npm with its
 			// own error) rather than blocking boot.
-			let registryCredentials: ResolvedRegistryCredential[] | undefined;
+			let credentials: ResolvedCredential[] | undefined;
 			if (applicationConfig.credentials?.length) {
 				try {
 					const { resolveCredentials } = await import('./secretOperations.ts');
-					registryCredentials = await resolveCredentials(applicationConfig.credentials, name);
+					credentials = await resolveCredentials(applicationConfig.credentials, name);
 				} catch (error) {
 					logger.warn?.(
 						`Could not resolve credentials for application ${name} at install time: ${(error as Error).message}`
@@ -764,7 +1017,7 @@ export async function installApplications() {
 				name,
 				packageIdentifier: applicationConfig.package,
 				install: applicationConfig.install,
-				registryCredentials,
+				credentials,
 			});
 
 			// Lock check: only install if not already installed with matching configuration
@@ -902,7 +1155,8 @@ export function nonInteractiveSpawn(
 	cwd: string,
 	timeoutMs: number = 60 * 60 * 1000,
 	onLine?: (stream: 'stdout' | 'stderr', line: string) => void,
-	npmUserconfigPath?: string
+	npmUserconfigPath?: string,
+	gitCredentialEnv?: Record<string, string>
 ): Promise<{ stdout: string; stderr: string; code: number }> {
 	return new Promise((resolve, reject) => {
 		logger
@@ -914,6 +1168,18 @@ export function nonInteractiveSpawn(
 		const gitSSHCommand = getGitSSHCommand();
 		if (gitSSHCommand) {
 			env.GIT_SSH_COMMAND = gitSSHCommand;
+		}
+
+		// The git credential channel is granted per spawn, and only to the one that clones the git
+		// reference. Every other spawn — notably `npm install`, where a dependency's install script can
+		// run — has it removed, so a transitive dependency cannot ask for a credential that was supplied
+		// for the top-level repository. Only the socket variable is stripped rather than any inherited
+		// GIT_ASKPASS/GIT_CONFIG_*: those may be the operator's own git auth, and without a socket to
+		// reach, our helper answers nothing and is inert.
+		if (gitCredentialEnv) {
+			Object.assign(env, gitCredentialEnv);
+		} else {
+			delete env[GIT_CREDENTIAL_SOCKET_ENV];
 		}
 
 		// A deploy carrying transient registry auth points npm at a per-deploy `.npmrc` so

--- a/components/deploymentRecorder.ts
+++ b/components/deploymentRecorder.ts
@@ -15,7 +15,7 @@ import { Readable, Transform, pipeline } from 'node:stream';
 import { databases } from '../resources/databases.ts';
 import { createBlob, isSaving, deleteBlob } from '../resources/blob.ts';
 import * as terms from '../utility/hdbTerms.ts';
-import type { RegistryAuthReference } from './secretOperations.ts';
+import type { RegistryCredentialReference } from './secretOperations.ts';
 import { ClientError } from '../utility/errors/hdbError.ts';
 import { logger } from '../utility/logging/logger.ts';
 import { hostname } from 'node:os';
@@ -62,10 +62,10 @@ interface CreateOptions {
 	user?: string;
 	restart_mode?: 'immediate' | 'rolling' | null;
 	rollback_of?: string | null;
-	// Registry-auth in reference form (`{ registry, secret, scope? }`) — never a literal token. Kept
-	// so a rollback can re-resolve the private-registry credential from hdb_secret without the
-	// operator re-supplying it. Null when the deploy used no auth or a no-custody transient token.
-	registry_auth?: RegistryAuthReference[] | null;
+	// Deploy credentials in reference form (`{ registry, secret, scope? }`) — never a literal token.
+	// Kept so a rollback can re-resolve the credential from hdb_secret without the operator
+	// re-supplying it. Null when the deploy used no credentials or a no-custody transient token.
+	credentials?: RegistryCredentialReference[] | null;
 	emitter?: ProgressEmitter;
 }
 
@@ -103,7 +103,7 @@ export class DeploymentRecorder {
 			completed_at: null,
 			user: options.user ?? null,
 			rollback_of: options.rollback_of ?? null,
-			registry_auth: options.registry_auth ?? null,
+			credentials: options.credentials ?? null,
 			error: null,
 		};
 		const recorder = new DeploymentRecorder(deploymentId, record);

--- a/components/deploymentRecorder.ts
+++ b/components/deploymentRecorder.ts
@@ -15,7 +15,7 @@ import { Readable, Transform, pipeline } from 'node:stream';
 import { databases } from '../resources/databases.ts';
 import { createBlob, isSaving, deleteBlob } from '../resources/blob.ts';
 import * as terms from '../utility/hdbTerms.ts';
-import type { RegistryCredentialReference } from './secretOperations.ts';
+import type { CredentialReference } from './secretOperations.ts';
 import { ClientError } from '../utility/errors/hdbError.ts';
 import { logger } from '../utility/logging/logger.ts';
 import { hostname } from 'node:os';
@@ -62,10 +62,11 @@ interface CreateOptions {
 	user?: string;
 	restart_mode?: 'immediate' | 'rolling' | null;
 	rollback_of?: string | null;
-	// Deploy credentials in reference form (`{ registry, secret, scope? }`) — never a literal token.
-	// Kept so a rollback can re-resolve the credential from hdb_secret without the operator
-	// re-supplying it. Null when the deploy used no credentials or a no-custody transient token.
-	credentials?: RegistryCredentialReference[] | null;
+	// Deploy credentials in reference form (`{ registry, secret, scope? }` / `{ host, secret,
+	// username? }`) — never a literal token. Kept so a rollback can re-resolve the credential from
+	// hdb_secret without the operator re-supplying it. Null when the deploy used no credentials or a
+	// no-custody transient token.
+	credentials?: CredentialReference[] | null;
 	emitter?: ProgressEmitter;
 }
 

--- a/components/gitCredentialHelper.js
+++ b/components/gitCredentialHelper.js
@@ -1,0 +1,115 @@
+'use strict';
+
+// Credential helper for private git-reference deploys (#1792), executed by git as a child process.
+//
+// It holds no secret. The token lives only in the deploying Harper process's memory; this script
+// asks for it over the per-deploy socket named by HARPER_GIT_CREDENTIAL_SOCKET (see
+// gitCredentialServer.ts) and writes the answer to stdout for git to consume. Nothing is written to
+// disk, and the token never appears in argv or in this process's environment.
+//
+// git invokes it two ways, so it answers both:
+//   - as a `credential.helper` (git >= 2.31, wired up via GIT_CONFIG_*): the operation
+//     (`get`/`store`/`erase`) is the last argument and the request is key=value lines on stdin.
+//   - as GIT_ASKPASS (every git version): the prompt is the first argument.
+// Only `get` yields anything; `store`/`erase` are deliberate no-ops, since persisting the
+// credential is exactly what this design exists to avoid.
+
+const net = require('node:net');
+
+const socketPath = process.env.HARPER_GIT_CREDENTIAL_SOCKET;
+
+function ask(request) {
+	return new Promise((resolve, reject) => {
+		const socket = net.connect(socketPath);
+		socket.setEncoding('utf8');
+		let response = '';
+		socket.on('error', reject);
+		socket.on('connect', () => socket.end(JSON.stringify(request)));
+		socket.on('data', (chunk) => (response += chunk));
+		socket.on('close', () => {
+			try {
+				resolve(response ? JSON.parse(response) : {});
+			} catch (error) {
+				reject(error);
+			}
+		});
+	});
+}
+
+function readStdin() {
+	return new Promise((resolve, reject) => {
+		let input = '';
+		process.stdin.setEncoding('utf8');
+		process.stdin.on('data', (chunk) => (input += chunk));
+		process.stdin.on('error', reject);
+		process.stdin.on('end', () => resolve(input));
+	});
+}
+
+// git's credential protocol: `key=value` lines terminated by a blank line.
+function parseCredentialRequest(input) {
+	const request = {};
+	for (const line of input.split('\n')) {
+		const separator = line.indexOf('=');
+		if (separator > 0) request[line.slice(0, separator)] = line.slice(separator + 1).replace(/\r$/, '');
+	}
+	return request;
+}
+
+/**
+ * Interpret a GIT_ASKPASS prompt, e.g. `Username for 'https://github.com': ` or
+ * `Password for 'https://x-access-token@github.com': `.
+ *
+ * The leading words are localized, so which of the two prompts this is has to be decided
+ * structurally rather than by matching English: git only asks for a password once it has a
+ * username, and it embeds that username in the URL it echoes back. Userinfo present therefore means
+ * the password prompt; absent means the username prompt.
+ */
+function parseAskpassPrompt(prompt) {
+	const quoted = /'([^']+)'/.exec(prompt);
+	if (!quoted) return null;
+	// url.username can carry a malformed percent-encoding sequence (e.g. from a redirect or a
+	// misconfigured remote), which makes decodeURIComponent throw a URIError — keep that inside the
+	// same try as the URL parse so it can't crash this process instead of just declining to answer.
+	try {
+		const url = new URL(quoted[1]);
+		return {
+			field: url.username ? 'password' : 'username',
+			protocol: url.protocol.replace(/:$/, ''),
+			host: url.host,
+			username: url.username ? decodeURIComponent(url.username) : undefined,
+		};
+	} catch {
+		return null;
+	}
+}
+
+async function main() {
+	if (!socketPath) return; // no session for this spawn: stay silent so git falls through unauthenticated
+
+	const args = process.argv.slice(2);
+	const operation = args[args.length - 1];
+
+	if (operation === 'get') {
+		const request = parseCredentialRequest(await readStdin());
+		const credential = await ask({ protocol: request.protocol, host: request.host, username: request.username });
+		if (!credential.password) return;
+		process.stdout.write(`username=${credential.username}\npassword=${credential.password}\n`);
+		return;
+	}
+	if (operation === 'store' || operation === 'erase') return;
+
+	const prompt = parseAskpassPrompt(args[0] ?? '');
+	if (!prompt) return;
+	const credential = await ask(prompt);
+	if (!credential.password) return;
+	process.stdout.write(`${prompt.field === 'username' ? credential.username : credential.password}\n`);
+}
+
+main().catch((error) => {
+	// Never leak request detail to git's stderr, which npm surfaces in deploy output. Exiting
+	// non-zero makes git treat the credential as unavailable and fail (GIT_TERMINAL_PROMPT=0
+	// prevents it from falling back to an interactive prompt).
+	process.stderr.write(`harper git credential helper failed: ${error.message}\n`);
+	process.exitCode = 1;
+});

--- a/components/gitCredentialServer.ts
+++ b/components/gitCredentialServer.ts
@@ -1,0 +1,251 @@
+// Per-deploy git credential channel for private git-reference deploys (#1792).
+//
+// npm shells out to git to resolve a `github:org/repo#semver:...` package, and a private repo makes
+// that clone need a credential. Every obvious way to hand git one persists it: a URL with embedded
+// userinfo lands in the package spec and the lockfile, a `credential.helper` or an `.npmrc` is a
+// file, and an env var is readable by every descendant process.
+//
+// Instead the token stays in this process's memory and is served over a per-deploy Unix socket in a
+// 0700 directory. git is pointed at gitCredentialHelper.js — a secret-free script that relays git's
+// request over that socket — and the socket dies with the spawn that needed it. The token never
+// reaches disk, argv, the package spec, the operation body, or the operations log.
+
+import { createServer, type Server, type Socket } from 'node:net';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ClientError } from '../utility/errors/hdbError.ts';
+import logger from '../utility/logging/harper_logger.ts';
+
+// GitHub's convention for authenticating a PAT over HTTPS: any non-empty username works, and
+// `x-access-token` is what its own tooling sends. GitLab wants `oauth2` and Bitbucket
+// `x-token-auth`, so a credential entry can override it.
+export const DEFAULT_GIT_USERNAME = 'x-access-token';
+
+// The one variable that carries authority: without it gitCredentialHelper.js cannot reach a session
+// and answers nothing, so stripping it from a spawn's environment fully disarms the helper even if
+// GIT_ASKPASS/GIT_CONFIG_* were somehow inherited.
+export const GIT_CREDENTIAL_SOCKET_ENV = 'HARPER_GIT_CREDENTIAL_SOCKET';
+
+// Generous for git's key=value request (a few hundred bytes), small enough that a peer streaming
+// junk cannot exhaust the heap.
+const MAX_REQUEST_BYTES = 64 * 1024;
+
+/** A git-host credential after resolution: a literal token, held in memory for one deploy. */
+export interface ResolvedGitCredential {
+	host: string;
+	token: string;
+	username?: string;
+}
+
+export interface GitCredentialSession {
+	/** Environment to merge into the spawn that performs the git clone — and only that spawn. */
+	env: Record<string, string>;
+	close(): Promise<void>;
+}
+
+/** `https://github.com/` / `GitHub.com` / `github.com/` all identify the same host. */
+export function normalizeGitHost(host: string): string {
+	return host
+		.trim()
+		.replace(/^[a-z0-9+.-]+:\/\//i, '')
+		.replace(/^\/\//, '')
+		.replace(/\/.*$/, '')
+		.replace(/^[^@]*@/, '')
+		.toLowerCase();
+}
+
+// A loopback remote never puts the credential on a network, so plaintext http to one is not a
+// disclosure. Anything else must be encrypted.
+function isLoopbackHost(host: string): boolean {
+	const hostname = host.replace(/:\d+$/, '').replace(/^\[|\]$/g, '');
+	return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+}
+
+function answerFor(credentials: Map<string, ResolvedGitCredential>, request: any) {
+	if (!request || typeof request !== 'object') return {};
+	const host = typeof request.host === 'string' ? normalizeGitHost(request.host) : '';
+	const credential = credentials.get(host);
+	// An unknown host is not an error: git also asks about public hosts, and answering nothing lets
+	// it proceed unauthenticated rather than failing the deploy.
+	if (!credential) return {};
+	// Never hand a token to a cleartext transport. git asks for `http://` credentials exactly as it
+	// asks for `https://` ones, so without this a `git+http://` package (or a remote downgraded by a
+	// redirect) would put the token on the wire in the clear.
+	const protocol = typeof request.protocol === 'string' ? request.protocol.toLowerCase() : '';
+	if (protocol && protocol !== 'https' && !isLoopbackHost(host)) {
+		logger.warn?.(`refusing to serve a git credential for '${host}' over ${protocol}: only https is allowed`);
+		return {};
+	}
+	// git's credential protocol is line-based (and askpass reads only the first line), so a token
+	// carrying a newline would be truncated or would inject protocol attributes. A literal token is
+	// already rejected by the op schema; one resolved from an hdb_secret row is not, so guard the
+	// write boundary — the same place the .npmrc writer guards (#1717).
+	if (/[\r\n\0]/.test(credential.token)) {
+		logger.warn?.(`git credential for '${host}' contains an illegal control character; refusing to serve it`);
+		return {};
+	}
+	// git only re-asks with a username once it has one; if it names a different user than the one
+	// this credential is for, the credential does not apply.
+	const username = credential.username ?? DEFAULT_GIT_USERNAME;
+	if (typeof request.username === 'string' && request.username && request.username !== username) return {};
+	return { username, password: credential.token };
+}
+
+// The `credential.helper` reset below only takes effect on git >= 2.31, where GIT_CONFIG_* is
+// honored; older git ignores those variables entirely and would fall through to GIT_ASKPASS with an
+// inherited helper chain still live — so a machine configured with `credential.helper=store` would
+// write this token to ~/.git-credentials. There is no way to disable an inherited helper on those
+// versions, so refuse to serve a credential at all rather than persist one behind the operator's back.
+const MINIMUM_GIT_VERSION = [2, 31];
+function assertGitSupportsConfigEnv(): void {
+	let version: string;
+	try {
+		version = execFileSync('git', ['--version'], { encoding: 'utf8' });
+	} catch (error) {
+		throw new ClientError(`git is required to deploy from a git reference, but could not be run: ${error}`);
+	}
+	const parsed = /(\d+)\.(\d+)/.exec(version);
+	if (!parsed) throw new ClientError(`Could not determine the git version from '${version.trim()}'`);
+	const [major, minor] = [Number(parsed[1]), Number(parsed[2])];
+	if (major < MINIMUM_GIT_VERSION[0] || (major === MINIMUM_GIT_VERSION[0] && minor < MINIMUM_GIT_VERSION[1])) {
+		throw new ClientError(
+			`git ${MINIMUM_GIT_VERSION.join('.')} or newer is required to deploy with a git-host credential ` +
+				`(found ${version.trim()}): older versions ignore GIT_CONFIG_*, so an inherited credential helper ` +
+				`could persist the token to disk.`
+		);
+	}
+}
+
+/**
+ * Start a credential session for one deploy. Returns the environment that lets git reach it, which
+ * the caller must apply ONLY to the spawn doing the clone (`npm pack`), never to the `npm install`
+ * that follows — a transitive dependency's install script must not be able to ask for a credential
+ * that was granted for the top-level repository.
+ *
+ * Wiring, in order of preference:
+ *   - `credential.helper` via GIT_CONFIG_* (git >= 2.31). Structured key=value protocol, no prompt
+ *     parsing. Inherited helpers are reset to empty first, so a machine configured with
+ *     `credential.helper=store` cannot write this token to ~/.git-credentials when git reports the
+ *     successful authentication back to its helper chain.
+ *   - GIT_ASKPASS, honored by every git version, as the fallback for git < 2.31 (where GIT_CONFIG_*
+ *     is silently ignored). npm's own git wrapper sets `GIT_ASKPASS=echo`, but only when the
+ *     variable is unset, so ours survives.
+ * GIT_TERMINAL_PROMPT=0 keeps git from falling back to a terminal prompt (which would hang a deploy
+ * rather than fail it) if neither path yields a credential.
+ */
+export async function startGitCredentialSession(
+	credentials: ResolvedGitCredential[],
+	helperPath: string
+): Promise<GitCredentialSession> {
+	const byHost = new Map<string, ResolvedGitCredential>();
+	for (const credential of credentials) {
+		const host = normalizeGitHost(credential.host);
+		// Two entries for the same host in one deploy is operator error — the second silently wins here
+		// (and its sealed secret already overwrote the first's, sharing a derived name). Surface it.
+		if (byHost.has(host)) logger.warn?.(`multiple git credentials supplied for host '${host}'; using the last`);
+		byHost.set(host, credential);
+	}
+
+	// The credential's confinement rests on filesystem permissions: a 0700 directory means only this
+	// uid can reach the socket. A Windows named pipe has no equivalent guarantee — it is created with
+	// a default security descriptor that can leave it open to other local users, which would hand the
+	// token to any process on the box. Rather than offer a quietly weaker credential channel, fail
+	// closed and let the operator use a deploy path whose isolation we can actually state.
+	if (process.platform === 'win32') {
+		throw new ClientError(
+			'git-host deploy credentials are not supported on Windows: the credential is served over a Unix ' +
+				'domain socket, which has no Windows equivalent that can be confined to this process owner.'
+		);
+	}
+	// Fail before minting a socket if git is too old for the credential-helper reset to hold.
+	assertGitSupportsConfigEnv();
+	// mkdtemp creates the directory 0700, so only this uid can reach the socket inside it.
+	const socketDir = await mkdtemp(join(tmpdir(), 'harper-git-cred-'));
+	const socketPath = join(socketDir, 'credential.sock');
+
+	const connections = new Set<Socket>();
+	// allowHalfOpen: the helper half-closes after sending its request, and we must still be able to
+	// write the answer back.
+	const server: Server = createServer({ allowHalfOpen: true }, (connection) => {
+		connections.add(connection);
+		connection.on('close', () => connections.delete(connection));
+		// A helper that dies mid-request must not take the node down with an unhandled 'error'.
+		connection.on('error', (error) => logger.warn?.(`git credential connection failed: ${error.message}`));
+		connection.setEncoding('utf8');
+		let request = '';
+		connection.on('data', (chunk) => {
+			request += chunk;
+			// A real request is a few hundred bytes. Cap it so a peer that streams without ever closing
+			// cannot grow this buffer until the node runs out of heap.
+			if (request.length > MAX_REQUEST_BYTES) {
+				logger.warn?.('git credential request exceeded the maximum size; dropping the connection');
+				connection.destroy();
+			}
+		});
+		connection.on('end', () => {
+			let answer: object;
+			try {
+				answer = answerFor(byHost, JSON.parse(request));
+			} catch {
+				answer = {};
+			}
+			connection.end(JSON.stringify(answer));
+		});
+	});
+	server.on('error', (error) => logger.warn?.(`git credential server failed: ${error.message}`));
+
+	try {
+		await new Promise<void>((resolve, reject) => {
+			server.once('error', reject);
+			server.listen(socketPath, () => {
+				server.removeListener('error', reject);
+				resolve();
+			});
+		});
+	} catch (error) {
+		// listen() failed, so no session is returned and nothing will call close() — take the temp dir
+		// with us rather than leaving a 0700 directory behind on every failed deploy.
+		await rm(socketDir, { recursive: true, force: true }).catch(() => {});
+		throw error;
+	}
+
+	// Quoted so a Harper installed under a path with spaces still works: git runs both the askpass
+	// command and a `!`-prefixed credential helper through a shell.
+	const helperCommand = `"${process.execPath}" "${helperPath}"`;
+	// Append to any GIT_CONFIG_* the operator already set rather than overwriting theirs; ours come
+	// last, which is also where git takes precedence from.
+	const inheritedCount = Number.parseInt(process.env.GIT_CONFIG_COUNT ?? '', 10);
+	const base = Number.isInteger(inheritedCount) && inheritedCount > 0 ? inheritedCount : 0;
+	const env: Record<string, string> = {
+		[GIT_CREDENTIAL_SOCKET_ENV]: socketPath,
+		GIT_TERMINAL_PROMPT: '0',
+		GIT_ASKPASS: helperCommand,
+		GIT_CONFIG_COUNT: String(base + 2),
+		// An empty value resets git's credential helper list, dropping any inherited helper.
+		[`GIT_CONFIG_KEY_${base}`]: 'credential.helper',
+		[`GIT_CONFIG_VALUE_${base}`]: '',
+		[`GIT_CONFIG_KEY_${base + 1}`]: 'credential.helper',
+		[`GIT_CONFIG_VALUE_${base + 1}`]: `!${helperCommand}`,
+	};
+
+	return {
+		env,
+		async close() {
+			byHost.clear();
+			// destroy() synchronously fires each connection's 'close' listener, which deletes it from this
+			// same Set — iterate a snapshot so that mid-iteration mutation cannot skip a connection.
+			const connectionsSnapshot = Array.from(connections);
+			for (const connection of connectionsSnapshot) connection.destroy();
+			connections.clear();
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+			try {
+				await rm(socketDir, { recursive: true, force: true });
+			} catch (error) {
+				// Called from a finally; a throw here would mask the deploy's own error.
+				logger.warn?.(`Failed to remove git credential socket dir ${socketDir}: ${(error as Error).message}`);
+			}
+		},
+	};
+}

--- a/components/operations.js
+++ b/components/operations.js
@@ -498,8 +498,10 @@ async function deployComponent(req) {
 				installCapture.push(manager, stream, line);
 				if (emitter) emit('install', { manager, stream, line });
 			},
-			// Private-registry credentials (already resolved above), used here for this node's npm pack/install.
-			registryCredentials: resolvedCredentials,
+			// Deploy credentials (already resolved above), used here for this node's npm pack/install:
+			// registry entries via a transient .npmrc, git-host entries via the in-memory credential
+			// socket the clone spawn talks to.
+			credentials: resolvedCredentials,
 		});
 		// Reduce req.credentials to references only (never a token) before it can reach an error/log
 		// path or replication: references are what peers resolve from their own replicated hdb_secret

--- a/components/operations.js
+++ b/components/operations.js
@@ -370,15 +370,15 @@ async function deployComponent(req) {
 		throw handleHDBError(validation, validation.message, HTTP_STATUS_CODES.BAD_REQUEST);
 	}
 
-	// Ingest any provided registry token into the secrets store so the credential lives as
+	// Ingest any provided credential token into the secrets store so the credential lives as
 	// replicated ciphertext (reference, not embed); already-reference entries pass through, and with
 	// no custody a literal token stays as a transient, this-node-only fallback (#1158). Peers
 	// re-running a replicated deploy already carry references and never re-ingest.
-	const { ingestRegistryAuth, resolveRegistryAuth } = require('./secretOperations.ts');
-	req.registryAuth = await ingestRegistryAuth(req, req.registryAuth, req.project);
+	const { ingestCredentials, resolveCredentials } = require('./secretOperations.ts');
+	req.credentials = await ingestCredentials(req, req.credentials, req.project);
 	// References are safe to persist (config + deployment row) and replicate; a no-custody literal
 	// token is not — it is used only for this node's install below, then stripped before replication.
-	const registryAuthReferences = (req.registryAuth ?? []).filter((entry) => entry && entry.secret !== undefined);
+	const credentialReferences = (req.credentials ?? []).filter((entry) => entry && entry.secret !== undefined);
 
 	// Write to root config if the request contains a package identifier
 	if (req.package) {
@@ -403,9 +403,9 @@ async function deployComponent(req) {
 			};
 		}
 		if (req.urlPath !== undefined) applicationConfig.urlPath = req.urlPath;
-		// Persist registry-auth references (never tokens) so every cold install of this component —
+		// Persist credential references (never tokens) so every cold install of this component —
 		// reboot, new peer, rollback — re-resolves the credential from the store.
-		if (registryAuthReferences.length) applicationConfig.registryAuth = registryAuthReferences;
+		if (credentialReferences.length) applicationConfig.credentials = credentialReferences;
 		await configUtils.addConfig(req.project, applicationConfig);
 	}
 
@@ -430,8 +430,8 @@ async function deployComponent(req) {
 				package_identifier: req.package ?? null,
 				user: req.hdb_user?.username,
 				restart_mode: req.restart === 'rolling' ? 'rolling' : req.restart ? 'immediate' : null,
-				// Reference form only — the rollback source for re-resolving registry auth.
-				registry_auth: registryAuthReferences.length ? registryAuthReferences : null,
+				// Reference form only — the rollback source for re-resolving the credential.
+				credentials: credentialReferences.length ? credentialReferences : null,
 				emitter,
 			});
 	if (recorder) req._deploymentId = recorder.deploymentId;
@@ -469,17 +469,17 @@ async function deployComponent(req) {
 			extractionPayload = row.payload_blob.stream();
 		}
 
-		// Resolve registryAuth references into concrete tokens for this node's npm pack/install
+		// Resolve credential references into concrete tokens for this node's npm pack/install
 		// (a no-custody literal-token fallback passes through unchanged). On a peer running a
 		// replicated deploy, the referenced hdb_secret row may arrive just behind the deploy op, so
 		// allow a bounded grace period (same budget as the payload-row wait) for it to replicate in.
-		let registryAuthWaitMs = 0;
+		let credentialsWaitMs = 0;
 		if (isReplicatedExecution) {
 			const requested = Number(req.deployment_timeout);
-			registryAuthWaitMs = Number.isFinite(requested) && requested >= 0 ? requested : DEFAULT_AWAIT_ROW_TIMEOUT_MS;
+			credentialsWaitMs = Number.isFinite(requested) && requested >= 0 ? requested : DEFAULT_AWAIT_ROW_TIMEOUT_MS;
 		}
-		const resolvedRegistryAuth = await resolveRegistryAuth(req.registryAuth, req.project, {
-			waitMs: registryAuthWaitMs,
+		const resolvedCredentials = await resolveCredentials(req.credentials, req.project, {
+			waitMs: credentialsWaitMs,
 		});
 
 		const application = new Application({
@@ -498,16 +498,16 @@ async function deployComponent(req) {
 				installCapture.push(manager, stream, line);
 				if (emitter) emit('install', { manager, stream, line });
 			},
-			// Private-registry auth (already resolved above), used here for this node's npm pack/install.
-			registryAuth: resolvedRegistryAuth,
+			// Private-registry credentials (already resolved above), used here for this node's npm pack/install.
+			registryCredentials: resolvedCredentials,
 		});
-		// Reduce req.registryAuth to references only (never a token) before it can reach an error/log
+		// Reduce req.credentials to references only (never a token) before it can reach an error/log
 		// path or replication: references are what peers resolve from their own replicated hdb_secret
 		// copy; a no-custody literal token is dropped entirely (peers fall back to their fabric-injected
 		// NPM_CONFIG_USERCONFIG, as before). This also fixes the prior success-only strip that leaked a
 		// literal token on a prepare/load failure.
-		if (registryAuthReferences.length) req.registryAuth = registryAuthReferences;
-		else delete req.registryAuth;
+		if (credentialReferences.length) req.credentials = credentialReferences;
+		else delete req.credentials;
 
 		emit('phase', { phase: 'prepare', status: 'start' });
 		await prepareApplication(application);
@@ -556,7 +556,7 @@ async function deployComponent(req) {
 		// ProgressEmitter holds function listeners that can't survive the replication
 		// channel's serialization; strip it unconditionally.
 		delete req.progress;
-		// req.registryAuth was already deleted immediately after the Application ctor (above) so the
+		// req.credentials was already deleted immediately after the Application ctor (above) so the
 		// token never reaches the replication channel or a peer's operation log; peers authenticate
 		// against the private registry via their own fabric-injected NPM_CONFIG_USERCONFIG on reinstall.
 		if (systemReplicated && recorder) {

--- a/components/operationsValidation.js
+++ b/components/operationsValidation.js
@@ -371,6 +371,25 @@ function packageComponentValidator(req) {
 	return validator.validateBySchema(req, packageProjSchema);
 }
 
+// An npm registry-auth credential entry, identified by its `registry` key.
+const REGISTRY_CREDENTIAL_ENTRY = Joi.object({
+	// registry and token are written verbatim into the transient .npmrc, which is line-based;
+	// forbid CR/LF so a super_user can't inject extra npm config lines. (registry also accepts
+	// bare hosts and //host/ forms, so a strict URI validator would reject supported inputs — the
+	// newline guard is the right scope here.)
+	registry: Joi.string()
+		.pattern(/^[^\r\n]+$/)
+		.required(),
+	token: Joi.string().pattern(/^[^\r\n]+$/),
+	// A reference into the hdb_secret store; same name grammar as set_secret's `name`.
+	secret: Joi.string()
+		.pattern(ENV_KEY_REGEX)
+		.messages({ 'string.pattern.base': `'secret' must only contain word characters, dots and dashes` }),
+	scope: Joi.string()
+		.pattern(/^@[a-z0-9-_.]+$/)
+		.optional(),
+}).xor('token', 'secret');
+
 /**
  * Validate deployComponent requests.
  * @param req
@@ -398,33 +417,24 @@ function deployComponentValidator(req) {
 			})
 			.optional()
 			.messages({ 'any.invalid': 'urlPath must not contain ".."' }),
-		// Private-registry auth. Each entry supplies its credential exactly one of two ways:
-		//   - `token`: a literal token, used only for this node's npm pack/install and never
-		//     persisted or replicated (stripped from req before replicateOperation).
+		// Deploy credentials. The array is kind-heterogeneous: an entry's kind is implied by its
+		// identifying key rather than a separate discriminator field, so a new kind (e.g. a git-host
+		// credential keyed by `host`, #1792) is added as another item alternative here without
+		// reshaping the field. Today the only kind is npm registry auth (`registry`).
+		//
+		// Every kind supplies its credential exactly one of two ways:
+		//   - `token`: a literal token, used only for this node's install and never persisted or
+		//     replicated (stripped from req before replicateOperation).
 		//   - `secret`: the name of an hdb_secret row (#1550); the token is resolved by decrypting
 		//     that row on this node at deploy time, so the credential lives in the secrets store
 		//     (reference, not embed) instead of travelling in the operation body.
-		registryAuth: Joi.array()
-			.items(
-				Joi.object({
-					// registry and token are written verbatim into the transient .npmrc, which is
-					// line-based; forbid CR/LF so a super_user can't inject extra npm config lines.
-					// (registry also accepts bare hosts and //host/ forms, so a strict URI validator
-					// would reject supported inputs — the newline guard is the right scope here.)
-					registry: Joi.string()
-						.pattern(/^[^\r\n]+$/)
-						.required(),
-					token: Joi.string().pattern(/^[^\r\n]+$/),
-					// A reference into the hdb_secret store; same name grammar as set_secret's `name`.
-					secret: Joi.string()
-						.pattern(ENV_KEY_REGEX)
-						.messages({ 'string.pattern.base': `'secret' must only contain word characters, dots and dashes` }),
-					scope: Joi.string()
-						.pattern(/^@[a-z0-9-_.]+$/)
-						.optional(),
-				}).xor('token', 'secret')
-			)
-			.optional(),
+		credentials: Joi.array().items(REGISTRY_CREDENTIAL_ENTRY).optional(),
+		// `registryAuth` was this field's name on the 5.2 dev line before it grew to carry other
+		// credential kinds. Rejected rather than ignored: validation allows unknown keys, so a caller
+		// still sending it would otherwise get a deploy that silently installs with no credentials.
+		registryAuth: Joi.any().forbidden().messages({
+			'any.unknown': `'registryAuth' has been renamed to 'credentials'`,
+		}),
 	}).with('urlPath', 'package');
 
 	return validator.validateBySchema(req, deployProjSchema);

--- a/components/operationsValidation.js
+++ b/components/operationsValidation.js
@@ -371,8 +371,14 @@ function packageComponentValidator(req) {
 	return validator.validateBySchema(req, packageProjSchema);
 }
 
-// An npm registry-auth credential entry, identified by its `registry` key.
+// An npm registry-auth credential entry, identified by its `registry` key. `host` is forbidden
+// rather than merely unused: operation validation allows unknown keys, so without this an entry
+// carrying both discriminators would validate as npm registry auth and its git half would be
+// silently dropped.
 const REGISTRY_CREDENTIAL_ENTRY = Joi.object({
+	host: Joi.any().forbidden().messages({
+		'any.unknown': `a credential entry is either npm registry auth ('registry') or git host auth ('host'), not both`,
+	}),
 	// registry and token are written verbatim into the transient .npmrc, which is line-based;
 	// forbid CR/LF so a super_user can't inject extra npm config lines. (registry also accepts
 	// bare hosts and //host/ forms, so a strict URI validator would reject supported inputs — the
@@ -388,7 +394,45 @@ const REGISTRY_CREDENTIAL_ENTRY = Joi.object({
 	scope: Joi.string()
 		.pattern(/^@[a-z0-9-_.]+$/)
 		.optional(),
-}).xor('token', 'secret');
+})
+	.xor('token', 'secret')
+	// The whole operation validates with allowUnknown, but a credential entry must not: an unknown
+	// key here (a typo'd or future secret-bearing field like `password`) would pass through ingest
+	// unchanged and be persisted to config/hdb_deployment and replicated, defeating reference-only.
+	.unknown(false);
+
+// A git-host credential entry, identified by its `host` key (#1792). Used to authenticate the
+// `git clone`/`git ls-remote` npm runs for a git-reference `package` (e.g. `github:org/repo`); the
+// token is served to git from memory, never written to a file or a URL.
+const GIT_CREDENTIAL_ENTRY = Joi.object({
+	// A bare host, optionally with a port — `github.com`, `git.example.com:8443`. A scheme or path is
+	// tolerated and normalized away, but a credential is matched by host, so keep the grammar tight.
+	host: Joi.string()
+		.pattern(/^[^\s/@\\]+$/)
+		.required()
+		.messages({ 'string.pattern.base': `'host' must be a bare git host, e.g. 'github.com'` }),
+	// The username half of git's HTTPS basic auth. Defaults to GitHub's `x-access-token` convention;
+	// GitLab wants `oauth2` and Bitbucket `x-token-auth`.
+	username: Joi.string()
+		.pattern(/^[^\r\n:]+$/)
+		.optional(),
+	// Capped like other secret-bearing fields (SECRET_MAX_LENGTH, above): an unbounded literal token
+	// here feeds straight into synchronous envelope-sealing crypto, so without a cap it's a
+	// resource-exhaustion vector, not just a storage one.
+	token: Joi.string()
+		.pattern(/^[^\r\n]+$/)
+		.max(SECRET_MAX_LENGTH),
+	secret: Joi.string()
+		.pattern(ENV_KEY_REGEX)
+		.messages({ 'string.pattern.base': `'secret' must only contain word characters, dots and dashes` }),
+	// `registry` forbidden for symmetry with the npm entry: an entry carrying both discriminators has
+	// no single kind and must be rejected, not silently treated as git auth.
+	registry: Joi.any().forbidden().messages({
+		'any.unknown': `a credential entry is either npm registry auth ('registry') or git host auth ('host'), not both`,
+	}),
+})
+	.xor('token', 'secret')
+	.unknown(false);
 
 /**
  * Validate deployComponent requests.
@@ -418,9 +462,9 @@ function deployComponentValidator(req) {
 			.optional()
 			.messages({ 'any.invalid': 'urlPath must not contain ".."' }),
 		// Deploy credentials. The array is kind-heterogeneous: an entry's kind is implied by its
-		// identifying key rather than a separate discriminator field, so a new kind (e.g. a git-host
-		// credential keyed by `host`, #1792) is added as another item alternative here without
-		// reshaping the field. Today the only kind is npm registry auth (`registry`).
+		// identifying key rather than a separate discriminator field, so a new kind is added as
+		// another item alternative here without reshaping the field. Today: npm registry auth
+		// (`registry`) and git host auth for a git-reference package (`host`, #1792).
 		//
 		// Every kind supplies its credential exactly one of two ways:
 		//   - `token`: a literal token, used only for this node's install and never persisted or
@@ -428,7 +472,18 @@ function deployComponentValidator(req) {
 		//   - `secret`: the name of an hdb_secret row (#1550); the token is resolved by decrypting
 		//     that row on this node at deploy time, so the credential lives in the secrets store
 		//     (reference, not embed) instead of travelling in the operation body.
-		credentials: Joi.array().items(REGISTRY_CREDENTIAL_ENTRY).optional(),
+		// Dispatched on the presence of `registry` rather than tried as alternatives, so a malformed
+		// entry reports what is actually wrong with it (a newline in the token, an invalid scope) rather
+		// than a generic "no alternative matched".
+		credentials: Joi.array()
+			.items(
+				Joi.alternatives().conditional('.registry', {
+					is: Joi.exist(),
+					then: REGISTRY_CREDENTIAL_ENTRY,
+					otherwise: GIT_CREDENTIAL_ENTRY,
+				})
+			)
+			.optional(),
 		// `registryAuth` was this field's name on the 5.2 dev line before it grew to carry other
 		// credential kinds. Rejected rather than ignored: validation allows unknown keys, so a caller
 		// still sending it would otherwise get a deploy that silently installs with no credentials.

--- a/components/secretOperations.ts
+++ b/components/secretOperations.ts
@@ -325,15 +325,21 @@ export function getSecretsPublicKey(req: any) {
 	return { public_key: publicKey, fingerprint };
 }
 
-/** A resolved registry-auth entry as consumed by the transient .npmrc writer. */
-export interface ResolvedRegistryAuthEntry {
+// deploy_component `credentials` is a kind-heterogeneous array: an entry's kind is implied by its
+// identifying key (today `registry` = npm registry auth; a git-host kind keyed by `host` is planned
+// in #1792), and every kind carries its credential as either a literal `token` or a `secret`
+// reference. Ingest/resolve below are kind-agnostic about that token/secret half and only branch on
+// the identifying key where a kind-specific detail is needed (the derived secret name).
+
+/** A resolved registry credential as consumed by the transient .npmrc writer. */
+export interface ResolvedRegistryCredential {
 	registry: string;
 	token: string;
 	scope?: string;
 }
 
-/** A registry-auth entry after ingestion: a reference into hdb_secret, never a token. */
-export interface RegistryAuthReference {
+/** A registry credential after ingestion: a reference into hdb_secret, never a token. */
+export interface RegistryCredentialReference {
 	registry: string;
 	secret: string;
 	scope?: string;
@@ -358,9 +364,9 @@ export function deriveRegistrySecretName(component: string, registry: string): s
 }
 
 /**
- * Ingest deploy_component `registryAuth` into the secrets store so a provided registry token lives
- * as ciphertext in the replicated, audited `hdb_secret` store (reference, not embed) rather than
- * travelling in the operation body. Returns the entries in reference form (`{ registry, secret }`).
+ * Ingest deploy_component `credentials` into the secrets store so a provided token lives as
+ * ciphertext in the replicated, audited `hdb_secret` store (reference, not embed) rather than
+ * travelling in the operation body. Returns the entries in reference form (`{ …, secret }`).
  *
  * - A literal `{ registry, token }` entry is encrypted (via `set_secret`, custody required) under a
  *   derived name granted to `component`, and returned as a reference. Overwrites an existing
@@ -373,15 +379,20 @@ export function deriveRegistrySecretName(component: string, registry: string): s
  *
  * Runs on the deploying main thread where custody is registered.
  */
-export async function ingestRegistryAuth(req: any, registryAuth: any[] | undefined, component: string): Promise<any[]> {
-	if (!Array.isArray(registryAuth) || registryAuth.length === 0) return registryAuth ?? [];
+export async function ingestCredentials(req: any, credentials: any[] | undefined, component: string): Promise<any[]> {
+	if (!Array.isArray(credentials) || credentials.length === 0) return credentials ?? [];
 	const custody = getSecretCustody();
 	const out: any[] = [];
-	for (const entry of registryAuth) {
+	for (const entry of credentials) {
 		// Already a reference (or nothing to seal without custody): leave as-is.
 		if (entry.secret !== undefined || !custody) {
 			out.push(entry);
 			continue;
+		}
+		// The derived secret name is the one kind-specific detail on this path; a new credential kind
+		// derives its name from its own identifying key.
+		if (entry.registry === undefined) {
+			throw new ClientError(`Unsupported credential entry: expected a 'registry' (npm registry auth) entry`);
 		}
 		const name = deriveRegistrySecretName(component, entry.registry);
 		// Reuse set_secret's seal-and-store path (encrypt with custody, grant to the component, audit
@@ -416,7 +427,7 @@ async function waitForSecretRow(table: any, name: string, waitMs: number): Promi
 }
 
 /**
- * Resolve deploy_component `registryAuth` entries that reference a stored secret
+ * Resolve deploy_component `credentials` entries that reference a stored secret
  * (`{ registry, secret }`) into concrete token entries (`{ registry, token }`) by decrypting the
  * named hdb_secret row on this thread. Entries that already carry a literal `token` pass through
  * unchanged, so this is a no-op for the token-only fallback form.
@@ -440,19 +451,19 @@ async function waitForSecretRow(table: any, name: string, waitMs: number): Promi
  * (OSS core, or a custody key not held here) a referenced secret cannot be resolved and the deploy
  * fails loudly rather than silently installing without auth.
  */
-export async function resolveRegistryAuth(
-	registryAuth: any[] | undefined,
+export async function resolveCredentials(
+	credentials: any[] | undefined,
 	component: string,
 	options: { waitMs?: number } = {}
-): Promise<ResolvedRegistryAuthEntry[] | undefined> {
-	if (!Array.isArray(registryAuth) || registryAuth.length === 0) return registryAuth;
+): Promise<ResolvedRegistryCredential[] | undefined> {
+	if (!Array.isArray(credentials) || credentials.length === 0) return credentials;
 	// Token-only requests must not require custody or a provisioned store — keep the fast path pure.
-	if (!registryAuth.some((entry) => entry && entry.secret !== undefined)) return registryAuth;
+	if (!credentials.some((entry) => entry && entry.secret !== undefined)) return credentials;
 
 	const waitMs = options.waitMs ?? 0;
 	const table = secretTable();
-	const resolved: ResolvedRegistryAuthEntry[] = [];
-	for (const entry of registryAuth) {
+	const resolved: ResolvedRegistryCredential[] = [];
+	for (const entry of credentials) {
 		if (!entry) continue; // parity with the fast-path guard above; validated entries are never null
 		if (entry.secret === undefined) {
 			resolved.push({ registry: entry.registry, token: entry.token, scope: entry.scope });
@@ -462,14 +473,14 @@ export async function resolveRegistryAuth(
 		const row = waitMs > 0 ? await waitForSecretRow(table, name, waitMs) : await table.get(name);
 		if (!row) {
 			throw new ClientError(
-				`registryAuth references secret '${name}', which does not exist`,
+				`credential entry references secret '${name}', which does not exist`,
 				HTTP_STATUS_CODES.NOT_FOUND
 			);
 		}
 		const grants = Array.isArray(row.grants) ? row.grants : [];
 		if (!row.processEnv && !grants.includes(component)) {
 			throw new ClientError(
-				`registryAuth secret '${name}' is not granted to component '${component}' ` +
+				`credential secret '${name}' is not granted to component '${component}' ` +
 					`(grant it with grant_secret, or set it processEnv:true)`,
 				HTTP_STATUS_CODES.FORBIDDEN
 			);
@@ -479,7 +490,7 @@ export async function resolveRegistryAuth(
 			// Server-state condition, not a client-fixable request: the same body would resolve once
 			// custody comes up, so report it retryable (503) rather than the ClientError default 400.
 			throw new ClientError(
-				`secrets custody is not initialized on this node; cannot resolve registryAuth secret '${name}'`,
+				`secrets custody is not initialized on this node; cannot resolve credential secret '${name}'`,
 				HTTP_STATUS_CODES.SERVICE_UNAVAILABLE
 			);
 		}
@@ -488,7 +499,7 @@ export async function resolveRegistryAuth(
 			token = custody.decrypt(row.envelope);
 		} catch (error) {
 			throw new ClientError(
-				`Failed to decrypt registryAuth secret '${name}': ${(error as Error).message}`,
+				`Failed to decrypt credential secret '${name}': ${(error as Error).message}`,
 				HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR
 			);
 		}

--- a/components/secretOperations.ts
+++ b/components/secretOperations.ts
@@ -23,6 +23,7 @@ import * as validator from './operationsValidation.js';
 import { getSecretCustody } from '../resources/secretDecryptor.ts';
 import { encryptEnvelope, parseEnvelopeFields } from '../utility/secretEnvelope.ts';
 import { ENV_ENCRYPTED_PREFIX } from '../utility/envFile.ts';
+import { normalizeGitHost, type ResolvedGitCredential } from './gitCredentialServer.ts';
 
 const { HTTP_STATUS_CODES } = hdbErrors;
 const SECRET_TABLE = terms.SYSTEM_TABLE_NAMES.SECRET_TABLE_NAME;
@@ -326,8 +327,8 @@ export function getSecretsPublicKey(req: any) {
 }
 
 // deploy_component `credentials` is a kind-heterogeneous array: an entry's kind is implied by its
-// identifying key (today `registry` = npm registry auth; a git-host kind keyed by `host` is planned
-// in #1792), and every kind carries its credential as either a literal `token` or a `secret`
+// identifying key (`registry` = npm registry auth, `host` = git host auth for a git-reference
+// package, #1792), and every kind carries its credential as either a literal `token` or a `secret`
 // reference. Ingest/resolve below are kind-agnostic about that token/secret half and only branch on
 // the identifying key where a kind-specific detail is needed (the derived secret name).
 
@@ -343,6 +344,21 @@ export interface RegistryCredentialReference {
 	registry: string;
 	secret: string;
 	scope?: string;
+}
+
+/** A git-host credential after ingestion: a reference into hdb_secret, never a token. */
+export interface GitCredentialReference {
+	host: string;
+	secret: string;
+	username?: string;
+}
+
+export type CredentialReference = RegistryCredentialReference | GitCredentialReference;
+export type ResolvedCredential = ResolvedRegistryCredential | ResolvedGitCredential;
+
+/** True when a credential entry (in any form) is npm registry auth rather than git host auth. */
+export function isRegistryCredential(entry: any): boolean {
+	return entry?.registry !== undefined;
 }
 
 /**
@@ -361,6 +377,62 @@ export function deriveRegistrySecretName(component: string, registry: string): s
 		.replace(/[^\w.-]+/g, '_');
 	const componentKey = String(component).replace(/[^\w.-]+/g, '_');
 	return `deploy.${componentKey}.${registryKey}`;
+}
+
+/**
+ * Deterministic name for the secret backing a literal git-host token, following the registry
+ * convention above but with a `git` kind segment: a registry entry accepts a bare host too, so
+ * without a distinguishing segment a git and a registry credential for the same host would derive
+ * the same name and silently overwrite each other's secret. Keyed by host rather than by
+ * repository: the credential entry identifies itself by host, so the name has to be derivable from
+ * the entry alone for a rotation to overwrite the same row. A per-repository credential is
+ * expressible today by scoping the token itself (a fine-grained PAT) rather than by splitting the
+ * secret name.
+ */
+export function deriveGitSecretName(component: string, host: string): string {
+	const hostKey = normalizeGitHost(host).replace(/[^\w.-]+/g, '_');
+	const componentKey = String(component).replace(/[^\w.-]+/g, '_');
+	return `deploy.${componentKey}.git.${hostKey}`;
+}
+
+/**
+ * An entry's kind, from its identifying key. Every path that rebuilds an entry goes through this, so
+ * an entry of an unrecognized kind fails loudly rather than being rebuilt into a half-empty one: an
+ * operation-body entry is schema-validated, but a `credentials` entry read back from
+ * applicationConfig or an hdb_deployment row is not.
+ */
+function credentialKind(entry: any): 'registry' | 'git' {
+	if (isRegistryCredential(entry)) return 'registry';
+	if (entry?.host !== undefined) return 'git';
+	throw new ClientError(
+		`Unsupported credential entry: expected a 'registry' (npm registry auth) or 'host' (git host auth) entry`
+	);
+}
+
+/** The hdb_secret name a literal-token entry seals into, by kind. */
+function deriveSecretName(entry: any, component: string): string {
+	return credentialKind(entry) === 'registry'
+		? deriveRegistrySecretName(component, entry.registry)
+		: deriveGitSecretName(component, entry.host);
+}
+
+/** Rebuild an entry in reference form, preserving only the fields its kind defines. */
+function toReference(entry: any, secret: string): CredentialReference {
+	if (credentialKind(entry) === 'registry') {
+		return entry.scope === undefined
+			? { registry: entry.registry, secret }
+			: { registry: entry.registry, secret, scope: entry.scope };
+	}
+	return entry.username === undefined
+		? { host: entry.host, secret }
+		: { host: entry.host, secret, username: entry.username };
+}
+
+/** Rebuild an entry in resolved (literal token) form, preserving only the fields its kind defines. */
+function toResolved(entry: any, token: string): ResolvedCredential {
+	return credentialKind(entry) === 'registry'
+		? { registry: entry.registry, token, scope: entry.scope }
+		: { host: entry.host, token, username: entry.username };
 }
 
 /**
@@ -389,12 +461,9 @@ export async function ingestCredentials(req: any, credentials: any[] | undefined
 			out.push(entry);
 			continue;
 		}
-		// The derived secret name is the one kind-specific detail on this path; a new credential kind
-		// derives its name from its own identifying key.
-		if (entry.registry === undefined) {
-			throw new ClientError(`Unsupported credential entry: expected a 'registry' (npm registry auth) entry`);
-		}
-		const name = deriveRegistrySecretName(component, entry.registry);
+		// The derived secret name is the one kind-specific detail on this path; each kind derives its
+		// name from its own identifying key.
+		const name = deriveSecretName(entry, component);
 		// Reuse set_secret's seal-and-store path (encrypt with custody, grant to the component, audit
 		// the mutation). The deploy request is already super_user, which set_secret requires.
 		await setSecret({
@@ -405,11 +474,7 @@ export async function ingestCredentials(req: any, credentials: any[] | undefined
 			grants: [component],
 			processEnv: false,
 		});
-		out.push(
-			entry.scope === undefined
-				? { registry: entry.registry, secret: name }
-				: { registry: entry.registry, secret: name, scope: entry.scope }
-		);
+		out.push(toReference(entry, name));
 	}
 	return out;
 }
@@ -455,18 +520,22 @@ export async function resolveCredentials(
 	credentials: any[] | undefined,
 	component: string,
 	options: { waitMs?: number } = {}
-): Promise<ResolvedRegistryCredential[] | undefined> {
+): Promise<ResolvedCredential[] | undefined> {
 	if (!Array.isArray(credentials) || credentials.length === 0) return credentials;
+	// Reject an unrecognized kind before anything consumes the array, including on the token-only fast
+	// path below: a caller that silently drops an entry it does not understand would install without
+	// the credential the operator asked for.
+	for (const entry of credentials) if (entry) credentialKind(entry);
 	// Token-only requests must not require custody or a provisioned store — keep the fast path pure.
 	if (!credentials.some((entry) => entry && entry.secret !== undefined)) return credentials;
 
 	const waitMs = options.waitMs ?? 0;
 	const table = secretTable();
-	const resolved: ResolvedRegistryCredential[] = [];
+	const resolved: ResolvedCredential[] = [];
 	for (const entry of credentials) {
 		if (!entry) continue; // parity with the fast-path guard above; validated entries are never null
 		if (entry.secret === undefined) {
-			resolved.push({ registry: entry.registry, token: entry.token, scope: entry.scope });
+			resolved.push(toResolved(entry, entry.token));
 			continue;
 		}
 		const name: string = entry.secret;
@@ -503,7 +572,7 @@ export async function resolveCredentials(
 				HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR
 			);
 		}
-		resolved.push({ registry: entry.registry, token, scope: entry.scope });
+		resolved.push(toResolved(entry, token));
 	}
 	return resolved;
 }

--- a/server/serverHelpers/serverUtilities.ts
+++ b/server/serverHelpers/serverUtilities.ts
@@ -84,13 +84,26 @@ export async function processLocalTransaction(req: OperationRequest, operationFu
 				harperLogger.logLevel === terms.LOG_LEVELS.TRACE)
 		) {
 			// Need to remove auth variables and secret-bearing fields, but we don't want to create
-			// an object unless the logging is actually going to happen. registryAuth carries a
-			// transient private registry token on deploy_component; value/values carry .env secrets
-			// from set_env_value; value/envelope carry secrets from set_secret — none may reach the
+			// an object unless the logging is actually going to happen. credentials carries a
+			// transient token on deploy_component (registryAuth is its pre-rename name — still
+			// stripped, since this runs ahead of the validation that now rejects it, and a stale
+			// caller's token must not reach the log); value/values carry .env secrets from
+			// set_env_value; value/envelope carry secrets from set_secret — none may reach the
 			// operations log.
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
-			const { hdb_user, hdbAuthHeader, password, payload, registryAuth, value, values, envelope, ...cleanBody } =
-				req.body;
+			/* eslint-disable no-unused-vars, @typescript-eslint/no-unused-vars */
+			const {
+				hdb_user,
+				hdbAuthHeader,
+				password,
+				payload,
+				credentials,
+				registryAuth,
+				value,
+				values,
+				envelope,
+				...cleanBody
+			} = req.body;
+			/* eslint-enable no-unused-vars, @typescript-eslint/no-unused-vars */
 			operationLog.info(cleanBody);
 		}
 	} catch (e) {

--- a/unitTests/components/Application.test.js
+++ b/unitTests/components/Application.test.js
@@ -66,35 +66,35 @@ npm error 404 '@scope/nonexistent-pkg@latest' is not in this registry.
 	});
 });
 
-describe('assertApplicationConfig registryAuth', () => {
-	it('accepts a config with no registryAuth', () => {
+describe('assertApplicationConfig credentials', () => {
+	it('accepts a config with no credentials', () => {
 		assert.doesNotThrow(() => assertApplicationConfig('app', { package: 'npm:@org/app@1.0.0' }));
 	});
 
-	it('accepts registryAuth reference entries', () => {
+	it('accepts credential reference entries', () => {
 		assert.doesNotThrow(() =>
 			assertApplicationConfig('app', {
 				package: 'npm:@org/app@1.0.0',
-				registryAuth: [{ registry: 'https://npm.pkg.github.com', secret: 'deploy.app.gh', scope: '@org' }],
+				credentials: [{ registry: 'https://npm.pkg.github.com', secret: 'deploy.app.gh', scope: '@org' }],
 			})
 		);
 	});
 
-	it('rejects registryAuth that is not an array', () => {
+	it('rejects credentials that is not an array', () => {
 		assert.throws(
-			() => assertApplicationConfig('app', { package: 'p', registryAuth: { registry: 'r', secret: 's' } }),
+			() => assertApplicationConfig('app', { package: 'p', credentials: { registry: 'r', secret: 's' } }),
 			/expected array/
 		);
 	});
 
-	it('rejects a registryAuth entry carrying a literal token (references only on disk)', () => {
+	it('rejects a credential entry carrying a literal token (references only on disk)', () => {
 		assert.throws(
-			() => assertApplicationConfig('app', { package: 'p', registryAuth: [{ registry: 'r', token: 'tok' }] }),
+			() => assertApplicationConfig('app', { package: 'p', credentials: [{ registry: 'r', token: 'tok' }] }),
 			/expected \{ registry, secret, scope\? \} reference/
 		);
 	});
 
-	it('rejects a registryAuth entry missing registry/secret', () => {
-		assert.throws(() => assertApplicationConfig('app', { package: 'p', registryAuth: [{ secret: 's' }] }), /reference/);
+	it('rejects a credential entry missing registry/secret', () => {
+		assert.throws(() => assertApplicationConfig('app', { package: 'p', credentials: [{ secret: 's' }] }), /reference/);
 	});
 });

--- a/unitTests/components/Application.test.js
+++ b/unitTests/components/Application.test.js
@@ -5,7 +5,7 @@ const assert = require('node:assert');
 const testUtils = require('../testUtils.js');
 testUtils.preTestPrep();
 
-const { isSSHAuthFailure, assertApplicationConfig } = require('#src/components/Application');
+const { isSSHAuthFailure, assertApplicationConfig, parseGitReference } = require('#src/components/Application');
 
 describe('isSSHAuthFailure', () => {
 	it('returns true for "Could not read from remote repository"', () => {
@@ -66,6 +66,72 @@ npm error 404 '@scope/nonexistent-pkg@latest' is not in this registry.
 	});
 });
 
+describe('parseGitReference', () => {
+	it('parses an explicit git+https:// identifier', () => {
+		assert.deepStrictEqual(parseGitReference('git+https://example.com/owner/repo.git'), {
+			cloneUrl: 'https://example.com/owner/repo.git',
+			committish: undefined,
+		});
+	});
+
+	it('parses a git:// identifier with a committish', () => {
+		assert.deepStrictEqual(parseGitReference('git://example.com/owner/repo.git#v1.2.3'), {
+			cloneUrl: 'git://example.com/owner/repo.git',
+			committish: 'v1.2.3',
+		});
+	});
+
+	it("resolves the github: shorthand this repo's own derivePackageIdentifier defaults to", () => {
+		assert.deepStrictEqual(parseGitReference('github:my-org/my-app'), {
+			cloneUrl: 'https://github.com/my-org/my-app.git',
+			committish: undefined,
+		});
+	});
+
+	it("resolves github: shorthand with a committish, matching the PR's own worked example", () => {
+		assert.deepStrictEqual(parseGitReference('github:my-org/my-app#semver:v1.2.3'), {
+			cloneUrl: 'https://github.com/my-org/my-app.git',
+			committish: 'semver:v1.2.3',
+		});
+	});
+
+	it('resolves the gitlab: shorthand', () => {
+		assert.deepStrictEqual(parseGitReference('gitlab:my-org/my-app'), {
+			cloneUrl: 'https://gitlab.com/my-org/my-app.git',
+			committish: undefined,
+		});
+	});
+
+	it('resolves the bitbucket: shorthand', () => {
+		assert.deepStrictEqual(parseGitReference('bitbucket:my-org/my-app'), {
+			cloneUrl: 'https://bitbucket.org/my-org/my-app.git',
+			committish: undefined,
+		});
+	});
+
+	it('resolves the gist: shorthand by id', () => {
+		assert.deepStrictEqual(parseGitReference('gist:af99f4b3ec6df5c56b03'), {
+			cloneUrl: 'https://gist.github.com/af99f4b3ec6df5c56b03.git',
+			committish: undefined,
+		});
+	});
+
+	it('resolves the gist: shorthand with an owner prefix, dropping the owner segment', () => {
+		assert.deepStrictEqual(parseGitReference('gist:my-org/af99f4b3ec6df5c56b03'), {
+			cloneUrl: 'https://gist.github.com/af99f4b3ec6df5c56b03.git',
+			committish: undefined,
+		});
+	});
+
+	it('returns null for an npm registry identifier', () => {
+		assert.strictEqual(parseGitReference('npm:some-package'), null);
+	});
+
+	it('returns null for a file identifier', () => {
+		assert.strictEqual(parseGitReference('file:../local-app'), null);
+	});
+});
+
 describe('assertApplicationConfig credentials', () => {
 	it('accepts a config with no credentials', () => {
 		assert.doesNotThrow(() => assertApplicationConfig('app', { package: 'npm:@org/app@1.0.0' }));
@@ -87,14 +153,29 @@ describe('assertApplicationConfig credentials', () => {
 		);
 	});
 
-	it('rejects a credential entry carrying a literal token (references only on disk)', () => {
-		assert.throws(
-			() => assertApplicationConfig('app', { package: 'p', credentials: [{ registry: 'r', token: 'tok' }] }),
-			/expected \{ registry, secret, scope\? \} reference/
+	it('accepts a git-host reference entry (#1792)', () => {
+		assert.doesNotThrow(() =>
+			assertApplicationConfig('app', {
+				package: 'github:myorg/private-app',
+				credentials: [{ host: 'github.com', secret: 'deploy.app.github.com' }],
+			})
 		);
 	});
 
-	it('rejects a credential entry missing registry/secret', () => {
+	it('rejects a credential entry carrying a literal token (references only on disk)', () => {
+		for (const entry of [
+			{ registry: 'r', token: 'tok' },
+			{ host: 'github.com', token: 'tok' },
+		]) {
+			assert.throws(
+				() => assertApplicationConfig('app', { package: 'p', credentials: [entry] }),
+				/reference$/m,
+				JSON.stringify(entry)
+			);
+		}
+	});
+
+	it('rejects a credential entry with no recognized identity (neither registry nor host)', () => {
 		assert.throws(() => assertApplicationConfig('app', { package: 'p', credentials: [{ secret: 's' }] }), /reference/);
 	});
 });

--- a/unitTests/components/credentials.test.js
+++ b/unitTests/components/credentials.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Covers the transient private-registry auth used by deploy_component: buildNpmrcContent
+// Covers the transient private-registry credentials used by deploy_component: buildNpmrcContent
 // normalizes each entry into npm's `.npmrc` auth-key form, and an Application materializes that
 // content into a per-deploy 0600 `.npmrc` (npmUserconfigPath) that is removed on cleanup. The
 // token must never persist beyond the deploy; these tests pin both the format and the lifecycle.
@@ -69,9 +69,9 @@ describe('buildNpmrcContent', () => {
 describe('Application transient .npmrc lifecycle', () => {
 	it('writes a 0600 .npmrc and exposes its path, then removes it on cleanup', async () => {
 		const app = new Application({
-			name: 'registry-auth-test',
+			name: 'registry-credentials-test',
 			packageIdentifier: 'npm:@myorg/app',
-			registryAuth: [{ registry: 'https://npm.pkg.github.com', token: 'secret', scope: '@myorg' }],
+			registryCredentials: [{ registry: 'https://npm.pkg.github.com', token: 'secret', scope: '@myorg' }],
 		});
 
 		assert.strictEqual(app.npmUserconfigPath, undefined, 'no path before write');
@@ -95,7 +95,7 @@ describe('Application transient .npmrc lifecycle', () => {
 		await assert.rejects(fs.stat(npmrcPath), /ENOENT/, 'file removed after cleanup');
 	});
 
-	it('writeTransientNpmrc is a no-op without registryAuth', async () => {
+	it('writeTransientNpmrc is a no-op without registry credentials', async () => {
 		const app = new Application({ name: 'no-auth-test', packageIdentifier: 'npm:@myorg/app' });
 		await app.writeTransientNpmrc();
 		assert.strictEqual(app.npmUserconfigPath, undefined);
@@ -116,7 +116,7 @@ describe('Application transient .npmrc lifecycle', () => {
 			const app = new Application({
 				name: 'merge-test',
 				packageIdentifier: 'npm:@myorg/app',
-				registryAuth: [{ registry: 'https://npm.pkg.github.com', token: 'secret', scope: '@myorg' }],
+				registryCredentials: [{ registry: 'https://npm.pkg.github.com', token: 'secret', scope: '@myorg' }],
 			});
 			await app.writeTransientNpmrc();
 			const contents = await fs.readFile(app.npmUserconfigPath, 'utf8');

--- a/unitTests/components/credentials.test.js
+++ b/unitTests/components/credentials.test.js
@@ -71,7 +71,7 @@ describe('Application transient .npmrc lifecycle', () => {
 		const app = new Application({
 			name: 'registry-credentials-test',
 			packageIdentifier: 'npm:@myorg/app',
-			registryCredentials: [{ registry: 'https://npm.pkg.github.com', token: 'secret', scope: '@myorg' }],
+			credentials: [{ registry: 'https://npm.pkg.github.com', token: 'secret', scope: '@myorg' }],
 		});
 
 		assert.strictEqual(app.npmUserconfigPath, undefined, 'no path before write');
@@ -116,7 +116,7 @@ describe('Application transient .npmrc lifecycle', () => {
 			const app = new Application({
 				name: 'merge-test',
 				packageIdentifier: 'npm:@myorg/app',
-				registryCredentials: [{ registry: 'https://npm.pkg.github.com', token: 'secret', scope: '@myorg' }],
+				credentials: [{ registry: 'https://npm.pkg.github.com', token: 'secret', scope: '@myorg' }],
 			});
 			await app.writeTransientNpmrc();
 			const contents = await fs.readFile(app.npmUserconfigPath, 'utf8');

--- a/unitTests/components/gitCredentialClone.test.js
+++ b/unitTests/components/gitCredentialClone.test.js
@@ -1,0 +1,339 @@
+'use strict';
+
+// End-to-end proof that the git credential channel actually authenticates a real clone (#1792).
+//
+// The mechanism this feature rests on lives entirely outside our process — git decides whether to
+// call a credential helper, npm decides which environment git inherits, and both have historically
+// had version-specific quirks here. A test that stubs the helper would prove none of that. So this
+// stands up a genuine private git remote (git-http-backend behind HTTP Basic auth) and deploys from
+// it through the real extractApplication path, asserting that the clone succeeds only because the
+// credential was served from memory.
+//
+// The remote speaks http rather than https purely so the test needs no certificate: git's credential
+// machinery is identical for both, and TLS terminates below the layer this feature touches.
+
+const assert = require('node:assert');
+const fs = require('node:fs/promises');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn, execFileSync } = require('node:child_process');
+const { existsSync } = require('node:fs');
+
+const testUtils = require('../testUtils.js');
+testUtils.preTestPrep();
+
+const { Application, extractApplication } = require('#src/components/Application');
+const { getConfigPath } = require('#src/config/configUtils');
+const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
+
+// git may not be installed/in PATH in every test environment; resolving this at module load time
+// (before mocha's before() hook gets a chance to skip gracefully) would crash the whole suite's
+// loading rather than just this file's tests, so fall back to undefined and let before() skip.
+let GIT_HTTP_BACKEND;
+try {
+	GIT_HTTP_BACKEND = path.join(execFileSync('git', ['--exec-path']).toString().trim(), 'git-http-backend');
+} catch {
+	// git not installed/in PATH; before() skips when GIT_HTTP_BACKEND is unset.
+}
+const TOKEN = 'ghp_test_token_value';
+const USERNAME = 'x-access-token';
+
+// The one Authorization header the remote accepts: git's HTTPS basic-auth convention for a PAT.
+function validAuthorization() {
+	return 'Basic ' + Buffer.from(`${USERNAME}:${TOKEN}`).toString('base64');
+}
+
+// A CGI bridge to git's own smart-HTTP server, gated on Basic auth — the smallest thing that is a
+// real private git remote rather than an imitation of one.
+function startPrivateGitServer(projectRoot, onAuthorization) {
+	const server = http.createServer((request, response) => {
+		const authorization = request.headers.authorization ?? '';
+		onAuthorization(authorization);
+		if (authorization !== validAuthorization()) {
+			response.writeHead(401, { 'WWW-Authenticate': 'Basic realm="harper-test"' });
+			response.end('unauthorized');
+			return;
+		}
+
+		const url = new URL(request.url, 'http://localhost');
+		const cgi = spawn(GIT_HTTP_BACKEND, {
+			env: {
+				...process.env,
+				GIT_PROJECT_ROOT: projectRoot,
+				GIT_HTTP_EXPORT_ALL: '1',
+				REQUEST_METHOD: request.method,
+				PATH_INFO: url.pathname,
+				QUERY_STRING: url.search.replace(/^\?/, ''),
+				CONTENT_TYPE: request.headers['content-type'] ?? '',
+				REMOTE_USER: USERNAME,
+			},
+		});
+		request.pipe(cgi.stdin);
+
+		// CGI replies with headers, a blank line, then the body — split it back out for the HTTP layer.
+		let head = Buffer.alloc(0);
+		let headersSent = false;
+		cgi.stdout.on('data', (chunk) => {
+			if (headersSent) return response.write(chunk);
+			head = Buffer.concat([head, chunk]);
+			const split = head.indexOf('\r\n\r\n');
+			if (split === -1) return;
+			const headers = {};
+			for (const line of head.subarray(0, split).toString().split('\r\n')) {
+				const separator = line.indexOf(':');
+				if (separator > 0) headers[line.slice(0, separator)] = line.slice(separator + 1).trim();
+			}
+			headersSent = true;
+			response.writeHead(Number(headers.Status?.split(' ')[0]) || 200, headers);
+			response.write(head.subarray(split + 4));
+		});
+		cgi.stdout.on('end', () => response.end());
+		cgi.on('error', () => response.destroy());
+	});
+
+	return new Promise((resolve) => {
+		server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port }));
+	});
+}
+
+// A bare repo with one commit, served as the "private" package. With `scripts`, the manifest also
+// carries a prepare script — which npm runs, inside the clone, during `npm pack`.
+async function createRepo(root, name, scripts) {
+	const work = path.join(root, 'work-' + name);
+	const bare = path.join(root, `${name}.git`);
+	await fs.mkdir(work, { recursive: true });
+	await fs.writeFile(
+		path.join(work, 'package.json'),
+		JSON.stringify({ name, version: '1.0.0', description: 'private test component', scripts }, null, 2)
+	);
+	await fs.writeFile(path.join(work, 'index.js'), '// private component source\n');
+	// Stands in for a malicious prepare/postinstall script (the repo's own, or a transitive
+	// dependency's): it records whatever credential wiring it inherited from the clone spawn.
+	await fs.writeFile(
+		path.join(work, 'steal.js'),
+		`require('node:fs').writeFileSync(process.env.HARPER_TEST_STEAL_OUT, JSON.stringify({\n` +
+			`  socket: process.env.HARPER_GIT_CREDENTIAL_SOCKET ?? null,\n` +
+			`  askpass: process.env.GIT_ASKPASS ?? null,\n` +
+			`}));\n`
+	);
+	const git = (...args) => execFileSync('git', args, { cwd: work, stdio: 'pipe' });
+	git('init', '--quiet', '--initial-branch=main');
+	git('config', 'user.email', 'test@harperdb.io');
+	git('config', 'user.name', 'Harper Test');
+	git('config', 'commit.gpgsign', 'false');
+	git('add', '.');
+	git('commit', '--quiet', '-m', 'initial');
+	execFileSync('git', ['clone', '--quiet', '--bare', work, bare], { stdio: 'pipe' });
+	return bare;
+}
+
+describe('private git-reference deploy (real clone over authenticated git-over-http)', function () {
+	// A real git clone through npm: slower than a unit test, but the only thing that proves the
+	// credential reaches git.
+	this.timeout(120_000);
+
+	let root;
+	let server;
+	let packageIdentifier;
+	let scriptedPackageIdentifier;
+	let seenAuthorization;
+	let stealOut;
+
+	before(async function () {
+		if (process.platform === 'win32' || !GIT_HTTP_BACKEND || !existsSync(GIT_HTTP_BACKEND)) return this.skip();
+		// extractApplication packs into the components root, which the unit-test config points at but
+		// does not create.
+		await fs.mkdir(getConfigPath(CONFIG_PARAMS.COMPONENTSROOT), { recursive: true });
+		root = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-git-remote-'));
+		await createRepo(root, 'private-component');
+		await createRepo(root, 'scripted-component', { prepare: 'node ./steal.js' });
+		stealOut = path.join(root, 'stolen.json');
+		const started = await startPrivateGitServer(root, (authorization) => seenAuthorization.push(authorization));
+		server = started.server;
+		packageIdentifier = `git+http://127.0.0.1:${started.port}/private-component.git`;
+		scriptedPackageIdentifier = `git+http://127.0.0.1:${started.port}/scripted-component.git`;
+	});
+
+	after(async () => {
+		await new Promise((resolve) => (server ? server.close(resolve) : resolve()));
+		if (root) await fs.rm(root, { recursive: true, force: true });
+	});
+
+	beforeEach(async () => {
+		seenAuthorization = [];
+		await fs.rm(stealOut, { force: true });
+	});
+
+	// The credential entry's host: the remote's host:port, which is what git asks about.
+	function gitHost() {
+		return new URL(packageIdentifier.slice('git+'.length)).host;
+	}
+
+	it('fails to clone the private repo without a credential', async () => {
+		const application = new Application({ name: 'git-clone-unauthenticated', packageIdentifier });
+		await assert.rejects(
+			() => extractApplication(application),
+			/Failed to download package/,
+			'a private repo must not be cloneable without a credential'
+		);
+		// npm points git at its own `GIT_ASKPASS=echo` when we supply none, so git does attempt an empty
+		// credential — what matters is that no request could carry the token.
+		assert.ok(
+			seenAuthorization.every((header) => !header.includes(validAuthorization().slice('Basic '.length))),
+			'the token cannot be presented without a credential session'
+		);
+	});
+
+	it('clones the private repo with a token served from memory, and the token never lands on disk', async () => {
+		const application = new Application({
+			name: 'git-clone-authenticated',
+			packageIdentifier,
+			credentials: [{ host: gitHost(), token: TOKEN }],
+		});
+
+		// Exactly the sequence prepareApplication runs: bring the credential socket up, clone, tear it down.
+		await application.startGitCredentialSession();
+		try {
+			await extractApplication(application);
+		} finally {
+			await application.cleanupGitCredentialSession();
+		}
+
+		// The clone actually happened, and it authenticated.
+		const packageJSON = JSON.parse(await fs.readFile(path.join(application.dirPath, 'package.json'), 'utf8'));
+		assert.strictEqual(packageJSON.name, 'private-component');
+		assert.ok(existsSync(path.join(application.dirPath, 'index.js')), 'repo contents extracted');
+		assert.ok(
+			seenAuthorization.some((header) => header === validAuthorization()),
+			'git presented the token from the credential session'
+		);
+
+		// The token is not in the package identifier npm was given, so it cannot reach a lockfile, the
+		// deployment row, or the operations log through it.
+		assert.ok(!application.packageIdentifier.includes(TOKEN), 'token not embedded in the package URL');
+		// Nor anywhere in the extracted component — the credential leaves no artifact behind.
+		const files = await fs.readdir(application.dirPath, { recursive: true, withFileTypes: true });
+		for (const file of files) {
+			if (!file.isFile()) continue;
+			const contents = await fs.readFile(path.join(file.parentPath ?? file.path, file.name), 'utf8').catch(() => '');
+			assert.ok(!contents.includes(TOKEN), `token found on disk in ${file.name}`);
+		}
+	});
+
+	it('does not persist the token to git-credentials even when a store helper is configured', async function () {
+		// The sharpest leak path: git reports a *successful* authentication back to its credential
+		// helper chain, so a machine with `credential.helper=store` (globally or URL-scoped) would write
+		// the token to ~/.git-credentials — silently. The GIT_CONFIG_* helper reset must survive a real
+		// clone, not just a synthetic `git credential approve`.
+		const home = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-git-home-'));
+		const gitConfig = path.join(home, '.gitconfig');
+		const credentialsFile = path.join(home, '.git-credentials');
+		const scopedCredentialsFile = path.join(home, '.git-credentials-scoped');
+		const host = gitHost();
+		await fs.writeFile(
+			gitConfig,
+			`[credential]\n\thelper = store --file ${credentialsFile}\n` +
+				`[credential "http://${host}"]\n\thelper = store --file ${scopedCredentialsFile}\n`
+		);
+
+		const application = new Application({
+			name: 'git-clone-store-helper',
+			packageIdentifier,
+			credentials: [{ host, token: TOKEN }],
+		});
+
+		const priorHome = process.env.HOME;
+		const priorConfigGlobal = process.env.GIT_CONFIG_GLOBAL;
+		process.env.HOME = home;
+		process.env.GIT_CONFIG_GLOBAL = gitConfig;
+		try {
+			await application.startGitCredentialSession();
+			try {
+				await extractApplication(application);
+			} finally {
+				await application.cleanupGitCredentialSession();
+			}
+		} finally {
+			if (priorHome === undefined) delete process.env.HOME;
+			else process.env.HOME = priorHome;
+			if (priorConfigGlobal === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+			else process.env.GIT_CONFIG_GLOBAL = priorConfigGlobal;
+		}
+
+		// The clone still authenticated (proving the helper chain was active)...
+		assert.ok(
+			seenAuthorization.some((header) => header === validAuthorization()),
+			'the clone authenticated, so git did run its credential machinery'
+		);
+		// ...yet neither store file received the token.
+		for (const file of [credentialsFile, scopedCredentialsFile]) {
+			const persisted = await fs.readFile(file, 'utf8').catch(() => '');
+			assert.ok(!persisted.includes(TOKEN), `token persisted to ${path.basename(file)}: ${persisted}`);
+		}
+		await fs.rm(home, { recursive: true, force: true });
+	});
+
+	// Packing a git reference is not just a download: npm clones the repo and runs its prepare/build
+	// script — and its dependencies' install scripts — on this node, inside the clone spawn. Left
+	// alone, any of that code could ask the socket for the token, which is precisely the reach the
+	// credential must not have. Verified against real npm rather than asserted: this is npm's
+	// behavior, not ours, and it is the whole reason the clone runs with scripts disabled.
+	it('does not run the repository prepare script during a credentialed clone, so nothing can reach the socket', async () => {
+		const application = new Application({
+			name: 'git-clone-scripted',
+			packageIdentifier: scriptedPackageIdentifier,
+			credentials: [{ host: gitHost(), token: TOKEN }],
+		});
+
+		await application.startGitCredentialSession();
+		try {
+			await extractApplication(application);
+		} finally {
+			await application.cleanupGitCredentialSession();
+		}
+
+		assert.ok(!existsSync(stealOut), 'the prepare script must not run while the credential is reachable');
+	});
+
+	it('runs the prepare script — with the credential in reach — only when the deploy opts into scripts', async () => {
+		// install_allow_scripts is the operator explicitly asking for this repository's code to run on
+		// the node. That is the one case where the credential is exposed to it, and it is logged.
+		const application = new Application({
+			name: 'git-clone-scripted-allowed',
+			packageIdentifier: scriptedPackageIdentifier,
+			install: { allowInstallScripts: true },
+			credentials: [{ host: gitHost(), token: TOKEN }],
+		});
+
+		process.env.HARPER_TEST_STEAL_OUT = stealOut;
+		try {
+			await application.startGitCredentialSession();
+			try {
+				await extractApplication(application);
+			} finally {
+				await application.cleanupGitCredentialSession();
+			}
+		} finally {
+			delete process.env.HARPER_TEST_STEAL_OUT;
+		}
+
+		assert.ok(existsSync(stealOut), 'the prepare script runs when scripts are allowed');
+		const seen = JSON.parse(await fs.readFile(stealOut, 'utf8'));
+		assert.ok(seen.socket, 'documents the exposure this opt-in accepts: the script can reach the socket');
+	});
+
+	it('stops authenticating once the session is closed', async () => {
+		// The credential is bound to the clone, not to the deploy: anything that runs after extraction
+		// (install scripts included) finds the socket gone.
+		const application = new Application({
+			name: 'git-clone-after-close',
+			packageIdentifier,
+			credentials: [{ host: gitHost(), token: TOKEN }],
+		});
+		await application.startGitCredentialSession();
+		await application.cleanupGitCredentialSession();
+
+		await assert.rejects(() => extractApplication(application), /Failed to download package/);
+	});
+});

--- a/unitTests/components/gitCredentials.test.js
+++ b/unitTests/components/gitCredentials.test.js
@@ -1,0 +1,415 @@
+'use strict';
+
+// Covers the git-host credential channel used by private git-reference deploys (#1792): a per-deploy
+// socket serves the token from memory, gitCredentialHelper.js relays git's request over it, and the
+// environment that reaches the helper is granted to the clone spawn only.
+//
+// The helper is exercised as a real child process (the way git runs it), not stubbed — the point of
+// the design is what crosses the process boundary, so a mocked helper would test nothing.
+
+const assert = require('node:assert');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const { execFile } = require('node:child_process');
+const net = require('node:net');
+
+const testUtils = require('../testUtils.js');
+testUtils.preTestPrep();
+
+const {
+	startGitCredentialSession,
+	normalizeGitHost,
+	DEFAULT_GIT_USERNAME,
+	GIT_CREDENTIAL_SOCKET_ENV,
+} = require('#src/components/gitCredentialServer');
+const { Application, GIT_CREDENTIAL_HELPER_PATH, nonInteractiveSpawn } = require('#src/components/Application');
+
+// Run the helper exactly as git would: the credential-helper protocol (operation as the last
+// argument, key=value request on stdin) or the GIT_ASKPASS protocol (prompt as the first argument).
+function runHelper({ args, stdin, env }) {
+	return new Promise((resolve, reject) => {
+		const child = execFile(
+			process.execPath,
+			[GIT_CREDENTIAL_HELPER_PATH, ...args],
+			{ env: { ...process.env, ...env } },
+			(error, stdout, stderr) => {
+				// A non-zero exit is a valid outcome here (git treats it as "no credential"), so report it
+				// rather than rejecting.
+				if (error && typeof error.code !== 'number') return reject(error);
+				resolve({ stdout, stderr, code: error ? error.code : 0 });
+			}
+		);
+		child.stdin.end(stdin ?? '');
+	});
+}
+
+describe('normalizeGitHost', () => {
+	it('reduces the forms a credential entry or a git prompt can carry to one host key', () => {
+		for (const input of ['github.com', 'GitHub.com', 'https://github.com', 'https://github.com/', '//github.com']) {
+			assert.strictEqual(normalizeGitHost(input), 'github.com', input);
+		}
+		// userinfo in a prompt URL is not part of the host identity
+		assert.strictEqual(normalizeGitHost('https://x-access-token@github.com'), 'github.com');
+		// a non-default port is, since it identifies a different endpoint
+		assert.strictEqual(normalizeGitHost('git.example.com:8443'), 'git.example.com:8443');
+	});
+});
+
+describe('git credential session', () => {
+	let session;
+
+	afterEach(async () => {
+		await session?.close();
+		session = undefined;
+	});
+
+	it('serves the token over the socket to a helper run as a git credential helper', async () => {
+		session = await startGitCredentialSession(
+			[{ host: 'github.com', token: 'ghp_secret' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+
+		const { stdout } = await runHelper({
+			args: ['get'],
+			stdin: 'protocol=https\nhost=github.com\n\n',
+			env: session.env,
+		});
+
+		assert.strictEqual(stdout, `username=${DEFAULT_GIT_USERNAME}\npassword=ghp_secret\n`);
+	});
+
+	it('answers a GIT_ASKPASS username prompt and password prompt, locale independently', async () => {
+		session = await startGitCredentialSession(
+			[{ host: 'github.com', token: 'ghp_secret' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+
+		// The username prompt's URL has no userinfo; the password prompt's does. That structural
+		// difference is what the helper keys on, so a translated prompt still resolves correctly.
+		const username = await runHelper({ args: [`Username for 'https://github.com': `], env: session.env });
+		assert.strictEqual(username.stdout, `${DEFAULT_GIT_USERNAME}\n`);
+
+		const password = await runHelper({
+			args: [`Password for 'https://x-access-token@github.com': `],
+			env: session.env,
+		});
+		assert.strictEqual(password.stdout, 'ghp_secret\n');
+
+		const translated = await runHelper({
+			args: [`Mot de passe pour 'https://x-access-token@github.com' : `],
+			env: session.env,
+		});
+		assert.strictEqual(translated.stdout, 'ghp_secret\n', 'a localized prompt still yields the password');
+	});
+
+	it('last-write-wins on a duplicate host, and the session still serves the surviving token', async () => {
+		session = await startGitCredentialSession(
+			[
+				{ host: 'github.com', token: 'first' },
+				{ host: 'github.com', token: 'second' },
+			],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		const { stdout } = await runHelper({
+			args: ['get'],
+			stdin: 'protocol=https\nhost=github.com\n\n',
+			env: session.env,
+		});
+		assert.strictEqual(stdout, `username=${DEFAULT_GIT_USERNAME}\npassword=second\n`);
+	});
+
+	it('honors a per-entry username (GitLab/Bitbucket use their own convention)', async () => {
+		session = await startGitCredentialSession(
+			[{ host: 'gitlab.com', token: 'glpat', username: 'oauth2' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		const { stdout } = await runHelper({
+			args: ['get'],
+			stdin: 'protocol=https\nhost=gitlab.com\n\n',
+			env: session.env,
+		});
+		assert.strictEqual(stdout, 'username=oauth2\npassword=glpat\n');
+	});
+
+	it('answers nothing for a host it holds no credential for', async () => {
+		session = await startGitCredentialSession(
+			[{ host: 'github.com', token: 'ghp_secret' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		// Silence rather than an error: git also asks about public hosts, and the clone of a public
+		// dependency must proceed unauthenticated instead of failing the deploy.
+		const { stdout } = await runHelper({
+			args: ['get'],
+			stdin: 'protocol=https\nhost=evil.example.com\n\n',
+			env: session.env,
+		});
+		assert.strictEqual(stdout, '');
+	});
+
+	it('refuses to serve a credential over cleartext http (only https, plus loopback)', async () => {
+		session = await startGitCredentialSession(
+			[
+				{ host: 'github.com', token: 'ghp_secret' },
+				{ host: '127.0.0.1:8080', token: 'local_tok' },
+			],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		// A public host over http would put the token on the wire in the clear — refuse.
+		const cleartext = await runHelper({
+			args: ['get'],
+			stdin: 'protocol=http\nhost=github.com\n\n',
+			env: session.env,
+		});
+		assert.strictEqual(cleartext.stdout, '', 'no credential over http to a public host');
+		// A loopback remote never touches a network, so http to it is fine (integration tests use it).
+		const loopback = await runHelper({
+			args: ['get'],
+			stdin: 'protocol=http\nhost=127.0.0.1:8080\n\n',
+			env: session.env,
+		});
+		assert.strictEqual(loopback.stdout, 'username=x-access-token\npassword=local_tok\n');
+	});
+
+	it('refuses to serve a token carrying a newline (would truncate or inject protocol attributes)', async () => {
+		// A literal token is rejected by the op schema, but one resolved from an hdb_secret row is not,
+		// so the write boundary must guard it — parity with the .npmrc writer.
+		session = await startGitCredentialSession(
+			[{ host: 'github.com', token: 'ghp\nquit=1' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		const { stdout } = await runHelper({
+			args: ['get'],
+			stdin: 'protocol=https\nhost=github.com\n\n',
+			env: session.env,
+		});
+		assert.strictEqual(stdout, '');
+	});
+
+	it('never yields the token to a store/erase request (the credential is not persistable)', async () => {
+		session = await startGitCredentialSession(
+			[{ host: 'github.com', token: 'ghp_secret' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		for (const operation of ['store', 'erase']) {
+			const { stdout } = await runHelper({
+				args: [operation],
+				stdin: 'protocol=https\nhost=github.com\nusername=x-access-token\npassword=ghp_secret\n\n',
+				env: session.env,
+			});
+			assert.strictEqual(stdout, '', `${operation} yields nothing`);
+		}
+	});
+
+	it('resets any inherited credential.helper so a configured `store` cannot persist the token', async () => {
+		session = await startGitCredentialSession([{ host: 'github.com', token: 't' }], GIT_CREDENTIAL_HELPER_PATH);
+		const count = Number(session.env.GIT_CONFIG_COUNT);
+		// The first of our two entries clears git's helper list; the second installs ours. Without the
+		// reset, git would report the successful authentication to an inherited helper — a machine with
+		// `credential.helper=store` would write this token to ~/.git-credentials.
+		assert.strictEqual(session.env[`GIT_CONFIG_KEY_${count - 2}`], 'credential.helper');
+		assert.strictEqual(session.env[`GIT_CONFIG_VALUE_${count - 2}`], '');
+		assert.strictEqual(session.env[`GIT_CONFIG_KEY_${count - 1}`], 'credential.helper');
+		assert.ok(session.env[`GIT_CONFIG_VALUE_${count - 1}`].startsWith('!'), 'ours is a shell-invoked helper');
+		assert.strictEqual(session.env.GIT_TERMINAL_PROMPT, '0', 'git must fail rather than hang on a prompt');
+	});
+
+	it('keeps the token off disk: the socket dir is 0700 and holds only a socket', async () => {
+		session = await startGitCredentialSession(
+			[{ host: 'github.com', token: 'ghp_secret' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		const socketPath = session.env[GIT_CREDENTIAL_SOCKET_ENV];
+		const socketDir = path.dirname(socketPath);
+
+		assert.strictEqual((await fs.stat(socketDir)).mode & 0o777, 0o700, 'socket dir is owner-only');
+		const entries = await fs.readdir(socketDir);
+		assert.deepStrictEqual(entries, ['credential.sock']);
+		assert.ok((await fs.stat(socketPath)).isSocket(), 'the only artifact is a socket, not a file with a token');
+	});
+
+	it('stops answering once the session is closed', async () => {
+		session = await startGitCredentialSession(
+			[{ host: 'github.com', token: 'ghp_secret' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		const env = session.env;
+		const socketPath = env[GIT_CREDENTIAL_SOCKET_ENV];
+
+		await session.close();
+		session = undefined;
+
+		// The credential is gone the moment the clone finishes — anything that runs later in the deploy
+		// (install scripts included) finds nothing to ask.
+		const { stdout, code } = await runHelper({ args: ['get'], stdin: 'protocol=https\nhost=github.com\n\n', env });
+		assert.strictEqual(stdout, '');
+		assert.strictEqual(code, 1, 'helper reports failure rather than silently succeeding');
+		await assert.rejects(fs.stat(socketPath), /ENOENT/, 'socket removed');
+	});
+
+	it('refuses to start on a git too old for the credential-helper reset', async () => {
+		// git < 2.31 ignores GIT_CONFIG_*, so the reset that stops an inherited `store` helper from
+		// persisting the token would be silently dead — fail the deploy rather than leak.
+		const fakeBin = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-fake-git-'));
+		const fakeGit = path.join(fakeBin, 'git');
+		await fs.writeFile(fakeGit, '#!/bin/sh\necho "git version 2.30.2"\n', { mode: 0o755 });
+		const priorPath = process.env.PATH;
+		process.env.PATH = `${fakeBin}:${priorPath}`;
+		try {
+			await assert.rejects(
+				() => startGitCredentialSession([{ host: 'github.com', token: 't' }], GIT_CREDENTIAL_HELPER_PATH),
+				/2\.31 or newer is required/
+			);
+		} finally {
+			process.env.PATH = priorPath;
+			await fs.rm(fakeBin, { recursive: true, force: true });
+		}
+	});
+
+	it('drops a connection that streams without end, rather than buffering it into an OOM', async () => {
+		session = await startGitCredentialSession(
+			[{ host: 'github.com', token: 'ghp_secret' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		const socket = net.connect(session.env[GIT_CREDENTIAL_SOCKET_ENV]);
+		await new Promise((resolve, reject) => {
+			socket.on('connect', resolve);
+			socket.on('error', reject);
+		});
+
+		const closed = new Promise((resolve) => socket.on('close', resolve));
+		// Never half-close: without a cap the server would accumulate this forever.
+		const junk = 'x'.repeat(64 * 1024);
+		// write() can return false under backpressure (the socket's internal buffer is full) well
+		// before the server-side cap is exceeded; resume on 'drain' instead of giving up, or this
+		// test hangs waiting for a 'close' the server never has a reason to send.
+		const write = () => {
+			if (!socket.writable) return;
+			if (socket.write(junk)) setImmediate(write);
+			else socket.once('drain', write);
+		};
+		write();
+
+		await closed; // the server destroys the connection instead of growing its buffer
+		assert.ok(socket.destroyed);
+	});
+
+	it('is inert without a session: the helper carries no secret of its own', async () => {
+		// GIT_CREDENTIAL_SOCKET_ENV is the only variable that carries authority. A helper reached with
+		// it stripped answers nothing, which is what makes stripping it from the install spawn sufficient.
+		const { stdout, code } = await runHelper({
+			args: ['get'],
+			stdin: 'protocol=https\nhost=github.com\n\n',
+			env: { [GIT_CREDENTIAL_SOCKET_ENV]: undefined },
+		});
+		assert.strictEqual(stdout, '');
+		assert.strictEqual(code, 0);
+	});
+});
+
+describe('Application git credential lifecycle', () => {
+	it('partitions resolved credentials by kind and exposes git env only while the session is open', async () => {
+		const app = new Application({
+			name: 'git-credentials-test',
+			packageIdentifier: 'github:myorg/private-app',
+			credentials: [
+				{ registry: 'https://npm.pkg.github.com', token: 'npm-tok', scope: '@myorg' },
+				{ host: 'github.com', token: 'git-tok' },
+			],
+		});
+
+		assert.deepStrictEqual(app.registryCredentials, [
+			{ registry: 'https://npm.pkg.github.com', token: 'npm-tok', scope: '@myorg' },
+		]);
+		assert.deepStrictEqual(app.gitCredentials, [{ host: 'github.com', token: 'git-tok' }]);
+		assert.strictEqual(app.gitCredentialEnv, undefined, 'no env before the session starts');
+
+		await app.startGitCredentialSession();
+		assert.ok(app.gitCredentialEnv[GIT_CREDENTIAL_SOCKET_ENV], 'env carries the socket while open');
+
+		await app.cleanupGitCredentialSession();
+		assert.strictEqual(app.gitCredentialEnv, undefined, 'env cleared after cleanup');
+		assert.strictEqual(app.gitCredentials, undefined, 'in-memory tokens dropped after cleanup');
+	});
+
+	it('starting a session is a no-op without git credentials', async () => {
+		const app = new Application({
+			name: 'no-git-credentials-test',
+			packageIdentifier: 'npm:@myorg/app',
+			credentials: [{ registry: 'https://npm.pkg.github.com', token: 'npm-tok' }],
+		});
+		await app.startGitCredentialSession();
+		assert.strictEqual(app.gitCredentialEnv, undefined);
+		await app.cleanupGitCredentialSession();
+	});
+});
+
+describe('nonInteractiveSpawn git credential scoping', () => {
+	let scriptDir;
+	let scriptPath;
+
+	before(async () => {
+		scriptDir = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-env-probe-'));
+		scriptPath = path.join(scriptDir, 'probe.js');
+		// Stands in for a dependency's install script: prints whatever git credential wiring it inherited.
+		await fs.writeFile(
+			scriptPath,
+			`const keys = Object.keys(process.env).filter((k) => k.startsWith('GIT_') || k === '${GIT_CREDENTIAL_SOCKET_ENV}');\n` +
+				`process.stdout.write(JSON.stringify(keys.sort()));\n`
+		);
+	});
+
+	after(async () => {
+		await fs.rm(scriptDir, { recursive: true, force: true });
+	});
+
+	async function probeEnv(gitCredentialEnv) {
+		const { stdout, code } = await nonInteractiveSpawn(
+			'env-probe',
+			process.execPath,
+			[scriptPath],
+			scriptDir,
+			30_000,
+			undefined,
+			undefined,
+			gitCredentialEnv
+		);
+		assert.strictEqual(code, 0, `probe exited ${code}`);
+		return JSON.parse(stdout.slice(stdout.indexOf('[')));
+	}
+
+	it('grants the credential environment to the spawn that clones, and to no other', async () => {
+		const session = await startGitCredentialSession(
+			[{ host: 'github.com', token: 'ghp_secret' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		try {
+			// The clone spawn (`npm pack`) is handed the session env...
+			const cloneEnv = await probeEnv(session.env);
+			assert.ok(cloneEnv.includes('GIT_ASKPASS'), 'clone spawn can reach the helper');
+			assert.ok(cloneEnv.includes(GIT_CREDENTIAL_SOCKET_ENV), 'clone spawn can reach the socket');
+
+			// ...and the install spawn, where a transitive dependency's install script can run, is not.
+			const installEnv = await probeEnv(undefined);
+			assert.ok(!installEnv.includes(GIT_CREDENTIAL_SOCKET_ENV), 'install spawn cannot reach the socket');
+			assert.ok(
+				!installEnv.some((key) => key.startsWith('GIT_CONFIG_') || key === 'GIT_ASKPASS'),
+				`install spawn saw git credential wiring: ${installEnv.join(', ')}`
+			);
+		} finally {
+			await session.close();
+		}
+	});
+
+	it('strips an inherited socket variable, disarming a helper wired up outside the session', async () => {
+		// Belt and braces: even if Harper's own environment somehow carried the socket variable, a spawn
+		// that was not granted the session must not inherit it.
+		process.env[GIT_CREDENTIAL_SOCKET_ENV] = '/tmp/not-a-real-session.sock';
+		try {
+			const installEnv = await probeEnv(undefined);
+			assert.ok(!installEnv.includes(GIT_CREDENTIAL_SOCKET_ENV), 'inherited socket variable stripped');
+		} finally {
+			delete process.env[GIT_CREDENTIAL_SOCKET_ENV];
+		}
+	});
+});

--- a/unitTests/components/gitSemverCommittish.test.js
+++ b/unitTests/components/gitSemverCommittish.test.js
@@ -12,6 +12,7 @@
 
 const assert = require('node:assert');
 const fs = require('node:fs/promises');
+const { existsSync } = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
@@ -216,5 +217,68 @@ describe('semver-range committish resolution on a credentialed git-reference dep
 		} finally {
 			await application.cleanupGitCredentialSession();
 		}
+	});
+});
+
+describe('semver-committish resolution excludes tags unsafe to pass to a shell (#1797 review)', function () {
+	this.timeout(60_000);
+
+	let root;
+	let marker;
+	let packageIdentifier;
+
+	before(async function () {
+		if (process.platform === 'win32' || !GIT_AVAILABLE) return this.skip();
+		await fs.mkdir(getConfigPath(CONFIG_PARAMS.COMPONENTSROOT), { recursive: true });
+		root = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-git-semver-injection-'));
+		marker = path.join(root, 'pwned-marker');
+
+		const work = path.join(root, 'work');
+		const bare = path.join(root, 'semver-injection.git');
+		await fs.mkdir(work, { recursive: true });
+		const git = (...args) => execFileSync('git', args, { cwd: work, stdio: 'pipe' });
+		git('init', '--quiet', '--initial-branch=main');
+		git('config', 'user.email', 'test@harperdb.io');
+		git('config', 'user.name', 'Harper Test');
+		git('config', 'commit.gpgsign', 'false');
+		await fs.writeFile(
+			path.join(work, 'package.json'),
+			JSON.stringify({ name: 'semver-injection', version: '1.0.0' }, null, 2)
+		);
+		git('add', '.');
+		git('commit', '--quiet', '-m', 'v1.0.0');
+		git('tag', '-a', 'v1.0.0', '-m', 'v1.0.0');
+		// A legal git tag name (git rejects a literal space in a ref name, so `${IFS}` stands in for
+		// one — the classic space-free shell payload; confirmed this still expands to a real space
+		// when a shell evaluates it) whose trailing suffix is a version-shaped string satisfying
+		// `^9.0.0` — the only tag that would. `nonInteractiveSpawn` checks out its resolved committish
+		// through a shell with no argument escaping, so if this tag name reached that spawn unfiltered,
+		// `$(...)` would run as a command substitution before git ever saw the checkout target.
+		git('tag', '-a', `$(touch\${IFS}${marker})v9.9.9`, '-m', 'malicious');
+
+		execFileSync('git', ['clone', '--quiet', '--bare', work, bare], { stdio: 'pipe' });
+		packageIdentifier = `git+file://${bare}`;
+	});
+
+	after(async () => {
+		if (root) await fs.rm(root, { recursive: true, force: true });
+	});
+
+	it('does not execute a shell metacharacter embedded in a resolved tag name, and fails resolution instead', async () => {
+		const application = new Application({
+			name: 'git-semver-injection',
+			packageIdentifier: `${packageIdentifier}#semver:^9.0.0`,
+			credentials: [{ host: 'example.com', token: 'unused-for-file-clone' }],
+		});
+		await application.startGitCredentialSession();
+		try {
+			// Only the malicious tag's embedded 9.9.9 satisfies ^9.0.0; excluding it from resolution
+			// means nothing satisfies the range, so this must fail closed rather than check it out.
+			await assert.rejects(() => extractApplication(application), /no tag satisfies range '\^9\.0\.0'/);
+		} finally {
+			await application.cleanupGitCredentialSession();
+		}
+
+		assert.ok(!existsSync(marker), 'the shell command substitution in the tag name must not have run');
 	});
 });

--- a/unitTests/components/gitSemverCommittish.test.js
+++ b/unitTests/components/gitSemverCommittish.test.js
@@ -1,0 +1,220 @@
+'use strict';
+
+// Covers resolving an npm-style `semver:<range>` committish to a concrete tag before `git checkout`
+// (#1797 follow-up). #1799's own worked example (`github:my-org/my-app#semver:v1.2.3`) documented this
+// form, but `packGitReferenceWithoutScripts` passed the committish straight to `git checkout`
+// unconditionally — which has no notion of npm's `semver:` prefix and simply fails.
+//
+// Exercised through the real credentialed-clone path (`extractApplication` with a git credential
+// session active), against a genuine local git repository, rather than unit-testing the resolution
+// logic in isolation: the whole point is that a `semver:` committish now survives all the way through
+// `packGitReferenceWithoutScripts` to a successful checkout.
+
+const assert = require('node:assert');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const testUtils = require('../testUtils.js');
+testUtils.preTestPrep();
+
+const { Application, extractApplication } = require('#src/components/Application');
+const { getConfigPath } = require('#src/config/configUtils');
+const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
+
+// git may not be installed/in PATH in every test environment; resolved lazily so a missing git skips
+// gracefully in before() rather than crashing the whole suite's loading.
+let GIT_AVAILABLE = true;
+try {
+	execFileSync('git', ['--version'], { stdio: 'pipe' });
+} catch {
+	GIT_AVAILABLE = false;
+}
+
+// A bare repo with tagged commits, each carrying a package.json `version` matching its tag, so a
+// resolved checkout can be verified by reading the extracted manifest back out. `tags` pairs a tag
+// name with the version it should carry — letting a case exercise a prefixed tag (`component-v3.0.0`)
+// alongside the plain ones. A `v1.2.3` branch (pointing at different content than the `v1.2.3` tag)
+// proves resolution checks out the tag, not a same-named branch.
+async function createTaggedRepo(root, tags) {
+	const work = path.join(root, 'work');
+	const bare = path.join(root, 'semver-component.git');
+	await fs.mkdir(work, { recursive: true });
+	const git = (...args) => execFileSync('git', args, { cwd: work, stdio: 'pipe' });
+	git('init', '--quiet', '--initial-branch=main');
+	git('config', 'user.email', 'test@harperdb.io');
+	git('config', 'user.name', 'Harper Test');
+	git('config', 'commit.gpgsign', 'false');
+
+	const writeVersion = async (version) => {
+		await fs.writeFile(
+			path.join(work, 'package.json'),
+			JSON.stringify({ name: 'semver-component', version, description: 'private test component' }, null, 2)
+		);
+		git('add', '.');
+		git('commit', '--quiet', '-m', `v${version}`);
+	};
+
+	for (const { tag, version } of tags) {
+		await writeVersion(version);
+		// Explicit -a -m avoids relying on the lightweight-tag default, which some git configs (e.g.
+		// tag.gpgSign or an editor-invoking core.editor) turn into an annotated tag needing a message.
+		git('tag', '-a', tag, '-m', tag);
+	}
+
+	// A branch sharing the resolved tag's name, pointing at different content: proves resolution
+	// checks out `refs/tags/v1.2.3` rather than an ambiguous bare `v1.2.3` that git would resolve to
+	// this branch first.
+	git('branch', 'v1.2.3');
+	git('checkout', '--quiet', 'v1.2.3');
+	await writeVersion('branch-decoy');
+	git('checkout', '--quiet', 'main');
+
+	execFileSync('git', ['clone', '--quiet', '--bare', work, bare], { stdio: 'pipe' });
+	return bare;
+}
+
+const STANDARD_TAGS = [
+	{ tag: 'v1.0.0', version: '1.0.0' },
+	{ tag: 'v1.2.3', version: '1.2.3' },
+	{ tag: 'v2.0.0', version: '2.0.0' },
+	// A common "prefixed tag" convention (e.g. a monorepo's per-package tags): npm's own git resolver
+	// extracts the trailing version-shaped suffix from a tag like this one.
+	{ tag: 'component-v3.0.0', version: '3.0.0' },
+];
+
+describe('semver-range committish resolution on a credentialed git-reference deploy', function () {
+	this.timeout(60_000);
+
+	let root;
+	let packageIdentifier;
+
+	before(async function () {
+		if (process.platform === 'win32' || !GIT_AVAILABLE) return this.skip();
+		// extractApplication packs into the components root, which the unit-test config points at but
+		// does not create.
+		await fs.mkdir(getConfigPath(CONFIG_PARAMS.COMPONENTSROOT), { recursive: true });
+		root = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-git-semver-'));
+		const bareRepo = await createTaggedRepo(root, STANDARD_TAGS);
+		// git+file:// takes the credentialed clone-and-checkout path exactly like git+https://; no
+		// network/HTTP fixture is needed to exercise checkout resolution.
+		packageIdentifier = `git+file://${bareRepo}`;
+	});
+
+	after(async () => {
+		if (root) await fs.rm(root, { recursive: true, force: true });
+	});
+
+	// A `credentials` entry with any host is enough to put the deploy on the credentialed path
+	// (application.gitCredentialEnv truthy), which is what routes through packGitReferenceWithoutScripts
+	// instead of a plain `npm pack`. The host need not match the git+file:// URL for this.
+	function credentialedApplication(name, committish) {
+		return new Application({
+			name,
+			packageIdentifier: `${packageIdentifier}#${committish}`,
+			credentials: [{ host: 'example.com', token: 'unused-for-file-clone' }],
+		});
+	}
+
+	it('resolves a semver:<range> committish to the highest satisfying tag before checkout', async () => {
+		const application = credentialedApplication('git-semver-resolve', 'semver:^1.0.0');
+		await application.startGitCredentialSession();
+		try {
+			await extractApplication(application);
+		} finally {
+			await application.cleanupGitCredentialSession();
+		}
+
+		const packageJSON = JSON.parse(await fs.readFile(path.join(application.dirPath, 'package.json'), 'utf8'));
+		// v1.2.3 is the highest tag satisfying ^1.0.0 (v2.0.0 is excluded by the caret range).
+		assert.strictEqual(packageJSON.version, '1.2.3');
+	});
+
+	it("resolves an exact semver:<version> committish, matching #1799's own worked example", async () => {
+		const application = credentialedApplication('git-semver-exact', 'semver:v2.0.0');
+		await application.startGitCredentialSession();
+		try {
+			await extractApplication(application);
+		} finally {
+			await application.cleanupGitCredentialSession();
+		}
+
+		const packageJSON = JSON.parse(await fs.readFile(path.join(application.dirPath, 'package.json'), 'utf8'));
+		assert.strictEqual(packageJSON.version, '2.0.0');
+	});
+
+	it('leaves a non-semver committish untouched, checking it out literally', async () => {
+		const application = credentialedApplication('git-semver-literal', 'v1.0.0');
+		await application.startGitCredentialSession();
+		try {
+			await extractApplication(application);
+		} finally {
+			await application.cleanupGitCredentialSession();
+		}
+
+		const packageJSON = JSON.parse(await fs.readFile(path.join(application.dirPath, 'package.json'), 'utf8'));
+		assert.strictEqual(packageJSON.version, '1.0.0');
+	});
+
+	it('decodes a URL-encoded range (e.g. semver:%5E1.0.0), matching npm-package-arg', async () => {
+		const application = credentialedApplication('git-semver-encoded', 'semver:%5E1.0.0');
+		await application.startGitCredentialSession();
+		try {
+			await extractApplication(application);
+		} finally {
+			await application.cleanupGitCredentialSession();
+		}
+
+		const packageJSON = JSON.parse(await fs.readFile(path.join(application.dirPath, 'package.json'), 'utf8'));
+		// %5E decodes to `^`, so this is the same range (and result) as the `^1.0.0` case above.
+		assert.strictEqual(packageJSON.version, '1.2.3');
+	});
+
+	it('resolves a range against the version embedded in a prefixed tag (component-v3.0.0)', async () => {
+		const application = credentialedApplication('git-semver-prefixed-tag', 'semver:^3.0.0');
+		await application.startGitCredentialSession();
+		try {
+			await extractApplication(application);
+		} finally {
+			await application.cleanupGitCredentialSession();
+		}
+
+		const packageJSON = JSON.parse(await fs.readFile(path.join(application.dirPath, 'package.json'), 'utf8'));
+		assert.strictEqual(packageJSON.version, '3.0.0');
+	});
+
+	it('checks out the resolved tag rather than a branch of the same name', async () => {
+		const application = credentialedApplication('git-semver-tag-not-branch', 'semver:v1.2.3');
+		await application.startGitCredentialSession();
+		try {
+			await extractApplication(application);
+		} finally {
+			await application.cleanupGitCredentialSession();
+		}
+
+		const packageJSON = JSON.parse(await fs.readFile(path.join(application.dirPath, 'package.json'), 'utf8'));
+		// The repo also has a branch named `v1.2.3` carrying `branch-decoy` content; an unqualified
+		// `git checkout v1.2.3` resolves to that branch (confirmed empirically), not the tag.
+		assert.strictEqual(packageJSON.version, '1.2.3');
+	});
+
+	it('throws a clear, diagnosable error when no tag satisfies the range', async () => {
+		const application = credentialedApplication('git-semver-unsatisfiable', 'semver:^9.9.9');
+		await application.startGitCredentialSession();
+		try {
+			await assert.rejects(
+				() => extractApplication(application),
+				(err) => {
+					assert.match(err.message, /no tag satisfies range '\^9\.9\.9'/);
+					assert.match(err.message, /v1\.0\.0/);
+					assert.match(err.message, /v1\.2\.3/);
+					assert.match(err.message, /v2\.0\.0/);
+					return true;
+				}
+			);
+		} finally {
+			await application.cleanupGitCredentialSession();
+		}
+	});
+});

--- a/unitTests/components/secretOperations.test.js
+++ b/unitTests/components/secretOperations.test.js
@@ -504,40 +504,40 @@ describe('secretOperations', () => {
 		});
 	});
 
-	describe('resolveRegistryAuth (deploy_component secret references)', () => {
+	describe('resolveCredentials (deploy_component secret references)', () => {
 		const gh = 'https://npm.pkg.github.com';
 
 		it('returns undefined/empty inputs untouched', async () => {
-			assert.equal(await secretOps.resolveRegistryAuth(undefined, 'app'), undefined);
+			assert.equal(await secretOps.resolveCredentials(undefined, 'app'), undefined);
 			const empty = [];
-			assert.equal(await secretOps.resolveRegistryAuth(empty, 'app'), empty);
+			assert.equal(await secretOps.resolveCredentials(empty, 'app'), empty);
 		});
 
 		it('passes literal-token entries through without needing custody or the store', async () => {
 			// No custody installed, mock table present but never read for the token-only fast path.
 			const input = [{ registry: gh, token: 'tok', scope: '@org' }];
-			const out = await secretOps.resolveRegistryAuth(input, 'app');
+			const out = await secretOps.resolveCredentials(input, 'app');
 			assert.strictEqual(out, input, 'token-only input returned as-is (identity)');
 		});
 
 		it('resolves a scoped secret granted to the deploying component', async () => {
 			installCustody();
 			await secretOps.setSecret({ ...su('set_secret'), name: 'GH_TOKEN', value: 'ghp_scoped', grants: ['app'] });
-			const out = await secretOps.resolveRegistryAuth([{ registry: gh, secret: 'GH_TOKEN', scope: '@org' }], 'app');
+			const out = await secretOps.resolveCredentials([{ registry: gh, secret: 'GH_TOKEN', scope: '@org' }], 'app');
 			assert.deepEqual(out, [{ registry: gh, token: 'ghp_scoped', scope: '@org' }]);
 		});
 
 		it('resolves a processEnv (global) secret for any component', async () => {
 			installCustody();
 			await secretOps.setSecret({ ...su('set_secret'), name: 'GLOBAL_TOKEN', value: 'ghp_global', processEnv: true });
-			const out = await secretOps.resolveRegistryAuth([{ registry: gh, secret: 'GLOBAL_TOKEN' }], 'any-app');
+			const out = await secretOps.resolveCredentials([{ registry: gh, secret: 'GLOBAL_TOKEN' }], 'any-app');
 			assert.deepEqual(out, [{ registry: gh, token: 'ghp_global', scope: undefined }]);
 		});
 
 		it('resolves literal and secret-backed entries together', async () => {
 			installCustody();
 			await secretOps.setSecret({ ...su('set_secret'), name: 'S', value: 'from_store', grants: ['app'] });
-			const out = await secretOps.resolveRegistryAuth(
+			const out = await secretOps.resolveCredentials(
 				[
 					{ registry: 'registry.example.com', token: 'literal' },
 					{ registry: gh, secret: 'S', scope: '@org' },
@@ -553,7 +553,7 @@ describe('secretOperations', () => {
 		it('rejects a reference to a non-existent secret with 404', async () => {
 			installCustody();
 			await assert.rejects(
-				async () => secretOps.resolveRegistryAuth([{ registry: gh, secret: 'MISSING' }], 'app'),
+				async () => secretOps.resolveCredentials([{ registry: gh, secret: 'MISSING' }], 'app'),
 				(err) => err.statusCode === 404 && /does not exist/.test(err.message)
 			);
 		});
@@ -562,7 +562,7 @@ describe('secretOperations', () => {
 			installCustody();
 			await secretOps.setSecret({ ...su('set_secret'), name: 'OTHER', value: 'x', grants: ['different-app'] });
 			await assert.rejects(
-				async () => secretOps.resolveRegistryAuth([{ registry: gh, secret: 'OTHER' }], 'app'),
+				async () => secretOps.resolveCredentials([{ registry: gh, secret: 'OTHER' }], 'app'),
 				(err) => err.statusCode === 403 && /not granted to component 'app'/.test(err.message)
 			);
 		});
@@ -574,7 +574,7 @@ describe('secretOperations', () => {
 			await secretOps.setSecret({ ...su('set_secret'), name: 'NO_KEY', value: 'x', grants: ['app'] });
 			clearSecretCustody();
 			await assert.rejects(
-				async () => secretOps.resolveRegistryAuth([{ registry: gh, secret: 'NO_KEY' }], 'app'),
+				async () => secretOps.resolveCredentials([{ registry: gh, secret: 'NO_KEY' }], 'app'),
 				// Server-state condition (custody down), not client-fixable → 503, not the default 400.
 				(err) => err.statusCode === 503 && /secrets custody is not initialized/.test(err.message)
 			);
@@ -591,10 +591,10 @@ describe('secretOperations', () => {
 				getPublicKey: () => ({ publicKey, fingerprint: fp }),
 			});
 			await assert.rejects(
-				async () => secretOps.resolveRegistryAuth([{ registry: gh, secret: 'BAD' }], 'app'),
+				async () => secretOps.resolveCredentials([{ registry: gh, secret: 'BAD' }], 'app'),
 				// Decrypt failure is a node/key condition, not a bad request → 500, not the default 400.
 				(err) =>
-					err.statusCode === 500 && /Failed to decrypt registryAuth secret 'BAD': unsupported padding/.test(err.message)
+					err.statusCode === 500 && /Failed to decrypt credential secret 'BAD': unsupported padding/.test(err.message)
 			);
 		});
 
@@ -602,7 +602,7 @@ describe('secretOperations', () => {
 			installCustody();
 			const start = Date.now();
 			await assert.rejects(
-				async () => secretOps.resolveRegistryAuth([{ registry: gh, secret: 'NEVER' }], 'app', { waitMs: 120 }),
+				async () => secretOps.resolveCredentials([{ registry: gh, secret: 'NEVER' }], 'app', { waitMs: 120 }),
 				(err) => err.statusCode === 404
 			);
 			assert.ok(Date.now() - start >= 100, 'should have waited out the grace period before 404');
@@ -615,7 +615,7 @@ describe('secretOperations', () => {
 			const realRow = installed.mock.rows.get('LATE');
 			installed.mock.rows.delete('LATE');
 			setTimeout(() => installed.mock.rows.set('LATE', realRow), 60);
-			const out = await secretOps.resolveRegistryAuth([{ registry: gh, secret: 'LATE' }], 'app', { waitMs: 2000 });
+			const out = await secretOps.resolveCredentials([{ registry: gh, secret: 'LATE' }], 'app', { waitMs: 2000 });
 			assert.deepEqual(out, [{ registry: gh, token: 'ghp_late', scope: undefined }]);
 		});
 	});
@@ -643,13 +643,13 @@ describe('secretOperations', () => {
 		});
 	});
 
-	describe('ingestRegistryAuth', () => {
+	describe('ingestCredentials', () => {
 		const gh = 'https://npm.pkg.github.com';
 		const deploy = (op = 'deploy_component') => su(op);
 
 		it('seals a literal token into the store and returns a reference; round-trips via resolve', async () => {
 			installCustody();
-			const refs = await secretOps.ingestRegistryAuth(
+			const refs = await secretOps.ingestCredentials(
 				deploy(),
 				[{ registry: gh, token: 'ghp_secret', scope: '@org' }],
 				'app'
@@ -660,31 +660,40 @@ describe('secretOperations', () => {
 			assert.deepEqual(row.grants, ['app']);
 			assert.equal(row.processEnv, false);
 			// Resolving the reference yields the original token back.
-			const resolved = await secretOps.resolveRegistryAuth(refs, 'app');
+			const resolved = await secretOps.resolveCredentials(refs, 'app');
 			assert.deepEqual(resolved, [{ registry: gh, token: 'ghp_secret', scope: '@org' }]);
 		});
 
 		it('passes already-reference entries through without minting a derived row', async () => {
 			installCustody();
 			const input = [{ registry: gh, secret: 'PREEXISTING' }];
-			const out = await secretOps.ingestRegistryAuth(deploy(), input, 'app');
+			const out = await secretOps.ingestCredentials(deploy(), input, 'app');
 			assert.deepEqual(out, [{ registry: gh, secret: 'PREEXISTING' }]);
 			assert.ok(!installed.mock.rows.has('deploy.app.npm.pkg.github.com'), 'no derived row minted');
 		});
 
 		it('without custody, leaves a literal token untouched (transient fallback) and stores nothing', async () => {
 			const input = [{ registry: gh, token: 'ghp_secret' }];
-			const out = await secretOps.ingestRegistryAuth(deploy(), input, 'app');
+			const out = await secretOps.ingestCredentials(deploy(), input, 'app');
 			assert.deepEqual(out, [{ registry: gh, token: 'ghp_secret' }]);
 			assert.equal(installed.mock.putCount, 0, 'no secret written without custody');
 		});
 
+		it('rejects a literal-token entry of an unrecognized kind (validation should have caught it)', async () => {
+			installCustody();
+			await assert.rejects(
+				async () => secretOps.ingestCredentials(deploy(), [{ host: 'github.com', token: 'ghp_secret' }], 'app'),
+				/Unsupported credential entry/
+			);
+			assert.equal(installed.mock.putCount, 0, 'nothing sealed for an entry with no derivable secret name');
+		});
+
 		it('is idempotent on token rotation — same derived row, latest value', async () => {
 			installCustody();
-			await secretOps.ingestRegistryAuth(deploy(), [{ registry: gh, token: 'v1' }], 'app');
-			await secretOps.ingestRegistryAuth(deploy(), [{ registry: gh, token: 'v2' }], 'app');
+			await secretOps.ingestCredentials(deploy(), [{ registry: gh, token: 'v1' }], 'app');
+			await secretOps.ingestCredentials(deploy(), [{ registry: gh, token: 'v2' }], 'app');
 			assert.equal(installed.mock.rows.size, 1, 'one derived row, overwritten');
-			const [resolved] = await secretOps.resolveRegistryAuth(
+			const [resolved] = await secretOps.resolveCredentials(
 				[{ registry: gh, secret: 'deploy.app.npm.pkg.github.com' }],
 				'app'
 			);

--- a/unitTests/components/secretOperations.test.js
+++ b/unitTests/components/secretOperations.test.js
@@ -620,6 +620,69 @@ describe('secretOperations', () => {
 		});
 	});
 
+	describe('resolveCredentials (git-host entries)', () => {
+		it('decrypts a git-host reference granted to the deploying component', async () => {
+			installCustody();
+			await secretOps.setSecret({ ...su('set_secret'), name: 'GIT_TOKEN', value: 'ghp_git', grants: ['app'] });
+			const out = await secretOps.resolveCredentials([{ host: 'github.com', secret: 'GIT_TOKEN' }], 'app');
+			assert.deepEqual(out, [{ host: 'github.com', token: 'ghp_git', username: undefined }]);
+		});
+
+		it('fails loudly for a git reference not granted to the deploying component (403)', async () => {
+			installCustody();
+			await secretOps.setSecret({ ...su('set_secret'), name: 'GIT_OTHER', value: 'x', grants: ['different-app'] });
+			await assert.rejects(
+				async () => secretOps.resolveCredentials([{ host: 'github.com', secret: 'GIT_OTHER' }], 'app'),
+				(err) => err.statusCode === 403 && /not granted to component 'app'/.test(err.message)
+			);
+		});
+
+		it('fails loudly for a git reference when custody is absent on this node (503)', async () => {
+			// The use side is fail-closed: no key here means the deploy stops, not that it silently
+			// clones without the credential and fails somewhere less legible.
+			installCustody();
+			await secretOps.setSecret({ ...su('set_secret'), name: 'GIT_NO_KEY', value: 'x', grants: ['app'] });
+			clearSecretCustody();
+			await assert.rejects(
+				async () => secretOps.resolveCredentials([{ host: 'github.com', secret: 'GIT_NO_KEY' }], 'app'),
+				(err) => err.statusCode === 503 && /secrets custody is not initialized/.test(err.message)
+			);
+		});
+
+		it('rejects an entry of an unrecognized kind rather than resolving it into a half-empty one', async () => {
+			// Symmetric with the ingest guard: a `credentials` entry read back from applicationConfig or
+			// an hdb_deployment row was never schema-validated, so an unknown kind must not silently
+			// produce an entry with an undefined identity.
+			installCustody();
+			await secretOps.setSecret({ ...su('set_secret'), name: 'S', value: 'x', grants: ['app'] });
+			await assert.rejects(
+				async () => secretOps.resolveCredentials([{ proxy: 'example.com', secret: 'S' }], 'app'),
+				/Unsupported credential entry/
+			);
+			await assert.rejects(
+				async () => secretOps.resolveCredentials([{ proxy: 'example.com', token: 'literal' }], 'app'),
+				/Unsupported credential entry/
+			);
+		});
+	});
+
+	describe('deriveGitSecretName', () => {
+		it('derives a stable name keyed by component and host, with a git segment disambiguating it from a registry secret', () => {
+			assert.equal(secretOps.deriveGitSecretName('my-app', 'github.com'), 'deploy.my-app.git.github.com');
+		});
+
+		it('is identical across the host forms that identify the same host', () => {
+			assert.equal(
+				secretOps.deriveGitSecretName('app', 'https://GitHub.com/'),
+				secretOps.deriveGitSecretName('app', 'github.com')
+			);
+		});
+
+		it('sanitizes a port to the set_secret name grammar', () => {
+			assert.equal(secretOps.deriveGitSecretName('app', 'git.example.com:8443'), 'deploy.app.git.git.example.com_8443');
+		});
+	});
+
 	describe('deriveRegistrySecretName', () => {
 		it('derives a stable name keyed by component and registry, sanitized to the name grammar', () => {
 			assert.equal(
@@ -682,10 +745,63 @@ describe('secretOperations', () => {
 		it('rejects a literal-token entry of an unrecognized kind (validation should have caught it)', async () => {
 			installCustody();
 			await assert.rejects(
-				async () => secretOps.ingestCredentials(deploy(), [{ host: 'github.com', token: 'ghp_secret' }], 'app'),
+				async () => secretOps.ingestCredentials(deploy(), [{ proxy: 'example.com', token: 'ghp_secret' }], 'app'),
 				/Unsupported credential entry/
 			);
 			assert.equal(installed.mock.putCount, 0, 'nothing sealed for an entry with no derivable secret name');
+		});
+
+		it('seals a git-host token the same way, keyed by host', async () => {
+			installCustody();
+			const refs = await secretOps.ingestCredentials(deploy(), [{ host: 'github.com', token: 'ghp_secret' }], 'app');
+			assert.deepEqual(refs, [{ host: 'github.com', secret: 'deploy.app.git.github.com' }]);
+			const row = installed.mock.rows.get('deploy.app.git.github.com');
+			assert.deepEqual(row.grants, ['app'], 'granted to the deploying component, not global');
+			assert.equal(row.processEnv, false);
+			assert.deepEqual(await secretOps.resolveCredentials(refs, 'app'), [
+				{ host: 'github.com', token: 'ghp_secret', username: undefined },
+			]);
+		});
+
+		it('preserves a git entry username through the seal/resolve round trip', async () => {
+			installCustody();
+			const refs = await secretOps.ingestCredentials(
+				deploy(),
+				[{ host: 'gitlab.com', token: 'glpat', username: 'oauth2' }],
+				'app'
+			);
+			assert.deepEqual(refs, [{ host: 'gitlab.com', secret: 'deploy.app.git.gitlab.com', username: 'oauth2' }]);
+			assert.deepEqual(await secretOps.resolveCredentials(refs, 'app'), [
+				{ host: 'gitlab.com', token: 'glpat', username: 'oauth2' },
+			]);
+		});
+
+		it('ingests npm and git entries side by side in one deploy', async () => {
+			installCustody();
+			const refs = await secretOps.ingestCredentials(
+				deploy(),
+				[
+					{ registry: gh, token: 'npm_tok', scope: '@org' },
+					{ host: 'github.com', token: 'git_tok' },
+				],
+				'app'
+			);
+			assert.deepEqual(refs, [
+				{ registry: gh, secret: 'deploy.app.npm.pkg.github.com', scope: '@org' },
+				{ host: 'github.com', secret: 'deploy.app.git.github.com' },
+			]);
+			assert.equal(installed.mock.rows.size, 2, 'each kind gets its own derived row');
+		});
+
+		it('without custody, leaves a literal git token untouched (transient fallback) and stores nothing', async () => {
+			const input = [{ host: 'github.com', token: 'ghp_secret' }];
+			const out = await secretOps.ingestCredentials(deploy(), input, 'app');
+			assert.deepEqual(out, [{ host: 'github.com', token: 'ghp_secret' }]);
+			assert.equal(installed.mock.putCount, 0, 'no secret written without custody');
+			// The deploy handler persists/replicates only entries with a `.secret` reference; a no-custody
+			// literal token is therefore not in that set and gets stripped from the op body entirely.
+			const references = out.filter((entry) => entry && entry.secret !== undefined);
+			assert.equal(references.length, 0, 'a no-custody literal token yields no persistable reference');
 		});
 
 		it('is idempotent on token rotation — same derived row, latest value', async () => {

--- a/unitTests/server/fastifyRoutes/operationsValidation.test.js
+++ b/unitTests/server/fastifyRoutes/operationsValidation.test.js
@@ -223,20 +223,20 @@ describe('Test operationsValidation module', () => {
 		});
 	});
 
-	describe('Test deployComponentValidator registryAuth', () => {
-		it('accepts a valid registryAuth array', () => {
+	describe('Test deployComponentValidator credentials', () => {
+		it('accepts a valid credentials array', () => {
 			const result = validator.deployComponentValidator({
 				project: 'my_app',
 				package: 'npm:@myorg/app@1.0.0',
-				registryAuth: [{ registry: 'https://npm.pkg.github.com', token: 'tok', scope: '@myorg' }],
+				credentials: [{ registry: 'https://npm.pkg.github.com', token: 'tok', scope: '@myorg' }],
 			});
 			expect(result).to.equal(undefined);
 		});
 
-		it('rejects a registryAuth entry missing a token', () => {
+		it('rejects a credential entry missing a token', () => {
 			const result = validator.deployComponentValidator({
 				project: 'my_app',
-				registryAuth: [{ registry: 'https://npm.pkg.github.com' }],
+				credentials: [{ registry: 'https://npm.pkg.github.com' }],
 			});
 			expect(result.message).to.contain('token');
 		});
@@ -244,23 +244,23 @@ describe('Test operationsValidation module', () => {
 		it('rejects an invalid scope', () => {
 			const result = validator.deployComponentValidator({
 				project: 'my_app',
-				registryAuth: [{ registry: 'https://npm.pkg.github.com', token: 'tok', scope: 'noatsign' }],
+				credentials: [{ registry: 'https://npm.pkg.github.com', token: 'tok', scope: 'noatsign' }],
 			});
 			expect(result.message).to.contain('scope');
 		});
 
-		it('rejects registryAuth that is not an array', () => {
+		it('rejects credentials that is not an array', () => {
 			const result = validator.deployComponentValidator({
 				project: 'my_app',
-				registryAuth: { registry: 'https://npm.pkg.github.com', token: 'tok' },
+				credentials: { registry: 'https://npm.pkg.github.com', token: 'tok' },
 			});
-			expect(result.message).to.contain('registryAuth');
+			expect(result.message).to.contain('credentials');
 		});
 
 		it('rejects a token containing a newline (.npmrc line injection)', () => {
 			const result = validator.deployComponentValidator({
 				project: 'my_app',
-				registryAuth: [{ registry: 'https://npm.pkg.github.com', token: 'tok\nregistry=https://evil.example.com/' }],
+				credentials: [{ registry: 'https://npm.pkg.github.com', token: 'tok\nregistry=https://evil.example.com/' }],
 			});
 			expect(result.message).to.contain('token');
 		});
@@ -268,7 +268,7 @@ describe('Test operationsValidation module', () => {
 		it('rejects a registry containing a newline (.npmrc line injection)', () => {
 			const result = validator.deployComponentValidator({
 				project: 'my_app',
-				registryAuth: [{ registry: 'https://npm.pkg.github.com\n//evil.example.com/:_authToken=x', token: 'tok' }],
+				credentials: [{ registry: 'https://npm.pkg.github.com\n//evil.example.com/:_authToken=x', token: 'tok' }],
 			});
 			expect(result.message).to.contain('registry');
 		});
@@ -277,7 +277,7 @@ describe('Test operationsValidation module', () => {
 			const result = validator.deployComponentValidator({
 				project: 'my_app',
 				package: 'npm:@myorg/app@1.0.0',
-				registryAuth: [{ registry: 'npm.pkg.github.com', token: 'tok' }],
+				credentials: [{ registry: 'npm.pkg.github.com', token: 'tok' }],
 			});
 			expect(result).to.equal(undefined);
 		});
@@ -286,7 +286,7 @@ describe('Test operationsValidation module', () => {
 			const result = validator.deployComponentValidator({
 				project: 'my_app',
 				package: 'npm:@myorg/app@1.0.0',
-				registryAuth: [{ registry: 'https://npm.pkg.github.com', secret: 'GH_TOKEN', scope: '@myorg' }],
+				credentials: [{ registry: 'https://npm.pkg.github.com', secret: 'GH_TOKEN', scope: '@myorg' }],
 			});
 			expect(result).to.equal(undefined);
 		});
@@ -294,7 +294,7 @@ describe('Test operationsValidation module', () => {
 		it('rejects an entry that supplies both token and secret (exactly one required)', () => {
 			const result = validator.deployComponentValidator({
 				project: 'my_app',
-				registryAuth: [{ registry: 'https://npm.pkg.github.com', token: 'tok', secret: 'GH_TOKEN' }],
+				credentials: [{ registry: 'https://npm.pkg.github.com', token: 'tok', secret: 'GH_TOKEN' }],
 			});
 			expect(result.message).to.contain('secret');
 		});
@@ -302,7 +302,7 @@ describe('Test operationsValidation module', () => {
 		it('rejects an entry supplying neither token nor secret', () => {
 			const result = validator.deployComponentValidator({
 				project: 'my_app',
-				registryAuth: [{ registry: 'https://npm.pkg.github.com' }],
+				credentials: [{ registry: 'https://npm.pkg.github.com' }],
 			});
 			expect(result.message).to.contain('secret');
 		});
@@ -310,9 +310,26 @@ describe('Test operationsValidation module', () => {
 		it('rejects an invalid secret name', () => {
 			const result = validator.deployComponentValidator({
 				project: 'my_app',
-				registryAuth: [{ registry: 'https://npm.pkg.github.com', secret: 'bad name/with slash' }],
+				credentials: [{ registry: 'https://npm.pkg.github.com', secret: 'bad name/with slash' }],
 			});
 			expect(result.message).to.contain('secret');
+		});
+
+		it('rejects the pre-rename registryAuth field (clean break, #1717 never shipped GA)', () => {
+			const result = validator.deployComponentValidator({
+				project: 'my_app',
+				package: 'npm:@myorg/app@1.0.0',
+				registryAuth: [{ registry: 'https://npm.pkg.github.com', token: 'tok' }],
+			});
+			expect(result.message).to.contain('registryAuth');
+		});
+
+		it('rejects an entry of an unrecognized kind (a git-host entry lands with #1792)', () => {
+			const result = validator.deployComponentValidator({
+				project: 'my_app',
+				credentials: [{ host: 'github.com', token: 'tok' }],
+			});
+			expect(result.message).to.contain('registry');
 		});
 	});
 

--- a/unitTests/server/fastifyRoutes/operationsValidation.test.js
+++ b/unitTests/server/fastifyRoutes/operationsValidation.test.js
@@ -324,12 +324,89 @@ describe('Test operationsValidation module', () => {
 			expect(result.message).to.contain('registryAuth');
 		});
 
-		it('rejects an entry of an unrecognized kind (a git-host entry lands with #1792)', () => {
+		it('accepts a git-host entry, with a token or a secret reference (#1792)', () => {
+			for (const entry of [
+				{ host: 'github.com', token: 'ghp_tok' },
+				{ host: 'github.com', secret: 'GH_TOKEN' },
+				{ host: 'gitlab.com', token: 'glpat', username: 'oauth2' },
+				{ host: 'git.example.com:8443', token: 'tok' },
+			]) {
+				const result = validator.deployComponentValidator({
+					project: 'my_app',
+					package: 'github:myorg/private-app',
+					credentials: [entry],
+				});
+				expect(result, JSON.stringify(entry)).to.be.undefined;
+			}
+		});
+
+		it('accepts npm and git entries in the same credentials array', () => {
 			const result = validator.deployComponentValidator({
 				project: 'my_app',
-				credentials: [{ host: 'github.com', token: 'tok' }],
+				package: 'github:myorg/private-app',
+				credentials: [
+					{ registry: 'https://npm.pkg.github.com', token: 'npm_tok', scope: '@myorg' },
+					{ host: 'github.com', token: 'git_tok' },
+				],
 			});
-			expect(result.message).to.contain('registry');
+			expect(result).to.be.undefined;
+		});
+
+		it('rejects a git entry supplying both a token and a secret', () => {
+			const result = validator.deployComponentValidator({
+				project: 'my_app',
+				credentials: [{ host: 'github.com', token: 'tok', secret: 'GH_TOKEN' }],
+			});
+			expect(result).to.be.ok;
+		});
+
+		it('rejects a git entry supplying neither a token nor a secret', () => {
+			const result = validator.deployComponentValidator({
+				project: 'my_app',
+				credentials: [{ host: 'github.com' }],
+			});
+			expect(result).to.be.ok;
+		});
+
+		it('rejects a host carrying a scheme, path, or userinfo (a credential is matched by host)', () => {
+			for (const host of ['https://github.com', 'github.com/myorg/repo', 'user@github.com', 'git hub.com']) {
+				const result = validator.deployComponentValidator({
+					project: 'my_app',
+					credentials: [{ host, token: 'tok' }],
+				});
+				expect(result, host).to.be.ok;
+			}
+		});
+
+		it('rejects an unknown key on an entry (a stray secret-bearing field must not persist)', () => {
+			// allowUnknown is on for the operation, but a credential entry with an extra key would carry
+			// that key through ingest into config/hdb_deployment and replication — reject it here.
+			for (const entry of [
+				{ registry: 'https://npm.pkg.github.com', token: 'tok', password: 'literal' },
+				{ host: 'github.com', secret: 'GH_TOKEN', password: 'literal' },
+			]) {
+				const result = validator.deployComponentValidator({
+					project: 'my_app',
+					package: 'github:myorg/private-app',
+					credentials: [entry],
+				});
+				expect(result, JSON.stringify(entry)).to.be.ok;
+			}
+		});
+
+		it('rejects an entry that is neither kind, or that is ambiguously both', () => {
+			const neither = validator.deployComponentValidator({
+				project: 'my_app',
+				credentials: [{ proxy: 'example.com', token: 'tok' }],
+			});
+			expect(neither).to.be.ok;
+			// `registry` and `host` are the kind discriminators; an entry carrying both has no single
+			// kind, so it must not be silently treated as one of them.
+			const both = validator.deployComponentValidator({
+				project: 'my_app',
+				credentials: [{ registry: 'https://npm.pkg.github.com', host: 'github.com', token: 'tok' }],
+			});
+			expect(both).to.be.ok;
 		});
 	});
 


### PR DESCRIPTION
## Summary

`deploy_component`'s `registryAuth` field becomes `credentials`, and the array is now kind-heterogeneous rather than npm-only.

An entry's *kind* is implied by its identifying key — `registry` means an npm registry-auth entry, exactly as today — rather than by a new `kind`/`type` discriminator field. That mirrors how entries already discriminate `token` vs `secret` via `.xor()`, and it means the planned git-host credential of [#1792](https://github.com/HarperFast/harper/issues/1792) (`{ host, token|secret }`) slots in as another item alternative in the same array instead of forcing another schema rewrite.

```json
"credentials": [
  { "registry": "https://npm.pkg.github.com", "scope": "@my-org", "token": "..." }
]
```

## Why

`registryAuth` ([#1717](https://github.com/HarperFast/harper/pull/1717)) shipped the whole credential pipeline — ingest a literal token into the encrypted `hdb_secret` store, replicate a `{ registry, secret }` reference rather than the token, resolve by decrypt-at-use with a grant check. That machinery is right; only the *shape* was npm-shaped. Renaming it now, while #1717 is still unreleased, avoids doing this after it has a GA API to preserve.

**Nothing about the security model changed.** Literal-token sealing, reference-only replication, the no-custody degraded passthrough, the grant check, the precise 404/403/503/500 resolve errors, and the bounded `waitMs` replication grace period are all carried over as-is; the existing tests for each were re-pointed at the new names and still assert the same behavior.

## Backward compatibility: clean break, with a guard

#1717 merged into the 5.2 dev line and has not shipped in a GA release, so there's no released API to keep an alias for — this is a clean rename.

But a clean rename needed one guard I did *not* expect. Operation validation runs with `allowUnknown: true`, so a caller still sending `registryAuth` would have sailed through validation and deployed **with no credentials at all** — surfacing as a confusing npm 401 rather than a bad-request. So `registryAuth` is now explicitly `forbidden()` with a message naming its replacement. It also stays in `processLocalTransaction`'s operations-log strip list: that redaction runs *ahead* of validation, so a stale caller's literal token would otherwise be logged before the request was rejected.

## Where to look

- `components/operationsValidation.js` — the field definition, the extracted `REGISTRY_CREDENTIAL_ENTRY` (the seam #1792 extends), and the `registryAuth` rejection.
- `server/serverHelpers/serverUtilities.ts` — both field names in the log strip; see the reasoning above.
- `components/secretOperations.ts` — pure rename (`ingestCredentials` / `resolveCredentials`), plus one guard: ingest now throws on an entry with no derivable secret name, so a future kind can't silently mint a garbage secret name off an `undefined` registry.

## Things a reviewer should weigh in on

1. **Persisted-form renames.** `applicationConfig.registryAuth` → `credentials` and the `hdb_deployment` row's `registry_auth` → `credentials` were renamed for consistency. A component deployed on an *earlier 5.2 dev build* keeps the old key in its config, where it is now ignored — that cold install proceeds without credentials. Acceptable on an unreleased line, but it is a real (if narrow) behavior change and worth a conscious ack.
2. **harper-pro coupling — needs a follow-up PR.** `harper-pro`'s `replication/logRedaction.ts` masks tokens by keying on `operation.registryAuth`; after this rename that mask matches nothing. It is defense-in-depth (core strips literal tokens before replication, so no known path leaks), but it should be updated to `credentials` in lockstep. Not fixable from this repo.
3. **Docs.** The unmerged `secrets-docs` documentation branch documents `registryAuth` and will need the new field name before it publishes.

## Testing

`test:unit:main`, `test:unit:resources`, and the `integrationTests/deploy` suite (24 passing) are green. The 10 failures in `test:unit:main` are a pre-existing `globalIsolation` fixture issue in my worktree (missing fixture `node_modules`); they pass on a clean `main` checkout.

Test changes are re-pointed assertions, not just renamed files — plus new cases for the rejected legacy field, an unrecognized entry kind at validation, and the ingest guard.

Generated by Claude Opus 4.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)