### PR TITLE
test(resources): promote QA read-consistency regression anchors

### DIFF
--- a/integrationTests/apiTests/utils/lifecycle.mjs
+++ b/integrationTests/apiTests/utils/lifecycle.mjs
@@ -1,36 +1,44 @@
 import assert from 'node:assert';
 import { setTimeout } from 'node:timers/promises';
+import { awaitJobCompleted } from './operations.mjs';
 
 const DEFAULT_READINESS_TIMEOUT_MS = 60000;
 const READINESS_POLL_INTERVAL_MS = 250;
 
 /**
- * Trigger `restart_service http_workers` and wait for the REST workers (and
- * any newly-registered component routes) to be serving traffic again.
+ * Trigger `restart_service http_workers` and wait for the restart to actually complete and
+ * the REST workers (and any newly-registered component routes) to be serving traffic again.
+ *
+ * On return the old workers are gone: callers can assume every subsequent request is served
+ * by a worker that will outlive the restart.
  *
  * `probePath` should be a REST route that returns a non-404 once the
  * just-installed component has registered its resources — typically the
  * route the test is about to exercise. Any response in [200, 499] excluding
  * 404 is treated as ready; 4xx auth/validation responses are fine.
  *
- * Replaces a fixed-duration sleep so the helper scales to slower
- * environments (Windows CI, contended runners).
- *
  * @param {ReturnType<import('./client.mjs').createApiClient>} client
  * @param {string} probePath REST path that should be served by the component
  * @param {number} [timeoutMs] overall readiness budget (default 60s)
  */
 export async function restartHttpWorkers(client, probePath, timeoutMs = DEFAULT_READINESS_TIMEOUT_MS) {
-	await client
+	const { body } = await client
 		.req()
 		.send({ operation: 'restart_service', service: 'http_workers' })
 		.expect((r) => assert.ok(r.body.message.includes('Restarting http_workers'), r.text))
 		.expect(200);
 
-	// Give the supervisor a moment to actually tear down the existing workers
-	// before polling, otherwise the first probe may hit a still-serving worker
-	// that's about to die.
-	await setTimeout(500);
+	// `restart_service` is a job: this 200 only means the job THREAD was launched
+	// (serverUtilities.executeJob -> jobRunner.runJob -> launchJobThread), not that any worker
+	// has been touched. The real teardown lands ~1s later, and later still on a contended
+	// runner. Waiting for the job to reach COMPLETE is what actually orders us *after* the
+	// restart: the job thread only returns once the main thread has posted `restart-complete`
+	// (bin/restart.ts), which it does after `restartWorkers('http')` has fully returned.
+	// Without this gate the readiness probe below reports on the OLD workers and the restart
+	// then kills them under the test that just started (#1833). The operations API is served
+	// by the main thread, so it stays reachable while the http workers cycle.
+	assert.ok(body.job_id, `restart_service returned no job_id: ${JSON.stringify(body)}`);
+	await awaitJobCompleted(client, body.job_id, { timeoutSeconds: Math.ceil(timeoutMs / 1000) });
 
 	const deadline = Date.now() + timeoutMs;
 	let lastStatus;

--- a/integrationTests/resources/relationship-graphql-snapshot-consistency.test.ts
+++ b/integrationTests/resources/relationship-graphql-snapshot-consistency.test.ts
@@ -1,0 +1,231 @@
+/**
+ * QA-593 — nested GraphQL @relationship expansion: cross-level read consistency under
+ * concurrent atomic child writes.
+ *
+ * Model: Publisher 1--* Series (Series.publisherId) 1--* Article (Article.seriesId), a
+ * 3-level @relationship graph at moderate scale (4 publishers x 8 series x 25 articles =
+ * 836 rows). Harper's relationship expander runs one search() at the parent level
+ * (Series) and a separate search() at the child level (Article) to fill in a nested
+ * GraphQL selection. A same-table bulk `update` ops-array call with no validation errors
+ * runs inside one transaction (atomic, all-or-nothing), so if a writer atomically
+ * bulk-updates all N children of a series to a new `gen` value, a single read of
+ * "articles for seriesId=X" nested under that series must see EITHER the fully-old
+ * generation OR the fully-new generation for the sibling set — never a mix (a torn read)
+ * — if the nested expansion reads the child collection through one consistent snapshot.
+ *
+ * Parent-vs-child generation SKEW across levels is expected and not itself a defect:
+ * Series.gen and its Article.gen values are written in two separate transactions
+ * (children first, then parent), so some skew across levels is normal.
+ *
+ * Originating QA-id: QA-593. Promoted from the qa-explorer promote-candidates snapshot
+ * (P-380) after a cold gate rerun on main.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { resolve } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
+import { createApiClient } from '../apiTests/utils/client.mjs';
+// @ts-expect-error utils/lifecycle.mjs has no type declarations; runtime resolves fine
+import { restartHttpWorkers } from '../apiTests/utils/lifecycle.mjs';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'relationship-graphql-snapshot-consistency');
+const skipSuite = process.env.HARPER_RUNTIME === 'bun' || process.platform === 'win32';
+
+const PUBLISHERS = 4;
+const SERIES_PER_PUB = 8;
+const ARTICLES_PER_SERIES = 25;
+const WRITE_ITERATIONS = 150;
+
+const pubId = (p: number) => `pub${p}`;
+const seriesId = (p: number, s: number) => `ser-${p}-${s}`;
+const articleId = (p: number, s: number, a: number) => `art-${p}-${s}-${a}`;
+
+suite(
+	'QA-593 content-catalog 3-level @relationship graph x GraphQL cross-level snapshot consistency',
+	{ skip: skipSuite },
+	(ctx: ContextWithHarper) => {
+		let client: ReturnType<typeof createApiClient>;
+		const findings: string[] = [];
+
+		async function gql(query: string) {
+			return client.reqGraphQl().send({ query }).timeout(10_000);
+		}
+		async function insert(table: string, records: any[]) {
+			return client.req().send({ operation: 'insert', table, records }).expect(200);
+		}
+		async function update(table: string, records: any[]) {
+			return client.req().send({ operation: 'update', table, records }).timeout(10_000);
+		}
+
+		before(async () => {
+			await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: {}, env: {} });
+			client = createApiClient(ctx.harper);
+
+			// Routes register async post-setup; only assert after this poll (per ttl.test.ts pattern).
+			await restartHttpWorkers(client, '/Publisher/', 120_000);
+
+			const publishers: any[] = [];
+			const series: any[] = [];
+			const articles: any[] = [];
+			for (let p = 0; p < PUBLISHERS; p++) {
+				publishers.push({ id: pubId(p), name: `publisher-${p}` });
+				for (let s = 0; s < SERIES_PER_PUB; s++) {
+					series.push({ id: seriesId(p, s), publisherId: pubId(p), name: `series-${p}-${s}`, gen: 0 });
+					for (let a = 0; a < ARTICLES_PER_SERIES; a++) {
+						articles.push({
+							id: articleId(p, s, a),
+							seriesId: seriesId(p, s),
+							title: `article-${p}-${s}-${String(a).padStart(3, '0')}`,
+							gen: 0,
+						});
+					}
+				}
+			}
+			await insert('Publisher', publishers);
+			await insert('Series', series);
+			for (let i = 0; i < articles.length; i += 200) await insert('Article', articles.slice(i, i + 200));
+
+			await sleep(1000); // index settle
+			console.log(
+				`[QA-593] seeded: publishers=${publishers.length} series=${series.length} articles=${articles.length}`
+			);
+		});
+
+		after(async () => {
+			await teardownHarper(ctx);
+			for (const f of findings) console.log('  ' + f);
+		});
+
+		// ============================================================== sanity / control
+		test('S sanity: static full-graph nested GraphQL traversal is complete and correctly parented at scale', async () => {
+			const t0 = performance.now();
+			const r = await gql('{ Publisher { id series { id publisherId gen articles { id seriesId gen } } } }');
+			const elapsed = performance.now() - t0;
+			strictEqual(r.status, 200, r.text);
+			const pubs = r.body?.data?.Publisher ?? [];
+			strictEqual(pubs.length, PUBLISHERS, 'must return all publishers');
+
+			let seriesCount = 0;
+			let articleCount = 0;
+			let misparented = 0;
+			for (const pub of pubs) {
+				for (const ser of pub.series ?? []) {
+					seriesCount++;
+					if (ser.publisherId !== pub.id) misparented++;
+					for (const art of ser.articles ?? []) {
+						articleCount++;
+						if (art.seriesId !== ser.id) misparented++;
+					}
+				}
+			}
+			const msg = `S sanity: publishers=${pubs.length} series=${seriesCount}/${PUBLISHERS * SERIES_PER_PUB} articles=${articleCount}/${PUBLISHERS * SERIES_PER_PUB * ARTICLES_PER_SERIES} misparented=${misparented} elapsed=${elapsed.toFixed(0)}ms`;
+			console.log(`[S] ${msg}`);
+			findings.push(msg);
+
+			strictEqual(seriesCount, PUBLISHERS * SERIES_PER_PUB, 'full series fan-out at scale');
+			strictEqual(articleCount, PUBLISHERS * SERIES_PER_PUB * ARTICLES_PER_SERIES, 'full article fan-out at scale');
+			strictEqual(misparented, 0, 'every child must resolve under its correct parent (no cross-wiring)');
+			ok(
+				elapsed < 15_000,
+				`full 836-row 3-level traversal should not take unreasonably long (got ${elapsed.toFixed(0)}ms)`
+			);
+		});
+
+		// ============================================================== main experiment
+		test('R cross-level snapshot consistency: nested GraphQL Series->articles under concurrent atomic child writes', async () => {
+			const hotSeries = seriesId(0, 0);
+			const hotArticleIds = Array.from({ length: ARTICLES_PER_SERIES }, (_, a) => articleId(0, 0, a));
+
+			const state = { done: false, writeErrors: 0, lastGenWritten: 0 };
+			const samples: { articlesLen: number; distinctChildGens: number; childGen: number | null; seriesGen: number }[] =
+				[];
+			let readErrors = 0;
+
+			async function writer() {
+				for (let i = 1; i <= WRITE_ITERATIONS; i++) {
+					try {
+						// Children first, atomically (single ops-array transaction), THEN parent
+						// (separate transaction) -- deliberately maximizing the parent/child skew
+						// window while keeping each individual write atomic within its own table.
+						const childRecords = hotArticleIds.map((id) => ({ id, gen: i }));
+						const childRes = await update('Article', childRecords);
+						if (childRes.status !== 200) state.writeErrors++;
+						const parentRes = await update('Series', [{ id: hotSeries, gen: i }]);
+						if (parentRes.status !== 200) state.writeErrors++;
+						state.lastGenWritten = i;
+					} catch {
+						state.writeErrors++;
+					}
+				}
+				state.done = true;
+			}
+
+			async function reader() {
+				while (!state.done) {
+					try {
+						const r = await gql(`{ Series(id: "${hotSeries}") { id gen articles { id gen } } }`);
+						if (r.status !== 200) {
+							readErrors++;
+							continue;
+						}
+						const ser = r.body?.data?.Series?.[0];
+						const arts: { id: string; gen: number }[] = ser?.articles ?? [];
+						const distinctGens = new Set(arts.map((a) => a.gen));
+						samples.push({
+							articlesLen: arts.length,
+							distinctChildGens: distinctGens.size,
+							childGen: distinctGens.size === 1 ? [...distinctGens][0] : null,
+							seriesGen: ser?.gen,
+						});
+					} catch {
+						readErrors++;
+					}
+				}
+			}
+
+			await Promise.all([writer(), reader()]);
+
+			const tornSamples = samples.filter((s) => s.distinctChildGens > 1);
+			const incompleteSamples = samples.filter((s) => s.articlesLen !== ARTICLES_PER_SERIES);
+			const skewSamples = samples.filter((s) => s.distinctChildGens === 1 && s.childGen !== s.seriesGen);
+
+			const msg =
+				`R race result: writeIters=${WRITE_ITERATIONS} writeErrors=${state.writeErrors} readErrors=${readErrors} ` +
+				`samples=${samples.length} torn(child-level mixed gens)=${tornSamples.length} incomplete(articlesLen!=${ARTICLES_PER_SERIES})=${incompleteSamples.length} ` +
+				`parentChildSkew=${skewSamples.length}/${samples.length} (${((skewSamples.length / Math.max(samples.length, 1)) * 100).toFixed(1)}%)`;
+			console.log(`[R] ${msg}`);
+			if (tornSamples.length) console.log(`[R] first torn sample: ${JSON.stringify(tornSamples[0])}`);
+			findings.push(
+				msg +
+					(tornSamples.length === 0 && incompleteSamples.length === 0
+						? ' -> READ-SIDE CONSISTENT'
+						: ' -> DEFECT SUSPECTED')
+			);
+			findings.push(
+				`R parent/child skew is EXPECTED (two separate transactions racing) and not itself a defect; only torn/incomplete child-set reads are.`
+			);
+
+			strictEqual(
+				state.writeErrors,
+				0,
+				'writer must not encounter ops-API errors (rules out harness/setup error before judging read side)'
+			);
+			ok(
+				samples.length > 20,
+				`reader should have gathered a meaningful number of samples during the race (got ${samples.length})`
+			);
+			strictEqual(
+				incompleteSamples.length,
+				0,
+				'every nested articles[] must have exactly ARTICLES_PER_SERIES entries (no dropped siblings mid-race)'
+			);
+			strictEqual(
+				tornSamples.length,
+				0,
+				'sibling Article rows returned under one Series in one response must never show mixed generations (atomic write must not be observable as torn on read)'
+			);
+		});
+	}
+);

--- a/integrationTests/resources/relationship-graphql-snapshot-consistency/config.yaml
+++ b/integrationTests/resources/relationship-graphql-snapshot-consistency/config.yaml
@@ -1,0 +1,4 @@
+graphqlSchema:
+  files: '*.graphql'
+rest: true
+graphql: true

--- a/integrationTests/resources/relationship-graphql-snapshot-consistency/schema.graphql
+++ b/integrationTests/resources/relationship-graphql-snapshot-consistency/schema.graphql
@@ -1,0 +1,31 @@
+# QA-593 (rel-pagination variant) — content-catalog 3-level @relationship graph,
+# instrumented with a monotonic `gen` counter at the Series and Article level so a
+# concurrent-write race can be detected from the READ side (see test file header).
+#
+# Chain: Publisher 1--* Series (Series.publisherId) 1--* Article (Article.seriesId)
+#   Publisher.series = @relationship(to: publisherId)
+#   Series.articles  = @relationship(to: seriesId)
+# All FKs @indexed.
+
+type Publisher @table @export {
+	id: ID @primaryKey
+	name: String
+	series: [Series] @relationship(to: publisherId)
+}
+
+type Series @table @export {
+	id: ID @primaryKey
+	publisherId: ID @indexed
+	name: String
+	gen: Int
+	publisher: Publisher @relationship(from: publisherId)
+	articles: [Article] @relationship(to: seriesId)
+}
+
+type Article @table @export {
+	id: ID @primaryKey
+	seriesId: ID @indexed
+	title: String
+	gen: Int
+	series: Series @relationship(from: seriesId)
+}

--- a/integrationTests/resources/sourcedfrom-eav-cache-coherence.test.ts
+++ b/integrationTests/resources/sourcedfrom-eav-cache-coherence.test.ts
@@ -1,0 +1,381 @@
+/**
+ * QA-595 — EAV product catalog fronted by a cache-sourced (`sourcedFrom`) resource:
+ * read-consistency of the assembled view under concurrent attribute-by-attribute writes.
+ *
+ * A "product" is not a row. It's assembled at read time from N Attribute rows (one row
+ * per entity+attribute-name — a real EAV junction table, keyed `${entityId}:${attrName}`).
+ * Product is a `@table(expiration: 3)` cache resource whose sourcedFrom get() reads those
+ * 5 rows ONE AT A TIME (deterministic order: name, price, color, stock, description) and
+ * returns the assembled view. The EAV substrate's unit of write (one row, one independent
+ * HTTP PUT) and the cache's unit of consistency (one assembled product, one cache entry)
+ * disagree — attribute-by-attribute mutation is inherently non-atomic from the cache's
+ * point of view.
+ *
+ * Three probes:
+ *   P1 bulk natural-conditions race hunt — 60 products x 5 attrs (300 rows) mutated
+ *      attribute-by-attribute (independent PUTs, no shared txn) with concurrent reads
+ *      racing the mutation, at realistic speed (no artificial delay). Looks for a
+ *      "torn" view (mixed old/new attrs in one assembled response) and — the actual
+ *      defect signature — whether any such view is still served after a full TTL+settle
+ *      window (permanently pinned) vs. self-heals (transient, expected).
+ *   P2 deterministic invalidate-vs-in-flight-fill race — widen the fill's window via a
+ *      controllable per-attribute read delay, start a slow fill BEFORE a mutation, mutate
+ *      all 5 attrs, THEN call the real `Table.invalidate(id)` API, and let the slow fill
+ *      (which read pre-mutation values) complete and write back to cache AFTER the
+ *      invalidate call lands. Confirms the race actually happened, observes whether the
+ *      stale write wins immediately, then hard-asserts eventual convergence past TTL+settle.
+ *   P3 TTL-expiry-mid-fill sanity — mutate attributes timed to straddle a cache entry's
+ *      natural TTL expiry while spraying concurrent reads across the boundary. Checks for
+ *      no hang/error and eventual convergence to the raw-Attribute-row oracle.
+ *
+ * Originating QA-id: QA-595. Promoted from the qa-explorer promote-candidates snapshot
+ * (P-382) after a cold gate rerun on main. Pairs with sourcedfrom-snapshot-scoping.test.ts
+ * (QA-596), which establishes WHY this holds (single-store transaction reuse) rather than
+ * just observing that it does.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { resolve } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
+import { createApiClient } from '../apiTests/utils/client.mjs';
+// @ts-expect-error utils/lifecycle.mjs has no type declarations; runtime resolves fine
+import { restartHttpWorkers } from '../apiTests/utils/lifecycle.mjs';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'sourcedfrom-eav-cache-coherence');
+const skipSuite = process.platform === 'win32';
+
+const ATTR_NAMES = ['name', 'price', 'color', 'stock', 'description'];
+const TTL_MS = 3000; // matches schema.graphql's Product @table(expiration: 3)
+const SETTLE_MS = 2500; // extra buffer past TTL before trusting convergence
+
+const N_PRODUCTS = 60; // 60 x 5 attrs = 300 EAV rows for the bulk probe
+const READS_PER_PRODUCT_DURING_BURST = 3;
+
+interface ProductBody {
+	id: string;
+	attrs: Record<string, string | null>;
+	gens: Record<string, number | null>;
+	fillSeq: number;
+	assembledAt: number;
+}
+
+function attrRow(entityId: string, attrName: string, gen: number) {
+	return { id: `${entityId}:${attrName}`, entityId, name: attrName, value: `${attrName}-g${gen}-${entityId}`, gen };
+}
+
+suite('QA-595 EAV catalog x sourcedFrom cache coherence', { skip: skipSuite }, (ctx: ContextWithHarper) => {
+	let client: ReturnType<typeof createApiClient>;
+	let restURL: string;
+	let headers: Record<string, string>;
+
+	async function putAttribute(entityId: string, attrName: string, gen: number): Promise<number> {
+		const key = `${entityId}:${attrName}`;
+		const res = await fetch(`${restURL}/Attribute/${encodeURIComponent(key)}`, {
+			method: 'PUT',
+			headers,
+			body: JSON.stringify(attrRow(entityId, attrName, gen)),
+		});
+		await res.text().catch(() => undefined);
+		if (![200, 201, 204].includes(res.status)) throw new Error(`PUT Attribute/${key} -> ${res.status}`);
+		return res.status;
+	}
+
+	async function getProduct(entityId: string): Promise<{ status: number; body: ProductBody | null }> {
+		const res = await fetch(`${restURL}/Product/${encodeURIComponent(entityId)}`, { headers });
+		const text = await res.text();
+		let body: ProductBody | null = null;
+		try {
+			body = JSON.parse(text);
+		} catch {
+			/* leave null */
+		}
+		return { status: res.status, body };
+	}
+
+	async function attrScan(entityId: string): Promise<Record<string, { value: string; gen: number } | null>> {
+		const res = await fetch(`${restURL}/AttrScan/?id=${encodeURIComponent(entityId)}`, { headers });
+		if (res.status !== 200) throw new Error(`AttrScan/${entityId} -> ${res.status}`);
+		return res.json();
+	}
+
+	async function productRaw(
+		entityId: string
+	): Promise<{ exists: boolean; value: ProductBody | null; version: number | null }> {
+		const res = await fetch(`${restURL}/ProductRaw/?id=${encodeURIComponent(entityId)}`, { headers });
+		if (res.status !== 200) throw new Error(`ProductRaw/${entityId} -> ${res.status}`);
+		return res.json();
+	}
+
+	async function invalidateProduct(entityId: string): Promise<void> {
+		const res = await fetch(`${restURL}/InvalidateProduct/`, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({ id: entityId }),
+		});
+		if (res.status !== 200) throw new Error(`InvalidateProduct/${entityId} -> ${res.status}: ${await res.text()}`);
+		await res.text().catch(() => undefined);
+	}
+
+	async function setReadDelay(ms: number): Promise<void> {
+		const res = await fetch(`${restURL}/Control/`, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({ readDelayMs: ms }),
+		});
+		if (res.status !== 200) throw new Error(`Control readDelayMs=${ms} -> ${res.status}`);
+		await res.text().catch(() => undefined);
+	}
+
+	function allGen1(gens: Record<string, number | null> | undefined): boolean {
+		const vals = Object.values(gens ?? {});
+		return vals.length === ATTR_NAMES.length && vals.every((g) => g === 1);
+	}
+
+	function matchesOracle(
+		attrs: Record<string, string | null> | undefined,
+		oracle: Record<string, { value: string; gen: number } | null>
+	): boolean {
+		if (!attrs) return false;
+		return ATTR_NAMES.every((a) => attrs[a] === (oracle[a]?.value ?? null));
+	}
+
+	before(async () => {
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: {}, env: {} });
+		client = createApiClient(ctx.harper);
+		restURL = ctx.harper.httpURL;
+		headers = { 'Content-Type': 'application/json', 'Authorization': client.headers.Authorization };
+
+		await restartHttpWorkers(client, '/AttrScan/');
+
+		// Seed the EAV substrate: N_PRODUCTS + 2 fixture products, 5 attrs each, all gen 0.
+		const seedRows: any[] = [];
+		for (let i = 0; i < N_PRODUCTS; i++) {
+			for (const a of ATTR_NAMES) seedRows.push(attrRow(`P${i}`, a, 0));
+		}
+		for (const id of ['RACE0', 'TTLBOUND0']) {
+			for (const a of ATTR_NAMES) seedRows.push(attrRow(id, a, 0));
+		}
+		const insertRes = await client
+			.req()
+			.send({ operation: 'insert', table: 'Attribute', records: seedRows })
+			.timeout(30_000);
+		strictEqual(insertRes.status, 200, `seed insert failed: ${JSON.stringify(insertRes.body).slice(0, 300)}`);
+		console.log(`[QA-595] seeded ${seedRows.length} EAV Attribute rows`);
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	test(
+		'P1: bulk attribute-by-attribute burst (300 rows, 60 products) — torn view persists past TTL+settle?',
+		{ timeout: 30_000 },
+		async () => {
+			const ids = Array.from({ length: N_PRODUCTS }, (_, i) => `P${i}`);
+			const observations = new Map<string, Array<Record<string, number | null>>>();
+
+			const ops: Array<Promise<unknown>> = [];
+			for (const id of ids) {
+				for (const attrName of ATTR_NAMES) ops.push(putAttribute(id, attrName, 1));
+				for (let k = 0; k < READS_PER_PRODUCT_DURING_BURST; k++) {
+					ops.push(
+						getProduct(id).then((r) => {
+							if (r.status === 200 && r.body) {
+								const arr = observations.get(id) ?? [];
+								arr.push(r.body.gens);
+								observations.set(id, arr);
+							}
+						})
+					);
+				}
+			}
+			await Promise.all(ops);
+
+			let tornCount = 0;
+			const tornSamples: Array<{ id: string; gens: Record<string, number | null> }> = [];
+			for (const [id, obsList] of observations) {
+				for (const gens of obsList) {
+					if (new Set(Object.values(gens)).size > 1) {
+						tornCount++;
+						if (tornSamples.length < 8) tornSamples.push({ id, gens });
+					}
+				}
+			}
+			console.log(
+				`[QA-595 P1] observations captured=${[...observations.values()].reduce((n, a) => n + a.length, 0)} ` +
+					`torn(mixed-gen)=${tornCount}\n  samples: ${JSON.stringify(tornSamples)}`
+			);
+
+			// settle well past TTL, then check convergence against the independent raw-row oracle
+			await sleep(TTL_MS + SETTLE_MS);
+
+			const staleAfterSettle: Array<{ id: string; gens: unknown; attrs: unknown; oracle: unknown }> = [];
+			for (const id of ids) {
+				const [prodRes, oracle] = await Promise.all([getProduct(id), attrScan(id)]);
+				ok(prodRes.status === 200 && prodRes.body, `GET /Product/${id} failed post-settle: ${prodRes.status}`);
+				const body = prodRes.body as ProductBody;
+				if (!allGen1(body.gens) || !matchesOracle(body.attrs, oracle)) {
+					staleAfterSettle.push({ id, gens: body.gens, attrs: body.attrs, oracle });
+				}
+			}
+			console.log(
+				`[QA-595 P1] products still stale/torn after TTL+settle: ${staleAfterSettle.length}/${N_PRODUCTS}\n` +
+					(staleAfterSettle.length ? `  samples: ${JSON.stringify(staleAfterSettle.slice(0, 5))}` : '')
+			);
+
+			strictEqual(
+				staleAfterSettle.length,
+				0,
+				`DEFECT: stale/torn cache view still pinned after TTL+settle for ${staleAfterSettle.length} product(s): ` +
+					JSON.stringify(staleAfterSettle.slice(0, 5))
+			);
+		}
+	);
+
+	test(
+		'P2: invalidate() vs in-flight slow fill race — does a stale fill overwrite the cache AFTER invalidate?',
+		{ timeout: 20_000 },
+		async () => {
+			const id = 'RACE0';
+			await setReadDelay(150); // ~750-900ms total fill duration across 5 sequential reads
+
+			const fillPromise = getProduct(id); // triggers a slow fill reading PRE-mutation (gen0) values
+
+			await sleep(220); // let the slow fill get partway through its 5 sequential reads
+			const mutateAt = Date.now();
+			await Promise.all(ATTR_NAMES.map((a) => putAttribute(id, a, 1))); // fast, independent burst mutation
+
+			await sleep(60);
+			const invalidateAt = Date.now();
+			await invalidateProduct(id);
+
+			const fillResult = await fillPromise;
+			const fillFinishedAt = Date.now();
+
+			ok(fillResult.status === 200 && fillResult.body, `slow fill GET failed: ${fillResult.status}`);
+			const raceConfirmed = fillFinishedAt > invalidateAt;
+			const fillBody = fillResult.body as ProductBody;
+			console.log(
+				`[QA-595 P2] mutateAt=+0ms invalidateAt=+${invalidateAt - mutateAt}ms fillFinishedAt=+${fillFinishedAt - mutateAt}ms ` +
+					`raceConfirmed(fill finished after invalidate)=${raceConfirmed}\n` +
+					`  the slow fill's OWN assembled view: gens=${JSON.stringify(fillBody?.gens)} attrs=${JSON.stringify(fillBody?.attrs)} ` +
+					`(torn=${new Set(Object.values(fillBody?.gens ?? {})).size > 1})`
+			);
+			ok(
+				raceConfirmed,
+				'test setup invalid: slow fill finished BEFORE invalidate landed — race window not achieved, adjust timings'
+			);
+
+			// Immediately after, BEFORE issuing any further GET (which could itself trigger a fresh
+			// fill and mask the answer): peek the RAW stored cache entry to see exactly what the
+			// slow fill's write-back left behind, undisturbed.
+			const rawAfterRace = await productRaw(id);
+			console.log(
+				`[QA-595 P2] raw cache entry immediately after race (no triggering read): exists=${rawAfterRace.exists} ` +
+					`version=${rawAfterRace.version} gens=${JSON.stringify(rawAfterRace.value?.gens)}`
+			);
+
+			// Now a normal GET (this may itself trigger a fresh fill if the raw entry above was
+			// absent/invalidated/expired — that's fine, it's the "does the client-visible read
+			// recover" question, distinct from the raw-entry question above).
+			const immediateAfter = await getProduct(id);
+			await setReadDelay(0);
+			const immediateBody = immediateAfter.body as ProductBody;
+			const immediateOk = allGen1(immediateBody?.gens);
+			console.log(
+				`[QA-595 P2] immediately after race (via normal GET): gens=${JSON.stringify(immediateBody?.gens)} allGen1=${immediateOk}`
+			);
+
+			// Settle past TTL and re-check: MUST converge to fully-gen1, matching raw oracle, regardless
+			// of what happened immediately after the race (a briefly-stale entry that self-heals is fine;
+			// one that stays wrong past TTL+settle is the actual defect).
+			await sleep(TTL_MS + SETTLE_MS);
+			const [settled, oracle] = await Promise.all([getProduct(id), attrScan(id)]);
+			const settledBody = settled.body as ProductBody;
+			const settledAllGen1 = allGen1(settledBody?.gens);
+			const settledMatchesOracle = matchesOracle(settledBody?.attrs, oracle);
+
+			console.log(
+				`[QA-595 P2] post-settle: gens=${JSON.stringify(settledBody?.gens)} attrs=${JSON.stringify(settledBody?.attrs)} ` +
+					`allGen1=${settledAllGen1} matchesOracle=${settledMatchesOracle}` +
+					(!immediateOk
+						? settledAllGen1
+							? ' — VERDICT: SURPRISING-OK, stale fill won the immediate race but self-healed by next TTL cycle'
+							: ' — VERDICT: DEFECT, stale entry remained pinned past a full TTL+settle window'
+						: ' — VERDICT: CLEAN, invalidate/race produced no observable staleness')
+			);
+
+			strictEqual(
+				settledAllGen1,
+				true,
+				`DEFECT: product view still not fully gen1 after TTL+settle following invalidate-vs-fill race: ${JSON.stringify(settledBody?.gens)}`
+			);
+			strictEqual(
+				settledMatchesOracle,
+				true,
+				`DEFECT: post-settle product attrs diverge from raw Attribute oracle: attrs=${JSON.stringify(
+					settledBody?.attrs
+				)} oracle=${JSON.stringify(oracle)}`
+			);
+		}
+	);
+
+	test(
+		'P3: attribute mutation straddling natural TTL expiry — no hang/error, eventual convergence',
+		{ timeout: 20_000 },
+		async () => {
+			const id = 'TTLBOUND0';
+			await setReadDelay(0);
+
+			const primeRes = await getProduct(id); // gen0 — starts this entry's TTL clock
+			ok(primeRes.status === 200, `prime GET failed: ${primeRes.status}`);
+			const primedAt = Date.now();
+
+			const spraySamples: Array<{ t: number; status: number | string }> = [];
+			const spray = (async () => {
+				const until = primedAt + TTL_MS + 1200;
+				while (Date.now() < until) {
+					const r = await getProduct(id).catch((e: Error) => ({ status: `ERR:${e.message}`, body: null }) as const);
+					spraySamples.push({ t: Date.now() - primedAt, status: r.status as any });
+					await sleep(80);
+				}
+			})();
+
+			// fire the burst mutation timed to overlap this entry's natural expiry moment
+			await sleep(Math.max(0, TTL_MS - 300));
+			const mutateAtOffset = Date.now() - primedAt;
+			await Promise.all(ATTR_NAMES.map((a) => putAttribute(id, a, 1)));
+
+			await spray;
+
+			const errors = spraySamples.filter((s) => typeof s.status !== 'number');
+			console.log(
+				`[QA-595 P3] spray samples=${spraySamples.length} mutate@+${mutateAtOffset}ms errors=${errors.length}` +
+					(errors.length ? ` samples: ${JSON.stringify(errors.slice(0, 5))}` : '')
+			);
+			strictEqual(
+				errors.length,
+				0,
+				`unexpected errors/hangs during TTL-boundary spray: ${JSON.stringify(errors.slice(0, 5))}`
+			);
+
+			await sleep(TTL_MS + SETTLE_MS);
+			const [settled, oracle] = await Promise.all([getProduct(id), attrScan(id)]);
+			const settledBody = settled.body as ProductBody;
+			const settledAllGen1 = allGen1(settledBody?.gens);
+			const settledMatchesOracle = matchesOracle(settledBody?.attrs, oracle);
+			console.log(
+				`[QA-595 P3] post-settle: gens=${JSON.stringify(settledBody?.gens)} allGen1=${settledAllGen1} matchesOracle=${settledMatchesOracle}`
+			);
+			strictEqual(
+				settledAllGen1 && settledMatchesOracle,
+				true,
+				`DEFECT: TTL-boundary mutation left product view unconverged: gens=${JSON.stringify(
+					settledBody?.gens
+				)} attrs=${JSON.stringify(settledBody?.attrs)} oracle=${JSON.stringify(oracle)}`
+			);
+		}
+	);
+});

