### PR TITLE
fix(windows): ride out longer AV holds in atomicWriteFile's rename retry

### DIFF
--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -7,7 +7,6 @@ import YAML from 'yaml';
 import path from 'path';
 import { threadId } from 'node:worker_threads';
 import { randomBytes } from 'node:crypto';
-import { performance } from 'node:perf_hooks';
 import isNumber from 'is-number';
 import propertiesReaderModule from 'properties-reader';
 import _ from 'lodash';
@@ -87,10 +86,15 @@ export function getConfigPath(param: string) {
 // Every worker thread runs its own RootConfigWatcher (chokidar), so a write on one thread
 // routinely races a hot-reload read on another; Windows Defender / AV real-time scanning can
 // hold a similar transient handle. Retry with exponential backoff to ride out the race -
-// callers are synchronous, so the wait is a synchronous busy-loop rather than a real sleep.
-const RENAME_RETRY_MAX_ATTEMPTS = 8;
+// callers are synchronous, so the wait is a synchronous sleep rather than an async one.
+// The budget must outlast a single AV real-time scan pass (seconds, not hundreds of ms):
+// the previous ~910ms budget was exhausted twice in a row by the same test on a CI runner
+// (harper#2036), so the worst case is now ~3.6s.
+const RENAME_RETRY_MAX_ATTEMPTS = 12;
 const RENAME_RETRY_INITIAL_DELAY_MS = 10;
-const RENAME_RETRY_MAX_DELAY_MS = 200;
+const RENAME_RETRY_MAX_DELAY_MS = 500;
+// Never notified; exists only so Atomics.wait can time out (a synchronous, CPU-idle sleep).
+const renameRetrySleepBuffer = new Int32Array(new SharedArrayBuffer(4));
 
 function atomicWriteFile(
 	filePath,
@@ -112,11 +116,10 @@ function atomicWriteFile(
 		} catch (err) {
 			if (retries > 0 && (err.code === 'EPERM' || err.code === 'EACCES')) {
 				retries--;
-				// Sleep synchronously (all call sites are sync) to allow the reader to close the
-				// file. Uses performance.now() rather than Date.now(): the latter tracks wall-clock
-				// time and can jump backward (NTP sync), which would turn this into an unbounded spin.
-				const start = performance.now();
-				while (performance.now() - start < delayMs) {}
+				// Sleep synchronously (all call sites are sync) to allow the holder to close the
+				// file. Atomics.wait yields the thread to the OS instead of spinning the CPU,
+				// which is what makes a multi-second worst-case budget affordable.
+				if (delayMs > 0) Atomics.wait(renameRetrySleepBuffer, 0, 0, delayMs);
 				delayMs = Math.min(delayMs * 2, maxDelayMs);
 				continue;
 			}

--- a/unitTests/config/configUtils.test.js
+++ b/unitTests/config/configUtils.test.js
@@ -246,12 +246,12 @@ describe('Test configUtils module', () => {
 			try {
 				// Use the default retry count (unspecified maxRetries) so this exercises the real
 				// production budget, but override the delay to ~0 so the backoff doesn't burn real
-				// wall-clock time (default backoff would take ~900ms for a persistent failure).
+				// wall-clock time (default backoff would take ~3.6s for a persistent failure).
 				expect(() => atomicWriteFile(ATOMIC_TEST_PATH, 'content', { initialDelayMs: 0, maxDelayMs: 0 })).to.throw(
 					epermError
 				);
-				// 1 initial attempt + 8 retries (the production default maxRetries)
-				expect(renameStub.callCount).to.equal(9);
+				// 1 initial attempt + 12 retries (the production default maxRetries)
+				expect(renameStub.callCount).to.equal(13);
 				const stragglers = fs
 					.readdirSync(ATOMIC_TEST_DIR)
 					.filter((e) => e.startsWith('atomic-write-test.yaml.') && e.endsWith('.tmp'));


### PR DESCRIPTION
## Why

The Windows Integration 6/6 job on [#2036 (chore(deps): Update rocksdb-js to 2.6.1)](https://github.com/HarperFast/harper/pull/2036) failed twice in a row (then passed on a third run) with:

```
EPERM: operation not permitted, rename '...harper-config.yaml.<pid>.<tid>.<rand>.tmp' -> '...harper-config.yaml'
```

The failing test's duration (~949ms) matches `atomicWriteFile`'s full retry budget (~910ms: 8 retries, 200ms cap) — the budget added in [#1714 (fix(windows): widen atomicWriteFile rename-retry backoff for EPERM/EACCES)](https://github.com/HarperFast/harper/pull/1714) was exhausted, not skipped. Node readers can't cause this (libuv opens with full sharing flags); the holder is almost certainly Defender/AV real-time scanning, and a single scan pass can exceed a second.

## Change

- Retry budget: 8 → 12 attempts, delay cap 200ms → 500ms (worst case ~3.6s, previously ~910ms).
- The synchronous wait is now a timeout-only `Atomics.wait` on a module-level `SharedArrayBuffer` instead of a `performance.now()` busy-spin — the thread yields to the OS instead of burning CPU, which is what makes the longer worst case affordable. Happy path is unchanged (no wait unless a rename actually fails).

Worst case still blocks the calling thread's event loop for ~3.6s, but only on the path that previously *threw* after ~0.9s of spinning; call sites are synchronous by design.

## Verification

- `unitTests/config/configUtils.test.js` (72 passing) — including the retry-exhaustion test updated to pin the new production budget (13 rename calls).
- `Atomics.wait` timed sleep verified on the main thread on Node 24 (returns `timed-out` after the requested delay).
- Cross-model review: Codex (gpt-5) — confirmed main-thread/worker legality of `Atomics.wait`, timeout-only safety of the never-notified buffer, and the backoff arithmetic; its one finding (unused `performance` import breaking lint) is fixed.

Generated by Claude (Fable 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)