### PR TITLE
Safe mode now disables worker preload modules

### DIFF
--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -326,8 +326,9 @@ function startWorker(path, options = {}) {
 	// instruments worker threads); `threads.preloadRequire` uses --require for CJS agents that
 	// document that path (e.g. dd-trace/init, Dynatrace OneAgent). --import is URL-based, so
 	// resolved paths are passed as file URLs. Not supported under Bun, which does not use
-	// execArgv here.
-	if (!isBun) {
+	// execArgv here. Safe mode also omits preloads because they are configured code,
+	// which safe mode must not resolve or execute.
+	if (!isBun && !process.env.HARPER_SAFE_MODE) {
 		for (const importPath of getImportModules()) execArgv.push('--import', pathToFileURL(importPath).href);
 		for (const requirePath of getRequireModules()) execArgv.push('--require', requirePath);
 	}

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -328,7 +328,9 @@ function startWorker(path, options = {}) {
 	// resolved paths are passed as file URLs. Not supported under Bun, which does not use
 	// execArgv here. Safe mode also omits preloads because they are configured code,
 	// which safe mode must not resolve or execute.
-	if (!isBun && !process.env.HARPER_SAFE_MODE) {
+	const isSafeMode =
+		process.env.HARPER_SAFE_MODE && process.env.HARPER_SAFE_MODE !== 'false' && process.env.HARPER_SAFE_MODE !== '0';
+	if (!isBun && !isSafeMode) {
 		for (const importPath of getImportModules()) execArgv.push('--import', pathToFileURL(importPath).href);
 		for (const requirePath of getRequireModules()) execArgv.push('--require', requirePath);
 	}

--- a/unitTests/server/threads/preloadSafeMode-fixtures/import.cjs
+++ b/unitTests/server/threads/preloadSafeMode-fixtures/import.cjs
@@ -1,0 +1,3 @@
+'use strict';
+
+globalThis.__harperImportPreloaded = true;

--- a/unitTests/server/threads/preloadSafeMode-fixtures/require.cjs
+++ b/unitTests/server/threads/preloadSafeMode-fixtures/require.cjs
@@ -1,0 +1,3 @@
+'use strict';
+
+globalThis.__harperRequirePreloaded = true;

--- a/unitTests/server/threads/preloadSafeMode-fixtures/worker.cjs
+++ b/unitTests/server/threads/preloadSafeMode-fixtures/worker.cjs
@@ -1,0 +1,9 @@
+'use strict';
+
+const { parentPort } = require('node:worker_threads');
+
+parentPort.postMessage({
+	importLoaded: globalThis.__harperImportPreloaded === true,
+	requireLoaded: globalThis.__harperRequirePreloaded === true,
+	execArgv: process.execArgv,
+});

--- a/unitTests/server/threads/preloadSafeMode.test.js
+++ b/unitTests/server/threads/preloadSafeMode.test.js
@@ -10,6 +10,28 @@ const { startWorker } = require('#js/server/threads/manageThreads');
 const FIXTURES = path.join(__dirname, 'preloadSafeMode-fixtures');
 const WORKER_FIXTURE = path.join(FIXTURES, 'worker.cjs');
 
+async function getWorkerReport() {
+	let worker;
+	try {
+		return await new Promise((resolve, reject) => {
+			worker = startWorker(WORKER_FIXTURE, {
+				name: 'safe-mode-preload-test',
+				autoRestart: false,
+				onStarted(spawned) {
+					spawned.once('message', resolve);
+					spawned.once('error', reject);
+					spawned.once('exit', (code) => reject(new Error(`Worker exited before reporting (code ${code})`)));
+				},
+			});
+		});
+	} finally {
+		if (worker) {
+			worker.wasShutdown = true;
+			await worker.terminate();
+		}
+	}
+}
+
 describe('worker preloads in safe mode', () => {
 	let originalSafeMode;
 	let originalPreload;
@@ -33,28 +55,20 @@ describe('worker preloads in safe mode', () => {
 
 	it('does not load or add flags for threads.preload and threads.preloadRequire modules', async function () {
 		this.timeout(30000);
-		let worker;
-		try {
-			const report = await new Promise((resolve, reject) => {
-				worker = startWorker(WORKER_FIXTURE, {
-					name: 'safe-mode-preload-test',
-					autoRestart: false,
-					onStarted(spawned) {
-						spawned.once('message', resolve);
-						spawned.once('error', reject);
-						spawned.once('exit', (code) => reject(new Error(`Worker exited before reporting (code ${code})`)));
-					},
-				});
-			});
-			assert.equal(report.importLoaded, false);
-			assert.equal(report.requireLoaded, false);
-			assert.equal(report.execArgv.includes('--import'), false);
-			assert.equal(report.execArgv.includes('--require'), false);
-		} finally {
-			if (worker) {
-				worker.wasShutdown = true;
-				await worker.terminate();
-			}
-		}
+		const report = await getWorkerReport();
+		assert.strictEqual(report.importLoaded, false);
+		assert.strictEqual(report.requireLoaded, false);
+		assert.strictEqual(report.execArgv.includes('--import'), false);
+		assert.strictEqual(report.execArgv.includes('--require'), false);
+	});
+
+	it('loads both configured preload forms outside safe mode', async function () {
+		this.timeout(30000);
+		delete process.env.HARPER_SAFE_MODE;
+		const report = await getWorkerReport();
+		assert.strictEqual(report.importLoaded, true);
+		assert.strictEqual(report.requireLoaded, true);
+		assert.strictEqual(report.execArgv.includes('--import'), true);
+		assert.strictEqual(report.execArgv.includes('--require'), true);
 	});
 });

--- a/unitTests/server/threads/preloadSafeMode.test.js
+++ b/unitTests/server/threads/preloadSafeMode.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const assert = require('node:assert');
+const path = require('node:path');
+
+const envMgr = require('#src/utility/environment/environmentManager');
+const hdbTerms = require('#src/utility/hdbTerms');
+const { startWorker } = require('#js/server/threads/manageThreads');
+
+const FIXTURES = path.join(__dirname, 'preloadSafeMode-fixtures');
+const WORKER_FIXTURE = path.join(FIXTURES, 'worker.cjs');
+
+describe('worker preloads in safe mode', () => {
+	let originalSafeMode;
+	let originalPreload;
+	let originalPreloadRequire;
+
+	before(() => {
+		originalSafeMode = process.env.HARPER_SAFE_MODE;
+		originalPreload = envMgr.get(hdbTerms.CONFIG_PARAMS.THREADS_PRELOAD);
+		originalPreloadRequire = envMgr.get(hdbTerms.CONFIG_PARAMS.THREADS_PRELOADREQUIRE);
+		envMgr.setProperty(hdbTerms.CONFIG_PARAMS.THREADS_PRELOAD, path.join(FIXTURES, 'import.cjs'));
+		envMgr.setProperty(hdbTerms.CONFIG_PARAMS.THREADS_PRELOADREQUIRE, path.join(FIXTURES, 'require.cjs'));
+		process.env.HARPER_SAFE_MODE = '1';
+	});
+
+	after(() => {
+		envMgr.setProperty(hdbTerms.CONFIG_PARAMS.THREADS_PRELOAD, originalPreload);
+		envMgr.setProperty(hdbTerms.CONFIG_PARAMS.THREADS_PRELOADREQUIRE, originalPreloadRequire);
+		if (originalSafeMode === undefined) delete process.env.HARPER_SAFE_MODE;
+		else process.env.HARPER_SAFE_MODE = originalSafeMode;
+	});
+
+	it('does not load or add flags for threads.preload and threads.preloadRequire modules', async function () {
+		this.timeout(30000);
+		let worker;
+		try {
+			const report = await new Promise((resolve, reject) => {
+				worker = startWorker(WORKER_FIXTURE, {
+					name: 'safe-mode-preload-test',
+					autoRestart: false,
+					onStarted(spawned) {
+						spawned.once('message', resolve);
+						spawned.once('error', reject);
+						spawned.once('exit', (code) => reject(new Error(`Worker exited before reporting (code ${code})`)));
+					},
+				});
+			});
+			assert.equal(report.importLoaded, false);
+			assert.equal(report.requireLoaded, false);
+			assert.equal(report.execArgv.includes('--import'), false);
+			assert.equal(report.execArgv.includes('--require'), false);
+		} finally {
+			if (worker) {
+				worker.wasShutdown = true;
+				await worker.terminate();
+			}
+		}
+	});
+});


### PR DESCRIPTION
When `HARPER_SAFE_MODE` is set, worker creation now skips resolving and passing configured `threads.preload` and `threads.preloadRequire` modules, preventing configured preload code from running in safe mode. Adds worker-level regression coverage for both the `--import` and `--require` paths.

No documentation update is needed because the configuration surface is unchanged; this aligns worker preloads with the existing safe-mode contract that user applications and components are not loaded.

Generated with OpenAI Codex (GPT-5).