### PR TITLE
fix(upgrade): activate new built-in components on in-place-upgraded configs

### DIFF
--- a/bin/run.ts
+++ b/bin/run.ts
@@ -179,6 +179,16 @@ async function initialize(calledByInstall = false, calledByMain = false) {
 		process.exit(1);
 	}
 
+	// A built-in component only activates when its config key is present. Fresh installs get these
+	// keys from defaultConfig.yaml, but an in-place upgrade carries the old config forward without a
+	// key added in a newer release (harper-pro#585). Ensure them on every boot — idempotent and
+	// scoped to genuinely-new built-ins registered in this runtime — so the fix self-heals even when
+	// a version bump ships no upgrade directive or a prior backfill write failed.
+	const backfilledKeys = configUtils.ensureBuiltInComponentConfigKeys();
+	if (backfilledKeys.length > 0) {
+		hdbLogger.info(`Activated built-in component(s) absent from an upgraded config: ${backfilledKeys.join(', ')}`);
+	}
+
 	checkJwtTokens();
 
 	await keys.reviewSelfSignedCert();

--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -344,9 +344,18 @@ export function ensureConfigKeysPresent(keys: string[]): string[] {
  * Deliberately scoped to genuinely-new built-ins — NOT every registered built-in. Component
  * activation is presence-gated (componentLoader iterates the config's keys), so re-adding a
  * long-standing key like `replication` would silently re-enable a component an operator disabled
- * by deleting its block. A newly-introduced built-in has no such history: its absence is always
- * "carried over from before it existed," never "intentionally removed." Add a key here only when
- * shipping a new built-in that must activate on already-upgraded instances.
+ * by deleting its block. A newly-introduced built-in has no such history: at upgrade time its
+ * absence is always "carried over from before it existed," never "intentionally removed."
+ *
+ * Consequence: once a backfilled key is on the safe-list, KEY DELETION IS NO LONGER A DISABLE
+ * MECHANISM for it — every boot re-adds the key and re-activates the component. Disabling must be
+ * explicit: set a falsy value (e.g. `secretCustody: false`). ensureConfigKeysPresent only writes
+ * when the key is entirely absent (hasIn is presence-based, true for `false`/`null`), and the
+ * loader treats a falsy value as disabled (`if (!config[name]) continue`), so an explicit `false`
+ * survives the backfill. This is the correct trade for a security-custody component — disabling it
+ * should be a deliberate act, not an accident of config drift (the exact failure mode of #585) —
+ * but document the falsy-disable convention wherever the key is exposed to operators.
+ * Add a key here only when shipping a new built-in that must activate on already-upgraded instances.
  */
 const UPGRADE_BACKFILL_BUILTIN_KEYS = ['secretCustody'];
 

--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -283,6 +283,103 @@ export function getConfigFilePath(bootPropsFilePath = hdbUtils.getPropsFilePath(
 }
 
 /**
+ * Ensure the given top-level keys exist in the on-disk config file, writing an empty block (`{}`)
+ * for each one that is absent. Only missing keys are added — existing values are never touched.
+ *
+ * Built-in components only load when their config key is present: componentLoader iterates the
+ * resolved config's keys, so a registered built-in with no matching key is never activated. Fresh
+ * installs get those keys from defaultConfig.yaml, but an in-place upgrade carries the pre-existing
+ * config forward, so a built-in introduced in a newer release (e.g. `secretCustody` in 5.2) stays
+ * dormant until its key appears. This restores parity with a fresh install. Callers pass the keys
+ * for the built-ins registered in THIS runtime, so nothing is added for a component the running
+ * distribution doesn't ship.
+ *
+ * @param keys - top-level config keys to ensure exist
+ * @returns the keys that were added (empty when none were missing)
+ */
+export function ensureConfigKeysPresent(keys: string[]): string[] {
+	const configFilePath = getConfigFilePath();
+	if (!configFilePath || !fs.existsSync(configFilePath)) return [];
+
+	const configDoc = parseYamlDoc(configFilePath);
+	const added: string[] = [];
+	for (const key of keys) {
+		if (!key || configDoc.hasIn([key])) continue;
+		configDoc.setIn([key], {});
+		added.push(key);
+	}
+	if (added.length === 0) return [];
+
+	if (configDoc.errors?.length > 0) {
+		throw handleHDBError(
+			new Error(),
+			`Error parsing ${configFilePath} ${configDoc.errors}`,
+			HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR
+		);
+	}
+	atomicWriteFile(configFilePath, String(configDoc));
+
+	// Mirror the additions into the already-memoized config so a built-in gated on the new key
+	// activates on the CURRENT boot: componentLoader reads the root config from getConfigObj(),
+	// which is cached early in boot — before an upgrade backfill runs — so a file-only write would
+	// otherwise not take effect until the next restart.
+	if (configObj) {
+		for (const key of added) {
+			if (configObj[key] === undefined) configObj[key] = {};
+		}
+	}
+	return added;
+}
+
+/**
+ * Built-in components introduced in a recent release whose config key must be backfilled onto
+ * in-place-upgraded instances. Fresh installs get these from defaultConfig.yaml, but an upgrade
+ * carries the old config forward without them, leaving the component dormant (harper-pro#585:
+ * secretCustody added in 5.2).
+ *
+ * Deliberately scoped to genuinely-new built-ins — NOT every registered built-in. Component
+ * activation is presence-gated (componentLoader iterates the config's keys), so re-adding a
+ * long-standing key like `replication` would silently re-enable a component an operator disabled
+ * by deleting its block. A newly-introduced built-in has no such history: its absence is always
+ * "carried over from before it existed," never "intentionally removed." Add a key here only when
+ * shipping a new built-in that must activate on already-upgraded instances.
+ */
+const UPGRADE_BACKFILL_BUILTIN_KEYS = ['secretCustody'];
+
+/**
+ * Ensure the config keys for recently-introduced built-in components exist, so a component added in
+ * a newer release activates on an in-place-upgraded instance (see UPGRADE_BACKFILL_BUILTIN_KEYS).
+ * Only keys for built-ins registered in THIS runtime (HARPER_BUILTIN_COMPONENTS) are considered, so
+ * nothing is written for a component the running distribution doesn't ship — e.g. secretCustody is
+ * Pro-only and is never added on OSS core, which registers no built-ins.
+ *
+ * Safe to call on every boot: idempotent (writes only when a key is genuinely missing) and cheap (a
+ * config read plus a key check). Running it unconditionally — rather than only on the upgrade path —
+ * means a transient write failure self-heals on the next boot, and version transitions that ship no
+ * data-migration directive are still covered. Never throws.
+ *
+ * @returns the keys that were added (empty when none were missing)
+ */
+export function ensureBuiltInComponentConfigKeys(): string[] {
+	const registeredBuiltIns = process.env.HARPER_BUILTIN_COMPONENTS;
+	if (!registeredBuiltIns) return [];
+	const registered = new Set(
+		registeredBuiltIns
+			.split(',')
+			.map((definition) => definition.split('=')[0].trim())
+			.filter(Boolean)
+	);
+	const keys = UPGRADE_BACKFILL_BUILTIN_KEYS.filter((key) => registered.has(key));
+	if (keys.length === 0) return [];
+	try {
+		return ensureConfigKeysPresent(keys);
+	} catch (error) {
+		logger.error('Failed to backfill built-in component config keys', error);
+		return [];
+	}
+}
+
+/**
  * If in memory config obj is undefined or init is being forced,
  * read and parses the Harper config file and add to config object.
  * @param force

--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -302,6 +302,14 @@ export function ensureConfigKeysPresent(keys: string[]): string[] {
 	if (!configFilePath || !fs.existsSync(configFilePath)) return [];
 
 	const configDoc = parseYamlDoc(configFilePath);
+	if (configDoc.errors?.length > 0) {
+		throw handleHDBError(
+			new Error(),
+			`Error parsing ${configFilePath} ${configDoc.errors}`,
+			HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR
+		);
+	}
+
 	const added: string[] = [];
 	for (const key of keys) {
 		if (!key || configDoc.hasIn([key])) continue;
@@ -310,22 +318,18 @@ export function ensureConfigKeysPresent(keys: string[]): string[] {
 	}
 	if (added.length === 0) return [];
 
-	if (configDoc.errors?.length > 0) {
-		throw handleHDBError(
-			new Error(),
-			`Error parsing ${configFilePath} ${configDoc.errors}`,
-			HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR
-		);
-	}
 	atomicWriteFile(configFilePath, String(configDoc));
 
 	// Mirror the additions into the already-memoized config so a built-in gated on the new key
 	// activates on the CURRENT boot: componentLoader reads the root config from getConfigObj(),
 	// which is cached early in boot — before an upgrade backfill runs — so a file-only write would
-	// otherwise not take effect until the next restart.
+	// otherwise not take effect until the next restart. flatConfigObj is backfilled alongside it so
+	// getFlatConfigObj()/getConfigValue() also see the new key on this boot rather than undefined.
 	if (configObj) {
 		for (const key of added) {
 			if (configObj[key] === undefined) configObj[key] = {};
+			const flatKey = key.toLowerCase();
+			if (flatConfigObj && flatConfigObj[flatKey] === undefined) flatConfigObj[flatKey] = configObj[key];
 		}
 	}
 	return added;

--- a/unitTests/config/configUtils.test.js
+++ b/unitTests/config/configUtils.test.js
@@ -3,6 +3,7 @@
 const sinon = require('sinon');
 const chai = require('chai');
 const expect = chai.expect;
+const assert = require('node:assert/strict');
 const rewire = require('rewire');
 const path = require('path');
 const fs = require('fs-extra');
@@ -246,10 +247,10 @@ describe('Test configUtils module', () => {
 		it('adds an empty block for a missing key and reports it', () => {
 			writeConfig('replication: {}\nanalytics:\n  enabled: true\n');
 			const added = ensureConfigKeysPresent(['secretCustody']);
-			expect(added).to.deep.equal(['secretCustody']);
+			assert.deepStrictEqual(added, ['secretCustody']);
 			const doc = YAML.parse(fs.readFileSync(ENSURE_CONFIG_PATH, 'utf8'));
-			expect(doc).to.have.property('secretCustody');
-			expect(doc.secretCustody).to.deep.equal({});
+			assert.ok('secretCustody' in doc);
+			assert.deepStrictEqual(doc.secretCustody, {});
 		});
 
 		it('never touches an existing key or its value', () => {
@@ -257,37 +258,37 @@ describe('Test configUtils module', () => {
 			ensureConfigKeysPresent(['analytics']);
 			const doc = YAML.parse(fs.readFileSync(ENSURE_CONFIG_PATH, 'utf8'));
 			// existing value preserved, not overwritten with {}
-			expect(doc.analytics).to.deep.equal({ enabled: true });
+			assert.deepStrictEqual(doc.analytics, { enabled: true });
 		});
 
 		it('only adds the keys that are missing', () => {
 			writeConfig('replication: {}\n');
 			const added = ensureConfigKeysPresent(['replication', 'secretCustody', 'analytics']);
-			expect(added.sort()).to.deep.equal(['analytics', 'secretCustody']);
+			assert.deepStrictEqual(added.sort(), ['analytics', 'secretCustody']);
 		});
 
 		it('is idempotent — a second run adds nothing', () => {
 			writeConfig('replication: {}\n');
-			expect(ensureConfigKeysPresent(['secretCustody'])).to.deep.equal(['secretCustody']);
-			expect(ensureConfigKeysPresent(['secretCustody'])).to.deep.equal([]);
+			assert.deepStrictEqual(ensureConfigKeysPresent(['secretCustody']), ['secretCustody']);
+			assert.deepStrictEqual(ensureConfigKeysPresent(['secretCustody']), []);
 		});
 
 		it('does not rewrite the file when no keys are missing', () => {
 			writeConfig('secretCustody: {}\n');
 			const before = fs.statSync(ENSURE_CONFIG_PATH).mtimeMs;
 			const added = ensureConfigKeysPresent(['secretCustody']);
-			expect(added).to.deep.equal([]);
-			expect(fs.statSync(ENSURE_CONFIG_PATH).mtimeMs).to.equal(before);
+			assert.deepStrictEqual(added, []);
+			assert.strictEqual(fs.statSync(ENSURE_CONFIG_PATH).mtimeMs, before);
 		});
 
 		it('ignores empty/falsy key names', () => {
 			writeConfig('replication: {}\n');
-			expect(ensureConfigKeysPresent(['', undefined])).to.deep.equal([]);
+			assert.deepStrictEqual(ensureConfigKeysPresent(['', undefined]), []);
 		});
 
 		it('returns [] when the config file does not exist', () => {
 			// no writeConfig — dir exists but file does not
-			expect(ensureConfigKeysPresent(['secretCustody'])).to.deep.equal([]);
+			assert.deepStrictEqual(ensureConfigKeysPresent(['secretCustody']), []);
 		});
 
 		it('mirrors added keys into the memoized configObj so they take effect on the current boot', () => {
@@ -296,10 +297,24 @@ describe('Test configUtils module', () => {
 			const restore = config_utils_rw.__set__('configObj', { replication: {} });
 			try {
 				ensureConfigKeysPresent(['secretCustody']);
-				expect(config_utils_rw.__get__('configObj')).to.have.property('secretCustody');
-				expect(config_utils_rw.__get__('configObj').secretCustody).to.deep.equal({});
+				assert.ok('secretCustody' in config_utils_rw.__get__('configObj'));
+				assert.deepStrictEqual(config_utils_rw.__get__('configObj').secretCustody, {});
 			} finally {
 				restore();
+			}
+		});
+
+		it('mirrors added keys into the memoized flatConfigObj so getConfigValue sees them on the current boot', () => {
+			writeConfig('replication: {}\n');
+			const restoreConfigObj = config_utils_rw.__set__('configObj', { replication: {} });
+			const restoreFlatConfigObj = config_utils_rw.__set__('flatConfigObj', { replication: {} });
+			try {
+				ensureConfigKeysPresent(['secretCustody']);
+				assert.ok('secretcustody' in config_utils_rw.__get__('flatConfigObj'));
+				assert.deepStrictEqual(config_utils_rw.__get__('flatConfigObj').secretcustody, {});
+			} finally {
+				restoreFlatConfigObj();
+				restoreConfigObj();
 			}
 		});
 	});
@@ -331,9 +346,9 @@ describe('Test configUtils module', () => {
 			process.env.HARPER_BUILTIN_COMPONENTS =
 				'replication=@/dist/replication/replicator.js,secretCustody=@/dist/security/keyCustody.js';
 			writeConfig('replication: {}\n');
-			expect(ensureBuiltInComponentConfigKeys()).to.deep.equal(['secretCustody']);
+			assert.deepStrictEqual(ensureBuiltInComponentConfigKeys(), ['secretCustody']);
 			const doc = YAML.parse(fs.readFileSync(BI_CONFIG_PATH, 'utf8'));
-			expect(doc.secretCustody).to.deep.equal({});
+			assert.deepStrictEqual(doc.secretCustody, {});
 		});
 
 		it('never re-adds a long-standing built-in absent from the config (e.g. admin-removed replication)', () => {
@@ -343,27 +358,27 @@ describe('Test configUtils module', () => {
 				'replication=@/dist/replication/replicator.js,secretCustody=@/dist/security/keyCustody.js';
 			writeConfig('analytics: {}\n');
 			const added = ensureBuiltInComponentConfigKeys();
-			expect(added).to.deep.equal(['secretCustody']);
+			assert.deepStrictEqual(added, ['secretCustody']);
 			const doc = YAML.parse(fs.readFileSync(BI_CONFIG_PATH, 'utf8'));
-			expect(doc).to.not.have.property('replication');
+			assert.ok(!('replication' in doc));
 		});
 
 		it('adds nothing on OSS core, which registers no built-ins', () => {
 			delete process.env.HARPER_BUILTIN_COMPONENTS;
 			writeConfig('replication: {}\n');
-			expect(ensureBuiltInComponentConfigKeys()).to.deep.equal([]);
+			assert.deepStrictEqual(ensureBuiltInComponentConfigKeys(), []);
 		});
 
 		it('adds nothing when secretCustody is not registered in this runtime', () => {
 			process.env.HARPER_BUILTIN_COMPONENTS = 'replication=@/dist/replication/replicator.js';
 			writeConfig('replication: {}\n');
-			expect(ensureBuiltInComponentConfigKeys()).to.deep.equal([]);
+			assert.deepStrictEqual(ensureBuiltInComponentConfigKeys(), []);
 		});
 
 		it('is a no-op when secretCustody is already present', () => {
 			process.env.HARPER_BUILTIN_COMPONENTS = 'secretCustody=@/dist/security/keyCustody.js';
 			writeConfig('secretCustody: {}\n');
-			expect(ensureBuiltInComponentConfigKeys()).to.deep.equal([]);
+			assert.deepStrictEqual(ensureBuiltInComponentConfigKeys(), []);
 		});
 	});
 

--- a/unitTests/config/configUtils.test.js
+++ b/unitTests/config/configUtils.test.js
@@ -222,6 +222,151 @@ describe('Test configUtils module', () => {
 		});
 	});
 
+	describe('Test ensureConfigKeysPresent function', () => {
+		const { ensureConfigKeysPresent } = config_utils_rw;
+		const ENSURE_DIR = path.join(DIRNAME, 'yaml', 'ensure-keys');
+		const ENSURE_CONFIG_PATH = path.join(ENSURE_DIR, hdbTerms.HARPER_CONFIG_FILE);
+
+		beforeEach(() => {
+			fs.ensureDirSync(ENSURE_DIR);
+			// getConfigFilePath() resolves the config file from the CLI/env root; point it at our
+			// temp dir. resolvePath() passes an absolute path through unchanged.
+			sandbox.stub(common_utils, 'getEnvCliRootPath').returns(ENSURE_DIR);
+		});
+
+		afterEach(() => {
+			sandbox.restore();
+			fs.removeSync(ENSURE_DIR);
+		});
+
+		function writeConfig(yaml) {
+			fs.writeFileSync(ENSURE_CONFIG_PATH, yaml);
+		}
+
+		it('adds an empty block for a missing key and reports it', () => {
+			writeConfig('replication: {}\nanalytics:\n  enabled: true\n');
+			const added = ensureConfigKeysPresent(['secretCustody']);
+			expect(added).to.deep.equal(['secretCustody']);
+			const doc = YAML.parse(fs.readFileSync(ENSURE_CONFIG_PATH, 'utf8'));
+			expect(doc).to.have.property('secretCustody');
+			expect(doc.secretCustody).to.deep.equal({});
+		});
+
+		it('never touches an existing key or its value', () => {
+			writeConfig('analytics:\n  enabled: true\n');
+			ensureConfigKeysPresent(['analytics']);
+			const doc = YAML.parse(fs.readFileSync(ENSURE_CONFIG_PATH, 'utf8'));
+			// existing value preserved, not overwritten with {}
+			expect(doc.analytics).to.deep.equal({ enabled: true });
+		});
+
+		it('only adds the keys that are missing', () => {
+			writeConfig('replication: {}\n');
+			const added = ensureConfigKeysPresent(['replication', 'secretCustody', 'analytics']);
+			expect(added.sort()).to.deep.equal(['analytics', 'secretCustody']);
+		});
+
+		it('is idempotent — a second run adds nothing', () => {
+			writeConfig('replication: {}\n');
+			expect(ensureConfigKeysPresent(['secretCustody'])).to.deep.equal(['secretCustody']);
+			expect(ensureConfigKeysPresent(['secretCustody'])).to.deep.equal([]);
+		});
+
+		it('does not rewrite the file when no keys are missing', () => {
+			writeConfig('secretCustody: {}\n');
+			const before = fs.statSync(ENSURE_CONFIG_PATH).mtimeMs;
+			const added = ensureConfigKeysPresent(['secretCustody']);
+			expect(added).to.deep.equal([]);
+			expect(fs.statSync(ENSURE_CONFIG_PATH).mtimeMs).to.equal(before);
+		});
+
+		it('ignores empty/falsy key names', () => {
+			writeConfig('replication: {}\n');
+			expect(ensureConfigKeysPresent(['', undefined])).to.deep.equal([]);
+		});
+
+		it('returns [] when the config file does not exist', () => {
+			// no writeConfig — dir exists but file does not
+			expect(ensureConfigKeysPresent(['secretCustody'])).to.deep.equal([]);
+		});
+
+		it('mirrors added keys into the memoized configObj so they take effect on the current boot', () => {
+			writeConfig('replication: {}\n');
+			// Simulate config already memoized earlier in boot (before this backfill runs).
+			const restore = config_utils_rw.__set__('configObj', { replication: {} });
+			try {
+				ensureConfigKeysPresent(['secretCustody']);
+				expect(config_utils_rw.__get__('configObj')).to.have.property('secretCustody');
+				expect(config_utils_rw.__get__('configObj').secretCustody).to.deep.equal({});
+			} finally {
+				restore();
+			}
+		});
+	});
+
+	describe('Test ensureBuiltInComponentConfigKeys function', () => {
+		const { ensureBuiltInComponentConfigKeys } = config_utils_rw;
+		const BI_DIR = path.join(DIRNAME, 'yaml', 'ensure-builtins');
+		const BI_CONFIG_PATH = path.join(BI_DIR, hdbTerms.HARPER_CONFIG_FILE);
+		let savedBuiltIns;
+
+		beforeEach(() => {
+			fs.ensureDirSync(BI_DIR);
+			sandbox.stub(common_utils, 'getEnvCliRootPath').returns(BI_DIR);
+			savedBuiltIns = process.env.HARPER_BUILTIN_COMPONENTS;
+		});
+
+		afterEach(() => {
+			sandbox.restore();
+			fs.removeSync(BI_DIR);
+			if (savedBuiltIns === undefined) delete process.env.HARPER_BUILTIN_COMPONENTS;
+			else process.env.HARPER_BUILTIN_COMPONENTS = savedBuiltIns;
+		});
+
+		function writeConfig(yaml) {
+			fs.writeFileSync(BI_CONFIG_PATH, yaml);
+		}
+
+		it('backfills secretCustody when it is a registered built-in and the key is missing', () => {
+			process.env.HARPER_BUILTIN_COMPONENTS =
+				'replication=@/dist/replication/replicator.js,secretCustody=@/dist/security/keyCustody.js';
+			writeConfig('replication: {}\n');
+			expect(ensureBuiltInComponentConfigKeys()).to.deep.equal(['secretCustody']);
+			const doc = YAML.parse(fs.readFileSync(BI_CONFIG_PATH, 'utf8'));
+			expect(doc.secretCustody).to.deep.equal({});
+		});
+
+		it('never re-adds a long-standing built-in absent from the config (e.g. admin-removed replication)', () => {
+			// replication is registered but NOT in the new-built-in backfill list, so a config that
+			// omits it (operator disabled it by removing the block) must stay without it.
+			process.env.HARPER_BUILTIN_COMPONENTS =
+				'replication=@/dist/replication/replicator.js,secretCustody=@/dist/security/keyCustody.js';
+			writeConfig('analytics: {}\n');
+			const added = ensureBuiltInComponentConfigKeys();
+			expect(added).to.deep.equal(['secretCustody']);
+			const doc = YAML.parse(fs.readFileSync(BI_CONFIG_PATH, 'utf8'));
+			expect(doc).to.not.have.property('replication');
+		});
+
+		it('adds nothing on OSS core, which registers no built-ins', () => {
+			delete process.env.HARPER_BUILTIN_COMPONENTS;
+			writeConfig('replication: {}\n');
+			expect(ensureBuiltInComponentConfigKeys()).to.deep.equal([]);
+		});
+
+		it('adds nothing when secretCustody is not registered in this runtime', () => {
+			process.env.HARPER_BUILTIN_COMPONENTS = 'replication=@/dist/replication/replicator.js';
+			writeConfig('replication: {}\n');
+			expect(ensureBuiltInComponentConfigKeys()).to.deep.equal([]);
+		});
+
+		it('is a no-op when secretCustody is already present', () => {
+			process.env.HARPER_BUILTIN_COMPONENTS = 'secretCustody=@/dist/security/keyCustody.js';
+			writeConfig('secretCustody: {}\n');
+			expect(ensureBuiltInComponentConfigKeys()).to.deep.equal([]);
+		});
+	});
+
 	describe('Test getDefaultConfig function', () => {
 		const expected_flat_default_config_obj = {
 			analytics_aggregateperiod: 60,


### PR DESCRIPTION
## Problem

A built-in component only loads when its **top-level config key is present** — `componentLoader` iterates the resolved config's keys (`for (const componentName in config)`) to decide what to activate. Fresh installs get those keys from `defaultConfig.yaml`, but an **in-place upgrade carries the pre-existing `harper-config.yaml` forward**, so a built-in introduced in a newer release never activates on an upgraded instance.

This is the root cause of [HarperFast/harper-pro#585](https://github.com/HarperFast/harper-pro/issues/585): secrets custody stayed dormant on instances upgraded to 5.2.x. The `secretCustody` key (added to `defaultConfig.yaml` for fresh installs) was never added to the carried-forward config, so `set_secret` silently stored values as `unverified` that could never be decrypted. Fresh 5.2.x installs were unaffected. The 5.2.0 upgrade handled the *data* side (`hdb_secret` table) but not the *config* side.

## Fix

Enforce the invariant "a newly-introduced built-in that gates on a config key has that key present" as a **self-healing, every-boot** step (`initialize()` in `bin/run.ts`):

- **`ensureConfigKeysPresent(keys)`** — adds `{}` for any absent top-level key, never touching existing values. Uses the YAML `Document` round-trip so user comments/formatting are preserved. Mirrors the addition into the memoized `configObj` so the component activates on the **same boot** (componentLoader reads the root config from `getConfigObj()`, which is cached before this runs).
- **`ensureBuiltInComponentConfigKeys()`** — the boot-time driver, scoped three ways:
  - **Only genuinely-new built-ins** (`UPGRADE_BACKFILL_BUILTIN_KEYS = ['secretCustody']`), so a long-standing presence-gated key like `replication` is never re-added — a component an operator disabled by deleting its block stays disabled.
  - **Intersected with the built-ins registered in this runtime** (`HARPER_BUILTIN_COMPONENTS`), so nothing is written on OSS core, which registers no built-ins (`secretCustody` is Pro-only).
  - **Idempotent + unconditional**, so it self-heals even when a version bump ships no upgrade directive or a prior write failed.


### Disabling a backfilled built-in (behavior change)

Because the backfill runs **every boot**, deleting the `secretCustody` block is no longer a durable off switch — it is re-added as `{}` and the component re-activates on the next boot. This is deliberate: for a security-custody component, disabling should be an explicit act, not an accident of config drift (config drift dropping the key is exactly what caused #585).

To disable, set an **explicit falsy value**: `secretCustody: false`. `ensureConfigKeysPresent` only writes when a key is *entirely absent* (`hasIn` is presence-based — `true` for `false`/`null`), so an explicit `false` is left untouched, and `componentLoader`'s `if (!config[name]) continue` reads it as disabled. The falsy-disable convention is documented next to the `secretCustody` block in harper-pro's `defaultConfig.yaml` (coordinated PR).

## Tests

13 new unit tests in `unitTests/config/configUtils.test.js` (66 passing total, no regressions) covering: missing-key add, non-destructive of existing values, idempotency, same-boot `configObj` mirroring, safe-list scoping (replication never re-added), OSS-core no-op, and unregistered-in-runtime no-op.

> **Scope note:** this is the OSS `harper` (core) repo, where the generic mechanism lives; `secretCustody` is registered only by harper-pro. The end-to-end upgrade test (5.1.x → 5.2.x → set/read a secret) belongs in **harper-pro** and will follow as a coordinated change against the core bump.

## Cross-model review

Ran the cross-model review (Codex + Gemini + Harper-domain adjudication). No blockers after adjudication. Addressed significant findings:
- **Re-enabling an admin-removed built-in** → scoped the backfill to genuinely-new built-ins (safe-list ∩ registered).
- **No-retry on write failure / no-directive version bump** → moved to an idempotent every-boot path instead of the upgrade-only path.
- Deferred (non-blocking, pre-existing): `atomicWriteFile` doesn't preserve file mode on rewrite — shared by all config writes, single-tenant model, and the backfilled block is `{}` (no key material in `harper-config.yaml`; keys live via fd 3). Worth a separate hardening pass on `atomicWriteFile`.

Fixes HarperFast/harper-pro#585

🤖 Generated with [Claude Code](https://claude.com/claude-code)
