### PR TITLE
chore(ci): bump ai-review-prompts to 224c2ad (#80 week-of-07-20 calibration)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,7 +33,7 @@ jobs:
     # Note: the `claude-review` label name is matched there too —
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@82c9484f6f2560be4a37032858311e429bccd56c # main 2026-07-21 (#73 severity-deflation + fail-closed calibration, #74 caller hygiene; on 9cf49d2 = #70 + #71)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@224c2adcfdb408d68c7ca48eb618623c990a96ad # main 2026-07-28 (#80 week-of-07-20 calibration: producing-side guard verification; on 82c9484)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -60,7 +60,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 82c9484f6f2560be4a37032858311e429bccd56c
+      ai-review-prompts-ref: 224c2adcfdb408d68c7ca48eb618623c990a96ad
       # CANARY (2026-07-11): run this repo's Claude reviews on Sonnet 5
       # while the fleet default stays claude-sonnet-4-6. Every ai-review-log
       # entry records `Model:`, so calibration can compare sonnet-5 vs

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -52,7 +52,7 @@ jobs:
     # Note: the `gemini-review` label name is matched there too —
     # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@82c9484f6f2560be4a37032858311e429bccd56c # main 2026-07-21 (#73 severity-deflation + fail-closed calibration, #74 caller hygiene; on 9cf49d2 = #70 + #71)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@224c2adcfdb408d68c7ca48eb618623c990a96ad # main 2026-07-28 (#80 week-of-07-20 calibration: producing-side guard verification; on 82c9484)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -70,7 +70,7 @@ jobs:
       # duplication is unavoidable: reusable workflows can't introspect
       # their own ref (`github.workflow_ref` resolves to the CALLER's
       # ref in workflow_call context), and `uses: …@<ref>` is literal.
-      ai-review-prompts-ref: 82c9484f6f2560be4a37032858311e429bccd56c
+      ai-review-prompts-ref: 224c2adcfdb408d68c7ca48eb618623c990a96ad
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/validate-caller-workflows.yml
+++ b/.github/workflows/validate-caller-workflows.yml
@@ -27,9 +27,9 @@ on:
 
 jobs:
   validate:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@82c9484f6f2560be4a37032858311e429bccd56c # main 2026-07-21 (#74: validator now covers gemini-*.{yml,yaml} callers too)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@224c2adcfdb408d68c7ca48eb618623c990a96ad # main 2026-07-28 (#80 week-of-07-20 calibration: producing-side guard verification; on 82c9484)
     with:
       # Same SHA as the `uses:` ref above — the reusable uses this
       # to check out the validator script at the matching version.
       # Same SHA-twice pattern as the other caller workflows.
-      ai-review-prompts-ref: 82c9484f6f2560be4a37032858311e429bccd56c
+      ai-review-prompts-ref: 224c2adcfdb408d68c7ca48eb618623c990a96ad


### PR DESCRIPTION
Review callers + validate pin 82c9484 → 224c2ad (uses + ai-review-prompts-ref in lockstep, all three caller files).

**What reviews pick up (#80):** the producing-side guard-verification rule — when a PR adds an enforcement check (session binding, config gate, enablement predicate), enumerate every path that *produces* the value it keys on before calling the gate correct. Three author-fixed oauth cases behind it.

With this bump, next Sunday's calibration sweep reads a full week at the previous ref (82c9484) — the first clean single-ref week for the #73 deflation-rule evaluation.

Note: edits the caller workflows → own review checks fail with the expected anti-tamper guard; clears on merge. Companions: oauth + harper-pro (same bump).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)