### PR TITLE
fix: expand ~/... install destination to an absolute path immediately after input

### DIFF
--- a/unitTests/install/installer.test.js
+++ b/unitTests/install/installer.test.js
@@ -572,3 +572,30 @@ describe('applyInstallModeDefaults', () => {
 		assert.equal(args.node_hostname, 'real-node.example.com');
 	});
 });
+
+// harper#672: the install destination prompt must expand `~/...` to an absolute path immediately
+// so every downstream consumer (mountHdb, createBootPropertiesFile, createConfigFile) agrees on the
+// same location, rather than each one independently (and inconsistently) trying to expand it.
+// `resolveInstallDestination` is the single funnel both the prompt's `filter` and the cmd/env/config
+// override path route through - tested directly against the real exported helper (no rewire).
+describe('resolveInstallDestination', () => {
+	const { resolveInstallDestination } = require('#js/utility/install/installer');
+
+	it('expands a ~/... destination to an absolute path under the home directory', () => {
+		assert.equal(resolveInstallDestination('~/dev/hdb'), path.join(os.homedir(), 'dev', 'hdb'));
+	});
+
+	it('leaves an absolute /... destination unchanged', () => {
+		assert.equal(resolveInstallDestination('/opt/harperdb'), '/opt/harperdb');
+	});
+
+	it('leaves a bare relative destination unchanged (preserves cwd-relative semantics)', () => {
+		assert.equal(resolveInstallDestination('hdb'), 'hdb');
+		assert.equal(resolveInstallDestination('nested/hdb'), 'nested/hdb');
+	});
+
+	it('leaves the default install destination (already absolute) unchanged', () => {
+		const defaultRoot = path.join(os.homedir(), 'hdb');
+		assert.equal(resolveInstallDestination(defaultRoot), defaultRoot);
+	});
+});

