### PR TITLE
test(txn): pin that commit retry exhaustion rejects the awaited request chain

### DIFF
--- a/unitTests/resources/requestPathRetryExhaustion.test.js
+++ b/unitTests/resources/requestPathRetryExhaustion.test.js
@@ -40,7 +40,11 @@ describe('request-path commit retry exhaustion rejects the awaited chain', () =>
 
 	afterEach(() => {
 		unhandled.length = 0; // isolate tests: one leak must not taint the following tests' assertions
+		// safety net: restore the commit stub even if a test bails before its finally runs
+		while (pendingRestores.length) pendingRestores.pop()();
 	});
+
+	const pendingRestores = [];
 
 	// Force native commits against the test database to fail: `reject` mode rejects with the given
 	// error code (the uncoordinated conflict path), `retryNow` mode resolves with the RETRY_NOW
@@ -59,7 +63,9 @@ describe('request-path commit retry exhaustion rejects the awaited chain', () =>
 			if (mode === 'retryNow') return Promise.resolve(RETRY_NOW_VALUE);
 			return Promise.reject(Object.assign(new Error('forced conflict'), { code }));
 		};
-		return { attempts, restore: () => (Transaction.prototype.commit = originalCommit) };
+		const restore = () => (Transaction.prototype.commit = originalCommit);
+		pendingRestores.push(restore);
+		return { attempts, restore };
 	}
 
 	async function writeThatExhausts(id) {
@@ -78,7 +84,8 @@ describe('request-path commit retry exhaustion rejects the awaited chain', () =>
 				() => ({ outcome: 'committed' }),
 				(error) => ({ outcome: 'rejected', error })
 			),
-			delay(ms).then(() => ({ outcome: 'hung' })),
+			// unref the race timer so a settled race doesn't keep the event loop alive for up to `ms`
+			delay(ms, undefined, { ref: false }).then(() => ({ outcome: 'hung' })),
 		]);
 	}
 

--- a/unitTests/resources/requestPathRetryExhaustion.test.js
+++ b/unitTests/resources/requestPathRetryExhaustion.test.js
@@ -38,6 +38,10 @@ describe('request-path commit retry exhaustion rejects the awaited chain', () =>
 		process.removeListener('unhandledRejection', onUnhandled);
 	});
 
+	afterEach(() => {
+		unhandled.length = 0; // isolate tests: one leak must not taint the following tests' assertions
+	});
+
 	// Force native commits against the test database to fail: `reject` mode rejects with the given
 	// error code (the uncoordinated conflict path), `retryNow` mode resolves with the RETRY_NOW
 	// sentinel (the coordinatedRetry conflict path). abort() stays real so retry transactions

--- a/unitTests/resources/requestPathRetryExhaustion.test.js
+++ b/unitTests/resources/requestPathRetryExhaustion.test.js
@@ -92,6 +92,10 @@ describe('request-path commit retry exhaustion rejects the awaited chain', () =>
 		} finally {
 			restore();
 		}
+		// unhandledRejection is emitted on a later event-loop turn than the rejection itself;
+		// drain before asserting or a leaked rejection could land after the check (and after
+		// the listener is removed in the after hook)
+		await delay(50);
 		assert.deepEqual(unhandled, [], 'exhaustion must not leak an unhandled rejection');
 	});
 
@@ -107,6 +111,10 @@ describe('request-path commit retry exhaustion rejects the awaited chain', () =>
 		} finally {
 			restore();
 		}
+		// unhandledRejection is emitted on a later event-loop turn than the rejection itself;
+		// drain before asserting or a leaked rejection could land after the check (and after
+		// the listener is removed in the after hook)
+		await delay(50);
 		assert.deepEqual(unhandled, [], 'exhaustion must not leak an unhandled rejection');
 	});
 
@@ -123,6 +131,10 @@ describe('request-path commit retry exhaustion rejects the awaited chain', () =>
 		} finally {
 			restore();
 		}
+		// unhandledRejection is emitted on a later event-loop turn than the rejection itself;
+		// drain before asserting or a leaked rejection could land after the check (and after
+		// the listener is removed in the after hook)
+		await delay(50);
 		assert.deepEqual(unhandled, [], 'exhaustion must not leak an unhandled rejection');
 	});
 });

