### PR TITLE
feat(cli): `harper deploy setup=true` — seal a durable deploy credential client-side

### DIFF
--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -507,7 +507,6 @@ function warnIfCommitNotPushed(committish: string): void {
 	}
 }
 
-
 // The credential only helps if it's for the host the package is cloned from: a `credential=gitlab.com`
 // against a github.com package builds a valid-looking reference the clone never asks for, and the
 // private deploy then fails as if nothing were configured. So the host comes from the package rather

--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -56,9 +56,10 @@ const TRANSPORT_ONLY_FIELDS = new Set([
 	'ref',
 	'credential',
 	// `deploy setup=true`'s token, read off the parsed request by deploySetup and sealed locally. No
-	// operation takes a top-level `token` (the one in `credentials[]` is nested and stripped with it),
-	// so keeping it out of every body costs nothing and means a mistyped `setup` — which parses as a
-	// bare word and falls through to a real deploy — can't carry a PAT to the server.
+	// operation takes a *top-level* `token`, so keeping it out of every body costs nothing and means a
+	// mistyped `setup` — which parses as a bare word and falls through to a real deploy — can't carry a
+	// PAT to the server. Distinct from `credentials[].token`, which is nested inside a field that IS
+	// sent (ingestCredentials seals it server-side) and is only kept out of the operations log.
 	'token',
 ]);
 

--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -7,7 +7,6 @@ envMgr.initSync();
 import * as terms from '../utility/hdbTerms.ts';
 import { httpRequest } from '../utility/common_utils.ts';
 import * as fs from 'fs-extra';
-import * as path from 'node:path';
 import * as YAML from 'yaml';
 import { Readable } from 'node:stream';
 import { execFileSync } from 'node:child_process';
@@ -56,6 +55,11 @@ const TRANSPORT_ONLY_FIELDS = new Set([
 	'by_ref',
 	'ref',
 	'credential',
+	// `deploy setup=true`'s token, read off the parsed request by deploySetup and sealed locally. No
+	// operation takes a top-level `token` (the one in `credentials[]` is nested and stripped with it),
+	// so keeping it out of every body costs nothing and means a mistyped `setup` — which parses as a
+	// bare word and falls through to a real deploy — can't carry a PAT to the server.
+	'token',
 ]);
 
 /**
@@ -253,7 +257,7 @@ function resolveTransportCredentials(req: any, urlCredentials: { username: strin
 // file — the command line already exposes it to shell history and process listings; the log
 // shouldn't be a third copy. This list is by field name, not exhaustive — any future secret-bearing
 // arg (a token, a key) needs to be added here explicitly, or it will reach logger.trace unredacted.
-const SECRET_FIELDS = new Set(['auth_password', 'password']);
+const SECRET_FIELDS = new Set(['auth_password', 'password', 'token']);
 
 // `target=https://admin:secret@host` carries a password too, so masking the userinfo is part of
 // making a target printable — the same string is echoed by the "Connecting to ..." line.
@@ -503,15 +507,6 @@ function warnIfCommitNotPushed(committish: string): void {
 	}
 }
 
-function defaultProjectName(projectPath: string): string {
-	try {
-		const pkg = JSON.parse(fs.readFileSync(path.join(projectPath, 'package.json'), 'utf8'));
-		if (typeof pkg.name === 'string' && pkg.name.length > 0) return pkg.name.replace(/^@[^/]+\//, '');
-	} catch {
-		// No/invalid package.json — fall back to the directory name.
-	}
-	return path.basename(projectPath);
-}
 
 // The credential only helps if it's for the host the package is cloned from: a `credential=gitlab.com`
 // against a github.com package builds a valid-looking reference the clone never asks for, and the
@@ -543,7 +538,11 @@ export function prepareDeployByRef(req: any): void {
 	// left is pushed by construction — and a shallow/detached runner checkout has no remote-tracking
 	// branches to check it against anyway.
 	if (!process.env.GITHUB_SHA) warnIfCommitNotPushed(committish);
-	if (!req.project) req.project = defaultProjectName(process.cwd());
+	// The same default the payload deploy and `deploy setup=true` use. A by-reference deploy is the
+	// flow the sealed credential feeds, and `set_secret`'s grant is keyed by project name, so a
+	// package.json-derived name here would ask for a secret granted to a different name whenever a
+	// checkout directory and its package name disagree.
+	if (!req.project) req.project = directoryProjectName();
 	// git+https (not ssh): a private clone is authenticated by a git-host token credential (#1799),
 	// which rides over HTTPS. A public repo needs no credential at all.
 	req.package = `git+https://${GIT_PACKAGE_HOST}/${repo}.git#${committish}`;

--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -6,19 +6,22 @@ import * as envMgr from '../utility/environment/environmentManager.ts';
 envMgr.initSync();
 import * as terms from '../utility/hdbTerms.ts';
 import { httpRequest } from '../utility/common_utils.ts';
-import * as path from 'path';
 import * as fs from 'fs-extra';
+import * as path from 'node:path';
 import * as YAML from 'yaml';
 import { Readable } from 'node:stream';
 import { execFileSync } from 'node:child_process';
 import { streamPackagedDirectory, packageDirectory, scanPackageDirectory } from '../components/packageComponent.ts';
-import { normalizeGitHost } from '../components/gitCredentialServer.ts';
 import { encode as encodeCbor } from 'cbor-x';
 import { buildMultipartBody } from './multipartBuilder.ts';
 import { parseSSE } from './sseConsumer.ts';
 import { DeployRenderer } from './deployRenderer.ts';
 import { getHdbPid } from '../utility/processManagement/processManagement.js';
 import { initConfig, getConfigPath } from '../config/configUtils.ts';
+// The `deploy setup` seal and this by-reference flag both name the same hdb_secret row, and the
+// server re-derives it from its own request — so the derivation lives in one dependency-free module
+// rather than being restated per caller (it also keeps `components/` off the CLI's import graph).
+import { deriveGitSecretName, directoryProjectName, normalizeGitHost } from '../utility/componentNames.ts';
 
 const OP_ALIASES = { deploy: 'deploy_component', package: 'package_component' };
 
@@ -35,16 +38,16 @@ const LOCAL_NOT_RUNNING_MESSAGE = 'Harper is not running. Use `harperdb run` (or
 // the SSE parser sees no events.
 const SSE_OPERATIONS = new Set(['deploy_component']);
 
+// The fields that decide *where* an operation connects and *as whom* — see transportContext().
+const CONNECTION_FIELDS = ['target', 'auth_username', 'auth_password', 'rejectUnauthorized'];
+
 // Properties on `req` that the CLI itself uses for transport/UX, not the operations API.
 // They never get serialized into the request body. `username`/`password` are deliberately
 // NOT here: those args are payload fields (e.g. the user add_user/alter_user create/alter),
 // not transport — use `auth_username`/`auth_password` (or env-var/`harper login` auth) to
 // authenticate as a different user than the one being operated on.
 const TRANSPORT_ONLY_FIELDS = new Set([
-	'target',
-	'auth_username',
-	'auth_password',
-	'rejectUnauthorized',
+	...CONNECTION_FIELDS,
 	'json',
 	'skip_node_modules',
 	'skip_symlinks',
@@ -54,6 +57,21 @@ const TRANSPORT_ONLY_FIELDS = new Set([
 	'ref',
 	'credential',
 ]);
+
+/**
+ * The connection half of a parsed CLI request, as a base for a *different* operation issued on the
+ * same command's behalf (`harper deploy setup=true` calls get_secrets_public_key and set_secret).
+ * Carrying these over keeps the sub-operation on the caller's target, identity, and TLS strictness;
+ * rebuilding a request with only `target` would silently authenticate with a saved login token
+ * instead of the credentials that were passed explicitly, and would fail against a self-signed
+ * target. Only these fields come along, so the originating command's own args (a deploy's `token`,
+ * `package`, …) never reach the sub-operation's body.
+ */
+function transportContext(req: any): any {
+	const context: any = {};
+	for (const field of CONNECTION_FIELDS) if (req[field] !== undefined) context[field] = req[field];
+	return context;
+}
 
 // Values that are opaque strings, never JSON. buildRequest otherwise JSON-parses every value, which
 // silently rewrites a git ref that happens to look numeric: `ref=1.0` becomes the number 1 (and then
