### PR TITLE
fix(deploy): retry peer-side payload_blob read on transient 503 stall (5.1 backport of #1838)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -108,6 +108,13 @@ Consequence for callers that wrap the source in a hashing `Transform`: calling `
 
 Future agents touching `components/deploymentRecorder.ts` for Slice B's streaming variant should pick one of the latter two patterns.
 
+## Peer-side deploy_component payload read: retryable blob stalls and `Readable.from()` cancellation
+
+`readPayloadBlobWithRetry` (`components/deploymentRecorder.ts`) wraps the peer's read of a replicated `hdb_deployment` row's `payload_blob` so a transient 503 `BlobReadError` (`BLOB_UNAVAILABLE_STATUS`, `resources/blob.ts`) — content bytes not arriving within `blobReadTimeout`, e.g. a parked blob send on the origin — retries instead of failing the whole deploy. Two non-obvious constraints shaped the design:
+
+- **Retry is only safe before any byte has reached the consumer.** Once a chunk is handed downstream, re-opening `Blob.stream()` from byte 0 would duplicate it (there's no cheap way to resume from an arbitrary offset across a fresh stream without also plumbing `Blob.slice()`, which was out of scope for this fix). So the helper retries only while the current attempt has yielded nothing yet; a stall after partial content fails immediately, same as before this existed.
+- **Backpressure and cancellation are two different problems, and both are easy to get wrong with a hand-rolled `ReadableStream`.** An early version wrapped the retry loop in `new ReadableStream({ async start(controller) { for await (...) controller.enqueue(chunk) } })` — this eagerly drains `streamFactory()` regardless of `controller.desiredSize`, defeating the whole point of not buffering a multi-GB payload in memory. Switching to an `async function*` consumed via `Readable.from()` restores real backpressure (the generator only resumes when the consumer wants more, matching how the un-wrapped `Blob.stream()` behaved pre-fix). But `Readable.from()`'s `return()`-on-destroy cancellation only takes effect at the generator's _next_ `yield` — while the loop is stuck retrying (no `yield` reached yet), destroying the `Readable` does nothing until the loop naturally exits, verified empirically (a generator that never yields kept retrying long after `.destroy()`). The fix: thread the constructed `Readable` back into the generator via a mutable cell (`readable` doesn't exist until after `Readable.from()` returns, so it can't be closed over directly) and check `.destroyed` explicitly at each loop iteration and after each backoff sleep.
+
 ## System table bootstrap: `systemSchema.json` + upgrade directive
 
 Adding a new system table (e.g. `hdb_deployment` in #641 Slice A) requires three changes:

--- a/components/deploymentRecorder.ts
+++ b/components/deploymentRecorder.ts
@@ -13,7 +13,7 @@ import { randomUUID } from 'node:crypto';
 import { createHash } from 'node:crypto';
 import { Readable, Transform, pipeline } from 'node:stream';
 import { databases } from '../resources/databases.ts';
-import { createBlob, isSaving, deleteBlob } from '../resources/blob.ts';
+import { createBlob, isSaving, deleteBlob, BLOB_UNAVAILABLE_STATUS } from '../resources/blob.ts';
 import * as terms from '../utility/hdbTerms.ts';
 import { ClientError } from '../utility/errors/hdbError.ts';
 import { logger } from '../utility/logging/logger.ts';
@@ -520,6 +520,92 @@ export async function awaitDeploymentRow(
 		`Timed out after ${timeoutMs}ms waiting for the deployment payload: ${cause}` +
 			(lastError ? ` (last error: ${(lastError as Error).message ?? lastError})` : '')
 	);
+}
+
+/**
+ * Peer-side helper — read a replicated deploy's payload_blob, retrying on the blob layer's
+ * retryable 503 (`BlobReadError` with `statusCode === BLOB_UNAVAILABLE_STATUS`,
+ * resources/blob.ts). That 503 fires when the row's blob header has replicated but content
+ * bytes stop arriving for `blobReadTimeout` (20s default) — a transient, self-healing stall
+ * (a parked/declined blob send on the origin, or event-loop starvation), not a real failure.
+ * Each fresh `stream()` call gets its own no-progress window, so re-opening after a short
+ * backoff converts the stall into a successful deploy instead of failing the peer's one-shot
+ * 20s window (harper-pro incident, 2026-07-16).
+ *
+ * Chunks are forwarded to the caller as they arrive via an async generator wrapped in
+ * `Readable.from()` — a retry never buffers the whole payload in memory (deploy payloads can
+ * be arbitrarily large, see the large-payload streaming regression test), and, unlike a manual
+ * `ReadableStream` `start()` loop that eagerly drains the source, `Readable.from()`'s pull
+ * protocol only resumes the generator when the consumer wants more, so backpressure from a
+ * slow extraction consumer propagates back to the underlying `Blob.stream()` the same as it
+ * did before this wrapper existed.
+ *
+ * This also bounds *when* a retry is safe: once any chunk has reached the consumer, re-opening
+ * from byte 0 would duplicate it, so we only retry while the current attempt has yielded
+ * nothing yet — the reported failure mode (no content bytes arrive at all within the
+ * no-progress window). A stall after partial content has already been forwarded fails
+ * immediately, exactly as an unwrapped read would.
+ *
+ * Non-retryable classes — 500 corrupt/incomplete, 404 gone/ENOENT, or anything without a
+ * `statusCode` — also fail immediately.
+ *
+ * Cancellation is checked explicitly rather than relying on the generator's own suspension
+ * points: while stuck retrying (no chunk has ever been yielded), the generator never reaches a
+ * `yield`, so `Readable.from()`'s normal `return()`-on-destroy cancellation — which only takes
+ * effect when the generator next suspends at a `yield` — would never get a chance to run,
+ * letting retries continue for the full `timeoutMs` budget after the consumer has already given
+ * up (verified empirically). We route the returned `Readable` into the generator via a shared
+ * cell so it can check `readable.destroyed` at each loop iteration and after each backoff sleep,
+ * stopping within one backoff interval (capped at `maxBackoffMs`) of destroy() instead.
+ *
+ * @param streamFactory Opens a fresh read of the blob, e.g. `() => row.payload_blob.stream()`.
+ *   A factory (not a single stream) so each retry is a genuinely new read with its own
+ *   no-progress window.
+ */
+export function readPayloadBlobWithRetry(
+	streamFactory: () => ReadableStream,
+	options: { timeoutMs?: number; initialBackoffMs?: number; maxBackoffMs?: number } = {}
+): Readable {
+	const cell: { readable?: Readable } = {};
+	const readable = Readable.from(readPayloadBlobChunks(streamFactory, options, cell));
+	cell.readable = readable;
+	return readable;
+}
+
+async function* readPayloadBlobChunks(
+	streamFactory: () => ReadableStream,
+	options: { timeoutMs?: number; initialBackoffMs?: number; maxBackoffMs?: number },
+	cell: { readable?: Readable }
+): AsyncGenerator<Buffer> {
+	const requested = Number(options.timeoutMs);
+	const timeoutMs = Number.isFinite(requested) && requested >= 0 ? requested : DEFAULT_AWAIT_ROW_TIMEOUT_MS;
+	const initialBackoffMs = options.initialBackoffMs ?? 2000;
+	const maxBackoffMs = options.maxBackoffMs ?? 5000;
+	const deadline = Date.now() + timeoutMs;
+	let backoffMs = initialBackoffMs;
+	let forwardedAnyBytes = false;
+	while (true) {
+		if (cell.readable?.destroyed) return;
+		try {
+			for await (const chunk of streamFactory() as unknown as AsyncIterable<Buffer>) {
+				yield chunk;
+				forwardedAnyBytes = true;
+			}
+			return;
+		} catch (error) {
+			if (forwardedAnyBytes || (error as { statusCode?: number })?.statusCode !== BLOB_UNAVAILABLE_STATUS) {
+				throw error;
+			}
+			const remaining = deadline - Date.now();
+			if (remaining <= 0) throw error;
+			await new Promise<void>((resolve) => {
+				const timer = setTimeout(resolve, Math.min(backoffMs, remaining));
+				timer.unref?.();
+			});
+			if (cell.readable?.destroyed) return;
+			backoffMs = Math.min(backoffMs * 2, maxBackoffMs);
+		}
+	}
 }
 
 function normalizePeerResult(raw: unknown): Record<string, unknown> {

--- a/components/deploymentRecorder.ts
+++ b/components/deploymentRecorder.ts
@@ -448,6 +448,11 @@ export class DeploymentRecorder {
 // via the `deployment_timeout` operation parameter.
 const DEFAULT_AWAIT_ROW_TIMEOUT_MS = 120_000;
 
+export function coerceTimeoutMs(value: unknown, fallback: number): number {
+	const requested = Number(value);
+	return Number.isFinite(requested) && requested >= 0 ? requested : fallback;
+}
+
 /**
  * Peer-side helper — wait for the hdb_deployment row to arrive via table replication,
  * then return it. The row is committed on origin before `replicateOperation` is
@@ -475,8 +480,7 @@ export async function awaitDeploymentRow(
 	// concatenates into a far-future "deadline" that silently defeats the timeout. Anything
 	// non-finite or negative falls back to the default rather than producing a NaN deadline
 	// (which would never satisfy `>= deadline` and loop forever).
-	const requested = Number(options.timeoutMs);
-	const timeoutMs = Number.isFinite(requested) && requested >= 0 ? requested : DEFAULT_AWAIT_ROW_TIMEOUT_MS;
+	const timeoutMs = coerceTimeoutMs(options.timeoutMs, DEFAULT_AWAIT_ROW_TIMEOUT_MS);
 	const maxIntervalMs = options.pollIntervalMs ?? 100;
 	// Start fast (5ms) so the common case — replication has already caught up — sees no
 	// human-noticeable latency, then back off exponentially up to maxIntervalMs for the
@@ -577,8 +581,7 @@ async function* readPayloadBlobChunks(
 	options: { timeoutMs?: number; initialBackoffMs?: number; maxBackoffMs?: number },
 	cell: { readable?: Readable }
 ): AsyncGenerator<Buffer> {
-	const requested = Number(options.timeoutMs);
-	const timeoutMs = Number.isFinite(requested) && requested >= 0 ? requested : DEFAULT_AWAIT_ROW_TIMEOUT_MS;
+	const timeoutMs = coerceTimeoutMs(options.timeoutMs, DEFAULT_AWAIT_ROW_TIMEOUT_MS);
 	const initialBackoffMs = options.initialBackoffMs ?? 2000;
 	const maxBackoffMs = options.maxBackoffMs ?? 5000;
 	const deadline = Date.now() + timeoutMs;

--- a/components/operations.js
+++ b/components/operations.js
@@ -18,7 +18,12 @@ const { packageDirectory } = require('../components/packageComponent.ts');
 const { Resources } = require('../resources/Resources.ts');
 const { Application, prepareApplication, ASIDE_STAGING_DIR } = require('./Application.ts');
 const { server } = require('../server/Server.ts');
-const { DeploymentRecorder, awaitDeploymentRow } = require('./deploymentRecorder.ts');
+const {
+	DeploymentRecorder,
+	awaitDeploymentRow,
+	readPayloadBlobWithRetry,
+	DEFAULT_AWAIT_ROW_TIMEOUT_MS,
+} = require('./deploymentRecorder.ts');
 const { ProgressEmitter } = require('../server/serverHelpers/progressEmitter.ts');
 
 /**
@@ -442,8 +447,23 @@ async function deployComponent(req) {
 			// The wait budget defaults to 120s but is overridable per-deploy via
 			// `deployment_timeout` (ms) for clusters where the system-table channel is
 			// heavily backlogged (harper-pro#402).
-			const row = await awaitDeploymentRow(req._deploymentId, { timeoutMs: req.deployment_timeout });
-			extractionPayload = row.payload_blob.stream();
+			const requestedTimeout = Number(req.deployment_timeout);
+			const payloadTimeoutMs =
+				Number.isFinite(requestedTimeout) && requestedTimeout >= 0 ? requestedTimeout : DEFAULT_AWAIT_ROW_TIMEOUT_MS;
+			// One deadline covers both phases (row wait + blob content) so a slow row doesn't
+			// double the peer's total worst-case wait — whatever's left of payloadTimeoutMs after
+			// the row arrives is what the blob retry gets.
+			const payloadDeadline = Date.now() + payloadTimeoutMs;
+			const row = await awaitDeploymentRow(req._deploymentId, { timeoutMs: payloadTimeoutMs });
+			// Blob content can stall independently of the row itself arriving (e.g. a
+			// parked/declined blob send on the origin, harper-pro#403) — the header lands but
+			// content bytes don't, and stream() gives up with a retryable 503 after
+			// blobReadTimeout of no progress. Retry with backoff, bounded by the remaining
+			// budget, so a transient stall doesn't fail the whole deploy (harper-pro incident,
+			// 2026-07-16).
+			extractionPayload = readPayloadBlobWithRetry(() => row.payload_blob.stream(), {
+				timeoutMs: Math.max(0, payloadDeadline - Date.now()),
+			});
 		}
 
 		const application = new Application({

--- a/components/operations.js
+++ b/components/operations.js
@@ -22,6 +22,7 @@ const {
 	DeploymentRecorder,
 	awaitDeploymentRow,
 	readPayloadBlobWithRetry,
+	coerceTimeoutMs,
 	DEFAULT_AWAIT_ROW_TIMEOUT_MS,
 } = require('./deploymentRecorder.ts');
 const { ProgressEmitter } = require('../server/serverHelpers/progressEmitter.ts');
@@ -447,9 +448,7 @@ async function deployComponent(req) {
 			// The wait budget defaults to 120s but is overridable per-deploy via
 			// `deployment_timeout` (ms) for clusters where the system-table channel is
 			// heavily backlogged (harper-pro#402).
-			const requestedTimeout = Number(req.deployment_timeout);
-			const payloadTimeoutMs =
-				Number.isFinite(requestedTimeout) && requestedTimeout >= 0 ? requestedTimeout : DEFAULT_AWAIT_ROW_TIMEOUT_MS;
+			const payloadTimeoutMs = coerceTimeoutMs(req.deployment_timeout, DEFAULT_AWAIT_ROW_TIMEOUT_MS);
 			// One deadline covers both phases (row wait + blob content) so a slow row doesn't
 			// double the peer's total worst-case wait — whatever's left of payloadTimeoutMs after
 			// the row arrives is what the blob retry gets.

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -155,7 +155,9 @@ function getBlobReadTimeout(): number {
 // hung connection: 404 when the file is cleanly gone, 503 while a write is still in progress (the
 // client can retry), 500 when the content is confidently corrupt/incomplete.
 const BLOB_GONE_STATUS = 404;
-const BLOB_UNAVAILABLE_STATUS = 503;
+// Exported so callers (e.g. the peer-side deploy_component payload read) can distinguish this
+// retryable class from the permanent ones without duplicating the status code.
+export const BLOB_UNAVAILABLE_STATUS = 503;
 const BLOB_CORRUPT_STATUS = 500;
 class BlobReadError extends Error {
 	statusCode: number;

--- a/unitTests/components/deploymentRecorder.test.js
+++ b/unitTests/components/deploymentRecorder.test.js
@@ -14,7 +14,11 @@ const assert = require('node:assert');
 const testUtils = require('../testUtils.js');
 testUtils.preTestPrep();
 
-const { DeploymentRecorder, awaitDeploymentRow } = require('#src/components/deploymentRecorder');
+const {
+	DeploymentRecorder,
+	awaitDeploymentRow,
+	readPayloadBlobWithRetry,
+} = require('#src/components/deploymentRecorder');
 const { databases } = require('#src/resources/databases');
 const terms = require('#src/utility/hdbTerms');
 
@@ -417,5 +421,221 @@ describe('awaitDeploymentRow', () => {
 
 	it('polls once then times out when timeoutMs is 0 and the row is absent', async () => {
 		await assert.rejects(() => awaitDeploymentRow('zero-absent', { timeoutMs: 0 }), /Timed out after 0ms/);
+	});
+});
+
+describe('readPayloadBlobWithRetry', () => {
+	// Mirrors what resources/blob.ts's stream() rejects a ReadableStream with: an Error carrying
+	// a `statusCode` (503 = BLOB_UNAVAILABLE_STATUS/retryable, 500 = corrupt/permanent).
+	function statusCodeStream(statusCode, message) {
+		return new ReadableStream({
+			start(controller) {
+				const error = new Error(message ?? `stream failed with ${statusCode}`);
+				error.statusCode = statusCode;
+				controller.error(error);
+			},
+		});
+	}
+
+	function successStream(content) {
+		return new ReadableStream({
+			start(controller) {
+				controller.enqueue(Buffer.from(content));
+				controller.close();
+			},
+		});
+	}
+
+	// A stream that delivers one chunk, then errors on the NEXT pull — used to prove a
+	// mid-stream 503 (bytes already forwarded) is NOT retried, unlike a 503 before any chunk
+	// arrives. Enqueuing and erroring within the same `start()` call doesn't model this: per
+	// the streams spec, controller.error() resets the internal queue, so a chunk enqueued and
+	// then errored in the same synchronous turn is discarded before a reader ever sees it.
+	// Splitting across two `pull()` calls forces the first chunk to actually be read out (and
+	// forwarded) before the stall.
+	function partialThenErrorStream(statusCode, message) {
+		let pulled = false;
+		return new ReadableStream({
+			pull(controller) {
+				if (!pulled) {
+					pulled = true;
+					controller.enqueue(Buffer.from('partial-'));
+					return;
+				}
+				const error = new Error(message ?? `stream failed with ${statusCode}`);
+				error.statusCode = statusCode;
+				controller.error(error);
+			},
+		});
+	}
+
+	async function readAll(stream) {
+		const chunks = [];
+		for await (const chunk of stream) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+		return Buffer.concat(chunks);
+	}
+
+	it('retries a 503 and resolves with the content once a later attempt succeeds', async () => {
+		let attempts = 0;
+		const streamFactory = () => {
+			attempts++;
+			return attempts < 3 ? statusCodeStream(503) : successStream('tarball-bytes');
+		};
+		const stream = readPayloadBlobWithRetry(streamFactory, { timeoutMs: 5000, initialBackoffMs: 5, maxBackoffMs: 5 });
+		const result = await readAll(stream);
+		assert.strictEqual(attempts, 3, 'retried twice before the third attempt succeeded');
+		assert.strictEqual(result.toString(), 'tarball-bytes');
+	});
+
+	it('rejects with the original stall error once the timeout budget is exhausted on repeated 503s', async () => {
+		let attempts = 0;
+		const streamFactory = () => {
+			attempts++;
+			return statusCodeStream(503, 'Blob read stalled: no further data is arriving');
+		};
+		const stream = readPayloadBlobWithRetry(streamFactory, { timeoutMs: 30, initialBackoffMs: 10, maxBackoffMs: 10 });
+		await assert.rejects(() => readAll(stream), /Blob read stalled: no further data is arriving/);
+		assert.ok(attempts >= 2, 'made at least one retry attempt before the budget ran out');
+	});
+
+	it('does not retry a 500 (permanent/corrupt) error — fails on the first attempt', async () => {
+		let attempts = 0;
+		const streamFactory = () => {
+			attempts++;
+			return statusCodeStream(500, 'Blob is corrupt');
+		};
+		const stream = readPayloadBlobWithRetry(streamFactory, { timeoutMs: 5000, initialBackoffMs: 5, maxBackoffMs: 5 });
+		await assert.rejects(() => readAll(stream), /Blob is corrupt/);
+		assert.strictEqual(attempts, 1, 'a non-retryable status must not be retried');
+	});
+
+	it('does not retry an error with no statusCode at all', async () => {
+		let attempts = 0;
+		const streamFactory = () => {
+			attempts++;
+			return new ReadableStream({
+				start(controller) {
+					controller.error(new Error('unexpected failure'));
+				},
+			});
+		};
+		const stream = readPayloadBlobWithRetry(streamFactory, { timeoutMs: 5000, initialBackoffMs: 5, maxBackoffMs: 5 });
+		await assert.rejects(() => readAll(stream), /unexpected failure/);
+		assert.strictEqual(attempts, 1);
+	});
+
+	it('does not retry a 503 once a chunk has already reached the consumer — avoids duplicating forwarded bytes', async () => {
+		let attempts = 0;
+		const streamFactory = () => {
+			attempts++;
+			return partialThenErrorStream(503, 'stalled mid-stream');
+		};
+		const stream = readPayloadBlobWithRetry(streamFactory, { timeoutMs: 5000, initialBackoffMs: 5, maxBackoffMs: 5 });
+		await assert.rejects(() => readAll(stream), /stalled mid-stream/);
+		assert.strictEqual(attempts, 1, 'a stall after partial content must not be retried');
+	});
+
+	it('succeeds on the first attempt without waiting when the stream is healthy', async () => {
+		let attempts = 0;
+		const streamFactory = () => {
+			attempts++;
+			return successStream('ok');
+		};
+		const before = Date.now();
+		const stream = readPayloadBlobWithRetry(streamFactory, { timeoutMs: 5000 });
+		const result = await readAll(stream);
+		assert.strictEqual(attempts, 1);
+		assert.strictEqual(result.toString(), 'ok');
+		assert.ok(Date.now() - before < 500, 'a healthy first read must not incur backoff delay');
+	});
+
+	it('forwards chunks without buffering the whole payload — large payloads stream through', async () => {
+		// Regression guard for a full-buffering design: with a multi-chunk stream, the wrapper
+		// must yield each chunk as it arrives rather than collecting them all before returning
+		// anything.
+		const streamFactory = () =>
+			new ReadableStream({
+				start(controller) {
+					controller.enqueue(Buffer.from('chunk-1-'));
+					controller.enqueue(Buffer.from('chunk-2'));
+					controller.close();
+				},
+			});
+		const stream = readPayloadBlobWithRetry(streamFactory, { timeoutMs: 5000 });
+		const iterator = stream[Symbol.asyncIterator]();
+		const first = await iterator.next();
+		assert.strictEqual(Buffer.from(first.value).toString(), 'chunk-1-', 'first chunk is forwarded on its own');
+		const second = await iterator.next();
+		assert.strictEqual(Buffer.from(second.value).toString(), 'chunk-2');
+		const done = await iterator.next();
+		assert.strictEqual(done.done, true);
+	});
+
+	it('is pull-based — reading one chunk does not drain a large source ahead of consumer demand', async () => {
+		// Regression guard for the eager-drain bug: a `for await` loop that enqueues into a
+		// Web ReadableStream without checking `desiredSize` keeps pulling from the source as
+		// fast as it can, regardless of whether the consumer has read anything yet — defeating
+		// the whole no-buffering design for a multi-GB payload. Readable.from()'s pull protocol
+		// only resumes the generator when the consumer asks for more, so the source must not be
+		// anywhere near drained after the consumer has read just one chunk.
+		const TOTAL_CHUNKS = 5000;
+		let innerPulls = 0;
+		const streamFactory = () =>
+			new ReadableStream({
+				pull(controller) {
+					innerPulls++;
+					if (innerPulls > TOTAL_CHUNKS) {
+						controller.close();
+						return;
+					}
+					controller.enqueue(Buffer.from(`chunk-${innerPulls}`));
+				},
+			});
+		const stream = readPayloadBlobWithRetry(streamFactory, { timeoutMs: 5000 });
+		const iterator = stream[Symbol.asyncIterator]();
+		const first = await iterator.next();
+		assert.strictEqual(Buffer.from(first.value).toString(), 'chunk-1');
+		assert.ok(
+			innerPulls < TOTAL_CHUNKS / 2,
+			`must not eagerly drain the source before the consumer asks for more (pulled ${innerPulls}/${TOTAL_CHUNKS} after reading just one chunk)`
+		);
+	});
+
+	it('performs a single check (no retry loop) when timeoutMs is 0', async () => {
+		let attempts = 0;
+		const streamFactory = () => {
+			attempts++;
+			return statusCodeStream(503, 'stalled');
+		};
+		const stream = readPayloadBlobWithRetry(streamFactory, { timeoutMs: 0 });
+		await assert.rejects(() => readAll(stream), /stalled/);
+		assert.strictEqual(attempts, 1, 'a 0 timeout must not retry at all');
+	});
+
+	it('bounds retries after the consumer destroys the stream — does not retry toward the full timeout budget', async () => {
+		let attempts = 0;
+		const streamFactory = () => {
+			attempts++;
+			return statusCodeStream(503);
+		};
+		const stream = readPayloadBlobWithRetry(streamFactory, {
+			timeoutMs: 10_000,
+			initialBackoffMs: 20,
+			maxBackoffMs: 20,
+		});
+		stream.resume(); // start consuming so the generator actually runs
+		await new Promise((resolve) => setTimeout(resolve, 50)); // let the first attempt fail and enter backoff
+		stream.destroy();
+		// destroy() only takes effect at the generator's next suspension point, not
+		// immediately, so some further attempts can still land in a short window — but they
+		// must stabilize well before the full 10s budget, not keep retrying toward it.
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		const attemptsAfterGracePeriod = attempts;
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		assert.strictEqual(
+			attempts,
+			attemptsAfterGracePeriod,
+			'retries must stop within a bounded window after destroy(), not continue toward the full timeout budget'
+		);
 	});
 });


### PR DESCRIPTION
## Summary

Cherry-picks the peer-side `payload_blob` read retry (HarperFast/harper#1838) onto the **v5.1** patch line. On a replicated `deploy_component`, a peer reads the tarball from the replicated `hdb_deployment` row's `payload_blob`, whose content arrives as in-flight `BLOB_CHUNK` frames the read blocks on (`components/operations.js`, peer branch). If the system-DB replication WebSocket reconnects mid-transfer, the header lands but content bytes don't, and `Blob.stream()` gives up after the 20s `blobReadTimeout` with a **retryable 503** (`resources/blob.ts`). On v5.1.22 nothing retried it, so a single transient reconnect fails the whole deploy for that peer.

`readPayloadBlobWithRetry` (`components/deploymentRecorder.ts`) retries a fresh `stream()` on the 503 with backoff, bounded by the same `timeoutMs` budget already used to wait for the row (one shared deadline covers row-wait + blob-content). It only retries while nothing has reached the consumer yet — a stall after partial content fails immediately (no duplicate bytes) — and streams chunks through a pull-based async generator + `Readable.from()`, preserving backpressure for large payloads. 500 corrupt / 404 gone still fail immediately.

## Why this is needed on 5.1 (field incident)

Root-caused live on a 15-node multi-region 5.1.22 prod cluster (Gen Digital Early Hints): a replicated deploy failed on the network-distant peers with

```
ServerError: Blob read stalled for .../blobs/system/0/0/57:
header reports 727695 bytes but only 0 are readable and no further data is arriving
```

Investigation (read-only, two peers) confirmed the trigger is a **transient replication WS reconnect** coinciding with `BLOB_CHUNK` delivery to a high-latency peer — not a cluster defect: CPU idle, TLS to peer `:9933` healthy, `database_sockets` connected with advancing versions, 1006 reconnects sparse/normal-WAN (hours with zero) plus event-driven storms. The one-shot 20s window was simply too brittle to absorb a normal reconnect on a long-haul transfer. This retry absorbs exactly that class. (Only workaround available in the field was a node-by-node unreplicated deploy.)

## Scope / backport notes

- Cherry-picks the two relevant commits from #1838: the retry fix (`e02efb47`) + the timeout-coercion dedup (`11cff13e`).
- **Deliberately omits** the third commit (`f2963763`, "reuse timeout coercion for credentials") — it refactors the credential-reference path, which does not exist on v5.1. Skipped, no dangling references.
- One trivial conflict resolved (the `deploymentRecorder` import line).

## Tests

`unitTests/components/deploymentRecorder.test.js` — **43 passing** on this branch, including the full `readPayloadBlobWithRetry` suite (503-then-success, budget-exhaustion, 500/no-statusCode immediate-fail, no-retry-after-partial-forward, zero-timeout, pull-based backpressure, bounded retries after `destroy()`). `tsc` build clean.

Refs HarperFast/harper#1838

🤖 Generated with [Claude Code](https://claude.com/claude-code)
