### PR TITLE
fix(audit): track deleteHistory removals with bounded concurrency

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -131,6 +131,13 @@ race the live set: each race attaches another reaction to every long-pending rem
 their tracked removals before settling, including when iteration throws. `scheduleAuditCleanup` remains
 sequential because it is an automatic background loop.
 
+Individual removal failures are logged and excluded from the returned count, but a purge that attempted
+at least one removal and completed none rejects with the first error after both phases have drained.
+Without that, `delete_transaction_logs_before` reports a successful `entries_deleted: 0` whether nothing
+was eligible or the store rejected every write, and an operator pruning to bound disk growth has no signal
+that pruning did nothing. Drain first, then decide: a failing store should still get every removal it can
+accept, and a single success means the purge made progress and reports normally.
+
 The optional primary-store cleanup snapshots each tombstone's key and version before yielding and passes
 that version to `remove()`. LMDB enforces the condition natively. Harper's RocksDB adapter re-reads and
 removes inside one native transaction, retrying a conflict once, because rocksdb-js's `remove()` accepts

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -118,14 +118,18 @@ The cross-thread subscription path (default `crossThreads`) drives every `Table.
 `scheduleAuditCleanup` (`auditStore.ts`) and `Table.deleteHistory` (`Table.ts`, the LMDB path behind
 `delete_transaction_logs_before`) both iterate a range of audit records and remove each one. Both were
 originally written as `completion = removeAuditEntry(auditStore, auditRecord)` inside the loop, awaiting
-only the final iteration's promise afterward. Any rejection from a non-last iteration (e.g. a decode
-failure over a corrupt/misaligned entry) was silently discarded — the promise reference was overwritten
-before it could be awaited or caught — and surfaced later as an unhandled rejection instead. On Bun this
-killed the process a few seconds after the operation had already reported success, with no shutdown log
-line. Fixed independently in both places (`d6c64eaee`/`4ad7fdc94`/`1f7ddbedd` for `scheduleAuditCleanup`,
-harper#F-264 for `deleteHistory`) by awaiting and catching each removal inline. Any future loop that
-removes audit/primary-store entries in a batch must do the same — never stash a per-iteration promise in
-an outer variable to await only the last one.
+only the final iteration's promise afterward. Any rejection from a non-last iteration was silently
+discarded — the promise reference was overwritten before it could be awaited or caught — and surfaced
+later as an unhandled rejection instead, with no logging to explain it. Any loop that removes
+audit/primary-store entries in a batch must await (and catch) each removal inline — never stash a
+per-iteration promise in an outer variable to await only the last one.
+
+`removeAuditEntry` has a second, nested version of the same hazard: for a `'delete'`-type audit record it
+also invokes a per-table delete callback (`addDeleteRemovalCallback`) that removes the corresponding
+primary-store tombstone. That callback's promise must be returned and joined with the audit-store
+removal (currently via `Promise.all`, with the callback's own rejection caught and logged separately so
+a failed tombstone cleanup doesn't get misreported as a failed audit-entry removal) — otherwise the
+tombstone removal is fire-and-forget and the same detached-rejection hazard reappears one level down.
 
 ## `createBlob(readable)` and `table.put()` don't synchronously drain the source
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -124,12 +124,18 @@ later as an unhandled rejection instead, with no logging to explain it. Any loop
 audit/primary-store entries in a batch must attach a rejection handler to every removal immediately
 and drain all tracked promises before returning — never stash a per-iteration promise in an outer
 variable to await only the last one. `Table.deleteHistory` allows up to 1,000 LMDB removals in flight
-(ten for a non-versioned fallback store) so storage writes batch without growing an unbounded pending
+(ten for RocksDB) so storage writes batch without growing an unbounded pending
 set. Live removals are tracked in a `Set`, and each one removes itself and wakes at most one parked
 producer when it settles, so any completion releases the loop. In these removal loops, do not repeatedly
 race the live set: each race attaches another reaction to every long-pending removal. Both phases drain
 their tracked removals before settling, including when iteration throws. `scheduleAuditCleanup` remains
 sequential because it is an automatic background loop.
+
+The optional primary-store cleanup snapshots each tombstone's key and version before yielding and passes
+that version to `remove()`. LMDB enforces the condition natively. Harper's RocksDB adapter re-reads and
+removes inside one native transaction, retrying a conflict once, because rocksdb-js's `remove()` accepts
+an options object rather than an LMDB-style version argument. Never replace this with a separate live read
+followed by an unconditional remove: a record recreated between those operations would be deleted.
 
 `removeAuditEntry` has a second, nested version of the same hazard: for a `'delete'`-type audit record it
 also invokes a per-table delete callback (`addDeleteRemovalCallback`) that removes the corresponding

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -124,11 +124,11 @@ later as an unhandled rejection instead, with no logging to explain it. Any loop
 audit/primary-store entries in a batch must attach a rejection handler to every removal immediately
 and drain all tracked promises before returning — never stash a per-iteration promise in an outer
 variable to await only the last one. `Table.deleteHistory` allows up to ten removals in flight so
-storage writes overlap without growing an unbounded pending set. Its fixed promise slots are awaited
-before reuse; repeatedly racing the whole live set would accumulate another reaction on a long-pending
-removal each iteration. Slot reuse is round-robin, so one slow removal can temporarily idle later slots;
-writes against the same store ordinarily settle in order. `scheduleAuditCleanup` remains sequential
-because it is an automatic background loop.
+storage writes overlap without growing an unbounded pending set. Live removals are tracked in a `Set`,
+and each one removes itself and wakes at most one parked producer when it settles, so any completion
+releases the loop. Do not repeatedly race the live set: each race attaches another reaction to every
+long-pending removal. Both phases drain their tracked removals before settling, including when iteration
+throws. `scheduleAuditCleanup` remains sequential because it is an automatic background loop.
 
 `removeAuditEntry` has a second, nested version of the same hazard: for a `'delete'`-type audit record it
 also invokes a per-table delete callback (`addDeleteRemovalCallback`) that removes the corresponding

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -113,7 +113,7 @@ The cross-thread subscription path (default `crossThreads`) drives every `Table.
 - **`notifyScheduled` + `setImmediate`** in the `'committed'` listener defers the iteration off the commit microtask. Multiple `'committed'` events that land in the same event-loop turn collapse into one notify pass. `notifyScheduled` stays set for the entire drain — including across yield-and-resume turns — so a re-entry from a new `'committed'` event cannot spawn a second concurrent notify on the same iterator.
 - **Batched yielding** in `notifyFromTransactionData` (`NOTIFY_BATCH_SIZE`) is gated by `allowYield`. The `'committed'` path passes `allowYield = true`; the `listenToCommits` (same-thread `aftercommit`) path does not, because that path holds an inter-thread `'thread-local-writes'` lock that must not span event-loop turns. `subscribersWithTxns` is carried across yields via `subscriptions.pendingTxnSubscribers` so the `end_txn` signal fires exactly once when the iterator truly drains. When `activeCount` drops to zero mid-yield, the next continuation drops the carry-over to avoid invoking ended subscribers' listeners.
 
-## Audit-entry removal loops must await each `removeAuditEntry()`/`removeEntry()` call inline
+## Audit-entry removal loops must track every `removeAuditEntry()`/`removeEntry()` promise
 
 `scheduleAuditCleanup` (`auditStore.ts`) and `Table.deleteHistory` (`Table.ts`, the LMDB path behind
 `delete_transaction_logs_before`) both iterate a range of audit records and remove each one. Both were
@@ -121,8 +121,11 @@ originally written as `completion = removeAuditEntry(auditStore, auditRecord)` i
 only the final iteration's promise afterward. Any rejection from a non-last iteration was silently
 discarded — the promise reference was overwritten before it could be awaited or caught — and surfaced
 later as an unhandled rejection instead, with no logging to explain it. Any loop that removes
-audit/primary-store entries in a batch must await (and catch) each removal inline — never stash a
-per-iteration promise in an outer variable to await only the last one.
+audit/primary-store entries in a batch must attach a rejection handler to every removal immediately
+and drain all tracked promises before returning — never stash a per-iteration promise in an outer
+variable to await only the last one. `Table.deleteHistory` allows up to ten removals in flight so
+storage writes overlap without growing an unbounded pending set; `scheduleAuditCleanup` remains
+sequential because it is an automatic background loop.
 
 `removeAuditEntry` has a second, nested version of the same hazard: for a `'delete'`-type audit record it
 also invokes a per-table delete callback (`addDeleteRemovalCallback`) that removes the corresponding

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -126,8 +126,9 @@ and drain all tracked promises before returning — never stash a per-iteration 
 variable to await only the last one. `Table.deleteHistory` allows up to ten removals in flight so
 storage writes overlap without growing an unbounded pending set. Its fixed promise slots are awaited
 before reuse; repeatedly racing the whole live set would accumulate another reaction on a long-pending
