### PR TITLE
fix(audit): give audit cleanup a real completion signal (deflake auditLog prune test)

### DIFF
--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -108,6 +108,9 @@ export const AUDIT_STORE_OPTIONS = {
 
 export let auditRetention = convertToMS(envGet(CONFIG_PARAMS.LOGGING_AUDITRETENTION)) || 86400 * 1000;
 const MAX_DELETES_PER_CLEANUP = 1000;
+// setTimeout silently falls back to 1ms for delays past this, which would turn the backoff into the
+// hot loop it is meant to avoid — a `logging.auditRetention` over ~248 days reaches it via retention/10
+const MAX_CLEANUP_DELAY = 2 ** 31 - 1;
 const FLOAT_TARGET = new Float64Array(1);
 const FLOAT_BUFFER = new Uint8Array(FLOAT_TARGET.buffer);
 let DEFAULT_AUDIT_CLEANUP_DELAY = 10000; // default delay of 10 seconds
@@ -165,10 +168,12 @@ export function openAuditStore(rootStore) {
 		}
 	});
 	/**
-	 * Schedules a pass of the audit cleanup loop. The returned promise settles once the pass that
-	 * serves this call has committed its deletions, so callers (notably tests) can await completion
-	 * instead of guessing a delay. A pass removes at most MAX_DELETES_PER_CLEANUP entries before
-	 * rescheduling itself, so settling means "that pass finished", not "the audit log is fully pruned".
+	 * Schedules a pass of the audit cleanup loop. The returned promise fulfills once the pass that
+	 * serves this call has finished, so callers (notably tests) can await completion instead of
+	 * guessing a delay. Two things it does not promise: a pass removes at most
+	 * MAX_DELETES_PER_CLEANUP entries before rescheduling itself, so fulfillment means "that pass
+	 * finished", not "the audit log is fully pruned"; and a pass that failed logs and fulfills rather
+	 * than rejecting, since this promise doubles as the loop's serialization barrier.
 	 */
 	function scheduleAuditCleanup(newCleanupDelay?: number): Promise<void> {
 		// Skip audit cleanup/purge in read-only mode
@@ -223,18 +228,22 @@ export function openAuditStore(rootStore) {
 						}
 					}
 					await committed;
+				} catch (error) {
+					// the timer callback is detached, so anything escaping here lands as an unhandled
+					// rejection instead of a log line — and skips the reschedule below with it
+					harperLogger.warn('Error during audit log cleanup', error);
 				} finally {
 					if (deleted === 0) {
 						// if we didn't delete anything, we can increase the delay (double until we get to one tenth of
-						// the retention time). `<<` would coerce to int32 here, and a sub-millisecond retention (used by
-						// tests) collapses the delay to 0 permanently — 0 << 1 is 0 — turning the backoff into a loop
-						// that reschedules every event turn for the life of the process.
-						auditCleanupDelay = Math.max(1, Math.min(auditCleanupDelay * 2, auditRetention / 10));
+						// the retention time). Plain arithmetic, not `<<`/`>>`: those coerce to int32, so a
+						// sub-millisecond retention collapsed the delay to 0 permanently (0 << 1 is 0), and a
+						// retention over ~248 days grows it past 2^31 where halving it wraps negative.
+						auditCleanupDelay = Math.max(1, Math.min(auditCleanupDelay * 2, auditRetention / 10, MAX_CLEANUP_DELAY));
 					} else {
 						// if we did delete something, update our updates since timestamp
 						updateLastRemoved(auditStore, lastKey);
 						// and do updates faster
-						if (auditCleanupDelay > 100) auditCleanupDelay = auditCleanupDelay >> 1;
+						if (auditCleanupDelay > 100) auditCleanupDelay = auditCleanupDelay / 2;
 					}
 					resolve();
 					scheduleAuditCleanup();

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -151,6 +151,9 @@ export function openAuditStore(rootStore) {
 		};
 	};
 	let pendingCleanup = null;
+	// resolver of the scheduled-but-not-yet-started pass, so a schedule that supersedes it can hand
+	// its callers over to the replacement instead of leaving them on a promise that never settles
+	let pendingCleanupResolve: (() => void) | null = null;
 	let lastCleanupResolution: Promise<void>;
 	let cleanupPriority = 0;
 	let auditCleanupDelay = DEFAULT_AUDIT_CLEANUP_DELAY;
@@ -161,24 +164,42 @@ export function openAuditStore(rootStore) {
 			return scheduleAuditCleanup(100);
 		}
 	});
