### PR TITLE
fix(cli): separate transport auth from operation payload for add_user/alter_user

### DIFF
--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -153,7 +153,102 @@ function operationFields(req: any): any {
 	return fields;
 }
 
-export { cliOperations, buildRequest };
+function basicAuthHeader(username: string, password: string): string {
+	return `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+}
+
+/**
+ * Picks the HTTP Basic credentials for a targeted operation from the first source that supplies
+ * any, in precedence order: the dedicated `auth_username=`/`auth_password=` args, then userinfo
+ * embedded in the target URL, then each env-var pair. Every source is all-or-nothing: pairing one
+ * source's username with another's password would send one identity's name with a different
+ * identity's secret, so a half-specified source is never completed from the next one (an empty
+ * value — a blank CI variable, say — counts as specified-but-missing).
+ *
+ * Returns undefined when no source is configured at all, which leaves authentication to the saved
+ * `harper login` token and, failing that, the legacy `username=`/`password=` payload fallback.
+ */
+function resolveTransportCredentials(req: any, urlCredentials: { username: string; password: string }) {
+	const sources = [
+		{
+			name: '`auth_username=`/`auth_password=`',
+			username: req.auth_username,
+			password: req.auth_password,
+			incompleteIsFatal: true,
+		},
+		{
+			name: 'the target URL',
+			// A URL with no userinfo yields empty strings, which here mean "absent" — unlike an
+			// explicitly passed empty value, there is nothing for the user to have gotten wrong.
+			username: urlCredentials.username || undefined,
+			password: urlCredentials.password || undefined,
+			incompleteIsFatal: true,
+		},
+		{
+			name: 'HARPER_CLI_USERNAME/HARPER_CLI_PASSWORD',
+			username: process.env.HARPER_CLI_USERNAME,
+			password: process.env.HARPER_CLI_PASSWORD,
+			incompleteIsFatal: false,
+		},
+		{
+			name: 'CLI_TARGET_USERNAME/CLI_TARGET_PASSWORD',
+			username: process.env.CLI_TARGET_USERNAME,
+			password: process.env.CLI_TARGET_PASSWORD,
+			incompleteIsFatal: false,
+		},
+	];
+	// A source counts as configured once either half is *supplied*, empty or not: `auth_username=`
+	// with an unset CI variable behind it is a broken credential, and quietly falling through to a
+	// saved admin token would run the command as the wrong identity.
+	for (const { name, username, password, incompleteIsFatal } of sources) {
+		if (username === undefined && password === undefined) continue;
+		if (!username || !password) {
+			const missing = username ? 'a password' : password ? 'a username' : 'a username and a password';
+			const detail = `${name} is missing ${missing}, and credentials are never combined across sources`;
+			// Credentials passed explicitly for this command have no other purpose, so an
+			// incomplete pair is a mistake worth failing on. The env vars double as `harper login`
+			// inputs — a lone HARPER_CLI_USERNAME or HARPER_CLI_PASSWORD is a supported login idiom
+			// with the other half prompted for — so an incomplete pair there is skipped with a
+			// warning instead of breaking every later operation in the same shell or CI job.
+			if (incompleteIsFatal) throw new Error(`Incomplete credentials: ${detail}.`);
+			console.error(`Ignoring incomplete credentials: ${detail}.`);
+			continue;
+		}
+		return { username, password };
+	}
+}
+
+// Secret-valued CLI args, whatever their role (transport auth or operation payload). Logging a
+// parsed CLI request must go through redactCredentials() so a password doesn't land in the log
+// file — the command line already exposes it to shell history and process listings; the log
+// shouldn't be a third copy.
+const SECRET_FIELDS = new Set(['auth_password', 'password']);
+
+// `target=https://admin:secret@host` carries a password too, so masking the userinfo is part of
+// making a target printable — the same string is echoed by the "Connecting to ..." line.
+function redactTargetUrl(target: unknown): unknown {
+	if (typeof target !== 'string') return target;
+	try {
+		const url = new URL(target);
+		if (!url.password) return target;
+		url.password = '***';
+		return url.toString();
+	} catch {
+		return target;
+	}
+}
+
+function redactCredentials(req: any): any {
+	const redacted: any = {};
+	for (const [key, value] of Object.entries(req)) {
+		if (SECRET_FIELDS.has(key) && value) redacted[key] = '***';
+		else if (key === 'target') redacted[key] = redactTargetUrl(value);
+		else redacted[key] = value;
+	}
+	return redacted;
+}
+
+export { cliOperations, buildRequest, redactCredentials };
 const PREPARE_OPERATION: any = {
 	deploy_component: async (req) => {
 		if (req.package) {
@@ -243,44 +338,28 @@ async function cliOperations(req: any, skipResponseLog = false) {
 	const allCredentials = loadCredentials();
 	req.target = normalizeTarget(resolveTarget(req, allCredentials));
 	let target;
+	let urlCredentials = { username: '', password: '' };
 	if (req.target) {
+		let parsedTarget;
 		try {
-			target = new URL(req.target);
+			parsedTarget = new URL(req.target);
 		} catch (error) {
 			try {
-				target = new URL(`https://${req.target}:9925`);
+				parsedTarget = new URL(`https://${req.target}:9925`);
 			} catch {
 				throw error;
 			}
 		}
 		const resolvedTarget = req.target;
+		urlCredentials = { username: parsedTarget.username, password: parsedTarget.password };
 		target = {
-			protocol: target.protocol,
-			hostname: target.hostname,
-			port: target.port,
-			// Dedicated auth args win outright (the CI/CD non-interactive path: authenticate as
-			// one user while creating/altering a different one). URL-embedded creds are next —
-			// also unambiguous auth intent. Env-var auth then wins over plain `username=`/
-			// `password=` so a configured CI login isn't silently shadowed by an operation's
-			// payload fields (e.g. add_user's `username=`/`password=` are the new user's
-			// credentials, not the caller's) — `username=`/`password=` remain the auth fallback
-			// for ops where they legitimately ARE the auth and nothing else is configured.
-			username:
-				req.auth_username ||
-				target.username ||
-				process.env.HARPER_CLI_USERNAME ||
-				process.env.CLI_TARGET_USERNAME ||
-				req.username,
-			password:
-				req.auth_password ||
-				target.password ||
-				process.env.HARPER_CLI_PASSWORD ||
-				process.env.CLI_TARGET_PASSWORD ||
-				req.password,
+			protocol: parsedTarget.protocol,
+			hostname: parsedTarget.hostname,
+			port: parsedTarget.port,
 			rejectUnauthorized: req.rejectUnauthorized,
 			resolvedTarget,
 		};
-		console.error(`Connecting to ${resolvedTarget}`);
+		console.error(`Connecting to ${redactTargetUrl(resolvedTarget)}`);
 	} else {
 		// if we aren't doing a targeted operation (like deploy), we initialize the config and verify that local harper
 		// is running and that we can communicate with it.
@@ -305,8 +384,15 @@ async function cliOperations(req: any, skipResponseLog = false) {
 		options.method = 'POST';
 		options.headers = { 'Content-Type': 'application/json' };
 		options.timeout = SSE_OPERATIONS.has(req.operation) ? SSE_OPERATION_TIMEOUT_MS : CLI_OPERATION_TIMEOUT_MS;
-		if (target?.username) {
-			options.headers.Authorization = `Basic ${Buffer.from(`${target.username}:${target.password}`).toString('base64')}`;
+		// Authentication precedence: explicitly configured credentials (dedicated args, URL
+		// userinfo, env vars) beat everything, then the saved `harper login` token, and only then
+		// the legacy `username=`/`password=` payload fallback below. The saved token must outrank
+		// that fallback: for add_user/alter_user those args are the credentials of the user being
+		// created/altered, so treating them as auth would authenticate as a user who doesn't exist
+		// yet (or as the wrong identity) instead of using the admin's existing session.
+		const transportCredentials = target ? resolveTransportCredentials(req, urlCredentials) : undefined;
+		if (transportCredentials) {
+			options.headers.Authorization = basicAuthHeader(transportCredentials.username, transportCredentials.password);
 		} else if (allCredentials) {
 			let tokens = null;
 			let lookupKey = null;
@@ -348,6 +434,13 @@ async function cliOperations(req: any, skipResponseLog = false) {
 				}
 				options.headers.Authorization = `Bearer ${tokens.operation_token}`;
 			}
+		}
+		// Legacy fallback for operations where `username=`/`password=` genuinely ARE the caller's
+		// credentials (e.g. `create_table username= password=`) and nothing else is configured.
+		// Both are required — a lone `username=` (as in `drop_user username=bob`) is payload, not
+		// a credential.
+		if (target && !options.headers.Authorization && req.username && req.password) {
+			options.headers.Authorization = basicAuthHeader(req.username, req.password);
 		}
 		// Streaming deploy (multipart upload + SSE progress) only works against >= 5.1 servers.
 		// When deploying to a remote target, probe its version first and downgrade to the

--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -221,7 +221,8 @@ function resolveTransportCredentials(req: any, urlCredentials: { username: strin
 // Secret-valued CLI args, whatever their role (transport auth or operation payload). Logging a
 // parsed CLI request must go through redactCredentials() so a password doesn't land in the log
 // file — the command line already exposes it to shell history and process listings; the log
-// shouldn't be a third copy.
+// shouldn't be a third copy. This list is by field name, not exhaustive — any future secret-bearing
+// arg (a token, a key) needs to be added here explicitly, or it will reach logger.trace unredacted.
 const SECRET_FIELDS = new Set(['auth_password', 'password']);
 
 // `target=https://admin:secret@host` carries a password too, so masking the userinfo is part of

--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -34,11 +34,14 @@ const LOCAL_NOT_RUNNING_MESSAGE = 'Harper is not running. Use `harperdb run` (or
 const SSE_OPERATIONS = new Set(['deploy_component']);
 
 // Properties on `req` that the CLI itself uses for transport/UX, not the operations API.
-// They never get serialized into the request body.
+// They never get serialized into the request body. `username`/`password` are deliberately
+// NOT here: those args are payload fields (e.g. the user add_user/alter_user create/alter),
+// not transport — use `auth_username`/`auth_password` (or env-var/`harper login` auth) to
+// authenticate as a different user than the one being operated on.
 const TRANSPORT_ONLY_FIELDS = new Set([
 	'target',
-	'username',
-	'password',
+	'auth_username',
+	'auth_password',
 	'rejectUnauthorized',
 	'json',
 	'skip_node_modules',
@@ -255,8 +258,25 @@ async function cliOperations(req: any, skipResponseLog = false) {
 			protocol: target.protocol,
 			hostname: target.hostname,
 			port: target.port,
-			username: req.username || target.username || process.env.HARPER_CLI_USERNAME || process.env.CLI_TARGET_USERNAME,
-			password: req.password || target.password || process.env.HARPER_CLI_PASSWORD || process.env.CLI_TARGET_PASSWORD,
+			// Dedicated auth args win outright (the CI/CD non-interactive path: authenticate as
+			// one user while creating/altering a different one). URL-embedded creds are next —
+			// also unambiguous auth intent. Env-var auth then wins over plain `username=`/
+			// `password=` so a configured CI login isn't silently shadowed by an operation's
+			// payload fields (e.g. add_user's `username=`/`password=` are the new user's
+			// credentials, not the caller's) — `username=`/`password=` remain the auth fallback
+			// for ops where they legitimately ARE the auth and nothing else is configured.
+			username:
+				req.auth_username ||
+				target.username ||
+				process.env.HARPER_CLI_USERNAME ||
+				process.env.CLI_TARGET_USERNAME ||
+				req.username,
+			password:
+				req.auth_password ||
+				target.password ||
+				process.env.HARPER_CLI_PASSWORD ||
+				process.env.CLI_TARGET_PASSWORD ||
+				req.password,
 			rejectUnauthorized: req.rejectUnauthorized,
 			resolvedTarget,
 		};
@@ -404,7 +424,10 @@ async function cliOperations(req: any, skipResponseLog = false) {
 				body = fields;
 			}
 		} else {
-			body = req;
+			// Same TRANSPORT_ONLY_FIELDS stripping as the deploy body paths above — auth_username/
+			// auth_password (and target/rejectUnauthorized/json/etc.) must never reach the wire as
+			// operation-payload fields, on this path either.
+			body = operationFields(req);
 		}
 		let response: any = await httpRequest(options, body);
 

--- a/bin/harper.ts
+++ b/bin/harper.ts
@@ -27,6 +27,9 @@ copy-db <source> <target>       - Copies a database from source path to target p
 dev <path>                      - Run the application in dev mode with debugging, foreground logging, no auth
 install                         - Install harperdb
 <api-operation> <param>=<value> - Run an API operation and return result to the CLI, not all operations are supported
+                                   For non-interactive auth (CI/CD) as a different user than the one being
+                                   operated on (e.g. add_user/alter_user), pass auth_username=<value>
+                                   auth_password=<value>, or set HARPER_CLI_USERNAME/HARPER_CLI_PASSWORD.
 login [target] [username]       - Login to a remote or local Harper instance
 logout [target]                 - Logout from Harper and clear saved JWT
 mcp [subcommand]                - MCP stdio bridge / print-config / doctor (see 'harper mcp help')

--- a/bin/harper.ts
+++ b/bin/harper.ts
@@ -32,6 +32,10 @@ install                         - Install harperdb
                                    or run 'harper login'. The equivalent auth_username=<value>
                                    auth_password=<value> args also work, but a password passed as an
                                    argument is exposed in shell history, process listings and CI logs.
+                                   A saved login token always outranks username=/password=, so a
+                                   stale token that fails to refresh will 401 rather than falling
+                                   back to them — run 'harper logout' or pass auth_username=/
+                                   auth_password= to override it.
 login [target] [username]       - Login to a remote or local Harper instance
 logout [target]                 - Logout from Harper and clear saved JWT
 mcp [subcommand]                - MCP stdio bridge / print-config / doctor (see 'harper mcp help')

--- a/bin/harper.ts
+++ b/bin/harper.ts
@@ -27,9 +27,11 @@ copy-db <source> <target>       - Copies a database from source path to target p
 dev <path>                      - Run the application in dev mode with debugging, foreground logging, no auth
 install                         - Install harperdb
 <api-operation> <param>=<value> - Run an API operation and return result to the CLI, not all operations are supported
-                                   For non-interactive auth (CI/CD) as a different user than the one being
-                                   operated on (e.g. add_user/alter_user), pass auth_username=<value>
-                                   auth_password=<value>, or set HARPER_CLI_USERNAME/HARPER_CLI_PASSWORD.
+                                   To authenticate as a different user than the one being operated on
+                                   (e.g. add_user/alter_user), set HARPER_CLI_USERNAME/HARPER_CLI_PASSWORD
+                                   or run 'harper login'. The equivalent auth_username=<value>
+                                   auth_password=<value> args also work, but a password passed as an
+                                   argument is exposed in shell history, process listings and CI logs.
 login [target] [username]       - Login to a remote or local Harper instance
 logout [target]                 - Logout from Harper and clear saved JWT
 mcp [subcommand]                - MCP stdio bridge / print-config / doctor (see 'harper mcp help')
@@ -156,7 +158,7 @@ async function harper() {
 			return require('./run').main();
 		default:
 			const cliApiOp = cliOperations.buildRequest();
-			logger.trace('calling cli operations with:', cliApiOp);
+			logger.trace('calling cli operations with:', cliOperations.redactCredentials(cliApiOp));
 			await cliOperations.cliOperations(cliApiOp);
 			return;
 	}

--- a/bin/login.ts
+++ b/bin/login.ts
@@ -46,14 +46,21 @@ export async function login(targetArg: string, usernameArg: string): Promise<voi
 
 	target = normalizeTarget(target);
 
+	// Whichever env namespace supplies anything owns both halves: taking a username from
+	// HARPER_CLI_USERNAME and a password from CLI_TARGET_PASSWORD would log in as one identity
+	// using another's secret. A half the chosen namespace doesn't set is prompted for, never
+	// borrowed from the other one.
+	const envPrefix = ['HARPER_CLI', 'CLI_TARGET'].find(
+		(prefix) => process.env[`${prefix}_USERNAME`] || process.env[`${prefix}_PASSWORD`]
+	);
+	const envUsername = envPrefix && process.env[`${envPrefix}_USERNAME`];
+	const envPassword = envPrefix && process.env[`${envPrefix}_PASSWORD`];
+
 	let targetUsername = usernameArg;
 	if (!targetUsername) {
-		if (process.env.CLI_TARGET_USERNAME) {
-			targetUsername = process.env.CLI_TARGET_USERNAME;
-			console.log(chalk.gray(`Using username from CLI_TARGET_USERNAME environment variable: ${targetUsername}`));
-		} else if (process.env.HARPER_CLI_USERNAME) {
-			targetUsername = process.env.HARPER_CLI_USERNAME;
-			console.log(chalk.gray(`Using username from HARPER_CLI_USERNAME environment variable: ${targetUsername}`));
+		if (envUsername) {
+			targetUsername = envUsername;
+			console.log(chalk.gray(`Using username from ${envPrefix}_USERNAME environment variable: ${targetUsername}`));
 		} else {
 			({ username: targetUsername } = await inquirer.prompt({
 				type: 'input',
@@ -63,11 +70,10 @@ export async function login(targetArg: string, usernameArg: string): Promise<voi
 		}
 	}
 
-	let targetPassword = process.env.CLI_TARGET_PASSWORD || process.env.HARPER_CLI_PASSWORD;
+	let targetPassword = envPassword;
 
 	if (targetPassword) {
-		const envVarName = process.env.CLI_TARGET_PASSWORD ? 'CLI_TARGET_PASSWORD' : 'HARPER_CLI_PASSWORD';
-		console.log(chalk.gray(`Using password from ${envVarName} environment variable.`));
+		console.log(chalk.gray(`Using password from ${envPrefix}_PASSWORD environment variable.`));
 	} else {
 		// `type: 'password'` with no `mask` hides input entirely — nothing is echoed until Enter.
 		({ password: targetPassword } = await inquirer.prompt({
@@ -86,6 +92,11 @@ export async function login(targetArg: string, usernameArg: string): Promise<voi
 		operation: 'create_authentication_tokens',
 		username: targetUsername,
 		password: targetPassword,
+		// Also passed as dedicated transport credentials: these ARE the caller's credentials, so
+		// the request must authenticate as them rather than reach for a saved token — which, on a
+		// re-login after expiry, would try (and fail) to refresh the very token being replaced.
+		auth_username: targetUsername,
+		auth_password: targetPassword,
 		target,
 	};
 

--- a/unitTests/bin/cliOperations.test.js
+++ b/unitTests/bin/cliOperations.test.js
@@ -765,4 +765,164 @@ describe('cliOperations', () => {
 			}
 		});
 	});
+
+	describe('dedicated auth args vs operation payload fields (harper#1872)', () => {
+		const captureRequest = () => {
+			const calls = [];
+			commonUtilsModule.httpRequest = async (options, body) => {
+				calls.push({ options, body });
+				return { statusCode: 200, body: JSON.stringify({ success: true }) };
+			};
+			return calls;
+		};
+
+		it('authenticates with auth_username/auth_password while add_user payload username/password stay in the body, not the auth header', async () => {
+			const calls = captureRequest();
+
+			await cliOperationsModule.cliOperations(
+				{
+					operation: 'add_user',
+					target: 'example.com',
+					auth_username: 'admin',
+					auth_password: 'admin-secret',
+					username: 'newuser',
+					password: 'new-user-secret',
+				},
+				true
+			);
+
+			assert.strictEqual(calls.length, 1);
+			const { options, body } = calls[0];
+			assert.strictEqual(
+				options.headers.Authorization,
+				`Basic ${Buffer.from('admin:admin-secret').toString('base64')}`
+			);
+			assert.strictEqual(body.username, 'newuser');
+			assert.strictEqual(body.password, 'new-user-secret');
+			assert.strictEqual(body.auth_username, undefined);
+			assert.strictEqual(body.auth_password, undefined);
+			assert.strictEqual(body.target, undefined);
+		});
+
+		it('falls back to plain username/password as auth when no auth_username/env-var auth is configured (backward compatible)', async () => {
+			const calls = captureRequest();
+
+			await cliOperationsModule.cliOperations(
+				{ operation: 'test', target: 'example.com', username: 'admin', password: 'admin-secret' },
+				true
+			);
+
+			const { options } = calls[0];
+			assert.strictEqual(
+				options.headers.Authorization,
+				`Basic ${Buffer.from('admin:admin-secret').toString('base64')}`
+			);
+		});
+
+		it('prefers env-var auth over payload username/password when auth_username/auth_password are absent', async () => {
+			const calls = captureRequest();
+			const originalUser = process.env.HARPER_CLI_USERNAME;
+			const originalPass = process.env.HARPER_CLI_PASSWORD;
+			process.env.HARPER_CLI_USERNAME = 'env-admin';
+			process.env.HARPER_CLI_PASSWORD = 'env-secret';
+			try {
+				await cliOperationsModule.cliOperations(
+					{ operation: 'add_user', target: 'example.com', username: 'newuser', password: 'new-user-secret' },
+					true
+				);
+			} finally {
+				if (originalUser === undefined) delete process.env.HARPER_CLI_USERNAME;
+				else process.env.HARPER_CLI_USERNAME = originalUser;
+				if (originalPass === undefined) delete process.env.HARPER_CLI_PASSWORD;
+				else process.env.HARPER_CLI_PASSWORD = originalPass;
+			}
+
+			const { options, body } = calls[0];
+			assert.strictEqual(
+				options.headers.Authorization,
+				`Basic ${Buffer.from('env-admin:env-secret').toString('base64')}`
+			);
+			// Env-var auth wins the transport leg, but the payload fields for the user being
+			// created are untouched — this is the whole point of the fix.
+			assert.strictEqual(body.username, 'newuser');
+			assert.strictEqual(body.password, 'new-user-secret');
+		});
+
+		it('strips auth_username/auth_password from a package deploy JSON body (the same non-multipart body path add_user uses)', async () => {
+			const calls = [];
+			commonUtilsModule.httpRequest = async (options, body) => {
+				calls.push({ options, body });
+				if (body?.operation === 'registration_info') {
+					return { statusCode: 200, body: JSON.stringify({ version: '5.0.31' }) };
+				}
+				return { statusCode: 200, body: JSON.stringify({ message: 'Successfully deployed', success: true }) };
+			};
+
+			await cliOperationsModule.cliOperations(
+				{
+					operation: 'deploy_component',
+					package: '@scope/widget',
+					project: 'widget',
+					target: 'example.com',
+					auth_username: 'admin',
+					auth_password: 'admin-secret',
+				},
+				true
+			);
+
+			assert.strictEqual(calls.length, 2);
+			const deploy = calls[1];
+			assert.strictEqual(
+				deploy.options.headers.Authorization,
+				`Basic ${Buffer.from('admin:admin-secret').toString('base64')}`
+			);
+			assert.strictEqual(deploy.body.auth_username, undefined);
+			assert.strictEqual(deploy.body.auth_password, undefined);
+		});
+
+		it('strips auth_username/auth_password from the multipart directory-deploy body fields', async () => {
+			const originalScan = packageComponentModule.scanPackageDirectory;
+			const originalStream = packageComponentModule.streamPackagedDirectory;
+			packageComponentModule.scanPackageDirectory = async () => ({ totalSize: 0, danglingSymlinks: [] });
+			packageComponentModule.streamPackagedDirectory = () => Readable.from(Buffer.from('fake-tar-bytes'));
+
+			const sseDoneResponse = (result) =>
+				Object.assign(Readable.from([`event: done\ndata: ${JSON.stringify({ result })}\n\n`]), {
+					statusCode: 200,
+					headers: { 'content-type': 'text/event-stream' },
+				});
+
+			let multipartText;
+			commonUtilsModule.httpRequest = async (options, body) => {
+				if (body && typeof body.operation === 'string' && body.operation === 'registration_info') {
+					return { statusCode: 200, body: JSON.stringify({ version: '5.1.7' }) };
+				}
+				// The multipart deploy body: a stream of form-data chunks, not a plain object.
+				const chunks = [];
+				for await (const chunk of body) chunks.push(Buffer.from(chunk));
+				multipartText = Buffer.concat(chunks).toString('utf8');
+				return sseDoneResponse({ message: 'Successfully deployed', success: true });
+			};
+
+			try {
+				await cliOperationsModule.cliOperations(
+					{
+						operation: 'deploy_component',
+						project: 'widget',
+						target: 'example.com',
+						auth_username: 'admin',
+						auth_password: 'admin-secret',
+					},
+					true
+				);
+			} finally {
+				packageComponentModule.scanPackageDirectory = originalScan;
+				packageComponentModule.streamPackagedDirectory = originalStream;
+			}
+
+			assert.doesNotMatch(multipartText, /name="auth_username"/);
+			assert.doesNotMatch(multipartText, /name="auth_password"/);
+			assert.match(multipartText, /name="operation"/);
+		});
+	});
 });

--- a/unitTests/bin/cliOperations.test.js
+++ b/unitTests/bin/cliOperations.test.js
@@ -924,5 +924,238 @@ describe('cliOperations', () => {
 			assert.doesNotMatch(multipartText, /name="auth_password"/);
 			assert.match(multipartText, /name="operation"/);
 		});
+
+		// The credentials of the user being created/altered must never outrank the caller's own
+		// saved session — otherwise `harper login` + `add_user` authenticates as a user that
+		// doesn't exist yet and 401s.
+		for (const operation of ['add_user', 'alter_user']) {
+			it(`uses the saved login token for ${operation} while its payload username/password stay in the body`, async () => {
+				saveCredentials('https://example.com:9925/', {
+					operation_token: 'admin-token',
+					refresh_token: 'admin-refresh',
+				});
+				tokenAuthModule.isJWTExpired = () => false;
+				const calls = captureRequest();
+
+				await cliOperationsModule.cliOperations(
+					{
+						operation,
+						target: 'example.com',
+						username: 'newuser',
+						password: 'new-user-secret',
+						role: 'cluster_user',
+					},
+					true
+				);
+
+				const { options, body } = calls[0];
+				assert.strictEqual(options.headers.Authorization, 'Bearer admin-token');
+				assert.strictEqual(body.username, 'newuser');
+				assert.strictEqual(body.password, 'new-user-secret');
+			});
+		}
+
+		it('does not treat a lone payload username as auth (drop_user with a saved token)', async () => {
+			saveCredentials('https://example.com:9925/', { operation_token: 'admin-token' });
+			tokenAuthModule.isJWTExpired = () => false;
+			const calls = captureRequest();
+
+			await cliOperationsModule.cliOperations({ operation: 'drop_user', target: 'example.com', username: 'bob' }, true);
+
+			const { options, body } = calls[0];
+			assert.strictEqual(options.headers.Authorization, 'Bearer admin-token');
+			assert.strictEqual(body.username, 'bob');
+		});
+
+		it('authenticates with the legacy CLI_TARGET_USERNAME/CLI_TARGET_PASSWORD pair', async () => {
+			const calls = captureRequest();
+			process.env.CLI_TARGET_USERNAME = 'legacy-admin';
+			process.env.CLI_TARGET_PASSWORD = 'legacy-secret';
+			try {
+				await cliOperationsModule.cliOperations({ operation: 'test', target: 'example.com' }, true);
+			} finally {
+				delete process.env.CLI_TARGET_USERNAME;
+				delete process.env.CLI_TARGET_PASSWORD;
+			}
+
+			assert.strictEqual(
+				calls[0].options.headers.Authorization,
+				`Basic ${Buffer.from('legacy-admin:legacy-secret').toString('base64')}`
+			);
+		});
+
+		describe('incomplete credential sources', () => {
+			let originalExit;
+			let originalConsoleError;
+			let consoleErrors;
+			let exitCode;
+
+			beforeEach(() => {
+				originalExit = process.exit;
+				originalConsoleError = console.error;
+				consoleErrors = [];
+				console.error = (...args) => consoleErrors.push(args.join(' '));
+				exitCode = undefined;
+				process.exit = (code) => {
+					exitCode = code;
+					throw new ProcessExitSignal(code);
+				};
+			});
+
+			afterEach(() => {
+				process.exit = originalExit;
+				console.error = originalConsoleError;
+			});
+
+			// The dangerous shape: without pair validation, `auth_username` would be paired with
+			// the *payload* password and the admin name sent with the new user's secret.
+			it('fails instead of pairing auth_username with a password from another source', async () => {
+				captureRequest();
+
+				await assert.rejects(
+					() =>
+						cliOperationsModule.cliOperations(
+							{
+								operation: 'add_user',
+								target: 'example.com',
+								auth_username: 'admin',
+								username: 'newuser',
+								password: 'new-user-secret',
+							},
+							true
+						),
+					ProcessExitSignal
+				);
+
+				assert.strictEqual(exitCode, 1);
+				assert.ok(consoleErrors.some((line) => line.includes('Incomplete credentials') && line.includes('username')));
+			});
+
+			it('fails on a lone auth_password', async () => {
+				captureRequest();
+
+				await assert.rejects(
+					() =>
+						cliOperationsModule.cliOperations(
+							{ operation: 'test', target: 'example.com', auth_password: 'admin-secret' },
+							true
+						),
+					ProcessExitSignal
+				);
+
+				assert.ok(consoleErrors.some((line) => line.includes('Incomplete credentials') && line.includes('password')));
+			});
+
+			// An empty value is "set but missing", not "unset" — a blank CI variable must not slip
+			// through the way `||` let it.
+			it('treats an empty auth_password as missing rather than absent', async () => {
+				captureRequest();
+
+				await assert.rejects(
+					() =>
+						cliOperationsModule.cliOperations(
+							{ operation: 'test', target: 'example.com', auth_username: 'admin', auth_password: '' },
+							true
+						),
+					ProcessExitSignal
+				);
+
+				assert.ok(consoleErrors.some((line) => line.includes('Incomplete credentials')));
+			});
+
+			// Unlike the args, a lone HARPER_CLI_USERNAME is a legitimate `harper login` idiom
+			// (the password is prompted for), so it must not break every later operation in the
+			// same shell — it is skipped, loudly, and the saved token is used instead.
+			it('warns and falls through to the saved token when only one env var of a pair is set', async () => {
+				saveCredentials('https://example.com:9925/', { operation_token: 'admin-token' });
+				tokenAuthModule.isJWTExpired = () => false;
+				const calls = captureRequest();
+				process.env.HARPER_CLI_USERNAME = 'env-admin';
+				delete process.env.HARPER_CLI_PASSWORD;
+				try {
+					await cliOperationsModule.cliOperations({ operation: 'test', target: 'example.com' }, true);
+				} finally {
+					delete process.env.HARPER_CLI_USERNAME;
+				}
+
+				assert.strictEqual(calls[0].options.headers.Authorization, 'Bearer admin-token');
+				assert.ok(consoleErrors.some((line) => line.includes('Ignoring incomplete credentials')));
+			});
+
+			// `auth_username=$ADMIN_USER auth_password=$ADMIN_PASS` with both CI variables unset
+			// arrives as two empty strings. Falling through would run the command as whoever the
+			// saved token belongs to instead of failing.
+			it('fails when both dedicated auth args are supplied but empty', async () => {
+				saveCredentials('https://example.com:9925/', { operation_token: 'admin-token' });
+				tokenAuthModule.isJWTExpired = () => false;
+				captureRequest();
+
+				await assert.rejects(
+					() =>
+						cliOperationsModule.cliOperations(
+							{ operation: 'test', target: 'example.com', auth_username: '', auth_password: '' },
+							true
+						),
+					ProcessExitSignal
+				);
+
+				assert.ok(consoleErrors.some((line) => line.includes('Incomplete credentials')));
+			});
+		});
+
+		it('masks a password embedded in the target URL in the connection log', async () => {
+			const originalConsoleError = console.error;
+			const consoleErrors = [];
+			console.error = (...args) => consoleErrors.push(args.join(' '));
+			const calls = captureRequest();
+			try {
+				await cliOperationsModule.cliOperations(
+					{ operation: 'test', target: 'https://admin:url-secret@example.com:9925' },
+					true
+				);
+			} finally {
+				console.error = originalConsoleError;
+			}
+
+			// The credentials still authenticate the request; only the printed form is masked.
+			assert.strictEqual(
+				calls[0].options.headers.Authorization,
+				`Basic ${Buffer.from('admin:url-secret').toString('base64')}`
+			);
+			const connecting = consoleErrors.find((line) => line.startsWith('Connecting to'));
+			assert.ok(!connecting.includes('url-secret'), connecting);
+			assert.ok(connecting.includes('admin:***@example.com'), connecting);
+		});
+	});
+
+	describe('redactCredentials', () => {
+		it('masks secret values while leaving the rest of the parsed request intact', () => {
+			const redacted = cliOperationsModule.redactCredentials({
+				operation: 'add_user',
+				username: 'newuser',
+				password: 'new-user-secret',
+				auth_username: 'admin',
+				auth_password: 'admin-secret',
+			});
+
+			assert.deepStrictEqual(redacted, {
+				operation: 'add_user',
+				username: 'newuser',
+				password: '***',
+				auth_username: 'admin',
+				auth_password: '***',
+			});
+		});
+
+		it('masks userinfo in the target URL and leaves a credential-free target alone', () => {
+			assert.strictEqual(
+				cliOperationsModule.redactCredentials({ target: 'https://admin:url-secret@example.com:9925/' }).target,
+				'https://admin:***@example.com:9925/'
+			);
+			assert.strictEqual(
+				cliOperationsModule.redactCredentials({ target: 'https://example.com:9925/' }).target,
+				'https://example.com:9925/'
+			);
+		});
 	});
 });

--- a/unitTests/bin/login.test.js
+++ b/unitTests/bin/login.test.js
@@ -169,4 +169,97 @@ describe('Login', () => {
 			assert.strictEqual(envContent, 'EXISTING_VAR=value\n\nHARPER_CLI_TARGET=https://example.com:9925/\n');
 		});
 	});
+
+	describe('credential sources', () => {
+		const testDir = path.join(os.tmpdir(), `harper-test-login-creds-${Date.now()}`);
+		const cliOperationsModule = require('#src/bin/cliOperations');
+		let originalCwd;
+		let originalExit;
+		let originalStdoutWrite;
+		let originalPrompt;
+		let originalCliOperations;
+		let loginRequest;
+
+		before(() => {
+			fs.mkdirSync(testDir, { recursive: true });
+			originalCwd = process.cwd;
+			process.cwd = () => testDir;
+			originalExit = process.exit;
+			process.exit = (code) => {
+				if (code !== 0) throw new Error('process.exit:' + code);
+			};
+			originalStdoutWrite = process.stdout.write;
+			process.stdout.write = () => {};
+			originalPrompt = inquirer.prompt;
+			inquirer.prompt = async (questions) => {
+				const q = Array.isArray(questions) ? questions[0] : questions;
+				return { [q.name]: `prompted-${q.name}` };
+			};
+			originalCliOperations = cliOperationsModule.cliOperations;
+			cliOperationsModule.cliOperations = async (req) => {
+				loginRequest = req;
+				return { operation_token: 'mock-token', refresh_token: 'mock-refresh', target: req.target };
+			};
+		});
+
+		after(() => {
+			process.cwd = originalCwd;
+			process.exit = originalExit;
+			process.stdout.write = originalStdoutWrite;
+			inquirer.prompt = originalPrompt;
+			cliOperationsModule.cliOperations = originalCliOperations;
+			fs.rmSync(testDir, { recursive: true, force: true });
+		});
+
+		beforeEach(() => {
+			loginRequest = undefined;
+			for (const name of [
+				'CLI_TARGET',
+				'HARPER_CLI_TARGET',
+				'CLI_TARGET_USERNAME',
+				'CLI_TARGET_PASSWORD',
+				'HARPER_CLI_USERNAME',
+				'HARPER_CLI_PASSWORD',
+			]) {
+				delete process.env[name];
+			}
+			fs.rmSync(path.join(testDir, '.env'), { force: true });
+		});
+
+		// Mixing namespaces would log in as one identity using another identity's secret.
+		it('never pairs a username from one env namespace with a password from the other', async () => {
+			process.env.HARPER_CLI_USERNAME = 'harper-admin';
+			process.env.CLI_TARGET_PASSWORD = 'legacy-secret';
+
+			await login('example.com');
+
+			assert.strictEqual(loginRequest.username, 'harper-admin');
+			assert.strictEqual(loginRequest.password, 'prompted-password');
+		});
+
+		it('uses the CLI_TARGET_* pair when it is the only namespace set', async () => {
+			process.env.CLI_TARGET_USERNAME = 'legacy-admin';
+			process.env.CLI_TARGET_PASSWORD = 'legacy-secret';
+
+			await login('example.com');
+
+			assert.strictEqual(loginRequest.username, 'legacy-admin');
+			assert.strictEqual(loginRequest.password, 'legacy-secret');
+		});
+
+		// Login's credentials ARE the caller's credentials, so they must ride as dedicated
+		// transport auth — otherwise a re-login after expiry tries to refresh the very token it is
+		// replacing and exits with "please run harper login".
+		it('sends the credentials as dedicated transport auth as well as payload fields', async () => {
+			process.env.HARPER_CLI_USERNAME = 'harper-admin';
+			process.env.HARPER_CLI_PASSWORD = 'harper-secret';
+
+			await login('example.com');
+
+			assert.strictEqual(loginRequest.auth_username, 'harper-admin');
+			assert.strictEqual(loginRequest.auth_password, 'harper-secret');
+			assert.strictEqual(loginRequest.username, 'harper-admin');
+			assert.strictEqual(loginRequest.password, 'harper-secret');
+		});
+	});
 });


### PR DESCRIPTION
## What / why

`add_user`/`alter_user` reused the same `username=`/`password=` CLI args as **both** the HTTP Basic auth credentials and the operation payload, so the CLI tried to log in *as the user being created*. That made non-interactive (CI/CD) `add_user`/`alter_user` — authenticating as an existing admin while creating/altering a different user — impossible. Env-var auth (`HARPER_CLI_USERNAME`/`HARPER_CLI_PASSWORD`) was also silently overridden by the payload params.

Root cause and fix, entirely in `bin/cliOperations.ts`:
- Added dedicated auth args `auth_username=`/`auth_password=` that always win the auth leg, and added them to `TRANSPORT_ONLY_FIELDS` so they never serialize into the request body.
- Removed `username`/`password` from `TRANSPORT_ONLY_FIELDS` — they're legitimate operation-payload fields for several ops (`add_user`, `alter_user`, `create_authentication_tokens`), not just transport. They remain the auth fallback for ops where they legitimately *are* the auth (e.g. plain `create_table ... username= password=`), preserving backward compatibility.
- Flipped auth precedence so env-var auth (`HARPER_CLI_USERNAME`/`HARPER_CLI_PASSWORD`, `CLI_TARGET_USERNAME`/`CLI_TARGET_PASSWORD`) beats plain `username=`/`password=` when no dedicated `auth_*` arg is set — otherwise a configured CI login is silently shadowed by an operation's own payload fields. Confirmed with @kriszyp before implementing (this is a deliberate behavior change, called out in the issue).
- Fixed the non-deploy JSON body path (`body = req`), which sent the entire raw, unstripped `req` object as the wire body — now uses the same `operationFields()` stripping the deploy paths already used, so `auth_username`/`auth_password` (and `target`/`rejectUnauthorized`/etc.) never leak into any request body.
- Updated the CLI `HELP` text (`bin/harper.ts`) to document the new args and env-var auth for the non-interactive path. Companion docs: [HarperFast/documentation#613](https://github.com/HarperFast/documentation/pull/613).

```diff
 const TRANSPORT_ONLY_FIELDS = new Set([
 	'target',
-	'username',
-	'password',
+	'auth_username',
+	'auth_password',
 	'rejectUnauthorized',
 	...
 ]);
...
 			username:
-				req.username || target.username || process.env.HARPER_CLI_USERNAME || process.env.CLI_TARGET_USERNAME,
+				req.auth_username ||
+				target.username ||
+				process.env.HARPER_CLI_USERNAME ||
+				process.env.CLI_TARGET_USERNAME ||
+				req.username,
...
 		} else {
-			body = req;
+			body = operationFields(req);
 		}
```

## Test plan
- Added `dedicated auth args vs operation payload fields (harper#1872)` describe block in `unitTests/bin/cliOperations.test.js`: auth_username/auth_password win the Basic-auth header while add_user payload username/password stay in the body; backward-compat fallback to plain username/password when nothing else is configured; env-var auth beats payload username/password; auth args stripped from both the non-deploy JSON body and the multipart directory-deploy body.
- Full `unitTests/bin/cliOperations.test.js` suite passes (30/30).
- Ran the broader unit suite (`test:unit:main` pattern): 3743 passing, 10 pre-existing failures in `unitTests/components/globalIsolation.test.js` unrelated to this change (component sandbox path resolution, reproduces identically on `main`).
- `oxlint` and `prettier --check` clean on all three changed files.

## Notes for reviewers
- `npm run build` currently fails on `main` with a pre-existing, unrelated TypeScript error in `resources/DatabaseTransaction.ts` (`Promise<number | void>` not assignable to `Promise<void>`, from #1688) — not touched by this PR, `tsc` still emits (`noEmitOnError` is off) so this didn't block testing.
- Docs: Companion documentation: [HarperFast/documentation#613](https://github.com/HarperFast/documentation/pull/613).

## Follow-up: review round 2 (commit `9473f61ba`)

Three issues from review, plus three found by an outside-model pass on the fix itself:

**1. Saved `harper login` token was still unreachable for `add_user`/`alter_user` (blocker).** The payload fallback was folded into `target.username` *before* the Authorization mode was chosen, and `if (target?.username)` selects Basic ahead of the saved-token branch — so `harper login` followed by `add_user username=newuser password=...` authenticated as the user being created and 401'd. Authentication now resolves in this order:

1. explicitly configured credentials (dedicated `auth_*` args → target-URL userinfo → `HARPER_CLI_*` → `CLI_TARGET_*`)
2. the saved `harper login` operation token
3. the legacy `username=`/`password=` payload fallback — now requiring *both*, so a lone `username=` (`drop_user username=bob`) stays payload rather than becoming half a credential

**2. Credentials are resolved as an atomic pair, never composed across sources.** `resolveTransportCredentials()` walks the sources and returns the first that supplies anything, so `auth_username=admin` can no longer be paired with an `add_user` payload password. A source counts as configured once either half is *supplied*, empty or not, so a blank CI variable doesn't read as "absent". An incomplete explicit source (args, URL userinfo) is a hard error; an incomplete env pair warns on stderr and is skipped, because a lone `HARPER_CLI_USERNAME`/`HARPER_CLI_PASSWORD` is a supported `harper login` idiom and shouldn't break every later operation in the same shell or CI job.

**3. Passwords no longer reach logs or terminal output.** The parsed CLI request is redacted before `logger.trace`, and a password embedded in `target=https://admin:secret@host` is masked in the `Connecting to ...` line and anywhere the target is logged. Help text now leads with the env-var form and states that a password passed as an argument is exposed to shell history, process listings and CI logs.

**Also fixed in `bin/login.ts` (found while verifying the above):**
- `harper login` mixed env namespaces — username from `CLI_TARGET_USERNAME`, password from `HARPER_CLI_PASSWORD` — which is the same cross-pairing hazard. Whichever namespace supplies anything now owns both halves; a half it doesn't set is prompted for. This also flips login's namespace preference to `HARPER_CLI_*`-first, matching the rest of the CLI (only observable if both complete pairs are set to different values).
- Login now passes its credentials as dedicated transport auth as well as payload fields. Without that, moving the saved token ahead of the payload fallback meant a re-login after expiry would try to refresh the very token it was replacing and could exit with "Refresh token expired... please run harper login again".

### Follow-up test plan
- `unitTests/bin/cliOperations.test.js`: 42 passing. New coverage — saved token wins for both `add_user` and `alter_user` while payload creds stay in the body; lone payload `username=` is not auth; `CLI_TARGET_*` pair still authenticates; lone `auth_username`, lone `auth_password`, empty `auth_password` and both-empty auth args all fail with a clear error; incomplete env pair warns and falls through to the saved token; URL password masked in the connection log; `redactCredentials()` unit tests.
- `unitTests/bin/login.test.js`: new `credential sources` block — no cross-namespace pairing, `CLI_TARGET_*`-only still works, credentials sent as dedicated transport auth.
- `npm run test:unit:main`: 3758 passing, 10 pre-existing `unitTests/components/globalIsolation.test.js` failures (verified identical with these changes stashed).
- `oxlint` and `prettier --check` clean.

### Open question for reviewers
The asymmetry in **2** is a judgment call: incomplete *explicit* credentials are fatal, incomplete *env* credentials only warn. The alternative (fatal everywhere) would break `export HARPER_CLI_USERNAME=admin; harper login; harper <op>` — every operation after the login would fail even though the saved token is perfectly good. Happy to make it uniformly fatal if reviewers prefer that.

### Note on the extra commit `676990fff`

`676990fff` is **not** part of this change. It's a one-line type widening in `resources/DatabaseTransaction.ts` (`recordCommitLatency`'s parameter to `Promise<unknown>`) that fixes the pre-existing `npm run build` failure from #1688, which was turning the downstream Next.js adapter integration check red on this PR for reasons unrelated to it. The same fix is queued as its own PR against `main`; once that lands, this commit is redundant and can be dropped in the rebase.

Refs #1872

🤖 Generated with [Claude Code](https://claude.com/claude-code)


