### PR TITLE
Remove vestigial resourceCache plumbing

### DIFF
--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -660,7 +660,6 @@ export class DatabaseTransaction implements Transaction {
 							// now reset transactions tracking; this transaction be reused and committed again
 							this.retries = 0; // reset per-native-transaction retry counter so a reused DatabaseTransaction's next batch starts fresh
 							this.clearWrites();
-							if (this.#context?.resourceCache) this.#context.resourceCache = null;
 							this.next = null;
 							let txnTime = this.timestamp;
 							this.timestamp = 0; // reset the timestamp as well
@@ -752,7 +751,6 @@ export class DatabaseTransaction implements Transaction {
 						cleanupUnusedBlobs(write.savedBlobs, collectRetainedFileIds(write.store.getEntry(write.key)?.value));
 				}
 				this.clearWrites();
-				if (this.#context?.resourceCache) this.#context.resourceCache = null;
 				const txnResolution: CommitResolution = {
 					txnTime: this.timestamp,
 				};
@@ -787,7 +785,6 @@ export class DatabaseTransaction implements Transaction {
 		}
 		// reset the transaction
 		this.clearWrites();
-		if (this.#context?.resourceCache) this.#context.resourceCache = null;
 	}
 	/**
 	 * Give up on a chain of linked transactions after exhausting conflict retries: poison every link

--- a/resources/ResourceInterface.ts
+++ b/resources/ResourceInterface.ts
@@ -95,7 +95,6 @@ export interface Context {
 	originatingOperation?: OperationFunctionName;
 	previousResidency?: string[];
 	nodeName?: string;
-	resourceCache?: Map<Id, any>;
 	_freezeRecords?: boolean; // until v5, we conditionally freeze records for back-compat
 	timestamp?: number;
 	includeExpensiveRecordCountEstimates?: boolean;
@@ -127,8 +126,6 @@ export interface SourceContext<TRequestContext = Context, Record extends object 
 	noCacheStore?: boolean;
 	/** Reference to the source Resource instance */
 	source?: ResourceInterface<Record>;
-	/** Shared resource cache from parent context for visibility of modifications */
-	resourceCache?: Map<Id, any>;
 	/** Database transaction for the context */
 	transaction?: DatabaseTransaction;
 	/** The time at which the cached entry should expire (ms since epoch) */

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5573,9 +5573,6 @@ export function makeTable(options) {
 			replacingVersion: existingVersion,
 			noCacheStore: false,
 			source: null,
-			// use the same resource cache as a parent context so that if modifications are made to resources,
-			// they are visible in the parent requesting context
-			resourceCache: context?.resourceCache,
 			transaction: undefined,
 			expiresAt: undefined,
 			lastModified: undefined,

--- a/resources/transaction.ts
+++ b/resources/transaction.ts
@@ -42,9 +42,6 @@ export function transaction<T>(
 	if (context.replicatedConfirmation) transaction.replicatedConfirmation = context.replicatedConfirmation;
 	if (context.sourceApply) transaction.sourceApply = true;
 	transaction.setContext(context);
-
-	// create a resource cache so that multiple requests to the same resource return the same resource
-	if (!context.resourceCache) context.resourceCache = new Map();
 	let result;
 	try {
 		result =


### PR DESCRIPTION
Pure deletion (12 lines). The per-transaction resource-instance cache was removed in 2cc16c35a ("No need for resource cache now that we have RocksDB"), but its plumbing stayed behind with no remaining reader: `transaction()` allocated a `new Map()` per transaction, `DatabaseTransaction` nulled it at three commit/abort sites, `Table` passed it into source contexts, and both Context interfaces declared the field.

Grepped harper and harper-pro for readers — none. The only behavioral effect is dropping a dead Map allocation per transaction.

Surfaced while investigating #1968 (the removal commit's RocksDB read-your-writes rationale is the same assumption PR #1970 corrects, which is how this dead code got noticed).

Note: `resourceCache?` was an optional field on the exported Context types; any external TS code *reading* it would now fail to compile. Nothing in-tree or in harper-pro does.

Tested: build clean; crud + caching unit tests pass on both engines. Cross-model review (Codex): no findings.

Generated by Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
