### PR TITLE
fix(resources): URL attribute-suffix routing for programmatic static-properties Resources

### DIFF
--- a/resources/Resource.ts
+++ b/resources/Resource.ts
@@ -395,7 +395,7 @@ export class Resource<Record extends object = any> implements ResourceInterface<
 				// name) without an `attributes` Array. Use an OWN-key check (not `properties[property]`,
 				// which would match inherited Object.prototype members like `constructor`/`toString`) —
 				// O(1), so no per-request projection on this path.
-				((this as any).properties != null && Object.hasOwn((this as any).properties, property))
+				(this.properties != null && Object.hasOwn(this.properties, property))
 			) {
 				// handle path.attribute for requesting a specific attribute using just the URL
 				path = path.slice(0, dotIndex); // remove the property from the path

--- a/resources/Resource.ts
+++ b/resources/Resource.ts
@@ -389,7 +389,14 @@ export class Resource<Record extends object = any> implements ResourceInterface<
 				// handle path.json, path.cbor, etc. for requesting a specific content type using just the URL
 				context.requestedContentType = requestedContentType;
 				path = path.slice(0, dotIndex); // remove the property from the path
-			} else if ((this as any).attributes?.find((attribute) => attribute.name === property)) {
+			} else if (
+				(this as any).attributes?.find((attribute) => attribute.name === property) ||
+				// A programmatic Resource may declare `static properties` (a Record keyed by attribute
+				// name) without an `attributes` Array. Use an OWN-key check (not `properties[property]`,
+				// which would match inherited Object.prototype members like `constructor`/`toString`) —
+				// O(1), so no per-request projection on this path.
+				((this as any).properties != null && Object.hasOwn((this as any).properties, property))
+			) {
 				// handle path.attribute for requesting a specific attribute using just the URL
 				path = path.slice(0, dotIndex); // remove the property from the path
 				if (query) query.property = property;

--- a/unitTests/resources/parsePath.test.js
+++ b/unitTests/resources/parsePath.test.js
@@ -1,0 +1,46 @@
+const assert = require('node:assert');
+const { Resource } = require('#src/resources/Resource');
+
+// #1922: URL attribute-suffix routing (/id.attr) resolves attributes via `this.attributes`. A
+// programmatic Resource may declare `static properties` (a Record keyed by attribute name) without
+// an `attributes` Array, so the suffix must also be looked up there — an O(1) key check, no
+// per-request projection.
+describe('Resource.parsePath attribute-suffix routing (#1922)', () => {
+	class ProgrammaticWidget extends Resource {
+		static properties = {
+			label: { type: 'string' },
+			size: { type: 'integer' },
+		};
+	}
+
+	it('routes /id.attr to a static-properties attribute (no attributes Array)', () => {
+		assert.strictEqual(ProgrammaticWidget.attributes, undefined, 'precondition: no attributes Array');
+		const query = {};
+		const result = ProgrammaticWidget.parsePath('123.label', {}, query);
+		assert.strictEqual(result, '123', 'the attribute suffix is stripped from the path');
+		assert.strictEqual(query.property, 'label', 'the attribute is bound onto the query');
+	});
+
+	it('returns { property, id } when no query object is provided', () => {
+		const result = ProgrammaticWidget.parsePath('123.size', {});
+		assert.deepStrictEqual(result, { property: 'size', id: '123' });
+	});
+
+	it('leaves an unknown suffix untouched', () => {
+		const query = {};
+		const result = ProgrammaticWidget.parsePath('123.nope', {}, query);
+		assert.strictEqual(result, '123.nope', 'a non-attribute suffix is not treated as an attribute');
+		assert.strictEqual(query.property, undefined);
+	});
+
+	it('does not treat inherited Object.prototype members as attributes', () => {
+		// `properties['constructor']` would be truthy via the prototype chain; the own-key check must
+		// reject it so /id.constructor (etc.) is not mistaken for an attribute suffix.
+		for (const proto of ['constructor', 'toString', 'hasOwnProperty', '__proto__']) {
+			const query = {};
+			const result = ProgrammaticWidget.parsePath(`123.${proto}`, {}, query);
+			assert.strictEqual(result, `123.${proto}`, `${proto} must not be treated as an attribute`);
+			assert.strictEqual(query.property, undefined);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Closes #1922 (follow-up from #1921's review). `Resource.parsePath` resolves a URL attribute suffix (`/Widget/id.label`) by scanning `this.attributes` for a matching name. A **programmatic** Resource that declares only `static properties` (a Record, no `attributes` Array — the shape #1921 makes first-class for schemas) has `attributes === undefined`, so that routing silently never matched.

Fix: fall back to an **own-key lookup** on the `static properties` Record, which is keyed by attribute name. It's O(1), so there's no per-request projection on this hot path (the issue floated a memoized projection; a direct key check is simpler and needs no cache or invalidation).

## Where to look

- **`resources/Resource.ts`** (`parsePath`) — one added clause: `... || (properties != null && Object.hasOwn(properties, property))`. `Object.hasOwn` (not `properties[property]`) is deliberate — a plain index would match inherited `Object.prototype` members (`constructor`, `toString`, …) and mistake `/id.constructor` for an attribute suffix. Table-backed routing is unchanged (the `attributes.find` check still runs first).

## Tests

`unitTests/resources/parsePath.test.js` — attribute-suffix routing on a programmatic `static properties` Resource (with/without a query object), an unknown suffix left untouched, and the inherited-prototype guard (`constructor`/`toString`/`hasOwnProperty`/`__proto__` are not treated as attributes).

Self-review caught the inherited-prototype issue; given the change is a single additive clause I did not run the full cross-model orchestration.

_PR generated by kAIle (Claude Opus 4.8)._
