### PR TITLE
test(apitests): await table clears on re-setup, make check-operations assertions diagnostic

### DIFF
--- a/unitTests/apiTests/RESTProperties-test.mjs
+++ b/unitTests/apiTests/RESTProperties-test.mjs
@@ -326,7 +326,10 @@ describe('test REST with property updates', function () {
 				}
 			);
 			assert(
-				response.data.some((record) => record.title === 'title0'),
+			assert(
+				Array.isArray(response.data) && response.data.some((record) => record.title === 'title0'),
+				`SELECT * FROM data.FourProp did not return title0: ${preview(response)}`
+			);
 				`SELECT * FROM data.FourProp did not return title0: ${preview(response)}`
 			);
 		});

--- a/unitTests/apiTests/RESTProperties-test.mjs
+++ b/unitTests/apiTests/RESTProperties-test.mjs
@@ -5,6 +5,12 @@ import axios from 'axios';
 import { setupTestApp, baseUrl, operationsUrl, testHost } from './setupTestApp.mjs';
 import { request } from 'http';
 
+// A bare `assert(data.some(...))` failure reports nothing about what came back, which makes an
+// intermittent failure in CI (where the run can't be re-created locally) close to undiagnosable.
+function preview(response) {
+	return `status ${response.status}, body ${JSON.stringify(response.data)?.slice(0, 2000)}`;
+}
+
 describe('test REST with property updates', function () {
 	before(async function () {
 		await setupTestApp();
@@ -240,7 +246,10 @@ describe('test REST with property updates', function () {
 				search_attribute: 'id',
 				search_value: '*',
 			});
-			assert(response.data.some((record) => record.title === 'title0'));
+			assert(
+				response.data.some((record) => record.title === 'title0'),
+				`search_by_value did not return title0: ${preview(response)}`
+			);
 		});
 		it('search_by_conditions with join', async function () {
 			let response = await axios.post(
@@ -258,7 +267,10 @@ describe('test REST with property updates', function () {
 					},
 				}
 			);
-			assert(response.data.some((record) => record.related.name === 'Related 6'));
+			assert(
+				response.data.some((record) => record.related.name === 'Related 6'),
+				`search_by_conditions with join did not return Related 6: ${preview(response)}`
+			);
 		});
 		it('search_by_conditions with different properties', async function () {
 			let response = await axios.post(
@@ -292,7 +304,10 @@ describe('test REST with property updates', function () {
 					},
 				}
 			);
-			assert(response.data.some((record) => record.relatedId === '6'));
+			assert(
+				response.data.some((record) => record.relatedId === '6'),
+				`search_by_conditions did not return relatedId 6: ${preview(response)}`
+			);
 			assert.equal(response.data[0].id, '34');
 			assert.equal(response.data[1].id, '33');
 		});
@@ -310,8 +325,10 @@ describe('test REST with property updates', function () {
 					},
 				}
 			);
-			if (response.status > 400) console.error(response.data);
-			assert(response.data.some((record) => record.title === 'title0'));
+			assert(
+				response.data.some((record) => record.title === 'title0'),
+				`SELECT * FROM data.FourProp did not return title0: ${preview(response)}`
+			);
 		});
 		it('sql returns all attributes and sub-object of array', async function () {
 			let response = await axios.put(`${baseUrl}/namespace/SubObject/6`, {
@@ -323,7 +340,10 @@ describe('test REST with property updates', function () {
 				operation: 'sql',
 				sql: 'SELECT * FROM data.SubObject',
 			});
-			assert(response.data.some((record) => record.subObject?.name === 'another sub-object'));
+			assert(
+				response.data.some((record) => record.subObject?.name === 'another sub-object'),
+				`SELECT * FROM data.SubObject did not return the sub-object: ${preview(response)}`
+			);
 		});
 		it('describe_table returns all attributes', async function () {
 			let response = await axios.post(operationsUrl, {

--- a/unitTests/apiTests/setupTestApp.mjs
+++ b/unitTests/apiTests/setupTestApp.mjs
@@ -115,11 +115,16 @@ export async function setupTestApp() {
 	createdRecords = [];
 
 	if (serverStarted) {
-		// if already started, clear out any previous records and recreate them
-		tables.VariedProps.clear();
-		tables.FourProp.clear();
-		tables.Related.clear();
-		tables.SubObject.clear();
+		// if already started, clear out any previous records and recreate them. Table.clear() resolves
+		// asynchronously, so it must be awaited — otherwise a clear can land after the records below have
+		// been written and silently wipe them, which shows up much later as an unrelated-looking empty
+		// result in whichever suite reads the table next.
+		await Promise.all([
+			tables.VariedProps.clear(),
+			tables.FourProp.clear(),
+			tables.Related.clear(),
+			tables.SubObject.clear(),
+		]);
 	} else {
 		const { startHTTPThreads } = await import('#src/server/threads/socketRouter');
 		serverStarted = await startHTTPThreads(config.threads || 0);


### PR DESCRIPTION
## What / why

Main's Unit Test job went red on `unitTests/apiTests/RESTProperties-test.mjs` →
`sql returns all attributes of four property object`, and the failure was attributed to
db03c474 (`fix(resources): serve a sort on the primary key from primary-store order`, the
fix for #773). **That attribution is wrong, and the test is flaky, not deterministic:**

- Re-running the *failed jobs only* of run `29915353343` (SHA `07c2bbc9`, main HEAD) with
  **no code change** turned them green. Main is green now.
- The failures move around: at `db03c474` only Node 24 failed (this test); at `07c2bbc9`
  Node 22 failed this test while Node 24 failed `test MQTT connections and commands >
  subscribe root with history`; at `604f4a97` only Node 26 failed, on
  `Table.getRecordCount > does not take a key count when the scan completes within the time
  budget`. Runs before db03c474 were red on yet other tests.
- The CI log for the failing case shows the query taking the **legacy** engine
  (`[sql-engine]: SQL engine v2 fallback: scan on "data.FourProp" has no usable index
  condition`). The legacy `SELECT *` path reaches `Table.search` via
  `ResourceBridge.searchByValue`, which passes `sort: searchObject.sort` — always
  `undefined` here. db03c474 only changed the `if (sort)` branch, so it is not on this
  code path at all.

So this PR does not "fix the regression" (there isn't one). It fixes the two things that
made this class of failure both *possible* and *undiagnosable*.

## Changes

**1. `setupTestApp()` did not await the table clears.** Every call after the first re-seeds
the tables, and `Table.clear()` returns a promise (`clear(): Promise<void>` on both `lmdb`
and `@harperfast/rocksdb-js`). The four calls were fire-and-forget, immediately followed by
the awaited PUTs that re-create the records — nothing orders the clear against them, so a
late clear can wipe the records it was meant to make room for. That presents much later as
an empty or short result in whichever suite reads the table next, which is exactly the
shape of the observed failure. Now awaited.

**2. The `check operations` assertions carried no message.** `assert(data.some(...))` fails
with a bare `AssertionError` — no status, no body, no indication whether the array was
empty or merely missing an attribute. That ambiguity is most of why diagnosing this cost
hours against a CI-only failure. All five now report the status and a truncated body.

## Test notes

- `unitTests/apiTests/RESTProperties-test.mjs`: the 14 REST tests pass locally; the 7
  `check operations` tests cannot run in this worktree because the operations API does not
  bind (see the caveat below) — they are exercised in CI.
- Ran `RBAC-test.mjs` + `RESTProperties-test.mjs` together to exercise the
  `serverStarted === true` branch that change 1 touches; no behavior change beyond the
  ordering.
- `npm run test:unit:main`: 3767 passing, 10 failing — all 10 in
  `unitTests/components/globalIsolation.test.js`, pre-existing in this worktree (its
  fixture `node_modules` are not installed) and untouched by this change.
- No product code is touched, so the #773 primary-key-sort regression tests in
  `integrationTests/apiTests/rest.test.mjs` are unaffected.

## Open concerns

- Change 1 is a *plausible* cause of the flake, not a proven one — I could not reproduce
  the failure locally (see below). It is correct regardless: an unawaited async clear
  racing the writes that follow it is a bug whether or not it is *this* bug. If the flake
  recurs, change 2 means the next CI failure will actually say what came back.
- Worth deciding separately: a couple of the other unit-test flakes (MQTT
  `subscribe root with history`, `Table.getRecordCount` time-budget) look like they deserve
  their own issues.

## Environment caveat found while working this

On Linux a unix socket path is capped at 107 bytes. The unit-test harness derives the
operations-API domain socket from the repo path (`unitTests/envDir/<pid>/operations-server`),
so from a long checkout path — e.g. any `.claude/worktrees/<name>` worktree — `listen`
fails with `EINVAL`. That throw happens inside `operationsServer`'s registration `try`, so
it takes down the **TCP** listener registration too: the whole operations API silently
disappears and every ops-API test fails with `ECONNREFUSED`, with no error surfaced by the
default test logging. That is why the failing test could not be run locally at all. Same
hazard applies to a real deployment with a long `rootPath`. Not fixed here — flagged for
triage.

Refs #773

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.8)