### PR TITLE
Authenticate private git-reference deploys from an in-memory credential

### DIFF
--- a/components/Application.ts
+++ b/components/Application.ts
@@ -181,6 +181,128 @@ export function isSSHAuthFailure(stderr: string): boolean {
 	);
 }
 
+// Git-reference package identifier forms recognized below for the credentialed-clone path: the
+// npm git-url spec forms this repo's own derivePackageIdentifier can produce for a git host
+// credential. An identifier that doesn't match falls back to `npm pack --ignore-scripts` (best
+// effort, same as before this fix — not a regression for a form this can't safely reclone).
+const GIT_URL_PREFIX = /^git\+(ssh|https?|file):\/\//i;
+const GIT_PROTOCOL_PREFIX = /^git:\/\//i;
+
+interface GitReference {
+	cloneUrl: string;
+	committish?: string;
+}
+
+/**
+ * Parses a `git+ssh://…`/`git+https://…`/`git+http://…`/`git+file://…`/`git://…` package identifier
+ * into a plain clone URL and optional committish, without depending on npm's own git-spec parser
+ * (npm-package-arg/hosted-git-info aren't dependencies of this repo). Returns null for any other
+ * form.
+ */
+function parseGitReference(packageIdentifier: string): GitReference | null {
+	const hashIndex = packageIdentifier.indexOf('#');
+	const committish = hashIndex === -1 ? undefined : packageIdentifier.slice(hashIndex + 1);
+	const spec = hashIndex === -1 ? packageIdentifier : packageIdentifier.slice(0, hashIndex);
+	if (GIT_URL_PREFIX.test(spec)) return { cloneUrl: spec.slice('git+'.length), committish };
+	if (GIT_PROTOCOL_PREFIX.test(spec)) return { cloneUrl: spec, committish };
+	return null;
+}
+
+const NEUTRALIZED_LIFECYCLE_SCRIPTS = ['preinstall', 'install', 'postinstall', 'prepack', 'prepare'];
+
+/**
+ * Clones a git reference ourselves — with the credential session's env, so the clone itself can
+ * still authenticate — and packs the checkout with its lifecycle scripts stripped, instead of
+ * letting `npm pack <git-url>` clone and pack it directly.
+ *
+ * `--ignore-scripts` is not a reliable suppression for a git source's own `prepare` script: pacote's
+ * DirFetcher runs it unconditionally on npm versions before 11.0.0 (the
+ * `if (this.opts.ignoreScripts) return` guard was only added upstream in npm 11) — which is exactly
+ * what Node 22's bundled npm (10.9.x) ships. A credentialed clone can't depend on which npm version
+ * happens to be on PATH, since a script running while the credential socket is reachable is exactly
+ * what this feature exists to prevent — so the script is removed from the checkout before packing,
+ * which works regardless of npm version.
+ */
+async function packGitReferenceWithoutScripts(
+	application: Application,
+	gitRef: GitReference,
+	parentDirPath: string
+): Promise<string> {
+	const cloneDir = await mkdtemp(join(tmpdir(), 'harper-git-clone-'));
+	try {
+		const { code: cloneCode, stderr: cloneStderr } = await nonInteractiveSpawn(
+			application.name,
+			'git',
+			['clone', '--quiet', gitRef.cloneUrl, cloneDir],
+			parentDirPath,
+			undefined,
+			undefined,
+			undefined,
+			application.gitCredentialEnv
+		);
+		if (cloneCode !== 0) {
+			if (isSSHAuthFailure(cloneStderr)) {
+				throw new Error(
+					`Failed to deploy private repository ${application.packageIdentifier}: SSH access failed. Verify the repository URL, configure an SSH key on this Harper instance, ensure the key has access to the target repository, and confirm the host is present in the ssh/known_hosts file.`,
+					{ cause: new Error(cloneStderr) }
+				);
+			}
+			throw new Error(`Failed to clone package ${application.packageIdentifier}: ${cloneStderr}`);
+		}
+
+		if (gitRef.committish) {
+			const { code: checkoutCode, stderr: checkoutStderr } = await nonInteractiveSpawn(
+				application.name,
+				'git',
+				['checkout', '--quiet', gitRef.committish],
+				cloneDir
+			);
+			if (checkoutCode !== 0) {
+				throw new Error(
+					`Failed to check out '${gitRef.committish}' for ${application.packageIdentifier}: ${checkoutStderr}`
+				);
+			}
+		}
+
+		// Strip the checkout's own lifecycle scripts before packing — the mechanism above only
+		// suppresses npm's git-clone behavior; a plain `npm pack <local-dir>` still runs `prepare`
+		// unless it's gone from the manifest.
+		const manifestPath = join(cloneDir, 'package.json');
+		const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+		if (manifest.scripts) {
+			for (const scriptName of NEUTRALIZED_LIFECYCLE_SCRIPTS) delete manifest.scripts[scriptName];
+			await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+		}
+
+		const { stdout, code, stderr } = await nonInteractiveSpawn(
+			application.name,
+			'npm',
+			['pack', '--json', '--ignore-scripts', cloneDir],
+			parentDirPath,
+			undefined,
+			undefined,
+			application.npmUserconfigPath
+		);
+		if (code !== 0) {
+			throw new Error(`Failed to pack package ${application.packageIdentifier}: ${stderr}`);
+		}
+		let packResult: Array<{ filename: string }>;
+		try {
+			packResult = JSON.parse(stdout.slice(stdout.indexOf('[')));
+		} catch (err) {
+			throw new Error(
+				`Failed to parse npm pack output for ${application.packageIdentifier}: ${err.message}\nstdout: ${stdout}`
+			);
+		}
+		if (!Array.isArray(packResult) || typeof packResult[0]?.filename !== 'string') {
+			throw new Error(`Unexpected npm pack output for ${application.packageIdentifier}:\n${stdout}`);
+		}
+		return join(parentDirPath, packResult[0].filename);
+	} finally {
+		await rm(cloneDir, { recursive: true, force: true });
+	}
+}
+
 // Hidden directory under the components root holding component versions renamed aside
 // during a deploy swap (see extractApplication). The leading dot keeps
 // loadComponentDirectories from loading its contents as components.
