### PR TITLE
fix(tls): honor `ciphers`/`SECLEVEL` from every configured source when building TLS listeners

### DIFF
--- a/integrationTests/security/tls-ciphers-seclevel.test.ts
+++ b/integrationTests/security/tls-ciphers-seclevel.test.ts
@@ -181,8 +181,13 @@ suite(
 		});
 
 		after(async () => {
-			await teardownHarper(ctx);
-			await rm(certsDir, { recursive: true, force: true, maxRetries: 3 });
+			// before() can fail prior to certsDir being assigned; still tear Harper down, and only
+			// remove what was actually created
+			try {
+				await teardownHarper(ctx);
+			} finally {
+				if (certsDir) await rm(certsDir, { recursive: true, force: true, maxRetries: 3 });
+			}
 		});
 
 		test('accepts a client cert chained through the SHA-1-signed CA', async () => {

--- a/integrationTests/security/tls-ciphers-seclevel.test.ts
+++ b/integrationTests/security/tls-ciphers-seclevel.test.ts
@@ -1,0 +1,210 @@
+/**
+ * TLS effective-cipher resolution — client CAs that need a relaxed OpenSSL security level.
+ *
+ * A client CA whose chain is SHA-1-signed only verifies when the listener's cipher string
+ * carries `DEFAULT@SECLEVEL=0` (OpenSSL otherwise fails the chain with "CA signature digest
+ * algorithm too weak", surfacing as authorizationError UNSPECIFIED on in-date certs). The
+ * cipher string — and its @SECLEVEL — only takes effect at the listener level: a context
+ * swapped in by the SNI callback does not carry its own cipher list onto the connection.
+ * Harper previously applied only `tls.ciphers ?? tls[0].ciphers`, silently ignoring a
+ * `ciphers` value on any other `tls[]` entry or certificate record, so mTLS deployments
+ * that relaxed the level on the CA entry were rejected wholesale after every boot.
+ *
+ * This boots Harper with `tls` as an array whose SECOND entry is the SHA-1 client CA
+ * carrying `ciphers: DEFAULT@SECLEVEL=0` (the previously-ignored position) and proves a
+ * client certificate chained through that CA completes mTLS and authenticates.
+ *
+ * Reproduction:
+ *   npm run test:integration -- "integrationTests/security/tls-ciphers-seclevel.test.ts"
+ */
+
+import { suite, test, before, after } from 'node:test';
+import { ok, rejects } from 'node:assert';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import * as https from 'node:https';
+import forge from 'node-forge';
+
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+
+const pki = forge.pki;
+const HTTPS_PORT = 9927;
+const FIXTURE_PATH = join(import.meta.dirname, 'fixture');
+const RELAXED_CIPHERS = 'DEFAULT@SECLEVEL=0';
+// Bun terminates TLS with BoringSSL, which has no @SECLEVEL concept — the listener cipher
+// resolution under test is the Node path only.
+const skipSuite = process.env.HARPER_RUNTIME === 'bun';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+interface PemChain {
+	caPem: string;
+	clientCertPem: string;
+	clientKeyPem: string;
+	serverCertPem: string;
+	serverKeyPem: string;
+	unchainedCertPem: string;
+	unchainedKeyPem: string;
+}
+
+function makeCert(
+	publicKey: forge.pki.rsa.PublicKey,
+	subjectCn: string,
+	issuerCn: string,
+	serialNumber: string,
+	extensions: any[]
+) {
+	const cert = pki.createCertificate();
+	cert.publicKey = publicKey;
+	cert.serialNumber = serialNumber;
+	cert.validity.notBefore = new Date(Date.now() - DAY_MS);
+	cert.validity.notAfter = new Date(Date.now() + 365 * DAY_MS);
+	const subject = [{ name: 'commonName', value: subjectCn }];
+	const issuer = [{ name: 'commonName', value: issuerCn }];
+	cert.setSubject(subject);
+	cert.setIssuer(issuer);
+	cert.setExtensions(extensions);
+	return cert;
+}
+
+/**
+ * Build the incident-shaped PKI: an RSA CA and client certificate both signed with SHA-1
+ * (the digest modern OpenSSL rejects above security level 0), plus an ordinary SHA-256
+ * self-signed server certificate for the listener's own identity.
+ */
+function makeSha1ChainPems(): PemChain {
+	const caKeys = pki.rsa.generateKeyPair(2048);
+	const caCert = makeCert(caKeys.publicKey, 'SHA1 Test Client CA', 'SHA1 Test Client CA', '01', [
+		{ name: 'basicConstraints', cA: true, critical: true },
+		{ name: 'keyUsage', keyCertSign: true, cRLSign: true, digitalSignature: true },
+	]);
+	caCert.sign(caKeys.privateKey, forge.md.sha1.create());
+
+	const clientKeys = pki.rsa.generateKeyPair(2048);
+	const clientCert = makeCert(clientKeys.publicKey, 'sha1-mtls-client', 'SHA1 Test Client CA', '02', [
+		{ name: 'basicConstraints', cA: false },
+		{ name: 'extKeyUsage', clientAuth: true },
+	]);
+	clientCert.sign(caKeys.privateKey, forge.md.sha1.create());
+
+	const serverKeys = pki.rsa.generateKeyPair(2048);
+	const serverCert = makeCert(serverKeys.publicKey, 'localhost', 'localhost', '03', [
+		{ name: 'basicConstraints', cA: false },
+		{ name: 'extKeyUsage', serverAuth: true },
+		{
+			name: 'subjectAltName',
+			altNames: [
+				{ type: 2, value: 'localhost' },
+				{ type: 7, ip: '127.0.0.1' },
+			],
+		},
+	]);
+	serverCert.sign(serverKeys.privateKey, forge.md.sha256.create());
+
+	// control: a self-signed client cert that does NOT chain to the CA — must be rejected
+	const unchainedKeys = pki.rsa.generateKeyPair(2048);
+	const unchainedCert = makeCert(unchainedKeys.publicKey, 'unchained-client', 'unchained-client', '04', [
+		{ name: 'basicConstraints', cA: false },
+		{ name: 'extKeyUsage', clientAuth: true },
+	]);
+	unchainedCert.sign(unchainedKeys.privateKey, forge.md.sha256.create());
+
+	return {
+		caPem: pki.certificateToPem(caCert),
+		clientCertPem: pki.certificateToPem(clientCert),
+		clientKeyPem: pki.privateKeyToPem(clientKeys.privateKey),
+		serverCertPem: pki.certificateToPem(serverCert),
+		serverKeyPem: pki.privateKeyToPem(serverKeys.privateKey),
+		unchainedCertPem: pki.certificateToPem(unchainedCert),
+		unchainedKeyPem: pki.privateKeyToPem(unchainedKeys.privateKey),
+	};
+}
+
+/** One HTTPS request; resolves with the status code (rejects on socket/handshake error). */
+function requestStatus(hostname: string, clientCert?: { cert: string; key: string }): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const request = https.request(
+			`https://${hostname}:${HTTPS_PORT}/`,
+			{
+				...clientCert,
+				// the client must also relax its own security level to present a SHA-1-signed cert
+				ciphers: clientCert ? RELAXED_CIPHERS : undefined,
+				rejectUnauthorized: false, // self-signed server cert; we only care about the client-cert side
+				agent: false, // no keep-alive agent — each call is an independent handshake
+			},
+			(response) => {
+				response.resume();
+				response.on('end', () => resolve(response.statusCode ?? 0));
+			}
+		);
+		request.setTimeout(10000, () => {
+			request.destroy();
+			reject(new Error('request timed out'));
+		});
+		request.on('error', reject);
+		request.end();
+	});
+}
+
+suite(
+	'TLS listener honors SECLEVEL from a non-first tls entry (mTLS with SHA-1 client CA)',
+	{ skip: skipSuite },
+	(ctx: ContextWithHarper) => {
+		let certsDir: string;
+		let chain: PemChain;
+
+		before(async () => {
+			certsDir = await mkdtemp(join(tmpdir(), 'harper-seclevel-test-'));
+			chain = makeSha1ChainPems();
+			const serverCertPath = join(certsDir, 'server-cert.pem');
+			const serverKeyPath = join(certsDir, 'server-key.pem');
+			const caPath = join(certsDir, 'sha1-client-ca.pem');
+			await writeFile(serverCertPath, chain.serverCertPem);
+			await writeFile(serverKeyPath, chain.serverKeyPem);
+			await writeFile(caPath, chain.caPem);
+
+			await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+				config: {
+					http: {
+						// required: the handshake itself gates — a client chain that fails verification is
+						// refused at the TLS layer, which is what makes the assertions below protocol-level
+						mtls: { user: 'admin', required: true },
+					},
+					tls: [
+						{ certificate: serverCertPath, privateKey: serverKeyPath },
+						// the previously-ignored position: not tls.ciphers, not tls[0].ciphers
+						{ certificateAuthority: caPath, ciphers: RELAXED_CIPHERS },
+					],
+				},
+			});
+		});
+
+		after(async () => {
+			await teardownHarper(ctx);
+			await rm(certsDir, { recursive: true, force: true, maxRetries: 3 });
+		});
+
+		test('accepts a client cert chained through the SHA-1-signed CA', async () => {
+			// with mtls.required, reaching HTTP at all means the chain verified — the TLS layer would
+			// otherwise have refused the handshake (exactly what happened while the SECLEVEL was ignored)
+			const status = await requestStatus(ctx.harper.hostname, {
+				cert: chain.clientCertPem,
+				key: chain.clientKeyPem,
+			});
+			ok(status !== 401, `expected the SHA-1-chained client cert to authenticate (got ${status})`);
+		});
+
+		test('still refuses a client cert that does not chain to the CA (verification actually gates)', async () => {
+			await rejects(
+				requestStatus(ctx.harper.hostname, {
+					cert: chain.unchainedCertPem,
+					key: chain.unchainedKeyPem,
+				}),
+				// the exact error varies (TLS alert vs connection reset, and by platform) — any refusal counts
+				(error: Error) => Boolean(error),
+				'expected the TLS handshake to be refused for an unchained client cert'
+			);
+		});
+	}
+);

