### PR TITLE
fix(txn): don't drop writes staged while read iterators defer the commit

### DIFF
--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -255,14 +255,20 @@ export class DatabaseTransaction implements Transaction {
 				// requested the commit already received its resolution (the writes were acknowledged when
 				// the transaction went LINGERING, since blocking on iterator completion could deadlock a
 				// response that streams the iterator), so a failure here cannot reject any awaited chain —
-				// log it loudly rather than leaking an unhandled rejection, and abort so the failed
-				// writes' blob files are cleaned up (no error middleware runs this late).
-				const committed = this.commit() as Promise<CommitResolution>;
-				if (committed?.then)
-					committed.catch((error) => {
-						harperLogger.error?.('Failed to commit lingering writes after read iterators completed', error);
-						this.abort();
-					});
+				// log it loudly rather than leaking an unhandled rejection (or throwing into the iterator
+				// consumer: with no async completions pending, commit() runs — and can throw —
+				// synchronously), and abort so the failed writes' blob files are cleaned up (no error
+				// middleware runs this late).
+				const onDeferredCommitError = (error: any) => {
+					harperLogger.error?.('Failed to commit lingering writes after read iterators completed', error);
+					this.abort();
+				};
+				try {
+					const committed = this.commit() as Promise<CommitResolution>;
+					if (committed?.then) committed.catch(onDeferredCommitError);
+				} catch (error) {
+					onDeferredCommitError(error);
+				}
 			} else {
 				this.transaction?.abort();
 				this.transaction = null;
@@ -618,7 +624,17 @@ export class DatabaseTransaction implements Transaction {
 									);
 								}
 								return this.commit({ ...options, transaction }); // try again
