### PR TITLE
fix(resources): drain in-flight source-populated cache writes before dropTable() drops column families

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1372,19 +1372,29 @@ export function makeTable(options) {
 			// the table stuck "dropping" for completeInterruptedDrop to retry (and fail
 			// identically) on every subsequent load (harper#1381). Drain any in-flight commits
 			// before the blob sweep below (so it observes every row a drain-caught write just
-			// committed) and before touching a single column family. Bounded: the tracked
-			// promise covers the whole source round-trip (see getFromSource), so a hung or
-			// slow source could otherwise wedge this drop forever.
+			// committed) and before touching a single column family.
+			//
+			// Bounded, and fails CLOSED: the tracked promise covers the whole source round-trip
+			// plus the local commit (see getFromSource), so a hung/slow source or a slow commit
+			// (e.g. a large blob write) could otherwise wedge this drop forever. Rather than
+			// give up and drop anyway - which would reopen exactly the race this drain exists to
+			// close, just less often - a timeout FAILS the drop. The tombstone written above is
+			// already durable, so completeInterruptedDrop picks the drop back up on the next
+			// load, once the stuck write has had time to finish.
 			if (pendingSourceCommits.size) {
 				const pending = [...pendingSourceCommits];
-				let timedOut = false;
-				await Promise.race([
+				let timer: NodeJS.Timeout;
+				const timedOut = Symbol('timedOut');
+				const result = await Promise.race([
 					Promise.allSettled(pending),
-					new Promise<void>((resolve) => setTimeout(() => ((timedOut = true), resolve()), LOCK_TIMEOUT)),
+					new Promise<typeof timedOut>((resolve) => {
+						timer = setTimeout(() => resolve(timedOut), LOCK_TIMEOUT);
+					}),
 				]);
-				if (timedOut) {
-					logger.warn?.(
-						`dropTable() timed out after ${LOCK_TIMEOUT}ms waiting for ${pending.length} in-flight source-populated cache write(s) on ${tableName}; proceeding with the drop anyway`
+				clearTimeout(timer);
+				if (result === timedOut) {
+					throw new Error(
+						`dropTable() timed out after ${LOCK_TIMEOUT}ms waiting for ${pending.length} in-flight source-populated cache write(s) on ${tableName} to settle; refusing to drop the column families out from under a write that may still be staged. The drop tombstone is durable, so this will be retried on the next load.`
 					);
 				}
 			}

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -371,8 +371,10 @@ export function makeTable(options) {
 	// must not drop this table's column families while one of those writes is still landing —
 	// racing a drop against an in-flight write is what corrupts the column family handle and
 	// produces "Invalid column family specified in write batch" (harper#1381). Track the
-	// in-flight commit promises here so dropTable() can drain them first.
+	// in-flight commit promises here so dropTable() can drain them first, and stop admitting
+	// new ones (droppingTable) once a drop has actually started.
 	const pendingSourceCommits = new Set<Promise<any>>();
+	let droppingTable = false;
 	let createdTimeProperty: Attribute | undefined,
 		updatedTimeProperty: Attribute | undefined,
 		expiresAtProperty: Attribute | undefined;
@@ -1348,30 +1350,48 @@ export function makeTable(options) {
 					if (tombstoneWrite?.then) await tombstoneWrite;
 				}
 			}
+			// A get() against a sourcedFrom table resolves to its caller before the resolved
+			// record's cache write has committed (see getFromSource) - the write lands "in the
+			// background" for latency reasons. Flip this BEFORE removing the table from the
+			// schema below: getFromSource() checks it and skips caching (treats the load as
+			// noCacheStore) for any call it admits from here on, including one that slipped in
+			// through a stale reference to this Table between the two steps.
+			droppingTable = true;
 			// Remove the table from the in-memory schema immediately so concurrent
 			// requests get "table does not exist" instead of racing the column
 			// family drops below. If a drop fails past this point the table stays
 			// invisible, and the tombstone guarantees the drop completes on the
 			// next startup (or on a same-name create).
 			delete databases[databaseName][tableName];
+			// The above stops new source-fill writes from starting, but a write from a get()
+			// that already returned to its caller may still be in flight. Dropping the column
+			// families out from under that write is a genuine invariant violation, not just a
+			// benign race: RocksDB rejects the still-open write batch with "Invalid column
+			// family specified in write batch" (or "Could not access column family N"), which
+			// can also abort this drop before it removes the tombstoned catalog rows - leaving
+			// the table stuck "dropping" for completeInterruptedDrop to retry (and fail
+			// identically) on every subsequent load (harper#1381). Drain any in-flight commits
+			// before the blob sweep below (so it observes every row a drain-caught write just
+			// committed) and before touching a single column family. Bounded: the tracked
+			// promise covers the whole source round-trip (see getFromSource), so a hung or
+			// slow source could otherwise wedge this drop forever.
+			if (pendingSourceCommits.size) {
+				const pending = [...pendingSourceCommits];
+				let timedOut = false;
+				await Promise.race([
+					Promise.allSettled(pending),
+					new Promise<void>((resolve) => setTimeout(() => ((timedOut = true), resolve()), LOCK_TIMEOUT)),
+				]);
+				if (timedOut) {
+					logger.warn?.(
+						`dropTable() timed out after ${LOCK_TIMEOUT}ms waiting for ${pending.length} in-flight source-populated cache write(s) on ${tableName}; proceeding with the drop anyway`
+					);
+				}
+			}
 			for (const entry of primaryStore.getRange({ versions: true, snapshot: false, lazy: true })) {
 				if (entry.metadataFlags & HAS_BLOBS && entry.value) {
 					deleteBlobsInObject(entry.value);
 				}
-			}
-			// A get() against a sourcedFrom table resolves to its caller before the resolved
-			// record's cache write has committed (see getFromSource) - the write lands "in the
-			// background" for latency reasons. No new request can reach this table now that it's
-			// removed from the schema above, but a write from a get() that already returned may
-			// still be in flight. Dropping the column families out from under that write is a
-			// genuine invariant violation, not just a benign race: RocksDB rejects the still-open
-			// write batch with "Invalid column family specified in write batch" (or "Could not
-			// access column family N"), which can also abort this drop before it removes the
-			// tombstoned catalog rows - leaving the table stuck "dropping" for
-			// completeInterruptedDrop to retry (and fail identically) on every subsequent load
-			// (harper#1381). Drain any in-flight commits before touching a single column family.
-			if (pendingSourceCommits.size) {
-				await Promise.allSettled([...pendingSourceCommits]);
 			}
 			if (databaseName === databasePath) {
 				// part of a database.
@@ -5592,7 +5612,10 @@ export function makeTable(options) {
 			replacingRecord: existingRecord,
 			replacingEntry: existingEntry,
 			replacingVersion: existingVersion,
-			noCacheStore: false,
+			// Once dropTable() has started, no new source-fill write may begin (dropTable()
+			// only drains writes already in flight - see there); still resolve the caller's
+			// read with fresh source data, just don't cache it into a table that's going away.
+			noCacheStore: droppingTable,
 			source: null,
 			// use the same resource cache as a parent context so that if modifications are made to resources,
 			// they are visible in the parent requesting context

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -366,6 +366,13 @@ export function makeTable(options) {
 	let hasSourceGet: any;
 	let primaryKeyAttribute: Attribute | undefined;
 	let lastEvictionCompletion: Promise<void> = Promise.resolve();
+	// getFromSource() intentionally resolves its caller before the resolved record's cache
+	// write has committed (see there) so GET latency doesn't pay for the write. dropTable()
+	// must not drop this table's column families while one of those writes is still landing —
+	// racing a drop against an in-flight write is what corrupts the column family handle and
+	// produces "Invalid column family specified in write batch" (harper#1381). Track the
+	// in-flight commit promises here so dropTable() can drain them first.
+	const pendingSourceCommits = new Set<Promise<any>>();
 	let createdTimeProperty: Attribute | undefined,
 		updatedTimeProperty: Attribute | undefined,
 		expiresAtProperty: Attribute | undefined;
@@ -1351,6 +1358,20 @@ export function makeTable(options) {
 				if (entry.metadataFlags & HAS_BLOBS && entry.value) {
 					deleteBlobsInObject(entry.value);
 				}
+			}
+			// A get() against a sourcedFrom table resolves to its caller before the resolved
+			// record's cache write has committed (see getFromSource) - the write lands "in the
+			// background" for latency reasons. No new request can reach this table now that it's
+			// removed from the schema above, but a write from a get() that already returned may
+			// still be in flight. Dropping the column families out from under that write is a
+			// genuine invariant violation, not just a benign race: RocksDB rejects the still-open
+			// write batch with "Invalid column family specified in write batch" (or "Could not
+			// access column family N"), which can also abort this drop before it removes the
+			// tombstoned catalog rows - leaving the table stuck "dropping" for
+			// completeInterruptedDrop to retry (and fail identically) on every subsequent load
+			// (harper#1381). Drain any in-flight commits before touching a single column family.
+			if (pendingSourceCommits.size) {
+				await Promise.allSettled([...pendingSourceCommits]);
 			}
 			if (databaseName === databasePath) {
 				// part of a database.
@@ -5585,8 +5606,11 @@ export function makeTable(options) {
 			// we don't want to wait for the transaction because we want to return as fast as possible
 			// and let the transaction commit in the background
 			let resolved;
+			// Tracked in pendingSourceCommits (below) so dropTable() can wait for this write to
+			// land before it drops the table's column families - see the comment there.
+			let commitPromise: Promise<any>;
 			when(
-				transaction(sourceContext, async (_txn) => {
+				(commitPromise = transaction(sourceContext, async (_txn) => {
 					const start = performance.now();
 					let updatedRecord;
 					let hasChanges, invalidated;
@@ -5838,16 +5862,19 @@ export function makeTable(options) {
 					if (embedBefore) await embedBefore();
 					sourceWrite.before = preCommitBlobsForRecordBefore(sourceWrite, updatedRecord);
 					dbTxn.addWrite(sourceWrite);
-				}),
+				})),
 				() => {
+					pendingSourceCommits.delete(commitPromise);
 					primaryStore.unlock(id);
 				},
 				(error) => {
+					pendingSourceCommits.delete(commitPromise);
 					primaryStore.unlock(id);
 					if (resolved) logger.error?.('Error committing cache update', error);
 					// else the error was already propagated as part of the promise that we returned
 				}
 			);
+			pendingSourceCommits.add(commitPromise);
 		});
 	}
 

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5639,8 +5639,17 @@ export function makeTable(options) {
 			// we don't want to wait for the transaction because we want to return as fast as possible
 			// and let the transaction commit in the background
 			let resolved;
-			// Tracked in pendingSourceCommits (below) so dropTable() can wait for this write to
-			// land before it drops the table's column families - see the comment there.
+			// Tracked in pendingSourceCommits (below) for the full lifetime of this transaction -
+			// including the source round-trip, not just from the point it's actually staged -
+			// so dropTable() can wait for it before dropping the table's column families (see the
+			// comment there). Registering only once a write reaches staging would track less (no
+			// Set churn for a plain cache miss, and a slow/hung source couldn't delay a drop) and
+			// is safe on its own given the live droppingTable re-checks in this function - but it
+			// would make dropTable()'s correctness depend on every future early-return path in
+			// this function remembering to check droppingTable, rather than on dropTable() simply
+			// waiting for whatever this function is doing. Tracking the whole lifetime is the
+			// belt to that suspenders, at the cost of a bounded wait on a merely slow source
+			// before the drain's fail-closed timeout below.
 			let commitPromise: Promise<any>;
 			when(
 				(commitPromise = transaction(sourceContext, async (_txn) => {
@@ -5898,9 +5907,7 @@ export function makeTable(options) {
 					if (embedBefore) await embedBefore();
 					if (droppingTable) {
 						// Re-check right before staging the write: dropTable() may have started
-						// while we were awaiting the embed step above, and the drain in dropTable()
-						// only waits for writes staged before it snapshotted pendingSourceCommits -
-						// staging one now would race the column-family drop (harper#1381).
+						// while we were awaiting the embed step above (harper#1381).
 						sourceContext.transaction.abort();
 						return;
 					}

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5749,8 +5749,11 @@ export function makeTable(options) {
 						sourceContext.transaction.abort();
 						return;
 					}
-					if (context?.noCacheStore || sourceContext.noCacheStore) {
-						// abort before we write any change
+					if (context?.noCacheStore || sourceContext.noCacheStore || droppingTable) {
+						// abort before we write any change. droppingTable is re-checked live (not just
+						// the noCacheStore snapshot taken at call start) because a call admitted before
+						// dropTable() began can still be sitting here after it started - the await above
+						// waited on the source, which may take arbitrarily long.
 						sourceContext.transaction.abort();
 						return;
 					}
@@ -5883,6 +5886,14 @@ export function makeTable(options) {
 						TableResource.userEmbedders
 					);
 					if (embedBefore) await embedBefore();
+					if (droppingTable) {
+						// Re-check right before staging the write: dropTable() may have started
+						// while we were awaiting the embed step above, and the drain in dropTable()
+						// only waits for writes staged before it snapshotted pendingSourceCommits -
+						// staging one now would race the column-family drop (harper#1381).
+						sourceContext.transaction.abort();
+						return;
+					}
 					sourceWrite.before = preCommitBlobsForRecordBefore(sourceWrite, updatedRecord);
 					dbTxn.addWrite(sourceWrite);
 				})),

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5650,9 +5650,7 @@ export function makeTable(options) {
 			// waiting for whatever this function is doing. Tracking the whole lifetime is the
 			// belt to that suspenders, at the cost of a bounded wait on a merely slow source
 			// before the drain's fail-closed timeout below.
-			let commitPromise: Promise<any>;
-			when(
-				(commitPromise = transaction(sourceContext, async (_txn) => {
+			const commitPromise = transaction(sourceContext, async (_txn) => {
 					const start = performance.now();
 					let updatedRecord;
 					let hasChanges, invalidated;
@@ -5913,7 +5911,10 @@ export function makeTable(options) {
 					}
 					sourceWrite.before = preCommitBlobsForRecordBefore(sourceWrite, updatedRecord);
 					dbTxn.addWrite(sourceWrite);
-				})),
+				});
+			pendingSourceCommits.add(commitPromise);
+			when(
+				commitPromise,
 				() => {
 					pendingSourceCommits.delete(commitPromise);
 					primaryStore.unlock(id);
@@ -5925,7 +5926,6 @@ export function makeTable(options) {
 					// else the error was already propagated as part of the promise that we returned
 				}
 			);
-			pendingSourceCommits.add(commitPromise);
 		});
 	}
 

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5651,267 +5651,266 @@ export function makeTable(options) {
 			// belt to that suspenders, at the cost of a bounded wait on a merely slow source
 			// before the drain's fail-closed timeout below.
 			const commitPromise = transaction(sourceContext, async (_txn) => {
-					const start = performance.now();
-					let updatedRecord;
-					let hasChanges, invalidated;
-					try {
-						updatedRecord = await throttledCallToSource(source, id, sourceContext, existingEntry);
-						invalidated = metadataFlags & INVALIDATED;
-						let version = sourceContext.lastModified || (invalidated && existingVersion);
-						hasChanges = invalidated || version > existingVersion || !existingRecord;
-						const resolveDuration = performance.now() - start;
-						recordAction(resolveDuration, 'cache-resolution', tableName, null, 'success');
-						if (responseHeaders)
-							appendHeader(responseHeaders, 'Server-Timing', `cache-resolve;dur=${resolveDuration.toFixed(2)}`, true);
-						if (expirationMs && sourceContext.expiresAt == undefined)
-							sourceContext.expiresAt = Date.now() + expirationMs;
-						if (updatedRecord) {
-							if (typeof updatedRecord !== 'object') throw new Error('Only objects can be cached and stored in tables');
-							if (updatedRecord.status > 0 && updatedRecord.headers) {
-								// if the source has a status code and headers, treat it as a response
-								const status = updatedRecord.status;
-								if (status === 304) {
-									// revalidation of our current cached record
-									updatedRecord = existingRecord;
-									version = existingVersion;
-								} else if (!CACHEABLE_STATUS_CODES.has(status)) {
-									// non-cacheable status - propagate to client without caching
-									throw new ServerError(updatedRecord.body || 'Error from source', status);
+				const start = performance.now();
+				let updatedRecord;
+				let hasChanges, invalidated;
+				try {
+					updatedRecord = await throttledCallToSource(source, id, sourceContext, existingEntry);
+					invalidated = metadataFlags & INVALIDATED;
+					let version = sourceContext.lastModified || (invalidated && existingVersion);
+					hasChanges = invalidated || version > existingVersion || !existingRecord;
+					const resolveDuration = performance.now() - start;
+					recordAction(resolveDuration, 'cache-resolution', tableName, null, 'success');
+					if (responseHeaders)
+						appendHeader(responseHeaders, 'Server-Timing', `cache-resolve;dur=${resolveDuration.toFixed(2)}`, true);
+					if (expirationMs && sourceContext.expiresAt == undefined) sourceContext.expiresAt = Date.now() + expirationMs;
+					if (updatedRecord) {
+						if (typeof updatedRecord !== 'object') throw new Error('Only objects can be cached and stored in tables');
+						if (updatedRecord.status > 0 && updatedRecord.headers) {
+							// if the source has a status code and headers, treat it as a response
+							const status = updatedRecord.status;
+							if (status === 304) {
+								// revalidation of our current cached record
+								updatedRecord = existingRecord;
+								version = existingVersion;
+							} else if (!CACHEABLE_STATUS_CODES.has(status)) {
+								// non-cacheable status - propagate to client without caching
+								throw new ServerError(updatedRecord.body || 'Error from source', status);
+							} else {
+								let headers: any;
+								const sourceHeaders = updatedRecord.headers;
+								if (sourceHeaders[Symbol.iterator]) {
+									headers = {};
+									for (let [name, value] of sourceHeaders) {
+										headers[name.toLowerCase()] = value;
+									}
 								} else {
-									let headers: any;
-									const sourceHeaders = updatedRecord.headers;
-									if (sourceHeaders[Symbol.iterator]) {
-										headers = {};
-										for (let [name, value] of sourceHeaders) {
-											headers[name.toLowerCase()] = value;
-										}
-									} else {
-										headers = sourceHeaders; // just a plain object
-									}
-									const contentType = sourceHeaders.get?.('Content-Type');
-									let data: any;
-									if (contentType === 'application/json' && updatedRecord.json) {
-										// use native .json() if possible
-										data = await updatedRecord.json();
-									} else {
-										const contentTypeHandler = contentType && contentTypes.get(contentType);
-										if (contentTypeHandler?.deserialize) {
-											data = contentTypeHandler.deserialize(
-												await (contentType.startsWith('text/') ? updatedRecord.text() : updatedRecord.bytes())
-											);
-										}
-									}
-									if (data !== undefined) {
-										// we have structured data that we have parsed
-										delete headers['content-type']; // don't store the content type if we have already parsed it
-										updatedRecord = { headers, data };
-									} else {
-										updatedRecord = { headers, body: createBlob(updatedRecord.body) };
-									}
-									if (status !== 200) updatedRecord.status = status;
+									headers = sourceHeaders; // just a plain object
 								}
+								const contentType = sourceHeaders.get?.('Content-Type');
+								let data: any;
+								if (contentType === 'application/json' && updatedRecord.json) {
+									// use native .json() if possible
+									data = await updatedRecord.json();
+								} else {
+									const contentTypeHandler = contentType && contentTypes.get(contentType);
+									if (contentTypeHandler?.deserialize) {
+										data = contentTypeHandler.deserialize(
+											await (contentType.startsWith('text/') ? updatedRecord.text() : updatedRecord.bytes())
+										);
+									}
+								}
+								if (data !== undefined) {
+									// we have structured data that we have parsed
+									delete headers['content-type']; // don't store the content type if we have already parsed it
+									updatedRecord = { headers, data };
+								} else {
+									updatedRecord = { headers, body: createBlob(updatedRecord.body) };
+								}
+								if (status !== 200) updatedRecord.status = status;
 							}
-							if (typeof updatedRecord.toJSON === 'function') updatedRecord = updatedRecord.toJSON();
-							// updatedRecord may still be a frozen record (e.g. a reused existingRecord); copy-on-mutate
-							// before stamping the primary key and created/updated times below (records are immutable —
-							// 5.2 record caching relies on it — so we must not write through the frozen object).
-							if (isFrozenRecordObject(updatedRecord)) updatedRecord = { ...updatedRecord };
-							if (primaryKey && updatedRecord[primaryKey] !== id) updatedRecord[primaryKey] = id;
 						}
-						resolved = true;
-						const resolvedEntry: Entry = {
-							key: id,
-							version,
-							value: updatedRecord,
-							expiresAt: sourceContext.expiresAt,
-							metadataFlags: 0,
-							size: 0,
-							localTime: 0,
-							nodeId: 0,
-							residencyId: 0,
-						} as any;
-						// Give the plain object the RecordObject prototype so getExpiresAt/getUpdatedTime
-						// are available on the immediately-resolved entry. We mutate the prototype
-						// in-place rather than copying so that the commit callback (which adds
-						// createdAt/updatedAt to updatedRecord) is still reflected in the entry value.
-						if (updatedRecord && updatedRecord.constructor === Object) {
-							Object.setPrototypeOf(updatedRecord, primaryStore.encoder.structPrototype);
-							entryMap.set(updatedRecord, resolvedEntry);
-						}
-						resolve(resolvedEntry);
-					} catch (error) {
-						error.message += ` while resolving record ${id} for ${tableName}`;
-						if (
-							existingRecord &&
-							(((error.code === 'ECONNRESET' || error.code === 'ECONNREFUSED' || error.code === 'EAI_AGAIN') &&
-								!context?.mustRevalidate) ||
-								(context?.staleIfError &&
-									(error.statusCode === 500 ||
-										error.statusCode === 502 ||
-										error.statusCode === 503 ||
-										error.statusCode === 504)))
-						) {
-							// these are conditions under which we can use stale data after an error
-							resolve({
-								key: id,
-								version: existingVersion,
-								value: existingRecord,
-							} as any);
-							logger.trace?.(error.message, '(returned stale record)');
-						} else reject(error);
-						const resolveDuration = performance.now() - start;
-						recordAction(resolveDuration, 'cache-resolution', tableName, null, 'fail');
-						if (responseHeaders)
-							appendHeader(responseHeaders, 'Server-Timing', `cache-resolve;dur=${resolveDuration.toFixed(2)}`, true);
-						sourceContext.transaction.abort();
-						return;
+						if (typeof updatedRecord.toJSON === 'function') updatedRecord = updatedRecord.toJSON();
+						// updatedRecord may still be a frozen record (e.g. a reused existingRecord); copy-on-mutate
+						// before stamping the primary key and created/updated times below (records are immutable —
+						// 5.2 record caching relies on it — so we must not write through the frozen object).
+						if (isFrozenRecordObject(updatedRecord)) updatedRecord = { ...updatedRecord };
+						if (primaryKey && updatedRecord[primaryKey] !== id) updatedRecord[primaryKey] = id;
 					}
-					if (context?.noCacheStore || sourceContext.noCacheStore || droppingTable) {
-						// abort before we write any change. droppingTable is re-checked live (not just
-						// the noCacheStore snapshot taken at call start) because a call admitted before
-						// dropTable() began can still be sitting here after it started - the await above
-						// waited on the source, which may take arbitrarily long.
-						sourceContext.transaction.abort();
-						return;
-					}
-					const dbTxn = txnForContext(sourceContext);
-					const sourceWrite: any = {
+					resolved = true;
+					const resolvedEntry: Entry = {
 						key: id,
-						store: primaryStore,
-						entry: existingEntry,
-						nodeName: 'source',
-						commit: (txnTime, existingEntry, _retry, transaction: any) => {
-							sourceWrite.skipped = false; // reset on each retry; cleanup happens after commit if still true
-							if (existingEntry?.version !== existingVersion) {
-								// don't do anything if the version has changed
-								sourceWrite.skipped = true;
-								return;
+						version,
+						value: updatedRecord,
+						expiresAt: sourceContext.expiresAt,
+						metadataFlags: 0,
+						size: 0,
+						localTime: 0,
+						nodeId: 0,
+						residencyId: 0,
+					} as any;
+					// Give the plain object the RecordObject prototype so getExpiresAt/getUpdatedTime
+					// are available on the immediately-resolved entry. We mutate the prototype
+					// in-place rather than copying so that the commit callback (which adds
+					// createdAt/updatedAt to updatedRecord) is still reflected in the entry value.
+					if (updatedRecord && updatedRecord.constructor === Object) {
+						Object.setPrototypeOf(updatedRecord, primaryStore.encoder.structPrototype);
+						entryMap.set(updatedRecord, resolvedEntry);
+					}
+					resolve(resolvedEntry);
+				} catch (error) {
+					error.message += ` while resolving record ${id} for ${tableName}`;
+					if (
+						existingRecord &&
+						(((error.code === 'ECONNRESET' || error.code === 'ECONNREFUSED' || error.code === 'EAI_AGAIN') &&
+							!context?.mustRevalidate) ||
+							(context?.staleIfError &&
+								(error.statusCode === 500 ||
+									error.statusCode === 502 ||
+									error.statusCode === 503 ||
+									error.statusCode === 504)))
+					) {
+						// these are conditions under which we can use stale data after an error
+						resolve({
+							key: id,
+							version: existingVersion,
+							value: existingRecord,
+						} as any);
+						logger.trace?.(error.message, '(returned stale record)');
+					} else reject(error);
+					const resolveDuration = performance.now() - start;
+					recordAction(resolveDuration, 'cache-resolution', tableName, null, 'fail');
+					if (responseHeaders)
+						appendHeader(responseHeaders, 'Server-Timing', `cache-resolve;dur=${resolveDuration.toFixed(2)}`, true);
+					sourceContext.transaction.abort();
+					return;
+				}
+				if (context?.noCacheStore || sourceContext.noCacheStore || droppingTable) {
+					// abort before we write any change. droppingTable is re-checked live (not just
+					// the noCacheStore snapshot taken at call start) because a call admitted before
+					// dropTable() began can still be sitting here after it started - the await above
+					// waited on the source, which may take arbitrarily long.
+					sourceContext.transaction.abort();
+					return;
+				}
+				const dbTxn = txnForContext(sourceContext);
+				const sourceWrite: any = {
+					key: id,
+					store: primaryStore,
+					entry: existingEntry,
+					nodeName: 'source',
+					commit: (txnTime, existingEntry, _retry, transaction: any) => {
+						sourceWrite.skipped = false; // reset on each retry; cleanup happens after commit if still true
+						if (existingEntry?.version !== existingVersion) {
+							// don't do anything if the version has changed
+							sourceWrite.skipped = true;
+							return;
+						}
+						updateIndices(id, existingRecord, updatedRecord, transaction && { transaction });
+						if (updatedRecord) {
+							if (existingEntry) {
+								context.previousResidency = TableResource.getResidencyRecord(existingEntry.residencyId);
 							}
-							updateIndices(id, existingRecord, updatedRecord, transaction && { transaction });
-							if (updatedRecord) {
-								if (existingEntry) {
-									context.previousResidency = TableResource.getResidencyRecord(existingEntry.residencyId);
-								}
-								let auditRecord: any;
-								let omitLocalRecord = false;
-								let residencyId: number;
-								if (updatedTimeProperty) {
-									updatedRecord[updatedTimeProperty.name] =
-										updatedTimeProperty.type === 'Date'
+							let auditRecord: any;
+							let omitLocalRecord = false;
+							let residencyId: number;
+							if (updatedTimeProperty) {
+								updatedRecord[updatedTimeProperty.name] =
+									updatedTimeProperty.type === 'Date'
+										? new Date(txnTime)
+										: updatedTimeProperty.type === 'String'
+											? new Date(txnTime).toISOString()
+											: txnTime;
+							}
+							if (createdTimeProperty && updatedRecord[createdTimeProperty.name] == null) {
+								const existingCreatedTime = existingEntry?.value?.[createdTimeProperty.name];
+								if (existingCreatedTime != null) {
+									updatedRecord[createdTimeProperty.name] = existingCreatedTime;
+								} else {
+									updatedRecord[createdTimeProperty.name] =
+										createdTimeProperty.type === 'Date'
 											? new Date(txnTime)
-											: updatedTimeProperty.type === 'String'
+											: createdTimeProperty.type === 'String'
 												? new Date(txnTime).toISOString()
 												: txnTime;
 								}
-								if (createdTimeProperty && updatedRecord[createdTimeProperty.name] == null) {
-									const existingCreatedTime = existingEntry?.value?.[createdTimeProperty.name];
-									if (existingCreatedTime != null) {
-										updatedRecord[createdTimeProperty.name] = existingCreatedTime;
+							}
+							const residency = residencyFromFunction(TableResource.getResidency(updatedRecord, context));
+							if (residency) {
+								if (!residency.includes(server.hostname)) {
+									// if we aren't in the residency list, specify that our local record should be omitted or be partial
+									auditRecord = updatedRecord;
+									omitLocalRecord = true;
+									if (TableResource.getResidencyById) {
+										// complete omission of the record that doesn't belong here
+										updatedRecord = undefined;
 									} else {
-										updatedRecord[createdTimeProperty.name] =
-											createdTimeProperty.type === 'Date'
-												? new Date(txnTime)
-												: createdTimeProperty.type === 'String'
-													? new Date(txnTime).toISOString()
-													: txnTime;
-									}
-								}
-								const residency = residencyFromFunction(TableResource.getResidency(updatedRecord, context));
-								if (residency) {
-									if (!residency.includes(server.hostname)) {
-										// if we aren't in the residency list, specify that our local record should be omitted or be partial
-										auditRecord = updatedRecord;
-										omitLocalRecord = true;
-										if (TableResource.getResidencyById) {
-											// complete omission of the record that doesn't belong here
-											updatedRecord = undefined;
-										} else {
-											// store the partial record
-											updatedRecord = null;
-											for (const name in indices) {
-												if (!updatedRecord) {
-													updatedRecord = {};
-												}
-												// if there are any indices, we need to preserve a partial invalidated record to ensure we can still do searches
-												updatedRecord[name] = auditRecord[name];
+										// store the partial record
+										updatedRecord = null;
+										for (const name in indices) {
+											if (!updatedRecord) {
+												updatedRecord = {};
 											}
-											if (createdTimeProperty && auditRecord[createdTimeProperty.name] != null) {
-												// preserve the created timestamp in the partial record so it isn't lost when we don't have residency
-												if (!updatedRecord) updatedRecord = {};
-												updatedRecord[createdTimeProperty.name] = auditRecord[createdTimeProperty.name];
-											}
+											// if there are any indices, we need to preserve a partial invalidated record to ensure we can still do searches
+											updatedRecord[name] = auditRecord[name];
+										}
+										if (createdTimeProperty && auditRecord[createdTimeProperty.name] != null) {
+											// preserve the created timestamp in the partial record so it isn't lost when we don't have residency
+											if (!updatedRecord) updatedRecord = {};
+											updatedRecord[createdTimeProperty.name] = auditRecord[createdTimeProperty.name];
 										}
 									}
-									residencyId = getResidencyId(residency);
 								}
-								logger.trace?.(
-									`Writing resolved record from source with id: ${id}, timestamp: ${new Date(txnTime).toISOString()}`
-								);
-								// TODO: We are doing a double check for ifVersion that should probably be cleaned out
+								residencyId = getResidencyId(residency);
+							}
+							logger.trace?.(
+								`Writing resolved record from source with id: ${id}, timestamp: ${new Date(txnTime).toISOString()}`
+							);
+							// TODO: We are doing a double check for ifVersion that should probably be cleaned out
+							updateRecord(
+								id,
+								updatedRecord,
+								existingEntry,
+								txnTime,
+								omitLocalRecord ? INVALIDATED : 0,
+								(audit && (hasChanges || omitLocalRecord)) || null,
+								{
+									user: (sourceContext as any)?.user,
+									expiresAt: sourceContext.expiresAt,
+									residencyId,
+									transaction,
+									tableToTrack: tableName,
+								},
+								'put',
+								Boolean(invalidated),
+								auditRecord
+							);
+							// arm the eviction scanner, mirroring the .put() path
+							if (sourceContext.expiresAt) scheduleCleanup();
+						} else if (existingEntry) {
+							logger.trace?.(
+								`Deleting resolved record from source with id: ${id}, timestamp: ${new Date(txnTime).toISOString()}`
+							);
+							if (audit || trackDeletes) {
 								updateRecord(
 									id,
-									updatedRecord,
+									null,
 									existingEntry,
 									txnTime,
-									omitLocalRecord ? INVALIDATED : 0,
-									(audit && (hasChanges || omitLocalRecord)) || null,
-									{
-										user: (sourceContext as any)?.user,
-										expiresAt: sourceContext.expiresAt,
-										residencyId,
-										transaction,
-										tableToTrack: tableName,
-									},
-									'put',
-									Boolean(invalidated),
-									auditRecord
+									0,
+									(audit && hasChanges) || null,
+									{ user: (sourceContext as any)?.user, transaction, tableToTrack: tableName },
+									'delete',
+									Boolean(invalidated)
 								);
-								// arm the eviction scanner, mirroring the .put() path
-								if (sourceContext.expiresAt) scheduleCleanup();
-							} else if (existingEntry) {
-								logger.trace?.(
-									`Deleting resolved record from source with id: ${id}, timestamp: ${new Date(txnTime).toISOString()}`
-								);
-								if (audit || trackDeletes) {
-									updateRecord(
-										id,
-										null,
-										existingEntry,
-										txnTime,
-										0,
-										(audit && hasChanges) || null,
-										{ user: (sourceContext as any)?.user, transaction, tableToTrack: tableName },
-										'delete',
-										Boolean(invalidated)
-									);
-								} else {
-									removeEntry(primaryStore, existingEntry, existingVersion);
-								}
+							} else {
+								removeEntry(primaryStore, existingEntry, existingVersion);
 							}
-						},
-					};
-					// The cache-from-source write bypasses `_writeUpdate`, so wire the embed hook here
-					// too (always the originating node). It runs after the client GET has resolved with
-					// fresh source data, so it's a background commit: an embedder failure aborts the cache
-					// write via the outer error handler (row re-embeds next read) and never reaches the
-					// caller. Source-resolution errors are handled earlier, with the stale-data fallback.
-					const embedBefore = buildEmbedBefore(
-						updatedRecord,
-						sourceContext,
-						undefined,
-						TableResource.embedAttributes,
-						TableResource.userEmbedders
-					);
-					if (embedBefore) await embedBefore();
-					if (droppingTable) {
-						// Re-check right before staging the write: dropTable() may have started
-						// while we were awaiting the embed step above (harper#1381).
-						sourceContext.transaction.abort();
-						return;
-					}
-					sourceWrite.before = preCommitBlobsForRecordBefore(sourceWrite, updatedRecord);
-					dbTxn.addWrite(sourceWrite);
-				});
+						}
+					},
+				};
+				// The cache-from-source write bypasses `_writeUpdate`, so wire the embed hook here
+				// too (always the originating node). It runs after the client GET has resolved with
+				// fresh source data, so it's a background commit: an embedder failure aborts the cache
+				// write via the outer error handler (row re-embeds next read) and never reaches the
+				// caller. Source-resolution errors are handled earlier, with the stale-data fallback.
+				const embedBefore = buildEmbedBefore(
+					updatedRecord,
+					sourceContext,
+					undefined,
+					TableResource.embedAttributes,
+					TableResource.userEmbedders
+				);
+				if (embedBefore) await embedBefore();
+				if (droppingTable) {
+					// Re-check right before staging the write: dropTable() may have started
+					// while we were awaiting the embed step above (harper#1381).
+					sourceContext.transaction.abort();
+					return;
+				}
+				sourceWrite.before = preCommitBlobsForRecordBefore(sourceWrite, updatedRecord);
+				dbTxn.addWrite(sourceWrite);
+			});
 			pendingSourceCommits.add(commitPromise);
 			when(
 				commitPromise,

--- a/unitTests/resources/Resource-get-context.test.js
+++ b/unitTests/resources/Resource-get-context.test.js
@@ -205,21 +205,24 @@ describe('dropTable waits for in-flight source-populated cache writes (harper#13
 		const sourceGate = new Promise((resolve) => {
 			releaseSource = resolve;
 		});
+		let sourceEntered;
+		const sourceEnteredPromise = new Promise((resolve) => {
+			sourceEntered = resolve;
+		});
 		TestTable.sourcedFrom({
 			get: async (id) => {
+				sourceEntered();
 				await sourceGate;
 				return { id, name: 'gated' };
 			},
 			available: () => true,
 		});
 
-		// Kick off a get() that will hang inside the source until we release it below. Its
-		// cache-write commit is registered as pending the moment this call starts.
+		// Kick off a get() that will hang inside the source until we release it below. Wait on
+		// an explicit signal (not a guessed number of ticks) that the source was actually
+		// entered, so this doesn't depend on scheduler timing under a loaded test runner.
 		const getPromise = TestTable.get('gated-1', {});
-
-		// Let the get() call reach the gated source and register its pending commit.
-		await new Promise((resolve) => setImmediate(resolve));
-		await new Promise((resolve) => setImmediate(resolve));
+		await sourceEnteredPromise;
 
 		let dropResolved = false;
 		const dropPromise = TestTable.dropTable().then(() => {
@@ -255,21 +258,27 @@ describe('dropTable waits for in-flight source-populated cache writes (harper#13
 		const firstGate = new Promise((resolve) => {
 			releaseFirst = resolve;
 		});
+		let firstEntered;
+		const firstEnteredPromise = new Promise((resolve) => {
+			firstEntered = resolve;
+		});
 		let lateSourceCalled = false;
 		TestTable.sourcedFrom({
 			get: async (id) => {
-				if (id === 'first') await firstGate;
-				else lateSourceCalled = true;
+				if (id === 'first') {
+					firstEntered();
+					await firstGate;
+				} else lateSourceCalled = true;
 				return { id, name: 'value' };
 			},
 			available: () => true,
 		});
 
 		// Start a write that keeps dropTable() draining, so there is a window in which the
-		// table is already marked dropping but the drop itself hasn't touched storage yet.
+		// table is already marked dropping but the drop itself hasn't touched storage yet. Wait
+		// on an explicit "entered the source" signal rather than a guessed number of ticks.
 		const firstGetPromise = TestTable.get('first', {});
-		await new Promise((resolve) => setImmediate(resolve));
-		await new Promise((resolve) => setImmediate(resolve));
+		await firstEnteredPromise;
 
 		const dropPromise = TestTable.dropTable();
 

--- a/unitTests/resources/Resource-get-context.test.js
+++ b/unitTests/resources/Resource-get-context.test.js
@@ -304,4 +304,14 @@ describe('dropTable waits for in-flight source-populated cache writes (harper#13
 		await firstGetPromise;
 		await dropPromise;
 	});
+
+	// Not covered by an automated test here: dropTable()'s drain is bounded by LOCK_TIMEOUT
+	// (10s) and FAILS the drop (throws, leaving the durable tombstone for completeInterruptedDrop
+	// to retry) rather than proceeding to drop column families out from under a write that may
+	// still be staged - see the comment above the drain in dropTable(). Exercising the real
+	// 10-second timeout here would make this suite slow, and sinon fake timers over the
+	// transaction/commit machinery this exercises reliably hung the test run rather than
+	// advancing it. Verified manually with a standalone script instead (a source that never
+	// resolves; dropTable() rejects with a "timed out" error after ~10s and no column family is
+	// touched).
 });

--- a/unitTests/resources/Resource-get-context.test.js
+++ b/unitTests/resources/Resource-get-context.test.js
@@ -176,3 +176,68 @@ describe('Resource.get context passing', function () {
 		assert(!result || result === null);
 	});
 });
+
+describe('dropTable waits for in-flight source-populated cache writes (harper#1381)', function () {
+	// Resource.get() resolves to its caller as soon as the source responds - the resulting
+	// cache write to the primary store commits "in the background" afterward (see
+	// getFromSource in Table.ts). If dropTable() drops the table's column families while one
+	// of those writes is still landing, RocksDB rejects the write with "Invalid column family
+	// specified in write batch" (or "Could not access column family N"), which can also abort
+	// the drop itself before it removes the tombstoned catalog rows - leaving the table stuck
+	// "dropping" for completeInterruptedDrop to retry (and fail identically) on every
+	// subsequent load. That is the failure this test reproduces deterministically: rather than
+	// racing real timing (which only sometimes loses), the source's resolution is gated behind
+	// a promise the test controls, so the in-flight write is provably still pending when
+	// dropTable() is called.
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return; // this table drop path is RocksDB-only
+
+	it('does not resolve dropTable() until a gated cache-from-source write has landed', async function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		const TestTable = table({
+			table: 'DropRaceTable',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+		});
+
+		let releaseSource;
+		const sourceGate = new Promise((resolve) => {
+			releaseSource = resolve;
+		});
+		TestTable.sourcedFrom({
+			get: async (id) => {
+				await sourceGate;
+				return { id, name: 'gated' };
+			},
+			available: () => true,
+		});
+
+		// Kick off a get() that will hang inside the source until we release it below. Its
+		// cache-write commit is registered as pending the moment this call starts.
+		const getPromise = TestTable.get('gated-1', {});
+
+		// Let the get() call reach the gated source and register its pending commit.
+		await new Promise((resolve) => setImmediate(resolve));
+		await new Promise((resolve) => setImmediate(resolve));
+
+		let dropResolved = false;
+		const dropPromise = TestTable.dropTable().then(() => {
+			dropResolved = true;
+		});
+
+		// The source hasn't been released yet, so the cache write can't have landed - dropTable()
+		// must still be waiting on it, not racing ahead to drop the column families.
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		assert.strictEqual(
+			dropResolved,
+			false,
+			'dropTable() must not drop the column families while a source-populated cache write is still in flight'
+		);
+
+		releaseSource();
+		await getPromise;
+		await dropPromise;
+		assert.strictEqual(dropResolved, true, 'dropTable() should resolve once the pending write has landed');
+	});
+});

--- a/unitTests/resources/Resource-get-context.test.js
+++ b/unitTests/resources/Resource-get-context.test.js
@@ -186,8 +186,9 @@ describe('dropTable waits for in-flight source-populated cache writes (harper#13
 	// the drop itself before it removes the tombstoned catalog rows - leaving the table stuck
 	// "dropping" for completeInterruptedDrop to retry (and fail identically) on every
 	// subsequent load. That is the failure this test reproduces deterministically: rather than
-	// racing real timing (which only sometimes loses), the source's resolution is gated behind
-	// a promise the test controls, so the in-flight write is provably still pending when
+	// racing real timing (which only sometimes loses), an async step in the write's own
+	// path (the @embed pre-commit hook) is gated behind a promise the test controls, so the
+	// GET has already resolved to its caller - and the write is provably still pending - when
 	// dropTable() is called.
 	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return; // this table drop path is RocksDB-only
 
@@ -198,47 +199,60 @@ describe('dropTable waits for in-flight source-populated cache writes (harper#13
 		const TestTable = table({
 			table: 'DropRaceTable',
 			database: 'test',
-			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'name' },
+				// A get() resolves to its caller as soon as the source responds; the resulting
+				// cache write only actually stages afterward, past an async embed-hook step (see
+				// getFromSource - the embed step runs after the caller's promise has resolved).
+				// Gating the embed hook (rather than source.get() itself) pins down that exact
+				// post-resolution, pre-staging window instead of merely proving dropTable() waits
+				// on an outstanding source fetch (which it deliberately no longer does - a call
+				// still waiting on the source isn't tracked as a pending commit).
+				{ name: 'vector', type: 'Array', embed: { source: 'name', model: 'unused' } },
+			],
 		});
 
-		let releaseSource;
-		const sourceGate = new Promise((resolve) => {
-			releaseSource = resolve;
+		let releaseEmbed;
+		const embedGate = new Promise((resolve) => {
+			releaseEmbed = resolve;
 		});
-		let sourceEntered;
-		const sourceEnteredPromise = new Promise((resolve) => {
-			sourceEntered = resolve;
+		let embedEntered;
+		const embedEnteredPromise = new Promise((resolve) => {
+			embedEntered = resolve;
+		});
+		TestTable.setEmbedAttribute('vector', async () => {
+			embedEntered();
+			await embedGate;
+			return [1, 2, 3];
 		});
 		TestTable.sourcedFrom({
-			get: async (id) => {
-				sourceEntered();
-				await sourceGate;
-				return { id, name: 'gated' };
-			},
+			get: async (id) => ({ id, name: 'gated' }),
 			available: () => true,
 		});
 
-		// Kick off a get() that will hang inside the source until we release it below. Wait on
-		// an explicit signal (not a guessed number of ticks) that the source was actually
-		// entered, so this doesn't depend on scheduler timing under a loaded test runner.
+		// The GET resolves as soon as source.get() does; only the embed hook (and the write it
+		// gates) is held back, so the caller already has its data while the write is still
+		// pending. Wait on an explicit signal that the embedder was entered - not a guessed
+		// number of ticks - so this doesn't depend on scheduler timing under a loaded test runner.
 		const getPromise = TestTable.get('gated-1', {});
-		await sourceEnteredPromise;
+		await embedEnteredPromise;
 
 		let dropResolved = false;
 		const dropPromise = TestTable.dropTable().then(() => {
 			dropResolved = true;
 		});
 
-		// The source hasn't been released yet, so the cache write can't have landed - dropTable()
+		// The embed hook hasn't been released yet, so the cache write can't have staged - dropTable()
 		// must still be waiting on it, not racing ahead to drop the column families.
 		await new Promise((resolve) => setTimeout(resolve, 100));
 		assert.strictEqual(
 			dropResolved,
 			false,
-			'dropTable() must not drop the column families while a source-populated cache write is still in flight'
+			'dropTable() must not drop the column families while a source-populated cache write is still pending'
 		);
 
-		releaseSource();
+		releaseEmbed();
 		await getPromise;
 		await dropPromise;
 		assert.strictEqual(dropResolved, true, 'dropTable() should resolve once the pending write has landed');

--- a/unitTests/resources/Resource-get-context.test.js
+++ b/unitTests/resources/Resource-get-context.test.js
@@ -240,4 +240,59 @@ describe('dropTable waits for in-flight source-populated cache writes (harper#13
 		await dropPromise;
 		assert.strictEqual(dropResolved, true, 'dropTable() should resolve once the pending write has landed');
 	});
+
+	it('does not start a new cache write once dropTable() has begun (late admission during the drain)', async function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+
+		const TestTable = table({
+			table: 'DropRaceLateAdmission',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+		});
+
+		let releaseFirst;
+		const firstGate = new Promise((resolve) => {
+			releaseFirst = resolve;
+		});
+		let lateSourceCalled = false;
+		TestTable.sourcedFrom({
+			get: async (id) => {
+				if (id === 'first') await firstGate;
+				else lateSourceCalled = true;
+				return { id, name: 'value' };
+			},
+			available: () => true,
+		});
+
+		// Start a write that keeps dropTable() draining, so there is a window in which the
+		// table is already marked dropping but the drop itself hasn't touched storage yet.
+		const firstGetPromise = TestTable.get('first', {});
+		await new Promise((resolve) => setImmediate(resolve));
+		await new Promise((resolve) => setImmediate(resolve));
+
+		const dropPromise = TestTable.dropTable();
+
+		// A get() admitted while the drop is draining must still return fresh source data...
+		const lateResult = await TestTable.get('late', {});
+		assert.ok(lateSourceCalled, 'the source should still be consulted for a late-admitted read');
+		assert.strictEqual(lateResult.name, 'value');
+		// ...but must not have started a new cache write into a table that's being dropped. The
+		// get() call itself resolves before its own cache write would land (that's the whole
+		// bug this file covers), so a correctly-blocked write and one that merely hasn't landed
+		// YET look identical immediately after the await above. Give a generous, bounded window
+		// for an (incorrectly) unblocked local write to land - the drop itself is still parked on
+		// the gated first write, so this checks storage well before any column family is
+		// touched, not a race against the drop.
+		await new Promise((resolve) => setTimeout(resolve, 200));
+		assert.strictEqual(
+			TestTable.primaryStore.getSync('late'),
+			undefined,
+			'a get() admitted after dropTable() started must not cache its result'
+		);
+
+		releaseFirst();
+		await firstGetPromise;
+		await dropPromise;
+	});
 });

--- a/unitTests/resources/Resource-get-context.test.js
+++ b/unitTests/resources/Resource-get-context.test.js
@@ -207,8 +207,7 @@ describe('dropTable waits for in-flight source-populated cache writes (harper#13
 				// getFromSource - the embed step runs after the caller's promise has resolved).
 				// Gating the embed hook (rather than source.get() itself) pins down that exact
 				// post-resolution, pre-staging window instead of merely proving dropTable() waits
-				// on an outstanding source fetch (which it deliberately no longer does - a call
-				// still waiting on the source isn't tracked as a pending commit).
+				// on the source round trip.
 				{ name: 'vector', type: 'Array', embed: { source: 'name', model: 'unused' } },
 			],
 		});


### PR DESCRIPTION
Human-Review-Need: 4 @ bf7428329d8f
## What / why

Root-causes and fixes the `Error: Put failed: Invalid argument: Invalid column family specified in write batch` flake reddening `Unit Test` on `main` (observed concentrated in `unitTests/resources/vectorIndexFormat.test.js`, e.g. run 30452497108 on commit 74224938f).

**Root cause.** `Resource.get()` against a `sourcedFrom` table resolves to its caller as soon as the source responds — the resulting cache write to the table's primary store commits **in the background** afterward (a deliberate latency optimization in `getFromSource()`, documented in the existing code: *"we don't want to wait for the transaction... let the transaction commit in the background"*). `Table.dropTable()` had no awareness of this: it would drop the table's RocksDB column families while one of these background writes was still landing. RocksDB rejects the still-open write batch with exactly this error, which can also abort `dropTable()` itself **before** it removes the tombstoned catalog rows — leaving the table stuck `dropping` for `completeInterruptedDrop` (in `resources/databases.ts`) to retry, and fail identically, on every subsequent `resetDatabases()` call for the rest of the process's life. That perpetual retry-and-fail cycle is what corrupts the shared internal catalog store, which is why an *unrelated* later table's write (the `attributesDbi.put(NEXT_TABLE_ID, ...)` inside `vectorIndexFormat.test.js`) ends up failing with the same error.

**Same defect as #1381, trigger identified.** #1381 diagnosed the *retry* symptom (`completeInterruptedDrop` failing on `removeSync`) but not *why* the drop was interrupted in the first place. I traced it to a concrete, reproducible trigger: `unitTests/resources/Resource-get-context.test.js`'s `after()` hook calls `dropTable()` immediately after its `it()` blocks' `sourcedFrom` `get()` calls — racing `dropTable()` against those calls' still-in-flight background cache writes. Confirmed directly in the CI log for the dispatched run: that file's `"after all" hook` fails, immediately followed by four `Error committing cache update` / `Could not access column family N` lines (one per earlier `it()` block's background write resuming after the column families were already gone), immediately followed by `Completing interrupted drop of table data.TestTableForContext` — the exact chain from trigger to #1381's retry loop to this dispatch's `vectorIndexFormat.test.js` symptom.

I also instrumented the real commit path locally and captured the race directly (not just inferred it): a `dropTable-start` timestamp landing *before* a preceding `get()` call's `commit-success` timestamp, in the unmodified test suite, on Node 26.

## The fix (`resources/Table.ts`)

- `dropTable()` now sets a per-table `droppingTable` flag **before** removing the table from the schema, and drains a `pendingSourceCommits` set of every `getFromSource()` transaction promise before touching a single column family (moved ahead of the existing blob-cleanup sweep too, so a drain-caught write's blobs aren't orphaned).
- `getFromSource()` treats `droppingTable` as `noCacheStore`, both at admission and **re-checked live** right before staging the write (after the async embed-hook step) — a call admitted before the drop started, or one still inside its own async prep, still returns fresh data but never starts/stages a write into a table that's going away.
- The drain is bounded by the existing `LOCK_TIMEOUT` (10s) and **fails closed**: if it times out, `dropTable()` throws rather than proceeding to drop anyway (which would silently reopen the exact race, just less often). The drop's tombstone is already durable at that point, so `completeInterruptedDrop` retries the whole drop on the next load — the same fail-and-retry shape the codebase already uses for a genuine drop failure.

## Test (`unitTests/resources/Resource-get-context.test.js`)

Two new deterministic regression tests (no timing-based "loop until it flakes" logic):
1. Gates the table's `@embed` pre-commit hook (via `setEmbedAttribute`) behind a promise the test controls. This hook runs *after* the GET has already resolved to its caller, so it pins down the exact post-resolution/pre-staging window the bug lives in. Fails before the fix, passes after.
2. Proves a `get()` admitted *while* `dropTable()` is draining still returns fresh source data but never caches it (closes the admission gap independently).

The drain's fail-closed timeout path is verified manually (a source that never resolves; `dropTable()` rejects with a "timed out" message at ~10s, no column family touched) rather than by an automated test — `sinon` fake timers over this code path reliably hung the test runner instead of advancing it, and exercising the real 10s wait would slow the suite. Noted in the test file.

## Known limitation — not fixed here, needs a separate task

The independent cross-model review (Codex, twice; Grok, once — see "Review" in the dispatch record) consistently flagged that `pendingSourceCommits`/`droppingTable` are **local to one `makeTable()` closure**, i.e. per-worker. In a multi-worker deployment, worker B can have a cache write staged while the main/ops thread runs `drop_table`, sees *its own* empty local set, and drops the column families anyway — B's write then resumes against the dropped handle and reproduces the original failure. A related, narrower gap: if the drain's timeout fires (a write staged and stalled past 10s), the durable tombstone is left in place, and an immediate same-name recreate could trigger `completeInterruptedDrop` to drop the column family while that stalled write is still trying to land.

Both are real and worth fixing, but they require actual cross-worker coordination (a broadcast prepare-drop/drain/ack protocol, and threading that state into `completeInterruptedDrop`/`table()`'s create path too) — a distinctly larger, separate architectural task, not a safe thing to bolt on under review pressure in this PR. This PR closes the single-process race that is what's actually failing in CI (mocha runs these tests in one process); I've filed the multi-worker gap as a Finding for follow-up.

Refs #1381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
