### PR TITLE
test: deflake audit log subscription-event assertion (split from #1999)

### DIFF
--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -49,10 +49,13 @@ describe('Audit log', () => {
 		// can therefore collapse to as few as 2 delivered events no matter how long we later
 		// poll for them — waiting for the notify drain to catch up after EACH write (rather than
 		// after the whole burst) is what actually makes delivery deterministic.
+		// >= rather than === in the condition: an overshoot (however it arose) should fall through
+		// to the assertions below with a clear message, not hang the waiter into its timeout.
 		async function waitForEventCount(count) {
-			for (let i = 0; i < 50 && events.length < count; i++) {
-				await delay(10);
-			}
+			await waitFor(() => events.length >= count, {
+				timeout: 5000,
+				message: `expected at least ${count} subscription events`,
+			});
 		}
 		await AuditedTable.put(1, { name: 'one' });
 		await waitForEventCount(1);

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -43,22 +43,34 @@ describe('Audit log', () => {
 	});
 	it('check log after writes and prune', async () => {
 		events = [];
+		// transactionBroadcast.ts coalesces 'committed' bursts landing in the same turn into a
+		// single notify pass, and the subscribe() listener (Table.ts) only delivers the LATEST
+		// value per id from that pass (by design, not a bug). Four same-turn writes to two ids
+		// can therefore collapse to as few as 2 delivered events no matter how long we later
+		// poll for them — waiting for the notify drain to catch up after EACH write (rather than
+		// after the whole burst) is what actually makes delivery deterministic.
+		async function waitForEventCount(count) {
+			for (let i = 0; i < 50 && events.length < count; i++) {
+				await delay(10);
+			}
+		}
 		await AuditedTable.put(1, { name: 'one' });
+		await waitForEventCount(1);
 		await AuditedTable.put(2, { name: 'two' });
+		await waitForEventCount(2);
 		await AuditedTable.put(2, { name: 'two-changed' });
+		await waitForEventCount(3);
 		await AuditedTable.delete(1);
+		await waitForEventCount(4);
 		assert.equal(AuditedTable.primaryStore.getEntry(1).value, null); // verify that there is a delete entry
 		let results = [];
 		for await (let entry of AuditedTable.getHistory()) {
 			results.push(entry);
 		}
 		assert.equal(results.length, 4);
-		// Subscription events are delivered off the commit path; nothing orders them against this
-		// assertion, so wait for them rather than sleeping a fixed 20ms and hoping.
-		await waitFor(() => events.length > 2, {
-			timeout: 5000,
-			message: 'Should have at least a couple of update events',
-		});
+		// The per-write waitForEventCount calls above already drained delivery after each write, so
+		// the full count is deterministic here — assert the tight bound rather than "a couple".
+		assert(events.length >= 4, 'Should have one live-subscription event per write');
 		if (AuditedTable.auditStore.reusableIterable) return; // rocksdb doesn't have any audit log cleanup from JS
 		setAuditRetention(0.001, 1);
 		// scheduleAuditCleanup() resolves once the pass serving the call has committed its deletions.


### PR DESCRIPTION
## Summary

Split out of #1999 per review feedback there — this test-only change is unrelated to the TLS fix and was one of the commits conflicting on the `v5.1` patch cherry-pick, so it shouldn't gate a customer patch.

`transactionBroadcast.ts` coalesces `committed` bursts landing in the same turn into a single notify pass, and the `subscribe()` listener delivers only the latest value per id from that pass (by design). Four same-turn writes to two ids can therefore collapse to as few as 2 delivered events no matter how long the test polls afterwards. The fix waits for the notify drain after each write instead of after the whole burst, which makes delivery deterministic and lets the assertion tighten from "at least a couple" (`> 2`) to the true bound (`>= 4`, one live-subscription event per write).

Rebased onto current `main`, which had independently gained a partial deflake (a `waitFor(> 2)` block); the per-write waits supersede it, so that block is replaced by the tight assertion. Main's cleanup-pass improvements in the same test are untouched.

## Testing

`unitTests/resources/auditLog.test.js`: 3/3 consecutive runs green (22 passing each, ~800 ms). A reviewer on #1999 also ran the original version of this change 3× with 51–69 ms completion against the 500 ms-per-write budget.

Refs #1999.

*Generated by Claude (Opus 5) for dispatch task fix-harper-1999.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)