### PR TITLE
fix(cli): friendly "Harper is not running" message on local connect failure

### DIFF
--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -438,20 +438,23 @@ async function cliOperations(req: any, skipResponseLog = false) {
 
 		return responseData;
 	} catch (err) {
-		let isConnectionFailure = false;
+		let code, message, hostname;
 		try {
-			isConnectionFailure = err != null && (err.code === 'ENOENT' || err.code === 'ECONNREFUSED');
+			code = err?.code;
+			message = err?.message;
+			hostname = err?.hostname;
 		} catch {}
+		const isConnectionFailure = code === 'ENOENT' || code === 'ECONNREFUSED';
 		if (isConnectionFailure && !target) {
 			console.error(LOCAL_NOT_RUNNING_MESSAGE);
 		} else if (isConnectionFailure) {
-			console.error(`error: Failed to connect to Harper (${err.code}): ${err.message}`);
-		} else if (err.code === 'EACCES') {
-			console.error(`error: Permission denied accessing the domain socket: ${err.message}`);
-		} else if (err.code === 'ENOTFOUND') {
-			console.error(`error: Host not found: "${err.hostname}" ${err.message}`);
+			console.error(`error: Failed to connect to Harper (${code}): ${message}`);
+		} else if (code === 'EACCES') {
+			console.error(`error: Permission denied accessing the domain socket: ${message}`);
+		} else if (code === 'ENOTFOUND') {
+			console.error(`error: Host not found: "${hostname}" ${message}`);
 		} else {
-			console.error(`error: ${err.message ?? err}`);
+			console.error(`error: ${message ?? err}`);
 		}
 		process.exit(1);
 	}

--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -438,7 +438,10 @@ async function cliOperations(req: any, skipResponseLog = false) {
 
 		return responseData;
 	} catch (err) {
-		const isConnectionFailure = err.code === 'ENOENT' || err.code === 'ECONNREFUSED';
+		let isConnectionFailure = false;
+		try {
+			isConnectionFailure = err != null && (err.code === 'ENOENT' || err.code === 'ECONNREFUSED');
+		} catch {}
 		if (isConnectionFailure && !target) {
 			console.error(LOCAL_NOT_RUNNING_MESSAGE);
 		} else if (isConnectionFailure) {

--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -9,6 +9,7 @@ import { httpRequest } from '../utility/common_utils.ts';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as YAML from 'yaml';
+import { Readable } from 'node:stream';
 import { streamPackagedDirectory, packageDirectory, scanPackageDirectory } from '../components/packageComponent.ts';
 import { encode as encodeCbor } from 'cbor-x';
 import { buildMultipartBody } from './multipartBuilder.ts';
@@ -87,6 +88,21 @@ async function targetSupportsStreamingDeploy(options: any): Promise<boolean> {
 		return versionSupportsStreamingDeploy(version);
 	} catch {
 		return true;
+	}
+}
+
+// Wraps the local packaging stream so an fs error while tar'ing up the payload (e.g. a file
+// vanishing after the pre-deploy scan, or a permissions failure reading the project tree)
+// surfaces as a descriptive packaging error instead of a raw fs error code. Without this, an
+// ENOENT from *packaging* is indistinguishable from an ENOENT/ECONNREFUSED connecting to the
+// local domain socket, and the catch block below (which classifies purely on err.code) would
+// misreport it as "Harper is not running" even though Harper is running fine. Mirrors the
+// legacy deploy path's wrapping of packageDirectory() below.
+async function* wrapPackagingStream(stream: Readable, projectPath: string): AsyncGenerator<Buffer> {
+	try {
+		for await (const chunk of stream) yield chunk as Buffer;
+	} catch (err: any) {
+		throw new Error(`Failed to package component directory '${projectPath}': ${err.message}`, { cause: err });
 	}
 }
 
@@ -331,7 +347,7 @@ async function cliOperations(req: any, skipResponseLog = false) {
 				name: 'payload',
 				filename: 'package.tar.gz',
 				contentType: 'application/gzip',
-				stream: packageStream,
+				stream: Readable.from(wrapPackagingStream(packageStream, req._projectPath)),
 			});
 			options.headers['Content-Type'] = multipart.contentType;
 			// Use chunked transfer-encoding: we don't know the total size up front because the

