### PR TITLE
fix(resources): store the real prior version for LMDB audit entries

### DIFF
--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -851,7 +851,7 @@ export function recordUpdater(store, tableId, auditStore) {
 						version: newVersion,
 						tableId,
 						recordId: id,
-						previousVersion: existingEntry?.localTime,
+						previousVersion: isRocksDB ? existingEntry?.version : existingEntry?.localTime,
 						nodeId,
 						user: username,
 						type,

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -851,7 +851,7 @@ export function recordUpdater(store, tableId, auditStore) {
 						version: newVersion,
 						tableId,
 						recordId: id,
-						previousVersion: existingEntry?.version,
+						previousVersion: existingEntry?.localTime,
 						nodeId,
 						user: username,
 						type,

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -851,7 +851,7 @@ export function recordUpdater(store, tableId, auditStore) {
 						version: newVersion,
 						tableId,
 						recordId: id,
-						previousVersion: store instanceof RocksDatabase ? existingEntry?.version : existingEntry?.localTime ? 1 : 0,
+						previousVersion: existingEntry?.version,
 						nodeId,
 						user: username,
 						type,

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -113,6 +113,24 @@ describe('Audit log', () => {
 		assert.equal(history[0].user, key.toString());
 		assert.deepEqual(history[0].value.id, key);
 	});
+	it('audit entries chain to the real prior version, not a placeholder flag', async () => {
+		const id = 'previous-version-chain';
+		await AuditedTable.put(id, { name: 'v1' });
+		await AuditedTable.put(id, { name: 'v2' });
+		await AuditedTable.put(id, { name: 'v3' });
+		const entries = [];
+		for (const entry of AuditedTable.auditStore.getRange({ start: 1 })) {
+			if (entry.tableId === AuditedTable.tableId && entry.recordId === id) entries.push(entry);
+		}
+		entries.sort((a, b) => a.version - b.version);
+		assert.equal(entries.length, 3);
+		// The first write has no prior entry, so previousVersion is falsy.
+		assert(!entries[0].previousVersion);
+		// Each later entry's previousVersion must point at the actual prior entry's version, not a
+		// 0/1 placeholder flag substituted from a shared per-environment register.
+		assert.equal(entries[1].previousVersion, entries[0].version);
+		assert.equal(entries[2].previousVersion, entries[1].version);
+	});
 	it('dynamically add new transaction logs to iterator', async function () {
 		if (!AuditedTable.auditStore.reusableIterable) return this.skip(); // only for rocksdb
 

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -138,10 +138,11 @@ describe('Audit log', () => {
 		);
 	});
 	// LMDB assigns each record's own localTime via lmdb-js's native monotonic clock, independent of
-	// the application-supplied `version` (e.g. a replicated write's origin timestamp, which can be
-	// backdated relative to this node's clock). previousVersion must point at the prior entry's
-	// localTime (the actual audit-store key space), not its origin version, or a replicated record's
-	// history becomes unwalkable.
+	// the application-supplied `version` (e.g. a replicated/out-of-order write's origin timestamp,
+	// which can be backdated relative to this node's clock). previousVersion must point at the prior
+	// entry's localTime (the actual audit-store key space getHistoryOfRecord pages through), not its
+	// origin version, or a replicated record's history becomes unwalkable once entries are more than
+	// the 100 ms audit window apart.
 	it('previousVersion resolves correctly even when a write carries a backdated/replicated version', async () => {
 		const id = 'replicated-version-chain';
 		const originVersion = Date.now() - 100_000;
@@ -152,6 +153,33 @@ describe('Audit log', () => {
 		const resolvedFirst = AuditedTable.auditStore.get(secondAudit.previousVersion, AuditedTable.tableId, id);
 		assert(resolvedFirst, 'previousVersion must resolve to the actual first audit entry');
 		assert.equal(resolvedFirst.version, originVersion);
+	});
+	// Same scenario driven through the real production consumer: Table.getHistoryOfRecord pages
+	// backward through the audit log in 100 ms windows, using each entry's previousVersion as the
+	// next window's boundary. With backdated/replicated-style origin versions spaced well beyond that
+	// window, a previousVersion in the wrong (origin-version) key space would jump the walk past the
+	// prior entry's real audit-store key and truncate the history.
+	it('getHistoryOfRecord walks the full chain for out-of-order writes spaced beyond the audit window', async () => {
+		const id = 'replicated-history-chain';
+		// Each write's *origin* version is deliberately backdated far from real time (simulating a
+		// replicated/out-of-order apply), while the *real* delay between writes spans multiple 100 ms
+		// audit windows in the actual local-time key space. A previousVersion pinned to the backdated
+		// origin version (instead of the real local audit-store key) would have getHistoryOfRecord's
+		// window walk search near the backdated timestamp, find nothing, and truncate the chain.
+		const origin = Date.now() - 100_000;
+		await AuditedTable.put(id, { name: 'v1' }, { timestamp: origin });
+		await delay(150);
+		await AuditedTable.put(id, { name: 'v2' }, { timestamp: origin + 1 });
+		await delay(150);
+		await AuditedTable.put(id, { name: 'v3' }, { timestamp: origin + 2 });
+		await delay(150);
+		await AuditedTable.put(id, { name: 'v4' }, { timestamp: origin + 3 });
+		const history = await AuditedTable.getHistoryOfRecord(id);
+		assert.equal(history.length, 4);
+		assert.deepEqual(
+			history.map((entry) => entry.value.name),
+			['v1', 'v2', 'v3', 'v4']
+		);
 	});
 	it('dynamically add new transaction logs to iterator', async function () {
 		if (!AuditedTable.auditStore.reusableIterable) return this.skip(); // only for rocksdb

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -113,7 +113,7 @@ describe('Audit log', () => {
 		assert.equal(history[0].user, key.toString());
 		assert.deepEqual(history[0].value.id, key);
 	});
-	it('audit entries chain to the real prior version, not a placeholder flag', async () => {
+	it('audit entries chain to the real prior audit-store key, not a placeholder flag', async () => {
 		const id = 'previous-version-chain';
 		await AuditedTable.put(id, { name: 'v1' });
 		await AuditedTable.put(id, { name: 'v2' });
@@ -126,10 +126,32 @@ describe('Audit log', () => {
 		assert.equal(entries.length, 3);
 		// The first write has no prior entry, so previousVersion is falsy.
 		assert(!entries[0].previousVersion);
-		// Each later entry's previousVersion must point at the actual prior entry's version, not a
-		// 0/1 placeholder flag substituted from a shared per-environment register.
-		assert.equal(entries[1].previousVersion, entries[0].version);
-		assert.equal(entries[2].previousVersion, entries[1].version);
+		// Each later entry's previousVersion must point at the actual prior entry's own audit-store
+		// key (localTime on LMDB; RocksDB's version field already *is* its key), not a 0/1 placeholder
+		// flag substituted from a shared per-environment register. Resolving it through the audit
+		// store proves the chain is walkable, not just numerically similar.
+		assert.equal(entries[1].previousVersion, entries[0].localTime ?? entries[0].version);
+		assert.equal(entries[2].previousVersion, entries[1].localTime ?? entries[1].version);
+		assert(
+			AuditedTable.auditStore.get(entries[1].previousVersion, AuditedTable.tableId, id),
+			'previousVersion must resolve back to the actual prior audit entry'
+		);
+	});
+	// LMDB assigns each record's own localTime via lmdb-js's native monotonic clock, independent of
+	// the application-supplied `version` (e.g. a replicated write's origin timestamp, which can be
+	// backdated relative to this node's clock). previousVersion must point at the prior entry's
+	// localTime (the actual audit-store key space), not its origin version, or a replicated record's
+	// history becomes unwalkable.
+	it('previousVersion resolves correctly even when a write carries a backdated/replicated version', async () => {
+		const id = 'replicated-version-chain';
+		const originVersion = Date.now() - 100_000;
+		await AuditedTable.put(id, { name: 'first' }, { timestamp: originVersion });
+		await AuditedTable.put(id, { name: 'second' }, { timestamp: originVersion + 1 });
+		const secondEntry = AuditedTable.primaryStore.getEntry(id);
+		const secondAudit = AuditedTable.auditStore.get(secondEntry.localTime, AuditedTable.tableId, id);
+		const resolvedFirst = AuditedTable.auditStore.get(secondAudit.previousVersion, AuditedTable.tableId, id);
+		assert(resolvedFirst, 'previousVersion must resolve to the actual first audit entry');
+		assert.equal(resolvedFirst.version, originVersion);
 	});
 	it('dynamically add new transaction logs to iterator', async function () {
 		if (!AuditedTable.auditStore.reusableIterable) return this.skip(); // only for rocksdb

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -364,7 +364,10 @@ describe('Caching', () => {
 			}
 			assert.equal(results.length, 1); // stale row served without waiting on source
 			assert.equal(results[0].id, 23);
-			assert.equal(sourceRequests, 1); // background revalidation was started
+			// The background revalidation is kicked off after the query already returned the stale
+			// row, so it may not have started yet on this tick (racy on a loaded CI runner) — poll
+			// for it instead, matching the same pattern used for the single-record path above.
+			await waitFor(() => sourceRequests === 1, { message: 'background revalidation should have started' });
 			assert.equal(sourceResponses, 0); // and the query did NOT block on it (response still gated)
 			assert(releaseSource, 'the source revalidation should be in-flight (gated)');
 			releaseSource(); // now let the background revalidation complete


### PR DESCRIPTION
## What / why

`RecordEncoder.ts:854` handed LMDB a boolean `0`/`1` flag as `previousVersion` where RocksDB got the real prior version. A flag of `1` sends the write down `auditStore.ts`'s placeholder-sentinel branch, where lmdb-js's native writer substitutes the value from a per-*environment* register rather than this record's true prior version. Since `getHistoryOfRecord` (Table.ts) walks `previousVersion` backward to page through audit-log windows, a corrupted pointer breaks audit-history reconstruction.

**Fix (revised after review):** `previousVersion: isRocksDB ? existingEntry?.version : existingEntry?.localTime`. My first pass used `existingEntry?.version` uniformly, on the assumption that `version` and `localTime` are the same field for both engines — true for RocksDB (its local timestamp is explicitly forced to equal `version` at write time), but **not** for LMDB: lmdb-js assigns `localTime` via its own native monotonic clock, independent of the caller-supplied `version`. For a replicated/out-of-order write carrying a backdated origin version (clock skew, catch-up replay), the two diverge arbitrarily, and LMDB's audit store is keyed by `localTime`, not `version` — so a `.version`-based pointer doesn't resolve to any real audit entry. Both Codex's independent pre-push review and @kriszyp's review caught this; details in the review thread.

Refs #F-249 (qa-wave-2026072900)

## Test plan
- `unitTests/resources/auditLog.test.js`:
  - "audit entries chain to the real prior audit-store key, not a placeholder flag" — 3 plain sequential writes; asserts each entry's `previousVersion` resolves via `auditStore.get()` to the true prior entry's own key. Fails on the original 0/1-flag code (decodes to a plausible-but-wrong float), passes with the fix, on both engines.
  - "previousVersion resolves correctly even when a write carries a backdated/replicated version" — explicit backdated `timestamp:`, confirms resolution through `auditStore.get()`. Fails against a `.version`-based fix (the bug this review round caught).
  - "getHistoryOfRecord walks the full chain for out-of-order writes spaced beyond the audit window" — backdated origin versions plus real `delay(150)` between writes so entries genuinely span multiple 100ms audit windows, asserted through the real production consumer (`Table.getHistoryOfRecord`). Reproduces the actual failure mode (truncates to 1 entry instead of 4) against a `.version`-based fix.
- `npm run build`, `npm run test:unit:resources` (both engines), `npm run test:unit:main`, `npm run format:write`, `npm run lint:required` all clean. The 10 pre-existing `globalIsolation.test.js` failures are present on `origin/main` too — unrelated to this change.

## Review history
- Codex's first pre-push pass (sha a37ba38f0) flagged a blocker on the `.version`-based fix; I initially misjudged it as a false alarm (verified `version`/`localTime` equal in a non-explicit-timestamp scenario) and pushed anyway.
- Codex's second pass (sha a1ca66208) and @kriszyp's review both independently confirmed the blocker with concrete repros using backdated `timestamp:` writes, which is what exposed the divergence. Fixed in b191a5ce8 — see the resolved review threads and the PR comment for the full root-cause writeup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