--- a/unitTests/resources/requestPathRetryExhaustion.test.js
+++ b/unitTests/resources/requestPathRetryExhaustion.test.js
@@ -1,0 +1,128 @@
+require('../testUtils');
+const assert = require('assert');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const { transaction } = require('#src/resources/transaction');
+const { setTimeout: delay } = require('node:timers/promises');
+const RETRY_NOW_VALUE = require('@harperfast/rocksdb-js').constants.RETRY_NOW_VALUE;
+
+// A request-path (non-sourceApply) transaction whose commit conflicts past the retry cap must
+// REJECT the promise chain the request handler awaits — the caller gets a loud ServerError (500),
+// never a silent hang. This is the invariant behind harper#1785: the client-observed "permanent
+// ingest hang" was the retry loop outliving the client's socket, so the eventual exhaustion error
+// was written to a dead connection. These tests pin that the exhaustion error (a) rejects the
+// awaited transaction() promise on both native conflict-signaling paths (ERR_BUSY/ERR_TRY_AGAIN
+// rejection, and the coordinatedRetry RETRY_NOW sentinel), (b) does so after exactly
+// MAX_RETRIES + 1 attempts, and (c) never leaks an unhandled rejection.
+describe('request-path commit retry exhaustion rejects the awaited chain', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+	const MAX_RETRIES = 40; // mirrors resources/DatabaseTransaction.ts
+	let ExhaustTable;
+	const unhandled = [];
+	const onUnhandled = (error) => unhandled.push(error);
+
+	before(async function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		ExhaustTable = table({
+			table: 'RetryExhaustionTable',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'writer' }],
+			audit: true,
+		});
+		process.on('unhandledRejection', onUnhandled);
+	});
+
+	after(() => {
+		process.removeListener('unhandledRejection', onUnhandled);
+	});
+
+	// Force native commits against the test database to fail: `reject` mode rejects with the given
+	// error code (the uncoordinated conflict path), `retryNow` mode resolves with the RETRY_NOW
+	// sentinel (the coordinatedRetry conflict path). abort() stays real so retry transactions
+	// release their native handles. Scoped to the test table's native db handle — background
+	// timers (hdb_analytics aggregation) commit their own transactions during the ~20s backoff
+	// window, and failing those spawns unrelated retry chains that pollute the attempt count.
+	function failCommits(mode, code) {
+		const { Transaction } = require('@harperfast/rocksdb-js');
+		const originalCommit = Transaction.prototype.commit;
+		const targetDb = ExhaustTable.primaryStore.store.db;
+		const attempts = [];
+		Transaction.prototype.commit = function (...args) {
+			if (this.store?.db !== targetDb) return originalCommit.apply(this, args);
+			attempts.push(this.id);
+			if (mode === 'retryNow') return Promise.resolve(RETRY_NOW_VALUE);
+			return Promise.reject(Object.assign(new Error('forced conflict'), { code }));
+		};
+		return { attempts, restore: () => (Transaction.prototype.commit = originalCommit) };
+	}
+
+	async function writeThatExhausts(id) {
+		const context = {};
+		return transaction(context, async () => {
+			// read first so the transaction is created via getReadTxn (coordinatedRetry), matching the
+			// operations-API bulk upsert flow (ResourceBridge reads each record before writing)
+			await ExhaustTable.get(id, context);
+			await ExhaustTable.put({ id, writer: 'exhaust' }, context);
+		});
+	}
+
+	function raceOutcome(txnDone, ms) {
+		return Promise.race([
+			Promise.resolve(txnDone).then(
+				() => ({ outcome: 'committed' }),
+				(error) => ({ outcome: 'rejected', error })
+			),
+			delay(ms).then(() => ({ outcome: 'hung' })),
+		]);
+	}
+
+	it('rejects with the retry-exhaustion ServerError when commits reject (ERR_TRY_AGAIN)', async function () {
+		this.timeout(60000);
+		const { attempts, restore } = failCommits('reject', 'ERR_TRY_AGAIN');
+		try {
+			// full quadratic backoff runs here (~20s): this also pins that exhaustion surfaces in
+			// tens of seconds — well inside client socket timeouts — not minutes
+			const { outcome, error } = await raceOutcome(writeThatExhausts('try-again'), 50000);
+			assert.equal(outcome, 'rejected', 'the awaited transaction promise must reject, not hang or commit');
+			assert.match(error.message, /After 40 retries, unable to commit/);
+			assert.equal(error.statusCode, 500, 'the exhaustion error must carry an HTTP status');
+			assert.equal(attempts.length, MAX_RETRIES + 1, 'one initial attempt plus MAX_RETRIES retries');
+		} finally {
+			restore();
+		}
+		assert.deepEqual(unhandled, [], 'exhaustion must not leak an unhandled rejection');
+	});
+
+	it('rejects with the retry-exhaustion ServerError when commits reject (ERR_BUSY)', async function () {
+		this.timeout(60000);
+		const { attempts, restore } = failCommits('reject', 'ERR_BUSY');
+		try {
+			const { outcome, error } = await raceOutcome(writeThatExhausts('busy'), 50000);
+			assert.equal(outcome, 'rejected', 'the awaited transaction promise must reject, not hang or commit');
+			assert.match(error.message, /After 40 retries, unable to commit/);
+			assert.equal(error.statusCode, 500, 'the exhaustion error must carry an HTTP status');
+			assert.equal(attempts.length, MAX_RETRIES + 1, 'one initial attempt plus MAX_RETRIES retries');
+		} finally {
+			restore();
+		}
+		assert.deepEqual(unhandled, [], 'exhaustion must not leak an unhandled rejection');
+	});
+
+	it('rejects with the coordinated-retry exhaustion ServerError when commits resolve RETRY_NOW', async function () {
+		this.timeout(15000);
+		const { attempts, restore } = failCommits('retryNow');
+		try {
+			// coordinated retries recurse without backoff, so this path must fail fast
+			const { outcome, error } = await raceOutcome(writeThatExhausts('retry-now'), 10000);
+			assert.equal(outcome, 'rejected', 'the awaited transaction promise must reject, not hang or commit');
+			assert.match(error.message, /After 40 coordinated retries, unable to commit/);
+			assert.equal(error.statusCode, 500, 'the exhaustion error must carry an HTTP status');
+			assert.equal(attempts.length, MAX_RETRIES + 1, 'one initial attempt plus MAX_RETRIES retries');
+		} finally {
+			restore();
+		}
+		assert.deepEqual(unhandled, [], 'exhaustion must not leak an unhandled rejection');
+	});
+});


