### PR TITLE
`delete_transaction_logs_before` with a table on RocksDB now returns an error instead of deleting the entire database's transaction log

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -479,6 +479,20 @@ corrupt by verify). This closes the "healthy-looking but incomplete" and concurr
 the remaining engine/blob point-in-time skew (a blob unlinked between the engine cut and the blob
 walk) is the documented best-effort limitation above.
 
+## RocksDB transaction log purges are database-wide only (`ResourceBridge.deleteTransactionLogsBefore`)
+
+On RocksDB, every table in a database writes to one shared set of transaction logs (partitioned per
+origin node, not per table), and `purgeLogs()` deletes whole log files — rocksdb-js has no table
+filter, and adding one would mean rewriting files instead of deleting them. So a table-scoped
+`delete_transaction_logs_before` is unimplementable at the storage layer; the bridge rejects
+`table` on RocksDB with a 400 rather than silently purging every sibling table's history
+(harper#2049 — the original code did exactly that, and a _typo'd_ table name did too, because a
+missing table fell through to the no-table branch; that now 404s). Two consequences to preserve:
+the deprecated `delete_audit_logs_before` op _requires_ `table`, so it always errors on RocksDB
+(the message steers callers to the new op without `table`); and the table/no-table checks in the
+bridge use `!= null` presence, not truthiness, so a table named `"0"` addressed numerically stays
+table-scoped instead of widening to a database purge.
+
 ## Scheduler: cluster-once execution without a consensus primitive (`resources/scheduler/`)
 
 The built-in `scheduler` plugin (#951) runs config-declared jobs "exactly once per cluster." The

--- a/dataLayer/harperBridge/ResourceBridge.ts
+++ b/dataLayer/harperBridge/ResourceBridge.ts
@@ -492,12 +492,25 @@ export class ResourceBridge extends BridgeMethods {
 				: typeof deleteObj.timestamp === 'string'
 					? Number.parseInt(deleteObj.timestamp)
 					: deleteObj.timestamp;
+		const databaseName = deleteObj.database || deleteObj.schema || DEFAULT_DATABASE;
 		const table = getTable(deleteObj);
+		// A nonexistent table must not fall through to the no-table branch below — on RocksDB that
+		// widens a table-scoped request (e.g. a typo) into a whole-database log purge (#2049).
+		// Presence check, not truthiness: a table named "0" addressed numerically is still table-scoped.
+		if (deleteObj.table != null && !table)
+			throw handleHDBError(
+				new Error(),
+				HDB_ERROR_MSGS.TABLE_NOT_FOUND(databaseName, deleteObj.table),
+				404,
+				undefined,
+				undefined,
+				true
+			);
 		if (!table) {
 			// no table, check if any of the tables are RocksDB
 			// since all tables share the same transaction log store, we break after the first
 			// RocksDB table is found
-			const tables = getDatabases()[deleteObj.database];
+			const tables = getDatabases()[databaseName];
 			if (tables) {
 				for (const table of Object.values(tables)) {
 					if (table.primaryStore instanceof RocksDatabase) {
@@ -509,9 +522,16 @@ export class ResourceBridge extends BridgeMethods {
 				}
 			}
 		} else if (table.primaryStore instanceof RocksDatabase) {
-			const deleted = table.primaryStore.purgeLogs({ before, includeEntryCounts: true });
-			totalResults.log_files_deleted += deleted.length;
-			totalResults.entries_deleted += deleted.reduce((acc, file) => acc + file.entries, 0);
+			// All tables in a RocksDB database share one transaction log with no per-table purge
+			// granularity; honoring `table` here would silently purge every sibling table's log (#2049).
+			throw handleHDBError(
+				new Error(),
+				`Table-level transaction log deletion is not supported for RocksDB tables because all tables in a database share one transaction log; to delete the transaction logs for the entire '${databaseName}' database, use delete_transaction_logs_before with only 'database' and 'timestamp'`,
+				400,
+				undefined,
+				undefined,
+				true
+			);
 		} else {
 			totalResults.entries_deleted += await table.deleteHistory(before, deleteObj.cleanup_deleted_records);
 		}
@@ -698,7 +718,8 @@ function getTable(operationObject: { database?: string; schema?: string; table?:
 	const databaseName = operationObject.database || operationObject.schema || DEFAULT_DATABASE;
 	const tables = getDatabases()[databaseName];
 	if (!tables) throw handleHDBError(new Error(), HDB_ERROR_MSGS.SCHEMA_NOT_FOUND(databaseName), 404);
-	return operationObject.table ? tables[operationObject.table] : undefined;
+	// Presence check, not truthiness, so a table named "0" resolves when addressed numerically.
+	return operationObject.table != null ? tables[operationObject.table] : undefined;
 }
 
 /**

--- a/integrationTests/apiTests/terminology.test.mjs
+++ b/integrationTests/apiTests/terminology.test.mjs
@@ -452,6 +452,10 @@ suite('Terminology aliases (database / primary_key)', (ctx) => {
 		await awaitJobCompleted(client, r.body.job_id, { timeoutSeconds: JOB_TIMEOUT_SECONDS });
 	});
 
+	// The two delete_audit_logs_before jobs below start fine but ERROR on RocksDB:
+	// the deprecated op requires `table`, and table-scoped transaction log deletion
+	// is rejected there because all tables in a database share one log (harper#2049).
+	// The database/schema param handling under test still resolves before that error.
 	test('delete_audit_logs_before with database param starts job', async () => {
 		const r = await client
 			.req()
@@ -463,7 +467,11 @@ suite('Terminology aliases (database / primary_key)', (ctx) => {
 			})
 			.expect((r) => assert.ok(r.body.message.includes('Starting job with id'), r.text))
 			.expect(200);
-		await awaitJobCompleted(client, r.body.job_id, { timeoutSeconds: JOB_TIMEOUT_SECONDS });
+		await awaitJobCompleted(client, r.body.job_id, {
+			timeoutSeconds: JOB_TIMEOUT_SECONDS,
+			// the error echoes the resolved database, proving the `database` param was honored
+			expectedError: "transaction logs for the entire 'job_guy' database",
+		});
 	});
 
 	test('delete_audit_logs_before without database starts job', async () => {
@@ -472,7 +480,11 @@ suite('Terminology aliases (database / primary_key)', (ctx) => {
 			.send({ operation: 'delete_audit_logs_before', table: 'friends', timestamp: 1690553291764 })
 			.expect((r) => assert.ok(r.body.message.includes('Starting job with id'), r.text))
 			.expect(200);
-		await awaitJobCompleted(client, r.body.job_id, { timeoutSeconds: JOB_TIMEOUT_SECONDS });
+		await awaitJobCompleted(client, r.body.job_id, {
+			timeoutSeconds: JOB_TIMEOUT_SECONDS,
+			// no database param resolves to the default 'data' database
+			expectedError: "transaction logs for the entire 'data' database",
+		});
 	});
 
 	test('csv_file_load with database param starts job', async () => {

--- a/integrationTests/apiTests/transaction-logs.test.mjs
+++ b/integrationTests/apiTests/transaction-logs.test.mjs
@@ -113,7 +113,27 @@ suite('Transaction Logs', (ctx) => {
 	test('delete_transaction_logs_before suiteStart deletes no files', async () => {
 		// `suiteStart` is from before any inserts happened — no log files should
 		// have been rotated out yet, so the job should run to completion with
-		// `log_files_deleted: 0` and `entries_deleted: 0`.
+		// `log_files_deleted: 0` and `entries_deleted: 0`. No `table`: on RocksDB
+		// the operation is database-wide only (harper#2049).
+		const response = await client
+			.req()
+			.send({
+				operation: 'delete_transaction_logs_before',
+				timestamp: `${suiteStart}`,
+				schema: SCHEMA,
+			})
+			.expect(200);
+
+		const jobId = getJobId(response.body);
+		const jobResponse = await awaitJob(client, jobId, 15);
+		assert.equal(jobResponse.body[0].result.log_files_deleted, 0, jobResponse.text);
+		assert.equal(jobResponse.body[0].result.entries_deleted, 0, jobResponse.text);
+	});
+
+	test('delete_transaction_logs_before with a table is rejected on RocksDB', async () => {
+		// All tables in a RocksDB database share one transaction log, so a
+		// table-scoped delete used to silently purge every sibling table's log
+		// (harper#2049). It must fail instead of widening the scope.
 		const response = await client
 			.req()
 			.send({
@@ -126,8 +146,8 @@ suite('Transaction Logs', (ctx) => {
 
 		const jobId = getJobId(response.body);
 		const jobResponse = await awaitJob(client, jobId, 15);
-		assert.equal(jobResponse.body[0].result.log_files_deleted, 0, jobResponse.text);
-		assert.equal(jobResponse.body[0].result.entries_deleted, 0, jobResponse.text);
+		assert.equal(jobResponse.body[0].status, 'ERROR', jobResponse.text);
+		assert.ok(JSON.stringify(jobResponse.body[0].message).includes('not supported for RocksDB'), jobResponse.text);
 	});
 
 	test('drop test_logs table', async () => {

--- a/integrationTests/apiTests/transactions.test.mjs
+++ b/integrationTests/apiTests/transactions.test.mjs
@@ -89,7 +89,12 @@ suite('Transactions / audit log', (ctx) => {
 			.expect(200);
 	});
 
-	test('delete_audit_logs_before returns deprecation hint', async () => {
+	test('delete_audit_logs_before is rejected on RocksDB', async () => {
+		// The deprecated op requires `table`, and on RocksDB table-scoped
+		// transaction log deletion is rejected because all tables in a database
+		// share one log (harper#2049) — so on RocksDB this op always fails with a
+		// message steering callers to delete_transaction_logs_before without a
+		// table. The success path (and its `deprecated` hint) is LMDB-only.
 		const response = await client
 			.req()
 			.send({
@@ -102,12 +107,8 @@ suite('Transactions / audit log', (ctx) => {
 
 		const jobId = getJobId(response.body);
 		const jobResponse = await awaitJob(client, jobId, 15);
-		assert.ok(jobResponse.body[0].message.includes('Successfully completed'), jobResponse.text);
-		assert.equal(
-			jobResponse.body[0].result?.deprecated,
-			'Please use delete_transaction_logs_before instead',
-			jobResponse.text
-		);
+		assert.equal(jobResponse.body[0].status, 'ERROR', jobResponse.text);
+		assert.ok(JSON.stringify(jobResponse.body[0].message).includes('not supported for RocksDB'), jobResponse.text);
 	});
 
 	test('create test_read table', async () => {

--- a/unitTests/resources/deleteTransactionLogsBeforeRocks.test.js
+++ b/unitTests/resources/deleteTransactionLogsBeforeRocks.test.js
@@ -1,0 +1,93 @@
+/**
+ * Regression guards for harper#2049: on RocksDB, all tables in a database share one
+ * transaction log with no per-table purge granularity, so a table-scoped
+ * delete_transaction_logs_before used to silently purge EVERY table's log in the
+ * database. A nonexistent table name (e.g. a typo) fell through to the same
+ * whole-database purge. Both must be rejected before any purge happens.
+ */
+require('../testUtils');
+const assert = require('node:assert');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const harperBridge = require('#src/dataLayer/harperBridge/harperBridge').default;
+
+describe('deleteTransactionLogsBefore on RocksDB (harper#2049)', () => {
+	if (process.env.HARPER_STORAGE_ENGINE === 'lmdb') return;
+
+	const DB = 'txnLogPurgeScope';
+	let TableA, TableB;
+
+	before(async () => {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		const attributes = [{ name: 'id', isPrimaryKey: true }, { name: 'name' }];
+		TableA = table({ table: 'TableA', database: DB, attributes });
+		TableB = table({ table: 'TableB', database: DB, attributes });
+		await TableA.put(1, { name: 'a1' });
+		await TableA.put(2, { name: 'a2' });
+		await TableB.put(1, { name: 'b1' });
+	});
+
+	async function historyCount(tbl) {
+		let count = 0;
+		for await (const _entry of tbl.getHistory()) count++;
+		return count;
+	}
+
+	it('rejects a table-scoped delete with a 400 and purges nothing', async () => {
+		await assert.rejects(
+			harperBridge.deleteTransactionLogsBefore({ database: DB, table: 'TableA', timestamp: Date.now() + 1000 }),
+			(error) => {
+				assert.strictEqual(error.statusCode, 400);
+				assert.match(error.message, /not supported for RocksDB/);
+				return true;
+			}
+		);
+		assert.ok((await historyCount(TableA)) >= 2, 'TableA history should be untouched');
+		assert.ok((await historyCount(TableB)) >= 1, 'TableB history should be untouched');
+	});
+
+	it('rejects a nonexistent table with a 404 instead of purging the whole database', async () => {
+		await assert.rejects(
+			harperBridge.deleteTransactionLogsBefore({ database: DB, table: 'NoSuchTable', timestamp: Date.now() + 1000 }),
+			(error) => {
+				assert.strictEqual(error.statusCode, 404);
+				return true;
+			}
+		);
+		assert.ok((await historyCount(TableA)) >= 2, 'TableA history should be untouched');
+		assert.ok((await historyCount(TableB)) >= 1, 'TableB history should be untouched');
+	});
+
+	it('treats a falsy table name as table-scoped rather than database-wide', async () => {
+		// A table named "0" addressed numerically must not fall into the no-table
+		// branch (which would purge the whole database's log on RocksDB).
+		table({ table: '0', database: DB, attributes: [{ name: 'id', isPrimaryKey: true }] });
+		await assert.rejects(
+			harperBridge.deleteTransactionLogsBefore({ database: DB, table: 0, timestamp: Date.now() + 1000 }),
+			(error) => {
+				assert.strictEqual(error.statusCode, 400);
+				assert.match(error.message, /not supported for RocksDB/);
+				return true;
+			}
+		);
+	});
+
+	it('rejects a nonexistent database with a 404', async () => {
+		await assert.rejects(
+			harperBridge.deleteTransactionLogsBefore({ database: 'NoSuchDatabase', timestamp: Date.now() + 1000 }),
+			(error) => {
+				assert.strictEqual(error.statusCode, 404);
+				return true;
+			}
+		);
+	});
+
+	it('still performs the database-wide purge when no table is given', async () => {
+		const results = await harperBridge.deleteTransactionLogsBefore({ database: DB, timestamp: Date.now() + 1000 });
+		assert.ok(results, 'should return results rather than throw');
+		assert.strictEqual(typeof results.entries_deleted, 'number');
+		assert.strictEqual(typeof results.log_files_deleted, 'number');
+	});
+});


### PR DESCRIPTION
Fixes #2049 ([RocksDB: table-scoped delete_transaction_logs_before destroys the entire database's transaction log](https://github.com/HarperFast/harper/issues/2049)).

## What changed

On RocksDB, all tables in a database share one transaction log, and rocksdb-js's `purgeLogs()` has no table dimension (whole-file purges, logs partitioned per origin node). The bridge previously *ignored* a `table` scope and purged the whole database's log — reporting success. Now, in `ResourceBridge.deleteTransactionLogsBefore`:

- `table` naming a RocksDB table → **400**, with a message pointing at the supported database-wide form (`delete_transaction_logs_before` with only `database` and `timestamp`).
- `table` naming a **nonexistent** table → **404** on either engine. The guard sits before the engine branch, so this is a behavior change on LMDB too: previously a typo'd name fell into the no-table branch — the whole-database purge on RocksDB, a silent `entries_deleted: 0` no-op on LMDB.
- The table checks use **presence (`!= null`), not truthiness**, in both the guard and `getTable()`, so a table named `"0"` addressed numerically stays table-scoped instead of widening to a database purge (found by cross-model review).
- No `table` → database-wide purge, unchanged. LMDB table-scoped `deleteHistory` → unchanged.

## Deliberate design consequence — reviewer attention here

The deprecated `delete_audit_logs_before` op **requires** `table` and funnels into the same bridge method, so on RocksDB it now **always errors** with the migration message. There is no way to honor its per-table contract on RocksDB without the silent widening this PR removes. Three integration tests that previously asserted job success for table-scoped calls were updated to assert the rejection (`transaction-logs.test.mjs`, `transactions.test.mjs`, `terminology.test.mjs` — the last now verifies database-param resolution via the database name echoed in the error).

Not addressed (same silent-ignore shape, but inert rather than destructive): `cleanup_deleted_records` is still silently ignored on the RocksDB no-table path — flagged in #2049 as a decide-alongside; can be a follow-up.

## Testing

- New unit tests (`unitTests/resources/deleteTransactionLogsBeforeRocks.test.js`, 5 passing): 400 on table-scoped, 404 on missing table/database, falsy-table-name regression, database-wide purge still succeeds. Skipped under `HARPER_STORAGE_ENGINE=lmdb`.
- `test:unit:resources` full run green (1365 passing); the three touched integration files green (75 passing).
- `test:integration:all` full run: 1624/1645 passing; the 3 failures (`shutdown-drain-e2e.test.ts`, `rolling-restart.test.ts`) reproduce identically on `origin/main` — pre-existing local-environment failures, unrelated to this change.
- Local `test:unit:main` hangs in `unitTests/components/applicationSpawn.test.js` on this machine **with and without this change** (verified A/B against main's `ResourceBridge.ts`) — known local-environment issue; relying on CI for that suite.

## Docs

Companion docs PR: [HarperFast/documentation#618](https://github.com/HarperFast/documentation/pull/618) — documents database-wide-only deletion on RocksDB and the deprecated op's behavior.

## Review

Cross-model review (thorough): author Claude (Fable 5); coverage: Codex ✓ (two findings — the falsy-table-name blocker and the dead-end error remediation — both fixed, then a final-artifact re-check ✓); Gemini ✗ (agy failing locally with a model/location config error; no Gemini coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
