### PR TITLE
fix(test): stop using fetch() in ttlResetOnWrite / static-cache-headers (Node 26.5.1 flakiness)

### DIFF
--- a/integrationTests/components/static-cache-headers.test.ts
+++ b/integrationTests/components/static-cache-headers.test.ts
@@ -19,6 +19,7 @@ import { suite, test, before, after } from 'node:test';
 import { strictEqual, ok } from 'node:assert';
 import { resolve } from 'node:path';
 import http from 'node:http';
+import https from 'node:https';
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 // @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
 import { createApiClient } from '../apiTests/utils/client.mjs';
@@ -46,12 +47,13 @@ suite('static plugin cache-header options', (ctx: ContextWithHarper) => {
 	function getPath(path: string, timeoutMs = 5_000): Promise<SimpleResponse> {
 		return new Promise((resolvePromise, reject) => {
 			const u = new URL(path, ctx.harper.httpURL);
+			const transport = u.protocol === 'https:' ? https : http;
 			let wallClockTimer: ReturnType<typeof setTimeout>;
 			const settle = (fn: () => void) => {
 				clearTimeout(wallClockTimer);
 				fn();
 			};
-			const req = http.request(
+			const req = transport.request(
 				{ hostname: u.hostname, port: u.port, path: u.pathname + u.search, timeout: timeoutMs },
 				(res) => {
 					res.on('data', () => {}); // drain

--- a/integrationTests/components/static-cache-headers.test.ts
+++ b/integrationTests/components/static-cache-headers.test.ts
@@ -96,9 +96,15 @@ suite('static plugin cache-header options', (ctx: ContextWithHarper) => {
 		let last: string | null = null;
 		let sinceResend = 0;
 		while (Date.now() < deadline) {
-			const res = await getCss();
-			last = res.headers.get('cache-control');
-			if (last === expected) return res;
+			// A single sample's timeout or a transient non-200 while the plugin is mid-reload
+			// shouldn't abort the whole poll — only the loop's own deadline should.
+			try {
+				const res = await getCss();
+				last = res.headers.get('cache-control');
+				if (last === expected) return res;
+			} catch {
+				/* retry within the poll window */
+			}
 			if (++sinceResend >= 10) {
 				sinceResend = 0;
 				await setStaticConfig(yaml);

--- a/integrationTests/components/static-cache-headers.test.ts
+++ b/integrationTests/components/static-cache-headers.test.ts
@@ -11,6 +11,9 @@
  * (of unbounded, multi-second duration under some Node/undici builds — see harper#2025) can block
  * this suite's poll loop for tens of seconds and read as the chokidar reload never landing, when
  * it's really the polling request itself that never landed. node:http isn't subject to that stall.
+ * Root cause: nodejs/undici#5600 (unref'd idle-socket-validation setImmediate stalls fetch() on an
+ * otherwise-idle event loop), bundled into Node via undici 8.9.0 (used by 26.5.1); fixed upstream by
+ * nodejs/undici#5609 but not yet in a released undici/Node build as of this writing.
  */
 import { suite, test, before, after } from 'node:test';
 import { strictEqual, ok } from 'node:assert';

--- a/integrationTests/components/static-cache-headers.test.ts
+++ b/integrationTests/components/static-cache-headers.test.ts
@@ -40,20 +40,30 @@ suite('static plugin cache-header options', (ctx: ContextWithHarper) => {
 		headers: { get(name: string): string | null };
 	}
 
-	function getPath(path: string): Promise<SimpleResponse> {
+	function getPath(path: string, timeoutMs = 5_000): Promise<SimpleResponse> {
 		return new Promise((resolvePromise, reject) => {
 			const u = new URL(path, ctx.harper.httpURL);
-			const req = http.request({ hostname: u.hostname, port: u.port, path: u.pathname }, (res) => {
-				res.on('data', () => {}); // drain
-				res.on('end', () => {
-					strictEqual(res.statusCode, 200);
-					const headers = res.headers;
-					resolvePromise({
-						status: res.statusCode!,
-						headers: { get: (name: string) => (headers[name.toLowerCase()] as string) ?? null },
+			const req = http.request(
+				{ hostname: u.hostname, port: u.port, path: u.pathname + u.search, timeout: timeoutMs },
+				(res) => {
+					res.on('data', () => {}); // drain
+					res.on('error', reject);
+					res.on('end', () => {
+						try {
+							strictEqual(res.statusCode, 200);
+						} catch (err) {
+							reject(err);
+							return;
+						}
+						const headers = res.headers;
+						resolvePromise({
+							status: res.statusCode!,
+							headers: { get: (name: string) => (headers[name.toLowerCase()] as string) ?? null },
+						});
 					});
-				});
-			});
+				}
+			);
+			req.on('timeout', () => req.destroy(new Error(`GET ${path} timed out after ${timeoutMs}ms`)));
 			req.on('error', reject);
 			req.end();
 		});
@@ -77,7 +87,7 @@ suite('static plugin cache-header options', (ctx: ContextWithHarper) => {
 		yaml: string,
 		expected: string | null,
 		timeoutMs = 20_000
-	): Promise<Response> {
+	): Promise<SimpleResponse> {
 		await setStaticConfig(yaml);
 		const deadline = Date.now() + timeoutMs;
 		let last: string | null = null;

--- a/integrationTests/components/static-cache-headers.test.ts
+++ b/integrationTests/components/static-cache-headers.test.ts
@@ -46,28 +46,41 @@ suite('static plugin cache-header options', (ctx: ContextWithHarper) => {
 	function getPath(path: string, timeoutMs = 5_000): Promise<SimpleResponse> {
 		return new Promise((resolvePromise, reject) => {
 			const u = new URL(path, ctx.harper.httpURL);
+			let wallClockTimer: ReturnType<typeof setTimeout>;
+			const settle = (fn: () => void) => {
+				clearTimeout(wallClockTimer);
+				fn();
+			};
 			const req = http.request(
 				{ hostname: u.hostname, port: u.port, path: u.pathname + u.search, timeout: timeoutMs },
 				(res) => {
 					res.on('data', () => {}); // drain
-					res.on('error', reject);
+					res.on('error', (err) => settle(() => reject(err)));
 					res.on('end', () => {
 						try {
 							strictEqual(res.statusCode, 200);
 						} catch (err) {
-							reject(err);
+							settle(() => reject(err));
 							return;
 						}
 						const headers = res.headers;
-						resolvePromise({
-							status: res.statusCode!,
-							headers: { get: (name: string) => (headers[name.toLowerCase()] as string) ?? null },
-						});
+						settle(() =>
+							resolvePromise({
+								status: res.statusCode!,
+								headers: { get: (name: string) => (headers[name.toLowerCase()] as string) ?? null },
+							})
+						);
 					});
 				}
 			);
 			req.on('timeout', () => req.destroy(new Error(`GET ${path} timed out after ${timeoutMs}ms`)));
-			req.on('error', reject);
+			req.on('error', (err) => settle(() => reject(err)));
+			// `timeout` above is socket-*inactivity*, not wall-clock — see ttlResetOnWrite.test.ts's
+			// httpRequest for the same fix and rationale.
+			wallClockTimer = setTimeout(
+				() => req.destroy(new Error(`GET ${path} timed out after ${timeoutMs}ms (wall-clock)`)),
+				timeoutMs
+			);
 			req.end();
 		});
 	}

--- a/integrationTests/components/static-cache-headers.test.ts
+++ b/integrationTests/components/static-cache-headers.test.ts
@@ -94,24 +94,37 @@ suite('static plugin cache-header options', (ctx: ContextWithHarper) => {
 		await setStaticConfig(yaml);
 		const deadline = Date.now() + timeoutMs;
 		let last: string | null = null;
+		let lastError: string | null = null;
 		let sinceResend = 0;
 		while (Date.now() < deadline) {
 			// A single sample's timeout or a transient non-200 while the plugin is mid-reload
-			// shouldn't abort the whole poll — only the loop's own deadline should.
+			// shouldn't abort the whole poll — only the loop's own deadline should. `last` keeps the
+			// most recent successful sample's value, so a persistently-failing sample (e.g. the
+			// static plugin regresses and starts 404ing) would otherwise report a stale "last seen"
+			// value that points at the reload path instead of the real failure — lastError carries
+			// the failure itself into the timeout message so that doesn't get misdiagnosed.
 			try {
 				const res = await getCss();
 				last = res.headers.get('cache-control');
+				lastError = null;
 				if (last === expected) return res;
-			} catch {
-				/* retry within the poll window */
+			} catch (err: any) {
+				lastError = err?.message ?? String(err);
 			}
 			if (++sinceResend >= 10) {
 				sinceResend = 0;
-				await setStaticConfig(yaml);
+				try {
+					await setStaticConfig(yaml);
+				} catch (err: any) {
+					lastError = err?.message ?? String(err);
+				}
 			}
 			await new Promise((r) => setTimeout(r, 200));
 		}
-		throw new Error(`Cache-Control never became ${JSON.stringify(expected)}; last seen: ${JSON.stringify(last)}`);
+		throw new Error(
+			`Cache-Control never became ${JSON.stringify(expected)}; last seen: ${JSON.stringify(last)}` +
+				(lastError ? `; last error: ${lastError}` : '')
+		);
 	}
 
 	test('default: public, max-age=0 with ETag/Last-Modified', async () => {

--- a/integrationTests/components/static-cache-headers.test.ts
+++ b/integrationTests/components/static-cache-headers.test.ts
@@ -6,10 +6,16 @@
  * set_component_file and poll until the next request reflects the new policy.
  *
  * Run: npm run test:integration -- "integrationTests/components/static-cache-headers.test.ts"
+ *
+ * Polling GETs use node:http directly rather than fetch()/undici: a global-fetch client stall
+ * (of unbounded, multi-second duration under some Node/undici builds — see harper#2025) can block
+ * this suite's poll loop for tens of seconds and read as the chokidar reload never landing, when
+ * it's really the polling request itself that never landed. node:http isn't subject to that stall.
  */
 import { suite, test, before, after } from 'node:test';
 import { strictEqual, ok } from 'node:assert';
 import { resolve } from 'node:path';
+import http from 'node:http';
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 // @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
 import { createApiClient } from '../apiTests/utils/client.mjs';
@@ -29,14 +35,31 @@ suite('static plugin cache-header options', (ctx: ContextWithHarper) => {
 		await teardownHarper(ctx);
 	});
 
-	async function getPath(path: string): Promise<Response> {
-		const res = await fetch(new URL(path, ctx.harper.httpURL));
-		strictEqual(res.status, 200);
-		await res.text(); // drain
-		return res;
+	interface SimpleResponse {
+		status: number;
+		headers: { get(name: string): string | null };
 	}
 
-	async function getCss(): Promise<Response> {
+	function getPath(path: string): Promise<SimpleResponse> {
+		return new Promise((resolvePromise, reject) => {
+			const u = new URL(path, ctx.harper.httpURL);
+			const req = http.request({ hostname: u.hostname, port: u.port, path: u.pathname }, (res) => {
+				res.on('data', () => {}); // drain
+				res.on('end', () => {
+					strictEqual(res.statusCode, 200);
+					const headers = res.headers;
+					resolvePromise({
+						status: res.statusCode!,
+						headers: { get: (name: string) => (headers[name.toLowerCase()] as string) ?? null },
+					});
+				});
+			});
+			req.on('error', reject);
+			req.end();
+		});
+	}
+
+	function getCss(): Promise<SimpleResponse> {
 		return getPath('/test.css');
 	}
 

--- a/integrationTests/database/ttlResetOnWrite.test.ts
+++ b/integrationTests/database/ttlResetOnWrite.test.ts
@@ -64,6 +64,11 @@ const CHECK_RESET_MS = TTL_MS + 200; // 2200ms — past original expiry, before 
 // Max extra slack for expiry (one background-sweep leeway).
 const EXPIRY_POLL_MS = 5_000;
 const EXPIRY_POLL_INTERVAL_MS = 200;
+// Cap each gone-check sample well under the interval, same reasoning as RESET_POLL_TIMEOUT_MS: a
+// sample bound to httpRequest's full default timeout could consume the whole window on one slow
+// response and get misread as the record surviving past its TTL (F-002 stale resurrection).
+const EXPIRY_POLL_SAMPLE_TIMEOUT_MS = 400;
+const EXPIRY_POLL_MIN_REMAINING_MS = 50;
 
 // The "record is RESET" check polls across the whole valid window (past the original expiry, up
 // to just before the reset-expiry) rather than sampling a single instant. Polling only helps if
@@ -251,18 +256,36 @@ suite(
 			}
 		}
 
+		interface AbsenceResult {
+			observed: boolean;
+			// true only if every sample that completed returned neither 200 nor 404 (timeout or
+			// transport error) — i.e. we never got a clean read at all. Mirrors
+			// PresenceResult.inconclusive: without it, a stalled response consuming the whole window
+			// reads as "still present" and gets reported as F-002 stale resurrection, when it's
+			// really "couldn't measure."
+			inconclusive: boolean;
+		}
+
 		/**
-		 * Poll until the record is absent (404) or timeout.
-		 * Returns true if it went absent within the deadline.
+		 * Poll until the record is absent (404), bounding every attempt and sleep to what's left
+		 * before the deadline so no sample can start once the window has closed. Returns as soon as
+		 * any sample observes it absent. Each attempt is capped at EXPIRY_POLL_SAMPLE_TIMEOUT_MS —
+		 * and further capped to the remaining time near the deadline — so one slow/stalled response
+		 * can't consume the whole window on its own.
 		 */
-		async function pollUntilGone(id: string, maxMs: number): Promise<boolean> {
+		async function pollUntilGone(id: string, maxMs: number): Promise<AbsenceResult> {
 			const deadline = Date.now() + maxMs;
-			while (Date.now() < deadline) {
-				const { status } = await getRecord(id);
-				if (status === 404) return true;
-				await sleep(EXPIRY_POLL_INTERVAL_MS);
+			let sawCleanSample = false;
+			while (deadline - Date.now() >= EXPIRY_POLL_MIN_REMAINING_MS) {
+				const remainingMs = deadline - Date.now();
+				const { status } = await getRecord(id, Math.min(EXPIRY_POLL_SAMPLE_TIMEOUT_MS, remainingMs));
+				if (status === 404) return { observed: true, inconclusive: false };
+				if (status === 200) sawCleanSample = true;
+				const sleepBudgetMs = deadline - Date.now();
+				if (sleepBudgetMs <= 0) break;
+				await sleep(Math.min(EXPIRY_POLL_INTERVAL_MS, sleepBudgetMs));
 			}
-			return false;
+			return { observed: false, inconclusive: !sawCleanSample };
 		}
 
 		interface PresenceResult {
@@ -356,7 +379,8 @@ suite(
 				if (waitForGone > 0) await sleep(waitForGone);
 
 				// Poll for gone (allow one extra sweep cycle).
-				result.goneObserved = await pollUntilGone(id, EXPIRY_POLL_MS);
+				const goneResult = await pollUntilGone(id, EXPIRY_POLL_MS);
+				result.goneObserved = goneResult.inconclusive ? 'not-checked' : goneResult.observed;
 
 				if (resetResult.inconclusive) {
 					// Never a clean read (200 or 404) within the window — a transport hiccup, not a
@@ -364,6 +388,12 @@ suite(
 					// TTL-reset defect.
 					result.finding =
 						'INCONCLUSIVE — no clean read within the reset-check window (transport issue, not a TTL defect)';
+				} else if (goneResult.inconclusive) {
+					// Same reasoning on the other side: never a clean read within the gone-check
+					// window. Without this branch a stalled/unmeasured gone-check reads as
+					// goneObserved=false and gets reported as F-002 stale resurrection.
+					result.finding =
+						'INCONCLUSIVE — no clean read within the gone-check window (transport issue, not a TTL defect)';
 				} else if (result.resetObserved && result.goneObserved) {
 					result.finding = 'RESET+EXPIRED — correct TTL reset';
 				} else if (!result.resetObserved && result.goneObserved) {
@@ -493,8 +523,13 @@ suite(
 				} else if (immediateStatus === 200) {
 					// Record present. Now wait to see if it expires at the RESET time or outlives it.
 					const expectedGoneBy = updateAt + TTL_MS + 2000; // reset TTL + 2s slack
-					const gone = await pollUntilGone(id, expectedGoneBy - Date.now() + 1000);
-					if (gone) {
+					const goneResult = await pollUntilGone(id, expectedGoneBy - Date.now() + 1000);
+					if (goneResult.inconclusive) {
+						// Never a clean read — a transport hiccup, not evidence either way. Counting
+						// this as resurrection would raise the suite's loudest data-integrity alarm
+						// for a stalled GET, which is exactly what this poll exists to avoid.
+						outcomes.transportErr++;
+					} else if (goneResult.observed) {
 						outcomes.cleanReset++;
 					} else {
 						// Still present past reset TTL — stale resurrection?

--- a/integrationTests/database/ttlResetOnWrite.test.ts
+++ b/integrationTests/database/ttlResetOnWrite.test.ts
@@ -175,19 +175,34 @@ suite(
 					headers['Content-Type'] = 'application/json';
 					headers['Content-Length'] = String(Buffer.byteLength(body));
 				}
+				let wallClockTimer: ReturnType<typeof setTimeout>;
+				const settle = (fn: () => void) => {
+					clearTimeout(wallClockTimer);
+					fn();
+				};
 				const req = http.request(
 					{ hostname: u.hostname, port: u.port, path: u.pathname + u.search, method, headers, timeout: timeoutMs },
 					(res) => {
 						const chunks: Buffer[] = [];
 						res.on('data', (chunk) => chunks.push(chunk));
-						res.on('error', reject);
+						res.on('error', (err) => settle(() => reject(err)));
 						res.on('end', () =>
-							resolvePromise({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf-8') })
+							settle(() =>
+								resolvePromise({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf-8') })
+							)
 						);
 					}
 				);
 				req.on('timeout', () => req.destroy(new Error(`request to ${url} timed out after ${timeoutMs}ms`)));
-				req.on('error', reject);
+				req.on('error', (err) => settle(() => reject(err)));
+				// `timeout` above is socket-*inactivity*, not wall-clock: a response that keeps
+				// emitting bytes inside each interval never trips it, so every poller's "one sample
+				// can't run past its budget" invariant isn't actually enforced by that option alone.
+				// This timer is the real absolute per-sample deadline.
+				wallClockTimer = setTimeout(
+					() => req.destroy(new Error(`request to ${url} timed out after ${timeoutMs}ms (wall-clock)`)),
+					timeoutMs
+				);
 				req.end(body);
 			});
 		}
@@ -378,6 +393,14 @@ suite(
 				// t=0: seed
 				const seedStatus = await restPut(id, { tag: 'seed', n: 0 });
 				const seedAt = Date.now();
+				if (seedStatus === 'error') {
+					// A transport failure here carries strictly less information than a half-measured
+					// window — MAX_PROBE_ATTEMPTS exists precisely for this class of bad luck, so this
+					// should retry too, not fail hard. Only a genuine non-2xx status is a real defect.
+					inconclusive = true;
+					result.finding = 'INCONCLUSIVE — seed PUT failed to complete (transport issue, not a TTL defect)';
+					return { result, inconclusive };
+				}
 				ok(seedStatus === 200 || seedStatus === 204, `[${label}] seed PUT returned ${seedStatus}`);
 
 				// t=N/2: update
@@ -390,6 +413,11 @@ suite(
 				const updateIssuedAt = Date.now();
 				const updateStatus = await doUpdate(id);
 				const updateAt = Date.now();
+				if (updateStatus === 'error') {
+					inconclusive = true;
+					result.finding = 'INCONCLUSIVE — update failed to complete (transport issue, not a TTL defect)';
+					return { result, inconclusive };
+				}
 				ok(
 					updateStatus === 200 || updateStatus === 204,
 					`[${label}] update returned ${updateStatus} (expected 200/204)`
@@ -415,27 +443,54 @@ suite(
 				const goneResult = await pollUntilGone(id, EXPIRY_POLL_MS);
 				result.goneObserved = goneResult.inconclusive ? 'not-checked' : goneResult.observed;
 
-				if (resetResult.inconclusive) {
-					// Never a clean read (200 or 404) within the window — a transport hiccup, not a
-					// TTL data signal either way. Reported distinctly so it isn't mistaken for a
-					// TTL-reset defect.
+				// A conclusive negative reading on EITHER axis is already actionable defect evidence
+				// on its own (NO-RESET from the reset axis, DID-NOT-EXPIRE/F-002 from the gone axis) —
+				// it must never be discarded by retrying just because the OTHER axis came back
+				// inconclusive. The retry wrapper only retries when `inconclusive` is true, so gating
+				// that flag on "is there NO conclusive defect to report" (not "is either axis merely
+				// unmeasured") is what keeps a measured defect from being thrown away and silently
+				// replaced by a lucky attempt on a fresh id.
+				const resetIsNoReset = !resetResult.inconclusive && resetResult.observed === false;
+				const goneIsDidNotExpire = !goneResult.inconclusive && goneResult.observed === false;
+
+				if (resetResult.inconclusive && goneResult.inconclusive) {
+					// Never a clean read (200 or 404) on EITHER axis — a transport hiccup, not a TTL
+					// data signal either way.
 					inconclusive = true;
 					result.finding =
-						'INCONCLUSIVE — no clean read within the reset-check window (transport issue, not a TTL defect)';
+						'INCONCLUSIVE — no clean read within either check window (transport issue, not a TTL defect)';
+				} else if (resetResult.inconclusive) {
+					if (goneIsDidNotExpire) {
+						// Reset axis unmeasured, but the gone axis conclusively caught the record
+						// outliving its TTL — that's the suite's loudest defect signal and stands on
+						// its own; don't let the unmeasured reset axis bury it under "INCONCLUSIVE".
+						result.finding =
+							'RESET-UNMEASURED + DID-NOT-EXPIRE (defect) — reset-check window inconclusive, but record conclusively outlived its TTL';
+					} else {
+						// Gone axis is clean (or also unreachable) and shows no defect — nothing to
+						// report, this window genuinely couldn't measure the reset.
+						inconclusive = true;
+						result.finding =
+							'INCONCLUSIVE — no clean read within the reset-check window (transport issue, not a TTL defect)';
+					}
 				} else if (goneResult.inconclusive) {
-					// Same reasoning on the other side: the deciding (last full-budget) sample in the
-					// gone-check window didn't complete cleanly — could follow several clean 200s
-					// earlier in the window (see pollUntilGone's docblock). Without this branch a
-					// stalled/unmeasured gone-check reads as goneObserved=false and gets reported as
-					// F-002 stale resurrection.
-					inconclusive = true;
-					result.finding =
-						'INCONCLUSIVE — no clean read within the gone-check window (transport issue, not a TTL defect)';
-				} else if (result.resetObserved && result.goneObserved) {
+					if (resetIsNoReset) {
+						// Symmetric case: reset axis conclusively measured NO-RESET; the deciding
+						// (last full-budget) sample in the gone-check window didn't complete cleanly —
+						// could follow several clean 200s earlier in the window (see pollUntilGone's
+						// docblock) — but the reset defect is already conclusive regardless.
+						result.finding =
+							'NO-RESET (defect) + GONE-UNMEASURED — reset conclusively did not happen; gone-check window inconclusive';
+					} else {
+						inconclusive = true;
+						result.finding =
+							'INCONCLUSIVE — no clean read within the gone-check window (transport issue, not a TTL defect)';
+					}
+				} else if (result.resetObserved === true && result.goneObserved === true) {
 					result.finding = 'RESET+EXPIRED — correct TTL reset';
-				} else if (!result.resetObserved && result.goneObserved) {
+				} else if (result.resetObserved === false && result.goneObserved === true) {
 					result.finding = 'NO-RESET — expired at original write time (defect if other surfaces reset)';
-				} else if (result.resetObserved && !result.goneObserved) {
+				} else if (result.resetObserved === true && result.goneObserved === false) {
 					result.finding = 'RESET but DID-NOT-EXPIRE — record outlived reset window (defect)';
 				} else {
 					result.finding = 'NEITHER — unexpected state';
@@ -454,7 +509,11 @@ suite(
 		 * while the result is INCONCLUSIVE. The reset-check window is inherently tight (see
 		 * MAX_PROBE_ATTEMPTS above), so a single unlucky window shouldn't fail the suite this change
 		 * exists to stabilize — but an attempt that's genuinely RESET/NO-RESET/DID-NOT-EXPIRE is
-		 * conclusive and is never retried or discarded.
+		 * conclusive and is never retried or discarded. This holds even when only ONE axis measured
+		 * cleanly: probeSurfaceOnce only sets `inconclusive` when there's no conclusive defect signal
+		 * on either axis (see its RESET-UNMEASURED/GONE-UNMEASURED branches) — a mixed
+		 * unmeasured-axis-plus-conclusive-defect result is never retried either, so a real defect
+		 * measured on one axis can't be thrown away just because the other axis stalled.
 		 */
 		async function probeSurface(
 			label: string,
@@ -540,6 +599,13 @@ suite(
 				resurrection: 0, // record survives past the reset TTL (stale resurrection F-002)
 				updateError: 0, // update returned non-2xx
 				transportErr: 0,
+				// The update itself landed at/after the record's natural expiry — this round never
+				// entered the intended "narrow window right before expiry" race at all, regardless of
+				// what the immediate check below would have shown. Excluded from the F-002 coverage
+				// floor's denominator (see the assertion below) rather than counted as any other
+				// outcome, so a loaded runner that keeps missing the window can't manufacture either a
+				// false pass (nothing raced, so nothing could resurrect) or a false coverage failure.
+				windowMissed: 0,
 			};
 
 			for (let round = 0; round < ROUNDS; round++) {
@@ -572,16 +638,32 @@ suite(
 					await deleteRecord(id);
 					continue;
 				}
+				if (updateAt >= seedAt + TTL_MS) {
+					// The update's own round-trip was slow enough that it landed after natural expiry
+					// would already have fired — this round missed the race window it was meant to
+					// probe, independent of whatever the record's state turns out to be.
+					outcomes.windowMissed++;
+					await deleteRecord(id);
+					continue;
+				}
 
 				// Short pause to let the expiry sweep possibly run.
 				await sleep(200);
 
-				// Check immediately after the update.
-				const { status: immediateStatus } = await getRecord(id);
+				// Check immediately after the update, tightly bounded: an unbounded read here could
+				// itself take long enough to cross the natural-expiry boundary, in which case a 404 no
+				// longer distinguishes "the expiry scanner won" from "this GET was just slow" — see the
+				// re-check below.
+				const { status: immediateStatus } = await getRecord(id, EXPIRY_POLL_SAMPLE_TIMEOUT_MS);
 
-				if (immediateStatus === 404) {
+				if (immediateStatus === 404 && Date.now() <= updateAt + TTL_MS) {
 					// The expiry scanner won — update was lost or ran before expiry committed.
 					outcomes.silentLoss++;
+				} else if (immediateStatus === 404) {
+					// A 404 that only completed after the record's natural (reset) expiry could
+					// legitimately reflect it — the GET itself was the slow part, not the write path.
+					// Undecidable from this sample alone.
+					outcomes.transportErr++;
 				} else if (immediateStatus === 200) {
 					// Record present. Now wait to see if it expires at the RESET time or outlives it.
 					const expectedGoneBy = updateAt + TTL_MS + 2000; // reset TTL + 2s slack
@@ -610,7 +692,8 @@ suite(
 					`  silentLoss   = ${outcomes.silentLoss}  ← update ACKed but immediately 404\n` +
 					`  resurrection = ${outcomes.resurrection}  ← F-002 family: stale value outlives reset TTL\n` +
 					`  updateError  = ${outcomes.updateError}\n` +
-					`  transportErr = ${outcomes.transportErr}\n`
+					`  transportErr = ${outcomes.transportErr}\n` +
+					`  windowMissed = ${outcomes.windowMissed}  ← update landed at/after natural expiry, never raced\n`
 			);
 
 			// silentLoss is tolerable (expiry beat the update — a timing race, not a data defect)
@@ -621,19 +704,28 @@ suite(
 			);
 			// At least one round should complete cleanly (basic smoke guard).
 			ok(outcomes.cleanReset + outcomes.silentLoss > 0, `No round completed cleanly — environment likely broken`);
+			// Rounds that never entered the race window (windowMissed) can't tell us anything about
+			// F-002 either way — excluded from the denominator so a loaded runner that keeps missing
+			// the window can't manufacture a coverage failure out of a race that never happened.
+			const racedRounds = ROUNDS - outcomes.windowMissed;
+			ok(
+				racedRounds > 0,
+				`all ${ROUNDS} rounds missed the intended race window (update landed at/after natural expiry) — ` +
+					`environment too slow to run this probe meaningfully [${ENGINE}]`
+			);
 			// Only cleanReset and resurrection rounds actually exercise the F-002 property —
 			// silentLoss and updateError both `continue` before the resurrection check ever runs.
 			// A first version of this guard capped transportErr alone, which missed that: a probe
 			// where every round lands in silentLoss (a legitimate outcome of the exact race this
 			// probe induces) would pass resurrection===0 having measured the property in zero
-			// rounds. Assert on the measured set directly instead of capping the unmeasured one.
+			// rounds. Assert on the measured set directly, over the raced rounds only.
 			ok(
-				outcomes.cleanReset + outcomes.resurrection >= ROUNDS / 2,
-				`only ${outcomes.cleanReset + outcomes.resurrection}/${ROUNDS} rounds actually measured the F-002 ` +
-					`property (cleanReset=${outcomes.cleanReset}, resurrection=${outcomes.resurrection}, ` +
+				outcomes.cleanReset + outcomes.resurrection >= racedRounds / 2,
+				`only ${outcomes.cleanReset + outcomes.resurrection}/${racedRounds} raced rounds actually measured ` +
+					`the F-002 property (cleanReset=${outcomes.cleanReset}, resurrection=${outcomes.resurrection}, ` +
 					`silentLoss=${outcomes.silentLoss}, updateError=${outcomes.updateError}, ` +
-					`transportErr=${outcomes.transportErr}) — the resurrection===0 check above isn't meaningful ` +
-					`with this little coverage [${ENGINE}]`
+					`transportErr=${outcomes.transportErr}, windowMissed=${outcomes.windowMissed}) — the ` +
+					`resurrection===0 check above isn't meaningful with this little coverage [${ENGINE}]`
 			);
 		});
 	}

--- a/integrationTests/database/ttlResetOnWrite.test.ts
+++ b/integrationTests/database/ttlResetOnWrite.test.ts
@@ -601,7 +601,7 @@ suite(
 				resurrection: 0, // record survives past the reset TTL (stale resurrection F-002)
 				updateError: 0, // update returned non-2xx
 				transportErr: 0,
-				// The update itself landed at/after the record's natural expiry — this round never
+				// The update was issued at/after the earliest possible natural expiry — this round never
 				// entered the intended "narrow window right before expiry" race at all, regardless of
 				// what the immediate check below would have shown. Excluded from the F-002 coverage
 				// floor's denominator (see the assertion below) rather than counted as any other
@@ -613,11 +613,10 @@ suite(
 			for (let round = 0; round < ROUNDS; round++) {
 				const id = `qa269-race-${round}`;
 
-				// Seed. The server applies the write at some point at-or-before the response lands, so
-				// the record's true expiry is anywhere in [seedIssuedAt + TTL_MS, seedAt + TTL_MS].
+				// Seed. The server cannot apply the write before it is issued, so seedIssuedAt + TTL_MS
+				// is the earliest possible natural expiry.
 				const seedIssuedAt = Date.now();
 				const seedStatus = await restPut(id, { tag: 'seed-race', n: 0 });
-				const seedAt = Date.now();
 				if (seedStatus === 'error' || (seedStatus !== 200 && seedStatus !== 204)) {
 					outcomes.transportErr++;
 					continue;
@@ -649,10 +648,10 @@ suite(
 				}
 				// Gate on when the update was ISSUED, not when its response landed (updateAt): the
 				// server could have applied it well before the response returned, so gating on
-				// response time could discard a round that genuinely raced. seedAt (response time,
-				// the LATEST possible natural expiry) stays the comparison bound — the conservative
-				// choice, so this only marks a round windowMissed when it's certain to have missed.
-				if (updateIssuedAt >= seedAt + TTL_MS) {
+				// response time could discard a round that genuinely raced. The earliest possible
+				// natural expiry is anchored on seedIssuedAt; after that point the update may recreate
+				// an already-expired record instead of exercising the intended race.
+				if (updateIssuedAt >= seedIssuedAt + TTL_MS) {
 					// The update was issued after natural expiry could already have fired — this round
 					// missed the race window it was meant to probe, independent of whatever the
 					// record's state turns out to be.
@@ -707,7 +706,7 @@ suite(
 					`  resurrection = ${outcomes.resurrection}  ← F-002 family: stale value outlives reset TTL\n` +
 					`  updateError  = ${outcomes.updateError}\n` +
 					`  transportErr = ${outcomes.transportErr}\n` +
-					`  windowMissed = ${outcomes.windowMissed}  ← update landed at/after natural expiry, never raced\n`
+					`  windowMissed = ${outcomes.windowMissed}  ← update issued at/after earliest natural expiry, never raced\n`
 			);
 
 			// silentLoss is tolerable (expiry beat the update — a timing race, not a data defect)
@@ -724,7 +723,7 @@ suite(
 			const racedRounds = ROUNDS - outcomes.windowMissed;
 			ok(
 				racedRounds > 0,
-				`all ${ROUNDS} rounds missed the intended race window (update landed at/after natural expiry) — ` +
+				`all ${ROUNDS} rounds missed the intended race window (update issued at/after earliest natural expiry) — ` +
 					`environment too slow to run this probe meaningfully [${ENGINE}]`
 			);
 			// At least one round should complete cleanly (basic smoke guard).

--- a/integrationTests/database/ttlResetOnWrite.test.ts
+++ b/integrationTests/database/ttlResetOnWrite.test.ts
@@ -85,7 +85,10 @@ const EXPIRY_POLL_SAMPLE_TIMEOUT_MS = 400;
 // the overall window so a slow/stalled one is abandoned in time for a retry within it.
 const RESET_POLL_INTERVAL_MS = 150;
 const RESET_POLL_TIMEOUT_MS = 300;
-// Safety margin before the reset-expiry deadline, so the last poll isn't racing the sweep itself.
+// Gap between the conservative intermediate-sample deadline and the true reset-expiry. Bounds
+// only the INTERMEDIATE samples in pollForPresent — the final sample deliberately runs all the
+// way to the true expiry (see pollForPresent's docblock), so this no longer describes "the last
+// poll," just how early the intermediate phase backs off to leave room for that final attempt.
 const RESET_CHECK_SAFETY_MS = 200;
 
 const skipSuite = process.platform === 'win32' || process.env.HARPER_RUNTIME === 'bun';
@@ -581,6 +584,15 @@ suite(
 			);
 			// At least one round should complete cleanly (basic smoke guard).
 			ok(outcomes.cleanReset + outcomes.silentLoss > 0, `No round completed cleanly — environment likely broken`);
+			// transportErr is unbounded by design (a stalled deciding sample routes here rather than
+			// a false resurrection alarm — see pollUntilGone), but if it dominates the rounds, the
+			// resurrection=== 0 assertion above is passing on data that was never actually measured.
+			// Guard against the probe going green while having measured almost nothing.
+			ok(
+				outcomes.transportErr <= ROUNDS / 2,
+				`${outcomes.transportErr}/${ROUNDS} rounds were transport-inconclusive — the F-002 check above didn't ` +
+					`get enough conclusive rounds to be meaningful [${ENGINE}]`
+			);
 		});
 	}
 );

--- a/integrationTests/database/ttlResetOnWrite.test.ts
+++ b/integrationTests/database/ttlResetOnWrite.test.ts
@@ -29,6 +29,9 @@
  * request-to-request timing against a TTL clock, and a global-fetch client stall (of unbounded,
  * multi-second duration under some Node/undici builds — see harper#2025) reads as a false
  * NO-RESET no matter how the check windows are computed. node:http isn't subject to that stall.
+ * Root cause: nodejs/undici#5600 (unref'd idle-socket-validation setImmediate stalls fetch() on an
+ * otherwise-idle event loop), bundled into Node via undici 8.9.0 (used by 26.5.1); fixed upstream by
+ * nodejs/undici#5609 but not yet in a released undici/Node build as of this writing.
  */
 import { suite, test, before, after } from 'node:test';
 import { ok } from 'node:assert';

--- a/integrationTests/database/ttlResetOnWrite.test.ts
+++ b/integrationTests/database/ttlResetOnWrite.test.ts
@@ -45,6 +45,7 @@ import { ok } from 'node:assert';
 import { resolve } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 import http from 'node:http';
+import https from 'node:https';
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 // @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
 import { createApiClient } from '../apiTests/utils/client.mjs';
@@ -170,6 +171,7 @@ suite(
 		): Promise<{ status: number; body: string }> {
 			return new Promise((resolvePromise, reject) => {
 				const u = new URL(url);
+				const transport = u.protocol === 'https:' ? https : http;
 				const headers: Record<string, string> = { Authorization: auth };
 				if (body !== undefined) {
 					headers['Content-Type'] = 'application/json';
@@ -180,7 +182,7 @@ suite(
 					clearTimeout(wallClockTimer);
 					fn();
 				};
-				const req = http.request(
+				const req = transport.request(
 					{ hostname: u.hostname, port: u.port, path: u.pathname + u.search, method, headers, timeout: timeoutMs },
 					(res) => {
 						const chunks: Buffer[] = [];

--- a/integrationTests/database/ttlResetOnWrite.test.ts
+++ b/integrationTests/database/ttlResetOnWrite.test.ts
@@ -611,7 +611,9 @@ suite(
 			for (let round = 0; round < ROUNDS; round++) {
 				const id = `qa269-race-${round}`;
 
-				// Seed
+				// Seed. The server applies the write at some point at-or-before the response lands, so
+				// the record's true expiry is anywhere in [seedIssuedAt + TTL_MS, seedAt + TTL_MS].
+				const seedIssuedAt = Date.now();
 				const seedStatus = await restPut(id, { tag: 'seed-race', n: 0 });
 				const seedAt = Date.now();
 				if (seedStatus === 'error' || (seedStatus !== 200 && seedStatus !== 204)) {
@@ -619,12 +621,17 @@ suite(
 					continue;
 				}
 
-				// Wait until just before the natural expiry fires.
-				const fireAt = seedAt + TTL_MS - WINDOW_BEFORE_EXPIRY_MS;
+				// Wait until just before the EARLIEST possible natural expiry (anchored on the seed's
+				// ISSUE time, not its response time): anchoring on the response time — as an earlier
+				// version of this probe did — could put fireAt after the record had already expired
+				// if the seed's own round-trip exceeded WINDOW_BEFORE_EXPIRY_MS, silently turning the
+				// "race" into a plain post-expiry write against a dead key.
+				const fireAt = seedIssuedAt + TTL_MS - WINDOW_BEFORE_EXPIRY_MS;
 				const waitMs = fireAt - Date.now();
 				if (waitMs > 0) await sleep(waitMs);
 
 				// Fire the update in the expiry race window.
+				const updateIssuedAt = Date.now();
 				const updateStatus = await restPut(id, { tag: `raced${round}`, n: round + 1 });
 				const updateAt = Date.now();
 
@@ -638,10 +645,15 @@ suite(
 					await deleteRecord(id);
 					continue;
 				}
-				if (updateAt >= seedAt + TTL_MS) {
-					// The update's own round-trip was slow enough that it landed after natural expiry
-					// would already have fired — this round missed the race window it was meant to
-					// probe, independent of whatever the record's state turns out to be.
+				// Gate on when the update was ISSUED, not when its response landed (updateAt): the
+				// server could have applied it well before the response returned, so gating on
+				// response time could discard a round that genuinely raced. seedAt (response time,
+				// the LATEST possible natural expiry) stays the comparison bound — the conservative
+				// choice, so this only marks a round windowMissed when it's certain to have missed.
+				if (updateIssuedAt >= seedAt + TTL_MS) {
+					// The update was issued after natural expiry could already have fired — this round
+					// missed the race window it was meant to probe, independent of whatever the
+					// record's state turns out to be.
 					outcomes.windowMissed++;
 					await deleteRecord(id);
 					continue;
@@ -702,17 +714,19 @@ suite(
 				outcomes.resurrection === 0,
 				`F-002 stale resurrection detected in ${outcomes.resurrection}/${ROUNDS} rounds [${ENGINE}]`
 			);
-			// At least one round should complete cleanly (basic smoke guard).
-			ok(outcomes.cleanReset + outcomes.silentLoss > 0, `No round completed cleanly — environment likely broken`);
 			// Rounds that never entered the race window (windowMissed) can't tell us anything about
 			// F-002 either way — excluded from the denominator so a loaded runner that keeps missing
 			// the window can't manufacture a coverage failure out of a race that never happened.
+			// Checked before the generic smoke guard below so an all-windowMissed run reports its
+			// actual, more specific cause instead of a generic "environment likely broken".
 			const racedRounds = ROUNDS - outcomes.windowMissed;
 			ok(
 				racedRounds > 0,
 				`all ${ROUNDS} rounds missed the intended race window (update landed at/after natural expiry) — ` +
 					`environment too slow to run this probe meaningfully [${ENGINE}]`
 			);
+			// At least one round should complete cleanly (basic smoke guard).
+			ok(outcomes.cleanReset + outcomes.silentLoss > 0, `No round completed cleanly — environment likely broken`);
 			// Only cleanReset and resurrection rounds actually exercise the F-002 property —
 			// silentLoss and updateError both `continue` before the resurrection check ever runs.
 			// A first version of this guard capped transportErr alone, which missed that: a probe

--- a/integrationTests/database/ttlResetOnWrite.test.ts
+++ b/integrationTests/database/ttlResetOnWrite.test.ts
@@ -64,9 +64,10 @@ const CHECK_RESET_MS = TTL_MS + 200; // 2200ms — past original expiry, before 
 // Max extra slack for expiry (one background-sweep leeway).
 const EXPIRY_POLL_MS = 5_000;
 const EXPIRY_POLL_INTERVAL_MS = 200;
-// Cap each gone-check sample well under the interval, same reasoning as RESET_POLL_TIMEOUT_MS: a
-// sample bound to httpRequest's full default timeout could consume the whole window on one slow
-// response and get misread as the record surviving past its TTL (F-002 stale resurrection).
+// Cap each gone-check sample well under the overall window, same reasoning as
+// RESET_POLL_TIMEOUT_MS: a sample bound to httpRequest's full default timeout could consume the
+// whole window on one slow response and get misread as the record surviving past its TTL (F-002
+// stale resurrection).
 const EXPIRY_POLL_SAMPLE_TIMEOUT_MS = 400;
 const EXPIRY_POLL_MIN_REMAINING_MS = 50;
 
@@ -75,7 +76,7 @@ const EXPIRY_POLL_MIN_REMAINING_MS = 50;
 // each sample is abandoned quickly: the window itself is a few hundred ms, so a sample bound to
 // httpRequest's full default timeout would consume the whole window on one slow response, same
 // as the single-check version it replaces. RESET_POLL_TIMEOUT_MS keeps each sample well under
-// the poll interval so a slow/stalled one is abandoned in time for a retry within the window.
+// the overall window so a slow/stalled one is abandoned in time for a retry within it.
 const RESET_POLL_INTERVAL_MS = 150;
 const RESET_POLL_TIMEOUT_MS = 300;
 // Safety margin before the reset-expiry deadline, so the last poll isn't racing the sweep itself.
@@ -275,17 +276,23 @@ suite(
 		 */
 		async function pollUntilGone(id: string, maxMs: number): Promise<AbsenceResult> {
 			const deadline = Date.now() + maxMs;
-			let sawCleanSample = false;
+			// Conclusiveness must come from the LAST completed sample, not "any sample, anywhere in
+			// the window": a 200 near the start only proves the record hadn't expired *yet*, and
+			// stays true no matter how stale it gets. If it were sticky, one early 200 (the common
+			// case — pollUntilGone is typically entered right after an immediate present-check) would
+			// make every later stall in the rest of the window read as conclusive "still present",
+			// which is exactly the stall-reads-as-defect failure this poll exists to prevent.
+			let lastSampleClean = false;
 			while (deadline - Date.now() >= EXPIRY_POLL_MIN_REMAINING_MS) {
 				const remainingMs = deadline - Date.now();
 				const { status } = await getRecord(id, Math.min(EXPIRY_POLL_SAMPLE_TIMEOUT_MS, remainingMs));
 				if (status === 404) return { observed: true, inconclusive: false };
-				if (status === 200) sawCleanSample = true;
+				lastSampleClean = status === 200;
 				const sleepBudgetMs = deadline - Date.now();
 				if (sleepBudgetMs <= 0) break;
 				await sleep(Math.min(EXPIRY_POLL_INTERVAL_MS, sleepBudgetMs));
 			}
-			return { observed: false, inconclusive: !sawCleanSample };
+			return { observed: false, inconclusive: !lastSampleClean };
 		}
 
 		interface PresenceResult {

--- a/integrationTests/database/ttlResetOnWrite.test.ts
+++ b/integrationTests/database/ttlResetOnWrite.test.ts
@@ -63,11 +63,13 @@ const EXPIRY_POLL_MS = 5_000;
 const EXPIRY_POLL_INTERVAL_MS = 200;
 
 // The "record is RESET" check polls across the whole valid window (past the original expiry, up
-// to just before the reset-expiry) rather than sampling a single instant. A single check is
-// vulnerable to its own request latency: if that one GET happens to be slow, it can land after
-// the reset-expiry has *also* passed and misread a genuine reset as NO-RESET. Polling means only
-// a single sample within the window needs to land on time.
+// to just before the reset-expiry) rather than sampling a single instant. Polling only helps if
+// each sample is abandoned quickly: the window itself is a few hundred ms, so a sample bound to
+// httpRequest's full default timeout would consume the whole window on one slow response, same
+// as the single-check version it replaces. RESET_POLL_TIMEOUT_MS keeps each sample well under
+// the poll interval so a slow/stalled one is abandoned in time for a retry within the window.
 const RESET_POLL_INTERVAL_MS = 150;
+const RESET_POLL_TIMEOUT_MS = 300;
 // Safety margin before the reset-expiry deadline, so the last poll isn't racing the sweep itself.
 const RESET_CHECK_SAFETY_MS = 200;
 
@@ -217,9 +219,9 @@ suite(
 			}
 		}
 
-		async function getRecord(id: string): Promise<{ status: number | 'error'; body: any }> {
+		async function getRecord(id: string, timeoutMs?: number): Promise<{ status: number | 'error'; body: any }> {
 			try {
-				const { status, body: rawBody } = await httpRequest('GET', `${httpURL}/Expiry/${id}`);
+				const { status, body: rawBody } = await httpRequest('GET', `${httpURL}/Expiry/${id}`, undefined, timeoutMs);
 				let body: any = null;
 				if (status === 200) {
 					try {
@@ -256,19 +258,34 @@ suite(
 			return false;
 		}
 
+		interface PresenceResult {
+			observed: boolean;
+			// true only if every sample in the window failed to complete (timeout/transport error) —
+			// i.e. we never got a clean read (200 or 404) at all. Distinguishes "couldn't measure"
+			// from an actual NO-RESET signal, so a transport hiccup doesn't get reported as a TTL
+			// data-integrity defect.
+			inconclusive: boolean;
+		}
+
 		/**
 		 * Poll for the record being present (200) up until deadlineAt, then take one final sample.
-		 * Returns true as soon as any sample observes it present. See RESET_POLL_INTERVAL_MS above
-		 * for why a single point-in-time check isn't reliable here.
+		 * Returns as soon as any sample observes it present. Each sample is bound to
+		 * RESET_POLL_TIMEOUT_MS (see its definition above) so one slow/stalled response can't
+		 * consume the whole window — a plain retry loop without that bound would inherit
+		 * httpRequest's full default timeout per sample and gain nothing over a single check.
 		 */
-		async function pollForPresent(id: string, deadlineAt: number): Promise<boolean> {
+		async function pollForPresent(id: string, deadlineAt: number): Promise<PresenceResult> {
+			let sawCleanSample = false;
 			while (Date.now() < deadlineAt) {
-				const { status } = await getRecord(id);
-				if (status === 200) return true;
+				const { status } = await getRecord(id, RESET_POLL_TIMEOUT_MS);
+				if (status === 200) return { observed: true, inconclusive: false };
+				if (status === 404) sawCleanSample = true;
 				await sleep(RESET_POLL_INTERVAL_MS);
 			}
-			const { status } = await getRecord(id);
-			return status === 200;
+			const { status } = await getRecord(id, RESET_POLL_TIMEOUT_MS);
+			if (status === 200) return { observed: true, inconclusive: false };
+			if (status === 404) sawCleanSample = true;
+			return { observed: false, inconclusive: !sawCleanSample };
 		}
 
 		// ── generic harness ───────────────────────────────────────────────────────
@@ -295,6 +312,11 @@ suite(
 				// t=N/2: update
 				const waitToUpdate = seedAt + HALF_TTL_MS - Date.now();
 				if (waitToUpdate > 0) await sleep(waitToUpdate);
+				// Anchor the reset-expiry deadline on when the update was ISSUED, not when its
+				// response returned: the server applies the reset at-or-before the response lands,
+				// so anchoring post-response erodes RESET_CHECK_SAFETY_MS by the update's own
+				// round-trip time.
+				const updateIssuedAt = Date.now();
 				const updateStatus = await doUpdate(id);
 				const updateAt = Date.now();
 				ok(
@@ -308,8 +330,9 @@ suite(
 				const waitForCheck = checkResetAt - Date.now();
 				if (waitForCheck > 0) await sleep(waitForCheck);
 
-				const resetDeadline = updateAt + TTL_MS - RESET_CHECK_SAFETY_MS;
-				result.resetObserved = await pollForPresent(id, resetDeadline);
+				const resetDeadline = updateIssuedAt + TTL_MS - RESET_CHECK_SAFETY_MS;
+				const resetResult = await pollForPresent(id, resetDeadline);
+				result.resetObserved = resetResult.inconclusive ? 'not-checked' : resetResult.observed;
 
 				// Now wait until well past the RESET expiry window (update_time + TTL_MS + slack).
 				const checkGoneAt = updateAt + TTL_MS + 1500;
@@ -319,7 +342,13 @@ suite(
 				// Poll for gone (allow one extra sweep cycle).
 				result.goneObserved = await pollUntilGone(id, EXPIRY_POLL_MS);
 
-				if (result.resetObserved && result.goneObserved) {
+				if (resetResult.inconclusive) {
+					// Never a clean read (200 or 404) within the window — a transport hiccup, not a
+					// TTL data signal either way. Reported distinctly so it isn't mistaken for a
+					// TTL-reset defect.
+					result.finding =
+						'INCONCLUSIVE — no clean read within the reset-check window (transport issue, not a TTL defect)';
+				} else if (result.resetObserved && result.goneObserved) {
 					result.finding = 'RESET+EXPIRED — correct TTL reset';
 				} else if (!result.resetObserved && result.goneObserved) {
 					result.finding = 'NO-RESET — expired at original write time (defect if other surfaces reset)';

--- a/integrationTests/database/ttlResetOnWrite.test.ts
+++ b/integrationTests/database/ttlResetOnWrite.test.ts
@@ -75,6 +75,9 @@ const RESET_POLL_INTERVAL_MS = 150;
 const RESET_POLL_TIMEOUT_MS = 300;
 // Safety margin before the reset-expiry deadline, so the last poll isn't racing the sweep itself.
 const RESET_CHECK_SAFETY_MS = 200;
+// Below this much time left in the window, a sample is doomed before it starts (its timeout would
+// be clamped to a few ms) — skip it rather than counting a guaranteed failure toward "no clean read".
+const RESET_POLL_MIN_REMAINING_MS = 50;
 
 const skipSuite = process.platform === 'win32' || process.env.HARPER_RUNTIME === 'bun';
 
@@ -264,14 +267,16 @@ suite(
 
 		interface PresenceResult {
 			observed: boolean;
-			// true only if every sample that completed *inside* the window (deadlineAt) failed to
-			// return a clean read (200 or 404) — i.e. we never got an in-window clean read at all.
-			// A 404 that lands after deadlineAt doesn't count as a clean sample: by the time it
-			// completed, the real reset-expiry (deadlineAt + RESET_CHECK_SAFETY_MS) may already have
-			// passed, so that 404 could reflect the record correctly expiring late rather than a
-			// genuine NO-RESET. Distinguishes "couldn't measure" from an actual NO-RESET signal, so a
-			// transport hiccup — or a sample that straddles the deadline — never gets reported as a
-			// TTL data-integrity defect.
+			// true only if every sample that completed inside the real reset-expiry (expiresAt)
+			// failed to return a clean read (200 or 404) — i.e. we never got a trustworthy read at
+			// all. A 404 that lands after expiresAt doesn't count as a clean sample: the record may
+			// have genuinely expired only *because* the check ran late, so that 404 could reflect a
+			// correct reset rather than a real NO-RESET. Note expiresAt, not the (earlier, more
+			// conservative) polling deadlineAt: a 404 landing between the two is still trustworthy —
+			// the real reset-expiry hasn't passed — and treating it as unclean would bias this check
+			// toward masking the very NO-RESET regressions it exists to catch. Distinguishes
+			// "couldn't measure" from an actual NO-RESET signal, so a transport hiccup never gets
+			// reported as a TTL data-integrity defect.
 			inconclusive: boolean;
 		}
 
@@ -280,15 +285,17 @@ suite(
 		 * before deadlineAt so no sample can start once the window has closed. Returns as soon as
 		 * any sample observes it present. Each attempt is capped at RESET_POLL_TIMEOUT_MS (see its
 		 * definition above) — and further capped to the remaining time near the deadline — so one
-		 * slow/stalled response can't consume the whole window or run past it.
+		 * slow/stalled response can't consume the whole window or run past it. Samples with less
+		 * than RESET_POLL_MIN_REMAINING_MS left are skipped rather than attempted: a timeout clamped
+		 * to a few ms is a guaranteed failure, not a real absence of a clean read.
 		 */
-		async function pollForPresent(id: string, deadlineAt: number): Promise<PresenceResult> {
+		async function pollForPresent(id: string, deadlineAt: number, expiresAt: number): Promise<PresenceResult> {
 			let sawCleanSample = false;
-			while (Date.now() < deadlineAt) {
+			while (deadlineAt - Date.now() >= RESET_POLL_MIN_REMAINING_MS) {
 				const remainingMs = deadlineAt - Date.now();
 				const { status } = await getRecord(id, Math.min(RESET_POLL_TIMEOUT_MS, remainingMs));
 				if (status === 200) return { observed: true, inconclusive: false };
-				if (status === 404 && Date.now() <= deadlineAt) sawCleanSample = true;
+				if (status === 404 && Date.now() <= expiresAt) sawCleanSample = true;
 				const sleepBudgetMs = deadlineAt - Date.now();
 				if (sleepBudgetMs <= 0) break;
 				await sleep(Math.min(RESET_POLL_INTERVAL_MS, sleepBudgetMs));
@@ -339,7 +346,8 @@ suite(
 				if (waitForCheck > 0) await sleep(waitForCheck);
 
 				const resetDeadline = updateIssuedAt + TTL_MS - RESET_CHECK_SAFETY_MS;
-				const resetResult = await pollForPresent(id, resetDeadline);
+				const resetExpiresAt = updateIssuedAt + TTL_MS;
+				const resetResult = await pollForPresent(id, resetDeadline, resetExpiresAt);
 				result.resetObserved = resetResult.inconclusive ? 'not-checked' : resetResult.observed;
 
 				// Now wait until well past the RESET expiry window (update_time + TTL_MS + slack).

--- a/integrationTests/database/ttlResetOnWrite.test.ts
+++ b/integrationTests/database/ttlResetOnWrite.test.ts
@@ -24,11 +24,17 @@
  * Reproduction:
  *   npm run test:integration -- "integrationTests/database/ttlResetOnWrite.test.ts"
  *   HARPER_STORAGE_ENGINE=lmdb npm run test:integration -- "integrationTests/database/ttlResetOnWrite.test.ts"
+ *
+ * Uses node:http directly rather than fetch()/undici: this suite's whole premise is measuring
+ * request-to-request timing against a TTL clock, and a global-fetch client stall (of unbounded,
+ * multi-second duration under some Node/undici builds — see harper#2025) reads as a false
+ * NO-RESET no matter how the check windows are computed. node:http isn't subject to that stall.
  */
 import { suite, test, before, after } from 'node:test';
 import { ok } from 'node:assert';
 import { resolve } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
+import http from 'node:http';
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 // @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
 import { createApiClient } from '../apiTests/utils/client.mjs';
@@ -55,6 +61,15 @@ const CHECK_RESET_MS = TTL_MS + 200; // 2200ms — past original expiry, before 
 // Max extra slack for expiry (one background-sweep leeway).
 const EXPIRY_POLL_MS = 5_000;
 const EXPIRY_POLL_INTERVAL_MS = 200;
+
+// The "record is RESET" check polls across the whole valid window (past the original expiry, up
+// to just before the reset-expiry) rather than sampling a single instant. A single check is
+// vulnerable to its own request latency: if that one GET happens to be slow, it can land after
+// the reset-expiry has *also* passed and misread a genuine reset as NO-RESET. Polling means only
+// a single sample within the window needs to land on time.
+const RESET_POLL_INTERVAL_MS = 150;
+// Safety margin before the reset-expiry deadline, so the last poll isn't racing the sweep itself.
+const RESET_CHECK_SAFETY_MS = 200;
 
 const skipSuite = process.platform === 'win32' || process.env.HARPER_RUNTIME === 'bun';
 
@@ -93,12 +108,8 @@ suite(
 			const deadline = Date.now() + 30_000;
 			while (Date.now() < deadline) {
 				try {
-					const r = await fetch(`${httpURL}/Expiry/`, {
-						method: 'GET',
-						headers: { Authorization: auth },
-						signal: AbortSignal.timeout(3_000),
-					});
-					if (r.status !== 503) break;
+					const { status } = await httpRequest('GET', `${httpURL}/Expiry/`);
+					if (status !== 503) break;
 				} catch {
 					/* not ready */
 				}
@@ -119,21 +130,42 @@ suite(
 		});
 
 		// ── low-level helpers ─────────────────────────────────────────────────────
+		// All requests go through node:http directly (see the file-header note on why fetch()
+		// isn't used here).
 
-		const jsonHeaders = () => ({
-			'Content-Type': 'application/json',
-			'Authorization': auth,
-		});
+		function httpRequest(
+			method: string,
+			url: string,
+			body?: string,
+			timeoutMs = 5_000
+		): Promise<{ status: number; body: string }> {
+			return new Promise((resolvePromise, reject) => {
+				const u = new URL(url);
+				const headers: Record<string, string> = { Authorization: auth };
+				if (body !== undefined) {
+					headers['Content-Type'] = 'application/json';
+					headers['Content-Length'] = String(Buffer.byteLength(body));
+				}
+				const req = http.request(
+					{ hostname: u.hostname, port: u.port, path: u.pathname + u.search, method, headers, timeout: timeoutMs },
+					(res) => {
+						const chunks: Buffer[] = [];
+						res.on('data', (chunk) => chunks.push(chunk));
+						res.on('end', () =>
+							resolvePromise({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf-8') })
+						);
+					}
+				);
+				req.on('timeout', () => req.destroy(new Error(`request to ${url} timed out after ${timeoutMs}ms`)));
+				req.on('error', reject);
+				req.end(body);
+			});
+		}
 
 		async function restPut(id: string, body: Record<string, unknown>): Promise<number | 'error'> {
 			try {
-				const r = await fetch(`${httpURL}/Expiry/${id}`, {
-					method: 'PUT',
-					headers: jsonHeaders(),
-					body: JSON.stringify({ id, ...body }),
-					signal: AbortSignal.timeout(5_000),
-				});
-				return r.status;
+				const { status } = await httpRequest('PUT', `${httpURL}/Expiry/${id}`, JSON.stringify({ id, ...body }));
+				return status;
 			} catch {
 				return 'error';
 			}
@@ -141,13 +173,8 @@ suite(
 
 		async function restPatch(id: string, body: Record<string, unknown>): Promise<number | 'error'> {
 			try {
-				const r = await fetch(`${httpURL}/Expiry/${id}`, {
-					method: 'PATCH',
-					headers: jsonHeaders(),
-					body: JSON.stringify(body),
-					signal: AbortSignal.timeout(5_000),
-				});
-				return r.status;
+				const { status } = await httpRequest('PATCH', `${httpURL}/Expiry/${id}`, JSON.stringify(body));
+				return status;
 			} catch {
 				return 'error';
 			}
@@ -155,18 +182,12 @@ suite(
 
 		async function opsUpdate(id: string, fields: Record<string, unknown>): Promise<number | 'error'> {
 			try {
-				const r = await fetch(opsURL, {
-					method: 'POST',
-					headers: jsonHeaders(),
-					body: JSON.stringify({
-						operation: 'update',
-						schema: 'data',
-						table: 'Expiry',
-						records: [{ id, ...fields }],
-					}),
-					signal: AbortSignal.timeout(5_000),
-				});
-				return r.status;
+				const { status } = await httpRequest(
+					'POST',
+					opsURL,
+					JSON.stringify({ operation: 'update', schema: 'data', table: 'Expiry', records: [{ id, ...fields }] })
+				);
+				return status;
 			} catch {
 				return 'error';
 			}
@@ -176,16 +197,12 @@ suite(
 		// parse errors, so we use `SET n = <number>` which parses cleanly.
 		async function sqlUpdate(id: string, newN: number): Promise<number | 'error'> {
 			try {
-				const r = await fetch(opsURL, {
-					method: 'POST',
-					headers: jsonHeaders(),
-					body: JSON.stringify({
-						operation: 'sql',
-						sql: `UPDATE data.Expiry SET n = ${newN} WHERE id = '${id}'`,
-					}),
-					signal: AbortSignal.timeout(5_000),
-				});
-				return r.status;
+				const { status } = await httpRequest(
+					'POST',
+					opsURL,
+					JSON.stringify({ operation: 'sql', sql: `UPDATE data.Expiry SET n = ${newN} WHERE id = '${id}'` })
+				);
+				return status;
 			} catch {
 				return 'error';
 			}
@@ -193,13 +210,8 @@ suite(
 
 		async function addTo(id: string, delta = 1): Promise<number | 'error'> {
 			try {
-				const r = await fetch(`${httpURL}/AddToCounter/`, {
-					method: 'POST',
-					headers: jsonHeaders(),
-					body: JSON.stringify({ id, delta }),
-					signal: AbortSignal.timeout(5_000),
-				});
-				return r.status;
+				const { status } = await httpRequest('POST', `${httpURL}/AddToCounter/`, JSON.stringify({ id, delta }));
+				return status;
 			} catch {
 				return 'error';
 			}
@@ -207,20 +219,16 @@ suite(
 
 		async function getRecord(id: string): Promise<{ status: number | 'error'; body: any }> {
 			try {
-				const r = await fetch(`${httpURL}/Expiry/${id}`, {
-					method: 'GET',
-					headers: { Authorization: auth },
-					signal: AbortSignal.timeout(5_000),
-				});
+				const { status, body: rawBody } = await httpRequest('GET', `${httpURL}/Expiry/${id}`);
 				let body: any = null;
-				if (r.status === 200) {
+				if (status === 200) {
 					try {
-						body = await r.json();
+						body = JSON.parse(rawBody);
 					} catch {
 						/* ignore */
 					}
 				}
-				return { status: r.status, body };
+				return { status, body };
 			} catch {
 				return { status: 'error', body: null };
 			}
@@ -228,11 +236,7 @@ suite(
 
 		async function deleteRecord(id: string): Promise<void> {
 			try {
-				await fetch(`${httpURL}/Expiry/${id}`, {
-					method: 'DELETE',
-					headers: { Authorization: auth },
-					signal: AbortSignal.timeout(5_000),
-				});
+				await httpRequest('DELETE', `${httpURL}/Expiry/${id}`);
 			} catch {
 				/* best-effort */
 			}
@@ -250,6 +254,21 @@ suite(
 				await sleep(EXPIRY_POLL_INTERVAL_MS);
 			}
 			return false;
+		}
+
+		/**
+		 * Poll for the record being present (200) up until deadlineAt, then take one final sample.
+		 * Returns true as soon as any sample observes it present. See RESET_POLL_INTERVAL_MS above
+		 * for why a single point-in-time check isn't reliable here.
+		 */
+		async function pollForPresent(id: string, deadlineAt: number): Promise<boolean> {
+			while (Date.now() < deadlineAt) {
+				const { status } = await getRecord(id);
+				if (status === 200) return true;
+				await sleep(RESET_POLL_INTERVAL_MS);
+			}
+			const { status } = await getRecord(id);
+			return status === 200;
 		}
 
 		// ── generic harness ───────────────────────────────────────────────────────
@@ -283,13 +302,14 @@ suite(
 					`[${label}] update returned ${updateStatus} (expected 200/204)`
 				);
 
-				// Wait until the ORIGINAL expiry has passed, then check.
+				// Wait until the ORIGINAL expiry has passed, then poll for presence up until just
+				// before the reset-expiry would fire (see pollForPresent/RESET_POLL_INTERVAL_MS).
 				const checkResetAt = seedAt + CHECK_RESET_MS;
 				const waitForCheck = checkResetAt - Date.now();
 				if (waitForCheck > 0) await sleep(waitForCheck);
 
-				const { status: resetStatus } = await getRecord(id);
-				result.resetObserved = resetStatus === 200;
+				const resetDeadline = updateAt + TTL_MS - RESET_CHECK_SAFETY_MS;
+				result.resetObserved = await pollForPresent(id, resetDeadline);
 
 				// Now wait until well past the RESET expiry window (update_time + TTL_MS + slack).
 				const checkGoneAt = updateAt + TTL_MS + 1500;

--- a/integrationTests/database/ttlResetOnWrite.test.ts
+++ b/integrationTests/database/ttlResetOnWrite.test.ts
@@ -153,6 +153,7 @@ suite(
 					(res) => {
 						const chunks: Buffer[] = [];
 						res.on('data', (chunk) => chunks.push(chunk));
+						res.on('error', reject);
 						res.on('end', () =>
 							resolvePromise({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf-8') })
 						);
@@ -260,31 +261,35 @@ suite(
 
 		interface PresenceResult {
 			observed: boolean;
-			// true only if every sample in the window failed to complete (timeout/transport error) —
-			// i.e. we never got a clean read (200 or 404) at all. Distinguishes "couldn't measure"
-			// from an actual NO-RESET signal, so a transport hiccup doesn't get reported as a TTL
-			// data-integrity defect.
+			// true only if every sample that completed *inside* the window (deadlineAt) failed to
+			// return a clean read (200 or 404) — i.e. we never got an in-window clean read at all.
+			// A 404 that lands after deadlineAt doesn't count as a clean sample: by the time it
+			// completed, the real reset-expiry (deadlineAt + RESET_CHECK_SAFETY_MS) may already have
+			// passed, so that 404 could reflect the record correctly expiring late rather than a
+			// genuine NO-RESET. Distinguishes "couldn't measure" from an actual NO-RESET signal, so a
+			// transport hiccup — or a sample that straddles the deadline — never gets reported as a
+			// TTL data-integrity defect.
 			inconclusive: boolean;
 		}
 
 		/**
-		 * Poll for the record being present (200) up until deadlineAt, then take one final sample.
-		 * Returns as soon as any sample observes it present. Each sample is bound to
-		 * RESET_POLL_TIMEOUT_MS (see its definition above) so one slow/stalled response can't
-		 * consume the whole window — a plain retry loop without that bound would inherit
-		 * httpRequest's full default timeout per sample and gain nothing over a single check.
+		 * Poll for the record being present (200), bounding every attempt and sleep to what's left
+		 * before deadlineAt so no sample can start once the window has closed. Returns as soon as
+		 * any sample observes it present. Each attempt is capped at RESET_POLL_TIMEOUT_MS (see its
+		 * definition above) — and further capped to the remaining time near the deadline — so one
+		 * slow/stalled response can't consume the whole window or run past it.
 		 */
 		async function pollForPresent(id: string, deadlineAt: number): Promise<PresenceResult> {
 			let sawCleanSample = false;
 			while (Date.now() < deadlineAt) {
-				const { status } = await getRecord(id, RESET_POLL_TIMEOUT_MS);
+				const remainingMs = deadlineAt - Date.now();
+				const { status } = await getRecord(id, Math.min(RESET_POLL_TIMEOUT_MS, remainingMs));
 				if (status === 200) return { observed: true, inconclusive: false };
-				if (status === 404) sawCleanSample = true;
-				await sleep(RESET_POLL_INTERVAL_MS);
+				if (status === 404 && Date.now() <= deadlineAt) sawCleanSample = true;
+				const sleepBudgetMs = deadlineAt - Date.now();
+				if (sleepBudgetMs <= 0) break;
+				await sleep(Math.min(RESET_POLL_INTERVAL_MS, sleepBudgetMs));
 			}
-			const { status } = await getRecord(id, RESET_POLL_TIMEOUT_MS);
-			if (status === 200) return { observed: true, inconclusive: false };
-			if (status === 404) sawCleanSample = true;
 			return { observed: false, inconclusive: !sawCleanSample };
 		}
 

--- a/integrationTests/database/ttlResetOnWrite.test.ts
+++ b/integrationTests/database/ttlResetOnWrite.test.ts
@@ -69,7 +69,6 @@ const EXPIRY_POLL_INTERVAL_MS = 200;
 // whole window on one slow response and get misread as the record surviving past its TTL (F-002
 // stale resurrection).
 const EXPIRY_POLL_SAMPLE_TIMEOUT_MS = 400;
-const EXPIRY_POLL_MIN_REMAINING_MS = 50;
 
 // The "record is RESET" check polls across the whole valid window (past the original expiry, up
 // to just before the reset-expiry) rather than sampling a single instant. Polling only helps if
@@ -259,20 +258,23 @@ suite(
 
 		interface AbsenceResult {
 			observed: boolean;
-			// true only if every sample that completed returned neither 200 nor 404 (timeout or
-			// transport error) — i.e. we never got a clean read at all. Mirrors
-			// PresenceResult.inconclusive: without it, a stalled response consuming the whole window
-			// reads as "still present" and gets reported as F-002 stale resurrection, when it's
-			// really "couldn't measure."
+			// true only if the LAST full-budget sample admitted within the window returned neither
+			// 200 nor 404 (timeout or transport error) — not "every sample ever," since a 200 goes
+			// stale: it proves the record hadn't expired *yet*, not that it's still present now.
+			// Without this, a stalled response on the deciding sample reads as "still present" and
+			// gets reported as F-002 stale resurrection, when it's really "couldn't measure."
 			inconclusive: boolean;
 		}
 
 		/**
-		 * Poll until the record is absent (404), bounding every attempt and sleep to what's left
-		 * before the deadline so no sample can start once the window has closed. Returns as soon as
-		 * any sample observes it absent. Each attempt is capped at EXPIRY_POLL_SAMPLE_TIMEOUT_MS —
-		 * and further capped to the remaining time near the deadline — so one slow/stalled response
-		 * can't consume the whole window on its own.
+		 * Poll until the record is absent (404), bounding every attempt to what's left before the
+		 * deadline so no sample can start once the window has closed. Returns as soon as any sample
+		 * observes it absent. A sample is only admitted — and only gets to decide conclusiveness —
+		 * once it can run with the FULL EXPIRY_POLL_SAMPLE_TIMEOUT_MS budget: since conclusiveness
+		 * comes from the last completed sample (see below), a window with a fixed size always has a
+		 * final admitted sample, and admitting one with a shortened, clamped budget would make that
+		 * structurally-doomed sample the one deciding "still present" vs "couldn't measure" — gating
+		 * the suite's loudest data-integrity alarm on its least reliable measurement.
 		 */
 		async function pollUntilGone(id: string, maxMs: number): Promise<AbsenceResult> {
 			const deadline = Date.now() + maxMs;
@@ -283,9 +285,8 @@ suite(
 			// make every later stall in the rest of the window read as conclusive "still present",
 			// which is exactly the stall-reads-as-defect failure this poll exists to prevent.
 			let lastSampleClean = false;
-			while (deadline - Date.now() >= EXPIRY_POLL_MIN_REMAINING_MS) {
-				const remainingMs = deadline - Date.now();
-				const { status } = await getRecord(id, Math.min(EXPIRY_POLL_SAMPLE_TIMEOUT_MS, remainingMs));
+			while (deadline - Date.now() >= EXPIRY_POLL_SAMPLE_TIMEOUT_MS) {
+				const { status } = await getRecord(id, EXPIRY_POLL_SAMPLE_TIMEOUT_MS);
 				if (status === 404) return { observed: true, inconclusive: false };
 				lastSampleClean = status === 200;
 				const sleepBudgetMs = deadline - Date.now();

--- a/integrationTests/database/ttlResetOnWrite.test.ts
+++ b/integrationTests/database/ttlResetOnWrite.test.ts
@@ -32,6 +32,13 @@
  * Root cause: nodejs/undici#5600 (unref'd idle-socket-validation setImmediate stalls fetch() on an
  * otherwise-idle event loop), bundled into Node via undici 8.9.0 (used by 26.5.1); fixed upstream by
  * nodejs/undici#5609 but not yet in a released undici/Node build as of this writing.
+ *
+ * The reset/gone checks additionally classify an unmeasurable window as INCONCLUSIVE (see
+ * PresenceResult/AbsenceResult below) so a transport hiccup is never reported as a TTL
+ * data-integrity defect. This is a diagnosis improvement, not a deflaking one, for surfaces 1-5:
+ * an INCONCLUSIVE window still fails its assertion (resetObserved/goneObserved isn't `true`) — it
+ * just fails with an accurate "couldn't measure" message instead of a false RESET/NO-RESET or
+ * F-002 verdict. Only the race probe (surface 6) has a bucket that absorbs INCONCLUSIVE outright.
  */
 import { suite, test, before, after } from 'node:test';
 import { ok } from 'node:assert';
@@ -80,9 +87,6 @@ const RESET_POLL_INTERVAL_MS = 150;
 const RESET_POLL_TIMEOUT_MS = 300;
 // Safety margin before the reset-expiry deadline, so the last poll isn't racing the sweep itself.
 const RESET_CHECK_SAFETY_MS = 200;
-// Below this much time left in the window, a sample is doomed before it starts (its timeout would
-// be clamped to a few ms) — skip it rather than counting a guaranteed failure toward "no clean read".
-const RESET_POLL_MIN_REMAINING_MS = 50;
 
 const skipSuite = process.platform === 'win32' || process.env.HARPER_RUNTIME === 'bun';
 
@@ -312,24 +316,32 @@ suite(
 		}
 
 		/**
-		 * Poll for the record being present (200), bounding every attempt and sleep to what's left
-		 * before deadlineAt so no sample can start once the window has closed. Returns as soon as
-		 * any sample observes it present. Each attempt is capped at RESET_POLL_TIMEOUT_MS (see its
-		 * definition above) — and further capped to the remaining time near the deadline — so one
-		 * slow/stalled response can't consume the whole window or run past it. Samples with less
-		 * than RESET_POLL_MIN_REMAINING_MS left are skipped rather than attempted: a timeout clamped
-		 * to a few ms is a guaranteed failure, not a real absence of a clean read.
+		 * Poll for the record being present (200) up to expiresAt (the true reset-expiry), in two
+		 * phases. Intermediate samples are bounded to RESET_POLL_TIMEOUT_MS and only admitted with
+		 * that full budget, and run up to deadlineAt (the conservative cutoff) — mirrors
+		 * pollUntilGone's "don't admit a sample you can't give a fair budget" rule, so one stall
+		 * can't eat the whole window and block a retry. The FINAL sample instead gets whatever time
+		 * remains up to expiresAt: a 200 landing at any point up to the real reset-expiry proves the
+		 * clock reset (the request can't have started before the original expiry), so clamping the
+		 * deciding sample to the intermediate budget would silently discard a valid late response
+		 * under load — the same masking failure this poll exists to avoid, just on the positive
+		 * (200) side of the check instead of the negative (404) side handled by expiresAt below.
 		 */
 		async function pollForPresent(id: string, deadlineAt: number, expiresAt: number): Promise<PresenceResult> {
 			let sawCleanSample = false;
-			while (deadlineAt - Date.now() >= RESET_POLL_MIN_REMAINING_MS) {
-				const remainingMs = deadlineAt - Date.now();
-				const { status } = await getRecord(id, Math.min(RESET_POLL_TIMEOUT_MS, remainingMs));
+			while (deadlineAt - Date.now() >= RESET_POLL_TIMEOUT_MS) {
+				const { status } = await getRecord(id, RESET_POLL_TIMEOUT_MS);
 				if (status === 200) return { observed: true, inconclusive: false };
 				if (status === 404 && Date.now() <= expiresAt) sawCleanSample = true;
 				const sleepBudgetMs = deadlineAt - Date.now();
 				if (sleepBudgetMs <= 0) break;
 				await sleep(Math.min(RESET_POLL_INTERVAL_MS, sleepBudgetMs));
+			}
+			const finalBudgetMs = expiresAt - Date.now();
+			if (finalBudgetMs > 0) {
+				const { status } = await getRecord(id, finalBudgetMs);
+				if (status === 200) return { observed: true, inconclusive: false };
+				if (status === 404 && Date.now() <= expiresAt) sawCleanSample = true;
 			}
 			return { observed: false, inconclusive: !sawCleanSample };
 		}
@@ -397,9 +409,11 @@ suite(
 					result.finding =
 						'INCONCLUSIVE — no clean read within the reset-check window (transport issue, not a TTL defect)';
 				} else if (goneResult.inconclusive) {
-					// Same reasoning on the other side: never a clean read within the gone-check
-					// window. Without this branch a stalled/unmeasured gone-check reads as
-					// goneObserved=false and gets reported as F-002 stale resurrection.
+					// Same reasoning on the other side: the deciding (last full-budget) sample in the
+					// gone-check window didn't complete cleanly — could follow several clean 200s
+					// earlier in the window (see pollUntilGone's docblock). Without this branch a
+					// stalled/unmeasured gone-check reads as goneObserved=false and gets reported as
+					// F-002 stale resurrection.
 					result.finding =
 						'INCONCLUSIVE — no clean read within the gone-check window (transport issue, not a TTL defect)';
 				} else if (result.resetObserved && result.goneObserved) {

--- a/integrationTests/database/ttlResetOnWrite.test.ts
+++ b/integrationTests/database/ttlResetOnWrite.test.ts
@@ -68,6 +68,15 @@ const CHECK_RESET_MS = TTL_MS + 200; // 2200ms — past original expiry, before 
 // Note: the "record is GONE" check anchors on the measured update time (updateAt + TTL_MS + slack),
 // not a seed-relative constant, so it accounts for real scheduling/HTTP drift in when the update lands.
 
+// The reset-presence check's window is inherently tight (order RESET_CHECK_SAFETY_MS +
+// RESET_POLL_TIMEOUT_MS wide) because it has to fit between the original expiry and the
+// reset-expiry. On a loaded runner, server latency alone can exceed that window even when TTL
+// reset worked correctly — no per-sample budget tuning fixes that, since the window's width is
+// bounded by TTL_S, not by how the samples inside it are scheduled. Retrying the whole
+// seed→update→check scenario on INCONCLUSIVE (fresh id, fresh timing) is what actually
+// distinguishes "this window was unlucky" from "TTL reset doesn't work."
+const MAX_PROBE_ATTEMPTS = 3;
+
 // Max extra slack for expiry (one background-sweep leeway).
 const EXPIRY_POLL_MS = 5_000;
 const EXPIRY_POLL_INTERVAL_MS = 200;
@@ -351,18 +360,19 @@ suite(
 
 		// ── generic harness ───────────────────────────────────────────────────────
 
-		async function probeSurface(
+		/** One attempt at the seed→update→check scenario. Does not retry. */
+		async function probeSurfaceOnce(
 			label: string,
-			idSuffix: string,
+			id: string,
 			doUpdate: (id: string) => Promise<number | 'error'>
-		): Promise<void> {
-			const id = `qa269-${idSuffix}`;
+		): Promise<{ result: SurfaceResult; inconclusive: boolean }> {
 			const result: SurfaceResult = {
 				surface: label,
 				resetObserved: 'not-checked',
 				goneObserved: 'not-checked',
 				finding: '',
 			};
+			let inconclusive = false;
 
 			try {
 				// t=0: seed
@@ -409,6 +419,7 @@ suite(
 					// Never a clean read (200 or 404) within the window — a transport hiccup, not a
 					// TTL data signal either way. Reported distinctly so it isn't mistaken for a
 					// TTL-reset defect.
+					inconclusive = true;
 					result.finding =
 						'INCONCLUSIVE — no clean read within the reset-check window (transport issue, not a TTL defect)';
 				} else if (goneResult.inconclusive) {
@@ -417,6 +428,7 @@ suite(
 					// earlier in the window (see pollUntilGone's docblock). Without this branch a
 					// stalled/unmeasured gone-check reads as goneObserved=false and gets reported as
 					// F-002 stale resurrection.
+					inconclusive = true;
 					result.finding =
 						'INCONCLUSIVE — no clean read within the gone-check window (transport issue, not a TTL defect)';
 				} else if (result.resetObserved && result.goneObserved) {
@@ -434,9 +446,34 @@ suite(
 				await deleteRecord(id);
 			}
 
-			matrix.push(result);
+			return { result, inconclusive };
+		}
+
+		/**
+		 * Runs probeSurfaceOnce, retrying (fresh id, fresh timing) up to MAX_PROBE_ATTEMPTS times
+		 * while the result is INCONCLUSIVE. The reset-check window is inherently tight (see
+		 * MAX_PROBE_ATTEMPTS above), so a single unlucky window shouldn't fail the suite this change
+		 * exists to stabilize — but an attempt that's genuinely RESET/NO-RESET/DID-NOT-EXPIRE is
+		 * conclusive and is never retried or discarded.
+		 */
+		async function probeSurface(
+			label: string,
+			idSuffix: string,
+			doUpdate: (id: string) => Promise<number | 'error'>
+		): Promise<void> {
+			let outcome: { result: SurfaceResult; inconclusive: boolean } | undefined;
+			for (let attempt = 1; attempt <= MAX_PROBE_ATTEMPTS; attempt++) {
+				const id = attempt === 1 ? `qa269-${idSuffix}` : `qa269-${idSuffix}-r${attempt}`;
+				outcome = await probeSurfaceOnce(label, id, doUpdate);
+				if (!outcome.inconclusive) break;
+				if (attempt < MAX_PROBE_ATTEMPTS) {
+					console.log(`[QA-269:${ENGINE}] ${label}: attempt ${attempt} inconclusive, retrying`);
+				}
+			}
+
+			matrix.push(outcome!.result);
 			console.log(
-				`[QA-269:${ENGINE}] ${label}: reset=${result.resetObserved} gone=${result.goneObserved} → ${result.finding}`
+				`[QA-269:${ENGINE}] ${label}: reset=${outcome!.result.resetObserved} gone=${outcome!.result.goneObserved} → ${outcome!.result.finding}`
 			);
 		}
 
@@ -584,14 +621,19 @@ suite(
 			);
 			// At least one round should complete cleanly (basic smoke guard).
 			ok(outcomes.cleanReset + outcomes.silentLoss > 0, `No round completed cleanly — environment likely broken`);
-			// transportErr is unbounded by design (a stalled deciding sample routes here rather than
-			// a false resurrection alarm — see pollUntilGone), but if it dominates the rounds, the
-			// resurrection=== 0 assertion above is passing on data that was never actually measured.
-			// Guard against the probe going green while having measured almost nothing.
+			// Only cleanReset and resurrection rounds actually exercise the F-002 property —
+			// silentLoss and updateError both `continue` before the resurrection check ever runs.
+			// A first version of this guard capped transportErr alone, which missed that: a probe
+			// where every round lands in silentLoss (a legitimate outcome of the exact race this
+			// probe induces) would pass resurrection===0 having measured the property in zero
+			// rounds. Assert on the measured set directly instead of capping the unmeasured one.
 			ok(
-				outcomes.transportErr <= ROUNDS / 2,
-				`${outcomes.transportErr}/${ROUNDS} rounds were transport-inconclusive — the F-002 check above didn't ` +
-					`get enough conclusive rounds to be meaningful [${ENGINE}]`
+				outcomes.cleanReset + outcomes.resurrection >= ROUNDS / 2,
+				`only ${outcomes.cleanReset + outcomes.resurrection}/${ROUNDS} rounds actually measured the F-002 ` +
+					`property (cleanReset=${outcomes.cleanReset}, resurrection=${outcomes.resurrection}, ` +
+					`silentLoss=${outcomes.silentLoss}, updateError=${outcomes.updateError}, ` +
+					`transportErr=${outcomes.transportErr}) — the resurrection===0 check above isn't meaningful ` +
+					`with this little coverage [${ENGINE}]`
 			);
 		});
 	}


### PR DESCRIPTION
## What / why

Issue #2025 asked whether Harper is genuinely broken on Node v26.5.1, or whether the four
failing integration tests are test-only artifacts. Verdict: **neither, cleanly** — it's a
genuine Node regression, but in the bundled `undici`/global `fetch()` *client*, not in
llhttp/server-side parsing and not in any Harper code path.

Root cause, independently reproduced:

- Installed 26.5.0 and 26.5.1 locally and reran the named tests against the same build under
  each — confirmed the CI bisect independently.
- Ruled out llhttp/server-side parsing: a raw `node:http` client hitting the identical running
  Harper server (REST PUT/POST/GET, ops API, SQL, custom resource) shows **zero** latency
  regression on 26.5.1 vs 26.5.0.
- Ruled out Harper's TTL-reset / chokidar-reload logic: a debug-instrumented run showed the
  *update* landing on schedule while the *check's own GET* took 1-2.6s to complete on 26.5.1
  (2-6ms on 26.5.0) — the delayed check, not the write, crossed the reset-expiry boundary.
  Direct `fs.writeFile` + chokidar reload (bypassing `fetch()` entirely) completed in 2.8ms on
  26.5.1.
- Found the mechanism with a **Harper-independent minimal repro**: two bare
  `node:http.createServer()` instances, `fetch()` in a loop mixing GET/POST across the two
  origins. 26.5.0: 300/300 rounds clean, max 10.8ms. 26.5.1: repeated multi-hundred-ms to
  20+ second stalls. This is a `nodejs/undici` bug.
- Cross-checked the same CI run (30614629057) across Node lines: v22/v24 shard 6 both
  ~4500-5300ms clean; v26 (26.5.1) ~5000-6500ms and failing. Same run, shard 4: v22/v24
  ~2060ms on the cache-header reload test; v26 ~24400-24600ms and timing out.
- Identified the upstream issue: **nodejs/undici#5600** — an unref'd `setImmediate()` in
  `scheduleIdleSocketValidation` (introduced in undici #5499) means the idle-socket-reuse check
  only runs once something else wakes the loop's check phase; on an otherwise-idle loop that can
  be a long wait, and the queued request sits behind it. Node 26.5.1 bundles undici **8.9.0**
  (`nodejs/node#64712`, published 2026-07-24), which has the regression. Matches our repro
  exactly: mechanism (idle-socket-reuse stall), trigger (idle event loop), and symptom scaling
  with how idle the loop is (their repro: up to ~500ms with a single-connection pool under a
  test runner; ours: up to 20+s in a near-empty two-server harness). Already fixed upstream by
  **nodejs/undici#5609** (merged 2026-07-29, "stop unref'ing the idle socket validation
  immediate") — but not yet in a released undici or Node build as of this PR, so nothing to pin
  to yet.

Root-cause attribution across the four named CI failures:
1. harper `ttlResetOnWrite.test.ts` (ops-update/SQL-UPDATE/addTo) — **fixed here**, same root
   cause: `fetch()` interleaving GET(httpURL)/POST(opsURL).
2. harper `static-cache-headers.test.ts` — **fixed here**, same root cause: `fetch()`-based
   polling GET.
3. harper-pro `analytics.test.mjs` — very likely the same root cause (also `fetch()`-based,
   cross-origin; confirmed by a read-only grep, not fixed — different repo, out of scope here).
4. harper-pro `addNodeLeaderNoMeshLeak.test.mjs` — **independent**: doesn't use `fetch()` at
   all; a 180s cluster-mesh timeout, unrelated mechanism.

## Fix

Both harper test files now use `node:http` directly for their timing-critical requests
(matching what `supertest`, already used elsewhere in these suites, does under the hood) —
proven immune to the undici stall via the isolated repro above.

`ttlResetOnWrite.test.ts` also gets an independent robustness fix: the TTL-reset check now
polls across the whole valid window (bounded per-sample timeout) instead of sampling a single
instant, and distinguishes a genuine transport failure (`INCONCLUSIVE`) from an actual
NO-RESET signal, so a network hiccup never renders as a TTL data-integrity defect.

**Not** pinning CI to 26.5.0 — the two Harper tests destabilized by the upstream bug are now
fixed at the root, so no pin is needed to go green. Issue #2025 stays open: the undici
regression itself is upstream (unfixable in Harper source) and already tracked at
[nodejs/undici#5600](https://github.com/nodejs/undici/issues/5600), fixed by
[nodejs/undici#5609](https://github.com/nodejs/undici/pull/5609) — watch for that landing in a
released undici/Node build, no new upstream issue needed.

## Test plan

- 3+ consecutive clean runs of each file on Node 26.5.1 (rocksdb + lmdb for the TTL suite)
  after the fixes, matching 26.5.0/v22/v24 timing (~4.5s/~2s respectively, no more 5-27s
  stalls/timeouts).
- 1 control run of each on 26.5.0 (unaffected either way, as expected).
- `tsc --noEmit`, `oxlint`, `prettier --check` clean on both files.
- Independent pre-push review (codex + gemini + grok + harper-domain, adjudicated) on the
  first commit found 3 real findings (serial polling not actually bounding per-sample latency,
  transport failures rendered as data defects, an unbounded-stall regression reintroduced in
  the "fixed" file) plus 3 nits — all addressed in the second commit and reverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Review-Coverage: authored=unknown; ran=none; rounds=1 @ c404a409f692</sub>

<sub>Human-Review-Need: 4 @ c404a409f692</sub>
