### PR TITLE
fix(analytics): drive get_analytics off the bounded time window, not the metric index (#1796)

### DIFF
--- a/resources/analytics/read.ts
+++ b/resources/analytics/read.ts
@@ -192,47 +192,52 @@ interface GetAnalyticsOpts {
 
 export async function get(metric: string, opts?: GetAnalyticsOpts): Promise<Metric[]> {
 	const { getAttributes, startTime, endTime, additionalConditions, log: logName } = opts ?? {};
-	const conditions: Conditions = [{ attribute: 'metric', comparator: 'equals', value: metric }];
+
+	// A two-sided time window bounds the primary-key (`id` = [time, nodeId]) range on both ends. When we
+	// have one, lead with it and pin execution order (below) so it drives the scan. `Table.search`
+	// otherwise reorders conditions by estimated cost, but the planner estimates a primary-key `between`
+	// as a flat 10% of the table (search.ts BETWEEN_ESTIMATE) rather than from the actual range width —
+	// so on a large `hdb_analytics` table a narrow window looks costlier than `metric equals`, iteration
+	// is driven off the metric index, and the metric's entire history is decoded instead of the window
+	// (#1796). The proper long-term fix is a range-width-aware cost estimate in search.ts.
+	const boundedWindow = Boolean(startTime && endTime);
+	const conditions: Conditions = [];
+	if (boundedWindow) {
+		conditions.push({ attribute: 'id', comparator: 'between', value: [startTime, endTime] });
+	}
+	conditions.push({ attribute: 'metric', comparator: 'equals', value: metric });
 	if (logName !== undefined) {
 		conditions.push({ attribute: 'log', comparator: 'equals', value: logName });
 	}
 	if (additionalConditions) {
 		conditions.push(...additionalConditions.map(conformCondition));
 	}
-	const select = getAttributes ?? [];
-
-	// ensure we're always selecting id
-	if (!isSelected(select, 'id')) {
-		select.push('id');
-	}
-
-	if (startTime && endTime) {
-		conditions.push({
-			attribute: 'id',
-			comparator: 'between',
-			value: [startTime, endTime],
-		});
-	} else {
+	// An open-ended range (only start or only end) can span the whole table, so we append it and leave
+	// ordering to the planner rather than forcing an unbounded range to drive — which could scan the
+	// full table for a selective metric.
+	if (!boundedWindow) {
 		if (startTime) {
-			conditions.push({
-				attribute: 'id',
-				comparator: 'greater_than_equal',
-				value: startTime,
-			});
+			conditions.push({ attribute: 'id', comparator: 'greater_than_equal', value: startTime });
 		}
 		if (endTime) {
-			conditions.push({
-				attribute: 'id',
-				comparator: 'less_than',
-				value: endTime,
-			});
+			conditions.push({ attribute: 'id', comparator: 'less_than', value: endTime });
 		}
+	}
+
+	const select = getAttributes ?? [];
+
+	// ensure we're always selecting id (an empty select array already selects everything, including id)
+	if (!isSelected(select, 'id')) {
+		select.push('id');
 	}
 
 	// `snapshot: false` lets these (potentially long-running) analytics scans read against the
 	// latest committed data without holding a consistent read snapshot open, so they stay easier
 	// on the rest of the system (a pinned snapshot would block compaction for the scan's duration).
 	const request: any = { conditions, allowConditionsOnDynamicAttributes: true, snapshot: false };
+	if (boundedWindow) {
+		request.enforceExecutionOrder = true;
+	}
 	if (select.length > 0) {
 		request['select'] = select;
 	}

--- a/resources/analytics/read.ts
+++ b/resources/analytics/read.ts
@@ -200,7 +200,7 @@ export async function get(metric: string, opts?: GetAnalyticsOpts): Promise<Metr
 	// so on a large `hdb_analytics` table a narrow window looks costlier than `metric equals`, iteration
 	// is driven off the metric index, and the metric's entire history is decoded instead of the window
 	// (#1796). The proper long-term fix is a range-width-aware cost estimate in search.ts.
-	const boundedWindow = Boolean(startTime && endTime);
+	const boundedWindow = startTime != null && endTime != null;
 	const conditions: Conditions = [];
 	if (boundedWindow) {
 		conditions.push({ attribute: 'id', comparator: 'between', value: [startTime, endTime] });
@@ -216,10 +216,10 @@ export async function get(metric: string, opts?: GetAnalyticsOpts): Promise<Metr
 	// ordering to the planner rather than forcing an unbounded range to drive — which could scan the
 	// full table for a selective metric.
 	if (!boundedWindow) {
-		if (startTime) {
+		if (startTime != null) {
 			conditions.push({ attribute: 'id', comparator: 'greater_than_equal', value: startTime });
 		}
-		if (endTime) {
+		if (endTime != null) {
 			conditions.push({ attribute: 'id', comparator: 'less_than', value: endTime });
 		}
 	}

--- a/unitTests/resources/analytics/read.test.js
+++ b/unitTests/resources/analytics/read.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { expect } = require('chai');
+const assert = require('node:assert/strict');
 const { describe, it } = require('mocha');
 const sinon = require('sinon');
 const { METRIC } = require('#src/resources/analytics/metadata');
@@ -534,5 +535,76 @@ describe('getOp (log filter)', () => {
 		}
 		expect(threw).to.be.true;
 		expect(searchStub.called).to.be.false;
+	});
+});
+
+describe('getOp (time-window condition order, #1796)', () => {
+	let capturedRequest;
+	let originalDatabases;
+	let originalServer;
+
+	beforeEach(() => {
+		originalDatabases = global.databases;
+		originalServer = global.server;
+		capturedRequest = undefined;
+		const search = (request) => {
+			capturedRequest = request;
+			return mockSearchIterable([]);
+		};
+		global.databases = { system: { hdb_analytics: { search, replicate: true } } };
+		global.server = { hostname: 'local-host', nodes: [] };
+	});
+
+	afterEach(() => {
+		global.databases = originalDatabases;
+		global.server = originalServer;
+	});
+
+	// The planner estimates a primary-key `between` as a flat 10% of the table, so on a large
+	// hdb_analytics table it drives iteration off the `metric` index and scans the metric's whole
+	// history. A two-sided window must lead and pin execution order so the window drives the scan.
+	// This assertion fails on the pre-fix ordering (metric first, no pin).
+	it('leads with the id-range `between` and pins execution order for a bounded window', async () => {
+		await collect(await getOp({ metric: 'utilization', start_time: 1000, end_time: 2000 }));
+
+		assert.deepEqual(capturedRequest.conditions[0], { attribute: 'id', comparator: 'between', value: [1000, 2000] });
+		assert.deepEqual(capturedRequest.conditions[1], {
+			attribute: 'metric',
+			comparator: 'equals',
+			value: 'utilization',
+		});
+		assert.equal(capturedRequest.enforceExecutionOrder, true);
+	});
+
+	// An open-ended range can span the whole table, so we don't force it to drive — leave the planner
+	// free rather than risk a full-table scan for a selective metric.
+	it('does not pin an open-ended range (start_time only) and leaves it to the planner', async () => {
+		await collect(await getOp({ metric: 'utilization', start_time: 1000 }));
+
+		assert.equal(capturedRequest.enforceExecutionOrder, undefined);
+		assert.deepEqual(capturedRequest.conditions[0], {
+			attribute: 'metric',
+			comparator: 'equals',
+			value: 'utilization',
+		});
+		assert.ok(
+			capturedRequest.conditions.some((c) => c.attribute === 'id' && c.comparator === 'greater_than_equal'),
+			'the open-ended id range is still present as a filter'
+		);
+	});
+
+	it('leaves reordering on (metric leads) when no time window is given', async () => {
+		await collect(await getOp({ metric: 'utilization' }));
+
+		assert.deepEqual(capturedRequest.conditions[0], {
+			attribute: 'metric',
+			comparator: 'equals',
+			value: 'utilization',
+		});
+		assert.equal(
+			capturedRequest.conditions.some((c) => c.attribute === 'id'),
+			false
+		);
+		assert.equal(capturedRequest.enforceExecutionOrder, undefined);
 	});
 });


### PR DESCRIPTION
Fixes #1796.

## Summary

`get_analytics` on a large `hdb_analytics` table scans the **entire history of the requested metric** instead of the requested time window, because condition reordering misestimates primary-key ranges.

`get()` in `resources/analytics/read.ts` built conditions as `[metric equals X, id between [start,end]]`. `Table.search` reorders conditions by estimated cost, but the planner estimates a primary-key `between` as a flat 10% of the table (`search.ts` `BETWEEN_ESTIMATE`) rather than from the actual range width. So for any metric that is <10% of the table's rows, iteration is driven off the **metric index** — decoding that metric's whole history and post-filtering by time. A 5-minute Studio Status query becomes a multi-million-row scan that never completes; stacked/retried scans exhaust the instance and it restarts.

## Fix

Lead with the primary-key range condition and set `enforceExecutionOrder: true` (the existing reorder opt-out honored in `Table.orderConditions`) **only for a two-sided `between` window**, so the bounded window drives the scan and `metric`/`log`/`additionalConditions` apply per row. Verified via `read.test.js` (the bounded-window assertion fails on the pre-fix ordering).

## Where to put attention (open items for the reviewer)

Both cross-model reviewers (Codex, Gemini) flagged that unconditionally pinning execution order would regress broad ranges. I narrowed the pin to two-sided `between` — open-ended ranges (`start_time`-only / `end_time`-only) keep the planner, since an unbounded range could scan the whole table for a selective metric. Two things I did **not** resolve, for your call:

1. **Residual wide-`between` tradeoff.** A deliberately *wide* two-sided window (say a year) on a very selective metric still pins the id range and so scans the window across all metrics rather than that metric's index. This is bounded and user-explicit (and pre-fix that query scanned the metric's full history anyway), but it's the case the flat `BETWEEN_ESTIMATE` fundamentally can't reason about. The real fix is a **range-width-aware cost estimate for primary-key `between` in `search.ts`** — worth a follow-up; happy to take it.

2. **Pre-existing boundary detail (Gemini).** The `id` key is `[time, nodeId]`; the `between` bounds are scalar `[startTime, endTime]`. Under ordered-binary sorting, `[endTime, nodeId]` sorts after the scalar `endTime`, so a row at *exactly* `endTime` may be excluded. This value is **unchanged by this PR** (result-equivalent to before — the same `between` was already in the conditions), so it's orthogonal, but flagging it in case you want it filed/fixed separately.

Suggested as a **patch candidate** — this is a production restart-causer on long-lived 5.1 clusters.

_Generated by an LLM (Claude Opus 4.8). Cross-reviewed by Codex + Gemini; the two items above are the unresolved ones they surfaced._
