### PR TITLE
fix(storage): honest Promise<number | void> type for commit-latency recorder

### DIFF
--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -41,8 +41,10 @@ export function setCommitLatencyRecorder(recorder: ((durationMs: number) => void
 // queue time. The recorder is wrapped so it can never throw — a metrics failure must neither break the
 // commit nor surface as an unhandled rejection on this floating `.then`. The thenable guard protects
 // against a future caller passing a non-Promise `commitResolution` (today it is always the rocksdb-js
-// async `Transaction.commit()` result, which is guaranteed to be a Promise).
-function recordCommitLatency(commitResolution: Promise<unknown> | void, submittedAt: number) {
+// async `Transaction.commit()` result, which is guaranteed to be a Promise). The parameter matches
+// `commit()`'s honest `Promise<number | void>` result (the coordinated-retry sentinel); the resolved
+// value is intentionally ignored — only the settle timing is recorded.
+function recordCommitLatency(commitResolution: Promise<number | void>, submittedAt: number) {
 	if (!recordCommitLatencyMs) return;
 	const record = () => {
 		try {
@@ -400,8 +402,8 @@ export class DatabaseTransaction implements Transaction {
 						if (this.writes.length > 0) {
 							// The transaction was created with coordinatedRetry:true (see
 							// getReadTxn), so commit() can resolve to RETRY_NOW_VALUE. That
-							// sentinel is handled in the resolve callback below and never
-							// propagates past that branch.
+							// sentinel (a number) is why commitResolution is typed
+							// Promise<number | void>; it is handled in the resolve callback below.
 							commitResolution = transaction.commit();
 							// Record how long this commit stays outstanding (submit → settle) as a distribution
 							// metric. This is the same clock the overload check uses (outstandingCommitStart is


### PR DESCRIPTION
## Summary
Fixes the org-wide **red `main` build** (`tsc` TS2345) introduced by #1688.

`resources/DatabaseTransaction.ts:367` passed `commitResolution` to `recordCommitLatency(_: Promise<void>, ...)`, but `commitResolution` is declared `Promise<number | void> | void`. The `as Promise<void>` cast on the `transaction.commit()` assignment (line 360) was **ineffective**: TypeScript's assignment narrowing filters the declared union and re-widens to the `Promise<number | void>` member, so the cast never took effect and the argument stayed `Promise<number | void>`.

## Fix
`commit()` honestly resolves to `number | void` — the coordinated-retry `RETRY_NOW_VALUE` sentinel, which is checked in the resolve callback (line 397). So:
- Widen `recordCommitLatency`'s parameter to `Promise<number | void>` (the honest type).
- Drop the misleading/ineffective `as Promise<void>` cast and correct the adjacent comment.

`recordCommitLatency` only records the submit→settle **timing** and ignores the resolved value, so the per-attempt latency metric is unchanged — the transient-conflict retry still rejects and re-issues `commit()`, re-arming per attempt.

## Where to look
- `resources/DatabaseTransaction.ts:45` — widened recorder parameter.
- `resources/DatabaseTransaction.ts:360` — cast removed; comment corrected.

## Tests
- `npm run build` (tsc) — clean.
- `unitTests/resources/transactionCommitLatency.test.js` — 2 passing.
- `npm run test:unit:resources` — 1162 passing, 14 pending.

Refs #1688.

_Generated by an LLM (Claude Opus 4.8)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)