### PR TITLE
Fix syntax error in udsMirror.test.js breaking main CI

### DIFF
--- a/unitTests/server/udsMirror.test.js
+++ b/unitTests/server/udsMirror.test.js
@@ -183,8 +183,8 @@ describe('UDS mirror (writeUdsMetadata, cleanup helpers)', () => {
 		function createSocket() {
 			const socket = new EventEmitter();
 			socket.setTimeout = sinon.stub().callsFake((ms, cb) => {
-				if (cb) socket.on('timeout', cb);
 				if (cb) socket.once('timeout', cb);
+			});
 			socket.destroy = sinon.stub();
 			return socket;
 		}


### PR DESCRIPTION
**Main is currently broken** — `64a0e01ba` ("Apply suggestion from @Devin-Holland", direct to main) replaced the closing `});` of the `callsFake` callback in `udsMirror.test.js` instead of the `socket.on` line the suggestion targeted, leaving the function unclosed. Format Check, runLinter, and all three unit-test jobs fail on main and on every PR's merge ref.

One-line repair: applies the suggestion as intended (`once` instead of `on`) and restores the closing brace. `node --check` clean, prettier 3.9 clean, all 35 udsMirror tests pass locally against a fresh build.

Opened ready (not draft) given main is red for everyone.

Generated by Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
