### PR TITLE
fix(auth): reject reserved role-permission names as database names + complete cluster_user handling

### DIFF
--- a/dataLayer/schema.ts
+++ b/dataLayer/schema.ts
@@ -23,7 +23,11 @@ const DB_NAME_CONSTRAINTS = Joi.string()
 	.min(1)
 	.max(commonValidators.schema_length.maximum)
 	.pattern(schemaRegex)
-	.messages({ 'string.pattern.base': '{:#label} ' + commonValidators.schema_format.message });
+	.invalid(...hdbTerms.RESERVED_DATABASE_NAMES)
+	.messages({
+		'string.pattern.base': '{:#label} ' + commonValidators.schema_format.message,
+		'any.invalid': "'{#value}' is a reserved name and cannot be used as a database name",
+	});
 
 const TABLE_NAME_CONSTRAINTS = Joi.string()
 	.min(1)

--- a/dataLayer/schema.ts
+++ b/dataLayer/schema.ts
@@ -49,6 +49,16 @@ const PRIMARY_KEY_CONSTRAINTS = Joi.string()
 
 /** EXPORTED FUNCTIONS **/
 
+/**
+ * Validate a database name on its own — reserved names, length, format — without touching storage.
+ * The create paths below run the same constraint as part of their request validation; exposing it
+ * separately lets the name rule (harper#1016) be exercised without creating a database as a
+ * side effect.
+ */
+export function validateDatabaseName(databaseName: string) {
+	return validateBySchema({ schema: databaseName }, Joi.object({ schema: DB_NAME_CONSTRAINTS }));
+}
+
 export async function createSchema(schemaCreateObject: any) {
 	let schemaStructure = await createSchemaStructure(schemaCreateObject);
 	// Await cross-worker propagation so the new schema is visible on every worker before

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1098,6 +1098,9 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 	// is also created by schema authoring — a `schema.graphql` `@table(database:)`
 	// or a programmatic `table()` call — which bypasses the create_schema
 	// validation. A reserved name collides with a role permission flag (harper#1016).
+	// Deliberately on this authoring path only, NOT in `database()`/`makeTable`: those
+	// are also the load and drop paths, so a reserved-name database created before this
+	// fix still loads (data stays accessible) and can be dropped to remediate.
 	if ((RESERVED_DATABASE_NAMES as readonly string[]).includes(databaseName)) {
 		throw new ClientError(`'${databaseName}' is a reserved name and cannot be used as a database name`);
 	}

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -11,7 +11,12 @@ import {
 } from '../dataLayer/harperBridge/lmdbBridge/lmdbUtility/initializePaths.js';
 import { makeTable } from './Table.ts';
 import OpenEnvironmentObject from '../utility/lmdb/OpenEnvironmentObject.ts';
-import { CONFIG_PARAMS, LEGACY_DATABASES_DIR_NAME, DATABASES_DIR_NAME } from '../utility/hdbTerms.ts';
+import {
+	CONFIG_PARAMS,
+	LEGACY_DATABASES_DIR_NAME,
+	DATABASES_DIR_NAME,
+	RESERVED_DATABASE_NAMES,
+} from '../utility/hdbTerms.ts';
 import { getConfigPath } from '../config/configUtils.ts';
 import { ClientError } from '../utility/errors/hdbError.ts';
 import { _assignPackageExport } from '../globals.js';
@@ -1089,6 +1094,13 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 		cacheControl,
 	} = tableDefinition;
 	if (!databaseName) databaseName = DEFAULT_DATABASE_NAME;
+	// Reject reserved names here too, not only at the operations API: a database
+	// is also created by schema authoring — a `schema.graphql` `@table(database:)`
+	// or a programmatic `table()` call — which bypasses the create_schema
+	// validation. A reserved name collides with a role permission flag (harper#1016).
+	if ((RESERVED_DATABASE_NAMES as readonly string[]).includes(databaseName)) {
+		throw new ClientError(`'${databaseName}' is a reserved name and cannot be used as a database name`);
+	}
 	const rootStore = database({ database: databaseName, table: tableName });
 	const tables = databases[databaseName];
 	logger.trace(`Defining ${tableName} in ${databaseName}`);