+	/**
+	 * Schedules a pass of the audit cleanup loop. The returned promise settles once the pass that
+	 * serves this call has committed its deletions, so callers (notably tests) can await completion
+	 * instead of guessing a delay. A pass removes at most MAX_DELETES_PER_CLEANUP entries before
+	 * rescheduling itself, so settling means "that pass finished", not "the audit log is fully pruned".
+	 */
 	function scheduleAuditCleanup(newCleanupDelay?: number): Promise<void> {
 		// Skip audit cleanup/purge in read-only mode
-		if (isReadOnlyMode()) return;
+		if (isReadOnlyMode()) return Promise.resolve();
 		if (auditStore instanceof RocksTransactionLogStore) {
 			auditStore.rootStore.purgeLogs({
 				before: Date.now() - auditRetention / (1 + cleanupPriority * cleanupPriority),
 			});
-			return;
+			return Promise.resolve();
 		}
 
 		if (newCleanupDelay) auditCleanupDelay = newCleanupDelay;
+		// the pass we are about to cancel has not started, so its callers are handed over to this one
+		const supersededResolve = pendingCleanupResolve;
 		clearTimeout(pendingCleanup);
 		const resolution = new Promise<void>((resolve) => {
+			pendingCleanupResolve = resolve;
 			pendingCleanup = setTimeout(async () => {
-				await lastCleanupResolution;
+				pendingCleanupResolve = null; // started, so a later schedule can no longer cancel this pass
+				// claim the serialization slot before yielding: assigning it after the await lets every
+				// pass released by the same resolution run concurrently over the same range
+				const previousCleanup = lastCleanupResolution;
 				lastCleanupResolution = resolution;
+				await previousCleanup;
 				// query for audit entries that are old
-				if (auditStore.rootStore.status === 'closed' || auditStore.rootStore.status === 'closing') return;
+				if (auditStore.rootStore.status === 'closed' || auditStore.rootStore.status === 'closing') {
+					// nothing to clean up and nothing to reschedule, but leaving `resolution` pending would
+					// wedge the loop permanently: it is now the resolution every later pass awaits
+					resolve();
+					return;
+				}
 				let deleted = 0;
 				let committed: Promise<void>;
 				let lastKey: any;
@@ -204,20 +225,24 @@ export function openAuditStore(rootStore) {
 					await committed;
 				} finally {
 					if (deleted === 0) {
-						// if we didn't delete anything, we can increase the delay (double until we get to one tenth of the retention time)
-						auditCleanupDelay = Math.min(auditCleanupDelay << 1, auditRetention / 10);
+						// if we didn't delete anything, we can increase the delay (double until we get to one tenth of
+						// the retention time). `<<` would coerce to int32 here, and a sub-millisecond retention (used by
+						// tests) collapses the delay to 0 permanently — 0 << 1 is 0 — turning the backoff into a loop
+						// that reschedules every event turn for the life of the process.
+						auditCleanupDelay = Math.max(1, Math.min(auditCleanupDelay * 2, auditRetention / 10));
 					} else {
 						// if we did delete something, update our updates since timestamp
 						updateLastRemoved(auditStore, lastKey);
 						// and do updates faster
 						if (auditCleanupDelay > 100) auditCleanupDelay = auditCleanupDelay >> 1;
 					}
-					resolve(undefined);
+					resolve();
 					scheduleAuditCleanup();
 				}
 				// we can run this pretty frequently since there is very little overhead to these queries
 			}, auditCleanupDelay).unref();
 		});
+		if (supersededResolve) resolution.then(supersededResolve);
 		return resolution;
 	}
 	auditStore.scheduleAuditCleanup = scheduleAuditCleanup;

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -206,7 +206,6 @@ export function openAuditStore(rootStore) {
 					return;
 				}
 				let deleted = 0;