--- a/integrationTests/resources/sourcedfrom-eav-cache-coherence.test.ts
+++ b/integrationTests/resources/sourcedfrom-eav-cache-coherence.test.ts
@@ -350,7 +350,7 @@ suite('QA-595 EAV catalog x sourcedFrom cache coherence', { skip: skipSuite }, (
 
 			await spray;
 
-			const errors = spraySamples.filter((s) => typeof s.status !== 'number');
+			const errors = spraySamples.filter((s) => typeof s.status !== 'number' || s.status >= 400);
 			console.log(
 				`[QA-595 P3] spray samples=${spraySamples.length} mutate@+${mutateAtOffset}ms errors=${errors.length}` +
 					(errors.length ? ` samples: ${JSON.stringify(errors.slice(0, 5))}` : '')

--- a/integrationTests/resources/sourcedfrom-eav-cache-coherence/config.yaml
+++ b/integrationTests/resources/sourcedfrom-eav-cache-coherence/config.yaml
@@ -1,0 +1,5 @@
+graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/resources/sourcedfrom-eav-cache-coherence/resources.js
+++ b/integrationTests/resources/sourcedfrom-eav-cache-coherence/resources.js
@@ -1,0 +1,95 @@
+// QA-595 — cache-sourced Product view assembled from EAV Attribute rows.
+//
+// Product.sourcedFrom's get() is the seam under test: it reads the 5 known Attribute
+// rows for an entity ONE AT A TIME (deterministic key order), so a concurrent
+// attribute-by-attribute burst mutation has a real window to land BETWEEN two of those
+// reads. `readDelayMs` (set via POST /Control) widens that window on demand for the
+// deterministic invalidate-race probe; it defaults to 0 (no artificial delay) for the
+// natural-conditions bulk race hunt.
+import { setTimeout as sleep } from 'node:timers/promises';
+
+const { Attribute, Product } = tables;
+
+export const ATTR_NAMES = ['name', 'price', 'color', 'stock', 'description'];
+
+let readDelayMs = 0;
+let fillCounter = 0;
+const fillLog = [];
+
+Product.sourcedFrom(
+	class extends Resource {
+		async get() {
+			const entityId = String(this.getId());
+			const fillSeq = ++fillCounter;
+			const startedAt = Date.now();
+			const attrs = {};
+			const gens = {};
+			for (const attrName of ATTR_NAMES) {
+				const row = await Attribute.get(`${entityId}:${attrName}`);
+				attrs[attrName] = row ? row.value : null;
+				gens[attrName] = row ? row.gen : null;
+				if (readDelayMs > 0) await sleep(readDelayMs);
+			}
+			const finishedAt = Date.now();
+			fillLog.push({ entityId, fillSeq, startedAt, finishedAt });
+			return { id: entityId, attrs, gens, fillSeq, assembledAt: finishedAt };
+		}
+	}
+);
+
+/** POST { readDelayMs } — set/clear the artificial per-attribute-read delay inside get(). */
+export class Control extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		if (typeof body?.readDelayMs === 'number') readDelayMs = body.readDelayMs;
+		return { ok: true, readDelayMs };
+	}
+}
+
+/** POST { id } — the real, public Table.invalidate(id) API against the cache table. */
+export class InvalidateProduct extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		const at = Date.now();
+		await Product.invalidate(body.id);
+		return { ok: true, id: body.id, at };
+	}
+}
+
+/** GET /FillLog/ — every fill this worker has run (entityId, fillSeq, start/finish ms). */
+export class FillLog extends Resource {
+	static loadAsInstance = false;
+	async get() {
+		return fillLog;
+	}
+}
+
+/** GET /ProductRaw/?id=P3 — the RAW stored Product cache entry (primaryStore.getEntry),
+ * bypassing sourcedFrom resolution entirely: no TTL check, no refill-on-miss, no
+ * invalidated-row substitution. Used to observe exactly what a fill wrote back without
+ * triggering (or masking behind) another fill. */
+export class ProductRaw extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const id = query && typeof query.get === 'function' ? query.get('id') : query?.id;
+		const store = Product.primaryStore;
+		const entry = store.getEntry(id);
+		if (entry == null) return { exists: false, value: null, version: null };
+		return { exists: true, value: entry.value, version: entry.version ?? null };
+	}
+}
+
+/** GET /AttrScan/?id=P3 — independent oracle: raw Attribute rows for one entity, read
+ * directly (bypassing Product's cache entirely). */
+export class AttrScan extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const id = query && typeof query.get === 'function' ? query.get('id') : query?.id;
+		const out = {};
+		for (const attrName of ATTR_NAMES) {
+			const row = await Attribute.get(`${id}:${attrName}`);
+			out[attrName] = row ? { value: row.value, gen: row.gen } : null;
+		}
+		return out;
+	}
+}

