### PR TITLE
fix(status): count all live worker threads for get_status cross-thread aggregation

### DIFF
--- a/components/status/crossThread.ts
+++ b/components/status/crossThread.ts
@@ -6,7 +6,11 @@
  */
 
 import { sendItcEvent } from '../../server/threads/itc.js';
-import { getWorkerIndex, onMessageByType, getWorkerCount, workers } from '../../server/threads/manageThreads.js';
+import {
+	getWorkerIndex,
+	onMessageByType,
+	getEligibleBroadcastRecipientCount,
+} from '../../server/threads/manageThreads.js';
 import { ITC_EVENT_TYPES } from '../../utility/hdbTerms.ts';
 import { loggerWithTag } from '../../utility/logging/logger.ts';
 import { ComponentStatusRegistry } from './ComponentStatusRegistry.ts';
@@ -118,27 +122,16 @@ export class CrossThreadStatusCollector {
 			const responses: Array<WorkerComponentStatuses> = [];
 			this.awaitingResponses.set(requestId, responses);
 
-			// Calculate expected number of responses (every OTHER live thread that will actually
-			// be asked). `workers` (populated only on the thread that spawns children -- normally
-			// the main thread) is the authoritative count of every live worker thread across ALL
-			// thread types (http, job, replication, ...). getWorkerCount() only reports the size
-			// of the CALLING thread's own same-type pool -- e.g. an HTTP worker only knows the
-			// HTTP pool size, and the main thread (which isn't itself a worker) falls back to a
-			// hardcoded 1 regardless of how many worker threads actually exist. That undercounts
-			// expectedResponses whenever get_status is served from the main thread with more than
-			// one worker running, so the collector declares victory after the first responder and
-			// silently drops every later (and possibly divergent) response -- masking exactly the
-			// per-worker health disagreement this collector exists to surface. Job workers are
-			// excluded: broadcastWithAcknowledgement() (which sendItcEvent uses below) skips
-			// isJobWorker ports entirely -- they run a single isolated task and never see this
-			// broadcast, so counting them would make expectedResponses unreachable and stall every
-			// collection to its full timeout. Falls back to the old same-type-pool estimate when
-			// `workers` is empty -- either a genuinely zero-worker process, or (more commonly)
-			// this thread isn't the one that spawns children, so it has no visibility into
-			// siblings; still an undercount for that latter case when multiple worker types
-			// coexist, but no worse than before this fix.
-			const nonJobWorkerCount = workers.filter((worker) => !worker.isJobWorker).length;
-			const expectedResponses = nonJobWorkerCount || getWorkerCount() || 1;
+			// Calculate expected number of responses: the exact count of other live threads this
+			// broadcast will reach. getEligibleBroadcastRecipientCount() mirrors
+			// broadcastWithAcknowledgement()'s own port filter (which sendItcEvent uses below), so
+			// it is accurate from ANY calling thread -- unlike getWorkerCount(), which only reports
+			// the CALLING thread's own same-type pool and falls back to a hardcoded 1 for the main
+			// thread regardless of how many worker threads actually exist. A genuine zero (no
+			// eligible recipients -- e.g. threads.count: 0, or a job-worker-only process) is
+			// preserved as 0 rather than coerced to 1, so the collector returns immediately instead
+			// of waiting out the full timeout for a response that will never arrive.
+			const expectedResponses = getEligibleBroadcastRecipientCount();
 
 			// Set up response collection with timeout
 			const responsePromise = new Promise<Array<WorkerComponentStatuses>>((resolve, reject) => {

--- a/components/status/crossThread.ts
+++ b/components/status/crossThread.ts
@@ -9,7 +9,7 @@ import { sendItcEvent } from '../../server/threads/itc.js';
 import {
 	getWorkerIndex,
 	onMessageByType,
-	getEligibleBroadcastRecipientCount,
+	getEligibleBroadcastRecipientThreadIds,
 } from '../../server/threads/manageThreads.js';
 import { ITC_EVENT_TYPES } from '../../utility/hdbTerms.ts';
 import { loggerWithTag } from '../../utility/logging/logger.ts';
@@ -31,7 +31,7 @@ const logger = loggerWithTag('componentStatus.crossThread');
  * Handles collection of component status from all worker threads
  */
 export class CrossThreadStatusCollector {
-	private awaitingResponses = new Map<number, Array<WorkerComponentStatuses>>();
+	private awaitingResponses = new Map<number, Map<number, WorkerComponentStatuses>>();
 	private responseCheckers = new Map<number, () => void>();
 	private nextRequestId = 1;
 	private listenerAttached = false;
@@ -57,8 +57,9 @@ export class CrossThreadStatusCollector {
 
 			// Find the pending request by requestId
 			const pendingResponses = this.awaitingResponses.get(message.requestId);
-			if (pendingResponses) {
-				pendingResponses.push({
+			if (pendingResponses && typeof message.threadId === 'number') {
+				pendingResponses.set(message.threadId, {
+					threadId: message.threadId,
 					workerIndex: message.workerIndex,
 					isMainThread: message.isMainThread || false,
 					statuses: message.statuses || [],
@@ -119,10 +120,10 @@ export class CrossThreadStatusCollector {
 
 			// Generate unique request ID and set up response collection
 			const requestId = this.nextRequestId++;
-			const responses: Array<WorkerComponentStatuses> = [];
+			const responses = new Map<number, WorkerComponentStatuses>();
 			this.awaitingResponses.set(requestId, responses);
 
-			const expectedResponses = getEligibleBroadcastRecipientCount();
+			const expectedThreadIds = getEligibleBroadcastRecipientThreadIds();
 
 			// Set up response collection with timeout
 			const responsePromise = new Promise<Array<WorkerComponentStatuses>>((resolve, reject) => {
@@ -131,11 +132,15 @@ export class CrossThreadStatusCollector {
 				// Check if we've received all expected responses
 				const checkComplete = () => {
 					const collectedResponses = this.awaitingResponses.get(requestId);
-					if (collectedResponses && collectedResponses.length >= expectedResponses && !resolved) {
+					if (
+						collectedResponses &&
+						!resolved &&
+						[...expectedThreadIds].every((threadId) => collectedResponses.has(threadId))
+					) {
 						resolved = true;
 						cleanup();
-						logger.trace?.(`Collected all ${collectedResponses.length} expected responses for request ${requestId}`);
-						resolve(collectedResponses);
+						logger.trace?.(`Collected all ${collectedResponses.size} expected responses for request ${requestId}`);
+						resolve([...collectedResponses.values()]);
 					}
 				};
 
@@ -143,14 +148,14 @@ export class CrossThreadStatusCollector {
 				const timeoutHandle = setTimeout(() => {
 					if (!resolved) {
 						resolved = true;
-						const collectedResponses = this.awaitingResponses.get(requestId) || [];
+						const collectedResponses = this.awaitingResponses.get(requestId) || new Map();
 						this.awaitingResponses.delete(requestId);
 						// Log timeout with diagnostic info
 						logger.debug?.(
-							`Collection timeout for request ${requestId}: collected ${collectedResponses.length}/${expectedResponses} responses`
+							`Collection timeout for request ${requestId}: collected ${collectedResponses.size}/${expectedThreadIds.size} responses`
 						);
 						// Resolve with whatever we've collected so far
-						resolve(collectedResponses);
+						resolve([...collectedResponses.values()]);
 					}
 				}, this.timeout);
 
@@ -195,20 +200,14 @@ export class CrossThreadStatusCollector {
 			const localThreadLabel = localWorkerIndex === undefined ? 'main' : `worker-${localWorkerIndex}`;
 
 			for (const [name, status] of localStatuses) {
-				aggregatedStatuses.set(`${name}@${localThreadLabel}`, {
-					...status,
-					workerIndex: localWorkerIndex,
-				});
+				this.setThreadStatus(aggregatedStatuses, name, localThreadLabel, status, localWorkerIndex);
 			}
 
 			// Add responses from other threads
 			for (const response of collectedResponses) {
+				const threadLabel = response.isMainThread ? 'main' : `worker-${response.workerIndex}`;
 				for (const [name, status] of response.statuses) {
-					const threadLabel = response.isMainThread ? 'main' : `worker-${response.workerIndex}`;
-					aggregatedStatuses.set(`${name}@${threadLabel}`, {
-						...status,
-						workerIndex: response.workerIndex,
-					});
+					this.setThreadStatus(aggregatedStatuses, name, threadLabel, status, response.workerIndex, response.threadId);
 				}
 			}
 
@@ -231,6 +230,22 @@ export class CrossThreadStatusCollector {
 		}
 	}
 
+	private setThreadStatus(
+		statuses: Map<string, ComponentStatusSummary>,
+		name: string,
+		threadLabel: string,
+		status: ComponentStatusSummary,
+		workerIndex: number | undefined,
+		threadId?: number
+	): void {
+		const baseKey = `${name}@${threadLabel}`;
+		const key = statuses.has(baseKey) ? `${baseKey}#thread-${threadId ?? statuses.size}` : baseKey;
+		statuses.set(key, {
+			...status,
+			workerIndex,
+		});
+	}
+
 	/**
 	 * Get status from local thread only (fallback when cross-thread collection fails)
 	 */
@@ -241,10 +256,7 @@ export class CrossThreadStatusCollector {
 		const localThreadLabel = localWorkerIndex === undefined ? 'main' : `worker-${localWorkerIndex}`;
 
 		for (const [name, status] of localStatuses) {
-			fallbackStatuses.set(`${name}@${localThreadLabel}`, {
-				...status,
-				workerIndex: localWorkerIndex,
-			});
+			this.setThreadStatus(fallbackStatuses, name, localThreadLabel, status, localWorkerIndex);
 		}
 		return fallbackStatuses;
 	}
@@ -317,7 +329,10 @@ export class StatusAggregator {
 		// Analyze all instances of this component
 		for (const [nameWithThread, status] of statusEntries) {
 			const atIndex = nameWithThread.lastIndexOf('@');
-			const threadLabel = atIndex !== -1 ? nameWithThread.substring(atIndex + 1) : '';
+			const threadLabelWithIdentity = atIndex !== -1 ? nameWithThread.substring(atIndex + 1) : '';
+			const identityIndex = threadLabelWithIdentity.indexOf('#');
+			const threadLabel =
+				identityIndex === -1 ? threadLabelWithIdentity : threadLabelWithIdentity.substring(0, identityIndex);
 
 			// Convert lastChecked to ms since epoch
 			const checkTime =
@@ -329,7 +344,7 @@ export class StatusAggregator {
 			} else if (threadLabel && threadLabel.startsWith('worker-')) {
 				const workerIndex = parseInt(threadLabel.substring(7)); // 'worker-'.length = 7
 				if (!isNaN(workerIndex)) {
-					lastCheckedTimes.workers[workerIndex] = checkTime;
+					lastCheckedTimes.workers[workerIndex] = Math.max(lastCheckedTimes.workers[workerIndex] ?? 0, checkTime);
 				}
 			}
 
@@ -359,7 +374,10 @@ export class StatusAggregator {
 			// There are inconsistencies - populate abnormalities
 			for (const [nameWithThread, status] of statusEntries) {
 				if (status.status !== determinedStatus) {
-					abnormalities.set(nameWithThread, {
+					const identityIndex = nameWithThread.indexOf('#', nameWithThread.indexOf('@'));
+					const publicNameWithThread =
+						identityIndex === -1 ? nameWithThread : nameWithThread.substring(0, identityIndex);
+					abnormalities.set(publicNameWithThread, {
 						workerIndex: status.workerIndex !== undefined ? status.workerIndex : -1,
 						status: status.status,
 						message: status.message,

--- a/components/status/crossThread.ts
+++ b/components/status/crossThread.ts
@@ -25,6 +25,20 @@ import {
 import { ITCError } from './errors.ts';
 
 const logger = loggerWithTag('componentStatus.crossThread');
+const THREAD_IDENTITY_SEPARATOR = '#thread-';
+const STATUS_PRIORITY = [
+	COMPONENT_STATUS_LEVELS.ERROR,
+	COMPONENT_STATUS_LEVELS.WARNING,
+	COMPONENT_STATUS_LEVELS.LOADING,
+	COMPONENT_STATUS_LEVELS.UNKNOWN,
+	COMPONENT_STATUS_LEVELS.HEALTHY,
+];
+
+function stripThreadIdentity(statusKey: string): string {
+	const threadLabelStart = statusKey.lastIndexOf('@') + 1;
+	const identityIndex = statusKey.indexOf(THREAD_IDENTITY_SEPARATOR, threadLabelStart);
+	return identityIndex === -1 ? statusKey : statusKey.substring(0, identityIndex);
+}
 
 /**
  * CrossThreadStatusCollector Class
@@ -132,16 +146,14 @@ export class CrossThreadStatusCollector {
 				// Check if we've received all expected responses
 				const checkComplete = () => {
 					const collectedResponses = this.awaitingResponses.get(requestId);
-					if (
-						collectedResponses &&
-						!resolved &&
-						[...expectedThreadIds].every((threadId) => collectedResponses.has(threadId))
-					) {
-						resolved = true;
-						cleanup();
-						logger.trace?.(`Collected all ${collectedResponses.size} expected responses for request ${requestId}`);
-						resolve([...collectedResponses.values()]);
+					if (!collectedResponses || resolved) return;
+					for (const threadId of expectedThreadIds) {
+						if (!collectedResponses.has(threadId)) return;
 					}
+					resolved = true;
+					cleanup();
+					logger.trace?.(`Collected all ${collectedResponses.size} expected responses for request ${requestId}`);
+					resolve([...collectedResponses.values()]);
 				};
 
 				// Set up timeout as fallback
@@ -239,7 +251,11 @@ export class CrossThreadStatusCollector {
 		threadId?: number
 	): void {
 		const baseKey = `${name}@${threadLabel}`;
-		const key = statuses.has(baseKey) ? `${baseKey}#thread-${threadId ?? statuses.size}` : baseKey;
+		let key = baseKey;
+		if (statuses.has(baseKey)) {
+			if (threadId === undefined) throw new Error(`Physical thread identity is required for duplicate ${baseKey}`);
+			key += `${THREAD_IDENTITY_SEPARATOR}${threadId}`;
+		}
 		statuses.set(key, {
 			...status,
 			workerIndex,
@@ -330,9 +346,7 @@ export class StatusAggregator {
 		for (const [nameWithThread, status] of statusEntries) {
 			const atIndex = nameWithThread.lastIndexOf('@');
 			const threadLabelWithIdentity = atIndex !== -1 ? nameWithThread.substring(atIndex + 1) : '';
-			const identityIndex = threadLabelWithIdentity.indexOf('#');
-			const threadLabel =
-				identityIndex === -1 ? threadLabelWithIdentity : threadLabelWithIdentity.substring(0, identityIndex);
+			const threadLabel = stripThreadIdentity(threadLabelWithIdentity);
 
 			// Convert lastChecked to ms since epoch
 			const checkTime =
@@ -374,9 +388,11 @@ export class StatusAggregator {
 			// There are inconsistencies - populate abnormalities
 			for (const [nameWithThread, status] of statusEntries) {
 				if (status.status !== determinedStatus) {
-					const identityIndex = nameWithThread.indexOf('#', nameWithThread.indexOf('@'));
-					const publicNameWithThread =
-						identityIndex === -1 ? nameWithThread : nameWithThread.substring(0, identityIndex);
+					const publicNameWithThread = stripThreadIdentity(nameWithThread);
+					const existing = abnormalities.get(publicNameWithThread);
+					if (existing && STATUS_PRIORITY.indexOf(existing.status) <= STATUS_PRIORITY.indexOf(status.status)) {
+						continue;
+					}
 					abnormalities.set(publicNameWithThread, {
 						workerIndex: status.workerIndex !== undefined ? status.workerIndex : -1,
 						status: status.status,
@@ -408,15 +424,7 @@ export class StatusAggregator {
 	 * Determine overall status based on priority
 	 */
 	private static determineOverallStatus(statusCounts: Map<ComponentStatusLevel, number>): ComponentStatusLevel {
-		const statusPriority = [
-			COMPONENT_STATUS_LEVELS.ERROR,
-			COMPONENT_STATUS_LEVELS.WARNING,
-			COMPONENT_STATUS_LEVELS.LOADING,
-			COMPONENT_STATUS_LEVELS.UNKNOWN,
-			COMPONENT_STATUS_LEVELS.HEALTHY,
-		];
-
-		for (const priorityStatus of statusPriority) {
+		for (const priorityStatus of STATUS_PRIORITY) {
 			if (statusCounts.has(priorityStatus) && statusCounts.get(priorityStatus)! > 0) {
 				return priorityStatus;
 			}

--- a/components/status/crossThread.ts
+++ b/components/status/crossThread.ts
@@ -6,7 +6,7 @@
  */
 
 import { sendItcEvent } from '../../server/threads/itc.js';
-import { getWorkerIndex, onMessageByType, getWorkerCount } from '../../server/threads/manageThreads.js';
+import { getWorkerIndex, onMessageByType, getWorkerCount, workers } from '../../server/threads/manageThreads.js';
 import { ITC_EVENT_TYPES } from '../../utility/hdbTerms.ts';
 import { loggerWithTag } from '../../utility/logging/logger.ts';
 import { ComponentStatusRegistry } from './ComponentStatusRegistry.ts';
@@ -118,12 +118,27 @@ export class CrossThreadStatusCollector {
 			const responses: Array<WorkerComponentStatuses> = [];
 			this.awaitingResponses.set(requestId, responses);
 
-			// Calculate expected number of responses
-			// Total threads = main thread (1) + worker threads (workerCount)
-			const workerCount = getWorkerCount() || 1;
-			const totalThreads = workerCount + 1;
-			// We expect responses from all threads except ourselves
-			const expectedResponses = totalThreads - 1;
+			// Calculate expected number of responses (every OTHER live thread that will actually
+			// be asked). `workers` (populated only on the thread that spawns children -- normally
+			// the main thread) is the authoritative count of every live worker thread across ALL
+			// thread types (http, job, replication, ...). getWorkerCount() only reports the size
+			// of the CALLING thread's own same-type pool -- e.g. an HTTP worker only knows the
+			// HTTP pool size, and the main thread (which isn't itself a worker) falls back to a
+			// hardcoded 1 regardless of how many worker threads actually exist. That undercounts
+			// expectedResponses whenever get_status is served from the main thread with more than
+			// one worker running, so the collector declares victory after the first responder and
+			// silently drops every later (and possibly divergent) response -- masking exactly the
+			// per-worker health disagreement this collector exists to surface. Job workers are
+			// excluded: broadcastWithAcknowledgement() (which sendItcEvent uses below) skips
+			// isJobWorker ports entirely -- they run a single isolated task and never see this
+			// broadcast, so counting them would make expectedResponses unreachable and stall every
+			// collection to its full timeout. Falls back to the old same-type-pool estimate when
+			// `workers` is empty -- either a genuinely zero-worker process, or (more commonly)
+			// this thread isn't the one that spawns children, so it has no visibility into
+			// siblings; still an undercount for that latter case when multiple worker types
+			// coexist, but no worse than before this fix.
+			const nonJobWorkerCount = workers.filter((worker) => !worker.isJobWorker).length;
+			const expectedResponses = nonJobWorkerCount || getWorkerCount() || 1;
 
 			// Set up response collection with timeout
 			const responsePromise = new Promise<Array<WorkerComponentStatuses>>((resolve, reject) => {

--- a/components/status/crossThread.ts
+++ b/components/status/crossThread.ts
@@ -122,15 +122,6 @@ export class CrossThreadStatusCollector {
 			const responses: Array<WorkerComponentStatuses> = [];
 			this.awaitingResponses.set(requestId, responses);
 
-			// Calculate expected number of responses: the exact count of other live threads this
-			// broadcast will reach. getEligibleBroadcastRecipientCount() mirrors
-			// broadcastWithAcknowledgement()'s own port filter (which sendItcEvent uses below), so
-			// it is accurate from ANY calling thread -- unlike getWorkerCount(), which only reports
-			// the CALLING thread's own same-type pool and falls back to a hardcoded 1 for the main
-			// thread regardless of how many worker threads actually exist. A genuine zero (no
-			// eligible recipients -- e.g. threads.count: 0, or a job-worker-only process) is
-			// preserved as 0 rather than coerced to 1, so the collector returns immediately instead
-			// of waiting out the full timeout for a response that will never arrive.
 			const expectedResponses = getEligibleBroadcastRecipientCount();
 
 			// Set up response collection with timeout

--- a/components/status/types.ts
+++ b/components/status/types.ts
@@ -75,6 +75,7 @@ export interface AggregatedComponentStatus {
  * Component status information from a worker thread
  */
 export interface WorkerComponentStatuses {
+	threadId?: number;
 	workerIndex: number | undefined;
 	isMainThread: boolean;
 	statuses: Array<[string, ComponentStatusSummary]>;

--- a/server/itc/serverHandlers.js
+++ b/server/itc/serverHandlers.js
@@ -11,7 +11,7 @@ const harperBridge =
 	require('../../dataLayer/harperBridge/harperBridge.ts').default ||
 	require('../../dataLayer/harperBridge/harperBridge.ts');
 const process = require('process');
-const { isMainThread, workerData } = require('worker_threads');
+const { isMainThread, threadId, workerData } = require('node:worker_threads');
 const { resetDatabases, closeDatabase } = require('../../resources/databases.ts');
 
 /**
@@ -187,6 +187,7 @@ async function componentStatusRequestHandler(event) {
 			message: {
 				requestId: event.message.requestId,
 				statuses: statusArray,
+				threadId,
 				workerIndex: workerIndex,
 				isMainThread: isMainThread,
 			},

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -144,7 +144,7 @@ module.exports = {
 	broadcastWithAcknowledgement,
 	getWorkerIndex,
 	getWorkerCount,
-	getEligibleBroadcastRecipientCount,
+	getEligibleBroadcastRecipientThreadIds,
 	getTicketKeys,
 	setMainIsWorker,
 	setTerminateTimeout,
@@ -196,13 +196,14 @@ function getWorkerCount() {
 function isEligibleBroadcastRecipient(port) {
 	return !port.isJobWorker;
 }
-// connectedPorts is a full mesh, and acknowledged broadcasts exclude job workers.
-function getEligibleBroadcastRecipientCount() {
-	let count = 0;
+function getEligibleBroadcastRecipientThreadIds() {
+	const recipientThreadIds = new Set();
 	for (const port of connectedPorts) {
-		if (isEligibleBroadcastRecipient(port)) count++;
+		if (isEligibleBroadcastRecipient(port) && port.threadId !== undefined) {
+			recipientThreadIds.add(port.threadId);
+		}
 	}
-	return count;
+	return recipientThreadIds;
 }
 function setMainIsWorker(isWorker) {
 	isMainWorker = isWorker;
@@ -217,6 +218,7 @@ let workerCount = 1; // should be assigned when workers are created
 const RESERVED_WORKER_DATA_KEYS = [
 	'addPorts',
 	'addThreadIds',
+	'addPortIsJobWorkers',
 	'workerIndex',
 	'workerCount',
 	'name',
@@ -395,6 +397,7 @@ function startWorker(path, options = {}) {
 			...collectProvidedWorkerData(options),
 			addPorts: portsToSend,
 			addThreadIds: channelsToConnect.map((channel) => channel.existingPort.threadId),
+			addPortIsJobWorkers: channelsToConnect.map((channel) => channel.existingPort.isJobWorker === true),
 			workerIndex: options.workerIndex,
 			workerCount: (workerCount = options.threadCount),
 			name: options.name,
@@ -854,7 +857,7 @@ if (parentPort && workerData?.addPorts) {
 	for (let i = 0, l = workerData.addPorts.length; i < l; i++) {
 		let port = workerData.addPorts[i];
 		port.threadId = workerData.addThreadIds[i];
-		addPort(port);
+		addPort(port, false, workerData.addPortIsJobWorkers?.[i]);
 	}
 	setInterval(() => {
 		// post our memory usage as a resource report, reporting our memory usage

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -137,7 +137,6 @@ module.exports = {
 	shutdownWorkers,
 	shutdownWorkersNow,
 	workers,
-	connectedPorts,
 	setMonitorListener,
 	onMessageFromWorkers,
 	onMessageByType,
@@ -194,17 +193,14 @@ function getWorkerIndex() {
 function getWorkerCount() {
 	return workerData ? workerData.workerCount : isMainWorker ? 1 : undefined;
 }
-// The exact number of other live threads a broadcastWithAcknowledgement() call from THIS
-// thread will reach: `connectedPorts` is a full mesh (every thread holds a direct port to
-// every other live thread, wired up in startWorker()/ADDED_PORT), and job workers are
-// excluded because broadcastWithAcknowledgement() skips isJobWorker ports entirely. Unlike
-// getWorkerCount() (which only knows the calling thread's own same-type pool, or 1 for the
-// non-worker main thread), this is accurate from any thread and correctly returns 0 when
-// there are no eligible recipients.
+function isEligibleBroadcastRecipient(port) {
+	return !port.isJobWorker;
+}
+// connectedPorts is a full mesh, and acknowledged broadcasts exclude job workers.
 function getEligibleBroadcastRecipientCount() {
 	let count = 0;
 	for (const port of connectedPorts) {
-		if (!port.isJobWorker) count++;
+		if (isEligibleBroadcastRecipient(port)) count++;
 	}
 	return count;
 }
@@ -730,7 +726,7 @@ function broadcastWithAcknowledgement(message, timeout = DEFAULT_ACK_TIMEOUT_MS)
 			// schema-change gossip. Including them causes a deadlock: the broadcast waits for
 			// the job worker's ACK while the job worker's event loop is busy waiting for the
 			// same broadcast to complete (re-entrant schema change triggered by the job op).
-			if (port.isJobWorker) continue;
+			if (!isEligibleBroadcastRecipient(port)) continue;
 			try {
 				let requestId = nextId++;
 				const ackHandler = () => {

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -137,6 +137,7 @@ module.exports = {
 	shutdownWorkers,
 	shutdownWorkersNow,
 	workers,
+	connectedPorts,
 	setMonitorListener,
 	onMessageFromWorkers,
 	onMessageByType,
@@ -144,6 +145,7 @@ module.exports = {
 	broadcastWithAcknowledgement,
 	getWorkerIndex,
 	getWorkerCount,
+	getEligibleBroadcastRecipientCount,
 	getTicketKeys,
 	setMainIsWorker,
 	setTerminateTimeout,
@@ -191,6 +193,20 @@ function getWorkerIndex() {
 }
 function getWorkerCount() {
 	return workerData ? workerData.workerCount : isMainWorker ? 1 : undefined;
+}
+// The exact number of other live threads a broadcastWithAcknowledgement() call from THIS
+// thread will reach: `connectedPorts` is a full mesh (every thread holds a direct port to
+// every other live thread, wired up in startWorker()/ADDED_PORT), and job workers are
+// excluded because broadcastWithAcknowledgement() skips isJobWorker ports entirely. Unlike
+// getWorkerCount() (which only knows the calling thread's own same-type pool, or 1 for the
+// non-worker main thread), this is accurate from any thread and correctly returns 0 when
+// there are no eligible recipients.
+function getEligibleBroadcastRecipientCount() {
+	let count = 0;
+	for (const port of connectedPorts) {
+		if (!port.isJobWorker) count++;
+	}
+	return count;
 }
 function setMainIsWorker(isWorker) {
 	isMainWorker = isWorker;

--- a/unitTests/components/status/crossThread.test.js
+++ b/unitTests/components/status/crossThread.test.js
@@ -568,5 +568,18 @@ describe('CrossThread Module', function () {
 			const abnormality = aggStatus.abnormalities.get('cache@worker-2');
 			assert.equal(abnormality.workerIndex, 2);
 		});
+
+		it('keeps the worst abnormal status when overlapping generations share a public worker label', function () {
+			const allStatuses = new Map([
+				['service@worker-1', { status: 'healthy', workerIndex: 1 }],
+				['service@worker-1#thread-8', { status: 'warning', workerIndex: 1 }],
+				['service@worker-2', { status: 'error', workerIndex: 2 }],
+			]);
+
+			const aggregated = StatusAggregator.aggregate(allStatuses).get('service');
+			assert.equal(aggregated.status, 'error');
+			assert.equal(aggregated.abnormalities.size, 1);
+			assert.equal(aggregated.abnormalities.get('service@worker-1').status, 'warning');
+		});
 	});
 });

--- a/unitTests/components/status/crossThread.test.js
+++ b/unitTests/components/status/crossThread.test.js
@@ -24,8 +24,11 @@ describe('CrossThread Module', function () {
 	describe('CrossThreadStatusCollector', function () {
 		let collector;
 		let registry;
+		let originalConnectedPorts;
 
 		beforeEach(function () {
+			originalConnectedPorts = [...manageThreadsModule.connectedPorts];
+			manageThreadsModule.connectedPorts.length = 0;
 			collector = new CrossThreadStatusCollector(1000); // 1 second timeout
 			registry = new ComponentStatusRegistry();
 		});
@@ -33,7 +36,8 @@ describe('CrossThread Module', function () {
 		afterEach(function () {
 			collector.cleanup();
 			registry.reset();
-			manageThreadsModule.connectedPorts.length = 0; // restore the shared array for other tests
+			manageThreadsModule.connectedPorts.length = 0;
+			manageThreadsModule.connectedPorts.push(...originalConnectedPorts);
 		});
 
 		it('should collect status from local thread only when no responses', async function () {

--- a/unitTests/components/status/crossThread.test.js
+++ b/unitTests/components/status/crossThread.test.js
@@ -4,6 +4,7 @@ const { CrossThreadStatusCollector, StatusAggregator } = require('#src/component
 const { ComponentStatusRegistry } = require('#src/components/status/ComponentStatusRegistry');
 const itcModule = require('#js/server/threads/itc');
 const manageThreadsModule = require('#js/server/threads/manageThreads');
+const connectedPorts = global.threads;
 
 describe('CrossThread Module', function () {
 	let sendItcEventStub;
@@ -27,8 +28,8 @@ describe('CrossThread Module', function () {
 		let originalConnectedPorts;
 
 		beforeEach(function () {
-			originalConnectedPorts = [...manageThreadsModule.connectedPorts];
-			manageThreadsModule.connectedPorts.length = 0;
+			originalConnectedPorts = [...connectedPorts];
+			connectedPorts.length = 0;
 			collector = new CrossThreadStatusCollector(1000); // 1 second timeout
 			registry = new ComponentStatusRegistry();
 		});
@@ -36,15 +37,14 @@ describe('CrossThread Module', function () {
 		afterEach(function () {
 			collector.cleanup();
 			registry.reset();
-			manageThreadsModule.connectedPorts.length = 0;
-			manageThreadsModule.connectedPorts.push(...originalConnectedPorts);
+			connectedPorts.length = 0;
+			connectedPorts.push(...originalConnectedPorts);
 		});
 
 		it('should collect status from local thread only when no responses', async function () {
 			registry.setStatus('localComp', 'healthy', 'All good');
 			// Test with main thread (undefined)
 			getWorkerIndexStub.returns(undefined);
-			// connectedPorts left empty, so there are no eligible responders to wait on.
 
 			// Simulate no responses from other threads
 			onMessageByTypeStub.callsFake(() => {});
@@ -62,8 +62,7 @@ describe('CrossThread Module', function () {
 			// Test with main thread (undefined)
 			getWorkerIndexStub.returns(undefined);
 
-			// Two connected (non-job-worker) ports -- the collector expects one response each.
-			manageThreadsModule.connectedPorts.push({}, {});
+			connectedPorts.push({}, {});
 
 			// Simulate responses from other threads
 			onMessageByTypeStub.callsFake((eventType, handler) => {
@@ -140,9 +139,7 @@ describe('CrossThread Module', function () {
 			// Test with main thread (undefined)
 			getWorkerIndexStub.returns(undefined);
 
-			// One connected port that never responds, so the collector genuinely has to wait
-			// out the timeout instead of resolving immediately with zero expected responses.
-			manageThreadsModule.connectedPorts.push({});
+			connectedPorts.push({});
 
 			// Never send responses
 			onMessageByTypeStub.callsFake(() => {});
@@ -161,8 +158,7 @@ describe('CrossThread Module', function () {
 			registry.setStatus('fastComp', 'healthy', 'Main thread');
 			getWorkerIndexStub.returns(0);
 
-			// Two connected (non-job-worker) ports -- the collector expects one response each.
-			manageThreadsModule.connectedPorts.push({}, {});
+			connectedPorts.push({}, {});
 
 			// Track when collection completes
 			const startTime = Date.now();
@@ -202,25 +198,16 @@ describe('CrossThread Module', function () {
 			assert.equal(collected.size, 3); // local + 2 workers
 		});
 
-		// These three cases exercise getEligibleBroadcastRecipientCount() (the exact count of
-		// other live threads a broadcast will reach, mirrored from broadcastWithAcknowledgement's
-		// own port filter) without stubbing anything new: `connectedPorts` is the real, exported
-		// module array (same pattern already used for `workers` elsewhere in this file), and
-		// completion is proven deterministically by capturing the response handler and resolving
-		// it synchronously, then asserting collect() settled before a setImmediate sentinel fires
-		// -- so this can't flake under a loaded CI runner the way a wall-clock deadline would.
 		describe('expectedResponses sizing (connectedPorts-based)', function () {
 			it('sizes expectedResponses from the exact eligible broadcast-recipient count, excluding job workers', async function () {
 				registry.setStatus('poolComp', 'healthy', 'Main thread');
 				getWorkerIndexStub.returns(0);
 
-				// 2 HTTP-worker ports + 1 job-worker port. Job workers never receive the
-				// broadcast (broadcastWithAcknowledgement skips isJobWorker ports), so
-				// expectedResponses must be 2 (the HTTP ports only), not 3.
 				const httpPortA = {};
 				const httpPortB = {};
 				const jobPort = { isJobWorker: true };
-				manageThreadsModule.connectedPorts.push(httpPortA, httpPortB, jobPort);
+				connectedPorts.push(httpPortA, httpPortB, jobPort);
+				assert.equal(manageThreadsModule.getEligibleBroadcastRecipientCount(), 2);
 
 				let handler;
 				onMessageByTypeStub.callsFake((eventType, h) => {
@@ -236,8 +223,6 @@ describe('CrossThread Module', function () {
 				);
 
 				const collectPromise = collector.collect(registry);
-				// Deliver both HTTP responses synchronously through the real handler seam --
-				// no timers involved, so there is nothing for CI load to delay.
 				handler({
 					message: {
 						requestId: 1,
@@ -254,13 +239,7 @@ describe('CrossThread Module', function () {
 						statuses: [['poolComp', { status: 'healthy' }]],
 					},
 				});
-				// No third response -- the (excluded) job worker is never asked.
-
 				const collected = await collectPromise;
-				// Resolution happened via the response handlers (microtask-ordered before any
-				// macrotask), not via a fallback timer -- if expectedResponses were wrongly 3
-				// (job worker included), collect() would still be waiting on the 1s collector
-				// timeout at this point.
 				assert.equal(sentinelFired, false, 'collect() should resolve before the setImmediate sentinel');
 				await sentinel;
 
@@ -272,7 +251,7 @@ describe('CrossThread Module', function () {
 			it('resolves immediately with zero eligible responders instead of waiting out the timeout', async function () {
 				registry.setStatus('soloComp', 'healthy', 'Main thread');
 				getWorkerIndexStub.returns(undefined); // main thread
-				// connectedPorts left empty: a genuinely zero-worker process.
+				assert.equal(manageThreadsModule.getEligibleBroadcastRecipientCount(), 0);
 
 				let sentinelFired = false;
 				const sentinel = new Promise((resolve) =>
@@ -283,8 +262,6 @@ describe('CrossThread Module', function () {
 				);
 
 				const collected = await collector.collect(registry);
-				// If zero were coerced back to 1, the collector would still be waiting for a
-				// response that will never arrive, and this assertion would fail.
 				assert.equal(sentinelFired, false, 'collect() should resolve immediately, not wait for a phantom responder');
 				await sentinel;
 
@@ -295,7 +272,8 @@ describe('CrossThread Module', function () {
 			it('resolves immediately when the only connected ports are job workers', async function () {
 				registry.setStatus('jobOnlyComp', 'healthy', 'Main thread');
 				getWorkerIndexStub.returns(undefined); // main thread
-				manageThreadsModule.connectedPorts.push({ isJobWorker: true }, { isJobWorker: true });
+				connectedPorts.push({ isJobWorker: true }, { isJobWorker: true });
+				assert.equal(manageThreadsModule.getEligibleBroadcastRecipientCount(), 0);
 
 				let sentinelFired = false;
 				const sentinel = new Promise((resolve) =>

--- a/unitTests/components/status/crossThread.test.js
+++ b/unitTests/components/status/crossThread.test.js
@@ -33,15 +33,14 @@ describe('CrossThread Module', function () {
 		afterEach(function () {
 			collector.cleanup();
 			registry.reset();
+			manageThreadsModule.connectedPorts.length = 0; // restore the shared array for other tests
 		});
 
 		it('should collect status from local thread only when no responses', async function () {
 			registry.setStatus('localComp', 'healthy', 'All good');
 			// Test with main thread (undefined)
 			getWorkerIndexStub.returns(undefined);
-
-			// Mock getWorkerCount
-			const getWorkerCountStub = sinon.stub(manageThreadsModule, 'getWorkerCount').returns(2);
+			// connectedPorts left empty, so there are no eligible responders to wait on.
 
 			// Simulate no responses from other threads
 			onMessageByTypeStub.callsFake(() => {});
@@ -51,9 +50,6 @@ describe('CrossThread Module', function () {
 			assert.equal(collected.size, 1);
 			assert.ok(collected.has('localComp@main'));
 			assert.equal(collected.get('localComp@main').status, 'healthy');
-
-			// Cleanup
-			getWorkerCountStub.restore();
 		});
 
 		it('should collect status from multiple threads', async function () {
@@ -62,8 +58,8 @@ describe('CrossThread Module', function () {
 			// Test with main thread (undefined)
 			getWorkerIndexStub.returns(undefined);
 
-			// Mock getWorkerCount
-			const getWorkerCountStub = sinon.stub(manageThreadsModule, 'getWorkerCount').returns(2);
+			// Two connected (non-job-worker) ports -- the collector expects one response each.
+			manageThreadsModule.connectedPorts.push({}, {});
 
 			// Simulate responses from other threads
 			onMessageByTypeStub.callsFake((eventType, handler) => {
@@ -114,18 +110,12 @@ describe('CrossThread Module', function () {
 			assert.ok(collected.has('sharedComp@main'));
 			assert.ok(collected.has('sharedComp@worker-1'));
 			assert.ok(collected.has('sharedComp@worker-2'));
-
-			// Cleanup
-			getWorkerCountStub.restore();
 		});
 
 		it('should handle ITC send failure', async function () {
 			registry.setStatus('fallbackComp', 'error', 'Local error');
 			// Test with main thread (undefined)
 			getWorkerIndexStub.returns(undefined);
-
-			// Mock getWorkerCount
-			const getWorkerCountStub = sinon.stub(manageThreadsModule, 'getWorkerCount').returns(2);
 
 			// Make sendItcEvent reject
 			sendItcEventStub.rejects(new Error('ITC failure'));
@@ -137,9 +127,6 @@ describe('CrossThread Module', function () {
 			// In test environment with undefined workerIndex, we get main thread
 			assert.ok(collected.has('fallbackComp@main'));
 			assert.equal(collected.get('fallbackComp@main').status, 'error');
-
-			// Cleanup
-			getWorkerCountStub.restore();
 		});
 
 		it('should handle collection timeout', async function () {
@@ -149,8 +136,9 @@ describe('CrossThread Module', function () {
 			// Test with main thread (undefined)
 			getWorkerIndexStub.returns(undefined);
 
-			// Mock getWorkerCount
-			const getWorkerCountStub = sinon.stub(manageThreadsModule, 'getWorkerCount').returns(2);
+			// One connected port that never responds, so the collector genuinely has to wait
+			// out the timeout instead of resolving immediately with zero expected responses.
+			manageThreadsModule.connectedPorts.push({});
 
 			// Never send responses
 			onMessageByTypeStub.callsFake(() => {});
@@ -162,7 +150,6 @@ describe('CrossThread Module', function () {
 			assert.ok(collected.has('timeoutComp@main'));
 
 			shortTimeoutCollector.cleanup();
-			getWorkerCountStub.restore();
 		});
 
 		it('should complete early when all threads respond', async function () {
@@ -170,9 +157,8 @@ describe('CrossThread Module', function () {
 			registry.setStatus('fastComp', 'healthy', 'Main thread');
 			getWorkerIndexStub.returns(0);
 
-			// Mock getWorkerCount to return 2 (expecting 2 worker responses)
-			const manageThreadsModule = require('#js/server/threads/manageThreads');
-			const getWorkerCountStub = sinon.stub(manageThreadsModule, 'getWorkerCount').returns(2);
+			// Two connected (non-job-worker) ports -- the collector expects one response each.
+			manageThreadsModule.connectedPorts.push({}, {});
 
 			// Track when collection completes
 			const startTime = Date.now();
@@ -210,70 +196,118 @@ describe('CrossThread Module', function () {
 			// Should complete much faster than timeout
 			assert.ok(resolveTime < 1000, `Collection took ${resolveTime}ms, should be < 1000ms`);
 			assert.equal(collected.size, 3); // local + 2 workers
-
-			// Cleanup the stub
-			getWorkerCountStub.restore();
 		});
 
-		it('uses the real `workers` registry (excluding job workers) to size expectedResponses, not getWorkerCount()', async function () {
-			this.timeout(5000);
-			registry.setStatus('poolComp', 'healthy', 'Main thread');
-			getWorkerIndexStub.returns(0);
+		// These three cases exercise getEligibleBroadcastRecipientCount() (the exact count of
+		// other live threads a broadcast will reach, mirrored from broadcastWithAcknowledgement's
+		// own port filter) without stubbing anything new: `connectedPorts` is the real, exported
+		// module array (same pattern already used for `workers` elsewhere in this file), and
+		// completion is proven deterministically by capturing the response handler and resolving
+		// it synchronously, then asserting collect() settled before a setImmediate sentinel fires
+		// -- so this can't flake under a loaded CI runner the way a wall-clock deadline would.
+		describe('expectedResponses sizing (connectedPorts-based)', function () {
+			it('sizes expectedResponses from the exact eligible broadcast-recipient count, excluding job workers', async function () {
+				registry.setStatus('poolComp', 'healthy', 'Main thread');
+				getWorkerIndexStub.returns(0);
 
-			// getWorkerCount() stubbed to a WRONG value (1) so the test fails if the collector
-			// falls back to it instead of using `workers`.
-			const getWorkerCountStub = sinon.stub(manageThreadsModule, 'getWorkerCount').returns(1);
+				// 2 HTTP-worker ports + 1 job-worker port. Job workers never receive the
+				// broadcast (broadcastWithAcknowledgement skips isJobWorker ports), so
+				// expectedResponses must be 2 (the HTTP ports only), not 3.
+				const httpPortA = {};
+				const httpPortB = {};
+				const jobPort = { isJobWorker: true };
+				manageThreadsModule.connectedPorts.push(httpPortA, httpPortB, jobPort);
 
-			// Populate the real `workers` registry with 2 HTTP workers + 1 job worker. Job
-			// workers never receive the broadcast (broadcastWithAcknowledgement skips
-			// isJobWorker ports), so expectedResponses must be 2 (the HTTP workers only), not 3.
-			const httpWorkerA = {};
-			const httpWorkerB = {};
-			const jobWorker = { isJobWorker: true };
-			manageThreadsModule.workers.push(httpWorkerA, httpWorkerB, jobWorker);
-
-			try {
-				const startTime = Date.now();
-				onMessageByTypeStub.callsFake((eventType, handler) => {
-					setTimeout(() => {
-						handler({
-							message: {
-								requestId: 1,
-								workerIndex: 1,
-								isMainThread: false,
-								statuses: [['poolComp', { status: 'healthy' }]],
-							},
-						});
-						handler({
-							message: {
-								requestId: 1,
-								workerIndex: 2,
-								isMainThread: false,
-								statuses: [['poolComp', { status: 'healthy' }]],
-							},
-						});
-						// No third response -- the (excluded) job worker never gets asked.
-					}, 50);
+				let handler;
+				onMessageByTypeStub.callsFake((eventType, h) => {
+					handler = h;
 				});
 
-				const collected = await collector.collect(registry);
-				const resolveTime = Date.now() - startTime;
-
-				// Resolves once the 2 real HTTP-worker responses arrive, well under the 1s
-				// collector timeout -- if expectedResponses were wrongly 3 (job worker
-				// included) or 1 (getWorkerCount() fallback used), this would either stall to
-				// the timeout or resolve before both real responses are captured.
-				assert.ok(
-					resolveTime < 500,
-					`Collection took ${resolveTime}ms, should complete quickly once both HTTP workers respond`
+				let sentinelFired = false;
+				const sentinel = new Promise((resolve) =>
+					setImmediate(() => {
+						sentinelFired = true;
+						resolve();
+					})
 				);
+
+				const collectPromise = collector.collect(registry);
+				// Deliver both HTTP responses synchronously through the real handler seam --
+				// no timers involved, so there is nothing for CI load to delay.
+				handler({
+					message: {
+						requestId: 1,
+						workerIndex: 1,
+						isMainThread: false,
+						statuses: [['poolComp', { status: 'healthy' }]],
+					},
+				});
+				handler({
+					message: {
+						requestId: 1,
+						workerIndex: 2,
+						isMainThread: false,
+						statuses: [['poolComp', { status: 'healthy' }]],
+					},
+				});
+				// No third response -- the (excluded) job worker is never asked.
+
+				const collected = await collectPromise;
+				// Resolution happened via the response handlers (microtask-ordered before any
+				// macrotask), not via a fallback timer -- if expectedResponses were wrongly 3
+				// (job worker included), collect() would still be waiting on the 1s collector
+				// timeout at this point.
+				assert.equal(sentinelFired, false, 'collect() should resolve before the setImmediate sentinel');
+				await sentinel;
+
 				assert.equal(collected.size, 3); // local + 2 HTTP workers
 				assert.ok(collected.has('poolComp@worker-1'));
 				assert.ok(collected.has('poolComp@worker-2'));
-			} finally {
-				manageThreadsModule.workers.length = 0; // restore the shared array for other tests
-				getWorkerCountStub.restore();
-			}
+			});
+
+			it('resolves immediately with zero eligible responders instead of waiting out the timeout', async function () {
+				registry.setStatus('soloComp', 'healthy', 'Main thread');
+				getWorkerIndexStub.returns(undefined); // main thread
+				// connectedPorts left empty: a genuinely zero-worker process.
+
+				let sentinelFired = false;
+				const sentinel = new Promise((resolve) =>
+					setImmediate(() => {
+						sentinelFired = true;
+						resolve();
+					})
+				);
+
+				const collected = await collector.collect(registry);
+				// If zero were coerced back to 1, the collector would still be waiting for a
+				// response that will never arrive, and this assertion would fail.
+				assert.equal(sentinelFired, false, 'collect() should resolve immediately, not wait for a phantom responder');
+				await sentinel;
+
+				assert.equal(collected.size, 1);
+				assert.ok(collected.has('soloComp@main'));
+			});
+
+			it('resolves immediately when the only connected ports are job workers', async function () {
+				registry.setStatus('jobOnlyComp', 'healthy', 'Main thread');
+				getWorkerIndexStub.returns(undefined); // main thread
+				manageThreadsModule.connectedPorts.push({ isJobWorker: true }, { isJobWorker: true });
+
+				let sentinelFired = false;
+				const sentinel = new Promise((resolve) =>
+					setImmediate(() => {
+						sentinelFired = true;
+						resolve();
+					})
+				);
+
+				const collected = await collector.collect(registry);
+				assert.equal(sentinelFired, false, 'collect() should resolve immediately when no non-job port is connected');
+				await sentinel;
+
+				assert.equal(collected.size, 1);
+				assert.ok(collected.has('jobOnlyComp@main'));
+			});
 		});
 
 		it('should reuse listener across multiple collections', async function () {

--- a/unitTests/components/status/crossThread.test.js
+++ b/unitTests/components/status/crossThread.test.js
@@ -215,6 +215,67 @@ describe('CrossThread Module', function () {
 			getWorkerCountStub.restore();
 		});
 
+		it('uses the real `workers` registry (excluding job workers) to size expectedResponses, not getWorkerCount()', async function () {
+			this.timeout(5000);
+			registry.setStatus('poolComp', 'healthy', 'Main thread');
+			getWorkerIndexStub.returns(0);
+
+			// getWorkerCount() stubbed to a WRONG value (1) so the test fails if the collector
+			// falls back to it instead of using `workers`.
+			const getWorkerCountStub = sinon.stub(manageThreadsModule, 'getWorkerCount').returns(1);
+
+			// Populate the real `workers` registry with 2 HTTP workers + 1 job worker. Job
+			// workers never receive the broadcast (broadcastWithAcknowledgement skips
+			// isJobWorker ports), so expectedResponses must be 2 (the HTTP workers only), not 3.
+			const httpWorkerA = {};
+			const httpWorkerB = {};
+			const jobWorker = { isJobWorker: true };
+			manageThreadsModule.workers.push(httpWorkerA, httpWorkerB, jobWorker);
+
+			try {
+				const startTime = Date.now();
+				onMessageByTypeStub.callsFake((eventType, handler) => {
+					setTimeout(() => {
+						handler({
+							message: {
+								requestId: 1,
+								workerIndex: 1,
+								isMainThread: false,
+								statuses: [['poolComp', { status: 'healthy' }]],
+							},
+						});
+						handler({
+							message: {
+								requestId: 1,
+								workerIndex: 2,
+								isMainThread: false,
+								statuses: [['poolComp', { status: 'healthy' }]],
+							},
+						});
+						// No third response -- the (excluded) job worker never gets asked.
+					}, 50);
+				});
+
+				const collected = await collector.collect(registry);
+				const resolveTime = Date.now() - startTime;
+
+				// Resolves once the 2 real HTTP-worker responses arrive, well under the 1s
+				// collector timeout -- if expectedResponses were wrongly 3 (job worker
+				// included) or 1 (getWorkerCount() fallback used), this would either stall to
+				// the timeout or resolve before both real responses are captured.
+				assert.ok(
+					resolveTime < 500,
+					`Collection took ${resolveTime}ms, should complete quickly once both HTTP workers respond`
+				);
+				assert.equal(collected.size, 3); // local + 2 HTTP workers
+				assert.ok(collected.has('poolComp@worker-1'));
+				assert.ok(collected.has('poolComp@worker-2'));
+			} finally {
+				manageThreadsModule.workers.length = 0; // restore the shared array for other tests
+				getWorkerCountStub.restore();
+			}
+		});
+
 		it('should reuse listener across multiple collections', async function () {
 			// First collection
 			await collector.collect(registry);

--- a/unitTests/components/status/crossThread.test.js
+++ b/unitTests/components/status/crossThread.test.js
@@ -62,7 +62,7 @@ describe('CrossThread Module', function () {
 			// Test with main thread (undefined)
 			getWorkerIndexStub.returns(undefined);
 
-			connectedPorts.push({}, {});
+			connectedPorts.push({ threadId: 7 }, { threadId: 8 });
 
 			// Simulate responses from other threads
 			onMessageByTypeStub.callsFake((eventType, handler) => {
@@ -71,6 +71,7 @@ describe('CrossThread Module', function () {
 					handler({
 						message: {
 							requestId: 1,
+							threadId: 7,
 							workerIndex: 1,
 							isMainThread: false,
 							statuses: [
@@ -88,6 +89,7 @@ describe('CrossThread Module', function () {
 					handler({
 						message: {
 							requestId: 1,
+							threadId: 8,
 							workerIndex: 2,
 							isMainThread: false,
 							statuses: [
@@ -139,7 +141,7 @@ describe('CrossThread Module', function () {
 			// Test with main thread (undefined)
 			getWorkerIndexStub.returns(undefined);
 
-			connectedPorts.push({});
+			connectedPorts.push({ threadId: 7 });
 
 			// Never send responses
 			onMessageByTypeStub.callsFake(() => {});
@@ -158,7 +160,7 @@ describe('CrossThread Module', function () {
 			registry.setStatus('fastComp', 'healthy', 'Main thread');
 			getWorkerIndexStub.returns(0);
 
-			connectedPorts.push({}, {});
+			connectedPorts.push({ threadId: 7 }, { threadId: 8 });
 
 			// Track when collection completes
 			const startTime = Date.now();
@@ -173,6 +175,7 @@ describe('CrossThread Module', function () {
 					handler({
 						message: {
 							requestId: 1,
+							threadId: 7,
 							workerIndex: 1,
 							isMainThread: false,
 							statuses: [['fastComp', { status: 'healthy' }]],
@@ -182,6 +185,7 @@ describe('CrossThread Module', function () {
 					handler({
 						message: {
 							requestId: 1,
+							threadId: 8,
 							workerIndex: 2,
 							isMainThread: false,
 							statuses: [['fastComp', { status: 'healthy' }]],
@@ -203,11 +207,11 @@ describe('CrossThread Module', function () {
 				registry.setStatus('poolComp', 'healthy', 'Main thread');
 				getWorkerIndexStub.returns(0);
 
-				const httpPortA = {};
-				const httpPortB = {};
-				const jobPort = { isJobWorker: true };
+				const httpPortA = { threadId: 7 };
+				const httpPortB = { threadId: 8 };
+				const jobPort = { threadId: 9, isJobWorker: true };
 				connectedPorts.push(httpPortA, httpPortB, jobPort);
-				assert.equal(manageThreadsModule.getEligibleBroadcastRecipientCount(), 2);
+				assert.equal(manageThreadsModule.getEligibleBroadcastRecipientThreadIds().size, 2);
 
 				let handler;
 				onMessageByTypeStub.callsFake((eventType, h) => {
@@ -226,6 +230,7 @@ describe('CrossThread Module', function () {
 				handler({
 					message: {
 						requestId: 1,
+						threadId: 7,
 						workerIndex: 1,
 						isMainThread: false,
 						statuses: [['poolComp', { status: 'healthy' }]],
@@ -234,6 +239,7 @@ describe('CrossThread Module', function () {
 				handler({
 					message: {
 						requestId: 1,
+						threadId: 8,
 						workerIndex: 2,
 						isMainThread: false,
 						statuses: [['poolComp', { status: 'healthy' }]],
@@ -248,10 +254,60 @@ describe('CrossThread Module', function () {
 				assert.ok(collected.has('poolComp@worker-2'));
 			});
 
+			it('keeps overlapping worker generations distinct and waits for each physical responder', async function () {
+				registry.setStatus('localComp', 'healthy', 'Main thread');
+				getWorkerIndexStub.returns(undefined);
+				connectedPorts.push({ threadId: 7 }, { threadId: 8 });
+
+				let handler;
+				onMessageByTypeStub.callsFake((eventType, responseHandler) => {
+					handler = responseHandler;
+				});
+
+				let settled = false;
+				const collectPromise = collector.collect(registry).then((collected) => {
+					settled = true;
+					return collected;
+				});
+				const oldGenerationResponse = {
+					message: {
+						requestId: 1,
+						threadId: 7,
+						workerIndex: 1,
+						isMainThread: false,
+						statuses: [['poolComp', { status: 'error', lastChecked: new Date(1000) }]],
+					},
+				};
+				handler(oldGenerationResponse);
+				handler(oldGenerationResponse);
+				await new Promise(setImmediate);
+				assert.equal(settled, false, 'a duplicate response must not stand in for the replacement worker');
+
+				handler({
+					message: {
+						requestId: 1,
+						threadId: 8,
+						workerIndex: 1,
+						isMainThread: false,
+						statuses: [['poolComp', { status: 'healthy', lastChecked: new Date(3000) }]],
+					},
+				});
+
+				const collected = await collectPromise;
+				assert.equal(collected.size, 3);
+				assert.ok(collected.has('poolComp@worker-1'));
+				assert.ok(collected.has('poolComp@worker-1#thread-8'));
+
+				const aggregated = StatusAggregator.aggregate(collected).get('poolComp');
+				assert.equal(aggregated.status, 'error');
+				assert.equal(aggregated.lastChecked.workers[1], 3000);
+				assert.equal(aggregated.abnormalities.get('poolComp@worker-1').status, 'healthy');
+			});
+
 			it('resolves immediately with zero eligible responders instead of waiting out the timeout', async function () {
 				registry.setStatus('soloComp', 'healthy', 'Main thread');
 				getWorkerIndexStub.returns(undefined); // main thread
-				assert.equal(manageThreadsModule.getEligibleBroadcastRecipientCount(), 0);
+				assert.equal(manageThreadsModule.getEligibleBroadcastRecipientThreadIds().size, 0);
 
 				let sentinelFired = false;
 				const sentinel = new Promise((resolve) =>
@@ -272,8 +328,8 @@ describe('CrossThread Module', function () {
 			it('resolves immediately when the only connected ports are job workers', async function () {
 				registry.setStatus('jobOnlyComp', 'healthy', 'Main thread');
 				getWorkerIndexStub.returns(undefined); // main thread
-				connectedPorts.push({ isJobWorker: true }, { isJobWorker: true });
-				assert.equal(manageThreadsModule.getEligibleBroadcastRecipientCount(), 0);
+				connectedPorts.push({ threadId: 7, isJobWorker: true }, { threadId: 8, isJobWorker: true });
+				assert.equal(manageThreadsModule.getEligibleBroadcastRecipientThreadIds().size, 0);
 
 				let sentinelFired = false;
 				const sentinel = new Promise((resolve) =>

--- a/unitTests/server/itc/serverHandlers.test.js
+++ b/unitTests/server/itc/serverHandlers.test.js
@@ -199,6 +199,7 @@ describe('Test hdbChildIpcHandler module', () => {
 			const responseMessage = sendToThreadStub.firstCall.args[1];
 			expect(responseMessage.type).to.equal('component_status_response');
 			expect(responseMessage.message.requestId).to.equal('req-789');
+			expect(responseMessage.message.threadId).to.be.a('number');
 			// Should have a trace confirming direct send (no error/debug fallback)
 			expect(log_error_stub).to.not.have.been.called;
 			sendToThreadStub.restore();

--- a/unitTests/server/threads/portMetadata-fixture.cjs
+++ b/unitTests/server/threads/portMetadata-fixture.cjs
@@ -6,7 +6,6 @@ require('#js/server/threads/manageThreads');
 setInterval(() => {}, 10000);
 
 parentPort.postMessage({
-	type: 'port-metadata-report',
 	ports: [...global.threads].map((port) => ({
 		threadId: port.threadId,
 		isJobWorker: port.isJobWorker === true,

--- a/unitTests/server/threads/portMetadata-fixture.cjs
+++ b/unitTests/server/threads/portMetadata-fixture.cjs
@@ -1,0 +1,15 @@
+'use strict';
+
+const { parentPort } = require('node:worker_threads');
+require('#js/server/threads/manageThreads');
+
+setInterval(() => {}, 10000);
+
+parentPort.postMessage({
+	type: 'port-metadata-report',
+	ports: [...global.threads].map((port) => ({
+		threadId: port.threadId,
+		isJobWorker: port.isJobWorker === true,
+	})),
+	eligibleThreadIds: global.threads.filter((port) => !port.isJobWorker).map((port) => port.threadId),
+});

--- a/unitTests/server/threads/workerDataProviders.test.js
+++ b/unitTests/server/threads/workerDataProviders.test.js
@@ -13,6 +13,7 @@ describe('registerWorkerDataProvider', () => {
 	it('rejects reserved workerData keys, duplicate names, and non-function providers', () => {
 		assert.throws(() => registerWorkerDataProvider('ticketKeys', () => 1), /already in use/);
 		assert.throws(() => registerWorkerDataProvider('addPorts', () => 1), /already in use/);
+		assert.throws(() => registerWorkerDataProvider('addPortIsJobWorkers', () => 1), /already in use/);
 		// consumed by threadServer.js, not spread by startWorker — must be reserved all the same
 		assert.throws(() => registerWorkerDataProvider('noServerStart', () => true), /already in use/);
 		assert.throws(() => registerWorkerDataProvider('__proto__', () => ({})), /already in use/);

--- a/unitTests/server/threads/workerPortMetadata.test.js
+++ b/unitTests/server/threads/workerPortMetadata.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const assert = require('node:assert');
+const path = require('node:path');
+const { THREAD_TYPES } = require('#src/utility/hdbTerms');
+const { startWorker } = require('#js/server/threads/manageThreads');
+
+const FIXTURE = path.join(__dirname, 'portMetadata-fixture.cjs');
+
+function startTopologyWorker(name, workerIndex, startedWorkers) {
+	return new Promise((resolve, reject) => {
+		startWorker(FIXTURE, {
+			name,
+			workerIndex,
+			threadCount: 2,
+			autoRestart: false,
+			onStarted(worker) {
+				startedWorkers.push(worker);
+				worker.once('message', resolve);
+				worker.once('error', reject);
+				worker.once('exit', (code) => reject(new Error(`Worker exited before reporting (code ${code})`)));
+			},
+		});
+	});
+}
+
+describe('worker port metadata', function () {
+	it('preserves the job-worker flag when an existing port is inherited by a new worker', async function () {
+		this.timeout(30000);
+		const startedWorkers = [];
+		try {
+			await startTopologyWorker(THREAD_TYPES.JOB, 0, startedWorkers);
+			const jobWorker = startedWorkers[0];
+			const observerReport = await startTopologyWorker(THREAD_TYPES.HTTP, 1, startedWorkers);
+
+			assert.deepEqual(
+				observerReport.ports.find((port) => port.threadId === jobWorker.threadId),
+				{ threadId: jobWorker.threadId, isJobWorker: true }
+			);
+			assert.equal(observerReport.eligibleThreadIds.includes(jobWorker.threadId), false);
+			assert.equal(observerReport.eligibleThreadIds.includes(0), true);
+		} finally {
+			for (const worker of startedWorkers.reverse()) {
+				worker.wasShutdown = true;
+				await worker.terminate();
+			}
+		}
+	});
+});


### PR DESCRIPTION
`get_status` previously sized collection from a logical worker count and could finish before every physical thread replied. During a rolling restart, the old and replacement threads can also share a logical worker index, so one response overwrote the other and could hide an error.

The collector now snapshots the eligible physical thread IDs, completes only after each expected physical thread replies, and keeps overlapping generations distinct internally. The public payload remains unchanged: duplicate generations collapse back to the existing `name@worker-N` label while retaining the worst status. Worker bootstrap also preserves job-worker metadata on inherited ports, so job workers remain excluded from status collection after later workers start.

Known limitations: a thread that cannot reply after the snapshot can still force the five-second timeout, and a timed-out partial result does not identify missing threads. These are existing payload/contract decisions rather than hidden behavior in this patch.

## For the human reviewer

1. The expected responder set is a physical-thread snapshot. This prevents duplicate replies from satisfying another thread's slot, but a booting, wedged, or exiting thread can make `get_status` wait for the full timeout. Dynamically removing departed threads would reduce restart latency, while still leaving booting or wedged threads ambiguous.
2. Overlapping generations remain separate for aggregation, but the public abnormalities map retains one entry per existing `name@worker-N` key. The implementation deterministically keeps the worst generation rather than widening the public payload with a thread identity.
3. Counting every generation means a routine redeploy can now expose a real transient `loading` or `error` state that the previous overwrite accidentally hid. This is intentional visibility, but it may make monitors observe restart windows they previously missed.
4. The added tests cover the status aggregation and real worker-port topology, but they do not run `get_status` through an actual rolling restart. That end-to-end scenario remains a useful follow-up.

## Verification

- Original live reproduction with `threads.count: 8`: one of eight workers observed before the fix and all eight after it, with the corrected request completing in about 15 ms.
- `npm run build` — passed.
- `npx mocha "unitTests/components/status/**/*.js"` — 140 passed.
- `npx mocha "unitTests/server/**/*.test.js"` — 621 passed, including the real two-worker inherited-port topology test.
- `npm run test:unit:resources` — 1,255 passed, 14 pending, 3 unrelated existing structure-replay/default failures.
- `npm run lint:required`, `npm run format:write`, and `git diff --check` — passed.
- The broader `npm run test:unit:server` script also executes worker fixture files as top-level tests and fails on the existing `workerData-fixture.js`; the `**/*.test.js` server suite above is green.
- The earlier branch revision passed `npm run test:integration:all` under Node 24.19 with 1,572 passed, 0 failed, 17 skipped, and 6 local runner cancellations. Integration was not rerun after this review-fix delta.

## Review coverage

Claude reviewed the design plan. Claude, Gemini, and Harper-domain reviewed the implementation at `7aeb702eb`; the actionable findings were fixed in `f52bb416c`. The current-head delta review completed independently with Claude and returned comments; Gemini returned no output and Harper-domain was pruned by the narrow-delta policy. Cursor/Grok/Composer legs were disabled because Grok was not authorized for this task. Receipt @ `f52bb416c`.

Refs #1951, #1931

_Updated by GPT-5.6 Codex._

<sub>Human-Review-Need: 4 @ 7ab44c05350d</sub>
