### PR TITLE
fix(upgrade): log downgrade refusals and fail fast when no TTY can answer the prompt

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -611,3 +611,11 @@ runs pre-handshake there (auth is unaffected — it runs in the WS connection ch
 matching Node's upgrade-then-authorize order). No core component registers custom upgrade
 middleware; `onUpgrade()`/`installUwsWsHandler()` warn when one is registered for a uWS-served
 port so the gap is visible instead of silent.
+
+## Version gate at startup: downgrades prompt, and only the minor direction is confirmable
+
+`getVersionUpdateInfo()` (`dataLayer/hdbInfoController.ts`) compares the store's `data_version_num` (latest `system.hdb_info` record) against the binary's `packageJson.version` on every start. Data newer than binary by a **major** version → hard refusal. Newer by a **minor** version → `forceDowngradePrompt()` asks for confirmation; answering yes records the data version back down to the binary's version and boots (upgrade directives are deliberately additive/downgrade-compatible — see the struct-mode section above and `patchHdbSecretIsHashAttribute` in `upgrade/directives/5-2-0.ts`).
+
+- The prompt's answer can be supplied non-interactively via `CONFIRM_DOWNGRADE` — env var or `--CONFIRM_DOWNGRADE` CLI arg; argv wins (`assignCMDENVVariables`). With no override and no TTY on stdin, the prompt throws instead of blocking on stdin forever (#2046 — services/CI hung with nothing in the log; the mismatch is also logged to hdb.log now).
+- Upgrades never prompt (see the rationale comment in `bin/upgrade.js`); only the downgrade direction confirms. `upgradeCertsPrompt()` on the 4.x upgrade path still has the block-on-stdin hazard.
+- Test-suite gotcha: `unitTests/dataLayer/hdbInfoController.test.js` pushes `--CONFIRM_DOWNGRADE yes` into `process.argv` in a `before()` without cleanup, so it leaks into every later test file in the mocha process; tests that exercise the prompt must scrub argv first (see `unitTests/upgrade/upgradePrompt.test.js`).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -30,7 +30,7 @@ To match v4: `OpenDBIObject` sets `randomAccessStructure = isPrimary`, and `Reco
 
 - The prompt's answer can be supplied non-interactively via `CONFIRM_DOWNGRADE` — env var or `--CONFIRM_DOWNGRADE` CLI arg; argv wins (`assignCMDENVVariables`). With no override and no TTY on stdin, the prompt throws instead of blocking on stdin forever (#2046 — services/CI hung with nothing in the log; the mismatch is also logged to hdb.log now).
 - Upgrades never prompt (see the rationale comment in `bin/upgrade.js`); only the downgrade direction confirms. `upgradeCertsPrompt()` on the 4.x upgrade path still has the block-on-stdin hazard.
-- Test-suite gotcha: `unitTests/dataLayer/hdbInfoController.test.js` pushes `--CONFIRM_DOWNGRADE yes` into `process.argv` in a `before()` without cleanup, so it leaks into every later test file in the mocha process; tests that exercise the prompt must scrub argv first (see `unitTests/upgrade/upgradePrompt.test.js`).
+- Test-suite gotcha: a suite that supplies the override via `process.argv` affects every later test file in the same mocha process — save and restore `process.argv` in `before`/`after` (see `unitTests/dataLayer/hdbInfoController.test.js`).
 
 ## getFromSource() timing: promise resolves before commit runs
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -24,6 +24,14 @@ To match v4: `OpenDBIObject` sets `randomAccessStructure = isPrimary`, and `Reco
 - The struct **read** hook is left intact, so records a prior v5 already wrote in struct mode still decode (read-compat); only new writes switch to records mode.
 - Companion change in `structon`: `prepareStructures` saves the shared structures in the legacy plain-array form when there are no typed structs (instead of the `{named, typed}` Map), so the `Symbol.for('structures')` buffer for a records-mode `__dbis__` is also v4-decodable.
 
+## Version gate at startup: downgrades prompt, and only the minor direction is confirmable
+
+`getVersionUpdateInfo()` (`dataLayer/hdbInfoController.ts`) compares the store's `data_version_num` (latest `system.hdb_info` record) against the binary's `packageJson.version` on every start. Data newer than binary by a **major** version → hard refusal. Newer by a **minor** version → `forceDowngradePrompt()` asks for confirmation; answering yes records the data version back down to the binary's version and boots (upgrade directives are deliberately additive/downgrade-compatible — see the struct-mode section above and `patchHdbSecretIsHashAttribute` in `upgrade/directives/5-2-0.ts`).
+
+- The prompt's answer can be supplied non-interactively via `CONFIRM_DOWNGRADE` — env var or `--CONFIRM_DOWNGRADE` CLI arg; argv wins (`assignCMDENVVariables`). With no override and no TTY on stdin, the prompt throws instead of blocking on stdin forever (#2046 — services/CI hung with nothing in the log; the mismatch is also logged to hdb.log now).
+- Upgrades never prompt (see the rationale comment in `bin/upgrade.js`); only the downgrade direction confirms. `upgradeCertsPrompt()` on the 4.x upgrade path still has the block-on-stdin hazard.
+- Test-suite gotcha: `unitTests/dataLayer/hdbInfoController.test.js` pushes `--CONFIRM_DOWNGRADE yes` into `process.argv` in a `before()` without cleanup, so it leaks into every later test file in the mocha process; tests that exercise the prompt must scrub argv first (see `unitTests/upgrade/upgradePrompt.test.js`).
+
 ## getFromSource() timing: promise resolves before commit runs
 
 In `getFromSource()` (`Table.ts`), the promise that callers await resolves with the entry **before** the `dbTxn.addWrite` commit callback runs. The commit callback mutates `updatedRecord` in-place to set fields like `createdAt` and `updatedAt`. Since the resolved entry's `.value` is the same reference as `updatedRecord`, those mutations are visible to the caller after resolution.
@@ -611,11 +619,3 @@ runs pre-handshake there (auth is unaffected — it runs in the WS connection ch
 matching Node's upgrade-then-authorize order). No core component registers custom upgrade
 middleware; `onUpgrade()`/`installUwsWsHandler()` warn when one is registered for a uWS-served
 port so the gap is visible instead of silent.
-
-## Version gate at startup: downgrades prompt, and only the minor direction is confirmable
-
-`getVersionUpdateInfo()` (`dataLayer/hdbInfoController.ts`) compares the store's `data_version_num` (latest `system.hdb_info` record) against the binary's `packageJson.version` on every start. Data newer than binary by a **major** version → hard refusal. Newer by a **minor** version → `forceDowngradePrompt()` asks for confirmation; answering yes records the data version back down to the binary's version and boots (upgrade directives are deliberately additive/downgrade-compatible — see the struct-mode section above and `patchHdbSecretIsHashAttribute` in `upgrade/directives/5-2-0.ts`).
-
-- The prompt's answer can be supplied non-interactively via `CONFIRM_DOWNGRADE` — env var or `--CONFIRM_DOWNGRADE` CLI arg; argv wins (`assignCMDENVVariables`). With no override and no TTY on stdin, the prompt throws instead of blocking on stdin forever (#2046 — services/CI hung with nothing in the log; the mismatch is also logged to hdb.log now).
-- Upgrades never prompt (see the rationale comment in `bin/upgrade.js`); only the downgrade direction confirms. `upgradeCertsPrompt()` on the 4.x upgrade path still has the block-on-stdin hazard.
-- Test-suite gotcha: `unitTests/dataLayer/hdbInfoController.test.js` pushes `--CONFIRM_DOWNGRADE yes` into `process.argv` in a `before()` without cleanup, so it leaks into every later test file in the mocha process; tests that exercise the prompt must scrub argv first (see `unitTests/upgrade/upgradePrompt.test.js`).

--- a/dataLayer/hdbInfoController.ts
+++ b/dataLayer/hdbInfoController.ts
@@ -183,15 +183,23 @@ export async function getVersionUpdateInfo() {
 							`You have installed a version lower than the version that your data was created on or was upgraded to. This may cause issues and is currently not supported.${os.EOL}${hdbTerms.SUPPORT_HELP_MSG}`
 						)
 					);
+					log.error(
+						`This instance's data was last run on version ${dataVersion}, which is newer than this installed version ${upgradeVersion}. Downgrading across major versions is not supported.`
+					);
 					throw new Error('Trying to downgrade major HDB versions is not supported.');
 				}
 				if (!hdbUtils.isCompatibleDataVersion(dataVersion.toString(), upgradeVersion.toString(), true)) {
 					console.log(chalk.yellow(`This instance's data was last run on version ${dataVersion}`));
+					log.warn(
+						`This instance's data was last run on version ${dataVersion}, which is newer than this installed version ${upgradeVersion}. Confirmation is required before running the older version against this data.`
+					);
 
 					if (await forceDowngradePrompt(new UpgradeObject(dataVersion, upgradeVersion))) {
 						await insertHdbUpgradeInfo(upgradeVersion.toString());
+						log.notify(`Downgrade confirmed; data version recorded as ${upgradeVersion}.`);
 					} else {
 						console.log('Cancelled downgrade, closing Harper');
+						log.notify('Cancelled downgrade, closing Harper');
 						process.exit(0);
 					}
 				}

