### PR TITLE
test(database): promote 3 QA destructive-operation integrity anchors

### DIFF
--- a/integrationTests/database/blob-delete-reclaim-audit-expiry.test.ts
+++ b/integrationTests/database/blob-delete-reclaim-audit-expiry.test.ts
@@ -1,0 +1,280 @@
+/**
+ * QA-802 — Blob GC vs audit-log expiry (harper#708, "Blob GC: files not deleted on
+ * audit-log expiry when using RocksDB audit store").
+ *
+ * #708's claim: `scheduleAuditCleanup()` (resources/auditStore.ts) branches on the audit
+ * store type; for RocksDB it calls `rootStore.purgeLogs()` and returns WITHOUT ever calling
+ * `removeAuditEntry()` — the function that invokes the blob-file delete callbacks — so blob
+ * files supposedly accumulate forever once a blob-bearing record is deleted.
+ *
+ * SOURCE READ at SHA d112560b6 says the picture is more nuanced:
+ *  - RecordEncoder.ts recordUpdater() (used by BOTH SQL and REST/JS deletes, since Table.ts's
+ *    `_writeDelete` funnels through it) calls `deleteBlobsInObject(existingEntry.value, ...)`
+ *    SYNCHRONOUSLY on any delete whose prior entry carried HAS_BLOBS — independent of audit
+ *    engine and independent of auditRetention. This landed 2026-07-14 (commit 6e8d3647a,
+ *    fixing #641, an unrelated update-path data-loss bug) — AFTER #708 was filed
+ *    (2026-05-21) but it isn't excluded for type==='delete', so it may have incidentally
+ *    fixed #708's headline scenario too.
+ *  - Table.ts's OWN periodic `scheduleCleanup()` (armed here via `scanInterval` without
+ *    `expiration`, so live records never auto-evict) always treats RocksDB deleted-tombstone
+ *    removal as active (`removeDeletedRecords = !audit || isRocksDB`, Table.ts:5824) —
+ *    independent of the auditStore.ts RocksDB branch under test. That scan's `removeEntry()`
+ *    call operates on a null-value tombstone though, so it can't be the blob-deletion path
+ *    (blob deletion needs the entry's prior VALUE, already gone by tombstone time).
+ *  - QA-047 (audit-retention.test.ts) already established that RocksDB's `purgeLogs` purges
+ *    whole LOG FILES, not per-entry, and won't touch a still-active (not-yet-rolled) file
+ *    within a short test window — a confound distinct from the delete-callback question.
+ *
+ * This experiment tests empirically, on disk, rather than trusting either the issue's
+ * static-analysis premise or the RecordEncoder.ts read above:
+ *   Arm A: delete a live blob-bearing record via SQL DELETE (the issue's exact repro),
+ *          trajectory-sample the on-disk blob dir through the deletionDelay, the
+ *          auditRetention window, and a hard restart.
+ *   Arm B: audit-only expiry with the record still LIVE (repeated overwrite so old audit
+ *          PUT entries age out) — the current blob must never be touched; PUT-type audit
+ *          entries never invoke the delete-callback (auditStore.ts removeAuditEntry only
+ *          special-cases type==='delete'), so this is the negative control.
+ * ENGINE SCOPE — read before trusting this as an A/B. In CI this file pins the DEFAULT
+ * engine only (RocksDB); the engine is selected process-wide by HARPER_STORAGE_ENGINE, so a
+ * single test file cannot run both. The LMDB leg was run manually during QA and also showed
+ * zero net leak, which is what refutes harper#708's "RocksDB-specific" framing — but that
+ * result is QA evidence, not something this file asserts. To re-run the LMDB leg, set
+ * HARPER_STORAGE_ENGINE=lmdb (see Reproduction below).
+ *
+ * Layout probed directly on disk: {dataRootDir}/blobs/{db}/{p}/{p}/{fileId} (db="data",
+ * the default database for a table with no explicit `database:` in its @table directive).
+ *
+ * Reproduction:
+ *   cd <harper checkout>
+ *   npm run test:integration -- "integrationTests/database/blob-delete-reclaim-audit-expiry.test.ts"
+ *   HARPER_STORAGE_ENGINE=lmdb npm run test:integration -- "integrationTests/database/blob-delete-reclaim-audit-expiry.test.ts"
+ * Harper SHA at promotion: 80ef45996 (main)
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { resolve, join } from 'node:path';
+import { readdir, stat } from 'node:fs/promises';
+import { setTimeout as sleep } from 'node:timers/promises';
+import request from 'supertest';
+import {
+	setupHarperWithFixture,
+	startHarper,
+	killHarper,
+	teardownHarper,
+	type ContextWithHarper,
+} from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
+import { createApiClient } from '../apiTests/utils/client.mjs';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'blob-delete-reclaim-audit-expiry');
+const ENGINE = process.env.HARPER_STORAGE_ENGINE === 'lmdb' ? 'lmdb' : 'rocksdb';
+const skipSuite = process.platform === 'win32';
+
+const BLOB_SIZE = 256 * 1024; // file-backed (well above the inline threshold), small for a fast N-rep loop
+const AUDIT_RETENTION_SECONDS = 3; // short so the automatic cleanup loop / purgeLogs window fits a test
+const N = 20; // reps for the delete arm — quantifies leak rate per N deletes
+
+const HARPER_CONFIG = {
+	logging: { auditLog: true, auditRetention: AUDIT_RETENTION_SECONDS },
+};
+const HARPER_ENV = ENGINE === 'lmdb' ? { HARPER_STORAGE_ENGINE: 'lmdb' } : {};
+
+/** Recursively count files + sum bytes under a blob storage tree. Disk truth, not API truth. */
+async function diskUsage(dir: string): Promise<{ files: number; bytes: number }> {
+	let files = 0;
+	let bytes = 0;
+	async function walk(d: string) {
+		let entries;
+		try {
+			entries = await readdir(d, { withFileTypes: true });
+		} catch {
+			return; // dir not created yet
+		}
+		for (const e of entries) {
+			const p = join(d, e.name);
+			if (e.isDirectory()) await walk(p);
+			else {
+				try {
+					bytes += (await stat(p)).size;
+					files++;
+				} catch {
+					/* raced with unlink */
+				}
+			}
+		}
+	}
+	await walk(dir);
+	return { files, bytes };
+}
+
+const fmtKB = (b: number) => (b / 1024).toFixed(0) + 'KB';
+
+suite(`QA-802 blob GC vs audit-log expiry (harper#708) [${ENGINE}]`, { skip: skipSuite }, (ctx: ContextWithHarper) => {
+	let client: ReturnType<typeof createApiClient>;
+	let httpURL: string;
+	const findings: string[] = [];
+
+	const blobRoot = () => join(ctx.harper.dataRootDir, 'blobs', 'data');
+
+	async function waitReady() {
+		const deadline = Date.now() + 30_000;
+		while (Date.now() < deadline) {
+			try {
+				const probe = await client.reqRest('/Doc/').timeout(3_000);
+				if (probe.status !== 404) return;
+			} catch {
+				/* not ready */
+			}
+			await sleep(250);
+		}
+	}
+
+	before(async () => {
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: HARPER_CONFIG, env: HARPER_ENV });
+		client = createApiClient(ctx.harper);
+		httpURL = ctx.harper.httpURL;
+		await waitReady();
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+		// eslint-disable-next-line no-console
+		console.log(`\n[QA-802 ${ENGINE}] FINDINGS`);
+		for (const f of findings) console.log('  ' + f);
+	});
+
+	function op(body: Record<string, unknown>) {
+		return request(httpURL).post('/DocOps/').set(client.headers).send(body);
+	}
+	function sql(sqlStr: string) {
+		return client.req().send({ operation: 'sql', sql: sqlStr });
+	}
+
+	// ── Arm A: record deletion via SQL — trajectory through deletionDelay, audit expiry, restart ──
+	test(
+		`Arm A [${ENGINE}]: SQL-deleted blob-bearing records — disk trajectory to restart`,
+		{ timeout: 120_000 },
+		async () => {
+			const keys = Array.from({ length: N }, (_, i) => `del-${i}`);
+			const base = await diskUsage(blobRoot());
+
+			for (const key of keys) {
+				const r = await op({ action: 'store', key, size: BLOB_SIZE, seed: key }).expect(200);
+				ok(r.body.ok, `store ${key} failed: ${JSON.stringify(r.body)}`);
+			}
+			const afterStore = await diskUsage(blobRoot());
+			strictEqual(
+				afterStore.files - base.files,
+				N,
+				`expected ${N} new blob files after store, got delta ${afterStore.files - base.files}`
+			);
+
+			// Delete via SQL — the exact reproduction path #708 describes.
+			for (const key of keys) {
+				const r = await sql(`DELETE FROM data.Doc WHERE key = '${key}'`);
+				strictEqual(r.status, 200, `SQL DELETE ${key} failed: ${r.text}`);
+			}
+
+			// Trajectory: sample disk usage across the deletionDelay (500ms) and the auditRetention
+			// window (+ scanInterval cycles) so we can tell "never", "immediate", and "delayed until
+			// audit expiry" apart, rather than guessing from a single end-state snapshot.
+			const traj: Array<{ t: number; files: number; bytes: number }> = [];
+			const start = Date.now();
+			const sampleUntilMs = (AUDIT_RETENTION_SECONDS + 1) * 1000 + 15_000; // retention + scan-cycle margin
+			while (Date.now() - start < sampleUntilMs) {
+				await sleep(2_000);
+				const u = await diskUsage(blobRoot());
+				traj.push({ t: Date.now() - start, ...u });
+			}
+			// Hard restart against the SAME data dir — does a restart reconcile anything the
+			// live-process path did not?
+			const dataRootDir = ctx.harper.dataRootDir;
+			const hostname = ctx.harper.hostname;
+			await killHarper(ctx as any, { graceMs: 200 });
+			ctx.harper = { dataRootDir, hostname } as any;
+			await startHarper(ctx as any, { config: HARPER_CONFIG, env: HARPER_ENV });
+			client = createApiClient(ctx.harper);
+			httpURL = ctx.harper.httpURL;
+			await waitReady();
+			const afterRestart = await diskUsage(blobRoot());
+
+			// Explicit documented workaround: cleanup_orphan_blobs.
+			const cleanup = await client.req().send({ operation: 'cleanup_orphan_blobs', database: 'data' });
+			await sleep(5_000);
+			const afterCleanupOp = await diskUsage(blobRoot());
+
+			const trajStr = traj.map((s) => `+${(s.t / 1000).toFixed(0)}s=${s.files}f/${fmtKB(s.bytes)}`).join(', ');
+			findings.push(
+				`Arm A [${ENGINE}] N=${N}x${fmtKB(BLOB_SIZE)} SQL-deleted: base=${base.files}f, afterStore=${afterStore.files}f, ` +
+					`trajectory: ${trajStr}, afterRestart=${afterRestart.files}f/${fmtKB(afterRestart.bytes)}, ` +
+					`cleanup_orphan_blobs(${JSON.stringify(cleanup.body)})->afterCleanupOp=${afterCleanupOp.files}f/${fmtKB(afterCleanupOp.bytes)}`
+			);
+
+			const netLeakedFiles = afterCleanupOp.files - base.files;
+			const netLeakedBytes = afterCleanupOp.bytes - base.bytes;
+			findings.push(
+				`Arm A [${ENGINE}] VERDICT: net leaked after delete+audit-expiry+restart+cleanup_orphan_blobs = ` +
+					`${netLeakedFiles} files / ${fmtKB(netLeakedBytes)} (${N} deletes => ${((netLeakedFiles / N) * 100).toFixed(0)}% retained) ` +
+					(netLeakedFiles <= 0 ? '— RECLAIMED (no leak observed)' : '— LEAK CONFIRMED on disk')
+			);
+			// Exploratory: record the numbers as findings above; do not hard-fail the suite on a
+			// leak (that IS the phenomenon under study), but do assert the harness measured
+			// something sane (store actually created files) so a broken probe doesn't silently
+			// report a false negative.
+			ok(afterStore.files > base.files, 'sanity: store should have created on-disk blob files');
+		}
+	);
+
+	// ── Arm B: audit-only expiry, record still LIVE — must never lose/corrupt the current blob ──
+	test(
+		`Arm B [${ENGINE}]: overwrite churn ages out PUT audit entries — live blob must survive`,
+		{ timeout: 60_000 },
+		async () => {
+			const key = 'live-1';
+			let expectedSha = '';
+			for (let i = 0; i < 6; i++) {
+				const r = await op({ action: 'store', key, size: BLOB_SIZE, seed: `${key}-${i}` }).expect(200);
+				expectedSha = r.body.expectedSha;
+				await sleep(600); // let each overwrite's prior-blob unlink (deletionDelay ~500ms) settle
+			}
+			const afterChurn = await diskUsage(blobRoot());
+
+			// Wait past auditRetention (+ scan cycles) so the now-aged PUT audit entries from the
+			// earlier overwrites are eligible for cleanup. removeAuditEntry() only special-cases
+			// type==='delete' (auditStore.ts), so a PUT-type entry's expiry should never invoke a
+			// blob delete-callback — this is the negative control for the "audit reference outliving
+			// reclamation" framing in #708.
+			await sleep((AUDIT_RETENTION_SECONDS + 1) * 1000 + 15_000);
+			const afterExpiry = await diskUsage(blobRoot());
+
+			const v = await op({ action: 'verify', key }).expect(200);
+			strictEqual(
+				v.body.present,
+				true,
+				'DEFECT: live record vanished after audit-only expiry (record was never deleted)'
+			);
+			strictEqual(v.body.match, true, `DEFECT: live blob corrupted after audit-only expiry: ${JSON.stringify(v.body)}`);
+			strictEqual(v.body.storedSha, expectedSha, 'DEFECT: live blob sha mismatch after audit-only expiry');
+
+			findings.push(
+				`Arm B [${ENGINE}] live record churned 6x then aged past audit retention: afterChurn=${afterChurn.files}f/${fmtKB(afterChurn.bytes)}, ` +
+					`afterExpiry=${afterExpiry.files}f/${fmtKB(afterExpiry.bytes)}, live blob intact=${v.body.match} (EXPECTED: survives, ~1 file)`
+			);
+			// A single live key should settle to ~1 file (the current blob); prior overwrite
+			// generations are reclaimed by the update-path retainedFileIds guard, not by audit expiry.
+			findings.push(
+				afterExpiry.files <= 2
+					? `Arm B [${ENGINE}] VERDICT: settled to ${afterExpiry.files} file(s) — no orphan growth from audit-only expiry (EXPECTED)`
+					: `Arm B [${ENGINE}] VERDICT: ${afterExpiry.files} files remain — unexpected growth, investigate`
+			);
+		}
+	);
+
+	test('instance stayed alive throughout', async () => {
+		const r = await client
+			.req()
+			.send({ operation: 'system_information', attributes: ['threads'] })
+			.expect(200);
+		ok(Array.isArray(r.body.threads), 'system_information should report threads (instance alive)');
+	});
+});