--- a/security/keys.ts
+++ b/security/keys.ts
@@ -821,11 +821,26 @@ if (typeof globalThis.Bun === 'undefined') {
 let caCerts = new Map();
 
 const SECLEVEL_PATTERN = /@SECLEVEL=(\d+)/i;
-// OpenSSL's default security level when a cipher string doesn't set one explicitly
-const DEFAULT_OPENSSL_SECURITY_LEVEL = 1;
-function securityLevelOf(ciphers) {
+/** Split a cipher string into its suite list and its explicit `@SECLEVEL` (undefined when unset). */
+function parseCipherString(ciphers) {
 	const match = SECLEVEL_PATTERN.exec(ciphers);
-	return match ? Number(match[1]) : DEFAULT_OPENSSL_SECURITY_LEVEL;
+	return {
+		suite: ciphers.replace(SECLEVEL_PATTERN, '').trim() || undefined,
+		level: match ? Number(match[1]) : undefined,
+	};
+}
+
+/**
+ * Whether a certificate (record or `tls[]` entry) can affect the given listener, mirroring
+ * createTLSSelector's tolerant selection: no `uses` is a generic certificate, `'https'` is the
+ * legacy generic use, and an authority matters exactly when the listener verifies client chains.
+ */
+function ciphersCandidateRelevant(usesRaw, isAuthority, servesCertificate, type, verifiesClientCerts) {
+	if (isAuthority && verifiesClientCerts) return true;
+	if (!servesCertificate) return false;
+	// normalize: stored as scalar in legacy/manual entries, expected array
+	const uses = Array.isArray(usesRaw) ? usesRaw : usesRaw ? [usesRaw] : [];
+	return uses.length === 0 || uses.includes(type) || uses.includes('https');
 }
 
 /**
@@ -837,62 +852,84 @@ function securityLevelOf(ciphers) {
  * so per-certificate `ciphers` — whether on a `tls` array entry or a certificate record — cannot
  * take effect on their own; a listener has exactly one effective cipher string. Historically only
  * `tls.ciphers ?? tls[0].ciphers` was applied and every other configured value was silently
- * ignored, including a CA record needing a relaxed
- * security level to verify legacy client chains (e.g. SHA-1-signed CAs requiring
- * `DEFAULT@SECLEVEL=0`, which fail with `authorizationError: UNSPECIFIED` at the default level).
+ * ignored, including a CA record needing a relaxed security level to verify legacy client chains
+ * (e.g. SHA-1-signed CAs requiring `DEFAULT@SECLEVEL=0`, which fail with
+ * `authorizationError: UNSPECIFIED` at the default level).
  *
- * Resolution:
- * 1. Top-level `tls.ciphers` wins when set (the explicit global knob).
- * 2. Otherwise every `tls[]` entry and relevant certificate record is a candidate: records whose
- *    `uses` includes the listener type, plus authority records when the listener verifies client
- *    certificates (mTLS) — a CA that needs a relaxed level must relax the listener itself.
- * 3. Conflicting candidates can't be honored together: the lowest explicit `@SECLEVEL` wins (a
- *    chain that needs the relaxed level fails outright without it, while the others merely also
- *    accept it), and everything ignored is logged as a warning.
+ * Resolution composes rather than picks a winner, because `@SECLEVEL` and the suite list are
+ * separable OpenSSL commands:
+ * 1. Candidates come from the listener's config layers in priority order (`configLayers`, e.g.
+ *    `operationsApi.tls` before root `tls` — an object's `ciphers` directly, an array's entries
+ *    filtered by {@link ciphersCandidateRelevant}) and then from relevant certificate records.
+ * 2. The suite list comes from the highest-priority suite-bearing candidate — a CA needing a
+ *    relaxed level must not replace or broaden the listener's configured suites.
+ * 3. The security level is the minimum explicit `@SECLEVEL` across candidates (a chain that needs
+ *    the relaxed level fails outright without it; the others merely also accept it). Candidates
+ *    without an explicit `@SECLEVEL` keep the runtime default — no level is assumed for them,
+ *    since the OpenSSL default varies across Node builds.
+ * Anything composed across sources or dropped (extra suite lists) is logged as a warning.
  */
-export function resolveEffectiveTlsCiphers(tlsConfig, certRecords, type, verifiesClientCerts): string | undefined {
+export function resolveEffectiveTlsCiphers(configLayers, certRecords, type, verifiesClientCerts): string | undefined {
 	const candidates = [];
-	const topLevel = Array.isArray(tlsConfig) ? undefined : tlsConfig?.ciphers;
-	if (Array.isArray(tlsConfig)) {
-		for (let index = 0; index < tlsConfig.length; index++) {
-			if (tlsConfig[index]?.ciphers) candidates.push({ source: `tls[${index}]`, ciphers: tlsConfig[index].ciphers });
+	for (const { source, config } of configLayers ?? []) {
+		if (!config) continue;
+		if (Array.isArray(config)) {
+			for (let index = 0; index < config.length; index++) {
+				const entry = config[index];
+				if (!entry?.ciphers) continue;
+				const isAuthority = Boolean(entry.certificateAuthority);
+				const servesCertificate = Boolean(entry.certificate) || !isAuthority;
+				if (ciphersCandidateRelevant(entry.uses, isAuthority, servesCertificate, type, verifiesClientCerts)) {
+					candidates.push({ source: `${source}[${index}]`, ciphers: entry.ciphers });
+				}
+			}
+		} else if (config.ciphers) {
+			// an object layer's ciphers is the listener config's own knob — always relevant
+			candidates.push({ source: `${source}.ciphers`, ciphers: config.ciphers });
 		}
 	}
 	for (const cert of certRecords ?? []) {
 		if (!cert?.ciphers) continue;
-		// normalize: stored as scalar in legacy/manual entries, expected array
-		const uses = Array.isArray(cert.uses) ? cert.uses : cert.uses ? [cert.uses] : [];
-		if (uses.includes(type) || (cert.is_authority && verifiesClientCerts)) {
+		// authority records are never served as listener certs — they matter only for verification
+		if (
+			ciphersCandidateRelevant(cert.uses, Boolean(cert.is_authority), !cert.is_authority, type, verifiesClientCerts)
+		) {
 			candidates.push({ source: `certificate '${cert.name}'`, ciphers: cert.ciphers });
 		}
 	}
-	if (topLevel) {
-		const ignored = candidates.filter((candidate) => candidate.ciphers !== topLevel);
-		if (ignored.length) {
-			logger.warn?.(
-				`tls.ciphers ('${topLevel}') is set and overrides the cipher configuration from ${ignored
-					.map((candidate) => `${candidate.source} ('${candidate.ciphers}')`)
-					.join(', ')} — a TLS listener has a single effective cipher string`
-			);
-		}
-		return topLevel;
-	}
 	if (candidates.length === 0) return undefined;
-	let chosen = candidates[0];
-	for (const candidate of candidates) {
-		if (securityLevelOf(candidate.ciphers) < securityLevelOf(chosen.ciphers)) chosen = candidate;
+
+	const parsed = candidates.map((candidate) => ({ ...candidate, ...parseCipherString(candidate.ciphers) }));
+	const suiteBearing = parsed.filter((candidate) => candidate.suite);
+	const suiteSource = suiteBearing[0];
+	let levelSource;
+	for (const candidate of parsed) {
+		if (candidate.level !== undefined && (levelSource === undefined || candidate.level < levelSource.level)) {
+			levelSource = candidate;
+		}
 	}
-	const ignored = candidates.filter((candidate) => candidate.ciphers !== chosen.ciphers);
-	if (ignored.length) {
-		logger.warn?.(
-			`Multiple TLS cipher configurations for the '${type}' listener; using '${chosen.ciphers}' from ${
-				chosen.source
-			} (lowest security level) and ignoring ${ignored
-				.map((candidate) => `${candidate.source} ('${candidate.ciphers}')`)
-				.join(', ')} — a TLS listener has a single effective cipher string`
+	// no suite anywhere means a bare @SECLEVEL override — anchor it to DEFAULT
+	const suite = suiteSource?.suite ?? 'DEFAULT';
+	const effective = levelSource === undefined ? suite : `${suite}@SECLEVEL=${levelSource.level}`;
+
+	const notes = [];
+	const droppedSuites = suiteBearing.filter((candidate) => candidate.suite !== suiteSource.suite);
+	if (droppedSuites.length) {
+		notes.push(
+			`suites from ${suiteSource.source} ('${suiteSource.suite}'); ignoring suite lists from ${droppedSuites
+				.map((candidate) => `${candidate.source} ('${candidate.suite}')`)
+				.join(', ')}`
 		);
 	}
-	return chosen.ciphers;
+	if (levelSource !== undefined && levelSource.source !== suiteSource?.source) {
+		notes.push(`security level ${levelSource.level} required by ${levelSource.source}`);
+	}
+	if (notes.length) {
+		logger.warn?.(
+			`Composed TLS cipher configuration for the '${type}' listener ('${effective}'): ${notes.join('; ')} — a listener has a single effective cipher string`
+		);
+	}
+	return effective;
 }
 
 /**
@@ -906,7 +943,14 @@ export function getEffectiveTlsCiphers(type, mtlsOptions?): string | undefined {
 	} catch (error) {
 		logger.trace?.('Certificate table not available while resolving TLS ciphers', error);
 	}
-	return resolveEffectiveTlsCiphers(envManager.get('tls'), certRecords, type, Boolean(mtlsOptions));
+	const configLayers = [];
+	// the operations API listener has its own tls section (merged separately by config
+	// composition, may inherit the root certificate while overriding ciphers) — it outranks root
+	if (type === 'operations-api') {
+		configLayers.push({ source: 'operationsApi.tls', config: envManager.get(CONFIG_PARAMS.OPERATIONSAPI_TLS) });
+	}
+	configLayers.push({ source: 'tls', config: envManager.get('tls') });
+	return resolveEffectiveTlsCiphers(configLayers, certRecords, type, Boolean(mtlsOptions));
 }
 
 /**

--- a/security/keys.ts
+++ b/security/keys.ts
@@ -820,6 +820,95 @@ if (typeof globalThis.Bun === 'undefined') {
 
 let caCerts = new Map();
 
+const SECLEVEL_PATTERN = /@SECLEVEL=(\d+)/i;
+// OpenSSL's default security level when a cipher string doesn't set one explicitly
+const DEFAULT_OPENSSL_SECURITY_LEVEL = 1;
+function securityLevelOf(ciphers) {
+	const match = SECLEVEL_PATTERN.exec(ciphers);
+	return match ? Number(match[1]) : DEFAULT_OPENSSL_SECURITY_LEVEL;
+}
+
+/**
+ * Resolve the single cipher string that actually governs a TLS listener.
+ *
+ * OpenSSL takes the cipher list — and any `@SECLEVEL=n` embedded in it, which controls
+ * client-certificate chain verification — from the context the server was created with. A context
+ * swapped in later by the SNI callback does not carry its own cipher list onto the connection,
+ * so per-certificate `ciphers` — whether on a `tls` array entry or a certificate record — cannot
+ * take effect on their own; a listener has exactly one effective cipher string. Historically only
+ * `tls.ciphers ?? tls[0].ciphers` was applied and every other configured value was silently
+ * ignored, including a CA record needing a relaxed
+ * security level to verify legacy client chains (e.g. SHA-1-signed CAs requiring
+ * `DEFAULT@SECLEVEL=0`, which fail with `authorizationError: UNSPECIFIED` at the default level).
+ *
+ * Resolution:
+ * 1. Top-level `tls.ciphers` wins when set (the explicit global knob).
+ * 2. Otherwise every `tls[]` entry and relevant certificate record is a candidate: records whose
+ *    `uses` includes the listener type, plus authority records when the listener verifies client
+ *    certificates (mTLS) — a CA that needs a relaxed level must relax the listener itself.
+ * 3. Conflicting candidates can't be honored together: the lowest explicit `@SECLEVEL` wins (a
+ *    chain that needs the relaxed level fails outright without it, while the others merely also
+ *    accept it), and everything ignored is logged as a warning.
+ */
+export function resolveEffectiveTlsCiphers(tlsConfig, certRecords, type, verifiesClientCerts): string | undefined {
+	const candidates = [];
+	const topLevel = Array.isArray(tlsConfig) ? undefined : tlsConfig?.ciphers;
+	if (Array.isArray(tlsConfig)) {
+		for (let index = 0; index < tlsConfig.length; index++) {
+			if (tlsConfig[index]?.ciphers) candidates.push({ source: `tls[${index}]`, ciphers: tlsConfig[index].ciphers });
+		}
+	}
+	for (const cert of certRecords ?? []) {
+		if (!cert?.ciphers) continue;
+		// normalize: stored as scalar in legacy/manual entries, expected array
+		const uses = Array.isArray(cert.uses) ? cert.uses : cert.uses ? [cert.uses] : [];
+		if (uses.includes(type) || (cert.is_authority && verifiesClientCerts)) {
+			candidates.push({ source: `certificate '${cert.name}'`, ciphers: cert.ciphers });
+		}
+	}
+	if (topLevel) {
+		const ignored = candidates.filter((candidate) => candidate.ciphers !== topLevel);
+		if (ignored.length) {
+			logger.warn?.(
+				`tls.ciphers ('${topLevel}') is set and overrides the cipher configuration from ${ignored
+					.map((candidate) => `${candidate.source} ('${candidate.ciphers}')`)
+					.join(', ')} — a TLS listener has a single effective cipher string`
+			);
+		}
+		return topLevel;
+	}
+	if (candidates.length === 0) return undefined;
+	let chosen = candidates[0];
+	for (const candidate of candidates) {
+		if (securityLevelOf(candidate.ciphers) < securityLevelOf(chosen.ciphers)) chosen = candidate;
+	}
+	const ignored = candidates.filter((candidate) => candidate.ciphers !== chosen.ciphers);
+	if (ignored.length) {
+		logger.warn?.(
+			`Multiple TLS cipher configurations for the '${type}' listener; using '${chosen.ciphers}' from ${
+				chosen.source
+			} (lowest security level) and ignoring ${ignored
+				.map((candidate) => `${candidate.source} ('${candidate.ciphers}')`)
+				.join(', ')} — a TLS listener has a single effective cipher string`
+		);
+	}
+	return chosen.ciphers;
+}
+
+/**
+ * Resolve the effective cipher string for a listener from the live config and certificate table.
+ * Safe to call before the certificate table exists (install, early boot) — config-only then.
+ */
+export function getEffectiveTlsCiphers(type, mtlsOptions?): string | undefined {
+	let certRecords;
+	try {
+		certRecords = databases?.system?.hdb_certificate?.search([]);
+	} catch (error) {
+		logger.trace?.('Certificate table not available while resolving TLS ciphers', error);
+	}
+	return resolveEffectiveTlsCiphers(envManager.get('tls'), certRecords, type, Boolean(mtlsOptions));
+}
+
 /**
  * Create a TLS selector that will choose the best TLS configuration/context for a given hostname
  * @param type
@@ -950,6 +1039,25 @@ export function createTLSSelector(type, mtlsOptions?, liveReload = true): any {
 							}
 						} catch (error) {
 							logger.error?.('Error applying TLS for', cert.name, error);
+						}
+					}
+					// The listener's cipher string (and its @SECLEVEL, which governs client-cert chain
+					// verification) is fixed at server creation and cannot be swapped by rebuilding SNI
+					// contexts. If a rebuild finds the effective value has changed (e.g. a certificate
+					// record with `ciphers` was added), the listener won't honor it until restart — warn
+					// instead of silently serving with the stale value.
+					if (server && server.appliedCiphers !== undefined) {
+						// use the same verifies-client-certs flag the listener was created with (http servers
+						// derive it from more than the selector's mtlsOptions) so this compares like with like
+						const effectiveCiphers =
+							getEffectiveTlsCiphers(type, server.verifiesClientCerts ?? Boolean(mtlsOptions)) ?? null;
+						// latch per distinct value: rebuilds recur (cert-table changes, key reloads) and the
+						// pending change shouldn't re-warn on every cycle until the restart happens
+						if (effectiveCiphers !== server.appliedCiphers && server.lastWarnedCiphers !== effectiveCiphers) {
+							server.lastWarnedCiphers = effectiveCiphers;
+							logger.warn?.(
+								`TLS cipher configuration for the '${type}' listener is now '${effectiveCiphers}' but the listener was started with '${server.appliedCiphers}' — a restart is required to apply it`
+							);
 						}
 					}
 					server?.secureContextsListeners.forEach((listener) => listener());

--- a/server/http.ts
+++ b/server/http.ts
@@ -12,7 +12,7 @@ import * as env from '../utility/environment/environmentManager.ts';
 import * as terms from '../utility/hdbTerms.ts';
 import { getConfigPath } from '../config/configUtils.ts';
 import { getTicketKeys, getWorkerIndex } from './threads/manageThreads.js';
-import { createTLSSelector } from '../security/keys.ts';
+import { createTLSSelector, getEffectiveTlsCiphers } from '../security/keys.ts';
 import { createSecureServer, createServer as createH2CServer } from 'node:http2';
 import { createServer as createSecureServerHttp1 } from 'node:https';
 import { createServer, IncomingMessage } from 'node:http';
@@ -420,7 +420,6 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 		let http2;
 
 		if (secure) {
-			const tlsConfig = env.get('tls');
 			// check if we want to enable HTTP/2; operations server doesn't use HTTP/2 because it doesn't allow the
 			// ALPNCallback to work with our custom protocol for replication
 			http2 = env.get(serverPrefix + '_http2');
@@ -435,7 +434,9 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 				requestCert: Boolean(mtls || isMtls),
 				ticketKeys: getTicketKeys(),
 				SNICallback: createTLSSelector(usageType ?? 'server', mtls),
-				ciphers: tlsConfig.ciphers ?? tlsConfig[0]?.ciphers,
+				// the listener-level cipher string is the only one OpenSSL honors (SNI contexts can't
+				// carry their own), so resolve it from every configured source
+				ciphers: getEffectiveTlsCiphers(usageType ?? 'server', mtls || isMtls),
 			});
 		}
 		const requestHandler = async (nodeRequest: IncomingMessage, nodeResponse: any) => {
@@ -619,6 +620,8 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 		if (secure) {
 			if (!server.ports) server.ports = [];
 			server.ports.push(port);
+			server.appliedCiphers = options.ciphers ?? null;
+			server.verifiesClientCerts = Boolean(mtls || isMtls);
 			options.SNICallback.initialize(server);
 			if (mtls) server.mtlsConfig = mtls;
 			server.on('secureConnection', (socket) => {
@@ -1082,6 +1085,9 @@ function getBunHTTPServer(port: number, secure: boolean, options: ServerOptions)
 		};
 		if (secure) {
 			// TLS config for Bun
+			// The resolved listener cipher string (getEffectiveTlsCiphers) is deliberately not applied
+			// here: Bun terminates TLS with BoringSSL, which has no OpenSSL @SECLEVEL concept, and the
+			// pseudo-server carries no appliedCiphers stamp so updateTLS's restart warning stays quiet.
 			const mtls = env.get(serverPrefix + '_mtls');
 			const tlsSelector = createTLSSelector(usageType ?? 'server', mtls);
 			// Create a pseudo-server object so the TLS selector can store secureContexts on it

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -27,7 +27,7 @@ const {
 } = require('../../components/shutdownDrain.ts');
 const { realExit } = require('./workerProcessGuard.ts');
 const { isBun } = require('../serverHelpers/Request.ts');
-const { createTLSSelector } = require('../../security/keys.ts');
+const { createTLSSelector, getEffectiveTlsCiphers } = require('../../security/keys.ts');
 const { startupLog } = require('../../bin/run.ts');
 const { SERVERS, setPortServerMap, portServer } = require('../serverRegistry.ts');
 const httpComponent = require('../http.ts');
@@ -570,7 +570,11 @@ function onSocket(listener, options) {
 	if (options.securePort) {
 		setPortServerMap(options.securePort, { protocol_name: 'TLS', name: getComponentName() });
 		const SNICallback = createTLSSelector('server', options.mtls);
-		const tlsConfig = env.get('tls');
+		// OpenSSL takes the cipher list (and its @SECLEVEL) from the context the server was created with;
+		// a context swapped in by the SNI callback doesn't carry its own cipher list onto the connection.
+		// The listener-level string is therefore the only one honored — resolve it from every configured
+		// source (see resolveEffectiveTlsCiphers in keys.ts).
+		const effectiveCiphers = getEffectiveTlsCiphers('server', options.mtls);
 		socketServer = createSecureSocketServer(
 			{
 				rejectUnauthorized: Boolean(options.mtls?.required),
@@ -578,13 +582,13 @@ function onSocket(listener, options) {
 				noDelay: true, // don't delay for Nagle's algorithm, it is a relic of the past that slows things down: https://brooker.co.za/blog/2024/05/09/nagle.html
 				keepAlive: true,
 				keepAliveInitialDelay: 600, // 10 minute keep-alive, want to be proactive about closing unused connections
-				// For some reason ciphers doesn't work from the secure context, despite node docs claiming it would. Lost
-				// count of how many node TLS bugs that makes
-				ciphers: tlsConfig.ciphers ?? tlsConfig[0]?.ciphers,
+				ciphers: effectiveCiphers,
 				SNICallback,
 			},
 			listener
 		);
+		socketServer.appliedCiphers = effectiveCiphers ?? null;
+		socketServer.verifiesClientCerts = Boolean(options.mtls);
 		SNICallback.initialize(socketServer);
 		// Only opt out of reusePort on macOS, which doesn't reliably support SO_REUSEPORT on all
 		// socket types (ENOTSUP). Everywhere else, sharing the port lets every worker accept

--- a/unitTests/security/keys.test.js
+++ b/unitTests/security/keys.test.js
@@ -640,4 +640,69 @@ describe('Test keys module', () => {
 			expect(watchTimers.get(watchPath), 'no timer should be registered when polling is disabled').to.be.undefined;
 		});
 	});
+
+	describe('resolveEffectiveTlsCiphers', () => {
+		const resolve = keys.__get__('resolveEffectiveTlsCiphers');
+		const RELAXED = 'DEFAULT@SECLEVEL=0';
+
+		it('returns undefined when nothing configures ciphers', () => {
+			expect(resolve({ certificate: 'x' }, [], 'server', false)).to.be.undefined;
+			expect(resolve(undefined, undefined, 'server', true)).to.be.undefined;
+		});
+
+		it('top-level tls.ciphers wins, including over conflicting certificate records', () => {
+			const records = [{ name: 'ca', is_authority: true, ciphers: RELAXED }];
+			expect(resolve({ ciphers: 'DEFAULT' }, records, 'server', true)).to.equal('DEFAULT');
+		});
+
+		it('honors a tls array entry beyond [0] (previously silently ignored)', () => {
+			expect(resolve([{ certificate: 'a' }, { certificate: 'b', ciphers: RELAXED }], [], 'server', false)).to.equal(
+				RELAXED
+			);
+		});
+
+		it('applies a matching-use certificate record when config sets no ciphers', () => {
+			const records = [{ name: 'cert', uses: ['server'], ciphers: RELAXED }];
+			expect(resolve({}, records, 'server', false)).to.equal(RELAXED);
+		});
+
+		it('normalizes a legacy scalar uses value', () => {
+			const records = [{ name: 'cert', uses: 'server', ciphers: RELAXED }];
+			expect(resolve({}, records, 'server', false)).to.equal(RELAXED);
+		});
+
+		it('applies an authority record when the listener verifies client certificates', () => {
+			// the incident shape: a client-CA record carrying SECLEVEL=0 for SHA-1-signed chains
+			const records = [{ name: 'legacy-client-ca', is_authority: true, ciphers: RELAXED }];
+			expect(resolve({}, records, 'server', true)).to.equal(RELAXED);
+		});
+
+		it('ignores an authority record when the listener does not verify client certificates', () => {
+			const records = [{ name: 'ca', is_authority: true, ciphers: RELAXED }];
+			expect(resolve({}, records, 'server', false)).to.be.undefined;
+		});
+
+		it('ignores records whose uses do not match the listener type', () => {
+			const records = [{ name: 'ops-cert', uses: ['operations-api'], ciphers: RELAXED }];
+			expect(resolve({}, records, 'server', false)).to.be.undefined;
+		});
+
+		it('picks the lowest explicit @SECLEVEL among conflicting candidates', () => {
+			const records = [{ name: 'ca', is_authority: true, ciphers: RELAXED }];
+			expect(resolve([{ certificate: 'a', ciphers: 'DEFAULT' }], records, 'server', true)).to.equal(RELAXED);
+		});
+
+		it('treats candidates without @SECLEVEL as the OpenSSL default level and keeps the first on ties', () => {
+			const records = [
+				{ name: 'a', uses: ['server'], ciphers: 'HIGH' },
+				{ name: 'b', uses: ['server'], ciphers: 'DEFAULT' },
+			];
+			expect(resolve({}, records, 'server', false)).to.equal('HIGH');
+		});
+
+		it('skips records without ciphers', () => {
+			const records = [{ name: 'plain', uses: ['server'] }, null];
+			expect(resolve({}, records, 'server', false)).to.be.undefined;
+		});
+	});
 });

--- a/unitTests/security/keys.test.js
+++ b/unitTests/security/keys.test.js
@@ -644,65 +644,117 @@ describe('Test keys module', () => {
 	describe('resolveEffectiveTlsCiphers', () => {
 		const resolve = keys.__get__('resolveEffectiveTlsCiphers');
 		const RELAXED = 'DEFAULT@SECLEVEL=0';
+		const layers = (config) => [{ source: 'tls', config }];
 
 		it('returns undefined when nothing configures ciphers', () => {
-			expect(resolve({ certificate: 'x' }, [], 'server', false)).to.be.undefined;
+			expect(resolve(layers({ certificate: 'x' }), [], 'server', false)).to.be.undefined;
 			expect(resolve(undefined, undefined, 'server', true)).to.be.undefined;
 		});
 
-		it('top-level tls.ciphers wins, including over conflicting certificate records', () => {
+		it('applies a lone tls.ciphers as-is', () => {
+			expect(resolve(layers({ ciphers: 'HIGH' }), [], 'server', false)).to.equal('HIGH');
+		});
+
+		it('composes a CA record SECLEVEL onto explicit tls.ciphers suites instead of replacing them', () => {
 			const records = [{ name: 'ca', is_authority: true, ciphers: RELAXED }];
-			expect(resolve({ ciphers: 'DEFAULT' }, records, 'server', true)).to.equal('DEFAULT');
+			expect(resolve(layers({ ciphers: 'HIGH' }), records, 'server', true)).to.equal('HIGH@SECLEVEL=0');
 		});
 
 		it('honors a tls array entry beyond [0] (previously silently ignored)', () => {
-			expect(resolve([{ certificate: 'a' }, { certificate: 'b', ciphers: RELAXED }], [], 'server', false)).to.equal(
-				RELAXED
-			);
+			expect(
+				resolve(layers([{ certificate: 'a' }, { certificate: 'b', ciphers: RELAXED }]), [], 'server', false)
+			).to.equal(RELAXED);
+		});
+
+		it('excludes a CA array entry when the listener does not verify client certificates', () => {
+			expect(
+				resolve(
+					layers([{ certificate: 'a' }, { certificateAuthority: 'ca.pem', ciphers: RELAXED }]),
+					[],
+					'server',
+					false
+				)
+			).to.be.undefined;
+		});
+
+		it('includes a CA array entry when the listener verifies client certificates', () => {
+			expect(
+				resolve(
+					layers([{ certificate: 'a' }, { certificateAuthority: 'ca.pem', ciphers: RELAXED }]),
+					[],
+					'server',
+					true
+				)
+			).to.equal(RELAXED);
 		});
 
 		it('applies a matching-use certificate record when config sets no ciphers', () => {
 			const records = [{ name: 'cert', uses: ['server'], ciphers: RELAXED }];
-			expect(resolve({}, records, 'server', false)).to.equal(RELAXED);
+			expect(resolve(layers({}), records, 'server', false)).to.equal(RELAXED);
+		});
+
+		it('applies generic (no uses) and legacy https records, mirroring selector relevance', () => {
+			expect(resolve(layers({}), [{ name: 'generic', ciphers: RELAXED }], 'server', false)).to.equal(RELAXED);
+			expect(resolve(layers({}), [{ name: 'legacy', uses: ['https'], ciphers: RELAXED }], 'server', false)).to.equal(
+				RELAXED
+			);
 		});
 
 		it('normalizes a legacy scalar uses value', () => {
 			const records = [{ name: 'cert', uses: 'server', ciphers: RELAXED }];
-			expect(resolve({}, records, 'server', false)).to.equal(RELAXED);
+			expect(resolve(layers({}), records, 'server', false)).to.equal(RELAXED);
 		});
 
 		it('applies an authority record when the listener verifies client certificates', () => {
 			// the incident shape: a client-CA record carrying SECLEVEL=0 for SHA-1-signed chains
 			const records = [{ name: 'legacy-client-ca', is_authority: true, ciphers: RELAXED }];
-			expect(resolve({}, records, 'server', true)).to.equal(RELAXED);
+			expect(resolve(layers({}), records, 'server', true)).to.equal(RELAXED);
 		});
 
 		it('ignores an authority record when the listener does not verify client certificates', () => {
 			const records = [{ name: 'ca', is_authority: true, ciphers: RELAXED }];
-			expect(resolve({}, records, 'server', false)).to.be.undefined;
+			expect(resolve(layers({}), records, 'server', false)).to.be.undefined;
 		});
 
 		it('ignores records whose uses do not match the listener type', () => {
 			const records = [{ name: 'ops-cert', uses: ['operations-api'], ciphers: RELAXED }];
-			expect(resolve({}, records, 'server', false)).to.be.undefined;
+			expect(resolve(layers({}), records, 'server', false)).to.be.undefined;
 		});
 
-		it('picks the lowest explicit @SECLEVEL among conflicting candidates', () => {
+		it('keeps the configured suite and applies the minimum explicit @SECLEVEL from a CA', () => {
 			const records = [{ name: 'ca', is_authority: true, ciphers: RELAXED }];
-			expect(resolve([{ certificate: 'a', ciphers: 'DEFAULT' }], records, 'server', true)).to.equal(RELAXED);
+			expect(resolve(layers([{ certificate: 'a', ciphers: 'DEFAULT' }]), records, 'server', true)).to.equal(
+				'DEFAULT@SECLEVEL=0'
+			);
+			expect(resolve(layers([{ certificate: 'a', ciphers: 'HIGH:!aNULL' }]), records, 'server', true)).to.equal(
+				'HIGH:!aNULL@SECLEVEL=0'
+			);
 		});
 
-		it('treats candidates without @SECLEVEL as the OpenSSL default level and keeps the first on ties', () => {
-			const records = [
-				{ name: 'a', uses: ['server'], ciphers: 'HIGH' },
-				{ name: 'b', uses: ['server'], ciphers: 'DEFAULT' },
+		it('does not assume a level for plain suites — an explicit @SECLEVEL always applies', () => {
+			// the runtime default varies across Node/OpenSSL builds (2 on current Node), so 'HIGH'
+			// carries no assumed level and the explicit SECLEVEL=1 must not lose a tie
+			const records = [{ name: 'b', uses: ['server'], ciphers: 'DEFAULT@SECLEVEL=1' }];
+			expect(resolve(layers([{ certificate: 'a', ciphers: 'HIGH' }]), records, 'server', false)).to.equal(
+				'HIGH@SECLEVEL=1'
+			);
+		});
+
+		it('prefers the operationsApi.tls layer over root tls for the operations listener', () => {
+			const opsLayers = [
+				{ source: 'operationsApi.tls', config: { ciphers: 'HIGH' } },
+				{ source: 'tls', config: { ciphers: 'DEFAULT' } },
 			];
-			expect(resolve({}, records, 'server', false)).to.equal('HIGH');
+			expect(resolve(opsLayers, [], 'operations-api', false)).to.equal('HIGH');
+		});
+
+		it('anchors a bare @SECLEVEL override to DEFAULT', () => {
+			expect(resolve(layers({ ciphers: '@SECLEVEL=0' }), [], 'server', false)).to.equal('DEFAULT@SECLEVEL=0');
 		});
 
 		it('skips records without ciphers', () => {
 			const records = [{ name: 'plain', uses: ['server'] }, null];
-			expect(resolve({}, records, 'server', false)).to.be.undefined;
+			expect(resolve(layers({}), records, 'server', false)).to.be.undefined;
 		});
 	});
 });


### PR DESCRIPTION
## Summary

A TLS listener has exactly one effective cipher string: OpenSSL takes the cipher list — and any `@SECLEVEL=n` embedded in it, which governs client-certificate chain verification — from the context the server was created with, and an SNI-swapped context does not carry its own cipher list onto the connection. Harper applied only `tls.ciphers ?? tls[0].ciphers` and silently ignored every other configured `ciphers` value: entries beyond `tls[0]` and certificate records (authority records' `ciphers` were never read at all).

This resolves the listener cipher string from every configured source (`resolveEffectiveTlsCiphers` in `security/keys.ts`), wired into both Node listener-creation sites (`server/http.ts`, `server/threads/threadServer.js`):

1. Candidates come from the listener's config layers in priority order (`operationsApi.tls` before root `tls` for the operations listener; array entries relevance-filtered — CA entries only when the listener verifies client certs, served entries matched by `uses` with the selector's tolerant rule incl. legacy `'https'` and no-`uses` generics) and from relevant certificate records.
2. The **suite list** comes from the highest-priority suite-bearing candidate — a client CA that needs `DEFAULT@SECLEVEL=0` (SHA-1-signed chains, else `authorizationError: UNSPECIFIED`) must not replace or broaden the listener's configured suites.
3. The **security level** is the minimum explicit `@SECLEVEL` across candidates; strings without one keep the runtime default (no level is assumed — the OpenSSL default varies across Node builds). The two compose, e.g. `HIGH:!aNULL` + CA `DEFAULT@SECLEVEL=0` → `HIGH:!aNULL@SECLEVEL=0`, and any cross-source composition or dropped suite list is logged.
4. When a cert-table change alters the resolved value after boot, `updateTLS` warns (once per value) that a restart is required — the listener-level string can't be swapped by an SNI-context rebuild.

Closes #1840.

## Purpose

An mTLS deployment whose client certs chain through SHA-1-signed CAs configured `ciphers: DEFAULT@SECLEVEL=0` on the CA entry — the natural, least-privilege place. `list_certificates` showed the override present while the verify path rejected every client. The only working escape hatch (top-level `tls.ciphers`) relaxes all listeners and is easy to lose in platform config reconciliation. (Field incident on 4.7; 5.x has the same shape.)

## Where to look

- **Suite/level composition** (`resolveEffectiveTlsCiphers`) is the policy decision: preserve the configured suites, apply only the minimum explicit `@SECLEVEL` any relevant cert requires, warn on everything composed or dropped. This follows the external (Codex) review on the first cut, which correctly objected to whole-string replacement and to an assumed default security level.
- **Authority entries/records participate only when the listener verifies client certs**. A CA's `SECLEVEL` matters exactly when its chains are being verified; a non-mTLS listener is not relaxed.
- **`server.appliedCiphers` / `server.verifiesClientCerts`** stamps at both creation sites feed the divergence warning in `updateTLS`; the Bun path is untouched (BoringSSL has no `@SECLEVEL`).
- Certificate records are read at listener creation (cold path, boot-time) and on cert-table rebuilds (debounced); nothing added to per-connection paths.

## Tests

- Unit (`unitTests/security/keys.test.js`): 17 cases over the pure resolver — layer precedence (incl. `operationsApi.tls`), array entries beyond `[0]`, CA-entry mTLS gating, authority/uses/legacy-`https` relevance, scalar-`uses` normalization, suite+minimum-`SECLEVEL` composition, no-assumed-level, bare-`@SECLEVEL` anchoring.
- Integration (`integrationTests/security/tls-ciphers-seclevel.test.ts`): boots Harper with `tls` as an array whose *second* entry is a SHA-1-signed client CA carrying `ciphers: DEFAULT@SECLEVEL=0` (the previously-ignored position) and `http.mtls.required`; asserts a client cert chained through that CA completes the handshake and an unchained cert is refused. Verified the test fails on unfixed code (the SHA-1 chain is refused — the incident) and passes with the fix.

Local runs: `test:unit:main` green except two consistently-failing-locally, unrelated cases also failing without this change (`globalIsolation "should enforce process spawning restrictions"`, `uwsServer "rejects a body over maxBodyBytes with 413"` EPIPE) and an intermittent macOS-local `EMFILE` teardown flake in `keys.test.js` tied to system fd pressure, not this diff. CI should arbitrate.

## Cross-model review

Thorough pass (Gemini leg + Harper-domain adjudication): no blockers, no significant concerns. Gemini's one substantive finding (an `isMtls`/`mtls` asymmetry that could fire a spurious restart warning) was fixed via the `verifiesClientCerts` stamps before this PR was opened; the repeat-warning and Bun-comment suggestions are folded in. Caveat: the Codex leg failed to complete (CLI exited during context collection), so there is no Codex coverage on this run. A follow-up external (Codex) review raised five findings on the first-cut resolution policy (whole-string replacement, assumed default level, unfiltered tls[] entries, operationsApi.tls gap, relevance drift from the selector); all five are addressed by the composed model in 773b42bb0 — see the resolved threads.

## Docs

`reference/http/tls.md` in HarperFast/documentation documents `tls.ciphers` as a single string only; a companion docs PR describing the multi-source resolution (and the restart-required caveat) will follow once the resolution policy here survives review.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