-removal each iteration. `scheduleAuditCleanup` remains sequential because it is an automatic background
-loop.
+removal each iteration. Slot reuse is round-robin, so one slow removal can temporarily idle later slots;
+writes against the same store ordinarily settle in order. `scheduleAuditCleanup` remains sequential
+because it is an automatic background loop.
 
 `removeAuditEntry` has a second, nested version of the same hazard: for a `'delete'`-type audit record it
 also invokes a per-table delete callback (`addDeleteRemovalCallback`) that removes the corresponding

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -130,6 +130,9 @@ primary-store tombstone. That callback's promise must be returned and joined wit
 removal (currently via `Promise.all`, with the callback's own rejection caught and logged separately so
 a failed tombstone cleanup doesn't get misreported as a failed audit-entry removal) — otherwise the
 tombstone removal is fire-and-forget and the same detached-rejection hazard reappears one level down.
+A tombstone whose cleanup fails this way is not swept automatically — `scheduleAuditCleanup`'s automatic
+pass never retries it, since the audit entry that would have triggered a retry is already gone. It sits
+in the primary store until an operator runs `delete_transaction_logs_before` with `cleanup_deleted_records: true`.
 
 ## `createBlob(readable)` and `table.put()` don't synchronously drain the source
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -124,8 +124,10 @@ later as an unhandled rejection instead, with no logging to explain it. Any loop
 audit/primary-store entries in a batch must attach a rejection handler to every removal immediately
 and drain all tracked promises before returning — never stash a per-iteration promise in an outer
 variable to await only the last one. `Table.deleteHistory` allows up to ten removals in flight so
-storage writes overlap without growing an unbounded pending set; `scheduleAuditCleanup` remains
-sequential because it is an automatic background loop.
+storage writes overlap without growing an unbounded pending set. Its fixed promise slots are awaited
+before reuse; repeatedly racing the whole live set would accumulate another reaction on a long-pending
+removal each iteration. `scheduleAuditCleanup` remains sequential because it is an automatic background
+loop.
 
 `removeAuditEntry` has a second, nested version of the same hazard: for a `'delete'`-type audit record it
 also invokes a per-table delete callback (`addDeleteRemovalCallback`) that removes the corresponding

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -123,12 +123,13 @@ discarded — the promise reference was overwritten before it could be awaited o
 later as an unhandled rejection instead, with no logging to explain it. Any loop that removes
 audit/primary-store entries in a batch must attach a rejection handler to every removal immediately
 and drain all tracked promises before returning — never stash a per-iteration promise in an outer
-variable to await only the last one. `Table.deleteHistory` allows up to ten removals in flight so
-storage writes overlap without growing an unbounded pending set. Live removals are tracked in a `Set`,
-and each one removes itself and wakes at most one parked producer when it settles, so any completion
-releases the loop. Do not repeatedly race the live set: each race attaches another reaction to every
-long-pending removal. Both phases drain their tracked removals before settling, including when iteration
-throws. `scheduleAuditCleanup` remains sequential because it is an automatic background loop.
+variable to await only the last one. `Table.deleteHistory` allows up to 1,000 LMDB removals in flight
+(ten for a non-versioned fallback store) so storage writes batch without growing an unbounded pending
+set. Live removals are tracked in a `Set`, and each one removes itself and wakes at most one parked
+producer when it settles, so any completion releases the loop. In these removal loops, do not repeatedly
+race the live set: each race attaches another reaction to every long-pending removal. Both phases drain
+their tracked removals before settling, including when iteration throws. `scheduleAuditCleanup` remains
+sequential because it is an automatic background loop.
 
 `removeAuditEntry` has a second, nested version of the same hazard: for a `'delete'`-type audit record it
 also invokes a per-table delete callback (`addDeleteRemovalCallback`) that removes the corresponding

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -113,6 +113,20 @@ The cross-thread subscription path (default `crossThreads`) drives every `Table.
 - **`notifyScheduled` + `setImmediate`** in the `'committed'` listener defers the iteration off the commit microtask. Multiple `'committed'` events that land in the same event-loop turn collapse into one notify pass. `notifyScheduled` stays set for the entire drain — including across yield-and-resume turns — so a re-entry from a new `'committed'` event cannot spawn a second concurrent notify on the same iterator.
 - **Batched yielding** in `notifyFromTransactionData` (`NOTIFY_BATCH_SIZE`) is gated by `allowYield`. The `'committed'` path passes `allowYield = true`; the `listenToCommits` (same-thread `aftercommit`) path does not, because that path holds an inter-thread `'thread-local-writes'` lock that must not span event-loop turns. `subscribersWithTxns` is carried across yields via `subscriptions.pendingTxnSubscribers` so the `end_txn` signal fires exactly once when the iterator truly drains. When `activeCount` drops to zero mid-yield, the next continuation drops the carry-over to avoid invoking ended subscribers' listeners.
 
+## Audit-entry removal loops must await each `removeAuditEntry()`/`removeEntry()` call inline
+
+`scheduleAuditCleanup` (`auditStore.ts`) and `Table.deleteHistory` (`Table.ts`, the LMDB path behind
+`delete_transaction_logs_before`) both iterate a range of audit records and remove each one. Both were
+originally written as `completion = removeAuditEntry(auditStore, auditRecord)` inside the loop, awaiting
+only the final iteration's promise afterward. Any rejection from a non-last iteration (e.g. a decode
+failure over a corrupt/misaligned entry) was silently discarded — the promise reference was overwritten
+before it could be awaited or caught — and surfaced later as an unhandled rejection instead. On Bun this
+killed the process a few seconds after the operation had already reported success, with no shutdown log
+line. Fixed independently in both places (`d6c64eaee`/`4ad7fdc94`/`1f7ddbedd` for `scheduleAuditCleanup`,
+harper#F-264 for `deleteHistory`) by awaiting and catching each removal inline. Any future loop that
+removes audit/primary-store entries in a batch must do the same — never stash a per-iteration promise in
+an outer variable to await only the last one.
+
 ## `createBlob(readable)` and `table.put()` don't synchronously drain the source
 
 When a blob attribute is created from a Node `Readable` (e.g. `createBlob(stream)` then `row.payload_blob = blob; await table.put(row)`), the put does **not** wait for the underlying stream to fully drain into the file before resolving. Internally `saveBlob` kicks off a `writeBlobWithStream` pipeline whose `storageInfo.saving` promise is tracked separately. The put resolves once encoding has captured the blob reference; the bytes finish writing concurrently.

--- a/resources/PrimaryRocksDatabase.ts
+++ b/resources/PrimaryRocksDatabase.ts
@@ -43,7 +43,8 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 
 	// Match LMDB's remove(key, version) contract without splitting the version check from the delete.
 	async removeIfVersion(id: any, version: number): Promise<boolean> {
-		for (let attempt = 0; attempt < 2; attempt++) {
+		let retried = false;
+		while (true) {
 			let transaction: Transaction | undefined;
 			try {
 				transaction = new Transaction(this.store);
@@ -60,11 +61,11 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 				try {
 					transaction?.abort();
 				} catch {}
-				if (attempt === 0 && error?.code === 'ERR_BUSY') continue;
-				throw error;
+				// rocksdb-js reports a writer that committed between our read and our commit as ERR_BUSY
+				if (retried || error?.code !== 'ERR_BUSY') throw error;
+				retried = true;
 			}
 		}
-		throw new Error('Versioned removal exhausted its retries');
 	}
 
 	/**

--- a/resources/PrimaryRocksDatabase.ts
+++ b/resources/PrimaryRocksDatabase.ts
@@ -1,4 +1,4 @@
-import { RocksDatabase, type RocksDatabaseOptions, constants, type Store } from '@harperfast/rocksdb-js';
+import { RocksDatabase, type RocksDatabaseOptions, constants, type Store, Transaction } from '@harperfast/rocksdb-js';
 
 const FRESH_VERSION_FLAG = constants.FRESH_VERSION_FLAG;
 import { WeakLRUCache } from 'weak-lru-cache';
@@ -38,6 +38,30 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 		super(pathOrStore, enableCache ? { ...options, verificationTable: true } : options);
 		if (enableCache) {
 			this.#cache = new WeakLRUCache();
+		}
+	}
+
+	// Match LMDB's remove(key, version) contract without splitting the version check from the delete.
+	async removeIfVersion(id: any, version: number): Promise<boolean> {
+		for (let attempt = 0; attempt < 2; attempt++) {
+			const transaction = new Transaction(this.store);
+			try {
+				const entry = this.getEntry(id, { transaction });
+				if (!entry || entry.version !== version) {
+					transaction.abort();
+					return false;
+				}
+				this.#cache?.delete(id);
+				super.removeSync(id, { transaction });
+				await transaction.commit();
+				return true;
+			} catch (error: any) {
+				try {
+					transaction.abort();
+				} catch {}
+				if (attempt === 0 && error?.code === 'ERR_BUSY') continue;
+				throw error;
+			}
 		}
 	}
 

--- a/resources/PrimaryRocksDatabase.ts
+++ b/resources/PrimaryRocksDatabase.ts
@@ -44,9 +44,10 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 	// Match LMDB's remove(key, version) contract without splitting the version check from the delete.
 	async removeIfVersion(id: any, version: number): Promise<boolean> {
 		for (let attempt = 0; attempt < 2; attempt++) {
-			const transaction = new Transaction(this.store);
+			let transaction: Transaction | undefined;
 			try {
-				const entry = this.getEntry(id, { transaction });
+				transaction = new Transaction(this.store);
+				const entry = this.#processEntry(super.getSync(id, { transaction }), id);
 				if (!entry || entry.version !== version) {
 					transaction.abort();
 					return false;
@@ -57,12 +58,13 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 				return true;
 			} catch (error: any) {
 				try {
-					transaction.abort();
+					transaction?.abort();
 				} catch {}
 				if (attempt === 0 && error?.code === 'ERR_BUSY') continue;
 				throw error;
 			}
 		}
+		throw new Error('Versioned removal exhausted its retries');
 	}
 
 	/**

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5052,9 +5052,7 @@ export function makeTable(options) {
 			this.userSetEmbedders.add(attribute_name);
 		}
 		static async deleteHistory(endTime = 0, cleanupDeletedRecords = false): Promise<number> {
-			const maxConcurrentRemovals = primaryStore.useVersions
-				? MAX_CONCURRENT_LMDB_HISTORY_REMOVALS
-				: MAX_CONCURRENT_HISTORY_REMOVALS;
+			const maxConcurrentRemovals = isRocksDB ? MAX_CONCURRENT_HISTORY_REMOVALS : MAX_CONCURRENT_LMDB_HISTORY_REMOVALS;
 			const inFlightRemovals = new Set<Promise<void>>();
 			const removalSlotWaiters: Array<() => void> = [];
 			function startRemoval(remove: () => MaybePromise<void>, errorMessage: string, onSuccess?: () => void): void {
@@ -5109,7 +5107,7 @@ export function makeTable(options) {
 						await rest(); // yield to other async operations
 						if (value === null && localTime < endTime) {
 							const backpressure = queueRemoval(
-								() => primaryStore.remove(key, primaryStore.useVersions ? version : undefined),
+								() => primaryStore.remove(key, version),
 								'Error removing deleted record during deleteHistory'
 							);
 							if (backpressure) await backpressure;

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5055,9 +5055,24 @@ export function makeTable(options) {
 			const maxConcurrentRemovals = isRocksDB ? MAX_CONCURRENT_HISTORY_REMOVALS : MAX_CONCURRENT_LMDB_HISTORY_REMOVALS;
 			const inFlightRemovals = new Set<Promise<void>>();
 			const removalSlotWaiters: Array<() => void> = [];
+			let removalsAttempted = 0;
+			let removalsSucceeded = 0;
+			let firstRemovalError: unknown;
 			function startRemoval(remove: () => MaybePromise<void>, errorMessage: string, onSuccess?: () => void): void {
+				removalsAttempted++;
 				const removal = new Promise<void>((resolve) => resolve(remove()))
-					.then(onSuccess, (error) => harperLogger.warn(errorMessage, error))
+					.then(
+						() => {
+							removalsSucceeded++;
+							onSuccess?.();
+						},
+						(error) => {
+							// record before logging: a logger that throws must not cost us the only
+							// reference to why every removal failed
+							if (firstRemovalError === undefined) firstRemovalError = error;
+							harperLogger.warn(errorMessage, error);
+						}
+					)
 					.catch(() => undefined)
 					.finally(() => {
 						inFlightRemovals.delete(removal);
@@ -5116,6 +5131,13 @@ export function makeTable(options) {
 				} finally {
 					await drainRemovals();
 				}
+			}
+			if (removalsAttempted > 0 && removalsSucceeded === 0) {
+				// every removal we attempted failed, so this purge made no progress at all. Reporting
+				// success here would be indistinguishable from "nothing was eligible for removal", and an
+				// operator pruning to bound disk growth would never learn the store rejected every write.
+				// Partial failures stay best-effort (logged, and excluded from the returned count).
+				throw firstRemovalError ?? new Error('Every removal attempted during deleteHistory failed');
 			}
 			return entriesDeleted;
 		}

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5051,22 +5051,20 @@ export function makeTable(options) {
 			this.userSetEmbedders.add(attribute_name);
 		}
 		static async deleteHistory(endTime = 0, cleanupDeletedRecords = false): Promise<number> {
-			const inFlightRemovals = new Set<Promise<void>>();
+			const removalSlots = new Array<Promise<void>>(MAX_CONCURRENT_HISTORY_REMOVALS);
+			let nextRemovalSlot = 0;
 			async function queueRemoval(
 				remove: () => MaybePromise<void>,
 				errorMessage: string,
 				onSuccess?: () => void
 			): Promise<void> {
-				const removal = new Promise<void>((resolve) => resolve(remove()))
+				const slot = nextRemovalSlot++ % MAX_CONCURRENT_HISTORY_REMOVALS;
+				await removalSlots[slot];
+				removalSlots[slot] = new Promise<void>((resolve) => resolve(remove()))
 					.then(onSuccess, (error) => harperLogger.warn(errorMessage, error))
-					.catch(() => undefined)
-					.finally(() => inFlightRemovals.delete(removal));
-				inFlightRemovals.add(removal);
-				if (inFlightRemovals.size >= MAX_CONCURRENT_HISTORY_REMOVALS) {
-					await Promise.race(inFlightRemovals);
-				}
+					.catch(() => undefined);
 			}
-			const drainRemovals = () => Promise.all(inFlightRemovals);
+			const drainRemovals = () => Promise.all(removalSlots);
 			let entriesDeleted = 0;
 			for (const auditRecord of auditStore.getRange({
 				start: 0,

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5059,6 +5059,7 @@ export function makeTable(options) {
 			): Promise<void> {
 				const removal = new Promise<void>((resolve) => resolve(remove()))
 					.then(onSuccess, (error) => harperLogger.warn(errorMessage, error))
+					.catch(() => undefined)
 					.finally(() => inFlightRemovals.delete(removal));
 				inFlightRemovals.add(removal);
 				if (inFlightRemovals.size >= MAX_CONCURRENT_HISTORY_REMOVALS) {

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5105,7 +5105,7 @@ export function makeTable(options) {
 					for (const entry of primaryStore.getRange({ start: 0, versions: true })) {
 						const { key, value, localTime, version } = entry;
 						await rest(); // yield to other async operations
-						if (value === null && localTime < endTime) {
+						if (value === null && version != null && localTime < endTime) {
 							const backpressure = queueRemoval(
 								() => primaryStore.remove(key, version),
 								'Error removing deleted record during deleteHistory'

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5051,50 +5051,69 @@ export function makeTable(options) {
 			this.userSetEmbedders.add(attribute_name);
 		}
 		static async deleteHistory(endTime = 0, cleanupDeletedRecords = false): Promise<number> {
-			const removalSlots = new Array<Promise<void>>(MAX_CONCURRENT_HISTORY_REMOVALS);
-			let nextRemovalSlot = 0;
-			async function queueRemoval(
+			const inFlightRemovals = new Set<Promise<void>>();
+			const removalSlotWaiters: Array<() => void> = [];
+			function startRemoval(remove: () => MaybePromise<void>, errorMessage: string, onSuccess?: () => void): void {
+				const removal = new Promise<void>((resolve) => resolve(remove()))
+					.then(onSuccess, (error) => harperLogger.warn(errorMessage, error))
+					.catch(() => undefined)
+					.finally(() => {
+						inFlightRemovals.delete(removal);
+						removalSlotWaiters.shift()?.();
+					});
+				inFlightRemovals.add(removal);
+			}
+			function queueRemoval(
 				remove: () => MaybePromise<void>,
 				errorMessage: string,
 				onSuccess?: () => void
-			): Promise<void> {
-				const slot = nextRemovalSlot++ % MAX_CONCURRENT_HISTORY_REMOVALS;
-				await removalSlots[slot];
-				removalSlots[slot] = new Promise<void>((resolve) => resolve(remove()))
-					.then(onSuccess, (error) => harperLogger.warn(errorMessage, error))
-					.catch(() => undefined);
+			): Promise<void> | undefined {
+				if (inFlightRemovals.size >= MAX_CONCURRENT_HISTORY_REMOVALS) {
+					return new Promise<void>((resolve) => {
+						removalSlotWaiters.push(resolve);
+					}).then(() => startRemoval(remove, errorMessage, onSuccess));
+				}
+				startRemoval(remove, errorMessage, onSuccess);
 			}
-			const drainRemovals = () => Promise.all(removalSlots);
+			const drainRemovals = () => Promise.all(inFlightRemovals);
 			let entriesDeleted = 0;
-			for (const auditRecord of auditStore.getRange({
-				start: 0,
-				end: endTime,
-			})) {
-				await rest(); // yield to other async operations
-				if (auditRecord.tableId !== tableId) continue;
-				await queueRemoval(
-					() => removeAuditEntry(auditStore, auditRecord),
-					'Error removing audit entry during deleteHistory',
-					() => {
-						entriesDeleted++;
-					}
-				);
+			try {
+				for (const auditRecord of auditStore.getRange({
+					start: 0,
+					end: endTime,
+				})) {
+					await rest(); // yield to other async operations
+					if (auditRecord.tableId !== tableId) continue;
+					const backpressure = queueRemoval(
+						() => removeAuditEntry(auditStore, auditRecord),
+						'Error removing audit entry during deleteHistory',
+						() => {
+							entriesDeleted++;
+						}
+					);
+					if (backpressure) await backpressure;
+				}
+			} finally {
+				await drainRemovals();
 			}
-			await drainRemovals();
 			if (cleanupDeletedRecords) {
 				// this is separate procedure we can do if the records are not being cleaned up by the audit log. This shouldn't
 				// ever happen, but if there are cleanup failures for some reason, we can run this to clean up the records
-				for (const entry of primaryStore.getRange({ start: 0, versions: true })) {
-					const { key, value, localTime, version } = entry;
-					await rest(); // yield to other async operations
-					if (value === null && localTime < endTime) {
-						await queueRemoval(
-							() => primaryStore.remove(key, primaryStore.useVersions ? version : undefined),
-							'Error removing deleted record during deleteHistory'
-						);
+				try {
+					for (const entry of primaryStore.getRange({ start: 0, versions: true })) {
+						const { key, value, localTime, version } = entry;
+						await rest(); // yield to other async operations
+						if (value === null && localTime < endTime) {
+							const backpressure = queueRemoval(
+								() => primaryStore.remove(key, primaryStore.useVersions ? version : undefined),
+								'Error removing deleted record during deleteHistory'
+							);
+							if (backpressure) await backpressure;
+						}
 					}
+				} finally {
+					await drainRemovals();
 				}
-				await drainRemovals();
 			}
 			return entriesDeleted;
 		}

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -120,6 +120,7 @@ const NULL_WITH_TIMESTAMP = new Uint8Array(9);
 NULL_WITH_TIMESTAMP[8] = 0xc0; // null
 const UNCACHEABLE_TIMESTAMP = Infinity; // we use this when dynamic content is accessed that we can't safely cache, and this prevents earlier timestamps from change the "last" modification
 const RECORD_PRUNING_INTERVAL = 60000; // one minute
+const MAX_CONCURRENT_HISTORY_REMOVALS = 10;
 // RocksDB-only: number of eviction/tombstone removals coalesced into a single transaction commit.
 // Each evict otherwise pays a full transaction commit, so batching amortizes that cost. LMDB already
 // coalesces async writes per event turn (eventTurnBatching), so it keeps the per-record path.
@@ -5050,6 +5051,21 @@ export function makeTable(options) {
 			this.userSetEmbedders.add(attribute_name);
 		}
 		static async deleteHistory(endTime = 0, cleanupDeletedRecords = false): Promise<number> {
+			const inFlightRemovals = new Set<Promise<void>>();
+			async function queueRemoval(
+				remove: () => MaybePromise<void>,
+				errorMessage: string,
+				onSuccess?: () => void
+			): Promise<void> {
+				const removal = new Promise<void>((resolve) => resolve(remove()))
+					.then(onSuccess, (error) => harperLogger.warn(errorMessage, error))
+					.finally(() => inFlightRemovals.delete(removal));
+				inFlightRemovals.add(removal);
+				if (inFlightRemovals.size >= MAX_CONCURRENT_HISTORY_REMOVALS) {
+					await Promise.race(inFlightRemovals);
+				}
+			}
+			const drainRemovals = () => Promise.all(inFlightRemovals);
 			let entriesDeleted = 0;
 			for (const auditRecord of auditStore.getRange({
 				start: 0,
@@ -5057,13 +5073,15 @@ export function makeTable(options) {
 			})) {
 				await rest(); // yield to other async operations
 				if (auditRecord.tableId !== tableId) continue;
-				try {
-					await removeAuditEntry(auditStore, auditRecord);
-					entriesDeleted++;
-				} catch (error) {
-					harperLogger.warn('Error removing audit entry during deleteHistory', error);
-				}
+				await queueRemoval(
+					() => removeAuditEntry(auditStore, auditRecord),
+					'Error removing audit entry during deleteHistory',
+					() => {
+						entriesDeleted++;
+					}
+				);
 			}
+			await drainRemovals();
 			if (cleanupDeletedRecords) {
 				// this is separate procedure we can do if the records are not being cleaned up by the audit log. This shouldn't
 				// ever happen, but if there are cleanup failures for some reason, we can run this to clean up the records
@@ -5071,13 +5089,13 @@ export function makeTable(options) {
 					const { value, localTime } = entry;
 					await rest(); // yield to other async operations
 					if (value === null && localTime < endTime) {
-						try {
-							await removeEntry(primaryStore, entry);
-						} catch (error) {
-							harperLogger.warn('Error removing deleted record during deleteHistory', error);
-						}
+						await queueRemoval(
+							() => removeEntry(primaryStore, entry),
+							'Error removing deleted record during deleteHistory'
+						);
 					}
 				}
+				await drainRemovals();
 			}
 			return entriesDeleted;
 		}

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5050,7 +5050,6 @@ export function makeTable(options) {
 			this.userSetEmbedders.add(attribute_name);
 		}
 		static async deleteHistory(endTime = 0, cleanupDeletedRecords = false): Promise<number> {
-			let completion: Promise<void>;
 			let entriesDeleted = 0;
 			for (const auditRecord of auditStore.getRange({
 				start: 0,
@@ -5058,7 +5057,14 @@ export function makeTable(options) {
 			})) {
 				await rest(); // yield to other async operations
 				if (auditRecord.tableId !== tableId) continue;
-				completion = removeAuditEntry(auditStore, auditRecord);
+				try {
+					// awaited so a rejection is caught here instead of escaping as an unhandled
+					// rejection once a later iteration's promise replaces this one (see auditStore.ts
+					// scheduleAuditCleanup for the same fix)
+					await removeAuditEntry(auditStore, auditRecord);
+				} catch (error) {
+					harperLogger.warn('Error removing audit entry during deleteHistory', error);
+				}
 				entriesDeleted++;
 			}
 			if (cleanupDeletedRecords) {
@@ -5068,11 +5074,14 @@ export function makeTable(options) {
 					const { value, localTime } = entry;
 					await rest(); // yield to other async operations
 					if (value === null && localTime < endTime) {
-						completion = removeEntry(primaryStore, entry);
+						try {
+							await removeEntry(primaryStore, entry);
+						} catch (error) {
+							harperLogger.warn('Error removing deleted record during deleteHistory', error);
+						}
 					}
 				}
 			}
-			await completion;
 			return entriesDeleted;
 		}
 		static async *getHistory(startTime = 0, endTime = Infinity) {

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5067,8 +5067,7 @@ export function makeTable(options) {
 							onSuccess?.();
 						},
 						(error) => {
-							// record before logging: a logger that throws must not cost us the only
-							// reference to why every removal failed
+							// capture before logging: a throwing logger must not cost us the error we may rethrow
 							if (firstRemovalError === undefined) firstRemovalError = error;
 							harperLogger.warn(errorMessage, error);
 						}
@@ -5133,10 +5132,8 @@ export function makeTable(options) {
 				}
 			}
 			if (removalsAttempted > 0 && removalsSucceeded === 0) {
-				// every removal we attempted failed, so this purge made no progress at all. Reporting
-				// success here would be indistinguishable from "nothing was eligible for removal", and an
-				// operator pruning to bound disk growth would never learn the store rejected every write.
-				// Partial failures stay best-effort (logged, and excluded from the returned count).
+				// zero progress must not report the same success as "nothing was eligible" (see DESIGN.md);
+				// partial failures stay best-effort, logged and excluded from the returned count
 				throw firstRemovalError ?? new Error('Every removal attempted during deleteHistory failed');
 			}
 			return entriesDeleted;

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5058,14 +5058,11 @@ export function makeTable(options) {
 				await rest(); // yield to other async operations
 				if (auditRecord.tableId !== tableId) continue;
 				try {
-					// awaited so a rejection is caught here instead of escaping as an unhandled
-					// rejection once a later iteration's promise replaces this one (see auditStore.ts
-					// scheduleAuditCleanup for the same fix)
 					await removeAuditEntry(auditStore, auditRecord);
+					entriesDeleted++;
 				} catch (error) {
 					harperLogger.warn('Error removing audit entry during deleteHistory', error);
 				}
-				entriesDeleted++;
 			}
 			if (cleanupDeletedRecords) {
 				// this is separate procedure we can do if the records are not being cleaned up by the audit log. This shouldn't
@@ -6230,7 +6227,7 @@ export function makeTable(options) {
 	}
 	function addDeleteRemoval() {
 		deleteCallbackHandle = auditStore?.addDeleteRemovalCallback(tableId, primaryStore, (id: Id, version: number) => {
-			primaryStore.remove(id, version);
+			return primaryStore.remove(id, version);
 		});
 	}
 	function runRecordExpirationEviction() {

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5085,11 +5085,11 @@ export function makeTable(options) {
 				// this is separate procedure we can do if the records are not being cleaned up by the audit log. This shouldn't
 				// ever happen, but if there are cleanup failures for some reason, we can run this to clean up the records
 				for (const entry of primaryStore.getRange({ start: 0, versions: true })) {
-					const { value, localTime } = entry;
+					const { key, value, localTime, version } = entry;
 					await rest(); // yield to other async operations
 					if (value === null && localTime < endTime) {
 						await queueRemoval(
-							() => removeEntry(primaryStore, entry),
+							() => primaryStore.remove(key, primaryStore.useVersions ? version : undefined),
 							'Error removing deleted record during deleteHistory'
 						);
 					}

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -121,6 +121,7 @@ NULL_WITH_TIMESTAMP[8] = 0xc0; // null
 const UNCACHEABLE_TIMESTAMP = Infinity; // we use this when dynamic content is accessed that we can't safely cache, and this prevents earlier timestamps from change the "last" modification
 const RECORD_PRUNING_INTERVAL = 60000; // one minute
 const MAX_CONCURRENT_HISTORY_REMOVALS = 10;
+const MAX_CONCURRENT_LMDB_HISTORY_REMOVALS = 1000;
 // RocksDB-only: number of eviction/tombstone removals coalesced into a single transaction commit.
 // Each evict otherwise pays a full transaction commit, so batching amortizes that cost. LMDB already
 // coalesces async writes per event turn (eventTurnBatching), so it keeps the per-record path.
@@ -5051,6 +5052,9 @@ export function makeTable(options) {
 			this.userSetEmbedders.add(attribute_name);
 		}
 		static async deleteHistory(endTime = 0, cleanupDeletedRecords = false): Promise<number> {
+			const maxConcurrentRemovals = primaryStore.useVersions
+				? MAX_CONCURRENT_LMDB_HISTORY_REMOVALS
+				: MAX_CONCURRENT_HISTORY_REMOVALS;
 			const inFlightRemovals = new Set<Promise<void>>();
 			const removalSlotWaiters: Array<() => void> = [];
 			function startRemoval(remove: () => MaybePromise<void>, errorMessage: string, onSuccess?: () => void): void {
@@ -5068,7 +5072,7 @@ export function makeTable(options) {
 				errorMessage: string,
 				onSuccess?: () => void
 			): Promise<void> | undefined {
-				if (inFlightRemovals.size >= MAX_CONCURRENT_HISTORY_REMOVALS) {
+				if (inFlightRemovals.size >= maxConcurrentRemovals) {
 					return new Promise<void>((resolve) => {
 						removalSlotWaiters.push(resolve);
 					}).then(() => startRemoval(remove, errorMessage, onSuccess));

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -284,21 +284,16 @@ export function removeAuditEntry(auditStore: any, auditRecord: AuditRecord): Pro
 		// at the same time so the audit table the primary table are in sync, assuming the entry matches this audit record version
 		const tableId = auditRecord.tableId;
 		const primaryStore = auditStore.tableStores[auditRecord.tableId];
-		if (primaryStore?.getEntry(auditRecord.recordId)?.version === auditRecord.version) {
-			try {
-				// a failed tombstone removal (sync throw or rejection) doesn't mean the audit entry
-				// removal failed — only auditStore.remove() below decides this function's outcome;
-				// the .catch is attached here, before anything else can throw synchronously, so this
-				// promise is never left without a handler
-				tombstoneRemoval = Promise.resolve(
-					auditStore.deleteCallbacks?.[tableId]?.(auditRecord.recordId, auditRecord.version)
-				).catch((error) => {
-					harperLogger.warn('Error removing deleted record while removing its audit entry', error);
-				});
-			} catch (error) {
+		if (primaryStore?.getEntry(auditRecord.recordId)?.version === auditRecord.version)
+			// a failed tombstone removal (sync throw or rejection) doesn't mean the audit entry removal
+			// failed — only auditStore.remove() below decides this function's outcome. The executor here
+			// catches a synchronous throw from the callback the same way `.catch` catches a rejection, in
+			// one handler, so this promise is never left without one attached
+			tombstoneRemoval = new Promise<void>((resolve) => {
+				resolve(auditStore.deleteCallbacks?.[tableId]?.(auditRecord.recordId, auditRecord.version));
+			}).catch((error) => {
 				harperLogger.warn('Error removing deleted record while removing its audit entry', error);
-			}
-		}
+			});
 	}
 	const auditRemoval = auditStore.remove(auditRecord.key);
 	return tombstoneRemoval ? Promise.all([tombstoneRemoval, auditRemoval]).then(() => undefined) : auditRemoval;

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -285,10 +285,8 @@ export function removeAuditEntry(auditStore: any, auditRecord: AuditRecord): Pro
 		const tableId = auditRecord.tableId;
 		const primaryStore = auditStore.tableStores[auditRecord.tableId];
 		if (primaryStore?.getEntry(auditRecord.recordId)?.version === auditRecord.version)
-			// a failed tombstone removal (sync throw or rejection) doesn't mean the audit entry removal
-			// failed — only auditStore.remove() below decides this function's outcome. The executor here
-			// catches a synchronous throw from the callback the same way `.catch` catches a rejection, in
-			// one handler, so this promise is never left without one attached
+			// a failed tombstone removal doesn't mean the audit entry removal failed — only
+			// auditStore.remove() below decides this function's outcome
 			tombstoneRemoval = new Promise<void>((resolve) => {
 				resolve(auditStore.deleteCallbacks?.[tableId]?.(auditRecord.recordId, auditRecord.version));
 			}).catch((error) => {

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -278,23 +278,30 @@ export function openAuditStore(rootStore) {
 }
 
 export function removeAuditEntry(auditStore: any, auditRecord: AuditRecord): Promise<void> {
-	let deleteCallbackResult: any;
+	let tombstoneRemoval: Promise<void> | undefined;
 	if (auditRecord.type === 'delete') {
 		// if this is a delete, we remove the delete entry from the primary table
 		// at the same time so the audit table the primary table are in sync, assuming the entry matches this audit record version
 		const tableId = auditRecord.tableId;
 		const primaryStore = auditStore.tableStores[auditRecord.tableId];
-		if (primaryStore?.getEntry(auditRecord.recordId)?.version === auditRecord.version)
-			deleteCallbackResult = auditStore.deleteCallbacks?.[tableId]?.(auditRecord.recordId, auditRecord.version);
+		if (primaryStore?.getEntry(auditRecord.recordId)?.version === auditRecord.version) {
+			try {
+				// a failed tombstone removal (sync throw or rejection) doesn't mean the audit entry
+				// removal failed — only auditStore.remove() below decides this function's outcome;
+				// the .catch is attached here, before anything else can throw synchronously, so this
+				// promise is never left without a handler
+				tombstoneRemoval = Promise.resolve(
+					auditStore.deleteCallbacks?.[tableId]?.(auditRecord.recordId, auditRecord.version)
+				).catch((error) => {
+					harperLogger.warn('Error removing deleted record while removing its audit entry', error);
+				});
+			} catch (error) {
+				harperLogger.warn('Error removing deleted record while removing its audit entry', error);
+			}
+		}
 	}
 	const auditRemoval = auditStore.remove(auditRecord.key);
-	if (!deleteCallbackResult) return auditRemoval;
-	// a failed tombstone removal doesn't mean the audit entry removal failed — it just leaves an
-	// orphaned primary-store record for the cleanupDeletedRecords fallback sweep to catch later
-	const tombstoneRemoval = Promise.resolve(deleteCallbackResult).catch((error) => {
-		harperLogger.warn('Error removing deleted record while removing its audit entry', error);
-	});
-	return Promise.all([tombstoneRemoval, auditRemoval]).then(() => undefined);
+	return tombstoneRemoval ? Promise.all([tombstoneRemoval, auditRemoval]).then(() => undefined) : auditRemoval;
 }
 
 function updateLastRemoved(auditStore, lastKey) {

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -288,8 +288,13 @@ export function removeAuditEntry(auditStore: any, auditRecord: AuditRecord): Pro
 			deleteCallbackResult = auditStore.deleteCallbacks?.[tableId]?.(auditRecord.recordId, auditRecord.version);
 	}
 	const auditRemoval = auditStore.remove(auditRecord.key);
-	// a caller awaiting only auditRemoval would leave a rejected deleteCallbackResult detached
-	return deleteCallbackResult ? Promise.all([deleteCallbackResult, auditRemoval]).then(() => undefined) : auditRemoval;
+	if (!deleteCallbackResult) return auditRemoval;
+	// a failed tombstone removal doesn't mean the audit entry removal failed — it just leaves an
+	// orphaned primary-store record for the cleanupDeletedRecords fallback sweep to catch later
+	const tombstoneRemoval = Promise.resolve(deleteCallbackResult).catch((error) => {
+		harperLogger.warn('Error removing deleted record while removing its audit entry', error);
+	});
+	return Promise.all([tombstoneRemoval, auditRemoval]).then(() => undefined);
 }
 
 function updateLastRemoved(auditStore, lastKey) {

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -278,15 +278,18 @@ export function openAuditStore(rootStore) {
 }
 
 export function removeAuditEntry(auditStore: any, auditRecord: AuditRecord): Promise<void> {
+	let deleteCallbackResult: any;
 	if (auditRecord.type === 'delete') {
 		// if this is a delete, we remove the delete entry from the primary table
 		// at the same time so the audit table the primary table are in sync, assuming the entry matches this audit record version
 		const tableId = auditRecord.tableId;
 		const primaryStore = auditStore.tableStores[auditRecord.tableId];
 		if (primaryStore?.getEntry(auditRecord.recordId)?.version === auditRecord.version)
-			auditStore.deleteCallbacks?.[tableId]?.(auditRecord.recordId, auditRecord.version);
+			deleteCallbackResult = auditStore.deleteCallbacks?.[tableId]?.(auditRecord.recordId, auditRecord.version);
 	}
-	return auditStore.remove(auditRecord.key);
+	const auditRemoval = auditStore.remove(auditRecord.key);
+	// a caller awaiting only auditRemoval would leave a rejected deleteCallbackResult detached
+	return deleteCallbackResult ? Promise.all([deleteCallbackResult, auditRemoval]).then(() => undefined) : auditRemoval;
 }
 
 function updateLastRemoved(auditStore, lastKey) {

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -228,7 +228,8 @@ function openRocksDatabase(path: string, options: RocksDatabaseOptions & { dupSo
 	} else {
 		db = new PrimaryRocksDatabase(path, options).open() as unknown as RocksRootDatabase;
 		// the RocksDB put and remove return promises, which masks thrown errors in non-awaiting calls to put/remove,
-		// making them unsafe to replace LMDB methods, which will synchronously throw errors if there is a problem
+		// making them unsafe to replace LMDB methods, which will synchronously throw errors if there is a problem.
+		// The versioned remove is necessarily async and its callers must await or otherwise track its promise.
 		db.put = db.putSync as any;
 		db.remove = ((id: any, removeOptions?: any) =>
 			typeof removeOptions === 'number'

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -230,7 +230,10 @@ function openRocksDatabase(path: string, options: RocksDatabaseOptions & { dupSo
 		// the RocksDB put and remove return promises, which masks thrown errors in non-awaiting calls to put/remove,
 		// making them unsafe to replace LMDB methods, which will synchronously throw errors if there is a problem
 		db.put = db.putSync as any;
-		db.remove = db.removeSync as any;
+		db.remove = ((id: any, removeOptions?: any) =>
+			typeof removeOptions === 'number'
+				? (db as unknown as PrimaryRocksDatabase).removeIfVersion(id, removeOptions)
+				: db.removeSync(id, removeOptions)) as any;
 		(db.encoder as any).name = options.name;
 	}
 	db.env = {};

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -105,7 +105,10 @@ describe('Audit log', () => {
 	});
 	// Regression test for harper#F-264 (see DESIGN.md's audit-entry-removal-loop invariant).
 	it('deleteHistory does not let a mid-loop removeAuditEntry rejection escape as an unhandled rejection', async function () {
-		if (AuditedTable.auditStore.reusableIterable) return; // rocksdb doesn't use deleteHistory (see ResourceBridge.deleteTransactionLogsBefore)
+		// rocksdb doesn't use deleteHistory (see ResourceBridge.deleteTransactionLogsBefore); this.skip()
+		// (rather than a bare return, as the file's other reusableIterable guards use) so the report
+		// distinguishes "skipped on this engine" from "passed"
+		if (AuditedTable.auditStore.reusableIterable) return this.skip();
 		await AuditedTable.deleteHistory(Date.now() + 60_000); // start from a clean backlog
 
 		await AuditedTable.put(30, { name: 'race-a' });

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -353,6 +353,29 @@ describe('Audit log', () => {
 			await AuditedTable.deleteHistory(Date.now() + 60_000, true);
 		}
 	});
+	it('RocksDB versioned removal preserves a record recreated after its tombstone', async function () {
+		if (!AuditedTable.primaryStore.isPrimaryRocksDatabase) return this.skip();
+		const recordId = 'rocks-cleanup-race';
+		try {
+			await AuditedTable.put(recordId, { name: 'deleted' });
+			await AuditedTable.delete(recordId);
+			const tombstone = AuditedTable.primaryStore.getEntry(recordId);
+			assert.equal(tombstone?.value, null, 'test setup: expected a tombstone');
+
+			await AuditedTable.put(recordId, { name: 'recreated' });
+			assert.equal(
+				await AuditedTable.primaryStore.remove(recordId, tombstone.version),
+				false,
+				'a stale conditional removal must not commit'
+			);
+			const recreated = AuditedTable.primaryStore.getEntry(recordId);
+			assert.equal(recreated?.value?.name, 'recreated');
+			assert.equal(await AuditedTable.primaryStore.remove(recordId, recreated.version), true);
+			assert.equal(AuditedTable.primaryStore.getEntry(recordId), undefined);
+		} finally {
+			await AuditedTable.primaryStore.remove(recordId);
+		}
+	});
 	it('deleteHistory waits for the table-registered tombstone removal callback', async function () {
 		if (AuditedTable.auditStore.reusableIterable) return this.skip();
 		await AuditedTable.deleteHistory(Date.now() + 60_000);

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -228,6 +228,109 @@ describe('Audit log', () => {
 			await AuditedTable.deleteHistory(Date.now() + 60_000);
 		}
 	});
+	async function createOrphanedTombstone(recordId) {
+		await AuditedTable.put(recordId, { name: 'deleted' });
+		await AuditedTable.delete(recordId);
+		const auditKeys = [];
+		for (const record of AuditedTable.auditStore.getRange({ start: 0, end: Infinity })) {
+			if (record.tableId === AuditedTable.tableId && record.recordId === recordId) auditKeys.push(record.key);
+		}
+		assert.equal(auditKeys.length, 2, 'test setup: expected put and delete audit entries');
+		for (const key of auditKeys) await AuditedTable.auditStore.remove(key);
+		assert.equal(
+			Array.from(AuditedTable.auditStore.getRange({ start: 0, end: Infinity })).some(
+				(record) => record.tableId === AuditedTable.tableId && record.recordId === recordId
+			),
+			false,
+			'test setup: expected the audit entries to be removed'
+		);
+		const tombstone = AuditedTable.primaryStore.getEntry(recordId);
+		assert.equal(tombstone?.value, null, 'test setup: expected an orphaned tombstone');
+		return tombstone;
+	}
+	it('deleteHistory cleanup removes an unchanged orphaned tombstone', async function () {
+		if (AuditedTable.auditStore.reusableIterable) return this.skip();
+		const cutoff = Date.now() + 60_000;
+		await AuditedTable.deleteHistory(cutoff, true);
+		const recordId = 'cleanup-unraced';
+		try {
+			await createOrphanedTombstone(recordId);
+			await AuditedTable.deleteHistory(cutoff, true);
+			assert.equal(AuditedTable.primaryStore.getEntry(recordId), undefined);
+		} finally {
+			await AuditedTable.delete(recordId).catch(() => {});
+			await AuditedTable.deleteHistory(Date.now() + 60_000, true);
+		}
+	});
+	it('deleteHistory cleanup preserves a record recreated while its stale tombstone waits for a slot', async function () {
+		if (AuditedTable.auditStore.reusableIterable) return this.skip();
+		const cutoff = Date.now() + 60_000;
+		await AuditedTable.deleteHistory(cutoff, true);
+
+		const recordId = 'cleanup-race';
+		const tombstone = await createOrphanedTombstone(recordId);
+
+		const primaryStore = AuditedTable.primaryStore;
+		const originalRemove = primaryStore.remove;
+		const removeWasOwnProperty = Object.hasOwn(primaryStore, 'remove');
+		let markRemovalStarted;
+		const removalStarted = new Promise((resolve) => {
+			markRemovalStarted = resolve;
+		});
+		let releaseImmediately = false;
+		let releaseRemoval;
+		let removalVersion;
+		let removalResult;
+		primaryStore.remove = function (id, version) {
+			if (id !== recordId || releaseImmediately) return originalRemove.call(this, id, version);
+			removalVersion = version;
+			return new Promise((resolve, reject) => {
+				let released = false;
+				releaseRemoval = () => {
+					if (released) return;
+					released = true;
+					return Promise.resolve(originalRemove.call(this, id, version)).then((result) => {
+						removalResult = result;
+						resolve(result);
+					}, reject);
+				};
+				markRemovalStarted();
+			});
+		};
+
+		let deletion;
+		try {
+			deletion = AuditedTable.deleteHistory(cutoff, true);
+			let removalTimeout;
+			try {
+				await Promise.race([
+					removalStarted,
+					deletion.then((entriesDeleted) => {
+						throw new Error(`deleteHistory resolved before cleanup removal started: ${entriesDeleted} entries`);
+					}),
+					new Promise((resolve, reject) => {
+						removalTimeout = setTimeout(() => reject(new Error('cleanup removal did not start')), 5000);
+					}),
+				]);
+			} finally {
+				clearTimeout(removalTimeout);
+			}
+			await AuditedTable.put(recordId, { name: 'recreated' });
+			releaseRemoval();
+			await deletion;
+			assert.equal(removalVersion, tombstone.version);
+			assert.equal(removalResult, false, 'the stale conditional removal must not commit');
+			assert.equal(AuditedTable.primaryStore.getEntry(recordId)?.value?.name, 'recreated');
+		} finally {
+			releaseImmediately = true;
+			releaseRemoval?.();
+			await deletion?.catch(() => {});
+			if (removeWasOwnProperty) primaryStore.remove = originalRemove;
+			else delete primaryStore.remove;
+			await AuditedTable.delete(recordId).catch(() => {});
+			await AuditedTable.deleteHistory(Date.now() + 60_000, true);
+		}
+	});
 	it('deleteHistory waits for the table-registered tombstone removal callback', async function () {
 		if (AuditedTable.auditStore.reusableIterable) return this.skip();
 		await AuditedTable.deleteHistory(Date.now() + 60_000);

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -228,6 +228,78 @@ describe('Audit log', () => {
 			await AuditedTable.deleteHistory(Date.now() + 60_000);
 		}
 	});
+	it('deleteHistory waits for the table-registered tombstone removal callback', async function () {
+		if (AuditedTable.auditStore.reusableIterable) return this.skip();
+		await AuditedTable.deleteHistory(Date.now() + 60_000);
+
+		const recordId = 60;
+		await AuditedTable.put(recordId, { name: 'joined-tombstone-removal' });
+		await AuditedTable.delete(recordId);
+		const registeredPrimaryStore = AuditedTable.auditStore.tableStores[AuditedTable.tableId];
+		const tombstone = registeredPrimaryStore.getEntry(recordId);
+		assert.equal(tombstone?.value, null);
+		const deleteAuditRecords = [];
+		for (const record of AuditedTable.auditStore.getRange({ start: 0, end: Infinity })) {
+			if (record.tableId === AuditedTable.tableId && record.recordId === recordId && record.type === 'delete') {
+				deleteAuditRecords.push(record);
+			}
+		}
+		assert.equal(deleteAuditRecords.length, 1);
+		assert.equal(tombstone.version, deleteAuditRecords[0].version);
+		assert.equal(typeof AuditedTable.auditStore.deleteCallbacks?.[AuditedTable.tableId], 'function');
+
+		const originalRemove = registeredPrimaryStore.remove;
+		let releaseTombstoneRemoval;
+		let markTombstoneRemovalStarted;
+		const tombstoneRemovalStarted = new Promise((resolve) => {
+			markTombstoneRemovalStarted = resolve;
+		});
+		const tombstoneRemovalGate = new Promise((resolve) => {
+			releaseTombstoneRemoval = resolve;
+		});
+		const heldRemove = async function (id, version) {
+			markTombstoneRemovalStarted({ id, version });
+			if (id !== recordId) return originalRemove.call(this, id, version);
+			await tombstoneRemovalGate;
+			return originalRemove.call(this, id, version);
+		};
+		registeredPrimaryStore.remove = heldRemove;
+		assert.equal(registeredPrimaryStore.remove, heldRemove);
+
+		let deletion;
+		try {
+			deletion = AuditedTable.deleteHistory(Date.now() + 60_000);
+			const callback = await Promise.race([
+				tombstoneRemovalStarted,
+				deletion.then((entriesDeleted) => {
+					throw new Error(
+						`deleteHistory resolved before invoking the registered callback: ${entriesDeleted} entries, tombstone=${String(
+							AuditedTable.primaryStore.getEntry(recordId)?.value
+						)}`
+					);
+				}),
+				delay(2000).then(() => {
+					throw new Error('table-registered tombstone removal callback did not start');
+				}),
+			]);
+			assert.equal(callback.id, recordId);
+			const state = await Promise.race([deletion.then(() => 'resolved'), delay(50, 'pending')]);
+			assert.equal(state, 'pending', 'deleteHistory must join the registered tombstone removal callback');
+
+			releaseTombstoneRemoval();
+			assert.equal(await deletion, 2);
+			assert.equal(
+				AuditedTable.primaryStore.getEntry(recordId),
+				undefined,
+				'the tombstone must be gone when deleteHistory resolves'
+			);
+		} finally {
+			releaseTombstoneRemoval();
+			await deletion?.catch(() => {});
+			registeredPrimaryStore.remove = originalRemove;
+			await AuditedTable.deleteHistory(Date.now() + 60_000);
+		}
+	});
 	for (const [label, failingCallback] of [
 		['rejects', () => Promise.reject(new Error('simulated primary-store tombstone removal failure'))],
 		[

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -214,8 +214,11 @@ describe('Audit log', () => {
 			await waitFor(() => removalCalls >= 10, { timeout: 5000, message: 'expected ten removals to start' });
 			assert.equal(removalCalls, 10, 'the eleventh removal must wait for an in-flight removal');
 
-			releaseRemovals.shift()();
-			await waitFor(() => removalCalls === 11, { timeout: 5000, message: 'expected the final removal to start' });
+			releaseRemovals.splice(4, 1)[0]();
+			await waitFor(() => removalCalls === 11, {
+				timeout: 5000,
+				message: 'expected the eleventh removal to start after any active removal completed',
+			});
 			while (releaseRemovals.length > 0) releaseRemovals.shift()();
 
 			assert.equal(await deletion, 11);

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -130,9 +130,7 @@ describe('Audit log', () => {
 			if (key === targetKey) return Promise.reject(new Error('simulated audit entry removal failure'));
 			return originalRemove(key);
 		};
-		harperLogger.warn = () => {
-			throw new Error('simulated logging failure');
-		};
+		const warnings = [];
 
 		let unhandledRejection;
 		const onUnhandledRejection = (reason) => {
@@ -140,8 +138,20 @@ describe('Audit log', () => {
 		};
 		process.on('unhandledRejection', onUnhandledRejection);
 		try {
-			const entriesDeleted = await AuditedTable.deleteHistory(Date.now() + 60_000);
+			let entriesDeleted;
+			harperLogger.warn = (...args) => {
+				warnings.push(args);
+				throw new Error('simulated logging failure');
+			};
+			try {
+				entriesDeleted = await AuditedTable.deleteHistory(Date.now() + 60_000);
+			} finally {
+				harperLogger.warn = originalWarn;
+			}
 			assert.equal(entriesDeleted, 1, 'only the successful removal should be counted, not the rejected one');
+			assert.equal(warnings.length, 1);
+			assert.equal(warnings[0][0], 'Error removing audit entry during deleteHistory');
+			assert.equal(warnings[0][1].message, 'simulated audit entry removal failure');
 			await delay(50);
 			assert.equal(
 				unhandledRejection,

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -156,42 +156,50 @@ describe('Audit log', () => {
 			await AuditedTable.deleteHistory(Date.now() + 60_000); // clear record 30's now-orphaned entry
 		}
 	});
-	it('removeAuditEntry does not let a rejected delete-callback block or escape the audit-store removal', async () => {
-		const auditRemoveCalls = [];
-		const fakeAuditStore = {
-			tableStores: { 7: { getEntry: () => ({ version: 42 }) } },
-			deleteCallbacks: {
-				7: () => Promise.reject(new Error('simulated primary-store tombstone removal failure')),
+	for (const [label, failingCallback] of [
+		['rejects', () => Promise.reject(new Error('simulated primary-store tombstone removal failure'))],
+		[
+			'throws synchronously',
+			() => {
+				throw new Error('simulated primary-store tombstone removal failure');
 			},
-			remove(key) {
-				auditRemoveCalls.push(key);
-				return Promise.resolve();
-			},
-		};
-		const deleteAuditRecord = { type: 'delete', tableId: 7, recordId: 'orphan', version: 42, key: 'audit-key' };
+		],
+	]) {
+		it(`removeAuditEntry does not let a delete-callback that ${label} block or escape the audit-store removal`, async () => {
+			const auditRemoveCalls = [];
+			const fakeAuditStore = {
+				tableStores: { 7: { getEntry: () => ({ version: 42 }) } },
+				deleteCallbacks: { 7: failingCallback },
+				remove(key) {
+					auditRemoveCalls.push(key);
+					return Promise.resolve();
+				},
+			};
+			const deleteAuditRecord = { type: 'delete', tableId: 7, recordId: 'orphan', version: 42, key: 'audit-key' };
 
-		let unhandledRejection;
-		const onUnhandledRejection = (reason) => {
-			unhandledRejection = reason;
-		};
-		process.on('unhandledRejection', onUnhandledRejection);
-		try {
-			await removeAuditEntry(fakeAuditStore, deleteAuditRecord); // must not reject
-			await delay(50);
-			assert.equal(
-				unhandledRejection,
-				undefined,
-				'a rejected delete-callback must not escape as an unhandled rejection'
+			let unhandledRejection;
+			const onUnhandledRejection = (reason) => {
+				unhandledRejection = reason;
+			};
+			process.on('unhandledRejection', onUnhandledRejection);
+			try {
+				await removeAuditEntry(fakeAuditStore, deleteAuditRecord); // must not reject
+				await delay(50);
+				assert.equal(
+					unhandledRejection,
+					undefined,
+					`a delete-callback that ${label} must not escape as an unhandled rejection`
+				);
+			} finally {
+				process.off('unhandledRejection', onUnhandledRejection);
+			}
+			assert.deepEqual(
+				auditRemoveCalls,
+				['audit-key'],
+				'the audit-store removal must still proceed even though the tombstone cleanup failed'
 			);
-		} finally {
-			process.off('unhandledRejection', onUnhandledRejection);
-		}
-		assert.deepEqual(
-			auditRemoveCalls,
-			['audit-key'],
-			'the audit-store removal must still proceed even though the tombstone cleanup failed'
-		);
-	});
+		});
+	}
 	it('check log after operations and prune', async () => {
 		await AuditedTable.operation({
 			operation: 'upsert',

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -156,6 +156,62 @@ describe('Audit log', () => {
 			await AuditedTable.deleteHistory(Date.now() + 60_000); // clear record 30's now-orphaned entry
 		}
 	});
+	it('deleteHistory limits concurrent removals without serializing them', async function () {
+		if (AuditedTable.auditStore.reusableIterable) return this.skip();
+		await AuditedTable.deleteHistory(Date.now() + 60_000);
+
+		for (let id = 40; id < 51; id++) await AuditedTable.put(id, { name: `concurrent-${id}` });
+		const targetKeys = new Set();
+		for (const record of AuditedTable.auditStore.getRange({ start: 0, end: Infinity })) {
+			if (record.tableId === AuditedTable.tableId && record.recordId >= 40 && record.recordId < 51) {
+				targetKeys.add(record.key);
+			}
+		}
+		assert.equal(targetKeys.size, 11, 'test setup: expected one audit entry per inserted record');
+
+		const originalRemove = AuditedTable.auditStore.remove.bind(AuditedTable.auditStore);
+		const releaseRemovals = [];
+		let activeRemovals = 0;
+		let maximumActiveRemovals = 0;
+		let removalCalls = 0;
+		let releaseImmediately = false;
+		AuditedTable.auditStore.remove = (key) => {
+			if (!targetKeys.has(key)) return originalRemove(key);
+			removalCalls++;
+			activeRemovals++;
+			maximumActiveRemovals = Math.max(maximumActiveRemovals, activeRemovals);
+			if (releaseImmediately) {
+				activeRemovals--;
+				return Promise.resolve();
+			}
+			return new Promise((resolve) => {
+				releaseRemovals.push(() => {
+					activeRemovals--;
+					resolve();
+				});
+			});
+		};
+
+		let deletion;
+		try {
+			deletion = AuditedTable.deleteHistory(Date.now() + 60_000);
+			await waitFor(() => removalCalls >= 10, { timeout: 5000, message: 'expected ten removals to start' });
+			assert.equal(removalCalls, 10, 'the eleventh removal must wait for an in-flight removal');
+
+			releaseRemovals.shift()();
+			await waitFor(() => removalCalls === 11, { timeout: 5000, message: 'expected the final removal to start' });
+			while (releaseRemovals.length > 0) releaseRemovals.shift()();
+
+			assert.equal(await deletion, 11);
+			assert.equal(maximumActiveRemovals, 10);
+		} finally {
+			releaseImmediately = true;
+			while (releaseRemovals.length > 0) releaseRemovals.shift()();
+			await deletion?.catch(() => {});
+			AuditedTable.auditStore.remove = originalRemove;
+			await AuditedTable.deleteHistory(Date.now() + 60_000);
+		}
+	});
 	for (const [label, failingCallback] of [
 		['rejects', () => Promise.reject(new Error('simulated primary-store tombstone removal failure'))],
 		[

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -11,6 +11,7 @@ const { RocksTransactionLogStore } = require('#src/resources/RocksTransactionLog
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { setTimeout: delay } = require('node:timers/promises');
 const { waitFor } = require('../waitFor');
+const sinon = require('sinon');
 require('#src/server/serverHelpers/serverUtilities');
 describe('Audit log', () => {
 	let AuditedTable;
@@ -101,6 +102,59 @@ describe('Audit log', () => {
 		assert.equal(AuditedTable.primaryStore.getEntry(1), undefined); // verify that the delete entry was removed
 		// verify that the twice-written entry was not removed
 		assert.equal(AuditedTable.primaryStore.getEntry(2)?.value?.name, 'two-changed');
+	});
+	// Regression test for harper#F-264: deleteHistory() (the LMDB path behind the
+	// delete_transaction_logs_before operation) used to stash each removeAuditEntry() promise in a
+	// single `completion` variable that a later iteration's promise would overwrite before it could
+	// be awaited or caught. A rejection from any non-last entry (e.g. a decode failure over a
+	// corrupt/misaligned audit entry) escaped as an unhandled rejection instead of being caught —
+	// on Bun this killed the process a few seconds after the operation had already reported
+	// COMPLETE. deleteHistory() now awaits and catches each removal inline.
+	it('deleteHistory does not let a mid-loop removeAuditEntry rejection escape as an unhandled rejection', async function () {
+		if (AuditedTable.auditStore.reusableIterable) return; // rocksdb doesn't use deleteHistory (see ResourceBridge.deleteTransactionLogsBefore)
+		await AuditedTable.deleteHistory(Date.now() + 60_000); // start from a clean backlog
+
+		await AuditedTable.put(30, { name: 'race-a' });
+		await AuditedTable.put(31, { name: 'race-b' });
+
+		const originalRemove = AuditedTable.auditStore.remove.bind(AuditedTable.auditStore);
+		let removeCalls = 0;
+		const removeStub = sinon.stub(AuditedTable.auditStore, 'remove').callsFake((key) => {
+			removeCalls++;
+			// fail only the first (non-last) removal in the loop; later removals must still proceed
+			if (removeCalls === 1) return Promise.reject(new Error('simulated audit entry removal failure'));
+			return originalRemove(key);
+		});
+
+		let unhandledRejection;
+		const onUnhandledRejection = (reason) => {
+			unhandledRejection = reason;
+		};
+		process.on('unhandledRejection', onUnhandledRejection);
+		try {
+			const entriesDeleted = await AuditedTable.deleteHistory(Date.now() + 60_000);
+			assert.equal(entriesDeleted, 2, 'both entries should be processed even though the first removal rejected');
+			// give the event loop a couple of turns for a stray unhandled rejection to surface
+			await delay(50);
+			assert.equal(
+				unhandledRejection,
+				undefined,
+				'a rejected removeAuditEntry() call must not escape as an unhandled rejection'
+			);
+			// record 30's audit entry genuinely failed to remove and is not retried; record 31's must be gone
+			const remaining = [];
+			for await (const entry of AuditedTable.getHistory()) remaining.push(entry.id);
+			assert.deepEqual(
+				remaining,
+				[30],
+				'the failed removal must be left in place, but later entries must still be pruned'
+			);
+		} finally {
+			process.off('unhandledRejection', onUnhandledRejection);
+			removeStub.restore();
+		}
+		// clean up record 30's now-orphaned audit entry so it doesn't leak into later tests
+		await AuditedTable.deleteHistory(Date.now() + 60_000);
 	});
 	it('check log after operations and prune', async () => {
 		await AuditedTable.operation({

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -6,12 +6,12 @@ const {
 	readAuditEntry,
 	createAuditEntry,
 	transactionKeyEncoder,
+	removeAuditEntry,
 } = require('#src/resources/auditStore');
 const { RocksTransactionLogStore } = require('#src/resources/RocksTransactionLogStore');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { setTimeout: delay } = require('node:timers/promises');
 const { waitFor } = require('../waitFor');
-const sinon = require('sinon');
 require('#src/server/serverHelpers/serverUtilities');
 describe('Audit log', () => {
 	let AuditedTable;
@@ -103,13 +103,7 @@ describe('Audit log', () => {
 		// verify that the twice-written entry was not removed
 		assert.equal(AuditedTable.primaryStore.getEntry(2)?.value?.name, 'two-changed');
 	});
-	// Regression test for harper#F-264: deleteHistory() (the LMDB path behind the
-	// delete_transaction_logs_before operation) used to stash each removeAuditEntry() promise in a
-	// single `completion` variable that a later iteration's promise would overwrite before it could
-	// be awaited or caught. A rejection from any non-last entry (e.g. a decode failure over a
-	// corrupt/misaligned audit entry) escaped as an unhandled rejection instead of being caught —
-	// on Bun this killed the process a few seconds after the operation had already reported
-	// COMPLETE. deleteHistory() now awaits and catches each removal inline.
+	// Regression test for harper#F-264 (see DESIGN.md's audit-entry-removal-loop invariant).
 	it('deleteHistory does not let a mid-loop removeAuditEntry rejection escape as an unhandled rejection', async function () {
 		if (AuditedTable.auditStore.reusableIterable) return; // rocksdb doesn't use deleteHistory (see ResourceBridge.deleteTransactionLogsBefore)
 		await AuditedTable.deleteHistory(Date.now() + 60_000); // start from a clean backlog
@@ -117,14 +111,20 @@ describe('Audit log', () => {
 		await AuditedTable.put(30, { name: 'race-a' });
 		await AuditedTable.put(31, { name: 'race-b' });
 
+		// find record 30's raw audit-store key so the injected failure targets that one entry specifically,
+		// the same way deleteHistory itself finds it (getHistory()'s yielded entries don't carry this key —
+		// its `localTime` field is the record's version, not the key)
+		let targetKey;
+		for (const record of AuditedTable.auditStore.getRange({ start: 0, end: Infinity })) {
+			if (record.tableId === AuditedTable.tableId && record.recordId === 30) targetKey = record.key;
+		}
+		assert.notEqual(targetKey, undefined, 'test setup: could not find record 30 in the audit log');
+
 		const originalRemove = AuditedTable.auditStore.remove.bind(AuditedTable.auditStore);
-		let removeCalls = 0;
-		const removeStub = sinon.stub(AuditedTable.auditStore, 'remove').callsFake((key) => {
-			removeCalls++;
-			// fail only the first (non-last) removal in the loop; later removals must still proceed
-			if (removeCalls === 1) return Promise.reject(new Error('simulated audit entry removal failure'));
+		AuditedTable.auditStore.remove = (key) => {
+			if (key === targetKey) return Promise.reject(new Error('simulated audit entry removal failure'));
 			return originalRemove(key);
-		});
+		};
 
 		let unhandledRejection;
 		const onUnhandledRejection = (reason) => {
@@ -133,7 +133,7 @@ describe('Audit log', () => {
 		process.on('unhandledRejection', onUnhandledRejection);
 		try {
 			const entriesDeleted = await AuditedTable.deleteHistory(Date.now() + 60_000);
-			assert.equal(entriesDeleted, 2, 'both entries should be processed even though the first removal rejected');
+			assert.equal(entriesDeleted, 1, 'only the successful removal should be counted, not the rejected one');
 			// give the event loop a couple of turns for a stray unhandled rejection to surface
 			await delay(50);
 			assert.equal(
@@ -151,10 +151,30 @@ describe('Audit log', () => {
 			);
 		} finally {
 			process.off('unhandledRejection', onUnhandledRejection);
-			removeStub.restore();
+			AuditedTable.auditStore.remove = originalRemove;
 		}
 		// clean up record 30's now-orphaned audit entry so it doesn't leak into later tests
 		await AuditedTable.deleteHistory(Date.now() + 60_000);
+	});
+	it("removeAuditEntry propagates the delete-callback's rejection instead of leaving it detached", async () => {
+		const primaryRemoveCalls = [];
+		const fakeAuditStore = {
+			tableStores: { 7: { getEntry: () => ({ version: 42 }) } },
+			deleteCallbacks: {
+				7: (id, version) => {
+					primaryRemoveCalls.push([id, version]);
+					return Promise.reject(new Error('simulated primary-store tombstone removal failure'));
+				},
+			},
+			remove: () => Promise.resolve(),
+		};
+		const deleteAuditRecord = { type: 'delete', tableId: 7, recordId: 'orphan', version: 42, key: 'audit-key' };
+		await assert.rejects(
+			() => removeAuditEntry(fakeAuditStore, deleteAuditRecord),
+			/simulated primary-store tombstone removal failure/,
+			"removeAuditEntry must reject when the delete-callback's promise rejects, not resolve with it detached"
+		);
+		assert.deepEqual(primaryRemoveCalls, [['orphan', 42]]);
 	});
 	it('check log after operations and prune', async () => {
 		await AuditedTable.operation({

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -353,8 +353,9 @@ describe('Audit log', () => {
 			await AuditedTable.deleteHistory(Date.now() + 60_000, true);
 		}
 	});
-	it('RocksDB versioned removal preserves a record recreated after its tombstone', async function () {
+	it('RocksDB versioned removal preserves records recreated before or during removal', async function () {
 		if (!AuditedTable.primaryStore.isPrimaryRocksDatabase) return this.skip();
+		const { Transaction } = require('@harperfast/rocksdb-js');
 		const recordId = 'rocks-cleanup-race';
 		try {
 			await AuditedTable.put(recordId, { name: 'deleted' });
@@ -370,7 +371,27 @@ describe('Audit log', () => {
 			);
 			const recreated = AuditedTable.primaryStore.getEntry(recordId);
 			assert.equal(recreated?.value?.name, 'recreated');
-			assert.equal(await AuditedTable.primaryStore.remove(recordId, recreated.version), true);
+
+			await AuditedTable.delete(recordId);
+			const secondTombstone = AuditedTable.primaryStore.getEntry(recordId);
+			const originalCommit = Transaction.prototype.commit;
+			let interleaved = false;
+			Transaction.prototype.commit = async function (...args) {
+				if (!interleaved) {
+					interleaved = true;
+					await AuditedTable.put(recordId, { name: 'concurrent' });
+				}
+				return originalCommit.apply(this, args);
+			};
+			try {
+				assert.equal(await AuditedTable.primaryStore.remove(recordId, secondTombstone.version), false);
+			} finally {
+				Transaction.prototype.commit = originalCommit;
+			}
+			assert(interleaved, 'a recreate should commit between the conditional read and delete commit');
+			const concurrent = AuditedTable.primaryStore.getEntry(recordId);
+			assert.equal(concurrent?.value?.name, 'concurrent');
+			assert.equal(await AuditedTable.primaryStore.remove(recordId, concurrent.version), true);
 			assert.equal(AuditedTable.primaryStore.getEntry(recordId), undefined);
 		} finally {
 			await AuditedTable.primaryStore.remove(recordId);

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -134,14 +134,12 @@ describe('Audit log', () => {
 		try {
 			const entriesDeleted = await AuditedTable.deleteHistory(Date.now() + 60_000);
 			assert.equal(entriesDeleted, 1, 'only the successful removal should be counted, not the rejected one');
-			// give the event loop a couple of turns for a stray unhandled rejection to surface
 			await delay(50);
 			assert.equal(
 				unhandledRejection,
 				undefined,
 				'a rejected removeAuditEntry() call must not escape as an unhandled rejection'
 			);
-			// record 30's audit entry genuinely failed to remove and is not retried; record 31's must be gone
 			const remaining = [];
 			for await (const entry of AuditedTable.getHistory()) remaining.push(entry.id);
 			assert.deepEqual(
@@ -152,29 +150,44 @@ describe('Audit log', () => {
 		} finally {
 			process.off('unhandledRejection', onUnhandledRejection);
 			AuditedTable.auditStore.remove = originalRemove;
+			await AuditedTable.deleteHistory(Date.now() + 60_000); // clear record 30's now-orphaned entry
 		}
-		// clean up record 30's now-orphaned audit entry so it doesn't leak into later tests
-		await AuditedTable.deleteHistory(Date.now() + 60_000);
 	});
-	it("removeAuditEntry propagates the delete-callback's rejection instead of leaving it detached", async () => {
-		const primaryRemoveCalls = [];
+	it('removeAuditEntry does not let a rejected delete-callback block or escape the audit-store removal', async () => {
+		const auditRemoveCalls = [];
 		const fakeAuditStore = {
 			tableStores: { 7: { getEntry: () => ({ version: 42 }) } },
 			deleteCallbacks: {
-				7: (id, version) => {
-					primaryRemoveCalls.push([id, version]);
-					return Promise.reject(new Error('simulated primary-store tombstone removal failure'));
-				},
+				7: () => Promise.reject(new Error('simulated primary-store tombstone removal failure')),
 			},
-			remove: () => Promise.resolve(),
+			remove(key) {
+				auditRemoveCalls.push(key);
+				return Promise.resolve();
+			},
 		};
 		const deleteAuditRecord = { type: 'delete', tableId: 7, recordId: 'orphan', version: 42, key: 'audit-key' };
-		await assert.rejects(
-			() => removeAuditEntry(fakeAuditStore, deleteAuditRecord),
-			/simulated primary-store tombstone removal failure/,
-			"removeAuditEntry must reject when the delete-callback's promise rejects, not resolve with it detached"
+
+		let unhandledRejection;
+		const onUnhandledRejection = (reason) => {
+			unhandledRejection = reason;
+		};
+		process.on('unhandledRejection', onUnhandledRejection);
+		try {
+			await removeAuditEntry(fakeAuditStore, deleteAuditRecord); // must not reject
+			await delay(50);
+			assert.equal(
+				unhandledRejection,
+				undefined,
+				'a rejected delete-callback must not escape as an unhandled rejection'
+			);
+		} finally {
+			process.off('unhandledRejection', onUnhandledRejection);
+		}
+		assert.deepEqual(
+			auditRemoveCalls,
+			['audit-key'],
+			'the audit-store removal must still proceed even though the tombstone cleanup failed'
 		);
-		assert.deepEqual(primaryRemoveCalls, [['orphan', 42]]);
 	});
 	it('check log after operations and prune', async () => {
 		await AuditedTable.operation({

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -12,6 +12,7 @@ const { RocksTransactionLogStore } = require('#src/resources/RocksTransactionLog
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { setTimeout: delay } = require('node:timers/promises');
 const { waitFor } = require('../waitFor');
+const harperLogger = require('#src/utility/logging/harper_logger');
 require('#src/server/serverHelpers/serverUtilities');
 describe('Audit log', () => {
 	let AuditedTable;
@@ -104,7 +105,7 @@ describe('Audit log', () => {
 		assert.equal(AuditedTable.primaryStore.getEntry(2)?.value?.name, 'two-changed');
 	});
 	// Regression test for harper#F-264 (see DESIGN.md's audit-entry-removal-loop invariant).
-	it('deleteHistory does not let a mid-loop removeAuditEntry rejection escape as an unhandled rejection', async function () {
+	it('deleteHistory contains a mid-loop rejection even when failure logging throws', async function () {
 		// rocksdb doesn't use deleteHistory (see ResourceBridge.deleteTransactionLogsBefore); this.skip()
 		// (rather than a bare return, as the file's other reusableIterable guards use) so the report
 		// distinguishes "skipped on this engine" from "passed"
@@ -124,9 +125,13 @@ describe('Audit log', () => {
 		assert.notEqual(targetKey, undefined, 'test setup: could not find record 30 in the audit log');
 
 		const originalRemove = AuditedTable.auditStore.remove.bind(AuditedTable.auditStore);
+		const originalWarn = harperLogger.warn;
 		AuditedTable.auditStore.remove = (key) => {
 			if (key === targetKey) return Promise.reject(new Error('simulated audit entry removal failure'));
 			return originalRemove(key);
+		};
+		harperLogger.warn = () => {
+			throw new Error('simulated logging failure');
 		};
 
 		let unhandledRejection;
@@ -152,6 +157,7 @@ describe('Audit log', () => {
 			);
 		} finally {
 			process.off('unhandledRejection', onUnhandledRejection);
+			harperLogger.warn = originalWarn;
 			AuditedTable.auditStore.remove = originalRemove;
 			await AuditedTable.deleteHistory(Date.now() + 60_000); // clear record 30's now-orphaned entry
 		}

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -176,14 +176,23 @@ describe('Audit log', () => {
 		if (AuditedTable.auditStore.reusableIterable) return this.skip();
 		await AuditedTable.deleteHistory(Date.now() + 60_000);
 
-		for (let id = 40; id < 51; id++) await AuditedTable.put(id, { name: `concurrent-${id}` });
+		const firstId = 40;
+		const concurrentRemovalLimit = 1000;
+		const recordCount = concurrentRemovalLimit + 1;
+		for (let id = firstId; id < firstId + recordCount; id++) {
+			await AuditedTable.put(id, { name: `concurrent-${id}` });
+		}
 		const targetKeys = new Set();
 		for (const record of AuditedTable.auditStore.getRange({ start: 0, end: Infinity })) {
-			if (record.tableId === AuditedTable.tableId && record.recordId >= 40 && record.recordId < 51) {
+			if (
+				record.tableId === AuditedTable.tableId &&
+				record.recordId >= firstId &&
+				record.recordId < firstId + recordCount
+			) {
 				targetKeys.add(record.key);
 			}
 		}
-		assert.equal(targetKeys.size, 11, 'test setup: expected one audit entry per inserted record');
+		assert.equal(targetKeys.size, recordCount, 'test setup: expected one audit entry per inserted record');
 
 		const originalRemove = AuditedTable.auditStore.remove.bind(AuditedTable.auditStore);
 		const releaseRemovals = [];
@@ -211,24 +220,34 @@ describe('Audit log', () => {
 		let deletion;
 		try {
 			deletion = AuditedTable.deleteHistory(Date.now() + 60_000);
-			await waitFor(() => removalCalls >= 10, { timeout: 5000, message: 'expected ten removals to start' });
-			assert.equal(removalCalls, 10, 'the eleventh removal must wait for an in-flight removal');
-
-			releaseRemovals.splice(4, 1)[0]();
-			await waitFor(() => removalCalls === 11, {
+			await waitFor(() => removalCalls >= concurrentRemovalLimit, {
 				timeout: 5000,
-				message: 'expected the eleventh removal to start after any active removal completed',
+				message: `expected ${concurrentRemovalLimit} removals to start`,
+			});
+			assert.equal(
+				removalCalls,
+				concurrentRemovalLimit,
+				'the next removal must wait while the concurrency limit is occupied'
+			);
+
+			releaseRemovals.splice(Math.floor(concurrentRemovalLimit / 2), 1)[0]();
+			await waitFor(() => removalCalls === recordCount, {
+				timeout: 5000,
+				message: 'expected the final removal to start after any active removal completed',
 			});
 			while (releaseRemovals.length > 0) releaseRemovals.shift()();
 
-			assert.equal(await deletion, 11);
-			assert.equal(maximumActiveRemovals, 10);
+			assert.equal(await deletion, recordCount);
+			assert.equal(maximumActiveRemovals, concurrentRemovalLimit);
 		} finally {
 			releaseImmediately = true;
 			while (releaseRemovals.length > 0) releaseRemovals.shift()();
 			await deletion?.catch(() => {});
 			AuditedTable.auditStore.remove = originalRemove;
 			await AuditedTable.deleteHistory(Date.now() + 60_000);
+			await AuditedTable.primaryStore.batch(() => {
+				for (let id = firstId; id < firstId + recordCount; id++) AuditedTable.primaryStore.remove(id);
+			});
 		}
 	});
 	async function createOrphanedTombstone(recordId) {

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -249,6 +249,7 @@ describe('Audit log', () => {
 		assert.equal(typeof AuditedTable.auditStore.deleteCallbacks?.[AuditedTable.tableId], 'function');
 
 		const originalRemove = registeredPrimaryStore.remove;
+		const removeWasOwnProperty = Object.hasOwn(registeredPrimaryStore, 'remove');
 		let releaseTombstoneRemoval;
 		let markTombstoneRemovalStarted;
 		const tombstoneRemovalStarted = new Promise((resolve) => {
@@ -269,19 +270,28 @@ describe('Audit log', () => {
 		let deletion;
 		try {
 			deletion = AuditedTable.deleteHistory(Date.now() + 60_000);
-			const callback = await Promise.race([
-				tombstoneRemovalStarted,
-				deletion.then((entriesDeleted) => {
-					throw new Error(
-						`deleteHistory resolved before invoking the registered callback: ${entriesDeleted} entries, tombstone=${String(
-							AuditedTable.primaryStore.getEntry(recordId)?.value
-						)}`
-					);
-				}),
-				delay(2000).then(() => {
-					throw new Error('table-registered tombstone removal callback did not start');
-				}),
-			]);
+			let callbackTimeout;
+			let callback;
+			try {
+				callback = await Promise.race([
+					tombstoneRemovalStarted,
+					deletion.then((entriesDeleted) => {
+						throw new Error(
+							`deleteHistory resolved before invoking the registered callback: ${entriesDeleted} entries, tombstone=${String(
+								AuditedTable.primaryStore.getEntry(recordId)?.value
+							)}`
+						);
+					}),
+					new Promise((resolve, reject) => {
+						callbackTimeout = setTimeout(
+							() => reject(new Error('table-registered tombstone removal callback did not start')),
+							2000
+						);
+					}),
+				]);
+			} finally {
+				clearTimeout(callbackTimeout);
+			}
 			assert.equal(callback.id, recordId);
 			const state = await Promise.race([deletion.then(() => 'resolved'), delay(50, 'pending')]);
 			assert.equal(state, 'pending', 'deleteHistory must join the registered tombstone removal callback');
@@ -296,7 +306,8 @@ describe('Audit log', () => {
 		} finally {
 			releaseTombstoneRemoval();
 			await deletion?.catch(() => {});
-			registeredPrimaryStore.remove = originalRemove;
+			if (removeWasOwnProperty) registeredPrimaryStore.remove = originalRemove;
+			else delete registeredPrimaryStore.remove;
 			await AuditedTable.deleteHistory(Date.now() + 60_000);
 		}
 	});

--- a/unitTests/resources/auditLog.test.js
+++ b/unitTests/resources/auditLog.test.js
@@ -105,71 +105,104 @@ describe('Audit log', () => {
 		assert.equal(AuditedTable.primaryStore.getEntry(2)?.value?.name, 'two-changed');
 	});
 	// Regression test for harper#F-264 (see DESIGN.md's audit-entry-removal-loop invariant).
-	it('deleteHistory contains a mid-loop rejection even when failure logging throws', async function () {
-		// rocksdb doesn't use deleteHistory (see ResourceBridge.deleteTransactionLogsBefore); this.skip()
-		// (rather than a bare return, as the file's other reusableIterable guards use) so the report
-		// distinguishes "skipped on this engine" from "passed"
+	// Run with both a throwing and a non-throwing failure logger: with a throwing one, an
+	// implementation that counted the removal *before* logging its failure would still pass
+	// (the injected throw preempts the count), so only the non-throwing pass pins the count.
+	for (const loggingThrows of [true, false]) {
+		const failedId = loggingThrows ? 30 : 32;
+		const succeededId = failedId + 1;
+		it(`deleteHistory contains a mid-loop rejection (failure logging ${
+			loggingThrows ? 'throws' : 'succeeds'
+		})`, async function () {
+			// rocksdb doesn't use deleteHistory (see ResourceBridge.deleteTransactionLogsBefore); this.skip()
+			// (rather than a bare return, as the file's other reusableIterable guards use) so the report
+			// distinguishes "skipped on this engine" from "passed"
+			if (AuditedTable.auditStore.reusableIterable) return this.skip();
+			await AuditedTable.deleteHistory(Date.now() + 60_000); // start from a clean backlog
+
+			await AuditedTable.put(failedId, { name: 'race-a' });
+			await AuditedTable.put(succeededId, { name: 'race-b' });
+
+			// find the failing record's raw audit-store key so the injected failure targets that one entry
+			// specifically, the same way deleteHistory itself finds it (getHistory()'s yielded entries don't
+			// carry this key — its `localTime` field is the record's version, not the key)
+			let targetKey;
+			for (const record of AuditedTable.auditStore.getRange({ start: 0, end: Infinity })) {
+				if (record.tableId === AuditedTable.tableId && record.recordId === failedId) targetKey = record.key;
+			}
+			assert.notEqual(targetKey, undefined, `test setup: could not find record ${failedId} in the audit log`);
+
+			const originalRemove = AuditedTable.auditStore.remove.bind(AuditedTable.auditStore);
+			const originalWarn = harperLogger.warn;
+			AuditedTable.auditStore.remove = (key) => {
+				if (key === targetKey) return Promise.reject(new Error('simulated audit entry removal failure'));
+				return originalRemove(key);
+			};
+			const warnings = [];
+
+			let unhandledRejection;
+			const onUnhandledRejection = (reason) => {
+				unhandledRejection = reason;
+			};
+			process.on('unhandledRejection', onUnhandledRejection);
+			try {
+				let entriesDeleted;
+				harperLogger.warn = (...args) => {
+					warnings.push(args);
+					if (loggingThrows) throw new Error('simulated logging failure');
+				};
+				try {
+					entriesDeleted = await AuditedTable.deleteHistory(Date.now() + 60_000);
+				} finally {
+					harperLogger.warn = originalWarn;
+				}
+				assert.equal(entriesDeleted, 1, 'only the successful removal should be counted, not the rejected one');
+				assert.equal(warnings.length, 1);
+				assert.equal(warnings[0][0], 'Error removing audit entry during deleteHistory');
+				assert.equal(warnings[0][1].message, 'simulated audit entry removal failure');
+				await delay(50);
+				assert.equal(
+					unhandledRejection,
+					undefined,
+					'a rejected removeAuditEntry() call must not escape as an unhandled rejection'
+				);
+				const remaining = [];
+				for await (const entry of AuditedTable.getHistory()) remaining.push(entry.id);
+				assert.deepEqual(
+					remaining,
+					[failedId],
+					'the failed removal must be left in place, but later entries must still be pruned'
+				);
+			} finally {
+				process.off('unhandledRejection', onUnhandledRejection);
+				harperLogger.warn = originalWarn;
+				AuditedTable.auditStore.remove = originalRemove;
+				await AuditedTable.deleteHistory(Date.now() + 60_000); // clear the now-orphaned entry
+			}
+		});
+	}
+	it('deleteHistory reports a purge that attempted removals and completed none', async function () {
 		if (AuditedTable.auditStore.reusableIterable) return this.skip();
-		await AuditedTable.deleteHistory(Date.now() + 60_000); // start from a clean backlog
+		const cutoff = () => Date.now() + 60_000;
+		await AuditedTable.deleteHistory(cutoff()); // start from a clean backlog
+		assert.equal(await AuditedTable.deleteHistory(cutoff()), 0, 'an empty backlog is not a failure');
 
-		await AuditedTable.put(30, { name: 'race-a' });
-		await AuditedTable.put(31, { name: 'race-b' });
-
-		// find record 30's raw audit-store key so the injected failure targets that one entry specifically,
-		// the same way deleteHistory itself finds it (getHistory()'s yielded entries don't carry this key —
-		// its `localTime` field is the record's version, not the key)
-		let targetKey;
-		for (const record of AuditedTable.auditStore.getRange({ start: 0, end: Infinity })) {
-			if (record.tableId === AuditedTable.tableId && record.recordId === 30) targetKey = record.key;
-		}
-		assert.notEqual(targetKey, undefined, 'test setup: could not find record 30 in the audit log');
+		await AuditedTable.put(34, { name: 'doomed-a' });
+		await AuditedTable.put(35, { name: 'doomed-b' });
 
 		const originalRemove = AuditedTable.auditStore.remove.bind(AuditedTable.auditStore);
 		const originalWarn = harperLogger.warn;
-		AuditedTable.auditStore.remove = (key) => {
-			if (key === targetKey) return Promise.reject(new Error('simulated audit entry removal failure'));
-			return originalRemove(key);
-		};
 		const warnings = [];
-
-		let unhandledRejection;
-		const onUnhandledRejection = (reason) => {
-			unhandledRejection = reason;
-		};
-		process.on('unhandledRejection', onUnhandledRejection);
+		AuditedTable.auditStore.remove = () => Promise.reject(new Error('simulated store failure'));
+		harperLogger.warn = (...args) => warnings.push(args);
 		try {
-			let entriesDeleted;
-			harperLogger.warn = (...args) => {
-				warnings.push(args);
-				throw new Error('simulated logging failure');
-			};
-			try {
-				entriesDeleted = await AuditedTable.deleteHistory(Date.now() + 60_000);
-			} finally {
-				harperLogger.warn = originalWarn;
-			}
-			assert.equal(entriesDeleted, 1, 'only the successful removal should be counted, not the rejected one');
-			assert.equal(warnings.length, 1);
-			assert.equal(warnings[0][0], 'Error removing audit entry during deleteHistory');
-			assert.equal(warnings[0][1].message, 'simulated audit entry removal failure');
-			await delay(50);
-			assert.equal(
-				unhandledRejection,
-				undefined,
-				'a rejected removeAuditEntry() call must not escape as an unhandled rejection'
-			);
-			const remaining = [];
-			for await (const entry of AuditedTable.getHistory()) remaining.push(entry.id);
-			assert.deepEqual(
-				remaining,
-				[30],
-				'the failed removal must be left in place, but later entries must still be pruned'
-			);
+			// a purge that made zero progress must not be indistinguishable from one that had nothing to do
+			await assert.rejects(AuditedTable.deleteHistory(cutoff()), /simulated store failure/);
+			assert.equal(warnings.length, 2, 'each failure is still logged individually');
 		} finally {
-			process.off('unhandledRejection', onUnhandledRejection);
 			harperLogger.warn = originalWarn;
 			AuditedTable.auditStore.remove = originalRemove;
-			await AuditedTable.deleteHistory(Date.now() + 60_000); // clear record 30's now-orphaned entry
+			await AuditedTable.deleteHistory(cutoff());
 		}
 	});
 	it('deleteHistory limits concurrent removals without serializing them', async function () {
@@ -284,13 +317,25 @@ describe('Audit log', () => {
 			await AuditedTable.deleteHistory(Date.now() + 60_000, true);
 		}
 	});
+	// Runs on both engines: it is the only test that carries a scan-captured version through
+	// deleteHistory's cleanup phase into remove(), and RocksDB is the default engine. Rather than
+	// createOrphanedTombstone (which can't orphan an entry in a RocksDB transaction log), it
+	// suppresses the audit-driven delete callback — the "the audit log isn't cleaning these up"
+	// state the cleanup phase exists for — so the tombstone survives to the cleanup scan.
 	it('deleteHistory cleanup preserves a record recreated while its stale tombstone waits for a slot', async function () {
-		if (AuditedTable.auditStore.reusableIterable) return this.skip();
 		const cutoff = Date.now() + 60_000;
 		await AuditedTable.deleteHistory(cutoff, true);
 
 		const recordId = 'cleanup-race';
-		const tombstone = await createOrphanedTombstone(recordId);
+		const deleteCallbacks = AuditedTable.auditStore.deleteCallbacks;
+		const tableId = AuditedTable.tableId;
+		const originalDeleteCallback = deleteCallbacks[tableId];
+		await AuditedTable.put(recordId, { name: 'to-delete' });
+		await AuditedTable.delete(recordId);
+		deleteCallbacks[tableId] = () => {};
+		const tombstone = AuditedTable.primaryStore.getEntry(recordId);
+		assert.equal(tombstone?.value, null, 'test setup: expected a tombstone');
+		assert.notEqual(tombstone?.version, undefined, 'test setup: expected a versioned tombstone');
 
 		const primaryStore = AuditedTable.primaryStore;
 		const originalRemove = primaryStore.remove;
@@ -340,7 +385,7 @@ describe('Audit log', () => {
 			await AuditedTable.put(recordId, { name: 'recreated' });
 			releaseRemoval();
 			await deletion;
-			assert.equal(removalVersion, tombstone.version);
+			assert.equal(removalVersion, tombstone.version, 'the cleanup scan must hand the version it captured to remove()');
 			assert.equal(removalResult, false, 'the stale conditional removal must not commit');
 			assert.equal(AuditedTable.primaryStore.getEntry(recordId)?.value?.name, 'recreated');
 		} finally {
@@ -349,6 +394,8 @@ describe('Audit log', () => {
 			await deletion?.catch(() => {});
 			if (removeWasOwnProperty) primaryStore.remove = originalRemove;
 			else delete primaryStore.remove;
+			if (originalDeleteCallback) deleteCallbacks[tableId] = originalDeleteCallback;
+			else delete deleteCallbacks[tableId];
 			await AuditedTable.delete(recordId).catch(() => {});
 			await AuditedTable.deleteHistory(Date.now() + 60_000, true);
 		}

--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -482,12 +482,15 @@ describe('Subscription replay', () => {
 			})();
 			try {
 				await concurrentWrites;
-				await waitFor(() => {
-					const ids = new Set(events.map((event) => event.id));
-					for (let i = 0; i < 300; i++) if (!ids.has(9000 + i)) return false;
-					for (let i = 0; i < concurrentCount; i++) if (!ids.has(10000 + i)) return false;
-					return true;
-				});
+				await waitFor(
+					() => {
+						const ids = new Set(events.map((event) => event.id));
+						for (let i = 0; i < 300; i++) if (!ids.has(9000 + i)) return false;
+						for (let i = 0; i < concurrentCount; i++) if (!ids.has(10000 + i)) return false;
+						return true;
+					},
+					{ timeout: 5000, message: 'not all replayed ids were delivered' }
+				);
 				// Let any late duplicate delivery reach the uniqueness assertion below.
 				await delay(200);
 			} finally {

--- a/unitTests/resources/subscriptionReplay.test.js
+++ b/unitTests/resources/subscriptionReplay.test.js
@@ -471,6 +471,8 @@ describe('Subscription replay', () => {
 				await StartTimeTable.put(9000 + i, { name: 'race_pre' + i });
 			}
 			const subscription = await StartTimeTable.subscribe({ startTime: startTime - 1, isCollection: true });
+			const events = [];
+			subscription.on('data', (event) => events.push(event));
 			// fire a batch of writes that will interleave with cursor yields
 			const concurrentCount = 50;
 			const concurrentWrites = (async () => {
@@ -478,9 +480,19 @@ describe('Subscription replay', () => {
 					await StartTimeTable.put(10000 + i, { name: 'race_concurrent' + i });
 				}
 			})();
-			const events = await collect(subscription, 200);
-			await concurrentWrites;
-			subscription.return?.();
+			try {
+				await concurrentWrites;
+				await waitFor(() => {
+					const ids = new Set(events.map((event) => event.id));
+					for (let i = 0; i < 300; i++) if (!ids.has(9000 + i)) return false;
+					for (let i = 0; i < concurrentCount; i++) if (!ids.has(10000 + i)) return false;
+					return true;
+				});
+				// Let any late duplicate delivery reach the uniqueness assertion below.
+				await delay(200);
+			} finally {
+				subscription.return?.();
+			}
 
 			const ids = new Set(events.map((e) => e.id));
 			for (let i = 0; i < 300; i++) {


### PR DESCRIPTION
`Table.deleteHistory()` now tracks every audit/tombstone removal with bounded, engine-aware concurrency: 1,000 writes for LMDB and ten for RocksDB. This prevents detached rejections and unbounded pending work while preserving the large LMDB batches required by the Windows purge path. The limiter waits only at real saturation, resumes on any completion, and drains both phases even when iteration throws.

`removeAuditEntry()` also joins the registered tombstone cleanup. Cleanup snapshots each key/version before yielding and removes only that version. LMDB enforces the condition natively; RocksDB re-reads and removes inside one native transaction, retrying a conflict once. Versionless tombstones are left in place rather than risking an unconditional delete. A regression test forces a recreate between the RocksDB read and commit and proves the stale cleanup preserves the live record.

A purge that attempted at least one removal and completed none now [rejects with the first storage error](https://github.com/HarperFast/harper/pull/2051/changes?w=1#diff-4ff51263bd99981165fc179149c3195ea0c0ca3e2f360bafee2a6bb356964377R5134), after both phases have drained. Previously every failure was warn-logged only, so `delete_transaction_logs_before` returned a successful `entries_deleted: 0` whether nothing was eligible or the store rejected every write — indistinguishable to an operator pruning to bound disk growth. Draining before deciding keeps all the progress a partially-failing store can still make, a single success reports normally, and partial failures stay best-effort (logged, excluded from the count). The response schema is unchanged.

The CI follow-up makes the heavy subscription-replay race test wait for every expected ID after concurrent writes finish. Its previous 200 ms quiet-window collector could close the subscription before the final delivery, which failed this PR's first Node 22 run with `missing concurrent id 10049`.

## For the human reviewer

1. The zero-progress rejection is the narrow option, not `entries_failed`. Adding a result field would expand this into a public API/docs/test contract change across LMDB, RocksDB and the deprecated `deleteAuditLogsBefore` wrapper; partial failures therefore still require log inspection to reconcile. Add `entries_failed` later only if callers need it programmatically. The new failure case is a job failure, not an unhandled rejection: `ResourceBridge.deleteTransactionLogsBefore` awaits `deleteHistory`, and `server/jobs/jobRunner.ts` records the rejection as job status `ERROR`. There is no end-to-end test of that path — inducing "every removal fails" needs fault injection at the store, so the route above is a code trace plus the unit regression.
2. A failed automatic tombstone removal still retires its audit entry. Keeping the audit entry would preserve an automatic retry trigger, but it could also hold audit cleanup behind a persistently failing primary-store write; the current behavior requires a later explicit `cleanup_deleted_records: true` sweep.
3. The LMDB cap intentionally trades some unbounded batching for bounded pending work. Ten concurrent writes timed out the 12,000-entry Windows purge at 60.48 seconds. Raising the bounded LMDB window to 1,000 reduced the same local 4,000-entry diagnostic from 1,678 ms to 56.6 ms; fresh Windows CI purged all 12,000 entries in 2.149 seconds.
4. Declined from the latest review round: Gemini read `db.remove = (id, opts) => typeof opts === 'number' ? removeIfVersion(...) : removeSync(...)` in [`databases.ts`](https://github.com/HarperFast/harper/pull/2051/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R234) as breaking a synchronous-boolean contract. lmdb-js's `remove(key, ifVersion)` already returns a promise, so the two engines agree, and the only numeric-version callers are `Table.ts:5124` and `Table.ts:6287`, both of which return or await the promise. Left as is.

## Verification

- `npm run build`, `npm run typecheck`, `npm run lint:required`, `npm run format:check` — passed.
- `npx mocha unitTests/resources/auditLog.test.js` — 26 passing, 6 pending. [`deleteHistory cleanup preserves a record recreated while its stale tombstone waits for a slot`](https://github.com/HarperFast/harper/pull/2051/changes?w=1#diff-044077436ab82ecf6c481205bdf0ac84571b38edf4ce663842e72349c3a7b38cR325) no longer needs `createOrphanedTombstone` and so now runs on RocksDB (previously pending), putting the scan-captured version hand-off under coverage on the default engine.
- `HARPER_STORAGE_ENGINE=lmdb npx mocha unitTests/resources/auditLog.test.js` — 26 passing, 6 pending, including the 1,001-operation limiter and stale-tombstone regressions.
- `npm run test:unit:resources` — 1353 passing, 3 failing. All three failures (`randomAccessFields` directive parsing, `replayStructures`) reproduce with this branch's `resources/` reverted to the previously reviewed head, so they are base drift, not this change; the branch is well behind `main`. CI at the merge base is the authority.
- `npm run test:unit:main` cannot run on the authoring machine: `~/.harperdb/hdb_boot_properties.file` points at an unrelated local install whose `system.mdb` this branch cannot open. CI covers it.
- The [mid-loop rejection regression](https://github.com/HarperFast/harper/pull/2051/changes?w=1#diff-044077436ab82ecf6c481205bdf0ac84571b38edf4ce663842e72349c3a7b38cR111) is now parameterised over a throwing and a non-throwing `warn` stub; the non-throwing arm is what pins `entriesDeleted === 1`, killing the `onSuccess?.()`-before-`warn` mutation the previous single arm let through.
- Temporary 4,000-entry LMDB purge diagnostic — deletion completed in 56.6 ms at the 1,000-write cap; the diagnostic file was removed after measurement.
- `npx mocha unitTests/resources/subscriptionReplay.test.js` — 27 passing, 9 pending; `HARPER_STORAGE_ENGINE=lmdb` — 36 passing.
- Fresh unit and integration CI at `df65e3cdff4b` — every Node, Bun, uWS, and Windows shard passed; Windows purge completed `entries_deleted: 12000` in 2.149 seconds.
- Mutation check: removing the production callback's `return` makes the wiring test fail because `deleteHistory()` resolves before tombstone cleanup; restoring it passes.
- `npm run test:integration -- --isolation=none "integrationTests/apiTests/transaction-logs.test.mjs"` — 7/7 passing.

## Review coverage

Originally authored by GPT-5.6 Codex; the failure-reporting policy and the two follow-up cleanups by Claude Opus. Pre-push review at `df6b7987d83d`: Codex (graded) and Gemini, three rounds — one full and two delta. Round 1 found the unreachable `throw new Error('Versioned removal exhausted its retries')` in [`PrimaryRocksDatabase.removeIfVersion`](https://github.com/HarperFast/harper/pull/2051/changes?w=1#diff-857a3b7947228534c5055a20509e57ee05474fb84e726499a502a2cfc9631f83R44) (fixed — a single-retry flag, same two attempts and same `ERR_BUSY`-only retry) and comment narration (trimmed in `Table.ts` and `auditStore.ts`). Rounds 2 and 3 found no new correctness, concurrency, or error-handling defect. Round 1's Codex leg and domain adjudication timed out against the one-shot budget; Gemini carried independent coverage there.

Refs #1963

Co-Authored-By: GPT-5 Codex <noreply@openai.com>
Co-Authored-By: Claude Opus <noreply@anthropic.com>

🤖 Generated with [Codex](https://openai.com/codex/) and [Claude Code](https://claude.com/claude-code)

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=3 @ df6b7987d83d</sub>

<sub>Human-Review-Need: 3 @ df6b7987d83d</sub>