--- a/integrationTests/resources/sourcedfrom-eav-cache-coherence/schema.graphql
+++ b/integrationTests/resources/sourcedfrom-eav-cache-coherence/schema.graphql
@@ -1,0 +1,27 @@
+# QA-595 — EAV product catalog fronted by a cache-sourced resource.
+#
+# Attribute is the EAV substrate: one row per (entity, attribute-name), keyed by a
+# composite string id `${entityId}:${attrName}`. entityId is @indexed so a product's
+# rows can also be range-scanned, but the cache-source resolver below reads the 5 known
+# per-product keys directly (deterministic assembly order).
+#
+# Product is the cache-sourced resource: a 3s TTL @table whose sourcedFrom resolver
+# (resources.js) assembles a product's view by reading all of its Attribute rows. The
+# EAV substrate's unit of write (one row) and the cache's unit of consistency (one
+# assembled product) disagree — that's exactly the seam under test.
+
+type Attribute @table @export {
+	id: ID @primaryKey
+	entityId: String @indexed
+	name: String
+	value: String
+	gen: Int
+}
+
+type Product @table(expiration: 3) @export {
+	id: ID @primaryKey
+	attrs: Any
+	gens: Any
+	fillSeq: Int
+	assembledAt: Long
+}

--- a/integrationTests/resources/sourcedfrom-snapshot-scoping.test.ts
+++ b/integrationTests/resources/sourcedfrom-snapshot-scoping.test.ts
@@ -141,10 +141,48 @@ suite(
 			return { status: res.status, body };
 		}
 
