### PR TITLE
fix(query): stop query planning from mutating the caller's conditions

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -2812,6 +2812,33 @@ export function makeTable(options) {
 					},
 				].concat(conditions);
 			}
+			// Shallow-clone each condition entry (recursing into nested `and`/`or`
+			// groups) so query planning never writes through to the caller's objects.
+			// Array-form entries (`[attribute, value]`) and primitives pass through as-is.
+			function cloneConditions(conditions: any[]): any[] {
+				return conditions.map((condition) => {
+					if (condition == null || typeof condition !== 'object') return condition;
+					if (Array.isArray(condition)) {
+						// array-form entry (`[attribute, value]`) may also carry named
+						// props (comparator, estimated_count); preserve both.
+						return Object.assign(condition.slice(), condition);
+					}
+					const copy = { ...condition };
+					if (copy.conditions) copy.conditions = cloneConditions(copy.conditions);
+					return copy;
+				});
+			}
+			// Never mutate the caller's conditions in place. Query planning annotates
+			// and restructures conditions as it runs — it pushes a `{ comparator: 'sort' }`
+			// pseudo-condition for index-order alignment, sets `descending`, caches
+			// `estimated_count`, collapses chained conditions, and coerces values — all
+			// on the entry objects. When the caller reuses the same array/objects across
+			// queries those annotations leak: a leaked pseudo-condition throws a coercion
+			// error, a stale `descending` reverses a scan, a cached `estimated_count`
+			// misplans (harper#1572). Copy the array and every entry (recursing into
+			// nested `and`/`or` groups) up front so all downstream mutation is on our own
+			// objects. Entries are small and shallow; the clone is cheap next to the query.
+			conditions = cloneConditions(conditions);
 			let orderAlignedCondition;
 			const filtered = {};
 

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -253,6 +253,25 @@ type ResidencyDefinition = number | string[] | void;
  * Instances of the returned class are Resource instances, intended to provide a consistent view or transaction of the table
  * @param options
  */
