### PR TITLE
fix(threads): worker threads must inherit the parent's in-process config overrides

### DIFF
--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -704,7 +704,7 @@ export function updateConfigObject(param: string, value: any) {
 	// configObj's falsiness as "not yet initialized" and lazily calls initConfig(), so creating
 	// an empty configObj here (before install writes the config file / initConfig ever runs)
 	// would permanently short-circuit that lazy init to an empty tree.
-	if (configObj !== undefined && !NON_NESTED_CONFIG_PARAMS.has(configObjKey)) {
+	if (configObj != null && !NON_NESTED_CONFIG_PARAMS.has(configObjKey)) {
 		const pathSegments = configObjKey.split('_');
 		let node = configObj;
 		for (let i = 0; i < pathSegments.length - 1; i++) {

--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -50,6 +50,14 @@ let flatDefaultConfigObj;
 let flatConfigObj;
 let configObj;
 
+// Canonical param names that live in CONFIG_PARAM_MAP but do NOT correspond to a path in the
+// harper-config.yaml schema (BOOT_PROP_PARAMS is boot-props-file-only bookkeeping — see its own
+// comment). Splitting one of these on '_' and writing it into the nested configObj tree would
+// silently create a bogus top-level section (e.g. 'settings_path' -> configObj.settings.path),
+// which componentLoader.ts treats as a real component to load, since it iterates every truthy
+// top-level key of the root config.
+const NON_NESTED_CONFIG_PARAMS = new Set<string>(Object.values(hdbTerms.BOOT_PROP_PARAMS));
+
 export function resolvePath(relativePath: string) {
 	if (relativePath?.startsWith('~/')) {
 		return path.join(hdbUtils.getHomeDir(), relativePath.slice(1));
@@ -696,16 +704,23 @@ export function updateConfigObject(param: string, value: any) {
 	// configObj's falsiness as "not yet initialized" and lazily calls initConfig(), so creating
 	// an empty configObj here (before install writes the config file / initConfig ever runs)
 	// would permanently short-circuit that lazy init to an empty tree.
-	if (configObj !== undefined) {
+	if (configObj !== undefined && !NON_NESTED_CONFIG_PARAMS.has(configObjKey)) {
 		const pathSegments = configObjKey.split('_');
 		let node = configObj;
 		for (let i = 0; i < pathSegments.length - 1; i++) {
 			const segment = pathSegments[i];
-			// Only auto-vivify a missing segment. An existing non-object value here is a legacy
-			// scalar shorthand for this key (e.g. `threads: 4`) — descending through it would
-			// silently replace that value with `{}`, discarding it out from under other readers.
-			if (node[segment] === undefined) node[segment] = {};
-			else if (typeof node[segment] !== 'object' || node[segment] === null) return;
+			if (node[segment] === undefined) {
+				// Nothing to delete on a path section that doesn't exist yet — and auto-vivifying it
+				// just to immediately delete the leaf would leave the (now-empty) intermediate
+				// objects behind, which is exactly the bogus-top-level-section risk above.
+				if (value === undefined) return;
+				node[segment] = {};
+			} else if (typeof node[segment] !== 'object' || node[segment] === null) {
+				// An existing non-object value here is a legacy scalar shorthand for this key (e.g.
+				// `threads: 4`) — descending through it would silently replace that value with `{}`,
+				// discarding it out from under other readers.
+				return;
+			}
 			node = node[segment];
 		}
 		// Match squashObj's own convention (below) of never writing an `undefined` value as an

--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -198,8 +198,7 @@ export function createConfigFile(args, skipFsValidation = false) {
 	// Validates config doc and if required sets default values for some parameters.
 	validateConfig(configDoc, skipFsValidation);
 
-	const configObj = configDoc.toJSON();
-	flatConfigObj = flattenConfig(configObj);
+	flatConfigObj = setActiveConfig(configDoc.toJSON());
 
 	// Create new config file and write config doc to it.
 	const hdbRoot = configDoc.getIn(['rootPath']) as string;
@@ -505,9 +504,9 @@ export function initConfig(force = false) {
 
 		// Validates config doc and if required sets default values for some parameters.
 		validateConfig(configDoc);
-		const configObj = configDoc.toJSON();
-		(server as any).config = configObj;
-		flatConfigObj = flattenConfig(configObj);
+		const parsedConfig = configDoc.toJSON();
+		(server as any).config = parsedConfig;
+		flatConfigObj = setActiveConfig(parsedConfig);
 
 		// If config has old version of logrotate enabled let user know it has been deprecated.
 		if (flatConfigObj['logging_rotation_rotate']) {
@@ -700,10 +699,11 @@ export function updateConfigObject(param: string, value: any) {
 	// nested-path readers derive behavior — e.g. a component's network port/protocol — from
 	// getConfigObj()'s tree, not the flattened map, so an override that only touched
 	// flatConfigObj was invisible to them (the on-disk shape kept winning regardless of
-	// setProperty()). Only mirror once a real config has been loaded — getConfigObj() treats
-	// configObj's falsiness as "not yet initialized" and lazily calls initConfig(), so creating
-	// an empty configObj here (before install writes the config file / initConfig ever runs)
-	// would permanently short-circuit that lazy init to an empty tree.
+	// setProperty()). configObj is null/undefined only before a live config has ever been
+	// installed (setActiveConfig) — during install, before the config file is written. Don't
+	// auto-vivify it here: getConfigObj() treats configObj's falsiness as "not yet initialized"
+	// and lazily calls initConfig(), so an empty object here would permanently short-circuit
+	// that lazy init to an empty tree.
 	if (configObj != null && !NON_NESTED_CONFIG_PARAMS.has(configObjKey)) {
 		const pathSegments = configObjKey.split('_');
 		let node = configObj;
@@ -895,7 +895,7 @@ export function updateConfigValue(
 	}
 	atomicWriteFile(configFileLocation, String(configDoc));
 	if (update_config_obj) {
-		flatConfigObj = flattenConfig(configDoc.toJSON());
+		flatConfigObj = setActiveConfig(configDoc.toJSON());
 	}
 	logger.trace(`Config parameter: ${param} updated with value: ${value}`);
 }
@@ -914,9 +914,28 @@ function backupConfigFile(configPath, hdbRoot) {
 	}
 }
 
+/**
+ * Flattens `obj` and installs it as the live config: the nested tree getConfigObj() hands out and
+ * updateConfigObject() mirrors overrides into, alongside the flat map returned here.
+ *
+ * Only the three callers that own the live config may do this. flattenConfig() also runs on
+ * throwaway docs — the defaults doc in getDefaultConfig()/createConfigFile(), and the user-supplied
+ * doc installer.ts reads for HDB_CONFIG — so setting configObj as a side effect of flattening left
+ * it pointing at a tree that was discarded moments later, which is indistinguishable from the live
+ * tree to every reader of configObj.
+ * @param obj
+ * @returns the flattened config
+ */
+function setActiveConfig(obj) {
+	const flatObj = flattenConfig(obj);
+	configObj = obj;
+	return flatObj;
+}
+
 const PRESERVED_PROPERTIES = ['databases'];
 /**
  * Flattens the JSON version of Harper config with underscores separating each parent/child key.
+ * Does NOT install `obj` as the live config — see setActiveConfig() for that.
  * @param obj
  * @returns {null}
  */
@@ -925,10 +944,7 @@ export function flattenConfig(obj) {
 	if (obj?.operationsApi?.network) obj.operationsApi.network = { ...obj.http, ...obj.operationsApi.network };
 	if (obj?.operationsApi) obj.operationsApi.tls = { ...obj.tls, ...obj.operationsApi.tls };
 
-	configObj = obj;
-	const flatObj = squashObj(obj);
-
-	return flatObj;
+	return squashObj(obj);
 
 	function squashObj(obj) {
 		let result = {};

--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -695,37 +695,36 @@ export function updateConfigObject(param: string, value: any) {
 
 	flatConfigObj[configObjKey.toLowerCase()] = value;
 
-	// Keep the nested config tree in sync too. componentLoader (root components) and other
+	// Keep the nested config tree in sync too: componentLoader (root components) and other
 	// nested-path readers derive behavior — e.g. a component's network port/protocol — from
-	// getConfigObj()'s tree, not the flattened map, so an override that only touched
-	// flatConfigObj was invisible to them (the on-disk shape kept winning regardless of
-	// setProperty()). configObj is null/undefined only before a live config has ever been
-	// installed (setActiveConfig) — during install, before the config file is written. Don't
-	// auto-vivify it here: getConfigObj() treats configObj's falsiness as "not yet initialized"
-	// and lazily calls initConfig(), so an empty object here would permanently short-circuit
-	// that lazy init to an empty tree.
+	// getConfigObj()'s tree, not the flattened map, so an override that only touched flatConfigObj
+	// was invisible to them. configObj is unset only before a live config has ever been installed
+	// (setActiveConfig), i.e. during install; don't auto-vivify it, since getConfigObj() reads its
+	// falsiness as "not yet initialized" and an empty object would short-circuit that lazy init
+	// permanently.
 	if (configObj != null && !NON_NESTED_CONFIG_PARAMS.has(configObjKey)) {
 		const pathSegments = configObjKey.split('_');
 		let node = configObj;
 		for (let i = 0; i < pathSegments.length - 1; i++) {
 			const segment = pathSegments[i];
 			if (node[segment] === undefined) {
-				// Nothing to delete on a path section that doesn't exist yet — and auto-vivifying it
-				// just to immediately delete the leaf would leave the (now-empty) intermediate
-				// objects behind, which is exactly the bogus-top-level-section risk above.
+				// Auto-vivifying ancestors only to delete the leaf would leave empty sections behind,
+				// which componentLoader.ts would treat as components to load.
 				if (value === undefined) return;
 				node[segment] = {};
 			} else if (typeof node[segment] !== 'object' || node[segment] === null) {
-				// An existing non-object value here is a legacy scalar shorthand for this key (e.g.
-				// `threads: 4`) — descending through it would silently replace that value with `{}`,
-				// discarding it out from under other readers.
+				// A legacy scalar shorthand for this key (e.g. `threads: 4`); descending would replace
+				// it with {} out from under other readers. Leaves the two views disagreeing on this
+				// param, so say so rather than diverging silently.
+				logger.trace(
+					`Config param '${configObjKey}' not mirrored into the nested config: '${segment}' holds a scalar value`
+				);
 				return;
 			}
 			node = node[segment];
 		}
-		// Match squashObj's own convention (below) of never writing an `undefined` value as an
-		// enumerable key: several root-config readers (e.g. bin/run.ts) iterate configObj's own
-		// keys and assume every one holds a real value.
+		// squashObj never writes an undefined value as an enumerable key either; root-config readers
+		// (e.g. bin/run.ts) iterate configObj's own keys and assume every one holds a real value.
 		const leaf = pathSegments[pathSegments.length - 1];
 		if (value === undefined) delete node[leaf];
 		else node[leaf] = value;
@@ -915,14 +914,11 @@ function backupConfigFile(configPath, hdbRoot) {
 }
 
 /**
- * Flattens `obj` and installs it as the live config: the nested tree getConfigObj() hands out and
- * updateConfigObject() mirrors overrides into, alongside the flat map returned here.
- *
- * Only the three callers that own the live config may do this. flattenConfig() also runs on
- * throwaway docs — the defaults doc in getDefaultConfig()/createConfigFile(), and the user-supplied
- * doc installer.ts reads for HDB_CONFIG — so setting configObj as a side effect of flattening left
- * it pointing at a tree that was discarded moments later, which is indistinguishable from the live
- * tree to every reader of configObj.
+ * Flattens `obj` and installs it as the live config — the nested tree getConfigObj() hands out and
+ * updateConfigObject() mirrors overrides into. Only callers that own the live config may do this:
+ * flattenConfig() also runs on docs that are discarded moments later (the defaults doc, the
+ * user-supplied doc installer.ts reads for HDB_CONFIG), and no reader of configObj can tell one of
+ * those from the real thing.
  * @param obj
  * @returns the flattened config
  */

--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -692,16 +692,24 @@ export function updateConfigObject(param: string, value: any) {
 	// nested-path readers derive behavior — e.g. a component's network port/protocol — from
 	// getConfigObj()'s tree, not the flattened map, so an override that only touched
 	// flatConfigObj was invisible to them (the on-disk shape kept winning regardless of
-	// setProperty()).
-	if (configObj === undefined) configObj = {};
-	const pathSegments = configObjKey.split('_');
-	let node = configObj;
-	for (let i = 0; i < pathSegments.length - 1; i++) {
-		const segment = pathSegments[i];
-		if (typeof node[segment] !== 'object' || node[segment] === null) node[segment] = {};
-		node = node[segment];
+	// setProperty()). Only mirror once a real config has been loaded — getConfigObj() treats
+	// configObj's falsiness as "not yet initialized" and lazily calls initConfig(), so creating
+	// an empty configObj here (before install writes the config file / initConfig ever runs)
+	// would permanently short-circuit that lazy init to an empty tree.
+	if (configObj !== undefined) {
+		const pathSegments = configObjKey.split('_');
+		let node = configObj;
+		for (let i = 0; i < pathSegments.length - 1; i++) {
+			const segment = pathSegments[i];
+			// Only auto-vivify a missing segment. An existing non-object value here is a legacy
+			// scalar shorthand for this key (e.g. `threads: 4`) — descending through it would
+			// silently replace that value with `{}`, discarding it out from under other readers.
+			if (node[segment] === undefined) node[segment] = {};
+			else if (typeof node[segment] !== 'object' || node[segment] === null) return;
+			node = node[segment];
+		}
+		node[pathSegments[pathSegments.length - 1]] = value;
 	}
-	node[pathSegments[pathSegments.length - 1]] = value;
 }
 
 /**

--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -708,7 +708,12 @@ export function updateConfigObject(param: string, value: any) {
 			else if (typeof node[segment] !== 'object' || node[segment] === null) return;
 			node = node[segment];
 		}
-		node[pathSegments[pathSegments.length - 1]] = value;
+		// Match squashObj's own convention (below) of never writing an `undefined` value as an
+		// enumerable key: several root-config readers (e.g. bin/run.ts) iterate configObj's own
+		// keys and assume every one holds a real value.
+		const leaf = pathSegments[pathSegments.length - 1];
+		if (value === undefined) delete node[leaf];
+		else node[leaf] = value;
 	}
 }
 

--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -687,6 +687,21 @@ export function updateConfigObject(param: string, value: any) {
 	}
 
 	flatConfigObj[configObjKey.toLowerCase()] = value;
+
+	// Keep the nested config tree in sync too. componentLoader (root components) and other
+	// nested-path readers derive behavior — e.g. a component's network port/protocol — from
+	// getConfigObj()'s tree, not the flattened map, so an override that only touched
+	// flatConfigObj was invisible to them (the on-disk shape kept winning regardless of
+	// setProperty()).
+	if (configObj === undefined) configObj = {};
+	const pathSegments = configObjKey.split('_');
+	let node = configObj;
+	for (let i = 0; i < pathSegments.length - 1; i++) {
+		const segment = pathSegments[i];
+		if (typeof node[segment] !== 'object' || node[segment] === null) node[segment] = {};
+		node = node[segment];
+	}
+	node[pathSegments[pathSegments.length - 1]] = value;
 }
 
 /**

--- a/dataLayer/harperBridge/lmdbBridge/lmdbUtility/initializePaths.js
+++ b/dataLayer/harperBridge/lmdbBridge/lmdbUtility/initializePaths.js
@@ -7,7 +7,7 @@ const path = require('path');
 const minimist = require('minimist');
 const fs = require('fs-extra');
 const _ = require('lodash');
-const { getConfigPath } = require('../../../../config/configUtils.ts');
+const { getConfigPath, updateConfigObject } = require('../../../../config/configUtils.ts');
 env.initSync();
 
 const { CONFIG_PARAMS, DATABASES_PARAM_CONFIG, SYSTEM_SCHEMA_NAME } = hdbTerms;
@@ -115,7 +115,7 @@ function initSystemSchemaPaths(schema, table) {
 					[SYSTEM_SCHEMA_NAME, DATABASES_PARAM_CONFIG.TABLES, table, DATABASES_PARAM_CONFIG.PATH],
 					systemTablePath
 				);
-				env.setProperty(CONFIG_PARAMS.DATABASES, schemasObj);
+				updateConfigObject(CONFIG_PARAMS.DATABASES, schemasObj);
 				return systemTablePath;
 			}
 
@@ -123,7 +123,7 @@ function initSystemSchemaPaths(schema, table) {
 			const systemSchemaPath = systemSchemaConf?.[DATABASES_PARAM_CONFIG.PATH];
 			if (systemSchemaPath) {
 				_.set(schemasObj, [SYSTEM_SCHEMA_NAME, DATABASES_PARAM_CONFIG.PATH], systemSchemaPath);
-				env.setProperty(CONFIG_PARAMS.DATABASES, schemasObj);
+				updateConfigObject(CONFIG_PARAMS.DATABASES, schemasObj);
 				return systemSchemaPath;
 			}
 		}
@@ -135,7 +135,7 @@ function initSystemSchemaPaths(schema, table) {
 		if (!fs.pathExistsSync(storagePath)) throw new Error(storagePath + ' does not exist');
 		const storageSchemaPath = path.join(storagePath, schema);
 		fs.mkdirsSync(storageSchemaPath);
-		env.setProperty(CONFIG_PARAMS.STORAGE_PATH, storagePath);
+		updateConfigObject(CONFIG_PARAMS.STORAGE_PATH, storagePath);
 
 		return storageSchemaPath;
 	}

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -237,9 +237,8 @@ function registerWorkerDataProvider(name, provider) {
 // effective config is never silently whatever happens to be installed on disk. Worker-side replay
 // is environmentManager.ts's applyInheritedConfigOverrides(), invoked from initSync(). Registered
 // on every thread (not just main) so a nested worker-of-a-worker also inherits the full chain.
-// A provider whose value fails to clone is only logged and skipped below — which for this one
-// means spawning the worker on the on-disk config, the very thing it exists to prevent — so
-// setProperty() rejects a non-cloneable value up front, at the caller that can still fix it.
+// setProperty() clones each value as it records it, so this provider cannot hit the log-and-skip
+// path below — which for this one would mean spawning the worker on the on-disk config.
 registerWorkerDataProvider('configOverrides', () => envMgr.getConfigOverrides());
 function collectProvidedWorkerData(options) {
 	if (workerDataProviders.size === 0) return undefined;

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -232,6 +232,12 @@ function registerWorkerDataProvider(name, provider) {
 		if (workerDataProviders.get(name) === provider) workerDataProviders.delete(name);
 	};
 }
+// Propagate this thread's in-process config overrides (env.setProperty — installer bootstrap or
+// the unit-test harness's per-run isolation) to every worker spawned from here, so a worker's
+// effective config is never silently whatever happens to be installed on disk. Worker-side replay
+// is environmentManager.ts's applyInheritedConfigOverrides(), invoked from initSync(). Registered
+// on every thread (not just main) so a nested worker-of-a-worker also inherits the full chain.
+registerWorkerDataProvider('configOverrides', () => envMgr.getConfigOverrides());
 function collectProvidedWorkerData(options) {
 	if (workerDataProviders.size === 0) return undefined;
 	let provided;

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -237,6 +237,9 @@ function registerWorkerDataProvider(name, provider) {
 // effective config is never silently whatever happens to be installed on disk. Worker-side replay
 // is environmentManager.ts's applyInheritedConfigOverrides(), invoked from initSync(). Registered
 // on every thread (not just main) so a nested worker-of-a-worker also inherits the full chain.
+// A provider whose value fails to clone is only logged and skipped below — which for this one
+// means spawning the worker on the on-disk config, the very thing it exists to prevent — so
+// setProperty() rejects a non-cloneable value up front, at the caller that can still fix it.
 registerWorkerDataProvider('configOverrides', () => envMgr.getConfigOverrides());
 function collectProvidedWorkerData(options) {
 	if (workerDataProviders.size === 0) return undefined;

--- a/unitTests/apiTests/mqtt-test.mjs
+++ b/unitTests/apiTests/mqtt-test.mjs
@@ -9,6 +9,7 @@ import { callOperation } from './utility.js';
 import { setupTestApp, baseUrl, wsBaseUrl, mqttUrl, mqttsUrl, testHost } from './setupTestApp.mjs';
 import environmentManager from '#src/utility/environment/environmentManager';
 const { get: env_get, setProperty } = environmentManager;
+import { getThisNodeName } from '#src/server/nodeName';
 import { connect, connectAsync } from 'mqtt';
 import { readFileSync } from 'fs';
 import { handleApplication as handleMQTTApplication } from '#src/server/mqtt';
@@ -598,7 +599,7 @@ describe('test MQTT connections and commands', function () {
 		let cert, ca;
 		for await (const certificate of databases.system.hdb_certificate.search([])) {
 			if (certificate.is_authority) ca = certificate.certificate;
-			else if (certificate.name === 'localhost') cert = certificate.certificate;
+			else if (certificate.name === getThisNodeName()) cert = certificate.certificate;
 		}
 		let client = await connectAsync(`mqtts://${testHost}:8884`, {
 			key: readFileSync(private_key_path),

--- a/unitTests/apiTests/mqtt-test.mjs
+++ b/unitTests/apiTests/mqtt-test.mjs
@@ -659,7 +659,7 @@ describe('test MQTT connections and commands', function () {
 			let cert, ca;
 			for await (const certificate of databases.system.hdb_certificate.search([])) {
 				if (certificate.is_authority) ca = certificate.certificate;
-				else if (certificate.name === 'localhost') cert = certificate.certificate;
+				else if (certificate.name === getThisNodeName()) cert = certificate.certificate;
 			}
 			let bad_client = await connectAsync(`wss://${testHost}:8885`, {
 				reconnectPeriod: 0,

--- a/unitTests/apiTests/mqtt-test.mjs
+++ b/unitTests/apiTests/mqtt-test.mjs
@@ -596,11 +596,17 @@ describe('test MQTT connections and commands', function () {
 		}).catch(() => null);
 
 		const private_key_path = env_get('tls_privateKey');
-		let cert, ca;
+		let cert, fallbackCert, ca;
 		for await (const certificate of databases.system.hdb_certificate.search([])) {
 			if (certificate.is_authority) ca = certificate.certificate;
-			else if (certificate.name === getThisNodeName()) cert = certificate.certificate;
+			else {
+				// See the WSS mTLS test below for why a name mismatch can happen and why the fallback
+				// is needed.
+				fallbackCert ??= certificate.certificate;
+				if (certificate.name === getThisNodeName()) cert = certificate.certificate;
+			}
 		}
+		cert ??= fallbackCert;
 		let client = await connectAsync(`mqtts://${testHost}:8884`, {
 			key: readFileSync(private_key_path),
 			cert,
@@ -656,11 +662,22 @@ describe('test MQTT connections and commands', function () {
 			});
 
 			const private_key_path = env_get('tls_privateKey');
-			let cert, ca;
+			let cert, fallbackCert, ca;
 			for await (const certificate of databases.system.hdb_certificate.search([])) {
 				if (certificate.is_authority) ca = certificate.certificate;
-				else if (certificate.name === getThisNodeName()) cert = certificate.certificate;
+				else {
+					// getThisNodeName() is derived from the current effective config (node.hostname, or
+					// a fallback chain through the operations-API listener address), which can differ
+					// from whatever this install's cert was actually generated under — e.g. an install
+					// with no node.hostname set falls back to '127.0.0.1' at cert-generation time, but
+					// this test process's fallback resolves through the harness's overridden, per-run
+					// loopback address instead. Fall back to any non-authority cert (there's exactly one
+					// in a simple, non-replicated install) rather than leaving the client with none.
+					fallbackCert ??= certificate.certificate;
+					if (certificate.name === getThisNodeName()) cert = certificate.certificate;
+				}
 			}
+			cert ??= fallbackCert;
 			let bad_client = await connectAsync(`wss://${testHost}:8885`, {
 				reconnectPeriod: 0,
 				clientId: 'test-bad-mtls',

--- a/unitTests/apiTests/setupTestApp.mjs
+++ b/unitTests/apiTests/setupTestApp.mjs
@@ -100,6 +100,11 @@ export async function setupTestApp() {
 
 	setProperty(hdbTerms.CONFIG_PARAMS.OPERATIONSAPI_NETWORK_DOMAINSOCKET, join(path, 'operations-server'));
 	setProperty(hdbTerms.CONFIG_PARAMS.OPERATIONSAPI_NETWORK_PORT, `${testHost}:9925`);
+	// The operations API is always plain HTTP in this harness (matching OPERATIONSAPI_NETWORK_PORT
+	// above); an ambient install whose securePort is also set (e.g. operationsApi.network.securePort:
+	// 9925) would otherwise leave that stale TLS port in the effective config alongside our plain-port
+	// override, so operations-API clients intermittently hit the wrong listener.
+	setProperty(hdbTerms.CONFIG_PARAMS.OPERATIONSAPI_NETWORK_SECUREPORT, null);
 	setProperty(hdbTerms.CONFIG_PARAMS.HTTP_SECUREPORT, null);
 	setProperty(hdbTerms.CONFIG_PARAMS.HTTP_PORT, `${testHost}:9926`);
 	setProperty(hdbTerms.CONFIG_PARAMS.MQTT_NETWORK_PORT, `${testHost}:1883`);

--- a/unitTests/config/configUtils.test.js
+++ b/unitTests/config/configUtils.test.js
@@ -1000,6 +1000,19 @@ describe('Test configUtils module', () => {
 			expect(nested_config).to.eql({ threads: 4 });
 			config_obj_rw();
 		});
+
+		it('deletes rather than writing an undefined value into the nested tree', () => {
+			// squashObj (below) never writes an undefined value as an enumerable key either; several
+			// root-config readers iterate configObj's own keys and assume every one holds a real value.
+			const nested_config = { databases: { data: { path: '/old' } } };
+			flat_config_obj_rw = config_utils_rw.__set__('flatConfigObj', {});
+			const config_obj_rw = config_utils_rw.__set__('configObj', nested_config);
+
+			config_utils_rw.updateConfigObject(hdbTerms.CONFIG_PARAMS.DATABASES, undefined);
+
+			expect(nested_config.hasOwnProperty('databases')).to.be.false;
+			config_obj_rw();
+		});
 	});
 
 	describe('Test updateConfigValue function', () => {

--- a/unitTests/config/configUtils.test.js
+++ b/unitTests/config/configUtils.test.js
@@ -1013,6 +1013,37 @@ describe('Test configUtils module', () => {
 			expect(nested_config.hasOwnProperty('databases')).to.be.false;
 			config_obj_rw();
 		});
+
+		it('does not auto-vivify missing ancestors when the value being set is undefined', () => {
+			// If it did, the (now-empty) intermediate objects it created on the way to the deleted
+			// leaf would be left behind — and componentLoader.ts treats any truthy top-level config
+			// key as a component to load.
+			const nested_config = {};
+			flat_config_obj_rw = config_utils_rw.__set__('flatConfigObj', {});
+			const config_obj_rw = config_utils_rw.__set__('configObj', nested_config);
+
+			config_utils_rw.updateConfigObject(hdbTerms.CONFIG_PARAMS.OPERATIONSAPI_NETWORK_SECUREPORT, undefined);
+
+			expect(nested_config).to.eql({});
+			config_obj_rw();
+		});
+
+		it('never mirrors a boot-props-file-only param (not a real config-tree path) into the nested tree', () => {
+			// SETTINGS_PATH_KEY ('settings_path') lives in BOOT_PROP_PARAMS, not the harper-config.yaml
+			// schema — CONFIG_PARAM_MAP still maps it (so the flat map keeps working), but splitting
+			// it on '_' and writing into the nested tree would create a bogus top-level
+			// configObj.settings.path, which componentLoader.ts would try to load as a component
+			// named 'settings'. installer.ts and testUtils.js's initTestEnvironment() both call
+			// setProperty() with this key on every install/test run.
+			const nested_config = { rootPath: '/hdb' };
+			flat_config_obj_rw = config_utils_rw.__set__('flatConfigObj', {});
+			const config_obj_rw = config_utils_rw.__set__('configObj', nested_config);
+
+			config_utils_rw.updateConfigObject(hdbTerms.BOOT_PROP_PARAMS.SETTINGS_PATH_KEY, '/hdb/settings.file');
+
+			expect(nested_config).to.eql({ rootPath: '/hdb' });
+			config_obj_rw();
+		});
 	});
 
 	describe('Test updateConfigValue function', () => {

--- a/unitTests/config/configUtils.test.js
+++ b/unitTests/config/configUtils.test.js
@@ -964,6 +964,42 @@ describe('Test configUtils module', () => {
 			);
 			logger_trace_stub.restore();
 		});
+
+		it('mirrors the override into the nested configObj tree at the corresponding path', () => {
+			const nested_config = { operationsApi: { network: { port: 9925, securePort: 9925 } } };
+			flat_config_obj_rw = config_utils_rw.__set__('flatConfigObj', {});
+			const config_obj_rw = config_utils_rw.__set__('configObj', nested_config);
+
+			config_utils_rw.updateConfigObject(hdbTerms.CONFIG_PARAMS.OPERATIONSAPI_NETWORK_SECUREPORT, null);
+
+			expect(nested_config.operationsApi.network.securePort).to.equal(null);
+			config_obj_rw();
+		});
+
+		it('does not initialize configObj — that would permanently short-circuit getConfigObj()s lazy initConfig()', () => {
+			// getConfigObj() treats a falsy configObj as "not yet initialized" and calls initConfig();
+			// creating configObj as {} here (before any real config has been loaded, e.g. during
+			// install before the config file exists) would make that check pass on an empty tree
+			// forever, and componentLoader's root-component load would see zero components.
+			flat_config_obj_rw = config_utils_rw.__set__('flatConfigObj', {});
+			const config_obj_rw = config_utils_rw.__set__('configObj', undefined);
+
+			config_utils_rw.updateConfigObject(hdbTerms.CONFIG_PARAMS.OPERATIONSAPI_NETWORK_SECUREPORT, null);
+
+			expect(config_utils_rw.__get__('configObj')).to.be.undefined;
+			config_obj_rw();
+		});
+
+		it('does not clobber an existing scalar value (legacy shorthand) while descending the nested path', () => {
+			const nested_config = { threads: 4 };
+			flat_config_obj_rw = config_utils_rw.__set__('flatConfigObj', {});
+			const config_obj_rw = config_utils_rw.__set__('configObj', nested_config);
+
+			config_utils_rw.updateConfigObject(hdbTerms.CONFIG_PARAMS.THREADS_COUNT, 2);
+
+			expect(nested_config).to.eql({ threads: 4 });
+			config_obj_rw();
+		});
 	});
 
 	describe('Test updateConfigValue function', () => {

--- a/unitTests/config/configUtils.test.js
+++ b/unitTests/config/configUtils.test.js
@@ -1044,6 +1044,24 @@ describe('Test configUtils module', () => {
 			expect(nested_config).to.eql({ rootPath: '/hdb' });
 			config_obj_rw();
 		});
+
+		it('flattening a throwaway doc does not make it the live config the mirror writes into', () => {
+			// flattenConfig() also runs on docs that are discarded moments later — the defaults doc in
+			// getDefaultConfig()/createConfigFile(), and the user-supplied doc installer.ts reads for
+			// an HDB_CONFIG install. When it installed those as configObj, the mirror above wrote the
+			// override into a tree nobody would ever read, which is the exact flat/nested divergence
+			// it exists to close. Only setActiveConfig()'s callers own the live tree.
+			const live_config = { operationsApi: { network: { port: 9925 } } };
+			flat_config_obj_rw = config_utils_rw.__set__('flatConfigObj', {});
+			const config_obj_rw = config_utils_rw.__set__('configObj', live_config);
+
+			config_utils_rw.flattenConfig({ operationsApi: { network: { port: 1 } } });
+			config_utils_rw.updateConfigObject(hdbTerms.CONFIG_PARAMS.OPERATIONSAPI_NETWORK_PORT, 9999);
+
+			expect(config_utils_rw.__get__('configObj')).to.equal(live_config);
+			expect(live_config.operationsApi.network.port).to.equal(9999);
+			config_obj_rw();
+		});
 	});
 
 	describe('Test updateConfigValue function', () => {

--- a/unitTests/utility/environment/environmentManager.test.js
+++ b/unitTests/utility/environment/environmentManager.test.js
@@ -230,7 +230,13 @@ describe('Test environmentManager module', () => {
 
 		it('reapplyAllOverrides replays every override applied on this thread through setProperty', () => {
 			const update_config_object = sandbox.stub(config_utils, 'updateConfigObject');
-			env_rw.__set__('appliedOverrides', new Map([['foo', 'bar'], ['baz', 42]]));
+			env_rw.__set__(
+				'appliedOverrides',
+				new Map([
+					['foo', 'bar'],
+					['baz', 42],
+				])
+			);
 			const reapply_all_overrides = env_rw.__get__('reapplyAllOverrides');
 
 			reapply_all_overrides();

--- a/unitTests/utility/environment/environmentManager.test.js
+++ b/unitTests/utility/environment/environmentManager.test.js
@@ -7,6 +7,7 @@ const config_utils = require('#src/config/configUtils');
 const common_utils = require('#src/utility/common_utils');
 const rewire = require('rewire');
 const fs = require('fs');
+const hdbTerms = require('#src/utility/hdbTerms');
 const env_rw = rewire('#src/utility/environment/environmentManager');
 const log = require('#src/utility/logging/harper_logger');
 
@@ -213,6 +214,18 @@ describe('Test environmentManager module', () => {
 			env_rw.setProperty('foo', 'first');
 			env_rw.setProperty('foo', 'second');
 			expect(env_rw.getConfigOverrides()).to.eql({ foo: 'second' });
+		});
+
+		it('collapses two different legacy aliases for the same canonical param onto one Map entry', () => {
+			// SERVER_PORT_KEY ('SERVER_PORT') and OPERATIONSAPI_NETWORK_PORT both canonicalize to
+			// 'operationsApi_network_port' (CONFIG_PARAM_MAP). Without canonical keying these would
+			// land in two separate Map entries, and replay order (Map insertion order) wouldn't
+			// guarantee the later call wins — a worker could end up on a stale alias's value even
+			// though its parent had already moved past it.
+			sandbox.stub(config_utils, 'updateConfigObject');
+			env_rw.setProperty(hdbTerms.HDB_SETTINGS_NAMES.SERVER_PORT_KEY, 9925);
+			env_rw.setProperty(hdbTerms.CONFIG_PARAMS.OPERATIONSAPI_NETWORK_PORT, 9926);
+			expect(env_rw.getConfigOverrides()).to.eql({ operationsApi_network_port: 9926 });
 		});
 
 		it('reapplyAllOverrides replays every override applied on this thread through setProperty', () => {

--- a/unitTests/utility/environment/environmentManager.test.js
+++ b/unitTests/utility/environment/environmentManager.test.js
@@ -254,5 +254,23 @@ describe('Test environmentManager module', () => {
 
 			expect(update_config_object.called).to.be.false;
 		});
+
+		it('syncs installProps HDB_ROOT from config AFTER replaying overrides, not from the pre-replay disk read', () => {
+			// Regression test for a bug the round-2 canonical-keying fix introduced: setProperty()
+			// records a rootPath override under its canonical name, not HDB_ROOT_KEY, so replaying it
+			// doesn't retrigger the installProps side effect in setProperty() itself — getHdbBasePath()
+			// only tracks an isolated rootPath override if this sync in initSync() runs after replay.
+			const update_config_object = sandbox.stub(config_utils, 'updateConfigObject');
+			sandbox.stub(config_utils, 'initConfig');
+			const get_config_value = sandbox.stub(config_utils, 'getConfigValue').returns('/isolated/root');
+			env_rw.__set__('propFileExists', true);
+			env_rw.__set__('inheritedOverridesApplied', true);
+			env_rw.__set__('appliedOverrides', new Map([['rootPath', '/isolated/root']]));
+
+			env_rw.initSync(true);
+
+			expect(get_config_value.calledAfter(update_config_object)).to.be.true;
+			expect(env_rw.getHdbBasePath()).to.equal('/isolated/root');
+		});
 	});
 });

--- a/unitTests/utility/environment/environmentManager.test.js
+++ b/unitTests/utility/environment/environmentManager.test.js
@@ -10,6 +10,7 @@ const fs = require('fs');
 const hdbTerms = require('#src/utility/hdbTerms');
 const env_rw = rewire('#src/utility/environment/environmentManager');
 const log = require('#src/utility/logging/harper_logger');
+const { Worker } = require('node:worker_threads');
 
 const TEST_PROP_1_NAME = 'root';
 const TEST_PROP_2_NAME = 'path';
@@ -282,6 +283,19 @@ describe('Test environmentManager module', () => {
 			expect(env_rw.getConfigOverrides()).to.be.undefined;
 		});
 
+		it('records a snapshot, so mutating the value afterwards cannot rewrite what workers inherit', () => {
+			// initializePaths.js and environmentUtility.ts cache derived per-database paths by mutating
+			// the live `databases` value in place, and that is the same object testUtils.js hands to
+			// setProperty — those derived paths must not reach a worker as if they were operator intent.
+			sandbox.stub(config_utils, 'updateConfigObject');
+			const databases = { data: { path: '/isolated/data' } };
+
+			env_rw.setProperty(hdbTerms.CONFIG_PARAMS.DATABASES, databases);
+			databases.derived = { path: '/ambient/derived' };
+
+			expect(env_rw.getConfigOverrides().databases).to.eql({ data: { path: '/isolated/data' } });
+		});
+
 		it('a forced initSync() reapplies overrides instead of silently dropping them after the disk re-read', () => {
 			// Regression test: initConfig(force) rebuilds configObj/flatConfigObj from disk, which
 			// would otherwise discard anything setProperty() had layered on top of it (e.g. after a
@@ -312,10 +326,9 @@ describe('Test environmentManager module', () => {
 		});
 
 		it('syncs installProps HDB_ROOT from config AFTER replaying overrides, not from the pre-replay disk read', () => {
-			// Regression test for a bug the round-2 canonical-keying fix introduced: setProperty()
-			// records a rootPath override under its canonical name, not HDB_ROOT_KEY, so replaying it
-			// doesn't retrigger the installProps side effect in setProperty() itself — getHdbBasePath()
-			// only tracks an isolated rootPath override if this sync in initSync() runs after replay.
+			// setProperty() records a rootPath override under its canonical name, not HDB_ROOT_KEY, so
+			// replaying it doesn't retrigger the installProps side effect in setProperty() itself —
+			// getHdbBasePath() tracks an overridden rootPath only if this sync runs after replay.
 			const update_config_object = sandbox.stub(config_utils, 'updateConfigObject');
 			sandbox.stub(config_utils, 'initConfig');
 			const get_config_value = sandbox.stub(config_utils, 'getConfigValue').returns('/isolated/root');
@@ -327,6 +340,36 @@ describe('Test environmentManager module', () => {
 
 			expect(get_config_value.calledAfter(update_config_object)).to.be.true;
 			expect(env_rw.getHdbBasePath()).to.equal('/isolated/root');
+		});
+
+		it('a real worker boots on the inherited overrides, not on the config installed on disk', async () => {
+			// The end-to-end claim the rest of this suite only covers in pieces: a worker whose
+			// workerData carries configOverrides must resolve those values after its own initSync()
+			// re-reads the on-disk config.
+			const worker = new Worker(
+				`const { parentPort, workerData } = require('node:worker_threads');
+				const env = require(${JSON.stringify(require.resolve('#src/utility/environment/environmentManager'))});
+				env.initSync();
+				parentPort.postMessage({
+					rootPath: env.get(${JSON.stringify(hdbTerms.CONFIG_PARAMS.ROOTPATH)}),
+					port: env.get(${JSON.stringify(hdbTerms.CONFIG_PARAMS.OPERATIONSAPI_NETWORK_PORT)}),
+				});`,
+				{
+					eval: true,
+					workerData: { configOverrides: { rootPath: '/inherited/root', operationsApi_network_port: 19925 } },
+				}
+			);
+
+			try {
+				const effective = await new Promise((resolve, reject) => {
+					worker.once('message', resolve);
+					worker.once('error', reject);
+					worker.once('exit', (code) => reject(new Error(`worker exited (${code}) before reporting its config`)));
+				});
+				expect(effective).to.eql({ rootPath: '/inherited/root', port: 19925 });
+			} finally {
+				await worker.terminate();
+			}
 		});
 	});
 });

--- a/unitTests/utility/environment/environmentManager.test.js
+++ b/unitTests/utility/environment/environmentManager.test.js
@@ -276,6 +276,19 @@ describe('Test environmentManager module', () => {
 			expect(update_config_object.calledWith('databases', { data: { path: '/iso' } })).to.be.true;
 		});
 
+		it('treats a reordered mapping as unchanged — key order in the YAML is formatting, not config', () => {
+			const update_config_object = sandbox.stub(config_utils, 'updateConfigObject');
+			sandbox.stub(config_utils, 'getConfigValue').returns({ securePort: 9925, port: null });
+			env_rw.__set__(
+				'appliedOverrides',
+				overrideMap(['operationsApi_network', { port: 9930 }, { port: null, securePort: 9925 }])
+			);
+
+			env_rw.__get__('reapplyAllOverrides')();
+
+			expect(update_config_object.calledWith('operationsApi_network', { port: 9930 })).to.be.true;
+		});
+
 		it('rejects a value that could not be handed to a worker rather than letting the spawn degrade', () => {
 			// manageThreads.js's configOverrides provider structuredClones this map into every worker
 			// and only logs a clone failure, spawning the worker on the on-disk config instead — so

--- a/unitTests/utility/environment/environmentManager.test.js
+++ b/unitTests/utility/environment/environmentManager.test.js
@@ -191,6 +191,10 @@ describe('Test environmentManager module', () => {
 	});
 
 	describe('Test config-override tracking and replay (worker-thread inheritance)', () => {
+		// appliedOverrides entries carry the override plus the configured value it displaced, so a
+		// forced reload can tell a config file that still says what it said from one that changed.
+		const overrideMap = (...entries) => new Map(entries.map(([name, value, base]) => [name, { value, base }]));
+
 		afterEach(() => {
 			sandbox.restore();
 			env_rw.__set__('appliedOverrides', new Map());
@@ -228,21 +232,54 @@ describe('Test environmentManager module', () => {
 			expect(env_rw.getConfigOverrides()).to.eql({ operationsApi_network_port: 9926 });
 		});
 
-		it('reapplyAllOverrides replays every override applied on this thread through setProperty', () => {
+		it('reapplyAllOverrides replays every override the reload left alone through setProperty', () => {
 			const update_config_object = sandbox.stub(config_utils, 'updateConfigObject');
-			env_rw.__set__(
-				'appliedOverrides',
-				new Map([
-					['foo', 'bar'],
-					['baz', 42],
-				])
-			);
+			sandbox.stub(config_utils, 'getConfigValue').returns(undefined);
+			env_rw.__set__('appliedOverrides', overrideMap(['foo', 'bar', undefined], ['baz', 42, undefined]));
 			const reapply_all_overrides = env_rw.__get__('reapplyAllOverrides');
 
 			reapply_all_overrides();
 
 			expect(update_config_object.calledWith('foo', 'bar')).to.be.true;
 			expect(update_config_object.calledWith('baz', 42)).to.be.true;
+		});
+
+		it('lets the config file win: a reload that changed the param retires the override', () => {
+			// A forced re-init is how an operator's harper-config.yaml edit takes effect (the RESTART
+			// handlers in security/keys.ts and processManagement.js). Replaying unconditionally would
+			// make editing an overridden param a silent no-op for the life of the process.
+			const update_config_object = sandbox.stub(config_utils, 'updateConfigObject');
+			sandbox.stub(config_utils, 'getConfigValue').returns('edited-on-disk');
+			env_rw.__set__('appliedOverrides', overrideMap(['node_hostname', 'overridden', 'original-on-disk']));
+
+			env_rw.__get__('reapplyAllOverrides')();
+
+			expect(update_config_object.called).to.be.false;
+			// Dropped from the map too, so it stops propagating to newly spawned workers — otherwise
+			// the skew this mechanism prevents would reappear from the other direction.
+			expect(env_rw.getConfigOverrides()).to.be.undefined;
+		});
+
+		it('compares object-valued params by content, since a reload rebuilds them as fresh objects', () => {
+			const update_config_object = sandbox.stub(config_utils, 'updateConfigObject');
+			sandbox.stub(config_utils, 'getConfigValue').returns({ data: { path: '/data' } });
+			env_rw.__set__(
+				'appliedOverrides',
+				overrideMap(['databases', { data: { path: '/iso' } }, { data: { path: '/data' } }])
+			);
+
+			env_rw.__get__('reapplyAllOverrides')();
+
+			expect(update_config_object.calledWith('databases', { data: { path: '/iso' } })).to.be.true;
+		});
+
+		it('rejects a value that could not be handed to a worker rather than letting the spawn degrade', () => {
+			// manageThreads.js's configOverrides provider structuredClones this map into every worker
+			// and only logs a clone failure, spawning the worker on the on-disk config instead — so
+			// the cloneability invariant is enforced here, where the caller can still fix it.
+			sandbox.stub(config_utils, 'updateConfigObject');
+			expect(() => env_rw.setProperty('rootPath', () => '/iso')).to.throw(/structured-cloneable/);
+			expect(env_rw.getConfigOverrides()).to.be.undefined;
 		});
 
 		it('a forced initSync() reapplies overrides instead of silently dropping them after the disk re-read', () => {
@@ -254,7 +291,7 @@ describe('Test environmentManager module', () => {
 			sandbox.stub(config_utils, 'getConfigValue');
 			env_rw.__set__('propFileExists', true);
 			env_rw.__set__('inheritedOverridesApplied', true);
-			env_rw.__set__('appliedOverrides', new Map([['locally_set_key', 'should-survive-reload']]));
+			env_rw.__set__('appliedOverrides', overrideMap(['locally_set_key', 'should-survive-reload', undefined]));
 
 			env_rw.initSync(true);
 
@@ -267,7 +304,7 @@ describe('Test environmentManager module', () => {
 			sandbox.stub(config_utils, 'getConfigValue');
 			env_rw.__set__('propFileExists', true);
 			env_rw.__set__('inheritedOverridesApplied', true);
-			env_rw.__set__('appliedOverrides', new Map([['locally_set_key', 'value']]));
+			env_rw.__set__('appliedOverrides', overrideMap(['locally_set_key', 'value', undefined]));
 
 			env_rw.initSync(false);
 
@@ -284,7 +321,7 @@ describe('Test environmentManager module', () => {
 			const get_config_value = sandbox.stub(config_utils, 'getConfigValue').returns('/isolated/root');
 			env_rw.__set__('propFileExists', true);
 			env_rw.__set__('inheritedOverridesApplied', true);
-			env_rw.__set__('appliedOverrides', new Map([['rootPath', '/isolated/root']]));
+			env_rw.__set__('appliedOverrides', overrideMap(['rootPath', '/isolated/root', '/isolated/root']));
 
 			env_rw.initSync(true);
 

--- a/unitTests/utility/environment/environmentManager.test.js
+++ b/unitTests/utility/environment/environmentManager.test.js
@@ -150,10 +150,17 @@ describe('Test environmentManager module', () => {
 
 	describe('Test initTestEnvironment function', () => {
 		let set_property_stub;
+		let set_property_rw;
 
 		before(() => {
 			set_property_stub = sandbox.stub();
-			env_rw.__set__('setProperty', set_property_stub);
+			set_property_rw = env_rw.__set__('setProperty', set_property_stub);
+		});
+
+		// Without this, the stubbed internal setProperty binding leaks into every describe block
+		// that runs later in this file (rewire's __set__ isn't reverted by sandbox.restore()).
+		after(() => {
+			set_property_rw();
 		});
 
 		afterEach(() => {
@@ -179,6 +186,73 @@ describe('Test environmentManager module', () => {
 
 			expect(set_property_stub.called).to.be.true;
 			expect(set_property_stub.callCount).to.equal(31);
+		});
+	});
+
+	describe('Test config-override tracking and replay (worker-thread inheritance)', () => {
+		afterEach(() => {
+			sandbox.restore();
+			env_rw.__set__('appliedOverrides', new Map());
+			env_rw.__set__('inheritedOverridesApplied', false);
+		});
+
+		it('getConfigOverrides returns undefined when nothing has been overridden on this thread', () => {
+			env_rw.__set__('appliedOverrides', new Map());
+			expect(env_rw.getConfigOverrides()).to.be.undefined;
+		});
+
+		it('getConfigOverrides reflects every setProperty call on this thread, in order', () => {
+			sandbox.stub(config_utils, 'updateConfigObject');
+			env_rw.setProperty('foo', 'bar');
+			env_rw.setProperty('baz', 42);
+			expect(env_rw.getConfigOverrides()).to.eql({ foo: 'bar', baz: 42 });
+		});
+
+		it('a later setProperty for the same param overwrites the value replayed to workers', () => {
+			sandbox.stub(config_utils, 'updateConfigObject');
+			env_rw.setProperty('foo', 'first');
+			env_rw.setProperty('foo', 'second');
+			expect(env_rw.getConfigOverrides()).to.eql({ foo: 'second' });
+		});
+
+		it('reapplyAllOverrides replays every override applied on this thread through setProperty', () => {
+			const update_config_object = sandbox.stub(config_utils, 'updateConfigObject');
+			env_rw.__set__('appliedOverrides', new Map([['foo', 'bar'], ['baz', 42]]));
+			const reapply_all_overrides = env_rw.__get__('reapplyAllOverrides');
+
+			reapply_all_overrides();
+
+			expect(update_config_object.calledWith('foo', 'bar')).to.be.true;
+			expect(update_config_object.calledWith('baz', 42)).to.be.true;
+		});
+
+		it('a forced initSync() reapplies overrides instead of silently dropping them after the disk re-read', () => {
+			// Regression test: initConfig(force) rebuilds configObj/flatConfigObj from disk, which
+			// would otherwise discard anything setProperty() had layered on top of it (e.g. after a
+			// component RESTART calls initSync(true) — see security/keys.ts).
+			const update_config_object = sandbox.stub(config_utils, 'updateConfigObject');
+			sandbox.stub(config_utils, 'initConfig');
+			sandbox.stub(config_utils, 'getConfigValue');
+			env_rw.__set__('propFileExists', true);
+			env_rw.__set__('inheritedOverridesApplied', true);
+			env_rw.__set__('appliedOverrides', new Map([['locally_set_key', 'should-survive-reload']]));
+
+			env_rw.initSync(true);
+
+			expect(update_config_object.calledWith('locally_set_key', 'should-survive-reload')).to.be.true;
+		});
+
+		it('a non-forced initSync() does not replay local overrides a second time', () => {
+			const update_config_object = sandbox.stub(config_utils, 'updateConfigObject');
+			sandbox.stub(config_utils, 'initConfig');
+			sandbox.stub(config_utils, 'getConfigValue');
+			env_rw.__set__('propFileExists', true);
+			env_rw.__set__('inheritedOverridesApplied', true);
+			env_rw.__set__('appliedOverrides', new Map([['locally_set_key', 'value']]));
+
+			env_rw.initSync(false);
+
+			expect(update_config_object.called).to.be.false;
 		});
 	});
 });

--- a/unitTests/utility/environment/environmentManager.test.js
+++ b/unitTests/utility/environment/environmentManager.test.js
@@ -7,6 +7,8 @@ const config_utils = require('#src/config/configUtils');
 const common_utils = require('#src/utility/common_utils');
 const rewire = require('rewire');
 const fs = require('fs');
+const os = require('node:os');
+const path = require('node:path');
 const hdbTerms = require('#src/utility/hdbTerms');
 const env_rw = rewire('#src/utility/environment/environmentManager');
 const log = require('#src/utility/logging/harper_logger');
@@ -341,35 +343,68 @@ describe('Test environmentManager module', () => {
 			expect(get_config_value.calledAfter(update_config_object)).to.be.true;
 			expect(env_rw.getHdbBasePath()).to.equal('/isolated/root');
 		});
+	});
 
-		it('a real worker boots on the inherited overrides, not on the config installed on disk', async () => {
-			// The end-to-end claim the rest of this suite only covers in pieces: a worker whose
-			// workerData carries configOverrides must resolve those values after its own initSync()
-			// re-reads the on-disk config.
+	describe('Test worker-thread inheritance end to end', () => {
+		// A real worker against a config file written for this test, so the assertion depends only on
+		// the mechanism and not on whatever Harper happens to be installed on the machine.
+		const fixtureRoot = path.join(os.tmpdir(), `hdb-config-inheritance-${process.pid}`);
+		const FIXTURE_PORT = 29925;
+		const INHERITED_ROOT = '/inherited/root';
+		const INHERITED_PORT = 19925;
+
+		before(() => {
+			fs.mkdirSync(path.join(fixtureRoot, 'database'), { recursive: true });
+			fs.mkdirSync(path.join(fixtureRoot, 'log'), { recursive: true });
+			// rewire gives configUtils its own module state, so writing this config file doesn't
+			// repoint the live config the rest of the suite runs against.
+			rewire('#src/config/configUtils').createConfigFile(
+				{
+					ROOTPATH: fixtureRoot,
+					OPERATIONSAPI_NETWORK_PORT: FIXTURE_PORT,
+					NODE_HOSTNAME: 'config-inheritance-fixture',
+				},
+				true
+			);
+		});
+
+		after(() => {
+			fs.rmSync(fixtureRoot, { recursive: true, force: true });
+		});
+
+		// ROOTPATH points the worker at the fixture config (common_utils' noBootFile path), so it
+		// boots with no boot-props file of its own.
+		async function bootWorker(configOverrides) {
 			const worker = new Worker(
-				`const { parentPort, workerData } = require('node:worker_threads');
+				`const { parentPort } = require('node:worker_threads');
 				const env = require(${JSON.stringify(require.resolve('#src/utility/environment/environmentManager'))});
 				env.initSync();
 				parentPort.postMessage({
 					rootPath: env.get(${JSON.stringify(hdbTerms.CONFIG_PARAMS.ROOTPATH)}),
 					port: env.get(${JSON.stringify(hdbTerms.CONFIG_PARAMS.OPERATIONSAPI_NETWORK_PORT)}),
 				});`,
-				{
-					eval: true,
-					workerData: { configOverrides: { rootPath: '/inherited/root', operationsApi_network_port: 19925 } },
-				}
+				{ eval: true, env: { ...process.env, ROOTPATH: fixtureRoot }, workerData: { configOverrides } }
 			);
-
 			try {
-				const effective = await new Promise((resolve, reject) => {
+				return await new Promise((resolve, reject) => {
 					worker.once('message', resolve);
 					worker.once('error', reject);
 					worker.once('exit', (code) => reject(new Error(`worker exited (${code}) before reporting its config`)));
 				});
-				expect(effective).to.eql({ rootPath: '/inherited/root', port: 19925 });
 			} finally {
 				await worker.terminate();
 			}
+		}
+
+		it('a worker with nothing inherited reads the config on disk', async () => {
+			expect(await bootWorker(undefined)).to.eql({ rootPath: fixtureRoot, port: FIXTURE_PORT });
+		});
+
+		it('a worker booted with inherited overrides resolves those instead of the config on disk', async () => {
+			expect(await bootWorker({ rootPath: INHERITED_ROOT, operationsApi_network_port: INHERITED_PORT })).to.eql({
+				rootPath: INHERITED_ROOT,
+				port: INHERITED_PORT,
+			});
 		});
 	});
 });

--- a/utility/environment/environmentManager.ts
+++ b/utility/environment/environmentManager.ts
@@ -9,6 +9,7 @@ import * as commonUtils from '../common_utils.ts';
 import * as hdbTerms from '../hdbTerms.ts';
 import * as configUtils from '../../config/configUtils.ts';
 import { mkdirSync } from 'node:fs';
+import { workerData } from 'node:worker_threads';
 
 const INIT_ERR = 'Error initializing environment manager';
 const BOOT_PROPS_FILE_PATH = 'BOOT_PROPS_FILE_PATH';
@@ -23,6 +24,14 @@ const installPropsToSave = {
 };
 let installProps: any = {};
 export { BOOT_PROPS_FILE_PATH };
+
+// Every param ever passed to setProperty() on this thread, in call order (so a later override
+// of the same param wins on replay). This is how a worker thread inherits its parent's in-process
+// config overrides — see applyInheritedConfigOverrides() and workerDataProvider registration in
+// server/threads/manageThreads.js. setProperty is installer/unit-test-only (see its docstring), so
+// this map stays small and is never touched on a normal production boot.
+const appliedOverrides = new Map<string, any>();
+let inheritedOverridesApplied = false;
 
 /**
  * The base path of the HDB install is often referenced, but is referenced as a const variable at the top of many
@@ -67,11 +76,38 @@ export function get(propName: string): any {
  * @param value
  */
 export function setProperty(propName: string, value: any) {
+	appliedOverrides.set(propName, value);
+
 	if (installPropsToSave[propName]) {
 		installProps[propName] = value;
 	}
 
 	configUtils.updateConfigObject(propName, value);
+}
+
+/**
+ * Every config override applied on this thread via setProperty(), for propagation to worker
+ * threads spawned from here (see server/threads/manageThreads.js's 'configOverrides'
+ * workerData provider). Returns undefined when nothing has been overridden, so a normal
+ * production boot contributes no extra workerData.
+ */
+export function getConfigOverrides(): Record<string, any> | undefined {
+	return appliedOverrides.size ? Object.fromEntries(appliedOverrides) : undefined;
+}
+
+/**
+ * Replays the parent thread's config overrides (received via workerData) on THIS thread, so a
+ * worker's effective config matches its parent's rather than silently falling back to whatever
+ * is installed on disk. Applied once per thread, right after the on-disk config is read — see
+ * initSync() — but reapplied on a forced re-init since that re-reads the whole config from disk
+ * and would otherwise drop the inherited overrides.
+ */
+function applyInheritedConfigOverrides() {
+	const inherited = (workerData as any)?.configOverrides;
+	if (!inherited) return;
+	for (const propName in inherited) {
+		setProperty(propName, inherited[propName]);
+	}
 }
 
 /**
@@ -112,6 +148,12 @@ export function initSync(force: boolean = false) {
 			// Only overwrite if we actually got a value from config
 			if (configHdbRoot !== undefined) {
 				installProps[hdbTerms.HDB_SETTINGS_NAMES.HDB_ROOT_KEY] = configHdbRoot;
+			}
+			// force implies the on-disk config was just re-read from scratch, which would otherwise
+			// silently drop overrides inherited from the parent thread — reapply them on top.
+			if (force || !inheritedOverridesApplied) {
+				inheritedOverridesApplied = true;
+				applyInheritedConfigOverrides();
 			}
 		}
 	} catch (err) {

--- a/utility/environment/environmentManager.ts
+++ b/utility/environment/environmentManager.ts
@@ -25,20 +25,17 @@ const installPropsToSave = {
 let installProps: any = {};
 export { BOOT_PROPS_FILE_PATH };
 
-// Every param ever passed to setProperty() on this thread, keyed by its canonical config param
-// (so aliases for the same param, and repeated overrides of the same param, replay as a single
-// last-write-wins entry rather than several conflicting ones). This is how a worker thread
-// inherits its parent's in-process config overrides — see applyInheritedConfigOverrides()/
-// reapplyAllOverrides() and the workerDataProvider registration in server/threads/manageThreads.js.
-// `base` is the configured value the override displaced, remembered from the *first* override of
-// that param so reapplyAllOverrides() can tell a reload that left the param alone from one that
-// is itself the change.
-// setProperty() is for operator/harness *intent* — an override that should survive a config reload
-// and propagate to every worker. Code caching a value it derived from config it just read (e.g.
-// dataLayer/harperBridge/lmdbBridge's initializePaths.js, utility/lmdb/environmentUtility.ts) must
-// call configUtils.updateConfigObject() directly instead: going through setProperty() here would
-// make that derived value outlive a config reload and get shipped to every worker as if it were an
-// override, pinning it even after the on-disk config the derivation was based on changes.
+// Every param passed to setProperty() on this thread, keyed by its canonical config param so
+// aliases for the same param collapse to one last-write-wins entry. Workers inherit this map (see
+// getConfigOverrides() and the workerDataProvider registration in server/threads/manageThreads.js)
+// and it is replayed after a forced config reload (reapplyAllOverrides()); `base` is the configured
+// value the override displaced, so that replay can tell a reload that left the param alone from one
+// that is itself the change.
+//
+// setProperty() is therefore for operator/harness *intent* only. Code caching a value it derived
+// from config it just read (initializePaths.js, utility/lmdb/environmentUtility.ts) must call
+// configUtils.updateConfigObject() directly, or that derived value would outlive the config it was
+// derived from and ship to every worker as if it were an override.
 const appliedOverrides = new Map<string, { value: any; base: any }>();
 let inheritedOverridesApplied = false;
 
@@ -89,31 +86,33 @@ export function get(propName: string): any {
  * @param value
  */
 export function setProperty(propName: string, value: any) {
-	// The recorded overrides are shipped to every worker by structuredClone (manageThreads.js's
-	// 'configOverrides' provider), where a clone failure is logged and the worker spawns anyway —
-	// on the on-disk config, which is exactly the divergence this mechanism exists to prevent, and
-	// the payload carries rootPath/storage.path. Reject a non-cloneable value here instead, at the
-	// caller that can actually fix it, so a spawn can never inherit a partial override set.
+	// Snapshot rather than keep the caller's reference: initializePaths.js and environmentUtility.ts
+	// cache derived per-database paths by mutating the live `databases` value in place, and that is
+	// often the very object handed to setProperty (unitTests/testUtils.js). Sharing it would leak
+	// those derived paths into what workers inherit and make an untouched param look changed on
+	// reload. Cloning here also settles cloneability at the caller that can still fix it —
+	// manageThreads.js's provider only logs a clone failure and spawns the worker on the on-disk
+	// config anyway, the exact divergence this mechanism exists to prevent.
+	let snapshot;
 	try {
-		structuredClone(value);
+		snapshot = structuredClone(value);
 	} catch (err) {
 		throw new Error(`Config property '${propName}' cannot be set to a value that is not structured-cloneable`, {
 			cause: err,
 		});
 	}
 
-	// Key by the canonical param name, not the raw alias passed in: CONFIG_PARAM_MAP is
-	// many-to-one (e.g. SERVER_PORT_KEY and OPERATIONSAPI_NETWORK_PORT both canonicalize to
-	// 'operationsApi_network_port'), so two callers overriding the "same" param through
-	// different aliases must land on one Map entry — otherwise replay can apply a stale alias
-	// after the canonical one, reintroducing the parent/worker skew this map exists to prevent.
+	// Key by the canonical param name, not the raw alias passed in: CONFIG_PARAM_MAP is many-to-one
+	// (e.g. SERVER_PORT_KEY and OPERATIONSAPI_NETWORK_PORT both canonicalize to
+	// 'operationsApi_network_port'), and replay of a stale alias after the canonical one would
+	// reintroduce the parent/worker skew this map exists to prevent.
 	const canonicalName = (hdbTerms.CONFIG_PARAM_MAP as any)[propName.toLowerCase()] ?? propName;
 	const existing = appliedOverrides.get(canonicalName);
 	appliedOverrides.set(canonicalName, {
-		value,
+		value: snapshot,
 		// Keep the first override's base: everything after it displaced an override, not a
 		// configured value, so it says nothing about what the config file held.
-		base: existing ? existing.base : configUtils.getConfigValue(propName),
+		base: existing ? existing.base : snapshotConfigValue(configUtils.getConfigValue(propName)),
 	});
 
 	if (installPropsToSave[propName]) {
@@ -153,44 +152,52 @@ function applyInheritedConfigOverrides() {
 	}
 }
 
+/** Detached copy of a config value; falls back to the value itself for the (unreached) non-cloneable case. */
+function snapshotConfigValue(value: any) {
+	try {
+		return structuredClone(value);
+	} catch {
+		return value;
+	}
+}
+
 /**
- * Config values come from YAML, so they are plain JSON — but a reload rebuilds them into fresh
- * objects, which never compare identical even when the file is byte-for-byte unchanged.
+ * A reload rebuilds config values into fresh objects, so identity says nothing about whether the
+ * file changed. Values that structuredClone accepts but JSON.stringify does not (cyclic, BigInt)
+ * count as changed rather than throwing out of the reload path — initSync()'s catch exits the
+ * process.
  */
 function sameConfigValue(a: any, b: any) {
 	if (Object.is(a, b)) return true;
 	if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') return false;
-	return JSON.stringify(a) === JSON.stringify(b);
+	try {
+		return JSON.stringify(a) === JSON.stringify(b);
+	} catch {
+		return false;
+	}
 }
 
 /**
- * Replays the overrides applied on this thread (both inherited-from-parent and applied locally via
- * setProperty) on top of a config that was just re-read from disk. A forced initSync() rebuilds the
- * whole config, discarding anything setProperty had layered on top; without this, that reload would
- * silently revert the thread to the on-disk config regardless of any overrides — the same defect
- * applyInheritedConfigOverrides() closes for a worker's first boot, but for a reload on any thread,
- * main included.
+ * Replays this thread's overrides on top of a config that was just re-read from disk. A forced
+ * initSync() rebuilds the whole config, which would otherwise revert the thread to the on-disk
+ * config regardless of any overrides — the same defect applyInheritedConfigOverrides() closes for a
+ * worker's first boot, but for a reload on any thread, main included.
  *
  * An override does NOT survive a reload that changed its own param on disk. A forced reload is how
  * an operator's config edit takes effect (the RESTART handlers in security/keys.ts and
- * processManagement.js), so replaying unconditionally would make editing an overridden param in
- * harper-config.yaml a silent no-op for the life of the process. The edit is the newer intent: the
- * override retires — and is dropped from the map, so it stops propagating to new workers too and
- * can't reintroduce the parent/worker skew from the other direction.
+ * processManagement.js), so replaying unconditionally would make editing an overridden param a
+ * silent no-op for the life of the process. The edit is the newer intent, so the override retires
+ * entirely — dropped from the map, so it stops reaching newly spawned workers as well.
  *
  * Call only after configUtils.initConfig(force) has repopulated the config from disk.
  */
 function reapplyAllOverrides() {
 	if (appliedOverrides.size === 0) return;
-	// Snapshot first: setProperty() re-inserts into appliedOverrides as we iterate, and mutating a
-	// Map while iterating it live is unnecessary risk here for no benefit.
+	// Iterate a snapshot: setProperty() re-inserts into appliedOverrides as we go.
 	for (const [propName, { value, base }] of [...appliedOverrides]) {
-		const reloaded = configUtils.getConfigValue(propName);
-		if (!sameConfigValue(reloaded, base)) {
+		if (!sameConfigValue(configUtils.getConfigValue(propName), base)) {
 			appliedOverrides.delete(propName);
-			log.notify(
-				`Config reload changed '${propName}'; dropping the in-process override of it (was ${JSON.stringify(value)})`
-			);
+			log.notify(`Config reload changed '${propName}'; dropping this thread's in-process override of it`);
 			continue;
 		}
 		setProperty(propName, value);

--- a/utility/environment/environmentManager.ts
+++ b/utility/environment/environmentManager.ts
@@ -30,13 +30,16 @@ export { BOOT_PROPS_FILE_PATH };
 // last-write-wins entry rather than several conflicting ones). This is how a worker thread
 // inherits its parent's in-process config overrides — see applyInheritedConfigOverrides()/
 // reapplyAllOverrides() and the workerDataProvider registration in server/threads/manageThreads.js.
+// `base` is the configured value the override displaced, remembered from the *first* override of
+// that param so reapplyAllOverrides() can tell a reload that left the param alone from one that
+// is itself the change.
 // setProperty() is for operator/harness *intent* — an override that should survive a config reload
 // and propagate to every worker. Code caching a value it derived from config it just read (e.g.
 // dataLayer/harperBridge/lmdbBridge's initializePaths.js, utility/lmdb/environmentUtility.ts) must
 // call configUtils.updateConfigObject() directly instead: going through setProperty() here would
 // make that derived value outlive a config reload and get shipped to every worker as if it were an
 // override, pinning it even after the on-disk config the derivation was based on changes.
-const appliedOverrides = new Map<string, any>();
+const appliedOverrides = new Map<string, { value: any; base: any }>();
 let inheritedOverridesApplied = false;
 
 /**
@@ -77,17 +80,41 @@ export function get(propName: string): any {
  * Note - this function will NOT update the config file. If you want to update the file
  * use the updateConfigValue method in configUtils.
  *
+ * The override is also recorded so it propagates to every worker thread spawned from here and
+ * survives a forced config reload — except a reload that changes this param on disk, which wins
+ * and retires the override (see reapplyAllOverrides()). `value` must be structured-cloneable.
+ *
  * This function should only be used by the installer and unit tests.
  * @param propName
  * @param value
  */
 export function setProperty(propName: string, value: any) {
+	// The recorded overrides are shipped to every worker by structuredClone (manageThreads.js's
+	// 'configOverrides' provider), where a clone failure is logged and the worker spawns anyway —
+	// on the on-disk config, which is exactly the divergence this mechanism exists to prevent, and
+	// the payload carries rootPath/storage.path. Reject a non-cloneable value here instead, at the
+	// caller that can actually fix it, so a spawn can never inherit a partial override set.
+	try {
+		structuredClone(value);
+	} catch (err) {
+		throw new Error(`Config property '${propName}' cannot be set to a value that is not structured-cloneable`, {
+			cause: err,
+		});
+	}
+
 	// Key by the canonical param name, not the raw alias passed in: CONFIG_PARAM_MAP is
 	// many-to-one (e.g. SERVER_PORT_KEY and OPERATIONSAPI_NETWORK_PORT both canonicalize to
 	// 'operationsApi_network_port'), so two callers overriding the "same" param through
 	// different aliases must land on one Map entry — otherwise replay can apply a stale alias
 	// after the canonical one, reintroducing the parent/worker skew this map exists to prevent.
-	appliedOverrides.set((hdbTerms.CONFIG_PARAM_MAP as any)[propName.toLowerCase()] ?? propName, value);
+	const canonicalName = (hdbTerms.CONFIG_PARAM_MAP as any)[propName.toLowerCase()] ?? propName;
+	const existing = appliedOverrides.get(canonicalName);
+	appliedOverrides.set(canonicalName, {
+		value,
+		// Keep the first override's base: everything after it displaced an override, not a
+		// configured value, so it says nothing about what the config file held.
+		base: existing ? existing.base : configUtils.getConfigValue(propName),
+	});
 
 	if (installPropsToSave[propName]) {
 		installProps[propName] = value;
@@ -103,7 +130,12 @@ export function setProperty(propName: string, value: any) {
  * production boot contributes no extra workerData.
  */
 export function getConfigOverrides(): Record<string, any> | undefined {
-	return appliedOverrides.size ? Object.fromEntries(appliedOverrides) : undefined;
+	if (!appliedOverrides.size) return undefined;
+	const overrides = {};
+	for (const [propName, { value }] of appliedOverrides) {
+		overrides[propName] = value;
+	}
+	return overrides;
 }
 
 /**
@@ -122,18 +154,45 @@ function applyInheritedConfigOverrides() {
 }
 
 /**
- * Replays every override ever applied on this thread (both inherited-from-parent and applied
- * locally via setProperty) on top of the current config. A forced initSync() re-reads the whole
- * config from disk, discarding anything setProperty had layered on top; without this, that reload
- * would silently revert the thread to the on-disk config regardless of any overrides — the same
- * defect applyInheritedConfigOverrides() closes for a worker's first boot, but for a reload on any
- * thread, main included.
+ * Config values come from YAML, so they are plain JSON — but a reload rebuilds them into fresh
+ * objects, which never compare identical even when the file is byte-for-byte unchanged.
+ */
+function sameConfigValue(a: any, b: any) {
+	if (Object.is(a, b)) return true;
+	if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') return false;
+	return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Replays the overrides applied on this thread (both inherited-from-parent and applied locally via
+ * setProperty) on top of a config that was just re-read from disk. A forced initSync() rebuilds the
+ * whole config, discarding anything setProperty had layered on top; without this, that reload would
+ * silently revert the thread to the on-disk config regardless of any overrides — the same defect
+ * applyInheritedConfigOverrides() closes for a worker's first boot, but for a reload on any thread,
+ * main included.
+ *
+ * An override does NOT survive a reload that changed its own param on disk. A forced reload is how
+ * an operator's config edit takes effect (the RESTART handlers in security/keys.ts and
+ * processManagement.js), so replaying unconditionally would make editing an overridden param in
+ * harper-config.yaml a silent no-op for the life of the process. The edit is the newer intent: the
+ * override retires — and is dropped from the map, so it stops propagating to new workers too and
+ * can't reintroduce the parent/worker skew from the other direction.
+ *
+ * Call only after configUtils.initConfig(force) has repopulated the config from disk.
  */
 function reapplyAllOverrides() {
 	if (appliedOverrides.size === 0) return;
 	// Snapshot first: setProperty() re-inserts into appliedOverrides as we iterate, and mutating a
 	// Map while iterating it live is unnecessary risk here for no benefit.
-	for (const [propName, value] of [...appliedOverrides]) {
+	for (const [propName, { value, base }] of [...appliedOverrides]) {
+		const reloaded = configUtils.getConfigValue(propName);
+		if (!sameConfigValue(reloaded, base)) {
+			appliedOverrides.delete(propName);
+			log.notify(
+				`Config reload changed '${propName}'; dropping the in-process override of it (was ${JSON.stringify(value)})`
+			);
+			continue;
+		}
 		setProperty(propName, value);
 	}
 }
@@ -177,7 +236,8 @@ export function initSync(force: boolean = false) {
 				applyInheritedConfigOverrides();
 			}
 			// force implies the on-disk config was just re-read from scratch, which would otherwise
-			// silently drop every override applied on this thread so far (inherited or local).
+			// silently drop every override applied on this thread so far (inherited or local) —
+			// except the ones the re-read itself changed, which the config file wins.
 			if (force) reapplyAllOverrides();
 
 			// Sync installProps' HDB_ROOT from the config's rootPath *after* any override replay

--- a/utility/environment/environmentManager.ts
+++ b/utility/environment/environmentManager.ts
@@ -27,9 +27,13 @@ export { BOOT_PROPS_FILE_PATH };
 
 // Every param ever passed to setProperty() on this thread, in call order (so a later override
 // of the same param wins on replay). This is how a worker thread inherits its parent's in-process
-// config overrides — see applyInheritedConfigOverrides() and workerDataProvider registration in
-// server/threads/manageThreads.js. setProperty is installer/unit-test-only (see its docstring), so
-// this map stays small and is never touched on a normal production boot.
+// config overrides — see applyInheritedConfigOverrides()/reapplyAllOverrides() and the
+// workerDataProvider registration in server/threads/manageThreads.js. setProperty() isn't only
+// installer/unit-test code despite its docstring — dataLayer/harperBridge/lmdbBridge's
+// initializePaths.js and utility/lmdb/environmentUtility.ts call it at runtime with the resolved
+// `databases`/`storage.path` config on an LMDB-engine install, so this map (and the workerData
+// payload cloned from it on every worker/job spawn) can hold that full tree, not just test/install
+// bootstrap keys.
 const appliedOverrides = new Map<string, any>();
 let inheritedOverridesApplied = false;
 
@@ -98,15 +102,32 @@ export function getConfigOverrides(): Record<string, any> | undefined {
 /**
  * Replays the parent thread's config overrides (received via workerData) on THIS thread, so a
  * worker's effective config matches its parent's rather than silently falling back to whatever
- * is installed on disk. Applied once per thread, right after the on-disk config is read — see
- * initSync() — but reapplied on a forced re-init since that re-reads the whole config from disk
- * and would otherwise drop the inherited overrides.
+ * is installed on disk. Applied once per thread, right after the on-disk config is first read —
+ * see initSync(). A later forced re-init is handled separately by reapplyAllOverrides(), since by
+ * then these inherited values are already folded into appliedOverrides.
  */
 function applyInheritedConfigOverrides() {
 	const inherited = (workerData as any)?.configOverrides;
 	if (!inherited) return;
-	for (const propName in inherited) {
+	for (const propName of Object.keys(inherited)) {
 		setProperty(propName, inherited[propName]);
+	}
+}
+
+/**
+ * Replays every override ever applied on this thread (both inherited-from-parent and applied
+ * locally via setProperty) on top of the current config. A forced initSync() re-reads the whole
+ * config from disk, discarding anything setProperty had layered on top; without this, that reload
+ * would silently revert the thread to the on-disk config regardless of any overrides — the same
+ * defect applyInheritedConfigOverrides() closes for a worker's first boot, but for a reload on any
+ * thread, main included.
+ */
+function reapplyAllOverrides() {
+	if (appliedOverrides.size === 0) return;
+	// Snapshot first: setProperty() re-inserts into appliedOverrides as we iterate, and mutating a
+	// Map while iterating it live is unnecessary risk here for no benefit.
+	for (const [propName, value] of [...appliedOverrides]) {
+		setProperty(propName, value);
 	}
 }
 
@@ -149,12 +170,13 @@ export function initSync(force: boolean = false) {
 			if (configHdbRoot !== undefined) {
 				installProps[hdbTerms.HDB_SETTINGS_NAMES.HDB_ROOT_KEY] = configHdbRoot;
 			}
-			// force implies the on-disk config was just re-read from scratch, which would otherwise
-			// silently drop overrides inherited from the parent thread — reapply them on top.
-			if (force || !inheritedOverridesApplied) {
+			if (!inheritedOverridesApplied) {
 				inheritedOverridesApplied = true;
 				applyInheritedConfigOverrides();
 			}
+			// force implies the on-disk config was just re-read from scratch, which would otherwise
+			// silently drop every override applied on this thread so far (inherited or local).
+			if (force) reapplyAllOverrides();
 		}
 	} catch (err) {
 		log.error(INIT_ERR);

--- a/utility/environment/environmentManager.ts
+++ b/utility/environment/environmentManager.ts
@@ -26,16 +26,15 @@ let installProps: any = {};
 export { BOOT_PROPS_FILE_PATH };
 
 // Every param passed to setProperty() on this thread, keyed by its canonical config param so
-// aliases for the same param collapse to one last-write-wins entry. Workers inherit this map (see
-// getConfigOverrides() and the workerDataProvider registration in server/threads/manageThreads.js)
-// and it is replayed after a forced config reload (reapplyAllOverrides()); `base` is the configured
-// value the override displaced, so that replay can tell a reload that left the param alone from one
-// that is itself the change.
+// aliases collapse to one last-write-wins entry. Workers inherit this map (getConfigOverrides() and
+// the workerDataProvider registration in server/threads/manageThreads.js) and it is replayed after
+// a forced config reload; `base` is the configured value the override displaced, which is how
+// reapplyAllOverrides() tells a reload that left the param alone from one that is itself the change.
 //
-// setProperty() is therefore for operator/harness *intent* only. Code caching a value it derived
+// setProperty() therefore means operator/harness *intent* only. Code caching a value it derived
 // from config it just read (initializePaths.js, utility/lmdb/environmentUtility.ts) must call
-// configUtils.updateConfigObject() directly, or that derived value would outlive the config it was
-// derived from and ship to every worker as if it were an override.
+// configUtils.updateConfigObject() directly, or the derived value outlives what it was derived from
+// and ships to every worker as an override.
 const appliedOverrides = new Map<string, { value: any; base: any }>();
 let inheritedOverridesApplied = false;
 
@@ -87,12 +86,10 @@ export function get(propName: string): any {
  */
 export function setProperty(propName: string, value: any) {
 	// Snapshot rather than keep the caller's reference: initializePaths.js and environmentUtility.ts
-	// cache derived per-database paths by mutating the live `databases` value in place, and that is
-	// often the very object handed to setProperty (unitTests/testUtils.js). Sharing it would leak
-	// those derived paths into what workers inherit and make an untouched param look changed on
-	// reload. Cloning here also settles cloneability at the caller that can still fix it —
-	// manageThreads.js's provider only logs a clone failure and spawns the worker on the on-disk
-	// config anyway, the exact divergence this mechanism exists to prevent.
+	// cache derived per-database paths by mutating the live `databases` value in place, which is
+	// often the very object handed to setProperty. Cloning here also settles cloneability at the
+	// caller that can still fix it — manageThreads.js's provider only logs a clone failure and
+	// spawns the worker on the on-disk config anyway.
 	let snapshot;
 	try {
 		snapshot = structuredClone(value);
@@ -161,17 +158,27 @@ function snapshotConfigValue(value: any) {
 	}
 }
 
+/** Key-ordering is a YAML formatting choice, not a config change, so it must not affect equality. */
+function stableStringify(value: any) {
+	if (value === null || typeof value !== 'object') return JSON.stringify(value);
+	if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+	return `{${Object.keys(value)
+		.sort()
+		.map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+		.join(',')}}`;
+}
+
 /**
  * A reload rebuilds config values into fresh objects, so identity says nothing about whether the
- * file changed. Values that structuredClone accepts but JSON.stringify does not (cyclic, BigInt)
- * count as changed rather than throwing out of the reload path — initSync()'s catch exits the
+ * file changed. Anything this cannot serialize (a cyclic value, which structuredClone accepts)
+ * counts as changed rather than throwing out of the reload path — initSync()'s catch exits the
  * process.
  */
 function sameConfigValue(a: any, b: any) {
 	if (Object.is(a, b)) return true;
 	if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') return false;
 	try {
-		return JSON.stringify(a) === JSON.stringify(b);
+		return stableStringify(a) === stableStringify(b);
 	} catch {
 		return false;
 	}

--- a/utility/environment/environmentManager.ts
+++ b/utility/environment/environmentManager.ts
@@ -25,15 +25,17 @@ const installPropsToSave = {
 let installProps: any = {};
 export { BOOT_PROPS_FILE_PATH };
 
-// Every param ever passed to setProperty() on this thread, in call order (so a later override
-// of the same param wins on replay). This is how a worker thread inherits its parent's in-process
-// config overrides — see applyInheritedConfigOverrides()/reapplyAllOverrides() and the
-// workerDataProvider registration in server/threads/manageThreads.js. setProperty() isn't only
-// installer/unit-test code despite its docstring — dataLayer/harperBridge/lmdbBridge's
-// initializePaths.js and utility/lmdb/environmentUtility.ts call it at runtime with the resolved
-// `databases`/`storage.path` config on an LMDB-engine install, so this map (and the workerData
-// payload cloned from it on every worker/job spawn) can hold that full tree, not just test/install
-// bootstrap keys.
+// Every param ever passed to setProperty() on this thread, keyed by its canonical config param
+// (so aliases for the same param, and repeated overrides of the same param, replay as a single
+// last-write-wins entry rather than several conflicting ones). This is how a worker thread
+// inherits its parent's in-process config overrides — see applyInheritedConfigOverrides()/
+// reapplyAllOverrides() and the workerDataProvider registration in server/threads/manageThreads.js.
+// setProperty() is for operator/harness *intent* — an override that should survive a config reload
+// and propagate to every worker. Code caching a value it derived from config it just read (e.g.
+// dataLayer/harperBridge/lmdbBridge's initializePaths.js, utility/lmdb/environmentUtility.ts) must
+// call configUtils.updateConfigObject() directly instead: going through setProperty() here would
+// make that derived value outlive a config reload and get shipped to every worker as if it were an
+// override, pinning it even after the on-disk config the derivation was based on changes.
 const appliedOverrides = new Map<string, any>();
 let inheritedOverridesApplied = false;
 
@@ -80,7 +82,12 @@ export function get(propName: string): any {
  * @param value
  */
 export function setProperty(propName: string, value: any) {
-	appliedOverrides.set(propName, value);
+	// Key by the canonical param name, not the raw alias passed in: CONFIG_PARAM_MAP is
+	// many-to-one (e.g. SERVER_PORT_KEY and OPERATIONSAPI_NETWORK_PORT both canonicalize to
+	// 'operationsApi_network_port'), so two callers overriding the "same" param through
+	// different aliases must land on one Map entry — otherwise replay can apply a stale alias
+	// after the canonical one, reintroducing the parent/worker skew this map exists to prevent.
+	appliedOverrides.set((hdbTerms.CONFIG_PARAM_MAP as any)[propName.toLowerCase()] ?? propName, value);
 
 	if (installPropsToSave[propName]) {
 		installProps[propName] = value;

--- a/utility/environment/environmentManager.ts
+++ b/utility/environment/environmentManager.ts
@@ -172,11 +172,6 @@ export function initSync(force: boolean = false) {
 	try {
 		if (propFileExists || doesPropFileExist() || commonUtils.noBootFile() || force) {
 			configUtils.initConfig(force);
-			const configHdbRoot = configUtils.getConfigValue(hdbTerms.HDB_SETTINGS_NAMES.HDB_ROOT_KEY);
-			// Only overwrite if we actually got a value from config
-			if (configHdbRoot !== undefined) {
-				installProps[hdbTerms.HDB_SETTINGS_NAMES.HDB_ROOT_KEY] = configHdbRoot;
-			}
 			if (!inheritedOverridesApplied) {
 				inheritedOverridesApplied = true;
 				applyInheritedConfigOverrides();
@@ -184,6 +179,18 @@ export function initSync(force: boolean = false) {
 			// force implies the on-disk config was just re-read from scratch, which would otherwise
 			// silently drop every override applied on this thread so far (inherited or local).
 			if (force) reapplyAllOverrides();
+
+			// Sync installProps' HDB_ROOT from the config's rootPath *after* any override replay
+			// above (not before): setProperty() records a rootPath override under its canonical
+			// CONFIG_PARAM_MAP name, not under HDB_ROOT_KEY, so replaying it doesn't retrigger this
+			// same side effect below in setProperty() — this sync is what makes getHdbBasePath()
+			// track an isolated rootPath override instead of staying pinned to whatever the pre-replay
+			// disk read produced.
+			const configHdbRoot = configUtils.getConfigValue(hdbTerms.HDB_SETTINGS_NAMES.HDB_ROOT_KEY);
+			// Only overwrite if we actually got a value from config
+			if (configHdbRoot !== undefined) {
+				installProps[hdbTerms.HDB_SETTINGS_NAMES.HDB_ROOT_KEY] = configHdbRoot;
+			}
 		}
 	} catch (err) {
 		log.error(INIT_ERR);

--- a/utility/lmdb/environmentUtility.ts
+++ b/utility/lmdb/environmentUtility.ts
@@ -13,6 +13,7 @@ import * as lmdbTerms from './terms.ts';
 import * as hdbTerms from '../hdbTerms.ts';
 import { resetDatabases } from '../../resources/databases.ts';
 import * as envMngr from '../environment/environmentManager.ts';
+import { updateConfigObject } from '../../config/configUtils.ts';
 
 const INTERNAL_DBIS_NAME = lmdbTerms.INTERNAL_DBIS_NAME;
 const DBI_DEFINITION_NAME = lmdbTerms.DBI_DEFINITION_NAME;
@@ -109,7 +110,7 @@ export async function createEnvironment(
 
 	envName = envName.toString();
 	let schemasConfig = envMngr.get(hdbTerms.CONFIG_PARAMS.DATABASES);
-	if (!schemasConfig) envMngr.setProperty(hdbTerms.CONFIG_PARAMS.DATABASES, (schemasConfig = {}));
+	if (!schemasConfig) updateConfigObject(hdbTerms.CONFIG_PARAMS.DATABASES, (schemasConfig = {}));
 	if (!schemasConfig[dbName]) schemasConfig[dbName] = {};
 	schemasConfig[dbName].path = basePath;
 	try {


### PR DESCRIPTION
## What

The `unitTests/apiTests` suite's isolation (per-PID rootPath, per-process loopback address, port overrides) is applied with in-process `env.setProperty()` calls on the main thread. Worker threads spawned during the run booted with a fresh `environmentManager`/`configUtils` module state and re-read `harper-config.yaml` from disk, so a worker silently fell back to whatever was actually installed and bound its ports on the wildcard address — the suite only passed when the developer's ambient install happened to be shaped like CI's.

Two closely-related root causes, both closing the same invariant ("a worker's effective config equals its parent's effective config"):

1. **Worker threads never received the parent's overrides at all.** `environmentManager.ts`'s `flatConfigObj` is module-scoped (each worker thread is its own V8 realm), populated once from disk. `setProperty()` only ever mutated the calling thread's own copy.
   - `setProperty()` now records every override into a canonical-name-keyed map (`getConfigOverrides()`), so different legacy aliases for the same param (e.g. `SERVER_PORT_KEY` / `OPERATIONSAPI_NETWORK_PORT`) collapse onto one last-write-wins entry instead of two independently-ordered ones.
   - `manageThreads.js` registers a `configOverrides` workerData provider via the existing `registerWorkerDataProvider` extension point, so every worker spawned from any thread — HTTP, job, or nested — inherits its parent's overrides.
   - `initSync()` replays inherited overrides once per thread, and replays the accumulated override set again after any forced re-init (e.g. a component RESTART), since that re-reads the whole config from disk and would otherwise silently drop everything layered on top of it — on any thread, including main. **A reload that changed the param itself wins:** each override records the configured value it displaced, and if the re-read produced a different value for that param the override retires (and is dropped from the map, so it stops reaching newly spawned workers). Without that, an operator editing an overridden key in `harper-config.yaml` and triggering a component restart would get a silent no-op for the life of the process. Values are compared with key-order-insensitive structural equality, so reformatting the YAML is not mistaken for a change.

2. **Even on the main thread, overrides never reached the nested config tree `componentLoader.ts` reads for built-in components.** `configUtils.ts` keeps config in two representations: a flat map and a nested tree (`configObj`, via `getConfigObj()`). `updateConfigObject()` — what `setProperty()` calls — only ever wrote the flat map. `componentLoader.ts`'s root-component load reads the nested tree directly and derives each built-in's network port/protocol from it (e.g. `operationsApi.network.securePort` decides whether `operationsServer` builds a TLS-only Fastify instance). So even with (1) fixed, a worker — or the main thread itself — whose ambient install had a non-null `operationsApi.network.securePort` still built a TLS-only listener, because componentLoader kept reading the stale on-disk value regardless of any override. Invisible on a CI-shaped install only because the on-disk value already happened to match what the harness wants.
   - `updateConfigObject()` now also mirrors into the nested tree, at the path implied by the flat key's underscore segments — with guards added over several review rounds: it never auto-vivifies `configObj` before a real config has ever loaded (would permanently short-circuit `getConfigObj()`'s lazy init), never clobbers an existing scalar shorthand (e.g. `threads: 4`) by descending through it, deletes rather than writes an `undefined` value (and doesn't auto-vivify ancestors just to immediately delete the leaf), and excludes params that live in `BOOT_PROP_PARAMS` rather than the actual YAML schema (`settings_path` is boot-props-file bookkeeping, not a real `settings:` config section — mirroring it naively would register a bogus `settings` component).

Three smaller, related fixes:

- `setupTestApp.mjs` nulled `http.securePort` when overriding `http.port`, but never did the same for `operationsApi.network.securePort` — an asymmetry that (combined with fix 2) left a stale TLS port in the effective config next to the plain-port override.
- `mqtt-test.mjs`'s two mTLS tests selected the client certificate by the literal string `'localhost'`. Switched to falling back through `getThisNodeName()` (the function the server itself uses to name its self-signed node cert) and then to any non-authority certificate, since `getThisNodeName()`'s own fallback chain can itself resolve differently between the install process and the test process on a hostname-null install (a fresh/non-replicated install has exactly one non-authority cert, so "any" is unambiguous here).
- `dataLayer/harperBridge/lmdbBridge/lmdbUtility/initializePaths.js` and `utility/lmdb/environmentUtility.ts` were calling `env.setProperty()` to cache values *derived* from config they'd just read (a schema path resolved from CLI args, a database's on-disk path) rather than genuine operator/harness overrides. Going through `setProperty()` made those derived values outlive a forced config reload and get shipped to every worker as if they were intentional overrides. Both now call `configUtils.updateConfigObject()` directly, which updates the same in-memory state without joining the override-tracking/propagation mechanism.

## Production-path impact

`config/configUtils.ts`'s `updateConfigObject()` change affects the same code path used at install time (`utility/install/installer.ts`) and any other `env.setProperty()` caller. This is a correctness fix within that path, not new behavior: it makes `configObj`/`flatConfigObj` consistent with each other, which is what `setProperty()`'s contract already implied. A worker that receives no overrides sees the new `workerData` provider return `undefined` and get skipped (per its existing "throws or returns non-cloneable → logged and skipped" contract) — production instances without in-process overrides see no behavior change.

Two further behavior notes on `setProperty()`, both from review:

- **`configObj` now means the live config tree.** It used to be assigned as a side effect of `flattenConfig()`, which also runs on documents that are thrown away moments later (the defaults document, the user-supplied document `installer.ts` reads for an `HDB_CONFIG` install), so the nested mirror's guard could not tell the live tree from a discarded one. Installing the live config is now explicit (`setActiveConfig()`), owned only by the three callers that build it.
- **`setProperty()` now rejects a value that is not structured-cloneable, and records a snapshot of the value.** The recorded overrides are `structuredClone`d into every worker, where a clone failure is only logged — landing the worker on the on-disk config, the exact divergence this change prevents, with `rootPath`/`storage.path` in the dropped payload. Failing at the caller instead keeps that impossible. Snapshotting also stops `initializePaths.js`/`environmentUtility.ts` from leaking derived per-database paths into the override set by mutating the live `databases` object in place.

## Scaffolding, not architecture: the worker-propagation half has a removal condition

This PR contains two independent fixes, and they have different lifespans. Please read them separately.

**Fix 2 (`updateConfigObject()` mirrors into the nested tree) is permanent.** It closes a real main-thread correctness bug: `setProperty()`'s documented contract ("will also update the config object configUtils maintains") was not honored, so an override reached the flat map but not the nested tree `componentLoader.ts` actually reads. Correcting an earlier version of this description: the installer's own `setProperty()` calls are *not* the justification. `installer.ts` has four (`storage.engine`, `install_user`, `settings_path`, `BOOT_PROPS_FILE_PATH`) — there is no RocksDB-compression call — and `storage.engine` is set before `createConfigFile()` has built any config tree, so the mirror is correctly skipped there and the same value reaches the file through `installParams` anyway. The reachable callers today are the test harness and harper-pro's `node_hostname`/`node_url` back-compat calls (`threads.count: 0`), plus any future runtime `setProperty()` caller — which is exactly why the contract has to hold rather than be documented as conditional.

**Fix 1 (worker threads inherit overrides via a `configOverrides` `workerData` provider) is a stopgap.** It exists solely because `unitTests/apiTests` boots Harper in-process and isolates itself with in-process `env.setProperty()` calls. Production instances have no in-process overrides, so this machinery carries a test-only need on the production worker-spawn path. It is the right call *today* — without it the suite fails on any install not shaped like CI's (181/10 observed on an adversarial install) — but it should not be built upon or treated as the intended design.

The end state is HarperFast/harper#2123, "Migrate unitTests/apiTests to the standard integration testing framework": move the suite to `integrationTests/` and `@harperfast/integration-testing`, which gives each suite a real child-process Harper with its own temp install directory and a file-locked loopback address. Real config in a real install propagates to workers by construction, and the override-inheritance problem stops existing.

**Removal condition:** when #2123 lands, the override tracking in `utility/environment/environmentManager.ts` and the `configOverrides` provider registration in `server/threads/manageThreads.js` come back out. That is listed in #2123's definition of done.

Worth noting the same architecture is the reason `test:unit:apitests` is prefixed with `node ./dist/bin/harper.js stop` — the suite stops the shared ambient install before running, so concurrent runs on a shared dev box kill each other's Harper regardless of address isolation. That is also fixed by #2123, not by this PR.

## Known limitation (out of scope for this PR)

Root components that use the newer Plugin API (`handleApplication`-based — MQTT, REST, fastifyRoutes, graphqlQuerying) read their config via `OptionsWatcher`, which re-parses `harper-config.yaml` off disk directly and never consults `getConfigObj()`/`flatConfigObj` at all. `env.setProperty()` overrides are invisible to that path. This PR's apitests verification (three different install shapes, including concurrent runs) didn't surface it because MQTT is still loaded through the older, `componentLoader`-driven path this PR does fix — but it's a real, pre-existing gap for any Plugin-API component, worth its own follow-up issue.

This PR fixes worker/main config divergence; no issue tracked that bug on its own, so the reference below is to the end-state issue. Refs #2123

## Testing

Verified against three different local installs (`node ./dist/bin/harper.js install` + isolated `HOME`, never the shared ambient install):
- **Adversarial** (`operationsApi.network.port: null` / `securePort: 9925`, `http.port: null` / `securePort: 9926`, `node.hostname` set to a non-`'localhost'` value — matches this issue's exact regression scenario): `npm run test:unit:apitests` 194 passing / 0 failing (was 181/10 on unpatched origin/main; 185/9 with only the worker-inheritance fix, before the nested-tree fix).
- **CI-shaped** (`DEFAULTS_MODE=dev`, `NODE_HOSTNAME=localhost`): 194/0, unaffected.
- **Hostname-null** (`node.hostname` unset entirely): 194/0 — this is what caught the mTLS cert-fallback issue above.
- `npm run test:unit:main` (4043 passing) and `npm run test:unit:resources` (1336 passing): unaffected, matches origin/main baseline (verified via a short-path throwaway worktree, since this repo's own worktree convention nests deep enough to independently trip two unrelated, pre-existing path-length issues — a domain-socket path limit and a Node module-sandbox check on a bare verification copy without its own `node_modules` — neither caused by this change).
- No more `[http/N] ... EADDRINUSE ... :::1883` in apitests output; no server banner reports a Root Path outside the per-PID `unitTests/envDir/<pid>` directory.
- Two concurrent `npm run test:unit:apitests` runs get distinct loopback addresses with no `EADDRINUSE` and correct per-run Root Path banners — the wildcard-bind collision this PR targets is gone. A separate mqtt-test.mjs timing sensitivity was observed under 2x concurrent full-suite load on this shared dev machine; it isn't port/address-collision-shaped (addresses were confirmed distinct) and wasn't root-caused — flagged as a follow-up, not blocking.
- New unit tests for the override-tracking/replay mechanism (`environmentManager.test.js`) and the nested-mirror guards (`configUtils.test.js`).
- An end-to-end test boots a real worker against a config file the test writes itself and asserts both directions: with no inherited overrides it reads the on-disk values, and with them it resolves the parent's values instead.
- Re-verified after the review-feedback round: apitests 194/0 on both a CI-shaped and the adversarial install, `test:unit:resources` 1336 passing, `test:unit:main` unchanged against its baseline.

This branch went through seven rounds of cross-model pre-push review (codex + gemini + grok + an internal Harper-domain pass) as fixes were made — see the commit messages for each round's findings and disposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Human-Review-Need: 3 @ 60881f8ce23d</sub>
