### PR TITLE
fix(http): WebSocket upgrades were silently dropped on the per-worker UDS mirror listeners

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -440,3 +440,26 @@ Three consequences worth knowing before touching packaging:
 - The Dockerfile installs the local tarball, so it gets **none** of this: its dependency tree is
   resolved fresh at image-build time against whatever is newest within our semver ranges, meaning the
   image is not reproducible and does not match what npm consumers receive (#1960).
+
+## Per-worker UDS mirrors are separate server instances — port-keyed wiring does not reach them (`server/http.ts`)
+
+With `tls.unixDomainSockets: true`, every secure port gets a per-worker cleartext mirror
+(`<worker>-<port>.sock`) so a fronting proxy (symphony) can terminate TLS and route to a specific
+worker. The mirror is a **separate** `http.Server` instance registered in `SERVERS[udsPath]` — it is
+_not_ `httpServers[port]` — so anything wired by port key (upgrade listeners, uWS `wsHandler`,
+mTLS flags, socket options) must be explicitly propagated to it. `getHTTPServer()` exposes the
+mirror as `server.udsMirror` (Node) / `server.udsMirrorUwsConfig` (HARPER_UWS_UDS) for exactly this;
+`onWebSocket()` uses those to attach the `'upgrade'` dispatch and uWS `wsHandler`. Two lessons paid
+for in production (WS handshakes died with a zero-byte close on the mirrors while SSE worked):
+
+- A Node HTTP server with **no** `'upgrade'` listener destroys upgrade sockets with no response and
+  no log — a silent per-server default that makes a missing listener look like a network problem.
+- `enableProxyProtocol()`'s data interception must hand the socket **back to the original
+  listeners** once the PROXY header decision is made (it re-attaches them and removes its wrapper).
+  A permanent wrapper breaks protocol handoffs: Node's upgrade path removes its parser's `'data'`
+  listener _by reference_ before ws takes over, so a lingering wrapper keeps feeding the freed HTTP
+  parser — which the parser pool can re-issue to another connection, injecting one connection's
+  WS frames into another's request stream (`Parse Error: Data after 'Connection: close'`).
+
+The h2c mirror (`HARPER_H2C_UDS`) is exempt: HTTP/1.1 `Upgrade` doesn't exist in h2, and the
+fronting proxy routes WS to the h1 mirror by ALPN.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -463,3 +463,10 @@ for in production (WS handshakes died with a zero-byte close on the mirrors whil
 
 The h2c mirror (`HARPER_H2C_UDS`) is exempt: HTTP/1.1 `Upgrade` doesn't exist in h2, and the
 fronting proxy routes WS to the h1 mirror by ALPN.
+
+Known limitation on uWS-served transports (`HARPER_UWS_HTTP` ports, `HARPER_UWS_UDS` mirrors):
+uWS accepts WebSocket handshakes natively in `app.ws()`, so `server.upgrade()` middleware never
+runs pre-handshake there (auth is unaffected — it runs in the WS connection chain on both paths,
+matching Node's upgrade-then-authorize order). No core component registers custom upgrade
+middleware; `onUpgrade()`/`installUwsWsHandler()` warn when one is registered for a uWS-served
+port so the gap is visible instead of silent.

--- a/server/http.ts
+++ b/server/http.ts
@@ -761,6 +761,8 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 					secure: true,
 					handler: makeUwsHandler(port, isOperationsServer, env.get(serverPrefix + '_requestQueueLimit')),
 				};
+				// Let onWebSocket() install its wsHandler on this mirror too
+				server.udsMirrorUwsConfig = uwsServeConfigs[udsPath];
 			} else {
 				// Create a plain HTTP server (no TLS) with the same request handler
 				const udsServer = createServer(
@@ -789,6 +791,10 @@ function getHTTPServer(port: number, secure: boolean, options: ServerOptions) {
 				if (mtls) udsServer.mtlsConfig = mtls;
 				enableProxyProtocol(udsServer);
 				SERVERS[udsPath] = udsServer;
+				// Let onWebSocket() attach its 'upgrade' dispatch to this mirror too — a Node
+				// HTTP server with no 'upgrade' listener destroys upgrade sockets with no
+				// response and no log.
+				server.udsMirror = udsServer;
 			}
 			registerUdsCleanupPaths(udsPath, yamlPath);
 
@@ -1529,34 +1535,38 @@ function onWebSocket(listener: (ws: WebSocket) => void, options: OnWebSocketOpti
 
 		const server = getHTTPServer(port, secure, options);
 
+		const installUwsWsHandler = (cfg: any) => {
+			if (!cfg || cfg.wsHandler) return;
+			// Honor a configured WebSocket maxPayload on the uWS transport too (else it defaults to 100 MiB).
+			if (options.maxPayload != null) cfg.wsMaxPayload = options.maxPayload;
+			cfg.wsHandler = (ws: any, upgrade: any) => {
+				try {
+					const request: any = new UwsRequest({
+						method: 'GET',
+						url: upgrade.url,
+						headers: upgrade.headers,
+						secure,
+						ip: upgrade.ip,
+					});
+					request.isWebSocket = true;
+					const chainCompletion = httpChain[port](request);
+					websocketChains[port](ws, request, chainCompletion);
+				} catch (error) {
+					harperLogger.warn('Error in handling WS connection', error);
+					try {
+						ws.close();
+					} catch {}
+				}
+			};
+		};
+		// A uWS-served UDS mirror (HARPER_UWS_UDS) needs the wsHandler regardless of whether the
+		// port itself is uWS- or Node-backed.
+		installUwsWsHandler((server as any)?.udsMirrorUwsConfig);
 		if ((server as any)?.uws) {
 			// uWS-backed port (HARPER_UWS_HTTP): uWS owns the socket, so route upgrades through uWS's
 			// native app.ws() rather than the Node ws.WebSocketServer + server 'upgrade' event. We wire a
 			// wsHandler into the shared uwsServeConfig; createUwsServer registers app.ws() when it listens.
-			const cfg = uwsServeConfigs[port];
-			if (cfg && !cfg.wsHandler) {
-				// Honor a configured WebSocket maxPayload on the uWS transport too (else it defaults to 100 MiB).
-				if (options.maxPayload != null) cfg.wsMaxPayload = options.maxPayload;
-				cfg.wsHandler = (ws: any, upgrade: any) => {
-					try {
-						const request: any = new UwsRequest({
-							method: 'GET',
-							url: upgrade.url,
-							headers: upgrade.headers,
-							secure,
-							ip: upgrade.ip,
-						});
-						request.isWebSocket = true;
-						const chainCompletion = httpChain[port](request);
-						websocketChains[port](ws, request, chainCompletion);
-					} catch (error) {
-						harperLogger.warn('Error in handling WS connection', error);
-						try {
-							ws.close();
-						} catch {}
-					}
-				};
-			}
+			installUwsWsHandler(uwsServeConfigs[port]);
 		} else if (!websocketServers[port]) {
 			websocketServers[port] = new WebSocketServer({
 				noServer: true,
@@ -1596,11 +1606,16 @@ function onWebSocket(listener: (ws: WebSocket) => void, options: OnWebSocketOpti
 			);
 
 			// Call the upgrade middleware chain
-			server.on('upgrade', (request, socket, head) => {
+			const dispatchUpgrade = (request, socket, head) => {
 				if (upgradeChains[port]) {
 					upgradeChains[port](request, socket, head);
 				}
-			});
+			};
+			server.on('upgrade', dispatchUpgrade);
+			// The UDS mirror is a separate http.Server; without its own 'upgrade' listener
+			// Node destroys upgrade sockets silently (zero-byte close), so WS worked on the
+			// TCP port but died on the mirror.
+			(server as any).udsMirror?.on('upgrade', dispatchUpgrade);
 		}
 
 		servers.push(server);
@@ -1647,7 +1662,6 @@ export function enableProxyProtocol(httpServer, prehandoffTimeout = 10_000) {
 				for (const listener of dataListeners) listener.call(socket, chunk);
 			};
 
-			let headerHandled = false;
 			// Accumulates a possibly-split PROXY header. Raw protocols (MQTT/replication) can't
 			// recover from a corrupted first packet, so we must not forward a partial header —
 			// it can arrive across multiple data events.
@@ -1658,8 +1672,7 @@ export function enableProxyProtocol(httpServer, prehandoffTimeout = 10_000) {
 			// unrelated keep-alive timeout.
 			const onPrehandoffTimeout = () => socket.destroy();
 			socket.setTimeout(prehandoffTimeout, onPrehandoffTimeout);
-			socket.on('data', (chunk: Buffer) => {
-				if (headerHandled) return forward(chunk);
+			const onData = (chunk: Buffer) => {
 				if (pending) chunk = Buffer.concat([pending, chunk]);
 
 				const decision = decodeProxyHeader(chunk);
@@ -1667,10 +1680,17 @@ export function enableProxyProtocol(httpServer, prehandoffTimeout = 10_000) {
 					pending = chunk;
 					return;
 				}
-				headerHandled = true;
 				pending = null;
 				socket.setTimeout(0);
 				socket.removeListener('timeout', onPrehandoffTimeout);
+				// Hand the socket back to its original listeners before forwarding. The wrapper
+				// must not outlive the header decision: protocol handoffs assume the listener
+				// they registered is the one attached (e.g. Node's HTTP upgrade path removes its
+				// parser's 'data' listener before ws takes over — with a lingering wrapper, WS
+				// frames would keep feeding the freed, re-poolable HTTP parser and corrupt
+				// whichever connection it is issued to next).
+				socket.removeListener('data', onData);
+				for (const listener of dataListeners) socket.on('data', listener);
 				if (decision.kind === 'none') {
 					// Not a PROXY header — forward everything unchanged.
 					return forward(chunk);
@@ -1679,7 +1699,8 @@ export function enableProxyProtocol(httpServer, prehandoffTimeout = 10_000) {
 				// Forward only the bytes after the PROXY header to the protocol parser.
 				const rest = chunk.subarray(decision.headerLength);
 				if (rest.length > 0) forward(rest);
-			});
+			};
+			socket.on('data', onData);
 		});
 	});
 }

--- a/server/http.ts
+++ b/server/http.ts
@@ -1487,8 +1487,25 @@ Object.defineProperty(IncomingMessage.prototype, 'upgrade', {
 const upgradeListeners = [],
 	upgradeChains = {};
 
+// uWS-served listeners (HARPER_UWS_HTTP ports, HARPER_UWS_UDS mirrors) accept WebSocket
+// handshakes natively in app.ws() — the Node 'upgrade' event never fires there, so
+// server.upgrade() middleware cannot run pre-handshake (auth still runs in the WS
+// connection chain, matching the Node path's upgrade-then-authorize order). Warn instead
+// of silently skipping the middleware. The default handler onWebSocket() registers is
+// exempt: its job (ws.handleUpgrade) is what uWS performs natively.
+function warnIfUpgradeMiddlewareUnreachable(listener: UpgradeListener, port: number | string) {
+	if ((listener as any).isDefaultWsUpgrade) return;
+	const server: any = httpServers[port];
+	if (server?.uws || server?.udsMirrorUwsConfig) {
+		harperLogger.warn(
+			`Upgrade middleware ('${getComponentName()}') is not applied on uWS-served listeners for port ${port}; uWS accepts WebSocket handshakes natively, so pre-handshake upgrade middleware only runs on Node-served listeners.`
+		);
+	}
+}
+
 function onUpgrade(listener: UpgradeListener, options: UpgradeOptions) {
 	for (const { port } of getPorts(options)) {
+		warnIfUpgradeMiddlewareUnreachable(listener, port);
 		const entry = {
 			listener,
 			port: options?.port || port,
@@ -1537,6 +1554,15 @@ function onWebSocket(listener: (ws: WebSocket) => void, options: OnWebSocketOpti
 
 		const installUwsWsHandler = (cfg: any) => {
 			if (!cfg || cfg.wsHandler) return;
+			// Registration-order complement to warnIfUpgradeMiddlewareUnreachable(): middleware
+			// registered before this uWS transport existed is equally unreachable.
+			for (const entry of upgradeListeners) {
+				if (entry.port == port && !(entry.listener as any).isDefaultWsUpgrade) {
+					harperLogger.warn(
+						`Upgrade middleware ('${entry.name}') is not applied on uWS-served listeners for port ${port}; uWS accepts WebSocket handshakes natively, so pre-handshake upgrade middleware only runs on Node-served listeners.`
+					);
+				}
+			}
 			// Honor a configured WebSocket maxPayload on the uWS transport too (else it defaults to 100 MiB).
 			if (options.maxPayload != null) cfg.wsMaxPayload = options.maxPayload;
 			cfg.wsHandler = (ws: any, upgrade: any) => {
@@ -1587,23 +1613,22 @@ function onWebSocket(listener: (ws: WebSocket) => void, options: OnWebSocketOpti
 			});
 
 			// Add the default upgrade handler if it doesn't exist.
-			onUpgrade(
-				(request, socket, head, next) => {
-					// If the request has already been upgraded, continue without upgrading
-					if (request.__harperdbRequestUpgraded || request.__harperRequestUpgraded) {
-						return next(request, socket, head);
-					}
+			const defaultUpgradeHandler = (request, socket, head, next) => {
+				// If the request has already been upgraded, continue without upgrading
+				if (request.__harperdbRequestUpgraded || request.__harperRequestUpgraded) {
+					return next(request, socket, head);
+				}
 
-					// Otherwise, upgrade the socket and then continue
-					return websocketServers[port].handleUpgrade(request, socket, head, (ws) => {
-						request.__harperdbRequestUpgraded = true;
-						request.__harperRequestUpgraded = true;
-						next(request, socket, head);
-						websocketServers[port].emit('connection', ws, request);
-					});
-				},
-				{ port }
-			);
+				// Otherwise, upgrade the socket and then continue
+				return websocketServers[port].handleUpgrade(request, socket, head, (ws) => {
+					request.__harperdbRequestUpgraded = true;
+					request.__harperRequestUpgraded = true;
+					next(request, socket, head);
+					websocketServers[port].emit('connection', ws, request);
+				});
+			};
+			(defaultUpgradeHandler as any).isDefaultWsUpgrade = true;
+			onUpgrade(defaultUpgradeHandler, { port });
 
 			// Call the upgrade middleware chain
 			const dispatchUpgrade = (request, socket, head) => {

--- a/server/serverHelpers/uwsServer.ts
+++ b/server/serverHelpers/uwsServer.ts
@@ -373,7 +373,8 @@ function registerWsBehavior(
 	maxPayload: number
 ): void {
 	app.ws('/*', {
-		maxPayload,
+		// uWS's option key — a plain `maxPayload` is silently ignored (default 16 KiB cap)
+		maxPayloadLength: maxPayload,
 		// Capture the upgrade request synchronously (uWS's HttpRequest is only valid here) and upgrade.
 		// Auth runs after open() in the ws chain, matching the Node path (which upgrades then authorizes).
 		upgrade: (res: UwsResponse, req: UwsRequestRaw, context: unknown) => {

--- a/unitTests/apiTests/mqtt-test.mjs
+++ b/unitTests/apiTests/mqtt-test.mjs
@@ -1163,8 +1163,12 @@ describe('test MQTT connections and commands', function () {
 				(key) => key.endsWith('.sock') && !preexistingCfgs.has(key)
 			);
 			assert.ok(mirrorCfgKey, 'securePort ws listener should create a uWS UDS mirror config');
-			assert.equal(typeof uwsServeConfigs[mirrorCfgKey].wsHandler, 'function', 'mirror config must get the wsHandler');
-			assert.equal(uwsServeConfigs[mirrorCfgKey].wsMaxPayload, 12345, 'mirror config must carry maxPayload');
+			assert.strictEqual(
+				typeof uwsServeConfigs[mirrorCfgKey].wsHandler,
+				'function',
+				'mirror config must get the wsHandler'
+			);
+			assert.strictEqual(uwsServeConfigs[mirrorCfgKey].wsMaxPayload, 12345, 'mirror config must carry maxPayload');
 		} finally {
 			delete process.env.HARPER_UWS_UDS;
 			setProperty('tls_unixDomainSockets', preexistingUds);
@@ -1193,12 +1197,13 @@ describe('test MQTT connections and commands', function () {
 		// Short path — sun_path is limited to ~104 bytes on macOS
 		const sockPath = join(tmpdir(), `hdb-ws-mirror-${process.pid}.sock`);
 		let mirror;
+		let client;
 		try {
 			global.server.ws((ws) => ws.on('message', (message) => ws.send(`echo:${message}`)), { securePort: 28886 });
 			const udsMirrorKey = Object.keys(SERVERS).find((key) => key.endsWith('.sock') && !preexistingServers[key]);
 			assert.ok(udsMirrorKey, 'securePort ws listener should create a UDS mirror when tls_unixDomainSockets is on');
 			mirror = SERVERS[udsMirrorKey];
-			assert.equal(mirror.listenerCount('upgrade'), 1, 'the UDS mirror must dispatch upgrade requests');
+			assert.strictEqual(mirror.listenerCount('upgrade'), 1, 'the UDS mirror must dispatch upgrade requests');
 
 			try {
 				unlinkSync(sockPath);
@@ -1208,7 +1213,7 @@ describe('test MQTT connections and commands', function () {
 				mirror.listen(sockPath, resolve);
 			});
 
-			const client = netConnect(sockPath);
+			client = netConnect(sockPath);
 			const key = randomBytes(16).toString('base64');
 			const status = await new Promise((resolve, reject) => {
 				let data = Buffer.alloc(0);
@@ -1230,7 +1235,7 @@ describe('test MQTT connections and commands', function () {
 				client.on('close', () => reject(new Error('connection closed before handshake response')));
 				setTimeout(() => reject(new Error('no handshake response')), 3000).unref();
 			});
-			assert.equal(status, 'HTTP/1.1 101 Switching Protocols');
+			assert.strictEqual(status, 'HTTP/1.1 101 Switching Protocols');
 
 			// Post-upgrade data must flow both ways through the proxy-protocol handoff
 			const echoed = new Promise((resolve, reject) => {
@@ -1246,9 +1251,9 @@ describe('test MQTT connections and commands', function () {
 			const mask = randomBytes(4);
 			const masked = Buffer.from(payload.map((byte, i) => byte ^ mask[i % 4]));
 			client.write(Buffer.concat([Buffer.from([0x81, 0x80 | payload.length]), mask, masked]));
-			assert.equal(await echoed, 'echo:hi');
-			client.destroy();
+			assert.strictEqual(await echoed, 'echo:hi');
 		} finally {
+			client?.destroy();
 			setProperty('tls_unixDomainSockets', preexistingUds);
 			if (mirror?.listening) await new Promise((resolve) => mirror.close(resolve));
 			try {

--- a/unitTests/apiTests/mqtt-test.mjs
+++ b/unitTests/apiTests/mqtt-test.mjs
@@ -1147,6 +1147,120 @@ describe('test MQTT connections and commands', function () {
 		}
 	});
 
+	it('installs the ws handler on a uWS-served UDS mirror config (HARPER_UWS_UDS)', async function () {
+		// The HARPER_UWS_UDS mirror is served by uWS from uwsServeConfigs, not a Node http.Server;
+		// server.ws() must install its wsHandler (and maxPayload) on that mirror config too.
+		const { uwsServeConfigs } = await import('#src/server/http');
+		const preexistingServers = { ...SERVERS };
+		const preexistingPortServer = new Map([...portServer.entries()].map(([key, servers]) => [key, [...servers]]));
+		const preexistingUds = env_get('tls_unixDomainSockets');
+		setProperty('tls_unixDomainSockets', true);
+		process.env.HARPER_UWS_UDS = '1';
+		const preexistingCfgs = new Set(Object.keys(uwsServeConfigs));
+		try {
+			global.server.ws(() => {}, { securePort: 28887, maxPayload: 12345 });
+			const mirrorCfgKey = Object.keys(uwsServeConfigs).find(
+				(key) => key.endsWith('.sock') && !preexistingCfgs.has(key)
+			);
+			assert.ok(mirrorCfgKey, 'securePort ws listener should create a uWS UDS mirror config');
+			assert.equal(typeof uwsServeConfigs[mirrorCfgKey].wsHandler, 'function', 'mirror config must get the wsHandler');
+			assert.equal(uwsServeConfigs[mirrorCfgKey].wsMaxPayload, 12345, 'mirror config must carry maxPayload');
+		} finally {
+			delete process.env.HARPER_UWS_UDS;
+			setProperty('tls_unixDomainSockets', preexistingUds);
+			for (const key of Object.keys(uwsServeConfigs)) if (!preexistingCfgs.has(key)) delete uwsServeConfigs[key];
+			for (const key of Object.keys(SERVERS)) delete SERVERS[key];
+			Object.assign(SERVERS, preexistingServers);
+			portServer.clear();
+			for (const [key, servers] of preexistingPortServer) portServer.set(key, servers);
+		}
+	});
+
+	it('wires WebSocket upgrade handling onto the UDS mirror (WS died with a zero-byte close there)', async function () {
+		// server.ws() attaches the upgrade dispatch to the port-keyed server; the UDS mirror is a
+		// separate http.Server and historically got no 'upgrade' listener, so Node destroyed WS
+		// handshakes on it silently. Exercise a real handshake + echo through the mirror socket,
+		// PROXY header included, exactly as a fronting proxy sends it.
+		const { unlinkSync } = await import('node:fs');
+		const { connect: netConnect } = await import('node:net');
+		const { randomBytes } = await import('node:crypto');
+		const { tmpdir } = await import('node:os');
+		const { join } = await import('node:path');
+		const preexistingServers = { ...SERVERS };
+		const preexistingPortServer = new Map([...portServer.entries()].map(([key, servers]) => [key, [...servers]]));
+		const preexistingUds = env_get('tls_unixDomainSockets');
+		setProperty('tls_unixDomainSockets', true);
+		// Short path — sun_path is limited to ~104 bytes on macOS
+		const sockPath = join(tmpdir(), `hdb-ws-mirror-${process.pid}.sock`);
+		let mirror;
+		try {
+			global.server.ws((ws) => ws.on('message', (message) => ws.send(`echo:${message}`)), { securePort: 28886 });
+			const udsMirrorKey = Object.keys(SERVERS).find((key) => key.endsWith('.sock') && !preexistingServers[key]);
+			assert.ok(udsMirrorKey, 'securePort ws listener should create a UDS mirror when tls_unixDomainSockets is on');
+			mirror = SERVERS[udsMirrorKey];
+			assert.equal(mirror.listenerCount('upgrade'), 1, 'the UDS mirror must dispatch upgrade requests');
+
+			try {
+				unlinkSync(sockPath);
+			} catch {}
+			await new Promise((resolve, reject) => {
+				mirror.once('error', reject);
+				mirror.listen(sockPath, resolve);
+			});
+
+			const client = netConnect(sockPath);
+			const key = randomBytes(16).toString('base64');
+			const status = await new Promise((resolve, reject) => {
+				let data = Buffer.alloc(0);
+				client.on('connect', () => {
+					client.write('PROXY TCP4 1.2.3.4 5.6.7.8 1111 2222\r\n');
+					client.write(
+						`GET / HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n` +
+							`Sec-WebSocket-Version: 13\r\nSec-WebSocket-Key: ${key}\r\n\r\n`
+					);
+				});
+				client.on('data', function onHandshake(chunk) {
+					data = Buffer.concat([data, chunk]);
+					if (data.includes('\r\n\r\n')) {
+						client.removeListener('data', onHandshake);
+						resolve(data.toString().split('\r\n')[0]);
+					}
+				});
+				client.on('error', reject);
+				client.on('close', () => reject(new Error('connection closed before handshake response')));
+				setTimeout(() => reject(new Error('no handshake response')), 3000).unref();
+			});
+			assert.equal(status, 'HTTP/1.1 101 Switching Protocols');
+
+			// Post-upgrade data must flow both ways through the proxy-protocol handoff
+			const echoed = new Promise((resolve, reject) => {
+				let frame = Buffer.alloc(0);
+				client.on('data', (chunk) => {
+					frame = Buffer.concat([frame, chunk]);
+					const length = frame[1] & 0x7f;
+					if (frame.length >= 2 + length) resolve(frame.subarray(2, 2 + length).toString());
+				});
+				setTimeout(() => reject(new Error('no echo received')), 3000).unref();
+			});
+			const payload = Buffer.from('hi');
+			const mask = randomBytes(4);
+			const masked = Buffer.from(payload.map((byte, i) => byte ^ mask[i % 4]));
+			client.write(Buffer.concat([Buffer.from([0x81, 0x80 | payload.length]), mask, masked]));
+			assert.equal(await echoed, 'echo:hi');
+			client.destroy();
+		} finally {
+			setProperty('tls_unixDomainSockets', preexistingUds);
+			if (mirror?.listening) await new Promise((resolve) => mirror.close(resolve));
+			try {
+				unlinkSync(sockPath);
+			} catch {}
+			for (const key of Object.keys(SERVERS)) delete SERVERS[key];
+			Object.assign(SERVERS, preexistingServers);
+			portServer.clear();
+			for (const [key, servers] of preexistingPortServer) portServer.set(key, servers);
+		}
+	});
+
 	it('socket listeners actually apply noDelay/keepAlive socket options', function () {
 		// net.createServer(listener, options) silently ignores the options object — options must be
 		// the first argument. Assert the servers onSocket creates carry the socket options, so an

--- a/unitTests/server/serverHelpers/uwsServer.test.js
+++ b/unitTests/server/serverHelpers/uwsServer.test.js
@@ -378,6 +378,34 @@ try {
 			assert.strictEqual(res.body.length, 0);
 		});
 
+		it('enforces wsMaxPayload by closing a connection that sends an oversized frame', async function () {
+			// Regression: registerWsBehavior passed `maxPayload` to app.ws(), but uWS's option key is
+			// `maxPayloadLength`, so the configured cap was silently ignored (uWS's 16 KiB default applied).
+			const cappedPort = port + 1;
+			const cappedServer = await createUwsServer({
+				port: cappedPort,
+				handler: async () => ({ status: 200, body: 'http' }),
+				wsHandler: (ws) => ws.on('message', (data) => ws.send(data)),
+				wsMaxPayload: 64,
+			});
+			try {
+				const client = new WebSocket(`ws://127.0.0.1:${cappedPort}/`);
+				await new Promise((resolve, reject) => {
+					client.on('open', resolve);
+					client.on('error', reject);
+				});
+				const closed = new Promise((resolve) => client.on('close', (code) => resolve(code)));
+				client.send(Buffer.alloc(1024));
+				const code = await Promise.race([
+					closed,
+					new Promise((resolve) => setTimeout(() => resolve('no-close'), 2000).unref()),
+				]);
+				assert.notStrictEqual(code, 'no-close', 'oversized frame must close the connection');
+			} finally {
+				cappedServer.close();
+			}
+		});
+
 		it('accepts an upgrade, exposes url/headers/ip, and round-trips text and binary frames', function (done) {
 			const client = new WebSocket(`ws://127.0.0.1:${port}/sub?x=1`, { headers: { authorization: 'Bearer t' } });
 			const frames = [];

--- a/unitTests/server/udsMirror.test.js
+++ b/unitTests/server/udsMirror.test.js
@@ -305,6 +305,133 @@ describe('UDS mirror (writeUdsMetadata, cleanup helpers)', () => {
 			socket.emit('timeout'); // an unrelated later timeout must be a no-op post-handoff
 			assert.strictEqual(socket.destroy.called, false);
 		});
+
+		it('uninstalls its wrapper and restores the original listeners once the header resolves', async () => {
+			// The wrapper must not outlive the header decision: Node's HTTP upgrade path
+			// removes the parser's 'data' listener by reference before ws takes over, so a
+			// lingering wrapper would keep feeding the freed (re-poolable) parser.
+			const socket = createSocket();
+			const server = new EventEmitter();
+			enableProxyProtocol(server);
+			const parserListener = () => {};
+			socket.on('data', parserListener);
+			server.emit('connection', socket);
+			await new Promise((resolve) => process.nextTick(resolve));
+			socket.emit('data', Buffer.from('PROXY TCP4 1.2.3.4 5.6.7.8 1111 2222\r\nHELLO'));
+			assert.deepStrictEqual(socket.listeners('data'), [parserListener]);
+		});
+	});
+
+	// ─── WS upgrade through the UDS mirror path (real sockets) ────────────────
+
+	describe('WebSocket upgrade over a proxy-protocol UDS server', () => {
+		// End-to-end regression for the two defects that silently killed WS on the UDS
+		// mirrors: a mirror with no 'upgrade' listener destroys the socket with a
+		// zero-byte close, and the old enableProxyProtocol wrapper kept forwarding
+		// post-upgrade frames into the freed HTTP parser (which the pool can re-issue
+		// to another connection, corrupting it).
+		const http = require('node:http');
+		const net = require('node:net');
+		const crypto = require('node:crypto');
+		const os = require('node:os');
+		const { WebSocketServer } = require('ws');
+
+		// Short path: sun_path is limited to ~104 bytes on macOS
+		const sockPath = path.join(os.tmpdir(), `hdb-ws-uds-${process.pid}.sock`);
+		let server, wss;
+
+		before(async () => {
+			try {
+				fs.unlinkSync(sockPath);
+			} catch {}
+			server = http.createServer((request, response) => response.end('ok'));
+			wss = new WebSocketServer({ noServer: true });
+			wss.on('connection', (ws) => ws.on('message', (msg) => ws.send(`echo:${msg}`)));
+			server.on('upgrade', (request, socket, head) => {
+				wss.handleUpgrade(request, socket, head, (ws) => wss.emit('connection', ws, request));
+			});
+			enableProxyProtocol(server);
+			await new Promise((resolve) => server.listen(sockPath, resolve));
+		});
+
+		after(async () => {
+			wss?.close();
+			server.closeAllConnections?.();
+			await new Promise((resolve) => server.close(resolve));
+			try {
+				fs.unlinkSync(sockPath);
+			} catch {}
+		});
+
+		function maskedTextFrame(text) {
+			const payload = Buffer.from(text);
+			const mask = crypto.randomBytes(4);
+			const masked = Buffer.from(payload.map((byte, i) => byte ^ mask[i % 4]));
+			return Buffer.concat([Buffer.from([0x81, 0x80 | payload.length]), mask, masked]);
+		}
+
+		function httpRequest() {
+			return new Promise((resolve, reject) => {
+				const client = net.connect(sockPath);
+				let data = '';
+				client.on('connect', () => {
+					client.write('PROXY TCP4 9.9.9.9 5.6.7.8 3333 2222\r\n');
+					client.write('GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n');
+				});
+				client.on('data', (chunk) => (data += chunk));
+				client.on('close', () => resolve(data.split('\r\n')[0]));
+				client.on('error', reject);
+			});
+		}
+
+		it('completes the handshake, echoes frames, and leaves pooled parsers intact', async () => {
+			const client = net.connect(sockPath);
+			const key = crypto.randomBytes(16).toString('base64');
+			let clientError = null;
+			server.once('clientError', (error) => (clientError = error));
+
+			const status = await new Promise((resolve, reject) => {
+				let data = Buffer.alloc(0);
+				client.on('connect', () => {
+					client.write('PROXY TCP4 1.2.3.4 5.6.7.8 1111 2222\r\n');
+					client.write(
+						`GET / HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n` +
+							`Sec-WebSocket-Version: 13\r\nSec-WebSocket-Key: ${key}\r\n\r\n`
+					);
+				});
+				client.on('data', function onHandshake(chunk) {
+					data = Buffer.concat([data, chunk]);
+					if (data.includes('\r\n\r\n')) {
+						client.removeListener('data', onHandshake);
+						resolve(data.toString().split('\r\n')[0]);
+					}
+				});
+				client.on('error', reject);
+				client.on('close', () => reject(new Error('connection closed before handshake response')));
+			});
+			assert.strictEqual(status, 'HTTP/1.1 101 Switching Protocols');
+
+			// Run another HTTP request first so the freed parser is re-issued from the
+			// pool; frames on the upgraded socket must not reach it.
+			assert.strictEqual(await httpRequest(), 'HTTP/1.1 200 OK');
+
+			const echoed = new Promise((resolve, reject) => {
+				let frame = Buffer.alloc(0);
+				client.on('data', (chunk) => {
+					frame = Buffer.concat([frame, chunk]);
+					const length = frame[1] & 0x7f;
+					if (frame.length >= 2 + length) resolve(frame.subarray(2, 2 + length).toString());
+				});
+				setTimeout(() => reject(new Error('no echo received')), 3000).unref();
+			});
+			client.write(maskedTextFrame('hi'));
+			assert.strictEqual(await echoed, 'echo:hi');
+			assert.strictEqual(clientError && clientError.message, null, 'frames must not leak into pooled HTTP parsers');
+
+			// The server must serve plain HTTP cleanly after the upgraded connection exchanged frames
+			assert.strictEqual(await httpRequest(), 'HTTP/1.1 200 OK');
+			client.destroy();
+		});
 	});
 
 	// ─── registerUdsCleanupPaths + cleanupUdsFiles ────────────────────────────

--- a/unitTests/server/udsMirror.test.js
+++ b/unitTests/server/udsMirror.test.js
@@ -390,47 +390,50 @@ describe('UDS mirror (writeUdsMetadata, cleanup helpers)', () => {
 			let clientError = null;
 			server.once('clientError', (error) => (clientError = error));
 
-			const status = await new Promise((resolve, reject) => {
-				let data = Buffer.alloc(0);
-				client.on('connect', () => {
-					client.write('PROXY TCP4 1.2.3.4 5.6.7.8 1111 2222\r\n');
-					client.write(
-						`GET / HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n` +
-							`Sec-WebSocket-Version: 13\r\nSec-WebSocket-Key: ${key}\r\n\r\n`
-					);
+			try {
+				const status = await new Promise((resolve, reject) => {
+					let data = Buffer.alloc(0);
+					client.on('connect', () => {
+						client.write('PROXY TCP4 1.2.3.4 5.6.7.8 1111 2222\r\n');
+						client.write(
+							`GET / HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n` +
+								`Sec-WebSocket-Version: 13\r\nSec-WebSocket-Key: ${key}\r\n\r\n`
+						);
+					});
+					client.on('data', function onHandshake(chunk) {
+						data = Buffer.concat([data, chunk]);
+						if (data.includes('\r\n\r\n')) {
+							client.removeListener('data', onHandshake);
+							resolve(data.toString().split('\r\n')[0]);
+						}
+					});
+					client.on('error', reject);
+					client.on('close', () => reject(new Error('connection closed before handshake response')));
 				});
-				client.on('data', function onHandshake(chunk) {
-					data = Buffer.concat([data, chunk]);
-					if (data.includes('\r\n\r\n')) {
-						client.removeListener('data', onHandshake);
-						resolve(data.toString().split('\r\n')[0]);
-					}
+				assert.strictEqual(status, 'HTTP/1.1 101 Switching Protocols');
+
+				// Run another HTTP request first so the freed parser is re-issued from the
+				// pool; frames on the upgraded socket must not reach it.
+				assert.strictEqual(await httpRequest(), 'HTTP/1.1 200 OK');
+
+				const echoed = new Promise((resolve, reject) => {
+					let frame = Buffer.alloc(0);
+					client.on('data', (chunk) => {
+						frame = Buffer.concat([frame, chunk]);
+						const length = frame[1] & 0x7f;
+						if (frame.length >= 2 + length) resolve(frame.subarray(2, 2 + length).toString());
+					});
+					setTimeout(() => reject(new Error('no echo received')), 3000).unref();
 				});
-				client.on('error', reject);
-				client.on('close', () => reject(new Error('connection closed before handshake response')));
-			});
-			assert.strictEqual(status, 'HTTP/1.1 101 Switching Protocols');
+				client.write(maskedTextFrame('hi'));
+				assert.strictEqual(await echoed, 'echo:hi');
+				assert.strictEqual(clientError, null, 'frames must not leak into pooled HTTP parsers');
 
-			// Run another HTTP request first so the freed parser is re-issued from the
-			// pool; frames on the upgraded socket must not reach it.
-			assert.strictEqual(await httpRequest(), 'HTTP/1.1 200 OK');
-
-			const echoed = new Promise((resolve, reject) => {
-				let frame = Buffer.alloc(0);
-				client.on('data', (chunk) => {
-					frame = Buffer.concat([frame, chunk]);
-					const length = frame[1] & 0x7f;
-					if (frame.length >= 2 + length) resolve(frame.subarray(2, 2 + length).toString());
-				});
-				setTimeout(() => reject(new Error('no echo received')), 3000).unref();
-			});
-			client.write(maskedTextFrame('hi'));
-			assert.strictEqual(await echoed, 'echo:hi');
-			assert.strictEqual(clientError && clientError.message, null, 'frames must not leak into pooled HTTP parsers');
-
-			// The server must serve plain HTTP cleanly after the upgraded connection exchanged frames
-			assert.strictEqual(await httpRequest(), 'HTTP/1.1 200 OK');
-			client.destroy();
+				// The server must serve plain HTTP cleanly after the upgraded connection exchanged frames
+				assert.strictEqual(await httpRequest(), 'HTTP/1.1 200 OK');
+			} finally {
+				client.destroy();
+			}
 		});
 	});
 


### PR DESCRIPTION
Fixes #2013.

## What was broken

With `tls.unixDomainSockets: true` (a fronting proxy terminating TLS and routing to per-worker UDS mirrors), every WebSocket handshake against a mirror was destroyed with a zero-byte close — no HTTP response, no error, nothing in the log. Plain HTTP and SSE worked; only `Upgrade` died. This took down all WS traffic behind the proxy, including MQTT-over-WSS from browsers. Reproduced on 5.1.22, 5.1.25, and `main`.

Two independent defects in `server/http.ts`:

1. **The UDS mirror has no `'upgrade'` listener.** `onWebSocket()` attaches the upgrade middleware dispatch via `server.on('upgrade', …)` on the port-keyed server only. The mirror is a separate `http.Server` (`SERVERS[udsPath]`), and a Node HTTP server with zero `'upgrade'` listeners destroys upgrade sockets (`socket.destroy()` in `_http_server.js`) — exactly the observed silent close. The experimental `HARPER_UWS_UDS` path had the same gap: `onWebSocket()` set `wsHandler` on `uwsServeConfigs[port]` but never on the mirror's `uwsServeConfigs[udsPath]`.

2. **`enableProxyProtocol()`'s interception outlives its purpose and corrupts post-upgrade traffic.** The wrapper captured the HTTP parser's `'data'` listeners at connection time and forwarded to that captured array forever. On upgrade, Node removes its parser listener *by reference* (a no-op — the wrapper holds it) and `ws` attaches new listeners, so every inbound WS frame was delivered both to `ws` and to the freed parser. Verified empirically: once the parser pool re-issues that parser to another connection, frames from the upgraded socket are injected into the other connection's parser (`clientError: Parse Error: Data after 'Connection: close'`) — cross-connection corruption, so fixing (1) alone was not enough.

## The fix

- `getHTTPServer()` exposes the mirror on the port server (`server.udsMirror` for Node, `server.udsMirrorUwsConfig` for `HARPER_UWS_UDS`); `onWebSocket()` attaches the same upgrade dispatch to the mirror (chains stay keyed by the mirrored port) and installs the uWS `wsHandler` on the mirror config. The uWS handler creation is extracted into one helper used by both the port config and the mirror config.
- `enableProxyProtocol()` now hands the socket back to its original listeners as soon as the PROXY header decision is made: it removes its wrapper and re-attaches the captured listeners, so all post-header traffic (including protocol handoffs like HTTP upgrade → ws) runs on real listeners with native semantics.
- Adjacent fix (found by the Codex review leg): `registerWsBehavior()` passed `{ maxPayload }` to uWS's `app.ws()`, but uWS's option key is `maxPayloadLength` — the configured WS payload cap (including the `wsMaxPayload` this PR propagates) was silently ignored and uWS's 16 KiB default applied. Now passed under the correct key, with a regression test (oversized frame must close the connection; verified fails pre-fix).

Known limitation, now surfaced instead of silent (raised in review): uWS-served transports (`HARPER_UWS_HTTP` ports, `HARPER_UWS_UDS` mirrors) accept WS handshakes natively in `app.ws()`, so custom `server.upgrade()` middleware cannot run pre-handshake there — this predates this PR on the uWS port path, no core component registers such middleware, and auth is unaffected (it runs in the WS connection chain on both paths, matching Node's upgrade-then-authorize order). `onUpgrade()`/`installUwsWsHandler()` now warn when custom upgrade middleware is registered for a uWS-served port. A real middleware bridge for uWS (if ever needed) is follow-up work.

Not affected / out of scope, per analysis requested in the thread: the raw MQTT (non-WS) UDS mirrors (`server.socket()` path — no HTTP upgrade involved) and the `HARPER_H2C_UDS` h2c mirror (HTTP/1.1 `Upgrade` doesn't exist in h2; the fronting proxy routes WS to the h1 mirror by ALPN). `websocketChains` itself was never stranded — it's invoked through the upgrade dispatch, which was the missing link.

## Verification

- Full stack: booted this branch with `tls.unixDomainSockets: true`; the original repro (`curl --unix-socket … -H Upgrade:websocket`) now returns **101** on the mirror (was `000`), and an MQTT-over-WebSocket CONNECT through the mirror reaches the broker and gets a CONNACK back.
- New regression tests (both verified to fail against the pre-fix code with the exact defect signatures):
  - `unitTests/server/udsMirror.test.js`: real UDS socket + PROXY v1 header + WS handshake + masked-frame echo, with an interleaved HTTP request to force parser-pool reuse (fails pre-fix with `Parse Error: Data after 'Connection: close'`); plus a listener-restoration unit test on the wrapper.
  - `unitTests/apiTests/mqtt-test.mjs`: `server.ws({securePort})` with `tls_unixDomainSockets` on — asserts the mirror gets the upgrade dispatch and completes a real handshake + echo through the mirror socket (fails pre-fix with a zero-byte close); plus a `HARPER_UWS_UDS` test asserting the uWS mirror config receives the `wsHandler`/`wsMaxPayload`.
  - `unitTests/server/serverHelpers/uwsServer.test.js`: oversized-frame close test for the `maxPayloadLength` fix (fails pre-fix).
- Suites run locally: `test:unit:resources` clean (1334 passing); `test:unit:main` 2904 passing with 2 failures and `test:unit:apitests` 182 passing with 10 failures — **all 12 failures reproduce identically on a clean `origin/main` baseline** in this environment (verified with a stash + rebuild), so they are pre-existing and unrelated; `test:integration:all` passes.

## Notes

- A **v5.1 backport is needed** (the affected deployments run 5.1.x, and the team wants a permanent core patch to load-test against rather than infra workarounds). I'll open the cherry-pick PR once this lands; it should ride the same 5.1 patch as #2010/#2011.
- Cross-model review (thorough): Gemini (`agy`) + Codex legs + Harper-domain adjudication. **No blockers, no significant concerns.** Gemini's one raised blocker (uWS-backed port leaving the Node mirror unwired) was refuted with code evidence — the `HARPER_UWS_HTTP` branch requires `!secure` and returns early, while mirrors are created only for secure ports, so the combination is unreachable. Codex's two real findings (the `maxPayloadLength` key bug; `node:` prefixes) are fixed in this PR; its uWS-mirror test-gap suggestion is covered by the added `HARPER_UWS_UDS` config test. Gemini's `socket.unshift` alternative was considered and declined: the manual forward preserves the exact pre-existing delivery mechanism the split-header tests pin, and the module's own Node-v24 comment documents that the parser's intake doesn't reliably see stream-level re-emission.
- Generated by Claude (Fable 5) pairing with Kris.