+// Shallow-clone each condition entry (recursing into nested `and`/`or` groups) so
+// query planning never writes through to the caller's objects (harper#1572).
+// Array-form entries (`[attribute, value]`) and primitives pass through as-is;
+// `chainedConditions` sub-entries are intentionally left shared: planning only
+// reads them (collapsing into the parent's value/comparator), never writes them.
+// Module-scoped (stateless) so it isn't re-created on every search().
+function cloneConditions(conditions: any[]): any[] {
+	return conditions.map((condition) => {
+		if (condition == null || typeof condition !== 'object') return condition;
+		if (Array.isArray(condition)) {
+			// array-form entry (`[attribute, value]`) may also carry named props
+			// (comparator, estimated_count); preserve both.
+			return Object.assign(condition.slice(), condition);
+		}
+		const copy = { ...condition };
+		if (copy.conditions) copy.conditions = cloneConditions(copy.conditions);
+		return copy;
+	});
+}
 // #section: setup-and-factory
 export function makeTable(options) {
 	const {
@@ -2811,24 +2830,6 @@ export function makeTable(options) {
 						value: id,
 					},
 				].concat(conditions);
-			}
-			// Shallow-clone each condition entry (recursing into nested `and`/`or`
-			// groups) so query planning never writes through to the caller's objects.
-			// Array-form entries (`[attribute, value]`) and primitives pass through as-is.
-			// `chainedConditions` sub-entries are intentionally left shared: planning only
-			// reads them (collapsing into the parent's value/comparator), never writes them.
-			function cloneConditions(conditions: any[]): any[] {
-				return conditions.map((condition) => {
-					if (condition == null || typeof condition !== 'object') return condition;
-					if (Array.isArray(condition)) {
-						// array-form entry (`[attribute, value]`) may also carry named
-						// props (comparator, estimated_count); preserve both.
-						return Object.assign(condition.slice(), condition);
-					}
-					const copy = { ...condition };
-					if (copy.conditions) copy.conditions = cloneConditions(copy.conditions);
-					return copy;
-				});
 			}
 			// Never mutate the caller's conditions in place. Query planning annotates
 			// and restructures conditions as it runs — it pushes a `{ comparator: 'sort' }`

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -2815,6 +2815,8 @@ export function makeTable(options) {
 			// Shallow-clone each condition entry (recursing into nested `and`/`or`
 			// groups) so query planning never writes through to the caller's objects.
 			// Array-form entries (`[attribute, value]`) and primitives pass through as-is.
+			// `chainedConditions` sub-entries are intentionally left shared: planning only
+			// reads them (collapsing into the parent's value/comparator), never writes them.
 			function cloneConditions(conditions: any[]): any[] {
 				return conditions.map((condition) => {
 					if (condition == null || typeof condition !== 'object') return condition;

--- a/unitTests/resources/conditionsArrayMutation.test.js
+++ b/unitTests/resources/conditionsArrayMutation.test.js
@@ -1,5 +1,5 @@
 require('../testUtils');
-const assert = require('node:assert/strict');
+const assert = require('node:assert');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { transaction } = require('#src/resources/transaction');
@@ -48,7 +48,7 @@ describe('#1572 query does not mutate the caller conditions array', () => {
 			const conditions = [{ attribute: 'category', comparator: 'equals', value: 'common' }];
 			await drain(T.search({ conditions, sort: { attribute: 'ts', descending: true } }));
 
-			assert.equal(conditions.length, 1, 'conditions array grew (sort pseudo-condition leaked)');
+			assert.strictEqual(conditions.length, 1, 'conditions array grew (sort pseudo-condition leaked)');
 			assert.ok(
 				!conditions.some((c) => c.comparator === 'sort'),
 				'a sort pseudo-condition leaked into the caller array'
@@ -63,7 +63,7 @@ describe('#1572 query does not mutate the caller conditions array', () => {
 			await drain(T.search({ conditions, sort: { attribute: 'ts', descending: true } }));
 			// query 2 — reuse the same array; a leaked pseudo-condition throws here
 			const count = await drain(T.search({ conditions }));
-			assert.equal(count, 20);
+			assert.strictEqual(count, 20);
 		});
 	});
 
@@ -75,8 +75,12 @@ describe('#1572 query does not mutate the caller conditions array', () => {
 			// caller's entry object.
 			const conditions = [{ attribute: 'ts', comparator: 'greater_than', value: '2023-11-14T22:13:20.000Z' }];
 			await drain(T.search(conditions));
-			assert.equal(conditions.length, 1, 'array-form target array was mutated');
-			assert.equal(conditions[0].value, '2023-11-14T22:13:20.000Z', 'caller condition value was coerced in place');
+			assert.strictEqual(conditions.length, 1, 'array-form target array was mutated');
+			assert.strictEqual(
+				conditions[0].value,
+				'2023-11-14T22:13:20.000Z',
+				'caller condition value was coerced in place'
+			);
 			assert.ok(!('estimated_count' in conditions[0]), 'estimated_count leaked onto the caller condition');
 		});
 	});
@@ -94,7 +98,7 @@ describe('#1572 query does not mutate the caller conditions array', () => {
 			const seen = [];
 			for await (const r of await T.search({ conditions: [condition] })) seen.push(r.ts.getTime());
 			const ascending = [...seen].sort((a, b) => a - b);
-			assert.deepEqual(seen, ascending, 'reused query scanned in reverse from a leaked descending flag');
+			assert.deepStrictEqual(seen, ascending, 'reused query scanned in reverse from a leaked descending flag');
 		});
 	});
 });

