### PR TITLE
cherry-pick: replay conflict retry on a fresh transaction after ERR_TRY_AGAIN (#1696) (→ v5.1)

### DIFF
--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -89,6 +89,9 @@ export type TransactionWrite = {
 	// the commit handler's most recent decision: true means it took an early-return that left savedBlobs unreferenced.
 	// reset at the top of each commit-handler invocation so retries see a fresh state.
 	skipped?: boolean;
+	// sticky: a non-isRetry staging of this write appended its audit entry (set in save(); the retry
+	// dedup guards in the commit handler read it to ignore the write's own orphaned entry)
+	appendedAuditEntry?: boolean;
 };
 
 type RocksTransactionWithRetry = RocksTransaction & { isRetry?: boolean };
@@ -250,6 +253,14 @@ export class DatabaseTransaction implements Transaction {
 			if (result?.then) this.completions.push(result);
 		}
 		operation.commit(txnTime, operation.entry, this.retries > 0, transaction);
+		// Sticky record that THIS write staged with its audit entry appended (log entries are written
+		// at staging and are not part of the transaction, so they survive an abort). isRetry stagings
+		// skip the log write, so they never set it. The retry dedup guards in the commit handler key
+		// off this: a launderable proxy (like last attempt's skipped state) breaks under multi-round
+		// retries where a recommit round self-skips before a fresh-transaction replay.
+		if (!operation.skipped && !(transaction as RocksTransactionWithRetry).isRetry) {
+			operation.appendedAuditEntry = true;
+		}
 		if (immediateCommit) {
 			return this.commit({ transaction }); // immediately commit if the harper transaction is closed
 		}
@@ -397,6 +408,32 @@ export class DatabaseTransaction implements Transaction {
 								// for future transactions
 								this.retries++;
 								harperLogger.debug?.('retrying', transaction.id, this.retries);
+								if (error.code === 'ERR_TRY_AGAIN') {
+									// ERR_BUSY recovers on recommit: the save loop re-writes each key, re-tracking it at
+									// the current sequence, so validation passes once the contention clears. ERR_TRY_AGAIN
+									// never does: the memtable history validation needs is gone (flushed during a
+									// bulk-ingest burst), and recommitting re-checks the same stranded snapshot, so it
+									// fails forever even on an idle database. A source-apply transaction's uncapped retry
+									// then spins for good and wedges the replication apply loop at its commit await,
+									// freezing every leg of that database on the node. Replay onto a fresh transaction
+									// instead: the save loop reloads each entry through it and re-resolves against
+									// current state. Carry over the commit hook the transaction-log store attached
+									// (aftercommit emit / structure watermarks; it reads its state off the original
+									// transaction object, which abort() leaves intact); isRetry in save() keeps the log
+									// entries themselves from being re-added.
+									const retryTransaction: RocksTransactionWithRetry = new RocksTransaction(
+										(this.writes.find((write) => write)?.store.store ?? this.db.store) as RocksStore
+									);
+									if (this.timestamp) retryTransaction.setTimestamp(this.timestamp);
+									(retryTransaction as any).onCommit = (transaction as any).onCommit;
+									try {
+										transaction.abort();
+									} catch (abortError) {
+										// usually already released by the failed commit; log for the unexpected case
+										harperLogger.debug?.('aborting stranded transaction after failed commit', abortError);
+									}
+									transaction = retryTransaction;
+								}
 								if (this.retries > 2) {
 									// Transactions applying data from a canonical source of truth (replication peer or
 									// external caching source) must never drop a write on a transient conflict: there is no
@@ -407,6 +444,13 @@ export class DatabaseTransaction implements Transaction {
 									const neverDropOnConflict = this.sourceApply;
 									if (this.retries > MAX_RETRIES) {
 										if (!neverDropOnConflict) {
+											// giving up: release the current transaction (original or the fresh replay above)
+											// so the throw does not leak its native handle
+											try {
+												transaction.abort();
+											} catch (abortError) {
+												harperLogger.debug?.('aborting conflicted transaction after exhausting retries', abortError);
+											}
 											throw new ServerError(
 												`After ${MAX_RETRIES} retries, unable to commit transaction, transaction is in conflict with ongoing writes`
 											);

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1946,6 +1946,16 @@ export function makeTable(options) {
 				},
 				before: writeToSource(),
 				commit: (txnTime: number, existingEntry: Entry, retry: boolean, transaction: any) => {
+					// Whether a prior attempt of THIS write appended its own audit entry (sticky, set in
+					// save(); log entries are not part of the aborted rocks transaction, so they survive).
+					// Only such a write can find its own orphaned entry in the dedup lookups below and must
+					// not treat it as "already applied". Per-write on purpose: the transaction-wide retry
+					// flag would also suppress dedup for a genuine re-delivered duplicate co-batched with
+					// the conflicting write (double-applying it) and for fresh writes staged through a
+					// reused transaction whose retries counter is stale. Sticky on purpose: a proxy read
+					// from the last attempt's skipped state launders when a recommit round self-skips
+					// (walk identity tie against its own staged record) before a fresh-transaction replay.
+					const stagedOwnAuditEntry = retry && write.appendedAuditEntry === true;
 					write.skipped = false; // reset on each retry; cleanup happens after commit if still true
 					if (retry) {
 						if (context && existingEntry?.version > (context.lastModified || 0))
@@ -2066,8 +2076,12 @@ export function makeTable(options) {
 							// local audit time, not version, so this version-keyed lookup doesn't apply there (LMDB keeps the
 							// exact unbounded walk). A miss (the keyed lookup can lag a back-to-back re-delivery — #1137)
 							// simply falls through to the walk, so this never changes correctness; the additionalAuditRefs
-							// check above remains the read-your-writes guard.
-							if (isRocksDB && dedupVersionCouldBeRetained(txnTime)) {
+							// check above remains the read-your-writes guard. Never when this write staged in a prior
+							// failed attempt: that attempt already appended this write's own audit entry, so the lookup
+							// would find it and skip the write as "already applied" when the record was never committed.
+							// A recommit of the same transaction survived that skip only because the old write batch
+							// still carried the put; a fresh-transaction replay (ERR_TRY_AGAIN) would drop the write.
+							if (isRocksDB && !stagedOwnAuditEntry && dedupVersionCouldBeRetained(txnTime)) {
 								const priorAudit = auditStore.get(txnTime, tableId, id, options?.nodeId);
 								if (
 									priorAudit &&
@@ -2126,7 +2140,11 @@ export function makeTable(options) {
 							// A re-delivered write whose exact (version, nodeId) is already in the audit log was already
 							// applied; drop it rather than re-applying it (double-applying commutative ops) or writing a
 							// duplicate audit-only record. Used by the early-out and the depth-cap block below.
+							// Never a duplicate for a write that staged in a prior failed attempt: that attempt already
+							// appended this write's own audit entry, so the lookup would match it while the record was
+							// never committed (see the up-front keyed dedup above).
 							const isReDeliveredDuplicate = () => {
+								if (stagedOwnAuditEntry) return false;
 								if (!dedupVersionCouldBeRetained(txnTime)) return false; // pre-retention version — skip the end-of-log scan (best-effort; see above)
 								const duplicate = auditStore.get(txnTime, tableId, id, options?.nodeId);
 								return (

--- a/unitTests/resources/sourceApplyConflictRetry.test.js
+++ b/unitTests/resources/sourceApplyConflictRetry.test.js
@@ -1,0 +1,231 @@
+require('../testUtils');
+const assert = require('assert');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const { transaction } = require('#src/resources/transaction');
+const { setTimeout: delay } = require('node:timers/promises');
+
+// A source-apply commit that fails its optimistic-conflict check must converge on retry. ERR_BUSY
+// always could: recommitting re-writes each key, re-tracking it at the current sequence, so
+// validation passes once the contention clears. ERR_TRY_AGAIN never could: the memtable history
+// validation needs is gone (flushed during a bulk-ingest burst), and recommitting the same
+// transaction re-checks the same stranded snapshot, so it fails forever even on an idle database.
+// The uncapped source-apply retry then spins for good and wedges the replication apply loop at its
+// commit await, freezing every replication leg of that database on the node. ERR_TRY_AGAIN retries
+// must replay the writes onto a fresh transaction so validation runs against current state.
+describe('source-apply conflict retry converges instead of spinning', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+	let SpinTable;
+
+	before(async function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		SpinTable = table({
+			table: 'ConflictRetryTable',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'writer' }, { name: 'count' }],
+			audit: true,
+		});
+	});
+
+	// Spy on commits so the test can see which attempt failed validation and whether the retry ran
+	// on a fresh transaction (a new transaction id) or recommitted the failed one.
+	function spyOnCommits() {
+		const { Transaction } = require('@harperfast/rocksdb-js');
+		const originalCommit = Transaction.prototype.commit;
+		const attempts = [];
+		Transaction.prototype.commit = function (...args) {
+			const attempt = { id: this.id };
+			attempts.push(attempt);
+			return originalCommit.apply(this, args).then(
+				(result) => {
+					attempt.ok = true;
+					return result;
+				},
+				(error) => {
+					attempt.code = error.code;
+					throw error;
+				}
+			);
+		};
+		return { attempts, restore: () => (Transaction.prototype.commit = originalCommit) };
+	}
+
+	async function applyWithMidTransactionConflict(id, record, concurrentRecord, disturb) {
+		const context = { sourceApply: true };
+		const txnDone = transaction(context, async () => {
+			await SpinTable.patch(id, record, context);
+			// an independent transaction on the same key, committed while this one is still open,
+			// so this transaction's commit fails optimistic validation
+			const concurrentContext = {};
+			await transaction(concurrentContext, async () => {
+				await SpinTable.patch(id, concurrentRecord, concurrentContext);
+			});
+			await disturb?.();
+		});
+		return Promise.race([
+			Promise.resolve(txnDone).then(
+				() => 'committed',
+				(error) => 'rejected: ' + error.message
+			),
+			delay(4000).then(() => 'spinning'),
+		]);
+	}
+
+	// The field failure was a locally-correct record with a missing change-feed entry, and the fix
+	// relies on the first attempt's audit entry surviving the aborted transaction. Pin that by
+	// counting the record's queryable patch entries (poll: the keyed transaction-log read can lag a
+	// recent write, #1137).
+	async function patchEntryCount(id, atLeast) {
+		for (let i = 0; i < 200; i++) {
+			let count = 0;
+			for (const entry of SpinTable.auditStore.getRange({ start: 1 })) {
+				if (entry.recordId === id && entry.type === 'patch') count++;
+			}
+			if (count >= atLeast) return count;
+			await delay(10);
+		}
+		return -1;
+	}
+
+	it('commits after a conflicting write lands mid-transaction (ERR_BUSY)', async function () {
+		this.timeout(15000);
+		const { attempts, restore } = spyOnCommits();
+		try {
+			await SpinTable.put('busy', { id: 'busy', writer: 'original' });
+			const outcome = await applyWithMidTransactionConflict('busy', { writer: 'apply' }, { writer: 'concurrent' });
+			assert.equal(outcome, 'committed', 'the conflicted source-apply commit must settle');
+			const failed = attempts.find((attempt) => attempt.code === 'ERR_BUSY' || attempt.code === 'ERR_TRY_AGAIN');
+			assert.ok(failed, 'the mid-transaction write should have failed the first commit validation');
+			assert.ok(
+				attempts.find((attempt, index) => attempt.ok && index > attempts.indexOf(failed)),
+				'a later commit attempt must succeed'
+			);
+		} finally {
+			restore();
+		}
+	});
+
+	it('commits after a memtable flush strands the transaction snapshot (ERR_TRY_AGAIN)', async function () {
+		this.timeout(15000);
+		const { attempts, restore } = spyOnCommits();
+		try {
+			await SpinTable.put('stranded', { id: 'stranded', writer: 'original' });
+			// compacting flushes the memtables, discarding the sequence history conflict validation
+			// needs, so the commit fails with ERR_TRY_AGAIN instead of ERR_BUSY
+			const outcome = await applyWithMidTransactionConflict(
+				'stranded',
+				{ writer: 'apply' },
+				{ writer: 'concurrent' },
+				() => SpinTable.primaryStore.store.compact()
+			);
+			assert.equal(outcome, 'committed', 'the stranded source-apply commit must settle');
+			// no change-feed assertion here: this write is fully superseded by the newer concurrent
+			// patch, and a superseded plain write takes the early-out with no dedicated audit entry by
+			// design (nothing to publish, and a redelivery re-folds to the same no-op). The entry
+			// invariant matters for commutative ops and is pinned in the increments test below.
+			const failed = attempts.find((attempt) => attempt.code === 'ERR_TRY_AGAIN');
+			assert.ok(failed, 'the flush should strand the snapshot outside the memtable window');
+			const retried = attempts.find((attempt, index) => attempt.ok && index > attempts.indexOf(failed));
+			assert.ok(retried, 'a later commit attempt must succeed');
+			assert.notEqual(retried.id, failed.id, 'the retry must run on a fresh transaction');
+			assert.ok(
+				!attempts.some((attempt, index) => index > attempts.indexOf(failed) && attempt.id === failed.id),
+				'the stranded transaction must never be recommitted'
+			);
+		} finally {
+			restore();
+		}
+	});
+
+	it('preserves concurrent commutative increments across a stranded-snapshot retry', async function () {
+		this.timeout(15000);
+		const { attempts, restore } = spyOnCommits();
+		try {
+			await SpinTable.put('counter', { id: 'counter', count: 0 });
+			const outcome = await applyWithMidTransactionConflict(
+				'counter',
+				{ count: { __op__: 'add', value: 1 } },
+				{ count: { __op__: 'add', value: 1 } },
+				() => SpinTable.primaryStore.store.compact()
+			);
+			assert.equal(outcome, 'committed', 'the stranded source-apply commit must settle');
+			assert.equal(
+				await patchEntryCount('counter', 2),
+				2,
+				'both increments must keep queryable change-feed entries (redelivery dedup depends on them)'
+			);
+			assert.ok(
+				attempts.some((attempt) => attempt.code === 'ERR_TRY_AGAIN'),
+				'premise: the flush must strand the snapshot (ERR_TRY_AGAIN), not just conflict (ERR_BUSY)'
+			);
+			const record = await SpinTable.get('counter');
+			assert.equal(record.count, 2, 'both increments must survive the fresh-transaction replay');
+		} finally {
+			restore();
+		}
+	});
+
+	it('still dedupes a genuine re-delivered duplicate co-batched with the conflicting write', async function () {
+		this.timeout(30000);
+		// The own-orphaned-entry suppression must be per-write, not transaction-wide: a genuine
+		// duplicate (its exact version and node already in the audit log from a committed
+		// transaction) that shares the batch with the write that caused the retry must still be
+		// deduped on the retry, or it double-applies its commutative op.
+		// natural versions throughout: an explicit past timestamp would predate every log entry's
+		// localTime and trip the #480 pre-retention guard, which disarms the keyed dedup this test is
+		// exercising (documented best-effort gap for out-of-timestamp-order logs)
+		await SpinTable.put('mixed-fresh', { id: 'mixed-fresh', count: 0 });
+		await SpinTable.patch('mixed-dup', { count: { __op__: 'add', value: 1 } });
+		// re-deliver at the exact committed version so the keyed dedup applies
+		const version = SpinTable.primaryStore.getEntry('mixed-dup').version;
+		// the keyed transaction-log lookup can lag a just-committed write (#1137); wait until the
+		// prior write's audit entry is readable so the duplicate is deduped by state, not by luck
+		let auditEntryVisible = false;
+		for (let i = 0; i < 200 && !auditEntryVisible; i++) {
+			const entry = SpinTable.auditStore.get(version, SpinTable.tableId, 'mixed-dup', undefined);
+			if (entry && entry.version === version) auditEntryVisible = true;
+			else await delay(10);
+		}
+		assert.ok(auditEntryVisible, 'premise: the committed duplicate audit entry must be readable');
+		// Bury the duplicate's entry past the out-of-order walk's depth cap so the walk cannot rescue
+		// it through its own identity-tie check; the skip must come from the guarded keyed dedup /
+		// isReDeliveredDuplicate paths, which is what makes this test discriminate a per-write guard
+		// from a transaction-wide one (the walk tie made the shallow variant pass under either).
+		for (let i = 0; i <= 1000; i++) {
+			await SpinTable.patch('mixed-dup', { writer: 'newer' + i });
+		}
+		assert.equal((await SpinTable.get('mixed-dup')).count, 1, 'premise: count intact after burying');
+		const { attempts, restore } = spyOnCommits();
+		try {
+			const context = { sourceApply: true, timestamp: version };
+			const txnDone = transaction(context, async () => {
+				await SpinTable.patch('mixed-fresh', { count: { __op__: 'add', value: 1 } }, context);
+				// exact re-delivery of the already-committed write: same key, same version, same node
+				await SpinTable.patch('mixed-dup', { count: { __op__: 'add', value: 1 } }, context);
+				const concurrentContext = {};
+				await transaction(concurrentContext, async () => {
+					await SpinTable.patch('mixed-fresh', { count: { __op__: 'add', value: 1 } }, concurrentContext);
+				});
+				await SpinTable.primaryStore.store.compact();
+			});
+			const outcome = await Promise.race([
+				Promise.resolve(txnDone).then(
+					() => 'committed',
+					(error) => 'rejected: ' + error.message
+				),
+				delay(6000).then(() => 'spinning'),
+			]);
+			assert.equal(outcome, 'committed', 'the batched source-apply commit must settle');
+			assert.ok(
+				attempts.some((attempt) => attempt.code === 'ERR_TRY_AGAIN'),
+				'premise: the flush must strand the snapshot (ERR_TRY_AGAIN), not just conflict (ERR_BUSY)'
+			);
+			assert.equal((await SpinTable.get('mixed-dup')).count, 1, 'the co-batched duplicate must not double-apply');
+			assert.equal((await SpinTable.get('mixed-fresh')).count, 2, 'both fresh increments must survive');
+		} finally {
+			restore();
+		}
+	});
+});


### PR DESCRIPTION
Cherry-pick of #1696 — **"fix(storage): replay conflict retry on a fresh transaction after ERR_TRY_AGAIN"** — onto the **5.1.x** patch line, per Kris's request.

## Apply
- **Clean cherry-pick, zero conflicts** (squash `f10eba31`). 3 files, +295 / −2, includes the `sourceApplyConflictRetry.test.js` unit test.
- Follow-up to #1223 (already on v5.1): #1223 retried ERR_TRY_AGAIN commits in place; #1696 replays the conflict retry on a **fresh** transaction so a source-apply commit can actually recover from ERR_TRY_AGAIN instead of wedging replication apply for the whole database.

## Before merge
- Confirm CI is green on `v5.1` (validates the change against the 5.1.x base).
- `v5.1` is unprotected — hold for Kris to merge, then cut 5.1.22.

🤖 Cherry-pick prepared by Claude (Opus 4.8) on Kris's behalf.