--- a/resources/roles.ts
+++ b/resources/roles.ts
@@ -2,8 +2,12 @@ import { getDatabases } from './databases.ts';
 import { alterRole, addRole } from '../security/role.ts';
 import { parseDocument } from 'yaml';
 import { isEqual } from 'lodash';
+import { RESERVED_DATABASE_NAMES } from '../utility/hdbTerms.ts';
 
-const USERS_NOT_DBS = ['super_user', 'structure_user'];
+// Named permission flags are keyed alongside per-database permissions in a role's
+// `permission` object; skip them when walking database permissions. This is the
+// same reserved set that database names are rejected from (harper#1016).
+const USERS_NOT_DBS: readonly string[] = RESERVED_DATABASE_NAMES;
 
 /**
  * This is the component for handling role declarations in the Harper system. This will read roles.yaml for role

--- a/security/permissionsTranslator.js
+++ b/security/permissionsTranslator.js
@@ -132,6 +132,9 @@ function translateRolePermissions(role, schema) {
 	const perms = role.permission;
 	finalPermissions[terms.SYSTEM_SCHEMA_NAME] = perms[terms.SYSTEM_SCHEMA_NAME];
 	finalPermissions.structure_user = perms.structure_user;
+	// Preserve cluster_user like the other named flags so a translated role keeps
+	// what it declared, rather than silently dropping it (harper#1016).
+	finalPermissions.cluster_user = perms.cluster_user;
 	// Preserve operations allowlist and its pre-expanded Set so the gate check in
 	// verifyPerms still has access after role.permission is replaced with fullRolePerms.
 	finalPermissions.operations = perms.operations;

--- a/unitTests/commonTestErrors.js
+++ b/unitTests/commonTestErrors.js
@@ -110,8 +110,6 @@ const TEST_ROLE_PERMS_ERROR = {
 	SU_ROLE_MISSING_ERROR: "Missing 'super_user' key/value in permission set",
 	SU_CU_ROLE_BOOLEAN_ERROR: (role) => `Value for '${role}' permission must be a boolean`,
 	SU_CU_ROLE_NO_PERMS_ALLOWED: (role) => `Roles with '${role}' set to true cannot have other permissions set.`,
-	SU_CU_ROLE_COMBINED_ERROR:
-		"Roles cannot have both 'super_user' and 'cluster_user' values included in their permissions set.",
 	TABLE_PERM_MISSING: (perm) => `Missing table ${perm.toUpperCase()} permission`,
 	TABLE_PERM_NOT_BOOLEAN: (perm) => `Table ${perm.toUpperCase()} permission must be a boolean`,
 	STRUCTURE_USER_ROLE_TYPE_ERROR: (role) => `Value for '${role}' permission must be a boolean or Array`,

--- a/unitTests/dataLayer/reservedSchemaNames.test.js
+++ b/unitTests/dataLayer/reservedSchemaNames.test.js
@@ -1,0 +1,53 @@
+const assert = require('node:assert/strict');
+const schema = require('#src/dataLayer/schema');
+const { table } = require('#src/resources/databases');
+
+// harper#1016: a role's `permission` object keys per-database permissions by
+// database name alongside named flags (super_user / cluster_user /
+// structure_user / operations / _expandedOperations). A database named after one
+// of those flags collides with it, so those names are rejected as database
+// identifiers — at both the operations API (create_schema / create_table) and
+// the schema-authoring path (graphql `@table(database:)` / programmatic table()).
+const RESERVED = ['super_user', 'cluster_user', 'structure_user', 'operations', '_expandedOperations'];
+
+describe('#1016 reserved database names', () => {
+	for (const name of RESERVED) {
+		it(`create_schema rejects reserved name '${name}'`, async () => {
+			await assert.rejects(
+				() => schema.createSchemaStructure({ operation: 'create_schema', schema: name }),
+				/reserved name/,
+				`create_schema accepted reserved name '${name}'`
+			);
+		});
+
+		it(`create_table rejects reserved database '${name}'`, async () => {
+			await assert.rejects(
+				() => schema.createTableStructure({ operation: 'create_table', schema: name, table: 't', primary_key: 'id' }),
+				/reserved name/,
+				`create_table accepted reserved database '${name}'`
+			);
+		});
+
+		it(`schema authoring (table()) rejects reserved database '${name}'`, () => {
+			// graphql `@table(database:)` and programmatic table() funnel through here,
+			// bypassing the operations-API validation. The check throws before any store IO.
+			assert.throws(
+				() => table({ database: name, table: 't', attributes: [{ name: 'id', isPrimaryKey: true }] }),
+				/reserved name/,
+				`table() accepted reserved database '${name}'`
+			);
+		});
+	}
+
+	it('does not reject a non-reserved database name as reserved', async () => {
+		// A normal name must pass the reserved-name check. It may still fail later
+		// (no schema metadata / bridge in this unit context) — just not as reserved.
+		let err;
+		try {
+			await schema.createSchemaStructure({ operation: 'create_schema', schema: 'my_normal_db' });
+		} catch (e) {
+			err = e;
+		}
+		if (err) assert.doesNotMatch(err.message, /reserved name/);
+	});
+});

--- a/unitTests/dataLayer/reservedSchemaNames.test.js
+++ b/unitTests/dataLayer/reservedSchemaNames.test.js
@@ -1,4 +1,4 @@
-const assert = require('node:assert/strict');
+const assert = require('node:assert');
 const schema = require('#src/dataLayer/schema');
 const { table } = require('#src/resources/databases');
 

--- a/unitTests/dataLayer/reservedSchemaNames.test.js
+++ b/unitTests/dataLayer/reservedSchemaNames.test.js
@@ -39,15 +39,17 @@ describe('#1016 reserved database names', () => {
 		});
 	}
 
-	it('does not reject a non-reserved database name as reserved', async () => {
-		// A normal name must pass the reserved-name check. It may still fail later
-		// (no schema metadata / bridge in this unit context) — just not as reserved.
-		let err;
-		try {
-			await schema.createSchemaStructure({ operation: 'create_schema', schema: 'my_normal_db' });
-		} catch (e) {
-			err = e;
+	// Validation-only control (review): calling `createSchemaStructure` with a nonexistent normal name
+	// takes the successful creation path, so it created `my_normal_db` on whatever root the environment
+	// was configured with and signalled a schema change — a unit test with a side effect on a developer
+	// checkout. `validateDatabaseName` runs the same constraint the create paths run, without the IO.
+	it('does not reject a non-reserved database name as reserved', () => {
+		assert.strictEqual(schema.validateDatabaseName('my_normal_db'), undefined);
+	});
+
+	it('rejects a reserved name through the same validation, so the control above is meaningful', () => {
+		for (const name of RESERVED) {
+			assert.match(schema.validateDatabaseName(name).message, /reserved name/);
 		}
-		if (err) assert.doesNotMatch(err.message, /reserved name/);
 	});
 });

--- a/unitTests/validation/role_validation.test.js
+++ b/unitTests/validation/role_validation.test.js
@@ -249,6 +249,31 @@ describe('Test role_validation module ', () => {
 			expect(test_result).to.equal(null);
 		});
 
+		it('NOMINAL - should return null for valid cluster_user = true ADD_ROLE object', () => {
+			const test_role_json = TEST_ADD_ROLE_OBJECT();
+			test_role_json.permission = { cluster_user: true };
+			const test_result = customValidate_rw(test_role_json, getAddRoleConstraints());
+
+			expect(test_result).to.equal(null);
+		});
+
+		// harper#1016: cluster_user is a boolean role flag, not a database name. A
+		// non-boolean value must report the boolean-type error, not a misleading
+		// "database 'cluster_user' does not exist".
+		it('should return the boolean error (not SCHEMA_NOT_FOUND) for non-boolean cluster_user', () => {
+			const test_role_json = TEST_ADD_ROLE_OBJECT();
+			test_role_json.permission = { cluster_user: 'wut' };
+			const test_result = customValidate_rw(test_role_json, getAddRoleConstraints());
+
+			expect(test_result.statusCode).to.equal(400);
+			expect(test_result.http_resp_msg.main_permissions).to.include(
+				TEST_ROLE_PERMS_ERROR.SU_CU_ROLE_BOOLEAN_ERROR('cluster_user')
+			);
+			expect(test_result.http_resp_msg.main_permissions).to.not.include(
+				TEST_SCHEMA_OP_ERROR.SCHEMA_NOT_FOUND('cluster_user')
+			);
+		});
+
 		it('NOMINAL - should return null for valid ALTER_ROLE object', () => {
 			const test_result = customValidate_rw(TEST_ALTER_ROLE_OBJECT(), getAlterRoleConstraints());
 			expect(test_result).to.equal(null);

--- a/unitTests/validation/role_validation.test.js
+++ b/unitTests/validation/role_validation.test.js
@@ -296,14 +296,27 @@ describe('Test role_validation module ', () => {
 			});
 		});
 
-		// harper#1016 (review): a malformed `permission` primitive must stay a 400, not a 500. `permission`
-		// is only presence-constrained, so these reach the role-flag loop; `in` throws on a primitive.
-		[{ p: 'x' }, { p: 1 }, { p: true }].forEach(({ p }) => {
-			it(`should not throw on a malformed permission primitive ${JSON.stringify(p)}`, () => {
-				const test_role_json = TEST_ADD_ROLE_OBJECT();
-				test_role_json.permission = p;
-				expect(() => customValidate_rw(test_role_json, getAddRoleConstraints())).to.not.throw();
-			});
+		// harper#1016 (review): `permission` is only presence-constrained, so any type reaches validation.
+		// A non-object carries no role flags and no database entries, so every downstream check is a no-op
+		// on it — without an explicit shape check the role validates clean and gets persisted, since
+		// `hdb_role.permission` has no storage type constraint either. Assert the 400, not merely that
+		// nothing throws: a silent pass is the actual bug here, and no-throw does not distinguish them.
+		[{ p: 'x' }, { p: 1 }, { p: true }, { p: [] }, { p: [{ super_user: true }] }, { p: 0 }, { p: '' }].forEach(
+			({ p }) => {
+				it(`should reject a non-object permission ${JSON.stringify(p)} with a 400`, () => {
+					const test_role_json = TEST_ADD_ROLE_OBJECT();
+					test_role_json.permission = p;
+					const test_result = customValidate_rw(test_role_json, getAddRoleConstraints());
+					expect(test_result, 'a non-object permission must not validate clean').to.not.equal(null);
+					expect(test_result.statusCode).to.equal(400);
+				});
+			}
+		);
+
+		it('should still accept a well-formed object permission', () => {
+			const test_role_json = TEST_ADD_ROLE_OBJECT();
+			test_role_json.permission = { super_user: true };
+			expect(customValidate_rw(test_role_json, getAddRoleConstraints())).to.equal(null);
 		});
 
 		// harper#1016 (review): cluster_user is exclusive like super_user. Before CU joined ROLE_TYPES the

--- a/unitTests/validation/role_validation.test.js
+++ b/unitTests/validation/role_validation.test.js
@@ -274,6 +274,28 @@ describe('Test role_validation module ', () => {
 			);
 		});
 
+		// harper#1016 (review): the boolean check must gate on key presence, not truthiness — a falsey
+		// non-boolean (0, '', null) must still be rejected rather than silently skipping both the check
+		// and the database-permission loop. Covers cluster_user and the latent super_user variant.
+		[
+			{ role: 'cluster_user', value: 0 },
+			{ role: 'cluster_user', value: null },
+			{ role: 'cluster_user', value: '' },
+			{ role: 'super_user', value: 0 },
+			{ role: 'super_user', value: null },
+		].forEach(({ role, value }) => {
+			it(`should reject a falsey non-boolean ${role} = ${JSON.stringify(value)} as a boolean error`, () => {
+				const test_role_json = TEST_ADD_ROLE_OBJECT();
+				test_role_json.permission = { [role]: value };
+				const test_result = customValidate_rw(test_role_json, getAddRoleConstraints());
+
+				expect(test_result.statusCode).to.equal(400);
+				expect(test_result.http_resp_msg.main_permissions).to.include(
+					TEST_ROLE_PERMS_ERROR.SU_CU_ROLE_BOOLEAN_ERROR(role)
+				);
+			});
+		});
+
 		it('NOMINAL - should return null for valid ALTER_ROLE object', () => {
 			const test_result = customValidate_rw(TEST_ALTER_ROLE_OBJECT(), getAlterRoleConstraints());
 			expect(test_result).to.equal(null);

--- a/unitTests/validation/role_validation.test.js
+++ b/unitTests/validation/role_validation.test.js
@@ -296,6 +296,36 @@ describe('Test role_validation module ', () => {
 			});
 		});
 
+		// harper#1016 (review): a malformed `permission` primitive must stay a 400, not a 500. `permission`
+		// is only presence-constrained, so these reach the role-flag loop; `in` throws on a primitive.
+		[{ p: 'x' }, { p: 1 }, { p: true }].forEach(({ p }) => {
+			it(`should not throw on a malformed permission primitive ${JSON.stringify(p)}`, () => {
+				const test_role_json = TEST_ADD_ROLE_OBJECT();
+				test_role_json.permission = p;
+				expect(() => customValidate_rw(test_role_json, getAddRoleConstraints())).to.not.throw();
+			});
+		});
+
+		// harper#1016 (review): cluster_user is exclusive like super_user. Before CU joined ROLE_TYPES the
+		// database-permission loop rejected this incidentally; that loop now skips it, so validateNoSUPerms
+		// has to enforce it.
+		[
+			{ extra: 'someDb', value: { tables: {} } },
+			{ extra: 'operations', value: ['add_role'] },
+			{ extra: 'structure_user', value: true },
+		].forEach(({ extra, value }) => {
+			it(`should reject cluster_user = true combined with ${extra}`, () => {
+				const test_role_json = TEST_ADD_ROLE_OBJECT();
+				test_role_json.permission = { cluster_user: true, [extra]: value };
+				const test_result = customValidate_rw(test_role_json, getAddRoleConstraints());
+
+				expect(test_result.statusCode).to.equal(400);
+				expect(test_result.http_resp_msg.main_permissions).to.include(
+					TEST_ROLE_PERMS_ERROR.SU_CU_ROLE_NO_PERMS_ALLOWED('cluster_user')
+				);
+			});
+		});
+
 		it('NOMINAL - should return null for valid ALTER_ROLE object', () => {
 			const test_result = customValidate_rw(TEST_ALTER_ROLE_OBJECT(), getAlterRoleConstraints());
 			expect(test_result).to.equal(null);

--- a/utility/errors/commonErrors.ts
+++ b/utility/errors/commonErrors.ts
@@ -166,6 +166,7 @@ const ROLE_PERMS_ERROR_MSGS = {
 		`Your role does not have permission to view database metadata for '${schema_name}'`,
 	SCHEMA_TABLE_PERM_ERROR: (schema_name, table_name) =>
 		`Your role does not have permission to view database.table metadata for '${schema_name}.${table_name}'`,
+	PERMISSION_NOT_OBJECT: "Value for 'permission' must be an object of role and database permissions",
 	SU_ROLE_MISSING_ERROR: "Missing 'super_user' key/value in permission set",
 	SU_CU_ROLE_BOOLEAN_ERROR: (role) => `Value for '${role}' permission must be a boolean`,
 	STRUCTURE_USER_ROLE_TYPE_ERROR: (role) => `Value for '${role}' permission must be a boolean or Array`,

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -83,9 +83,16 @@ export const LAUNCH_SERVICE_SCRIPTS = {
 	MAIN: 'dist/bin/harper.js',
 } as const;
 
-/** Specifies user role types */
+/**
+ * Special boolean role flags validated as role types (not database permissions).
+ * `cluster_user` belongs here alongside `super_user`: role validation checks both
+ * are booleans (SU_CU_ROLE_BOOLEAN_ERROR), and without it a non-boolean
+ * `cluster_user` falls through to database validation and reports a misleading
+ * "database 'cluster_user' does not exist" error (harper#1016).
+ */
 export const ROLE_TYPES_ENUM = {
 	SUPER_USER: 'super_user',
+	CLUSTER_USER: 'cluster_user',
 } as const;
 
 /**

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -102,6 +102,8 @@ export const ROLE_TYPES_ENUM = {
  * a `super_user` flag from a `super_user` database's permissions — producing
  * undefined behavior, so these are rejected as database/schema identifiers
  * (harper#1016). Keep in sync with `UserRoleNamedPermissions` in security/user.ts.
+ * `access` is deliberately NOT here: roles.ts strips it out of `permission`
+ * before persistence (scoped-delegation), so it never collides at runtime.
  */
 export const RESERVED_DATABASE_NAMES = [
 	'super_user',

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -88,6 +88,22 @@ export const ROLE_TYPES_ENUM = {
 	SUPER_USER: 'super_user',
 } as const;
 
+/**
+ * Named permission flags that live in a role's `permission` object alongside
+ * per-database permission blocks, which are keyed by database name. A database
+ * named after one of these flags collides with it — the role parser cannot tell
+ * a `super_user` flag from a `super_user` database's permissions — producing
+ * undefined behavior, so these are rejected as database/schema identifiers
+ * (harper#1016). Keep in sync with `UserRoleNamedPermissions` in security/user.ts.
+ */
+export const RESERVED_DATABASE_NAMES = [
+	'super_user',
+	'cluster_user',
+	'structure_user',
+	'operations',
+	'_expandedOperations',
+] as const;
+
 /** Email address for support requests */
 export const HDB_SUPPORT_ADDRESS = 'support@harperdb.io';
 

--- a/validation/role_validation.ts
+++ b/validation/role_validation.ts
@@ -100,7 +100,11 @@ function customValidate(object, constraints) {
 		}
 		//check if cu or su values, if included, are booleans
 		ROLE_TYPES.forEach((role) => {
-			if (object.permission[role as any] && !validate.isBoolean(object.permission[role as any])) {
+			// Gate on key presence, not truthiness: a falsey non-boolean (0, '', null) must still be
+			// rejected as a non-boolean. A truthiness gate would let those skip both this check AND the
+			// database-permission loop below (the key is a role type, so that loop excludes it), so an
+			// add/alter role would silently accept a value that violates the boolean contract.
+			if (role in object.permission && !validate.isBoolean(object.permission[role as any])) {
 				addPermError(HDB_ERROR_MSGS.SU_CU_ROLE_BOOLEAN_ERROR(role as any), validationErrors, undefined, undefined);
 			}
 		});

--- a/validation/role_validation.ts
+++ b/validation/role_validation.ts
@@ -91,8 +91,16 @@ function customValidate(object, constraints) {
 		});
 	}
 