--- a/unitTests/resources/conditionsArrayMutation.test.js
+++ b/unitTests/resources/conditionsArrayMutation.test.js
@@ -1,0 +1,96 @@
+require('../testUtils');
+const assert = require('node:assert/strict');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { transaction } = require('#src/resources/transaction');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+
+// harper#1572: Table.search({ conditions, sort }) must not mutate the caller's
+// conditions array. The planner pushes a `{ comparator: 'sort' }` pseudo-condition
+// onto the array to align with an index's order; when that pseudo-condition sorts
+// first by estimate it is kept and leaks into the caller's array, so a later reuse
+// of the same array treats the valueless pseudo-condition as a real condition and
+// throws a coercion error.
+//
+// A sort pseudo-condition estimates at totalCount/2, so it lands first (and leaks)
+// whenever the real condition matches MORE than half the rows — hence `category`
+// matching every row below.
+async function drain(iterable) {
+	let count = 0;
+	for await (const _ of await iterable) count++;
+	return count;
+}
+
+describe('#1572 query does not mutate the caller conditions array', () => {
+	let T;
+	before(async function () {
+		this.timeout(60000);
+		setupTestDBPath();
+		setMainIsWorker(true);
+		T = table({
+			table: 'MutTest',
+			database: 'test',
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'category', indexed: true },
+				// typed sort attribute: on reuse, coercion runs on the leaked valueless
+				// pseudo-condition and throws (as the reported Date attribute did)
+				{ name: 'ts', type: 'Date', indexed: true },
+			],
+		});
+		let last;
+		for (let i = 0; i < 20; i++) last = T.put({ id: i, category: 'common', ts: new Date(1_700_000_000_000 + i) });
+		await last;
+	});
+
+	it('leaves the conditions array unchanged after a sort query', async () => {
+		await transaction(async () => {
+			const conditions = [{ attribute: 'category', comparator: 'equals', value: 'common' }];
+			await drain(T.search({ conditions, sort: { attribute: 'ts', descending: true } }));
+
+			assert.equal(conditions.length, 1, 'conditions array grew (sort pseudo-condition leaked)');
+			assert.ok(
+				!conditions.some((c) => c.comparator === 'sort'),
+				'a sort pseudo-condition leaked into the caller array'
+			);
+		});
+	});
+
+	it('allows reusing the same conditions array after a sort query', async () => {
+		await transaction(async () => {
+			const conditions = [{ attribute: 'category', comparator: 'equals', value: 'common' }];
+			// query 1 — sorted; must not poison `conditions`
+			await drain(T.search({ conditions, sort: { attribute: 'ts', descending: true } }));
+			// query 2 — reuse the same array; a leaked pseudo-condition throws here
+			const count = await drain(T.search({ conditions }));
+			assert.equal(count, 20);
+		});
+	});
+
+	it('does not mutate a conditions array passed as the target directly', async () => {
+		await transaction(async () => {
+			// array-form target: search(conditions) rather than search({ conditions })
+			const conditions = [{ attribute: 'category', comparator: 'equals', value: 'common' }];
+			await drain(T.search(conditions));
+			assert.equal(conditions.length, 1, 'array-form target array was mutated');
+			assert.ok(!conditions.some((c) => c.comparator === 'sort'));
+		});
+	});
+
+	it('does not leak a sort descending flag onto a reused condition object', async () => {
+		await transaction(async () => {
+			// condition on the SAME attribute as the sort: planning aligns the sort by
+			// setting `descending` on the existing condition entry. That must not persist
+			// onto the caller's object and reverse an unrelated later query.
+			const condition = { attribute: 'ts', comparator: 'greater_than', value: new Date(0) };
+			await drain(T.search({ conditions: [condition], sort: { attribute: 'ts', descending: true } }));
+			assert.ok(!('descending' in condition), 'descending leaked onto the caller condition object');
+
+			// reuse without a sort: results must be in ascending (natural) order
+			const seen = [];
+			for await (const r of await T.search({ conditions: [condition] })) seen.push(r.ts.getTime());
+			const ascending = [...seen].sort((a, b) => a - b);
+			assert.deepEqual(seen, ascending, 'reused query scanned in reverse from a leaked descending flag');
+		});
+	});
+});