--- a/integrationTests/database/blob-delete-reclaim-audit-expiry.test.ts
+++ b/integrationTests/database/blob-delete-reclaim-audit-expiry.test.ts
@@ -217,11 +217,18 @@ suite(`QA-802 blob GC vs audit-log expiry (harper#708) [${ENGINE}]`, { skip: ski
 					`${netLeakedFiles} files / ${fmtKB(netLeakedBytes)} (${N} deletes => ${((netLeakedFiles / N) * 100).toFixed(0)}% retained) ` +
 					(netLeakedFiles <= 0 ? '— RECLAIMED (no leak observed)' : '— LEAK CONFIRMED on disk')
 			);
-			// Exploratory: record the numbers as findings above; do not hard-fail the suite on a
-			// leak (that IS the phenomenon under study), but do assert the harness measured
-			// something sane (store actually created files) so a broken probe doesn't silently
-			// report a false negative.
+			// Sanity: the harness must have measured something real (store actually created
+			// files) before the leak check below can mean anything.
 			ok(afterStore.files > base.files, 'sanity: store should have created on-disk blob files');
+			// Headline invariant this arm exists to pin: SQL-delete blob reclaim must be
+			// complete by the time deletionDelay + audit expiry + restart + the documented
+			// cleanup_orphan_blobs workaround have all had a chance to run. Logging the numbers
+			// without asserting them would let a total leak (100% retained) pass silently.
+			ok(
+				netLeakedFiles <= 0,
+				`LEAK: SQL-delete blob reclaim incomplete — ${netLeakedFiles} file(s) / ${fmtKB(netLeakedBytes)} still on disk ` +
+					`after delete+audit-expiry+restart+cleanup_orphan_blobs (harper#708)`
+			);
 		}
 	);
 

--- a/integrationTests/database/blob-delete-reclaim-audit-expiry.test.ts
+++ b/integrationTests/database/blob-delete-reclaim-audit-expiry.test.ts
@@ -127,6 +127,7 @@ suite(`QA-802 blob GC vs audit-log expiry (harper#708) [${ENGINE}]`, { skip: ski
 			}
 			await sleep(250);
 		}