-							} else throw error;
+							} else {
+								// terminal (non-conflict) failure: release the native handle so it doesn't leak;
+								// usually already released by the failed commit itself, abort for the unexpected
+								// case (same defensive pattern as the retry-exhaustion give-up above)
+								try {
+									transaction.abort();
+								} catch (abortError) {
+									harperLogger.debug?.('aborting transaction after failed commit', abortError);
+								}
+								throw error;
+							}
 						}
 					);
 				}

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -190,6 +190,9 @@ export class DatabaseTransaction implements Transaction {
 	retries = 0;
 	declare next: DatabaseTransaction;
 	declare stale: boolean;
+	// Whether this read handle's base reference (readTxnsUsed starts at 1 in getReadTxn) has been
+	// consumed by a commit round; iterator references are consumed only by doneReadTxn().
+	declare baseReadRefConsumed?: boolean;
 	declare startedFrom?: {
 		resourceName: string;
 		method: string;
@@ -234,6 +237,7 @@ export class DatabaseTransaction implements Transaction {
 		}
 
 		this.readTxnsUsed = 1;
+		this.baseReadRefConsumed = false; // fresh handle, fresh base reference for commit() to consume
 		if (DEBUG_LONG_TXNS) {
 			this.stackTraces = [new StartedTransaction()];
 		}
@@ -256,7 +260,8 @@ export class DatabaseTransaction implements Transaction {
 			// The native handle was only being held open for the read iterators: any writes staged
 			// through it were already committed at commit() time by replaying them onto a fresh
 			// transaction (see the outstanding-iterators branch in commit()), so aborting it here
-			// discards nothing — the audit/txn-log entries appended at staging survive the abort.
+			// discards nothing — the replay re-staged the writes AND their audit/txn-log entries
+			// into its own transaction; this handle's never-committed log batch dies with it.
 			trackedTxns.delete(this);
 			this.transaction?.abort();
 			this.transaction = null;
@@ -360,8 +365,9 @@ export class DatabaseTransaction implements Transaction {
 			if (result?.then) this.completions.push(result);
 		}
 		operation.commit(txnTime, operation.entry, this.retries > 0, transaction);
-		// Sticky record that THIS write staged with its audit entry appended (log entries are written
-		// at staging and are not part of the transaction, so they survive an abort). isRetry stagings
+		// Sticky record that THIS write staged with its audit entry appended (log entries batch on the
+		// native transaction and are durably written by its commit attempt — even a failed one — so
+		// they survive the abort-after-failed-commit of the retry paths). isRetry stagings
 		// skip the log write, so they never set it. The retry dedup guards in the commit handler key
 		// off this: a launderable proxy (like last attempt's skipped state) breaks under multi-round
 		// retries where a recommit round self-skips before a fresh-transaction replay.
@@ -398,11 +404,14 @@ export class DatabaseTransaction implements Transaction {
 				// RocksTransaction.commit() resolves with RETRY_NOW_VALUE (a number) under
 				// coordinatedRetry, or void on a normal commit/abort.
 				let commitResolution: Promise<number | void> | void;
-				// Consume this commit's own read reference — but only on the initial round: retry
-				// recursions and immediate-commit paths re-enter with an explicit options.transaction
-				// after the reference is already consumed, and must not steal one owned by an
+				// Consume this commit's own read reference — exactly once per read handle: retry
+				// recursions, immediate-commit re-entries, and a second top-level commit() (wrapper
+				// commit after an explicit in-handler commit) must not steal a reference owned by an
 				// outstanding iterator (doneReadTxn() would then never release the native handle).
-				if (!options.transaction) this.readTxnsUsed--;
+				if (!this.baseReadRefConsumed) {
+					this.baseReadRefConsumed = true;
+					this.readTxnsUsed--;
+				}
 				if (this.readTxnsUsed > 0) {
 					// Outstanding iterators still stream through this.transaction — their native iterators
 					// live inside it (GetIterator wraps its write batch + snapshot), so committing or
@@ -417,15 +426,18 @@ export class DatabaseTransaction implements Transaction {
 					this.writes = this.writes.filter((write) => write); // filter out removed entries
 					if (this.writes.length > 0) {
 						if (!options.transaction) {
-							const replayTransaction: RocksTransactionWithRetry = new RocksTransaction(
+							// Deliberately NOT marked isRetry and NOT carrying over the original's onCommit:
+							// audit/txn-log entries batch natively on the transaction they were staged into and
+							// are only durably written by that transaction's commit attempt (an abort discards
+							// them — unlike the ERR_TRY_AGAIN replay below, where the original's FAILED commit
+							// attempt already wrote its log batch). The original handle here never attempts a
+							// commit, so the replayed stagings must re-append their entries into the replay
+							// transaction's own batch — which also installs the replay's own commit hook.
+							const replayTransaction = new RocksTransaction(
 								(this.writes[0].store.store ?? this.db.store) as RocksStore,
 								{ coordinatedRetry: true }
 							);
 							if (this.timestamp) replayTransaction.setTimestamp(this.timestamp);
-							(replayTransaction as any).onCommit = (transaction as any)?.onCommit;
-							// the original stagings appended their audit/txn-log entries (they survive the
-							// original handle's abort); the replay must not re-append them
-							replayTransaction.isRetry = true;
 							this.retries++; // a replay round: commit handlers re-base on the reloaded entries
 							for (const operation of this.writes) {
 								this.save(operation, replayTransaction, true, options);
@@ -531,7 +543,11 @@ export class DatabaseTransaction implements Transaction {
 								harperLogger.warn?.('onCommit handler failed after commit', error);
 							}
 							if (this.next) {
-								completions.push(this.next.commit(options));
+								// never forward options.transaction (a retry/replay round's HEAD-store handle) to
+								// the next store — it must commit its own writes through its own transaction
+								completions.push(
+									this.next.commit(options.transaction ? { ...options, transaction: undefined } : options)
+								);
 							}
 							if (options?.flush) {
 								completions.push(this.writes[0].store.flushed);
@@ -680,7 +696,10 @@ export class DatabaseTransaction implements Transaction {
 				if (this.next) {
 					// now run any other transactions
 					options.timestamp = this.timestamp;
-					const nextResolution = this.next?.commit(options);
+					// as above: the next store must not inherit this store's explicit native transaction
+					const nextResolution = this.next?.commit(
+						options.transaction ? { ...options, transaction: undefined } : options
+					);
 					if ((nextResolution as any)?.then)
 						return (nextResolution as any)?.then((nextResolution) => ({
 							txnTime: this.timestamp,

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -251,8 +251,16 @@ export class DatabaseTransaction implements Transaction {
 		if (--this.readTxnsUsed === 0) {
 			trackedTxns.delete(this);
 			if (this.open === TRANSACTION_STATE.LINGERING) {
-				// if we have lingering writes, we have to call commit to finish them
-				this.commit();
+				// if we have lingering writes, we have to call commit to finish them. The caller that
+				// requested the commit already received its resolution (the writes were acknowledged when
+				// the transaction went LINGERING, since blocking on iterator completion could deadlock a
+				// response that streams the iterator), so a failure here cannot reject any awaited chain —
+				// log it loudly rather than leaking an unhandled rejection.
+				const committed = this.commit() as Promise<CommitResolution>;
+				if (committed?.then)
+					committed.then(null, (error) =>
+						harperLogger.error?.('Failed to commit lingering writes after read iterators completed', error)
+					);
 			} else {
 				this.transaction?.abort();
 				this.transaction = null;
@@ -612,11 +620,17 @@ export class DatabaseTransaction implements Transaction {
 						}
 					);
 				}
-				for (const write of this.writes) {
-					if (write?.skipped && write?.savedBlobs)
-						cleanupUnusedBlobs(write.savedBlobs, collectRetainedFileIds(write.store.getEntry(write.key)?.value));
+				if (this.open !== TRANSACTION_STATE.LINGERING) {
+					for (const write of this.writes) {
+						if (write?.skipped && write?.savedBlobs)
+							cleanupUnusedBlobs(write.savedBlobs, collectRetainedFileIds(write.store.getEntry(write.key)?.value));
+					}
+					// A LINGERING commit deferred its writes to the doneReadTxn() commit that runs when the
+					// last outstanding read iterator finishes; clearing them here would make that deferred
+					// commit find an empty write set and abort the native transaction, silently dropping
+					// every staged write after the caller was told the commit succeeded.
+					this.writes = [];
 				}
-				this.writes = [];
 				if (this.#context?.resourceCache) this.#context.resourceCache = null;
 				const txnResolution: CommitResolution = {
 					txnTime: this.timestamp,

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -255,12 +255,14 @@ export class DatabaseTransaction implements Transaction {
 				// requested the commit already received its resolution (the writes were acknowledged when
 				// the transaction went LINGERING, since blocking on iterator completion could deadlock a
 				// response that streams the iterator), so a failure here cannot reject any awaited chain —
-				// log it loudly rather than leaking an unhandled rejection.
+				// log it loudly rather than leaking an unhandled rejection, and abort so the failed
+				// writes' blob files are cleaned up (no error middleware runs this late).
 				const committed = this.commit() as Promise<CommitResolution>;
 				if (committed?.then)
-					committed.then(null, (error) =>
-						harperLogger.error?.('Failed to commit lingering writes after read iterators completed', error)
-					);
+					committed.catch((error) => {
+						harperLogger.error?.('Failed to commit lingering writes after read iterators completed', error);
+						this.abort();
+					});
 			} else {
 				this.transaction?.abort();
 				this.transaction = null;

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -20,7 +20,11 @@ const DEBUG_LONG_TXNS = envMngr.get(CONFIG_PARAMS.STORAGE_DEBUGLONGTRANSACTIONS)
 export const TRANSACTION_STATE = {
 	CLOSED: 0, // the transaction has been committed or aborted and can no longer be used for writes (if read txn is active, it can be used for reads)
 	OPEN: 1, // the transaction is open and can be used for reads and writes
-	LINGERING: 2, // the transaction has completed a read, but can be used for immediate writes
+	// LMDB-only (LMDBTransaction.ts): committed while reads were outstanding, still usable for immediate
+	// writes. The RocksDB path never enters this state — a commit with outstanding iterators replays its
+	// writes onto a fresh transaction and commits immediately (see the outstanding-iterators branch in
+	// commit()), going straight to CLOSED.
+	LINGERING: 2,
 };
 const MAX_RETRIES = 40;
 // Cap the per-retry backoff so replication-applied transactions, which retry conflicts without a
@@ -249,31 +253,31 @@ export class DatabaseTransaction implements Transaction {
 	doneReadTxn() {
 		if (!this.transaction) return;
 		if (--this.readTxnsUsed === 0) {
+			// The native handle was only being held open for the read iterators: any writes staged
+			// through it were already committed at commit() time by replaying them onto a fresh
+			// transaction (see the outstanding-iterators branch in commit()), so aborting it here
+			// discards nothing — the audit/txn-log entries appended at staging survive the abort.
 			trackedTxns.delete(this);
-			if (this.open === TRANSACTION_STATE.LINGERING) {
-				// if we have lingering writes, we have to call commit to finish them. The caller that
-				// requested the commit already received its resolution (the writes were acknowledged when
-				// the transaction went LINGERING, since blocking on iterator completion could deadlock a
-				// response that streams the iterator), so a failure here cannot reject any awaited chain —
-				// log it loudly rather than leaking an unhandled rejection (or throwing into the iterator
-				// consumer: with no async completions pending, commit() runs — and can throw —
-				// synchronously), and abort so the failed writes' blob files are cleaned up (no error
-				// middleware runs this late).
-				const onDeferredCommitError = (error: any) => {
-					harperLogger.error?.('Failed to commit lingering writes after read iterators completed', error);
-					this.abort();
-				};
-				try {
-					const committed = this.commit() as Promise<CommitResolution>;
-					if (committed?.then) committed.catch(onDeferredCommitError);
-				} catch (error) {
-					onDeferredCommitError(error);
-				}
-			} else {
-				this.transaction?.abort();
-				this.transaction = null;
-			}
+			this.transaction?.abort();
+			this.transaction = null;
 		}
+	}
+
+	/**
+	 * Force-release the retained native read handle without touching staged writes. Used by the
+	 * long-transaction monitor for a CLOSED (already-acknowledged) transaction whose iterators have
+	 * held the read snapshot past the open-transaction limit: the writes are not the monitor's to
+	 * abort (an in-flight replay commit owns them), only the snapshot's lifetime is enforced.
+	 */
+	releaseReadTxn(): void {
+		trackedTxns.delete(this);
+		this.readTxnsUsed = 0; // doneReadTxn() no-ops for the remaining iterators (guarded on this.transaction)
+		try {
+			this.transaction?.abort();
+		} catch (error) {
+			harperLogger.debug?.('releasing timed-out read transaction', error);
+		}
+		this.transaction = null;
 	}
 
 	disregardReadTxn(): void {
@@ -311,7 +315,11 @@ export class DatabaseTransaction implements Transaction {
 
 	save(operation: TransactionWrite, transaction?: RocksTransaction, reloadEntry = false, options?: CommitOptions) {
 		let txnTime = this.timestamp;
-		transaction ??= this.transaction;
+		// Only an OPEN transaction accepts new staged writes. After commit, this.transaction may still
+		// be retained for outstanding read iterators; staging into it would silently discard the write
+		// when doneReadTxn() aborts the handle, so such writes commit immediately on a fresh
+		// transaction below instead.
+		if (!transaction && this.open === TRANSACTION_STATE.OPEN) transaction = this.transaction;
 		let immediateCommit = false;
 		if (!transaction) {
 			transaction = new RocksTransaction(operation.store.store as RocksStore);
@@ -390,23 +398,45 @@ export class DatabaseTransaction implements Transaction {
 				// RocksTransaction.commit() resolves with RETRY_NOW_VALUE (a number) under
 				// coordinatedRetry, or void on a normal commit/abort.
 				let commitResolution: Promise<number | void> | void;
-				if (--this.readTxnsUsed > 0) {
-					// we still have outstanding iterators using the transaction, we can't just commit/abort it, we will still
-					// need to use it
+				// Consume this commit's own read reference — but only on the initial round: retry
+				// recursions and immediate-commit paths re-enter with an explicit options.transaction
+				// after the reference is already consumed, and must not steal one owned by an
+				// outstanding iterator (doneReadTxn() would then never release the native handle).
+				if (!options.transaction) this.readTxnsUsed--;
+				if (this.readTxnsUsed > 0) {
+					// Outstanding iterators still stream through this.transaction — their native iterators
+					// live inside it (GetIterator wraps its write batch + snapshot), so committing or
+					// aborting the handle now would invalidate them mid-stream. Leave it open for the
+					// iterators (doneReadTxn() aborts it when the last one finishes) and commit the writes
+					// NOW by replaying them onto a fresh transaction, the same shape as the ERR_TRY_AGAIN
+					// replay below: entries reload through the new transaction and re-resolve against
+					// current state, and conflicts surface through the normal retry ladder. Deferring the
+					// native commit to doneReadTxn() instead (the old LINGERING state) meant anything that
+					// kept the last iterator from finishing cleanly — a hung stream, the long-transaction
+					// monitor's timeout abort — dropped writes the caller had already been told committed.
+					this.writes = this.writes.filter((write) => write); // filter out removed entries
 					if (this.writes.length > 0) {
-						// if there are outstanding writes, we have to call commit later to finish them
-						this.open = TRANSACTION_STATE.LINGERING;
-						/* TODO: This is not really the intended behavior though, we want to immediately commit writes, but continue to use
-						 * the transaction, as there is likely existing references to the transaction in other parts of the codebase,
-						 * particularly in the query iterator */
+						if (!options.transaction) {
+							const replayTransaction: RocksTransactionWithRetry = new RocksTransaction(
+								(this.writes[0].store.store ?? this.db.store) as RocksStore,
+								{ coordinatedRetry: true }
+							);
+							if (this.timestamp) replayTransaction.setTimestamp(this.timestamp);
+							(replayTransaction as any).onCommit = (transaction as any)?.onCommit;
+							// the original stagings appended their audit/txn-log entries (they survive the
+							// original handle's abort); the replay must not re-append them
+							replayTransaction.isRetry = true;
+							this.retries++; // a replay round: commit handlers re-base on the reloaded entries
+							for (const operation of this.writes) {
+								this.save(operation, replayTransaction, true, options);
+							}
+							transaction = replayTransaction;
+						}
+						// with options.transaction set this is a retry round — the save loop above already
+						// re-staged the writes into it
+						commitResolution = transaction.commit() as Promise<void>;
+						recordCommitLatency(commitResolution, performance.now());
 					}
-					/*
-				commitResolution =
-					this.writes.length > 0
-						? transaction?.commit({ renewAfterCommit: true }) // Try to use RocksDB's CommitAndTryCreateSnapshot
-			: // don't abort, we still have outstanding reads to complete
-							null;
-				*/
 				} else {
 					// no more reads need to be performed, just commit/abort based if there are any writes
 					trackedTxns.delete(this);
@@ -638,17 +668,11 @@ export class DatabaseTransaction implements Transaction {
 						}
 					);
 				}
-				if (this.open !== TRANSACTION_STATE.LINGERING) {
-					for (const write of this.writes) {
-						if (write?.skipped && write?.savedBlobs)
-							cleanupUnusedBlobs(write.savedBlobs, collectRetainedFileIds(write.store.getEntry(write.key)?.value));
-					}
-					// A LINGERING commit deferred its writes to the doneReadTxn() commit that runs when the
-					// last outstanding read iterator finishes; clearing them here would make that deferred
-					// commit find an empty write set and abort the native transaction, silently dropping
-					// every staged write after the caller was told the commit succeeded.
-					this.writes = [];
+				for (const write of this.writes) {
+					if (write?.skipped && write?.savedBlobs)
+						cleanupUnusedBlobs(write.savedBlobs, collectRetainedFileIds(write.store.getEntry(write.key)?.value));
 				}
+				this.writes = [];
 				if (this.#context?.resourceCache) this.#context.resourceCache = null;
 				const txnResolution: CommitResolution = {
 					txnTime: this.timestamp,
@@ -709,9 +733,6 @@ export class DatabaseTransaction implements Transaction {
 		// in the chain un-poisoned (and thus eligible to be force-committed by a later commit cascade).
 		for (let txn: DatabaseTransaction = this; txn; txn = txn.next) {
 			txn.timedOut = true;
-			// Force the CLOSED path when releasing the read snapshot: doneReadTxn() flushes lingering writes via
-			// commit() while open === LINGERING, and commit() now throws transactionOpenTooLongError once poisoned.
-			// Closing first makes the release discard (abort) the uncommitted writes instead, which is the intent.
 			txn.open = TRANSACTION_STATE.CLOSED;
 		}
 		for (let txn: DatabaseTransaction = this; txn; txn = txn.next) {
@@ -781,7 +802,20 @@ function startMonitoringTxns() {
 		for (const txn of trackedTxns) {
 			if (txn.timeout <= 0) {
 				const url = (txn.getContext() as any)?.url;
-				if (txn.hasPendingWrites() && !txn.sourceApply && !txn.isReplay) {
+				if (txn.open === TRANSACTION_STATE.CLOSED) {
+					// The commit was already acknowledged; any staged writes are riding an in-flight
+					// replay commit (see the outstanding-iterators branch in commit()) and are not the
+					// monitor's to abort — dropping them here would re-introduce the silent
+					// write-loss-after-ack this branch structure exists to prevent. Only the read
+					// snapshot's lifetime is left to enforce: release the retained native handle that
+					// the overdue iterators are holding open.
+					harperLogger.warn?.(
+						`Read iterators held a committed transaction's snapshot past the open-transaction limit; releasing it, from table: ${
+							(txn.db as any)?.name + (url ? ' path: ' + url : '')
+						}`
+					);
+					txn.releaseReadTxn();
+				} else if (txn.hasPendingWrites() && !txn.sourceApply && !txn.isReplay) {
 					// Abort and surface an error rather than force-committing a partial write set: silently
 					// committing on the application's behalf breaks atomicity and can leave orphaned
 					// secondary-index entries that only a full index rebuild repairs (issue #1407). The app

--- a/unitTests/apiTests/setupTestApp.mjs
+++ b/unitTests/apiTests/setupTestApp.mjs
@@ -115,11 +115,17 @@ export async function setupTestApp() {
 	createdRecords = [];
 
 	if (serverStarted) {
-		// if already started, clear out any previous records and recreate them
-		tables.VariedProps.clear();
-		tables.FourProp.clear();
-		tables.Related.clear();
-		tables.SubObject.clear();
+		// if already started, clear out any previous records and recreate them. RocksDB's
+		// clear() is an unsynchronized native range-delete (no coordination with in-flight
+		// transaction commits, unlike LMDB's single-writer instruction queue) — awaiting it
+		// here is required so the reseed PUTs below can't race a still-in-flight delete and
+		// have their fresh inserts wiped out from under them.
+		await Promise.all([
+			tables.VariedProps.clear(),
+			tables.FourProp.clear(),
+			tables.Related.clear(),
+			tables.SubObject.clear(),
+		]);
 	} else {
 		const { startHTTPThreads } = await import('#src/server/threads/socketRouter');
 		serverStarted = await startHTTPThreads(config.threads || 0);

--- a/unitTests/resources/lingeringWriteCommit.test.js
+++ b/unitTests/resources/lingeringWriteCommit.test.js
@@ -1,0 +1,111 @@
+require('../testUtils');
+const assert = require('assert');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const { transaction } = require('#src/resources/transaction');
+const { TRANSACTION_STATE } = require('#src/resources/DatabaseTransaction');
+const { setTimeout: delay } = require('node:timers/promises');
+
+// A commit issued while a search iterator still holds the read transaction goes LINGERING: the
+// native commit is deferred until the last iterator finishes (doneReadTxn), because blocking the
+// commit on iterator completion could deadlock a response that streams the iterator after the
+// handler returns. The staged writes must survive that deferral — commit() used to clear
+// this.writes on the LINGERING fall-through, so the deferred commit found an empty write set and
+// aborted the native transaction, silently dropping every write the caller was told succeeded.
+describe('lingering commit preserves writes staged while iterators are open', () => {
+	let LingerTable;
+	const unhandled = [];
+	const onUnhandled = (error) => unhandled.push(error);
+
+	before(async () => {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		LingerTable = table({
+			table: 'LingeringWriteTable',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'v' }],
+			audit: true,
+		});
+		await LingerTable.put({ id: 'seed1', v: 1 });
+		await LingerTable.put({ id: 'seed2', v: 2 });
+		process.on('unhandledRejection', onUnhandled);
+	});
+
+	after(() => {
+		process.removeListener('unhandledRejection', onUnhandled);
+	});
+
+	// Start a search and pull a single result so the iterator keeps the read transaction in use
+	// (useReadTxn) across the transaction()'s commit; finish it afterward to trigger the deferred
+	// doneReadTxn commit.
+	async function commitWithOpenIterator(writeId, disturb) {
+		let iterator;
+		const context = {};
+		await transaction(context, async () => {
+			const results = await LingerTable.search({ conditions: [] }, context);
+			iterator = results[Symbol.asyncIterator]();
+			await iterator.next();
+			await LingerTable.put({ id: writeId, v: 42 }, context);
+			await disturb?.(context);
+		});
+		assert.equal(
+			context.transaction.open,
+			TRANSACTION_STATE.LINGERING,
+			'premise: the open iterator must defer the commit (LINGERING)'
+		);
+		while (!(await iterator.next()).done);
+		// the deferred commit runs from the iterator's onDone; give its async resolution a beat
+		for (let i = 0; i < 200 && !(await LingerTable.get(writeId)); i++) await delay(10);
+	}
+
+	it('commits the staged write once the iterator completes', async function () {
+		this.timeout(15000);
+		await commitWithOpenIterator('linger-write');
+		const record = await LingerTable.get('linger-write');
+		assert.ok(record, 'the write staged during the lingering transaction must be committed, not dropped');
+		assert.equal(record.v, 42);
+		assert.deepEqual(unhandled, [], 'the deferred commit must not leak an unhandled rejection');
+	});
+
+	it('commits writes staged after the transaction went lingering', async function () {
+		this.timeout(15000);
+		// a LINGERING transaction still accepts writes (save() stages into the retained native
+		// transaction); those must also survive to the deferred commit
+		let iterator;
+		const context = {};
+		await transaction(context, async () => {
+			const results = await LingerTable.search({ conditions: [] }, context);
+			iterator = results[Symbol.asyncIterator]();
+			await iterator.next();
+			await LingerTable.put({ id: 'linger-early', v: 1 }, context);
+		});
+		assert.equal(context.transaction.open, TRANSACTION_STATE.LINGERING);
+		await LingerTable.put({ id: 'linger-late', v: 2 }, context);
+		while (!(await iterator.next()).done);
+		for (let i = 0; i < 200 && !(await LingerTable.get('linger-late')); i++) await delay(10);
+		assert.ok(await LingerTable.get('linger-early'), 'pre-lingering write must be committed');
+		assert.ok(await LingerTable.get('linger-late'), 'post-lingering write must be committed');
+		assert.deepEqual(unhandled, [], 'the deferred commit must not leak an unhandled rejection');
+	});
+
+	it('a failing deferred commit is logged, not an unhandled rejection', async function () {
+		this.timeout(15000);
+		const { Transaction } = require('@harperfast/rocksdb-js');
+		const originalCommit = Transaction.prototype.commit;
+		const targetDb = LingerTable.primaryStore.store.db;
+		let forcedFailures = 0;
+		await commitWithOpenIterator('linger-fail', () => {
+			// arm after the transaction is set up: fail the deferred native commit terminally
+			Transaction.prototype.commit = function (...args) {
+				if (this.store?.db !== targetDb) return originalCommit.apply(this, args);
+				forcedFailures++;
+				return Promise.reject(Object.assign(new Error('forced terminal failure'), { code: 'ERR_CORRUPTION' }));
+			};
+		}).finally(() => (Transaction.prototype.commit = originalCommit));
+		assert.ok(forcedFailures > 0, 'premise: the deferred commit must have run and failed');
+		assert.equal(await LingerTable.get('linger-fail'), undefined, 'the failed write is not committed');
+		await delay(100);
+		assert.deepEqual(unhandled, [], 'a deferred-commit failure must be caught and logged, never unhandled');
+	});
+});

--- a/unitTests/resources/lingeringWriteCommit.test.js
+++ b/unitTests/resources/lingeringWriteCommit.test.js
@@ -68,10 +68,13 @@ describe('lingering commit preserves writes staged while iterators are open', ()
 		assert.deepEqual(unhandled, [], 'the deferred commit must not leak an unhandled rejection');
 	});
 
-	it('commits writes staged after the transaction went lingering', async function () {
+	it('a write after the transaction went lingering commits independently; the lingering write still lands', async function () {
 		this.timeout(15000);
-		// a LINGERING transaction still accepts writes (save() stages into the retained native
-		// transaction); those must also survive to the deferred commit
+		// The transactional wrapper only reuses a context transaction that is OPEN (Resource.ts), so a
+		// put against the same context after LINGERING runs on a fresh transaction and commits
+		// immediately — it must not disturb the lingering transaction's deferred writes. (Internal
+		// paths that reach a LINGERING transaction via txnForContext stage into the retained native
+		// transaction and ride the same deferred commit as the pre-lingering writes pinned above.)
 		let iterator;
 		const context = {};
 		await transaction(context, async () => {
@@ -80,12 +83,14 @@ describe('lingering commit preserves writes staged while iterators are open', ()
 			await iterator.next();
 			await LingerTable.put({ id: 'linger-early', v: 1 }, context);
 		});
-		assert.equal(context.transaction.open, TRANSACTION_STATE.LINGERING);
+		const lingeringTxn = context.transaction;
+		assert.equal(lingeringTxn.open, TRANSACTION_STATE.LINGERING);
 		await LingerTable.put({ id: 'linger-late', v: 2 }, context);
+		assert.notEqual(context.transaction, lingeringTxn, 'premise: the late write ran on a fresh transaction');
+		assert.ok(await LingerTable.get('linger-late'), 'the independent write must be committed immediately');
 		while (!(await iterator.next()).done);
-		for (let i = 0; i < 200 && !(await LingerTable.get('linger-late')); i++) await delay(10);
-		assert.ok(await LingerTable.get('linger-early'), 'pre-lingering write must be committed');
-		assert.ok(await LingerTable.get('linger-late'), 'post-lingering write must be committed');
+		for (let i = 0; i < 200 && !(await LingerTable.get('linger-early')); i++) await delay(10);
+		assert.ok(await LingerTable.get('linger-early'), 'the lingering write must still be committed');
 		assert.deepEqual(unhandled, [], 'the deferred commit must not leak an unhandled rejection');
 	});
 

--- a/unitTests/resources/lingeringWriteCommit.test.js
+++ b/unitTests/resources/lingeringWriteCommit.test.js
@@ -74,6 +74,11 @@ describe('commit with open read iterators commits writes immediately on a replay
 		await delay(50); // give a released-handle failure a beat to surface as an unhandledRejection
 		assert.equal(context.transaction.transaction, null, 'the drained iterator must release the native handle');
 		assert.ok(await LingerTable.get('linger-write'), 'releasing the read handle must not disturb the committed write');
+		// audit/txn-log entries batch on the native transaction they were staged into and are only
+		// written by its commit; the replay must re-stage them into ITS transaction — the original
+		// handle's batch dies with the abort above. Exactly one entry: no loss, no duplication.
+		const history = await LingerTable.getHistoryOfRecord('linger-write');
+		assert.equal(history.length, 1, 'the replayed write must carry exactly one audit entry (not zero, not two)');
 		assert.deepEqual(unhandled, [], 'the replay commit must not leak an unhandled rejection');
 	});
 

--- a/unitTests/resources/lingeringWriteCommit.test.js
+++ b/unitTests/resources/lingeringWriteCommit.test.js
@@ -7,16 +7,17 @@ const { transaction } = require('#src/resources/transaction');
 const { TRANSACTION_STATE } = require('#src/resources/DatabaseTransaction');
 const { setTimeout: delay } = require('node:timers/promises');
 
-// A commit issued while a search iterator still holds the read transaction goes LINGERING: the
-// native commit is deferred until the last iterator finishes (doneReadTxn), because blocking the
-// commit on iterator completion could deadlock a response that streams the iterator after the
-// handler returns. The staged writes must survive that deferral — commit() used to clear
-// this.writes on the LINGERING fall-through, so the deferred commit found an empty write set and
-// aborted the native transaction, silently dropping every write the caller was told succeeded.
-describe('lingering commit preserves writes staged while iterators are open', () => {
+// A commit issued while a search iterator still holds the read transaction cannot commit the
+// native handle (the iterator's native cursor lives inside it), but it must not defer the writes
+// either: the old LINGERING deferral committed them from doneReadTxn() when the last iterator
+// finished, so anything that kept that from happening cleanly — a hung stream, the
+// long-transaction monitor's timeout abort — silently dropped writes the caller had already been
+// told were committed. commit() now replays the staged writes onto a fresh transaction and
+// commits them immediately (ERR_TRY_AGAIN-replay style); the original handle stays open only for
+// the iterators and is aborted, empty of responsibilities, when they finish.
+describe('commit with open read iterators commits writes immediately on a replay transaction', () => {
 	// RocksDB-only: LMDB never defers a commit on open read transactions (its reads don't block
-	// writes; a post-LINGERING write goes through an ImmediateTransaction), so the deferral this
-	// pins doesn't exist there.
+	// writes), so the iterator-retained-handle scenario this pins doesn't exist there.
 	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
 	let LingerTable;
 	const unhandled = [];
@@ -41,8 +42,7 @@ describe('lingering commit preserves writes staged while iterators are open', ()
 	});
 
 	// Start a search and pull a single result so the iterator keeps the read transaction in use
-	// (useReadTxn) across the transaction()'s commit; finish it afterward to trigger the deferred
-	// doneReadTxn commit.
+	// (useReadTxn) across the transaction()'s commit.
 	async function commitWithOpenIterator(writeId, disturb) {
 		let iterator;
 		const context = {};
@@ -53,82 +53,87 @@ describe('lingering commit preserves writes staged while iterators are open', ()
 			await LingerTable.put({ id: writeId, v: 42 }, context);
 			await disturb?.(context);
 		});
-		assert.equal(
-			context.transaction.open,
-			TRANSACTION_STATE.LINGERING,
-			'premise: the open iterator must defer the commit (LINGERING)'
-		);
-		while (!(await iterator.next()).done);
-		// the deferred commit runs from the iterator's onDone; give its async resolution a beat
-		for (let i = 0; i < 200 && !(await LingerTable.get(writeId)); i++) await delay(10);
-		return context;
+		return { context, iterator };
 	}
 
-	it('commits the staged write once the iterator completes', async function () {
+	it('the write is durable when commit resolves, while the iterator is still open', async function () {
 		this.timeout(15000);
-		await commitWithOpenIterator('linger-write');
+		const { context, iterator } = await commitWithOpenIterator('linger-write');
+		assert.equal(
+			context.transaction.open,
+			TRANSACTION_STATE.CLOSED,
+			'the commit must close the transaction — no LINGERING deferral'
+		);
+		assert.ok(context.transaction.transaction, 'premise: the open iterator must retain the native read handle');
+		// the awaited commit chain includes the replay commit, so the write is already readable —
+		// before the iterator finishes
 		const record = await LingerTable.get('linger-write');
-		assert.ok(record, 'the write staged during the lingering transaction must be committed, not dropped');
+		assert.ok(record, 'the write staged behind an open iterator must be committed by the time commit resolves');
 		assert.equal(record.v, 42);
-		await delay(50); // unhandledRejection lands on a later event-loop turn
-		assert.deepEqual(unhandled, [], 'the deferred commit must not leak an unhandled rejection');
+		while (!(await iterator.next()).done);
+		await delay(50); // give a released-handle failure a beat to surface as an unhandledRejection
+		assert.equal(context.transaction.transaction, null, 'the drained iterator must release the native handle');
+		assert.ok(await LingerTable.get('linger-write'), 'releasing the read handle must not disturb the committed write');
+		assert.deepEqual(unhandled, [], 'the replay commit must not leak an unhandled rejection');
 	});
 
-	it('a write after the transaction went lingering commits independently; the lingering write still lands', async function () {
+	it('a write after the transaction closed commits independently; the earlier write is already durable', async function () {
 		this.timeout(15000);
 		// The transactional wrapper only reuses a context transaction that is OPEN (Resource.ts), so a
-		// put against the same context after LINGERING runs on a fresh transaction and commits
-		// immediately — it must not disturb the lingering transaction's deferred writes. (Internal
-		// paths that reach a LINGERING transaction via txnForContext stage into the retained native
-		// transaction and ride the same deferred commit as the pre-lingering writes pinned above.)
-		let iterator;
-		const context = {};
-		await transaction(context, async () => {
-			const results = await LingerTable.search({ conditions: [] }, context);
-			iterator = results[Symbol.asyncIterator]();
-			await iterator.next();
-			await LingerTable.put({ id: 'linger-early', v: 1 }, context);
-		});
-		const lingeringTxn = context.transaction;
-		assert.equal(lingeringTxn.open, TRANSACTION_STATE.LINGERING);
+		// put against the same context after the commit runs on a fresh transaction. (Internal paths
+		// that reach the retained transaction via txnForContext take save()'s immediate-commit branch —
+		// a closed transaction never accepts new staged writes.)
+		const { context, iterator } = await commitWithOpenIterator('linger-early');
+		const closedTxn = context.transaction;
+		assert.equal(closedTxn.open, TRANSACTION_STATE.CLOSED);
+		assert.ok(await LingerTable.get('linger-early'), 'the pre-close write must already be committed');
 		await LingerTable.put({ id: 'linger-late', v: 2 }, context);
-		assert.notEqual(context.transaction, lingeringTxn, 'premise: the late write ran on a fresh transaction');
+		assert.notEqual(context.transaction, closedTxn, 'premise: the late write ran on a fresh transaction');
 		assert.ok(await LingerTable.get('linger-late'), 'the independent write must be committed immediately');
 		while (!(await iterator.next()).done);
-		for (let i = 0; i < 200 && !(await LingerTable.get('linger-early')); i++) await delay(10);
-		assert.ok(await LingerTable.get('linger-early'), 'the lingering write must still be committed');
+		assert.ok(await LingerTable.get('linger-early'), 'draining the iterator must not disturb the earlier write');
 		await delay(50); // unhandledRejection lands on a later event-loop turn
-		assert.deepEqual(unhandled, [], 'the deferred commit must not leak an unhandled rejection');
+		assert.deepEqual(unhandled, [], 'neither commit may leak an unhandled rejection');
 	});
 
-	it('a failing deferred commit is logged and aborted, not an unhandled rejection', async function () {
+	it('a terminally failing replay commit rejects the awaited commit chain; the iterator survives', async function () {
 		this.timeout(15000);
 		const { Transaction } = require('@harperfast/rocksdb-js');
 		const originalCommit = Transaction.prototype.commit;
 		const targetDb = LingerTable.primaryStore.store.db;
 		let forcedFailures = 0;
-		let context;
+		let rejection;
+		let iterator;
+		const context = {};
 		try {
-			context = await commitWithOpenIterator('linger-fail', () => {
-				// arm after the transaction is set up: fail the deferred native commit terminally
+			await transaction(context, async () => {
+				const results = await LingerTable.search({ conditions: [] }, context);
+				iterator = results[Symbol.asyncIterator]();
+				await iterator.next();
+				await LingerTable.put({ id: 'linger-fail', v: 42 }, context);
+				// arm after the transaction is set up: fail the replay's native commit terminally
 				Transaction.prototype.commit = function (...args) {
 					if (this.store?.db !== targetDb) return originalCommit.apply(this, args);
 					forcedFailures++;
 					return Promise.reject(Object.assign(new Error('forced terminal failure'), { code: 'ERR_CORRUPTION' }));
 				};
-			});
+			}).then(
+				() => {},
+				(error) => {
+					rejection = error;
+				}
+			);
 		} finally {
 			Transaction.prototype.commit = originalCommit;
 		}
-		assert.ok(forcedFailures > 0, 'premise: the deferred commit must have run and failed');
+		assert.ok(forcedFailures > 0, 'premise: the replay commit must have run and failed');
+		assert.ok(rejection, 'a terminal replay-commit failure must reject the awaited commit chain, not vanish');
+		assert.equal(rejection.message, 'forced terminal failure');
 		assert.equal(await LingerTable.get('linger-fail'), undefined, 'the failed write is not committed');
-		// unhandledRejection is emitted on a later event-loop turn; drain before asserting
+		// the original read handle must survive the replay failure: the iterator finishes normally
+		while (!(await iterator.next()).done);
+		assert.equal(context.transaction.transaction, null, 'the drained iterator must still release the native handle');
 		await delay(100);
-		assert.deepEqual(unhandled, [], 'a deferred-commit failure must be caught and logged, never unhandled');
-		assert.equal(
-			context.transaction.writes.length,
-			0,
-			'the failed deferred commit must abort so staged writes (and their blob files) are cleaned up'
-		);
+		assert.deepEqual(unhandled, [], 'a replay-commit failure must reject the awaited chain, never float unhandled');
 	});
 });

--- a/unitTests/resources/lingeringWriteCommit.test.js
+++ b/unitTests/resources/lingeringWriteCommit.test.js
@@ -14,6 +14,10 @@ const { setTimeout: delay } = require('node:timers/promises');
 // this.writes on the LINGERING fall-through, so the deferred commit found an empty write set and
 // aborted the native transaction, silently dropping every write the caller was told succeeded.
 describe('lingering commit preserves writes staged while iterators are open', () => {
+	// RocksDB-only: LMDB never defers a commit on open read transactions (its reads don't block
+	// writes; a post-LINGERING write goes through an ImmediateTransaction), so the deferral this
+	// pins doesn't exist there.
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
 	let LingerTable;
 	const unhandled = [];
 	const onUnhandled = (error) => unhandled.push(error);

--- a/unitTests/resources/lingeringWriteCommit.test.js
+++ b/unitTests/resources/lingeringWriteCommit.test.js
@@ -57,6 +57,7 @@ describe('lingering commit preserves writes staged while iterators are open', ()
 		while (!(await iterator.next()).done);
 		// the deferred commit runs from the iterator's onDone; give its async resolution a beat
 		for (let i = 0; i < 200 && !(await LingerTable.get(writeId)); i++) await delay(10);
+		return context;
 	}
 
 	it('commits the staged write once the iterator completes', async function () {
@@ -65,6 +66,7 @@ describe('lingering commit preserves writes staged while iterators are open', ()
 		const record = await LingerTable.get('linger-write');
 		assert.ok(record, 'the write staged during the lingering transaction must be committed, not dropped');
 		assert.equal(record.v, 42);
+		await delay(50); // unhandledRejection lands on a later event-loop turn
 		assert.deepEqual(unhandled, [], 'the deferred commit must not leak an unhandled rejection');
 	});
 
@@ -91,26 +93,38 @@ describe('lingering commit preserves writes staged while iterators are open', ()
 		while (!(await iterator.next()).done);
 		for (let i = 0; i < 200 && !(await LingerTable.get('linger-early')); i++) await delay(10);
 		assert.ok(await LingerTable.get('linger-early'), 'the lingering write must still be committed');
+		await delay(50); // unhandledRejection lands on a later event-loop turn
 		assert.deepEqual(unhandled, [], 'the deferred commit must not leak an unhandled rejection');
 	});
 
-	it('a failing deferred commit is logged, not an unhandled rejection', async function () {
+	it('a failing deferred commit is logged and aborted, not an unhandled rejection', async function () {
 		this.timeout(15000);
 		const { Transaction } = require('@harperfast/rocksdb-js');
 		const originalCommit = Transaction.prototype.commit;
 		const targetDb = LingerTable.primaryStore.store.db;
 		let forcedFailures = 0;
-		await commitWithOpenIterator('linger-fail', () => {
-			// arm after the transaction is set up: fail the deferred native commit terminally
-			Transaction.prototype.commit = function (...args) {
-				if (this.store?.db !== targetDb) return originalCommit.apply(this, args);
-				forcedFailures++;
-				return Promise.reject(Object.assign(new Error('forced terminal failure'), { code: 'ERR_CORRUPTION' }));
-			};
-		}).finally(() => (Transaction.prototype.commit = originalCommit));
+		let context;
+		try {
+			context = await commitWithOpenIterator('linger-fail', () => {
+				// arm after the transaction is set up: fail the deferred native commit terminally
+				Transaction.prototype.commit = function (...args) {
+					if (this.store?.db !== targetDb) return originalCommit.apply(this, args);
+					forcedFailures++;
+					return Promise.reject(Object.assign(new Error('forced terminal failure'), { code: 'ERR_CORRUPTION' }));
+				};
+			});
+		} finally {
+			Transaction.prototype.commit = originalCommit;
+		}
 		assert.ok(forcedFailures > 0, 'premise: the deferred commit must have run and failed');
 		assert.equal(await LingerTable.get('linger-fail'), undefined, 'the failed write is not committed');
+		// unhandledRejection is emitted on a later event-loop turn; drain before asserting
 		await delay(100);
 		assert.deepEqual(unhandled, [], 'a deferred-commit failure must be caught and logged, never unhandled');
+		assert.equal(
+			context.transaction.writes.length,
+			0,
+			'the failed deferred commit must abort so staged writes (and their blob files) are cleaned up'
+		);
 	});
 });


### PR DESCRIPTION
## Summary

A commit issued while a search iterator still holds the read transaction cannot commit the native handle — the iterator's native cursor lives inside it (`GetIterator` wraps the transaction's write batch + snapshot, and RocksDB invalidates it on commit). The old code deferred the entire native commit to `doneReadTxn()` (the LINGERING state), and the LINGERING fall-through cleared `this.writes`, so the deferred commit found an empty write set and **aborted the native transaction with the staged writes in it** — every write silently dropped after the caller was told the commit succeeded.

Found while root-causing the #1785 follow-up; empirically confirmed on main — the new test fails without the fix.

## Approach (reworked after review discussion)

The first version of this PR preserved `this.writes` across the deferral so the deferred commit worked. Review (cb1kenobi) showed the deferral itself is the hazard: any path that keeps the last iterator from finishing cleanly — the long-transaction monitor's timeout abort, a hung stream — still dropped acknowledged writes. So this now **eliminates the deferred commit entirely** on the RocksDB path:

- `commit()` with outstanding iterators replays the staged writes onto a **fresh transaction and commits them immediately**, ERR_TRY_AGAIN-replay style: entries reload through the new transaction, commit handlers re-base on them (CAS re-resolves against current state), and conflicts surface through the normal retry ladder. The replay is part of the awaited commit chain, so the caller's acknowledgment now covers actual durability — and a terminal commit failure **rejects the awaited chain** instead of being loggable-only.
- The replay deliberately does **not** carry `isRetry`: audit/txn-log entries batch natively on the transaction they were staged into and are only written by its commit *attempt* (the ERR_TRY_AGAIN replay relies on the original's *failed* commit having already written its batch; here the original never attempts one). The replayed stagings re-append their entries into the replay transaction's own batch — the test asserts exactly one audit entry (no loss, no duplication).
- The original native handle stays open solely for the iterators and is aborted, with no remaining responsibilities, when the last one finishes. `TRANSACTION_STATE.LINGERING` is now LMDB-only (LMDB overrides all the relevant methods; its path is unchanged).
- `save()` no longer stages writes into a retained non-OPEN handle (they would be discarded by that abort) — internal `txnForContext` writers now commit immediately on a fresh transaction.
- The long-transaction monitor never aborts a CLOSED (already-acknowledged) transaction's writes: for an overdue CLOSED-but-tracked transaction it releases just the read snapshot (`releaseReadTxn()`), preserving the open-time bound for hung iterators without re-introducing write loss (the cb1kenobi finding).
- The commit's base read reference is now consumed **exactly once per read handle** (`baseReadRefConsumed`), so retry rounds, immediate-commit re-entries, and a second top-level `commit()` can't steal an iterator's reference and abort the handle under it.
- Multi-store: `this.next.commit()` no longer inherits a retry/replay round's head-store `options.transaction` (pre-existing bug; the next store must commit through its own transaction).

## Where to look

- The outstanding-iterators branch in `DatabaseTransaction.commit()` (the replay) and the simplified `doneReadTxn()`.
- The monitor's new CLOSED branch + `releaseReadTxn()`.
- `unitTests/resources/lingeringWriteCommit.test.js` — asserts immediate durability while the iterator is still open, exactly-one audit entry, independent post-close writes, and that a terminally failing replay commit rejects the awaited chain while the iterator survives.
- A `renewAfterCommit`/`CommitAndTryCreateSnapshot` + iterator-reseek primitive in rocksdb-js would let the original handle commit directly (the old TODO's intent) and replace the replay; noted as follow-up work.

Likely a v5.1 patch candidate — the bug exists on the release branch.

Cross-model reviewed (Codex traced repo paths; Gemini via direct API on the diff): Codex's audit-entry blocker, read-reference theft, and next-chain transaction leak are fixed in the final commits; coverage: codex ✓ / gemini ✗ (agy hung) → api ✓.

Generated by an LLM (Claude Fable 5 + Claude Sonnet 5), supervised by Kris.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
