### PR TITLE
refactor(integrationTests): extract waitForRouteReady from restartHttpWorkers

### DIFF
--- a/integrationTests/apiTests/utils/lifecycle.mjs
+++ b/integrationTests/apiTests/utils/lifecycle.mjs
@@ -6,6 +6,39 @@ const DEFAULT_READINESS_TIMEOUT_MS = 60000;
 const READINESS_POLL_INTERVAL_MS = 250;
 
 /**
+ * Poll `probePath` until it stops returning 404, i.e. until the route is registered and
+ * being served. Any response in [200, 499] excluding 404 is treated as ready; 4xx
+ * auth/validation responses are fine.
+ *
+ * Use this directly (without `restartHttpWorkers`) when the component/route is already
+ * installed and only async post-boot route registration needs to be awaited — no worker
+ * restart involved.
+ *
+ * @param {ReturnType<import('./client.mjs').createApiClient>} client
+ * @param {string} probePath REST path that should be served by the component
+ * @param {number} [timeoutMs] overall readiness budget (default 60s)
+ */
+export async function waitForRouteReady(client, probePath, timeoutMs = DEFAULT_READINESS_TIMEOUT_MS) {
+	const deadline = Date.now() + timeoutMs;
+	let lastStatus;
+	let lastError;
+	while (Date.now() < deadline) {
+		try {
+			const response = await client.reqRest(probePath).timeout(2000);
+			lastStatus = response.status;
+			if (response.status !== 404) return;
+		} catch (err) {
+			lastError = err;
+		}
+		await setTimeout(READINESS_POLL_INTERVAL_MS);
+	}
+	throw new Error(
+		`Probe ${probePath} did not become ready within ${timeoutMs}ms ` +
+			`(last status=${lastStatus ?? 'none'}, last error=${lastError?.message ?? 'none'})`
+	);
+}
+
+/**
  * Trigger `restart_service http_workers` and wait for the restart to actually complete and
  * the REST workers (and any newly-registered component routes) to be serving traffic again.
  *
@@ -40,21 +73,9 @@ export async function restartHttpWorkers(client, probePath, timeoutMs = DEFAULT_
 	assert.ok(body.job_id, `restart_service returned no job_id: ${JSON.stringify(body)}`);
 	await awaitJobCompleted(client, body.job_id, { timeoutSeconds: Math.ceil(timeoutMs / 1000) });
 
-	const deadline = Date.now() + timeoutMs;
-	let lastStatus;
-	let lastError;
-	while (Date.now() < deadline) {
-		try {
-			const response = await client.reqRest(probePath).timeout(2000);
-			lastStatus = response.status;
-			if (response.status !== 404) return;
-		} catch (err) {
-			lastError = err;
-		}
-		await setTimeout(READINESS_POLL_INTERVAL_MS);
+	try {
+		await waitForRouteReady(client, probePath, timeoutMs);
+	} catch (err) {
+		throw new Error(`${err.message} after restart_service`);
 	}
-	throw new Error(
-		`Probe ${probePath} did not become ready within ${timeoutMs}ms after restart_service ` +
-			`(last status=${lastStatus ?? 'none'}, last error=${lastError?.message ?? 'none'})`
-	);
 }

--- a/integrationTests/apiTests/utils/lifecycle.mjs
+++ b/integrationTests/apiTests/utils/lifecycle.mjs
@@ -76,6 +76,6 @@ export async function restartHttpWorkers(client, probePath, timeoutMs = DEFAULT_
 	try {
 		await waitForRouteReady(client, probePath, timeoutMs);
 	} catch (err) {
-		throw new Error(`${err.message} after restart_service`);
+		throw new Error(err.message + ' after restart_service', { cause: err });
 	}
 }

--- a/integrationTests/database/eviction-secondary-index.test.ts
+++ b/integrationTests/database/eviction-secondary-index.test.ts
@@ -45,6 +45,8 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 // @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
 import { createApiClient } from './../apiTests/utils/client.mjs';
+// @ts-expect-error utils/lifecycle.mjs has no type declarations; runtime resolves fine
+import { waitForRouteReady } from './../apiTests/utils/lifecycle.mjs';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'eviction-secondary-index');
 const SCHEMA = 'data';
@@ -86,19 +88,8 @@ suite(`QA-179 TTL eviction sweep vs secondary index [${ENGINE}]`, { skip: skipSu
 		proc?.stdout?.on('data', (d: Buffer) => (procOutput += d.toString()));
 		proc?.stderr?.on('data', (d: Buffer) => (procOutput += d.toString()));
 
-		// Poll for route readiness (component is pre-installed; no restart needed)
-		{
-			const deadline = Date.now() + 120_000;
-			while (Date.now() < deadline) {
-				try {
-					const probe = await client.reqRest('/Expiring/').timeout(2000);
-					if (probe.status !== 404) break;
-				} catch {
-					/* not ready yet */
-				}
-				await sleep(250);
-			}
-		}
+		// Wait for route readiness (component is pre-installed; no restart needed).
+		await waitForRouteReady(client, '/Expiring/', 120_000);
 	});
 
 	after(async () => {


### PR DESCRIPTION
## What / why

Review finding on [PR #1886 (test(database): promote 2 QA secondary-index integrity anchors)](https://github.com/HarperFast/harper/pull/1886) noted that the "poll for HTTP-route readiness after fixture boot" logic is duplicated: `restartHttpWorkers()` in `integrationTests/apiTests/utils/lifecycle.mjs` has the ~15-line poll loop inline, and `integrationTests/database/eviction-secondary-index.test.ts` re-implements the same loop verbatim for its no-restart-needed case (the component is pre-installed there, so it can't call `restartHttpWorkers` — it only needs the readiness poll, not the restart).

This extracts the poll loop into a standalone exported `waitForRouteReady(client, probePath, timeoutMs)`, which `restartHttpWorkers()` now calls internally, and which `eviction-secondary-index.test.ts` calls directly instead of duplicating the block. Behavior is unchanged — `restartHttpWorkers()`'s timeout budgeting and error message are preserved (the error message gets `after restart_service` appended, same as before).

## Scope note

The finding's suggested location was a shared helper in `@harperfast/integration-testing` (an external published package). The actual duplicated code lives in `integrationTests/apiTests/utils/lifecycle.mjs` within this repo (already the shared home for `restartHttpWorkers` and other test-lifecycle helpers) — not in the external package, which is only used here for `setupHarperWithFixture`/`teardownHarper`. Keeping the fix in-repo avoids a cross-repo publish/version-bump coordination for what's a same-repo duplication.

The two other files named in the finding (`aborted-update-index-migration.test.ts`, `eviction-index-atomicity-lmdb.test.ts`) exist only on PR #1886's branch (not yet merged to `main`), so they aren't touched here; once that PR lands they'd be natural candidates to adopt `waitForRouteReady` too if they have the same duplicated block.

## Test plan

- `npm run build` — clean.
- `npm run test:integration -- "integrationTests/database/eviction-secondary-index.test.ts"` — 3/3 pass (exercises the new `waitForRouteReady` call site).
- `npm run test:integration -- "integrationTests/database/multi-condition-query.test.ts"` — 7/7 pass (exercises `restartHttpWorkers`, confirming the refactor didn't change its behavior).
- `prettier --check` / `oxlint` clean on both changed files.

Generated by Claude Sonnet 5 (dev-agent, dispatch `finding-fix-harper-sorr`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)