### PR TITLE
chore: migrate to @harperfast/code-guidelines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,7 @@
 				"harper": "dist/bin/harper.js"
 			},
 			"devDependencies": {
-				"@harperdb/code-guidelines": "^0.0.6",
+				"@harperfast/code-guidelines": "^0.1.1",
 				"@harperfast/integration-testing": "^0.6.2",
 				"@modelcontextprotocol/sdk": "^1.29.0",
 				"@types/busboy": "^1.5.4",
@@ -2125,10 +2125,10 @@
 				"@hapi/hoek": "^9.0.0"
 			}
 		},
-		"node_modules/@harperdb/code-guidelines": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/@harperdb/code-guidelines/-/code-guidelines-0.0.6.tgz",
-			"integrity": "sha512-fHrhVw17A9gdP0K2J7s/5mP397obG4KFFm6cSGikaUetUU5sFps3/jUj23cexpTkakEOdgGnn5l3Q5TV1eBLCA==",
+		"node_modules/@harperfast/code-guidelines": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/code-guidelines/-/code-guidelines-0.1.1.tgz",
+			"integrity": "sha512-NgYNRfNtbTGm8JFja5sLFzDD9e6WyeYVuGbnvVhp7rw9vRpAMrDYky27n1RkHTwEvnai2j6hQfm4XwmMH89Wvg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -2145,8 +2145,10 @@
 				"typescript": ">= 5.9"
 			}
 		},
