### PR TITLE
fix: built-in agent drains operations tools from the lazy provider

### DIFF
--- a/agent/registryTools.ts
+++ b/agent/registryTools.ts
@@ -20,7 +20,7 @@
 
 import { registerOperationsTools } from '../components/mcp/tools/operations.ts';
 import {
-	snapshotProfileTools,
+	listProfileTools,
 	type AuthedUser,
 	type ToolCallContext,
 	type ToolDef as RegistryToolDef,
@@ -60,7 +60,7 @@ export function ensureOperationsToolsRegistered(): void {
  *     is never cached in the handler closure.
  */
 export function composeRegistryTools(listingUser: AuthedUser, resolveIdentity: () => Promise<AuthedUser>): AgentTool[] {
-	const defs = snapshotProfileTools('operations');
+	const defs = listProfileTools('operations');
 	const out: AgentTool[] = [];
 	for (const def of defs) {
 		if (!def.visibleTo(listingUser)) continue;

--- a/components/mcp/toolRegistry.ts
+++ b/components/mcp/toolRegistry.ts
@@ -238,8 +238,9 @@ export function snapshotProfileTools(profile: McpProfile): ToolDef[] {
 export function listProfileTools(profile: McpProfile): ToolDef[] {
 	const byName = new Map<string, ToolDef>();
 	const provider = profileProviders.get(profile);
-	if (provider) {
-		for (const def of provider.list()) byName.set(def.name, def);
+	const providerTools = provider?.list?.();
+	if (providerTools) {
+		for (const def of providerTools) byName.set(def.name, def);
 	}
 	for (const def of registry.values()) {
 		if (def.profile === profile) byName.set(def.name, def);

--- a/components/mcp/toolRegistry.ts
+++ b/components/mcp/toolRegistry.ts
@@ -228,6 +228,26 @@ export function snapshotProfileTools(profile: McpProfile): ToolDef[] {
 }
 
 /**
+ * Every tool a profile currently exposes: its dynamic provider's tools merged
+ * with its statically-registered tools, deduped by name (static wins, matching
+ * `getTool`/`buildToolListPage`). Unlike `snapshotProfileTools` — which reads
+ * only the static registry for atomic-rebuild restore — this includes lazy
+ * providers, so the built-in agent (which drains the `operations` profile, a
+ * pure lazy provider) sees the operation tools at all.
+ */
+export function listProfileTools(profile: McpProfile): ToolDef[] {
+	const byName = new Map<string, ToolDef>();
+	const provider = profileProviders.get(profile);
+	if (provider) {
+		for (const def of provider.list()) byName.set(def.name, def);
+	}
+	for (const def of registry.values()) {
+		if (def.profile === profile) byName.set(def.name, def);
+	}
+	return [...byName.values()];
+}
+
+/**
  * Remove every tool registered for a profile. Used to rebuild the
  * application-profile tool set when schemas change (a table may have been
  * added/removed after the initial registration); see `refreshApplicationTools`.
@@ -317,19 +337,8 @@ export function listTools(args: ListToolsArgs): ListToolsResult {
 }
 
 function computeFilteredList(user: AuthedUser, profile: McpProfile): ToolDescriptor[] {
-	// Merge the profile's dynamic provider (if any) with its statically-registered
-	// tools, deduping by name. Provider entries are inserted first so a static
-	// registration of the same name overrides them (curated wins — see getTool).
-	const byName = new Map<string, ToolDef>();
-	const provider = profileProviders.get(profile);
-	if (provider) {
-		for (const def of provider.list()) byName.set(def.name, def);
-	}
-	for (const def of registry.values()) {
-		if (def.profile === profile) byName.set(def.name, def);
-	}
 	const out: ToolDescriptor[] = [];
-	for (const def of byName.values()) {
+	for (const def of listProfileTools(profile)) {
 		if (!def.visibleTo(user)) continue;
 		out.push({
 			name: def.name,

--- a/unitTests/agent/registryTools.test.js
+++ b/unitTests/agent/registryTools.test.js
@@ -14,7 +14,7 @@
  */
 
 const assert = require('node:assert/strict');
-const { addTool, _resetRegistryForTest } = require('#src/components/mcp/toolRegistry');
+const { addTool, setProfileToolProvider, _resetRegistryForTest } = require('#src/components/mcp/toolRegistry');
 const { composeRegistryTools, _resetRegistryToolsForTests } = require('#src/agent/registryTools');
 const { composeToolset } = require('#src/agent/toolset');
 
@@ -69,6 +69,32 @@ describe('agent/registryTools composeRegistryTools', () => {
 		addTool(opTool({ name: 'app_op', profile: 'application' }));
 		const names = composeRegistryTools(SUPER_USER, identity(SUPER_USER)).map((t) => t.def.name);
 		assert.deepEqual(names, ['ops_op']);
+	});
+
+	// Regression: the real Operations profile registers via a *lazy provider*
+	// (setProfileToolProvider), not static addTool. Draining it with the
+	// static-only snapshot returned nothing, so the agent had zero operation
+	// tools. composeRegistryTools must see provider-supplied tools.
+	it('drains operations tools registered via a lazy provider, not just static addTool', () => {
+		setProfileToolProvider('operations', {
+			list: () => [opTool({ name: 'restart_service' }), opTool({ name: 'sql' })],
+			get: (name) => (name === 'restart_service' || name === 'sql' ? opTool({ name }) : undefined),
+		});
+		const names = composeRegistryTools(SUPER_USER, identity(SUPER_USER))
+			.map((t) => t.def.name)
+			.sort();
+		assert.deepEqual(names, ['restart_service', 'sql']);
+	});
+
+	it('merges provider and static operations tools, static winning on a name collision', () => {
+		setProfileToolProvider('operations', {
+			list: () => [opTool({ name: 'sql', description: 'from provider' })],
+			get: (name) => (name === 'sql' ? opTool({ name, description: 'from provider' }) : undefined),
+		});
+		addTool(opTool({ name: 'sql', description: 'from static' }));
+		const byName = new Map(composeRegistryTools(SUPER_USER, identity(SUPER_USER)).map((t) => [t.def.name, t]));
+		assert.equal(byName.size, 1);
+		assert.equal(byName.get('sql').def.description, 'from static');
 	});
 
 	it('marks a tool destructive when annotations.destructiveHint is set', () => {

--- a/unitTests/components/mcp/toolRegistry.test.js
+++ b/unitTests/components/mcp/toolRegistry.test.js
@@ -185,12 +185,29 @@ describe('mcp/toolRegistry', () => {
 	});
 
 	describe('setProfileToolProvider (dynamic per-profile tools)', () => {
-		const { setProfileToolProvider } = require('#src/components/mcp/toolRegistry');
+		const { setProfileToolProvider, listProfileTools } = require('#src/components/mcp/toolRegistry');
 
 		function provider(defs) {
 			const byName = new Map(defs.map((d) => [d.name, d]));
 			return { list: () => defs, get: (name) => byName.get(name) };
 		}
+
+		// listProfileTools is what the built-in agent drains (unlike
+		// snapshotProfileTools, which is static-only and misses providers).
+		it('listProfileTools includes provider tools and merges static (static wins)', () => {
+			addTool(makeTool({ name: 'dup', profile: 'operations', description: 'static wins' }));
+			addTool(makeTool({ name: 'static_only', profile: 'operations' }));
+			setProfileToolProvider(
+				'operations',
+				provider([
+					makeTool({ name: 'dup', profile: 'operations', description: 'provider loses' }),
+					makeTool({ name: 'prov_only', profile: 'operations' }),
+				])
+			);
+			const byName = new Map(listProfileTools('operations').map((d) => [d.name, d]));
+			assert.deepEqual([...byName.keys()].sort(), ['dup', 'prov_only', 'static_only']);
+			assert.equal(byName.get('dup').description, 'static wins');
+		});
 
 		it('lists provider tools merged with statically-registered tools', () => {
 			addTool(makeTool({ name: 'static_op', profile: 'operations' }));

--- a/unitTests/components/mcp/toolRegistry.test.js
+++ b/unitTests/components/mcp/toolRegistry.test.js
@@ -209,6 +209,17 @@ describe('mcp/toolRegistry', () => {
 			assert.equal(byName.get('dup').description, 'static wins');
 		});
 
+		it('listProfileTools tolerates a provider without a ready list', () => {
+			addTool(makeTool({ name: 'static_op', profile: 'operations' }));
+			for (const list of [undefined, () => undefined, () => null]) {
+				setProfileToolProvider('operations', { list, get: () => undefined });
+				assert.deepEqual(
+					listProfileTools('operations').map((def) => def.name),
+					['static_op']
+				);
+			}
+		});
+
 		it('lists provider tools merged with statically-registered tools', () => {
 			addTool(makeTool({ name: 'static_op', profile: 'operations' }));
 			setProfileToolProvider('operations', provider([makeTool({ name: 'dynamic_op', profile: 'operations' })]));


### PR DESCRIPTION
## Summary

The built-in agent drains the MCP `operations` profile to expose Harper operations (`sql`, `restart_service`, `deploy_component`, …) as agent tools. It was getting **zero** of them: `composeRegistryTools` used `snapshotProfileTools('operations')`, which reads only the static `registry` Map — but the operations profile is registered as a **lazy provider** (`setProfileToolProvider`), not static `addTool` entries. So the drain was always empty, regardless of `agent.user` or `mcp.operations.allow`. (The `application` profile was unaffected because it uses static `addTool`; the HTTP `tools/list` path was unaffected because `computeFilteredList` already merges the provider.)

## Change

- Add `listProfileTools(profile)` to `toolRegistry.ts` — merges the profile's provider tools with its static tools, deduped by name (static wins, matching `getTool`/`computeFilteredList`).
- `composeRegistryTools` uses `listProfileTools` instead of `snapshotProfileTools`.
- Refactor `computeFilteredList` (the `tools/list` path) to reuse `listProfileTools`, so the merge lives in one place.
- `snapshotProfileTools` is intentionally left unchanged — its contract is a static-only capture for atomic-rebuild restore.

## Verification

Reproduced live on a Fabric instance (`harper-pro 5.2.0-alpha.6`): before, an enabled agent with a superuser `agent.user` and `mcp.operations.allow` still listed no operations tools; after, it lists exactly the allow-listed set and autonomously drove a full test → `sql`-query → `write_file` fix → `restart_service` reload → verify loop. Unit tests added in `registryTools.test.js` (agent drains lazy-provider tools; static-wins merge) and `toolRegistry.test.js` (`listProfileTools` direct coverage).

## For the reviewer

- **One open item (not addressed here, pre-existing):** the operations tool list is composed once at agent startup and retained for the component lifetime, so operations registered by components loading *after* the agent would not appear. `snapshotProfileTools` had the same one-shot behavior, and listing is explicitly a non-security-boundary startup snapshot (per-call `resolveIdentity` handles enforcement). Widening to dynamic re-composition felt out of scope for this fix — flagging in case you'd prefer it addressed here.

_Generated by an LLM (Claude Opus 4.8), reviewed by Codex and Gemini before opening._
