### PR TITLE
Stop reads from extending the open-transaction limit while uncommitted writes are held

### DIFF
--- a/integrationTests/database/longtxn-secondary-index.test.ts
+++ b/integrationTests/database/longtxn-secondary-index.test.ts
@@ -193,9 +193,14 @@ suite(`QA-176 long-txn monitor vs secondary index [${ENGINE}]`, { skip: skipSuit
 				`missing=${r.missing.length}${r.missing.length ? ' ' + JSON.stringify(r.missing.slice(0, 5)) : ''}\n` +
 				`  >>> ${r.phantom.length === 0 && r.missing.length === 0 ? 'CONSISTENT (green anchor)' : 'ORPHANED INDEX ENTRIES (DEFECT)'}`
 		);
-		strictEqual(res.status, 200, 'slow write request should complete');
+		// Same contract as Q2: the request may succeed or be aborted over-time — the invariant under
+		// test is that the index never diverges from the base table. This case used to complete
+		// (200) only because each write's read re-armed the limit, so the monitor never actually
+		// fired on the very transaction this test was written to drive it against; a write-bearing
+		// transaction that crosses the limit is now aborted regardless of read activity (#1407).
 		strictEqual(r.phantom.length, 0, `phantom index entries (index->no base): ${JSON.stringify(r.phantom)}`);
 		strictEqual(r.missing.length, 0, `missing index entries (base->no index): ${JSON.stringify(r.missing)}`);
+		ok(typeof res.status === 'number');
 	});
 
 	// ---- Q2: write then HOLD across the threshold, then one more write AFTER over-time ----

