### PR TITLE
fix(storage): translate the LMDB compression descriptor for RocksDB stores

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@fastify/cors": "^11.2.0",
 				"@fastify/static": "^9.1.3",
 				"@harperfast/extended-iterable": "^1.0.1",
-				"@harperfast/rocksdb-js": "^2.5.0",
+				"@harperfast/rocksdb-js": "~2.6.1",
 				"@harperfast/skills": "^1.10.8",
 				"@turf/area": "6.5.0",
 				"@turf/boolean-contains": "6.5.0",
@@ -2494,9 +2494,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js/-/rocksdb-js-2.5.0.tgz",
-			"integrity": "sha512-v8T3J9n87seoDwKPmYxKdeC7gyA6lI9CJqU/MJMYfjfF1hyzb0aOjzRZx2X4wqm+iBJKtLNp8EKjEpIQuajeQQ==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js/-/rocksdb-js-2.6.1.tgz",
+			"integrity": "sha512-9LBZsbb/wrsqe5Bua6DjsSZhYhO8WbNMKgmiHoHAVmKh0TVKqSlvndQnM0X4O+TslxxOKUtMjt1PeZXX+8RFfA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@harperfast/extended-iterable": "1.0.3",
@@ -2510,20 +2510,20 @@
 				"node": "^22.18.0 || >=24.0.0"
 			},
 			"optionalDependencies": {
-				"@harperfast/rocksdb-js-darwin-arm64": "2.5.0",
-				"@harperfast/rocksdb-js-darwin-x64": "2.5.0",
-				"@harperfast/rocksdb-js-linux-arm64-glibc": "2.5.0",
-				"@harperfast/rocksdb-js-linux-arm64-musl": "2.5.0",
-				"@harperfast/rocksdb-js-linux-x64-glibc": "2.5.0",
-				"@harperfast/rocksdb-js-linux-x64-musl": "2.5.0",
-				"@harperfast/rocksdb-js-win32-arm64": "2.5.0",
-				"@harperfast/rocksdb-js-win32-x64": "2.5.0"
+				"@harperfast/rocksdb-js-darwin-arm64": "2.6.1",
+				"@harperfast/rocksdb-js-darwin-x64": "2.6.1",
+				"@harperfast/rocksdb-js-linux-arm64-glibc": "2.6.1",
+				"@harperfast/rocksdb-js-linux-arm64-musl": "2.6.1",
+				"@harperfast/rocksdb-js-linux-x64-glibc": "2.6.1",
+				"@harperfast/rocksdb-js-linux-x64-musl": "2.6.1",
+				"@harperfast/rocksdb-js-win32-arm64": "2.6.1",
+				"@harperfast/rocksdb-js-win32-x64": "2.6.1"
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-darwin-arm64": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-arm64/-/rocksdb-js-darwin-arm64-2.5.0.tgz",
-			"integrity": "sha512-AmBoXKqjVvLrcuqvyjDFVLAEp8r5nJt+djXkKGVVl9c8OohsaRMDl91TzVbTI/pWiPSL1BZKHLVMoYJZ/a+jKw==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-arm64/-/rocksdb-js-darwin-arm64-2.6.1.tgz",
+			"integrity": "sha512-iq5lCjFey4aYG9/W7ETiaZQ5r2A43fX75DCCnIG7s9aVuE39Ug2TVKz8MOD7NPrIzygLbw7SYjijB23ApCquiA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2537,9 +2537,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-darwin-x64": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-x64/-/rocksdb-js-darwin-x64-2.5.0.tgz",
-			"integrity": "sha512-Cy3qKRrZ6I1kE9NlK5dI8LdhA9wlpnYmwJfIa1xT/entpN/3lrkKR/VA190fmdCXa1LV4Rjx1BNM2pSQj9bpsg==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-x64/-/rocksdb-js-darwin-x64-2.6.1.tgz",
+			"integrity": "sha512-F/m7eIriZVk1qTvt70ehNIEsvUTVPdF2g92ZQX8Pka/219E2b4T0S2e6VHB61EBN/W7ylrphbjo956wfHeqLsA==",
 			"cpu": [
 				"x64"
 			],
@@ -2553,9 +2553,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-arm64-glibc": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-glibc/-/rocksdb-js-linux-arm64-glibc-2.5.0.tgz",
-			"integrity": "sha512-3SNtSriey9XqAeUr9gbILhX46iNUVLqA/of4z0C+S2J1QCnPywl1cPvT7YoF9ck0GOoCqXm1xbTUzAPxB2MDGw==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-glibc/-/rocksdb-js-linux-arm64-glibc-2.6.1.tgz",
+			"integrity": "sha512-Epiywik4lq3EkNAw13/JXZp08wZX+sKzeek/wsRP8L58WK8iiv+lL+1FeTQIaZ0y5x2bXfy1apyfvIPenTlpTg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2572,9 +2572,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-arm64-musl": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-musl/-/rocksdb-js-linux-arm64-musl-2.5.0.tgz",
-			"integrity": "sha512-jLFO8Stvl2LBEfZRjO7Kp2noO7Xse9jztZJuEM8uwAmj6y9hLf31ysGR4tVTdGqHTHkSNWIpy+mb0Fv+A9c2dg==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-musl/-/rocksdb-js-linux-arm64-musl-2.6.1.tgz",
+			"integrity": "sha512-oytTCkkB1m6aOMq5+W8iQxrKB+U53/Anfb5hgsky0UXHaJTQ55GO2KAxwMOLxAFwrTwsDc5RwZul0AdXvLdHjQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2591,9 +2591,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-x64-glibc": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-glibc/-/rocksdb-js-linux-x64-glibc-2.5.0.tgz",
-			"integrity": "sha512-50AVHiLIz7BDf/mihi6FYF21FAWkOVgexcp+SmPL9FouClq93D/IjmmNC5O2HmFVKKjAWvNaakHEyofdNNr8yw==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-glibc/-/rocksdb-js-linux-x64-glibc-2.6.1.tgz",
+			"integrity": "sha512-A5tI89GD11eboM6l76nKqqcEM7UoB2ESbo/RPDoUaQxhhp0Q5o4CwVcgy/G+T4NBhhHSVASIvUgeR0L+xiG7Og==",
 			"cpu": [
 				"x64"
 			],
@@ -2610,9 +2610,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-x64-musl": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-2.5.0.tgz",
-			"integrity": "sha512-yWWULelWWMkavYbHJuYao5LAiG6IVK9/CzwsYdt/V0mgpVGBdGH5oKVbX+rwtM7H0vyqCNIuctXg9A0m8Bn48g==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-2.6.1.tgz",
+			"integrity": "sha512-owicSZXl+CPKKong+NTBHGzzTZ8Vq633rsewu+B1u1qlXhpV0W5HiKtcvpyJ6PbIXukjt9STtBC1rImUiaPw3Q==",
 			"cpu": [
 				"x64"
 			],
@@ -2629,9 +2629,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-win32-arm64": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-2.5.0.tgz",
-			"integrity": "sha512-r4UpDG9qeZR8GS7u3tQMJrMqhHPd+yU6m7fI6rqtkdjjULKvLMbpqQ8slkd7mzG0dSx3gYbVzCV1VijqA4vQmg==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-2.6.1.tgz",
+			"integrity": "sha512-GKVaaQnDmf8t1x5Ws6F2+WSevAeQRo85lFx/WEdtmkrqs/bE34lIYAUSQxzs2ALBs+R8kLj5gpoRc8KhBaUV+g==",
 			"cpu": [
 				"arm64"
 			],
@@ -2645,9 +2645,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-win32-x64": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-x64/-/rocksdb-js-win32-x64-2.5.0.tgz",
-			"integrity": "sha512-9CKwGDr8nBY/JoMT7AUUkUxmCQ6kfEqy9o/5mNDD6wjYfhMQ4ToTblTe33jgC84No3ociJavwT38HntXfO5xAA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-x64/-/rocksdb-js-win32-x64-2.6.1.tgz",
+			"integrity": "sha512-LF8sQVLAvqKc0waKMBQ5ADiHVUv9kwpj79RudY5xCIh3Qn3va6EYKLSxQezOPyZDX0yAOzpzacFnYNAno+7mnQ==",
 			"cpu": [
 				"x64"
 			],

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
 		"@fastify/cors": "^11.2.0",
 		"@fastify/static": "^9.1.3",
 		"@harperfast/extended-iterable": "^1.0.1",
-		"@harperfast/rocksdb-js": "^2.5.0",
+		"@harperfast/rocksdb-js": "~2.6.1",
 		"@harperfast/skills": "^1.10.8",
 		"@turf/area": "6.5.0",
 		"@turf/boolean-contains": "6.5.0",

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -176,8 +176,35 @@ export const databaseEventsEmitter = new EventEmitter<DatabaseWatcherEventMap>()
 export const tables: Tables = Object.create(null);
 export const databases: Databases = Object.create(null);
 
+/**
+ * Harper's `storage.compression` config - and the `compression` descriptor persisted on a table's
+ * primary attribute - describe LMDB's per-value compression: `{ startingOffset, threshold,
+ * dictionary }`. RocksDB compresses whole SST blocks and blob files itself, and as of rocksdb-js
+ * 2.6 the `compression` store option means that: an algorithm name, or `{ algorithm, level }`.
+ * 2.6.1 accepts an object with no `algorithm` as "unset", but `''` (an unset `storage.compression`)
+ * and the booleans still throw, so the config has to be translated before it reaches the store -
+ * for re-opens of existing tables (whose persisted descriptor is LMDB-shaped) as much as new ones.
+ *
+ * Exported for unit test: every branch here is a startup path, and the ones that throw without it
+ * are exactly the ones a table-level test cannot reach.
+ */
+export function resolveRocksCompression(compression: any) {
+	if (compression == null) return undefined;
+	// a blank string is how an unset `storage.compression` reaches here (it survives the `&&` in
+	// getDefaultCompression), and rocksdb-js rejects it as an unknown algorithm rather than ignoring it
+	if (typeof compression === 'string' && compression.trim() === '') return undefined;
+	// already RocksDB-shaped ('lz4', { algorithm: 'zstd', level: 3 }, ...): pass through
+	if (typeof compression === 'string') return compression;
+	if (typeof compression === 'object' && compression.algorithm != null) return compression;
+	// LMDB descriptor: compression is on, so take the rocksdb-js default (lz4 where the build
+	// supports it) by leaving the option unset - naming lz4 explicitly would instead throw on a
+	// build without it. `storage.compression: false` reaches here as false and disables it.
+	return compression ? undefined : 'none';
+}
+
 function openRocksDatabase(path: string, options: RocksDatabaseOptions & { dupSort?: boolean }) {
 	options.disableWAL ??= true;
+	(options as any).compression = resolveRocksCompression((options as any).compression);
 	// Apply read-only mode if enabled
 	if (isReadOnlyMode()) {
 		options.readOnly = true;
@@ -745,7 +772,9 @@ function initStores(
 			}
 			const dbiInit = createOpenDBIObject(!primaryAttribute.isPrimaryKey, primaryAttribute.isPrimaryKey);
 			dbiInit.compression = primaryAttribute.compression;
-			if (dbiInit.compression) {
+			// threshold only applies to the LMDB descriptor shape; a RocksDB algorithm name has no
+			// threshold, and assigning a property to a string primitive throws under strict mode
+			if (dbiInit.compression && typeof dbiInit.compression === 'object') {
 				const compressionThreshold =
 					envGet(CONFIG_PARAMS.STORAGE_COMPRESSION_THRESHOLD) || DEFAULT_COMPRESSION_THRESHOLD; // this is the only thing that can change;
 				dbiInit.compression.threshold = compressionThreshold;

--- a/unitTests/resources/databases.test.js
+++ b/unitTests/resources/databases.test.js
@@ -3,7 +3,14 @@ const assert = require('assert');
 const { setupTestDBPath } = require('../testUtils');
 const { existsSync, mkdirSync, writeFileSync } = require('node:fs');
 const { dirname, join } = require('node:path');
-const { table, flushDatabases, dropDatabase, getDatabases, resetDatabases } = require('#src/resources/databases');
+const {
+	table,
+	flushDatabases,
+	dropDatabase,
+	getDatabases,
+	resetDatabases,
+	resolveRocksCompression,
+} = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { RocksDatabase } = require('@harperfast/rocksdb-js');
 const { beginRestore, completeRestore, RESTORE_META_DIR } = require('#src/dataLayer/restoreMarker');
@@ -51,6 +58,61 @@ describe('table() randomAccessFields directive', () => {
 		const encoder = RafTable.primaryStore.encoder;
 		assert.strictEqual(encoder.randomAccessStructure, true);
 		assert.ok(encoder._writeStruct.length > 0, 'expected the real struct-write hook');
+	});
+});
+
+describe('table() compression', () => {
+	before(function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+	});
+
+	it('opens the primary store with lz4 under the default config', function () {
+		const CompressionTable = table({
+			table: 'CompressionDefault',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }],
+		});
+		if (!(CompressionTable.primaryStore instanceof RocksDatabase)) return this.skip();
+		assert.strictEqual(CompressionTable.primaryStore.compression?.algorithm, 'lz4');
+	});
+});
+
+// The default config yields the LMDB descriptor object, which rocksdb-js 2.6.1 already accepts as
+// "unset" - so the table-level test above passes with or without the translation. The inputs that
+// actually throw are `''` (an unset storage.compression, rejected as an unknown algorithm) and the
+// booleans (rejected as a malformed option), and only a direct test reaches them.
+describe('resolveRocksCompression', () => {
+	it("treats an unset storage.compression ('') as unset rather than an algorithm name", () => {
+		assert.strictEqual(resolveRocksCompression(''), undefined);
+		assert.strictEqual(resolveRocksCompression('   '), undefined);
+	});
+
+	it('maps the LMDB descriptor and `true` to unset, taking the rocksdb-js default', () => {
+		assert.strictEqual(resolveRocksCompression({ startingOffset: 32, threshold: 4036 }), undefined);
+		assert.strictEqual(resolveRocksCompression(true), undefined);
+	});
+
+	it('maps `storage.compression: false` to no compression', () => {
+		assert.strictEqual(resolveRocksCompression(false), 'none');
+	});
+
+	it('passes an already-RocksDB-shaped option through untouched', () => {
+		assert.strictEqual(resolveRocksCompression('zstd'), 'zstd');
+		const descriptor = { algorithm: 'zstd', level: 3 };
+		assert.strictEqual(resolveRocksCompression(descriptor), descriptor);
+	});
+
+	it('leaves an omitted option unset', () => {
+		assert.strictEqual(resolveRocksCompression(undefined), undefined);
+		assert.strictEqual(resolveRocksCompression(null), undefined);
+	});
+
+	// the resolver runs on every store open, so a throw here fails startup rather than one table
+	it('never throws, whatever shape the persisted attribute holds', () => {
+		for (const input of [0, 1, [], [6], NaN, Symbol('x'), () => {}]) {
+			assert.doesNotThrow(() => resolveRocksCompression(input));
+		}
 	});
 });
 