--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -19,6 +19,12 @@ import { initConfig, getConfigPath } from '../config/configUtils.ts';
 
 const OP_ALIASES = { deploy: 'deploy_component', package: 'package_component' };
 
+// Shown for any local-instance connection failure (missing pid, missing/stale domain
+// socket, or a refused/ENOENT connect against it) — they're all the same user-facing
+// scenario: Harper isn't running. Remote-target failures keep the detailed error instead,
+// since there's no single "just start it" fix for those.
+const LOCAL_NOT_RUNNING_MESSAGE = 'Harper is not running. Use `harperdb run` (or `harperdb start`) to start it.';
+
 // Operations whose responses should be consumed as text/event-stream so live phase events
 // (prepare, load, replicate, restart) render as they happen instead of after the whole
 // deploy completes. Add an operation here only after wiring its server-side
@@ -213,12 +219,12 @@ async function cliOperations(req: any, skipResponseLog = false) {
 		console.error('Connecting to local Harper instance');
 		initConfig();
 		if (!getHdbPid()) {
-			console.error('Harper must be running to perform this operation');
+			console.error(LOCAL_NOT_RUNNING_MESSAGE);
 			process.exit(1);
 		}
 
 		if (!fs.existsSync(getConfigPath(terms.CONFIG_PARAMS.OPERATIONSAPI_NETWORK_DOMAINSOCKET))) {
-			console.error('No domain socket found, unable to perform this operation');
+			console.error(LOCAL_NOT_RUNNING_MESSAGE);
 			process.exit(1);
 		}
 	}