-		async function setGap(ms: number): Promise<void> {
+		/**
+		 * Run one trial: `fill` is already in flight (its resolver is mid-gap), `duringFill`
+		 * lands the concurrent commit inside that gap. Both are always awaited, so a trial can
+		 * never leave a request in flight past the end of the test — an orphaned fetch that
+		 * rejects after teardown surfaces as an unhandledRejection blamed on whichever test is
+		 * running by then, masking the real failure (#1833). `duringFill`'s error wins: the
+		 * fill's is usually just downstream of it.
+		 */
+		async function trial<T>(fill: Promise<T>, duringFill: () => Promise<void>): Promise<T> {
+			const [filled, mutated] = await Promise.allSettled([fill, duringFill()]);
+			if (mutated.status === 'rejected') throw mutated.reason;
+			if (filled.status === 'rejected') throw filled.reason;
+			return filled.value;
+		}
+
+		/** POST the gap and return the threadId of the worker now holding it. */
+		async function setGap(ms: number): Promise<number> {
 			const res = await fetch(`${restURL}/Control/`, { method: 'POST', headers, body: JSON.stringify({ gapMs: ms }) });
 			if (res.status !== 200) throw new Error(`Control gapMs=${ms} -> ${res.status}`);
-			await res.text().catch(() => undefined);
+			const body = (await res.json().catch(() => null)) as { gapMs?: number; threadId?: number } | null;
+			ok(body && body.gapMs === ms, `Control did not accept gapMs=${ms}: ${JSON.stringify(body)}`);
+			ok(typeof body!.threadId === 'number', `Control returned no threadId: ${JSON.stringify(body)}`);
+			return body!.threadId!;
+		}
+
+		/**
+		 * `gapMs` is resources.js module state on ONE worker. If that worker is replaced mid-test the
+		 * replacement silently reverts to the default (100ms) gap — shorter than MUTATE_AT_MS — so the
+		 * mutation lands *after* the resolver already read its second row and every probe below becomes
+		 * a vacuous pass: tornCount=0 proves nothing. That is exactly what a premature
+		 * `restartHttpWorkers()` used to cause (#1833). Pin it: the worker we handed the gap to must
+		 * still be the one serving.
+		 */
+		async function assertGapWorkerStillServing(expectedThreadId: number): Promise<void> {
+			const { status, body } = await getJSON<{ threadId: number }>('/WhoAmI/');
+			ok(status === 200 && body, `GET /WhoAmI/ failed: ${status}`);
+			strictEqual(
+				body!.threadId,
+				expectedThreadId,
+				`the worker holding gapMs=${GAP_MS} was replaced mid-test (was thread ${expectedThreadId}, now ` +
+					`${body!.threadId}): the probe ran with the default gap and proves nothing`
+			);
 		}
 
 		before(async () => {
@@ -173,7 +211,7 @@ suite(
 			"P1: single-store real-gap fill — does the resolver's OWN pinned snapshot survive a mid-await commit on the row it hasn't read yet?",
 			{ timeout: 60_000 },
 			async () => {
-				await setGap(GAP_MS);
+				const gapThreadId = await setGap(GAP_MS);
 				const ids = Array.from({ length: N_TRIALS }, (_, i) => `S${i}`);
 
 				// seed slotA/slotB at gen0 for every trial entity
@@ -184,12 +222,17 @@ suite(
 
 				const results: Array<{ id: string; body: SingleBody | null; status: number }> = [];
 				for (const id of ids) {
-					const fillPromise = getJSON<SingleBody>(`/SingleTableSnap/${id}`); // reads slotA(gen0), awaits GAP_MS, reads slotB
-					await sleep(MUTATE_AT_MS); // land the mutation inside the gap, before slotB is read
-					await putCell(id, 'slotB', 1); // concurrent writer: slotB gen0 -> gen1, mid-await
-					const r = await fillPromise;
+					const r = await trial(
+						getJSON<SingleBody>(`/SingleTableSnap/${id}`), // reads slotA(gen0), awaits GAP_MS, reads slotB
+						async () => {
+							await sleep(MUTATE_AT_MS); // land the mutation inside the gap, before slotB is read
+							await putCell(id, 'slotB', 1); // concurrent writer: slotB gen0 -> gen1, mid-await
+						}
+					);
 					results.push({ id, body: r.body, status: r.status });
 				}
+
+				await assertGapWorkerStillServing(gapThreadId);
 
 				let tornCount = 0; // fill's OWN view mixes slotA gen0 with slotB gen1 (post-mutation)
 				const tornSamples: Array<{ id: string; gens: unknown }> = [];
@@ -236,7 +279,7 @@ suite(
 			'P2: cross-database real-gap fill — does a resolver spanning two databases see a torn (mixed-vintage) view across a mid-await commit?',
 			{ timeout: 60_000 },
 			async () => {
-				await setGap(GAP_MS);
+				const gapThreadId = await setGap(GAP_MS);
 				const ids = Array.from({ length: N_TRIALS }, (_, i) => `C${i}`);
 
 				for (const id of ids) {
@@ -247,12 +290,17 @@ suite(
 				const results: Array<{ id: string; body: CrossBody | null; status: number }> = [];
 				let debugLogged = 0;
 				for (const id of ids) {
-					const fillPromise = getJSON<CrossBody>(`/CrossTableSnap/${id}`); // reads RowA(gen0), awaits GAP_MS, reads RowB
-					await sleep(MUTATE_AT_MS);
-					const mutateStartedAt = Date.now();
-					await putRow('RowB', id, 1); // concurrent writer: RowB gen0 -> gen1, mid-await, BEFORE the resolver touches RowB
-					const mutateAckAt = Date.now();
-					const r = await fillPromise;
+					let mutateStartedAt = 0;
+					let mutateAckAt = 0;
+					const r = await trial(
+						getJSON<CrossBody>(`/CrossTableSnap/${id}`), // reads RowA(gen0), awaits GAP_MS, reads RowB
+						async () => {
+							await sleep(MUTATE_AT_MS);
+							mutateStartedAt = Date.now();
+							await putRow('RowB', id, 1); // concurrent writer: RowB gen0 -> gen1, mid-await, BEFORE the resolver touches RowB
+							mutateAckAt = Date.now();
+						}
+					);
 					results.push({ id, body: r.body, status: r.status });
 					if (debugLogged < 5 && r.body) {
 						const b = r.body as any;
@@ -264,6 +312,8 @@ suite(
 						debugLogged++;
 					}
 				}
+
+				await assertGapWorkerStillServing(gapThreadId);
 
 				let tornCount = 0; // fill's own view: genA=0 (pre-gap snapshot) but genB=1 (post-mutation) -- mixed vintage
 				const tornSamples: Array<{ id: string; genA: unknown; genB: unknown }> = [];
@@ -311,7 +361,7 @@ suite(
 			'P3: two DIFFERENT tables in the SAME database — isolates whether the P2 seam is "two tables" or specifically "two databases"',
 			{ timeout: 60_000 },
 			async () => {
-				await setGap(GAP_MS);
+				const gapThreadId = await setGap(GAP_MS);
 				const ids = Array.from({ length: N_TRIALS }, (_, i) => `T${i}`);
 
 				for (const id of ids) {
@@ -321,12 +371,17 @@ suite(
 
 				const results: Array<{ id: string; body: TwoTableSameDbBody | null; status: number }> = [];
 				for (const id of ids) {
-					const fillPromise = getJSON<TwoTableSameDbBody>(`/TwoTableSameDbSnap/${id}`); // reads RowA(gen0), awaits GAP_MS, reads RowC
-					await sleep(MUTATE_AT_MS);
-					await putRow('RowC', id, 1); // concurrent writer: RowC gen0 -> gen1, mid-await, BEFORE the resolver touches RowC
-					const r = await fillPromise;
+					const r = await trial(
+						getJSON<TwoTableSameDbBody>(`/TwoTableSameDbSnap/${id}`), // reads RowA(gen0), awaits GAP_MS, reads RowC
+						async () => {
+							await sleep(MUTATE_AT_MS);
+							await putRow('RowC', id, 1); // concurrent writer: RowC gen0 -> gen1, mid-await, BEFORE the resolver touches RowC
+						}
+					);
 					results.push({ id, body: r.body, status: r.status });
 				}
+
+				await assertGapWorkerStillServing(gapThreadId);
 
 				let tornCount = 0;
 				const tornSamples: Array<{ id: string; genA: unknown; genC: unknown }> = [];

--- a/integrationTests/resources/sourcedfrom-snapshot-scoping.test.ts
+++ b/integrationTests/resources/sourcedfrom-snapshot-scoping.test.ts
@@ -1,0 +1,373 @@
+/**
+ * QA-596 — is a `sourcedFrom` cache resolver's snapshot read-scoping CONTRACTUAL or
+ * incidental?
+ *
+ * QA-595 (sourcedfrom-eav-cache-coherence.test.ts) found zero torn views across an EAV
+ * resolver that read 5 rows back-to-back with no real async gap between reads. That
+ * proved reads LOOK snapshot-scoped, but not why, and therefore not whether it's
+ * guaranteed.
+ *
+ * MECHANISM (traced in harper at 3dbcf7b9e):
+ *   1. resources/Table.ts `getFromSource` invokes the resolver inside
+ *      `transaction(sourceContext, async (_txn) => { ... throttledCallToSource(...) ... })`.
+ *   2. resources/transaction.ts `transaction()` creates a fresh `DatabaseTransaction` and,
+ *      because `sourceContext` carries no ambient AsyncLocalStorage store of its own, runs
+ *      the callback via `contextStorage.run(context, () => callback(transaction))`. Node's
+ *      AsyncLocalStorage keeps that store live across every `await` inside the callback's
+ *      async continuation, not just its first synchronous tick — real timers included.
+ *   3. Inside the resolver, a nested read like `Attribute.get(key)` (no explicit context
+ *      arg) falls through to resources/Resource.ts `context = contextStorage.getStore() ?? {}`
+ *      — picking up the SAME `sourceContext`, whose `.transaction` is OPEN, so
+ *      resources/transaction.ts reuses the identical `DatabaseTransaction` for every
+ *      subsequent read in the fill.
+ *   4. DatabaseTransaction.getReadTxn() (resources/DatabaseTransaction.ts) memoizes ONE
+ *      underlying RocksTransaction per store, lazily opened on first touch and reused for
+ *      every later `getEntry()` call — that's the actual MVCC snapshot pin. It is never
+ *      re-opened until the outer `transaction()` wrapper commits, which happens only AFTER
+ *      the resolver's `get()` returns.
+ *   5. BUT: for a resolver spanning two DATABASES, `txnForContext` (resources/Table.ts)
+ *      chains a SEPARATE `DatabaseTransaction` per store, and each chained store's
+ *      RocksTransaction is ALSO opened lazily, independently, on ITS first touch — not
+ *      eagerly for the whole logical transaction. So a second database's snapshot is
+ *      pinned whenever the resolver first reads it, which can be AFTER a real async gap
+ *      during which a writer committed to that database. Single-database reads (even
+ *      across multiple tables, since all tables in one database share one rootStore path)
+ *      share one snapshot by construction (deliberate transaction reuse); cross-DATABASE
+ *      reads only share a snapshot if both databases happen to have been touched before
+ *      any intervening commit — an incidental, timing-dependent property, not a guarantee.
+ *
+ * Three probes force a real async gap (a real timer, not a same-tick microtask hop)
+ * straddling a concurrent commit:
+ *   P1 single-store: SingleTableSnap resolver reads Cell row slotA, awaits a real 500ms
+ *      timer, then reads Cell row slotB (same table/store as slotA). A concurrent writer
+ *      mutates slotB mid-gap. The fill's OWN view of slotB stays pinned to the
+ *      pre-mutation value.
+ *   P2 cross-DATABASE: CrossTableSnap resolver reads RowA (default db), awaits the same
+ *      real gap, then reads RowB (a table in a SEPARATE database, "qa596b"). A concurrent
+ *      writer mutates RowB mid-gap. RowB's snapshot is not pinned until touched, so the
+ *      fill's own view of genB picks up the concurrent write — a genuinely torn
+ *      cross-database snapshot. This is EXPECTED (by-design), not a defect — the test
+ *      only asserts no hang/error and eventual convergence, not a particular torn count.
+ *   P3 cross-TABLE, same database: isolates whether the P2 seam is "two tables" or
+ *      specifically "two databases" — RowA and RowC are two distinct tables sharing one
+ *      database/rootStore, so this predicts the SAME guarantee as P1 (consistent despite
+ *      the real gap), confirming the seam found in P2 is the database boundary, not the
+ *      table boundary.
+ *
+ * Originating QA-id: QA-596. Promoted from the qa-explorer promote-candidates snapshot
+ * (P-383) after a cold gate rerun on main. Pairs with sourcedfrom-eav-cache-coherence.test.ts
+ * (QA-595).
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { resolve } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
+import { createApiClient } from '../apiTests/utils/client.mjs';
+// @ts-expect-error utils/lifecycle.mjs has no type declarations; runtime resolves fine
+import { restartHttpWorkers } from '../apiTests/utils/lifecycle.mjs';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'sourcedfrom-snapshot-scoping');
+const skipSuite = process.platform === 'win32';
+
+const TTL_MS = 3000; // matches schema.graphql's @table(expiration: 3) on both cache tables
+const SETTLE_MS = 2500;
+const GAP_MS = 500; // the real async gap forced inside both resolvers via Control { gapMs }
+const MUTATE_AT_MS = 150; // fire the concurrent mutation partway through the gap, well clear of both edges
+const N_TRIALS = 20; // distinct entities per probe, so each trial forces a fresh fill
+
+interface SingleBody {
+	id: string;
+	gens: { slotA: number | null; slotB: number | null };
+	fillSeq: number;
+	assembledAt: number;
+}
+interface CrossBody {
+	id: string;
+	genA: number | null;
+	genB: number | null;
+	fillSeq: number;
+	assembledAt: number;
+}
+interface TwoTableSameDbBody {
+	id: string;
+	genA: number | null;
+	genC: number | null;
+	fillSeq: number;
+	assembledAt: number;
+}
+
+suite(
+	'QA-596 sourcedFrom resolver snapshot scoping under a real async gap',
+	{ skip: skipSuite },
+	(ctx: ContextWithHarper) => {
+		let client: ReturnType<typeof createApiClient>;
+		let restURL: string;
+		let headers: Record<string, string>;
+
+		async function putCell(entityId: string, slot: string, gen: number): Promise<number> {
+			const key = `${entityId}:${slot}`;
+			const res = await fetch(`${restURL}/Cell/${encodeURIComponent(key)}`, {
+				method: 'PUT',
+				headers,
+				body: JSON.stringify({ id: key, entityId, slot, gen }),
+			});
+			await res.text().catch(() => undefined);
+			if (![200, 201, 204].includes(res.status)) throw new Error(`PUT Cell/${key} -> ${res.status}`);
+			return res.status;
+		}
+
+		async function putRow(table: 'RowA' | 'RowB' | 'RowC', id: string, gen: number): Promise<number> {
+			const res = await fetch(`${restURL}/${table}/${encodeURIComponent(id)}`, {
+				method: 'PUT',
+				headers,
+				body: JSON.stringify({ id, gen }),
+			});
+			await res.text().catch(() => undefined);
+			if (![200, 201, 204].includes(res.status)) throw new Error(`PUT ${table}/${id} -> ${res.status}`);
+			return res.status;
+		}
+
+		async function getJSON<T>(path: string): Promise<{ status: number; body: T | null }> {
+			const res = await fetch(`${restURL}${path}`, { headers });
+			const text = await res.text();
+			let body: T | null = null;
+			try {
+				body = JSON.parse(text);
+			} catch {
+				/* leave null */
+			}
+			return { status: res.status, body };
+		}
+
+		async function setGap(ms: number): Promise<void> {
+			const res = await fetch(`${restURL}/Control/`, { method: 'POST', headers, body: JSON.stringify({ gapMs: ms }) });
+			if (res.status !== 200) throw new Error(`Control gapMs=${ms} -> ${res.status}`);
+			await res.text().catch(() => undefined);
+		}
+
+		before(async () => {
+			// Single worker (default thread count) deliberately: resources.js's `gapMs`/`fillLog` module
+			// state is per-worker-thread (each worker loads its own copy of resources.js), and POST
+			// /Control/ only lands on whichever worker handles that one request. With multiple workers,
+			// GETs load-balanced onto a worker that never received the gapMs update would silently run
+			// with the default gap, turning "mutate mid-gap" into an uncontrolled race against whatever
+			// gap that worker happens to be using. The mechanism under test (AsyncLocalStorage-propagated
+			// context + DatabaseTransaction reuse) is single-request/single-worker by construction, so a
+			// single worker isolates the real question. `threadId` is still reported per fill for
+			// attribution/debugging.
+			await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: {}, env: {} });
+			client = createApiClient(ctx.harper);
+			restURL = ctx.harper.httpURL;
+			headers = { 'Content-Type': 'application/json', 'Authorization': client.headers.Authorization };
+
+			await restartHttpWorkers(client, '/WhoAmI/');
+		});
+
+		after(async () => {
+			await teardownHarper(ctx);
+		});
+
+		test(
+			"P1: single-store real-gap fill — does the resolver's OWN pinned snapshot survive a mid-await commit on the row it hasn't read yet?",
+			{ timeout: 60_000 },
+			async () => {
+				await setGap(GAP_MS);
+				const ids = Array.from({ length: N_TRIALS }, (_, i) => `S${i}`);
+
+				// seed slotA/slotB at gen0 for every trial entity
+				for (const id of ids) {
+					await putCell(id, 'slotA', 0);
+					await putCell(id, 'slotB', 0);
+				}
+
+				const results: Array<{ id: string; body: SingleBody | null; status: number }> = [];
+				for (const id of ids) {
+					const fillPromise = getJSON<SingleBody>(`/SingleTableSnap/${id}`); // reads slotA(gen0), awaits GAP_MS, reads slotB
+					await sleep(MUTATE_AT_MS); // land the mutation inside the gap, before slotB is read
+					await putCell(id, 'slotB', 1); // concurrent writer: slotB gen0 -> gen1, mid-await
+					const r = await fillPromise;
+					results.push({ id, body: r.body, status: r.status });
+				}
+
+				let tornCount = 0; // fill's OWN view mixes slotA gen0 with slotB gen1 (post-mutation)
+				const tornSamples: Array<{ id: string; gens: unknown }> = [];
+				for (const { id, body, status } of results) {
+					ok(status === 200 && body, `GET /SingleTableSnap/${id} failed: ${status}`);
+					if (body!.gens.slotA !== 0) throw new Error(`unexpected slotA for ${id}: ${JSON.stringify(body!.gens)}`);
+					if (body!.gens.slotB !== 0) {
+						tornCount++;
+						if (tornSamples.length < 8) tornSamples.push({ id, gens: body!.gens });
+					}
+				}
+				console.log(
+					`[QA-596 P1] trials=${N_TRIALS} torn(fill's own slotB reflects the mid-gap commit)=${tornCount}\n` +
+						`  samples: ${JSON.stringify(tornSamples)}`
+				);
+
+				// eventual convergence sanity: after TTL+settle, a fresh fill must see gen1 for both slots
+				await sleep(TTL_MS + SETTLE_MS);
+				const staleAfterSettle: Array<{ id: string; gens: unknown }> = [];
+				for (const id of ids) {
+					const r = await getJSON<SingleBody>(`/SingleTableSnap/${id}`);
+					ok(r.status === 200 && r.body, `post-settle GET /SingleTableSnap/${id} failed: ${r.status}`);
+					if (r.body!.gens.slotA !== 0 || r.body!.gens.slotB !== 1) staleAfterSettle.push({ id, gens: r.body!.gens });
+				}
+				console.log(`[QA-596 P1] unconverged after TTL+settle: ${staleAfterSettle.length}/${N_TRIALS}`);
+				strictEqual(
+					staleAfterSettle.length,
+					0,
+					`convergence sanity failed: ${JSON.stringify(staleAfterSettle.slice(0, 5))}`
+				);
+
+				// the core claim under test: single-store fills stayed on ONE pinned snapshot across the
+				// real async gap, in every trial, despite the mutation landing mid-await.
+				strictEqual(
+					tornCount,
+					0,
+					`snapshot scoping did NOT survive a real async gap within one store: ${tornCount}/${N_TRIALS} fills observed ` +
+						`their own slotB read reflect a commit that landed mid-await: ${JSON.stringify(tornSamples)}`
+				);
+			}
+		);
+
+		test(
+			'P2: cross-database real-gap fill — does a resolver spanning two databases see a torn (mixed-vintage) view across a mid-await commit?',
+			{ timeout: 60_000 },
+			async () => {
+				await setGap(GAP_MS);
+				const ids = Array.from({ length: N_TRIALS }, (_, i) => `C${i}`);
+
+				for (const id of ids) {
+					await putRow('RowA', id, 0);
+					await putRow('RowB', id, 0);
+				}
+
+				const results: Array<{ id: string; body: CrossBody | null; status: number }> = [];
+				let debugLogged = 0;
+				for (const id of ids) {
+					const fillPromise = getJSON<CrossBody>(`/CrossTableSnap/${id}`); // reads RowA(gen0), awaits GAP_MS, reads RowB
+					await sleep(MUTATE_AT_MS);
+					const mutateStartedAt = Date.now();
+					await putRow('RowB', id, 1); // concurrent writer: RowB gen0 -> gen1, mid-await, BEFORE the resolver touches RowB
+					const mutateAckAt = Date.now();
+					const r = await fillPromise;
+					results.push({ id, body: r.body, status: r.status });
+					if (debugLogged < 5 && r.body) {
+						const b = r.body as any;
+						console.log(
+							`[QA-596 P2 timing] id=${id} startedAt=+0 preGapAt=+${b.preGapAt - b.startedAt}ms ` +
+								`mutateStartedAt=+${mutateStartedAt - b.startedAt}ms mutateAckAt=+${mutateAckAt - b.startedAt}ms ` +
+								`postGapAt=+${b.postGapAt - b.startedAt}ms finishedAt=+${b.finishedAt - b.startedAt}ms genB=${b.genB}`
+						);
+						debugLogged++;
+					}
+				}
+
+				let tornCount = 0; // fill's own view: genA=0 (pre-gap snapshot) but genB=1 (post-mutation) -- mixed vintage
+				const tornSamples: Array<{ id: string; genA: unknown; genB: unknown }> = [];
+				let allOldCount = 0; // genA=0, genB=0 -- cross-database snapshot held despite the real gap
+				for (const { id, body, status } of results) {
+					ok(status === 200 && body, `GET /CrossTableSnap/${id} failed: ${status}`);
+					if (body!.genA !== 0) throw new Error(`unexpected genA for ${id}: ${JSON.stringify(body)}`);
+					if (body!.genB === 1) {
+						tornCount++;
+						if (tornSamples.length < 8) tornSamples.push({ id, genA: body!.genA, genB: body!.genB });
+					} else if (body!.genB === 0) {
+						allOldCount++;
+					}
+				}
+				console.log(
+					`[QA-596 P2] trials=${N_TRIALS} torn(genA=old,genB=new mid-gap commit visible)=${tornCount} ` +
+						`all-old(cross-database snapshot held)=${allOldCount}\n  samples: ${JSON.stringify(tornSamples)}`
+				);
+
+				// eventual convergence sanity: not a correctness requirement under test here, just confirm
+				// no hang/error and the cache eventually reflects reality.
+				await sleep(TTL_MS + SETTLE_MS);
+				const staleAfterSettle: Array<{ id: string; genA: unknown; genB: unknown }> = [];
+				for (const id of ids) {
+					const r = await getJSON<CrossBody>(`/CrossTableSnap/${id}`);
+					ok(r.status === 200 && r.body, `post-settle GET /CrossTableSnap/${id} failed: ${r.status}`);
+					if (r.body!.genA !== 0 || r.body!.genB !== 1)
+						staleAfterSettle.push({ id, genA: r.body!.genA, genB: r.body!.genB });
+				}
+				console.log(`[QA-596 P2] unconverged after TTL+settle: ${staleAfterSettle.length}/${N_TRIALS}`);
+				strictEqual(
+					staleAfterSettle.length,
+					0,
+					`convergence sanity failed: ${JSON.stringify(staleAfterSettle.slice(0, 5))}`
+				);
+
+				// NOTE: no hard assertion on tornCount here. This probe exists to OBSERVE whether the
+				// cross-database case breaks the single-store guarantee proven above; the observed
+				// distribution (logged) is itself the finding QA-596 was asked to establish, not a
+				// pass/fail gate — a torn cross-database view here is EXPECTED (by design), not a defect.
+			}
+		);
+
+		test(
+			'P3: two DIFFERENT tables in the SAME database — isolates whether the P2 seam is "two tables" or specifically "two databases"',
+			{ timeout: 60_000 },
+			async () => {
+				await setGap(GAP_MS);
+				const ids = Array.from({ length: N_TRIALS }, (_, i) => `T${i}`);
+
+				for (const id of ids) {
+					await putRow('RowA', id, 0);
+					await putRow('RowC', id, 0);
+				}
+
+				const results: Array<{ id: string; body: TwoTableSameDbBody | null; status: number }> = [];
+				for (const id of ids) {
+					const fillPromise = getJSON<TwoTableSameDbBody>(`/TwoTableSameDbSnap/${id}`); // reads RowA(gen0), awaits GAP_MS, reads RowC
+					await sleep(MUTATE_AT_MS);
+					await putRow('RowC', id, 1); // concurrent writer: RowC gen0 -> gen1, mid-await, BEFORE the resolver touches RowC
+					const r = await fillPromise;
+					results.push({ id, body: r.body, status: r.status });
+				}
+
+				let tornCount = 0;
+				const tornSamples: Array<{ id: string; genA: unknown; genC: unknown }> = [];
+				for (const { id, body, status } of results) {
+					ok(status === 200 && body, `GET /TwoTableSameDbSnap/${id} failed: ${status}`);
+					if (body!.genA !== 0) throw new Error(`unexpected genA for ${id}: ${JSON.stringify(body)}`);
+					if (body!.genC !== 0) {
+						tornCount++;
+						if (tornSamples.length < 8) tornSamples.push({ id, genA: body!.genA, genC: body!.genC });
+					}
+				}
+				console.log(
+					`[QA-596 P3] trials=${N_TRIALS} torn(genA=old,genC=new mid-gap commit visible, same-db cross-table)=${tornCount}\n` +
+						`  samples: ${JSON.stringify(tornSamples)}`
+				);
+
+				await sleep(TTL_MS + SETTLE_MS);
+				const staleAfterSettle: Array<{ id: string; genA: unknown; genC: unknown }> = [];
+				for (const id of ids) {
+					const r = await getJSON<TwoTableSameDbBody>(`/TwoTableSameDbSnap/${id}`);
+					ok(r.status === 200 && r.body, `post-settle GET /TwoTableSameDbSnap/${id} failed: ${r.status}`);
+					if (r.body!.genA !== 0 || r.body!.genC !== 1)
+						staleAfterSettle.push({ id, genA: r.body!.genA, genC: r.body!.genC });
+				}
+				console.log(`[QA-596 P3] unconverged after TTL+settle: ${staleAfterSettle.length}/${N_TRIALS}`);
+				strictEqual(
+					staleAfterSettle.length,
+					0,
+					`convergence sanity failed: ${JSON.stringify(staleAfterSettle.slice(0, 5))}`
+				);
+
+				// core claim: two tables in the SAME database share the reused-transaction snapshot just
+				// like two rows in one table (P1) -- the seam found in P2 is the DATABASE boundary, not
+				// the table boundary.
+				strictEqual(
+					tornCount,
+					0,
+					`snapshot scoping did NOT survive a real async gap across two same-database tables: ${tornCount}/${N_TRIALS} ` +
+						`fills observed their own second-table read reflect a commit that landed mid-await: ${JSON.stringify(tornSamples)}`
+				);
+			}
+		);
+	}
+);

--- a/integrationTests/resources/sourcedfrom-snapshot-scoping/config.yaml
+++ b/integrationTests/resources/sourcedfrom-snapshot-scoping/config.yaml
@@ -1,0 +1,5 @@
+graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/resources/sourcedfrom-snapshot-scoping/resources.js
+++ b/integrationTests/resources/sourcedfrom-snapshot-scoping/resources.js
@@ -1,0 +1,140 @@
+// QA-596 — force a genuinely async gap (real timer, real event-loop yield) mid-resolver-fill,
+// straddling a concurrent commit, and see whether the assembled view still comes from one
+// consistent snapshot. Two shapes: single-store (SingleTableSnap over Cell) and cross-store
+// (CrossTableSnap over RowA + RowB).
+import { setTimeout as sleep } from 'node:timers/promises';
+import { threadId } from 'node:worker_threads';
+
+const { Cell, RowA, RowC, SingleTableSnap, CrossTableSnap, TwoTableSameDbSnap } = tables;
+// RowB lives in a SEPARATE Harper database ("qa596b", see schema.graphql) so it gets its own
+// RocksDB root store -- a genuine cross-store boundary, unlike RowA which shares the default
+// database's store with Cell (same rootStore.path => same txnForContext chain link).
+const RowB = databases.qa596b.RowB;
+
+let gapMs = 100;
+let fillCounter = 0;
+const fillLog = [];
+
+SingleTableSnap.sourcedFrom(
+	class extends Resource {
+		async get() {
+			const entityId = String(this.getId());
+			const fillSeq = ++fillCounter;
+			const startedAt = Date.now();
+			const first = await Cell.get(`${entityId}:slotA`);
+			// genuinely async: a real timer, a real macrotask yield -- not just a microtask hop
+			await sleep(gapMs);
+			const second = await Cell.get(`${entityId}:slotB`);
+			const finishedAt = Date.now();
+			const result = {
+				id: entityId,
+				gens: { slotA: first ? first.gen : null, slotB: second ? second.gen : null },
+				fillSeq,
+				assembledAt: finishedAt,
+			};
+			fillLog.push({ kind: 'single', entityId, fillSeq, startedAt, finishedAt, threadId, result });
+			return result;
+		}
+	}
+);
+
+CrossTableSnap.sourcedFrom(
+	class extends Resource {
+		async get() {
+			const entityId = String(this.getId());
+			const fillSeq = ++fillCounter;
+			const startedAt = Date.now();
+			const a = await RowA.get(entityId);
+			const preGapAt = Date.now(); // RowA read done, about to yield for the real gap
+			// genuinely async gap BETWEEN reading two different tables/stores
+			await sleep(gapMs);
+			const postGapAt = Date.now(); // gap elapsed, about to touch RowB's store for the FIRST time
+			const b = await RowB.get(entityId);
+			const finishedAt = Date.now();
+			const result = {
+				id: entityId,
+				genA: a ? a.gen : null,
+				genB: b ? b.gen : null,
+				fillSeq,
+				startedAt,
+				preGapAt,
+				postGapAt,
+				finishedAt,
+				assembledAt: finishedAt,
+			};
+			fillLog.push({ kind: 'cross', entityId, fillSeq, startedAt, finishedAt, threadId, result });
+			return result;
+		}
+	}
+);
+
+TwoTableSameDbSnap.sourcedFrom(
+	class extends Resource {
+		async get() {
+			const entityId = String(this.getId());
+			const fillSeq = ++fillCounter;
+			const startedAt = Date.now();
+			const a = await RowA.get(entityId);
+			// genuinely async gap between two DIFFERENT tables that share the SAME database/rootStore
+			await sleep(gapMs);
+			const c = await RowC.get(entityId);
+			const finishedAt = Date.now();
+			const result = {
+				id: entityId,
+				genA: a ? a.gen : null,
+				genC: c ? c.gen : null,
+				fillSeq,
+				assembledAt: finishedAt,
+			};
+			fillLog.push({ kind: 'two-table-same-db', entityId, fillSeq, startedAt, finishedAt, threadId, result });
+			return result;
+		}
+	}
+);
+
+/** POST { gapMs } — set/clear the artificial real-timer gap inside both resolvers' get(). */
+export class Control extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		if (typeof body?.gapMs === 'number') gapMs = body.gapMs;
+		return { ok: true, gapMs, threadId };
+	}
+}
+
+/** GET /FillLog/ — every fill this worker has run (which worker, timing, and its own result). */
+export class FillLog extends Resource {
+	static loadAsInstance = false;
+	async get() {
+		return fillLog;
+	}
+}
+
+/** GET /WhoAmI/ — this worker's threadId (process.pid is identical across worker_threads). */
+export class WhoAmI extends Resource {
+	static loadAsInstance = false;
+	async get() {
+		return { threadId };
+	}
+}
+
+/** GET /CellScan/?id=S1 — independent oracle: raw Cell rows for one entity, bypassing SingleTableSnap. */
+export class CellScan extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const id = query && typeof query.get === 'function' ? query.get('id') : query?.id;
+		const a = await Cell.get(`${id}:slotA`);
+		const b = await Cell.get(`${id}:slotB`);
+		return { slotA: a ? a.gen : null, slotB: b ? b.gen : null };
+	}
+}
+
+/** GET /RowScan/?id=C1 — independent oracle: raw RowA/RowB for one entity, bypassing CrossTableSnap. */
+export class RowScan extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const id = query && typeof query.get === 'function' ? query.get('id') : query?.id;
+		const a = await RowA.get(id);
+		const b = await RowB.get(id);
+		return { genA: a ? a.gen : null, genB: b ? b.gen : null };
+	}
+}

--- a/integrationTests/resources/sourcedfrom-snapshot-scoping/schema.graphql
+++ b/integrationTests/resources/sourcedfrom-snapshot-scoping/schema.graphql
@@ -1,0 +1,73 @@
+# QA-596 — is a sourcedFrom resolver's snapshot read-scoping CONTRACTUAL or incidental?
+#
+# QA-595 proved reads LOOK snapshot-scoped but never forced a genuinely async gap (a real
+# event-loop yield, e.g. a timer) mid-fill, across a concurrent commit. This fixture forces
+# that gap in two shapes:
+#
+#   1. Single-store (Cell): both rows a resolver reads live in the SAME table/store. Tests
+#      whether the read-transaction reuse mechanism (resources/Table.ts getFromSource ->
+#      transaction() -> AsyncLocalStorage-propagated context -> reused DatabaseTransaction)
+#      survives a real timer await between the two reads.
+#   2. Cross-DATABASE (RowA in the default db / RowB in db "qa596b"): resources/databases.ts
+#      opens one shared RocksDB root store PER DATABASE (all tables in the same database are
+#      column families of the SAME rootStore, keyed by rootStore.path) — so two tables in the
+#      SAME database are, for txnForContext's chaining check (resources/Table.ts:5026-5069,
+#      `transaction.db?.path === primaryStore.path`), the SAME store and share ONE reused
+#      RocksTransaction/snapshot no differently than two rows in one table. A genuine
+#      cross-STORE test needs two different databases: each gets its own chained
+#      DatabaseTransaction (`transaction.next`), and each chained link's underlying
+#      RocksTransaction is opened LAZILY on ITS OWN first touch, independent of the other. So a
+#      real async gap between reading db-A's table and db-B's table gives a concurrent writer
+#      to db-B's table a window to land BEFORE db-B's snapshot is pinned, while db-A's snapshot
+#      (already pinned) does not see it. Tests whether that produces a genuinely torn
+#      (mixed-vintage) cross-database view.
+#   3. Cross-TABLE, SAME database (RowA / RowC, both default db): isolates whether the seam in
+#      (2) is really "two tables" or specifically "two databases" -- RowA and RowC are two
+#      distinct tables (distinct primaryStore/column-family) but share one rootStore.path, so
+#      txnForContext's chaining check treats them as the same store. Predicts the same
+#      guarantee as (1): consistent despite the real gap.
+
+type Cell @table @export {
+	id: ID @primaryKey
+	entityId: String @indexed
+	slot: String
+	gen: Int
+}
+
+type RowA @table @export {
+	id: ID @primaryKey
+	gen: Int
+}
+
+type RowB @table(database: "qa596b") @export {
+	id: ID @primaryKey
+	gen: Int
+}
+
+type RowC @table @export {
+	id: ID @primaryKey
+	gen: Int
+}
+
+type SingleTableSnap @table(expiration: 3) @export {
+	id: ID @primaryKey
+	gens: Any
+	fillSeq: Int
+	assembledAt: Long
+}
+
+type CrossTableSnap @table(expiration: 3) @export {
+	id: ID @primaryKey
+	genA: Int
+	genB: Int
+	fillSeq: Int
+	assembledAt: Long
+}
+
+type TwoTableSameDbSnap @table(expiration: 3) @export {
+	id: ID @primaryKey
+	genA: Int
+	genC: Int
+	fillSeq: Int
+	assembledAt: Long
+}


### PR DESCRIPTION
## Summary

Promotes three cold-verified-green QA-explorer regression specs into `integrationTests/resources/`, pinning read-consistency guarantees around Harper's `@relationship` GraphQL expansion and `sourcedFrom` cache resolvers:

- **`relationship-graphql-snapshot-consistency`** (QA-593) — nested GraphQL `Series -> articles` expansion never returns a torn (mixed-generation) sibling set when a writer atomically bulk-updates all of a series' children concurrently with reads. Parent/child generation *skew* across the two separate write transactions is expected and is not what this test gates on — only a torn *child-level* set is.
- **`sourcedfrom-eav-cache-coherence`** (QA-595) — an EAV-assembled `sourcedFrom` cache resource (5 attribute rows fused into one cached "product") converges to the raw-row oracle after TTL+settle under a bulk attribute-by-attribute mutation burst and a deterministic `invalidate()`-vs-in-flight-fill race.
- **`sourcedfrom-snapshot-scoping`** (QA-596) — establishes *why* the QA-595 guarantee holds: a `sourcedFrom` resolver's snapshot read-scoping survives a real async gap (not just a same-tick microtask hop) for reads within one database (single-table and cross-table), and documents that it is **not** guaranteed across two databases — by design, not a defect.

All three were cold-rerun on current `main` (gate SHA `3c5aeb9b7`) before promotion, then re-run again after relocation into their final path in this worktree.

## Notes

- Test-only — no product code changes.
- A fourth candidate (QA-597, EAV × Blob type-drift × blob-store reclamation) also gated GREEN but was excluded from this batch: it's a blob-lifecycle/reclamation test, not a read-consistency test, so it doesn't fit this PR's theme. Will follow in a separate batch.
- Generated by Claude Opus 4.8.