### PR DESCRIPTION
## What broke

rocksdb-js 2.6.0 gave the `compression` store option a real meaning — a RocksDB block/blob algorithm — and validates it. Harper has been passing an unrelated, LMDB-era `compression` value through the same options object: `getDefaultCompression()` returns msgpackr's `{ startingOffset, threshold, dictionary }` descriptor, or the raw config value when falsy. 2.5.0 never read `options.compression` at all, so it was silently ignored. Now it's parsed.

On 2.6.1 an unset `storage.compression` resolves to `''` and throws:

```
Error: Unsupported compression algorithm "". This build supports: none, snappy, zlib, bzip2, lz4, lz4hc, zstd
    at normalizeCompression (node_modules/@harperfast/rocksdb-js/src/store.ts:166:9)
    at openRocksDatabase (resources/databases.ts:214:48)
```

Every RocksDB store open throws, which takes component loading and the status table down with it — visible as the three `componentLoader.test.js` failures on #2036.

## Why this is a main-branch bug, not a bump-branch bug

main pinned `^2.5.0`, which already satisfies 2.6.1 (published 2026-07-31). CI is green only because `npm ci` uses the lockfile.

The published **shrinkwrap** does protect registry installs — `npm-shrinkwrap.json` ships in the tarball and npm honors it via `_hasShrinkwrap`. But the **Docker image does not go through that path**: `Dockerfile:55` runs `npm install --ignore-scripts --global harper-*.tgz`, and a tarball install has no packument, so npm never learns the shrinkwrap exists and resolves fresh from `package.json`. That gap is already documented in `dependencies.md`. So a release cut from main today would ship an image resolving `^2.5.0` → 2.6.1 → broken on every table open.

