### PR TITLE
Write the version/metadata prefix on LMDB→RocksDB migrated records (v5.1 backport of #2014)

### DIFF
--- a/bin/copyDb.ts
+++ b/bin/copyDb.ts
@@ -458,9 +458,14 @@ export function verifyMigratedDatabase(databasePath: string): Record<string, { r
 		handles.push(dbisDb);
 		for (const { key, value: attribute } of dbisDb.getRange({})) {
 			if (typeof key === 'symbol' || !attribute?.isPrimaryKey) continue;
+			// per-table handles close per-iteration so a many-table sweep does not hold every CF
+			// handle open at once; only the two pre-loop opens need the leak-safety array
 			const rawDbi = RocksDatabase.open(databasePath, { name: key, encoding: false });
-			handles.push(rawDbi);
-			report[key] = countRecords(rawDbi);
+			try {
+				report[key] = countRecords(rawDbi);
+			} finally {
+				rawDbi.close();
+			}
 		}
 	} finally {
 		for (const handle of handles.reverse()) {

--- a/bin/copyDb.ts
+++ b/bin/copyDb.ts
@@ -3,11 +3,12 @@ import { open, asBinary } from 'lmdb';
 import { join } from 'path';
 import { move, remove } from 'fs-extra';
 import { existsSync, mkdirSync } from 'node:fs';
+import { rename } from 'node:fs/promises';
 import { get } from '../utility/environment/environmentManager.ts';
 import OpenEnvironmentObject from '../utility/lmdb/OpenEnvironmentObject.ts';
 import { OpenDBIObject } from '../utility/lmdb/OpenDBIObject.ts';
 import { INTERNAL_DBIS_NAME, AUDIT_STORE_NAME } from '../utility/lmdb/terms.ts';
-import { CONFIG_PARAMS, DATABASES_DIR_NAME } from '../utility/hdbTerms.ts';
+import { CONFIG_PARAMS, DATABASES_DIR_NAME, MIGRATING_DIR_SUFFIX } from '../utility/hdbTerms.ts';
 import { AUDIT_STORE_OPTIONS } from '../resources/auditStore.ts';
 import { describeSchema } from '../dataLayer/schemaDescribe.ts';
 import { updateConfigValue } from '../config/configUtils.ts';
@@ -20,7 +21,13 @@ import {
 	encodeBlobsWithFilePath,
 	endPendingMigrationBlobSaves,
 } from '../resources/blob.ts';
-import { RecordEncoder, setNextEncoding, lastMetadata, METADATA } from '../resources/RecordEncoder.ts';
+import {
+	RecordEncoder,
+	setNextEncoding,
+	clearNextEncoding,
+	lastMetadata,
+	METADATA,
+} from '../resources/RecordEncoder.ts';
 
 export async function compactOnStart() {
 	hdbLogger.notify('Running compact on start');
@@ -330,7 +337,7 @@ function openRocksDb(path: string, options: RocksDatabaseOptions & { dupSort?: b
 		db = new (RocksIndexStore as any)(path, options).open();
 	} else {
 		db = RocksDatabase.open(path, options);
-		db.encoder.name = options.name;
+		if (db.encoder) db.encoder.name = options.name;
 	}
 	return db;
 }
@@ -379,7 +386,7 @@ export async function migrateOnStart() {
 
 			console.log('Migrating', databaseName, 'from LMDB to RocksDB at', targetPath);
 
-			await copyDbToRocks(rootStore, databaseName, targetPath);
+			await migrateDatabaseToRocks(rootStore, databaseName, targetPath);
 
 			// Back up the original LMDB file
 			console.log('Backing up LMDB', databaseName, 'to', backupDest);
@@ -412,11 +419,104 @@ export async function migrateOnStart() {
 	}
 }
 
+/**
+ * Count records in a raw (encoding: false) store whose value lacks the 8-byte version prefix
+ * (0x42 = first byte of a ms-epoch float64). Symbol keys are internal and skipped. First-byte
+ * classification is a heuristic: a prefix-less classic record can also lead with 0x42 (structure
+ * ref id 2) and would be undercounted — fine for the whole-table detection this report serves.
+ */
+function countRecords(rawDbi): { records: number; unversioned: number } {
+	let records = 0;
+	let unversioned = 0;
+	for (const { key, value } of rawDbi.getRange({})) {
+		if (typeof key === 'symbol') continue;
+		records++;
+		if (!value || value.length < 8 || value[0] !== 0x42) unversioned++;
+	}
+	return { records, unversioned };
+}
+
+/**
+ * Verification sweep for an already-migrated RocksDB database (harper#2012): reports, per
+ * primary-key dbi, how many records lack the version/metadata prefix. Such records decode
+ * without their record prototype on point reads and carry no version; a nonzero count beyond a
+ * table's known version-less records means it needs the no-op rewrite pass. Read-only, but takes
+ * the RocksDB lock — run in-process (inspector) on a live instance, or offline.
+ */
+export function verifyMigratedDatabase(databasePath: string): Record<string, { records: number; unversioned: number }> {
+	const rootStore = RocksDatabase.open(databasePath, {});
+	const dbisDb = RocksDatabase.open(databasePath, {
+		name: INTERNAL_DBIS_NAME,
+		sharedStructuresKey: Symbol.for('structures'),
+	});
+	const report: Record<string, { records: number; unversioned: number }> = {};
+	try {
+		for (const { key, value: attribute } of dbisDb.getRange({})) {
+			if (typeof key === 'symbol' || !attribute?.isPrimaryKey) continue;
+			const rawDbi = RocksDatabase.open(databasePath, { name: key, encoding: false });
+			try {
+				report[key] = countRecords(rawDbi);
+			} finally {
+				rawDbi.close();
+			}
+		}
+	} finally {
+		dbisDb.close();
+		rootStore.close();
+	}
+	return report;
+}
+
+/**
+ * Migrate one database LMDB→RocksDB with restart-safe promotion: copy into a staging directory
+ * (excluded from database discovery) and atomically rename it to targetPath only after the copy
+ * fully verifies. A failure part-way must never leave a partial RocksDB at targetPath — on the
+ * next boot both <db>.mdb and <db>/ would be discovered, and whichever binds last wins; if the
+ * partial RocksDB won, migrateOnStart would see "already RocksDB", clear the flag, and abandon
+ * the intact LMDB. Any stale staging dir is removed before retrying, so an interrupted migration
+ * (throw or SIGKILL) always recovers by re-migrating from the untouched LMDB source.
+ */
+export async function migrateDatabaseToRocks(sourceRootStore, databaseName: string, targetPath: string) {
+	const stagingPath = targetPath + MIGRATING_DIR_SUFFIX;
+	await remove(stagingPath);
+	try {
+		await copyDbToRocks(sourceRootStore, databaseName, stagingPath);
+	} catch (error) {
+		try {
+			await remove(stagingPath);
+		} catch {
+			// discovery ignores the staging dir and the next attempt removes it
+		}
+		throw error;
+	}
+	// A directory already at targetPath can only be a stale partial from a pre-staging build's
+	// failed attempt (or a complete copy from a crash after rename but before the flag cleared) —
+	// discovery bound the LMDB source this boot, and we just produced a fresh verified copy from
+	// it, so replace.
+	await remove(targetPath);
+	// On Windows a directory rename can transiently fail while RocksDB background threads release
+	// their last file handles after close(); retry briefly before giving up.
+	for (let attempt = 0; ; attempt++) {
+		try {
+			await rename(stagingPath, targetPath);
+			break;
+		} catch (error: any) {
+			if (attempt >= 4 || !(error.code === 'EPERM' || error.code === 'EBUSY' || error.code === 'EACCES')) throw error;
+			await new Promise((resolve) => setTimeout(resolve, 250));
+		}
+	}
+}
+
 export async function copyDbToRocks(sourceRootStore, sourceDatabase: string, targetPath: string) {
 	console.log(`Migrating database ${sourceDatabase} to RocksDB at ${targetPath}`);
 	const sourceDbisDb = sourceRootStore.dbisDb;
 
 	const targetRootStore = openRocksDb(targetPath, { disableWAL: false });
+	// Every handle opened on targetPath. All must be closed before returning so the caller can
+	// atomically rename a staging directory into place — rocksdb-js registers descriptors by
+	// path string, so a handle left open on the staging path would hold the DB lock against the
+	// runtime's open of the renamed directory (harper#2012 restart-safety).
+	const targetHandles: RocksDatabase[] = [targetRootStore];
 	// sharedStructuresKey wires the rocksdb-js getStructures/saveStructures closures
 	// so that the plain msgpackr.Encoder used here persists structures within the
 	// __dbis__ CF at Symbol.for('structures'). The runtime attributesDbi RecordEncoder
@@ -430,6 +530,7 @@ export async function copyDbToRocks(sourceRootStore, sourceDatabase: string, tar
 		name: INTERNAL_DBIS_NAME,
 		sharedStructuresKey: Symbol.for('structures'),
 	});
+	targetHandles.push(targetDbisDb);
 
 	const STRUCTURES_KEY = Symbol.for('structures');
 	const copyStructures = (sourceDbi, storeName: string, extraTarget?: RocksDatabase) => {
@@ -454,8 +555,11 @@ export async function copyDbToRocks(sourceRootStore, sourceDatabase: string, tar
 	// referencing fileIds whose files were never durably written — exactly the missing-blob-file
 	// state that triggers the base-copy resync wedge in harper#1337.
 	const pendingBlobSaves = beginPendingMigrationBlobSaves();
-	const transaction = sourceDbisDb.useReadTransaction();
+	// Acquired inside the try: if it throws, the finally must still close the target handles so a
+	// staging directory can be removed and its path reopened cleanly (harper#2012).
+	let transaction;
 	try {
+		transaction = sourceDbisDb.useReadTransaction();
 		for (const { key, value: attribute } of sourceDbisDb.getRange({ transaction })) {
 			const isPrimary = attribute.isPrimaryKey;
 			targetDbisDb.put(key, attribute);
@@ -484,8 +588,10 @@ export async function copyDbToRocks(sourceRootStore, sourceDatabase: string, tar
 			let canonicalStructures: any;
 			if (!isPrimary) {
 				targetDbi = openRocksDb(targetPath, { dupSort: true, name: key });
+				targetHandles.push(targetDbi);
 			} else {
 				targetDbi = openRocksDb(targetPath, { name: key });
+				targetHandles.push(targetDbi);
 				// Patch the existing encoder (encoder is a getter-only property on RocksDatabase, cannot be replaced)
 				// to install RecordEncoder's encode method so metadata headers (timestamps, HAS_BLOBS flag) are written
 				const existingEncoder = targetDbi.encoder as any;
@@ -527,7 +633,49 @@ export async function copyDbToRocks(sourceRootStore, sourceDatabase: string, tar
 			copyStructures(sourceDbi, key);
 
 			console.log('migrating', key, 'from', sourceDatabase, 'to RocksDB');
-			await copyDbiToRocks(sourceDbi, targetDbi, isPrimary, transaction, observerEncoder);
+			const copied = await copyDbiToRocks(sourceDbi, targetDbi, isPrimary, transaction, observerEncoder);
+			if (copied?.firstVersioned !== undefined) {
+				const { firstVersioned, versionlessKeys } = copied;
+				// Invariant tripwire (#2012): a versioned record must round-trip with its 8-byte
+				// version prefix. The full big-endian float64 is compared to the source version —
+				// a first-byte check alone is ambiguous, since a prefix-less classic record can
+				// also lead with 0x42 (structure ref id 2). Failing here keeps the migration
+				// incomplete (LMDB source intact, migrateOnStart flag retained) instead of
+				// shipping a database whose records silently lost versions and record prototypes.
+				await firstVersioned.written;
+				await written;
+				const roundTrip = targetDbi.getBinarySync(firstVersioned.key);
+				const roundTripVersion = roundTrip && roundTrip.length >= 8 ? roundTrip.readDoubleBE(0) : undefined;
+				if (roundTripVersion !== firstVersioned.version) {
+					throw new Error(
+						`Migration of ${sourceDatabase} wrote record ${JSON.stringify(firstVersioned.key)} without its ` +
+							`version/metadata prefix (expected version ${firstVersioned.version}, read back ${roundTripVersion}) — ` +
+							`records would lose versions and prototypes`
+					);
+				}
+				// Full verification sweep (harper#2012 ask #3): every migrated record that had a source
+				// version must carry the prefix. Version-less source records are exempted by KEY, not
+				// by byte inspection — a plain classic body can also lead with 0x42 (structure ref
+				// id 2), so byte sniffing could misclassify them and throw spuriously. For versioned
+				// records the first-byte check suffices: a systemic prefix regression trips on the
+				// very first record (and the exact-header tripwire above already validated one).
+				const rawDbi = openRocksDb(targetPath, { name: key, encoding: false });
+				targetHandles.push(rawDbi);
+				let unprefixed = 0;
+				let scanned = 0;
+				for (const { key: recordKey, value } of rawDbi.getRange({})) {
+					if (typeof recordKey === 'symbol') continue;
+					if (versionlessKeys.has(typeof recordKey === 'object' ? JSON.stringify(recordKey) : recordKey)) continue;
+					scanned++;
+					if (!value || value.length < 8 || value[0] !== 0x42) unprefixed++;
+				}
+				if (unprefixed > 0) {
+					throw new Error(
+						`Migration of ${sourceDatabase}/${key} left ${unprefixed} of ${scanned} versioned record(s) without ` +
+							`the version/metadata prefix — records would lose versions and prototypes`
+					);
+				}
+			}
 
 			// Persist the canonical v5 classic structures the observer built, so every v5 runtime worker
 			// adopts one agreed dictionary on startup instead of minting its own from an empty durable and
@@ -591,13 +739,25 @@ export async function copyDbToRocks(sourceRootStore, sourceDatabase: string, tar
 		// later background failure is silently observed instead of crashing the process via
 		// Node's unhandledRejection.
 		for (const saving of pendingBlobSaves) saving.catch(() => {});
-		transaction.done();
-		targetRootStore.close();
+		transaction?.done();
+		// Close every target handle (dbi CFs before the root) so no descriptor holds the DB lock
+		// on this path — required for the caller's staging-directory rename (harper#2012).
+		for (const handle of targetHandles.reverse()) {
+			try {
+				handle.close();
+			} catch (error) {
+				console.error('Error closing migration target store', error);
+			}
+		}
 	}
 
 	async function copyDbiToRocks(sourceDbi, targetDbi, isPrimary, transaction, observerEncoder?) {
 		let recordsCopied = 0;
 		let skippedRecord = 0;
+		let firstVersioned;
+		// keys (normalized for compound keys) of source records with no version, deliberately
+		// encoded plain — the verification sweep exempts them by key, never by byte sniffing
+		const versionlessKeys = new Set();
 		const MAX_RETRIES = 1000;
 		let retries = MAX_RETRIES;
 		let start = null;
@@ -626,18 +786,31 @@ export async function copyDbToRocks(sourceRootStore, sourceDatabase: string, tar
 							// lastMetadata is set by RecordEncoder.decode for unpatched stores;
 							// entry fields are set by handleLocalTimeForGets for patched stores
 							const sourceMeta = lastMetadata;
-							setNextEncoding(
-								version,
-								entryMetadataFlags ?? sourceMeta?.[METADATA] ?? 0,
-								entryExpiresAt ?? sourceMeta?.expiresAt ?? -1,
-								entryNodeId ?? sourceMeta?.nodeId ?? -1,
-								entryResidencyId ?? sourceMeta?.residencyId ?? 0
-							);
+							if (version) {
+								setNextEncoding(
+									version,
+									entryMetadataFlags ?? sourceMeta?.[METADATA] ?? 0,
+									entryExpiresAt ?? sourceMeta?.expiresAt ?? -1,
+									entryNodeId ?? sourceMeta?.nodeId ?? -1,
+									entryResidencyId ?? sourceMeta?.residencyId ?? 0
+								);
+							} else {
+								// A flags-word-only prefix (no leading timestamp) is misparsed by the RocksDB
+								// decode heuristic (8 bytes consumed as a timestamp), so a version-less source
+								// record must be encoded plain; the read path repairs its prototype (#2012).
+								// Cleared even though the plain-encode hook would not consume stale globals:
+								// they may have leaked from a prior record whose encode was skipped or threw.
+								clearNextEncoding();
+								versionlessKeys.add(typeof key === 'object' ? JSON.stringify(key) : key);
+							}
 							written = encodeBlobsWithFilePath(
 								() => targetDbi.put(key, value, version),
 								typeof key === 'number' ? key : recordsCopied,
 								sourceRootStore
 							);
+							// Capture the put promise so the tripwire awaits THIS record's write, not
+							// an ordering assumption about later puts in the batch.
+							if (version) firstVersioned ??= { key, version, written };
 							// Feed only the record's SHAPE to the observer so it accumulates the canonical
 							// classic structure (key list) for this shape; the encoded output is discarded.
 							// A classic/named structure depends only on the keys, so we stub every leaf value
@@ -694,7 +867,7 @@ export async function copyDbToRocks(sourceRootStore, sourceDatabase: string, tar
 					}
 				}
 				console.log('finish migrating, copied', recordsCopied, 'entries, skipped', skippedRecord, 'delete records');
-				return;
+				return { firstVersioned, versionlessKeys };
 			} catch (err) {
 				console.error(
 					`Error iterating dbi for ${sourceDatabase} near key ${JSON.stringify(start)}, retrying (${retries} retries left):`,
@@ -702,11 +875,15 @@ export async function copyDbToRocks(sourceRootStore, sourceDatabase: string, tar
 				);
 				if (typeof start === 'string') {
 					if (start === 'z') {
-						return console.error('Reached end of dbi', start, 'for', sourceDatabase);
+						console.error('Reached end of dbi', start, 'for', sourceDatabase);
+						return;
 					}
 					start = start.slice(0, -2) + 'z';
 				} else if (typeof start === 'number') start++;
-				else return console.error('Unknown key type', start, 'for', sourceDatabase);
+				else {
+					console.error('Unknown key type', start, 'for', sourceDatabase);
+					return;
+				}
 			}
 		}
 		// Fail loudly so migrateOnStart's try/catch preserves the migrateOnStart flag and

--- a/bin/copyDb.ts
+++ b/bin/copyDb.ts
@@ -444,25 +444,32 @@ function countRecords(rawDbi): { records: number; unversioned: number } {
  * the RocksDB lock — run in-process (inspector) on a live instance, or offline.
  */
 export function verifyMigratedDatabase(databasePath: string): Record<string, { records: number; unversioned: number }> {
-	const rootStore = RocksDatabase.open(databasePath, {});
-	const dbisDb = RocksDatabase.open(databasePath, {
-		name: INTERNAL_DBIS_NAME,
-		sharedStructuresKey: Symbol.for('structures'),
-	});
+	// Every open handle, so a failure at any point (e.g. the second open throwing on lock
+	// contention) cannot leak an earlier handle that would hold the RocksDB lock on the very
+	// diagnostic path operators use after a broken migration.
+	const handles: RocksDatabase[] = [];
 	const report: Record<string, { records: number; unversioned: number }> = {};
 	try {
+		handles.push(RocksDatabase.open(databasePath, {}));
+		const dbisDb = RocksDatabase.open(databasePath, {
+			name: INTERNAL_DBIS_NAME,
+			sharedStructuresKey: Symbol.for('structures'),
+		});
+		handles.push(dbisDb);
 		for (const { key, value: attribute } of dbisDb.getRange({})) {
 			if (typeof key === 'symbol' || !attribute?.isPrimaryKey) continue;
 			const rawDbi = RocksDatabase.open(databasePath, { name: key, encoding: false });
-			try {
-				report[key] = countRecords(rawDbi);
-			} finally {
-				rawDbi.close();
-			}
+			handles.push(rawDbi);
+			report[key] = countRecords(rawDbi);
 		}
 	} finally {
-		dbisDb.close();
-		rootStore.close();
+		for (const handle of handles.reverse()) {
+			try {
+				handle.close();
+			} catch (error) {
+				console.error('Error closing verification store', error);
+			}
+		}
 	}
 	return report;
 }

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -158,7 +158,11 @@ export class RecordEncoder extends StructonEncoder {
 		if (!options.randomAccessStructure) this._writeStruct = () => 0;
 		const superEncode = this.encode;
 		this.encode = function (record, options?) {
-			if (!this.useVersions) {
+			// Explicit opt-out only: `this` may be a foreign encoder this hook was grafted onto
+			// (copyDb patches the migration target's plain msgpackr encoder with it), where
+			// useVersions is undefined. Treating undefined as non-versioned silently stripped the
+			// metadata prefix from every LMDB→RocksDB migrated record (harper#2012).
+			if (this.useVersions === false) {
 				// harper#1307: this store does not carry version metadata, so it never prefixes its records.
 				// Encode plainly and LEAVE any in-flight *NextEncoding globals untouched for their real owner:
 				// they belong to a versioned write (recordUpdater staged the primary's metadata and a nested

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -11,7 +11,7 @@ import {
 } from '../dataLayer/harperBridge/lmdbBridge/lmdbUtility/initializePaths.js';
 import { makeTable } from './Table.ts';
 import OpenEnvironmentObject from '../utility/lmdb/OpenEnvironmentObject.ts';
-import { CONFIG_PARAMS, LEGACY_DATABASES_DIR_NAME, DATABASES_DIR_NAME } from '../utility/hdbTerms.ts';
+import { CONFIG_PARAMS, LEGACY_DATABASES_DIR_NAME, DATABASES_DIR_NAME, MIGRATING_DIR_SUFFIX } from '../utility/hdbTerms.ts';
 import { getConfigPath } from '../config/configUtils.ts';
 import { _assignPackageExport } from '../globals.js';
 import { getIndexedValues } from '../utility/lmdb/commonUtility.ts';
@@ -259,6 +259,8 @@ export function getDatabases(): Databases {
 		// First load all the databases from our main database folder
 		// TODO: Load any databases defined with explicit storage paths from the config
 		for (const databaseEntry of readdirSync(databasePath, { withFileTypes: true })) {
+			// in-progress migration staging dirs are not databases until atomically renamed into place
+			if (databaseEntry.name.endsWith(MIGRATING_DIR_SUFFIX)) continue;
 			const dbName = basename(databaseEntry.name, '.mdb');
 			const dbPath = join(databasePath, databaseEntry.name);
 
@@ -318,6 +320,7 @@ export function getDatabases(): Databases {
 			const databasePath = schemaConfig.path;
 			if (existsSync(databasePath)) {
 				for (const databaseEntry of readdirSync(databasePath, { withFileTypes: true })) {
+					if (databaseEntry.name.endsWith(MIGRATING_DIR_SUFFIX)) continue;
 					if (databaseEntry.isFile() && extname(databaseEntry.name).toLowerCase() === '.mdb') {
 						readMetaDb(join(databasePath, databaseEntry.name), basename(databaseEntry.name, '.mdb'), dbName);
 					} else {

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -11,7 +11,12 @@ import {
 } from '../dataLayer/harperBridge/lmdbBridge/lmdbUtility/initializePaths.js';
 import { makeTable } from './Table.ts';
 import OpenEnvironmentObject from '../utility/lmdb/OpenEnvironmentObject.ts';
-import { CONFIG_PARAMS, LEGACY_DATABASES_DIR_NAME, DATABASES_DIR_NAME, MIGRATING_DIR_SUFFIX } from '../utility/hdbTerms.ts';
+import {
+	CONFIG_PARAMS,
+	LEGACY_DATABASES_DIR_NAME,
+	DATABASES_DIR_NAME,
+	MIGRATING_DIR_SUFFIX,
+} from '../utility/hdbTerms.ts';
 import { getConfigPath } from '../config/configUtils.ts';
 import { _assignPackageExport } from '../globals.js';
 import { getIndexedValues } from '../utility/lmdb/commonUtility.ts';

--- a/unitTests/bin/migrationCanonicalStructures.test.js
+++ b/unitTests/bin/migrationCanonicalStructures.test.js
@@ -7,7 +7,7 @@
 // prevention -- needs the runtime's multi-CF open + per-worker encoder wiring, which this single-handle
 // harness can't replicate; that is validated by the cluster repro. See the NOTE on the describe below.)
 const fs = require('fs-extra');
-const assert = require('node:assert/strict');
+const assert = require('node:assert');
 const path = require('path');
 const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
@@ -20,15 +20,18 @@ const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
 // concern: it requires the runtime's multi-column-family open + per-worker encoder wiring, which this
 // single-handle unit harness can't replicate. The observer's captured dictionary is verified in-process
 // during the migration; cross-process adoption is validated by the cluster repro.
-describe('migration: records still decode after the canonical-structures change (#1453)', function () {
-	if ((process.env.HARPER_STORAGE_ENGINE || envGet(CONFIG_PARAMS.STORAGE_ENGINE)) !== 'lmdb') return;
-	const { setupTestDBPath } = require('../testUtils');
-	const copyDB = require('#src/bin/copyDb');
-	const { RocksDatabase } = require('@harperfast/rocksdb-js');
+const { setupTestDBPath } = require('../testUtils');
+const copyDB = require('#src/bin/copyDb');
+const { RocksDatabase } = require('@harperfast/rocksdb-js');
 
+const isLMDB = (process.env.HARPER_STORAGE_ENGINE || envGet(CONFIG_PARAMS.STORAGE_ENGINE)) === 'lmdb';
+
+describe('migration: records still decode after the canonical-structures change (#1453)', function () {
 	let rootPath, targetPath, Tbl;
 
 	before(async function () {
+		// this.skip() (not a bare return in the describe body) so the gate is visible as pending
+		if (!isLMDB) return this.skip();
 		rootPath = setupTestDBPath();
 		setMainIsWorker(true);
 		Tbl = table({
@@ -47,27 +50,37 @@ describe('migration: records still decode after the canonical-structures change 
 	});
 
 	after(async function () {
-		await fs.remove(path.join(rootPath, 'rocks-migrated-cstruct'));
+		if (rootPath) await fs.remove(path.join(rootPath, 'rocks-migrated-cstruct'));
 	});
 
 	it('migrated records decode after reopen (structures resolve)', function () {
 		// Open the migrated primary CF the same way the v5 runtime would and read records back.
 		// With the canonical structures persisted, every migrated record (including the bare
 		// structure-id references after the first of each shape) must decode, not null out.
-		const cf = RocksDatabase.open(targetPath, { name: 'CacheStruct/', sharedStructuresKey: Symbol.for('structures') });
+		// RecordEncoder is required since #2012: migrated records carry the version/metadata
+		// prefix again, which a plain msgpackr decoder cannot strip. (v5.1 has no
+		// PrimaryRocksDatabase; decode returns the metadata wrapper { value, version, ... }.)
+		const { RecordEncoder } = require('#src/resources/RecordEncoder');
+		const cf = RocksDatabase.open(targetPath, {
+			name: 'CacheStruct/',
+			sharedStructuresKey: Symbol.for('structures'),
+			encoder: { Encoder: RecordEncoder },
+		});
+		cf.encoder.isRocksDB = true;
 		try {
 			const failures = [];
 			for (const id of ['a', 'b', 'c']) {
 				let rec;
 				try {
-					rec = cf.get(id);
+					const decoded = cf.encoder.decode(cf.getBinarySync(id));
+					rec = decoded?.value ?? decoded;
 				} catch (e) {
 					rec = { __threw: e.message };
 				}
 				console.log(`record ${id}:`, JSON.stringify(rec));
 				if (!rec || rec.__threw || rec.content === undefined || rec.headers === undefined) failures.push(id);
 			}
-			assert.equal(
+			assert.strictEqual(
 				failures.length,
 				0,
 				`migrated records ${failures.join(',')} did not decode after reopen (structures did not resolve)`

--- a/unitTests/bin/migrationMetadataPrefix.test.js
+++ b/unitTests/bin/migrationMetadataPrefix.test.js
@@ -1,0 +1,85 @@
+// Regression guard for HarperFast/harper#2012: the LMDB→RocksDB migration must write each
+// record with the [8-byte version][flags word] metadata prefix. The #1307 opt-out guard read
+// `this.useVersions` off the migration target's plain msgpackr encoder (undefined), so every
+// migrated record was stored prefix-less: no version, and point reads returned prototype-less
+// plain objects (scans repaired the prototype, hiding it from search-based tests).
+const fs = require('fs-extra');
+const assert = require('node:assert');
+const path = require('path');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const { get: envGet } = require('#src/utility/environment/environmentManager');
+const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
+
+const { setupTestDBPath } = require('../testUtils');
+const copyDB = require('#src/bin/copyDb');
+const { RocksDatabase } = require('@harperfast/rocksdb-js');
+const { RecordEncoder } = require('#src/resources/RecordEncoder');
+
+const isLMDB = (process.env.HARPER_STORAGE_ENGINE || envGet(CONFIG_PARAMS.STORAGE_ENGINE)) === 'lmdb';
+
+describe('migration: records carry the version/metadata prefix (#2012)', function () {
+	let rootPath, targetPath, Tbl;
+	const sourceVersions = new Map();
+
+	before(async function () {
+		// this.skip() (not a bare return in the describe body) so the gate is visible as pending
+		if (!isLMDB) return this.skip();
+		rootPath = setupTestDBPath();
+		setMainIsWorker(true);
+		Tbl = table({
+			table: 'PrefixGuard',
+			database: 'pgtest',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }, { name: 'rank' }],
+		});
+		await Tbl.put({ id: 'a', name: 'alpha', rank: 1 });
+		await Tbl.put({ id: 'b', name: 'beta', rank: 2 });
+		await Tbl.put({ id: 'c', name: 'gamma', rank: 3 });
+		for (const id of ['a', 'b', 'c']) {
+			sourceVersions.set(id, Tbl.primaryStore.getEntry(id).version);
+		}
+
+		targetPath = path.join(rootPath, 'rocks-migrated-prefix', 'pgtest');
+		await fs.remove(targetPath);
+		await copyDB.copyDbToRocks(Tbl.primaryStore.rootStore, 'pgtest', targetPath);
+	});
+
+	after(async function () {
+		if (rootPath) await fs.remove(path.join(rootPath, 'rocks-migrated-prefix'));
+	});
+
+	it('migrated record bytes start with the 8-byte version prefix', function () {
+		const cf = RocksDatabase.open(targetPath, { name: 'PrefixGuard/', encoding: false });
+		try {
+			for (const id of ['a', 'b', 'c']) {
+				const raw = cf.getBinarySync(id);
+				assert(raw, `record ${id} missing from migrated CF`);
+				// float64 of a current-era ms timestamp starts with 0x42
+				assert.strictEqual(raw[0], 0x42, `record ${id} first byte ${raw[0]} — metadata prefix missing`);
+			}
+		} finally {
+			cf.close();
+		}
+	});
+
+	it('migrated records decode with fields and source version via the runtime record decoder', function () {
+		// v5.1 has no PrimaryRocksDatabase; the runtime reads through RecordEncoder.decode, which
+		// returns a metadata wrapper { value, version, ... } for prefixed records.
+		const cf = RocksDatabase.open(targetPath, {
+			name: 'PrefixGuard/',
+			encoder: { Encoder: RecordEncoder },
+			sharedStructuresKey: Symbol.for('structures'),
+		});
+		cf.encoder.isRocksDB = true;
+		try {
+			for (const id of ['a', 'b', 'c']) {
+				const decoded = cf.encoder.decode(cf.getBinarySync(id));
+				assert(decoded?.value, `record ${id} did not decode to a metadata wrapper (prefix missing)`);
+				assert.strictEqual(decoded.value.name, { a: 'alpha', b: 'beta', c: 'gamma' }[id]);
+				assert.strictEqual(decoded.version, sourceVersions.get(id), `record ${id} lost its source version`);
+			}
+		} finally {
+			cf.close();
+		}
+	});
+});

--- a/unitTests/bin/migrationStagingRecovery.test.js
+++ b/unitTests/bin/migrationStagingRecovery.test.js
@@ -1,0 +1,122 @@
+// Restart-safety guards for the staged LMDB→RocksDB migration (harper#2012 review):
+// a failed migration must never leave a partial RocksDB at the database's real path, because on
+// the next boot both <db>.mdb and <db>/ are discovered and whichever binds last wins — a partial
+// RocksDB that wins gets promoted (flag cleared) while the intact LMDB is abandoned. The
+// migration therefore stages into <db>.migrating (excluded from discovery) and atomically
+// renames after verification, replacing any stale artifact at the real path.
+const fs = require('fs-extra');
+const assert = require('node:assert');
+const path = require('path');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const { get: envGet } = require('#src/utility/environment/environmentManager');
+const { CONFIG_PARAMS, MIGRATING_DIR_SUFFIX } = require('#src/utility/hdbTerms');
+const { setupTestDBPath } = require('../testUtils');
+const copyDB = require('#src/bin/copyDb');
+const { RocksDatabase } = require('@harperfast/rocksdb-js');
+const { RecordEncoder } = require('#src/resources/RecordEncoder');
+
+const isLMDB = (process.env.HARPER_STORAGE_ENGINE || envGet(CONFIG_PARAMS.STORAGE_ENGINE)) === 'lmdb';
+
+describe('migration: staging directory recovery (#2012)', function () {
+	let rootPath, baseDir, targetPath, stagingPath, Tbl;
+
+	before(async function () {
+		// this.skip() (not a bare return in the describe body) so the gate is visible as pending
+		if (!isLMDB) return this.skip();
+		rootPath = setupTestDBPath();
+		setMainIsWorker(true);
+		Tbl = table({
+			table: 'StagedRec',
+			database: 'stagetest',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+		});
+		await Tbl.put({ id: 'a', name: 'alpha' });
+		await Tbl.put({ id: 'b', name: 'beta' });
+
+		baseDir = path.join(rootPath, 'rocks-staging-recovery');
+		targetPath = path.join(baseDir, 'stagetest');
+		stagingPath = targetPath + MIGRATING_DIR_SUFFIX;
+		await fs.remove(baseDir);
+	});
+
+	after(async function () {
+		if (baseDir) await fs.remove(baseDir);
+	});
+
+	it('a failed migration removes its staging dir and leaves no artifact at the target path', async function () {
+		// A source whose dbi iteration throws immediately — the staging dir is created before the
+		// copy loop starts, so the catch path must clean it up and leave targetPath absent.
+		const brokenSource = {
+			dbisDb: {
+				useReadTransaction() {
+					throw new Error('injected migration failure');
+				},
+			},
+		};
+		await assert.rejects(
+			() => copyDB.migrateDatabaseToRocks(brokenSource, 'stagetest', targetPath),
+			/injected migration failure/
+		);
+		assert.strictEqual(fs.existsSync(stagingPath), false, 'staging dir must be removed on failure');
+		assert.strictEqual(fs.existsSync(targetPath), false, 'no artifact may appear at the target path on failure');
+		// the LMDB source is untouched and still serves reads
+		assert.strictEqual((await Tbl.get('a')).name, 'alpha');
+	});
+
+	it('promotion replaces stale staging and a stale partial RocksDB at the target path', async function () {
+		// Simulate the "both artifacts present after an interrupted run" restart state: a junk
+		// leftover staging dir AND a partial (unreadable) RocksDB already at the real path.
+		await fs.outputFile(path.join(stagingPath, 'junk'), 'stale staging from a failed attempt');
+		await fs.outputFile(path.join(targetPath, 'CURRENT'), 'MANIFEST-000001\n');
+		await fs.outputFile(path.join(targetPath, 'MANIFEST-000001'), 'partial');
+
+		await copyDB.migrateDatabaseToRocks(Tbl.primaryStore.rootStore, 'stagetest', targetPath);
+
+		assert.strictEqual(fs.existsSync(stagingPath), false, 'staging dir must not survive promotion');
+
+		// Opening the renamed directory also guards the close-all-handles contract: a handle
+		// leaked on the staging path would still hold the RocksDB LOCK for this store.
+		const cf = RocksDatabase.open(targetPath, {
+			name: 'StagedRec/',
+			encoder: { Encoder: RecordEncoder },
+			sharedStructuresKey: Symbol.for('structures'),
+		});
+		cf.encoder.isRocksDB = true;
+		try {
+			for (const id of ['a', 'b']) {
+				const decoded = cf.encoder.decode(cf.getBinarySync(id));
+				assert(decoded?.value, `record ${id} missing after promotion`);
+				assert(decoded.version > 0, `record ${id} lost its version`);
+			}
+		} finally {
+			cf.close();
+		}
+	});
+
+	it('verifyMigratedDatabase reports zero unversioned records for a clean migration', function () {
+		const report = copyDB.verifyMigratedDatabase(targetPath);
+		assert.deepStrictEqual(report['StagedRec/'], { records: 2, unversioned: 0 });
+	});
+
+	it('database discovery ignores *.migrating staging directories', async function () {
+		const { getDatabases, resetDatabases } = require('#src/resources/databases');
+		const databasesDir = path.join(rootPath, 'database');
+		const ghostDir = path.join(databasesDir, 'ghost' + MIGRATING_DIR_SUFFIX);
+		// Rocks markers that would otherwise make discovery open it as a database
+		await fs.outputFile(path.join(ghostDir, 'CURRENT'), 'MANIFEST-000001\n');
+		await fs.outputFile(path.join(ghostDir, 'MANIFEST-000001'), 'partial');
+		try {
+			resetDatabases();
+			const databases = getDatabases();
+			assert.strictEqual(
+				databases['ghost' + MIGRATING_DIR_SUFFIX],
+				undefined,
+				'staging dir must not be discovered as a database'
+			);
+		} finally {
+			await fs.remove(ghostDir);
+			resetDatabases();
+		}
+	});
+});

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -129,6 +129,9 @@ export const HDB_FILE_PERMISSIONS = 0o700;
 
 /** Database directory */
 export const DATABASES_DIR_NAME = 'database';
+/** Suffix for in-progress LMDB→RocksDB migration staging directories: excluded from database
+ * discovery, atomically renamed into place only after the migration fully verifies (harper#2012) */
+export const MIGRATING_DIR_SUFFIX = '.migrating';
 /** Legacy Database directory */
 export const LEGACY_DATABASES_DIR_NAME = 'schema';
 /** Transaction directory */


### PR DESCRIPTION
Manual v5.1 backport of #2014 (fixes the v5.1 exposure of #2012). The v5.1 line is affected from **v5.1.2** — #1307 shipped in it the same day it merged — so every `storage.migrateOnStart` run on v5.1.2–v5.1.23 wrote records without the `[8-byte version][flags word]` prefix, silently dropping record versions. Empirically confirmed by @heskew on 5.1.23 and by ancestry check ([details](https://github.com/HarperFast/harper/issues/2012#issuecomment-5138392320)).

**Why v5.1 instances look healthy:** this branch has no `PrimaryRocksDatabase`; the `handleLocalTimeForGets` wrapper repairs record prototypes unconditionally on point reads, so affected instances read correctly and only lose versions (cache admission, `ifVersion`/CAS, replication version comparisons). The invisible-records symptom fires when they upgrade to 5.2 — so shipping this in 5.1 stops new damage, and `verifyMigratedDatabase` identifies instances needing the rewrite pass before any 5.2 upgrade.

## Variant differences from #2014 (main)

- **Dropped:** the `resources/PrimaryRocksDatabase.ts` read-side changes and `unitTests/resources/primaryRocksMetadataRepair.test.js` — the file doesn't exist on v5.1 and the wrapper already repairs unconditionally.
- **Adapted:** the migration tests verify via `RecordEncoder.decode` metadata wrappers (`{ value, version }`) instead of `PrimaryRocksDatabase` point reads.
- **Ported unchanged:** `copyDb.ts` wholesale (byte-identical base pre-fix): explicit `useVersions === false` opt-out in the RecordEncoder encode hook, staged migration (`<db>.migrating` + atomic rename + close-all-handles + Windows rename retry), exact-header tripwire, key-exempted full verification sweep, `verifyMigratedDatabase` export, discovery exclusion of `*.migrating` dirs, `MIGRATING_DIR_SUFFIX` in hdbTerms.

## Tests

`unitTests/bin/migration*.test.js`: 7 passing under `HARPER_STORAGE_ENGINE=lmdb`, 7 pending (visible skip) under rocks; full lmdb bin suite 69 passing locally. Note: local run used a newer rocksdb-js than the branch lockfile (shared node_modules) — CI arbitrates against the real pin.

All review findings from #2014 (Codex tripwire ambiguity, kriszyp staging restart-safety, heskew verification gaps, cb1kenobi sweep byte-sniffing) are incorporated since this ports the final state.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)