### PR TITLE
Release the retained read handle's write intents when an outstanding-iterator commit replays

### DIFF
--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -1120,6 +1120,15 @@ function startMonitoringTxns() {
 
 startMonitoringTxns();
 
+/**
+ * Test seam: re-arms the once-per-process replay warning. The whole unit suite shares one process,
+ * so whichever test first drives a commit under open iterators consumes the warning for every test
+ * after it.
+ */
+export function resetReplayedWritesWarning() {
+	replayedWritesWarned = false;
+}
+
 export function setTxnExpiration(ms) {
 	clearInterval(timer);
 	txnExpiration = ms;

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -654,6 +654,15 @@ export class DatabaseTransaction implements Transaction {
 						// write-transaction-queue-depth, the one metric that can observe a commit that never
 						// settles (harper#2001), reading zero for exactly this path.
 					}
+					// The retained handle's staged writes are now owned by the replay (staged above,
+					// which installed the replay's own write intents on the same VT slots) or were
+					// removed — either way no commit will ever run on this handle, so its write
+					// intents can only be released here: left in place, other writers'
+					// coordinated-retry commits park on them until the last iterator finishes
+					// (harper#2001's leaked-holder wedge). Reads through the retained handle,
+					// including read-your-own-writes, keep working; abandonWrites is idempotent
+					// across retry rounds. Optional call: older rocksdb-js lacks it.
+					(this.transaction as { abandonWrites?: () => void }).abandonWrites?.();
 				} else {
 					// no more reads need to be performed, just commit/abort based if there are any writes
 					trackedTxns.delete(this);

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -134,6 +134,9 @@ export function getOutstandingCommits(): { count: number; oldestAgeMs: number | 
 		oldestAgeMs: oldestOutstandingCommit ? performance.now() - oldestOutstandingCommit.start : undefined,
 	};
 }
+// Once per process: committing under open read iterators forces a write replay, so the warning is
+// about the caller's pattern, not the individual commit.
+let replayedWritesWarned = false;
 
 // The analytics module registers a recorder here at load (dependency inversion, mirroring
 // `replicationConfirmation` below) so the storage layer doesn't statically import the analytics/server
@@ -356,6 +359,9 @@ export class DatabaseTransaction implements Transaction {
 	// open-transaction limit. Once poisoned, any further addWrite/commit throws transactionOpenTooLongError
 	// so the request rolls back cleanly instead of silently committing a partial write set (issue #1407).
 	declare timedOut?: boolean;
+	// Set once the retained read handle's write intents have been released (see commit()'s
+	// outstanding-iterators branch), so a retry round cannot re-fire the release.
+	declare writesAbandoned?: boolean;
 
 	getReadTxn(disableSnapshot?: boolean): ReadTransaction {
 		this.readTxnRefCount = (this.readTxnRefCount || 0) + 1;
@@ -626,6 +632,14 @@ export class DatabaseTransaction implements Transaction {
 					this.writes = this.writes.filter((write) => write); // filter out removed entries
 					if (this.writes.length > 0) {
 						if (!options.transaction) {
+							if (!replayedWritesWarned) {
+								replayedWritesWarned = true;
+								harperLogger.warn?.(
+									`Committing while read iterators are still open: ${this.writes.length} staged write(s) must be re-staged and committed on a second transaction, doubling their write work` +
+										(this.startedFrom ? `, from ${this.startedFrom.resourceName}.${this.startedFrom.method}` : '') +
+										`. Fully consume (or close) iterators before committing to avoid this. Logged once per process.`
+								);
+							}
 							// Deliberately NOT marked isRetry and NOT carrying over the original's onCommit:
 							// audit/txn-log entries batch natively on the transaction they were staged into and
 							// are only durably written by that transaction's commit attempt (an abort discards
@@ -658,13 +672,18 @@ export class DatabaseTransaction implements Transaction {
 					// writes — so this is the only place its write intents can be released. Left in
 					// place, other writers' coordinated-retry commits park on them until the last
 					// iterator finishes (harper#2001). Reads through the handle, including
-					// read-your-own-writes, keep working. Fenced like the other post-submit steps
-					// here: the replay commit is already in flight, so a throw must not skip
-					// onCommit/the chain-store commit below. Optional: rocksdb-js < 2.7 lacks it.
-					try {
-						(this.transaction as { abandonWrites?: () => void }).abandonWrites?.();
-					} catch (error) {
-						harperLogger.warn?.('Failed to release write intents on a retained read transaction', error);
+					// read-your-own-writes, keep working. Once only: a coordinated-retry or backoff
+					// round re-enters this branch on the same retained handle. Fenced like the other
+					// post-submit steps here: the replay commit is already in flight, so a throw must
+					// not skip onCommit/the chain-store commit below. Optional: rocksdb-js < 2.7
+					// lacks the method.
+					if (!this.writesAbandoned) {
+						this.writesAbandoned = true;
+						try {
+							(this.transaction as { abandonWrites?: () => void } | null)?.abandonWrites?.();
+						} catch (error) {
+							harperLogger.warn?.('Failed to release write intents on a retained read transaction', error);
+						}
 					}
 				} else {
 					// no more reads need to be performed, just commit/abort based if there are any writes

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -654,15 +654,18 @@ export class DatabaseTransaction implements Transaction {
 						// write-transaction-queue-depth, the one metric that can observe a commit that never
 						// settles (harper#2001), reading zero for exactly this path.
 					}
-					// The retained handle's staged writes are now owned by the replay (staged above,
-					// which installed the replay's own write intents on the same VT slots) or were
-					// removed — either way no commit will ever run on this handle, so its write
-					// intents can only be released here: left in place, other writers'
-					// coordinated-retry commits park on them until the last iterator finishes
-					// (harper#2001's leaked-holder wedge). Reads through the retained handle,
-					// including read-your-own-writes, keep working; abandonWrites is idempotent
-					// across retry rounds. Optional call: older rocksdb-js lacks it.
-					(this.transaction as { abandonWrites?: () => void }).abandonWrites?.();
+					// No commit will ever run on the retained handle — the replay above owns these
+					// writes — so this is the only place its write intents can be released. Left in
+					// place, other writers' coordinated-retry commits park on them until the last
+					// iterator finishes (harper#2001). Reads through the handle, including
+					// read-your-own-writes, keep working. Fenced like the other post-submit steps
+					// here: the replay commit is already in flight, so a throw must not skip
+					// onCommit/the chain-store commit below. Optional: rocksdb-js < 2.7 lacks it.
+					try {
+						(this.transaction as { abandonWrites?: () => void }).abandonWrites?.();
+					} catch (error) {
+						harperLogger.warn?.('Failed to release write intents on a retained read transaction', error);
+					}
 				} else {
 					// no more reads need to be performed, just commit/abort based if there are any writes
 					trackedTxns.delete(this);

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -7,6 +7,7 @@ const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { transaction } = require('#src/resources/transaction');
 const { IterableEventQueue } = require('#src/resources/IterableEventQueue');
 const { RocksDatabase } = require('@harperfast/rocksdb-js');
+const harperLogger = require('#src/utility/logging/harper_logger');
 const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
 
 // The package blocks deep imports of its package.json, so walk up from the resolved entry point.
@@ -135,26 +136,35 @@ describe('Transactions', () => {
 		const context = {};
 		let abandonCalls = 0;
 		let iterator;
-		await transaction(context, async () => {
-			iterator = TxnTest2.search([], context)[Symbol.asyncIterator]();
-			const first = await iterator.next();
-			assert.ok(!first.done, 'test setup: the iterator must be outstanding at commit');
-			await TxnTest2.put('aw-write', { name: 'aw-write' }, context);
-			const retained = context.transaction.transaction;
-			if (nativeExpected) {
-				assert.equal(
-					typeof retained.abandonWrites,
-					'function',
-					'installed rocksdb-js should expose abandonWrites; without it the call site is a silent no-op'
-				);
-			}
-			const original = retained.abandonWrites?.bind(retained);
-			retained.abandonWrites = function () {
-				abandonCalls++;
-				return original?.();
-			};
-		});
+		const replayWarnings = [];
+		const originalWarn = harperLogger.warn;
+		harperLogger.warn = (...args) => replayWarnings.push(args.join(' '));
+		try {
+			await transaction(context, async () => {
+				iterator = TxnTest2.search([], context)[Symbol.asyncIterator]();
+				const first = await iterator.next();
+				assert.ok(!first.done, 'test setup: the iterator must be outstanding at commit');
+				await TxnTest2.put('aw-write', { name: 'aw-write' }, context);
+				const retained = context.transaction.transaction;
+				if (nativeExpected) {
+					assert.equal(
+						typeof retained.abandonWrites,
+						'function',
+						'installed rocksdb-js should expose abandonWrites; without it the call site is a silent no-op'
+					);
+				}
+				const original = retained.abandonWrites?.bind(retained);
+				retained.abandonWrites = function () {
+					abandonCalls++;
+					return original?.();
+				};
+			});
+		} finally {
+			harperLogger.warn = originalWarn;
+		}
 		assert.equal(abandonCalls, 1, 'the replay commit must abandon the retained handle writes');
+		assert.equal(replayWarnings.length, 1, 'the replay must warn the author about the doubled write work');
+		assert.match(replayWarnings[0], /read iterators are still open/);
 		assert.equal((await TxnTest2.get('aw-write')).name, 'aw-write', 'the replayed write must be durable');
 		let remaining = 0;
 		while (!(await iterator.next()).done) {

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -104,6 +104,42 @@ describe('Transactions', () => {
 		}
 		assert.equal(sevens.length, 1);
 	});
+	it('abandons the retained handle writes when a commit with outstanding iterators replays', async function () {
+		// RocksDB-only: the outstanding-iterators commit branch replays staged writes onto a
+		// fresh transaction and retains the original handle solely for the iterators. The
+		// retained handle's VT write intents can never be released by a commit, so the branch
+		// must call abandonWrites() on it — otherwise other writers' coordinated-retry commits
+		// park on those intents until the last iterator finishes (harper#2001).
+		if (isLMDB) this.skip();
+		await TxnTest2.put('aw-seed-1', { name: 'aw-seed' });
+		await TxnTest2.put('aw-seed-2', { name: 'aw-seed' });
+		const context = {};
+		let abandonCalls = 0;
+		let iterator;
+		await transaction(context, async () => {
+			iterator = TxnTest2.search([], context)[Symbol.asyncIterator]();
+			const first = await iterator.next();
+			assert.ok(!first.done, 'test setup: the iterator must be outstanding at commit');
+			await TxnTest2.put('aw-write', { name: 'aw-write' }, context);
+			// Spy on the retained native handle. Injected even when the installed rocksdb-js
+			// predates abandonWrites: the call site feature-detects, so this asserts harper's
+			// side of the contract regardless of the dependency version (the release semantics
+			// themselves are covered by rocksdb-js's own park-wake test).
+			const retained = context.transaction.transaction;
+			const original = retained.abandonWrites?.bind(retained);
+			retained.abandonWrites = function () {
+				abandonCalls++;
+				return original?.();
+			};
+		});
+		assert.equal(abandonCalls, 1, 'the replay commit must abandon the retained handle writes');
+		assert.equal((await TxnTest2.get('aw-write')).name, 'aw-write', 'the replayed write must be durable');
+		let remaining = 0;
+		while (!(await iterator.next()).done) {
+			remaining++;
+		}
+		assert.ok(remaining >= 1, 'the retained handle must keep serving the outstanding iterator');
+	});
 	describe('Testing updates', () => {
 		it('Can update with addTo and set', async function () {
 			const context = {};

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -9,6 +9,22 @@ const { IterableEventQueue } = require('#src/resources/IterableEventQueue');
 const { RocksDatabase } = require('@harperfast/rocksdb-js');
 const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
 
+// The package blocks deep imports of its package.json, so walk up from the resolved entry point.
+function installedRocksdbVersion() {
+	const { existsSync, readFileSync } = require('node:fs');
+	const { dirname, join } = require('node:path');
+	let dir = dirname(require.resolve('@harperfast/rocksdb-js'));
+	for (let depth = 0; depth < 5; depth++) {
+		const candidate = join(dir, 'package.json');
+		if (existsSync(candidate)) {
+			const parsed = JSON.parse(readFileSync(candidate, 'utf8'));
+			if (parsed.name === '@harperfast/rocksdb-js') return parsed.version;
+		}
+		dir = dirname(dir);
+	}
+	throw new Error('could not resolve the installed @harperfast/rocksdb-js version');
+}
+
 describe('Transactions', () => {
 	let TxnTest, TxnTest2, TxnTest3;
 	let test_subscription;
@@ -105,12 +121,15 @@ describe('Transactions', () => {
 		assert.equal(sevens.length, 1);
 	});
 	it('abandons the retained handle writes when a commit with outstanding iterators replays', async function () {
-		// RocksDB-only: the outstanding-iterators commit branch replays staged writes onto a
-		// fresh transaction and retains the original handle solely for the iterators. The
-		// retained handle's VT write intents can never be released by a commit, so the branch
-		// must call abandonWrites() on it — otherwise other writers' coordinated-retry commits
-		// park on those intents until the last iterator finishes (harper#2001).
+		// The outstanding-iterators commit branch replays staged writes onto a fresh transaction
+		// and retains the original handle for the iterators; its VT write intents can never be
+		// released by a commit, so the branch must call abandonWrites() (harper#2001). The
+		// release semantics themselves are covered by rocksdb-js's park-wake test; this pins
+		// Harper's side of the contract, including that the native method still exists once the
+		// dependency carrying it is installed — a silent `?.` no-op would leave the wedge live.
 		if (isLMDB) this.skip();
+		const [major, minor] = installedRocksdbVersion().split('.').map(Number);
+		const nativeExpected = major > 2 || (major === 2 && minor >= 7);
 		await TxnTest2.put('aw-seed-1', { name: 'aw-seed' });
 		await TxnTest2.put('aw-seed-2', { name: 'aw-seed' });
 		const context = {};
@@ -121,11 +140,14 @@ describe('Transactions', () => {
 			const first = await iterator.next();
 			assert.ok(!first.done, 'test setup: the iterator must be outstanding at commit');
 			await TxnTest2.put('aw-write', { name: 'aw-write' }, context);
-			// Spy on the retained native handle. Injected even when the installed rocksdb-js
-			// predates abandonWrites: the call site feature-detects, so this asserts harper's
-			// side of the contract regardless of the dependency version (the release semantics
-			// themselves are covered by rocksdb-js's own park-wake test).
 			const retained = context.transaction.transaction;
+			if (nativeExpected) {
+				assert.equal(
+					typeof retained.abandonWrites,
+					'function',
+					'installed rocksdb-js should expose abandonWrites; without it the call site is a silent no-op'
+				);
+			}
 			const original = retained.abandonWrites?.bind(retained);
 			retained.abandonWrites = function () {
 				abandonCalls++;

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -8,6 +8,7 @@ const { transaction } = require('#src/resources/transaction');
 const { IterableEventQueue } = require('#src/resources/IterableEventQueue');
 const { RocksDatabase } = require('@harperfast/rocksdb-js');
 const harperLogger = require('#src/utility/logging/harper_logger');
+const { resetReplayedWritesWarning } = require('#src/resources/DatabaseTransaction');
 const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
 
 // The package blocks deep imports of its package.json, so walk up from the resolved entry point.
@@ -137,6 +138,8 @@ describe('Transactions', () => {
 		let abandonCalls = 0;
 		let iterator;
 		const replayWarnings = [];
+		// The warning is once per process and the whole suite shares one, so re-arm it here.
+		resetReplayedWritesWarning();
 		const originalWarn = harperLogger.warn;
 		harperLogger.warn = (...args) => replayWarnings.push(args.join(' '));
 		try {


### PR DESCRIPTION
Human-Review-Need: 4 @ 1ce8e9c1ebf5
## Why

`8d69f1bd1` replaced the LINGERING deferral: a commit with outstanding read iterators now replays its staged writes onto a fresh transaction and commits them immediately, keeping the original native handle open solely so the iterators can finish. That closed a real class of acknowledged-write loss.

What it left behind is the retained handle's **verification-table write intents**. The replay owns those writes now, so no commit will ever run on the original handle — nothing releases its intents until the last iterator drains (or the long-transaction monitor releases the snapshot). Meanwhile every other writer's `coordinatedRetry` commit that conflicts on those slots parks on them. With today's unbounded park that is #2001's per-thread write wedge: a live capture showed one slot lock-tagged with `holders=3 woken=0` more than five hours after onset, with the wedged thread 503-ing every write.

The retention window predates `8d69f1bd1` (LINGERING held the intents too), but there the pending commit still intended to write them. After the replay they are dead locks, which also makes them safe to release early.

## What

Call `abandonWrites()` on the retained handle right after the replay commit is submitted. It drops the dead VT intents while leaving reads — including read-your-own-writes — working for the outstanding iterators.

Ordering is safe by construction: the replay's save loop has already staged its own intents on the same slots, so VT publish-blocking never gaps; a writer parked on the original's tracker wakes once both are released.

The call is fenced in try/catch, matching this function's other post-submit steps (`onCommit`, `leaveWriteQueue`): the replay commit is already in flight, so a throw here must not skip the `aftercommit` notify or the chain-store commit for an already-durable write.

## Depends on HarperFast/rocksdb-js#747

`abandonWrites()` does not exist in the pinned `@harperfast/rocksdb-js` 2.6.1 — **this change is inert until #747 lands, is released, and the dependency is bumped**. The call is feature-detected (`?.`) so it is safe to merge in either order, and the test asserts the native method *must* exist once a version ≥ 2.7 is installed, so the fix cannot stay silently no-op after the bump.

## Testing

`unitTests/resources/transaction.test.js` — new RocksDB-only case: an outstanding iterator plus a staged write drives the replay branch, and asserts the retained handle is abandoned exactly once, the replayed write is durable, and the iterator keeps producing entries afterward. Version-gated assertion that the native method is present once the dependency carries it.

End-to-end verification route: the release semantics are proven in rocksdb-js#747's park/wake test (a parked coordinated-retry commit resolves `RETRY_NOW` the moment the holder abandons). On the Harper side the wedge mechanism itself was reproduced live on a test cluster — see #2001 for the A/B — but it needs a leaked holder plus a conflicting commit, which is not something the unit suite can stage; this test pins the call contract and the surrounding invariants instead.

`unitTests/resources/transaction.test.js`: 30 passing. Cross-model review: codex + gemini + Harper domain pass.

Generated with Claude Fable 5.
