### PR TITLE
feat(server): let liveSubscriptionAuth revoke a single subscriber without ending its subscription

### DIFF
--- a/server/liveSubscriptionAuth.ts
+++ b/server/liveSubscriptionAuth.ts
@@ -129,13 +129,15 @@ function stopIfIdle(): void {
  * mutate state shared across them — `registerLiveSubscriptionForContext` in resources/Resource.ts
  * mutates `context.user` to the freshly-rechecked principal, which is safe only because each context
  * today belongs to exactly one subscriber; (3) `revoke` must be idempotent and safe to run concurrently
- * with the caller's own teardown — a *rejected* attempt is retried on the next sweep (see
- * `claimAndTerminate`), an attempt that never settles is not retried and the entry is not rechecked
- * again, and `unregister()` racing an in-flight `revoke` is only closed up to the point the await
- * begins, not for the remainder of it.
+ * with the caller's own teardown — a *rejected* attempt is re-invoked on the next sweep, but only if
+ * that sweep's `recheck` again denies, so a subscription whose permission was restored in between is
+ * left half-torn-down and treated as healthy; an attempt that never settles is not retried at all and
+ * the entry is never rechecked again; and `unregister()` racing an in-flight `revoke` is only closed
+ * up to the point the await begins, not for the remainder of it.
  */
 export function registerLiveSubscription(opts: {
-	subscription: any;
+	/** Optional when `revoke` is supplied: a revoke-only registrant may own no subscription object. */
+	subscription?: any;
 	username: string;
 	authExpiresAt?: number;
 	recheck: () => Promise<boolean>;

--- a/server/liveSubscriptionAuth.ts
+++ b/server/liveSubscriptionAuth.ts
@@ -52,6 +52,17 @@ function errorMessage(error: unknown): string {
 	}
 }
 
+// hdbLogger's file-backed transport can itself throw (e.g. ENOSPC/EIO on the underlying
+// fs.appendFileSync) with nothing between it and the caller. A logging call inside a fail-closed
+// catch arm must never be the thing that defeats fail-closed by escaping as a new exception.
+function safeLog(log: ((message: string) => void) | undefined, message: string): void {
+	try {
+		log?.(message);
+	} catch {
+		/* a broken logger must not turn a contained failure into a new one */
+	}
+}
+
 function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
 	return new Promise((resolve, reject) => {
 		const timer = setTimeout(() => reject(new Error(message)), ms);
@@ -81,7 +92,7 @@ const NOOP_HANDLE = { unregister: () => {} };
 // closed catch-arm call (e.g. a logger call that itself throws) would otherwise escape as an
 // unhandled rejection from these fire-and-forget triggers.
 function triggerSweep(): void {
-	void sweep().catch((error) => hdbLogger.error?.(`liveSubscriptionAuth: sweep failed: ${errorMessage(error)}`));
+	void sweep().catch((error) => safeLog(hdbLogger.error, `liveSubscriptionAuth: sweep failed: ${errorMessage(error)}`));
 }
 
 function ensureStarted(): void {
@@ -211,12 +222,18 @@ export function registerLiveSubscription(opts: {
  * that never settles would hold `sweeping` true forever (the `finally` in `sweep()` never runs),
  * silently disabling re-authorization for every subscription on the worker, not just this entry's.
  * `recheck` has the same unbounded-await shape but is registry-controlled Harper code; `revoke` is
- * arbitrary caller code, which is the materially wider exposure this bound closes. A timeout does not
- * cancel the underlying call — `entry.pendingTerminate` caches it, so a retry on the next sweep
- * re-awaits the SAME in-flight attempt instead of invoking `terminate`/`revoke` a second time while
- * the first is still running; the cache clears once that attempt actually settles (success or
- * failure), so a genuinely stuck call is never retried, but a merely slow one gets a fresh invocation
- * next time only after it's actually done.
+ * arbitrary caller code, which is the materially wider exposure this bound closes.
+ *
+ * A timeout does not cancel the underlying call — `entry.pendingTerminate` caches it, so a retry on
+ * the next sweep re-awaits the SAME in-flight attempt instead of invoking `terminate`/`revoke` a
+ * second time while the first is still running. Committing the removal (`registry.delete` + the
+ * success log) happens from a handler attached to that cached attempt directly, NOT from the code
+ * below that raced it with a timeout: a `revoke` that succeeds after this sweep's timeout window
+ * closes, but before the next sweep starts, must still be committed exactly once — reusing it as a
+ * plain resolved value in a later `claimAndTerminate` call would silently discard that success and
+ * invoke `revoke` again next sweep, precisely the double-invocation this cache exists to prevent.
+ * Attaching the commit/failure handler once, at the point the attempt is created, means it fires
+ * whenever the attempt settles, whether or not any sweep is actively awaiting it at that moment.
  */
 function invokeTerminate(entry: LiveSubscription): Promise<void> {
 	try {
@@ -233,22 +250,38 @@ async function claimAndTerminate(entry: LiveSubscription, reason: string): Promi
 		attempt = invokeTerminate(entry);
 		entry.pendingTerminate = attempt;
 		const settledAttempt = attempt;
-		const clearIfCurrent = () => {
-			if (entry.pendingTerminate === settledAttempt) entry.pendingTerminate = undefined;
-		};
-		attempt.then(clearIfCurrent, clearIfCurrent);
+		attempt.then(
+			() => {
+				if (entry.pendingTerminate === settledAttempt) entry.pendingTerminate = undefined;
+				if (registry.delete(entry)) {
+					safeLog(hdbLogger.info, `liveSubscriptionAuth: revoked subscription for ${entry.username} (${reason})`);
+				}
+			},
+			(error) => {
+				if (entry.pendingTerminate === settledAttempt) entry.pendingTerminate = undefined;
+				safeLog(
+					hdbLogger.error,
+					`liveSubscriptionAuth: terminate failed for ${entry.username} (${reason}), will retry next sweep: ${errorMessage(error)}`
+				);
+			}
+		);
 	}
 	const timeoutMs = terminateTimeoutMs();
 	try {
 		await withTimeout(attempt, timeoutMs, `terminate timed out after ${timeoutMs}ms`);
-	} catch (error) {
-		hdbLogger.error?.(
-			`liveSubscriptionAuth: terminate failed for ${entry.username} (${reason}), will retry next sweep: ${errorMessage(error)}`
-		);
+	} catch {
+		// If the attempt itself already rejected, the handler above already logged the definitive
+		// failure and cleared pendingTerminate — nothing more to do. If it's still pending (this is
+		// our own timeout firing, not a rejection), pendingTerminate still points at it; log that this
+		// sweep is still waiting so a persistently hung revoke doesn't go completely silent.
+		if (entry.pendingTerminate === attempt) {
+			safeLog(
+				hdbLogger.error,
+				`liveSubscriptionAuth: terminate for ${entry.username} (${reason}) still pending after ${timeoutMs}ms, will retry next sweep`
+			);
+		}
 		return false;
 	}
-	registry.delete(entry);
-	hdbLogger.info?.(`liveSubscriptionAuth: revoked subscription for ${entry.username} (${reason})`);
 	return true;
 }
 

--- a/server/liveSubscriptionAuth.ts
+++ b/server/liveSubscriptionAuth.ts
@@ -205,36 +205,6 @@ export function registerLiveSubscription(opts: {
 	return { unregister };
 }
 
-/**
- * Remove `entry` and run its terminate/revoke, but only commit the removal once terminate actually
- * settles successfully (or times out — see below) — and only if the caller hasn't already
- * unregistered this entry itself (checked via `registry.has`, not a delete-then-restore, so a failed
- * attempt never revisits the entry within the same sweep pass; it's simply left in place for the
- * next one). This makes revocation fail-closed on *tracking*: a `revoke` that throws, rejects, or
- * never settles (e.g. a shared-feed refcount release hitting a wedged backing store) leaves the entry
- * registered instead of being forgotten, so the next sweep retries — recheck fails the same way, so
- * the retry converges once teardown succeeds. The `info` log on success reports that terminate was
- * *invoked without error*, not that delivery is provably stopped — the default terminate (no `revoke`
- * supplied) still swallows its own errors internally, unchanged from #1414, so that guarantee is only
- * as strong as it always was on the legacy path.
- *
- * `terminate` is raced against `terminateTimeoutMs()`: without a bound, a caller-supplied `revoke`
- * that never settles would hold `sweeping` true forever (the `finally` in `sweep()` never runs),
- * silently disabling re-authorization for every subscription on the worker, not just this entry's.
- * `recheck` has the same unbounded-await shape but is registry-controlled Harper code; `revoke` is
- * arbitrary caller code, which is the materially wider exposure this bound closes.
- *
- * A timeout does not cancel the underlying call — `entry.pendingTerminate` caches it, so a retry on
- * the next sweep re-awaits the SAME in-flight attempt instead of invoking `terminate`/`revoke` a
- * second time while the first is still running. Committing the removal (`registry.delete` + the
- * success log) happens from a handler attached to that cached attempt directly, NOT from the code
- * below that raced it with a timeout: a `revoke` that succeeds after this sweep's timeout window
- * closes, but before the next sweep starts, must still be committed exactly once — reusing it as a
- * plain resolved value in a later `claimAndTerminate` call would silently discard that success and
- * invoke `revoke` again next sweep, precisely the double-invocation this cache exists to prevent.
- * Attaching the commit/failure handler once, at the point the attempt is created, means it fires
- * whenever the attempt settles, whether or not any sweep is actively awaiting it at that moment.
- */
 function invokeTerminate(entry: LiveSubscription): Promise<void> {
 	try {
 		return Promise.resolve(entry.terminate());
@@ -243,29 +213,54 @@ function invokeTerminate(entry: LiveSubscription): Promise<void> {
 	}
 }
 
+/**
+ * Remove `entry` and run its terminate/revoke, but only if the caller hasn't already unregistered
+ * this entry itself (checked via `registry.has`, not a delete-then-restore, so a failed attempt never
+ * revisits the entry within the same sweep pass; it's simply left in place for the next one). This
+ * makes revocation fail-closed on *tracking*: a `revoke` that throws, rejects, or never settles (e.g.
+ * a shared-feed refcount release hitting a wedged backing store) leaves the entry registered instead
+ * of being forgotten, so the next sweep retries — recheck fails the same way, so the retry converges
+ * once teardown succeeds.
+ *
+ * `terminate` is invoked at most once per entry no matter how many sweeps it takes to settle.
+ * `entry.pendingTerminate` caches the in-flight attempt, and the commit/failure handler is attached to
+ * it ONCE, at creation — it fires whenever the attempt settles (success, rejection, or, for the
+ * default terminate, a synchronous self-unregister via `subscription.end`'s wrapper), regardless of
+ * whether any sweep is actively awaiting it at that moment. This is what makes a late success (one
+ * that lands after this sweep's timeout window closes but before the next sweep starts) commit
+ * exactly once instead of being silently discarded and re-invoked. A sweep that finds an attempt
+ * already in flight from a previous pass does not re-invoke `terminate`/`revoke` and does not re-race
+ * it either — the outcome will be handled by the original handler whenever it settles; there is
+ * nothing left for a second wait to accomplish, and re-racing it would cost another full
+ * `terminateTimeoutMs()` of serialized sweep time per stuck entry, every single pass, forever.
+ *
+ * Only the FIRST attempt is raced against `terminateTimeoutMs()`: without a bound, a caller-supplied
+ * `revoke` that never settles would hold `sweeping` true forever (the `finally` in `sweep()` never
+ * runs), silently disabling re-authorization for every subscription on the worker, not just this
+ * entry's. `recheck` has the same unbounded-await shape but is registry-controlled Harper code;
+ * `revoke` is arbitrary caller code, which is the materially wider exposure this bound closes.
+ */
 async function claimAndTerminate(entry: LiveSubscription, reason: string): Promise<boolean> {
 	if (!registry.has(entry)) return false; // the caller already unregistered this entry itself
-	let attempt = entry.pendingTerminate;
-	if (!attempt) {
-		attempt = invokeTerminate(entry);
-		entry.pendingTerminate = attempt;
-		const settledAttempt = attempt;
-		attempt.then(
-			() => {
-				if (entry.pendingTerminate === settledAttempt) entry.pendingTerminate = undefined;
-				if (registry.delete(entry)) {
-					safeLog(hdbLogger.info, `liveSubscriptionAuth: revoked subscription for ${entry.username} (${reason})`);
-				}
-			},
-			(error) => {
-				if (entry.pendingTerminate === settledAttempt) entry.pendingTerminate = undefined;
-				safeLog(
-					hdbLogger.error,
-					`liveSubscriptionAuth: terminate failed for ${entry.username} (${reason}), will retry next sweep: ${errorMessage(error)}`
-				);
-			}
-		);
-	}
+	if (entry.pendingTerminate) return false; // already being handled by a prior sweep's attempt
+
+	const attempt = invokeTerminate(entry);
+	entry.pendingTerminate = attempt;
+	attempt.then(
+		() => {
+			if (entry.pendingTerminate === attempt) entry.pendingTerminate = undefined;
+			registry.delete(entry);
+			safeLog(hdbLogger.info, `liveSubscriptionAuth: revoked subscription for ${entry.username} (${reason})`);
+		},
+		(error) => {
+			if (entry.pendingTerminate === attempt) entry.pendingTerminate = undefined;
+			safeLog(
+				hdbLogger.error,
+				`liveSubscriptionAuth: terminate failed for ${entry.username} (${reason}), will retry next sweep: ${errorMessage(error)}`
+			);
+		}
+	);
+
 	const timeoutMs = terminateTimeoutMs();
 	try {
 		await withTimeout(attempt, timeoutMs, `terminate timed out after ${timeoutMs}ms`);

--- a/server/liveSubscriptionAuth.ts
+++ b/server/liveSubscriptionAuth.ts
@@ -85,26 +85,19 @@ function stopIfIdle(): void {
 /**
  * Register a live subscription for continuous re-authorization.
  *
- * If `revoke` is omitted, behavior matches #1414 exactly: terminate defaults to
- * end()/close()/emit('close') on `subscription`, and the subscription's own teardown (end()/close)
- * automatically unregisters it.
+ * Without `revoke`, teardown is end()/close()/emit('close') on `subscription`, and the
+ * subscription's own teardown unregisters the entry so callers need not.
  *
- * If `revoke` is supplied, it is used as the entry's terminate instead and the subscription object
- * is left untouched (no `end` wrapping, no 'close' listener) — the caller unregisters through the
- * returned handle. This is the seam a feed shared by many subscribers needs: revocation must stay
- * per subscriber even once feed delivery is shared, so the registry can't assume it owns the
- * subscription object or that only one registrant will ever mutate it.
- *
- * Three invariants a `revoke` caller must uphold, none enforced here: (1) it owns the entry's
- * lifetime end-to-end — nothing detects a leaked registration, so a caller that forgets
- * `unregister()` on some teardown path degrades sweep latency for every other tracked subscriber,
- * not just its own; (2) if it shares one feed (and one `recheck`) across subscribers, `recheck`
- * must not mutate state shared across them — `registerLiveSubscriptionForContext` in
- * resources/Resource.ts mutates `context.user` to the freshly-rechecked principal, which is safe
- * only because each context today belongs to exactly one subscriber; (3) `revoke` gets exactly one
- * best-effort invocation — the entry is untracked before it runs, so a `revoke` that throws, rejects
- * or never settles is logged and never retried, and a caller needing recovery from a failed teardown
- * must implement it inside `revoke`.
+ * With `revoke`, that becomes the teardown and `subscription` is never touched — no `end` wrapping,
+ * no 'close' listener — because a feed shared by many subscribers must stay revocable per subscriber,
+ * so the registry can neither own the shared object nor let every registrant mutate it. A `revoke`
+ * caller owns the entry's lifetime: nothing detects a leaked registration, and a forgotten
+ * `unregister()` degrades sweep latency for every other tracked subscriber. It also owns teardown
+ * recovery — the entry is untracked before `revoke` runs and `revoke` is invoked exactly once, so one
+ * that throws, rejects or never settles is logged and never retried. A `recheck` shared across
+ * subscribers must not mutate state shared across them: `registerLiveSubscriptionForContext` in
+ * resources/Resource.ts mutates `context.user`, which is safe only while each context has exactly
+ * one subscriber.
  */
 export function registerLiveSubscription(
 	opts: {
@@ -113,8 +106,8 @@ export function registerLiveSubscription(
 		recheck: () => Promise<boolean>;
 	} & (
 		| { subscription: any; revoke?: undefined }
-		// a revoke-only registrant may own no subscription object; requiring one of the two modes keeps
-		// a caller that supplies neither from type-checking into a silent no-op registration
+		// requiring one of the two modes stops a caller that supplies neither from type-checking
+		// into a silent no-op registration; a revoke-only registrant may own no subscription object
 		| { subscription?: any; revoke: () => void | Promise<void> }
 	)
 ): { unregister: () => void } {
@@ -161,14 +154,14 @@ export function registerLiveSubscription(
 	return { unregister };
 }
 
-/**
- * Untrack an entry and tear it down, best effort. Untracking first keeps a `revoke` that hangs or
- * fails from wedging the sweep or being re-entered by a later one; recovering from a failed teardown
- * is the caller's job, per registerLiveSubscription's third invariant.
- */
-function terminateEntry(entry: LiveSubscription, reason: string): void {
+/** Untrack first: a `terminate` that hangs or fails must not wedge the sweep or be re-entered by a later one. */
+function terminateEntry(
+	entry: LiveSubscription,
+	reason: string,
+	notice: ((message: string) => void) | undefined = hdbLogger.info
+): void {
 	registry.delete(entry);
-	safeLog(hdbLogger.warn, `liveSubscriptionAuth: revoking subscription for ${entry.username} (${reason})`);
+	safeLog(notice, `liveSubscriptionAuth: revoking subscription for ${entry.username} (${reason})`);
 	const failed = (error: unknown) =>
 		safeLog(
 			hdbLogger.error,
@@ -186,7 +179,7 @@ async function sweep(): Promise<void> {
 	if (sweeping) return; // a slow recheck must not overlap with the next tick/event
 	sweeping = true;
 	try {
-		// snapshot: an entry the caller unregisters mid-sweep must not be rechecked or revoked
+		// snapshot bounds the pass to entries present at its start; the has() guards cover the rest
 		for (const entry of Array.from(registry)) {
 			if (!registry.has(entry)) continue;
 			try {
@@ -196,7 +189,7 @@ async function sweep(): Promise<void> {
 				if (expired || !stillAuthorized) terminateEntry(entry, expired ? 'token expired' : 'no longer authorized');
 			} catch (error) {
 				// fail closed: if authorization can't be confirmed, revoke
-				if (registry.has(entry)) terminateEntry(entry, `recheck error: ${errorMessage(error)}`);
+				if (registry.has(entry)) terminateEntry(entry, `recheck error: ${errorMessage(error)}`, hdbLogger.warn);
 			}
 		}
 	} finally {

--- a/server/liveSubscriptionAuth.ts
+++ b/server/liveSubscriptionAuth.ts
@@ -17,6 +17,14 @@ import hdbLogger from '../utility/logging/harper_logger.ts';
 // Backstop interval; also catches token expiry, which is not event-signaled. Overridable for tests.
 const RECHECK_INTERVAL_MS = Number(process.env.HARPER_SUBSCRIPTION_REAUTH_INTERVAL_MS) || 30_000;
 
+// Bounds how long a caller-supplied terminate/revoke may hold the serialized sweep before being
+// treated as a failure (same fail-closed retry as a throw/rejection). The default terminate settles
+// long before this — it only ever engages for a caller-supplied `revoke` that hangs. Read fresh per
+// call rather than cached at module load, so tests can override it without a require-cache reset.
+function terminateTimeoutMs(): number {
+	return Number(process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS) || 5_000;
+}
+
 interface LiveSubscription {
 	username: string;
 	/** JWT `exp` (seconds since epoch) of the credential the subscription was opened with, if any. */
@@ -28,7 +36,31 @@ interface LiveSubscription {
 }
 
 function errorMessage(error: unknown): string {
-	return error instanceof Error ? error.message : String(error);
+	try {
+		return error instanceof Error ? error.message : String(error);
+	} catch {
+		// a thrown value whose own String()/toString() throws (e.g. Object.create(null)) must not turn
+		// a contained failure into a new one — this runs inside a sweep catch handler with no outer guard.
+		return '<error message unavailable>';
+	}
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => reject(new Error(message)), ms);
+		// don't let a pending timeout keep the process alive
+		(timer as any).unref?.();
+		promise.then(
+			(value) => {
+				clearTimeout(timer);
+				resolve(value);
+			},
+			(error) => {
+				clearTimeout(timer);
+				reject(error);
+			}
+		);
+	});
 }
 
 const registry = new Set<LiveSubscription>();
@@ -79,13 +111,16 @@ function stopIfIdle(): void {
  * stay per subscriber even once feed delivery is shared, so the registry can't assume it owns the
  * subscription object or that only one registrant will ever mutate it.
  *
- * Two invariants a `revoke` caller must uphold, not enforced by this module: (1) it owns the entry's
- * lifetime end-to-end — nothing here detects a leaked registration, so a caller that forgets
+ * Three invariants a `revoke` caller must uphold, not enforced by this module: (1) it owns the
+ * entry's lifetime end-to-end — nothing here detects a leaked registration, so a caller that forgets
  * `unregister()` on some teardown path degrades sweep latency for every other tracked subscriber, not
  * just its own; (2) if it shares one feed (and one `recheck`) across subscribers, `recheck` must not
  * mutate state shared across them — `registerLiveSubscriptionForContext` in resources/Resource.ts
  * mutates `context.user` to the freshly-rechecked principal, which is safe only because each context
- * today belongs to exactly one subscriber.
+ * today belongs to exactly one subscriber; (3) `revoke` must be idempotent and safe to run concurrently
+ * with the caller's own teardown — a failed attempt is retried on the next sweep (see
+ * `claimAndTerminate`), and `unregister()` racing an in-flight `revoke` is only closed up to the point
+ * the await begins, not for the remainder of it.
  */
 export function registerLiveSubscription(opts: {
 	subscription: any;
@@ -143,20 +178,31 @@ export function registerLiveSubscription(opts: {
 
 /**
  * Remove `entry` and run its terminate/revoke, but only commit the removal once terminate actually
- * succeeds — and only if the caller hasn't already unregistered this entry itself (checked via
- * `registry.has`, not a delete-then-restore, so a failed attempt never revisits the entry within the
- * same sweep pass; it's simply left in place for the next one). This makes revocation genuinely
- * fail-closed: a `revoke` that throws or rejects (e.g. a shared-feed refcount release hitting a
- * transient backing-store error) leaves the entry registered instead of being forgotten, so the next
- * sweep retries — recheck fails the same way, so the retry converges once teardown succeeds. It also
- * means a `revoke`/default-terminate failure never masquerades as a successful revocation in the log.
- * `terminate` is awaited (it may be async) so a rejection is caught here rather than becoming an
- * unhandled rejection on the worker.
+ * settles successfully (or times out — see below) — and only if the caller hasn't already
+ * unregistered this entry itself (checked via `registry.has`, not a delete-then-restore, so a failed
+ * attempt never revisits the entry within the same sweep pass; it's simply left in place for the
+ * next one). This makes revocation fail-closed on *tracking*: a `revoke` that throws, rejects, or
+ * never settles (e.g. a shared-feed refcount release hitting a wedged backing store) leaves the entry
+ * registered instead of being forgotten, so the next sweep retries — recheck fails the same way, so
+ * the retry converges once teardown succeeds. The `info` log on success reports that terminate was
+ * *invoked without error*, not that delivery is provably stopped — the default terminate (no `revoke`
+ * supplied) still swallows its own errors internally, unchanged from #1414, so that guarantee is only
+ * as strong as it always was on the legacy path.
+ *
+ * `terminate` is raced against `terminateTimeoutMs()`: without a bound, a caller-supplied `revoke`
+ * that never settles would hold `sweeping` true forever (the `finally` in `sweep()` never runs),
+ * silently disabling re-authorization for every subscription on the worker, not just this entry's.
+ * `recheck` has the same unbounded-await shape but is registry-controlled Harper code; `revoke` is
+ * arbitrary caller code, which is the materially wider exposure this bound closes.
  */
 async function claimAndTerminate(entry: LiveSubscription, reason: string): Promise<boolean> {
 	if (!registry.has(entry)) return false; // the caller already unregistered this entry itself
 	try {
-		await entry.terminate();
+		await withTimeout(
+			Promise.resolve(entry.terminate()),
+			terminateTimeoutMs(),
+			`terminate timed out after ${terminateTimeoutMs()}ms`
+		);
 	} catch (error) {
 		hdbLogger.error?.(
 			`liveSubscriptionAuth: terminate failed for ${entry.username} (${reason}), will retry next sweep: ${errorMessage(error)}`

--- a/server/liveSubscriptionAuth.ts
+++ b/server/liveSubscriptionAuth.ts
@@ -23,8 +23,12 @@ interface LiveSubscription {
 	authExpiresAt?: number;
 	/** Returns true if the principal is still authorized for this subscription. */
 	recheck: () => Promise<boolean>;
-	/** Stop delivery and tear down the subscription. */
-	terminate: () => void;
+	/** Stop delivery and tear down the subscription. May be async (e.g. a shared-feed refcount release). */
+	terminate: () => void | Promise<void>;
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
 }
 
 const registry = new Set<LiveSubscription>();
@@ -74,13 +78,21 @@ function stopIfIdle(): void {
  * returned handle instead. This is the seam a feed shared by many subscribers needs: revocation must
  * stay per subscriber even once feed delivery is shared, so the registry can't assume it owns the
  * subscription object or that only one registrant will ever mutate it.
+ *
+ * Two invariants a `revoke` caller must uphold, not enforced by this module: (1) it owns the entry's
+ * lifetime end-to-end — nothing here detects a leaked registration, so a caller that forgets
+ * `unregister()` on some teardown path degrades sweep latency for every other tracked subscriber, not
+ * just its own; (2) if it shares one feed (and one `recheck`) across subscribers, `recheck` must not
+ * mutate state shared across them — `registerLiveSubscriptionForContext` in resources/Resource.ts
+ * mutates `context.user` to the freshly-rechecked principal, which is safe only because each context
+ * today belongs to exactly one subscriber.
  */
 export function registerLiveSubscription(opts: {
 	subscription: any;
 	username: string;
 	authExpiresAt?: number;
 	recheck: () => Promise<boolean>;
-	revoke?: () => void;
+	revoke?: () => void | Promise<void>;
 }): { unregister: () => void } {
 	const { subscription, username, authExpiresAt, recheck, revoke } = opts;
 	if (!subscription || typeof subscription !== 'object' || subscription.closed) return NOOP_HANDLE;
@@ -134,14 +146,16 @@ export function registerLiveSubscription(opts: {
  * removes it from the registry. `Set.delete`'s boolean return is a lock-free claim token: it's
  * false if the entry was already removed — by a caller's `unregister()` racing an in-flight
  * `recheck()`, or by another sweep path — so terminate/revoke runs at most once per entry, and
- * never for one the caller has already torn down itself.
+ * never for one the caller has already torn down itself. `terminate` is awaited (it may be async,
+ * e.g. a shared-feed refcount release) so a rejection is caught here rather than becoming an
+ * unhandled rejection on the worker.
  */
-function claimAndTerminate(entry: LiveSubscription): boolean {
+async function claimAndTerminate(entry: LiveSubscription): Promise<boolean> {
 	if (!registry.delete(entry)) return false;
 	try {
-		entry.terminate();
+		await entry.terminate();
 	} catch (error) {
-		hdbLogger.warn?.(`liveSubscriptionAuth: terminate failed for ${entry.username}: ${(error as Error).message}`);
+		hdbLogger.warn?.(`liveSubscriptionAuth: terminate failed for ${entry.username}: ${errorMessage(error)}`);
 	}
 	return true;
 }
@@ -155,12 +169,12 @@ async function sweep(): Promise<void> {
 			try {
 				const expired = entry.authExpiresAt != null && now >= entry.authExpiresAt * 1000;
 				const stillAuthorized = expired ? false : await entry.recheck();
-				if (expired || !stillAuthorized) claimAndTerminate(entry);
+				if (expired || !stillAuthorized) await claimAndTerminate(entry);
 			} catch (error) {
 				// fail closed: if authorization can't be confirmed, revoke
-				if (claimAndTerminate(entry)) {
+				if (await claimAndTerminate(entry)) {
 					hdbLogger.warn?.(
-						`liveSubscriptionAuth: revoked subscription for ${entry.username} after recheck error: ${(error as Error).message}`
+						`liveSubscriptionAuth: revoked subscription for ${entry.username} after recheck error: ${errorMessage(error)}`
 					);
 				}
 			}

--- a/server/liveSubscriptionAuth.ts
+++ b/server/liveSubscriptionAuth.ts
@@ -129,9 +129,10 @@ function stopIfIdle(): void {
  * mutate state shared across them — `registerLiveSubscriptionForContext` in resources/Resource.ts
  * mutates `context.user` to the freshly-rechecked principal, which is safe only because each context
  * today belongs to exactly one subscriber; (3) `revoke` must be idempotent and safe to run concurrently
- * with the caller's own teardown — a failed attempt is retried on the next sweep (see
- * `claimAndTerminate`), and `unregister()` racing an in-flight `revoke` is only closed up to the point
- * the await begins, not for the remainder of it.
+ * with the caller's own teardown — a *rejected* attempt is retried on the next sweep (see
+ * `claimAndTerminate`), an attempt that never settles is not retried and the entry is not rechecked
+ * again, and `unregister()` racing an in-flight `revoke` is only closed up to the point the await
+ * begins, not for the remainder of it.
  */
 export function registerLiveSubscription(opts: {
 	subscription: any;
@@ -202,6 +203,7 @@ function invokeTerminate(entry: LiveSubscription): Promise<void> {
  */
 async function claimAndTerminate(entry: LiveSubscription, reason: string): Promise<boolean> {
 	if (!registry.has(entry)) return false; // the caller already unregistered this entry itself
+	if (entry.pendingTerminate) return false; // at-most-once, enforced here so any caller gets it, not just sweep()
 
 	const attempt = invokeTerminate(entry);
 	entry.pendingTerminate = attempt;

--- a/server/liveSubscriptionAuth.ts
+++ b/server/liveSubscriptionAuth.ts
@@ -178,9 +178,8 @@ function terminateEntry(
 async function sweep(): Promise<void> {
 	if (sweeping) return; // a slow recheck must not overlap with the next tick/event
 	sweeping = true;
-	// Per-subscriber revocation lines are info, which the shipped default (logging.level: warn) drops.
-	// One aggregate per pass carries the same news at the level operators actually read, without
-	// turning a mass role change into one warn per subscriber.
+	// the per-subscriber lines are info, which the shipped default (logging.level: warn) drops; one
+	// aggregate keeps the pass visible without making a mass role change a warn per subscriber
 	const revokedByReason = new Map<string, number>();
 	const countRevocation = (reason: string) => revokedByReason.set(reason, (revokedByReason.get(reason) ?? 0) + 1);
 	try {
@@ -213,7 +212,9 @@ async function sweep(): Promise<void> {
 			const breakdown = Array.from(revokedByReason, ([reason, count]) => `${reason}: ${count}`).join(', ');
 			safeLog(
 				hdbLogger.warn,
-				`liveSubscriptionAuth: revoked ${total} live subscription${total === 1 ? '' : 's'} (${breakdown})`
+				// "revoking", like the per-subscriber line: teardown is dispatched, not awaited, and a
+				// failure surfaces on its own error line
+				`liveSubscriptionAuth: revoking ${total} live subscription${total === 1 ? '' : 's'} (${breakdown})`
 			);
 		}
 	}

--- a/server/liveSubscriptionAuth.ts
+++ b/server/liveSubscriptionAuth.ts
@@ -142,21 +142,29 @@ export function registerLiveSubscription(opts: {
 }
 
 /**
- * Delete `entry` and run its terminate/revoke, but only if this call is the one that actually
- * removes it from the registry. `Set.delete`'s boolean return is a lock-free claim token: it's
- * false if the entry was already removed — by a caller's `unregister()` racing an in-flight
- * `recheck()`, or by another sweep path — so terminate/revoke runs at most once per entry, and
- * never for one the caller has already torn down itself. `terminate` is awaited (it may be async,
- * e.g. a shared-feed refcount release) so a rejection is caught here rather than becoming an
+ * Remove `entry` and run its terminate/revoke, but only commit the removal once terminate actually
+ * succeeds — and only if the caller hasn't already unregistered this entry itself (checked via
+ * `registry.has`, not a delete-then-restore, so a failed attempt never revisits the entry within the
+ * same sweep pass; it's simply left in place for the next one). This makes revocation genuinely
+ * fail-closed: a `revoke` that throws or rejects (e.g. a shared-feed refcount release hitting a
+ * transient backing-store error) leaves the entry registered instead of being forgotten, so the next
+ * sweep retries — recheck fails the same way, so the retry converges once teardown succeeds. It also
+ * means a `revoke`/default-terminate failure never masquerades as a successful revocation in the log.
+ * `terminate` is awaited (it may be async) so a rejection is caught here rather than becoming an
  * unhandled rejection on the worker.
  */
-async function claimAndTerminate(entry: LiveSubscription): Promise<boolean> {
-	if (!registry.delete(entry)) return false;
+async function claimAndTerminate(entry: LiveSubscription, reason: string): Promise<boolean> {
+	if (!registry.has(entry)) return false; // the caller already unregistered this entry itself
 	try {
 		await entry.terminate();
 	} catch (error) {
-		hdbLogger.warn?.(`liveSubscriptionAuth: terminate failed for ${entry.username}: ${errorMessage(error)}`);
+		hdbLogger.error?.(
+			`liveSubscriptionAuth: terminate failed for ${entry.username} (${reason}), will retry next sweep: ${errorMessage(error)}`
+		);
+		return false;
 	}
+	registry.delete(entry);
+	hdbLogger.info?.(`liveSubscriptionAuth: revoked subscription for ${entry.username} (${reason})`);
 	return true;
 }
 
@@ -169,14 +177,12 @@ async function sweep(): Promise<void> {
 			try {
 				const expired = entry.authExpiresAt != null && now >= entry.authExpiresAt * 1000;
 				const stillAuthorized = expired ? false : await entry.recheck();
-				if (expired || !stillAuthorized) await claimAndTerminate(entry);
+				if (expired || !stillAuthorized) {
+					await claimAndTerminate(entry, expired ? 'token expired' : 'no longer authorized');
+				}
 			} catch (error) {
 				// fail closed: if authorization can't be confirmed, revoke
-				if (await claimAndTerminate(entry)) {
-					hdbLogger.warn?.(
-						`liveSubscriptionAuth: revoked subscription for ${entry.username} after recheck error: ${errorMessage(error)}`
-					);
-				}
+				await claimAndTerminate(entry, `recheck error: ${errorMessage(error)}`);
 			}
 		}
 	} finally {

--- a/server/liveSubscriptionAuth.ts
+++ b/server/liveSubscriptionAuth.ts
@@ -18,10 +18,7 @@ import hdbLogger from '../utility/logging/harper_logger.ts';
 const RECHECK_INTERVAL_MS = Number(process.env.HARPER_SUBSCRIPTION_REAUTH_INTERVAL_MS) || 30_000;
 const MAX_TIMEOUT_MS = 2_147_483_647;
 
-// Bounds how long a caller-supplied terminate/revoke may hold the serialized sweep before being
-// treated as a failure (same fail-closed retry as a throw/rejection). The default terminate settles
-// long before this — it only ever engages for a caller-supplied `revoke` that hangs. Read fresh per
-// call rather than cached at module load, so tests can override it without a require-cache reset.
+// Read fresh per call so tests can override it without resetting the module cache.
 function terminateTimeoutMs(): number {
 	const timeoutMs = Number(process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS) || 5_000;
 	return Math.min(Math.max(timeoutMs, 1), MAX_TIMEOUT_MS);
@@ -35,12 +32,7 @@ interface LiveSubscription {
 	recheck: () => Promise<boolean>;
 	/** Stop delivery and tear down the subscription. May be async (e.g. a shared-feed refcount release). */
 	terminate: () => void | Promise<void>;
-	/**
-	 * The in-flight `terminate()` call, if a prior attempt is still pending (timed out, not settled).
-	 * Reused rather than calling `terminate` again, so a hung `revoke` is never invoked twice for the
-	 * same entry — the seam's documented idempotency invariant is enforced here rather than merely
-	 * assumed of caller code.
-	 */
+	/** The in-flight terminate call, cleared after it settles. */
 	pendingTerminate?: Promise<void>;
 }
 
@@ -48,15 +40,10 @@ function errorMessage(error: unknown): string {
 	try {
 		return error instanceof Error ? error.message : String(error);
 	} catch {
-		// a thrown value whose own String()/toString() throws (e.g. Object.create(null)) must not turn
-		// a contained failure into a new one — this runs inside a sweep catch handler with no outer guard.
 		return '<error message unavailable>';
 	}
 }
 
-// hdbLogger's file-backed transport can itself throw (e.g. ENOSPC/EIO on the underlying
-// fs.appendFileSync) with nothing between it and the caller. A logging call inside a fail-closed
-// catch arm must never be the thing that defeats fail-closed by escaping as a new exception.
 function safeLog(log: ((message: string) => void) | undefined, message: string): void {
 	try {
 		log?.(message);
@@ -90,9 +77,6 @@ let sweeping = false;
 
 const NOOP_HANDLE = { unregister: () => {} };
 
-// sweep()'s own try/finally protects its recheck body, but a throw from claimAndTerminate's fail-
-// closed catch-arm call (e.g. a logger call that itself throws) would otherwise escape as an
-// unhandled rejection from these fire-and-forget triggers.
 function triggerSweep(): void {
 	void sweep().catch((error) => safeLog(hdbLogger.error, `liveSubscriptionAuth: sweep failed: ${errorMessage(error)}`));
 }
@@ -157,10 +141,6 @@ export function registerLiveSubscription(opts: {
 	revoke?: () => void | Promise<void>;
 }): { unregister: () => void } {
 	const { subscription, username, authExpiresAt, recheck, revoke } = opts;
-	// The registry-owned teardown path needs a live, mutable subscription object to wrap; the
-	// caller-owned `revoke` path never touches `subscription` at all (see below), so a caller with no
-	// meaningful subscription object to hand over — the expected shape for a shared feed — isn't held
-	// to that requirement.
 	if (!revoke && (!subscription || typeof subscription !== 'object' || subscription.closed)) return NOOP_HANDLE;
 
 	const entry: LiveSubscription = {
@@ -216,40 +196,9 @@ function invokeTerminate(entry: LiveSubscription): Promise<void> {
 }
 
 /**
- * Remove `entry` and run its terminate/revoke, but only if the caller hasn't already unregistered
- * this entry itself (checked via `registry.has`, not a delete-then-restore, so a failed attempt never
- * revisits the entry within the same sweep pass; it's simply left in place for the next one). This
- * makes revocation fail-closed on *tracking*: a `revoke` that throws, rejects, or never settles (e.g.
- * a shared-feed refcount release hitting a wedged backing store) leaves the entry registered instead
- * of being forgotten, so the next sweep retries — recheck fails the same way, so the retry converges
- * once teardown succeeds.
- *
- * `terminate` is invoked at most once per entry no matter how many sweeps it takes to settle.
- * `entry.pendingTerminate` caches the in-flight attempt, and the commit/failure handler is attached to
- * it ONCE, at creation — it fires whenever the attempt settles (success, rejection, or, for the
- * default terminate, a synchronous self-unregister via `subscription.end`'s wrapper), regardless of
- * whether any sweep is actively awaiting it at that moment. This is what makes a late success (one
- * that lands after this sweep's timeout window closes but before the next sweep starts) commit
- * exactly once instead of being silently discarded and re-invoked. A sweep that finds an attempt
- * already in flight from a previous pass does not re-invoke `terminate`/`revoke` and does not re-race
- * it either — the outcome will be handled by the original handler whenever it settles, and re-racing
- * it would cost another full `terminateTimeoutMs()` of serialized sweep time per stuck entry, every
- * single pass, forever, for a result nothing uses. It does still log on every such sweep (cheaply, no
- * wait) — without that, a permanently stuck `revoke` would log exactly once, ever, then go silent for
- * the rest of the worker's life, which is worse than the cost it replaced.
- *
- * The success log says "terminate completed", not "revoked" — the default terminate (no `revoke`
- * supplied) still swallows `end()`/`close()`/`emit` errors internally, unchanged from #1414, so this
- * module cannot always tell whether delivery actually stopped, only that terminate ran without an
- * error reaching it.
- *
- * Only the FIRST attempt is raced against `terminateTimeoutMs()`: without a bound, a caller-supplied
- * `revoke` that never settles would hold `sweeping` true forever (the `finally` in `sweep()` never
- * runs), silently disabling re-authorization for every subscription on the worker, not just this
- * entry's. `recheck` has the same unbounded-await shape and is NOT similarly bounded here — not
- * because it's safe (production `recheck` bottoms out in `resource.allowRead`, user-overridable
- * application code, same as `revoke`), but because bounding it would change behavior on the DEFAULT
- * (no-`revoke`) path, which this seam's own acceptance contract requires to stay identical to #1414.
+ * Terminate a registered entry and remove it only after success. A rejected attempt remains tracked
+ * for retry; a pending attempt is not invoked again. The settle handler commits a late success even
+ * after the sweep's timeout has elapsed.
  */
 async function claimAndTerminate(entry: LiveSubscription, reason: string): Promise<boolean> {
 	if (!registry.has(entry)) return false; // the caller already unregistered this entry itself
@@ -276,14 +225,10 @@ async function claimAndTerminate(entry: LiveSubscription, reason: string): Promi
 	try {
 		await withTimeout(attempt, timeoutMs, `terminate timed out after ${timeoutMs}ms`);
 	} catch {
-		// If the attempt itself already rejected, the handler above already logged the definitive
-		// failure and cleared pendingTerminate — nothing more to do. If it's still pending (this is
-		// our own timeout firing, not a rejection), pendingTerminate still points at it; log that this
-		// sweep is still waiting so a persistently hung revoke doesn't go completely silent.
 		if (entry.pendingTerminate === attempt) {
 			safeLog(
 				hdbLogger.error,
-				`liveSubscriptionAuth: terminate for ${entry.username} (${reason}) still pending after ${timeoutMs}ms, will retry next sweep`
+				`liveSubscriptionAuth: terminate for ${entry.username} (${reason}) still pending after ${timeoutMs}ms; awaiting settlement`
 			);
 		}
 		return false;
@@ -298,8 +243,6 @@ async function sweep(): Promise<void> {
 		for (const entry of Array.from(registry)) {
 			if (!registry.has(entry)) continue;
 			if (entry.pendingTerminate) {
-				// A prior sweep's attempt is already deciding this entry's fate; recheck() would only be
-				// a wasted storage read (findAndValidateUser + allowRead) for an outcome we already know.
 				safeLog(
 					hdbLogger.error,
 					`liveSubscriptionAuth: terminate for ${entry.username} (previously pending) still pending from an earlier sweep`
@@ -307,8 +250,6 @@ async function sweep(): Promise<void> {
 				continue;
 			}
 			try {
-				// Read fresh per entry rather than once before the loop: a slow recheck or terminate on
-				// an earlier entry must not leave a later entry's expiry judged against a stale timestamp.
 				const now = Date.now();
 				const expired = entry.authExpiresAt != null && now >= entry.authExpiresAt * 1000;
 				const stillAuthorized = expired ? false : await entry.recheck();

--- a/server/liveSubscriptionAuth.ts
+++ b/server/liveSubscriptionAuth.ts
@@ -61,32 +61,45 @@ function stopIfIdle(): void {
 }
 
 /**
- * Register a live subscription for continuous re-authorization. The returned subscription's normal
- * teardown (end()/close) automatically unregisters it, so callers don't need to.
+ * Register a live subscription for continuous re-authorization.
+ *
+ * If `revoke` is omitted, behavior matches #1414 exactly: terminate defaults to
+ * end()/close()/emit('close') on `subscription`, and the subscription's own teardown (end()/close)
+ * automatically unregisters it.
+ *
+ * If `revoke` is supplied, it is used as the entry's terminate instead, and the subscription object
+ * is left untouched (no `end` wrapping, no 'close' listener) — the caller unregisters through the
+ * returned handle instead. This is the seam a feed shared by many subscribers needs: revocation must
+ * stay per subscriber even once feed delivery is shared, so the registry can't assume it owns the
+ * subscription object or that only one registrant will ever mutate it.
  */
 export function registerLiveSubscription(opts: {
 	subscription: any;
 	username: string;
 	authExpiresAt?: number;
 	recheck: () => Promise<boolean>;
-}): void {
-	const { subscription, username, authExpiresAt, recheck } = opts;
-	if (!subscription || typeof subscription !== 'object' || subscription.closed) return;
+	revoke?: () => void;
+}): { unregister: () => void } {
+	const { subscription, username, authExpiresAt, recheck, revoke } = opts;
+	const noop = { unregister: () => {} };
+	if (!subscription || typeof subscription !== 'object' || subscription.closed) return noop;
 
 	const entry: LiveSubscription = {
 		username,
 		authExpiresAt,
 		recheck,
-		terminate: () => {
-			// end() removes the subscription from the broadcast loop and closes its iterable queue.
-			try {
-				if (subscription.end) subscription.end();
-				else if (subscription.close) subscription.close();
-				else subscription.emit?.('close');
-			} catch {
-				/* ignore */
-			}
-		},
+		terminate:
+			revoke ??
+			(() => {
+				// end() removes the subscription from the broadcast loop and closes its iterable queue.
+				try {
+					if (subscription.end) subscription.end();
+					else if (subscription.close) subscription.close();
+					else subscription.emit?.('close');
+				} catch {
+					/* ignore */
+				}
+			}),
 	};
 	registry.add(entry);
 
@@ -94,19 +107,25 @@ export function registerLiveSubscription(opts: {
 		registry.delete(entry);
 		stopIfIdle();
 	};
-	// Both transports ultimately call end() on normal teardown (MQTT unsubscribe/disconnect; SSE close
-	// is wired to end()); wrap it so a closed stream never leaks a registry entry. Also listen for
-	// 'close' to cover any iterable that closes without an end().
-	const originalEnd = typeof subscription.end === 'function' ? subscription.end.bind(subscription) : null;
-	if (originalEnd) {
-		subscription.end = function (...args: any[]) {
-			unregister();
-			return originalEnd(...args);
-		};
+
+	if (!revoke) {
+		// Both transports ultimately call end() on normal teardown (MQTT unsubscribe/disconnect; SSE close
+		// is wired to end()); wrap it so a closed stream never leaks a registry entry. Also listen for
+		// 'close' to cover any iterable that closes without an end(). Skipped when `revoke` is supplied:
+		// the caller owns unregistration, and a subscription shared by many subscribers must not be
+		// mutated once per registrant.
+		const originalEnd = typeof subscription.end === 'function' ? subscription.end.bind(subscription) : null;
+		if (originalEnd) {
+			subscription.end = function (...args: any[]) {
+				unregister();
+				return originalEnd(...args);
+			};
+		}
+		subscription.on?.('close', unregister);
 	}
-	subscription.on?.('close', unregister);
 
 	ensureStarted();
+	return { unregister };
 }
 
 async function sweep(): Promise<void> {
@@ -145,4 +164,9 @@ async function sweep(): Promise<void> {
 /** Test-only: current number of tracked subscriptions. */
 export function _liveSubscriptionCount(): number {
 	return registry.size;
+}
+
+/** Test-only: run a sweep synchronously, bypassing the interval/ITC triggers. */
+export function _sweepNow(): Promise<void> {
+	return sweep();
 }

--- a/server/liveSubscriptionAuth.ts
+++ b/server/liveSubscriptionAuth.ts
@@ -33,6 +33,13 @@ interface LiveSubscription {
 	recheck: () => Promise<boolean>;
 	/** Stop delivery and tear down the subscription. May be async (e.g. a shared-feed refcount release). */
 	terminate: () => void | Promise<void>;
+	/**
+	 * The in-flight `terminate()` call, if a prior attempt is still pending (timed out, not settled).
+	 * Reused rather than calling `terminate` again, so a hung `revoke` is never invoked twice for the
+	 * same entry — the seam's documented idempotency invariant is enforced here rather than merely
+	 * assumed of caller code.
+	 */
+	pendingTerminate?: Promise<void>;
 }
 
 function errorMessage(error: unknown): string {
@@ -70,9 +77,16 @@ let sweeping = false;
 
 const NOOP_HANDLE = { unregister: () => {} };
 
+// sweep()'s own try/finally protects its recheck body, but a throw from claimAndTerminate's fail-
+// closed catch-arm call (e.g. a logger call that itself throws) would otherwise escape as an
+// unhandled rejection from these fire-and-forget triggers.
+function triggerSweep(): void {
+	void sweep().catch((error) => hdbLogger.error?.(`liveSubscriptionAuth: sweep failed: ${errorMessage(error)}`));
+}
+
 function ensureStarted(): void {
 	if (!sweepTimer) {
-		sweepTimer = setInterval(() => void sweep(), RECHECK_INTERVAL_MS);
+		sweepTimer = setInterval(triggerSweep, RECHECK_INTERVAL_MS);
 		// don't keep the worker alive solely for the recheck timer
 		sweepTimer.unref?.();
 	}
@@ -82,7 +96,7 @@ function ensureStarted(): void {
 			// user/role cache before invoking listeners, so recheck() observes the new permissions.
 			const handlers = require('./itc/serverHandlers.js');
 			if (handlers?.userHandler?.addListener) {
-				handlers.userHandler.addListener(() => void sweep());
+				handlers.userHandler.addListener(triggerSweep);
 				itcListenerInstalled = true;
 			}
 		} catch (error) {
@@ -130,7 +144,11 @@ export function registerLiveSubscription(opts: {
 	revoke?: () => void | Promise<void>;
 }): { unregister: () => void } {
 	const { subscription, username, authExpiresAt, recheck, revoke } = opts;
-	if (!subscription || typeof subscription !== 'object' || subscription.closed) return NOOP_HANDLE;
+	// The registry-owned teardown path needs a live, mutable subscription object to wrap; the
+	// caller-owned `revoke` path never touches `subscription` at all (see below), so a caller with no
+	// meaningful subscription object to hand over — the expected shape for a shared feed — isn't held
+	// to that requirement.
+	if (!revoke && (!subscription || typeof subscription !== 'object' || subscription.closed)) return NOOP_HANDLE;
 
 	const entry: LiveSubscription = {
 		username,
@@ -193,16 +211,36 @@ export function registerLiveSubscription(opts: {
  * that never settles would hold `sweeping` true forever (the `finally` in `sweep()` never runs),
  * silently disabling re-authorization for every subscription on the worker, not just this entry's.
  * `recheck` has the same unbounded-await shape but is registry-controlled Harper code; `revoke` is
- * arbitrary caller code, which is the materially wider exposure this bound closes.
+ * arbitrary caller code, which is the materially wider exposure this bound closes. A timeout does not
+ * cancel the underlying call — `entry.pendingTerminate` caches it, so a retry on the next sweep
+ * re-awaits the SAME in-flight attempt instead of invoking `terminate`/`revoke` a second time while
+ * the first is still running; the cache clears once that attempt actually settles (success or
+ * failure), so a genuinely stuck call is never retried, but a merely slow one gets a fresh invocation
+ * next time only after it's actually done.
  */
+function invokeTerminate(entry: LiveSubscription): Promise<void> {
+	try {
+		return Promise.resolve(entry.terminate());
+	} catch (error) {
+		return Promise.reject(error);
+	}
+}
+
 async function claimAndTerminate(entry: LiveSubscription, reason: string): Promise<boolean> {
 	if (!registry.has(entry)) return false; // the caller already unregistered this entry itself
+	let attempt = entry.pendingTerminate;
+	if (!attempt) {
+		attempt = invokeTerminate(entry);
+		entry.pendingTerminate = attempt;
+		const settledAttempt = attempt;
+		const clearIfCurrent = () => {
+			if (entry.pendingTerminate === settledAttempt) entry.pendingTerminate = undefined;
+		};
+		attempt.then(clearIfCurrent, clearIfCurrent);
+	}
+	const timeoutMs = terminateTimeoutMs();
 	try {
-		await withTimeout(
-			Promise.resolve(entry.terminate()),
-			terminateTimeoutMs(),
-			`terminate timed out after ${terminateTimeoutMs()}ms`
-		);
+		await withTimeout(attempt, timeoutMs, `terminate timed out after ${timeoutMs}ms`);
 	} catch (error) {
 		hdbLogger.error?.(
 			`liveSubscriptionAuth: terminate failed for ${entry.username} (${reason}), will retry next sweep: ${errorMessage(error)}`

--- a/server/liveSubscriptionAuth.ts
+++ b/server/liveSubscriptionAuth.ts
@@ -16,13 +16,6 @@ import hdbLogger from '../utility/logging/harper_logger.ts';
 
 // Backstop interval; also catches token expiry, which is not event-signaled. Overridable for tests.
 const RECHECK_INTERVAL_MS = Number(process.env.HARPER_SUBSCRIPTION_REAUTH_INTERVAL_MS) || 30_000;
-const MAX_TIMEOUT_MS = 2_147_483_647;
-
-// Read fresh per call so tests can override it without resetting the module cache.
-function terminateTimeoutMs(): number {
-	const timeoutMs = Number(process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS) || 5_000;
-	return Math.min(Math.max(timeoutMs, 1), MAX_TIMEOUT_MS);
-}
 
 interface LiveSubscription {
 	username: string;
@@ -30,10 +23,8 @@ interface LiveSubscription {
 	authExpiresAt?: number;
 	/** Returns true if the principal is still authorized for this subscription. */
 	recheck: () => Promise<boolean>;
-	/** Stop delivery and tear down the subscription. May be async (e.g. a shared-feed refcount release). */
+	/** Stop delivery and tear down. May be async (e.g. a shared-feed refcount release). */
 	terminate: () => void | Promise<void>;
-	/** The in-flight terminate call, cleared after it settles. */
-	pendingTerminate?: Promise<void>;
 }
 
 function errorMessage(error: unknown): string {
@@ -50,24 +41,6 @@ function safeLog(log: ((message: string) => void) | undefined, message: string):
 	} catch {
 		/* a broken logger must not turn a contained failure into a new one */
 	}
-}
-
-function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
-	return new Promise((resolve, reject) => {
-		const timer = setTimeout(() => reject(new Error(message)), ms);
-		// don't let a pending timeout keep the process alive
-		(timer as any).unref?.();
-		promise.then(
-			(value) => {
-				clearTimeout(timer);
-				resolve(value);
-			},
-			(error) => {
-				clearTimeout(timer);
-				reject(error);
-			}
-		);
-	});
 }
 
 const registry = new Set<LiveSubscription>();
@@ -116,24 +89,22 @@ function stopIfIdle(): void {
  * end()/close()/emit('close') on `subscription`, and the subscription's own teardown (end()/close)
  * automatically unregisters it.
  *
- * If `revoke` is supplied, it is used as the entry's terminate instead, and the subscription object
+ * If `revoke` is supplied, it is used as the entry's terminate instead and the subscription object
  * is left untouched (no `end` wrapping, no 'close' listener) — the caller unregisters through the
- * returned handle instead. This is the seam a feed shared by many subscribers needs: revocation must
- * stay per subscriber even once feed delivery is shared, so the registry can't assume it owns the
+ * returned handle. This is the seam a feed shared by many subscribers needs: revocation must stay
+ * per subscriber even once feed delivery is shared, so the registry can't assume it owns the
  * subscription object or that only one registrant will ever mutate it.
  *
- * Three invariants a `revoke` caller must uphold, not enforced by this module: (1) it owns the
- * entry's lifetime end-to-end — nothing here detects a leaked registration, so a caller that forgets
- * `unregister()` on some teardown path degrades sweep latency for every other tracked subscriber, not
- * just its own; (2) if it shares one feed (and one `recheck`) across subscribers, `recheck` must not
- * mutate state shared across them — `registerLiveSubscriptionForContext` in resources/Resource.ts
- * mutates `context.user` to the freshly-rechecked principal, which is safe only because each context
- * today belongs to exactly one subscriber; (3) `revoke` must be idempotent and safe to run concurrently
- * with the caller's own teardown — a *rejected* attempt is re-invoked on the next sweep, but only if
- * that sweep's `recheck` again denies, so a subscription whose permission was restored in between is
- * left half-torn-down and treated as healthy; an attempt that never settles is not retried at all and
- * the entry is never rechecked again; and `unregister()` racing an in-flight `revoke` is only closed
- * up to the point the await begins, not for the remainder of it.
+ * Three invariants a `revoke` caller must uphold, none enforced here: (1) it owns the entry's
+ * lifetime end-to-end — nothing detects a leaked registration, so a caller that forgets
+ * `unregister()` on some teardown path degrades sweep latency for every other tracked subscriber,
+ * not just its own; (2) if it shares one feed (and one `recheck`) across subscribers, `recheck`
+ * must not mutate state shared across them — `registerLiveSubscriptionForContext` in
+ * resources/Resource.ts mutates `context.user` to the freshly-rechecked principal, which is safe
+ * only because each context today belongs to exactly one subscriber; (3) `revoke` gets exactly one
+ * best-effort invocation — the entry is untracked before it runs, so a `revoke` that throws, rejects
+ * or never settles is logged and never retried, and a caller needing recovery from a failed teardown
+ * must implement it inside `revoke`.
  */
 export function registerLiveSubscription(
 	opts: {
@@ -158,13 +129,9 @@ export function registerLiveSubscription(
 			revoke ??
 			(() => {
 				// end() removes the subscription from the broadcast loop and closes its iterable queue.
-				try {
-					if (subscription.end) subscription.end();
-					else if (subscription.close) subscription.close();
-					else subscription.emit?.('close');
-				} catch {
-					/* ignore */
-				}
+				if (subscription.end) subscription.end();
+				else if (subscription.close) subscription.close();
+				else subscription.emit?.('close');
 			}),
 	};
 	registry.add(entry);
@@ -194,79 +161,42 @@ export function registerLiveSubscription(
 	return { unregister };
 }
 
-function invokeTerminate(entry: LiveSubscription): Promise<void> {
-	try {
-		return Promise.resolve(entry.terminate());
-	} catch (error) {
-		return Promise.reject(error);
-	}
-}
-
 /**
- * Terminate a registered entry and remove it only after success. A rejected attempt remains tracked
- * for retry; a pending attempt is not invoked again. The settle handler commits a late success even
- * after the sweep's timeout has elapsed.
+ * Untrack an entry and tear it down, best effort. Untracking first keeps a `revoke` that hangs or
+ * fails from wedging the sweep or being re-entered by a later one; recovering from a failed teardown
+ * is the caller's job, per registerLiveSubscription's third invariant.
  */
-async function claimAndTerminate(entry: LiveSubscription, reason: string): Promise<boolean> {
-	if (!registry.has(entry)) return false; // the caller already unregistered this entry itself
-	if (entry.pendingTerminate) return false; // at-most-once, enforced here so any caller gets it, not just sweep()
-
-	const attempt = invokeTerminate(entry);
-	entry.pendingTerminate = attempt;
-	attempt.then(
-		() => {
-			if (entry.pendingTerminate === attempt) entry.pendingTerminate = undefined;
-			registry.delete(entry);
-			stopIfIdle();
-			safeLog(hdbLogger.warn, `liveSubscriptionAuth: terminate completed for ${entry.username} (${reason})`);
-		},
-		(error) => {
-			if (entry.pendingTerminate === attempt) entry.pendingTerminate = undefined;
-			safeLog(
-				hdbLogger.error,
-				`liveSubscriptionAuth: terminate failed for ${entry.username} (${reason}), will retry on the next sweep that still denies: ${errorMessage(error)}`
-			);
-		}
-	);
-
-	const timeoutMs = terminateTimeoutMs();
+function terminateEntry(entry: LiveSubscription, reason: string): void {
+	registry.delete(entry);
+	safeLog(hdbLogger.warn, `liveSubscriptionAuth: revoking subscription for ${entry.username} (${reason})`);
+	const failed = (error: unknown) =>
+		safeLog(
+			hdbLogger.error,
+			`liveSubscriptionAuth: terminate failed for ${entry.username} (${reason}): ${errorMessage(error)}`
+		);
 	try {
-		await withTimeout(attempt, timeoutMs, `terminate timed out after ${timeoutMs}ms`);
-	} catch {
-		if (entry.pendingTerminate === attempt) {
-			safeLog(
-				hdbLogger.error,
-				`liveSubscriptionAuth: terminate for ${entry.username} (${reason}) still pending after ${timeoutMs}ms; awaiting settlement`
-			);
-		}
-		return false;
+		// an async terminate's rejection would otherwise surface as an unhandled rejection on the timer's stack
+		Promise.resolve(entry.terminate()).catch(failed);
+	} catch (error) {
+		failed(error);
 	}
-	return true;
 }
 
 async function sweep(): Promise<void> {
 	if (sweeping) return; // a slow recheck must not overlap with the next tick/event
 	sweeping = true;
 	try {
+		// snapshot: an entry the caller unregisters mid-sweep must not be rechecked or revoked
 		for (const entry of Array.from(registry)) {
 			if (!registry.has(entry)) continue;
-			if (entry.pendingTerminate) {
-				safeLog(
-					hdbLogger.error,
-					`liveSubscriptionAuth: terminate for ${entry.username} (previously pending) still pending from an earlier sweep`
-				);
-				continue;
-			}
 			try {
-				const now = Date.now();
-				const expired = entry.authExpiresAt != null && now >= entry.authExpiresAt * 1000;
+				const expired = entry.authExpiresAt != null && Date.now() >= entry.authExpiresAt * 1000;
 				const stillAuthorized = expired ? false : await entry.recheck();
-				if (expired || !stillAuthorized) {
-					await claimAndTerminate(entry, expired ? 'token expired' : 'no longer authorized');
-				}
+				if (!registry.has(entry)) continue;
+				if (expired || !stillAuthorized) terminateEntry(entry, expired ? 'token expired' : 'no longer authorized');
 			} catch (error) {
 				// fail closed: if authorization can't be confirmed, revoke
-				await claimAndTerminate(entry, `recheck error: ${errorMessage(error)}`);
+				if (registry.has(entry)) terminateEntry(entry, `recheck error: ${errorMessage(error)}`);
 			}
 		}
 	} finally {

--- a/server/liveSubscriptionAuth.ts
+++ b/server/liveSubscriptionAuth.ts
@@ -230,19 +230,38 @@ function invokeTerminate(entry: LiveSubscription): Promise<void> {
  * that lands after this sweep's timeout window closes but before the next sweep starts) commit
  * exactly once instead of being silently discarded and re-invoked. A sweep that finds an attempt
  * already in flight from a previous pass does not re-invoke `terminate`/`revoke` and does not re-race
- * it either — the outcome will be handled by the original handler whenever it settles; there is
- * nothing left for a second wait to accomplish, and re-racing it would cost another full
- * `terminateTimeoutMs()` of serialized sweep time per stuck entry, every single pass, forever.
+ * it either — the outcome will be handled by the original handler whenever it settles, and re-racing
+ * it would cost another full `terminateTimeoutMs()` of serialized sweep time per stuck entry, every
+ * single pass, forever, for a result nothing uses. It does still log on every such sweep (cheaply, no
+ * wait) — without that, a permanently stuck `revoke` would log exactly once, ever, then go silent for
+ * the rest of the worker's life, which is worse than the cost it replaced.
+ *
+ * The success log says "terminate completed", not "revoked" — the default terminate (no `revoke`
+ * supplied) still swallows `end()`/`close()`/`emit` errors internally, unchanged from #1414, so this
+ * module cannot always tell whether delivery actually stopped, only that terminate ran without an
+ * error reaching it.
  *
  * Only the FIRST attempt is raced against `terminateTimeoutMs()`: without a bound, a caller-supplied
  * `revoke` that never settles would hold `sweeping` true forever (the `finally` in `sweep()` never
  * runs), silently disabling re-authorization for every subscription on the worker, not just this
- * entry's. `recheck` has the same unbounded-await shape but is registry-controlled Harper code;
- * `revoke` is arbitrary caller code, which is the materially wider exposure this bound closes.
+ * entry's. `recheck` has the same unbounded-await shape and is NOT similarly bounded here — not
+ * because it's safe (production `recheck` bottoms out in `resource.allowRead`, user-overridable
+ * application code, same as `revoke`), but because bounding it would change behavior on the DEFAULT
+ * (no-`revoke`) path, which this seam's own acceptance contract requires to stay identical to #1414.
  */
 async function claimAndTerminate(entry: LiveSubscription, reason: string): Promise<boolean> {
 	if (!registry.has(entry)) return false; // the caller already unregistered this entry itself
-	if (entry.pendingTerminate) return false; // already being handled by a prior sweep's attempt
+	if (entry.pendingTerminate) {
+		// A prior sweep's attempt is still in flight; its own settle handler (below) commits the
+		// outcome whenever it arrives, so there's nothing to gain by re-invoking or re-racing it — but
+		// silence would be worse than the per-sweep timeout log this replaced: a permanently stuck
+		// revoke would otherwise log exactly once, ever, then vanish. Log cheaply (no wait) instead.
+		safeLog(
+			hdbLogger.error,
+			`liveSubscriptionAuth: terminate for ${entry.username} (${reason}) still pending from an earlier sweep`
+		);
+		return false;
+	}
 
 	const attempt = invokeTerminate(entry);
 	entry.pendingTerminate = attempt;
@@ -250,7 +269,7 @@ async function claimAndTerminate(entry: LiveSubscription, reason: string): Promi
 		() => {
 			if (entry.pendingTerminate === attempt) entry.pendingTerminate = undefined;
 			registry.delete(entry);
-			safeLog(hdbLogger.info, `liveSubscriptionAuth: revoked subscription for ${entry.username} (${reason})`);
+			safeLog(hdbLogger.info, `liveSubscriptionAuth: terminate completed for ${entry.username} (${reason})`);
 		},
 		(error) => {
 			if (entry.pendingTerminate === attempt) entry.pendingTerminate = undefined;
@@ -284,9 +303,17 @@ async function sweep(): Promise<void> {
 	if (sweeping) return; // a slow recheck must not overlap with the next tick/event
 	sweeping = true;
 	try {
-		const now = Date.now();
 		for (const entry of registry) {
+			if (entry.pendingTerminate) {
+				// A prior sweep's attempt is already deciding this entry's fate; recheck() would only be
+				// a wasted storage read (findAndValidateUser + allowRead) for an outcome we already know.
+				await claimAndTerminate(entry, 'previously pending');
+				continue;
+			}
 			try {
+				// Read fresh per entry rather than once before the loop: a slow recheck or terminate on
+				// an earlier entry must not leave a later entry's expiry judged against a stale timestamp.
+				const now = Date.now();
 				const expired = entry.authExpiresAt != null && now >= entry.authExpiresAt * 1000;
 				const stillAuthorized = expired ? false : await entry.recheck();
 				if (expired || !stillAuthorized) {

--- a/server/liveSubscriptionAuth.ts
+++ b/server/liveSubscriptionAuth.ts
@@ -32,6 +32,8 @@ let sweepTimer: any = null;
 let itcListenerInstalled = false;
 let sweeping = false;
 
+const NOOP_HANDLE = { unregister: () => {} };
+
 function ensureStarted(): void {
 	if (!sweepTimer) {
 		sweepTimer = setInterval(() => void sweep(), RECHECK_INTERVAL_MS);
@@ -81,8 +83,7 @@ export function registerLiveSubscription(opts: {
 	revoke?: () => void;
 }): { unregister: () => void } {
 	const { subscription, username, authExpiresAt, recheck, revoke } = opts;
-	const noop = { unregister: () => {} };
-	if (!subscription || typeof subscription !== 'object' || subscription.closed) return noop;
+	if (!subscription || typeof subscription !== 'object' || subscription.closed) return NOOP_HANDLE;
 
 	const entry: LiveSubscription = {
 		username,
@@ -128,6 +129,23 @@ export function registerLiveSubscription(opts: {
 	return { unregister };
 }
 
+/**
+ * Delete `entry` and run its terminate/revoke, but only if this call is the one that actually
+ * removes it from the registry. `Set.delete`'s boolean return is a lock-free claim token: it's
+ * false if the entry was already removed — by a caller's `unregister()` racing an in-flight
+ * `recheck()`, or by another sweep path — so terminate/revoke runs at most once per entry, and
+ * never for one the caller has already torn down itself.
+ */
+function claimAndTerminate(entry: LiveSubscription): boolean {
+	if (!registry.delete(entry)) return false;
+	try {
+		entry.terminate();
+	} catch (error) {
+		hdbLogger.warn?.(`liveSubscriptionAuth: terminate failed for ${entry.username}: ${(error as Error).message}`);
+	}
+	return true;
+}
+
 async function sweep(): Promise<void> {
 	if (sweeping) return; // a slow recheck must not overlap with the next tick/event
 	sweeping = true;
@@ -137,22 +155,14 @@ async function sweep(): Promise<void> {
 			try {
 				const expired = entry.authExpiresAt != null && now >= entry.authExpiresAt * 1000;
 				const stillAuthorized = expired ? false : await entry.recheck();
-				const revoke = expired || !stillAuthorized;
-				if (revoke) {
-					registry.delete(entry);
-					entry.terminate();
-				}
+				if (expired || !stillAuthorized) claimAndTerminate(entry);
 			} catch (error) {
 				// fail closed: if authorization can't be confirmed, revoke
-				registry.delete(entry);
-				try {
-					entry.terminate();
-				} catch {
-					/* ignore */
+				if (claimAndTerminate(entry)) {
+					hdbLogger.warn?.(
+						`liveSubscriptionAuth: revoked subscription for ${entry.username} after recheck error: ${(error as Error).message}`
+					);
 				}
-				hdbLogger.warn?.(
-					`liveSubscriptionAuth: revoked subscription for ${entry.username} after recheck error: ${(error as Error).message}`
-				);
 			}
 		}
 	} finally {

--- a/server/liveSubscriptionAuth.ts
+++ b/server/liveSubscriptionAuth.ts
@@ -135,14 +135,18 @@ function stopIfIdle(): void {
  * the entry is never rechecked again; and `unregister()` racing an in-flight `revoke` is only closed
  * up to the point the await begins, not for the remainder of it.
  */
-export function registerLiveSubscription(opts: {
-	/** Optional when `revoke` is supplied: a revoke-only registrant may own no subscription object. */
-	subscription?: any;
-	username: string;
-	authExpiresAt?: number;
-	recheck: () => Promise<boolean>;
-	revoke?: () => void | Promise<void>;
-}): { unregister: () => void } {
+export function registerLiveSubscription(
+	opts: {
+		username: string;
+		authExpiresAt?: number;
+		recheck: () => Promise<boolean>;
+	} & (
+		| { subscription: any; revoke?: undefined }
+		// a revoke-only registrant may own no subscription object; requiring one of the two modes keeps
+		// a caller that supplies neither from type-checking into a silent no-op registration
+		| { subscription?: any; revoke: () => void | Promise<void> }
+	)
+): { unregister: () => void } {
 	const { subscription, username, authExpiresAt, recheck, revoke } = opts;
 	if (!revoke && (!subscription || typeof subscription !== 'object' || subscription.closed)) return NOOP_HANDLE;
 
@@ -220,7 +224,7 @@ async function claimAndTerminate(entry: LiveSubscription, reason: string): Promi
 			if (entry.pendingTerminate === attempt) entry.pendingTerminate = undefined;
 			safeLog(
 				hdbLogger.error,
-				`liveSubscriptionAuth: terminate failed for ${entry.username} (${reason}), will retry next sweep: ${errorMessage(error)}`
+				`liveSubscriptionAuth: terminate failed for ${entry.username} (${reason}), will retry on the next sweep that still denies: ${errorMessage(error)}`
 			);
 		}
 	);

--- a/server/liveSubscriptionAuth.ts
+++ b/server/liveSubscriptionAuth.ts
@@ -16,13 +16,15 @@ import hdbLogger from '../utility/logging/harper_logger.ts';
 
 // Backstop interval; also catches token expiry, which is not event-signaled. Overridable for tests.
 const RECHECK_INTERVAL_MS = Number(process.env.HARPER_SUBSCRIPTION_REAUTH_INTERVAL_MS) || 30_000;
+const MAX_TIMEOUT_MS = 2_147_483_647;
 
 // Bounds how long a caller-supplied terminate/revoke may hold the serialized sweep before being
 // treated as a failure (same fail-closed retry as a throw/rejection). The default terminate settles
 // long before this — it only ever engages for a caller-supplied `revoke` that hangs. Read fresh per
 // call rather than cached at module load, so tests can override it without a require-cache reset.
 function terminateTimeoutMs(): number {
-	return Number(process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS) || 5_000;
+	const timeoutMs = Number(process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS) || 5_000;
+	return Math.min(Math.max(timeoutMs, 1), MAX_TIMEOUT_MS);
 }
 
 interface LiveSubscription {
@@ -251,17 +253,6 @@ function invokeTerminate(entry: LiveSubscription): Promise<void> {
  */
 async function claimAndTerminate(entry: LiveSubscription, reason: string): Promise<boolean> {
 	if (!registry.has(entry)) return false; // the caller already unregistered this entry itself
-	if (entry.pendingTerminate) {
-		// A prior sweep's attempt is still in flight; its own settle handler (below) commits the
-		// outcome whenever it arrives, so there's nothing to gain by re-invoking or re-racing it — but
-		// silence would be worse than the per-sweep timeout log this replaced: a permanently stuck
-		// revoke would otherwise log exactly once, ever, then vanish. Log cheaply (no wait) instead.
-		safeLog(
-			hdbLogger.error,
-			`liveSubscriptionAuth: terminate for ${entry.username} (${reason}) still pending from an earlier sweep`
-		);
-		return false;
-	}
 
 	const attempt = invokeTerminate(entry);
 	entry.pendingTerminate = attempt;
@@ -269,7 +260,8 @@ async function claimAndTerminate(entry: LiveSubscription, reason: string): Promi
 		() => {
 			if (entry.pendingTerminate === attempt) entry.pendingTerminate = undefined;
 			registry.delete(entry);
-			safeLog(hdbLogger.info, `liveSubscriptionAuth: terminate completed for ${entry.username} (${reason})`);
+			stopIfIdle();
+			safeLog(hdbLogger.warn, `liveSubscriptionAuth: terminate completed for ${entry.username} (${reason})`);
 		},
 		(error) => {
 			if (entry.pendingTerminate === attempt) entry.pendingTerminate = undefined;
@@ -303,11 +295,15 @@ async function sweep(): Promise<void> {
 	if (sweeping) return; // a slow recheck must not overlap with the next tick/event
 	sweeping = true;
 	try {
-		for (const entry of registry) {
+		for (const entry of Array.from(registry)) {
+			if (!registry.has(entry)) continue;
 			if (entry.pendingTerminate) {
 				// A prior sweep's attempt is already deciding this entry's fate; recheck() would only be
 				// a wasted storage read (findAndValidateUser + allowRead) for an outcome we already know.
-				await claimAndTerminate(entry, 'previously pending');
+				safeLog(
+					hdbLogger.error,
+					`liveSubscriptionAuth: terminate for ${entry.username} (previously pending) still pending from an earlier sweep`
+				);
 				continue;
 			}
 			try {

--- a/server/liveSubscriptionAuth.ts
+++ b/server/liveSubscriptionAuth.ts
@@ -178,6 +178,11 @@ function terminateEntry(
 async function sweep(): Promise<void> {
 	if (sweeping) return; // a slow recheck must not overlap with the next tick/event
 	sweeping = true;
+	// Per-subscriber revocation lines are info, which the shipped default (logging.level: warn) drops.
+	// One aggregate per pass carries the same news at the level operators actually read, without
+	// turning a mass role change into one warn per subscriber.
+	const revokedByReason = new Map<string, number>();
+	const countRevocation = (reason: string) => revokedByReason.set(reason, (revokedByReason.get(reason) ?? 0) + 1);
 	try {
 		// snapshot bounds the pass to entries present at its start; the has() guards cover the rest
 		for (const entry of Array.from(registry)) {
@@ -186,15 +191,31 @@ async function sweep(): Promise<void> {
 				const expired = entry.authExpiresAt != null && Date.now() >= entry.authExpiresAt * 1000;
 				const stillAuthorized = expired ? false : await entry.recheck();
 				if (!registry.has(entry)) continue;
-				if (expired || !stillAuthorized) terminateEntry(entry, expired ? 'token expired' : 'no longer authorized');
+				if (expired || !stillAuthorized) {
+					const reason = expired ? 'token expired' : 'no longer authorized';
+					terminateEntry(entry, reason);
+					countRevocation(reason);
+				}
 			} catch (error) {
 				// fail closed: if authorization can't be confirmed, revoke
-				if (registry.has(entry)) terminateEntry(entry, `recheck error: ${errorMessage(error)}`, hdbLogger.warn);
+				if (registry.has(entry)) {
+					terminateEntry(entry, `recheck error: ${errorMessage(error)}`, hdbLogger.warn);
+					countRevocation('recheck error');
+				}
 			}
 		}
 	} finally {
 		sweeping = false;
 		stopIfIdle();
+		if (revokedByReason.size > 0) {
+			let total = 0;
+			for (const count of revokedByReason.values()) total += count;
+			const breakdown = Array.from(revokedByReason, ([reason, count]) => `${reason}: ${count}`).join(', ');
+			safeLog(
+				hdbLogger.warn,
+				`liveSubscriptionAuth: revoked ${total} live subscription${total === 1 ? '' : 's'} (${breakdown})`
+			);
+		}
 	}
 }
 

--- a/unitTests/server/liveSubscriptionAuth.test.js
+++ b/unitTests/server/liveSubscriptionAuth.test.js
@@ -234,45 +234,50 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 			assert.strictEqual(_liveSubscriptionCount(), 0);
 		});
 
-		it('a throwing revoke is invoked exactly once, and its entry is still removed exactly once (no double-terminate)', async () => {
+		it('a throwing revoke leaves the entry registered for retry (fail-closed), and converges once revoke succeeds', async () => {
 			const subscription = fakeSubscription();
-			let throwingCalls = 0;
-			const revokeThrows = () => {
-				throwingCalls++;
-				throw new Error('revoke failed mid-teardown (e.g. a shared-feed refcount decrement)');
+			let calls = 0;
+			const revoke = () => {
+				calls++;
+				if (calls === 1) throw new Error('revoke failed mid-teardown (e.g. a shared-feed refcount decrement)');
 			};
 			const revokeOther = spyFn();
 			register({
 				subscription,
-				username: 'throws-on-revoke',
+				username: 'throws-once-on-revoke',
 				authExpiresAt: 0,
 				recheck: async () => true,
-				revoke: revokeThrows,
+				revoke,
 			});
 			register({ subscription, username: 'other', recheck: async () => true, revoke: revokeOther });
 			assert.strictEqual(_liveSubscriptionCount(), 2);
 
-			await _sweepNow();
+			await _sweepNow(); // revoke throws; fail-closed must not silently drop tracking
 
-			assert.strictEqual(throwingCalls, 1, 'a throwing revoke must not be invoked a second time');
+			assert.strictEqual(calls, 1);
 			assert.strictEqual(revokeOther.calls.length, 0, 'other subscribers sharing the object must not be revoked');
-			assert.strictEqual(_liveSubscriptionCount(), 1, 'the throwing entry must still be removed exactly once');
+			assert.strictEqual(_liveSubscriptionCount(), 2, 'a failed revoke must leave the entry registered');
+
+			await _sweepNow(); // the next sweep retries; this time revoke succeeds
+
+			assert.strictEqual(calls, 2, 'the next sweep must retry a previously failed revoke');
+			assert.strictEqual(_liveSubscriptionCount(), 1, 'the entry is removed once revoke actually succeeds');
 		});
 
-		it('an async revoke that rejects is contained (no unhandled rejection) and its entry is still removed', async () => {
+		it('an async revoke that rejects is contained (no unhandled rejection), leaves the entry registered for retry, and converges once it succeeds', async () => {
 			const subscription = fakeSubscription();
-			let rejectingCalls = 0;
-			const revokeRejects = async () => {
-				rejectingCalls++;
-				throw new Error('shared-feed release failed (e.g. backing store timeout)');
+			let calls = 0;
+			const revoke = async () => {
+				calls++;
+				if (calls === 1) throw new Error('shared-feed release failed (e.g. backing store timeout)');
 			};
 			const revokeOther = spyFn();
 			register({
 				subscription,
-				username: 'async-revoke-throws',
+				username: 'async-revoke-throws-once',
 				authExpiresAt: 0,
 				recheck: async () => true,
-				revoke: revokeRejects,
+				revoke,
 			});
 			register({ subscription, username: 'other', recheck: async () => true, revoke: revokeOther });
 			assert.strictEqual(_liveSubscriptionCount(), 2);
@@ -281,9 +286,14 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 			// fail this test — awaiting here alone proves it stayed contained inside claimAndTerminate.
 			await _sweepNow();
 
-			assert.strictEqual(rejectingCalls, 1, 'a rejecting async revoke must not be invoked a second time');
+			assert.strictEqual(calls, 1);
 			assert.strictEqual(revokeOther.calls.length, 0, 'other subscribers sharing the object must not be revoked');
-			assert.strictEqual(_liveSubscriptionCount(), 1, 'the rejecting entry must still be removed exactly once');
+			assert.strictEqual(_liveSubscriptionCount(), 2, 'a rejected revoke must leave the entry registered');
+
+			await _sweepNow(); // the next sweep retries; this time revoke succeeds
+
+			assert.strictEqual(calls, 2, 'the next sweep must retry a previously rejected revoke');
+			assert.strictEqual(_liveSubscriptionCount(), 1, 'the entry is removed once the async revoke actually succeeds');
 		});
 
 		it('does not terminate an entry the caller already unregistered while its recheck was still in flight', async () => {

--- a/unitTests/server/liveSubscriptionAuth.test.js
+++ b/unitTests/server/liveSubscriptionAuth.test.js
@@ -403,8 +403,18 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 				assert.strictEqual(calls, 1, 'a still-pending revoke must not be invoked a second time');
 				assert.strictEqual(_liveSubscriptionCount(), 1);
 
-				resolveRevoke(); // the underlying call finally completes
-				await _sweepNow(); // this sweep observes the (now-settled) same attempt and commits it
+				// Resolve on its own, with no sweep actively awaiting it — models the realistic case where
+				// the underlying call finishes sometime in the ~30s gap between sweeps, not synchronously
+				// adjacent to one. The settle handler must commit the removal on its own; an implementation
+				// that only committed from inside an active sweep's await would miss this and later
+				// re-invoke revoke, discarding the success that already happened.
+				resolveRevoke();
+				await new Promise((resolveTick) => setImmediate(resolveTick));
+
+				assert.strictEqual(calls, 1, 'the late success must be committed without any sweep watching it');
+				assert.strictEqual(_liveSubscriptionCount(), 0, 'the entry must be removed as soon as the attempt settles');
+
+				await _sweepNow(); // a further sweep must not touch it again — already gone
 
 				assert.strictEqual(calls, 1, 'the entry is removed without ever calling revoke a second time');
 				assert.strictEqual(_liveSubscriptionCount(), 0);

--- a/unitTests/server/liveSubscriptionAuth.test.js
+++ b/unitTests/server/liveSubscriptionAuth.test.js
@@ -5,19 +5,24 @@ testUtils.preTestPrep();
 
 const assert = require('node:assert');
 const { EventEmitter } = require('node:events');
-const sinon = require('sinon');
 
-const {
-	registerLiveSubscription,
-	_liveSubscriptionCount,
-	_sweepNow,
-} = require('#src/server/liveSubscriptionAuth');
+const { registerLiveSubscription, _liveSubscriptionCount, _sweepNow } = require('#src/server/liveSubscriptionAuth');
+
+// A bare call-recording function: `.calls` is the arg list of each invocation, in order.
+function spyFn(impl) {
+	function spy(...args) {
+		spy.calls.push(args);
+		return impl ? impl(...args) : undefined;
+	}
+	spy.calls = [];
+	return spy;
+}
 
 // A minimal stand-in for the SSE/WS/MQTT subscription object: an EventEmitter (for the 'close'
 // self-wiring path) with an end() the registry can wrap.
 function fakeSubscription() {
 	const subscription = new EventEmitter();
-	subscription.end = sinon.stub();
+	subscription.end = spyFn();
 	return subscription;
 }
 
@@ -53,12 +58,12 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 
 			await _sweepNow();
 
-			assert.strictEqual(originalEnd.callCount, 1);
+			assert.strictEqual(originalEnd.calls.length, 1);
 			assert.strictEqual(_liveSubscriptionCount(), 0);
 		});
 
 		it('falls back to close() when end() is absent', async () => {
-			const subscription = { close: sinon.stub() };
+			const subscription = { close: spyFn() };
 			register({
 				subscription,
 				username: 'bob',
@@ -69,13 +74,18 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 
 			await _sweepNow();
 
-			assert.strictEqual(subscription.close.callCount, 1);
+			assert.strictEqual(subscription.close.calls.length, 1);
 			assert.strictEqual(_liveSubscriptionCount(), 0);
 		});
 
 		it("falls back to emit('close') when end() and close() are both absent", async () => {
 			const subscription = new EventEmitter();
-			const emitSpy = sinon.spy(subscription, 'emit');
+			const originalEmit = subscription.emit.bind(subscription);
+			const emitCalls = [];
+			subscription.emit = (...args) => {
+				emitCalls.push(args);
+				return originalEmit(...args);
+			};
 			register({
 				subscription,
 				username: 'carol',
@@ -86,7 +96,7 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 
 			await _sweepNow();
 
-			assert.ok(emitSpy.calledWith('close'));
+			assert.ok(emitCalls.some((args) => args[0] === 'close'));
 			assert.strictEqual(_liveSubscriptionCount(), 0);
 		});
 
@@ -108,8 +118,8 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 
 			subscription.end('arg');
 
-			assert.strictEqual(originalEnd.callCount, 1);
-			assert.deepStrictEqual(originalEnd.firstCall.args, ['arg']);
+			assert.strictEqual(originalEnd.calls.length, 1);
+			assert.deepStrictEqual(originalEnd.calls[0], ['arg']);
 			assert.strictEqual(_liveSubscriptionCount(), 0);
 			handles.pop(); // already unregistered by end()
 		});
@@ -118,7 +128,7 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 	describe('revoke supplied (new seam)', () => {
 		it('uses revoke as terminate instead of end()/close()/emit', async () => {
 			const subscription = fakeSubscription();
-			const revoke = sinon.stub();
+			const revoke = spyFn();
 			register({
 				subscription,
 				username: 'frank',
@@ -130,8 +140,8 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 
 			await _sweepNow();
 
-			assert.strictEqual(revoke.callCount, 1);
-			assert.strictEqual(subscription.end.callCount, 0, 'revoke must be used instead of end()');
+			assert.strictEqual(revoke.calls.length, 1);
+			assert.strictEqual(subscription.end.calls.length, 0, 'revoke must be used instead of end()');
 			assert.strictEqual(_liveSubscriptionCount(), 0);
 		});
 
@@ -140,20 +150,16 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 			const originalEnd = subscription.end;
 			const listenersBefore = subscription.listenerCount('close');
 
-			register({ subscription, username: 'grace', recheck: async () => true, revoke: sinon.stub() });
+			register({ subscription, username: 'grace', recheck: async () => true, revoke: spyFn() });
 
 			assert.strictEqual(subscription.end, originalEnd, 'subscription.end must not be replaced');
-			assert.strictEqual(
-				subscription.listenerCount('close'),
-				listenersBefore,
-				"no 'close' listener should be added"
-			);
+			assert.strictEqual(subscription.listenerCount('close'), listenersBefore, "no 'close' listener should be added");
 		});
 
 		it('returns an unregister handle that removes only its own entry', () => {
 			const subscription = fakeSubscription();
-			const a = register({ subscription, username: 'a', recheck: async () => true, revoke: sinon.stub() });
-			register({ subscription, username: 'b', recheck: async () => true, revoke: sinon.stub() });
+			const a = register({ subscription, username: 'a', recheck: async () => true, revoke: spyFn() });
+			register({ subscription, username: 'b', recheck: async () => true, revoke: spyFn() });
 			assert.strictEqual(_liveSubscriptionCount(), 2);
 
 			a.unregister();
@@ -164,10 +170,15 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 
 		it('revoking one of N entries sharing one subscription object invokes only that revoke, leaves the rest registered, and never touches the shared subscription', async () => {
 			const subscription = fakeSubscription();
-			const emitSpy = sinon.spy(subscription, 'emit');
-			const revokeA = sinon.stub();
-			const revokeB = sinon.stub();
-			const revokeC = sinon.stub();
+			const originalEmit = subscription.emit.bind(subscription);
+			const emitCalls = [];
+			subscription.emit = (...args) => {
+				emitCalls.push(args);
+				return originalEmit(...args);
+			};
+			const revokeA = spyFn();
+			const revokeB = spyFn();
+			const revokeC = spyFn();
 			register({ subscription, username: 'a', authExpiresAt: 0, recheck: async () => true, revoke: revokeA });
 			register({ subscription, username: 'b', recheck: async () => true, revoke: revokeB });
 			register({ subscription, username: 'c', recheck: async () => true, revoke: revokeC });
@@ -175,19 +186,19 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 
 			await _sweepNow();
 
-			assert.strictEqual(revokeA.callCount, 1, 'the expired subscriber should be revoked');
-			assert.strictEqual(revokeB.callCount, 0, 'other subscribers must not be revoked');
-			assert.strictEqual(revokeC.callCount, 0, 'other subscribers must not be revoked');
+			assert.strictEqual(revokeA.calls.length, 1, 'the expired subscriber should be revoked');
+			assert.strictEqual(revokeB.calls.length, 0, 'other subscribers must not be revoked');
+			assert.strictEqual(revokeC.calls.length, 0, 'other subscribers must not be revoked');
 			assert.strictEqual(_liveSubscriptionCount(), 2, 'the other two entries must remain registered');
-			assert.strictEqual(subscription.end.callCount, 0, 'the shared subscription must not be ended');
-			assert.strictEqual(emitSpy.called, false, 'the shared subscription must not be closed');
+			assert.strictEqual(subscription.end.calls.length, 0, 'the shared subscription must not be ended');
+			assert.strictEqual(emitCalls.length, 0, 'the shared subscription must not be closed');
 		});
 
 		it('a throwing recheck among several sharing one subscription revokes only that entry (fail-closed)', async () => {
 			const subscription = fakeSubscription();
-			const revokeThrows = sinon.stub();
-			const revokeOkA = sinon.stub();
-			const revokeOkB = sinon.stub();
+			const revokeThrows = spyFn();
+			const revokeOkA = spyFn();
+			const revokeOkB = spyFn();
 			register({
 				subscription,
 				username: 'throws',
@@ -202,24 +213,79 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 
 			await _sweepNow();
 
-			assert.strictEqual(revokeThrows.callCount, 1);
-			assert.strictEqual(revokeOkA.callCount, 0);
-			assert.strictEqual(revokeOkB.callCount, 0);
+			assert.strictEqual(revokeThrows.calls.length, 1);
+			assert.strictEqual(revokeOkA.calls.length, 0);
+			assert.strictEqual(revokeOkB.calls.length, 0);
 			assert.strictEqual(_liveSubscriptionCount(), 2);
-			assert.strictEqual(subscription.end.callCount, 0);
+			assert.strictEqual(subscription.end.calls.length, 0);
 		});
 
 		it('revokes on token expiry without consulting recheck', async () => {
 			const subscription = fakeSubscription();
-			const revoke = sinon.stub();
-			const recheck = sinon.stub().rejects(new Error('recheck must not be called for an expired token'));
+			const revoke = spyFn();
+			const recheck = spyFn(() => Promise.reject(new Error('recheck must not be called for an expired token')));
 			register({ subscription, username: 'expired', authExpiresAt: 0, recheck, revoke });
 			handles.pop();
 
 			await _sweepNow();
 
-			assert.strictEqual(recheck.callCount, 0);
-			assert.strictEqual(revoke.callCount, 1);
+			assert.strictEqual(recheck.calls.length, 0);
+			assert.strictEqual(revoke.calls.length, 1);
+			assert.strictEqual(_liveSubscriptionCount(), 0);
+		});
+
+		it('a throwing revoke is invoked exactly once, and its entry is still removed exactly once (no double-terminate)', async () => {
+			const subscription = fakeSubscription();
+			let throwingCalls = 0;
+			const revokeThrows = () => {
+				throwingCalls++;
+				throw new Error('revoke failed mid-teardown (e.g. a shared-feed refcount decrement)');
+			};
+			const revokeOther = spyFn();
+			register({
+				subscription,
+				username: 'throws-on-revoke',
+				authExpiresAt: 0,
+				recheck: async () => true,
+				revoke: revokeThrows,
+			});
+			register({ subscription, username: 'other', recheck: async () => true, revoke: revokeOther });
+			assert.strictEqual(_liveSubscriptionCount(), 2);
+
+			await _sweepNow();
+
+			assert.strictEqual(throwingCalls, 1, 'a throwing revoke must not be invoked a second time');
+			assert.strictEqual(revokeOther.calls.length, 0, 'other subscribers sharing the object must not be revoked');
+			assert.strictEqual(_liveSubscriptionCount(), 1, 'the throwing entry must still be removed exactly once');
+		});
+
+		it('does not terminate an entry the caller already unregistered while its recheck was still in flight', async () => {
+			const subscription = fakeSubscription();
+			const revoke = spyFn();
+			let releaseRecheck;
+			const recheckGate = new Promise((resolveGate) => {
+				releaseRecheck = resolveGate;
+			});
+			const handle = register({
+				subscription,
+				username: 'racer',
+				recheck: async () => {
+					await recheckGate;
+					return false; // resolves "no longer authorized" only after the caller has already torn down
+				},
+				revoke,
+			});
+			handles.pop(); // this test manages the handle itself
+
+			const sweepPromise = _sweepNow();
+			await new Promise((resolveTick) => setImmediate(resolveTick)); // let sweep reach the awaited recheck
+			handle.unregister(); // the caller (e.g. a client disconnect) tears down mid-recheck
+			assert.strictEqual(_liveSubscriptionCount(), 0);
+
+			releaseRecheck();
+			await sweepPromise;
+
+			assert.strictEqual(revoke.calls.length, 0, 'revoke must not fire for an entry the caller already unregistered');
 			assert.strictEqual(_liveSubscriptionCount(), 0);
 		});
 	});

--- a/unitTests/server/liveSubscriptionAuth.test.js
+++ b/unitTests/server/liveSubscriptionAuth.test.js
@@ -1,0 +1,226 @@
+'use strict';
+
+const testUtils = require('../testUtils.js');
+testUtils.preTestPrep();
+
+const assert = require('node:assert');
+const { EventEmitter } = require('node:events');
+const sinon = require('sinon');
+
+const {
+	registerLiveSubscription,
+	_liveSubscriptionCount,
+	_sweepNow,
+} = require('#src/server/liveSubscriptionAuth');
+
+// A minimal stand-in for the SSE/WS/MQTT subscription object: an EventEmitter (for the 'close'
+// self-wiring path) with an end() the registry can wrap.
+function fakeSubscription() {
+	const subscription = new EventEmitter();
+	subscription.end = sinon.stub();
+	return subscription;
+}
+
+describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
+	// Registry is module-level state shared by every test in this process (and by the unref'd
+	// sweep timer), so every test must leave it empty — otherwise a later test, or a later test
+	// file, inherits stale entries.
+	const handles = [];
+	function register(opts) {
+		const handle = registerLiveSubscription(opts);
+		handles.push(handle);
+		return handle;
+	}
+
+	afterEach(() => {
+		while (handles.length) handles.pop().unregister();
+		assert.strictEqual(_liveSubscriptionCount(), 0, 'test left an entry in the registry');
+	});
+
+	describe('revoke absent (regression: unchanged from #1414)', () => {
+		it('defaults terminate to end() on sweep-triggered revocation (expiry)', async () => {
+			const subscription = fakeSubscription();
+			const originalEnd = subscription.end; // registering replaces subscription.end with a wrapper
+			// Sweep-triggered revocation (expired) exercises the default terminate, which calls the
+			// (wrapped) end() — proving both the default terminate and the end-wrapping in one path.
+			register({
+				subscription,
+				username: 'alice',
+				authExpiresAt: 0, // 1970 — already expired
+				recheck: async () => true,
+			});
+			handles.pop(); // sweep will remove this entry itself
+
+			await _sweepNow();
+
+			assert.strictEqual(originalEnd.callCount, 1);
+			assert.strictEqual(_liveSubscriptionCount(), 0);
+		});
+
+		it('falls back to close() when end() is absent', async () => {
+			const subscription = { close: sinon.stub() };
+			register({
+				subscription,
+				username: 'bob',
+				authExpiresAt: 0,
+				recheck: async () => true,
+			});
+			handles.pop();
+
+			await _sweepNow();
+
+			assert.strictEqual(subscription.close.callCount, 1);
+			assert.strictEqual(_liveSubscriptionCount(), 0);
+		});
+
+		it("falls back to emit('close') when end() and close() are both absent", async () => {
+			const subscription = new EventEmitter();
+			const emitSpy = sinon.spy(subscription, 'emit');
+			register({
+				subscription,
+				username: 'carol',
+				authExpiresAt: 0,
+				recheck: async () => true,
+			});
+			handles.pop();
+
+			await _sweepNow();
+
+			assert.ok(emitSpy.calledWith('close'));
+			assert.strictEqual(_liveSubscriptionCount(), 0);
+		});
+
+		it("self-unregisters on the subscription's own 'close' event, independent of sweep", async () => {
+			const subscription = fakeSubscription();
+			register({ subscription, username: 'dave', recheck: async () => true });
+			assert.strictEqual(_liveSubscriptionCount(), 1);
+
+			subscription.emit('close');
+
+			assert.strictEqual(_liveSubscriptionCount(), 0);
+			handles.pop(); // already unregistered by the 'close' listener
+		});
+
+		it('calling end() invokes the original end() exactly once and unregisters first', () => {
+			const subscription = fakeSubscription();
+			const originalEnd = subscription.end; // registering replaces subscription.end with a wrapper
+			register({ subscription, username: 'erin', recheck: async () => true });
+
+			subscription.end('arg');
+
+			assert.strictEqual(originalEnd.callCount, 1);
+			assert.deepStrictEqual(originalEnd.firstCall.args, ['arg']);
+			assert.strictEqual(_liveSubscriptionCount(), 0);
+			handles.pop(); // already unregistered by end()
+		});
+	});
+
+	describe('revoke supplied (new seam)', () => {
+		it('uses revoke as terminate instead of end()/close()/emit', async () => {
+			const subscription = fakeSubscription();
+			const revoke = sinon.stub();
+			register({
+				subscription,
+				username: 'frank',
+				authExpiresAt: 0,
+				recheck: async () => true,
+				revoke,
+			});
+			handles.pop();
+
+			await _sweepNow();
+
+			assert.strictEqual(revoke.callCount, 1);
+			assert.strictEqual(subscription.end.callCount, 0, 'revoke must be used instead of end()');
+			assert.strictEqual(_liveSubscriptionCount(), 0);
+		});
+
+		it('does not mutate the subscription object: end identity and listener count unchanged', () => {
+			const subscription = fakeSubscription();
+			const originalEnd = subscription.end;
+			const listenersBefore = subscription.listenerCount('close');
+
+			register({ subscription, username: 'grace', recheck: async () => true, revoke: sinon.stub() });
+
+			assert.strictEqual(subscription.end, originalEnd, 'subscription.end must not be replaced');
+			assert.strictEqual(
+				subscription.listenerCount('close'),
+				listenersBefore,
+				"no 'close' listener should be added"
+			);
+		});
+
+		it('returns an unregister handle that removes only its own entry', () => {
+			const subscription = fakeSubscription();
+			const a = register({ subscription, username: 'a', recheck: async () => true, revoke: sinon.stub() });
+			register({ subscription, username: 'b', recheck: async () => true, revoke: sinon.stub() });
+			assert.strictEqual(_liveSubscriptionCount(), 2);
+
+			a.unregister();
+			handles.splice(handles.indexOf(a), 1);
+
+			assert.strictEqual(_liveSubscriptionCount(), 1);
+		});
+
+		it('revoking one of N entries sharing one subscription object invokes only that revoke, leaves the rest registered, and never touches the shared subscription', async () => {
+			const subscription = fakeSubscription();
+			const emitSpy = sinon.spy(subscription, 'emit');
+			const revokeA = sinon.stub();
+			const revokeB = sinon.stub();
+			const revokeC = sinon.stub();
+			register({ subscription, username: 'a', authExpiresAt: 0, recheck: async () => true, revoke: revokeA });
+			register({ subscription, username: 'b', recheck: async () => true, revoke: revokeB });
+			register({ subscription, username: 'c', recheck: async () => true, revoke: revokeC });
+			assert.strictEqual(_liveSubscriptionCount(), 3);
+
+			await _sweepNow();
+
+			assert.strictEqual(revokeA.callCount, 1, 'the expired subscriber should be revoked');
+			assert.strictEqual(revokeB.callCount, 0, 'other subscribers must not be revoked');
+			assert.strictEqual(revokeC.callCount, 0, 'other subscribers must not be revoked');
+			assert.strictEqual(_liveSubscriptionCount(), 2, 'the other two entries must remain registered');
+			assert.strictEqual(subscription.end.callCount, 0, 'the shared subscription must not be ended');
+			assert.strictEqual(emitSpy.called, false, 'the shared subscription must not be closed');
+		});
+
+		it('a throwing recheck among several sharing one subscription revokes only that entry (fail-closed)', async () => {
+			const subscription = fakeSubscription();
+			const revokeThrows = sinon.stub();
+			const revokeOkA = sinon.stub();
+			const revokeOkB = sinon.stub();
+			register({
+				subscription,
+				username: 'throws',
+				recheck: async () => {
+					throw new Error('recheck backend unavailable');
+				},
+				revoke: revokeThrows,
+			});
+			register({ subscription, username: 'ok-a', recheck: async () => true, revoke: revokeOkA });
+			register({ subscription, username: 'ok-b', recheck: async () => true, revoke: revokeOkB });
+			assert.strictEqual(_liveSubscriptionCount(), 3);
+
+			await _sweepNow();
+
+			assert.strictEqual(revokeThrows.callCount, 1);
+			assert.strictEqual(revokeOkA.callCount, 0);
+			assert.strictEqual(revokeOkB.callCount, 0);
+			assert.strictEqual(_liveSubscriptionCount(), 2);
+			assert.strictEqual(subscription.end.callCount, 0);
+		});
+
+		it('revokes on token expiry without consulting recheck', async () => {
+			const subscription = fakeSubscription();
+			const revoke = sinon.stub();
+			const recheck = sinon.stub().rejects(new Error('recheck must not be called for an expired token'));
+			register({ subscription, username: 'expired', authExpiresAt: 0, recheck, revoke });
+			handles.pop();
+
+			await _sweepNow();
+
+			assert.strictEqual(recheck.callCount, 0);
+			assert.strictEqual(revoke.callCount, 1);
+			assert.strictEqual(_liveSubscriptionCount(), 0);
+		});
+	});
+});

--- a/unitTests/server/liveSubscriptionAuth.test.js
+++ b/unitTests/server/liveSubscriptionAuth.test.js
@@ -6,10 +6,14 @@ testUtils.preTestPrep();
 const assert = require('node:assert');
 const { EventEmitter } = require('node:events');
 
+// The module reads its interval once at import and the first register() starts a real timer; a
+// background tick landing mid-test would make _sweepNow() a no-op via the `sweeping` guard.
+process.env.HARPER_SUBSCRIPTION_REAUTH_INTERVAL_MS = String(24 * 60 * 60 * 1000);
+
 const { registerLiveSubscription, _liveSubscriptionCount, _sweepNow } = require('#src/server/liveSubscriptionAuth');
 const hdbLogger = require('#src/utility/logging/harper_logger');
 
-// A bare call-recording function: `.calls` is the arg list of each invocation, in order.
+// `.calls` is the arg list of each invocation, in order.
 function spyFn(impl) {
 	function spy(...args) {
 		spy.calls.push(args);
@@ -19,8 +23,7 @@ function spyFn(impl) {
 	return spy;
 }
 
-// A minimal stand-in for the SSE/WS/MQTT subscription object: an EventEmitter (for the 'close'
-// self-wiring path) with an end() the registry can wrap.
+// Stand-in for the SSE/WS/MQTT subscription object.
 function fakeSubscription() {
 	const subscription = new EventEmitter();
 	subscription.end = spyFn();
@@ -63,9 +66,12 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 			assert.strictEqual(_liveSubscriptionCount(), 0);
 		});
 
-		it('logs a warning when it revokes on the default path', async () => {
+		it('logs an expected revocation at info, not warn', async () => {
+			const originalInfo = hdbLogger.info;
 			const originalWarn = hdbLogger.warn;
+			const infoMessages = [];
 			const warnMessages = [];
+			hdbLogger.info = (message) => infoMessages.push(message);
 			hdbLogger.warn = (message) => warnMessages.push(message);
 			try {
 				const subscription = fakeSubscription();
@@ -80,11 +86,13 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 				await _sweepNow();
 
 				assert.ok(
-					warnMessages.some((message) => message.includes('logged-user')),
-					`expected a revocation log for the default terminate path, got: ${JSON.stringify(warnMessages)}`
+					infoMessages.some((message) => message.includes('logged-user')),
+					`expected a revocation log for the default terminate path, got: ${JSON.stringify(infoMessages)}`
 				);
+				assert.deepStrictEqual(warnMessages, [], 'routine expiry must not warn once per subscriber');
 				assert.strictEqual(_liveSubscriptionCount(), 0);
 			} finally {
+				hdbLogger.info = originalInfo;
 				hdbLogger.warn = originalWarn;
 			}
 		});
@@ -260,7 +268,10 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 			assert.strictEqual(emitCalls.length, 0, 'the shared subscription must not be closed');
 		});
 
-		it('a throwing recheck among several sharing one subscription revokes only that entry (fail-closed)', async () => {
+		it('a throwing recheck among several sharing one subscription revokes only that entry, at warn (fail-closed)', async () => {
+			const originalWarn = hdbLogger.warn;
+			const warnMessages = [];
+			hdbLogger.warn = (message) => warnMessages.push(message);
 			const subscription = fakeSubscription();
 			const revokeThrows = spyFn();
 			const revokeOkA = spyFn();
@@ -284,6 +295,11 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 			assert.strictEqual(revokeOkB.calls.length, 0);
 			assert.strictEqual(_liveSubscriptionCount(), 2);
 			assert.strictEqual(subscription.end.calls.length, 0);
+			assert.ok(
+				warnMessages.some((message) => message.includes('throws') && message.includes('recheck backend unavailable')),
+				`a recheck failure must still warn, got: ${JSON.stringify(warnMessages)}`
+			);
+			hdbLogger.warn = originalWarn;
 		});
 
 		it('revokes on token expiry without consulting recheck', async () => {

--- a/unitTests/server/liveSubscriptionAuth.test.js
+++ b/unitTests/server/liveSubscriptionAuth.test.js
@@ -362,7 +362,7 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 			assert.strictEqual(_liveSubscriptionCount(), 1, 'the entry is removed once the async revoke actually succeeds');
 		});
 
-		it('bounds a never-settling revoke so it cannot wedge the sweep, and the entry is retried next sweep', async () => {
+		it('bounds a never-settling revoke so it cannot wedge the sweep, and other entries are still processed', async () => {
 			const originalTimeout = process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS;
 			process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS = '30';
 			try {
@@ -395,10 +395,23 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 
 				assert.strictEqual(hangingCalls, 1);
 				assert.strictEqual(otherRevoke.calls.length, 1, 'a hung revoke must not block other entries in the same sweep');
-				assert.strictEqual(
-					_liveSubscriptionCount(),
-					1,
-					'the hung entry stays registered for retry; the other is revoked'
+				assert.strictEqual(_liveSubscriptionCount(), 1, 'the hung entry stays registered; the other is revoked');
+
+				// A second sweep must not re-invoke the still-hanging revoke — it stays registered
+				// (nothing decides it's dead), but every sweep still logs it so a permanently stuck entry
+				// doesn't go completely silent after one line.
+				const originalError = hdbLogger.error;
+				const errorMessages = [];
+				hdbLogger.error = (message) => errorMessages.push(message);
+				try {
+					await _sweepNow();
+				} finally {
+					hdbLogger.error = originalError;
+				}
+				assert.strictEqual(hangingCalls, 1, 'a second sweep must not re-invoke a still-hanging revoke');
+				assert.ok(
+					errorMessages.some((message) => message.includes('hangs-on-revoke')),
+					`expected a per-sweep visibility log for the still-stuck entry, got: ${JSON.stringify(errorMessages)}`
 				);
 			} finally {
 				if (originalTimeout === undefined) delete process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS;
@@ -427,18 +440,19 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 				assert.strictEqual(_liveSubscriptionCount(), 1);
 
 				// Still pending: must not invoke revoke again, and — since the settle handler (not this
-				// wait) is what commits the eventual outcome — must not re-race the timeout either. A
-				// sweep that did re-race would take close to the configured 20ms; this one should return
-				// near-instantly.
-				const before = Date.now();
-				await _sweepNow();
-				const elapsedMs = Date.now() - before;
+				// wait) is what commits the eventual outcome — must not re-race the timeout either. Rather
+				// than asserting a tight wall-clock margin (AGENTS.md flags exactly that pattern as a
+				// flakiness root cause), raise the timeout enormously and race the sweep against a short
+				// deterministic marker: an implementation that re-raced the pending attempt could not win
+				// that race, no matter how loaded the test runner is.
+				process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS = '100000';
+				const outcome = await Promise.race([
+					_sweepNow().then(() => 'sweep'),
+					new Promise((resolveMarker) => setTimeout(() => resolveMarker('marker'), 250)),
+				]);
+				assert.strictEqual(outcome, 'sweep', 'a sweep finding an already-pending attempt must not re-race the timeout');
 				assert.strictEqual(calls, 1, 'a still-pending revoke must not be invoked a second time');
 				assert.strictEqual(_liveSubscriptionCount(), 1);
-				assert.ok(
-					elapsedMs < 15,
-					`a sweep finding an already-pending attempt must not re-race the timeout (took ${elapsedMs}ms)`
-				);
 
 				// Resolve on its own, with no sweep actively awaiting it — models the realistic case where
 				// the underlying call finishes sometime in the ~30s gap between sweeps, not synchronously

--- a/unitTests/server/liveSubscriptionAuth.test.js
+++ b/unitTests/server/liveSubscriptionAuth.test.js
@@ -259,6 +259,33 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 			assert.strictEqual(_liveSubscriptionCount(), 1, 'the throwing entry must still be removed exactly once');
 		});
 
+		it('an async revoke that rejects is contained (no unhandled rejection) and its entry is still removed', async () => {
+			const subscription = fakeSubscription();
+			let rejectingCalls = 0;
+			const revokeRejects = async () => {
+				rejectingCalls++;
+				throw new Error('shared-feed release failed (e.g. backing store timeout)');
+			};
+			const revokeOther = spyFn();
+			register({
+				subscription,
+				username: 'async-revoke-throws',
+				authExpiresAt: 0,
+				recheck: async () => true,
+				revoke: revokeRejects,
+			});
+			register({ subscription, username: 'other', recheck: async () => true, revoke: revokeOther });
+			assert.strictEqual(_liveSubscriptionCount(), 2);
+
+			// If the rejection escaped as an unhandled rejection, testUtils' handler would throw and
+			// fail this test — awaiting here alone proves it stayed contained inside claimAndTerminate.
+			await _sweepNow();
+
+			assert.strictEqual(rejectingCalls, 1, 'a rejecting async revoke must not be invoked a second time');
+			assert.strictEqual(revokeOther.calls.length, 0, 'other subscribers sharing the object must not be revoked');
+			assert.strictEqual(_liveSubscriptionCount(), 1, 'the rejecting entry must still be removed exactly once');
+		});
+
 		it('does not terminate an entry the caller already unregistered while its recheck was still in flight', async () => {
 			const subscription = fakeSubscription();
 			const revoke = spyFn();

--- a/unitTests/server/liveSubscriptionAuth.test.js
+++ b/unitTests/server/liveSubscriptionAuth.test.js
@@ -156,6 +156,45 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 			assert.strictEqual(subscription.listenerCount('close'), listenersBefore, "no 'close' listener should be added");
 		});
 
+		it('registers successfully with revoke supplied even when subscription is null/undefined/closed', async () => {
+			const revokeForNull = spyFn();
+			const revokeForUndefined = spyFn();
+			const revokeForClosed = spyFn();
+			register({
+				subscription: null,
+				username: 'null-sub',
+				authExpiresAt: 0,
+				recheck: async () => true,
+				revoke: revokeForNull,
+			});
+			register({
+				subscription: undefined,
+				username: 'undefined-sub',
+				authExpiresAt: 0,
+				recheck: async () => true,
+				revoke: revokeForUndefined,
+			});
+			register({
+				subscription: { closed: true },
+				username: 'closed-sub',
+				authExpiresAt: 0,
+				recheck: async () => true,
+				revoke: revokeForClosed,
+			});
+			assert.strictEqual(
+				_liveSubscriptionCount(),
+				3,
+				'revoke-supplied callers must not need a live subscription object'
+			);
+
+			await _sweepNow();
+
+			assert.strictEqual(revokeForNull.calls.length, 1);
+			assert.strictEqual(revokeForUndefined.calls.length, 1);
+			assert.strictEqual(revokeForClosed.calls.length, 1);
+			assert.strictEqual(_liveSubscriptionCount(), 0);
+		});
+
 		it('returns an unregister handle that removes only its own entry', () => {
 			const subscription = fakeSubscription();
 			const a = register({ subscription, username: 'a', recheck: async () => true, revoke: spyFn() });
@@ -334,6 +373,41 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 					1,
 					'the hung entry stays registered for retry; the other is revoked'
 				);
+			} finally {
+				if (originalTimeout === undefined) delete process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS;
+				else process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS = originalTimeout;
+			}
+		});
+
+		it('does not re-invoke a still-pending revoke on retry, and commits once it eventually resolves', async () => {
+			const originalTimeout = process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS;
+			process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS = '20';
+			try {
+				const subscription = fakeSubscription();
+				let calls = 0;
+				let resolveRevoke;
+				const revoke = () => {
+					calls++;
+					return new Promise((resolveP) => {
+						resolveRevoke = resolveP;
+					});
+				};
+				register({ subscription, username: 'slow-revoke', authExpiresAt: 0, recheck: async () => true, revoke });
+				handles.pop();
+
+				await _sweepNow(); // times out (revoke hasn't settled yet); invoked once
+				assert.strictEqual(calls, 1);
+				assert.strictEqual(_liveSubscriptionCount(), 1);
+
+				await _sweepNow(); // still pending; must reuse the in-flight call, not invoke revoke again
+				assert.strictEqual(calls, 1, 'a still-pending revoke must not be invoked a second time');
+				assert.strictEqual(_liveSubscriptionCount(), 1);
+
+				resolveRevoke(); // the underlying call finally completes
+				await _sweepNow(); // this sweep observes the (now-settled) same attempt and commits it
+
+				assert.strictEqual(calls, 1, 'the entry is removed without ever calling revoke a second time');
+				assert.strictEqual(_liveSubscriptionCount(), 0);
 			} finally {
 				if (originalTimeout === undefined) delete process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS;
 				else process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS = originalTimeout;

--- a/unitTests/server/liveSubscriptionAuth.test.js
+++ b/unitTests/server/liveSubscriptionAuth.test.js
@@ -98,7 +98,7 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 					`routine expiry must warn once per sweep, got: ${JSON.stringify(warnMessages)}`
 				);
 				assert.ok(
-					warnMessages[0].includes('revoked 3 live subscriptions') && warnMessages[0].includes('token expired: 3'),
+					warnMessages[0].includes('revoking 3 live subscriptions') && warnMessages[0].includes('token expired: 3'),
 					`the aggregate must carry the count and reasons, got: ${warnMessages[0]}`
 				);
 				assert.strictEqual(_liveSubscriptionCount(), 0);

--- a/unitTests/server/liveSubscriptionAuth.test.js
+++ b/unitTests/server/liveSubscriptionAuth.test.js
@@ -296,6 +296,50 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 			assert.strictEqual(_liveSubscriptionCount(), 1, 'the entry is removed once the async revoke actually succeeds');
 		});
 
+		it('bounds a never-settling revoke so it cannot wedge the sweep, and the entry is retried next sweep', async () => {
+			const originalTimeout = process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS;
+			process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS = '30';
+			try {
+				const hangingSubscription = fakeSubscription();
+				const otherSubscription = fakeSubscription();
+				let hangingCalls = 0;
+				const hangingRevoke = () => {
+					hangingCalls++;
+					return new Promise(() => {}); // never settles
+				};
+				const otherRevoke = spyFn();
+				register({
+					subscription: hangingSubscription,
+					username: 'hangs-on-revoke',
+					authExpiresAt: 0,
+					recheck: async () => true,
+					revoke: hangingRevoke,
+				});
+				register({
+					subscription: otherSubscription,
+					username: 'other',
+					authExpiresAt: 0,
+					recheck: async () => true,
+					revoke: otherRevoke,
+				});
+				assert.strictEqual(_liveSubscriptionCount(), 2);
+
+				// Without the timeout bound, this await would never resolve — the whole point of the test.
+				await _sweepNow();
+
+				assert.strictEqual(hangingCalls, 1);
+				assert.strictEqual(otherRevoke.calls.length, 1, 'a hung revoke must not block other entries in the same sweep');
+				assert.strictEqual(
+					_liveSubscriptionCount(),
+					1,
+					'the hung entry stays registered for retry; the other is revoked'
+				);
+			} finally {
+				if (originalTimeout === undefined) delete process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS;
+				else process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS = originalTimeout;
+			}
+		});
+
 		it('does not terminate an entry the caller already unregistered while its recheck was still in flight', async () => {
 			const subscription = fakeSubscription();
 			const revoke = spyFn();

--- a/unitTests/server/liveSubscriptionAuth.test.js
+++ b/unitTests/server/liveSubscriptionAuth.test.js
@@ -63,7 +63,7 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 			assert.strictEqual(_liveSubscriptionCount(), 0);
 		});
 
-		it('logs successful default-path revocation at warning level', async () => {
+		it('logs a warning when it revokes on the default path', async () => {
 			const originalWarn = hdbLogger.warn;
 			const warnMessages = [];
 			hdbLogger.warn = (message) => warnMessages.push(message);
@@ -81,7 +81,7 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 
 				assert.ok(
 					warnMessages.some((message) => message.includes('logged-user')),
-					`expected a success log for the default terminate path, got: ${JSON.stringify(warnMessages)}`
+					`expected a revocation log for the default terminate path, got: ${JSON.stringify(warnMessages)}`
 				);
 				assert.strictEqual(_liveSubscriptionCount(), 0);
 			} finally {
@@ -315,209 +315,92 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 			assert.strictEqual(_liveSubscriptionCount(), 1);
 		});
 
-		it('a throwing revoke leaves the entry registered for retry (fail-closed), and converges once revoke succeeds', async () => {
+		it('a throwing revoke is contained and does not disturb other subscribers sharing the object', async () => {
 			const subscription = fakeSubscription();
-			let calls = 0;
 			const revoke = () => {
-				calls++;
-				if (calls === 1) throw new Error('revoke failed mid-teardown (e.g. a shared-feed refcount decrement)');
+				throw new Error('revoke failed mid-teardown (e.g. a shared-feed refcount decrement)');
 			};
 			const revokeOther = spyFn();
 			register({
 				subscription,
-				username: 'throws-once-on-revoke',
+				username: 'throws-on-revoke',
 				authExpiresAt: 0,
 				recheck: async () => true,
 				revoke,
 			});
+			handles.pop(); // sweep untracks this entry itself
 			register({ subscription, username: 'other', recheck: async () => true, revoke: revokeOther });
 			assert.strictEqual(_liveSubscriptionCount(), 2);
 
-			await _sweepNow(); // revoke throws; fail-closed must not silently drop tracking
+			await _sweepNow();
 
-			assert.strictEqual(calls, 1);
 			assert.strictEqual(revokeOther.calls.length, 0, 'other subscribers sharing the object must not be revoked');
-			assert.strictEqual(_liveSubscriptionCount(), 2, 'a failed revoke must leave the entry registered');
-
-			await _sweepNow(); // the next sweep retries; this time revoke succeeds
-
-			assert.strictEqual(calls, 2, 'the next sweep must retry a previously failed revoke');
-			assert.strictEqual(_liveSubscriptionCount(), 1, 'the entry is removed once revoke actually succeeds');
+			assert.strictEqual(subscription.end.calls.length, 0, 'the shared subscription must not be ended');
+			assert.strictEqual(_liveSubscriptionCount(), 1, 'the revoked entry is untracked; the other stays registered');
 		});
 
-		it('an async revoke that rejects is contained (no unhandled rejection), leaves the entry registered for retry, and converges once it succeeds', async () => {
+		it('an async revoke that rejects is contained (no unhandled rejection) and is not retried', async () => {
 			const subscription = fakeSubscription();
 			let calls = 0;
 			const revoke = async () => {
 				calls++;
-				if (calls === 1) throw new Error('shared-feed release failed (e.g. backing store timeout)');
+				throw new Error('shared-feed release failed (e.g. backing store timeout)');
 			};
-			const revokeOther = spyFn();
 			register({
 				subscription,
-				username: 'async-revoke-throws-once',
+				username: 'async-revoke-rejects',
 				authExpiresAt: 0,
 				recheck: async () => true,
 				revoke,
 			});
-			register({ subscription, username: 'other', recheck: async () => true, revoke: revokeOther });
-			assert.strictEqual(_liveSubscriptionCount(), 2);
+			handles.pop();
 
-			// If the rejection escaped as an unhandled rejection, testUtils' handler would throw and
-			// fail this test — awaiting here alone proves it stayed contained inside claimAndTerminate.
+			// If the rejection escaped, testUtils' unhandled-rejection handler would fail this test.
 			await _sweepNow();
+			await new Promise((resolveTick) => setImmediate(resolveTick)); // let the rejection settle
 
 			assert.strictEqual(calls, 1);
-			assert.strictEqual(revokeOther.calls.length, 0, 'other subscribers sharing the object must not be revoked');
-			assert.strictEqual(_liveSubscriptionCount(), 2, 'a rejected revoke must leave the entry registered');
+			assert.strictEqual(_liveSubscriptionCount(), 0);
 
-			await _sweepNow(); // the next sweep retries; this time revoke succeeds
+			await _sweepNow();
 
-			assert.strictEqual(calls, 2, 'the next sweep must retry a previously rejected revoke');
-			assert.strictEqual(_liveSubscriptionCount(), 1, 'the entry is removed once the async revoke actually succeeds');
+			assert.strictEqual(calls, 1, 'a rejected revoke is best effort: the registry does not retry it');
 		});
 
-		it('clamps the terminate timeout to the maximum delay supported by setTimeout', async () => {
-			const originalTimeout = process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS;
-			const originalSetTimeout = global.setTimeout;
-			const observedDelays = [];
-			process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS = '999999999999';
-			global.setTimeout = (callback, delay, ...args) => {
-				observedDelays.push(delay);
-				return originalSetTimeout(callback, delay, ...args);
+		it('a never-settling revoke cannot wedge the sweep or block the entries after it', async () => {
+			let hangingCalls = 0;
+			const hangingRevoke = () => {
+				hangingCalls++;
+				return new Promise(() => {}); // never settles
 			};
-			try {
-				register({
-					subscription: fakeSubscription(),
-					username: 'bounded-timeout',
-					authExpiresAt: 0,
-					recheck: async () => true,
-					revoke: spyFn(),
-				});
-				handles.pop();
+			const otherRevoke = spyFn();
+			register({
+				subscription: fakeSubscription(),
+				username: 'hangs-on-revoke',
+				authExpiresAt: 0,
+				recheck: async () => true,
+				revoke: hangingRevoke,
+			});
+			register({
+				subscription: fakeSubscription(),
+				username: 'other',
+				authExpiresAt: 0,
+				recheck: async () => true,
+				revoke: otherRevoke,
+			});
+			handles.length = 0; // sweep untracks both entries itself
+			assert.strictEqual(_liveSubscriptionCount(), 2);
 
-				await _sweepNow();
+			// Without terminate being fire-and-forget, this await would never resolve — the point of the test.
+			await _sweepNow();
 
-				assert.ok(observedDelays.includes(2_147_483_647));
-				assert.strictEqual(_liveSubscriptionCount(), 0);
-			} finally {
-				global.setTimeout = originalSetTimeout;
-				if (originalTimeout === undefined) delete process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS;
-				else process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS = originalTimeout;
-			}
-		});
+			assert.strictEqual(hangingCalls, 1);
+			assert.strictEqual(otherRevoke.calls.length, 1, 'a hung revoke must not block later entries in the same sweep');
+			assert.strictEqual(_liveSubscriptionCount(), 0);
 
-		it('bounds a never-settling revoke so it cannot wedge the sweep, and other entries are still processed', async () => {
-			const originalTimeout = process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS;
-			process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS = '30';
-			try {
-				const hangingSubscription = fakeSubscription();
-				const otherSubscription = fakeSubscription();
-				let hangingCalls = 0;
-				const hangingRevoke = () => {
-					hangingCalls++;
-					return new Promise(() => {}); // never settles
-				};
-				const otherRevoke = spyFn();
-				register({
-					subscription: hangingSubscription,
-					username: 'hangs-on-revoke',
-					authExpiresAt: 0,
-					recheck: async () => true,
-					revoke: hangingRevoke,
-				});
-				register({
-					subscription: otherSubscription,
-					username: 'other',
-					authExpiresAt: 0,
-					recheck: async () => true,
-					revoke: otherRevoke,
-				});
-				assert.strictEqual(_liveSubscriptionCount(), 2);
+			await _sweepNow(); // the sweep loop is not wedged; nothing is left to re-invoke
 
-				// Without the timeout bound, this await would never resolve — the whole point of the test.
-				await _sweepNow();
-
-				assert.strictEqual(hangingCalls, 1);
-				assert.strictEqual(otherRevoke.calls.length, 1, 'a hung revoke must not block other entries in the same sweep');
-				assert.strictEqual(_liveSubscriptionCount(), 1, 'the hung entry stays registered; the other is revoked');
-
-				// A second sweep must not re-invoke the still-hanging revoke — it stays registered
-				// (nothing decides it's dead), but every sweep still logs it so a permanently stuck entry
-				// doesn't go completely silent after one line.
-				const originalError = hdbLogger.error;
-				const errorMessages = [];
-				hdbLogger.error = (message) => errorMessages.push(message);
-				try {
-					await _sweepNow();
-				} finally {
-					hdbLogger.error = originalError;
-				}
-				assert.strictEqual(hangingCalls, 1, 'a second sweep must not re-invoke a still-hanging revoke');
-				assert.ok(
-					errorMessages.some((message) => message.includes('hangs-on-revoke')),
-					`expected a per-sweep visibility log for the still-stuck entry, got: ${JSON.stringify(errorMessages)}`
-				);
-			} finally {
-				if (originalTimeout === undefined) delete process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS;
-				else process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS = originalTimeout;
-			}
-		});
-
-		it('does not re-invoke a still-pending revoke on retry, and commits once it eventually resolves', async () => {
-			const originalTimeout = process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS;
-			process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS = '20';
-			try {
-				const subscription = fakeSubscription();
-				let calls = 0;
-				let resolveRevoke;
-				const revoke = () => {
-					calls++;
-					return new Promise((resolveP) => {
-						resolveRevoke = resolveP;
-					});
-				};
-				register({ subscription, username: 'slow-revoke', authExpiresAt: 0, recheck: async () => true, revoke });
-				handles.pop();
-
-				await _sweepNow(); // times out (revoke hasn't settled yet); invoked once
-				assert.strictEqual(calls, 1);
-				assert.strictEqual(_liveSubscriptionCount(), 1);
-
-				// Still pending: must not invoke revoke again, and — since the settle handler (not this
-				// wait) is what commits the eventual outcome — must not re-race the timeout either. Rather
-				// than asserting a tight wall-clock margin (AGENTS.md flags exactly that pattern as a
-				// flakiness root cause), raise the timeout enormously and race the sweep against a short
-				// deterministic marker: an implementation that re-raced the pending attempt could not win
-				// that race, no matter how loaded the test runner is.
-				process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS = '100000';
-				const outcome = await Promise.race([
-					_sweepNow().then(() => 'sweep'),
-					new Promise((resolveMarker) => setTimeout(() => resolveMarker('marker'), 250)),
-				]);
-				assert.strictEqual(outcome, 'sweep', 'a sweep finding an already-pending attempt must not re-race the timeout');
-				assert.strictEqual(calls, 1, 'a still-pending revoke must not be invoked a second time');
-				assert.strictEqual(_liveSubscriptionCount(), 1);
-
-				// Resolve on its own, with no sweep actively awaiting it — models the realistic case where
-				// the underlying call finishes sometime in the ~30s gap between sweeps, not synchronously
-				// adjacent to one. The settle handler must commit the removal on its own; an implementation
-				// that only committed from inside an active sweep's await would miss this and later
-				// re-invoke revoke, discarding the success that already happened.
-				resolveRevoke();
-				await new Promise((resolveTick) => setImmediate(resolveTick));
-
-				assert.strictEqual(calls, 1, 'the late success must be committed without any sweep watching it');
-				assert.strictEqual(_liveSubscriptionCount(), 0, 'the entry must be removed as soon as the attempt settles');
-
-				await _sweepNow(); // a further sweep must not touch it again — already gone
-
-				assert.strictEqual(calls, 1, 'the entry is removed without ever calling revoke a second time');
-				assert.strictEqual(_liveSubscriptionCount(), 0);
-			} finally {
-				if (originalTimeout === undefined) delete process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS;
-				else process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS = originalTimeout;
-			}
+			assert.strictEqual(hangingCalls, 1);
 		});
 
 		it('does not terminate an entry the caller already unregistered while its recheck was still in flight', async () => {

--- a/unitTests/server/liveSubscriptionAuth.test.js
+++ b/unitTests/server/liveSubscriptionAuth.test.js
@@ -63,10 +63,10 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 			assert.strictEqual(_liveSubscriptionCount(), 0);
 		});
 
-		it('logs a successful revocation on the default (end()-wrapping) path (regression: the success commit must fire even though end() self-unregisters synchronously before the settle handler runs)', async () => {
-			const originalInfo = hdbLogger.info;
-			const infoMessages = [];
-			hdbLogger.info = (message) => infoMessages.push(message);
+		it('logs a successful revocation at the default warning level on the default (end()-wrapping) path (regression: the success commit must fire even though end() self-unregisters synchronously before the settle handler runs)', async () => {
+			const originalWarn = hdbLogger.warn;
+			const warnMessages = [];
+			hdbLogger.warn = (message) => warnMessages.push(message);
 			try {
 				const subscription = fakeSubscription();
 				register({
@@ -80,12 +80,12 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 				await _sweepNow();
 
 				assert.ok(
-					infoMessages.some((message) => message.includes('logged-user')),
-					`expected a success log for the default terminate path, got: ${JSON.stringify(infoMessages)}`
+					warnMessages.some((message) => message.includes('logged-user')),
+					`expected a success log for the default terminate path, got: ${JSON.stringify(warnMessages)}`
 				);
 				assert.strictEqual(_liveSubscriptionCount(), 0);
 			} finally {
-				hdbLogger.info = originalInfo;
+				hdbLogger.warn = originalWarn;
 			}
 		});
 
@@ -290,7 +290,8 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 			const subscription = fakeSubscription();
 			const revoke = spyFn();
 			const recheck = spyFn(() => Promise.reject(new Error('recheck must not be called for an expired token')));
-			register({ subscription, username: 'expired', authExpiresAt: 0, recheck, revoke });
+			const nowSec = Math.floor(Date.now() / 1000);
+			register({ subscription, username: 'expired', authExpiresAt: nowSec - 5, recheck, revoke });
 			handles.pop();
 
 			await _sweepNow();
@@ -298,6 +299,20 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 			assert.strictEqual(recheck.calls.length, 0);
 			assert.strictEqual(revoke.calls.length, 1);
 			assert.strictEqual(_liveSubscriptionCount(), 0);
+		});
+
+		it('keeps a subscription registered while its token remains valid', async () => {
+			const subscription = fakeSubscription();
+			const revoke = spyFn();
+			const recheck = spyFn(() => Promise.resolve(true));
+			const nowSec = Math.floor(Date.now() / 1000);
+			register({ subscription, username: 'still-valid', authExpiresAt: nowSec + 300, recheck, revoke });
+
+			await _sweepNow();
+
+			assert.strictEqual(recheck.calls.length, 1);
+			assert.strictEqual(revoke.calls.length, 0);
+			assert.strictEqual(_liveSubscriptionCount(), 1);
 		});
 
 		it('a throwing revoke leaves the entry registered for retry (fail-closed), and converges once revoke succeeds', async () => {
@@ -360,6 +375,36 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 
 			assert.strictEqual(calls, 2, 'the next sweep must retry a previously rejected revoke');
 			assert.strictEqual(_liveSubscriptionCount(), 1, 'the entry is removed once the async revoke actually succeeds');
+		});
+
+		it('clamps the terminate timeout to the maximum delay supported by setTimeout', async () => {
+			const originalTimeout = process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS;
+			const originalSetTimeout = global.setTimeout;
+			let observedDelay;
+			process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS = '999999999999';
+			global.setTimeout = (callback, delay, ...args) => {
+				observedDelay = delay;
+				return originalSetTimeout(callback, delay, ...args);
+			};
+			try {
+				register({
+					subscription: fakeSubscription(),
+					username: 'bounded-timeout',
+					authExpiresAt: 0,
+					recheck: async () => true,
+					revoke: spyFn(),
+				});
+				handles.pop();
+
+				await _sweepNow();
+
+				assert.strictEqual(observedDelay, 2_147_483_647);
+				assert.strictEqual(_liveSubscriptionCount(), 0);
+			} finally {
+				global.setTimeout = originalSetTimeout;
+				if (originalTimeout === undefined) delete process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS;
+				else process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS = originalTimeout;
+			}
 		});
 
 		it('bounds a never-settling revoke so it cannot wedge the sweep, and other entries are still processed', async () => {
@@ -503,6 +548,39 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 
 			assert.strictEqual(revoke.calls.length, 0, 'revoke must not fire for an entry the caller already unregistered');
 			assert.strictEqual(_liveSubscriptionCount(), 0);
+		});
+
+		it('does not recheck a snapshotted entry that unregisters before the sweep reaches it', async () => {
+			let releaseFirstRecheck;
+			const firstRecheckGate = new Promise((resolveGate) => {
+				releaseFirstRecheck = resolveGate;
+			});
+			register({
+				subscription: fakeSubscription(),
+				username: 'first',
+				recheck: async () => {
+					await firstRecheckGate;
+					return true;
+				},
+				revoke: spyFn(),
+			});
+			const laterRecheck = spyFn(() => Promise.resolve(true));
+			const laterHandle = register({
+				subscription: fakeSubscription(),
+				username: 'later',
+				recheck: laterRecheck,
+				revoke: spyFn(),
+			});
+
+			const sweepPromise = _sweepNow();
+			await new Promise((resolveTick) => setImmediate(resolveTick));
+			laterHandle.unregister();
+			handles.splice(handles.indexOf(laterHandle), 1);
+			releaseFirstRecheck();
+			await sweepPromise;
+
+			assert.strictEqual(laterRecheck.calls.length, 0);
+			assert.strictEqual(_liveSubscriptionCount(), 1);
 		});
 	});
 });

--- a/unitTests/server/liveSubscriptionAuth.test.js
+++ b/unitTests/server/liveSubscriptionAuth.test.js
@@ -66,7 +66,7 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 			assert.strictEqual(_liveSubscriptionCount(), 0);
 		});
 
-		it('logs an expected revocation at info, not warn', async () => {
+		it('logs each expected revocation at info and one aggregate warn per sweep', async () => {
 			const originalInfo = hdbLogger.info;
 			const originalWarn = hdbLogger.warn;
 			const infoMessages = [];
@@ -74,14 +74,10 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 			hdbLogger.info = (message) => infoMessages.push(message);
 			hdbLogger.warn = (message) => warnMessages.push(message);
 			try {
-				const subscription = fakeSubscription();
-				register({
-					subscription,
-					username: 'logged-user',
-					authExpiresAt: 0,
-					recheck: async () => true,
-				});
-				handles.pop();
+				for (const username of ['logged-user', 'logged-user-2', 'logged-user-3']) {
+					register({ subscription: fakeSubscription(), username, authExpiresAt: 0, recheck: async () => true });
+					handles.pop();
+				}
 
 				await _sweepNow();
 
@@ -89,10 +85,41 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 					infoMessages.some((message) => message.includes('logged-user')),
 					`expected a revocation log for the default terminate path, got: ${JSON.stringify(infoMessages)}`
 				);
-				assert.deepStrictEqual(warnMessages, [], 'routine expiry must not warn once per subscriber');
+				assert.strictEqual(
+					infoMessages.filter((message) => message.includes('revoking subscription')).length,
+					3,
+					`expected one info line per revoked subscriber, got: ${JSON.stringify(infoMessages)}`
+				);
+				// the default logging level drops info, so the pass must still be visible at warn — once,
+				// not once per subscriber
+				assert.strictEqual(
+					warnMessages.length,
+					1,
+					`routine expiry must warn once per sweep, got: ${JSON.stringify(warnMessages)}`
+				);
+				assert.ok(
+					warnMessages[0].includes('revoked 3 live subscriptions') && warnMessages[0].includes('token expired: 3'),
+					`the aggregate must carry the count and reasons, got: ${warnMessages[0]}`
+				);
 				assert.strictEqual(_liveSubscriptionCount(), 0);
 			} finally {
 				hdbLogger.info = originalInfo;
+				hdbLogger.warn = originalWarn;
+			}
+		});
+
+		it('does not log an aggregate for a sweep that revokes nothing', async () => {
+			const originalWarn = hdbLogger.warn;
+			const warnMessages = [];
+			hdbLogger.warn = (message) => warnMessages.push(message);
+			try {
+				register({ subscription: fakeSubscription(), username: 'stays', recheck: async () => true });
+
+				await _sweepNow();
+
+				assert.deepStrictEqual(warnMessages, []);
+				assert.strictEqual(_liveSubscriptionCount(), 1);
+			} finally {
 				hdbLogger.warn = originalWarn;
 			}
 		});

--- a/unitTests/server/liveSubscriptionAuth.test.js
+++ b/unitTests/server/liveSubscriptionAuth.test.js
@@ -272,34 +272,37 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 			const originalWarn = hdbLogger.warn;
 			const warnMessages = [];
 			hdbLogger.warn = (message) => warnMessages.push(message);
-			const subscription = fakeSubscription();
-			const revokeThrows = spyFn();
-			const revokeOkA = spyFn();
-			const revokeOkB = spyFn();
-			register({
-				subscription,
-				username: 'throws',
-				recheck: async () => {
-					throw new Error('recheck backend unavailable');
-				},
-				revoke: revokeThrows,
-			});
-			register({ subscription, username: 'ok-a', recheck: async () => true, revoke: revokeOkA });
-			register({ subscription, username: 'ok-b', recheck: async () => true, revoke: revokeOkB });
-			assert.strictEqual(_liveSubscriptionCount(), 3);
+			try {
+				const subscription = fakeSubscription();
+				const revokeThrows = spyFn();
+				const revokeOkA = spyFn();
+				const revokeOkB = spyFn();
+				register({
+					subscription,
+					username: 'throws',
+					recheck: async () => {
+						throw new Error('recheck backend unavailable');
+					},
+					revoke: revokeThrows,
+				});
+				register({ subscription, username: 'ok-a', recheck: async () => true, revoke: revokeOkA });
+				register({ subscription, username: 'ok-b', recheck: async () => true, revoke: revokeOkB });
+				assert.strictEqual(_liveSubscriptionCount(), 3);
 
-			await _sweepNow();
+				await _sweepNow();
 
-			assert.strictEqual(revokeThrows.calls.length, 1);
-			assert.strictEqual(revokeOkA.calls.length, 0);
-			assert.strictEqual(revokeOkB.calls.length, 0);
-			assert.strictEqual(_liveSubscriptionCount(), 2);
-			assert.strictEqual(subscription.end.calls.length, 0);
-			assert.ok(
-				warnMessages.some((message) => message.includes('throws') && message.includes('recheck backend unavailable')),
-				`a recheck failure must still warn, got: ${JSON.stringify(warnMessages)}`
-			);
-			hdbLogger.warn = originalWarn;
+				assert.strictEqual(revokeThrows.calls.length, 1);
+				assert.strictEqual(revokeOkA.calls.length, 0);
+				assert.strictEqual(revokeOkB.calls.length, 0);
+				assert.strictEqual(_liveSubscriptionCount(), 2);
+				assert.strictEqual(subscription.end.calls.length, 0);
+				assert.ok(
+					warnMessages.some((message) => message.includes('throws') && message.includes('recheck backend unavailable')),
+					`a recheck failure must still warn, got: ${JSON.stringify(warnMessages)}`
+				);
+			} finally {
+				hdbLogger.warn = originalWarn;
+			}
 		});
 
 		it('revokes on token expiry without consulting recheck', async () => {

--- a/unitTests/server/liveSubscriptionAuth.test.js
+++ b/unitTests/server/liveSubscriptionAuth.test.js
@@ -7,6 +7,7 @@ const assert = require('node:assert');
 const { EventEmitter } = require('node:events');
 
 const { registerLiveSubscription, _liveSubscriptionCount, _sweepNow } = require('#src/server/liveSubscriptionAuth');
+const hdbLogger = require('#src/utility/logging/harper_logger');
 
 // A bare call-recording function: `.calls` is the arg list of each invocation, in order.
 function spyFn(impl) {
@@ -60,6 +61,32 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 
 			assert.strictEqual(originalEnd.calls.length, 1);
 			assert.strictEqual(_liveSubscriptionCount(), 0);
+		});
+
+		it('logs a successful revocation on the default (end()-wrapping) path (regression: the success commit must fire even though end() self-unregisters synchronously before the settle handler runs)', async () => {
+			const originalInfo = hdbLogger.info;
+			const infoMessages = [];
+			hdbLogger.info = (message) => infoMessages.push(message);
+			try {
+				const subscription = fakeSubscription();
+				register({
+					subscription,
+					username: 'logged-user',
+					authExpiresAt: 0,
+					recheck: async () => true,
+				});
+				handles.pop();
+
+				await _sweepNow();
+
+				assert.ok(
+					infoMessages.some((message) => message.includes('logged-user')),
+					`expected a success log for the default terminate path, got: ${JSON.stringify(infoMessages)}`
+				);
+				assert.strictEqual(_liveSubscriptionCount(), 0);
+			} finally {
+				hdbLogger.info = originalInfo;
+			}
 		});
 
 		it('falls back to close() when end() is absent', async () => {
@@ -399,9 +426,19 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 				assert.strictEqual(calls, 1);
 				assert.strictEqual(_liveSubscriptionCount(), 1);
 
-				await _sweepNow(); // still pending; must reuse the in-flight call, not invoke revoke again
+				// Still pending: must not invoke revoke again, and — since the settle handler (not this
+				// wait) is what commits the eventual outcome — must not re-race the timeout either. A
+				// sweep that did re-race would take close to the configured 20ms; this one should return
+				// near-instantly.
+				const before = Date.now();
+				await _sweepNow();
+				const elapsedMs = Date.now() - before;
 				assert.strictEqual(calls, 1, 'a still-pending revoke must not be invoked a second time');
 				assert.strictEqual(_liveSubscriptionCount(), 1);
+				assert.ok(
+					elapsedMs < 15,
+					`a sweep finding an already-pending attempt must not re-race the timeout (took ${elapsedMs}ms)`
+				);
 
 				// Resolve on its own, with no sweep actively awaiting it — models the realistic case where
 				// the underlying call finishes sometime in the ~30s gap between sweeps, not synchronously

--- a/unitTests/server/liveSubscriptionAuth.test.js
+++ b/unitTests/server/liveSubscriptionAuth.test.js
@@ -63,7 +63,7 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 			assert.strictEqual(_liveSubscriptionCount(), 0);
 		});
 
-		it('logs a successful revocation at the default warning level on the default (end()-wrapping) path (regression: the success commit must fire even though end() self-unregisters synchronously before the settle handler runs)', async () => {
+		it('logs successful default-path revocation at warning level', async () => {
 			const originalWarn = hdbLogger.warn;
 			const warnMessages = [];
 			hdbLogger.warn = (message) => warnMessages.push(message);
@@ -380,10 +380,10 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 		it('clamps the terminate timeout to the maximum delay supported by setTimeout', async () => {
 			const originalTimeout = process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS;
 			const originalSetTimeout = global.setTimeout;
-			let observedDelay;
+			const observedDelays = [];
 			process.env.HARPER_SUBSCRIPTION_TERMINATE_TIMEOUT_MS = '999999999999';
 			global.setTimeout = (callback, delay, ...args) => {
-				observedDelay = delay;
+				observedDelays.push(delay);
 				return originalSetTimeout(callback, delay, ...args);
 			};
 			try {
@@ -398,7 +398,7 @@ describe('liveSubscriptionAuth.ts registerLiveSubscription', () => {
 
 				await _sweepNow();
 
-				assert.strictEqual(observedDelay, 2_147_483_647);
+				assert.ok(observedDelays.includes(2_147_483_647));
 				assert.strictEqual(_liveSubscriptionCount(), 0);
 			} finally {
 				global.setTimeout = originalSetTimeout;


### PR DESCRIPTION
## Summary

`registerLiveSubscription` (the #1414 continuous re-authorization registry) now accepts an optional `revoke?: () => void | Promise<void>`, used as the entry's terminate instead of the hard-coded `end()`/`close()`/`emit('close')` on the subscription object, and returns an `{ unregister }` handle. When `revoke` is supplied [the subscription object is left completely untouched](https://github.com/HarperFast/harper/pull/2039/changes?w=1#diff-af3f596067a99a6721197f0532f9cfe257d8c2d42a64eb6493b472dd2e6fec74R137) — no `end` wrapping, no `'close'` listener — and [the caller unregisters through the returned handle](https://github.com/HarperFast/harper/pull/2039/changes?w=1#diff-af3f596067a99a6721197f0532f9cfe257d8c2d42a64eb6493b472dd2e6fec74R154) instead.

**Why:** profiling a production node found ~157,888 live `Subscription` objects across only 29 distinct topics, almost entirely per-connection bookkeeping (each carries its own `DatabaseTransaction`, `TableResource`, `Generator`). The fix is to share one feed per topic across its subscribers while keeping authorization per subscriber — but revocation today works by destroying the subscription object, which is exactly wrong once that object is shared: wiring `terminate` to a shared feed would disconnect every subscriber on one user's revocation or token expiry (and, since `sweep()` fails closed on recheck errors, one transient error would tear the feed down for everyone). This PR is **only the prerequisite seam** — no shared feeds, no refcounting, no subscriber-list machinery.

**Revocation granularity must stay per subscriber even once feed granularity becomes per topic** — that's the invariant this seam exists to establish.

## Scope reduced from the earlier revision

Earlier revisions of this branch also shipped a revocation state machine — `pendingTerminate`, a bounded terminate timeout, settle-handler late-commit, and fail-closed retry across sweeps — roughly 120 lines whose only exercise was its own tests, since nothing in this repo supplies `revoke`. That is now removed, per the owner's decision on review feedback ("reduce scope"): the timeout and idempotency requirements are unknowable without a real caller, and the shared-feed follow-up may want different ones.

What remains is the seam plus the one change the seam genuinely forces: [`terminate` may now return a promise](https://github.com/HarperFast/harper/pull/2039/changes?w=1#diff-af3f596067a99a6721197f0532f9cfe257d8c2d42a64eb6493b472dd2e6fec74R158), so [`terminateEntry` untracks the entry first and dispatches teardown once, fire-and-forget, containing a synchronous throw and a rejection alike](https://github.com/HarperFast/harper/pull/2039/changes?w=1#diff-af3f596067a99a6721197f0532f9cfe257d8c2d42a64eb6493b472dd2e6fec74R170). Untracking first is what keeps a hung `revoke` from wedging the sweep — [awaiting it would hold the `sweeping` mutex forever](https://github.com/HarperFast/harper/pull/2039/changes?w=1#diff-af3f596067a99a6721197f0532f9cfe257d8c2d42a64eb6493b472dd2e6fec74R178) — and it matches the pre-existing default-path behavior, which also deleted the entry before calling `terminate()`. The consequence, [stated in the contract](https://github.com/HarperFast/harper/pull/2039/changes?w=1#diff-af3f596067a99a6721197f0532f9cfe257d8c2d42a64eb6493b472dd2e6fec74R96): a `revoke` that throws, rejects or never settles is logged and never retried.

Three smaller changes came out of this branch's review rounds:
- Revocation logging is two-level. Each revocation keeps its own `info` line, and every sweep that revoked anything [closes with one aggregate `warn`](https://github.com/HarperFast/harper/pull/2039/changes?w=1#diff-af3f596067a99a6721197f0532f9cfe257d8c2d42a64eb6493b472dd2e6fec74R217) carrying the total and a per-reason breakdown. Harper ships `logging.level: warn` (`static/defaultConfig.yaml:46`), so an `info`-only line would make every expected revocation invisible on a default deployment; a `warn` per subscriber would turn one mass role change into a 10k-line storm. The aggregate is emitted from `sweep()`'s `finally`, and it says *revoking*, not *revoked*, because `terminate` is dispatched fire-and-forget — a teardown that fails still gets its own `error` line. `warn` also still covers the per-entry recheck-failure path it covered on `main`.
- The unit suite [pins `HARPER_SUBSCRIPTION_REAUTH_INTERVAL_MS` before importing the module](https://github.com/HarperFast/harper/pull/2039/changes?w=1#diff-abda1759bc4f13a990a4ac3d2c9b7435a05a9b0eb0e43aebe96abd52f5c49b8cR11). It previously ran against the real 30s interval, where a background tick makes `_sweepNow()` a no-op through the `sweeping` guard and assertions then run against a sweep that never happened.

When `revoke` is omitted, behavior is unchanged from #1414 in every respect except the new revocation logging; the sole existing caller (`registerLiveSubscriptionForContext` in `resources/Resource.ts`) doesn't pass `revoke`.

## For the human reviewer

The load-bearing judgment call is **fail-open teardown**: with the state machine gone, a `revoke` that never settles leaves a deauthorized subscriber attached with no further authorization evaluation. Reviewers raised this in every round. It is [documented on the API](https://github.com/HarperFast/harper/pull/2039/changes?w=1#diff-af3f596067a99a6721197f0532f9cfe257d8c2d42a64eb6493b472dd2e6fec74R96) and cannot manifest on this branch (no caller supplies `revoke`), and it is deliberately the shared-feed caller's problem to solve where the timeout/idempotency semantics are actually known — but it should be ratified before that wiring lands, and it is cheap to revisit now while the seam is unused.

Declined this round, all pre-existing on `main` and out of scope for a scope-reduction change — each is worth its own issue:
- **`sweep()` is N serialized `recheck()` round-trips behind one global mutex** (adjudicated major). The production `recheck` does a `findAndValidateUser` + `allowRead` per entry with no memoization across entries sharing a username, and there is no timeout on it. This seam does raise registry cardinality from per-stream-object to per-subscriber, which makes N bigger — but the serialization, the mutex, and the unbounded await are all unchanged from `main`.
- **ITC-triggered sweeps are dropped with no trailing pass**: `if (sweeping) return` discards a user-change broadcast arriving mid-sweep, so revocation falls back to the 30s backstop. A dirty flag re-run in `sweep()`'s `finally` closes it. (One reviewer described the exposure as "up to 24 hours" — that reads the *test* interval override; production is the 30s backstop.)
- **The recheck-failure path still warns once per entry**, as it does on `main` — each of those lines carries a distinct error message, so collapsing it into the aggregate would cost diagnostics rather than noise. The aggregate counts those entries too, under `recheck error`.
- **A leaked `'close'` listener and the never-restored `end` wrapper on the default path**: `unregister()` removes the registry entry but does not `removeListener('close', …)` or put back the original `end`. Pre-existing from #1414 and harmless for a per-connection subscription object that is discarded on close, but it would matter for a pooled or reused stream object.
- **Two-mode discriminated union vs two named entry points**, and **`_sweepNow`/`_liveSubscriptionCount` exported from the production module** — both flagged as API-shape decisions, both cheapest to change now.

**Refuted, not declined:** the last review round's remaining "major" claims `hdbLogger.info`/`warn`/`error` are unbound *methods*, so passing them as references (`safeLog(notice, …)`, `notice = hdbLogger.info`) throws a `this` `TypeError` that `safeLog` swallows, silently suppressing every revocation log. They are module-level free functions — `export function info(...args) { mainLogger.info(...args); }` at `utility/logging/harper_logger.ts:807`, `:825`, `:861` — with no `this` reference, so a bare reference is safe, and the suite's `logs each expected revocation at info and one aggregate warn per sweep` test asserts the lines are actually emitted. The `Human-Review-Need: 4` footer below still counts it: that round's adjudication leg was auto-pruned as a narrow low-risk delta, so the grade is "outside findings unadjudicated", not a live defect.

## Verification

- `npm run build`, `npm run lint:required`, `npm run format:write` — clean.
- `npx mocha "unitTests/server/**/*.test.js"` — 715 passing, including the 20 tests in this file. Two of them cover the aggregate: [one info line per subscriber plus exactly one warn with the count and reasons](https://github.com/HarperFast/harper/pull/2039/changes?w=1#diff-abda1759bc4f13a990a4ac3d2c9b7435a05a9b0eb0e43aebe96abd52f5c49b8cR69), and [no aggregate at all for a pass that revokes nothing](https://github.com/HarperFast/harper/pull/2039/changes?w=1#diff-abda1759bc4f13a990a4ac3d2c9b7435a05a9b0eb0e43aebe96abd52f5c49b8cR111).
- **End-to-end route: existing integration suite.** `npm run test:integration -- integrationTests/security/subscription-revocation.test.ts` — 6/6 passing, unmodified, covering SSE/WS/MQTT revocation on `drop_user`, `alter_role`, and token expiry. This is what proves the sole in-repo caller is unaffected; the `revoke` path itself has no end-to-end route until the shared-feed caller lands, and is covered only by unit tests ([rejection containment](https://github.com/HarperFast/harper/pull/2039/changes?w=1#diff-abda1759bc4f13a990a4ac3d2c9b7435a05a9b0eb0e43aebe96abd52f5c49b8cR361), [hang containment](https://github.com/HarperFast/harper/pull/2039/changes?w=1#diff-abda1759bc4f13a990a4ac3d2c9b7435a05a9b0eb0e43aebe96abd52f5c49b8cR389), [no subscription mutation](https://github.com/HarperFast/harper/pull/2039/changes?w=1#diff-abda1759bc4f13a990a4ac3d2c9b7435a05a9b0eb0e43aebe96abd52f5c49b8cR183)).
- `npm run test:unit:main` and `npm run test:unit:resources` both have failures on this machine that reproduce identically with `origin/main`'s copy of both changed files: `test:unit:main` aborts at import with `LZ4 not supported in this build` against a stale local database dir, and `test:unit:resources` fails 3 tests in `replayStructures` / `randomAccessFields`, neither of which imports this module.

Refs #1414

---
Generated with Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=8 @ 096f399f9302</sub>

<sub>Human-Review-Need: 4 @ 096f399f9302</sub>
