### PR TITLE
fix(mcp): list verb tools for table-less Resources to any authenticated user

### DIFF
--- a/components/mcp/toolRegistry.ts
+++ b/components/mcp/toolRegistry.ts
@@ -363,6 +363,16 @@ export function isSuperUser(user: AuthedUser | undefined): boolean {
 }
 
 /**
+ * True if the request carries an authenticated principal. Anonymous MCP sessions are a supported
+ * deployment (the public-docs case, #1609) — the adapter hands them through as `{ username: '' }`
+ * rather than rejecting them — so a listing filter that means "any real user" has to test for this
+ * explicitly. `user?.role` is not a proxy: an authenticated user may legitimately carry no role.
+ */
+export function isAuthenticated(user: AuthedUser | undefined): boolean {
+	return typeof user?.username === 'string' && user.username.length > 0;
+}
+
+/**
  * Class-level verb introspection. Mirrors `resources/openApi.ts:149-153` so
  * a class is considered to "have" a verb only if its prototype overrides the
  * base Resource implementation. Note that `post`'s default in Harper's

--- a/components/mcp/tools/application.ts
+++ b/components/mcp/tools/application.ts
@@ -27,6 +27,7 @@ import harperLogger from '../../../utility/logging/harper_logger.ts';
 import {
 	addTool,
 	clearProfileTools,
+	isAuthenticated,
 	snapshotProfileTools,
 	type AuthedUser,
 	type ToolCallContext,
@@ -710,10 +711,15 @@ function makeVisibleTo(
 		if (user?.role?.permission?.super_user === true) return true;
 		// A Resource with no backing table has no static permission gate to consult, so listing is
 		// open to any authenticated caller and the Resource's own `allow*` predicates enforce at call
-		// time. This matches custom `mcpTools`, which have never had a listing filter beyond
-		// authentication — and hiding these while still accepting `tools/call` on them bought no
-		// security, only undiscoverable tools (#1940).
-		if (!databaseName || !tableName) return true;
+		// time — hiding these while still accepting `tools/call` on them bought no security, only
+		// undiscoverable tools (#1940).
+		//
+		// Anonymous sessions stay excluded. They are a supported deployment (#1609) and reach here as
+		// `{ username: '' }`, so this must be tested explicitly. Custom `mcpTools` DO list to them, but
+		// that is an author opt-in — declaring `static mcpTools` is a deliberate act of publishing.
+		// Verb tools are generated for every exported Resource with no author action, so publishing an
+		// app's field names and docstrings to unauthenticated callers by default is not equivalent.
+		if (!databaseName || !tableName) return isAuthenticated(user);
 		const perm = getUserTablePermissions(user, databaseName, tableName);
 		if (!perm) return false;
 		if (mode === 'read') return perm.read === true || perm.describe === true;

--- a/components/mcp/tools/application.ts
+++ b/components/mcp/tools/application.ts
@@ -708,11 +708,12 @@ function makeVisibleTo(
 	return function visibleTo(user: AuthedUser): boolean {
 		// Super-user sees everything.
 		if (user?.role?.permission?.super_user === true) return true;
-		// Non-table Resources have no static permission gate — runtime allow*
-		// predicates enforce. Conservative default: don't list them for
-		// non-super users; they can still call via tools/call if they know
-		// the tool name (pass-through is documented behavior).
-		if (!databaseName || !tableName) return false;
+		// A Resource with no backing table has no static permission gate to consult, so listing is
+		// open to any authenticated caller and the Resource's own `allow*` predicates enforce at call
+		// time. This matches custom `mcpTools`, which have never had a listing filter beyond
+		// authentication — and hiding these while still accepting `tools/call` on them bought no
+		// security, only undiscoverable tools (#1940).
+		if (!databaseName || !tableName) return true;
 		const perm = getUserTablePermissions(user, databaseName, tableName);
 		if (!perm) return false;
 		if (mode === 'read') return perm.read === true || perm.describe === true;

--- a/unitTests/components/mcp/tools/application.test.js
+++ b/unitTests/components/mcp/tools/application.test.js
@@ -333,9 +333,11 @@ describe('mcp/tools/application — registration', () => {
 
 	it('lists verb tools for a table-less Resource to any authenticated user (#1940)', () => {
 		// No databaseName/tableName means no static permission gate to consult, so listing is open and
-		// the Resource's own allow* predicates enforce at call time — the same contract custom
-		// `mcpTools` have always had. Hiding these while still accepting tools/call bought no security.
+		// the Resource's own allow* predicates enforce at call time. Hiding these while still accepting
+		// tools/call bought no security — visibleTo is not consulted at call time.
 		const Inventory = makeTableResource({
+			databaseName: undefined,
+			tableName: undefined,
 			primaryKey: 'sku',
 			attributes: [{ name: 'sku', type: 'String', isPrimaryKey: true }],
 		});
@@ -347,6 +349,20 @@ describe('mcp/tools/application — registration', () => {
 			assert.equal(tool.visibleTo(NOBODY), true, `${name} is listed for a user with no table grants`);
 			assert.equal(tool.visibleTo(SUPER), true, `${name} is listed for super_user`);
 		}
+	});
+
+	it('does NOT list a table-less Resource to an anonymous session (#1940)', () => {
+		// Anonymous MCP sessions are supported (#1609) and reach visibleTo as `{ username: '' }` —
+		// `user?.role?...` optional-chains straight past the super-user check, so without an explicit
+		// test the table-less branch would publish every app Resource's field names and docstrings to
+		// unauthenticated callers on the application port.
+		const Inventory = makeTableResource({ databaseName: undefined, tableName: undefined, primaryKey: 'sku' });
+		_setResourcesForTest(makeRegistry([['Inventory', { Resource: Inventory }]]));
+		registerApplicationTools();
+		const tool = getTool('get_Inventory');
+		assert.equal(tool.visibleTo({ username: '' }), false, 'anonymous session (empty username)');
+		assert.equal(tool.visibleTo(undefined), false, 'no user object at all');
+		assert.equal(tool.visibleTo({}), false, 'user object with no username');
 	});
 
 	it('still gates a table-backed Resource by table permissions after #1940', () => {

--- a/unitTests/components/mcp/tools/application.test.js
+++ b/unitTests/components/mcp/tools/application.test.js
@@ -331,6 +331,33 @@ describe('mcp/tools/application — registration', () => {
 		assert.equal(update.visibleTo(ALICE_WRITE), true);
 	});
 
+	it('lists verb tools for a table-less Resource to any authenticated user (#1940)', () => {
+		// No databaseName/tableName means no static permission gate to consult, so listing is open and
+		// the Resource's own allow* predicates enforce at call time — the same contract custom
+		// `mcpTools` have always had. Hiding these while still accepting tools/call bought no security.
+		const Inventory = makeTableResource({
+			primaryKey: 'sku',
+			attributes: [{ name: 'sku', type: 'String', isPrimaryKey: true }],
+		});
+		_setResourcesForTest(makeRegistry([['Inventory', { Resource: Inventory }]]));
+		registerApplicationTools();
+		for (const name of ['get_Inventory', 'search_Inventory', 'create_Inventory', 'delete_Inventory']) {
+			const tool = getTool(name);
+			assert.ok(tool, `${name} registered`);
+			assert.equal(tool.visibleTo(NOBODY), true, `${name} is listed for a user with no table grants`);
+			assert.equal(tool.visibleTo(SUPER), true, `${name} is listed for super_user`);
+		}
+	});
+
+	it('still gates a table-backed Resource by table permissions after #1940', () => {
+		// Guards against the #1940 change leaking into the table-backed path.
+		const Product = makeTableResource({ databaseName: 'data', tableName: 'product' });
+		_setResourcesForTest(makeRegistry([['Product', { Resource: Product }]]));
+		registerApplicationTools();
+		assert.equal(getTool('get_Product').visibleTo(NOBODY), false);
+		assert.equal(getTool('delete_Product').visibleTo(ALICE_READ), false);
+	});
+
 	it('flags delete_ tools as destructive and get_/search_ as readOnly', () => {
 		const Product = makeTableResource({ databaseName: 'data', tableName: 'product' });
 		_setResourcesForTest(makeRegistry([['Product', { Resource: Product }]]));


### PR DESCRIPTION
Closes #1940.

## Problem

`makeVisibleTo` gated `tools/list` visibility on the Resource having a backing database and table:

```ts
if (!databaseName || !tableName) return false;
```

A purely programmatic Resource — a `Resource` subclass overriding the verbs, or one aggregating across tables — has neither, so **no non-super user saw any of its verb tools**. That is precisely the class of Resource #1920/#1921 just taught to emit rich `inputSchema` / `outputSchema`, so the feature was invisible to the realistic MCP caller.

The gate also bought no access control. `tools/call` does not consult `visibleTo` — `toolRegistry.ts`'s own docblock says so ("explicitly NOT a security boundary") and `transport.ts` dispatches straight from `getTool(name, profile)` to the handler, with an existing pass-through test for a hallucinated name. So hiding these tools cost discoverability and nothing else.

## Change

Table-less Resources are listed to any **authenticated** caller; their `allow*` predicates enforce at call time. Table-backed Resources are untouched — still `getUserTablePermissions` per mode.

## Two corrections to my first commit (review found both)

**The first commit returned `true` unconditionally, which included anonymous callers.** `tools/list` has no auth gate: the MCP handler mounts `{ after: 'authentication' }`, which is ordering, not a requirement, so an unauthenticated request arrives as `{ username: '' }` and optional-chains past the super-user check. Every exported programmatic Resource's field names, docstrings, and `enum` values would have been published to anyone who could reach the application port. Fixed in `8a8eb36ff` with an explicit `isAuthenticated` helper, plus a regression test covering `{ username: '' }`, `undefined`, and `{}`.

**The "parity with custom `mcpTools`" argument was too broad** and I've dropped it. Custom tools do list to anonymous sessions — deliberately, for the public-docs case (#1609) — but declaring `static mcpTools` is an author opt-in, a conscious act of publishing. Verb tools are generated for every exported Resource with no author action, so the defaults are not equivalent and shouldn't be aligned by pointing at each other.

## Where to look

- **The authenticated-vs-anonymous line is the security judgment.** Authenticated users with zero grants now see descriptors (names, descriptions, property descriptions, `enum` values) for table-less Resources they previously couldn't enumerate. Data access is unchanged — that was always the `allow*` predicates' job — but descriptor *text* is a real disclosure surface: a `withSchema` contract copies author-declared property schemas verbatim, and an `enum` can encode business data (tenant codes, tier names). If you'd rather this be opt-in rather than opt-out, say so and I'll switch it to a `static mcp` flag.
- Three tests: table-less Resource listed to a no-grants user across four verbs; the anonymous case; and a guard that the table-backed path still denies.

Full MCP unit suite (477 tests) passes.

## Related, not fixed here

Review also surfaced that `detectVerbs` manufactures a `create_*` tool for **every** `Resource` subclass — it checks `typeof p.post === 'function'` with no base-prototype comparison, unlike `hasClassLevelVerbs` one file over — which reaches Harper's own `login` Resource. Filed as #1945; independent of this change (that's about which tools exist, this is about who sees them).

Docs follow-up in [documentation#605](https://github.com/HarperFast/documentation/pull/605), which documents the old super-user-only behavior.

_PR description generated by kAIle (Claude Opus 4.8)._