-	//need this check to avoid unexpected errors if someone doesn't have permissions key included in request
-	if (object.permission) {
+	// `permission` is only presence-constrained, so any type reaches here. Anything that is not a plain
+	// object carries no role flags and no database entries, so every check below is a no-op on it and the
+	// role would validate clean and be persisted — `hdb_role.permission` has no storage type constraint
+	// to catch it later. Reject the shape itself, and skip the per-key checks that assume an object.
+	const permissionIsObject =
+		typeof object.permission === 'object' && object.permission !== null && !Array.isArray(object.permission);
+	if (object.permission !== undefined && !permissionIsObject) {
+		addPermError(HDB_ERROR_MSGS.PERMISSION_NOT_OBJECT, validationErrors, undefined, undefined);
+	}
+	if (permissionIsObject) {
 		//check if role is SU or CU and has perms included
 		const suPermsError = validateNoSUPerms(object);
 		if (suPermsError) {
@@ -104,9 +112,6 @@ function customValidate(object, constraints) {
 			// rejected as a non-boolean. A truthiness gate would let those skip both this check AND the
 			// database-permission loop below (the key is a role type, so that loop excludes it), so an
 			// add/alter role would silently accept a value that violates the boolean contract.
-			// `Object.hasOwn`, not `in`: `permission` is only presence-constrained, so a malformed payload
-			// (`permission: 'x'` / `1` / `true`) reaches here, and `in` throws on a primitive — turning a
-			// validation failure into a 500. `hasOwn` coerces and returns false instead.
 			if (Object.hasOwn(object.permission, role) && !validate.isBoolean(object.permission[role as any])) {
 				addPermError(HDB_ERROR_MSGS.SU_CU_ROLE_BOOLEAN_ERROR(role as any), validationErrors, undefined, undefined);
 			}

--- a/validation/role_validation.ts
+++ b/validation/role_validation.ts
@@ -104,7 +104,10 @@ function customValidate(object, constraints) {
 			// rejected as a non-boolean. A truthiness gate would let those skip both this check AND the
 			// database-permission loop below (the key is a role type, so that loop excludes it), so an
 			// add/alter role would silently accept a value that violates the boolean contract.
-			if (role in object.permission && !validate.isBoolean(object.permission[role as any])) {
+			// `Object.hasOwn`, not `in`: `permission` is only presence-constrained, so a malformed payload
+			// (`permission: 'x'` / `1` / `true`) reaches here, and `in` throws on a primitive — turning a
+			// validation failure into a 500. `hasOwn` coerces and returns false instead.
+			if (Object.hasOwn(object.permission, role) && !validate.isBoolean(object.permission[role as any])) {
 				addPermError(HDB_ERROR_MSGS.SU_CU_ROLE_BOOLEAN_ERROR(role as any), validationErrors, undefined, undefined);
 			}
 		});
@@ -272,11 +275,19 @@ function customValidate(object, constraints) {
 function validateNoSUPerms(obj) {
 	const { operation, permission } = obj;
 	if (operation === terms.OPERATIONS_ENUM.ADD_ROLE || operation === terms.OPERATIONS_ENUM.ALTER_ROLE) {
-		//Check if role type is super user
-		const isSuRole = permission.super_user === true;
+		// A malformed `permission` (only presence-constrained) must not throw here either.
+		if (typeof permission !== 'object' || permission === null) return null;
 		const hasPerms = Object.keys(permission).length > 1;
-		if (hasPerms && isSuRole) {
+		if (!hasPerms) return null;
+		// Both role types are exclusive — the error message has always named CU as well. Before
+		// `cluster_user` joined ROLE_TYPES it was rejected incidentally, by the database-permission loop
+		// treating it as a database whose value wasn't an object; now that the loop skips it, the
+		// exclusivity has to be enforced here or `{ cluster_user: true, someDb: {...} }` validates.
+		if (permission.super_user === true) {
 			return HDB_ERROR_MSGS.SU_CU_ROLE_NO_PERMS_ALLOWED(terms.ROLE_TYPES_ENUM.SUPER_USER);
+		}
+		if (permission.cluster_user === true) {
+			return HDB_ERROR_MSGS.SU_CU_ROLE_NO_PERMS_ALLOWED(terms.ROLE_TYPES_ENUM.CLUSTER_USER);
 		}
 	}
 	return null;


### PR DESCRIPTION
## Summary

A role's `permission` object mixes named flags — `super_user`, `cluster_user`, `structure_user`, `operations`, `_expandedOperations` — with per-database permission blocks keyed by **database name**. A database named after one of those flags collides with it: the role parser cannot tell a `super_user` flag from a `super_user` database's permissions.

## Purpose

Fixes [#1016](https://github.com/HarperFast/harper/issues/1016). Beyond "undefined behavior," there's a concrete **privilege-escalation** path (surfaced in review): a component shipping `@table(database: "super_user")` plus a `roles.yaml` granting permissions on that "database" makes `permission.super_user` a truthy **object**, and the super-user check (`!!permission.super_user`) then reads as granted.

## The fix

Reject the reserved names as database identifiers on **both** creation surfaces, from one shared source of truth (`RESERVED_DATABASE_NAMES` in `hdbTerms.ts`):

1. **Operations API** (`create_schema` / `create_table`) — `.invalid(...)` on `DB_NAME_CONSTRAINTS` in `dataLayer/schema.ts`.
2. **Schema authoring** (`schema.graphql` `@table(database:)` / programmatic `table()`) — a check in `resources/databases.ts::table()`, which registers databases and **bypasses** the operations validation. This is the path the escalation uses.

It also folds the incomplete `USERS_NOT_DBS` in `resources/roles.ts` (was `['super_user', 'structure_user']` — missing `cluster_user`/`operations`) into the same shared constant, fixing a latent bug where a `roles.yaml` using those flags mis-parsed them as database names.

## Where to look

- **Enforcement at two layers.** The operations-only version was incomplete — the graphql/programmatic path was the reviewers' blocker. `table()` throws a `ClientError` (matching the existing schema-validation throws in `graphql.ts`), so it's load-safe: an invalid schema fails to load rather than bricking the instance.
- **Reserved set completeness.** `_expandedOperations` is included (an internal, `_`-prefixed key) because `schemaRegex` permits leading underscores and a same-named database would overwrite the cached operations `Set` at translation time (a `TypeError` crash). Confirm the set matches `UserRoleNamedPermissions` in `security/user.ts`.
- **Case sensitivity.** `.invalid()` matches exact strings; database names are currently case-sensitive (case-insensitive handling is separate issue #1028), so exact match is correct.

## Tests

New `unitTests/dataLayer/reservedSchemaNames.test.js` — each reserved name × three surfaces (`create_schema`, `create_table`, `table()`), plus a non-reserved control. 15 of 16 fail on `origin/main` (verified by reverting the source files). Existing `resources/databases`, `query`, `crud`, `defineTable-registration`, `permissions`, `permissionsTranslator` suites pass unchanged.

## Also fixed (related `cluster_user` gaps, second commit)

Three pre-existing gaps in how `cluster_user` is handled as a role flag, surfaced in review:

- **`role_validation.ts` misleading error** — its boolean-flag list came from `ROLE_TYPES_ENUM` (only `super_user`), so a non-boolean `cluster_user` skipped the boolean check and fell through to database validation, reporting `database 'cluster_user' does not exist` instead of the boolean-type error the `SU_CU_ROLE_BOOLEAN_ERROR` name already implies. Fixed by adding `CLUSTER_USER` to `ROLE_TYPES_ENUM`. Guarded by two new `role_validation` tests (both fail on `origin/main`).
- **`permissionsTranslator.js` dropped `cluster_user`** — preserved `super_user`/`structure_user`/`operations` but not `cluster_user`. Now preserved alongside them. Note: `cluster_user` is read nowhere at runtime today (only a type def + an impersonation-clear write), so this is a consistency/hygiene fix with no behavioral effect — flagging that explicitly.
- **Dead `SU_CU_ROLE_COMBINED_ERROR`** removed from the test-error helper — no production counterpart, no test uses it (the su+cu rejection is covered by `SU_CU_ROLE_NO_PERMS_ALLOWED`).

## Upgrade / migration note

Deep-review (auth + data-integrity domain passes) confirmed the fix is startup-safe: a reserved-name database that already exists on disk still **loads** (schema replay goes through `makeTable`, not the guarded `table()`), so its data stays accessible, and it can be **dropped** to remediate (the drop path goes through `database()`, also unguarded — which is why the check is deliberately on the authoring path only).

But such a database's **component will fail to load** after upgrade — the `@table(database:)` authoring call now throws, so that Resource becomes an `ErrorResource` (logged, isolated to that component; not fatal to the instance). The highest-risk name is **`operations`**, which only became a permission flag recently (`95aa06fd1`), so pre-existing `operations` databases are more plausible than `super_user` ones. **Release notes should tell operators to rename any pre-existing database named after a reserved flag before upgrading.**

## Note

Security-adjacent (the escalation path). Milestone is v5.2; **could be a v5.1 patch** given the security angle — flagging for a decision rather than labeling.

_Generated by an LLM (Claude Opus 4.8)._
