### PR TITLE
Canonicalize PACKAGE_ROOT so it matches realpath'd allowedPath checks

### DIFF
--- a/unitTests/utility/packageUtils.test.js
+++ b/unitTests/utility/packageUtils.test.js
@@ -2,7 +2,9 @@ const { describe, it } = require('mocha');
 
 const assert = require('node:assert');
 const { join } = require('node:path');
-const { readFileSync } = require('node:fs');
+const { readFileSync, realpathSync, symlinkSync, rmSync, mkdtempSync } = require('node:fs');
+const os = require('node:os');
+const { execFileSync } = require('node:child_process');
 
 const packageUtils = require('#src/utility/packageUtils');
 
@@ -17,6 +19,45 @@ describe('packageUtils', () => {
 
 	it('should export the HarperDB package root as PACKAGE_ROOT', () => {
 		assert.equal(typeof packageUtils.PACKAGE_ROOT, 'string');
-		assert.equal(packageUtils.PACKAGE_ROOT, join(__dirname, '../..'));
+		// realpathSync'd: PACKAGE_ROOT is canonicalized (see the symlink test below), so compare
+		// against the canonical form rather than the raw join, which would only coincidentally
+		// match unless this suite itself is invoked with --preserve-symlinks.
+		assert.equal(packageUtils.PACKAGE_ROOT, realpathSync(join(__dirname, '../..')));
+	});
+
+	it('should canonicalize PACKAGE_ROOT when the checkout is reached through a symlink', () => {
+		// security/jsLoader.ts's allowed-path check always realpathSync()s the module it is
+		// loading before comparing it against an allowedPath prefix. If PACKAGE_ROOT (used as
+		// that prefix by consumers/tests) is not equally canonical, a symlinked checkout root
+		// makes an in-scope module look "outside of allowed path" even though it isn't.
+		//
+		// Node's default require() already realpath()s __dirname, which would mask a
+		// regression here — so this exercises it under --preserve-symlinks (in a child
+		// process, since the flag can't be toggled for an already-running process),
+		// the same condition that lets a symlinked checkout diverge from PACKAGE_ROOT.
+		const realRoot = join(__dirname, '../..');
+		const tmpDir = mkdtempSync(join(os.tmpdir(), 'harper-pkgutils-test-'));
+		const linkPath = join(tmpDir, 'harper-link');
+		try {
+			symlinkSync(realRoot, linkPath, 'dir');
+		} catch (err) {
+			rmSync(tmpDir, { recursive: true, force: true });
+			if (err.code === 'EPERM' || err.code === 'ENOTSUP') return; // no symlink support in this CI env
+			throw err;
+		}
+		try {
+			const output = execFileSync(
+				process.execPath,
+				[
+					'--preserve-symlinks',
+					'-e',
+					`console.log(require(${JSON.stringify(join(linkPath, 'utility/packageUtils.js'))}).PACKAGE_ROOT)`,
+				],
+				{ encoding: 'utf8' }
+			).trim();
+			assert.equal(output, realpathSync(realRoot));
+		} finally {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/utility/packageUtils.js
+++ b/utility/packageUtils.js
@@ -1,6 +1,6 @@
 'use strict';
 const { join, dirname } = require('node:path');
-const { existsSync, readFileSync } = require('node:fs');
+const { existsSync, readFileSync, realpathSync } = require('node:fs');
 
 /**
  * A naive find-up implementation to find the root package.json, and
@@ -37,10 +37,13 @@ const packageJsonPath = findPackageJson();
 const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
 
 /**
- * The Harper package root directory.
+ * The Harper package root directory, canonicalized (symlinks resolved).
  *
- * Works across dev and prod (built).
+ * Works across dev and prod (built). Callers that compare this against a `realpathSync`'d
+ * path (e.g. the module sandbox's allowed-path check in security/jsLoader.ts) need it
+ * canonical too, or a symlinked checkout (e.g. `--preserve-symlinks`, a symlinked worktree
+ * root) makes the string comparison fail even though the path is legitimately inside.
  */
-const PACKAGE_ROOT = dirname(packageJsonPath);
+const PACKAGE_ROOT = realpathSync(dirname(packageJsonPath));
 
 module.exports = { packageJson, PACKAGE_ROOT };


### PR DESCRIPTION
## What / why

`unitTests/components/globalIsolation.test.js` was reported to intermittently reject `node_modules/mqtt` as "outside of allowed path" specifically when the checkout root is reached through a symlink (observed with dev-agent worktrees under `.claude/worktrees/...`).

Root cause: `PACKAGE_ROOT` (`utility/packageUtils.js`) is derived from a raw directory walk (`__dirname` → `dirname()` up to the nearest `package.json`) with no `realpathSync`. Meanwhile `security/jsLoader.ts`'s `checkAllowedModulePath` **always** `realpathSync()`s the module path it's validating before doing `path.startsWith(allowedPath)`. Whenever the process resolves symlinks inconsistently for these two paths (confirmed reproducible under `--preserve-symlinks`, which some environments set via `NODE_OPTIONS`), `PACKAGE_ROOT` keeps a symlinked prefix while the module path gets canonicalized — so `startsWith` never matches, even though the module is legitimately in scope.

`components/componentLoader.ts` already calls `realpathSync(componentDirectory)` for its `allowedPath` sources — this closes the same gap for `PACKAGE_ROOT`, which several test fixtures (and any other consumer treating it as an allow-list prefix) rely on being canonical.

## Fix

`utility/packageUtils.js`: wrap `PACKAGE_ROOT`'s computed value in `realpathSync()`.

## Test plan

- Added `unitTests/utility/packageUtils.test.js`: spawns a child `node --preserve-symlinks` process that requires `utility/packageUtils.js` through a freshly created symlink to the repo root, and asserts `PACKAGE_ROOT` still equals the canonical (non-symlinked) path. Verified this test **fails without the fix** and **passes with it**.
- Hardened the pre-existing `PACKAGE_ROOT` equality assertion to compare against `realpathSync(...)` rather than a raw `join(...)`, so it stays correct if the suite itself is ever invoked with `--preserve-symlinks` (Gemini review leg caught this).
- `npm run build` + `npm run test:unit:main` (3784 passing, 0 failing) and `unitTests/components/globalIsolation.test.js` + `unitTests/security/**` all green.
- `npm run format:write` / `oxlint` clean on both changed files.

## Review

Cross-model review (quick mode — diff <200 lines): the `reviewer`/`codex-reviewer` subagents aren't installed in this dev-agent profile, so I ran the Gemini leg (`agy`) directly on the diff. It flagged one real issue (the pre-existing equality assertion would break under `--preserve-symlinks`), which is fixed above; its other two suggestions (Windows symlink type, `return` vs `this.skip()`) match the established pattern already used in `unitTests/agent/fsTools.test.js`, so left as-is for consistency.

Refs finding from dispatch `finding-fix-harper-i7a1` (queued from `fix-harper-1880`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)