### PR DESCRIPTION
## Summary

Test-only. Closes out the #1785 follow-up ("retry-exhaustion error never reaches the HTTP caller"): investigation showed the propagation is **intact** on main — the 5.1.19 field symptom was retry-cycle latency (pre-#1696 per-record txn-log scans blocking the event loop) outliving the client's socket, not a swallowed rejection. These tests pin the invariant so it stays true:

- All three native conflict-signaling paths (`ERR_TRY_AGAIN`, `ERR_BUSY` rejections; coordinated `RETRY_NOW` sentinel) reject the awaited `transaction()` promise with the ServerError (statusCode 500) after exactly `MAX_RETRIES + 1` native attempts, in bounded time, with no unhandled rejection.

## Where to look

- The two rejection-path tests run the **real quadratic backoff (~19.5s each)** — deliberate, since bounded wall-clock is part of the invariant (the 5.1.19 failure mode was exactly this taking ~7 minutes). If the ~40s suite cost is unwanted, faking timers or a test-scoped `MAX_RETRY_DELAY_MS` override are the alternatives (raised by the Gemini review; left as-is intentionally).
- The commit stub is scoped to the test table's native db handle: a global stub poisons background `hdb_analytics` aggregation transactions, which spawn their own 40-retry chains and pollute the attempt count (708 attempts observed).

Generated by an LLM (Claude Fable 5), supervised by Kris.

🤖 Generated with [Claude Code](https://claude.com/claude-code)