### PR TITLE
fix(logging): render structured operation-error diagnostics past Console's default depth/breadth

### DIFF
--- a/unitTests/utility/OperationFunctionCaller.test.js
+++ b/unitTests/utility/OperationFunctionCaller.test.js
@@ -149,7 +149,10 @@ describe(`Test callOperationFunctionAsAwait`, function () {
 
 			// Proves the reassigned hdb_logger.error is the same function callOperationFunctionAsAwait
 			// invokes (not a different export) - if it weren't, logged_calls would still be empty here.
-			assert.ok(logged_calls.length >= 2, `expected the error label and payload to both be logged, got: ${logged_calls}`);
+			assert.ok(
+				logged_calls.length >= 2,
+				`expected the error label and payload to both be logged, got: ${logged_calls}`
+			);
 			assert.ok(
 				logged_calls[0].join(' ').includes('Error calling operation:'),
 				`expected the first logged call to be the operation-error label, got: ${logged_calls[0]}`
@@ -179,7 +182,10 @@ describe(`Test callOperationFunctionAsAwait`, function () {
 				// expected - the structured error is rethrown after being logged
 			}
 
-			assert.ok(logged_calls.length >= 2, `expected the error label and payload to both be logged, got: ${logged_calls}`);
+			assert.ok(
+				logged_calls.length >= 2,
+				`expected the error label and payload to both be logged, got: ${logged_calls}`
+			);
 			// If OperationFunctionCaller inspected http_resp_msg directly instead of routing it through
 			// log.error, this would instead be a pre-formatted string with secretHeader dumped raw into
 			// it (the #1734 regression) - the real logger's own sanitizeErrorArgs/errorForLog (covered by
@@ -211,7 +217,10 @@ describe(`Test callOperationFunctionAsAwait`, function () {
 				// expected - the structured error is rethrown after being logged
 			}
 
-			assert.ok(logged_calls.length >= 2, `expected the error label and payload to both be logged, got: ${logged_calls}`);
+			assert.ok(
+				logged_calls.length >= 2,
+				`expected the error label and payload to both be logged, got: ${logged_calls}`
+			);
 			assert.strictEqual(
 				logged_calls[1][0],
 				vm_error,

--- a/unitTests/utility/OperationFunctionCaller.test.js
+++ b/unitTests/utility/OperationFunctionCaller.test.js
@@ -5,6 +5,7 @@
 //testUtils.preTestPrep();
 const assert = require('assert');
 const op_func_caller = require('#src/utility/OperationFunctionCaller');
+const hdb_logger = require('#src/utility/logging/harper_logger');
 const { promisify } = require('util');
 
 class TestInputObject {
@@ -102,5 +103,120 @@ describe(`Test callOperationFunctionAsAwait`, function () {
 			assert.strictEqual(test_input.followup_run, false);
 			assert.strictEqual(test_input.was_run, false);
 		}
+	});
+
+	describe('Logging an error carrying a structured http_resp_msg (harper#1982)', function () {
+		let original_error;
+		let logged_calls;
+
+		beforeEach(function () {
+			original_error = hdb_logger.error;
+			logged_calls = [];
+			hdb_logger.error = (...args) => logged_calls.push(args);
+		});
+
+		afterEach(function () {
+			hdb_logger.error = original_error;
+		});
+
+		it('renders a full 200-line install capture, including a >10000-char line, without flattening or truncating it', async function () {
+			const lines = [];
+			for (let i = 0; i < 199; i++) {
+				lines.push({ manager: 'npm', stream: 'stderr', line: `npm error line ${i}` });
+			}
+			// createInstallCapture bounds the *total* capture to 16KB, not each line, so a single
+			// line can legitimately be within a few bytes of that whole-capture cap.
+			const long_line = `npm error boom ${'x'.repeat(10500)} end-of-long-line`;
+			lines.push({ manager: 'npm', stream: 'stderr', line: long_line });
+
+			const test_func_exception = async function () {
+				const err = new Error('Failed to install dependencies for hdbms using npm default. Exit code: 1');
+				err.http_resp_msg = {
+					error: err.message,
+					phase: 'prepare',
+					install_output: { lines, truncated: false, dropped_lines: 0 },
+					deployment_id: 'test-deployment-id',
+				};
+				throw err;
+			};
+
+			try {
+				await op_func_caller.callOperationFunctionAsAwait(test_func_exception, new TestInputObject(), null);
+				assert.fail('expected callOperationFunctionAsAwait to reject');
+			} catch {
+				// expected - the structured error is rethrown after being logged
+			}
+
+			// Proves the reassigned hdb_logger.error is the same function callOperationFunctionAsAwait
+			// invokes (not a different export) - if it weren't, logged_calls would still be empty here.
+			assert.ok(logged_calls.length >= 2, `expected the error label and payload to both be logged, got: ${logged_calls}`);
+			assert.ok(
+				logged_calls[0].join(' ').includes('Error calling operation:'),
+				`expected the first logged call to be the operation-error label, got: ${logged_calls[0]}`
+			);
+
+			const logged = logged_calls.map((call_args) => call_args.join(' ')).join('\n');
+			assert.ok(!logged.includes('[Object]'), `logged output flattened a nested object: ${logged}`);
+			assert.ok(!logged.includes('more item'), `logged output truncated the lines array: ${logged}`);
+			assert.ok(!logged.includes('more character'), `logged output truncated a long line: ${logged}`);
+			assert.ok(logged.includes('npm error line 198'), 'logged output is missing the last short line');
+			assert.ok(logged.includes('end-of-long-line'), 'logged output is missing the tail of the long line');
+		});
+
+		it('passes an Error-valued http_resp_msg to log.error unchanged instead of inspecting it raw (#1734)', async function () {
+			const http_error = new Error('upstream boom');
+			http_error.secretHeader = 'do-not-leak-me';
+			const test_func_exception = async function () {
+				const err = new Error('operation failed');
+				err.http_resp_msg = http_error;
+				throw err;
+			};
+
+			try {
+				await op_func_caller.callOperationFunctionAsAwait(test_func_exception, new TestInputObject(), null);
+				assert.fail('expected callOperationFunctionAsAwait to reject');
+			} catch {
+				// expected - the structured error is rethrown after being logged
+			}
+
+			assert.ok(logged_calls.length >= 2, `expected the error label and payload to both be logged, got: ${logged_calls}`);
+			// If OperationFunctionCaller inspected http_resp_msg directly instead of routing it through
+			// log.error, this would instead be a pre-formatted string with secretHeader dumped raw into
+			// it (the #1734 regression) - the real logger's own sanitizeErrorArgs/errorForLog (covered by
+			// harper_logger.test.js) is what's responsible for stripping it before this reaches the log.
+			assert.strictEqual(
+				logged_calls[1][0],
+				http_error,
+				'expected the raw Error instance to be passed to log.error, not a pre-formatted string'
+			);
+		});
+
+		it('routes a VM cross-realm Error-valued http_resp_msg unchanged too (#1734)', async function () {
+			// Component code runs through node:vm, so a VM-created Error fails `instanceof Error`
+			// against this realm's Error constructor even though it is one (harper#1982 review).
+			const vm = require('vm');
+			const vm_error = vm.runInNewContext('new Error("vm upstream boom")');
+			assert.strictEqual(vm_error instanceof Error, false, 'precondition: cross-realm Error fails instanceof');
+
+			const test_func_exception = async function () {
+				const err = new Error('operation failed');
+				err.http_resp_msg = vm_error;
+				throw err;
+			};
+
+			try {
+				await op_func_caller.callOperationFunctionAsAwait(test_func_exception, new TestInputObject(), null);
+				assert.fail('expected callOperationFunctionAsAwait to reject');
+			} catch {
+				// expected - the structured error is rethrown after being logged
+			}
+
+			assert.ok(logged_calls.length >= 2, `expected the error label and payload to both be logged, got: ${logged_calls}`);
+			assert.strictEqual(
+				logged_calls[1][0],
+				vm_error,
+				'expected the raw VM Error instance to be passed to log.error, not a pre-formatted string'
+			);
+		});
 	});
 });

--- a/unitTests/utility/OperationFunctionCaller.test.js
+++ b/unitTests/utility/OperationFunctionCaller.test.js
@@ -227,5 +227,36 @@ describe(`Test callOperationFunctionAsAwait`, function () {
 				'expected the raw VM Error instance to be passed to log.error, not a pre-formatted string'
 			);
 		});
+
+		it('reads a getter-backed http_resp_msg exactly once, so classification and logging cannot see different values (#1982 review)', async function () {
+			const secret_payload = { detail: { config: { headers: { Authorization: 'Bearer super-secret-token' } } } };
+			let read_count = 0;
+			const test_func_exception = async function () {
+				const err = new Error('operation failed');
+				Object.defineProperty(err, 'http_resp_msg', {
+					// A hostile/buggy accessor that looks like a safe string on an early read (the kind
+					// the old multi-read code would classify as "safe, pass through raw") but returns a
+					// secret-carrying object once actually logged - proving classification and logging
+					// now see the exact same snapshot rather than racing across separate reads.
+					get() {
+						read_count++;
+						return read_count === 1 ? 'looks safe' : secret_payload;
+					},
+				});
+				throw err;
+			};
+
+			try {
+				await op_func_caller.callOperationFunctionAsAwait(test_func_exception, new TestInputObject(), null);
+				assert.fail('expected callOperationFunctionAsAwait to reject');
+			} catch {
+				// expected - the structured error is rethrown after being logged
+			}
+
+			assert.strictEqual(read_count, 1, `expected http_resp_msg to be read exactly once, got ${read_count} reads`);
+			const logged = logged_calls.map((call_args) => call_args.join(' ')).join('\n');
+			assert.ok(!logged.includes('super-secret-token'), `logged output leaked the secret: ${logged}`);
+			assert.ok(logged.includes('looks safe'), `expected the single classified/logged value, got: ${logged}`);
+		});
 	});
 });

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -1389,6 +1389,66 @@ describe('Test harper_logger module', () => {
 			expect(result).to.not.include('super-secret-token');
 			expect(result).to.not.include('Authorization');
 		});
