### PR TITLE
chore(ci): bump ai-review-prompts to 82c9484 (#73 calibration + #74 caller hygiene)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,7 +33,7 @@ jobs:
     # Note: the `claude-review` label name is matched there too —
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@9cf49d23cb046ecd6c87f3bba86dc3338d6998fb # main 2026-06-29 (#70 week-of-06-22 calibration + #71 prompt-ref tracking; on 1bbc562 = #67 + #69)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@82c9484f6f2560be4a37032858311e429bccd56c # main 2026-07-21 (#73 severity-deflation + fail-closed calibration, #74 caller hygiene; on 9cf49d2 = #70 + #71)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -60,7 +60,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 9cf49d23cb046ecd6c87f3bba86dc3338d6998fb
+      ai-review-prompts-ref: 82c9484f6f2560be4a37032858311e429bccd56c
       # CANARY (2026-07-11): run this repo's Claude reviews on Sonnet 5
       # while the fleet default stays claude-sonnet-4-6. Every ai-review-log
       # entry records `Model:`, so calibration can compare sonnet-5 vs

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -52,7 +52,7 @@ jobs:
     # Note: the `gemini-review` label name is matched there too —
     # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@9cf49d23cb046ecd6c87f3bba86dc3338d6998fb # main 2026-06-29 (#70 week-of-06-22 calibration + #71 prompt-ref tracking; on 1bbc562 = #67 + #69)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@82c9484f6f2560be4a37032858311e429bccd56c # main 2026-07-21 (#73 severity-deflation + fail-closed calibration, #74 caller hygiene; on 9cf49d2 = #70 + #71)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -70,7 +70,7 @@ jobs:
       # duplication is unavoidable: reusable workflows can't introspect
       # their own ref (`github.workflow_ref` resolves to the CALLER's
       # ref in workflow_call context), and `uses: …@<ref>` is literal.
-      ai-review-prompts-ref: 9cf49d23cb046ecd6c87f3bba86dc3338d6998fb
+      ai-review-prompts-ref: 82c9484f6f2560be4a37032858311e429bccd56c
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/validate-caller-workflows.yml
+++ b/.github/workflows/validate-caller-workflows.yml
@@ -27,9 +27,9 @@ on:
 
 jobs:
   validate:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@6463b3da6326f0ca4646fb6b5139c2ecf92130f6 # main 2026-05-06 (post #11/#12/#14)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@82c9484f6f2560be4a37032858311e429bccd56c # main 2026-07-21 (#74: validator now covers gemini-*.{yml,yaml} callers too)
     with:
       # Same SHA as the `uses:` ref above — the reusable uses this
       # to check out the validator script at the matching version.
       # Same SHA-twice pattern as the other caller workflows.
-      ai-review-prompts-ref: 6463b3da6326f0ca4646fb6b5139c2ecf92130f6
+      ai-review-prompts-ref: 82c9484f6f2560be4a37032858311e429bccd56c


### PR DESCRIPTION
Review callers 9cf49d2 → 82c9484, validate pin → same SHA (uses + ai-review-prompts-ref in lockstep, all three caller files).

**What reviews pick up (#73, week-of-06-29 calibration):** the severity-deflation mirror rule (peer-flagged defects can't be talked down with unproven "unreachable"/"no escalation" claims), fail-closed / validate-at-registration on new surfaces, and secret-redaction routing checks. These target the dominant partial class in the last two triage batches.

**What validate picks up (#74):** the caller validator now covers `gemini-*.{yml,yaml}` callers too — closes the shadow-job/mutable-ref guard gap flagged in rocksdb-js#701 review feedback.

The `model: claude-sonnet-5` canary line and the caller-permissions block are untouched. With prompt-ref tracking live, next Sunday's calibration sweep becomes the first before/after read across `9cf49d2` → `82c9484`.

Note: this PR edits the caller workflows, so its own review checks fail with the expected anti-tamper guard; clears on merge. Companions: oauth + harper-pro (same bump).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)