-				let committed: Promise<void>;
 				let lastKey: any;
 				try {
 					for (const auditRecord of auditStore.getRange({
@@ -215,7 +214,9 @@ export function openAuditStore(rootStore) {
 						end: Date.now() - auditRetention / (1 + cleanupPriority * cleanupPriority), // remove up until the audit retention time, reducing audit retention time if cleanup is higher priority
 					})) {
 						try {
-							committed = removeAuditEntry(auditStore, auditRecord);
+							// awaited so a rejection (not just a synchronous throw) is caught here instead of
+							// escaping as an unhandled rejection once a later iteration's promise replaces this one
+							await removeAuditEntry(auditStore, auditRecord);
 						} catch (error) {
 							harperLogger.warn('Error removing audit entry', error);
 						}
@@ -227,12 +228,17 @@ export function openAuditStore(rootStore) {
 							break;
 						}
 					}
-					await committed;
 				} catch (error) {
 					// the timer callback is detached, so anything escaping here lands as an unhandled
 					// rejection instead of a log line — and skips the reschedule below with it
 					harperLogger.warn('Error during audit log cleanup', error);
 				} finally {
+					// resolve() first and unconditionally: updateLastRemoved() below can throw
+					// synchronously if the store transitions to closing/closed mid-pass, and a throw
+					// from the rest of this block must not skip settling `resolution` — that's the
+					// serialization barrier every later pass awaits, and never settling it wedges the
+					// cleanup loop for the life of the store.
+					resolve();
 					if (deleted === 0) {
 						// if we didn't delete anything, we can increase the delay (double until we get to one tenth of
 						// the retention time). Plain arithmetic, not `<<`/`>>`: those coerce to int32, so a
@@ -245,7 +251,6 @@ export function openAuditStore(rootStore) {
 						// and do updates faster
 						if (auditCleanupDelay > 100) auditCleanupDelay = auditCleanupDelay / 2;
 					}
-					resolve();
 					scheduleAuditCleanup();
 				}
 				// we can run this pretty frequently since there is very little overhead to these queries

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -10,6 +10,7 @@ const {
 const { RocksTransactionLogStore } = require('#src/resources/RocksTransactionLogStore');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { setTimeout: delay } = require('node:timers/promises');
+const { waitFor } = require('../waitFor');
 require('#src/server/serverHelpers/serverUtilities');
 describe('Audit log', () => {
 	let AuditedTable;
@@ -52,25 +53,34 @@ describe('Audit log', () => {
 			results.push(entry);
 		}
 		assert.equal(results.length, 4);
-		// Poll for the subscription events instead of a fixed 20ms delay, which is too short
-		// on a loaded CI runner and made this assertion flaky.
-		for (let i = 0; i < 20 && events.length <= 2; i++) {
-			await delay(10);
-		}
-		assert(events.length > 2, 'Should have at least a couple of update events');
+		// Subscription events are delivered off the commit path; nothing orders them against this
+		// assertion, so wait for them rather than sleeping a fixed 20ms and hoping.
+		await waitFor(() => events.length > 2, {
+			timeout: 5000,
+			message: 'Should have at least a couple of update events',
+		});
 		if (AuditedTable.auditStore.reusableIterable) return; // rocksdb doesn't have any audit log cleanup from JS
 		setAuditRetention(0.001, 1);
-		AuditedTable.auditStore.scheduleAuditCleanup(1);
+		// scheduleAuditCleanup() resolves once the pass serving the call has committed its deletions.
+		// This first one races the put below, so it may or may not see record 3's audit entry.
+		const firstPass = AuditedTable.auditStore.scheduleAuditCleanup(1);
 		await AuditedTable.put(3, { name: 'three' });
-		// Poll until cleanup completes (was a fixed 20ms which is too short on a loaded CI runner)
-		for (let i = 0; i < 20; i++) {
-			await new Promise((resolve) => setTimeout(resolve, 10));
-			results = [];
-			for await (let entry of AuditedTable.getHistory()) {
-				results.push(entry);
-			}
-			if (results.length === 0) break;
-		}
+		await firstPass;
+		// Drive passes until the log is drained. Every iteration awaits a whole pass, so it makes real
+		// progress rather than hoping a background timer landed inside a fixed wall-clock budget — which
+		// is what the previous 20 x 10ms poll did. More than one iteration is only needed if the store
+		// holds more than MAX_DELETES_PER_CLEANUP stale entries, since a pass stops at that cap.
+		results = await waitFor(
+			async () => {
+				await AuditedTable.auditStore.scheduleAuditCleanup(1);
+				const remaining = [];
+				for await (let entry of AuditedTable.getHistory()) {
+					remaining.push(entry);
+				}
+				return remaining.length === 0 ? remaining : false;
+			},
+			{ timeout: 10000, interval: 0, message: 'audit log was not pruned' }
+		);
 
 		assert.equal(results.length, 0);
 		assert.equal(AuditedTable.primaryStore.getEntry(1), undefined); // verify that the delete entry was removed


### PR DESCRIPTION
## What

The `Audit log > check log after writes and prune` unit test is the largest single contributor to the `Unit Test` workflow flaking on `main` — 6 of the 18 real failures between 2026-07-21 and 2026-07-27. It fails in two variants, and both are the same shape: the test guesses a wall-clock budget for asynchronous work it has no way to observe.

Fixing the second variant properly meant giving the audit-cleanup loop a completion signal, which in turn surfaced several genuine defects in that loop.

## Root causes

### Variant 1 — `auditLog.test.js:56`, "Should have at least a couple of update events" (4 occurrences, rocksdb `test:unit:resources`)

```js
await delay(20);
assert(events.length > 2, 'Should have at least a couple of update events');
```

Subscription events are delivered off the commit path. Nothing orders them against this assertion, so the 20 ms sleep is a bet. It now waits for the events via the repo's `waitFor` helper — same assertion, no wall-clock bet.

### Variant 2 — `auditLog.test.js:71`, `4 == 0` (2 occurrences, lmdb `test:unit:lmdb`)

The test scheduled an audit prune and then polled for 20 × 10 ms hoping it had landed. The prune runs on a self-rescheduling background timer inside `openAuditStore`'s closure; the test had no way to observe it, so the assertion was betting on a 200 ms budget covering `schedule → timer → one setImmediate yield per deleted entry → async commit`, on a shared audit store that every table in the database writes to.

`scheduleAuditCleanup()` now returns a promise that fulfills when the pass serving the call has finished, and the test awaits that instead of polling.

### Product defects found while making that promise trustworthy

All in `resources/auditStore.ts`, all pre-existing:

1. **The `closed`/`closing` early return wedges the loop permanently.** It returned without resolving `resolution` — *after* `resolution` had been stored in `lastCleanupResolution`. Every later pass awaits that variable, so one transient `closing` observation deadlocks audit cleanup for the life of the store, and the early return does not reschedule either.
2. **Concurrent passes over the same range.** `lastCleanupResolution = resolution` was assigned *after* `await lastCleanupResolution`, so every pass released by the same resolution proceeded together. The slot is now claimed before yielding.
3. **Superseded pending passes strand their callers.** A `scheduleAuditCleanup()` that cancels a not-yet-started pass left that pass's promise unsettled forever. Superseded callers are handed to the replacement.
4. **The backoff collapses to a hot loop.** `auditCleanupDelay << 1` coerces to int32, so a sub-millisecond retention pins the delay at 0 permanently (`0 << 1` is `0`) — and it stays 0 even after retention returns to normal. Measured over one `test:unit:resources` run: **129 sub-millisecond reschedules before, 0 after**. The sibling `>> 1` has the mirror-image bug (a retention over ~24.8 days wraps negative when halved), and `setTimeout` silently falls back to 1 ms past `2^31-1`, which a retention over ~248 days reaches via `retention / 10`. All three now use plain arithmetic with a clamp.
5. **The pass could escape as an unhandled rejection.** A rejected commit or a throw out of the range iteration left the detached timer callback rejecting. It is logged now.

## What this does *not* claim

I could not reproduce variant 2 locally. I tried an event-loop hog (40 ms blocked out of every 45 ms), a 200-entry audit backlog on the shared store, and 25 repetitions per engine — all green on the pre-fix code. So the *mechanism* behind `4 == 0` (which entry survived, and why 200 ms was not enough that day) is not proven at the level variant 1 is. What is certain is that the old assertion had no completion signal to wait on and the new one does; and the four loop defects above are real regardless.

The new form still fails if the prune genuinely does not happen — it times out at 10 s with `audit log was not pruned` instead of asserting at 200 ms — so this does not convert a product failure into a pass.

## Also worth knowing: signature D was already fixed

The dispatch that produced this work also listed an apitests signature (`RESTProperties-test.mjs:243`/`:314`, `cache-test.mjs:111`, 404s on `SimpleCache/3` and `CacheOfHttp/direct-fetch`). All six occurrences are dated 2026-07-21/22 and stop at 6e7630c5a (2026-07-23), which added the missing `await` to the four `Table.clear()` calls in `setupTestApp()`. The 404s and the `JSON.parse(...) === null` are exactly a wiped `FourProp` — a late clear landing on the freshly written seed records. No recurrence in the ~9 green full-matrix runs since. Nothing to do here.

## Test notes

- `unitTests/resources/auditLog.test.js`: 25× rocksdb + 25× lmdb, all green; 10× lmdb under a synthetic event-loop hog, all green.
- Full `test:unit:resources`: 4× rocksdb (1263 passing) and 8× lmdb (1126 passing) green. One lmdb run failed `dropTableGhost.test.js:70` — reproduced 1-in-5 on the **unpatched** baseline too, so it is a separate pre-existing flake, filed as a finding.
- `test:unit:main`: 3801 passing.
- `test:unit:apitests` cannot fully run in this environment (no local `harper install`, so the operations/MQTT listeners do not bind); 155 passing / 10 failing identically with and without this change, i.e. neutral.

## Review

Cross-model reviewed (Gemini via `agy` + Codex, adjudicated inline — the `reviewer`/`codex-reviewer` subagents are not available to dispatched workers). Both outside legs found real issues in the first commit; the second commit is those fixes. No unresolved blockers.

Generated by Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)