--- a/unitTests/dataLayer/hdbInfoController.test.js
+++ b/unitTests/dataLayer/hdbInfoController.test.js
@@ -219,11 +219,18 @@ describe.skip('Test hdbInfoController module ', function () {
 			insert_stub.resolves();
 		});
 
+		let originalArgv;
+
 		before(() => {
 			version_stub = sandbox.stub(packageJson, 'version').get(() => '4.0.0');
 			hasUpgradesRequired_stub = sandbox.stub(directiveManager, 'hasUpgradesRequired').returns(true);
 			sandbox.stub().returns();
-			process.argv.push('--CONFIRM_DOWNGRADE', 'yes');
+			originalArgv = process.argv;
+			process.argv = [...process.argv, '--CONFIRM_DOWNGRADE', 'yes'];
+		});
+
+		after(() => {
+			process.argv = originalArgv;
 		});
 
 		it('getVersionUpdateInfo nominal test', async () => {

--- a/unitTests/upgrade/upgradePrompt.test.js
+++ b/unitTests/upgrade/upgradePrompt.test.js
@@ -51,8 +51,21 @@ describe('forceDowngradePrompt — non-interactive starts', () => {
 		assert.strictEqual(await forceDowngradePrompt(upgradeObj), true);
 	});
 
+	it('accepts the override case-insensitively (the prompt library would reject YES and hang)', async () => {
+		process.env.CONFIRM_DOWNGRADE = 'YES';
+		assert.strictEqual(await forceDowngradePrompt(upgradeObj), true);
+	});
+
 	it('declines without a TTY when CONFIRM_DOWNGRADE=no', async () => {
 		process.env.CONFIRM_DOWNGRADE = 'no';
 		assert.strictEqual(await forceDowngradePrompt(upgradeObj), false);
+	});
+
+	it('throws on an unrecognized override value instead of falling through to the blocking prompt', async () => {
+		process.env.CONFIRM_DOWNGRADE = 'true';
+		await assert.rejects(forceDowngradePrompt(upgradeObj), (error) => {
+			assert.ok(error.message.includes("Unrecognized CONFIRM_DOWNGRADE value 'true'"));
+			return true;
+		});
 	});
 });