@@ -432,7 +438,10 @@ async function cliOperations(req: any, skipResponseLog = false) {
 
 		return responseData;
 	} catch (err) {
-		if (err.code === 'ENOENT' || err.code === 'ECONNREFUSED') {
+		const isConnectionFailure = err.code === 'ENOENT' || err.code === 'ECONNREFUSED';
+		if (isConnectionFailure && !target) {
+			console.error(LOCAL_NOT_RUNNING_MESSAGE);
+		} else if (isConnectionFailure) {
 			console.error(`error: Failed to connect to Harper (${err.code}): ${err.message}`);
 		} else if (err.code === 'EACCES') {
 			console.error(`error: Permission denied accessing the domain socket: ${err.message}`);

--- a/unitTests/bin/cliOperations.test.js
+++ b/unitTests/bin/cliOperations.test.js
@@ -369,4 +369,103 @@ describe('cliOperations', () => {
 			assert.ok(consoleErrors.some((line) => line.startsWith('error:')));
 		});
 	});
+
+	describe('local packaging errors are not misclassified as "Harper is not running" (PR #1808)', () => {
+		const NOT_RUNNING_MESSAGE = 'Harper is not running. Use `harperdb run` (or `harperdb start`) to start it.';
+
+		let originalGetHdbPid;
+		let originalInitConfig;
+		let originalGetConfigPath;
+		let originalScan;
+		let originalStreamPackagedDirectory;
+		let originalExit;
+		let originalConsoleError;
+		let consoleErrors;
+		let exitCode;
+
+		beforeEach(() => {
+			originalGetHdbPid = processManagementModule.getHdbPid;
+			originalInitConfig = configUtilsModule.initConfig;
+			originalGetConfigPath = configUtilsModule.getConfigPath;
+			originalScan = packageComponentModule.scanPackageDirectory;
+			originalStreamPackagedDirectory = packageComponentModule.streamPackagedDirectory;
+			originalExit = process.exit;
+			originalConsoleError = console.error;
+
+			// Same "Harper is running" pre-check setup as above, so the failure below comes
+			// from packaging the local deploy payload, not from the pid/socket pre-checks.
+			const socketPath = path.join(testDir, 'operations-server.sock');
+			fs.ensureFileSync(socketPath);
+			configUtilsModule.initConfig = () => {};
+			processManagementModule.getHdbPid = () => 12345;
+			configUtilsModule.getConfigPath = () => socketPath;
+
+			packageComponentModule.scanPackageDirectory = async () => ({ totalSize: 0, danglingSymlinks: [] });
+
+			consoleErrors = [];
+			console.error = (...args) => consoleErrors.push(args.join(' '));
+			exitCode = undefined;
+			process.exit = (code) => {
+				exitCode = code;
+				throw new ProcessExitSignal(code);
+			};
+		});
+
+		afterEach(() => {
+			processManagementModule.getHdbPid = originalGetHdbPid;
+			configUtilsModule.initConfig = originalInitConfig;
+			configUtilsModule.getConfigPath = originalGetConfigPath;
+			packageComponentModule.scanPackageDirectory = originalScan;
+			packageComponentModule.streamPackagedDirectory = originalStreamPackagedDirectory;
+			process.exit = originalExit;
+			console.error = originalConsoleError;
+		});
+
+		it('shows a descriptive packaging error (not the friendly "not running" message) for a local deploy ENOENT from a missing file in the payload', async () => {
+			// Simulates a file vanishing (or being unreadable) while tar'ing up the component
+			// directory for a local `deploy_component` — an fs-level ENOENT that has nothing to
+			// do with the connection to the local Harper instance.
+			packageComponentModule.streamPackagedDirectory = () => {
+				const err = new Error("ENOENT: no such file or directory, open '/project/missing-file.txt'");
+				err.code = 'ENOENT';
+				// Destroying from within _read (rather than an unconditional process.nextTick)
+				// guarantees the stream already has a consumer attached — the same ordering a
+				// real tar-fs/fs error arrives under, once something has started reading.
+				return new Readable({
+					read() {
+						this.destroy(err);
+					},
+				});
+			};
+
+			// Mirrors the real httpRequest's contract for a streamed (multipart) body: the body
+			// stream's 'error' event rejects the call — exactly the channel that must not leak a
+			// raw ENOENT the catch block would otherwise mistake for a connection failure.
+			commonUtilsModule.httpRequest = async (_options, data) => {
+				if (data && typeof data.pipe === 'function') {
+					return new Promise((resolve, reject) => {
+						data.on('error', reject);
+						data.on('data', () => {});
+						data.on('end', () => resolve({ statusCode: 200, body: '{}' }));
+					});
+				}
+				return { statusCode: 200, body: '{}' };
+			};
+
+			await assert.rejects(
+				() => cliOperationsModule.cliOperations({ operation: 'deploy_component', project: 'widget' }, true),
+				ProcessExitSignal
+			);
+
+			assert.strictEqual(exitCode, 1);
+			assert.ok(
+				!consoleErrors.includes(NOT_RUNNING_MESSAGE),
+				`expected the packaging error not to be shown as "Harper is not running", got: ${JSON.stringify(consoleErrors)}`
+			);
+			assert.ok(
+				consoleErrors.some((line) => line.includes('Failed to package component directory')),
+				`expected a descriptive packaging error, got: ${JSON.stringify(consoleErrors)}`
+			);
+		});
+	});
 });

--- a/unitTests/bin/cliOperations.test.js
+++ b/unitTests/bin/cliOperations.test.js
@@ -350,5 +350,23 @@ describe('cliOperations', () => {
 			assert.ok(!consoleErrors.includes(NOT_RUNNING_MESSAGE));
 			assert.ok(consoleErrors.some((line) => line.includes('error: Failed to connect to Harper (ECONNREFUSED)')));
 		});
+
+		it('does not crash on a throwing err.code getter, even past the connection-failure check', async () => {
+			commonUtilsModule.httpRequest = async () => {
+				const err = {};
+				Object.defineProperty(err, 'code', {
+					get() {
+						throw new Error('proxy trap: code is not readable');
+					},
+				});
+				err.message = 'should not be reachable either, since code threw first';
+				throw err;
+			};
+
+			await assert.rejects(() => cliOperationsModule.cliOperations({ operation: 'status' }, true), ProcessExitSignal);
+
+			assert.strictEqual(exitCode, 1);
+			assert.ok(consoleErrors.some((line) => line.startsWith('error:')));
+		});
 	});
 });