@@ -274,49 +396,61 @@ export async function extractApplication(application: Application) {
 			// reach the credential must not have (a transitive dependency's postinstall could ask the
 			// socket for a token granted for the top-level repository), so scripts are off for a
 			// credentialed clone unless the deploy explicitly opted into them.
-			const packArgs = ['pack', '--json', application.packageIdentifier];
-			if (application.gitCredentialEnv && !application.install?.allowInstallScripts) {
-				packArgs.push('--ignore-scripts');
-			} else if (application.gitCredentialEnv) {
-				application.logger.warn(
-					`Deploying ${application.name} from a git reference with install scripts enabled: the repository's ` +
-						`prepare/build scripts and its dependencies' install scripts run on this node during the clone and ` +
-						`can read the git credential. Unset install_allow_scripts to keep the credential out of their reach.`
-				);
-			}
-			const { stdout, code, stderr } = await nonInteractiveSpawn(
-				application.name,
-				'npm',
-				packArgs,
-				parentDirPath,
-				undefined,
-				undefined,
-				application.npmUserconfigPath,
-				application.gitCredentialEnv
-			);
-			if (code !== 0) {
-				if (isSSHAuthFailure(stderr)) {
-					throw new Error(
-						`Failed to deploy private repository ${application.packageIdentifier}: SSH access failed. Verify the repository URL, configure an SSH key on this Harper instance, ensure the key has access to the target repository, and confirm the host is present in the ssh/known_hosts file.`,
-						{ cause: new Error(stderr) }
+			const scriptsDisallowed = application.gitCredentialEnv && !application.install?.allowInstallScripts;
+			// `--ignore-scripts` alone isn't a reliable way to enforce that: pacote's DirFetcher runs a
+			// git source's `prepare` unconditionally on npm versions before 11.0.0 (see
+			// packGitReferenceWithoutScripts), which is exactly what Node 22's bundled npm ships. For a
+			// recognized git-reference identifier, clone and pack it ourselves with scripts stripped
+			// instead, sidestepping that npm code path entirely.
+			const gitRef = scriptsDisallowed ? parseGitReference(application.packageIdentifier) : null;
+
+			if (gitRef) {
+				tarballPath = await packGitReferenceWithoutScripts(application, gitRef, parentDirPath);
+			} else {
+				const packArgs = ['pack', '--json', application.packageIdentifier];
+				if (scriptsDisallowed) {
+					packArgs.push('--ignore-scripts');
+				} else if (application.gitCredentialEnv) {
+					application.logger.warn(
+						`Deploying ${application.name} from a git reference with install scripts enabled: the repository's ` +
+							`prepare/build scripts and its dependencies' install scripts run on this node during the clone and ` +
+							`can read the git credential. Unset install_allow_scripts to keep the credential out of their reach.`
 					);
 				}
-				throw new Error(`Failed to download package ${application.packageIdentifier}: ${stderr}`);
-			}
-
-			let packResult: Array<{ filename: string }>;
-			try {
-				packResult = JSON.parse(stdout.slice(stdout.indexOf('[')));
-			} catch (err) {
-				throw new Error(
-					`Failed to parse npm pack output for ${application.packageIdentifier}: ${err.message}\nstdout: ${stdout}`
+				const { stdout, code, stderr } = await nonInteractiveSpawn(
+					application.name,
+					'npm',
+					packArgs,
+					parentDirPath,
+					undefined,
+					undefined,
+					application.npmUserconfigPath,
+					application.gitCredentialEnv
 				);
-			}
-			if (!Array.isArray(packResult) || typeof packResult[0]?.filename !== 'string') {
-				throw new Error(`Unexpected npm pack output for ${application.packageIdentifier}:\n${stdout}`);
-			}
+				if (code !== 0) {
+					if (isSSHAuthFailure(stderr)) {
+						throw new Error(
+							`Failed to deploy private repository ${application.packageIdentifier}: SSH access failed. Verify the repository URL, configure an SSH key on this Harper instance, ensure the key has access to the target repository, and confirm the host is present in the ssh/known_hosts file.`,
+							{ cause: new Error(stderr) }
+						);
+					}
+					throw new Error(`Failed to download package ${application.packageIdentifier}: ${stderr}`);
+				}
 
-			tarballPath = join(parentDirPath, packResult[0].filename);
+				let packResult: Array<{ filename: string }>;
+				try {
+					packResult = JSON.parse(stdout.slice(stdout.indexOf('[')));
+				} catch (err) {
+					throw new Error(
+						`Failed to parse npm pack output for ${application.packageIdentifier}: ${err.message}\nstdout: ${stdout}`
+					);
+				}
+				if (!Array.isArray(packResult) || typeof packResult[0]?.filename !== 'string') {
+					throw new Error(`Unexpected npm pack output for ${application.packageIdentifier}:\n${stdout}`);
+				}
+
+				tarballPath = join(parentDirPath, packResult[0].filename);
+			}
 			shouldDeleteTarball = true;
 			tarball = createReadStream(tarballPath);
 		}

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -262,10 +262,28 @@ export async function extractApplication(application: Application) {
 			// `npm pack --json` writes a JSON array describing the packed tarball(s). This is also the
 			// spawn that clones a git-reference package, so it is the only one given the git credential
 			// environment.
+			//
+			// Packing a git reference is not just a download: npm clones the repo and, if its manifest
+			// has a prepare/build/install script, runs `npm install` inside the clone and then that
+			// script — so the repo's own code AND its dependencies' install scripts execute on this node,
+			// inheriting this spawn's environment. With a credential session live, that is exactly the
+			// reach the credential must not have (a transitive dependency's postinstall could ask the
+			// socket for a token granted for the top-level repository), so scripts are off for a
+			// credentialed clone unless the deploy explicitly opted into them.
+			const packArgs = ['pack', '--json', application.packageIdentifier];
+			if (application.gitCredentialEnv && !application.install?.allowInstallScripts) {
+				packArgs.push('--ignore-scripts');
+			} else if (application.gitCredentialEnv) {
+				application.logger.warn(
+					`Deploying ${application.name} from a git reference with install scripts enabled: the repository's ` +
+						`prepare/build scripts and its dependencies' install scripts run on this node during the clone and ` +
+						`can read the git credential. Unset install_allow_scripts to keep the credential out of their reach.`
+				);
+			}
 			const { stdout, code, stderr } = await nonInteractiveSpawn(
 				application.name,
 				'npm',
-				['pack', '--json', application.packageIdentifier],
+				packArgs,
 				parentDirPath,
 				undefined,
 				undefined,
@@ -604,12 +622,14 @@ export class Application {
 		this.onInstallLine = onInstallLine;
 		// Split by kind: registry credentials go into the transient .npmrc, git credentials into the
 		// credential socket. An entry belongs to exactly one of them (the op schema is an xor).
+		// secretOperations owns the same predicate, but it is only ever imported from here lazily (it
+		// pulls in the datastore), so this stays a local check rather than a boot-time import.
 		if (credentials?.length) {
 			const registryCredentials = credentials.filter(
 				(entry): entry is ResolvedRegistryCredential => (entry as any).registry !== undefined
 			);
 			const gitCredentials = credentials.filter(
-				(entry): entry is ResolvedGitCredential => (entry as any).host !== undefined
+				(entry): entry is ResolvedGitCredential => (entry as any).registry === undefined
 			);
 			if (registryCredentials.length) this.registryCredentials = registryCredentials;
 			if (gitCredentials.length) this.gitCredentials = gitCredentials;

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -3,7 +3,13 @@ import { getConfigObj, getConfigValue, getConfigPath } from '../config/configUti
 import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 import logger from '../utility/logging/harper_logger.ts';
 import { broadcastDeployStart, broadcastDeployEnd } from './deployLifecycle.ts';
-import type { RegistryCredentialReference, ResolvedRegistryCredential } from './secretOperations.ts';
+import type { CredentialReference, ResolvedCredential, ResolvedRegistryCredential } from './secretOperations.ts';
+import {
+	GIT_CREDENTIAL_SOCKET_ENV,
+	startGitCredentialSession,
+	type GitCredentialSession,
+	type ResolvedGitCredential,
+} from './gitCredentialServer.ts';
 
 import { basename, dirname, extname, join } from 'node:path';
 import {
@@ -42,7 +48,7 @@ interface ApplicationConfig {
 	// Deploy credentials in reference form only — each entry names an hdb_secret row, never a token.
 	// Recorded by deploy_component so every (cold) install — reboot, new peer, rollback — re-resolves
 	// the credential from the store rather than needing it re-supplied.
-	credentials?: RegistryCredentialReference[];
+	credentials?: CredentialReference[];
 	// an application config can have other arbitrary properties
 	[key: string]: unknown;
 }
@@ -90,7 +96,8 @@ export class InvalidCredentialsPropertyError extends TypeError {
 export class InvalidCredentialEntryError extends TypeError {
 	constructor(applicationName: string) {
 		super(
-			`Invalid 'credentials' entry for application ${applicationName}: expected { registry, secret, scope? } reference`
+			`Invalid 'credentials' entry for application ${applicationName}: expected a { registry, secret, scope? } ` +
+				`or { host, secret, username? } reference`
 		);
 	}
 }
@@ -139,11 +146,14 @@ export function assertApplicationConfig(
 		}
 		for (const entry of entries) {
 			// Config carries references only — a literal `token` here would mean a plaintext credential
-			// was persisted to disk, which the deploy path is designed to prevent.
+			// was persisted to disk, which the deploy path is designed to prevent. An entry is npm
+			// registry auth (`registry`) or git host auth (`host`); anything else is not a credential we
+			// know how to resolve, so reject it rather than install without it.
+			const identity = (entry as any)?.registry ?? (entry as any)?.host;
 			if (
 				typeof entry !== 'object' ||
 				entry === null ||
-				typeof (entry as any).registry !== 'string' ||
+				typeof identity !== 'string' ||
 				typeof (entry as any).secret !== 'string'
 			) {
 				throw new InvalidCredentialEntryError(applicationName);
@@ -171,6 +181,10 @@ export function isSSHAuthFailure(stderr: string): boolean {
 // during a deploy swap (see extractApplication). The leading dot keeps
 // loadComponentDirectories from loading its contents as components.
 export const ASIDE_STAGING_DIR = '.deploy-aside';
+
+// The credential helper git executes for a private git-reference deploy. It ships alongside this
+// module (both in source and in dist), holds no secret, and is inert without a live session.
+export const GIT_CREDENTIAL_HELPER_PATH = join(__dirname, 'gitCredentialHelper.js');
 
 /**
  * Extract an application given payload (content of the application) or package (npm-compatible identifier to the application).
@@ -245,7 +259,9 @@ export async function extractApplication(application: Application) {
 				}
 			}
 		} else {
-			// `npm pack --json` writes a JSON array describing the packed tarball(s).
+			// `npm pack --json` writes a JSON array describing the packed tarball(s). This is also the
+			// spawn that clones a git-reference package, so it is the only one given the git credential
+			// environment.
 			const { stdout, code, stderr } = await nonInteractiveSpawn(
 				application.name,
 				'npm',
@@ -253,7 +269,8 @@ export async function extractApplication(application: Application) {
 				parentDirPath,
 				undefined,
 				undefined,
-				application.npmUserconfigPath
+				application.npmUserconfigPath,
+				application.gitCredentialEnv
 			);
 			if (code !== 0) {
 				if (isSSHAuthFailure(stderr)) {
@@ -552,7 +569,9 @@ interface ApplicationOptions {
 	packageIdentifier?: string;
 	install?: { command?: string; timeout?: number; allowInstallScripts?: boolean };
 	onInstallLine?: OnInstallLine;
-	registryCredentials?: ResolvedRegistryCredential[];
+	// Deploy credentials already resolved to literal tokens, of any kind; partitioned by the
+	// constructor into the npm and git halves, which are injected by entirely different mechanisms.
+	credentials?: ResolvedCredential[];
 }
 
 export class Application {
@@ -568,21 +587,33 @@ export class Application {
 	// token is held only in memory and a per-deploy `.npmrc`; it is never persisted to config,
 	// hdb_deployment, or replicated.
 	registryCredentials?: ResolvedRegistryCredential[];
+	// Transient git-host credentials, likewise resolved to literal tokens and held only in memory:
+	// they are served to git over a per-deploy socket (gitCredentialServer.ts), never written anywhere.
+	gitCredentials?: ResolvedGitCredential[];
 	// Path to the per-deploy `.npmrc`, set by writeTransientNpmrc() during prepareApplication and
 	// passed to the spawn calls; undefined when no registry credentials were provided.
 	npmUserconfigPath?: string;
 	#npmrcTempDir?: string;
+	#gitCredentialSession?: GitCredentialSession;
 
-	constructor({ name, payload, packageIdentifier, install, onInstallLine, registryCredentials }: ApplicationOptions) {
+	constructor({ name, payload, packageIdentifier, install, onInstallLine, credentials }: ApplicationOptions) {
 		this.name = name;
 		this.payload = payload;
 		this.packageIdentifier = packageIdentifier && derivePackageIdentifier(packageIdentifier);
 		this.install = install;
 		this.onInstallLine = onInstallLine;
-		// `credentials` is kind-heterogeneous (registry today, a planned git-host kind later — see
-		// secretOperations.ts); filter to registry-shaped entries so buildNpmrcContent (which assumes
-		// `.registry` on every entry) never sees a non-registry kind once one exists.
-		this.registryCredentials = registryCredentials?.filter((entry) => entry && 'registry' in entry);
+		// Split by kind: registry credentials go into the transient .npmrc, git credentials into the
+		// credential socket. An entry belongs to exactly one of them (the op schema is an xor).
+		if (credentials?.length) {
+			const registryCredentials = credentials.filter(
+				(entry): entry is ResolvedRegistryCredential => (entry as any).registry !== undefined
+			);
+			const gitCredentials = credentials.filter(
+				(entry): entry is ResolvedGitCredential => (entry as any).host !== undefined
+			);
+			if (registryCredentials.length) this.registryCredentials = registryCredentials;
+			if (gitCredentials.length) this.gitCredentials = gitCredentials;
+		}
 		const componentsRoot = getConfigPath(CONFIG_PARAMS.COMPONENTSROOT);
 		if (!componentsRoot) throw new Error('componentsRoot is not configured');
 		this.dirPath = join(componentsRoot, name);
@@ -619,6 +650,37 @@ export class Application {
 		content += buildNpmrcContent(this.registryCredentials);
 		await writeFile(npmrcPath, content, { mode: 0o600 });
 		this.npmUserconfigPath = npmrcPath;
+	}
+
+	// Environment that lets git reach this deploy's credential socket. Applied ONLY to the spawn that
+	// clones the git reference (`npm pack`) — see prepareApplication.
+	get gitCredentialEnv(): Record<string, string> | undefined {
+		return this.#gitCredentialSession?.env;
+	}
+
+	// Start serving this deploy's git-host credentials from memory. No-op without git credentials.
+	async startGitCredentialSession(): Promise<void> {
+		if (!this.gitCredentials?.length) return;
+		if (this.#gitCredentialSession) await this.cleanupGitCredentialSession();
+		this.#gitCredentialSession = await startGitCredentialSession(this.gitCredentials, GIT_CREDENTIAL_HELPER_PATH);
+	}
+
+	// Tear the socket down as soon as the clone is done, so nothing later in the deploy — including
+	// the component's own install scripts — can still ask for the credential.
+	async cleanupGitCredentialSession(): Promise<void> {
+		const session = this.#gitCredentialSession;
+		if (!session) return;
+		this.#gitCredentialSession = undefined;
+		try {
+			await session.close();
+		} catch (error) {
+			// Called from prepareApplication's finally; a throw here would mask the deploy's own error.
+			this.logger.warn(`Failed to close git credential session:`, error);
+		} finally {
+			// Drop the in-memory tokens too, so they can't surface in a later heap dump or error
+			// serialization of this Application instance.
+			this.gitCredentials = undefined;
+		}
 	}
 
 	// Remove the transient `.npmrc` (and its temp dir) once the deploy's npm work is done.
@@ -680,7 +742,16 @@ export async function prepareApplication(application: Application) {
 		// Materialize the per-deploy `.npmrc` before extraction so both `npm pack` (extract) and
 		// `npm install` authenticate against the private registry; always remove it afterward.
 		await application.writeTransientNpmrc();
-		await extractApplication(application);
+		try {
+			// The git credential socket only has to be up for extraction — that is where npm resolves and
+			// clones a git-reference package. Closing it before installApplication means the credential is
+			// already gone by the time the component's dependency tree (and any install script it is
+			// allowed to run) executes.
+			await application.startGitCredentialSession();
+			await extractApplication(application);
+		} finally {
+			await application.cleanupGitCredentialSession();
+		}
 		await installApplication(application);
 	} finally {
 		await application.cleanupTransientNpmrc();
@@ -748,11 +819,11 @@ export async function installApplications() {
 			// re-supplied. Best-effort: if custody isn't available yet or a referenced secret is
 			// missing, log and install without it (a truly private package then fails in npm with its
 			// own error) rather than blocking boot.
-			let registryCredentials: ResolvedRegistryCredential[] | undefined;
+			let credentials: ResolvedCredential[] | undefined;
 			if (applicationConfig.credentials?.length) {
 				try {
 					const { resolveCredentials } = await import('./secretOperations.ts');
-					registryCredentials = await resolveCredentials(applicationConfig.credentials, name);
+					credentials = await resolveCredentials(applicationConfig.credentials, name);
 				} catch (error) {
 					logger.warn?.(
 						`Could not resolve credentials for application ${name} at install time: ${(error as Error).message}`
@@ -764,7 +835,7 @@ export async function installApplications() {
 				name,
 				packageIdentifier: applicationConfig.package,
 				install: applicationConfig.install,
-				registryCredentials,
+				credentials,
 			});
 
 			// Lock check: only install if not already installed with matching configuration
@@ -902,7 +973,8 @@ export function nonInteractiveSpawn(
 	cwd: string,
 	timeoutMs: number = 60 * 60 * 1000,
 	onLine?: (stream: 'stdout' | 'stderr', line: string) => void,
-	npmUserconfigPath?: string
+	npmUserconfigPath?: string,
+	gitCredentialEnv?: Record<string, string>
 ): Promise<{ stdout: string; stderr: string; code: number }> {
 	return new Promise((resolve, reject) => {
 		logger
@@ -914,6 +986,18 @@ export function nonInteractiveSpawn(
 		const gitSSHCommand = getGitSSHCommand();
 		if (gitSSHCommand) {
 			env.GIT_SSH_COMMAND = gitSSHCommand;
+		}
+
+		// The git credential channel is granted per spawn, and only to the one that clones the git
+		// reference. Every other spawn — notably `npm install`, where a dependency's install script can
+		// run — has it removed, so a transitive dependency cannot ask for a credential that was supplied
+		// for the top-level repository. Only the socket variable is stripped rather than any inherited
+		// GIT_ASKPASS/GIT_CONFIG_*: those may be the operator's own git auth, and without a socket to
+		// reach, our helper answers nothing and is inert.
+		if (gitCredentialEnv) {
+			Object.assign(env, gitCredentialEnv);
+		} else {
+			delete env[GIT_CREDENTIAL_SOCKET_ENV];
 		}
 
 		// A deploy carrying transient registry auth points npm at a per-deploy `.npmrc` so

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -147,14 +147,18 @@ export function assertApplicationConfig(
 		for (const entry of entries) {
 			// Config carries references only — a literal `token` here would mean a plaintext credential
 			// was persisted to disk, which the deploy path is designed to prevent. An entry is npm
-			// registry auth (`registry`) or git host auth (`host`); anything else is not a credential we
-			// know how to resolve, so reject it rather than install without it.
-			const identity = (entry as any)?.registry ?? (entry as any)?.host;
+			// registry auth (`registry`) XOR git host auth (`host`); anything else is not a credential we
+			// know how to resolve, so reject it rather than install without it. An entry carrying both
+			// discriminators, or a stray `token`, is rejected rather than coerced into a single kind.
+			const record = entry as any;
+			const hasRegistry = typeof record?.registry === 'string';
+			const hasHost = typeof record?.host === 'string';
 			if (
 				typeof entry !== 'object' ||
 				entry === null ||
-				typeof identity !== 'string' ||
-				typeof (entry as any).secret !== 'string'
+				hasRegistry === hasHost || // neither, or both
+				typeof record.secret !== 'string' ||
+				record.token !== undefined
 			) {
 				throw new InvalidCredentialEntryError(applicationName);
 			}

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -188,23 +188,47 @@ export function isSSHAuthFailure(stderr: string): boolean {
 const GIT_URL_PREFIX = /^git\+(ssh|https?|file):\/\//i;
 const GIT_PROTOCOL_PREFIX = /^git:\/\//i;
 
+// Hosted-git shorthand prefixes: the same table derivePackageIdentifier implicitly relies on when it
+// defaults a bare `owner/repo` to `github:owner/repo`, plus the other hosts npm's own shorthand spec
+// recognizes. A bare `owner/repo` never reaches parseGitReference directly — the Application
+// constructor always runs packageIdentifier through derivePackageIdentifier first, which turns it
+// into `github:owner/repo` — so only the prefixed forms need handling here.
+const HOSTED_GIT_HOSTS: Record<string, string> = {
+	github: 'github.com',
+	gitlab: 'gitlab.com',
+	bitbucket: 'bitbucket.org',
+	gist: 'gist.github.com',
+};
+const HOSTED_GIT_PREFIX = /^(github|gitlab|bitbucket|gist):(.+)$/i;
+
 interface GitReference {
 	cloneUrl: string;
 	committish?: string;
 }
 
 /**
- * Parses a `git+ssh://…`/`git+https://…`/`git+http://…`/`git+file://…`/`git://…` package identifier
- * into a plain clone URL and optional committish, without depending on npm's own git-spec parser
- * (npm-package-arg/hosted-git-info aren't dependencies of this repo). Returns null for any other
- * form.
+ * Parses a `git+ssh://…`/`git+https://…`/`git+http://…`/`git+file://…`/`git://…`, or hosted-git
+ * shorthand (`github:owner/repo`, `gitlab:owner/repo`, `bitbucket:owner/repo`, `gist:id`) package
+ * identifier into a plain clone URL and optional committish, without depending on npm's own git-spec
+ * parser (npm-package-arg/hosted-git-info aren't dependencies of this repo). Returns null for any
+ * other form.
  */
-function parseGitReference(packageIdentifier: string): GitReference | null {
+export function parseGitReference(packageIdentifier: string): GitReference | null {
 	const hashIndex = packageIdentifier.indexOf('#');
 	const committish = hashIndex === -1 ? undefined : packageIdentifier.slice(hashIndex + 1);
 	const spec = hashIndex === -1 ? packageIdentifier : packageIdentifier.slice(0, hashIndex);
 	if (GIT_URL_PREFIX.test(spec)) return { cloneUrl: spec.slice('git+'.length), committish };
 	if (GIT_PROTOCOL_PREFIX.test(spec)) return { cloneUrl: spec, committish };
+	const hostedMatch = HOSTED_GIT_PREFIX.exec(spec);
+	if (hostedMatch) {
+		const [, prefix, path] = hostedMatch;
+		const host = HOSTED_GIT_HOSTS[prefix.toLowerCase()];
+		// A gist clone URL is keyed by id alone; an optional `owner/` in the shorthand (npm accepts
+		// `gist:[owner/]id`) has no place in the URL and is dropped.
+		const urlPath =
+			prefix.toLowerCase() === 'gist' && path.includes('/') ? path.slice(path.lastIndexOf('/') + 1) : path;
+		return { cloneUrl: `https://${host}/${urlPath}.git`, committish };
+	}
 	return null;
 }
 

--- a/components/deploymentRecorder.ts
+++ b/components/deploymentRecorder.ts
@@ -15,7 +15,7 @@ import { Readable, Transform, pipeline } from 'node:stream';
 import { databases } from '../resources/databases.ts';
 import { createBlob, isSaving, deleteBlob } from '../resources/blob.ts';
 import * as terms from '../utility/hdbTerms.ts';
-import type { RegistryCredentialReference } from './secretOperations.ts';
+import type { CredentialReference } from './secretOperations.ts';
 import { ClientError } from '../utility/errors/hdbError.ts';
 import { logger } from '../utility/logging/logger.ts';
 import { hostname } from 'node:os';
@@ -62,10 +62,11 @@ interface CreateOptions {
 	user?: string;
 	restart_mode?: 'immediate' | 'rolling' | null;
 	rollback_of?: string | null;
-	// Deploy credentials in reference form (`{ registry, secret, scope? }`) — never a literal token.
-	// Kept so a rollback can re-resolve the credential from hdb_secret without the operator
-	// re-supplying it. Null when the deploy used no credentials or a no-custody transient token.
-	credentials?: RegistryCredentialReference[] | null;
+	// Deploy credentials in reference form (`{ registry, secret, scope? }` / `{ host, secret,
+	// username? }`) — never a literal token. Kept so a rollback can re-resolve the credential from
+	// hdb_secret without the operator re-supplying it. Null when the deploy used no credentials or a
+	// no-custody transient token.
+	credentials?: CredentialReference[] | null;
 	emitter?: ProgressEmitter;
 }
 

--- a/components/gitCredentialHelper.js
+++ b/components/gitCredentialHelper.js
@@ -68,18 +68,20 @@ function parseCredentialRequest(input) {
 function parseAskpassPrompt(prompt) {
 	const quoted = /'([^']+)'/.exec(prompt);
 	if (!quoted) return null;
-	let url;
+	// url.username can carry a malformed percent-encoding sequence (e.g. from a redirect or a
+	// misconfigured remote), which makes decodeURIComponent throw a URIError — keep that inside the
+	// same try as the URL parse so it can't crash this process instead of just declining to answer.
 	try {
-		url = new URL(quoted[1]);
+		const url = new URL(quoted[1]);
+		return {
+			field: url.username ? 'password' : 'username',
+			protocol: url.protocol.replace(/:$/, ''),
+			host: url.host,
+			username: url.username ? decodeURIComponent(url.username) : undefined,
+		};
 	} catch {
 		return null;
 	}
-	return {
-		field: url.username ? 'password' : 'username',
-		protocol: url.protocol.replace(/:$/, ''),
-		host: url.host,
-		username: url.username ? decodeURIComponent(url.username) : undefined,
-	};
 }
 
 async function main() {

--- a/components/gitCredentialHelper.js
+++ b/components/gitCredentialHelper.js
@@ -1,0 +1,113 @@
+'use strict';
+
+// Credential helper for private git-reference deploys (#1792), executed by git as a child process.
+//
+// It holds no secret. The token lives only in the deploying Harper process's memory; this script
+// asks for it over the per-deploy socket named by HARPER_GIT_CREDENTIAL_SOCKET (see
+// gitCredentialServer.ts) and writes the answer to stdout for git to consume. Nothing is written to
+// disk, and the token never appears in argv or in this process's environment.
+//
+// git invokes it two ways, so it answers both:
+//   - as a `credential.helper` (git >= 2.31, wired up via GIT_CONFIG_*): the operation
+//     (`get`/`store`/`erase`) is the last argument and the request is key=value lines on stdin.
+//   - as GIT_ASKPASS (every git version): the prompt is the first argument.
+// Only `get` yields anything; `store`/`erase` are deliberate no-ops, since persisting the
+// credential is exactly what this design exists to avoid.
+
+const net = require('node:net');
+
+const socketPath = process.env.HARPER_GIT_CREDENTIAL_SOCKET;
+
+function ask(request) {
+	return new Promise((resolve, reject) => {
+		const socket = net.connect(socketPath);
+		socket.setEncoding('utf8');
+		let response = '';
+		socket.on('error', reject);
+		socket.on('connect', () => socket.end(JSON.stringify(request)));
+		socket.on('data', (chunk) => (response += chunk));
+		socket.on('close', () => {
+			try {
+				resolve(response ? JSON.parse(response) : {});
+			} catch (error) {
+				reject(error);
+			}
+		});
+	});
+}
+
+function readStdin() {
+	return new Promise((resolve, reject) => {
+		let input = '';
+		process.stdin.setEncoding('utf8');
+		process.stdin.on('data', (chunk) => (input += chunk));
+		process.stdin.on('error', reject);
+		process.stdin.on('end', () => resolve(input));
+	});
+}
+
+// git's credential protocol: `key=value` lines terminated by a blank line.
+function parseCredentialRequest(input) {
+	const request = {};
+	for (const line of input.split('\n')) {
+		const separator = line.indexOf('=');
+		if (separator > 0) request[line.slice(0, separator)] = line.slice(separator + 1).replace(/\r$/, '');
+	}
+	return request;
+}
+
+/**
+ * Interpret a GIT_ASKPASS prompt, e.g. `Username for 'https://github.com': ` or
+ * `Password for 'https://x-access-token@github.com': `.
+ *
+ * The leading words are localized, so which of the two prompts this is has to be decided
+ * structurally rather than by matching English: git only asks for a password once it has a
+ * username, and it embeds that username in the URL it echoes back. Userinfo present therefore means
+ * the password prompt; absent means the username prompt.
+ */
+function parseAskpassPrompt(prompt) {
+	const quoted = /'([^']+)'/.exec(prompt);
+	if (!quoted) return null;
+	let url;
+	try {
+		url = new URL(quoted[1]);
+	} catch {
+		return null;
+	}
+	return {
+		field: url.username ? 'password' : 'username',
+		protocol: url.protocol.replace(/:$/, ''),
+		host: url.host,
+		username: url.username ? decodeURIComponent(url.username) : undefined,
+	};
+}
+
+async function main() {
+	if (!socketPath) return; // no session for this spawn: stay silent so git falls through unauthenticated
+
+	const args = process.argv.slice(2);
+	const operation = args[args.length - 1];
+
+	if (operation === 'get') {
+		const request = parseCredentialRequest(await readStdin());
+		const credential = await ask({ protocol: request.protocol, host: request.host, username: request.username });
+		if (!credential.password) return;
+		process.stdout.write(`username=${credential.username}\npassword=${credential.password}\n`);
+		return;
+	}
+	if (operation === 'store' || operation === 'erase') return;
+
+	const prompt = parseAskpassPrompt(args[0] ?? '');
+	if (!prompt) return;
+	const credential = await ask(prompt);
+	if (!credential.password) return;
+	process.stdout.write(`${prompt.field === 'username' ? credential.username : credential.password}\n`);
+}
+
+main().catch((error) => {
+	// Never leak request detail to git's stderr, which npm surfaces in deploy output. Exiting
+	// non-zero makes git treat the credential as unavailable and fail (GIT_TERMINAL_PROMPT=0
+	// prevents it from falling back to an interactive prompt).
+	process.stderr.write(`harper git credential helper failed: ${error.message}\n`);
+	process.exitCode = 1;
+});

--- a/components/gitCredentialServer.ts
+++ b/components/gitCredentialServer.ts
@@ -5,17 +5,16 @@
 // userinfo lands in the package spec and the lockfile, a `credential.helper` or an `.npmrc` is a
 // file, and an env var is readable by every descendant process.
 //
-// Instead the token stays in this process's memory and is served over a per-deploy Unix socket
-// (named pipe on Windows) in a 0700 directory. git is pointed at gitCredentialHelper.js — a
-// secret-free script that relays git's request over that socket — and the socket dies with the
-// spawn that needed it. The token never reaches disk, argv, the package spec, the operation body,
-// or the operations log.
+// Instead the token stays in this process's memory and is served over a per-deploy Unix socket in a
+// 0700 directory. git is pointed at gitCredentialHelper.js — a secret-free script that relays git's
+// request over that socket — and the socket dies with the spawn that needed it. The token never
+// reaches disk, argv, the package spec, the operation body, or the operations log.
 
 import { createServer, type Server, type Socket } from 'node:net';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { randomUUID } from 'node:crypto';
+import { ClientError } from '../utility/errors/hdbError.ts';
 import logger from '../utility/logging/harper_logger.ts';
 
 // GitHub's convention for authenticating a PAT over HTTPS: any non-empty username works, and
@@ -27,6 +26,10 @@ export const DEFAULT_GIT_USERNAME = 'x-access-token';
 // and answers nothing, so stripping it from a spawn's environment fully disarms the helper even if
 // GIT_ASKPASS/GIT_CONFIG_* were somehow inherited.
 export const GIT_CREDENTIAL_SOCKET_ENV = 'HARPER_GIT_CREDENTIAL_SOCKET';
+
+// Generous for git's key=value request (a few hundred bytes), small enough that a peer streaming
+// junk cannot exhaust the heap.
+const MAX_REQUEST_BYTES = 64 * 1024;
 
 /** A git-host credential after resolution: a literal token, held in memory for one deploy. */
 export interface ResolvedGitCredential {
@@ -89,15 +92,20 @@ export async function startGitCredentialSession(
 	const byHost = new Map<string, ResolvedGitCredential>();
 	for (const credential of credentials) byHost.set(normalizeGitHost(credential.host), credential);
 
-	let socketDir: string | undefined;
-	let socketPath: string;
+	// The credential's confinement rests on filesystem permissions: a 0700 directory means only this
+	// uid can reach the socket. A Windows named pipe has no equivalent guarantee — it is created with
+	// a default security descriptor that can leave it open to other local users, which would hand the
+	// token to any process on the box. Rather than offer a quietly weaker credential channel, fail
+	// closed and let the operator use a deploy path whose isolation we can actually state.
 	if (process.platform === 'win32') {
-		socketPath = `\\\\.\\pipe\\harper-git-cred-${randomUUID()}`;
-	} else {
-		// mkdtemp creates the directory 0700, so only this uid can reach the socket inside it.
-		socketDir = await mkdtemp(join(tmpdir(), 'harper-git-cred-'));
-		socketPath = join(socketDir, 'credential.sock');
+		throw new ClientError(
+			'git-host deploy credentials are not supported on Windows: the credential is served over a Unix ' +
+				'domain socket, which has no Windows equivalent that can be confined to this process owner.'
+		);
 	}
+	// mkdtemp creates the directory 0700, so only this uid can reach the socket inside it.
+	const socketDir = await mkdtemp(join(tmpdir(), 'harper-git-cred-'));
+	const socketPath = join(socketDir, 'credential.sock');
 
 	const connections = new Set<Socket>();
 	// allowHalfOpen: the helper half-closes after sending its request, and we must still be able to
@@ -109,7 +117,15 @@ export async function startGitCredentialSession(
 		connection.on('error', (error) => logger.warn?.(`git credential connection failed: ${error.message}`));
 		connection.setEncoding('utf8');
 		let request = '';
-		connection.on('data', (chunk) => (request += chunk));
+		connection.on('data', (chunk) => {
+			request += chunk;
+			// A real request is a few hundred bytes. Cap it so a peer that streams without ever closing
+			// cannot grow this buffer until the node runs out of heap.
+			if (request.length > MAX_REQUEST_BYTES) {
+				logger.warn?.('git credential request exceeded the maximum size; dropping the connection');
+				connection.destroy();
+			}
+		});
 		connection.on('end', () => {
 			let answer: object;
 			try {
@@ -122,13 +138,20 @@ export async function startGitCredentialSession(
 	});
 	server.on('error', (error) => logger.warn?.(`git credential server failed: ${error.message}`));
 
-	await new Promise<void>((resolve, reject) => {
-		server.once('error', reject);
-		server.listen(socketPath, () => {
-			server.removeListener('error', reject);
-			resolve();
+	try {
+		await new Promise<void>((resolve, reject) => {
+			server.once('error', reject);
+			server.listen(socketPath, () => {
+				server.removeListener('error', reject);
+				resolve();
+			});
 		});
-	});
+	} catch (error) {
+		// listen() failed, so no session is returned and nothing will call close() — take the temp dir
+		// with us rather than leaving a 0700 directory behind on every failed deploy.
+		await rm(socketDir, { recursive: true, force: true }).catch(() => {});
+		throw error;
+	}
 
 	// Quoted so a Harper installed under a path with spaces still works: git runs both the askpass
 	// command and a `!`-prefixed credential helper through a shell.
@@ -156,13 +179,11 @@ export async function startGitCredentialSession(
 			for (const connection of connections) connection.destroy();
 			connections.clear();
 			await new Promise<void>((resolve) => server.close(() => resolve()));
-			if (socketDir) {
-				try {
-					await rm(socketDir, { recursive: true, force: true });
-				} catch (error) {
-					// Called from a finally; a throw here would mask the deploy's own error.
-					logger.warn?.(`Failed to remove git credential socket dir ${socketDir}: ${(error as Error).message}`);
-				}
+			try {
+				await rm(socketDir, { recursive: true, force: true });
+			} catch (error) {
+				// Called from a finally; a throw here would mask the deploy's own error.
+				logger.warn?.(`Failed to remove git credential socket dir ${socketDir}: ${(error as Error).message}`);
 			}
 		},
 	};

--- a/components/gitCredentialServer.ts
+++ b/components/gitCredentialServer.ts
@@ -64,7 +64,8 @@ function isLoopbackHost(host: string): boolean {
 }
 
 function answerFor(credentials: Map<string, ResolvedGitCredential>, request: any) {
-	const host = typeof request?.host === 'string' ? normalizeGitHost(request.host) : '';
+	if (!request || typeof request !== 'object') return {};
+	const host = typeof request.host === 'string' ? normalizeGitHost(request.host) : '';
 	const credential = credentials.get(host);
 	// An unknown host is not an error: git also asks about public hosts, and answering nothing lets
 	// it proceed unauthenticated rather than failing the deploy.
@@ -233,7 +234,10 @@ export async function startGitCredentialSession(
 		env,
 		async close() {
 			byHost.clear();
-			for (const connection of connections) connection.destroy();
+			// destroy() synchronously fires each connection's 'close' listener, which deletes it from this
+			// same Set — iterate a snapshot so that mid-iteration mutation cannot skip a connection.
+			const connectionsSnapshot = Array.from(connections);
+			for (const connection of connectionsSnapshot) connection.destroy();
 			connections.clear();
 			await new Promise<void>((resolve) => server.close(() => resolve()));
 			try {

--- a/components/gitCredentialServer.ts
+++ b/components/gitCredentialServer.ts
@@ -139,7 +139,13 @@ export async function startGitCredentialSession(
 	helperPath: string
 ): Promise<GitCredentialSession> {
 	const byHost = new Map<string, ResolvedGitCredential>();
-	for (const credential of credentials) byHost.set(normalizeGitHost(credential.host), credential);
+	for (const credential of credentials) {
+		const host = normalizeGitHost(credential.host);
+		// Two entries for the same host in one deploy is operator error — the second silently wins here
+		// (and its sealed secret already overwrote the first's, sharing a derived name). Surface it.
+		if (byHost.has(host)) logger.warn?.(`multiple git credentials supplied for host '${host}'; using the last`);
+		byHost.set(host, credential);
+	}
 
 	// The credential's confinement rests on filesystem permissions: a 0700 directory means only this
 	// uid can reach the socket. A Windows named pipe has no equivalent guarantee — it is created with

--- a/components/gitCredentialServer.ts
+++ b/components/gitCredentialServer.ts
@@ -11,6 +11,7 @@
 // reaches disk, argv, the package spec, the operation body, or the operations log.
 
 import { createServer, type Server, type Socket } from 'node:net';
+import { execFileSync } from 'node:child_process';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -55,17 +56,65 @@ export function normalizeGitHost(host: string): string {
 		.toLowerCase();
 }
 
+// A loopback remote never puts the credential on a network, so plaintext http to one is not a
+// disclosure. Anything else must be encrypted.
+function isLoopbackHost(host: string): boolean {
+	const hostname = host.replace(/:\d+$/, '').replace(/^\[|\]$/g, '');
+	return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+}
+
 function answerFor(credentials: Map<string, ResolvedGitCredential>, request: any) {
 	const host = typeof request?.host === 'string' ? normalizeGitHost(request.host) : '';
 	const credential = credentials.get(host);
 	// An unknown host is not an error: git also asks about public hosts, and answering nothing lets
 	// it proceed unauthenticated rather than failing the deploy.
 	if (!credential) return {};
+	// Never hand a token to a cleartext transport. git asks for `http://` credentials exactly as it
+	// asks for `https://` ones, so without this a `git+http://` package (or a remote downgraded by a
+	// redirect) would put the token on the wire in the clear.
+	const protocol = typeof request.protocol === 'string' ? request.protocol.toLowerCase() : '';
+	if (protocol && protocol !== 'https' && !isLoopbackHost(host)) {
+		logger.warn?.(`refusing to serve a git credential for '${host}' over ${protocol}: only https is allowed`);
+		return {};
+	}
+	// git's credential protocol is line-based (and askpass reads only the first line), so a token
+	// carrying a newline would be truncated or would inject protocol attributes. A literal token is
+	// already rejected by the op schema; one resolved from an hdb_secret row is not, so guard the
+	// write boundary — the same place the .npmrc writer guards (#1717).
+	if (/[\r\n\0]/.test(credential.token)) {
+		logger.warn?.(`git credential for '${host}' contains an illegal control character; refusing to serve it`);
+		return {};
+	}
 	// git only re-asks with a username once it has one; if it names a different user than the one
 	// this credential is for, the credential does not apply.
 	const username = credential.username ?? DEFAULT_GIT_USERNAME;
 	if (typeof request.username === 'string' && request.username && request.username !== username) return {};
 	return { username, password: credential.token };
+}
+
+// The `credential.helper` reset below only takes effect on git >= 2.31, where GIT_CONFIG_* is
+// honored; older git ignores those variables entirely and would fall through to GIT_ASKPASS with an
+// inherited helper chain still live — so a machine configured with `credential.helper=store` would
+// write this token to ~/.git-credentials. There is no way to disable an inherited helper on those
+// versions, so refuse to serve a credential at all rather than persist one behind the operator's back.
+const MINIMUM_GIT_VERSION = [2, 31];
+function assertGitSupportsConfigEnv(): void {
+	let version: string;
+	try {
+		version = execFileSync('git', ['--version'], { encoding: 'utf8' });
+	} catch (error) {
+		throw new ClientError(`git is required to deploy from a git reference, but could not be run: ${error}`);
+	}
+	const parsed = /(\d+)\.(\d+)/.exec(version);
+	if (!parsed) throw new ClientError(`Could not determine the git version from '${version.trim()}'`);
+	const [major, minor] = [Number(parsed[1]), Number(parsed[2])];
+	if (major < MINIMUM_GIT_VERSION[0] || (major === MINIMUM_GIT_VERSION[0] && minor < MINIMUM_GIT_VERSION[1])) {
+		throw new ClientError(
+			`git ${MINIMUM_GIT_VERSION.join('.')} or newer is required to deploy with a git-host credential ` +
+				`(found ${version.trim()}): older versions ignore GIT_CONFIG_*, so an inherited credential helper ` +
+				`could persist the token to disk.`
+		);
+	}
 }
 
 /**
@@ -103,6 +152,8 @@ export async function startGitCredentialSession(
 				'domain socket, which has no Windows equivalent that can be confined to this process owner.'
 		);
 	}
+	// Fail before minting a socket if git is too old for the credential-helper reset to hold.
+	assertGitSupportsConfigEnv();
 	// mkdtemp creates the directory 0700, so only this uid can reach the socket inside it.
 	const socketDir = await mkdtemp(join(tmpdir(), 'harper-git-cred-'));
 	const socketPath = join(socketDir, 'credential.sock');

--- a/components/gitCredentialServer.ts
+++ b/components/gitCredentialServer.ts
@@ -1,0 +1,169 @@
+// Per-deploy git credential channel for private git-reference deploys (#1792).
+//
+// npm shells out to git to resolve a `github:org/repo#semver:...` package, and a private repo makes
+// that clone need a credential. Every obvious way to hand git one persists it: a URL with embedded
+// userinfo lands in the package spec and the lockfile, a `credential.helper` or an `.npmrc` is a
+// file, and an env var is readable by every descendant process.
+//
+// Instead the token stays in this process's memory and is served over a per-deploy Unix socket
+// (named pipe on Windows) in a 0700 directory. git is pointed at gitCredentialHelper.js — a
+// secret-free script that relays git's request over that socket — and the socket dies with the
+// spawn that needed it. The token never reaches disk, argv, the package spec, the operation body,
+// or the operations log.
+
+import { createServer, type Server, type Socket } from 'node:net';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import logger from '../utility/logging/harper_logger.ts';
+
+// GitHub's convention for authenticating a PAT over HTTPS: any non-empty username works, and
+// `x-access-token` is what its own tooling sends. GitLab wants `oauth2` and Bitbucket
+// `x-token-auth`, so a credential entry can override it.
+export const DEFAULT_GIT_USERNAME = 'x-access-token';
+
+// The one variable that carries authority: without it gitCredentialHelper.js cannot reach a session
+// and answers nothing, so stripping it from a spawn's environment fully disarms the helper even if
+// GIT_ASKPASS/GIT_CONFIG_* were somehow inherited.
+export const GIT_CREDENTIAL_SOCKET_ENV = 'HARPER_GIT_CREDENTIAL_SOCKET';
+
+/** A git-host credential after resolution: a literal token, held in memory for one deploy. */
+export interface ResolvedGitCredential {
+	host: string;
+	token: string;
+	username?: string;
+}
+
+export interface GitCredentialSession {
+	/** Environment to merge into the spawn that performs the git clone — and only that spawn. */
+	env: Record<string, string>;
+	close(): Promise<void>;
+}
+
+/** `https://github.com/` / `GitHub.com` / `github.com/` all identify the same host. */
+export function normalizeGitHost(host: string): string {
+	return host
+		.trim()
+		.replace(/^[a-z0-9+.-]+:\/\//i, '')
+		.replace(/^\/\//, '')
+		.replace(/\/.*$/, '')
+		.replace(/^[^@]*@/, '')
+		.toLowerCase();
+}
+
+function answerFor(credentials: Map<string, ResolvedGitCredential>, request: any) {
+	const host = typeof request?.host === 'string' ? normalizeGitHost(request.host) : '';
+	const credential = credentials.get(host);
+	// An unknown host is not an error: git also asks about public hosts, and answering nothing lets
+	// it proceed unauthenticated rather than failing the deploy.
+	if (!credential) return {};
+	// git only re-asks with a username once it has one; if it names a different user than the one
+	// this credential is for, the credential does not apply.
+	const username = credential.username ?? DEFAULT_GIT_USERNAME;
+	if (typeof request.username === 'string' && request.username && request.username !== username) return {};
+	return { username, password: credential.token };
+}
+
+/**
+ * Start a credential session for one deploy. Returns the environment that lets git reach it, which
+ * the caller must apply ONLY to the spawn doing the clone (`npm pack`), never to the `npm install`
+ * that follows — a transitive dependency's install script must not be able to ask for a credential
+ * that was granted for the top-level repository.
+ *
+ * Wiring, in order of preference:
+ *   - `credential.helper` via GIT_CONFIG_* (git >= 2.31). Structured key=value protocol, no prompt
+ *     parsing. Inherited helpers are reset to empty first, so a machine configured with
+ *     `credential.helper=store` cannot write this token to ~/.git-credentials when git reports the
+ *     successful authentication back to its helper chain.
+ *   - GIT_ASKPASS, honored by every git version, as the fallback for git < 2.31 (where GIT_CONFIG_*
+ *     is silently ignored). npm's own git wrapper sets `GIT_ASKPASS=echo`, but only when the
+ *     variable is unset, so ours survives.
+ * GIT_TERMINAL_PROMPT=0 keeps git from falling back to a terminal prompt (which would hang a deploy
+ * rather than fail it) if neither path yields a credential.
+ */
+export async function startGitCredentialSession(
+	credentials: ResolvedGitCredential[],
+	helperPath: string
+): Promise<GitCredentialSession> {
+	const byHost = new Map<string, ResolvedGitCredential>();
+	for (const credential of credentials) byHost.set(normalizeGitHost(credential.host), credential);
+
+	let socketDir: string | undefined;
+	let socketPath: string;
+	if (process.platform === 'win32') {
+		socketPath = `\\\\.\\pipe\\harper-git-cred-${randomUUID()}`;
+	} else {
+		// mkdtemp creates the directory 0700, so only this uid can reach the socket inside it.
+		socketDir = await mkdtemp(join(tmpdir(), 'harper-git-cred-'));
+		socketPath = join(socketDir, 'credential.sock');
+	}
+
+	const connections = new Set<Socket>();
+	// allowHalfOpen: the helper half-closes after sending its request, and we must still be able to
+	// write the answer back.
+	const server: Server = createServer({ allowHalfOpen: true }, (connection) => {
+		connections.add(connection);
+		connection.on('close', () => connections.delete(connection));
+		// A helper that dies mid-request must not take the node down with an unhandled 'error'.
+		connection.on('error', (error) => logger.warn?.(`git credential connection failed: ${error.message}`));
+		connection.setEncoding('utf8');
+		let request = '';
+		connection.on('data', (chunk) => (request += chunk));
+		connection.on('end', () => {
+			let answer: object;
+			try {
+				answer = answerFor(byHost, JSON.parse(request));
+			} catch {
+				answer = {};
+			}
+			connection.end(JSON.stringify(answer));
+		});
+	});
+	server.on('error', (error) => logger.warn?.(`git credential server failed: ${error.message}`));
+
+	await new Promise<void>((resolve, reject) => {
+		server.once('error', reject);
+		server.listen(socketPath, () => {
+			server.removeListener('error', reject);
+			resolve();
+		});
+	});
+
+	// Quoted so a Harper installed under a path with spaces still works: git runs both the askpass
+	// command and a `!`-prefixed credential helper through a shell.
+	const helperCommand = `"${process.execPath}" "${helperPath}"`;
+	// Append to any GIT_CONFIG_* the operator already set rather than overwriting theirs; ours come
+	// last, which is also where git takes precedence from.
+	const inheritedCount = Number.parseInt(process.env.GIT_CONFIG_COUNT ?? '', 10);
+	const base = Number.isInteger(inheritedCount) && inheritedCount > 0 ? inheritedCount : 0;
+	const env: Record<string, string> = {
+		[GIT_CREDENTIAL_SOCKET_ENV]: socketPath,
+		GIT_TERMINAL_PROMPT: '0',
+		GIT_ASKPASS: helperCommand,
+		GIT_CONFIG_COUNT: String(base + 2),
+		// An empty value resets git's credential helper list, dropping any inherited helper.
+		[`GIT_CONFIG_KEY_${base}`]: 'credential.helper',
+		[`GIT_CONFIG_VALUE_${base}`]: '',
+		[`GIT_CONFIG_KEY_${base + 1}`]: 'credential.helper',
+		[`GIT_CONFIG_VALUE_${base + 1}`]: `!${helperCommand}`,
+	};
+
+	return {
+		env,
+		async close() {
+			byHost.clear();
+			for (const connection of connections) connection.destroy();
+			connections.clear();
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+			if (socketDir) {
+				try {
+					await rm(socketDir, { recursive: true, force: true });
+				} catch (error) {
+					// Called from a finally; a throw here would mask the deploy's own error.
+					logger.warn?.(`Failed to remove git credential socket dir ${socketDir}: ${(error as Error).message}`);
+				}
+			}
+		},
+	};
+}

--- a/components/operations.js
+++ b/components/operations.js
@@ -498,8 +498,10 @@ async function deployComponent(req) {
 				installCapture.push(manager, stream, line);
 				if (emitter) emit('install', { manager, stream, line });
 			},
-			// Private-registry credentials (already resolved above), used here for this node's npm pack/install.
-			registryCredentials: resolvedCredentials,
+			// Deploy credentials (already resolved above), used here for this node's npm pack/install:
+			// registry entries via a transient .npmrc, git-host entries via the in-memory credential
+			// socket the clone spawn talks to.
+			credentials: resolvedCredentials,
 		});
 		// Reduce req.credentials to references only (never a token) before it can reach an error/log
 		// path or replication: references are what peers resolve from their own replicated hdb_secret

--- a/components/operationsValidation.js
+++ b/components/operationsValidation.js
@@ -416,7 +416,12 @@ const GIT_CREDENTIAL_ENTRY = Joi.object({
 	username: Joi.string()
 		.pattern(/^[^\r\n:]+$/)
 		.optional(),
-	token: Joi.string().pattern(/^[^\r\n]+$/),
+	// Capped like other secret-bearing fields (SECRET_MAX_LENGTH, above): an unbounded literal token
+	// here feeds straight into synchronous envelope-sealing crypto, so without a cap it's a
+	// resource-exhaustion vector, not just a storage one.
+	token: Joi.string()
+		.pattern(/^[^\r\n]+$/)
+		.max(SECRET_MAX_LENGTH),
 	secret: Joi.string()
 		.pattern(ENV_KEY_REGEX)
 		.messages({ 'string.pattern.base': `'secret' must only contain word characters, dots and dashes` }),

--- a/components/operationsValidation.js
+++ b/components/operationsValidation.js
@@ -394,7 +394,12 @@ const REGISTRY_CREDENTIAL_ENTRY = Joi.object({
 	scope: Joi.string()
 		.pattern(/^@[a-z0-9-_.]+$/)
 		.optional(),
-}).xor('token', 'secret');
+})
+	.xor('token', 'secret')
+	// The whole operation validates with allowUnknown, but a credential entry must not: an unknown
+	// key here (a typo'd or future secret-bearing field like `password`) would pass through ingest
+	// unchanged and be persisted to config/hdb_deployment and replicated, defeating reference-only.
+	.unknown(false);
 
 // A git-host credential entry, identified by its `host` key (#1792). Used to authenticate the
 // `git clone`/`git ls-remote` npm runs for a git-reference `package` (e.g. `github:org/repo`); the
@@ -415,7 +420,14 @@ const GIT_CREDENTIAL_ENTRY = Joi.object({
 	secret: Joi.string()
 		.pattern(ENV_KEY_REGEX)
 		.messages({ 'string.pattern.base': `'secret' must only contain word characters, dots and dashes` }),
-}).xor('token', 'secret');
+	// `registry` forbidden for symmetry with the npm entry: an entry carrying both discriminators has
+	// no single kind and must be rejected, not silently treated as git auth.
+	registry: Joi.any().forbidden().messages({
+		'any.unknown': `a credential entry is either npm registry auth ('registry') or git host auth ('host'), not both`,
+	}),
+})
+	.xor('token', 'secret')
+	.unknown(false);
 
 /**
  * Validate deployComponent requests.

--- a/components/operationsValidation.js
+++ b/components/operationsValidation.js
@@ -371,8 +371,14 @@ function packageComponentValidator(req) {
 	return validator.validateBySchema(req, packageProjSchema);
 }
 
-// An npm registry-auth credential entry, identified by its `registry` key.
+// An npm registry-auth credential entry, identified by its `registry` key. `host` is forbidden
+// rather than merely unused: operation validation allows unknown keys, so without this an entry
+// carrying both discriminators would validate as npm registry auth and its git half would be
+// silently dropped.
 const REGISTRY_CREDENTIAL_ENTRY = Joi.object({
+	host: Joi.any().forbidden().messages({
+		'any.unknown': `a credential entry is either npm registry auth ('registry') or git host auth ('host'), not both`,
+	}),
 	// registry and token are written verbatim into the transient .npmrc, which is line-based;
 	// forbid CR/LF so a super_user can't inject extra npm config lines. (registry also accepts
 	// bare hosts and //host/ forms, so a strict URI validator would reject supported inputs — the
@@ -388,6 +394,27 @@ const REGISTRY_CREDENTIAL_ENTRY = Joi.object({
 	scope: Joi.string()
 		.pattern(/^@[a-z0-9-_.]+$/)
 		.optional(),
+}).xor('token', 'secret');
+
+// A git-host credential entry, identified by its `host` key (#1792). Used to authenticate the
+// `git clone`/`git ls-remote` npm runs for a git-reference `package` (e.g. `github:org/repo`); the
+// token is served to git from memory, never written to a file or a URL.
+const GIT_CREDENTIAL_ENTRY = Joi.object({
+	// A bare host, optionally with a port — `github.com`, `git.example.com:8443`. A scheme or path is
+	// tolerated and normalized away, but a credential is matched by host, so keep the grammar tight.
+	host: Joi.string()
+		.pattern(/^[^\s/@\\]+$/)
+		.required()
+		.messages({ 'string.pattern.base': `'host' must be a bare git host, e.g. 'github.com'` }),
+	// The username half of git's HTTPS basic auth. Defaults to GitHub's `x-access-token` convention;
+	// GitLab wants `oauth2` and Bitbucket `x-token-auth`.
+	username: Joi.string()
+		.pattern(/^[^\r\n:]+$/)
+		.optional(),
+	token: Joi.string().pattern(/^[^\r\n]+$/),
+	secret: Joi.string()
+		.pattern(ENV_KEY_REGEX)
+		.messages({ 'string.pattern.base': `'secret' must only contain word characters, dots and dashes` }),
 }).xor('token', 'secret');
 
 /**
@@ -418,9 +445,9 @@ function deployComponentValidator(req) {
 			.optional()
 			.messages({ 'any.invalid': 'urlPath must not contain ".."' }),
 		// Deploy credentials. The array is kind-heterogeneous: an entry's kind is implied by its
-		// identifying key rather than a separate discriminator field, so a new kind (e.g. a git-host
-		// credential keyed by `host`, #1792) is added as another item alternative here without
-		// reshaping the field. Today the only kind is npm registry auth (`registry`).
+		// identifying key rather than a separate discriminator field, so a new kind is added as
+		// another item alternative here without reshaping the field. Today: npm registry auth
+		// (`registry`) and git host auth for a git-reference package (`host`, #1792).
 		//
 		// Every kind supplies its credential exactly one of two ways:
 		//   - `token`: a literal token, used only for this node's install and never persisted or
@@ -428,7 +455,18 @@ function deployComponentValidator(req) {
 		//   - `secret`: the name of an hdb_secret row (#1550); the token is resolved by decrypting
 		//     that row on this node at deploy time, so the credential lives in the secrets store
 		//     (reference, not embed) instead of travelling in the operation body.
-		credentials: Joi.array().items(REGISTRY_CREDENTIAL_ENTRY).optional(),
+		// Dispatched on the presence of `registry` rather than tried as alternatives, so a malformed
+		// entry reports what is actually wrong with it (a newline in the token, an invalid scope) rather
+		// than a generic "no alternative matched".
+		credentials: Joi.array()
+			.items(
+				Joi.alternatives().conditional('.registry', {
+					is: Joi.exist(),
+					then: REGISTRY_CREDENTIAL_ENTRY,
+					otherwise: GIT_CREDENTIAL_ENTRY,
+				})
+			)
+			.optional(),
 		// `registryAuth` was this field's name on the 5.2 dev line before it grew to carry other
 		// credential kinds. Rejected rather than ignored: validation allows unknown keys, so a caller
 		// still sending it would otherwise get a deploy that silently installs with no credentials.

--- a/components/secretOperations.ts
+++ b/components/secretOperations.ts
@@ -389,7 +389,7 @@ export function deriveRegistrySecretName(component: string, registry: string): s
 export function deriveGitSecretName(component: string, host: string): string {
 	const hostKey = normalizeGitHost(host).replace(/[^\w.-]+/g, '_');
 	const componentKey = String(component).replace(/[^\w.-]+/g, '_');
-	return `deploy.${componentKey}.${hostKey}`;
+	return `deploy.${componentKey}.git.${hostKey}`;
 }
 
 /**

--- a/components/secretOperations.ts
+++ b/components/secretOperations.ts
@@ -381,10 +381,13 @@ export function deriveRegistrySecretName(component: string, registry: string): s
 
 /**
  * Deterministic name for the secret backing a literal git-host token, following the registry
- * convention above. Keyed by host rather than by repository: the credential entry identifies itself
- * by host, so the name has to be derivable from the entry alone for a rotation to overwrite the same
- * row. A per-repository credential is expressible today by scoping the token itself (a fine-grained
- * PAT) rather than by splitting the secret name.
+ * convention above but with a `git` kind segment: a registry entry accepts a bare host too, so
+ * without a distinguishing segment a git and a registry credential for the same host would derive
+ * the same name and silently overwrite each other's secret. Keyed by host rather than by
+ * repository: the credential entry identifies itself by host, so the name has to be derivable from
+ * the entry alone for a rotation to overwrite the same row. A per-repository credential is
+ * expressible today by scoping the token itself (a fine-grained PAT) rather than by splitting the
+ * secret name.
  */
 export function deriveGitSecretName(component: string, host: string): string {
 	const hostKey = normalizeGitHost(host).replace(/[^\w.-]+/g, '_');

--- a/components/secretOperations.ts
+++ b/components/secretOperations.ts
@@ -23,6 +23,7 @@ import * as validator from './operationsValidation.js';
 import { getSecretCustody } from '../resources/secretDecryptor.ts';
 import { encryptEnvelope, parseEnvelopeFields } from '../utility/secretEnvelope.ts';
 import { ENV_ENCRYPTED_PREFIX } from '../utility/envFile.ts';
+import { normalizeGitHost, type ResolvedGitCredential } from './gitCredentialServer.ts';
 
 const { HTTP_STATUS_CODES } = hdbErrors;
 const SECRET_TABLE = terms.SYSTEM_TABLE_NAMES.SECRET_TABLE_NAME;
@@ -326,8 +327,8 @@ export function getSecretsPublicKey(req: any) {
 }
 
 // deploy_component `credentials` is a kind-heterogeneous array: an entry's kind is implied by its
-// identifying key (today `registry` = npm registry auth; a git-host kind keyed by `host` is planned
-// in #1792), and every kind carries its credential as either a literal `token` or a `secret`
+// identifying key (`registry` = npm registry auth, `host` = git host auth for a git-reference
+// package, #1792), and every kind carries its credential as either a literal `token` or a `secret`
 // reference. Ingest/resolve below are kind-agnostic about that token/secret half and only branch on
 // the identifying key where a kind-specific detail is needed (the derived secret name).
 
@@ -343,6 +344,21 @@ export interface RegistryCredentialReference {
 	registry: string;
 	secret: string;
 	scope?: string;
+}
+
+/** A git-host credential after ingestion: a reference into hdb_secret, never a token. */
+export interface GitCredentialReference {
+	host: string;
+	secret: string;
+	username?: string;
+}
+
+export type CredentialReference = RegistryCredentialReference | GitCredentialReference;
+export type ResolvedCredential = ResolvedRegistryCredential | ResolvedGitCredential;
+
+/** True when a credential entry (in any form) is npm registry auth rather than git host auth. */
+export function isRegistryCredential(entry: any): boolean {
+	return entry?.registry !== undefined;
 }
 
 /**
@@ -361,6 +377,59 @@ export function deriveRegistrySecretName(component: string, registry: string): s
 		.replace(/[^\w.-]+/g, '_');
 	const componentKey = String(component).replace(/[^\w.-]+/g, '_');
 	return `deploy.${componentKey}.${registryKey}`;
+}
+
+/**
+ * Deterministic name for the secret backing a literal git-host token, following the registry
+ * convention above. Keyed by host rather than by repository: the credential entry identifies itself
+ * by host, so the name has to be derivable from the entry alone for a rotation to overwrite the same
+ * row. A per-repository credential is expressible today by scoping the token itself (a fine-grained
+ * PAT) rather than by splitting the secret name.
+ */
+export function deriveGitSecretName(component: string, host: string): string {
+	const hostKey = normalizeGitHost(host).replace(/[^\w.-]+/g, '_');
+	const componentKey = String(component).replace(/[^\w.-]+/g, '_');
+	return `deploy.${componentKey}.${hostKey}`;
+}
+
+/**
+ * An entry's kind, from its identifying key. Every path that rebuilds an entry goes through this, so
+ * an entry of an unrecognized kind fails loudly rather than being rebuilt into a half-empty one: an
+ * operation-body entry is schema-validated, but a `credentials` entry read back from
+ * applicationConfig or an hdb_deployment row is not.
+ */
+function credentialKind(entry: any): 'registry' | 'git' {
+	if (isRegistryCredential(entry)) return 'registry';
+	if (entry?.host !== undefined) return 'git';
+	throw new ClientError(
+		`Unsupported credential entry: expected a 'registry' (npm registry auth) or 'host' (git host auth) entry`
+	);
+}
+
+/** The hdb_secret name a literal-token entry seals into, by kind. */
+function deriveSecretName(entry: any, component: string): string {
+	return credentialKind(entry) === 'registry'
+		? deriveRegistrySecretName(component, entry.registry)
+		: deriveGitSecretName(component, entry.host);
+}
+
+/** Rebuild an entry in reference form, preserving only the fields its kind defines. */
+function toReference(entry: any, secret: string): CredentialReference {
+	if (credentialKind(entry) === 'registry') {
+		return entry.scope === undefined
+			? { registry: entry.registry, secret }
+			: { registry: entry.registry, secret, scope: entry.scope };
+	}
+	return entry.username === undefined
+		? { host: entry.host, secret }
+		: { host: entry.host, secret, username: entry.username };
+}
+
+/** Rebuild an entry in resolved (literal token) form, preserving only the fields its kind defines. */
+function toResolved(entry: any, token: string): ResolvedCredential {
+	return credentialKind(entry) === 'registry'
+		? { registry: entry.registry, token, scope: entry.scope }
+		: { host: entry.host, token, username: entry.username };
 }
 
 /**
@@ -389,12 +458,9 @@ export async function ingestCredentials(req: any, credentials: any[] | undefined
 			out.push(entry);
 			continue;
 		}
-		// The derived secret name is the one kind-specific detail on this path; a new credential kind
-		// derives its name from its own identifying key.
-		if (entry.registry === undefined) {
-			throw new ClientError(`Unsupported credential entry: expected a 'registry' (npm registry auth) entry`);
-		}
-		const name = deriveRegistrySecretName(component, entry.registry);
+		// The derived secret name is the one kind-specific detail on this path; each kind derives its
+		// name from its own identifying key.
+		const name = deriveSecretName(entry, component);
 		// Reuse set_secret's seal-and-store path (encrypt with custody, grant to the component, audit
 		// the mutation). The deploy request is already super_user, which set_secret requires.
 		await setSecret({
@@ -405,11 +471,7 @@ export async function ingestCredentials(req: any, credentials: any[] | undefined
 			grants: [component],
 			processEnv: false,
 		});
-		out.push(
-			entry.scope === undefined
-				? { registry: entry.registry, secret: name }
-				: { registry: entry.registry, secret: name, scope: entry.scope }
-		);
+		out.push(toReference(entry, name));
 	}
 	return out;
 }
@@ -455,18 +517,22 @@ export async function resolveCredentials(
 	credentials: any[] | undefined,
 	component: string,
 	options: { waitMs?: number } = {}
-): Promise<ResolvedRegistryCredential[] | undefined> {
+): Promise<ResolvedCredential[] | undefined> {
 	if (!Array.isArray(credentials) || credentials.length === 0) return credentials;
+	// Reject an unrecognized kind before anything consumes the array, including on the token-only fast
+	// path below: a caller that silently drops an entry it does not understand would install without
+	// the credential the operator asked for.
+	for (const entry of credentials) if (entry) credentialKind(entry);
 	// Token-only requests must not require custody or a provisioned store — keep the fast path pure.
 	if (!credentials.some((entry) => entry && entry.secret !== undefined)) return credentials;
 
 	const waitMs = options.waitMs ?? 0;
 	const table = secretTable();
-	const resolved: ResolvedRegistryCredential[] = [];
+	const resolved: ResolvedCredential[] = [];
 	for (const entry of credentials) {
 		if (!entry) continue; // parity with the fast-path guard above; validated entries are never null
 		if (entry.secret === undefined) {
-			resolved.push({ registry: entry.registry, token: entry.token, scope: entry.scope });
+			resolved.push(toResolved(entry, entry.token));
 			continue;
 		}
 		const name: string = entry.secret;
@@ -503,7 +569,7 @@ export async function resolveCredentials(
 				HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR
 			);
 		}
-		resolved.push({ registry: entry.registry, token, scope: entry.scope });
+		resolved.push(toResolved(entry, token));
 	}
 	return resolved;
 }

--- a/unitTests/components/Application.test.js
+++ b/unitTests/components/Application.test.js
@@ -5,7 +5,7 @@ const assert = require('node:assert');
 const testUtils = require('../testUtils.js');
 testUtils.preTestPrep();
 
-const { isSSHAuthFailure, assertApplicationConfig } = require('#src/components/Application');
+const { isSSHAuthFailure, assertApplicationConfig, parseGitReference } = require('#src/components/Application');
 
 describe('isSSHAuthFailure', () => {
 	it('returns true for "Could not read from remote repository"', () => {
@@ -63,6 +63,72 @@ npm error 404 '@scope/nonexistent-pkg@latest' is not in this registry.
 
 	it('returns false for empty stderr', () => {
 		assert.strictEqual(isSSHAuthFailure(''), false);
+	});
+});
+
+describe('parseGitReference', () => {
+	it('parses an explicit git+https:// identifier', () => {
+		assert.deepStrictEqual(parseGitReference('git+https://example.com/owner/repo.git'), {
+			cloneUrl: 'https://example.com/owner/repo.git',
+			committish: undefined,
+		});
+	});
+
+	it('parses a git:// identifier with a committish', () => {
+		assert.deepStrictEqual(parseGitReference('git://example.com/owner/repo.git#v1.2.3'), {
+			cloneUrl: 'git://example.com/owner/repo.git',
+			committish: 'v1.2.3',
+		});
+	});
+
+	it("resolves the github: shorthand this repo's own derivePackageIdentifier defaults to", () => {
+		assert.deepStrictEqual(parseGitReference('github:my-org/my-app'), {
+			cloneUrl: 'https://github.com/my-org/my-app.git',
+			committish: undefined,
+		});
+	});
+
+	it("resolves github: shorthand with a committish, matching the PR's own worked example", () => {
+		assert.deepStrictEqual(parseGitReference('github:my-org/my-app#semver:v1.2.3'), {
+			cloneUrl: 'https://github.com/my-org/my-app.git',
+			committish: 'semver:v1.2.3',
+		});
+	});
+
+	it('resolves the gitlab: shorthand', () => {
+		assert.deepStrictEqual(parseGitReference('gitlab:my-org/my-app'), {
+			cloneUrl: 'https://gitlab.com/my-org/my-app.git',
+			committish: undefined,
+		});
+	});
+
+	it('resolves the bitbucket: shorthand', () => {
+		assert.deepStrictEqual(parseGitReference('bitbucket:my-org/my-app'), {
+			cloneUrl: 'https://bitbucket.org/my-org/my-app.git',
+			committish: undefined,
+		});
+	});
+
+	it('resolves the gist: shorthand by id', () => {
+		assert.deepStrictEqual(parseGitReference('gist:af99f4b3ec6df5c56b03'), {
+			cloneUrl: 'https://gist.github.com/af99f4b3ec6df5c56b03.git',
+			committish: undefined,
+		});
+	});
+
+	it('resolves the gist: shorthand with an owner prefix, dropping the owner segment', () => {
+		assert.deepStrictEqual(parseGitReference('gist:my-org/af99f4b3ec6df5c56b03'), {
+			cloneUrl: 'https://gist.github.com/af99f4b3ec6df5c56b03.git',
+			committish: undefined,
+		});
+	});
+
+	it('returns null for an npm registry identifier', () => {
+		assert.strictEqual(parseGitReference('npm:some-package'), null);
+	});
+
+	it('returns null for a file identifier', () => {
+		assert.strictEqual(parseGitReference('file:../local-app'), null);
 	});
 });
 

--- a/unitTests/components/Application.test.js
+++ b/unitTests/components/Application.test.js
@@ -87,14 +87,29 @@ describe('assertApplicationConfig credentials', () => {
 		);
 	});
 
-	it('rejects a credential entry carrying a literal token (references only on disk)', () => {
-		assert.throws(
-			() => assertApplicationConfig('app', { package: 'p', credentials: [{ registry: 'r', token: 'tok' }] }),
-			/expected \{ registry, secret, scope\? \} reference/
+	it('accepts a git-host reference entry (#1792)', () => {
+		assert.doesNotThrow(() =>
+			assertApplicationConfig('app', {
+				package: 'github:myorg/private-app',
+				credentials: [{ host: 'github.com', secret: 'deploy.app.github.com' }],
+			})
 		);
 	});
 
-	it('rejects a credential entry missing registry/secret', () => {
+	it('rejects a credential entry carrying a literal token (references only on disk)', () => {
+		for (const entry of [
+			{ registry: 'r', token: 'tok' },
+			{ host: 'github.com', token: 'tok' },
+		]) {
+			assert.throws(
+				() => assertApplicationConfig('app', { package: 'p', credentials: [entry] }),
+				/reference$/m,
+				JSON.stringify(entry)
+			);
+		}
+	});
+
+	it('rejects a credential entry with no recognized identity (neither registry nor host)', () => {
 		assert.throws(() => assertApplicationConfig('app', { package: 'p', credentials: [{ secret: 's' }] }), /reference/);
 	});
 });

--- a/unitTests/components/credentials.test.js
+++ b/unitTests/components/credentials.test.js
@@ -71,7 +71,7 @@ describe('Application transient .npmrc lifecycle', () => {
 		const app = new Application({
 			name: 'registry-credentials-test',
 			packageIdentifier: 'npm:@myorg/app',
-			registryCredentials: [{ registry: 'https://npm.pkg.github.com', token: 'secret', scope: '@myorg' }],
+			credentials: [{ registry: 'https://npm.pkg.github.com', token: 'secret', scope: '@myorg' }],
 		});
 
 		assert.strictEqual(app.npmUserconfigPath, undefined, 'no path before write');
@@ -116,7 +116,7 @@ describe('Application transient .npmrc lifecycle', () => {
 			const app = new Application({
 				name: 'merge-test',
 				packageIdentifier: 'npm:@myorg/app',
-				registryCredentials: [{ registry: 'https://npm.pkg.github.com', token: 'secret', scope: '@myorg' }],
+				credentials: [{ registry: 'https://npm.pkg.github.com', token: 'secret', scope: '@myorg' }],
 			});
 			await app.writeTransientNpmrc();
 			const contents = await fs.readFile(app.npmUserconfigPath, 'utf8');

--- a/unitTests/components/gitCredentialClone.test.js
+++ b/unitTests/components/gitCredentialClone.test.js
@@ -1,0 +1,208 @@
+'use strict';
+
+// End-to-end proof that the git credential channel actually authenticates a real clone (#1792).
+//
+// The mechanism this feature rests on lives entirely outside our process — git decides whether to
+// call a credential helper, npm decides which environment git inherits, and both have historically
+// had version-specific quirks here. A test that stubs the helper would prove none of that. So this
+// stands up a genuine private git remote (git-http-backend behind HTTP Basic auth) and deploys from
+// it through the real extractApplication path, asserting that the clone succeeds only because the
+// credential was served from memory.
+//
+// The remote speaks http rather than https purely so the test needs no certificate: git's credential
+// machinery is identical for both, and TLS terminates below the layer this feature touches.
+
+const assert = require('node:assert');
+const fs = require('node:fs/promises');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn, execFileSync } = require('node:child_process');
+const { existsSync } = require('node:fs');
+
+const testUtils = require('../testUtils.js');
+testUtils.preTestPrep();
+
+const { Application, extractApplication } = require('#src/components/Application');
+const { getConfigPath } = require('#src/config/configUtils');
+const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
+
+const GIT_HTTP_BACKEND = path.join(execFileSync('git', ['--exec-path']).toString().trim(), 'git-http-backend');
+const TOKEN = 'ghp_test_token_value';
+const USERNAME = 'x-access-token';
+
+// The one Authorization header the remote accepts: git's HTTPS basic-auth convention for a PAT.
+function validAuthorization() {
+	return 'Basic ' + Buffer.from(`${USERNAME}:${TOKEN}`).toString('base64');
+}
+
+// A CGI bridge to git's own smart-HTTP server, gated on Basic auth — the smallest thing that is a
+// real private git remote rather than an imitation of one.
+function startPrivateGitServer(projectRoot, onAuthorization) {
+	const server = http.createServer((request, response) => {
+		const authorization = request.headers.authorization ?? '';
+		onAuthorization(authorization);
+		if (authorization !== validAuthorization()) {
+			response.writeHead(401, { 'WWW-Authenticate': 'Basic realm="harper-test"' });
+			response.end('unauthorized');
+			return;
+		}
+
+		const url = new URL(request.url, 'http://localhost');
+		const cgi = spawn(GIT_HTTP_BACKEND, {
+			env: {
+				...process.env,
+				GIT_PROJECT_ROOT: projectRoot,
+				GIT_HTTP_EXPORT_ALL: '1',
+				REQUEST_METHOD: request.method,
+				PATH_INFO: url.pathname,
+				QUERY_STRING: url.search.replace(/^\?/, ''),
+				CONTENT_TYPE: request.headers['content-type'] ?? '',
+				REMOTE_USER: USERNAME,
+			},
+		});
+		request.pipe(cgi.stdin);
+
+		// CGI replies with headers, a blank line, then the body — split it back out for the HTTP layer.
+		let head = Buffer.alloc(0);
+		let headersSent = false;
+		cgi.stdout.on('data', (chunk) => {
+			if (headersSent) return response.write(chunk);
+			head = Buffer.concat([head, chunk]);
+			const split = head.indexOf('\r\n\r\n');
+			if (split === -1) return;
+			const headers = {};
+			for (const line of head.subarray(0, split).toString().split('\r\n')) {
+				const separator = line.indexOf(':');
+				if (separator > 0) headers[line.slice(0, separator)] = line.slice(separator + 1).trim();
+			}
+			headersSent = true;
+			response.writeHead(Number(headers.Status?.split(' ')[0]) || 200, headers);
+			response.write(head.subarray(split + 4));
+		});
+		cgi.stdout.on('end', () => response.end());
+		cgi.on('error', () => response.destroy());
+	});
+
+	return new Promise((resolve) => {
+		server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port }));
+	});
+}
+
+// A bare repo with one commit, served as the "private" package.
+async function createRepo(root, name) {
+	const work = path.join(root, 'work');
+	const bare = path.join(root, `${name}.git`);
+	await fs.mkdir(work, { recursive: true });
+	await fs.writeFile(
+		path.join(work, 'package.json'),
+		JSON.stringify({ name, version: '1.0.0', description: 'private test component' }, null, 2)
+	);
+	await fs.writeFile(path.join(work, 'index.js'), '// private component source\n');
+	const git = (...args) => execFileSync('git', args, { cwd: work, stdio: 'pipe' });
+	git('init', '--quiet', '--initial-branch=main');
+	git('config', 'user.email', 'test@harperdb.io');
+	git('config', 'user.name', 'Harper Test');
+	git('config', 'commit.gpgsign', 'false');
+	git('add', '.');
+	git('commit', '--quiet', '-m', 'initial');
+	execFileSync('git', ['clone', '--quiet', '--bare', work, bare], { stdio: 'pipe' });
+	return bare;
+}
+
+describe('private git-reference deploy (real clone over authenticated git-over-http)', function () {
+	// A real git clone through npm: slower than a unit test, but the only thing that proves the
+	// credential reaches git.
+	this.timeout(120_000);
+
+	let root;
+	let server;
+	let packageIdentifier;
+	let seenAuthorization;
+
+	before(async function () {
+		if (process.platform === 'win32' || !existsSync(GIT_HTTP_BACKEND)) return this.skip();
+		// extractApplication packs into the components root, which the unit-test config points at but
+		// does not create.
+		await fs.mkdir(getConfigPath(CONFIG_PARAMS.COMPONENTSROOT), { recursive: true });
+		root = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-git-remote-'));
+		await createRepo(root, 'private-component');
+		const started = await startPrivateGitServer(root, (authorization) => seenAuthorization.push(authorization));
+		server = started.server;
+		packageIdentifier = `git+http://127.0.0.1:${started.port}/private-component.git`;
+	});
+
+	after(async () => {
+		await new Promise((resolve) => (server ? server.close(resolve) : resolve()));
+		if (root) await fs.rm(root, { recursive: true, force: true });
+	});
+
+	beforeEach(() => {
+		seenAuthorization = [];
+	});
+
+	it('fails to clone the private repo without a credential', async () => {
+		const application = new Application({ name: 'git-clone-unauthenticated', packageIdentifier });
+		await assert.rejects(
+			() => extractApplication(application),
+			/Failed to download package/,
+			'a private repo must not be cloneable without a credential'
+		);
+		// npm points git at its own `GIT_ASKPASS=echo` when we supply none, so git does attempt an empty
+		// credential — what matters is that no request could carry the token.
+		assert.ok(
+			seenAuthorization.every((header) => !header.includes(validAuthorization().slice('Basic '.length))),
+			'the token cannot be presented without a credential session'
+		);
+	});
+
+	it('clones the private repo with a token served from memory, and the token never lands on disk', async () => {
+		const application = new Application({
+			name: 'git-clone-authenticated',
+			packageIdentifier,
+			credentials: [{ host: `127.0.0.1:${new URL(packageIdentifier.slice(4)).port}`, token: TOKEN }],
+		});
+
+		// Exactly the sequence prepareApplication runs: bring the credential socket up, clone, tear it down.
+		await application.startGitCredentialSession();
+		try {
+			await extractApplication(application);
+		} finally {
+			await application.cleanupGitCredentialSession();
+		}
+
+		// The clone actually happened, and it authenticated.
+		const packageJSON = JSON.parse(await fs.readFile(path.join(application.dirPath, 'package.json'), 'utf8'));
+		assert.strictEqual(packageJSON.name, 'private-component');
+		assert.ok(existsSync(path.join(application.dirPath, 'index.js')), 'repo contents extracted');
+		assert.ok(
+			seenAuthorization.some((header) => header === validAuthorization()),
+			'git presented the token from the credential session'
+		);
+
+		// The token is not in the package identifier npm was given, so it cannot reach a lockfile, the
+		// deployment row, or the operations log through it.
+		assert.ok(!application.packageIdentifier.includes(TOKEN), 'token not embedded in the package URL');
+		// Nor anywhere in the extracted component — the credential leaves no artifact behind.
+		const files = await fs.readdir(application.dirPath, { recursive: true, withFileTypes: true });
+		for (const file of files) {
+			if (!file.isFile()) continue;
+			const contents = await fs.readFile(path.join(file.parentPath ?? file.path, file.name), 'utf8').catch(() => '');
+			assert.ok(!contents.includes(TOKEN), `token found on disk in ${file.name}`);
+		}
+	});
+
+	it('stops authenticating once the session is closed', async () => {
+		// The credential is bound to the clone, not to the deploy: anything that runs after extraction
+		// (install scripts included) finds the socket gone.
+		const application = new Application({
+			name: 'git-clone-after-close',
+			packageIdentifier,
+			credentials: [{ host: `127.0.0.1:${new URL(packageIdentifier.slice(4)).port}`, token: TOKEN }],
+		});
+		await application.startGitCredentialSession();
+		await application.cleanupGitCredentialSession();
+
+		await assert.rejects(() => extractApplication(application), /Failed to download package/);
+	});
+});

--- a/unitTests/components/gitCredentialClone.test.js
+++ b/unitTests/components/gitCredentialClone.test.js
@@ -213,6 +213,59 @@ describe('private git-reference deploy (real clone over authenticated git-over-h
 		}
 	});
 
+	it('does not persist the token to git-credentials even when a store helper is configured', async function () {
+		// The sharpest leak path: git reports a *successful* authentication back to its credential
+		// helper chain, so a machine with `credential.helper=store` (globally or URL-scoped) would write
+		// the token to ~/.git-credentials — silently. The GIT_CONFIG_* helper reset must survive a real
+		// clone, not just a synthetic `git credential approve`.
+		const home = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-git-home-'));
+		const gitConfig = path.join(home, '.gitconfig');
+		const credentialsFile = path.join(home, '.git-credentials');
+		const scopedCredentialsFile = path.join(home, '.git-credentials-scoped');
+		const host = gitHost();
+		await fs.writeFile(
+			gitConfig,
+			`[credential]\n\thelper = store --file ${credentialsFile}\n` +
+				`[credential "http://${host}"]\n\thelper = store --file ${scopedCredentialsFile}\n`
+		);
+
+		const application = new Application({
+			name: 'git-clone-store-helper',
+			packageIdentifier,
+			credentials: [{ host, token: TOKEN }],
+		});
+
+		const priorHome = process.env.HOME;
+		const priorConfigGlobal = process.env.GIT_CONFIG_GLOBAL;
+		process.env.HOME = home;
+		process.env.GIT_CONFIG_GLOBAL = gitConfig;
+		try {
+			await application.startGitCredentialSession();
+			try {
+				await extractApplication(application);
+			} finally {
+				await application.cleanupGitCredentialSession();
+			}
+		} finally {
+			if (priorHome === undefined) delete process.env.HOME;
+			else process.env.HOME = priorHome;
+			if (priorConfigGlobal === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+			else process.env.GIT_CONFIG_GLOBAL = priorConfigGlobal;
+		}
+
+		// The clone still authenticated (proving the helper chain was active)...
+		assert.ok(
+			seenAuthorization.some((header) => header === validAuthorization()),
+			'the clone authenticated, so git did run its credential machinery'
+		);
+		// ...yet neither store file received the token.
+		for (const file of [credentialsFile, scopedCredentialsFile]) {
+			const persisted = await fs.readFile(file, 'utf8').catch(() => '');
+			assert.ok(!persisted.includes(TOKEN), `token persisted to ${path.basename(file)}: ${persisted}`);
+		}
+		await fs.rm(home, { recursive: true, force: true });
+	});
+
 	// Packing a git reference is not just a download: npm clones the repo and runs its prepare/build
 	// script — and its dependencies' install scripts — on this node, inside the clone spawn. Left
 	// alone, any of that code could ask the socket for the token, which is precisely the reach the

--- a/unitTests/components/gitCredentialClone.test.js
+++ b/unitTests/components/gitCredentialClone.test.js
@@ -27,7 +27,15 @@ const { Application, extractApplication } = require('#src/components/Application
 const { getConfigPath } = require('#src/config/configUtils');
 const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
 
-const GIT_HTTP_BACKEND = path.join(execFileSync('git', ['--exec-path']).toString().trim(), 'git-http-backend');
+// git may not be installed/in PATH in every test environment; resolving this at module load time
+// (before mocha's before() hook gets a chance to skip gracefully) would crash the whole suite's
+// loading rather than just this file's tests, so fall back to undefined and let before() skip.
+let GIT_HTTP_BACKEND;
+try {
+	GIT_HTTP_BACKEND = path.join(execFileSync('git', ['--exec-path']).toString().trim(), 'git-http-backend');
+} catch {
+	// git not installed/in PATH; before() skips when GIT_HTTP_BACKEND is unset.
+}
 const TOKEN = 'ghp_test_token_value';
 const USERNAME = 'x-access-token';
 
@@ -133,7 +141,7 @@ describe('private git-reference deploy (real clone over authenticated git-over-h
 	let stealOut;
 
 	before(async function () {
-		if (process.platform === 'win32' || !existsSync(GIT_HTTP_BACKEND)) return this.skip();
+		if (process.platform === 'win32' || !GIT_HTTP_BACKEND || !existsSync(GIT_HTTP_BACKEND)) return this.skip();
 		// extractApplication packs into the components root, which the unit-test config points at but
 		// does not create.
 		await fs.mkdir(getConfigPath(CONFIG_PARAMS.COMPONENTSROOT), { recursive: true });

--- a/unitTests/components/gitCredentialClone.test.js
+++ b/unitTests/components/gitCredentialClone.test.js
@@ -89,16 +89,26 @@ function startPrivateGitServer(projectRoot, onAuthorization) {
 	});
 }
 
-// A bare repo with one commit, served as the "private" package.
-async function createRepo(root, name) {
-	const work = path.join(root, 'work');
+// A bare repo with one commit, served as the "private" package. With `scripts`, the manifest also
+// carries a prepare script — which npm runs, inside the clone, during `npm pack`.
+async function createRepo(root, name, scripts) {
+	const work = path.join(root, 'work-' + name);
 	const bare = path.join(root, `${name}.git`);
 	await fs.mkdir(work, { recursive: true });
 	await fs.writeFile(
 		path.join(work, 'package.json'),
-		JSON.stringify({ name, version: '1.0.0', description: 'private test component' }, null, 2)
+		JSON.stringify({ name, version: '1.0.0', description: 'private test component', scripts }, null, 2)
 	);
 	await fs.writeFile(path.join(work, 'index.js'), '// private component source\n');
+	// Stands in for a malicious prepare/postinstall script (the repo's own, or a transitive
+	// dependency's): it records whatever credential wiring it inherited from the clone spawn.
+	await fs.writeFile(
+		path.join(work, 'steal.js'),
+		`require('node:fs').writeFileSync(process.env.HARPER_TEST_STEAL_OUT, JSON.stringify({\n` +
+			`  socket: process.env.HARPER_GIT_CREDENTIAL_SOCKET ?? null,\n` +
+			`  askpass: process.env.GIT_ASKPASS ?? null,\n` +
+			`}));\n`
+	);
 	const git = (...args) => execFileSync('git', args, { cwd: work, stdio: 'pipe' });
 	git('init', '--quiet', '--initial-branch=main');
 	git('config', 'user.email', 'test@harperdb.io');
@@ -118,7 +128,9 @@ describe('private git-reference deploy (real clone over authenticated git-over-h
 	let root;
 	let server;
 	let packageIdentifier;
+	let scriptedPackageIdentifier;
 	let seenAuthorization;
+	let stealOut;
 
 	before(async function () {
 		if (process.platform === 'win32' || !existsSync(GIT_HTTP_BACKEND)) return this.skip();
@@ -127,9 +139,12 @@ describe('private git-reference deploy (real clone over authenticated git-over-h
 		await fs.mkdir(getConfigPath(CONFIG_PARAMS.COMPONENTSROOT), { recursive: true });
 		root = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-git-remote-'));
 		await createRepo(root, 'private-component');
+		await createRepo(root, 'scripted-component', { prepare: 'node ./steal.js' });
+		stealOut = path.join(root, 'stolen.json');
 		const started = await startPrivateGitServer(root, (authorization) => seenAuthorization.push(authorization));
 		server = started.server;
 		packageIdentifier = `git+http://127.0.0.1:${started.port}/private-component.git`;
+		scriptedPackageIdentifier = `git+http://127.0.0.1:${started.port}/scripted-component.git`;
 	});
 
 	after(async () => {
@@ -137,9 +152,15 @@ describe('private git-reference deploy (real clone over authenticated git-over-h
 		if (root) await fs.rm(root, { recursive: true, force: true });
 	});
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		seenAuthorization = [];
+		await fs.rm(stealOut, { force: true });
 	});
+
+	// The credential entry's host: the remote's host:port, which is what git asks about.
+	function gitHost() {
+		return new URL(packageIdentifier.slice('git+'.length)).host;
+	}
 
 	it('fails to clone the private repo without a credential', async () => {
 		const application = new Application({ name: 'git-clone-unauthenticated', packageIdentifier });
@@ -160,7 +181,7 @@ describe('private git-reference deploy (real clone over authenticated git-over-h
 		const application = new Application({
 			name: 'git-clone-authenticated',
 			packageIdentifier,
-			credentials: [{ host: `127.0.0.1:${new URL(packageIdentifier.slice(4)).port}`, token: TOKEN }],
+			credentials: [{ host: gitHost(), token: TOKEN }],
 		});
 
 		// Exactly the sequence prepareApplication runs: bring the credential socket up, clone, tear it down.
@@ -192,13 +213,62 @@ describe('private git-reference deploy (real clone over authenticated git-over-h
 		}
 	});
 
+	// Packing a git reference is not just a download: npm clones the repo and runs its prepare/build
+	// script — and its dependencies' install scripts — on this node, inside the clone spawn. Left
+	// alone, any of that code could ask the socket for the token, which is precisely the reach the
+	// credential must not have. Verified against real npm rather than asserted: this is npm's
+	// behavior, not ours, and it is the whole reason the clone runs with scripts disabled.
+	it('does not run the repository prepare script during a credentialed clone, so nothing can reach the socket', async () => {
+		const application = new Application({
+			name: 'git-clone-scripted',
+			packageIdentifier: scriptedPackageIdentifier,
+			credentials: [{ host: gitHost(), token: TOKEN }],
+		});
+
+		await application.startGitCredentialSession();
+		try {
+			await extractApplication(application);
+		} finally {
+			await application.cleanupGitCredentialSession();
+		}
+
+		assert.ok(!existsSync(stealOut), 'the prepare script must not run while the credential is reachable');
+	});
+
+	it('runs the prepare script — with the credential in reach — only when the deploy opts into scripts', async () => {
+		// install_allow_scripts is the operator explicitly asking for this repository's code to run on
+		// the node. That is the one case where the credential is exposed to it, and it is logged.
+		const application = new Application({
+			name: 'git-clone-scripted-allowed',
+			packageIdentifier: scriptedPackageIdentifier,
+			install: { allowInstallScripts: true },
+			credentials: [{ host: gitHost(), token: TOKEN }],
+		});
+
+		process.env.HARPER_TEST_STEAL_OUT = stealOut;
+		try {
+			await application.startGitCredentialSession();
+			try {
+				await extractApplication(application);
+			} finally {
+				await application.cleanupGitCredentialSession();
+			}
+		} finally {
+			delete process.env.HARPER_TEST_STEAL_OUT;
+		}
+
+		assert.ok(existsSync(stealOut), 'the prepare script runs when scripts are allowed');
+		const seen = JSON.parse(await fs.readFile(stealOut, 'utf8'));
+		assert.ok(seen.socket, 'documents the exposure this opt-in accepts: the script can reach the socket');
+	});
+
 	it('stops authenticating once the session is closed', async () => {
 		// The credential is bound to the clone, not to the deploy: anything that runs after extraction
 		// (install scripts included) finds the socket gone.
 		const application = new Application({
 			name: 'git-clone-after-close',
 			packageIdentifier,
-			credentials: [{ host: `127.0.0.1:${new URL(packageIdentifier.slice(4)).port}`, token: TOKEN }],
+			credentials: [{ host: gitHost(), token: TOKEN }],
 		});
 		await application.startGitCredentialSession();
 		await application.cleanupGitCredentialSession();

--- a/unitTests/components/gitCredentials.test.js
+++ b/unitTests/components/gitCredentials.test.js
@@ -1,0 +1,312 @@
+'use strict';
+
+// Covers the git-host credential channel used by private git-reference deploys (#1792): a per-deploy
+// socket serves the token from memory, gitCredentialHelper.js relays git's request over it, and the
+// environment that reaches the helper is granted to the clone spawn only.
+//
+// The helper is exercised as a real child process (the way git runs it), not stubbed — the point of
+// the design is what crosses the process boundary, so a mocked helper would test nothing.
+
+const assert = require('node:assert');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const { execFile } = require('node:child_process');
+
+const testUtils = require('../testUtils.js');
+testUtils.preTestPrep();
+
+const {
+	startGitCredentialSession,
+	normalizeGitHost,
+	DEFAULT_GIT_USERNAME,
+	GIT_CREDENTIAL_SOCKET_ENV,
+} = require('#src/components/gitCredentialServer');
+const { Application, GIT_CREDENTIAL_HELPER_PATH, nonInteractiveSpawn } = require('#src/components/Application');
+
+// Run the helper exactly as git would: the credential-helper protocol (operation as the last
+// argument, key=value request on stdin) or the GIT_ASKPASS protocol (prompt as the first argument).
+function runHelper({ args, stdin, env }) {
+	return new Promise((resolve, reject) => {
+		const child = execFile(
+			process.execPath,
+			[GIT_CREDENTIAL_HELPER_PATH, ...args],
+			{ env: { ...process.env, ...env } },
+			(error, stdout, stderr) => {
+				// A non-zero exit is a valid outcome here (git treats it as "no credential"), so report it
+				// rather than rejecting.
+				if (error && typeof error.code !== 'number') return reject(error);
+				resolve({ stdout, stderr, code: error ? error.code : 0 });
+			}
+		);
+		child.stdin.end(stdin ?? '');
+	});
+}
+
+describe('normalizeGitHost', () => {
+	it('reduces the forms a credential entry or a git prompt can carry to one host key', () => {
+		for (const input of ['github.com', 'GitHub.com', 'https://github.com', 'https://github.com/', '//github.com']) {
+			assert.strictEqual(normalizeGitHost(input), 'github.com', input);
+		}
+		// userinfo in a prompt URL is not part of the host identity
+		assert.strictEqual(normalizeGitHost('https://x-access-token@github.com'), 'github.com');
+		// a non-default port is, since it identifies a different endpoint
+		assert.strictEqual(normalizeGitHost('git.example.com:8443'), 'git.example.com:8443');
+	});
+});
+
+describe('git credential session', () => {
+	let session;
+
+	afterEach(async () => {
+		await session?.close();
+		session = undefined;
+	});
+
+	it('serves the token over the socket to a helper run as a git credential helper', async () => {
+		session = await startGitCredentialSession(
+			[{ host: 'github.com', token: 'ghp_secret' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+
+		const { stdout } = await runHelper({
+			args: ['get'],
+			stdin: 'protocol=https\nhost=github.com\n\n',
+			env: session.env,
+		});
+
+		assert.strictEqual(stdout, `username=${DEFAULT_GIT_USERNAME}\npassword=ghp_secret\n`);
+	});
+
+	it('answers a GIT_ASKPASS username prompt and password prompt, locale independently', async () => {
+		session = await startGitCredentialSession(
+			[{ host: 'github.com', token: 'ghp_secret' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+
+		// The username prompt's URL has no userinfo; the password prompt's does. That structural
+		// difference is what the helper keys on, so a translated prompt still resolves correctly.
+		const username = await runHelper({ args: [`Username for 'https://github.com': `], env: session.env });
+		assert.strictEqual(username.stdout, `${DEFAULT_GIT_USERNAME}\n`);
+
+		const password = await runHelper({
+			args: [`Password for 'https://x-access-token@github.com': `],
+			env: session.env,
+		});
+		assert.strictEqual(password.stdout, 'ghp_secret\n');
+
+		const translated = await runHelper({
+			args: [`Mot de passe pour 'https://x-access-token@github.com' : `],
+			env: session.env,
+		});
+		assert.strictEqual(translated.stdout, 'ghp_secret\n', 'a localized prompt still yields the password');
+	});
+
+	it('honors a per-entry username (GitLab/Bitbucket use their own convention)', async () => {
+		session = await startGitCredentialSession(
+			[{ host: 'gitlab.com', token: 'glpat', username: 'oauth2' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		const { stdout } = await runHelper({
+			args: ['get'],
+			stdin: 'protocol=https\nhost=gitlab.com\n\n',
+			env: session.env,
+		});
+		assert.strictEqual(stdout, 'username=oauth2\npassword=glpat\n');
+	});
+
+	it('answers nothing for a host it holds no credential for', async () => {
+		session = await startGitCredentialSession(
+			[{ host: 'github.com', token: 'ghp_secret' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		// Silence rather than an error: git also asks about public hosts, and the clone of a public
+		// dependency must proceed unauthenticated instead of failing the deploy.
+		const { stdout } = await runHelper({
+			args: ['get'],
+			stdin: 'protocol=https\nhost=evil.example.com\n\n',
+			env: session.env,
+		});
+		assert.strictEqual(stdout, '');
+	});
+
+	it('never yields the token to a store/erase request (the credential is not persistable)', async () => {
+		session = await startGitCredentialSession(
+			[{ host: 'github.com', token: 'ghp_secret' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		for (const operation of ['store', 'erase']) {
+			const { stdout } = await runHelper({
+				args: [operation],
+				stdin: 'protocol=https\nhost=github.com\nusername=x-access-token\npassword=ghp_secret\n\n',
+				env: session.env,
+			});
+			assert.strictEqual(stdout, '', `${operation} yields nothing`);
+		}
+	});
+
+	it('resets any inherited credential.helper so a configured `store` cannot persist the token', async () => {
+		session = await startGitCredentialSession([{ host: 'github.com', token: 't' }], GIT_CREDENTIAL_HELPER_PATH);
+		const count = Number(session.env.GIT_CONFIG_COUNT);
+		// The first of our two entries clears git's helper list; the second installs ours. Without the
+		// reset, git would report the successful authentication to an inherited helper — a machine with
+		// `credential.helper=store` would write this token to ~/.git-credentials.
+		assert.strictEqual(session.env[`GIT_CONFIG_KEY_${count - 2}`], 'credential.helper');
+		assert.strictEqual(session.env[`GIT_CONFIG_VALUE_${count - 2}`], '');
+		assert.strictEqual(session.env[`GIT_CONFIG_KEY_${count - 1}`], 'credential.helper');
+		assert.ok(session.env[`GIT_CONFIG_VALUE_${count - 1}`].startsWith('!'), 'ours is a shell-invoked helper');
+		assert.strictEqual(session.env.GIT_TERMINAL_PROMPT, '0', 'git must fail rather than hang on a prompt');
+	});
+
+	it('keeps the token off disk: the socket dir is 0700 and holds only a socket', async () => {
+		session = await startGitCredentialSession(
+			[{ host: 'github.com', token: 'ghp_secret' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		const socketPath = session.env[GIT_CREDENTIAL_SOCKET_ENV];
+		const socketDir = path.dirname(socketPath);
+
+		assert.strictEqual((await fs.stat(socketDir)).mode & 0o777, 0o700, 'socket dir is owner-only');
+		const entries = await fs.readdir(socketDir);
+		assert.deepStrictEqual(entries, ['credential.sock']);
+		assert.ok((await fs.stat(socketPath)).isSocket(), 'the only artifact is a socket, not a file with a token');
+	});
+
+	it('stops answering once the session is closed', async () => {
+		session = await startGitCredentialSession(
+			[{ host: 'github.com', token: 'ghp_secret' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		const env = session.env;
+		const socketPath = env[GIT_CREDENTIAL_SOCKET_ENV];
+
+		await session.close();
+		session = undefined;
+
+		// The credential is gone the moment the clone finishes — anything that runs later in the deploy
+		// (install scripts included) finds nothing to ask.
+		const { stdout, code } = await runHelper({ args: ['get'], stdin: 'protocol=https\nhost=github.com\n\n', env });
+		assert.strictEqual(stdout, '');
+		assert.strictEqual(code, 1, 'helper reports failure rather than silently succeeding');
+		await assert.rejects(fs.stat(socketPath), /ENOENT/, 'socket removed');
+	});
+
+	it('is inert without a session: the helper carries no secret of its own', async () => {
+		// GIT_CREDENTIAL_SOCKET_ENV is the only variable that carries authority. A helper reached with
+		// it stripped answers nothing, which is what makes stripping it from the install spawn sufficient.
+		const { stdout, code } = await runHelper({
+			args: ['get'],
+			stdin: 'protocol=https\nhost=github.com\n\n',
+			env: { [GIT_CREDENTIAL_SOCKET_ENV]: undefined },
+		});
+		assert.strictEqual(stdout, '');
+		assert.strictEqual(code, 0);
+	});
+});
+
+describe('Application git credential lifecycle', () => {
+	it('partitions resolved credentials by kind and exposes git env only while the session is open', async () => {
+		const app = new Application({
+			name: 'git-credentials-test',
+			packageIdentifier: 'github:myorg/private-app',
+			credentials: [
+				{ registry: 'https://npm.pkg.github.com', token: 'npm-tok', scope: '@myorg' },
+				{ host: 'github.com', token: 'git-tok' },
+			],
+		});
+
+		assert.deepStrictEqual(app.registryCredentials, [
+			{ registry: 'https://npm.pkg.github.com', token: 'npm-tok', scope: '@myorg' },
+		]);
+		assert.deepStrictEqual(app.gitCredentials, [{ host: 'github.com', token: 'git-tok' }]);
+		assert.strictEqual(app.gitCredentialEnv, undefined, 'no env before the session starts');
+
+		await app.startGitCredentialSession();
+		assert.ok(app.gitCredentialEnv[GIT_CREDENTIAL_SOCKET_ENV], 'env carries the socket while open');
+
+		await app.cleanupGitCredentialSession();
+		assert.strictEqual(app.gitCredentialEnv, undefined, 'env cleared after cleanup');
+		assert.strictEqual(app.gitCredentials, undefined, 'in-memory tokens dropped after cleanup');
+	});
+
+	it('starting a session is a no-op without git credentials', async () => {
+		const app = new Application({
+			name: 'no-git-credentials-test',
+			packageIdentifier: 'npm:@myorg/app',
+			credentials: [{ registry: 'https://npm.pkg.github.com', token: 'npm-tok' }],
+		});
+		await app.startGitCredentialSession();
+		assert.strictEqual(app.gitCredentialEnv, undefined);
+		await app.cleanupGitCredentialSession();
+	});
+});
+
+describe('nonInteractiveSpawn git credential scoping', () => {
+	let scriptDir;
+	let scriptPath;
+
+	before(async () => {
+		scriptDir = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-env-probe-'));
+		scriptPath = path.join(scriptDir, 'probe.js');
+		// Stands in for a dependency's install script: prints whatever git credential wiring it inherited.
+		await fs.writeFile(
+			scriptPath,
+			`const keys = Object.keys(process.env).filter((k) => k.startsWith('GIT_') || k === '${GIT_CREDENTIAL_SOCKET_ENV}');\n` +
+				`process.stdout.write(JSON.stringify(keys.sort()));\n`
+		);
+	});
+
+	after(async () => {
+		await fs.rm(scriptDir, { recursive: true, force: true });
+	});
+
+	async function probeEnv(gitCredentialEnv) {
+		const { stdout, code } = await nonInteractiveSpawn(
+			'env-probe',
+			process.execPath,
+			[scriptPath],
+			scriptDir,
+			30_000,
+			undefined,
+			undefined,
+			gitCredentialEnv
+		);
+		assert.strictEqual(code, 0, `probe exited ${code}`);
+		return JSON.parse(stdout.slice(stdout.indexOf('[')));
+	}
+
+	it('grants the credential environment to the spawn that clones, and to no other', async () => {
+		const session = await startGitCredentialSession(
+			[{ host: 'github.com', token: 'ghp_secret' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		try {
+			// The clone spawn (`npm pack`) is handed the session env...
+			const cloneEnv = await probeEnv(session.env);
+			assert.ok(cloneEnv.includes('GIT_ASKPASS'), 'clone spawn can reach the helper');
+			assert.ok(cloneEnv.includes(GIT_CREDENTIAL_SOCKET_ENV), 'clone spawn can reach the socket');
+
+			// ...and the install spawn, where a transitive dependency's install script can run, is not.
+			const installEnv = await probeEnv(undefined);
+			assert.ok(!installEnv.includes(GIT_CREDENTIAL_SOCKET_ENV), 'install spawn cannot reach the socket');
+			assert.ok(
+				!installEnv.some((key) => key.startsWith('GIT_CONFIG_') || key === 'GIT_ASKPASS'),
+				`install spawn saw git credential wiring: ${installEnv.join(', ')}`
+			);
+		} finally {
+			await session.close();
+		}
+	});
+
+	it('strips an inherited socket variable, disarming a helper wired up outside the session', async () => {
+		// Belt and braces: even if Harper's own environment somehow carried the socket variable, a spawn
+		// that was not granted the session must not inherit it.
+		process.env[GIT_CREDENTIAL_SOCKET_ENV] = '/tmp/not-a-real-session.sock';
+		try {
+			const installEnv = await probeEnv(undefined);
+			assert.ok(!installEnv.includes(GIT_CREDENTIAL_SOCKET_ENV), 'inherited socket variable stripped');
+		} finally {
+			delete process.env[GIT_CREDENTIAL_SOCKET_ENV];
+		}
+	});
+});

--- a/unitTests/components/gitCredentials.test.js
+++ b/unitTests/components/gitCredentials.test.js
@@ -280,7 +280,14 @@ describe('git credential session', () => {
 		const closed = new Promise((resolve) => socket.on('close', resolve));
 		// Never half-close: without a cap the server would accumulate this forever.
 		const junk = 'x'.repeat(64 * 1024);
-		const write = () => socket.writable && socket.write(junk) && setImmediate(write);
+		// write() can return false under backpressure (the socket's internal buffer is full) well
+		// before the server-side cap is exceeded; resume on 'drain' instead of giving up, or this
+		// test hangs waiting for a 'close' the server never has a reason to send.
+		const write = () => {
+			if (!socket.writable) return;
+			if (socket.write(junk)) setImmediate(write);
+			else socket.once('drain', write);
+		};
 		write();
 
 		await closed; // the server destroys the connection instead of growing its buffer

--- a/unitTests/components/gitCredentials.test.js
+++ b/unitTests/components/gitCredentials.test.js
@@ -12,6 +12,7 @@ const fs = require('node:fs/promises');
 const os = require('node:os');
 const path = require('node:path');
 const { execFile } = require('node:child_process');
+const net = require('node:net');
 
 const testUtils = require('../testUtils.js');
 testUtils.preTestPrep();
@@ -189,6 +190,27 @@ describe('git credential session', () => {
 		assert.strictEqual(stdout, '');
 		assert.strictEqual(code, 1, 'helper reports failure rather than silently succeeding');
 		await assert.rejects(fs.stat(socketPath), /ENOENT/, 'socket removed');
+	});
+
+	it('drops a connection that streams without end, rather than buffering it into an OOM', async () => {
+		session = await startGitCredentialSession(
+			[{ host: 'github.com', token: 'ghp_secret' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		const socket = net.connect(session.env[GIT_CREDENTIAL_SOCKET_ENV]);
+		await new Promise((resolve, reject) => {
+			socket.on('connect', resolve);
+			socket.on('error', reject);
+		});
+
+		const closed = new Promise((resolve) => socket.on('close', resolve));
+		// Never half-close: without a cap the server would accumulate this forever.
+		const junk = 'x'.repeat(64 * 1024);
+		const write = () => socket.writable && socket.write(junk) && setImmediate(write);
+		write();
+
+		await closed; // the server destroys the connection instead of growing its buffer
+		assert.ok(socket.destroyed);
 	});
 
 	it('is inert without a session: the helper carries no secret of its own', async () => {

--- a/unitTests/components/gitCredentials.test.js
+++ b/unitTests/components/gitCredentials.test.js
@@ -131,6 +131,45 @@ describe('git credential session', () => {
 		assert.strictEqual(stdout, '');
 	});
 
+	it('refuses to serve a credential over cleartext http (only https, plus loopback)', async () => {
+		session = await startGitCredentialSession(
+			[
+				{ host: 'github.com', token: 'ghp_secret' },
+				{ host: '127.0.0.1:8080', token: 'local_tok' },
+			],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		// A public host over http would put the token on the wire in the clear — refuse.
+		const cleartext = await runHelper({
+			args: ['get'],
+			stdin: 'protocol=http\nhost=github.com\n\n',
+			env: session.env,
+		});
+		assert.strictEqual(cleartext.stdout, '', 'no credential over http to a public host');
+		// A loopback remote never touches a network, so http to it is fine (integration tests use it).
+		const loopback = await runHelper({
+			args: ['get'],
+			stdin: 'protocol=http\nhost=127.0.0.1:8080\n\n',
+			env: session.env,
+		});
+		assert.strictEqual(loopback.stdout, 'username=x-access-token\npassword=local_tok\n');
+	});
+
+	it('refuses to serve a token carrying a newline (would truncate or inject protocol attributes)', async () => {
+		// A literal token is rejected by the op schema, but one resolved from an hdb_secret row is not,
+		// so the write boundary must guard it — parity with the .npmrc writer.
+		session = await startGitCredentialSession(
+			[{ host: 'github.com', token: 'ghp\nquit=1' }],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		const { stdout } = await runHelper({
+			args: ['get'],
+			stdin: 'protocol=https\nhost=github.com\n\n',
+			env: session.env,
+		});
+		assert.strictEqual(stdout, '');
+	});
+
 	it('never yields the token to a store/erase request (the credential is not persistable)', async () => {
 		session = await startGitCredentialSession(
 			[{ host: 'github.com', token: 'ghp_secret' }],
@@ -190,6 +229,25 @@ describe('git credential session', () => {
 		assert.strictEqual(stdout, '');
 		assert.strictEqual(code, 1, 'helper reports failure rather than silently succeeding');
 		await assert.rejects(fs.stat(socketPath), /ENOENT/, 'socket removed');
+	});
+
+	it('refuses to start on a git too old for the credential-helper reset', async () => {
+		// git < 2.31 ignores GIT_CONFIG_*, so the reset that stops an inherited `store` helper from
+		// persisting the token would be silently dead — fail the deploy rather than leak.
+		const fakeBin = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-fake-git-'));
+		const fakeGit = path.join(fakeBin, 'git');
+		await fs.writeFile(fakeGit, '#!/bin/sh\necho "git version 2.30.2"\n', { mode: 0o755 });
+		const priorPath = process.env.PATH;
+		process.env.PATH = `${fakeBin}:${priorPath}`;
+		try {
+			await assert.rejects(
+				() => startGitCredentialSession([{ host: 'github.com', token: 't' }], GIT_CREDENTIAL_HELPER_PATH),
+				/2\.31 or newer is required/
+			);
+		} finally {
+			process.env.PATH = priorPath;
+			await fs.rm(fakeBin, { recursive: true, force: true });
+		}
 	});
 
 	it('drops a connection that streams without end, rather than buffering it into an OOM', async () => {

--- a/unitTests/components/gitCredentials.test.js
+++ b/unitTests/components/gitCredentials.test.js
@@ -103,6 +103,22 @@ describe('git credential session', () => {
 		assert.strictEqual(translated.stdout, 'ghp_secret\n', 'a localized prompt still yields the password');
 	});
 
+	it('last-write-wins on a duplicate host, and the session still serves the surviving token', async () => {
+		session = await startGitCredentialSession(
+			[
+				{ host: 'github.com', token: 'first' },
+				{ host: 'github.com', token: 'second' },
+			],
+			GIT_CREDENTIAL_HELPER_PATH
+		);
+		const { stdout } = await runHelper({
+			args: ['get'],
+			stdin: 'protocol=https\nhost=github.com\n\n',
+			env: session.env,
+		});
+		assert.strictEqual(stdout, `username=${DEFAULT_GIT_USERNAME}\npassword=second\n`);
+	});
+
 	it('honors a per-entry username (GitLab/Bitbucket use their own convention)', async () => {
 		session = await startGitCredentialSession(
 			[{ host: 'gitlab.com', token: 'glpat', username: 'oauth2' }],

--- a/unitTests/components/secretOperations.test.js
+++ b/unitTests/components/secretOperations.test.js
@@ -793,6 +793,17 @@ describe('secretOperations', () => {
 			assert.equal(installed.mock.rows.size, 2, 'each kind gets its own derived row');
 		});
 
+		it('without custody, leaves a literal git token untouched (transient fallback) and stores nothing', async () => {
+			const input = [{ host: 'github.com', token: 'ghp_secret' }];
+			const out = await secretOps.ingestCredentials(deploy(), input, 'app');
+			assert.deepEqual(out, [{ host: 'github.com', token: 'ghp_secret' }]);
+			assert.equal(installed.mock.putCount, 0, 'no secret written without custody');
+			// The deploy handler persists/replicates only entries with a `.secret` reference; a no-custody
+			// literal token is therefore not in that set and gets stripped from the op body entirely.
+			const references = out.filter((entry) => entry && entry.secret !== undefined);
+			assert.equal(references.length, 0, 'a no-custody literal token yields no persistable reference');
+		});
+
 		it('is idempotent on token rotation — same derived row, latest value', async () => {
 			installCustody();
 			await secretOps.ingestCredentials(deploy(), [{ registry: gh, token: 'v1' }], 'app');

--- a/unitTests/components/secretOperations.test.js
+++ b/unitTests/components/secretOperations.test.js
@@ -620,6 +620,69 @@ describe('secretOperations', () => {
 		});
 	});
 
+	describe('resolveCredentials (git-host entries)', () => {
+		it('decrypts a git-host reference granted to the deploying component', async () => {
+			installCustody();
+			await secretOps.setSecret({ ...su('set_secret'), name: 'GIT_TOKEN', value: 'ghp_git', grants: ['app'] });
+			const out = await secretOps.resolveCredentials([{ host: 'github.com', secret: 'GIT_TOKEN' }], 'app');
+			assert.deepEqual(out, [{ host: 'github.com', token: 'ghp_git', username: undefined }]);
+		});
+
+		it('fails loudly for a git reference not granted to the deploying component (403)', async () => {
+			installCustody();
+			await secretOps.setSecret({ ...su('set_secret'), name: 'GIT_OTHER', value: 'x', grants: ['different-app'] });
+			await assert.rejects(
+				async () => secretOps.resolveCredentials([{ host: 'github.com', secret: 'GIT_OTHER' }], 'app'),
+				(err) => err.statusCode === 403 && /not granted to component 'app'/.test(err.message)
+			);
+		});
+
+		it('fails loudly for a git reference when custody is absent on this node (503)', async () => {
+			// The use side is fail-closed: no key here means the deploy stops, not that it silently
+			// clones without the credential and fails somewhere less legible.
+			installCustody();
+			await secretOps.setSecret({ ...su('set_secret'), name: 'GIT_NO_KEY', value: 'x', grants: ['app'] });
+			clearSecretCustody();
+			await assert.rejects(
+				async () => secretOps.resolveCredentials([{ host: 'github.com', secret: 'GIT_NO_KEY' }], 'app'),
+				(err) => err.statusCode === 503 && /secrets custody is not initialized/.test(err.message)
+			);
+		});
+
+		it('rejects an entry of an unrecognized kind rather than resolving it into a half-empty one', async () => {
+			// Symmetric with the ingest guard: a `credentials` entry read back from applicationConfig or
+			// an hdb_deployment row was never schema-validated, so an unknown kind must not silently
+			// produce an entry with an undefined identity.
+			installCustody();
+			await secretOps.setSecret({ ...su('set_secret'), name: 'S', value: 'x', grants: ['app'] });
+			await assert.rejects(
+				async () => secretOps.resolveCredentials([{ proxy: 'example.com', secret: 'S' }], 'app'),
+				/Unsupported credential entry/
+			);
+			await assert.rejects(
+				async () => secretOps.resolveCredentials([{ proxy: 'example.com', token: 'literal' }], 'app'),
+				/Unsupported credential entry/
+			);
+		});
+	});
+
+	describe('deriveGitSecretName', () => {
+		it('derives a stable name keyed by component and host, following the registry convention', () => {
+			assert.equal(secretOps.deriveGitSecretName('my-app', 'github.com'), 'deploy.my-app.github.com');
+		});
+
+		it('is identical across the host forms that identify the same host', () => {
+			assert.equal(
+				secretOps.deriveGitSecretName('app', 'https://GitHub.com/'),
+				secretOps.deriveGitSecretName('app', 'github.com')
+			);
+		});
+
+		it('sanitizes a port to the set_secret name grammar', () => {
+			assert.equal(secretOps.deriveGitSecretName('app', 'git.example.com:8443'), 'deploy.app.git.example.com_8443');
+		});
+	});
+
 	describe('deriveRegistrySecretName', () => {
 		it('derives a stable name keyed by component and registry, sanitized to the name grammar', () => {
 			assert.equal(
@@ -682,10 +745,52 @@ describe('secretOperations', () => {
 		it('rejects a literal-token entry of an unrecognized kind (validation should have caught it)', async () => {
 			installCustody();
 			await assert.rejects(
-				async () => secretOps.ingestCredentials(deploy(), [{ host: 'github.com', token: 'ghp_secret' }], 'app'),
+				async () => secretOps.ingestCredentials(deploy(), [{ proxy: 'example.com', token: 'ghp_secret' }], 'app'),
 				/Unsupported credential entry/
 			);
 			assert.equal(installed.mock.putCount, 0, 'nothing sealed for an entry with no derivable secret name');
+		});
+
+		it('seals a git-host token the same way, keyed by host', async () => {
+			installCustody();
+			const refs = await secretOps.ingestCredentials(deploy(), [{ host: 'github.com', token: 'ghp_secret' }], 'app');
+			assert.deepEqual(refs, [{ host: 'github.com', secret: 'deploy.app.github.com' }]);
+			const row = installed.mock.rows.get('deploy.app.github.com');
+			assert.deepEqual(row.grants, ['app'], 'granted to the deploying component, not global');
+			assert.equal(row.processEnv, false);
+			assert.deepEqual(await secretOps.resolveCredentials(refs, 'app'), [
+				{ host: 'github.com', token: 'ghp_secret', username: undefined },
+			]);
+		});
+
+		it('preserves a git entry username through the seal/resolve round trip', async () => {
+			installCustody();
+			const refs = await secretOps.ingestCredentials(
+				deploy(),
+				[{ host: 'gitlab.com', token: 'glpat', username: 'oauth2' }],
+				'app'
+			);
+			assert.deepEqual(refs, [{ host: 'gitlab.com', secret: 'deploy.app.gitlab.com', username: 'oauth2' }]);
+			assert.deepEqual(await secretOps.resolveCredentials(refs, 'app'), [
+				{ host: 'gitlab.com', token: 'glpat', username: 'oauth2' },
+			]);
+		});
+
+		it('ingests npm and git entries side by side in one deploy', async () => {
+			installCustody();
+			const refs = await secretOps.ingestCredentials(
+				deploy(),
+				[
+					{ registry: gh, token: 'npm_tok', scope: '@org' },
+					{ host: 'github.com', token: 'git_tok' },
+				],
+				'app'
+			);
+			assert.deepEqual(refs, [
+				{ registry: gh, secret: 'deploy.app.npm.pkg.github.com', scope: '@org' },
+				{ host: 'github.com', secret: 'deploy.app.github.com' },
+			]);
+			assert.equal(installed.mock.rows.size, 2, 'each kind gets its own derived row');
 		});
 
 		it('is idempotent on token rotation — same derived row, latest value', async () => {

--- a/unitTests/components/secretOperations.test.js
+++ b/unitTests/components/secretOperations.test.js
@@ -667,8 +667,8 @@ describe('secretOperations', () => {
 	});
 
 	describe('deriveGitSecretName', () => {
-		it('derives a stable name keyed by component and host, following the registry convention', () => {
-			assert.equal(secretOps.deriveGitSecretName('my-app', 'github.com'), 'deploy.my-app.github.com');
+		it('derives a stable name keyed by component and host, with a git segment disambiguating it from a registry secret', () => {
+			assert.equal(secretOps.deriveGitSecretName('my-app', 'github.com'), 'deploy.my-app.git.github.com');
 		});
 
 		it('is identical across the host forms that identify the same host', () => {
@@ -679,7 +679,7 @@ describe('secretOperations', () => {
 		});
 
 		it('sanitizes a port to the set_secret name grammar', () => {
-			assert.equal(secretOps.deriveGitSecretName('app', 'git.example.com:8443'), 'deploy.app.git.example.com_8443');
+			assert.equal(secretOps.deriveGitSecretName('app', 'git.example.com:8443'), 'deploy.app.git.git.example.com_8443');
 		});
 	});
 
@@ -754,8 +754,8 @@ describe('secretOperations', () => {
 		it('seals a git-host token the same way, keyed by host', async () => {
 			installCustody();
 			const refs = await secretOps.ingestCredentials(deploy(), [{ host: 'github.com', token: 'ghp_secret' }], 'app');
-			assert.deepEqual(refs, [{ host: 'github.com', secret: 'deploy.app.github.com' }]);
-			const row = installed.mock.rows.get('deploy.app.github.com');
+			assert.deepEqual(refs, [{ host: 'github.com', secret: 'deploy.app.git.github.com' }]);
+			const row = installed.mock.rows.get('deploy.app.git.github.com');
 			assert.deepEqual(row.grants, ['app'], 'granted to the deploying component, not global');
 			assert.equal(row.processEnv, false);
 			assert.deepEqual(await secretOps.resolveCredentials(refs, 'app'), [
@@ -770,7 +770,7 @@ describe('secretOperations', () => {
 				[{ host: 'gitlab.com', token: 'glpat', username: 'oauth2' }],
 				'app'
 			);
-			assert.deepEqual(refs, [{ host: 'gitlab.com', secret: 'deploy.app.gitlab.com', username: 'oauth2' }]);
+			assert.deepEqual(refs, [{ host: 'gitlab.com', secret: 'deploy.app.git.gitlab.com', username: 'oauth2' }]);
 			assert.deepEqual(await secretOps.resolveCredentials(refs, 'app'), [
 				{ host: 'gitlab.com', token: 'glpat', username: 'oauth2' },
 			]);
@@ -788,7 +788,7 @@ describe('secretOperations', () => {
 			);
 			assert.deepEqual(refs, [
 				{ registry: gh, secret: 'deploy.app.npm.pkg.github.com', scope: '@org' },
-				{ host: 'github.com', secret: 'deploy.app.github.com' },
+				{ host: 'github.com', secret: 'deploy.app.git.github.com' },
 			]);
 			assert.equal(installed.mock.rows.size, 2, 'each kind gets its own derived row');
 		});

--- a/unitTests/server/fastifyRoutes/operationsValidation.test.js
+++ b/unitTests/server/fastifyRoutes/operationsValidation.test.js
@@ -324,12 +324,73 @@ describe('Test operationsValidation module', () => {
 			expect(result.message).to.contain('registryAuth');
 		});
 
-		it('rejects an entry of an unrecognized kind (a git-host entry lands with #1792)', () => {
+		it('accepts a git-host entry, with a token or a secret reference (#1792)', () => {
+			for (const entry of [
+				{ host: 'github.com', token: 'ghp_tok' },
+				{ host: 'github.com', secret: 'GH_TOKEN' },
+				{ host: 'gitlab.com', token: 'glpat', username: 'oauth2' },
+				{ host: 'git.example.com:8443', token: 'tok' },
+			]) {
+				const result = validator.deployComponentValidator({
+					project: 'my_app',
+					package: 'github:myorg/private-app',
+					credentials: [entry],
+				});
+				expect(result, JSON.stringify(entry)).to.be.undefined;
+			}
+		});
+
+		it('accepts npm and git entries in the same credentials array', () => {
 			const result = validator.deployComponentValidator({
 				project: 'my_app',
-				credentials: [{ host: 'github.com', token: 'tok' }],
+				package: 'github:myorg/private-app',
+				credentials: [
+					{ registry: 'https://npm.pkg.github.com', token: 'npm_tok', scope: '@myorg' },
+					{ host: 'github.com', token: 'git_tok' },
+				],
 			});
-			expect(result.message).to.contain('registry');
+			expect(result).to.be.undefined;
+		});
+
+		it('rejects a git entry supplying both a token and a secret', () => {
+			const result = validator.deployComponentValidator({
+				project: 'my_app',
+				credentials: [{ host: 'github.com', token: 'tok', secret: 'GH_TOKEN' }],
+			});
+			expect(result).to.be.ok;
+		});
+
+		it('rejects a git entry supplying neither a token nor a secret', () => {
+			const result = validator.deployComponentValidator({
+				project: 'my_app',
+				credentials: [{ host: 'github.com' }],
+			});
+			expect(result).to.be.ok;
+		});
+
+		it('rejects a host carrying a scheme, path, or userinfo (a credential is matched by host)', () => {
+			for (const host of ['https://github.com', 'github.com/myorg/repo', 'user@github.com', 'git hub.com']) {
+				const result = validator.deployComponentValidator({
+					project: 'my_app',
+					credentials: [{ host, token: 'tok' }],
+				});
+				expect(result, host).to.be.ok;
+			}
+		});
+
+		it('rejects an entry that is neither kind, or that is ambiguously both', () => {
+			const neither = validator.deployComponentValidator({
+				project: 'my_app',
+				credentials: [{ proxy: 'example.com', token: 'tok' }],
+			});
+			expect(neither).to.be.ok;
+			// `registry` and `host` are the kind discriminators; an entry carrying both has no single
+			// kind, so it must not be silently treated as one of them.
+			const both = validator.deployComponentValidator({
+				project: 'my_app',
+				credentials: [{ registry: 'https://npm.pkg.github.com', host: 'github.com', token: 'tok' }],
+			});
+			expect(both).to.be.ok;
 		});
 	});
 

--- a/unitTests/server/fastifyRoutes/operationsValidation.test.js
+++ b/unitTests/server/fastifyRoutes/operationsValidation.test.js
@@ -378,6 +378,22 @@ describe('Test operationsValidation module', () => {
 			}
 		});
 
+		it('rejects an unknown key on an entry (a stray secret-bearing field must not persist)', () => {
+			// allowUnknown is on for the operation, but a credential entry with an extra key would carry
+			// that key through ingest into config/hdb_deployment and replication — reject it here.
+			for (const entry of [
+				{ registry: 'https://npm.pkg.github.com', token: 'tok', password: 'literal' },
+				{ host: 'github.com', secret: 'GH_TOKEN', password: 'literal' },
+			]) {
+				const result = validator.deployComponentValidator({
+					project: 'my_app',
+					package: 'github:myorg/private-app',
+					credentials: [entry],
+				});
+				expect(result, JSON.stringify(entry)).to.be.ok;
+			}
+		});
+
 		it('rejects an entry that is neither kind, or that is ambiguously both', () => {
 			const neither = validator.deployComponentValidator({
 				project: 'my_app',


### PR DESCRIPTION
Implements #1792: a `deploy_component` with a git-reference `package` (`github:my-org/my-app#semver:v1.2.3`) against a **private** repo can now authenticate the `git ls-remote`/`git clone` that npm shells out to — without the token ever reaching disk, argv, the package URL, a lockfile, the operations log, or the replicated operation body.

> **Stacked on #1797** (`deploy-component-credentials-array`), whose `credentials` array this rides on. **Base this PR's merge on #1797 landing first** — the base branch is set to it, so the diff shown here is only what #1792 adds.

## What it does

The credential is a second *kind* in #1797's `credentials` array, discriminated by `host` the way npm entries are by `registry`:

```jsonc
{
  "operation": "deploy_component",
  "project": "my-app",
  "package": "github:my-org/my-app#semver:v1.2.3",
  "credentials": [
    { "host": "github.com", "token": "ghp_..." }          // or { host, secret: "GH_TOKEN" }
  ]
}
```

Ingest, seal-into-`hdb_secret`, grant-check, resolve-at-use, bounded-wait-for-a-replicated-row and replicate-as-reference are #1717's existing paths, unchanged — only the derived secret name (`deploy.<component>.<host>`) and the injection mechanism are new. `username` is optional and defaults to GitHub's `x-access-token` (GitLab wants `oauth2`, Bitbucket `x-token-auth`).

**Injection.** The token stays in the deploying process's memory and is served over a per-deploy Unix socket in a 0700 dir. git is pointed at `components/gitCredentialHelper.js` — a secret-free script that relays git's request over that socket — and the socket dies with the spawn that needed it. There is no transient file at all, which is what makes this stronger than the `.npmrc` (#1717) and SSH-key-file (harper-pro#581) patterns.

## Where to look

- **`components/gitCredentialServer.ts`** (new) — the socket, the env it hands git, and the lifecycle. Wiring is `credential.helper` via `GIT_CONFIG_*` (structured key=value protocol) with `GIT_ASKPASS` as the fallback. **Inherited credential helpers are reset to empty first** — otherwise a machine with `credential.helper=store` would persist this token to `~/.git-credentials` when git reports the successful auth back to its helper chain. That reset only works on git ≥ 2.31 (older git ignores `GIT_CONFIG_*`), so a git-host credential now **requires git ≥ 2.31** and fails closed below it rather than risk the leak. The reset is verified end-to-end against a real clone with both a global and a URL-scoped `store` helper configured.
- **`components/Application.ts`** — `extractApplication` (the `npm pack` spawn is the only one given the credential env; see the `--ignore-scripts` gating below) and `nonInteractiveSpawn` (strips the socket var from every other spawn).
- **`unitTests/components/gitCredentialClone.test.js`** — stands up a real private git remote (`git-http-backend` behind HTTP Basic auth) and deploys from it through the real extract path. The mechanism lives entirely in git and npm, so a stubbed helper would prove nothing; this asserts the clone succeeds *only* because the credential was served from memory, and (the sharpest one) that **no** `store` helper persists the token.

## The two calls I'd most like reviewed

**1. `--ignore-scripts` on credentialed clones.** Packing a git reference is not just a download: npm clones the repo and, if its manifest has a prepare/build/install script, runs `npm install` *inside the clone* and then that script — so the repo's own code **and its dependencies' install scripts** execute during `npm pack`, inheriting that spawn's environment. I verified against real npm that a transitive dependency's `preinstall` sees `HARPER_GIT_CREDENTIAL_SOCKET` and can ask for the token. Closing the socket before the later `npm install` did *not* close this, because it all happens earlier.

So a credentialed clone runs with `--ignore-scripts` **unless** the deploy set `install_allow_scripts` — the operator explicitly asking for that code to run here. That case is allowed and logged, naming the exposure it accepts. **Consequence to ack:** a private git repo that needs a build step must now set `install_allow_scripts: true`, and doing so means its prepare script (and its deps' install scripts) can read the credential.

**2. Windows fails closed.** A named pipe is created with a default security descriptor that can leave it readable by other local users, and the whole confinement argument rests on the 0700 directory a Unix socket sits in. So git-host credentials throw on win32 rather than offering a quietly weaker channel (registry-cred and public-git deploys still work on Windows). A real loss of Windows functionality — say the word if you'd rather ship it with a warning.

## By-design limitations worth a release note (not defects)

- A private repo needing a build step must set `install_allow_scripts: true` (see #1 above).
- A **private git-hosted transitive dependency** of a git-deployed component will fail to install: the socket is closed before `npm install` and only the top-level clone is credentialed. This is the intended security boundary.
- **Pre-existing, not fixed here:** a git-reference deploy runs scripts at pack time *regardless* of `install_allow_scripts` (that flag only ever reached the `npm install` spawn), so public git deploys already run on-node code with scripts nominally "off". Scoping `--ignore-scripts` to credentialed clones keeps this PR's blast radius at zero; the general fix deserves its own issue.

## Tests

New: git-kind ingest/resolution (grant-check → 403, no-custody → 503, unrecognized-kind guard, no-custody-token-is-not-persistable), the helper's two protocols as a real child process (incl. a localized prompt), env-scoping (the install spawn sees no credential wiring), the socket lifecycle + 64KB request cap, https-only + newline refusal, the git-version gate, and the real authenticated clone (which also proves the prepare script does not run while the credential is reachable, that it does under `install_allow_scripts`, and that no `store` helper persists the token).

`test:unit:main` 3462 passing / 10 failing — the 10 are a pre-existing `globalIsolation` fixture failure in a worktree (missing fixture `node_modules`; identical on the base commit). `test:unit:resources` green. `integrationTests/deploy` 24/0.

## Review notes

Cross-model review (Gemini + Codex, adjudicated) drove real hardening: the clone-time install-script exposure and the Windows pipe issue (both fixed), plus a cleartext-http downgrade, a git-<2.31 persistence gap, a newline-in-resolved-token injection, unknown-keys persisting, an unbounded socket read, and a temp-dir leak — all fixed in commits `849e6a6`/`4b9bb3c0`/`3566c21`. A Harper-domain pass then traced the leak/replication paths and found no remaining blockers. Two claims were false positives (`__dirname`/`require` "break under ESM" — the package is CommonJS, verified against dist).

🤖 Generated by Claude Opus 4.8 (an LLM) — please review accordingly.