@@ -266,6 +284,7 @@ export {
 	buildRequest,
 	redactCredentials,
 	refreshExpiredOperationToken,
+	transportContext,
 	resolveGitTarget,
 	resolveCredentialHost,
 	deriveGitSecretName,
@@ -494,18 +513,6 @@ function defaultProjectName(projectPath: string): string {
 	return path.basename(projectPath);
 }
 
-// Must produce the same name as the server's `deriveGitSecretName` (secretOperations.ts), so the
-// reference this attaches matches the row `harper deploy setup=true` sealed and a literal-token
-// deploy would use: `deploy.<component>.git.<host>`. Rather than restate the host-normalization
-// chain, this shares the server's own `normalizeGitHost` — a future host quirk added there then
-// can't drift from what the CLI sends. (gitCredentialServer.ts pulls in only node builtins plus
-// the error/logger utilities `bin/` already uses, so importing it costs the CLI nothing.)
-function deriveGitSecretName(component: string, host: string): string {
-	const hostPart = normalizeGitHost(host).replace(/[^\w.-]+/g, '_');
-	const componentPart = String(component).replace(/[^\w.-]+/g, '_');
-	return `deploy.${componentPart}.git.${hostPart}`;
-}
-
 // The credential only helps if it's for the host the package is cloned from: a `credential=gitlab.com`
 // against a github.com package builds a valid-looking reference the clone never asks for, and the
 // private deploy then fails as if nothing were configured. So the host comes from the package rather
@@ -563,7 +570,7 @@ const PREPARE_OPERATION: any = {
 		}
 
 		const projectPath = process.cwd();
-		if (!req.project) req.project = path.basename(projectPath);
+		if (!req.project) req.project = directoryProjectName(projectPath);
 		const packageOptions = {
 			skip_node_modules: req.skip_node_modules !== false,
 			skip_symlinks: req.skip_symlinks === true,

--- a/bin/deploySetup.ts
+++ b/bin/deploySetup.ts
@@ -38,6 +38,14 @@ import {
 	PROJECT_NAME_PATTERN,
 } from '../utility/componentNames.ts';
 
+// `formatCliError` (bin/harper.ts) prints message-only for an error carrying a numeric `statusCode`
+// and keeps the stack for anything else, on the assumption that a stack means a bug. Everything this
+// flow throws is a usage or cluster-capability problem the operator can act on, so it gets a code —
+// the value only selects the clean formatting.
+function cliError(message: string): Error {
+	return Object.assign(new Error(message), { statusCode: 400 });
+}
+
 function tryCommand(command: string, args: string[]): string {
 	try {
 		return execFileSync(command, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
@@ -79,38 +87,40 @@ export function resolveComponentName(req: any): string | undefined {
 export function resolveGitHost(host: unknown): string {
 	const normalized = typeof host === 'string' ? normalizeGitHost(host) : '';
 	if (!GIT_HOST_PATTERN.test(normalized)) {
-		throw new Error(`Invalid git host ${JSON.stringify(host)} — expected a bare host, e.g. 'github.com'.`);
+		throw cliError(`Invalid git host ${JSON.stringify(host)} — expected a bare host, e.g. 'github.com'.`);
 	}
 	return normalized;
 }
 
 /**
- * The grants to send with the seal: this component, plus whatever the row already grants.
+ * Store the sealed envelope and make sure the component can use it, as two server-side atomic steps.
+ * Returns the row's full grant list, as the server reports it.
  *
- * `set_secret` replaces rather than merges (`grants = dedupeGrants(req.grants ?? existing?.grants)`),
- * so rotating a token here while sending only this component would revoke any grant an operator added
- * separately with `grant_secret` — the realistic case being a monorepo whose second component deploys
- * from the same repo. That revocation is invisible until the other component's next deploy fails, so
- * the union is read first. A lookup failure falls back to this component alone (the pre-existing
- * behavior) and says so, rather than aborting a rotation the operator asked for.
+ * `grants` is deliberately omitted from `set_secret`: it *replaces* rather than merges
+ * (`grants = dedupeGrants(req.grants ?? existing?.grants)`, secretOperations.ts), so sending only this
+ * component would silently revoke a grant an operator had added with `grant_secret` — a monorepo's
+ * second component being the realistic case, and invisible until its next deploy fails. Omitting the
+ * field keeps the stored list untouched under the server's `withSecretLock`, and the idempotent
+ * `grant_secret` then adds this component in a second locked step. Doing the merge on the client
+ * instead would cost the same two round trips while reintroducing a race: a `revoke_secret` landing
+ * between the read and the write would be silently undone.
+ *
+ * A brand-new row is briefly ungranted between the calls, which is harmless — it can't be resolved by
+ * any deploy until the grant lands. Nothing is printed until both steps succeed, so a failure part-way
+ * doesn't claim a credential is ready to use.
  */
-export async function resolveGrants(transport: any, secretName: string, component: string): Promise<string[]> {
-	try {
-		const listed: any = await cliOperations({ ...transport, operation: 'list_secrets' }, true);
-		const row = listed?.secrets?.find((secret: any) => secret?.name === secretName);
-		const existing: string[] = Array.isArray(row?.grants) ? row.grants : [];
-		if (existing.length && !existing.includes(component)) {
-			console.log(chalk.gray(`  Keeping existing grant(s) on "${secretName}": ${existing.join(', ')}`));
-		}
-		return [...new Set([component, ...existing])];
-	} catch {
-		console.log(
-			chalk.yellow(
-				`Note: couldn't read existing grants for "${secretName}"; storing it granted to "${component}" only.`
-			)
-		);
-		return [component];
-	}
+export async function storeSealedSecret(
+	transport: any,
+	secretName: string,
+	envelope: string,
+	component: string
+): Promise<string[]> {
+	await cliOperations({ ...transport, operation: 'set_secret', name: secretName, envelope }, true);
+	const granted: any = await cliOperations(
+		{ ...transport, operation: 'grant_secret', name: secretName, component },
+		true
+	);
+	return Array.isArray(granted?.grants) ? granted.grants : [component];
 }
 
 export async function deploySetup(req: any): Promise<void> {
@@ -120,19 +130,14 @@ export async function deploySetup(req: any): Promise<void> {
 	// deploy args that brought us here (`setup`, `token`, `package`) never reach either body.
 	const transport = transportContext(req);
 
-	// 1. Fetch the cluster's public secrets key.
-	let keyResponse: any;
-	try {
-		keyResponse = await cliOperations({ ...transport, operation: 'get_secrets_public_key' }, true);
-	} catch (error) {
-		throw new Error(
-			`Could not fetch the cluster's secrets public key: ${error instanceof Error ? error.message : String(error)}`
-		);
-	}
+	// 1. Fetch the cluster's public secrets key. Not wrapped in a try/catch: `cliOperations` reports
+	// the failure and exits rather than throwing, so a catch here would be dead code promising a
+	// friendlier message that never runs.
+	const keyResponse: any = await cliOperations({ ...transport, operation: 'get_secrets_public_key' }, true);
 	const publicKey: string | undefined = keyResponse?.public_key;
 	const fingerprint: string | undefined = keyResponse?.fingerprint;
 	if (!publicKey || !fingerprint) {
-		throw new Error(
+		throw cliError(
 			"This cluster didn't return a secrets public key — secrets custody isn't initialized on it " +
 				'(available on Harper Pro / Fabric). Without it, a credential cannot be sealed client-side.'
 		);
@@ -154,7 +159,7 @@ export async function deploySetup(req: any): Promise<void> {
 		).provider;
 
 	if (provider !== 'github' && provider !== 'npm') {
-		throw new Error(`Unsupported provider "${provider}" — supported providers are "github" and "npm".`);
+		throw cliError(`Unsupported provider "${provider}" — supported providers are "github" and "npm".`);
 	}
 
 	// 3. Which component is the credential for? (the grant is scoped to it)
@@ -171,7 +176,7 @@ export async function deploySetup(req: any): Promise<void> {
 			).project ?? ''
 		);
 	if (!PROJECT_NAME_PATTERN.test(component)) {
-		throw new Error(
+		throw cliError(
 			`"${component}" is not a usable component name — a deploy accepts letters, numbers, dashes and underscores.`
 		);
 	}
@@ -245,7 +250,7 @@ export async function deploySetup(req: any): Promise<void> {
 	}
 
 	token = typeof token === 'string' ? token.trim() : undefined;
-	if (!token) throw new Error('No token was provided; nothing to store.');
+	if (!token) throw cliError('No token was provided; nothing to store.');
 
 	// 4. Seal the token locally. Only ciphertext leaves this machine.
 	const envelope = ENV_ENCRYPTED_PREFIX + encryptEnvelope(token, publicKey, fingerprint);
@@ -257,8 +262,7 @@ export async function deploySetup(req: any): Promise<void> {
 		provider === 'github'
 			? deriveGitSecretName(component, credentialKey)
 			: deriveRegistrySecretName(component, credentialKey);
-	const grants = await resolveGrants(transport, secretName, component);
-	await cliOperations({ ...transport, operation: 'set_secret', name: secretName, envelope, grants }, true);
+	const grants = await storeSealedSecret(transport, secretName, envelope, component);
 
 	// 6. Print the credentials reference the deploy should use.
 	credentialEntry.secret = secretName;

--- a/bin/deploySetup.ts
+++ b/bin/deploySetup.ts
@@ -13,8 +13,9 @@
 //   1. get_secrets_public_key  → the cluster's RSA public key + fingerprint
 //   2. source a token          → `gh auth token`, or paste a fine-grained PAT / npm token
 //   3. encryptEnvelope(...)     → seal it locally into an `enc:v1:` envelope (pure client-side crypto)
-//   4. set_secret {envelope}    → store ciphertext, granted to the component
-//   5. print the `credentials` reference the deploy should use
+//   4. set_secret {envelope}    → store ciphertext, in the component-scoped tier
+//   5. grant_secret            → let this component resolve it (see storeSealedSecret for why it's two calls)
+//   6. print the `credentials` reference the deploy should use
 //
 // Every name this flow derives — the component it grants to, the host it labels the credential with,
 // the hdb_secret row it writes — has to match what the deploy will derive from its own request, or it
@@ -105,6 +106,15 @@ export function resolveGitHost(host: unknown): string {
  * instead would cost the same two round trips while reintroducing a race: a `revoke_secret` landing
  * between the read and the write would be silently undone.
  *
+ * `processEnv: false` is explicit, and load-bearing rather than decorative. `set_secret` otherwise
+ * inherits the stored tier, so if the derived row already existed as a processEnv (global) secret the
+ * pasted token would be written into the tier every component and child process reads — and only then
+ * would `grant_secret` reject the row for being global, leaving the CLI reporting a failure it had
+ * already committed. (Sending `grants` used to mask this: the server rejects processEnv+grants before
+ * writing. Omitting them for the merge above removed that accident, so the intent is now stated.) This
+ * converts such a row to the scoped tier, which is what this flow promises — and the name is
+ * component-derived, so a global secret at it was never serving anything the scoped one doesn't.
+ *
  * A brand-new row is briefly ungranted between the calls, which is harmless — it can't be resolved by
  * any deploy until the grant lands. Nothing is printed until both steps succeed, so a failure part-way
  * doesn't claim a credential is ready to use.
@@ -115,7 +125,7 @@ export async function storeSealedSecret(
 	envelope: string,
 	component: string
 ): Promise<string[]> {
-	await cliOperations({ ...transport, operation: 'set_secret', name: secretName, envelope }, true);
+	await cliOperations({ ...transport, operation: 'set_secret', name: secretName, envelope, processEnv: false }, true);
 	const granted: any = await cliOperations(
 		{ ...transport, operation: 'grant_secret', name: secretName, component },
 		true

--- a/bin/deploySetup.ts
+++ b/bin/deploySetup.ts
@@ -1,0 +1,204 @@
+'use strict';
+
+// `harper deploy setup=true` — provision a durable, encrypted credential the cluster uses to fetch
+// private deploy sources (a private GitHub repo, or a private npm registry).
+//
+// The whole point is that the token is sealed *on this machine* with the cluster's public secrets
+// key and only the ciphertext is ever transmitted or stored — the cluster (and its logs, its
+// operations journal, its replication) never sees the plaintext, and decrypts it only in-memory at
+// deploy/rollback time. Because the token is durable (unlike a CI `GITHUB_TOKEN`, which dies at job
+// end), a re-resolve rollback works for as long as the token is valid.
+//
+// Flow:
+//   1. get_secrets_public_key  → the cluster's RSA public key + fingerprint
+//   2. source a token          → `gh auth token`, or paste a fine-grained PAT / npm token
+//   3. encryptEnvelope(...)     → seal it locally into an `enc:v1:` envelope (pure client-side crypto)
+//   4. set_secret {envelope}    → store ciphertext, granted to the component
+//   5. print the `credentials` reference the deploy should use
+
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { cliOperations } from './cliOperations.ts';
+import { encryptEnvelope } from '../utility/secretEnvelope.ts';
+import { ENV_ENCRYPTED_PREFIX } from '../utility/envFile.ts';
+
+// Mirror the server's derived secret names (secretOperations.ts `deriveRegistrySecretName` and
+// `deriveGitSecretName`) EXACTLY, so a `deploy setup` seal and a later literal-token deploy overwrite
+// the SAME hdb_secret row. git hosts get a `.git.` segment (and normalizeGitHost handling); registries
+// don't — without the segment, a git and a registry credential for the same host would collide.
+function deriveSecretName(component: string, key: string, provider: string): string {
+	const componentPart = String(component).replace(/[^\w.-]+/g, '_');
+	if (provider === 'github') {
+		// mirrors gitCredentialServer.normalizeGitHost() + deriveGitSecretName's `.git.` segment
+		const hostPart = key
+			.trim()
+			.replace(/^[a-z0-9+.-]+:\/\//i, '')
+			.replace(/^\/\//, '')
+			.replace(/\/.*$/, '')
+			.replace(/^[^@]*@/, '')
+			.toLowerCase()
+			.replace(/[^\w.-]+/g, '_');
+		return `deploy.${componentPart}.git.${hostPart}`;
+	}
+	const registryPart = key
+		.trim()
+		.replace(/^https?:\/\//i, '')
+		.replace(/^\/\//, '')
+		.replace(/\/+$/, '')
+		.toLowerCase()
+		.replace(/[^\w.-]+/g, '_');
+	return `deploy.${componentPart}.${registryPart}`;
+}
+
+function tryCommand(command: string, args: string[]): string {
+	try {
+		return execFileSync(command, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+	} catch {
+		return '';
+	}
+}
+
+function defaultComponentName(): string {
+	try {
+		const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
+		if (typeof pkg.name === 'string' && pkg.name.length > 0) return pkg.name.replace(/^@[^/]+\//, '');
+	} catch {
+		// no package.json — fall back to the directory name
+	}
+	return path.basename(process.cwd());
+}
+
+export async function deploySetup(req: any): Promise<void> {
+	// 1. Fetch the cluster's public secrets key. Target + auth are resolved by cliOperations exactly
+	// as they are for a deploy (harper login, or CLI_TARGET + HARPER_CLI_USERNAME/PASSWORD).
+	let keyResponse: any;
+	try {
+		keyResponse = await cliOperations({ operation: 'get_secrets_public_key', target: req.target }, true);
+	} catch (error) {
+		throw new Error(
+			`Could not fetch the cluster's secrets public key: ${error instanceof Error ? error.message : String(error)}`
+		);
+	}
+	const publicKey: string | undefined = keyResponse?.public_key;
+	const fingerprint: string | undefined = keyResponse?.fingerprint;
+	if (!publicKey || !fingerprint) {
+		throw new Error(
+			"This cluster didn't return a secrets public key — secrets custody isn't initialized on it " +
+				'(available on Harper Pro / Fabric). Without it, a credential cannot be sealed client-side.'
+		);
+	}
+
+	// 2. Which private source?
+	const provider: string =
+		req.provider ??
+		(
+			await inquirer.prompt({
+				type: 'list',
+				name: 'provider',
+				message: 'What private source needs a credential?',
+				choices: [
+					{ name: 'GitHub repository (private git clone)', value: 'github' },
+					{ name: 'npm registry (private packages / dependencies)', value: 'npm' },
+				],
+			})
+		).provider;
+
+	if (provider !== 'github' && provider !== 'npm') {
+		throw new Error(`Unsupported provider "${provider}" — supported providers are "github" and "npm".`);
+	}
+
+	// 3. Which component is the credential for? (the grant is scoped to it)
+	const component: string =
+		req.project ??
+		req.component ??
+		(
+			await inquirer.prompt({
+				type: 'input',
+				name: 'component',
+				message: 'Component (project) name this credential is for:',
+				default: defaultComponentName(),
+			})
+		).component;
+
+	let credentialKey: string; // host (github) or registry (npm) — the credentials-entry discriminator
+	let credentialEntry: Record<string, string>;
+	let token: string | undefined = req.token;
+
+	if (provider === 'github') {
+		const host = req.host ?? 'github.com';
+		credentialKey = host;
+		if (!token) {
+			const ghToken = tryCommand('gh', ['auth', 'token']);
+			const choices: Array<{ name: string; value: string }> = [];
+			if (ghToken) choices.push({ name: 'Use your gh CLI session token (gh auth token)', value: 'gh' });
+			choices.push({ name: 'Paste a fine-grained PAT (Contents: Read-only on this repo)', value: 'paste' });
+			const how =
+				choices.length === 1
+					? 'paste'
+					: (
+							await inquirer.prompt({
+								type: 'list',
+								name: 'how',
+								message: 'How should I get the GitHub token?',
+								choices,
+							})
+						).how;
+			if (how === 'gh') {
+				token = ghToken;
+			} else {
+				console.log(
+					chalk.gray(
+						'Create one at https://github.com/settings/personal-access-tokens/new\n' +
+							'  Repository access → only your repo; Permissions → Contents: Read-only.'
+					)
+				);
+				token = (await inquirer.prompt({ type: 'password', name: 'token', message: 'Paste the token:', mask: '*' }))
+					.token;
+			}
+		}
+		credentialEntry = { host };
+	} else {
+		const registry = req.registry ?? 'registry.npmjs.org';
+		credentialKey = registry;
+		if (!token) {
+			console.log(chalk.gray('Tip: `npm token create --read-only` mints a granular npm token from the CLI.'));
+			token = (await inquirer.prompt({ type: 'password', name: 'token', message: 'Paste the npm token:', mask: '*' }))
+				.token;
+		}
+		credentialEntry = req.scope ? { registry, scope: req.scope } : { registry };
+	}
+
+	token = typeof token === 'string' ? token.trim() : undefined;
+	if (!token) throw new Error('No token was provided; nothing to store.');
+
+	// 4. Seal the token locally. Only ciphertext leaves this machine.
+	const envelope = ENV_ENCRYPTED_PREFIX + encryptEnvelope(token, publicKey, fingerprint);
+
+	// 5. Store the sealed token, granted to the component. The server never sees the plaintext.
+	const secretName = deriveSecretName(component, credentialKey, provider);
+	await cliOperations(
+		{ operation: 'set_secret', name: secretName, envelope, grants: [component], target: req.target },
+		true
+	);
+
+	// 6. Print the credentials reference the deploy should use.
+	credentialEntry.secret = secretName;
+	console.log(chalk.green(`\n✓ Sealed "${credentialKey}" credential and stored it as secret "${secretName}".`));
+	console.log(chalk.gray("  It was encrypted here with the cluster's public key — only ciphertext was sent."));
+	console.log(
+		chalk.gray(`  Granted to component "${component}"; the cluster decrypts it only at deploy/rollback time.`)
+	);
+	console.log('\nUse it in your deploy:');
+	console.log(chalk.cyan(`  credentials='${JSON.stringify([credentialEntry])}'`));
+	if (provider === 'github') {
+		console.log(
+			chalk.gray(
+				`  e.g. harper deploy_component project=${component} package=github:<owner>/<repo>#<sha> \\\n` +
+					`         credentials='${JSON.stringify([credentialEntry])}' restart=true replicated=true`
+			)
+		);
+	}
+}

--- a/bin/deploySetup.ts
+++ b/bin/deploySetup.ts
@@ -132,9 +132,18 @@ export async function deploySetup(req: any): Promise<void> {
 		credentialKey = host;
 		if (!token) {
 			const ghToken = tryCommand('gh', ['auth', 'token']);
-			const choices: Array<{ name: string; value: string }> = [];
-			if (ghToken) choices.push({ name: 'Use your gh CLI session token (gh auth token)', value: 'gh' });
-			choices.push({ name: 'Paste a fine-grained PAT (Contents: Read-only on this repo)', value: 'paste' });
+			// A fine-grained PAT is offered FIRST, and is therefore the default selection. What gets
+			// sealed here is durable and replayed on every cold deploy and rollback, so it should be
+			// the narrowest credential that does the job — one repo, Contents: Read-only. A `gh` CLI
+			// session token is one keypress cheaper but typically carries repo/read:org/gist/workflow
+			// across the whole account, so offering it first would make least privilege the path of
+			// most resistance.
+			const choices: Array<{ name: string; value: string }> = [
+				{ name: 'Paste a fine-grained PAT (Contents: Read-only on this repo) — recommended', value: 'paste' },
+			];
+			if (ghToken) {
+				choices.push({ name: 'Use your gh CLI session token (broad account scopes)', value: 'gh' });
+			}
 			const how =
 				choices.length === 1
 					? 'paste'
@@ -147,6 +156,13 @@ export async function deploySetup(req: any): Promise<void> {
 							})
 						).how;
 			if (how === 'gh') {
+				console.log(
+					chalk.yellow(
+						'Note: your gh CLI token usually carries broad account scopes (repo, read:org, gist,\n' +
+							'  workflow) and is long-lived. It will be stored encrypted and reused for future\n' +
+							'  deploys and rollbacks of this component. A fine-grained PAT is the safer choice.'
+					)
+				);
 				token = ghToken;
 			} else {
 				console.log(

--- a/bin/deploySetup.ts
+++ b/bin/deploySetup.ts
@@ -29,7 +29,7 @@ import { ENV_ENCRYPTED_PREFIX } from '../utility/envFile.ts';
 // `deriveGitSecretName`) EXACTLY, so a `deploy setup` seal and a later literal-token deploy overwrite
 // the SAME hdb_secret row. git hosts get a `.git.` segment (and normalizeGitHost handling); registries
 // don't — without the segment, a git and a registry credential for the same host would collide.
-function deriveSecretName(component: string, key: string, provider: string): string {
+export function deriveSecretName(component: string, key: string, provider: string): string {
 	const componentPart = String(component).replace(/[^\w.-]+/g, '_');
 	if (provider === 'github') {
 		// mirrors gitCredentialServer.normalizeGitHost() + deriveGitSecretName's `.git.` segment

--- a/bin/deploySetup.ts
+++ b/bin/deploySetup.ts
@@ -84,6 +84,35 @@ export function resolveGitHost(host: unknown): string {
 	return normalized;
 }
 
+/**
+ * The grants to send with the seal: this component, plus whatever the row already grants.
+ *
+ * `set_secret` replaces rather than merges (`grants = dedupeGrants(req.grants ?? existing?.grants)`),
+ * so rotating a token here while sending only this component would revoke any grant an operator added
+ * separately with `grant_secret` — the realistic case being a monorepo whose second component deploys
+ * from the same repo. That revocation is invisible until the other component's next deploy fails, so
+ * the union is read first. A lookup failure falls back to this component alone (the pre-existing
+ * behavior) and says so, rather than aborting a rotation the operator asked for.
+ */
+async function resolveGrants(transport: any, secretName: string, component: string): Promise<string[]> {
+	try {
+		const listed: any = await cliOperations({ ...transport, operation: 'list_secrets' }, true);
+		const row = listed?.secrets?.find((secret: any) => secret?.name === secretName);
+		const existing: string[] = Array.isArray(row?.grants) ? row.grants : [];
+		if (existing.length && !existing.includes(component)) {
+			console.log(chalk.gray(`  Keeping existing grant(s) on "${secretName}": ${existing.join(', ')}`));
+		}
+		return [...new Set([component, ...existing])];
+	} catch {
+		console.log(
+			chalk.yellow(
+				`Note: couldn't read existing grants for "${secretName}"; storing it granted to "${component}" only.`
+			)
+		);
+		return [component];
+	}
+}
+
 export async function deploySetup(req: any): Promise<void> {
 	// Every operation this flow issues rides the caller's connection context — the target, the
 	// explicitly passed credentials, the TLS strictness — so the seal is stored on the instance the
@@ -228,15 +257,15 @@ export async function deploySetup(req: any): Promise<void> {
 		provider === 'github'
 			? deriveGitSecretName(component, credentialKey)
 			: deriveRegistrySecretName(component, credentialKey);
-	await cliOperations({ ...transport, operation: 'set_secret', name: secretName, envelope, grants: [component] }, true);
+	const grants = await resolveGrants(transport, secretName, component);
+	await cliOperations({ ...transport, operation: 'set_secret', name: secretName, envelope, grants }, true);
 
 	// 6. Print the credentials reference the deploy should use.
 	credentialEntry.secret = secretName;
 	console.log(chalk.green(`\n✓ Sealed "${credentialKey}" credential and stored it as secret "${secretName}".`));
 	console.log(chalk.gray("  It was encrypted here with the cluster's public key — only ciphertext was sent."));
-	console.log(
-		chalk.gray(`  Granted to component "${component}"; the cluster decrypts it only at deploy/rollback time.`)
-	);
+	const grantSummary = grants.length > 1 ? `components ${grants.map((g) => `"${g}"`).join(', ')}` : `component "${component}"`;
+	console.log(chalk.gray(`  Granted to ${grantSummary}; the cluster decrypts it only at deploy/rollback time.`));
 	console.log('\nUse it in your deploy:');
 	console.log(chalk.cyan(`  credentials='${JSON.stringify([credentialEntry])}'`));
 	if (provider === 'github') {

--- a/bin/deploySetup.ts
+++ b/bin/deploySetup.ts
@@ -15,43 +15,28 @@
 //   3. encryptEnvelope(...)     → seal it locally into an `enc:v1:` envelope (pure client-side crypto)
 //   4. set_secret {envelope}    → store ciphertext, granted to the component
 //   5. print the `credentials` reference the deploy should use
+//
+// Every name this flow derives — the component it grants to, the host it labels the credential with,
+// the hdb_secret row it writes — has to match what the deploy will derive from its own request, or it
+// seals a credential the deploy cannot use. Those derivations therefore come from
+// utility/componentNames.ts, the one module both this client and the server's deploy path use.
 
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 import { execFileSync } from 'node:child_process';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import { cliOperations } from './cliOperations.ts';
+import { cliOperations, transportContext } from './cliOperations.ts';
 import { encryptEnvelope } from '../utility/secretEnvelope.ts';
 import { ENV_ENCRYPTED_PREFIX } from '../utility/envFile.ts';
-
-// Mirror the server's derived secret names (secretOperations.ts `deriveRegistrySecretName` and
-// `deriveGitSecretName`) EXACTLY, so a `deploy setup` seal and a later literal-token deploy overwrite
-// the SAME hdb_secret row. git hosts get a `.git.` segment (and normalizeGitHost handling); registries
-// don't — without the segment, a git and a registry credential for the same host would collide.
-export function deriveSecretName(component: string, key: string, provider: string): string {
-	const componentPart = String(component).replace(/[^\w.-]+/g, '_');
-	if (provider === 'github') {
-		// mirrors gitCredentialServer.normalizeGitHost() + deriveGitSecretName's `.git.` segment
-		const hostPart = key
-			.trim()
-			.replace(/^[a-z0-9+.-]+:\/\//i, '')
-			.replace(/^\/\//, '')
-			.replace(/\/.*$/, '')
-			.replace(/^[^@]*@/, '')
-			.toLowerCase()
-			.replace(/[^\w.-]+/g, '_');
-		return `deploy.${componentPart}.git.${hostPart}`;
-	}
-	const registryPart = key
-		.trim()
-		.replace(/^https?:\/\//i, '')
-		.replace(/^\/\//, '')
-		.replace(/\/+$/, '')
-		.toLowerCase()
-		.replace(/[^\w.-]+/g, '_');
-	return `deploy.${componentPart}.${registryPart}`;
-}
+import {
+	canonicalProjectName,
+	deriveGitSecretName,
+	deriveRegistrySecretName,
+	directoryProjectName,
+	normalizeGitHost,
+	projectNameFromPackage,
+	GIT_HOST_PATTERN,
+	PROJECT_NAME_PATTERN,
+} from '../utility/componentNames.ts';
 
 function tryCommand(command: string, args: string[]): string {
 	try {
@@ -61,22 +46,55 @@ function tryCommand(command: string, args: string[]): string {
 	}
 }
 
-function defaultComponentName(): string {
-	try {
-		const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
-		if (typeof pkg.name === 'string' && pkg.name.length > 0) return pkg.name.replace(/^@[^/]+\//, '');
-	} catch {
-		// no package.json — fall back to the directory name
+/**
+ * The component (project) the credential is granted to, resolved the way `deploy_component` resolves
+ * the project it deploys: an explicit `project` canonicalized (`@scope/app` deploys as `app`),
+ * otherwise the name a `package` spec implies. Undefined when the request names neither — the caller
+ * prompts, defaulting to the same directory name a `harper deploy` from here would send.
+ *
+ * The grant has to name the project the later deploy actually runs as: `resolveCredentials` rejects a
+ * secret that isn't granted to it, so a name resolved any other way here seals a credential the
+ * deploy refuses to use.
+ */
+export function resolveComponentName(req: any): string | undefined {
+	if (typeof req.project === 'string' && req.project) return canonicalProjectName(req.project);
+	// Not canonicalized further, matching the server: a package-derived name is used as-is, so a spec
+	// that yields an unusable one (`…/repo.git` → `repo.git`) fails the grammar check below here rather
+	// than at deploy time.
+	if (typeof req.package === 'string' && req.package) return projectNameFromPackage(req.package);
+	return undefined;
+}
+
+/**
+ * The canonical bare host for a git credential — `https://github.com/owner/repo` and
+ * `git@github.com` both identify `github.com`. Resolved once and then used for everything the host
+ * decides: which `gh` account token is read, the derived secret name, and the `host` on the printed
+ * credentials entry. Without that, `host=ghe.example.com` would label (and store) the *default*
+ * host's `gh` token for the enterprise host, and a later deploy would hand a github.com credential to
+ * ghe.example.com.
+ *
+ * Anything still outside the deploy schema's `host` grammar after normalization is rejected here,
+ * rather than sealed into a credential entry the deploy would refuse.
+ */
+export function resolveGitHost(host: unknown): string {
+	const normalized = typeof host === 'string' ? normalizeGitHost(host) : '';
+	if (!GIT_HOST_PATTERN.test(normalized)) {
+		throw new Error(`Invalid git host ${JSON.stringify(host)} — expected a bare host, e.g. 'github.com'.`);
 	}
-	return path.basename(process.cwd());
+	return normalized;
 }
 
 export async function deploySetup(req: any): Promise<void> {
-	// 1. Fetch the cluster's public secrets key. Target + auth are resolved by cliOperations exactly
-	// as they are for a deploy (harper login, or CLI_TARGET + HARPER_CLI_USERNAME/PASSWORD).
+	// Every operation this flow issues rides the caller's connection context — the target, the
+	// explicitly passed credentials, the TLS strictness — so the seal is stored on the instance the
+	// user is talking to, as the identity they authenticated as. Only those fields carry over; the
+	// deploy args that brought us here (`setup`, `token`, `package`) never reach either body.
+	const transport = transportContext(req);
+
+	// 1. Fetch the cluster's public secrets key.
 	let keyResponse: any;
 	try {
-		keyResponse = await cliOperations({ operation: 'get_secrets_public_key', target: req.target }, true);
+		keyResponse = await cliOperations({ ...transport, operation: 'get_secrets_public_key' }, true);
 	} catch (error) {
 		throw new Error(
 			`Could not fetch the cluster's secrets public key: ${error instanceof Error ? error.message : String(error)}`
@@ -111,27 +129,35 @@ export async function deploySetup(req: any): Promise<void> {
 	}
 
 	// 3. Which component is the credential for? (the grant is scoped to it)
-	const component: string =
-		req.project ??
-		req.component ??
-		(
-			await inquirer.prompt({
-				type: 'input',
-				name: 'component',
-				message: 'Component (project) name this credential is for:',
-				default: defaultComponentName(),
-			})
-		).component;
+	const component =
+		resolveComponentName(req) ??
+		canonicalProjectName(
+			(
+				await inquirer.prompt({
+					type: 'input',
+					name: 'project',
+					message: 'Component (project) name this credential is for:',
+					default: directoryProjectName(),
+				})
+			).project ?? ''
+		);
+	if (!PROJECT_NAME_PATTERN.test(component)) {
+		throw new Error(
+			`"${component}" is not a usable component name — a deploy accepts letters, numbers, dashes and underscores.`
+		);
+	}
 
 	let credentialKey: string; // host (github) or registry (npm) — the credentials-entry discriminator
 	let credentialEntry: Record<string, string>;
 	let token: string | undefined = req.token;
 
 	if (provider === 'github') {
-		const host = req.host ?? 'github.com';
+		const host = resolveGitHost(req.host ?? 'github.com');
 		credentialKey = host;
 		if (!token) {
-			const ghToken = tryCommand('gh', ['auth', 'token']);
+			// Bound to the host being provisioned: `gh auth token` with no `--hostname` returns whichever
+			// host gh considers default, which for a GHE host is the wrong account's token.
+			const ghToken = tryCommand('gh', ['auth', 'token', '--hostname', host]);
 			// A fine-grained PAT is offered FIRST, and is therefore the default selection. What gets
 			// sealed here is durable and replayed on every cold deploy and rollback, so it should be
 			// the narrowest credential that does the job — one repo, Contents: Read-only. A `gh` CLI
@@ -141,8 +167,10 @@ export async function deploySetup(req: any): Promise<void> {
 			const choices: Array<{ name: string; value: string }> = [
 				{ name: 'Paste a fine-grained PAT (Contents: Read-only on this repo) — recommended', value: 'paste' },
 			];
+			// Offered only when gh actually holds a token for *this* host, so choosing it can't fall back
+			// to another host's credential.
 			if (ghToken) {
-				choices.push({ name: 'Use your gh CLI session token (broad account scopes)', value: 'gh' });
+				choices.push({ name: `Use your gh CLI session token for ${host} (broad account scopes)`, value: 'gh' });
 			}
 			const how =
 				choices.length === 1
@@ -167,7 +195,7 @@ export async function deploySetup(req: any): Promise<void> {
 			} else {
 				console.log(
 					chalk.gray(
-						'Create one at https://github.com/settings/personal-access-tokens/new\n' +
+						`Create one at https://${host}/settings/personal-access-tokens/new\n` +
 							'  Repository access → only your repo; Permissions → Contents: Read-only.'
 					)
 				);
@@ -177,7 +205,7 @@ export async function deploySetup(req: any): Promise<void> {
 		}
 		credentialEntry = { host };
 	} else {
-		const registry = req.registry ?? 'registry.npmjs.org';
+		const registry = typeof req.registry === 'string' && req.registry ? req.registry : 'registry.npmjs.org';
 		credentialKey = registry;
 		if (!token) {
 			console.log(chalk.gray('Tip: `npm token create --read-only` mints a granular npm token from the CLI.'));
@@ -193,12 +221,14 @@ export async function deploySetup(req: any): Promise<void> {
 	// 4. Seal the token locally. Only ciphertext leaves this machine.
 	const envelope = ENV_ENCRYPTED_PREFIX + encryptEnvelope(token, publicKey, fingerprint);
 
-	// 5. Store the sealed token, granted to the component. The server never sees the plaintext.
-	const secretName = deriveSecretName(component, credentialKey, provider);
-	await cliOperations(
-		{ operation: 'set_secret', name: secretName, envelope, grants: [component], target: req.target },
-		true
-	);
+	// 5. Store the sealed token, granted to the component. The server never sees the plaintext. The
+	// derived name is the one the server's literal-token path would use for the same component and
+	// host/registry, so re-running this rotates the same row rather than piling up a second one.
+	const secretName =
+		provider === 'github'
+			? deriveGitSecretName(component, credentialKey)
+			: deriveRegistrySecretName(component, credentialKey);
+	await cliOperations({ ...transport, operation: 'set_secret', name: secretName, envelope, grants: [component] }, true);
 
 	// 6. Print the credentials reference the deploy should use.
 	credentialEntry.secret = secretName;

--- a/bin/deploySetup.ts
+++ b/bin/deploySetup.ts
@@ -94,7 +94,7 @@ export function resolveGitHost(host: unknown): string {
  * the union is read first. A lookup failure falls back to this component alone (the pre-existing
  * behavior) and says so, rather than aborting a rotation the operator asked for.
  */
-async function resolveGrants(transport: any, secretName: string, component: string): Promise<string[]> {
+export async function resolveGrants(transport: any, secretName: string, component: string): Promise<string[]> {
 	try {
 		const listed: any = await cliOperations({ ...transport, operation: 'list_secrets' }, true);
 		const row = listed?.secrets?.find((secret: any) => secret?.name === secretName);

--- a/bin/deploySetup.ts
+++ b/bin/deploySetup.ts
@@ -264,7 +264,8 @@ export async function deploySetup(req: any): Promise<void> {
 	credentialEntry.secret = secretName;
 	console.log(chalk.green(`\n✓ Sealed "${credentialKey}" credential and stored it as secret "${secretName}".`));
 	console.log(chalk.gray("  It was encrypted here with the cluster's public key — only ciphertext was sent."));
-	const grantSummary = grants.length > 1 ? `components ${grants.map((g) => `"${g}"`).join(', ')}` : `component "${component}"`;
+	const grantSummary =
+		grants.length > 1 ? `components ${grants.map((g) => `"${g}"`).join(', ')}` : `component "${component}"`;
 	console.log(chalk.gray(`  Granted to ${grantSummary}; the cluster decrypts it only at deploy/rollback time.`));
 	console.log('\nUse it in your deploy:');
 	console.log(chalk.cyan(`  credentials='${JSON.stringify([credentialEntry])}'`));

--- a/bin/harper.ts
+++ b/bin/harper.ts
@@ -177,6 +177,14 @@ async function harper() {
 				await deploySetup(cliApiOp);
 				return;
 			}
+			// A `token=` that didn't reach the setup flow is a mistyped invocation, not a deploy field —
+			// `harper deploy setup token=…` (no `=true`) parses `setup` as a bare word that buildRequest
+			// drops, so it would otherwise proceed as an ordinary deploy carrying a live credential it has
+			// no use for. Refuse rather than deploy: the token is redacted and never sent either way, but
+			// silently ignoring it would leave the user believing a credential was provisioned.
+			if (cliApiOp.operation === 'deploy_component' && cliApiOp.token !== undefined) {
+				throw new Error('`token=` is only valid with `setup=true` — did you mean `harper deploy setup=true`?');
+			}
 			logger.trace('calling cli operations with:', cliOperations.redactCredentials(cliApiOp));
 			await cliOperations.cliOperations(cliApiOp);
 			return;

--- a/bin/harper.ts
+++ b/bin/harper.ts
@@ -170,6 +170,13 @@ async function harper() {
 			return require('./run').main();
 		default:
 			const cliApiOp = cliOperations.buildRequest();
+			// `harper deploy setup=true` provisions an encrypted deploy credential (client-side sealed
+			// token) rather than deploying — an interactive flow, not a single operation call.
+			if (cliApiOp.operation === 'deploy_component' && cliApiOp.setup) {
+				const { deploySetup } = require('./deploySetup');
+				await deploySetup(cliApiOp);
+				return;
+			}
 			logger.trace('calling cli operations with:', cliOperations.redactCredentials(cliApiOp));
 			await cliOperations.cliOperations(cliApiOp);
 			return;

--- a/bin/harper.ts
+++ b/bin/harper.ts
@@ -183,7 +183,12 @@ async function harper() {
 			// no use for. Refuse rather than deploy: the token is redacted and never sent either way, but
 			// silently ignoring it would leave the user believing a credential was provisioned.
 			if (cliApiOp.operation === 'deploy_component' && cliApiOp.token !== undefined) {
-				throw new Error('`token=` is only valid with `setup=true` — did you mean `harper deploy setup=true`?');
+				// statusCode so formatCliError prints this as a one-line hint rather than a stack trace —
+				// it's a typo, not a crash.
+				throw Object.assign(
+					new Error('`token=` is only valid with `setup=true` — did you mean `harper deploy setup=true`?'),
+					{ statusCode: 400 }
+				);
 			}
 			logger.trace('calling cli operations with:', cliOperations.redactCredentials(cliApiOp));
 			await cliOperations.cliOperations(cliApiOp);

--- a/components/gitCredentialServer.ts
+++ b/components/gitCredentialServer.ts
@@ -17,6 +17,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ClientError } from '../utility/errors/hdbError.ts';
 import logger from '../utility/logging/harper_logger.ts';
+import { normalizeGitHost } from '../utility/componentNames.ts';
 
 // GitHub's convention for authenticating a PAT over HTTPS: any non-empty username works, and
 // `x-access-token` is what its own tooling sends. GitLab wants `oauth2` and Bitbucket
@@ -45,16 +46,9 @@ export interface GitCredentialSession {
 	close(): Promise<void>;
 }
 
-/** `https://github.com/` / `GitHub.com` / `github.com/` all identify the same host. */
-export function normalizeGitHost(host: string): string {
-	return host
-		.trim()
-		.replace(/^[a-z0-9+.-]+:\/\//i, '')
-		.replace(/^\/\//, '')
-		.replace(/\/.*$/, '')
-		.replace(/^[^@]*@/, '')
-		.toLowerCase();
-}
+// Re-exported from its shared home (utility/componentNames.ts): the CLI's `deploy setup` flow has to
+// canonicalize a host exactly as this server does, and can't import from components/.
+export { normalizeGitHost };
 
 // A loopback remote never puts the credential on a network, so plaintext http to one is not a
 // disclosure. Anything else must be encrypted.

--- a/components/operations.js
+++ b/components/operations.js
@@ -19,6 +19,7 @@ const {
 	upsertEnvValues,
 	removeEnvKeys,
 } = require('../utility/envFile.ts');
+const { canonicalProjectName, projectNameFromPackage } = require('../utility/componentNames.ts');
 const { handleHDBError, ServerError, hdbErrors } = require('../utility/errors/hdbError.ts');
 const { HDB_ERROR_MSGS, HTTP_STATUS_CODES } = hdbErrors;
 const manageThreads = require('../server/threads/manageThreads.js');
@@ -107,7 +108,7 @@ function getCustomFunctions() {
  */
 function getCustomFunction(req) {
 	if (req.project) {
-		req.project = path.parse(req.project).name;
+		req.project = canonicalProjectName(req.project);
 	}
 
 	if (req.file) {
@@ -145,7 +146,7 @@ function getCustomFunction(req) {
  */
 async function setCustomFunction(req) {
 	if (req.project) {
-		req.project = path.parse(req.project).name;
+		req.project = canonicalProjectName(req.project);
 	}
 
 	if (req.file) {
@@ -185,7 +186,7 @@ async function setCustomFunction(req) {
  */
 async function dropCustomFunction(req) {
 	if (req.project) {
-		req.project = path.parse(req.project).name;
+		req.project = canonicalProjectName(req.project);
 	}
 
 	if (req.file) {
@@ -224,7 +225,7 @@ async function dropCustomFunction(req) {
  */
 async function addComponent(req) {
 	if (req.project) {
-		req.project = path.parse(req.project).name;
+		req.project = canonicalProjectName(req.project);
 	}
 
 	const validation = validator.addComponentValidator(req);
@@ -273,7 +274,7 @@ async function addComponent(req) {
  */
 async function dropCustomFunctionProject(req) {
 	if (req.project) {
-		req.project = path.parse(req.project).name;
+		req.project = canonicalProjectName(req.project);
 	}
 
 	const validation = validator.dropCustomFunctionProjectValidator(req);
@@ -328,7 +329,7 @@ async function dropCustomFunctionProject(req) {
  */
 async function packageComponent(req) {
 	if (req.project) {
-		req.project = path.parse(req.project).name;
+		req.project = canonicalProjectName(req.project);
 	}
 
 	const validation = validator.packageComponentValidator(req);
@@ -367,9 +368,9 @@ async function packageComponent(req) {
  */
 async function deployComponent(req) {
 	if (req.project) {
-		req.project = path.parse(req.project).name;
+		req.project = canonicalProjectName(req.project);
 	} else if (req.package) {
-		req.project = getProjectNameFromPackage(req.package);
+		req.project = projectNameFromPackage(req.package);
 	}
 
 	const validation = validator.deployComponentValidator(req);
@@ -802,32 +803,6 @@ function isSystemDatabaseReplicated() {
 	// Unknown shape — be conservative and assume not replicated rather than risking a
 	// strip that strands peers.
 	return false;
-}
-
-/**
- * Extracts a project name from the specified package name or URL
- * @param {string} pkg - Package name or URL
- * @returns {string} The project name
- */
-function getProjectNameFromPackage(pkg) {
-	if (pkg.startsWith('git+ssh://')) {
-		return path.basename(pkg.split('#')[0].replace(/\.git$/, ''));
-	}
-
-	if (pkg.startsWith('http://') || pkg.startsWith('https://')) {
-		return path.basename(new URL(pkg.replace(/\.git$/, '')).pathname);
-	}
-
-	if (pkg.startsWith('file://')) {
-		try {
-			const { name } = JSON.parse(fs.readFileSync(path.join(pkg, 'package.json'), 'utf8'));
-			return path.basename(name);
-		} catch {
-			//
-		}
-	}
-
-	return path.basename(pkg);
 }
 
 /**

--- a/components/operationsValidation.js
+++ b/components/operationsValidation.js
@@ -10,9 +10,10 @@ const configUtils = require('../config/configUtils.ts');
 const { hdbErrors } = require('../utility/errors/hdbError.ts');
 const { HDB_ERROR_MSGS } = hdbErrors;
 const { ENV_ENCRYPTED_PREFIX } = require('../utility/envFile.ts');
-
-// File name can only be alphanumeric, dash and underscores
-const PROJECT_FILE_NAME_REGEX = /^[a-zA-Z0-9-_]+$/;
+// File and project names can only be alphanumeric, dash and underscores. Both patterns are shared
+// with the CLI (utility/componentNames.ts): `harper deploy setup=true` resolves a project name and a
+// credential host client-side, and has to reject exactly what these schemas would.
+const { PROJECT_NAME_PATTERN: PROJECT_FILE_NAME_REGEX, GIT_HOST_PATTERN } = require('../utility/componentNames.ts');
 
 // dotenv's accepted key character set. Restricting keys to this prevents a crafted key (e.g. one
 // containing `=` or a newline) from injecting extra assignments into a .env file.
@@ -413,7 +414,7 @@ const GIT_CREDENTIAL_ENTRY = Joi.object({
 	// A bare host, optionally with a port — `github.com`, `git.example.com:8443`. A scheme or path is
 	// tolerated and normalized away, but a credential is matched by host, so keep the grammar tight.
 	host: Joi.string()
-		.pattern(/^[^\s/@\\]+$/)
+		.pattern(GIT_HOST_PATTERN)
 		.required()
 		.messages({ 'string.pattern.base': `'host' must be a bare git host, e.g. 'github.com'` }),
 	// The username half of git's HTTPS basic auth. Defaults to GitHub's `x-access-token` convention;

--- a/components/secretOperations.ts
+++ b/components/secretOperations.ts
@@ -23,7 +23,8 @@ import * as validator from './operationsValidation.js';
 import { getSecretCustody } from '../resources/secretDecryptor.ts';
 import { encryptEnvelope, parseEnvelopeFields } from '../utility/secretEnvelope.ts';
 import { ENV_ENCRYPTED_PREFIX } from '../utility/envFile.ts';
-import { normalizeGitHost, type ResolvedGitCredential } from './gitCredentialServer.ts';
+import { type ResolvedGitCredential } from './gitCredentialServer.ts';
+import { deriveGitSecretName, deriveRegistrySecretName } from '../utility/componentNames.ts';
 
 const { HTTP_STATUS_CODES } = hdbErrors;
 const SECRET_TABLE = terms.SYSTEM_TABLE_NAMES.SECRET_TABLE_NAME;
@@ -361,39 +362,10 @@ export function isRegistryCredential(entry: any): boolean {
 	return entry?.registry !== undefined;
 }
 
-/**
- * Deterministic name for the auto-minted secret backing a literal registry token: keyed by the
- * deploying component and the registry, so re-supplying (or rotating) the token on a later deploy
- * overwrites the same row rather than accumulating one per deploy. Sanitized to the set_secret name
- * grammar (`\w.-`), since a registry can carry a scheme, port, or path.
- */
-export function deriveRegistrySecretName(component: string, registry: string): string {
-	const registryKey = registry
-		.trim()
-		.replace(/^https?:\/\//i, '')
-		.replace(/^\/\//, '')
-		.replace(/\/+$/, '')
-		.toLowerCase()
-		.replace(/[^\w.-]+/g, '_');
-	const componentKey = String(component).replace(/[^\w.-]+/g, '_');
-	return `deploy.${componentKey}.${registryKey}`;
-}
-
-/**
- * Deterministic name for the secret backing a literal git-host token, following the registry
- * convention above but with a `git` kind segment: a registry entry accepts a bare host too, so
- * without a distinguishing segment a git and a registry credential for the same host would derive
- * the same name and silently overwrite each other's secret. Keyed by host rather than by
- * repository: the credential entry identifies itself by host, so the name has to be derivable from
- * the entry alone for a rotation to overwrite the same row. A per-repository credential is
- * expressible today by scoping the token itself (a fine-grained PAT) rather than by splitting the
- * secret name.
- */
-export function deriveGitSecretName(component: string, host: string): string {
-	const hostKey = normalizeGitHost(host).replace(/[^\w.-]+/g, '_');
-	const componentKey = String(component).replace(/[^\w.-]+/g, '_');
-	return `deploy.${componentKey}.git.${hostKey}`;
-}
+// Re-exported from their shared home (utility/componentNames.ts): `harper deploy setup=true` seals a
+// credential client-side and has to land on the same hdb_secret row this module's literal-token path
+// would, so the derivations can't live behind this module's server-side dependencies.
+export { deriveGitSecretName, deriveRegistrySecretName };
 
 /**
  * An entry's kind, from its identifying key. Every path that rebuilds an entry goes through this, so

--- a/server/serverHelpers/serverUtilities.ts
+++ b/server/serverHelpers/serverUtilities.ts
@@ -93,7 +93,9 @@ export async function processLocalTransaction(req: OperationRequest, operationFu
 			// stripped, since this runs ahead of the validation that now rejects it, and a stale
 			// caller's token must not reach the log); value/values carry .env secrets from
 			// set_env_value; value/envelope carry secrets from set_secret — none may reach the
-			// operations log.
+			// operations log. `token` is stripped defensively: no operation declares one at the top
+			// level today, but validation allows unknown keys, so a caller that sends one anyway (a
+			// mistyped `harper deploy setup token=…`) would otherwise log a live credential.
 			/* eslint-disable no-unused-vars, @typescript-eslint/no-unused-vars */
 			const {
 				hdb_user,
@@ -105,6 +107,7 @@ export async function processLocalTransaction(req: OperationRequest, operationFu
 				value,
 				values,
 				envelope,
+				token,
 				...cleanBody
 			} = req.body;
 			/* eslint-enable no-unused-vars, @typescript-eslint/no-unused-vars */

--- a/unitTests/bin/cliOperations.test.js
+++ b/unitTests/bin/cliOperations.test.js
@@ -810,6 +810,42 @@ describe('cliOperations', () => {
 		});
 	});
 
+	// `deploy setup=true` introduced `token=` as an arg carrying a durable PAT. A mistyped invocation
+	// (`harper deploy setup token=…` — bare `setup` is dropped by buildRequest) falls through to an
+	// ordinary deploy, so the token must not be loggable or serializable on ANY path, not just the
+	// setup one.
+	describe('token= is never logged or sent', () => {
+		it('redacts token in the parsed-request trace log', () => {
+			const redacted = cliOperationsModule.redactCredentials({
+				operation: 'deploy_component',
+				project: 'web',
+				token: 'github_pat_11ABCDE_secret',
+			});
+			assert.strictEqual(redacted.token, '***');
+			assert.strictEqual(redacted.project, 'web', 'non-secret fields still readable in the log');
+		});
+
+		it('strips token from the operation body sent to the server', async () => {
+			saveCredentials('https://example.com:9925/', { operation_token: 'valid-token', refresh_token: 'r' });
+			tokenAuthModule.isJWTExpired = () => false;
+
+			let sentBody;
+			commonUtilsModule.httpRequest = async (_options, body) => {
+				sentBody = body;
+				return { statusCode: 200, body: JSON.stringify({ success: true }) };
+			};
+
+			await cliOperationsModule.cliOperations(
+				{ operation: 'set_secret', name: 'deploy.web.git.github.com', token: 'github_pat_11ABCDE_secret' },
+				true
+			);
+
+			assert.ok(sentBody, 'request body was captured');
+			assert.strictEqual(sentBody.token, undefined, 'token must not reach the wire as an operation field');
+			assert.strictEqual(sentBody.name, 'deploy.web.git.github.com', 'real operation fields still sent');
+		});
+	});
+
 	describe('transportContext', () => {
 		// `harper deploy setup=true` issues get_secrets_public_key + set_secret on the caller's behalf.
 		// Dropping the explicit credentials would silently perform (and audit) those mutations as

--- a/unitTests/bin/cliOperations.test.js
+++ b/unitTests/bin/cliOperations.test.js
@@ -810,6 +810,37 @@ describe('cliOperations', () => {
 		});
 	});
 
+	describe('transportContext', () => {
+		// `harper deploy setup=true` issues get_secrets_public_key + set_secret on the caller's behalf.
+		// Dropping the explicit credentials would silently perform (and audit) those mutations as
+		// whoever the saved login token is; dropping rejectUnauthorized would fail a self-signed target.
+		it('carries the connection fields and nothing else', () => {
+			assert.deepStrictEqual(
+				cliOperationsModule.transportContext({
+					operation: 'deploy_component',
+					setup: true,
+					token: 'ghp_secret',
+					package: 'github:owner/repo',
+					json: true,
+					target: 'https://example.com:9925',
+					auth_username: 'admin',
+					auth_password: 'pw',
+					rejectUnauthorized: false,
+				}),
+				{
+					target: 'https://example.com:9925',
+					auth_username: 'admin',
+					auth_password: 'pw',
+					rejectUnauthorized: false,
+				}
+			);
+		});
+
+		it('omits fields the caller did not supply, so normal resolution (env vars, saved token) still applies', () => {
+			assert.deepStrictEqual(cliOperationsModule.transportContext({ operation: 'set_secret' }), {});
+		});
+	});
+
 	describe('operation timeout selection', () => {
 		const target = 'https://example.com:9925/';
 

--- a/unitTests/bin/deploySetup.test.js
+++ b/unitTests/bin/deploySetup.test.js
@@ -33,6 +33,36 @@ describe('deploySetup', () => {
 			const { directoryProjectName } = require('#src/utility/componentNames');
 			assert.strictEqual(directoryProjectName(), path.basename(process.cwd()));
 		});
+
+		// The seal is granted to the name setup resolves; `deploy by_ref=true` asks for a secret named
+		// after the project IT resolves. If the two defaults disagree, resolveCredentials rejects the
+		// stored secret as not granted — so they must agree even where a checkout directory and its
+		// package.json name differ, which is exactly the case that used to diverge.
+		it("agrees with prepareDeployByRef's project default, including when package.json disagrees", () => {
+			const fs = require('fs-extra');
+			const os = require('node:os');
+			const { prepareDeployByRef } = require('#src/bin/cliOperations');
+			const dir = path.join(os.tmpdir(), `harper-project-default-${process.pid}`, 'my-app-repo');
+			fs.ensureDirSync(dir);
+			fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: '@acme/my-app' }));
+			const cwd = process.cwd();
+			try {
+				process.chdir(dir);
+				const req = { operation: 'deploy_component', by_ref: true, ref: 'HEAD' };
+				try {
+					prepareDeployByRef(req);
+				} catch {
+					// Not a git repo — resolveGitTarget throws before setting `project`; resolve the default
+					// the same way it does instead, which is the agreement under test.
+					req.project = require('#src/utility/componentNames').directoryProjectName();
+				}
+				assert.strictEqual(req.project, 'my-app-repo', 'by_ref must not prefer the package.json name');
+				assert.strictEqual(req.project, resolveComponentName({ project: req.project }));
+			} finally {
+				process.chdir(cwd);
+				fs.removeSync(path.dirname(dir));
+			}
+		});
 	});
 
 	describe('resolveGitHost', () => {

--- a/unitTests/bin/deploySetup.test.js
+++ b/unitTests/bin/deploySetup.test.js
@@ -137,6 +137,24 @@ describe('deploySetup', () => {
 			);
 		});
 
+		// If the derived row already exists as a processEnv (global) secret, set_secret inherits that
+		// tier — so without this the pasted token lands in the tier every component and child process
+		// reads, and only then does grant_secret reject the row, reporting a failure it already
+		// committed. Sending `grants` used to mask it (the server rejects processEnv+grants before
+		// writing); omitting them for the merge removed that accident.
+		it('pins the credential to the scoped tier, so it cannot be written as a global secret', async () => {
+			stub({ grants: ['web'] });
+
+			await storeSealedSecret({}, SECRET, ENVELOPE, 'web');
+
+			const setSecret = calls.find((c) => c.operation === 'set_secret');
+			assert.strictEqual(
+				setSecret.processEnv,
+				false,
+				'inheriting a stored processEnv tier would publish this token globally'
+			);
+		});
+
 		it('grants this component in a second, idempotent call after the row exists', async () => {
 			stub({ name: SECRET, grants: ['web'], changed: true });
 

--- a/unitTests/bin/deploySetup.test.js
+++ b/unitTests/bin/deploySetup.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+// `deriveSecretName` must mirror the server's `deriveGitSecretName` / `deriveRegistrySecretName`
+// (components/secretOperations.ts) exactly, or a `harper deploy setup=true` seal and a literal-token
+// deploy would store the credential under different hdb_secret names. These cases lock that in so a
+// future drift on either side fails here instead of silently.
+const assert = require('node:assert');
+const { deriveSecretName } = require('#src/bin/deploySetup');
+
+describe('deploySetup deriveSecretName', () => {
+	it('github → deploy.<component>.git.<host> (matches server deriveGitSecretName)', () => {
+		assert.strictEqual(deriveSecretName('my-app', 'github.com', 'github'), 'deploy.my-app.git.github.com');
+	});
+
+	it('normalizes a git host: strips scheme, user, and path', () => {
+		assert.strictEqual(deriveSecretName('my-app', 'git@github.com', 'github'), 'deploy.my-app.git.github.com');
+		assert.strictEqual(
+			deriveSecretName('my-app', 'https://github.com/owner/repo', 'github'),
+			'deploy.my-app.git.github.com'
+		);
+	});
+
+	it('npm → deploy.<component>.<registry> (matches server deriveRegistrySecretName)', () => {
+		assert.strictEqual(deriveSecretName('my-app', 'registry.npmjs.org', 'npm'), 'deploy.my-app.registry.npmjs.org');
+		assert.strictEqual(
+			deriveSecretName('my-app', 'https://npm.pkg.github.com', 'npm'),
+			'deploy.my-app.npm.pkg.github.com'
+		);
+	});
+
+	it('sanitizes the component name to the set_secret grammar', () => {
+		assert.strictEqual(deriveSecretName('@scope/app', 'github.com', 'github'), 'deploy._scope_app.git.github.com');
+	});
+});

--- a/unitTests/bin/deploySetup.test.js
+++ b/unitTests/bin/deploySetup.test.js
@@ -1,34 +1,52 @@
 'use strict';
 
-// `deriveSecretName` must mirror the server's `deriveGitSecretName` / `deriveRegistrySecretName`
-// (components/secretOperations.ts) exactly, or a `harper deploy setup=true` seal and a literal-token
-// deploy would store the credential under different hdb_secret names. These cases lock that in so a
-// future drift on either side fails here instead of silently.
+// `harper deploy setup=true` grants the credential it seals to a component and labels it with a host.
+// Both have to come out the way the *deploy* will resolve them — a component the deploy doesn't run
+// as, or a host it wouldn't accept, seals a credential that can never be used. The derivations
+// themselves are covered in unitTests/utility/componentNames.test.js; these cases cover how this flow
+// resolves its inputs.
 const assert = require('node:assert');
-const { deriveSecretName } = require('#src/bin/deploySetup');
+const path = require('node:path');
+const { resolveComponentName, resolveGitHost } = require('#src/bin/deploySetup');
 
-describe('deploySetup deriveSecretName', () => {
-	it('github → deploy.<component>.git.<host> (matches server deriveGitSecretName)', () => {
-		assert.strictEqual(deriveSecretName('my-app', 'github.com', 'github'), 'deploy.my-app.git.github.com');
+describe('deploySetup', () => {
+	describe('resolveComponentName', () => {
+		it('canonicalizes an explicit project like deploy_component does', () => {
+			assert.strictEqual(resolveComponentName({ project: 'web' }), 'web');
+			// The server reduces `project` with path.parse().name, so a scoped name grants the bare one.
+			assert.strictEqual(resolveComponentName({ project: '@scope/app' }), 'app');
+		});
+
+		it('falls back to the project a package spec implies', () => {
+			assert.strictEqual(resolveComponentName({ package: 'github:owner/repo' }), 'repo');
+			assert.strictEqual(resolveComponentName({ project: 'web', package: 'github:owner/repo' }), 'web');
+		});
+
+		it('leaves the default to the caller when the request names neither', () => {
+			assert.strictEqual(resolveComponentName({}), undefined);
+			// A non-string arg (`project=5` is JSON-parsed to a number) is not a name; prompt instead of
+			// throwing inside path.parse.
+			assert.strictEqual(resolveComponentName({ project: 5 }), undefined);
+		});
+
+		it('matches the directory name a bare `harper deploy` from the same cwd would send', () => {
+			const { directoryProjectName } = require('#src/utility/componentNames');
+			assert.strictEqual(directoryProjectName(), path.basename(process.cwd()));
+		});
 	});
 
-	it('normalizes a git host: strips scheme, user, and path', () => {
-		assert.strictEqual(deriveSecretName('my-app', 'git@github.com', 'github'), 'deploy.my-app.git.github.com');
-		assert.strictEqual(
-			deriveSecretName('my-app', 'https://github.com/owner/repo', 'github'),
-			'deploy.my-app.git.github.com'
-		);
-	});
+	describe('resolveGitHost', () => {
+		it('canonicalizes to the bare host the credential entry carries', () => {
+			assert.strictEqual(resolveGitHost('github.com'), 'github.com');
+			assert.strictEqual(resolveGitHost('https://github.com/owner/repo'), 'github.com');
+			assert.strictEqual(resolveGitHost('git@ghe.example.com'), 'ghe.example.com');
+			assert.strictEqual(resolveGitHost('git.example.com:8443'), 'git.example.com:8443');
+		});
 
-	it('npm → deploy.<component>.<registry> (matches server deriveRegistrySecretName)', () => {
-		assert.strictEqual(deriveSecretName('my-app', 'registry.npmjs.org', 'npm'), 'deploy.my-app.registry.npmjs.org');
-		assert.strictEqual(
-			deriveSecretName('my-app', 'https://npm.pkg.github.com', 'npm'),
-			'deploy.my-app.npm.pkg.github.com'
-		);
-	});
-
-	it('sanitizes the component name to the set_secret grammar', () => {
-		assert.strictEqual(deriveSecretName('@scope/app', 'github.com', 'github'), 'deploy._scope_app.git.github.com');
+		it('rejects what the deploy schema would reject rather than sealing an unusable entry', () => {
+			for (const host of ['', '   ', 'git hub.com', 'a@b@c.com', undefined, 5]) {
+				assert.throws(() => resolveGitHost(host), /Invalid git host/, String(host));
+			}
+		});
 	});
 });

--- a/unitTests/bin/deploySetup.test.js
+++ b/unitTests/bin/deploySetup.test.js
@@ -7,8 +7,9 @@
 // resolves its inputs.
 const assert = require('node:assert');
 const path = require('node:path');
-const { resolveComponentName, resolveGitHost } = require('#src/bin/deploySetup');
+const { resolveComponentName, resolveGitHost, resolveGrants } = require('#src/bin/deploySetup');
 const { directoryProjectName } = require('#src/utility/componentNames');
+const cliOperationsModule = require('#src/bin/cliOperations');
 
 describe('deploySetup', () => {
 	describe('resolveComponentName', () => {
@@ -91,6 +92,73 @@ describe('deploySetup', () => {
 			for (const host of ['', '   ', 'git hub.com', 'a@b@c.com', undefined, 5]) {
 				assert.throws(() => resolveGitHost(host), /Invalid git host/, String(host));
 			}
+		});
+	});
+
+	// `set_secret` replaces grants rather than merging, so sending only this component on a rotation
+	// would silently revoke a grant an operator added with `grant_secret` — invisible until the other
+	// component's next deploy fails. Both branches are pinned: the union, and the lookup-failure
+	// fallback that still replaces (which is why it warns).
+	describe('resolveGrants', () => {
+		const SECRET = 'deploy.web.git.github.com';
+		let originalCliOperations;
+		let originalLog;
+		let logged;
+
+		beforeEach(() => {
+			originalCliOperations = cliOperationsModule.cliOperations;
+			originalLog = console.log;
+			logged = [];
+			console.log = (...args) => logged.push(args.join(' '));
+		});
+
+		afterEach(() => {
+			cliOperationsModule.cliOperations = originalCliOperations;
+			console.log = originalLog;
+		});
+
+		it("unions this component with the row's existing grants, so a rotation keeps them", async () => {
+			cliOperationsModule.cliOperations = async (req) => {
+				assert.strictEqual(req.operation, 'list_secrets');
+				return {
+					secrets: [
+						{ name: SECRET, grants: ['other-app'] },
+						{ name: 'unrelated', grants: ['nope'] },
+					],
+				};
+			};
+
+			const grants = await resolveGrants({ target: 'example.com' }, SECRET, 'web');
+
+			assert.deepStrictEqual([...grants].sort(), ['other-app', 'web']);
+			assert.ok(
+				logged.some((line) => line.includes('other-app')),
+				`should report the grant it preserved, got: ${JSON.stringify(logged)}`
+			);
+		});
+
+		it('does not duplicate the component when the row already grants it', async () => {
+			cliOperationsModule.cliOperations = async () => ({ secrets: [{ name: SECRET, grants: ['web'] }] });
+			assert.deepStrictEqual(await resolveGrants({}, SECRET, 'web'), ['web']);
+		});
+
+		it('sends only this component when the row does not exist yet', async () => {
+			cliOperationsModule.cliOperations = async () => ({ secrets: [] });
+			assert.deepStrictEqual(await resolveGrants({}, SECRET, 'web'), ['web']);
+		});
+
+		it('falls back to this component alone on a lookup failure, and says so', async () => {
+			cliOperationsModule.cliOperations = async () => {
+				throw new Error('list_secrets is not available');
+			};
+
+			const grants = await resolveGrants({}, SECRET, 'web');
+
+			assert.deepStrictEqual(grants, ['web']);
+			assert.ok(
+				logged.some((line) => line.includes(SECRET) && /couldn't read existing grants/i.test(line)),
+				`the replace is only acceptable if it's visible, got: ${JSON.stringify(logged)}`
+			);
 		});
 	});
 });

--- a/unitTests/bin/deploySetup.test.js
+++ b/unitTests/bin/deploySetup.test.js
@@ -8,6 +8,7 @@
 const assert = require('node:assert');
 const path = require('node:path');
 const { resolveComponentName, resolveGitHost } = require('#src/bin/deploySetup');
+const { directoryProjectName } = require('#src/utility/componentNames');
 
 describe('deploySetup', () => {
 	describe('resolveComponentName', () => {
@@ -30,7 +31,6 @@ describe('deploySetup', () => {
 		});
 
 		it('matches the directory name a bare `harper deploy` from the same cwd would send', () => {
-			const { directoryProjectName } = require('#src/utility/componentNames');
 			assert.strictEqual(directoryProjectName(), path.basename(process.cwd()));
 		});
 
@@ -41,26 +41,40 @@ describe('deploySetup', () => {
 		it("agrees with prepareDeployByRef's project default, including when package.json disagrees", () => {
 			const fs = require('fs-extra');
 			const os = require('node:os');
+			const { execFileSync } = require('node:child_process');
 			const { prepareDeployByRef } = require('#src/bin/cliOperations');
-			const dir = path.join(os.tmpdir(), `harper-project-default-${process.pid}`, 'my-app-repo');
+			// A real repo, so prepareDeployByRef runs its own resolution rather than us substituting a
+			// fallback — otherwise a regression back to the package.json name would still pass here.
+			const root = path.join(os.tmpdir(), `harper-project-default-${process.pid}`);
+			const dir = path.join(root, 'my-app-repo');
 			fs.ensureDirSync(dir);
 			fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: '@acme/my-app' }));
+			const git = (...args) => execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+			git('init', '-q');
+			git('config', 'user.email', 'test@example.com');
+			git('config', 'user.name', 'Test');
+			git('config', 'commit.gpgsign', 'false');
+			git('remote', 'add', 'origin', 'https://github.com/acme/my-app-repo.git');
+			git('add', 'package.json');
+			git('commit', '-qm', 'init');
+
 			const cwd = process.cwd();
+			const savedSha = process.env.GITHUB_SHA;
 			try {
+				delete process.env.GITHUB_SHA; // else the committish comes from the CI env, not this repo
 				process.chdir(dir);
-				const req = { operation: 'deploy_component', by_ref: true, ref: 'HEAD' };
-				try {
-					prepareDeployByRef(req);
-				} catch {
-					// Not a git repo — resolveGitTarget throws before setting `project`; resolve the default
-					// the same way it does instead, which is the agreement under test.
-					req.project = require('#src/utility/componentNames').directoryProjectName();
-				}
+				const req = { operation: 'deploy_component', by_ref: true };
+				prepareDeployByRef(req);
 				assert.strictEqual(req.project, 'my-app-repo', 'by_ref must not prefer the package.json name');
+				// The name setup would grant, for the same cwd, must be the name by_ref deploys under —
+				// otherwise resolveCredentials rejects the sealed secret as not granted.
+				assert.strictEqual(req.project, directoryProjectName());
 				assert.strictEqual(req.project, resolveComponentName({ project: req.project }));
 			} finally {
 				process.chdir(cwd);
-				fs.removeSync(path.dirname(dir));
+				if (savedSha === undefined) delete process.env.GITHUB_SHA;
+				else process.env.GITHUB_SHA = savedSha;
+				fs.removeSync(root);
 			}
 		});
 	});

--- a/unitTests/bin/deploySetup.test.js
+++ b/unitTests/bin/deploySetup.test.js
@@ -7,7 +7,7 @@
 // resolves its inputs.
 const assert = require('node:assert');
 const path = require('node:path');
-const { resolveComponentName, resolveGitHost, resolveGrants } = require('#src/bin/deploySetup');
+const { resolveComponentName, resolveGitHost, storeSealedSecret } = require('#src/bin/deploySetup');
 const { directoryProjectName } = require('#src/utility/componentNames');
 const cliOperationsModule = require('#src/bin/cliOperations');
 
@@ -95,70 +95,85 @@ describe('deploySetup', () => {
 		});
 	});
 
-	// `set_secret` replaces grants rather than merging, so sending only this component on a rotation
+	// `set_secret` REPLACES grants rather than merging, so sending `grants: [component]` on a rotation
 	// would silently revoke a grant an operator added with `grant_secret` — invisible until the other
-	// component's next deploy fails. Both branches are pinned: the union, and the lookup-failure
-	// fallback that still replaces (which is why it warns).
-	describe('resolveGrants', () => {
+	// component's next deploy fails. Omitting the field keeps the stored list under the server's own
+	// lock, and idempotent `grant_secret` adds this component. The protocol IS the fix, so it's what
+	// these cases pin.
+	describe('storeSealedSecret', () => {
 		const SECRET = 'deploy.web.git.github.com';
+		const ENVELOPE = 'enc:v1:abc';
 		let originalCliOperations;
-		let originalLog;
-		let logged;
+		let calls;
 
 		beforeEach(() => {
 			originalCliOperations = cliOperationsModule.cliOperations;
-			originalLog = console.log;
-			logged = [];
-			console.log = (...args) => logged.push(args.join(' '));
+			calls = [];
 		});
 
 		afterEach(() => {
 			cliOperationsModule.cliOperations = originalCliOperations;
-			console.log = originalLog;
 		});
 
-		it("unions this component with the row's existing grants, so a rotation keeps them", async () => {
+		function stub(grantResult) {
 			cliOperationsModule.cliOperations = async (req) => {
-				assert.strictEqual(req.operation, 'list_secrets');
-				return {
-					secrets: [
-						{ name: SECRET, grants: ['other-app'] },
-						{ name: 'unrelated', grants: ['nope'] },
-					],
-				};
+				calls.push(req);
+				return req.operation === 'grant_secret' ? grantResult : {};
 			};
+		}
 
-			const grants = await resolveGrants({ target: 'example.com' }, SECRET, 'web');
+		it('stores the envelope WITHOUT grants, so the server keeps any it already has', async () => {
+			stub({ name: SECRET, grants: ['web'], changed: true });
 
-			assert.deepStrictEqual([...grants].sort(), ['other-app', 'web']);
-			assert.ok(
-				logged.some((line) => line.includes('other-app')),
-				`should report the grant it preserved, got: ${JSON.stringify(logged)}`
+			await storeSealedSecret({ target: 'example.com' }, SECRET, ENVELOPE, 'web');
+
+			const setSecret = calls.find((c) => c.operation === 'set_secret');
+			assert.ok(setSecret, 'set_secret was called');
+			assert.strictEqual(setSecret.envelope, ENVELOPE);
+			assert.strictEqual(
+				'grants' in setSecret,
+				false,
+				'sending grants here would replace the stored list and revoke other components'
 			);
 		});
 
-		it('does not duplicate the component when the row already grants it', async () => {
-			cliOperationsModule.cliOperations = async () => ({ secrets: [{ name: SECRET, grants: ['web'] }] });
-			assert.deepStrictEqual(await resolveGrants({}, SECRET, 'web'), ['web']);
-		});
+		it('grants this component in a second, idempotent call after the row exists', async () => {
+			stub({ name: SECRET, grants: ['web'], changed: true });
 
-		it('sends only this component when the row does not exist yet', async () => {
-			cliOperationsModule.cliOperations = async () => ({ secrets: [] });
-			assert.deepStrictEqual(await resolveGrants({}, SECRET, 'web'), ['web']);
-		});
+			await storeSealedSecret({}, SECRET, ENVELOPE, 'web');
 
-		it('falls back to this component alone on a lookup failure, and says so', async () => {
-			cliOperationsModule.cliOperations = async () => {
-				throw new Error('list_secrets is not available');
-			};
-
-			const grants = await resolveGrants({}, SECRET, 'web');
-
-			assert.deepStrictEqual(grants, ['web']);
-			assert.ok(
-				logged.some((line) => line.includes(SECRET) && /couldn't read existing grants/i.test(line)),
-				`the replace is only acceptable if it's visible, got: ${JSON.stringify(logged)}`
+			assert.deepStrictEqual(
+				calls.map((c) => c.operation),
+				['set_secret', 'grant_secret'],
+				'grant_secret 404s if it runs before the row exists, so order matters'
 			);
+			const grant = calls[1];
+			assert.strictEqual(grant.name, SECRET);
+			assert.strictEqual(grant.component, 'web');
+		});
+
+		it("reports the server's full grant list, so a preserved grant is visible", async () => {
+			stub({ name: SECRET, grants: ['other-app', 'web'], changed: true });
+			assert.deepStrictEqual(await storeSealedSecret({}, SECRET, ENVELOPE, 'web'), ['other-app', 'web']);
+		});
+
+		it('falls back to this component for the summary when the response carries no grants', async () => {
+			stub({});
+			assert.deepStrictEqual(await storeSealedSecret({}, SECRET, ENVELOPE, 'web'), ['web']);
+		});
+
+		it('carries the caller transport context into both calls', async () => {
+			stub({ grants: ['web'] });
+			await storeSealedSecret(
+				{ target: 'https://example.com:9925', rejectUnauthorized: false },
+				SECRET,
+				ENVELOPE,
+				'web'
+			);
+			for (const call of calls) {
+				assert.strictEqual(call.target, 'https://example.com:9925', call.operation);
+				assert.strictEqual(call.rejectUnauthorized, false, call.operation);
+			}
 		});
 	});
 });

--- a/unitTests/utility/componentNames.test.js
+++ b/unitTests/utility/componentNames.test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+// These names are derived independently by the CLI (`harper deploy setup=true`) and by the server's
+// deploy path, so they live in one module and are locked down here. A change to any of them changes
+// which hdb_secret row a sealed credential lands in, or which project it is granted to.
+const assert = require('node:assert');
+const path = require('node:path');
+const {
+	canonicalProjectName,
+	deriveGitSecretName,
+	deriveRegistrySecretName,
+	directoryProjectName,
+	normalizeGitHost,
+	projectNameFromPackage,
+	GIT_HOST_PATTERN,
+	PROJECT_NAME_PATTERN,
+} = require('#src/utility/componentNames');
+
+describe('componentNames', () => {
+	describe('normalizeGitHost', () => {
+		it('reduces scheme, userinfo, path and case to a bare host', () => {
+			for (const input of [
+				'github.com',
+				'GitHub.com',
+				'github.com/',
+				'https://github.com',
+				'https://github.com/owner/repo',
+				'git@github.com',
+				'https://x-access-token@github.com/',
+			]) {
+				assert.strictEqual(normalizeGitHost(input), 'github.com', input);
+			}
+		});
+
+		it('keeps a port', () => {
+			assert.strictEqual(normalizeGitHost('git.example.com:8443'), 'git.example.com:8443');
+		});
+	});
+
+	describe('secret names', () => {
+		it('git → deploy.<component>.git.<host>', () => {
+			assert.strictEqual(deriveGitSecretName('my-app', 'github.com'), 'deploy.my-app.git.github.com');
+			assert.strictEqual(deriveGitSecretName('my-app', 'git@github.com'), 'deploy.my-app.git.github.com');
+			assert.strictEqual(
+				deriveGitSecretName('my-app', 'https://github.com/owner/repo'),
+				'deploy.my-app.git.github.com'
+			);
+		});
+
+		it('registry → deploy.<component>.<registry>', () => {
+			assert.strictEqual(deriveRegistrySecretName('my-app', 'registry.npmjs.org'), 'deploy.my-app.registry.npmjs.org');
+			assert.strictEqual(
+				deriveRegistrySecretName('my-app', 'https://npm.pkg.github.com/'),
+				'deploy.my-app.npm.pkg.github.com'
+			);
+		});
+
+		it('keeps a git and a registry credential for the same host in separate rows', () => {
+			assert.notStrictEqual(
+				deriveGitSecretName('app', 'npm.pkg.github.com'),
+				deriveRegistrySecretName('app', 'npm.pkg.github.com')
+			);
+		});
+
+		it('sanitizes both halves to the set_secret name grammar', () => {
+			assert.strictEqual(deriveGitSecretName('@scope/app', 'github.com'), 'deploy._scope_app.git.github.com');
+			assert.strictEqual(
+				deriveRegistrySecretName('app', 'registry.example.com:4873/path/'),
+				'deploy.app.registry.example.com_4873_path'
+			);
+		});
+	});
+
+	describe('project names', () => {
+		it('canonicalizes an explicit project the way deploy_component does', () => {
+			assert.strictEqual(canonicalProjectName('web'), 'web');
+			assert.strictEqual(canonicalProjectName('@scope/app'), 'app');
+			assert.strictEqual(canonicalProjectName('app.tgz'), 'app');
+		});
+
+		it('derives a project from a package spec', () => {
+			assert.strictEqual(projectNameFromPackage('github:owner/repo'), 'repo');
+			assert.strictEqual(projectNameFromPackage('git+ssh://git@github.com/owner/repo.git#abc123'), 'repo');
+			assert.strictEqual(projectNameFromPackage('https://github.com/owner/repo.git'), 'repo');
+		});
+
+		it('defaults a directory deploy to the directory name', () => {
+			assert.strictEqual(directoryProjectName(path.join('/tmp', 'checkout')), 'checkout');
+		});
+	});
+
+	describe('patterns', () => {
+		it('PROJECT_NAME_PATTERN accepts what a project-scoped operation accepts', () => {
+			for (const name of ['web', 'my-app', 'my_app', 'app2']) assert.ok(PROJECT_NAME_PATTERN.test(name), name);
+			for (const name of ['', '@scope/app', 'my.app', 'my app']) assert.ok(!PROJECT_NAME_PATTERN.test(name), name);
+		});
+
+		it('GIT_HOST_PATTERN accepts a bare host, with or without a port', () => {
+			for (const host of ['github.com', 'git.example.com:8443']) assert.ok(GIT_HOST_PATTERN.test(host), host);
+			for (const host of ['', 'https://github.com', 'github.com/owner', 'git@github.com', 'git hub.com'])
+				assert.ok(!GIT_HOST_PATTERN.test(host), host);
+		});
+	});
+});

--- a/utility/componentNames.ts
+++ b/utility/componentNames.ts
@@ -1,0 +1,107 @@
+'use strict';
+
+// The names a component deploy has to agree on across the CLI (`bin/`) and the server
+// (`components/`): the project (component) name a deploy resolves to, the canonical form of a git
+// host, and the hdb_secret names a deploy credential seals into.
+//
+// They live here, in one dependency-free module, because both sides derive them independently.
+// `harper deploy setup=true` seals a credential on the client and grants it to a project; the deploy
+// that later consumes it re-derives the secret name and the project from its own request. A
+// divergence is silent — the secret lands in a row the deploy never reads, or is granted to a project
+// the deploy isn't running as — so a second copy of any of these is a bug waiting on a future edit to
+// one side. Node builtins only, so the CLI can import it without pulling in the server's
+// databases/config surface.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/** Project (component) names accepted by the project-scoped operations: alphanumeric, dash, underscore. */
+export const PROJECT_NAME_PATTERN = /^[a-zA-Z0-9-_]+$/;
+
+/**
+ * A credential entry's `host`: a bare host, optionally with a port — `github.com`,
+ * `git.example.com:8443`. `normalizeGitHost` reduces most inputs to this form; anything still
+ * outside it (an embedded space, a second `@`) is rejected rather than guessed at.
+ */
+export const GIT_HOST_PATTERN = /^[^\s/@\\]+$/;
+
+/** `https://github.com/` / `GitHub.com` / `github.com/` all identify the same host. */
+export function normalizeGitHost(host: string): string {
+	return host
+		.trim()
+		.replace(/^[a-z0-9+.-]+:\/\//i, '')
+		.replace(/^\/\//, '')
+		.replace(/\/.*$/, '')
+		.replace(/^[^@]*@/, '')
+		.toLowerCase();
+}
+
+/**
+ * The canonical form of an explicitly named project: `@scope/app` and `app.tgz` both deploy as
+ * `app`. Every project-scoped operation reduces its `project` this way, so the CLI has to resolve the
+ * same name the server will when it grants a credential to one.
+ */
+export function canonicalProjectName(project: string): string {
+	return path.parse(project).name;
+}
+
+/** The project name a deploy derives from its `package` spec when no `project` was given. */
+export function projectNameFromPackage(pkg: string): string {
+	if (pkg.startsWith('git+ssh://')) {
+		return path.basename(pkg.split('#')[0].replace(/\.git$/, ''));
+	}
+
+	if (pkg.startsWith('http://') || pkg.startsWith('https://')) {
+		return path.basename(new URL(pkg.replace(/\.git$/, '')).pathname);
+	}
+
+	if (pkg.startsWith('file://')) {
+		try {
+			const { name } = JSON.parse(fs.readFileSync(path.join(pkg, 'package.json'), 'utf8'));
+			return path.basename(name);
+		} catch {
+			//
+		}
+	}
+
+	return path.basename(pkg);
+}
+
+/** The project name a directory deploy (`harper deploy` with no `package`) defaults to. */
+export function directoryProjectName(cwd: string = process.cwd()): string {
+	return path.basename(cwd);
+}
+
+/**
+ * Deterministic name for the auto-minted secret backing a literal registry token: keyed by the
+ * deploying component and the registry, so re-supplying (or rotating) the token on a later deploy
+ * overwrites the same row rather than accumulating one per deploy. Sanitized to the set_secret name
+ * grammar (`\w.-`), since a registry can carry a scheme, port, or path.
+ */
+export function deriveRegistrySecretName(component: string, registry: string): string {
+	const registryKey = registry
+		.trim()
+		.replace(/^https?:\/\//i, '')
+		.replace(/^\/\//, '')
+		.replace(/\/+$/, '')
+		.toLowerCase()
+		.replace(/[^\w.-]+/g, '_');
+	const componentKey = String(component).replace(/[^\w.-]+/g, '_');
+	return `deploy.${componentKey}.${registryKey}`;
+}
+
+/**
+ * Deterministic name for the secret backing a literal git-host token, following the registry
+ * convention above but with a `git` kind segment: a registry entry accepts a bare host too, so
+ * without a distinguishing segment a git and a registry credential for the same host would derive
+ * the same name and silently overwrite each other's secret. Keyed by host rather than by
+ * repository: the credential entry identifies itself by host, so the name has to be derivable from
+ * the entry alone for a rotation to overwrite the same row. A per-repository credential is
+ * expressible today by scoping the token itself (a fine-grained PAT) rather than by splitting the
+ * secret name.
+ */
+export function deriveGitSecretName(component: string, host: string): string {
+	const hostKey = normalizeGitHost(host).replace(/[^\w.-]+/g, '_');
+	const componentKey = String(component).replace(/[^\w.-]+/g, '_');
+	return `deploy.${componentKey}.git.${hostKey}`;
+}


### PR DESCRIPTION
**Ready for review** — no longer a draft/RFC. Implements #1778; part of the create-harper deploy-by-reference effort. Rebased on current `main`, with all review threads to date resolved.

`harper deploy setup=true` — a guided, client-side credential-provisioning flow (what `harper login` is for auth, but for deploy tokens):

1. `get_secrets_public_key` → the cluster's public key + fingerprint.
2. Source a token interactively — a pasted fine-grained PAT (Contents: Read-only, the recommended default), your `gh` CLI session token, or `npm token create` for a private registry.
3. `encryptEnvelope(...)` → seal it **locally** into an `enc:v1:` envelope (pure client-side crypto; the plaintext never leaves the machine).
4. `set_secret { envelope, processEnv: false }` → store only ciphertext, in the component-scoped tier; the cluster decrypts it in-memory only at deploy/rollback time.
5. `grant_secret { component }` → let the component resolve it. Two calls rather than one so the server merges grants under its own lock (see below).
6. Print the `credentials` reference the deploy uses.

Because the token is **durable** (unlike a CI `GITHUB_TOKEN`, revoked at job end), re-deploying an older ref later works without re-entering it. Rollback itself is credential-free in the common case — HarperFast/harper#1849's `revert_component` swaps to the retained previous build rather than re-fetching; the sealed token is only needed to re-fetch an *arbitrary* older ref. One flow unifies git-host (`{host, …}`) and npm-registry (`{registry, …}`) credentials.

**Where:** new `bin/deploySetup.ts` + a `harper deploy setup=true` intercept in `bin/harper.ts`. Builds on the `credentials` array (#1797), the git-host credential (#1799), and the `hdb_secret` client-side envelope (#1717); custody ships on by default (harper-pro#560).

## Where to look

**One derivation, shared with the server** (`utility/componentNames.ts`, new). Every name this flow derives has to match what the deploy re-derives from its own request, and a mismatch is silent — the seal lands in an `hdb_secret` row the deploy never reads, or is granted to a project it isn't running as. So host normalization, the `deploy.<component>[.git].<key>` secret names, project-name resolution and the project/host grammars live in one dependency-free module, consumed by `components/gitCredentialServer.ts`, `components/secretOperations.ts`, `components/operations.js`, `components/operationsValidation.js` and the CLI. The two `components/` modules re-export their previous names, so existing importers and their tests are unchanged, and `getProjectNameFromPackage` moved out of `operations.js` with its body unchanged (renamed, plus type annotations). This also removed the copy of `deriveGitSecretName` that `deploy by_ref=true` (#1850) had grown independently in `bin/cliOperations.ts` — verified byte-identical output across host/component spellings before swapping.

**`token=` is registered as secret-bearing** (`bin/cliOperations.ts`, `server/serverHelpers/serverUtilities.ts`). This PR introduced `token=` as an arg carrying a durable PAT. `harper deploy setup token=…` — bare `setup`, which `buildRequest` drops — falls through to an ordinary deploy, and the token was reaching `logger.trace` unredacted, the `deploy_component` body, and the server's operations log. Now in `SECRET_FIELDS` + `TRANSPORT_ONLY_FIELDS`, stripped server-side, and a top-level `token` on a deploy fails with a pointer to `setup=true` rather than silently deploying.

**Grants are merged by the server, not the client.** `set_secret` *replaces* grants, so sending `grants: [component]` on a rotation silently revoked a grant added separately with `grant_secret` (a monorepo's second component). Omitting the field keeps the stored list under `withSecretLock`; idempotent `grant_secret` follows. `processEnv: false` is explicit and load-bearing: without it, `set_secret` inherits a stored global tier and would write the pasted token where every component and child process reads it.

## Open for reviewers

**This changes #1850's deployed project name.** `prepareDeployByRef` resolved its own default via a `package.json`-preferring `defaultProjectName`; it now uses the shared `directoryProjectName`, so a by-reference deploy in a checkout whose directory and package name differ deploys under the directory name. I aligned that direction because only the directory default is common to all three deploy paths (npm-registry credentials are consumed by payload deploys too), but it is a behavior change to merged code and the #1850 author may want to weigh in.

Tests: `unitTests/utility/componentNames.test.js` (new), plus cases in `unitTests/bin/deploySetup.test.js` and `unitTests/bin/cliOperations.test.js` covering the two-call grant protocol, the scoped-tier pin, `token=` redaction and body-stripping, host canonicalization, and that setup's project default agrees with `prepareDeployByRef`'s.

Refs #1778, #1797, #1799.

## Related — deploy-by-reference effort

- `HarperFast/harper#1849` — two-phase stage/activate + `revert_component`
- `HarperFast/harper#1850` — `harper deploy by_ref=true` (deploy by git reference)
- `HarperFast/harper#1851` — `harper deploy setup=true` (client-side sealed deploy credential)
- `HarperFast/harper#1876` — CI token auth + `harper login --for-ci`
- `HarperFast/harper-pro#594` — `add_ssh_key generate=true` (cluster-side keygen)
- `HarperFast/create-harper#118` — scaffolds this flow
- `HarperFast/documentation#599` — two-phase deploy, revert, by-reference deploys, sealed credentials, `add_ssh_key generate`, OIDC (all v5.3.0)
- `HarperFast/documentation#630` — CI token credentials in the canonical auth precedence (v5.2.0, shipped; mergeable independently)
- `HarperFast/documentation#617` — `by_ref` ref pinning, `credential=true`, GitHub Actions behavior
- `HarperFast/documentation#616` — merged into #599's branch on 2026-07-30; its content now lives in the three PRs above

<sub>🤖 Description and implementation assisted by Claude Code (Opus 5).</sub>

