### PR TITLE
Add gemini-code-assist styleguide to reduce review noise

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -3,8 +3,12 @@ memory_config:
   disabled: false
 code_review:
   disable: false
+  # MEDIUM (the default) kept: LOW drowns reviews in nits; HIGH would drop legitimate medium findings.
+  # Severity honesty is enforced via styleguide.md instead.
   comment_severity_threshold: MEDIUM
-  max_review_comments: -1
+  # Cap total comments per review; measured pattern was the same finding repeated per-hunk (4x in one PR).
+  # A finite cap forces prioritization; styleguide.md additionally requires one comment per distinct finding.
+  max_review_comments: 15
   pull_request_opened:
     help: false
     summary: false
@@ -13,4 +17,4 @@ code_review:
 ignore_patterns:
   - 'package-lock.json'
 
-# Note that you can also include a styleguide.md which provides a system prompt for the AI to follow for the reviews.
+# styleguide.md alongside this file is injected into every review prompt (house style + review discipline).

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,43 @@
+# Harper review styleguide
+
+Harper is a high-performance Node.js database/application platform. `AGENTS.md` at the repo root is the
+authority on conventions — when in doubt, defer to it rather than general best practice.
+
+## House style (do not flag these as issues)
+
+- Tests use plain `node:assert` (`import assert from 'node:assert'`). Do NOT recommend Chai/expect, and do
+  NOT recommend `node:assert/strict` — plain `assert` is the deliberate house style and `/strict` imports
+  are lint-rejected. Use `assert.strictEqual`/`assert.deepStrictEqual` explicitly where strict semantics
+  are needed.
+- Formatting is Prettier-enforced: tabs for indentation, semicolons. Never comment on formatting.
+- TypeScript runs via Node type stripping (TypeStrip), so: no TS `enum`s, no constructor parameter
+  properties, relative imports must include the file extension, and Node builtins use the `node:` prefix.
+  These are constraints, not style choices.
+- `== null` / `!= null` loose equality is the intentional idiom for null-or-undefined checks. Do not
+  suggest `===` there.
+- Circular imports between modules are acceptable in this codebase by design; do not flag them.
+- New npm dependencies require explicit justification (`dependencies.md`); implementing in-repo is often
+  preferred. Flag new dependencies, don't suggest adding them.
+- Use named exports only; no default exports in new code.
+
+## Review discipline
+
+- Before asserting that a function, method, guard, or API "does not exist" or "is never handled", verify
+  by reading the relevant file(s) in this repo. If you cannot verify, phrase it as a question, not a finding.
+- State each distinct finding exactly once, with a list of all affected locations. Never repeat the same
+  comment on multiple similar hunks.
+- Only review code changed in this PR. No findings on pre-existing/unchanged lines, and ignore artifacts
+  of rebases/merges that are not authored changes.
+- Severity honesty: `critical`/`high` requires a concrete failure scenario (specific input or sequence →
+  wrong outcome) stated in the comment. Cosmetic, by-design, or test-only observations are `low` at most.
+- Performance is a feature here. Do flag hot-path allocations, unnecessary async/await layers, and
+  per-request work that could be hoisted. Do NOT suggest defensive try/catch, extra validation layers, or
+  cloning on hot paths without evidence of an actual failure mode.
+
+## Threat model
+
+App developers deploying code to Harper are trusted administrators; there is no untrusted multi-tenant
+code execution, and deployment is containerized (Docker/Fabric). Do not raise sandbox-escape,
+"malicious plugin", or intra-process isolation concerns that assume untrusted application code. Real
+security findings (authn/authz bypass on network-facing surfaces, injection from external input) are
+still in scope.


### PR DESCRIPTION
FYI, this was put together based on a review of the Gemini's PR reviews over the last month and where it was noisy vs helpful.

Adds a `.gemini/styleguide.md` (injected into every Gemini Code Assist review prompt) and tightens the existing `.gemini/config.yaml`, calibrated from a 30-day mining pass over 94 harper/harper-pro PRs (261 review findings).

Measured noise patterns this targets:
- Stale-convention advice contradicting house style (recommended Chai over `node:assert`; recommended `node:assert/strict` on 4+ separate PRs — both backwards).
- False existence claims — asserting functions/guards/APIs don't exist when they do (3 false claims in one PR).
- The same finding repeated verbatim per-hunk (4x in one PR) instead of once with a location list.
- Findings on pre-existing/unchanged code and rebase artifacts.
- Severity inflation — cosmetic/by-design/test-only items flagged as blockers.

Changes:
- `.gemini/styleguide.md` (new): Harper house style facts (plain `node:assert`, TypeStrip constraints, `== null` idiom, circular-imports-by-design, dependency policy), review discipline (verify existence claims, dedupe findings, changed-lines-only, concrete failure scenario required for high severity, hot-path performance emphasis), and threat-model framing (trusted app developers, no untrusted multi-tenant code).
- `.gemini/config.yaml`: `max_review_comments` -1 (unlimited) → 15 to cap duplication-driven volume; severity threshold stays MEDIUM (commented rationale inline).

Generated by an LLM (Claude Fable 5) working with Kris.

🤖 Generated with [Claude Code](https://claude.com/claude-code)