### PR TITLE
feat(cli): token env vars for CI/CD auth

### DIFF
--- a/bin/agentCli.ts
+++ b/bin/agentCli.ts
@@ -15,7 +15,7 @@
  */
 
 import * as readline from 'node:readline';
-import { loadCredentials, normalizeTarget } from './cliCredentials.ts';
+import { loadCredentials, normalizeTarget, extractTargetCredentials } from './cliCredentials.ts';
 import { refreshExpiredOperationToken } from './cliOperations.ts';
 import { httpRequest } from '../utility/common_utils.ts';
 import { getHdbPid } from '../utility/processManagement/processManagement.js';
@@ -149,6 +149,8 @@ async function resolveConnection(opts: CliOptions): Promise<Connection> {
 
 	if (rawTarget) {
 		const resolved = normalizeTarget(rawTarget);
+		// `resolved` is credential-free by construction, so userinfo has to come off the raw target.
+		const urlCredentials = extractTargetCredentials(rawTarget);
 		let url: URL;
 		try {
 			url = new URL(resolved);
@@ -158,9 +160,17 @@ async function resolveConnection(opts: CliOptions): Promise<Connection> {
 			url = new URL(`https://${withPort}`);
 		}
 		const username =
-			opts.username || url.username || process.env.HARPER_CLI_USERNAME || process.env.CLI_TARGET_USERNAME || '';
+			opts.username ||
+			urlCredentials.username ||
+			process.env.HARPER_CLI_USERNAME ||
+			process.env.CLI_TARGET_USERNAME ||
+			'';
 		const password =
-			opts.password || url.password || process.env.HARPER_CLI_PASSWORD || process.env.CLI_TARGET_PASSWORD || '';
+			opts.password ||
+			urlCredentials.password ||
+			process.env.HARPER_CLI_PASSWORD ||
+			process.env.CLI_TARGET_PASSWORD ||
+			'';
 		const options: any = {
 			protocol: url.protocol,
 			hostname: url.hostname,
@@ -168,7 +178,7 @@ async function resolveConnection(opts: CliOptions): Promise<Connection> {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 		};
-		if (opts.username || opts.password || url.username) {
+		if (opts.username || opts.password || urlCredentials.username) {
 			options.headers.Authorization = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
 		} else {
 			const tokens = credentials?.targets?.[resolved];

--- a/bin/cliCredentials.ts
+++ b/bin/cliCredentials.ts
@@ -16,20 +16,49 @@ interface Tokens {
 	refresh_token: string;
 }
 
+function withScheme(target: string): string {
+	return target.startsWith('http://') || target.startsWith('https://') ? target : 'https://' + target;
+}
+
 /**
- * Normalizes a target operations API URL to a canonical form (with trailing slash).
+ * Reads the userinfo out of a raw, pre-normalization target URL. `normalizeTarget` strips it, so a
+ * caller that authenticates with `https://user:password@host` has to take it from the raw string
+ * before normalizing. Absent userinfo yields empty strings.
+ */
+export function extractTargetCredentials(target: string): { username: string; password: string } {
+	if (target) {
+		try {
+			const url = new URL(withScheme(target));
+			return { username: url.username, password: url.password };
+		} catch {
+			// Not a valid URL — there is no userinfo to extract, and the target itself will fail later.
+		}
+	}
+	return { username: '', password: '' };
+}
+
+/**
+ * Normalizes a target operations API URL to a canonical form (with trailing slash), free of any
+ * embedded credentials.
+ *
+ * A normalized target is an identity, not a credential: it keys ~/.harperdb/credentials.json, is
+ * echoed by the "Connecting to ..." line, written to `.env`, and emitted by `harper login --for-ci`.
+ * Userinfo riding along would put the password in all four, so it is dropped here rather than at
+ * each of those sites — use `extractTargetCredentials` to read it for transport authentication.
  */
 export function normalizeTarget(target: string): string {
 	if (!target) return target;
-	let normalized = target;
-	if (!normalized.startsWith('http://') && !normalized.startsWith('https://')) {
-		normalized = 'https://' + normalized;
-	}
+	let normalized = withScheme(target);
 	try {
 		const url = new URL(normalized);
-		if (!url.port && !normalized.includes(':', normalized.indexOf('://') + 3)) {
-			url.port = '9925';
-		}
+		// Whether a port was written out explicitly. `url.port` is empty for a default port
+		// (`https://host:443`), hence the fallback to the raw authority — with any `user:password`
+		// removed first, since that colon is userinfo, not a port.
+		const authority = normalized.slice(normalized.indexOf('://') + 3).split(/[/?#]/)[0];
+		const hasExplicitPort = !!url.port || authority.slice(authority.lastIndexOf('@') + 1).includes(':');
+		url.username = '';
+		url.password = '';
+		if (!hasExplicitPort) url.port = '9925';
 		normalized = url.toString();
 	} catch {
 		// If it's not a valid URL yet, we'll let it be handled later or it will fail

--- a/bin/cliCredentials.ts
+++ b/bin/cliCredentials.ts
@@ -60,6 +60,14 @@ export function normalizeTarget(target: string): string {
 		url.password = '';
 		if (!hasExplicitPort) url.port = '9925';
 		normalized = url.toString();
+		// `URL` serializes a default port away, so `https://host:443` would come back port-less and a
+		// second pass — login normalizes, then cliOperations normalizes again — would read that as
+		// "no port given" and append 9925, silently retargeting. Writing the port back keeps this
+		// idempotent, which every caller assumes since the output is also the credentials-file key.
+		if (hasExplicitPort && !url.port) {
+			const defaultPort = url.protocol === 'https:' ? '443' : '80';
+			normalized = normalized.replace(`//${url.host}`, `//${url.host}:${defaultPort}`);
+		}
 	} catch {
 		// If it's not a valid URL yet, we'll let it be handled later or it will fail
 	}

--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -450,12 +450,20 @@ async function cliOperations(req: any, skipResponseLog = false) {
 		const transportCredentials = target ? resolveTransportCredentials(req, urlCredentials) : undefined;
 		if (transportCredentials) {
 			options.headers.Authorization = basicAuthHeader(transportCredentials.username, transportCredentials.password);
-		} else {
-			// Bearer-token auth. Env-var tokens (for CI/CD — see `harper login`) take precedence
-			// over the stored ~/.harperdb/credentials.json entry: they're an explicit per-invocation
-			// override that needs no prior `harper login` on the runner. A token refreshed from env
-			// vars is used in-memory only (there's no file to write back to); a token refreshed from
-			// the credentials file is persisted as before.
+		} else if (target) {
+			// Bearer-token auth, for remote targets ONLY. A local operation goes over the domain
+			// socket, which the server trusts via `bypassLocalAuth` — but that bypass is an
+			// `else if` on "no Authorization header present" (security/auth.ts), so attaching a
+			// Bearer token to a local request opts out of the trust and gets validated instead,
+			// 401ing on a token minted for some other cluster. Since these env vars are meant to
+			// persist across a whole CI job (or a developer's shell), an ungated read here would
+			// break every local `harper` command run in that environment.
+			//
+			// Env-var tokens (for CI/CD — see `harper login --for-ci`) take precedence over the
+			// stored ~/.harperdb/credentials.json entry: they're an explicit per-invocation override
+			// that needs no prior `harper login` on the runner. A token refreshed from env vars is
+			// used in-memory only (there's no file to write back to); a token refreshed from the
+			// credentials file is persisted as before.
 			const envOperationToken = (
 				process.env.HARPER_CLI_OPERATION_TOKEN || process.env.CLI_TARGET_OPERATION_TOKEN
 			)?.trim();
@@ -465,7 +473,7 @@ async function cliOperations(req: any, skipResponseLog = false) {
 			let persistKey: string | null = null; // non-null => persist a refreshed operation token back to the file
 			if (envOperationToken || envRefreshToken) {
 				tokens = { operation_token: envOperationToken, refresh_token: envRefreshToken };
-			} else if (target && allCredentials?.targets) {
+			} else if (allCredentials?.targets) {
 				persistKey = target.resolvedTarget;
 				tokens = allCredentials.targets[persistKey] ?? null;
 			}

--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { loadCredentials, saveCredentials, normalizeTarget } from './cliCredentials.ts';
+import { loadCredentials, saveCredentials, normalizeTarget, extractTargetCredentials } from './cliCredentials.ts';
 import { isJWTExpired } from '../security/tokenAuthentication.ts';
 import * as envMgr from '../utility/environment/environmentManager.ts';
 envMgr.initSync();
@@ -393,9 +393,12 @@ async function cliOperations(req: any, skipResponseLog = false) {
 	require('dotenv').config();
 
 	const allCredentials = loadCredentials();
-	req.target = normalizeTarget(resolveTarget(req, allCredentials));
+	const rawTarget = resolveTarget(req, allCredentials);
+	// Userinfo is a transport credential, and `normalizeTarget` strips it so the resolved target can
+	// be logged, stored and emitted freely — so read it off the raw value first.
+	const urlCredentials = extractTargetCredentials(rawTarget);
+	req.target = normalizeTarget(rawTarget);
 	let target;
-	let urlCredentials = { username: '', password: '' };
 	if (req.target) {
 		let parsedTarget;
 		try {
@@ -408,7 +411,6 @@ async function cliOperations(req: any, skipResponseLog = false) {
 			}
 		}
 		const resolvedTarget = req.target;
-		urlCredentials = { username: parsedTarget.username, password: parsedTarget.password };
 		target = {
 			protocol: parsedTarget.protocol,
 			hostname: parsedTarget.hostname,
@@ -464,10 +466,25 @@ async function cliOperations(req: any, skipResponseLog = false) {
 			// that needs no prior `harper login` on the runner. A token refreshed from env vars is
 			// used in-memory only (there's no file to write back to); a token refreshed from the
 			// credentials file is persisted as before.
-			const envOperationToken = (
-				process.env.HARPER_CLI_OPERATION_TOKEN || process.env.CLI_TARGET_OPERATION_TOKEN
-			)?.trim();
-			const envRefreshToken = (process.env.HARPER_CLI_REFRESH_TOKEN || process.env.CLI_TARGET_REFRESH_TOKEN)?.trim();
+			//
+			// Whichever namespace supplies a token owns both halves. Resolving them independently
+			// would let `HARPER_CLI_OPERATION_TOKEN` from one user pair with
+			// `CLI_TARGET_REFRESH_TOKEN` from another: commands would run as the first identity
+			// until its operation token expired, then silently continue as the second. `login.ts`
+			// selects its username/password namespace as a unit for exactly this reason.
+			const tokenPrefix = ['HARPER_CLI', 'CLI_TARGET'].find(
+				(prefix) =>
+					process.env[`${prefix}_OPERATION_TOKEN`] !== undefined || process.env[`${prefix}_REFRESH_TOKEN`] !== undefined
+			);
+			const envOperationToken = tokenPrefix ? process.env[`${tokenPrefix}_OPERATION_TOKEN`]?.trim() : undefined;
+			const envRefreshToken = tokenPrefix ? process.env[`${tokenPrefix}_REFRESH_TOKEN`]?.trim() : undefined;
+			// A namespace that is set but blank is a broken CI secret, not a request to fall back to
+			// whatever the developer last logged in as — say so rather than switching identity silently.
+			if (tokenPrefix && !envOperationToken && !envRefreshToken) {
+				console.error(
+					`Ignoring empty ${tokenPrefix}_OPERATION_TOKEN/${tokenPrefix}_REFRESH_TOKEN; falling back to saved login credentials.`
+				);
+			}
 
 			let tokens: { operation_token?: string; refresh_token?: string } | null = null;
 			let persistKey: string | null = null; // non-null => persist a refreshed operation token back to the file

--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -328,19 +328,28 @@ function resolveTarget(req, allCredentials) {
 }
 
 /**
- * If `tokens.operation_token` is expired and a `refresh_token` is on hand, refreshes it via
- * `refresh_operation_token`, persisting the new token to the credentials file and updating
- * `tokens.operation_token` in place. Shared by `cliOperations` and any other CLI transport
- * (e.g. `harper agent`) authenticating with stored `harper login` tokens, so refresh behavior
- * stays in one place instead of drifting between callers.
+ * Ensures `tokens.operation_token` is usable, minting a fresh one via `refresh_operation_token`
+ * when it is expired — or absent entirely, which is the refresh-token-only shape a CI/CD runner
+ * gets from `HARPER_CLI_REFRESH_TOKEN`. Updates `tokens.operation_token` in place.
+ *
+ * `persistKey` is the credentials-file key to write the refreshed token back to; pass `null` for
+ * tokens sourced from env vars, which have no file entry and stay in memory for this invocation
+ * only. Shared by `cliOperations` and any other CLI transport (e.g. `harper agent`) authenticating
+ * with tokens, so refresh behavior stays in one place instead of drifting between callers.
  */
 async function refreshExpiredOperationToken(
 	options: any,
-	tokens: { operation_token: string; refresh_token: string },
-	lookupKey: string
+	tokens: { operation_token?: string; refresh_token?: string },
+	persistKey: string | null
 ): Promise<void> {
-	if (!tokens.refresh_token || !isJWTExpired(tokens.operation_token)) return;
-	console.error('Operation token expired, attempting to refresh...');
+	if (!tokens.refresh_token) return;
+	// Short-circuited so `isJWTExpired` never runs on an absent token.
+	if (tokens.operation_token && !isJWTExpired(tokens.operation_token)) return;
+	console.error(
+		tokens.operation_token
+			? 'Operation token expired, attempting to refresh...'
+			: 'Minting an operation token from the refresh token...'
+	);
 	try {
 		// Always use the standard operation timeout for this call, even when the caller's
 		// own options carry the longer SSE timeout (e.g. a deploy_component retry) — the
@@ -354,10 +363,13 @@ async function refreshExpiredOperationToken(
 			const refreshData = JSON.parse(refreshResponse.body);
 			if (refreshData.operation_token) {
 				tokens.operation_token = refreshData.operation_token;
-				saveCredentials(lookupKey, {
-					operation_token: tokens.operation_token,
-					refresh_token: tokens.refresh_token,
-				});
+				// Only file-based credentials are persisted; env-var tokens have no file entry.
+				if (persistKey) {
+					saveCredentials(persistKey, {
+						operation_token: tokens.operation_token,
+						refresh_token: tokens.refresh_token,
+					});
+				}
 				console.error('Operation token refreshed successfully.');
 			}
 		} else if (refreshResponse.statusCode === 401) {
@@ -430,25 +442,41 @@ async function cliOperations(req: any, skipResponseLog = false) {
 		options.headers = { 'Content-Type': 'application/json' };
 		options.timeout = SSE_OPERATIONS.has(req.operation) ? SSE_OPERATION_TIMEOUT_MS : CLI_OPERATION_TIMEOUT_MS;
 		// Authentication precedence: explicitly configured credentials (dedicated args, URL
-		// userinfo, env vars) beat everything, then the saved `harper login` token, and only then
-		// the legacy `username=`/`password=` payload fallback below. The saved token must outrank
-		// that fallback: for add_user/alter_user those args are the credentials of the user being
-		// created/altered, so treating them as auth would authenticate as a user who doesn't exist
-		// yet (or as the wrong identity) instead of using the admin's existing session.
+		// userinfo, env vars) beat everything, then env-var tokens, then the saved `harper login`
+		// token, and only then the legacy `username=`/`password=` payload fallback below. The
+		// tokens must outrank that fallback: for add_user/alter_user those args are the credentials
+		// of the user being created/altered, so treating them as auth would authenticate as a user
+		// who doesn't exist yet (or as the wrong identity) instead of using the admin's session.
 		const transportCredentials = target ? resolveTransportCredentials(req, urlCredentials) : undefined;
 		if (transportCredentials) {
 			options.headers.Authorization = basicAuthHeader(transportCredentials.username, transportCredentials.password);
-		} else if (allCredentials) {
-			let tokens = null;
-			let lookupKey = null;
-			if (target && allCredentials.targets) {
-				lookupKey = target.resolvedTarget;
-				tokens = allCredentials.targets[lookupKey] ?? null;
+		} else {
+			// Bearer-token auth. Env-var tokens (for CI/CD — see `harper login`) take precedence
+			// over the stored ~/.harperdb/credentials.json entry: they're an explicit per-invocation
+			// override that needs no prior `harper login` on the runner. A token refreshed from env
+			// vars is used in-memory only (there's no file to write back to); a token refreshed from
+			// the credentials file is persisted as before.
+			const envOperationToken = (
+				process.env.HARPER_CLI_OPERATION_TOKEN || process.env.CLI_TARGET_OPERATION_TOKEN
+			)?.trim();
+			const envRefreshToken = (
+				process.env.HARPER_CLI_REFRESH_TOKEN || process.env.CLI_TARGET_REFRESH_TOKEN
+			)?.trim();
+
+			let tokens: { operation_token?: string; refresh_token?: string } | null = null;
+			let persistKey: string | null = null; // non-null => persist a refreshed operation token back to the file
+			if (envOperationToken || envRefreshToken) {
+				tokens = { operation_token: envOperationToken, refresh_token: envRefreshToken };
+			} else if (target && allCredentials?.targets) {
+				persistKey = target.resolvedTarget;
+				tokens = allCredentials.targets[persistKey] ?? null;
 			}
 
-			if (tokens?.operation_token) {
-				await refreshExpiredOperationToken(options, tokens, lookupKey || target?.resolvedTarget);
-				options.headers.Authorization = `Bearer ${tokens.operation_token}`;
+			if (tokens?.operation_token || tokens?.refresh_token) {
+				await refreshExpiredOperationToken(options, tokens, persistKey);
+				if (tokens.operation_token) {
+					options.headers.Authorization = `Bearer ${tokens.operation_token}`;
+				}
 			}
 		}
 		// Legacy fallback for operations where `username=`/`password=` genuinely ARE the caller's

--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -459,9 +459,7 @@ async function cliOperations(req: any, skipResponseLog = false) {
 			const envOperationToken = (
 				process.env.HARPER_CLI_OPERATION_TOKEN || process.env.CLI_TARGET_OPERATION_TOKEN
 			)?.trim();
-			const envRefreshToken = (
-				process.env.HARPER_CLI_REFRESH_TOKEN || process.env.CLI_TARGET_REFRESH_TOKEN
-			)?.trim();
+			const envRefreshToken = (process.env.HARPER_CLI_REFRESH_TOKEN || process.env.CLI_TARGET_REFRESH_TOKEN)?.trim();
 
 			let tokens: { operation_token?: string; refresh_token?: string } | null = null;
 			let persistKey: string | null = null; // non-null => persist a refreshed operation token back to the file

--- a/bin/harper.ts
+++ b/bin/harper.ts
@@ -42,6 +42,11 @@ login [target] [username]       - Login to a remote or local Harper instance
                                    refresh token) to stdout in dotenv format, and everything else
                                    to stderr, so it pipes without the token hitting your screen:
                                      harper login --for-ci | gh secret set --env-file -
+                                   Log in as a user dedicated to that one CI consumer: Harper
+                                   stores a single refresh token per user, so this revokes any
+                                   refresh token that user already holds — another runner, another
+                                   machine, or an earlier 'harper login' will 401 on its next
+                                   refresh. Two consumers cannot share a user.
 logout [target]                 - Logout from Harper and clear saved JWT
 mcp [subcommand]                - MCP stdio bridge / print-config / doctor (see 'harper mcp help')
 register                        - Register harperdb

--- a/bin/harper.ts
+++ b/bin/harper.ts
@@ -38,6 +38,10 @@ install                         - Install harperdb
                                    back to them — run 'harper logout' or pass auth_username=/
                                    auth_password= to override it.
 login [target] [username]       - Login to a remote or local Harper instance
+                                   --for-ci prints the CI/CD credentials (target + long-lived
+                                   refresh token) to stdout in dotenv format, and everything else
+                                   to stderr, so it pipes without the token hitting your screen:
+                                     harper login --for-ci | gh secret set --env-file -
 logout [target]                 - Logout from Harper and clear saved JWT
 mcp [subcommand]                - MCP stdio bridge / print-config / doctor (see 'harper mcp help')
 register                        - Register harperdb
@@ -97,10 +101,13 @@ async function harper() {
 		case SERVICE_ACTIONS_ENUM.STATUS:
 			return (require('./status').default || require('./status'))();
 		case SERVICE_ACTIONS_ENUM.LOGIN: {
-			const target = process.argv[3];
-			const username = process.argv[4];
+			const args = process.argv.slice(3);
+			const forCi = args.includes('--for-ci');
+			// Flags are filtered out so they can appear anywhere without being mistaken for the
+			// positional target/username.
+			const [target, username] = args.filter((arg) => !arg.startsWith('-'));
 			const { login } = require('./login');
-			return login(target, username);
+			return login(target, username, { forCi });
 		}
 		case SERVICE_ACTIONS_ENUM.LOGOUT: {
 			const target = process.argv[3];

--- a/bin/login.ts
+++ b/bin/login.ts
@@ -39,6 +39,16 @@ export async function login(
 	);
 	say(chalk.gray('your cluster, which will be saved inside ~/.harperdb/credentials.json\n'));
 
+	if (forCi) {
+		say(
+			chalk.yellow(
+				'Harper stores one refresh token per user, so this login replaces whatever refresh token\n' +
+					'that user already holds — including one a CI runner may be using right now. Log in as a\n' +
+					'user created for this single consumer, not your personal account.\n'
+			)
+		);
+	}
+
 	const defaultTarget = process.env.HARPER_CLI_TARGET || process.env.CLI_TARGET;
 	let target = targetArg || defaultTarget;
 
@@ -80,8 +90,24 @@ export async function login(
 			({ username: targetUsername } = await ask({
 				type: 'input',
 				name: 'username',
-				message: 'Cluster Username:',
+				message: forCi ? 'CI Username (a user dedicated to this consumer):' : 'Cluster Username:',
 			}));
+		}
+	}
+
+	// The CLI cannot verify that a user is dedicated to CI, but it can refuse to rotate that user's
+	// only refresh token silently: name the user and make someone say yes. Skipped when stdin is not
+	// a TTY — a runner has already committed to this and there is nobody to ask.
+	if (forCi && process.stdin.isTTY) {
+		const { confirmed } = await ask({
+			type: 'confirm',
+			name: 'confirmed',
+			message: `Mint a CI refresh token for '${targetUsername}'? This revokes any refresh token it already holds.`,
+			default: false,
+		});
+		if (!confirmed) {
+			console.error(chalk.red('Aborted. Create a user dedicated to this CI consumer and log in as that user.'));
+			process.exit(1);
 		}
 	}
 
@@ -154,7 +180,7 @@ export async function login(
 
 		say(`Successfully logged in to ${resolvedTarget} and saved credentials.`);
 
-		if (forCi) printCiCdEnv(resolvedTarget, response.refresh_token);
+		if (forCi) printCiCdEnv(resolvedTarget, response.refresh_token, targetUsername);
 
 		process.exit(0);
 	} else {
@@ -177,33 +203,11 @@ export async function login(
  *
  * That's also why the explanatory comments go to stderr rather than riding along as `#` lines:
  * every consumer of this block reads it as data.
- */
-/**
- * Strips any userinfo from a target URL. `normalizeTarget` round-trips through `URL.toString()`,
- * which preserves it — so `harper login https://admin:hunter2@host --for-ci` would otherwise write
- * the admin password into the `HARPER_CLI_TARGET` secret and onto the terminal, which is exactly
- * the exposure this flag exists to avoid. Credentials are dropped rather than masked, since the
- * emitted value has to stay usable as a target.
  *
- * The result is re-normalized because `normalizeTarget` only appends the default port when it finds
- * no `:` after the scheme — a heuristic the `:` in `user:password` defeats, which would otherwise
- * emit a port-less target that CI resolves to 443 instead of 9925. Re-running it on the
- * credential-free URL gets the port right without changing `normalizeTarget` for every other caller
- * (its output keys the saved credentials file, so changing it would invalidate existing logins).
+ * `target` needs no sanitizing here: `normalizeTarget` guarantees a credential-free target, which is
+ * the same value already stored, echoed and written to `.env`.
  */
-function targetWithoutCredentials(target: string): string {
-	try {
-		const url = new URL(target);
-		if (!url.username && !url.password) return target;
-		url.username = '';
-		url.password = '';
-		return normalizeTarget(url.toString());
-	} catch {
-		return target;
-	}
-}
-
-function printCiCdEnv(target: string, refreshToken: string): void {
+function printCiCdEnv(target: string, refreshToken: string, username: string): void {
 	if (!refreshToken) {
 		// Fail loudly instead of emitting a half-block: a silent empty stdout would be piped
 		// straight into a secret store and "succeed" at storing nothing.
@@ -223,6 +227,24 @@ function printCiCdEnv(target: string, refreshToken: string): void {
 				'# token is long-lived; the CLI mints a fresh operation token from it on each run.\n'
 		)
 	);
-	process.stdout.write(`HARPER_CLI_TARGET=${targetWithoutCredentials(target)}\n`);
+	process.stderr.write(chalk.yellow(rotationWarning(username)));
+	process.stdout.write(`HARPER_CLI_TARGET=${target}\n`);
 	process.stdout.write(`HARPER_CLI_REFRESH_TOKEN=${refreshToken}\n`);
+}
+
+/**
+ * Harper stores exactly one refresh-token hash per user (`createTokens` overwrites
+ * `hdb_user.refresh_token`, and refresh validation accepts only that hash), so minting a refresh
+ * token revokes that user's previous one. There is no way to hold two live refresh credentials for
+ * one user, which makes rotation — not concurrency — the property a CI credential has to be built
+ * around, and it is invisible until a second holder's next refresh 401s. Until the server grows
+ * named, independently revocable credentials (HarperFast/harper#2018), the CLI's job is to make
+ * that unmissable and to push each consumer onto its own user.
+ */
+function rotationWarning(username: string): string {
+	return (
+		`\nOne refresh token per user: this replaced any refresh token '${username}' already held.\n` +
+		`Anything still using an older one — another runner, another machine, an earlier\n` +
+		`'harper login' — will fail on its next refresh. Give each CI consumer its own user.\n`
+	);
 }

--- a/bin/login.ts
+++ b/bin/login.ts
@@ -138,8 +138,45 @@ export async function login(targetArg: string, usernameArg: string): Promise<voi
 		}
 
 		console.log(`Successfully logged in to ${resolvedTarget} and saved credentials.`);
+
+		await maybePrintCiCdEnv(resolvedTarget, response.refresh_token);
+
 		process.exit(0);
 	} else {
 		throw new Error('Failed to retrieve authentication tokens.');
 	}
+}
+
+/**
+ * After a successful interactive login, offer to print the environment variables that let a
+ * CI/CD pipeline (GitHub Actions, etc.) run `harper deploy` without a stored password. Emits the
+ * long-lived refresh token only — cliOperations' Bearer-token path mints a fresh operation token
+ * from it on each run (HARPER_CLI_REFRESH_TOKEN), so it's the single durable secret CI needs.
+ *
+ * Skipped when stdin isn't a TTY (e.g. a scripted/CI login driven by HARPER_CLI_PASSWORD) so it
+ * never blocks on a prompt or dumps tokens into non-interactive output.
+ */
+async function maybePrintCiCdEnv(target: string, refreshToken: string): Promise<void> {
+	if (!process.stdin.isTTY) return;
+	if (!refreshToken) return;
+
+	const { show } = await inquirer.prompt({
+		type: 'confirm',
+		name: 'show',
+		message: 'Print environment variables so CI/CD can deploy without your password?',
+		default: false,
+	});
+	if (!show) return;
+
+	console.log(chalk.cyan('\n# Harper CI/CD credentials'));
+	console.log(
+		chalk.gray(
+			'# Store these as secrets in your CI/CD provider (e.g. GitHub Actions repository secrets)\n' +
+				'# and expose them as environment variables to your `harper deploy` step. The refresh\n' +
+				'# token is long-lived; the CLI mints a fresh operation token from it on each run.'
+		)
+	);
+	console.log(`HARPER_CLI_TARGET=${target}`);
+	console.log(`HARPER_CLI_REFRESH_TOKEN=${refreshToken}`);
+	console.log();
 }

--- a/bin/login.ts
+++ b/bin/login.ts
@@ -8,27 +8,42 @@ import { cliOperations } from './cliOperations.ts';
 
 /**
  * Executes the login command.
+ *
+ * With `forCi`, stdout carries *only* the machine-readable CI/CD credential block (dotenv format)
+ * and every human-facing byte — banner, prompts, status — goes to stderr, so the command can be
+ * piped straight into a secret store or the clipboard without the token ever hitting the screen or
+ * the shell history. See `printCiCdEnv`.
  */
-export async function login(targetArg: string, usernameArg: string): Promise<void> {
+export async function login(
+	targetArg: string,
+	usernameArg: string,
+	{ forCi = false }: { forCi?: boolean } = {}
+): Promise<void> {
 	dotenv.config();
 
-	console.log(chalk.cyan('\nHarper login'));
-	console.log(
+	// In --for-ci mode stdout is reserved for the credential block, so anything a human reads is
+	// written to stderr instead. inquirer defaults to stdout too, hence its own output stream —
+	// without it the user would be typing their password blind into the pipe.
+	const say = forCi ? (message = '') => process.stderr.write(`${message}\n`) : (message = '') => console.log(message);
+	const ask = forCi ? inquirer.createPromptModule({ output: process.stderr }) : inquirer.prompt;
+
+	say(chalk.cyan('\nHarper login'));
+	say(
 		chalk.gray(
 			'Harper apps can be deployed to Fabric for free, where one runtime can house your app, database, cache, and messaging.'
 		)
 	);
-	console.log(chalk.gray('https://fabric.harper.fast/\n'));
-	console.log(
+	say(chalk.gray('https://fabric.harper.fast/\n'));
+	say(
 		chalk.gray('If you create a cluster, you can enter your credentials here. They will be exchanged for a JWT from')
 	);
-	console.log(chalk.gray('your cluster, which will be saved inside ~/.harperdb/credentials.json\n'));
+	say(chalk.gray('your cluster, which will be saved inside ~/.harperdb/credentials.json\n'));
 
 	const defaultTarget = process.env.HARPER_CLI_TARGET || process.env.CLI_TARGET;
 	let target = targetArg || defaultTarget;
 
 	if (!targetArg) {
-		const { target: input } = await inquirer.prompt({
+		const { target: input } = await ask({
 			type: 'input',
 			name: 'target',
 			message: 'Cluster Target URL:',
@@ -60,9 +75,9 @@ export async function login(targetArg: string, usernameArg: string): Promise<voi
 	if (!targetUsername) {
 		if (envUsername) {
 			targetUsername = envUsername;
-			console.log(chalk.gray(`Using username from ${envPrefix}_USERNAME environment variable: ${targetUsername}`));
+			say(chalk.gray(`Using username from ${envPrefix}_USERNAME environment variable: ${targetUsername}`));
 		} else {
-			({ username: targetUsername } = await inquirer.prompt({
+			({ username: targetUsername } = await ask({
 				type: 'input',
 				name: 'username',
 				message: 'Cluster Username:',
@@ -73,10 +88,10 @@ export async function login(targetArg: string, usernameArg: string): Promise<voi
 	let targetPassword = envPassword;
 
 	if (targetPassword) {
-		console.log(chalk.gray(`Using password from ${envPrefix}_PASSWORD environment variable.`));
+		say(chalk.gray(`Using password from ${envPrefix}_PASSWORD environment variable.`));
 	} else {
 		// `type: 'password'` with no `mask` hides input entirely — nothing is echoed until Enter.
-		({ password: targetPassword } = await inquirer.prompt({
+		({ password: targetPassword } = await ask({
 			type: 'password',
 			name: 'password',
 			message: 'Cluster Password:',
@@ -130,16 +145,16 @@ export async function login(targetArg: string, usernameArg: string): Promise<voi
 				) {
 					const envLine = `\nHARPER_CLI_TARGET=${resolvedTarget}\n`;
 					fs.appendFileSync(envPath, envLine);
-					console.log(`Added HARPER_CLI_TARGET to .env`);
+					say(`Added HARPER_CLI_TARGET to .env`);
 				}
 			}
 		} catch (err) {
 			console.error(chalk.yellow(`Could not update .env: ${err instanceof Error ? err.message : String(err)}`));
 		}
 
-		console.log(`Successfully logged in to ${resolvedTarget} and saved credentials.`);
+		say(`Successfully logged in to ${resolvedTarget} and saved credentials.`);
 
-		await maybePrintCiCdEnv(resolvedTarget, response.refresh_token);
+		if (forCi) printCiCdEnv(resolvedTarget, response.refresh_token);
 
 		process.exit(0);
 	} else {
@@ -148,35 +163,41 @@ export async function login(targetArg: string, usernameArg: string): Promise<voi
 }
 
 /**
- * After a successful interactive login, offer to print the environment variables that let a
- * CI/CD pipeline (GitHub Actions, etc.) run `harper deploy` without a stored password. Emits the
- * long-lived refresh token only — cliOperations' Bearer-token path mints a fresh operation token
- * from it on each run (HARPER_CLI_REFRESH_TOKEN), so it's the single durable secret CI needs.
+ * Writes the environment variables that let a CI/CD pipeline (GitHub Actions, etc.) run
+ * `harper deploy` without a stored password. Emits the long-lived refresh token only —
+ * cliOperations' Bearer-token path mints a fresh operation token from it on each run
+ * (HARPER_CLI_REFRESH_TOKEN), so it's the single durable secret CI needs.
  *
- * Skipped when stdin isn't a TTY (e.g. a scripted/CI login driven by HARPER_CLI_PASSWORD) so it
- * never blocks on a prompt or dumps tokens into non-interactive output.
+ * stdout gets nothing but the `KEY=value` lines, in dotenv format and free of ANSI codes, so the
+ * whole command pipes cleanly into a secret store or the clipboard and the token never appears
+ * on screen or in shell history:
+ *
+ *   harper login --for-ci | gh secret set --env-file -   # sets both secrets on the repo
+ *   harper login --for-ci | pbcopy                       # or paste them in by hand
+ *
+ * That's also why the explanatory comments go to stderr rather than riding along as `#` lines:
+ * every consumer of this block reads it as data.
  */
-async function maybePrintCiCdEnv(target: string, refreshToken: string): Promise<void> {
-	if (!process.stdin.isTTY) return;
-	if (!refreshToken) return;
+function printCiCdEnv(target: string, refreshToken: string): void {
+	if (!refreshToken) {
+		// Fail loudly instead of emitting a half-block: a silent empty stdout would be piped
+		// straight into a secret store and "succeed" at storing nothing.
+		console.error(
+			chalk.red(
+				'This cluster returned no refresh token, so there is no durable credential to give CI.\n' +
+					'Upgrade the cluster, or authenticate CI with HARPER_CLI_USERNAME/HARPER_CLI_PASSWORD instead.'
+			)
+		);
+		process.exit(1);
+	}
 
-	const { show } = await inquirer.prompt({
-		type: 'confirm',
-		name: 'show',
-		message: 'Print environment variables so CI/CD can deploy without your password?',
-		default: false,
-	});
-	if (!show) return;
-
-	console.log(chalk.cyan('\n# Harper CI/CD credentials'));
-	console.log(
+	process.stderr.write(
 		chalk.gray(
-			'# Store these as secrets in your CI/CD provider (e.g. GitHub Actions repository secrets)\n' +
+			'\n# Store these as secrets in your CI/CD provider (e.g. GitHub Actions repository secrets)\n' +
 				'# and expose them as environment variables to your `harper deploy` step. The refresh\n' +
-				'# token is long-lived; the CLI mints a fresh operation token from it on each run.'
+				'# token is long-lived; the CLI mints a fresh operation token from it on each run.\n'
 		)
 	);
-	console.log(`HARPER_CLI_TARGET=${target}`);
-	console.log(`HARPER_CLI_REFRESH_TOKEN=${refreshToken}`);
-	console.log();
+	process.stdout.write(`HARPER_CLI_TARGET=${target}\n`);
+	process.stdout.write(`HARPER_CLI_REFRESH_TOKEN=${refreshToken}\n`);
 }

--- a/bin/login.ts
+++ b/bin/login.ts
@@ -178,6 +178,31 @@ export async function login(
  * That's also why the explanatory comments go to stderr rather than riding along as `#` lines:
  * every consumer of this block reads it as data.
  */
+/**
+ * Strips any userinfo from a target URL. `normalizeTarget` round-trips through `URL.toString()`,
+ * which preserves it — so `harper login https://admin:hunter2@host --for-ci` would otherwise write
+ * the admin password into the `HARPER_CLI_TARGET` secret and onto the terminal, which is exactly
+ * the exposure this flag exists to avoid. Credentials are dropped rather than masked, since the
+ * emitted value has to stay usable as a target.
+ *
+ * The result is re-normalized because `normalizeTarget` only appends the default port when it finds
+ * no `:` after the scheme — a heuristic the `:` in `user:password` defeats, which would otherwise
+ * emit a port-less target that CI resolves to 443 instead of 9925. Re-running it on the
+ * credential-free URL gets the port right without changing `normalizeTarget` for every other caller
+ * (its output keys the saved credentials file, so changing it would invalidate existing logins).
+ */
+function targetWithoutCredentials(target: string): string {
+	try {
+		const url = new URL(target);
+		if (!url.username && !url.password) return target;
+		url.username = '';
+		url.password = '';
+		return normalizeTarget(url.toString());
+	} catch {
+		return target;
+	}
+}
+
 function printCiCdEnv(target: string, refreshToken: string): void {
 	if (!refreshToken) {
 		// Fail loudly instead of emitting a half-block: a silent empty stdout would be piped
@@ -198,6 +223,6 @@ function printCiCdEnv(target: string, refreshToken: string): void {
 				'# token is long-lived; the CLI mints a fresh operation token from it on each run.\n'
 		)
 	);
-	process.stdout.write(`HARPER_CLI_TARGET=${target}\n`);
+	process.stdout.write(`HARPER_CLI_TARGET=${targetWithoutCredentials(target)}\n`);
 	process.stdout.write(`HARPER_CLI_REFRESH_TOKEN=${refreshToken}\n`);
 }

--- a/unitTests/bin/cliOperations.test.js
+++ b/unitTests/bin/cliOperations.test.js
@@ -152,6 +152,44 @@ describe('cliOperations', () => {
 			assert.strictEqual(result.success, true);
 		});
 
+		// These env vars are meant to persist for a whole CI job (or a developer's shell), so they
+		// must not bleed onto local operations. The domain socket is trusted via `bypassLocalAuth`,
+		// but that bypass only applies when NO Authorization header is present (security/auth.ts) —
+		// attaching a Bearer token opts out of the trust and 401s on a token minted for a different
+		// cluster, breaking commands that worked before these vars existed.
+		it('does not attach a Bearer token to a local (no-target) operation', async () => {
+			process.env.HARPER_CLI_REFRESH_TOKEN = 'env-refresh';
+			process.env.HARPER_CLI_OPERATION_TOKEN = 'env-op-token';
+			tokenAuthModule.isJWTExpired = () => false;
+
+			const originalGetHdbPid = processManagementModule.getHdbPid;
+			const originalInitConfig = configUtilsModule.initConfig;
+			const originalGetConfigPath = configUtilsModule.getConfigPath;
+			const socketPath = path.join(testDir, 'local-auth-check.sock');
+			fs.ensureFileSync(socketPath);
+			configUtilsModule.initConfig = () => {};
+			processManagementModule.getHdbPid = () => 12345;
+			configUtilsModule.getConfigPath = () => socketPath;
+
+			const requested = [];
+			commonUtilsModule.httpRequest = async (options, req) => {
+				requested.push({ auth: options.headers.Authorization, operation: req.operation });
+				return { statusCode: 200, body: JSON.stringify({ success: true }) };
+			};
+
+			try {
+				// No `target` — this goes over the local domain socket.
+				await cliOperationsModule.cliOperations({ operation: 'test' }, true);
+			} finally {
+				processManagementModule.getHdbPid = originalGetHdbPid;
+				configUtilsModule.initConfig = originalInitConfig;
+				configUtilsModule.getConfigPath = originalGetConfigPath;
+			}
+
+			assert.strictEqual(requested.length, 1, 'should not have fired a refresh_operation_token call');
+			assert.strictEqual(requested[0].auth, undefined);
+		});
+
 		it('mints an operation token from HARPER_CLI_REFRESH_TOKEN alone, without persisting it', async () => {
 			process.env.HARPER_CLI_REFRESH_TOKEN = 'env-refresh';
 			tokenAuthModule.isJWTExpired = () => true;

--- a/unitTests/bin/cliOperations.test.js
+++ b/unitTests/bin/cliOperations.test.js
@@ -251,6 +251,79 @@ describe('cliOperations', () => {
 			await cliOperationsModule.cliOperations({ operation: 'test', target: 'example.com' }, true);
 			assert.strictEqual(seenAuth, 'Bearer alias-op-token');
 		});
+
+		// Resolving the two variables independently would let an operation token from one namespace
+		// pair with a refresh token from the other. Since the two can belong to different users, the
+		// command would run as the first identity until its operation token expired and then, at an
+		// arbitrary moment mid-job, silently continue as the second.
+		it('takes both tokens from one namespace, never mixing HARPER_CLI_* with CLI_TARGET_*', async () => {
+			process.env.HARPER_CLI_OPERATION_TOKEN = 'user-a-op-token';
+			process.env.CLI_TARGET_REFRESH_TOKEN = 'user-b-refresh';
+			// The chosen namespace's operation token is expired, so a refresh WOULD fire if the
+			// other namespace's refresh token were reachable.
+			tokenAuthModule.isJWTExpired = () => true;
+
+			const requested = [];
+			commonUtilsModule.httpRequest = async (options, req) => {
+				requested.push({ auth: options.headers.Authorization, operation: req.operation });
+				return { statusCode: 200, body: JSON.stringify({ success: true }) };
+			};
+
+			await cliOperationsModule.cliOperations({ operation: 'test', target: 'example.com' }, true);
+
+			// HARPER_CLI_* is selected as a unit: its operation token is used and its (unset) refresh
+			// token means no refresh, rather than reaching into CLI_TARGET_REFRESH_TOKEN.
+			assert.deepStrictEqual(
+				requested.map((r) => r.operation),
+				['test']
+			);
+			assert.strictEqual(requested[0].auth, 'Bearer user-a-op-token');
+		});
+
+		// A blank value is a CI secret that failed to populate. Falling through to the developer's
+		// saved login would run the job as the wrong identity instead of failing where it broke.
+		it('does not fall back to the other namespace when the selected one is set but empty', async () => {
+			process.env.HARPER_CLI_REFRESH_TOKEN = '';
+			process.env.CLI_TARGET_REFRESH_TOKEN = 'other-namespace-refresh';
+			saveCredentials(target, { operation_token: 'file-token', refresh_token: 'file-refresh' });
+			tokenAuthModule.isJWTExpired = () => false;
+
+			let seenAuth;
+			commonUtilsModule.httpRequest = async (options) => {
+				seenAuth = options.headers.Authorization;
+				return { statusCode: 200, body: JSON.stringify({ success: true }) };
+			};
+
+			await cliOperationsModule.cliOperations({ operation: 'test', target: 'example.com' }, true);
+			assert.strictEqual(seenAuth, 'Bearer file-token');
+		});
+	});
+
+	// The resolved target is an identity, not a credential: it keys ~/.harperdb/credentials.json, is
+	// echoed by "Connecting to ...", written to .env, and emitted by `harper login --for-ci`.
+	// Userinfo is stripped once, in normalizeTarget, so none of those sites can leak a password.
+	describe('target userinfo is transport-only', () => {
+		it('authenticates with embedded userinfo but keys credentials off the credential-free target', async () => {
+			tokenAuthModule.isJWTExpired = () => false;
+
+			let seen;
+			commonUtilsModule.httpRequest = async (options) => {
+				seen = options;
+				return { statusCode: 200, body: JSON.stringify({ success: true }) };
+			};
+
+			const req = { operation: 'test', target: 'https://admin:hunter2@example.com' };
+			const result = await cliOperationsModule.cliOperations(req, true);
+
+			// The password still authenticates the request...
+			assert.strictEqual(seen.headers.Authorization, `Basic ${Buffer.from('admin:hunter2').toString('base64')}`);
+			// ...but never survives into the resolved target, which is what gets stored and printed.
+			assert.strictEqual(req.target, 'https://example.com:9925/');
+			assert.strictEqual(result.resolvedTarget, 'https://example.com:9925/');
+			// The `:` in `user:password` used to defeat the default-port heuristic, so this target
+			// was contacted on 443 while being emitted as :9925.
+			assert.strictEqual(seen.port, '9925');
+		});
 	});
 
 	describe('deploy_component cross-version compatibility', () => {
@@ -1245,7 +1318,7 @@ describe('cliOperations', () => {
 			});
 		});
 
-		it('masks a password embedded in the target URL in the connection log', async () => {
+		it('keeps a password embedded in the target URL out of the connection log', async () => {
 			const originalConsoleError = console.error;
 			const consoleErrors = [];
 			console.error = (...args) => consoleErrors.push(args.join(' '));
@@ -1259,14 +1332,14 @@ describe('cliOperations', () => {
 				console.error = originalConsoleError;
 			}
 
-			// The credentials still authenticate the request; only the printed form is masked.
+			// The credentials still authenticate the request; the resolved target they were taken from
+			// carries no userinfo at all, so there is nothing left to mask by the time it is printed.
 			assert.strictEqual(
 				calls[0].options.headers.Authorization,
 				`Basic ${Buffer.from('admin:url-secret').toString('base64')}`
 			);
 			const connecting = consoleErrors.find((line) => line.startsWith('Connecting to'));
-			assert.ok(!connecting.includes('url-secret'), connecting);
-			assert.ok(connecting.includes('admin:***@example.com'), connecting);
+			assert.strictEqual(connecting, 'Connecting to https://example.com:9925/');
 		});
 	});
 

--- a/unitTests/bin/cliOperations.test.js
+++ b/unitTests/bin/cliOperations.test.js
@@ -111,6 +111,110 @@ describe('cliOperations', () => {
 		assert.strictEqual(creds.targets[target].operation_token, 'new-token');
 	});
 
+	describe('env-var token auth (CI/CD)', () => {
+		const target = 'https://example.com:9925/';
+		const envVars = [
+			'HARPER_CLI_OPERATION_TOKEN',
+			'HARPER_CLI_REFRESH_TOKEN',
+			'CLI_TARGET_OPERATION_TOKEN',
+			'CLI_TARGET_REFRESH_TOKEN',
+		];
+		const saved = {};
+
+		beforeEach(() => {
+			for (const v of envVars) {
+				saved[v] = process.env[v];
+				delete process.env[v];
+			}
+		});
+
+		afterEach(() => {
+			for (const v of envVars) {
+				if (saved[v] === undefined) delete process.env[v];
+				else process.env[v] = saved[v];
+			}
+		});
+
+		it('uses HARPER_CLI_OPERATION_TOKEN directly, overriding stored file credentials', async () => {
+			// A stored file token that must NOT win against the explicit env override.
+			saveCredentials(target, { operation_token: 'file-token', refresh_token: 'file-refresh' });
+			process.env.HARPER_CLI_OPERATION_TOKEN = 'env-op-token';
+			tokenAuthModule.isJWTExpired = () => false;
+
+			let seenAuth;
+			commonUtilsModule.httpRequest = async (options) => {
+				seenAuth = options.headers.Authorization;
+				return { statusCode: 200, body: JSON.stringify({ success: true }) };
+			};
+
+			const result = await cliOperationsModule.cliOperations({ operation: 'test', target: 'example.com' }, true);
+			assert.strictEqual(seenAuth, 'Bearer env-op-token');
+			assert.strictEqual(result.success, true);
+		});
+
+		it('mints an operation token from HARPER_CLI_REFRESH_TOKEN alone, without persisting it', async () => {
+			process.env.HARPER_CLI_REFRESH_TOKEN = 'env-refresh';
+			tokenAuthModule.isJWTExpired = () => true;
+
+			const calls = [];
+			commonUtilsModule.httpRequest = async (options, req) => {
+				calls.push({ options, req });
+				if (req.operation === 'refresh_operation_token') {
+					assert.strictEqual(options.headers.Authorization, 'Bearer env-refresh');
+					return { statusCode: 200, body: JSON.stringify({ operation_token: 'minted-token' }) };
+				}
+				return { statusCode: 200, body: JSON.stringify({ success: true }) };
+			};
+
+			const result = await cliOperationsModule.cliOperations({ operation: 'test', target: 'example.com' }, true);
+			assert.strictEqual(calls[0].req.operation, 'refresh_operation_token');
+			assert.strictEqual(calls[1].options.headers.Authorization, 'Bearer minted-token');
+			assert.strictEqual(result.success, true);
+
+			// Env-var tokens have no backing file, so nothing is written to credentials.json.
+			const { loadCredentials } = require('#src/bin/cliCredentials');
+			assert.strictEqual(loadCredentials().targets[target], undefined);
+		});
+
+		it('refreshes an expired HARPER_CLI_OPERATION_TOKEN using HARPER_CLI_REFRESH_TOKEN, without persisting', async () => {
+			process.env.HARPER_CLI_OPERATION_TOKEN = 'expired-env-token';
+			process.env.HARPER_CLI_REFRESH_TOKEN = 'env-refresh';
+			tokenAuthModule.isJWTExpired = (token) => token === 'expired-env-token';
+
+			const calls = [];
+			commonUtilsModule.httpRequest = async (options, req) => {
+				calls.push({ options, req });
+				if (req.operation === 'refresh_operation_token') {
+					assert.strictEqual(options.headers.Authorization, 'Bearer env-refresh');
+					return { statusCode: 200, body: JSON.stringify({ operation_token: 'minted-token' }) };
+				}
+				return { statusCode: 200, body: JSON.stringify({ success: true }) };
+			};
+
+			const result = await cliOperationsModule.cliOperations({ operation: 'test', target: 'example.com' }, true);
+			assert.strictEqual(calls[0].req.operation, 'refresh_operation_token');
+			assert.strictEqual(calls[1].options.headers.Authorization, 'Bearer minted-token');
+			assert.strictEqual(result.success, true);
+
+			const { loadCredentials } = require('#src/bin/cliCredentials');
+			assert.strictEqual(loadCredentials().targets[target], undefined);
+		});
+
+		it('also reads the CLI_TARGET_* alias variables', async () => {
+			process.env.CLI_TARGET_OPERATION_TOKEN = 'alias-op-token';
+			tokenAuthModule.isJWTExpired = () => false;
+
+			let seenAuth;
+			commonUtilsModule.httpRequest = async (options) => {
+				seenAuth = options.headers.Authorization;
+				return { statusCode: 200, body: JSON.stringify({ success: true }) };
+			};
+
+			await cliOperationsModule.cliOperations({ operation: 'test', target: 'example.com' }, true);
+			assert.strictEqual(seenAuth, 'Bearer alias-op-token');
+		});
+	});
+
 	describe('deploy_component cross-version compatibility', () => {
 		const target = 'https://example.com:9925/';
 		let originalPackageDirectory;

--- a/unitTests/bin/login.test.js
+++ b/unitTests/bin/login.test.js
@@ -85,7 +85,6 @@ describe('Login', () => {
 		let originalCwd;
 		let originalExit;
 		let originalStdoutWrite;
-		let originalStdinIsTTY;
 
 		// Mock cliOperations
 		const cliOperationsModule = require('#src/bin/cliOperations');
@@ -108,11 +107,6 @@ describe('Login', () => {
 			originalStdoutWrite = process.stdout.write;
 			process.stdout.write = () => {};
 
-			// A non-TTY stdin makes login skip the interactive CI/CD env prompt (as in CI), so
-			// these tests never block on it regardless of how the suite is launched.
-			originalStdinIsTTY = process.stdin.isTTY;
-			process.stdin.isTTY = false;
-
 			originalCliOperations = cliOperationsModule.cliOperations;
 			cliOperationsModule.cliOperations = async (req) => {
 				if (req.operation === 'create_authentication_tokens') {
@@ -130,7 +124,6 @@ describe('Login', () => {
 			process.cwd = originalCwd;
 			process.exit = originalExit;
 			process.stdout.write = originalStdoutWrite;
-			process.stdin.isTTY = originalStdinIsTTY;
 			cliOperationsModule.cliOperations = originalCliOperations;
 			fs.rmSync(testDir, { recursive: true, force: true });
 		});
@@ -183,7 +176,6 @@ describe('Login', () => {
 		let originalCwd;
 		let originalExit;
 		let originalStdoutWrite;
-		let originalStdinIsTTY;
 		let originalPrompt;
 		let originalCliOperations;
 		let loginRequest;
@@ -198,10 +190,6 @@ describe('Login', () => {
 			};
 			originalStdoutWrite = process.stdout.write;
 			process.stdout.write = () => {};
-			// Non-interactive stdin so login skips the CI/CD env-var confirm; these tests are about
-			// which credentials are sent, and shouldn't depend on whether the runner has a TTY.
-			originalStdinIsTTY = process.stdin.isTTY;
-			process.stdin.isTTY = false;
 			originalPrompt = inquirer.prompt;
 			inquirer.prompt = async (questions) => {
 				const q = Array.isArray(questions) ? questions[0] : questions;
@@ -218,7 +206,6 @@ describe('Login', () => {
 			process.cwd = originalCwd;
 			process.exit = originalExit;
 			process.stdout.write = originalStdoutWrite;
-			process.stdin.isTTY = originalStdinIsTTY;
 			inquirer.prompt = originalPrompt;
 			cliOperationsModule.cliOperations = originalCliOperations;
 			fs.rmSync(testDir, { recursive: true, force: true });
@@ -276,18 +263,24 @@ describe('Login', () => {
 		});
 	});
 
-	describe('CI/CD environment variable output', () => {
+	// `harper login --for-ci` is meant to be piped (`| gh secret set --env-file -`, `| pbcopy`), so
+	// what matters is not just that the credentials are printed but WHICH stream each byte lands
+	// on: anything besides the dotenv block on stdout corrupts the pipe, and a token on stderr
+	// defeats the point of keeping it off the screen.
+	describe('CI/CD environment variable output (--for-ci)', () => {
 		const testDir = path.join(os.tmpdir(), `harper-test-login-cicd-${Date.now()}`);
 		const cliOperationsModule = require('#src/bin/cliOperations');
 		let originalCwd;
 		let originalHome;
 		let originalExit;
-		let originalStdinIsTTY;
 		let originalPrompt;
 		let originalConsoleLog;
+		let originalStdoutWrite;
+		let originalStderrWrite;
 		let originalCliOperations;
-		let logged;
-		let confirmAnswer;
+		let stdout;
+		let stderr;
+		let refreshToken;
 
 		before(() => {
 			fs.mkdirSync(testDir, { recursive: true });
@@ -303,21 +296,16 @@ describe('Login', () => {
 				if (code !== 0) throw new Error('process.exit:' + code);
 			};
 
-			// Interactive stdin so login reaches the CI/CD confirm prompt.
-			originalStdinIsTTY = process.stdin.isTTY;
-			process.stdin.isTTY = true;
-
 			originalPrompt = inquirer.prompt;
 			inquirer.prompt = async (questions) => {
 				const q = Array.isArray(questions) ? questions[0] : questions;
-				if (q.name === 'show') return { show: confirmAnswer };
 				return { [q.name]: 'mock-response' };
 			};
 
 			originalCliOperations = cliOperationsModule.cliOperations;
 			cliOperationsModule.cliOperations = async (req) => {
 				if (req.operation === 'create_authentication_tokens') {
-					return { operation_token: 'op-tok', refresh_token: 'ref-tok', target: req.target };
+					return { operation_token: 'op-tok', refresh_token: refreshToken, target: req.target };
 				}
 				return {};
 			};
@@ -328,46 +316,95 @@ describe('Login', () => {
 			if (originalHome === undefined) delete process.env.HOME;
 			else process.env.HOME = originalHome;
 			process.exit = originalExit;
-			process.stdin.isTTY = originalStdinIsTTY;
 			inquirer.prompt = originalPrompt;
 			cliOperationsModule.cliOperations = originalCliOperations;
 			fs.rmSync(testDir, { recursive: true, force: true });
 		});
 
 		beforeEach(() => {
-			logged = [];
-			originalConsoleLog = console.log;
-			console.log = (...args) => {
-				logged.push(args.join(' '));
-			};
-			// Password from env so login stays non-interactive apart from the CI/CD confirm.
+			stdout = [];
+			stderr = [];
+			refreshToken = 'ref-tok';
+			// Password from env so login needs no interactive prompt.
 			process.env.HARPER_CLI_PASSWORD = 'password';
 		});
 
 		afterEach(() => {
-			console.log = originalConsoleLog;
 			delete process.env.HARPER_CLI_PASSWORD;
 			delete process.env.HARPER_CLI_TARGET;
 			delete process.env.CLI_TARGET;
 		});
 
-		it('prints the target and refresh token (only) when the user opts in', async () => {
-			confirmAnswer = true;
-			await login('example.com', 'mockuser');
-			const out = logged.join('\n');
-			assert.ok(out.includes('HARPER_CLI_TARGET=https://example.com:9925/'), out);
-			assert.ok(out.includes('HARPER_CLI_REFRESH_TOKEN=ref-tok'), out);
+		// Captures the streams only for the duration of the call — leaving them patched would also
+		// swallow mocha's own reporter output and mix it into these assertions.
+		async function captureLogin(...args) {
+			originalStdoutWrite = process.stdout.write;
+			originalStderrWrite = process.stderr.write;
+			originalConsoleLog = console.log;
+			process.stdout.write = (chunk) => {
+				stdout.push(String(chunk));
+				return true;
+			};
+			process.stderr.write = (chunk) => {
+				stderr.push(String(chunk));
+				return true;
+			};
+			// console.log is bound to the original stdout, so patch it too — otherwise a stray
+			// console.log would print for real and escape the "stdout is only the dotenv block" check.
+			console.log = (...parts) => {
+				stdout.push(`${parts.join(' ')}\n`);
+			};
+			try {
+				return await login(...args);
+			} finally {
+				process.stdout.write = originalStdoutWrite;
+				process.stderr.write = originalStderrWrite;
+				console.log = originalConsoleLog;
+			}
+		}
+
+		it('writes nothing but the dotenv block to stdout, so it can be piped', async () => {
+			await captureLogin('example.com', 'mockuser', { forCi: true });
+
+			// Exactly two lines, both KEY=value — `gh secret set --env-file -` reads this verbatim.
+			const lines = stdout
+				.join('')
+				.split('\n')
+				.filter((line) => line.length > 0);
+			assert.deepStrictEqual(lines, [
+				'HARPER_CLI_TARGET=https://example.com:9925/',
+				'HARPER_CLI_REFRESH_TOKEN=ref-tok',
+			]);
 			// The short-lived operation token is intentionally not emitted — the refresh token is
 			// the single durable secret; the CLI mints an operation token from it on each run.
-			assert.ok(!out.includes('HARPER_CLI_OPERATION_TOKEN'), out);
+			assert.ok(!stdout.join('').includes('HARPER_CLI_OPERATION_TOKEN'), stdout.join(''));
 		});
 
-		it('does not print tokens when the user declines', async () => {
-			confirmAnswer = false;
-			await login('example.com', 'mockuser');
-			const out = logged.join('\n');
-			assert.ok(!out.includes('HARPER_CLI_OPERATION_TOKEN='), out);
+		it('keeps the banner and status messages on stderr, away from the pipe', async () => {
+			await captureLogin('example.com', 'mockuser', { forCi: true });
+
+			const err = stderr.join('');
+			assert.ok(err.includes('Harper login'), err);
+			assert.ok(err.includes('Successfully logged in'), err);
+			// The token must never be duplicated onto stderr — keeping it off the screen is the
+			// whole reason for piping.
+			assert.ok(!err.includes('ref-tok'), err);
+		});
+
+		it('prints nothing at all without the flag (default login is unchanged)', async () => {
+			await captureLogin('example.com', 'mockuser');
+
+			const out = stdout.join('');
 			assert.ok(!out.includes('HARPER_CLI_REFRESH_TOKEN='), out);
+			assert.ok(!out.includes('ref-tok'), out);
+		});
+
+		// A silent empty stdout would be piped into a secret store and "succeed" at storing nothing.
+		it('fails loudly when the cluster returns no refresh token', async () => {
+			refreshToken = undefined;
+
+			await assert.rejects(() => captureLogin('example.com', 'mockuser', { forCi: true }), /process\.exit:1/);
+			assert.ok(!stdout.join('').includes('HARPER_CLI_TARGET='), stdout.join(''));
 		});
 	});
 });

--- a/unitTests/bin/login.test.js
+++ b/unitTests/bin/login.test.js
@@ -39,6 +39,26 @@ describe('Login', () => {
 		it('should handle existing paths', () => {
 			assert.strictEqual(normalizeTarget('example.com/api'), 'https://example.com:9925/api/');
 		});
+
+		// A normalized target keys the credentials file, is echoed in status output, written to .env
+		// and emitted by `harper login --for-ci`. Userinfo riding along would put the password in all
+		// four, so it is dropped here rather than at each of those sites.
+		it('should strip embedded credentials', () => {
+			assert.strictEqual(normalizeTarget('https://admin:hunter2@example.com:9925'), 'https://example.com:9925/');
+			assert.strictEqual(normalizeTarget('admin@example.com:1234'), 'https://example.com:1234/');
+		});
+
+		// The default port is applied by looking for a `:` in the authority, which the `:` in
+		// `user:password` used to satisfy — so a userinfo target came out port-less and resolved to
+		// 443 instead of 9925.
+		it('should still apply the default port when credentials contain a colon', () => {
+			assert.strictEqual(normalizeTarget('https://admin:hunter2@example.com'), 'https://example.com:9925/');
+		});
+
+		it('should preserve an explicitly written default port', () => {
+			assert.strictEqual(normalizeTarget('https://example.com:443'), 'https://example.com/');
+			assert.strictEqual(normalizeTarget('http://example.com:80'), 'http://example.com/');
+		});
 	});
 
 	describe('function arguments', () => {
@@ -278,6 +298,7 @@ describe('Login', () => {
 		let originalStdoutWrite;
 		let originalStderrWrite;
 		let originalCliOperations;
+		let originalIsTty;
 		let stdout;
 		let stderr;
 		let refreshToken;
@@ -327,12 +348,17 @@ describe('Login', () => {
 			refreshToken = 'ref-tok';
 			// Password from env so login needs no interactive prompt.
 			process.env.HARPER_CLI_PASSWORD = 'password';
+			// Non-TTY by default: the dedicated-CI-user confirmation only fires when there is a human
+			// to ask, and these cases assert the unattended (runner) path.
+			originalIsTty = process.stdin.isTTY;
+			process.stdin.isTTY = false;
 		});
 
 		afterEach(() => {
 			delete process.env.HARPER_CLI_PASSWORD;
 			delete process.env.HARPER_CLI_TARGET;
 			delete process.env.CLI_TARGET;
+			process.stdin.isTTY = originalIsTty;
 		});
 
 		// Captures the streams only for the duration of the call — leaving them patched would also
@@ -391,16 +417,102 @@ describe('Login', () => {
 			assert.ok(!err.includes('ref-tok'), err);
 		});
 
-		// normalizeTarget round-trips through URL.toString(), which preserves userinfo — so a target
-		// given with embedded credentials would otherwise write the password into the emitted secret
-		// and onto the terminal, the exact exposure this flag exists to prevent.
-		it('strips credentials embedded in the target URL', async () => {
+		// A target given with embedded credentials must not put the password anywhere the resolved
+		// target goes. Sanitizing only the emitted line would still leave it on the terminal, in
+		// ~/.harperdb/credentials.json and in .env — so the strip happens once, in normalizeTarget,
+		// and this asserts every one of those destinations.
+		it('keeps credentials embedded in the target URL out of stdout, stderr, and everything persisted', async () => {
+			fs.writeFileSync(path.join(testDir, '.env'), 'EXISTING=1\n');
 			await captureLogin('https://admin:hunter2@example.com', 'mockuser', { forCi: true });
 
 			const out = stdout.join('');
-			assert.ok(!out.includes('hunter2'), out);
-			assert.ok(!out.includes('admin:'), out);
 			assert.ok(out.includes('HARPER_CLI_TARGET=https://example.com:9925/'), out);
+
+			const err = stderr.join('');
+			const credentialsFile = fs.readFileSync(path.join(testDir, '.harperdb', 'credentials.json'), 'utf8');
+			const envFile = fs.readFileSync(path.join(testDir, '.env'), 'utf8');
+			for (const [name, contents] of [
+				['stdout', out],
+				['stderr', err],
+				['credentials.json', credentialsFile],
+				['.env', envFile],
+			]) {
+				assert.ok(!contents.includes('hunter2'), `${name} leaked the password: ${contents}`);
+				assert.ok(!contents.includes('admin@'), `${name} leaked the username: ${contents}`);
+			}
+			// The credentials-file key and the emitted target are the same value, so a later
+			// `harper deploy` against the emitted target finds the entry this login wrote.
+			assert.ok(JSON.parse(credentialsFile).targets['https://example.com:9925/'], credentialsFile);
+			fs.rmSync(path.join(testDir, '.env'), { force: true });
+		});
+
+		// Harper stores one refresh-token hash per user, so this credential is a rotation, not an
+		// addition: any refresh token the user already held is now dead. That is invisible until some
+		// other holder's next refresh 401s, so the command has to say it out loud.
+		it("warns on stderr that the user's previous refresh token was revoked", async () => {
+			await captureLogin('example.com', 'ci-deploy', { forCi: true });
+
+			const err = stderr.join('');
+			assert.ok(err.includes('One refresh token per user'), err);
+			assert.ok(err.includes("'ci-deploy'"), err);
+			assert.ok(err.includes('Give each CI consumer its own user'), err);
+			// The warning is human-facing, so it must not disturb the pipe.
+			const lines = stdout
+				.join('')
+				.split('\n')
+				.filter((line) => line.length > 0);
+			assert.deepStrictEqual(lines, [
+				'HARPER_CLI_TARGET=https://example.com:9925/',
+				'HARPER_CLI_REFRESH_TOKEN=ref-tok',
+			]);
+		});
+
+		it('does not warn about rotation on a default login, which mints nothing durable for CI', async () => {
+			await captureLogin('example.com', 'mockuser');
+
+			assert.ok(!stderr.join('').includes('One refresh token per user'), stderr.join(''));
+		});
+
+		// The CLI cannot verify that a user is dedicated to CI, but it can refuse to rotate that
+		// user's only refresh token without someone saying yes.
+		describe('dedicated-CI-user confirmation (interactive)', () => {
+			let originalCreatePromptModule;
+			let confirmAnswer;
+			let confirmMessage;
+
+			beforeEach(() => {
+				process.stdin.isTTY = true;
+				confirmMessage = undefined;
+				originalCreatePromptModule = inquirer.createPromptModule;
+				inquirer.createPromptModule = () => async (questions) => {
+					const q = Array.isArray(questions) ? questions[0] : questions;
+					if (q.type === 'confirm') {
+						confirmMessage = q.message;
+						return { [q.name]: confirmAnswer };
+					}
+					return { [q.name]: 'mock-response' };
+				};
+			});
+
+			afterEach(() => {
+				inquirer.createPromptModule = originalCreatePromptModule;
+			});
+
+			it('names the user and proceeds when confirmed', async () => {
+				confirmAnswer = true;
+				await captureLogin('example.com', 'ci-deploy', { forCi: true });
+
+				assert.ok(confirmMessage.includes("'ci-deploy'"), confirmMessage);
+				assert.ok(confirmMessage.includes('revokes any refresh token it already holds'), confirmMessage);
+				assert.ok(stdout.join('').includes('HARPER_CLI_REFRESH_TOKEN=ref-tok'), stdout.join(''));
+			});
+
+			it('exits without minting anything when declined', async () => {
+				confirmAnswer = false;
+
+				await assert.rejects(() => captureLogin('example.com', 'ci-deploy', { forCi: true }), /process\.exit:1/);
+				assert.strictEqual(stdout.join(''), '');
+			});
 		});
 
 		it('prints nothing at all without the flag (default login is unchanged)', async () => {

--- a/unitTests/bin/login.test.js
+++ b/unitTests/bin/login.test.js
@@ -85,6 +85,7 @@ describe('Login', () => {
 		let originalCwd;
 		let originalExit;
 		let originalStdoutWrite;
+		let originalStdinIsTTY;
 
 		// Mock cliOperations
 		const cliOperationsModule = require('#src/bin/cliOperations');
@@ -107,6 +108,11 @@ describe('Login', () => {
 			originalStdoutWrite = process.stdout.write;
 			process.stdout.write = () => {};
 
+			// A non-TTY stdin makes login skip the interactive CI/CD env prompt (as in CI), so
+			// these tests never block on it regardless of how the suite is launched.
+			originalStdinIsTTY = process.stdin.isTTY;
+			process.stdin.isTTY = false;
+
 			originalCliOperations = cliOperationsModule.cliOperations;
 			cliOperationsModule.cliOperations = async (req) => {
 				if (req.operation === 'create_authentication_tokens') {
@@ -124,6 +130,7 @@ describe('Login', () => {
 			process.cwd = originalCwd;
 			process.exit = originalExit;
 			process.stdout.write = originalStdoutWrite;
+			process.stdin.isTTY = originalStdinIsTTY;
 			cliOperationsModule.cliOperations = originalCliOperations;
 			fs.rmSync(testDir, { recursive: true, force: true });
 		});
@@ -176,6 +183,7 @@ describe('Login', () => {
 		let originalCwd;
 		let originalExit;
 		let originalStdoutWrite;
+		let originalStdinIsTTY;
 		let originalPrompt;
 		let originalCliOperations;
 		let loginRequest;
@@ -190,6 +198,10 @@ describe('Login', () => {
 			};
 			originalStdoutWrite = process.stdout.write;
 			process.stdout.write = () => {};
+			// Non-interactive stdin so login skips the CI/CD env-var confirm; these tests are about
+			// which credentials are sent, and shouldn't depend on whether the runner has a TTY.
+			originalStdinIsTTY = process.stdin.isTTY;
+			process.stdin.isTTY = false;
 			originalPrompt = inquirer.prompt;
 			inquirer.prompt = async (questions) => {
 				const q = Array.isArray(questions) ? questions[0] : questions;
@@ -206,6 +218,7 @@ describe('Login', () => {
 			process.cwd = originalCwd;
 			process.exit = originalExit;
 			process.stdout.write = originalStdoutWrite;
+			process.stdin.isTTY = originalStdinIsTTY;
 			inquirer.prompt = originalPrompt;
 			cliOperationsModule.cliOperations = originalCliOperations;
 			fs.rmSync(testDir, { recursive: true, force: true });
@@ -260,6 +273,101 @@ describe('Login', () => {
 			assert.strictEqual(loginRequest.auth_password, 'harper-secret');
 			assert.strictEqual(loginRequest.username, 'harper-admin');
 			assert.strictEqual(loginRequest.password, 'harper-secret');
+		});
+	});
+
+	describe('CI/CD environment variable output', () => {
+		const testDir = path.join(os.tmpdir(), `harper-test-login-cicd-${Date.now()}`);
+		const cliOperationsModule = require('#src/bin/cliOperations');
+		let originalCwd;
+		let originalHome;
+		let originalExit;
+		let originalStdinIsTTY;
+		let originalPrompt;
+		let originalConsoleLog;
+		let originalCliOperations;
+		let logged;
+		let confirmAnswer;
+
+		before(() => {
+			fs.mkdirSync(testDir, { recursive: true });
+			originalCwd = process.cwd;
+			process.cwd = () => testDir;
+
+			// Keep saveCredentials off the developer's real ~/.harperdb/credentials.json.
+			originalHome = process.env.HOME;
+			process.env.HOME = testDir;
+
+			originalExit = process.exit;
+			process.exit = (code) => {
+				if (code !== 0) throw new Error('process.exit:' + code);
+			};
+
+			// Interactive stdin so login reaches the CI/CD confirm prompt.
+			originalStdinIsTTY = process.stdin.isTTY;
+			process.stdin.isTTY = true;
+
+			originalPrompt = inquirer.prompt;
+			inquirer.prompt = async (questions) => {
+				const q = Array.isArray(questions) ? questions[0] : questions;
+				if (q.name === 'show') return { show: confirmAnswer };
+				return { [q.name]: 'mock-response' };
+			};
+
+			originalCliOperations = cliOperationsModule.cliOperations;
+			cliOperationsModule.cliOperations = async (req) => {
+				if (req.operation === 'create_authentication_tokens') {
+					return { operation_token: 'op-tok', refresh_token: 'ref-tok', target: req.target };
+				}
+				return {};
+			};
+		});
+
+		after(() => {
+			process.cwd = originalCwd;
+			if (originalHome === undefined) delete process.env.HOME;
+			else process.env.HOME = originalHome;
+			process.exit = originalExit;
+			process.stdin.isTTY = originalStdinIsTTY;
+			inquirer.prompt = originalPrompt;
+			cliOperationsModule.cliOperations = originalCliOperations;
+			fs.rmSync(testDir, { recursive: true, force: true });
+		});
+
+		beforeEach(() => {
+			logged = [];
+			originalConsoleLog = console.log;
+			console.log = (...args) => {
+				logged.push(args.join(' '));
+			};
+			// Password from env so login stays non-interactive apart from the CI/CD confirm.
+			process.env.HARPER_CLI_PASSWORD = 'password';
+		});
+
+		afterEach(() => {
+			console.log = originalConsoleLog;
+			delete process.env.HARPER_CLI_PASSWORD;
+			delete process.env.HARPER_CLI_TARGET;
+			delete process.env.CLI_TARGET;
+		});
+
+		it('prints the target and refresh token (only) when the user opts in', async () => {
+			confirmAnswer = true;
+			await login('example.com', 'mockuser');
+			const out = logged.join('\n');
+			assert.ok(out.includes('HARPER_CLI_TARGET=https://example.com:9925/'), out);
+			assert.ok(out.includes('HARPER_CLI_REFRESH_TOKEN=ref-tok'), out);
+			// The short-lived operation token is intentionally not emitted — the refresh token is
+			// the single durable secret; the CLI mints an operation token from it on each run.
+			assert.ok(!out.includes('HARPER_CLI_OPERATION_TOKEN'), out);
+		});
+
+		it('does not print tokens when the user declines', async () => {
+			confirmAnswer = false;
+			await login('example.com', 'mockuser');
+			const out = logged.join('\n');
+			assert.ok(!out.includes('HARPER_CLI_OPERATION_TOKEN='), out);
+			assert.ok(!out.includes('HARPER_CLI_REFRESH_TOKEN='), out);
 		});
 	});
 });

--- a/unitTests/bin/login.test.js
+++ b/unitTests/bin/login.test.js
@@ -56,8 +56,25 @@ describe('Login', () => {
 		});
 
 		it('should preserve an explicitly written default port', () => {
-			assert.strictEqual(normalizeTarget('https://example.com:443'), 'https://example.com/');
-			assert.strictEqual(normalizeTarget('http://example.com:80'), 'http://example.com/');
+			assert.strictEqual(normalizeTarget('https://example.com:443'), 'https://example.com:443/');
+			assert.strictEqual(normalizeTarget('http://example.com:80'), 'http://example.com:80/');
+		});
+
+		// login normalizes, then cliOperations normalizes again. `URL` serializes a default port away,
+		// so without writing it back the second pass would read `https://host:443` as port-less and
+		// append 9925 — silently sending the request somewhere else than the user asked for.
+		it('should be idempotent', () => {
+			for (const target of [
+				'example.com',
+				'https://example.com:443',
+				'http://example.com:80',
+				'https://admin:hunter2@example.com',
+				'example.com:1234',
+				'example.com/api',
+			]) {
+				const once = normalizeTarget(target);
+				assert.strictEqual(normalizeTarget(once), once, target);
+			}
 		});
 	});
 

--- a/unitTests/bin/login.test.js
+++ b/unitTests/bin/login.test.js
@@ -391,6 +391,18 @@ describe('Login', () => {
 			assert.ok(!err.includes('ref-tok'), err);
 		});
 
+		// normalizeTarget round-trips through URL.toString(), which preserves userinfo — so a target
+		// given with embedded credentials would otherwise write the password into the emitted secret
+		// and onto the terminal, the exact exposure this flag exists to prevent.
+		it('strips credentials embedded in the target URL', async () => {
+			await captureLogin('https://admin:hunter2@example.com', 'mockuser', { forCi: true });
+
+			const out = stdout.join('');
+			assert.ok(!out.includes('hunter2'), out);
+			assert.ok(!out.includes('admin:'), out);
+			assert.ok(out.includes('HARPER_CLI_TARGET=https://example.com:9925/'), out);
+		});
+
 		it('prints nothing at all without the flag (default login is unchanged)', async () => {
 			await captureLogin('example.com', 'mockuser');
 


### PR DESCRIPTION
## Summary

Two small additions that give a clean local-login → CI/CD path so Harper credentials don't have to live in the wild:

1. **`harper login --for-ci` prints a pipeable CI/CD credential block.** After a successful login it writes the target and the long-lived refresh token to **stdout**, in dotenv format, so it never has to appear on screen or in shell history:

   ```sh
   harper login --for-ci | gh secret set --env-file -   # sets both repo secrets in one shot
   harper login --for-ci | pbcopy                       # or paste them in by hand
   ```

   ```
   HARPER_CLI_TARGET=https://my-instance:9925/
   HARPER_CLI_REFRESH_TOKEN=eyJ...
   ```

   Without the flag, `harper login` behaves exactly as before and prints no credentials.

2. **The CLI's Bearer-token path reads tokens from env vars.** `harper deploy` and other remote operations now honor `HARPER_CLI_OPERATION_TOKEN` / `HARPER_CLI_REFRESH_TOKEN` (with `CLI_TARGET_*` aliases), so a runner can authenticate without a stored password or a prior `harper login`.

## Stream discipline (why the flag, not a prompt)

An earlier revision asked interactively ("Print environment variables so CI/CD can deploy without your password?"). A flag is easier to guide people to, and — more importantly — it makes the output *composable*. For a pipe to actually work, the streams have to split cleanly:

- **stdout** carries only the two `KEY=value` lines, dotenv-formatted and ANSI-free, so `gh secret set --env-file -` consumes it verbatim. The explanatory comments moved to **stderr** rather than riding along as `#` lines, since every consumer of this block reads it as data.
- **stderr** carries everything a human reads — banner, status, prompts. inquirer writes to stdout by default, so `--for-ci` hands it an stderr prompt module; without that the password prompt would be invisible, swallowed by the pipe.
- **A cluster that returns no refresh token is a loud failure** (exit 1) rather than a silent empty block — which would otherwise pipe into a secret store and "succeed" at storing nothing.

`--for-ci` is filtered out of argv before the positional target/username are read, so it can appear anywhere in the command.

## Behavior

- **Precedence:** explicit username → Basic (unchanged); else **env-var tokens** (override the credentials file); else `~/.harperdb/credentials.json` (unchanged).
- **Refresh-token-only works:** if no operation token is supplied (or it's expired), the CLI mints a fresh one from the refresh token — so CI needs only `HARPER_CLI_TARGET` + `HARPER_CLI_REFRESH_TOKEN` as durable secrets.
- **No file writes for env tokens:** a token refreshed from env vars is used in-memory only; file-based credentials still persist their refreshed token exactly as before.

## Tests

- `unitTests/bin/login.test.js` — four cases covering *which stream each byte lands on*, since that's the feature: stdout is exactly the two lines (asserted as an exact array, so any stray output fails), stderr never contains the token, the default path prints nothing, and a missing refresh token exits 1.
- `unitTests/bin/cliOperations.test.js` — env token overrides file creds; refresh-token-only minting; expired-token refresh without persisting; `CLI_TARGET_*` alias.
- 63 passing across both suites; `oxlint` and `prettier --check` clean.
- Verified end-to-end against a mock cluster: stdout parses as dotenv with exactly the two keys and zero ANSI escapes, and stderr contains **0** occurrences of the token.

## Rebase note

Rebased onto `main` (v5.2.0-beta.3). Main had extracted the inline token-refresh logic into a shared `refreshExpiredOperationToken` helper; rather than re-inlining this branch's copy, I taught that helper the two behaviors this PR needs (mint when the operation token is absent, not just expired; `persistKey: string | null` so env-var tokens skip `saveCredentials`). See the [rebase comment](https://github.com/HarperFast/harper/pull/1876#issuecomment-5121838602) for detail.

## Review round (`6f91873`)

Three things from review, each fixed at the source rather than at the symptom:

**A resolved target is an identity, not a credential.** `normalizeTarget` now strips userinfo, so the one canonical target is what gets stored as the credentials-file key, echoed in status text, written to `.env`, and emitted by `--for-ci`. Previously only the emitted line was sanitized, leaving the password in the other three. Callers that authenticate with userinfo read it off the *raw* target via the new `extractTargetCredentials` (`cliOperations`, `agentCli`).

This also settles the port: the default-port heuristic looked for a `:` after the scheme, which the `:` in `user:password` satisfied — so `https://admin:pw@host` was contacted on 443 while being emitted as `:9925`. The check now runs against the authority with userinfo removed, so contacted and emitted agree, and there's no second normalization to disagree with the first. Saved logins keyed by a userinfo URL need a re-login; those entries were storing a plaintext password as a JSON key.

**One env token namespace, selected as a unit.** `HARPER_CLI_OPERATION_TOKEN` and `HARPER_CLI_REFRESH_TOKEN` were resolved independently, so an operation token from one user could pair with a refresh token from another — running as the first identity until its operation token expired, then silently continuing as the second. A namespace now owns both halves, matching how `login.ts` already selects username/password. A selected-but-blank namespace warns and falls back to the credentials file rather than letting the other namespace win by being non-empty.

**Refresh-token rotation is explicit.** Harper stores one refresh-token hash per user — `createTokens` overwrites `hdb_user.refresh_token` and refresh validation accepts only that hash — so minting a CI credential revokes whatever that user already held, invisibly, until the displaced holder's next refresh 401s. `--for-ci` now states this before it prompts, labels the username prompt as a dedicated CI user, requires an interactive confirmation naming that user (skipped when stdin isn't a TTY, so runners are unaffected; `| gh secret set` still hits it since only stdout is piped), and repeats the warning beside the credential block. `harper help` documents it. The client can't verify that a user is *dedicated* to CI — the real fix is server-side, filed as [#2018 — Auth: support multiple named, independently revocable refresh credentials per user](https://github.com/HarperFast/harper/issues/2018).

One adjacent fix while in that function (`90d86a5`): `normalizeTarget` wasn't idempotent for an explicitly written default port. `URL` serializes `:443` away, so `https://host:443` came back port-less, and the second pass — login normalizes, then cliOperations normalizes again — read that as "no port given" and appended 9925. `harper login https://host:443` was therefore talking to `:9925`. Pre-existing, but the output is also the credentials-file key, so idempotence is something every caller already assumes.

Tests added: target userinfo is absent from stdout, stderr, `credentials.json` and `.env` (and the stored key matches the emitted target); `normalizeTarget` strips credentials, still applies the default port past a `user:password` colon, preserves an explicitly written default port, and is idempotent across a set of representative targets; the two token namespaces never mix, and a blank one doesn't fall through; the rotation warning names the user without disturbing the pipe; the confirmation names the user, proceeds on yes, and mints nothing on no.

## Related — deploy-by-reference effort

- `HarperFast/harper#1849` — two-phase stage/activate + `revert_component`
- `HarperFast/harper#1850` — `harper deploy by_ref=true` (deploy by git reference)
- `HarperFast/harper#1851` — `harper deploy setup=true` (client-side sealed deploy credential)
- `HarperFast/harper-pro#594` — `add_ssh_key generate=true` (cluster-side keygen)
- `HarperFast/create-harper#118` — scaffolds this flow; its deploy workflow consumes `HARPER_CLI_TARGET` + `HARPER_CLI_REFRESH_TOKEN` from this PR
- `HarperFast/documentation#599` — docs for the two-phase work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

