### PR TITLE
Fail soft on operations API domain socket bind failure; warn on path-length overflow

### DIFF
--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -1,7 +1,7 @@
 import * as hdbTerms from '../utility/hdbTerms.ts';
 import * as hdbUtils from '../utility/common_utils.ts';
 import logger from '../utility/logging/harper_logger.ts';
-import { configValidator } from '../validation/configValidator.ts';
+import { configValidator, getDomainSocketPathLengthWarning } from '../validation/configValidator.ts';
 import fs from 'fs-extra';
 import YAML from 'yaml';
 import path from 'path';
@@ -662,7 +662,10 @@ function validateConfig(configDoc, skipFsValidation = false) {
 	configDoc.setIn(['logging', 'root'], validation.value.logging.root);
 	configDoc.setIn(['storage', 'path'], validation.value.storage.path);
 	configDoc.setIn(['logging', 'rotation', 'path'], validation.value.logging.rotation.path);
-	configDoc.setIn(['operationsApi', 'network', 'domainSocket'], validation.value?.operationsApi?.network?.domainSocket);
+	const domainSocket = validation.value?.operationsApi?.network?.domainSocket;
+	configDoc.setIn(['operationsApi', 'network', 'domainSocket'], domainSocket);
+	const domainSocketWarning = getDomainSocketPathLengthWarning(validation.value.rootPath, domainSocket);
+	if (domainSocketWarning) logger.warn(domainSocketWarning);
 }
 
 /**

--- a/server/DESIGN.md
+++ b/server/DESIGN.md
@@ -69,6 +69,11 @@ A request entering `http.ts` does **not** go through Fastify. The two `handleApp
 | `transactionLogCooling.ts` | Main-thread timer that cools transaction-log mmaps.      |
 
 > Workers receive `workerData.noServerStart = true` — never start the server inside a worker.
+>
+> `threadServer.listenOnDomainSocket()` skips a listener only when its path exceeds the platform's
+> `sockaddr_un.sun_path` byte limit (some Node versions reject it; others silently truncate it).
+> Every actual `listen()` error rejects startup, and the temporary bind-error listener is removed
+> once the socket is listening.
 
 ### Where periodic maintenance runs (main thread vs last worker)
 

--- a/server/http.ts
+++ b/server/http.ts
@@ -737,10 +737,6 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 			server.isSecure = true;
 		}
 		registerServer(server, port);
-		// Lets threadServer.js identify the operations API's own listeners (TCP and its domain
-		// socket) so it can tell a lost convenience mirror apart from a domain-socket bind failure
-		// that leaves the operations API with no listener at all.
-		server.isOperationsServer = isOperationsServer;
 		// macOS doesn't support SO_REUSEPORT on all socket types; operations API also doesn't need it
 		if (isOperationsServer || process.platform === 'darwin') server.noReusePort = true;
 

--- a/server/http.ts
+++ b/server/http.ts
@@ -68,9 +68,26 @@ export const uwsServeConfigs: Record<string, any> = {};
 // them out of SERVERS is what prevents a competing Node server from binding the same port.
 const fallbackServers: Record<string | number, any> = {};
 const udsCleanupPaths: { socketPath: string; yamlPath: string }[] = [];
+// Sockets whose listen() has failed (see threadServer.js's fail-soft UDS handling). A TLS mirror's
+// YAML metadata is written on its own schedule (SNICallback readiness / cert reload), independent of
+// whether the mirror socket ever actually bound, so a failed bind must both cancel any metadata write
+// still pending and remove one already on disk — otherwise a fronting proxy keeps advertising a socket
+// nothing is listening on.
+const failedUdsPaths = new Set<string>();
 
 export function registerUdsCleanupPaths(socketPath: string, yamlPath: string) {
 	udsCleanupPaths.push({ socketPath, yamlPath });
+}
+
+/** Mark a Unix domain socket's listen() as failed: suppress its metadata and remove any already written. */
+export function markUdsBindFailed(socketPath: string) {
+	failedUdsPaths.add(socketPath);
+	const entry = udsCleanupPaths.find((candidate) => candidate.socketPath === socketPath);
+	if (entry) {
+		try {
+			unlinkSync(entry.yamlPath);
+		} catch {}
+	}
 }
 
 export function cleanupUdsFiles() {
@@ -720,6 +737,10 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 			server.isSecure = true;
 		}
 		registerServer(server, port);
+		// Lets threadServer.js identify the operations API's own listeners (TCP and its domain
+		// socket) so it can tell a lost convenience mirror apart from a domain-socket bind failure
+		// that leaves the operations API with no listener at all.
+		server.isOperationsServer = isOperationsServer;
 		// macOS doesn't support SO_REUSEPORT on all socket types; operations API also doesn't need it
 		if (isOperationsServer || process.platform === 'darwin') server.noReusePort = true;
 
@@ -775,7 +796,12 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 			}
 			registerUdsCleanupPaths(udsPath, yamlPath);
 
-			const writeMetadata = () => writeUdsMetadata(yamlPath, port, server, undefined, !process.env.HARPER_UWS_UDS);
+			// Skip (and don't re-arm) the write if this mirror's listen() already failed — see
+			// markUdsBindFailed(). SNICallback readiness and cert reloads are independent of the
+			// socket's bind outcome, so without this check a failed mirror could still get advertised.
+			const writeMetadata = () => {
+				if (!failedUdsPaths.has(udsPath)) writeUdsMetadata(yamlPath, port, server, undefined, !process.env.HARPER_UWS_UDS);
+			};
 			options.SNICallback.ready.then(writeMetadata);
 			server.secureContextsListeners.push(writeMetadata);
 
@@ -812,7 +838,9 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 				SERVERS[udsPathH2] = h2Front;
 				registerUdsCleanupPaths(udsPathH2, yamlPathH2);
 
-				const writeMetadataH2 = () => writeUdsMetadata(yamlPathH2, port, server, 'h2');
+				const writeMetadataH2 = () => {
+					if (!failedUdsPaths.has(udsPathH2)) writeUdsMetadata(yamlPathH2, port, server, 'h2');
+				};
 				options.SNICallback.ready.then(writeMetadataH2);
 				server.secureContextsListeners.push(writeMetadataH2);
 			}

--- a/server/http.ts
+++ b/server/http.ts
@@ -796,7 +796,8 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 			// markUdsBindFailed(). SNICallback readiness and cert reloads are independent of the
 			// socket's bind outcome, so without this check a failed mirror could still get advertised.
 			const writeMetadata = () => {
-				if (!failedUdsPaths.has(udsPath)) writeUdsMetadata(yamlPath, port, server, undefined, !process.env.HARPER_UWS_UDS);
+				if (!failedUdsPaths.has(udsPath))
+					writeUdsMetadata(yamlPath, port, server, undefined, !process.env.HARPER_UWS_UDS);
 			};
 			options.SNICallback.ready.then(writeMetadata);
 			server.secureContextsListeners.push(writeMetadata);

