### PR TITLE
fix: TTL eviction/delete no longer orphans secondary-index entries (F-149)

### DIFF
--- a/integrationTests/database/eviction-index-null-reindex.test.ts
+++ b/integrationTests/database/eviction-index-null-reindex.test.ts
@@ -1,0 +1,140 @@
+/**
+ * harper#1894 (F-149) regression — TTL/expiration eviction must not orphan secondary-index entries.
+ *
+ * Removing a record (delete or the background TTL-eviction sweep) calls
+ * `updateIndices(id, existingRecord, null)` to clear that record's secondary-index entries. The bug:
+ * with `record === null`, `updateIndices` resolved the *new* indexed value to `null` rather than
+ * "absent", and for an `indexNulls` index — the DEFAULT for `@indexed` — it then RE-ADDED a
+ * `[null, id]` index entry immediately after removing the real `[value, id]` one. The result was a
+ * dangling index entry (raw key `null`, value = the id of a now-deleted record) for every evicted
+ * row: on RocksDB an `@indexed` TTL table left 100% of its rows dangling in the raw index.
+ *
+ * The classic search_by_value oracle can't observe this — it joins each index hit back through the
+ * primary record and drops the hit when the record is gone — so it reported "0 phantom" vacuously.
+ * This test reads the raw index DBI directly (RawIndex / PrimaryIds, no join) so a dangling entry is
+ * visible, and additionally asserts the legitimate indexNulls behavior the fix must preserve: a
+ * present record whose indexed attribute is genuinely `null` stays indexed under null.
+ *
+ * Scoped to RocksDB (where F-149 manifests and the raw-index-DBI oracle reads reliably through a
+ * resource; see the skipSuite note). LMDB eviction/index consistency is covered by the cross-engine
+ * eviction-secondary-index.test.ts, and the fix itself is engine-agnostic (shared updateIndices()).
+ */
+import { suite, test, before, after } from 'node:test';
+import { deepStrictEqual, strictEqual } from 'node:assert';
+import { resolve } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
+import { createApiClient } from './../apiTests/utils/client.mjs';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'eviction-index-null-reindex');
+const ENGINE = process.env.HARPER_STORAGE_ENGINE === 'lmdb' ? 'lmdb' : 'rocksdb';
+const EXPIRING_BUCKETS = ['E1', 'E2', 'E3'];
+const ROWS_PER_BUCKET = 40; // 120 expiring rows total — enough that the sweep runs several batches
+// The oracle reads the raw secondary-index DBI directly (t.indices[field].getRange()). That direct-DBI
+// read is reliable on RocksDB but not through a resource on LMDB (getRange on the LMDB index DBI does
+// not enumerate committed rows the same way — a harness limitation, not a Harper bug), and F-149 is a
+// RocksDB-manifested defect. LMDB eviction/index consistency is covered by the cross-engine
+// eviction-secondary-index.test.ts; the fix itself is engine-agnostic (shared updateIndices()).
+const skipSuite = process.platform === 'win32' || ENGINE === 'lmdb';
+
+suite(`F-149 eviction null-reindex vs secondary index [${ENGINE}]`, { skip: skipSuite }, (ctx: ContextWithHarper) => {
+	let client: ReturnType<typeof createApiClient>;
+	let httpURL: string;
+
+	before(async () => {
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+			config: { threads: { count: 1 }, logging: { console: true, level: 'error' } },
+			env: {},
+		});
+		client = createApiClient(ctx.harper);
+		httpURL = ctx.harper.httpURL;
+		const deadline = Date.now() + 120_000;
+		while (Date.now() < deadline) {
+			try {
+				const probe = await client.reqRest('/Expiring/').timeout(2000);
+				if (probe.status !== 404) break;
+			} catch {
+				/* not ready yet */
+			}
+			await sleep(250);
+		}
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	function postJSON(path: string, body: unknown): Promise<Response> {
+		return fetch(`${httpURL}${path}`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', 'Authorization': client.headers.Authorization },
+			body: JSON.stringify(body),
+		});
+	}
+	async function getJSON(path: string): Promise<any> {
+		const res = await fetch(`${httpURL}${path}`, { headers: { Authorization: client.headers.Authorization } });
+		return res.json();
+	}
+	const rawIndex = (table: string) => getJSON(`/RawIndex/?table=${table}`);
+	const primaryIds = (table: string) => getJSON(`/PrimaryIds/?table=${table}`);
+
+	test('TTL eviction removes both the base row and its raw secondary-index entry (no [null,id] orphan)', async () => {
+		for (const bucket of EXPIRING_BUCKETS) {
+			const res = await postJSON('/Load/', { table: 'Expiring', bucket, prefix: bucket, count: ROWS_PER_BUCKET });
+			strictEqual(res.status, 200, `seed Expiring/${bucket}`);
+		}
+		const total = EXPIRING_BUCKETS.length * ROWS_PER_BUCKET;
+
+		// Pre-expiry: every row present in both the base store and the raw index.
+		strictEqual((await primaryIds('Expiring')).ids.length, total, 'all expiring rows present pre-expiry (base)');
+		strictEqual((await rawIndex('Expiring')).count, total, 'all expiring rows present pre-expiry (raw index)');
+
+		// Let the TTL (12s) elapse and the periodic sweep (scanInterval 1s) run, with NO intervening reads
+		// (isolates the periodic-sweep path from on-read lazy eviction). Poll a bounded window for drain.
+		const deadline = Date.now() + 30_000;
+		let base = (await primaryIds('Expiring')).ids.length;
+		let idx = (await rawIndex('Expiring')).count;
+		while (Date.now() < deadline && (base > 0 || idx > 0)) {
+			await sleep(1_000);
+			base = (await primaryIds('Expiring')).ids.length;
+			idx = (await rawIndex('Expiring')).count;
+		}
+
+		const rawAfter = await rawIndex('Expiring');
+		strictEqual(base, 0, 'expiring base rows fully evicted');
+		// The regression: before the fix this was `total` (every row left a dangling [null,id] entry).
+		strictEqual(
+			rawAfter.count,
+			0,
+			`expiring raw index fully cleared — no dangling entries. Survivors: ${JSON.stringify(
+				rawAfter.entries.slice(0, 10)
+			)}`
+		);
+	});
+
+	test('indexNulls is preserved — a present record whose indexed attribute is null stays indexed under null', async () => {
+		// Permanent table: never expires. One row with a real bucket, one with a genuinely-null bucket.
+		strictEqual((await postJSON('/Load/', { table: 'Permanent', bucket: 'P1', prefix: 'P1', count: 5 })).status, 200);
+		strictEqual((await postJSON('/Load/', { table: 'Permanent', bucket: 'null', prefix: 'PN', count: 3 })).status, 200);
+
+		// Give any sweep a chance to (wrongly) touch these — they must all survive, fully indexed.
+		await sleep(4_000);
+
+		const base = (await primaryIds('Permanent')).ids;
+		strictEqual(base.length, 8, 'all permanent rows retained (base)');
+
+		const raw = await rawIndex('Permanent');
+		strictEqual(raw.count, 8, 'all permanent rows retained (raw index)');
+
+		// Every base id must appear exactly once in the raw index; the 3 null-bucket rows must be
+		// indexed under the null key (the legitimate indexNulls behavior the fix preserves).
+		const indexedIds = raw.entries.map((e: any) => e.value).sort();
+		deepStrictEqual(indexedIds, [...base].sort(), 'every permanent row is indexed exactly once');
+		const nullBucketIds = raw.entries
+			.filter((e: any) => e.key === null)
+			.map((e: any) => e.value)
+			.sort();
+		deepStrictEqual(nullBucketIds, ['PN-000000', 'PN-000001', 'PN-000002'], 'null-bucket rows indexed under null');
+	});
+});

