### PR TITLE
fix(mcp/openapi): share one schema emitter so the two surfaces stop diverging

### DIFF
--- a/components/mcp/resources.ts
+++ b/components/mcp/resources.ts
@@ -38,6 +38,7 @@ import harperLogger from '../../utility/logging/harper_logger.ts';
 import { AccessViolation } from '../../utility/errors/hdbError.ts';
 import { SERVER_CAPABILITIES, SERVER_INFO, SUPPORTED_PROTOCOL_VERSIONS } from './lifecycle.ts';
 import { encodeCursor } from './pagination.ts';
+import { resolveAttributes } from '../../resources/jsonSchemaTypes.ts';
 import {
 	customResourceCompletionValues,
 	listCustomResources,
@@ -820,7 +821,9 @@ function readTableSchema(db: string, table: string, user: AuthedUser, href: stri
 		}
 	}
 	if (!resource) return { ok: false, reason: `table not found: ${db}.${table}` };
-	const attributes = resource.attributes ?? [];
+	// Fall back to a programmatic Resource's `static properties` when it declares no attributes Array,
+	// so schema introspection matches the tool/OpenAPI surfaces.
+	const attributes = resolveAttributes(resource);
 	const filteredAttributes = filterAttributesByPermissions(attributes, perm?.attribute_permissions);
 	const body = {
 		database: db,

--- a/components/mcp/tools/application.ts
+++ b/components/mcp/tools/application.ts
@@ -49,6 +49,7 @@ import {
 } from '../customResourceRegistry.ts';
 import { notifyPromptsListChanged, notifyResourcesListChanged, notifyToolsListChanged } from '../listChanged.ts';
 import { decodeCursor, encodeCursor } from '../pagination.ts';
+import { resolveAttributes } from '../../../resources/jsonSchemaTypes.ts';
 import {
 	type AttributePermissionEntry,
 	type HarperAttribute,
@@ -1356,7 +1357,9 @@ function buildApplicationTools(resources: ResourcesRegistry): void {
 		const tableName = ResourceClass?.tableName;
 		const suffix = uniqueSuffix(path, databaseName, claimedSuffixes);
 		claimedSuffixes.add(suffix);
-		const attributes = (ResourceClass?.attributes ?? []) as HarperAttribute[];
+		// A programmatic Resource may declare `static properties` without an `attributes` Array; resolve
+		// the effective attributes so its verb tools get a rich inputSchema instead of a skeletal one.
+		const attributes = resolveAttributes(ResourceClass) as HarperAttribute[];
 		if (hasVerbs) {
 			toolsRegistered += registerVerbTools({
 				path,

--- a/components/mcp/tools/schemas/derive.ts
+++ b/components/mcp/tools/schemas/derive.ts
@@ -25,6 +25,10 @@ export interface HarperAttribute {
 	assignCreatedTime?: boolean;
 	assignUpdatedTime?: boolean;
 	expiresAt?: boolean;
+	// JSON-Schema hints a programmatic Resource may carry via `static properties`.
+	enum?: readonly (string | number | boolean | null)[];
+	format?: string;
+	const?: unknown;
 }
 
 export interface AttributePermissionEntry {
@@ -63,6 +67,16 @@ function harperTypeToJsonSchema(type: string | undefined): { type: string | stri
 		case 'Any':
 		case undefined:
 			return {};
+		case 'string':
+		case 'integer':
+		case 'number':
+		case 'boolean':
+		case 'object':
+		case 'array':
+		case 'null':
+			// A programmatic Resource's `static properties` already speaks JSON Schema (lowercase types,
+			// no collision with Harper's capitalized GraphQL types); pass those through unchanged.
+			return { type };
 		default:
 			return { type: 'string' };
 	}
@@ -97,6 +111,9 @@ function attributeToProperty(attr: HarperAttribute): object {
 	if (attr.description && !base.description) {
 		base.description = attr.description;
 	}
+	if (attr.enum && !('enum' in base)) base.enum = attr.enum;
+	if (attr.format && !('format' in base)) base.format = attr.format;
+	if (attr.const !== undefined && !('const' in base)) base.const = attr.const;
 	return base;
 }
 

--- a/components/mcp/tools/schemas/derive.ts
+++ b/components/mcp/tools/schemas/derive.ts
@@ -19,6 +19,8 @@ export interface HarperAttribute {
 	description?: string;
 	hidden?: boolean;
 	nullable?: boolean;
+	/** Source JSON-Schema type union from `static properties`; MCP accepts type arrays, so it passes through. */
+	types?: readonly string[];
 	isPrimaryKey?: boolean;
 	properties?: HarperAttribute[];
 	elements?: HarperAttribute;
@@ -97,6 +99,10 @@ function attributeToProperty(attr: HarperAttribute): object {
 			type: 'array',
 			items: attributeToProperty(attr.elements),
 		};
+	} else if (attr.types) {
+		// MCP speaks JSON Schema, which has type unions — emit the author's union as declared rather
+		// than the single `type` the attribute form collapses to.
+		base = { type: [...attr.types] };
 	} else {
 		base = harperTypeToJsonSchema(attr.type) as typeof base;
 	}

--- a/components/mcp/tools/schemas/derive.ts
+++ b/components/mcp/tools/schemas/derive.ts
@@ -11,6 +11,8 @@
  * doesn't waste tokens on fields it can't write), NOT a security boundary.
  */
 
+import { JSON_SCHEMA_SCALAR_TYPES } from '../../../../resources/jsonSchemaTypes.ts';
+
 export interface HarperAttribute {
 	name: string;
 	type?: string;
@@ -29,6 +31,8 @@ export interface HarperAttribute {
 	enum?: readonly (string | number | boolean | null)[];
 	format?: string;
 	const?: unknown;
+	required?: readonly string[];
+	additionalProperties?: boolean;
 }
 
 export interface AttributePermissionEntry {
@@ -46,6 +50,9 @@ type Mode = 'read' | 'insert' | 'update';
  * than blocking the field entirely; the runtime will validate.
  */
 function harperTypeToJsonSchema(type: string | undefined): { type: string | string[] } | object {
+	// A programmatic Resource's `static properties` already speaks JSON Schema (lowercase types, no
+	// collision with Harper's capitalized GraphQL types); pass those through unchanged.
+	if (type && JSON_SCHEMA_SCALAR_TYPES.has(type)) return { type };
 	switch (type) {
 		case 'Int':
 		case 'Long':
@@ -67,16 +74,6 @@ function harperTypeToJsonSchema(type: string | undefined): { type: string | stri
 		case 'Any':
 		case undefined:
 			return {};
-		case 'string':
-		case 'integer':
-		case 'number':
-		case 'boolean':
-		case 'object':
-		case 'array':
-		case 'null':
-			// A programmatic Resource's `static properties` already speaks JSON Schema (lowercase types,
-			// no collision with Harper's capitalized GraphQL types); pass those through unchanged.
-			return { type };
 		default:
 			return { type: 'string' };
 	}
@@ -93,6 +90,8 @@ function attributeToProperty(attr: HarperAttribute): object {
 			type: 'object',
 			properties: Object.fromEntries(attr.properties.map((p) => [p.name, attributeToProperty(p)])),
 		};
+		if (attr.required) base.required = attr.required;
+		if (attr.additionalProperties !== undefined) base.additionalProperties = attr.additionalProperties;
 	} else if (attr.type === 'array' && attr.elements) {
 		base = {
 			type: 'array',

--- a/components/mcp/tools/schemas/derive.ts
+++ b/components/mcp/tools/schemas/derive.ts
@@ -55,7 +55,10 @@ type Mode = 'read' | 'insert' | 'update';
  * types when nullable). Falls back to "string" for unknown types — better
  * than blocking the field entirely; the runtime will validate.
  */
-function harperTypeToJsonSchema(type: string | undefined): { type: string | string[] } | object {
+function harperTypeToJsonSchema(
+	type: string | undefined,
+	attributeName?: string
+): { type: string | string[] } | object {
 	// A programmatic Resource's `static properties` already speaks JSON Schema (lowercase types, no
 	// collision with Harper's capitalized GraphQL types); pass those through unchanged.
 	if (type && JSON_SCHEMA_SCALAR_TYPES.has(type)) return { type };
@@ -84,7 +87,7 @@ function harperTypeToJsonSchema(type: string | undefined): { type: string | stri
 			// Neither a Harper type nor a JSON Schema type. This used to coerce to `string` while OpenAPI
 			// emitted `{}` — two different wrong answers from one typo. Warn (once per name) and emit
 			// untyped, matching OpenAPI (#1942).
-			const resolved = resolveDeclaredType(type, 'an MCP tool schema');
+			const resolved = resolveDeclaredType(type, `MCP tool schema property "${attributeName ?? '<unnamed>'}"`);
 			return resolved ? { type: resolved } : {};
 		}
 	}
@@ -100,8 +103,24 @@ function harperTypeToJsonSchema(type: string | undefined): { type: string | stri
 function attributeToProperty(attr: HarperAttribute): object | undefined {
 	return attributeToSchema(attr as AttributeLike, {
 		dialect: 'json-schema',
-		mapPrimitive: (type) => harperTypeToJsonSchema(type) as JsonSchemaFragment,
+		mapPrimitive: (type, a) => harperTypeToJsonSchema(type, a.name) as JsonSchemaFragment,
 	});
+}
+
+/**
+ * The `id` argument's schema. Verb tools surface the primary key as the record's address, not as one
+ * of its fields, so a `@hidden` primary key still has to be typed here — otherwise the tool advertises
+ * a required argument with no type at all. Falls back only when there is no primary key to describe.
+ */
+function primaryKeySchema(pk: HarperAttribute | undefined): object {
+	if (!pk) return { type: 'string' };
+	return (
+		attributeToSchema(pk as AttributeLike, {
+			dialect: 'json-schema',
+			mapPrimitive: (type, a) => harperTypeToJsonSchema(type, a.name) as JsonSchemaFragment,
+			ignoreHidden: true,
+		}) ?? { type: 'string' }
+	);
 }
 
 /**
@@ -174,7 +193,7 @@ export function deriveGetSchema(
 	_permissions: AttributePermissionEntry[] | undefined
 ): object {
 	const pk = findPrimaryKey(attributes);
-	const pkSchema = (pk && attributeToProperty(pk)) ?? { type: 'string' };
+	const pkSchema = primaryKeySchema(pk);
 	return {
 		type: 'object',
 		properties: {
@@ -262,7 +281,7 @@ export function deriveUpdateSchema(
 		type: 'object',
 		properties: {
 			id: pk
-				? { ...attributeToProperty(pk), description: `Primary key (${pk.name}). Required.` }
+				? { ...primaryKeySchema(pk), description: `Primary key (${pk.name}). Required.` }
 				: { type: 'string', description: 'Primary key. Required.' },
 			...properties,
 		},
@@ -279,7 +298,7 @@ export function deriveDeleteSchema(
 		type: 'object',
 		properties: {
 			id: pk
-				? { ...attributeToProperty(pk), description: `Primary key (${pk.name}).` }
+				? { ...primaryKeySchema(pk), description: `Primary key (${pk.name}).` }
 				: { type: 'string', description: 'Primary key.' },
 		},
 		required: ['id'],
@@ -361,7 +380,7 @@ export function deriveCreateOutputSchema(
 	_permissions: AttributePermissionEntry[] | undefined
 ): object {
 	const pk = findPrimaryKey(attributes);
-	const idSchema = (pk && attributeToProperty(pk)) ?? { type: 'string' };
+	const idSchema = primaryKeySchema(pk);
 	return {
 		type: 'object',
 		properties: {

--- a/components/mcp/tools/schemas/derive.ts
+++ b/components/mcp/tools/schemas/derive.ts
@@ -11,7 +11,13 @@
  * doesn't waste tokens on fields it can't write), NOT a security boundary.
  */
 
-import { JSON_SCHEMA_SCALAR_TYPES } from '../../../../resources/jsonSchemaTypes.ts';
+import {
+	JSON_SCHEMA_SCALAR_TYPES,
+	attributeToSchema,
+	resolveDeclaredType,
+	type AttributeLike,
+	type JsonSchemaFragment,
+} from '../../../../resources/jsonSchemaTypes.ts';
 
 export interface HarperAttribute {
 	name: string;
@@ -74,46 +80,28 @@ function harperTypeToJsonSchema(type: string | undefined): { type: string | stri
 		case 'Any':
 		case undefined:
 			return {};
-		default:
-			return { type: 'string' };
+		default: {
+			// Neither a Harper type nor a JSON Schema type. This used to coerce to `string` while OpenAPI
+			// emitted `{}` — two different wrong answers from one typo. Warn (once per name) and emit
+			// untyped, matching OpenAPI (#1942).
+			const resolved = resolveDeclaredType(type, 'an MCP tool schema');
+			return resolved ? { type: resolved } : {};
+		}
 	}
 }
 
-function attributeToProperty(attr: HarperAttribute): object {
-	let base: { type?: string | string[]; description?: string; [key: string]: unknown };
-	// The GraphQL parser emits nested objects via `.properties` (not a capitalized `'Object'` type) and
-	// list types as lowercase `type: 'array'` with `.elements` — the prior `'Object'`/`'Array'` literal
-	// checks never matched, so nested shapes fell through to a bare `{ type: 'string' }`. Detect them the
-	// way the parser actually emits, matching the shared `attributeToFragment` projector.
-	if (attr.properties) {
-		base = {
-			type: 'object',
-			properties: Object.fromEntries(attr.properties.map((p) => [p.name, attributeToProperty(p)])),
-		};
-		if (attr.required) base.required = attr.required;
-		if (attr.additionalProperties !== undefined) base.additionalProperties = attr.additionalProperties;
-	} else if (attr.type === 'array' && attr.elements) {
-		base = {
-			type: 'array',
-			items: attributeToProperty(attr.elements),
-		};
-	} else {
-		base = harperTypeToJsonSchema(attr.type) as typeof base;
-	}
-	if (attr.nullable && 'type' in base) {
-		const t = base.type;
-		const types = Array.isArray(t) ? t : [t as string];
-		if (!types.includes('null')) {
-			base.type = [...types, 'null'];
-		}
-	}
-	if (attr.description && !base.description) {
-		base.description = attr.description;
-	}
-	if (attr.enum && !('enum' in base)) base.enum = attr.enum;
-	if (attr.format && !('format' in base)) base.format = attr.format;
-	if (attr.const !== undefined && !('const' in base)) base.const = attr.const;
-	return base;
+/**
+ * Emit an attribute as an MCP property schema. The traversal (nesting, arrays, `hidden` suppression,
+ * hint propagation, nullability) is shared with the OpenAPI generator so the two can't describe the
+ * same fragment differently; only the Harper-primitive mapping below is MCP-specific.
+ *
+ * Returns `undefined` for a `hidden` attribute — callers skip it.
+ */
+function attributeToProperty(attr: HarperAttribute): object | undefined {
+	return attributeToSchema(attr as AttributeLike, {
+		dialect: 'json-schema',
+		mapPrimitive: (type) => harperTypeToJsonSchema(type) as JsonSchemaFragment,
+	});
 }
 
 /**
@@ -167,7 +155,9 @@ function buildPropertiesObject(
 		// Skip auto-managed columns from write inputs — Harper assigns them.
 		if (mode !== 'read' && (attr.assignCreatedTime || attr.assignUpdatedTime || attr.expiresAt)) continue;
 		if (mode !== 'read' && (attr.computed !== undefined || attr.computedFromExpression !== undefined)) continue;
-		properties[attr.name] = attributeToProperty(attr);
+		const schema = attributeToProperty(attr);
+		if (!schema) continue;
+		properties[attr.name] = schema;
 		if (mode === 'insert' && !attr.nullable && !attr.isPrimaryKey) {
 			required.push(attr.name);
 		}
@@ -184,7 +174,7 @@ export function deriveGetSchema(
 	_permissions: AttributePermissionEntry[] | undefined
 ): object {
 	const pk = findPrimaryKey(attributes);
-	const pkSchema = pk ? attributeToProperty(pk) : { type: 'string' };
+	const pkSchema = (pk && attributeToProperty(pk)) ?? { type: 'string' };
 	return {
 		type: 'object',
 		properties: {
@@ -317,7 +307,9 @@ function deriveRecordSchema(
 	const required: string[] = [];
 	for (const attr of attributes) {
 		if (!attributeVisible(attr, permissions, 'read')) continue;
-		properties[attr.name] = attributeToProperty(attr);
+		const schema = attributeToProperty(attr);
+		if (!schema) continue;
+		properties[attr.name] = schema;
 		const requiredOnOutput =
 			attr.nullable === false || attr.assignCreatedTime || attr.assignUpdatedTime || attr.isPrimaryKey;
 		if (requiredOnOutput) required.push(attr.name);
@@ -369,7 +361,7 @@ export function deriveCreateOutputSchema(
 	_permissions: AttributePermissionEntry[] | undefined
 ): object {
 	const pk = findPrimaryKey(attributes);
-	const idSchema = pk ? attributeToProperty(pk) : { type: 'string' };
+	const idSchema = (pk && attributeToProperty(pk)) ?? { type: 'string' };
 	return {
 		type: 'object',
 		properties: {

--- a/integrationTests/resources/openapi-static-properties.test.mjs
+++ b/integrationTests/resources/openapi-static-properties.test.mjs
@@ -1,0 +1,106 @@
+/**
+ * OpenAPI emission for a programmatic Resource's `static properties` (#1941/#1942).
+ *
+ * The existing `apiTests/open-api.test.mjs` asserts the document's *structure* — that `paths` and
+ * `components.schemas` exist. Nothing asserted the emitted property schemas, so a wrong `nullable`, a
+ * leaked `@hidden` field, or a dropped nested `enum` would ship green. These emitter behaviors are
+ * per-surface and easy to regress silently, so they are pinned against the real document here.
+ *
+ * Skipped on Windows for the same reason as the sibling suite: `restart_service http_workers` after a
+ * component install crashes Harper on the single-worker model (HarperFast/harper#549).
+ */
+import { suite, test, before, after } from 'node:test';
+import assert from 'node:assert';
+import { startHarper, teardownHarper } from '@harperfast/integration-testing';
+import { createApiClient } from '../apiTests/utils/client.mjs';
+import { installAppComponent } from '../apiTests/utils/components.mjs';
+
+const RESOURCES_JS = `export class OrderSummary extends Resource {
+\tstatic description = 'Rolled-up order totals.';
+\tstatic primaryKey = 'orderId';
+\tstatic properties = {
+\t\torderId: { type: 'string', primaryKey: true, description: 'Order id.' },
+\t\tstatus: { type: 'string', enum: ['open', 'closed'], description: 'Fulfillment state.' },
+\t\tnote: { type: ['string', 'null'], description: 'Nullable note.' },
+\t\tprofile: {
+\t\t\ttype: 'object',
+\t\t\tproperties: {
+\t\t\t\tname: { type: 'string', description: 'Visible name.' },
+\t\t\t\tcreditScore: { type: 'integer', hidden: true, description: 'INTERNAL-ONLY-MARKER' },
+\t\t\t},
+\t\t\trequired: ['name', 'creditScore'],
+\t\t},
+\t\tallHidden: { type: 'object', properties: { secret: { type: 'string', hidden: true } }, required: ['secret'] },
+\t\ttags: { type: 'array', items: { type: 'string', enum: ['x', 'y'], description: 'Tag.' } },
+\t};
+\tget() {
+\t\treturn { orderId: 'o1' };
+\t}
+}
+`;
+
+const CONFIG_YAML = `rest: true
+jsResource:
+  files: resources.js
+`;
+
+const skipSuite = process.platform === 'win32';
+
+suite('OpenAPI — static properties emission', { skip: skipSuite }, (ctx) => {
+	let client;
+	let schema;
+
+	before(async () => {
+		await startHarper(ctx, { config: {}, env: {} });
+		client = createApiClient(ctx.harper);
+		await installAppComponent(client, {
+			project: 'staticPropsApp',
+			files: { 'resources.js': RESOURCES_JS, 'config.yaml': CONFIG_YAML },
+			probePath: '/OrderSummary/',
+			restartTimeoutMs: 120000,
+		});
+		const r = await client.reqRest('/openapi').expect(200);
+		schema = r.body.components.schemas.OrderSummary;
+		assert.ok(schema, `OrderSummary schema missing from the document: ${r.text.slice(0, 400)}`);
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	test('emits per-property type, description, and enum from static properties', () => {
+		assert.equal(schema.properties.status.type, 'string');
+		assert.equal(schema.properties.status.description, 'Fulfillment state.');
+		assert.deepEqual(schema.properties.status.enum, ['open', 'closed']);
+	});
+
+	test('emits OpenAPI `nullable` for a top-level nullable property', () => {
+		// OpenAPI 3.0.3 has no union types. This was computed only to derive `required` and never
+		// emitted, so a nullable property was advertised as non-nullable (#1942).
+		assert.equal(schema.properties.note.type, 'string');
+		assert.equal(schema.properties.note.nullable, true);
+	});
+
+	test('suppresses a @hidden sub-property of a nested object, and its description', () => {
+		assert.ok(schema.properties.profile.properties.name, 'visible sub-property kept');
+		assert.equal(schema.properties.profile.properties.creditScore, undefined, 'hidden sub-property emitted');
+	});
+
+	test('never emits `hidden` as a schema key, and never leaks a hidden description', () => {
+		const doc = JSON.stringify(schema);
+		assert.equal(doc.includes('"hidden"'), false, `hidden directive leaked into the document: ${doc}`);
+		assert.equal(doc.includes('INTERNAL-ONLY-MARKER'), false, 'hidden sub-property description leaked');
+	});
+
+	test('drops a suppressed name from `required`, and omits `required` when nothing survives', () => {
+		// `required: []` is invalid under draft-04 (which OpenAPI 3.0.3 inherits).
+		assert.deepEqual(schema.properties.profile.required, ['name']);
+		assert.equal('required' in schema.properties.allHidden, false, 'empty required must be omitted');
+		assert.equal('required' in schema, false, 'top-level empty required must be omitted');
+	});
+
+	test('carries enum and description into array items', () => {
+		assert.deepEqual(schema.properties.tags.items.enum, ['x', 'y']);
+		assert.equal(schema.properties.tags.items.description, 'Tag.');
+	});
+});

--- a/resources/jsonSchemaTypes.ts
+++ b/resources/jsonSchemaTypes.ts
@@ -30,6 +30,8 @@ export interface JsonSchemaFragment {
 	additionalProperties?: boolean;
 	format?: string;
 	const?: unknown;
+	/** Binary encoding of a string-typed value. Emitted on the MCP surface only — not a 3.0.3 keyword. */
+	contentEncoding?: string;
 }
 
 /**
@@ -302,7 +304,14 @@ export function attributeToSchema(attr: AttributeLike, options: SchemaEmitOption
 			if (items) fragment.items = items;
 		}
 	} else {
-		Object.assign(fragment, options.mapPrimitive(attr.type, attr));
+		// Copy the mapper's result field by field rather than merging it wholesale: the set of keys a
+		// surface may contribute to a leaf schema is fixed, and spreading an arbitrary object here would
+		// let a mapper put anything into an emitted document.
+		const primitive = options.mapPrimitive(attr.type, attr);
+		if (primitive.type !== undefined) fragment.type = primitive.type;
+		if (primitive.description !== undefined) fragment.description = primitive.description;
+		if (primitive.format !== undefined) fragment.format = primitive.format;
+		if (primitive.contentEncoding !== undefined) fragment.contentEncoding = primitive.contentEncoding;
 	}
 
 	if (attr.nullable) applyNullability(fragment, options.dialect);

--- a/resources/jsonSchemaTypes.ts
+++ b/resources/jsonSchemaTypes.ts
@@ -306,18 +306,31 @@ export function attributeToSchema(attr: AttributeLike, options: SchemaEmitOption
 	}
 
 	if (attr.nullable) applyNullability(fragment, options.dialect);
-	if (attr.description && fragment.description === undefined) fragment.description = attr.description;
+	// An explicitly declared `description`/`format` outranks whatever the primitive mapper supplied as a
+	// default — a author writing `{ type: 'Date', format: 'date-time' }` means `date-time`, not the
+	// Harper type name the mapper stamps on.
+	if (attr.description) fragment.description = attr.description;
 	if (attr.enum && fragment.enum === undefined) fragment.enum = attr.enum;
-	if (attr.format && fragment.format === undefined) fragment.format = attr.format;
+	if (attr.format) fragment.format = attr.format;
 	if (attr.const !== undefined) {
 		// `const` is JSON Schema draft-06. OpenAPI 3.0.3's Schema Object is the draft-04 subset, so it
 		// has no such keyword — emit the equivalent single-value `enum` for that dialect. MCP speaks
 		// current JSON Schema and takes `const` directly.
 		if (options.dialect === 'openapi-3.0.3') {
-			if (fragment.enum === undefined) fragment.enum = [attr.const as never];
+			// Intersect rather than skip when both are declared: dropping the `const` would leave OpenAPI
+			// advertising a wider value set than MCP, from one declaration.
+			fragment.enum = fragment.enum
+				? (fragment.enum.filter((value) => value === attr.const) as never[])
+				: [attr.const as never];
 		} else if (fragment.const === undefined) {
 			fragment.const = attr.const;
 		}
+	}
+	// OpenAPI 3.0's `nullable` does not widen an `enum` — a validator still rejects `null` unless the
+	// value list contains it. Without this, marking an enum (or a const, now emitted as one) nullable
+	// produces a schema that contradicts itself.
+	if (options.dialect === 'openapi-3.0.3' && fragment.nullable && fragment.enum && !fragment.enum.includes(null)) {
+		fragment.enum = [...fragment.enum, null];
 	}
 	// `hidden` / `primaryKey` / `assignCreatedTime` / `assignUpdatedTime` are Harper directives, not
 	// schema vocabulary — they never belong in an emitted document.

--- a/resources/jsonSchemaTypes.ts
+++ b/resources/jsonSchemaTypes.ts
@@ -28,6 +28,8 @@ export interface JsonSchemaFragment {
 	additionalProperties?: boolean;
 	format?: string;
 	const?: unknown;
+	/** Emitted by the OpenAPI 3.0 projection for a genuine multi-type union; not authored directly. */
+	oneOf?: JsonSchemaFragment[];
 }
 
 /**
@@ -71,6 +73,12 @@ export interface AttributeLike {
 	assignCreatedTime?: boolean;
 	assignUpdatedTime?: boolean;
 	nullable?: boolean;
+	/**
+	 * The source JSON-Schema type union, verbatim, when `static properties` declared one. `type` holds
+	 * the first non-null member so single-type consumers keep working; surfaces that can express a
+	 * union (MCP passes it through, OpenAPI 3.0 translates it to `oneOf`) read this instead.
+	 */
+	types?: readonly string[];
 	elements?: AttributeLike;
 	/** Sub-attributes of a nested object field (the same array form `Table.validate` iterates). */
 	properties?: AttributeLike[];
@@ -107,6 +115,10 @@ export function attributeToFragment(attr: AttributeLike): JsonSchemaFragment {
 	} else if (attr.type === 'array' && attr.elements) {
 		fragment.type = 'array';
 		fragment.items = attributeToFragment(attr.elements);
+	} else if (attr.types) {
+		// A declared union round-trips verbatim; collapsing it to `attr.type` here would make the
+		// canonical `Table.properties` disagree with what the author wrote.
+		fragment.type = [...attr.types] as JsonSchemaType[];
 	} else {
 		const jsonType = attr.type ? DATA_TYPES[attr.type] : undefined;
 		if (jsonType) fragment.type = jsonType;
@@ -157,9 +169,11 @@ function fragmentToAttribute(name: string, fragment: JsonSchemaFragment): Attrib
 		// than misleadingly reusing the array field's own name.
 		attr.elements = fragmentToAttribute('', fragment.items);
 	} else if (Array.isArray(fragment.type)) {
-		// JSON-Schema union type. Fold a `'null'` member into `nullable` (the OpenAPI-expressible form)
-		// and keep the remaining member. A single non-null member is the common `['T','null']` case; a
-		// genuine multi-type union isn't expressible on an attribute, so the first member is kept.
+		// JSON-Schema union type. Keep the source union on `types` so surfaces that can express one
+		// (MCP natively, OpenAPI 3.0 via `oneOf`) don't have to reconstruct it, and fold a `'null'`
+		// member into `nullable` as well since that is the form OpenAPI needs. `type` carries the first
+		// non-null member for the single-type consumers (validation, query coercion) that read it.
+		attr.types = fragment.type;
 		const members = fragment.type.filter((t) => t !== 'null');
 		if (members.length !== fragment.type.length) attr.nullable = true;
 		if (members.length > 0) attr.type = members[0];

--- a/resources/jsonSchemaTypes.ts
+++ b/resources/jsonSchemaTypes.ts
@@ -30,6 +30,21 @@ export interface JsonSchemaFragment {
 	const?: unknown;
 }
 
+/**
+ * The JSON-Schema scalar/structural type names. A programmatic Resource's `static properties` speaks
+ * JSON Schema directly (lowercase), so the MCP and OpenAPI type mappers pass these through unchanged
+ * rather than treating them as unknown Harper types. Shared so the two mappers can't drift apart.
+ */
+export const JSON_SCHEMA_SCALAR_TYPES: ReadonlySet<string> = new Set([
+	'string',
+	'integer',
+	'number',
+	'boolean',
+	'object',
+	'array',
+	'null',
+]);
+
 export const DATA_TYPES: Record<string, JsonSchemaType> = {
 	Int: 'integer',
 	Float: 'number',
@@ -64,6 +79,9 @@ export interface AttributeLike {
 	enum?: readonly (string | number | boolean | null)[];
 	format?: string;
 	const?: unknown;
+	/** Object-level constraints for a nested object field, carried through the round-trip. */
+	required?: readonly string[];
+	additionalProperties?: boolean;
 }
 
 /**
@@ -84,6 +102,8 @@ export function attributeToFragment(attr: AttributeLike): JsonSchemaFragment {
 		fragment.type = 'object';
 		fragment.properties = {};
 		for (const sub of attr.properties) fragment.properties[sub.name] = attributeToFragment(sub);
+		if (attr.required) fragment.required = attr.required;
+		if (attr.additionalProperties !== undefined) fragment.additionalProperties = attr.additionalProperties;
 	} else if (attr.type === 'array' && attr.elements) {
 		fragment.type = 'array';
 		fragment.items = attributeToFragment(attr.elements);
@@ -128,11 +148,22 @@ function fragmentToAttribute(name: string, fragment: JsonSchemaFragment): Attrib
 	const attr: AttributeLike = { name };
 	if (fragment.properties) {
 		attr.properties = Object.entries(fragment.properties).map(([subName, sub]) => fragmentToAttribute(subName, sub));
+		if (fragment.required) attr.required = fragment.required;
+		if (fragment.additionalProperties !== undefined) attr.additionalProperties = fragment.additionalProperties;
 	} else if (fragment.type === 'array' && fragment.items) {
 		attr.type = 'array';
-		attr.elements = fragmentToAttribute(name, fragment.items);
+		// The element attribute's name is unused (attributeToFragment ignores it); keep it empty rather
+		// than misleadingly reusing the array field's own name.
+		attr.elements = fragmentToAttribute('', fragment.items);
+	} else if (Array.isArray(fragment.type)) {
+		// JSON-Schema union type. Fold a `'null'` member into `nullable` (the OpenAPI-expressible form)
+		// and keep the remaining member. A single non-null member is the common `['T','null']` case; a
+		// genuine multi-type union isn't expressible on an attribute, so the first member is kept.
+		const members = fragment.type.filter((t) => t !== 'null');
+		if (members.length !== fragment.type.length) attr.nullable = true;
+		if (members.length > 0) attr.type = members[0];
 	} else if (fragment.type != null) {
-		attr.type = Array.isArray(fragment.type) ? fragment.type[0] : fragment.type;
+		attr.type = fragment.type;
 	}
 	if (fragment.description) attr.description = fragment.description;
 	if (fragment.primaryKey) attr.isPrimaryKey = true;

--- a/resources/jsonSchemaTypes.ts
+++ b/resources/jsonSchemaTypes.ts
@@ -59,6 +59,11 @@ export interface AttributeLike {
 	elements?: AttributeLike;
 	/** Sub-attributes of a nested object field (the same array form `Table.validate` iterates). */
 	properties?: AttributeLike[];
+	// JSON-Schema-only hints an author may declare on `static properties`; carried through the
+	// projection so they survive the properties <-> attributes round-trip.
+	enum?: readonly (string | number | boolean | null)[];
+	format?: string;
+	const?: unknown;
 }
 
 /**
@@ -93,6 +98,9 @@ export function attributeToFragment(attr: AttributeLike): JsonSchemaFragment {
 	if (attr.assignUpdatedTime) fragment.assignUpdatedTime = true;
 	if (attr.hidden) fragment.hidden = true;
 	if (attr.nullable) fragment.nullable = true;
+	if (attr.enum) fragment.enum = attr.enum;
+	if (attr.format) fragment.format = attr.format;
+	if (attr.const !== undefined) fragment.const = attr.const;
 	return fragment;
 }
 
@@ -107,4 +115,55 @@ export function projectAttributesToProperties(attributes: AttributeLike[]): Reco
 		result[attr.name] = attributeToFragment(attr);
 	}
 	return result;
+}
+
+/**
+ * Structural inverse of `attributeToFragment`: rebuild an attribute from a JSON Schema fragment.
+ * A programmatic Resource may declare `static properties` (the Record form) without populating the
+ * `attributes` Array; the schema-derivation paths (MCP `derive.ts`, OpenAPI) read attributes, so a
+ * bare declaration would otherwise yield a skeletal schema. Projecting the fragments back into
+ * attributes lets those paths produce the same rich schema they build for table-backed resources.
+ */
+function fragmentToAttribute(name: string, fragment: JsonSchemaFragment): AttributeLike {
+	const attr: AttributeLike = { name };
+	if (fragment.properties) {
+		attr.properties = Object.entries(fragment.properties).map(([subName, sub]) => fragmentToAttribute(subName, sub));
+	} else if (fragment.type === 'array' && fragment.items) {
+		attr.type = 'array';
+		attr.elements = fragmentToAttribute(name, fragment.items);
+	} else if (fragment.type != null) {
+		attr.type = Array.isArray(fragment.type) ? fragment.type[0] : fragment.type;
+	}
+	if (fragment.description) attr.description = fragment.description;
+	if (fragment.primaryKey) attr.isPrimaryKey = true;
+	if (fragment.assignCreatedTime) attr.assignCreatedTime = true;
+	if (fragment.assignUpdatedTime) attr.assignUpdatedTime = true;
+	if (fragment.hidden) attr.hidden = true;
+	if (fragment.nullable) attr.nullable = true;
+	if (fragment.enum) attr.enum = fragment.enum;
+	if (fragment.format) attr.format = fragment.format;
+	if (fragment.const !== undefined) attr.const = fragment.const;
+	return attr;
+}
+
+/**
+ * Project a `Record<string, JsonSchemaFragment>` (the `static properties` form) back into the
+ * `Attribute[]` Array the schema-derivation paths consume. Inverse of `projectAttributesToProperties`.
+ */
+export function projectPropertiesToAttributes(properties: Record<string, JsonSchemaFragment>): AttributeLike[] {
+	return Object.entries(properties).map(([name, fragment]) => fragmentToAttribute(name, fragment));
+}
+
+/**
+ * The effective attribute Array for a Resource/Table class: its declared `attributes` when present,
+ * otherwise the projection of a bare `static properties` declaration. Keeps MCP and OpenAPI schema
+ * derivation identical for table-backed and programmatic Resources.
+ */
+export function resolveAttributes(source?: {
+	attributes?: AttributeLike[];
+	properties?: Record<string, JsonSchemaFragment>;
+}): AttributeLike[] {
+	if (source?.attributes?.length) return source.attributes;
+	if (source?.properties) return projectPropertiesToAttributes(source.properties);
+	return [];
 }

--- a/resources/jsonSchemaTypes.ts
+++ b/resources/jsonSchemaTypes.ts
@@ -11,6 +11,8 @@
  * type emission in lockstep.
  */
 
+import logger from '../utility/logging/harper_logger.ts';
+
 export type JsonSchemaType = 'string' | 'integer' | 'number' | 'boolean' | 'object' | 'array' | 'null';
 
 export interface JsonSchemaFragment {
@@ -184,6 +186,118 @@ function fragmentToAttribute(name: string, fragment: JsonSchemaFragment): Attrib
  */
 export function projectPropertiesToAttributes(properties: Record<string, JsonSchemaFragment>): AttributeLike[] {
 	return Object.entries(properties).map(([name, fragment]) => fragmentToAttribute(name, fragment));
+}
+
+/**
+ * The schema dialect a consumer surface emits. The two differ in exactly one respect that matters
+ * here: JSON Schema expresses nullability as a `'null'` member of a type union, while OpenAPI 3.0.3
+ * has no union types and uses the `nullable` keyword.
+ */
+export type SchemaDialect = 'json-schema' | 'openapi-3.0.3';
+
+export interface SchemaEmitOptions {
+	dialect: SchemaDialect;
+	/**
+	 * Maps a leaf attribute's declared type to its base schema. Each surface keeps its own primitive
+	 * mapping — MCP widens `Date` to `['string','number']` and tags `Bytes` with `contentEncoding`,
+	 * OpenAPI emits a `format`. Those differences are deliberate, so they stay with the caller; only
+	 * the traversal around them is shared.
+	 */
+	mapPrimitive: (type: string | undefined) => JsonSchemaFragment;
+}
+
+const warnedUnknownTypes = new Set<string>();
+
+/**
+ * Resolve a declared type name to its JSON Schema equivalent, or `undefined` when the name belongs to
+ * neither vocabulary. Harper recognizes both the capitalized GraphQL names (`String`, `Int`) and the
+ * lowercase JSON Schema names a `static properties` fragment uses.
+ *
+ * An unrecognized name used to resolve differently per surface — MCP coerced it to `'string'`, OpenAPI
+ * emitted an untyped `{}` — with no signal to the author. Warn once per name so a typo is visible
+ * instead of silently producing two different wrong schemas (#1942).
+ */
+export function resolveDeclaredType(type: string | undefined, context?: string): JsonSchemaType | undefined {
+	if (!type) return undefined;
+	const mapped = DATA_TYPES[type];
+	if (mapped) return mapped;
+	if (JSON_SCHEMA_SCALAR_TYPES.has(type)) return type as JsonSchemaType;
+	if (!warnedUnknownTypes.has(type)) {
+		warnedUnknownTypes.add(type);
+		logger.warn(
+			`Unrecognized schema type "${type}"${context ? ` on ${context}` : ''}: not a Harper type (${Object.keys(DATA_TYPES).join(', ')}) nor a JSON Schema type (${[...JSON_SCHEMA_SCALAR_TYPES].join(', ')}). The property will be emitted without a type.`
+		);
+	}
+	return undefined;
+}
+
+/** Test hook: the unknown-type warning is once-per-process, which would leak across test cases. */
+export function _resetUnknownTypeWarningsForTest(): void {
+	warnedUnknownTypes.clear();
+}
+
+/**
+ * Emit an attribute as a schema fragment for a *consumer* surface (MCP tool descriptors, the OpenAPI
+ * document), as opposed to `attributeToFragment`, which produces the canonical, front-end-neutral
+ * `Table.properties` Record.
+ *
+ * Returns `undefined` for a `hidden` attribute so callers skip it — at every nesting level, not just
+ * the top one. Suppression used to be implemented in each surface's top-level loop, so a hidden
+ * sub-property of a nested object was emitted anyway, and OpenAPI additionally leaked `hidden: true`
+ * into the public document as a schema key (#1941).
+ *
+ * Per-property hints (`description`, `enum`, `format`, `const`) propagate at every level too; OpenAPI
+ * previously attached them only to top-level properties, so the two surfaces described the same nested
+ * fragment differently (#1942).
+ */
+export function attributeToSchema(attr: AttributeLike, options: SchemaEmitOptions): JsonSchemaFragment | undefined {
+	if (attr.hidden) return undefined;
+	const fragment: JsonSchemaFragment = {};
+
+	if (attr.properties) {
+		fragment.type = 'object';
+		fragment.properties = {};
+		const visibleNames = new Set<string>();
+		for (const sub of attr.properties) {
+			const subSchema = attributeToSchema(sub, options);
+			if (!subSchema) continue;
+			fragment.properties[sub.name] = subSchema;
+			visibleNames.add(sub.name);
+		}
+		// Drop suppressed sub-properties from `required` too — advertising a required property the
+		// schema does not define makes the object unsatisfiable for any client that validates.
+		if (attr.required) fragment.required = attr.required.filter((name) => visibleNames.has(name));
+		if (attr.additionalProperties !== undefined) fragment.additionalProperties = attr.additionalProperties;
+	} else if (attr.type === 'array') {
+		fragment.type = 'array';
+		// `{ type: 'array' }` with no element schema is valid — an array of anything.
+		if (attr.elements) {
+			const items = attributeToSchema(attr.elements, options);
+			if (items) fragment.items = items;
+		}
+	} else {
+		Object.assign(fragment, options.mapPrimitive(attr.type));
+	}
+
+	if (attr.nullable) applyNullability(fragment, options.dialect);
+	if (attr.description && fragment.description === undefined) fragment.description = attr.description;
+	if (attr.enum && fragment.enum === undefined) fragment.enum = attr.enum;
+	if (attr.format && fragment.format === undefined) fragment.format = attr.format;
+	if (attr.const !== undefined && fragment.const === undefined) fragment.const = attr.const;
+	// `hidden` / `primaryKey` / `assignCreatedTime` / `assignUpdatedTime` are Harper directives, not
+	// schema vocabulary — they never belong in an emitted document.
+	return fragment;
+}
+
+function applyNullability(fragment: JsonSchemaFragment, dialect: SchemaDialect): void {
+	if (dialect === 'openapi-3.0.3') {
+		// OpenAPI 3.0.3 has no union types; `nullable` is the spec-provided expression.
+		fragment.nullable = true;
+		return;
+	}
+	if (!('type' in fragment) || fragment.type === undefined) return;
+	const types = Array.isArray(fragment.type) ? fragment.type : [fragment.type];
+	if (!types.includes('null')) fragment.type = [...types, 'null'] as JsonSchemaType[];
 }
 
 /**

--- a/resources/jsonSchemaTypes.ts
+++ b/resources/jsonSchemaTypes.ts
@@ -201,10 +201,24 @@ export interface SchemaEmitOptions {
 	 * Maps a leaf attribute's declared type to its base schema. Each surface keeps its own primitive
 	 * mapping — MCP widens `Date` to `['string','number']` and tags `Bytes` with `contentEncoding`,
 	 * OpenAPI emits a `format`. Those differences are deliberate, so they stay with the caller; only
-	 * the traversal around them is shared.
+	 * the traversal around them is shared. The attribute is passed so a diagnostic can name the
+	 * property the type was declared on, rather than whatever the recursion started from.
 	 */
-	mapPrimitive: (type: string | undefined) => JsonSchemaFragment;
+	mapPrimitive: (type: string | undefined, attr: AttributeLike) => JsonSchemaFragment;
+	/**
+	 * Emit the attribute even when it is `hidden`. Only for the primary key, which verb tools surface
+	 * as the `id` addressing argument rather than as a field — `@hidden` suppresses a field from the
+	 * schema, but the key you address a record by is still required to call the tool.
+	 */
+	ignoreHidden?: boolean;
 }
+
+/**
+ * Harper primitive type names that carry no `DATA_TYPES` entry. `Any` is deliberately untyped (it
+ * accepts anything); `Blob` is a first-class column type that serializes as a string. Both are in
+ * `graphql.ts`'s `PRIMITIVE_TYPES`, so neither is a typo and neither should warn.
+ */
+const UNMAPPED_HARPER_TYPES: Record<string, JsonSchemaType | undefined> = { Any: undefined, Blob: 'string' };
 
 const warnedUnknownTypes = new Set<string>();
 
@@ -219,13 +233,17 @@ const warnedUnknownTypes = new Set<string>();
  */
 export function resolveDeclaredType(type: string | undefined, context?: string): JsonSchemaType | undefined {
 	if (!type) return undefined;
-	const mapped = DATA_TYPES[type];
-	if (mapped) return mapped;
+	// `Object.hasOwn`, not a bare index: `DATA_TYPES` is an object literal, so `type: 'constructor'`
+	// or `'__proto__'` would otherwise resolve to a prototype member and put a function (or
+	// `Object.prototype`) into an emitted schema.
+	if (Object.hasOwn(DATA_TYPES, type)) return DATA_TYPES[type];
+	if (Object.hasOwn(UNMAPPED_HARPER_TYPES, type)) return UNMAPPED_HARPER_TYPES[type];
 	if (JSON_SCHEMA_SCALAR_TYPES.has(type)) return type as JsonSchemaType;
 	if (!warnedUnknownTypes.has(type)) {
 		warnedUnknownTypes.add(type);
+		const harperTypes = [...Object.keys(DATA_TYPES), ...Object.keys(UNMAPPED_HARPER_TYPES)].join(', ');
 		logger.warn(
-			`Unrecognized schema type "${type}"${context ? ` on ${context}` : ''}: not a Harper type (${Object.keys(DATA_TYPES).join(', ')}) nor a JSON Schema type (${[...JSON_SCHEMA_SCALAR_TYPES].join(', ')}). The property will be emitted without a type.`
+			`Unrecognized schema type "${type}"${context ? ` on ${context}` : ''}: not a Harper type (${harperTypes}) nor a JSON Schema type (${[...JSON_SCHEMA_SCALAR_TYPES].join(', ')}). The property will be emitted without a type.`
 		);
 	}
 	return undefined;
@@ -251,32 +269,40 @@ export function _resetUnknownTypeWarningsForTest(): void {
  * fragment differently (#1942).
  */
 export function attributeToSchema(attr: AttributeLike, options: SchemaEmitOptions): JsonSchemaFragment | undefined {
-	if (attr.hidden) return undefined;
+	if (attr.hidden && !options.ignoreHidden) return undefined;
 	const fragment: JsonSchemaFragment = {};
+	// `ignoreHidden` applies to this attribute only — a hidden sub-property of a surfaced primary key
+	// is still a hidden field and stays suppressed.
+	const childOptions = options.ignoreHidden ? { ...options, ignoreHidden: false } : options;
 
 	if (attr.properties) {
 		fragment.type = 'object';
 		fragment.properties = {};
 		const visibleNames = new Set<string>();
 		for (const sub of attr.properties) {
-			const subSchema = attributeToSchema(sub, options);
+			const subSchema = attributeToSchema(sub, childOptions);
 			if (!subSchema) continue;
 			fragment.properties[sub.name] = subSchema;
 			visibleNames.add(sub.name);
 		}
 		// Drop suppressed sub-properties from `required` too — advertising a required property the
-		// schema does not define makes the object unsatisfiable for any client that validates.
-		if (attr.required) fragment.required = attr.required.filter((name) => visibleNames.has(name));
+		// schema does not define makes the object unsatisfiable for any client that validates. Omit the
+		// key entirely when nothing survives: JSON Schema draft-04 (which OpenAPI 3.0.3 inherits)
+		// requires `required` to have at least one element, so `required: []` fails validators.
+		if (attr.required) {
+			const visibleRequired = attr.required.filter((name) => visibleNames.has(name));
+			if (visibleRequired.length > 0) fragment.required = visibleRequired;
+		}
 		if (attr.additionalProperties !== undefined) fragment.additionalProperties = attr.additionalProperties;
 	} else if (attr.type === 'array') {
 		fragment.type = 'array';
 		// `{ type: 'array' }` with no element schema is valid — an array of anything.
 		if (attr.elements) {
-			const items = attributeToSchema(attr.elements, options);
+			const items = attributeToSchema(attr.elements, childOptions);
 			if (items) fragment.items = items;
 		}
 	} else {
-		Object.assign(fragment, options.mapPrimitive(attr.type));
+		Object.assign(fragment, options.mapPrimitive(attr.type, attr));
 	}
 
 	if (attr.nullable) applyNullability(fragment, options.dialect);
@@ -290,12 +316,14 @@ export function attributeToSchema(attr: AttributeLike, options: SchemaEmitOption
 }
 
 function applyNullability(fragment: JsonSchemaFragment, dialect: SchemaDialect): void {
+	// Both dialects express nullability as a modification of `type`, so neither has anything to say
+	// about a fragment that never resolved one.
+	if (!('type' in fragment) || fragment.type === undefined) return;
 	if (dialect === 'openapi-3.0.3') {
 		// OpenAPI 3.0.3 has no union types; `nullable` is the spec-provided expression.
 		fragment.nullable = true;
 		return;
 	}
-	if (!('type' in fragment) || fragment.type === undefined) return;
 	const types = Array.isArray(fragment.type) ? fragment.type : [fragment.type];
 	if (!types.includes('null')) fragment.type = [...types, 'null'] as JsonSchemaType[];
 }

--- a/resources/jsonSchemaTypes.ts
+++ b/resources/jsonSchemaTypes.ts
@@ -118,9 +118,10 @@ export function attributeToFragment(attr: AttributeLike): JsonSchemaFragment {
 	if (attr.assignUpdatedTime) fragment.assignUpdatedTime = true;
 	if (attr.hidden) fragment.hidden = true;
 	if (attr.nullable) fragment.nullable = true;
-	if (attr.enum) fragment.enum = attr.enum;
-	if (attr.format) fragment.format = attr.format;
-	if (attr.const !== undefined) fragment.const = attr.const;
+	// NOTE: enum/format/const are deliberately NOT emitted here. This projector feeds the canonical,
+	// front-end-neutral `Table.properties` Record, where a code-first `types.enum` column must stay
+	// identical to its GraphQL `String` equivalent (types.enum is advisory — see defineTable.ts). The
+	// MCP/OpenAPI schema paths (derive.ts / openApi.ts) surface those hints for programmatic Resources.
 	return fragment;
 }
 

--- a/resources/openApi.ts
+++ b/resources/openApi.ts
@@ -34,7 +34,7 @@ function openApiPrimitive(type: string | undefined, attributeName: string | unde
 	if (!resolved) return {};
 	// 3.0.x has no `'null'` type — nullability is the `nullable` keyword, so a bare `type: 'null'`
 	// becomes an untyped nullable schema rather than a type the dialect can't express.
-	if (resolved === 'null') return { nullable: true };
+	if (resolved === 'null') return {}; // 3.0 has no null type; a bare `nullable` on an untyped schema says nothing
 	// Preserve the Harper type name as `format` for the types where it adds information, matching the
 	// top-level `Type()` emitter.
 	return Object.hasOwn(DATA_TYPES, type) ? (new Type(resolved, type) as JsonSchemaFragment) : { type: resolved };
@@ -225,18 +225,30 @@ export function generateJsonApi(resources: Resources, serverHttpURL: string) {
 				if (props[name] && typeof props[name] === 'object' && !('$ref' in props[name])) {
 					const prop = props[name] as {
 						description?: string;
-						enum?: unknown;
+						enum?: unknown[];
+						type?: unknown;
 						format?: string;
 						const?: unknown;
 						nullable?: boolean;
 					};
 					if (description) prop.description = description;
 					if (attr.enum && prop.enum === undefined) prop.enum = attr.enum;
-					if (attr.format && prop.format === undefined) prop.format = attr.format;
+					// An author-declared `format` outranks the Harper type name `Type()` stamps on.
+					if (attr.format) prop.format = attr.format;
 					// `const` is draft-06; this document declares 3.0.3 (the draft-04 subset), so emit the
-					// equivalent single-value `enum` rather than a keyword the dialect doesn't define.
-					if (attr.const !== undefined && prop.enum === undefined) prop.enum = [attr.const];
-					if (nullable && prop.nullable === undefined) prop.nullable = true;
+					// equivalent single-value `enum`. Intersect when both are declared, so OpenAPI never
+					// advertises a wider value set than MCP from the same declaration.
+					if (attr.const !== undefined) {
+						prop.enum = Array.isArray(prop.enum) ? prop.enum.filter((value) => value === attr.const) : [attr.const];
+					}
+					// Only a typed schema can be nullable — a bare `{ nullable: true }` says nothing in 3.0,
+					// matching the guard the shared emitter applies.
+					if (nullable && prop.nullable === undefined && prop.type !== undefined) prop.nullable = true;
+					// 3.0's `nullable` does not widen an `enum`; without `null` in the list a validator
+					// rejects it regardless of the flag.
+					if (prop.nullable && Array.isArray(prop.enum) && !prop.enum.includes(null)) {
+						prop.enum = [...prop.enum, null];
+					}
 				}
 				queryParamsArray.push(new Parameter(name, 'query', props[name]));
 			}

--- a/resources/openApi.ts
+++ b/resources/openApi.ts
@@ -6,9 +6,61 @@ import {
 	JSON_SCHEMA_SCALAR_TYPES,
 	attributeToFragment,
 	projectPropertiesToAttributes,
+	type JsonSchemaFragment,
 } from './jsonSchemaTypes.ts';
 
 const OPENAPI_VERSION = '3.0.3';
+
+/**
+ * Convert a canonical `Table.properties` fragment into one this document's declared dialect accepts.
+ *
+ * `attributeToFragment` produces the front-end-neutral projection: it speaks current JSON Schema and
+ * carries Harper's own directives, neither of which belongs in an emitted 3.0.3 document. Rather than
+ * bend that projector (its output is also `Table.properties`, which must stay neutral), translate on
+ * the way out — recursively, since nested objects and array items are the paths that leak.
+ */
+function toOpenApiDialect(fragment: JsonSchemaFragment): JsonSchemaFragment {
+	// `hidden` / `primaryKey` / the timestamp flags are Harper behavior, not schema vocabulary.
+	const {
+		hidden: _hidden,
+		primaryKey: _primaryKey,
+		assignCreatedTime: _assignCreatedTime,
+		assignUpdatedTime: _assignUpdatedTime,
+		const: constValue,
+		...rest
+	} = fragment;
+	const out: JsonSchemaFragment = rest;
+	// 3.0 has no `'null'` type and no type unions; nullability is the `nullable` keyword alone.
+	if (Array.isArray(out.type)) {
+		const members = out.type.filter((t) => t !== 'null');
+		if (members.length !== out.type.length) out.nullable = true;
+		if (members.length > 0) out.type = members[0];
+		else delete out.type;
+	} else if (out.type === 'null') {
+		delete out.type;
+	}
+	// `const` is draft-06; emit the equivalent single-value `enum`, intersecting when both are declared.
+	if (constValue !== undefined) {
+		out.enum = Array.isArray(out.enum) ? out.enum.filter((v) => v === constValue) : [constValue as never];
+	}
+	// 3.0's `nullable` does not widen an `enum` — without `null` in the list a validator rejects it.
+	if (out.nullable && Array.isArray(out.enum) && !out.enum.includes(null)) out.enum = [...out.enum, null];
+	if (out.properties) {
+		const translated: Record<string, JsonSchemaFragment> = {};
+		for (const [key, sub] of Object.entries(out.properties)) {
+			if (sub.hidden) continue; // a hidden sub-property must not surface, and `required` follows below
+			translated[key] = toOpenApiDialect(sub);
+		}
+		out.properties = translated;
+		if (out.required) {
+			const visible = out.required.filter((key) => Object.hasOwn(translated, key));
+			if (visible.length > 0) out.required = visible;
+			else delete out.required;
+		}
+	}
+	if (out.items) out.items = toOpenApiDialect(out.items);
+	return out;
+}
 
 const SCHEMA_COMP_REF = '#/components/schemas/';
 const DESCRIPTION_200 = 'successful operation';
@@ -164,18 +216,21 @@ export function generateJsonApi(resources: Resources, serverHttpURL: string) {
 					} else if (attr.properties) {
 						// Nested object from `static properties` — the shared projector emits the full object
 						// schema (sub-properties recursed); OpenAPI's table path uses $refs instead.
-						props[name] = attributeToFragment(attr);
+						props[name] = toOpenApiDialect(attributeToFragment(attr));
 					} else if (type === 'array') {
 						if (!elements) {
 							// `{ type: 'array' }` with no items — valid JSON Schema (array of anything).
 							props[name] = { type: 'array' };
 						} else if (elements.properties) {
 							// array of nested objects — project the element to its full object schema
-							props[name] = { type: 'array', items: attributeToFragment(elements) };
+							props[name] = { type: 'array', items: toOpenApiDialect(attributeToFragment(elements)) };
 						} else if (elements.type === 'Any') {
 							props[name] = { type: 'array', items: { format: elements.type } };
 						} else if (!DATA_TYPES[elements.type] && JSON_SCHEMA_SCALAR_TYPES.has(elements.type)) {
-							props[name] = { type: 'array', items: new Type(elements.type) };
+							props[name] =
+								elements.type === 'null'
+									? { type: 'array', items: {} }
+									: { type: 'array', items: new Type(elements.type) };
 						} else {
 							props[name] = { type: 'array', items: new Type(DATA_TYPES[elements.type], elements.type) };
 						}
@@ -199,7 +254,8 @@ export function generateJsonApi(resources: Resources, serverHttpURL: string) {
 					const prop = props[name] as { description?: string; enum?: unknown; format?: string };
 					if (description) prop.description = description;
 					if (attr.enum && prop.enum === undefined) prop.enum = attr.enum;
-					if (attr.format && prop.format === undefined) prop.format = attr.format;
+					// An author-declared `format` outranks the Harper type name `Type()` stamps on.
+					if (attr.format) prop.format = attr.format;
 					if (attr.const !== undefined && prop.enum === undefined) prop.enum = [attr.const];
 				}
 				queryParamsArray.push(new Parameter(name, 'query', props[name]));

--- a/resources/openApi.ts
+++ b/resources/openApi.ts
@@ -166,7 +166,10 @@ export function generateJsonApi(resources: Resources, serverHttpURL: string) {
 						// schema (sub-properties recursed); OpenAPI's table path uses $refs instead.
 						props[name] = attributeToFragment(attr);
 					} else if (type === 'array') {
-						if (elements.properties) {
+						if (!elements) {
+							// `{ type: 'array' }` with no items — valid JSON Schema (array of anything).
+							props[name] = { type: 'array' };
+						} else if (elements.properties) {
 							// array of nested objects — project the element to its full object schema
 							props[name] = { type: 'array', items: attributeToFragment(elements) };
 						} else if (elements.type === 'Any') {

--- a/resources/openApi.ts
+++ b/resources/openApi.ts
@@ -251,12 +251,27 @@ export function generateJsonApi(resources: Resources, serverHttpURL: string) {
 				// subset: `const` only arrived in draft-06, so it is not a keyword here. Emit the
 				// equivalent single-value `enum` instead of a keyword the declared dialect doesn't define.
 				if (props[name] && typeof props[name] === 'object' && !('$ref' in props[name])) {
-					const prop = props[name] as { description?: string; enum?: unknown; format?: string };
+					const prop = props[name] as {
+						description?: string;
+						enum?: unknown[];
+						format?: string;
+						nullable?: boolean;
+					};
 					if (description) prop.description = description;
 					if (attr.enum && prop.enum === undefined) prop.enum = attr.enum;
 					// An author-declared `format` outranks the Harper type name `Type()` stamps on.
 					if (attr.format) prop.format = attr.format;
-					if (attr.const !== undefined && prop.enum === undefined) prop.enum = [attr.const];
+					// Intersect rather than defer: `const` narrows an `enum` declared alongside it.
+					if (attr.const !== undefined) {
+						prop.enum = Array.isArray(prop.enum) ? prop.enum.filter((value) => value === attr.const) : [attr.const];
+					}
+					// `type: ['string', 'null']` folds to `type: 'string'` + `nullable` upstream; without this the
+					// scalar path emits the type alone and the document claims the field rejects null.
+					if (nullable) prop.nullable = true;
+					// 3.0's `nullable` does not widen an `enum` — without `null` in the list a validator rejects it.
+					if (prop.nullable && Array.isArray(prop.enum) && !prop.enum.includes(null)) {
+						prop.enum = [...prop.enum, null];
+					}
 				}
 				queryParamsArray.push(new Parameter(name, 'query', props[name]));
 			}

--- a/resources/openApi.ts
+++ b/resources/openApi.ts
@@ -1,14 +1,14 @@
 import { packageJson } from '../utility/packageUtils.js';
 import { Resources, routePatternToTemplate } from './Resources.ts';
 import { Resource } from './Resource.ts';
-import { DATA_TYPES, attributeToFragment, projectPropertiesToAttributes } from './jsonSchemaTypes.ts';
+import {
+	DATA_TYPES,
+	JSON_SCHEMA_SCALAR_TYPES,
+	attributeToFragment,
+	projectPropertiesToAttributes,
+} from './jsonSchemaTypes.ts';
 
 const OPENAPI_VERSION = '3.0.3';
-
-// A programmatic Resource's `static properties` uses JSON Schema types directly (lowercase). Harper's
-// GraphQL attribute types are all capitalized and live in DATA_TYPES, so a lowercase scalar reaching
-// the attribute mapper came from `static properties` and should be emitted as-is.
-const JSON_SCHEMA_SCALARS = new Set(['string', 'integer', 'number', 'boolean', 'object', 'array', 'null']);
 
 const SCHEMA_COMP_REF = '#/components/schemas/';
 const DESCRIPTION_200 = 'successful operation';
@@ -166,16 +166,19 @@ export function generateJsonApi(resources: Resources, serverHttpURL: string) {
 						// schema (sub-properties recursed); OpenAPI's table path uses $refs instead.
 						props[name] = attributeToFragment(attr);
 					} else if (type === 'array') {
-						if (elements.type === 'Any') {
+						if (elements.properties) {
+							// array of nested objects — project the element to its full object schema
+							props[name] = { type: 'array', items: attributeToFragment(elements) };
+						} else if (elements.type === 'Any') {
 							props[name] = { type: 'array', items: { format: elements.type } };
-						} else if (!DATA_TYPES[elements.type] && JSON_SCHEMA_SCALARS.has(elements.type)) {
+						} else if (!DATA_TYPES[elements.type] && JSON_SCHEMA_SCALAR_TYPES.has(elements.type)) {
 							props[name] = { type: 'array', items: new Type(elements.type) };
 						} else {
 							props[name] = { type: 'array', items: new Type(DATA_TYPES[elements.type], elements.type) };
 						}
 					} else if (type === 'Any') {
 						props[name] = { format: type };
-					} else if (!DATA_TYPES[type] && JSON_SCHEMA_SCALARS.has(type)) {
+					} else if (!DATA_TYPES[type] && JSON_SCHEMA_SCALAR_TYPES.has(type)) {
 						props[name] = new Type(type);
 					} else {
 						props[name] = new Type(DATA_TYPES[type], type);

--- a/resources/openApi.ts
+++ b/resources/openApi.ts
@@ -30,11 +30,15 @@ function toOpenApiDialect(fragment: JsonSchemaFragment): JsonSchemaFragment {
 		...rest
 	} = fragment;
 	const out: JsonSchemaFragment = rest;
-	// 3.0 has no `'null'` type and no type unions; nullability is the `nullable` keyword alone.
+	// 3.0 has no `'null'` type and no type unions: nullability is the `nullable` keyword, and a genuine
+	// multi-type union is `oneOf`. Keeping only the first member would silently narrow the contract.
 	if (Array.isArray(out.type)) {
 		const members = out.type.filter((t) => t !== 'null');
 		if (members.length !== out.type.length) out.nullable = true;
-		if (members.length > 0) out.type = members[0];
+		if (members.length > 1) {
+			delete out.type;
+			out.oneOf = members.map((member) => ({ type: member }));
+		} else if (members.length === 1) out.type = members[0];
 		else delete out.type;
 	} else if (out.type === 'null') {
 		delete out.type;
@@ -60,6 +64,24 @@ function toOpenApiDialect(fragment: JsonSchemaFragment): JsonSchemaFragment {
 	}
 	if (out.items) out.items = toOpenApiDialect(out.items);
 	return out;
+}
+
+/**
+ * The non-null members of an attribute's declared type union, but only when there is more than one —
+ * `['string','null']` is nullability, not a union, and the existing single-type path already handles
+ * it. Returns undefined when the attribute has no union to translate.
+ */
+function unionMembers(attr: { types?: readonly string[] }): string[] | undefined {
+	if (!attr.types) return undefined;
+	const members = attr.types.filter((member) => member !== 'null');
+	return members.length > 1 ? members : undefined;
+}
+
+/** A single union member as a 3.0 Schema Object, using the same type mapping as the scalar path. */
+function openApiUnionMember(member: string) {
+	return !DATA_TYPES[member] && JSON_SCHEMA_SCALAR_TYPES.has(member)
+		? new Type(member)
+		: new Type(DATA_TYPES[member], member);
 }
 
 const SCHEMA_COMP_REF = '#/components/schemas/';
@@ -190,6 +212,7 @@ export function generateJsonApi(resources: Resources, serverHttpURL: string) {
 		if (attributes) {
 			for (const attr of attributes) {
 				const { type, name, elements, relationship, definition, nullable, description, hidden } = attr;
+				const union = unionMembers(attr);
 				// @hidden field-level: suppress the attribute from props, query params, and required.
 				if (hidden) continue;
 				const def = definition ?? elements?.definition;
@@ -217,6 +240,10 @@ export function generateJsonApi(resources: Resources, serverHttpURL: string) {
 						// Nested object from `static properties` — the shared projector emits the full object
 						// schema (sub-properties recursed); OpenAPI's table path uses $refs instead.
 						props[name] = toOpenApiDialect(attributeToFragment(attr));
+					} else if (union) {
+						// A genuine multi-type union (`['string','number']`). 3.0 has no type arrays, so the
+						// equivalent is `oneOf`; `attr.type` alone would drop every member but the first.
+						props[name] = { oneOf: union.map(openApiUnionMember) };
 					} else if (type === 'array') {
 						if (!elements) {
 							// `{ type: 'array' }` with no items — valid JSON Schema (array of anything).

--- a/resources/openApi.ts
+++ b/resources/openApi.ts
@@ -3,7 +3,6 @@ import { Resources, routePatternToTemplate } from './Resources.ts';
 import { Resource } from './Resource.ts';
 import {
 	DATA_TYPES,
-	JSON_SCHEMA_SCALAR_TYPES,
 	type AttributeLike,
 	type JsonSchemaFragment,
 	attributeToSchema,
@@ -22,15 +21,20 @@ const OPENAPI_VERSION = '3.0.3';
 function attributeToOpenApiSchema(attr: AttributeLike): JsonSchemaFragment | undefined {
 	return attributeToSchema(attr, {
 		dialect: 'openapi-3.0.3',
-		mapPrimitive: (type) => {
-			if (type === 'Any' || type === undefined) return {};
-			const resolved = resolveDeclaredType(type, `OpenAPI property "${attr.name}"`);
-			if (!resolved) return {};
-			// Preserve the Harper type name as `format` for the types where it adds information, matching
-			// the top-level `Type()` emitter.
-			return DATA_TYPES[type] ? (new Type(resolved, type) as JsonSchemaFragment) : { type: resolved };
-		},
+		// `mapped` is the attribute the recursion actually reached, not the one it started from — a bad
+		// type on `profile.creditScore` has to name that, not `profile`.
+		mapPrimitive: (type, mapped) => openApiPrimitive(type, mapped.name || attr.name),
 	});
+}
+
+/** Shared by the nested emitter and the top-level attribute loop so both warn on an unknown type. */
+function openApiPrimitive(type: string | undefined, attributeName: string | undefined): JsonSchemaFragment {
+	if (type === 'Any' || type === undefined) return {};
+	const resolved = resolveDeclaredType(type, `OpenAPI property "${attributeName || '<unnamed>'}"`);
+	if (!resolved) return {};
+	// Preserve the Harper type name as `format` for the types where it adds information, matching the
+	// top-level `Type()` emitter.
+	return Object.hasOwn(DATA_TYPES, type) ? (new Type(resolved, type) as JsonSchemaFragment) : { type: resolved };
 }
 
 const SCHEMA_COMP_REF = '#/components/schemas/';
@@ -201,11 +205,13 @@ export function generateJsonApi(resources: Resources, serverHttpURL: string) {
 							props[name] = { type: 'array', items: attributeToOpenApiSchema(elements) ?? {} };
 						}
 					} else if (type === 'Any') {
+						// `format: 'Any'` with no `type` — preserved from the original emitter.
 						props[name] = { format: type };
-					} else if (!DATA_TYPES[type] && JSON_SCHEMA_SCALAR_TYPES.has(type)) {
-						props[name] = new Type(type);
 					} else {
-						props[name] = new Type(DATA_TYPES[type], type);
+						// Through the shared primitive mapper so an unrecognized type name warns here too.
+						// Previously only the MCP deriver warned, so a typo went unreported whenever the MCP
+						// component was disabled — the exact silence #1942 set out to remove.
+						props[name] = openApiPrimitive(type, name);
 					}
 				}
 				// Attach per-property JSON-Schema hints (description/enum/format/const) so they surface in

--- a/resources/openApi.ts
+++ b/resources/openApi.ts
@@ -604,7 +604,10 @@ function ResourceSchema(properties, additionalProperties?: boolean, required?: s
 	this.type = 'object';
 	this.properties = properties;
 	this.additionalProperties = additionalProperties;
-	this.required = required;
+	// Omit an empty list rather than emitting `required: []`. JSON Schema draft-04, which OpenAPI
+	// 3.0.3 inherits, requires at least one element, so `[]` fails strict validators — and a schema
+	// whose attributes are all nullable produces exactly that.
+	if (required?.length) this.required = required;
 	if (description) this.description = description;
 }
 

--- a/resources/openApi.ts
+++ b/resources/openApi.ts
@@ -1,9 +1,14 @@
 import { packageJson } from '../utility/packageUtils.js';
 import { Resources, routePatternToTemplate } from './Resources.ts';
 import { Resource } from './Resource.ts';
-import { DATA_TYPES } from './jsonSchemaTypes.ts';
+import { DATA_TYPES, attributeToFragment, projectPropertiesToAttributes } from './jsonSchemaTypes.ts';
 
 const OPENAPI_VERSION = '3.0.3';
+
+// A programmatic Resource's `static properties` uses JSON Schema types directly (lowercase). Harper's
+// GraphQL attribute types are all capitalized and live in DATA_TYPES, so a lowercase scalar reaching
+// the attribute mapper came from `static properties` and should be emitted as-is.
+const JSON_SCHEMA_SCALARS = new Set(['string', 'integer', 'number', 'boolean', 'object', 'array', 'null']);
 
 const SCHEMA_COMP_REF = '#/components/schemas/';
 const DESCRIPTION_200 = 'successful operation';
@@ -115,10 +120,15 @@ export function generateJsonApi(resources: Resources, serverHttpURL: string) {
 		// Used as both the schema-level `description` (in components.schemas) and as a prefix
 		// on each path-level operation description.
 		const tableDoc: string | undefined = resource.Resource.description;
-		if (!attributes && resources.allTypes.has(resource.path)) {
+		// A programmatic Resource may declare `static properties` (Record) without an `attributes`
+		// Array; project it so per-property schemas are emitted instead of a skeletal object.
+		if (!attributes?.length && resource.Resource.properties) {
+			attributes = projectPropertiesToAttributes(resource.Resource.properties);
+		}
+		if (!attributes?.length && resources.allTypes.has(resource.path)) {
 			const possibleType = resources.allTypes.get(resource.path);
 			sealed = possibleType.sealed;
-			attributes = possibleType.attributes ?? possibleType.properties;
+			attributes = possibleType.attributes ?? projectPropertiesToAttributes(possibleType.properties ?? {});
 		}
 		if (!primaryKey) continue;
 		const props = {};
@@ -151,21 +161,34 @@ export function generateJsonApi(resources: Resources, serverHttpURL: string) {
 						} else {
 							props[name] = { $ref: SCHEMA_COMP_REF + def.type };
 						}
+					} else if (attr.properties) {
+						// Nested object from `static properties` — the shared projector emits the full object
+						// schema (sub-properties recursed); OpenAPI's table path uses $refs instead.
+						props[name] = attributeToFragment(attr);
 					} else if (type === 'array') {
 						if (elements.type === 'Any') {
 							props[name] = { type: 'array', items: { format: elements.type } };
+						} else if (!DATA_TYPES[elements.type] && JSON_SCHEMA_SCALARS.has(elements.type)) {
+							props[name] = { type: 'array', items: new Type(elements.type) };
 						} else {
 							props[name] = { type: 'array', items: new Type(DATA_TYPES[elements.type], elements.type) };
 						}
 					} else if (type === 'Any') {
 						props[name] = { format: type };
+					} else if (!DATA_TYPES[type] && JSON_SCHEMA_SCALARS.has(type)) {
+						props[name] = new Type(type);
 					} else {
 						props[name] = new Type(DATA_TYPES[type], type);
 					}
 				}
-				// Attach per-property description so it surfaces in Swagger UI / Redoc.
-				if (description && props[name] && typeof props[name] === 'object' && !('$ref' in props[name])) {
-					(props[name] as { description?: string }).description = description;
+				// Attach per-property JSON-Schema hints (description/enum/format/const) so they surface in
+				// Swagger UI / Redoc; enum in particular tells clients the allowed values.
+				if (props[name] && typeof props[name] === 'object' && !('$ref' in props[name])) {
+					const prop = props[name] as { description?: string; enum?: unknown; format?: string; const?: unknown };
+					if (description) prop.description = description;
+					if (attr.enum && prop.enum === undefined) prop.enum = attr.enum;
+					if (attr.format && prop.format === undefined) prop.format = attr.format;
+					if (attr.const !== undefined && prop.const === undefined) prop.const = attr.const;
 				}
 				queryParamsArray.push(new Parameter(name, 'query', props[name]));
 			}
@@ -542,10 +565,10 @@ function ResourceSchema(properties, additionalProperties?: boolean, required?: s
 	if (description) this.description = description;
 }
 
-function Type(type, format) {
+function Type(type, format?) {
 	this.type = type;
 	if (type === 'string' || type === 'number' || type === 'integer') {
-		if (format !== 'String') {
+		if (format !== undefined && format !== 'String') {
 			this.format = format;
 		}
 	}

--- a/resources/openApi.ts
+++ b/resources/openApi.ts
@@ -182,19 +182,25 @@ export function generateJsonApi(resources: Resources, serverHttpURL: string) {
 					} else if (type === 'Any') {
 						props[name] = { format: type };
 					} else if (!DATA_TYPES[type] && JSON_SCHEMA_SCALAR_TYPES.has(type)) {
-						props[name] = new Type(type);
+						// OpenAPI 3.0.3 has no `'null'` type — nullability is expressed by the `nullable`
+						// keyword, so a bare `type: 'null'` becomes an untyped nullable schema.
+						props[name] = type === 'null' ? { nullable: true } : new Type(type);
 					} else {
 						props[name] = new Type(DATA_TYPES[type], type);
 					}
 				}
-				// Attach per-property JSON-Schema hints (description/enum/format/const) so they surface in
+				// Attach per-property JSON-Schema hints (description/enum/format) so they surface in
 				// Swagger UI / Redoc; enum in particular tells clients the allowed values.
+				//
+				// This document declares OpenAPI 3.0.3, whose Schema Object is the JSON Schema draft-04
+				// subset: `const` only arrived in draft-06, so it is not a keyword here. Emit the
+				// equivalent single-value `enum` instead of a keyword the declared dialect doesn't define.
 				if (props[name] && typeof props[name] === 'object' && !('$ref' in props[name])) {
-					const prop = props[name] as { description?: string; enum?: unknown; format?: string; const?: unknown };
+					const prop = props[name] as { description?: string; enum?: unknown; format?: string };
 					if (description) prop.description = description;
 					if (attr.enum && prop.enum === undefined) prop.enum = attr.enum;
 					if (attr.format && prop.format === undefined) prop.format = attr.format;
-					if (attr.const !== undefined && prop.const === undefined) prop.const = attr.const;
+					if (attr.const !== undefined && prop.enum === undefined) prop.enum = [attr.const];
 				}
 				queryParamsArray.push(new Parameter(name, 'query', props[name]));
 			}

--- a/resources/openApi.ts
+++ b/resources/openApi.ts
@@ -4,11 +4,34 @@ import { Resource } from './Resource.ts';
 import {
 	DATA_TYPES,
 	JSON_SCHEMA_SCALAR_TYPES,
-	attributeToFragment,
+	type AttributeLike,
+	type JsonSchemaFragment,
+	attributeToSchema,
 	projectPropertiesToAttributes,
+	resolveDeclaredType,
 } from './jsonSchemaTypes.ts';
 
 const OPENAPI_VERSION = '3.0.3';
+
+/**
+ * Emit an attribute as an OpenAPI 3.0.3 property schema. Shares its traversal with the MCP deriver so
+ * the two can't describe the same nested fragment differently; the primitive mapping stays
+ * OpenAPI-specific (`format` carries the Harper type name, which MCP has no equivalent for).
+ * Returns `undefined` for a `@hidden` attribute — callers skip it.
+ */
+function attributeToOpenApiSchema(attr: AttributeLike): JsonSchemaFragment | undefined {
+	return attributeToSchema(attr, {
+		dialect: 'openapi-3.0.3',
+		mapPrimitive: (type) => {
+			if (type === 'Any' || type === undefined) return {};
+			const resolved = resolveDeclaredType(type, `OpenAPI property "${attr.name}"`);
+			if (!resolved) return {};
+			// Preserve the Harper type name as `format` for the types where it adds information, matching
+			// the top-level `Type()` emitter.
+			return DATA_TYPES[type] ? (new Type(resolved, type) as JsonSchemaFragment) : { type: resolved };
+		},
+	});
+}
 
 const SCHEMA_COMP_REF = '#/components/schemas/';
 const DESCRIPTION_200 = 'successful operation';
@@ -162,22 +185,20 @@ export function generateJsonApi(resources: Resources, serverHttpURL: string) {
 							props[name] = { $ref: SCHEMA_COMP_REF + def.type };
 						}
 					} else if (attr.properties) {
-						// Nested object from `static properties` — the shared projector emits the full object
-						// schema (sub-properties recursed); OpenAPI's table path uses $refs instead.
-						props[name] = attributeToFragment(attr);
+						// Nested object from `static properties` — emit the full object schema through the
+						// shared emitter (sub-properties recursed, @hidden suppressed at every level, hints
+						// carried); OpenAPI's table path uses $refs instead.
+						props[name] = attributeToOpenApiSchema(attr) ?? {};
 					} else if (type === 'array') {
 						if (!elements) {
 							// `{ type: 'array' }` with no items — valid JSON Schema (array of anything).
 							props[name] = { type: 'array' };
-						} else if (elements.properties) {
-							// array of nested objects — project the element to its full object schema
-							props[name] = { type: 'array', items: attributeToFragment(elements) };
 						} else if (elements.type === 'Any') {
 							props[name] = { type: 'array', items: { format: elements.type } };
-						} else if (!DATA_TYPES[elements.type] && JSON_SCHEMA_SCALAR_TYPES.has(elements.type)) {
-							props[name] = { type: 'array', items: new Type(elements.type) };
 						} else {
-							props[name] = { type: 'array', items: new Type(DATA_TYPES[elements.type], elements.type) };
+							// Object and primitive elements alike go through the shared emitter, so an item's
+							// enum/format/const/description survives instead of being flattened to its type.
+							props[name] = { type: 'array', items: attributeToOpenApiSchema(elements) ?? {} };
 						}
 					} else if (type === 'Any') {
 						props[name] = { format: type };
@@ -188,13 +209,23 @@ export function generateJsonApi(resources: Resources, serverHttpURL: string) {
 					}
 				}
 				// Attach per-property JSON-Schema hints (description/enum/format/const) so they surface in
-				// Swagger UI / Redoc; enum in particular tells clients the allowed values.
+				// Swagger UI / Redoc; enum in particular tells clients the allowed values. `nullable` is
+				// OpenAPI 3.0.3's expression of a nullable property — it was previously computed only to
+				// derive `required` and never emitted, so a nullable property was advertised as
+				// non-nullable while a nested one (via the shared emitter) was not (#1942).
 				if (props[name] && typeof props[name] === 'object' && !('$ref' in props[name])) {
-					const prop = props[name] as { description?: string; enum?: unknown; format?: string; const?: unknown };
+					const prop = props[name] as {
+						description?: string;
+						enum?: unknown;
+						format?: string;
+						const?: unknown;
+						nullable?: boolean;
+					};
 					if (description) prop.description = description;
 					if (attr.enum && prop.enum === undefined) prop.enum = attr.enum;
 					if (attr.format && prop.format === undefined) prop.format = attr.format;
 					if (attr.const !== undefined && prop.const === undefined) prop.const = attr.const;
+					if (nullable && prop.nullable === undefined) prop.nullable = true;
 				}
 				queryParamsArray.push(new Parameter(name, 'query', props[name]));
 			}

--- a/unitTests/components/mcp/tools/application.test.js
+++ b/unitTests/components/mcp/tools/application.test.js
@@ -1087,3 +1087,127 @@ describe('mcp/tools/application — custom mcpResources opt-in (#1609)', () => {
 		assert.equal(matchCustomResource('application', 'docs:///index'), undefined);
 	});
 });
+
+describe('mcp/tools/application — #1920 programmatic `static properties` + docstrings', () => {
+	beforeEach(() => {
+		_resetRegistryForTest();
+		_setRequestTargetForTest(FakeRequestTarget);
+	});
+
+	afterEach(() => {
+		_resetRegistryForTest();
+		_setResourcesForTest(undefined);
+		_setRequestTargetForTest(undefined);
+		_resetApplicationToolsRegisteredForTest();
+	});
+
+	// A programmatic Resource: declares `static properties` (Record) and NO `attributes` Array.
+	function makeProgrammaticResource({ path, tableName, description, properties }) {
+		class Cls {}
+		Cls.databaseName = 'data';
+		Cls.tableName = tableName;
+		Cls.primaryKey = 'id';
+		if (description) Cls.description = description;
+		if (properties) Cls.properties = properties;
+		for (const v of ['get', 'put', 'patch', 'delete', 'search', 'post']) Cls.prototype[v] = function () {};
+		Cls.get = async (t) => ({ id: t.id });
+		Cls.put = async () => ({ ok: true });
+		Cls.patch = async () => ({ ok: true });
+		Cls.post = async (_t, d) => ({ created: true, ...d });
+		Cls.delete = async () => ({ deleted: true });
+		Cls.search = async () => [];
+		return { path, Resource: Cls };
+	}
+
+	it('derives a rich inputSchema from `static properties` when no attributes are declared', () => {
+		const Widget = makeProgrammaticResource({
+			path: 'Widget',
+			tableName: 'widget',
+			properties: {
+				id: { type: 'string', primaryKey: true },
+				label: { type: 'string', description: 'Human-readable label' },
+				size: { type: 'integer', description: 'Width in pixels' },
+				status: { type: 'string', enum: ['active', 'archived'] },
+				tags: { type: 'array', items: { type: 'string' } },
+			},
+		});
+		_setResourcesForTest(makeRegistry([['Widget', { Resource: Widget.Resource }]]));
+		registerApplicationTools();
+		const create = getTool('create_Widget');
+		assert.ok(create, 'create_Widget registered');
+		// Non-skeletal: each declared property surfaces with its type AND description.
+		assert.equal(create.inputSchema.properties.label.type, 'string');
+		assert.equal(create.inputSchema.properties.label.description, 'Human-readable label');
+		assert.equal(create.inputSchema.properties.size.type, 'integer');
+		assert.equal(create.inputSchema.properties.size.description, 'Width in pixels');
+		// enum and array shapes survive too (per cross-model review).
+		assert.deepEqual(create.inputSchema.properties.status.enum, ['active', 'archived']);
+		assert.equal(create.inputSchema.properties.tags.type, 'array');
+		assert.equal(create.inputSchema.properties.tags.items.type, 'string');
+	});
+
+	it('prefixes the verb-tool description with the class docstring / static description', () => {
+		const Widget = makeProgrammaticResource({
+			path: 'Widget',
+			tableName: 'widget',
+			description: 'A widget in the catalog.',
+			properties: { id: { type: 'string', primaryKey: true }, label: { type: 'string', description: 'The label' } },
+		});
+		_setResourcesForTest(makeRegistry([['Widget', { Resource: Widget.Resource }]]));
+		registerApplicationTools();
+		const get = getTool('get_Widget');
+		assert.ok(get, 'get_Widget registered');
+		assert.ok(
+			get.description.includes('A widget in the catalog.'),
+			`expected the docstring prefix on the tool description, got: ${get.description}`
+		);
+	});
+
+	it('carries per-attribute descriptions from a table-backed Resource into the tool inputSchema', () => {
+		// The table-backed path (real attributes carrying descriptions, as the GraphQL parser emits).
+		const Product = makeTableResource({
+			databaseName: 'data',
+			tableName: 'product',
+			attributes: [
+				{ name: 'id', isPrimaryKey: true, type: 'String' },
+				{ name: 'sku', type: 'String', description: 'Stock keeping unit' },
+			],
+		});
+		Product.description = 'A product record.';
+		_setResourcesForTest(makeRegistry([['Product', { Resource: Product }]]));
+		registerApplicationTools();
+		const create = getTool('create_Product');
+		assert.ok(create, 'create_Product registered');
+		assert.equal(create.inputSchema.properties.sku.description, 'Stock keeping unit');
+		const get = getTool('get_Product');
+		assert.ok(get.description.includes('A product record.'), `expected docstring prefix, got: ${get.description}`);
+	});
+
+	it('inherits `static properties` through class extension', () => {
+		class Base {}
+		Base.databaseName = 'data';
+		Base.primaryKey = 'id';
+		Base.properties = {
+			id: { type: 'string', primaryKey: true },
+			label: { type: 'string', description: 'inherited label' },
+		};
+		class Special extends Base {}
+		Special.tableName = 'special';
+		for (const v of ['get', 'put', 'patch', 'delete', 'search', 'post']) Special.prototype[v] = function () {};
+		Special.get = async (t) => ({ id: t.id });
+		Special.put = async () => ({});
+		Special.patch = async () => ({});
+		Special.post = async (_t, d) => d;
+		Special.delete = async () => ({});
+		Special.search = async () => [];
+		_setResourcesForTest(makeRegistry([['Special', { Resource: Special }]]));
+		registerApplicationTools();
+		const create = getTool('create_Special');
+		assert.ok(create, 'create_Special registered');
+		assert.equal(
+			create.inputSchema.properties.label.description,
+			'inherited label',
+			'child should derive its schema from the inherited static properties'
+		);
+	});
+});

--- a/unitTests/components/mcp/tools/application.test.js
+++ b/unitTests/components/mcp/tools/application.test.js
@@ -1146,6 +1146,35 @@ describe('mcp/tools/application — #1920 programmatic `static properties` + doc
 		assert.equal(create.inputSchema.properties.tags.items.type, 'string');
 	});
 
+	it('carries const, nested-object required, and array-of-object into the MCP inputSchema', () => {
+		const Widget = makeProgrammaticResource({
+			path: 'Widget',
+			tableName: 'widget',
+			properties: {
+				id: { type: 'string', primaryKey: true },
+				kind: { type: 'string', const: 'widget' },
+				dims: {
+					type: 'object',
+					required: ['w'],
+					additionalProperties: false,
+					properties: { w: { type: 'integer' }, h: { type: 'integer' } },
+				},
+				rows: { type: 'array', items: { type: 'object', properties: { x: { type: 'integer' } } } },
+			},
+		});
+		_setResourcesForTest(makeRegistry([['Widget', { Resource: Widget.Resource }]]));
+		registerApplicationTools();
+		const create = getTool('create_Widget');
+		assert.ok(create, 'create_Widget registered');
+		assert.equal(create.inputSchema.properties.kind.const, 'widget');
+		assert.deepEqual(create.inputSchema.properties.dims.required, ['w']);
+		assert.equal(create.inputSchema.properties.dims.additionalProperties, false);
+		assert.equal(create.inputSchema.properties.dims.properties.w.type, 'integer');
+		assert.equal(create.inputSchema.properties.rows.type, 'array');
+		assert.equal(create.inputSchema.properties.rows.items.type, 'object');
+		assert.equal(create.inputSchema.properties.rows.items.properties.x.type, 'integer');
+	});
+
 	it('prefixes the verb-tool description with the class docstring / static description', () => {
 		const Widget = makeProgrammaticResource({
 			path: 'Widget',

--- a/unitTests/components/mcp/tools/convergence.test.js
+++ b/unitTests/components/mcp/tools/convergence.test.js
@@ -223,3 +223,79 @@ describe('mcp/openapi — schema emitter convergence (#1941, #1942)', () => {
 		assert.equal(openapi.b.type, 'integer');
 	});
 });
+
+// Emitter-level behaviors that are cheaper to assert directly than through both surfaces.
+describe('attributeToSchema — emitter edge cases (#1941, #1942)', () => {
+	const {
+		attributeToSchema,
+		resolveDeclaredType,
+		_resetUnknownTypeWarningsForTest: resetWarnings,
+	} = require('#src/resources/jsonSchemaTypes');
+	const emit = (attr, dialect = 'openapi-3.0.3') =>
+		attributeToSchema(attr, { dialect, mapPrimitive: (type) => (type ? { type } : {}) });
+
+	beforeEach(() => resetWarnings());
+
+	it('omits `required` entirely when every required sub-property is suppressed', () => {
+		// JSON Schema draft-04 (which OpenAPI 3.0.3 inherits) requires at least one element, so
+		// `required: []` fails validators — and this list was synthesized from a non-empty one.
+		const out = emit({
+			name: 'profile',
+			properties: [{ name: 'secret', type: 'string', hidden: true }],
+			required: ['secret'],
+		});
+		assert.equal('required' in out, false, `required must be omitted, got ${JSON.stringify(out)}`);
+	});
+
+	it('does not resolve Object.prototype members as type names', () => {
+		// `DATA_TYPES` is an object literal, so a bare index put a function (or Object.prototype) into
+		// the emitted schema and suppressed the warning for a genuinely bogus name.
+		for (const bogus of ['constructor', '__proto__', 'toString']) {
+			assert.equal(resolveDeclaredType(bogus), undefined, `${bogus} must not resolve`);
+		}
+	});
+
+	it('drops nullability when the type never resolved', () => {
+		// A bare `nullable: true` with no `type` is meaningless in OpenAPI 3.0.3 — it modifies `type`.
+		const out = attributeToSchema(
+			{ name: 'x', type: 'Nonsense', nullable: true },
+			{ dialect: 'openapi-3.0.3', mapPrimitive: () => ({}) }
+		);
+		assert.equal(out.nullable, undefined, `got ${JSON.stringify(out)}`);
+	});
+
+	it('warns once per unrecognized type name, and names the property', () => {
+		const logger = require('#src/utility/logging/harper_logger');
+		const warnings = [];
+		const original = logger.warn;
+		logger.warn = (m) => warnings.push(String(m));
+		try {
+			resolveDeclaredType('Nonsense', 'OpenAPI property "widget"');
+			resolveDeclaredType('Nonsense', 'OpenAPI property "widget"');
+		} finally {
+			logger.warn = original;
+		}
+		assert.equal(warnings.length, 1, 'warn-once per name');
+		assert.ok(warnings[0].includes('"Nonsense"'), warnings[0]);
+		assert.ok(warnings[0].includes('widget'), `warning should name the property: ${warnings[0]}`);
+		assert.ok(warnings[0].includes('Blob'), `Harper type list should be complete: ${warnings[0]}`);
+	});
+
+	it('keeps a hidden sub-property suppressed even under ignoreHidden', () => {
+		// ignoreHidden exists for the primary-key addressing argument; it must not cascade into fields.
+		const out = attributeToSchema(
+			{
+				name: 'pk',
+				hidden: true,
+				properties: [
+					{ name: 'visible', type: 'string' },
+					{ name: 'secret', type: 'string', hidden: true },
+				],
+			},
+			{ dialect: 'json-schema', mapPrimitive: (type) => ({ type }), ignoreHidden: true }
+		);
+		assert.ok(out, 'the hidden attribute itself is emitted');
+		assert.ok(out.properties.visible);
+		assert.equal(out.properties.secret, undefined, 'hidden sub-property stays suppressed');
+	});
+});

--- a/unitTests/components/mcp/tools/convergence.test.js
+++ b/unitTests/components/mcp/tools/convergence.test.js
@@ -1,0 +1,77 @@
+// #1920 — a single class-level metadata source (docstring + `static properties`) must surface on
+// BOTH the MCP tool descriptors and the OpenAPI document. This is the cross-surface convergence the
+// #1095 acceptance called for; previously each surface was tested in isolation.
+const assert = require('node:assert');
+const {
+	registerApplicationTools,
+	_setResourcesForTest,
+	_setRequestTargetForTest,
+	_resetApplicationToolsRegisteredForTest,
+} = require('#src/components/mcp/tools/application');
+const { getTool, _resetRegistryForTest } = require('#src/components/mcp/toolRegistry');
+const { generateJsonApi } = require('#src/resources/openApi');
+
+class FakeRequestTarget {}
+
+// One programmatic Resource, shared by both surfaces.
+function makeResources() {
+	class Widget {}
+	Widget.databaseName = 'data';
+	Widget.tableName = 'widget';
+	Widget.primaryKey = 'id';
+	Widget.description = 'A widget in the catalog.';
+	Widget.properties = {
+		id: { type: 'string', primaryKey: true },
+		label: { type: 'string', description: 'Human-readable label' },
+	};
+	for (const v of ['get', 'put', 'patch', 'delete', 'search', 'post']) Widget.prototype[v] = function () {};
+	Widget.get = async (t) => ({ id: t.id });
+	Widget.put = async () => ({ ok: true });
+	Widget.patch = async () => ({ ok: true });
+	Widget.post = async (_t, d) => ({ created: true, ...d });
+	Widget.delete = async () => ({ deleted: true });
+	Widget.search = async () => [];
+
+	const resources = new Map();
+	resources.set('Widget', { path: 'Widget', Resource: Widget, hasSubPaths: false, relativeURL: '' });
+	resources.allTypes = new Map();
+	return resources;
+}
+
+describe('mcp/openapi — #1920 description convergence across surfaces', () => {
+	beforeEach(() => {
+		_resetRegistryForTest();
+		_setRequestTargetForTest(FakeRequestTarget);
+	});
+	afterEach(() => {
+		_resetRegistryForTest();
+		_setResourcesForTest(undefined);
+		_setRequestTargetForTest(undefined);
+		_resetApplicationToolsRegisteredForTest();
+	});
+
+	it('surfaces the docstring and per-property descriptions on both MCP tools and OpenAPI', () => {
+		const resources = makeResources();
+
+		// MCP side
+		_setResourcesForTest(resources);
+		registerApplicationTools();
+		const get = getTool('get_Widget');
+		const create = getTool('create_Widget');
+		assert.ok(get && create, 'MCP verb tools registered');
+		assert.ok(
+			get.description.includes('A widget in the catalog.'),
+			`MCP get tool should carry the docstring, got: ${get.description}`
+		);
+		assert.equal(create.inputSchema.properties.label.description, 'Human-readable label');
+
+		// OpenAPI side — same source
+		const api = generateJsonApi(resources, 'https://harper.fast');
+		const schema = api.components.schemas.Widget;
+		assert.equal(schema.description, 'A widget in the catalog.', 'OpenAPI schema should carry the docstring');
+		assert.equal(schema.properties.label.description, 'Human-readable label');
+
+		// Convergence: the per-property description is identical on both surfaces.
+		assert.equal(create.inputSchema.properties.label.description, schema.properties.label.description);
+	});
+});

--- a/unitTests/components/mcp/tools/convergence.test.js
+++ b/unitTests/components/mcp/tools/convergence.test.js
@@ -23,6 +23,7 @@ function makeResources() {
 	Widget.properties = {
 		id: { type: 'string', primaryKey: true },
 		label: { type: 'string', description: 'Human-readable label' },
+		mixed: { type: ['string', 'number'] },
 	};
 	for (const v of ['get', 'put', 'patch', 'delete', 'search', 'post']) Widget.prototype[v] = function () {};
 	Widget.get = async (t) => ({ id: t.id });
@@ -73,5 +74,21 @@ describe('mcp/openapi — #1920 description convergence across surfaces', () => 
 
 		// Convergence: the per-property description is identical on both surfaces.
 		assert.equal(create.inputSchema.properties.label.description, schema.properties.label.description);
+	});
+
+	it('expresses a declared type union on each surface in that surface’s own dialect', () => {
+		const resources = makeResources();
+
+		_setResourcesForTest(resources);
+		registerApplicationTools();
+		const create = getTool('create_Widget');
+		// MCP speaks JSON Schema, which has type unions — pass the author's declaration through.
+		assert.deepEqual(create.inputSchema.properties.mixed.type, ['string', 'number']);
+
+		// OpenAPI 3.0 has no type arrays; the equivalent is `oneOf`. Same declaration, two encodings —
+		// what must NOT happen is either surface narrowing it to `string`.
+		const schema = generateJsonApi(resources, 'https://harper.fast').components.schemas.Widget;
+		assert.deepEqual(schema.properties.mixed.oneOf, [{ type: 'string' }, { type: 'number' }]);
+		assert.equal(schema.properties.mixed.type, undefined);
 	});
 });

--- a/unitTests/components/mcp/tools/convergence.test.js
+++ b/unitTests/components/mcp/tools/convergence.test.js
@@ -10,6 +10,7 @@ const {
 } = require('#src/components/mcp/tools/application');
 const { getTool, _resetRegistryForTest } = require('#src/components/mcp/toolRegistry');
 const { generateJsonApi } = require('#src/resources/openApi');
+const { _resetUnknownTypeWarningsForTest } = require('#src/resources/jsonSchemaTypes');
 
 class FakeRequestTarget {}
 
@@ -73,5 +74,152 @@ describe('mcp/openapi — #1920 description convergence across surfaces', () => 
 
 		// Convergence: the per-property description is identical on both surfaces.
 		assert.equal(create.inputSchema.properties.label.description, schema.properties.label.description);
+	});
+});
+
+// #1941 / #1942 — the two surfaces used to diverge below the top level: OpenAPI dropped hints inside
+// nested objects, neither suppressed a hidden sub-property, and nullability was expressed three
+// different ways. These assert the same fragment on both surfaces, side by side.
+describe('mcp/openapi — schema emitter convergence (#1941, #1942)', () => {
+	beforeEach(() => {
+		_resetRegistryForTest();
+		_setRequestTargetForTest(FakeRequestTarget);
+		_resetUnknownTypeWarningsForTest();
+	});
+	afterEach(() => {
+		_resetRegistryForTest();
+		_setResourcesForTest(undefined);
+		_setRequestTargetForTest(undefined);
+		_resetApplicationToolsRegisteredForTest();
+	});
+
+	// Builds both surfaces from one `static properties` declaration and hands back the emitted
+	// property schemas so a test can compare them directly.
+	function bothSurfaces(properties) {
+		class Thing {}
+		Thing.databaseName = 'data';
+		Thing.tableName = 'thing';
+		Thing.primaryKey = 'id';
+		Thing.properties = { id: { type: 'string', primaryKey: true }, ...properties };
+		for (const v of ['get', 'put', 'patch', 'delete', 'search', 'post']) Thing.prototype[v] = function () {};
+		Thing.get = async (t) => ({ id: t.id });
+		Thing.put = async () => ({ ok: true });
+		Thing.patch = async () => ({ ok: true });
+		Thing.post = async (_t, d) => ({ created: true, ...d });
+		Thing.delete = async () => ({ deleted: true });
+		Thing.search = async () => [];
+
+		const resources = new Map();
+		resources.set('Thing', { path: 'Thing', Resource: Thing, hasSubPaths: false, relativeURL: '' });
+		resources.allTypes = new Map();
+
+		_setResourcesForTest(resources);
+		registerApplicationTools();
+		const mcp = getTool('create_Thing').inputSchema.properties;
+		const openapi = generateJsonApi(resources, 'https://harper.fast').components.schemas.Thing.properties;
+		return { mcp, openapi };
+	}
+
+	it('suppresses a hidden sub-property on both surfaces and never emits `hidden` as a schema key', () => {
+		const { mcp, openapi } = bothSurfaces({
+			profile: {
+				type: 'object',
+				properties: {
+					name: { type: 'string' },
+					creditScore: { type: 'integer', hidden: true, description: 'internal only' },
+				},
+			},
+		});
+		for (const [surface, props] of [
+			['mcp', mcp],
+			['openapi', openapi],
+		]) {
+			assert.ok(props.profile.properties.name, `${surface}: visible sub-property kept`);
+			assert.equal(
+				props.profile.properties.creditScore,
+				undefined,
+				`${surface}: hidden sub-property must be suppressed`
+			);
+			assert.equal(
+				JSON.stringify(props.profile).includes('"hidden"'),
+				false,
+				`${surface}: the hidden directive must not leak into the emitted schema`
+			);
+			assert.equal(
+				JSON.stringify(props.profile).includes('internal only'),
+				false,
+				`${surface}: a hidden sub-property's description must not leak`
+			);
+		}
+	});
+
+	it('drops a suppressed sub-property from the nested `required` list', () => {
+		// Advertising a required property the schema doesn't define makes the object unsatisfiable.
+		const { mcp, openapi } = bothSurfaces({
+			profile: {
+				type: 'object',
+				properties: { name: { type: 'string' }, secret: { type: 'string', hidden: true } },
+				required: ['name', 'secret'],
+			},
+		});
+		assert.deepEqual(mcp.profile.required, ['name']);
+		assert.deepEqual(openapi.profile.required, ['name']);
+	});
+
+	it('carries enum/format/const/description into nested objects and array items on both surfaces', () => {
+		const { mcp, openapi } = bothSurfaces({
+			order: {
+				type: 'object',
+				properties: {
+					status: { type: 'string', enum: ['open', 'closed'], description: 'Fulfillment state.' },
+					placedAt: { type: 'string', format: 'date-time' },
+					kind: { type: 'string', const: 'order' },
+				},
+			},
+			tags: { type: 'array', items: { type: 'string', enum: ['a', 'b'], description: 'Tag value.' } },
+		});
+		for (const [surface, props] of [
+			['mcp', mcp],
+			['openapi', openapi],
+		]) {
+			assert.deepEqual(props.order.properties.status.enum, ['open', 'closed'], `${surface}: nested enum`);
+			assert.equal(props.order.properties.status.description, 'Fulfillment state.', `${surface}: nested description`);
+			assert.equal(props.order.properties.placedAt.format, 'date-time', `${surface}: nested format`);
+			assert.equal(props.order.properties.kind.const, 'order', `${surface}: nested const`);
+			assert.deepEqual(props.tags.items.enum, ['a', 'b'], `${surface}: array item enum`);
+			assert.equal(props.tags.items.description, 'Tag value.', `${surface}: array item description`);
+		}
+	});
+
+	it('expresses nullability per dialect, consistently at top level and nested', () => {
+		const { mcp, openapi } = bothSurfaces({
+			note: { type: ['string', 'null'] },
+			wrapper: { type: 'object', properties: { inner: { type: 'string', nullable: true } } },
+		});
+		// MCP speaks JSON Schema: a union including 'null'.
+		assert.deepEqual(mcp.note.type, ['string', 'null'], 'mcp top-level union');
+		assert.deepEqual(mcp.wrapper.properties.inner.type, ['string', 'null'], 'mcp nested union');
+		assert.equal(mcp.note.nullable, undefined, 'mcp must not emit the OpenAPI keyword');
+		// OpenAPI 3.0.3 has no union types: the `nullable` keyword, at BOTH levels (it was previously
+		// emitted only on nested properties and silently dropped at the top level).
+		assert.equal(openapi.note.type, 'string', 'openapi top-level stays a single type');
+		assert.equal(openapi.note.nullable, true, 'openapi top-level nullable is emitted');
+		assert.equal(openapi.wrapper.properties.inner.nullable, true, 'openapi nested nullable is emitted');
+	});
+
+	it('emits an unrecognized type name as untyped on both surfaces instead of diverging', () => {
+		// MCP used to coerce an unknown name to `string` while OpenAPI emitted `{}` — two different
+		// wrong answers from one typo, with no signal to the author.
+		const { mcp, openapi } = bothSurfaces({ weird: { type: 'Text' } });
+		assert.equal(mcp.weird.type, undefined, 'mcp does not invent a type');
+		assert.equal(openapi.weird.type, undefined, 'openapi does not invent a type');
+	});
+
+	it('leaves recognized GraphQL and JSON Schema type names mapping correctly', () => {
+		const { mcp, openapi } = bothSurfaces({ a: { type: 'String' }, b: { type: 'integer' } });
+		assert.equal(mcp.a.type, 'string');
+		assert.equal(mcp.b.type, 'integer');
+		assert.equal(openapi.a.type, 'string');
+		assert.equal(openapi.b.type, 'integer');
 	});
 });

--- a/unitTests/components/mcp/tools/derive.test.js
+++ b/unitTests/components/mcp/tools/derive.test.js
@@ -199,3 +199,58 @@ describe('mcp/tools/schemas/derive', () => {
 		});
 	});
 });
+
+// #1941/#1942 follow-ups found in review of the shared-emitter refactor.
+describe('mcp/derive — hidden attributes and unrecognized types', () => {
+	const hiddenPk = [{ name: 'id', type: 'Int', isPrimaryKey: true, hidden: true }];
+
+	it('keeps the primary key typed on every verb even when it is @hidden', () => {
+		// The `id` argument addresses the record; it is not one of the record's fields, so @hidden must
+		// not strip it. Suppressing it produced a REQUIRED tool argument with no type at all, and the
+		// four derive sites disagreed with each other.
+		const get = deriveGetSchema(hiddenPk, undefined).properties.id;
+		const update = deriveUpdateSchema(hiddenPk, undefined).properties.id;
+		const del = deriveDeleteSchema(hiddenPk, undefined).properties.id;
+		for (const [verb, schema] of [
+			['get', get],
+			['update', update],
+			['delete', del],
+		]) {
+			assert.equal(schema.type, 'integer', `${verb} keeps the declared PK type`);
+		}
+		assert.equal(get.type, update.type, 'all verbs agree on the id type');
+		assert.equal(get.type, del.type);
+	});
+
+	it('still suppresses a hidden non-key attribute from the same schemas', () => {
+		// Guards the fix above from over-reaching: only the PK is exempt.
+		const attrs = [
+			{ name: 'id', type: 'String', isPrimaryKey: true },
+			{ name: 'secret', type: 'String', hidden: true },
+		];
+		assert.equal(deriveCreateSchema(attrs, undefined).properties.secret, undefined);
+		assert.equal(deriveGetOutputSchema(attrs, undefined).properties.secret, undefined);
+	});
+
+	it('does not warn for Harper primitives that carry no DATA_TYPES entry (Blob, Any)', () => {
+		// `Blob` and `Any` are in graphql.ts's PRIMITIVE_TYPES but absent from DATA_TYPES, so a naive
+		// lookup reported them as typos on every process start.
+		const logger = require('#src/utility/logging/harper_logger');
+		const warnings = [];
+		const original = logger.warn;
+		logger.warn = (m) => warnings.push(String(m));
+		try {
+			deriveGetOutputSchema(
+				[
+					{ name: 'id', type: 'String', isPrimaryKey: true },
+					{ name: 'payload', type: 'Blob' },
+					{ name: 'anything', type: 'Any' },
+				],
+				undefined
+			);
+		} finally {
+			logger.warn = original;
+		}
+		assert.deepEqual(warnings, [], `Blob/Any must not warn: ${JSON.stringify(warnings)}`);
+	});
+});

--- a/unitTests/components/mcp/tools/operations.test.js
+++ b/unitTests/components/mcp/tools/operations.test.js
@@ -349,6 +349,27 @@ describe('mcp/tools/operations — registration', () => {
 		const { tools } = listTools({ user: SUPER, profile: 'operations', sessionId: 's', limit: 200 });
 		assert.equal(tools.length, 0);
 	});
+
+	it('does not emit idempotentHint on the actual non-idempotent tools (add_user, add_role)', () => {
+		// add_user / add_role / create_* are NOT idempotent under MCP semantics — a second call
+		// returns an "already exists" error, so annotating them idempotent nudges LLMs into retry
+		// loops. IDEMPOTENT_OPERATIONS ships empty; verify that against the EMITTED tool annotations,
+		// not just the descriptions map (which would pass trivially).
+		envOverrides.mcp_operations_allow = ['add_user', 'add_role', 'describe_all'];
+		_setOperationFunctionMapForTest(
+			makeOpMap([
+				['add_user', null],
+				['add_role', null],
+				['describe_all', null],
+			])
+		);
+		registerOperationsTools();
+		for (const name of ['add_user', 'add_role', 'describe_all']) {
+			const tool = getTool(name);
+			assert.ok(tool, `${name} registered`);
+			assert.notEqual(tool.annotations?.idempotentHint, true, `${name} must not be annotated idempotentHint:true`);
+		}
+	});
 });
 
 describe('mcp/tools/operations — catalog coverage lint', () => {
@@ -384,12 +405,10 @@ describe('mcp/tools/operations — catalog coverage lint', () => {
 		assert.deepEqual(missing, [], `Operations on DEFAULT_ALLOW without a description: ${missing.join(', ')}`);
 	});
 
-	it('OPERATION_DESCRIPTIONS does not annotate non-idempotent operations as idempotent (sanity)', () => {
-		// add_user / create_* are NOT idempotent under MCP semantics — second call returns
-		// an "already exists" error. Annotating them as idempotent nudges LLMs into
-		// retry loops with confusing failures. Catch via description-text sniff plus
-		// the IDEMPOTENT_OPERATIONS set check below.
-		assert.ok(!('idempotentHint' in OPERATION_DESCRIPTIONS), 'descriptions are strings, not objects');
+	it('OPERATION_DESCRIPTIONS entries are strings (annotations are emitted at registration, tested there)', () => {
+		// idempotentHint / readOnlyHint etc. are emitted onto the registered tool, not stored here.
+		// The emitted-annotation behavior for non-idempotent ops is asserted in the registration suite.
+		assert.ok(Object.values(OPERATION_DESCRIPTIONS).every((d) => typeof d === 'string'));
 	});
 
 	it('all description entries cite the source handler in a preceding comment', () => {

--- a/unitTests/resources/graphqlMetadata.test.js
+++ b/unitTests/resources/graphqlMetadata.test.js
@@ -154,4 +154,37 @@ describe('GraphQL parser — metadata capture (#1095)', () => {
 			assert.ok(tables.ShapeCheck.properties.title);
 		});
 	});
+
+	// #1920: a programmatic Resource may declare `static properties` (the Record form) without an
+	// `attributes` Array; `projectPropertiesToAttributes` rebuilds the Array so the schema-derivation
+	// paths (MCP, OpenAPI) can consume it. It must be the structural inverse of the forward projection.
+	describe('projectPropertiesToAttributes (#1920)', () => {
+		const { projectPropertiesToAttributes, projectAttributesToProperties } = require('#src/resources/jsonSchemaTypes');
+
+		it('projects each property into a named attribute carrying type + description + flags', () => {
+			const attrs = projectPropertiesToAttributes({
+				id: { type: 'string', primaryKey: true },
+				label: { type: 'string', description: 'Human-readable label' },
+				size: { type: 'integer', description: 'Width in pixels', nullable: true },
+			});
+			const byName = Object.fromEntries(attrs.map((a) => [a.name, a]));
+			assert.strictEqual(byName.id.isPrimaryKey, true);
+			assert.strictEqual(byName.label.type, 'string');
+			assert.strictEqual(byName.label.description, 'Human-readable label');
+			assert.strictEqual(byName.size.type, 'integer');
+			assert.strictEqual(byName.size.nullable, true);
+		});
+
+		it('round-trips with projectAttributesToProperties (properties -> attributes -> properties)', () => {
+			// Includes JSON-only hints (enum, format) and nested/array shapes to prove nothing is dropped.
+			const properties = {
+				sku: { type: 'string', description: 'Stock keeping unit', primaryKey: true },
+				status: { type: 'string', enum: ['active', 'archived'], format: 'x-status' },
+				tags: { type: 'array', items: { type: 'string' } },
+				dims: { type: 'object', properties: { w: { type: 'integer' }, h: { type: 'integer' } } },
+			};
+			const roundTripped = projectAttributesToProperties(projectPropertiesToAttributes(properties));
+			assert.deepStrictEqual(roundTripped, properties);
+		});
+	});
 });

--- a/unitTests/resources/graphqlMetadata.test.js
+++ b/unitTests/resources/graphqlMetadata.test.js
@@ -176,11 +176,12 @@ describe('GraphQL parser — metadata capture (#1095)', () => {
 		});
 
 		it('round-trips with projectAttributesToProperties (properties -> attributes -> properties)', () => {
-			// Includes JSON-only hints (enum, format), nested/array shapes, and nested object-level
-			// constraints (required/additionalProperties) to prove nothing is dropped.
+			// The `.properties` projection is front-end-neutral: type, description, primaryKey,
+			// nested/array shapes, and nested object-level constraints (required/additionalProperties)
+			// survive. enum/format/const deliberately do NOT (they'd break code-first ⇔ GraphQL parity
+			// for `types.enum`; the MCP/OpenAPI schema paths surface those instead — see below).
 			const properties = {
 				sku: { type: 'string', description: 'Stock keeping unit', primaryKey: true },
-				status: { type: 'string', enum: ['active', 'archived'], format: 'x-status' },
 				tags: { type: 'array', items: { type: 'string' } },
 				dims: {
 					type: 'object',

--- a/unitTests/resources/graphqlMetadata.test.js
+++ b/unitTests/resources/graphqlMetadata.test.js
@@ -176,15 +176,27 @@ describe('GraphQL parser — metadata capture (#1095)', () => {
 		});
 
 		it('round-trips with projectAttributesToProperties (properties -> attributes -> properties)', () => {
-			// Includes JSON-only hints (enum, format) and nested/array shapes to prove nothing is dropped.
+			// Includes JSON-only hints (enum, format), nested/array shapes, and nested object-level
+			// constraints (required/additionalProperties) to prove nothing is dropped.
 			const properties = {
 				sku: { type: 'string', description: 'Stock keeping unit', primaryKey: true },
 				status: { type: 'string', enum: ['active', 'archived'], format: 'x-status' },
 				tags: { type: 'array', items: { type: 'string' } },
-				dims: { type: 'object', properties: { w: { type: 'integer' }, h: { type: 'integer' } } },
+				dims: {
+					type: 'object',
+					required: ['w'],
+					additionalProperties: false,
+					properties: { w: { type: 'integer' }, h: { type: 'integer' } },
+				},
 			};
 			const roundTripped = projectAttributesToProperties(projectPropertiesToAttributes(properties));
 			assert.deepStrictEqual(roundTripped, properties);
+		});
+
+		it('folds a JSON-Schema union `["T","null"]` into nullable (not truncated to the first member)', () => {
+			const [note] = projectPropertiesToAttributes({ note: { type: ['string', 'null'] } });
+			assert.strictEqual(note.type, 'string');
+			assert.strictEqual(note.nullable, true, 'the null member must become nullable, not be dropped');
 		});
 	});
 });

--- a/unitTests/resources/graphqlMetadata.test.js
+++ b/unitTests/resources/graphqlMetadata.test.js
@@ -199,5 +199,24 @@ describe('GraphQL parser — metadata capture (#1095)', () => {
 			assert.strictEqual(note.type, 'string');
 			assert.strictEqual(note.nullable, true, 'the null member must become nullable, not be dropped');
 		});
+
+		it('preserves a genuine multi-type union instead of keeping only the first member', () => {
+			const [mixed] = projectPropertiesToAttributes({ mixed: { type: ['string', 'number'] } });
+			assert.deepStrictEqual(mixed.types, ['string', 'number']);
+			assert.strictEqual(mixed.type, 'string', 'single-type consumers still see the first member');
+		});
+
+		it('round-trips a union back to the declared fragment (properties -> attributes -> properties)', () => {
+			const declared = { mixed: { type: ['string', 'number'] }, maybe: { type: ['string', 'null'] } };
+			const round = projectAttributesToProperties(projectPropertiesToAttributes(declared));
+			assert.deepStrictEqual(round.mixed.type, ['string', 'number']);
+			assert.deepStrictEqual(round.maybe.type, ['string', 'null']);
+		});
+
+		it('keeps a `["null"]`-only declaration nullable rather than silently untyped', () => {
+			const [nothing] = projectPropertiesToAttributes({ nothing: { type: ['null'] } });
+			assert.strictEqual(nothing.nullable, true);
+			assert.deepStrictEqual(nothing.types, ['null']);
+		});
 	});
 });

--- a/unitTests/resources/openApi.test.js
+++ b/unitTests/resources/openApi.test.js
@@ -348,7 +348,12 @@ describe('openApi — declared dialect compliance (3.0.3)', () => {
 	// Keywords absent from the draft-04 subset OpenAPI 3.0.x is built on.
 	const POST_DRAFT4_KEYWORDS = ['const', 'contentEncoding', 'contentMediaType', 'if', 'then', 'else', '$defs'];
 
+	// `components.securitySchemes` holds Security Scheme Objects, not Schema Objects — their `type`
+	// ("http", "apiKey", …) is a different vocabulary and must not be judged against Schema Object rules.
+	const NON_SCHEMA_SUBTREES = ['$.components.securitySchemes'];
+
 	function walk(node, visit, path = '$') {
+		if (NON_SCHEMA_SUBTREES.some((prefix) => path.startsWith(prefix))) return;
 		if (node === null || typeof node !== 'object') return;
 		if (Array.isArray(node)) {
 			node.forEach((item, i) => walk(item, visit, `${path}[${i}]`));
@@ -366,8 +371,14 @@ describe('openApi — declared dialect compliance (3.0.3)', () => {
 			kind: { type: 'string', const: 'widget' },
 			nothing: { type: 'null' },
 			maybe: { type: ['string', 'null'] },
-			nested: { type: 'object', properties: { inner: { type: 'string', const: 'x' } } },
+			nested: { type: 'object', properties: { inner: { type: 'string', const: 'x' }, deepNull: { type: 'null' } } },
 			list: { type: 'array', items: { type: 'string', const: 'y' } },
+			nullableEnum: { type: 'string', enum: ['a', 'b'], nullable: true },
+			nullableConst: { type: 'string', const: 'fixed', nullable: true },
+			bogus: { type: 'Text' },
+			secret: { type: 'string', hidden: true },
+			when: { type: 'Date', format: 'date-time' },
+			bytes: { type: 'Bytes' },
 		};
 		Widget.prototype.get = function () {};
 		const resources = new Map();
@@ -390,17 +401,58 @@ describe('openApi — declared dialect compliance (3.0.3)', () => {
 		expect(offenders, `post-draft-04 keywords in a 3.0.3 document: ${offenders.join(', ')}`).to.deep.equal([]);
 	});
 
-	it('never emits `type: "null"`, which 3.0.x does not define', () => {
+	it('emits only the six type values 3.0.x defines, and never a type array', () => {
+		// 3.0's `type` is a closed enum of single values: no `'null'`, no unions, and nothing from
+		// Harper's own vocabulary. Checking only for `'null'` would sail past `type: 'Text'` or
+		// `['string','number']`, both equally invalid here.
+		const OPENAPI_30_TYPES = ['string', 'number', 'integer', 'boolean', 'object', 'array'];
 		const offenders = [];
 		walk(buildDocument(), (node, path) => {
+			if (!Object.hasOwn(node, 'type')) return;
 			const t = node.type;
-			if (t === 'null' || (Array.isArray(t) && t.includes('null'))) offenders.push(`${path}.type`);
+			if (Array.isArray(t)) offenders.push(`${path}.type=[${t.join(',')}] (unions invalid in 3.0)`);
+			else if (!OPENAPI_30_TYPES.includes(t)) offenders.push(`${path}.type=${String(t)}`);
 		});
-		expect(offenders, `\`null\` types in a 3.0.3 document: ${offenders.join(', ')}`).to.deep.equal([]);
+		expect(offenders, `invalid 3.0 types: ${offenders.join(', ')}`).to.deep.equal([]);
 	});
 
-	it('translates `const` to a single-value `enum`', () => {
-		const schema = buildDocument().components.schemas.Widget;
-		expect(schema.properties.kind.enum).to.deep.equal(['widget']);
+	it('never leaks a Harper directive into the emitted document', () => {
+		// `hidden`/`primaryKey`/the timestamp flags drive Harper behavior; they are not schema vocabulary
+		// and a consumer parsing this document has no meaning for them.
+		const DIRECTIVES = ['hidden', 'primaryKey', 'assignCreatedTime', 'assignUpdatedTime'];
+		const offenders = [];
+		walk(buildDocument(), (node, path) => {
+			for (const key of DIRECTIVES) if (Object.hasOwn(node, key)) offenders.push(`${path}.${key}`);
+		});
+		expect(offenders, `Harper directives in the document: ${offenders.join(', ')}`).to.deep.equal([]);
+	});
+
+	it('translates `const` to a single-value `enum`, at every depth', () => {
+		const props = buildDocument().components.schemas.Widget.properties;
+		expect(props.kind.enum).to.deep.equal(['widget']);
+		expect(props.kind).to.not.have.property('const');
+		expect(props.nested.properties.inner.enum).to.deep.equal(['x']);
+		expect(props.list.items.enum).to.deep.equal(['y']);
+	});
+
+	it('includes null in the value list when a nullable property carries an enum', () => {
+		// 3.0's `nullable` does not widen an `enum` — without `null` in the list a validator rejects it
+		// regardless of the flag, so the schema would contradict itself.
+		const doc = buildDocument();
+		const props = doc.components.schemas.Widget.properties;
+		expect(props.nullableEnum.enum).to.deep.equal(['a', 'b', null]);
+		expect(props.nullableEnum.nullable).to.equal(true);
+		expect(props.nullableConst.enum).to.deep.equal(['fixed', null]);
+	});
+
+	it('lets an author-declared format outrank the Harper type name', () => {
+		expect(buildDocument().components.schemas.Widget.properties.when.format).to.equal('date-time');
+	});
+
+	it('emits the properties under test (guards the walk assertions against an empty document)', () => {
+		const props = buildDocument().components.schemas.Widget.properties;
+		for (const key of ['kind', 'nothing', 'maybe', 'nested', 'list', 'nullableEnum', 'nullableConst', 'when']) {
+			expect(props, `fixture property ${key} missing — walk assertions would pass vacuously`).to.have.property(key);
+		}
 	});
 });

--- a/unitTests/resources/openApi.test.js
+++ b/unitTests/resources/openApi.test.js
@@ -419,6 +419,22 @@ describe('openApi — declared dialect compliance (3.0.3)', () => {
 		expect(props.kind).to.not.have.property('const');
 	});
 
+	it('carries nullability onto the emitted scalar schema', () => {
+		// The walk assertions above only prove `type: 'null'` and unions are gone; they would pass just as
+		// happily if nullability were dropped instead of translated.
+		const props = buildDocument().components.schemas.Widget.properties;
+		expect(props.maybe).to.deep.equal({ type: 'string', nullable: true });
+		expect(props.nothing.nullable).to.equal(true);
+	});
+
+	it('widens a nullable `enum` with `null` (3.0 `nullable` does not do it)', () => {
+		const props = buildDocument().components.schemas.Widget.properties;
+		expect(props.nullableEnum.nullable).to.equal(true);
+		expect(props.nullableEnum.enum).to.deep.equal(['a', 'b', null]);
+		// `const` + `nullable`: the single-value enum still has to admit null.
+		expect(props.nullableConst.enum).to.deep.equal(['fixed', null]);
+	});
+
 	it('emits the properties under test (guards the walk assertions against an empty document)', () => {
 		const props = buildDocument().components.schemas.Widget.properties;
 		for (const key of ['kind', 'nothing', 'maybe', 'nested', 'list', 'nullableEnum', 'nullableConst', 'when']) {

--- a/unitTests/resources/openApi.test.js
+++ b/unitTests/resources/openApi.test.js
@@ -322,3 +322,69 @@ describe('test openApi module', () => {
 		});
 	});
 });
+
+// The document declares OpenAPI 3.0.3, whose Schema Object is the JSON Schema draft-04 subset.
+// Keywords from later drafts (`const`, added in draft-06) and JSON Schema's `'null'` type are not
+// part of that dialect, so emitting them produces a document strict validators reject. This walks
+// the whole generated document rather than checking one property, so any future emit path that
+// reaches for a newer keyword is caught here instead of in a consumer's tooling.
+describe('openApi — declared dialect compliance (3.0.3)', () => {
+	// Keywords absent from the draft-04 subset OpenAPI 3.0.x is built on.
+	const POST_DRAFT4_KEYWORDS = ['const', 'contentEncoding', 'contentMediaType', 'if', 'then', 'else', '$defs'];
+
+	function walk(node, visit, path = '$') {
+		if (node === null || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			node.forEach((item, i) => walk(item, visit, `${path}[${i}]`));
+			return;
+		}
+		visit(node, path);
+		for (const [key, value] of Object.entries(node)) walk(value, visit, `${path}.${key}`);
+	}
+
+	function buildDocument() {
+		class Widget {}
+		Widget.primaryKey = 'id';
+		Widget.properties = {
+			id: { type: 'string', primaryKey: true },
+			kind: { type: 'string', const: 'widget' },
+			nothing: { type: 'null' },
+			maybe: { type: ['string', 'null'] },
+			nested: { type: 'object', properties: { inner: { type: 'string', const: 'x' } } },
+			list: { type: 'array', items: { type: 'string', const: 'y' } },
+		};
+		Widget.prototype.get = function () {};
+		const resources = new Map();
+		resources.set('Widget', { path: 'Widget', Resource: Widget, hasSubPaths: false, relativeURL: '' });
+		resources.allTypes = new Map();
+		return generateJsonApi(resources, 'https://harper.fast');
+	}
+
+	it('declares 3.0.x', () => {
+		expect(buildDocument().openapi).to.match(/^3\.0\./);
+	});
+
+	it('emits no post-draft-04 keywords anywhere in the document', () => {
+		const offenders = [];
+		walk(buildDocument(), (node, path) => {
+			for (const keyword of POST_DRAFT4_KEYWORDS) {
+				if (Object.hasOwn(node, keyword)) offenders.push(`${path}.${keyword}`);
+			}
+		});
+		expect(offenders, `post-draft-04 keywords in a 3.0.3 document: ${offenders.join(', ')}`).to.deep.equal([]);
+	});
+
+	it('never emits `type: "null"`, which 3.0.x does not define', () => {
+		const offenders = [];
+		walk(buildDocument(), (node, path) => {
+			const t = node.type;
+			if (t === 'null' || (Array.isArray(t) && t.includes('null'))) offenders.push(`${path}.type`);
+		});
+		expect(offenders, `\`null\` types in a 3.0.3 document: ${offenders.join(', ')}`).to.deep.equal([]);
+	});
+
+	it('translates `const` to a single-value `enum`', () => {
+		const schema = buildDocument().components.schemas.Widget;
+		expect(schema.properties.kind.enum).to.deep.equal(['widget']);
+	});
+});

--- a/unitTests/resources/openApi.test.js
+++ b/unitTests/resources/openApi.test.js
@@ -254,4 +254,58 @@ describe('test openApi module', () => {
 			expect(api.paths).not.to.have.property('/secret/{id}');
 		});
 	});
+
+	describe('#1920 programmatic `static properties`', () => {
+		function programmaticResources() {
+			const r = new Map();
+			r.set('Widget', {
+				path: 'Widget',
+				Resource: {
+					prototype: { get: () => [], put: () => [], patch: () => [], delete: () => [], post: () => [] },
+					description: 'A widget in the catalog.',
+					// Record form only — no `attributes` Array.
+					properties: {
+						id: { type: 'string', primaryKey: true },
+						label: { type: 'string', description: 'Human-readable label' },
+						size: { type: 'integer', description: 'Width in pixels' },
+					},
+				},
+			});
+			r.allTypes = new Map();
+			return r;
+		}
+
+		it('emits per-property schemas (type + description) from a bare static-properties declaration', () => {
+			const api = generateJsonApi(programmaticResources(), serverURL);
+			const schema = api.components.schemas.Widget;
+			expect(schema).to.have.property('description', 'A widget in the catalog.');
+			expect(schema.properties.label).to.include({ type: 'string', description: 'Human-readable label' });
+			expect(schema.properties.size).to.include({ type: 'integer', description: 'Width in pixels' });
+		});
+
+		it('emits array items, enum, and nested-object shapes (not undefined/skeletal)', () => {
+			const r = new Map();
+			r.set('Gadget', {
+				path: 'Gadget',
+				Resource: {
+					prototype: { get: () => [], put: () => [] },
+					properties: {
+						id: { type: 'string', primaryKey: true },
+						tags: { type: 'array', items: { type: 'string' } },
+						status: { type: 'string', enum: ['active', 'archived'] },
+						dims: { type: 'object', properties: { w: { type: 'integer' }, h: { type: 'integer' } } },
+					},
+				},
+			});
+			r.allTypes = new Map();
+			const schema = generateJsonApi(r, serverURL).components.schemas.Gadget;
+			// array-of-scalar: items carry the JSON type, not `undefined`
+			expect(schema.properties.tags).to.deep.include({ type: 'array', items: { type: 'string' } });
+			// enum surfaces the allowed values
+			expect(schema.properties.status.enum).to.deep.equal(['active', 'archived']);
+			// nested object is recursed, not emitted as a bare/undefined object
+			expect(schema.properties.dims.type).to.equal('object');
+			expect(schema.properties.dims.properties.w).to.include({ type: 'integer' });
+		});
+	});
 });

--- a/unitTests/resources/openApi.test.js
+++ b/unitTests/resources/openApi.test.js
@@ -332,7 +332,12 @@ describe('openApi — declared dialect compliance (3.0.3)', () => {
 	// Keywords absent from the draft-04 subset OpenAPI 3.0.x is built on.
 	const POST_DRAFT4_KEYWORDS = ['const', 'contentEncoding', 'contentMediaType', 'if', 'then', 'else', '$defs'];
 
+	// `components.securitySchemes` holds Security Scheme Objects, not Schema Objects — their `type`
+	// ("http", "apiKey", …) is a different vocabulary and must not be judged against Schema Object rules.
+	const NON_SCHEMA_SUBTREES = ['$.components.securitySchemes'];
+
 	function walk(node, visit, path = '$') {
+		if (NON_SCHEMA_SUBTREES.some((prefix) => path.startsWith(prefix))) return;
 		if (node === null || typeof node !== 'object') return;
 		if (Array.isArray(node)) {
 			node.forEach((item, i) => walk(item, visit, `${path}[${i}]`));
@@ -350,14 +355,22 @@ describe('openApi — declared dialect compliance (3.0.3)', () => {
 			kind: { type: 'string', const: 'widget' },
 			nothing: { type: 'null' },
 			maybe: { type: ['string', 'null'] },
-			nested: { type: 'object', properties: { inner: { type: 'string', const: 'x' } } },
+			nested: { type: 'object', properties: { inner: { type: 'string', const: 'x' }, deepNull: { type: 'null' } } },
 			list: { type: 'array', items: { type: 'string', const: 'y' } },
+			nullableEnum: { type: 'string', enum: ['a', 'b'], nullable: true },
+			nullableConst: { type: 'string', const: 'fixed', nullable: true },
+			bogus: { type: 'Text' },
+			secret: { type: 'string', hidden: true },
+			when: { type: 'Date', format: 'date-time' },
+			bytes: { type: 'Bytes' },
 		};
 		Widget.prototype.get = function () {};
 		const resources = new Map();
 		resources.set('Widget', { path: 'Widget', Resource: Widget, hasSubPaths: false, relativeURL: '' });
 		resources.allTypes = new Map();
-		return generateJsonApi(resources, 'https://harper.fast');
+		// Judge what a consumer actually receives: `JSON.stringify` drops undefined-valued keys,
+		// so walking the live object would flag artifacts that never reach the wire.
+		return JSON.parse(JSON.stringify(generateJsonApi(resources, 'https://harper.fast')));
 	}
 
 	it('declares 3.0.x', () => {
@@ -374,17 +387,42 @@ describe('openApi — declared dialect compliance (3.0.3)', () => {
 		expect(offenders, `post-draft-04 keywords in a 3.0.3 document: ${offenders.join(', ')}`).to.deep.equal([]);
 	});
 
-	it('never emits `type: "null"`, which 3.0.x does not define', () => {
+	it('emits only the six type values 3.0.x defines, and never a type array', () => {
+		// 3.0's `type` is a closed enum of single values: no `'null'`, no unions, and nothing from
+		// Harper's own vocabulary. Checking only for `'null'` would sail past `type: 'Text'` or
+		// `['string','number']`, both equally invalid here.
+		const OPENAPI_30_TYPES = ['string', 'number', 'integer', 'boolean', 'object', 'array'];
 		const offenders = [];
 		walk(buildDocument(), (node, path) => {
+			if (!Object.hasOwn(node, 'type')) return;
 			const t = node.type;
-			if (t === 'null' || (Array.isArray(t) && t.includes('null'))) offenders.push(`${path}.type`);
+			if (Array.isArray(t)) offenders.push(`${path}.type=[${t.join(',')}] (unions invalid in 3.0)`);
+			else if (!OPENAPI_30_TYPES.includes(t)) offenders.push(`${path}.type=${String(t)}`);
 		});
-		expect(offenders, `\`null\` types in a 3.0.3 document: ${offenders.join(', ')}`).to.deep.equal([]);
+		expect(offenders, `invalid 3.0 types: ${offenders.join(', ')}`).to.deep.equal([]);
 	});
 
-	it('translates `const` to a single-value `enum`', () => {
-		const schema = buildDocument().components.schemas.Widget;
-		expect(schema.properties.kind.enum).to.deep.equal(['widget']);
+	it('never leaks a Harper directive into the emitted document', () => {
+		// `hidden`/`primaryKey`/the timestamp flags drive Harper behavior; they are not schema vocabulary
+		// and a consumer parsing this document has no meaning for them.
+		const DIRECTIVES = ['hidden', 'primaryKey', 'assignCreatedTime', 'assignUpdatedTime'];
+		const offenders = [];
+		walk(buildDocument(), (node, path) => {
+			for (const key of DIRECTIVES) if (Object.hasOwn(node, key)) offenders.push(`${path}.${key}`);
+		});
+		expect(offenders, `Harper directives in the document: ${offenders.join(', ')}`).to.deep.equal([]);
+	});
+
+	it('translates a top-level `const` to a single-value `enum`', () => {
+		const props = buildDocument().components.schemas.Widget.properties;
+		expect(props.kind.enum).to.deep.equal(['widget']);
+		expect(props.kind).to.not.have.property('const');
+	});
+
+	it('emits the properties under test (guards the walk assertions against an empty document)', () => {
+		const props = buildDocument().components.schemas.Widget.properties;
+		for (const key of ['kind', 'nothing', 'maybe', 'nested', 'list', 'nullableEnum', 'nullableConst', 'when']) {
+			expect(props, `fixture property ${key} missing — walk assertions would pass vacuously`).to.have.property(key);
+		}
 	});
 });

--- a/unitTests/resources/openApi.test.js
+++ b/unitTests/resources/openApi.test.js
@@ -293,7 +293,12 @@ describe('test openApi module', () => {
 						id: { type: 'string', primaryKey: true },
 						tags: { type: 'array', items: { type: 'string' } },
 						status: { type: 'string', enum: ['active', 'archived'] },
-						dims: { type: 'object', properties: { w: { type: 'integer' }, h: { type: 'integer' } } },
+						dims: {
+							type: 'object',
+							required: ['w'],
+							properties: { w: { type: 'integer' }, h: { type: 'integer' } },
+						},
+						rows: { type: 'array', items: { type: 'object', properties: { x: { type: 'integer' } } } },
 					},
 				},
 			});
@@ -303,9 +308,14 @@ describe('test openApi module', () => {
 			expect(schema.properties.tags).to.deep.include({ type: 'array', items: { type: 'string' } });
 			// enum surfaces the allowed values
 			expect(schema.properties.status.enum).to.deep.equal(['active', 'archived']);
-			// nested object is recursed, not emitted as a bare/undefined object
+			// nested object is recursed, with its object-level constraints preserved
 			expect(schema.properties.dims.type).to.equal('object');
 			expect(schema.properties.dims.properties.w).to.include({ type: 'integer' });
+			expect(schema.properties.dims.required).to.deep.equal(['w']);
+			// array-of-object: items are the recursed object shape, not an undefined-typed blob
+			expect(schema.properties.rows.type).to.equal('array');
+			expect(schema.properties.rows.items.type).to.equal('object');
+			expect(schema.properties.rows.items.properties.x).to.include({ type: 'integer' });
 		});
 	});
 });

--- a/unitTests/resources/openApi.test.js
+++ b/unitTests/resources/openApi.test.js
@@ -299,6 +299,7 @@ describe('test openApi module', () => {
 							properties: { w: { type: 'integer' }, h: { type: 'integer' } },
 						},
 						rows: { type: 'array', items: { type: 'object', properties: { x: { type: 'integer' } } } },
+						anything: { type: 'array' }, // no items — valid JSON Schema, must not crash generation
 					},
 				},
 			});
@@ -316,6 +317,8 @@ describe('test openApi module', () => {
 			expect(schema.properties.rows.type).to.equal('array');
 			expect(schema.properties.rows.items.type).to.equal('object');
 			expect(schema.properties.rows.items.properties.x).to.include({ type: 'integer' });
+			// array with no items: emitted as a bare array (no crash on undefined elements)
+			expect(schema.properties.anything).to.deep.equal({ type: 'array' });
 		});
 	});
 });

--- a/unitTests/resources/openApi.test.js
+++ b/unitTests/resources/openApi.test.js
@@ -322,3 +322,19 @@ describe('test openApi module', () => {
 		});
 	});
 });
+
+// #1942 follow-up: `required: []` is invalid under JSON Schema draft-04, which OpenAPI 3.0.3
+// inherits — a resource whose attributes are all nullable produced exactly that.
+describe('openApi — empty required omission', () => {
+	it('omits the top-level `required` key when no attribute is non-nullable', () => {
+		class AllOptional {}
+		AllOptional.primaryKey = 'id';
+		AllOptional.properties = { id: { type: 'string', primaryKey: true }, label: { type: 'string' } };
+		AllOptional.prototype.get = function () {};
+		const resources = new Map();
+		resources.set('AllOptional', { path: 'AllOptional', Resource: AllOptional, hasSubPaths: false, relativeURL: '' });
+		resources.allTypes = new Map();
+		const schema = generateJsonApi(resources, 'https://harper.fast').components.schemas.AllOptional;
+		expect(schema).to.not.have.property('required');
+	});
+});

--- a/unitTests/resources/openApi.test.js
+++ b/unitTests/resources/openApi.test.js
@@ -355,6 +355,8 @@ describe('openApi — declared dialect compliance (3.0.3)', () => {
 			kind: { type: 'string', const: 'widget' },
 			nothing: { type: 'null' },
 			maybe: { type: ['string', 'null'] },
+			mixed: { type: ['string', 'number'] },
+			mixedMaybe: { type: ['string', 'integer', 'null'] },
 			nested: { type: 'object', properties: { inner: { type: 'string', const: 'x' }, deepNull: { type: 'null' } } },
 			list: { type: 'array', items: { type: 'string', const: 'y' } },
 			nullableEnum: { type: 'string', enum: ['a', 'b'], nullable: true },
@@ -435,9 +437,34 @@ describe('openApi — declared dialect compliance (3.0.3)', () => {
 		expect(props.nullableConst.enum).to.deep.equal(['fixed', null]);
 	});
 
+	it('translates a genuine multi-type union to `oneOf`', () => {
+		// 3.0 has no type arrays. Keeping only the first member would narrow the contract silently —
+		// a client would be told `mixed` is a string when the resource also accepts a number.
+		const props = buildDocument().components.schemas.Widget.properties;
+		expect(props.mixed).to.deep.equal({ oneOf: [{ type: 'string' }, { type: 'number' }] });
+		expect(props.mixed).to.not.have.property('type');
+	});
+
+	it('carries nullability alongside a union', () => {
+		const props = buildDocument().components.schemas.Widget.properties;
+		expect(props.mixedMaybe.oneOf).to.deep.equal([{ type: 'string' }, { type: 'integer' }]);
+		expect(props.mixedMaybe.nullable).to.equal(true);
+	});
+
 	it('emits the properties under test (guards the walk assertions against an empty document)', () => {
 		const props = buildDocument().components.schemas.Widget.properties;
-		for (const key of ['kind', 'nothing', 'maybe', 'nested', 'list', 'nullableEnum', 'nullableConst', 'when']) {
+		for (const key of [
+			'kind',
+			'nothing',
+			'maybe',
+			'mixed',
+			'mixedMaybe',
+			'nested',
+			'list',
+			'nullableEnum',
+			'nullableConst',
+			'when',
+		]) {
 			expect(props, `fixture property ${key} missing — walk assertions would pass vacuously`).to.have.property(key);
 		}
 	});


### PR DESCRIPTION
Closes #1941, closes #1942.

> **Stacked on #1921.** The base branch is `feat/mcp-static-properties-tests-1920`, not `main` — the code paths these issues describe (OpenAPI's nested-object branch, the `enum`/`format`/`const` passthrough, `JSON_SCHEMA_SCALAR_TYPES`) only exist there. GitHub will retarget this to `main` automatically when #1921 merges. **Do not merge before #1921.**

## Root cause

`attributeToFragment` ended up serving two masters: the canonical, front-end-neutral `Table.properties` Record, and — since #1921 — OpenAPI's nested-object emit. Those have opposite requirements. The canonical projection must carry `hidden` (it round-trips through `fragmentToAttribute`) and must *not* carry `enum`/`format`/`const` (a code-first `types.enum` column has to stay identical to its GraphQL equivalent). An emitted document is the exact reverse. So the nested paths quietly drifted away from MCP's, and every divergence in #1942 lives at that seam.

Rather than bolt more conditionals onto the shared projector, this adds a second, purpose-built one:

```ts
attributeToSchema(attr, { dialect, mapPrimitive })
```

One traversal — nesting, arrays, `hidden` suppression, hint propagation, nullability — used by both surfaces. Each surface keeps its own primitive mapping, because those differences are legitimate: MCP widens `Date` to `['string','number']` and tags `Bytes` with `contentEncoding`; OpenAPI carries the Harper type name as `format`. Unifying those too would churn table-backed output, which #1921 was careful to leave alone. `attributeToFragment` is untouched.

## What changed behaviorally

**#1941** — `hidden` is honored at every nesting level, not just the top. A hidden sub-property of a nested object was previously emitted on both surfaces *with its description*, and OpenAPI additionally wrote `hidden: true` into the public document as a schema key — advertising that the field was meant to be suppressed. Harper directives (`hidden`, `primaryKey`, `assignCreatedTime`, `assignUpdatedTime`) are no longer emitted into schemas at all. A suppressed name is also dropped from the nested `required` list, which would otherwise make the object unsatisfiable for a validating client.

**#1942** — all three:

- An unrecognized type name (`'Text'`) coerced to `string` on MCP and to untyped `{}` on OpenAPI. Both now emit untyped, and `resolveDeclaredType` warns once per name so the typo is visible rather than silently producing two different wrong schemas.
- `enum`/`format`/`const`/`description` reached only top-level properties on OpenAPI. Nested objects and array items now carry them, matching MCP.
- OpenAPI read `nullable` only to compute `required` and never emitted it — so a nullable top-level property was advertised as non-nullable, while a *nested* one (routed through the shared projector) was not. Both levels now emit `nullable: true`; MCP continues to emit the `['T','null']` union and never the keyword.

## Where to look

- **`applyNullability` is the one place the dialects legitimately differ**, and it's the piece most worth checking. OpenAPI 3.0.3 has no union types, so `nullable: true` is the only expression available; JSON Schema has no `nullable` keyword. If you'd rather MCP *also* emit `nullable` for client compatibility, that's a one-line change — but it would be non-standard.
- **Two of my own tests failed on first run** and caught real gaps: OpenAPI's primitive array-item branch still bypassed the shared emitter (dropping item `enum`/`description`), and I'd added `resolveDeclaredType` without wiring it into MCP's `default:` case. Both fixed; the tests are the reason I know.
- **The emitted-output change is user-visible.** Anyone consuming `/openapi.json` sees `nullable: true` appear on top-level properties, `hidden: true` disappear from nested ones, and untyped `{}` where an unrecognized type name previously produced `{"type":"string"}` on the MCP side. That last one is the only case where a client could see *less* type information than before — deliberate, since the previous value was a guess.

Seven convergence tests assert MCP and OpenAPI output side by side for the same fragment, which is the regression shape these issues kept slipping through. 534 tests pass across the MCP, OpenAPI, GraphQL-metadata, and code-first-parity suites.

Docs follow-up: [documentation#605](https://github.com/HarperFast/documentation/pull/605) documents the current (pre-fix) per-surface caveats and will need them collapsed once this lands.

_PR description generated by kAIle (Claude Opus 4.8)._