--- a/unitTests/resources/conditionsArrayMutation.test.js
+++ b/unitTests/resources/conditionsArrayMutation.test.js
@@ -67,13 +67,17 @@ describe('#1572 query does not mutate the caller conditions array', () => {
 		});
 	});
 
-	it('does not mutate a conditions array passed as the target directly', async () => {
+	it('does not mutate a conditions array (or its entries) passed as the target directly', async () => {
 		await transaction(async () => {
-			// array-form target: search(conditions) rather than search({ conditions })
-			const conditions = [{ attribute: 'category', comparator: 'equals', value: 'common' }];
+			// array-form target: search(conditions) rather than search({ conditions }).
+			// `ts` is Date-typed, so planning coerces the string bound to a Date — that
+			// coercion (and any estimate annotation) must land on our copy, not the
+			// caller's entry object.
+			const conditions = [{ attribute: 'ts', comparator: 'greater_than', value: '2023-11-14T22:13:20.000Z' }];
 			await drain(T.search(conditions));
 			assert.equal(conditions.length, 1, 'array-form target array was mutated');
-			assert.ok(!conditions.some((c) => c.comparator === 'sort'));
+			assert.equal(conditions[0].value, '2023-11-14T22:13:20.000Z', 'caller condition value was coerced in place');
+			assert.ok(!('estimated_count' in conditions[0]), 'estimated_count leaked onto the caller condition');
 		});
 	});
 


### PR DESCRIPTION
## Summary

`Table.search()` / `get()` took the caller's conditions **by reference** and annotated them in place while planning the query — it pushes a `{ comparator: 'sort' }` pseudo-condition for index-order alignment, sets `descending`, caches `estimated_count`, collapses chained conditions, and coerces values, all on the caller's entry objects. A caller that reuses the same array or condition objects across queries (a natural pattern for a module-level `const BASE = [...]`) then reads leaked state.

## Purpose

Fixes [#1572](https://github.com/HarperFast/harper/issues/1572). The most visible symptom is the reported throw: a kept sort pseudo-condition is treated as a real, valueless condition on reuse and fails coercion with `Invalid value for attribute … "undefined"`. Because whether the pseudo-condition is kept depends on live index estimates (it's kept when it sorts first), it presented as phantom nondeterminism — the reporter lost a day to it. Kris confirmed and escalated it.

## The fix

Clone the conditions array **and every entry** (recursing into nested `and`/`or` groups) at intake, so all downstream planning mutation lands on our own objects and never reaches the caller. Two hunks in `resources/Table.ts` plus a regression test.

## Where to look

- **Scope of the clone.** The original diagnosis suggested copying the array; the cross-model review (Codex + Gemini) surfaced that the array copy alone is insufficient — the *entries* are shared too, so `descending`, `estimated_count`, chained-condition collapse, and coercion still leak onto the caller's objects, and a bare array-alias check also misses the `search(conditionsArray)` (array-as-target) form. Hence the full entry clone. Worth confirming the clone depth is right (array + entries + nested `.conditions`; array-form `[attr, value]` entries preserved via `Object.assign`).
- **Hot path.** This runs on every search-with-conditions. Conditions arrays are tiny (1–5 shallow entries), so the clone is negligible next to the query, but it is a new per-query allocation — flagging it explicitly.

## Tests

New `unitTests/resources/conditionsArrayMutation.test.js` — four cases: array not mutated after a sort query, reuse doesn't throw, **array-form target** not mutated, and a leaked **`descending`** doesn't reverse a later reused query. Three of the four fail on unfixed code (verified by reverting `resources/Table.ts` to `origin/main`). `query.test.js` (105) + `crud` + `dataLoader` + `getRecordCount` pass unchanged.

## Note

Small, safe, defensive change to a real correctness bug present since ≥5.1.15 — a **v5.1 patch** candidate.

_Generated by an LLM (Claude Opus 4.8)._