+
+		it('never invokes ANY trap on a nested Proxy - not just a throwing one - and never leaks its target', () => {
+			const secret_error = new Error('request failed');
+			secret_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
+			let trap_calls = 0;
+			const hostile = new Proxy(
+				{ error: secret_error },
+				{
+					ownKeys() {
+						trap_calls++;
+						return Reflect.ownKeys({ error: secret_error });
+					},
+					getPrototypeOf() {
+						trap_calls++;
+						return Object.prototype;
+					},
+					get(target, prop) {
+						trap_calls++;
+						return Reflect.get(target, prop);
+					},
+				}
+			);
+			const result = render({ hostile }, { depth: 8 });
+			expect(trap_calls).to.equal(0, 'no Proxy trap should ever be invoked while sanitizing');
+			expect(result).to.not.include('super-secret-token');
+			expect(result).to.not.include('Authorization');
+			expect(result).to.include('Proxy');
+		});
+
+		it('clamps an unbounded/huge caller-requested maxArrayLength to a hard ceiling instead of scanning the full array', () => {
+			const huge_array = new Array(1_000_000).fill(0);
+			const start = process.hrtime.bigint();
+			const result = render({ huge_array }, { depth: 8, maxArrayLength: Infinity });
+			const elapsed_ms = Number(process.hrtime.bigint() - start) / 1e6;
+			expect(elapsed_ms).to.be.below(
+				2000,
+				'an unbounded requested maxArrayLength must not defeat the sanitize breadth ceiling'
+			);
+			expect(result).to.include('sanitize budget');
+		});
+
+		it('never returns a nested Error unsanitized once the sanitize depth cap is hit (requires a caller-requested depth beyond the cap)', () => {
+			const secret_error = new Error('request failed');
+			secret_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
+			let value = secret_error;
+			for (let i = 0; i < 25; i++) value = { nested: value };
+			const result = render(value, { depth: 30 });
+			expect(result).to.not.include('super-secret-token');
+			expect(result).to.not.include('Authorization');
+		});
+
+		it('still resolves a huge expando-free Buffer/boxed-String via the fast path instead of scanning every index', () => {
+			const huge_buffer = Buffer.alloc(1_000_000);
+			const huge_boxed_string = new String('x'.repeat(1_000_000));
+			const start = process.hrtime.bigint();
+			const result = render({ huge_buffer, huge_boxed_string }, { depth: 8 });
+			const elapsed_ms = Number(process.hrtime.bigint() - start) / 1e6;
+			expect(elapsed_ms).to.be.below(500, 'the expando-free fast path must not scan every element/character');
+			expect(result).to.match(/Buffer\.from\(|<Buffer/);
+		});
 	});
 
 	describe('Test isErrorLike function (harper#1982)', () => {

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -1104,6 +1104,55 @@ describe('Test harper_logger module', () => {
 			expect(result).to.include('Error: request failed');
 		});
 
+		it('sanitizes a secret-carrying Error held by a class/custom-prototype instance, preserving its class name', () => {
+			const nested_error = new Error('request failed');
+			nested_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
+			class Diagnostic {
+				constructor(cause) {
+					this.cause = cause;
+				}
+			}
+			const value = { diagnostic: new Diagnostic(nested_error) };
+			const result = render(value, { depth: 8 });
+			expect(result).to.not.include('super-secret-token');
+			expect(result).to.include('Error: request failed');
+			expect(result).to.include('Diagnostic');
+		});
+
+		it('never invokes an accessor-backed array entry, and never resolves an overridden Map/Set iterator', () => {
+			let array_getter_calls = 0;
+			const hostile_array = [];
+			Object.defineProperty(hostile_array, 0, {
+				enumerable: true,
+				get() {
+					array_getter_calls++;
+					return 'should not be called';
+				},
+			});
+			hostile_array.length = 1;
+
+			let iterator_calls = 0;
+			const hostile_map = new Map([['key', 'value']]);
+			hostile_map[Symbol.iterator] = function* () {
+				iterator_calls++;
+				yield ['poisoned', 'should not appear'];
+			};
+			const hostile_set = new Set(['value']);
+			hostile_set[Symbol.iterator] = function* () {
+				iterator_calls++;
+				yield 'poisoned';
+			};
+
+			const result = render({ hostile_array, hostile_map, hostile_set }, { depth: 8 });
+			expect(array_getter_calls).to.equal(0);
+			expect(iterator_calls).to.equal(0);
+			expect(result).to.include('[Getter]');
+			expect(result).to.not.include('should not be called');
+			expect(result).to.include("'key' => 'value'");
+			expect(result).to.include("'value'");
+			expect(result).to.not.include('poisoned');
+		});
+
 		it('leaves built-in container types (Date, Map, Buffer) rendered natively instead of corrupting them', () => {
 			const date = new Date('2024-01-01T00:00:00.000Z');
 			const map = new Map([['key', 'value']]);

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -1390,28 +1390,6 @@ describe('Test harper_logger module', () => {
 			expect(result).to.not.include('Authorization');
 		});
 
-		it('falls back to a safe placeholder (not the raw child) if a nested sanitize step throws for a reason other than a Proxy trap', () => {
-			// Defensive coverage: with the isProxy gate now catching every Proxy before any
-			// reflection, no known real-world input reaches this catch block today - it's tested
-			// directly here (by forcing Array.isArray to throw for one specific value) so it stays
-			// proven safe as a backstop against whatever unforeseen way a future value might throw.
-			const secret_error = new Error('request failed');
-			secret_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
-			const sentinel = { error: secret_error };
-			const original_is_array = Array.isArray;
-			const stub = sinon.stub(Array, 'isArray').callsFake((v) => {
-				if (v === sentinel) throw new Error('isArray boom');
-				return original_is_array(v);
-			});
-			try {
-				const result = render({ sentinel }, { depth: 8 });
-				expect(result).to.not.include('super-secret-token');
-				expect(result).to.not.include('Authorization');
-			} finally {
-				stub.restore();
-			}
-		});
-
 		it('never invokes ANY trap on a nested Proxy - not just a throwing one - and never leaks its target', () => {
 			const secret_error = new Error('request failed');
 			secret_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -1500,7 +1500,7 @@ describe('Test harper_logger module', () => {
 			expect(isErrorLike(proxy)).to.equal(false);
 		});
 
-		it('never invokes a live (non-revoked) Proxy\'s getPrototypeOf trap - `instanceof` would otherwise trigger it', () => {
+		it("never invokes a live (non-revoked) Proxy's getPrototypeOf trap - `instanceof` would otherwise trigger it", () => {
 			let trap_calls = 0;
 			const hostile = new Proxy(new Error('gone'), {
 				getPrototypeOf(target) {

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -1269,6 +1269,48 @@ describe('Test harper_logger module', () => {
 			expect(result).to.not.include('super-secret-token');
 			expect(result).to.include('Error: vm request failed');
 		});
+
+		it('bounds sanitization breadth for a plain object with a huge number of own properties', () => {
+			const huge_object = {};
+			for (let i = 0; i < 200_000; i++) huge_object[`key_${i}`] = i;
+			const start = process.hrtime.bigint();
+			const result = render({ huge_object }, { depth: 8, maxArrayLength: 250 });
+			const elapsed_ms = Number(process.hrtime.bigint() - start) / 1e6;
+			expect(elapsed_ms).to.be.below(
+				2000,
+				'sanitizing a wide plain object should stay bounded, not clone every property'
+			);
+			expect(result).to.include('sanitize budget');
+		});
+
+		it('never hands a Promise to inspect() raw, even one resolved with a secret-carrying Error (#1734)', () => {
+			const secret_error = new Error('request failed');
+			secret_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
+			const value = { pending_check: Promise.resolve(secret_error) };
+			const result = render(value, { depth: 8 });
+			expect(result).to.not.include('super-secret-token');
+			expect(result).to.not.include('Authorization');
+			expect(result).to.include('Promise');
+		});
+
+		it('falls back to a safe placeholder (not the raw child) when a nested value throws while being sanitized (#1734)', () => {
+			const secret_error = new Error('request failed');
+			secret_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
+			// A Proxy whose `ownKeys` trap throws is reached one level into the walk (the plain-object
+			// branch calls Object.keys on it), so the recursive sanitize call on `hostile` itself
+			// throws - exercising the catch-fallback around a nested step, not the top-level guard.
+			const hostile = new Proxy(
+				{ error: secret_error },
+				{
+					ownKeys() {
+						throw new Error('ownKeys boom');
+					},
+				}
+			);
+			const result = render({ hostile }, { depth: 8 });
+			expect(result).to.not.include('super-secret-token');
+			expect(result).to.not.include('Authorization');
+		});
 	});
 
 	describe('Test isErrorLike function (harper#1982)', () => {

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -1000,6 +1000,138 @@ describe('Test harper_logger module', () => {
 		});
 	});
 
+	describe('Test inspectForLog function (harper#1982)', () => {
+		const util = require('util');
+		const { inspectForLog } = harperLoggerModule;
+		// inspectForLog returns a lazy wrapper; render it the same way the logger does.
+		const render = (value, options) => util.inspect(inspectForLog(value, options));
+
+		it('renders past Console default depth/array/string limits when given explicit options', () => {
+			const value = {
+				install_output: {
+					lines: [{ manager: 'npm', stream: 'stderr', line: 'npm error boom' }],
+				},
+			};
+			const result = render(value, { depth: 8, maxArrayLength: 250, maxStringLength: 20000 });
+			expect(result).to.not.include('[Object]');
+			expect(result).to.include('npm error boom');
+		});
+
+		it('defers rendering until actually stringified (does not compute eagerly)', () => {
+			let rendered = false;
+			const hostile = {
+				get [util.inspect.custom]() {
+					rendered = true;
+					return () => 'rendered-on-demand';
+				},
+			};
+			const wrapper = inspectForLog(hostile, { depth: 8 });
+			expect(rendered).to.equal(false, 'inspectForLog should not have touched the value yet');
+			expect(util.inspect(wrapper)).to.equal('rendered-on-demand');
+			expect(rendered).to.equal(true);
+		});
+
+		it('never throws, even if the value has a hostile custom inspect hook', () => {
+			const hostile = {
+				[util.inspect.custom]() {
+					throw new Error('formatter boom');
+				},
+			};
+			expect(() => render(hostile)).to.not.throw();
+			expect(render(hostile)).to.include('Unrenderable value');
+			expect(render(hostile)).to.include('formatter boom');
+		});
+
+		it('never throws on a revoked Proxy', () => {
+			const { proxy, revoke } = Proxy.revocable({}, {});
+			revoke();
+			expect(() => render(proxy)).to.not.throw();
+		});
+
+		it('sanitizes a nested Error at depth instead of exposing its own-enumerable properties raw (#1734)', () => {
+			// http_resp_msg is a generic field - a future caller could embed a raw Error several
+			// levels deep in it, unlike the known deployComponent shape this was written for.
+			const nested_error = new Error('request failed');
+			nested_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
+			const value = { detail: { cause: { error: nested_error } }, other: 'fine' };
+
+			const result = render(value, { depth: 8, maxArrayLength: 250, maxStringLength: 20000 });
+			expect(result).to.not.include('super-secret-token');
+			expect(result).to.not.include('Authorization');
+			expect(result).to.include('Error: request failed');
+			expect(result).to.include('fine');
+		});
+
+		it('preserves an enumerable symbol property (e.g. a nested value’s own custom inspect hook)', () => {
+			const custom_rendered = { [util.inspect.custom]: () => 'custom-nested-render' };
+			const value = { inner: custom_rendered };
+			const result = render(value, { depth: 8 });
+			expect(result).to.include('custom-nested-render');
+		});
+
+		it('sanitizes a secret-carrying Error reached a second time through a cycle', () => {
+			const nested_error = new Error('request failed');
+			nested_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
+			const value = { error: nested_error };
+			value.self = value; // cycle: the second path to `value` must not bypass sanitization
+
+			const result = render(value, { depth: 8, maxArrayLength: 250, maxStringLength: 20000 });
+			expect(result).to.not.include('super-secret-token');
+			expect(result).to.include('Error: request failed');
+		});
+
+		it('leaves built-in container types (Date, Map, Buffer) rendered natively instead of corrupting them', () => {
+			const date = new Date('2024-01-01T00:00:00.000Z');
+			const map = new Map([['key', 'value']]);
+			const buffer = Buffer.from('hi');
+			const result = render({ date, map, buffer }, { depth: 8 });
+			expect(result).to.include('2024-01-01T00:00:00.000Z');
+			expect(result).to.include("Map(1)");
+			expect(result).to.include('key');
+			expect(result).to.match(/Buffer\.from\(|<Buffer/);
+		});
+
+		it('omits a field whose getter throws instead of letting it fail the whole render', () => {
+			const hostile = {};
+			Object.defineProperty(hostile, 'poison', {
+				enumerable: true,
+				get() {
+					throw new Error('getter boom');
+				},
+			});
+			const value = { hostile, fine: 'still here' };
+			const result = render(value, { depth: 8 });
+			expect(result).to.not.include('Unrenderable value');
+			expect(result).to.include('still here');
+		});
+	});
+
+	describe('Test isErrorLike function (harper#1982)', () => {
+		const { isErrorLike } = harperLoggerModule;
+
+		it('recognizes a same-realm Error', () => {
+			expect(isErrorLike(new Error('boom'))).to.equal(true);
+		});
+
+		it('recognizes a cross-realm (VM-created) Error', () => {
+			const vm = require('vm');
+			const vmError = vm.runInNewContext('new Error("vm boom")');
+			expect(vmError instanceof Error).to.equal(false); // different realm's Error constructor
+			expect(isErrorLike(vmError)).to.equal(true);
+		});
+
+		it('does not recognize a plain object', () => {
+			expect(isErrorLike({ message: 'not an error' })).to.equal(false);
+		});
+
+		it('does not throw and returns false for a revoked Proxy', () => {
+			const { proxy, revoke } = Proxy.revocable(new Error('gone'), {});
+			revoke();
+			expect(() => isErrorLike(proxy)).to.not.throw();
+			expect(isErrorLike(proxy)).to.equal(false);
+		});
+	});
+
 	describe('Test logger auto-wrap of Error args (#1734)', () => {
 		// The HarperLogger level methods route every Error argument through errorForLog before
 		// Console formatting, so raw `logger.error(error)` calls anywhere in the codebase (or in

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -1371,12 +1371,12 @@ describe('Test harper_logger module', () => {
 			expect(result).to.include('[Function: plain_function]');
 		});
 
-		it('falls back to a safe placeholder (not the raw child) when a nested value throws while being sanitized (#1734)', () => {
+		it('fails closed for a Proxy whose `ownKeys` trap throws - caught by the isProxy gate before the trap ever runs (#1734)', () => {
 			const secret_error = new Error('request failed');
 			secret_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
-			// A Proxy whose `ownKeys` trap throws is reached one level into the walk (the plain-object
-			// branch calls Object.keys on it), so the recursive sanitize call on `hostile` itself
-			// throws - exercising the catch-fallback around a nested step, not the top-level guard.
+			// types.isProxy now recognizes `hostile` and returns a placeholder before any reflection,
+			// so the `ownKeys` trap never actually runs (see the dedicated trap-count test below) -
+			// this just pins the end-to-end secret-safety outcome for this shape.
 			const hostile = new Proxy(
 				{ error: secret_error },
 				{
@@ -1388,6 +1388,28 @@ describe('Test harper_logger module', () => {
 			const result = render({ hostile }, { depth: 8 });
 			expect(result).to.not.include('super-secret-token');
 			expect(result).to.not.include('Authorization');
+		});
+
+		it('falls back to a safe placeholder (not the raw child) if a nested sanitize step throws for a reason other than a Proxy trap', () => {
+			// Defensive coverage: with the isProxy gate now catching every Proxy before any
+			// reflection, no known real-world input reaches this catch block today - it's tested
+			// directly here (by forcing Array.isArray to throw for one specific value) so it stays
+			// proven safe as a backstop against whatever unforeseen way a future value might throw.
+			const secret_error = new Error('request failed');
+			secret_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
+			const sentinel = { error: secret_error };
+			const original_is_array = Array.isArray;
+			const stub = sinon.stub(Array, 'isArray').callsFake((v) => {
+				if (v === sentinel) throw new Error('isArray boom');
+				return original_is_array(v);
+			});
+			try {
+				const result = render({ sentinel }, { depth: 8 });
+				expect(result).to.not.include('super-secret-token');
+				expect(result).to.not.include('Authorization');
+			} finally {
+				stub.restore();
+			}
 		});
 
 		it('never invokes ANY trap on a nested Proxy - not just a throwing one - and never leaks its target', () => {
@@ -1440,14 +1462,38 @@ describe('Test harper_logger module', () => {
 			expect(result).to.not.include('Authorization');
 		});
 
-		it('still resolves a huge expando-free Buffer/boxed-String via the fast path instead of scanning every index', () => {
+		it('fails closed to a bounded, quick placeholder for a huge Buffer/boxed-String instead of scanning every index - even when expando-free', () => {
+			// Above MAX_INDEXED_EXPANDO_CHECK_LENGTH, hasEnumerableOwnProps can't cheaply verify "no
+			// expando" (that's the whole point of the size cap - see its doc comment), so it fails
+			// CLOSED: a huge Buffer/boxed-String is treated as if it has an expando even when it does
+			// not, trading native-format fidelity (only above this size) for never scanning it and
+			// never guessing "clean" on data it didn't actually check.
 			const huge_buffer = Buffer.alloc(1_000_000);
 			const huge_boxed_string = new String('x'.repeat(1_000_000));
 			const start = process.hrtime.bigint();
 			const result = render({ huge_buffer, huge_boxed_string }, { depth: 8 });
 			const elapsed_ms = Number(process.hrtime.bigint() - start) / 1e6;
-			expect(elapsed_ms).to.be.below(500, 'the expando-free fast path must not scan every element/character');
+			expect(elapsed_ms).to.be.below(500, 'failing closed above the size cap must not scan every element/character');
+			expect(result).to.not.match(/Buffer\.from\(|<Buffer/);
+			expect(result).to.include('with own properties omitted for safety');
+		});
+
+		it('still resolves a small expando-free Buffer/boxed-String natively (below the size cap, fast path unaffected)', () => {
+			const small_buffer = Buffer.from('hi');
+			const small_boxed_string = new String('hi');
+			const result = render({ small_buffer, small_boxed_string }, { depth: 8 });
 			expect(result).to.match(/Buffer\.from\(|<Buffer/);
+			expect(result).to.include('hi');
+		});
+
+		it('fails closed (safe summary, not raw) for a Buffer just over the size cap that actually carries an expando', () => {
+			const secret_error = new Error('request failed');
+			secret_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
+			const hostile_buffer = Buffer.alloc(10_001);
+			hostile_buffer.cause = secret_error;
+			const result = render({ hostile_buffer }, { depth: 8 });
+			expect(result).to.not.include('super-secret-token');
+			expect(result).to.not.include('Authorization');
 		});
 	});
 
@@ -1474,6 +1520,18 @@ describe('Test harper_logger module', () => {
 			revoke();
 			expect(() => isErrorLike(proxy)).to.not.throw();
 			expect(isErrorLike(proxy)).to.equal(false);
+		});
+
+		it('never invokes a live (non-revoked) Proxy\'s getPrototypeOf trap - `instanceof` would otherwise trigger it', () => {
+			let trap_calls = 0;
+			const hostile = new Proxy(new Error('gone'), {
+				getPrototypeOf(target) {
+					trap_calls++;
+					return Reflect.getPrototypeOf(target);
+				},
+			});
+			expect(isErrorLike(hostile)).to.equal(false);
+			expect(trap_calls).to.equal(0, 'isErrorLike must classify a Proxy without reflecting on it at all');
 		});
 	});
 

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -1293,6 +1293,84 @@ describe('Test harper_logger module', () => {
 			expect(result).to.include('Promise');
 		});
 
+		it('bounds total sanitize work (containers + primitive leaves), not just container count', () => {
+			// Each object has 1 container + 250 primitive fields; the global node budget must count
+			// leaves too, or 250 containers * 250 fields could walk ~62,500 values while only
+			// registering as 250 against MAX_SANITIZE_NODES.
+			const many_small_objects = {};
+			for (let i = 0; i < 250; i++) {
+				const child = {};
+				for (let j = 0; j < 250; j++) child[`f${j}`] = j;
+				many_small_objects[`child_${i}`] = child;
+			}
+			const start = process.hrtime.bigint();
+			const result = render(many_small_objects, { depth: 8, maxArrayLength: 250 });
+			const elapsed_ms = Number(process.hrtime.bigint() - start) / 1e6;
+			expect(elapsed_ms).to.be.below(2000, 'leaf values must count against the shared node budget too');
+			expect(result).to.include('sanitize budget');
+		});
+
+		it('never hands a Date, RegExp, WeakMap, or WeakSet to inspect() raw once it carries a secret-bearing expando (#1734)', () => {
+			const secret_error = new Error('request failed');
+			secret_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
+
+			const hostile_date = new Date('2024-01-01T00:00:00.000Z');
+			hostile_date.cause = secret_error;
+			const hostile_regexp = /abc/gi;
+			hostile_regexp.cause = secret_error;
+			const hostile_weakmap = new WeakMap();
+			hostile_weakmap.cause = secret_error;
+			const hostile_weakset = new WeakSet();
+			hostile_weakset.cause = secret_error;
+
+			const result = render({ hostile_date, hostile_regexp, hostile_weakmap, hostile_weakset }, { depth: 8 });
+			expect(result).to.not.include('super-secret-token');
+			expect(result).to.not.include('Authorization');
+			// The expando-free common case is untouched: native rendering is still preserved.
+			expect(result).to.include('2024-01-01T00:00:00.000Z');
+			expect(result).to.match(/\/abc\/gi/);
+		});
+
+		it('still renders a Date/RegExp/WeakMap/WeakSet exactly natively when it has no expando (fast path unaffected)', () => {
+			const date = new Date('2024-01-01T00:00:00.000Z');
+			const regexp = /abc/gi;
+			const result = render({ date, regexp }, { depth: 8 });
+			expect(result).to.include('2024-01-01T00:00:00.000Z');
+			expect(result).to.match(/\/abc\/gi/);
+		});
+
+		it('falls back to a bounded, safe summary (not the raw value) for a Buffer/boxed-primitive carrying a secret-bearing expando (#1734)', () => {
+			const secret_error = new Error('request failed');
+			secret_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
+			const hostile_buffer = Buffer.from('hi');
+			hostile_buffer.cause = secret_error;
+			const hostile_boxed_number = Object.assign(new Number(5), { cause: secret_error });
+
+			const result = render({ hostile_buffer, hostile_boxed_number }, { depth: 8 });
+			expect(result).to.not.include('super-secret-token');
+			expect(result).to.not.include('Authorization');
+		});
+
+		it('sanitizes a function’s secret-bearing expando instead of handing the raw function to inspect() (#1734)', () => {
+			const secret_error = new Error('request failed');
+			secret_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
+			function hostile_function() {}
+			hostile_function.cause = secret_error;
+
+			const result = render({ hostile_function }, { depth: 8 });
+			expect(result).to.not.include('super-secret-token');
+			expect(result).to.not.include('Authorization');
+			expect(result).to.include('Error: request failed');
+		});
+
+		it('still renders a plain function raw when it has no expando (fast path unaffected)', () => {
+			function plain_function(a, b) {
+				return a + b;
+			}
+			const result = render({ plain_function }, { depth: 8 });
+			expect(result).to.include('[Function: plain_function]');
+		});
+
 		it('falls back to a safe placeholder (not the raw child) when a nested value throws while being sanitized (#1734)', () => {
 			const secret_error = new Error('request failed');
 			secret_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -1048,6 +1048,18 @@ describe('Test harper_logger module', () => {
 			expect(() => render(proxy)).to.not.throw();
 		});
 
+		it('never throws when the custom inspect hook throws a hostile value (a revoked Proxy) instead of an Error', () => {
+			const { proxy, revoke } = Proxy.revocable({}, {});
+			revoke();
+			const hostile = {
+				[util.inspect.custom]() {
+					throw proxy; // `err instanceof Error` and `String(err)` both throw on a revoked Proxy
+				},
+			};
+			expect(() => render(hostile)).to.not.throw();
+			expect(render(hostile)).to.include('Unrenderable value');
+		});
+
 		it('sanitizes a nested Error at depth instead of exposing its own-enumerable properties raw (#1734)', () => {
 			// http_resp_msg is a generic field - a future caller could embed a raw Error several
 			// levels deep in it, unlike the known deployComponent shape this was written for.
@@ -1080,13 +1092,25 @@ describe('Test harper_logger module', () => {
 			expect(result).to.include('Error: request failed');
 		});
 
+		it('sanitizes a secret-carrying Error nested inside a Map or Set instead of leaving it raw', () => {
+			const nested_error = new Error('request failed');
+			nested_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
+			const value = {
+				map: new Map([['cause', nested_error]]),
+				set: new Set([nested_error]),
+			};
+			const result = render(value, { depth: 8 });
+			expect(result).to.not.include('super-secret-token');
+			expect(result).to.include('Error: request failed');
+		});
+
 		it('leaves built-in container types (Date, Map, Buffer) rendered natively instead of corrupting them', () => {
 			const date = new Date('2024-01-01T00:00:00.000Z');
 			const map = new Map([['key', 'value']]);
 			const buffer = Buffer.from('hi');
 			const result = render({ date, map, buffer }, { depth: 8 });
 			expect(result).to.include('2024-01-01T00:00:00.000Z');
-			expect(result).to.include("Map(1)");
+			expect(result).to.include('Map(1)');
 			expect(result).to.include('key');
 			expect(result).to.match(/Buffer\.from\(|<Buffer/);
 		});

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -1153,6 +1153,61 @@ describe('Test harper_logger module', () => {
 			expect(result).to.not.include('poisoned');
 		});
 
+		it('bounds sanitization breadth instead of visiting every index of a huge sparse array', () => {
+			const huge_sparse_array = new Array(0xffffffff - 1); // length only - no actual elements
+			const start = process.hrtime.bigint();
+			const result = render({ huge_sparse_array }, { depth: 8, maxArrayLength: 250 });
+			const elapsed_ms = Number(process.hrtime.bigint() - start) / 1e6;
+			expect(elapsed_ms).to.be.below(
+				2000,
+				'sanitizing a huge sparse array should stay bounded, not scan its full length'
+			);
+			expect(result).to.include('sanitize budget');
+		});
+
+		it('bounds sanitization breadth for a large Map/Set rather than cloning every entry', () => {
+			const huge_map = new Map(Array.from({ length: 10_000 }, (_, i) => [i, i]));
+			const huge_set = new Set(Array.from({ length: 10_000 }, (_, i) => i));
+			const result = render({ huge_map, huge_set }, { depth: 8, maxArrayLength: 250 });
+			expect(result).to.include('sanitize budget');
+		});
+
+		it('creates own properties via defineProperty instead of assignment, so an inherited setter or an own `__proto__` key cannot run during sanitization', () => {
+			let setter_calls = 0;
+			class WithSetter {
+				set detail(_v) {
+					setter_calls++;
+				}
+			}
+			const secret_error = new Error('request failed');
+			secret_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
+			const with_setter = new WithSetter();
+			// Object.defineProperty (unlike `with_setter.detail = secret_error`, which would just
+			// invoke the class's setter above) creates an OWN data property that shadows it - the
+			// exact shape a real diagnostic payload could produce and the one this test needs.
+			Object.defineProperty(with_setter, 'detail', {
+				value: secret_error,
+				enumerable: true,
+				writable: true,
+				configurable: true,
+			});
+
+			const proto_bomb = {};
+			Object.defineProperty(proto_bomb, '__proto__', {
+				value: { own_marker: 'PROTO_BOMB_SURVIVED' },
+				enumerable: true,
+			});
+
+			const result = render({ with_setter, proto_bomb }, { depth: 8 });
+			expect(setter_calls).to.equal(0);
+			expect(result).to.not.include('super-secret-token');
+			expect(result).to.include('Error: request failed');
+			// If sanitization used plain assignment instead of defineProperty, `result['__proto__'] =`
+			// would reparent the CLONE instead of creating an own property, silently dropping this
+			// marker from the render (a reparented plain object shows no inherited properties).
+			expect(result).to.include('PROTO_BOMB_SURVIVED');
+		});
+
 		it('leaves built-in container types (Date, Map, Buffer) rendered natively instead of corrupting them', () => {
 			const date = new Date('2024-01-01T00:00:00.000Z');
 			const map = new Map([['key', 'value']]);

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -1128,6 +1128,43 @@ describe('Test harper_logger module', () => {
 			expect(result).to.not.include('Unrenderable value');
 			expect(result).to.include('still here');
 		});
+
+		it('never invokes a getter while sanitizing — describes it as [Getter] instead, same as util.inspect’s default', () => {
+			let call_count = 0;
+			const value = {};
+			Object.defineProperty(value, 'lazy', {
+				enumerable: true,
+				get() {
+					call_count++;
+					return 'should not be called';
+				},
+			});
+			const result = render({ value, fine: 'still here' }, { depth: 8 });
+			expect(call_count).to.equal(0);
+			expect(result).to.include('[Getter]');
+			expect(result).to.not.include('should not be called');
+			expect(result).to.include('still here');
+		});
+
+		it('sanitizes a secret-carrying Error nested inside a VM cross-realm plain object, Map, and Set', () => {
+			const vm = require('vm');
+			const context = vm.createContext();
+			const vm_error = vm.runInContext('new Error("vm request failed")', context);
+			vm_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
+			const vm_plain_object = vm.runInContext('({})', context);
+			vm_plain_object.cause = vm_error;
+			const vm_map = vm.runInContext('new Map()', context);
+			vm_map.set('cause', vm_error);
+			const vm_set = vm.runInContext('new Set()', context);
+			vm_set.add(vm_error);
+
+			expect(vm_plain_object instanceof Object).to.equal(false); // different realm's Object constructor
+			expect(vm_map instanceof Map).to.equal(false); // different realm's Map constructor
+
+			const result = render({ vm_plain_object, vm_map, vm_set }, { depth: 8 });
+			expect(result).to.not.include('super-secret-token');
+			expect(result).to.include('Error: vm request failed');
+		});
 	});
 
 	describe('Test isErrorLike function (harper#1982)', () => {

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -1119,6 +1119,25 @@ describe('Test harper_logger module', () => {
 			expect(result).to.include('Diagnostic');
 		});
 
+		it('renders the rest of a structured payload instead of losing it all when a nested value carries a branded prototype (e.g. URL) the clone cannot safely wear', () => {
+			// URL's own properties (href, protocol, ...) are getters on URL.prototype backed by a
+			// #private internal slot the sanitized clone never has - restoring URL.prototype onto a
+			// stateless clone makes util.inspect throw once it tries to render it via those getters.
+			// Without a per-node fallback, that throw happens inside inspectForLog's OWN try/catch,
+			// which then replaces the ENTIRE payload with "[Unrenderable value]" - not just the URL
+			// field - losing phase/install_output/deployment_id for one nested URL anywhere in the tree.
+			const value = {
+				phase: 'install',
+				target: new URL('https://example.com/path'),
+				install_output: { lines: ['step 1 ok', 'step 2 ok'] },
+			};
+			const result = render(value, { depth: 8 });
+			expect(result).to.not.include('Unrenderable value');
+			expect(result).to.include('install');
+			expect(result).to.include('step 1 ok');
+			expect(result).to.include('step 2 ok');
+		});
+
 		it('never invokes an accessor-backed array entry, and never resolves an overridden Map/Set iterator', () => {
 			let array_getter_calls = 0;
 			const hostile_array = [];

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -1082,6 +1082,21 @@ describe('Test harper_logger module', () => {
 			assert.ok(result.includes('custom-nested-render'));
 		});
 
+		it('sanitizes what a preserved custom inspect hook RETURNS, not just what it is called with - a hook returning a secret-bearing Error must not leak it (#1994 review)', () => {
+			// The hook itself runs at real render time, entirely outside this walk, so its return value
+			// has never been through deepSanitizeErrors. A hook that hands back a closure-captured Error
+			// carrying a secret must still have that Error sanitized before the final util.inspect call
+			// renders whatever the hook returned.
+			const secret_error = new Error('request failed');
+			secret_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
+			const custom_rendered = { [util.inspect.custom]: () => secret_error };
+			const value = { inner: custom_rendered };
+			const result = render(value, { depth: 8 });
+			assert.ok(!result.includes('super-secret-token'));
+			assert.ok(!result.includes('Authorization'));
+			assert.ok(result.includes('Error: request failed'));
+		});
+
 		it('sanitizes a secret-carrying Error reached a second time through a cycle', () => {
 			const nested_error = new Error('request failed');
 			nested_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
@@ -1397,6 +1412,31 @@ describe('Test harper_logger module', () => {
 			assert.match(result, /\/abc\/gi/);
 		});
 
+		it("reconstructs an expando-bearing RegExp's flags via individual internal-slot getters, never the combined `flags` getter, so a hostile flag-property expando is never invoked (#1994 review)", () => {
+			// RegExp.prototype.flags is specified to synthesize its result by reading `this.global`,
+			// `this.ignoreCase`, etc as ordinary [[Get]]s on the RegExp instance - unlike the individual
+			// flag getters (`global`, `ignoreCase`, ...), which read the internal [[OriginalFlags]] slot
+			// directly. A RegExp carrying an expando that shadows one of those names with a hostile
+			// getter would have the combined getter invoke it while merely trying to reconstruct a safe
+			// copy for logging.
+			let trap_calls = 0;
+			const hostile_regexp = /abc/gi;
+			hostile_regexp.detail = 'fine'; // the expando that routes this into safeOpaqueBuiltinSummary
+			Object.defineProperty(hostile_regexp, 'global', {
+				get() {
+					trap_calls++;
+					return true;
+				},
+			});
+			const result = render({ hostile_regexp }, { depth: 8 });
+			assert.strictEqual(
+				trap_calls,
+				0,
+				"reconstructing the flags must never read the instance's own `global` property"
+			);
+			assert.match(result, /\/abc\/gi/);
+		});
+
 		it('falls back to a bounded, safe summary (not the raw value) for a Buffer/boxed-primitive carrying a secret-bearing expando (#1734)', () => {
 			const secret_error = new Error('request failed');
 			secret_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
@@ -1617,6 +1657,27 @@ describe('Test harper_logger module', () => {
 			assert.strictEqual(isErrorLike(hostile), false);
 			assert.strictEqual(trap_calls, 0, 'isErrorLike must classify a Proxy without reflecting on it at all');
 		});
+
+		it("never invokes a Proxy ANCESTOR's getPrototypeOf trap either, even when the argument itself is an ordinary (non-Proxy) object (#1994 review)", () => {
+			// types.isProxy(arg) alone only rejects `arg` itself being a Proxy. `arg instanceof Error`
+			// walks the FULL prototype chain via [[GetPrototypeOf]] - for
+			// `Object.create(Object.create(proxyAncestor))`, `arg` is an ordinary object, but the walk
+			// still reaches `proxyAncestor` a couple of levels up and invokes its trap.
+			let trap_calls = 0;
+			const proxy_ancestor = new Proxy(Error.prototype, {
+				getPrototypeOf(target) {
+					trap_calls++;
+					return Reflect.getPrototypeOf(target);
+				},
+			});
+			const hostile = Object.create(Object.create(proxy_ancestor));
+			assert.strictEqual(isErrorLike(hostile), false);
+			assert.strictEqual(
+				trap_calls,
+				0,
+				'isErrorLike must not walk the prototype chain at all - a Proxy anywhere in it must never be reflected on'
+			);
+		});
 	});
 
 	describe('Test logger auto-wrap of Error args (#1734)', () => {
@@ -1751,6 +1812,24 @@ describe('Test harper_logger module', () => {
 			const error = new Error('origin fetch failed', { cause: hostileCause });
 			expect(() => logger.error(error)).to.not.throw();
 			expect(lines.join('\n')).to.include('Error: origin fetch failed');
+		});
+
+		it("does not throw when a cause's stack getter throws a revoked Proxy instead of a normal value (#1994 review)", () => {
+			// `err instanceof Error`/`String(err)` (the old catch-block rendering) both throw on a
+			// revoked Proxy - so if the value thrown by a hostile getter here IS one, the old code's own
+			// error-recovery path would itself throw, escaping renderErrorLine entirely.
+			const { logger, lines } = createCapturingLogger();
+			const { proxy, revoke } = Proxy.revocable({}, {});
+			revoke();
+			const hostileCause = {};
+			Object.defineProperty(hostileCause, 'stack', {
+				get() {
+					throw proxy;
+				},
+			});
+			const error = new Error('origin fetch failed', { cause: hostileCause });
+			assert.doesNotThrow(() => logger.error(error));
+			assert.ok(lines.join('\n').includes('Error: origin fetch failed'));
 		});
 	});
 });

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -1139,6 +1139,50 @@ describe('Test harper_logger module', () => {
 			assert.ok(result.includes('step 2 ok'));
 		});
 
+		it("never invokes a Proxy prototype's trap while checking whether a branded prototype is safe to wear (#1994 review)", () => {
+			// The branded-prototype safety check above (`inspect(result)` on the empty clone) used to
+			// run against ANY non-null, non-Object.prototype prototype, including a live Proxy - so a
+			// hostile trap (e.g. `get() { while (true) {} }`) would run during what is supposed to be a
+			// passive safety probe on the error-logging path, wedging the worker while it tries to log
+			// and rethrow the original operation failure. A Proxy prototype must be rejected outright,
+			// the same way types.isProxy already gates every other reflection in this file.
+			let trap_calls = 0;
+			const hostile_proto = new Proxy(
+				{},
+				{
+					get(target, prop) {
+						trap_calls++;
+						return Reflect.get(target, prop);
+					},
+				}
+			);
+			const hostile = Object.create(hostile_proto);
+			hostile.detail = 'fine';
+			const result = render({ hostile }, { depth: 8 });
+			assert.strictEqual(trap_calls, 0, 'a Proxy prototype must never be probed, only rejected');
+			assert.ok(result.includes('fine'));
+		});
+
+		it("invokes a nested value's custom inspect hook (reached via its branded prototype) at most once - not once during the internal safety probe and again for the real render (#1994 review)", () => {
+			// Before the fix, the safety probe called plain `inspect(result)`, which - like any
+			// util.inspect call - invokes `[util.inspect.custom]` if the prototype defines one. That ran
+			// the class's custom inspector once here (silently, on an empty, still-mid-construction
+			// clone) and once more later for the actual render, corrupting a stateful/one-shot
+			// inspector's real output on its second call.
+			let calls = 0;
+			class OneShot {
+				[util.inspect.custom]() {
+					calls++;
+					if (calls > 1) throw new Error('called twice');
+					return 'one-shot-rendered';
+				}
+			}
+			const value = { branded: Object.create(OneShot.prototype) };
+			const result = render(value, { depth: 8 });
+			assert.strictEqual(calls, 1, 'the custom inspector must be invoked exactly once, not probed separately');
+			assert.ok(result.includes('one-shot-rendered'));
+		});
+
 		it('never invokes an accessor-backed array entry, and never resolves an overridden Map/Set iterator', () => {
 			let array_getter_calls = 0;
 			const hostile_array = [];
@@ -1391,6 +1435,26 @@ describe('Test harper_logger module', () => {
 
 			render({ boxed_string: makeBoxedString() }, { depth: 8 });
 			assert.strictEqual(invoked, baseline);
+		});
+
+		it('never invokes a hostile `Symbol.toStringTag` getter while picking a safe-summary tag for an opaque built-in that actually carries an expando (#1994 review)', () => {
+			// The classification test above only exercises an expando-free boxed String, which returns
+			// raw before safeOpaqueBuiltinSummary is ever reached. Adding an expando routes it through
+			// safeOpaqueBuiltinSummary's tag detection instead, which used to call
+			// Object.prototype.toString.call(value) - the exact same class of getter-invocation bug the
+			// classification fix above already closed, just in the other place it was still present.
+			let invoked = 0;
+			const boxed_string = new String('hi');
+			Object.defineProperty(boxed_string, Symbol.toStringTag, {
+				get() {
+					invoked++;
+					return 'String';
+				},
+			});
+			boxed_string.detail = 'fine'; // the expando that routes this into safeOpaqueBuiltinSummary
+			const result = render({ boxed_string }, { depth: 8 });
+			assert.strictEqual(invoked, 0, 'safeOpaqueBuiltinSummary must not read Symbol.toStringTag while picking a label');
+			assert.ok(result.includes('String with own properties omitted for safety'));
 		});
 
 		it('sanitizes a function’s secret-bearing expando instead of handing the raw function to inspect() (#1734)', () => {

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('node:assert');
 const sinon = require('sinon');
 const chai = require('chai');
 const expect = chai.expect;
@@ -1013,8 +1014,8 @@ describe('Test harper_logger module', () => {
 				},
 			};
 			const result = render(value, { depth: 8, maxArrayLength: 250, maxStringLength: 20000 });
-			expect(result).to.not.include('[Object]');
-			expect(result).to.include('npm error boom');
+			assert.ok(!result.includes('[Object]'));
+			assert.ok(result.includes('npm error boom'));
 		});
 
 		it('defers rendering until actually stringified (does not compute eagerly)', () => {
@@ -1026,9 +1027,9 @@ describe('Test harper_logger module', () => {
 				},
 			};
 			const wrapper = inspectForLog(hostile, { depth: 8 });
-			expect(rendered).to.equal(false, 'inspectForLog should not have touched the value yet');
-			expect(util.inspect(wrapper)).to.equal('rendered-on-demand');
-			expect(rendered).to.equal(true);
+			assert.strictEqual(rendered, false, 'inspectForLog should not have touched the value yet');
+			assert.strictEqual(util.inspect(wrapper), 'rendered-on-demand');
+			assert.strictEqual(rendered, true);
 		});
 
 		it('never throws, even if the value has a hostile custom inspect hook', () => {
@@ -1037,15 +1038,15 @@ describe('Test harper_logger module', () => {
 					throw new Error('formatter boom');
 				},
 			};
-			expect(() => render(hostile)).to.not.throw();
-			expect(render(hostile)).to.include('Unrenderable value');
-			expect(render(hostile)).to.include('formatter boom');
+			assert.doesNotThrow(() => render(hostile));
+			assert.ok(render(hostile).includes('Unrenderable value'));
+			assert.ok(render(hostile).includes('formatter boom'));
 		});
 
 		it('never throws on a revoked Proxy', () => {
 			const { proxy, revoke } = Proxy.revocable({}, {});
 			revoke();
-			expect(() => render(proxy)).to.not.throw();
+			assert.doesNotThrow(() => render(proxy));
 		});
 
 		it('never throws when the custom inspect hook throws a hostile value (a revoked Proxy) instead of an Error', () => {
@@ -1056,8 +1057,8 @@ describe('Test harper_logger module', () => {
 					throw proxy; // `err instanceof Error` and `String(err)` both throw on a revoked Proxy
 				},
 			};
-			expect(() => render(hostile)).to.not.throw();
-			expect(render(hostile)).to.include('Unrenderable value');
+			assert.doesNotThrow(() => render(hostile));
+			assert.ok(render(hostile).includes('Unrenderable value'));
 		});
 
 		it('sanitizes a nested Error at depth instead of exposing its own-enumerable properties raw (#1734)', () => {
@@ -1068,17 +1069,17 @@ describe('Test harper_logger module', () => {
 			const value = { detail: { cause: { error: nested_error } }, other: 'fine' };
 
 			const result = render(value, { depth: 8, maxArrayLength: 250, maxStringLength: 20000 });
-			expect(result).to.not.include('super-secret-token');
-			expect(result).to.not.include('Authorization');
-			expect(result).to.include('Error: request failed');
-			expect(result).to.include('fine');
+			assert.ok(!result.includes('super-secret-token'));
+			assert.ok(!result.includes('Authorization'));
+			assert.ok(result.includes('Error: request failed'));
+			assert.ok(result.includes('fine'));
 		});
 
 		it('preserves an enumerable symbol property (e.g. a nested value’s own custom inspect hook)', () => {
 			const custom_rendered = { [util.inspect.custom]: () => 'custom-nested-render' };
 			const value = { inner: custom_rendered };
 			const result = render(value, { depth: 8 });
-			expect(result).to.include('custom-nested-render');
+			assert.ok(result.includes('custom-nested-render'));
 		});
 
 		it('sanitizes a secret-carrying Error reached a second time through a cycle', () => {
@@ -1088,8 +1089,8 @@ describe('Test harper_logger module', () => {
 			value.self = value; // cycle: the second path to `value` must not bypass sanitization
 
 			const result = render(value, { depth: 8, maxArrayLength: 250, maxStringLength: 20000 });
-			expect(result).to.not.include('super-secret-token');
-			expect(result).to.include('Error: request failed');
+			assert.ok(!result.includes('super-secret-token'));
+			assert.ok(result.includes('Error: request failed'));
 		});
 
 		it('sanitizes a secret-carrying Error nested inside a Map or Set instead of leaving it raw', () => {
@@ -1100,8 +1101,8 @@ describe('Test harper_logger module', () => {
 				set: new Set([nested_error]),
 			};
 			const result = render(value, { depth: 8 });
-			expect(result).to.not.include('super-secret-token');
-			expect(result).to.include('Error: request failed');
+			assert.ok(!result.includes('super-secret-token'));
+			assert.ok(result.includes('Error: request failed'));
 		});
 
 		it('sanitizes a secret-carrying Error held by a class/custom-prototype instance, preserving its class name', () => {
@@ -1114,9 +1115,9 @@ describe('Test harper_logger module', () => {
 			}
 			const value = { diagnostic: new Diagnostic(nested_error) };
 			const result = render(value, { depth: 8 });
-			expect(result).to.not.include('super-secret-token');
-			expect(result).to.include('Error: request failed');
-			expect(result).to.include('Diagnostic');
+			assert.ok(!result.includes('super-secret-token'));
+			assert.ok(result.includes('Error: request failed'));
+			assert.ok(result.includes('Diagnostic'));
 		});
 
 		it('renders the rest of a structured payload instead of losing it all when a nested value carries a branded prototype (e.g. URL) the clone cannot safely wear', () => {
@@ -1132,10 +1133,10 @@ describe('Test harper_logger module', () => {
 				install_output: { lines: ['step 1 ok', 'step 2 ok'] },
 			};
 			const result = render(value, { depth: 8 });
-			expect(result).to.not.include('Unrenderable value');
-			expect(result).to.include('install');
-			expect(result).to.include('step 1 ok');
-			expect(result).to.include('step 2 ok');
+			assert.ok(!result.includes('Unrenderable value'));
+			assert.ok(result.includes('install'));
+			assert.ok(result.includes('step 1 ok'));
+			assert.ok(result.includes('step 2 ok'));
 		});
 
 		it('never invokes an accessor-backed array entry, and never resolves an overridden Map/Set iterator', () => {
@@ -1163,13 +1164,13 @@ describe('Test harper_logger module', () => {
 			};
 
 			const result = render({ hostile_array, hostile_map, hostile_set }, { depth: 8 });
-			expect(array_getter_calls).to.equal(0);
-			expect(iterator_calls).to.equal(0);
-			expect(result).to.include('[Getter]');
-			expect(result).to.not.include('should not be called');
-			expect(result).to.include("'key' => 'value'");
-			expect(result).to.include("'value'");
-			expect(result).to.not.include('poisoned');
+			assert.strictEqual(array_getter_calls, 0);
+			assert.strictEqual(iterator_calls, 0);
+			assert.ok(result.includes('[Getter]'));
+			assert.ok(!result.includes('should not be called'));
+			assert.ok(result.includes("'key' => 'value'"));
+			assert.ok(result.includes("'value'"));
+			assert.ok(!result.includes('poisoned'));
 		});
 
 		it('bounds sanitization breadth instead of visiting every index of a huge sparse array', () => {
@@ -1177,18 +1178,15 @@ describe('Test harper_logger module', () => {
 			const start = process.hrtime.bigint();
 			const result = render({ huge_sparse_array }, { depth: 8, maxArrayLength: 250 });
 			const elapsed_ms = Number(process.hrtime.bigint() - start) / 1e6;
-			expect(elapsed_ms).to.be.below(
-				2000,
-				'sanitizing a huge sparse array should stay bounded, not scan its full length'
-			);
-			expect(result).to.include('sanitize budget');
+			assert.ok(elapsed_ms < 2000, 'sanitizing a huge sparse array should stay bounded, not scan its full length');
+			assert.ok(result.includes('sanitize budget'));
 		});
 
 		it('bounds sanitization breadth for a large Map/Set rather than cloning every entry', () => {
 			const huge_map = new Map(Array.from({ length: 10_000 }, (_, i) => [i, i]));
 			const huge_set = new Set(Array.from({ length: 10_000 }, (_, i) => i));
 			const result = render({ huge_map, huge_set }, { depth: 8, maxArrayLength: 250 });
-			expect(result).to.include('sanitize budget');
+			assert.ok(result.includes('sanitize budget'));
 		});
 
 		it('creates own properties via defineProperty instead of assignment, so an inherited setter or an own `__proto__` key cannot run during sanitization', () => {
@@ -1218,13 +1216,13 @@ describe('Test harper_logger module', () => {
 			});
 
 			const result = render({ with_setter, proto_bomb }, { depth: 8 });
-			expect(setter_calls).to.equal(0);
-			expect(result).to.not.include('super-secret-token');
-			expect(result).to.include('Error: request failed');
+			assert.strictEqual(setter_calls, 0);
+			assert.ok(!result.includes('super-secret-token'));
+			assert.ok(result.includes('Error: request failed'));
 			// If sanitization used plain assignment instead of defineProperty, `result['__proto__'] =`
 			// would reparent the CLONE instead of creating an own property, silently dropping this
 			// marker from the render (a reparented plain object shows no inherited properties).
-			expect(result).to.include('PROTO_BOMB_SURVIVED');
+			assert.ok(result.includes('PROTO_BOMB_SURVIVED'));
 		});
 
 		it('leaves built-in container types (Date, Map, Buffer) rendered natively instead of corrupting them', () => {
@@ -1232,10 +1230,10 @@ describe('Test harper_logger module', () => {
 			const map = new Map([['key', 'value']]);
 			const buffer = Buffer.from('hi');
 			const result = render({ date, map, buffer }, { depth: 8 });
-			expect(result).to.include('2024-01-01T00:00:00.000Z');
-			expect(result).to.include('Map(1)');
-			expect(result).to.include('key');
-			expect(result).to.match(/Buffer\.from\(|<Buffer/);
+			assert.ok(result.includes('2024-01-01T00:00:00.000Z'));
+			assert.ok(result.includes('Map(1)'));
+			assert.ok(result.includes('key'));
+			assert.match(result, /Buffer\.from\(|<Buffer/);
 		});
 
 		it('omits a field whose getter throws instead of letting it fail the whole render', () => {
@@ -1248,8 +1246,8 @@ describe('Test harper_logger module', () => {
 			});
 			const value = { hostile, fine: 'still here' };
 			const result = render(value, { depth: 8 });
-			expect(result).to.not.include('Unrenderable value');
-			expect(result).to.include('still here');
+			assert.ok(!result.includes('Unrenderable value'));
+			assert.ok(result.includes('still here'));
 		});
 
 		it('never invokes a getter while sanitizing — describes it as [Getter] instead, same as util.inspect’s default', () => {
@@ -1263,10 +1261,10 @@ describe('Test harper_logger module', () => {
 				},
 			});
 			const result = render({ value, fine: 'still here' }, { depth: 8 });
-			expect(call_count).to.equal(0);
-			expect(result).to.include('[Getter]');
-			expect(result).to.not.include('should not be called');
-			expect(result).to.include('still here');
+			assert.strictEqual(call_count, 0);
+			assert.ok(result.includes('[Getter]'));
+			assert.ok(!result.includes('should not be called'));
+			assert.ok(result.includes('still here'));
 		});
 
 		it('sanitizes a secret-carrying Error nested inside a VM cross-realm plain object, Map, and Set', () => {
@@ -1281,12 +1279,12 @@ describe('Test harper_logger module', () => {
 			const vm_set = vm.runInContext('new Set()', context);
 			vm_set.add(vm_error);
 
-			expect(vm_plain_object instanceof Object).to.equal(false); // different realm's Object constructor
-			expect(vm_map instanceof Map).to.equal(false); // different realm's Map constructor
+			assert.strictEqual(vm_plain_object instanceof Object, false); // different realm's Object constructor
+			assert.strictEqual(vm_map instanceof Map, false); // different realm's Map constructor
 
 			const result = render({ vm_plain_object, vm_map, vm_set }, { depth: 8 });
-			expect(result).to.not.include('super-secret-token');
-			expect(result).to.include('Error: vm request failed');
+			assert.ok(!result.includes('super-secret-token'));
+			assert.ok(result.includes('Error: vm request failed'));
 		});
 
 		it('bounds sanitization breadth for a plain object with a huge number of own properties', () => {
@@ -1295,11 +1293,8 @@ describe('Test harper_logger module', () => {
 			const start = process.hrtime.bigint();
 			const result = render({ huge_object }, { depth: 8, maxArrayLength: 250 });
 			const elapsed_ms = Number(process.hrtime.bigint() - start) / 1e6;
-			expect(elapsed_ms).to.be.below(
-				2000,
-				'sanitizing a wide plain object should stay bounded, not clone every property'
-			);
-			expect(result).to.include('sanitize budget');
+			assert.ok(elapsed_ms < 2000, 'sanitizing a wide plain object should stay bounded, not clone every property');
+			assert.ok(result.includes('sanitize budget'));
 		});
 
 		it('never hands a Promise to inspect() raw, even one resolved with a secret-carrying Error (#1734)', () => {
@@ -1307,9 +1302,9 @@ describe('Test harper_logger module', () => {
 			secret_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
 			const value = { pending_check: Promise.resolve(secret_error) };
 			const result = render(value, { depth: 8 });
-			expect(result).to.not.include('super-secret-token');
-			expect(result).to.not.include('Authorization');
-			expect(result).to.include('Promise');
+			assert.ok(!result.includes('super-secret-token'));
+			assert.ok(!result.includes('Authorization'));
+			assert.ok(result.includes('Promise'));
 		});
 
 		it('bounds total sanitize work (containers + primitive leaves), not just container count', () => {
@@ -1325,8 +1320,8 @@ describe('Test harper_logger module', () => {
 			const start = process.hrtime.bigint();
 			const result = render(many_small_objects, { depth: 8, maxArrayLength: 250 });
 			const elapsed_ms = Number(process.hrtime.bigint() - start) / 1e6;
-			expect(elapsed_ms).to.be.below(2000, 'leaf values must count against the shared node budget too');
-			expect(result).to.include('sanitize budget');
+			assert.ok(elapsed_ms < 2000, 'leaf values must count against the shared node budget too');
+			assert.ok(result.includes('sanitize budget'));
 		});
 
 		it('never hands a Date, RegExp, WeakMap, or WeakSet to inspect() raw once it carries a secret-bearing expando (#1734)', () => {
@@ -1343,19 +1338,19 @@ describe('Test harper_logger module', () => {
 			hostile_weakset.cause = secret_error;
 
 			const result = render({ hostile_date, hostile_regexp, hostile_weakmap, hostile_weakset }, { depth: 8 });
-			expect(result).to.not.include('super-secret-token');
-			expect(result).to.not.include('Authorization');
+			assert.ok(!result.includes('super-secret-token'));
+			assert.ok(!result.includes('Authorization'));
 			// The expando-free common case is untouched: native rendering is still preserved.
-			expect(result).to.include('2024-01-01T00:00:00.000Z');
-			expect(result).to.match(/\/abc\/gi/);
+			assert.ok(result.includes('2024-01-01T00:00:00.000Z'));
+			assert.match(result, /\/abc\/gi/);
 		});
 
 		it('still renders a Date/RegExp/WeakMap/WeakSet exactly natively when it has no expando (fast path unaffected)', () => {
 			const date = new Date('2024-01-01T00:00:00.000Z');
 			const regexp = /abc/gi;
 			const result = render({ date, regexp }, { depth: 8 });
-			expect(result).to.include('2024-01-01T00:00:00.000Z');
-			expect(result).to.match(/\/abc\/gi/);
+			assert.ok(result.includes('2024-01-01T00:00:00.000Z'));
+			assert.match(result, /\/abc\/gi/);
 		});
 
 		it('falls back to a bounded, safe summary (not the raw value) for a Buffer/boxed-primitive carrying a secret-bearing expando (#1734)', () => {
@@ -1366,8 +1361,8 @@ describe('Test harper_logger module', () => {
 			const hostile_boxed_number = Object.assign(new Number(5), { cause: secret_error });
 
 			const result = render({ hostile_buffer, hostile_boxed_number }, { depth: 8 });
-			expect(result).to.not.include('super-secret-token');
-			expect(result).to.not.include('Authorization');
+			assert.ok(!result.includes('super-secret-token'));
+			assert.ok(!result.includes('Authorization'));
 		});
 
 		it('does not additionally invoke a hostile `Symbol.toStringTag` getter on a boxed String while classifying it - only util.inspect’s own native rendering does', () => {
@@ -1395,7 +1390,7 @@ describe('Test harper_logger module', () => {
 			invoked = 0;
 
 			render({ boxed_string: makeBoxedString() }, { depth: 8 });
-			expect(invoked).to.equal(baseline);
+			assert.strictEqual(invoked, baseline);
 		});
 
 		it('sanitizes a function’s secret-bearing expando instead of handing the raw function to inspect() (#1734)', () => {
@@ -1405,9 +1400,9 @@ describe('Test harper_logger module', () => {
 			hostile_function.cause = secret_error;
 
 			const result = render({ hostile_function }, { depth: 8 });
-			expect(result).to.not.include('super-secret-token');
-			expect(result).to.not.include('Authorization');
-			expect(result).to.include('Error: request failed');
+			assert.ok(!result.includes('super-secret-token'));
+			assert.ok(!result.includes('Authorization'));
+			assert.ok(result.includes('Error: request failed'));
 		});
 
 		it('still renders a plain function raw when it has no expando (fast path unaffected)', () => {
@@ -1415,7 +1410,7 @@ describe('Test harper_logger module', () => {
 				return a + b;
 			}
 			const result = render({ plain_function }, { depth: 8 });
-			expect(result).to.include('[Function: plain_function]');
+			assert.ok(result.includes('[Function: plain_function]'));
 		});
 
 		it('fails closed for a Proxy whose `ownKeys` trap throws - caught by the isProxy gate before the trap ever runs (#1734)', () => {
@@ -1433,8 +1428,8 @@ describe('Test harper_logger module', () => {
 				}
 			);
 			const result = render({ hostile }, { depth: 8 });
-			expect(result).to.not.include('super-secret-token');
-			expect(result).to.not.include('Authorization');
+			assert.ok(!result.includes('super-secret-token'));
+			assert.ok(!result.includes('Authorization'));
 		});
 
 		it('never invokes ANY trap on a nested Proxy - not just a throwing one - and never leaks its target', () => {
@@ -1459,10 +1454,10 @@ describe('Test harper_logger module', () => {
 				}
 			);
 			const result = render({ hostile }, { depth: 8 });
-			expect(trap_calls).to.equal(0, 'no Proxy trap should ever be invoked while sanitizing');
-			expect(result).to.not.include('super-secret-token');
-			expect(result).to.not.include('Authorization');
-			expect(result).to.include('Proxy');
+			assert.strictEqual(trap_calls, 0, 'no Proxy trap should ever be invoked while sanitizing');
+			assert.ok(!result.includes('super-secret-token'));
+			assert.ok(!result.includes('Authorization'));
+			assert.ok(result.includes('Proxy'));
 		});
 
 		it('clamps an unbounded/huge caller-requested maxArrayLength to a hard ceiling instead of scanning the full array', () => {
@@ -1470,11 +1465,11 @@ describe('Test harper_logger module', () => {
 			const start = process.hrtime.bigint();
 			const result = render({ huge_array }, { depth: 8, maxArrayLength: Infinity });
 			const elapsed_ms = Number(process.hrtime.bigint() - start) / 1e6;
-			expect(elapsed_ms).to.be.below(
-				2000,
+			assert.ok(
+				elapsed_ms < 2000,
 				'an unbounded requested maxArrayLength must not defeat the sanitize breadth ceiling'
 			);
-			expect(result).to.include('sanitize budget');
+			assert.ok(result.includes('sanitize budget'));
 		});
 
 		it('never returns a nested Error unsanitized once the sanitize depth cap is hit (requires a caller-requested depth beyond the cap)', () => {
@@ -1483,8 +1478,8 @@ describe('Test harper_logger module', () => {
 			let value = secret_error;
 			for (let i = 0; i < 25; i++) value = { nested: value };
 			const result = render(value, { depth: 30 });
-			expect(result).to.not.include('super-secret-token');
-			expect(result).to.not.include('Authorization');
+			assert.ok(!result.includes('super-secret-token'));
+			assert.ok(!result.includes('Authorization'));
 		});
 
 		it('fails closed to a bounded, quick placeholder for a huge Buffer/boxed-String instead of scanning every index - even when expando-free', () => {
@@ -1498,17 +1493,17 @@ describe('Test harper_logger module', () => {
 			const start = process.hrtime.bigint();
 			const result = render({ huge_buffer, huge_boxed_string }, { depth: 8 });
 			const elapsed_ms = Number(process.hrtime.bigint() - start) / 1e6;
-			expect(elapsed_ms).to.be.below(500, 'failing closed above the size cap must not scan every element/character');
-			expect(result).to.not.match(/Buffer\.from\(|<Buffer/);
-			expect(result).to.include('with own properties omitted for safety');
+			assert.ok(elapsed_ms < 500, 'failing closed above the size cap must not scan every element/character');
+			assert.ok(!/Buffer\.from\(|<Buffer/.test(result));
+			assert.ok(result.includes('with own properties omitted for safety'));
 		});
 
 		it('still resolves a small expando-free Buffer/boxed-String natively (below the size cap, fast path unaffected)', () => {
 			const small_buffer = Buffer.from('hi');
 			const small_boxed_string = new String('hi');
 			const result = render({ small_buffer, small_boxed_string }, { depth: 8 });
-			expect(result).to.match(/Buffer\.from\(|<Buffer/);
-			expect(result).to.include('hi');
+			assert.match(result, /Buffer\.from\(|<Buffer/);
+			assert.ok(result.includes('hi'));
 		});
 
 		it('fails closed (safe summary, not raw) for a Buffer just over the size cap that actually carries an expando', () => {
@@ -1517,8 +1512,8 @@ describe('Test harper_logger module', () => {
 			const hostile_buffer = Buffer.alloc(10_001);
 			hostile_buffer.cause = secret_error;
 			const result = render({ hostile_buffer }, { depth: 8 });
-			expect(result).to.not.include('super-secret-token');
-			expect(result).to.not.include('Authorization');
+			assert.ok(!result.includes('super-secret-token'));
+			assert.ok(!result.includes('Authorization'));
 		});
 	});
 
@@ -1526,25 +1521,25 @@ describe('Test harper_logger module', () => {
 		const { isErrorLike } = harperLoggerModule;
 
 		it('recognizes a same-realm Error', () => {
-			expect(isErrorLike(new Error('boom'))).to.equal(true);
+			assert.strictEqual(isErrorLike(new Error('boom')), true);
 		});
 
 		it('recognizes a cross-realm (VM-created) Error', () => {
 			const vm = require('vm');
 			const vmError = vm.runInNewContext('new Error("vm boom")');
-			expect(vmError instanceof Error).to.equal(false); // different realm's Error constructor
-			expect(isErrorLike(vmError)).to.equal(true);
+			assert.strictEqual(vmError instanceof Error, false); // different realm's Error constructor
+			assert.strictEqual(isErrorLike(vmError), true);
 		});
 
 		it('does not recognize a plain object', () => {
-			expect(isErrorLike({ message: 'not an error' })).to.equal(false);
+			assert.strictEqual(isErrorLike({ message: 'not an error' }), false);
 		});
 
 		it('does not throw and returns false for a revoked Proxy', () => {
 			const { proxy, revoke } = Proxy.revocable(new Error('gone'), {});
 			revoke();
-			expect(() => isErrorLike(proxy)).to.not.throw();
-			expect(isErrorLike(proxy)).to.equal(false);
+			assert.doesNotThrow(() => isErrorLike(proxy));
+			assert.strictEqual(isErrorLike(proxy), false);
 		});
 
 		it("never invokes a live (non-revoked) Proxy's getPrototypeOf trap - `instanceof` would otherwise trigger it", () => {
@@ -1555,8 +1550,8 @@ describe('Test harper_logger module', () => {
 					return Reflect.getPrototypeOf(target);
 				},
 			});
-			expect(isErrorLike(hostile)).to.equal(false);
-			expect(trap_calls).to.equal(0, 'isErrorLike must classify a Proxy without reflecting on it at all');
+			assert.strictEqual(isErrorLike(hostile), false);
+			assert.strictEqual(trap_calls, 0, 'isErrorLike must classify a Proxy without reflecting on it at all');
 		});
 	});
 
@@ -1668,8 +1663,8 @@ describe('Test harper_logger module', () => {
 			logger.dir(proxy);
 			logger.table([proxy]);
 			const output = lines.join('\n');
-			expect(output).to.not.include('super-secret-token');
-			expect(output).to.not.include('hdb_secret');
+			assert.ok(!output.includes('super-secret-token'));
+			assert.ok(!output.includes('hdb_secret'));
 		});
 
 		it('does not throw when a revoked Proxy appears as a cause', () => {

--- a/unitTests/utility/logging/harper_logger.test.js
+++ b/unitTests/utility/logging/harper_logger.test.js
@@ -1351,6 +1351,34 @@ describe('Test harper_logger module', () => {
 			expect(result).to.not.include('Authorization');
 		});
 
+		it('does not additionally invoke a hostile `Symbol.toStringTag` getter on a boxed String while classifying it - only util.inspect’s own native rendering does', () => {
+			// util.inspect itself reads Symbol.toStringTag on every value it renders (to decide the
+			// display tag), so the getter firing once, from inspect's own native formatting of the
+			// final sanitized value, is unavoidable and not what this guards against. What the fix at
+			// hasEnumerableOwnProps (types.isStringObject instead of Object.prototype.toString.call)
+			// removes is a SECOND invocation from our own classification logic, reached before inspect
+			// ever sees the value - i.e. running a hostile getter as a side effect of merely deciding
+			// how to sanitize, not of rendering.
+			let invoked = 0;
+			const makeBoxedString = () => {
+				const boxed_string = new String('hi');
+				Object.defineProperty(boxed_string, Symbol.toStringTag, {
+					get() {
+						invoked++;
+						return 'String';
+					},
+				});
+				return boxed_string;
+			};
+
+			util.inspect(makeBoxedString());
+			const baseline = invoked;
+			invoked = 0;
+
+			render({ boxed_string: makeBoxedString() }, { depth: 8 });
+			expect(invoked).to.equal(baseline);
+		});
+
 		it('sanitizes a function’s secret-bearing expando instead of handing the raw function to inspect() (#1734)', () => {
 			const secret_error = new Error('request failed');
 			secret_error.config = { headers: { Authorization: 'Bearer super-secret-token' } };
@@ -1610,6 +1638,19 @@ describe('Test harper_logger module', () => {
 			revoke();
 			expect(() => logger.error('operation failed', proxy)).to.not.throw();
 			expect(lines.join('\n')).to.include('operation failed');
+		});
+
+		it('does not leak a secret through a live (non-revoked) Proxy wrapping an Error (#1734)', () => {
+			const { logger, lines } = createCapturingLogger();
+			const error = new Error('origin fetch failed');
+			error.hdb_secret = 'Bearer super-secret-token';
+			const proxy = new Proxy(error, {});
+			logger.error(proxy);
+			logger.dir(proxy);
+			logger.table([proxy]);
+			const output = lines.join('\n');
+			expect(output).to.not.include('super-secret-token');
+			expect(output).to.not.include('hdb_secret');
 		});
 
 		it('does not throw when a revoked Proxy appears as a cause', () => {

--- a/utility/OperationFunctionCaller.ts
+++ b/utility/OperationFunctionCaller.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import log from './logging/harper_logger.ts';
+import log, { isErrorLike, inspectForLog } from './logging/harper_logger.ts';
 import * as terms from './hdbTerms.ts';
 
 /**
@@ -53,7 +53,24 @@ export async function callOperationFunctionAsAwait(
 		// This check is here to make sure a new HdbError is logged correctly
 		if (err.http_resp_msg) {
 			log.error(`Error calling operation: ${promisifiedFunction.name}`);
-			log.error(err.http_resp_msg);
+			if (typeof err.http_resp_msg === 'string' || isErrorLike(err.http_resp_msg)) {
+				// A string passes through as-is; an Error (same-realm or a VM-created cross-realm
+				// Error - component code runs through node:vm) goes through the normal log.error path
+				// so it gets the same secret-safe handling as any other logged Error (#1734), rather
+				// than the raw inspect() below.
+				log.error(err.http_resp_msg);
+			} else {
+				// Otherwise http_resp_msg is a structured diagnostic object (e.g. deployComponent's
+				// phase/install_output/deployment_id detail). Console's defaults (depth: 2,
+				// maxArrayLength: 100, maxStringLength: 10000) flatten that to `[Object]`, drop array
+				// entries past the 100th, and truncate any individual string over 10000 chars - hiding
+				// the very data an operator needs to grep (harper#1982), most concretely
+				// install_output.lines, which is capped at 200 entries / 16KB total. inspectForLog
+				// renders it fully, bounded well above that cap rather than left unbounded, and defers
+				// the (potentially expensive) render until the logger's level gate actually writes the
+				// entry rather than paying for it on a call that gets discarded.
+				log.error(inspectForLog(err.http_resp_msg, { depth: 8, maxArrayLength: 250, maxStringLength: 20000 }));
+			}
 			throw err;
 		}
 		log.error(`Error calling operation: ${promisifiedFunction.name}`);

--- a/utility/OperationFunctionCaller.ts
+++ b/utility/OperationFunctionCaller.ts
@@ -51,14 +51,18 @@ export async function callOperationFunctionAsAwait(
 			throw err;
 		}
 		// This check is here to make sure a new HdbError is logged correctly
-		if (err.http_resp_msg) {
+		// Read exactly once: err.http_resp_msg could be an accessor (component code is not required
+		// to use a plain data property), and classifying one read while logging a later, different
+		// read would let a value that was never actually checked reach the "safe" raw log.error path.
+		const http_resp_msg = err.http_resp_msg;
+		if (http_resp_msg) {
 			log.error(`Error calling operation: ${promisifiedFunction.name}`);
-			if (typeof err.http_resp_msg === 'string' || isErrorLike(err.http_resp_msg)) {
+			if (typeof http_resp_msg === 'string' || isErrorLike(http_resp_msg)) {
 				// A string passes through as-is; an Error (same-realm or a VM-created cross-realm
 				// Error - component code runs through node:vm) goes through the normal log.error path
 				// so it gets the same secret-safe handling as any other logged Error (#1734), rather
 				// than the raw inspect() below.
-				log.error(err.http_resp_msg);
+				log.error(http_resp_msg);
 			} else {
 				// Otherwise http_resp_msg is a structured diagnostic object (e.g. deployComponent's
 				// phase/install_output/deployment_id detail). Console's defaults (depth: 2,
@@ -69,7 +73,7 @@ export async function callOperationFunctionAsAwait(
 				// renders it fully, bounded well above that cap rather than left unbounded, and defers
 				// the (potentially expensive) render until the logger's level gate actually writes the
 				// entry rather than paying for it on a call that gets discarded.
-				log.error(inspectForLog(err.http_resp_msg, { depth: 8, maxArrayLength: 250, maxStringLength: 20000 }));
+				log.error(inspectForLog(http_resp_msg, { depth: 8, maxArrayLength: 250, maxStringLength: 20000 }));
 			}
 			throw err;
 		}

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -186,14 +186,21 @@ async function updateLogSettings() {
 /**
  * True when the argument is an Error (same-realm or native cross-realm — component code runs
  * through node:vm, so a VM-created Error fails `instanceof Error` but passes `isNativeError`).
- * The try/catch guards exotic objects whose prototype is unreachable (e.g. a revoked Proxy,
- * where `instanceof` throws) — the logger must never throw on any input, and util.format
+ * A Proxy is checked and rejected FIRST, before `instanceof`: `instanceof` walks the prototype
+ * chain via `[[GetPrototypeOf]]`, which for a Proxy invokes its `getPrototypeOf` trap - a trap
+ * that hangs (an infinite loop) or has side effects would run to completion regardless of the
+ * try/catch below (which only helps a trap that throws), on whatever path called isErrorLike
+ * (e.g. logging a DIFFERENT operation's failure). `types.isProxy` queries the exotic object's
+ * internal slots directly and never reflects on it, so it's always safe to check first, even on
+ * a revoked Proxy. The try/catch below still guards other exotic objects whose prototype is
+ * unreachable for other reasons — the logger must never throw on any input, and util.format
  * renders those fine raw. Exported so call sites outside this module (e.g.
  * OperationFunctionCaller, deciding how to log an error-shaped value it didn't itself catch as
  * an Error) can reuse the same classification instead of a weaker local `instanceof` check.
  */
 export function isErrorLike(arg: any): boolean {
 	try {
+		if (types.isProxy(arg)) return false;
 		return arg instanceof Error || isNativeError(arg);
 	} catch {
 		return false;
@@ -1157,8 +1164,9 @@ function isOpaqueBuiltin(value: object): boolean {
 // so a hostile value can shadow it with an own `length` property reporting whatever it likes.
 const TYPED_ARRAY_PROTO = Object.getPrototypeOf(Uint8Array.prototype);
 
-// Above this many elements, hasEnumerableOwnProps skips its indexed-type check and assumes "no
-// expando" rather than paying for it - see the comment at that check for why.
+// Above this many elements, hasEnumerableOwnProps skips its indexed-type check and fails closed
+// (assumes an expando IS present, safe direction) rather than paying for it - see the comment at
+// that check for why.
 const MAX_INDEXED_EXPANDO_CHECK_LENGTH = 10_000;
 
 /**
@@ -1183,9 +1191,14 @@ const MAX_INDEXED_EXPANDO_CHECK_LENGTH = 10_000;
  * a multi-hundred-MB Buffer or huge boxed string would materialize a matching number of key strings
  * merely to decide this supposedly-cheap fast path applies, turning it into an attacker-sized scan
  * on the error-logging path itself. Above MAX_INDEXED_EXPANDO_CHECK_LENGTH elements, skip the check
- * and assume no expando instead: deliberately attaching a secret-bearing Error to an indexed value
- * that large is a vanishingly unlikely, deliberately hostile construction, and unconditionally
- * scanning it is a worse trade than accepting that narrow, contrived residual risk.
+ * and FAIL CLOSED (assume it HAS an expando) rather than skip it and assume clean: the safe
+ * direction when we can't verify is always "has an expando" (same as the hostile-trap catch above),
+ * never "verified clean" - failing open here would return e.g. a `Buffer.alloc(10_001)` carrying a
+ * real, ordinary-sized expando raw, unsanitized. Failing closed still avoids the expensive scan
+ * (that's the whole point of the size cap) - it just means a huge but genuinely expando-free
+ * Buffer/string also renders as safeOpaqueBuiltinSummary's generic placeholder above this size,
+ * rather than its full native format. Losing pretty-printing for a buffer/string that large is a
+ * reasonable trade for never guessing "clean" on data we didn't actually check.
  */
 function hasEnumerableOwnProps(value: object): boolean {
 	try {
@@ -1197,7 +1210,7 @@ function hasEnumerableOwnProps(value: object): boolean {
 			// property per spec and can't be shadowed, so a direct read is already safe.
 			const length = isTypedArray ? Reflect.get(TYPED_ARRAY_PROTO, 'length', value) : (value as any).length;
 			if (typeof length !== 'number') return true; // couldn't verify the intrinsic size - conservative
-			if (length > MAX_INDEXED_EXPANDO_CHECK_LENGTH) return false; // too large to check - accepted tradeoff
+			if (length > MAX_INDEXED_EXPANDO_CHECK_LENGTH) return true; // too large to check - fail closed, not clean
 			const keys = Object.keys(value);
 			for (const key of keys) {
 				const index = key === '' ? NaN : Number(key);
@@ -1371,7 +1384,12 @@ function deepSanitizeErrors(
 		}
 		if (isFunction && !hasEnumerableOwnProps(value)) return value; // same fast path, for functions
 	} catch {
-		return value; // e.g. a revoked Proxy - util.inspect renders those fine on its own
+		// The types.isProxy check above already routes every Proxy (revoked or not) to a placeholder
+		// before this block ever runs, so nothing YET IDENTIFIED reaches this catch on real input -
+		// but on the same "never fall back to raw" principle as every other catch in this walk, a
+		// safe placeholder costs nothing here and closes the door on whatever unforeseen way a
+		// future value might still throw here.
+		return sanitizeFailurePlaceholder();
 	}
 	// A function reaching here carries an expando: fall through into the generic object walk below
 	// (Object.keys/getOwnPropertyDescriptor/getOwnPropertySymbols all work the same on a function as

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -1063,6 +1063,15 @@ const MAX_SANITIZE_DEPTH = 20;
 // *original* error, before inspect ever gets a chance to truncate the output.
 const DEFAULT_MAX_SANITIZE_ENTRIES = 1000;
 const MAX_SANITIZE_NODES = 50_000;
+// Hard ceiling on the per-container breadth budget, regardless of what a caller requests via
+// inspectForLog's `maxArrayLength` option. Without this, a caller passing an unbounded value
+// (`Infinity`, or just a very large finite one) sets a container's own loop limit that high too -
+// so even though deepSanitizeErrors itself starts returning cheap placeholders once
+// MAX_SANITIZE_NODES is exhausted, the PARENT loop (the one iterating a huge array/Map/Set's
+// entries) still runs for its full stated limit before that ever kicks in, defeating the budget as
+// a real ceiling on total work. The one caller in this codebase passes 250; this only bites a
+// caller that deliberately (or by bug) requests something far larger.
+const HARD_MAX_SANITIZE_ENTRIES = 10_000;
 
 interface SanitizeBudget {
 	nodes: number;
@@ -1141,6 +1150,17 @@ function isOpaqueBuiltin(value: object): boolean {
 	);
 }
 
+// %TypedArray%.prototype - the shared abstract superclass prototype every concrete TypedArray
+// (Uint8Array, Buffer, etc.) inherits `length` from. Read once so hasEnumerableOwnProps can bind
+// to it explicitly via Reflect.get, the same hijack-avoidance pattern as the Map/Set branches'
+// `Reflect.get(Map.prototype, 'size', value)` - the intrinsic `length` getter is spec-configurable,
+// so a hostile value can shadow it with an own `length` property reporting whatever it likes.
+const TYPED_ARRAY_PROTO = Object.getPrototypeOf(Uint8Array.prototype);
+
+// Above this many elements, hasEnumerableOwnProps skips its indexed-type check and assumes "no
+// expando" rather than paying for it - see the comment at that check for why.
+const MAX_INDEXED_EXPANDO_CHECK_LENGTH = 10_000;
+
 /**
  * True if `value` has any own-enumerable string or symbol property beyond its own intrinsic data -
  * i.e. an expando - since none of isOpaqueBuiltin's types (nor a bare function) normally carry any.
@@ -1151,22 +1171,40 @@ function isOpaqueBuiltin(value: object): boolean {
  *
  * A TypedArray/Buffer's own numeric indices ARE its intrinsic byte/element data, own-enumerable
  * exactly like any other array - `Object.keys(Buffer.from('hi'))` is `['0', '1']` - so those don't
- * count as expandos here; only a key beyond `[0, length)` does. DataView has no such index
- * properties (its data is accessed only via get/set methods), so it's excluded from that carve-out.
+ * count as expandos here; only a key beyond `[0, length)` does. A boxed String has the same shape
+ * (`Object.keys(new String('hi'))` is the same `['0', '1']`) and gets the same carve-out; detected
+ * via the intrinsic `Object.prototype.toString` tag rather than `instanceof String` (realm/hijack-
+ * safe, same technique safeOpaqueBuiltinSummary's fallback tag uses). DataView has no such index
+ * properties (its data is accessed only via get/set methods), so it's excluded from the carve-out
+ * and goes through the plain `Object.keys(value).length > 0` check like any ordinary object.
+ *
+ * For either indexed shape, checking for an expando against `Object.keys` costs one array
+ * allocation sized to the FULL length just to answer "clean or not" - fine for a small buffer, but
+ * a multi-hundred-MB Buffer or huge boxed string would materialize a matching number of key strings
+ * merely to decide this supposedly-cheap fast path applies, turning it into an attacker-sized scan
+ * on the error-logging path itself. Above MAX_INDEXED_EXPANDO_CHECK_LENGTH elements, skip the check
+ * and assume no expando instead: deliberately attaching a secret-bearing Error to an indexed value
+ * that large is a vanishingly unlikely, deliberately hostile construction, and unconditionally
+ * scanning it is a worse trade than accepting that narrow, contrived residual risk.
  */
 function hasEnumerableOwnProps(value: object): boolean {
 	try {
-		const keys = Object.keys(value);
-		if (keys.length > 0) {
-			if (ArrayBuffer.isView(value) && typeof (value as any).length === 'number' && !types.isDataView(value)) {
-				const length = (value as any).length;
-				for (const key of keys) {
-					const index = key === '' ? NaN : Number(key);
-					if (!(Number.isInteger(index) && index >= 0 && index < length && String(index) === key)) return true;
-				}
-			} else {
-				return true;
+		const isTypedArray = ArrayBuffer.isView(value) && !types.isDataView(value);
+		const isBoxedString = types.isBoxedPrimitive(value) && Object.prototype.toString.call(value) === '[object String]';
+		if (isTypedArray || isBoxedString) {
+			// The typed-array getter is bound explicitly (see TYPED_ARRAY_PROTO above) to survive a
+			// shadowed own `length`; a boxed String's `length` is a non-configurable, non-writable own
+			// property per spec and can't be shadowed, so a direct read is already safe.
+			const length = isTypedArray ? Reflect.get(TYPED_ARRAY_PROTO, 'length', value) : (value as any).length;
+			if (typeof length !== 'number') return true; // couldn't verify the intrinsic size - conservative
+			if (length > MAX_INDEXED_EXPANDO_CHECK_LENGTH) return false; // too large to check - accepted tradeoff
+			const keys = Object.keys(value);
+			for (const key of keys) {
+				const index = key === '' ? NaN : Number(key);
+				if (!(Number.isInteger(index) && index >= 0 && index < length && String(index) === key)) return true;
 			}
+		} else if (Object.keys(value).length > 0) {
+			return true;
 		}
 		for (const sym of Object.getOwnPropertySymbols(value)) {
 			if (Object.getOwnPropertyDescriptor(value, sym)?.enumerable) return true;
@@ -1288,9 +1326,26 @@ function deepSanitizeErrors(
 	// before this cap ever engaged.
 	if (++budget.nodes > MAX_SANITIZE_NODES) return labelPlaceholder('[Unrenderable value: sanitize budget exceeded]');
 	if (value === null || (typeof value !== 'object' && typeof value !== 'function')) return value;
+	// Checked before isErrorLike/anything else that reflects on `value`: types.isProxy queries the
+	// exotic object's internal slots directly (safe even on a revoked Proxy - it never throws), but
+	// EVERY reflective operation past this point - `instanceof` inside isErrorLike, Array.isArray,
+	// Object.getPrototypeOf, Object.keys - invokes whatever trap the Proxy's handler defines for it.
+	// A throwing trap was already caught by the try/catch below, but a trap that hangs (an infinite
+	// loop) or has side effects runs to completion regardless of any catch - on the very path meant
+	// to log a DIFFERENT failure. There is no privileged way in userland to read a Proxy's target
+	// without going through its traps (the exact reason native util.inspect's default rendering,
+	// which does have that privileged access, isn't reusable here - see the Promise note above for
+	// the same class of "can't safely introspect this" tradeoff), so a Proxy is never reflected on
+	// at all: always a safe, static placeholder, trap or no trap.
+	if (types.isProxy(value)) return labelPlaceholder('[Proxy]');
 	if (isErrorLike(value)) return errorForLog(value);
 	if (seen.has(value)) return seen.get(value);
-	if (depth >= MAX_SANITIZE_DEPTH) return value;
+	// Depth-capped values are never handed back raw: an Error directly AT this depth is already
+	// caught by isErrorLike above, but a plain container here could still hold an Error somewhere
+	// inside it that we're choosing not to recurse into - handing it back unsanitized would let a
+	// caller-requested depth greater than MAX_SANITIZE_DEPTH (the one caller in this codebase uses
+	// 8, well under it) reach and print that Error's own-enumerable properties raw (#1734).
+	if (depth >= MAX_SANITIZE_DEPTH) return labelPlaceholder('[Unrenderable value: sanitize depth exceeded]');
 
 	let isArray: boolean, isMap: boolean, isSet: boolean, isFunction: boolean;
 	try {
@@ -1521,7 +1576,7 @@ export function inspectForLog(value: any, options?: any) {
 			const maxEntries = Number(options?.maxArrayLength);
 			const budget: SanitizeBudget = {
 				nodes: 0,
-				maxEntries: maxEntries > 0 ? maxEntries : DEFAULT_MAX_SANITIZE_ENTRIES,
+				maxEntries: maxEntries > 0 ? Math.min(maxEntries, HARD_MAX_SANITIZE_ENTRIES) : DEFAULT_MAX_SANITIZE_ENTRIES,
 			};
 			return inspect(deepSanitizeErrors(value, new WeakMap(), 0, budget), options);
 		} catch (err) {

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -1067,12 +1067,15 @@ function isPlainObject(value: object): boolean {
  * anywhere inside a value later rendered with a raised inspect depth (see inspectForLog) would
  * otherwise surface its own-enumerable properties raw.
  *
- * Only plain objects and arrays are rebuilt. Anything else (Date, Map, Set, Buffer, RegExp, a
- * class instance) is returned as-is: rebuilding one via Object.keys() would silently corrupt its
- * rendering (a Date/Map/Buffer's actual data isn't reachable through its own enumerable string
- * keys - Object.keys(new Date()) is `[]`) in exchange for a residual gap - a raw Error nested
- * inside one of these container types is not sanitized - that mirrors sanitizeErrorArgs' own
- * accepted shallow-by-design boundary rather than introducing a new one.
+ * Plain objects, arrays, Map, and Set are rebuilt so an Error nested inside them is still reached
+ * and sanitized. Anything else (Date, Buffer, RegExp, a class instance) is returned as-is:
+ * rebuilding one via Object.keys() would silently corrupt its rendering (a Date/Buffer's actual
+ * data isn't reachable through its own enumerable string keys - Object.keys(new Date()) is `[]`)
+ * in exchange for a residual gap - a raw Error nested inside one of these types is not sanitized -
+ * that mirrors sanitizeErrorArgs' own accepted shallow-by-design boundary rather than introducing
+ * a new one. Map/Set are common enough carriers for a nested cause (e.g. an aggregated-errors map)
+ * that leaving them raw would hand the raised inspect depth here a real secret-leak path #1734
+ * guards against everywhere else, so they get the same rebuild-and-sanitize treatment as objects.
  *
  * Cycle-safe via a WeakMap from original to its (in-progress) clone, registered before recursing
  * into children, so a cycle resolves to the clone in progress rather than falling back to the raw
@@ -1088,10 +1091,12 @@ function deepSanitizeErrors(value: any, seen: WeakMap<object, any> = new WeakMap
 	if (seen.has(value)) return seen.get(value);
 	if (depth >= MAX_SANITIZE_DEPTH) return value;
 
-	let isArray: boolean;
+	let isArray: boolean, isMap: boolean, isSet: boolean;
 	try {
 		isArray = Array.isArray(value);
-		if (!isArray && !isPlainObject(value)) return value;
+		isMap = !isArray && value instanceof Map;
+		isSet = !isArray && !isMap && value instanceof Set;
+		if (!isArray && !isMap && !isSet && !isPlainObject(value)) return value;
 	} catch {
 		return value; // e.g. a revoked Proxy - util.inspect renders those fine on its own
 	}
@@ -1104,6 +1109,32 @@ function deepSanitizeErrors(value: any, seen: WeakMap<object, any> = new WeakMap
 				clone.push(deepSanitizeErrors(item, seen, depth + 1));
 			} catch {
 				clone.push(item);
+			}
+		}
+		return clone;
+	}
+
+	if (isMap) {
+		const clone = new Map();
+		seen.set(value, clone);
+		for (const [k, v] of value) {
+			try {
+				clone.set(deepSanitizeErrors(k, seen, depth + 1), deepSanitizeErrors(v, seen, depth + 1));
+			} catch {
+				clone.set(k, v);
+			}
+		}
+		return clone;
+	}
+
+	if (isSet) {
+		const clone = new Set();
+		seen.set(value, clone);
+		for (const item of value) {
+			try {
+				clone.add(deepSanitizeErrors(item, seen, depth + 1));
+			} catch {
+				clone.add(item);
 			}
 		}
 		return clone;
@@ -1169,7 +1200,11 @@ export function inspectForLog(value: any, options?: any) {
 		try {
 			return inspect(deepSanitizeErrors(value), options);
 		} catch (err) {
-			return `[Unrenderable value: ${err instanceof Error ? err.message : String(err)}]`;
+			// errorToString is the guaranteed-never-throw stringifier (unlike `err instanceof Error` or
+			// `String(err)` here, both of which can themselves throw on a hostile value - e.g. a revoked
+			// Proxy thrown by a nested custom-inspect hook - which would otherwise escape this catch and
+			// mask the real operation error being logged).
+			return `[Unrenderable value: ${errorToString(err)}]`;
 		}
 	};
 	return { [inspect.custom]: render, toString: render };

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -1122,12 +1122,12 @@ const SYMBOLS_TRUNCATED_MARKER = Symbol('sanitize: symbol-keyed properties trunc
  * the header). There is no supported synchronous way to read that value in order to sanitize it, so
  * the only safe option is to never hand a Promise to inspect() raw.
  *
- * Residual gap, accepted rather than chased further: an *expando* own-enumerable property stashed
- * directly on one of these remaining opaque built-ins (e.g. `const d = new Date(); d.cause =
- * secretError`) is not reached either, since the value is returned entirely unwalked to protect its
- * native rendering. Attaching an expando to a Date/Buffer/etc. is not a pattern any real diagnostic
- * payload (deployComponent's or otherwise) produces - unlike the Map/Set/class-instance cases above,
- * which are ordinary, expected shapes for a generic `http_resp_msg` field.
+ * An *expando* own-enumerable property stashed directly on one of these (e.g. `const d = new
+ * Date(); d.cause = secretError`) would otherwise leak the same way the Promise case above does -
+ * inspect() renders own-enumerable properties on ANY object, opaque built-ins included. Handled by
+ * hasEnumerableOwnProps/safeOpaqueBuiltinSummary below: the fast, zero-cost, common path (no
+ * expando) returns the value raw and untouched; only a value actually carrying one pays for a safe
+ * replacement.
  */
 function isOpaqueBuiltin(value: object): boolean {
 	return (
@@ -1139,6 +1139,76 @@ function isOpaqueBuiltin(value: object): boolean {
 		types.isWeakSet(value) ||
 		types.isBoxedPrimitive(value) // a boxed Boolean/Number/String/Symbol/BigInt wrapper
 	);
+}
+
+/**
+ * True if `value` has any own-enumerable string or symbol property beyond its own intrinsic data -
+ * i.e. an expando - since none of isOpaqueBuiltin's types (nor a bare function) normally carry any.
+ * Checked before deciding whether an opaque built-in/function is safe to hand to inspect() raw.
+ * Errs conservative: if the check itself cannot be completed safely (a hostile `ownKeys`/descriptor
+ * trap), treat that as "has an expando" rather than risk a false "clean" on something we couldn't
+ * actually verify.
+ *
+ * A TypedArray/Buffer's own numeric indices ARE its intrinsic byte/element data, own-enumerable
+ * exactly like any other array - `Object.keys(Buffer.from('hi'))` is `['0', '1']` - so those don't
+ * count as expandos here; only a key beyond `[0, length)` does. DataView has no such index
+ * properties (its data is accessed only via get/set methods), so it's excluded from that carve-out.
+ */
+function hasEnumerableOwnProps(value: object): boolean {
+	try {
+		const keys = Object.keys(value);
+		if (keys.length > 0) {
+			if (ArrayBuffer.isView(value) && typeof (value as any).length === 'number' && !types.isDataView(value)) {
+				const length = (value as any).length;
+				for (const key of keys) {
+					const index = key === '' ? NaN : Number(key);
+					if (!(Number.isInteger(index) && index >= 0 && index < length && String(index) === key)) return true;
+				}
+			} else {
+				return true;
+			}
+		}
+		for (const sym of Object.getOwnPropertySymbols(value)) {
+			if (Object.getOwnPropertyDescriptor(value, sym)?.enumerable) return true;
+		}
+		return false;
+	} catch {
+		return true;
+	}
+}
+
+/**
+ * Returns a value safe to hand to inspect() in place of an opaque built-in that (unusually) carries
+ * an expando property - reached only via hasEnumerableOwnProps returning true, never on the common
+ * expando-free path. Date/RegExp/WeakMap/WeakSet are cheap to reconstruct byte/value-for-value from
+ * their intrinsic prototype (bound explicitly via .call/Reflect.get, not `value.getTime()` etc,
+ * exactly so an own property shadowing that method - the same class of hijack the Map/Set branches
+ * below guard against - can't run instead of the real accessor); WeakMap/WeakSet never expose their
+ * entries via inspect regardless, so a fresh empty instance loses nothing. Buffer/TypedArray/
+ * DataView/ArrayBuffer/boxed-primitives are left as a bounded type-tag summary instead: safely
+ * reconstructing an exact byte-for-byte or value-for-value copy needs per-subtype branching that
+ * isn't worth it for how rarely one of these ever carries an expando in the first place.
+ */
+function safeOpaqueBuiltinSummary(value: object): any {
+	try {
+		if (types.isDate(value)) return new Date(Date.prototype.getTime.call(value));
+		if (types.isRegExp(value)) {
+			const source = Reflect.get(RegExp.prototype, 'source', value);
+			const flags = Reflect.get(RegExp.prototype, 'flags', value);
+			return new RegExp(source, flags);
+		}
+		if (types.isWeakMap(value)) return new WeakMap();
+		if (types.isWeakSet(value)) return new WeakSet();
+	} catch {
+		// fall through to the generic tag-only summary below
+	}
+	let tag = 'value';
+	try {
+		tag = Object.prototype.toString.call(value).slice(8, -1);
+	} catch {
+		// leave the generic tag
+	}
+	return labelPlaceholder(`[${tag} with own properties omitted for safety]`);
 }
 
 /** Defines `key` as an own DATA property via defineProperty rather than `target[key] = value`.
@@ -1206,13 +1276,23 @@ function deepSanitizeErrors(
 	depth = 0,
 	budget: SanitizeBudget = { nodes: 0, maxEntries: DEFAULT_MAX_SANITIZE_ENTRIES }
 ): any {
-	if (value === null || typeof value !== 'object') return value;
+	// Functions are `typeof 'function'`, not 'object' - included here (rather than falling through
+	// as if they were a harmless primitive) because a function is just as capable of carrying an
+	// expando own-enumerable property (`fn.cause = secretError`, an ordinary and not-even-unusual
+	// JS pattern) as a plain object is, and inspect() renders those own properties the same way.
+	// Counted first, before even the primitive-leaf check below, so a primitive leaf (string/number/
+	// etc in an array/object, the overwhelmingly common case) consumes exactly as much of the shared
+	// budget as a container does. Without this, only container nodes counted towards
+	// MAX_SANITIZE_NODES while each one's up-to-budget.maxEntries primitive children were free, so
+	// e.g. 50,000 containers of 250 primitive fields each could still walk ~12.5 million values
+	// before this cap ever engaged.
+	if (++budget.nodes > MAX_SANITIZE_NODES) return labelPlaceholder('[Unrenderable value: sanitize budget exceeded]');
+	if (value === null || (typeof value !== 'object' && typeof value !== 'function')) return value;
 	if (isErrorLike(value)) return errorForLog(value);
 	if (seen.has(value)) return seen.get(value);
 	if (depth >= MAX_SANITIZE_DEPTH) return value;
-	if (++budget.nodes > MAX_SANITIZE_NODES) return labelPlaceholder('[Unrenderable value: sanitize budget exceeded]');
 
-	let isArray: boolean, isMap: boolean, isSet: boolean;
+	let isArray: boolean, isMap: boolean, isSet: boolean, isFunction: boolean;
 	try {
 		isArray = Array.isArray(value);
 		// types.isMap/isSet check an internal slot, not the prototype chain, so (like isNativeError)
@@ -1221,15 +1301,29 @@ function deepSanitizeErrors(
 		// (and any Error nested inside) unsanitized at the raised inspect depth below.
 		isMap = !isArray && types.isMap(value);
 		isSet = !isArray && !isMap && types.isSet(value);
+		isFunction = !isArray && !isMap && !isSet && typeof value === 'function';
 		// See the Promise note on isOpaqueBuiltin above: its resolved/rejected value is arbitrary
 		// caller data that inspect() renders directly (own-enumerable properties included), and there
 		// is no supported synchronous way to read it in order to sanitize it - so unlike every other
 		// opaque built-in, a Promise is never handed to inspect() raw, sanitized or not.
 		if (!isArray && !isMap && !isSet && types.isPromise(value)) return labelPlaceholder('[Promise]');
-		if (!isArray && !isMap && !isSet && isOpaqueBuiltin(value)) return value;
+		if (!isArray && !isMap && !isSet && !isFunction && isOpaqueBuiltin(value)) {
+			// Fast, faithful, zero-cost path for the overwhelming common case: no expando, so the
+			// value is returned exactly as-is and inspect() renders its normal native format. Only a
+			// value that actually carries an expando pays for safeOpaqueBuiltinSummary below.
+			if (!hasEnumerableOwnProps(value)) return value;
+			return safeOpaqueBuiltinSummary(value);
+		}
+		if (isFunction && !hasEnumerableOwnProps(value)) return value; // same fast path, for functions
 	} catch {
 		return value; // e.g. a revoked Proxy - util.inspect renders those fine on its own
 	}
+	// A function reaching here carries an expando: fall through into the generic object walk below
+	// (Object.keys/getOwnPropertyDescriptor/getOwnPropertySymbols all work the same on a function as
+	// on a plain object) so that expando gets sanitized like any other object's - the clone won't be
+	// callable and inspect() renders it as a plain `Function { ... }` rather than `[Function: name]`,
+	// but that's a safe, honest trade for a case inspect() would otherwise render with a raw,
+	// unsanitized secret alongside it.
 
 	if (isArray) {
 		const clone: any[] = [];

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -1052,6 +1052,37 @@ export function errorForLog(error: any) {
 // capped so a pathological/adversarial structure can't blow the stack.
 const MAX_SANITIZE_DEPTH = 20;
 
+// Default per-container breadth cap (used when inspectForLog's caller didn't request a specific
+// maxArrayLength) and an absolute ceiling on total nodes visited across the WHOLE walk. Per-
+// container breadth alone isn't enough: a structure that is merely wide at every one of
+// MAX_SANITIZE_DEPTH levels multiplies out to an astronomical node count, so a global counter is
+// the actual backstop. Both exist because sanitizing happens BEFORE util.inspect's own
+// maxArrayLength truncation runs - a huge/sparse array or a huge Map/Set in a structured error
+// (`new Array(0xffffffff)`, or a hostile component's crafted payload) would otherwise force this
+// walk to visit billions of entries and wedge the event loop while just trying to log the
+// *original* error, before inspect ever gets a chance to truncate the output.
+const DEFAULT_MAX_SANITIZE_ENTRIES = 1000;
+const MAX_SANITIZE_NODES = 50_000;
+
+interface SanitizeBudget {
+	nodes: number;
+	maxEntries: number;
+}
+
+/** A util.inspect-style placeholder rendered without invoking anything, used both for an unread
+ *  accessor property and for a budget-truncated container tail. */
+function labelPlaceholder(label: string) {
+	return { [inspect.custom]: () => label, toString: () => label };
+}
+
+/** A util.inspect-style placeholder for an accessor property, describing it without invoking the
+ *  getter — see the getter-invocation note on deepSanitizeErrors below. */
+function accessorPlaceholder(descriptor: PropertyDescriptor) {
+	return labelPlaceholder(
+		descriptor.get && descriptor.set ? '[Getter/Setter]' : descriptor.get ? '[Getter]' : '[Setter]'
+	);
+}
+
 /**
  * True for the specific built-ins whose actual data is NOT reachable through their own-enumerable
  * string/symbol keys, so rebuilding them via a property walk would silently corrupt their
@@ -1063,6 +1094,13 @@ const MAX_SANITIZE_DEPTH = 20;
  * depth below a real, generic secret-leak path. `types.is*` checks an internal slot, not the
  * prototype chain, so - like isNativeError / types.isMap / types.isSet elsewhere in this file -
  * this is realm-independent: a VM-created Date is still recognized as opaque.
+ *
+ * Residual gap, accepted rather than chased further: an *expando* own-enumerable property stashed
+ * directly on one of these opaque built-ins (e.g. `const d = new Date(); d.cause = secretError`)
+ * is not reached either, since the value is returned entirely unwalked to protect its native
+ * rendering. Attaching an expando to a Date/Buffer/Promise/etc. is not a pattern any real
+ * diagnostic payload (deployComponent's or otherwise) produces - unlike the Map/Set/class-instance
+ * cases above, which are ordinary, expected shapes for a generic `http_resp_msg` field.
  */
 function isOpaqueBuiltin(value: object): boolean {
 	return (
@@ -1077,11 +1115,16 @@ function isOpaqueBuiltin(value: object): boolean {
 	);
 }
 
-/** A util.inspect-style placeholder for an accessor property, describing it without invoking the
- *  getter — see the getter-invocation note on deepSanitizeErrors below. */
-function accessorPlaceholder(descriptor: PropertyDescriptor) {
-	const label = descriptor.get && descriptor.set ? '[Getter/Setter]' : descriptor.get ? '[Getter]' : '[Setter]';
-	return { [inspect.custom]: () => label, toString: () => label };
+/** Defines `key` as an own DATA property via defineProperty rather than `target[key] = value`.
+ *  Once a sanitized clone's prototype is restored to the original's (see deepSanitizeErrors), a
+ *  plain assignment for a key that has an inherited accessor further up that prototype chain would
+ *  invoke the INHERITED SETTER instead of creating an own property - running arbitrary code during
+ *  what should be a passive render - and a key literally named `__proto__` would hit the legacy
+ *  Object.prototype.__proto__ setter and reparent the clone instead of storing a property named
+ *  "__proto__". defineProperty always creates/replaces an own property directly, regardless of key
+ *  name or what the prototype chain declares. */
+function defineOwnProperty(target: any, key: string | symbol, value: any) {
+	Object.defineProperty(target, key, { value, writable: true, enumerable: true, configurable: true });
 }
 
 /**
@@ -1121,13 +1164,27 @@ function accessorPlaceholder(descriptor: PropertyDescriptor) {
  * of `for...of`; Map/Set are walked via their intrinsic prototype methods bound with `.call`,
  * which reads the internal slot data directly rather than going through the instance's own (or an
  * overriding subclass's) iterator method. Objects read property descriptors and recurse only into
- * a data descriptor's value; an accessor gets accessorPlaceholder's label instead.
+ * a data descriptor's value; an accessor gets accessorPlaceholder's label instead. Every own
+ * property is written via defineOwnProperty rather than assignment, so a clone whose prototype was
+ * restored to a class's prototype can't trigger an inherited setter (or the legacy `__proto__`
+ * setter) partway through the walk.
+ *
+ * Breadth-bounded via `budget`, shared across the whole walk (not reset per container): each
+ * container is capped at `budget.maxEntries` entries (with a placeholder noting what was
+ * skipped), and the walk stops sanitizing entirely past `MAX_SANITIZE_NODES` total nodes visited,
+ * regardless of per-container caps - see the constants' comment for why both are needed.
  */
-function deepSanitizeErrors(value: any, seen: WeakMap<object, any> = new WeakMap(), depth = 0): any {
+function deepSanitizeErrors(
+	value: any,
+	seen: WeakMap<object, any> = new WeakMap(),
+	depth = 0,
+	budget: SanitizeBudget = { nodes: 0, maxEntries: DEFAULT_MAX_SANITIZE_ENTRIES }
+): any {
 	if (value === null || typeof value !== 'object') return value;
 	if (isErrorLike(value)) return errorForLog(value);
 	if (seen.has(value)) return seen.get(value);
 	if (depth >= MAX_SANITIZE_DEPTH) return value;
+	if (++budget.nodes > MAX_SANITIZE_NODES) return labelPlaceholder('[Unrenderable value: sanitize budget exceeded]');
 
 	let isArray: boolean, isMap: boolean, isSet: boolean;
 	try {
@@ -1147,7 +1204,14 @@ function deepSanitizeErrors(value: any, seen: WeakMap<object, any> = new WeakMap
 		const clone: any[] = [];
 		seen.set(value, clone);
 		const length = value.length;
-		for (let i = 0; i < length; i++) {
+		// Reserve one slot for the truncation marker when overflowing, so the clone's final size is
+		// exactly budget.maxEntries - matching whatever maxArrayLength the caller will inspect() with
+		// - rather than maxEntries + 1, which util.inspect's OWN truncation would then clip anyway,
+		// silently hiding the marker (and the fact that anything was dropped at all) behind its
+		// generic "... N more items" ellipsis.
+		const overflow = length > budget.maxEntries;
+		const limit = overflow ? budget.maxEntries - 1 : length;
+		for (let i = 0; i < limit; i++) {
 			let descriptor;
 			try {
 				descriptor = Object.getOwnPropertyDescriptor(value, i);
@@ -1160,40 +1224,60 @@ function deepSanitizeErrors(value: any, seen: WeakMap<object, any> = new WeakMap
 				continue;
 			}
 			try {
-				clone[i] = deepSanitizeErrors(descriptor.value, seen, depth + 1);
+				clone[i] = deepSanitizeErrors(descriptor.value, seen, depth + 1, budget);
 			} catch {
 				clone[i] = descriptor.value;
 			}
 		}
+		if (overflow) clone[limit] = labelPlaceholder(`[${length - limit} more array entries omitted (sanitize budget)]`);
 		return clone;
 	}
 
 	if (isMap) {
 		const clone = new Map();
 		seen.set(value, clone);
+		// Reflect.get with an explicit receiver reads Map.prototype's intrinsic `size` getter bound
+		// to value's internal slot, bypassing an overriding subclass's own `size` the same way the
+		// .call-bound entries() below bypasses an overriding subclass's Symbol.iterator.
+		const size = Reflect.get(Map.prototype, 'size', value);
+		const overflow = size > budget.maxEntries;
+		const limit = overflow ? budget.maxEntries - 1 : size;
+		let count = 0;
 		// Map.prototype.entries bound via .call reads the internal [[MapData]] slot directly,
 		// rather than resolving value's own (or an overriding subclass's) Symbol.iterator.
 		for (const [k, v] of Map.prototype.entries.call(value)) {
+			if (count++ >= limit) break;
 			try {
-				clone.set(deepSanitizeErrors(k, seen, depth + 1), deepSanitizeErrors(v, seen, depth + 1));
+				clone.set(deepSanitizeErrors(k, seen, depth + 1, budget), deepSanitizeErrors(v, seen, depth + 1, budget));
 			} catch {
 				clone.set(k, v);
 			}
 		}
+		if (overflow)
+			clone.set(
+				labelPlaceholder('[truncated]'),
+				labelPlaceholder(`[${size - limit} more Map entries omitted (sanitize budget)]`)
+			);
 		return clone;
 	}
 
 	if (isSet) {
 		const clone = new Set();
 		seen.set(value, clone);
+		const size = Reflect.get(Set.prototype, 'size', value);
+		const overflow = size > budget.maxEntries;
+		const limit = overflow ? budget.maxEntries - 1 : size;
+		let count = 0;
 		// Same rationale as the Map branch above: Set.prototype.values via .call, not for...of.
 		for (const item of Set.prototype.values.call(value)) {
+			if (count++ >= limit) break;
 			try {
-				clone.add(deepSanitizeErrors(item, seen, depth + 1));
+				clone.add(deepSanitizeErrors(item, seen, depth + 1, budget));
 			} catch {
 				clone.add(item);
 			}
 		}
+		if (overflow) clone.add(labelPlaceholder(`[${size - limit} more Set entries omitted (sanitize budget)]`));
 		return clone;
 	}
 
@@ -1213,13 +1297,13 @@ function deepSanitizeErrors(value: any, seen: WeakMap<object, any> = new WeakMap
 		}
 		if (!descriptor) continue; // removed mid-walk by another property's getter side effect
 		if (descriptor.get || descriptor.set) {
-			result[key] = accessorPlaceholder(descriptor);
+			defineOwnProperty(result, key, accessorPlaceholder(descriptor));
 			continue;
 		}
 		try {
-			result[key] = deepSanitizeErrors(descriptor.value, seen, depth + 1);
+			defineOwnProperty(result, key, deepSanitizeErrors(descriptor.value, seen, depth + 1, budget));
 		} catch {
-			result[key] = descriptor.value;
+			defineOwnProperty(result, key, descriptor.value);
 		}
 	}
 	for (const sym of Object.getOwnPropertySymbols(value)) {
@@ -1237,20 +1321,20 @@ function deepSanitizeErrors(value: any, seen: WeakMap<object, any> = new WeakMap
 			// reading it here isn't new arbitrary-code exposure the way an ordinary data getter
 			// would be - it's the documented render-hook contract, just resolved one level earlier.
 			try {
-				result[sym] = value[sym];
+				defineOwnProperty(result, sym, value[sym]);
 			} catch {
 				// leave unset - inspect() will render the rest of the object without a custom hook
 			}
 			continue;
 		}
 		if (descriptor.get || descriptor.set) {
-			result[sym] = accessorPlaceholder(descriptor);
+			defineOwnProperty(result, sym, accessorPlaceholder(descriptor));
 			continue;
 		}
 		try {
-			result[sym] = deepSanitizeErrors(descriptor.value, seen, depth + 1);
+			defineOwnProperty(result, sym, deepSanitizeErrors(descriptor.value, seen, depth + 1, budget));
 		} catch {
-			result[sym] = descriptor.value;
+			defineOwnProperty(result, sym, descriptor.value);
 		}
 	}
 	return result;
@@ -1267,11 +1351,19 @@ function deepSanitizeErrors(value: any, seen: WeakMap<object, any> = new WeakMap
  * logged (e.g. replace the caught operation error with an inspect error). Any Error nested inside
  * `value` is sanitized via deepSanitizeErrors before rendering, so a raised inspect depth here
  * can't surface a nested Error's own-enumerable properties (#1734) the way the raw value would.
+ * `options.maxArrayLength`, if given, also bounds sanitization's own per-container breadth (see
+ * deepSanitizeErrors' budget) - a caller raising the render limit is raising how much genuinely
+ * needs to be walked, not just how much of an already-cheap walk gets displayed.
  */
 export function inspectForLog(value: any, options?: any) {
 	const render = () => {
 		try {
-			return inspect(deepSanitizeErrors(value), options);
+			const maxEntries = Number(options?.maxArrayLength);
+			const budget: SanitizeBudget = {
+				nodes: 0,
+				maxEntries: maxEntries > 0 ? maxEntries : DEFAULT_MAX_SANITIZE_ENTRIES,
+			};
+			return inspect(deepSanitizeErrors(value, new WeakMap(), 0, budget), options);
 		} catch (err) {
 			// errorToString is the guaranteed-never-throw stringifier (unlike `err instanceof Error` or
 			// `String(err)` here, both of which can themselves throw on a hostile value - e.g. a revoked

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -1052,10 +1052,31 @@ export function errorForLog(error: any) {
 // capped so a pathological/adversarial structure can't blow the stack.
 const MAX_SANITIZE_DEPTH = 20;
 
-/** proto === Object.prototype covers `{}`/object literals; proto === null covers Object.create(null). */
+/**
+ * Realm-independent plain-object check: component code runs through node:vm, so a VM-created
+ * object literal's prototype is a *different realm's* Object.prototype and fails a same-realm
+ * `proto === Object.prototype` comparison - which would fall through to the "leave raw" branch
+ * below and hand a VM diagnostic payload's nested Errors an unsanitized path to the raised inspect
+ * depth (the same cross-realm concern isErrorLike already accounts for via isNativeError).
+ * `Object.prototype.toString.call` reports the internal-slot tag ('[object Object]'), not the
+ * prototype chain, so it is realm-independent the same way it is for Map/Set/Date/Error - but a
+ * class instance also reports '[object Object]' when it has no custom Symbol.toStringTag, so that
+ * alone can't distinguish "object literal" from "class instance". The second check does: the
+ * *real* Object.prototype (in any realm) sits exactly one level up (its own prototype is null);
+ * a class instance's prototype chain has its class's prototype in between, so this is false for
+ * `new Causes()` while still true for a VM-created `{}`.
+ */
 function isPlainObject(value: object): boolean {
+	if (Object.prototype.toString.call(value) !== '[object Object]') return false;
 	const proto = Object.getPrototypeOf(value);
-	return proto === Object.prototype || proto === null;
+	return proto === null || Object.getPrototypeOf(proto) === null;
+}
+
+/** A util.inspect-style placeholder for an accessor property, describing it without invoking the
+ *  getter — see the getter-invocation note on deepSanitizeErrors below. */
+function accessorPlaceholder(descriptor: PropertyDescriptor) {
+	const label = descriptor.get && descriptor.set ? '[Getter/Setter]' : descriptor.get ? '[Getter]' : '[Setter]';
+	return { [inspect.custom]: () => label, toString: () => label };
 }
 
 /**
@@ -1084,6 +1105,13 @@ function isPlainObject(value: object): boolean {
  * individually guarded so one hostile getter or exotic nested value can only cost that one
  * field, not the whole render (inspectForLog's own try/catch around inspect() is still the final
  * backstop regardless).
+ *
+ * Never invokes an accessor (getter) property: unlike util.inspect's default (which shows a
+ * getter as `[Getter]` without calling it), reading `value[key]` for every own-enumerable key
+ * would call every getter - turning a passive render of a caught operation error into arbitrary
+ * synchronous code execution (a getter that loops, blocks, or mutates state runs while the logger
+ * is just trying to report the *original* error). Property descriptors are read instead, and only
+ * a data descriptor's value is recursed into; an accessor gets accessorPlaceholder's label.
  */
 function deepSanitizeErrors(value: any, seen: WeakMap<object, any> = new WeakMap(), depth = 0): any {
 	if (value === null || typeof value !== 'object') return value;
@@ -1094,8 +1122,12 @@ function deepSanitizeErrors(value: any, seen: WeakMap<object, any> = new WeakMap
 	let isArray: boolean, isMap: boolean, isSet: boolean;
 	try {
 		isArray = Array.isArray(value);
-		isMap = !isArray && value instanceof Map;
-		isSet = !isArray && !isMap && value instanceof Set;
+		// types.isMap/isSet check an internal slot, not the prototype chain, so (like isNativeError)
+		// they still recognize a Map/Set created in a different realm (component code runs through
+		// node:vm) - `instanceof Map`/`Set` would not, silently leaving that container's contents
+		// (and any Error nested inside) unsanitized at the raised inspect depth below.
+		isMap = !isArray && types.isMap(value);
+		isSet = !isArray && !isMap && types.isSet(value);
 		if (!isArray && !isMap && !isSet && !isPlainObject(value)) return value;
 	} catch {
 		return value; // e.g. a revoked Proxy - util.inspect renders those fine on its own
@@ -1143,16 +1175,21 @@ function deepSanitizeErrors(value: any, seen: WeakMap<object, any> = new WeakMap
 	const result: Record<string | symbol, any> = {};
 	seen.set(value, result);
 	for (const key of Object.keys(value)) {
-		let raw;
+		let descriptor;
 		try {
-			raw = value[key];
+			descriptor = Object.getOwnPropertyDescriptor(value, key);
 		} catch {
-			continue; // a throwing getter - omit rather than risk a second throw re-reading it
+			continue; // a hostile descriptor trap - omit rather than risk a second throw
+		}
+		if (!descriptor) continue; // removed mid-walk by another property's getter side effect
+		if (descriptor.get || descriptor.set) {
+			result[key] = accessorPlaceholder(descriptor);
+			continue;
 		}
 		try {
-			result[key] = deepSanitizeErrors(raw, seen, depth + 1);
+			result[key] = deepSanitizeErrors(descriptor.value, seen, depth + 1);
 		} catch {
-			result[key] = raw;
+			result[key] = descriptor.value;
 		}
 	}
 	for (const sym of Object.getOwnPropertySymbols(value)) {
@@ -1164,20 +1201,26 @@ function deepSanitizeErrors(value: any, seen: WeakMap<object, any> = new WeakMap
 		}
 		if (!descriptor?.enumerable) continue;
 		if (sym === inspect.custom) {
-			// The custom renderer itself, not data - preserve unchanged rather than sanitize/invoke.
-			result[sym] = value[sym];
+			// The custom renderer itself, not data - preserve unchanged (even if defined via an
+			// accessor) rather than replace it with an accessor placeholder. util.inspect's own
+			// top-level render finds this hook via the exact same `value[sym]` property access, so
+			// reading it here isn't new arbitrary-code exposure the way an ordinary data getter
+			// would be - it's the documented render-hook contract, just resolved one level earlier.
+			try {
+				result[sym] = value[sym];
+			} catch {
+				// leave unset - inspect() will render the rest of the object without a custom hook
+			}
 			continue;
 		}
-		let raw;
-		try {
-			raw = value[sym];
-		} catch {
+		if (descriptor.get || descriptor.set) {
+			result[sym] = accessorPlaceholder(descriptor);
 			continue;
 		}
 		try {
-			result[sym] = deepSanitizeErrors(raw, seen, depth + 1);
+			result[sym] = deepSanitizeErrors(descriptor.value, seen, depth + 1);
 		} catch {
-			result[sym] = raw;
+			result[sym] = descriptor.value;
 		}
 	}
 	return result;

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -1053,23 +1053,28 @@ export function errorForLog(error: any) {
 const MAX_SANITIZE_DEPTH = 20;
 
 /**
- * Realm-independent plain-object check: component code runs through node:vm, so a VM-created
- * object literal's prototype is a *different realm's* Object.prototype and fails a same-realm
- * `proto === Object.prototype` comparison - which would fall through to the "leave raw" branch
- * below and hand a VM diagnostic payload's nested Errors an unsanitized path to the raised inspect
- * depth (the same cross-realm concern isErrorLike already accounts for via isNativeError).
- * `Object.prototype.toString.call` reports the internal-slot tag ('[object Object]'), not the
- * prototype chain, so it is realm-independent the same way it is for Map/Set/Date/Error - but a
- * class instance also reports '[object Object]' when it has no custom Symbol.toStringTag, so that
- * alone can't distinguish "object literal" from "class instance". The second check does: the
- * *real* Object.prototype (in any realm) sits exactly one level up (its own prototype is null);
- * a class instance's prototype chain has its class's prototype in between, so this is false for
- * `new Causes()` while still true for a VM-created `{}`.
+ * True for the specific built-ins whose actual data is NOT reachable through their own-enumerable
+ * string/symbol keys, so rebuilding them via a property walk would silently corrupt their
+ * rendering (Object.keys(new Date()) is `[]`; a Buffer's bytes live in a typed-array internal
+ * slot, not enumerable own properties). Everything else - an object literal, a class instance, a
+ * VM cross-realm object of either - IS walked and rebuilt: a class or custom-prototype instance is
+ * just as capable of holding a nested Error as a plain object (`http_resp_msg` is a generic field,
+ * not limited to the known deploy payload), and leaving instances raw would hand the raised inspect
+ * depth below a real, generic secret-leak path. `types.is*` checks an internal slot, not the
+ * prototype chain, so - like isNativeError / types.isMap / types.isSet elsewhere in this file -
+ * this is realm-independent: a VM-created Date is still recognized as opaque.
  */
-function isPlainObject(value: object): boolean {
-	if (Object.prototype.toString.call(value) !== '[object Object]') return false;
-	const proto = Object.getPrototypeOf(value);
-	return proto === null || Object.getPrototypeOf(proto) === null;
+function isOpaqueBuiltin(value: object): boolean {
+	return (
+		types.isDate(value) ||
+		types.isRegExp(value) ||
+		types.isArrayBufferView(value) || // covers Buffer and every TypedArray/DataView
+		types.isAnyArrayBuffer(value) ||
+		types.isPromise(value) ||
+		types.isWeakMap(value) ||
+		types.isWeakSet(value) ||
+		types.isBoxedPrimitive(value) // a boxed Boolean/Number/String/Symbol/BigInt wrapper
+	);
 }
 
 /** A util.inspect-style placeholder for an accessor property, describing it without invoking the
@@ -1088,15 +1093,15 @@ function accessorPlaceholder(descriptor: PropertyDescriptor) {
  * anywhere inside a value later rendered with a raised inspect depth (see inspectForLog) would
  * otherwise surface its own-enumerable properties raw.
  *
- * Plain objects, arrays, Map, and Set are rebuilt so an Error nested inside them is still reached
- * and sanitized. Anything else (Date, Buffer, RegExp, a class instance) is returned as-is:
- * rebuilding one via Object.keys() would silently corrupt its rendering (a Date/Buffer's actual
- * data isn't reachable through its own enumerable string keys - Object.keys(new Date()) is `[]`)
- * in exchange for a residual gap - a raw Error nested inside one of these types is not sanitized -
- * that mirrors sanitizeErrorArgs' own accepted shallow-by-design boundary rather than introducing
- * a new one. Map/Set are common enough carriers for a nested cause (e.g. an aggregated-errors map)
- * that leaving them raw would hand the raised inspect depth here a real secret-leak path #1734
- * guards against everywhere else, so they get the same rebuild-and-sanitize treatment as objects.
+ * Arrays, Map, Set, and every other object EXCEPT the isOpaqueBuiltin exclusions above are rebuilt
+ * so an Error nested inside them at any depth is still reached and sanitized - a raw Error left
+ * unsanitized anywhere in the tree would surface its own-enumerable properties (e.g. an axios
+ * `config.headers.Authorization`) raw once the raised inspect depth below reaches it. A rebuilt
+ * object/class-instance clone has the original's prototype restored (Object.setPrototypeOf) so
+ * inspect() still shows its real class name and picks up any inspect.custom hook defined on the
+ * class's prototype (not an own property, so the symbol walk below wouldn't otherwise see it) -
+ * the clone differs from the original only in which of its OWN enumerable properties got swapped
+ * for a sanitized/placeholder value, same as it would for a plain object.
  *
  * Cycle-safe via a WeakMap from original to its (in-progress) clone, registered before recursing
  * into children, so a cycle resolves to the clone in progress rather than falling back to the raw
@@ -1106,12 +1111,17 @@ function accessorPlaceholder(descriptor: PropertyDescriptor) {
  * field, not the whole render (inspectForLog's own try/catch around inspect() is still the final
  * backstop regardless).
  *
- * Never invokes an accessor (getter) property: unlike util.inspect's default (which shows a
- * getter as `[Getter]` without calling it), reading `value[key]` for every own-enumerable key
- * would call every getter - turning a passive render of a caught operation error into arbitrary
- * synchronous code execution (a getter that loops, blocks, or mutates state runs while the logger
- * is just trying to report the *original* error). Property descriptors are read instead, and only
- * a data descriptor's value is recursed into; an accessor gets accessorPlaceholder's label.
+ * Never invokes an accessor (getter) property, and never resolves an overridable Symbol.iterator:
+ * unlike util.inspect's default (which shows a getter as `[Getter]` without calling it), reading
+ * `value[key]`/`value[sym]` for every own-enumerable key - or iterating an array/Map/Set with
+ * `for...of`, which resolves the value's own-or-inherited `Symbol.iterator` - would run arbitrary
+ * synchronous code, including a subclass instance's overridden iterator, while the logger is just
+ * trying to report the *original* error (a hostile accessor/iterator that loops, blocks, or
+ * mutates state runs regardless). Arrays are walked by own property descriptor per index instead
+ * of `for...of`; Map/Set are walked via their intrinsic prototype methods bound with `.call`,
+ * which reads the internal slot data directly rather than going through the instance's own (or an
+ * overriding subclass's) iterator method. Objects read property descriptors and recurse only into
+ * a data descriptor's value; an accessor gets accessorPlaceholder's label instead.
  */
 function deepSanitizeErrors(value: any, seen: WeakMap<object, any> = new WeakMap(), depth = 0): any {
 	if (value === null || typeof value !== 'object') return value;
@@ -1128,7 +1138,7 @@ function deepSanitizeErrors(value: any, seen: WeakMap<object, any> = new WeakMap
 		// (and any Error nested inside) unsanitized at the raised inspect depth below.
 		isMap = !isArray && types.isMap(value);
 		isSet = !isArray && !isMap && types.isSet(value);
-		if (!isArray && !isMap && !isSet && !isPlainObject(value)) return value;
+		if (!isArray && !isMap && !isSet && isOpaqueBuiltin(value)) return value;
 	} catch {
 		return value; // e.g. a revoked Proxy - util.inspect renders those fine on its own
 	}
@@ -1136,11 +1146,23 @@ function deepSanitizeErrors(value: any, seen: WeakMap<object, any> = new WeakMap
 	if (isArray) {
 		const clone: any[] = [];
 		seen.set(value, clone);
-		for (const item of value) {
+		const length = value.length;
+		for (let i = 0; i < length; i++) {
+			let descriptor;
 			try {
-				clone.push(deepSanitizeErrors(item, seen, depth + 1));
+				descriptor = Object.getOwnPropertyDescriptor(value, i);
 			} catch {
-				clone.push(item);
+				continue; // leave index i a hole rather than risk a second throw
+			}
+			if (!descriptor) continue; // a genuine sparse-array hole - leave it, not `undefined`
+			if (descriptor.get || descriptor.set) {
+				clone[i] = accessorPlaceholder(descriptor);
+				continue;
+			}
+			try {
+				clone[i] = deepSanitizeErrors(descriptor.value, seen, depth + 1);
+			} catch {
+				clone[i] = descriptor.value;
 			}
 		}
 		return clone;
@@ -1149,7 +1171,9 @@ function deepSanitizeErrors(value: any, seen: WeakMap<object, any> = new WeakMap
 	if (isMap) {
 		const clone = new Map();
 		seen.set(value, clone);
-		for (const [k, v] of value) {
+		// Map.prototype.entries bound via .call reads the internal [[MapData]] slot directly,
+		// rather than resolving value's own (or an overriding subclass's) Symbol.iterator.
+		for (const [k, v] of Map.prototype.entries.call(value)) {
 			try {
 				clone.set(deepSanitizeErrors(k, seen, depth + 1), deepSanitizeErrors(v, seen, depth + 1));
 			} catch {
@@ -1162,7 +1186,8 @@ function deepSanitizeErrors(value: any, seen: WeakMap<object, any> = new WeakMap
 	if (isSet) {
 		const clone = new Set();
 		seen.set(value, clone);
-		for (const item of value) {
+		// Same rationale as the Map branch above: Set.prototype.values via .call, not for...of.
+		for (const item of Set.prototype.values.call(value)) {
 			try {
 				clone.add(deepSanitizeErrors(item, seen, depth + 1));
 			} catch {
@@ -1174,6 +1199,11 @@ function deepSanitizeErrors(value: any, seen: WeakMap<object, any> = new WeakMap
 
 	const result: Record<string | symbol, any> = {};
 	seen.set(value, result);
+	try {
+		Object.setPrototypeOf(result, Object.getPrototypeOf(value));
+	} catch {
+		// leave result's prototype as plain Object - inspect() renders it without the class name
+	}
 	for (const key of Object.keys(value)) {
 		let descriptor;
 		try {

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -184,11 +184,15 @@ async function updateLogSettings() {
 }
 
 /**
- * True when the argument is an Error (same-realm or native cross-realm). The try/catch guards
- * exotic objects whose prototype is unreachable (e.g. a revoked Proxy, where `instanceof`
- * throws) — the logger must never throw on any input, and util.format renders those fine raw.
+ * True when the argument is an Error (same-realm or native cross-realm — component code runs
+ * through node:vm, so a VM-created Error fails `instanceof Error` but passes `isNativeError`).
+ * The try/catch guards exotic objects whose prototype is unreachable (e.g. a revoked Proxy,
+ * where `instanceof` throws) — the logger must never throw on any input, and util.format
+ * renders those fine raw. Exported so call sites outside this module (e.g.
+ * OperationFunctionCaller, deciding how to log an error-shaped value it didn't itself catch as
+ * an Error) can reuse the same classification instead of a weaker local `instanceof` check.
  */
-function isErrorLike(arg: any): boolean {
+export function isErrorLike(arg: any): boolean {
 	try {
 		return arg instanceof Error || isNativeError(arg);
 	} catch {
@@ -344,6 +348,8 @@ module.exports = {
 	startOnMainThread: updateLogSettings,
 	errorToString,
 	errorForLog,
+	inspectForLog,
+	isErrorLike,
 	disableStdio,
 	externalLogger,
 };
@@ -1042,6 +1048,133 @@ export function errorForLog(error: any) {
 	return { [inspect.custom]: render, toString: render };
 }
 
+// Bounds deepSanitizeErrors' walk: deep enough to reach any realistic diagnostic payload shape,
+// capped so a pathological/adversarial structure can't blow the stack.
+const MAX_SANITIZE_DEPTH = 20;
+
+/** proto === Object.prototype covers `{}`/object literals; proto === null covers Object.create(null). */
+function isPlainObject(value: object): boolean {
+	const proto = Object.getPrototypeOf(value);
+	return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Recursively walks a plain object/array, replacing every Error-like value found at any depth
+ * with its errorForLog wrapper (see isErrorLike/errorForLog and #1734). sanitizeErrorArgs is
+ * deliberately shallow because it guards the hot, frequent top-level log-call path — this walk is
+ * for inspectForLog's callers instead, which are low-frequency (a caught error's diagnostic
+ * detail), so the extra traversal cost doesn't matter and full coverage does: an Error nested
+ * anywhere inside a value later rendered with a raised inspect depth (see inspectForLog) would
+ * otherwise surface its own-enumerable properties raw.
+ *
+ * Only plain objects and arrays are rebuilt. Anything else (Date, Map, Set, Buffer, RegExp, a
+ * class instance) is returned as-is: rebuilding one via Object.keys() would silently corrupt its
+ * rendering (a Date/Map/Buffer's actual data isn't reachable through its own enumerable string
+ * keys - Object.keys(new Date()) is `[]`) in exchange for a residual gap - a raw Error nested
+ * inside one of these container types is not sanitized - that mirrors sanitizeErrorArgs' own
+ * accepted shallow-by-design boundary rather than introducing a new one.
+ *
+ * Cycle-safe via a WeakMap from original to its (in-progress) clone, registered before recursing
+ * into children, so a cycle resolves to the clone in progress rather than falling back to the raw
+ * original (which would bypass sanitization on the repeated branch) - and depth-capped so a
+ * pathologically deep structure can't blow the stack. Every property read and recursive step is
+ * individually guarded so one hostile getter or exotic nested value can only cost that one
+ * field, not the whole render (inspectForLog's own try/catch around inspect() is still the final
+ * backstop regardless).
+ */
+function deepSanitizeErrors(value: any, seen: WeakMap<object, any> = new WeakMap(), depth = 0): any {
+	if (value === null || typeof value !== 'object') return value;
+	if (isErrorLike(value)) return errorForLog(value);
+	if (seen.has(value)) return seen.get(value);
+	if (depth >= MAX_SANITIZE_DEPTH) return value;
+
+	let isArray: boolean;
+	try {
+		isArray = Array.isArray(value);
+		if (!isArray && !isPlainObject(value)) return value;
+	} catch {
+		return value; // e.g. a revoked Proxy - util.inspect renders those fine on its own
+	}
+
+	if (isArray) {
+		const clone: any[] = [];
+		seen.set(value, clone);
+		for (const item of value) {
+			try {
+				clone.push(deepSanitizeErrors(item, seen, depth + 1));
+			} catch {
+				clone.push(item);
+			}
+		}
+		return clone;
+	}
+
+	const result: Record<string | symbol, any> = {};
+	seen.set(value, result);
+	for (const key of Object.keys(value)) {
+		let raw;
+		try {
+			raw = value[key];
+		} catch {
+			continue; // a throwing getter - omit rather than risk a second throw re-reading it
+		}
+		try {
+			result[key] = deepSanitizeErrors(raw, seen, depth + 1);
+		} catch {
+			result[key] = raw;
+		}
+	}
+	for (const sym of Object.getOwnPropertySymbols(value)) {
+		let descriptor;
+		try {
+			descriptor = Object.getOwnPropertyDescriptor(value, sym);
+		} catch {
+			continue;
+		}
+		if (!descriptor?.enumerable) continue;
+		if (sym === inspect.custom) {
+			// The custom renderer itself, not data - preserve unchanged rather than sanitize/invoke.
+			result[sym] = value[sym];
+			continue;
+		}
+		let raw;
+		try {
+			raw = value[sym];
+		} catch {
+			continue;
+		}
+		try {
+			result[sym] = deepSanitizeErrors(raw, seen, depth + 1);
+		} catch {
+			result[sym] = raw;
+		}
+	}
+	return result;
+}
+
+/**
+ * Returns a log-safe lazy wrapper around `util.inspect(value, options)`, for call sites that need
+ * to log a structured, non-Error value with non-default inspect options (e.g. a deeper depth or
+ * higher array/string limits than Console's defaults, to avoid flattening nested diagnostic data —
+ * see harper#1982). Same rationale as errorForLog: the wrapper defers the (potentially expensive,
+ * e.g. large-array) render until the logger's level gate actually writes the entry, and the render
+ * itself can never throw regardless of what `value` is — including a hostile nested
+ * `[util.inspect.custom]` hook — so a formatting failure can never mask the real thing being
+ * logged (e.g. replace the caught operation error with an inspect error). Any Error nested inside
+ * `value` is sanitized via deepSanitizeErrors before rendering, so a raised inspect depth here
+ * can't surface a nested Error's own-enumerable properties (#1734) the way the raw value would.
+ */
+export function inspectForLog(value: any, options?: any) {
+	const render = () => {
+		try {
+			return inspect(deepSanitizeErrors(value), options);
+		} catch (err) {
+			return `[Unrenderable value: ${err instanceof Error ? err.message : String(err)}]`;
+		}
+	};
+	return { [inspect.custom]: render, toString: render };
+}
+
 export function setMainLogger(logger: any) {
 	mainLogger = logger;
 }
@@ -1101,4 +1234,6 @@ export default {
 	AuthAuditLog,
 	errorToString,
 	errorForLog,
+	inspectForLog,
+	isErrorLike,
 };

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -1084,6 +1084,26 @@ function accessorPlaceholder(descriptor: PropertyDescriptor) {
 }
 
 /**
+ * Placeholder substituted when a recursive sanitize step on a child throws, instead of falling
+ * back to that child's raw (unsanitized) value. A throw here is not a reason to skip sanitizing -
+ * it is exactly the case a hostile value produces (e.g. a Proxy whose `ownKeys` trap throws once
+ * reached one level down), and the child that triggered it may itself contain an unsanitized
+ * Error. Falling back to raw would silently hand that Error to inspect() at the raised depth,
+ * recreating the #1734 leak this whole walk exists to prevent.
+ */
+function sanitizeFailurePlaceholder() {
+	return labelPlaceholder('[Unrenderable value: sanitize failed]');
+}
+
+// Unique symbol keys for the plain-object breadth-cap markers below, rather than a string key
+// like the array/Map/Set truncation markers use - a hostile or just plain unlucky object could
+// have an own string property literally named the same as a string marker, silently colliding
+// with (and hiding) real data. A locally-scoped Symbol can never collide with an enumerable
+// string OR pre-existing symbol key on the original value.
+const KEYS_TRUNCATED_MARKER = Symbol('sanitize: string-keyed properties truncated');
+const SYMBOLS_TRUNCATED_MARKER = Symbol('sanitize: symbol-keyed properties truncated');
+
+/**
  * True for the specific built-ins whose actual data is NOT reachable through their own-enumerable
  * string/symbol keys, so rebuilding them via a property walk would silently corrupt their
  * rendering (Object.keys(new Date()) is `[]`; a Buffer's bytes live in a typed-array internal
@@ -1095,12 +1115,19 @@ function accessorPlaceholder(descriptor: PropertyDescriptor) {
  * prototype chain, so - like isNativeError / types.isMap / types.isSet elsewhere in this file -
  * this is realm-independent: a VM-created Date is still recognized as opaque.
  *
+ * Promise is deliberately NOT included here (handled separately in deepSanitizeErrors, see below):
+ * unlike the others, a Promise's resolved/rejected value is not merely internal-slot data with a
+ * fixed rendering, it's arbitrary caller data - and util.inspect renders it directly, own-enumerable
+ * properties and all (`util.inspect(Promise.resolve(errorWithSecretHeader), { depth: 8 })` prints
+ * the header). There is no supported synchronous way to read that value in order to sanitize it, so
+ * the only safe option is to never hand a Promise to inspect() raw.
+ *
  * Residual gap, accepted rather than chased further: an *expando* own-enumerable property stashed
- * directly on one of these opaque built-ins (e.g. `const d = new Date(); d.cause = secretError`)
- * is not reached either, since the value is returned entirely unwalked to protect its native
- * rendering. Attaching an expando to a Date/Buffer/Promise/etc. is not a pattern any real
- * diagnostic payload (deployComponent's or otherwise) produces - unlike the Map/Set/class-instance
- * cases above, which are ordinary, expected shapes for a generic `http_resp_msg` field.
+ * directly on one of these remaining opaque built-ins (e.g. `const d = new Date(); d.cause =
+ * secretError`) is not reached either, since the value is returned entirely unwalked to protect its
+ * native rendering. Attaching an expando to a Date/Buffer/etc. is not a pattern any real diagnostic
+ * payload (deployComponent's or otherwise) produces - unlike the Map/Set/class-instance cases above,
+ * which are ordinary, expected shapes for a generic `http_resp_msg` field.
  */
 function isOpaqueBuiltin(value: object): boolean {
 	return (
@@ -1108,7 +1135,6 @@ function isOpaqueBuiltin(value: object): boolean {
 		types.isRegExp(value) ||
 		types.isArrayBufferView(value) || // covers Buffer and every TypedArray/DataView
 		types.isAnyArrayBuffer(value) ||
-		types.isPromise(value) ||
 		types.isWeakMap(value) ||
 		types.isWeakSet(value) ||
 		types.isBoxedPrimitive(value) // a boxed Boolean/Number/String/Symbol/BigInt wrapper
@@ -1195,6 +1221,11 @@ function deepSanitizeErrors(
 		// (and any Error nested inside) unsanitized at the raised inspect depth below.
 		isMap = !isArray && types.isMap(value);
 		isSet = !isArray && !isMap && types.isSet(value);
+		// See the Promise note on isOpaqueBuiltin above: its resolved/rejected value is arbitrary
+		// caller data that inspect() renders directly (own-enumerable properties included), and there
+		// is no supported synchronous way to read it in order to sanitize it - so unlike every other
+		// opaque built-in, a Promise is never handed to inspect() raw, sanitized or not.
+		if (!isArray && !isMap && !isSet && types.isPromise(value)) return labelPlaceholder('[Promise]');
 		if (!isArray && !isMap && !isSet && isOpaqueBuiltin(value)) return value;
 	} catch {
 		return value; // e.g. a revoked Proxy - util.inspect renders those fine on its own
@@ -1226,7 +1257,7 @@ function deepSanitizeErrors(
 			try {
 				clone[i] = deepSanitizeErrors(descriptor.value, seen, depth + 1, budget);
 			} catch {
-				clone[i] = descriptor.value;
+				clone[i] = sanitizeFailurePlaceholder();
 			}
 		}
 		if (overflow) clone[limit] = labelPlaceholder(`[${length - limit} more array entries omitted (sanitize budget)]`);
@@ -1247,11 +1278,21 @@ function deepSanitizeErrors(
 		// rather than resolving value's own (or an overriding subclass's) Symbol.iterator.
 		for (const [k, v] of Map.prototype.entries.call(value)) {
 			if (count++ >= limit) break;
+			// Sanitized independently (rather than in one combined try) so a throw sanitizing the key
+			// doesn't also discard an already-sanitized value, or vice versa - each side falls back to
+			// its own placeholder, never to the other's raw counterpart.
+			let sanitizedKey, sanitizedValue;
 			try {
-				clone.set(deepSanitizeErrors(k, seen, depth + 1, budget), deepSanitizeErrors(v, seen, depth + 1, budget));
+				sanitizedKey = deepSanitizeErrors(k, seen, depth + 1, budget);
 			} catch {
-				clone.set(k, v);
+				sanitizedKey = sanitizeFailurePlaceholder();
 			}
+			try {
+				sanitizedValue = deepSanitizeErrors(v, seen, depth + 1, budget);
+			} catch {
+				sanitizedValue = sanitizeFailurePlaceholder();
+			}
+			clone.set(sanitizedKey, sanitizedValue);
 		}
 		if (overflow)
 			clone.set(
@@ -1274,7 +1315,7 @@ function deepSanitizeErrors(
 			try {
 				clone.add(deepSanitizeErrors(item, seen, depth + 1, budget));
 			} catch {
-				clone.add(item);
+				clone.add(sanitizeFailurePlaceholder());
 			}
 		}
 		if (overflow) clone.add(labelPlaceholder(`[${size - limit} more Set entries omitted (sanitize budget)]`));
@@ -1288,7 +1329,16 @@ function deepSanitizeErrors(
 	} catch {
 		// leave result's prototype as plain Object - inspect() renders it without the class name
 	}
-	for (const key of Object.keys(value)) {
+	// Object.keys/getOwnPropertySymbols themselves are one unavoidable O(n) pass (a plain object,
+	// unlike Array/Map/Set, has no O(1) size to check before enumerating) - but everything AFTER
+	// that (getOwnPropertyDescriptor + recurse + defineProperty per key) is the expensive part, and
+	// that part IS capped at budget.maxEntries, same as every other container branch, so a
+	// million-key object can't turn a single log call into a million-entry clone.
+	const keys = Object.keys(value);
+	const keysOverflow = keys.length > budget.maxEntries;
+	const keysLimit = keysOverflow ? budget.maxEntries - 1 : keys.length;
+	for (let i = 0; i < keysLimit; i++) {
+		const key = keys[i];
 		let descriptor;
 		try {
 			descriptor = Object.getOwnPropertyDescriptor(value, key);
@@ -1303,10 +1353,20 @@ function deepSanitizeErrors(
 		try {
 			defineOwnProperty(result, key, deepSanitizeErrors(descriptor.value, seen, depth + 1, budget));
 		} catch {
-			defineOwnProperty(result, key, descriptor.value);
+			defineOwnProperty(result, key, sanitizeFailurePlaceholder());
 		}
 	}
-	for (const sym of Object.getOwnPropertySymbols(value)) {
+	if (keysOverflow)
+		defineOwnProperty(
+			result,
+			KEYS_TRUNCATED_MARKER,
+			labelPlaceholder(`[${keys.length - keysLimit} more properties omitted (sanitize budget)]`)
+		);
+	const symbols = Object.getOwnPropertySymbols(value);
+	const symbolsOverflow = symbols.length > budget.maxEntries;
+	const symbolsLimit = symbolsOverflow ? budget.maxEntries - 1 : symbols.length;
+	for (let i = 0; i < symbolsLimit; i++) {
+		const sym = symbols[i];
 		let descriptor;
 		try {
 			descriptor = Object.getOwnPropertyDescriptor(value, sym);
@@ -1334,9 +1394,15 @@ function deepSanitizeErrors(
 		try {
 			defineOwnProperty(result, sym, deepSanitizeErrors(descriptor.value, seen, depth + 1, budget));
 		} catch {
-			defineOwnProperty(result, sym, descriptor.value);
+			defineOwnProperty(result, sym, sanitizeFailurePlaceholder());
 		}
 	}
+	if (symbolsOverflow)
+		defineOwnProperty(
+			result,
+			SYMBOLS_TRUNCATED_MARKER,
+			labelPlaceholder(`[${symbols.length - symbolsLimit} more symbol properties omitted (sanitize budget)]`)
+		);
 	return result;
 }
 

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -1276,12 +1276,17 @@ function safeOpaqueBuiltinSummary(value: object): any {
 	} catch {
 		// fall through to the generic tag-only summary below
 	}
+	// A fixed, types.is*-derived tag - never Object.prototype.toString.call(value), which reads the
+	// value's own Symbol.toStringTag and would invoke a hostile getter defined there while merely
+	// picking a label (the same class of bug fixed in isErrorLike's classification - see there). Every
+	// branch here is an internal-slot check, so none of them can run caller-controlled code.
 	let tag = 'value';
-	try {
-		tag = Object.prototype.toString.call(value).slice(8, -1);
-	} catch {
-		// leave the generic tag
-	}
+	if (types.isStringObject(value)) tag = 'String';
+	else if (types.isNumberObject(value)) tag = 'Number';
+	else if (types.isBooleanObject(value)) tag = 'Boolean';
+	else if (types.isSymbolObject(value)) tag = 'Symbol';
+	else if (types.isArrayBufferView(value)) tag = 'ArrayBufferView';
+	else if (types.isAnyArrayBuffer(value)) tag = 'ArrayBuffer';
 	return labelPlaceholder(`[${tag} with own properties omitted for safety]`);
 }
 
@@ -1518,18 +1523,30 @@ function deepSanitizeErrors(
 		const proto = Object.getPrototypeOf(value);
 		Object.setPrototypeOf(result, proto);
 		// A branded built-in with private internal slots (URL, Headers, Request/Response, or any
-		// custom class whose own accessors/[util.inspect.custom] read `#private` state) throws when
-		// util.inspect later renders a value wearing its prototype but lacking its real internal
-		// state - and that throw happens inside Node's OWN inspect logic, well after this walk has
-		// returned, so the only way to catch it here is to actually try inspecting the empty clone
-		// now, before any properties are attached. Left unguarded, that throw would surface all the
-		// way up to inspectForLog's outer catch and replace the ENTIRE structured payload - not just
-		// this one nested field - with a single "[Unrenderable value]", losing phase/install_output/
-		// deployment_id and everything else alongside it, for one URL-shaped field anywhere in the
-		// tree. Skipped for `null`/`Object.prototype`, the overwhelmingly common case for a JSON-like
-		// diagnostic payload, where no exotic prototype is ever attached and this check would be pure
-		// overhead for a class that could never fail it.
-		if (proto !== null && proto !== Object.prototype) inspect(result);
+		// custom class whose own accessors read `#private` state) throws when util.inspect later
+		// renders a value wearing its prototype but lacking its real internal state - and that throw
+		// happens inside Node's OWN inspect logic, well after this walk has returned, so the only way
+		// to catch it here is to actually try inspecting the empty clone now, before any properties are
+		// attached. Left unguarded, that throw would surface all the way up to inspectForLog's outer
+		// catch and replace the ENTIRE structured payload - not just this one nested field - with a
+		// single "[Unrenderable value]", losing phase/install_output/deployment_id and everything else
+		// alongside it, for one URL-shaped field anywhere in the tree. Skipped for `null`/
+		// `Object.prototype`, the overwhelmingly common case for a JSON-like diagnostic payload, where
+		// no exotic prototype is ever attached and this check would be pure overhead for a class that
+		// could never fail it.
+		//
+		// A Proxy prototype is rejected outright, never probed: `Object.getPrototypeOf`/`inspect` on a
+		// value wearing it would invoke the Proxy's own traps (e.g. a `get` trap read while inspect
+		// looks up `.constructor`), running arbitrary caller-controlled code - and a hostile trap that
+		// never returns (`get() { while (true) {} }`) would wedge the worker on the error-logging path
+		// itself. `customInspect: false` keeps the probe from invoking `[util.inspect.custom]` too, so
+		// a legitimate class's custom inspector is invoked at most once - by the real render later -
+		// rather than once here (silently) and once more for the actual output, which would corrupt a
+		// stateful/one-shot inspector's second call.
+		if (proto !== null && proto !== Object.prototype) {
+			if (types.isProxy(proto)) throw new Error('unsafe Proxy prototype');
+			inspect(result, { customInspect: false });
+		}
 	} catch {
 		// Reset to plain Object - inspect() renders it without the class name, but every actual
 		// property attached below is still safe to render (see above for why the prototype itself,

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -1515,9 +1515,26 @@ function deepSanitizeErrors(
 	const result: Record<string | symbol, any> = {};
 	seen.set(value, result);
 	try {
-		Object.setPrototypeOf(result, Object.getPrototypeOf(value));
+		const proto = Object.getPrototypeOf(value);
+		Object.setPrototypeOf(result, proto);
+		// A branded built-in with private internal slots (URL, Headers, Request/Response, or any
+		// custom class whose own accessors/[util.inspect.custom] read `#private` state) throws when
+		// util.inspect later renders a value wearing its prototype but lacking its real internal
+		// state - and that throw happens inside Node's OWN inspect logic, well after this walk has
+		// returned, so the only way to catch it here is to actually try inspecting the empty clone
+		// now, before any properties are attached. Left unguarded, that throw would surface all the
+		// way up to inspectForLog's outer catch and replace the ENTIRE structured payload - not just
+		// this one nested field - with a single "[Unrenderable value]", losing phase/install_output/
+		// deployment_id and everything else alongside it, for one URL-shaped field anywhere in the
+		// tree. Skipped for `null`/`Object.prototype`, the overwhelmingly common case for a JSON-like
+		// diagnostic payload, where no exotic prototype is ever attached and this check would be pure
+		// overhead for a class that could never fail it.
+		if (proto !== null && proto !== Object.prototype) inspect(result);
 	} catch {
-		// leave result's prototype as plain Object - inspect() renders it without the class name
+		// Reset to plain Object - inspect() renders it without the class name, but every actual
+		// property attached below is still safe to render (see above for why the prototype itself,
+		// not the data, is what's unsafe here).
+		Object.setPrototypeOf(result, Object.prototype);
 	}
 	// Object.keys/getOwnPropertySymbols themselves are one unavoidable O(n) pass (a plain object,
 	// unlike Array/Map/Set, has no O(1) size to check before enumerating) - but everything AFTER

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -186,22 +186,24 @@ async function updateLogSettings() {
 /**
  * True when the argument is an Error (same-realm or native cross-realm — component code runs
  * through node:vm, so a VM-created Error fails `instanceof Error` but passes `isNativeError`).
- * A Proxy is checked and rejected FIRST, before `instanceof`: `instanceof` walks the prototype
- * chain via `[[GetPrototypeOf]]`, which for a Proxy invokes its `getPrototypeOf` trap - a trap
- * that hangs (an infinite loop) or has side effects would run to completion regardless of the
- * try/catch below (which only helps a trap that throws), on whatever path called isErrorLike
- * (e.g. logging a DIFFERENT operation's failure). `types.isProxy` queries the exotic object's
- * internal slots directly and never reflects on it, so it's always safe to check first, even on
- * a revoked Proxy. The try/catch below still guards other exotic objects whose prototype is
- * unreachable for other reasons — the logger must never throw on any input, and util.format
- * renders those fine raw. Exported so call sites outside this module (e.g.
- * OperationFunctionCaller, deciding how to log an error-shaped value it didn't itself catch as
- * an Error) can reuse the same classification instead of a weaker local `instanceof` check.
+ * Classified via `util.types.isNativeError` alone, never `instanceof Error`: `instanceof` walks
+ * the prototype chain via `[[GetPrototypeOf]]`, which for a value like
+ * `Object.create(Object.create(proxyAncestor))` eventually reaches `proxyAncestor` and invokes
+ * ITS `getPrototypeOf` trap, even though `arg` itself is an ordinary object and not a Proxy - a
+ * trap that hangs (an infinite loop) or has side effects would run to completion on whatever path
+ * called isErrorLike (e.g. logging a DIFFERENT operation's failure). `isNativeError` checks an
+ * internal slot directly, the same realm-independent, prototype-chain-independent mechanism
+ * `types.isMap`/`types.isDate`/etc. use elsewhere in this file, so it recognizes same-realm,
+ * cross-realm (VM), and Error-subclass instances without ever walking a prototype chain. The
+ * try/catch below still guards other exotic objects for other reasons — the logger must never
+ * throw on any input, and util.format renders those fine raw. Exported so call sites outside this
+ * module (e.g. OperationFunctionCaller, deciding how to log an error-shaped value it didn't itself
+ * catch as an Error) can reuse the same classification instead of a weaker local `instanceof`
+ * check.
  */
 export function isErrorLike(arg: any): boolean {
 	try {
-		if (types.isProxy(arg)) return false;
-		return arg instanceof Error || isNativeError(arg);
+		return isNativeError(arg);
 	} catch {
 		return false;
 	}
@@ -1019,8 +1021,12 @@ function renderErrorLine(error: any): string {
 		const base = typeof error?.stack === 'string' ? error.stack : errorToString(error);
 		return base + loggablePropsSuffix(error);
 	} catch (err) {
-		// error?.stack itself can throw on a hostile object even though errorToString cannot.
-		return `[Unrenderable Error: ${err instanceof Error ? err.message : String(err)}]`;
+		// error?.stack itself can throw on a hostile object (e.g. a getter on a `cause` chain member
+		// that throws a revoked Proxy) - `err` is then whatever was thrown, so it must be rendered via
+		// errorToString, the only renderer in this file explicitly guaranteed never to throw regardless
+		// of input. `err instanceof Error`/`String(err)` are NOT safe here: both throw on a revoked
+		// Proxy, which would defeat this catch's whole purpose.
+		return `[Unrenderable Error: ${errorToString(err)}]`;
 	}
 }
 
@@ -1268,7 +1274,23 @@ function safeOpaqueBuiltinSummary(value: object): any {
 		if (types.isDate(value)) return new Date(Date.prototype.getTime.call(value));
 		if (types.isRegExp(value)) {
 			const source = Reflect.get(RegExp.prototype, 'source', value);
-			const flags = Reflect.get(RegExp.prototype, 'flags', value);
+			// Built manually from each individual flag getter (bound via Reflect.get, same
+			// hijack-avoidance pattern as source/Map/Set elsewhere in this file) rather than reading
+			// the combined `RegExp.prototype.flags` getter: per spec, `flags` synthesizes its result by
+			// reading `this.global`, `this.ignoreCase`, etc. as ordinary property gets on `value` -
+			// each individual flag getter (`global`, `ignoreCase`, ...) instead reads the internal
+			// [[OriginalFlags]] slot directly, the same as `source`. An expando shadowing e.g. `global`
+			// with a hostile getter would otherwise have `flags` invoke it while merely trying to
+			// reconstruct a safe copy of the RegExp.
+			let flags = '';
+			if (Reflect.get(RegExp.prototype, 'hasIndices', value)) flags += 'd';
+			if (Reflect.get(RegExp.prototype, 'global', value)) flags += 'g';
+			if (Reflect.get(RegExp.prototype, 'ignoreCase', value)) flags += 'i';
+			if (Reflect.get(RegExp.prototype, 'multiline', value)) flags += 'm';
+			if (Reflect.get(RegExp.prototype, 'dotAll', value)) flags += 's';
+			if (Reflect.get(RegExp.prototype, 'unicode', value)) flags += 'u';
+			if (Reflect.get(RegExp.prototype, 'unicodeSets', value)) flags += 'v';
+			if (Reflect.get(RegExp.prototype, 'sticky', value)) flags += 'y';
 			return new RegExp(source, flags);
 		}
 		if (types.isWeakMap(value)) return new WeakMap();
@@ -1300,6 +1322,59 @@ function safeOpaqueBuiltinSummary(value: object): any {
  *  name or what the prototype chain declares. */
 function defineOwnProperty(target: any, key: string | symbol, value: any) {
 	Object.defineProperty(target, key, { value, writable: true, enumerable: true, configurable: true });
+}
+
+/**
+ * True if `proto` (and every prototype above it, up to but excluding Object.prototype/null) is
+ * safe for a stateless sanitized clone to wear - i.e. util.inspect can later render a value with
+ * this prototype without running any caller-controlled code.
+ *
+ * This used to be answered by actually calling `inspect()` on the empty clone as a probe - but
+ * that IS running caller-controlled code, just earlier and silently: `inspect()` walks the full
+ * prototype chain (not just the immediate level) doing its own class-name/tag detection, which
+ * invokes a Proxy ANCESTOR's traps (`types.isProxy(proto)` alone only catches the immediate
+ * level), reads an inherited `Symbol.toStringTag` getter, and - even with `customInspect: false`
+ * suppressing the clone's OWN custom inspector - still leaves that same inspector to be invoked a
+ * second time by the real render later. A hostile trap/getter that never returns wedges the
+ * logging worker regardless of which of those two invocations reaches it.
+ *
+ * So this never invokes anything: `types.isProxy` and `Object.getOwnPropertyNames`/
+ * `getOwnPropertyDescriptor`/`getPrototypeOf` are internal-slot/structural reads on each
+ * non-Proxy level, same as the rest of this file's reflection. A level is rejected if it's a
+ * Proxy (any trap, including on revocation) or defines any OWN accessor (getter/setter) property
+ * - the exact shape of a branded built-in's internal-slot getter (e.g. URL.prototype's
+ * `href`/`protocol`/...), and there is no way to tell "safe getter" from "hostile getter" without
+ * invoking it, so any accessor anywhere in the chain fails closed. An ordinary class's prototype
+ * (only a data `constructor` property, plus perhaps plain methods) passes, so a plain
+ * custom-class instance still renders with its real class name (see the 'Diagnostic' test).
+ */
+function isSafeToWearPrototype(proto: object): boolean {
+	let level: any = proto;
+	while (level !== null && level !== Object.prototype) {
+		if (types.isProxy(level)) return false;
+		let keys: (string | symbol)[];
+		try {
+			keys = [...Object.getOwnPropertyNames(level), ...Object.getOwnPropertySymbols(level)];
+		} catch {
+			return false;
+		}
+		for (const key of keys) {
+			if (key === 'constructor') continue; // an ordinary data property on every class prototype
+			let descriptor;
+			try {
+				descriptor = Object.getOwnPropertyDescriptor(level, key);
+			} catch {
+				return false;
+			}
+			if (descriptor && (descriptor.get || descriptor.set)) return false;
+		}
+		try {
+			level = Object.getPrototypeOf(level);
+		} catch {
+			return false;
+		}
+	}
+	return true;
 }
 
 /**
@@ -1521,37 +1596,32 @@ function deepSanitizeErrors(
 	seen.set(value, result);
 	try {
 		const proto = Object.getPrototypeOf(value);
-		Object.setPrototypeOf(result, proto);
 		// A branded built-in with private internal slots (URL, Headers, Request/Response, or any
 		// custom class whose own accessors read `#private` state) throws when util.inspect later
-		// renders a value wearing its prototype but lacking its real internal state - and that throw
-		// happens inside Node's OWN inspect logic, well after this walk has returned, so the only way
-		// to catch it here is to actually try inspecting the empty clone now, before any properties are
-		// attached. Left unguarded, that throw would surface all the way up to inspectForLog's outer
-		// catch and replace the ENTIRE structured payload - not just this one nested field - with a
-		// single "[Unrenderable value]", losing phase/install_output/deployment_id and everything else
-		// alongside it, for one URL-shaped field anywhere in the tree. Skipped for `null`/
-		// `Object.prototype`, the overwhelmingly common case for a JSON-like diagnostic payload, where
-		// no exotic prototype is ever attached and this check would be pure overhead for a class that
-		// could never fail it.
+		// renders a value wearing its prototype but lacking its real internal state - and losing it
+		// unguarded would surface all the way up to inspectForLog's outer catch and replace the
+		// ENTIRE structured payload - not just this one nested field - with a single "[Unrenderable
+		// value]", losing phase/install_output/deployment_id and everything else alongside it, for
+		// one URL-shaped field anywhere in the tree.
 		//
-		// A Proxy prototype is rejected outright, never probed: `Object.getPrototypeOf`/`inspect` on a
-		// value wearing it would invoke the Proxy's own traps (e.g. a `get` trap read while inspect
-		// looks up `.constructor`), running arbitrary caller-controlled code - and a hostile trap that
-		// never returns (`get() { while (true) {} }`) would wedge the worker on the error-logging path
-		// itself. `customInspect: false` keeps the probe from invoking `[util.inspect.custom]` too, so
-		// a legitimate class's custom inspector is invoked at most once - by the real render later -
-		// rather than once here (silently) and once more for the actual output, which would corrupt a
-		// stateful/one-shot inspector's second call.
-		if (proto !== null && proto !== Object.prototype) {
-			if (types.isProxy(proto)) throw new Error('unsafe Proxy prototype');
-			inspect(result, { customInspect: false });
+		// This USED to be answered by actually calling `inspect()` on the empty clone as a probe, but
+		// that runs the same caller-controlled code it's trying to guard against, just earlier and
+		// silently: a Proxy ANYWHERE in the ancestor chain (not just the immediate `proto`) still gets
+		// its traps invoked by inspect's own class-name/tag walk, an inherited `Symbol.toStringTag`
+		// getter still gets read, and even `customInspect: false` only stops the PROBE's own call from
+		// invoking a custom inspector - the real render right after still invokes it a second time,
+		// corrupting a stateful/one-shot inspector's actual output. `isSafeToWearPrototype` answers the
+		// same question without invoking anything (see its doc comment); `proto` is restored only when
+		// it says so. Skipped for `null`/`Object.prototype`, the overwhelmingly common case for a
+		// JSON-like diagnostic payload, where no exotic prototype is ever attached and this check would
+		// be pure overhead for a class that could never fail it.
+		if (proto !== null && proto !== Object.prototype && isSafeToWearPrototype(proto)) {
+			Object.setPrototypeOf(result, proto);
 		}
 	} catch {
-		// Reset to plain Object - inspect() renders it without the class name, but every actual
-		// property attached below is still safe to render (see above for why the prototype itself,
-		// not the data, is what's unsafe here).
-		Object.setPrototypeOf(result, Object.prototype);
+		// Fall through with the clone's default Object.prototype - inspect() renders it without the
+		// class name, but every actual property attached below is still safe to render (see above for
+		// why the prototype itself, not the data, is what's unsafe here).
 	}
 	// Object.keys/getOwnPropertySymbols themselves are one unavoidable O(n) pass (a plain object,
 	// unlike Array/Map/Set, has no O(1) size to check before enumerating) - but everything AFTER
@@ -1604,11 +1674,30 @@ function deepSanitizeErrors(
 			// top-level render finds this hook via the exact same `value[sym]` property access, so
 			// reading it here isn't new arbitrary-code exposure the way an ordinary data getter
 			// would be - it's the documented render-hook contract, just resolved one level earlier.
+			let original;
 			try {
-				defineOwnProperty(result, sym, value[sym]);
+				original = value[sym];
 			} catch {
-				// leave unset - inspect() will render the rest of the object without a custom hook
+				continue; // leave unset - inspect() will render the rest of the object without a custom hook
 			}
+			if (typeof original !== 'function') continue; // not a valid hook - nothing to wrap or invoke
+			// The hook itself runs at REAL render time, entirely outside this walk - so whatever it
+			// RETURNS has never been through deepSanitizeErrors. Left as-is, a hook that returns a
+			// closure-captured secret-bearing Error (or any value with one nested inside) would have
+			// that Error rendered raw by the outer util.inspect call, bypassing this sanitizer entirely
+			// (#1994 review). This wraps the hook so the CALL is unchanged (still invoked with `this`
+			// bound to the original untrusted `value`, same as inspect would do directly) but its return
+			// value is sanitized with a fresh depth/budget - independent of this walk's own counters,
+			// which by render time are long since exhausted or out of scope.
+			defineOwnProperty(result, sym, (...args: any[]) => {
+				let rendered;
+				try {
+					rendered = original.apply(value, args);
+				} catch (err) {
+					return `[Unrenderable value: ${errorToString(err)}]`;
+				}
+				return deepSanitizeErrors(rendered, new WeakMap(), 0, { nodes: 0, maxEntries: DEFAULT_MAX_SANITIZE_ENTRIES });
+			});
 			continue;
 		}
 		if (descriptor.get || descriptor.set) {

--- a/utility/logging/harper_logger.ts
+++ b/utility/logging/harper_logger.ts
@@ -208,22 +208,43 @@ export function isErrorLike(arg: any): boolean {
 }
 
 /**
+ * True when `arg` needs sanitizeErrorArg's replacement before reaching Console's raw formatting:
+ * either it's error-like, or it's a live Proxy that isErrorLike deliberately reports as false (see
+ * isErrorLike above) but that Console's default inspect would still reflect on directly - which,
+ * if the Proxy happens to wrap an Error, dumps its own-enumerable properties unsanitized (#1734).
+ */
+function needsSanitizing(arg: any): boolean {
+	return types.isProxy(arg) || isErrorLike(arg);
+}
+
+/**
+ * Replaces an Error (or a Proxy - live-or-revoked, whatever it wraps) with a safe placeholder
+ * before it reaches Console's util.inspect formatting; same Proxy-first ordering and rationale as
+ * deepSanitizeErrors' `types.isProxy` check (see there) - reflecting on a Proxy at all, even just
+ * to classify it, risks running a hostile trap on the shallow logging path too.
+ */
+function sanitizeErrorArg(arg: any) {
+	if (types.isProxy(arg)) return labelPlaceholder('[Proxy]');
+	return isErrorLike(arg) ? errorForLog(arg) : arg;
+}
+
+/**
  * Replaces every Error argument with its log-safe errorForLog wrapper before the args reach
  * Console's util.inspect formatting, which would otherwise dump the error's own-enumerable
  * properties — where libraries and app code stash credentials (axios config headers, an
  * hdb_secret for an outbound Authorization header) — into hdb.log (see #1734 and errorForLog).
  * Called inside each level gate so filtered-out log calls pay nothing beyond the arg scan,
- * and only allocates when an Error is actually present. Deliberately shallow: an Error nested
- * inside a logged object/array is not rewritten (deep-walking every logged structure is not
- * worth the per-call cost, and the #1734 threat is raw thrown errors).
+ * and only allocates when an Error (or Proxy needing the same treatment) is actually present.
+ * Deliberately shallow: an Error nested inside a logged object/array is not rewritten (deep-
+ * walking every logged structure is not worth the per-call cost, and the #1734 threat is raw
+ * thrown errors).
  */
 function sanitizeErrorArgs(args: any[]) {
 	for (let i = 0; i < args.length; i++) {
-		if (isErrorLike(args[i])) {
+		if (needsSanitizing(args[i])) {
 			const sanitized = args.slice(0, i);
 			for (let j = i; j < args.length; j++) {
-				const arg = args[j];
-				sanitized[j] = isErrorLike(arg) ? errorForLog(arg) : arg;
+				sanitized[j] = sanitizeErrorArg(args[j]);
 			}
 			return sanitized;
 		}
@@ -307,10 +328,10 @@ class HarperLogger extends Console {
 		super.log(...sanitizeErrorArgs(args));
 	}
 	dir(item, options?) {
-		super.dir(isErrorLike(item) ? errorForLog(item) : item, options);
+		super.dir(sanitizeErrorArg(item), options);
 	}
 	table(data, columns?) {
-		super.table(Array.isArray(data) ? sanitizeErrorArgs(data) : isErrorLike(data) ? errorForLog(data) : data, columns);
+		super.table(Array.isArray(data) ? sanitizeErrorArgs(data) : sanitizeErrorArg(data), columns);
 	}
 	withTag(tag) {
 		return loggerWithTag(tag, true, this);
@@ -1181,8 +1202,10 @@ const MAX_INDEXED_EXPANDO_CHECK_LENGTH = 10_000;
  * exactly like any other array - `Object.keys(Buffer.from('hi'))` is `['0', '1']` - so those don't
  * count as expandos here; only a key beyond `[0, length)` does. A boxed String has the same shape
  * (`Object.keys(new String('hi'))` is the same `['0', '1']`) and gets the same carve-out; detected
- * via the intrinsic `Object.prototype.toString` tag rather than `instanceof String` (realm/hijack-
- * safe, same technique safeOpaqueBuiltinSummary's fallback tag uses). DataView has no such index
+ * via `types.isStringObject` (an internal-slot check, like `isOpaqueBuiltin`'s `types.is*` checks
+ * above) rather than `Object.prototype.toString.call`, which reads the value's own
+ * `Symbol.toStringTag` property - a hostile value defining that as a getter would have it run
+ * during this supposedly passive classification. DataView has no such index
  * properties (its data is accessed only via get/set methods), so it's excluded from the carve-out
  * and goes through the plain `Object.keys(value).length > 0` check like any ordinary object.
  *
@@ -1203,7 +1226,7 @@ const MAX_INDEXED_EXPANDO_CHECK_LENGTH = 10_000;
 function hasEnumerableOwnProps(value: object): boolean {
 	try {
 		const isTypedArray = ArrayBuffer.isView(value) && !types.isDataView(value);
-		const isBoxedString = types.isBoxedPrimitive(value) && Object.prototype.toString.call(value) === '[object String]';
+		const isBoxedString = types.isStringObject(value);
 		if (isTypedArray || isBoxedString) {
 			// The typed-array getter is bound explicitly (see TYPED_ARRAY_PROTO above) to survive a
 			// shadowed own `length`; a boxed String's `length` is a non-configurable, non-writable own


### PR DESCRIPTION
## What / why

`deployComponent` (and any other operation whose error carries a structured `http_resp_msg`) logged its diagnostic payload through `log.error(err.http_resp_msg)`. Node's `Console` defaults to `util.inspect` depth 2 / `maxArrayLength` 100 / `maxStringLength` 10000, so a nested `install_output.lines` array flattened to `[Object]` — exactly the npm stdout/stderr an operator needs to diagnose the real failure (see #1982).

`OperationFunctionCaller` now renders a structured (non-string, non-Error) `http_resp_msg` through a new `inspectForLog(value, { depth, maxArrayLength, maxStringLength })` helper in `harper_logger.ts`, with explicit limits generous enough to cover the full 200-line/16 KiB install capture.

## Why this touches more than one call site

Raising the inspect depth for this one payload isn't safe by itself: `harper_logger.ts` already carries dedicated logic (from #1734) to strip an Error's own-enumerable properties before logging it, specifically because raising inspect depth elsewhere had previously leaked credentials (axios `config.headers.Authorization`, etc.) nested inside logged Errors. `inspectForLog` needed the same guarantee at a deeper, caller-controlled depth, applied recursively to whatever shape a structured diagnostic turns out to have — not just the known `install_output` shape, since the field is generic.

That recursive sanitizer (`deepSanitizeErrors`) is the bulk of the diff. It:
- Replaces any Error found at any depth with the existing `errorForLog` wrapper (never its raw own-enumerable properties)
- Never invokes a getter, an overridden `Symbol.iterator`, or a Proxy trap of any kind — only reads data descriptors directly
- Is cycle-safe, depth-capped, and breadth-bounded per container plus a shared total-node budget, so a pathological/huge structure can't wedge the logging path itself
- Handles arrays, Maps, Sets, class instances, functions, and the opaque built-ins (Date/RegExp/Buffer/TypedArray/WeakMap/WeakSet/boxed primitives/Promise) each according to what's actually safe to reflect on

## Test plan

- `npm run build` clean
- `npm run test:unit:logging` — 119 passing (0 failing)
- `unitTests/utility/OperationFunctionCaller.test.js` — 9 passing, including the exact 200-line/16 KiB repro from the issue

## Review history

This branch was independently pre-push reviewed by Codex across 5 rounds (the diff went through several rounds of fixes for issues the reviewer found — breadth/budget bugs, a Promise/Proxy/opaque-builtin secret-leak class of issue, and a couple of fail-open bugs I introduced while fixing the earlier rounds). Final round: `verdict: LGTM`, no findings.

Refs #1982

🤖 Generated with [Claude Code](https://claude.com/claude-code)