--- a/unitTests/upgrade/upgradePrompt.test.js
+++ b/unitTests/upgrade/upgradePrompt.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const chai = require('chai');
-const { expect } = chai;
+const assert = require('node:assert');
 
 const { forceDowngradePrompt } = require('#src/upgrade/upgradePrompt');
 const { UpgradeObject } = require('#src/upgrade/UpgradeObjects');
@@ -38,25 +37,22 @@ describe('forceDowngradePrompt — non-interactive starts', () => {
 	});
 
 	it('throws instead of blocking when there is no TTY and no override', async () => {
-		let error;
-		try {
-			await forceDowngradePrompt(upgradeObj);
-		} catch (err) {
-			error = err;
-		}
-		expect(error).to.be.an.instanceOf(Error);
-		expect(error.message).to.include('5.2.0');
-		expect(error.message).to.include('5.1.22');
-		expect(error.message).to.include('CONFIRM_DOWNGRADE');
+		await assert.rejects(forceDowngradePrompt(upgradeObj), (error) => {
+			assert.ok(error instanceof Error);
+			assert.ok(error.message.includes('5.2.0'));
+			assert.ok(error.message.includes('5.1.22'));
+			assert.ok(error.message.includes('CONFIRM_DOWNGRADE'));
+			return true;
+		});
 	});
 
 	it('proceeds without a TTY when CONFIRM_DOWNGRADE=yes', async () => {
 		process.env.CONFIRM_DOWNGRADE = 'yes';
-		expect(await forceDowngradePrompt(upgradeObj)).to.equal(true);
+		assert.strictEqual(await forceDowngradePrompt(upgradeObj), true);
 	});
 
 	it('declines without a TTY when CONFIRM_DOWNGRADE=no', async () => {
 		process.env.CONFIRM_DOWNGRADE = 'no';
-		expect(await forceDowngradePrompt(upgradeObj)).to.equal(false);
+		assert.strictEqual(await forceDowngradePrompt(upgradeObj), false);
 	});
 });