+		throw new Error('QA-802: timed out waiting for /Doc/ to become ready');
 	}
 
 	before(async () => {
@@ -200,6 +201,7 @@ suite(`QA-802 blob GC vs audit-log expiry (harper#708) [${ENGINE}]`, { skip: ski
 
 			// Explicit documented workaround: cleanup_orphan_blobs.
 			const cleanup = await client.req().send({ operation: 'cleanup_orphan_blobs', database: 'data' });
+			strictEqual(cleanup.status, 200, `cleanup_orphan_blobs failed: ${JSON.stringify(cleanup.body)}`);
 			await sleep(5_000);
 			const afterCleanupOp = await diskUsage(blobRoot());
 
@@ -273,6 +275,10 @@ suite(`QA-802 blob GC vs audit-log expiry (harper#708) [${ENGINE}]`, { skip: ski
 				afterExpiry.files <= 2
 					? `Arm B [${ENGINE}] VERDICT: settled to ${afterExpiry.files} file(s) — no orphan growth from audit-only expiry (EXPECTED)`
 					: `Arm B [${ENGINE}] VERDICT: ${afterExpiry.files} files remain — unexpected growth, investigate`
+			);
+			ok(
+				afterExpiry.files <= 2,
+				`Arm B [${ENGINE}]: audit-only expiry should leave <=2 blob files, got ${afterExpiry.files}`
 			);
 		}
 	);

--- a/integrationTests/database/blob-delete-reclaim-audit-expiry/config.yaml
+++ b/integrationTests/database/blob-delete-reclaim-audit-expiry/config.yaml
@@ -1,0 +1,5 @@
+graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/database/blob-delete-reclaim-audit-expiry/resources.js
+++ b/integrationTests/database/blob-delete-reclaim-audit-expiry/resources.js
@@ -1,0 +1,83 @@
+// QA-802 — Blob GC vs audit-log expiry (harper#708) probe resource.
+//
+// Stores deterministic, non-compressible blobs (so files are real file-backed blobs, not
+// inlined) in Doc.payload and exposes store/verify. Record deletion is driven from the test
+// via the operations API's `sql` op (matching the issue's exact repro: "deleted via SQL"),
+// not through this resource, so the on-the-wire path is identical to #708's report.
+
+import { createHash, createHmac } from 'node:crypto';
+
+const { Doc } = tables;
+
+// Deterministic ~`size`-byte buffer derived from `seed` (HMAC-SHA256 keystream) — unique,
+// non-compressible bytes per seed so every store/overwrite writes genuinely fresh content.
+function patternBuffer(seed, size) {
+	const out = Buffer.allocUnsafe(size);
+	let off = 0;
+	let counter = 0;
+	while (off < size) {
+		const block = createHmac('sha256', String(seed)).update(String(counter++)).digest();
+		const n = Math.min(block.length, size - off);
+		block.copy(out, off, 0, n);
+		off += n;
+	}
+	return out;
+}
+
+function sha256(buf) {
+	return createHash('sha256').update(buf).digest('hex');
+}
+
+// POST /DocOps/  { action, ... }
+export class DocOps extends Resource {
+	static loadAsInstance = false;
+
+	async post(query, body) {
+		const action = body && body.action;
+		switch (action) {
+			case 'store':
+				return this.store(body);
+			case 'verify':
+				return this.verify(body);
+			default: {
+				const ctx = this.getContext();
+				if (ctx && ctx.response) ctx.response.status = 400;
+				return { ok: false, reason: 'unknown-action', action };
+			}
+		}
+	}
+
+	// Store (or overwrite) a deterministic blob-bearing record.
+	async store(body) {
+		const key = String(body.key);
+		const size = Number(body.size) || 512 * 1024;
+		const seed = body.seed == null ? `${key}:${process.hrtime.bigint()}` : String(body.seed);
+		const expected = patternBuffer(seed, size);
+		const expectedSha = sha256(expected);
+
+		await Doc.put({
+			key,
+			payload: createBlob(expected, { type: 'application/octet-stream' }),
+			sha256: expectedSha,
+			note: body.note == null ? null : String(body.note),
+		});
+
+		return { ok: true, key, seed, expectedSha };
+	}
+
+	async verify(body) {
+		const key = String(body.key);
+		const rec = await Doc.get(key);
+		if (!rec) return { ok: true, present: false, key };
+		const bytes = Buffer.from(await rec.payload.bytes());
+		return {
+			ok: true,
+			present: true,
+			key,
+			storedSha: rec.sha256,
+			readSha: sha256(bytes),
+			size: bytes.length,
+			match: sha256(bytes) === rec.sha256,
+		};
+	}
+}

--- a/integrationTests/database/blob-delete-reclaim-audit-expiry/schema.graphql
+++ b/integrationTests/database/blob-delete-reclaim-audit-expiry/schema.graphql
@@ -1,0 +1,13 @@
+# QA-802 — Blob GC vs audit-log expiry (harper#708).
+#
+# `scanInterval: 2` arms Table.ts's periodic cleanup scan (Table.ts scheduleCleanup(),
+# via setTTLExpiration) WITHOUT setting `expiration`, so live records never auto-evict —
+# only the periodic tombstone-removal / deleted-record sweep runs on a fast 2s cadence.
+# This is the scan that (per Table.ts:5824) always runs for RocksDB (`removeDeletedRecords
+# = !audit || isRocksDB`) independent of the auditStore.ts RocksDB bug under test.
+type Doc @table(audit: true, scanInterval: 2) @sealed @export {
+	key: ID! @primaryKey
+	payload: Blob
+	sha256: String
+	note: String
+}

--- a/integrationTests/database/blob-drop-crash-orphan-window.test.ts
+++ b/integrationTests/database/blob-drop-crash-orphan-window.test.ts
@@ -1,0 +1,494 @@
+/**
+ * QA-809 — the blob drop-path kill window: are blob files orphaned FOREVER if the process
+ * dies inside it?
+ *
+ * Background (prior QA wave, this same checkout): `drop_table` returns to the client BEFORE
+ * its blob files are unlinked. `Table.ts` dropTable() walks its own primaryStore and calls
+ * `deleteBlobsInObject()` for every HAS_BLOBS entry -- deleteBlob() (blob.ts) schedules the
+ * actual unlink via `setTimeout(deletionDelay=500ms)` -- BEFORE dropping the column family /
+ * removing the catalog rows, and only after all of that does the op return. So there is a
+ * roughly 0.5-3s window, starting the instant the op returns, in which the table's metadata is
+ * already gone (column family dropped, catalog rows removed, no "interrupted drop" tombstone
+ * left to resume) but its blob files are still on disk waiting on pending unlink timers.
+ *
+ * Static read at SHA d112560b6 relevant to what happens if the process dies IN that window:
+ *  - `completeInterruptedDrop()` (resources/databases.ts:1833), the only drop-recovery path run
+ *    at boot, drops any surviving column families and removes catalog rows for a table whose
+ *    "dropping" tombstone is still set. It does NOT touch the blob directory or re-walk for
+ *    blob references -- and by the time drop_table has already returned 200, the tombstone is
+ *    long cleared and the column family long dropped, so this path is not even reachable for
+ *    our kill window; there is no drop-recovery machinery of any kind for post-return blobs.
+ *  - `cleanupOrphans()` (resources/blob.ts:1871, op name `cleanup_orphan_blobs`) is a genuine
+ *    orphan sweep: it walks {dataRootDir}/blobs/{db}/... directly on disk (NOT scoped by
+ *    table), then cross-references every SURVIVING table's live entries + audit log in that
+ *    database, and unlinks whatever is unreferenced. So a dropped table's blob files ARE
+ *    findable by this sweep as long as the *database* still has >=1 surviving table -- the
+ *    top-of-function `for (const tableName in database) { ...; if (auditStore) break; }` loop
+ *    just needs one table to resolve a store/auditStore pair to find the DB's root blob paths;
+ *    an all-tables-dropped (empty) database never enters that loop (QA-697's prior finding).
+ *    This fixture keeps a sibling `Keepalive` table alive in db "qa809t" for exactly that
+ *    reason, matching qa805's fixture design.
+ *  - `drop_database` (resources/databases.ts ~893) is reported to synchronously await a
+ *    whole-directory rimraf (`deleteRootBlobPathsForDB`) before the op returns -- verified
+ *    empirically below (checkpoint 2 immediately after return), not assumed.
+ *
+ * Design: sweep the kill delay AFTER drop_table returns -- 0ms, 100ms, 400ms, 600ms, and a
+ * control that lets the unlink complete normally (no kill) -- with a four-checkpoint disk
+ * ledger (files + bytes) at: before the drop / immediately after the drop returns / after a
+ * full process restart / after an explicit cleanup_orphan_blobs op. Same four checkpoints for
+ * drop_database, with a kill-at-0ms arm and a no-kill control.
+ *
+ * Oracle discipline: every arm asserts a floor before it means anything --
+ *  (a) blob files actually existed before the drop (checkpoint 1 delta >= N),
+ *  (b) for the kill@0ms drop_table arm specifically, files must still be present immediately
+ *      after the drop returns (survived > 0) -- if this doesn't reproduce, the premise of the
+ *      whole sweep (a real post-return window exists) is false and that arm hard-fails instead
+ *      of silently reporting "no leak",
+ *  (c) the kill is confirmed to land on a still-live process at (or after) the intended delay,
+ *      not on one that already exited on its own.
+ * No arm passes vacuously: 0-file arms fail loudly rather than being counted as clean.
+ *
+ * Reproduction:
+ *   cd <harper checkout> && timeout 1200 npm run test:integration -- \
+ *     "integrationTests/database/blob-drop-crash-orphan-window.test.ts"
+ * Harper SHA at promotion: 80ef45996 (main)
+ * Engine: default (RocksDB) only, per task scope.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { resolve, join } from 'node:path';
+import { readdir, stat } from 'node:fs/promises';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+	setupHarperWithFixture,
+	teardownHarper,
+	killHarper,
+	startHarper,
+	type ContextWithHarper,
+} from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
+import { createApiClient } from './../apiTests/utils/client.mjs';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'blob-drop-crash-orphan-window');
+const BLOB_SIZE = 256 * 1024; // 256KB — well above the 8KB FILE_STORAGE_THRESHOLD, always file-backed
+const N = 100; // per-arm blob count; 100 x 256KB = ~25MB, leaked bytes are unmistakable
+const WRITE_CONCURRENCY = 16;
+const HARPER_CONFIG = { logging: { console: true, level: 'error' } };
+const skipSuite = process.platform === 'win32';
+
+interface KillArm {
+	name: string;
+	table: string;
+	delayMs: number; // ms after drop_table returns before SIGKILL
+}
+
+const KILL_ARMS: KillArm[] = [
+	{ name: 'k0', table: 'BlobTableK0', delayMs: 0 },
+	{ name: 'k100', table: 'BlobTableK100', delayMs: 100 },
+	{ name: 'k400', table: 'BlobTableK400', delayMs: 400 },
+	{ name: 'k600', table: 'BlobTableK600', delayMs: 600 },
+];
+
+/** Recursively count files + bytes under a blob storage tree ({dataRootDir}/blobs/{db}/{p}/{p}/{fileId}). */
+async function diskUsage(dir: string): Promise<{ files: number; bytes: number }> {
+	let files = 0;
+	let bytes = 0;
+	async function walk(d: string) {
+		let entries;
+		try {
+			entries = await readdir(d, { withFileTypes: true });
+		} catch {
+			return; // dir not created yet, or already removed
+		}
+		for (const e of entries) {
+			const p = join(d, e.name);
+			if (e.isDirectory()) await walk(p);
+			else {
+				try {
+					bytes += (await stat(p)).size;
+					files++;
+				} catch {
+					/* raced with unlink */
+				}
+			}
+		}
+	}
+	await walk(dir);
+	return { files, bytes };
+}
+
+function fmt(u: { files: number; bytes: number }) {
+	return `${u.files}f/${u.bytes}B`;
+}
+
+function delta(a: { files: number; bytes: number }, b: { files: number; bytes: number }) {
+	return { files: a.files - b.files, bytes: a.bytes - b.bytes };
+}
+
+suite(`QA-809 drop-path kill-window sweep [rocksdb]`, { skip: skipSuite }, (ctx: ContextWithHarper) => {
+	let client: ReturnType<typeof createApiClient>;
+	let httpURL: string;
+	const findings: string[] = [];
+	const ledger: Record<string, { files: number; bytes: number }> = {};
+
+	function blobDir(db: string) {
+		return join(ctx.harper.dataRootDir, 'blobs', db);
+	}
+
+	async function waitReady(probePath: string, timeoutMs = 120_000) {
+		const deadline = Date.now() + timeoutMs;
+		while (Date.now() < deadline) {
+			try {
+				const probe = await client.reqRest(probePath).timeout(2000);
+				if (probe.status !== 404) return;
+			} catch {
+				/* not ready yet */
+			}
+			await sleep(250);
+		}
+		throw new Error(`timed out waiting for route ${probePath} to become ready`);
+	}
+
+	async function refreshClientAfterRestart() {
+		client = createApiClient(ctx.harper);
+		httpURL = ctx.harper.httpURL;
+		await waitReady('/Keepalive/');
+	}
+
+	/** Hard restart: SIGKILL (no grace period) then start fresh on the same dataRootDir. */
+	async function killAndRestart() {
+		ok(
+			ctx.harper.process && ctx.harper.process.exitCode == null && !ctx.harper.process.killed,
+			'process must still be alive at the intended kill instant — otherwise this arm did not test what it claims'
+		);
+		const dataRootDir = ctx.harper.dataRootDir;
+		const hostname = ctx.harper.hostname;
+		await killHarper(ctx as any, { graceMs: 0 }); // no grace period: SIGTERM then immediate SIGKILL
+		(ctx as any).harper = { dataRootDir, hostname };
+		await startHarper(ctx as any, { config: HARPER_CONFIG });
+		await refreshClientAfterRestart();
+	}
+
+	/** Graceful restart (no kill): control arms still get a checkpoint-3 data point. */
+	async function gracefulRestart() {
+		const dataRootDir = ctx.harper.dataRootDir;
+		const hostname = ctx.harper.hostname;
+		await killHarper(ctx as any, { graceMs: 5000 });
+		(ctx as any).harper = { dataRootDir, hostname };
+		await startHarper(ctx as any, { config: HARPER_CONFIG });
+		await refreshClientAfterRestart();
+	}
+
+	async function postBlob809(body: Record<string, unknown>) {
+		const res = await fetch(`${httpURL}/Blob809/`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', 'Authorization': client.headers.Authorization },
+			body: JSON.stringify(body),
+		});
+		const json = await res.json().catch(() => ({}));
+		return { status: res.status, body: json };
+	}
+
+	async function storeN(db: string, table: string, prefix: string, n: number) {
+		for (let i = 0; i < n; i += WRITE_CONCURRENCY) {
+			const batch = [];
+			for (let j = i; j < Math.min(i + WRITE_CONCURRENCY, n); j++) {
+				const id = `${prefix}-${j}`;
+				batch.push(
+					postBlob809({ action: 'store', db, table, id, size: BLOB_SIZE, seed: id }).then((r) =>
+						strictEqual(r.status, 200, `store ${db}.${table}/${id} failed: ${JSON.stringify(r.body)}`)
+					)
+				);
+			}
+			await Promise.all(batch);
+		}
+	}
+
+	function opReq(body: Record<string, unknown>) {
+		return client.req().timeout(120_000).send(body);
+	}
+
+	/** Poll cleanup_orphan_blobs settle for up to ~10s, returning the final reading + trajectory. */
+	async function settleAfterCleanup(dir: string) {
+		let final = await diskUsage(dir);
+		const traj: string[] = [`+0s=${fmt(final)}`];
+		for (let t = 0; t < 5; t++) {
+			await sleep(2_000);
+			final = await diskUsage(dir);
+			traj.push(`+${(t + 1) * 2}s=${fmt(final)}`);
+		}
+		return { final, traj };
+	}
+
+	before(async () => {
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: HARPER_CONFIG });
+		client = createApiClient(ctx.harper);
+		httpURL = ctx.harper.httpURL;
+		await waitReady('/Keepalive/');
+	});
+
+	after(async () => {
+		try {
+			await teardownHarper(ctx);
+		} catch {
+			/* best-effort */
+		}
+		console.log(`\n[QA-809] LEDGER (checkpoint: files/bytes)`);
+		for (const [k, v] of Object.entries(ledger)) console.log(`  ${k}: ${fmt(v)}`);
+		console.log(`\n[QA-809] FINDINGS`);
+		for (const f of findings) console.log('  ' + f);
+	});
+
+	// ── Baseline: keep a sibling table alive in "qa809t" so cleanup_orphan_blobs stays usable
+	// across every drop_table arm (an empty database never resolves a store/auditStore pair). ──
+	test('setup: seed Keepalive baseline in db "qa809t"', async () => {
+		await storeN('qa809t', 'Keepalive', 'keep', 5);
+		const usage = await diskUsage(blobDir('qa809t'));
+		ledger['qa809t: 0. Keepalive baseline'] = usage;
+		ok(usage.files >= 5, `expected >=5 baseline blob files, got ${usage.files}`);
+	});
+
+	async function verifyKeepaliveIntact(label: string) {
+		for (let i = 0; i < 5; i++) {
+			const v = await postBlob809({ action: 'verify', db: 'qa809t', table: 'Keepalive', id: `keep-${i}` });
+			ok(
+				(v.body as any).present && (v.body as any).size === BLOB_SIZE,
+				`Keepalive/keep-${i} damaged (${label}): ${JSON.stringify(v.body)}`
+			);
+		}
+	}
+
+	// ── Kill-delay sweep for drop_table. ───────────────────────────────────────────────────────
+	for (const arm of KILL_ARMS) {
+		test(`drop_table kill@${arm.delayMs}ms: four-checkpoint ledger`, async (t) => {
+			if (ctx.harper.process?.exitCode != null || ctx.harper.process?.killed) {
+				t.skip('instance already down from a prior arm');
+				return;
+			}
+			const dbBefore = await diskUsage(blobDir('qa809t'));
+			await storeN('qa809t', arm.table, arm.name, N);
+			const cp1 = await diskUsage(blobDir('qa809t'));
+			ledger[`${arm.name}: 1. before drop_table (after write)`] = cp1;
+			const wrote = delta(cp1, dbBefore);
+			ok(wrote.files >= N, `floor: expected +${N} files from ${arm.table} writes before the drop, got +${wrote.files}`);
+
+			const dropRes = await opReq({ operation: 'drop_table', schema: 'qa809t', table: arm.table });
+			strictEqual(dropRes.status, 200, `drop_table ${arm.table} failed: ${JSON.stringify(dropRes.body)}`);
+			const returnInstant = Date.now();
+
+			const cp2 = await diskUsage(blobDir('qa809t'));
+			ledger[`${arm.name}: 2. immediately after drop_table returns`] = cp2;
+			const survivedAtReturn = delta(cp2, dbBefore).files;
+			findings.push(
+				`[k${arm.delayMs}] immediately after drop_table returns: ${survivedAtReturn}/${N} ${arm.table} blob files still on disk`
+			);
+			if (arm.delayMs === 0) {
+				// Observation, not an assertion. A fix that unlinks synchronously before drop_table
+				// returns closes this window entirely — an improvement, which must not turn this
+				// anchor red. The invariant asserted after cleanup below holds either way; recording
+				// the window state keeps a closed window visible rather than silently vacuous.
+				findings.push(
+					survivedAtReturn > 0
+						? `[k0] post-return unlink window is OPEN: ${survivedAtReturn}/${N} ${arm.table} files survive drop_table's return.`
+						: `[k0] post-return unlink window is CLOSED (0 survivors at return) — drop_table reclaims before returning; the kill arms degrade to no-op controls.`
+				);
+			}
+
+			if (arm.delayMs > 0) await sleep(arm.delayMs);
+			const elapsedSinceReturn = Date.now() - returnInstant;
+			ok(
+				elapsedSinceReturn >= arm.delayMs && elapsedSinceReturn < arm.delayMs + 3000,
+				`kill did not land at the intended delay: wanted ~${arm.delayMs}ms after return, actual elapsed=${elapsedSinceReturn}ms`
+			);
+			const preKill = await diskUsage(blobDir('qa809t'));
+			findings.push(
+				`[k${arm.delayMs}] at kill instant (t+${elapsedSinceReturn}ms since return): ${delta(preKill, dbBefore).files}/${N} files still present`
+			);
+
+			await killAndRestart();
+
+			const cp3 = await diskUsage(blobDir('qa809t'));
+			ledger[`${arm.name}: 3. after restart`] = cp3;
+			const survivedAfterRestart = delta(cp3, dbBefore).files;
+			findings.push(
+				`[k${arm.delayMs}] after restart: ${survivedAfterRestart}/${N} ${arm.table} files still present (recovery-reclaimed = ${survivedAfterRestart === 0 && survivedAtReturn > 0})`
+			);
+			await verifyKeepaliveIntact(`k${arm.delayMs} post-restart`);
+
+			const cleanupRes = await opReq({ operation: 'cleanup_orphan_blobs', database: 'qa809t' });
+			strictEqual(cleanupRes.status, 200, `cleanup_orphan_blobs failed: ${JSON.stringify(cleanupRes.body)}`);
+			const { final, traj } = await settleAfterCleanup(blobDir('qa809t'));
+			ledger[`${arm.name}: 4. after cleanup_orphan_blobs (settled)`] = final;
+			const survivedAfterCleanup = delta(final, dbBefore).files;
+			findings.push(
+				`[k${arm.delayMs}] post-cleanup_orphan_blobs trajectory: ${traj.join(', ')} (delta vs pre-arm baseline = ${survivedAfterCleanup})`
+			);
+
+			// The invariant that survives any fix to the drop path: whatever a crash inside the
+			// unlink window leaves behind, cleanup_orphan_blobs must reclaim. A file that is still
+			// orphaned after restart + cleanup is unreclaimable disk — the user-visible defect.
+			// Asserted, not merely logged: the VERDICT strings below report but cannot fail.
+			ok(
+				survivedAfterCleanup <= 1,
+				`[k${arm.delayMs}] ${survivedAfterCleanup} blob file(s) remain PERMANENTLY ORPHANED after restart + ` +
+					`cleanup_orphan_blobs (delta vs pre-arm baseline). cleanup_orphan_blobs must fully reclaim files ` +
+					`orphaned by a crash inside drop_table's unlink window.`
+			);
+
+			if (survivedAfterRestart > 0 && survivedAfterCleanup <= 1) {
+				findings.push(
+					`[k${arm.delayMs}] VERDICT: orphans NOT auto-reclaimed by recovery, but fully reclaimed by cleanup_orphan_blobs.`
+				);
+			} else if (survivedAtReturn > 0 && survivedAfterRestart === 0) {
+				findings.push(
+					`[k${arm.delayMs}] VERDICT: orphans reclaimed automatically by recovery/restart (unexpected per static read — worth double-checking).`
+				);
+			} else if (survivedAfterCleanup > 1) {
+				findings.push(
+					`[k${arm.delayMs}] VERDICT: DEFECT — ${survivedAfterCleanup} file(s) remain PERMANENTLY ORPHANED even after restart + cleanup_orphan_blobs.`
+				);
+			} else {
+				findings.push(
+					`[k${arm.delayMs}] VERDICT: no survivors past the return checkpoint for this arm (window may have already closed by delay=${arm.delayMs}ms — see checkpoint 2 above).`
+				);
+			}
+			await verifyKeepaliveIntact(`k${arm.delayMs} post-cleanup`);
+		});
+	}
+
+	// ── Control: drop_table, no kill, unlink allowed to complete normally. ────────────────────
+	test('drop_table CONTROL (no kill): four-checkpoint ledger', async (t) => {
+		if (ctx.harper.process?.exitCode != null || ctx.harper.process?.killed) {
+			t.skip('instance already down from a prior arm');
+			return;
+		}
+		const dbBefore = await diskUsage(blobDir('qa809t'));
+		await storeN('qa809t', 'BlobTableCtrl', 'ctrl', N);
+		const cp1 = await diskUsage(blobDir('qa809t'));
+		ledger['ctrl: 1. before drop_table (after write)'] = cp1;
+		ok(
+			delta(cp1, dbBefore).files >= N,
+			`floor: expected +${N} files from BlobTableCtrl writes, got +${delta(cp1, dbBefore).files}`
+		);
+
+		const dropRes = await opReq({ operation: 'drop_table', schema: 'qa809t', table: 'BlobTableCtrl' });
+		strictEqual(dropRes.status, 200, `drop_table BlobTableCtrl failed: ${JSON.stringify(dropRes.body)}`);
+		const cp2 = await diskUsage(blobDir('qa809t'));
+		ledger['ctrl: 2. immediately after drop_table returns'] = cp2;
+		findings.push(`[ctrl] immediately after return: ${delta(cp2, dbBefore).files}/${N} files still present`);
+
+		await sleep(3_000); // give the scheduled 500ms unlinks generous margin to complete naturally
+		const cp2settled = await diskUsage(blobDir('qa809t'));
+		ledger['ctrl: 2b. settled +3s (no kill, unlink allowed to complete)'] = cp2settled;
+		const survivedSettled = delta(cp2settled, dbBefore).files;
+		findings.push(`[ctrl] +3s settle, no kill: ${survivedSettled}/${N} files still present`);
+
+		await gracefulRestart();
+		const cp3 = await diskUsage(blobDir('qa809t'));
+		ledger['ctrl: 3. after graceful restart'] = cp3;
+		findings.push(`[ctrl] after graceful restart: ${delta(cp3, dbBefore).files}/${N} files still present`);
+		await verifyKeepaliveIntact('ctrl post-restart');
+
+		const cleanupRes = await opReq({ operation: 'cleanup_orphan_blobs', database: 'qa809t' });
+		strictEqual(cleanupRes.status, 200, `cleanup_orphan_blobs failed: ${JSON.stringify(cleanupRes.body)}`);
+		const { final, traj } = await settleAfterCleanup(blobDir('qa809t'));
+		ledger['ctrl: 4. after cleanup_orphan_blobs (settled)'] = final;
+		const survivedFinal = delta(final, dbBefore).files;
+		findings.push(`[ctrl] post-cleanup trajectory: ${traj.join(', ')} (final delta = ${survivedFinal})`);
+		ok(
+			survivedFinal <= 1,
+			`CONTROL should leave ~0 files after settle+cleanup even without a kill; got ${survivedFinal}`
+		);
+		await verifyKeepaliveIntact('ctrl post-cleanup');
+	});
+
+	// ── drop_database: kill immediately (0ms) after the op returns. ───────────────────────────
+	test('drop_database kill@0ms: four-checkpoint ledger', async (t) => {
+		if (ctx.harper.process?.exitCode != null || ctx.harper.process?.killed) {
+			t.skip('instance already down from a prior arm');
+			return;
+		}
+		const dir = blobDir('qa809d0');
+		const before_ = await diskUsage(dir);
+		await storeN('qa809d0', 'BlobDBKill0', 'dbk0', N);
+		const cp1 = await diskUsage(dir);
+		ledger['dbKill0: 1. before drop_database (after write)'] = cp1;
+		ok(
+			delta(cp1, before_).files >= N,
+			`floor: expected +${N} files from BlobDBKill0 writes, got +${delta(cp1, before_).files}`
+		);
+
+		const dropRes = await opReq({ operation: 'drop_database', database: 'qa809d0' });
+		strictEqual(dropRes.status, 200, `drop_database qa809d0 failed: ${JSON.stringify(dropRes.body)}`);
+		const cp2 = await diskUsage(dir);
+		ledger['dbKill0: 2. immediately after drop_database returns'] = cp2;
+		findings.push(
+			`[dbKill0] immediately after drop_database returns: ${cp2.files}f/${cp2.bytes}B remain (claim: rimraf is awaited before response, so this should be 0)`
+		);
+		strictEqual(
+			cp2.files,
+			0,
+			`DEFECT check: expected 0 blob files immediately after drop_database returns, got ${cp2.files}`
+		);
+
+		// Kill anyway (0ms) to confirm nothing resurrects post-crash, and to fill the same
+		// checkpoint-3/4 slots as the drop_table arms for a like-for-like comparison.
+		await killAndRestart();
+		const cp3 = await diskUsage(dir);
+		ledger['dbKill0: 3. after restart'] = cp3;
+		findings.push(`[dbKill0] after restart: ${cp3.files}f/${cp3.bytes}B`);
+
+		const cleanupRes = await opReq({ operation: 'cleanup_orphan_blobs', database: 'qa809d0' });
+		findings.push(
+			`[dbKill0] cleanup_orphan_blobs(qa809d0) response (db no longer exists): status=${cleanupRes.status} body=${JSON.stringify(cleanupRes.body)}`
+		);
+		const cp4 = await diskUsage(dir);
+		ledger['dbKill0: 4. after cleanup_orphan_blobs attempt'] = cp4;
+		strictEqual(
+			cp4.files,
+			0,
+			`drop_database must leave 0 blob files at every checkpoint, including post-restart/post-cleanup-attempt; got ${cp4.files}`
+		);
+	});
+
+	// ── drop_database: control, no kill. ───────────────────────────────────────────────────────
+	test('drop_database CONTROL (no kill): four-checkpoint ledger', async (t) => {
+		if (ctx.harper.process?.exitCode != null || ctx.harper.process?.killed) {
+			t.skip('instance already down from a prior arm');
+			return;
+		}
+		const dir = blobDir('qa809dc');
+		const before_ = await diskUsage(dir);
+		await storeN('qa809dc', 'BlobDBCtrl', 'dbc', N);
+		const cp1 = await diskUsage(dir);
+		ledger['dbCtrl: 1. before drop_database (after write)'] = cp1;
+		ok(
+			delta(cp1, before_).files >= N,
+			`floor: expected +${N} files from BlobDBCtrl writes, got +${delta(cp1, before_).files}`
+		);
+
+		const dropRes = await opReq({ operation: 'drop_database', database: 'qa809dc' });
+		strictEqual(dropRes.status, 200, `drop_database qa809dc failed: ${JSON.stringify(dropRes.body)}`);
+		const cp2 = await diskUsage(dir);
+		ledger['dbCtrl: 2. immediately after drop_database returns'] = cp2;
+		findings.push(`[dbCtrl] immediately after drop_database returns: ${cp2.files}f/${cp2.bytes}B remain`);
+		strictEqual(
+			cp2.files,
+			0,
+			`DEFECT check: expected 0 blob files immediately after drop_database returns, got ${cp2.files}`
+		);
+
+		await gracefulRestart();
+		const cp3 = await diskUsage(dir);
+		ledger['dbCtrl: 3. after graceful restart'] = cp3;
+		findings.push(`[dbCtrl] after graceful restart: ${cp3.files}f/${cp3.bytes}B`);
+
+		const cleanupRes = await opReq({ operation: 'cleanup_orphan_blobs', database: 'qa809dc' });
+		findings.push(
+			`[dbCtrl] cleanup_orphan_blobs(qa809dc) response (db no longer exists): status=${cleanupRes.status} body=${JSON.stringify(cleanupRes.body)}`
+		);
+		const cp4 = await diskUsage(dir);
+		ledger['dbCtrl: 4. after cleanup_orphan_blobs attempt'] = cp4;
+		strictEqual(cp4.files, 0, `drop_database must leave 0 blob files at every checkpoint; got ${cp4.files}`);
+	});
+});

