### PR TITLE
fix(replication): stop the resume-cursor write freezing the apply worker

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -615,10 +615,20 @@ export function makeTable(options) {
 														// Staging failed (encoding, or the store closing under a shutdown race), so
 														// nothing will commit this transaction. Abort it rather than leaking a native
 														// transaction that would pin a snapshot and hold off compaction.
-														seqTransaction.abort();
+														try {
+															seqTransaction.abort();
+														} catch {}
 														throw error;
 													}
-													return seqTransaction.commit();
+													return seqTransaction.commit().catch((error) => {
+														// A rejected commit leaves the handle open too, so release it here as well —
+														// same reason as the staging failure above, and the same shape as the
+														// eviction paths' commit failures (see evict/commitItems below).
+														try {
+															seqTransaction.abort();
+														} catch {}
+														throw error;
+													});
 												}
 												return dbisDb.put(seqKey, seqRecord);
 											};

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -554,7 +554,7 @@ export function makeTable(options) {
 									// still need to reference it afterward.
 									const committingTxn = txnInProgress;
 									committingTxn?.resolve();
-									let updateRecordedSequenceId: () => void;
+									let updateRecordedSequenceId: () => MaybePromise<void>;
 									if (event.localTime && lastSequenceId !== event.localTime) {
 										if (event.remoteNodeIds?.length > 0) {
 											updateRecordedSequenceId = () => {
@@ -597,10 +597,30 @@ export function makeTable(options) {
 													new Date(event.localTime),
 													event.remoteNodeIds
 												);
-												dbisDb.put(seqKey, {
-													seqId,
-													nodes: nodeStates,
-												});
+												const seqRecord = { seqId, nodes: nodeStates };
+												// On RocksDB `put` is aliased to `putSync` (see openRocksDatabase), so writing
+												// the cursor directly absorbs RocksDB write-stall back-pressure on the event
+												// loop — during bulk catch-up a single call has been measured blocking for
+												// 101s, which also stops this worker's keep-alives and gets the subscription
+												// torn down by the sender's receive watchdog (harper-pro#603). Staging into a
+												// transaction and committing it is the natively-async write path: the stage is
+												// an in-memory WriteBatch append and the stall is absorbed off-thread by the
+												// commit. Awaiting it keeps the same ordering as the blocking call did, and
+												// back-pressures the apply loop instead of freezing it.
+												if (isRocksDB) {
+													const seqTransaction = new RocksTransaction((dbisDb as any).store);
+													try {
+														(dbisDb as any).putSync(seqKey, seqRecord, { transaction: seqTransaction });
+													} catch (error) {
+														// Staging failed (encoding, or the store closing under a shutdown race), so
+														// nothing will commit this transaction. Abort it rather than leaking a native
+														// transaction that would pin a snapshot and hold off compaction.
+														seqTransaction.abort();
+														throw error;
+													}
+													return seqTransaction.commit();
+												}
+												return dbisDb.put(seqKey, seqRecord);
 											};
 											lastSequenceId = event.localTime;
 										}
@@ -626,7 +646,7 @@ export function makeTable(options) {
 									}
 									// Only reached when the commit succeeded; a failure propagates to the handler's catch
 									// and the sequence id is intentionally not advanced past the unapplied write.
-									if (updateRecordedSequenceId) updateRecordedSequenceId();
+									if (updateRecordedSequenceId) await updateRecordedSequenceId();
 									continue;
 								}
 								if (txnInProgress) {

--- a/unitTests/resources/replicationSeqCursor.test.js
+++ b/unitTests/resources/replicationSeqCursor.test.js
@@ -1,0 +1,154 @@
+const assert = require('assert');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const { waitFor } = require('../waitFor');
+require('#src/server/serverHelpers/serverUtilities');
+
+// The replication apply loop records a per-peer resume cursor when it finishes applying a
+// transaction. On RocksDB `dbisDb.put` is aliased to `putSync` (openRocksDatabase), so writing that
+// cursor directly absorbs RocksDB write-stall back-pressure on the apply worker's event loop — a
+// single call was measured blocking for 101s during bulk catch-up, which also stops the worker's
+// keep-alives and gets the subscription torn down by the sender's watchdog (harper-pro#603). The
+// cursor must therefore be staged into a transaction and committed through the natively-async path.
+describe('replication sequence-cursor write (harper-pro#603)', () => {
+	// RocksDB-only: on LMDB `put` is genuinely async, so the apply loop keeps using it directly.
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+
+	before(function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+	});
+
+	// A table fed only by an intermediate (replication) source that yields `events` in order, then
+	// holds the subscription open until `held` resolves (so the apply loop stays alive for assertions).
+	function makeReplicatedTable(name, events, held) {
+		const ReplicatedTable = table({
+			table: name,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+		});
+		ReplicatedTable.sourcedFrom(
+			{
+				subscribeOnThisThread() {
+					return true;
+				},
+				async *subscribe() {
+					for (const event of events) yield event;
+					await held;
+				},
+			},
+			{ intermediateSource: true }
+		);
+		return ReplicatedTable;
+	}
+
+	const SEQ = Symbol.for('seq');
+	const isSeqKey = (key) => Array.isArray(key) && key[0] === SEQ;
+	const readCursor = (Table, nodeId) => Table.dbisDB.getSync([SEQ, nodeId]);
+
+	// Observe every cursor write: which ones were staged into a transaction (the async path) and
+	// which went straight to the store as a blocking write (the regression this fix removes).
+	// `put` is an own property aliased onto putSync at open time, so the two are spied separately.
+	function spyOnCursorWrites(Table, onStage) {
+		const dbisDB = Table.dbisDB;
+		const staged = [];
+		const blocking = [];
+		const originalPutSync = dbisDB.putSync;
+		const originalPut = dbisDB.put;
+		dbisDB.putSync = function (key, value, options) {
+			if (isSeqKey(key)) {
+				if (options?.transaction) {
+					staged.push({ key, value, transaction: options.transaction });
+					onStage?.(options.transaction);
+				} else blocking.push({ key, value });
+			}
+			return originalPutSync.apply(this, arguments);
+		};
+		dbisDB.put = function (key, value) {
+			if (isSeqKey(key)) blocking.push({ key, value });
+			return originalPut.apply(this, arguments);
+		};
+		return {
+			staged,
+			blocking,
+			restore() {
+				dbisDB.putSync = originalPutSync;
+				dbisDB.put = originalPut;
+			},
+		};
+	}
+
+	it('stages the cursor into a transaction instead of writing it on the event loop', async function () {
+		let release;
+		const held = new Promise((resolve) => (release = resolve));
+		const now = Date.now();
+		const ReplicatedTable = makeReplicatedTable(
+			'SeqCursorTable',
+			[
+				{ type: 'put', id: 1, value: { id: 1, name: 'replicated' }, timestamp: now },
+				{ type: 'end_txn', localTime: now, timestamp: now, remoteNodeIds: [41] },
+			],
+			held
+		);
+		const spy = spyOnCursorWrites(ReplicatedTable);
+		try {
+			await waitFor(() => readCursor(ReplicatedTable, 41)?.seqId === now, {
+				timeout: 5000,
+				message: 'cursor recorded for the peer',
+			});
+			assert.equal(spy.blocking.length, 0, 'the cursor must never be written with a blocking store write');
+			assert.equal(spy.staged.length, 1, 'the cursor must be staged into a transaction');
+			assert.equal(spy.staged[0].value.seqId, now);
+		} finally {
+			spy.restore();
+			release();
+		}
+	});
+
+	it('aborts the cursor transaction when its commit fails, and keeps applying', async function () {
+		let release;
+		const held = new Promise((resolve) => (release = resolve));
+		const now = Date.now();
+		// two transactions: the first one's cursor commit is forced to fail, the second must still land
+		const ReplicatedTable = makeReplicatedTable(
+			'SeqCursorFailTable',
+			[
+				{ type: 'put', id: 1, value: { id: 1, name: 'first' }, timestamp: now },
+				{ type: 'end_txn', localTime: now, timestamp: now, remoteNodeIds: [42] },
+				{ type: 'put', id: 2, value: { id: 2, name: 'second' }, timestamp: now + 1 },
+				{ type: 'end_txn', localTime: now + 1, timestamp: now + 1, remoteNodeIds: [42] },
+			],
+			held
+		);
+		const aborted = [];
+		let failNext = true;
+		// Fail only the first cursor transaction's commit, leaving the record transactions alone, and
+		// record the abort. The stub never commits, so the wrapped abort is what releases the handle.
+		const spy = spyOnCursorWrites(ReplicatedTable, (transaction) => {
+			if (!failNext) return;
+			failNext = false;
+			transaction.commit = () =>
+				Promise.reject(Object.assign(new Error('forced cursor commit failure'), { code: 'ERR_BUSY' }));
+			const originalAbort = transaction.abort.bind(transaction);
+			transaction.abort = () => {
+				aborted.push(transaction);
+				return originalAbort();
+			};
+		});
+		try {
+			await waitFor(async () => (await ReplicatedTable.get(2))?.name === 'second', {
+				timeout: 5000,
+				message: 'apply loop survived the failure',
+			});
+			assert.equal(aborted.length, 1, 'a failed cursor commit must abort its transaction rather than leak the handle');
+			// the failed cursor is not recorded, but the loop is not wedged: the next one is
+			await waitFor(() => readCursor(ReplicatedTable, 42)?.seqId === now + 1, {
+				timeout: 5000,
+				message: 'the next cursor still records',
+			});
+		} finally {
+			spy.restore();
+			release();
+		}
+	});
+});


### PR DESCRIPTION
## What

The replication apply loop in `resources/Table.ts` persists the per-peer resume cursor with `dbisDb.put()`. On RocksDB that call is **not** asynchronous — `openRocksDatabase` (`resources/databases.ts:202`) deliberately aliases `put` onto `putSync` so thrown errors aren't masked by a promise:

```js
db.put = db.putSync as any;
db.remove = db.removeSync as any;
```

So the cursor write absorbs RocksDB write-stall back-pressure **on the worker's event loop**. Measured locally during bulk catch-up at Fabric's RocksDB sizing: up to **101s inside a single call**, and ~700s of a 725s catch-up window spent inside these writes in aggregate.

A frozen event loop stops everything else on that thread, including the replication keep-alive — so the sender's receive watchdog concludes the receiver is dead and tears the subscription down (4 reconnects per local run, 9 in the failing nightly), discarding in-flight work.

This change stages the cursor into a transaction and commits that. Staging is an in-memory WriteBatch append; `Transaction.commit()` is the one natively-async write path in rocksdb-js. The same stall is now awaited off-thread instead of blocking. Either half failing (staging or commit) aborts the transaction rather than leaking a native handle that would pin a snapshot and hold off compaction — the shape `evict()` and `commitItems()` already use in this file.

## What this does *not* do

It does **not** make catch-up faster. The wait is genuine storage back-pressure and is unchanged in duration — this only stops it rendering the worker unresponsive. The nightly `Large-data large-catchup` job will not be turned green by this alone; catch-up throughput is bounded by RocksDB flush capacity at the configured WriteBufferManager size, which is a provisioning question tracked separately.

## Why the write stays where it is

The obvious alternative — folding the cursor write into the data transaction it describes — is **unsafe**. harper-pro's `replicationConnection.ts` assigns `endTxnEvent.localTime = lastDurableSequenceId` *inside* `onCommit`, and may `await flushCopyRowsDurable()` first. Core reads `event.localTime` only after awaiting `onCommit`. That clamp is what stops the persisted cursor advancing past a blob that is not yet durable, so writing the cursor inside the data transaction (which commits *before* `onCommit` runs) would persist the unclamped value and break the no-data-loss guarantee.

So the write keeps its exact position in the sequence; only the mechanism changes.

## Review follow-ups (second round)

- **A failed `seqTransaction.commit()` now aborts.** It previously returned its rejection with the handle still open. Raised by both review bots; real, and the same leak the staging-failure branch immediately above it was already guarding against.
- **The RocksDB branch now has coverage** — `unitTests/resources/replicationSeqCursor.test.js` drives an `end_txn` event carrying `remoteNodeIds` through the apply loop (an intermediate/replication source, the only path that reaches this closure) and asserts:
  1. the cursor is staged into a transaction and **never** written with a blocking store write (`put`/unstaged `putSync` on `__dbis__` are both spied);
  2. a forced cursor-commit failure aborts that transaction and the apply loop keeps applying the next transaction's writes and cursor.

  Both assertions were checked against the pre-fix code: stripping the `isRocksDB` branch fails (1); removing just the commit `.catch` fails (2). Skipped under `HARPER_STORAGE_ENGINE=lmdb`, where `put` is genuinely async.

## Test notes

4 local 4GB catch-up runs per arm against a real 2-node cluster, at Fabric's RocksDB sizing (8GB instance → blockCache 15% / WBM 5%), alternating builds to control for machine drift:

| variant | throughput | converged | event-loop-lag warnings | watchdog teardowns |
|---|---|---|---|---|
| **this change** | 5.7ᵀ, 6.5, 7.5, 8.3 MB/s | 3/4 | **0, 0, 0, 0** | **0, 0, 0, 0** |
| baseline | 5.3ᵀ, 5.6ᵀ, 11.3, 16.4 MB/s | 2/4 | 11, 11, 4, 5 | 4, 4, 3, 1 |

(ᵀ = exceeded the test's budget)

The freeze/teardown columns are the claim. The throughput column is explicitly **not** — the spread is wide enough on both arms that n=4 supports no throughput conclusion, and none is claimed. Instrumenting the commit directly showed why the two arms should be equivalent there: the cursor commit costs ~1.2ms mean when RocksDB is healthy and blocks only when the *shared* WriteBufferManager is stalled — the identical condition the data commits face. Baseline performs the same operations in the same order (`putSync` after `await committingTxn.committed`), so it already paid a data-commit stall followed by a cursor-write stall, sequentially. Only the thread-blocking property differs.

One further 4 GB run on the current head (post-merge with `main`, at the same Fabric RocksDB sizing — `blockCache=1228 MB wbm=409 MB`): converged in **528.8s** of a 720s budget at 7.7 MB/s, with **0** event-loop-lag warnings and **0** watchdog teardowns. Longest no-progress gap 44s, against the harness's 300s wedge guard. Full core `unitTests/resources` suite: 1240 passing.

Also run: harper-pro `test:unit` (394 passing), and `fullyConnectedReplication` / `directionalFlowReplication` / `receiveBacklogMemory` (11/11, including the LMDB replication suite which exercises the non-RocksDB branch).

`integrationTests/cloneNode/cloneResume.test.mjs` fails on this branch — but it fails **identically on baseline** (same error, same ~184s), so it is pre-existing and unrelated.

## Reviewer notes / open concerns

- The LMDB branch now `await`s `dbisDb.put()` where it previously left the promise floating. That's a small deliberate behaviour change (it also stops a potential unhandled rejection); lmdb-js batches writes so the latency is negligible, and the LMDB replication suite passes. Happy to revert to fire-and-forget if you'd rather I not touch that path.
- `main` has since been merged in, so this is current; the paired harper-pro PR (HarperFast/harper-pro#604) points its `core` submodule at this branch's head.

Refs harper-pro#603

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.8)