--- a/server/threads/socketRouter.ts
+++ b/server/threads/socketRouter.ts
@@ -39,7 +39,11 @@ export async function startHTTPThreads(threadCount = 2, dynamicThreads?: boolean
 			const { loadRootComponents } = require('../loadRootComponents.js');
 			if (threadCount === 0) {
 				setMainIsWorker(true);
-				await require('./threadServer.js').startServers();
+				const threadServer = require('./threadServer.js');
+				await threadServer.startServers();
+				// startServers() schedules listener startup after loading components; await its cached
+				// batch so a bind failure reaches bin/run.ts and exits non-zero in single-thread mode too.
+				await threadServer.listenOnPorts();
 				return Promise.resolve([]);
 			}
 			await loadRootComponents();

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -27,6 +27,7 @@ const {
 } = require('../../components/shutdownDrain.ts');
 const { realExit } = require('./workerProcessGuard.ts');
 const { isBun } = require('../serverHelpers/Request.ts');
+const { getDomainSocketPathMaxBytes, isDomainSocketPathTooLong } = require('../../utility/domainSocket.ts');
 const { createTLSSelector, getEffectiveTlsCiphers } = require('../../security/keys.ts');
 const { startupLog } = require('../../bin/run.ts');
 const { SERVERS, setPortServerMap, portServer, socketOptionDefaults } = require('../serverRegistry.ts');
@@ -95,6 +96,7 @@ process.on('unhandledRejection', (reason) => {
 });
 env.initSync();
 exports.globals = globals;
+exports.listenOnDomainSocket = listenOnDomainSocket;
 exports.listenOnPorts = listenOnPorts;
 exports.startServers = startServers;
 exports.closeServers = closeServers;
@@ -253,39 +255,37 @@ function startServers() {
 	});
 	return loaded;
 }
-/** True if some other TCP (non-UDS) listener registered by the operations API exists in SERVERS. */
-function hasOperationsTcpEndpoint() {
-	for (const key in SERVERS) {
-		if (!key.includes?.('/') && SERVERS[key]?.isOperationsServer) return true;
-	}
-	return false;
-}
-
 /**
- * Handle a failed Unix domain socket bind: this fails soft (see listenOnPorts()'s UDS branch) for
- * every path-keyed listener in SERVERS, not just the operations API's — a domain socket is a
- * convenience mirror of its same-named TCP listener, and rejecting here used to abort the whole
- * startup batch (process.exit in bin/run.ts's main()) over one socket, most commonly EINVAL from a
- * rootPath-derived path exceeding the platform's ~107-byte sun_path limit.
- *
- * A lost mirror is routine when a TCP/other listener for the same server is still coming up
- * alongside it, but the operations API can also be configured with only a domain socket (no
- * port/securePort) — in that case this failure leaves it with no listener at all, which is worth a
- * louder log than "lost a convenience mirror". Either way, also suppress/remove any TLS-mirror
- * metadata already advertised for this socket (see markUdsBindFailed()) so a fronting proxy doesn't
- * keep routing to a socket nothing is listening on.
+ * An overlong path is the only condition that can skip a domain-socket listener. Check before
+ * listen() because supported Node versions differ: some reject the path while others truncate and
+ * bind it somewhere clients cannot reach using the configured path.
  */