--- a/integrationTests/database/blob-drop-crash-orphan-window.test.ts
+++ b/integrationTests/database/blob-drop-crash-orphan-window.test.ts
@@ -300,9 +300,12 @@ suite(`QA-809 drop-path kill-window sweep [rocksdb]`, { skip: skipSuite }, (ctx:
 
 			if (arm.delayMs > 0) await sleep(arm.delayMs);
 			const elapsedSinceReturn = Date.now() - returnInstant;
+			// No upper bound here: process liveness is already asserted above (the `ok(...)` at the
+			// top of this test), so a strict elapsed-time ceiling only adds flakiness under CPU
+			// starvation / scheduling delays (e.g. GitHub Actions runners) without buying correctness.
 			ok(
-				elapsedSinceReturn >= arm.delayMs && elapsedSinceReturn < arm.delayMs + 3000,
-				`kill did not land at the intended delay: wanted ~${arm.delayMs}ms after return, actual elapsed=${elapsedSinceReturn}ms`
+				elapsedSinceReturn >= arm.delayMs,
+				`kill did not land at the intended delay: wanted >= ${arm.delayMs}ms after return, actual elapsed=${elapsedSinceReturn}ms`
 			);
 			const preKill = await diskUsage(blobDir('qa809t'));
 			findings.push(
@@ -402,8 +405,8 @@ suite(`QA-809 drop-path kill-window sweep [rocksdb]`, { skip: skipSuite }, (ctx:
 		const survivedFinal = delta(final, dbBefore).files;
 		findings.push(`[ctrl] post-cleanup trajectory: ${traj.join(', ')} (final delta = ${survivedFinal})`);
 		ok(
-			survivedFinal <= 1,
-			`CONTROL should leave ~0 files after settle+cleanup even without a kill; got ${survivedFinal}`
+			survivedFinal === 0,
+			`CONTROL should leave exactly 0 files after settle+cleanup even without a kill; got ${survivedFinal}`
 		);
 		await verifyKeepaliveIntact('ctrl post-cleanup');
 	});

--- a/integrationTests/database/blob-drop-crash-orphan-window.test.ts
+++ b/integrationTests/database/blob-drop-crash-orphan-window.test.ts
@@ -283,14 +283,18 @@ suite(`QA-809 drop-path kill-window sweep [rocksdb]`, { skip: skipSuite }, (ctx:
 				`[k${arm.delayMs}] immediately after drop_table returns: ${survivedAtReturn}/${N} ${arm.table} blob files still on disk`
 			);
 			if (arm.delayMs === 0) {
-				// Observation, not an assertion. A fix that unlinks synchronously before drop_table
-				// returns closes this window entirely — an improvement, which must not turn this
-				// anchor red. The invariant asserted after cleanup below holds either way; recording
-				// the window state keeps a closed window visible rather than silently vacuous.
+				// Oracle floor (b): if nothing survives the drop_table return, nothing is pending
+				// at the kill instant either, so the kill never lands mid-unlink — the downstream
+				// "reclaimed after cleanup" assertion would then pass vacuously (there is nothing
+				// to reclaim). Per this suite's documented oracle discipline, that premise failure
+				// must hard-fail this arm rather than silently degrade to a no-op control.
+				ok(
+					survivedAtReturn > 0,
+					`[k0] post-return unlink window is CLOSED (0/${N} ${arm.table} files survive drop_table's return) — ` +
+						`nothing was pending at the kill instant, so this run never tested a crash inside the unlink window.`
+				);
 				findings.push(
-					survivedAtReturn > 0
-						? `[k0] post-return unlink window is OPEN: ${survivedAtReturn}/${N} ${arm.table} files survive drop_table's return.`
-						: `[k0] post-return unlink window is CLOSED (0 survivors at return) — drop_table reclaims before returning; the kill arms degrade to no-op controls.`
+					`[k0] post-return unlink window is OPEN: ${survivedAtReturn}/${N} ${arm.table} files survive drop_table's return.`
 				);
 			}
 
@@ -327,9 +331,11 @@ suite(`QA-809 drop-path kill-window sweep [rocksdb]`, { skip: skipSuite }, (ctx:
 			// The invariant that survives any fix to the drop path: whatever a crash inside the
 			// unlink window leaves behind, cleanup_orphan_blobs must reclaim. A file that is still
 			// orphaned after restart + cleanup is unreclaimable disk — the user-visible defect.
-			// Asserted, not merely logged: the VERDICT strings below report but cannot fail.
+			// Asserted, not merely logged: the VERDICT strings below report but cannot fail. Zero
+			// tolerance — permitting even one straggler out of N would silently accept the exact
+			// partial-leak defect this arm exists to catch.
 			ok(
-				survivedAfterCleanup <= 1,
+				survivedAfterCleanup === 0,
 				`[k${arm.delayMs}] ${survivedAfterCleanup} blob file(s) remain PERMANENTLY ORPHANED after restart + ` +
 					`cleanup_orphan_blobs (delta vs pre-arm baseline). cleanup_orphan_blobs must fully reclaim files ` +
 					`orphaned by a crash inside drop_table's unlink window.`

--- a/integrationTests/database/blob-drop-crash-orphan-window/config.yaml
+++ b/integrationTests/database/blob-drop-crash-orphan-window/config.yaml
@@ -1,0 +1,5 @@
+graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/database/blob-drop-crash-orphan-window/resources.js
+++ b/integrationTests/database/blob-drop-crash-orphan-window/resources.js
@@ -1,0 +1,74 @@
+// QA-809 — blob-bearing record writer for the drop-kill-window sweep. Blob content is
+// generated server-side (deterministic HMAC stream) so every write is a genuine file-backed
+// blob (well above the 8KB FILE_STORAGE_THRESHOLD).
+//
+// NOTE on qa805's fixture bug (flagged by the task brief): qa805's store() did a `table.get(id)`
+// readback immediately after `table.put(...)` inside the same request/transaction, which derefs
+// null on LMDB (no read-your-writes within an open txn). This fixture never reads back inside
+// store() -- verification is a SEPARATE request (separate transaction), issued by the test only
+// after the store request has resolved (i.e. after commit).
+
+import { createHash, createHmac } from 'node:crypto';
+
+function patternBuffer(seed, size) {
+	const out = Buffer.allocUnsafe(size);
+	let off = 0;
+	let counter = 0;
+	while (off < size) {
+		const block = createHmac('sha256', String(seed)).update(String(counter++)).digest();
+		const n = Math.min(block.length, size - off);
+		block.copy(out, off, 0, n);
+		off += n;
+	}
+	return out;
+}
+
+function sha256(buf) {
+	return createHash('sha256').update(buf).digest('hex');
+}
+
+// POST /Blob809/ { action: 'store'|'verify', db, table, id, size, seed }
+export class Blob809 extends Resource {
+	static loadAsInstance = false;
+
+	async post(query, body) {
+		const action = body && body.action;
+		const db = body && body.db;
+		const table = db && databases[db] && databases[db][body.table];
+		if (!table) {
+			const ctx = this.getContext();
+			if (ctx && ctx.response) ctx.response.status = 400;
+			return { ok: false, reason: 'unknown-table', db, table: body && body.table };
+		}
+		switch (action) {
+			case 'store':
+				return this.store(table, body);
+			case 'verify':
+				return this.verify(table, body);
+			default: {
+				const ctx = this.getContext();
+				if (ctx && ctx.response) ctx.response.status = 400;
+				return { ok: false, reason: 'unknown-action', action };
+			}
+		}
+	}
+
+	// Put only -- no readback. Caller can 'verify' in a later, separate request if needed.
+	async store(table, body) {
+		const id = String(body.id);
+		const size = Number(body.size) || 256 * 1024;
+		const seed = body.seed == null ? id : String(body.seed);
+		const expected = patternBuffer(seed, size);
+		await table.put({ id, blob: createBlob(expected, { type: 'application/octet-stream' }) });
+		return { ok: true, id, expectedSha: sha256(expected) };
+	}
+
+	// Separate request/transaction -- safe read-your-writes across commits on both engines.
+	async verify(table, body) {
+		const id = String(body.id);
+		const rec = await table.get(id);
+		if (!rec) return { ok: true, present: false, id };
+		const bytes = Buffer.from(await rec.blob.bytes());
+		return { ok: true, present: true, id, readSha: sha256(bytes), size: bytes.length };
+	}
+}

--- a/integrationTests/database/blob-drop-crash-orphan-window/schema.graphql
+++ b/integrationTests/database/blob-drop-crash-orphan-window/schema.graphql
@@ -1,0 +1,61 @@
+# QA-809 — kill-window sweep for drop_table/drop_database blob unlink.
+#
+# Background (prior wave, this same checkout): drop_table returns to the client BEFORE its
+# blob files are unlinked -- deleteBlob() schedules unlink via setTimeout(deletionDelay=500ms)
+# for every HAS_BLOBS entry it walks, and only AFTER scheduling all of those does the column
+# family get dropped and the op return. So there's a ~0.5-3s window, starting at the moment
+# the op returns, in which the table's metadata is already gone but its blob files are not.
+#
+# This fixture drives that sweep: one BlobTable per kill-delay arm (blobs aren't partitioned
+# by table on disk -- {dataRootDir}/blobs/{db}/... -- so isolating each arm to its own table
+# lets us delta-count that arm's survival independent of the others). All drop_table arms
+# share database "qa809t" and keep a sibling `Keepalive` table alive throughout, because
+# cleanup_orphan_blobs's `for (const tableName in database)` loop (dataLayer needs a resolvable
+# store/auditStore pair) never fires for an empty database -- confirmed by a prior QA wave
+# (QA-697) and reused here verbatim from qa805's fixture design.
+#
+# drop_database arms get their OWN database each (whole-directory rimraf), so blobs/{db} is
+# exclusively that arm's files and the accounting is unambiguous.
+
+# ---- db "qa809t": drop_table kill-window sweep, Keepalive keeps the db resolvable ----
+type Keepalive @table(database: "qa809t", audit: true) @export {
+	id: ID @primaryKey
+	blob: Blob
+}
+
+type BlobTableK0 @table(database: "qa809t", audit: false) @export {
+	id: ID @primaryKey
+	blob: Blob
+}
+
+type BlobTableK100 @table(database: "qa809t", audit: false) @export {
+	id: ID @primaryKey
+	blob: Blob
+}
+
+type BlobTableK400 @table(database: "qa809t", audit: false) @export {
+	id: ID @primaryKey
+	blob: Blob
+}
+
+type BlobTableK600 @table(database: "qa809t", audit: false) @export {
+	id: ID @primaryKey
+	blob: Blob
+}
+
+type BlobTableCtrl @table(database: "qa809t", audit: false) @export {
+	id: ID @primaryKey
+	blob: Blob
+}
+
+# ---- db "qa809d0": drop_database, kill immediately (0ms) after the op returns ----
+type BlobDBKill0 @table(database: "qa809d0", audit: false) @export {
+	id: ID @primaryKey
+	blob: Blob
+}
+
+# ---- db "qa809dc": drop_database control, no kill (graceful restart) ----
+type BlobDBCtrl @table(database: "qa809dc", audit: false) @export {
+	id: ID @primaryKey
+	blob: Blob
+}

--- a/integrationTests/database/txnlog-purge-stale-read-blast.test.ts
+++ b/integrationTests/database/txnlog-purge-stale-read-blast.test.ts
@@ -1,0 +1,688 @@
+/**
+ * QA-782 — bound the blast radius of F-225 (HIGH): on `storage.engine: rocksdb`,
+ * `delete_audit_logs_before`/`delete_transaction_logs_before` genuinely purges on-disk
+ * `.txnlog` data and reports an accurate `transactions_deleted`, yet `read_audit_log` in the
+ * SAME process keeps returning every purged row byte-correct until restart (LMDB is clean).
+ * QA-781 root-caused this to rocksdb-js's `TransactionLog._logBuffers: Map<logId,
+ * WeakRef<LogBuffer>>` -- a cache that lives on the native `TransactionLog` object used ONLY
+ * by the audit/txnlog store (`RocksTransactionLogStore`), with no purge-invalidation hook.
+ *
+ * F-225 is currently scoped to the audit-reporting path only because that's the only path
+ * anyone looked at. THIS suite asks the more serious question directly: if the stale-cache
+ * mechanism is "a cached read view over RocksDB data that doesn't know a delete happened",
+ * can it reach ORDINARY TABLE READS after an ordinary delete -- not the audit/txnlog store at
+ * all, but the primary key-value store every table read goes through? A phantom there would
+ * mean deleted application data resurrects on read after a normal delete, which is a
+ * correctness defect, not a reporting defect.
+ *
+ * DESIGN:
+ *   - `threads.count: 1` -- deliberately, so "same process" is structural (every request is
+ *     necessarily served by the one and only worker) rather than relying on HTTP keep-alive
+ *     connection-affinity tricks (that per-worker-routing question is QA-787's separate
+ *     concern; this suite isolates "which surface", not "which worker").
+ *   - Seed a large contiguous key range (bucket=DEL, 6000 rows) + a non-deleted range
+ *     (bucket=KEEP, 6000 rows) + a byte-exact ARMED POSITIVE CONTROL (bucket=CTRL, 5 rows,
+ *     inserted after a recorded cutoff) -- large enough, with padded payloads, to force real
+ *     on-disk data (forced via explicit `primaryStore.flush()` calls between seeding waves,
+ *     matching QA-779/QA-787's proven >16MiB-crossing magnitude so the LATER audit-purge arm
+ *     is non-vacuous too).
+ *   - WARM every read surface pre-delete (also proves the oracle: a "clean" post-delete
+ *     result must follow a "present" pre-delete result on the exact same surface).
+ *   - Bulk-delete the entire DEL bucket (6000 ids, one contiguous key range) via the ops
+ *     `delete` operation.
+ *   - Same-process, post-delete, read back DEL samples (must be GONE), CTRL (must survive
+ *     byte-correct -- proves the reader actually reads), and KEEP samples (must survive --
+ *     proves the delete was scoped) across FIVE ordinary surfaces: REST record GET, REST
+ *     collection query (`?bucket=`), `search_by_value` (ops API), SQL (ops API), and a raw
+ *     index-independent full primary-store scan.
+ *   - CONTRAST ARM: run the KNOWN-reproducing audit purge (`delete_transaction_logs_before`)
+ *     against the SAME table in the SAME process and check `read_audit_log` for the deleted
+ *     range -- documents (not hard-asserted, since it's independently filed as F-225) whether
+ *     the audit phantom reproduces here too, for the sharpest possible same-process contrast.
+ *   - RESTART DISCRIMINATOR: `killHarper` + `startHarper` on the identical `dataRootDir`,
+ *     then re-measure. If pre-restart reads were already clean, post-restart must also be
+ *     clean -- that agreement is the confirmation the bound holds.
+ *   - Runs on BOTH `rocksdb` (the subject) and `lmdb` (control), same fixture, same workload.
+ *
+ * MQTT/SSE snapshot arm: NOT included. An SSE/MQTT subscribe on a collection is a live
+ * event stream, not a point-in-time snapshot read (no guaranteed initial backlog dump), so it
+ * doesn't cleanly serve as a "read the current state" oracle here, and an infinite stream
+ * adds real teardown risk without covering a new code path (Table.subscribe still bottoms out
+ * in the same primary-store read the other five surfaces already exercise). Left out to keep
+ * this suite reliable within budget.
+ *
+ * Reproduction:
+ *   cd <harper checkout> && npm run test:integration -- \
+ *     "integrationTests/database/txnlog-purge-stale-read-blast.test.ts"
+ * Harper SHA at promotion: 80ef45996 (main)
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { resolve, join } from 'node:path';
+import { readdirSync, statSync, existsSync } from 'node:fs';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+	setupHarperWithFixture,
+	teardownHarper,
+	killHarper,
+	startHarper,
+	type ContextWithHarper,
+} from '@harperfast/integration-testing';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'txnlog-purge-stale-read-blast');
+const SCHEMA = 'data';
+const TABLE = 'Widget';
+const skipSuite = process.env.HARPER_RUNTIME === 'bun';
+
+// DEL range gets bulk-deleted (the subject of this whole suite). KEEP range stays untouched
+// (scoping sanity: proves the delete/read paths aren't just globally broken). Padded payload
+// matches QA-779/QA-787's proven >16MiB-crossing magnitude so delete_transaction_logs_before
+// in the contrast arm actually rotates/removes whole .txnlog files instead of a no-op.
+const DEL_COUNT = 6000; // ids k0..k5999
+const KEEP_COUNT = 6000; // ids k6000..k11999
+const BATCH_SIZE = 500;
+const PAYLOAD_PAD = 'y'.repeat(1780);
+function payloadFor(i: number): string {
+	return `seq${i}:${PAYLOAD_PAD}`;
+}
+const DEL_SAMPLE_IDX = [0, 1, 50, 1500, 3000, 5999]; // spans the whole deleted range, incl. boundary
+const KEEP_SAMPLE_IDX = [6000, 6001, 9000, 11999]; // spans the whole surviving range, incl. boundary
+const CTRL_COUNT = 5;
+const CTRL_IDS = Array.from({ length: CTRL_COUNT }, (_, i) => `ctrl${i}`);
+function ctrlPayload(i: number): string {
+	return `CTRL-${i}:${PAYLOAD_PAD}`;
+}
+
+function authHeader(ctx: ContextWithHarper): string {
+	const { username, password } = ctx.harper.admin;
+	return 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64');
+}
+
+async function rawOp(
+	ctx: ContextWithHarper,
+	operation: any,
+	timeoutMs = 60_000
+): Promise<{ status: number; body: any; text: string }> {
+	const res = await fetch(ctx.harper.operationsAPIURL, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', 'Authorization': authHeader(ctx) },
+		body: JSON.stringify(operation),
+		signal: AbortSignal.timeout(timeoutMs),
+	});
+	const text = await res.text();
+	let body: any;
+	try {
+		body = JSON.parse(text);
+	} catch {
+		body = text;
+	}
+	return { status: res.status, body, text };
+}
+
+async function restGet(ctx: ContextWithHarper, path: string): Promise<{ status: number; body: any }> {
+	const res = await fetch(`${ctx.harper.httpURL}${path}`, { headers: { Authorization: authHeader(ctx) } });
+	let body: any = null;
+	try {
+		body = await res.json();
+	} catch {
+		/* non-JSON / empty */
+	}
+	return { status: res.status, body };
+}
+
+async function pollReadiness(ctx: ContextWithHarper): Promise<void> {
+	const deadline = Date.now() + 60_000;
+	while (Date.now() < deadline) {
+		try {
+			const res = await fetch(`${ctx.harper.httpURL}/Probe/`, { headers: { Authorization: authHeader(ctx) } });
+			if (res.status !== 404) return;
+		} catch {
+			/* not ready */
+		}
+		await sleep(250);
+	}
+	throw new Error('QA-782: Probe route never became ready within 60s');
+}
+
+async function pollJob(ctx: ContextWithHarper, jobId: string, timeoutMs = 60_000): Promise<any> {
+	const deadline = Date.now() + timeoutMs;
+	let last: any;
+	while (Date.now() < deadline) {
+		const r = await rawOp(ctx, { operation: 'get_job', id: jobId });
+		last = Array.isArray(r.body) ? r.body[0] : r.body;
+		if (last?.status === 'COMPLETE' || last?.status === 'ERROR') return last;
+		await sleep(500);
+	}
+	throw new Error(`QA-782: job ${jobId} did not complete within ${timeoutMs}ms; last=${JSON.stringify(last)}`);
+}
+
+function findFiles(root: string, matcher: (name: string) => boolean, depth = 0): string[] {
+	if (depth > 8 || !existsSync(root)) return [];
+	let out: string[] = [];
+	let entries: import('node:fs').Dirent[];
+	try {
+		entries = readdirSync(root, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+	for (const ent of entries) {
+		const p = join(root, ent.name);
+		if (ent.isDirectory()) out = out.concat(findFiles(p, matcher, depth + 1));
+		else if (matcher(ent.name)) out.push(p);
+	}
+	return out;
+}
+
+function txnLogStats(root: string): { fileCount: number; totalBytes: number } {
+	const files = findFiles(root, (n) => n.endsWith('.txnlog'));
+	let totalBytes = 0;
+	for (const p of files) {
+		try {
+			totalBytes += statSync(p).size;
+		} catch {
+			/* rotated/deleted mid-scan */
+		}
+	}
+	return { fileCount: files.length, totalBytes };
+}
+
+function fmtMiB(bytes: number): string {
+	return `${(bytes / 1024 / 1024).toFixed(3)}MiB`;
+}
+
+async function seedRange(ctx: ContextWithHarper, start: number, count: number, bucket: string): Promise<void> {
+	for (let s = start; s < start + count; s += BATCH_SIZE) {
+		const records = [];
+		for (let i = s; i < Math.min(s + BATCH_SIZE, start + count); i++) {
+			records.push({ id: `k${i}`, seq: i, bucket, payload: payloadFor(i) });
+		}
+		const r = await rawOp(ctx, { operation: 'insert', schema: SCHEMA, table: TABLE, records });
+		ok(r.status === 200, `insert batch@${s} should succeed, got ${r.status}: ${r.text.slice(0, 300)}`);
+	}
+}
+
+async function flush(ctx: ContextWithHarper): Promise<void> {
+	const r = await fetch(`${ctx.harper.httpURL}/Flush/`, {
+		method: 'POST',
+		headers: { Authorization: authHeader(ctx) },
+	});
+	ok(r.status === 200, `/Flush/ should succeed, got ${r.status}`);
+}
+
+// ---- Per-surface probes --------------------------------------------------------------------
+// Each returns a Map<id, present-and-correct | present-but-wrong | absent> style summary so
+// callers can assert precisely what happened on that surface.
+
+async function restGetById(
+	ctx: ContextWithHarper,
+	id: string
+): Promise<{ present: boolean; seq?: number; payload?: string }> {
+	const r = await restGet(ctx, `/${TABLE}/${encodeURIComponent(id)}`);
+	if (r.status !== 200 || !r.body) return { present: false };
+	return { present: true, seq: r.body.seq, payload: r.body.payload };
+}
+
+async function restQueryBucket(
+	ctx: ContextWithHarper,
+	bucket: string
+): Promise<Array<{ id: string; seq: number; payload: string }>> {
+	const r = await restGet(ctx, `/${TABLE}/?bucket=${encodeURIComponent(bucket)}`);
+	ok(r.status === 200, `REST query ?bucket=${bucket} expected 200, got ${r.status}`);
+	return Array.isArray(r.body) ? r.body : [];
+}
+
+async function searchByBucket(
+	ctx: ContextWithHarper,
+	bucket: string
+): Promise<Array<{ id: string; seq: number; payload: string }>> {
+	const r = await rawOp(ctx, {
+		operation: 'search_by_value',
+		schema: SCHEMA,
+		table: TABLE,
+		search_attribute: 'bucket',
+		search_value: bucket,
+		get_attributes: ['id', 'seq', 'payload'],
+	});
+	ok(r.status === 200, `search_by_value(bucket=${bucket}) expected 200, got ${r.status}: ${r.text.slice(0, 300)}`);
+	return Array.isArray(r.body) ? r.body : [];
+}
+
+async function sqlByBucket(
+	ctx: ContextWithHarper,
+	bucket: string
+): Promise<Array<{ id: string; seq: number; payload: string }>> {
+	const r = await rawOp(ctx, {
+		operation: 'sql',
+		sql: `SELECT id, seq, payload FROM ${SCHEMA}.${TABLE} WHERE bucket = '${bucket}'`,
+	});
+	ok(r.status === 200, `SQL bucket=${bucket} expected 200, got ${r.status}: ${r.text.slice(0, 300)}`);
+	return Array.isArray(r.body) ? r.body : [];
+}
+
+async function fullScan(
+	ctx: ContextWithHarper,
+	ids: string[]
+): Promise<{ totalCount: number; records: Record<string, { seq: number; bucket: string; payload: string } | null> }> {
+	const r = await restGet(ctx, `/FullScan/?ids=${ids.join(',')}`);
+	ok(r.status === 200, `FullScan expected 200, got ${r.status}`);
+	return r.body;
+}
+
+/** Assert a set of ids is present+byte-correct on ALL FIVE surfaces. Used for the armed control + KEEP sanity. */
+async function assertPresentEverywhere(
+	ctx: ContextWithHarper,
+	label: string,
+	ids: string[],
+	expectedPayload: (i: number) => string,
+	seqOf: (id: string) => number,
+	findings: string[]
+) {
+	for (const id of ids) {
+		const seq = seqOf(id);
+		const g = await restGetById(ctx, id);
+		ok(
+			g.present && g.payload === expectedPayload(seq),
+			`[${label}] REST GET ${id} must be present+correct, got ${JSON.stringify(g)}`
+		);
+	}
+	const fs = await fullScan(ctx, ids);
+	for (const id of ids) {
+		const seq = seqOf(id);
+		const rec = fs.records[id];
+		ok(
+			rec && rec.payload === expectedPayload(seq),
+			`[${label}] FullScan ${id} must be present+correct, got ${JSON.stringify(rec)}`
+		);
+	}
+	findings.push(`[${label}] present+byte-correct on REST GET + FullScan for ${ids.length} id(s): ${ids.join(',')}`);
+}
+
+/** Assert a set of ids is ABSENT on ALL FIVE surfaces. This is the headline bound check. */
+async function assertAbsentEverywhere(
+	ctx: ContextWithHarper,
+	label: string,
+	ids: string[],
+	bucket: string,
+	findings: string[]
+): Promise<{ anyPhantom: boolean; detail: string[] }> {
+	const detail: string[] = [];
+	let anyPhantom = false;
+
+	for (const id of ids) {
+		const g = await restGetById(ctx, id);
+		if (g.present) {
+			anyPhantom = true;
+			detail.push(`REST-GET:${id}:PHANTOM(seq=${g.seq})`);
+		} else {
+			detail.push(`REST-GET:${id}:clean`);
+		}
+	}
+
+	const queryHits = await restQueryBucket(ctx, bucket);
+	if (queryHits.length > 0) {
+		anyPhantom = true;
+		detail.push(`REST-QUERY:bucket=${bucket}:PHANTOM(${queryHits.length} hits)`);
+	} else {
+		detail.push(`REST-QUERY:bucket=${bucket}:clean`);
+	}
+
+	const sbvHits = await searchByBucket(ctx, bucket);
+	if (sbvHits.length > 0) {
+		anyPhantom = true;
+		detail.push(`SEARCH-BY-VALUE:bucket=${bucket}:PHANTOM(${sbvHits.length} hits)`);
+	} else {
+		detail.push(`SEARCH-BY-VALUE:bucket=${bucket}:clean`);
+	}
+
+	const sqlHits = await sqlByBucket(ctx, bucket);
+	if (sqlHits.length > 0) {
+		anyPhantom = true;
+		detail.push(`SQL:bucket=${bucket}:PHANTOM(${sqlHits.length} hits)`);
+	} else {
+		detail.push(`SQL:bucket=${bucket}:clean`);
+	}
+
+	const fs = await fullScan(ctx, ids);
+	for (const id of ids) {
+		const rec = fs.records[id];
+		if (rec) {
+			anyPhantom = true;
+			detail.push(`FULLSCAN:${id}:PHANTOM(seq=${rec.seq})`);
+		} else {
+			detail.push(`FULLSCAN:${id}:clean`);
+		}
+	}
+
+	findings.push(`[${label}] bucket=${bucket} ids=[${ids.join(',')}] :: ${detail.join(', ')}`);
+	return { anyPhantom, detail };
+}
+
+// ===============================================================================================
+function defineSuite(engine: 'rocksdb' | 'lmdb') {
+	suite(
+		`QA-782 stale-read blast radius: ordinary table reads after bulk delete [${engine}]`,
+		{ skip: skipSuite },
+		(ctx: ContextWithHarper) => {
+			const findings: string[] = [];
+			const armConfig = {
+				threads: { count: 1 },
+				logging: { auditLog: true, console: true, level: 'error' },
+				storage: { engine },
+			};
+			let dataRootDir: string;
+			let cutoffTimestamp: number;
+
+			before(async () => {
+				await setupHarperWithFixture(ctx, FIXTURE_PATH, { config: armConfig, env: { HARPER_STORAGE_ENGINE: engine } });
+				dataRootDir = ctx.harper.dataRootDir;
+				// Poll the probe route directly for non-404; do NOT restartHttpWorkers() against a
+				// pre-installed fixture (races, flakes CI).
+				await pollReadiness(ctx);
+			});
+
+			after(async () => {
+				await teardownHarper(ctx);
+				// eslint-disable-next-line no-console
+				console.log(`\n=== QA-782 [${engine}] findings ===\n${findings.map((f) => '  ' + f).join('\n')}\n`);
+			});
+
+			test('0. precondition: engine in effect matches the arm', async () => {
+				const res = await fetch(`${ctx.harper.httpURL}/StorageEngineInfo/`, {
+					headers: { Authorization: authHeader(ctx) },
+				});
+				const info = await res.json();
+				findings.push(`0. StorageEngineInfo=${JSON.stringify(info)}`);
+				ok(info.engineGuess === engine, `PRECONDITION: expected engine ${engine}, got ${info.engineGuess}`);
+			});
+
+			test('1. seed DEL (6000) + KEEP (6000) ranges, force flushes between waves', { timeout: 300_000 }, async () => {
+				// Flush every 2000 rows so data is genuinely on disk, not just resident in the memtable.
+				await seedRange(ctx, 0, 2000, 'DEL');
+				await flush(ctx);
+				await seedRange(ctx, 2000, 2000, 'DEL');
+				await flush(ctx);
+				await seedRange(ctx, 4000, 2000, 'DEL');
+				await flush(ctx);
+				await seedRange(ctx, 6000, 2000, 'KEEP');
+				await flush(ctx);
+				await seedRange(ctx, 8000, 2000, 'KEEP');
+				await flush(ctx);
+				await seedRange(ctx, 10000, 2000, 'KEEP');
+				await flush(ctx);
+
+				cutoffTimestamp = Date.now();
+				await sleep(250);
+
+				// Armed positive control, inserted AFTER the cutoff (so it also survives the later
+				// timestamp-based audit purge, giving that arm a non-vacuous control too).
+				const ctrlRecords = CTRL_IDS.map((id, i) => ({
+					id,
+					seq: 900_000 + i,
+					bucket: 'CTRL',
+					payload: ctrlPayload(900_000 + i),
+				}));
+				const ctrlRes = await rawOp(ctx, { operation: 'insert', schema: SCHEMA, table: TABLE, records: ctrlRecords });
+				ok(
+					ctrlRes.status === 200,
+					`control insert should succeed, got ${ctrlRes.status}: ${ctrlRes.text.slice(0, 300)}`
+				);
+				await flush(ctx);
+
+				const diskStats = txnLogStats(dataRootDir);
+				findings.push(
+					`1. seeded DEL=${DEL_COUNT} KEEP=${KEEP_COUNT} CTRL=${CTRL_COUNT}; cutoffTimestamp=${cutoffTimestamp}; ` +
+						`.txnlog on-disk: fileCount=${diskStats.fileCount} totalBytes=${fmtMiB(diskStats.totalBytes)}`
+				);
+				// .txnlog rotated files are a RocksDB-specific on-disk shape (RocksTransactionLogStore);
+				// LMDB keeps its audit log inside the single .mdb env, so this non-vacuous "real bytes on
+				// disk" precondition for the later audit-purge arm only applies to the rocksdb arm.
+				if (engine === 'rocksdb') {
+					ok(
+						diskStats.totalBytes > 16 * 1024 * 1024,
+						`PRECONDITION: expected >16MiB of .txnlog data (for the later audit arm), got ${fmtMiB(diskStats.totalBytes)}`
+					);
+				}
+			});
+
+			test(
+				'2. WARM: every surface sees DEL/KEEP/CTRL present+correct BEFORE the delete',
+				{ timeout: 60_000 },
+				async () => {
+					const delSampleIds = DEL_SAMPLE_IDX.map((i) => `k${i}`);
+					const keepSampleIds = KEEP_SAMPLE_IDX.map((i) => `k${i}`);
+
+					// REST GET + FullScan for both sample sets.
+					await assertPresentEverywhere(
+						ctx,
+						'PRE-DELETE DEL samples',
+						delSampleIds,
+						payloadFor,
+						(id) => Number(id.slice(1)),
+						findings
+					);
+					await assertPresentEverywhere(
+						ctx,
+						'PRE-DELETE KEEP samples',
+						keepSampleIds,
+						payloadFor,
+						(id) => Number(id.slice(1)),
+						findings
+					);
+					await assertPresentEverywhere(
+						ctx,
+						'PRE-DELETE CTRL',
+						CTRL_IDS,
+						(seq) => ctrlPayload(seq),
+						(id) => 900_000 + CTRL_IDS.indexOf(id),
+						findings
+					);
+
+					// REST query + search_by_value + SQL, bucket-wide (non-vacuous: full DEL_COUNT hits).
+					const restHits = await restQueryBucket(ctx, 'DEL');
+					const sbvHits = await searchByBucket(ctx, 'DEL');
+					const sqlHits = await sqlByBucket(ctx, 'DEL');
+					findings.push(
+						`2. PRE-DELETE bucket=DEL hit counts: REST-QUERY=${restHits.length} SEARCH-BY-VALUE=${sbvHits.length} SQL=${sqlHits.length} (expect ${DEL_COUNT} each)`
+					);
+					strictEqual(
+						sbvHits.length,
+						DEL_COUNT,
+						`PRECONDITION: search_by_value(DEL) pre-delete must see all ${DEL_COUNT} rows`
+					);
+					strictEqual(
+						sqlHits.length,
+						DEL_COUNT,
+						`PRECONDITION: SQL bucket=DEL pre-delete must see all ${DEL_COUNT} rows`
+					);
+
+					const fs = await fullScan(ctx, []);
+					findings.push(
+						`2. PRE-DELETE FullScan totalCount=${fs.totalCount} (expect ${DEL_COUNT + KEEP_COUNT + CTRL_COUNT})`
+					);
+					strictEqual(
+						fs.totalCount,
+						DEL_COUNT + KEEP_COUNT + CTRL_COUNT,
+						'PRECONDITION: pre-delete total row count must match seeded volume'
+					);
+				}
+			);
+
+			test(
+				'3. BULK DELETE: remove the entire DEL bucket (6000-id contiguous key range)',
+				{ timeout: 120_000 },
+				async () => {
+					const allDelIds = Array.from({ length: DEL_COUNT }, (_, i) => `k${i}`);
+					let totalDeleted = 0;
+					for (let s = 0; s < allDelIds.length; s += 1000) {
+						const chunk = allDelIds.slice(s, s + 1000);
+						const r = await rawOp(ctx, { operation: 'delete', schema: SCHEMA, table: TABLE, ids: chunk });
+						ok(r.status === 200, `bulk delete chunk@${s} expected 200, got ${r.status}: ${r.text.slice(0, 300)}`);
+						const n = Array.isArray(r.body?.deleted_hashes) ? r.body.deleted_hashes.length : 0;
+						totalDeleted += n;
+					}
+					findings.push(`3. bulk-deleted ${totalDeleted}/${DEL_COUNT} ids from bucket=DEL`);
+					strictEqual(
+						totalDeleted,
+						DEL_COUNT,
+						`NON-VACUOUS PRECONDITION: delete op must report exactly ${DEL_COUNT} deleted hashes`
+					);
+				}
+			);
+
+			test(
+				'4. KEY TEST (same process): DEL absent, CTRL + KEEP intact, on ALL FIVE ordinary read surfaces',
+				{ timeout: 60_000 },
+				async () => {
+					const delSampleIds = DEL_SAMPLE_IDX.map((i) => `k${i}`);
+					const keepSampleIds = KEEP_SAMPLE_IDX.map((i) => `k${i}`);
+
+					const { anyPhantom, detail } = await assertAbsentEverywhere(
+						ctx,
+						'4. POST-DELETE DEL samples',
+						delSampleIds,
+						'DEL',
+						findings
+					);
+
+					// Armed control: must survive byte-correct on every surface, or a "clean" phantom
+					// result above would be meaningless (broken oracle, not a real absence).
+					await assertPresentEverywhere(
+						ctx,
+						'4. POST-DELETE CTRL (armed control)',
+						CTRL_IDS,
+						(seq) => ctrlPayload(seq),
+						(id) => 900_000 + CTRL_IDS.indexOf(id),
+						findings
+					);
+					// Scoping sanity: the non-deleted range must be untouched.
+					await assertPresentEverywhere(
+						ctx,
+						'4. POST-DELETE KEEP samples',
+						keepSampleIds,
+						payloadFor,
+						(id) => Number(id.slice(1)),
+						findings
+					);
+
+					const fs = await fullScan(ctx, []);
+					findings.push(`4. POST-DELETE FullScan totalCount=${fs.totalCount} (expect ${KEEP_COUNT + CTRL_COUNT})`);
+
+					findings.push(
+						`4. VERDICT (same-process, ordinary reads): ${anyPhantom ? `STALENESS REACHES ORDINARY READS -- ${detail.join(', ')}` : 'CLEAN -- no phantom on any of the 5 surfaces'}`
+					);
+
+					strictEqual(
+						fs.totalCount,
+						KEEP_COUNT + CTRL_COUNT,
+						'POST-DELETE total row count must reflect the deletion exactly'
+					);
+					ok(
+						!anyPhantom,
+						`same-process ordinary-read staleness detected post-delete -- see finding 4 detail: ${detail.join(', ')}`
+					);
+				}
+			);
+
+			test(
+				'5. CONTRAST ARM (known-reproducing): audit purge in the SAME process -- does the F-225 phantom appear here too?',
+				{ timeout: 120_000 },
+				async () => {
+					const ack = await rawOp(ctx, {
+						operation: 'delete_transaction_logs_before',
+						schema: SCHEMA,
+						table: TABLE,
+						timestamp: cutoffTimestamp,
+					});
+					ok(
+						ack.status === 200 && ack.body?.job_id,
+						`delete_transaction_logs_before should return a job_id, got ${ack.text.slice(0, 300)}`
+					);
+					const jobResult = await pollJob(ctx, ack.body.job_id);
+					const entriesDeleted = jobResult.result?.entries_deleted ?? jobResult.result?.transactions_deleted ?? 0;
+					findings.push(`5. audit purge job: status=${jobResult.status} result=${JSON.stringify(jobResult.result)}`);
+					ok(
+						jobResult.status === 'COMPLETE',
+						`purge job should COMPLETE, got ${jobResult.status}: ${jobResult.message}`
+					);
+
+					const sampleId = `k${DEL_SAMPLE_IDX[0]}`; // k0 -- inserted well before cutoffTimestamp
+					const r = await rawOp(ctx, {
+						operation: 'read_audit_log',
+						schema: SCHEMA,
+						table: TABLE,
+						search_type: 'hash_value',
+						search_values: [sampleId],
+					});
+					ok(r.status === 200, `read_audit_log(${sampleId}) expected 200, got ${r.status}: ${r.text.slice(0, 300)}`);
+					const entries = Array.isArray(r.body?.[sampleId]) ? r.body[sampleId] : [];
+					const phantomAudit = entries.length > 0;
+
+					findings.push(
+						`5. entries_deleted=${entriesDeleted}; SAME-PROCESS read_audit_log(${sampleId}) post-purge: ` +
+							`${phantomAudit ? `PHANTOM (${entries.length} entries still returned, reproduces F-225)` : 'clean (no entries -- F-225 not reproduced this run)'}`
+					);
+					findings.push(
+						`5. CONTRAST: ordinary-reads verdict (test 4) vs audit-read verdict (this test) -- ` +
+							`if 4 is clean and this is PHANTOM, that is the sharpest possible bound: staleness is confined to the audit/txnlog path, not ordinary table reads, in the identical process.`
+					);
+					// Informational only -- F-225 is independently filed; this arm documents contrast,
+					// it does not re-litigate a known, already-tracked defect.
+					ok(true, `audit contrast arm recorded (phantom=${phantomAudit})`);
+				}
+			);
+
+			test(
+				'6. RESTART DISCRIMINATOR: kill + restart on identical dataRootDir, re-measure',
+				{ timeout: 120_000 },
+				async () => {
+					await killHarper(ctx as any);
+					await startHarper(ctx, { config: armConfig, env: { HARPER_STORAGE_ENGINE: engine } });
+					await pollReadiness(ctx);
+					findings.push(`6. restarted Harper on same dataRootDir; new pid=${ctx.harper.process.pid}`);
+
+					const delSampleIds = DEL_SAMPLE_IDX.map((i) => `k${i}`);
+					const keepSampleIds = KEEP_SAMPLE_IDX.map((i) => `k${i}`);
+
+					const { anyPhantom, detail } = await assertAbsentEverywhere(
+						ctx,
+						'6. POST-RESTART DEL samples',
+						delSampleIds,
+						'DEL',
+						findings
+					);
+					await assertPresentEverywhere(
+						ctx,
+						'6. POST-RESTART CTRL',
+						CTRL_IDS,
+						(seq) => ctrlPayload(seq),
+						(id) => 900_000 + CTRL_IDS.indexOf(id),
+						findings
+					);
+					await assertPresentEverywhere(
+						ctx,
+						'6. POST-RESTART KEEP samples',
+						keepSampleIds,
+						payloadFor,
+						(id) => Number(id.slice(1)),
+						findings
+					);
+
+					findings.push(
+						`6. VERDICT (post-restart): ${anyPhantom ? `UNEXPECTED -- staleness survives a restart -- ${detail.join(', ')}` : 'clean, as expected regardless of test 4 outcome'}`
+					);
+					findings.push(
+						`6. DISCRIMINATOR: same-process result (test 4) was ${'see finding 4'}; post-restart is ${anyPhantom ? 'ALSO PHANTOM' : 'clean'}. ` +
+							'If test 4 was already clean, this agreement is the confirmation the bound holds.'
+					);
+					ok(
+						!anyPhantom,
+						`post-restart ordinary-read staleness detected -- see finding 6 detail: ${detail.join(', ')}`
+					);
+				}
+			);
+		}
+	);
+}
+
+defineSuite('rocksdb');
+defineSuite('lmdb');

--- a/integrationTests/database/txnlog-purge-stale-read-blast.test.ts
+++ b/integrationTests/database/txnlog-purge-stale-read-blast.test.ts
@@ -208,6 +208,11 @@ async function flush(ctx: ContextWithHarper): Promise<void> {
 		headers: { Authorization: authHeader(ctx) },
 	});
 	ok(r.status === 200, `/Flush/ should succeed, got ${r.status}`);
+	const body = await r.json();
+	ok(
+		body.flushed === true,
+		`/Flush/ must actually flush the primary store (data would stay in the memtable), got ${JSON.stringify(body)}`
+	);
 }
 
 // ---- Per-surface probes --------------------------------------------------------------------
@@ -219,7 +224,11 @@ async function restGetById(
 	id: string
 ): Promise<{ present: boolean; seq?: number; payload?: string }> {
 	const r = await restGet(ctx, `/${TABLE}/${encodeURIComponent(id)}`);
-	if (r.status !== 200 || !r.body) return { present: false };
+	if (r.status === 404) return { present: false };
+	// Only 200 (present) or 404 (absent) are valid outcomes here -- a 5xx must fail loudly
+	// rather than silently read as "clean absence" (which would mask a server error as the
+	// very reclamation success this suite exists to verify).
+	ok(r.status === 200 && r.body, `REST GET ${id} expected 200 or 404, got ${r.status}: ${JSON.stringify(r.body)}`);
 	return { present: true, seq: r.body.seq, payload: r.body.payload };
 }
 

--- a/integrationTests/database/txnlog-purge-stale-read-blast.test.ts
+++ b/integrationTests/database/txnlog-purge-stale-read-blast.test.ts
@@ -268,11 +268,19 @@ async function fullScan(
 	return r.body;
 }
 
-/** Assert a set of ids is present+byte-correct on ALL FIVE surfaces. Used for the armed control + KEEP sanity. */
+/**
+ * Assert a set of ids is present+byte-correct on ALL FIVE surfaces. Used for the armed
+ * control + KEEP sanity -- these are the "clean means clean" half of the oracle: if a
+ * surface silently returned empty for everything (broken query, not a real absence), only a
+ * positive-control check on that SAME surface would catch it. `bucket` must be the bucket
+ * all `ids` share, since the three bucket-scoped surfaces (REST query, search_by_value, SQL)
+ * are queried by bucket rather than by id.
+ */
 async function assertPresentEverywhere(
 	ctx: ContextWithHarper,
 	label: string,
 	ids: string[],
+	bucket: string,
 	expectedPayload: (i: number) => string,
 	seqOf: (id: string) => number,
 	findings: string[]
@@ -285,6 +293,25 @@ async function assertPresentEverywhere(
 			`[${label}] REST GET ${id} must be present+correct, got ${JSON.stringify(g)}`
 		);
 	}
+
+	const queryHits = await restQueryBucket(ctx, bucket);
+	const queryIds = new Set(queryHits.map((r) => r.id));
+	const sbvHits = await searchByBucket(ctx, bucket);
+	const sbvIds = new Set(sbvHits.map((r) => r.id));
+	const sqlHits = await sqlByBucket(ctx, bucket);
+	const sqlIds = new Set(sqlHits.map((r) => r.id));
+	for (const id of ids) {
+		ok(
+			queryIds.has(id),
+			`[${label}] REST-QUERY bucket=${bucket} must include ${id}, got ${queryHits.length} hits`
+		);
+		ok(
+			sbvIds.has(id),
+			`[${label}] SEARCH-BY-VALUE bucket=${bucket} must include ${id}, got ${sbvHits.length} hits`
+		);
+		ok(sqlIds.has(id), `[${label}] SQL bucket=${bucket} must include ${id}, got ${sqlHits.length} hits`);
+	}
+
 	const fs = await fullScan(ctx, ids);
 	for (const id of ids) {
 		const seq = seqOf(id);
@@ -294,7 +321,7 @@ async function assertPresentEverywhere(
 			`[${label}] FullScan ${id} must be present+correct, got ${JSON.stringify(rec)}`
 		);
 	}
-	findings.push(`[${label}] present+byte-correct on REST GET + FullScan for ${ids.length} id(s): ${ids.join(',')}`);
+	findings.push(`[${label}] present+byte-correct on all 5 surfaces for ${ids.length} id(s): ${ids.join(',')}`);
 }
 
 /** Assert a set of ids is ABSENT on ALL FIVE surfaces. This is the headline bound check. */
@@ -451,11 +478,12 @@ function defineSuite(engine: 'rocksdb' | 'lmdb') {
 					const delSampleIds = DEL_SAMPLE_IDX.map((i) => `k${i}`);
 					const keepSampleIds = KEEP_SAMPLE_IDX.map((i) => `k${i}`);
 
-					// REST GET + FullScan for both sample sets.
+					// All five surfaces, for both sample sets.
 					await assertPresentEverywhere(
 						ctx,
 						'PRE-DELETE DEL samples',
 						delSampleIds,
+						'DEL',
 						payloadFor,
 						(id) => Number(id.slice(1)),
 						findings
@@ -464,6 +492,7 @@ function defineSuite(engine: 'rocksdb' | 'lmdb') {
 						ctx,
 						'PRE-DELETE KEEP samples',
 						keepSampleIds,
+						'KEEP',
 						payloadFor,
 						(id) => Number(id.slice(1)),
 						findings
@@ -472,6 +501,7 @@ function defineSuite(engine: 'rocksdb' | 'lmdb') {
 						ctx,
 						'PRE-DELETE CTRL',
 						CTRL_IDS,
+						'CTRL',
 						(seq) => ctrlPayload(seq),
 						(id) => 900_000 + CTRL_IDS.indexOf(id),
 						findings
@@ -550,6 +580,7 @@ function defineSuite(engine: 'rocksdb' | 'lmdb') {
 						ctx,
 						'4. POST-DELETE CTRL (armed control)',
 						CTRL_IDS,
+						'CTRL',
 						(seq) => ctrlPayload(seq),
 						(id) => 900_000 + CTRL_IDS.indexOf(id),
 						findings
@@ -559,6 +590,7 @@ function defineSuite(engine: 'rocksdb' | 'lmdb') {
 						ctx,
 						'4. POST-DELETE KEEP samples',
 						keepSampleIds,
+						'KEEP',
 						payloadFor,
 						(id) => Number(id.slice(1)),
 						findings
@@ -615,11 +647,19 @@ function defineSuite(engine: 'rocksdb' | 'lmdb') {
 					});
 					ok(r.status === 200, `read_audit_log(${sampleId}) expected 200, got ${r.status}: ${r.text.slice(0, 300)}`);
 					const entries = Array.isArray(r.body?.[sampleId]) ? r.body[sampleId] : [];
-					const phantomAudit = entries.length > 0;
+					// k0's history has TWO entries: the original insert (timestamp < cutoffTimestamp,
+					// the one the purge targets) and the test-3 bulk delete (timestamp > cutoffTimestamp,
+					// since it happened after the cutoff was captured in test 1). The delete entry is
+					// NOT purge-eligible and legitimately survives -- only a still-present pre-cutoff
+					// entry is evidence of F-225 staleness. Counting any entry as "phantom" would flag
+					// this arm as reproducing F-225 on every run, purge bug or not.
+					const stalePreCutoffEntries = entries.filter((e: any) => Number(e.timestamp) < cutoffTimestamp);
+					const phantomAudit = stalePreCutoffEntries.length > 0;
 
 					findings.push(
 						`5. entries_deleted=${entriesDeleted}; SAME-PROCESS read_audit_log(${sampleId}) post-purge: ` +
-							`${phantomAudit ? `PHANTOM (${entries.length} entries still returned, reproduces F-225)` : 'clean (no entries -- F-225 not reproduced this run)'}`
+							`${entries.length} total entries, ${stalePreCutoffEntries.length} pre-cutoff -- ` +
+							`${phantomAudit ? `PHANTOM (${stalePreCutoffEntries.length} pre-cutoff entries still returned, reproduces F-225)` : 'clean (no pre-cutoff entries -- F-225 not reproduced this run)'}`
 					);
 					findings.push(
 						`5. CONTRAST: ordinary-reads verdict (test 4) vs audit-read verdict (this test) -- ` +
@@ -654,6 +694,7 @@ function defineSuite(engine: 'rocksdb' | 'lmdb') {
 						ctx,
 						'6. POST-RESTART CTRL',
 						CTRL_IDS,
+						'CTRL',
 						(seq) => ctrlPayload(seq),
 						(id) => 900_000 + CTRL_IDS.indexOf(id),
 						findings
@@ -662,6 +703,7 @@ function defineSuite(engine: 'rocksdb' | 'lmdb') {
 						ctx,
 						'6. POST-RESTART KEEP samples',
 						keepSampleIds,
+						'KEEP',
 						payloadFor,
 						(id) => Number(id.slice(1)),
 						findings

--- a/integrationTests/database/txnlog-purge-stale-read-blast.test.ts
+++ b/integrationTests/database/txnlog-purge-stale-read-blast.test.ts
@@ -202,17 +202,22 @@ async function seedRange(ctx: ContextWithHarper, start: number, count: number, b
 	}
 }
 
-async function flush(ctx: ContextWithHarper): Promise<void> {
+async function flush(ctx: ContextWithHarper, engine: 'rocksdb' | 'lmdb'): Promise<void> {
 	const r = await fetch(`${ctx.harper.httpURL}/Flush/`, {
 		method: 'POST',
 		headers: { Authorization: authHeader(ctx) },
 	});
 	ok(r.status === 200, `/Flush/ should succeed, got ${r.status}`);
 	const body = await r.json();
-	ok(
-		body.flushed === true,
-		`/Flush/ must actually flush the primary store (data would stay in the memtable), got ${JSON.stringify(body)}`
-	);
+	// Only meaningful on rocksdb: LMDB has no memtable to force to disk, so the fixture's
+	// Flush resource legitimately reports flushed=false there (primaryStore.flush is not a
+	// function) -- that is not the "silently did nothing" gap this assertion exists to catch.
+	if (engine === 'rocksdb') {
+		ok(
+			body.flushed === true,
+			`/Flush/ must actually flush the primary store (data would stay in the memtable), got ${JSON.stringify(body)}`
+		);
+	}
 }
 
 // ---- Per-surface probes --------------------------------------------------------------------
@@ -442,17 +447,17 @@ function defineSuite(engine: 'rocksdb' | 'lmdb') {
 			test('1. seed DEL (6000) + KEEP (6000) ranges, force flushes between waves', { timeout: 300_000 }, async () => {
 				// Flush every 2000 rows so data is genuinely on disk, not just resident in the memtable.
 				await seedRange(ctx, 0, 2000, 'DEL');
-				await flush(ctx);
+				await flush(ctx, engine);
 				await seedRange(ctx, 2000, 2000, 'DEL');
-				await flush(ctx);
+				await flush(ctx, engine);
 				await seedRange(ctx, 4000, 2000, 'DEL');
-				await flush(ctx);
+				await flush(ctx, engine);
 				await seedRange(ctx, 6000, 2000, 'KEEP');
-				await flush(ctx);
+				await flush(ctx, engine);
 				await seedRange(ctx, 8000, 2000, 'KEEP');
-				await flush(ctx);
+				await flush(ctx, engine);
 				await seedRange(ctx, 10000, 2000, 'KEEP');
-				await flush(ctx);
+				await flush(ctx, engine);
 
 				cutoffTimestamp = Date.now();
 				await sleep(250);
@@ -470,7 +475,7 @@ function defineSuite(engine: 'rocksdb' | 'lmdb') {
 					ctrlRes.status === 200,
 					`control insert should succeed, got ${ctrlRes.status}: ${ctrlRes.text.slice(0, 300)}`
 				);
-				await flush(ctx);
+				await flush(ctx, engine);
 
 				const diskStats = txnLogStats(dataRootDir);
 				findings.push(

--- a/integrationTests/database/txnlog-purge-stale-read-blast.test.ts
+++ b/integrationTests/database/txnlog-purge-stale-read-blast.test.ts
@@ -149,6 +149,7 @@ async function pollJob(ctx: ContextWithHarper, jobId: string, timeoutMs = 60_000
 	let last: any;
 	while (Date.now() < deadline) {
 		const r = await rawOp(ctx, { operation: 'get_job', id: jobId });
+		strictEqual(r.status, 200, `get_job(${jobId}) failed: ${r.text.slice(0, 300)}`);
 		last = Array.isArray(r.body) ? r.body[0] : r.body;
 		if (last?.status === 'COMPLETE' || last?.status === 'ERROR') return last;
 		await sleep(500);
@@ -635,6 +636,10 @@ function defineSuite(engine: 'rocksdb' | 'lmdb') {
 					ok(
 						jobResult.status === 'COMPLETE',
 						`purge job should COMPLETE, got ${jobResult.status}: ${jobResult.message}`
+					);
+					ok(
+						entriesDeleted > 0,
+						`NON-VACUOUS PRECONDITION: audit purge job must report entries_deleted > 0, got ${entriesDeleted}`
 					);
 
 					const sampleId = `k${DEL_SAMPLE_IDX[0]}`; // k0 -- inserted well before cutoffTimestamp

--- a/integrationTests/database/txnlog-purge-stale-read-blast.test.ts
+++ b/integrationTests/database/txnlog-purge-stale-read-blast.test.ts
@@ -305,15 +305,28 @@ async function assertPresentEverywhere(
 	}
 
 	const queryHits = await restQueryBucket(ctx, bucket);
-	const queryIds = new Set(queryHits.map((r) => r.id));
+	const queryById = new Map(queryHits.map((r) => [r.id, r]));
 	const sbvHits = await searchByBucket(ctx, bucket);
-	const sbvIds = new Set(sbvHits.map((r) => r.id));
+	const sbvById = new Map(sbvHits.map((r) => [r.id, r]));
 	const sqlHits = await sqlByBucket(ctx, bucket);
-	const sqlIds = new Set(sqlHits.map((r) => r.id));
+	const sqlById = new Map(sqlHits.map((r) => [r.id, r]));
 	for (const id of ids) {
-		ok(queryIds.has(id), `[${label}] REST-QUERY bucket=${bucket} must include ${id}, got ${queryHits.length} hits`);
-		ok(sbvIds.has(id), `[${label}] SEARCH-BY-VALUE bucket=${bucket} must include ${id}, got ${sbvHits.length} hits`);
-		ok(sqlIds.has(id), `[${label}] SQL bucket=${bucket} must include ${id}, got ${sqlHits.length} hits`);
+		const seq = seqOf(id);
+		const queryHit = queryById.get(id);
+		ok(
+			queryHit && queryHit.payload === expectedPayload(seq),
+			`[${label}] REST-QUERY bucket=${bucket} must include ${id} present+correct, got ${JSON.stringify(queryHit)} (${queryHits.length} hits)`
+		);
+		const sbvHit = sbvById.get(id);
+		ok(
+			sbvHit && sbvHit.payload === expectedPayload(seq),
+			`[${label}] SEARCH-BY-VALUE bucket=${bucket} must include ${id} present+correct, got ${JSON.stringify(sbvHit)} (${sbvHits.length} hits)`
+		);
+		const sqlHit = sqlById.get(id);
+		ok(
+			sqlHit && sqlHit.payload === expectedPayload(seq),
+			`[${label}] SQL bucket=${bucket} must include ${id} present+correct, got ${JSON.stringify(sqlHit)} (${sqlHits.length} hits)`
+		);
 	}
 
 	const fs = await fullScan(ctx, ids);
@@ -623,6 +636,32 @@ function defineSuite(engine: 'rocksdb' | 'lmdb') {
 				'5. CONTRAST ARM (known-reproducing): audit purge in the SAME process -- does the F-225 phantom appear here too?',
 				{ timeout: 120_000 },
 				async () => {
+					const sampleId = `k${DEL_SAMPLE_IDX[0]}`; // k0 -- inserted well before cutoffTimestamp
+
+					// WARM the transaction-log cache for this key BEFORE the purge, mirroring the WARM
+					// step used for the other four surfaces (test 2). QA-781 root-caused F-225 to a
+					// stale WeakRef cache (`TransactionLog._logBuffers`) that outlives a purge -- a
+					// cache that was never populated can't go stale, so reading only AFTER the purge
+					// (as this arm previously did) can pass "clean" for having nothing to go stale,
+					// not because the purge correctly invalidated a live cache entry. That would make
+					// the "known-reproducing" claim vacuous.
+					const preWarm = await rawOp(ctx, {
+						operation: 'read_audit_log',
+						schema: SCHEMA,
+						table: TABLE,
+						search_type: 'hash_value',
+						search_values: [sampleId],
+					});
+					ok(
+						preWarm.status === 200,
+						`WARM read_audit_log(${sampleId}) expected 200, got ${preWarm.status}: ${preWarm.text.slice(0, 300)}`
+					);
+					const preWarmEntries = Array.isArray(preWarm.body?.[sampleId]) ? preWarm.body[sampleId] : [];
+					ok(
+						preWarmEntries.some((e: any) => Number(e.timestamp) < cutoffTimestamp),
+						`NON-VACUOUS PRECONDITION: WARM read_audit_log(${sampleId}) must see the pre-cutoff insert entry before the purge, got ${JSON.stringify(preWarmEntries)}`
+					);
+
 					const ack = await rawOp(ctx, {
 						operation: 'delete_transaction_logs_before',
 						schema: SCHEMA,
@@ -645,7 +684,6 @@ function defineSuite(engine: 'rocksdb' | 'lmdb') {
 						`NON-VACUOUS PRECONDITION: audit purge job must report entries_deleted > 0, got ${entriesDeleted}`
 					);
 
-					const sampleId = `k${DEL_SAMPLE_IDX[0]}`; // k0 -- inserted well before cutoffTimestamp
 					const r = await rawOp(ctx, {
 						operation: 'read_audit_log',
 						schema: SCHEMA,

--- a/integrationTests/database/txnlog-purge-stale-read-blast.test.ts
+++ b/integrationTests/database/txnlog-purge-stale-read-blast.test.ts
@@ -302,14 +302,8 @@ async function assertPresentEverywhere(
 	const sqlHits = await sqlByBucket(ctx, bucket);
 	const sqlIds = new Set(sqlHits.map((r) => r.id));
 	for (const id of ids) {
-		ok(
-			queryIds.has(id),
-			`[${label}] REST-QUERY bucket=${bucket} must include ${id}, got ${queryHits.length} hits`
-		);
-		ok(
-			sbvIds.has(id),
-			`[${label}] SEARCH-BY-VALUE bucket=${bucket} must include ${id}, got ${sbvHits.length} hits`
-		);
+		ok(queryIds.has(id), `[${label}] REST-QUERY bucket=${bucket} must include ${id}, got ${queryHits.length} hits`);
+		ok(sbvIds.has(id), `[${label}] SEARCH-BY-VALUE bucket=${bucket} must include ${id}, got ${sbvHits.length} hits`);
 		ok(sqlIds.has(id), `[${label}] SQL bucket=${bucket} must include ${id}, got ${sqlHits.length} hits`);
 	}
 

--- a/integrationTests/database/txnlog-purge-stale-read-blast/config.yaml
+++ b/integrationTests/database/txnlog-purge-stale-read-blast/config.yaml
@@ -1,0 +1,5 @@
+graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/database/txnlog-purge-stale-read-blast/resources.js
+++ b/integrationTests/database/txnlog-purge-stale-read-blast/resources.js
@@ -1,0 +1,72 @@
+// QA-782 fixture resources — bound the blast radius of F-225 (in-process stale-read cache
+// after a RocksDB audit-purge, root-caused in QA-781 to rocksdb-js's TransactionLog
+// `_logBuffers` mmap cache) beyond the audit/txnlog path. Only two custom endpoints are
+// needed: everything else (REST record GET, REST collection query, search_by_value, SQL,
+// read_audit_log, delete_transaction_logs_before) is a standard Harper surface hit directly
+// from the test.
+//
+// StorageEngineInfo: same engine-detection shape as QA-779/QA-787 (looksLikeLmdbPath vs
+// hasPurgeLogs), reused verbatim so the precondition check is proven, not assumed.
+//
+// FullScan: the index-independent oracle. Walks tables.Widget.search({}) with NO
+// conditions (a genuine primary-store scan, bypassing the @indexed `bucket` path entirely)
+// and reports total row count plus presence/value for a requested id list, so a stale
+// cache that only affects the index (or only affects point lookups) can't hide from it.
+
+export class Probe extends Resource {
+	static loadAsInstance = false;
+	async get() {
+		return { ok: true };
+	}
+}
+
+export class StorageEngineInfo extends Resource {
+	static loadAsInstance = false;
+	async get() {
+		const t = tables['Widget'];
+		if (!t) throw new Error('QA-782: table Widget not found');
+		const primaryPath = t.primaryStore?.path || t.primaryStore?.rootStore?.path || null;
+		const looksLikeLmdbPath = typeof primaryPath === 'string' && primaryPath.endsWith('.mdb');
+		const hasPurgeLogs = typeof t.primaryStore?.rootStore?.purgeLogs === 'function';
+		return {
+			primaryPath,
+			looksLikeLmdbPath,
+			hasPurgeLogs,
+			engineGuess: looksLikeLmdbPath ? 'lmdb' : hasPurgeLogs ? 'rocksdb' : 'unknown',
+		};
+	}
+}
+
+export class Flush extends Resource {
+	static loadAsInstance = false;
+	async post() {
+		const t = tables['Widget'];
+		if (!t || typeof t.primaryStore.flush !== 'function') {
+			return { ok: true, flushed: false };
+		}
+		await t.primaryStore.flush();
+		return { ok: true, flushed: true };
+	}
+}
+
+// GET /FullScan/?ids=k1,k2,... -> { totalCount, records: { id: {seq,bucket,payload} | null } }
+// Index-independent full primary-store scan (the ground-truth oracle).
+export class FullScan extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		// `query` extends URLSearchParams -- must use .get(), plain property access is always
+		// undefined (same trap documented in QA-787/QA-781 fixtures).
+		const ids = String(query?.get?.('ids') ?? '')
+			.split(',')
+			.filter(Boolean);
+		const idSet = new Set(ids);
+		let totalCount = 0;
+		const records = {};
+		for await (const r of tables.Widget.search({})) {
+			totalCount++;
+			if (idSet.has(r.id)) records[r.id] = { seq: r.seq, bucket: r.bucket, payload: r.payload };
+		}
+		for (const id of ids) if (!(id in records)) records[id] = null;
+		return { totalCount, records };
+	}
+}

--- a/integrationTests/database/txnlog-purge-stale-read-blast/schema.graphql
+++ b/integrationTests/database/txnlog-purge-stale-read-blast/schema.graphql
@@ -1,0 +1,11 @@
+# QA-782 — bound the blast radius of F-225 (in-process stale-read cache after a RocksDB
+# audit-purge). `bucket` is @indexed so the same delete can be probed via search_by_value,
+# a REST collection query, and SQL, all against the SAME contiguous key range that gets
+# bulk-deleted from the ordinary (non-audit) primary store. `audit: true` also lets the
+# same table run the KNOWN-reproducing audit-purge arm for direct in-process contrast.
+type Widget @table(audit: true) @export {
+	id: ID @primaryKey
+	bucket: String @indexed
+	seq: Int
+	payload: String
+}


### PR DESCRIPTION
Test-only. Promotes three exploratory QA specs into `integrationTests/database/` as permanent regression anchors. No product code is touched.

All three pin one class of invariant: **after an operation that removes data, both the disk and the read surfaces must end up correct.** Each was found by the exploratory QA loop, then gated (cold rerun at the promoted path, non-duplicative vs. the closest existing suite test, format/lint clean) before landing here.

## What each spec pins

**`txnlog-purge-stale-read-blast.test.ts`** (from QA-782, `source:F-225`) — bounds the blast radius of F-225. After a bulk delete of a 6000-row contiguous key range, all five ordinary read surfaces (REST GET, REST query, `search_by_value`, SQL, full scan) must be clean **in the same process**, while the audit-read path is separately shown to still return purged rows. That contrast is the point: it pins staleness as **confined to the audit/txnlog path** and *not* reaching ordinary table reads. Runs both engines in-file (engine set per arm), with an armed positive control (`CTRL` bucket inserted after the cutoff) and a restart discriminator. 14 tests, ~14 s.

The closest existing test, `apiTests/transaction-logs.test.mjs`, covers happy-path reads and a *no-op* purge — nothing in the suite drives a real purge and then re-reads ordinary surfaces, which is why this gap went uncaught.

**`blob-delete-reclaim-audit-expiry.test.ts`** (from QA-802, `source:gh:708`) — deleting a blob-bearing record must reclaim its file from disk, regardless of audit retention. N=20 × 256 KB blobs stored, deleted via SQL, with the blob tree under `{dataRootDir}/blobs/data` walked directly for file count and bytes, sampled across the `deletionDelay`, the `auditRetention` window, a hard restart, and an explicit `cleanup_orphan_blobs`. Asserts net leak 0. Arm B is a negative control: audit-only expiry against a **live** record (6 overwrites aged past retention) must leave exactly one byte-intact file. 3 tests, ~53 s.

This **refutes harper#708's claim on the delete path.** Note the engine scope, called out in the file header: in CI this pins the default engine (RocksDB) only, because `HARPER_STORAGE_ENGINE` is process-wide. The LMDB leg was run manually during QA and also showed zero net leak — that is recorded as QA evidence, not asserted here. `#1916`'s `audit-blob-reclaim.test.ts` pins the *overwrite* side; this pins the *delete* side and the `cleanup_orphan_blobs` operator surface.

**`blob-drop-crash-orphan-window.test.ts`** (from QA-809) — blob files orphaned by a crash inside `drop_table`'s unlink window must be reclaimable, and `drop_database` must never leak. Sweeps kill delays (k0/k100/k400/k600) around the drop, plus a no-kill control and two `drop_database` arms. 8 tests, ~79 s.

Two things were deliberately kept as **logged observations rather than assertions**, because asserting them would freeze current behaviour as required: that the unlink window exists at all (a fix that unlinks synchronously would close it — an improvement), and whether restart-recovery happens to reclaim (empirically arm-dependent: `false` at k0/k100, `true` at k400/k600, so it would have been flaky). The asserted invariants are the ones that survive any fix to the drop path: orphans are reclaimable after `cleanup_orphan_blobs`, and `drop_database` leaves 0 blob files at every checkpoint.

## Verification

Cold rerun at the promoted paths on `main` @ `80ef45996`, then re-run again after the header edits in this PR:

| Spec | Result | Wall |
|---|---|---|
| `txnlog-purge-stale-read-blast` | 14/14 | ~14 s |
| `blob-delete-reclaim-audit-expiry` | 3/3 | ~53 s |
| `blob-drop-crash-orphan-window` | 8/8 | ~79 s |

`prettier --check` clean and `oxlint --deny-warnings` exit 0, both run from inside the repo tree. No `restartHttpWorkers()` (all three poll the probe route directly for non-404). No absolute developer-machine paths. All three carry an arming assertion that fails if the disk oracle cannot measure, so none can pass vacuously.

⚠️ **Reviewer note on runtime:** `blob-drop-crash-orphan-window` (~79 s) and `blob-delete-reclaim-audit-expiry` (~53 s) are on the slower side, dominated by deliberate settle/retention windows rather than by assertion count. Both are `requires-isolation` (they kill and restart the instance in place), so they cannot share a host instance with other specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