--- a/integrationTests/database/eviction-index-null-reindex/config.yaml
+++ b/integrationTests/database/eviction-index-null-reindex/config.yaml
@@ -1,0 +1,5 @@
+graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/database/eviction-index-null-reindex/resources.js
+++ b/integrationTests/database/eviction-index-null-reindex/resources.js
@@ -1,0 +1,60 @@
+// harper#1894 (F-149) regression fixture. See schema.graphql for the bug description.
+//
+// Direct-store oracle: RawIndex / PrimaryIds read the raw secondary-index DBI and the raw primary
+// store via .getRange() with NO join back through the primary record, so a dangling [null|value, id]
+// index entry left behind by eviction is visible (the blind search_by_value oracle joins through the
+// gone record and so can never see it).
+
+function pad(n) {
+	return String(n).padStart(6, '0');
+}
+function getTable(name) {
+	const t = tables[name];
+	if (!t) throw new Error(`unknown table "${name}"`);
+	return t;
+}
+function qget(query, key) {
+	if (!query) return undefined;
+	return query.get ? query.get(key) : query[key];
+}
+
+// POST /Load/ { table, count, bucket } — bulk insert rows. `bucket` may be the string "null" to
+// exercise the legitimate indexNulls path (a present record whose indexed attribute is null).
+export class Load extends Resource {
+	static loadAsInstance = false;
+	async post(query, body) {
+		const b = body || query || {};
+		const t = getTable(b.table);
+		const n = Number(b.count) || 0;
+		const bucket = b.bucket === 'null' ? null : (b.bucket ?? 'B');
+		const prefix = b.prefix || b.bucket || 'B';
+		const ids = [];
+		for (let i = 0; i < n; i++) {
+			const id = `${prefix}-${pad(i)}`;
+			ids.push(id);
+			await t.put({ id, bucket, seq: i });
+		}
+		return { ok: true, count: n };
+	}
+}
+
+// GET /RawIndex/?table=X&field=bucket -> every raw {key,value} pair in the secondary index, no join.
+export class RawIndex extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const t = getTable(qget(query, 'table'));
+		const index = t.indices[qget(query, 'field') || 'bucket'];
+		const entries = [...index.getRange({ values: true, snapshot: false })].map(({ key, value }) => ({ key, value }));
+		return { count: entries.length, entries };
+	}
+}
+
+// GET /PrimaryIds/?table=X -> every raw id in the primary store, read directly (no expiresAt filter,
+// no join) so a base-count oracle can't race the async on-read lazy-eviction path.
+export class PrimaryIds extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const t = getTable(qget(query, 'table'));
+		return { ids: [...t.primaryStore.getRange({ snapshot: false, values: false })].map((entry) => entry.key) };
+	}
+}

