### PR TITLE
fix(tls): keep rebuilding the SNI selector when a pass produces only a default context (empty per-hostname map)

### DIFF
--- a/security/keys.ts
+++ b/security/keys.ts
@@ -1162,45 +1162,53 @@ export function createTLSSelector(type, mtlsOptions?, liveReload = true): any {
 							logger.error?.('Error applying TLS for', cert.name, error);
 						}
 					}
-					if (liveReload && secureContexts.size === 0 && !defaultContextSetThisPass) {
-						// The not-loaded-yet guard above only covers the table object being absent, not the
-						// table being present but every row failing to apply (e.g. a private key not yet
-						// available on this thread, caught above per-cert). Resolving here would still write
-						// an empty `certificates:` list — the exact customer-visible symptom this PR exists to
-						// fix. Retry on the same debounce instead of publishing that state; a rebuild trigger
-						// (cert-table change or private-key reload, both already wired to scheduleRebuild) is
-						// almost certainly still coming on a normal boot, and this just avoids a window where
-						// we'd otherwise publish empty in the meantime.
-						//
-						// `!defaultContextSetThisPass` because an empty hostname map is not the same as "no TLS
-						// available": a cert whose hostnames resolve to [] (no usable SANs and no CN) builds no
-						// per-hostname entry but still sets a serviceable default context — that listener must
-						// resolve and serve via the default rather than retry forever for hostname entries that
-						// can't exist. It must be the per-pass flag, not the persistent `defaultContext` (see its
-						// declaration note): keying off the closure variable would disarm this retry for every
-						// pass after the first success, reopening the publish-empty window on live rebuilds.
+					if (liveReload && secureContexts.size === 0) {
+						// An empty per-hostname `secureContexts` map is not a valid steady state for a
+						// live-reloading SNI listener, so re-check on the debounce instead of resolving it as
+						// final. Two ways to land here:
+						//   1. Table object present but no row applied yet (e.g. a private key not yet available
+						//      on this thread, caught per-cert above) — the boot-order case this retry was
+						//      originally written for.
+						//   2. Only a default-eligible cert with no per-hostname entry applied — a record whose
+						//      stored `hostnames` is `[]`, or a cert with no SANs and no CN — while the real
+						//      per-domain certs have not landed on this thread yet. Those can arrive via a
+						//      bulk/initial-sync path that never fires this selector's hdb_certificate
+						//      subscription (the same event bypass #1999 documented for table swaps), so nothing
+						//      else re-triggers a rebuild. The raw-socket MQTT `securePort` listener then
+						//      publishes an empty `certificates:` list to its UDS metadata once at boot and keeps
+						//      it until restart, and a fronting proxy that routes by that list (Symphony on 8883)
+						//      serves the node certificate for every custom-domain SNI — the customer-visible bug.
 						//
 						// Gated on liveReload: transient, single-use selectors (getReplicationCert) legitimately
-						// resolve empty — e.g. the bootstrap check `if (!(await getReplicationCert())) { create
-						// one }` in generateCertAuthority's caller depends on an empty resolution meaning "no
-						// cert yet," and must not hang waiting for a cert that this exact call is about to create.
-						//
-						// Latched like the system-db wait above: this retries indefinitely on the debounce, and
-						// an unlatched warn would emit ~57k lines/day from a listener stuck this way.
+						// resolve empty — the bootstrap check `if (!(await getReplicationCert()))` depends on an
+						// empty resolution meaning "no cert yet" and must not hang. Latched like the system-db
+						// wait above (an unlatched warn would emit tens of thousands of lines/day when stuck).
 						if (server && !server.tlsSelectorWarnedZeroCerts) {
 							server.tlsSelectorWarnedZeroCerts = true;
 							logger.warn?.(
-								`TLS selector for the '${type}' listener resolved zero certificates; retrying every ${TLS_REBUILD_DEBOUNCE_MS}ms`
+								`TLS selector for the '${type}' listener resolved an empty per-hostname certificate map; retrying every ${TLS_REBUILD_DEBOUNCE_MS}ms`
 							);
 						}
 						scheduleRebuild();
-						return;
+						// No default context produced either → stay pending exactly as before: nothing to serve,
+						// and resolving would let Bun's listener path start plaintext (see the system-db guard
+						// above). If a default WAS produced this pass, fall through to resolve + publish so the
+						// listener serves via that default immediately, while the scheduleRebuild above stays
+						// armed to pick up the per-domain certs and rewrite the exported metadata once they load.
+						// This is the deliberate change from the original "default set ⇒ resolve and stop":
+						// serving a default is fine for a direct TLS client, but an SNI-routing proxy needs the
+						// per-hostname list, so an empty map must keep re-checking even when a default exists.
+						// Keyed off the per-pass `defaultContextSetThisPass`, never the persistent
+						// `defaultContext` (which survives passes and would wrongly report "have one" here).
+						if (!defaultContextSetThisPass) return;
 					}
-					// A successful pass ends any warn latches so a later recurrence logs again.
-					if (server) {
-						server.tlsSelectorWaitedForSystemDb = false;
-						server.tlsSelectorWarnedZeroCerts = false;
-					}
+					// Reaching here means the table was loaded (we passed the not-loaded guard), so clear that
+					// wait latch regardless of cert population, so a later system-db outage logs again.
+					if (server) server.tlsSelectorWaitedForSystemDb = false;
+					// The zero-cert latch clears only on a populated pass: the empty-map-with-default
+					// fall-through above also reaches here and must not clear it (that would re-warn on every
+					// debounced re-check while the per-domain certs are still loading).
+					if (server && secureContexts.size > 0) server.tlsSelectorWarnedZeroCerts = false;
 					// The listener's cipher string (and its @SECLEVEL, which governs client-cert chain
 					// verification) is fixed at server creation and cannot be swapped by rebuilding SNI
 					// contexts. If a rebuild finds the effective value has changed (e.g. a certificate

--- a/unitTests/security/keys.test.js
+++ b/unitTests/security/keys.test.js
@@ -672,6 +672,59 @@ describe('Test keys module', () => {
 				await databases.system.hdb_certificate.delete(triggerCertName).catch(() => {});
 			}
 		});
