### PR TITLE
fix(components): preserve entry events across deploy scans

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -129,6 +129,10 @@ Future agents touching `components/deploymentRecorder.ts` for Slice B's streamin
 
 The deploy lifecycle broadcast deliberately sits _outside_ the lock. Overlapping requests therefore increment the existing per-component lifecycle refcount before queueing; watchers remain suppressed continuously until the final queued preparation ends. The lock itself covers credential materialization, extraction, and installation. Its fully-written owner record is published with an atomic rename, so contenders never observe a partially initialized lock. A lock is never stolen from a known-live owner based on elapsed wall time: installs can be long-running and clocks can jump. Locks from a dead process are reclaimed, and a same-process contender asks the main thread whether the owning worker still exists so a worker crash does not wedge that component until Harper restarts. The bounded wait remains a backstop when owner liveness cannot be established.
 
+Extraction renames an existing component aside before writing the replacement. If extraction or
+single-directory normalization fails, the partial replacement is removed and the aside is renamed
+back before the deploy lifecycle resumes the component's watchers.
+
 A package-manager timeout must not release this lock while npm descendants are still mutating `node_modules`. POSIX spawns therefore run in a dedicated process group; timeout sends the group `SIGTERM`, escalates to `SIGKILL`, and waits for exit before rejecting. Windows uses `taskkill /T /F` for the equivalent process-tree termination. `manageThreads` tracks each spawned process tree by its owning Harper thread and force-terminates it if that worker exits, preventing detached installers from surviving a worker restart or Harper shutdown. `SIGKILL`/`taskkill` only queue termination, so a worker's dead-owner reclamation (above) waits for that thread's tracked process groups to be confirmed gone, not merely signaled—otherwise a replacement preparation could start while the old writer might still be alive. A process group a dead worker's own event loop spawned is never reaped from another thread, so it persists as a zombie rather than fully disappearing; since a zombie can no longer touch the filesystem, confirmation treats a zombie the same as a fully reaped exit.
 
 Boot's `harper-application-lock.json` records an application configuration only after preparation fulfills. Recording at queue time would make a failed install look complete and suppress its retry on the next boot.
@@ -649,10 +653,11 @@ layers it uses are proven equivalent:
 - `EntryHandler` compares consumer-visible watched entries.
 - `ApplicationScope` records the file URL and load-time digest of every application-local module
   that Harper's VM or compartment loader reads, including application-local package imports and
-  package self-references, together with the resolved target of each relative import. After a deploy,
-  those exact logical paths are re-read and each relative import is resolved again against the
-  replacement tree; adding a higher-priority `foo.js` ahead of a previously resolved `foo.json` is
-  therefore a runtime change even when `foo.json` itself is byte-identical.
+  package self-references, together with every application-local resolution edge. After a deploy,
+  those exact logical paths are re-read and each edge is resolved again against the replacement tree
+  after evicting Node's matching resolution-cache entry. Adding a higher-priority `foo.js` ahead of a
+  previously resolved `foo.json` is therefore a runtime change even when `foo.json` itself is
+  byte-identical.
 - The deploy pipeline compares dependency metadata at the same preparation stage: the previous
   installed tree before extraction versus the replacement tree after installation.
 
@@ -663,7 +668,8 @@ opaque path requires a restart on redeploy. `harper deploy` omits `node_modules`
 `package_component` that want restart-free comparison must likewise set `skip_node_modules: true`.
 Npm dependencies delegated from the default VM loader to Node's native loader are instead covered
 by the installed package/lock comparison—otherwise the default `dependencyLoader: auto` mode would
-make nearly every application opaque. `package.json` is compared as parsed JSON so formatting and
+make nearly every application opaque. Explicit `dependencyLoader: native` remains authoritative;
+an application-local import delegated by that setting marks the runtime opaque. `package.json` is compared as parsed JSON so formatting and
 key order are irrelevant, while lockfiles remain exact installed-tree evidence. A module first
 loaded while a deploy is in flight also invalidates the old runtime rather than letting a mixed
 generation appear equivalent. This is deliberately proof-oriented: an unused new local file need

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -129,6 +129,11 @@ Future agents touching `components/deploymentRecorder.ts` for Slice B's streamin
 
 The deploy lifecycle broadcast deliberately sits _outside_ the lock. Overlapping requests therefore increment the existing per-component lifecycle refcount before queueing; watchers remain suppressed continuously until the final queued preparation ends. The lock itself covers credential materialization, extraction, and installation. Its fully-written owner record is published with an atomic rename, so contenders never observe a partially initialized lock. A lock is never stolen from a known-live owner based on elapsed wall time: installs can be long-running and clocks can jump. Locks from a dead process are reclaimed, and a same-process contender asks the main thread whether the owning worker still exists so a worker crash does not wedge that component until Harper restarts. The bounded wait remains a backstop when owner liveness cannot be established.
 
+A plugin load that begins while its component is being deployed waits for that lifecycle to end before
+starting `handleApplication`; if a deploy begins during the load, the plugin timeout counts only active,
+unpaused load time. This prevents a long install from looking like a hung plugin while its entry handlers
+are deliberately paused against the intermediate tree.
+
 Extraction renames an existing component aside before writing the replacement and keeps it until
 dependency installation and metadata verification complete. Any preparation failure atomically
 renames the partial tree into hidden staging before restoring the prior tree, so a live writer cannot
@@ -658,7 +663,8 @@ layers it uses are proven equivalent:
   those exact logical paths are re-read and each edge is resolved again against the replacement tree
   after evicting Node's matching resolution-cache entry. Adding a higher-priority `foo.js` ahead of a
   previously resolved `foo.json` is therefore a runtime change even when `foo.json` itself is
-  byte-identical.
+  byte-identical. For import-only package exports that Node's CommonJS resolver cannot resolve, the
+  package manifest itself is recorded as a runtime input so an exports-map retarget is also observable.
 - The deploy pipeline compares dependency metadata at the same preparation stage: the previous
   installed tree before extraction versus the replacement tree after installation.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -609,3 +609,28 @@ runs pre-handshake there (auth is unaffected — it runs in the WS connection ch
 matching Node's upgrade-then-authorize order). No core component registers custom upgrade
 middleware; `onUpgrade()`/`installUwsWsHandler()` warn when one is registered for a uWS-served
 port so the gap is visible instead of silent.
+## Deploy watcher generations preserve logical entry events
+
+Component deploys pause each scope's `EntryHandler` while the component directory is replaced. A
+new chokidar instance then performs a cold-style initial scan, which reports every surviving path
+as `add`/`addDir` and cannot report paths that disappeared. Exposing those raw scan events changed
+the public `scope.handleEntry()` contract in #1806: consumers could no longer distinguish an
+unchanged file from a changed one, and deletions vanished entirely.
+
+`EntryHandler` therefore owns the deploy boundary. It retains a compact snapshot of matching paths
+(entry kind, URL path, and a SHA-256 content digest for files), assigns each watcher a monotonically
+increasing generation, and compares the resumed generation's scan with the pre-pause snapshot. The
+comparison emits only logical `add`, `change`, `unlink`, `addDir`, and `unlinkDir` events; unchanged
+entries remain silent. File contents are still read once for the event payload and are not retained
+in the snapshot. Reads and readiness are generation-scoped, and a per-path sequence prevents a slow
+read from an obsolete event from overwriting a newer state. Missing paths are synthesized as unlink
+events only after the resumed scan and all of its reads complete.
+
+Every watcher recreation uses the same comparison. The first generation compares against an empty
+snapshot and therefore retains its cold-load `add` behavior; deploy resume, configuration updates,
+and polling recovery compare against the last completed generation. This keeps file identity intact
+when watcher recovery could otherwise replay stale modules as new and ensures an update racing a
+deploy scan cannot discard its removals. New component deploys still use `Application#isNewComponent`
+to mark a restart as required for #674; package metadata changes outside consumer globs are tracked by
+the deploy operation, and other existing-component redeploys request a restart only when their logical
+entry or configuration changes require one.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -609,6 +609,7 @@ runs pre-handshake there (auth is unaffected — it runs in the WS connection ch
 matching Node's upgrade-then-authorize order). No core component registers custom upgrade
 middleware; `onUpgrade()`/`installUwsWsHandler()` warn when one is registered for a uWS-served
 port so the gap is visible instead of silent.
+
 ## Deploy watcher generations preserve logical entry events
 
 Component deploys pause each scope's `EntryHandler` while the component directory is replaced. A
@@ -631,6 +632,40 @@ snapshot and therefore retains its cold-load `add` behavior; deploy resume, conf
 and polling recovery compare against the last completed generation. This keeps file identity intact
 when watcher recovery could otherwise replay stale modules as new and ensures an update racing a
 deploy scan cannot discard its removals. New component deploys still use `Application#isNewComponent`
-to mark a restart as required for #674; package metadata changes outside consumer globs are tracked by
-the deploy operation, and other existing-component redeploys request a restart only when their logical
-entry or configuration changes require one.
+to mark a restart as required for #674; other existing-component redeploys request a restart only when
+their logical entry, loaded runtime, or configuration changes require one.
+
+## Restart-free deploys require proof of runtime equivalence
+
+`EntryHandler` intentionally observes only the files a component declares in its `files` option. It
+cannot prove that the JavaScript runtime is unchanged: a watched `resources.js` can import an
+unwatched `lib/db.js`, and installed dependencies live under the watcher's ignored `node_modules`
+tree. Conversely, hashing the entire extracted tree treats unused source and generated caches as
+runtime changes and collapses restart-free deploys back into unconditional restarts.
+
+Runtime equivalence is therefore layered. A deploy can remain restart-free only when all three
+layers it uses are proven equivalent:
+
+- `EntryHandler` compares consumer-visible watched entries.
+- `ApplicationScope` records the file URL and load-time digest of every application-local module
+  that Harper's VM or compartment loader reads, together with the local resolution candidates for
+  extensionless relative imports. After a deploy, those exact logical paths and resolution inputs
+  are compared with the installed replacement tree; adding a higher-priority `foo.js` ahead of a
+  previously resolved `foo.json` is therefore a runtime change even when `foo.json` itself is
+  byte-identical.
+- The deploy pipeline compares dependency metadata at the same preparation stage: the previous
+  installed tree before extraction versus the replacement tree after installation.
+
+Loader or installer paths that Harper cannot observe are conservative. Full native module loading,
+custom install commands, enabled install scripts, and installs without deterministic lock evidence
+mark the runtime opaque; an existing component using an opaque path requires a restart on redeploy.
+Npm dependencies delegated from the default VM loader to Node's native loader are instead covered
+by the installed package/lock comparison—otherwise the default `dependencyLoader: auto` mode would
+make nearly every application opaque. `package.json` is compared as parsed JSON so formatting and
+key order are irrelevant, while lockfiles remain exact installed-tree evidence. A module first
+loaded while a deploy is in flight also invalidates the old runtime rather than letting a mixed
+generation appear equivalent. This is deliberately proof-oriented: an unused new local file need
+not restart a fully observed runtime, but a changed or missing imported helper, changed resolution
+input, changed dependency evidence, or any genuinely opaque runtime does. Entry changes themselves
+remain consumer-directed: the static plugin applies asset changes incrementally, while executable
+consumers such as `jsResource` request a restart on their logical `change` or `unlink` events.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -129,9 +129,10 @@ Future agents touching `components/deploymentRecorder.ts` for Slice B's streamin
 
 The deploy lifecycle broadcast deliberately sits _outside_ the lock. Overlapping requests therefore increment the existing per-component lifecycle refcount before queueing; watchers remain suppressed continuously until the final queued preparation ends. The lock itself covers credential materialization, extraction, and installation. Its fully-written owner record is published with an atomic rename, so contenders never observe a partially initialized lock. A lock is never stolen from a known-live owner based on elapsed wall time: installs can be long-running and clocks can jump. Locks from a dead process are reclaimed, and a same-process contender asks the main thread whether the owning worker still exists so a worker crash does not wedge that component until Harper restarts. The bounded wait remains a backstop when owner liveness cannot be established.
 
-Extraction renames an existing component aside before writing the replacement. If extraction or
-single-directory normalization fails, the partial replacement is removed and the aside is renamed
-back before the deploy lifecycle resumes the component's watchers.
+Extraction renames an existing component aside before writing the replacement and keeps it until
+dependency installation and metadata verification complete. Any preparation failure atomically
+renames the partial tree into hidden staging before restoring the prior tree, so a live writer cannot
+wedge rollback with `ENOTEMPTY`; cleanup completes while the same-component lock is still held.
 
 A package-manager timeout must not release this lock while npm descendants are still mutating `node_modules`. POSIX spawns therefore run in a dedicated process group; timeout sends the group `SIGTERM`, escalates to `SIGKILL`, and waits for exit before rejecting. Windows uses `taskkill /T /F` for the equivalent process-tree termination. `manageThreads` tracks each spawned process tree by its owning Harper thread and force-terminates it if that worker exits, preventing detached installers from surviving a worker restart or Harper shutdown. `SIGKILL`/`taskkill` only queue termination, so a worker's dead-owner reclamation (above) waits for that thread's tracked process groups to be confirmed gone, not merely signaled—otherwise a replacement preparation could start while the old writer might still be alive. A process group a dead worker's own event loop spawned is never reaped from another thread, so it persists as a zombie rather than fully disappearing; since a zombie can no longer touch the filesystem, confirmation treats a zombie the same as a fully reaped exit.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -648,17 +648,19 @@ layers it uses are proven equivalent:
 
 - `EntryHandler` compares consumer-visible watched entries.
 - `ApplicationScope` records the file URL and load-time digest of every application-local module
-  that Harper's VM or compartment loader reads, together with the local resolution candidates for
-  extensionless relative imports. After a deploy, those exact logical paths and resolution inputs
-  are compared with the installed replacement tree; adding a higher-priority `foo.js` ahead of a
-  previously resolved `foo.json` is therefore a runtime change even when `foo.json` itself is
-  byte-identical.
+  that Harper's VM or compartment loader reads, including application-local package imports and
+  package self-references, together with the resolved target of each relative import. After a deploy,
+  those exact logical paths are re-read and each relative import is resolved again against the
+  replacement tree; adding a higher-priority `foo.js` ahead of a previously resolved `foo.json` is
+  therefore a runtime change even when `foo.json` itself is byte-identical.
 - The deploy pipeline compares dependency metadata at the same preparation stage: the previous
   installed tree before extraction versus the replacement tree after installation.
 
 Loader or installer paths that Harper cannot observe are conservative. Full native module loading,
-custom install commands, enabled install scripts, and installs without deterministic lock evidence
-mark the runtime opaque; an existing component using an opaque path requires a restart on redeploy.
+custom install commands, enabled install scripts, payloads that already contain `node_modules`, and
+installs without deterministic lock evidence mark the runtime opaque; an existing component using an
+opaque path requires a restart on redeploy. `harper deploy` omits `node_modules` by default; callers of
+`package_component` that want restart-free comparison must likewise set `skip_node_modules: true`.
 Npm dependencies delegated from the default VM loader to Node's native loader are instead covered
 by the installed package/lock comparison—otherwise the default `dependencyLoader: auto` mode would
 make nearly every application opaque. `package.json` is compared as parsed JSON so formatting and

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -487,8 +487,7 @@ const MAX_INSTALL_COMMANDS = 2;
 // module (both in source and in dist), holds no secret, and is inert without a live session.
 export const GIT_CREDENTIAL_HELPER_PATH = join(__dirname, 'gitCredentialHelper.js');
 
-const PACKAGE_METADATA_FILES = [
-	'package.json',
+const PACKAGE_LOCK_FILES = [
 	'package-lock.json',
 	'npm-shrinkwrap.json',
 	'pnpm-lock.yaml',
@@ -497,26 +496,86 @@ const PACKAGE_METADATA_FILES = [
 	'bun.lockb',
 ];
 
-async function readPackageMetadata(directory: string): Promise<Map<string, Buffer>> {
-	const metadata = new Map<string, Buffer>();
-	await Promise.all(
-		PACKAGE_METADATA_FILES.map(async (filename) => {
+type InstalledPackageMetadata = {
+	files: Map<string, Buffer>;
+	readable: boolean;
+	hasLockfile: boolean;
+	hasInstallableDependencies: boolean;
+};
+
+export async function readInstalledPackageMetadata(directory: string): Promise<InstalledPackageMetadata> {
+	const files = new Map<string, Buffer>();
+	let readable = true;
+	let packageJSON: any;
+	await Promise.all([
+		(async () => {
 			try {
-				metadata.set(filename, await readFile(join(directory, filename)));
+				const contents = await readFile(join(directory, 'package.json'));
+				try {
+					packageJSON = JSON.parse(contents.toString());
+					files.set('package.json', Buffer.from(JSON.stringify(canonicalizeJSON(packageJSON))));
+				} catch {
+					files.set('package.json', contents);
+				}
 			} catch (error) {
-				if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+				if ((error as NodeJS.ErrnoException).code !== 'ENOENT') readable = false;
 			}
-		})
-	);
-	return metadata;
+		})(),
+		...PACKAGE_LOCK_FILES.map(async (filename) => {
+			try {
+				files.set(filename, await readFile(join(directory, filename)));
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== 'ENOENT') readable = false;
+			}
+		}),
+	]);
+	return {
+		files,
+		readable,
+		hasLockfile: PACKAGE_LOCK_FILES.some((filename) => files.has(filename)),
+		hasInstallableDependencies: ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'].some(
+			(field) => {
+				const dependencies = packageJSON?.[field];
+				return (
+					typeof dependencies === 'object' &&
+					dependencies !== null &&
+					!Array.isArray(dependencies) &&
+					Object.keys(dependencies).length > 0
+				);
+			}
+		),
+	};
 }
 
-function packageMetadataEqual(previous: Map<string, Buffer>, current: Map<string, Buffer>): boolean {
-	if (previous.size !== current.size) return false;
-	for (const [filename, contents] of previous) {
-		if (!current.get(filename)?.equals(contents)) return false;
+export function installedPackageMetadataEqual(
+	previous: InstalledPackageMetadata,
+	current: InstalledPackageMetadata
+): boolean {
+	if (!previous.readable || !current.readable || previous.files.size !== current.files.size) return false;
+	for (const [filename, contents] of previous.files) {
+		if (!current.files.get(filename)?.equals(contents)) return false;
 	}
 	return true;
+}
+
+export function installedRuntimeChanged(
+	previous: InstalledPackageMetadata,
+	current: InstalledPackageMetadata,
+	installationIsOpaque: boolean
+): boolean {
+	return (
+		installationIsOpaque ||
+		(current.hasInstallableDependencies && !current.hasLockfile) ||
+		!installedPackageMetadataEqual(previous, current)
+	);
+}
+
+function canonicalizeJSON(value: any): any {
+	if (Array.isArray(value)) return value.map(canonicalizeJSON);
+	if (!value || typeof value !== 'object') return value;
+	const canonical: Record<string, any> = Object.create(null);
+	for (const key of Object.keys(value).sort()) canonical[key] = canonicalizeJSON(value[key]);
+	return canonical;
 }
 
 /**
@@ -539,8 +598,6 @@ export async function extractApplication(application: Application) {
 	if (application.payload && application.packageIdentifier) {
 		throw new Error('Both payload and package cannot be provided');
 	}
-	const previousPackageMetadata = await readPackageMetadata(application.dirPath);
-
 	// Resolve the tarball from the input
 	let tarballPath: string;
 	let tarball: Readable;
@@ -609,6 +666,7 @@ export async function extractApplication(application: Application) {
 			// not have, so this gates the pack step regardless of whether a credential happens to be in
 			// play.
 			const allowScripts = !!application.install?.allowInstallScripts;
+			if (allowScripts) application.installationIsOpaque = true;
 			// `--ignore-scripts` alone isn't a reliable way to enforce that: pacote's DirFetcher runs a
 			// git source's `prepare` unconditionally on npm versions before 11.0.0 (see
 			// packGitReferenceWithoutScripts), which is exactly what Node 22's bundled npm ships. For a
@@ -702,13 +760,6 @@ export async function extractApplication(application: Application) {
 		// Finally, remove the temp dir
 		await rm(tempDirPath, { recursive: true, force: true });
 	}
-	if (didRenameAside) {
-		application.packageMetadataChanged = !packageMetadataEqual(
-			previousPackageMetadata,
-			await readPackageMetadata(application.dirPath)
-		);
-	}
-
 	// Clean up the original tarball
 	if (shouldDeleteTarball && tarballPath) {
 		await rm(tarballPath, { force: true });
@@ -751,6 +802,7 @@ export async function installApplication(application: Application) {
 		// Does node_modules exist?
 		await access(join(application.dirPath, 'node_modules'), constants.F_OK);
 		application.logger.info(`Application ${application.name} already has node_modules; skipping install`);
+		application.installationIsOpaque = true;
 		return;
 	} catch (err) {
 		if (err.code !== 'ENOENT') throw err;
@@ -774,6 +826,7 @@ export async function installApplication(application: Application) {
 		);
 		// if it succeeds, return
 		if (code === 0) {
+			application.installationIsOpaque = true;
 			return;
 		}
 		if (stdout) {
@@ -836,6 +889,7 @@ export async function installApplication(application: Application) {
 
 		// if it succeeds, return
 		if (code === 0) {
+			if (application.install?.allowInstallScripts) application.installationIsOpaque = true;
 			return;
 		}
 
@@ -893,6 +947,7 @@ export async function installApplication(application: Application) {
 
 	// if it succeeds, return
 	if (code === 0) {
+		if (application.install?.allowInstallScripts) application.installationIsOpaque = true;
 		return;
 	}
 
@@ -959,9 +1014,10 @@ export class Application {
 	// that independently requests a restart if the redeploy actually needs one.
 	isNewComponent: boolean = true;
 	// Package metadata is intentionally outside most plugin `files` globs, but changing it can replace
-	// dependencies or module entry points underneath already-imported code. extractApplication compares
-	// manifests and lockfiles across the atomic swap so deployComponent can request the required restart.
+	// dependencies or module entry points underneath already-imported code. prepareApplication compares
+	// normalized manifests and lockfiles after installation so deployComponent can request the required restart.
 	packageMetadataChanged: boolean = false;
+	installationIsOpaque: boolean = false;
 
 	constructor({ name, payload, packageIdentifier, install, onInstallLine, credentials }: ApplicationOptions) {
 		this.name = name;
@@ -1113,6 +1169,7 @@ export async function prepareApplication(application: Application) {
 		await withComponentPreparationLock(
 			application.dirPath,
 			async () => {
+				const previousPackageMetadata = await readInstalledPackageMetadata(application.dirPath);
 				try {
 					// Materialize the per-deploy `.npmrc` before extraction so both `npm pack` (extract) and
 					// `npm install` authenticate against the private registry; always remove it afterward.
@@ -1128,6 +1185,14 @@ export async function prepareApplication(application: Application) {
 						await application.cleanupGitCredentialSession();
 					}
 					await installApplication(application);
+					if (!application.isNewComponent) {
+						const currentPackageMetadata = await readInstalledPackageMetadata(application.dirPath);
+						application.packageMetadataChanged = installedRuntimeChanged(
+							previousPackageMetadata,
+							currentPackageMetadata,
+							application.installationIsOpaque
+						);
+					}
 				} finally {
 					await application.cleanupTransientNpmrc();
 				}

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -745,7 +745,8 @@ export async function extractApplication(application: Application) {
 		const extracted = await readdir(application.dirPath, { withFileTypes: true });
 		if (extracted.length === 1 && extracted[0].isDirectory()) {
 			const topLevelDirPath = join(application.dirPath, extracted[0].name);
-			tempDirPath = await mkdtemp(application.dirPath);
+			await mkdir(asideStagingDir, { recursive: true });
+			tempDirPath = await mkdtemp(join(asideStagingDir, '.normalize-'));
 			await cp(topLevelDirPath, tempDirPath, { recursive: true });
 			await rm(topLevelDirPath, { recursive: true, force: true });
 			await cp(tempDirPath, application.dirPath, { recursive: true });
@@ -788,11 +789,9 @@ export async function extractApplication(application: Application) {
 	// earlier deploys whose workers have since exited, and a copy that survives because
 	// its worker is still live is swept by the next deploy. The failure is expected in
 	// the live-worker case, so it's logged at trace rather than as a warning.
-	if (asidePath) {
-		rm(asideStagingDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }).catch((err) =>
-			logger.trace?.(`Deferred cleanup of previous ${application.name} component directory: ${err.message}`)
-		);
-	}
+	rm(asideStagingDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }).catch((err) =>
+		logger.trace?.(`Deferred cleanup of previous ${application.name} component directory: ${err.message}`)
+	);
 }
 
 /**

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -737,6 +737,7 @@ export async function extractApplication(application: Application) {
 	// A directory existed for this component name prior to this deploy, so this is a redeploy of
 	// an already-active component rather than a first-time deploy. See `isNewComponent` above.
 	if (asidePath) application.isNewComponent = false;
+	let tempDirPath: string | undefined;
 	try {
 		await mkdir(application.dirPath, { recursive: true });
 		await pipeline(tarball, gunzip(), extract(application.dirPath));
@@ -744,19 +745,33 @@ export async function extractApplication(application: Application) {
 		const extracted = await readdir(application.dirPath, { withFileTypes: true });
 		if (extracted.length === 1 && extracted[0].isDirectory()) {
 			const topLevelDirPath = join(application.dirPath, extracted[0].name);
-			const tempDirPath = await mkdtemp(application.dirPath);
+			tempDirPath = await mkdtemp(application.dirPath);
 			await cp(topLevelDirPath, tempDirPath, { recursive: true });
 			await rm(topLevelDirPath, { recursive: true, force: true });
 			await cp(tempDirPath, application.dirPath, { recursive: true });
 			await rm(tempDirPath, { recursive: true, force: true });
+			tempDirPath = undefined;
 		}
 	} catch (error) {
-		try {
-			await rm(application.dirPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
-			if (asidePath) await rename(asidePath, application.dirPath);
-		} catch (rollbackError) {
+		const rollbackErrors: unknown[] = [];
+		for (const path of [application.dirPath, tempDirPath]) {
+			if (!path) continue;
+			try {
+				await rm(path, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+			} catch (rollbackError) {
+				rollbackErrors.push(rollbackError);
+			}
+		}
+		if (asidePath) {
+			try {
+				await rename(asidePath, application.dirPath);
+			} catch (rollbackError) {
+				rollbackErrors.push(rollbackError);
+			}
+		}
+		if (rollbackErrors.length > 0) {
 			throw new AggregateError(
-				[error, rollbackError],
+				[error, ...rollbackErrors],
 				`Failed to extract ${application.name} and restore its previous component directory`
 			);
 		}

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -801,7 +801,9 @@ export async function installApplication(application: Application) {
 	try {
 		// Does node_modules exist?
 		await access(join(application.dirPath, 'node_modules'), constants.F_OK);
-		application.logger.info(`Application ${application.name} already has node_modules; skipping install`);
+		application.logger.info(
+			`Application ${application.name} already has node_modules; skipping install and treating the runtime as opaque for redeploy comparison`
+		);
 		application.installationIsOpaque = true;
 		return;
 	} catch (err) {

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -772,7 +772,19 @@ export async function extractApplication(
 	}
 	// Clean up the original tarball
 	if (shouldDeleteTarball && tarballPath) {
-		await rm(tarballPath, { force: true });
+		try {
+			await rm(tarballPath, { force: true });
+		} catch (error) {
+			try {
+				await rollbackExtractedDirectory(application, asideStagingDir, asidePath);
+			} catch (rollbackError) {
+				throw new AggregateError(
+					[error, rollbackError],
+					`Failed to clean up the package for ${application.name} and restore its previous component directory`
+				);
+			}
+			throw error;
+		}
 	}
 
 	// Remove this component's aside copies. The old worker may still hold files open
@@ -812,13 +824,23 @@ async function rollbackExtractedDirectory(
 	asidePath: string | undefined
 ): Promise<void> {
 	await mkdir(asideStagingDir, { recursive: true });
+	const retryableRenameCodes = new Set(['EEXIST', 'ENOTEMPTY', 'EPERM', 'EACCES', 'EBUSY']);
 	const displaceCurrentDirectory = async () => {
 		const displacedPath = join(asideStagingDir, `.failed-${process.pid}-${Date.now()}-${randomUUID()}`);
-		try {
-			await rename(application.dirPath, displacedPath);
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+		let lastError: unknown;
+		for (let attempt = 0; attempt < 100; attempt++) {
+			try {
+				await rename(application.dirPath, displacedPath);
+				return;
+			} catch (error) {
+				const code = (error as NodeJS.ErrnoException).code;
+				if (code === 'ENOENT') return;
+				if (!retryableRenameCodes.has(code ?? '')) throw error;
+				lastError = error;
+				await delay(10);
+			}
 		}
+		throw lastError;
 	};
 
 	await displaceCurrentDirectory();
@@ -832,8 +854,9 @@ async function rollbackExtractedDirectory(
 				break;
 			} catch (error) {
 				restoreError = error;
-				if (!['EEXIST', 'ENOTEMPTY'].includes((error as NodeJS.ErrnoException).code ?? '')) break;
+				if (!retryableRenameCodes.has((error as NodeJS.ErrnoException).code ?? '')) break;
 				await displaceCurrentDirectory();
+				await delay(10);
 			}
 		}
 		if (!restored) throw restoreError;

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -483,6 +483,11 @@ const COMPONENT_PREPARATION_WAIT_MARGIN_MS = 30000;
 const MAX_GIT_EXTRACTION_COMMANDS = 4;
 const MAX_INSTALL_COMMANDS = 2;
 
+type ExtractionTransaction = {
+	commit(): Promise<void>;
+	rollback(): Promise<void>;
+};
+
 // The credential helper git executes for a private git-reference deploy. It ships alongside this
 // module (both in source and in dist), holds no secret, and is inert without a live session.
 export const GIT_CREDENTIAL_HELPER_PATH = join(__dirname, 'gitCredentialHelper.js');
@@ -588,7 +593,10 @@ function canonicalizeJSON(value: any): any {
  * This method may be called from any Harper thread. Same-component calls are serialized across
  * threads by the preparation lock below.
  */
-export async function extractApplication(application: Application) {
+export async function extractApplication(
+	application: Application,
+	deferCommit = false
+): Promise<ExtractionTransaction | undefined> {
 	// Can't specify neither
 	if (!application.payload && !application.packageIdentifier) {
 		throw new Error('Either payload or package must be provided');
@@ -737,7 +745,6 @@ export async function extractApplication(application: Application) {
 	// A directory existed for this component name prior to this deploy, so this is a redeploy of
 	// an already-active component rather than a first-time deploy. See `isNewComponent` above.
 	if (asidePath) application.isNewComponent = false;
-	let tempDirPath: string | undefined;
 	try {
 		await mkdir(application.dirPath, { recursive: true });
 		await pipeline(tarball, gunzip(), extract(application.dirPath));
@@ -746,33 +753,18 @@ export async function extractApplication(application: Application) {
 		if (extracted.length === 1 && extracted[0].isDirectory()) {
 			const topLevelDirPath = join(application.dirPath, extracted[0].name);
 			await mkdir(asideStagingDir, { recursive: true });
-			tempDirPath = await mkdtemp(join(asideStagingDir, '.normalize-'));
+			const tempDirPath = await mkdtemp(join(asideStagingDir, '.normalize-'));
 			await cp(topLevelDirPath, tempDirPath, { recursive: true });
 			await rm(topLevelDirPath, { recursive: true, force: true });
 			await cp(tempDirPath, application.dirPath, { recursive: true });
 			await rm(tempDirPath, { recursive: true, force: true });
-			tempDirPath = undefined;
 		}
 	} catch (error) {
-		const rollbackErrors: unknown[] = [];
-		for (const path of [application.dirPath, tempDirPath]) {
-			if (!path) continue;
-			try {
-				await rm(path, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
-			} catch (rollbackError) {
-				rollbackErrors.push(rollbackError);
-			}
-		}
-		if (asidePath) {
-			try {
-				await rename(asidePath, application.dirPath);
-			} catch (rollbackError) {
-				rollbackErrors.push(rollbackError);
-			}
-		}
-		if (rollbackErrors.length > 0) {
+		try {
+			await rollbackExtractedDirectory(application, asideStagingDir, asidePath);
+		} catch (rollbackError) {
 			throw new AggregateError(
-				[error, ...rollbackErrors],
+				[error, rollbackError],
 				`Failed to extract ${application.name} and restore its previous component directory`
 			);
 		}
@@ -789,9 +781,65 @@ export async function extractApplication(application: Application) {
 	// earlier deploys whose workers have since exited, and a copy that survives because
 	// its worker is still live is swept by the next deploy. The failure is expected in
 	// the live-worker case, so it's logged at trace rather than as a warning.
-	rm(asideStagingDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }).catch((err) =>
-		logger.trace?.(`Deferred cleanup of previous ${application.name} component directory: ${err.message}`)
-	);
+	let settled = false;
+	const transaction: ExtractionTransaction = {
+		async commit() {
+			if (settled) return;
+			settled = true;
+			await cleanupExtractionStaging(application, asideStagingDir);
+		},
+		async rollback() {
+			if (settled) return;
+			settled = true;
+			await rollbackExtractedDirectory(application, asideStagingDir, asidePath);
+		},
+	};
+	if (deferCommit) return transaction;
+	await transaction.commit();
+}
+
+async function cleanupExtractionStaging(application: Application, asideStagingDir: string): Promise<void> {
+	try {
+		await rm(asideStagingDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+	} catch (error) {
+		logger.trace?.(`Cleanup of previous ${application.name} component directory deferred: ${error.message}`);
+	}
+}
+
+async function rollbackExtractedDirectory(
+	application: Application,
+	asideStagingDir: string,
+	asidePath: string | undefined
+): Promise<void> {
+	await mkdir(asideStagingDir, { recursive: true });
+	const displaceCurrentDirectory = async () => {
+		const displacedPath = join(asideStagingDir, `.failed-${process.pid}-${Date.now()}-${randomUUID()}`);
+		try {
+			await rename(application.dirPath, displacedPath);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+		}
+	};
+
+	await displaceCurrentDirectory();
+	if (asidePath) {
+		let restored = false;
+		let restoreError: unknown;
+		for (let attempt = 0; attempt < 100; attempt++) {
+			try {
+				await rename(asidePath, application.dirPath);
+				restored = true;
+				break;
+			} catch (error) {
+				restoreError = error;
+				if (!['EEXIST', 'ENOTEMPTY'].includes((error as NodeJS.ErrnoException).code ?? '')) break;
+				await displaceCurrentDirectory();
+			}
+		}
+		if (!restored) throw restoreError;
+	}
+
+	await cleanupExtractionStaging(application, asideStagingDir);
 }
 
 /**
@@ -1179,6 +1227,7 @@ export async function prepareApplication(application: Application) {
 			application.dirPath,
 			async () => {
 				const previousPackageMetadata = await readInstalledPackageMetadata(application.dirPath);
+				let extraction: ExtractionTransaction | undefined;
 				try {
 					// Materialize the per-deploy `.npmrc` before extraction so both `npm pack` (extract) and
 					// `npm install` authenticate against the private registry; always remove it afterward.
@@ -1189,7 +1238,7 @@ export async function prepareApplication(application: Application) {
 						// already gone by the time the component's dependency tree (and any install script it is
 						// allowed to run) executes.
 						await application.startGitCredentialSession();
-						await extractApplication(application);
+						extraction = await extractApplication(application, true);
 					} finally {
 						await application.cleanupGitCredentialSession();
 					}
@@ -1202,6 +1251,17 @@ export async function prepareApplication(application: Application) {
 							application.installationIsOpaque
 						);
 					}
+					await extraction?.commit();
+				} catch (error) {
+					try {
+						await extraction?.rollback();
+					} catch (rollbackError) {
+						throw new AggregateError(
+							[error, rollbackError],
+							`Failed to prepare ${application.name} and restore its previous component directory`
+						);
+					}
+					throw error;
 				} finally {
 					await application.cleanupTransientNpmrc();
 				}

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -1233,7 +1233,7 @@ export function derivePackageIdentifier(packageIdentifier: string) {
  * @returns A promise that resolves when all preparation steps complete.
  */
 export async function prepareApplication(application: Application) {
-	await broadcastDeployStart(application.name);
+	const deploymentId = await broadcastDeployStart(application.name);
 	try {
 		const commandTimeoutMs = application.install?.timeout ?? DEFAULT_COMMAND_TIMEOUT_MS;
 		await withComponentPreparationLock(
@@ -1301,7 +1301,7 @@ export async function prepareApplication(application: Application) {
 			}
 		);
 	} finally {
-		broadcastDeployEnd(application.name);
+		broadcastDeployEnd(application.name, deploymentId);
 	}
 }
 

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -772,19 +772,9 @@ export async function extractApplication(
 	}
 	// Clean up the original tarball
 	if (shouldDeleteTarball && tarballPath) {
-		try {
-			await rm(tarballPath, { force: true });
-		} catch (error) {
-			try {
-				await rollbackExtractedDirectory(application, asideStagingDir, asidePath);
-			} catch (rollbackError) {
-				throw new AggregateError(
-					[error, rollbackError],
-					`Failed to clean up the package for ${application.name} and restore its previous component directory`
-				);
-			}
-			throw error;
-		}
+		await rm(tarballPath, { force: true }).catch((error) =>
+			application.logger.warn(`Failed to remove temporary package ${tarballPath}:`, error)
+		);
 	}
 
 	// Remove this component's aside copies. The old worker may still hold files open

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -487,6 +487,38 @@ const MAX_INSTALL_COMMANDS = 2;
 // module (both in source and in dist), holds no secret, and is inert without a live session.
 export const GIT_CREDENTIAL_HELPER_PATH = join(__dirname, 'gitCredentialHelper.js');
 
+const PACKAGE_METADATA_FILES = [
+	'package.json',
+	'package-lock.json',
+	'npm-shrinkwrap.json',
+	'pnpm-lock.yaml',
+	'yarn.lock',
+	'bun.lock',
+	'bun.lockb',
+];
+
+async function readPackageMetadata(directory: string): Promise<Map<string, Buffer>> {
+	const metadata = new Map<string, Buffer>();
+	await Promise.all(
+		PACKAGE_METADATA_FILES.map(async (filename) => {
+			try {
+				metadata.set(filename, await readFile(join(directory, filename)));
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+			}
+		})
+	);
+	return metadata;
+}
+
+function packageMetadataEqual(previous: Map<string, Buffer>, current: Map<string, Buffer>): boolean {
+	if (previous.size !== current.size) return false;
+	for (const [filename, contents] of previous) {
+		if (!current.get(filename)?.equals(contents)) return false;
+	}
+	return true;
+}
+
 /**
  * Extract an application given payload (content of the application) or package (npm-compatible identifier to the application).
  *
@@ -507,6 +539,7 @@ export async function extractApplication(application: Application) {
 	if (application.payload && application.packageIdentifier) {
 		throw new Error('Both payload and package cannot be provided');
 	}
+	const previousPackageMetadata = await readPackageMetadata(application.dirPath);
 
 	// Resolve the tarball from the input
 	let tarballPath: string;
@@ -668,6 +701,12 @@ export async function extractApplication(application: Application) {
 		await cp(tempDirPath, application.dirPath, { recursive: true });
 		// Finally, remove the temp dir
 		await rm(tempDirPath, { recursive: true, force: true });
+	}
+	if (didRenameAside) {
+		application.packageMetadataChanged = !packageMetadataEqual(
+			previousPackageMetadata,
+			await readPackageMetadata(application.dirPath)
+		);
 	}
 
 	// Clean up the original tarball
@@ -919,6 +958,10 @@ export class Application {
 	// an existing, already-loaded component already has a live file watcher (Scope/EntryHandler)
 	// that independently requests a restart if the redeploy actually needs one.
 	isNewComponent: boolean = true;
+	// Package metadata is intentionally outside most plugin `files` globs, but changing it can replace
+	// dependencies or module entry points underneath already-imported code. extractApplication compares
+	// manifests and lockfiles across the atomic swap so deployComponent can request the required restart.
+	packageMetadataChanged: boolean = false;
 
 	constructor({ name, payload, packageIdentifier, install, onInstallLine, credentials }: ApplicationOptions) {
 		this.name = name;

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -721,12 +721,13 @@ export async function extractApplication(application: Application) {
 	// component, and the per-component path means a sibling component never collides
 	// with (or sweeps) another's aside.
 	const asideStagingDir = join(dirname(application.dirPath), ASIDE_STAGING_DIR, basename(application.dirPath));
-	let didRenameAside = false;
+	let asidePath: string | undefined;
 	try {
 		await access(application.dirPath, constants.F_OK);
 		await mkdir(asideStagingDir, { recursive: true });
-		await rename(application.dirPath, join(asideStagingDir, `${process.pid}-${Date.now()}-${randomUUID()}`));
-		didRenameAside = true;
+		const candidateAsidePath = join(asideStagingDir, `${process.pid}-${Date.now()}-${randomUUID()}`);
+		await rename(application.dirPath, candidateAsidePath);
+		asidePath = candidateAsidePath;
 	} catch (err) {
 		// Ignore does not exist error
 		if (err.code !== 'ENOENT') {
@@ -735,30 +736,31 @@ export async function extractApplication(application: Application) {
 	}
 	// A directory existed for this component name prior to this deploy, so this is a redeploy of
 	// an already-active component rather than a first-time deploy. See `isNewComponent` above.
-	if (didRenameAside) application.isNewComponent = false;
-	// Finally, create the application directory fresh
-	await mkdir(application.dirPath, { recursive: true });
+	if (asidePath) application.isNewComponent = false;
+	try {
+		await mkdir(application.dirPath, { recursive: true });
+		await pipeline(tarball, gunzip(), extract(application.dirPath));
 
-	// Now pipeline the tarball into maybe-gunzip then tar-fs to reliably decompress and extract the contents
-	await pipeline(tarball, gunzip(), extract(application.dirPath));
-
-	// If the extracted directory contains a single folder, move the contents up one level
-	// The `npm pack` command does this (the top-level folder is called "package")
-	// Other packing tools may have similar behavior, but the directory name is not guaranteed.
-	const extracted = await readdir(application.dirPath, { withFileTypes: true });
-	if (extracted.length === 1 && extracted[0].isDirectory()) {
-		const topLevelDirPath = join(application.dirPath, extracted[0].name);
-
-		const tempDirPath = await mkdtemp(application.dirPath);
-
-		// Copy contents of top-level directory to temp directory (in order to avoid collisions of top-level directory name and one of the contents)
-		await cp(topLevelDirPath, tempDirPath, { recursive: true });
-		// Remove top-level directory
-		await rm(topLevelDirPath, { recursive: true, force: true });
-		// Copy contents of temp directory to application directory
-		await cp(tempDirPath, application.dirPath, { recursive: true });
-		// Finally, remove the temp dir
-		await rm(tempDirPath, { recursive: true, force: true });
+		const extracted = await readdir(application.dirPath, { withFileTypes: true });
+		if (extracted.length === 1 && extracted[0].isDirectory()) {
+			const topLevelDirPath = join(application.dirPath, extracted[0].name);
+			const tempDirPath = await mkdtemp(application.dirPath);
+			await cp(topLevelDirPath, tempDirPath, { recursive: true });
+			await rm(topLevelDirPath, { recursive: true, force: true });
+			await cp(tempDirPath, application.dirPath, { recursive: true });
+			await rm(tempDirPath, { recursive: true, force: true });
+		}
+	} catch (error) {
+		try {
+			await rm(application.dirPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+			if (asidePath) await rename(asidePath, application.dirPath);
+		} catch (rollbackError) {
+			throw new AggregateError(
+				[error, rollbackError],
+				`Failed to extract ${application.name} and restore its previous component directory`
+			);
+		}
+		throw error;
 	}
 	// Clean up the original tarball
 	if (shouldDeleteTarball && tarballPath) {
@@ -771,7 +773,7 @@ export async function extractApplication(application: Application) {
 	// earlier deploys whose workers have since exited, and a copy that survives because
 	// its worker is still live is swept by the next deploy. The failure is expected in
 	// the live-worker case, so it's logged at trace rather than as a warning.
-	if (didRenameAside) {
+	if (asidePath) {
 		rm(asideStagingDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }).catch((err) =>
 			logger.trace?.(`Deferred cleanup of previous ${application.name} component directory: ${err.message}`)
 		);
@@ -1007,17 +1009,8 @@ export class Application {
 	npmUserconfigPath?: string;
 	#npmrcTempDir?: string;
 	#gitCredentialSession?: GitCredentialSession;
-	// Whether this component's directory did not already exist when extractApplication ran —
-	// i.e. this deploy is the component's first, as opposed to a redeploy of something already
-	// active. Defaults true and is flipped to false by extractApplication when it finds (and
-	// renames aside) a pre-existing directory for this component name. Used by deployComponent to
-	// scope its unconditional requestRestart() call to genuinely new components (harper#1806):
-	// an existing, already-loaded component already has a live file watcher (Scope/EntryHandler)
-	// that independently requests a restart if the redeploy actually needs one.
+	// Existing components rely on their runtime-equivalence checks; only a first deploy restarts unconditionally.
 	isNewComponent: boolean = true;
-	// Package metadata is intentionally outside most plugin `files` globs, but changing it can replace
-	// dependencies or module entry points underneath already-imported code. prepareApplication compares
-	// normalized manifests and lockfiles after installation so deployComponent can request the required restart.
 	packageMetadataChanged: boolean = false;
 	installationIsOpaque: boolean = false;
 

--- a/components/ApplicationScope.ts
+++ b/components/ApplicationScope.ts
@@ -4,6 +4,7 @@ import { forComponent } from '../utility/logging/harper_logger.ts';
 import { scopedImport } from '../security/jsLoader.ts';
 import * as env from '../utility/environment/environmentManager.ts';
 import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
+import { RuntimeModuleTracker } from './RuntimeModuleTracker.ts';
 
 export class MissingDefaultFilesOptionError extends Error {
 	constructor() {
@@ -24,14 +25,17 @@ export class ApplicationScope {
 	mode?: 'native' | 'vm' | 'vm-current-context' | 'compartment'; // option to set this from the scope
 	dependencyLoader?: 'native' | 'app' | 'auto'; // option to set this from the scope
 	allowedPath?: string;
+	runtimeRoot?: string;
 	config: any;
 	moduleCache: any; // used by the loader to retain a cache of modules, type is an internal detail of the loader
+	#runtimeModules: RuntimeModuleTracker;
 	constructor(name: string, resources: Resources, server: Server, isInternal = false) {
 		this.name = name;
 		this.logger = forComponent(name, !isInternal);
 
 		this.resources = resources;
 		this.server = server;
+		this.#runtimeModules = new RuntimeModuleTracker(() => this.runtimeRoot);
 
 		this.mode = env.get(CONFIG_PARAMS.APPLICATIONS_MODULELOADER) ?? 'vm-current-context';
 		this.dependencyLoader = env.get(CONFIG_PARAMS.APPLICATIONS_DEPENDENCYLOADER);
@@ -49,5 +53,25 @@ export class ApplicationScope {
 	 */
 	async import(filePath: string): Promise<unknown> {
 		return scopedImport(filePath, this);
+	}
+
+	recordLoadedModule(moduleUrl: string, source: string | Buffer): void {
+		this.#runtimeModules.recordModule(moduleUrl, source);
+	}
+
+	recordModuleResolution(specifier: string, referrer: string, resolvedUrl: string): void {
+		this.#runtimeModules.recordResolution(specifier, referrer, resolvedUrl);
+	}
+
+	markNativeRuntime(): void {
+		this.#runtimeModules.markNativeRuntime();
+	}
+
+	beginDeploy(): void {
+		this.#runtimeModules.beginDeploy();
+	}
+
+	finishDeploy(): Promise<boolean> {
+		return this.#runtimeModules.finishDeploy();
 	}
 }

--- a/components/ApplicationScope.ts
+++ b/components/ApplicationScope.ts
@@ -5,6 +5,7 @@ import { scopedImport } from '../security/jsLoader.ts';
 import * as env from '../utility/environment/environmentManager.ts';
 import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 import { RuntimeModuleTracker } from './RuntimeModuleTracker.ts';
+import { deployLifecycle } from './deployLifecycle.ts';
 
 export class MissingDefaultFilesOptionError extends Error {
 	constructor() {
@@ -36,6 +37,7 @@ export class ApplicationScope {
 		this.resources = resources;
 		this.server = server;
 		this.#runtimeModules = new RuntimeModuleTracker(() => this.runtimeRoot);
+		if (deployLifecycle.isDeployInFlight(name)) this.#runtimeModules.beginDeploy();
 
 		this.mode = env.get(CONFIG_PARAMS.APPLICATIONS_MODULELOADER) ?? 'vm-current-context';
 		this.dependencyLoader = env.get(CONFIG_PARAMS.APPLICATIONS_DEPENDENCYLOADER);

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -1,5 +1,6 @@
 import { type Logger } from '../utility/logging/logger.ts';
 import { loggerWithTag } from '../utility/logging/harper_logger.ts';
+import { createHash } from 'node:crypto';
 import type { Stats } from 'node:fs';
 import { EventEmitter, once } from 'node:events';
 import { Component, FileAndURLPathConfig } from './Component.ts';
@@ -74,25 +75,42 @@ export type EntryHandlerEventMap = {
 	unlinkDir: [entry: UnlinkDirectoryEvent];
 };
 
+type EntrySnapshot =
+	{ entryType: 'file'; urlPath: string; digest: Buffer } | { entryType: 'directory'; urlPath: string };
+
+type RedeployScan = {
+	generation: number;
+	previousEntries: Map<string, EntrySnapshot>;
+	currentEntries: Map<string, EntrySnapshot>;
+	removalsEmitted: Set<string>;
+};
+
 export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	#component: Component;
 	#watcher?: FSWatcher;
 	#logger: Logger;
 	#pendingFileReads: Set<Promise<void>>;
+	#pendingFileReadsByGeneration: Map<number, Set<Promise<void>>>;
 	#isInitialScanComplete: boolean;
+	#readyGeneration = 0;
+	#watchGeneration = 0;
+	#eventSequence = 0;
+	#latestPathSequence = new Map<string, number>();
+	#entries = new Map<string, EntrySnapshot>();
+	#redeployScan?: RedeployScan;
 	// When true, #watch() short-circuits without creating a chokidar watcher.
 	// pause() sets it, resume() clears it. Lets a deploy quiesce the watcher
 	// without losing the EntryHandler instance (and therefore listener
 	// attachments registered by plugins via scope.handleEntry(handler)).
-	#paused: boolean = false;
+	#paused = false;
 	// Tracks the in-flight close() promise from pause() so resume() can await
 	// the old watcher's inotify handles releasing before installing a fresh
 	// chokidar instance — otherwise a rapid pause→resume can overlap teardown
 	// and setup, which under inotify pressure can produce spurious EMFILE.
 	#pausedClose?: Promise<void>;
-	#usingPolling: boolean = false;
-	#closed: boolean = false;
-	#openCount: number = 0;
+	#usingPolling = false;
+	#closed = false;
+	#openCount = 0;
 	ready: Promise<any[]>;
 
 	constructor(name: string, directory: string, config: FilesOption | FileAndURLPathConfig, logger?: Logger) {
@@ -101,6 +119,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		this.#component = new Component(name, directory, castConfig(config));
 		this.#logger = logger || loggerWithTag(name);
 		this.#pendingFileReads = new Set();
+		this.#pendingFileReadsByGeneration = new Map();
 		this.#isInitialScanComplete = false;
 		this.ready = once(this, 'ready');
 		this.#watch();
@@ -114,7 +133,8 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		return this.#component.directory;
 	}
 
-	#handleAll(...[event, path, stats]: FSWatcherEventMap['all']): void {
+	#handleAll(generation: number, ...[event, path, stats]: FSWatcherEventMap['all']): void {
+		if (generation !== this.#watchGeneration) return;
 		if (path === '') path = '/';
 
 		if (!isMatch(path, this.#component.globOptions.source, { ignore: this.#component.globOptions.ignore })) return;
@@ -124,26 +144,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		switch (event) {
 			case 'add':
 			case 'change': {
-				const urlPath = deriveURLPath(this.#component, path, 'file');
-				const fileReadPromise = readFile(absolutePath)
-					.then((contents) => {
-						const entry: AddFileEvent | ChangeFileEvent = {
-							eventType: event,
-							entryType: 'file' as const,
-							contents,
-							stats,
-							absolutePath,
-							urlPath,
-						};
-						this.emit('all', entry);
-						this.emit(event, entry as any);
-					})
-					.finally(() => {
-						this.#pendingFileReads.delete(fileReadPromise);
-						this.#checkIfAllComplete();
-					});
-
-				this.#pendingFileReads.add(fileReadPromise);
+				this.#queueFileRead(generation, event, path, absolutePath, stats, readFile(absolutePath));
 				break;
 			}
 			case 'unlink': {
@@ -155,24 +156,183 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 					absolutePath,
 					urlPath,
 				};
-				this.emit('all', entry);
-				this.emit(event, entry);
+				this.#handleRemovedEntry(generation, entry);
 				break;
 			}
 			case 'addDir':
 			case 'unlinkDir': {
 				const urlPath = deriveURLPath(this.#component, path, 'directory');
-				const entry: DirectoryEntryEvent = {
-					eventType: event,
-					entryType: 'directory' as const,
-					stats,
-					absolutePath,
-					urlPath,
-				};
-				this.emit('all', entry);
-				this.emit(event, entry as any);
+				if (event === 'addDir') {
+					const entry: AddDirectoryEvent = {
+						eventType: event,
+						entryType: 'directory',
+						stats,
+						absolutePath,
+						urlPath,
+					};
+					this.#handleAddedEntry(generation, entry, this.#snapshot(entry));
+				} else {
+					const entry: UnlinkDirectoryEvent = {
+						eventType: event,
+						entryType: 'directory',
+						stats,
+						absolutePath,
+						urlPath,
+					};
+					this.#handleRemovedEntry(generation, entry);
+				}
 				break;
 			}
+		}
+	}
+
+	#queueFileRead(
+		generation: number,
+		event: 'add' | 'change',
+		path: string,
+		absolutePath: string,
+		stats: Stats | undefined,
+		contentsPromise: Promise<Buffer>
+	): Promise<void> {
+		const sequence = ++this.#eventSequence;
+		this.#latestPathSequence.set(absolutePath, sequence);
+
+		const fileReadPromise = contentsPromise
+			.then((contents) => {
+				if (generation !== this.#watchGeneration || this.#latestPathSequence.get(absolutePath) !== sequence) return;
+				const entry: AddFileEvent | ChangeFileEvent = {
+					eventType: event,
+					entryType: 'file',
+					contents,
+					stats,
+					absolutePath,
+					urlPath: deriveURLPath(this.#component, path, 'file'),
+				};
+				this.#handleAddedEntry(generation, entry, this.#snapshot(entry));
+			})
+			.catch((error) => {
+				if (
+					generation !== this.#watchGeneration ||
+					(error as NodeJS.ErrnoException | null | undefined)?.code === 'ENOENT'
+				)
+					return;
+				this.#handleError(error);
+			})
+			.finally(() => {
+				if (this.#latestPathSequence.get(absolutePath) === sequence) this.#latestPathSequence.delete(absolutePath);
+				this.#pendingFileReads.delete(fileReadPromise);
+				const generationReads = this.#pendingFileReadsByGeneration.get(generation);
+				generationReads?.delete(fileReadPromise);
+				if (generationReads?.size === 0) this.#pendingFileReadsByGeneration.delete(generation);
+				this.#checkIfAllComplete(generation);
+			});
+
+		this.#pendingFileReads.add(fileReadPromise);
+		let generationReads = this.#pendingFileReadsByGeneration.get(generation);
+		if (!generationReads) this.#pendingFileReadsByGeneration.set(generation, (generationReads = new Set()));
+		generationReads.add(fileReadPromise);
+		return fileReadPromise;
+	}
+
+	#snapshot(entry: AddFileEvent | ChangeFileEvent | AddDirectoryEvent): EntrySnapshot {
+		if (entry.entryType === 'file')
+			return {
+				entryType: entry.entryType,
+				urlPath: entry.urlPath,
+				digest: createHash('sha256').update(entry.contents).digest(),
+			};
+		return { entryType: entry.entryType, urlPath: entry.urlPath };
+	}
+
+	#handleAddedEntry(
+		generation: number,
+		entry: AddFileEvent | ChangeFileEvent | AddDirectoryEvent,
+		snapshot: EntrySnapshot
+	): void {
+		if (generation !== this.#watchGeneration) return;
+		const scan = this.#redeployScan?.generation === generation ? this.#redeployScan : undefined;
+		if (!scan) {
+			const wasKnown = this.#entries.has(entry.absolutePath);
+			this.#entries.set(entry.absolutePath, snapshot);
+			// A newer change read can supersede an initial add read for the same path. The consumer still
+			// needs its first event to be an add so it can load the entry before handling later changes.
+			if (entry.entryType === 'file' && entry.eventType === 'change' && !wasKnown)
+				this.#emitEntry({ ...entry, eventType: 'add' });
+			else this.#emitEntry(entry);
+			return;
+		}
+
+		const wasRemovedDuringScan = scan.removalsEmitted.delete(entry.absolutePath);
+		const currentEntry = scan.currentEntries.get(entry.absolutePath);
+		const previousEntry = wasRemovedDuringScan
+			? undefined
+			: (currentEntry ?? scan.previousEntries.get(entry.absolutePath));
+		scan.currentEntries.set(entry.absolutePath, snapshot);
+
+		if (!previousEntry) {
+			this.#emitAddition(entry);
+			return;
+		}
+		if (previousEntry.entryType !== snapshot.entryType || previousEntry.urlPath !== snapshot.urlPath) {
+			this.#emitRemoval(previousEntry, entry.absolutePath);
+			this.#emitAddition(entry);
+			return;
+		}
+		if (
+			snapshot.entryType === 'file' &&
+			previousEntry.entryType === 'file' &&
+			!previousEntry.digest.equals(snapshot.digest)
+		) {
+			this.#emitEntry({ ...entry, eventType: 'change' } as ChangeFileEvent);
+		}
+	}
+
+	#emitAddition(entry: AddFileEvent | ChangeFileEvent | AddDirectoryEvent): void {
+		if (entry.entryType === 'file') this.#emitEntry({ ...entry, eventType: 'add' });
+		else this.#emitEntry({ ...entry, eventType: 'addDir' });
+	}
+
+	#handleRemovedEntry(generation: number, entry: UnlinkFileEvent | UnlinkDirectoryEvent): void {
+		if (generation !== this.#watchGeneration) return;
+		// Absence invalidates any pending read sequence for this path without retaining every path ever seen.
+		this.#latestPathSequence.delete(entry.absolutePath);
+		const scan = this.#redeployScan?.generation === generation ? this.#redeployScan : undefined;
+		if (!scan) {
+			this.#entries.delete(entry.absolutePath);
+			this.#emitEntry(entry);
+			return;
+		}
+
+		const knownEntry = scan.currentEntries.get(entry.absolutePath) ?? scan.previousEntries.get(entry.absolutePath);
+		scan.currentEntries.delete(entry.absolutePath);
+		if (!knownEntry || scan.removalsEmitted.has(entry.absolutePath)) return;
+		this.#emitRemoval(knownEntry, entry.absolutePath);
+		scan.removalsEmitted.add(entry.absolutePath);
+	}
+
+	#emitRemoval(snapshot: EntrySnapshot, absolutePath: string): void {
+		if (snapshot.entryType === 'file')
+			this.#emitEntry({ eventType: 'unlink', entryType: 'file', absolutePath, urlPath: snapshot.urlPath });
+		else this.#emitEntry({ eventType: 'unlinkDir', entryType: 'directory', absolutePath, urlPath: snapshot.urlPath });
+	}
+
+	#emitEntry(entry: FileEntryEvent | DirectoryEntryEvent): void {
+		this.emit('all', entry);
+		switch (entry.eventType) {
+			case 'add':
+				this.emit('add', entry);
+				break;
+			case 'change':
+				this.emit('change', entry);
+				break;
+			case 'unlink':
+				this.emit('unlink', entry);
+				break;
+			case 'addDir':
+				this.emit('addDir', entry);
+				break;
+			case 'unlinkDir':
+				this.emit('unlinkDir', entry);
 		}
 	}
 
@@ -199,21 +359,66 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		this.emit('error', error);
 	}
 
-	#handleReady(): void {
+	#handleReady(generation: number): void {
+		if (generation !== this.#watchGeneration) return;
 		this.#isInitialScanComplete = true;
-		if (this.#pendingFileReads.size > 0) {
-			this.#logger.debug?.(
-				`Initial scan complete, still waiting for ${this.#pendingFileReads.size} pending file reads`
-			);
+		const pendingReads = this.#pendingFileReadsByGeneration.get(generation)?.size ?? 0;
+		if (pendingReads > 0) {
+			this.#logger.debug?.(`Initial scan complete, still waiting for ${pendingReads} pending file reads`);
 		}
-		this.#checkIfAllComplete();
+		this.#checkIfAllComplete(generation);
 	}
 
-	#checkIfAllComplete(): void {
+	#checkIfAllComplete(generation: number): void {
 		// Only emit 'ready' once the initial scan is complete AND all file reads are done
-		if (this.#isInitialScanComplete && this.#pendingFileReads.size === 0) {
+		if (
+			generation === this.#watchGeneration &&
+			this.#readyGeneration !== generation &&
+			this.#isInitialScanComplete &&
+			!this.#pendingFileReadsByGeneration.has(generation)
+		) {
+			this.#readyGeneration = generation;
+			const listenerErrors = this.#finishRedeployScan(generation);
 			this.emit('ready');
+			// `events.once(this, 'ready')` rejects if `error` is emitted first. Surface consumer failures only
+			// after resolving the generation's ready latch so one bad removal listener cannot strand startup.
+			for (const error of listenerErrors) this.#handleError(error);
 		}
+	}
+
+	#finishRedeployScan(generation: number): unknown[] {
+		const scan = this.#redeployScan;
+		if (!scan || scan.generation !== generation) return [];
+		const listenerErrors: unknown[] = [];
+		const missingEntries = [...scan.previousEntries].filter(
+			([absolutePath]) => !scan.currentEntries.has(absolutePath) && !scan.removalsEmitted.has(absolutePath)
+		);
+		// Match watcher deletion semantics: descendants disappear before the directory that contained them.
+		missingEntries.sort(([a], [b]) => b.length - a.length);
+		// Commit the generation before invoking consumer code. A synchronously throwing removal listener must
+		// not leave the old snapshot installed or keep the readiness latch permanently unresolved.
+		this.#entries = scan.currentEntries;
+		this.#redeployScan = undefined;
+		for (const [absolutePath, snapshot] of missingEntries) {
+			try {
+				this.#emitRemoval(snapshot, absolutePath);
+			} catch (error) {
+				listenerErrors.push(error);
+			}
+		}
+		return listenerErrors;
+	}
+
+	#observedEntries(): Map<string, EntrySnapshot> {
+		const scan = this.#redeployScan;
+		if (!scan) return this.#entries;
+		// A generation can be replaced before `ready`, after some events have already reached consumers.
+		// Carry exactly that observed state forward: retain previously known paths that this partial scan
+		// has not reached, apply additions/changes it emitted, and remove paths whose unlink was emitted.
+		const observedEntries = new Map(scan.previousEntries);
+		for (const absolutePath of scan.removalsEmitted) observedEntries.delete(absolutePath);
+		for (const [absolutePath, snapshot] of scan.currentEntries) observedEntries.set(absolutePath, snapshot);
+		return observedEntries;
 	}
 
 	async #watch() {
@@ -225,7 +430,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 			this.#pausedClose = undefined;
 		}
 
-		await this.#watcher?.close();
+		if (this.#watcher) await this.#watcher.close();
 		this.#watcher = undefined;
 
 		// If close() landed while a previous close()/recreate was awaiting, don't
@@ -235,11 +440,22 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		// pause() may have landed in the gap before our async close resolved.
 		// If so, do not install a replacement watcher — resume() will.
 		if (this.#paused) return this.ready;
+		const generation = ++this.#watchGeneration;
 
-		// When a fresh watcher is installed (after pause+resume, or update), the
-		// initial scan emits add events anew, so reset the readiness latch so
-		// `ready` resolves after the new scan completes.
+		// Every watcher generation gets its own readiness latch and compares its
+		// initial scan with the last completed generation. The first generation
+		// compares against an empty snapshot, preserving its cold-load add events;
+		// pause/resume, config updates, and polling recovery all preserve logical
+		// identity instead of replaying surviving entries as fresh adds.
 		this.#isInitialScanComplete = false;
+		const previousEntries = this.#observedEntries();
+		this.#entries = previousEntries;
+		this.#redeployScan = {
+			generation,
+			previousEntries,
+			currentEntries: new Map(),
+			removalsEmitted: new Set(),
+		};
 
 		const allowedBases = this.#component.patternBases.map((base) => join(this.#component.directory, base));
 
@@ -280,9 +496,9 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 					);
 				},
 			})
-			.on('all', this.#handleAll.bind(this))
+			.on('all', (...args) => this.#handleAll(generation, ...args))
 			.on('error', this.#handleError.bind(this))
-			.on('ready', this.#handleReady.bind(this));
+			.on('ready', () => this.#handleReady(generation));
 
 		return this.ready;
 	}
@@ -292,6 +508,12 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	// real ENOSPC/EMFILE on the host.
 	_simulateWatcherErrorForTests(error: unknown): void {
 		this.#handleError(error);
+	}
+
+	// Test-only: enqueue a controllable file read through the same generation checks as chokidar events.
+	_simulateFileReadForTests(event: 'add' | 'change', path: string, contents: Promise<Buffer>): Promise<void> {
+		const absolutePath = join(this.directory, path);
+		return this.#queueFileRead(this.#watchGeneration, event, path, absolutePath, undefined, contents);
 	}
 
 	// Test-only: whether the watcher has fallen back to polling.
@@ -307,6 +529,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	}
 
 	close(): Promise<this> {
+		this.#watchGeneration++;
 		this.#closed = true;
 		const pendingReads = [...this.#pendingFileReads];
 		const watcherClose = this.#watcher ? Promise.resolve(this.#watcher.close()).catch(() => {}) : Promise.resolve();
@@ -332,6 +555,10 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	 * Idempotent. Awaiting `ready` while paused will not resolve until resume().
 	 */
 	pause(): void {
+		if (this.#paused) return;
+		// Invalidate callbacks and reads already queued by the watcher being paused. They belong to the
+		// pre-deploy tree and must not be mistaken for events from the resumed generation.
+		this.#watchGeneration++;
 		this.#paused = true;
 		// Reset `ready` to a fresh pending promise so the documented "awaiting
 		// ready while paused will not resolve until resume()" contract holds even
@@ -350,10 +577,8 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 
 	/**
 	 * Reinstate the watcher previously stopped by pause(). The fresh chokidar
-	 * instance does an initial scan and emits add events for every file
-	 * currently matching the configured globs — by design, since the typical
-	 * caller (Scope, on deploy:end) wants plugins to see the post-deploy tree
-	 * as if loading cold.
+	 * instance scans the post-pause tree, compares it with the retained snapshot,
+	 * and emits only the logical add, change, unlink, addDir, and unlinkDir events.
 	 *
 	 * No-op if not currently paused.
 	 */

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -83,8 +83,7 @@ type RedeployScan = {
 	previousEntries: Map<string, EntrySnapshot>;
 	currentEntries: Map<string, EntrySnapshot>;
 	removalsEmitted: Set<string>;
-	readFailures: Set<string>;
-	readErrors: unknown[];
+	readFailures: Map<string, unknown>;
 };
 
 export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
@@ -243,6 +242,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 			.then(
 				(contents) => {
 					if (generation !== this.#watchGeneration || this.#latestPathSequence.get(absolutePath) !== sequence) return;
+					if (this.#redeployScan?.generation === generation) this.#redeployScan.readFailures.delete(absolutePath);
 					const entry: AddFileEvent | ChangeFileEvent = {
 						eventType: event,
 						entryType: 'file',
@@ -260,12 +260,12 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 				(error) => {
 					if (
 						generation !== this.#watchGeneration ||
+						this.#latestPathSequence.get(absolutePath) !== sequence ||
 						(error as NodeJS.ErrnoException | null | undefined)?.code === 'ENOENT'
 					)
 						return;
 					if (this.#redeployScan?.generation === generation) {
-						this.#redeployScan.readFailures.add(absolutePath);
-						this.#redeployScan.readErrors.push(error);
+						this.#redeployScan.readFailures.set(absolutePath, error);
 					} else {
 						this.#handleWatcherError(error);
 					}
@@ -310,8 +310,8 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 			// A newer change read can supersede an initial add read for the same path. The consumer still
 			// needs its first event to be an add so it can load the entry before handling later changes.
 			if (entry.entryType === 'file' && entry.eventType === 'change' && !wasKnown)
-				this.#emitEntry({ ...entry, eventType: 'add' });
-			else this.#emitEntry(entry);
+				this.#emitEntrySafely({ ...entry, eventType: 'add' });
+			else this.#emitEntrySafely(entry);
 			return;
 		}
 
@@ -340,13 +340,13 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 			previousEntry.entryType === 'file' &&
 			!previousEntry.digest.equals(snapshot.digest)
 		) {
-			this.#emitEntry({ ...entry, eventType: 'change' } as ChangeFileEvent);
+			this.#emitEntrySafely({ ...entry, eventType: 'change' } as ChangeFileEvent);
 		}
 	}
 
 	#emitAddition(entry: AddFileEvent | ChangeFileEvent | AddDirectoryEvent): void {
-		if (entry.entryType === 'file') this.#emitEntry({ ...entry, eventType: 'add' });
-		else this.#emitEntry({ ...entry, eventType: 'addDir' });
+		if (entry.entryType === 'file') this.#emitEntrySafely({ ...entry, eventType: 'add' });
+		else this.#emitEntrySafely({ ...entry, eventType: 'addDir' });
 	}
 
 	#handleRemovedEntry(generation: number, entry: UnlinkFileEvent | UnlinkDirectoryEvent): void {
@@ -356,14 +356,18 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		const scan = this.#redeployScan?.generation === generation ? this.#redeployScan : undefined;
 		if (!scan) {
 			this.#entries.delete(entry.absolutePath);
-			this.#emitEntry(entry);
+			this.#emitEntrySafely(entry);
 			return;
 		}
 
 		const knownEntry = scan.currentEntries.get(entry.absolutePath) ?? scan.previousEntries.get(entry.absolutePath);
 		scan.currentEntries.delete(entry.absolutePath);
 		if (!knownEntry || scan.removalsEmitted.has(entry.absolutePath)) return;
-		this.#emitRemoval(knownEntry, entry.absolutePath);
+		try {
+			this.#emitRemoval(knownEntry, entry.absolutePath);
+		} catch (error) {
+			this.#reportConsumerError(error);
+		}
 		scan.removalsEmitted.add(entry.absolutePath);
 	}
 
@@ -390,6 +394,14 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 				break;
 			case 'unlinkDir':
 				this.emit('unlinkDir', entry);
+		}
+	}
+
+	#emitEntrySafely(entry: FileEntryEvent | DirectoryEntryEvent): void {
+		try {
+			this.#emitEntry(entry);
+		} catch (error) {
+			this.#reportConsumerError(error);
 		}
 	}
 
@@ -452,9 +464,9 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		const scan = this.#redeployScan;
 		if (!scan || scan.generation !== generation) return { listenerErrors: [], readErrors: [] };
 		const listenerErrors: unknown[] = [];
-		for (const absolutePath of scan.readFailures) {
+		for (const absolutePath of scan.readFailures.keys()) {
 			const previousEntry = scan.previousEntries.get(absolutePath);
-			if (previousEntry) scan.currentEntries.set(absolutePath, previousEntry);
+			if (previousEntry && !scan.currentEntries.has(absolutePath)) scan.currentEntries.set(absolutePath, previousEntry);
 		}
 		const missingEntries = [...scan.previousEntries].filter(
 			([absolutePath]) => !scan.currentEntries.has(absolutePath) && !scan.removalsEmitted.has(absolutePath)
@@ -472,7 +484,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 				listenerErrors.push(error);
 			}
 		}
-		return { listenerErrors, readErrors: scan.readErrors };
+		return { listenerErrors, readErrors: [...scan.readFailures.values()] };
 	}
 
 	#observedEntries(): Map<string, EntrySnapshot> {
@@ -551,8 +563,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 			previousEntries,
 			currentEntries: new Map(),
 			removalsEmitted: new Set(),
-			readFailures: new Set(),
-			readErrors: [],
+			readFailures: new Map(),
 		};
 
 		const allowedBases = this.#component.patternBases.map((base) => join(this.#component.directory, base));

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -93,33 +93,20 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	#pendingFileReads: Set<Promise<void>>;
 	#pendingFileReadsByGeneration: Map<number, Set<Promise<void>>>;
 	#isInitialScanComplete: boolean;
+	#readyPending = false;
 	#readyGeneration = 0;
 	#watchGeneration = 0;
 	#eventSequence = 0;
 	#latestPathSequence = new Map<string, number>();
 	#entries = new Map<string, EntrySnapshot>();
 	#redeployScan?: RedeployScan;
-	// When true, #watch() short-circuits without creating a chokidar watcher.
-	// pause() sets it, resume() clears it. Lets a deploy quiesce the watcher
-	// without losing the EntryHandler instance (and therefore listener
-	// attachments registered by plugins via scope.handleEntry(handler)).
 	#paused = false;
-	// Tracks the in-flight close() promise from pause() so resume() can await
-	// the old watcher's inotify handles releasing before installing a fresh
-	// chokidar instance — otherwise a rapid pause→resume can overlap teardown
-	// and setup, which under inotify pressure can produce spurious EMFILE.
 	#pausedClose?: Promise<void>;
-	// Set while a watcher replacement is in flight, to serialize the next one. Concurrent
-	// #watch() calls would otherwise each observe the same live watcher before their close()
-	// await and then install their own, orphaning the intervening chokidar instance's inotify
-	// handles. Left undefined when idle so the first install — which has nothing to await —
-	// still claims its generation synchronously.
+	// Serializes replacements so concurrent update/recovery calls cannot orphan an intervening watcher.
 	#watchInstall?: Promise<void>;
 	#usingPolling = false;
 	#closed = false;
 	#openCount = 0;
-	// Chokidar instances opened but not yet closed. Normally holds at most one entry; a larger
-	// set means a replacement watcher orphaned a live one, leaking its inotify handles.
 	#liveWatchers = new Set<FSWatcher>();
 	ready: Promise<any[]>;
 
@@ -132,14 +119,15 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		this.#pendingFileReadsByGeneration = new Map();
 		this.#isInitialScanComplete = false;
 		this.ready = this.#createReadyLatch();
-		// Fire-and-forget: the returned readiness latch rejects if the first generation emits
-		// `error` before `ready`, and consumers observe that through the 'error' event instead.
 		this.#watch().catch(() => {});
 	}
 
 	#createReadyLatch(): Promise<any[]> {
+		if (this.#readyPending) return this.ready;
+		this.#readyPending = true;
 		const ready = new Promise<any[]>((resolve, reject) => {
 			const cleanup = () => {
+				this.#readyPending = false;
 				this.off('ready', handleReady);
 				this.off('error', handleError);
 				this.off('close', handleClose);
@@ -160,8 +148,6 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 			this.once('error', handleError);
 			this.once('close', handleClose);
 		});
-		// Keep a fire-and-forget watcher lifecycle from producing an unhandled rejection while
-		// preserving rejection for callers that await this same promise.
 		void ready.catch(() => {});
 		return ready;
 	}
@@ -351,7 +337,6 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 
 	#handleRemovedEntry(generation: number, entry: UnlinkFileEvent | UnlinkDirectoryEvent): void {
 		if (generation !== this.#watchGeneration) return;
-		// Absence invalidates any pending read sequence for this path without retaining every path ever seen.
 		this.#latestPathSequence.delete(entry.absolutePath);
 		const scan = this.#redeployScan?.generation === generation ? this.#redeployScan : undefined;
 		if (!scan) {
@@ -429,7 +414,8 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	}
 
 	#reportConsumerError(error: unknown): void {
-		this.emit('error', error);
+		if (this.listenerCount('error') > 0) this.emit('error', error);
+		else this.#logger.error?.('Error in entry listener:', error);
 	}
 
 	#handleReady(generation: number): void {
@@ -443,7 +429,6 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	}
 
 	#checkIfAllComplete(generation: number): void {
-		// Only emit 'ready' once the initial scan is complete AND all file reads are done
 		if (
 			generation === this.#watchGeneration &&
 			this.#readyGeneration !== generation &&
@@ -500,12 +485,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	}
 
 	async #watch() {
-		// Replacement is serialized: an update() racing another update() or the polling-fallback
-		// recovery must not tear down and install watchers concurrently, or the watcher installed
-		// by the first call is overwritten by the second and never closed.
 		const install = this.#watchInstall ? this.#watchInstall.then(() => this.#installWatcher()) : this.#installWatcher();
-		// Release the chain once this replacement settles — a failed install must not block or
-		// reject later callers.
 		const settled: Promise<void> = install.then(
 			() => {
 				if (this.#watchInstall === settled) this.#watchInstall = undefined;
@@ -521,9 +501,6 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	}
 
 	async #installWatcher(): Promise<void> {
-		// If pause() retained an in-flight close, wait for it to release inotify
-		// handles before we install a new watcher. Otherwise a fast pause→resume
-		// can overlap teardown and setup under inotify pressure.
 		if (this.#pausedClose) {
 			await this.#pausedClose;
 			this.#pausedClose = undefined;
@@ -541,20 +518,11 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 			if (this.#watcher === outgoing) this.#watcher = undefined;
 		}
 
-		// If close() landed while a previous close()/recreate was awaiting, don't
-		// install a fresh watcher — it would outlive the EntryHandler.
 		if (this.#closed) return;
 
-		// pause() may have landed in the gap before our async close resolved.
-		// If so, do not install a replacement watcher — resume() will.
 		if (this.#paused) return;
 		const generation = ++this.#watchGeneration;
 
-		// Every watcher generation gets its own readiness latch and compares its
-		// initial scan with the last completed generation. The first generation
-		// compares against an empty snapshot, preserving its cold-load add events;
-		// pause/resume, config updates, and polling recovery all preserve logical
-		// identity instead of replaying surviving entries as fresh adds.
 		this.#isInitialScanComplete = false;
 		const previousEntries = this.#observedEntries();
 		this.#entries = previousEntries;
@@ -613,33 +581,23 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		this.#liveWatchers.add(watcher);
 	}
 
-	// Test-only: simulate the underlying chokidar watcher emitting an error.
-	// Exposed so the polling-fallback path can be exercised without triggering a
-	// real ENOSPC/EMFILE on the host.
 	_simulateWatcherErrorForTests(error: unknown): void {
 		this.#handleWatcherError(error);
 	}
 
-	// Test-only: enqueue a controllable file read through the same generation checks as chokidar events.
 	_simulateFileReadForTests(event: 'add' | 'change', path: string, contents: Promise<Buffer>): Promise<void> {
 		const absolutePath = join(this.directory, path);
 		return this.#queueFileRead(this.#watchGeneration, event, path, absolutePath, undefined, contents);
 	}
 
-	// Test-only: whether the watcher has fallen back to polling.
 	get _usingPollingForTests(): boolean {
 		return this.#usingPolling;
 	}
 
-	// Test-only: number of times the underlying watcher has been (re)opened.
-	// Used to assert that a close()-during-fallback race didn't install a
-	// replacement watcher.
 	get _openCountForTests(): number {
 		return this.#openCount;
 	}
 
-	// Test-only: chokidar instances opened but not yet closed. The invariant is <= 1; anything
-	// higher means a replacement watcher orphaned a live one and leaked its inotify handles.
 	get _liveWatcherCountForTests(): number {
 		return this.#liveWatchers.size;
 	}
@@ -657,8 +615,6 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 					})
 			: Promise.resolve();
 		this.#watcher = undefined;
-		// If paused, there may be an in-flight close from pause() that hasn't settled yet.
-		// Include it so close() doesn't resolve while inotify handles are still releasing.
 		const pausedClose = this.#pausedClose ?? Promise.resolve();
 		this.#pausedClose = undefined;
 
@@ -679,23 +635,13 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	 */
 	pause(): void {
 		if (this.#paused || this.#closed) return;
-		// Invalidate callbacks and reads already queued by the watcher being paused. They belong to the
-		// pre-deploy tree and must not be mistaken for events from the resumed generation.
 		this.#watchGeneration++;
 		this.#paused = true;
-		// Reset `ready` to a fresh pending promise so the documented "awaiting
-		// ready while paused will not resolve until resume()" contract holds even
-		// when the watcher had already become ready before pause(). The next
-		// 'ready' emit will come from the chokidar instance installed by resume().
 		this.ready = this.#createReadyLatch();
 		if (this.#watcher) {
-			// Retain the close promise so resume()→#watch() can await full
-			// teardown before opening a new watcher.
 			const outgoing = this.#watcher;
 			this.#pausedClose = Promise.resolve(outgoing.close())
-				.catch(() => {
-					// Teardown errors aren't actionable; swallow so resume can proceed.
-				})
+				.catch(() => {})
 				.then(() => {
 					this.#liveWatchers.delete(outgoing);
 				});
@@ -713,8 +659,6 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	resume(): Promise<any[]> {
 		if (!this.#paused) return this.ready;
 		this.#paused = false;
-		// `this.ready` was already reset to a pending promise in pause(); just
-		// trigger the watcher recreation and let its 'ready' emit resolve it.
 		return this.#watch();
 	}
 

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -2,7 +2,7 @@ import { type Logger } from '../utility/logging/logger.ts';
 import { loggerWithTag } from '../utility/logging/harper_logger.ts';
 import { createHash } from 'node:crypto';
 import type { Stats } from 'node:fs';
-import { EventEmitter, once } from 'node:events';
+import { EventEmitter } from 'node:events';
 import { Component, FileAndURLPathConfig } from './Component.ts';
 import chokidar, { FSWatcher, FSWatcherEventMap } from 'chokidar';
 import { join } from 'node:path';
@@ -83,6 +83,8 @@ type RedeployScan = {
 	previousEntries: Map<string, EntrySnapshot>;
 	currentEntries: Map<string, EntrySnapshot>;
 	removalsEmitted: Set<string>;
+	readFailures: Set<string>;
+	readErrors: unknown[];
 };
 
 export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
@@ -130,10 +132,39 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		this.#pendingFileReads = new Set();
 		this.#pendingFileReadsByGeneration = new Map();
 		this.#isInitialScanComplete = false;
-		this.ready = once(this, 'ready');
+		this.ready = this.#createReadyLatch();
 		// Fire-and-forget: the returned readiness latch rejects if the first generation emits
 		// `error` before `ready`, and consumers observe that through the 'error' event instead.
 		this.#watch().catch(() => {});
+	}
+
+	#createReadyLatch(): Promise<any[]> {
+		const ready = new Promise<any[]>((resolve, reject) => {
+			const cleanup = () => {
+				this.off('ready', handleReady);
+				this.off('error', handleError);
+				this.off('close', handleClose);
+			};
+			const handleReady = () => {
+				cleanup();
+				resolve([]);
+			};
+			const handleError = (error: unknown) => {
+				cleanup();
+				reject(error);
+			};
+			const handleClose = () => {
+				cleanup();
+				reject(new Error(`Entry handler for ${this.name} closed before becoming ready`));
+			};
+			this.once('ready', handleReady);
+			this.once('error', handleError);
+			this.once('close', handleClose);
+		});
+		// Keep a fire-and-forget watcher lifecycle from producing an unhandled rejection while
+		// preserving rejection for callers that await this same promise.
+		void ready.catch(() => {});
+		return ready;
 	}
 
 	get name(): string {
@@ -209,26 +240,37 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		this.#latestPathSequence.set(absolutePath, sequence);
 
 		const fileReadPromise = contentsPromise
-			.then((contents) => {
-				if (generation !== this.#watchGeneration || this.#latestPathSequence.get(absolutePath) !== sequence) return;
-				const entry: AddFileEvent | ChangeFileEvent = {
-					eventType: event,
-					entryType: 'file',
-					contents,
-					stats,
-					absolutePath,
-					urlPath: deriveURLPath(this.#component, path, 'file'),
-				};
-				this.#handleAddedEntry(generation, entry, this.#snapshot(entry));
-			})
-			.catch((error) => {
-				if (
-					generation !== this.#watchGeneration ||
-					(error as NodeJS.ErrnoException | null | undefined)?.code === 'ENOENT'
-				)
-					return;
-				this.#handleError(error);
-			})
+			.then(
+				(contents) => {
+					if (generation !== this.#watchGeneration || this.#latestPathSequence.get(absolutePath) !== sequence) return;
+					const entry: AddFileEvent | ChangeFileEvent = {
+						eventType: event,
+						entryType: 'file',
+						contents,
+						stats,
+						absolutePath,
+						urlPath: deriveURLPath(this.#component, path, 'file'),
+					};
+					try {
+						this.#handleAddedEntry(generation, entry, this.#snapshot(entry));
+					} catch (error) {
+						this.#reportConsumerError(error);
+					}
+				},
+				(error) => {
+					if (
+						generation !== this.#watchGeneration ||
+						(error as NodeJS.ErrnoException | null | undefined)?.code === 'ENOENT'
+					)
+						return;
+					if (this.#redeployScan?.generation === generation) {
+						this.#redeployScan.readFailures.add(absolutePath);
+						this.#redeployScan.readErrors.push(error);
+					} else {
+						this.#handleWatcherError(error);
+					}
+				}
+			)
 			.finally(() => {
 				if (this.#latestPathSequence.get(absolutePath) === sequence) this.#latestPathSequence.delete(absolutePath);
 				this.#pendingFileReads.delete(fileReadPromise);
@@ -285,7 +327,11 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 			return;
 		}
 		if (previousEntry.entryType !== snapshot.entryType || previousEntry.urlPath !== snapshot.urlPath) {
-			this.#emitRemoval(previousEntry, entry.absolutePath);
+			try {
+				this.#emitRemoval(previousEntry, entry.absolutePath);
+			} catch (error) {
+				this.#reportConsumerError(error);
+			}
 			this.#emitAddition(entry);
 			return;
 		}
@@ -347,7 +393,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		}
 	}
 
-	#handleError(error: unknown): void {
+	#handleWatcherError(error: unknown): void {
 		if (isWatcherExhaustionError(error)) {
 			// Swallow every exhaustion error — chokidar can emit several before the
 			// failed native watcher closes, and we don't want a flurry of ENOSPC to
@@ -367,6 +413,10 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 			}
 			return;
 		}
+		this.#reportConsumerError(error);
+	}
+
+	#reportConsumerError(error: unknown): void {
 		this.emit('error', error);
 	}
 
@@ -389,18 +439,23 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 			!this.#pendingFileReadsByGeneration.has(generation)
 		) {
 			this.#readyGeneration = generation;
-			const listenerErrors = this.#finishRedeployScan(generation);
+			const { listenerErrors, readErrors } = this.#finishRedeployScan(generation);
 			this.emit('ready');
-			// `events.once(this, 'ready')` rejects if `error` is emitted first. Surface consumer failures only
+			// The readiness latch rejects if `error` is emitted first. Surface consumer failures only
 			// after resolving the generation's ready latch so one bad removal listener cannot strand startup.
-			for (const error of listenerErrors) this.#handleError(error);
+			for (const error of listenerErrors) this.#reportConsumerError(error);
+			for (const error of readErrors) this.#handleWatcherError(error);
 		}
 	}
 
-	#finishRedeployScan(generation: number): unknown[] {
+	#finishRedeployScan(generation: number): { listenerErrors: unknown[]; readErrors: unknown[] } {
 		const scan = this.#redeployScan;
-		if (!scan || scan.generation !== generation) return [];
+		if (!scan || scan.generation !== generation) return { listenerErrors: [], readErrors: [] };
 		const listenerErrors: unknown[] = [];
+		for (const absolutePath of scan.readFailures) {
+			const previousEntry = scan.previousEntries.get(absolutePath);
+			if (previousEntry) scan.currentEntries.set(absolutePath, previousEntry);
+		}
 		const missingEntries = [...scan.previousEntries].filter(
 			([absolutePath]) => !scan.currentEntries.has(absolutePath) && !scan.removalsEmitted.has(absolutePath)
 		);
@@ -417,7 +472,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 				listenerErrors.push(error);
 			}
 		}
-		return listenerErrors;
+		return { listenerErrors, readErrors: scan.readErrors };
 	}
 
 	#observedEntries(): Map<string, EntrySnapshot> {
@@ -496,6 +551,8 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 			previousEntries,
 			currentEntries: new Map(),
 			removalsEmitted: new Set(),
+			readFailures: new Set(),
+			readErrors: [],
 		};
 
 		const allowedBases = this.#component.patternBases.map((base) => join(this.#component.directory, base));
@@ -538,7 +595,9 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 				},
 			})
 			.on('all', (...args) => this.#handleAll(generation, ...args))
-			.on('error', this.#handleError.bind(this))
+			.on('error', (error) => {
+				if (generation === this.#watchGeneration) this.#handleWatcherError(error);
+			})
 			.on('ready', () => this.#handleReady(generation)));
 		this.#liveWatchers.add(watcher);
 	}
@@ -547,7 +606,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	// Exposed so the polling-fallback path can be exercised without triggering a
 	// real ENOSPC/EMFILE on the host.
 	_simulateWatcherErrorForTests(error: unknown): void {
-		this.#handleError(error);
+		this.#handleWatcherError(error);
 	}
 
 	// Test-only: enqueue a controllable file read through the same generation checks as chokidar events.
@@ -608,7 +667,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	 * Idempotent. Awaiting `ready` while paused will not resolve until resume().
 	 */
 	pause(): void {
-		if (this.#paused) return;
+		if (this.#paused || this.#closed) return;
 		// Invalidate callbacks and reads already queued by the watcher being paused. They belong to the
 		// pre-deploy tree and must not be mistaken for events from the resumed generation.
 		this.#watchGeneration++;
@@ -617,7 +676,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		// ready while paused will not resolve until resume()" contract holds even
 		// when the watcher had already become ready before pause(). The next
 		// 'ready' emit will come from the chokidar instance installed by resume().
-		this.ready = once(this, 'ready');
+		this.ready = this.#createReadyLatch();
 		if (this.#watcher) {
 			// Retain the close promise so resume()→#watch() can await full
 			// teardown before opening a new watcher.
@@ -649,11 +708,13 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	}
 
 	update(config: FilesOption | FileAndURLPathConfig) {
+		if (this.#closed) return this.ready;
+		this.#watchGeneration++;
 		this.#component = new Component(this.name, this.directory, castConfig(config));
 		// Re-arm the readiness latch for parity with pause(). Without this, awaiting update() on an
 		// already-ready handler resolves against the outgoing generation's 'ready' — before the
 		// replacement generation has scanned, digested, and emitted its logical events.
-		if (!this.#closed) this.ready = once(this, 'ready');
+		this.ready = this.#createReadyLatch();
 
 		return this.#watch();
 	}

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -512,6 +512,8 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 			// teardown in its own settle set; only clear it if close() didn't already replace it.
 			try {
 				await outgoing.close();
+			} catch (error) {
+				this.#logger.warn?.(`Failed to close the previous watcher for ${this.name}; replacing it anyway:`, error);
 			} finally {
 				this.#liveWatchers.delete(outgoing);
 			}

--- a/components/EntryHandler.ts
+++ b/components/EntryHandler.ts
@@ -108,9 +108,18 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	// chokidar instance — otherwise a rapid pause→resume can overlap teardown
 	// and setup, which under inotify pressure can produce spurious EMFILE.
 	#pausedClose?: Promise<void>;
+	// Set while a watcher replacement is in flight, to serialize the next one. Concurrent
+	// #watch() calls would otherwise each observe the same live watcher before their close()
+	// await and then install their own, orphaning the intervening chokidar instance's inotify
+	// handles. Left undefined when idle so the first install — which has nothing to await —
+	// still claims its generation synchronously.
+	#watchInstall?: Promise<void>;
 	#usingPolling = false;
 	#closed = false;
 	#openCount = 0;
+	// Chokidar instances opened but not yet closed. Normally holds at most one entry; a larger
+	// set means a replacement watcher orphaned a live one, leaking its inotify handles.
+	#liveWatchers = new Set<FSWatcher>();
 	ready: Promise<any[]>;
 
 	constructor(name: string, directory: string, config: FilesOption | FileAndURLPathConfig, logger?: Logger) {
@@ -122,7 +131,9 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		this.#pendingFileReadsByGeneration = new Map();
 		this.#isInitialScanComplete = false;
 		this.ready = once(this, 'ready');
-		this.#watch();
+		// Fire-and-forget: the returned readiness latch rejects if the first generation emits
+		// `error` before `ready`, and consumers observe that through the 'error' event instead.
+		this.#watch().catch(() => {});
 	}
 
 	get name(): string {
@@ -422,6 +433,27 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 	}
 
 	async #watch() {
+		// Replacement is serialized: an update() racing another update() or the polling-fallback
+		// recovery must not tear down and install watchers concurrently, or the watcher installed
+		// by the first call is overwritten by the second and never closed.
+		const install = this.#watchInstall ? this.#watchInstall.then(() => this.#installWatcher()) : this.#installWatcher();
+		// Release the chain once this replacement settles — a failed install must not block or
+		// reject later callers.
+		const settled: Promise<void> = install.then(
+			() => {
+				if (this.#watchInstall === settled) this.#watchInstall = undefined;
+			},
+			() => {
+				if (this.#watchInstall === settled) this.#watchInstall = undefined;
+			}
+		);
+		this.#watchInstall = settled;
+		await install;
+
+		return this.ready;
+	}
+
+	async #installWatcher(): Promise<void> {
 		// If pause() retained an in-flight close, wait for it to release inotify
 		// handles before we install a new watcher. Otherwise a fast pause→resume
 		// can overlap teardown and setup under inotify pressure.
@@ -430,16 +462,25 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 			this.#pausedClose = undefined;
 		}
 
-		if (this.#watcher) await this.#watcher.close();
-		this.#watcher = undefined;
+		const outgoing = this.#watcher;
+		if (outgoing) {
+			// Stays installed across the await so a close() landing in the gap still includes this
+			// teardown in its own settle set; only clear it if close() didn't already replace it.
+			try {
+				await outgoing.close();
+			} finally {
+				this.#liveWatchers.delete(outgoing);
+			}
+			if (this.#watcher === outgoing) this.#watcher = undefined;
+		}
 
 		// If close() landed while a previous close()/recreate was awaiting, don't
 		// install a fresh watcher — it would outlive the EntryHandler.
-		if (this.#closed) return this.ready;
+		if (this.#closed) return;
 
 		// pause() may have landed in the gap before our async close resolved.
 		// If so, do not install a replacement watcher — resume() will.
-		if (this.#paused) return this.ready;
+		if (this.#paused) return;
 		const generation = ++this.#watchGeneration;
 
 		// Every watcher generation gets its own readiness latch and compares its
@@ -460,7 +501,7 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		const allowedBases = this.#component.patternBases.map((base) => join(this.#component.directory, base));
 
 		this.#openCount++;
-		this.#watcher = chokidar
+		const watcher = (this.#watcher = chokidar
 			.watch(this.#component.commonPatternBase, {
 				cwd: this.#component.directory,
 				persistent: false,
@@ -498,9 +539,8 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 			})
 			.on('all', (...args) => this.#handleAll(generation, ...args))
 			.on('error', this.#handleError.bind(this))
-			.on('ready', () => this.#handleReady(generation));
-
-		return this.ready;
+			.on('ready', () => this.#handleReady(generation)));
+		this.#liveWatchers.add(watcher);
 	}
 
 	// Test-only: simulate the underlying chokidar watcher emitting an error.
@@ -528,11 +568,24 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		return this.#openCount;
 	}
 
+	// Test-only: chokidar instances opened but not yet closed. The invariant is <= 1; anything
+	// higher means a replacement watcher orphaned a live one and leaked its inotify handles.
+	get _liveWatcherCountForTests(): number {
+		return this.#liveWatchers.size;
+	}
+
 	close(): Promise<this> {
 		this.#watchGeneration++;
 		this.#closed = true;
 		const pendingReads = [...this.#pendingFileReads];
-		const watcherClose = this.#watcher ? Promise.resolve(this.#watcher.close()).catch(() => {}) : Promise.resolve();
+		const outgoing = this.#watcher;
+		const watcherClose = outgoing
+			? Promise.resolve(outgoing.close())
+					.catch(() => {})
+					.then(() => {
+						this.#liveWatchers.delete(outgoing);
+					})
+			: Promise.resolve();
 		this.#watcher = undefined;
 		// If paused, there may be an in-flight close from pause() that hasn't settled yet.
 		// Include it so close() doesn't resolve while inotify handles are still releasing.
@@ -568,9 +621,14 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 		if (this.#watcher) {
 			// Retain the close promise so resume()→#watch() can await full
 			// teardown before opening a new watcher.
-			this.#pausedClose = Promise.resolve(this.#watcher.close()).catch(() => {
-				// Teardown errors aren't actionable; swallow so resume can proceed.
-			});
+			const outgoing = this.#watcher;
+			this.#pausedClose = Promise.resolve(outgoing.close())
+				.catch(() => {
+					// Teardown errors aren't actionable; swallow so resume can proceed.
+				})
+				.then(() => {
+					this.#liveWatchers.delete(outgoing);
+				});
 			this.#watcher = undefined;
 		}
 	}
@@ -592,6 +650,10 @@ export class EntryHandler extends EventEmitter<EntryHandlerEventMap> {
 
 	update(config: FilesOption | FileAndURLPathConfig) {
 		this.#component = new Component(this.name, this.directory, castConfig(config));
+		// Re-arm the readiness latch for parity with pause(). Without this, awaiting update() on an
+		// already-ready handler resolves against the outgoing generation's 'ready' — before the
+		// replacement generation has scanned, digested, and emitted its logical events.
+		if (!this.#closed) this.ready = once(this, 'ready');
 
 		return this.#watch();
 	}

--- a/components/RuntimeModuleTracker.ts
+++ b/components/RuntimeModuleTracker.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
-import { createRequire } from 'node:module';
-import { isAbsolute, relative, resolve, sep } from 'node:path';
+import { createRequire, Module } from 'node:module';
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 type Source = string | Buffer;
@@ -41,7 +41,6 @@ export class RuntimeModuleTracker {
 	}
 
 	recordResolution(specifier: string, referrer: string, resolvedUrl: string): void {
-		if (!specifier.startsWith('.')) return;
 		const referrerPath = this.#localPath(referrer);
 		if (!referrerPath || !this.#localPath(resolvedUrl)) return;
 		const key = `${referrerPath}\0${specifier}`;
@@ -76,6 +75,7 @@ export class RuntimeModuleTracker {
 			const referrerPath = key.slice(0, separator);
 			const specifier = key.slice(separator + 1);
 			try {
+				invalidateResolutionCache(specifier, referrerPath, previousResolvedUrl);
 				const resolved = createRequire(pathToFileURL(referrerPath)).resolve(specifier);
 				const resolvedUrl = isAbsolute(resolved) ? pathToFileURL(resolved).toString() : resolved;
 				if (resolvedUrl !== previousResolvedUrl) return true;
@@ -97,6 +97,20 @@ export class RuntimeModuleTracker {
 			(!relativePath.startsWith(`..${sep}`) && relativePath !== '..' && !isAbsolute(relativePath))
 		)
 			return modulePath;
+	}
+}
+
+function invalidateResolutionCache(specifier: string, referrerPath: string, previousResolvedUrl: string): void {
+	const pathCache = (Module as unknown as { _pathCache?: Record<string, string> })._pathCache;
+	if (!pathCache) return;
+	const previousPath = previousResolvedUrl.startsWith('file:')
+		? fileURLToPath(previousResolvedUrl)
+		: previousResolvedUrl;
+	const relativeKey = `${specifier}\0${dirname(referrerPath)}`;
+	if (pathCache[relativeKey] === previousPath) delete pathCache[relativeKey];
+	if (specifier.startsWith('.')) return;
+	for (const cacheKey of Object.keys(pathCache)) {
+		if (cacheKey.startsWith(`${specifier}\0`) && pathCache[cacheKey] === previousPath) delete pathCache[cacheKey];
 	}
 }
 

--- a/components/RuntimeModuleTracker.ts
+++ b/components/RuntimeModuleTracker.ts
@@ -75,6 +75,7 @@ export class RuntimeModuleTracker {
 			const referrerPath = key.slice(0, separator);
 			const specifier = key.slice(separator + 1);
 			try {
+				// Node does not invalidate this cache when a component tree is replaced in place.
 				invalidateResolutionCache(specifier, referrerPath, previousResolvedUrl);
 				const resolved = createRequire(pathToFileURL(referrerPath)).resolve(specifier);
 				const resolvedUrl = isAbsolute(resolved) ? pathToFileURL(resolved).toString() : resolved;

--- a/components/RuntimeModuleTracker.ts
+++ b/components/RuntimeModuleTracker.ts
@@ -1,12 +1,12 @@
 import { createHash } from 'node:crypto';
-import { lstatSync, readFileSync, readlinkSync } from 'node:fs';
-import { lstat, readFile, readlink } from 'node:fs/promises';
-import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 type Source = string | Buffer;
 
-const RESOLUTION_EXTENSIONS = ['', '.js', '.json', '.node', '.ts', '.tsx', '.cjs', '.mjs'];
+const MODULE_COMPARE_CONCURRENCY = 16;
 
 export class RuntimeModuleTracker {
 	#getRoot: () => string | undefined;
@@ -45,7 +45,7 @@ export class RuntimeModuleTracker {
 		const referrerPath = this.#localPath(referrer);
 		if (!referrerPath || !this.#localPath(resolvedUrl)) return;
 		const key = `${referrerPath}\0${specifier}`;
-		if (!this.#resolutions.has(key)) this.#resolutions.set(key, resolutionFingerprint(specifier, referrerPath));
+		if (!this.#resolutions.has(key)) this.#resolutions.set(key, resolvedUrl);
 		if (this.#deployInFlight) this.#loadedDuringDeploy = true;
 	}
 
@@ -58,18 +58,30 @@ export class RuntimeModuleTracker {
 
 	async #compare(): Promise<boolean> {
 		if (this.#nativeRuntime || this.#loadedDuringDeploy) return true;
-		for (const [modulePath, previousDigest] of this.#modules) {
-			try {
-				if (digest(await readFile(modulePath)) !== previousDigest) return true;
-			} catch {
-				return true;
-			}
+		const modules = [...this.#modules];
+		for (let start = 0; start < modules.length; start += MODULE_COMPARE_CONCURRENCY) {
+			const changed = await Promise.all(
+				modules.slice(start, start + MODULE_COMPARE_CONCURRENCY).map(async ([modulePath, previousDigest]) => {
+					try {
+						return digest(await readFile(modulePath)) !== previousDigest;
+					} catch {
+						return true;
+					}
+				})
+			);
+			if (changed.includes(true)) return true;
 		}
-		for (const [key, previousFingerprint] of this.#resolutions) {
+		for (const [key, previousResolvedUrl] of this.#resolutions) {
 			const separator = key.indexOf('\0');
 			const referrerPath = key.slice(0, separator);
 			const specifier = key.slice(separator + 1);
-			if ((await resolutionFingerprintAsync(specifier, referrerPath)) !== previousFingerprint) return true;
+			try {
+				const resolved = createRequire(pathToFileURL(referrerPath)).resolve(specifier);
+				const resolvedUrl = isAbsolute(resolved) ? pathToFileURL(resolved).toString() : resolved;
+				if (resolvedUrl !== previousResolvedUrl) return true;
+			} catch {
+				return true;
+			}
 		}
 		return false;
 	}
@@ -85,58 +97,6 @@ export class RuntimeModuleTracker {
 			(!relativePath.startsWith(`..${sep}`) && relativePath !== '..' && !isAbsolute(relativePath))
 		)
 			return modulePath;
-	}
-}
-
-function resolutionFingerprint(specifier: string, referrerPath: string): string {
-	return JSON.stringify(
-		resolutionCandidates(specifier, referrerPath).map((candidate) => [candidate, candidateState(candidate)])
-	);
-}
-
-async function resolutionFingerprintAsync(specifier: string, referrerPath: string): Promise<string> {
-	return JSON.stringify(
-		await Promise.all(
-			resolutionCandidates(specifier, referrerPath).map(async (candidate) => [
-				candidate,
-				await candidateStateAsync(candidate),
-			])
-		)
-	);
-}
-
-function resolutionCandidates(specifier: string, referrerPath: string): string[] {
-	const basePath = resolve(dirname(referrerPath), specifier);
-	const candidates = new Set<string>();
-	for (const extension of RESOLUTION_EXTENSIONS) candidates.add(basePath + extension);
-	candidates.add(resolve(basePath, 'package.json'));
-	for (const extension of RESOLUTION_EXTENSIONS.slice(1)) candidates.add(resolve(basePath, `index${extension}`));
-	return [...candidates];
-}
-
-function candidateState(path: string): string {
-	try {
-		const stats = lstatSync(path);
-		if (stats.isSymbolicLink()) return `link:${readlinkSync(path)}`;
-		if (stats.isDirectory()) return 'directory';
-		if (!stats.isFile()) return 'other';
-		return path.endsWith('package.json') ? `file:${digest(readFileSync(path))}` : 'file';
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return 'missing';
-		return `error:${(error as NodeJS.ErrnoException).code ?? 'unknown'}`;
-	}
-}
-
-async function candidateStateAsync(path: string): Promise<string> {
-	try {
-		const stats = await lstat(path);
-		if (stats.isSymbolicLink()) return `link:${await readlink(path)}`;
-		if (stats.isDirectory()) return 'directory';
-		if (!stats.isFile()) return 'other';
-		return path.endsWith('package.json') ? `file:${digest(await readFile(path))}` : 'file';
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return 'missing';
-		return `error:${(error as NodeJS.ErrnoException).code ?? 'unknown'}`;
 	}
 }
 

--- a/components/RuntimeModuleTracker.ts
+++ b/components/RuntimeModuleTracker.ts
@@ -78,7 +78,7 @@ export class RuntimeModuleTracker {
 			const specifier = key.slice(separator + 1);
 			try {
 				// Node does not invalidate this cache when a component tree is replaced in place.
-				invalidateResolutionCache(specifier, referrerPath, previousResolvedUrl);
+				if (!invalidateResolutionCache(specifier, referrerPath, previousResolvedUrl)) return true;
 				const resolved = createRequire(pathToFileURL(referrerPath)).resolve(specifier);
 				const resolvedUrl = isAbsolute(resolved) ? pathToFileURL(resolved).toString() : resolved;
 				if (resolvedUrl !== previousResolvedUrl) return true;
@@ -103,18 +103,19 @@ export class RuntimeModuleTracker {
 	}
 }
 
-function invalidateResolutionCache(specifier: string, referrerPath: string, previousResolvedUrl: string): void {
+function invalidateResolutionCache(specifier: string, referrerPath: string, previousResolvedUrl: string): boolean {
 	const pathCache = (Module as unknown as { _pathCache?: Record<string, string> })._pathCache;
-	if (!pathCache) return;
+	if (!pathCache) return false;
 	const previousPath = previousResolvedUrl.startsWith('file:')
 		? fileURLToPath(previousResolvedUrl)
 		: previousResolvedUrl;
 	const relativeKey = `${specifier}\0${dirname(referrerPath)}`;
 	if (pathCache[relativeKey] === previousPath) delete pathCache[relativeKey];
-	if (specifier.startsWith('.')) return;
+	if (specifier.startsWith('.')) return true;
 	for (const cacheKey of Object.keys(pathCache)) {
 		if (cacheKey.startsWith(`${specifier}\0`) && pathCache[cacheKey] === previousPath) delete pathCache[cacheKey];
 	}
+	return true;
 }
 
 function digest(source: Source): string {

--- a/components/RuntimeModuleTracker.ts
+++ b/components/RuntimeModuleTracker.ts
@@ -1,0 +1,145 @@
+import { createHash } from 'node:crypto';
+import { lstatSync, readFileSync, readlinkSync } from 'node:fs';
+import { lstat, readFile, readlink } from 'node:fs/promises';
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+type Source = string | Buffer;
+
+const RESOLUTION_EXTENSIONS = ['', '.js', '.json', '.node', '.ts', '.tsx', '.cjs', '.mjs'];
+
+export class RuntimeModuleTracker {
+	#getRoot: () => string | undefined;
+	#modules = new Map<string, string>();
+	#resolutions = new Map<string, string>();
+	#nativeRuntime = false;
+	#deployInFlight = false;
+	#loadedDuringDeploy = false;
+	#comparison?: Promise<boolean>;
+
+	constructor(getRoot: () => string | undefined) {
+		this.#getRoot = getRoot;
+	}
+
+	beginDeploy(): void {
+		if (this.#deployInFlight) return;
+		this.#deployInFlight = true;
+		this.#loadedDuringDeploy = false;
+		this.#comparison = undefined;
+	}
+
+	markNativeRuntime(): void {
+		this.#nativeRuntime = true;
+		if (this.#deployInFlight) this.#loadedDuringDeploy = true;
+	}
+
+	recordModule(moduleUrl: string, source: Source): void {
+		const modulePath = this.#localPath(moduleUrl);
+		if (!modulePath) return;
+		if (!this.#modules.has(modulePath)) this.#modules.set(modulePath, digest(source));
+		if (this.#deployInFlight) this.#loadedDuringDeploy = true;
+	}
+
+	recordResolution(specifier: string, referrer: string, resolvedUrl: string): void {
+		if (!specifier.startsWith('.')) return;
+		const referrerPath = this.#localPath(referrer);
+		if (!referrerPath || !this.#localPath(resolvedUrl)) return;
+		const key = `${referrerPath}\0${specifier}`;
+		if (!this.#resolutions.has(key)) this.#resolutions.set(key, resolutionFingerprint(specifier, referrerPath));
+		if (this.#deployInFlight) this.#loadedDuringDeploy = true;
+	}
+
+	finishDeploy(): Promise<boolean> {
+		if (!this.#deployInFlight) return this.#comparison ?? Promise.resolve(false);
+		this.#deployInFlight = false;
+		this.#comparison = this.#compare();
+		return this.#comparison;
+	}
+
+	async #compare(): Promise<boolean> {
+		if (this.#nativeRuntime || this.#loadedDuringDeploy) return true;
+		for (const [modulePath, previousDigest] of this.#modules) {
+			try {
+				if (digest(await readFile(modulePath)) !== previousDigest) return true;
+			} catch {
+				return true;
+			}
+		}
+		for (const [key, previousFingerprint] of this.#resolutions) {
+			const separator = key.indexOf('\0');
+			const referrerPath = key.slice(0, separator);
+			const specifier = key.slice(separator + 1);
+			if ((await resolutionFingerprintAsync(specifier, referrerPath)) !== previousFingerprint) return true;
+		}
+		return false;
+	}
+
+	#localPath(moduleUrl: string): string | undefined {
+		if (!moduleUrl.startsWith('file:')) return;
+		const root = this.#getRoot();
+		if (!root) return;
+		const modulePath = fileURLToPath(moduleUrl);
+		const relativePath = relative(resolve(root), modulePath);
+		if (
+			relativePath === '' ||
+			(!relativePath.startsWith(`..${sep}`) && relativePath !== '..' && !isAbsolute(relativePath))
+		)
+			return modulePath;
+	}
+}
+
+function resolutionFingerprint(specifier: string, referrerPath: string): string {
+	return JSON.stringify(
+		resolutionCandidates(specifier, referrerPath).map((candidate) => [candidate, candidateState(candidate)])
+	);
+}
+
+async function resolutionFingerprintAsync(specifier: string, referrerPath: string): Promise<string> {
+	return JSON.stringify(
+		await Promise.all(
+			resolutionCandidates(specifier, referrerPath).map(async (candidate) => [
+				candidate,
+				await candidateStateAsync(candidate),
+			])
+		)
+	);
+}
+
+function resolutionCandidates(specifier: string, referrerPath: string): string[] {
+	const basePath = resolve(dirname(referrerPath), specifier);
+	const candidates = new Set<string>();
+	for (const extension of RESOLUTION_EXTENSIONS) candidates.add(basePath + extension);
+	candidates.add(resolve(basePath, 'package.json'));
+	for (const extension of RESOLUTION_EXTENSIONS.slice(1)) candidates.add(resolve(basePath, `index${extension}`));
+	return [...candidates];
+}
+
+function candidateState(path: string): string {
+	try {
+		const stats = lstatSync(path);
+		if (stats.isSymbolicLink()) return `link:${readlinkSync(path)}`;
+		if (stats.isDirectory()) return 'directory';
+		if (!stats.isFile()) return 'other';
+		return path.endsWith('package.json') ? `file:${digest(readFileSync(path))}` : 'file';
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return 'missing';
+		return `error:${(error as NodeJS.ErrnoException).code ?? 'unknown'}`;
+	}
+}
+
+async function candidateStateAsync(path: string): Promise<string> {
+	try {
+		const stats = await lstat(path);
+		if (stats.isSymbolicLink()) return `link:${await readlink(path)}`;
+		if (stats.isDirectory()) return 'directory';
+		if (!stats.isFile()) return 'other';
+		return path.endsWith('package.json') ? `file:${digest(await readFile(path))}` : 'file';
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return 'missing';
+		return `error:${(error as NodeJS.ErrnoException).code ?? 'unknown'}`;
+	}
+}
+
+function digest(source: Source): string {
+	return createHash('sha256').update(source).digest('base64');
+}

--- a/components/RuntimeModuleTracker.ts
+++ b/components/RuntimeModuleTracker.ts
@@ -44,8 +44,10 @@ export class RuntimeModuleTracker {
 		const referrerPath = this.#localPath(referrer);
 		if (!referrerPath || !this.#localPath(resolvedUrl)) return;
 		const key = `${referrerPath}\0${specifier}`;
-		if (!this.#resolutions.has(key)) this.#resolutions.set(key, resolvedUrl);
-		if (this.#deployInFlight) this.#loadedDuringDeploy = true;
+		if (!this.#resolutions.has(key)) {
+			this.#resolutions.set(key, resolvedUrl);
+			if (this.#deployInFlight) this.#loadedDuringDeploy = true;
+		}
 	}
 
 	finishDeploy(): Promise<boolean> {

--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -355,6 +355,7 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 			.on('unlink', this.#defaultEntryHandlerListener('unlink'))
 			.on('addDir', this.#defaultEntryHandlerListener('addDir'))
 			.on('unlinkDir', this.#defaultEntryHandlerListener('unlinkDir'));
+		if (this.#deployInFlight) entryHandler.pause();
 
 		this.#entryHandlers.push(entryHandler);
 

--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -66,13 +66,7 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 	#pendingInitialLoads: Set<Promise<void>>;
 	#deployStartHandler: (name: string) => void;
 	#deployEndHandler: (name: string) => void;
-	// While a deploy of this component is in flight, EntryHandler events do not
-	// drive requestRestart() — the deploy itself produces hundreds of file
-	// changes that would otherwise pile up. Logical changes from the completed
-	// post-deploy scan can request the restart after this gate is lowered.
 	#deployInFlight: boolean = false;
-	// OptionsWatcher and plugin callbacks are not paused with EntryHandlers. Preserve a restart they
-	// request during the deploy window and replay it once the intermediate filesystem state is gone.
 	#restartRequestedDuringDeploy: boolean = false;
 	applicationScope?: ApplicationScope;
 
@@ -259,7 +253,8 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 	}
 
 	#handleError(error: unknown): void {
-		this.emit('error', error);
+		if (this.listenerCount('error') > 0) this.emit('error', error);
+		else this.#logger.error?.('Error in component scope:', error);
 	}
 
 	async close(): Promise<this> {
@@ -325,16 +320,8 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 		const restartRequestedDuringDeploy = this.#restartRequestedDuringDeploy;
 		this.#restartRequestedDuringDeploy = false;
 
-		// Resume each EntryHandler BEFORE notifying plugins. Otherwise a plugin
-		// throwing in its deploy:end handler would abort this function and
-		// leave the watchers permanently paused (surfaced by Gemini review).
-		// The fresh chokidar watcher compares the post-deploy scan with its
-		// retained pre-deploy snapshot and emits only logical changes. Plugin
-		// handlers stay attached across the pause.
+		// Resume before notifying plugins so a throwing deploy:end listener cannot strand the watchers.
 		for (const entryHandler of this.#entryHandlers) {
-			// `ready` rejects if the resumed generation emits `error` first (the handler's own
-			// 'error' listener reports it); nothing here awaits it, so swallow to avoid an
-			// unhandled rejection.
 			void entryHandler.resume().catch(() => {});
 		}
 		if (restartRequestedDuringDeploy) this.requestRestart();
@@ -351,9 +338,6 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 		this.#safeEmit('deploy:end', componentName);
 	}
 
-	// Swallow and log listener exceptions so one buggy plugin can't stop us
-	// from running the rest of the deploy-lifecycle bookkeeping. EventEmitter
-	// by default rethrows from synchronous listeners.
 	#safeEmit(event: 'deploy:start' | 'deploy:end', componentName: string): void {
 		try {
 			this.emit(event, componentName);
@@ -411,9 +395,6 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 					return;
 				}
 
-				// Otherwise, if an entry handler exists, update it with the new config. The returned
-				// readiness latch is not awaited here and rejects if the new generation errors, so
-				// swallow it — the handler's 'error' listener already reports it.
 				void scope.#entryHandler.update(config as FileAndURLPathConfig).catch(() => {});
 
 				return;
@@ -542,8 +523,6 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 
 	requestRestart() {
 		if (this.#deployInFlight) {
-			// Defer while a deploy is rewriting this component's files. EntryHandlers are paused, but
-			// OptionsWatcher and plugin callbacks can still observe a lasting configuration change.
 			this.#restartRequestedDuringDeploy = true;
 			this.#logger.debug?.(`Restart suppressed (deploy in flight) for ${this.#appName}`);
 			return;

--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -38,8 +38,10 @@ export type ScopeEventsMap = {
 	// file-driven work to avoid acting on intermediate states.
 	'deploy:start': [componentName: string];
 	// Fired after deploy I/O completes (success or failure). The scope's
-	// EntryHandlers have been recreated by this point; subsequent `add`/`change`
-	// events reflect the post-deploy tree.
+	// EntryHandlers have been resumed by this point; their replacement watcher
+	// generation compares the post-deploy scan with the retained pre-deploy
+	// snapshot, so subsequent events are the logical differences of that tree,
+	// not a replay of every surviving file as an `add`.
 	'deploy:end': [componentName: string];
 	[record: string]: [...args: unknown[]];
 };
@@ -329,7 +331,10 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 		// retained pre-deploy snapshot and emits only logical changes. Plugin
 		// handlers stay attached across the pause.
 		for (const entryHandler of this.#entryHandlers) {
-			void entryHandler.resume();
+			// `ready` rejects if the resumed generation emits `error` first (the handler's own
+			// 'error' listener reports it); nothing here awaits it, so swallow to avoid an
+			// unhandled rejection.
+			void entryHandler.resume().catch(() => {});
 		}
 		if (restartRequestedDuringDeploy) this.requestRestart();
 
@@ -396,8 +401,10 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 					return;
 				}
 
-				// Otherwise, if an entry handler exists, update it with the new config
-				scope.#entryHandler.update(config as FileAndURLPathConfig);
+				// Otherwise, if an entry handler exists, update it with the new config. The returned
+				// readiness latch is not awaited here and rejects if the new generation errors, so
+				// swallow it — the handler's 'error' listener already reports it.
+				void scope.#entryHandler.update(config as FileAndURLPathConfig).catch(() => {});
 
 				return;
 			}

--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -112,6 +112,7 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 		this.#directory = directory;
 		this.#configFilePath = configFilePath;
 		this.#logger = loggerWithTag(this.#appName);
+		this.#deployInFlight = deployLifecycle.isDeployInFlight(this.#appName);
 
 		this.databaseEvents = databaseEventsEmitter;
 		this.applicationScope = applicationScope;

--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -551,6 +551,7 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 				deployLifecycle.off('deploy:end', handleDeployEnd);
 				reject(new Error(`Timed out waiting for deployment of ${this.#appName} to complete`));
 			}, timeoutMs);
+			timer.unref?.();
 			const handleDeployEnd = (componentName: string) => {
 				if (componentName !== this.#appName || this.#deployInFlight) return;
 				deployLifecycle.off('deploy:end', handleDeployEnd);

--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -544,6 +544,28 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 		}
 	}
 
+	waitForDeployCompletion(timeoutMs = 6 * 60 * 60 * 1000): Promise<void> {
+		if (!this.#deployInFlight) return Promise.resolve();
+		return new Promise((resolve, reject) => {
+			const timer = setTimeout(() => {
+				deployLifecycle.off('deploy:end', handleDeployEnd);
+				reject(new Error(`Timed out waiting for deployment of ${this.#appName} to complete`));
+			}, timeoutMs);
+			const handleDeployEnd = (componentName: string) => {
+				if (componentName !== this.#appName || this.#deployInFlight) return;
+				deployLifecycle.off('deploy:end', handleDeployEnd);
+				clearTimeout(timer);
+				resolve();
+			};
+			deployLifecycle.on('deploy:end', handleDeployEnd);
+			if (!this.#deployInFlight) {
+				deployLifecycle.off('deploy:end', handleDeployEnd);
+				clearTimeout(timer);
+				resolve();
+			}
+		});
+	}
+
 	/**
 	 * Import a file into the scope's sandbox.
 	 * @param filePath - The path of the file to import.

--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -307,6 +307,7 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 	#onDeployStart(componentName: string): void {
 		this.#deployInFlight = true;
 		this.#restartRequestedDuringDeploy = false;
+		this.applicationScope?.beginDeploy();
 		// Pause each EntryHandler so it stops emitting events for the
 		// intermediate filesystem state the deploy is writing, and so it
 		// releases its inotify handles while npm install is unpacking
@@ -337,6 +338,15 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 			void entryHandler.resume().catch(() => {});
 		}
 		if (restartRequestedDuringDeploy) this.requestRestart();
+		void this.applicationScope
+			?.finishDeploy()
+			.then((runtimeChanged) => {
+				if (runtimeChanged) this.requestRestart();
+			})
+			.catch((error) => {
+				this.#logger.error?.(`Could not verify the loaded runtime after deploying ${this.#appName}:`, error);
+				this.requestRestart();
+			});
 
 		this.#safeEmit('deploy:end', componentName);
 	}

--- a/components/Scope.ts
+++ b/components/Scope.ts
@@ -66,9 +66,12 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 	#deployEndHandler: (name: string) => void;
 	// While a deploy of this component is in flight, EntryHandler events do not
 	// drive requestRestart() — the deploy itself produces hundreds of file
-	// changes that would otherwise pile up. A single coalesced restart is
-	// triggered by the post-deploy re-scan instead.
+	// changes that would otherwise pile up. Logical changes from the completed
+	// post-deploy scan can request the restart after this gate is lowered.
 	#deployInFlight: boolean = false;
+	// OptionsWatcher and plugin callbacks are not paused with EntryHandlers. Preserve a restart they
+	// request during the deploy window and replay it once the intermediate filesystem state is gone.
+	#restartRequestedDuringDeploy: boolean = false;
 	applicationScope?: ApplicationScope;
 
 	options: OptionsWatcher;
@@ -301,6 +304,7 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 
 	#onDeployStart(componentName: string): void {
 		this.#deployInFlight = true;
+		this.#restartRequestedDuringDeploy = false;
 		// Pause each EntryHandler so it stops emitting events for the
 		// intermediate filesystem state the deploy is writing, and so it
 		// releases its inotify handles while npm install is unpacking
@@ -315,18 +319,19 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 
 	#onDeployEnd(componentName: string): void {
 		this.#deployInFlight = false;
+		const restartRequestedDuringDeploy = this.#restartRequestedDuringDeploy;
+		this.#restartRequestedDuringDeploy = false;
 
 		// Resume each EntryHandler BEFORE notifying plugins. Otherwise a plugin
 		// throwing in its deploy:end handler would abort this function and
 		// leave the watchers permanently paused (surfaced by Gemini review).
-		// The fresh chokidar watcher does an initial scan and emits add events
-		// for the post-deploy tree; the existing per-event listener calls
-		// scope.requestRestart() for each, and the restart debounce in
-		// componentLoader collapses them into a single restart cycle. Plugin
+		// The fresh chokidar watcher compares the post-deploy scan with its
+		// retained pre-deploy snapshot and emits only logical changes. Plugin
 		// handlers stay attached across the pause.
 		for (const entryHandler of this.#entryHandlers) {
 			void entryHandler.resume();
 		}
+		if (restartRequestedDuringDeploy) this.requestRestart();
 
 		this.#safeEmit('deploy:end', componentName);
 	}
@@ -520,9 +525,9 @@ export class Scope extends EventEmitter<ScopeEventsMap> {
 
 	requestRestart() {
 		if (this.#deployInFlight) {
-			// Suppressed: a deploy is rewriting this component's files. The
-			// post-deploy re-scan in #onDeployEnd will trigger the coalesced
-			// restart instead.
+			// Defer while a deploy is rewriting this component's files. EntryHandlers are paused, but
+			// OptionsWatcher and plugin callbacks can still observe a lasting configuration change.
+			this.#restartRequestedDuringDeploy = true;
 			this.#logger.debug?.(`Restart suppressed (deploy in flight) for ${this.#appName}`);
 			return;
 		}

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -29,6 +29,7 @@ import * as scheduler from '../resources/scheduler/scheduler.ts';
 import { restartWorkers, getWorkerIndex } from '../server/threads/manageThreads.js';
 import { resetRestartNeeded, subscribeToRestartRequests } from './requestRestart.ts';
 import { trackScopeClose } from './scopeShutdown.ts';
+import { deployLifecycle } from './deployLifecycle.ts';
 import { toScopeMount, nestScopeMount, type ScopeMount } from './scopeMount.ts';
 import { scopedImport } from '../security/jsLoader.ts';
 import { server } from '../server/Server.ts';
@@ -312,6 +313,7 @@ function symlinkHarperModule(componentDirectory: string) {
  */
 function sequentiallyHandleApplication(scope: Scope, plugin: PluginModule) {
 	return scope.ready.then(async () => {
+		await scope.waitForDeployCompletion();
 		// Timeout priority is user config, plugin default, finally 30 seconds
 		const timeout = scope.options.get(['timeout']) || plugin.defaultTimeout || 30_000; // default 30 second timeout
 		if (typeof timeout !== 'number') {
@@ -333,32 +335,70 @@ function sequentiallyHandleApplication(scope: Scope, plugin: PluginModule) {
 				}, timeout + 5_000); // extra time for lock acquisition
 			});
 		}
-		let loadTimeout: NodeJS.Timeout;
 		try {
 			// note that handleApplication can throw sync or async errors, need to run finally block for both
-			await Promise.race([
+			await withDeployAwareTimeout(
 				Promise.resolve(plugin.handleApplication(scope)).then(async () => {
 					// Wait for any initial entry handler loads to complete
 					// This ensures all async operations (like secureImport) finish before the component is marked as loaded
 					await scope.waitForInitialLoads();
 				}),
-				new Promise(
-					(_, reject) =>
-						(loadTimeout = setTimeout(
-							() =>
-								reject(
-									new Error(
-										`handleApplication timed out after ${timeout}ms for ${scope.pluginName} on behalf of ${scope.appName}`
-									)
-								),
-							timeout
-						))
-				),
-			]);
+				scope,
+				timeout
+			);
 		} finally {
 			Status.primaryStore.unlock(scope.pluginName);
-			clearTimeout(loadTimeout);
 		}
+	});
+}
+
+function withDeployAwareTimeout<T>(operation: Promise<T>, scope: Scope, timeout: number): Promise<T> {
+	return new Promise((resolve, reject) => {
+		let remaining = timeout;
+		let activeSince = 0;
+		let timer: NodeJS.Timeout | undefined;
+		const cleanup = () => {
+			if (timer) clearTimeout(timer);
+			deployLifecycle.off('deploy:start', handleDeployStart);
+			deployLifecycle.off('deploy:end', handleDeployEnd);
+		};
+		const rejectTimeout = () => {
+			cleanup();
+			reject(
+				new Error(
+					`handleApplication timed out after ${timeout}ms for ${scope.pluginName} on behalf of ${scope.appName}`
+				)
+			);
+		};
+		const arm = () => {
+			if (deployLifecycle.isDeployInFlight(scope.appName)) return;
+			if (remaining <= 0) return rejectTimeout();
+			activeSince = Date.now();
+			timer = setTimeout(rejectTimeout, remaining);
+		};
+		function handleDeployStart(componentName: string) {
+			if (componentName !== scope.appName || !timer) return;
+			remaining -= Date.now() - activeSince;
+			clearTimeout(timer);
+			timer = undefined;
+		}
+		function handleDeployEnd(componentName: string) {
+			if (componentName === scope.appName) arm();
+		}
+
+		deployLifecycle.on('deploy:start', handleDeployStart);
+		deployLifecycle.on('deploy:end', handleDeployEnd);
+		operation.then(
+			(value) => {
+				cleanup();
+				resolve(value);
+			},
+			(error) => {
+				cleanup();
+				reject(error);
+			}
+		);
+		arm();
 	});
 }
 

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -354,6 +354,7 @@ function sequentiallyHandleApplication(scope: Scope, plugin: PluginModule) {
 
 function withDeployAwareTimeout<T>(operation: Promise<T>, scope: Scope, timeout: number): Promise<T> {
 	return new Promise((resolve, reject) => {
+		const absoluteTimeout = timeout + 6 * 60 * 60 * 1000;
 		let remaining = timeout;
 		let activeSince = 0;
 		let timer: NodeJS.Timeout | undefined;
@@ -364,15 +365,13 @@ function withDeployAwareTimeout<T>(operation: Promise<T>, scope: Scope, timeout:
 			deployLifecycle.off('deploy:start', handleDeployStart);
 			deployLifecycle.off('deploy:end', handleDeployEnd);
 		};
-		const rejectTimeout = () => {
+		const rejectTimeout = (limit = timeout) => {
 			cleanup();
 			reject(
-				new Error(
-					`handleApplication timed out after ${timeout}ms for ${scope.pluginName} on behalf of ${scope.appName}`
-				)
+				new Error(`handleApplication timed out after ${limit}ms for ${scope.pluginName} on behalf of ${scope.appName}`)
 			);
 		};
-		absoluteTimer = setTimeout(rejectTimeout, timeout + 6 * 60 * 60 * 1000);
+		absoluteTimer = setTimeout(() => rejectTimeout(absoluteTimeout), absoluteTimeout);
 		absoluteTimer.unref?.();
 		const arm = () => {
 			if (deployLifecycle.isDeployInFlight(scope.appName)) return;

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -357,8 +357,10 @@ function withDeployAwareTimeout<T>(operation: Promise<T>, scope: Scope, timeout:
 		let remaining = timeout;
 		let activeSince = 0;
 		let timer: NodeJS.Timeout | undefined;
+		let absoluteTimer: NodeJS.Timeout;
 		const cleanup = () => {
 			if (timer) clearTimeout(timer);
+			clearTimeout(absoluteTimer);
 			deployLifecycle.off('deploy:start', handleDeployStart);
 			deployLifecycle.off('deploy:end', handleDeployEnd);
 		};
@@ -370,6 +372,8 @@ function withDeployAwareTimeout<T>(operation: Promise<T>, scope: Scope, timeout:
 				)
 			);
 		};
+		absoluteTimer = setTimeout(rejectTimeout, timeout + 6 * 60 * 60 * 1000);
+		absoluteTimer.unref?.();
 		const arm = () => {
 			if (deployLifecycle.isDeployInFlight(scope.appName)) return;
 			if (remaining <= 0) return rejectTimeout();

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -405,6 +405,7 @@ export async function loadComponent(
 		appName,
 		mount,
 	} = options;
+	applicationScope.runtimeRoot ??= resolvedFolder;
 	applicationScope.allowedPath ??= realpathSync(componentDirectory);
 	if (providedLoadedComponents) loadedComponents = providedLoadedComponents;
 	try {

--- a/components/deployLifecycle.ts
+++ b/components/deployLifecycle.ts
@@ -9,11 +9,11 @@
 //
 // This module solves that by broadcasting a structured "deploy:start" /
 // "deploy:end" signal to every Harper thread. Each thread's deploy emitter
-// fires locally so Scopes (and any plugin subscribers) can react: Scopes close
-// their EntryHandlers on start, recreate them on end. The result is that
+// fires locally so Scopes (and any plugin subscribers) can react: Scopes pause
+// their EntryHandlers on start and resume them on end. The result is that
 // during a deploy, no watcher fires events for the deployed component, and
-// after the deploy the recreated watcher emits one fresh add per current file
-// — collapsed by the existing restart debounce into a single restart.
+// after the deploy the watcher compares the new tree with its retained snapshot
+// and emits the same logical add/change/unlink events consumers saw before #1806.
 //
 // State sharing across threads is intentionally narrow: the local Set of
 // in-flight component names is rebuilt from the broadcast stream. Plugins that

--- a/components/deployLifecycle.ts
+++ b/components/deployLifecycle.ts
@@ -26,9 +26,11 @@ import { isMainThread, threadId } from 'node:worker_threads';
 import {
 	broadcast,
 	broadcastWithAcknowledgement,
+	awaitThreadProcessGroupsTerminated,
 	onMessageByType,
 	onThreadExit,
 } from '../server/threads/manageThreads.js';
+import harperLogger from '../utility/logging/harper_logger.ts';
 
 const DEPLOY_LIFECYCLE_MSG = 'harper:deploy:lifecycle';
 
@@ -89,6 +91,14 @@ class DeployLifecycle extends EventEmitter<DeployLifecycleEventsMap> {
 		}
 	}
 
+	async _reclaimOwnerAfterTermination(
+		ownerThreadId: number,
+		waitForTermination: (ownerThreadId: number) => Promise<void> = awaitThreadProcessGroupsTerminated
+	): Promise<void> {
+		await waitForTermination(ownerThreadId);
+		this._reclaimOwner(ownerThreadId);
+	}
+
 	#removeDeployment(deploymentId: string): void {
 		const deployment = this.#deployments.get(deploymentId);
 		if (!deployment) return;
@@ -98,7 +108,11 @@ class DeployLifecycle extends EventEmitter<DeployLifecycleEventsMap> {
 		active.delete(deploymentId);
 		if (active.size === 0) {
 			this.#byComponent.delete(deployment.name);
-			this.emit('deploy:end', deployment.name);
+			try {
+				this.emit('deploy:end', deployment.name);
+			} catch (error) {
+				harperLogger.error(`Listener for deploy:end threw while reclaiming ${deployment.name}:`, error);
+			}
 		}
 	}
 
@@ -129,7 +143,11 @@ function ensureReceiver() {
 // suppress only the main thread's watchers and the worker watchers would keep
 // firing restart storms (harper#488).
 ensureReceiver();
-onThreadExit((deadThreadId: number) => deployLifecycle._reclaimOwner(deadThreadId));
+onThreadExit((deadThreadId: number) => {
+	void deployLifecycle
+		._reclaimOwnerAfterTermination(deadThreadId)
+		.catch((error) => harperLogger.error(`Could not reclaim deployments from thread ${deadThreadId}:`, error));
+});
 
 /**
  * Announce the start of a deploy for `componentName`. Awaits acknowledgement

--- a/components/deployLifecycle.ts
+++ b/components/deployLifecycle.ts
@@ -96,6 +96,7 @@ class DeployLifecycle extends EventEmitter<DeployLifecycleEventsMap> {
 		ownerThreadId: number,
 		waitForTermination: (ownerThreadId: number) => Promise<void> = waitForOwnerTermination
 	): Promise<void> {
+		if (ownerThreadId === 0 || ownerThreadId === threadId) return;
 		this.#deadOwners.add(ownerThreadId);
 		await waitForTermination(ownerThreadId);
 		this._reclaimOwner(ownerThreadId);
@@ -137,7 +138,18 @@ class DeployLifecycle extends EventEmitter<DeployLifecycleEventsMap> {
 export const deployLifecycle = new DeployLifecycle();
 
 async function waitForOwnerTermination(ownerThreadId: number): Promise<void> {
-	while (await isThreadRunning(ownerThreadId)) await delay(25);
+	let timeoutReported = false;
+	for (;;) {
+		try {
+			if (!(await isThreadRunning(ownerThreadId))) return;
+		} catch (error) {
+			if (!timeoutReported) {
+				timeoutReported = true;
+				harperLogger.warn(`Retrying liveness check for exited thread ${ownerThreadId}:`, error);
+			}
+		}
+		await delay(25, undefined, { ref: false });
+	}
 }
 
 let receiverInstalled = false;

--- a/components/deployLifecycle.ts
+++ b/components/deployLifecycle.ts
@@ -15,19 +15,30 @@
 // after the deploy the watcher compares the new tree with its retained snapshot
 // and emits the same logical add/change/unlink events consumers saw before #1806.
 //
-// State sharing across threads is intentionally narrow: the local Set of
-// in-flight component names is rebuilt from the broadcast stream. Plugins that
-// need to gate their own work on deploy progress import `deployLifecycle` and
-// listen to the events directly.
+// State sharing across threads is intentionally narrow: local deployment-owner
+// records are rebuilt from the broadcast stream and reclaimed when their owner
+// thread exits. Plugins that need to gate their own work on deploy progress
+// import `deployLifecycle` and listen to the events directly.
 
 import { EventEmitter } from 'node:events';
-import { isMainThread } from 'node:worker_threads';
-import { broadcast, broadcastWithAcknowledgement, onMessageByType } from '../server/threads/manageThreads.js';
+import { randomUUID } from 'node:crypto';
+import { isMainThread, threadId } from 'node:worker_threads';
+import {
+	broadcast,
+	broadcastWithAcknowledgement,
+	onMessageByType,
+	onThreadExit,
+} from '../server/threads/manageThreads.js';
 
 const DEPLOY_LIFECYCLE_MSG = 'harper:deploy:lifecycle';
 
 export type DeployPhase = 'start' | 'end';
-export type DeployLifecycleEvent = { name: string; phase: DeployPhase };
+export type DeployLifecycleEvent = {
+	name: string;
+	phase: DeployPhase;
+	deploymentId?: string;
+	ownerThreadId?: number;
+};
 
 type DeployLifecycleEventsMap = {
 	'deploy:start': [componentName: string];
@@ -35,39 +46,69 @@ type DeployLifecycleEventsMap = {
 };
 
 class DeployLifecycle extends EventEmitter<DeployLifecycleEventsMap> {
-	// Ref-counts in-flight deploys per component. Concurrent deploys of the
-	// same name (rare, but possible if an operator queues two before the first
-	// resolves) overlap: 0→1 fires deploy:start, 1→0 fires deploy:end. Any
-	// intermediate increment/decrement is silent so watchers aren't toggled
-	// out from under an active deploy by a peer ending early.
-	#inFlight = new Map<string, number>();
+	#deployments = new Map<string, { name: string; ownerThreadId: number }>();
+	#byComponent = new Map<string, Set<string>>();
+	#deadOwners = new Set<number>();
+	#legacyDeployments = new Map<string, string[]>();
+	#legacySequence = 0;
 
 	isDeployInFlight(componentName: string): boolean {
-		return (this.#inFlight.get(componentName) ?? 0) > 0;
+		return (this.#byComponent.get(componentName)?.size ?? 0) > 0;
 	}
 
 	// Process a deploy lifecycle event in-process. Called both from the
 	// broadcast receiver (for events originating on another thread) and from
 	// the broadcaster (so the originating thread also reacts locally).
 	_handle(event: DeployLifecycleEvent): void {
-		const current = this.#inFlight.get(event.name) ?? 0;
+		const ownerThreadId = event.ownerThreadId ?? threadId;
+		let deploymentId = event.deploymentId;
 		if (event.phase === 'start') {
-			this.#inFlight.set(event.name, current + 1);
-			if (current === 0) this.emit('deploy:start', event.name);
-		} else {
-			const next = Math.max(0, current - 1);
-			if (next === 0) {
-				this.#inFlight.delete(event.name);
-				if (current > 0) this.emit('deploy:end', event.name);
-			} else {
-				this.#inFlight.set(event.name, next);
+			if (this.#deadOwners.has(ownerThreadId)) return;
+			if (!deploymentId) {
+				deploymentId = `legacy:${threadId}:${++this.#legacySequence}`;
+				const legacy = this.#legacyDeployments.get(event.name) ?? [];
+				legacy.push(deploymentId);
+				this.#legacyDeployments.set(event.name, legacy);
 			}
+			if (this.#deployments.has(deploymentId)) return;
+			const active = this.#byComponent.get(event.name) ?? new Set<string>();
+			this.#deployments.set(deploymentId, { name: event.name, ownerThreadId });
+			this.#byComponent.set(event.name, active);
+			active.add(deploymentId);
+			if (active.size === 1) this.emit('deploy:start', event.name);
+			return;
+		}
+		if (!deploymentId) deploymentId = this.#legacyDeployments.get(event.name)?.pop();
+		if (deploymentId) this.#removeDeployment(deploymentId);
+	}
+
+	_reclaimOwner(ownerThreadId: number): void {
+		this.#deadOwners.add(ownerThreadId);
+		for (const [deploymentId, deployment] of this.#deployments) {
+			if (deployment.ownerThreadId === ownerThreadId) this.#removeDeployment(deploymentId);
+		}
+	}
+
+	#removeDeployment(deploymentId: string): void {
+		const deployment = this.#deployments.get(deploymentId);
+		if (!deployment) return;
+		this.#deployments.delete(deploymentId);
+		const active = this.#byComponent.get(deployment.name);
+		if (!active) return;
+		active.delete(deploymentId);
+		if (active.size === 0) {
+			this.#byComponent.delete(deployment.name);
+			this.emit('deploy:end', deployment.name);
 		}
 	}
 
 	// Test-only: clear in-flight state without firing events.
 	_clearForTests(): void {
-		this.#inFlight.clear();
+		this.#deployments.clear();
+		this.#byComponent.clear();
+		this.#deadOwners.clear();
+		this.#legacyDeployments.clear();
+		this.#legacySequence = 0;
 	}
 }
 
@@ -88,6 +129,7 @@ function ensureReceiver() {
 // suppress only the main thread's watchers and the worker watchers would keep
 // firing restart storms (harper#488).
 ensureReceiver();
+onThreadExit((deadThreadId: number) => deployLifecycle._reclaimOwner(deadThreadId));
 
 /**
  * Announce the start of a deploy for `componentName`. Awaits acknowledgement
@@ -98,9 +140,10 @@ ensureReceiver();
  * component compose correctly (each call must be paired with exactly one
  * broadcastDeployEnd).
  */
-export async function broadcastDeployStart(componentName: string): Promise<void> {
+export async function broadcastDeployStart(componentName: string): Promise<string> {
 	ensureReceiver();
-	const event: DeployLifecycleEvent = { name: componentName, phase: 'start' };
+	const deploymentId = randomUUID();
+	const event: DeployLifecycleEvent = { name: componentName, phase: 'start', deploymentId, ownerThreadId: threadId };
 	deployLifecycle._handle(event); // local thread first
 	let timer: ReturnType<typeof setTimeout> | undefined;
 	try {
@@ -125,6 +168,7 @@ export async function broadcastDeployStart(componentName: string): Promise<void>
 	} finally {
 		if (timer) clearTimeout(timer);
 	}
+	return deploymentId;
 }
 
 /**
@@ -135,9 +179,9 @@ export async function broadcastDeployStart(componentName: string): Promise<void>
  * Must be called exactly once per matching broadcastDeployStart, even if the
  * deploy errored — typically from a `finally` block.
  */
-export function broadcastDeployEnd(componentName: string): void {
+export function broadcastDeployEnd(componentName: string, deploymentId: string): void {
 	ensureReceiver();
-	const event: DeployLifecycleEvent = { name: componentName, phase: 'end' };
+	const event: DeployLifecycleEvent = { name: componentName, phase: 'end', deploymentId, ownerThreadId: threadId };
 	deployLifecycle._handle(event);
 	try {
 		void broadcast({ type: DEPLOY_LIFECYCLE_MSG, event }, false);

--- a/components/deployLifecycle.ts
+++ b/components/deployLifecycle.ts
@@ -22,11 +22,12 @@
 
 import { EventEmitter } from 'node:events';
 import { randomUUID } from 'node:crypto';
+import { setTimeout as delay } from 'node:timers/promises';
 import { isMainThread, threadId } from 'node:worker_threads';
 import {
 	broadcast,
 	broadcastWithAcknowledgement,
-	awaitThreadProcessGroupsTerminated,
+	isThreadRunning,
 	onMessageByType,
 	onThreadExit,
 } from '../server/threads/manageThreads.js';
@@ -77,7 +78,7 @@ class DeployLifecycle extends EventEmitter<DeployLifecycleEventsMap> {
 			this.#deployments.set(deploymentId, { name: event.name, ownerThreadId });
 			this.#byComponent.set(event.name, active);
 			active.add(deploymentId);
-			if (active.size === 1) this.emit('deploy:start', event.name);
+			if (active.size === 1) this.#emitSafely('deploy:start', event.name);
 			return;
 		}
 		if (!deploymentId) deploymentId = this.#legacyDeployments.get(event.name)?.pop();
@@ -93,8 +94,9 @@ class DeployLifecycle extends EventEmitter<DeployLifecycleEventsMap> {
 
 	async _reclaimOwnerAfterTermination(
 		ownerThreadId: number,
-		waitForTermination: (ownerThreadId: number) => Promise<void> = awaitThreadProcessGroupsTerminated
+		waitForTermination: (ownerThreadId: number) => Promise<void> = waitForOwnerTermination
 	): Promise<void> {
+		this.#deadOwners.add(ownerThreadId);
 		await waitForTermination(ownerThreadId);
 		this._reclaimOwner(ownerThreadId);
 	}
@@ -108,10 +110,16 @@ class DeployLifecycle extends EventEmitter<DeployLifecycleEventsMap> {
 		active.delete(deploymentId);
 		if (active.size === 0) {
 			this.#byComponent.delete(deployment.name);
+			this.#emitSafely('deploy:end', deployment.name);
+		}
+	}
+
+	#emitSafely(event: 'deploy:start' | 'deploy:end', componentName: string): void {
+		for (const listener of this.rawListeners(event)) {
 			try {
-				this.emit('deploy:end', deployment.name);
+				listener.call(this, componentName);
 			} catch (error) {
-				harperLogger.error(`Listener for deploy:end threw while reclaiming ${deployment.name}:`, error);
+				harperLogger.error(`Listener for ${event} threw for ${componentName}:`, error);
 			}
 		}
 	}
@@ -127,6 +135,10 @@ class DeployLifecycle extends EventEmitter<DeployLifecycleEventsMap> {
 }
 
 export const deployLifecycle = new DeployLifecycle();
+
+async function waitForOwnerTermination(ownerThreadId: number): Promise<void> {
+	while (await isThreadRunning(ownerThreadId)) await delay(25);
+}
 
 let receiverInstalled = false;
 function ensureReceiver() {

--- a/components/operations.js
+++ b/components/operations.js
@@ -646,12 +646,10 @@ async function deployComponent(req) {
 			// deploy checks its own local isNewComponent, since directory state (and therefore
 			// whether the component was already active) can differ per node.
 			//
-			// An existing, already-active component being redeployed does NOT force a restart
-			// here: some updates (e.g. static files only) may not need one at all, and when one
-			// genuinely is needed, that component's already-running file watcher (Scope/
-			// EntryHandler, see deployLifecycle.ts) independently detects the post-deploy file
-			// changes and requests the restart itself.
-			if (application.isNewComponent) {
+			// An existing component's watched files are handled by Scope/EntryHandler. Package
+			// metadata is deliberately outside most plugin globs, so compare it across the atomic
+			// swap as well: a dependency or module-entry change also invalidates loaded code.
+			if (application.isNewComponent || application.packageMetadataChanged) {
 				const { requestRestart } = require('./requestRestart.ts');
 				requestRestart();
 			}

--- a/integrationTests/deploy/redeploy-restart-flag-deletion.test.ts
+++ b/integrationTests/deploy/redeploy-restart-flag-deletion.test.ts
@@ -2,13 +2,11 @@
  * Redeploy of an active jsResource component that *deletes* a resource file must also flag
  * restartRequired (harper#1817 follow-up).
  *
- * The original harper#1817 fix (see redeploy-restart-flag.test.ts) handles a redeployed file whose
- * *contents* changed: the fresh post-redeploy chokidar scan re-emits every surviving file as `'add'`,
- * and jsResource treats a re-`add` of an already-loaded file like a change. But a redeploy that
- * removes a resource file entirely produces no event at all for it — no re-`add`, no `unlink` —
- * because the fresh watcher's initial scan only reports what's currently on disk and has no memory
- * of the prior tree. Left unhandled, the deleted resource stays registered and active in memory,
- * with no signal to the operator that anything changed.
+ * EntryHandler retains the pre-deploy snapshot and compares it with the resumed watcher's initial
+ * scan. A surviving file with changed contents emits `change`; a file absent from the completed scan
+ * emits `unlink`, which causes jsResource to request a restart. Before that generation diff existed,
+ * the fresh watcher had no memory of the prior tree, so a deleted resource produced no event and
+ * stayed registered and active in memory with no signal to the operator that anything changed.
  *
  * This test deploys a jsResource component with a single resource file, then redeploys with that
  * file entirely absent (restart:false), and asserts `get_status.restartRequired` flips to `true`.

--- a/integrationTests/deploy/redeploy-runtime-equivalence.test.ts
+++ b/integrationTests/deploy/redeploy-runtime-equivalence.test.ts
@@ -75,7 +75,7 @@ async function buildResolutionPayload(addJavaScriptCandidate: boolean): Promise<
 	}
 }
 
-async function buildPureESMPayload(): Promise<string> {
+async function buildPureESMPayload(version: number): Promise<string> {
 	const directory = await mkdtemp(join(tmpdir(), 'redeploy-pure-esm-'));
 	try {
 		const dependencyDirectory = join(directory, 'vendor', 'pure-esm-probe');
@@ -103,7 +103,7 @@ async function buildPureESMPayload(): Promise<string> {
 		);
 		await writeFile(join(directory, 'package.json'), JSON.stringify(rootPackage) + '\n');
 		await writeFile(join(dependencyDirectory, 'package.json'), JSON.stringify(dependencyPackage) + '\n');
-		await writeFile(join(dependencyDirectory, 'index.js'), 'export const VERSION = 1;\n');
+		await writeFile(join(dependencyDirectory, 'index.js'), `export const VERSION = ${version};\n`);
 		await writeFile(
 			join(directory, 'package-lock.json'),
 			JSON.stringify({
@@ -305,7 +305,7 @@ suite('Redeploy runtime-equivalence proof', (ctx: ContextWithHarper) => {
 		await operation(ctx, {
 			operation: 'deploy_component',
 			project: PURE_ESM_PROJECT,
-			payload: await buildPureESMPayload(),
+			payload: await buildPureESMPayload(1),
 			restart: true,
 		});
 		await waitForVersion(ctx, 'PureESMVersion', 1);
@@ -316,11 +316,22 @@ suite('Redeploy runtime-equivalence proof', (ctx: ContextWithHarper) => {
 		await operation(ctx, {
 			operation: 'deploy_component',
 			project: PURE_ESM_PROJECT,
-			payload: await buildPureESMPayload(),
+			payload: await buildPureESMPayload(1),
 			restart: false,
 		});
 		await sleep(2_000);
 		strictEqual(await getRestartRequired(ctx), false);
+		strictEqual(await readResourceVersion(ctx, 'PureESMVersion'), 1);
+	});
+
+	test('changing only import-only dependency source requests restart', async () => {
+		await operation(ctx, {
+			operation: 'deploy_component',
+			project: PURE_ESM_PROJECT,
+			payload: await buildPureESMPayload(2),
+			restart: false,
+		});
+		await waitForRestartRequired(ctx);
 		strictEqual(await readResourceVersion(ctx, 'PureESMVersion'), 1);
 	});
 

--- a/integrationTests/deploy/redeploy-runtime-equivalence.test.ts
+++ b/integrationTests/deploy/redeploy-runtime-equivalence.test.ts
@@ -1,5 +1,5 @@
 import { suite, test, before, after } from 'node:test';
-import { ok, strictEqual } from 'node:assert';
+import { ok, rejects, strictEqual } from 'node:assert';
 import { join } from 'node:path';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -325,6 +325,7 @@ suite('Redeploy runtime-equivalence proof', (ctx: ContextWithHarper) => {
 	});
 
 	test('changing only import-only dependency source requests restart', async () => {
+		strictEqual(await getRestartRequired(ctx), false);
 		await operation(ctx, {
 			operation: 'deploy_component',
 			project: PURE_ESM_PROJECT,
@@ -357,7 +358,24 @@ suite('Redeploy runtime-equivalence proof', (ctx: ContextWithHarper) => {
 		strictEqual(await getRestartRequired(ctx), false);
 	});
 
+	test('a failed dependency install restores the loaded component tree', async () => {
+		await rejects(
+			operation(ctx, {
+				operation: 'deploy_component',
+				project: PACKAGE_METADATA_PROJECT,
+				payload: await buildPackageMetadataPayload(2, true),
+				restart: false,
+				install_command: 'sh -c "exit 1"',
+				install_timeout: 30_000,
+			}),
+			/operation deploy_component failed with 500/
+		);
+		strictEqual(await getRestartRequired(ctx), false);
+		strictEqual(await readResourceVersion(ctx, 'MetadataVersion'), 1);
+	});
+
 	test('a changed installed dependency requests restart', async () => {
+		strictEqual(await getRestartRequired(ctx), false);
 		await operation(ctx, {
 			operation: 'deploy_component',
 			project: PACKAGE_METADATA_PROJECT,

--- a/integrationTests/deploy/redeploy-runtime-equivalence.test.ts
+++ b/integrationTests/deploy/redeploy-runtime-equivalence.test.ts
@@ -11,6 +11,7 @@ import { authHeader, getRestartRequired, operation } from './redeploy-restart-fl
 const RELATIVE_PROJECT = 'redeploy-relative-runtime-app';
 const PACKAGE_IMPORT_PROJECT = 'redeploy-package-import-runtime-app';
 const PACKAGE_METADATA_PROJECT = 'redeploy-package-metadata-app';
+const RESOLUTION_PROJECT = 'redeploy-resolution-runtime-app';
 
 async function buildRuntimePayload(className: string, version: number, packageImport: boolean): Promise<string> {
 	const directory = await mkdtemp(join(tmpdir(), 'redeploy-runtime-equivalence-'));
@@ -46,6 +47,27 @@ async function buildRuntimePayload(className: string, version: number, packageIm
 				'}\n'
 		);
 		await writeFile(join(directory, 'helper.js'), `export const VERSION = ${version};\n`);
+		return await targz(directory);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+}
+
+async function buildResolutionPayload(addJavaScriptCandidate: boolean): Promise<string> {
+	const directory = await mkdtemp(join(tmpdir(), 'redeploy-runtime-resolution-'));
+	try {
+		await writeFile(join(directory, 'config.yaml'), 'jsResource:\n  files: resources.js\nrest: true\n');
+		await writeFile(join(directory, 'package.json'), '{"name":"redeploy-resolution-runtime-app","type":"module"}\n');
+		await writeFile(
+			join(directory, 'resources.js'),
+			"import helper from './helper';\n" +
+				'export class ResolutionVersion extends Resource {\n' +
+				'\tstatic loadAsInstance = false;\n' +
+				'\tget() { return { version: helper.VERSION }; }\n' +
+				'}\n'
+		);
+		await writeFile(join(directory, 'helper.json'), '{"VERSION":1}\n');
+		if (addJavaScriptCandidate) await writeFile(join(directory, 'helper.js'), 'export default { VERSION: 2 };\n');
 		return await targz(directory);
 	} finally {
 		await rm(directory, { recursive: true, force: true });
@@ -205,6 +227,28 @@ suite('Redeploy runtime-equivalence proof', (ctx: ContextWithHarper) => {
 		});
 		await waitForRestartRequired(ctx);
 		strictEqual(await readResourceVersion(ctx, 'PackageImportVersion'), 1);
+	});
+
+	test('loads an extensionless import through its initial JSON candidate', async () => {
+		await operation(ctx, {
+			operation: 'deploy_component',
+			project: RESOLUTION_PROJECT,
+			payload: await buildResolutionPayload(false),
+			restart: true,
+		});
+		await waitForVersion(ctx, 'ResolutionVersion', 1);
+	});
+
+	test('adding a higher-priority resolution candidate requests restart', async () => {
+		strictEqual(await getRestartRequired(ctx), false);
+		await operation(ctx, {
+			operation: 'deploy_component',
+			project: RESOLUTION_PROJECT,
+			payload: await buildResolutionPayload(true),
+			restart: false,
+		});
+		await waitForRestartRequired(ctx);
+		strictEqual(await readResourceVersion(ctx, 'ResolutionVersion'), 1);
 	});
 
 	test('loads a component with deterministic dependency metadata', async () => {

--- a/integrationTests/deploy/redeploy-runtime-equivalence.test.ts
+++ b/integrationTests/deploy/redeploy-runtime-equivalence.test.ts
@@ -13,6 +13,19 @@ const PACKAGE_IMPORT_PROJECT = 'redeploy-package-import-runtime-app';
 const PACKAGE_METADATA_PROJECT = 'redeploy-package-metadata-app';
 const RESOLUTION_PROJECT = 'redeploy-resolution-runtime-app';
 const PURE_ESM_PROJECT = 'redeploy-pure-esm-runtime-app';
+const STATIC_PROJECT = 'redeploy-static-runtime-app';
+
+async function buildStaticPayload(contents: string): Promise<string> {
+	const directory = await mkdtemp(join(tmpdir(), 'redeploy-static-runtime-'));
+	try {
+		await mkdir(join(directory, 'web'));
+		await writeFile(join(directory, 'config.yaml'), "static:\n  root: web\n  files: 'web/**'\n");
+		await writeFile(join(directory, 'web', 'asset.txt'), contents);
+		return await targz(directory);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+}
 
 async function buildRuntimePayload(className: string, version: number, packageImport: boolean): Promise<string> {
 	const directory = await mkdtemp(join(tmpdir(), 'redeploy-runtime-equivalence-'));
@@ -228,6 +241,24 @@ async function waitForRestartClear(ctx: ContextWithHarper): Promise<void> {
 	throw new Error('Timed out waiting for restartRequired to clear');
 }
 
+async function waitForStaticContent(ctx: ContextWithHarper, expected: string): Promise<void> {
+	const deadline = Date.now() + 30_000;
+	while (Date.now() < deadline) {
+		try {
+			const response = await fetch(`${ctx.harper.httpURL}/asset.txt`, {
+				headers: { Authorization: authHeader(ctx) },
+			});
+			if (response.status === 200) {
+				if ((await response.text()) === expected) return;
+			} else {
+				await response.body?.cancel();
+			}
+		} catch {}
+		await sleep(250);
+	}
+	throw new Error(`Timed out waiting for static content ${expected}`);
+}
+
 suite('Redeploy runtime-equivalence proof', (ctx: ContextWithHarper) => {
 	before(async () => {
 		await startHarper(ctx);
@@ -258,6 +289,28 @@ suite('Redeploy runtime-equivalence proof', (ctx: ContextWithHarper) => {
 		await sleep(2_000);
 		strictEqual(await getRestartRequired(ctx), false);
 		strictEqual(await readResourceVersion(ctx, 'RelativeVersion'), 1);
+	});
+
+	test('loads a static asset', async () => {
+		await operation(ctx, {
+			operation: 'deploy_component',
+			project: STATIC_PROJECT,
+			payload: await buildStaticPayload('version 1'),
+			restart: true,
+		});
+		await waitForStaticContent(ctx, 'version 1');
+		await waitForRestartClear(ctx);
+	});
+
+	test('serves changed static content without a restart', async () => {
+		await operation(ctx, {
+			operation: 'deploy_component',
+			project: STATIC_PROJECT,
+			payload: await buildStaticPayload('version 2'),
+			restart: false,
+		});
+		await waitForStaticContent(ctx, 'version 2');
+		strictEqual(await getRestartRequired(ctx), false);
 	});
 
 	test('changing only an unwatched relative helper requests restart', async () => {

--- a/integrationTests/deploy/redeploy-runtime-equivalence.test.ts
+++ b/integrationTests/deploy/redeploy-runtime-equivalence.test.ts
@@ -12,6 +12,7 @@ const RELATIVE_PROJECT = 'redeploy-relative-runtime-app';
 const PACKAGE_IMPORT_PROJECT = 'redeploy-package-import-runtime-app';
 const PACKAGE_METADATA_PROJECT = 'redeploy-package-metadata-app';
 const RESOLUTION_PROJECT = 'redeploy-resolution-runtime-app';
+const PURE_ESM_PROJECT = 'redeploy-pure-esm-runtime-app';
 
 async function buildRuntimePayload(className: string, version: number, packageImport: boolean): Promise<string> {
 	const directory = await mkdtemp(join(tmpdir(), 'redeploy-runtime-equivalence-'));
@@ -68,6 +69,55 @@ async function buildResolutionPayload(addJavaScriptCandidate: boolean): Promise<
 		);
 		await writeFile(join(directory, 'helper.json'), '{"VERSION":1}\n');
 		if (addJavaScriptCandidate) await writeFile(join(directory, 'helper.js'), 'export default { VERSION: 2 };\n');
+		return await targz(directory);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+}
+
+async function buildPureESMPayload(): Promise<string> {
+	const directory = await mkdtemp(join(tmpdir(), 'redeploy-pure-esm-'));
+	try {
+		const dependencyDirectory = join(directory, 'vendor', 'pure-esm-probe');
+		const rootPackage = {
+			name: PURE_ESM_PROJECT,
+			version: '1.0.0',
+			type: 'module',
+			dependencies: { 'pure-esm-probe': 'file:vendor/pure-esm-probe' },
+		};
+		const dependencyPackage = {
+			name: 'pure-esm-probe',
+			version: '1.0.0',
+			type: 'module',
+			exports: { '.': { import: './index.js' } },
+		};
+		await mkdir(dependencyDirectory, { recursive: true });
+		await writeFile(join(directory, 'config.yaml'), 'jsResource:\n  files: resources.js\nrest: true\n');
+		await writeFile(
+			join(directory, 'resources.js'),
+			"import { VERSION } from 'pure-esm-probe';\n" +
+				'export class PureESMVersion extends Resource {\n' +
+				'\tstatic loadAsInstance = false;\n' +
+				'\tget() { return { version: VERSION }; }\n' +
+				'}\n'
+		);
+		await writeFile(join(directory, 'package.json'), JSON.stringify(rootPackage) + '\n');
+		await writeFile(join(dependencyDirectory, 'package.json'), JSON.stringify(dependencyPackage) + '\n');
+		await writeFile(join(dependencyDirectory, 'index.js'), 'export const VERSION = 1;\n');
+		await writeFile(
+			join(directory, 'package-lock.json'),
+			JSON.stringify({
+				name: PURE_ESM_PROJECT,
+				version: '1.0.0',
+				lockfileVersion: 3,
+				requires: true,
+				packages: {
+					'': rootPackage,
+					'node_modules/pure-esm-probe': { resolved: 'vendor/pure-esm-probe', link: true },
+					'vendor/pure-esm-probe': dependencyPackage,
+				},
+			}) + '\n'
+		);
 		return await targz(directory);
 	} finally {
 		await rm(directory, { recursive: true, force: true });
@@ -249,6 +299,29 @@ suite('Redeploy runtime-equivalence proof', (ctx: ContextWithHarper) => {
 		});
 		await waitForRestartRequired(ctx);
 		strictEqual(await readResourceVersion(ctx, 'ResolutionVersion'), 1);
+	});
+
+	test('loads a dependency with import-only package exports', async () => {
+		await operation(ctx, {
+			operation: 'deploy_component',
+			project: PURE_ESM_PROJECT,
+			payload: await buildPureESMPayload(),
+			restart: true,
+		});
+		await waitForVersion(ctx, 'PureESMVersion', 1);
+	});
+
+	test('an identical import-only dependency redeploy remains restart-free', async () => {
+		strictEqual(await getRestartRequired(ctx), false);
+		await operation(ctx, {
+			operation: 'deploy_component',
+			project: PURE_ESM_PROJECT,
+			payload: await buildPureESMPayload(),
+			restart: false,
+		});
+		await sleep(2_000);
+		strictEqual(await getRestartRequired(ctx), false);
+		strictEqual(await readResourceVersion(ctx, 'PureESMVersion'), 1);
 	});
 
 	test('loads a component with deterministic dependency metadata', async () => {

--- a/integrationTests/deploy/redeploy-runtime-equivalence.test.ts
+++ b/integrationTests/deploy/redeploy-runtime-equivalence.test.ts
@@ -1,7 +1,7 @@
 import { suite, test, before, after } from 'node:test';
 import { ok, rejects, strictEqual } from 'node:assert';
 import { join } from 'node:path';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { setTimeout as sleep } from 'node:timers/promises';
 
@@ -75,7 +75,7 @@ async function buildResolutionPayload(addJavaScriptCandidate: boolean): Promise<
 	}
 }
 
-async function buildPureESMPayload(version: number): Promise<string> {
+async function buildPureESMPayload(version: number, exportsTarget = 'index.js'): Promise<string> {
 	const directory = await mkdtemp(join(tmpdir(), 'redeploy-pure-esm-'));
 	try {
 		const dependencyDirectory = join(directory, 'vendor', 'pure-esm-probe');
@@ -89,7 +89,7 @@ async function buildPureESMPayload(version: number): Promise<string> {
 			name: 'pure-esm-probe',
 			version: '1.0.0',
 			type: 'module',
-			exports: { '.': { import: './index.js' } },
+			exports: { '.': { import: `./${exportsTarget}` } },
 		};
 		await mkdir(dependencyDirectory, { recursive: true });
 		await writeFile(join(directory, 'config.yaml'), 'jsResource:\n  files: resources.js\nrest: true\n');
@@ -103,7 +103,12 @@ async function buildPureESMPayload(version: number): Promise<string> {
 		);
 		await writeFile(join(directory, 'package.json'), JSON.stringify(rootPackage) + '\n');
 		await writeFile(join(dependencyDirectory, 'package.json'), JSON.stringify(dependencyPackage) + '\n');
-		await writeFile(join(dependencyDirectory, 'index.js'), `export const VERSION = ${version};\n`);
+		if (exportsTarget === 'index.js') {
+			await writeFile(join(dependencyDirectory, 'index.js'), `export const VERSION = ${version};\n`);
+		} else {
+			await writeFile(join(dependencyDirectory, 'entry-v1.js'), `export const VERSION = ${version};\n`);
+			await writeFile(join(dependencyDirectory, 'entry-v2.js'), `export const VERSION = ${version + 1};\n`);
+		}
 		await writeFile(
 			join(directory, 'package-lock.json'),
 			JSON.stringify({
@@ -114,7 +119,7 @@ async function buildPureESMPayload(version: number): Promise<string> {
 				packages: {
 					'': rootPackage,
 					'node_modules/pure-esm-probe': { resolved: 'vendor/pure-esm-probe', link: true },
-					'vendor/pure-esm-probe': dependencyPackage,
+					'vendor/pure-esm-probe': { name: 'pure-esm-probe', version: '1.0.0', type: 'module' },
 				},
 			}) + '\n'
 		);
@@ -214,6 +219,15 @@ async function waitForRestartRequired(ctx: ContextWithHarper): Promise<void> {
 	throw new Error('Timed out waiting for restartRequired');
 }
 
+async function waitForRestartClear(ctx: ContextWithHarper): Promise<void> {
+	const deadline = Date.now() + 30_000;
+	while (Date.now() < deadline) {
+		if (!(await getRestartRequired(ctx))) return;
+		await sleep(250);
+	}
+	throw new Error('Timed out waiting for restartRequired to clear');
+}
+
 suite('Redeploy runtime-equivalence proof', (ctx: ContextWithHarper) => {
 	before(async () => {
 		await startHarper(ctx);
@@ -309,6 +323,7 @@ suite('Redeploy runtime-equivalence proof', (ctx: ContextWithHarper) => {
 			restart: true,
 		});
 		await waitForVersion(ctx, 'PureESMVersion', 1);
+		await waitForRestartClear(ctx);
 	});
 
 	test('an identical import-only dependency redeploy remains restart-free', async () => {
@@ -370,6 +385,10 @@ suite('Redeploy runtime-equivalence proof', (ctx: ContextWithHarper) => {
 			}),
 			/operation deploy_component failed with 500/
 		);
+		const restoredPackageJSON = JSON.parse(
+			await readFile(join(ctx.harper.dataRootDir, 'components', PACKAGE_METADATA_PROJECT, 'package.json'), 'utf8')
+		);
+		strictEqual(restoredPackageJSON.dependencies['probe-dependency'], 'file:vendor/probe-dependency-v1');
 		strictEqual(await getRestartRequired(ctx), false);
 		strictEqual(await readResourceVersion(ctx, 'MetadataVersion'), 1);
 	});
@@ -384,5 +403,38 @@ suite('Redeploy runtime-equivalence proof', (ctx: ContextWithHarper) => {
 		});
 		await waitForRestartRequired(ctx);
 		ok(await getRestartRequired(ctx));
+	});
+});
+
+suite('Redeploy import-only exports retarget proof', (ctx: ContextWithHarper) => {
+	before(async () => {
+		await startHarper(ctx);
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	test('loads the initial exports target', async () => {
+		await operation(ctx, {
+			operation: 'deploy_component',
+			project: PURE_ESM_PROJECT,
+			payload: await buildPureESMPayload(10, 'entry-v1.js'),
+			restart: true,
+		});
+		await waitForVersion(ctx, 'PureESMVersion', 10);
+		await waitForRestartClear(ctx);
+	});
+
+	test('retargeting import-only package exports requests restart', async () => {
+		strictEqual(await getRestartRequired(ctx), false);
+		await operation(ctx, {
+			operation: 'deploy_component',
+			project: PURE_ESM_PROJECT,
+			payload: await buildPureESMPayload(10, 'entry-v2.js'),
+			restart: false,
+		});
+		await waitForRestartRequired(ctx);
+		strictEqual(await readResourceVersion(ctx, 'PureESMVersion'), 10);
 	});
 });

--- a/integrationTests/deploy/redeploy-runtime-equivalence.test.ts
+++ b/integrationTests/deploy/redeploy-runtime-equivalence.test.ts
@@ -1,0 +1,242 @@
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { join } from 'node:path';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { startHarper, teardownHarper, targz, type ContextWithHarper } from '@harperfast/integration-testing';
+import { authHeader, getRestartRequired, operation } from './redeploy-restart-flag-helpers.ts';
+
+const RELATIVE_PROJECT = 'redeploy-relative-runtime-app';
+const PACKAGE_IMPORT_PROJECT = 'redeploy-package-import-runtime-app';
+const PACKAGE_METADATA_PROJECT = 'redeploy-package-metadata-app';
+
+async function buildRuntimePayload(className: string, version: number, packageImport: boolean): Promise<string> {
+	const directory = await mkdtemp(join(tmpdir(), 'redeploy-runtime-equivalence-'));
+	try {
+		await writeFile(join(directory, 'config.yaml'), 'jsResource:\n  files: resources.js\nrest: true\n');
+		if (packageImport) {
+			await writeFile(
+				join(directory, 'package.json'),
+				JSON.stringify({
+					name: PACKAGE_IMPORT_PROJECT,
+					version: '1.0.0',
+					type: 'module',
+					imports: { '#helper': './helper.js' },
+				}) + '\n'
+			);
+			await writeFile(
+				join(directory, 'package-lock.json'),
+				JSON.stringify({
+					name: PACKAGE_IMPORT_PROJECT,
+					version: '1.0.0',
+					lockfileVersion: 3,
+					requires: true,
+					packages: { '': { name: PACKAGE_IMPORT_PROJECT, version: '1.0.0' } },
+				}) + '\n'
+			);
+		}
+		await writeFile(
+			join(directory, 'resources.js'),
+			`import { VERSION } from '${packageImport ? '#helper' : './helper.js'}';\n` +
+				`export class ${className} extends Resource {\n` +
+				'\tstatic loadAsInstance = false;\n' +
+				'\tget() { return { version: VERSION }; }\n' +
+				'}\n'
+		);
+		await writeFile(join(directory, 'helper.js'), `export const VERSION = ${version};\n`);
+		return await targz(directory);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+}
+
+async function buildPackageMetadataPayload(dependencyVersion: number, prettyPackageJSON: boolean): Promise<string> {
+	const directory = await mkdtemp(join(tmpdir(), 'redeploy-package-metadata-'));
+	try {
+		const dependencyDirectory = `probe-dependency-v${dependencyVersion}`;
+		const dependencySpecifier = `file:vendor/${dependencyDirectory}`;
+		const rootPackage = prettyPackageJSON
+			? {
+					dependencies: { 'probe-dependency': dependencySpecifier },
+					type: 'module',
+					version: '1.0.0',
+					name: PACKAGE_METADATA_PROJECT,
+				}
+			: {
+					name: PACKAGE_METADATA_PROJECT,
+					version: '1.0.0',
+					type: 'module',
+					dependencies: { 'probe-dependency': dependencySpecifier },
+				};
+		const dependencyPackage = { name: 'probe-dependency', version: `${dependencyVersion}.0.0` };
+
+		await mkdir(join(directory, 'vendor', dependencyDirectory), { recursive: true });
+		await writeFile(join(directory, 'config.yaml'), 'jsResource:\n  files: resources.js\nrest: true\n');
+		await writeFile(
+			join(directory, 'resources.js'),
+			'export class MetadataVersion extends Resource {\n' +
+				'\tstatic loadAsInstance = false;\n' +
+				'\tget() { return { version: 1 }; }\n' +
+				'}\n'
+		);
+		await writeFile(
+			join(directory, 'package.json'),
+			JSON.stringify(rootPackage, null, prettyPackageJSON ? 2 : undefined) + '\n'
+		);
+		await writeFile(
+			join(directory, 'vendor', dependencyDirectory, 'package.json'),
+			JSON.stringify(dependencyPackage) + '\n'
+		);
+		await writeFile(
+			join(directory, 'package-lock.json'),
+			JSON.stringify({
+				name: PACKAGE_METADATA_PROJECT,
+				version: '1.0.0',
+				lockfileVersion: 3,
+				requires: true,
+				packages: {
+					'': rootPackage,
+					'node_modules/probe-dependency': { resolved: `vendor/${dependencyDirectory}`, link: true },
+					[`vendor/${dependencyDirectory}`]: dependencyPackage,
+				},
+			}) + '\n'
+		);
+		return await targz(directory);
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+}
+
+async function readResourceVersion(ctx: ContextWithHarper, resourceName: string): Promise<number | undefined> {
+	try {
+		const response = await fetch(`${ctx.harper.httpURL}/${resourceName}`, {
+			headers: { Authorization: authHeader(ctx) },
+		});
+		if (response.status !== 200) {
+			await response.body?.cancel();
+			return;
+		}
+		return ((await response.json()) as { version?: number } | null)?.version;
+	} catch {
+		return;
+	}
+}
+
+async function waitForVersion(ctx: ContextWithHarper, resourceName: string, version: number): Promise<void> {
+	const deadline = Date.now() + 30_000;
+	while (Date.now() < deadline) {
+		if ((await readResourceVersion(ctx, resourceName)) === version) return;
+		await sleep(250);
+	}
+	throw new Error(`Timed out waiting for ${resourceName} version ${version}`);
+}
+
+async function waitForRestartRequired(ctx: ContextWithHarper): Promise<void> {
+	const deadline = Date.now() + 30_000;
+	while (Date.now() < deadline) {
+		if (await getRestartRequired(ctx)) return;
+		await sleep(250);
+	}
+	throw new Error('Timed out waiting for restartRequired');
+}
+
+suite('Redeploy runtime-equivalence proof', (ctx: ContextWithHarper) => {
+	before(async () => {
+		await startHarper(ctx);
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	test('loads a resource with an unwatched relative helper', async () => {
+		await operation(ctx, {
+			operation: 'deploy_component',
+			project: RELATIVE_PROJECT,
+			payload: await buildRuntimePayload('RelativeVersion', 1, false),
+			restart: true,
+		});
+		await waitForVersion(ctx, 'RelativeVersion', 1);
+	});
+
+	test('an identical redeploy remains restart-free', async () => {
+		strictEqual(await getRestartRequired(ctx), false);
+		await operation(ctx, {
+			operation: 'deploy_component',
+			project: RELATIVE_PROJECT,
+			payload: await buildRuntimePayload('RelativeVersion', 1, false),
+			restart: false,
+		});
+		await sleep(2_000);
+		strictEqual(await getRestartRequired(ctx), false);
+		strictEqual(await readResourceVersion(ctx, 'RelativeVersion'), 1);
+	});
+
+	test('changing only an unwatched relative helper requests restart', async () => {
+		await operation(ctx, {
+			operation: 'deploy_component',
+			project: RELATIVE_PROJECT,
+			payload: await buildRuntimePayload('RelativeVersion', 2, false),
+			restart: false,
+		});
+		await waitForRestartRequired(ctx);
+		strictEqual(await readResourceVersion(ctx, 'RelativeVersion'), 1);
+	});
+
+	test('loads an app-local package import', async () => {
+		await operation(ctx, {
+			operation: 'deploy_component',
+			project: PACKAGE_IMPORT_PROJECT,
+			payload: await buildRuntimePayload('PackageImportVersion', 1, true),
+			restart: true,
+		});
+		await waitForVersion(ctx, 'PackageImportVersion', 1);
+	});
+
+	test('changing only an app-local package-import helper requests restart', async () => {
+		strictEqual(await getRestartRequired(ctx), false);
+		await operation(ctx, {
+			operation: 'deploy_component',
+			project: PACKAGE_IMPORT_PROJECT,
+			payload: await buildRuntimePayload('PackageImportVersion', 2, true),
+			restart: false,
+		});
+		await waitForRestartRequired(ctx);
+		strictEqual(await readResourceVersion(ctx, 'PackageImportVersion'), 1);
+	});
+
+	test('loads a component with deterministic dependency metadata', async () => {
+		await operation(ctx, {
+			operation: 'deploy_component',
+			project: PACKAGE_METADATA_PROJECT,
+			payload: await buildPackageMetadataPayload(1, false),
+			restart: true,
+		});
+		await waitForVersion(ctx, 'MetadataVersion', 1);
+	});
+
+	test('package.json formatting and key order remain restart-free', async () => {
+		strictEqual(await getRestartRequired(ctx), false);
+		await operation(ctx, {
+			operation: 'deploy_component',
+			project: PACKAGE_METADATA_PROJECT,
+			payload: await buildPackageMetadataPayload(1, true),
+			restart: false,
+		});
+		await sleep(2_000);
+		strictEqual(await getRestartRequired(ctx), false);
+	});
+
+	test('a changed installed dependency requests restart', async () => {
+		await operation(ctx, {
+			operation: 'deploy_component',
+			project: PACKAGE_METADATA_PROJECT,
+			payload: await buildPackageMetadataPayload(2, true),
+			restart: false,
+		});
+		await waitForRestartRequired(ctx);
+		ok(await getRestartRequired(ctx));
+	});
+});

--- a/resources/jsResource.ts
+++ b/resources/jsResource.ts
@@ -69,41 +69,13 @@ export class ResourceLoadError extends Error {
  *
  * Once a file has been loaded it cannot be unloaded without a restart.
  *
- * Thus, this plugin only handle files as they are added (`add` event). All other events result in a restart request.
+ * Thus, this plugin only handles files as they are added (`add` event). All other events result in a restart request.
  *
- * A redeploy tears down and reinstalls the component's files while this scope's watcher is paused
- * (see `Scope`/`EntryHandler` deploy lifecycle); on resume the fresh chokidar scan re-emits every
- * existing file as `'add'` — including ones whose contents just changed. Treating those as plain
- * adds would silently re-run against the stale module cache and never flag a restart (harper#1817).
- * So we track which files this scope has already loaded: a re-`add` of a known file is a redeploy of
- * loaded code we cannot hot-swap, and is handled like a `change` — request a restart. A first-time
- * `add` (initial load, or a genuinely new file added at runtime) still loads without a restart.
- *
- * A redeploy that *deletes* a loaded file is a different shape of the same problem: the fresh
- * chokidar scan only reports what's currently on disk, so a file that's gone produces no event at
- * all — no re-`add`, no `unlink` — and the modified-file handling above never sees it. Left
- * unhandled, the deleted resource stays registered and active in memory (harper#1817 follow-up). So
- * we also track which files the post-redeploy scan pass reports, and once that scan's `ready` fires,
- * diff it against everything this scope has ever loaded: anything missing was deleted, and is
- * handled the same way as a modified file — request a restart.
- *
- * That diff must only run for an actual redeploy rescan, not every time `EntryHandler` emits
- * `ready` — it also refires after each ordinary runtime add/change once that file's read settles
- * (its initial-scan-complete latch never resets outside a full rescan), and diffing against that
- * would falsely treat every other already-loaded file as deleted. So the diff window is gated by
- * the scope's own `deploy:start`/`deploy:end` bracket (see `Scope`): `deploy:start` pauses the
- * watcher and opens the window (and is where we reset the scan-file tracking, since no file events
- * can land while paused), and the first `ready` afterward — the resumed watcher's fresh scan
- * completing — closes it and runs the diff.
+ * EntryHandler preserves file identity across a deploy pause/resume and emits `change` or `unlink`
+ * for loaded files that changed or disappeared, so those events request the required restart.
  */
 export async function handleApplication(scope: Scope) {
-	const loadedResourceFiles = new Set<string>();
-	// Files reported as `add` since the most recent `deploy:start`, populated only while
-	// `awaitingPostRedeployScan` is true — see the gating note above.
-	let currentScanFiles = new Set<string>();
-	let awaitingPostRedeployScan = false;
-
-	const entryHandler = scope.handleEntry(async function handleResourceEntry(entryEvent) {
+	scope.handleEntry(async function handleResourceEntry(entryEvent) {
 		if (entryEvent.entryType !== 'file') {
 			scope.logger.warn(
 				`jsResource plugin cannot handle entry type ${entryEvent.entryType}. Modify the 'files' option in ${scope.configFilePath} to only include files.`
@@ -111,13 +83,7 @@ export async function handleApplication(scope: Scope) {
 			return;
 		}
 
-		if (awaitingPostRedeployScan && entryEvent.eventType === 'add') {
-			// Recorded unconditionally — before the loaded/re-add branch below — so the post-scan
-			// deletion diff sees every file this scan reported, whether newly loaded or already known.
-			currentScanFiles.add(entryEvent.absolutePath);
-		}
-
-		if (entryEvent.eventType !== 'add' || loadedResourceFiles.has(entryEvent.absolutePath)) {
+		if (entryEvent.eventType !== 'add') {
 			scope.requestRestart();
 			return;
 		}
@@ -133,9 +99,6 @@ export async function handleApplication(scope: Scope) {
 				scope.logger.debug?.(`Registered root resource: ${path}`);
 			}
 			recurseForResources(scope, resourceModule, root);
-			// Record the load so a later re-`add` of this same file (a redeploy re-scan) is treated
-			// as a change and requests a restart rather than silently re-serving stale cached code.
-			loadedResourceFiles.add(entryEvent.absolutePath);
 			// A JS resource that extends an exported @table is the one carrying author opt-ins
 			// (`static mcpTools`/`mcpPrompts`), and it registers here — after the schema-derived
 			// table class and after the MCP component's boot scan. Signal so listing surfaces
@@ -144,26 +107,6 @@ export async function handleApplication(scope: Scope) {
 		} catch (error) {
 			// Rethrow with more context
 			throw new ResourceLoadError(entryEvent.absolutePath, error);
-		}
-	});
-
-	// Optional chaining: a mock/test scope may not implement EventEmitter, and Scope#handleEntry
-	// itself can return undefined (e.g. MissingDefaultFilesOptionError). In real use `scope` is
-	// always an EventEmitter and `entryHandler` is always the EntryHandler backing this watcher.
-	scope.on?.('deploy:start', () => {
-		awaitingPostRedeployScan = true;
-		currentScanFiles = new Set();
-	});
-
-	entryHandler?.on?.('ready', () => {
-		if (!awaitingPostRedeployScan) return;
-		awaitingPostRedeployScan = false;
-		for (const loadedFile of loadedResourceFiles) {
-			if (!currentScanFiles.has(loadedFile)) {
-				// Known file that the just-completed scan never reported — deleted during the redeploy.
-				loadedResourceFiles.delete(loadedFile);
-				scope.requestRestart();
-			}
 		}
 	});
 }

--- a/resources/roles.ts
+++ b/resources/roles.ts
@@ -20,8 +20,13 @@ export function handleApplication(
 	const rolesByFile = new Map<string, Set<string>>();
 	const contentsByFile = new Map<string, Buffer>();
 	let pending = Promise.resolve();
-	const entryHandler = scope.handleEntry((entry) => {
-		const operation = pending.then(async () => {
+	const enqueue = (operation: () => Promise<void>) => {
+		const queued = pending.then(operation);
+		pending = queued.catch(() => {});
+		return queued;
+	};
+	const entryHandler = scope.handleEntry((entry) =>
+		enqueue(async () => {
 			if (entry.entryType !== 'file') return;
 			const previousRoles = rolesByFile.get(entry.absolutePath) ?? new Set<string>();
 			if (entry.eventType === 'unlink') {
@@ -38,16 +43,15 @@ export function handleApplication(
 				new Set([...previousRoles].filter((roleName) => !currentRoles.has(roleName))),
 				rolesByFile
 			);
-		});
-		pending = operation.catch(() => {});
-		return operation;
-	});
+		})
+	);
 	scope.on('deploy:end', () => {
 		void entryHandler.ready
-			.then(() => pending)
-			.then(async () => {
-				for (const contents of contentsByFile.values()) await handleFile(contents, ensureRoleFn);
-			})
+			.then(() =>
+				enqueue(async () => {
+					for (const contents of contentsByFile.values()) await handleFile(contents, ensureRoleFn);
+				})
+			)
 			.catch((error) => scope.logger.error?.('Could not reconcile roles after deploy:', error));
 	});
 }

--- a/resources/roles.ts
+++ b/resources/roles.ts
@@ -15,8 +15,8 @@ const USERS_NOT_DBS: readonly string[] = RESERVED_DATABASE_NAMES;
  */
 export function handleApplication(scope: import('../components/Scope.ts').Scope) {
 	scope.handleEntry(async (entry) => {
-		if (entry.eventType === 'unlink') return;
-		return handleFile((entry as any).contents);
+		if (entry.entryType !== 'file' || entry.eventType === 'unlink') return;
+		return handleFile(entry.contents);
 	});
 }
 

--- a/resources/roles.ts
+++ b/resources/roles.ts
@@ -45,11 +45,18 @@ export function handleApplication(
 			);
 		})
 	);
+	if (!entryHandler) return;
 	scope.on('deploy:end', () => {
 		void entryHandler.ready
 			.then(() =>
 				enqueue(async () => {
-					for (const contents of contentsByFile.values()) await handleFile(contents, ensureRoleFn);
+					for (const contents of contentsByFile.values()) {
+						try {
+							await handleFile(contents, ensureRoleFn);
+						} catch (error) {
+							scope.logger.error?.('Could not reconcile a roles file after deploy:', error);
+						}
+					}
 				})
 			)
 			.catch((error) => scope.logger.error?.('Could not reconcile roles after deploy:', error));
@@ -140,10 +147,10 @@ async function ensureRole(role) {
 	for await (let existingRole of roleTable.search([{ attribute: 'role', value: role.role }] as any)) {
 		// use the existing role id so we can update in place. Legacy roles may have a UUID for the id instead of the role name
 		const { __createdtime__, __updatedtime__, ...existingRoleData } = existingRole;
+		role.id = existingRole.id;
 		if (isEqual(existingRoleData, role)) {
 			return;
 		}
-		role.id = existingRole.id;
 		return alterRole(role);
 	}
 	return addRole(role);

--- a/resources/roles.ts
+++ b/resources/roles.ts
@@ -14,10 +14,37 @@ const USERS_NOT_DBS: readonly string[] = RESERVED_DATABASE_NAMES;
  * definitions and ensure that they are created in the system database.
  */
 export function handleApplication(scope: import('../components/Scope.ts').Scope) {
+	const rolesByFile = new Map<string, Set<string>>();
 	scope.handleEntry(async (entry) => {
-		if (entry.entryType !== 'file' || entry.eventType === 'unlink') return;
-		return handleFile(entry.contents);
+		if (entry.entryType !== 'file') return;
+		const previousRoles = rolesByFile.get(entry.absolutePath) ?? new Set<string>();
+		if (entry.eventType === 'unlink') {
+			rolesByFile.delete(entry.absolutePath);
+			warnForStaleRoles(scope, previousRoles, rolesByFile);
+			return;
+		}
+		const currentRoles = await handleFile(entry.contents);
+		rolesByFile.set(entry.absolutePath, currentRoles);
+		warnForStaleRoles(
+			scope,
+			new Set([...previousRoles].filter((roleName) => !currentRoles.has(roleName))),
+			rolesByFile
+		);
 	});
+}
+
+function warnForStaleRoles(
+	scope: import('../components/Scope.ts').Scope,
+	removedRoles: Set<string>,
+	rolesByFile: Map<string, Set<string>>
+): void {
+	const stillDeclared = new Set<string>();
+	for (const roleNames of rolesByFile.values()) for (const roleName of roleNames) stillDeclared.add(roleName);
+	const staleRoles = [...removedRoles].filter((roleName) => !stillDeclared.has(roleName));
+	if (staleRoles.length === 0) return;
+	scope.logger.warn(
+		`Role definitions removed for ${staleRoles.join(', ')}; existing roles and grants remain active until explicitly altered or deleted`
+	);
 }
 
 /**
@@ -27,7 +54,9 @@ export function handleApplication(scope: import('../components/Scope.ts').Scope)
  */
 async function handleFile(rolesContent) {
 	let rolesToDefine = parseDocument(rolesContent.toString(), { simpleKeys: true } as any).toJSON();
+	const roleNames = new Set<string>();
 	for (let roleName in rolesToDefine) {
+		roleNames.add(roleName);
 		let role = rolesToDefine[roleName];
 		if (!role.permission) {
 			// we allow the permission object to be collapsed into the root object for convenience
@@ -80,6 +109,7 @@ async function handleFile(rolesContent) {
 		role.role = role.id = roleName;
 		await ensureRole(role);
 	}
+	return roleNames;
 }
 async function ensureRole(role) {
 	const roleTable = getDatabases().system.hdb_role;

--- a/resources/roles.ts
+++ b/resources/roles.ts
@@ -13,23 +13,42 @@ const USERS_NOT_DBS: readonly string[] = RESERVED_DATABASE_NAMES;
  * This is the component for handling role declarations in the Harper system. This will read roles.yaml for role
  * definitions and ensure that they are created in the system database.
  */
-export function handleApplication(scope: import('../components/Scope.ts').Scope) {
+export function handleApplication(
+	scope: import('../components/Scope.ts').Scope,
+	ensureRoleFn: (role: any) => Promise<unknown> = ensureRole
+) {
 	const rolesByFile = new Map<string, Set<string>>();
-	scope.handleEntry(async (entry) => {
-		if (entry.entryType !== 'file') return;
-		const previousRoles = rolesByFile.get(entry.absolutePath) ?? new Set<string>();
-		if (entry.eventType === 'unlink') {
-			rolesByFile.delete(entry.absolutePath);
-			warnForStaleRoles(scope, previousRoles, rolesByFile);
-			return;
-		}
-		const currentRoles = await handleFile(entry.contents);
-		rolesByFile.set(entry.absolutePath, currentRoles);
-		warnForStaleRoles(
-			scope,
-			new Set([...previousRoles].filter((roleName) => !currentRoles.has(roleName))),
-			rolesByFile
-		);
+	const contentsByFile = new Map<string, Buffer>();
+	let pending = Promise.resolve();
+	const entryHandler = scope.handleEntry((entry) => {
+		const operation = pending.then(async () => {
+			if (entry.entryType !== 'file') return;
+			const previousRoles = rolesByFile.get(entry.absolutePath) ?? new Set<string>();
+			if (entry.eventType === 'unlink') {
+				rolesByFile.delete(entry.absolutePath);
+				contentsByFile.delete(entry.absolutePath);
+				warnForStaleRoles(scope, previousRoles, rolesByFile);
+				return;
+			}
+			contentsByFile.set(entry.absolutePath, entry.contents);
+			const currentRoles = await handleFile(entry.contents, ensureRoleFn);
+			rolesByFile.set(entry.absolutePath, currentRoles);
+			warnForStaleRoles(
+				scope,
+				new Set([...previousRoles].filter((roleName) => !currentRoles.has(roleName))),
+				rolesByFile
+			);
+		});
+		pending = operation.catch(() => {});
+		return operation;
+	});
+	scope.on('deploy:end', () => {
+		void entryHandler.ready
+			.then(() => pending)
+			.then(async () => {
+				for (const contents of contentsByFile.values()) await handleFile(contents, ensureRoleFn);
+			})
+			.catch((error) => scope.logger.error?.('Could not reconcile roles after deploy:', error));
 	});
 }
 
@@ -52,7 +71,7 @@ function warnForStaleRoles(
  * the right shape and created in the system database.
  * @param rolesContent
  */
-async function handleFile(rolesContent) {
+async function handleFile(rolesContent, ensureRoleFn: (role: any) => Promise<unknown>) {
 	let rolesToDefine = parseDocument(rolesContent.toString(), { simpleKeys: true } as any).toJSON();
 	const roleNames = new Set<string>();
 	for (let roleName in rolesToDefine) {
@@ -107,7 +126,7 @@ async function handleFile(rolesContent) {
 			}
 		}
 		role.role = role.id = roleName;
-		await ensureRole(role);
+		await ensureRoleFn(role);
 	}
 	return roleNames;
 }

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -6,7 +6,7 @@ import { models as harperModelsSingleton } from '../resources/models/Models.ts';
 import { defineTable, types } from '../resources/defineTable.ts';
 import { defineResource, t, schemaOf, projectTableFragment } from '../resources/defineResource.ts';
 import { readFile } from 'node:fs/promises';
-import { dirname, isAbsolute } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { pathToFileURL, fileURLToPath } from 'node:url';
 import { SourceTextModule, SyntheticModule, createContext, runInContext, runInThisContext } from 'node:vm';
 import { ApplicationScope } from '../components/ApplicationScope.ts';
@@ -28,7 +28,6 @@ import {
 	statSync,
 	realpathSync,
 } from 'node:fs';
-import { join } from 'node:path';
 import { EventEmitter } from 'node:events';
 import { whenComponentsLoaded } from '../server/threads/threadServer.js';
 
@@ -342,9 +341,9 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 				return getHarperExports(scope);
 			}
 			if (resolvedUrl.startsWith('file://')) {
-				const source = readFileSync(new URL(resolvedUrl), { encoding: 'utf-8' });
-				scope.recordLoadedModule?.(resolvedUrl, source);
-				return loadCJS(resolvedUrl, source).exports;
+				const contents = readFileSync(new URL(resolvedUrl));
+				scope.recordLoadedModule?.(resolvedUrl, contents);
+				return loadCJS(resolvedUrl, contents.toString('utf-8')).exports;
 			}
 			return require(resolvedUrl);
 		};
@@ -463,6 +462,12 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 		if (specifier.startsWith('.')) {
 			return true;
 		}
+		// Package imports (`#name`) and package self-references can resolve back into the
+		// application without being relative specifiers. They are application source, not
+		// dependencies, so keep them in the observable loader as well.
+		if (isApplicationLocalModule(resolvedUrl)) {
+			return true;
+		}
 
 		// Check the dependencyLoader for definitive settings, if it is native we always use native loader
 		if (scope.dependencyLoader === 'native') {
@@ -479,6 +484,16 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 			return packageDependsOnHarper(resolvedUrl);
 		}
 		return false;
+	}
+
+	function isApplicationLocalModule(url: string): boolean {
+		if (!scope.runtimeRoot || !url.startsWith('file://') || url.includes('/node_modules/')) return false;
+		const modulePath = fileURLToPath(url);
+		const relativePath = relative(resolve(scope.runtimeRoot), modulePath);
+		return (
+			relativePath === '' ||
+			(!relativePath.startsWith(`..${sep}`) && relativePath !== '..' && !isAbsolute(relativePath))
+		);
 	}
 
 	/**
@@ -645,9 +660,9 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 
 		if (url.startsWith('file://') && usePrivateGlobal) {
 			checkAllowedModulePath(url, scope.allowedPath);
-			const source = readFileSync(new URL(url), { encoding: 'utf-8' });
-			scope.recordLoadedModule?.(url, source);
-			return createModuleFromSource(url, source, usePrivateGlobal);
+			const contents = readFileSync(new URL(url));
+			scope.recordLoadedModule?.(url, contents);
+			return createModuleFromSource(url, contents.toString('utf-8'), usePrivateGlobal);
 		}
 
 		// For Node.js built-in modules (node:) and npm packages without application loader for dependency
@@ -655,6 +670,7 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 		if (replacedModule) {
 			return createSyntheticModule(url, normalizeImportedModule(replacedModule));
 		}
+		if (isApplicationLocalModule(url)) scope.markNativeRuntime?.();
 		return import(url).then((importedModule) => createSyntheticModule(url, normalizeImportedModule(importedModule)));
 	}
 	// Load the entry module
@@ -703,8 +719,9 @@ async function getCompartment(scope: ApplicationScope, globals) {
 						},
 					};
 				} else if (moduleSpecifier.startsWith('file:') && !moduleSpecifier.includes('node_modules')) {
-					let moduleText = await readFile(new URL(moduleSpecifier), { encoding: 'utf-8' });
-					scope.recordLoadedModule?.(moduleSpecifier, moduleText);
+					const moduleContents = await readFile(new URL(moduleSpecifier));
+					scope.recordLoadedModule?.(moduleSpecifier, moduleContents);
+					let moduleText = moduleContents.toString('utf-8');
 					// Handle JSON files in compartment mode the same way as in VM mode
 					if (moduleSpecifier.endsWith('.json')) {
 						const jsonData = parseJsonModule(moduleText, moduleSpecifier);

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -351,6 +351,10 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 				return getHarperExports(scope);
 			}
 			if (resolvedUrl.startsWith('file://')) {
+				if (resolvedUrl.endsWith('.node')) {
+					scope.markNativeRuntime?.();
+					return require(fileURLToPath(resolvedUrl));
+				}
 				const contents = readFileSync(new URL(resolvedUrl));
 				scope.recordLoadedModule?.(resolvedUrl, contents);
 				return loadCJS(resolvedUrl, contents.toString('utf-8')).exports;
@@ -664,6 +668,11 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 
 		if (url.startsWith('file://') && usePrivateGlobal) {
 			checkAllowedModulePath(url, scope.allowedPath);
+			if (url.endsWith('.node')) {
+				scope.markNativeRuntime?.();
+				const nativeModule = createRequire(url)(fileURLToPath(url));
+				return createSyntheticModule(url, normalizeImportedModule(nativeModule));
+			}
 			const contents = readFileSync(new URL(url));
 			scope.recordLoadedModule?.(url, contents);
 			return createModuleFromSource(url, contents.toString('utf-8'), usePrivateGlobal);

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -178,7 +178,10 @@ function walkExportsConditions(entry: unknown, conditions: readonly string[]): s
  * ERR_PACKAGE_PATH_NOT_EXPORTED for pure-ESM packages (exports map with only "import"
  * conditions and no "require").
  */
-function resolveESMPackageExports(specifier: string, fromDir: string): string | null {
+function resolveESMPackageExports(
+	specifier: string,
+	fromDir: string
+): { resolvedUrl: string; packageJsonUrl: string; packageJsonSource: Buffer } | null {
 	const isScoped = specifier.startsWith('@');
 	const parts = specifier.split('/');
 	const packageName = isScoped ? `${parts[0]}/${parts[1]}` : parts[0];
@@ -189,8 +192,11 @@ function resolveESMPackageExports(specifier: string, fromDir: string): string | 
 	while (true) {
 		const pkgRoot = join(dir, 'node_modules', packageName);
 		let pkgJson: any;
+		let packageJsonSource: Buffer;
+		const packageJsonPath = join(pkgRoot, 'package.json');
 		try {
-			pkgJson = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf-8'));
+			packageJsonSource = readFileSync(packageJsonPath);
+			pkgJson = JSON.parse(packageJsonSource.toString());
 		} catch {
 			const parent = dirname(dir);
 			if (parent === dir) return null;
@@ -220,7 +226,11 @@ function resolveESMPackageExports(specifier: string, fromDir: string): string | 
 		const relative = walkExportsConditions(entry, ['import', 'node', 'default']);
 		if (!relative) return null;
 
-		return pathToFileURL(realpathSync(join(pkgRoot, relative))).toString();
+		return {
+			resolvedUrl: pathToFileURL(realpathSync(join(pkgRoot, relative))).toString(),
+			packageJsonUrl: pathToFileURL(realpathSync(packageJsonPath)).toString(),
+			packageJsonSource,
+		};
 	}
 }
 
@@ -301,7 +311,8 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 					: dirname(resolveReferrer);
 				const esmResolved = resolveESMPackageExports(specifier, referrerDir);
 				if (esmResolved) {
-					return esmResolved;
+					scope.recordLoadedModule?.(esmResolved.packageJsonUrl, esmResolved.packageJsonSource);
+					return esmResolved.resolvedUrl;
 				}
 			}
 			throw err;

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -220,7 +220,7 @@ function resolveESMPackageExports(specifier: string, fromDir: string): string | 
 		const relative = walkExportsConditions(entry, ['import', 'node', 'default']);
 		if (!relative) return null;
 
-		return pathToFileURL(join(pkgRoot, relative)).toString();
+		return pathToFileURL(realpathSync(join(pkgRoot, relative))).toString();
 	}
 }
 

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -105,6 +105,7 @@ async function importScoped(moduleUrl: string, scope?: ApplicationScope) {
 				return await loadModuleWithVM(moduleUrl, scope, true);
 			}
 		}
+		if (scope) scope.markNativeRuntime?.();
 		// important! we need to await the import, otherwise the error will not be caught
 		return await import(moduleUrl);
 	} catch (err) {
@@ -286,7 +287,9 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 		try {
 			const resolved = createRequire(resolveReferrer).resolve(specifier);
 			if (isAbsolute(resolved)) {
-				return pathToFileURL(resolved).toString();
+				const resolvedUrl = pathToFileURL(resolved).toString();
+				scope.recordModuleResolution?.(specifier, referrer, resolvedUrl);
+				return resolvedUrl;
 			}
 			return resolved;
 		} catch (err) {
@@ -298,7 +301,10 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 					? dirname(fileURLToPath(resolveReferrer))
 					: dirname(resolveReferrer);
 				const esmResolved = resolveESMPackageExports(specifier, referrerDir);
-				if (esmResolved) return esmResolved;
+				if (esmResolved) {
+					scope.recordModuleResolution?.(specifier, referrer, esmResolved);
+					return esmResolved;
+				}
 			}
 			throw err;
 		}
@@ -337,6 +343,7 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 			}
 			if (resolvedUrl.startsWith('file://')) {
 				const source = readFileSync(new URL(resolvedUrl), { encoding: 'utf-8' });
+				scope.recordLoadedModule?.(resolvedUrl, source);
 				return loadCJS(resolvedUrl, source).exports;
 			}
 			return require(resolvedUrl);
@@ -639,6 +646,7 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 		if (url.startsWith('file://') && usePrivateGlobal) {
 			checkAllowedModulePath(url, scope.allowedPath);
 			const source = readFileSync(new URL(url), { encoding: 'utf-8' });
+			scope.recordLoadedModule?.(url, source);
 			return createModuleFromSource(url, source, usePrivateGlobal);
 		}
 
@@ -679,6 +687,7 @@ async function getCompartment(scope: ApplicationScope, globals) {
 				const resolved = createRequire(moduleReferrer).resolve(moduleSpecifier);
 				if (isAbsolute(resolved)) {
 					const resolvedURL = pathToFileURL(resolved).toString();
+					scope.recordModuleResolution?.(moduleSpecifier, moduleReferrer, resolvedURL);
 					return resolvedURL;
 				}
 				return moduleSpecifier;
@@ -695,6 +704,7 @@ async function getCompartment(scope: ApplicationScope, globals) {
 					};
 				} else if (moduleSpecifier.startsWith('file:') && !moduleSpecifier.includes('node_modules')) {
 					let moduleText = await readFile(new URL(moduleSpecifier), { encoding: 'utf-8' });
+					scope.recordLoadedModule?.(moduleSpecifier, moduleText);
 					// Handle JSON files in compartment mode the same way as in VM mode
 					if (moduleSpecifier.endsWith('.json')) {
 						const jsonData = parseJsonModule(moduleText, moduleSpecifier);

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -301,7 +301,6 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 					: dirname(resolveReferrer);
 				const esmResolved = resolveESMPackageExports(specifier, referrerDir);
 				if (esmResolved) {
-					scope.recordModuleResolution?.(specifier, resolveReferrer, esmResolved);
 					return esmResolved;
 				}
 			}

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -234,6 +234,17 @@ function resolveESMPackageExports(
 	}
 }
 
+function normalizeImportedModule(importedModule: any): any {
+	const cjsModule = importedModule['module.exports'];
+	if (cjsModule) {
+		importedModule = importedModule.default ? { default: importedModule.default, ...cjsModule } : cjsModule;
+	}
+	if (!importedModule.default) {
+		importedModule = { default: importedModule, ...importedModule };
+	}
+	return importedModule;
+}
+
 /**
  * Load a module using Node's vm.Module API with optional sandboxing
  * @param moduleUrl - The URL of the module to load
@@ -352,8 +363,10 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 			}
 			if (resolvedUrl.startsWith('file://')) {
 				if (resolvedUrl.endsWith('.node')) {
+					checkAllowedModulePath(resolvedUrl, scope.allowedPath);
+					const nativeModule = require(fileURLToPath(resolvedUrl));
 					scope.markNativeRuntime?.();
-					return require(fileURLToPath(resolvedUrl));
+					return nativeModule;
 				}
 				const contents = readFileSync(new URL(resolvedUrl));
 				scope.recordLoadedModule?.(resolvedUrl, contents);
@@ -575,22 +588,6 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 	}
 
 	/**
-	 * Normalize imported module to ensure it has proper exports including default
-	 */
-	function normalizeImportedModule(importedModule: any): any {
-		const cjsModule = importedModule['module.exports'];
-		if (cjsModule) {
-			// back-compat import
-			importedModule = importedModule.default ? { default: importedModule.default, ...cjsModule } : cjsModule;
-		}
-		// Ensure there's a default export for ESM imports that expect it
-		if (!importedModule.default) {
-			importedModule = { default: importedModule, ...importedModule };
-		}
-		return importedModule;
-	}
-
-	/**
 	 * Create a SourceTextModule or SyntheticModule from source code
 	 */
 	function createModuleFromSource(
@@ -669,8 +666,8 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 		if (url.startsWith('file://') && usePrivateGlobal) {
 			checkAllowedModulePath(url, scope.allowedPath);
 			if (url.endsWith('.node')) {
-				scope.markNativeRuntime?.();
 				const nativeModule = createRequire(url)(fileURLToPath(url));
+				scope.markNativeRuntime?.();
 				return createSyntheticModule(url, normalizeImportedModule(nativeModule));
 			}
 			const contents = readFileSync(new URL(url));
@@ -729,6 +726,18 @@ async function getCompartment(scope: ApplicationScope, globals) {
 						exports: Object.keys(harperExports),
 						execute(exports) {
 							Object.assign(exports, harperExports);
+						},
+					};
+				} else if (moduleSpecifier.startsWith('file:') && moduleSpecifier.endsWith('.node')) {
+					checkAllowedModulePath(moduleSpecifier, scope.allowedPath);
+					const nativeModule = createRequire(moduleSpecifier)(fileURLToPath(moduleSpecifier));
+					scope.markNativeRuntime?.();
+					const moduleExports = normalizeImportedModule(nativeModule);
+					return {
+						imports: [],
+						exports: Object.keys(moduleExports),
+						execute(exports) {
+							Object.assign(exports, moduleExports);
 						},
 					};
 				} else if (moduleSpecifier.startsWith('file:') && !moduleSpecifier.includes('node_modules')) {

--- a/security/jsLoader.ts
+++ b/security/jsLoader.ts
@@ -287,7 +287,7 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 			const resolved = createRequire(resolveReferrer).resolve(specifier);
 			if (isAbsolute(resolved)) {
 				const resolvedUrl = pathToFileURL(resolved).toString();
-				scope.recordModuleResolution?.(specifier, referrer, resolvedUrl);
+				scope.recordModuleResolution?.(specifier, resolveReferrer, resolvedUrl);
 				return resolvedUrl;
 			}
 			return resolved;
@@ -301,7 +301,7 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 					: dirname(resolveReferrer);
 				const esmResolved = resolveESMPackageExports(specifier, referrerDir);
 				if (esmResolved) {
-					scope.recordModuleResolution?.(specifier, referrer, esmResolved);
+					scope.recordModuleResolution?.(specifier, resolveReferrer, esmResolved);
 					return esmResolved;
 				}
 			}
@@ -462,17 +462,11 @@ async function loadModuleWithVM(moduleUrl: string, scope: ApplicationScope, useC
 		if (specifier.startsWith('.')) {
 			return true;
 		}
-		// Package imports (`#name`) and package self-references can resolve back into the
-		// application without being relative specifiers. They are application source, not
-		// dependencies, so keep them in the observable loader as well.
-		if (isApplicationLocalModule(resolvedUrl)) {
-			return true;
-		}
-
 		// Check the dependencyLoader for definitive settings, if it is native we always use native loader
 		if (scope.dependencyLoader === 'native') {
 			return false;
 		}
+		if (isApplicationLocalModule(resolvedUrl)) return true;
 
 		// If it is set to always use the app module loader
 		if (scope.dependencyLoader === 'app') {

--- a/server/static.ts
+++ b/server/static.ts
@@ -245,7 +245,7 @@ export function handleApplication(scope: Scope) {
 
 	// Handle entry events for the default entry handler based on the `files` and `urlPath` options
 	scope.handleEntry((entry) => {
-		if (urlPathRestartPending) return;
+		if (urlPathRestartPending && entry.eventType !== 'unlink' && entry.eventType !== 'unlinkDir') return;
 		// entry.urlPath includes the component's base URL path, but when a `urlPath` is configured
 		// the routing chain strips that mount prefix from req.pathname before this plugin's handler
 		// runs — so key the maps relative to the base (#1583)

--- a/server/static.ts
+++ b/server/static.ts
@@ -189,6 +189,7 @@ export function handleApplication(scope: Scope) {
 	// keep agreeing with the entry URL paths the file map is keyed by — but a redirect Location has
 	// to carry the application's mount too, or it would point outside the mount (#1583).
 	const externalBaseURLPath = scope.externalBasePath(baseURLPath);
+	let urlPathRestartPending = false;
 
 	// A bare `before:` / `after:` key in YAML parses as null — treat it as unset, like before this
 	// option was validated.
@@ -226,7 +227,7 @@ export function handleApplication(scope: Scope) {
 			return;
 		}
 		if (key[0] === 'urlPath') {
-			// The route mount cannot be changed on a live server registration — restart to apply
+			urlPathRestartPending = true;
 			scope.requestRestart();
 			return;
 		}
@@ -244,6 +245,7 @@ export function handleApplication(scope: Scope) {
 
 	// Handle entry events for the default entry handler based on the `files` and `urlPath` options
 	scope.handleEntry((entry) => {
+		if (urlPathRestartPending) return;
 		// entry.urlPath includes the component's base URL path, but when a `urlPath` is configured
 		// the routing chain strips that mount prefix from req.pathname before this plugin's handler
 		// runs — so key the maps relative to the base (#1583)

--- a/server/static.ts
+++ b/server/static.ts
@@ -190,6 +190,8 @@ export function handleApplication(scope: Scope) {
 	// to carry the application's mount too, or it would point outside the mount (#1583).
 	const externalBaseURLPath = scope.externalBasePath(baseURLPath);
 	let urlPathRestartPending = false;
+	let fileSelectionChangePending = false;
+	let entryHandler: ReturnType<Scope['handleEntry']>;
 
 	// A bare `before:` / `after:` key in YAML parses as null — treat it as unset, like before this
 	// option was validated.
@@ -221,6 +223,12 @@ export function handleApplication(scope: Scope) {
 
 	scope.options.on('change', (key) => {
 		if (key[0] === 'files') {
+			fileSelectionChangePending = true;
+			const updateReady = entryHandler?.ready;
+			const clearPending = () => {
+				if (entryHandler?.ready === updateReady) fileSelectionChangePending = false;
+			};
+			updateReady?.then(clearPending, clearPending);
 			// EntryHandler updates are incremental: paths no longer matched emit unlink, newly matched
 			// paths emit add, and common unchanged paths remain valid in these maps.
 			scope.logger.info(`Static file matches updated due to change in ${key.join('.')}`);
@@ -244,8 +252,12 @@ export function handleApplication(scope: Scope) {
 	});
 
 	// Handle entry events for the default entry handler based on the `files` and `urlPath` options
-	scope.handleEntry((entry) => {
-		if (urlPathRestartPending && entry.eventType !== 'unlink' && entry.eventType !== 'unlinkDir') return;
+	entryHandler = scope.handleEntry((entry) => {
+		if (
+			urlPathRestartPending &&
+			(!fileSelectionChangePending || (entry.eventType !== 'unlink' && entry.eventType !== 'unlinkDir'))
+		)
+			return;
 		// entry.urlPath includes the component's base URL path, but when a `urlPath` is configured
 		// the routing chain strips that mount prefix from req.pathname before this plugin's handler
 		// runs — so key the maps relative to the base (#1583)

--- a/server/static.ts
+++ b/server/static.ts
@@ -1,5 +1,5 @@
 import { realpathSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { Scope } from '../components/Scope';
 import { resolveBaseURLPath } from '../components/resolveBaseURLPath.ts';
 import { convertToMS } from '../utility/common_utils.ts';
@@ -285,8 +285,12 @@ export function handleApplication(scope: Scope) {
 				// If the file is an index.html, remove it from the index entries as well
 				if (urlPath.endsWith('index.html')) {
 					let lastSlashIndex = urlPath.lastIndexOf('/');
-					removeOwnedPath(indexEntries, indexEntryOwners, urlPath.slice(0, lastSlashIndex), entry.absolutePath);
+					const directoryURLPath = urlPath.slice(0, lastSlashIndex);
+					const directoryOwner = dirname(entry.absolutePath);
+					removeOwnedPath(indexEntries, indexEntryOwners, directoryURLPath, entry.absolutePath);
+					removeOwnedPath(indexEntries, indexEntryOwners, directoryURLPath, directoryOwner);
 					removeOwnedPath(indexEntries, indexEntryOwners, urlPath.slice(0, lastSlashIndex + 1), entry.absolutePath);
+					removeOwnedPath(indexEntries, indexEntryOwners, urlPath.slice(0, lastSlashIndex + 1), directoryOwner);
 				}
 				break;
 		}

--- a/server/static.ts
+++ b/server/static.ts
@@ -52,7 +52,7 @@ import send from 'send';
  *
  * This plugin dynamically updates its behavior based on the current configuration file. Users can make updates and immediately see the changes reflect in the next request.
  *
- * Updates to the `files` option will clear the in-memory maps and allow them to regenerate based on the new configuration (since the default EntryHandler will regenerate anyways).
+ * Updates to the `files` option incrementally add newly matched paths and remove paths that no longer match while preserving common entries.
  * Updates to `urlPath` request a restart: the HTTP route mount is registered once at load and cannot be re-registered on a live server (#1583).
  */
 /**
@@ -187,10 +187,9 @@ export function handleApplication(scope: Scope) {
 
 	scope.options.on('change', (key) => {
 		if (key[0] === 'files') {
-			// If the files option changes, clear the maps and let the entry handler regenerate them
-			staticFiles.clear();
-			indexEntries.clear();
-			scope.logger.info(`Static files reinitialized due to change in ${key.join('.')}`);
+			// EntryHandler updates are incremental: paths no longer matched emit unlink, newly matched
+			// paths emit add, and common unchanged paths remain valid in these maps.
+			scope.logger.info(`Static file matches updated due to change in ${key.join('.')}`);
 			return;
 		}
 		if (key[0] === 'urlPath') {
@@ -222,12 +221,15 @@ export function handleApplication(scope: Scope) {
 		switch (entry.eventType) {
 			// Directories only matter for the `index` files
 			case 'addDir':
-			case 'unlinkDir':
 				// Handle `index.html` for directories for if/when the user enables the `index` option
 				const indexPath = join(entry.absolutePath, 'index.html');
-				if (existsSync(indexPath)) {
-					indexEntries[entry.eventType === 'addDir' ? 'set' : 'delete'](urlPath, indexPath);
-				}
+				if (existsSync(indexPath)) indexEntries.set(urlPath, indexPath);
+				break;
+			case 'unlinkDir':
+				// A config update can add a new absolute directory at this same URL before the old
+				// directory's synthesized unlink arrives. Remove only the identity being unlinked.
+				const removedIndexPath = join(entry.absolutePath, 'index.html');
+				if (indexEntries.get(urlPath) === removedIndexPath) indexEntries.delete(urlPath);
 				break;
 			// Otherwise, user must specify pattern to match individual files
 			case 'add':
@@ -243,7 +245,10 @@ export function handleApplication(scope: Scope) {
 				}
 				break;
 			case 'unlink':
-				// Remove the file from memory when it is deleted
+				// Additions are emitted while scanning, before removals synthesized at ready. When a files
+				// update re-roots two absolute files to the same URL, do not let the old unlink delete the
+				// replacement that was just added.
+				if (staticFiles.get(urlPath) !== entry.absolutePath) break;
 				staticFiles.delete(urlPath);
 				// If the file is an index.html, remove it from the index entries as well
 				if (urlPath.endsWith('index.html')) {

--- a/server/static.ts
+++ b/server/static.ts
@@ -146,7 +146,40 @@ export function handleApplication(scope: Scope) {
 	// in-memory map of static files
 	// keys are the URL paths relative to the mount base, values are the absolute paths to the files
 	const staticFiles = new Map<string, string>();
-	const indexEntries = new Map<string, string>();
+	const indexEntries = new Map<string, string | null>();
+	const staticFileOwners = new Map<string, Map<string, string>>();
+	const indexEntryOwners = new Map<string, Map<string, string | null>>();
+
+	function setOwnedPath<Path>(
+		paths: Map<string, Path>,
+		ownersByURL: Map<string, Map<string, Path>>,
+		urlPath: string,
+		owner: string,
+		path: Path
+	) {
+		let owners = ownersByURL.get(urlPath);
+		if (!owners) ownersByURL.set(urlPath, (owners = new Map()));
+		owners.delete(owner);
+		owners.set(owner, path);
+		paths.set(urlPath, path);
+	}
+
+	function removeOwnedPath<Path>(
+		paths: Map<string, Path>,
+		ownersByURL: Map<string, Map<string, Path>>,
+		urlPath: string,
+		owner: string
+	) {
+		const owners = ownersByURL.get(urlPath);
+		if (!owners?.delete(owner)) return;
+		const replacement = [...owners.values()].at(-1);
+		if (replacement === undefined) {
+			ownersByURL.delete(urlPath);
+			paths.delete(urlPath);
+		} else {
+			paths.set(urlPath, replacement);
+		}
+	}
 
 	// The HTTP route below is registered once, with the urlPath in effect at load time; the mount
 	// cannot be re-registered at runtime. Capture the matching base once so map keys always agree
@@ -223,38 +256,37 @@ export function handleApplication(scope: Scope) {
 			case 'addDir':
 				// Handle `index.html` for directories for if/when the user enables the `index` option
 				const indexPath = join(entry.absolutePath, 'index.html');
-				if (existsSync(indexPath)) indexEntries.set(urlPath, indexPath);
+				if (existsSync(indexPath)) setOwnedPath(indexEntries, indexEntryOwners, urlPath, entry.absolutePath, indexPath);
 				break;
 			case 'unlinkDir':
-				// A config update can add a new absolute directory at this same URL before the old
-				// directory's synthesized unlink arrives. Remove only the identity being unlinked.
-				const removedIndexPath = join(entry.absolutePath, 'index.html');
-				if (indexEntries.get(urlPath) === removedIndexPath) indexEntries.delete(urlPath);
+				removeOwnedPath(indexEntries, indexEntryOwners, urlPath, entry.absolutePath);
 				break;
 			// Otherwise, user must specify pattern to match individual files
 			case 'add':
 				// Store the file in memory for serving
-				staticFiles.set(urlPath, entry.absolutePath);
+				setOwnedPath(staticFiles, staticFileOwners, urlPath, entry.absolutePath, entry.absolutePath);
 				// If the file is an index.html, also store it in the index entries
 				if (urlPath.endsWith('index.html')) {
 					// Without trailing slash; null -> 301 redirect to trailing slash
 					let lastSlashIndex = urlPath.lastIndexOf('/');
-					indexEntries.set(urlPath.slice(0, lastSlashIndex), null);
+					setOwnedPath(indexEntries, indexEntryOwners, urlPath.slice(0, lastSlashIndex), entry.absolutePath, null);
 					// With trailing slash; serves the index.html file
-					indexEntries.set(urlPath.slice(0, lastSlashIndex + 1), entry.absolutePath);
+					setOwnedPath(
+						indexEntries,
+						indexEntryOwners,
+						urlPath.slice(0, lastSlashIndex + 1),
+						entry.absolutePath,
+						entry.absolutePath
+					);
 				}
 				break;
 			case 'unlink':
-				// Additions are emitted while scanning, before removals synthesized at ready. When a files
-				// update re-roots two absolute files to the same URL, do not let the old unlink delete the
-				// replacement that was just added.
-				if (staticFiles.get(urlPath) !== entry.absolutePath) break;
-				staticFiles.delete(urlPath);
+				removeOwnedPath(staticFiles, staticFileOwners, urlPath, entry.absolutePath);
 				// If the file is an index.html, remove it from the index entries as well
 				if (urlPath.endsWith('index.html')) {
 					let lastSlashIndex = urlPath.lastIndexOf('/');
-					indexEntries.delete(urlPath.slice(0, lastSlashIndex));
-					indexEntries.delete(urlPath.slice(0, lastSlashIndex + 1));
+					removeOwnedPath(indexEntries, indexEntryOwners, urlPath.slice(0, lastSlashIndex), entry.absolutePath);
+					removeOwnedPath(indexEntries, indexEntryOwners, urlPath.slice(0, lastSlashIndex + 1), entry.absolutePath);
 				}
 				break;
 		}

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -151,7 +151,6 @@ module.exports = {
 	restoreShutdownDeadline,
 	registerWorkerDataProvider,
 	onThreadExit,
-	awaitThreadProcessGroupsTerminated,
 	registerProcessGroup,
 	unregisterProcessGroup,
 	isThreadRunning,
@@ -1089,10 +1088,6 @@ async function isThreadRunning(ownerThreadId, timeoutMs = THREAD_INFO_REQUEST_TI
 	// in flight — wait for that to be confirmed before reporting the owner as reclaimable.
 	await awaitProcessGroupTermination(ownerThreadId);
 	return false;
-}
-
-function awaitThreadProcessGroupsTerminated(ownerThreadId) {
-	return awaitProcessGroupTermination(ownerThreadId);
 }
 
 if (isMainThread) {

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -151,6 +151,7 @@ module.exports = {
 	restoreShutdownDeadline,
 	registerWorkerDataProvider,
 	onThreadExit,
+	awaitThreadProcessGroupsTerminated,
 	registerProcessGroup,
 	unregisterProcessGroup,
 	isThreadRunning,
@@ -1088,6 +1089,10 @@ async function isThreadRunning(ownerThreadId, timeoutMs = THREAD_INFO_REQUEST_TI
 	// in flight — wait for that to be confirmed before reporting the owner as reclaimable.
 	await awaitProcessGroupTermination(ownerThreadId);
 	return false;
+}
+
+function awaitThreadProcessGroupsTerminated(ownerThreadId) {
+	return awaitProcessGroupTermination(ownerThreadId);
 }
 
 if (isMainThread) {

--- a/unitTests/components/ApplicationRuntimeMetadata.test.js
+++ b/unitTests/components/ApplicationRuntimeMetadata.test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const assert = require('node:assert');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const testUtils = require('../testUtils.js');
+testUtils.preTestPrep();
+
+const {
+	installedPackageMetadataEqual,
+	installedRuntimeChanged,
+	readInstalledPackageMetadata,
+} = require('#src/components/Application');
+
+describe('installed application runtime metadata', () => {
+	beforeEach(async function () {
+		this.previous = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-metadata-previous-'));
+		this.current = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-metadata-current-'));
+	});
+
+	afterEach(async function () {
+		await Promise.all([
+			fs.rm(this.previous, { recursive: true, force: true }),
+			fs.rm(this.current, { recursive: true, force: true }),
+		]);
+	});
+
+	it('normalizes package.json formatting and key order', async function () {
+		await fs.writeFile(
+			path.join(this.previous, 'package.json'),
+			'{"version":"1.0.0","dependencies":{"second":"2","first":"1"},"name":"app"}\n'
+		);
+		await fs.writeFile(
+			path.join(this.current, 'package.json'),
+			JSON.stringify(
+				{
+					name: 'app',
+					dependencies: { first: '1', second: '2' },
+					version: '1.0.0',
+				},
+				null,
+				2
+			)
+		);
+		await Promise.all([
+			fs.writeFile(path.join(this.previous, 'package-lock.json'), '{"lockfileVersion":3}\n'),
+			fs.writeFile(path.join(this.current, 'package-lock.json'), '{"lockfileVersion":3}\n'),
+		]);
+
+		const previous = await readInstalledPackageMetadata(this.previous);
+		const current = await readInstalledPackageMetadata(this.current);
+		assert.equal(installedPackageMetadataEqual(previous, current), true);
+		assert.equal(installedRuntimeChanged(previous, current, false), false);
+	});
+
+	it('compares generated lock evidence after installation', async function () {
+		await Promise.all([
+			fs.writeFile(path.join(this.previous, 'package.json'), '{"name":"app"}\n'),
+			fs.writeFile(path.join(this.current, 'package.json'), '{"name":"app"}\n'),
+			fs.writeFile(path.join(this.previous, 'package-lock.json'), '{"packages":{"node_modules/x":{"version":"1"}}}\n'),
+			fs.writeFile(path.join(this.current, 'package-lock.json'), '{"packages":{"node_modules/x":{"version":"2"}}}\n'),
+		]);
+
+		assert.equal(
+			installedRuntimeChanged(
+				await readInstalledPackageMetadata(this.previous),
+				await readInstalledPackageMetadata(this.current),
+				false
+			),
+			true
+		);
+	});
+
+	it('fails closed for dependency installs without lock evidence or with opaque scripts', async function () {
+		await Promise.all([
+			fs.writeFile(path.join(this.previous, 'package.json'), '{"name":"app","dependencies":{"x":"1"}}\n'),
+			fs.writeFile(path.join(this.current, 'package.json'), '{"name":"app","dependencies":{"x":"1"}}\n'),
+		]);
+		const previous = await readInstalledPackageMetadata(this.previous);
+		const current = await readInstalledPackageMetadata(this.current);
+
+		assert.equal(installedPackageMetadataEqual(previous, current), true);
+		assert.equal(
+			installedRuntimeChanged(previous, current, false),
+			true,
+			'an unlocked install is not reproducible evidence'
+		);
+		assert.equal(installedRuntimeChanged(previous, current, true), true, 'custom scripts make the install opaque');
+	});
+
+	it('canonicalizes __proto__ as data without mutating the accumulator prototype', async function () {
+		await fs.writeFile(
+			path.join(this.current, 'package.json'),
+			'{"name":"app","__proto__":{"polluted":true},"dependencies":"not-an-object"}\n'
+		);
+
+		const metadata = await readInstalledPackageMetadata(this.current);
+		const canonicalPackage = JSON.parse(metadata.files.get('package.json').toString());
+		assert.equal(Object.hasOwn(canonicalPackage, '__proto__'), true);
+		assert.deepEqual(canonicalPackage.__proto__, { polluted: true });
+		assert.equal(metadata.hasInstallableDependencies, false);
+	});
+});

--- a/unitTests/components/EntryHandler.test.js
+++ b/unitTests/components/EntryHandler.test.js
@@ -351,6 +351,30 @@ describe('EntryHandler', () => {
 		await entryHandler.close();
 	});
 
+	it('routes steady-state unlink and addDir listener throws through error', async () => {
+		const entryHandler = new EntryHandler(this.name, this.directory, '.');
+		await entryHandler.ready;
+
+		const errors = [];
+		entryHandler.on('error', (error) => errors.push(error));
+		entryHandler.on('unlink', (entry) => {
+			if (entry.absolutePath === join(this.directory, 'c')) throw new Error('unlink listener failed');
+		});
+		entryHandler.on('addDir', (entry) => {
+			if (entry.absolutePath === join(this.directory, 'new-directory')) throw new Error('addDir listener failed');
+		});
+
+		rmSync(join(this.directory, 'c'));
+		await waitFor(() => errors.length === 1);
+		await mkdir(join(this.directory, 'new-directory'));
+		await waitFor(() => errors.length === 2);
+		assert.deepEqual(
+			errors.map((error) => error.message),
+			['unlink listener failed', 'addDir listener failed']
+		);
+		await entryHandler.close();
+	});
+
 	it('ignores a pending read from the watcher generation invalidated by pause', async () => {
 		const entryHandler = new EntryHandler(this.name, this.directory, '.');
 		await entryHandler.ready;

--- a/unitTests/components/EntryHandler.test.js
+++ b/unitTests/components/EntryHandler.test.js
@@ -3,7 +3,7 @@ const { EventEmitter, once } = require('node:events');
 const assert = require('node:assert');
 const { join, basename } = require('node:path');
 const { tmpdir } = require('node:os');
-const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = require('node:fs');
+const { chmodSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } = require('node:fs');
 const { writeFile, mkdir } = require('node:fs/promises');
 const { spy } = require('sinon');
 const { waitFor } = require('../waitFor.js');
@@ -423,6 +423,61 @@ describe('EntryHandler', () => {
 			'the superseding update generation retains the deletion diff exactly once'
 		);
 		await entryHandler.close();
+	});
+
+	it('invalidates a pending outgoing read before applying new URL configuration', async () => {
+		const entryHandler = new EntryHandler(this.name, this.directory, { files: 'a', urlPath: '/old' });
+		await entryHandler.ready;
+
+		const entries = [];
+		entryHandler.on('all', (entry) => entries.push(entry));
+		let resolveRead;
+		const pendingRead = entryHandler._simulateFileReadForTests(
+			'change',
+			'a',
+			new Promise((resolve) => (resolveRead = resolve))
+		);
+		const update = entryHandler.update({ files: 'a', urlPath: '/new' });
+		resolveRead(Buffer.from('stale'));
+
+		await Promise.all([pendingRead, update]);
+		assert.deepEqual(
+			entries.map((entry) => [entry.eventType, entry.urlPath]),
+			[
+				['unlink', '/old/a'],
+				['add', '/new/a'],
+			]
+		);
+		await entryHandler.close();
+	});
+
+	it('preserves a known file when a redeploy scan cannot read it', async () => {
+		if (process.platform === 'win32') return;
+		const entryHandler = new EntryHandler(this.name, this.directory, 'a');
+		await entryHandler.ready;
+		const pollingReady = once(entryHandler, 'ready');
+		entryHandler._simulateWatcherErrorForTests(Object.assign(new Error('exhausted'), { code: 'ENOSPC' }));
+		await pollingReady;
+
+		const entries = [];
+		const errors = [];
+		entryHandler.on('all', (entry) => entries.push(entry));
+		entryHandler.on('error', (error) => errors.push(error));
+		const filePath = join(this.directory, 'a');
+		entryHandler.pause();
+		chmodSync(filePath, 0o000);
+		try {
+			await entryHandler.resume();
+			await waitFor(() => errors.length === 1);
+			assert.equal(errors[0].code, 'EACCES');
+			assert.equal(
+				entries.some((entry) => entry.eventType === 'unlink'),
+				false
+			);
+		} finally {
+			chmodSync(filePath, 0o600);
+			await entryHandler.close();
+		}
 	});
 
 	it('routes primitive listener throws through error without rejecting the file read', async () => {
@@ -886,6 +941,37 @@ describe('EntryHandler', () => {
 			assert.equal(errorSpy.callCount, 1, 'non-exhaustion error should propagate');
 
 			entryHandler.close();
+			rmSync(directory, { recursive: true, force: true });
+		});
+
+		it('does not treat an exhaustion-shaped consumer exception as a watcher failure', async () => {
+			const { directory } = createFixture(['a.txt']);
+			const entryHandler = new EntryHandler(basename(directory), directory, '**/*');
+			await entryHandler.ready;
+
+			const errors = [];
+			entryHandler.on('error', (error) => errors.push(error));
+			entryHandler.on('change', () => {
+				throw Object.assign(new Error('consumer failed'), { code: 'ENOSPC' });
+			});
+
+			await writeFile(join(directory, 'a.txt'), 'changed');
+			await waitFor(() => errors.length === 1);
+			assert.equal(entryHandler._usingPollingForTests, false);
+
+			await entryHandler.close();
+			rmSync(directory, { recursive: true, force: true });
+		});
+
+		it('rejects a paused readiness latch when the handler closes', async () => {
+			const { directory } = createFixture(['a.txt']);
+			const entryHandler = new EntryHandler(basename(directory), directory, '**/*');
+			await entryHandler.ready;
+			entryHandler.pause();
+			const pausedReady = entryHandler.ready;
+
+			await entryHandler.close();
+			await assert.rejects(pausedReady, /closed before becoming ready/);
 			rmSync(directory, { recursive: true, force: true });
 		});
 

--- a/unitTests/components/EntryHandler.test.js
+++ b/unitTests/components/EntryHandler.test.js
@@ -511,6 +511,46 @@ describe('EntryHandler', () => {
 		assert.equal(entryHandler.listenerCount('addDir'), 0, 'addDir event listener should be removed');
 	});
 
+	it('serializes concurrent config updates without orphaning a watcher', async () => {
+		// A single config save that changes both `files` and `urlPath` drives two OptionsWatcher
+		// `change` events in one tick, so two update() calls enter watcher replacement while a
+		// watcher is live (not paused). Each must close the watcher it actually replaced —
+		// otherwise the first call's fresh chokidar instance is overwritten, never closed, and
+		// its inotify handles leak until GC (the pressure mode of harper#488).
+		const entryHandler = new EntryHandler(this.name, this.directory, 'a');
+		await entryHandler.ready;
+		assert.equal(entryHandler._liveWatcherCountForTests, 1, 'one live watcher after the initial scan');
+
+		await Promise.all([entryHandler.update('b'), entryHandler.update('c')]);
+
+		assert.equal(entryHandler._openCountForTests, 3, 'the initial watcher plus one per update');
+		assert.equal(entryHandler._liveWatcherCountForTests, 1, 'each replacement closes the watcher it replaced');
+
+		await entryHandler.close();
+		assert.equal(entryHandler._liveWatcherCountForTests, 0, 'close() releases the last watcher');
+	});
+
+	it('update() readiness does not resolve against the outgoing generation', async () => {
+		// update() must re-arm the readiness latch the way pause() does. Otherwise awaiting it on
+		// an already-ready handler resolves immediately against the previous generation's `ready`,
+		// before the replacement generation has scanned, digested, and emitted its diff.
+		const entryHandler = new EntryHandler(this.name, this.directory, 'a');
+		await entryHandler.ready;
+
+		const events = [];
+		entryHandler.on('all', (entry) => events.push(entry.eventType));
+
+		await entryHandler.update('b');
+
+		assert.deepEqual(
+			[...events].sort(),
+			['add', 'unlink'],
+			'the new generation has emitted its full diff by the time update() resolves'
+		);
+
+		await entryHandler.close();
+	});
+
 	it('should resolve the correct urlPath for files', async () => {
 		const entryHandler = new EntryHandler(this.name, this.directory, 'foo/d');
 

--- a/unitTests/components/EntryHandler.test.js
+++ b/unitTests/components/EntryHandler.test.js
@@ -351,6 +351,25 @@ describe('EntryHandler', () => {
 		await entryHandler.close();
 	});
 
+	it('logs a consumer exception when no error listener is attached', async () => {
+		const errors = [];
+		const entryHandler = new EntryHandler(this.name, this.directory, '.', {
+			error: (...args) => errors.push(args),
+		});
+		await entryHandler.ready;
+		entryHandler.on('unlink', () => {
+			throw new Error('unhandled removal listener failed');
+		});
+
+		entryHandler.pause();
+		rmSync(join(this.directory, 'c'));
+		await entryHandler.resume();
+
+		assert.equal(errors.length, 1);
+		assert.equal(errors[0][1].message, 'unhandled removal listener failed');
+		await entryHandler.close();
+	});
+
 	it('routes steady-state unlink and addDir listener throws through error', async () => {
 		const entryHandler = new EntryHandler(this.name, this.directory, '.');
 		await entryHandler.ready;
@@ -591,16 +610,13 @@ describe('EntryHandler', () => {
 	});
 
 	it('serializes concurrent config updates without orphaning a watcher', async () => {
-		// A single config save that changes both `files` and `urlPath` drives two OptionsWatcher
-		// `change` events in one tick, so two update() calls enter watcher replacement while a
-		// watcher is live (not paused). Each must close the watcher it actually replaced —
-		// otherwise the first call's fresh chokidar instance is overwritten, never closed, and
-		// its inotify handles leak until GC (the pressure mode of harper#488).
 		const entryHandler = new EntryHandler(this.name, this.directory, 'a');
 		await entryHandler.ready;
 		assert.equal(entryHandler._liveWatcherCountForTests, 1, 'one live watcher after the initial scan');
 
-		await Promise.all([entryHandler.update('b'), entryHandler.update('c')]);
+		const updates = [entryHandler.update('b'), entryHandler.update('c')];
+		assert.equal(entryHandler.listenerCount('ready'), 1, 'concurrent updates share one readiness latch');
+		await Promise.all(updates);
 
 		assert.equal(entryHandler._openCountForTests, 3, 'the initial watcher plus one per update');
 		assert.equal(entryHandler._liveWatcherCountForTests, 1, 'each replacement closes the watcher it replaced');

--- a/unitTests/components/EntryHandler.test.js
+++ b/unitTests/components/EntryHandler.test.js
@@ -249,6 +249,199 @@ describe('EntryHandler', () => {
 		await entryHandler.close();
 	});
 
+	it('emits logical file and directory diffs after pause and resume', async () => {
+		const entryHandler = new EntryHandler(this.name, this.directory, '.');
+		await entryHandler.ready;
+
+		const entries = [];
+		let readyCount = 0;
+		entryHandler.on('all', (entry) => entries.push(entry));
+		entryHandler.on('ready', () => readyCount++);
+
+		entryHandler.pause();
+		await writeFile(join(this.directory, 'b'), 'changed');
+		rmSync(join(this.directory, 'c'));
+		await writeFile(join(this.directory, 'new-file'), 'new');
+		await mkdir(join(this.directory, 'new-directory'));
+		rmSync(join(this.directory, 'foo', 'bar'), { recursive: true });
+
+		await entryHandler.resume();
+
+		assert.equal(readyCount, 1, 'the resumed watcher emits ready once');
+		assert.equal(
+			entries.some((entry) => entry.absolutePath === join(this.directory, 'a')),
+			false,
+			'an unchanged file emits no redeploy event'
+		);
+		assert.deepEqual(
+			entries
+				.map((entry) => [entry.eventType, entry.absolutePath.slice(this.directory.length + 1)])
+				.sort((a, b) => a[1].localeCompare(b[1]) || a[0].localeCompare(b[0])),
+			[
+				['change', 'b'],
+				['unlink', 'c'],
+				['unlinkDir', 'foo/bar'],
+				['unlink', 'foo/bar/f'],
+				['unlink', 'foo/bar/g'],
+				['addDir', 'new-directory'],
+				['add', 'new-file'],
+			].sort((a, b) => a[1].localeCompare(b[1]) || a[0].localeCompare(b[0]))
+		);
+		assert.deepEqual(
+			entries.find((entry) => entry.absolutePath === join(this.directory, 'b')).contents,
+			Buffer.from('changed'),
+			'the synthesized change carries the post-deploy contents'
+		);
+		const removedSubtreeEvents = entries
+			.filter((entry) => entry.absolutePath.startsWith(join(this.directory, 'foo', 'bar')))
+			.map((entry) => entry.eventType);
+		assert.deepEqual(
+			removedSubtreeEvents,
+			['unlink', 'unlink', 'unlinkDir'],
+			'children are unlinked before their directory'
+		);
+
+		await entryHandler.close();
+	});
+
+	it('emits unlink then add when an entry changes type across pause and resume', async () => {
+		const entryHandler = new EntryHandler(this.name, this.directory, '.');
+		await entryHandler.ready;
+
+		const entries = [];
+		entryHandler.on('all', (entry) => {
+			if (entry.absolutePath === join(this.directory, 'a')) entries.push(entry);
+		});
+
+		entryHandler.pause();
+		rmSync(join(this.directory, 'a'));
+		await mkdir(join(this.directory, 'a'));
+		await entryHandler.resume();
+
+		assert.deepEqual(
+			entries.map((entry) => entry.eventType),
+			['unlink', 'addDir']
+		);
+		await entryHandler.close();
+	});
+
+	it('commits the resumed generation even when a removal listener throws synchronously', async () => {
+		const entryHandler = new EntryHandler(this.name, this.directory, '.');
+		await entryHandler.ready;
+
+		let emittedError;
+		let unlinkCount = 0;
+		entryHandler.on('error', (error) => (emittedError = error));
+		entryHandler.on('unlink', (entry) => {
+			if (entry.absolutePath === join(this.directory, 'c')) {
+				unlinkCount++;
+				throw new Error('removal listener failed');
+			}
+		});
+
+		entryHandler.pause();
+		rmSync(join(this.directory, 'c'));
+		await entryHandler.resume();
+		assert.equal(emittedError?.message, 'removal listener failed');
+		assert.equal(unlinkCount, 1);
+
+		entryHandler.pause();
+		await entryHandler.resume();
+		assert.equal(unlinkCount, 1, 'the committed snapshot does not replay the same removal');
+		await entryHandler.close();
+	});
+
+	it('ignores a pending read from the watcher generation invalidated by pause', async () => {
+		const entryHandler = new EntryHandler(this.name, this.directory, '.');
+		await entryHandler.ready;
+
+		const entries = [];
+		entryHandler.on('all', (entry) => entries.push(entry));
+		let resolveRead;
+		const pendingRead = entryHandler._simulateFileReadForTests(
+			'add',
+			'stale-file',
+			new Promise((resolve) => (resolveRead = resolve))
+		);
+
+		entryHandler.pause();
+		resolveRead(Buffer.from('pre-deploy'));
+		await pendingRead;
+		await entryHandler.resume();
+
+		assert.equal(entries.length, 0, 'stale reads neither emit nor pollute the resumed generation diff');
+		await entryHandler.close();
+	});
+
+	it('carries entries emitted by an interrupted first scan into the resumed diff', async () => {
+		const entryHandler = new EntryHandler(this.name, this.directory, '.');
+		const resourcePath = join(this.directory, 'resource.js');
+		const resourceEvents = [];
+		entryHandler.on('all', (entry) => {
+			if (entry.absolutePath === resourcePath) resourceEvents.push(entry);
+		});
+
+		let resolveHold;
+		const holdRead = entryHandler._simulateFileReadForTests(
+			'add',
+			'hold-open',
+			new Promise((resolve) => (resolveHold = resolve))
+		);
+		await entryHandler._simulateFileReadForTests('add', 'resource.js', Promise.resolve(Buffer.from('old')));
+		assert.deepEqual(
+			resourceEvents.map((entry) => entry.eventType),
+			['add']
+		);
+
+		entryHandler.pause();
+		await writeFile(resourcePath, 'new');
+		resolveHold(Buffer.from('ignored'));
+		await holdRead;
+		await entryHandler.resume();
+
+		assert.deepEqual(
+			resourceEvents.map((entry) => entry.eventType),
+			['add', 'change'],
+			'an entry already exposed to consumers is changed, not replayed as a fresh add'
+		);
+		await entryHandler.close();
+	});
+
+	it('preserves the pre-deploy snapshot when update races the resumed scan', async () => {
+		const entryHandler = new EntryHandler(this.name, this.directory, '.');
+		await entryHandler.ready;
+
+		const entries = [];
+		entryHandler.on('all', (entry) => entries.push(entry));
+		entryHandler.pause();
+		rmSync(join(this.directory, 'c'));
+
+		await Promise.all([entryHandler.resume(), entryHandler.update('.')]);
+		assert.deepEqual(
+			entries.filter((entry) => entry.absolutePath === join(this.directory, 'c')).map((entry) => entry.eventType),
+			['unlink'],
+			'the superseding update generation retains the deletion diff exactly once'
+		);
+		await entryHandler.close();
+	});
+
+	it('routes primitive listener throws through error without rejecting the file read', async () => {
+		const entryHandler = new EntryHandler(this.name, this.directory, '.');
+		await entryHandler.ready;
+
+		let emittedError;
+		const listenerFailure = 'listener failed';
+		entryHandler.on('error', (error) => (emittedError = error));
+		entryHandler.on('change', () => {
+			throw listenerFailure;
+		});
+
+		await writeFile(join(this.directory, 'a'), 'changed');
+		await waitFor(() => emittedError !== undefined);
+		assert.equal(emittedError, listenerFailure);
+		await entryHandler.close();
+	});
+
 	it('should handle updating the config', async () => {
 		const entryHandler = new EntryHandler(this.name, this.directory, 'a');
 
@@ -266,6 +459,8 @@ describe('EntryHandler', () => {
 
 		const addDirHandlerSpy = spy();
 		entryHandler.on('addDir', addDirHandlerSpy);
+		const unlinkHandlerSpy = spy();
+		entryHandler.on('unlink', unlinkHandlerSpy);
 
 		await waitFor(() => allHandlerSpy.callCount === 1);
 
@@ -286,13 +481,16 @@ describe('EntryHandler', () => {
 		allHandlerSpy.resetHistory();
 		addHandlerSpy.resetHistory();
 		addDirHandlerSpy.resetHistory();
+		unlinkHandlerSpy.resetHistory();
 
 		await entryHandler.update('b');
 
-		await waitFor(() => allHandlerSpy.callCount === 1);
+		await waitFor(() => allHandlerSpy.callCount === 2);
 
 		assert.equal(readyEventSpy.callCount, 1, 'ready event should be triggered again once');
-		assert.equal(allHandlerSpy.callCount, 1, 'all event should be triggered for each new entry');
+		assert.equal(allHandlerSpy.callCount, 2, 'the old match is removed before the new match is added');
+		assert.equal(unlinkHandlerSpy.callCount, 1, 'the old config match emits unlink');
+		assert.equal(unlinkHandlerSpy.getCall(0).args[0].absolutePath, aPath);
 		assert.equal(addHandlerSpy.callCount, 1, 'add event should be triggered for the updated singular file');
 		const addArgB = addHandlerSpy.getCall(0).args[0];
 		const bPath = join(this.directory, 'b');
@@ -486,7 +684,7 @@ describe('EntryHandler', () => {
 	});
 
 	describe('pause / resume', () => {
-		it('stops emitting while paused and re-emits add events on resume', async () => {
+		it('stops emitting while paused and emits only logical additions on resume', async () => {
 			const { directory } = createFixture(['a', 'b', 'c']);
 			const entryHandler = new EntryHandler(basename(directory), directory, '**/*');
 			const addSpy = spy();
@@ -503,13 +701,10 @@ describe('EntryHandler', () => {
 			await new Promise((r) => setTimeout(r, 100));
 			assert.equal(addSpy.callCount, initialAdds, 'no events while paused');
 
-			// Resume — fresh scan should emit add for every current file (now 4)
+			// Resume — the fresh scan should report only the file created while paused.
 			await entryHandler.resume();
-			await new Promise((r) => setTimeout(r, 200));
-			assert.ok(
-				addSpy.callCount >= initialAdds + 4,
-				`resume should re-emit add for current files, got ${addSpy.callCount} total`
-			);
+			assert.equal(addSpy.callCount, initialAdds + 1, 'resume should emit one add for the new file');
+			assert.equal(addSpy.lastCall.args[0].absolutePath, join(directory, 'd'));
 
 			await entryHandler.close();
 			rmSync(directory, { recursive: true, force: true });
@@ -526,10 +721,11 @@ describe('EntryHandler', () => {
 			assert.ok(before >= 1);
 
 			entryHandler.pause();
+			await writeFile(join(directory, 'a'), 'changed');
 			await entryHandler.resume();
-			await new Promise((r) => setTimeout(r, 200));
 
-			assert.ok(allSpy.callCount > before, 'all listener still attached after resume');
+			assert.equal(allSpy.callCount, before + 1, 'all listener still attached after resume');
+			assert.equal(allSpy.lastCall.args[0].eventType, 'change');
 
 			await entryHandler.close();
 			rmSync(directory, { recursive: true, force: true });
@@ -610,13 +806,18 @@ describe('EntryHandler', () => {
 			entryHandler.on('error', errorSpy);
 
 			assert.equal(entryHandler._usingPollingForTests, false);
+			const recoveryEntries = [];
+			entryHandler.on('all', (entry) => recoveryEntries.push(entry));
+			const recoveryReady = once(entryHandler, 'ready');
 
 			entryHandler._simulateWatcherErrorForTests(Object.assign(new Error('boom'), { code: 'ENOSPC' }));
 
 			// Allow the close+reopen-with-polling to settle.
 			await waitFor(() => entryHandler._usingPollingForTests === true, 2000);
+			await recoveryReady;
 			assert.equal(entryHandler._usingPollingForTests, true);
 			assert.equal(errorSpy.callCount, 0, 'ENOSPC should be swallowed');
+			assert.deepEqual(recoveryEntries, [], 'unchanged entries are not replayed as adds during recovery');
 
 			// The polling watcher should pick up subsequent file writes; default
 			// directory polling interval is 3s, so allow up to 5s.

--- a/unitTests/components/RuntimeModuleTracker.test.js
+++ b/unitTests/components/RuntimeModuleTracker.test.js
@@ -5,7 +5,7 @@ const { mkdtempSync, rmSync, writeFileSync } = require('node:fs');
 const { join } = require('node:path');
 const { tmpdir } = require('node:os');
 const { pathToFileURL } = require('node:url');
-const { createRequire } = require('node:module');
+const { createRequire, Module } = require('node:module');
 const { RuntimeModuleTracker } = require('#src/components/RuntimeModuleTracker');
 
 describe('RuntimeModuleTracker', () => {
@@ -57,6 +57,24 @@ describe('RuntimeModuleTracker', () => {
 		this.tracker.beginDeploy();
 		writeFileSync(join(this.directory, 'helper.js'), 'export default {};');
 		assert.equal(await this.tracker.finishDeploy(), true);
+	});
+
+	it('fails closed when Node resolution cache invalidation is unavailable', async () => {
+		const referrerPath = join(this.directory, 'resources.js');
+		const helperPath = join(this.directory, 'helper.js');
+		writeFileSync(referrerPath, 'import helper from "./helper";');
+		writeFileSync(helperPath, 'export default {};');
+		this.tracker.recordModule(pathToFileURL(helperPath).href, 'export default {};');
+		this.tracker.recordResolution('./helper', pathToFileURL(referrerPath).href, pathToFileURL(helperPath).href);
+
+		const pathCache = Module._pathCache;
+		try {
+			Module._pathCache = undefined;
+			this.tracker.beginDeploy();
+			assert.equal(await this.tracker.finishDeploy(), true);
+		} finally {
+			Module._pathCache = pathCache;
+		}
 	});
 
 	it('conservatively invalidates native and mixed-generation runtimes', async () => {

--- a/unitTests/components/RuntimeModuleTracker.test.js
+++ b/unitTests/components/RuntimeModuleTracker.test.js
@@ -33,6 +33,16 @@ describe('RuntimeModuleTracker', () => {
 		assert.equal(await this.tracker.finishDeploy(), true);
 	});
 
+	it('compares the same raw bytes that the loader recorded', async () => {
+		const modulePath = join(this.directory, 'invalid-utf8.js');
+		const source = Buffer.from([0x2f, 0x2f, 0x20, 0xff, 0x0a]);
+		writeFileSync(modulePath, source);
+		this.tracker.recordModule(pathToFileURL(modulePath).href, source);
+
+		this.tracker.beginDeploy();
+		assert.equal(await this.tracker.finishDeploy(), false);
+	});
+
 	it('detects a new higher-priority extensionless resolution candidate', async () => {
 		const referrerPath = join(this.directory, 'resources.js');
 		const jsonPath = join(this.directory, 'helper.json');

--- a/unitTests/components/RuntimeModuleTracker.test.js
+++ b/unitTests/components/RuntimeModuleTracker.test.js
@@ -5,6 +5,7 @@ const { mkdtempSync, rmSync, writeFileSync } = require('node:fs');
 const { join } = require('node:path');
 const { tmpdir } = require('node:os');
 const { pathToFileURL } = require('node:url');
+const { createRequire } = require('node:module');
 const { RuntimeModuleTracker } = require('#src/components/RuntimeModuleTracker');
 
 describe('RuntimeModuleTracker', () => {
@@ -48,8 +49,10 @@ describe('RuntimeModuleTracker', () => {
 		const jsonPath = join(this.directory, 'helper.json');
 		writeFileSync(referrerPath, 'import helper from "./helper";');
 		writeFileSync(jsonPath, '{}');
+		const initiallyResolved = createRequire(pathToFileURL(referrerPath)).resolve('./helper');
+		assert.equal(initiallyResolved, jsonPath);
 		this.tracker.recordModule(pathToFileURL(jsonPath).href, '{}');
-		this.tracker.recordResolution('./helper', pathToFileURL(referrerPath).href, pathToFileURL(jsonPath).href);
+		this.tracker.recordResolution('./helper', pathToFileURL(referrerPath).href, pathToFileURL(initiallyResolved).href);
 
 		this.tracker.beginDeploy();
 		writeFileSync(join(this.directory, 'helper.js'), 'export default {};');

--- a/unitTests/components/RuntimeModuleTracker.test.js
+++ b/unitTests/components/RuntimeModuleTracker.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const assert = require('node:assert');
+const { mkdtempSync, rmSync, writeFileSync } = require('node:fs');
+const { join } = require('node:path');
+const { tmpdir } = require('node:os');
+const { pathToFileURL } = require('node:url');
+const { RuntimeModuleTracker } = require('#src/components/RuntimeModuleTracker');
+
+describe('RuntimeModuleTracker', () => {
+	beforeEach(() => {
+		this.directory = mkdtempSync(join(tmpdir(), 'harper-runtime-modules-'));
+		this.tracker = new RuntimeModuleTracker(() => this.directory);
+	});
+
+	afterEach(() => rmSync(this.directory, { recursive: true, force: true }));
+
+	it('detects changed and missing loaded modules but ignores unused files', async () => {
+		const modulePath = join(this.directory, 'resources.js');
+		writeFileSync(modulePath, 'export const value = 1;');
+		this.tracker.recordModule(pathToFileURL(modulePath).href, 'export const value = 1;');
+
+		this.tracker.beginDeploy();
+		writeFileSync(join(this.directory, 'unused.js'), 'unused');
+		assert.equal(await this.tracker.finishDeploy(), false);
+
+		this.tracker.beginDeploy();
+		writeFileSync(modulePath, 'export const value = 2;');
+		assert.equal(await this.tracker.finishDeploy(), true);
+
+		this.tracker.beginDeploy();
+		rmSync(modulePath);
+		assert.equal(await this.tracker.finishDeploy(), true);
+	});
+
+	it('detects a new higher-priority extensionless resolution candidate', async () => {
+		const referrerPath = join(this.directory, 'resources.js');
+		const jsonPath = join(this.directory, 'helper.json');
+		writeFileSync(referrerPath, 'import helper from "./helper";');
+		writeFileSync(jsonPath, '{}');
+		this.tracker.recordModule(pathToFileURL(jsonPath).href, '{}');
+		this.tracker.recordResolution('./helper', pathToFileURL(referrerPath).href, pathToFileURL(jsonPath).href);
+
+		this.tracker.beginDeploy();
+		writeFileSync(join(this.directory, 'helper.js'), 'export default {};');
+		assert.equal(await this.tracker.finishDeploy(), true);
+	});
+
+	it('conservatively invalidates native and mixed-generation runtimes', async () => {
+		this.tracker.markNativeRuntime();
+		this.tracker.beginDeploy();
+		assert.equal(await this.tracker.finishDeploy(), true);
+
+		const observedTracker = new RuntimeModuleTracker(() => this.directory);
+		const modulePath = join(this.directory, 'lazy.js');
+		writeFileSync(modulePath, 'export default 1;');
+		observedTracker.beginDeploy();
+		observedTracker.recordModule(pathToFileURL(modulePath).href, 'export default 1;');
+		assert.equal(await observedTracker.finishDeploy(), true);
+	});
+
+	it('ignores modules outside the deployed application root', async () => {
+		const outsideDirectory = mkdtempSync(join(tmpdir(), 'harper-runtime-outside-'));
+		try {
+			const modulePath = join(outsideDirectory, 'shared.js');
+			writeFileSync(modulePath, 'old');
+			this.tracker.recordModule(pathToFileURL(modulePath).href, 'old');
+			this.tracker.beginDeploy();
+			writeFileSync(modulePath, 'new');
+			assert.equal(await this.tracker.finishDeploy(), false);
+		} finally {
+			rmSync(outsideDirectory, { recursive: true, force: true });
+		}
+	});
+});

--- a/unitTests/components/Scope.test.js
+++ b/unitTests/components/Scope.test.js
@@ -518,6 +518,38 @@ describe('Scope', () => {
 			}
 		});
 
+		it('resumes a mid-deploy scope when the deploy owner exits', async () => {
+			const ownerThreadId = 41;
+			deployLifecycle._handle({
+				name: this.appName,
+				phase: 'start',
+				deploymentId: 'orphaned-deploy',
+				ownerThreadId,
+			});
+			const scope = new Scope(
+				this.appName,
+				this.pluginName,
+				this.directory,
+				this.configFilePath,
+				new ApplicationScope(this.appName, this.resources, this.server)
+			);
+			try {
+				const entries = [];
+				const entryHandler = scope.handleEntry({ files: 'test.js' }, (entry) => entries.push(entry));
+				const deployWait = scope.waitForDeployCompletion();
+				await waitFor(() => entryHandler._liveWatcherCountForTests === 0);
+
+				deployLifecycle._reclaimOwner(ownerThreadId);
+				await deployWait;
+				await entryHandler.ready;
+
+				assert.equal(deployLifecycle.isDeployInFlight(this.appName), false);
+				assert.ok(entries.length > 0, 'reclaiming the dead owner resumes the paused handler');
+			} finally {
+				await scope.close();
+			}
+		});
+
 		it('pauses entry handlers and emits the changed-file diff on deploy:end without losing plugin listeners', async () => {
 			writeFileSync(this.configFilePath, stringify({ [this.pluginName]: { files: 'test.js' } }));
 

--- a/unitTests/components/Scope.test.js
+++ b/unitTests/components/Scope.test.js
@@ -261,6 +261,22 @@ describe('Scope', () => {
 		await scope.close();
 	});
 
+	it('logs a forwarded child error when no scope error listener remains', async () => {
+		writeFileSync(this.configFilePath, stringify({ [this.pluginName]: { foo: 'bar' } }));
+		const scope = new Scope(
+			this.appName,
+			this.pluginName,
+			this.directory,
+			this.configFilePath,
+			this.resources,
+			this.server
+		);
+		await scope.ready;
+
+		assert.doesNotThrow(() => scope.options.emit('error', new Error('child listener failed')));
+		await scope.close();
+	});
+
 	it('should support custom entry handlers', async () => {
 		writeFileSync(this.configFilePath, stringify({ [this.pluginName]: { foo: 'bar' } }));
 

--- a/unitTests/components/Scope.test.js
+++ b/unitTests/components/Scope.test.js
@@ -498,10 +498,16 @@ describe('Scope', () => {
 			try {
 				const entries = [];
 				const entryHandler = scope.handleEntry({ files: 'test.js' }, (entry) => entries.push(entry));
+				let deployWaitResolved = false;
+				const deployWait = scope.waitForDeployCompletion().then(() => {
+					deployWaitResolved = true;
+				});
 				await waitFor(() => entryHandler._liveWatcherCountForTests === 0);
 				assert.equal(entries.length, 0, 'a handler created mid-deploy must not scan the intermediate tree');
+				assert.equal(deployWaitResolved, false, 'component loading remains gated by the active deploy');
 
 				deployLifecycle._handle({ name: this.appName, phase: 'end' });
+				await deployWait;
 				await entryHandler.ready;
 				assert.ok(entries.length > 0, 'the handler scans after deploy:end resumes it');
 			} finally {

--- a/unitTests/components/Scope.test.js
+++ b/unitTests/components/Scope.test.js
@@ -425,10 +425,9 @@ describe('Scope', () => {
 			scope.requestRestart();
 			assert.equal(restartNeeded(), false, 'requestRestart was suppressed during deploy');
 
-			// Exit the deploy — restarts should be enabled again
+			// Exit the deploy — the suppressed request is replayed once, after the gate is lowered.
 			deployLifecycle._handle({ name: this.appName, phase: 'end' });
-			scope.requestRestart();
-			assert.equal(restartNeeded(), true, 'requestRestart works again after deploy:end');
+			assert.equal(restartNeeded(), true, 'a lasting restart request is replayed after deploy:end');
 
 			await scope.close();
 		});
@@ -457,7 +456,7 @@ describe('Scope', () => {
 			await scope.close();
 		});
 
-		it('pauses entry handlers on deploy:start and resumes them on deploy:end without losing plugin listeners', async () => {
+		it('pauses entry handlers and emits the changed-file diff on deploy:end without losing plugin listeners', async () => {
 			writeFileSync(this.configFilePath, stringify({ [this.pluginName]: { files: 'test.js' } }));
 
 			const scope = new Scope(
@@ -472,21 +471,23 @@ describe('Scope', () => {
 			// Register a plugin-style entry handler with a callback. Codex caught
 			// the original close+recreate design dropping these callbacks; this
 			// case guards against that regression.
-			const handlerSpy = spy();
-			const entryHandler = scope.handleEntry(handlerSpy);
+			const entries = [];
+			const entryHandler = scope.handleEntry((entry) => entries.push(entry));
 			await entryHandler.ready;
-			const callsBeforeDeploy = handlerSpy.callCount;
+			const callsBeforeDeploy = entries.length;
 			assert.ok(callsBeforeDeploy > 0, 'plugin handler fires for initial files');
 
 			// Enter and exit a deploy without touching the EntryHandler instance.
 			deployLifecycle._handle({ name: this.appName, phase: 'start' });
 			// Settle the pause's pending watcher.close() promise before resuming.
 			await new Promise((r) => setTimeout(r, 50));
+			await writeFile(this.testFilePath, '"deployed";');
 			deployLifecycle._handle({ name: this.appName, phase: 'end' });
 
-			// The same EntryHandler instance keeps the plugin's callback; the
-			// post-deploy re-scan should fire it again for the same file(s).
-			await waitFor(() => handlerSpy.callCount > callsBeforeDeploy, 3000);
+			// The same EntryHandler instance keeps the plugin's callback and translates the resumed
+			// watcher's fresh add into the logical change relative to the pre-deploy generation.
+			await waitFor(() => entries.length > callsBeforeDeploy, 3000);
+			assert.equal(entries.at(-1).eventType, 'change');
 
 			// And the EntryHandler instance is unchanged — listener attachment is
 			// preserved, not re-issued through a fresh wrapper.
@@ -494,10 +495,10 @@ describe('Scope', () => {
 
 			// Subsequent post-deploy file changes still fire the plugin handler
 			// (the wired listener is still attached).
-			const callsAfterResume = handlerSpy.callCount;
+			const callsAfterResume = entries.length;
 			await writeFile(this.testFilePath, '"after-deploy";');
-			await waitFor(() => handlerSpy.callCount > callsAfterResume);
-			assert.ok(handlerSpy.callCount > callsAfterResume, 'post-deploy change fires the plugin handler');
+			await waitFor(() => entries.length > callsAfterResume);
+			assert.ok(entries.length > callsAfterResume, 'post-deploy change fires the plugin handler');
 
 			await scope.close();
 		});

--- a/unitTests/components/Scope.test.js
+++ b/unitTests/components/Scope.test.js
@@ -486,6 +486,32 @@ describe('Scope', () => {
 			await scope.close();
 		});
 
+		it('keeps entry handlers created during deploy paused until deploy:end', async () => {
+			deployLifecycle._handle({ name: this.appName, phase: 'start' });
+			const scope = new Scope(
+				this.appName,
+				this.pluginName,
+				this.directory,
+				this.configFilePath,
+				new ApplicationScope(this.appName, this.resources, this.server)
+			);
+			try {
+				const entries = [];
+				const entryHandler = scope.handleEntry({ files: 'test.js' }, (entry) => entries.push(entry));
+				await waitFor(() => entryHandler._liveWatcherCountForTests === 0);
+				assert.equal(entries.length, 0, 'a handler created mid-deploy must not scan the intermediate tree');
+
+				deployLifecycle._handle({ name: this.appName, phase: 'end' });
+				await entryHandler.ready;
+				assert.ok(entries.length > 0, 'the handler scans after deploy:end resumes it');
+			} finally {
+				if (deployLifecycle.isDeployInFlight(this.appName)) {
+					deployLifecycle._handle({ name: this.appName, phase: 'end' });
+				}
+				await scope.close();
+			}
+		});
+
 		it('pauses entry handlers and emits the changed-file diff on deploy:end without losing plugin listeners', async () => {
 			writeFileSync(this.configFilePath, stringify({ [this.pluginName]: { files: 'test.js' } }));
 

--- a/unitTests/components/Scope.test.js
+++ b/unitTests/components/Scope.test.js
@@ -4,6 +4,7 @@ const { EventEmitter } = require('node:events');
 const assert = require('node:assert');
 const { join, basename } = require('node:path');
 const { tmpdir } = require('node:os');
+const { pathToFileURL } = require('node:url');
 const { mkdtempSync, writeFileSync, rmSync } = require('node:fs');
 const { stringify } = require('yaml');
 const { spy } = require('sinon');
@@ -275,6 +276,19 @@ describe('Scope', () => {
 
 		assert.doesNotThrow(() => scope.options.emit('error', new Error('child listener failed')));
 		await scope.close();
+	});
+
+	it('invalidates a runtime first loaded by a scope created during deploy', async () => {
+		deployLifecycle._handle({ name: this.appName, phase: 'start' });
+		try {
+			const applicationScope = new ApplicationScope(this.appName, this.resources, this.server);
+			applicationScope.runtimeRoot = this.directory;
+			applicationScope.recordLoadedModule(pathToFileURL(this.testFilePath).href, Buffer.from('"foo";'));
+
+			assert.equal(await applicationScope.finishDeploy(), true);
+		} finally {
+			deployLifecycle._handle({ name: this.appName, phase: 'end' });
+		}
 	});
 
 	it('should support custom entry handlers', async () => {

--- a/unitTests/components/deployLifecycle.test.js
+++ b/unitTests/components/deployLifecycle.test.js
@@ -77,8 +77,8 @@ describe('deployLifecycle', () => {
 		});
 
 		it('ends a deploy when its owner thread exits', () => {
-			const endSpy = require('sinon').spy();
-			deployLifecycle.on('deploy:end', endSpy);
+			let endCount = 0;
+			deployLifecycle.on('deploy:end', () => endCount++);
 			deployLifecycle._handle({
 				name: 'foo',
 				phase: 'start',
@@ -89,7 +89,7 @@ describe('deployLifecycle', () => {
 			deployLifecycle._reclaimOwner(41);
 
 			assert.equal(deployLifecycle.isDeployInFlight('foo'), false);
-			assert.equal(endSpy.callCount, 1);
+			assert.equal(endCount, 1);
 		});
 
 		it('waits for the dead owner process group before ending its deploy', async () => {
@@ -122,11 +122,11 @@ describe('deployLifecycle', () => {
 
 		it('continues reclaiming when one component deploy:end listener throws', () => {
 			const originalError = console.error;
-			const survivingListener = require('sinon').spy();
+			const received = [];
 			deployLifecycle.on('deploy:end', (name) => {
 				if (name === 'foo') throw new Error('consumer failed');
 			});
-			deployLifecycle.on('deploy:end', survivingListener);
+			deployLifecycle.on('deploy:end', (name) => received.push(name));
 			deployLifecycle._handle({
 				name: 'foo',
 				phase: 'start',
@@ -149,19 +149,16 @@ describe('deployLifecycle', () => {
 
 			assert.equal(deployLifecycle.isDeployInFlight('foo'), false);
 			assert.equal(deployLifecycle.isDeployInFlight('bar'), false);
-			assert.deepEqual(
-				survivingListener.getCalls().map(({ args }) => args[0]),
-				['foo', 'bar']
-			);
+			assert.deepEqual(received, ['foo', 'bar']);
 		});
 
 		it('continues deploy:start emission when one listener throws', () => {
 			const originalError = console.error;
-			const survivingListener = require('sinon').spy();
+			const received = [];
 			deployLifecycle.on('deploy:start', () => {
 				throw new Error('consumer failed');
 			});
-			deployLifecycle.on('deploy:start', survivingListener);
+			deployLifecycle.on('deploy:start', (name) => received.push(name));
 
 			try {
 				console.error = () => {};
@@ -175,13 +172,21 @@ describe('deployLifecycle', () => {
 				console.error = originalError;
 			}
 
-			assert.equal(survivingListener.calledOnceWith('foo'), true);
+			assert.deepEqual(received, ['foo']);
 			assert.equal(deployLifecycle.isDeployInFlight('foo'), true);
 		});
 
+		it('ignores parent and current-thread exit notifications', async () => {
+			let waited = false;
+			await deployLifecycle._reclaimOwnerAfterTermination(0, async () => {
+				waited = true;
+			});
+			assert.equal(waited, false);
+		});
+
 		it('keeps an overlapping live-owner deploy active and ignores late starts from a dead owner', () => {
-			const endSpy = require('sinon').spy();
-			deployLifecycle.on('deploy:end', endSpy);
+			let endCount = 0;
+			deployLifecycle.on('deploy:end', () => endCount++);
 			deployLifecycle._handle({
 				name: 'foo',
 				phase: 'start',
@@ -197,7 +202,7 @@ describe('deployLifecycle', () => {
 
 			deployLifecycle._reclaimOwner(41);
 			assert.equal(deployLifecycle.isDeployInFlight('foo'), true);
-			assert.equal(endSpy.callCount, 0);
+			assert.equal(endCount, 0);
 
 			deployLifecycle._handle({
 				name: 'foo',
@@ -213,7 +218,7 @@ describe('deployLifecycle', () => {
 			});
 
 			assert.equal(deployLifecycle.isDeployInFlight('foo'), false);
-			assert.equal(endSpy.callCount, 1);
+			assert.equal(endCount, 1);
 		});
 	});
 });

--- a/unitTests/components/deployLifecycle.test.js
+++ b/unitTests/components/deployLifecycle.test.js
@@ -75,5 +75,58 @@ describe('deployLifecycle', () => {
 			assert.equal(endSpy.callCount, 0);
 			assert.equal(deployLifecycle.isDeployInFlight('never-started'), false);
 		});
+
+		it('ends a deploy when its owner thread exits', () => {
+			const endSpy = require('sinon').spy();
+			deployLifecycle.on('deploy:end', endSpy);
+			deployLifecycle._handle({
+				name: 'foo',
+				phase: 'start',
+				deploymentId: 'dead-deploy',
+				ownerThreadId: 41,
+			});
+
+			deployLifecycle._reclaimOwner(41);
+
+			assert.equal(deployLifecycle.isDeployInFlight('foo'), false);
+			assert.equal(endSpy.callCount, 1);
+		});
+
+		it('keeps an overlapping live-owner deploy active and ignores late starts from a dead owner', () => {
+			const endSpy = require('sinon').spy();
+			deployLifecycle.on('deploy:end', endSpy);
+			deployLifecycle._handle({
+				name: 'foo',
+				phase: 'start',
+				deploymentId: 'dead-deploy',
+				ownerThreadId: 41,
+			});
+			deployLifecycle._handle({
+				name: 'foo',
+				phase: 'start',
+				deploymentId: 'live-deploy',
+				ownerThreadId: 42,
+			});
+
+			deployLifecycle._reclaimOwner(41);
+			assert.equal(deployLifecycle.isDeployInFlight('foo'), true);
+			assert.equal(endSpy.callCount, 0);
+
+			deployLifecycle._handle({
+				name: 'foo',
+				phase: 'start',
+				deploymentId: 'late-deploy',
+				ownerThreadId: 41,
+			});
+			deployLifecycle._handle({
+				name: 'foo',
+				phase: 'end',
+				deploymentId: 'live-deploy',
+				ownerThreadId: 42,
+			});
+
+			assert.equal(deployLifecycle.isDeployInFlight('foo'), false);
+			assert.equal(endSpy.callCount, 1);
+		});
 	});
 });

--- a/unitTests/components/deployLifecycle.test.js
+++ b/unitTests/components/deployLifecycle.test.js
@@ -92,6 +92,56 @@ describe('deployLifecycle', () => {
 			assert.equal(endSpy.callCount, 1);
 		});
 
+		it('waits for the dead owner process group before ending its deploy', async () => {
+			let releaseTermination;
+			const termination = new Promise((resolve) => {
+				releaseTermination = resolve;
+			});
+			deployLifecycle._handle({
+				name: 'foo',
+				phase: 'start',
+				deploymentId: 'terminating-deploy',
+				ownerThreadId: 41,
+			});
+
+			const reclaim = deployLifecycle._reclaimOwnerAfterTermination(41, () => termination);
+			await Promise.resolve();
+			assert.equal(deployLifecycle.isDeployInFlight('foo'), true);
+
+			releaseTermination();
+			await reclaim;
+			assert.equal(deployLifecycle.isDeployInFlight('foo'), false);
+		});
+
+		it('continues reclaiming when one component deploy:end listener throws', () => {
+			const originalError = console.error;
+			deployLifecycle.on('deploy:end', (name) => {
+				if (name === 'foo') throw new Error('consumer failed');
+			});
+			deployLifecycle._handle({
+				name: 'foo',
+				phase: 'start',
+				deploymentId: 'foo-deploy',
+				ownerThreadId: 41,
+			});
+			deployLifecycle._handle({
+				name: 'bar',
+				phase: 'start',
+				deploymentId: 'bar-deploy',
+				ownerThreadId: 41,
+			});
+
+			try {
+				console.error = () => {};
+				deployLifecycle._reclaimOwner(41);
+			} finally {
+				console.error = originalError;
+			}
+
+			assert.equal(deployLifecycle.isDeployInFlight('foo'), false);
+			assert.equal(deployLifecycle.isDeployInFlight('bar'), false);
+		});
+
 		it('keeps an overlapping live-owner deploy active and ignores late starts from a dead owner', () => {
 			const endSpy = require('sinon').spy();
 			deployLifecycle.on('deploy:end', endSpy);

--- a/unitTests/components/deployLifecycle.test.js
+++ b/unitTests/components/deployLifecycle.test.js
@@ -107,6 +107,13 @@ describe('deployLifecycle', () => {
 			const reclaim = deployLifecycle._reclaimOwnerAfterTermination(41, () => termination);
 			await Promise.resolve();
 			assert.equal(deployLifecycle.isDeployInFlight('foo'), true);
+			deployLifecycle._handle({
+				name: 'bar',
+				phase: 'start',
+				deploymentId: 'late-deploy',
+				ownerThreadId: 41,
+			});
+			assert.equal(deployLifecycle.isDeployInFlight('bar'), false, 'late starts from the dead owner stay ignored');
 
 			releaseTermination();
 			await reclaim;
@@ -115,9 +122,11 @@ describe('deployLifecycle', () => {
 
 		it('continues reclaiming when one component deploy:end listener throws', () => {
 			const originalError = console.error;
+			const survivingListener = require('sinon').spy();
 			deployLifecycle.on('deploy:end', (name) => {
 				if (name === 'foo') throw new Error('consumer failed');
 			});
+			deployLifecycle.on('deploy:end', survivingListener);
 			deployLifecycle._handle({
 				name: 'foo',
 				phase: 'start',
@@ -140,6 +149,34 @@ describe('deployLifecycle', () => {
 
 			assert.equal(deployLifecycle.isDeployInFlight('foo'), false);
 			assert.equal(deployLifecycle.isDeployInFlight('bar'), false);
+			assert.deepEqual(
+				survivingListener.getCalls().map(({ args }) => args[0]),
+				['foo', 'bar']
+			);
+		});
+
+		it('continues deploy:start emission when one listener throws', () => {
+			const originalError = console.error;
+			const survivingListener = require('sinon').spy();
+			deployLifecycle.on('deploy:start', () => {
+				throw new Error('consumer failed');
+			});
+			deployLifecycle.on('deploy:start', survivingListener);
+
+			try {
+				console.error = () => {};
+				deployLifecycle._handle({
+					name: 'foo',
+					phase: 'start',
+					deploymentId: 'start-listener-deploy',
+					ownerThreadId: 42,
+				});
+			} finally {
+				console.error = originalError;
+			}
+
+			assert.equal(survivingListener.calledOnceWith('foo'), true);
+			assert.equal(deployLifecycle.isDeployInFlight('foo'), true);
 		});
 
 		it('keeps an overlapping live-owner deploy active and ignores late starts from a dead owner', () => {

--- a/unitTests/components/extractApplicationSwap.test.js
+++ b/unitTests/components/extractApplicationSwap.test.js
@@ -185,6 +185,23 @@ describe('extractApplication directory swap', () => {
 		await fs.rm(sourceDir, { recursive: true, force: true });
 	});
 
+	it('restores the previous component directory when extraction fails', async () => {
+		const componentsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'extract-swap-rollback-'));
+		const dirPath = path.join(componentsRoot, 'web');
+		await fs.mkdir(dirPath, { recursive: true });
+		await fs.writeFile(path.join(dirPath, 'package.json'), '{"name":"web","version":"1.0.0"}\n');
+		await fs.writeFile(path.join(dirPath, 'index.js'), 'module.exports = () => 1;\n');
+
+		const app = new Application({ name: 'web', payload: Buffer.from('not a tar archive') });
+		app.dirPath = dirPath;
+
+		await assert.rejects(() => extractApplication(app));
+		assert.strictEqual(JSON.parse(await fs.readFile(path.join(dirPath, 'package.json'), 'utf8')).version, '1.0.0');
+		assert.strictEqual(await fs.readFile(path.join(dirPath, 'index.js'), 'utf8'), 'module.exports = () => 1;\n');
+
+		await fs.rm(componentsRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+	});
+
 	it('leaves runtime metadata comparison to post-install preparation', async () => {
 		const componentsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'extract-swap-identical-'));
 		const dirPath = path.join(componentsRoot, 'web');

--- a/unitTests/components/extractApplicationSwap.test.js
+++ b/unitTests/components/extractApplicationSwap.test.js
@@ -198,6 +198,10 @@ describe('extractApplication directory swap', () => {
 		await assert.rejects(() => extractApplication(app));
 		assert.strictEqual(JSON.parse(await fs.readFile(path.join(dirPath, 'package.json'), 'utf8')).version, '1.0.0');
 		assert.strictEqual(await fs.readFile(path.join(dirPath, 'index.js'), 'utf8'), 'module.exports = () => 1;\n');
+		assert.deepStrictEqual(
+			(await fs.readdir(componentsRoot)).filter((entry) => !entry.startsWith('.')),
+			['web']
+		);
 
 		await fs.rm(componentsRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 	});

--- a/unitTests/components/extractApplicationSwap.test.js
+++ b/unitTests/components/extractApplicationSwap.test.js
@@ -180,13 +180,12 @@ describe('extractApplication directory swap', () => {
 
 		await extractApplication(app);
 		assert.strictEqual(app.isNewComponent, false, 'a pre-existing directory was renamed aside, so this is a redeploy');
-		assert.strictEqual(app.packageMetadataChanged, true, 'changed package metadata requires a restart');
 
 		await fs.rm(componentsRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 		await fs.rm(sourceDir, { recursive: true, force: true });
 	});
 
-	it('does not mark byte-identical package metadata as changed', async () => {
+	it('leaves runtime metadata comparison to post-install preparation', async () => {
 		const componentsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'extract-swap-identical-'));
 		const dirPath = path.join(componentsRoot, 'web');
 		const packageJSON = '{"name":"web","version":"1.0.0"}\n';
@@ -206,7 +205,7 @@ describe('extractApplication directory swap', () => {
 
 		await extractApplication(app);
 		assert.strictEqual(app.isNewComponent, false);
-		assert.strictEqual(app.packageMetadataChanged, false, 'identical manifests and lockfiles stay restart-free');
+		assert.strictEqual(app.packageMetadataChanged, false, 'extraction alone does not compare pre-install metadata');
 
 		await fs.rm(componentsRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 		await fs.rm(sourceDir, { recursive: true, force: true });

--- a/unitTests/components/extractApplicationSwap.test.js
+++ b/unitTests/components/extractApplicationSwap.test.js
@@ -180,6 +180,33 @@ describe('extractApplication directory swap', () => {
 
 		await extractApplication(app);
 		assert.strictEqual(app.isNewComponent, false, 'a pre-existing directory was renamed aside, so this is a redeploy');
+		assert.strictEqual(app.packageMetadataChanged, true, 'changed package metadata requires a restart');
+
+		await fs.rm(componentsRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+		await fs.rm(sourceDir, { recursive: true, force: true });
+	});
+
+	it('does not mark byte-identical package metadata as changed', async () => {
+		const componentsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'extract-swap-identical-'));
+		const dirPath = path.join(componentsRoot, 'web');
+		const packageJSON = '{"name":"web","version":"1.0.0"}\n';
+		await fs.mkdir(dirPath, { recursive: true });
+		await fs.writeFile(path.join(dirPath, 'package.json'), packageJSON);
+		await fs.writeFile(path.join(dirPath, 'package-lock.json'), '{"lockfileVersion":3}\n');
+
+		const sourceDir = await makeFixture({
+			'package.json': packageJSON,
+			'package-lock.json': '{"lockfileVersion":3}\n',
+		});
+		const app = new Application({
+			name: 'web',
+			payload: await packageDirectory(sourceDir, { skip_node_modules: true }),
+		});
+		app.dirPath = dirPath;
+
+		await extractApplication(app);
+		assert.strictEqual(app.isNewComponent, false);
+		assert.strictEqual(app.packageMetadataChanged, false, 'identical manifests and lockfiles stay restart-free');
 
 		await fs.rm(componentsRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 		await fs.rm(sourceDir, { recursive: true, force: true });

--- a/unitTests/components/extractApplicationSwap.test.js
+++ b/unitTests/components/extractApplicationSwap.test.js
@@ -94,6 +94,56 @@ describe('extractApplication directory swap', () => {
 		await fs.rm(sourceDir, { recursive: true, force: true });
 	});
 
+	it('atomically restores the previous tree when preparation fails under a live writer', async function () {
+		this.timeout(20000);
+		const componentsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'extract-swap-live-rollback-'));
+		const dirPath = path.join(componentsRoot, 'web');
+		const cacheDir = path.join(dirPath, '.next', 'cache');
+		await fs.mkdir(cacheDir, { recursive: true });
+		await fs.writeFile(path.join(dirPath, 'package.json'), '{"name":"web","version":"1.0.0"}\n');
+		await fs.writeFile(path.join(dirPath, 'index.js'), 'module.exports = () => 1;\n');
+		const sourceDir = await makeFixture({
+			'package.json': '{"name":"web","version":"2.0.0"}\n',
+			'index.js': 'module.exports = () => 2;\n',
+		});
+		const app = new Application({
+			name: 'web',
+			payload: await packageDirectory(sourceDir, { skip_node_modules: true }),
+		});
+		app.dirPath = dirPath;
+
+		let writing = true;
+		const writer = (async () => {
+			let writes = 0;
+			while (writing) {
+				try {
+					await fs.mkdir(cacheDir, { recursive: true });
+					await fs.writeFile(path.join(cacheDir, `live-${writes++}`), 'data');
+				} catch {
+					/* directory swapped between writes */
+				}
+			}
+		})();
+
+		try {
+			const extraction = await extractApplication(app, true);
+			await extraction.rollback();
+		} finally {
+			writing = false;
+			await writer;
+		}
+
+		assert.strictEqual(JSON.parse(await fs.readFile(path.join(dirPath, 'package.json'), 'utf8')).version, '1.0.0');
+		assert.strictEqual(await fs.readFile(path.join(dirPath, 'index.js'), 'utf8'), 'module.exports = () => 1;\n');
+		assert.deepStrictEqual(
+			(await fs.readdir(componentsRoot)).filter((entry) => !entry.startsWith('.')),
+			['web']
+		);
+
+		await fs.rm(componentsRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+		await fs.rm(sourceDir, { recursive: true, force: true });
+	});
+
 	it('reclaims a stale aside copy left by an earlier deploy', async function () {
 		this.timeout(20000);
 

--- a/unitTests/components/extractApplicationSwap.test.js
+++ b/unitTests/components/extractApplicationSwap.test.js
@@ -144,6 +144,33 @@ describe('extractApplication directory swap', () => {
 		await fs.rm(sourceDir, { recursive: true, force: true });
 	});
 
+	it('normalizes a single-directory archive through hidden staging', async () => {
+		const componentsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'extract-swap-normalize-'));
+		const dirPath = path.join(componentsRoot, 'web');
+		const sourceDir = await makeFixture({
+			'wrapper/package.json': '{"name":"web","version":"2.0.0"}\n',
+			'wrapper/index.js': 'module.exports = () => 2;\n',
+		});
+		const app = new Application({
+			name: 'web',
+			payload: await packageDirectory(sourceDir, { skip_node_modules: true }),
+		});
+		app.dirPath = dirPath;
+
+		await extractApplication(app);
+
+		assert.strictEqual(JSON.parse(await fs.readFile(path.join(dirPath, 'package.json'), 'utf8')).version, '2.0.0');
+		assert.strictEqual(await fs.readFile(path.join(dirPath, 'index.js'), 'utf8'), 'module.exports = () => 2;\n');
+		assert.deepStrictEqual(
+			(await fs.readdir(componentsRoot)).filter((entry) => !entry.startsWith('.')),
+			['web'],
+			'archive normalization must not leave a visible sibling that can load as a component'
+		);
+
+		await fs.rm(componentsRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+		await fs.rm(sourceDir, { recursive: true, force: true });
+	});
+
 	// harper#1806: deployComponent uses Application#isNewComponent to scope its own
 	// requestRestart() call to components that have never been deployed before, leaving an
 	// existing component's redeploy to the component's own file watcher.

--- a/unitTests/components/prepareApplicationSerialization.test.js
+++ b/unitTests/components/prepareApplicationSerialization.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('node:assert');
-const { access, mkdtemp, readFile, rm, writeFile } = require('node:fs/promises');
+const { access, mkdir, mkdtemp, readFile, rm, writeFile } = require('node:fs/promises');
 const { tmpdir } = require('node:os');
 const { join } = require('node:path');
 
@@ -20,6 +20,30 @@ async function makePayload(rootDir, name, version, installScript) {
 }
 
 describe('prepareApplication serialization', () => {
+	it('restores the loaded component tree when installation fails', async function () {
+		this.timeout(10000);
+		const rootDir = await mkdtemp(join(tmpdir(), 'prepare-application-rollback-'));
+		const componentDirPath = join(rootDir, 'shared');
+		await mkdir(componentDirPath, { recursive: true });
+		await writeFile(join(componentDirPath, 'package.json'), JSON.stringify({ name: 'shared', version: '1.0.0' }));
+		await writeFile(join(componentDirPath, 'index.js'), 'module.exports = 1;\n');
+
+		const failedApplication = new Application({
+			name: 'shared',
+			payload: await makePayload(rootDir, 'shared', '2.0.0', 'process.exit(2);'),
+			install: { command: 'node install.js', timeout: 5000 },
+		});
+		failedApplication.dirPath = componentDirPath;
+
+		try {
+			await assert.rejects(() => prepareApplication(failedApplication), /Failed to install dependencies/);
+			assert.equal(JSON.parse(await readFile(join(componentDirPath, 'package.json'), 'utf8')).version, '1.0.0');
+			assert.equal(await readFile(join(componentDirPath, 'index.js'), 'utf8'), 'module.exports = 1;\n');
+		} finally {
+			await rm(rootDir, { recursive: true, force: true });
+		}
+	});
+
 	it('keeps extraction and installation ordered for the same component directory', async function () {
 		this.timeout(10000);
 		const rootDir = await mkdtemp(join(tmpdir(), 'prepare-application-serialization-'));

--- a/unitTests/resources/jsResource.test.js
+++ b/unitTests/resources/jsResource.test.js
@@ -166,6 +166,48 @@ describe('jsResource', () => {
 		assert.equal(importSpy.callCount, 2, 'each distinct new file should be imported');
 	});
 
+	it('requests a restart and re-registers when a loaded file is replaced in place', async () => {
+		// An editor/atomic-rename save of an already-loaded resource reaches this plugin as
+		// `unlink` then `add` for the same path. The unlink must request the restart (the old
+		// module cannot be unloaded), and the re-add must still re-register so the resource stays
+		// reachable during the restart debounce. Replaces the redeploy-specific coverage that the
+		// EntryHandler-level fix made obsolete.
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		let capturedHandler;
+		const importSpy = spy(async () => ({ default: { get() {} } }));
+		const mockScope = {
+			handleEntry: spy((handler) => {
+				capturedHandler = handler;
+			}),
+			resources: new Map(),
+			logger: { warn: spy(), debug: spy(), error: spy() },
+			requestRestart: spy(),
+			import: importSpy,
+		};
+
+		await handleApplication(mockScope);
+
+		const absolutePath = join(testDir, 'replaced.js');
+		await capturedHandler({ entryType: 'file', eventType: 'add', absolutePath, urlPath: '/replaced.js' });
+		assert.equal(mockScope.requestRestart.callCount, 0, 'the first load of a path does not restart');
+		const registeredPaths = [...mockScope.resources.keys()].sort();
+		assert.ok(registeredPaths.length > 0, 'the resource is registered on first load');
+
+		await capturedHandler({ entryType: 'file', eventType: 'unlink', absolutePath, urlPath: '/replaced.js' });
+		assert.equal(mockScope.requestRestart.callCount, 1, 'removing a loaded file requests the restart');
+		assert.equal(importSpy.callCount, 1, 'unlink must not import');
+
+		await capturedHandler({ entryType: 'file', eventType: 'add', absolutePath, urlPath: '/replaced.js' });
+		assert.equal(mockScope.requestRestart.callCount, 1, 'the re-add rides the restart already requested');
+		assert.deepEqual(
+			[...mockScope.resources.keys()].sort(),
+			registeredPaths,
+			're-registering the same path stays idempotent — no stale duplicate endpoint'
+		);
+	});
+
 	it('exposes an exported defineTable handle as an endpoint', async () => {
 		// `defineTable` registers eagerly at import time; the handle is a real table class, so the
 		// existing export walk exposes it — the code-first analog of GraphQL's @export, and the same

--- a/unitTests/resources/jsResource.test.js
+++ b/unitTests/resources/jsResource.test.js
@@ -5,7 +5,6 @@ const { writeFileSync } = require('node:fs');
 const { join } = require('node:path');
 const { tmpdir } = require('node:os');
 const { mkdtempSync, rmSync } = require('node:fs');
-const { EventEmitter } = require('node:events');
 const { setupTestDBPath } = require('../testUtils');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { defineTable, types } = require('#src/resources/defineTable');
@@ -130,48 +129,6 @@ describe('jsResource', () => {
 		);
 	});
 
-	it('requests a restart when an already-loaded file is re-added (redeploy re-scan)', async () => {
-		// A redeploy pauses/resumes the watcher; the fresh chokidar scan re-emits every existing
-		// file as `add`, including one whose contents just changed. The first add loads the module;
-		// the second add for the same path must be treated like a change — flag a restart and NOT
-		// re-import stale cached code (harper#1817).
-		setupTestDBPath();
-		setMainIsWorker(true);
-		const resourceFile = join(testDir, 'resources.js');
-		writeFileSync(resourceFile, 'export default { get() {} };');
-
-		let capturedHandler;
-		const importSpy = spy(async () => ({ default: { get() {} } }));
-		const mockScope = {
-			handleEntry: spy((handler) => {
-				capturedHandler = handler;
-			}),
-			resources: new Map(),
-			logger: { warn: spy(), debug: spy(), error: spy() },
-			requestRestart: spy(),
-			import: importSpy,
-		};
-
-		await handleApplication(mockScope);
-
-		const addEvent = {
-			entryType: 'file',
-			eventType: 'add',
-			absolutePath: resourceFile,
-			urlPath: '/resources.js',
-		};
-
-		// Initial load: registers, no restart.
-		await capturedHandler(addEvent);
-		assert.equal(mockScope.requestRestart.callCount, 0, 'initial add should not request a restart');
-		assert.equal(importSpy.callCount, 1, 'initial add should import the module once');
-
-		// Redeploy re-scan: same file re-emitted as `add` → treat like a change.
-		await capturedHandler(addEvent);
-		assert.equal(mockScope.requestRestart.callCount, 1, 're-add of a loaded file should request a restart');
-		assert.equal(importSpy.callCount, 1, 're-add should NOT re-import (avoids serving stale cached code)');
-	});
-
 	it('loads a genuinely new file added at runtime without requesting a restart', async () => {
 		// A first-time `add` for a path never seen before (e.g. a new resource file dropped in at
 		// runtime) must still hot-load without forcing a restart — only re-adds of known files do.
@@ -207,126 +164,6 @@ describe('jsResource', () => {
 
 		assert.equal(mockScope.requestRestart.callCount, 0, 'distinct new files should not request a restart');
 		assert.equal(importSpy.callCount, 2, 'each distinct new file should be imported');
-	});
-
-	it('requests a restart when a loaded file is missing from a redeploy re-scan (deletion)', async () => {
-		// A redeploy's fresh chokidar scan only reports files that still exist on disk — a file
-		// deleted during the redeploy produces no event at all (no re-`add`, no `unlink`), so the
-		// re-`add` handling above never sees it. jsResource must diff the loaded-files set against
-		// what the scan actually reported once its `ready` fires, and flag a restart for anything
-		// missing (harper#1817 follow-up: deletion gap).
-		setupTestDBPath();
-		setMainIsWorker(true);
-		const resourceFile = join(testDir, 'resources.js');
-		writeFileSync(resourceFile, 'export default { get() {} };');
-
-		let capturedHandler;
-		// A real EventEmitter stands in for the EntryHandler scope.handleEntry() returns in
-		// production — jsResource listens for its 'ready' event to know when a scan pass completed.
-		const entryHandlerStub = new EventEmitter();
-		const importSpy = spy(async () => ({ default: { get() {} } }));
-		// The scope itself is an EventEmitter in production (deploy:start/deploy:end); mirror that
-		// so jsResource can arm the post-redeploy diff window the same way it does against a real Scope.
-		const mockScope = Object.assign(new EventEmitter(), {
-			handleEntry: spy((handler) => {
-				capturedHandler = handler;
-				return entryHandlerStub;
-			}),
-			resources: new Map(),
-			logger: { warn: spy(), debug: spy(), error: spy() },
-			requestRestart: spy(),
-			import: importSpy,
-		});
-
-		await handleApplication(mockScope);
-
-		// Initial scan: the file loads, then the entry handler's scan completes.
-		await capturedHandler({
-			entryType: 'file',
-			eventType: 'add',
-			absolutePath: resourceFile,
-			urlPath: '/resources.js',
-		});
-		entryHandlerStub.emit('ready');
-		assert.equal(mockScope.requestRestart.callCount, 0, 'initial scan should not request a restart');
-
-		// Redeploy: Scope pauses the watcher (deploy:start) then resumes it; resourceFile was deleted,
-		// so the fresh scan's re-`add` pass reports nothing for it at all — no event fires. Only the
-		// scan-complete diff, armed by deploy:start, can catch this.
-		mockScope.emit('deploy:start', 'test-app');
-		entryHandlerStub.emit('ready');
-		assert.equal(
-			mockScope.requestRestart.callCount,
-			1,
-			'a file missing from the redeploy re-scan should request a restart'
-		);
-	});
-
-	it('does not treat other loaded files as deleted when `ready` refires after an ordinary runtime add', async () => {
-		// EntryHandler's `ready` isn't scoped to full rescans: it also refires after every ordinary
-		// add/change once that file's read settles, because its initial-scan-complete latch never
-		// resets outside a full rescan (see EntryHandler#checkIfAllComplete). A naive deletion diff
-		// keyed off every `ready` would see only the just-added file in view and treat every other
-		// already-loaded file as deleted, breaking hot-load-without-restart for multi-file components.
-		// The diff must only run inside a genuine redeploy window (deploy:start -> next ready).
-		setupTestDBPath();
-		setMainIsWorker(true);
-		const fileA = join(testDir, 'a.js');
-		const fileB = join(testDir, 'b.js');
-		writeFileSync(fileA, 'export default { get() {} };');
-		writeFileSync(fileB, 'export default { get() {} };');
-
-		let capturedHandler;
-		const entryHandlerStub = new EventEmitter();
-		const importSpy = spy(async () => ({ default: { get() {} } }));
-		const mockScope = Object.assign(new EventEmitter(), {
-			handleEntry: spy((handler) => {
-				capturedHandler = handler;
-				return entryHandlerStub;
-			}),
-			resources: new Map(),
-			logger: { warn: spy(), debug: spy(), error: spy() },
-			requestRestart: spy(),
-			import: importSpy,
-		});
-
-		await handleApplication(mockScope);
-
-		// Initial scan loads fileA only, then settles.
-		await capturedHandler({ entryType: 'file', eventType: 'add', absolutePath: fileA, urlPath: '/a.js' });
-		entryHandlerStub.emit('ready');
-		assert.equal(mockScope.requestRestart.callCount, 0, 'initial scan should not request a restart');
-
-		// Genuinely new file dropped in at runtime (no redeploy in progress): loads without a restart,
-		// then EntryHandler's `ready` refires (its steady-state behavior, not a rescan boundary).
-		await capturedHandler({ entryType: 'file', eventType: 'add', absolutePath: fileB, urlPath: '/b.js' });
-		entryHandlerStub.emit('ready');
-
-		assert.equal(
-			mockScope.requestRestart.callCount,
-			0,
-			'a ready refire outside a redeploy window must not treat fileA as deleted'
-		);
-
-		// Confirm neither file's loaded-tracking was corrupted by the earlier spurious `ready`: a
-		// later genuine redeploy re-scan (both files still present, as a real fresh scan would report)
-		// still recognizes them as known — restart requested, neither re-imported — rather than
-		// mistakenly re-importing a file the bug had wrongly forgotten.
-		const restartCountBeforeRedeploy = mockScope.requestRestart.callCount;
-		mockScope.emit('deploy:start', 'test-app');
-		await capturedHandler({ entryType: 'file', eventType: 'add', absolutePath: fileA, urlPath: '/a.js' });
-		await capturedHandler({ entryType: 'file', eventType: 'add', absolutePath: fileB, urlPath: '/b.js' });
-		entryHandlerStub.emit('ready');
-
-		assert.ok(
-			mockScope.requestRestart.callCount > restartCountBeforeRedeploy,
-			'a real redeploy re-scan of known files should still request a restart'
-		);
-		assert.equal(
-			importSpy.callCount,
-			2,
-			'neither fileA nor fileB should be re-imported (both still tracked as loaded)'
-		);
 	});
 
 	it('exposes an exported defineTable handle as an endpoint', async () => {

--- a/unitTests/resources/rolesEntryEvents.test.js
+++ b/unitTests/resources/rolesEntryEvents.test.js
@@ -1,47 +1,74 @@
 'use strict';
 
 const assert = require('node:assert');
-const rewire = require('rewire');
+const { handleApplication } = require('#src/resources/roles');
 
-const roles = rewire('#src/resources/roles');
-roles.__set__('ensureRole', async () => {});
-const { handleApplication } = roles;
+function testScope(warnings = []) {
+	let handler;
+	const listeners = new Map();
+	return {
+		scope: {
+			handleEntry(entryHandler) {
+				handler = entryHandler;
+				return { ready: Promise.resolve() };
+			},
+			on(event, listener) {
+				listeners.set(event, listener);
+			},
+			logger: { warn: (message) => warnings.push(message), error() {} },
+		},
+		get handler() {
+			return handler;
+		},
+		fire(event) {
+			listeners.get(event)?.();
+		},
+	};
+}
 
 describe('roles entry events', () => {
 	it('ignores directory and unlink events without reading file contents', async () => {
-		let handler;
-		handleApplication({
-			handleEntry(entryHandler) {
-				handler = entryHandler;
-			},
-		});
+		const harness = testScope();
+		handleApplication(harness.scope, async () => {});
 
-		await assert.doesNotReject(() => handler({ entryType: 'directory', eventType: 'addDir' }));
-		await assert.doesNotReject(() => handler({ entryType: 'directory', eventType: 'unlinkDir' }));
-		await assert.doesNotReject(() => handler({ entryType: 'file', eventType: 'unlink' }));
+		await assert.doesNotReject(() => harness.handler({ entryType: 'directory', eventType: 'addDir' }));
+		await assert.doesNotReject(() => harness.handler({ entryType: 'directory', eventType: 'unlinkDir' }));
+		await assert.doesNotReject(() => harness.handler({ entryType: 'file', eventType: 'unlink' }));
 	});
 
 	it('warns when a declared role disappears without revoking its grants', async () => {
-		let handler;
 		const warnings = [];
-		handleApplication({
-			handleEntry(entryHandler) {
-				handler = entryHandler;
-			},
-			logger: { warn: (message) => warnings.push(message) },
-		});
+		const harness = testScope(warnings);
+		handleApplication(harness.scope, async () => {});
 
 		const absolutePath = '/app/roles.yaml';
-		await handler({
+		await harness.handler({
 			entryType: 'file',
 			eventType: 'add',
 			absolutePath,
 			contents: Buffer.from('reporter:\n  access: none\n'),
 		});
-		await handler({ entryType: 'file', eventType: 'unlink', absolutePath });
+		await harness.handler({ entryType: 'file', eventType: 'unlink', absolutePath });
 
 		assert.equal(warnings.length, 1);
 		assert.match(warnings[0], /reporter/);
 		assert.match(warnings[0], /remain active/);
+	});
+
+	it('reconciles unchanged declared roles after deploy', async () => {
+		const harness = testScope();
+		const ensured = [];
+		handleApplication(harness.scope, async (role) => ensured.push(role.role));
+
+		await harness.handler({
+			entryType: 'file',
+			eventType: 'add',
+			absolutePath: '/app/roles.yaml',
+			contents: Buffer.from('reporter:\n  access: none\n'),
+		});
+		harness.fire('deploy:end');
+		await new Promise((resolve) => setImmediate(resolve));
+
+		assert.deepEqual(ensured, ['reporter', 'reporter']);
 	});
 });

--- a/unitTests/resources/rolesEntryEvents.test.js
+++ b/unitTests/resources/rolesEntryEvents.test.js
@@ -4,7 +4,7 @@ const assert = require('node:assert');
 const { handleApplication } = require('#src/resources/roles');
 const { waitFor } = require('../waitFor.js');
 
-function testScope(warnings = []) {
+function testScope(warnings = [], errors = []) {
 	let handler;
 	const listeners = new Map();
 	return {
@@ -16,7 +16,7 @@ function testScope(warnings = []) {
 			on(event, listener) {
 				listeners.set(event, listener);
 			},
-			logger: { warn: (message) => warnings.push(message), error() {} },
+			logger: { warn: (message) => warnings.push(message), error: (...args) => errors.push(args) },
 		},
 		get handler() {
 			return handler;
@@ -104,5 +104,31 @@ describe('roles entry events', () => {
 		releaseReconcile();
 		await change;
 		assert.deepEqual(applied, ['none', 'none', 'super_user']);
+	});
+
+	it('continues reconciling other role files after one is invalid', async () => {
+		const errors = [];
+		const harness = testScope([], errors);
+		const ensured = [];
+		handleApplication(harness.scope, async (role) => ensured.push(role.role));
+
+		await assert.rejects(
+			harness.handler({
+				entryType: 'file',
+				eventType: 'add',
+				absolutePath: '/app/invalid.yaml',
+				contents: Buffer.from('broken:\n  dev:\n    dog:\n      attribute_permissions: invalid\n'),
+			})
+		);
+		await harness.handler({
+			entryType: 'file',
+			eventType: 'add',
+			absolutePath: '/app/valid.yaml',
+			contents: Buffer.from('reader:\n  access: none\n'),
+		});
+
+		harness.fire('deploy:end');
+		await waitFor(() => ensured.length === 2 && errors.length === 1);
+		assert.deepEqual(ensured, ['reader', 'reader']);
 	});
 });

--- a/unitTests/resources/rolesEntryEvents.test.js
+++ b/unitTests/resources/rolesEntryEvents.test.js
@@ -1,7 +1,11 @@
 'use strict';
 
 const assert = require('node:assert');
-const { handleApplication } = require('#src/resources/roles');
+const rewire = require('rewire');
+
+const roles = rewire('#src/resources/roles');
+roles.__set__('ensureRole', async () => {});
+const { handleApplication } = roles;
 
 describe('roles entry events', () => {
 	it('ignores directory and unlink events without reading file contents', async () => {
@@ -15,5 +19,29 @@ describe('roles entry events', () => {
 		await assert.doesNotReject(() => handler({ entryType: 'directory', eventType: 'addDir' }));
 		await assert.doesNotReject(() => handler({ entryType: 'directory', eventType: 'unlinkDir' }));
 		await assert.doesNotReject(() => handler({ entryType: 'file', eventType: 'unlink' }));
+	});
+
+	it('warns when a declared role disappears without revoking its grants', async () => {
+		let handler;
+		const warnings = [];
+		handleApplication({
+			handleEntry(entryHandler) {
+				handler = entryHandler;
+			},
+			logger: { warn: (message) => warnings.push(message) },
+		});
+
+		const absolutePath = '/app/roles.yaml';
+		await handler({
+			entryType: 'file',
+			eventType: 'add',
+			absolutePath,
+			contents: Buffer.from('reporter:\n  access: none\n'),
+		});
+		await handler({ entryType: 'file', eventType: 'unlink', absolutePath });
+
+		assert.equal(warnings.length, 1);
+		assert.match(warnings[0], /reporter/);
+		assert.match(warnings[0], /remain active/);
 	});
 });

--- a/unitTests/resources/rolesEntryEvents.test.js
+++ b/unitTests/resources/rolesEntryEvents.test.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert');
 const { handleApplication } = require('#src/resources/roles');
+const { waitFor } = require('../waitFor.js');
 
 function testScope(warnings = []) {
 	let handler;
@@ -67,8 +68,41 @@ describe('roles entry events', () => {
 			contents: Buffer.from('reporter:\n  access: none\n'),
 		});
 		harness.fire('deploy:end');
-		await new Promise((resolve) => setImmediate(resolve));
+		await waitFor(() => ensured.length === 2);
 
 		assert.deepEqual(ensured, ['reporter', 'reporter']);
+	});
+
+	it('serializes a live role change behind deploy reconciliation', async () => {
+		const harness = testScope();
+		const applied = [];
+		let releaseReconcile;
+		const reconcileBlocked = new Promise((resolve) => (releaseReconcile = resolve));
+		handleApplication(harness.scope, async (role) => {
+			applied.push(role.access);
+			if (applied.length === 2) await reconcileBlocked;
+		});
+
+		const absolutePath = '/app/roles.yaml';
+		await harness.handler({
+			entryType: 'file',
+			eventType: 'add',
+			absolutePath,
+			contents: Buffer.from('reporter:\n  access: none\n'),
+		});
+		harness.fire('deploy:end');
+		await waitFor(() => applied.length === 2);
+		const change = harness.handler({
+			entryType: 'file',
+			eventType: 'change',
+			absolutePath,
+			contents: Buffer.from('reporter:\n  access: super_user\n'),
+		});
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.deepEqual(applied, ['none', 'none']);
+
+		releaseReconcile();
+		await change;
+		assert.deepEqual(applied, ['none', 'none', 'super_user']);
 	});
 });

--- a/unitTests/resources/rolesEntryEvents.test.js
+++ b/unitTests/resources/rolesEntryEvents.test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const assert = require('node:assert');
+const { handleApplication } = require('#src/resources/roles');
+
+describe('roles entry events', () => {
+	it('ignores directory and unlink events without reading file contents', async () => {
+		let handler;
+		handleApplication({
+			handleEntry(entryHandler) {
+				handler = entryHandler;
+			},
+		});
+
+		await assert.doesNotReject(() => handler({ entryType: 'directory', eventType: 'addDir' }));
+		await assert.doesNotReject(() => handler({ entryType: 'directory', eventType: 'unlinkDir' }));
+		await assert.doesNotReject(() => handler({ entryType: 'file', eventType: 'unlink' }));
+	});
+});

--- a/unitTests/security/jsLoader/jsLoader.test.js
+++ b/unitTests/security/jsLoader/jsLoader.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { mkdtempSync, rmSync, writeFileSync } = require('node:fs');
+const { mkdirSync, mkdtempSync, rmSync, writeFileSync } = require('node:fs');
 const { tmpdir } = require('node:os');
 const { join } = require('node:path');
 const { pathToFileURL } = require('node:url');
@@ -225,30 +225,113 @@ describe('pure-ESM package resolution', () => {
 });
 
 describe('native addon delegation', () => {
-	it('delegates transitive .node requires and marks the runtime opaque', async () => {
-		const runtimeRoot = mkdtempSync(join(tmpdir(), 'js-loader-native-addon-'));
-		const wrapperPath = join(runtimeRoot, 'wrapper.cjs');
-		const addonPath = join(runtimeRoot, 'addon.node');
-		writeFileSync(wrapperPath, "module.exports = require('./addon.node');\n");
+	let runtimeRoot;
+	let addonPath;
+	let originalLoader;
+
+	beforeEach(() => {
+		runtimeRoot = mkdtempSync(join(tmpdir(), 'js-loader-native-addon-'));
+		addonPath = join(runtimeRoot, 'addon.node');
 		writeFileSync(addonPath, Buffer.from([0xff, 0x00, 0xfe]));
-		const originalLoader = require.extensions['.node'];
+		originalLoader = require.extensions['.node'];
+	});
+
+	afterEach(() => {
+		require.extensions['.node'] = originalLoader;
+		rmSync(runtimeRoot, { recursive: true, force: true });
+	});
+
+	it('delegates transitive CJS .node requires and marks the runtime opaque', async () => {
+		const wrapperPath = join(runtimeRoot, 'wrapper.cjs');
+		writeFileSync(wrapperPath, "module.exports = require('./addon.node');\n");
 		let nativeRuntimeMarked = false;
 		require.extensions['.node'] = (module) => {
 			module.exports = { delegated: true };
 		};
+		const result = await scopedImport(wrapperPath, {
+			...vmScope(),
+			runtimeRoot,
+			markNativeRuntime: () => {
+				nativeRuntimeMarked = true;
+			},
+		});
+		expect(result.default.delegated).to.equal(true);
+		expect(nativeRuntimeMarked).to.equal(true);
+	});
+
+	it('delegates compartment .node imports and marks the runtime opaque', async () => {
+		const entryPath = join(runtimeRoot, 'entry.mjs');
+		writeFileSync(entryPath, "import addon from './addon.node'; export default addon;\n");
+		let nativeRuntimeMarked = false;
+		require.extensions['.node'] = (module) => {
+			module.exports = { delegated: true };
+		};
+		const result = await scopedImport(entryPath, {
+			mode: 'compartment',
+			runtimeRoot,
+			allowedPath: runtimeRoot,
+			resources: {},
+			markNativeRuntime: () => {
+				nativeRuntimeMarked = true;
+			},
+		});
+		expect(result.default.delegated).to.equal(true);
+		expect(nativeRuntimeMarked).to.equal(true);
+	});
+
+	it('delegates ESM .node imports and marks the runtime opaque', async () => {
+		const entryPath = join(runtimeRoot, 'entry.mjs');
+		writeFileSync(entryPath, "import addon from './addon.node'; export default addon;\n");
+		let nativeRuntimeMarked = false;
+		require.extensions['.node'] = (module) => {
+			module.exports = { delegated: true };
+		};
+		const result = await scopedImport(entryPath, {
+			...vmScope(),
+			runtimeRoot,
+			markNativeRuntime: () => {
+				nativeRuntimeMarked = true;
+			},
+		});
+		expect(result.default.delegated).to.equal(true);
+		expect(nativeRuntimeMarked).to.equal(true);
+	});
+
+	it('does not mark a failed optional native load as opaque', async () => {
+		const wrapperPath = join(runtimeRoot, 'wrapper.cjs');
+		writeFileSync(
+			wrapperPath,
+			"try { module.exports = require('./addon.node'); } catch { module.exports = { fallback: true }; }\n"
+		);
+		let nativeRuntimeMarked = false;
+		require.extensions['.node'] = () => {
+			throw new Error('ABI mismatch');
+		};
+		const result = await scopedImport(wrapperPath, {
+			...vmScope(),
+			runtimeRoot,
+			markNativeRuntime: () => {
+				nativeRuntimeMarked = true;
+			},
+		});
+		expect(result.default.fallback).to.equal(true);
+		expect(nativeRuntimeMarked).to.equal(false);
+	});
+
+	it('rejects a CJS native addon outside allowedPath', async () => {
+		const allowedPath = join(runtimeRoot, 'allowed');
+		const wrapperPath = join(allowedPath, 'wrapper.cjs');
+		mkdirSync(allowedPath);
+		writeFileSync(wrapperPath, "module.exports = require('../addon.node');\n");
+		require.extensions['.node'] = (module) => {
+			module.exports = { delegated: true };
+		};
+		let error;
 		try {
-			const result = await scopedImport(wrapperPath, {
-				...vmScope(),
-				runtimeRoot,
-				markNativeRuntime: () => {
-					nativeRuntimeMarked = true;
-				},
-			});
-			expect(result.default.delegated).to.equal(true);
-			expect(nativeRuntimeMarked).to.equal(true);
-		} finally {
-			require.extensions['.node'] = originalLoader;
-			rmSync(runtimeRoot, { recursive: true, force: true });
+			await scopedImport(wrapperPath, { ...vmScope(), runtimeRoot, allowedPath });
+		} catch (caught) {
+			error = caught;
 		}
+		expect(error?.message).to.include('outside of allowed path');
 	});
 });

--- a/unitTests/security/jsLoader/jsLoader.test.js
+++ b/unitTests/security/jsLoader/jsLoader.test.js
@@ -223,3 +223,32 @@ describe('pure-ESM package resolution', () => {
 		expect(loadedModules.some((url) => url.endsWith('/pure-esm-pkg/package.json'))).to.equal(true);
 	});
 });
+
+describe('native addon delegation', () => {
+	it('delegates transitive .node requires and marks the runtime opaque', async () => {
+		const runtimeRoot = mkdtempSync(join(tmpdir(), 'js-loader-native-addon-'));
+		const wrapperPath = join(runtimeRoot, 'wrapper.cjs');
+		const addonPath = join(runtimeRoot, 'addon.node');
+		writeFileSync(wrapperPath, "module.exports = require('./addon.node');\n");
+		writeFileSync(addonPath, Buffer.from([0xff, 0x00, 0xfe]));
+		const originalLoader = require.extensions['.node'];
+		let nativeRuntimeMarked = false;
+		require.extensions['.node'] = (module) => {
+			module.exports = { delegated: true };
+		};
+		try {
+			const result = await scopedImport(wrapperPath, {
+				...vmScope(),
+				runtimeRoot,
+				markNativeRuntime: () => {
+					nativeRuntimeMarked = true;
+				},
+			});
+			expect(result.default.delegated).to.equal(true);
+			expect(nativeRuntimeMarked).to.equal(true);
+		} finally {
+			require.extensions['.node'] = originalLoader;
+			rmSync(runtimeRoot, { recursive: true, force: true });
+		}
+	});
+});

--- a/unitTests/security/jsLoader/jsLoader.test.js
+++ b/unitTests/security/jsLoader/jsLoader.test.js
@@ -211,12 +211,15 @@ describe('pure-ESM package resolution', () => {
 	it('should import a pure-ESM package (exports map with only "import" conditions, no "require")', async () => {
 		const runtimeRoot = join(__dirname, 'fixtures', 'esm-only-test');
 		const resolutions = [];
+		const loadedModules = [];
 		const result = await scopedImport(join(runtimeRoot, 'uses-pure-esm-pkg.mjs'), {
 			...vmScope(),
 			runtimeRoot,
 			recordModuleResolution: (specifier) => resolutions.push(specifier),
+			recordLoadedModule: (url) => loadedModules.push(url),
 		});
 		expect(result.value).to.equal('esm-only');
 		expect(resolutions).not.to.include('pure-esm-pkg');
+		expect(loadedModules.some((url) => url.endsWith('/pure-esm-pkg/package.json'))).to.equal(true);
 	});
 });

--- a/unitTests/security/jsLoader/jsLoader.test.js
+++ b/unitTests/security/jsLoader/jsLoader.test.js
@@ -100,6 +100,24 @@ describe('scopedImport', () => {
 		const lib = await result.load();
 		expect(lib.baz).to.equal('pow');
 	});
+
+	it('records transitive local modules and their resolution edges', async () => {
+		const loadedModules = [];
+		const resolutions = [];
+		const scope = {
+			mode: 'vm-current-context',
+			recordLoadedModule: (url) => loadedModules.push(url),
+			recordModuleResolution: (specifier, referrer, resolvedUrl) =>
+				resolutions.push({ specifier, referrer, resolvedUrl }),
+		};
+
+		const result = await scopedImport(join(__dirname, 'fixtures', 'uses-dynamic-import.cjs'), scope);
+		await result.load();
+
+		expect(loadedModules.some((url) => url.endsWith('/uses-dynamic-import.cjs'))).to.equal(true);
+		expect(loadedModules.some((url) => url.endsWith('/libgood.cjs'))).to.equal(true);
+		expect(resolutions.some(({ specifier }) => specifier === './libgood.cjs')).to.equal(true);
+	});
 });
 
 describe('import.meta compatibility', () => {

--- a/unitTests/security/jsLoader/jsLoader.test.js
+++ b/unitTests/security/jsLoader/jsLoader.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { mkdtempSync, rmSync, writeFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
 const { join } = require('node:path');
 const { pathToFileURL } = require('node:url');
 const { scopedImport } = require('#src/security/jsLoader');
@@ -117,6 +119,49 @@ describe('scopedImport', () => {
 		expect(loadedModules.some((url) => url.endsWith('/uses-dynamic-import.cjs'))).to.equal(true);
 		expect(loadedModules.some((url) => url.endsWith('/libgood.cjs'))).to.equal(true);
 		expect(resolutions.some(({ specifier }) => specifier === './libgood.cjs')).to.equal(true);
+	});
+
+	it('keeps app-local package imports in the observable loader', async () => {
+		const directory = mkdtempSync(join(tmpdir(), 'harper-js-loader-imports-'));
+		try {
+			writeFileSync(
+				join(directory, 'package.json'),
+				JSON.stringify({
+					name: 'app-local-imports',
+					type: 'module',
+					imports: { '#helper': './helper.js' },
+					exports: { './self': './self.js' },
+				})
+			);
+			writeFileSync(
+				join(directory, 'entry.js'),
+				"export { value } from '#helper';\nexport { selfValue } from 'app-local-imports/self';\n"
+			);
+			writeFileSync(join(directory, 'helper.js'), 'export const value = 42;\n');
+			writeFileSync(join(directory, 'self.js'), 'export const selfValue = 84;\n');
+
+			const loadedModules = [];
+			const resolutions = [];
+			let nativeRuntime = false;
+			const result = await scopedImport(join(directory, 'entry.js'), {
+				mode: 'vm-current-context',
+				runtimeRoot: directory,
+				recordLoadedModule: (url) => loadedModules.push(url),
+				recordModuleResolution: (specifier, referrer, resolvedUrl) =>
+					resolutions.push({ specifier, referrer, resolvedUrl }),
+				markNativeRuntime: () => (nativeRuntime = true),
+			});
+
+			expect(result.value).to.equal(42);
+			expect(result.selfValue).to.equal(84);
+			expect(loadedModules.some((url) => url.endsWith('/helper.js'))).to.equal(true);
+			expect(loadedModules.some((url) => url.endsWith('/self.js'))).to.equal(true);
+			expect(resolutions.some(({ specifier }) => specifier === '#helper')).to.equal(true);
+			expect(resolutions.some(({ specifier }) => specifier === 'app-local-imports/self')).to.equal(true);
+			expect(nativeRuntime).to.equal(false);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/unitTests/security/jsLoader/jsLoader.test.js
+++ b/unitTests/security/jsLoader/jsLoader.test.js
@@ -209,7 +209,14 @@ describe('pure-ESM package resolution', () => {
 	// createRequire().resolve() (CJS resolver) throws ERR_PACKAGE_PATH_NOT_EXPORTED for these;
 	// the fix returns the raw specifier so createModule() falls through to dynamic import().
 	it('should import a pure-ESM package (exports map with only "import" conditions, no "require")', async () => {
-		const result = await scopedImport(join(__dirname, 'fixtures', 'esm-only-test', 'uses-pure-esm-pkg.mjs'), vmScope());
+		const runtimeRoot = join(__dirname, 'fixtures', 'esm-only-test');
+		const resolutions = [];
+		const result = await scopedImport(join(runtimeRoot, 'uses-pure-esm-pkg.mjs'), {
+			...vmScope(),
+			runtimeRoot,
+			recordModuleResolution: (specifier) => resolutions.push(specifier),
+		});
 		expect(result.value).to.equal('esm-only');
+		expect(resolutions).not.to.include('pure-esm-pkg');
 	});
 });

--- a/unitTests/security/jsLoader/jsLoader.test.js
+++ b/unitTests/security/jsLoader/jsLoader.test.js
@@ -121,7 +121,7 @@ describe('scopedImport', () => {
 		expect(resolutions.some(({ specifier }) => specifier === './libgood.cjs')).to.equal(true);
 	});
 
-	it('keeps app-local package imports in the observable loader', async () => {
+	it('keeps app-local package imports observable unless native loading is explicit', async () => {
 		const directory = mkdtempSync(join(tmpdir(), 'harper-js-loader-imports-'));
 		try {
 			writeFileSync(
@@ -159,6 +159,17 @@ describe('scopedImport', () => {
 			expect(resolutions.some(({ specifier }) => specifier === '#helper')).to.equal(true);
 			expect(resolutions.some(({ specifier }) => specifier === 'app-local-imports/self')).to.equal(true);
 			expect(nativeRuntime).to.equal(false);
+
+			let explicitNativeRuntime = false;
+			const nativeResult = await scopedImport(join(directory, 'entry.js'), {
+				mode: 'vm-current-context',
+				runtimeRoot: directory,
+				dependencyLoader: 'native',
+				markNativeRuntime: () => (explicitNativeRuntime = true),
+			});
+			expect(nativeResult.value).to.equal(42);
+			expect(nativeResult.selfValue).to.equal(84);
+			expect(explicitNativeRuntime).to.equal(true);
 		} finally {
 			rmSync(directory, { recursive: true, force: true });
 		}

--- a/unitTests/server/static.test.js
+++ b/unitTests/server/static.test.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const assert = require('assert');
+const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = require('node:fs');
+const { join } = require('node:path');
+const { tmpdir } = require('node:os');
 const { handleApplication } = require('#src/server/static');
 
 // A minimal Scope stand-in: captures the http registration and warning log so tests can
@@ -187,6 +190,47 @@ describe('static plugin fallthrough: false warning', () => {
 });
 
 describe('static plugin ordering live reload', () => {
+	it('keeps a replacement with the same URL when the old absolute file unlinks afterward', () => {
+		const directory = mkdtempSync(join(tmpdir(), 'harper-static-identity-'));
+		const oldPath = join(directory, 'web', 'index.html');
+		const newPath = join(directory, 'dist', 'index.html');
+		mkdirSync(join(directory, 'web'), { recursive: true });
+		mkdirSync(join(directory, 'dist'), { recursive: true });
+		writeFileSync(oldPath, 'old');
+		writeFileSync(newPath, 'new');
+
+		try {
+			const { scope, state } = fakeScope();
+			handleApplication(scope);
+			const entry = (eventType, absolutePath) =>
+				state.entryCallback({ eventType, entryType: 'file', absolutePath, urlPath: '/index.html' });
+			entry('add', oldPath);
+			entry('add', newPath);
+			entry('unlink', oldPath);
+
+			const request = {
+				method: 'GET',
+				isWebSocket: false,
+				pathname: '/index.html',
+				url: '/index.html',
+				headers: {},
+			};
+			const fallthrough = Symbol('fallthrough');
+			assert.notStrictEqual(
+				state.listener(request, () => fallthrough),
+				fallthrough
+			);
+
+			entry('unlink', newPath);
+			assert.strictEqual(
+				state.listener(request, () => fallthrough),
+				fallthrough
+			);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
 	it('requests a restart when before or after changes', () => {
 		const { scope, state } = fakeScope();
 		handleApplication(scope);

--- a/unitTests/server/static.test.js
+++ b/unitTests/server/static.test.js
@@ -312,7 +312,7 @@ describe('static plugin ordering live reload', () => {
 		assert.equal(state.restartRequests, 1);
 	});
 
-	it('keeps serving the registered route while a urlPath restart is pending', () => {
+	it('applies removals but ignores additions while a urlPath restart is pending', () => {
 		const { scope, state } = fakeScope();
 		handleApplication(scope);
 		state.entryCallback({ eventType: 'add', entryType: 'file', absolutePath: __filename, urlPath: '/asset.js' });
@@ -322,9 +322,16 @@ describe('static plugin ordering live reload', () => {
 		state.entryCallback({ eventType: 'add', entryType: 'file', absolutePath: __filename, urlPath: '/new/asset.js' });
 
 		const fallthrough = Symbol('fallthrough');
-		assert.notStrictEqual(
+		assert.strictEqual(
 			state.listener(
 				{ method: 'GET', isWebSocket: false, pathname: '/asset.js', url: '/asset.js', headers: {} },
+				() => fallthrough
+			),
+			fallthrough
+		);
+		assert.strictEqual(
+			state.listener(
+				{ method: 'GET', isWebSocket: false, pathname: '/new/asset.js', url: '/new/asset.js', headers: {} },
 				() => fallthrough
 			),
 			fallthrough

--- a/unitTests/server/static.test.js
+++ b/unitTests/server/static.test.js
@@ -190,6 +190,30 @@ describe('static plugin fallthrough: false warning', () => {
 });
 
 describe('static plugin ordering live reload', () => {
+	it('removes a directory-owned index when index.html unlinks', () => {
+		const directory = mkdtempSync(join(tmpdir(), 'harper-static-index-unlink-'));
+		const indexPath = join(directory, 'index.html');
+		writeFileSync(indexPath, 'index');
+
+		try {
+			const { scope, state } = fakeScope();
+			handleApplication(scope);
+			state.entryCallback({ eventType: 'addDir', entryType: 'directory', absolutePath: directory, urlPath: '/' });
+			state.entryCallback({ eventType: 'add', entryType: 'file', absolutePath: indexPath, urlPath: '/index.html' });
+			rmSync(indexPath);
+			state.entryCallback({ eventType: 'unlink', entryType: 'file', absolutePath: indexPath, urlPath: '/index.html' });
+
+			const request = { method: 'GET', isWebSocket: false, pathname: '/', url: '/', headers: {} };
+			const fallthrough = Symbol('fallthrough');
+			assert.strictEqual(
+				state.listener(request, () => fallthrough),
+				fallthrough
+			);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
 	it('keeps a replacement with the same URL when the old absolute file unlinks afterward', () => {
 		const directory = mkdtempSync(join(tmpdir(), 'harper-static-identity-'));
 		const oldPath = join(directory, 'web', 'index.html');

--- a/unitTests/server/static.test.js
+++ b/unitTests/server/static.test.js
@@ -312,7 +312,7 @@ describe('static plugin ordering live reload', () => {
 		assert.equal(state.restartRequests, 1);
 	});
 
-	it('applies removals but ignores additions while a urlPath restart is pending', () => {
+	it('keeps the registered route while only a urlPath restart is pending', () => {
 		const { scope, state } = fakeScope();
 		handleApplication(scope);
 		state.entryCallback({ eventType: 'add', entryType: 'file', absolutePath: __filename, urlPath: '/asset.js' });
@@ -322,7 +322,7 @@ describe('static plugin ordering live reload', () => {
 		state.entryCallback({ eventType: 'add', entryType: 'file', absolutePath: __filename, urlPath: '/new/asset.js' });
 
 		const fallthrough = Symbol('fallthrough');
-		assert.strictEqual(
+		assert.notStrictEqual(
 			state.listener(
 				{ method: 'GET', isWebSocket: false, pathname: '/asset.js', url: '/asset.js', headers: {} },
 				() => fallthrough
@@ -336,6 +336,25 @@ describe('static plugin ordering live reload', () => {
 			),
 			fallthrough
 		);
+	});
+
+	it('applies file-selection removals while a urlPath restart is pending', () => {
+		const { scope, state } = fakeScope();
+		handleApplication(scope);
+		state.entryCallback({ eventType: 'add', entryType: 'file', absolutePath: __filename, urlPath: '/asset.js' });
+
+		scope.fireChange('urlPath');
+		scope.fireChange('files');
+		state.entryCallback({ eventType: 'unlink', entryType: 'file', absolutePath: __filename, urlPath: '/asset.js' });
+		state.entryCallback({ eventType: 'add', entryType: 'file', absolutePath: __filename, urlPath: '/new/asset.js' });
+
+		const fallthrough = Symbol('fallthrough');
+		for (const pathname of ['/asset.js', '/new/asset.js']) {
+			assert.strictEqual(
+				state.listener({ method: 'GET', isWebSocket: false, pathname, url: pathname, headers: {} }, () => fallthrough),
+				fallthrough
+			);
+		}
 	});
 
 	it('does not request a restart for options read per-request', () => {

--- a/unitTests/server/static.test.js
+++ b/unitTests/server/static.test.js
@@ -312,6 +312,25 @@ describe('static plugin ordering live reload', () => {
 		assert.equal(state.restartRequests, 1);
 	});
 
+	it('keeps serving the registered route while a urlPath restart is pending', () => {
+		const { scope, state } = fakeScope();
+		handleApplication(scope);
+		state.entryCallback({ eventType: 'add', entryType: 'file', absolutePath: __filename, urlPath: '/asset.js' });
+
+		scope.fireChange('urlPath');
+		state.entryCallback({ eventType: 'unlink', entryType: 'file', absolutePath: __filename, urlPath: '/asset.js' });
+		state.entryCallback({ eventType: 'add', entryType: 'file', absolutePath: __filename, urlPath: '/new/asset.js' });
+
+		const fallthrough = Symbol('fallthrough');
+		assert.notStrictEqual(
+			state.listener(
+				{ method: 'GET', isWebSocket: false, pathname: '/asset.js', url: '/asset.js', headers: {} },
+				() => fallthrough
+			),
+			fallthrough
+		);
+	});
+
 	it('does not request a restart for options read per-request', () => {
 		const { scope, state } = fakeScope();
 		handleApplication(scope);

--- a/unitTests/server/static.test.js
+++ b/unitTests/server/static.test.js
@@ -231,6 +231,47 @@ describe('static plugin ordering live reload', () => {
 		}
 	});
 
+	it('restores a surviving colliding file when the active file unlinks', () => {
+		const directory = mkdtempSync(join(tmpdir(), 'harper-static-collision-'));
+		const oldPath = join(directory, 'web', 'index.html');
+		const newPath = join(directory, 'dist', 'index.html');
+		mkdirSync(join(directory, 'web'), { recursive: true });
+		mkdirSync(join(directory, 'dist'), { recursive: true });
+		writeFileSync(oldPath, 'old');
+		writeFileSync(newPath, 'new');
+
+		try {
+			const { scope, state } = fakeScope();
+			handleApplication(scope);
+			const entry = (eventType, absolutePath) =>
+				state.entryCallback({ eventType, entryType: 'file', absolutePath, urlPath: '/index.html' });
+			entry('add', oldPath);
+			entry('add', newPath);
+			entry('unlink', newPath);
+
+			const request = {
+				method: 'GET',
+				isWebSocket: false,
+				pathname: '/index.html',
+				url: '/index.html',
+				headers: {},
+			};
+			const fallthrough = Symbol('fallthrough');
+			assert.notStrictEqual(
+				state.listener(request, () => fallthrough),
+				fallthrough
+			);
+
+			entry('unlink', oldPath);
+			assert.strictEqual(
+				state.listener(request, () => fallthrough),
+				fallthrough
+			);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
 	it('requests a restart when before or after changes', () => {
 		const { scope, state } = fakeScope();
 		handleApplication(scope);


### PR DESCRIPTION
## Summary

Closes #1934 and restores the `scope.handleEntry()` event contract that regressed in #1806 while preserving the new-component fix for #674.

Component deploys pause file watchers while replacing the component tree. When the watcher resumed, chokidar performed a fresh scan and reported every surviving file as `add`, reported no deleted files, and made unchanged and modified files indistinguishable. Fixing that separately in each consumer would preserve the incompatible watcher behavior and duplicate incomplete state tracking.

## Fix

`EntryHandler` now retains a compact snapshot and compares every replacement watcher generation with the last consumer-observed state:

- unchanged files and directories remain silent
- modified files emit `change` with their new contents
- new paths emit `add` / `addDir`
- removed paths emit `unlink` / `unlinkDir`, with descendants emitted before their directory
- file/directory type changes emit the old removal followed by the new addition

Snapshots retain path metadata and SHA-256 file digests, not file contents. Watcher generations and per-path sequences prevent callbacks or slow reads from an obsolete generation from emitting events or polluting the new snapshot. Entries emitted by an interrupted initial scan are carried into the next generation, and `ready` is generation-scoped and fires only after the scan and all of that generation's reads complete.

Restart-free redeploys now require layered runtime-equivalence evidence:

- the JS loader records every application-local module actually loaded plus its resolution edges, including transitive relative imports, package imports/self-references, pure-ESM export targets, and extensionless resolution candidates
- native addons delegate to Node's `.node` loader in CJS, ESM, and compartment modes and conservatively make the runtime restart-required
- package metadata is compared after installation; custom/opaque installs, install scripts, bundled `node_modules`, and unlocked dependency installs fail closed
- extraction and installation are one transaction, retaining the previous component tree until preparation succeeds and restoring it after extraction or install failure

Deploy lifecycle events carry a deployment UUID and owner thread. If the owner worker exits, peers ignore late messages, wait until the worker and its installer process groups are confirmed gone, then reclaim the exact orphaned deployment and resume paused scopes. Overlapping live deployments remain gated.

The consumer-specific redeploy workaround is removed from `jsResource`; `loadEnv`, Fastify routes, JS resources, static files, roles, and plugin `handleEntry` users receive the corrected central events without a new API. Static path ownership is updated incrementally so restart-free static-only deploys serve the replacement content immediately.

## Validation

- `npm run build`
- `npm run lint:required`
- `npm run test:types`
- focused unit suites: green (latest lifecycle/Scope/thread tests: 47 passing; broader redeploy-focused run: 134 passing)
- live Harper deploy proof: **22/22 passing** across four suites
  - identical deploy remains restart-free
  - changed static asset is served immediately without restart
  - transitive relative/package imports, pure-ESM exports retargeting, and extensionless resolution changes require restart
  - package formatting/key order remains restart-free; changed installed dependencies require restart
  - failed install restores the prior on-disk tree and live resource
  - code/resource deletion cases set `restartRequired`
- full integration suite previously completed with 1,643 passing, 0 failures, 6 cancelled, and 20 skipped; the nonzero exit was the existing optional Ollama setup incompatibility under local Node 26 (`ERR_IMPORT_ATTRIBUTE_MISSING` for `json/systemSchema.json`), with those files unchanged

## Review coverage

Author: Codex. Standard `cross-model-review/bin/prepush-review.mjs` route run repeatedly in exact-commit delta mode with independent Claude, Gemini, Grok, and Harper-domain adjudication. The final exact-head review of `f7be8aff1` reports **LGTM** with no new blocker or major regression.

Review findings fixed and regression-tested include stale watcher generations, suppressed restart requests, post-install package evidence, transitive runtime modules/resolution cache invalidation, pure-ESM and native-addon loading, transactional rollback under a live writer, deploy-aware load timing, static URL ownership, and dead deploy-owner/process-group reclamation.

_PR implementation generated by Codex._
