### PR TITLE
fix: gate npm pack --ignore-scripts on install_allow_scripts alone

### DIFF
--- a/components/Application.ts
+++ b/components/Application.ts
@@ -255,7 +255,12 @@ export function parseGitReference(packageIdentifier: string): GitReference | nul
 	const spec = hashIndex === -1 ? packageIdentifier : packageIdentifier.slice(0, hashIndex);
 	if (GIT_URL_PREFIX.test(spec)) return { cloneUrl: spec.slice('git+'.length), committish };
 	if (GIT_PROTOCOL_PREFIX.test(spec)) return { cloneUrl: spec, committish };
-	if (BARE_GIT_HOST_URL_PREFIX.test(spec)) return { cloneUrl: spec, committish };
+	// Both of these forms are ones npm resolves via hosted-git-info, which — unlike the explicit
+	// `git+`/`git:` URL forms above — URL-decodes the whole committish while parsing it (e.g. a
+	// branch name containing `/` arriving as `%2F`-escaped resolves correctly either way, but a
+	// committish using other reserved characters needs this to match a real ref name).
+	const decodedCommittish = committish === undefined ? undefined : decodeURIComponentOrRaw(committish);
+	if (BARE_GIT_HOST_URL_PREFIX.test(spec)) return { cloneUrl: spec, committish: decodedCommittish };
 	const hostedMatch = HOSTED_GIT_PREFIX.exec(spec);
 	if (hostedMatch) {
 		const [, prefix, path] = hostedMatch;
@@ -265,12 +270,21 @@ export function parseGitReference(packageIdentifier: string): GitReference | nul
 			// accepts `gist:[owner/]id`) has no place in the URL and is dropped.
 			const id = path.includes('/') ? path.slice(path.lastIndexOf('/') + 1) : path;
 			if (!/^[^/#:]+$/.test(id)) return null;
-			return { cloneUrl: `https://${host}/${id}.git`, committish };
+			return { cloneUrl: `https://${host}/${id}.git`, committish: decodedCommittish };
 		}
 		if (!/^[^/#:]+\/[^/#:]+$/.test(path)) return null;
-		return { cloneUrl: `https://${host}/${path}.git`, committish };
+		return { cloneUrl: `https://${host}/${path}.git`, committish: decodedCommittish };
 	}
 	return null;
+}
+
+/** decodeURIComponent, falling back to the raw input on a malformed escape rather than throwing. */
+function decodeURIComponentOrRaw(value: string): string {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		return value;
+	}
 }
 
 const NEUTRALIZED_LIFECYCLE_SCRIPTS = ['preinstall', 'install', 'postinstall', 'prepack', 'prepare'];
@@ -304,13 +318,8 @@ async function resolveCommittish(application: Application, committish: string, c
 	if (!SEMVER_COMMITTISH_PREFIX.test(committish)) return committish;
 	// npm's own package-arg parser URL-decodes the value after `semver:` (a range containing `^`/`~`
 	// can arrive percent-encoded, e.g. `#semver:%5E1.0.0`); do the same rather than evaluating it raw.
-	const rawRange = committish.slice('semver:'.length);
-	let range: string;
-	try {
-		range = decodeURIComponent(rawRange);
-	} catch {
-		range = rawRange;
-	}
+	// (A harmless no-op if parseGitReference already decoded the whole committish upstream.)
+	const range = decodeURIComponentOrRaw(committish.slice('semver:'.length));
 
 	// `git tag --list` rather than `for-each-ref --format=...`: nonInteractiveSpawn runs through a
 	// shell, and a `%(...)` format string is unsafe to pass through one.

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -184,8 +184,10 @@ export function isSSHAuthFailure(stderr: string): boolean {
 
 // Git-reference package identifier forms recognized below for the credentialed-clone path: the
 // npm git-url spec forms this repo's own derivePackageIdentifier can produce for a git host
-// credential. An identifier that doesn't match falls back to `npm pack --ignore-scripts` (best
-// effort, same as before this fix — not a regression for a form this can't safely reclone).
+// credential, plus the raw forms a caller may pass directly (any identifier containing ':' is
+// passed through as-is by derivePackageIdentifier). A form parseGitReference doesn't recognize but
+// looksLikeGitReference does is treated as "recognized as git, but not safely handleable" (see
+// extractApplication) rather than silently falling back to `npm pack --ignore-scripts`.
 const GIT_URL_PREFIX = /^git\+(ssh|https?|file):\/\//i;
 const GIT_PROTOCOL_PREFIX = /^git:\/\//i;
 
@@ -202,33 +204,71 @@ const HOSTED_GIT_HOSTS: Record<string, string> = {
 };
 const HOSTED_GIT_PREFIX = /^(github|gitlab|bitbucket|gist):(.+)$/i;
 
+// A bare `https://`/`http://` URL to one of the hosts above is *also* a git-reference install, not a
+// plain download: hosted-git-info (which npm's own git-arg resolution is built on) lists plain
+// http/https in every host's `protocols` array, so `npm pack https://github.com/owner/repo` clones
+// the repo exactly like the `git+https://` form does — it just doesn't carry the `git+` prefix that
+// would otherwise mark it as one.
+const BARE_GIT_HOST_URL_PREFIX = new RegExp(
+	`^https?://(${Object.values(HOSTED_GIT_HOSTS)
+		.map((host) => host.replace(/\./g, '\\.'))
+		.join('|')})/`,
+	'i'
+);
+
 interface GitReference {
 	cloneUrl: string;
 	committish?: string;
 }
 
+// True for a packageIdentifier that names a git source in some form parseGitReference recognizes OR
+// doesn't (a malformed hosted shorthand, or a `#path:` committish naming npm's monorepo-subdirectory
+// extension, which neither this nor the semver-committish resolution below implements). Lets
+// extractApplication distinguish "not git at all" (safe to fall back to plain `npm pack
+// --ignore-scripts`) from "git, but a form we can't safely reclone" (must fail loudly instead).
+function looksLikeGitReference(packageIdentifier: string): boolean {
+	return (
+		GIT_URL_PREFIX.test(packageIdentifier) ||
+		GIT_PROTOCOL_PREFIX.test(packageIdentifier) ||
+		HOSTED_GIT_PREFIX.test(packageIdentifier) ||
+		BARE_GIT_HOST_URL_PREFIX.test(packageIdentifier)
+	);
+}
+
 /**
- * Parses a `git+ssh://…`/`git+https://…`/`git+http://…`/`git+file://…`/`git://…`, or hosted-git
- * shorthand (`github:owner/repo`, `gitlab:owner/repo`, `bitbucket:owner/repo`, `gist:id`) package
- * identifier into a plain clone URL and optional committish, without depending on npm's own git-spec
- * parser (npm-package-arg/hosted-git-info aren't dependencies of this repo). Returns null for any
- * other form.
+ * Parses a `git+ssh://…`/`git+https://…`/`git+http://…`/`git+file://…`/`git://…`, a bare
+ * `https://`/`http://` URL to a known git host, or hosted-git shorthand (`github:owner/repo`,
+ * `gitlab:owner/repo`, `bitbucket:owner/repo`, `gist:[owner/]id`) package identifier into a plain
+ * clone URL and optional committish, without depending on npm's own git-spec parser
+ * (npm-package-arg/hosted-git-info aren't dependencies of this repo).
+ *
+ * Returns null for a `#path:` committish (npm's git-url monorepo-subdirectory extension, which this
+ * doesn't implement — a `#semver:` committish IS handled, downstream, by packGitReferenceWithoutScripts's
+ * resolveCommittish) or for a hosted shorthand that isn't a plain `owner/repo` (or `gist:[owner/]id`)
+ * — callers should treat that as "recognized as git, but not safely handleable" (see
+ * looksLikeGitReference) rather than silently falling back.
  */
 export function parseGitReference(packageIdentifier: string): GitReference | null {
 	const hashIndex = packageIdentifier.indexOf('#');
 	const committish = hashIndex === -1 ? undefined : packageIdentifier.slice(hashIndex + 1);
+	if (committish?.startsWith('path:')) return null;
 	const spec = hashIndex === -1 ? packageIdentifier : packageIdentifier.slice(0, hashIndex);
 	if (GIT_URL_PREFIX.test(spec)) return { cloneUrl: spec.slice('git+'.length), committish };
 	if (GIT_PROTOCOL_PREFIX.test(spec)) return { cloneUrl: spec, committish };
+	if (BARE_GIT_HOST_URL_PREFIX.test(spec)) return { cloneUrl: spec, committish };
 	const hostedMatch = HOSTED_GIT_PREFIX.exec(spec);
 	if (hostedMatch) {
 		const [, prefix, path] = hostedMatch;
 		const host = HOSTED_GIT_HOSTS[prefix.toLowerCase()];
-		// A gist clone URL is keyed by id alone; an optional `owner/` in the shorthand (npm accepts
-		// `gist:[owner/]id`) has no place in the URL and is dropped.
-		const urlPath =
-			prefix.toLowerCase() === 'gist' && path.includes('/') ? path.slice(path.lastIndexOf('/') + 1) : path;
-		return { cloneUrl: `https://${host}/${urlPath}.git`, committish };
+		if (prefix.toLowerCase() === 'gist') {
+			// A gist clone URL is keyed by id alone; an optional `owner/` in the shorthand (npm
+			// accepts `gist:[owner/]id`) has no place in the URL and is dropped.
+			const id = path.includes('/') ? path.slice(path.lastIndexOf('/') + 1) : path;
+			if (!/^[^/#:]+$/.test(id)) return null;
+			return { cloneUrl: `https://${host}/${id}.git`, committish };
+		}
+		if (!/^[^/#:]+\/[^/#:]+$/.test(path)) return null;
+		return { cloneUrl: `https://${host}/${path}.git`, committish };
 	}
 	return null;
 }
@@ -369,33 +409,55 @@ async function packGitReferenceWithoutScripts(
 			await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
 		}
 
-		const { stdout, code, stderr } = await nonInteractiveSpawn(
-			application.name,
-			'npm',
-			['pack', '--json', '--ignore-scripts', cloneDir],
-			parentDirPath,
-			undefined,
-			undefined,
-			application.npmUserconfigPath
-		);
-		if (code !== 0) {
-			throw new Error(`Failed to pack package ${application.packageIdentifier}: ${stderr}`);
-		}
-		let packResult: Array<{ filename: string }>;
-		try {
-			packResult = JSON.parse(stdout.slice(stdout.indexOf('[')));
-		} catch (err) {
-			throw new Error(
-				`Failed to parse npm pack output for ${application.packageIdentifier}: ${err.message}\nstdout: ${stdout}`
-			);
-		}
-		if (!Array.isArray(packResult) || typeof packResult[0]?.filename !== 'string') {
-			throw new Error(`Unexpected npm pack output for ${application.packageIdentifier}:\n${stdout}`);
-		}
-		return join(parentDirPath, packResult[0].filename);
+		return await runNpmPack(application, ['pack', '--json', '--ignore-scripts', cloneDir], parentDirPath);
 	} finally {
 		await rm(cloneDir, { recursive: true, force: true });
 	}
+}
+
+/**
+ * Runs `npm pack` with the given args and returns the resulting tarball's path under `cwd`. Shared
+ * between the git-reference reclone path above and the plain identifier path in extractApplication.
+ */
+async function runNpmPack(
+	application: Application,
+	packArgs: string[],
+	cwd: string,
+	gitCredentialEnv?: Record<string, string>
+): Promise<string> {
+	const { stdout, code, stderr } = await nonInteractiveSpawn(
+		application.name,
+		'npm',
+		packArgs,
+		cwd,
+		undefined,
+		undefined,
+		application.npmUserconfigPath,
+		gitCredentialEnv
+	);
+	if (code !== 0) {
+		if (isSSHAuthFailure(stderr)) {
+			throw new Error(
+				`Failed to deploy private repository ${application.packageIdentifier}: SSH access failed. Verify the repository URL, configure an SSH key on this Harper instance, ensure the key has access to the target repository, and confirm the host is present in the ssh/known_hosts file.`,
+				{ cause: new Error(stderr) }
+			);
+		}
+		throw new Error(`Failed to download package ${application.packageIdentifier}: ${stderr}`);
+	}
+
+	let packResult: Array<{ filename: string }>;
+	try {
+		packResult = JSON.parse(stdout.slice(stdout.indexOf('[')));
+	} catch (err) {
+		throw new Error(
+			`Failed to parse npm pack output for ${application.packageIdentifier}: ${err.message}\nstdout: ${stdout}`
+		);
+	}
+	if (!Array.isArray(packResult) || typeof packResult[0]?.filename !== 'string') {
+		throw new Error(`Unexpected npm pack output for ${application.packageIdentifier}:\n${stdout}`);
+	}
+
+	return join(cwd, packResult[0].filename);
 }
 
 // Hidden directory under the components root holding component versions renamed aside
@@ -486,24 +548,37 @@ export async function extractApplication(application: Application) {
 			//
 			// Packing a git reference is not just a download: npm clones the repo and, if its manifest
 			// has a prepare/build/install script, runs `npm install` inside the clone and then that
-			// script — so the repo's own code AND its dependencies' install scripts execute on this node,
-			// inheriting this spawn's environment. With a credential session live, that is exactly the
-			// reach the credential must not have (a transitive dependency's postinstall could ask the
-			// socket for a token granted for the top-level repository), so scripts are off for a
-			// credentialed clone unless the deploy explicitly opted into them.
-			const scriptsDisallowed = application.gitCredentialEnv && !application.install?.allowInstallScripts;
+			// script — so the repository's (and its dependencies') install scripts can execute on this
+			// node during the pack step alone, independent of the later `npm install`.
+			// `install_allow_scripts` is the operator-facing switch for whether component code is
+			// allowed to run scripts on this node at all — with a credential session live, an
+			// unreviewed script also reaching the socket (a transitive dependency's postinstall asking
+			// for a token granted to the top-level repository) is exactly the reach the credential must
+			// not have, so this gates the pack step regardless of whether a credential happens to be in
+			// play.
+			const allowScripts = !!application.install?.allowInstallScripts;
 			// `--ignore-scripts` alone isn't a reliable way to enforce that: pacote's DirFetcher runs a
 			// git source's `prepare` unconditionally on npm versions before 11.0.0 (see
 			// packGitReferenceWithoutScripts), which is exactly what Node 22's bundled npm ships. For a
 			// recognized git-reference identifier, clone and pack it ourselves with scripts stripped
 			// instead, sidestepping that npm code path entirely.
-			const gitRef = scriptsDisallowed ? parseGitReference(application.packageIdentifier) : null;
+			const gitRef = allowScripts ? null : parseGitReference(application.packageIdentifier);
+
+			if (!allowScripts && !gitRef && looksLikeGitReference(application.packageIdentifier)) {
+				// Recognized as git, but a form the reclone-and-strip-scripts path above can't safely
+				// handle (a `#path:` committish, or a hosted shorthand other than a plain `owner/repo`) —
+				// fail loudly rather than silently falling through to the unreliable `npm pack
+				// --ignore-scripts` below.
+				throw new Error(
+					`Cannot deploy git-reference package '${application.packageIdentifier}' with install scripts disallowed: this identifier's form (e.g. a '#path:' committish, or a hosted shorthand other than a plain 'owner/repo') isn't one this repo's script-suppression handling supports. Set install.allowInstallScripts to true, or use a plain git URL with a branch/tag/commit committish instead.`
+				);
+			}
 
 			if (gitRef) {
 				tarballPath = await packGitReferenceWithoutScripts(application, gitRef, parentDirPath);
 			} else {
 				const packArgs = ['pack', '--json', application.packageIdentifier];
-				if (scriptsDisallowed) {
+				if (!allowScripts) {
 					packArgs.push('--ignore-scripts');
 				} else if (application.gitCredentialEnv) {
 					application.logger.warn(
@@ -512,39 +587,7 @@ export async function extractApplication(application: Application) {
 							`can read the git credential. Unset install_allow_scripts to keep the credential out of their reach.`
 					);
 				}
-				const { stdout, code, stderr } = await nonInteractiveSpawn(
-					application.name,
-					'npm',
-					packArgs,
-					parentDirPath,
-					undefined,
-					undefined,
-					application.npmUserconfigPath,
-					application.gitCredentialEnv
-				);
-				if (code !== 0) {
-					if (isSSHAuthFailure(stderr)) {
-						throw new Error(
-							`Failed to deploy private repository ${application.packageIdentifier}: SSH access failed. Verify the repository URL, configure an SSH key on this Harper instance, ensure the key has access to the target repository, and confirm the host is present in the ssh/known_hosts file.`,
-							{ cause: new Error(stderr) }
-						);
-					}
-					throw new Error(`Failed to download package ${application.packageIdentifier}: ${stderr}`);
-				}
-
-				let packResult: Array<{ filename: string }>;
-				try {
-					packResult = JSON.parse(stdout.slice(stdout.indexOf('[')));
-				} catch (err) {
-					throw new Error(
-						`Failed to parse npm pack output for ${application.packageIdentifier}: ${err.message}\nstdout: ${stdout}`
-					);
-				}
-				if (!Array.isArray(packResult) || typeof packResult[0]?.filename !== 'string') {
-					throw new Error(`Unexpected npm pack output for ${application.packageIdentifier}:\n${stdout}`);
-				}
-
-				tarballPath = join(parentDirPath, packResult[0].filename);
+				tarballPath = await runNpmPack(application, packArgs, parentDirPath, application.gitCredentialEnv);
 			}
 			shouldDeleteTarball = true;
 			tarball = createReadStream(tarballPath);

--- a/unitTests/components/Application.test.js
+++ b/unitTests/components/Application.test.js
@@ -130,6 +130,47 @@ describe('parseGitReference', () => {
 	it('returns null for a file identifier', () => {
 		assert.strictEqual(parseGitReference('file:../local-app'), null);
 	});
+
+	it('returns null for a #path: committish (npm git-url subdirectory extension, unimplemented)', () => {
+		assert.strictEqual(parseGitReference('github:my-org/my-app#path:packages/foo'), null);
+	});
+
+	it('returns null for a malformed hosted shorthand (not a plain owner/repo)', () => {
+		assert.strictEqual(parseGitReference('github:not-owner-slash-repo'), null);
+	});
+
+	it('parses a bare https:// URL to a known git host', () => {
+		assert.deepStrictEqual(parseGitReference('https://github.com/my-org/my-app'), {
+			cloneUrl: 'https://github.com/my-org/my-app',
+			committish: undefined,
+		});
+	});
+
+	// hosted-git-info (which npm's own resolution for `owner:repo` shorthand and bare host URLs is
+	// built on) URL-decodes the whole committish while parsing these two forms specifically.
+	it('decodes a percent-encoded committish for the github: shorthand, matching hosted-git-info', () => {
+		assert.deepStrictEqual(parseGitReference('github:my-org/my-app#feature%2Ffoo'), {
+			cloneUrl: 'https://github.com/my-org/my-app.git',
+			committish: 'feature/foo',
+		});
+	});
+
+	it('decodes a percent-encoded committish for a bare host URL, matching hosted-git-info', () => {
+		assert.deepStrictEqual(parseGitReference('https://github.com/my-org/my-app#feature%2Ffoo'), {
+			cloneUrl: 'https://github.com/my-org/my-app',
+			committish: 'feature/foo',
+		});
+	});
+
+	// An explicit git+ URL form goes through npm-package-arg's own URL.hash extraction instead of
+	// hosted-git-info, which does NOT decode the committish — so this deliberately does not either,
+	// matching real npm rather than "fixing" what would be a divergence from it.
+	it('does NOT decode a percent-encoded committish for an explicit git+https:// URL, matching npm-package-arg', () => {
+		assert.deepStrictEqual(parseGitReference('git+https://example.com/owner/repo.git#feature%2Ffoo'), {
+			cloneUrl: 'https://example.com/owner/repo.git',
+			committish: 'feature%2Ffoo',
+		});
+	});
 });
 
 describe('assertApplicationConfig credentials', () => {

--- a/unitTests/components/gitCredentialClone.test.js
+++ b/unitTests/components/gitCredentialClone.test.js
@@ -174,7 +174,11 @@ describe('private git-reference deploy (real clone over authenticated git-over-h
 		const application = new Application({ name: 'git-clone-unauthenticated', packageIdentifier });
 		await assert.rejects(
 			() => extractApplication(application),
-			/Failed to download package/,
+			// Without install_allow_scripts (the default), install scripts are disallowed regardless of
+			// whether a credential is present (harper#1818/#1819), so this now takes the
+			// clone-and-strip-scripts path (packGitReferenceWithoutScripts) rather than a plain `npm
+			// pack` — its own clone failure is worded differently ("clone" vs "download").
+			/Failed to clone package/,
 			'a private repo must not be cloneable without a credential'
 		);
 		// npm points git at its own `GIT_ASKPASS=echo` when we supply none, so git does attempt an empty
@@ -334,6 +338,7 @@ describe('private git-reference deploy (real clone over authenticated git-over-h
 		await application.startGitCredentialSession();
 		await application.cleanupGitCredentialSession();
 
-		await assert.rejects(() => extractApplication(application), /Failed to download package/);
+		// Same clone-and-strip-scripts path as above, so the same wording applies once the socket is gone.
+		await assert.rejects(() => extractApplication(application), /Failed to clone package/);
 	});
 });

--- a/unitTests/components/gitPackIgnoreScripts.test.js
+++ b/unitTests/components/gitPackIgnoreScripts.test.js
@@ -10,7 +10,7 @@
 // uncredentialed git-reference deploy, against a real local git repo and real npm pack rather than
 // asserting on the constructed spawn args.
 
-const assert = require('node:assert/strict');
+const assert = require('node:assert');
 const fs = require('node:fs/promises');
 const { existsSync } = require('node:fs');
 const os = require('node:os');
@@ -119,19 +119,19 @@ describe('bare https/http git-host URL recognition (#1819)', function () {
 	it('parses a bare https:// URL to a known git host into a clone URL', function () {
 		const ref = parseGitReference('https://github.com/owner/repo.git');
 		assert.ok(ref);
-		assert.equal(ref.cloneUrl, 'https://github.com/owner/repo.git');
-		assert.equal(ref.committish, undefined);
+		assert.strictEqual(ref.cloneUrl, 'https://github.com/owner/repo.git');
+		assert.strictEqual(ref.committish, undefined);
 	});
 
 	it('parses a bare http:// URL with a committish', function () {
 		const ref = parseGitReference('http://gitlab.com/owner/repo#deadbeef');
 		assert.ok(ref);
-		assert.equal(ref.cloneUrl, 'http://gitlab.com/owner/repo');
-		assert.equal(ref.committish, 'deadbeef');
+		assert.strictEqual(ref.cloneUrl, 'http://gitlab.com/owner/repo');
+		assert.strictEqual(ref.committish, 'deadbeef');
 	});
 
 	it('does not treat a bare URL to an unrecognized host as a git reference', function () {
-		assert.equal(parseGitReference('https://example.com/owner/repo.git'), null);
+		assert.strictEqual(parseGitReference('https://example.com/owner/repo.git'), null);
 	});
 
 	// `#semver:` was originally unimplemented here too (as this test's history shows — see blame),

--- a/unitTests/components/gitPackIgnoreScripts.test.js
+++ b/unitTests/components/gitPackIgnoreScripts.test.js
@@ -1,0 +1,152 @@
+'use strict';
+
+// Regression for #1818: `npm pack` on a git-reference deploy isn't just a download — npm clones
+// the repo and, if its manifest has a prepare/build/install script, runs `npm install` inside the
+// clone and then that script, so the repository's own code runs on this node during the pack step
+// alone, before the later `npm install` even starts. `install_allow_scripts` is the operator-facing
+// switch for whether a deployed component's scripts may run on this node, so it has to gate this
+// step too — previously it only reached the later `npm install`, and only when a git credential
+// happened to be in play (harper#1799). This proves the gate now applies to a plain,
+// uncredentialed git-reference deploy, against a real local git repo and real npm pack rather than
+// asserting on the constructed spawn args.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const { existsSync } = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const testUtils = require('../testUtils.js');
+testUtils.preTestPrep();
+
+const { Application, extractApplication, parseGitReference } = require('#src/components/Application');
+const { getConfigPath } = require('#src/config/configUtils');
+const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
+
+// git may not be installed/in PATH in every test environment; resolve this before mocha's before()
+// hook so we can skip gracefully instead of crashing the whole suite's loading.
+let GIT_AVAILABLE = true;
+try {
+	execFileSync('git', ['--version'], { stdio: 'ignore' });
+} catch {
+	GIT_AVAILABLE = false;
+}
+
+// A bare repo with one commit, whose manifest carries a prepare script — which npm runs, inside
+// the clone, during `npm pack`.
+async function createRepo(root, name) {
+	const work = path.join(root, `work-${name}`);
+	const bare = path.join(root, `${name}.git`);
+	await fs.mkdir(work, { recursive: true });
+	await fs.writeFile(
+		path.join(work, 'package.json'),
+		JSON.stringify({ name, version: '1.0.0', scripts: { prepare: 'node ./mark.js' } }, null, 2)
+	);
+	await fs.writeFile(
+		path.join(work, 'mark.js'),
+		`require('node:fs').writeFileSync(process.env.HARPER_TEST_PACK_MARKER, 'ran');\n`
+	);
+	const git = (...args) => execFileSync('git', args, { cwd: work, stdio: 'pipe' });
+	git('init', '--quiet', '--initial-branch=main');
+	git('config', 'user.email', 'test@harperdb.io');
+	git('config', 'user.name', 'Harper Test');
+	git('config', 'commit.gpgsign', 'false');
+	git('add', '.');
+	git('commit', '--quiet', '-m', 'initial');
+	execFileSync('git', ['clone', '--quiet', '--bare', work, bare], { stdio: 'pipe' });
+	return bare;
+}
+
+describe('npm pack --ignore-scripts for git-reference deploys (#1818)', function () {
+	this.timeout(60_000);
+
+	let root;
+	let packageIdentifier;
+	let marker;
+
+	before(async function () {
+		if (process.platform === 'win32' || !GIT_AVAILABLE) return this.skip();
+		// extractApplication packs into the components root, which the unit-test config points at
+		// but does not create.
+		await fs.mkdir(getConfigPath(CONFIG_PARAMS.COMPONENTSROOT), { recursive: true });
+		root = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-git-pack-'));
+		const bare = await createRepo(root, 'pack-scripted');
+		packageIdentifier = `git+file://${bare}`;
+	});
+
+	after(async () => {
+		if (root) await fs.rm(root, { recursive: true, force: true });
+	});
+
+	beforeEach(() => {
+		marker = path.join(root, `marker-${process.hrtime.bigint()}`);
+	});
+
+	afterEach(async () => {
+		delete process.env.HARPER_TEST_PACK_MARKER;
+		await fs.rm(marker, { force: true });
+	});
+
+	it('does not run the prepare script during npm pack when install_allow_scripts is unset, without a git credential involved', async () => {
+		const application = new Application({ name: 'pack-scripted-default', packageIdentifier });
+		process.env.HARPER_TEST_PACK_MARKER = marker;
+
+		await extractApplication(application);
+
+		assert.ok(!existsSync(marker), 'prepare script must not run during npm pack by default');
+	});
+
+	it('runs the prepare script during npm pack when install_allow_scripts is explicitly true', async () => {
+		const application = new Application({
+			name: 'pack-scripted-allowed',
+			packageIdentifier,
+			install: { allowInstallScripts: true },
+		});
+		process.env.HARPER_TEST_PACK_MARKER = marker;
+
+		await extractApplication(application);
+
+		assert.ok(existsSync(marker), 'prepare script should run once scripts are explicitly allowed');
+	});
+});
+
+// Regression for the #1819 review comment: a bare `https://`/`http://` git-host URL (no `git+`
+// prefix) is resolved by npm exactly like `git+https://` — hosted-git-info lists plain http/https
+// in every known host's `protocols` array — so it must be recognized as a git reference too,
+// instead of silently falling through to the unreliable `npm pack --ignore-scripts` path.
+describe('bare https/http git-host URL recognition (#1819)', function () {
+	it('parses a bare https:// URL to a known git host into a clone URL', function () {
+		const ref = parseGitReference('https://github.com/owner/repo.git');
+		assert.ok(ref);
+		assert.equal(ref.cloneUrl, 'https://github.com/owner/repo.git');
+		assert.equal(ref.committish, undefined);
+	});
+
+	it('parses a bare http:// URL with a committish', function () {
+		const ref = parseGitReference('http://gitlab.com/owner/repo#deadbeef');
+		assert.ok(ref);
+		assert.equal(ref.cloneUrl, 'http://gitlab.com/owner/repo');
+		assert.equal(ref.committish, 'deadbeef');
+	});
+
+	it('does not treat a bare URL to an unrecognized host as a git reference', function () {
+		assert.equal(parseGitReference('https://example.com/owner/repo.git'), null);
+	});
+
+	// `#semver:` was originally unimplemented here too (as this test's history shows — see blame),
+	// but harper#1797's follow-up added semver-range committish resolution
+	// (packGitReferenceWithoutScripts's resolveCommittish), so a `#semver:` committish is now a
+	// safely-handleable form regardless of URL shape. `#path:` (npm's git-url monorepo-subdirectory
+	// extension) remains genuinely unimplemented by either feature, so it's used here instead to
+	// exercise the same "recognized as git, but not safely handleable" guard.
+	it('refuses a bare-URL git reference in a form it cannot safely handle, rather than falling through to npm pack --ignore-scripts', async function () {
+		if (process.platform === 'win32' || !GIT_AVAILABLE) return this.skip();
+		const application = new Application({
+			name: 'pack-bare-url-unsupported',
+			packageIdentifier: 'https://github.com/some-owner/some-repo#path:packages/foo',
+		});
+
+		await assert.rejects(extractApplication(application), /install scripts disallowed/);
+	});
+});


### PR DESCRIPTION
## Summary
`npm pack` on a git-reference `packageIdentifier` isn't just a download — npm clones the repo and, if its manifest has a `prepare`/`build`/`install` script, runs `npm install` inside the clone and then that script. That means the repo's own code (and its dependencies' install scripts) can execute on this node during the pack step alone, before the later `npm install` even runs. `install_allow_scripts` is the operator-facing switch for whether a deployed component may run scripts on this node at all, but it never reached this pack step — so a git-reference deploy with `install_allow_scripts: false` still ran pack-time scripts unconditionally.

Fixes this by passing `--ignore-scripts` to `npm pack` whenever `install_allow_scripts` is not explicitly enabled, for any non-`file:` `packageIdentifier`.

Refs #1818

## Note on scope vs. the issue text
The issue (and #1799, still open/unmerged) describes this as a `gitCredentialEnv &&`-gated condition. `gitCredentialEnv` doesn't exist on `main` yet — it's introduced by #1799, which isn't merged. What *does* exist on `main` today is the more fundamental gap: `npm pack` never passed `--ignore-scripts` at all, regardless of `install_allow_scripts`, for **any** git-reference deploy (credentialed or not). This PR fixes that root gap directly, unconditionally on `!application.install?.allowInstallScripts` — no `gitCredentialEnv` involved, since it isn't in scope on `main`.

When #1799 lands, its `gitCredentialEnv`-gated `--ignore-scripts` condition will need to be reconciled with this change — per the issue's own suggested fix, that just means dropping the `application.gitCredentialEnv &&` prefix, since the gate this PR adds already covers it.

The issue also asks to re-examine the adjacent warn-log branch (only fires today when `gitCredentialEnv` is set and scripts are allowed). That branch doesn't exist on `main` either — it's credential-specific wording tied to #1799's still-unmerged feature, so there's nothing to change here; #1799 is the right place to decide whether that log should also fire for the uncredentialed allow-scripts case.

## Test coverage
Added `unitTests/components/gitPackIgnoreScripts.test.js` — an end-to-end test against a real local git repo and real `npm pack` (no mocking of the spawn args), following the pattern already used by #1799's `gitCredentialClone.test.js`:
- prepare script does **not** run during pack when `install_allow_scripts` is unset (default), with no git credential involved
- prepare script **does** run when `install_allow_scripts: true` is explicitly set

Existing `Application.test.js`, `extractApplicationSwap.test.js`, `applicationSpawn.test.js`, and `packageComponent.test.js` pass unchanged, as does the full `test:unit:main` suite (3423 passing; the 10 `globalIsolation.test.js` failures are a pre-existing worktree-environment issue — a `node_modules` path-resolution mismatch unrelated to this change, confirmed by reproducing them against `main` with this diff stashed out).

## Update: rebased onto main now that #1797/#1799 are merged
#1797 (git credential sessions) and #1799 (semver-range committish resolution) both merged to `main` after this branch was created, and both independently rewrote the same region of `Application.ts` (`parseGitReference`, `packGitReferenceWithoutScripts`, and the `extractApplication` gating logic this PR touches). A plain `git rebase main` applied with no conflict markers but silently discarded #1797/#1799's entire credential-threading and semver-resolution work — confirmed by diffing the rebase result against `main` and finding `gitCredentialEnv`, `resolveCommittish`, etc. missing entirely. Reconciled by hand instead of trusting that result; see the "Rebase onto main and reconcile..." commit message for the detailed reasoning.

The merged implementation keeps #1797's credential-threading and semver resolution, plus this PR's `looksLikeGitReference`/bare-URL recognition, `runNpmPack` dedup, and — per this PR's own note above — broadens the script-suppression gate to `!allowInstallScripts` alone (dropping the credential requirement). `parseGitReference` now rejects only `#path:` (still unimplemented) rather than also `#semver:`, since #1797 makes that form handleable.

A follow-up push addressed two Codex CLI findings from cross-model review of the rebase: `parseGitReference` now decodes a percent-encoded committish for the `owner:repo` shorthand and bare host URLs (matching hosted-git-info's actual behavior, verified by reading its source), while deliberately leaving explicit `git+`/`git:` URL forms undecoded (matching npm-package-arg's own, different behavior for those forms) — plus a test-lint fix.

**Two further findings from that review are open, not fixed in this PR** — pre-existing gaps in this PR's own `looksLikeGitReference`/`BARE_GIT_HOST_URL_PREFIX` design (not introduced by the rebase), each judged to need independently-risky, non-trivial changes to close properly rather than a quick guess under this rebase's scope:
- `looksLikeGitReference`/`parseGitReference` don't recognize npm's SSH shorthand forms (`git@host:owner/repo.git`, `ssh://git@host/...`) or SourceHut. Those still fall through to the plain `npm pack --ignore-scripts` path — still attempted (this PR's core fix does apply), just not the more robust reclone-and-strip-scripts path, so they retain the pacote/npm&lt;11 `--ignore-scripts` caveat already documented above `packGitReferenceWithoutScripts`.
- `BARE_GIT_HOST_URL_PREFIX` matches any path under a known git host, including a hosted tarball archive URL (e.g. `.../archive/refs/tags/v1.0.0.tar.gz`), which would misclassify a previously-working tarball deploy as a git clone and attempt `git clone` against it. Properly distinguishing the two needs per-host path-shape rules matching hosted-git-info's own archive-URL detection — worth a focused follow-up.

Rebased test suite (`gitSemverCommittish.test.js`, `Application.test.js`, `gitCredentials.test.js`, `gitCredentialClone.test.js`, `gitPackIgnoreScripts.test.js`, `extractApplicationSwap.test.js`, `applicationSpawn.test.js`, `packageComponent.test.js`, `credentials.test.js`) all pass — 89 tests.

---
Generated by Claude Sonnet 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