`~2.6.1` closes the range as well as fixing the incompatibility.

## The fix

Translate at `openRocksDatabase`, the single point every RocksDB store opens — so re-opens of existing tables, whose *persisted* descriptor is LMDB-shaped, are covered along with new ones.

| input | resolves to | effect |
|---|---|---|
| `''` (unset config), `true`, LMDB descriptor | unset | rocksdb-js default (lz4) |
| `false` | `'none'` | no compression |
| `'zstd'`, `{ algorithm, level }` | pass through | as given |

Compression-on leaves the option *unset* rather than naming `lz4`, because an explicit `lz4` would throw on a build without it.

## Behavior change worth a release note

The 2.6 binaries link lz4/zstd/bzip2 for the first time. Verified against the shipped natives:

| symbol | 2.5.0 | 2.6.1 |
|---|---|---|
| `LZ4_compress` | ABSENT | PRESENT |
| `ZSTD_compress` | ABSENT | PRESENT |
| `BZ2_bzCompress` | ABSENT | PRESENT |

2.5.0 also exported no `supportedCompression`. So RocksDB stores were **uncompressed** until now. That means `storage.compression: false` preserves today's behavior, and the notable change is the **default turning compression on (lz4)** — a disk win, but it changes on-disk format and CPU profile for new/compacted files. Existing SST/blob data stays readable.

