### PR TITLE
fix(server): socket noDelay/keepAlive options were never applied on TCP/UDS listeners, and keep-alive delay was 600ms not 10min

### DIFF
--- a/server/http.ts
+++ b/server/http.ts
@@ -466,7 +466,7 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 			highWaterMark: 128 * 1024,
 			noDelay: true, // don't delay for Nagle's algorithm, it is a relic of the past that slows things down: https://brooker.co.za/blog/2024/05/09/nagle.html
 			keepAlive: true,
-			keepAliveInitialDelay: 600, // lower the initial delay to 10 minutes, we want to be proactive about closing unused connections
+			keepAliveInitialDelay: 600_000, // in ms: probe after 10 minutes idle, to proactively detect and close dead connections
 			maxHeaderSize: env.get(terms.CONFIG_PARAMS.HTTP_MAXHEADERSIZE),
 		};
 		const mtls = env.get(serverPrefix + '_mtls');
@@ -734,7 +734,7 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 						highWaterMark: 128 * 1024,
 						noDelay: true,
 						keepAlive: true,
-						keepAliveInitialDelay: 600,
+						keepAliveInitialDelay: 600_000,
 						maxHeaderSize: env.get(terms.CONFIG_PARAMS.HTTP_MAXHEADERSIZE),
 					},
 					(nodeRequest: IncomingMessage, nodeResponse: any) => {

--- a/server/http.ts
+++ b/server/http.ts
@@ -25,7 +25,7 @@ import { Readable, Writable, pipeline } from 'node:stream';
 import { mkdirSync, writeFileSync, unlinkSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { server, type ServerOptions, type HttpOptions, type UpgradeOptions, UpgradeListener } from './Server.ts';
-import { setPortServerMap, SERVERS } from './serverRegistry.ts';
+import { setPortServerMap, SERVERS, socketOptionDefaults } from './serverRegistry.ts';
 import { getComponentName } from '../components/componentLoader.ts';
 import { throttle } from './throttle.ts';
 import { makeCallbackChain as buildCallbackChain, describeChains } from './middlewareChain.ts';
@@ -464,9 +464,7 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 			// we set this higher (2x times the default in v22, 8x times the default in v20) because it can help with
 			// performance
 			highWaterMark: 128 * 1024,
-			noDelay: true, // don't delay for Nagle's algorithm, it is a relic of the past that slows things down: https://brooker.co.za/blog/2024/05/09/nagle.html
-			keepAlive: true,
-			keepAliveInitialDelay: 600_000, // in ms: probe after 10 minutes idle, to proactively detect and close dead connections
+			...socketOptionDefaults,
 			maxHeaderSize: env.get(terms.CONFIG_PARAMS.HTTP_MAXHEADERSIZE),
 		};
 		const mtls = env.get(serverPrefix + '_mtls');
@@ -732,9 +730,7 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 						headersTimeout,
 						requestTimeout,
 						highWaterMark: 128 * 1024,
-						noDelay: true,
-						keepAlive: true,
-						keepAliveInitialDelay: 600_000,
+						...socketOptionDefaults,
 						maxHeaderSize: env.get(terms.CONFIG_PARAMS.HTTP_MAXHEADERSIZE),
 					},
 					(nodeRequest: IncomingMessage, nodeResponse: any) => {

--- a/server/serverRegistry.ts
+++ b/server/serverRegistry.ts
@@ -1,5 +1,13 @@
 export const SERVERS = {};
 
+// Socket hygiene defaults shared by every listener Harper creates (HTTP/S, TLS, plain TCP, UDS mirrors),
+// kept in one place so the values can't drift between listener types.
+export const socketOptionDefaults = {
+	noDelay: true, // don't delay for Nagle's algorithm, it is a relic of the past that slows things down: https://brooker.co.za/blog/2024/05/09/nagle.html
+	keepAlive: true, // probe idle connections so dead peers are proactively detected and closed
+	keepAliveInitialDelay: 600_000, // in ms (net.Server floors it to whole seconds): probe after 10 minutes idle
+};
+
 export const portServer = new Map();
 
 export function setPortServerMap(port, server) {

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -29,7 +29,7 @@ const { realExit } = require('./workerProcessGuard.ts');
 const { isBun } = require('../serverHelpers/Request.ts');
 const { createTLSSelector, getEffectiveTlsCiphers } = require('../../security/keys.ts');
 const { startupLog } = require('../../bin/run.ts');
-const { SERVERS, setPortServerMap, portServer } = require('../serverRegistry.ts');
+const { SERVERS, setPortServerMap, portServer, socketOptionDefaults } = require('../serverRegistry.ts');
 const httpComponent = require('../http.ts');
 const globals = require('../../globals.js');
 const { whenScopesClosed } = require('../../components/scopeShutdown.ts');
@@ -579,9 +579,7 @@ function onSocket(listener, options) {
 			{
 				rejectUnauthorized: Boolean(options.mtls?.required),
 				requestCert: Boolean(options.mtls),
-				noDelay: true, // don't delay for Nagle's algorithm, it is a relic of the past that slows things down: https://brooker.co.za/blog/2024/05/09/nagle.html
-				keepAlive: true,
-				keepAliveInitialDelay: 600_000, // in ms: probe after 10 minutes idle, to proactively detect and close dead connections
+				...socketOptionDefaults,
 				ciphers: effectiveCiphers,
 				SNICallback,
 			},
@@ -611,14 +609,7 @@ function onSocket(listener, options) {
 			const udsPath = join(socketsDir, `${socketName}.sock`);
 			const yamlPath = join(socketsDir, `${socketName}.yaml`);
 
-			const udsServer = createSocketServer(
-				{
-					noDelay: true,
-					keepAlive: true,
-					keepAliveInitialDelay: 600_000,
-				},
-				listener
-			);
+			const udsServer = createSocketServer({ ...socketOptionDefaults }, listener);
 
 			udsServer.isPerThreadSocket = true;
 			// Strip the PROXY v1 header a fronting proxy (e.g. symphony) prepends, same as the
@@ -635,14 +626,7 @@ function onSocket(listener, options) {
 	}
 	if (options.port) {
 		setPortServerMap(options.port, { protocol_name: 'TCP', name: getComponentName() });
-		socketServer = createSocketServer(
-			{
-				noDelay: true,
-				keepAlive: true,
-				keepAliveInitialDelay: 600_000,
-			},
-			listener
-		);
+		socketServer = createSocketServer({ ...socketOptionDefaults }, listener);
 		// See the securePort path above: opt out of reusePort only on macOS so every worker can
 		// accept connections for this listener elsewhere, and mark it worker-owned.
 		if (process.platform === 'darwin') socketServer.noReusePort = true;

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -581,7 +581,7 @@ function onSocket(listener, options) {
 				requestCert: Boolean(options.mtls),
 				noDelay: true, // don't delay for Nagle's algorithm, it is a relic of the past that slows things down: https://brooker.co.za/blog/2024/05/09/nagle.html
 				keepAlive: true,
-				keepAliveInitialDelay: 600, // 10 minute keep-alive, want to be proactive about closing unused connections
+				keepAliveInitialDelay: 600_000, // in ms: probe after 10 minutes idle, to proactively detect and close dead connections
 				ciphers: effectiveCiphers,
 				SNICallback,
 			},
@@ -611,11 +611,14 @@ function onSocket(listener, options) {
 			const udsPath = join(socketsDir, `${socketName}.sock`);
 			const yamlPath = join(socketsDir, `${socketName}.yaml`);
 
-			const udsServer = createSocketServer(listener, {
-				noDelay: true,
-				keepAlive: true,
-				keepAliveInitialDelay: 600,
-			});
+			const udsServer = createSocketServer(
+				{
+					noDelay: true,
+					keepAlive: true,
+					keepAliveInitialDelay: 600_000,
+				},
+				listener
+			);
 
 			udsServer.isPerThreadSocket = true;
 			// Strip the PROXY v1 header a fronting proxy (e.g. symphony) prepends, same as the
@@ -632,11 +635,14 @@ function onSocket(listener, options) {
 	}
 	if (options.port) {
 		setPortServerMap(options.port, { protocol_name: 'TCP', name: getComponentName() });
-		socketServer = createSocketServer(listener, {
-			noDelay: true,
-			keepAlive: true,
-			keepAliveInitialDelay: 600,
-		});
+		socketServer = createSocketServer(
+			{
+				noDelay: true,
+				keepAlive: true,
+				keepAliveInitialDelay: 600_000,
+			},
+			listener
+		);
 		// See the securePort path above: opt out of reusePort only on macOS so every worker can
 		// accept connections for this listener elsewhere, and mark it worker-owned.
 		if (process.platform === 'darwin') socketServer.noReusePort = true;

--- a/unitTests/apiTests/mqtt-test.mjs
+++ b/unitTests/apiTests/mqtt-test.mjs
@@ -1147,6 +1147,45 @@ describe('test MQTT connections and commands', function () {
 		}
 	});
 
+	it('socket listeners actually apply noDelay/keepAlive socket options', function () {
+		// net.createServer(listener, options) silently ignores the options object — options must be
+		// the first argument. Assert the servers onSocket creates carry the socket options, so an
+		// arg-order regression fails here. Node stores keepAliveInitialDelay in whole seconds
+		// (~~(ms / 1000)), so the configured 600_000 ms surfaces as 600; the old value of 600 ms
+		// floored to 0 and never yielded the intended 10-minute delay.
+		const preexistingServers = { ...SERVERS };
+		const preexistingPortServer = new Map([...portServer.entries()].map(([key, servers]) => [key, [...servers]]));
+		const preexistingUds = env_get('tls_unixDomainSockets');
+		// Enable the UDS mirror so the securePort call exercises that third createSocketServer site too
+		setProperty('tls_unixDomainSockets', true);
+		try {
+			const assertSocketOptions = (server, label) => {
+				assert.equal(server.noDelay, true, `${label} should disable Nagle`);
+				assert.equal(server.keepAlive, true, `${label} should enable TCP keep-alive`);
+				assert.equal(server.keepAliveInitialDelay, 600, `${label} keep-alive initial delay should be 10 minutes`);
+			};
+			assertSocketOptions(
+				global.server.socket(() => {}, { port: 21885 }),
+				'TCP listener'
+			);
+			assertSocketOptions(
+				global.server.socket(() => {}, { securePort: 28885 }),
+				'TLS listener'
+			);
+			const udsMirrorKey = Object.keys(SERVERS).find((key) => key.endsWith('.sock') && !preexistingServers[key]);
+			assert.ok(udsMirrorKey, 'securePort listener should create a UDS mirror when tls_unixDomainSockets is on');
+			assertSocketOptions(SERVERS[udsMirrorKey], 'UDS mirror listener');
+		} finally {
+			setProperty('tls_unixDomainSockets', preexistingUds);
+			// These listeners were never bound (no listen()); restore both registries to their exact
+			// pre-test state so nothing leaks into other tests.
+			for (const key of Object.keys(SERVERS)) delete SERVERS[key];
+			Object.assign(SERVERS, preexistingServers);
+			portServer.clear();
+			for (const [key, servers] of preexistingPortServer) portServer.set(key, servers);
+		}
+	});
+
 	after(() => {
 		clientV4?.end();
 		clientV5?.end();


### PR DESCRIPTION
## Summary

`onSocket()` in `server/threads/threadServer.js` created its plain-TCP listener and the TLS UDS mirror with `net.createServer(listener, options)`. Node's signature is `net.createServer([options][, connectionListener])` — when the first argument is a function it becomes the connection listener and the second argument is **silently ignored**, so `noDelay`/`keepAlive`/`keepAliveInitialDelay` were never applied on those servers. Fixed by swapping to options-first.

While auditing the other listener sites, a second latent bug turned up: `keepAliveInitialDelay` is in **milliseconds** and `net.Server` floors it to whole seconds (`~~(ms/1000)`), so the value `600` — commented as "10 minute keep-alive" — floored to a 0-second initial delay everywhere it *was* applied (the TLS listener and both HTTP server sites). In practice that meant `SO_KEEPALIVE` enabled with the OS-default idle time (~2 h on Linux), not 10 minutes. Changed to `600_000` at every site.

Since the trio was repeated at five sites and had already drifted, it now lives in one shared `socketOptionDefaults` export in `serverRegistry.ts` (a leaf module both `http.ts` and `threadServer.js` already import).

## Behavior changes to weigh (this is the part worth reviewing)

Options that were inert for years now take effect:

- **Plain-TCP component listeners (e.g. MQTT 1883)**: Nagle is now disabled and TCP keep-alive is enabled (probe after 10 min idle). Healthy idle connections are unaffected — probes are ACKed by any live peer; only true half-open connections (peer crashed, NAT/firewall dropped the flow) get reaped, which was the original stated intent. This also removes a long-standing asymmetry with the TLS listener (8883), which always had `noDelay`.
- **TLS listener + HTTP/HTTPS servers + HTTP UDS mirror**: keep-alive idle tightens from OS default (~2 h) to 10 minutes.
- **UDS mirrors**: the options are no-ops on AF_UNIX handles (net.js applies them only when the handle supports `setNoDelay`/`setKeepAlive`), so no behavior change there — fixed for correctness and consistency.

## Verification

- Empirically confirmed both bugs and the fix against Node 24: reversed args leave `server.noDelay/keepAlive` false; `600` floors to 0 s; `600_000` yields `setKeepAlive(true, 600)` on the accepted socket's handle.
- New regression test in `unitTests/apiTests/mqtt-test.mjs` asserts the three `server.socket()`-created listeners (TCP, TLS, and the UDS mirror via `tls_unixDomainSockets`) actually carry the options. Verified it fails against the old code and passes with the fix.
- MQTT apiTest suite: identical pass/fail set before vs. after the change locally (the local failures are pre-existing environment issues, also present on `main`); `udsMirror.test.js` 26/26 passing.

## Notes

- **Merge overlap with [PR #1858 (kris/pp2-mtls)](https://github.com/HarperFast/harper/pull/1858)**: it touches the same UDS-mirror call site (wrapping the listener in `withProxyProtocol(listener)`). Whichever lands second has a small, mechanical conflict — the listener argument (wrapped or not) just stays in the second position.
- Cross-model reviews: Codex — no findings; Gemini — no blockers, one dedup suggestion (adopted as `socketOptionDefaults`).
- Generated by an LLM (Claude Fable 5), reviewed and verified as described above.