--- a/unitTests/bin/cliOperations.test.js
+++ b/unitTests/bin/cliOperations.test.js
@@ -11,6 +11,18 @@ const cliOperationsModule = require('#src/bin/cliOperations');
 const commonUtilsModule = require('#src/utility/common_utils');
 const tokenAuthModule = require('#src/security/tokenAuthentication');
 const packageComponentModule = require('#src/components/packageComponent');
+const processManagementModule = require('#src/utility/processManagement/processManagement');
+const configUtilsModule = require('#src/config/configUtils');
+
+// Thrown by the mocked process.exit below so a call to it unwinds the async
+// cliOperations() call (rather than actually terminating the test runner) and
+// is observable via assert.rejects.
+class ProcessExitSignal extends Error {
+	constructor(code) {
+		super(`process.exit(${code})`);
+		this.code = code;
+	}
+}
 
 describe('cliOperations', () => {
 	const testDir = path.join(os.tmpdir(), `harper-test-cli-ops-${Date.now()}`);
@@ -228,6 +240,115 @@ describe('cliOperations', () => {
 			const deploy = calls[1];
 			assert.strictEqual(deploy.options.headers.Accept, 'text/event-stream');
 			assert.strictEqual(result.success, true);
+		});
+	});
+
+	describe('"Harper is not running" messaging (harper#658)', () => {
+		const NOT_RUNNING_MESSAGE = 'Harper is not running. Use `harperdb run` (or `harperdb start`) to start it.';
+
+		let originalGetHdbPid;
+		let originalInitConfig;
+		let originalGetConfigPath;
+		let originalExit;
+		let originalConsoleError;
+		let consoleErrors;
+		let exitCode;
+
+		beforeEach(() => {
+			originalGetHdbPid = processManagementModule.getHdbPid;
+			originalInitConfig = configUtilsModule.initConfig;
+			originalGetConfigPath = configUtilsModule.getConfigPath;
+			originalExit = process.exit;
+			originalConsoleError = console.error;
+
+			// Pretend the local instance is running with a domain socket present on disk, so
+			// the early pid/socket pre-checks pass and the failure surfaces from the actual
+			// connection attempt (the httpRequest mock below), exercising the catch block
+			// rather than short-circuiting on the pre-checks.
+			const socketPath = path.join(testDir, 'operations-server.sock');
+			fs.ensureFileSync(socketPath);
+			configUtilsModule.initConfig = () => {};
+			processManagementModule.getHdbPid = () => 12345;
+			configUtilsModule.getConfigPath = () => socketPath;
+
+			consoleErrors = [];
+			console.error = (...args) => consoleErrors.push(args.join(' '));
+			exitCode = undefined;
+			process.exit = (code) => {
+				exitCode = code;
+				throw new ProcessExitSignal(code);
+			};
+		});
+
+		afterEach(() => {
+			processManagementModule.getHdbPid = originalGetHdbPid;
+			configUtilsModule.initConfig = originalInitConfig;
+			configUtilsModule.getConfigPath = originalGetConfigPath;
+			process.exit = originalExit;
+			console.error = originalConsoleError;
+		});
+
+		it('shows the friendly message (and non-zero exit) when no local pid is found', async () => {
+			processManagementModule.getHdbPid = () => undefined;
+
+			await assert.rejects(() => cliOperationsModule.cliOperations({ operation: 'status' }, true), ProcessExitSignal);
+
+			assert.strictEqual(exitCode, 1);
+			assert.ok(consoleErrors.includes(NOT_RUNNING_MESSAGE));
+		});
+
+		it('shows the friendly message (and non-zero exit) when the domain socket file is missing', async () => {
+			configUtilsModule.getConfigPath = () => path.join(testDir, 'no-such-operations-server.sock');
+
+			await assert.rejects(() => cliOperationsModule.cliOperations({ operation: 'status' }, true), ProcessExitSignal);
+
+			assert.strictEqual(exitCode, 1);
+			assert.ok(consoleErrors.includes(NOT_RUNNING_MESSAGE));
+		});
+
+		it('shows the friendly message (and non-zero exit) for a local ECONNREFUSED', async () => {
+			commonUtilsModule.httpRequest = async () => {
+				const err = new Error('connect ECONNREFUSED /fake/operations-server.sock');
+				err.code = 'ECONNREFUSED';
+				throw err;
+			};
+
+			await assert.rejects(() => cliOperationsModule.cliOperations({ operation: 'status' }, true), ProcessExitSignal);
+
+			assert.strictEqual(exitCode, 1);
+			assert.ok(consoleErrors.includes(NOT_RUNNING_MESSAGE));
+			assert.ok(!consoleErrors.some((line) => line.includes('ECONNREFUSED')));
+		});
+
+		it('shows the friendly message (and non-zero exit) for a local ENOENT (stale/missing socket)', async () => {
+			commonUtilsModule.httpRequest = async () => {
+				const err = new Error('ENOENT: no such file or directory, connect /fake/operations-server.sock');
+				err.code = 'ENOENT';
+				throw err;
+			};
+
+			await assert.rejects(() => cliOperationsModule.cliOperations({ operation: 'status' }, true), ProcessExitSignal);
+
+			assert.strictEqual(exitCode, 1);
+			assert.ok(consoleErrors.includes(NOT_RUNNING_MESSAGE));
+			assert.ok(!consoleErrors.some((line) => line.includes('ENOENT')));
+		});
+
+		it('keeps the detailed error (not the friendly message) for a remote-target connection failure', async () => {
+			commonUtilsModule.httpRequest = async () => {
+				const err = new Error('connect ECONNREFUSED 1.2.3.4:9925');
+				err.code = 'ECONNREFUSED';
+				throw err;
+			};
+
+			await assert.rejects(
+				() => cliOperationsModule.cliOperations({ operation: 'status', target: 'example.com' }, true),
+				ProcessExitSignal
+			);
+
+			assert.strictEqual(exitCode, 1);
+			assert.ok(!consoleErrors.includes(NOT_RUNNING_MESSAGE));
+			assert.ok(consoleErrors.some((line) => line.includes('error: Failed to connect to Harper (ECONNREFUSED)')));
 		});
 	});
 });