## Testing

- `test:unit:main` — 4221 passing
- `test:unit:resources` — 1354 passing
- `test:integration:all` — clean (exit 0)
- Direct `resolveRocksCompression` cases for `''`, `false`, `true`, the LMDB descriptor, `{algorithm, level}`, and a never-throws sweep

The table-level test alone was **not** sufficient and this is worth knowing when reading the diff: 2.6.1 accepts an object with no `algorithm` as "unset", so the default config (which yields the descriptor) exercises the one input that never failed — that test passes with or without the fix. The inputs that actually throw are `''` and the booleans, and only a direct test reaches them. Caught by the cross-model review; the resolver is exported for that reason.

## Open items for the reviewer

1. **`storage.compression: zstd` is silently downgraded to lz4.** `getDefaultCompression()` returns `LMDB_COMPRESSION && LMDB_COMPRESSION_OPTS`, so any truthy value — including an algorithm name — is discarded in favor of the LMDB options object. The string pass-through branch here is therefore unreachable *from config* today. Wiring it through is a new user-facing capability (needs docs + a release note), so I left it out of a fix PR. Worth a follow-up.
2. **harper-pro still pins `^2.5.0`** (both the root and its `core` submodule). Both resolve to 2.6.1 today so it's dormant, but once 2.7.0 ships npm would hoist 2.7.x for harper-pro and nest 2.6.x under core — two copies of a binding whose registry is process-global. Wants a coordinated bump.

## Provenance

Root-caused and written by Claude Opus 5. Reviewed pre-push by Codex, Gemini, Grok, and the Harper domain pass; the test-effectiveness finding above came from that review and is fixed here. One reviewer finding was **dropped as disproven** — a claimed crash from injecting `threshold` into a RocksDB descriptor: `normalizeCompression` reads only `algorithm`/`level` and ignores extra keys (verified by opening a DB with `{algorithm:'lz4', level:3, threshold:4036}`), and the branch is unreachable because `primaryAttribute.compression` only ever originates from `getDefaultCompression`'s LMDB shape.

Unblocks #2036.