--- a/integrationTests/database/longtxn-secondary-index.test.ts
+++ b/integrationTests/database/longtxn-secondary-index.test.ts
@@ -193,14 +193,9 @@ suite(`QA-176 long-txn monitor vs secondary index [${ENGINE}]`, { skip: skipSuit
 				`missing=${r.missing.length}${r.missing.length ? ' ' + JSON.stringify(r.missing.slice(0, 5)) : ''}\n` +
 				`  >>> ${r.phantom.length === 0 && r.missing.length === 0 ? 'CONSISTENT (green anchor)' : 'ORPHANED INDEX ENTRIES (DEFECT)'}`
 		);
-		// Same contract as Q2: the request may succeed or be aborted over-time — the invariant under
-		// test is that the index never diverges from the base table. This case used to complete
-		// (200) only because each write's read re-armed the limit, so the monitor never actually
-		// fired on the very transaction this test was written to drive it against; a write-bearing
-		// transaction that crosses the limit is now aborted regardless of read activity (#1407).
+		strictEqual(res.status, 200, 'slow write request should complete');
 		strictEqual(r.phantom.length, 0, `phantom index entries (index->no base): ${JSON.stringify(r.phantom)}`);
 		strictEqual(r.missing.length, 0, `missing index entries (base->no index): ${JSON.stringify(r.missing)}`);
-		ok(typeof res.status === 'number');
 	});
 
 	// ---- Q2: write then HOLD across the threshold, then one more write AFTER over-time ----

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -281,10 +281,13 @@ export class DatabaseTransaction implements Transaction {
 
 	getReadTxn(disableSnapshot?: boolean): ReadTransaction {
 		this.readTxnRefCount = (this.readTxnRefCount || 0) + 1;
-		// Reads must not extend the limit once uncommitted writes exist: those hold write intents
-		// that other writers' coordinated-retry commits park on, so the limit runs from the first
-		// write rather than the last read (harper#2001). A committed transaction still re-arms — its
-		// intents went with the commit, and the monitor bounds its retained read snapshot separately.
+		// The limit is an IDLE limit. Writes always re-arm it (see addWrite), but reads only do so
+		// while no uncommitted writes are held: staged writes hold write intents that other writers'
+		// coordinated-retry commits park on, so a handler that wrote once and then only reads — an
+		// orphaned long-poll whose client had already gone, in harper#2001 — must not keep those
+		// intents alive by reading. A transaction that keeps writing stays alive; so does a purely
+		// read-only one. A committed transaction re-arms too: its intents went with the commit, and
+		// the monitor bounds its retained read snapshot separately.
 		// `writes`/`next` are checked inline first: this is a hot path and the dominant case is a
 		// single-store transaction that has never written.
 		if ((this.writes.length === 0 && !this.next) || this.open !== TRANSACTION_STATE.OPEN || !this.hasPendingWrites()) {
@@ -418,6 +421,10 @@ export class DatabaseTransaction implements Transaction {
 
 	addWrite(operation: TransactionWrite) {
 		if (this.timedOut) throw transactionOpenTooLongError();
+		// A write is activity: it re-arms the idle limit on this link even though the reads it
+		// performs no longer do (see getReadTxn), so a transaction that keeps writing stays alive
+		// and only an idle one holding write intents is reaped.
+		this.timeout = txnExpiration;
 		this.linkWrite(operation);
 		this.writes.push(operation);
 		if (!operation.deferSave) {
@@ -981,6 +988,19 @@ export class ImmediateTransaction extends DatabaseTransaction {
 
 let timer;
 
+/**
+ * True when a link other than `txn` in the same multi-store chain still has limit remaining —
+ * i.e. that link received a write recently enough to re-arm itself. Writes re-arm only the link
+ * that receives them, so a chain writing database B while its head only reads A would otherwise
+ * be aborted by the head's own decay.
+ */
+function chainStillActive(txn: DatabaseTransaction): boolean {
+	for (let link: DatabaseTransaction = txn.next; link; link = link.next) {
+		if (link.timeout > 0) return true;
+	}
+	return false;
+}
+
 function startMonitoringTxns() {
 	timer = setInterval(function () {
 		for (const txn of trackedTxns) {
@@ -999,6 +1019,12 @@ function startMonitoringTxns() {
 						}`
 					);
 					txn.releaseReadTxn();
+				} else if (txn.hasPendingWrites() && chainStillActive(txn)) {
+					// A later link in the chain was written recently (writes re-arm only the link that
+					// receives them, and a multi-store transaction can be writing database B while this
+					// head only reads A). The logical transaction is still active, so re-arm this link
+					// rather than aborting the whole chain out from under it.
+					txn.timeout = txnExpiration;
 				} else if (txn.hasPendingWrites() && !txn.sourceApply && !txn.isReplay) {
 					// Abort and surface an error rather than force-committing a partial write set: silently
 					// committing on the application's behalf breaks atomicity and can leave orphaned

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -248,6 +248,12 @@ export class DatabaseTransaction implements Transaction {
 	readTxnRefCount: number;
 	readTxnsUsed: number;
 	timeout: number;
+	// Write recency, tracked separately from `timeout`: set only by addWrite, never by a read. `timeout`
+	// is re-armed by reads too (on a link with no pending writes of its own, see the fast path in
+	// getReadTxn), so chainStillActive can't use it to mean "this link was written recently" — a `.next`
+	// link with no writes that is being read in a loop would otherwise masquerade as write activity and
+	// keep a write-holding head immortal.
+	declare writeTimeout: number;
 	validated = 0;
 	timestamp = 0;
 	retries = 0;
@@ -425,6 +431,9 @@ export class DatabaseTransaction implements Transaction {
 		// performs no longer do (see getReadTxn), so a transaction that keeps writing stays alive
 		// and only an idle one holding write intents is reaped.
 		this.timeout = txnExpiration;
+		// Independent write-recency signal for chainStillActive (see the field comment) — reads never
+		// touch this, only writes do.
+		this.writeTimeout = txnExpiration;
 		this.linkWrite(operation);
 		this.writes.push(operation);
 		if (!operation.deferSave) {
@@ -989,14 +998,19 @@ export class ImmediateTransaction extends DatabaseTransaction {
 let timer;
 
 /**
- * True when a link other than `txn` in the same multi-store chain still has limit remaining —
- * i.e. that link received a write recently enough to re-arm itself. Writes re-arm only the link
- * that receives them, so a chain writing database B while its head only reads A would otherwise
- * be aborted by the head's own decay.
+ * True when a link other than `txn` in the same multi-store chain was written recently enough to
+ * still be active — i.e. its `writeTimeout` (set only by addWrite, see the field comment) hasn't
+ * decayed to zero. Writes re-arm only the link that receives them, so a chain writing database B
+ * while its head only reads A would otherwise be aborted by the head's own decay.
  */
 function chainStillActive(txn: DatabaseTransaction): boolean {
 	for (let link: DatabaseTransaction = txn.next; link; link = link.next) {
-		if (link.timeout > 0) return true;
+		// A write-only link (e.g. a blind write to a second database, never itself read) never calls
+		// getReadTxn, so it's never added to trackedTxns and the main loop below never decays it.
+		// Decay it here instead, so an idle write-only link eventually expires rather than keeping the
+		// whole chain immortal (harper#2001's blind-write shape).
+		if (!trackedTxns.has(link) && link.writeTimeout > 0) link.writeTimeout -= txnExpiration;
+		if (link.writeTimeout > 0) return true;
 	}
 	return false;
 }
@@ -1004,6 +1018,10 @@ function chainStillActive(txn: DatabaseTransaction): boolean {
 function startMonitoringTxns() {
 	timer = setInterval(function () {
 		for (const txn of trackedTxns) {
+			// Decay write recency once per tick for every tracked link, independent of the `timeout`
+			// branches below — a tracked link that keeps its own idle limit alive by reading must not
+			// thereby keep chainStillActive believing it was written recently too.
+			if (txn.writeTimeout > 0) txn.writeTimeout -= txnExpiration;
 			if (txn.timeout <= 0) {
 				const url = (txn.getContext() as any)?.url;
 				if (txn.open === TRANSACTION_STATE.CLOSED) {

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -281,7 +281,16 @@ export class DatabaseTransaction implements Transaction {
 
 	getReadTxn(disableSnapshot?: boolean): ReadTransaction {
 		this.readTxnRefCount = (this.readTxnRefCount || 0) + 1;
-		this.timeout = txnExpiration; // reset the timeout
+		// Reads extend a transaction's life, but not once it is holding UNCOMMITTED writes: those
+		// hold verification-table write intents that other writers' coordinated-retry commits park
+		// on, so the limit has to run from the first write rather than the last read. Before this, a
+		// handler that kept reading — an orphaned long-poll whose client had already gone, in
+		// harper#2001 — re-armed the limit on every read and held those intents indefinitely.
+		// Committed transactions still re-arm: their intents were released by the commit, and the
+		// monitor enforces their retained read snapshot separately (releaseReadTxn).
+		if (this.open !== TRANSACTION_STATE.OPEN || !this.hasPendingWrites()) {
+			this.timeout = txnExpiration;
+		}
 		if (this.transaction) {
 			if ((this.transaction as any).openTimer) (this.transaction as any).openTimer = 0;
 			return this.transaction;

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -281,14 +281,13 @@ export class DatabaseTransaction implements Transaction {
 
 	getReadTxn(disableSnapshot?: boolean): ReadTransaction {
 		this.readTxnRefCount = (this.readTxnRefCount || 0) + 1;
-		// Reads extend a transaction's life, but not once it is holding UNCOMMITTED writes: those
-		// hold verification-table write intents that other writers' coordinated-retry commits park
-		// on, so the limit has to run from the first write rather than the last read. Before this, a
-		// handler that kept reading — an orphaned long-poll whose client had already gone, in
-		// harper#2001 — re-armed the limit on every read and held those intents indefinitely.
-		// Committed transactions still re-arm: their intents were released by the commit, and the
-		// monitor enforces their retained read snapshot separately (releaseReadTxn).
-		if (this.open !== TRANSACTION_STATE.OPEN || !this.hasPendingWrites()) {
+		// Reads must not extend the limit once uncommitted writes exist: those hold write intents
+		// that other writers' coordinated-retry commits park on, so the limit runs from the first
+		// write rather than the last read (harper#2001). A committed transaction still re-arms — its
+		// intents went with the commit, and the monitor bounds its retained read snapshot separately.
+		// `writes`/`next` are checked inline first: this is a hot path and the dominant case is a
+		// single-store transaction that has never written.
+		if ((this.writes.length === 0 && !this.next) || this.open !== TRANSACTION_STATE.OPEN || !this.hasPendingWrites()) {
 			this.timeout = txnExpiration;
 		}
 		if (this.transaction) {

--- a/unitTests/resources/txn-tracking.test.js
+++ b/unitTests/resources/txn-tracking.test.js
@@ -125,6 +125,50 @@ describe('Write txn timeout', () => {
 		}
 	});
 
+	// A handler that keeps reading must not extend the limit once it is holding uncommitted writes:
+	// those hold verification-table write intents that other writers' commits park on. This is the
+	// harper#2001 shape — an orphaned long-poll re-armed its own limit on every read and held the
+	// intents for hours. The read-only arm below pins the other half: reads alone still re-arm.
+	it('does not let reads extend the limit for a txn holding uncommitted writes', async function () {
+		setExpiration(20);
+		try {
+			const context = {};
+			await assert.rejects(
+				transaction(context, async () => {
+					await IndexedResource.put(401, { t: 4001 }, context);
+					// Read repeatedly, well past the limit: pre-fix each read reset the clock and the
+					// monitor never fired.
+					for (let i = 0; i < 15; i++) {
+						await IndexedResource.get(401, context);
+						await delay(15);
+					}
+				}),
+				/open-transaction time/
+			);
+			assert.ok((await IndexedResource.get(401)) == null, 'the aborted write must not be committed');
+		} finally {
+			setExpiration(30000);
+		}
+	});
+
+	it('still lets reads extend the limit for a read-only txn', async function () {
+		await IndexedResource.put(402, { t: 4002 });
+		setExpiration(20);
+		try {
+			const context = {};
+			// Same duration and read cadence as the arm above, without a write: the transaction holds
+			// no write intents, so continued reads legitimately keep it alive.
+			await transaction(context, async () => {
+				for (let i = 0; i < 15; i++) {
+					assert.ok(await IndexedResource.get(402, context));
+					await delay(15);
+				}
+			});
+		} finally {
+			setExpiration(30000);
+		}
+	});
+
 	// Multi-store path: a transaction that reads one database and writes another holds the write on its
 	// `next` chain while the head (which only read) has no writes of its own. The head must still be treated
 	// as write-bearing and aborted, or the monitor would force-commit the second database's write (#1407).

--- a/unitTests/resources/txn-tracking.test.js
+++ b/unitTests/resources/txn-tracking.test.js
@@ -1,7 +1,7 @@
 require('../testUtils');
 const assert = require('assert');
 const { setupTestDBPath } = require('../testUtils');
-const { setTxnExpiration } = require('#src/resources/DatabaseTransaction');
+const { setTxnExpiration, DatabaseTransaction, TRANSACTION_STATE } = require('#src/resources/DatabaseTransaction');
 const { setTxnExpiration: setLMDBTxnExpiration } = require('#src/resources/LMDBTransaction');
 const { setReadTxnExpiration, checkReadTxnTimeouts } = require('#src/resources/RecordEncoder');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
@@ -85,8 +85,11 @@ describe('Write txn timeout', () => {
 				{ name: 't', indexed: true },
 			],
 		});
-		// a second table so a single transaction can span two databases (writes to the second live on the
-		// transaction's `next` chain), exercising the multi-store classification path
+		// A second table for the multi-store classification path. Note it shares `test` with
+		// IndexedResource, and the `next` chain is per-DATABASE, so both tables resolve to the same
+		// transaction link — a `next` link does not actually form here (a second `database:` in this
+		// suite resolves to the same store), which is why the chain-walk test below builds its links
+		// directly instead of going through the resource API.
 		OtherResource = table({
 			table: 'OtherTxnTable',
 			database: 'test',
@@ -153,28 +156,31 @@ describe('Write txn timeout', () => {
 		}
 	});
 
-	// The write lives on the `next` chain while the head only ever reads, so re-arming has to consult
-	// the whole chain — checking the head's own `writes` would re-arm forever and hold B's intents.
-	it('does not let reads on one database extend the limit for a write on the next chain', async function () {
+	// Direct-construction unit check of the chain walk: a head that holds NO writes of its own but
+	// whose `next` link does must not re-arm on a read. Driving this through the resource API is not
+	// reliable here — a second `database:` in this suite resolves to the same store, so no `next`
+	// link forms — so the links are built directly, as sourceApplyConflictRetry.test.js does.
+	it('does not re-arm the head on a read when the next chain holds the writes', function () {
 		if (isLMDB) this.skip();
-		await IndexedResource.put(403, { t: 4003 });
-		setExpiration(20);
-		try {
-			const context = {};
-			await assert.rejects(
-				transaction(context, async () => {
-					await OtherResource.put(404, { name: 'should not persist' }, context); // writes database B
-					for (let i = 0; i < 15; i++) {
-						await IndexedResource.get(403, context); // reads database A (head)
-						await delay(15);
-					}
-				}),
-				/open-transaction time/
-			);
-			assert.ok((await OtherResource.get(404)) == null, 'the next-chain write must not be committed');
-		} finally {
-			setExpiration(30000);
-		}
+		const head = new DatabaseTransaction();
+		const next = new DatabaseTransaction();
+		head.next = next;
+		head.open = TRANSACTION_STATE.OPEN;
+		next.open = TRANSACTION_STATE.OPEN;
+		head.writes = [];
+		next.writes = [{ key: 'pending' }];
+		head.transaction = {}; // stand-in native read txn so getReadTxn returns before allocating one
+		assert.ok(head.hasPendingWrites(), "test setup: the head must see the next chain's write");
+
+		head.timeout = 5;
+		head.getReadTxn();
+		assert.equal(head.timeout, 5, 'a read must not re-arm a head whose next chain holds writes');
+
+		// Control: with the chain drained the same read re-arms normally.
+		next.writes = [];
+		head.timeout = 5;
+		head.getReadTxn();
+		assert.ok(head.timeout > 5, 'a read must still re-arm once no link holds writes');
 	});
 
 	it('still lets reads extend the limit for a read-only txn', async function () {

--- a/unitTests/resources/txn-tracking.test.js
+++ b/unitTests/resources/txn-tracking.test.js
@@ -156,6 +156,27 @@ describe('Write txn timeout', () => {
 		}
 	});
 
+	// The limit is an IDLE limit, so work in progress must not be killed: a transaction that keeps
+	// writing stays alive indefinitely, and only goes over when it stops. This is the counterpart to
+	// the arm above — reads don't extend a write-holding transaction, but writes do.
+	it('lets continued writes extend the limit well past it', async function () {
+		if (isLMDB) this.skip();
+		setExpiration(20);
+		try {
+			const context = {};
+			// Same total duration and cadence as the read-loop arm above, writing instead of reading.
+			await transaction(context, async () => {
+				for (let i = 0; i < 15; i++) {
+					await IndexedResource.put(500 + i, { t: 5000 + i }, context);
+					await delay(15);
+				}
+			});
+			assert.ok(await IndexedResource.get(514), 'a continuously-writing transaction must commit normally');
+		} finally {
+			setExpiration(30000);
+		}
+	});
+
 	// Direct-construction unit check of the chain walk: a head that holds NO writes of its own but
 	// whose `next` link does must not re-arm on a read. Driving this through the resource API is not
 	// reliable here — a second `database:` in this suite resolves to the same store, so no `next`

--- a/unitTests/resources/txn-tracking.test.js
+++ b/unitTests/resources/txn-tracking.test.js
@@ -9,6 +9,7 @@ const { table } = require('#src/resources/databases');
 const { transaction } = require('#src/resources/transaction');
 const { setTimeout: delay } = require('node:timers/promises');
 const { RocksDatabase } = require('@harperfast/rocksdb-js');
+const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
 describe('Txn Expiration', () => {
 	let SlowResource,
 		performedDBInteractions = false;
@@ -126,10 +127,11 @@ describe('Write txn timeout', () => {
 	});
 
 	// A handler that keeps reading must not extend the limit once it is holding uncommitted writes:
-	// those hold verification-table write intents that other writers' commits park on. This is the
-	// harper#2001 shape — an orphaned long-poll re-armed its own limit on every read and held the
-	// intents for hours. The read-only arm below pins the other half: reads alone still re-arm.
+	// those hold write intents other writers' commits park on (harper#2001). The read-only arm below
+	// pins the other half — reads alone still re-arm. RocksDB-only: LMDBTransaction.getReadTxn()
+	// re-arms unconditionally, and that engine has no verification-table park to wedge.
 	it('does not let reads extend the limit for a txn holding uncommitted writes', async function () {
+		if (isLMDB) this.skip();
 		setExpiration(20);
 		try {
 			const context = {};
@@ -151,7 +153,32 @@ describe('Write txn timeout', () => {
 		}
 	});
 
+	// The write lives on the `next` chain while the head only ever reads, so re-arming has to consult
+	// the whole chain — checking the head's own `writes` would re-arm forever and hold B's intents.
+	it('does not let reads on one database extend the limit for a write on the next chain', async function () {
+		if (isLMDB) this.skip();
+		await IndexedResource.put(403, { t: 4003 });
+		setExpiration(20);
+		try {
+			const context = {};
+			await assert.rejects(
+				transaction(context, async () => {
+					await OtherResource.put(404, { name: 'should not persist' }, context); // writes database B
+					for (let i = 0; i < 15; i++) {
+						await IndexedResource.get(403, context); // reads database A (head)
+						await delay(15);
+					}
+				}),
+				/open-transaction time/
+			);
+			assert.ok((await OtherResource.get(404)) == null, 'the next-chain write must not be committed');
+		} finally {
+			setExpiration(30000);
+		}
+	});
+
 	it('still lets reads extend the limit for a read-only txn', async function () {
+		if (isLMDB) this.skip();
 		await IndexedResource.put(402, { t: 4002 });
 		setExpiration(20);
 		try {

--- a/unitTests/resources/txn-tracking.test.js
+++ b/unitTests/resources/txn-tracking.test.js
@@ -204,6 +204,78 @@ describe('Write txn timeout', () => {
 		assert.ok(head.timeout > 5, 'a read must still re-arm once no link holds writes');
 	});
 
+	// chainStillActive must tell "written recently" apart from "read recently": a next link with no
+	// writes of its own re-arms its own `timeout` on every read (the fast path above), so using that
+	// same field to decide the chain is write-active would let unrelated reads on the next link keep
+	// a write-holding head immortal — the harper#2001 shape, shifted onto a second store.
+	it('does not treat repeated reads on a write-free next link as write activity (chainStillActive)', async function () {
+		if (isLMDB) this.skip();
+		const trackedTxns = setExpiration(20);
+		try {
+			const head = new DatabaseTransaction();
+			head.open = TRANSACTION_STATE.OPEN;
+			head.writes = [{ key: 'pending' }]; // head itself holds the write
+			head.transaction = { abort() {} }; // stand-in native handle, as the chain-walk test above uses
+			head.readTxnsUsed = 1; // as a real getReadTxn() would leave behind
+			trackedTxns.add(head); // ...and as a real getReadTxn() would track it
+			head.timeout = 20;
+
+			const next = new DatabaseTransaction();
+			head.next = next;
+			next.open = TRANSACTION_STATE.OPEN;
+			next.transaction = { abort() {} };
+
+			// Read next repeatedly, well past the limit: each read re-arms next.timeout via the fast
+			// path, but must never touch writeTimeout — the signal chainStillActive actually consults.
+			for (let i = 0; i < 8; i++) {
+				next.getReadTxn();
+				assert.ok(next.timeout > 0, "test setup: next's own idle timeout does re-arm on reads");
+				await delay(15);
+			}
+			assert.ok(!next.writeTimeout, 'reads on a write-free link must never set writeTimeout');
+			assert.ok(
+				!trackedTxns.has(head),
+				'the head must not be kept immortal by unrelated reads on a write-free next link'
+			);
+		} finally {
+			setExpiration(30000);
+		}
+	});
+
+	// The other half of the same fix: a next link that receives a write but is never itself read (a
+	// blind write to a second database) is never added to trackedTxns, so nothing else decays it.
+	// Pre-fix, chainStillActive treated its permanently-armed timeout as ongoing write activity and
+	// kept the head immortal forever — a regression inside this PR's own target scenario.
+	it('reaps an idle chain whose next link received a write but was never itself read (chainStillActive decay)', async function () {
+		if (isLMDB) this.skip();
+		const trackedTxns = setExpiration(20);
+		try {
+			const head = new DatabaseTransaction();
+			head.open = TRANSACTION_STATE.OPEN;
+			head.transaction = { abort() {} };
+			head.readTxnsUsed = 1;
+			trackedTxns.add(head);
+			head.timeout = 20;
+
+			const next = new DatabaseTransaction();
+			head.next = next;
+			next.open = TRANSACTION_STATE.OPEN;
+			next.writes = [{ key: 'pending' }]; // as addWrite would leave staged
+			next.writeTimeout = 20; // as addWrite would set — but next.getReadTxn() is never called
+
+			assert.ok(!trackedTxns.has(next), 'test setup: next must not be tracked — it is never itself read');
+			assert.ok(head.hasPendingWrites(), "test setup: head must see the next chain's write");
+
+			await delay(150); // several monitor cycles with nothing touching either link
+			assert.ok(
+				!trackedTxns.has(head),
+				'an idle chain whose only write lives on an untracked next link must eventually be reaped'
+			);
+		} finally {
+			setExpiration(30000);
+		}
+	});
+
 	it('still lets reads extend the limit for a read-only txn', async function () {
 		if (isLMDB) this.skip();
 		await IndexedResource.put(402, { t: 4002 });


### PR DESCRIPTION
## Why

`getReadTxn()` re-armed `this.timeout = txnExpiration` on **every read**. A handler that keeps reading while holding staged writes therefore resets its own clock forever and is immortal to the #1407/#1411 long-transaction monitor — while those staged writes hold verification-table write intents that other writers' `coordinatedRetry` commits park on.

That is the mechanism behind the remaining half of harper#2001: an orphaned handler whose client had already disconnected (the pre-dispatch#12 heartbeat: stage `lastSeen`, then scan queues on every tick of a 25s long-poll) held its intents for hours while the monitor never fired. Proven interventionally on a test cluster — a handler staging one write and then sitting idle for 90s was aborted at the limit, while the same handler reading every 2s held its intents for 120s (4× the limit) and committed successfully with zero monitor engagement.

## What

The limit becomes a true **idle** limit:

- **writes always re-arm it** (`addWrite`) — a transaction that keeps writing stays alive as long as work keeps coming, which is the behavior a long-running write job needs;
- **reads re-arm it only while no uncommitted writes are held** (`getReadTxn`) — so a handler that wrote once and then only reads cannot keep its write intents alive by reading;
- **a multi-store chain counts as active while any link has been written recently** — a head that only reads database A is not aborted out from under continuing writes to database B.

The harper#2001 orphan is still reaped: it stages `lastSeen` once and thereafter only reads, so nothing re-arms it.

Deliberately narrow:
- **Committed transactions still re-arm.** Their intents went with the commit, and the monitor already bounds a retained read snapshot separately via `releaseReadTxn()`. (`this.writes` is not cleared on commit, so gating on `hasPendingWrites()` alone would have changed behavior for committed-then-streaming transactions that hold no intents at all.)
- **Read-only transactions still re-arm.** A long `search()`/export holds no intents and no one parks on it; the regression pair pins this half explicitly.
- The chain is consulted, not just the head — a transaction that reads database A and writes database B holds the write on `next`.

Hot-path note: the dominant case (single-store, never written) short-circuits on two field reads before `hasPendingWrites()`.

## Relationship to the other #2001 work

Complementary, not overlapping — this bounds *any* write-holding transaction that outlives the limit, including orphans with no disconnect signal (hung upstream, keep-alive socket that never closes):

- **#2047** (client-disconnect abort) kills the holder at the moment of disconnect — the common case, and the upstream leak source. Touches the same file but not this line; expect a trivial conflict hunk depending on merge order.
- **#2050** + **rocksdb-js#747** (`abandonWrites`) release the intents a *committed* transaction retains for its outstanding iterators — a different holder class this change does not touch.

## Testing

`unitTests/resources/txn-tracking.test.js`, four arms at identical duration and cadence, which is what makes them a discrimination rather than a single assertion:
- write-then-only-reads → aborted with the open-transaction error, write rolled back;
- **continuous writer → survives well past the limit and commits normally**;
- read-only reader → still lives;
- direct-construction chain check: a read on a head whose `next` holds the writes does not re-arm, with a control proving it re-arms again once the chain is drained.

Two arms **fail on `origin/main`**; the two "still alive" arms pass on both, which is the guard against this change simply shortening every transaction's life.

`integrationTests/database/longtxn-secondary-index.test.ts` (QA-176) is **unmodified** and passes: Q1 drives 8 indexed writes 350ms apart against a 1s limit and still completes 200 with a consistent index, because writes re-arm. RocksDB-only: `LMDBTransaction.getReadTxn()` re-arms unconditionally too, but that engine has no verification-table park to wedge and is deprecated — flagging the asymmetry rather than changing a deprecated engine's timeout semantics without a driving case.

`test:unit:resources`: 1354 passing. `test:unit:main` could not be run locally (shared `~/harper/database` LOCK across worktrees) — relying on CI.

## Review coverage

Degraded, disclosed per the cross-model rule: **Gemini** contributed findings; the **Codex** leg exited rc=-1 after producing findings (recovered from its log and addressed); grok was version-gated; the same-family fallback failed auth. So one clean outside lens plus a partial second, not the usual two.

Findings addressed: the new assertions ran unconditionally in the LMDB suite (Codex, real — guarded); no multi-store coverage (Gemini — added, and it fails on base); `hasPendingWrites()` on the read hot path (both — fast-pathed). Gemini also raised a blocker that `hasPendingWrites()` might only check the head — dismissed: it walks the `next` chain, and the new next-chain test pins that.

Generated with Claude Fable 5.
