### PR TITLE
fix: remove duplicate assert in RESTProperties-test

### DIFF
--- a/unitTests/apiTests/RESTProperties-test.mjs
+++ b/unitTests/apiTests/RESTProperties-test.mjs
@@ -326,10 +326,7 @@ describe('test REST with property updates', function () {
 				}
 			);
 			assert(
-			assert(
 				Array.isArray(response.data) && response.data.some((record) => record.title === 'title0'),
-				`SELECT * FROM data.FourProp did not return title0: ${preview(response)}`
-			);
 				`SELECT * FROM data.FourProp did not return title0: ${preview(response)}`
 			);
 		});


### PR DESCRIPTION
## Summary
Commit 228e4bc3a inadvertently duplicated an `assert()` call around line 328-334, creating malformed syntax with nested asserts and orphaned template literal. This caused lint, format, and unit test CI jobs to fail on main.

Removed the extra leading `assert(` and trailing orphaned template-literal+`);` to restore the single well-formed assertion, restoring intent from commit 6e7630c5a ('test(apitests): await table clears on re-setup, make assertions diagnostic').

## Test plan
- [x] lint:required passes (oxlint)
- [x] format:check passes (prettier)
- [x] Test file parses correctly and tests run (syntax fixed)

Refs #228e4bc3a

🤖 Generated with [Claude Code](https://claude.com/claude-code)