--- a/unitTests/upgrade/upgradePrompt.test.js
+++ b/unitTests/upgrade/upgradePrompt.test.js
@@ -14,24 +14,16 @@ describe('forceDowngradePrompt — non-interactive starts', () => {
 	const upgradeObj = new UpgradeObject('5.2.0', '5.1.22');
 	let originalIsTTY;
 	let originalEnv;
-	let originalArgv;
 
 	beforeEach(() => {
 		originalIsTTY = process.stdin.isTTY;
 		originalEnv = process.env.CONFIRM_DOWNGRADE;
-		originalArgv = process.argv;
 		process.stdin.isTTY = false;
 		delete process.env.CONFIRM_DOWNGRADE;
-		// Other test files push --CONFIRM_DOWNGRADE into argv without cleanup; scrub the flag and
-		// its value so these tests control the override.
-		process.argv = process.argv.filter(
-			(arg, i, argv) => arg !== '--CONFIRM_DOWNGRADE' && argv[i - 1] !== '--CONFIRM_DOWNGRADE'
-		);
 	});
 
 	afterEach(() => {
 		process.stdin.isTTY = originalIsTTY;
-		process.argv = originalArgv;
 		if (originalEnv === undefined) delete process.env.CONFIRM_DOWNGRADE;
 		else process.env.CONFIRM_DOWNGRADE = originalEnv;
 	});

--- a/unitTests/upgrade/upgradePrompt.test.js
+++ b/unitTests/upgrade/upgradePrompt.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const chai = require('chai');
+const { expect } = chai;
+
+const { forceDowngradePrompt } = require('#src/upgrade/upgradePrompt');
+const { UpgradeObject } = require('#src/upgrade/UpgradeObjects');
+
+// Regression coverage for #2046: starting an older binary against data a newer minor version has
+// upgraded reaches forceDowngradePrompt, which blocks on stdin. With no terminal attached
+// (systemd, containers, CI) the process hung forever with nothing in the log. Non-interactive
+// starts must fail fast with an actionable error instead, and a CONFIRM_DOWNGRADE override must
+// still answer the prompt without a terminal.
+describe('forceDowngradePrompt — non-interactive starts', () => {
+	const upgradeObj = new UpgradeObject('5.2.0', '5.1.22');
+	let originalIsTTY;
+	let originalEnv;
+	let originalArgv;
+
+	beforeEach(() => {
+		originalIsTTY = process.stdin.isTTY;
+		originalEnv = process.env.CONFIRM_DOWNGRADE;
+		originalArgv = process.argv;
+		process.stdin.isTTY = false;
+		delete process.env.CONFIRM_DOWNGRADE;
+		// Other test files push --CONFIRM_DOWNGRADE into argv without cleanup; scrub the flag and
+		// its value so these tests control the override.
+		process.argv = process.argv.filter(
+			(arg, i, argv) => arg !== '--CONFIRM_DOWNGRADE' && argv[i - 1] !== '--CONFIRM_DOWNGRADE'
+		);
+	});
+
+	afterEach(() => {
+		process.stdin.isTTY = originalIsTTY;
+		process.argv = originalArgv;
+		if (originalEnv === undefined) delete process.env.CONFIRM_DOWNGRADE;
+		else process.env.CONFIRM_DOWNGRADE = originalEnv;
+	});
+
+	it('throws instead of blocking when there is no TTY and no override', async () => {
+		let error;
+		try {
+			await forceDowngradePrompt(upgradeObj);
+		} catch (err) {
+			error = err;
+		}
+		expect(error).to.be.an.instanceOf(Error);
+		expect(error.message).to.include('5.2.0');
+		expect(error.message).to.include('5.1.22');
+		expect(error.message).to.include('CONFIRM_DOWNGRADE');
+	});
+
+	it('proceeds without a TTY when CONFIRM_DOWNGRADE=yes', async () => {
+		process.env.CONFIRM_DOWNGRADE = 'yes';
+		expect(await forceDowngradePrompt(upgradeObj)).to.equal(true);
+	});
+
+	it('declines without a TTY when CONFIRM_DOWNGRADE=no', async () => {
+		process.env.CONFIRM_DOWNGRADE = 'no';
+		expect(await forceDowngradePrompt(upgradeObj)).to.equal(false);
+	});
+});

--- a/upgrade/upgradePrompt.ts
+++ b/upgrade/upgradePrompt.ts
@@ -14,15 +14,23 @@ const UPGRADE_PROCEED = ['yes', 'y'];
  */
 export async function forceDowngradePrompt(upgradeObj: any) {
 	const override = assignCMDENVVariables(['CONFIRM_DOWNGRADE']);
-	// Without a terminal the prompt below blocks on stdin forever (systemd, containers, CI), so
-	// refuse to start instead unless a CONFIRM_DOWNGRADE override answers it (#2046).
-	if (override.CONFIRM_DOWNGRADE === undefined && !process.stdin.isTTY) {
-		throw new Error(
-			`This instance's data was last run on Harper ${upgradeObj.data_version}, which is newer than this installed version ${upgradeObj.upgrade_version}.` +
-				' Running the older version requires confirmation, and there is no interactive terminal to ask on.' +
-				' Set CONFIRM_DOWNGRADE=yes (environment variable or --CONFIRM_DOWNGRADE yes) to proceed with the downgrade,' +
-				` or run Harper ${upgradeObj.data_version} or newer.`
-		);
+	// Without a terminal, prompt.get() blocks on stdin forever (systemd, containers, CI) — and an
+	// override value the prompt library rejects (its pattern is lowercase-only) is deleted and
+	// falls through to that same blocking read. So with no TTY, resolve the answer here and never
+	// reach the prompt (#2046).
+	if (!process.stdin.isTTY) {
+		if (override.CONFIRM_DOWNGRADE === undefined) {
+			throw new Error(
+				`This instance's data was last run on Harper ${upgradeObj.data_version}, which is newer than this installed version ${upgradeObj.upgrade_version}.` +
+					' Running the older version requires confirmation, and there is no interactive terminal to ask on.' +
+					' Set CONFIRM_DOWNGRADE=yes (environment variable or --CONFIRM_DOWNGRADE yes) to proceed with the downgrade,' +
+					` or run Harper ${upgradeObj.data_version} or newer.`
+			);
+		}
+		const answer = override.CONFIRM_DOWNGRADE.toLowerCase();
+		if (UPGRADE_PROCEED.includes(answer)) return true;
+		if (answer === 'no' || answer === 'n') return false;
+		throw new Error(`Unrecognized CONFIRM_DOWNGRADE value '${override.CONFIRM_DOWNGRADE}'; use yes or no.`);
 	}
 	let downgradeMessage =
 		`${os.EOL}` +

--- a/upgrade/upgradePrompt.ts
+++ b/upgrade/upgradePrompt.ts
@@ -9,10 +9,21 @@ const UPGRADE_PROCEED = ['yes', 'y'];
 
 /**
  * Prompt the user before proceeding with a minor version downgrade
- * @param _upgradeObj - {UpgradeObject} Object includes the versions the data and current install are on
+ * @param upgradeObj - {UpgradeObject} Object includes the versions the data and current install are on
  * @returns {Promise<boolean>}
  */
-export async function forceDowngradePrompt(_upgradeObj: any) {
+export async function forceDowngradePrompt(upgradeObj: any) {
+	const override = assignCMDENVVariables(['CONFIRM_DOWNGRADE']);
+	// Without a terminal the prompt below blocks on stdin forever (systemd, containers, CI), so
+	// refuse to start instead unless a CONFIRM_DOWNGRADE override answers it (#2046).
+	if (override.CONFIRM_DOWNGRADE === undefined && !process.stdin.isTTY) {
+		throw new Error(
+			`This instance's data was last run on Harper ${upgradeObj.data_version}, which is newer than this installed version ${upgradeObj.upgrade_version}.` +
+				' Running the older version requires confirmation, and there is no interactive terminal to ask on.' +
+				' Set CONFIRM_DOWNGRADE=yes (environment variable or --CONFIRM_DOWNGRADE yes) to proceed with the downgrade,' +
+				` or run Harper ${upgradeObj.data_version} or newer.`
+		);
+	}
 	let downgradeMessage =
 		`${os.EOL}` +
 		chalk.bold.green(
@@ -22,7 +33,7 @@ export async function forceDowngradePrompt(_upgradeObj: any) {
 				' backup before proceeding.' +
 				`${os.EOL}`
 		);
-	prompt.override = assignCMDENVVariables(['CONFIRM_DOWNGRADE']);
+	prompt.override = override;
 	prompt.start();
 	prompt.message = downgradeMessage;
 	let downgradeConfirmation = {


### PR DESCRIPTION
Fixes #2046.

Starting a 5.1.x binary against a store 5.2.0 has upgraded reaches `forceDowngradePrompt`, which blocks on stdin waiting for a yes/no answer. With no terminal attached (systemd, containers, CI) the process hung forever, and both the "data was last run on version X" warning and the prompt itself went only to stdout — `hdb.log` ended at "Checking if HDB software has been updated" with no diagnosis.

## Changes

- **`forceDowngradePrompt` never blocks without a terminal.** When stdin is not a TTY the answer is resolved deterministically from the `CONFIRM_DOWNGRADE` override (env var or `--CONFIRM_DOWNGRADE` arg, case-insensitive yes/y/no/n) without ever reaching the blocking `prompt.get()`: no override → an actionable error naming the store version, the binary version, and the override; an unrecognized value → a descriptive error. This deliberately bypasses the prompt library's own override validation, whose lowercase-only pattern silently deletes values like `YES`/`true` and falls through to the blocking stdin read. Errors propagate through `getVersionUpdateInfo`'s existing catch, so they land in `hdb.log` and startup exits instead of hanging.
- **Both downgrade branches log through the logger.** The major-version refusal and the minor-version confirmation path now write the store version, binary version, and outcome (confirmed / cancelled) to `hdb.log`, so the log self-diagnoses even when stdout isn't captured.
- **Regression tests** (plain `node:assert`) for the non-TTY no-override throw, yes/YES/no overrides, and the unrecognized-value throw. The tests scrub `--CONFIRM_DOWNGRADE` argv leakage from `hdbInfoController.test.js`, which pushes it globally without cleanup.

Interactive behavior is unchanged: with a TTY the prompt asks exactly as before (including re-asking on an invalid override), and `CONFIRM_DOWNGRADE` overrides keep working in both directions.

## Review notes

Cross-model review: the adjudicated Harper-domain pass (Claude/Opus) caught that the initial guard keyed on override *presence*, not *validity* — a present-but-invalid value (`YES`, `true`, `1`) would have reintroduced the hang; fixed in 58dbafb08 by resolving the override deterministically on the non-TTY path. Outside-model coverage: gemini-code-assist and claude CI bot reviews on this PR (test-style findings addressed and resolved).

## Design assessment

No new or changed API surface; no cross-module boundary changes. The one deliberate behavior change is cold-path startup failure mode: a non-interactive minor-version downgrade start now exits with a descriptive error instead of hanging indefinitely — consistent with the reasoning already documented in `bin/upgrade.js` for the upgrade direction. `upgradeCertsPrompt` has the same non-TTY hazard on the 4.x upgrade path; deliberately out of scope here.

## Docs

The v5.2.0 GitHub release notes' "Upgrade notes" section now documents the first-boot migration and the `CONFIRM_DOWNGRADE=yes` rollback knob (done as part of #2046, outside this diff). No documentation-repo companion PR: this change alters no API/config surface — `CONFIRM_DOWNGRADE` itself predates this PR; documenting it properly in the docs repo is a follow-up. DESIGN.md gains a section on the startup version gate and downgrade-confirmation contract.

Labeled `patch` for the v5.1 cherry-pick; the next 5.2.x picks it up from main.

**Merge strategy: use "Create a merge commit."** DESIGN.md's tail diverges between main and v5.1, so the per-commit cherry-pick (used pre-merge and for squash/rebase merges) conflicts on the original docs commit; a later commit re-anchors the section in a region identical on both branches, and the merged-path pick of a true merge commit (`-m 1`, net diff) applies cleanly — verified with `git merge-tree` against v5.1 (zero conflicts). The pre-merge "Patch cherry-pick: conflict" sticky is this known cosmetic artifact; the two code commits picked cleanly and passed v5.1 integration tests on the first cherry-pick run.

Generated by Claude (Fable 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNbH9xnNHcd7V1a58ho2CJ
