### PR TITLE
fix(mcp): enforce row-level allowRead on custom mcpResources reads (#1735)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -223,6 +223,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
 
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/components/mcp/customResourceRegistry.ts
+++ b/components/mcp/customResourceRegistry.ts
@@ -16,6 +16,36 @@
  * sessions where the deployment allows them (the public-docs case #1609 is
  * built around) — and the author's method enforces any access control it
  * needs at read time.
+ *
+ * When a custom resource wraps *row-level-guarded* table data, the author MUST
+ * fetch it through the exported (routing) Resource — the subclass that carries
+ * the row-level `allow*` predicates — with a `checkPermission`-bearing
+ * RequestTarget, so those predicates run against the calling MCP user. The MCP
+ * layer runs the read inside a transaction that carries that user
+ * (`readCustomResource` in `resources.ts`), so the read authorizes correctly:
+ *
+ *     import { RequestTarget } from 'harper';
+ *     export class Order extends tables.Order {
+ *       allowRead(user) { return user?.username != null && this.customerId === user.username; }
+ *     }
+ *     export class OrderDocs extends Resource {
+ *       async readOrder(params, context) {
+ *         const target = new RequestTarget();
+ *         target.id = params.orderId;
+ *         target.checkPermission = context.user?.role?.permission ?? true;
+ *         return { text: JSON.stringify(await Order.get(target)) }; // enforces allowRead
+ *       }
+ *     }
+ *     OrderDocs.mcpResources = [{ uriTemplate: 'orders:///{+orderId}', method: 'readOrder' }];
+ *
+ * Fetching the same row via the *base* table (`tables.Order.get(id)`) would
+ * dispatch on the base class, whose `allowRead` is a table-level grant only —
+ * it does NOT run the per-record override and leaks another user's row (#1735).
+ *
+ * Call the guarded fetch single-arg (`Order.get(target)`) so it runs under the
+ * user-carrying ambient transaction — do NOT forward the resource's own context
+ * (`Order.get(target, this.getContext())`), which starts an independent
+ * transaction and drops that shared, isolated snapshot.
  */
 import type { McpProfile } from './transport.ts';
 import type { AuthedUser } from './toolRegistry.ts';

--- a/components/mcp/resources.ts
+++ b/components/mcp/resources.ts
@@ -35,6 +35,7 @@
 import * as env from '../../utility/environment/environmentManager.ts';
 import { CONFIG_PARAMS, OPERATIONS_ENUM } from '../../utility/hdbTerms.ts';
 import harperLogger from '../../utility/logging/harper_logger.ts';
+import { AccessViolation } from '../../utility/errors/hdbError.ts';
 import { SERVER_CAPABILITIES, SERVER_INFO, SUPPORTED_PROTOCOL_VERSIONS } from './lifecycle.ts';
 import { encodeCursor } from './pagination.ts';
 import {
@@ -548,7 +549,21 @@ async function readCustomResource(
 ): Promise<ReadResourceOk | ReadResourceFail> {
 	const { def, params } = custom;
 	try {
-		const result = await def.read(params, { user, profile });
+		// Run the author's `read` inside a transaction that carries the calling
+		// user, so a row-level-guarded fetch the author performs against the
+		// exported (routing) Resource — e.g. `Order.get(target)` with a
+		// `checkPermission`-bearing RequestTarget — runs that Resource's
+		// `allowRead` against the real MCP session user, the same gate REST
+		// enforces (#1735). We deliberately do NOT set `authorize` here: that
+		// would force-authorize the author's *first* internal read (Resource.ts
+		// consumes `context.authorize` once), breaking trusted internal lookups.
+		// Per-record enforcement is opt-in via the author's `checkPermission`.
+		// Merge onto any ambient store (usually none on the MCP HTTP path) so an
+		// inherited transaction/cache is preserved rather than clobbered; `user`
+		// binds last. Same idiom as processLocalTransaction's `{ ...currentStore, user }`.
+		// Lazy-require the server-layer machinery (see file-top note on eager init).
+		const { transaction, contextStorage } = require('../../resources/transaction');
+		const result = await transaction({ ...contextStorage.getStore(), user }, () => def.read(params, { user, profile }));
 		if (typeof result === 'string') {
 			return { ok: true, contents: [{ uri, mimeType: def.mimeType ?? 'text/plain', text: result }] };
 		}
@@ -583,6 +598,15 @@ async function readCustomResource(
 		}
 		return { ok: false, reason: `custom resource '${def.name}' returned no content for: ${uri}` };
 	} catch (err) {
+		// An AccessViolation raised by the underlying Resource's `allow*` predicate
+		// is a permission error, not a read failure — surface it as such (without
+		// leaking the row) so the client sees the same denial REST returns, rather
+		// than a generic "failed to read" (#1735). Match the class, not a status
+		// code, so an unrelated author error that happens to carry 401/403 (e.g. an
+		// upstream fetch) still surfaces as a read failure and stays in the log.
+		if (err instanceof AccessViolation) {
+			return { ok: false, reason: `permission denied: ${uri}` };
+		}
 		// Author read errors surface as read failures (JSON-RPC error at the
 		// transport), with the raw error only in the server log — same
 		// sanitization posture as custom tools.

--- a/integrationTests/fixtures/mcp-custom-resources-authz/config.yaml
+++ b/integrationTests/fixtures/mcp-custom-resources-authz/config.yaml
@@ -1,0 +1,9 @@
+# #1735 — MCP custom mcpResources (#1609) must enforce row-level allowRead.
+graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true
+graphql: true
+databases:
+  - name: data

--- a/integrationTests/fixtures/mcp-custom-resources-authz/resources.js
+++ b/integrationTests/fixtures/mcp-custom-resources-authz/resources.js
@@ -1,0 +1,60 @@
+// #1735 — MCP custom mcpResources (#1609) vs row-level allowRead.
+//
+// Order: per-row allowRead denies rows whose customerId doesn't match the
+// requesting user's username (super_user always passes).
+//
+// OrderDocs: a component-author-style Resource publishing a custom MCP content
+// resource `orders:///{+orderId}` (the #1609 `static mcpResources` pattern),
+// wrapping real, row-level-guarded table data.
+//
+// SECURE fetch pattern (the fix for #1735): fetch through the *exported*
+// (routing) `Order` Resource with a `checkPermission`-bearing RequestTarget, so
+// its per-record `allowRead` runs against the calling MCP session user — the
+// same gate REST enforces. Calling `tables.Order.get()` instead would dispatch
+// on the *base* table class, whose `allowRead` is a table-level grant only, and
+// would leak another user's row. The MCP layer runs the read inside a
+// transaction that carries the calling user (components/mcp/resources.ts), so a
+// single-arg `Order.get(target)` authorizes against that user.
+
+import { RequestTarget } from 'harper';
+
+function isSuper(user) {
+	return !!user?.role?.permission?.super_user;
+}
+
+export class Order extends tables.Order {
+	allowRead(user) {
+		if (isSuper(user)) return true;
+		return user?.username != null && this.customerId === user.username;
+	}
+}
+
+export class OrderDocs extends Resource {
+	async readOrder(params, context) {
+		const target = new RequestTarget();
+		target.id = params.orderId;
+		// Ask the Resource to enforce its row-level allow* against this user.
+		target.checkPermission = context?.user?.role?.permission ?? true;
+		const order = await Order.get(target);
+		if (!order) throw new Error(`no such order: ${params.orderId}`);
+		return {
+			text: JSON.stringify({
+				id: order.id,
+				customerId: order.customerId,
+				item: order.item,
+				total: order.total,
+			}),
+			mimeType: 'application/json',
+		};
+	}
+}
+
+OrderDocs.mcpResources = [
+	{
+		uriTemplate: 'orders:///{+orderId}',
+		name: 'order by id',
+		description: 'Fetch an order by id (wraps table data, the realistic #1609 use case)',
+		mimeType: 'application/json',
+		method: 'readOrder',
+	},
+];

--- a/integrationTests/fixtures/mcp-custom-resources-authz/schema.graphql
+++ b/integrationTests/fixtures/mcp-custom-resources-authz/schema.graphql
@@ -1,0 +1,12 @@
+# #1735 — the natural #1609 use case: a custom MCP content resource that wraps
+# real, row-level-allowRead-gated table data. `Order` rows carry `customerId`;
+# `resources.js` denies a row to any authenticated user whose username doesn't
+# match it (super_user always passes). @export keeps the table on the normal
+# REST path for the anchor check.
+
+type Order @table @export {
+	id: ID @primaryKey
+	customerId: String
+	item: String
+	total: Float
+}

--- a/integrationTests/mcp/custom-resources-authz.test.ts
+++ b/integrationTests/mcp/custom-resources-authz.test.ts
@@ -1,0 +1,187 @@
+/**
+ * MCP custom content resources (#1609) — row-level allowRead enforcement (#1735).
+ *
+ * Regression coverage for an authorization bypass on the custom `mcpResources`
+ * read path. A component author wraps real table data behind a friendly MCP URI
+ * (`orders:///{+orderId}`). When `Order` has a row-level `allowRead(user)` guard,
+ * a low-priv MCP `resources/read` of another user's row must be denied — the same
+ * as REST — not returned with full content.
+ *
+ * Two things make that hold, and this fixture exercises both:
+ *   1. The custom-resource read runs inside a transaction that carries the calling
+ *      MCP user (components/mcp/resources.ts `readCustomResource`), so an internal
+ *      guarded fetch authorizes against the real session user.
+ *   2. The author fetches through the *exported* (routing) `Order` Resource with a
+ *      `checkPermission`-bearing RequestTarget — `Order.get(target)` — so its
+ *      per-record `allowRead` runs. Fetching via the base `tables.Order.get()`
+ *      would dispatch on the base table (table-level RBAC only) and leak.
+ *
+ * The fixture's `Order` subclass restricts reads to `customerId === username`
+ * (super users pass); table-level read is granted, so the only barrier between
+ * `lowuser` and another user's order is the per-record guard — exactly what must
+ * hold on MCP just as it does on REST.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok } from 'node:assert';
+import { resolve } from 'node:path';
+
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, '../fixtures/mcp-custom-resources-authz');
+
+const LOWUSER = { username: 'mcp_res_lowuser', password: 'LowPw-1735!' };
+const ROLE = 'mcp_res_reader';
+
+const ORDER_A = 'order-A'; // owned by lowuser
+const ORDER_B = 'order-B'; // owned by admin — the forbidden row
+const ORDER_B_ITEM = 'widget-B-secret';
+const ORDER_B_TOTAL = 51599.15; // sentinel we scan for in a leak
+
+function basicAuth(username: string, password: string): string {
+	return `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+}
+
+/** Open an MCP application-profile client authenticated as the given user. */
+async function appClient(
+	ctx: ContextWithHarper,
+	username: string,
+	password: string
+): Promise<{ client: Client; transport: StreamableHTTPClientTransport }> {
+	const transport = new StreamableHTTPClientTransport(new URL('/mcp', ctx.harper.httpURL), {
+		requestInit: { headers: { Authorization: basicAuth(username, password) } },
+	});
+	const client = new Client({ name: 'mcp-custom-resources-authz', version: '1.0.0' }, { capabilities: {} });
+	await client.connect(transport);
+	return { client, transport };
+}
+
+interface ReadResult {
+	contents?: Array<{ uri: string; text?: string; mimeType?: string }>;
+}
+
+function readText(result: ReadResult): string {
+	return result.contents?.map((c) => c.text ?? '').join('') ?? '';
+}
+
+/** Operations-API call as admin (super user). */
+async function opsAsAdmin(ctx: ContextWithHarper, body: object): Promise<any> {
+	const res = await fetch(new URL('', ctx.harper.operationsAPIURL), {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			'Authorization': basicAuth(ctx.harper.admin.username, ctx.harper.admin.password),
+		},
+		body: JSON.stringify(body),
+	});
+	const text = await res.text();
+	try {
+		return JSON.parse(text);
+	} catch {
+		return text;
+	}
+}
+
+suite('MCP custom content resources row-level allowRead (#1735)', (ctx: ContextWithHarper) => {
+	let admin: { client: Client; transport: StreamableHTTPClientTransport };
+	let low: { client: Client; transport: StreamableHTTPClientTransport };
+
+	before(async () => {
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+			config: { mcp: { application: { mountPath: '/mcp' } } },
+			env: {},
+		});
+
+		// Table-level read only — the per-row allowRead guard is the real barrier.
+		await opsAsAdmin(ctx, {
+			operation: 'add_role',
+			role: ROLE,
+			permission: {
+				super_user: false,
+				data: {
+					tables: {
+						Order: { read: true, insert: false, update: false, delete: false, attribute_permissions: [] },
+					},
+				},
+			},
+		});
+		await opsAsAdmin(ctx, {
+			operation: 'add_user',
+			role: ROLE,
+			username: LOWUSER.username,
+			password: LOWUSER.password,
+			active: true,
+		});
+
+		await opsAsAdmin(ctx, {
+			operation: 'insert',
+			schema: 'data',
+			table: 'Order',
+			records: [
+				{ id: ORDER_A, customerId: LOWUSER.username, item: 'widget-A', total: 12.34 },
+				{ id: ORDER_B, customerId: ctx.harper.admin.username, item: ORDER_B_ITEM, total: ORDER_B_TOTAL },
+			],
+		});
+
+		admin = await appClient(ctx, ctx.harper.admin.username, ctx.harper.admin.password);
+		low = await appClient(ctx, LOWUSER.username, LOWUSER.password);
+	});
+
+	after(async () => {
+		await admin?.transport.close();
+		await low?.transport.close();
+		await teardownHarper(ctx);
+	});
+
+	// ── REST anchor: proves allowRead is wired and enforced on the base path ──
+	test('REST anchor: lowuser is denied a direct point-read of order B', async () => {
+		const res = await fetch(new URL(`/Order/${ORDER_B}`, ctx.harper.httpURL), {
+			headers: { Authorization: basicAuth(LOWUSER.username, LOWUSER.password) },
+		});
+		await res.body?.cancel();
+		ok(res.status === 403 || res.status === 404, `expected 403/404 REST anchor deny, got ${res.status}`);
+	});
+
+	// ── Positive control: the read handler works end-to-end for an allowed row ─
+	test('lowuser MCP resources/read on own order A succeeds with real content', async () => {
+		const result = (await low.client.readResource({ uri: `orders:///${ORDER_A}` })) as ReadResult;
+		ok(readText(result).includes('widget-A'), `own order content present: ${JSON.stringify(result.contents)}`);
+	});
+
+	// ── The security oracle: forbidden row must NOT come back ──────────────────
+	test('lowuser MCP resources/read on order B (not theirs) is denied, no leak', async () => {
+		let deniedError: string | undefined;
+		let text = '';
+		try {
+			const result = (await low.client.readResource({ uri: `orders:///${ORDER_B}` })) as ReadResult;
+			text = readText(result);
+		} catch (err) {
+			deniedError = (err as Error)?.message ?? String(err);
+		}
+		// No content leak.
+		ok(
+			!text.includes(ORDER_B_ITEM) && !text.includes(String(ORDER_B_TOTAL)),
+			'SECURITY: order B content leaked to lowuser via MCP custom resource read'
+		);
+		// And the denial must be an authorization error specifically — not a
+		// generic read failure (import error, handler bug) that would fail open.
+		ok(deniedError !== undefined, 'order B read should have been rejected, not returned');
+		ok(/permission denied/i.test(deniedError), `expected a permission-denied error, got: ${deniedError}`);
+	});
+
+	// ── Enumeration is not a separate leak vector ──────────────────────────────
+	test('resources/templates/list does not leak order B id/content', async () => {
+		const listed = await low.client.listResourceTemplates();
+		const blob = JSON.stringify(listed.resourceTemplates ?? []);
+		ok(!blob.includes(ORDER_B) && !blob.includes(ORDER_B_ITEM), 'templates/list should advertise only the URI shape');
+	});
+
+	// ── Positive control: super user reads both, so the handler isn't just broken ─
+	test('admin (super_user) MCP resources/read succeeds on both order A and B', async () => {
+		const a = (await admin.client.readResource({ uri: `orders:///${ORDER_A}` })) as ReadResult;
+		const b = (await admin.client.readResource({ uri: `orders:///${ORDER_B}` })) as ReadResult;
+		ok(readText(a).includes('widget-A'), 'admin reads A');
+		ok(readText(b).includes(ORDER_B_ITEM), 'admin reads B');
+	});
+});


### PR DESCRIPTION
## Summary

A #1609 custom `mcpResources` read that wraps row-level-guarded table data leaked another user's forbidden row over MCP `resources/read` (`200` + full content) where the same low-priv request correctly `403`s over REST. Fixes #1735.

**Root cause (confirmed by runtime instrumentation):** inside the author's custom `read`, the natural `tables.Order.get(id)` dispatches on the **base table class**, whose `allowRead` is a table-level *grant* that a user with table-level `read` satisfies. The per-record `allowRead` override lives only on the exported subclass in the routing registry — REST routes through it and denies; the author's base-table fetch does not. (Even a `checkPermission`-bearing RequestTarget on `tables.X.get()` still leaks — only `Order.get()`, the exported subclass, enforces.)

## Changes

- **`readCustomResource`** now runs the author's `read` inside a `transaction({ user })` so a guarded fetch the author performs carries the real MCP session user. `authorize` is **intentionally not set** — that would force-authorize the author's *first* internal read (Harper consumes `context.authorize` once), breaking trusted internal lookups; per-record enforcement stays opt-in via the author's `checkPermission`. An `AccessViolation` now surfaces as a `permission denied` read failure rather than a generic "failed to read".
- **Author-facing doc comment** (`customResourceRegistry.ts`) documents the secure pattern — fetch gated data through the exported (routing) Resource with a `checkPermission` RequestTarget (`Order.get(target)`) — and warns that `tables.X.get()` leaks.
- **Regression test + fixture** (`integrationTests/mcp/custom-resources-authz.test.ts`, `fixtures/mcp-custom-resources-authz/`).

## Where to look / open considerations

- The design choice to thread the user **without** `authorize` (§`readCustomResource`) is the load-bearing decision — it makes the secure pattern work while leaving the author's other internal reads trusted. Worth a sanity check that this is the right default vs. mirroring `subscribeToResource`'s `authorize: true`.
- This makes the **correct** pattern work and documents it; it does **not** auto-block a naive `tables.X.get(id)` author (inherent — base table = table-level grant; per maintainer decision we are not making base tables enforce subclass overrides).
- Not in scope, flagged in #1735: a structural guardrail (lint/test asserting registered read handlers thread an authorize-context). Can file a follow-up.

## Tests

`integrationTests/mcp/` — new `custom-resources-authz` (5/5), plus `custom-resources` (8/8) and `row-authz` (8/8) as regression checks, all green locally. The user-facing docs repo has no custom-`mcpResources` section on `main` yet (only in-progress worktrees), so the secure example lives in the code doc-comment; happy to add to the docs repo once that section lands.

🤖 Generated by KrAIs (Claude Opus 4.8, 1M context)