### PR TITLE
fix(types): widen recordCommitLatency parameter so the build type-checks

### DIFF
--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -42,7 +42,9 @@ export function setCommitLatencyRecorder(recorder: ((durationMs: number) => void
 // commit nor surface as an unhandled rejection on this floating `.then`. The thenable guard protects
 // against a future caller passing a non-Promise `commitResolution` (today it is always the rocksdb-js
 // async `Transaction.commit()` result, which is guaranteed to be a Promise).
-function recordCommitLatency(commitResolution: Promise<void>, submittedAt: number) {
+// Parameter widened to Promise<unknown> because callers may resolve with RETRY_NOW_VALUE (a number)
+// on coordinated retry, but we only record the timing and never read the resolved value.
+function recordCommitLatency(commitResolution: Promise<unknown>, submittedAt: number) {
 	if (!recordCommitLatencyMs) return;
 	const record = () => {
 		try {


### PR DESCRIPTION
## What
Widen the `recordCommitLatency()` parameter type from `Promise<void>` to `Promise<unknown>` to accommodate callers that resolve with `RETRY_NOW_VALUE` (a number) on coordinated retry.

## Why
The `recordCommitLatency()` function only reads settlement timing via `.then()` and never touches the resolved value — `Promise<unknown>` is the honest parameter type. This eliminates the TS2345 type error that has prevented `npm run build` from type-checking cleanly since commit-latency work in #1688.

The error cascades to the Next.js adapter integration workflow: even though Harper's own CI tolerates it (`noEmitOnError` is off, so tests run), the adapter workflow builds harper and treats a non-zero tsc exit as a failure. This unblocks any PR flagged by the adapter-changes detector.

## Test plan
- ✅ `npx tsc --project tsconfig.build.json --noEmit` exits 0 (no type errors)
- ✅ `npm run build` completes successfully
- ✅ `npm run test:unit:resources` passes: 1238 passing / 14 pending (baseline)
- ✅ prettier + oxlint clean

## Notes
Only `resources/DatabaseTransaction.ts` changed: the `recordCommitLatency` parameter type + explanatory comment. No cast removed, no declared type changed elsewhere — the existing `as Promise<void>` at the assignment survives for the surrounding retry logic.

Refs #1688

🤖 Generated with [Claude Code](https://claude.com/claude-code)