### PR TITLE
fix: ensure CLI failure paths exit non-zero, including operation timeouts

### DIFF
--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -102,7 +102,11 @@ function versionSupportsStreamingDeploy(version: unknown): boolean {
  */
 async function targetSupportsStreamingDeploy(options: any): Promise<boolean> {
 	try {
-		const probeOptions = { ...options, headers: { ...options.headers, Accept: 'application/json' } };
+		const probeOptions = {
+			...options,
+			headers: { ...options.headers, Accept: 'application/json' },
+			timeout: CLI_OPERATION_TIMEOUT_MS,
+		};
 		delete probeOptions.streamResponse;
 		const response = await httpRequest(probeOptions, { operation: 'registration_info' });
 		if (response.statusCode !== 200 || !response.body) return true;
@@ -289,7 +293,7 @@ async function cliOperations(req: any, skipResponseLog = false) {
 				if (tokens.refresh_token && isJWTExpired(tokens.operation_token)) {
 					console.error('Operation token expired, attempting to refresh...');
 					try {
-						const refreshOptions = { ...options };
+						const refreshOptions = { ...options, timeout: CLI_OPERATION_TIMEOUT_MS };
 						refreshOptions.headers = { ...options.headers, Authorization: `Bearer ${tokens.refresh_token}` };
 						const refreshResponse = await httpRequest(refreshOptions, {
 							operation: 'refresh_operation_token',

--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -69,10 +69,16 @@ const STREAMING_DEPLOY_MIN_MINOR = 1;
 // separate env vars to keep in sync.
 const DEFAULT_CLI_OPERATION_TIMEOUT_MS = 60000;
 const DEFAULT_SSE_OPERATION_TIMEOUT_MS = 600000; // 10 minutes
+// Largest delay Node's setTimeout accepts; a larger value is silently coerced and fires in
+// ~1ms instead of the intended delay, so out-of-range input is treated the same as any other
+// invalid input below (falls back to DEFAULT_CLI_OPERATION_TIMEOUT_MS) rather than passed through.
+const MAX_CLI_OPERATION_TIMEOUT_MS = 2147483647; // 2^31 - 1
 const RAW_CLI_OPERATION_TIMEOUT = (process.env.HARPER_CLI_TIMEOUT_MS || process.env.CLI_TIMEOUT_MS)?.trim();
 const PARSED_CLI_OPERATION_TIMEOUT = RAW_CLI_OPERATION_TIMEOUT ? Number(RAW_CLI_OPERATION_TIMEOUT) : NaN;
 const CLI_OPERATION_TIMEOUT_OVERRIDE_MS =
-	Number.isInteger(PARSED_CLI_OPERATION_TIMEOUT) && PARSED_CLI_OPERATION_TIMEOUT >= 0
+	Number.isInteger(PARSED_CLI_OPERATION_TIMEOUT) &&
+	PARSED_CLI_OPERATION_TIMEOUT >= 0 &&
+	PARSED_CLI_OPERATION_TIMEOUT <= MAX_CLI_OPERATION_TIMEOUT_MS
 		? PARSED_CLI_OPERATION_TIMEOUT
 		: undefined;
 const CLI_OPERATION_TIMEOUT_MS = CLI_OPERATION_TIMEOUT_OVERRIDE_MS ?? DEFAULT_CLI_OPERATION_TIMEOUT_MS;

--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -56,6 +56,14 @@ const TRANSPORT_ONLY_FIELDS = new Set([
 const STREAMING_DEPLOY_MIN_MAJOR = 5;
 const STREAMING_DEPLOY_MIN_MINOR = 1;
 
+// Idle-socket timeout for CLI Op-API requests: no traffic (in either direction) for this long
+// means the target is unreachable or wedged. Resets on any activity, so a slow-but-active
+// upload/deploy is unaffected — only a fully silent connection trips it. Overridable for
+// operations against known-slow targets.
+const DEFAULT_CLI_OPERATION_TIMEOUT_MS = 60000;
+const CLI_OPERATION_TIMEOUT_MS =
+	Number(process.env.HARPER_CLI_TIMEOUT_MS || process.env.CLI_TIMEOUT_MS) || DEFAULT_CLI_OPERATION_TIMEOUT_MS;
+
 /**
  * Parses a Harper version string (e.g. "5.0.31", "5.1.0-beta.2") and reports whether the
  * server is new enough to accept the multipart + SSE streaming deploy. Unparseable input
@@ -252,6 +260,7 @@ async function cliOperations(req: any, skipResponseLog = false) {
 		};
 		options.method = 'POST';
 		options.headers = { 'Content-Type': 'application/json' };
+		options.timeout = CLI_OPERATION_TIMEOUT_MS;
 		if (target?.username) {
 			options.headers.Authorization = `Basic ${Buffer.from(`${target.username}:${target.password}`).toString('base64')}`;
 		} else if (allCredentials) {

--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -61,8 +61,12 @@ const STREAMING_DEPLOY_MIN_MINOR = 1;
 // upload/deploy is unaffected — only a fully silent connection trips it. Overridable for
 // operations against known-slow targets.
 const DEFAULT_CLI_OPERATION_TIMEOUT_MS = 60000;
+const RAW_CLI_OPERATION_TIMEOUT = (process.env.HARPER_CLI_TIMEOUT_MS || process.env.CLI_TIMEOUT_MS)?.trim();
+const PARSED_CLI_OPERATION_TIMEOUT = RAW_CLI_OPERATION_TIMEOUT ? Number(RAW_CLI_OPERATION_TIMEOUT) : NaN;
 const CLI_OPERATION_TIMEOUT_MS =
-	Number(process.env.HARPER_CLI_TIMEOUT_MS || process.env.CLI_TIMEOUT_MS) || DEFAULT_CLI_OPERATION_TIMEOUT_MS;
+	Number.isInteger(PARSED_CLI_OPERATION_TIMEOUT) && PARSED_CLI_OPERATION_TIMEOUT >= 0
+		? PARSED_CLI_OPERATION_TIMEOUT
+		: DEFAULT_CLI_OPERATION_TIMEOUT_MS;
 
 /**
  * Parses a Harper version string (e.g. "5.0.31", "5.1.0-beta.2") and reports whether the

--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -60,13 +60,23 @@ const STREAMING_DEPLOY_MIN_MINOR = 1;
 // means the target is unreachable or wedged. Resets on any activity, so a slow-but-active
 // upload/deploy is unaffected — only a fully silent connection trips it. Overridable for
 // operations against known-slow targets.
+//
+// SSE-based operations (see SSE_OPERATIONS above) get a much longer default: a long-running
+// deploy_component can go quiet between phase events (e.g. a slow replicate/load step) for well
+// over a minute even though the connection is perfectly healthy, so the generic 60s default is
+// too tight for this one. HARPER_CLI_TIMEOUT_MS/CLI_TIMEOUT_MS, when set, overrides BOTH
+// defaults uniformly — it's a single "I know what timeout I want" escape hatch rather than two
+// separate env vars to keep in sync.
 const DEFAULT_CLI_OPERATION_TIMEOUT_MS = 60000;
+const DEFAULT_SSE_OPERATION_TIMEOUT_MS = 600000; // 10 minutes
 const RAW_CLI_OPERATION_TIMEOUT = (process.env.HARPER_CLI_TIMEOUT_MS || process.env.CLI_TIMEOUT_MS)?.trim();
 const PARSED_CLI_OPERATION_TIMEOUT = RAW_CLI_OPERATION_TIMEOUT ? Number(RAW_CLI_OPERATION_TIMEOUT) : NaN;
-const CLI_OPERATION_TIMEOUT_MS =
+const CLI_OPERATION_TIMEOUT_OVERRIDE_MS =
 	Number.isInteger(PARSED_CLI_OPERATION_TIMEOUT) && PARSED_CLI_OPERATION_TIMEOUT >= 0
 		? PARSED_CLI_OPERATION_TIMEOUT
-		: DEFAULT_CLI_OPERATION_TIMEOUT_MS;
+		: undefined;
+const CLI_OPERATION_TIMEOUT_MS = CLI_OPERATION_TIMEOUT_OVERRIDE_MS ?? DEFAULT_CLI_OPERATION_TIMEOUT_MS;
+const SSE_OPERATION_TIMEOUT_MS = CLI_OPERATION_TIMEOUT_OVERRIDE_MS ?? DEFAULT_SSE_OPERATION_TIMEOUT_MS;
 
 /**
  * Parses a Harper version string (e.g. "5.0.31", "5.1.0-beta.2") and reports whether the
@@ -264,7 +274,7 @@ async function cliOperations(req: any, skipResponseLog = false) {
 		};
 		options.method = 'POST';
 		options.headers = { 'Content-Type': 'application/json' };
-		options.timeout = CLI_OPERATION_TIMEOUT_MS;
+		options.timeout = SSE_OPERATIONS.has(req.operation) ? SSE_OPERATION_TIMEOUT_MS : CLI_OPERATION_TIMEOUT_MS;
 		if (target?.username) {
 			options.headers.Authorization = `Basic ${Buffer.from(`${target.username}:${target.password}`).toString('base64')}`;
 		} else if (allCredentials) {

--- a/bin/status.ts
+++ b/bin/status.ts
@@ -61,5 +61,5 @@ async function status() {
 	}
 
 	console.log(YAML.stringify(status));
-	process.exit();
+	process.exit(0);
 }

--- a/unitTests/bin/cliOperations.test.js
+++ b/unitTests/bin/cliOperations.test.js
@@ -604,6 +604,48 @@ describe('cliOperations', () => {
 			assert.strictEqual(capturedOptions.timeout, 600000);
 		});
 
+		it('uses the non-SSE timeout for the streaming-deploy version probe, not the 10-minute SSE timeout', async () => {
+			let probeOptions;
+			commonUtilsModule.httpRequest = async (options, req) => {
+				if (req.operation === 'registration_info') {
+					probeOptions = options;
+					return { statusCode: 200, body: JSON.stringify({ version: '5.1.7' }) };
+				}
+				return sseDoneResponse({ message: 'Successfully deployed', success: true });
+			};
+
+			await cliOperationsModule.cliOperations(
+				{ operation: 'deploy_component', package: '@scope/widget', project: 'widget', target: 'example.com' },
+				true
+			);
+
+			assert.strictEqual(probeOptions.timeout, 60000);
+		});
+
+		it('uses the non-SSE timeout for an operation-token refresh, not the 10-minute SSE timeout', async () => {
+			tokenAuthModule.isJWTExpired = (token) => token === 'expired-token';
+			saveCredentials(target, { operation_token: 'expired-token', refresh_token: 'refresh-token' });
+
+			let refreshOptions;
+			commonUtilsModule.httpRequest = async (options, req) => {
+				if (req.operation === 'registration_info') {
+					return { statusCode: 200, body: JSON.stringify({ version: '5.1.7' }) };
+				}
+				if (req.operation === 'refresh_operation_token') {
+					refreshOptions = options;
+					return { statusCode: 200, body: JSON.stringify({ operation_token: 'new-token' }) };
+				}
+				return sseDoneResponse({ message: 'Successfully deployed', success: true });
+			};
+
+			await cliOperationsModule.cliOperations(
+				{ operation: 'deploy_component', package: '@scope/widget', project: 'widget', target: 'example.com' },
+				true
+			);
+
+			assert.strictEqual(refreshOptions.timeout, 60000);
+		});
+
 		it('HARPER_CLI_TIMEOUT_MS overrides the non-SSE default', async () => {
 			const originalEnv = process.env.HARPER_CLI_TIMEOUT_MS;
 			process.env.HARPER_CLI_TIMEOUT_MS = '5000';

--- a/unitTests/bin/cliOperations.test.js
+++ b/unitTests/bin/cliOperations.test.js
@@ -549,6 +549,50 @@ describe('cliOperations', () => {
 			assert.strictEqual(typeof capturedOptions.timeout, 'number');
 			assert.ok(capturedOptions.timeout > 0);
 		});
+
+		it('exits non-zero with a clear message (not a bare "aborted") when an SSE deploy_component times out mid-stream', async () => {
+			commonUtilsModule.httpRequest = async (options, req) => {
+				if (req.operation === 'registration_info') {
+					return { statusCode: 200, body: JSON.stringify({ version: '5.1.7' }) };
+				}
+				// Simulate the real streamed response: headers arrive and one phase event
+				// flows, then the connection goes idle. httpRequest's own timeout handling
+				// (common_utils.ts) destroys this response with its descriptive ETIMEDOUT
+				// error — mirror that here rather than letting Node manufacture a generic
+				// "aborted" error, since that manufacturing only happens on a real socket.
+				let pushed = false;
+				const response = new Readable({
+					read() {
+						if (!pushed) {
+							pushed = true;
+							this.push('event: phase\ndata: {"phase":"prepare"}\n\n');
+							return;
+						}
+						const err = new Error('Request timed out after 600000ms with no response from the server');
+						err.code = 'ETIMEDOUT';
+						this.destroy(err);
+					},
+				});
+				response.statusCode = 200;
+				response.headers = { 'content-type': 'text/event-stream' };
+				return response;
+			};
+
+			await cliOperationsModule.cliOperations(
+				{ operation: 'deploy_component', package: '@scope/widget', project: 'widget', target: 'example.com' },
+				true
+			);
+
+			assert.deepStrictEqual(exitCalls, [1]);
+			assert.ok(
+				consoleErrorLines.some((line) => line.includes('timed out')),
+				`expected a timeout message on stderr, got: ${consoleErrorLines}`
+			);
+			assert.ok(
+				!consoleErrorLines.some((line) => /^error:\s*aborted\s*$/i.test(line.trim())),
+				`should not surface a bare "aborted" message, got: ${consoleErrorLines}`
+			);
+		});
 	});
 
 	describe('operation timeout selection', () => {

--- a/unitTests/bin/cliOperations.test.js
+++ b/unitTests/bin/cliOperations.test.js
@@ -739,5 +739,30 @@ describe('cliOperations', () => {
 				reloadCliOperations();
 			}
 		});
+
+		it('HARPER_CLI_TIMEOUT_MS above the 32-bit setTimeout ceiling falls back to the default instead of the raw value', async () => {
+			const originalEnv = process.env.HARPER_CLI_TIMEOUT_MS;
+			// Exceeds 2147483647 (2^31 - 1): Node's setTimeout silently coerces values above this
+			// and fires almost immediately, so out-of-range input must fall back like any other
+			// invalid input rather than being passed through as the raw oversized value.
+			process.env.HARPER_CLI_TIMEOUT_MS = '9999999999';
+			try {
+				const freshModule = reloadCliOperations();
+
+				let capturedOptions;
+				commonUtilsModule.httpRequest = async (options) => {
+					capturedOptions = options;
+					return { statusCode: 200, body: JSON.stringify({ success: true }) };
+				};
+
+				await freshModule.cliOperations({ operation: 'test', target: 'example.com' }, true);
+
+				assert.strictEqual(capturedOptions.timeout, 60000);
+			} finally {
+				if (originalEnv === undefined) delete process.env.HARPER_CLI_TIMEOUT_MS;
+				else process.env.HARPER_CLI_TIMEOUT_MS = originalEnv;
+				reloadCliOperations();
+			}
+		});
 	});
 });

--- a/unitTests/bin/cliOperations.test.js
+++ b/unitTests/bin/cliOperations.test.js
@@ -550,4 +550,108 @@ describe('cliOperations', () => {
 			assert.ok(capturedOptions.timeout > 0);
 		});
 	});
+
+	describe('operation timeout selection', () => {
+		const target = 'https://example.com:9925/';
+
+		// Streams an SSE `done` event so the modern (>= 5.1) deploy path resolves.
+		const sseDoneResponse = (result) =>
+			Object.assign(Readable.from([`event: done\ndata: ${JSON.stringify({ result })}\n\n`]), {
+				statusCode: 200,
+				headers: { 'content-type': 'text/event-stream' },
+			});
+
+		// Forces a fresh module instance so its module-level timeout constants are recomputed
+		// against the current process.env (they're only evaluated once, at first require).
+		function reloadCliOperations() {
+			const resolved = require.resolve('#src/bin/cliOperations');
+			delete require.cache[resolved];
+			return require('#src/bin/cliOperations');
+		}
+
+		beforeEach(() => {
+			saveCredentials(target, { operation_token: 'valid-token', refresh_token: 'refresh-token' });
+			tokenAuthModule.isJWTExpired = () => false;
+		});
+
+		it('defaults to 60000ms (60s) for non-SSE operations', async () => {
+			let capturedOptions;
+			commonUtilsModule.httpRequest = async (options) => {
+				capturedOptions = options;
+				return { statusCode: 200, body: JSON.stringify({ success: true }) };
+			};
+
+			await cliOperationsModule.cliOperations({ operation: 'test', target: 'example.com' }, true);
+
+			assert.strictEqual(capturedOptions.timeout, 60000);
+		});
+
+		it('defaults to 600000ms (10 min) for SSE-based operations like deploy_component', async () => {
+			let capturedOptions;
+			commonUtilsModule.httpRequest = async (options, req) => {
+				if (req.operation === 'registration_info') {
+					return { statusCode: 200, body: JSON.stringify({ version: '5.1.7' }) };
+				}
+				capturedOptions = options;
+				return sseDoneResponse({ message: 'Successfully deployed', success: true });
+			};
+
+			await cliOperationsModule.cliOperations(
+				{ operation: 'deploy_component', package: '@scope/widget', project: 'widget', target: 'example.com' },
+				true
+			);
+
+			assert.strictEqual(capturedOptions.timeout, 600000);
+		});
+
+		it('HARPER_CLI_TIMEOUT_MS overrides the non-SSE default', async () => {
+			const originalEnv = process.env.HARPER_CLI_TIMEOUT_MS;
+			process.env.HARPER_CLI_TIMEOUT_MS = '5000';
+			try {
+				const freshModule = reloadCliOperations();
+
+				let capturedOptions;
+				commonUtilsModule.httpRequest = async (options) => {
+					capturedOptions = options;
+					return { statusCode: 200, body: JSON.stringify({ success: true }) };
+				};
+
+				await freshModule.cliOperations({ operation: 'test', target: 'example.com' }, true);
+
+				assert.strictEqual(capturedOptions.timeout, 5000);
+			} finally {
+				if (originalEnv === undefined) delete process.env.HARPER_CLI_TIMEOUT_MS;
+				else process.env.HARPER_CLI_TIMEOUT_MS = originalEnv;
+				reloadCliOperations();
+			}
+		});
+
+		it('HARPER_CLI_TIMEOUT_MS overrides the SSE default too (single override for both paths)', async () => {
+			const originalEnv = process.env.HARPER_CLI_TIMEOUT_MS;
+			process.env.HARPER_CLI_TIMEOUT_MS = '5000';
+			try {
+				const freshModule = reloadCliOperations();
+
+				let capturedOptions;
+				commonUtilsModule.httpRequest = async (options, req) => {
+					if (req.operation === 'registration_info') {
+						return { statusCode: 200, body: JSON.stringify({ version: '5.1.7' }) };
+					}
+					capturedOptions = options;
+					return sseDoneResponse({ message: 'Successfully deployed', success: true });
+				};
+
+				await freshModule.cliOperations(
+					{ operation: 'deploy_component', package: '@scope/widget', project: 'widget', target: 'example.com' },
+					true
+				);
+
+				assert.strictEqual(capturedOptions.timeout, 5000);
+			} finally {
+				if (originalEnv === undefined) delete process.env.HARPER_CLI_TIMEOUT_MS;
+				else process.env.HARPER_CLI_TIMEOUT_MS = originalEnv;
+				reloadCliOperations();
+			}
+		});
+	});
 });

--- a/unitTests/bin/cliOperations.test.js
+++ b/unitTests/bin/cliOperations.test.js
@@ -468,4 +468,86 @@ describe('cliOperations', () => {
 			);
 		});
 	});
+
+	describe('exit codes on failure', () => {
+		const target = 'https://example.com:9925/';
+		let originalExit;
+		let originalConsoleError;
+		let exitCalls;
+		let consoleErrorLines;
+
+		beforeEach(() => {
+			saveCredentials(target, { operation_token: 'valid-token', refresh_token: 'refresh-token' });
+			tokenAuthModule.isJWTExpired = () => false;
+
+			exitCalls = [];
+			originalExit = process.exit;
+			process.exit = (code) => {
+				exitCalls.push(code);
+			};
+
+			consoleErrorLines = [];
+			originalConsoleError = console.error;
+			console.error = (...args) => {
+				consoleErrorLines.push(args.join(' '));
+			};
+		});
+
+		afterEach(() => {
+			process.exit = originalExit;
+			console.error = originalConsoleError;
+		});
+
+		it('exits non-zero with a clear message when the request times out', async () => {
+			commonUtilsModule.httpRequest = async () => {
+				const err = new Error('Request timed out after 60000ms with no response from the server');
+				err.code = 'ETIMEDOUT';
+				throw err;
+			};
+
+			await cliOperationsModule.cliOperations({ operation: 'test', target: 'example.com' }, true);
+
+			assert.deepStrictEqual(exitCalls, [1]);
+			assert.ok(
+				consoleErrorLines.some((line) => line.includes('timed out')),
+				`expected a timeout message on stderr, got: ${consoleErrorLines}`
+			);
+		});
+
+		it('exits non-zero on a generic connection error', async () => {
+			commonUtilsModule.httpRequest = async () => {
+				const err = new Error('connect ECONNREFUSED 127.0.0.1:9925');
+				err.code = 'ECONNREFUSED';
+				throw err;
+			};
+
+			await cliOperationsModule.cliOperations({ operation: 'test', target: 'example.com' }, true);
+
+			assert.deepStrictEqual(exitCalls, [1]);
+		});
+
+		it('exits non-zero when the server returns a non-2xx status', async () => {
+			commonUtilsModule.httpRequest = async () => ({
+				statusCode: 500,
+				body: JSON.stringify({ error: 'boom' }),
+			});
+
+			await cliOperationsModule.cliOperations({ operation: 'test', target: 'example.com' }, true);
+
+			assert.deepStrictEqual(exitCalls, [1]);
+		});
+
+		it('applies a default idle-socket timeout to the request options', async () => {
+			let capturedOptions;
+			commonUtilsModule.httpRequest = async (options) => {
+				capturedOptions = options;
+				return { statusCode: 200, body: JSON.stringify({ success: true }) };
+			};
+
+			await cliOperationsModule.cliOperations({ operation: 'test', target: 'example.com' }, true);
+
+			assert.strictEqual(typeof capturedOptions.timeout, 'number');
+			assert.ok(capturedOptions.timeout > 0);
+		});
+	});
 });

--- a/unitTests/utility/common_utils.test.js
+++ b/unitTests/utility/common_utils.test.js
@@ -624,4 +624,57 @@ describe('Test common_utils module', () => {
 			);
 		});
 	});
+
+	describe('Test httpRequest timeout mid-stream (SSE-style streamResponse)', () => {
+		const http = require('node:http');
+		let server, port;
+
+		before((done) => {
+			// Sends headers plus one event, then goes silent forever — mirrors a wedged
+			// deploy_component whose server stops emitting SSE phase events mid-stream.
+			server = http.createServer((req, res) => {
+				res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+				res.write('event: phase\ndata: {"phase":"prepare"}\n\n');
+			});
+			server.listen(0, '127.0.0.1', () => {
+				port = server.address().port;
+				done();
+			});
+		});
+
+		after((done) => {
+			server.close(done);
+		});
+
+		it('surfaces the same clear "timed out" message on the response stream, not a bare "aborted"', async () => {
+			const response = await cu.httpRequest(
+				{
+					protocol: 'http:',
+					hostname: '127.0.0.1',
+					port,
+					// The CLI always POSTs Op-API requests (see cliOperations.ts); matching that
+					// here matters because a GET request whose body httpRequest still writes
+					// causes an unrelated, immediate ECONNRESET from Node's http server.
+					method: 'POST',
+					headers: { Accept: 'text/event-stream' },
+					timeout: 50,
+					streamResponse: true,
+				},
+				{}
+			);
+
+			const chunks = [];
+			let caught;
+			try {
+				for await (const chunk of response) chunks.push(chunk);
+			} catch (err) {
+				caught = err;
+			}
+
+			assert.ok(caught, 'expected the response stream to error once the idle timeout fires');
+			assert.strictEqual(caught.code, 'ETIMEDOUT');
+			assert.match(caught.message, /timed out after \d+ms/i);
+			assert.doesNotMatch(caught.message, /^aborted$/i);
+		});
+	});
 });

--- a/unitTests/utility/common_utils.test.js
+++ b/unitTests/utility/common_utils.test.js
@@ -585,4 +585,43 @@ describe('Test common_utils module', () => {
 			expect(Number.isNaN(cu.convertToMS('abc'))).to.equal(true);
 		});
 	});
+
+	describe('Test httpRequest timeout', () => {
+		const http = require('node:http');
+		let server, port;
+
+		before((done) => {
+			// Never responds, so the client-side idle timeout is the only thing that can end the request.
+			server = http.createServer(() => {});
+			server.listen(0, '127.0.0.1', () => {
+				port = server.address().port;
+				done();
+			});
+		});
+
+		after((done) => {
+			server.close(done);
+		});
+
+		it('rejects with a clear ETIMEDOUT error when the server never responds', async () => {
+			await assert.rejects(
+				cu.httpRequest(
+					{
+						protocol: 'http:',
+						hostname: '127.0.0.1',
+						port,
+						method: 'POST',
+						headers: { 'Content-Type': 'application/json' },
+						timeout: 50,
+					},
+					{}
+				),
+				(err) => {
+					expect(err.code).to.equal('ETIMEDOUT');
+					expect(err.message).to.match(/timed out/i);
+					return true;
+				}
+			);
+		});
+	});
 });

--- a/unitTests/utility/common_utils.test.js
+++ b/unitTests/utility/common_utils.test.js
@@ -617,8 +617,8 @@ describe('Test common_utils module', () => {
 					{}
 				),
 				(err) => {
-					expect(err.code).to.equal('ETIMEDOUT');
-					expect(err.message).to.match(/timed out/i);
+					assert.strictEqual(err.code, 'ETIMEDOUT');
+					assert.match(err.message, /timed out/i);
 					return true;
 				}
 			);

--- a/utility/common_utils.ts
+++ b/utility/common_utils.ts
@@ -789,6 +789,19 @@ export function httpRequest(options: any, data: any): Promise<http.IncomingMessa
 			reject(err);
 		});
 
+		// `options.timeout` arms Node's socket idle timer (reset by any traffic in either
+		// direction), so a slow-but-active upload/download or a long-running deploy phase
+		// won't trip it — only a connection that goes fully silent does. Node only emits the
+		// event; it doesn't abort the request, so we destroy it ourselves to turn a stuck
+		// request into a rejected promise instead of a silent hang.
+		if (options.timeout) {
+			req.on('timeout', () => {
+				const err: any = new Error(`Request timed out after ${options.timeout}ms with no response from the server`);
+				err.code = 'ETIMEDOUT';
+				req.destroy(err);
+			});
+		}
+
 		// A Readable body is streamed with chunked transfer-encoding (e.g. multipart deploys
 		// over the 2 GB Buffer cap); .pipe also takes care of closing the request when the
 		// source ends. Everything else is sent as a single write.

--- a/utility/common_utils.ts
+++ b/utility/common_utils.ts
@@ -766,11 +766,16 @@ export function httpRequest(options: any, data: any): Promise<http.IncomingMessa
 		options = { ...options };
 		delete options.streamResponse;
 	}
+	// Tracks the resolved response for a streamed request so a subsequent idle timeout can
+	// destroy it directly with our descriptive error (see the `timeout` handler below).
+	let streamedResponse: (http.IncomingMessage & { body?: string }) | undefined;
+
 	return new Promise((resolve, reject) => {
 		const req = client.request(options, (response: http.IncomingMessage & { body?: string }) => {
 			if (streamResponse) {
 				// Hand the raw stream to the caller; do not setEncoding so binary-safe consumers
 				// (or SSE parsers that prefer Buffers) still work.
+				streamedResponse = response;
 				resolve(response);
 				return;
 			}
@@ -798,6 +803,14 @@ export function httpRequest(options: any, data: any): Promise<http.IncomingMessa
 			req.on('timeout', () => {
 				const err: any = new Error(`Request timed out after ${options.timeout}ms with no response from the server`);
 				err.code = 'ETIMEDOUT';
+				// For a streamed response (e.g. SSE) whose headers already arrived, the promise
+				// above has already resolved — destroying only `req` lets Node's own socket-close
+				// handling (_http_client.js socketCloseListener) manufacture its own generic
+				// "aborted"/ECONNRESET error on the response instead, discarding this descriptive
+				// one. Destroy the response first, with our error, so whoever is reading it
+				// directly (e.g. the SSE parser's `for await`) sees the same clear "timed out"
+				// message a non-streamed timeout produces.
+				if (streamedResponse && !streamedResponse.destroyed) streamedResponse.destroy(err);
 				req.destroy(err);
 			});
 		}


### PR DESCRIPTION
## Summary
- Fixes a bare `process.exit()` in `bin/status.ts` (exits 0 with no explicit code — was the one such spot in `bin/`).
- Adds a client-side idle-socket timeout to the CLI's Op-API HTTP requests (`utility/common_utils.ts` `httpRequest`, wired up with a default in `bin/cliOperations.ts`), so a request against an unreachable/wedged target now fails fast with a clear stderr message and exit code `1` instead of hanging indefinitely.

## Why
CI/CD pipelines check the CLI's exit code; a hang (no timeout existed before this change) or a bare `process.exit()` reads as success and lets a broken pipeline step continue silently.

## Details
- The timeout (`options.timeout`, default 60s, overridable via `HARPER_CLI_TIMEOUT_MS`/`CLI_TIMEOUT_MS`) is an **idle** timeout — it resets on any traffic in either direction, so a slow-but-active upload or a long-running deploy phase isn't affected, only a connection that goes fully silent.
- On timeout, the request is destroyed with an `ETIMEDOUT`-coded error, which flows through `cliOperations.ts`'s existing catch-all (`console.error` + `process.exit(1)`) — no new error-code taxonomy needed.
- Audited all `process.exit(` call sites in `bin/`; the `status.ts` bare call was the only one missing an explicit code. All other failure paths (missing Harper/socket, non-2xx response, connection errors, etc.) already exited `1` correctly.

## Test coverage
- `unitTests/utility/common_utils.test.js`: `httpRequest` rejects with a clear `ETIMEDOUT` error when a real local server never responds.
- `unitTests/bin/cliOperations.test.js`: new `exit codes on failure` suite — asserts `process.exit(1)` + a stderr message for the timeout case, a generic connection error, and a non-2xx server response; asserts the default timeout is applied to request options.
- Manually verified end-to-end against a black-holed address (timeout → exit 1) and a refused connection (`ECONNREFUSED` → exit 1).

Refs [harper#584](https://github.com/HarperFast/harper/issues/584).

Generated with [Claude Code](https://claude.com/claude-code) (Sonnet 5).