### PR TITLE
fix(txn): retry ERR_TRY_AGAIN on the same transaction (native in-place reset)

### DIFF
--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -463,6 +463,17 @@ export class DatabaseTransaction implements Transaction {
 								// at MAX_RETRIES; sourceApply transactions keep retrying with periodic warn.
 								if (this.retries > MAX_RETRIES) {
 									if (!this.sourceApply) {
+										// giving up: release the transaction so the throw does not leak its native handle
+										// (mirrors the rejection-path give-up below; without it the handle — and any
+										// unpublished transaction-log position — lingers until GC)
+										try {
+											transaction.abort();
+										} catch (abortError) {
+											harperLogger.debug?.(
+												'aborting conflicted transaction after exhausting coordinated retries',
+												abortError
+											);
+										}
 										throw new ServerError(
 											`After ${MAX_RETRIES} coordinated retries, unable to commit transaction, transaction is in conflict with ongoing writes`
 										);

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -354,7 +354,7 @@ export class DatabaseTransaction implements Transaction {
 	 */
 	commit(options: CommitOptions = {}): MaybePromise<CommitResolution> {
 		if (this.timedOut) throw transactionOpenTooLongError();
-		let transaction = options.transaction ?? this.transaction; // we need to preserve this transaction as we might to resurrect it if we have to retry
+		const transaction = options.transaction ?? this.transaction; // reused across retries; the native layer resets it in place (fresh snapshot) on IsBusy/TryAgain
 		for (let i = 0; i < this.writes.length; i++) {
 			let operation = this.writes[i];
 			if (!operation || (this.retries === 0 && operation.saved)) continue;
@@ -544,35 +544,18 @@ export class DatabaseTransaction implements Transaction {
 								// for future transactions
 								this.retries++;
 								harperLogger.debug?.('retrying', transaction.id, this.retries);
-								if (error.code === 'ERR_TRY_AGAIN') {
-									// ERR_BUSY recovers on recommit: the save loop re-writes each key, re-tracking it at
-									// the current sequence, so validation passes once the contention clears. ERR_TRY_AGAIN
-									// never does: the memtable history validation needs is gone (flushed during a
-									// bulk-ingest burst), and recommitting re-checks the same stranded snapshot, so it
-									// fails forever even on an idle database. A source-apply transaction's uncapped retry
-									// then spins for good and wedges the replication apply loop at its commit await,
-									// freezing every leg of that database on the node. Replay onto a fresh transaction
-									// instead: the save loop reloads each entry through it and re-resolves against
-									// current state. Carry over the commit hook the transaction-log store attached
-									// (aftercommit emit / structure watermarks; it reads its state off the original
-									// transaction object, which abort() leaves intact); the retry-site isRetry stamp
-									// below keeps the log entries themselves from being re-added.
-									const retryTransaction: RocksTransactionWithRetry = new RocksTransaction(
-										(this.writes.find((write) => write)?.store.store ?? this.db.store) as RocksStore
-									);
-									if (this.timestamp) retryTransaction.setTimestamp(this.timestamp);
-									(retryTransaction as any).onCommit = (transaction as any).onCommit;
-									try {
-										transaction.abort();
-									} catch (abortError) {
-										// usually already released by the failed commit; log for the unexpected case
-										harperLogger.debug?.('aborting stranded transaction after failed commit', abortError);
-									}
-									transaction = retryTransaction;
-								}
+								// ERR_BUSY and ERR_TRY_AGAIN are both retried by recommitting the SAME native
+								// transaction. ERR_BUSY recovers because the save loop re-writes each key, re-tracking
+								// it at the current sequence. ERR_TRY_AGAIN — a snapshot stranded outside the memtable
+								// conflict-check window after a bulk-ingest flush — used to fail forever on recommit
+								// because the native layer left the stranded snapshot in place; rocksdb-js now resets
+								// the transaction onto a fresh snapshot on the failed TryAgain commit, exactly as it
+								// always did for IsBusy, so the re-run's save loop re-resolves against current state and
+								// converges. Keeping the same transaction means its committedPosition survives the reset
+								// (WAL write-once, rocksdb-js#668) and its onCommit hook stays attached, so the
+								// already-staged change-feed entry publishes only when the retry really commits — no
+								// premature publish, and no fresh-transaction replay that would drop the entry.
 								// Mark the native transaction as a retry so RocksTransactionLogStore skips re-staging entries.
-								// Stamp AFTER the possible ERR_TRY_AGAIN swap above so the fresh replay transaction is
-								// marked too; otherwise it would re-stage audit/change-feed log entries on recommit.
 								(transaction as RocksTransactionWithRetry).isRetry = true;
 								if (this.retries > 2) {
 									// Transactions applying data from a canonical source of truth (replication peer or
@@ -584,8 +567,7 @@ export class DatabaseTransaction implements Transaction {
 									const neverDropOnConflict = this.sourceApply;
 									if (this.retries > MAX_RETRIES) {
 										if (!neverDropOnConflict) {
-											// giving up: release the current transaction (original or the fresh replay above)
-											// so the throw does not leak its native handle
+											// giving up: release the transaction so the throw does not leak its native handle
 											try {
 												transaction.abort();
 											} catch (abortError) {

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -463,17 +463,9 @@ export class DatabaseTransaction implements Transaction {
 								// at MAX_RETRIES; sourceApply transactions keep retrying with periodic warn.
 								if (this.retries > MAX_RETRIES) {
 									if (!this.sourceApply) {
-										// giving up: release the transaction so the throw does not leak its native handle
-										// (mirrors the rejection-path give-up below; without it the handle — and any
-										// unpublished transaction-log position — lingers until GC)
-										try {
-											transaction.abort();
-										} catch (abortError) {
-											harperLogger.debug?.(
-												'aborting conflicted transaction after exhausting coordinated retries',
-												abortError
-											);
-										}
+										// giving up: poison and abort the whole linked chain so no link leaks its native
+										// handle / read snapshot — or any unpublished transaction-log position — until GC.
+										this.abortChainAfterRetries(transaction);
 										throw new ServerError(
 											`After ${MAX_RETRIES} coordinated retries, unable to commit transaction, transaction is in conflict with ongoing writes`
 										);
@@ -578,12 +570,9 @@ export class DatabaseTransaction implements Transaction {
 									const neverDropOnConflict = this.sourceApply;
 									if (this.retries > MAX_RETRIES) {
 										if (!neverDropOnConflict) {
-											// giving up: release the transaction so the throw does not leak its native handle
-											try {
-												transaction.abort();
-											} catch (abortError) {
-												harperLogger.debug?.('aborting conflicted transaction after exhausting retries', abortError);
-											}
+											// giving up: poison and abort the whole linked chain so no link leaks its native
+											// handle / read snapshot until GC.
+											this.abortChainAfterRetries(transaction);
 											throw new ServerError(
 												`After ${MAX_RETRIES} retries, unable to commit transaction, transaction is in conflict with ongoing writes`
 											);
@@ -644,6 +633,35 @@ export class DatabaseTransaction implements Transaction {
 		// reset the transaction
 		this.writes = [];
 		if (this.#context?.resourceCache) this.#context.resourceCache = null;
+	}
+	/**
+	 * Give up on a chain of linked transactions after exhausting conflict retries: poison every link
+	 * first, then abort each link's native transaction and release its DatabaseTransaction-level
+	 * resources. Two passes (mirroring abortDueToTimeout) so a throw while aborting one link can't leave
+	 * later links (this.next) holding native handles / read snapshots until GC. `headTransaction` is the
+	 * head link's native transaction, which commit() detached to a local before this point
+	 * (this.transaction is already null), so it is aborted directly; every other link still owns its
+	 * native transaction on `txn.transaction`.
+	 */
+	abortChainAfterRetries(headTransaction: RocksTransaction): void {
+		for (let txn: DatabaseTransaction = this; txn; txn = txn.next) {
+			txn.open = TRANSACTION_STATE.CLOSED;
+		}
+		for (let txn: DatabaseTransaction = this; txn; txn = txn.next) {
+			const nativeTxn = txn === this ? headTransaction : txn.transaction;
+			// Clear the native handle and read-snapshot bookkeeping so the abort() below only performs
+			// non-native cleanup (blobs, writes) and can't double-abort (RocksTransaction.abort() throws
+			// on an already-aborted handle) or spin abort()'s doneReadTxn loop on a nulled handle.
+			txn.transaction = null;
+			txn.readTxnsUsed = 0;
+			trackedTxns.delete(txn);
+			try {
+				nativeTxn?.abort();
+			} catch (abortError) {
+				harperLogger.debug?.('aborting conflicted transaction in chain after exhausting retries', abortError);
+			}
+			txn.abort();
+		}
 	}
 	/**
 	 * True if this transaction — or any database in its multi-store `next` chain — has writes accumulated

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -660,7 +660,14 @@ export class DatabaseTransaction implements Transaction {
 			} catch (abortError) {
 				harperLogger.debug?.('aborting conflicted transaction in chain after exhausting retries', abortError);
 			}
-			txn.abort();
+			try {
+				// abort() synchronously walks savedBlobs and can call write.store.getEntry(), which can throw
+				// (closed store, decode error). Catch and continue so one link's wrapper-cleanup failure can't
+				// strand later links' native handles — they were already detached/aborted above regardless.
+				txn.abort();
+			} catch (abortError) {
+				harperLogger.debug?.('cleaning up conflicted transaction in chain after exhausting retries', abortError);
+			}
 		}
 	}
 	/**

--- a/unitTests/resources/sourceApplyConflictRetry.test.js
+++ b/unitTests/resources/sourceApplyConflictRetry.test.js
@@ -11,12 +11,13 @@ const RETRY_NOW_VALUE = require('@harperfast/rocksdb-js').constants.RETRY_NOW_VA
 
 // A source-apply commit that fails its optimistic-conflict check must converge on retry. ERR_BUSY
 // always could: recommitting re-writes each key, re-tracking it at the current sequence, so
-// validation passes once the contention clears. ERR_TRY_AGAIN never could: the memtable history
+// validation passes once the contention clears. ERR_TRY_AGAIN could not: the memtable history
 // validation needs is gone (flushed during a bulk-ingest burst), and recommitting the same
-// transaction re-checks the same stranded snapshot, so it fails forever even on an idle database.
-// The uncapped source-apply retry then spins for good and wedges the replication apply loop at its
-// commit await, freezing every replication leg of that database on the node. ERR_TRY_AGAIN retries
-// must replay the writes onto a fresh transaction so validation runs against current state.
+// transaction re-checked the same stranded snapshot, so it failed forever even on an idle database.
+// The uncapped source-apply retry then spun for good and wedged the replication apply loop at its
+// commit await, freezing every replication leg of that database on the node. rocksdb-js now resets
+// the transaction onto a fresh snapshot on a failed TryAgain commit (as it always did for IsBusy),
+// so the retry recommits the SAME transaction and its re-run validates against current state.
 describe('source-apply conflict retry converges instead of spinning', () => {
 	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
 	let SpinTable;
@@ -32,8 +33,8 @@ describe('source-apply conflict retry converges instead of spinning', () => {
 		});
 	});
 
-	// Spy on commits so the test can see which attempt failed validation and whether the retry ran
-	// on a fresh transaction (a new transaction id) or recommitted the failed one.
+	// Spy on commits so the test can see which attempt failed validation and confirm the retry
+	// recommitted the same transaction (same id) after the native in-place snapshot reset.
 	function spyOnCommits() {
 		const { Transaction } = require('@harperfast/rocksdb-js');
 		const originalCommit = Transaction.prototype.commit;
@@ -144,10 +145,10 @@ describe('source-apply conflict retry converges instead of spinning', () => {
 			assert.ok(failed, 'the flush should strand the snapshot outside the memtable window');
 			const retried = attempts.find((attempt, index) => attempt.ok && index > attempts.indexOf(failed));
 			assert.ok(retried, 'a later commit attempt must succeed');
-			assert.notEqual(retried.id, failed.id, 'the retry must run on a fresh transaction');
-			assert.ok(
-				!attempts.some((attempt, index) => index > attempts.indexOf(failed) && attempt.id === failed.id),
-				'the stranded transaction must never be recommitted'
+			assert.equal(
+				retried.id,
+				failed.id,
+				'the retry must recommit the same transaction, reset in place onto a fresh snapshot'
 			);
 		} finally {
 			restore();

--- a/unitTests/resources/sourceApplyConflictRetry.test.js
+++ b/unitTests/resources/sourceApplyConflictRetry.test.js
@@ -5,6 +5,7 @@ const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { transaction } = require('#src/resources/transaction');
 const { setTimeout: delay } = require('node:timers/promises');
+const { DatabaseTransaction, TRANSACTION_STATE, setTxnExpiration } = require('#src/resources/DatabaseTransaction');
 // A coordinatedRetry transaction (the source-apply path) signals an optimistic write conflict by
 // resolving commit() with this sentinel instead of rejecting with ERR_BUSY.
 const RETRY_NOW_VALUE = require('@harperfast/rocksdb-js').constants.RETRY_NOW_VALUE;
@@ -243,5 +244,68 @@ describe('source-apply conflict retry converges instead of spinning', () => {
 		} finally {
 			restore();
 		}
+	});
+});
+
+// abortChainAfterRetries() gives up on a linked chain of transactions (multi-store commit) after
+// exhausting conflict retries. Its two-pass design (poison every link, then abort/release each) exists
+// specifically so a throw from one link's cleanup can't strand later links holding native handles /
+// read snapshots until GC. Exercised directly against the class rather than through 40 real retries,
+// which would require forcing MAX_RETRIES real conflicts end-to-end.
+describe('abortChainAfterRetries chain cleanup', () => {
+	// A minimal stand-in for a native RocksTransaction: abort() is the only method the wrapper calls.
+	function fakeNative() {
+		return {
+			aborted: false,
+			abort() {
+				this.aborted = true;
+			},
+		};
+	}
+
+	it("still detaches, untracks, and natively aborts later links when an earlier link's wrapper cleanup throws", () => {
+		const head = new DatabaseTransaction();
+		const next = new DatabaseTransaction();
+		head.next = next;
+
+		const headNative = fakeNative();
+		const nextNative = fakeNative();
+		next.transaction = nextNative;
+
+		// The head's write throws from wrapper cleanup (abort() synchronously calls
+		// write.store.getEntry(), which can fail on a closed store or decode error).
+		head.writes = [
+			{
+				savedBlobs: true,
+				key: 'poison',
+				store: {
+					getEntry() {
+						throw new Error('store closed');
+					},
+				},
+			},
+		];
+		next.writes = [];
+
+		const trackedTxns = setTxnExpiration(30000); // grabs the module's live tracking Set, no behavior change
+		trackedTxns.add(head);
+		trackedTxns.add(next);
+
+		// Must not throw: a link's cleanup failure is caught and logged, not propagated (or it would
+		// pre-empt the caller's give-up ServerError at the call site).
+		assert.doesNotThrow(() => head.abortChainAfterRetries(headNative));
+
+		assert.equal(head.open, TRANSACTION_STATE.CLOSED, 'head must be poisoned even though its cleanup threw');
+		assert.equal(next.open, TRANSACTION_STATE.CLOSED, 'later link must be poisoned');
+
+		assert.ok(headNative.aborted, 'head native transaction must still be aborted');
+		assert.ok(
+			nextNative.aborted,
+			"later link's native transaction must be aborted despite the earlier link's cleanup exception"
+		);
+
+		assert.equal(next.transaction, null, 'later link must have its native handle detached');
+		assert.ok(!trackedTxns.has(head), 'head must be untracked');
+		assert.ok(!trackedTxns.has(next), "later link must be untracked despite the earlier link's cleanup exception");
 	});
 });


### PR DESCRIPTION
Pairs with HarperFast/rocksdb-js#710. rocksdb-js 2.5.0 is now published; rebased onto latest `main` (which had independently picked up the same dependency bump) and verified against the real native build — see Validation below.

## Problem

#1696 fixed the #1695 source-apply `ERR_TRY_AGAIN` spin by replaying the writes onto a **fresh** `RocksTransaction`, because the native layer left the stranded snapshot in place so recommitting the same transaction never converged. But that workaround leaned on a rocksdb-js defect: the transaction-log publish gate (`!IsBusy`) published the change-feed entry on the **failed** commit, and the fresh replay (marked `isRetry`) relied on that premature publish to keep the entry from being lost — an entry visible ahead of its data for every reader in the window, and a permanent phantom if the retry was ultimately abandoned.

## Fix

rocksdb-js#710 makes the native layer reset the transaction onto a fresh snapshot on a failed `TryAgain` commit — exactly as it always did for `IsBusy` — and publish log entries only on a real commit. So the fresh-transaction replay becomes both unnecessary and wrong (a fresh transaction with `isRetry` would never publish the now-unpublished entry, re-manifesting #1695). This PR:

- **Recommits the SAME transaction on `ERR_TRY_AGAIN`, like `ERR_BUSY` always did.** Its `committedPosition` survives the native reset (WAL write-once, rocksdb-js#668) and its `onCommit` hook stays attached, so the staged change-feed entry publishes exactly once, only when the retry really commits.
- **Aborts the native transaction on coordinated-retry give-up** (pre-existing gap surfaced by review: the `RETRY_NOW` exhaustion path threw without releasing the handle, leaving an unpublished log position pinning the committed-read watermark until GC; the rejection-path give-up already aborted).
- **Poisons and aborts the whole linked chain on give-up**, not just the head, via a shared `abortChainAfterRetries()` helper mirroring `abortDueToTimeout()`'s two-pass pattern — and guards each link's wrapper cleanup (`txn.abort()`, which can throw from `savedBlobs`/`getEntry()`) so one link's failure can't strand later links' native handles/read snapshots.
- **Bumps `@harperfast/rocksdb-js` to `^2.5.0`** — the paired-fix floor.

The `Table.ts` `appendedAuditEntry` guards from #1696 are deliberately **kept**: they already govern the `ERR_BUSY` same-transaction recommit, and the scenario they defend against is *less* reachable now (failed attempts never publish). Whether the TryAgain-specific rationale is now dead code deserves its own analysis — follow-up issue to come.

## Validation

Against the real, published rocksdb-js 2.5.0 build:

- `unitTests/resources/sourceApplyConflictRetry.test.js` — including the **real** `compact()`-induced `ERR_TRY_AGAIN` repro, with the assertion inverted from fresh-transaction-id to **same**-transaction-id — plus a new focused unit test forcing one chain link's wrapper cleanup to throw and asserting later links are still detached/untracked/natively aborted. 5/5 passing.
- `npm run test:unit:resources`: 1249/1249 passing.
- `npm ci`, `format:check`, `lint:required`: clean.
- CI: Format Check, Lint, Integration Tests, Claude PR Review all green. `Unit Test` had one unrelated flaky failure (`caching.test.js`, timing-based) that passed on rerun. The advisory, non-blocking `Next.js Integration Tests (downstream)` check fails on a pre-existing `main` type error (unrelated to this diff, already being fixed on a separate branch).

## Review history

Two review passes, both addressed:

**Cross-model review (Codex ×2 + Harper-domain adjudication; Gemini leg failed — agy hang):**
- **Blocker (addressed):** version coupling not encoded → `^2.5.0` floor.
- **Verified & fixed:** coordinated give-up abort (above).
- **Adjudicated no-new-hazard:** the `appendedAuditEntry` double-apply scenario requires a failed attempt's entry to be *visible* during retry — exactly what the new publish gate removes.

**Live discussion review (Codex + Harper domain pass) after 2.5.0 published:**
- **Blocker (addressed):** lockfile still resolved 2.4.0 after the manifest bump; regenerated against the real 2.5.0 publish and rebased onto `main`'s independent bump of the same dependency to restore a clean merge (which had also silently stalled `pull_request`-triggered CI).
- **Significant (addressed):** `abortChainAfterRetries()`'s per-link wrapper `txn.abort()` was unguarded — a throw on an early link (from `savedBlobs`/`getEntry()`) exited the cleanup loop before later chain links were touched, contradicting the two-pass design's own guarantee (also independently flagged by Gemini earlier in review — see inline thread). Fixed by guarding that call too, with a regression test.

*KrAIs, via Claude*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