--- a/utility/install/installer.ts
+++ b/utility/install/installer.ts
@@ -261,7 +261,7 @@ async function installPrompts(promptOverride) {
 			default: DEFAULT_HDB_ROOT,
 			// Runs before validate, so the existing-install check below (and everything after it)
 			// sees the same expanded path rather than a literal, unresolved `~/...` string.
-			filter: (value) => resolveInstallDestination(value),
+			filter: resolveInstallDestination,
 			validate: async (value) => {
 				if (checkForEmptyValue(value)) return checkForEmptyValue(value);
 				if (await fs.pathExists(path.join(value, 'system', 'hdb_user.mdb')))

--- a/utility/install/installer.ts
+++ b/utility/install/installer.ts
@@ -27,6 +27,7 @@ import * as globalSchema from '../globalSchema.ts';
 import { promisify } from 'util';
 const pSchemaToGlobal = promisify(globalSchema.setSchemaDataToGlobal);
 import * as keys from '../../security/keys.ts';
+import { resolveConfiguredPath } from '../../config/componentEnvPrepass.ts';
 
 // Removes the color formatting that was being applied to the prompt answer.
 const PROMPT_ANSWER_TRANSFORMER = (answer) => answer;
@@ -84,8 +85,19 @@ let ignoreExisting = false;
  * This module orchestrates the installation of Harper.
  */
 
-export { install, updateConfigEnv, setIgnoreExisting };
+export { install, updateConfigEnv, setIgnoreExisting, resolveInstallDestination };
 install.createSuperUser = createSuperUser;
+
+/**
+ * Expands a `~/...` install destination to an absolute path so every downstream consumer
+ * (directory creation, boot props file, harperdb-config.yaml) resolves the same location instead
+ * of each independently (and inconsistently) trying to expand it (harper#672). Absolute paths and
+ * plain relative paths (no `~`, no leading `/`) are returned unchanged, preserving the existing
+ * cwd-relative behavior for relative paths.
+ */
+function resolveInstallDestination(value) {
+	return resolveConfiguredPath(value, undefined) ?? value;
+}
 
 /**
  * Calls all the functions that are needed to install Harper.
@@ -237,6 +249,9 @@ async function installPrompts(promptOverride) {
 			name: hdbTerms.INSTALL_PROMPTS.ROOTPATH,
 			prefix: PROMPT_PREFIX,
 			default: DEFAULT_HDB_ROOT,
+			// Runs before validate, so the existing-install check below (and everything after it)
+			// sees the same expanded path rather than a literal, unresolved `~/...` string.
+			filter: (value) => resolveInstallDestination(value),
 			validate: async (value) => {
 				if (checkForEmptyValue(value)) return checkForEmptyValue(value);
 				if (await fs.pathExists(path.join(value, 'system', 'hdb_user.mdb')))
@@ -302,16 +317,22 @@ async function installPrompts(promptOverride) {
 	];
 
 	const answers = await inquirer.prompt(promptsSchema);
-	// If there are no answers all the prompts have been overridden.
-	if (Object.keys(answers).length === 0) {
-		return promptOverride;
-	}
-
 	// Loop through the answers and if they dont exist in the promptOverride obj add them.
+	// (No-op when all prompts were overridden and answers is empty.)
 	for (const param in answers) {
 		if (promptOverride[param] === undefined) {
 			promptOverride[param] = answers[param];
 		}
+	}
+
+	// The prompt's filter already expands a `~/...` ROOTPATH answer, but ROOTPATH may instead have
+	// arrived via cmd/env/config-file override (skipping the prompt, and its filter, entirely) -
+	// resolve it here too so every downstream consumer (mountHdb, createBootPropertiesFile,
+	// createConfigFile) sees the same expanded absolute path (harper#672).
+	if (promptOverride[hdbTerms.INSTALL_PROMPTS.ROOTPATH] !== undefined) {
+		promptOverride[hdbTerms.INSTALL_PROMPTS.ROOTPATH] = resolveInstallDestination(
+			promptOverride[hdbTerms.INSTALL_PROMPTS.ROOTPATH]
+		);
 	}
 
 	return promptOverride;

--- a/utility/install/installer.ts
+++ b/utility/install/installer.ts
@@ -95,7 +95,7 @@ install.createSuperUser = createSuperUser;
  * plain relative paths (no `~`, no leading `/`) are returned unchanged, preserving the existing
  * cwd-relative behavior for relative paths.
  */
-function resolveInstallDestination(value) {
+function resolveInstallDestination(value: string): string {
 	return resolveConfiguredPath(value, undefined) ?? value;
 }
 
@@ -119,7 +119,7 @@ async function install() {
 	// A cmd/env/config-file-sourced ROOTPATH skips the install prompt (and its `~/...`-expanding
 	// filter) entirely, so resolve it here - before it's validated (installValidator, below) or
 	// used anywhere else - to keep it consistent with the interactively-entered path (harper#672).
-	if (promptOverride[hdbTerms.INSTALL_PROMPTS.ROOTPATH] !== undefined) {
+	if (promptOverride[hdbTerms.INSTALL_PROMPTS.ROOTPATH] != null) {
 		promptOverride[hdbTerms.INSTALL_PROMPTS.ROOTPATH] = resolveInstallDestination(
 			promptOverride[hdbTerms.INSTALL_PROMPTS.ROOTPATH]
 		);

--- a/utility/install/installer.ts
+++ b/utility/install/installer.ts
@@ -115,6 +115,16 @@ async function install() {
 	// Check to see if any cmd/env vars are passed that override install prompts.
 	const promptOverride = checkForPromptOverride();
 	Object.assign(promptOverride, configFromFile);
+
+	// A cmd/env/config-file-sourced ROOTPATH skips the install prompt (and its `~/...`-expanding
+	// filter) entirely, so resolve it here - before it's validated (installValidator, below) or
+	// used anywhere else - to keep it consistent with the interactively-entered path (harper#672).
+	if (promptOverride[hdbTerms.INSTALL_PROMPTS.ROOTPATH] !== undefined) {
+		promptOverride[hdbTerms.INSTALL_PROMPTS.ROOTPATH] = resolveInstallDestination(
+			promptOverride[hdbTerms.INSTALL_PROMPTS.ROOTPATH]
+		);
+	}
+
 	const hasRequiredPromptOverrides =
 		promptOverride[hdbTerms.INSTALL_PROMPTS.ROOTPATH] &&
 		promptOverride[hdbTerms.INSTALL_PROMPTS.HDB_ADMIN_USERNAME] &&
@@ -317,22 +327,16 @@ async function installPrompts(promptOverride) {
 	];
 
 	const answers = await inquirer.prompt(promptsSchema);
+	// If there are no answers all the prompts have been overridden.
+	if (Object.keys(answers).length === 0) {
+		return promptOverride;
+	}
+
 	// Loop through the answers and if they dont exist in the promptOverride obj add them.
-	// (No-op when all prompts were overridden and answers is empty.)
 	for (const param in answers) {
 		if (promptOverride[param] === undefined) {
 			promptOverride[param] = answers[param];
 		}
-	}
-
-	// The prompt's filter already expands a `~/...` ROOTPATH answer, but ROOTPATH may instead have
-	// arrived via cmd/env/config-file override (skipping the prompt, and its filter, entirely) -
-	// resolve it here too so every downstream consumer (mountHdb, createBootPropertiesFile,
-	// createConfigFile) sees the same expanded absolute path (harper#672).
-	if (promptOverride[hdbTerms.INSTALL_PROMPTS.ROOTPATH] !== undefined) {
-		promptOverride[hdbTerms.INSTALL_PROMPTS.ROOTPATH] = resolveInstallDestination(
-			promptOverride[hdbTerms.INSTALL_PROMPTS.ROOTPATH]
-		);
 	}
 
 	return promptOverride;


### PR DESCRIPTION
## Summary

The install prompt ("Please enter a destination for Harper:") stored a `~/...` answer verbatim as `ROOTPATH`. Directory-creation steps (`mountHdb`, `createBootPropertiesFile`) used that raw, unexpanded string relative to `cwd` — creating a literal `~` directory — while config composition later tilde-expanded the *persisted* `rootPath` value on read (via the existing `resolveConfiguredPath` helper), so the two disagreed and a later step threw `ENOENT` looking for `harperdb-config.yaml` at the (correctly) expanded path.

## Fix

Adds `resolveInstallDestination()` to `utility/install/installer.ts`, which delegates to the existing `resolveConfiguredPath(value, undefined)` in `config/componentEnvPrepass.ts` (tilde → `os.homedir()`-relative absolute; absolute path passthrough; bare relative path passthrough, preserving today's cwd-relative behavior). It's wired in at both places raw input enters:

- The `ROOTPATH` inquirer prompt's `filter` (runs before `validate`, so the existing-install check also sees the expanded path).
- A funnel in `install()`, right after `promptOverride` is assembled from cmd/env/`--config` sources and before `installValidator` runs — so a `~/...` value from any of those sources is normalized before it's validated or used anywhere downstream.

Every subsequent consumer (`envManager.setHdbBasePath`, `mountHdb`, `createBootPropertiesFile`, `createConfigFile`) now reads the single already-expanded `hdbRoot`/`installParams.ROOTPATH` value.

## Testing

- New unit tests in `unitTests/install/installer.test.js` (`describe('resolveInstallDestination', ...)`) covering tilde expansion, absolute passthrough, relative passthrough, and the default (already-absolute) destination — added as a top-level describe block since the rest of that file is pre-existing `describe.skip`'d and stale.
- `npm run typecheck`, `npm run build`, `npx oxlint`, and `npm run test:unit:main` all pass. 10 pre-existing failures in `unitTests/components/globalIsolation.test.js` are unrelated (worktree module-path sandboxing issue, reproduced identically on `main`).

## Notes for reviewer

- This environment didn't have the `codex-reviewer`/`reviewer` subagents registered, so the usual cross-model review pass couldn't run as designed; an independent Claude read confirmed the inquirer filter-before-validate ordering and the `resolveConfiguredPath` behavior against the actual source, and caught the `installValidator`-ordering gap now fixed in the second commit.

Refs harper#672

🤖 Generated with [Claude Code](https://claude.com/claude-code)