### PR TITLE
test(uws): fix macOS EPIPE flake in the UDS 413 test

### DIFF
--- a/unitTests/server/serverHelpers/uwsServer.test.js
+++ b/unitTests/server/serverHelpers/uwsServer.test.js
@@ -34,13 +34,74 @@ try {
 }
 
 // Issue an HTTP/1.1 request over a Unix domain socket and collect the full response.
+//
+// A server that responds early (e.g. 413 for an over-limit body) is allowed to close the connection
+// before the client has finished flushing the request body — correct per HTTP, but it races the
+// client's outstanding write against the close. Node's http client normally forwards any socket error
+// straight to `req`'s own 'error' event — except for the specific window right after a keep-alive
+// response finishes, where the client detaches its listener before handing the socket back to the
+// agent's free-connection pool and reattaching one (`responseKeepAlive` in Node's `_http_client.js`,
+// which has its own upstream `// TODO(ronag): ... the socket has no 'error' handler` comment on exactly
+// this gap). A write that fails in that window is unhandled and becomes an uncaught exception
+// attributed to whichever test happens to be running — that's the macOS flake this helper exists to
+// close. `agent: false` below is therefore the primary fix: without connection pooling, the gap window
+// never opens. The socket-level listener is retained as a second layer, in case an equivalent
+// unhandled-window exists on a platform/libuv path this can't be verified against from Linux.
+//
+// Settles exactly once, from whichever channel gets there first:
+//   - `req`'s own 'error' event, for as long as the request is attached to its socket (covers
+//     everything that can happen before or during a normal response, including a pre-response
+//     failure like a missing socket path).
+//   - a socket-level 'error' listener, described above. EPIPE/ECONNRESET are exactly the expected
+//     shape of the write-vs-close race and are swallowed once the promise has settled; a sibling
+//     delivery of the same event that already settled the promise a moment earlier is a no-op, so
+//     this can't double-fire for a single error. An unrelated error arriving after settlement can't
+//     reject an already-settled promise either way, so it's unavoidably absorbed — logged via
+//     udsRequestWarnings (asserted empty in this file's `after`) rather than disappearing silently.
+//   - `req`'s 'close' event, if the connection closes without either of the above (e.g. the server
+//     commits headers and then aborts mid-body) — otherwise that would hang until Mocha's timeout.
+//
+// Uses a fresh connection per call (`agent: false`) rather than Node's default keep-alive pooling, both
+// for the reason above and because this file issues many requests against the same socketPath, and a
+// shared pooled socket would carry the socket listener across requests and accumulate one per call.
+// Errors udsRequest couldn't fail the promise with because it arrived after settlement — see the
+// helper's docblock. Asserted empty in this file's `after`, so a genuinely broken transport still
+// fails the run instead of scrolling past as a log line nobody reads.
+const udsRequestWarnings = [];
+
 function udsRequest(socketPath, { method = 'GET', pathName = '/', headers = {}, body } = {}) {
 	return new Promise((resolve, reject) => {
-		const req = http.request({ socketPath, method, path: pathName, headers }, (res) => {
+		let settled = false;
+		// Node's own socket-error forwarding to `req` always runs before our 'socket' listener below sees
+		// the same event (both fire synchronously within one 'error' emission), so an ordinary pre-response
+		// failure settles the promise via `req.on('error')` a moment before our listener also observes it —
+		// that's an echo of an event already handled, not a new one. `settledThisTick` distinguishes that
+		// from a genuinely late arrival (the queued microtask clears it once the current synchronous
+		// dispatch is done), so only the latter is worth logging.
+		let settledThisTick = false;
+		const settleResolve = (value) => {
+			if (settled) return;
+			settled = true;
+			settledThisTick = true;
+			queueMicrotask(() => {
+				settledThisTick = false;
+			});
+			resolve(value);
+		};
+		const settleReject = (err) => {
+			if (settled) return;
+			settled = true;
+			settledThisTick = true;
+			queueMicrotask(() => {
+				settledThisTick = false;
+			});
+			reject(err);
+		};
+		const req = http.request({ socketPath, method, path: pathName, headers, agent: false }, (res) => {
 			const chunks = [];
 			res.on('data', (c) => chunks.push(c));
 			res.on('end', () =>
-				resolve({
+				settleResolve({
 					status: res.statusCode,
 					statusMessage: res.statusMessage,
 					headers: res.headers,
@@ -48,7 +109,22 @@ function udsRequest(socketPath, { method = 'GET', pathName = '/', headers = {}, 
 				})
 			);
 		});
-		req.on('error', reject);
+		req.on('socket', (socket) => {
+			socket.on('error', (err) => {
+				if (settled) {
+					if (!settledThisTick && err.code !== 'EPIPE' && err.code !== 'ECONNRESET') {
+						udsRequestWarnings.push(err);
+					}
+					return;
+				}
+				if (err.code === 'EPIPE' || err.code === 'ECONNRESET') return;
+				settleReject(err);
+			});
+		});
+		req.on('error', settleReject);
+		req.once('close', () => {
+			if (!settled) settleReject(new Error('connection closed before response completed'));
+		});
 		if (body) req.write(body);
 		req.end();
 	});
@@ -130,6 +206,7 @@ function readBody(request) {
 				/* best effort */
 			}
 		}
+		assert.deepStrictEqual(udsRequestWarnings, [], 'udsRequest saw an unexpected post-settlement socket error');
 	});
 
 	it('serves a bodyless GET', async function () {
@@ -200,6 +277,14 @@ function readBody(request) {
 		}
 	});
 
+	it('rejects with the underlying error when the connection fails before any response', async function () {
+		const missingSocket = path.join(os.tmpdir(), `uws-no-such-socket-${process.pid}.sock`);
+		await assert.rejects(udsRequest(missingSocket, { pathName: '/' }), (err) => {
+			assert.strictEqual(err.code, 'ENOENT');
+			return true;
+		});
+	});
+
 	it('rejects a body over maxBodyBytes with 413', async function () {
 		const overLimitSocket = path.join(os.tmpdir(), `uws-413-test-${process.pid}.sock`);
 		if (fs.existsSync(overLimitSocket)) fs.unlinkSync(overLimitSocket);
@@ -209,6 +294,9 @@ function readBody(request) {
 			handler: async (request) => ({ status: 200, body: await readBody(request) }),
 		});
 		try {
+			// A real over-limit upload is always this shape: production's default maxBodyBytes is 100 MiB
+			// (server/serverHelpers/uwsServer.ts), so every 413 in practice happens while the client still
+			// has bytes queued to send — the write-vs-close race udsRequest is built to tolerate.
 			const res = await udsRequest(overLimitSocket, {
 				method: 'POST',
 				pathName: '/echo',


### PR DESCRIPTION
## What / why

`uWS UDS adapter (createUwsServer) rejects a body over maxBodyBytes with 413` flaked on macOS: the 413 assertion passed, but an uncaught `EPIPE` landed afterward and mocha attributed it to the test, failing the run (green on Linux CI).

Root cause: the server correctly responds 413 and closes early without draining the rest of an over-limit body. The client's outstanding write can still be in flight when the socket closes, and Node's http client stops forwarding socket errors to the request in the window right after a keep-alive response completes (`responseKeepAlive` in Node's own `_http_client.js`, which carries an upstream `// TODO(ronag): ... the socket has no 'error' handler` comment on exactly this gap) — so the late write failure becomes an uncaught exception with nothing listening.

Confirmed this reproduces on Linux too, not just inferred as macOS-only: against the real `createUwsServer`, the pre-fix helper rejects with a raw `EPIPE` on roughly half of 40 trials using the test's existing 8KB-body/1KB-cap fixture (no artificial size inflation needed). With the fix, 40/40 resolve cleanly to 413.

Fix (in the shared `udsRequest` test helper, so it protects every test in the file, not just the 413 case):
- `agent: false` per request — the primary fix, avoids the pooled-connection gap entirely.
- A socket-level `error` listener as a second layer, tolerating only `EPIPE`/`ECONNRESET`; a `settledThisTick` flag distinguishes Node's synchronous same-event echo (already handled via `req`'s own forwarding) from a genuinely late arrival worth recording. Anything else post-settlement is collected and asserted empty in `after()`, rather than silently absorbed.
- Reject on `close` if the promise never settled, so a truncated response fails with a diagnosable error instead of hanging to Mocha's timeout.
- A new test for a connection failure before any response.

No changes to `server/serverHelpers/uwsServer.ts` — the server's behavior (respond early, don't drain an over-limit body) is correct per HTTP and is preserved untouched.

## Verification

- `npx mocha unitTests/server/serverHelpers/uwsServer.test.js`: 21/21 passing, stable across repeated runs, no `MaxListenersExceededWarning`.
- Broader `unitTests/server/**/*.test.js`: 679 passing.
- Confirmed the 413 assertion is still genuine: temporarily disabled the server's over-limit check and the test correctly failed (`200 !== 413`), then reverted.
- Confirmed the fix's necessity and sufficiency directly against the real server (not just the synthetic race description): pre-fix ~50% raw-EPIPE rejection rate at the test's exact fixture size; post-fix 40/40 clean.

## Review

Nine rounds of independent pre-push review (Codex/Gemini/Grok + a Harper-domain pass) drove the final design — several earlier iterations each reintroduced a variant of the exact duplicate-error/uncaught-exception bug this change removes (a competing listener installed too early causing double delivery, then a module-global listener-ownership slot that orphaned a socket when the file's second UDS connection was opened). Final round: verdict LGTM (Codex), no findings from Grok; Gemini's remaining concern (pre-response EPIPE could still defeat the fix) was tested directly against the real server and did not reproduce in 60 combined trials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)