-function handleDomainSocketBindFailure(port, server, err) {
-	httpComponent.markUdsBindFailed(port);
-	const message = `Failed to bind domain socket listener${server.name ? ` for '${server.name}'` : ''} at ${port}: ${err.message}. Continuing without this domain socket.`;
-	if (server.isOperationsServer && !hasOperationsTcpEndpoint()) {
-		harperLogger.fatal(
-			`${message} No other operations API endpoint (port/securePort) is configured — the operations API has no listener.`,
-			err
+function listenOnDomainSocket(port, server) {
+	if (isDomainSocketPathTooLong(port)) {
+		httpComponent.markUdsBindFailed(port);
+		harperLogger.error(
+			`Not binding domain socket listener${server.name ? ` for '${server.name}'` : ''} at ${port}: the ${Buffer.byteLength(port)}-byte path exceeds the platform limit of ${getDomainSocketPathMaxBytes()} bytes. Continuing without this domain socket.`
 		);
-	} else {
-		harperLogger.error(message, err);
+		return Promise.resolve({ port, failed: true });
 	}
+	if (existsSync(port)) unlinkSync(port);
+	return new Promise((resolve, reject) => {
+		function onError(error) {
+			reject(error);
+		}
+		function onListening() {
+			server.removeListener('error', onError);
+			harperLogger.info('Domain socket listening on ' + port);
+			resolve({ port, name: server.name, protocol_name: server.protocol_name });
+		}
+		try {
+			server.once('error', onError);
+			server.listen({ path: port }, onListening);
+		} catch (error) {
+			server.removeListener('error', onError);
+			reject(error);
+		}
+	});
 }
 
 let listening;
@@ -298,20 +298,7 @@ function listenOnPorts() {
 
 		// If server is unix domain socket
 		if (port.includes?.('/')) {
-			if (existsSync(port)) unlinkSync(port);
-			listening.push(
-				new Promise((resolve) => {
-					server
-						.listen({ path: port }, () => {
-							resolve({ port, name: server.name, protocol_name: server.protocol_name });
-							harperLogger.info('Domain socket listening on ' + port);
-						})
-						.on('error', (err) => {
-							handleDomainSocketBindFailure(port, server, err);
-							resolve({ port, failed: true });
-						});
-				})
-			);
+			listening.push(listenOnDomainSocket(port, server));
 			continue;
 		}
 		let listen_on;
@@ -548,22 +535,7 @@ async function listenOnPortsBun() {
 		if (server?.stop || bunServeConfigs[port]) continue;
 		if (server?.listen) {
 			if (port.includes?.('/')) {
-				if (existsSync(port)) unlinkSync(port);
-				listening.push(
-					new Promise((resolve) => {
-						server
-							.listen({ path: port }, () => {
-								resolve({ port });
-								harperLogger.info('Domain socket listening on ' + port);
-							})
-							.on('error', (err) => {
-								// See handleDomainSocketBindFailure()/listenOnPorts() above: a domain
-								// socket bind failure must not abort the rest of this Promise.all batch.
-								handleDomainSocketBindFailure(port, server, err);
-								resolve({ port, failed: true });
-							});
-					})
-				);
+				listening.push(listenOnDomainSocket(port, server));
 			} else {
 				const lastColon = String(port).lastIndexOf(':');
 				const rawHostname = lastColon > 0 ? String(port).slice(0, lastColon).replace(/[[\]]/g, '') : null;

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -253,6 +253,41 @@ function startServers() {
 	});
 	return loaded;
 }
+/** True if some other TCP (non-UDS) listener registered by the operations API exists in SERVERS. */
+function hasOperationsTcpEndpoint() {
+	for (const key in SERVERS) {
+		if (!key.includes?.('/') && SERVERS[key]?.isOperationsServer) return true;
+	}
+	return false;
+}
+
+/**
+ * Handle a failed Unix domain socket bind: this fails soft (see listenOnPorts()'s UDS branch) for
+ * every path-keyed listener in SERVERS, not just the operations API's — a domain socket is a
+ * convenience mirror of its same-named TCP listener, and rejecting here used to abort the whole
+ * startup batch (process.exit in bin/run.ts's main()) over one socket, most commonly EINVAL from a
+ * rootPath-derived path exceeding the platform's ~107-byte sun_path limit.
+ *
+ * A lost mirror is routine when a TCP/other listener for the same server is still coming up
+ * alongside it, but the operations API can also be configured with only a domain socket (no
+ * port/securePort) — in that case this failure leaves it with no listener at all, which is worth a
+ * louder log than "lost a convenience mirror". Either way, also suppress/remove any TLS-mirror
+ * metadata already advertised for this socket (see markUdsBindFailed()) so a fronting proxy doesn't
+ * keep routing to a socket nothing is listening on.
+ */
+function handleDomainSocketBindFailure(port, server, err) {
+	httpComponent.markUdsBindFailed(port);
+	const message = `Failed to bind domain socket listener${server.name ? ` for '${server.name}'` : ''} at ${port}: ${err.message}. Continuing without this domain socket.`;
+	if (server.isOperationsServer && !hasOperationsTcpEndpoint()) {
+		harperLogger.fatal(
+			`${message} No other operations API endpoint (port/securePort) is configured — the operations API has no listener.`,
+			err
+		);
+	} else {
+		harperLogger.error(message, err);
+	}
+}
+
 let listening;
 function listenOnPorts() {
 	if (isBun) return listenOnPortsBun();
@@ -272,17 +307,7 @@ function listenOnPorts() {
 							harperLogger.info('Domain socket listening on ' + port);
 						})
 						.on('error', (err) => {
-							// A domain socket is a convenience mirror of the same-named TCP/other
-							// listeners in this Promise.all batch (e.g. the operations API's UDS
-							// alongside its TCP port) — rejecting here used to fail the whole batch,
-							// which aborted startup (process.exit in bin/run.ts's main()) over one
-							// socket, most commonly EINVAL from a rootPath-derived path exceeding the
-							// platform's ~107-byte sun_path limit. Fail soft: log and keep going so the
-							// TCP listener (and everything else) still comes up.
-							harperLogger.error(
-								`Failed to bind domain socket listener${server.name ? ` for '${server.name}'` : ''} at ${port}: ${err.message}. Continuing without this domain socket.`,
-								err
-							);
+							handleDomainSocketBindFailure(port, server, err);
 							resolve({ port, failed: true });
 						});
 				})
@@ -532,12 +557,9 @@ async function listenOnPortsBun() {
 								harperLogger.info('Domain socket listening on ' + port);
 							})
 							.on('error', (err) => {
-								// See the same fail-soft handling in listenOnPorts() above: a domain
+								// See handleDomainSocketBindFailure()/listenOnPorts() above: a domain
 								// socket bind failure must not abort the rest of this Promise.all batch.
-								harperLogger.error(
-									`Failed to bind domain socket listener at ${port}: ${err.message}. Continuing without this domain socket.`,
-									err
-								);
+								handleDomainSocketBindFailure(port, server, err);
 								resolve({ port, failed: true });
 							});
 					})

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -265,13 +265,26 @@ function listenOnPorts() {
 		if (port.includes?.('/')) {
 			if (existsSync(port)) unlinkSync(port);
 			listening.push(
-				new Promise((resolve, reject) => {
+				new Promise((resolve) => {
 					server
 						.listen({ path: port }, () => {
 							resolve({ port, name: server.name, protocol_name: server.protocol_name });
 							harperLogger.info('Domain socket listening on ' + port);
 						})
-						.on('error', reject);
+						.on('error', (err) => {
+							// A domain socket is a convenience mirror of the same-named TCP/other
+							// listeners in this Promise.all batch (e.g. the operations API's UDS
+							// alongside its TCP port) — rejecting here used to fail the whole batch,
+							// which aborted startup (process.exit in bin/run.ts's main()) over one
+							// socket, most commonly EINVAL from a rootPath-derived path exceeding the
+							// platform's ~107-byte sun_path limit. Fail soft: log and keep going so the
+							// TCP listener (and everything else) still comes up.
+							harperLogger.error(
+								`Failed to bind domain socket listener${server.name ? ` for '${server.name}'` : ''} at ${port}: ${err.message}. Continuing without this domain socket.`,
+								err
+							);
+							resolve({ port, failed: true });
+						});
 				})
 			);
 			continue;
@@ -512,13 +525,21 @@ async function listenOnPortsBun() {
 			if (port.includes?.('/')) {
 				if (existsSync(port)) unlinkSync(port);
 				listening.push(
-					new Promise((resolve, reject) => {
+					new Promise((resolve) => {
 						server
 							.listen({ path: port }, () => {
 								resolve({ port });
 								harperLogger.info('Domain socket listening on ' + port);
 							})
-							.on('error', reject);
+							.on('error', (err) => {
+								// See the same fail-soft handling in listenOnPorts() above: a domain
+								// socket bind failure must not abort the rest of this Promise.all batch.
+								harperLogger.error(
+									`Failed to bind domain socket listener at ${port}: ${err.message}. Continuing without this domain socket.`,
+									err
+								);
+								resolve({ port, failed: true });
+							});
 					})
 				);
 			} else {

--- a/unitTests/config/configUtils.test.js
+++ b/unitTests/config/configUtils.test.js
@@ -750,6 +750,35 @@ describe('Test configUtils module', () => {
 			expect(set_in_stub.args[4][1]).to.equal('path/for/rotated/logs');
 		});
 
+		it('Test a domainSocket exceeding the Unix socket path limit logs a warning but does not throw', () => {
+			const fake_validation = {
+				value: {
+					rootPath: '/' + 'a'.repeat(120),
+					threads: { count: 1 },
+					componentsRoot: '/yaml/components',
+					logging: { root: '/yaml/log', rotation: { path: '/yaml/log/rotated' } },
+					storage: { path: '/yaml/storage' },
+					operationsApi: { network: { domainSocket: 'operations-server' } },
+				},
+			};
+			config_validator_stub = sandbox.stub(configValidatorModule, 'configValidator').returns(fake_validation);
+			const logger_warn_stub = sandbox.stub(logger, 'warn');
+
+			const fake_config_doc = { toJSON: () => ({}), setIn: () => {} };
+
+			let error;
+			try {
+				validate_config(fake_config_doc);
+			} catch (err) {
+				error = err;
+			}
+
+			expect(error, `Error was: ${error}`).to.not.exist;
+			expect(logger_warn_stub.calledOnce).to.be.true;
+			expect(logger_warn_stub.firstCall.args[0]).to.include('Unix domain socket path limit');
+			logger_warn_stub.restore();
+		});
+
 		it('Test error is thrown if operationsApi securePort collides with http securePort', () => {
 			const fake_config_doc = {
 				toJSON: () => ({

--- a/unitTests/server/threads/threadServerListenOnPorts.test.js
+++ b/unitTests/server/threads/threadServerListenOnPorts.test.js
@@ -1,77 +1,57 @@
 'use strict';
 
-const { expect } = require('chai');
-const sinon = require('sinon');
-const rewire = require('rewire');
-const EventEmitter = require('node:events');
+const assert = require('node:assert/strict');
+const net = require('node:net');
+const os = require('node:os');
+const path = require('node:path');
 const { SERVERS } = require('#src/server/serverRegistry');
+const { listenOnPorts } = require('#src/server/threads/threadServer');
 
 /**
  * A too-long Unix domain socket path (e.g. the operations API's domain socket under a deeply
  * nested rootPath, such as a `.claude/worktrees/<name>` checkout) fails at listen() time with an
- * async 'error' event (EINVAL), not a synchronous throw. Before this fix, that rejected the
- * Promise.all() covering every listener started in the same batch — TCP ports included — which
- * aborted the whole startup sequence (see bin/run.ts's main(), which process.exit(1)s on any
- * rejection from startHTTPThreads()).
+ * async 'error' event (EINVAL/ENAMETOOLONG), not a synchronous throw. Before this fix, that
+ * rejected the Promise.all() covering every listener started in the same batch — TCP ports
+ * included — which aborted the whole startup sequence (see bin/run.ts's main(), which
+ * process.exit(1)s on any rejection from startHTTPThreads()).
+ *
+ * Uses real net.Server instances and a real overlong socket path — rather than rewire and a
+ * stubbed logger — so the fail-soft behavior is exercised through listenOnPorts()'s real,
+ * exported implementation. listenOnPorts() caches its result on a module-level variable after the
+ * first call, so both assertions read from one shared real invocation instead of each resetting
+ * that private state.
  */
 describe('threadServer listenOnPorts — domain socket fail-soft', () => {
-	let threadServer;
+	const longSocketPath = path.join(os.tmpdir(), `harper-1907-unit-test-${'a'.repeat(200)}.sock`);
+	let failingServer;
+	let tcpServer;
+	let results;
 
-	beforeEach(() => {
-		threadServer = rewire('#src/server/threads/threadServer');
-		// SERVERS is a shared module-level singleton; make sure no other test/process state leaks in.
-		for (const key of Object.keys(SERVERS)) delete SERVERS[key];
-		threadServer.__set__('listening', undefined);
+	before(async () => {
+		failingServer = net.createServer();
+		tcpServer = net.createServer();
+		SERVERS[longSocketPath] = failingServer;
+		SERVERS['0'] = tcpServer;
+
+		results = await listenOnPorts();
 	});
 
-	afterEach(() => {
-		for (const key of Object.keys(SERVERS)) delete SERVERS[key];
-		sinon.restore();
+	after(() => {
+		failingServer.close();
+		tcpServer.close();
+		delete SERVERS[longSocketPath];
+		delete SERVERS['0'];
 	});
 
-	function makeFakeServer({ failWith } = {}) {
-		const server = new EventEmitter();
-		server.name = 'fake-server';
-		server.listen = (_opts, cb) => {
-			process.nextTick(() => {
-				if (failWith) server.emit('error', failWith);
-				else cb();
-			});
-			return server;
-		};
-		return server;
-	}
-
-	it('resolves (does not reject) when a domain socket listener fails, and logs the error', async () => {
-		const harperLogger = threadServer.__get__('harperLogger');
-		const errorSpy = sinon.stub(harperLogger, 'error');
-		const einval = Object.assign(new Error('listen EINVAL: invalid argument'), { code: 'EINVAL' });
-		const failingSocketPath = '/tmp/harper-1839-unit-test-domain-socket-simulated-einval';
-
-		SERVERS[failingSocketPath] = makeFakeServer({ failWith: einval });
-
-		const results = await threadServer.listenOnPorts();
-
-		expect(results).to.have.lengthOf(1);
-		expect(results[0]).to.include({ port: failingSocketPath, failed: true });
-		expect(errorSpy.calledOnce).to.equal(true);
-		expect(errorSpy.firstCall.args[0]).to.include(failingSocketPath);
+	it('resolves (does not reject) when a domain socket listener fails', () => {
+		const failing = results.find((result) => result.port === longSocketPath);
+		assert.ok(failing, 'expected a result for the failing domain socket');
+		assert.equal(failing.failed, true);
 	});
 
-	it('still resolves a working TCP listener even when a sibling domain socket in the same batch fails', async () => {
-		const harperLogger = threadServer.__get__('harperLogger');
-		sinon.stub(harperLogger, 'error');
-		sinon.stub(harperLogger, 'trace');
-		const einval = Object.assign(new Error('listen EINVAL: invalid argument'), { code: 'EINVAL' });
-		const failingSocketPath = '/tmp/harper-1839-unit-test-domain-socket-simulated-einval-2';
-
-		SERVERS[failingSocketPath] = makeFakeServer({ failWith: einval });
-		SERVERS['19925'] = makeFakeServer();
-
-		const results = await threadServer.listenOnPorts();
-
-		const ports = results.map((r) => r.port);
-		expect(ports).to.include(failingSocketPath);
-		expect(ports).to.include('19925');
+	it('still resolves a working TCP listener in the same batch', () => {
+		const tcp = results.find((result) => result.port === '0');
+		assert.ok(tcp, 'expected a result for the sibling TCP listener');
+		assert.equal(tcp.failed, undefined);
 	});
 });

--- a/unitTests/server/threads/threadServerListenOnPorts.test.js
+++ b/unitTests/server/threads/threadServerListenOnPorts.test.js
@@ -8,21 +8,31 @@ const { SERVERS } = require('#src/server/serverRegistry');
 const { listenOnPorts } = require('#src/server/threads/threadServer');
 
 /**
- * A too-long Unix domain socket path (e.g. the operations API's domain socket under a deeply
- * nested rootPath, such as a `.claude/worktrees/<name>` checkout) fails at listen() time with an
- * async 'error' event (EINVAL/ENAMETOOLONG), not a synchronous throw. Before this fix, that
- * rejected the Promise.all() covering every listener started in the same batch — TCP ports
+ * A domain socket bind can fail at listen() time with an async 'error' event (e.g. EINVAL from an
+ * overlong path under a deeply nested rootPath, such as a `.claude/worktrees/<name>` checkout,
+ * or ENOENT/EACCES from a missing parent directory), not a synchronous throw. Before this fix,
+ * that rejected the Promise.all() covering every listener started in the same batch — TCP ports
  * included — which aborted the whole startup sequence (see bin/run.ts's main(), which
  * process.exit(1)s on any rejection from startHTTPThreads()).
  *
- * Uses real net.Server instances and a real overlong socket path — rather than rewire and a
- * stubbed logger — so the fail-soft behavior is exercised through listenOnPorts()'s real,
- * exported implementation. listenOnPorts() caches its result on a module-level variable after the
- * first call, so both assertions read from one shared real invocation instead of each resetting
- * that private state.
+ * This uses a socket path under a non-existent parent directory (not an overlong path) to trigger
+ * the failure: an overlong `sun_path` isn't a portable trigger across our supported Node versions
+ * — on Node 22.x, libuv silently truncates the path and *succeeds* (the socket file lands at the
+ * truncated path, not the requested one) instead of raising EINVAL like Node 24+ does. A missing
+ * parent directory reliably produces an async bind error on every supported Node version.
+ *
+ * Uses real net.Server instances — rather than rewire and a stubbed logger — so the fail-soft
+ * behavior is exercised through listenOnPorts()'s real, exported implementation. listenOnPorts()
+ * caches its result on a module-level variable after the first call, so both assertions read from
+ * one shared real invocation instead of each resetting that private state.
  */
 describe('threadServer listenOnPorts — domain socket fail-soft', () => {
-	const longSocketPath = path.join(os.tmpdir(), `harper-1907-unit-test-${'a'.repeat(200)}.sock`);
+	const failingSocketPath = path.join(
+		os.tmpdir(),
+		`harper-1907-unit-test-${process.pid}`,
+		'nonexistent-dir',
+		'op.sock'
+	);
 	let failingServer;
 	let tcpServer;
 	let results;
@@ -30,7 +40,7 @@ describe('threadServer listenOnPorts — domain socket fail-soft', () => {
 	before(async () => {
 		failingServer = net.createServer();
 		tcpServer = net.createServer();
-		SERVERS[longSocketPath] = failingServer;
+		SERVERS[failingSocketPath] = failingServer;
 		SERVERS['0'] = tcpServer;
 
 		results = await listenOnPorts();
@@ -39,12 +49,12 @@ describe('threadServer listenOnPorts — domain socket fail-soft', () => {
 	after(() => {
 		failingServer.close();
 		tcpServer.close();
-		delete SERVERS[longSocketPath];
+		delete SERVERS[failingSocketPath];
 		delete SERVERS['0'];
 	});
 
 	it('resolves (does not reject) when a domain socket listener fails', () => {
-		const failing = results.find((result) => result.port === longSocketPath);
+		const failing = results.find((result) => result.port === failingSocketPath);
 		assert.ok(failing, 'expected a result for the failing domain socket');
 		assert.equal(failing.failed, true);
 	});

--- a/unitTests/server/threads/threadServerListenOnPorts.test.js
+++ b/unitTests/server/threads/threadServerListenOnPorts.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+const rewire = require('rewire');
+const EventEmitter = require('node:events');
+const { SERVERS } = require('#src/server/serverRegistry');
+
+/**
+ * A too-long Unix domain socket path (e.g. the operations API's domain socket under a deeply
+ * nested rootPath, such as a `.claude/worktrees/<name>` checkout) fails at listen() time with an
+ * async 'error' event (EINVAL), not a synchronous throw. Before this fix, that rejected the
+ * Promise.all() covering every listener started in the same batch — TCP ports included — which
+ * aborted the whole startup sequence (see bin/run.ts's main(), which process.exit(1)s on any
+ * rejection from startHTTPThreads()).
+ */
+describe('threadServer listenOnPorts — domain socket fail-soft', () => {
+	let threadServer;
+
+	beforeEach(() => {
+		threadServer = rewire('#src/server/threads/threadServer');
+		// SERVERS is a shared module-level singleton; make sure no other test/process state leaks in.
+		for (const key of Object.keys(SERVERS)) delete SERVERS[key];
+		threadServer.__set__('listening', undefined);
+	});
+
+	afterEach(() => {
+		for (const key of Object.keys(SERVERS)) delete SERVERS[key];
+		sinon.restore();
+	});
+
+	function makeFakeServer({ failWith } = {}) {
+		const server = new EventEmitter();
+		server.name = 'fake-server';
+		server.listen = (_opts, cb) => {
+			process.nextTick(() => {
+				if (failWith) server.emit('error', failWith);
+				else cb();
+			});
+			return server;
+		};
+		return server;
+	}
+
+	it('resolves (does not reject) when a domain socket listener fails, and logs the error', async () => {
+		const harperLogger = threadServer.__get__('harperLogger');
+		const errorSpy = sinon.stub(harperLogger, 'error');
+		const einval = Object.assign(new Error('listen EINVAL: invalid argument'), { code: 'EINVAL' });
+		const failingSocketPath = '/tmp/harper-1839-unit-test-domain-socket-simulated-einval';
+
+		SERVERS[failingSocketPath] = makeFakeServer({ failWith: einval });
+
+		const results = await threadServer.listenOnPorts();
+
+		expect(results).to.have.lengthOf(1);
+		expect(results[0]).to.include({ port: failingSocketPath, failed: true });
+		expect(errorSpy.calledOnce).to.equal(true);
+		expect(errorSpy.firstCall.args[0]).to.include(failingSocketPath);
+	});
+
+	it('still resolves a working TCP listener even when a sibling domain socket in the same batch fails', async () => {
+		const harperLogger = threadServer.__get__('harperLogger');
+		sinon.stub(harperLogger, 'error');
+		sinon.stub(harperLogger, 'trace');
+		const einval = Object.assign(new Error('listen EINVAL: invalid argument'), { code: 'EINVAL' });
+		const failingSocketPath = '/tmp/harper-1839-unit-test-domain-socket-simulated-einval-2';
+
+		SERVERS[failingSocketPath] = makeFakeServer({ failWith: einval });
+		SERVERS['19925'] = makeFakeServer();
+
+		const results = await threadServer.listenOnPorts();
+
+		const ports = results.map((r) => r.port);
+		expect(ports).to.include(failingSocketPath);
+		expect(ports).to.include('19925');
+	});
+});

--- a/unitTests/server/threads/threadServerListenOnPorts.test.js
+++ b/unitTests/server/threads/threadServerListenOnPorts.test.js
@@ -1,30 +1,18 @@
 'use strict';
 
-const assert = require('node:assert/strict');
+const assert = require('node:assert');
 const net = require('node:net');
 const os = require('node:os');
 const path = require('node:path');
 const { SERVERS } = require('#src/server/serverRegistry');
-const { listenOnPorts } = require('#src/server/threads/threadServer');
+const { listenOnDomainSocket, listenOnPorts } = require('#src/server/threads/threadServer');
+const { getDomainSocketPathMaxBytes } = require('#src/utility/domainSocket');
 
 /**
- * A domain socket bind can fail at listen() time with an async 'error' event (e.g. EINVAL from an
- * overlong path under a deeply nested rootPath, such as a `.claude/worktrees/<name>` checkout,
- * or ENOENT/EACCES from a missing parent directory), not a synchronous throw. Before this fix,
- * that rejected the Promise.all() covering every listener started in the same batch — TCP ports
- * included — which aborted the whole startup sequence (see bin/run.ts's main(), which
- * process.exit(1)s on any rejection from startHTTPThreads()).
- *
- * This uses a socket path under a non-existent parent directory (not an overlong path) to trigger
- * the failure: an overlong `sun_path` isn't a portable trigger across our supported Node versions
- * — on Node 22.x, libuv silently truncates the path and *succeeds* (the socket file lands at the
- * truncated path, not the requested one) instead of raising EINVAL like Node 24+ does. A missing
- * parent directory reliably produces an async bind error on every supported Node version.
- *
- * Uses real net.Server instances — rather than rewire and a stubbed logger — so the fail-soft
- * behavior is exercised through listenOnPorts()'s real, exported implementation. listenOnPorts()
- * caches its result on a module-level variable after the first call, so both assertions read from
- * one shared real invocation instead of each resetting that private state.
+ * An overlong path is the only domain-socket bind failure that startup may tolerate. Node versions
+ * differ on whether they reject or truncate such a path, so the classification itself is tested
+ * directly. A missing parent reliably produces a filesystem error and verifies the real
+ * listenOnPorts() batch rejects, preserving bin/run.ts's process.exit(1) startup path.
  */
 describe('threadServer listenOnPorts — domain socket fail-soft', () => {
 	const failingSocketPath = path.join(
@@ -34,34 +22,33 @@ describe('threadServer listenOnPorts — domain socket fail-soft', () => {
 		'op.sock'
 	);
 	let failingServer;
-	let tcpServer;
-	let results;
-
-	before(async () => {
-		failingServer = net.createServer();
-		tcpServer = net.createServer();
-		SERVERS[failingSocketPath] = failingServer;
-		SERVERS['0'] = tcpServer;
-
-		results = await listenOnPorts();
-	});
+	let listeningServer;
+	const listeningSocketPath = path.join(os.tmpdir(), `harper-1907-listening-${process.pid}.sock`);
 
 	after(() => {
-		failingServer.close();
-		tcpServer.close();
+		if (failingServer?.listening) failingServer.close();
+		if (listeningServer?.listening) listeningServer.close();
 		delete SERVERS[failingSocketPath];
-		delete SERVERS['0'];
 	});
 
-	it('resolves (does not reject) when a domain socket listener fails', () => {
-		const failing = results.find((result) => result.port === failingSocketPath);
-		assert.ok(failing, 'expected a result for the failing domain socket');
-		assert.equal(failing.failed, true);
+	it('skips only an overlong domain socket path', async () => {
+		const overlongPath = '/' + 'a'.repeat(getDomainSocketPathMaxBytes());
+		const overlongServer = net.createServer();
+		const result = await listenOnDomainSocket(overlongPath, overlongServer);
+		assert.strictEqual(result.failed, true);
+		assert.strictEqual(overlongServer.listening, false);
 	});
 
-	it('still resolves a working TCP listener in the same batch', () => {
-		const tcp = results.find((result) => result.port === '0');
-		assert.ok(tcp, 'expected a result for the sibling TCP listener');
-		assert.equal(tcp.failed, undefined);
+	it('removes its bind-error listener after a successful listen', async () => {
+		listeningServer = net.createServer();
+		await listenOnDomainSocket(listeningSocketPath, listeningServer);
+		assert.strictEqual(listeningServer.listenerCount('error'), 0);
+		await new Promise((resolve) => listeningServer.close(resolve));
+	});
+
+	it('rejects startup for a non-path-length domain socket failure', async () => {
+		failingServer = net.createServer();
+		SERVERS[failingSocketPath] = failingServer;
+		await assert.rejects(listenOnPorts());
 	});
 });

--- a/unitTests/server/udsMirror.test.js
+++ b/unitTests/server/udsMirror.test.js
@@ -17,6 +17,7 @@ const {
 	cleanupUdsFiles,
 	cleanupSocketsDirectory,
 	enableProxyProtocol,
+	markUdsBindFailed,
 } = require('#src/server/http');
 
 const TEST_SOCKETS_DIR = path.join(testUtils.ENV_DIR_PATH, 'sockets');
@@ -294,6 +295,25 @@ describe('UDS mirror (writeUdsMetadata, cleanup helpers)', () => {
 		it('cleanupUdsFiles does not throw when files are already gone', () => {
 			registerUdsCleanupPaths(path.join(TEST_SOCKETS_DIR, 'ghost.sock'), path.join(TEST_SOCKETS_DIR, 'ghost.yaml'));
 			assert.doesNotThrow(() => cleanupUdsFiles());
+		});
+	});
+
+	// ─── markUdsBindFailed ─────────────────────────────────────────────────────
+
+	describe('markUdsBindFailed', () => {
+		it('removes a YAML metadata file already written for the failed socket', () => {
+			const sockPath = path.join(TEST_SOCKETS_DIR, 'failed.sock');
+			const yamlPath = path.join(TEST_SOCKETS_DIR, 'failed.yaml');
+			fs.writeFileSync(yamlPath, 'stale: metadata\n');
+			registerUdsCleanupPaths(sockPath, yamlPath);
+
+			markUdsBindFailed(sockPath);
+
+			assert.ok(!fs.existsSync(yamlPath), 'stale metadata for the failed mirror should be removed');
+		});
+
+		it('does not throw when the socket was never registered or has no metadata file on disk', () => {
+			assert.doesNotThrow(() => markUdsBindFailed(path.join(TEST_SOCKETS_DIR, 'never-registered.sock')));
 		});
 	});
 

--- a/unitTests/utility/domainSocket.test.js
+++ b/unitTests/utility/domainSocket.test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const assert = require('node:assert');
+const { getDomainSocketPathMaxBytes, isDomainSocketPathTooLong } = require('#src/utility/domainSocket');
+
+describe('domain socket path limits', () => {
+	it('uses the platform sockaddr_un.sun_path capacity', () => {
+		assert.strictEqual(getDomainSocketPathMaxBytes('darwin'), 103);
+		assert.strictEqual(getDomainSocketPathMaxBytes('linux'), 107);
+		assert.strictEqual(getDomainSocketPathMaxBytes('win32'), 107);
+	});
+
+	it('counts path bytes rather than JavaScript characters', () => {
+		assert.strictEqual(isDomainSocketPathTooLong('a'.repeat(107), 'linux'), false);
+		assert.strictEqual(isDomainSocketPathTooLong('a'.repeat(108), 'linux'), true);
+		assert.strictEqual(isDomainSocketPathTooLong('é'.repeat(54), 'linux'), true);
+	});
+});

--- a/unitTests/validation/configValidator.test.js
+++ b/unitTests/validation/configValidator.test.js
@@ -198,6 +198,48 @@ describe('Test configValidator module', () => {
 		});
 	});
 
+	describe('getDomainSocketPathLengthWarning', () => {
+		const { getDomainSocketPathLengthWarning, UDS_PATH_MAX_BYTES } = config_val;
+
+		it('warns when a relative domainSocket resolves past the platform Unix socket path limit', () => {
+			// The real-world trigger: domainSocket left at its default relative name, with only
+			// rootPath being long (e.g. a nested `.claude/worktrees/<name>` checkout).
+			const longRoot = path.join(HDB_ROOT, 'a'.repeat(120));
+			const warning = getDomainSocketPathLengthWarning(longRoot, 'operations-server');
+
+			expect(warning).to.include('operationsApi.network.domainSocket');
+			expect(warning).to.include('exceeds the');
+			expect(warning).to.include('Unix domain socket path limit');
+		});
+
+		it('warns when an absolute domainSocket itself exceeds the limit', () => {
+			const longAbsolute = '/' + 'a'.repeat(120);
+			const warning = getDomainSocketPathLengthWarning('/hdb', longAbsolute);
+
+			expect(warning).to.include('Unix domain socket path limit');
+		});
+
+		it('returns null when the resolved path is within the platform limit', () => {
+			expect(getDomainSocketPathLengthWarning('/hdb', 'operations-server')).to.equal(null);
+		});
+
+		it('returns null when domainSocket is disabled (false)', () => {
+			const longRoot = path.join(HDB_ROOT, 'a'.repeat(120));
+			expect(getDomainSocketPathLengthWarning(longRoot, false)).to.equal(null);
+		});
+
+		it('resolves a path right at the limit as OK and one byte over as a warning', () => {
+			// 5-char root + '/' + N-char socket name must equal UDS_PATH_MAX_BYTES exactly at the
+			// boundary; asserting on both sides guards against an off-by-one in the comparison.
+			const root = '/root'; // 5 bytes
+			const atLimit = 'a'.repeat(UDS_PATH_MAX_BYTES - root.length - 1); // -1 for the joining '/'
+			const overLimit = atLimit + 'a';
+
+			expect(getDomainSocketPathLengthWarning(root, atLimit)).to.equal(null);
+			expect(getDomainSocketPathLengthWarning(root, overLimit)).to.include('Unix domain socket path limit');
+		});
+	});
+
 	describe('Directory-path pattern is a linear-time denylist (ReDoS regression, #1779)', () => {
 		const directoryPathPattern = config_val.__get__('DIRECTORY_PATH_PATTERN');
 

--- a/unitTests/validation/configValidator.test.js
+++ b/unitTests/validation/configValidator.test.js
@@ -256,6 +256,21 @@ describe('Test configValidator module', () => {
 			expect(warning).to.include('Unix domain socket path limit on win32');
 			expect(getDomainSocketPathLengthWarning('C:\\hdb', 'C:\\short', 'win32')).to.equal(null);
 		});
+
+		it('resolves a relative rootPath against process.cwd() the same way getConfigPath() does, matching runtime EINVAL', () => {
+			// getConfigPath() (configUtils.ts) resolves the config-file value with
+			// `path.resolve(rootPath, value)`; from a deeply nested cwd, a short-looking relative
+			// rootPath can still resolve past the byte limit at runtime, so this must warn too.
+			const relativeRoot = path.join('a'.repeat(120), 'b'.repeat(120));
+			const warning = getDomainSocketPathLengthWarning(relativeRoot, 'operations-server');
+
+			expect(warning).to.include(path.resolve(relativeRoot, 'operations-server'));
+			expect(warning).to.include('Unix domain socket path limit');
+		});
+
+		it('does not warn when a relative rootPath resolves within the limit', () => {
+			expect(getDomainSocketPathLengthWarning('relative/root', 'operations-server')).to.equal(null);
+		});
 	});
 
 	describe('Directory-path pattern is a linear-time denylist (ReDoS regression, #1779)', () => {

--- a/unitTests/validation/configValidator.test.js
+++ b/unitTests/validation/configValidator.test.js
@@ -238,6 +238,24 @@ describe('Test configValidator module', () => {
 			expect(getDomainSocketPathLengthWarning(root, atLimit)).to.equal(null);
 			expect(getDomainSocketPathLengthWarning(root, overLimit)).to.include('Unix domain socket path limit');
 		});
+
+		it('applies the 103-byte darwin limit regardless of the host platform running the test', () => {
+			const root = '/root';
+			const overDarwinLimit = 'a'.repeat(103 - root.length - 1 + 1);
+
+			expect(getDomainSocketPathLengthWarning(root, overDarwinLimit, 'darwin')).to.include(
+				'Unix domain socket path limit on darwin'
+			);
+			expect(getDomainSocketPathLengthWarning(root, overDarwinLimit, 'linux')).to.equal(null);
+		});
+
+		it('resolves win32 paths with backslash join semantics regardless of the host platform running the test', () => {
+			const warning = getDomainSocketPathLengthWarning('C:\\hdb', 'a'.repeat(120), 'win32');
+
+			expect(warning).to.include('C:\\hdb\\' + 'a'.repeat(120));
+			expect(warning).to.include('Unix domain socket path limit on win32');
+			expect(getDomainSocketPathLengthWarning('C:\\hdb', 'C:\\short', 'win32')).to.equal(null);
+		});
 	});
 
 	describe('Directory-path pattern is a linear-time denylist (ReDoS regression, #1779)', () => {

--- a/utility/domainSocket.ts
+++ b/utility/domainSocket.ts
@@ -1,0 +1,7 @@
+export function getDomainSocketPathMaxBytes(platform = process.platform) {
+	return platform === 'darwin' ? 103 : 107;
+}
+
+export function isDomainSocketPathTooLong(socketPath: string, platform = process.platform) {
+	return Buffer.byteLength(socketPath) > getDomainSocketPathMaxBytes(platform);
+}

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import * as hdbLogger from '../utility/logging/harper_logger.ts';
 import * as hdbUtils from '../utility/common_utils.ts';
 import * as hdbTerms from '../utility/hdbTerms.ts';
+import { getDomainSocketPathMaxBytes } from '../utility/domainSocket.ts';
 import * as validator from './validationWrapper.ts';
 
 const DEFAULT_LOG_FOLDER = 'log';
@@ -415,17 +416,10 @@ function validatePath(value, helpers) {
 
 // A Unix domain socket path is stored in a fixed-size `sockaddr_un.sun_path` buffer that must
 // also fit a trailing NUL — 108 bytes on Linux (107 usable), 104 on macOS (103 usable). A path
-// at or beyond that limit fails at listen() time with a bare EINVAL (see listenOnPorts() in
-// server/threads/threadServer.js, which now fails soft on that error rather than aborting
-// startup). This is a *warning*, not a schema error: a long rootPath is common (nested worktree
-// checkouts, deep install paths) and losing the domain socket costs nothing but a convenience
-// mirror of the TCP operations-API port — it must not block config validation / startup the way
-// a real schema error does (validateConfig in configUtils.ts throws on any Joi error).
-function udsPathMaxBytes(platform) {
-	return platform === 'darwin' ? 103 : 107;
-}
-
-export const UDS_PATH_MAX_BYTES = udsPathMaxBytes(process.platform);
+// beyond that limit can fail at listen() time or be silently truncated, depending on the supported
+// Node version. threadServer.js therefore skips only this known-overlong listener before calling
+// listen(). This remains a warning rather than a schema error so configured TCP endpoints can start.
+export const UDS_PATH_MAX_BYTES = getDomainSocketPathMaxBytes();
 
 /**
  * Returns a warning message if `domainSocket` (resolved against `hdbRootPath`) would exceed the
@@ -452,9 +446,9 @@ export function getDomainSocketPathLengthWarning(hdbRootPath, domainSocket, plat
 		resolvedValue = platformPath.resolve(hdbRootPath, domainSocket);
 	}
 	const byteLength = Buffer.byteLength(resolvedValue);
-	const limit = udsPathMaxBytes(platform);
+	const limit = getDomainSocketPathMaxBytes(platform);
 	if (byteLength <= limit) return null;
-	return `operationsApi.network.domainSocket resolves to "${resolvedValue}" (${byteLength} bytes), which exceeds the ${limit}-byte Unix domain socket path limit on ${platform}. The operations API will start without its domain socket (the TCP port is unaffected) — use a shorter rootPath, set operationsApi.network.domainSocket to a short absolute path outside rootPath, or set it to false to silence this warning.`;
+	return `operationsApi.network.domainSocket resolves to "${resolvedValue}" (${byteLength} bytes), which exceeds the ${limit}-byte Unix domain socket path limit on ${platform}. The domain socket may be unavailable or truncated; any configured TCP endpoint is unaffected — use a shorter rootPath, set operationsApi.network.domainSocket to a short absolute path outside rootPath, or set it to false to silence this warning.`;
 }
 
 function validateRotationMaxSize(value, helpers) {

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -413,6 +413,38 @@ function validatePath(value, helpers) {
 	}
 }
 
+// A Unix domain socket path is stored in a fixed-size `sockaddr_un.sun_path` buffer that must
+// also fit a trailing NUL — 108 bytes on Linux (107 usable), 104 on macOS (103 usable). A path
+// at or beyond that limit fails at listen() time with a bare EINVAL (see listenOnPorts() in
+// server/threads/threadServer.js, which now fails soft on that error rather than aborting
+// startup). This is a *warning*, not a schema error: a long rootPath is common (nested worktree
+// checkouts, deep install paths) and losing the domain socket costs nothing but a convenience
+// mirror of the TCP operations-API port — it must not block config validation / startup the way
+// a real schema error does (validateConfig in configUtils.ts throws on any Joi error).
+export const UDS_PATH_MAX_BYTES = process.platform === 'darwin' ? 103 : 107;
+
+/**
+ * Returns a warning message if `domainSocket` (resolved against `hdbRootPath`) would exceed the
+ * platform's Unix domain socket path limit, or null if it fits (or domainSocket is falsy/non-string,
+ * i.e. disabled). Called from configUtils.ts's validateConfig, after the Joi schema (which resolves
+ * the default) has already run — non-blocking, so it's a plain function rather than a Joi custom rule.
+ */
+export function getDomainSocketPathLengthWarning(hdbRootPath, domainSocket) {
+	if (!domainSocket || typeof domainSocket !== 'string') return null;
+
+	let resolvedValue;
+	if (domainSocket.startsWith('~/')) {
+		resolvedValue = path.join(os.homedir(), domainSocket.slice(1));
+	} else if (path.isAbsolute(domainSocket)) {
+		resolvedValue = domainSocket;
+	} else {
+		resolvedValue = path.join(hdbRootPath, domainSocket);
+	}
+	const byteLength = Buffer.byteLength(resolvedValue);
+	if (byteLength <= UDS_PATH_MAX_BYTES) return null;
+	return `operationsApi.network.domainSocket resolves to "${resolvedValue}" (${byteLength} bytes), which exceeds the ${UDS_PATH_MAX_BYTES}-byte Unix domain socket path limit on ${process.platform}. The operations API will start without its domain socket (the TCP port is unaffected) — use a shorter rootPath, set operationsApi.network.domainSocket to a short absolute path outside rootPath, or set it to false to silence this warning.`;
+}
+
 function validateRotationMaxSize(value, helpers) {
 	const unit = value.slice(-1);
 	if (unit !== 'G' && unit !== 'M' && unit !== 'K') {

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -421,28 +421,36 @@ function validatePath(value, helpers) {
 // checkouts, deep install paths) and losing the domain socket costs nothing but a convenience
 // mirror of the TCP operations-API port — it must not block config validation / startup the way
 // a real schema error does (validateConfig in configUtils.ts throws on any Joi error).
-export const UDS_PATH_MAX_BYTES = process.platform === 'darwin' ? 103 : 107;
+function udsPathMaxBytes(platform) {
+	return platform === 'darwin' ? 103 : 107;
+}
+
+export const UDS_PATH_MAX_BYTES = udsPathMaxBytes(process.platform);
 
 /**
  * Returns a warning message if `domainSocket` (resolved against `hdbRootPath`) would exceed the
  * platform's Unix domain socket path limit, or null if it fits (or domainSocket is falsy/non-string,
  * i.e. disabled). Called from configUtils.ts's validateConfig, after the Joi schema (which resolves
  * the default) has already run — non-blocking, so it's a plain function rather than a Joi custom rule.
+ * `platform` defaults to `process.platform` but is accepted as a parameter so the path-resolution
+ * logic for every platform can be unit tested from any CI host.
  */
-export function getDomainSocketPathLengthWarning(hdbRootPath, domainSocket) {
+export function getDomainSocketPathLengthWarning(hdbRootPath, domainSocket, platform = process.platform) {
 	if (!domainSocket || typeof domainSocket !== 'string') return null;
 
+	const platformPath = platform === 'win32' ? path.win32 : path.posix;
 	let resolvedValue;
 	if (domainSocket.startsWith('~/')) {
-		resolvedValue = path.join(os.homedir(), domainSocket.slice(1));
-	} else if (path.isAbsolute(domainSocket)) {
+		resolvedValue = platformPath.join(os.homedir(), domainSocket.slice(1));
+	} else if (platformPath.isAbsolute(domainSocket)) {
 		resolvedValue = domainSocket;
 	} else {
-		resolvedValue = path.join(hdbRootPath, domainSocket);
+		resolvedValue = platformPath.join(hdbRootPath, domainSocket);
 	}
 	const byteLength = Buffer.byteLength(resolvedValue);
-	if (byteLength <= UDS_PATH_MAX_BYTES) return null;
-	return `operationsApi.network.domainSocket resolves to "${resolvedValue}" (${byteLength} bytes), which exceeds the ${UDS_PATH_MAX_BYTES}-byte Unix domain socket path limit on ${process.platform}. The operations API will start without its domain socket (the TCP port is unaffected) — use a shorter rootPath, set operationsApi.network.domainSocket to a short absolute path outside rootPath, or set it to false to silence this warning.`;
+	const limit = udsPathMaxBytes(platform);
+	if (byteLength <= limit) return null;
+	return `operationsApi.network.domainSocket resolves to "${resolvedValue}" (${byteLength} bytes), which exceeds the ${limit}-byte Unix domain socket path limit on ${platform}. The operations API will start without its domain socket (the TCP port is unaffected) — use a shorter rootPath, set operationsApi.network.domainSocket to a short absolute path outside rootPath, or set it to false to silence this warning.`;
 }
 
 function validateRotationMaxSize(value, helpers) {

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -445,7 +445,11 @@ export function getDomainSocketPathLengthWarning(hdbRootPath, domainSocket, plat
 	} else if (platformPath.isAbsolute(domainSocket)) {
 		resolvedValue = domainSocket;
 	} else {
-		resolvedValue = platformPath.join(hdbRootPath, domainSocket);
+		// getConfigPath() (configUtils.ts) resolves this same value at runtime with
+		// `path.resolve(rootPath, value)`, not `.join()` — when rootPath is itself relative (the
+		// `rootPath` config value has no absolute-path requirement), resolve() folds in the process's
+		// cwd while join() would leave the result relative, undercounting its real byte length.
+		resolvedValue = platformPath.resolve(hdbRootPath, domainSocket);
 	}
 	const byteLength = Buffer.byteLength(resolvedValue);
 	const limit = udsPathMaxBytes(platform);


### PR DESCRIPTION
## What / why

The operations API's Unix-domain-socket path is derived from `rootPath` by default. When that path exceeds `sockaddr_un.sun_path` (107 usable bytes on Linux, 103 on macOS), supported Node versions do not behave consistently: some reject `listen()`, while others silently truncate the path and bind a socket clients cannot reach at the configured name.

That known, deterministic path-length condition should not prevent a configured TCP endpoint from starting. Every other operations API listener failure is catastrophic and must reject startup so `bin/run.ts` exits non-zero.

## Changes

- Preflight UDS paths using byte length and skip only paths beyond the platform limit. This avoids both rejected and silently truncated binds.
- Keep every actual `listen()` failure hard: the listener promise rejects, including permission, missing-parent, address-conflict, and other filesystem/runtime errors.
- In single-thread mode, explicitly await the cached listener batch so a bind rejection reaches the top-level non-zero exit path.
- Remove the temporary bind-error listener after a successful listen, preventing later live-server errors from being misclassified as bind failures.
- Warn on an overlong configured operations socket with conditional wording: the domain socket may be unavailable/truncated; any separately configured TCP endpoint is unaffected.
- Suppress proxy discovery metadata only for the preflight-skipped overlong UDS path.

## Test notes

- Added coverage for platform limits and UTF-8 byte counting.
- Added real `net.Server` coverage proving an overlong path is skipped, an in-limit bind removes its temporary error listener, and a non-path-length filesystem bind failure rejects startup.
- Validation/config suites: 142 passing.
- Focused UDS/server/utility suites: 33 passing.
- Main unit suite: 3,800 passing, 188 pending.
- Resources unit suite: 1,251 passing, 14 pending.
- Build, lint, and formatting checks pass locally.
- The full integration run reached one pre-existing QA-269 `SQL UPDATE resets TTL` failure; all UDS/startup coverage and the remaining integration run passed.

## Review coverage

- Cross-model review: Gemini completed; its Node-version truncation finding led to the preflight check. The local Claude leg timed out before producing a usable review; the repository's Claude review workflow will re-run on this push.

No configuration or API surface was added, so no documentation companion is needed.

Generated with Codex.
