### PR TITLE
fix(storage): bound the interrupted-drop retry to one actionable error

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -137,7 +137,7 @@ const LOCK_TIMEOUT = 10000;
 // concurrent worker may already have dropped it; the storage engine reports
 // that as "Column family already dropped!". The family being gone is the
 // intended outcome, so swallow that specific error and rethrow anything else.
-function ignoreAlreadyDropped(error: any): void {
+export function ignoreAlreadyDropped(error: any): void {
 	if (error?.message?.includes('Column family already dropped')) return;
 	throw error;
 }

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -13,6 +13,7 @@ import {
 } from '../utility/hdbTerms.ts';
 import { type Database } from 'lmdb';
 import { Script } from 'node:vm';
+import { randomUUID } from 'node:crypto';
 import { getIndexedValues } from '../utility/lmdb/commonUtility.ts';
 import { getThisNodeId, exportIdMapping } from './nodeIdMapping.ts';
 import lodash from 'lodash';
@@ -1191,6 +1192,14 @@ export function makeTable(options) {
 				const primaryMeta = (dbisDb as any).getSync(primaryCatalogKey);
 				if (primaryMeta && !primaryMeta.dropping) {
 					primaryMeta.dropping = true;
+					// Stamps this drop's identity so the interrupted-drop retry budget in
+					// databases.ts can be scoped to THIS drop rather than the table name: a
+					// worker that exhausts the budget for a table can observe the catalog
+					// mid-flight between this drop's completion and a same-name recreate's
+					// own drop, without ever seeing a non-tombstoned row to reset on. Keying
+					// the budget by generation instead makes the new drop's tombstone carry
+					// its own fresh key regardless of what any worker last observed.
+					primaryMeta.dropGeneration = randomUUID();
 					// put is rebound to putSync on RocksDB stores; on LMDB it returns
 					// a promise, so await it to make the tombstone durable before the
 					// destructive work below

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -227,7 +227,15 @@ const MAX_INTERRUPTED_DROP_ATTEMPTS = 3;
 // Keyed with a NUL separator rather than a dot so that database "a.b" table "c"
 // and database "a" table "b.c" cannot share a budget.
 const interruptedDropAttempts = new Map<string, number>();
-const interruptedDropKey = (databaseName: string, tableName: string) => `${databaseName}\0${tableName}`;
+// Scoped by drop generation (Table.ts stamps a fresh id on every dropping
+// tombstone) rather than just database + table: a worker can exhaust one
+// drop's budget, then observe the table recreated and dropped again without
+// ever seeing an intermediate non-tombstoned row to reset on. Keying by
+// generation means the new drop's tombstone always carries a fresh key,
+// independent of what any worker last observed. Tombstones written before
+// this field existed fall back to a shared 'legacy' bucket.
+const interruptedDropKey = (databaseName: string, tableName: string, generation?: string) =>
+	`${databaseName}\0${tableName}\0${generation ?? 'legacy'}`;
 let loadedDatabases; // indicates if we have loaded databases from the file system yet
 
 // This is used to track all the databases that are found when iterating through the file system so that anything that is missing
@@ -555,7 +563,7 @@ function initStores(
 	// it, because creating over a half-dropped table would resurrect its catalog
 	// rows. There a failure propagates to the caller as its own single error.
 	for (const [tableName, tableDef] of tablesToLoad) {
-		const dropKey = interruptedDropKey(databaseName, tableName);
+		const dropKey = interruptedDropKey(databaseName, tableName, tableDef.primary?.dropGeneration);
 		if (!tableDef.primary?.dropping) {
 			// No tombstone, so any budget this table spent belongs to a drop that
 			// has since been resolved - by the create path, which completes
@@ -584,7 +592,7 @@ function initStores(
 					// including threads:0 where the main thread acts as worker 0 - logs it, so one
 					// stuck table produces one actionable error instead of one per worker.
 					logger.error(
-						`Unable to complete the interrupted drop of table ${dropLabel} after ${attempt} attempts; giving up until this node restarts. ${tableName} stays unloaded, with its catalog rows and column families left in place. An "Invalid column family specified in write batch" cause means the storage environment for ${databaseName} has latched a background error and will reject every write to every table in it until this node restarts.`,
+						`Unable to complete the interrupted drop of table ${dropLabel} after ${attempt} attempts; giving up until this worker restarts (a full node restart also resets this). ${tableName} stays unloaded, with its catalog rows and column families left in place. An "Invalid column family specified in write batch" cause means the storage environment for ${databaseName} has latched a background error and will reject every write to every table in it until this node restarts.`,
 						error
 					);
 				}
@@ -1275,8 +1283,10 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 				// reconcile below, which is the only other place that returns a spent
 				// budget. Without clearing it here too, a table that gets dropped again
 				// before any reconcile observes it live in between would have its NEXT
-				// interrupted drop inherit this one's spent attempts.
-				interruptedDropAttempts.delete(interruptedDropKey(databaseName, tableName));
+				// interrupted drop inherit this one's spent attempts. Generation-scoped
+				// keying (see interruptedDropKey) already makes that impossible, but
+				// clearing it here too avoids leaving a dead entry behind.
+				interruptedDropAttempts.delete(interruptedDropKey(databaseName, tableName, existingTableMeta?.dropGeneration));
 			}
 			if (rootStore instanceof RocksDatabase) {
 				primaryStore = openRocksDatabase(rootStore.path, { ...dbiInit, name: dbiName, cache: true } as any);
@@ -1912,7 +1922,10 @@ function completeInterruptedDrop(rootStore, attributesDbi, databaseName: string,
 		}
 	}
 	for (const key of attributesDbi.getKeys({ start: tableName + '/', end: tableName + '0' })) {
-		attributesDbi.remove(key);
+		// removeSync (not remove): same reasoning as dropSync above - the async
+		// remove() rejects after this function has already returned, so a
+		// catalog-removal failure would bypass the retry accounting entirely.
+		(attributesDbi as any).removeSync(key);
 	}
 }
 

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -215,6 +215,16 @@ _assignPackageExport('databases', databases);
 _assignPackageExport('tables', tables);
 
 const NEXT_TABLE_ID = Symbol.for('next-table-id');
+// How many times the schema load will try to finish a tombstoned drop before
+// giving up for the rest of this process's lifetime. A drop that fails once
+// almost always fails identically forever - the usual cause is a RocksDB
+// environment that latched a background error and now rejects every write it
+// receives - and the schema load re-runs on every resetDatabases(), so an
+// unbounded retry turns one broken table into a per-reload log flood in every
+// worker thread.
+const MAX_INTERRUPTED_DROP_ATTEMPTS = 3;
+// `database.table` -> consecutive failed completion attempts in this thread.
+const interruptedDropAttempts = new Map<string, number>();
 let loadedDatabases; // indicates if we have loaded databases from the file system yet
 
 // This is used to track all the databases that are found when iterating through the file system so that anything that is missing
@@ -537,16 +547,31 @@ function initStores(
 	// partway, the tombstone survives alongside the catalog rows. Without this
 	// reconcile, those rows would silently resurrect the table below
 	// (recreating any missing column families as empty stores).
+	// The attempt budget is deliberately scoped to this reconcile: the create path
+	// calls completeInterruptedDrop under the exclusive lock and must never skip
+	// it, because creating over a half-dropped table would resurrect its catalog
+	// rows. There a failure propagates to the caller as its own single error.
 	for (const [tableName, tableDef] of tablesToLoad) {
 		if (!tableDef.primary?.dropping) continue;
-		try {
-			completeInterruptedDrop(rootStore, attributesDbi, databaseName, tableName);
-			definedTables?.delete(tableName);
-		} catch (error) {
-			logger.error(
-				`Failed to complete interrupted drop of table ${databaseName}.${tableName}; will retry on next start`,
-				error
-			);
+		const dropKey = `${databaseName}.${tableName}`;
+		const failedAttempts = interruptedDropAttempts.get(dropKey) ?? 0;
+		if (failedAttempts < MAX_INTERRUPTED_DROP_ATTEMPTS) {
+			try {
+				completeInterruptedDrop(rootStore, attributesDbi, databaseName, tableName);
+				interruptedDropAttempts.delete(dropKey);
+				definedTables?.delete(tableName);
+			} catch (error) {
+				const attempt = failedAttempts + 1;
+				interruptedDropAttempts.set(dropKey, attempt);
+				if (attempt < MAX_INTERRUPTED_DROP_ATTEMPTS) {
+					logger.debug(`Failed to complete interrupted drop of table ${dropKey}, attempt ${attempt}`, error);
+				} else {
+					logger.error(
+						`Unable to complete the interrupted drop of table ${dropKey} after ${attempt} attempts; giving up until this node restarts. ${tableName} stays unloaded, with its catalog rows and column families left in place. An "Invalid column family specified in write batch" cause means the storage environment for ${databaseName} has latched a background error and will reject every write to every table in it until this node restarts.`,
+						error
+					);
+				}
+			}
 		}
 		// whether or not cleanup succeeded, never load a table that was being dropped
 		tablesToLoad.delete(tableName);

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -223,19 +223,41 @@ const NEXT_TABLE_ID = Symbol.for('next-table-id');
 // unbounded retry turns one broken table into a per-reload log flood in every
 // worker thread.
 const MAX_INTERRUPTED_DROP_ATTEMPTS = 3;
-// database + table -> consecutive failed completion attempts in this thread.
-// Keyed with a NUL separator rather than a dot so that database "a.b" table "c"
-// and database "a" table "b.c" cannot share a budget.
+// physical store path + table -> consecutive failed completion attempts in
+// this thread. Keyed by the physical store path rather than the database
+// alias name: multiple database names can point at the same directory
+// (config-level aliasing), and readMetaDb/readRocksMetaDb reconcile each
+// alias's schema independently, so a table shared by N aliases would
+// otherwise be attempted (and give up) N times over - once per alias - on
+// top of the once-per-worker duplication. Keying by path collapses all of
+// that back down to one budget, and one give-up log via the worker-0 gate
+// below, per physical table. Keyed with a NUL separator rather than a dot so
+// that path "a.b" table "c" and path "a" table "b.c" cannot share a budget.
 const interruptedDropAttempts = new Map<string, number>();
 // Scoped by drop generation (Table.ts stamps a fresh id on every dropping
-// tombstone) rather than just database + table: a worker can exhaust one
-// drop's budget, then observe the table recreated and dropped again without
-// ever seeing an intermediate non-tombstoned row to reset on. Keying by
+// tombstone) rather than just path + table: a worker can exhaust one drop's
+// budget, then observe the table recreated and dropped again without ever
+// seeing an intermediate non-tombstoned row to reset on. Keying by
 // generation means the new drop's tombstone always carries a fresh key,
 // independent of what any worker last observed. Tombstones written before
 // this field existed fall back to a shared 'legacy' bucket.
-const interruptedDropKey = (databaseName: string, tableName: string, generation?: string) =>
-	`${databaseName}\0${tableName}\0${generation ?? 'legacy'}`;
+const interruptedDropKey = (storePath: string, tableName: string, generation?: string) =>
+	`${storePath}\0${tableName}\0${generation ?? 'legacy'}`;
+// A live (non-tombstoned) row never carries the dropGeneration of whatever
+// drop it resolved - generations are only stamped while dropping - so a
+// lookup keyed off the live row's (absent) generation can only ever hit the
+// 'legacy' bucket, never the actual spent UUID entry. That entry is
+// harmless (a new drop always gets a fresh generation-scoped key regardless)
+// but never gets cleaned up either, leaking one Map entry per historical
+// drop generation for the worker's lifetime. Sweep every entry under this
+// path+table prefix instead of guessing which generation to target.
+const interruptedDropKeyPrefix = (storePath: string, tableName: string) => `${storePath}\0${tableName}\0`;
+function clearInterruptedDropEntries(storePath: string, tableName: string) {
+	const prefix = interruptedDropKeyPrefix(storePath, tableName);
+	for (const key of interruptedDropAttempts.keys()) {
+		if (key.startsWith(prefix)) interruptedDropAttempts.delete(key);
+	}
+}
 let loadedDatabases; // indicates if we have loaded databases from the file system yet
 
 // This is used to track all the databases that are found when iterating through the file system so that anything that is missing
@@ -563,14 +585,14 @@ function initStores(
 	// it, because creating over a half-dropped table would resurrect its catalog
 	// rows. There a failure propagates to the caller as its own single error.
 	for (const [tableName, tableDef] of tablesToLoad) {
-		const dropKey = interruptedDropKey(databaseName, tableName, tableDef.primary?.dropGeneration);
+		const dropKey = interruptedDropKey(path, tableName, tableDef.primary?.dropGeneration);
 		if (!tableDef.primary?.dropping) {
 			// No tombstone, so any budget this table spent belongs to a drop that
 			// has since been resolved - by the create path, which completes
 			// interrupted drops itself and never passes through here. Leaving the
 			// budget spent would permanently skip cleanup for the table's NEXT
 			// interrupted drop.
-			interruptedDropAttempts.delete(dropKey);
+			clearInterruptedDropEntries(path, tableName);
 			continue;
 		}
 		const failedAttempts = interruptedDropAttempts.get(dropKey) ?? 0;
@@ -1285,8 +1307,9 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 				// before any reconcile observes it live in between would have its NEXT
 				// interrupted drop inherit this one's spent attempts. Generation-scoped
 				// keying (see interruptedDropKey) already makes that impossible, but
-				// clearing it here too avoids leaving a dead entry behind.
-				interruptedDropAttempts.delete(interruptedDropKey(databaseName, tableName, existingTableMeta?.dropGeneration));
+				// clearing it here too avoids leaving a dead entry behind - for every
+				// generation this table has ever spent, not just the one on this row.
+				clearInterruptedDropEntries(rootStore.path, tableName);
 			}
 			if (rootStore instanceof RocksDatabase) {
 				primaryStore = openRocksDatabase(rootStore.path, { ...dbiInit, name: dbiName, cache: true } as any);
@@ -1928,12 +1951,27 @@ function completeInterruptedDrop(rootStore, attributesDbi, databaseName: string,
 			}
 		}
 	}
+	// The primary catalog row (the `dropping` tombstone itself, keyed at exactly
+	// `tableName + '/'`) sorts first among these keys and so would be removed
+	// before the attribute rows that follow it. Removing it last instead means a
+	// removeSync failure partway through leaves the tombstone in place alongside
+	// whatever attribute rows didn't get removed yet, so a later retry still
+	// recognizes the table as mid-drop - instead of the tombstone vanishing
+	// first and stranding orphaned attribute rows that the next load would
+	// misread as a live (non-dropping) table.
+	const primaryCatalogKey = tableName + '/';
+	let removePrimaryLast = false;
 	for (const key of attributesDbi.getKeys({ start: tableName + '/', end: tableName + '0' })) {
+		if (key === primaryCatalogKey) {
+			removePrimaryLast = true;
+			continue;
+		}
 		// removeSync (not remove): same reasoning as dropSync above - the async
 		// remove() rejects after this function has already returned, so a
 		// catalog-removal failure would bypass the retry accounting entirely.
 		(attributesDbi as any).removeSync(key);
 	}
+	if (removePrimaryLast) (attributesDbi as any).removeSync(primaryCatalogKey);
 }
 
 export function dropTableMeta({ table: tableName, database: databaseName }) {

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -577,7 +577,12 @@ function initStores(
 				const dropLabel = `${databaseName}.${tableName}`;
 				if (attempt < MAX_INTERRUPTED_DROP_ATTEMPTS) {
 					logger.debug(`Failed to complete interrupted drop of table ${dropLabel}, attempt ${attempt}`, error);
-				} else {
+				} else if (manageThreads.getWorkerIndex() === 0) {
+					// The attempt budget (and this failure) is independently tracked per worker
+					// thread, and the failure isn't transient, so every worker converges on the
+					// same give-up outcome. Only worker 0 - which exists in every threading mode,
+					// including threads:0 where the main thread acts as worker 0 - logs it, so one
+					// stuck table produces one actionable error instead of one per worker.
 					logger.error(
 						`Unable to complete the interrupted drop of table ${dropLabel} after ${attempt} attempts; giving up until this node restarts. ${tableName} stays unloaded, with its catalog rows and column families left in place. An "Invalid column family specified in write batch" cause means the storage environment for ${databaseName} has latched a background error and will reject every write to every table in it until this node restarts.`,
 						error
@@ -1266,6 +1271,12 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 				// entry as an existing table would recurse forever on the stale
 				// catalog row.
 				completeInterruptedDrop(rootStore, attributesDbi, databaseName, tableName);
+				// This resolves the drop without ever going through the schema-load
+				// reconcile below, which is the only other place that returns a spent
+				// budget. Without clearing it here too, a table that gets dropped again
+				// before any reconcile observes it live in between would have its NEXT
+				// interrupted drop inherit this one's spent attempts.
+				interruptedDropAttempts.delete(interruptedDropKey(databaseName, tableName));
 			}
 			if (rootStore instanceof RocksDatabase) {
 				primaryStore = openRocksDatabase(rootStore.path, { ...dbiInit, name: dbiName, cache: true } as any);
@@ -1890,8 +1901,11 @@ function completeInterruptedDrop(rootStore, attributesDbi, databaseName: string,
 				const objectStorage =
 					value?.isPrimaryKey || (value?.indexed?.type && CUSTOM_INDEXES[value.indexed.type]?.useObjectStore);
 				const store = (rootStore as any).openDB(key, createOpenDBIObject(!objectStorage, objectStorage) as any);
-				// lmdb drop commits with the env's next transaction
-				store.drop?.();
+				// dropSync (not drop): this function is synchronous, and its callers rely on
+				// a thrown error to count against the retry budget below - the async drop()
+				// resolves/rejects after this try/catch has already returned, so a failure
+				// there would silently bypass the retry accounting entirely.
+				store.dropSync?.();
 			} catch (error) {
 				logger.warn(`Failed dropping store ${key} of ${databaseName}.${tableName}`, error);
 			}

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -253,6 +253,14 @@ const interruptedDropKey = (storePath: string, tableName: string, generation?: s
 // path+table prefix instead of guessing which generation to target.
 const interruptedDropKeyPrefix = (storePath: string, tableName: string) => `${storePath}\0${tableName}\0`;
 function clearInterruptedDropEntries(storePath: string, tableName: string) {
+	// This runs on every table on every reconcile pass (including every live,
+	// never-dropped table), so an unconditional scan would make schema reload
+	// cost grow with the total number of tracked retry entries on top of the
+	// table count. interruptedDropAttempts is empty in the overwhelming common
+	// case (no drop has ever failed to complete), so this size check keeps the
+	// healthy-system cost at O(1) and only pays for the scan while there is
+	// actually something to sweep.
+	if (interruptedDropAttempts.size === 0) return;
 	const prefix = interruptedDropKeyPrefix(storePath, tableName);
 	for (const key of interruptedDropAttempts.keys()) {
 		if (key.startsWith(prefix)) interruptedDropAttempts.delete(key);

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -223,48 +223,41 @@ const NEXT_TABLE_ID = Symbol.for('next-table-id');
 // unbounded retry turns one broken table into a per-reload log flood in every
 // worker thread.
 const MAX_INTERRUPTED_DROP_ATTEMPTS = 3;
-// physical store path + table -> consecutive failed completion attempts in
-// this thread. Keyed by the physical store path rather than the database
-// alias name: multiple database names can point at the same directory
-// (config-level aliasing), and readMetaDb/readRocksMetaDb reconcile each
-// alias's schema independently, so a table shared by N aliases would
-// otherwise be attempted (and give up) N times over - once per alias - on
-// top of the once-per-worker duplication. Keying by path collapses all of
-// that back down to one budget, and one give-up log via the worker-0 gate
-// below, per physical table. Keyed with a NUL separator rather than a dot so
-// that path "a.b" table "c" and path "a" table "b.c" cannot share a budget.
-const interruptedDropAttempts = new Map<string, number>();
-// Scoped by drop generation (Table.ts stamps a fresh id on every dropping
-// tombstone) rather than just path + table: a worker can exhaust one drop's
-// budget, then observe the table recreated and dropped again without ever
-// seeing an intermediate non-tombstoned row to reset on. Keying by
-// generation means the new drop's tombstone always carries a fresh key,
-// independent of what any worker last observed. Tombstones written before
-// this field existed fall back to a shared 'legacy' bucket.
-const interruptedDropKey = (storePath: string, tableName: string, generation?: string) =>
-	`${storePath}\0${tableName}\0${generation ?? 'legacy'}`;
-// A live (non-tombstoned) row never carries the dropGeneration of whatever
-// drop it resolved - generations are only stamped while dropping - so a
-// lookup keyed off the live row's (absent) generation can only ever hit the
-// 'legacy' bucket, never the actual spent UUID entry. That entry is
-// harmless (a new drop always gets a fresh generation-scoped key regardless)
-// but never gets cleaned up either, leaking one Map entry per historical
-// drop generation for the worker's lifetime. Sweep every entry under this
-// path+table prefix instead of guessing which generation to target.
-const interruptedDropKeyPrefix = (storePath: string, tableName: string) => `${storePath}\0${tableName}\0`;
+// physical store path + table -> drop generation -> consecutive failed
+// completion attempts in this thread. Keyed by the physical store path
+// rather than the database alias name: multiple database names can point at
+// the same directory (config-level aliasing), and readMetaDb/readRocksMetaDb
+// reconcile each alias's schema independently, so a table shared by N
+// aliases would otherwise be attempted (and give up) N times over - once per
+// alias - on top of the once-per-worker duplication. Keying by path
+// collapses all of that back down to one budget, and one give-up log via the
+// worker-0 gate below, per physical table.
+//
+// Nested by generation (Table.ts stamps a fresh id on every dropping
+// tombstone) rather than a single flat count per path+table: a worker can
+// exhaust one drop's budget, then observe the table recreated and dropped
+// again without ever seeing an intermediate non-tombstoned row to reset on.
+// A fresh generation always gets a fresh inner-map key, independent of what
+// any worker last observed. Tombstones written before this field existed
+// fall back to a shared 'legacy' bucket. Nesting (rather than a flat map
+// keyed by a combined string) also makes "clear every generation for this
+// path+table" an O(1) delete of the outer entry instead of a scan - a live
+// (non-tombstoned) row never carries the dropGeneration of whatever drop it
+// resolved, so a resolution can only ever identify the outer path+table key,
+// never the specific spent generation to target.
+const interruptedDropAttempts = new Map<string, Map<string, number>>();
+const interruptedDropTableKey = (storePath: string, tableName: string) => `${storePath}\0${tableName}`;
+function getInterruptedDropAttempts(storePath: string, tableName: string, generation?: string): number {
+	return interruptedDropAttempts.get(interruptedDropTableKey(storePath, tableName))?.get(generation ?? 'legacy') ?? 0;
+}
+function setInterruptedDropAttempts(storePath: string, tableName: string, generation: string | undefined, attempts: number) {
+	const tableKey = interruptedDropTableKey(storePath, tableName);
+	let generations = interruptedDropAttempts.get(tableKey);
+	if (!generations) interruptedDropAttempts.set(tableKey, (generations = new Map()));
+	generations.set(generation ?? 'legacy', attempts);
+}
 function clearInterruptedDropEntries(storePath: string, tableName: string) {
-	// This runs on every table on every reconcile pass (including every live,
-	// never-dropped table), so an unconditional scan would make schema reload
-	// cost grow with the total number of tracked retry entries on top of the
-	// table count. interruptedDropAttempts is empty in the overwhelming common
-	// case (no drop has ever failed to complete), so this size check keeps the
-	// healthy-system cost at O(1) and only pays for the scan while there is
-	// actually something to sweep.
-	if (interruptedDropAttempts.size === 0) return;
-	const prefix = interruptedDropKeyPrefix(storePath, tableName);
-	for (const key of interruptedDropAttempts.keys()) {
-		if (key.startsWith(prefix)) interruptedDropAttempts.delete(key);
-	}
+	interruptedDropAttempts.delete(interruptedDropTableKey(storePath, tableName));
 }
 let loadedDatabases; // indicates if we have loaded databases from the file system yet
 
@@ -593,17 +586,19 @@ function initStores(
 	// it, because creating over a half-dropped table would resurrect its catalog
 	// rows. There a failure propagates to the caller as its own single error.
 	for (const [tableName, tableDef] of tablesToLoad) {
-		const dropKey = interruptedDropKey(path, tableName, tableDef.primary?.dropGeneration);
 		if (!tableDef.primary?.dropping) {
 			// No tombstone, so any budget this table spent belongs to a drop that
 			// has since been resolved - by the create path, which completes
 			// interrupted drops itself and never passes through here. Leaving the
 			// budget spent would permanently skip cleanup for the table's NEXT
-			// interrupted drop.
+			// interrupted drop. Checked (and, on the common all-live path, skipped)
+			// before touching the generation or the map at all, since this runs for
+			// every table on every reconcile pass.
 			clearInterruptedDropEntries(path, tableName);
 			continue;
 		}
-		const failedAttempts = interruptedDropAttempts.get(dropKey) ?? 0;
+		const generation = tableDef.primary?.dropGeneration;
+		const failedAttempts = getInterruptedDropAttempts(path, tableName, generation);
 		if (failedAttempts < MAX_INTERRUPTED_DROP_ATTEMPTS) {
 			try {
 				completeInterruptedDrop(rootStore, attributesDbi, databaseName, tableName);
@@ -617,7 +612,7 @@ function initStores(
 				definedTables?.delete(tableName);
 			} catch (error) {
 				const attempt = failedAttempts + 1;
-				interruptedDropAttempts.set(dropKey, attempt);
+				setInterruptedDropAttempts(path, tableName, generation, attempt);
 				const dropLabel = `${databaseName}.${tableName}`;
 				if (attempt < MAX_INTERRUPTED_DROP_ATTEMPTS) {
 					logger.debug(`Failed to complete interrupted drop of table ${dropLabel}, attempt ${attempt}`, error);
@@ -1320,7 +1315,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 				// budget. Without clearing it here too, a table that gets dropped again
 				// before any reconcile observes it live in between would have its NEXT
 				// interrupted drop inherit this one's spent attempts. Generation-scoped
-				// keying (see interruptedDropKey) already makes that impossible, but
+				// keying (see interruptedDropAttempts) already makes that impossible, but
 				// clearing it here too avoids leaving a dead entry behind - for every
 				// generation this table has ever spent, not just the one on this row.
 				clearInterruptedDropEntries(rootStore.path, tableName);

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -599,7 +599,13 @@ function initStores(
 		if (failedAttempts < MAX_INTERRUPTED_DROP_ATTEMPTS) {
 			try {
 				completeInterruptedDrop(rootStore, attributesDbi, databaseName, tableName);
-				interruptedDropAttempts.delete(dropKey);
+				// Sweep every generation this worker has ever tracked for this table, not
+				// just the one just resolved: if a prior generation was exhausted here,
+				// then resolved+recreated+re-dropped by another worker as this generation
+				// without this worker ever observing a live row in between (the only other
+				// place that sweeps), the prior generation's entry would otherwise never
+				// be cleared.
+				clearInterruptedDropEntries(path, tableName);
 				definedTables?.delete(tableName);
 			} catch (error) {
 				const attempt = failedAttempts + 1;

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -250,7 +250,12 @@ const interruptedDropTableKey = (storePath: string, tableName: string) => `${sto
 function getInterruptedDropAttempts(storePath: string, tableName: string, generation?: string): number {
 	return interruptedDropAttempts.get(interruptedDropTableKey(storePath, tableName))?.get(generation ?? 'legacy') ?? 0;
 }
-function setInterruptedDropAttempts(storePath: string, tableName: string, generation: string | undefined, attempts: number) {
+function setInterruptedDropAttempts(
+	storePath: string,
+	tableName: string,
+	generation: string | undefined,
+	attempts: number
+) {
 	const tableKey = interruptedDropTableKey(storePath, tableName);
 	let generations = interruptedDropAttempts.get(tableKey);
 	if (!generations) interruptedDropAttempts.set(tableKey, (generations = new Map()));

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -223,8 +223,11 @@ const NEXT_TABLE_ID = Symbol.for('next-table-id');
 // unbounded retry turns one broken table into a per-reload log flood in every
 // worker thread.
 const MAX_INTERRUPTED_DROP_ATTEMPTS = 3;
-// `database.table` -> consecutive failed completion attempts in this thread.
+// database + table -> consecutive failed completion attempts in this thread.
+// Keyed with a NUL separator rather than a dot so that database "a.b" table "c"
+// and database "a" table "b.c" cannot share a budget.
 const interruptedDropAttempts = new Map<string, number>();
+const interruptedDropKey = (databaseName: string, tableName: string) => `${databaseName}\0${tableName}`;
 let loadedDatabases; // indicates if we have loaded databases from the file system yet
 
 // This is used to track all the databases that are found when iterating through the file system so that anything that is missing
@@ -552,8 +555,16 @@ function initStores(
 	// it, because creating over a half-dropped table would resurrect its catalog
 	// rows. There a failure propagates to the caller as its own single error.
 	for (const [tableName, tableDef] of tablesToLoad) {
-		if (!tableDef.primary?.dropping) continue;
-		const dropKey = `${databaseName}.${tableName}`;
+		const dropKey = interruptedDropKey(databaseName, tableName);
+		if (!tableDef.primary?.dropping) {
+			// No tombstone, so any budget this table spent belongs to a drop that
+			// has since been resolved - by the create path, which completes
+			// interrupted drops itself and never passes through here. Leaving the
+			// budget spent would permanently skip cleanup for the table's NEXT
+			// interrupted drop.
+			interruptedDropAttempts.delete(dropKey);
+			continue;
+		}
 		const failedAttempts = interruptedDropAttempts.get(dropKey) ?? 0;
 		if (failedAttempts < MAX_INTERRUPTED_DROP_ATTEMPTS) {
 			try {
@@ -563,11 +574,12 @@ function initStores(
 			} catch (error) {
 				const attempt = failedAttempts + 1;
 				interruptedDropAttempts.set(dropKey, attempt);
+				const dropLabel = `${databaseName}.${tableName}`;
 				if (attempt < MAX_INTERRUPTED_DROP_ATTEMPTS) {
-					logger.debug(`Failed to complete interrupted drop of table ${dropKey}, attempt ${attempt}`, error);
+					logger.debug(`Failed to complete interrupted drop of table ${dropLabel}, attempt ${attempt}`, error);
 				} else {
 					logger.error(
-						`Unable to complete the interrupted drop of table ${dropKey} after ${attempt} attempts; giving up until this node restarts. ${tableName} stays unloaded, with its catalog rows and column families left in place. An "Invalid column family specified in write batch" cause means the storage environment for ${databaseName} has latched a background error and will reject every write to every table in it until this node restarts.`,
+						`Unable to complete the interrupted drop of table ${dropLabel} after ${attempt} attempts; giving up until this node restarts. ${tableName} stays unloaded, with its catalog rows and column families left in place. An "Invalid column family specified in write batch" cause means the storage environment for ${databaseName} has latched a background error and will reject every write to every table in it until this node restarts.`,
 						error
 					);
 				}

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -9,7 +9,7 @@ import {
 	getBaseSchemaPath,
 	getTransactionAuditStoreBasePath,
 } from '../dataLayer/harperBridge/lmdbBridge/lmdbUtility/initializePaths.js';
-import { makeTable } from './Table.ts';
+import { makeTable, ignoreAlreadyDropped } from './Table.ts';
 import OpenEnvironmentObject from '../utility/lmdb/OpenEnvironmentObject.ts';
 import { CONFIG_PARAMS, LEGACY_DATABASES_DIR_NAME, DATABASES_DIR_NAME } from '../utility/hdbTerms.ts';
 import { getConfigPath } from '../config/configUtils.ts';
@@ -1885,20 +1885,27 @@ async function runIndexing(Table, attributes, indicesToRemove) {
  * catalog rows. Called from the boot-time schema load and from the create
  * path when a same-named table is created over a tombstoned entry. Callers
  * are expected to hold the database's exclusive lock or be in single-threaded
- * startup; the per-store drops tolerate races (another worker may be
- * completing the same drop concurrently).
+ * startup; a redundant drop of an already-gone store (another worker may be
+ * completing the same drop concurrently) is tolerated, but any other
+ * per-store failure propagates so the catalog rows are NOT removed - a store
+ * that failed to drop must keep its tombstone, or a same-name recreate could
+ * reuse (LMDB) or resurrect (RocksDB) the old store's data. Logged only at
+ * debug: the caller's retry loop is what decides when a failure is
+ * actionable, and logging here on every attempt would flood at the same
+ * volume this function's callers are bounding.
  */
 function completeInterruptedDrop(rootStore, attributesDbi, databaseName: string, tableName: string) {
-	logger.warn(`Completing interrupted drop of table ${databaseName}.${tableName}`);
+	logger.debug(`Completing interrupted drop of table ${databaseName}.${tableName}`);
 	if (rootStore instanceof RocksDatabase) {
 		for (const columnName of (rootStore as any).columns) {
 			if (columnName.startsWith(tableName + '/')) {
+				const columnStore = openRocksDatabase(rootStore.path, { name: columnName } as any);
 				try {
-					const columnStore = openRocksDatabase(rootStore.path, { name: columnName } as any);
 					columnStore.dropSync();
-					columnStore.close();
 				} catch (error) {
-					logger.warn(`Failed dropping column family ${columnName} of ${databaseName}.${tableName}`, error);
+					ignoreAlreadyDropped(error);
+				} finally {
+					columnStore.close();
 				}
 			}
 		}
@@ -1907,17 +1914,17 @@ function completeInterruptedDrop(rootStore, attributesDbi, databaseName: string,
 		// be dropped too; removing only the catalog rows would let a same-name
 		// recreate silently inherit the previous table's records.
 		for (const { key, value } of attributesDbi.getRange({ start: tableName + '/', end: tableName + '0' })) {
+			const objectStorage =
+				value?.isPrimaryKey || (value?.indexed?.type && CUSTOM_INDEXES[value.indexed.type]?.useObjectStore);
+			const store = (rootStore as any).openDB(key, createOpenDBIObject(!objectStorage, objectStorage) as any);
 			try {
-				const objectStorage =
-					value?.isPrimaryKey || (value?.indexed?.type && CUSTOM_INDEXES[value.indexed.type]?.useObjectStore);
-				const store = (rootStore as any).openDB(key, createOpenDBIObject(!objectStorage, objectStorage) as any);
 				// dropSync (not drop): this function is synchronous, and its callers rely on
 				// a thrown error to count against the retry budget below - the async drop()
 				// resolves/rejects after this try/catch has already returned, so a failure
 				// there would silently bypass the retry accounting entirely.
 				store.dropSync?.();
 			} catch (error) {
-				logger.warn(`Failed dropping store ${key} of ${databaseName}.${tableName}`, error);
+				ignoreAlreadyDropped(error);
 			}
 		}
 	}

--- a/unitTests/resources/dropTableGhost.test.js
+++ b/unitTests/resources/dropTableGhost.test.js
@@ -246,6 +246,101 @@ describe('dropTable ghost regression', () => {
 		await dbisDb.committed;
 	});
 
+	it('only logs the give-up error from worker 0, not every worker', async function () {
+		this.timeout(20000);
+		// Every worker thread tracks its own budget and independently exhausts it,
+		// so without a single-worker gate this would log once per worker instead
+		// of once for the whole process. Uses two tables (one exhausted as a
+		// non-worker-0 thread, one as worker 0) because a table's budget only
+		// logs once, at the reload where it first hits MAX_INTERRUPTED_DROP_ATTEMPTS
+		// - re-observing an already-exhausted table from worker 0 does not re-log.
+		//
+		// table() reassigns rootStore.dbisDb to a fresh openDB() result on every
+		// create, so dbisDb must be (re-)fetched after a table is defined, not
+		// before - an earlier reference goes stale the moment the next table is
+		// created and stubbing it has no effect on the reconcile's real attributesDbi.
+		const stuckTombstone = async (table) => {
+			const Stuck = defineTable(table);
+			await Stuck.put({ id: 1, str: 'data' });
+			const dbisDb = getDbisDb();
+			const meta = dbisDb.getSync(`${table}/`);
+			meta.dropping = true;
+			await dbisDb.put(`${table}/`, meta);
+			delete databases[TEST_DB][table];
+			return dbisDb;
+		};
+		const stubFailingRemove = (dbisDb, table) => {
+			const originalRemove = dbisDb.remove;
+			dbisDb.remove = function (key, ...rest) {
+				if (typeof key === 'string' && key.startsWith(`${table}/`)) {
+					throw new Error('Remove failed: Invalid argument: Invalid column family specified in write batch');
+				}
+				return originalRemove.call(this, key, ...rest);
+			};
+			return () => {
+				dbisDb.remove = originalRemove;
+			};
+		};
+		const storageLogger = harperLogger.forComponent('storage');
+		const originalLogError = storageLogger.error;
+		const errorLogs = [];
+		storageLogger.error = (message, ...rest) => {
+			errorLogs.push(message);
+			return originalLogError.call(storageLogger, message, ...rest);
+		};
+		const reload = () => {
+			resetDatabases();
+			getDatabases();
+		};
+		const cleanUpTombstone = (dbisDb, table) => {
+			for (const key of [...dbisDb.getKeys({ start: `${table}/`, end: `${table}0` })]) {
+				dbisDb.remove(key);
+			}
+		};
+
+		const OTHER_WORKER_TABLE = `GhostWorkerGateOther_${process.pid}_${Date.now()}`;
+		const WORKER_ZERO_TABLE = `GhostWorkerGateZero_${process.pid}_${Date.now()}`;
+		try {
+			// exhaust the non-worker-0 table's budget entirely off-gate
+			let dbisDb = await stuckTombstone(OTHER_WORKER_TABLE);
+			let restoreRemove = stubFailingRemove(dbisDb, OTHER_WORKER_TABLE);
+			setMainIsWorker(false);
+			for (let i = 0; i < 5; i++) reload();
+			restoreRemove();
+			assert.equal(
+				errorLogs.filter((message) => String(message).includes(OTHER_WORKER_TABLE)).length,
+				0,
+				'a non-worker-0 thread must not log the give-up error'
+			);
+			cleanUpTombstone(dbisDb, OTHER_WORKER_TABLE);
+
+			// a fresh table's budget, exhausted on-gate, must log exactly once - this
+			// must be a separate table since the first one's budget is already spent
+			// and would no longer be retried (so re-observing it under worker 0
+			// would not exercise the gate at all)
+			dbisDb = await stuckTombstone(WORKER_ZERO_TABLE);
+			restoreRemove = stubFailingRemove(dbisDb, WORKER_ZERO_TABLE);
+			setMainIsWorker(true);
+			for (let i = 0; i < 5; i++) reload();
+			restoreRemove();
+			// setupTestDBPath() points data/dev/test/test2 at the same physical
+			// path, so this table's tombstone is reconciled (and separately
+			// budgeted) once per database name - matched here on the exact
+			// "database.table" identifier to isolate the worker-0 gate from that
+			// unrelated per-alias multiplication (see PR review discussion).
+			assert.equal(
+				errorLogs.filter((message) => String(message).includes(`${TEST_DB}.${WORKER_ZERO_TABLE}`)).length,
+				1,
+				'worker 0 must log the give-up error exactly once'
+			);
+			cleanUpTombstone(dbisDb, WORKER_ZERO_TABLE);
+			await dbisDb.committed;
+		} finally {
+			storageLogger.error = originalLogError;
+			setMainIsWorker(true);
+		}
+	});
+
 	// A spent budget must not outlive the drop that spent it. The create path
 	// completes interrupted drops itself, under the exclusive lock, and never
 	// passes through the reconcile - so a table can go from "budget exhausted" to

--- a/unitTests/resources/dropTableGhost.test.js
+++ b/unitTests/resources/dropTableGhost.test.js
@@ -225,16 +225,21 @@ describe('dropTable ghost regression', () => {
 			`completion attempts must stop, not repeat on every schema reload (${attempts - attemptsWhenExhausted} more over 5 further reloads)`
 		);
 
-		// the tombstone is mirrored into every database that shares this store, so
-		// each stuck table gets its own give-up error - and only one
+		// setupTestDBPath() mirrors this store's tombstone into every database
+		// alias that shares its physical path (data/dev/test/test2), and the
+		// reconcile runs once per alias per reload - but the retry budget is
+		// keyed on the physical store path, not the alias name, so all four
+		// aliases share one budget and this physically-one table gives up
+		// exactly once total, under whichever alias's reconcile pass happened
+		// to be the one that spent the last attempt.
 		const giveUpLogs = errorLogs.filter((message) => String(message).includes(TABLE));
 		const loggedTables = giveUpLogs.map((message) => String(message).match(/table (\S+)/)[1]);
-		assert.ok(loggedTables.includes(`${TEST_DB}.${TABLE}`), 'the stuck table must be named in the error');
 		assert.equal(
-			new Set(loggedTables).size,
 			loggedTables.length,
-			`each stuck table must log exactly one actionable error, got ${loggedTables.join(', ')}`
+			1,
+			`a table shared by every database alias must give up exactly once total, got: ${loggedTables.join(', ')}`
 		);
+		assert.ok(loggedTables[0].endsWith(`.${TABLE}`), 'the stuck table must be named in the error');
 		assert.match(giveUpLogs[0], /giving up until this worker restarts/);
 		// the table must stay unloaded regardless
 		assert.equal(getDatabases()[TEST_DB]?.[TABLE], undefined, 'a tombstoned table must never load');
@@ -325,14 +330,16 @@ describe('dropTable ghost regression', () => {
 			for (let i = 0; i < 5; i++) reload();
 			restoreRemove();
 			// setupTestDBPath() points data/dev/test/test2 at the same physical
-			// path, so this table's tombstone is reconciled (and separately
-			// budgeted) once per database name - matched here on the exact
-			// "database.table" identifier to isolate the worker-0 gate from that
-			// unrelated per-alias multiplication (see PR review discussion).
+			// path, so this table's tombstone is reconciled once per database
+			// alias per reload - but the retry budget is keyed on the physical
+			// store path (see interruptedDropKey), not the alias name, so all
+			// four aliases' reconcile passes share one budget and this table
+			// still gives up exactly once total, regardless of which alias's
+			// pass happens to be the one that trips the gate.
 			assert.equal(
-				errorLogs.filter((message) => String(message).includes(`${TEST_DB}.${WORKER_ZERO_TABLE}`)).length,
+				errorLogs.filter((message) => String(message).includes(WORKER_ZERO_TABLE)).length,
 				1,
-				'worker 0 must log the give-up error exactly once'
+				`worker 0 must log the give-up error exactly once across all database aliases, got: ${errorLogs.join(' | ')}`
 			);
 			cleanUpTombstone(dbisDb, WORKER_ZERO_TABLE);
 			await dbisDb.committed;

--- a/unitTests/resources/dropTableGhost.test.js
+++ b/unitTests/resources/dropTableGhost.test.js
@@ -470,4 +470,53 @@ describe('dropTable ghost regression', () => {
 		}
 		await dbisDb.committed;
 	});
+
+	// Cross-model review: completeInterruptedDrop used to swallow every
+	// per-store dropSync failure (not just the tolerated "already dropped"
+	// race), then remove the catalog rows and let the caller clear the retry
+	// budget anyway - so a store that genuinely failed to drop was declared
+	// complete. A same-name recreate would then reuse (LMDB) or resurrect
+	// (RocksDB) that store's leftover data. LMDB-only: intercepts
+	// rootStore.openDB, the reconcile's own per-store open call, which is not
+	// reachable by stubbing a table's primaryStore/dbisDb like the other tests.
+	it('a genuine store-drop failure during reconcile preserves the tombstone instead of declaring success', async function () {
+		if (process.env.HARPER_STORAGE_ENGINE !== 'lmdb') return this.skip();
+		this.timeout(20000);
+		const TABLE = `GhostDropSyncFail_${process.pid}_${Date.now()}`;
+		const Stuck = defineTable(TABLE);
+		await Stuck.put({ id: 1, str: 'data' });
+		const dbisDb = getDbisDb();
+		const rootStore = Stuck.primaryStore.rootStore;
+		const meta = dbisDb.getSync(`${TABLE}/`);
+		meta.dropping = true;
+		await dbisDb.put(`${TABLE}/`, meta);
+		delete databases[TEST_DB][TABLE];
+
+		const originalOpenDB = rootStore.openDB;
+		rootStore.openDB = function (key, ...rest) {
+			const store = originalOpenDB.call(this, key, ...rest);
+			if (typeof key === 'string' && key.startsWith(`${TABLE}/`)) {
+				store.dropSync = () => {
+					throw new Error('disk I/O error');
+				};
+			}
+			return store;
+		};
+		try {
+			resetDatabases();
+			getDatabases();
+		} finally {
+			rootStore.openDB = originalOpenDB;
+		}
+
+		const survivingMeta = dbisDb.getSync(`${TABLE}/`);
+		assert.ok(survivingMeta?.dropping, 'a genuine store-drop failure must leave the tombstone in place');
+		assert.equal(getDatabases()[TEST_DB]?.[TABLE], undefined, 'a tombstoned table must never load');
+
+		// clean up by hand now that dropSync works again
+		for (const key of [...dbisDb.getKeys({ start: `${TABLE}/`, end: `${TABLE}0` })]) {
+			dbisDb.remove(key);
+		}
+		await dbisDb.committed;
+	});
 });

--- a/unitTests/resources/dropTableGhost.test.js
+++ b/unitTests/resources/dropTableGhost.test.js
@@ -526,4 +526,62 @@ describe('dropTable ghost regression', () => {
 		}
 		await dbisDb.committed;
 	});
+
+	// PR review (codex, pre-push): the earlier "bounds the retries" test fails
+	// removeSync for every row under the table's prefix, including the primary
+	// tombstone itself, so it can't tell whether the tombstone is removed
+	// before or after the other catalog rows - both orderings fail identically
+	// there. This test instead lets the primary tombstone's own removeSync
+	// succeed and fails only a secondary (indexed-attribute) row's, so it can
+	// distinguish the two: with the tombstone removed first, it would already
+	// be gone by the time the secondary row's removal throws; with it removed
+	// last (the fix), the throw happens before the primary is ever touched, so
+	// it must still be present after the failed reconcile.
+	it('a mid-cleanup catalog-row failure leaves the primary tombstone in place, not already-removed', async function () {
+		this.timeout(20000);
+		const TABLE = `GhostTombstoneOrder_${process.pid}_${Date.now()}`;
+		const Stuck = table({
+			table: TABLE,
+			database: TEST_DB,
+			attributes: [
+				{ name: 'id', type: 'Int', isPrimaryKey: true },
+				{ name: 'str', type: 'String', indexed: true },
+			],
+		});
+		await Stuck.put({ id: 1, str: 'data' });
+		const dbisDb = getDbisDb();
+		const secondaryKey = `${TABLE}/str`;
+		assert.ok(dbisDb.getSync(secondaryKey), 'the indexed attribute must have its own catalog row for this test to be meaningful');
+
+		const meta = dbisDb.getSync(`${TABLE}/`);
+		meta.dropping = true;
+		await dbisDb.put(`${TABLE}/`, meta);
+		delete databases[TEST_DB][TABLE];
+
+		const originalRemoveSync = dbisDb.removeSync;
+		dbisDb.removeSync = function (key, ...rest) {
+			if (key === secondaryKey) {
+				throw new Error('Remove failed: Invalid argument: Invalid column family specified in write batch');
+			}
+			return originalRemoveSync.call(this, key, ...rest);
+		};
+		try {
+			resetDatabases();
+			getDatabases();
+		} finally {
+			dbisDb.removeSync = originalRemoveSync;
+		}
+
+		assert.ok(
+			dbisDb.getSync(`${TABLE}/`)?.dropping,
+			'the primary tombstone must survive a failure removing a different catalog row'
+		);
+		assert.equal(getDatabases()[TEST_DB]?.[TABLE], undefined, 'a tombstoned table must never load');
+
+		// clean up by hand now that removeSync works again
+		for (const key of [...dbisDb.getKeys({ start: `${TABLE}/`, end: `${TABLE}0` })]) {
+			dbisDb.remove(key);
+		}
+		await dbisDb.committed;
+	});
 });

--- a/unitTests/resources/dropTableGhost.test.js
+++ b/unitTests/resources/dropTableGhost.test.js
@@ -171,13 +171,17 @@ describe('dropTable ghost regression', () => {
 
 	it('bounds the retries of a drop that can never complete', async function () {
 		this.timeout(20000);
-		const Stuck = defineTable('GhostRetryBound');
+		// The attempt budget is module-level and deliberately survives until the
+		// process restarts, so a fixed name would start this test with a spent
+		// budget on any in-process re-run (a mocha retry, say).
+		const TABLE = `GhostRetryBound_${process.pid}_${Date.now()}`;
+		const Stuck = defineTable(TABLE);
 		await Stuck.put({ id: 1, str: 'data' });
 		const dbisDb = getDbisDb();
-		const meta = dbisDb.getSync('GhostRetryBound/');
+		const meta = dbisDb.getSync(`${TABLE}/`);
 		meta.dropping = true;
-		await dbisDb.put('GhostRetryBound/', meta);
-		delete databases[TEST_DB].GhostRetryBound;
+		await dbisDb.put(`${TABLE}/`, meta);
+		delete databases[TEST_DB][TABLE];
 
 		// completeInterruptedDrop finishes by removing the table's catalog rows.
 		// Fail that the way a storage environment that can no longer accept writes
@@ -185,7 +189,7 @@ describe('dropTable ghost regression', () => {
 		const originalRemove = dbisDb.remove;
 		let attempts = 0;
 		dbisDb.remove = function (key, ...rest) {
-			if (typeof key === 'string' && key.startsWith('GhostRetryBound/')) {
+			if (typeof key === 'string' && key.startsWith(`${TABLE}/`)) {
 				attempts++;
 				throw new Error('Remove failed: Invalid argument: Invalid column family specified in write batch');
 			}
@@ -222,9 +226,9 @@ describe('dropTable ghost regression', () => {
 
 		// the tombstone is mirrored into every database that shares this store, so
 		// each stuck table gets its own give-up error - and only one
-		const giveUpLogs = errorLogs.filter((message) => String(message).includes('GhostRetryBound'));
+		const giveUpLogs = errorLogs.filter((message) => String(message).includes(TABLE));
 		const loggedTables = giveUpLogs.map((message) => String(message).match(/table (\S+)/)[1]);
-		assert.ok(loggedTables.includes(`${TEST_DB}.GhostRetryBound`), 'the stuck table must be named in the error');
+		assert.ok(loggedTables.includes(`${TEST_DB}.${TABLE}`), 'the stuck table must be named in the error');
 		assert.equal(
 			new Set(loggedTables).size,
 			loggedTables.length,
@@ -232,11 +236,75 @@ describe('dropTable ghost regression', () => {
 		);
 		assert.match(giveUpLogs[0], /giving up until this node restarts/);
 		// the table must stay unloaded regardless
-		assert.equal(getDatabases()[TEST_DB]?.GhostRetryBound, undefined, 'a tombstoned table must never load');
+		assert.equal(getDatabases()[TEST_DB]?.[TABLE], undefined, 'a tombstoned table must never load');
 
 		// the budget is exhausted for this process, so clean the tombstoned rows up
 		// by hand rather than leaving a stuck table behind for later tests
-		for (const key of [...dbisDb.getKeys({ start: 'GhostRetryBound/', end: 'GhostRetryBound0' })]) {
+		for (const key of [...dbisDb.getKeys({ start: `${TABLE}/`, end: `${TABLE}0` })]) {
+			dbisDb.remove(key);
+		}
+		await dbisDb.committed;
+	});
+
+	// A spent budget must not outlive the drop that spent it. The create path
+	// completes interrupted drops itself, under the exclusive lock, and never
+	// passes through the reconcile - so a table can go from "budget exhausted" to
+	// "alive again" without the reconcile ever seeing a success. If the budget
+	// survived that, the table's NEXT interrupted drop would be skipped outright
+	// and its catalog rows would silently resurrect it.
+	it('clears a spent retry budget once the table is no longer tombstoned', async function () {
+		this.timeout(20000);
+		const TABLE = `GhostBudgetReset_${process.pid}_${Date.now()}`;
+		const Stuck = defineTable(TABLE);
+		await Stuck.put({ id: 1, str: 'data' });
+		const dbisDb = getDbisDb();
+
+		const setDropping = async (dropping) => {
+			const meta = dbisDb.getSync(`${TABLE}/`);
+			meta.dropping = dropping;
+			await dbisDb.put(`${TABLE}/`, meta);
+		};
+
+		const originalRemove = dbisDb.remove;
+		let attempts = 0;
+		dbisDb.remove = function (key, ...rest) {
+			if (typeof key === 'string' && key.startsWith(`${TABLE}/`)) {
+				attempts++;
+				throw new Error('Remove failed: Invalid argument: Invalid column family specified in write batch');
+			}
+			return originalRemove.call(this, key, ...rest);
+		};
+		const reload = () => {
+			resetDatabases();
+			getDatabases();
+		};
+
+		try {
+			// spend the whole budget on a first interrupted drop
+			await setDropping(true);
+			delete databases[TEST_DB][TABLE];
+			for (let i = 0; i < 5; i++) reload();
+			const spent = attempts;
+			assert.ok(spent > 0, 'the first interrupted drop must be attempted');
+
+			// the drop is resolved elsewhere (the create path) and the table lives
+			// again: one reload with no tombstone must return the budget
+			await setDropping(false);
+			reload();
+
+			// a second interrupted drop must get a fresh budget, not the spent one
+			await setDropping(true);
+			delete databases[TEST_DB][TABLE];
+			reload();
+			assert.ok(
+				attempts > spent,
+				`a later interrupted drop must be retried again, not skipped on the previous drop's spent budget (attempts stuck at ${attempts})`
+			);
+		} finally {
+			dbisDb.remove = originalRemove;
+		}
+
+		for (const key of [...dbisDb.getKeys({ start: `${TABLE}/`, end: `${TABLE}0` })]) {
 			dbisDb.remove(key);
 		}
 		await dbisDb.committed;

--- a/unitTests/resources/dropTableGhost.test.js
+++ b/unitTests/resources/dropTableGhost.test.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 const { setupTestDBPath } = require('../testUtils');
 const { table, database, databases, getDatabases, resetDatabases } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const harperLogger = require('#src/utility/logging/harper_logger');
 
 const TEST_DB = 'test';
 
@@ -166,5 +167,78 @@ describe('dropTable ghost regression', () => {
 		const survived = dbisDb.getSync('GhostDropRaceCreate/');
 		assert.ok(survived, 'a same-name table created during the drop must keep its catalog row');
 		assert.ok(!survived.dropping, 'the surviving row must be the fresh (non-tombstoned) create');
+	});
+
+	it('bounds the retries of a drop that can never complete', async function () {
+		this.timeout(20000);
+		const Stuck = defineTable('GhostRetryBound');
+		await Stuck.put({ id: 1, str: 'data' });
+		const dbisDb = getDbisDb();
+		const meta = dbisDb.getSync('GhostRetryBound/');
+		meta.dropping = true;
+		await dbisDb.put('GhostRetryBound/', meta);
+		delete databases[TEST_DB].GhostRetryBound;
+
+		// completeInterruptedDrop finishes by removing the table's catalog rows.
+		// Fail that the way a storage environment that can no longer accept writes
+		// does, so every completion attempt fails identically and forever.
+		const originalRemove = dbisDb.remove;
+		let attempts = 0;
+		dbisDb.remove = function (key, ...rest) {
+			if (typeof key === 'string' && key.startsWith('GhostRetryBound/')) {
+				attempts++;
+				throw new Error('Remove failed: Invalid argument: Invalid column family specified in write batch');
+			}
+			return originalRemove.call(this, key, ...rest);
+		};
+		const storageLogger = harperLogger.forComponent('storage');
+		const originalLogError = storageLogger.error;
+		const errorLogs = [];
+		storageLogger.error = (message, ...rest) => {
+			errorLogs.push(message);
+			return originalLogError.call(storageLogger, message, ...rest);
+		};
+
+		const reload = () => {
+			resetDatabases();
+			getDatabases();
+		};
+		let attemptsWhenExhausted = 0;
+		try {
+			for (let i = 0; i < 5; i++) reload();
+			attemptsWhenExhausted = attempts;
+			for (let i = 0; i < 5; i++) reload();
+		} finally {
+			storageLogger.error = originalLogError;
+			dbisDb.remove = originalRemove;
+		}
+
+		assert.ok(attemptsWhenExhausted > 0, 'the interrupted drop must be attempted at least once');
+		assert.equal(
+			attempts,
+			attemptsWhenExhausted,
+			`completion attempts must stop, not repeat on every schema reload (${attempts - attemptsWhenExhausted} more over 5 further reloads)`
+		);
+
+		// the tombstone is mirrored into every database that shares this store, so
+		// each stuck table gets its own give-up error - and only one
+		const giveUpLogs = errorLogs.filter((message) => String(message).includes('GhostRetryBound'));
+		const loggedTables = giveUpLogs.map((message) => String(message).match(/table (\S+)/)[1]);
+		assert.ok(loggedTables.includes(`${TEST_DB}.GhostRetryBound`), 'the stuck table must be named in the error');
+		assert.equal(
+			new Set(loggedTables).size,
+			loggedTables.length,
+			`each stuck table must log exactly one actionable error, got ${loggedTables.join(', ')}`
+		);
+		assert.match(giveUpLogs[0], /giving up until this node restarts/);
+		// the table must stay unloaded regardless
+		assert.equal(getDatabases()[TEST_DB]?.GhostRetryBound, undefined, 'a tombstoned table must never load');
+
+		// the budget is exhausted for this process, so clean the tombstoned rows up
+		// by hand rather than leaving a stuck table behind for later tests
+		for (const key of [...dbisDb.getKeys({ start: 'GhostRetryBound/', end: 'GhostRetryBound0' })]) {
+			dbisDb.remove(key);
+		}
+		await dbisDb.committed;
 	});
 });

--- a/unitTests/resources/dropTableGhost.test.js
+++ b/unitTests/resources/dropTableGhost.test.js
@@ -551,7 +551,10 @@ describe('dropTable ghost regression', () => {
 		await Stuck.put({ id: 1, str: 'data' });
 		const dbisDb = getDbisDb();
 		const secondaryKey = `${TABLE}/str`;
-		assert.ok(dbisDb.getSync(secondaryKey), 'the indexed attribute must have its own catalog row for this test to be meaningful');
+		assert.ok(
+			dbisDb.getSync(secondaryKey),
+			'the indexed attribute must have its own catalog row for this test to be meaningful'
+		);
 
 		const meta = dbisDb.getSync(`${TABLE}/`);
 		meta.dropping = true;

--- a/unitTests/resources/dropTableGhost.test.js
+++ b/unitTests/resources/dropTableGhost.test.js
@@ -183,17 +183,18 @@ describe('dropTable ghost regression', () => {
 		await dbisDb.put(`${TABLE}/`, meta);
 		delete databases[TEST_DB][TABLE];
 
-		// completeInterruptedDrop finishes by removing the table's catalog rows.
-		// Fail that the way a storage environment that can no longer accept writes
-		// does, so every completion attempt fails identically and forever.
-		const originalRemove = dbisDb.remove;
+		// completeInterruptedDrop finishes by removing the table's catalog rows via
+		// removeSync. Fail that the way a storage environment that can no longer
+		// accept writes does, so every completion attempt fails identically and
+		// forever.
+		const originalRemoveSync = dbisDb.removeSync;
 		let attempts = 0;
-		dbisDb.remove = function (key, ...rest) {
+		dbisDb.removeSync = function (key, ...rest) {
 			if (typeof key === 'string' && key.startsWith(`${TABLE}/`)) {
 				attempts++;
 				throw new Error('Remove failed: Invalid argument: Invalid column family specified in write batch');
 			}
-			return originalRemove.call(this, key, ...rest);
+			return originalRemoveSync.call(this, key, ...rest);
 		};
 		const storageLogger = harperLogger.forComponent('storage');
 		const originalLogError = storageLogger.error;
@@ -214,7 +215,7 @@ describe('dropTable ghost regression', () => {
 			for (let i = 0; i < 5; i++) reload();
 		} finally {
 			storageLogger.error = originalLogError;
-			dbisDb.remove = originalRemove;
+			dbisDb.removeSync = originalRemoveSync;
 		}
 
 		assert.ok(attemptsWhenExhausted > 0, 'the interrupted drop must be attempted at least once');
@@ -234,7 +235,7 @@ describe('dropTable ghost regression', () => {
 			loggedTables.length,
 			`each stuck table must log exactly one actionable error, got ${loggedTables.join(', ')}`
 		);
-		assert.match(giveUpLogs[0], /giving up until this node restarts/);
+		assert.match(giveUpLogs[0], /giving up until this worker restarts/);
 		// the table must stay unloaded regardless
 		assert.equal(getDatabases()[TEST_DB]?.[TABLE], undefined, 'a tombstoned table must never load');
 
@@ -270,15 +271,15 @@ describe('dropTable ghost regression', () => {
 			return dbisDb;
 		};
 		const stubFailingRemove = (dbisDb, table) => {
-			const originalRemove = dbisDb.remove;
-			dbisDb.remove = function (key, ...rest) {
+			const originalRemoveSync = dbisDb.removeSync;
+			dbisDb.removeSync = function (key, ...rest) {
 				if (typeof key === 'string' && key.startsWith(`${table}/`)) {
 					throw new Error('Remove failed: Invalid argument: Invalid column family specified in write batch');
 				}
-				return originalRemove.call(this, key, ...rest);
+				return originalRemoveSync.call(this, key, ...rest);
 			};
 			return () => {
-				dbisDb.remove = originalRemove;
+				dbisDb.removeSync = originalRemoveSync;
 			};
 		};
 		const storageLogger = harperLogger.forComponent('storage');
@@ -360,14 +361,14 @@ describe('dropTable ghost regression', () => {
 			await dbisDb.put(`${TABLE}/`, meta);
 		};
 
-		const originalRemove = dbisDb.remove;
+		const originalRemoveSync = dbisDb.removeSync;
 		let attempts = 0;
-		dbisDb.remove = function (key, ...rest) {
+		dbisDb.removeSync = function (key, ...rest) {
 			if (typeof key === 'string' && key.startsWith(`${TABLE}/`)) {
 				attempts++;
 				throw new Error('Remove failed: Invalid argument: Invalid column family specified in write batch');
 			}
-			return originalRemove.call(this, key, ...rest);
+			return originalRemoveSync.call(this, key, ...rest);
 		};
 		const reload = () => {
 			resetDatabases();
@@ -396,7 +397,72 @@ describe('dropTable ghost regression', () => {
 				`a later interrupted drop must be retried again, not skipped on the previous drop's spent budget (attempts stuck at ${attempts})`
 			);
 		} finally {
-			dbisDb.remove = originalRemove;
+			dbisDb.removeSync = originalRemoveSync;
+		}
+
+		for (const key of [...dbisDb.getKeys({ start: `${TABLE}/`, end: `${TABLE}0` })]) {
+			dbisDb.remove(key);
+		}
+		await dbisDb.committed;
+	});
+
+	// PR review (kriszyp): the reset above depends on this worker observing an
+	// intermediate non-tombstoned row between two drops. A worker can exhaust
+	// drop A's budget, then never see A's catalog removal - because some other
+	// worker/process completed it and immediately recreated + re-dropped the
+	// table as drop B - before this worker's next reload. Without a per-drop
+	// identity, that reload would see only B's tombstone with A's spent count
+	// and skip every cleanup attempt for B. The budget is now keyed by the
+	// tombstone's own dropGeneration (stamped fresh by Table.ts on every drop),
+	// so B's tombstone never shares a key with A's, with no intermediate
+	// non-tombstoned reload required.
+	it('gives a fresh budget to a same-name drop that never left a non-tombstoned row visible', async function () {
+		this.timeout(20000);
+		const TABLE = `GhostGenerationRace_${process.pid}_${Date.now()}`;
+		const Stuck = defineTable(TABLE);
+		await Stuck.put({ id: 1, str: 'data' });
+		const dbisDb = getDbisDb();
+
+		const tombstone = async (generation) => {
+			const meta = dbisDb.getSync(`${TABLE}/`);
+			meta.dropping = true;
+			meta.dropGeneration = generation;
+			await dbisDb.put(`${TABLE}/`, meta);
+		};
+
+		const originalRemoveSync = dbisDb.removeSync;
+		let attempts = 0;
+		dbisDb.removeSync = function (key, ...rest) {
+			if (typeof key === 'string' && key.startsWith(`${TABLE}/`)) {
+				attempts++;
+				throw new Error('Remove failed: Invalid argument: Invalid column family specified in write batch');
+			}
+			return originalRemoveSync.call(this, key, ...rest);
+		};
+		const reload = () => {
+			resetDatabases();
+			getDatabases();
+		};
+
+		try {
+			// exhaust generation A's budget entirely
+			await tombstone('generation-A');
+			delete databases[TEST_DB][TABLE];
+			for (let i = 0; i < 5; i++) reload();
+			const spentOnA = attempts;
+			assert.ok(spentOnA > 0, 'generation A must be attempted');
+
+			// jump straight to generation B's tombstone - no reload ever observed a
+			// non-tombstoned row in between, unlike the previous test
+			await tombstone('generation-B');
+			delete databases[TEST_DB][TABLE];
+			reload();
+			assert.ok(
+				attempts > spentOnA,
+				`generation B must get its own budget instead of inheriting A's spent count (attempts stuck at ${attempts})`
+			);
+		} finally {
+			dbisDb.removeSync = originalRemoveSync;
 		}
 
 		for (const key of [...dbisDb.getKeys({ start: `${TABLE}/`, end: `${TABLE}0` })]) {


### PR DESCRIPTION
## What

Bounds the `completeInterruptedDrop` retry in the schema-load reconcile to 3 attempts per table per process, and replaces N identical `error` lines with one actionable error.

**This PR fixes only the log flood.** The underlying data-loss/blast-radius defect is root-caused below but deliberately not fixed here — the fix belongs in `@harperfast/rocksdb-js` and needs a direction decision first.

## Root cause of the 44-test cascade (Unit Test run [30237981148](https://github.com/HarperFast/harper/actions/runs/30237981148), sha `fe3994f4`, Node v24)

Refs #1381, which describes this failure but attributes it to "the column family is already gone/inconsistent". The real mechanism is worse and is not test-specific.

**A single write through a dropped RocksDB column-family handle latches a background error on the entire RocksDB environment. From that instant, every write to every column family in that environment fails with the same generic `Invalid argument: Invalid column family specified in write batch` — including column families created after the fact — until the environment is fully closed and reopened. Reads keep working.**

Reproduced directly against `@harperfast/rocksdb-js@2.5.0` (the version CI resolved):

```
baseline victim write ok: v0
columns after drop: [ 'default', 'victim' ]
--- victim write AFTER the drop, before any stale write ---
  ok                                    <-- the drop alone is harmless
--- write through the STALE dropped handle ---
  FAILED: Put failed: Invalid argument: Invalid column family specified in write batch
--- victim write AFTER the stale write ---
  POISONED: Put failed: Invalid argument: Invalid column family specified in write batch
--- a brand-new, unrelated CF opened after the poison ---
  POISONED: Put failed: Invalid argument: Invalid column family specified in write batch
--- reads still work? ---
  victim k0 = v0
```

A follow-up run confirms the latch clears only on a full close + reopen of every handle to that path — i.e. in production, a node restart.

`test/drop.test.ts` in rocksdb-js already documents this in a comment ("the failed write contaminates the env's shared write path, so writes through OTHER handles in this database fail afterward too"), but nothing enforces it.

### How harper triggered it

1. `unitTests/resources/Resource-get-context.test.js` exercises a sourced (cache) table. Each `Resource.get` that resolves from source stages a **background** cache write and returns to the caller without awaiting it — `resources/Table.ts:5641` is the error handler for exactly that fire-and-forget commit.
2. The suite's `after` hook calls `await TestTable.dropTable()`. Nothing quiesces those in-flight commits, so `primaryStore.dropSync()` (`resources/Table.ts:1259`) drops the column family out from under them.
3. Those commits land on the dropped CF and poison the environment. The CI log shows them, including a CF-id-specific variant that only a dropped CF produces:
   ```
   [main/0] [error]: Error committing cache update Error: Transaction commit failed: Invalid argument: Invalid column family specified in write batch
   [main/0] [error]: Error committing cache update Error: Transaction commit failed: Invalid argument: Could not access column family 154
   ```
4. The **very next write in the drop itself** — `dbisDb.remove` in `removeTombstonedCatalog` (`resources/Table.ts:1231`) — is the first victim. `dropTable` throws and the `dropping` tombstone survives, as designed.
5. Every subsequent test in the process then fails, not on its own table but on the shared catalog store: `table()` → `dbisDb.putSync` at `resources/databases.ts:1243`. Worker threads fail identically on their own unrelated tables (`vectorIndex-thread.js` → `Transaction commit failed: ...`). 44 failing tests.
6. `completeInterruptedDrop` runs once per database per `resetDatabases()`, fails identically every time, and logged an identical error each time — 4 databases × ~25 test files ≈ the ~100-line flood. That is what this PR fixes.

So the two symptoms in #1381 have one cause, and the blast radius is not a test artifact: in production, any drop that races an in-flight write to that table takes down **all writes to that whole database** until the node restarts.

## What this PR changes

`resources/databases.ts` — the reconcile loop in `initStores` now tracks consecutive failures per `database.table` and stops after 3, logging intermediate attempts at `debug` and one `error` that names the table, says what was left behind, and explains what an `Invalid column family` cause implies.

The budget is scoped to the reconcile. The create path (`databases.ts:1255`) also calls `completeInterruptedDrop`, under the exclusive lock, and must never skip it — creating over a half-dropped table would resurrect its catalog rows — so there the failure keeps propagating to the caller as its own single error.

Flood in the observed scenario goes from ~100 error lines to 4 (one per stuck table).

## What is NOT fixed here

- **The invariant, unenforced:** *no write may be issued against a dropped column family.* Nothing checks it; RocksDB discovers the violation inside a shared write batch and takes the whole environment down. The containing fix belongs in rocksdb-js — mark `ColumnFamilyDescriptor` dropped on `DropColumnFamily` and reject writes through a dropped handle with a scoped error naming the column family, before RocksDB sees the batch. That converts an environment-killing fail-open into one legible, contained failure. Its regression test belongs at that layer too (writes to CF X keep working after CF Y is dropped and written through).
- **The trigger, in harper:** `dropTable` does not quiesce in-flight writes to the table before dropping its column families. Removing the table from `databases[db][name]` stops new logical operations in the dropping thread only; already-staged transactions and other worker threads are unaffected. Fixing this properly is a change to how drops sequence against the transaction layer.

Both are being raised for a direction decision before any cross-repo work starts.

## Test notes

- New case in `unitTests/resources/dropTableGhost.test.js`: makes `completeInterruptedDrop`'s catalog removal fail permanently, drives 10 schema reloads, and asserts attempts stop after the budget and that each stuck table logs exactly one give-up error naming it.
- Negative control: with the `databases.ts` change reverted the new test fails with `completion attempts must stop, not repeat on every schema reload (20 more over 5 further reloads)`; the other 6 cases in the file still pass.
- `npm run test:unit:resources` — 1264 passing, 14 pending.
- `npm run test:unit:main` — 3801 passing, 188 pending.
- `npm run lint:required` clean; prettier run on the two changed files only.

Generated by Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
