### PR TITLE
fix: reject null hash values on delete + primary-key changes on populated tables (studio#1199)

### DIFF
--- a/dataLayer/harperBridge/ResourceBridge.ts
+++ b/dataLayer/harperBridge/ResourceBridge.ts
@@ -282,6 +282,13 @@ export class ResourceBridge extends BridgeMethods {
 		return transaction(context, async (transaction) => {
 			const ids: Id[] =
 				deleteObj.ids || deleteObj.hash_values || deleteObj.records.map((record) => record[Table.primaryKey]);
+			// A null/undefined hash value must never reach Table.delete: with no key bound it is coerced
+			// into a whole-collection target and silently deletes EVERY record in the table (reported as
+			// "1 of 1 record successfully deleted"). Reject before touching anything, mirroring the
+			// primary-key guard search_by_id already enforces. See HarperFast/studio#1199.
+			for (const id of ids) {
+				if (id == null) throw new ClientError('Invalid primary key of null', 400);
+			}
 			const deleted = [];
 			const skipped = [];
 			for (const id of ids) {

--- a/resources/Resource.ts
+++ b/resources/Resource.ts
@@ -689,8 +689,11 @@ function transactional(
 				query = new RequestTarget();
 				query.id = id;
 				if (id == null) {
-					if (options.method === 'get') {
-						throw new Error(`Using an argument with a value of ${id} for ${options.method}, is not allowed`);
+					if (options.method === 'get' || options.method === 'delete') {
+						// For delete, a bare null/undefined id would be coerced into a whole-collection
+						// target and silently delete every record (studio#1199); a deliberate delete-all
+						// must use an explicit query object instead.
+						throw new ClientError(`Using an argument with a value of ${id} for ${options.method}, is not allowed`);
 					}
 					query.isCollection = true;
 				}

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -13,6 +13,7 @@ import { makeTable } from './Table.ts';
 import OpenEnvironmentObject from '../utility/lmdb/OpenEnvironmentObject.ts';
 import { CONFIG_PARAMS, LEGACY_DATABASES_DIR_NAME, DATABASES_DIR_NAME } from '../utility/hdbTerms.ts';
 import { getConfigPath } from '../config/configUtils.ts';
+import { ClientError } from '../utility/errors/hdbError.ts';
 import { _assignPackageExport } from '../globals.js';
 import { getIndexedValues } from '../utility/lmdb/commonUtility.ts';
 import * as signalling from '../utility/signalling.ts';
@@ -1119,6 +1120,29 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 		primaryKey = Table.primaryKey;
 		if (Table.primaryStore.rootStore.status === 'closed') {
 			throw new Error(`Can not use a closed data store from ${tableName} class`);
+		}
+		// Reject moving the primary key to a different attribute on a table that already has records.
+		// The storage key (Table.primaryKey) is never re-pointed here, so honoring the change would
+		// leave describe reporting the new attribute while every record — old and newly inserted — stays
+		// keyed by the original one; search_by_id/update/delete by the declared key then all miss. Only
+		// schema-authored callers (@table / defineTable / create_table) reassert the declaration, so
+		// gate on schemaDefinedExplicit to leave cluster schema-replication / data-loader callers alone.
+		// See HarperFast/studio#1199.
+		const declaredPrimaryKey = attributes.find((attribute) => attribute.isPrimaryKey)?.name;
+		if (schemaDefinedExplicit && declaredPrimaryKey && declaredPrimaryKey !== Table.primaryKey) {
+			let hasRecords = false;
+			for (const _entry of Table.primaryStore.getRange({ start: true })) {
+				hasRecords = true;
+				break;
+			}
+			if (hasRecords) {
+				throw new ClientError(
+					`Cannot change the primary key of table '${databaseName}.${tableName}' from '${Table.primaryKey}' to ` +
+						`'${declaredPrimaryKey}' because it already contains records. Recreate the table with the new primary ` +
+						`key, or migrate the existing records.`,
+					400
+				);
+			}
 		}
 		// it table already exists, get the split segments setting
 		if (splitSegments == undefined) splitSegments = Table.splitSegments;

--- a/unitTests/dataLayer/delete.test.js
+++ b/unitTests/dataLayer/delete.test.js
@@ -190,7 +190,7 @@ describe('Tests for delete.js', () => {
 			delete_obj.hash_values = [8, null, 9];
 			let test_err_result = await testUtils.testError(
 				_delete.deleteRecord(delete_obj),
-				"'hash_values' must not contain null"
+				"'hash_values[1]' must not contain null"
 			);
 
 			expect(test_err_result).to.be.true;

--- a/unitTests/dataLayer/delete.test.js
+++ b/unitTests/dataLayer/delete.test.js
@@ -180,6 +180,24 @@ describe('Tests for delete.js', () => {
 			expect(test_err_result).to.be.true;
 		});
 
+		it('Test that a null hash value is rejected before the bridge is called (studio#1199)', async () => {
+			// A null/undefined hash value would be coerced downstream into a whole-collection target
+			// and silently delete every record in the table (reported as "1 of 1"). The validator must
+			// reject it up front, before deleteRecords is ever reached.
+			let bridge_spy = sandbox.stub().resolves();
+			let revert = _delete.__set__('harperBridge', { deleteRecords: bridge_spy });
+			let delete_obj = testUtils.deepClone(DELETE_OBJ_TEST);
+			delete_obj.hash_values = [8, null, 9];
+			let test_err_result = await testUtils.testError(
+				_delete.deleteRecord(delete_obj),
+				"'hash_values' must not contain null"
+			);
+
+			expect(test_err_result).to.be.true;
+			expect(bridge_spy).to.not.have.been.called;
+			revert();
+		});
+
 		it('Test for nominal behaviour, success msg is returned', async () => {
 			global.hdb_schema = {
 				[DELETE_RECORDS_TEST.schema]: {

--- a/unitTests/resources/deleteNullPrimaryKey.test.js
+++ b/unitTests/resources/deleteNullPrimaryKey.test.js
@@ -1,0 +1,57 @@
+const { setupTestDBPath } = require('../testUtils');
+const { loadGQLSchema } = require('#src/resources/graphql');
+const harperBridge = require('#src/dataLayer/harperBridge/harperBridge').default;
+const { transaction } = require('#src/resources/transaction');
+const assert = require('node:assert');
+
+// The Operations API `delete` is guarded up front by deleteValidator, but the SQL `DELETE` path
+// (sqlTranslator/deleteTranslator.ts) and other internal callers reach ResourceBridge.deleteRecords
+// directly with only `records`/`ids`/`hash_values` set -- never touching the validator. A null
+// primary key there would be coerced into a whole-collection target and silently delete every row,
+// so the bridge guards each id itself. These exercise that guard directly (studio#1199).
+describe('ResourceBridge.deleteRecords rejects a null primary key', () => {
+	before(async () => {
+		setupTestDBPath();
+		await loadGQLSchema(`
+		type NullPkDelete @table {
+			id: Int @primaryKey
+			name: String
+		}`);
+		await transaction((context) =>
+			Promise.all([
+				tables.NullPkDelete.put({ id: 1, name: 'a' }, context),
+				tables.NullPkDelete.put({ id: 2, name: 'b' }, context),
+			])
+		);
+	});
+
+	function recordCount() {
+		let count = 0;
+		for (const _entry of tables.NullPkDelete.primaryStore.getRange({ start: true })) count++;
+		return count;
+	}
+
+	const cases = [
+		['hash_values', { schema: 'data', table: 'NullPkDelete', hash_values: [null] }],
+		['ids', { schema: 'data', table: 'NullPkDelete', ids: [null] }],
+		// The SQL DELETE shape: records whose primary-key attribute is unset map to a null id.
+		['records missing the primary key', { schema: 'data', table: 'NullPkDelete', records: [{ name: 'c' }] }],
+	];
+
+	for (const [label, deleteObj] of cases) {
+		it(`throws for ${label} and deletes nothing`, async () => {
+			await assert.rejects(() => harperBridge.deleteRecords(deleteObj), /Invalid primary key of null/);
+			assert.strictEqual(recordCount(), 2, 'no records should have been deleted');
+		});
+	}
+
+	it('still deletes normally by a real primary key (the guard does not block valid ids)', async () => {
+		const result = await harperBridge.deleteRecords({ schema: 'data', table: 'NullPkDelete', hash_values: [2] });
+		assert.deepStrictEqual(result.deleted_hashes, [2]);
+		assert.deepStrictEqual(result.skipped_hashes, []);
+	});
+
+	after(async () => {
+		await tables.NullPkDelete?.indexingOperation;
+	});
+});

--- a/unitTests/resources/deleteNullResourceApi.test.js
+++ b/unitTests/resources/deleteNullResourceApi.test.js
@@ -1,0 +1,60 @@
+const { setupTestDBPath } = require('../testUtils');
+const { loadGQLSchema } = require('#src/resources/graphql');
+const { transaction } = require('#src/resources/transaction');
+const assert = require('node:assert');
+
+// The Resource API mirror of the studio#1199 bug class: `Table.delete(null)` (or undefined, or no
+// argument) was normalized by transactional() into a whole-collection target with no conditions and
+// silently deleted every record, returning true. A bare null id must throw; a deliberate delete-all
+// still works through an explicit query object.
+describe('Table.delete with a null/undefined id', () => {
+	before(async () => {
+		setupTestDBPath();
+		await loadGQLSchema(`
+		type NullIdResourceDelete @table {
+			id: Int @primaryKey
+			name: String
+		}`);
+		await transaction((context) =>
+			Promise.all([
+				tables.NullIdResourceDelete.put({ id: 1, name: 'a' }, context),
+				tables.NullIdResourceDelete.put({ id: 2, name: 'b' }, context),
+			])
+		);
+	});
+
+	function recordCount() {
+		// deletes leave tombstone entries in the primary store, so count only live values
+		let count = 0;
+		for (const entry of tables.NullIdResourceDelete.primaryStore.getRange({ start: true }))
+			if (entry.value != null) count++;
+		return count;
+	}
+
+	for (const [label, invoke] of [
+		['null', () => tables.NullIdResourceDelete.delete(null)],
+		['undefined', () => tables.NullIdResourceDelete.delete(undefined)],
+		['no argument', () => tables.NullIdResourceDelete.delete()],
+	]) {
+		it(`throws for ${label} and deletes nothing`, () => {
+			assert.throws(invoke, /is not allowed/);
+			assert.strictEqual(recordCount(), 2, 'no records should have been deleted');
+		});
+	}
+
+	it('still deletes normally by a real id', async () => {
+		assert.strictEqual(await transaction((context) => tables.NullIdResourceDelete.delete(2, context)), true);
+		await tables.NullIdResourceDelete.primaryStore.flushed;
+		assert.strictEqual(recordCount(), 1);
+	});
+
+	it('still deletes the whole collection through an explicit query object', async () => {
+		assert.strictEqual(await transaction((context) => tables.NullIdResourceDelete.delete({}, context)), true);
+		await tables.NullIdResourceDelete.primaryStore.flushed;
+		assert.strictEqual(recordCount(), 0);
+	});
+
+	after(async () => {
+		await tables.NullIdResourceDelete?.indexingOperation;
+	});
+});

--- a/unitTests/resources/update-schema.test.js
+++ b/unitTests/resources/update-schema.test.js
@@ -70,6 +70,27 @@ describe('Update Schema', () => {
 		const state_attribute = tables.SchemaChanges.attributes.find((a) => a.name === 'state');
 		assert(state_attribute.nullable !== false);
 	});
+	it('rejects moving the primary key on a table that already has records (studio#1199)', async function () {
+		// SchemaChanges is populated by the tests above and keyed by `id`. Moving @primaryKey to a
+		// different attribute must be rejected: the storage key isn't re-pointed, so it would leave
+		// describe reporting the new key while every record stays keyed by `id`.
+		let caught;
+		try {
+			await loadGQLSchema(`
+			type SchemaChanges @table {
+				id: Int
+				state: String @primaryKey
+				city: String @indexed
+			}`);
+		} catch (error) {
+			caught = error;
+		}
+		assert(caught, 'expected changing the primary key to throw');
+		assert(caught.message.includes('primary key'), `expected a primary-key error, got: ${caught && caught.message}`);
+		assert.equal(caught.statusCode, 400);
+		// The real primary key must be left untouched.
+		assert.equal(tables.SchemaChanges.primaryKey, 'id');
+	});
 	after(async function () {
 		// Wait for any pending indexing to finish so no LMDB read transactions
 		// remain open when the next test suite calls resetDatabases()/close().

--- a/unitTests/validation/deleteValidator.test.js
+++ b/unitTests/validation/deleteValidator.test.js
@@ -32,4 +32,35 @@ describe('Test deleteValidator module', () => {
 		const result = deleteValidator(test_del_obj);
 		expect(result.message).to.equal("'hash_values' must be an array");
 	});
+
+	it('Test null in hash_values rejected (would wipe the table -- studio#1199)', () => {
+		const test_del_obj = {
+			schema: 'unit',
+			table: 'test',
+			hash_values: [1, null, '3vs'],
+		};
+		const result = deleteValidator(test_del_obj);
+		expect(result.message).to.equal("'hash_values' must not contain null");
+	});
+
+	it('Test null in ids rejected', () => {
+		const test_del_obj = {
+			schema: 'unit',
+			table: 'test',
+			ids: [null],
+			hash_values: [1],
+		};
+		const result = deleteValidator(test_del_obj);
+		expect(result.message).to.equal("'hash_values' must not contain null");
+	});
+
+	it('Test valid string and number hash_values pass', () => {
+		const test_del_obj = {
+			schema: 'unit',
+			table: 'test',
+			hash_values: ['1a', 1, '3vs'],
+		};
+		const result = deleteValidator(test_del_obj);
+		expect(result).to.be.undefined;
+	});
 });

--- a/unitTests/validation/deleteValidator.test.js
+++ b/unitTests/validation/deleteValidator.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const chai = require('chai');
-const { expect } = chai;
+const assert = require('node:assert');
 const deleteValidator = require('#src/validation/deleteValidator').default;
 
 describe('Test deleteValidator module', () => {
@@ -11,7 +10,7 @@ describe('Test deleteValidator module', () => {
 			hash_values: ['1a', 1, '3vs'],
 		};
 		const result = deleteValidator(test_del_obj);
-		expect(result.message).to.equal("'table' is required");
+		assert.strictEqual(result.message, "'table' is required");
 	});
 
 	it('Test hash_values required returned', () => {
@@ -20,7 +19,7 @@ describe('Test deleteValidator module', () => {
 			table: 'test',
 		};
 		const result = deleteValidator(test_del_obj);
-		expect(result.message).to.equal("'hash_values' is required");
+		assert.strictEqual(result.message, "'hash_values' is required");
 	});
 
 	it('Test hash_values invalid returned', () => {
@@ -30,7 +29,7 @@ describe('Test deleteValidator module', () => {
 			hash_values: '1abc',
 		};
 		const result = deleteValidator(test_del_obj);
-		expect(result.message).to.equal("'hash_values' must be an array");
+		assert.strictEqual(result.message, "'hash_values' must be an array");
 	});
 
 	it('Test null in hash_values rejected (would wipe the table -- studio#1199)', () => {
@@ -40,10 +39,10 @@ describe('Test deleteValidator module', () => {
 			hash_values: [1, null, '3vs'],
 		};
 		const result = deleteValidator(test_del_obj);
-		expect(result.message).to.equal("'hash_values' must not contain null");
+		assert.strictEqual(result.message, "'hash_values[1]' must not contain null");
 	});
 
-	it('Test null in ids rejected', () => {
+	it('Test null in ids rejected (names the ids field, not hash_values)', () => {
 		const test_del_obj = {
 			schema: 'unit',
 			table: 'test',
@@ -51,7 +50,7 @@ describe('Test deleteValidator module', () => {
 			hash_values: [1],
 		};
 		const result = deleteValidator(test_del_obj);
-		expect(result.message).to.equal("'hash_values' must not contain null");
+		assert.strictEqual(result.message, "'ids[0]' must not contain null");
 	});
 
 	it('Test valid string and number hash_values pass', () => {
@@ -61,6 +60,6 @@ describe('Test deleteValidator module', () => {
 			hash_values: ['1a', 1, '3vs'],
 		};
 		const result = deleteValidator(test_del_obj);
-		expect(result).to.be.undefined;
+		assert.strictEqual(result, undefined);
 	});
 });

--- a/validation/deleteValidator.ts
+++ b/validation/deleteValidator.ts
@@ -2,12 +2,19 @@ import * as validator from './validationWrapper.ts';
 import Joi from 'joi';
 import { hdbTable, hdbDatabase } from './common_validators.ts';
 
+// `hash_values`/`ids` are lists of primary keys. Items may be strings, numbers, or composite
+// (array/object) keys, but never `null`/`undefined`: a null key is coerced downstream into a
+// whole-collection target that wipes the table (see HarperFast/studio#1199), reject at the boundary.
+const hashValue = Joi.any().invalid(null).messages({
+	'any.invalid': `'hash_values' must not contain null`,
+});
+
 const deleteSchema = Joi.object({
 	schema: hdbDatabase,
 	database: hdbDatabase,
 	table: hdbTable,
-	hash_values: Joi.array().required(),
-	ids: Joi.array(),
+	hash_values: Joi.array().items(hashValue).required(),
+	ids: Joi.array().items(hashValue),
 });
 
 export default function (deleteObject: any) {

--- a/validation/deleteValidator.ts
+++ b/validation/deleteValidator.ts
@@ -5,8 +5,10 @@ import { hdbTable, hdbDatabase } from './common_validators.ts';
 // `hash_values`/`ids` are lists of primary keys. Items may be strings, numbers, or composite
 // (array/object) keys, but never `null`/`undefined`: a null key is coerced downstream into a
 // whole-collection target that wipes the table (see HarperFast/studio#1199), reject at the boundary.
+// `{#label}` resolves to the offending field/index (e.g. `hash_values[0]` or `ids[0]`) so the error
+// names the right field whether the null came in via `hash_values` or `ids`.
 const hashValue = Joi.any().invalid(null).messages({
-	'any.invalid': `'hash_values' must not contain null`,
+	'any.invalid': `{#label} must not contain null`,
 });
 
 const deleteSchema = Joi.object({


### PR DESCRIPTION
Two related data-integrity fixes behind **HarperFast/studio#1199** ("500 'hash_values' must be strings or numbers"). Studio companion PR: **HarperFast/studio#1529**.

---

## 1. `delete` with a null hash value wipes the whole table

A `delete` with a null/undefined value in `hash_values` deletes **every record in the table** while reporting `"1 of 1 record successfully deleted"`:

```jsonc
{"operation":"delete","database":"data","table":"T","hash_values":[null]}
// → {"message":"1 of 1 record successfully deleted","deleted_hashes":[null]}  (200)
// → table now has 0 rows
```

Reproduced on 4.7.23 and 5.0.15. `hash_values:[]` is a safe no-op and `[999]` (absent key) deletes nothing — only `null` triggers the wipe. A null id is coerced by `transactional` into a whole-collection target (only `get` was guarded against null), so `Table.delete` takes the search-and-delete-all branch and `search()` runs with no key bound.

**Fix:** reject `null`/`undefined` items in `deleteValidator` (composite array/object keys still allowed), and guard each id in `ResourceBridge.deleteRecords` before `Table.delete` so no caller can trip the coercion. Tests at both layers.

## 2. Changing `@primaryKey` on a populated table corrupts it

Changing which attribute is the primary key (via GraphQL schema, `defineTable`, or `create_table`) on a table that already has records leaves the table in a lying state: the real hash/storage key never moves, so `describe_table` reports the newly-declared attribute while **every** record — old *and* newly inserted, even through the raw Operations API — stays keyed by the original attribute. `search_by_id`/update/delete by the declared key then all miss. I confirmed this by inserting `{email:"…"}` into a table whose `describe` said `primary_key: "email"` and finding the row keyed by a generated `id` UUID.

This is the actual origin of #1199 (a row's declared primary key resolves to nothing → studio builds doomed requests).

**Fix:** `table()` is the single factory every front-end funnels through. On the existing-table branch, if a schema-authored declaration names a different primary key **and** the table has any records, throw a `ClientError` instead of silently diverging describe from storage. Empty tables and settings-only reasserts are unaffected. Regression test in `unitTests/resources/update-schema.test.js`.

> Scope note: this rejects the corrupting change with a clear error. Actually *migrating* (re-keying existing records to the new attribute) is a larger feature and intentionally out of scope here.

---

Existing delete/schema tests remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)