### PR TITLE
ci: run a single Node version for integration tests on PR pushes

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main, 'v[0-9]+.[0-9]+']
   pull_request:
+  schedule:
+    - cron: '0 7 * * *'
   workflow_dispatch:
     inputs:
       node-version:
@@ -31,7 +33,11 @@ jobs:
       - name: Set Node versions
         id: set-node-versions
         run: |
-          if [ "${{ github.event.inputs.node-version }}" == "all" ] || [ -z "${{ github.event.inputs.node-version }}" ]; then
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            # PR pushes run a single representative Node version to keep the dev loop fast;
+            # the full 22/24/26 matrix runs on push to main/release and on the nightly schedule.
+            echo "node-versions=[24]" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event.inputs.node-version }}" == "all" ] || [ -z "${{ github.event.inputs.node-version }}" ]; then
             echo "node-versions=[22, 24, 26]" >> $GITHUB_OUTPUT
           else
             echo "node-versions=[${{ github.event.inputs.node-version }}]" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What

Trims integration-test CI cost on PR pushes without losing cross-version coverage:

- **PR pushes** now run the integration suite on a **single representative Node version (24)** instead of the full `22/24/26` matrix — dropping the `run-integration-tests` fan-out from 18 shards to 6.
- The **full `22/24/26` matrix still runs** on pushes to `main`/release branches, and on a **new nightly schedule** (`0 7 * * *`).
- `workflow_dispatch` behavior is unchanged (still respects the `node-version` input).

Windows/Bun/uWS variant jobs are untouched. Shard counts are unchanged (already 6-way).

## Why

Every PR push was paying for the full three-Node matrix, tripling integration compute and stretching the wall-clock that CI-monitoring sessions wait on. Cross-Node regressions are still caught on `main` and nightly; per-push we only need one representative version.

## Risk

Low. A Node-version-specific regression would surface on the next `main` push / nightly rather than on the PR push itself — an acceptable trade for the dev-loop speedup. The change is a conditional in the existing `generate-node-version-matrix` job.

— KrAIs (Claude Opus 4.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)