### PR DESCRIPTION
## Summary
When a CLI operation targets the local Harper instance and Harper isn't running, unify the various local-failure messages onto one friendly line:

```
Harper is not running. Use `harperdb run` (or `harperdb start`) to start it.
```

This now covers all four local-only failure points in `cliOperations()`:
- no pid file / process not running
- domain socket file missing (the `harper#585`-style stale/never-created socket case)
- a live connect that fails with `ECONNREFUSED`
- a live connect that fails with `ENOENT`

Remote-target connection failures are unchanged — they keep the existing `error: Failed to connect to Harper (<code>): <message>` detail, per the issue (remote errors are already informative enough, and there's no single "just start it" remedy for a remote target). Exit code stays non-zero (`process.exit(1)`) in every branch — no change there.

## Scope note for the reviewer
The issue's example command is `harperdb status`, but `bin/status.ts` is a separate code path that reads the pid file directly and never opens the operations-API socket — so it can't hit `ECONNREFUSED`/`ENOENT` at all, and this change doesn't alter its output. The actual local-connection code lives in `bin/cliOperations.ts` (the path used by all "operation" style CLI commands, e.g. `harperdb get_configuration`), which is what this PR fixes. I did not touch `status.ts` since it has no stack-trace-exposing bug to fix. Flagging in case `status` specifically was expected to change.

`harper#585` (the socket-never-created root cause referenced in the issue) is already closed, fixed by #299 — this PR doesn't duplicate that work, it just makes sure the CLI-side message is friendly if a stale/missing socket is ever hit again for any reason.

## Test coverage
Added to `unitTests/bin/cliOperations.test.js`:
- friendly message + exit 1 when no local pid is found
- friendly message + exit 1 when the socket file is missing
- friendly message + exit 1 on a local `ECONNREFUSED` during connect
- friendly message + exit 1 on a local `ENOENT` during connect
- remote-target `ECONNREFUSED` still gets the detailed message, not the friendly one

I verified the two "live connect" tests actually exercise the `catch` block (not just short-circuited by the earlier pid/socket pre-checks) by temporarily reverting the catch-block change and confirming those two tests fail.

---
Generated by Claude Sonnet 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)