### PR TITLE
Activate WAF on upgraded instances

### DIFF
--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -363,7 +363,7 @@ export function ensureConfigKeysPresent(keys: string[]): string[] {
  * Built-in components introduced in a recent release whose config key must be backfilled onto
  * in-place-upgraded instances. Fresh installs get these from defaultConfig.yaml, but an upgrade
  * carries the old config forward without them, leaving the component dormant (harper-pro#585:
- * secretCustody added in 5.2).
+ * secretCustody and WAF added in 5.2).
  *
  * Deliberately scoped to genuinely-new built-ins — NOT every registered built-in. Component
  * activation is presence-gated (componentLoader iterates the config's keys), so re-adding a
@@ -381,7 +381,7 @@ export function ensureConfigKeysPresent(keys: string[]): string[] {
  * but document the falsy-disable convention wherever the key is exposed to operators.
  * Add a key here only when shipping a new built-in that must activate on already-upgraded instances.
  */
-const UPGRADE_BACKFILL_BUILTIN_KEYS = ['secretCustody'];
+const UPGRADE_BACKFILL_BUILTIN_KEYS = ['secretCustody', 'waf'];
 
 /**
  * Ensure the config keys for recently-introduced built-in components exist, so a component added in

--- a/unitTests/config/configUtils.test.js
+++ b/unitTests/config/configUtils.test.js
@@ -402,6 +402,14 @@ describe('Test configUtils module', () => {
 			assert.deepStrictEqual(doc.secretCustody, {});
 		});
 
+		it('backfills waf when it is a registered built-in and the key is missing', () => {
+			process.env.HARPER_BUILTIN_COMPONENTS = 'waf=@/dist/waf/waf.js';
+			writeConfig('replication: {}\n');
+			assert.deepStrictEqual(ensureBuiltInComponentConfigKeys(), ['waf']);
+			const doc = YAML.parse(fs.readFileSync(BI_CONFIG_PATH, 'utf8'));
+			assert.deepStrictEqual(doc.waf, {});
+		});
+
 		it('never re-adds a long-standing built-in absent from the config (e.g. admin-removed replication)', () => {
 			// replication is registered but NOT in the new-built-in backfill list, so a config that
 			// omits it (operator disabled it by removing the block) must stay without it.


### PR DESCRIPTION
## Summary

Adds `waf` to the safe list of newly introduced built-in component keys that are restored on in-place upgrades. This gives upgraded Harper Pro 5.2 instances the same WAF activation behavior as fresh installs while preserving explicit `waf: false` configuration.

The focused backfill test covers registration-gated activation and the persisted empty WAF config block. General WAF documentation is already covered by [docs: add Web Application Firewall reference](https://github.com/HarperFast/documentation/pull/603).

Generated by Codex (GPT-5).