### PR TITLE
fix(resources): serve a sort on the primary key from primary-store order

### DIFF
--- a/integrationTests/apiTests/rest.test.mjs
+++ b/integrationTests/apiTests/rest.test.mjs
@@ -193,4 +193,55 @@ suite('REST query syntax', { skip: skipSuite }, (ctx) => {
 		const bigProperty = Array(1000000).fill('this is a test');
 		return request(client.restURL).post('/Related/').set(client.headers).send({ bigProperty }).expect(413);
 	});
+
+	/**
+	 * Sorting by the primary key with no other condition used to fail with
+	 * `404 "id is not indexed and not combined with any other conditions"`: the
+	 * sort-alignment check in Table.search only accepted attributes carrying a
+	 * secondary index, and the primary key has none. The primary store is itself
+	 * keyed in primary-key order, so the scan is already aligned — a sort on it
+	 * must be served, not rejected.
+	 *
+	 * This is also what makes the SQL engine's no-WHERE `ORDER BY <pk> LIMIT n`
+	 * O(window) instead of a full scan + in-memory sort (D-219).
+	 */
+	test('[rest] Sort by primary key ascending', () => {
+		return client
+			.reqRest('/Related/?sort(id)&limit(3)')
+			.expect((r) =>
+				assert.deepEqual(
+					r.body.map((x) => x.id),
+					['1', '2', '3'],
+					r.text
+				)
+			)
+			.expect(200);
+	});
+
+	test('[rest] Sort by primary key descending', () => {
+		return client
+			.reqRest('/Related/?sort(-id)&limit(3)')
+			.expect((r) =>
+				assert.deepEqual(
+					r.body.map((x) => x.id),
+					['5', '4', '3'],
+					r.text
+				)
+			)
+			.expect(200);
+	});
+
+	// limit(a,b) is a range, not (offset, count): offset=a, limit=b-a.
+	test('[rest] Sort by primary key with offset', () => {
+		return client
+			.reqRest('/Related/?sort(id)&limit(1,3)')
+			.expect((r) =>
+				assert.deepEqual(
+					r.body.map((x) => x.id),
+					['2', '3'],
+					r.text
+				)
+			)
+			.expect(200);
+	});
 });

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -2875,8 +2875,10 @@ export function makeTable(options) {
 								} is not a defined attribute`,
 								404
 							);
-						if (attribute.indexed) {
-							// if it is indexed, we add a pseudo-condition to align with the natural sort order of the index
+						if (attribute.indexed || attribute.isPrimaryKey) {
+							// if it is indexed, we add a pseudo-condition to align with the natural sort order of the index.
+							// the primary key has no secondary index, but the primary store is itself keyed in
+							// primary-key order, so scanning it is already aligned with the sort
 							orderAlignedCondition = { ...sort, comparator: 'sort' };
 							conditions.push(orderAlignedCondition);
 						} else if (conditions.length === 0 && !target.allowFullScan)


### PR DESCRIPTION
## What

`Table.search` only added the order-aligned pseudo-condition when the sort attribute carried a **secondary** index. The primary key doesn't have one, so sorting by it with no other condition was rejected:

```
GET /MyTable/?sort(id)&limit(20)
404  "id is not indexed and not combined with any other conditions"
```

The primary store is itself keyed in primary-key order, so a scan of it is *already* aligned with the sort — there's nothing to reject. Sorting by primary key is about the most natural sort a table has, and it was the one sort that didn't work.

```diff
-						if (attribute.indexed) {
-							// if it is indexed, we add a pseudo-condition to align with the natural sort order of the index
+						if (attribute.indexed || attribute.isPrimaryKey) {
+							// if it is indexed, we add a pseudo-condition to align with the natural sort order of the index.
+							// the primary key has no secondary index, but the primary store is itself keyed in
+							// primary-key order, so scanning it is already aligned with the sort
 							orderAlignedCondition = { ...sort, comparator: 'sort' };
 							conditions.push(orderAlignedCondition);
 						} else if (conditions.length === 0 && !target.allowFullScan)
```

With the pseudo-condition in place the scan streams in primary-key order and a pushed limit early-terminates, so `sort(<pk>)&limit(n)` becomes **O(window)** instead of a full scan plus an in-memory sort.

## Why this is safe for the primary key specifically

The two hazards that make a *secondary*-index sort diverge from a full-scan-then-stable-sort don't apply to the primary key:

- **DESC ties** — a secondary index entry is composite `[value, primaryKey]`, so reversing it returns ties primary-key-DESC instead of the stable primary-key-ASC. The primary key is unique, so it has no ties.
- **Null omission** — a secondary index omits null-valued rows. The primary key is always present.

## How it was found

While benchmarking the new SQL engine (#1285), `ORDER BY <pk> LIMIT 20` was the one query shape that scaled linearly with table size on **both** engines, which contradicted D-219's O(window) intent. Driving `Table.search` directly (no SQL) isolated it — the primary key 404'd while secondary indexes were genuinely flat at ~1.2ms across an 8× table growth.

This lands independently of #1285. On that branch it takes the new engine's `ORDER BY <pk> LIMIT 20` from **118ms → 1.6ms at 40k rows** and makes it flat across table growth. The benchmark itself is a follow-up PR.

## Testing

- **Three new `rest.test.mjs` regression tests** (ASC / DESC / offset). Confirmed all three fail with the exact `id is not indexed...` 404 without this change, and pass with it.
- ASC, DESC, offset and DESC+offset each checked against a locally computed expectation over a 3k-row table — ordering is exact in both directions.
- `rest.test.mjs` 15/15, `unitTests/resources/**` 1146 passing.
- On #1285's branch: northwind 562 pass / 0 fail (including the `ORDER BY <secondary> DESC` cases that 50f917bb6 fixed), SQL differential 12/12, sqlEngine unit 96.

## Note for reviewers

One behavior change beyond the fix: `?sort(id)` with **no** limit is now a permitted full scan (streamed in key order) where it previously 404'd. That matches how `?sort(<indexed attribute>)` already behaves today, so this makes the primary key consistent with secondary indexes rather than introducing a new class of scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
