### PR TITLE
Fix recordCommitLatency parameter type for the widened commitResolution union

### DIFF
--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -42,7 +42,7 @@ export function setCommitLatencyRecorder(recorder: ((durationMs: number) => void
 // commit nor surface as an unhandled rejection on this floating `.then`. The thenable guard protects
 // against a future caller passing a non-Promise `commitResolution` (today it is always the rocksdb-js
 // async `Transaction.commit()` result, which is guaranteed to be a Promise).
-function recordCommitLatency(commitResolution: Promise<void>, submittedAt: number) {
+function recordCommitLatency(commitResolution: Promise<unknown> | void, submittedAt: number) {
 	if (!recordCommitLatencyMs) return;
 	const record = () => {
 		try {
@@ -399,11 +399,10 @@ export class DatabaseTransaction implements Transaction {
 						this.writes = this.writes.filter((write) => write); // filter out removed entries
 						if (this.writes.length > 0) {
 							// The transaction was created with coordinatedRetry:true (see
-							// getReadTxn), so commit() can resolve to RETRY_NOW_VALUE.
-							// That sentinel is handled in the resolve callback below and the
-							// cast to Promise<void> is safe — the sentinel never propagates
-							// past that branch.
-							commitResolution = transaction.commit() as Promise<void>;
+							// getReadTxn), so commit() can resolve to RETRY_NOW_VALUE. That
+							// sentinel is handled in the resolve callback below and never
+							// propagates past that branch.
+							commitResolution = transaction.commit();
 							// Record how long this commit stays outstanding (submit → settle) as a distribution
 							// metric. This is the same clock the overload check uses (outstandingCommitStart is
 							// stamped at submit), so a rising p99/p999 is the leading indicator for the


### PR DESCRIPTION
Main currently has a TS2345 at `resources/DatabaseTransaction.ts:413`: [6e6d57ed8](https://github.com/HarperFast/harper/commit/6e6d57ed8) widened `commitResolution` to `Promise<number | void> | void` for the LMDB-engine guard, but `recordCommitLatency` still declared `Promise<void>`.

The main build job tolerates tsc errors, but the **Next.js adapter integration workflow builds harper with errors fatal — so this fails those checks on every PR** (observed on [#1898](https://github.com/HarperFast/harper/pull/1898), all three Node versions).

The recorder only times settlement (fulfil or reject) and already thenable-guards, so it takes `Promise<unknown> | void`; the now-redundant `as Promise<void>` cast on `transaction.commit()` is removed with its stale comment. Type-only — no runtime change. `tsc --noEmit -p tsconfig.build.json` exits clean with this patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8)