--- a/integrationTests/database/eviction-index-null-reindex/schema.graphql
+++ b/integrationTests/database/eviction-index-null-reindex/schema.graphql
@@ -1,0 +1,26 @@
+# harper#1894 (F-149) regression — TTL eviction must not orphan secondary-index entries.
+#
+# Root cause: removing a record calls updateIndices(id, existingRecord, null). With record=null,
+# `updateIndices` used to resolve the new indexed value to `null` (rather than "absent"), and for an
+# `indexNulls` index (the DEFAULT for @indexed) it then RE-ADDED a [null, id] index entry right after
+# removing the real [value, id] one — leaving a dangling index entry with no backing record. The
+# blind search_by_value oracle can't see it (it joins index hits back through the now-gone primary
+# record), so this hid for a long time; a raw-index-DBI read exposes it.
+#
+# `bucket` is the @indexed attribute under test (indexNulls defaults to true). The TTL is set
+# generously (12s) relative to the sequential HTTP seeding so a slow runner cannot start evicting
+# the first rows before the pre-expiry assertion runs (the sweep fires every scanInterval).
+type Expiring @table(expiration: 12, scanInterval: 1) @export {
+	id: ID @primaryKey
+	bucket: String @indexed
+	seq: Int
+}
+
+# Control table with no expiration. Rows must survive the sweep AND stay indexed — including a row
+# whose `bucket` is genuinely null, which must remain indexed under null (the legitimate indexNulls
+# behavior the fix must preserve, distinct from the delete/evict re-index bug).
+type Permanent @table @export {
+	id: ID @primaryKey
+	bucket: String @indexed
+	seq: Int
+}

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -4780,7 +4780,14 @@ export function makeTable(options) {
 			const index = indices[key];
 			const isIndexing = index.isIndexing;
 			const resolver = propertyResolvers[key];
-			const value = record && (resolver ? resolver(record) : record[key]);
+			// A null/undefined `record` means the record is being removed entirely (delete/eviction pass
+			// record=null), so there are NO values to index — resolve to undefined, not null. `record &&`
+			// yields `null` for record===null, which getIndexedValues() then treats as a genuine null field
+			// value and (for an indexNulls index — the default for @indexed) re-adds a [null, id] entry after
+			// the real [value, id] entry was removed, orphaning it against the now-deleted record. A record
+			// that is present but whose attribute is null is a different case (record is a truthy object) and
+			// still indexes under null. See harper#1894 (F-149).
+			const value = record == null ? undefined : resolver ? resolver(record) : record[key];
 			const existingValue = existingRecord && (resolver ? resolver(existingRecord) : existingRecord[key]);
 			if (value === existingValue && !isIndexing) {
 				continue;


### PR DESCRIPTION
Resolves #1894.

## Problem
Record removal — the background TTL/expiration eviction sweep **and** plain deletes — calls `updateIndices(id, existingRecord, null)` to clear that record's secondary-index entries. With `record === null`, the line `const value = record && (...)` resolved the *new* indexed value to `null` rather than "absent". Because `indexNulls` **defaults to `true`** for every `@indexed` attribute, `getIndexedValues(null, indexNulls)` returns `[null]`, so `updateIndices` removed the real `[value, id]` index entry and then immediately **re-added a `[null, id]` entry** — a dangling index entry (raw key `null`, value = the id of a now-deleted record).

On RocksDB an `@indexed` TTL table left **100% of evicted rows** dangling in the raw index (unbounded index bloat / phantom hits under a null-valued query). The classic `search_by_value` oracle can't observe it — it joins each index hit back through the primary record and drops the hit when the record is gone — which is why "phantom=0" read as clean for so long.

> **Note on the root cause vs the issue's trace.** The issue (F-149) traced this to the eviction batcher's transaction being bound to `primaryStore.store`. That trace is **incorrect** — normal deletes use the same `primaryStore.store`-bound raw transaction and persist fine, and the leak reproduces on the per-record `evict()` path too, single- *and* multi-worker. It's engine-agnostic, in shared `updateIndices()`, and — because `updateIndices` is shared — it also affects **plain deletes**, not just eviction.

## Fix
A removed record has no values to index, so resolve `value` to `undefined` (not `null`) when `record == null` → nothing is re-added after the real entry is removed. A record that is *present* but whose attribute is genuinely `null` is a different case (`record` is a truthy object) and still indexes under `null`, so the `indexNulls` feature is preserved.

```diff
-			const value = record && (resolver ? resolver(record) : record[key]);
+			const value = record == null ? undefined : resolver ? resolver(record) : record[key];
```

## Test
Adds `integrationTests/database/eviction-index-null-reindex.test.ts` (RocksDB) with a **direct raw-index-DBI oracle** — reads `t.indices[field].getRange()` with no join, so the `[null, id]` orphan is visible — plus a guard that a present record with a genuinely-null field stays indexed under `null`. Fails without the fix, passes with it.

## Verification
- P-398 (plain `@indexed`) and P-399 (FK-target) reproducers: index fully cleared, 0 dangling (was 750 / 241).
- Green: `eviction-secondary-index`, `indexed-update-churn`, `compound-index-conditions`, `delete-update-race`, `indexed-numeric-range`, `bigint-indexed-range`, vector-index (unit + integration), `longtxn-secondary-index`; LMDB `eviction` path unaffected.

## Cross-model review
Codex + Gemini + Harper domain pass. Core fix confirmed correct across all `updateIndices` callers and the HNSW custom-index path. One Gemini "blocker" on the adjacent `existingValue` line was **refuted** — that line's `null` result for a null `existingRecord` is intentional asymmetry (it's what makes removal clean up the `[null,id]` entry), it's unchanged by this PR, and the described skip never triggers on the real insert path. Test-file lint/format/flake findings were addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)