+
+		it('keeps rebuilding until the per-hostname certs load; recovery is driven by the retry, not the subscription', async function () {
+			// Regression for the port-8883 Symphony bug (follow-up to #1999). A raw-socket TLS listener
+			// (MQTT `securePort`) whose pass produces only a default-eligible cert with no per-hostname
+			// entry — a record with `hostnames: []`, or one whose real per-domain certs have not synced to
+			// this thread yet — used to resolve and STOP (`!defaultContextSetThisPass` disarmed the retry),
+			// so the exported UDS `certificates:` list stayed empty until restart even after the per-domain
+			// certs loaded via a bulk/sync path that never fires the selector's subscription. It must keep
+			// rebuilding until the per-hostname map populates, while still resolving `.ready` (serve via the
+			// default meanwhile — no plaintext hang).
+			this.timeout(6000);
+			searchStub.restore(); // replace the describe's empty stub with a default-only, hostname-less row
+			const defaultOnlyCert = {
+				name: 'default-only-no-hostnames-' + Date.now(),
+				certificate: test_cert,
+				private_key_name: actual_cert.private_key_name,
+				uses: [],
+				is_authority: false,
+				is_self_signed: true,
+				hostnames: [], // sets a default context (quality > 0) but contributes no per-hostname SNI entry
+			};
+			searchStub = sandbox.stub(databases.system.hdb_certificate, 'search').returns([defaultOnlyCert]);
+
+			const pseudoServer = { secureContexts: null, secureContextsListeners: [] };
+			const selector = keys.createTLSSelector('mqtt', undefined, true);
+			const readyPromise = selector.initialize(pseudoServer);
+
+			let settled = false;
+			readyPromise.then(
+				() => (settled = true),
+				() => (settled = true)
+			);
+
+			// A default was produced, so `.ready` resolves and the listener serves via it (must not hang),
+			// but the per-hostname map is empty and the retry path must have latched its warn.
+			await waitFor(() => settled, { timeout: 2000, message: '.ready must resolve via the default context' });
+			assert.strictEqual(pseudoServer.secureContexts.size, 0, 'a hostname-less default builds no per-hostname entry');
+			assert.ok(pseudoServer.defaultContext, 'the default context must be set so the listener can serve');
+			assert.strictEqual(
+				pseudoServer.tlsSelectorWarnedZeroCerts,
+				true,
+				'an empty per-hostname map must take the retry path even when a default context was produced'
+			);
+
+			// The real per-domain certs (loaded in this suite's before()) become visible. Recovery must come
+			// from the scheduled rebuild — restoring the stub fires no cert-table event — which is exactly what
+			// the pre-fix "default set => resolve and stop" path failed to schedule.
+			searchStub.restore();
+			await waitFor(() => pseudoServer.secureContexts.size > 0, {
+				timeout: 4000,
+				message: 'the selector never republished the per-domain certs after they became visible',
+			});
+		});
 	});
 
 	describe('createTLSSelector when the hdb_certificate table object is swapped out', () => {


### PR DESCRIPTION
## Summary

Follow-up to #1999 / #2005. On an affected production cluster, port 8883 (MQTT-over-TLS, terminated by the Symphony proxy) still serves the node certificate for custom-domain SNIs on `harper-pro` 5.1.25 (which contains #1999). Verified live, read-only:

- every worker's `sockets/<n>-8883.yaml` is 42 bytes (empty `certificates:`) while the `<n>-9926` mirror is the full ~82 KB;
- on the wire, an MQTT-TLS handshake for a custom-domain SNI on 8883 returns the node cert; the same SNI on 443 returns the correct leaf;
- none of #1999's new breadcrumbs (`resolved zero certificates`, `waiting for system.hdb_certificate`) ever fired (checked `hdb.log` and `docker logs`).

## The gap #1999 left

#1999 fixed the *not-loaded* and *table-swap* cases, but not a pass that ends with a **default context set but an empty per-hostname `secureContexts` map**. The guard `secureContexts.size === 0 && !defaultContextSetThisPass` treats "a default was set" as success and resolves-and-stops, so on the boot pass that produced the empty map, no retry was armed.

## What this changes (`security/keys.ts`, `createTLSSelector`)

Re-check on the debounce whenever the per-hostname map is empty, regardless of whether a default was produced:
- no default → stay pending as before (nothing to serve; resolving would let Bun's path start plaintext);
- default set → resolve `.ready` (serve via the default, no hang) but keep the scheduled rebuild armed so a later pass republishes the per-hostname list.

Warn-latch resets are split so the empty-map-with-default fall-through doesn't re-warn on each re-check.

## ⚠️ Open question — read before relying on this (from @kriszyp's live investigation)

Live CDP inspection of a running node shows the **in-memory 8883 selector maps ARE populated** (all custom domains, write-listener registered), while the on-disk yaml is still the 42-byte boot artifact — and calling `writeUdsMetadata` against the live map produces a correct yaml. So a rebuild *did* run and populate the map after the empty publish, yet the listener fan-out that should have rewritten the yaml didn't take effect. **There may be a second defect between map-population and republish that this PR does not address** — this PR arms and relies on that same fan-out.

Discriminating test before treating this as the fix: on a plain-5.1.25 node, one benign `hdb_certificate` write, then check the `sockets/<n>-8883.yaml` mtime + content:
- heals to the full list → the fan-out works, boot ordering was the whole story, this PR closes the window;
- stays 42 bytes → a second defect between rebuild and republish that this PR does not touch — find it before shipping.

A lead worth checking there: in the raw-socket path (`threads/threadServer.js onSocket`) the write-listener is `push`ed onto `secureContextsListeners` **after** `SNICallback.initialize(...)`, so the first populating pass's fan-out can fire against a listener set that doesn't yet include `writeMetadata`.

## Notes

- Root cause is inferred from live evidence + code; not debugger-traced by me.
- #2003 is orthogonal (shifts cert *quality*, not `secureContexts` membership).
- Interim unblock in flight: host-manager #170 (source the list from a populated sibling socket).
- `unitTests/security/keys.test.js` 55/55 locally; the new test fails without the fix (verified by reverting). Full suites via CI.

*Generated by Claude (Opus 4.8), investigation + fix driven with Devin.*
