### PR TITLE
Keep uWebSockets.js opt-in for npm consumers

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -60,9 +60,9 @@ Generally, dependencies are added by simply adding them to the dependencies list
 ## uWebSockets.js
 
 - Need for usage: Optional high-performance HTTP/WebSocket backend (#914), gated default-off behind HARPER_UWS_UDS (plaintext UDS behind symphony) / HARPER_UWS_HTTP (direct plaintext TCP). Loaded lazily only when a flag is set.
-- Size/memory cost: Prebuilt native V8 addon (~1MB per platform binary; the git dependency clones the repo with all platform binaries).
-- Security: Actively maintained C++ HTTP server; no npm advisory registry entry (installed as a git dependency, not from npm).
-- Binary compilation: Yes — ABI-locked, platform-specific prebuilt `.node` binaries committed in the repo. No musl/Alpine (glibc only). Installed via `github:uNetworking/uWebSockets.js#<tag>`, so it needs git at install time; being an optionalDependency, install tolerates its absence (missing git, unsupported platform) and Harper runs without it.
+- Size/memory cost: Prebuilt native V8 addon (~1MB per platform binary; the GitHub tarball contains all platform binaries).
+- Security: Actively maintained C++ HTTP server; no npm advisory registry entry (installed from a pinned GitHub tarball, not from npm).
+- Binary compilation: Yes — ABI-locked, platform-specific prebuilt `.node` binaries committed in the repo. No musl/Alpine (glibc only). Harper declares version 20.68.0 as an optional peer; operators enabling the backend must install the pinned GitHub tarball separately. It remains a devDependency so Harper's uWS test jobs install it without adding the GitHub tarball to consumers' production locks.
 - Overlap: Overlaps `ws` (WebSockets) and the Node/Bun HTTP paths; this is an alternative transport, not an addition.
 - Eventual removal: Kept as long as it demonstrates a meaningful throughput/latency win over the Node path; the flags let it be dropped without touching the default path.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,6 +131,7 @@
 				"typescript": "^5.8.2",
 				"typescript-eslint": "^8.45.0",
 				"undici": "^7.24.4",
+				"uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js/archive/624987739d4da0acb628aaf2a10fc43e7ce27c5c.tar.gz",
 				"why-is-node-still-running": "^1.0.0"
 			},
 			"engines": {
@@ -139,14 +140,17 @@
 			"optionalDependencies": {
 				"bufferutil": "^4.0.9",
 				"segfault-handler": "^1.3.0",
-				"utf-8-validate": "^5.0.10",
-				"uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js/archive/624987739d4da0acb628aaf2a10fc43e7ce27c5c.tar.gz"
+				"utf-8-validate": "^5.0.10"
 			},
 			"peerDependencies": {
-				"@aws-sdk/client-bedrock-runtime": "^3.0.0"
+				"@aws-sdk/client-bedrock-runtime": "^3.0.0",
+				"uWebSockets.js": "20.68.0"
 			},
 			"peerDependenciesMeta": {
 				"@aws-sdk/client-bedrock-runtime": {
+					"optional": true
+				},
+				"uWebSockets.js": {
 					"optional": true
 				}
 			}
@@ -14752,8 +14756,8 @@
 			"version": "20.68.0",
 			"resolved": "https://github.com/uNetworking/uWebSockets.js/archive/624987739d4da0acb628aaf2a10fc43e7ce27c5c.tar.gz",
 			"integrity": "sha512-BcXO02DANWelQzJyMd2G875nBeZDDYHZxqE7uOH9cAsf62Ur3hl5+4crdqBWvFF+DzbUxJoswPqvE3i2aAEZ1g==",
-			"license": "Apache-2.0",
-			"optional": true
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/validate.js": {
 			"version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
 		"typescript": "^5.8.2",
 		"typescript-eslint": "^8.45.0",
 		"undici": "^7.24.4",
+		"uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js/archive/624987739d4da0acb628aaf2a10fc43e7ce27c5c.tar.gz",
 		"why-is-node-still-running": "^1.0.0"
 	},
 	"dependencies": {
@@ -257,14 +258,17 @@
 	"optionalDependencies": {
 		"bufferutil": "^4.0.9",
 		"segfault-handler": "^1.3.0",
-		"utf-8-validate": "^5.0.10",
-		"uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js/archive/624987739d4da0acb628aaf2a10fc43e7ce27c5c.tar.gz"
+		"utf-8-validate": "^5.0.10"
 	},
 	"peerDependencies": {
-		"@aws-sdk/client-bedrock-runtime": "^3.0.0"
+		"@aws-sdk/client-bedrock-runtime": "^3.0.0",
+		"uWebSockets.js": "20.68.0"
 	},
 	"peerDependenciesMeta": {
 		"@aws-sdk/client-bedrock-runtime": {
+			"optional": true
+		},
+		"uWebSockets.js": {
 			"optional": true
 		}
 	}

--- a/server/serverHelpers/uwsServer.ts
+++ b/server/serverHelpers/uwsServer.ts
@@ -13,7 +13,7 @@
  *    symphony upstream, real client IP via X-Forwarded-For, so this server never touches certs.
  *  - HARPER_UWS_HTTP: a direct plaintext TCP HTTP port (real peer IP from the socket).
  *
- * `uWebSockets.js` is an optionalDependency (ABI/platform-specific, built by CI).
+ * `uWebSockets.js` is an optional peer (ABI/platform-specific, installed for CI as a devDependency).
  */
 import { STATUS_CODES } from 'node:http';
 import { EventEmitter } from 'node:events';

--- a/unitTests/build-tools/pruneShrinkwrapDev.test.mjs
+++ b/unitTests/build-tools/pruneShrinkwrapDev.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { copyFile, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+describe('published shrinkwrap pruning', function () {
+	it('keeps uWebSockets.js opt-in and out of consumer production locks', async function () {
+		const manifest = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
+		assert.equal(manifest.optionalDependencies['uWebSockets.js'], undefined);
+		assert.equal(manifest.peerDependencies['uWebSockets.js'], '20.68.0');
+		assert.equal(manifest.peerDependenciesMeta['uWebSockets.js'].optional, true);
+		assert.match(manifest.devDependencies['uWebSockets.js'], /^https:\/\/github\.com\//);
+
+		const tempDir = await mkdtemp(join(tmpdir(), 'harper-shrinkwrap-'));
+		const shrinkwrap = join(tempDir, 'npm-shrinkwrap.json');
+		try {
+			await copyFile(join(root, 'package-lock.json'), shrinkwrap);
+			execFileSync(process.execPath, [join(root, 'build-tools/prune-shrinkwrap-dev.mjs'), shrinkwrap]);
+
+			const lock = JSON.parse(await readFile(shrinkwrap, 'utf8'));
+			assert.equal(lock.packages[''].devDependencies, undefined);
+			assert.equal(lock.packages['node_modules/uWebSockets.js'], undefined);
+			assert.equal(lock.packages[''].peerDependencies['uWebSockets.js'], '20.68.0');
+			assert.equal(lock.packages[''].peerDependenciesMeta['uWebSockets.js'].optional, true);
+		} finally {
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/unitTests/build-tools/pruneShrinkwrapDev.test.mjs
+++ b/unitTests/build-tools/pruneShrinkwrapDev.test.mjs
@@ -10,10 +10,10 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 describe('published shrinkwrap pruning', function () {
 	it('keeps uWebSockets.js opt-in and out of consumer production locks', async function () {
 		const manifest = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
-		assert.strictEqual(manifest.optionalDependencies['uWebSockets.js'], undefined);
-		assert.strictEqual(manifest.peerDependencies['uWebSockets.js'], '20.68.0');
-		assert.strictEqual(manifest.peerDependenciesMeta['uWebSockets.js'].optional, true);
-		assert.match(manifest.devDependencies['uWebSockets.js'], /^https:\/\/github\.com\//);
+		assert.strictEqual(manifest.optionalDependencies?.['uWebSockets.js'], undefined);
+		assert.strictEqual(manifest.peerDependencies?.['uWebSockets.js'], '20.68.0');
+		assert.strictEqual(manifest.peerDependenciesMeta?.['uWebSockets.js']?.optional, true);
+		assert.match(manifest.devDependencies?.['uWebSockets.js'], /^https:\/\/github\.com\//);
 
 		const tempDir = await mkdtemp(join(tmpdir(), 'harper-shrinkwrap-'));
 		const shrinkwrap = join(tempDir, 'npm-shrinkwrap.json');
@@ -22,10 +22,10 @@ describe('published shrinkwrap pruning', function () {
 			execFileSync(process.execPath, [join(root, 'build-tools/prune-shrinkwrap-dev.mjs'), shrinkwrap]);
 
 			const lock = JSON.parse(await readFile(shrinkwrap, 'utf8'));
-			assert.strictEqual(lock.packages[''].devDependencies, undefined);
+			assert.strictEqual(lock.packages['']?.devDependencies, undefined);
 			assert.strictEqual(lock.packages['node_modules/uWebSockets.js'], undefined);
-			assert.strictEqual(lock.packages[''].peerDependencies['uWebSockets.js'], '20.68.0');
-			assert.strictEqual(lock.packages[''].peerDependenciesMeta['uWebSockets.js'].optional, true);
+			assert.strictEqual(lock.packages['']?.peerDependencies?.['uWebSockets.js'], '20.68.0');
+			assert.strictEqual(lock.packages['']?.peerDependenciesMeta?.['uWebSockets.js']?.optional, true);
 		} finally {
 			await rm(tempDir, { recursive: true, force: true });
 		}

--- a/unitTests/build-tools/pruneShrinkwrapDev.test.mjs
+++ b/unitTests/build-tools/pruneShrinkwrapDev.test.mjs
@@ -1,4 +1,4 @@
-import assert from 'node:assert/strict';
+import assert from 'node:assert';
 import { execFileSync } from 'node:child_process';
 import { copyFile, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -10,9 +10,9 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 describe('published shrinkwrap pruning', function () {
 	it('keeps uWebSockets.js opt-in and out of consumer production locks', async function () {
 		const manifest = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
-		assert.equal(manifest.optionalDependencies['uWebSockets.js'], undefined);
-		assert.equal(manifest.peerDependencies['uWebSockets.js'], '20.68.0');
-		assert.equal(manifest.peerDependenciesMeta['uWebSockets.js'].optional, true);
+		assert.strictEqual(manifest.optionalDependencies['uWebSockets.js'], undefined);
+		assert.strictEqual(manifest.peerDependencies['uWebSockets.js'], '20.68.0');
+		assert.strictEqual(manifest.peerDependenciesMeta['uWebSockets.js'].optional, true);
 		assert.match(manifest.devDependencies['uWebSockets.js'], /^https:\/\/github\.com\//);
 
 		const tempDir = await mkdtemp(join(tmpdir(), 'harper-shrinkwrap-'));
@@ -22,10 +22,10 @@ describe('published shrinkwrap pruning', function () {
 			execFileSync(process.execPath, [join(root, 'build-tools/prune-shrinkwrap-dev.mjs'), shrinkwrap]);
 
 			const lock = JSON.parse(await readFile(shrinkwrap, 'utf8'));
-			assert.equal(lock.packages[''].devDependencies, undefined);
-			assert.equal(lock.packages['node_modules/uWebSockets.js'], undefined);
-			assert.equal(lock.packages[''].peerDependencies['uWebSockets.js'], '20.68.0');
-			assert.equal(lock.packages[''].peerDependenciesMeta['uWebSockets.js'].optional, true);
+			assert.strictEqual(lock.packages[''].devDependencies, undefined);
+			assert.strictEqual(lock.packages['node_modules/uWebSockets.js'], undefined);
+			assert.strictEqual(lock.packages[''].peerDependencies['uWebSockets.js'], '20.68.0');
+			assert.strictEqual(lock.packages[''].peerDependenciesMeta['uWebSockets.js'].optional, true);
 		} finally {
 			await rm(tempDir, { recursive: true, force: true });
 		}

--- a/unitTests/server/serverHelpers/uwsServer.test.js
+++ b/unitTests/server/serverHelpers/uwsServer.test.js
@@ -2,7 +2,7 @@
  * Unit tests for the uWS UDS adapter (server/serverHelpers/uwsServer.ts, #914).
  *
  * Exercises the request-construction and response-serialization paths of createUwsServer over a
- * real Unix domain socket, without booting Harper. uWebSockets.js is an optionalDependency (built
+ * real Unix domain socket, without booting Harper. uWebSockets.js is an optional peer (installed
  * by CI); when it isn't installed for the current platform, the whole suite skips.
  */
 const assert = require('node:assert');


### PR DESCRIPTION
Moves the pinned uWebSockets.js archive from a production optional dependency to an optional peer, while retaining it as a dev dependency for Harper CI. This prevents published shrinkwraps from creating dangling optional edges that make consumer `npm ci` fail when npm omits the GitHub archive; operators enabling the default-off uWS backend can install the pinned archive explicitly.

Companion: [HarperFast/harper-pro#609 — Keep uWebSockets.js opt-in while bundling it in official images](https://github.com/HarperFast/harper-pro/pull/609). No documentation companion is needed: the uWS backend remains default-off/experimental, and `dependencies.md` now records the explicit-install requirement.

Generated by KrAIs (OpenAI GPT-5).