### PR TITLE
Implement get_deployment_payload and delete_deployment_payload operations

### DIFF
--- a/components/deploymentOperations.ts
+++ b/components/deploymentOperations.ts
@@ -6,9 +6,11 @@
 import { Readable } from 'node:stream';
 import { databases } from '../resources/databases.ts';
 import * as terms from '../utility/hdbTerms.ts';
-import { ClientError } from '../utility/errors/hdbError.ts';
+import { ClientError, hdbErrors } from '../utility/errors/hdbError.ts';
 import { getActiveEmitter } from './deploymentRecorder.ts';
 import type { ProgressEmitter } from '../server/serverHelpers/progressEmitter.ts';
+
+const { HTTP_STATUS_CODES } = hdbErrors;
 
 const DEPLOYMENT_TABLE = terms.SYSTEM_TABLE_NAMES.DEPLOYMENT_TABLE_NAME;
 const TERMINAL_STATUSES = new Set(['success', 'failed', 'rolled_back']);
@@ -30,7 +32,16 @@ interface GetRequest {
 
 interface PayloadRequest {
 	deployment_id: string;
-	hdb_user?: { username?: string };
+	hdb_user?: { username?: string; role?: { permission?: { super_user?: boolean } } };
+}
+
+function requireSuperUser(req: PayloadRequest, operationName: string): void {
+	if (!req?.hdb_user?.role?.permission?.super_user) {
+		throw new ClientError(
+			`Operation '${operationName}' is restricted to super_user roles`,
+			HTTP_STATUS_CODES.FORBIDDEN
+		);
+	}
 }
 
 function deploymentTable() {
@@ -195,8 +206,15 @@ async function requireDeploymentRow(deploymentId: unknown): Promise<any> {
  * can be hundreds of MB and a base64 round-trip materializes multi-hundred-MB strings (V8's
  * string cap is ~512MiB, so large payloads would hard-fail with ERR_STRING_TOO_LONG).
  * serverHandlers.js pipes any returned Readable that carries a `headers` Map.
+ *
+ * Unlike the other deployment ops, this ALSO enforces super_user directly (matching the
+ * secrets-store ops) rather than relying only on the registered permission, so it cannot be
+ * delegated to a non-SU role via a role's `operations` allowlist (operation_authorization.ts
+ * gate-2). The full tarball can embed secrets — `get_deployment`/`list_deployments` only ever
+ * expose stripped metadata, so this is the one deployment op with that exposure.
  */
 export async function handleGetDeploymentPayload(req: PayloadRequest): Promise<Readable> {
+	requireSuperUser(req, 'get_deployment_payload');
 	const row = await requireDeploymentRow(req?.deployment_id);
 	if (row.payload_blob == null) {
 		throw new ClientError(

--- a/components/deploymentOperations.ts
+++ b/components/deploymentOperations.ts
@@ -1,8 +1,9 @@
 'use strict';
 
-// Read-side operations against system.hdb_deployment.
-// Write-side lives in deploymentRecorder.ts; this module only reads.
+// Operations against system.hdb_deployment: reads (list/get/payload download) plus the
+// one targeted write, delete_deployment_payload. Deploy-time writes live in deploymentRecorder.ts.
 
+import { Readable } from 'node:stream';
 import { databases } from '../resources/databases.ts';
 import * as terms from '../utility/hdbTerms.ts';
 import { ClientError } from '../utility/errors/hdbError.ts';
@@ -25,6 +26,11 @@ interface GetRequest {
 	deployment_id: string;
 	// Set by serverHandlers.js when the client asks for `Accept: text/event-stream`.
 	progress?: ProgressEmitter;
+}
+
+interface PayloadRequest {
+	deployment_id: string;
+	hdb_user?: { username?: string };
 }
 
 function deploymentTable() {
@@ -170,4 +176,90 @@ export async function handleGetDeployment(req: GetRequest): Promise<any> {
 	}
 
 	return stripBlob(row);
+}
+
+async function requireDeploymentRow(deploymentId: unknown): Promise<any> {
+	if (typeof deploymentId !== 'string' || !deploymentId) {
+		throw new ClientError(`'deployment_id' is required`);
+	}
+	const table = deploymentTable();
+	const row = await table.get(deploymentId);
+	if (!row) {
+		throw new ClientError(`No deployment found with id '${deploymentId}'`, 404);
+	}
+	return row;
+}
+
+/**
+ * Stream the stored payload tarball back to the caller as raw bytes. Never base64 — payloads
+ * can be hundreds of MB and a base64 round-trip materializes multi-hundred-MB strings (V8's
+ * string cap is ~512MiB, so large payloads would hard-fail with ERR_STRING_TOO_LONG).
+ * serverHandlers.js pipes any returned Readable that carries a `headers` Map.
+ */
+export async function handleGetDeploymentPayload(req: PayloadRequest): Promise<Readable> {
+	const row = await requireDeploymentRow(req?.deployment_id);
+	if (row.payload_blob == null) {
+		throw new ClientError(
+			`No payload is stored for deployment '${req.deployment_id}' (it may have been reclaimed by ` +
+				`payload retention or delete_deployment_payload)`,
+			404
+		);
+	}
+	// Blob.stream() blocks on incomplete chunk writes, so serving a still-replicating row is
+	// safe — the response streams as the bytes land.
+	const stream = Readable.fromWeb(row.payload_blob.stream() as any);
+	const headers = new Map<string, string>();
+	headers.set('content-type', 'application/octet-stream');
+	// Sourced from the stored row, not the request, so header content is never client-chosen.
+	headers.set('content-disposition', `attachment; filename="deployment-${row.deployment_id}.tar.gz"`);
+	(stream as any).headers = headers;
+	// The payload is already a gzipped tar; tell serverHandlers not to recompress it.
+	(stream as any).preCompressed = true;
+	return stream;
+}
+
+/**
+ * Drop a deployment's stored payload tarball, retaining the row (metadata, event_log) as the
+ * audit trail. Committing the row with payload_blob nulled unlinks the blob file locally via
+ * RecordEncoder's retained-blob check AND replicates the null so peers drop their copies too —
+ * one call reclaims the space cluster-wide (same mechanism as the automatic post-deploy
+ * retention drop in operations.js).
+ */
+export async function handleDeleteDeploymentPayload(
+	req: PayloadRequest
+): Promise<{ message: string; deployment_id: string; freed_bytes: number }> {
+	const row = await requireDeploymentRow(req?.deployment_id);
+	if (!TERMINAL_STATUSES.has(row.status)) {
+		// A non-terminal deployment's blob may still be the replication channel peers are
+		// installing from; yanking it mid-flight would wedge them.
+		throw new ClientError(
+			`Deployment '${req.deployment_id}' is not in a terminal state (status '${row.status}'); ` +
+				`its payload may still be in use. Wait for the deployment to finish before deleting the payload.`,
+			409
+		);
+	}
+	if (row.payload_blob == null) {
+		// Idempotent: deleting an already-reclaimed payload succeeds without a write.
+		return {
+			message: `No payload stored for deployment '${req.deployment_id}'`,
+			deployment_id: req.deployment_id,
+			freed_bytes: 0,
+		};
+	}
+	const freedBytes = typeof row.payload_size === 'number' ? row.payload_size : 0;
+	// Copy before mutating — the row from get() may be a shared/cached record.
+	const updated: any = { ...row, payload_blob: null };
+	updated.event_log = Array.isArray(row.event_log) ? [...row.event_log] : [];
+	// Mirror the recorder's event_log entry shape and the automatic drop's event name.
+	updated.event_log.push({
+		t: Date.now(),
+		event: 'payload_dropped',
+		data: { payload_size: freedBytes, deleted_by: req.hdb_user?.username ?? null },
+	});
+	await deploymentTable().put(updated);
+	return {
+		message: `Deleted payload for deployment '${req.deployment_id}'`,
+		deployment_id: req.deployment_id,
+		freed_bytes: freedBytes,
+	};
 }

--- a/components/mcp/tools/operations.ts
+++ b/components/mcp/tools/operations.ts
@@ -180,6 +180,21 @@ const DESTRUCTIVE_OPERATIONS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Operations whose handler returns a raw byte stream (`Readable`) for the operations HTTP API,
+ * not a value MCP can serialize. Checked and rejected BEFORE the handler runs — not after the
+ * handler has already returned a stream — because these producers acquire real resources (an
+ * open fd, an LMDB read transaction) before or independent of the stream being consumed, and
+ * destroying an unconsumed stream does not reliably run their cleanup. Concretely,
+ * `get_backup`'s LMDB path (`lmdbGetBackup.js`) opens its fd and read transaction, then returns
+ * `Readable.from(asyncGenerator)`; per the async-generator spec, calling `.return()` (which
+ * `.destroy()` triggers) on a generator that has never been iterated resolves it to `done` and
+ * skips its body — including the `readTxn.done()` cleanup at the tail of that body — so the fd
+ * and transaction leak on every rejected call. Rejecting before dispatch means the fd/txn are
+ * never opened at all.
+ */
+const STREAMING_OPERATIONS: ReadonlySet<string> = new Set(['get_backup', 'get_deployment_payload']);
+
+/**
  * Read-only operations carry `readOnlyHint: true`. The category is wider
  * than the default allow list (some custom-allowed ops are also read-only
  * — `system_information`, for example). Any op matching one of these
@@ -285,6 +300,19 @@ export function makeOperationToolHandler(operationName: string) {
 			operation: operationName,
 			hdb_user: context.user,
 		};
+		if (STREAMING_OPERATIONS.has(operationName)) {
+			// Reject before the handler runs at all — see STREAMING_OPERATIONS' comment for why
+			// destroying an already-returned stream isn't sufficient cleanup for these producers.
+			return {
+				isError: true,
+				content: [
+					{
+						type: 'text',
+						text: `operation '${operationName}' returns a byte stream and is only available over the operations HTTP API`,
+					},
+				],
+			};
+		}
 		try {
 			const chooseOperation = getChooseOperation();
 			const processLocalTransaction = getProcessLocalTransaction();
@@ -294,16 +322,17 @@ export function makeOperationToolHandler(operationName: string) {
 			const operationFn = chooseOperation(body);
 			const data = await processLocalTransaction({ body }, operationFn);
 			if (data instanceof Readable) {
-				// Streaming ops (get_backup, get_deployment_payload) return raw bytes for the HTTP
-				// surface; JSON.stringify would emit stream internals, not the payload. Destroy the
-				// source so file-backed streams release their descriptors.
+				// Backstop for an operation outside STREAMING_OPERATIONS unexpectedly returning a
+				// stream (e.g. a future op added without updating that set). JSON.stringify would
+				// otherwise emit stream internals, not the payload. Best-effort cleanup only — see
+				// STREAMING_OPERATIONS' comment; the real fix for a known op is adding it there.
 				data.destroy();
 				return {
 					isError: true,
 					content: [
 						{
 							type: 'text',
-							text: `operation '${operationName}' returns a byte stream and is only available over the operations HTTP API`,
+							text: `operation '${operationName}' returned an unexpected byte stream result`,
 						},
 					],
 				};

--- a/components/mcp/tools/operations.ts
+++ b/components/mcp/tools/operations.ts
@@ -33,6 +33,7 @@
  * server-side validation errors surface as `isError: true` results without
  * the MCP layer needing to know what each operation expects.
  */
+import { Readable } from 'node:stream';
 import * as env from '../../../utility/environment/environmentManager.ts';
 import { CONFIG_PARAMS } from '../../../utility/hdbTerms.ts';
 import harperLogger from '../../../utility/logging/harper_logger.ts';
@@ -175,6 +176,7 @@ const DESTRUCTIVE_OPERATIONS: ReadonlySet<string> = new Set([
 	'restart_service',
 	'set_configuration',
 	'remove_node',
+	'delete_deployment_payload',
 ]);
 
 /**
@@ -291,6 +293,21 @@ export function makeOperationToolHandler(operationName: string) {
 			}
 			const operationFn = chooseOperation(body);
 			const data = await processLocalTransaction({ body }, operationFn);
+			if (data instanceof Readable) {
+				// Streaming ops (get_backup, get_deployment_payload) return raw bytes for the HTTP
+				// surface; JSON.stringify would emit stream internals, not the payload. Destroy the
+				// source so file-backed streams release their descriptors.
+				data.destroy();
+				return {
+					isError: true,
+					content: [
+						{
+							type: 'text',
+							text: `operation '${operationName}' returns a byte stream and is only available over the operations HTTP API`,
+						},
+					],
+				};
+			}
 			const text = typeof data === 'string' ? data : JSON.stringify(data ?? null);
 			const result: ToolResult = {
 				content: [{ type: 'text', text }],

--- a/server/serverHelpers/serverHandlers.js
+++ b/server/serverHelpers/serverHandlers.js
@@ -174,10 +174,18 @@ async function handlePostRequest(req, res, _bypassAuth = false) {
 				res.header(name, value);
 			}
 			// fastify-compress has one job. I don't know why it can't do it. So we compress here to
-			// handle the case of returning a stream
-			if (req.headers['accept-encoding']?.includes('gzip')) {
+			// handle the case of returning a stream. Streams marked preCompressed (e.g. a stored
+			// .tar.gz payload) are passed through as-is — recompressing them wastes CPU for zero gain.
+			if (!result.preCompressed && req.headers['accept-encoding']?.includes('gzip')) {
 				res.header('content-encoding', 'gzip');
-				result = result.pipe(createGzip({ level: constants.Z_BEST_SPEED })); // go fast
+				const gzip = createGzip({ level: constants.Z_BEST_SPEED }); // go fast
+				// .pipe() does not forward source errors; without this an async read error on the
+				// source (e.g. get_backup's file stream) fires 'error' with no listener and takes
+				// the whole worker down via uncaughtException. Destroying the gzip stream propagates
+				// the error to Fastify, which aborts just this response. (preCompressed streams skip
+				// this block and get Fastify's own error handling on the raw stream.)
+				result.on('error', (error) => gzip.destroy(error));
+				result = result.pipe(gzip);
 			}
 		}
 		return result;

--- a/server/serverHelpers/serverHandlers.js
+++ b/server/serverHelpers/serverHandlers.js
@@ -179,13 +179,19 @@ async function handlePostRequest(req, res, _bypassAuth = false) {
 			if (!result.preCompressed && req.headers['accept-encoding']?.includes('gzip')) {
 				res.header('content-encoding', 'gzip');
 				const gzip = createGzip({ level: constants.Z_BEST_SPEED }); // go fast
-				// .pipe() does not forward source errors; without this an async read error on the
-				// source (e.g. get_backup's file stream) fires 'error' with no listener and takes
-				// the whole worker down via uncaughtException. Destroying the gzip stream propagates
-				// the error to Fastify, which aborts just this response. (preCompressed streams skip
-				// this block and get Fastify's own error handling on the raw stream.)
-				result.on('error', (error) => gzip.destroy(error));
-				result = result.pipe(gzip);
+				// .pipe() does not tear down across the pipe in either direction, so wire both:
+				// - source error → destroy gzip: an async read error on the source (e.g. get_backup's
+				//   file stream) would otherwise fire 'error' with no listener and take the whole
+				//   worker down via uncaughtException; destroying the gzip stream propagates the
+				//   error to Fastify, which aborts just this response.
+				// - gzip close → destroy source: when the client disconnects mid-download Fastify
+				//   destroys only the stream it was handed (gzip); destroy the source too so its
+				//   underlying file/blob read stops and descriptors release. (No-op after a normal
+				//   end. preCompressed streams skip this block; Fastify handles them directly.)
+				const source = result;
+				source.on('error', (error) => gzip.destroy(error));
+				gzip.on('close', () => source.destroy());
+				result = source.pipe(gzip);
 			}
 		}
 		return result;

--- a/server/serverHelpers/serverUtilities.ts
+++ b/server/serverHelpers/serverUtilities.ts
@@ -554,6 +554,14 @@ function initializeOperationFunctionMap(): Map<OperationFunctionName, OperationF
 		terms.OPERATIONS_ENUM.GET_DEPLOYMENT,
 		new OperationFunctionObject(deploymentOperations.handleGetDeployment)
 	);
+	opFuncMap.set(
+		terms.OPERATIONS_ENUM.GET_DEPLOYMENT_PAYLOAD,
+		new OperationFunctionObject(deploymentOperations.handleGetDeploymentPayload)
+	);
+	opFuncMap.set(
+		terms.OPERATIONS_ENUM.DELETE_DEPLOYMENT_PAYLOAD,
+		new OperationFunctionObject(deploymentOperations.handleDeleteDeploymentPayload)
+	);
 	opFuncMap.set(terms.OPERATIONS_ENUM.SET_SECRET, new OperationFunctionObject(secretOperations.setSecret));
 	opFuncMap.set(terms.OPERATIONS_ENUM.GRANT_SECRET, new OperationFunctionObject(secretOperations.grantSecret));
 	opFuncMap.set(terms.OPERATIONS_ENUM.REVOKE_SECRET, new OperationFunctionObject(secretOperations.revokeSecret));

--- a/unitTests/components/deploymentOperations.test.js
+++ b/unitTests/components/deploymentOperations.test.js
@@ -19,6 +19,8 @@ const { databases } = require('#src/resources/databases');
 const terms = require('#src/utility/hdbTerms');
 
 const DEPLOYMENT_TABLE = terms.SYSTEM_TABLE_NAMES.DEPLOYMENT_TABLE_NAME;
+const SUPER_USER = { username: 'admin', role: { permission: { super_user: true } } };
+const NON_SUPER_USER = { username: 'operator', role: { permission: { super_user: false } } };
 
 function installMockDeploymentTable() {
 	const rows = new Map();
@@ -69,12 +71,29 @@ describe('handleGetDeploymentPayload', () => {
 	});
 	afterEach(() => installed.restore());
 
-	it('rejects a missing deployment_id', async () => {
-		await assert.rejects(handleGetDeploymentPayload({}), /'deployment_id' is required/);
+	it('rejects a caller with no hdb_user as forbidden, before any deployment lookup', async () => {
+		await assert.rejects(handleGetDeploymentPayload({ deployment_id: 'd1' }), (err) => {
+			assert.match(err.message, /restricted to super_user/);
+			assert.strictEqual(err.statusCode, 403);
+			return true;
+		});
+	});
+
+	it('rejects a non-super_user role as forbidden — cannot be delegated via a role grant', async () => {
+		installed.mock.rows.set('d1', { deployment_id: 'd1', status: 'success', payload_blob: mockBlob(Buffer.from('x')) });
+		await assert.rejects(handleGetDeploymentPayload({ deployment_id: 'd1', hdb_user: NON_SUPER_USER }), (err) => {
+			assert.match(err.message, /restricted to super_user/);
+			assert.strictEqual(err.statusCode, 403);
+			return true;
+		});
+	});
+
+	it('rejects a missing deployment_id (for a super_user caller)', async () => {
+		await assert.rejects(handleGetDeploymentPayload({ hdb_user: SUPER_USER }), /'deployment_id' is required/);
 	});
 
 	it('404s on an unknown deployment_id', async () => {
-		await assert.rejects(handleGetDeploymentPayload({ deployment_id: 'nope' }), (err) => {
+		await assert.rejects(handleGetDeploymentPayload({ deployment_id: 'nope', hdb_user: SUPER_USER }), (err) => {
 			assert.match(err.message, /No deployment found/);
 			assert.strictEqual(err.statusCode, 404);
 			return true;
@@ -83,7 +102,7 @@ describe('handleGetDeploymentPayload', () => {
 
 	it('404s when the payload has been reclaimed', async () => {
 		installed.mock.rows.set('d1', { deployment_id: 'd1', status: 'success', payload_blob: null });
-		await assert.rejects(handleGetDeploymentPayload({ deployment_id: 'd1' }), (err) => {
+		await assert.rejects(handleGetDeploymentPayload({ deployment_id: 'd1', hdb_user: SUPER_USER }), (err) => {
 			assert.match(err.message, /No payload is stored/);
 			assert.strictEqual(err.statusCode, 404);
 			return true;
@@ -93,7 +112,7 @@ describe('handleGetDeploymentPayload', () => {
 	it('streams the raw payload bytes with download headers', async () => {
 		const bytes = Buffer.from('tarball-bytes-here');
 		installed.mock.rows.set('d1', { deployment_id: 'd1', status: 'success', payload_blob: mockBlob(bytes) });
-		const stream = await handleGetDeploymentPayload({ deployment_id: 'd1' });
+		const stream = await handleGetDeploymentPayload({ deployment_id: 'd1', hdb_user: SUPER_USER });
 		assert.ok(stream instanceof Readable, 'must be a Node Readable so serverHandlers pipes it');
 		assert.strictEqual(stream.headers.get('content-type'), 'application/octet-stream');
 		assert.match(stream.headers.get('content-disposition'), /deployment-d1\.tar\.gz/);

--- a/unitTests/components/deploymentOperations.test.js
+++ b/unitTests/components/deploymentOperations.test.js
@@ -1,0 +1,171 @@
+'use strict';
+
+// Unit tests for the payload operations in deploymentOperations:
+//   - `handleGetDeploymentPayload()` — streams the stored tarball as raw bytes with
+//     download headers attached (never base64; see the handler's V8 string-cap note).
+//   - `handleDeleteDeploymentPayload()` — nulls payload_blob on a terminal row to reclaim
+//     storage cluster-wide, retaining the row metadata + event_log as the audit trail.
+//
+// The table layer is a tiny Map-backed mock on `databases.system`, mirroring
+// deploymentRecorder.test.js.
+
+const assert = require('node:assert');
+const { Readable } = require('node:stream');
+const testUtils = require('../testUtils.js');
+testUtils.preTestPrep();
+
+const { handleGetDeploymentPayload, handleDeleteDeploymentPayload } = require('#src/components/deploymentOperations');
+const { databases } = require('#src/resources/databases');
+const terms = require('#src/utility/hdbTerms');
+
+const DEPLOYMENT_TABLE = terms.SYSTEM_TABLE_NAMES.DEPLOYMENT_TABLE_NAME;
+
+function installMockDeploymentTable() {
+	const rows = new Map();
+	const puts = [];
+	const mock = {
+		rows,
+		puts,
+		async get(id) {
+			return rows.get(id);
+		},
+		async put(row) {
+			puts.push(row);
+			rows.set(row.deployment_id, row);
+		},
+	};
+	if (!databases.system) databases.system = {};
+	const prior = databases.system[DEPLOYMENT_TABLE];
+	databases.system[DEPLOYMENT_TABLE] = mock;
+	return {
+		mock,
+		restore() {
+			databases.system[DEPLOYMENT_TABLE] = prior;
+		},
+	};
+}
+
+// Minimal stand-in for a stored Blob: stream() yields the bytes as a web ReadableStream,
+// matching resources/blob.ts's stream() signature.
+function mockBlob(bytes) {
+	return {
+		size: bytes.length,
+		stream() {
+			return Readable.toWeb(Readable.from([bytes]));
+		},
+	};
+}
+
+async function collect(stream) {
+	const chunks = [];
+	for await (const chunk of stream) chunks.push(chunk);
+	return Buffer.concat(chunks);
+}
+
+describe('handleGetDeploymentPayload', () => {
+	let installed;
+	beforeEach(() => {
+		installed = installMockDeploymentTable();
+	});
+	afterEach(() => installed.restore());
+
+	it('rejects a missing deployment_id', async () => {
+		await assert.rejects(handleGetDeploymentPayload({}), /'deployment_id' is required/);
+	});
+
+	it('404s on an unknown deployment_id', async () => {
+		await assert.rejects(handleGetDeploymentPayload({ deployment_id: 'nope' }), (err) => {
+			assert.match(err.message, /No deployment found/);
+			assert.strictEqual(err.statusCode, 404);
+			return true;
+		});
+	});
+
+	it('404s when the payload has been reclaimed', async () => {
+		installed.mock.rows.set('d1', { deployment_id: 'd1', status: 'success', payload_blob: null });
+		await assert.rejects(handleGetDeploymentPayload({ deployment_id: 'd1' }), (err) => {
+			assert.match(err.message, /No payload is stored/);
+			assert.strictEqual(err.statusCode, 404);
+			return true;
+		});
+	});
+
+	it('streams the raw payload bytes with download headers', async () => {
+		const bytes = Buffer.from('tarball-bytes-here');
+		installed.mock.rows.set('d1', { deployment_id: 'd1', status: 'success', payload_blob: mockBlob(bytes) });
+		const stream = await handleGetDeploymentPayload({ deployment_id: 'd1' });
+		assert.ok(stream instanceof Readable, 'must be a Node Readable so serverHandlers pipes it');
+		assert.strictEqual(stream.headers.get('content-type'), 'application/octet-stream');
+		assert.match(stream.headers.get('content-disposition'), /deployment-d1\.tar\.gz/);
+		assert.deepStrictEqual(await collect(stream), bytes);
+	});
+});
+
+describe('handleDeleteDeploymentPayload', () => {
+	let installed;
+	beforeEach(() => {
+		installed = installMockDeploymentTable();
+	});
+	afterEach(() => installed.restore());
+
+	it('rejects a missing deployment_id', async () => {
+		await assert.rejects(handleDeleteDeploymentPayload({}), /'deployment_id' is required/);
+	});
+
+	it('404s on an unknown deployment_id', async () => {
+		await assert.rejects(handleDeleteDeploymentPayload({ deployment_id: 'nope' }), (err) => {
+			assert.strictEqual(err.statusCode, 404);
+			return true;
+		});
+	});
+
+	it('409s on a non-terminal deployment (blob may still be replicating to peers)', async () => {
+		installed.mock.rows.set('d1', { deployment_id: 'd1', status: 'pending', payload_blob: mockBlob(Buffer.from('x')) });
+		await assert.rejects(handleDeleteDeploymentPayload({ deployment_id: 'd1' }), (err) => {
+			assert.match(err.message, /not in a terminal state/);
+			assert.strictEqual(err.statusCode, 409);
+			return true;
+		});
+		assert.strictEqual(installed.mock.puts.length, 0, 'must not write the row');
+	});
+
+	it('nulls the blob, retains metadata, and appends an audit event', async () => {
+		const original = {
+			deployment_id: 'd1',
+			project: 'my-app',
+			status: 'success',
+			payload_blob: mockBlob(Buffer.from('x')),
+			payload_size: 12345,
+			payload_hash: 'abc',
+			event_log: [{ t: 1, event: 'phase', data: { phase: 'success' } }],
+		};
+		installed.mock.rows.set('d1', original);
+		const result = await handleDeleteDeploymentPayload({
+			deployment_id: 'd1',
+			hdb_user: { username: 'admin' },
+		});
+		assert.strictEqual(result.freed_bytes, 12345);
+		assert.strictEqual(result.deployment_id, 'd1');
+
+		const written = installed.mock.puts[0];
+		assert.strictEqual(written.payload_blob, null);
+		assert.strictEqual(written.payload_size, 12345, 'metadata is retained');
+		assert.strictEqual(written.payload_hash, 'abc');
+		const dropEvent = written.event_log.at(-1);
+		assert.strictEqual(dropEvent.event, 'payload_dropped');
+		assert.deepStrictEqual(dropEvent.data, { payload_size: 12345, deleted_by: 'admin' });
+
+		// The fetched row object must not be mutated in place (it may be a shared/cached record).
+		assert.notStrictEqual(written, original);
+		assert.ok(original.payload_blob, 'original row untouched');
+		assert.strictEqual(original.event_log.length, 1);
+	});
+
+	it('is idempotent when the payload is already gone', async () => {
+		installed.mock.rows.set('d1', { deployment_id: 'd1', status: 'failed', payload_blob: null });
+		const result = await handleDeleteDeploymentPayload({ deployment_id: 'd1' });
+		assert.strictEqual(result.freed_bytes, 0);
+		assert.match(result.message, /No payload stored/);
+		assert.strictEqual(installed.mock.puts.length, 0, 'no write on the idempotent path');
+	});
+});

--- a/unitTests/components/mcp/tools/operations.test.js
+++ b/unitTests/components/mcp/tools/operations.test.js
@@ -513,23 +513,50 @@ describe('mcp/tools/operations — handler dispatch', () => {
 		assert.deepEqual(res.structuredContent, { message: 'success' });
 	});
 
-	it('rejects streaming (Readable) results with isError and destroys the stream', async () => {
-		// get_deployment_payload / get_backup return raw byte streams for the HTTP surface;
-		// over MCP they must fail cleanly instead of JSON.stringify-ing stream internals.
-		const stream = Readable.from([Buffer.from('tarball-bytes')]);
-		_setChooseOperationForTest(() => async () => stream);
+	it('rejects known streaming operations (get_deployment_payload) before ever dispatching them', async () => {
+		// get_backup's LMDB path opens an fd + read transaction before its Readable is even
+		// returned, and destroying that stream unread does not run its cleanup (calling
+		// .return() on a never-started async generator skips its body, including
+		// readTxn.done()). So the fix is to never call the handler for a known streaming op,
+		// not to destroy its result after the fact. Assert chooseOperation is never invoked.
+		let chosen = false;
+		_setChooseOperationForTest(() => {
+			chosen = true;
+			return async () => Readable.from([Buffer.from('tarball-bytes')]);
+		});
 		_setProcessLocalTransactionForTest(async (_req, fn) => await fn({}));
-		envOverrides.mcp_operations_allow = ['get_deployment_payload'];
-		_setOperationFunctionMapForTest(makeOpMap([['get_deployment_payload', null]]));
+		envOverrides.mcp_operations_allow = ['get_deployment_payload', 'get_backup'];
+		_setOperationFunctionMapForTest(
+			makeOpMap([
+				['get_deployment_payload', null],
+				['get_backup', null],
+			])
+		);
 		registerOperationsTools();
 
-		const res = await getTool('get_deployment_payload').handler(
-			{},
-			{ user: SUPER, profile: 'operations', sessionId: 's' }
-		);
+		for (const opName of ['get_deployment_payload', 'get_backup']) {
+			chosen = false;
+			const res = await getTool(opName).handler({}, { user: SUPER, profile: 'operations', sessionId: 's' });
+			assert.equal(res.isError, true);
+			assert.match(res.content[0].text, /byte stream/);
+			assert.equal(chosen, false, `${opName} must not reach chooseOperation/the handler`);
+		}
+	});
+
+	it('backstops an unlisted operation that unexpectedly returns a stream, and destroys it', async () => {
+		// Defense in depth for an op outside STREAMING_OPERATIONS (e.g. added without updating
+		// that set) — best-effort cleanup via destroy(), distinct message from the pre-dispatch
+		// rejection above.
+		const stream = Readable.from([Buffer.from('unexpected-bytes')]);
+		_setChooseOperationForTest(() => async () => stream);
+		_setProcessLocalTransactionForTest(async (_req, fn) => await fn({}));
+		_setOperationFunctionMapForTest(makeOpMap([['describe_all', null]]));
+		registerOperationsTools();
+
+		const res = await getTool('describe_all').handler({}, { user: SUPER, profile: 'operations', sessionId: 's' });
 
 		assert.equal(res.isError, true);
-		assert.match(res.content[0].text, /byte stream/);
-		assert.equal(stream.destroyed, true, 'stream must be destroyed so file-backed sources release fds');
+		assert.match(res.content[0].text, /unexpected byte stream/);
+		assert.equal(stream.destroyed, true, 'backstop must still destroy an unconsumed stream');
 	});
 });

--- a/unitTests/components/mcp/tools/operations.test.js
+++ b/unitTests/components/mcp/tools/operations.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert');
+const { Readable } = require('node:stream');
 const {
 	registerOperationsTools,
 	DEFAULT_ALLOW,
@@ -510,5 +511,25 @@ describe('mcp/tools/operations — handler dispatch', () => {
 
 		assert.equal(res.isError, undefined);
 		assert.deepEqual(res.structuredContent, { message: 'success' });
+	});
+
+	it('rejects streaming (Readable) results with isError and destroys the stream', async () => {
+		// get_deployment_payload / get_backup return raw byte streams for the HTTP surface;
+		// over MCP they must fail cleanly instead of JSON.stringify-ing stream internals.
+		const stream = Readable.from([Buffer.from('tarball-bytes')]);
+		_setChooseOperationForTest(() => async () => stream);
+		_setProcessLocalTransactionForTest(async (_req, fn) => await fn({}));
+		envOverrides.mcp_operations_allow = ['get_deployment_payload'];
+		_setOperationFunctionMapForTest(makeOpMap([['get_deployment_payload', null]]));
+		registerOperationsTools();
+
+		const res = await getTool('get_deployment_payload').handler(
+			{},
+			{ user: SUPER, profile: 'operations', sessionId: 's' }
+		);
+
+		assert.equal(res.isError, true);
+		assert.match(res.content[0].text, /byte stream/);
+		assert.equal(stream.destroyed, true, 'stream must be destroyed so file-backed sources release fds');
 	});
 });

--- a/unitTests/server/serverHelpers/serverHandlers.test.js
+++ b/unitTests/server/serverHelpers/serverHandlers.test.js
@@ -4,6 +4,7 @@ const testUtils = require('../../testUtils.js');
 testUtils.preTestPrep();
 
 const assert = require('assert');
+const { Readable } = require('node:stream');
 const sinon = require('sinon');
 const sandbox = sinon.createSandbox();
 const rewire = require('rewire');
@@ -462,6 +463,51 @@ describe('Test serverHandlers.js module ', () => {
 			assert.ok(process_local_trans_stub.calledOnce === true, 'processLocalTransaction was not called');
 			assert.ok(error_log_stub.calledOnce === true, 'Error not logged');
 			assert.ok(error_log_stub.args[0][0] === TEST_ERR, 'Error message not logged');
+		});
+
+		it('Should forward source stream errors through the gzip pipe instead of crashing the worker', async () => {
+			const source = Readable.from(
+				(async function* () {
+					yield Buffer.from('partial');
+					throw new Error('blob read failed');
+				})()
+			);
+			source.headers = new Map([['content-type', 'application/octet-stream']]);
+			process_local_trans_stub.resolves(source);
+			const stream_req = { body: { operation: 'get_deployment_payload' }, headers: { 'accept-encoding': 'gzip' } };
+			const headers_set = {};
+			const stream_res = { header: (name, value) => (headers_set[name] = value) };
+
+			const result = await serverHandlers_rw.handlePostRequest(stream_req, stream_res);
+
+			assert.ok(result !== source, 'gzip path should return the piped stream');
+			assert.strictEqual(headers_set['content-encoding'], 'gzip');
+			// Without the error forwarding, the source error fires with no listener and kills the
+			// process via uncaughtException; with it, the returned stream rejects.
+			await assert.rejects(
+				(async () => {
+					// eslint-disable-next-line no-unused-vars, no-empty
+					for await (const chunk of result) {
+					}
+				})(),
+				/blob read failed/
+			);
+		});
+
+		it('Should pass a preCompressed stream through without recompressing', async () => {
+			const source = Readable.from([Buffer.from('already-gzipped-bytes')]);
+			source.headers = new Map([['content-type', 'application/octet-stream']]);
+			source.preCompressed = true;
+			process_local_trans_stub.resolves(source);
+			const stream_req = { body: { operation: 'get_deployment_payload' }, headers: { 'accept-encoding': 'gzip' } };
+			const headers_set = {};
+			const stream_res = { header: (name, value) => (headers_set[name] = value) };
+
+			const result = await serverHandlers_rw.handlePostRequest(stream_req, stream_res);
+
+			assert.strictEqual(result, source, 'preCompressed stream must pass through untouched');
+			assert.strictEqual(headers_set['content-encoding'], undefined);
+			assert.strictEqual(headers_set['content-type'], 'application/octet-stream');
 		});
 	});
 });

--- a/unitTests/server/serverHelpers/serverHandlers.test.js
+++ b/unitTests/server/serverHelpers/serverHandlers.test.js
@@ -494,6 +494,21 @@ describe('Test serverHandlers.js module ', () => {
 			);
 		});
 
+		it('Should destroy the source stream when the gzip side is torn down (client disconnect)', async () => {
+			// An endless source, like a large blob mid-stream when the client goes away.
+			const source = new Readable({ read() {} });
+			source.headers = new Map([['content-type', 'application/octet-stream']]);
+			process_local_trans_stub.resolves(source);
+			const stream_req = { body: { operation: 'get_backup' }, headers: { 'accept-encoding': 'gzip' } };
+			const stream_res = { header: () => {} };
+
+			const result = await serverHandlers_rw.handlePostRequest(stream_req, stream_res);
+			result.destroy(); // what Fastify does to the stream it was handed when the client disconnects
+			await new Promise((resolve) => setImmediate(resolve));
+
+			assert.strictEqual(source.destroyed, true, 'source must be destroyed so its fd/blob read releases');
+		});
+
 		it('Should pass a preCompressed stream through without recompressing', async () => {
 			const source = Readable.from([Buffer.from('already-gzipped-bytes')]);
 			source.headers = new Map([['content-type', 'application/octet-stream']]);

--- a/utility/operation_authorization.ts
+++ b/utility/operation_authorization.ts
@@ -294,6 +294,14 @@ requiredPermissions.set(
 	deploymentOperations.handleGetDeployment.name,
 	new (permission as any)(true, [], terms.OPERATIONS_ENUM.GET_DEPLOYMENT)
 );
+requiredPermissions.set(
+	deploymentOperations.handleGetDeploymentPayload.name,
+	new (permission as any)(true, [], terms.OPERATIONS_ENUM.GET_DEPLOYMENT_PAYLOAD)
+);
+requiredPermissions.set(
+	deploymentOperations.handleDeleteDeploymentPayload.name,
+	new (permission as any)(true, [], terms.OPERATIONS_ENUM.DELETE_DEPLOYMENT_PAYLOAD)
+);
 
 // Secrets-store operations. All SU-only; the handlers ALSO enforce super_user directly, so these
 // cannot be delegated through a role's `operations` allowlist (gate-2 bypass below).

--- a/utility/operation_authorization.ts
+++ b/utility/operation_authorization.ts
@@ -294,6 +294,10 @@ requiredPermissions.set(
 	deploymentOperations.handleGetDeployment.name,
 	new (permission as any)(true, [], terms.OPERATIONS_ENUM.GET_DEPLOYMENT)
 );
+// get_deployment_payload streams the full tarball (which can embed secrets), unlike
+// get_deployment/list_deployments (metadata only), so it ALSO enforces super_user directly in
+// the handler — it cannot be delegated through a role's `operations` allowlist (gate-2 bypass
+// below), matching the secrets-store ops.
 requiredPermissions.set(
 	deploymentOperations.handleGetDeploymentPayload.name,
 	new (permission as any)(true, [], terms.OPERATIONS_ENUM.GET_DEPLOYMENT_PAYLOAD)


### PR DESCRIPTION
Both operations have been documented (operations-api reference + 5.1 release notes) and enum-declared since 5.1, but were never registered — calling them returned `Operation 'delete_deployment_payload' not found` (#1893, reported from a Fabric quota-cleanup workflow).

## What this adds

- **`get_deployment_payload`** (`components/deploymentOperations.ts`) — streams the stored deployment tarball back as **raw bytes** with `content-type: application/octet-stream` + a `content-disposition` filename, via the existing `Readable`+headers pipe path in `serverHandlers.js` (the `get_backup` mechanism). Deliberately never base64: payloads can be hundreds of MB, and a base64 round-trip materializes multi-hundred-MB V8 strings (hard `ERR_STRING_TOO_LONG` near ~400MB). The stream is marked `preCompressed` so the already-gzipped tar isn't re-gzipped.
- **`delete_deployment_payload`** — nulls `payload_blob` on the row and re-puts it; the RecordEncoder retained-blob check unlinks the local blob file and the replicated null makes every peer drop its copy too (the same cluster-wide reclaim mechanism as the automatic post-deploy retention drop from #1496). Row metadata + `event_log` are retained as the audit trail, with a `payload_dropped` event recording `deleted_by`. **Guards:** 409 on non-terminal deployments (their blob may still be the replication channel peers install from); idempotent success (`freed_bytes: 0`) when the payload is already gone; 404 for unknown ids.
- Registration + authorization for both, mirroring `get_deployment`'s super_user permission shape.

## Hardening found by review (in this PR)

- **`serverHandlers.js` gzip pipe now forwards source-stream errors.** `.pipe()` doesn't propagate them, so an async read error on a returned stream (e.g. `get_backup`'s file stream) fired `'error'` with no listener → `uncaughtException` → whole worker exits. Latent before this PR; blob streams made it much more reachable. Now the error destroys the gzip stream and Fastify aborts just that response.
- **MCP operations adapter** returns a clean `isError` for streaming (`Readable`) results instead of `JSON.stringify`-ing stream internals, and destroys the stream so file-backed sources release fds. `delete_deployment_payload` added to `DESTRUCTIVE_OPERATIONS`. (Neither payload op is in the MCP default-allow surface; this covers explicit `mcp.operations.allow` opt-ins, and `get_backup` as well.)

## Considered decisions (flagging for review)

- **Delegability:** both ops use `get_deployment`'s permission shape, meaning an SU can grant them to a role via its `operations` allowlist (gate-2). Considered self-enforcing super_user like the secrets ops (tarballs can embed secrets), but delegation requires a deliberate per-op SU grant, and a non-SU cleanup-automation principal is exactly the #1893 use case. Happy to tighten if reviewers disagree.
- **Rollback/redeploy-by-reference is deliberately out of scope** — that belongs with the two-phase deploy work in #1849 (design comment there).

## Verification

- Unit: 105 passing across the four touched test files (new: handler behaviors, gzip error-forwarding, preCompressed pass-through, MCP streaming guard).
- Live smoke (scratch instance from this branch's dist): deployed 1.2MB payload → real blob file on disk; `get_deployment_payload` byte-identical round-trip (sha256 match) with and without `Accept-Encoding: gzip`; `delete_deployment_payload` → `freed_bytes` correct, **blob file physically unlinked**, `payload_blob_present:false`, `payload_dropped` audit event, idempotent second call, 404s on reclaimed/unknown.

Cross-model coverage: codex ✓ / gemini ✓ / Harper-domain pass ✓ (thorough), + final-artifact pass after the review fixes. All blockers/concerns from review addressed above.

Docs: companion PR [documentation#600](https://github.com/HarperFast/documentation/pull/600) adds the delete response shape, terminal-status requirement, and raw-bytes (not base64) clarification.

Fixes #1893

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8)
