### PR TITLE
fix(sandbox): wire the six typed-resources exports into the component sandbox

### DIFF
--- a/resources/defineResource.ts
+++ b/resources/defineResource.ts
@@ -550,12 +550,25 @@ function applyContractMetadata(carrier: any, contract: Contract): void {
  */
 function wrapStaticVerb(original: Function, compiled: CompiledVerb): Function {
 	const { queryFragment, bodyFragment, hasBody } = compiled;
+	function validateAndDispatch(this: any, target: any, rest: any[], body: any) {
+		const issues: ValidationIssue[] = [];
+		if (queryFragment) coerceAndValidateQuery(queryFragment, target, issues);
+		if (hasBody && bodyFragment) rest[0] = validateBody(bodyFragment, body, issues);
+		if (issues.length) throw new ValidationError(issues);
+		return original.call(this, target, ...rest);
+	}
 	return function (this: any, target: any, ...rest: any[]) {
 		if (target instanceof URLSearchParams) {
-			const issues: ValidationIssue[] = [];
-			if (queryFragment) coerceAndValidateQuery(queryFragment, target, issues);
-			if (hasBody && bodyFragment) rest[0] = validateBody(bodyFragment, rest[0], issues);
-			if (issues.length) throw new ValidationError(issues);
+			const body = rest[0];
+			// REST.ts's streaming deserializer hands the body over as a still-pending promise
+			// (`request.data`); await it before validating, or it reads as an empty object and every
+			// declared-required field is (incorrectly) reported missing. A plain value (as passed by a
+			// programmatic call or a unit test) validates synchronously, preserving the synchronous-throw
+			// contract those callers rely on.
+			if (hasBody && bodyFragment && body && typeof body.then === 'function') {
+				return body.then((resolvedBody: any) => validateAndDispatch.call(this, target, rest, resolvedBody));
+			}
+			return validateAndDispatch.call(this, target, rest, body);
 		}
 		return original.call(this, target, ...rest);
 	};

--- a/resources/openApi.ts
+++ b/resources/openApi.ts
@@ -102,6 +102,10 @@ export function generateJsonApi(resources: Resources, serverHttpURL: string) {
 		// @hidden type-level: drop the Resource from the OpenAPI document entirely.
 		// Data remains queryable through Harper's other interfaces under RBAC.
 		if (resource.Resource.hidden === true) continue;
+		// request-contract resources (`defineResource`/`Resource.withSchema`) at a static (non-parameterised)
+		// path are emitted below, alongside their parameterised counterparts, off the declared contract —
+		// not the table-CRUD assumptions this loop makes (primary key, generated schema component, etc).
+		if (resource.Resource.requestContract) continue;
 
 		const { path } = resource;
 		const strippedPath = path.split('/').pop(); // strip any namespace from path
@@ -311,26 +315,14 @@ export function generateJsonApi(resources: Resources, serverHttpURL: string) {
 		}
 	}
 
-	// Parameterised routes (e.g. `/widget/:id/action/:action`) live outside the resource Map; emit them as templated
-	// paths with `{param}` path parameters so they appear in the OpenAPI document like any other endpoint.
-	for (const route of resources.paramRoutes ?? []) {
-		const entry = route.entry;
-		if (!entry?.path || entry.Resource?.isError) continue;
-		// @hidden: drop the Resource from the OpenAPI document entirely.
-		if (entry.Resource?.hidden === true) continue;
+	// Emit OpenAPI paths for a request-contract resource (`defineResource`/`Resource.withSchema`), whether
+	// declared at a static path (`/OrderIntake`) or a parameterised one (`/widget/:id`) — each verb's
+	// query/body/response is driven off the shared `inputSchemas`/`outputSchemas` the contract compiled,
+	// the same `JsonSchemaFragment` IR that drives runtime validation/coercion, so the spec matches what
+	// the server actually enforces (rather than the table-CRUD generation above).
+	const emitContractRoutes = (url: string, entry: { Resource: any }, pathParams: any[]) => {
 		const { prototype } = entry.Resource;
-		if (!prototype) continue;
-
-		const { template, params } = routePatternToTemplate(route.segments);
-		const url = `/${template}`;
-		const pathParams = params.map((param) => {
-			const parameter = new Parameter(param.name, 'path', { type: 'string' });
-			parameter.required = true;
-			parameter.description = param.wildcard
-				? 'captures the remaining path segments'
-				: `value bound from the :${param.name} path segment`;
-			return parameter;
-		});
+		if (!prototype) return;
 
 		const tableDoc: string | undefined = entry.Resource.description;
 		const withDoc = (sentence: string) => (tableDoc ? `${tableDoc} ${sentence}` : sentence);
@@ -408,6 +400,35 @@ export function generateJsonApi(resources: Resources, serverHttpURL: string) {
 				}
 			);
 		}
+	};
+
+	// Request-contract resources declared at a static (non-parameterised) path (e.g. `defineResource({path:
+	// '/OrderIntake', ...})`) — skipped by the table-CRUD loop above, emitted here off the declared contract.
+	for (const [, entry] of resources) {
+		if (!entry.Resource?.requestContract || entry.Resource.isError || entry.Resource.hidden === true) continue;
+		emitContractRoutes(`/${entry.path}`, entry, []);
+	}
+
+	// Parameterised routes (e.g. `/widget/:id/action/:action`) live outside the resource Map; emit them as templated
+	// paths with `{param}` path parameters so they appear in the OpenAPI document like any other endpoint.
+	for (const route of resources.paramRoutes ?? []) {
+		const entry = route.entry;
+		if (!entry?.path || entry.Resource?.isError) continue;
+		// @hidden: drop the Resource from the OpenAPI document entirely.
+		if (entry.Resource?.hidden === true) continue;
+
+		const { template, params } = routePatternToTemplate(route.segments);
+		const url = `/${template}`;
+		const pathParams = params.map((param) => {
+			const parameter = new Parameter(param.name, 'path', { type: 'string' });
+			parameter.required = true;
+			parameter.description = param.wildcard
+				? 'captures the remaining path segments'
+				: `value bound from the :${param.name} path segment`;
+			return parameter;
+		});
+
+		emitContractRoutes(url, entry, pathParams);
 	}
 
 	for (const [, value] of resources.allTypes) {

--- a/resources/openApi.ts
+++ b/resources/openApi.ts
@@ -321,6 +321,7 @@ export function generateJsonApi(resources: Resources, serverHttpURL: string) {
 	// the same `JsonSchemaFragment` IR that drives runtime validation/coercion, so the spec matches what
 	// the server actually enforces (rather than the table-CRUD generation above).
 	const emitContractRoutes = (url: string, entry: { Resource: any }, pathParams: any[]) => {
+		if (!entry?.Resource) return;
 		const { prototype } = entry.Resource;
 		if (!prototype) return;
 
@@ -405,8 +406,11 @@ export function generateJsonApi(resources: Resources, serverHttpURL: string) {
 	// Request-contract resources declared at a static (non-parameterised) path (e.g. `defineResource({path:
 	// '/OrderIntake', ...})`) — skipped by the table-CRUD loop above, emitted here off the declared contract.
 	for (const [, entry] of resources) {
-		if (!entry.Resource?.requestContract || entry.Resource.isError || entry.Resource.hidden === true) continue;
-		emitContractRoutes(`/${entry.path}`, entry, []);
+		if (!entry) continue;
+		if (!entry.path || !entry.Resource?.requestContract || entry.Resource.isError || entry.Resource.hidden === true)
+			continue;
+		const path = entry.path.startsWith('/') ? entry.path : '/' + entry.path;
+		emitContractRoutes(path, entry, []);
 	}
 
 	// Parameterised routes (e.g. `/widget/:id/action/:action`) live outside the resource Map; emit them as templated

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -3,6 +3,8 @@ import { contextStorage, transaction } from '../resources/transaction.ts';
 import { RequestTarget } from '../resources/RequestTarget.ts';
 import { tables, databases } from '../resources/databases.ts';
 import { models as harperModelsSingleton } from '../resources/models/Models.ts';
+import { defineTable, types } from '../resources/defineTable.ts';
+import { defineResource, t, schemaOf, projectTableFragment } from '../resources/defineResource.ts';
 import { readFile } from 'node:fs/promises';
 import { dirname, isAbsolute } from 'node:path';
 import { pathToFileURL, fileURLToPath } from 'node:url';
@@ -805,6 +807,12 @@ function getHarperExports(scope: ApplicationScope) {
 		Resource,
 		tables,
 		databases,
+		defineTable,
+		types,
+		defineResource,
+		t,
+		schemaOf,
+		projectTableFragment,
 		// `harper.models` — same singleton that's surfaced as the top-level
 		// `models` package export (see `resources/models/Models.ts`).  The
 		// registry it reads from is populated at boot by

--- a/unitTests/resources/defineResource.test.js
+++ b/unitTests/resources/defineResource.test.js
@@ -164,6 +164,29 @@ describe('defineResource / Resource.withSchema — runtime request contract', ()
 			// first arg is not a URLSearchParams → the wrapper delegates untouched
 			assert.doesNotThrow(() => Widget.post({ notATarget: true }, { anything: 1 }));
 		});
+
+		it('awaits a thenable body (the REST streaming path) before validating, dispatching the resolved value', async () => {
+			const target = targetWith('limit=1', '1');
+			const result = await Widget.post(target, Promise.resolve({ name: 'ok', count: 3 }));
+			assert.deepStrictEqual(result, {});
+			assert.strictEqual(ran, true);
+		});
+
+		it('rejects a bad resolved value on a thenable body with the same per-field issues', async () => {
+			const target = targetWith('limit=1', '1');
+			let error;
+			try {
+				await Widget.post(target, Promise.resolve({ name: 5 }));
+			} catch (e) {
+				error = e;
+			}
+			assert.ok(error, 'should throw');
+			assert.strictEqual(error.name, 'ValidationError');
+			const codes = error.errors.map((i) => `${i.path}:${i.code}`);
+			assert.ok(codes.includes('body.name:type'), codes.join(','));
+			assert.ok(codes.includes('body.count:required'), codes.join(','));
+			assert.strictEqual(ran, false);
+		});
 	});
 
 	describe('nullability — non-nullable by default, .nullable opts in', () => {

--- a/unitTests/resources/openApi-contract.test.js
+++ b/unitTests/resources/openApi-contract.test.js
@@ -79,3 +79,51 @@ describe('openApi — request-contract emission', () => {
 		expect(Object.keys(postResponse.properties)).to.deep.equal(['id']);
 	});
 });
+
+// a request-contract resource declared at a static (non-parameterised) path lives in the `resources`
+// Map itself (not `resources.paramRoutes`, which only holds parameterised routes) — skipped by the
+// table-CRUD loop above and emitted by the same `emitContractRoutes` helper, off the declared contract.
+function makeStaticContractResource() {
+	function OrderIntake() {}
+	OrderIntake.prototype.post = function () {};
+	OrderIntake.path = 'order-intake';
+	OrderIntake.requestContract = { path: '/order-intake' };
+	OrderIntake.inputSchemas = {
+		post: {
+			body: { type: 'object', properties: { sku: { type: 'string' } }, required: ['sku'] },
+		},
+	};
+	OrderIntake.outputSchemas = {
+		post: { type: 'object', properties: { id: { type: 'string' } } },
+	};
+	return OrderIntake;
+}
+
+function makeResourcesWithStaticContract() {
+	const resources = new Map();
+	resources.allTypes = new Map();
+	resources.set('order-intake', { path: 'order-intake', Resource: makeStaticContractResource() });
+	return resources;
+}
+
+describe('openApi — request-contract emission at a static path (resources Map, not paramRoutes)', () => {
+	let api;
+	beforeEach(() => {
+		api = generateJsonApi(makeResourcesWithStaticContract(), serverURL);
+	});
+
+	it('emits the path off the declared contract instead of falling through to table-CRUD', () => {
+		expect(api.paths['/order-intake']).to.exist;
+		expect(api.paths['/order-intake'].get).to.be.undefined;
+	});
+
+	it('emits the declared request body and response schema on POST', () => {
+		const post = api.paths['/order-intake'].post;
+		expect(post).to.exist;
+		const schema = post.requestBody.content['application/json'].schema;
+		expect(schema.properties).to.have.property('sku');
+		expect(schema.required).to.deep.equal(['sku']);
+		const response = post.responses['200'].content['application/json'].schema;
+		expect(Object.keys(response.properties)).to.deep.equal(['id']);
+	});
+});

--- a/unitTests/security/jsLoader/jsLoader.test.js
+++ b/unitTests/security/jsLoader/jsLoader.test.js
@@ -66,6 +66,12 @@ describe('scopedImport', () => {
 		const result = await scopedImport(join(__dirname, 'fixtures', 'uses-harperdb.cjs'), scope);
 		expect(result.Resource).to.be.a('function');
 		expect(result.tables).to.exist;
+		expect(result.defineTable).to.be.a('function');
+		expect(result.defineResource).to.be.a('function');
+		expect(result.schemaOf).to.be.a('function');
+		expect(result.projectTableFragment).to.be.a('function');
+		expect(result.t).to.exist;
+		expect(result.types).to.exist;
 		// #1325/#1534: the model-backend registration API reaches components through
 		// `require('harperdb').models` (getHarperExports) — methods on the models
 		// singleton, NOT separate top-level exports (those generic globals were


### PR DESCRIPTION
## Summary

The code-first typed-resources API (`defineTable`, `defineResource`, `t`, `schemaOf`, `projectTableFragment`, `types`, added in #1767 / RFC 0001) is exported from the package's public surface but was missing from `getHarperExports()` in `security/jsLoader.ts`. That object feeds the synthetic `harper` module the sandboxed/lockdown component loader builds, so a component doing `import { defineTable, defineResource } from 'harper'` failed at **link time** — every route on the component 500s. The `native` loader mode (which imports the real package) was unaffected. The feature was effectively dead-on-arrival via its only documented component-authoring entry point.

Fixes the missing exports, plus two further defects the fix uncovered (see below).

## Changes

- **`security/jsLoader.ts`** — add the six exports as real runtime values to `getHarperExports()`.
- **`resources/defineResource.ts`** — `wrapStaticVerb`'s body validation ran synchronously against `request.data`, but REST.ts's streaming deserializer hands the body over as a still-pending `Promise`. The validator always saw an empty object and reported every required field missing, regardless of what was actually sent. Now awaits a thenable body before validating; a plain value (programmatic `.post(record)` calls, unit tests) still validates and throws synchronously — preserves the existing sync-throw contract those callers rely on.
- **`resources/openApi.ts`** — OpenAPI generation only read a resource's declared request contract (`inputSchemas`/`outputSchemas`) for parameterised routes (`/widget/:id`). A `defineResource` endpoint at a static path (no `:id`, e.g. `/OrderIntake`) fell through the table-CRUD generator instead and lost its documented request/response shape. Extracted the contract-driven path emission into a shared `emitContractRoutes` helper used by both static and parameterised contract resources.

## Why the extra two fixes

Once the sandbox link-time failure was fixed, the reachability itself exposed these two bugs — previously nothing ever exercised a `defineResource` endpoint through the real request path, since the whole component failed to load. Both are required to get the repro test's remaining probes green, and both are small, targeted fixes in the same files/area as the primary fix.

## Test plan

`integrationTests/qa-scratch/qa560-typed-resources.test.ts` (gitignored QA-explorer scratch fixture, not part of this diff — a `defineTable`/`defineResource` component with no `.graphql` file, loaded through the real sandboxed `jsResource` path): **9/11 → 11/11** passing.

Also ran, all clean:
- `npm run build`
- `npm run test:unit:main` (excluding one pre-existing-broken suite unrelated to this change — `unitTests/components/globalIsolation.test.js` fails identically on unmodified `main` in this worktree, a `node_modules` path-sandboxing artifact of the worktree setup, not a code regression)
- `npm run test:unit:resources` (1128 passing, 0 failing)
- `oxlint` / `prettier` clean on changed files

## Findings (not fixed — out of scope for this PR)

- **Declared `response` schemas are documentation-only, not runtime-enforced.** `defineResource`'s contract lets you declare a per-verb `response` shape (`t.object({...})`), and OpenAPI reflects it, but nothing validates the actual handler return value against it — a handler can return extra/undeclared properties silently. Verified via the repro test's dedicated probe. Worth a design discussion: either enforce it or make the "advisory-only" nature explicit in the `response` schema's doc comment.
- **A hand-rolled raw JSON-Schema `body`/`query` object silently disables validation.** `internalOf()` (`resources/defineResource.ts:70`) reads `schema?._fragment`; a plain object with no `_fragment` marker (i.e., not built via `t.*`/`schemaOf`) resolves to an empty fragment (`{}`), and `validateBody`/`coerceAndValidateQuery` treat an empty/typeless fragment as "nothing to validate" — the declared contract becomes a silent no-op with no error or warning. This was flagged in the original issue as a landmine worth checking once `defineResource` was reachable; confirmed real. Not fixed here (would need either stricter typing to reject raw fragment objects at the `body`/`query` call sites, or a runtime shape-detection + warning) — flagging for a follow-up.

Refs [harper#1815](https://github.com/HarperFast/harper/issues/1815)

Generated by Claude Sonnet 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)