-		"node_modules/@harperdb/code-guidelines/node_modules/@typescript-eslint/eslint-plugin": {
+		"node_modules/@harperfast/code-guidelines/node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "8.44.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.0.tgz",
+			"integrity": "sha512-EGDAOGX+uwwekcS0iyxVDmRV9HX6FLSM5kzrAToLTsr9OWCIKG/y3lQheCq18yZ5Xh78rRKJiEpP0ZaCs4ryOQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2173,8 +2175,10 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
-		"node_modules/@harperdb/code-guidelines/node_modules/@typescript-eslint/parser": {
+		"node_modules/@harperfast/code-guidelines/node_modules/@typescript-eslint/parser": {
 			"version": "8.44.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.0.tgz",
+			"integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2196,8 +2200,10 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
-		"node_modules/@harperdb/code-guidelines/node_modules/@typescript-eslint/project-service": {
+		"node_modules/@harperfast/code-guidelines/node_modules/@typescript-eslint/project-service": {
 			"version": "8.44.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.0.tgz",
+			"integrity": "sha512-ZeaGNraRsq10GuEohKTo4295Z/SuGcSq2LzfGlqiuEvfArzo/VRrT0ZaJsVPuKZ55lVbNk8U6FcL+ZMH8CoyVA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2216,8 +2222,10 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
-		"node_modules/@harperdb/code-guidelines/node_modules/@typescript-eslint/scope-manager": {
+		"node_modules/@harperfast/code-guidelines/node_modules/@typescript-eslint/scope-manager": {
 			"version": "8.44.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.0.tgz",
+			"integrity": "sha512-87Jv3E+al8wpD+rIdVJm/ItDBe/Im09zXIjFoipOjr5gHUhJmTzfFLuTJ/nPTMc2Srsroy4IBXwcTCHyRR7KzA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2232,8 +2240,10 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@harperdb/code-guidelines/node_modules/@typescript-eslint/tsconfig-utils": {
+		"node_modules/@harperfast/code-guidelines/node_modules/@typescript-eslint/tsconfig-utils": {
 			"version": "8.44.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz",
+			"integrity": "sha512-x5Y0+AuEPqAInc6yd0n5DAcvtoQ/vyaGwuX5HE9n6qAefk1GaedqrLQF8kQGylLUb9pnZyLf+iEiL9fr8APDtQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2247,8 +2257,10 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
-		"node_modules/@harperdb/code-guidelines/node_modules/@typescript-eslint/type-utils": {
+		"node_modules/@harperfast/code-guidelines/node_modules/@typescript-eslint/type-utils": {
 			"version": "8.44.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.0.tgz",
+			"integrity": "sha512-9cwsoSxJ8Sak67Be/hD2RNt/fsqmWnNE1iHohG8lxqLSNY8xNfyY7wloo5zpW3Nu9hxVgURevqfcH6vvKCt6yg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2270,8 +2282,10 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
-		"node_modules/@harperdb/code-guidelines/node_modules/@typescript-eslint/types": {
+		"node_modules/@harperfast/code-guidelines/node_modules/@typescript-eslint/types": {
 			"version": "8.44.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.0.tgz",
+			"integrity": "sha512-ZSl2efn44VsYM0MfDQe68RKzBz75NPgLQXuGypmym6QVOWL5kegTZuZ02xRAT9T+onqvM6T8CdQk0OwYMB6ZvA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2282,8 +2296,10 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@harperdb/code-guidelines/node_modules/@typescript-eslint/typescript-estree": {
+		"node_modules/@harperfast/code-guidelines/node_modules/@typescript-eslint/typescript-estree": {
 			"version": "8.44.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.0.tgz",
+			"integrity": "sha512-lqNj6SgnGcQZwL4/SBJ3xdPEfcBuhCG8zdcwCPgYcmiPLgokiNDKlbPzCwEwu7m279J/lBYWtDYL+87OEfn8Jw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2309,8 +2325,10 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
-		"node_modules/@harperdb/code-guidelines/node_modules/@typescript-eslint/utils": {
+		"node_modules/@harperfast/code-guidelines/node_modules/@typescript-eslint/utils": {
 			"version": "8.44.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.0.tgz",
+			"integrity": "sha512-nktOlVcg3ALo0mYlV+L7sWUD58KG4CMj1rb2HUVOO4aL3K/6wcD+NERqd0rrA5Vg06b42YhF6cFxeixsp9Riqg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2331,8 +2349,10 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
-		"node_modules/@harperdb/code-guidelines/node_modules/@typescript-eslint/visitor-keys": {
+		"node_modules/@harperfast/code-guidelines/node_modules/@typescript-eslint/visitor-keys": {
 			"version": "8.44.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.0.tgz",
+			"integrity": "sha512-zaz9u8EJ4GBmnehlrpoKvj/E3dNbuQ7q0ucyZImm3cLqJ8INTc970B1qEqDX/Rzq65r3TvVTN7kHWPBoyW7DWw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2347,21 +2367,27 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@harperdb/code-guidelines/node_modules/balanced-match": {
+		"node_modules/@harperfast/code-guidelines/node_modules/balanced-match": {
 			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@harperdb/code-guidelines/node_modules/brace-expansion": {
-			"version": "2.0.2",
+		"node_modules/@harperfast/code-guidelines/node_modules/brace-expansion": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+			"integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
 		},
-		"node_modules/@harperdb/code-guidelines/node_modules/eslint-visitor-keys": {
+		"node_modules/@harperfast/code-guidelines/node_modules/eslint-visitor-keys": {
 			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -2371,16 +2397,20 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/@harperdb/code-guidelines/node_modules/ignore": {
-			"version": "7.0.5",
+		"node_modules/@harperfast/code-guidelines/node_modules/ignore": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+			"integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
 			}
 		},
-		"node_modules/@harperdb/code-guidelines/node_modules/minimatch": {
+		"node_modules/@harperfast/code-guidelines/node_modules/minimatch": {
 			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2393,8 +2423,10 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/@harperdb/code-guidelines/node_modules/typescript-eslint": {
+		"node_modules/@harperfast/code-guidelines/node_modules/typescript-eslint": {
 			"version": "8.44.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.44.0.tgz",
+			"integrity": "sha512-ib7mCkYuIzYonCq9XWF5XNw+fkj2zg629PSa9KNIQ47RXFF763S5BIX4wqz1+FLPogTZoiw8KmCiRPRa8bL3qw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2525,9 +2557,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2543,9 +2572,6 @@
 			"integrity": "sha512-jLFO8Stvl2LBEfZRjO7Kp2noO7Xse9jztZJuEM8uwAmj6y9hLf31ysGR4tVTdGqHTHkSNWIpy+mb0Fv+A9c2dg==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -2563,9 +2589,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2581,9 +2604,6 @@
 			"integrity": "sha512-yWWULelWWMkavYbHJuYao5LAiG6IVK9/CzwsYdt/V0mgpVGBdGH5oKVbX+rwtM7H0vyqCNIuctXg9A0m8Bn48g==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -3301,11 +3321,13 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
 			"version": "3.0.4",
@@ -3314,11 +3336,13 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
 			"version": "3.0.4",
@@ -3327,11 +3351,13 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
 			"version": "3.0.4",
@@ -3340,11 +3366,13 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
 			"version": "3.0.4",
@@ -3353,11 +3381,13 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
 			"version": "3.0.4",
@@ -3366,11 +3396,13 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/@noble/hashes": {
 			"version": "1.8.0",
@@ -3539,9 +3571,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3559,9 +3588,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3579,9 +3605,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3599,9 +3622,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3619,9 +3639,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3639,9 +3656,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3659,9 +3673,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3679,9 +3690,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,7 @@
 				"harper": "dist/bin/harper.js"
 			},
 			"devDependencies": {
-				"@harperfast/code-guidelines": "^0.1.1",
+				"@harperfast/code-guidelines": "^0.1.2",
 				"@harperfast/integration-testing": "^0.6.2",
 				"@modelcontextprotocol/sdk": "^1.29.0",
 				"@types/busboy": "^1.5.4",
@@ -2126,9 +2126,9 @@
 			}
 		},
 		"node_modules/@harperfast/code-guidelines": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/code-guidelines/-/code-guidelines-0.1.1.tgz",
-			"integrity": "sha512-NgYNRfNtbTGm8JFja5sLFzDD9e6WyeYVuGbnvVhp7rw9vRpAMrDYky27n1RkHTwEvnai2j6hQfm4XwmMH89Wvg==",
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/code-guidelines/-/code-guidelines-0.1.2.tgz",
+			"integrity": "sha512-kMW4OgDRcNttjYvhtjS+5idKQEN6SPTl9n7xNs/x7xRJ4Yr3x2ZdZGlc0U/wH7Bq3C+bKl6Dx65NH0RG6xIl5w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2557,6 +2557,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2572,6 +2575,9 @@
 			"integrity": "sha512-jLFO8Stvl2LBEfZRjO7Kp2noO7Xse9jztZJuEM8uwAmj6y9hLf31ysGR4tVTdGqHTHkSNWIpy+mb0Fv+A9c2dg==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -2589,6 +2595,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2604,6 +2613,9 @@
 			"integrity": "sha512-yWWULelWWMkavYbHJuYao5LAiG6IVK9/CzwsYdt/V0mgpVGBdGH5oKVbX+rwtM7H0vyqCNIuctXg9A0m8Bn48g==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -3321,13 +3333,11 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
 			"version": "3.0.4",
@@ -3336,13 +3346,11 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
 			"version": "3.0.4",
@@ -3351,13 +3359,11 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
 			"version": "3.0.4",
@@ -3366,13 +3372,11 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
 			"version": "3.0.4",
@@ -3381,13 +3385,11 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
 			"version": "3.0.4",
@@ -3396,13 +3398,11 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@noble/hashes": {
 			"version": "1.8.0",
@@ -3571,6 +3571,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3588,6 +3591,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3605,6 +3611,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3622,6 +3631,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3639,6 +3651,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3656,6 +3671,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3673,6 +3691,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3690,6 +3711,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
 		}
 	},
 	"devDependencies": {
-		"@harperdb/code-guidelines": "^0.0.6",
+		"@harperfast/code-guidelines": "^0.1.1",
 		"@harperfast/integration-testing": "^0.6.2",
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"@types/busboy": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
 		}
 	},
 	"devDependencies": {
-		"@harperfast/code-guidelines": "^0.1.1",
+		"@harperfast/code-guidelines": "^0.1.2",
 		"@harperfast/integration-testing": "^0.6.2",
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"@types/busboy": "^1.5.4",

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -3,7 +3,7 @@
  * @see https://prettier.io/docs/en/configuration.html
  * @type {import("prettier").Config}
  */
-import harperConfig from '@harperdb/code-guidelines/prettier';
+import harperConfig from '@harperfast/code-guidelines/prettier';
 
 export default {
 	...harperConfig,


### PR DESCRIPTION
`@harperdb/code-guidelines` has been deprecated and republished as `@harperfast/code-guidelines`. Version 0.1.2 is functionally identical to 0.0.6 — no config changes, just the new package name (0.1.2 also adds a `files` allowlist so `.claude` and `docs` are no longer included in the published artifact).

This updates the dependency, any config references (prettier/eslint/docs), and the lockfile. No new lockfiles were added.

<sub>sent with Claude Fable 5</sub>