### PR TITLE
Fix sourcedFrom cache-fill conflict convergence

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -49,13 +49,24 @@ the source responds, a valid positive, finite, Date-representable `sourceContext
 record's candidate version, and the reserved timestamp is only its fallback. A 304 retains the
 existing version.
 
+The candidate is capped at local time (`max(reserved token, Date.now())`). A record's version is also
+this node's ordering token — `precedesExistingVersion()` compares a write's transaction timestamp
+against it — so a source that reports a `lastModified` ahead of local time (a skewed origin clock)
+would otherwise make every later local write to that row look out-of-order and be discarded until
+wall-clock caught up. Capping costs the shared-version property only for that misbehaving case, and
+the cap is logged.
+
 The ordering token is not installed on `sourceContext.timestamp`: the source-resolution transaction
 keeps its own default timestamp, so a slow fetch does not backdate its transaction-log entry. LMDB
 stores the source candidate directly, preserving its separate source-version/local-time semantics;
 only RocksDB clamps a non-advancing candidate because it uses one version for both roles.
 
 Revalidations retain exact-CAS semantics, and a source miss cannot delete a record that raced the
-fetch. First fills may replace a raced record only when their candidate version orders after it. A
+fetch. First fills may replace a raced record only when their candidate version is strictly greater
+than the raced record's. The comparison is deliberately not `precedesExistingVersion()`: that breaks
+a version tie with the _executing_ node's name, and a fill from a shared source carries no node
+identity of its own, so two replicas resolving the same tie could keep different values at the same
+version — the one state anti-entropy cannot repair. On a tie the raced record wins on every replica. A
 RocksDB replacement whose candidate cannot advance the current version stores at the current version
 and carries `VERSION_NOT_UNIQUE_FLAG`; [rocksdb-js#766](https://github.com/HarperFast/rocksdb-js/pull/766)
 then refuses to publish or confirm that version through the VerificationTable. This avoids inventing

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -68,7 +68,7 @@ a version tie with the _executing_ node's name, and a fill from a shared source 
 identity of its own, so two replicas resolving the same tie could keep different values at the same
 version — the one state anti-entropy cannot repair. On a tie the raced record wins on every replica. A
 RocksDB replacement whose candidate cannot advance the current version stores at the current version
-and carries `VERSION_NOT_UNIQUE_FLAG`; [rocksdb-js#766](https://github.com/HarperFast/rocksdb-js/pull/766)
+and carries `VERSION_NOT_UNIQUE_FLAG`; rocksdb-js 2.8.0 ([#766](https://github.com/HarperFast/rocksdb-js/pull/766))
 then refuses to publish or confirm that version through the VerificationTable. This avoids inventing
 an epsilon timestamp solely to force replacement while keeping stale record-cache values from being
 vouched as fresh.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -40,6 +40,23 @@ Consequence: never replace `entry.value` with a copy of `updatedRecord` in this 
 
 The sharing cuts both ways: the caller's mutations are visible to the **commit**, which encodes whatever the object holds at commit time. A downstream consumer that mutates the resolved record before the deferred commit runs corrupts what gets persisted — `finalizeResponse` (`server/REST.ts`) did exactly this, overwriting `.headers` with a web `Headers` (no enumerable own keys → stored as `{}`) and stamping `.status` (#1702; LMDB-only because RocksDB commits encode synchronously). Consumers must copy before mutating; `finalizeResponse` now copies any `entryMap`-tracked record.
 
+## getFromSource() keeps source versions separate from fill ordering
+
+`getFromSource()` reserves a fallback timestamp before calling the source so competing first fills
+whose source does not report a version have a stable ordering token. An inherited request/transaction
+timestamp is used when present; otherwise the storage engine supplies a monotonic timestamp. After
+the source responds, a valid positive, finite, Date-representable `sourceContext.lastModified` is the
+record's candidate version, and the reserved timestamp is only its fallback. A 304 retains the
+existing version.
+
+Revalidations retain exact-CAS semantics, and a source miss cannot delete a record that raced the
+fetch. First fills may replace a raced record only when their candidate version orders after it. A
+RocksDB replacement whose candidate cannot advance the current version stores at the current version
+and carries `VERSION_NOT_UNIQUE_FLAG`; [rocksdb-js#766](https://github.com/HarperFast/rocksdb-js/pull/766)
+then refuses to publish or confirm that version through the VerificationTable. This avoids inventing
+an epsilon timestamp solely to force replacement while keeping stale record-cache values from being
+vouched as fresh.
+
 ## Blob orphan cleanup: pre-saved files outlive cancelled commits
 
 Blobs flagged with `saveBeforeCommit` (or `saveInRecord`) are written to disk in the `beforeIntermediate` phase of a `TransactionWrite`, _before_ the LMDB/RocksDB write commits. The write's commit callback can still skip the actual record write — for older versions, supersedence by future updates, residency mismatches, or full transaction abort. In every such path the file is on disk but no record references it.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -49,6 +49,11 @@ the source responds, a valid positive, finite, Date-representable `sourceContext
 record's candidate version, and the reserved timestamp is only its fallback. A 304 retains the
 existing version.
 
+The ordering token is not installed on `sourceContext.timestamp`: the source-resolution transaction
+keeps its own default timestamp, so a slow fetch does not backdate its transaction-log entry. LMDB
+stores the source candidate directly, preserving its separate source-version/local-time semantics;
+only RocksDB clamps a non-advancing candidate because it uses one version for both roles.
+
 Revalidations retain exact-CAS semantics, and a source miss cannot delete a record that raced the
 fetch. First fills may replace a raced record only when their candidate version orders after it. A
 RocksDB replacement whose candidate cannot advance the current version stores at the current version
@@ -56,6 +61,9 @@ and carries `VERSION_NOT_UNIQUE_FLAG`; [rocksdb-js#766](https://github.com/Harpe
 then refuses to publish or confirm that version through the VerificationTable. This avoids inventing
 an epsilon timestamp solely to force replacement while keeping stale record-cache values from being
 vouched as fresh.
+
+The flag is also applied to ordinary resequenced RocksDB writes. Those records remain ineligible for
+VerificationTable fast-path confirmation until a later write advances their version.
 
 ## Blob orphan cleanup: pre-saved files outlive cancelled commits
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
 				"minimist": "1.2.8",
 				"moment": "2.30.1",
 				"mqtt-packet": "~9.0.1",
-				"msgpackr": "2.0.5",
+				"msgpackr": "2.0.6",
 				"needle": "3.5.0",
 				"node-forge": "^1.3.1",
 				"node-stream-zip": "1.16.0",
@@ -2659,15 +2659,6 @@
 			],
 			"engines": {
 				"node": "^22.18.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@harperfast/rocksdb-js/node_modules/msgpackr": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.6.tgz",
-			"integrity": "sha512-plGul/tqjt9vqWFR9zyqyLZls6gb5KTLvnsRO2B9+TZ8tNiXiVI/CR8LiDWlAX4IUeVkQ9gsmzKA6voC2QOciw==",
-			"license": "MIT",
-			"optionalDependencies": {
-				"msgpackr-extract": "^3.0.4"
 			}
 		},
 		"node_modules/@harperfast/skills": {
@@ -11566,9 +11557,9 @@
 			"license": "MIT"
 		},
 		"node_modules/msgpackr": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.5.tgz",
-			"integrity": "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.6.tgz",
+			"integrity": "sha512-plGul/tqjt9vqWFR9zyqyLZls6gb5KTLvnsRO2B9+TZ8tNiXiVI/CR8LiDWlAX4IUeVkQ9gsmzKA6voC2QOciw==",
 			"license": "MIT",
 			"optionalDependencies": {
 				"msgpackr-extract": "^3.0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@fastify/cors": "^11.2.0",
 				"@fastify/static": "^9.1.3",
 				"@harperfast/extended-iterable": "1.0.3",
-				"@harperfast/rocksdb-js": "2.7.1",
+				"@harperfast/rocksdb-js": "2.8.0",
 				"@harperfast/skills": "^1.10.8",
 				"@turf/area": "6.5.0",
 				"@turf/boolean-contains": "6.5.0",
@@ -2495,13 +2495,13 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js/-/rocksdb-js-2.7.1.tgz",
-			"integrity": "sha512-Fs+Ki/9ysu4w0oGl4NN+6LWlKlQtUpw0RUZlOewbAXStEzJ4087Dk1vHKM2YqnAqNYoZb0UOz2XeoM8YkelMww==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js/-/rocksdb-js-2.8.0.tgz",
+			"integrity": "sha512-czswCG+1KCRMYe6XQcsh5u28IQ6EbIx9eXPQd0kmjiLbtoMjiszYE92756bZJSbDykbR2OJLOazMZg7+qfFSJA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@harperfast/extended-iterable": "1.0.3",
-				"msgpackr": "2.0.5",
+				"msgpackr": "2.0.6",
 				"ordered-binary": "1.6.1"
 			},
 			"bin": {
@@ -2511,20 +2511,20 @@
 				"node": "^22.18.0 || >=24.0.0"
 			},
 			"optionalDependencies": {
-				"@harperfast/rocksdb-js-darwin-arm64": "2.7.1",
-				"@harperfast/rocksdb-js-darwin-x64": "2.7.1",
-				"@harperfast/rocksdb-js-linux-arm64-glibc": "2.7.1",
-				"@harperfast/rocksdb-js-linux-arm64-musl": "2.7.1",
-				"@harperfast/rocksdb-js-linux-x64-glibc": "2.7.1",
-				"@harperfast/rocksdb-js-linux-x64-musl": "2.7.1",
-				"@harperfast/rocksdb-js-win32-arm64": "2.7.1",
-				"@harperfast/rocksdb-js-win32-x64": "2.7.1"
+				"@harperfast/rocksdb-js-darwin-arm64": "2.8.0",
+				"@harperfast/rocksdb-js-darwin-x64": "2.8.0",
+				"@harperfast/rocksdb-js-linux-arm64-glibc": "2.8.0",
+				"@harperfast/rocksdb-js-linux-arm64-musl": "2.8.0",
+				"@harperfast/rocksdb-js-linux-x64-glibc": "2.8.0",
+				"@harperfast/rocksdb-js-linux-x64-musl": "2.8.0",
+				"@harperfast/rocksdb-js-win32-arm64": "2.8.0",
+				"@harperfast/rocksdb-js-win32-x64": "2.8.0"
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-darwin-arm64": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-arm64/-/rocksdb-js-darwin-arm64-2.7.1.tgz",
-			"integrity": "sha512-H0aEOziU6WFaVUjoRvsWVUoIEAZ6ylLRYTa4z4R7SRVUt2pzpjiUMW1mHBTmIRAue/Fwsfm8SCM95WQj5goFKA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-arm64/-/rocksdb-js-darwin-arm64-2.8.0.tgz",
+			"integrity": "sha512-v7cj3bGpRptZHXSbhVzYJ0k+jyMD0Z0kX0u8YNZH6Xq+ifZ6zBkBbyoSdvQ2waGLJXxBORylUxTgYMvTZWiQBA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2538,9 +2538,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-darwin-x64": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-x64/-/rocksdb-js-darwin-x64-2.7.1.tgz",
-			"integrity": "sha512-YDPVGmfFyg9sCu3C+uulJa68o4B06pJ8MDWSgSqm+5uNXh4QNWuMSE1x2wLZYOt1hxE7xptHXzhMFFuSqIcvtg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-x64/-/rocksdb-js-darwin-x64-2.8.0.tgz",
+			"integrity": "sha512-9mMPPvRhxjLorE7u1gN3n+InzT4XHXQkHYdNKE6qN4iwZy0vM8iHoQLwIiN9GpzUiueEqBEilAP/9mIOHhMgBw==",
 			"cpu": [
 				"x64"
 			],
@@ -2554,9 +2554,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-arm64-glibc": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-glibc/-/rocksdb-js-linux-arm64-glibc-2.7.1.tgz",
-			"integrity": "sha512-8LoPDc4muFb4U09VMWC1BJZRA/CxYBer1eIRW6Td6EfB8lOiBgZlpQvmc44GilYgrH4/C1at8lMK+G24U2CDyA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-glibc/-/rocksdb-js-linux-arm64-glibc-2.8.0.tgz",
+			"integrity": "sha512-H1nNimVbIB4/6Sxv5DrxmP1asHLbxTCHuZ2ZN/zudqPkp/bTTSs5RsczOH6JeKTEUxUsJDTXM4nGRcn6LwFaOg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2573,9 +2573,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-arm64-musl": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-musl/-/rocksdb-js-linux-arm64-musl-2.7.1.tgz",
-			"integrity": "sha512-vqeH0JM/FUbQfx1Q5n21aBCiLUukN/qMXKa5d3YUQt7hH1fFA4d9wQhnRqwV9VbIjxm6i3drYAy5HaFkU2TV1g==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-musl/-/rocksdb-js-linux-arm64-musl-2.8.0.tgz",
+			"integrity": "sha512-EqG4lkYptNviIcPPaQjK+X4ufjqzSImIvVxP89GHFHrbOJkGgEwRpiya0gWfGu3vJ1iGL1XL1nsU/kEjeDOugg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2592,9 +2592,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-x64-glibc": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-glibc/-/rocksdb-js-linux-x64-glibc-2.7.1.tgz",
-			"integrity": "sha512-2pbbjq36Ln+ln31a3oDf2ic5IQNvrXNP9ND6LM7lMYUjuG/7tV3tWK79x2AyATym6iq0Kmz5Sp0b8tnUL2nQNg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-glibc/-/rocksdb-js-linux-x64-glibc-2.8.0.tgz",
+			"integrity": "sha512-MZPKZ6gF8kCy/KXTav4tc7T2uq+iOunxDOYq7nifZkCCy+0+C9U7g9CZx0NErORRQRP29x3z0zEKkCQ/go5c6Q==",
 			"cpu": [
 				"x64"
 			],
@@ -2611,9 +2611,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-x64-musl": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-2.7.1.tgz",
-			"integrity": "sha512-hrk3BvNjjrWV0j0XjDZ80r3XIQdLnP2nH/WNy+KFU484XEkdXONmj0zH0hsOJVItTv3JShEECWOk6BXlR3osaw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-2.8.0.tgz",
+			"integrity": "sha512-PnMn1f/UxGOZKxlayR82tzsFCGoaMu0mBGKMmP/r2rbxzX5T89T0c+aVhuhpgNrFlWXTdawlA10Oh/YjfT/2qQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2630,9 +2630,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-win32-arm64": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-2.7.1.tgz",
-			"integrity": "sha512-E4Y725WvIcJjfSidOJt/gee4ogKWaFxj8exX/D6Kw2+v5RxuVjMgyKyOIxXQ+nLd18XGXTKj6HtgYzWOJfbEGg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-2.8.0.tgz",
+			"integrity": "sha512-4khqmGbIebiCwY3FVIgcUXEmMapgWP8f97aNrbThPDCIkuJscB3yoAG4A8OJo+Jln/TdjJZOgy8e2ir9F926dA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2646,9 +2646,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-win32-x64": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-x64/-/rocksdb-js-win32-x64-2.7.1.tgz",
-			"integrity": "sha512-7TcSJ3gXgknoccLe+Tc0nqAxOA1kt5FE30GFrrTs7MyZczdO1rioRiccqhgcRA4UvW8Xc29GwJPd9ehmK8yYHg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-x64/-/rocksdb-js-win32-x64-2.8.0.tgz",
+			"integrity": "sha512-E5HpBAnRwotITq++534WCinMvYidkkPoaAD5uwBNHiQbNt6YYvNZllJAIh/bukXD+uO6DL6qUMmVkeBh3kWK5A==",
 			"cpu": [
 				"x64"
 			],
@@ -2659,6 +2659,15 @@
 			],
 			"engines": {
 				"node": "^22.18.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@harperfast/rocksdb-js/node_modules/msgpackr": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.6.tgz",
+			"integrity": "sha512-plGul/tqjt9vqWFR9zyqyLZls6gb5KTLvnsRO2B9+TZ8tNiXiVI/CR8LiDWlAX4IUeVkQ9gsmzKA6voC2QOciw==",
+			"license": "MIT",
+			"optionalDependencies": {
+				"msgpackr-extract": "^3.0.4"
 			}
 		},
 		"node_modules/@harperfast/skills": {

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
 		"@fastify/cors": "^11.2.0",
 		"@fastify/static": "^9.1.3",
 		"@harperfast/extended-iterable": "1.0.3",
-		"@harperfast/rocksdb-js": "2.7.1",
+		"@harperfast/rocksdb-js": "2.8.0",
 		"@harperfast/skills": "^1.10.8",
 		"@turf/area": "6.5.0",
 		"@turf/boolean-contains": "6.5.0",

--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
 		"minimist": "1.2.8",
 		"moment": "2.30.1",
 		"mqtt-packet": "~9.0.1",
-		"msgpackr": "2.0.5",
+		"msgpackr": "2.0.6",
 		"needle": "3.5.0",
 		"node-forge": "^1.3.1",
 		"node-stream-zip": "1.16.0",

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -804,7 +804,7 @@ export function recordUpdater(store, tableId, auditStore) {
 					: TIMESTAMP_ASSIGN_NEW | 0x4000 // or just assign a new one
 				: NO_TIMESTAMP;
 		const expiresAt = options?.expiresAt;
-		if (expiresAt >= 0) assignMetadata = Math.max(assignMetadata, 0) | HAS_EXPIRATION;
+		if (expiresAt >= 0) assignMetadata |= HAS_EXPIRATION;
 		if (isRocksDB && record !== undefined && existingEntry?.version != null && newVersion <= existingEntry.version) {
 			assignMetadata = Math.max(assignMetadata, 0) | VERSION_NOT_UNIQUE_FLAG;
 		}

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -122,6 +122,8 @@ export const HAS_NODE_ID = 64;
 export const PENDING_LOCAL_TIME = 1;
 export const HAS_STRUCTURE_UPDATE = 0x100;
 export const HAS_ADDITIONAL_AUDIT_REFS = 0x80;
+// Cross-package record-header contract with rocksdb-js VERSION_NOT_UNIQUE_FLAG.
+export const VERSION_NOT_UNIQUE_FLAG = 0x10000;
 
 const TRACKED_WRITE_TYPES = new Set(['put', 'patch', 'delete', 'message', 'publish']);
 // For now we use this as the private property mechanism for mapping records to entries.
@@ -806,6 +808,9 @@ export function recordUpdater(store, tableId, auditStore) {
 		if (expiresAt >= 0) assignMetadata |= HAS_EXPIRATION;
 		metadataInNextEncoding = assignMetadata;
 		expiresAtNextEncoding = expiresAt;
+		if (isRocksDB && record !== undefined && existingEntry?.version != null && newVersion <= existingEntry.version) {
+			metadataInNextEncoding = Math.max(metadataInNextEncoding, 0) | VERSION_NOT_UNIQUE_FLAG;
+		}
 		const putOptions: {
 			version: number;
 			instructedWrite?: boolean;

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -122,7 +122,6 @@ export const HAS_NODE_ID = 64;
 export const PENDING_LOCAL_TIME = 1;
 export const HAS_STRUCTURE_UPDATE = 0x100;
 export const HAS_ADDITIONAL_AUDIT_REFS = 0x80;
-// Cross-package record-header contract with rocksdb-js VERSION_NOT_UNIQUE_FLAG.
 export const VERSION_NOT_UNIQUE_FLAG = 0x10000;
 
 const TRACKED_WRITE_TYPES = new Set(['put', 'patch', 'delete', 'message', 'publish']);
@@ -805,12 +804,12 @@ export function recordUpdater(store, tableId, auditStore) {
 					: TIMESTAMP_ASSIGN_NEW | 0x4000 // or just assign a new one
 				: NO_TIMESTAMP;
 		const expiresAt = options?.expiresAt;
-		if (expiresAt >= 0) assignMetadata |= HAS_EXPIRATION;
+		if (expiresAt >= 0) assignMetadata = Math.max(assignMetadata, 0) | HAS_EXPIRATION;
+		if (isRocksDB && record !== undefined && existingEntry?.version != null && newVersion <= existingEntry.version) {
+			assignMetadata = Math.max(assignMetadata, 0) | VERSION_NOT_UNIQUE_FLAG;
+		}
 		metadataInNextEncoding = assignMetadata;
 		expiresAtNextEncoding = expiresAt;
-		if (isRocksDB && record !== undefined && existingEntry?.version != null && newVersion <= existingEntry.version) {
-			metadataInNextEncoding = Math.max(metadataInNextEncoding, 0) | VERSION_NOT_UNIQUE_FLAG;
-		}
 		const putOptions: {
 			version: number;
 			instructedWrite?: boolean;

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -6206,12 +6206,17 @@ export function makeTable(options) {
 					nodeName: 'source',
 					commit: (txnTime, existingEntry, _retry, transaction: any) => {
 						sourceWrite.skipped = false; // reset on each retry; cleanup happens after commit if still true
-						if (existingEntry?.version !== existingVersion) {
-							// don't do anything if the version has changed
+						if (
+							existingEntry?.version !== existingVersion &&
+							(existingVersion != null || precedesExistingVersion(txnTime, existingEntry) <= 0)
+						) {
+							// Revalidations retain exact-CAS semantics. Competing fills of a missing key use the
+							// table's deterministic ordering, so every node keeps the same winner.
 							sourceWrite.skipped = true;
 							return;
 						}
-						updateIndices(id, existingRecord, updatedRecord, transaction && { transaction });
+						const currentRecord = existingEntry?.value;
+						updateIndices(id, currentRecord, updatedRecord, transaction && { transaction });
 						if (updatedRecord) {
 							if (existingEntry) {
 								context.previousResidency = TableResource.getResidencyRecord(existingEntry.residencyId);
@@ -6228,7 +6233,7 @@ export function makeTable(options) {
 											: txnTime;
 							}
 							if (createdTimeProperty && updatedRecord[createdTimeProperty.name] == null) {
-								const existingCreatedTime = existingEntry?.value?.[createdTimeProperty.name];
+								const existingCreatedTime = currentRecord?.[createdTimeProperty.name];
 								if (existingCreatedTime != null) {
 									updatedRecord[createdTimeProperty.name] = existingCreatedTime;
 								} else {

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -6039,6 +6039,13 @@ export function makeTable(options) {
 		setLoadedFromSource(target, true);
 
 		const existingRecord = existingEntry?.value;
+		const inheritedTimestamp = context?.timestamp || context?.transaction?.timestamp;
+		const monotonicTimestamp = () =>
+			isRocksDB ? (primaryStore as RocksDatabase).getMonotonicTimestamp() : getNextMonotonicTime();
+		const sourceTimestamp =
+			inheritedTimestamp && (existingVersion == null || inheritedTimestamp > existingVersion)
+				? inheritedTimestamp
+				: Math.max(monotonicTimestamp(), existingVersion == null ? 0 : existingVersion + 0.000488);
 		// it is important to remember that this is _NOT_ part of the current transaction; nothing is changing
 		// with the canonical data, we are simply fulfilling our local copy of the canonical data, but still don't
 		// want a timestamp later than the current transaction
@@ -6056,6 +6063,7 @@ export function makeTable(options) {
 			noCacheStore: droppingTable,
 			source: null,
 			transaction: undefined,
+			timestamp: sourceTimestamp,
 			expiresAt: undefined,
 			lastModified: undefined,
 		};

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -6002,17 +6002,9 @@ export function makeTable(options) {
 		const existingVersion = existingEntry?.version;
 		const existingRecord = existingEntry?.value;
 		const inheritedTimestamp = context?.timestamp || context?.transaction?.timestamp;
-		const monotonicTimestamp = isRocksDB
-			? (primaryStore as RocksDatabase).getMonotonicTimestamp()
-			: getNextMonotonicTime();
-		const nextExistingVersion =
-			existingVersion == null
-				? 0
-				: existingVersion + Math.max(Math.abs(existingVersion) * Number.EPSILON, Number.MIN_VALUE);
 		const sourceTimestamp =
-			inheritedTimestamp && (existingVersion == null || inheritedTimestamp > existingVersion)
-				? inheritedTimestamp
-				: Math.max(monotonicTimestamp, nextExistingVersion);
+			inheritedTimestamp ||
+			(isRocksDB ? (primaryStore as RocksDatabase).getMonotonicTimestamp() : getNextMonotonicTime());
 		let whenResolved, timer;
 		// We start by locking the record so that there is only one resolution happening at once;
 		// if there is already a resolution in process, we want to use the results of that resolution
@@ -6052,8 +6044,7 @@ export function makeTable(options) {
 		setLoadedFromSource(target, true);
 
 		// it is important to remember that this is _NOT_ part of the current transaction; nothing is changing
-		// with the canonical data, we are simply fulfilling our local copy of the canonical data. We preserve the
-		// request timestamp unless advancing it is required to replace an existing version.
+		// with the canonical data, we are simply fulfilling our local copy of the canonical data.
 		// we create a new context for the source, we want to determine the timestamp and don't want to
 		// attribute this to the current user
 		const sourceContext = {
@@ -6090,13 +6081,19 @@ export function makeTable(options) {
 			// before the drain's fail-closed timeout below.
 			const commitPromise = transaction(sourceContext, async (_txn) => {
 				const start = performance.now();
-				let updatedRecord, assignCreatedTime;
+				let updatedRecord, assignCreatedTime, sourceVersion;
 				let hasChanges, invalidated;
 				try {
 					updatedRecord = await throttledCallToSource(source, id, sourceContext, existingEntry);
 					invalidated = metadataFlags & INVALIDATED;
-					let version = sourceContext.lastModified || (invalidated && existingVersion);
-					hasChanges = invalidated || version > existingVersion || !existingRecord;
+					const reportedVersion = sourceContext.lastModified;
+					const validReportedVersion =
+						typeof reportedVersion === 'number' &&
+						Number.isFinite(reportedVersion) &&
+						reportedVersion > 0 &&
+						!Number.isNaN(new Date(reportedVersion).getTime());
+					sourceVersion = validReportedVersion ? reportedVersion : sourceTimestamp;
+					hasChanges = invalidated || sourceVersion > existingVersion || !existingRecord;
 					const resolveDuration = performance.now() - start;
 					recordAction(resolveDuration, 'cache-resolution', tableName, null, 'success');
 					if (responseHeaders)
@@ -6110,7 +6107,7 @@ export function makeTable(options) {
 							if (status === 304) {
 								// revalidation of our current cached record
 								updatedRecord = existingRecord;
-								version = existingVersion;
+								sourceVersion = existingVersion;
 							} else if (!CACHEABLE_STATUS_CODES.has(status)) {
 								// non-cacheable status - propagate to client without caching
 								throw new ServerError(updatedRecord.body || 'Error from source', status);
@@ -6157,9 +6154,13 @@ export function makeTable(options) {
 					}
 					assignCreatedTime = createdTimeProperty && updatedRecord?.[createdTimeProperty.name] == null;
 					resolved = true;
+					const resolvedVersion =
+						isRocksDB && updatedRecord && existingVersion != null
+							? Math.max(sourceVersion, existingVersion)
+							: sourceVersion;
 					const resolvedEntry: Entry = {
 						key: id,
-						version,
+						version: resolvedVersion,
 						value: updatedRecord,
 						expiresAt: sourceContext.expiresAt,
 						metadataFlags: 0,
@@ -6218,17 +6219,21 @@ export function makeTable(options) {
 					store: primaryStore,
 					entry: undefined,
 					nodeName: 'source',
-					commit: (txnTime, existingEntry, _retry, transaction: any) => {
+					commit: (_txnTime, existingEntry, _retry, transaction: any) => {
 						sourceWrite.skipped = false; // reset on each retry; cleanup happens after commit if still true
 						if (
 							existingEntry?.version !== existingVersion &&
-							(existingVersion != null || !updatedRecord || precedesExistingVersion(txnTime, existingEntry) <= 0)
+							(existingVersion != null || !updatedRecord || precedesExistingVersion(sourceVersion, existingEntry) <= 0)
 						) {
 							// Revalidations retain exact-CAS semantics; first fills use deterministic ordering.
 							sourceWrite.skipped = true;
 							return;
 						}
 						const currentRecord = existingEntry?.value;
+						const recordVersion =
+							isRocksDB && existingEntry?.version != null
+								? Math.max(sourceVersion, existingEntry.version)
+								: sourceVersion;
 						updateIndices(id, currentRecord, updatedRecord, transaction && { transaction });
 						if (updatedRecord) {
 							if (existingEntry) {
@@ -6240,10 +6245,10 @@ export function makeTable(options) {
 							if (updatedTimeProperty) {
 								updatedRecord[updatedTimeProperty.name] =
 									updatedTimeProperty.type === 'Date'
-										? new Date(txnTime)
+										? new Date(recordVersion)
 										: updatedTimeProperty.type === 'String'
-											? new Date(txnTime).toISOString()
-											: txnTime;
+											? new Date(recordVersion).toISOString()
+											: recordVersion;
 							}
 							if (assignCreatedTime) {
 								const existingCreatedTime = currentRecord?.[createdTimeProperty.name];
@@ -6252,10 +6257,10 @@ export function makeTable(options) {
 								} else {
 									updatedRecord[createdTimeProperty.name] =
 										createdTimeProperty.type === 'Date'
-											? new Date(txnTime)
+											? new Date(recordVersion)
 											: createdTimeProperty.type === 'String'
-												? new Date(txnTime).toISOString()
-												: txnTime;
+												? new Date(recordVersion).toISOString()
+												: recordVersion;
 								}
 							}
 							const residency = residencyFromFunction(TableResource.getResidency(updatedRecord, context));
@@ -6287,14 +6292,14 @@ export function makeTable(options) {
 								residencyId = getResidencyId(residency);
 							}
 							logger.trace?.(
-								`Writing resolved record from source with id: ${id}, timestamp: ${new Date(txnTime).toISOString()}`
+								`Writing resolved record from source with id: ${id}, timestamp: ${new Date(recordVersion).toISOString()}`
 							);
 							// TODO: We are doing a double check for ifVersion that should probably be cleaned out
 							updateRecord(
 								id,
 								updatedRecord,
 								existingEntry,
-								txnTime,
+								recordVersion,
 								omitLocalRecord ? INVALIDATED : 0,
 								(audit && (hasChanges || omitLocalRecord)) || null,
 								{
@@ -6312,14 +6317,14 @@ export function makeTable(options) {
 							if (sourceContext.expiresAt) scheduleCleanup();
 						} else if (existingEntry) {
 							logger.trace?.(
-								`Deleting resolved record from source with id: ${id}, timestamp: ${new Date(txnTime).toISOString()}`
+								`Deleting resolved record from source with id: ${id}, timestamp: ${new Date(recordVersion).toISOString()}`
 							);
 							if (audit || trackDeletes) {
 								updateRecord(
 									id,
 									null,
 									existingEntry,
-									txnTime,
+									recordVersion,
 									0,
 									(audit && hasChanges) || null,
 									{ user: (sourceContext as any)?.user, transaction, tableToTrack: tableName },

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -6000,6 +6000,18 @@ export function makeTable(options) {
 		const metadataFlags = existingEntry?.metadataFlags;
 
 		const existingVersion = existingEntry?.version;
+		const existingRecord = existingEntry?.value;
+		const inheritedTimestamp = context?.timestamp || context?.transaction?.timestamp;
+		const monotonicTimestamp = () =>
+			isRocksDB ? (primaryStore as RocksDatabase).getMonotonicTimestamp() : getNextMonotonicTime();
+		const nextExistingVersion =
+			existingVersion == null
+				? 0
+				: existingVersion + Math.max(Math.abs(existingVersion) * Number.EPSILON, Number.MIN_VALUE);
+		const sourceTimestamp =
+			inheritedTimestamp && (existingVersion == null || inheritedTimestamp > existingVersion)
+				? inheritedTimestamp
+				: Math.max(monotonicTimestamp(), nextExistingVersion);
 		let whenResolved, timer;
 		// We start by locking the record so that there is only one resolution happening at once;
 		// if there is already a resolution in process, we want to use the results of that resolution
@@ -6038,17 +6050,9 @@ export function makeTable(options) {
 		// lock acquired — this request will actually load from source
 		setLoadedFromSource(target, true);
 
-		const existingRecord = existingEntry?.value;
-		const inheritedTimestamp = context?.timestamp || context?.transaction?.timestamp;
-		const monotonicTimestamp = () =>
-			isRocksDB ? (primaryStore as RocksDatabase).getMonotonicTimestamp() : getNextMonotonicTime();
-		const sourceTimestamp =
-			inheritedTimestamp && (existingVersion == null || inheritedTimestamp > existingVersion)
-				? inheritedTimestamp
-				: Math.max(monotonicTimestamp(), existingVersion == null ? 0 : existingVersion + 0.000488);
 		// it is important to remember that this is _NOT_ part of the current transaction; nothing is changing
-		// with the canonical data, we are simply fulfilling our local copy of the canonical data, but still don't
-		// want a timestamp later than the current transaction
+		// with the canonical data, we are simply fulfilling our local copy of the canonical data. We preserve the
+		// request timestamp unless advancing it is required to replace an existing version.
 		// we create a new context for the source, we want to determine the timestamp and don't want to
 		// attribute this to the current user
 		const sourceContext = {

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -485,6 +485,7 @@ export function makeTable(options) {
 	if (!properties) properties = projectAttributesToProperties(attributes);
 	const updateRecord = recordUpdater(primaryStore, tableId, auditStore);
 	let warnedNullSourcePut = false; // latched: one warn per table per worker (see _writeUpdate)
+	let warnedFutureSourceVersion = false; // likewise, for a source clock ahead of ours (see getFromSource)
 	let sourceLoad: any; // if a source has a load function (replicator), record it here
 	let hasSourceGet: any;
 	let primaryKeyAttribute: Attribute | undefined;
@@ -6092,7 +6093,25 @@ export function makeTable(options) {
 						Number.isFinite(reportedVersion) &&
 						reportedVersion > 0 &&
 						reportedVersion <= MAX_DATE_TIMESTAMP;
-					sourceVersion = validReportedVersion ? reportedVersion : sourceTimestamp;
+					if (validReportedVersion) {
+						// A record version is also this node's ordering token (precedesExistingVersion), so a
+						// source-reported version ahead of local time would make every subsequent local write look
+						// out-of-order and be discarded until wall-clock caught up — freezing the row. Honor what
+						// the source reports, but never beyond now.
+						const versionCeiling = Math.max(sourceTimestamp, Date.now());
+						sourceVersion = Math.min(reportedVersion, versionCeiling);
+						if (sourceVersion !== reportedVersion) {
+							logger.trace?.(
+								`Capping future source version for ${tableName} id ${id}: ${reportedVersion} -> ${sourceVersion}`
+							);
+							if (!warnedFutureSourceVersion) {
+								warnedFutureSourceVersion = true;
+								logger.warn?.(
+									`The source for ${tableName} reported a lastModified ahead of local time (${new Date(reportedVersion).toISOString()}) for id ${id}; capping cached record versions at local time`
+								);
+							}
+						}
+					} else sourceVersion = sourceTimestamp;
 					hasChanges = invalidated || (validReportedVersion && reportedVersion > existingVersion) || !existingRecord;
 					const resolveDuration = performance.now() - start;
 					recordAction(resolveDuration, 'cache-resolution', tableName, null, 'success');
@@ -6221,18 +6240,27 @@ export function makeTable(options) {
 					nodeName: 'source',
 					commit: (_txnTime, existingEntry, _retry, transaction: any) => {
 						sourceWrite.skipped = false; // reset on each retry; cleanup happens after commit if still true
+						const racedVersion = existingEntry?.version;
+						// A first fill may replace a record that raced it only when its candidate version strictly
+						// orders after that record. The comparison has to be replica-independent, so a tie leaves the
+						// raced record in place: precedesExistingVersion() would break the tie with *this* node's
+						// name, and a fill from a shared source has no node identity of its own, so two replicas
+						// resolving the same tie could keep different values at the same version.
+						const replacesRacedRecord = racedVersion == null || sourceVersion > racedVersion;
 						if (
-							existingEntry?.version !== existingVersion &&
-							(existingVersion != null || !updatedRecord || precedesExistingVersion(sourceVersion, existingEntry) <= 0)
+							racedVersion !== existingVersion &&
+							// Revalidations retain exact-CAS semantics; first fills use deterministic ordering.
+							(existingVersion != null || !updatedRecord || !replacesRacedRecord)
 						) {
+							logger.trace?.(
+								`Discarding resolved record from source with id: ${id}, source version: ${sourceVersion}, current version: ${racedVersion}`
+							);
 							sourceWrite.skipped = true;
 							return;
 						}
 						const currentRecord = existingEntry?.value;
 						const recordVersion =
-							isRocksDB && existingEntry?.version != null
-								? Math.max(sourceVersion, existingEntry.version)
-								: sourceVersion;
+							isRocksDB && racedVersion != null ? Math.max(sourceVersion, racedVersion) : sourceVersion;
 						updateIndices(id, currentRecord, updatedRecord, transaction && { transaction });
 						if (updatedRecord) {
 							if (existingEntry) {

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -132,6 +132,7 @@ type MaybePromise<T> = T | Promise<T>;
 const NULL_WITH_TIMESTAMP = new Uint8Array(9);
 NULL_WITH_TIMESTAMP[8] = 0xc0; // null
 const UNCACHEABLE_TIMESTAMP = Infinity; // we use this when dynamic content is accessed that we can't safely cache, and this prevents earlier timestamps from change the "last" modification
+const MAX_DATE_TIMESTAMP = 8.64e15;
 const RECORD_PRUNING_INTERVAL = 60000; // one minute
 const MAX_CONCURRENT_HISTORY_REMOVALS = 10;
 const MAX_CONCURRENT_LMDB_HISTORY_REMOVALS = 1000;
@@ -6059,7 +6060,6 @@ export function makeTable(options) {
 			noCacheStore: droppingTable,
 			source: null,
 			transaction: undefined,
-			timestamp: sourceTimestamp,
 			expiresAt: undefined,
 			lastModified: undefined,
 		};
@@ -6091,9 +6091,9 @@ export function makeTable(options) {
 						typeof reportedVersion === 'number' &&
 						Number.isFinite(reportedVersion) &&
 						reportedVersion > 0 &&
-						!Number.isNaN(new Date(reportedVersion).getTime());
+						reportedVersion <= MAX_DATE_TIMESTAMP;
 					sourceVersion = validReportedVersion ? reportedVersion : sourceTimestamp;
-					hasChanges = invalidated || sourceVersion > existingVersion || !existingRecord;
+					hasChanges = invalidated || (validReportedVersion && reportedVersion > existingVersion) || !existingRecord;
 					const resolveDuration = performance.now() - start;
 					recordAction(resolveDuration, 'cache-resolution', tableName, null, 'success');
 					if (responseHeaders)
@@ -6225,7 +6225,6 @@ export function makeTable(options) {
 							existingEntry?.version !== existingVersion &&
 							(existingVersion != null || !updatedRecord || precedesExistingVersion(sourceVersion, existingEntry) <= 0)
 						) {
-							// Revalidations retain exact-CAS semantics; first fills use deterministic ordering.
 							sourceWrite.skipped = true;
 							return;
 						}

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -6002,8 +6002,9 @@ export function makeTable(options) {
 		const existingVersion = existingEntry?.version;
 		const existingRecord = existingEntry?.value;
 		const inheritedTimestamp = context?.timestamp || context?.transaction?.timestamp;
-		const monotonicTimestamp = () =>
-			isRocksDB ? (primaryStore as RocksDatabase).getMonotonicTimestamp() : getNextMonotonicTime();
+		const monotonicTimestamp = isRocksDB
+			? (primaryStore as RocksDatabase).getMonotonicTimestamp()
+			: getNextMonotonicTime();
 		const nextExistingVersion =
 			existingVersion == null
 				? 0
@@ -6011,7 +6012,7 @@ export function makeTable(options) {
 		const sourceTimestamp =
 			inheritedTimestamp && (existingVersion == null || inheritedTimestamp > existingVersion)
 				? inheritedTimestamp
-				: Math.max(monotonicTimestamp(), nextExistingVersion);
+				: Math.max(monotonicTimestamp, nextExistingVersion);
 		let whenResolved, timer;
 		// We start by locking the record so that there is only one resolution happening at once;
 		// if there is already a resolution in process, we want to use the results of that resolution

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -15,7 +15,7 @@ import { type Database } from 'lmdb';
 import { Script } from 'node:vm';
 import { randomUUID } from 'node:crypto';
 import { performance } from 'node:perf_hooks';
-import { getIndexedValues } from '../utility/lmdb/commonUtility.ts';
+import { getIndexedValues, getNextMonotonicTime } from '../utility/lmdb/commonUtility.ts';
 import { getThisNodeId, exportIdMapping } from './nodeIdMapping.ts';
 import lodash from 'lodash';
 import { ExtendedIterable, SKIP } from '@harperfast/extended-iterable';
@@ -6077,7 +6077,7 @@ export function makeTable(options) {
 			// before the drain's fail-closed timeout below.
 			const commitPromise = transaction(sourceContext, async (_txn) => {
 				const start = performance.now();
-				let updatedRecord;
+				let updatedRecord, assignCreatedTime;
 				let hasChanges, invalidated;
 				try {
 					updatedRecord = await throttledCallToSource(source, id, sourceContext, existingEntry);
@@ -6142,6 +6142,7 @@ export function makeTable(options) {
 						if (isFrozenRecordObject(updatedRecord)) updatedRecord = { ...updatedRecord };
 						if (primaryKey && updatedRecord[primaryKey] !== id) updatedRecord[primaryKey] = id;
 					}
+					assignCreatedTime = createdTimeProperty && updatedRecord?.[createdTimeProperty.name] == null;
 					resolved = true;
 					const resolvedEntry: Entry = {
 						key: id,
@@ -6202,16 +6203,15 @@ export function makeTable(options) {
 				const sourceWrite: any = {
 					key: id,
 					store: primaryStore,
-					entry: existingEntry,
+					entry: undefined,
 					nodeName: 'source',
 					commit: (txnTime, existingEntry, _retry, transaction: any) => {
 						sourceWrite.skipped = false; // reset on each retry; cleanup happens after commit if still true
 						if (
 							existingEntry?.version !== existingVersion &&
-							(existingVersion != null || precedesExistingVersion(txnTime, existingEntry) <= 0)
+							(existingVersion != null || !updatedRecord || precedesExistingVersion(txnTime, existingEntry) <= 0)
 						) {
-							// Revalidations retain exact-CAS semantics. Competing fills of a missing key use the
-							// table's deterministic ordering, so every node keeps the same winner.
+							// Revalidations retain exact-CAS semantics; first fills use deterministic ordering.
 							sourceWrite.skipped = true;
 							return;
 						}
@@ -6232,7 +6232,7 @@ export function makeTable(options) {
 											? new Date(txnTime).toISOString()
 											: txnTime;
 							}
-							if (createdTimeProperty && updatedRecord[createdTimeProperty.name] == null) {
+							if (assignCreatedTime) {
 								const existingCreatedTime = currentRecord?.[createdTimeProperty.name];
 								if (existingCreatedTime != null) {
 									updatedRecord[createdTimeProperty.name] = existingCreatedTime;

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -485,7 +485,7 @@ export function makeTable(options) {
 	if (!properties) properties = projectAttributesToProperties(attributes);
 	const updateRecord = recordUpdater(primaryStore, tableId, auditStore);
 	let warnedNullSourcePut = false; // latched: one warn per table per worker (see _writeUpdate)
-	let warnedFutureSourceVersion = false; // likewise, for a source clock ahead of ours (see getFromSource)
+	let warnedFutureSourceVersion = false; // likewise (see getFromSource)
 	let sourceLoad: any; // if a source has a load function (replicator), record it here
 	let hasSourceGet: any;
 	let primaryKeyAttribute: Attribute | undefined;

--- a/unitTests/resources/caching-rocks-database.test.js
+++ b/unitTests/resources/caching-rocks-database.test.js
@@ -130,20 +130,22 @@ describe('PrimaryRocksDatabase', function () {
 		assert(resequenced.metadataFlags & VERSION_NOT_UNIQUE_FLAG);
 	});
 
-	(constants?.VERSION_NOT_UNIQUE_FLAG === VERSION_NOT_UNIQUE_FLAG ? it : it.skip)(
-		'does not vouch for stale cached data after a version-reusing write',
-		async function () {
-			const now = Date.now();
-			await TestTable.put(11, { name: 'base', count: 0 });
-			await TestTable.patch(11, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 100 });
-			await TestTable.get(11);
-			await TestTable.get(11);
-			const inOrder = TestTable.primaryStore.getEntry(11);
-			assert(TestTable.primaryStore.verifyVersion(11, inOrder.version));
+	it('does not vouch for stale cached data after a version-reusing write', async function () {
+		// Skip only while the installed rocksdb-js predates the export (HarperFast/rocksdb-js#766). Once it is
+		// present the two sides must agree on the bit, so a future value drift fails here instead of silently
+		// removing the only test that guards this behavior.
+		if (constants?.VERSION_NOT_UNIQUE_FLAG === undefined) return this.skip();
+		assert.equal(constants.VERSION_NOT_UNIQUE_FLAG, VERSION_NOT_UNIQUE_FLAG);
+		const now = Date.now();
+		await TestTable.put(11, { name: 'base', count: 0 });
+		await TestTable.patch(11, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 100 });
+		await TestTable.get(11);
+		await TestTable.get(11);
+		const inOrder = TestTable.primaryStore.getEntry(11);
+		assert(TestTable.primaryStore.verifyVersion(11, inOrder.version));
 
-			await TestTable.patch(11, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 50 });
-			assert.equal((await TestTable.get(11)).count, 2);
-			assert(!TestTable.primaryStore.verifyVersion(11, inOrder.version));
-		}
-	);
+		await TestTable.patch(11, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 50 });
+		assert.equal((await TestTable.get(11)).count, 2);
+		assert(!TestTable.primaryStore.verifyVersion(11, inOrder.version));
+	});
 });

--- a/unitTests/resources/caching-rocks-database.test.js
+++ b/unitTests/resources/caching-rocks-database.test.js
@@ -131,10 +131,7 @@ describe('PrimaryRocksDatabase', function () {
 	});
 
 	it('does not vouch for stale cached data after a version-reusing write', async function () {
-		// Skip only while the installed rocksdb-js predates the export (HarperFast/rocksdb-js#766). Once it is
-		// present the two sides must agree on the bit, so a future value drift fails here instead of silently
-		// removing the only test that guards this behavior.
-		if (constants?.VERSION_NOT_UNIQUE_FLAG === undefined) return this.skip();
+		// A drift between Harper's flag and the native constant would silently disarm the assertions below.
 		assert.equal(constants.VERSION_NOT_UNIQUE_FLAG, VERSION_NOT_UNIQUE_FLAG);
 		const now = Date.now();
 		await TestTable.put(11, { name: 'base', count: 0 });

--- a/unitTests/resources/caching-rocks-database.test.js
+++ b/unitTests/resources/caching-rocks-database.test.js
@@ -2,6 +2,7 @@ require('../testUtils');
 const assert = require('assert');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
+const { VERSION_NOT_UNIQUE_FLAG } = require('#src/resources/RecordEncoder');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { RocksDatabase } = require('@harperfast/rocksdb-js');
 const { PrimaryRocksDatabase } = require('#src/resources/PrimaryRocksDatabase');
@@ -18,7 +19,7 @@ describe('PrimaryRocksDatabase', function () {
 		TestTable = table({
 			table: 'PrimaryRocksTest',
 			database: 'test',
-			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }, { name: 'count' }],
 		});
 	});
 
@@ -108,5 +109,17 @@ describe('PrimaryRocksDatabase', function () {
 		await TestTable.put(8, { name: 'eight updated' }); // clears cache entry
 		const result = await TestTable.get(8);
 		assert.equal(result.name, 'eight updated');
+	});
+
+	it('marks a record whose version was reused by a resequenced write', async function () {
+		const now = Date.now();
+		await TestTable.put(9, { name: 'base', count: 0 });
+		await TestTable.patch(9, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 100 });
+		const inOrder = TestTable.primaryStore.getEntry(9);
+		await TestTable.patch(9, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 50 });
+		const resequenced = TestTable.primaryStore.getEntry(9);
+		assert.equal(resequenced.version, inOrder.version);
+		assert.equal(resequenced.value.count, 2);
+		assert(resequenced.metadataFlags & VERSION_NOT_UNIQUE_FLAG);
 	});
 });

--- a/unitTests/resources/caching-rocks-database.test.js
+++ b/unitTests/resources/caching-rocks-database.test.js
@@ -4,7 +4,7 @@ const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { VERSION_NOT_UNIQUE_FLAG } = require('#src/resources/RecordEncoder');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
-const { RocksDatabase } = require('@harperfast/rocksdb-js');
+const { RocksDatabase, constants } = require('@harperfast/rocksdb-js');
 const { PrimaryRocksDatabase } = require('#src/resources/PrimaryRocksDatabase');
 
 const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
@@ -19,7 +19,12 @@ describe('PrimaryRocksDatabase', function () {
 		TestTable = table({
 			table: 'PrimaryRocksTest',
 			database: 'test',
-			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }, { name: 'count' }],
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'name' },
+				{ name: 'count' },
+				{ name: 'expiresAt', expiresAt: true, indexed: true },
+			],
 		});
 	});
 
@@ -113,13 +118,32 @@ describe('PrimaryRocksDatabase', function () {
 
 	it('marks a record whose version was reused by a resequenced write', async function () {
 		const now = Date.now();
+		const expiresAt = now + 60_000;
 		await TestTable.put(9, { name: 'base', count: 0 });
 		await TestTable.patch(9, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 100 });
 		const inOrder = TestTable.primaryStore.getEntry(9);
-		await TestTable.patch(9, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 50 });
+		await TestTable.patch(9, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 50, expiresAt });
 		const resequenced = TestTable.primaryStore.getEntry(9);
 		assert.equal(resequenced.version, inOrder.version);
 		assert.equal(resequenced.value.count, 2);
+		assert.equal(resequenced.expiresAt, expiresAt);
 		assert(resequenced.metadataFlags & VERSION_NOT_UNIQUE_FLAG);
 	});
+
+	(constants?.VERSION_NOT_UNIQUE_FLAG === VERSION_NOT_UNIQUE_FLAG ? it : it.skip)(
+		'does not vouch for stale cached data after a version-reusing write',
+		async function () {
+			const now = Date.now();
+			await TestTable.put(11, { name: 'base', count: 0 });
+			await TestTable.patch(11, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 100 });
+			await TestTable.get(11);
+			await TestTable.get(11);
+			const inOrder = TestTable.primaryStore.getEntry(11);
+			assert(TestTable.primaryStore.verifyVersion(11, inOrder.version));
+
+			await TestTable.patch(11, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 50 });
+			assert.equal((await TestTable.get(11)).count, 2);
+			assert(!TestTable.primaryStore.verifyVersion(11, inOrder.version));
+		}
+	);
 });

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -11,6 +11,7 @@ const { waitFor } = require('../waitFor.js');
 describe('Caching', () => {
 	let CachingTable,
 		IndexedCachingTable,
+		ConflictCachingTable,
 		CachingTableStaleWhileRevalidate,
 		SwrQueryTable,
 		Source,
@@ -18,6 +19,14 @@ describe('Caching', () => {
 		sourceResponses = 0;
 	let swrEnabled = true;
 	let sourceGate = null; // when set, SwrQueryTable's source defers responding until the test releases it
+	let conflictSourceRequest;
+	let conflictTimestamp = 0;
+	function nextConflictTimestamp() {
+		return (conflictTimestamp = Math.max(
+			conflictTimestamp + 1000,
+			ConflictCachingTable.primaryStore.getMonotonicTimestamp() + 1000
+		));
+	}
 	let observedSwrIds = []; // ids the SwrQueryTable SWR hook saw via this.getId(), for the per-row-identity test
 	let events = [];
 	let timer = 0;
@@ -86,6 +95,22 @@ describe('Caching', () => {
 			},
 		});
 		IndexedCachingTable.sourcedFrom(Source);
+		ConflictCachingTable = table({
+			table: 'ConflictCachingTable',
+			database: 'test',
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'name', indexed: true },
+				{ name: 'createdAt', type: 'Date', assignCreatedTime: true },
+			],
+		});
+		ConflictCachingTable.sourcedFrom({
+			get(id, context) {
+				return new Promise((resolve) => {
+					conflictSourceRequest = { id, timestamp: context.timestamp, respond: resolve };
+				});
+			},
+		});
 		let subscription = await CachingTable.subscribe({});
 
 		subscription.on('data', (event) => {
@@ -473,6 +498,93 @@ describe('Caching', () => {
 			return_value = true;
 		}
 	});
+	it('orders first source fills from fetch start without overwriting a later write', async function () {
+		const id = 610;
+		conflictSourceRequest = null;
+		const fill = ConflictCachingTable.get(id);
+		await waitFor(() => conflictSourceRequest?.id === id);
+		const sourceTimestamp = conflictSourceRequest.timestamp;
+		assert.equal(typeof sourceTimestamp, 'number');
+		await ConflictCachingTable.put(id, { id, name: 'authoritative' });
+		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'authoritative');
+		conflictSourceRequest.respond({ id, name: 'source' });
+		assert.equal((await fill).name, 'source');
+		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'authoritative');
+		assert(ConflictCachingTable.primaryStore.getEntry(id).version > sourceTimestamp);
+	});
+
+	it('first source fill replaces an older raced record and its index entries', async function () {
+		const id = 611;
+		conflictSourceRequest = null;
+		const fill = ConflictCachingTable.get(id, { timestamp: nextConflictTimestamp() });
+		await waitFor(() => conflictSourceRequest?.id === id);
+		const sourceTimestamp = conflictSourceRequest.timestamp;
+		const createdAt = new Date(sourceTimestamp - 0.0001);
+		await ConflictCachingTable.put(id, { id, name: 'older', createdAt });
+		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'older');
+		const racedEntry = ConflictCachingTable.primaryStore.getEntry(id);
+		assert(racedEntry.version < sourceTimestamp);
+		const racedCreatedAt = racedEntry.value.createdAt;
+		conflictSourceRequest.respond({ id, name: 'source' });
+		assert.equal((await fill).name, 'source');
+		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'source');
+		const stored = ConflictCachingTable.primaryStore.getSync(id);
+		assert.equal(stored.createdAt.getTime(), racedCreatedAt.getTime());
+		const oldIndex = [];
+		for await (const record of ConflictCachingTable.search({ conditions: [{ attribute: 'name', value: 'older' }] }))
+			oldIndex.push(record);
+		assert.equal(oldIndex.length, 0);
+		const sourceIndex = [];
+		for await (const record of ConflictCachingTable.search({ conditions: [{ attribute: 'name', value: 'source' }] }))
+			sourceIndex.push(record);
+		assert.deepEqual(
+			sourceIndex.map((record) => record.id),
+			[id]
+		);
+	});
+
+	it('revalidation retains exact-CAS when a lower-version write races the source', async function () {
+		const id = 612;
+		await ConflictCachingTable.put(id, { id, name: 'seed' });
+		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'seed');
+		await ConflictCachingTable.invalidate(id);
+		await waitFor(() => ConflictCachingTable.primaryStore.getEntry(id)?.metadataFlags);
+		conflictSourceRequest = null;
+		const fill = ConflictCachingTable.get(id, { timestamp: nextConflictTimestamp() });
+		await waitFor(() => conflictSourceRequest?.id === id);
+		const sourceTimestamp = conflictSourceRequest.timestamp;
+		await ConflictCachingTable.put(id, { id, name: 'raced' });
+		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'raced');
+		assert(ConflictCachingTable.primaryStore.getEntry(id).version < sourceTimestamp);
+		conflictSourceRequest.respond({ id, name: 'source' });
+		assert.equal((await fill).name, 'source');
+		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'raced');
+		assert.equal(ConflictCachingTable.primaryStore.getSync(id).name, 'raced');
+	});
+
+	it('source deletion does not remove a record that raced the fill', async function () {
+		const id = 613;
+		conflictSourceRequest = null;
+		const fill = ConflictCachingTable.get(id, { timestamp: nextConflictTimestamp() });
+		await waitFor(() => conflictSourceRequest?.id === id);
+		const sourceTimestamp = conflictSourceRequest.timestamp;
+		await ConflictCachingTable.put(id, { id, name: 'older-delete' });
+		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'older-delete');
+		assert(ConflictCachingTable.primaryStore.getEntry(id).version < sourceTimestamp);
+		conflictSourceRequest.respond(undefined);
+		assert.equal(await fill, undefined);
+		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'older-delete');
+		const indexed = [];
+		for await (const record of ConflictCachingTable.search({
+			conditions: [{ attribute: 'name', value: 'older-delete' }],
+		}))
+			indexed.push(record);
+		assert.deepEqual(
+			indexed.map((record) => record.id),
+			[id]
+		);
+	});
+
 	it('Source throw error', async function () {
 		try {
 			IndexedCachingTable.setTTLExpiration(0.005);

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -7,6 +7,7 @@ const { Resource } = require('#src/resources/Resource');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { RequestTarget } = require('#src/resources/RequestTarget');
 const { VERSION_NOT_UNIQUE_FLAG } = require('#src/resources/RecordEncoder');
+const { INVALIDATED } = require('#src/resources/Table');
 const { waitFor } = require('../waitFor.js');
 
 describe('Caching', () => {
@@ -508,11 +509,11 @@ describe('Caching', () => {
 	});
 	it('orders first source fills from fetch start without overwriting a later write', async function () {
 		const id = 610;
+		const sourceTimestamp = nextConflictTimestamp();
 		conflictSourceRequest = null;
-		const fill = ConflictCachingTable.get(id);
+		const fill = ConflictCachingTable.get(id, { timestamp: sourceTimestamp });
 		await waitFor(() => conflictSourceRequest?.id === id);
-		const sourceTimestamp = conflictSourceRequest.timestamp;
-		assert.equal(typeof sourceTimestamp, 'number');
+		assert.equal(conflictSourceRequest.timestamp, undefined);
 		await ConflictCachingTable.put(id, { id, name: 'authoritative' }, { timestamp: sourceTimestamp + 1 });
 		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'authoritative');
 		const authoritativeVersion = ConflictCachingTable.primaryStore.getEntry(id).version;
@@ -530,13 +531,13 @@ describe('Caching', () => {
 		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'seed-regression');
 		const existingVersion = ConflictCachingTable.primaryStore.getEntry(id).version;
 		await ConflictCachingTable.invalidate(id);
-		await waitFor(() => ConflictCachingTable.primaryStore.getEntry(id)?.metadataFlags);
+		await waitFor(() => ConflictCachingTable.primaryStore.getEntry(id)?.metadataFlags & INVALIDATED);
 		const invalidatedVersion = ConflictCachingTable.primaryStore.getEntry(id).version;
 		conflictSourceRequest = null;
 		const requestTimestamp = existingVersion - 1000;
 		const fill = ConflictCachingTable.get(id, { timestamp: requestTimestamp });
 		await waitFor(() => conflictSourceRequest?.id === id);
-		assert.equal(conflictSourceRequest.timestamp, requestTimestamp);
+		assert.equal(conflictSourceRequest.timestamp, undefined);
 		conflictSourceRequest.respond({ id, name: 'refreshed' });
 		assert.equal((await fill).name, 'refreshed');
 		await waitFor(() => !ConflictCachingTable.primaryStore.hasLock(id));
@@ -563,7 +564,7 @@ describe('Caching', () => {
 		const id = 620;
 		await ConflictCachingTable.put(id, { id, name: 'seed-reported-version' });
 		await ConflictCachingTable.invalidate(id);
-		await waitFor(() => ConflictCachingTable.primaryStore.getEntry(id)?.metadataFlags);
+		await waitFor(() => ConflictCachingTable.primaryStore.getEntry(id)?.metadataFlags & INVALIDATED);
 		const invalidatedVersion = ConflictCachingTable.primaryStore.getEntry(id).version;
 		const requestTimestamp = nextConflictTimestamp();
 		const reportedVersion = invalidatedVersion - 1000;
@@ -598,10 +599,10 @@ describe('Caching', () => {
 
 	it('first source fill replaces an older raced record and its index entries', async function () {
 		const id = 611;
+		const sourceTimestamp = nextConflictTimestamp();
 		conflictSourceRequest = null;
-		const fill = ConflictCachingTable.get(id, { timestamp: nextConflictTimestamp() });
+		const fill = ConflictCachingTable.get(id, { timestamp: sourceTimestamp });
 		await waitFor(() => conflictSourceRequest?.id === id);
-		const sourceTimestamp = conflictSourceRequest.timestamp;
 		const createdAt = new Date(sourceTimestamp - 0.0001);
 		await ConflictCachingTable.put(id, { id, name: 'older', createdAt }, { timestamp: sourceTimestamp - 1 });
 		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'older');
@@ -631,11 +632,11 @@ describe('Caching', () => {
 		await ConflictCachingTable.put(id, { id, name: 'seed' });
 		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'seed');
 		await ConflictCachingTable.invalidate(id);
-		await waitFor(() => ConflictCachingTable.primaryStore.getEntry(id)?.metadataFlags);
+		await waitFor(() => ConflictCachingTable.primaryStore.getEntry(id)?.metadataFlags & INVALIDATED);
 		conflictSourceRequest = null;
-		const fill = ConflictCachingTable.get(id, { timestamp: nextConflictTimestamp() });
+		const sourceTimestamp = nextConflictTimestamp();
+		const fill = ConflictCachingTable.get(id, { timestamp: sourceTimestamp });
 		await waitFor(() => conflictSourceRequest?.id === id);
-		const sourceTimestamp = conflictSourceRequest.timestamp;
 		await ConflictCachingTable.put(id, { id, name: 'raced' }, { timestamp: sourceTimestamp - 1 });
 		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'raced');
 		assert(ConflictCachingTable.primaryStore.getEntry(id).version < sourceTimestamp);
@@ -649,10 +650,10 @@ describe('Caching', () => {
 
 	it('source deletion does not remove a record that raced the fill', async function () {
 		const id = 613;
+		const sourceTimestamp = nextConflictTimestamp();
 		conflictSourceRequest = null;
-		const fill = ConflictCachingTable.get(id, { timestamp: nextConflictTimestamp() });
+		const fill = ConflictCachingTable.get(id, { timestamp: sourceTimestamp });
 		await waitFor(() => conflictSourceRequest?.id === id);
-		const sourceTimestamp = conflictSourceRequest.timestamp;
 		await ConflictCachingTable.put(id, { id, name: 'older-delete' }, { timestamp: sourceTimestamp - 1 });
 		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'older-delete');
 		assert(ConflictCachingTable.primaryStore.getEntry(id).version < sourceTimestamp);

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -6,6 +6,7 @@ const { table } = require('#src/resources/databases');
 const { Resource } = require('#src/resources/Resource');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { RequestTarget } = require('#src/resources/RequestTarget');
+const { VERSION_NOT_UNIQUE_FLAG } = require('#src/resources/RecordEncoder');
 const { waitFor } = require('../waitFor.js');
 
 describe('Caching', () => {
@@ -107,7 +108,14 @@ describe('Caching', () => {
 		ConflictCachingTable.sourcedFrom({
 			get(id, context) {
 				return new Promise((resolve) => {
-					conflictSourceRequest = { id, timestamp: context.timestamp, respond: resolve };
+					conflictSourceRequest = {
+						id,
+						timestamp: context.timestamp,
+						respond(value, lastModified) {
+							context.lastModified = lastModified;
+							resolve(value);
+						},
+					};
 				});
 			},
 		});
@@ -516,7 +524,7 @@ describe('Caching', () => {
 		assert(ConflictCachingTable.primaryStore.getEntry(id).version > sourceTimestamp);
 	});
 
-	it('advances a revalidation version when the request timestamp predates the cached record', async function () {
+	it('reuses a revalidation version when the request timestamp predates the cached record', async function () {
 		const id = 614;
 		await ConflictCachingTable.put(id, { id, name: 'seed-regression' });
 		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'seed-regression');
@@ -525,14 +533,67 @@ describe('Caching', () => {
 		await waitFor(() => ConflictCachingTable.primaryStore.getEntry(id)?.metadataFlags);
 		const invalidatedVersion = ConflictCachingTable.primaryStore.getEntry(id).version;
 		conflictSourceRequest = null;
-		const fill = ConflictCachingTable.get(id, { timestamp: existingVersion - 1000 });
+		const requestTimestamp = existingVersion - 1000;
+		const fill = ConflictCachingTable.get(id, { timestamp: requestTimestamp });
 		await waitFor(() => conflictSourceRequest?.id === id);
-		assert(conflictSourceRequest.timestamp > invalidatedVersion);
+		assert.equal(conflictSourceRequest.timestamp, requestTimestamp);
 		conflictSourceRequest.respond({ id, name: 'refreshed' });
 		assert.equal((await fill).name, 'refreshed');
 		await waitFor(() => !ConflictCachingTable.primaryStore.hasLock(id));
 		assert.equal(ConflictCachingTable.primaryStore.getSync(id).name, 'refreshed');
-		assert(ConflictCachingTable.primaryStore.getEntry(id).version > invalidatedVersion);
+		const refreshedEntry = ConflictCachingTable.primaryStore.getEntry(id);
+		assert.equal(refreshedEntry.version, invalidatedVersion);
+		assert(refreshedEntry.metadataFlags & VERSION_NOT_UNIQUE_FLAG);
+	});
+
+	it('uses a source-reported version before the transaction timestamp', async function () {
+		const id = 615;
+		const requestTimestamp = nextConflictTimestamp();
+		const reportedVersion = requestTimestamp - 100;
+		conflictSourceRequest = null;
+		const fill = ConflictCachingTable.get(id, { timestamp: requestTimestamp });
+		await waitFor(() => conflictSourceRequest?.id === id);
+		conflictSourceRequest.respond({ id, name: 'reported-version' }, reportedVersion);
+		assert.equal((await fill).getUpdatedTime(), reportedVersion);
+		await waitFor(() => !ConflictCachingTable.primaryStore.hasLock(id));
+		assert.equal(ConflictCachingTable.primaryStore.getEntry(id).version, reportedVersion);
+	});
+
+	it('clamps an older source-reported revalidation version instead of using the request timestamp', async function () {
+		const id = 620;
+		await ConflictCachingTable.put(id, { id, name: 'seed-reported-version' });
+		await ConflictCachingTable.invalidate(id);
+		await waitFor(() => ConflictCachingTable.primaryStore.getEntry(id)?.metadataFlags);
+		const invalidatedVersion = ConflictCachingTable.primaryStore.getEntry(id).version;
+		const requestTimestamp = nextConflictTimestamp();
+		const reportedVersion = invalidatedVersion - 1000;
+		conflictSourceRequest = null;
+		const fill = ConflictCachingTable.get(id, { timestamp: requestTimestamp });
+		await waitFor(() => conflictSourceRequest?.id === id);
+		conflictSourceRequest.respond({ id, name: 'reported-revalidation' }, reportedVersion);
+		assert.equal((await fill).getUpdatedTime(), invalidatedVersion);
+		await waitFor(() => !ConflictCachingTable.primaryStore.hasLock(id));
+		const refreshedEntry = ConflictCachingTable.primaryStore.getEntry(id);
+		assert.equal(refreshedEntry.version, invalidatedVersion);
+		assert(refreshedEntry.metadataFlags & VERSION_NOT_UNIQUE_FLAG);
+	});
+
+	it('falls back from an invalid source-reported version', async function () {
+		for (const [id, reportedVersion] of [
+			[616, Infinity],
+			[617, NaN],
+			[618, -1],
+			[619, Number.MAX_VALUE],
+		]) {
+			const requestTimestamp = nextConflictTimestamp();
+			conflictSourceRequest = null;
+			const fill = ConflictCachingTable.get(id, { timestamp: requestTimestamp });
+			await waitFor(() => conflictSourceRequest?.id === id);
+			conflictSourceRequest.respond({ id, name: 'fallback-version' }, reportedVersion);
+			assert.equal((await fill).getUpdatedTime(), requestTimestamp);
+			await waitFor(() => !ConflictCachingTable.primaryStore.hasLock(id));
+			assert.equal(ConflictCachingTable.primaryStore.getEntry(id).version, requestTimestamp);
+		}
 	});
 
 	it('first source fill replaces an older raced record and its index entries', async function () {

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -25,7 +25,7 @@ describe('Caching', () => {
 	let sourceGate = null; // when set, SwrQueryTable's source defers responding until the test releases it
 	let ConflictSideEffectTable;
 	let conflictSourceRequest;
-	let conflictSourceWriteId = null; // when set, the conflict source writes this row inside its own transaction
+	let conflictSourceWriteId = null;
 	let conflictTimestamp = 0;
 	// Apply a record the way replication does, attributed to `nodeId`, so a version tie against a fill is
 	// resolved against a *peer's* identity rather than this node's own.
@@ -131,7 +131,6 @@ describe('Caching', () => {
 						id,
 						timestamp: context.timestamp,
 						respond(value, lastModified) {
-							// a source that writes while resolving does so in the source's own transaction
 							if (conflictSourceWriteId != null)
 								ConflictSideEffectTable.put(
 									conflictSourceWriteId,
@@ -704,7 +703,7 @@ describe('Caching', () => {
 		// no request timestamp: the ceiling is local time, which is what a skewed source clock outruns
 		const fill = ConflictCachingTable.get(id);
 		await waitFor(() => conflictSourceRequest?.id === id);
-		const futureVersion = Date.now() + 10_000_000; // ~2.8h ahead
+		const futureVersion = Date.now() + 10_000_000;
 		conflictSourceRequest.respond({ id, name: 'source-future' }, futureVersion);
 		assert.equal((await fill).name, 'source-future');
 		await waitFor(() => !ConflictCachingTable.primaryStore.hasLock(id));
@@ -773,13 +772,11 @@ describe('Caching', () => {
 				const fill = ConflictCachingTable.get(key, { timestamp: base });
 				await waitFor(() => conflictSourceRequest?.id === key);
 				if (writeDuringFetch) {
-					// the write is already committed when the fill's commit transaction reloads the entry
 					await commitWrite(key, writeWith, writeVersion);
 					conflictSourceRequest.respond(fillWith, sourceVersion);
 					await fill;
 					await waitFor(() => !ConflictCachingTable.primaryStore.hasLock(key));
 				} else {
-					// the fill commits first and the write is resequenced against it
 					conflictSourceRequest.respond(fillWith, sourceVersion);
 					await fill;
 					await waitFor(() => !ConflictCachingTable.primaryStore.hasLock(key));
@@ -800,7 +797,7 @@ describe('Caching', () => {
 	it('does not backdate a write the source performs while resolving', async function () {
 		const id = 640;
 		const sideId = 641;
-		const requestTimestamp = Date.now() - 3_600_000; // an hour-old request/transaction timestamp
+		const requestTimestamp = Date.now() - 3_600_000;
 		const before = Date.now();
 		conflictSourceWriteId = sideId;
 		try {

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -505,7 +505,7 @@ describe('Caching', () => {
 		await waitFor(() => conflictSourceRequest?.id === id);
 		const sourceTimestamp = conflictSourceRequest.timestamp;
 		assert.equal(typeof sourceTimestamp, 'number');
-		await ConflictCachingTable.put(id, { id, name: 'authoritative' });
+		await ConflictCachingTable.put(id, { id, name: 'authoritative' }, { timestamp: sourceTimestamp + 1 });
 		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'authoritative');
 		const authoritativeVersion = ConflictCachingTable.primaryStore.getEntry(id).version;
 		conflictSourceRequest.respond({ id, name: 'source' });
@@ -523,15 +523,16 @@ describe('Caching', () => {
 		const existingVersion = ConflictCachingTable.primaryStore.getEntry(id).version;
 		await ConflictCachingTable.invalidate(id);
 		await waitFor(() => ConflictCachingTable.primaryStore.getEntry(id)?.metadataFlags);
+		const invalidatedVersion = ConflictCachingTable.primaryStore.getEntry(id).version;
 		conflictSourceRequest = null;
 		const fill = ConflictCachingTable.get(id, { timestamp: existingVersion - 1000 });
 		await waitFor(() => conflictSourceRequest?.id === id);
-		assert(conflictSourceRequest.timestamp > existingVersion);
+		assert(conflictSourceRequest.timestamp > invalidatedVersion);
 		conflictSourceRequest.respond({ id, name: 'refreshed' });
 		assert.equal((await fill).name, 'refreshed');
 		await waitFor(() => !ConflictCachingTable.primaryStore.hasLock(id));
 		assert.equal(ConflictCachingTable.primaryStore.getSync(id).name, 'refreshed');
-		assert(ConflictCachingTable.primaryStore.getEntry(id).version > existingVersion);
+		assert(ConflictCachingTable.primaryStore.getEntry(id).version > invalidatedVersion);
 	});
 
 	it('first source fill replaces an older raced record and its index entries', async function () {
@@ -541,7 +542,7 @@ describe('Caching', () => {
 		await waitFor(() => conflictSourceRequest?.id === id);
 		const sourceTimestamp = conflictSourceRequest.timestamp;
 		const createdAt = new Date(sourceTimestamp - 0.0001);
-		await ConflictCachingTable.put(id, { id, name: 'older', createdAt });
+		await ConflictCachingTable.put(id, { id, name: 'older', createdAt }, { timestamp: sourceTimestamp - 1 });
 		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'older');
 		const racedEntry = ConflictCachingTable.primaryStore.getEntry(id);
 		assert(racedEntry.version < sourceTimestamp);
@@ -574,7 +575,7 @@ describe('Caching', () => {
 		const fill = ConflictCachingTable.get(id, { timestamp: nextConflictTimestamp() });
 		await waitFor(() => conflictSourceRequest?.id === id);
 		const sourceTimestamp = conflictSourceRequest.timestamp;
-		await ConflictCachingTable.put(id, { id, name: 'raced' });
+		await ConflictCachingTable.put(id, { id, name: 'raced' }, { timestamp: sourceTimestamp - 1 });
 		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'raced');
 		assert(ConflictCachingTable.primaryStore.getEntry(id).version < sourceTimestamp);
 		const racedVersion = ConflictCachingTable.primaryStore.getEntry(id).version;
@@ -591,7 +592,7 @@ describe('Caching', () => {
 		const fill = ConflictCachingTable.get(id, { timestamp: nextConflictTimestamp() });
 		await waitFor(() => conflictSourceRequest?.id === id);
 		const sourceTimestamp = conflictSourceRequest.timestamp;
-		await ConflictCachingTable.put(id, { id, name: 'older-delete' });
+		await ConflictCachingTable.put(id, { id, name: 'older-delete' }, { timestamp: sourceTimestamp - 1 });
 		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'older-delete');
 		assert(ConflictCachingTable.primaryStore.getEntry(id).version < sourceTimestamp);
 		const racedVersion = ConflictCachingTable.primaryStore.getEntry(id).version;

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -8,6 +8,8 @@ const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { RequestTarget } = require('#src/resources/RequestTarget');
 const { VERSION_NOT_UNIQUE_FLAG } = require('#src/resources/RecordEncoder');
 const { INVALIDATED } = require('#src/resources/Table');
+const { exportIdMapping } = require('#src/resources/nodeIdMapping');
+const { transaction } = require('#src/resources/transaction');
 const { waitFor } = require('../waitFor.js');
 
 describe('Caching', () => {
@@ -21,8 +23,19 @@ describe('Caching', () => {
 		sourceResponses = 0;
 	let swrEnabled = true;
 	let sourceGate = null; // when set, SwrQueryTable's source defers responding until the test releases it
+	let ConflictSideEffectTable;
 	let conflictSourceRequest;
+	let conflictSourceWriteId = null; // when set, the conflict source writes this row inside its own transaction
 	let conflictTimestamp = 0;
+	// Apply a record the way replication does, attributed to `nodeId`, so a version tie against a fill is
+	// resolved against a *peer's* identity rather than this node's own.
+	async function applyFromPeer(id, record, timestamp, nodeId) {
+		const context = { source: {}, timestamp };
+		await transaction(context, async () => {
+			const resource = await ConflictCachingTable.getResource(id, context);
+			return resource._writeUpdate(id, record, true, { isNotification: true, nodeId });
+		});
+	}
 	function nextConflictTimestamp() {
 		return (conflictTimestamp = Math.max(
 			conflictTimestamp + 1000,
@@ -106,6 +119,11 @@ describe('Caching', () => {
 				{ name: 'createdAt', type: 'Date', assignCreatedTime: true },
 			],
 		});
+		ConflictSideEffectTable = table({
+			table: 'ConflictSideEffectTable',
+			database: 'test',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+		});
 		ConflictCachingTable.sourcedFrom({
 			get(id, context) {
 				return new Promise((resolve) => {
@@ -113,6 +131,13 @@ describe('Caching', () => {
 						id,
 						timestamp: context.timestamp,
 						respond(value, lastModified) {
+							// a source that writes while resolving does so in the source's own transaction
+							if (conflictSourceWriteId != null)
+								ConflictSideEffectTable.put(
+									conflictSourceWriteId,
+									{ id: conflictSourceWriteId, name: 'side-effect' },
+									context
+								);
 							context.lastModified = lastModified;
 							resolve(value);
 						},
@@ -671,6 +696,129 @@ describe('Caching', () => {
 			indexed.map((record) => record.id),
 			[id]
 		);
+	});
+
+	it('caps a source-reported version ahead of local time so later local writes still land', async function () {
+		const id = 621;
+		conflictSourceRequest = null;
+		// no request timestamp: the ceiling is local time, which is what a skewed source clock outruns
+		const fill = ConflictCachingTable.get(id);
+		await waitFor(() => conflictSourceRequest?.id === id);
+		const futureVersion = Date.now() + 10_000_000; // ~2.8h ahead
+		conflictSourceRequest.respond({ id, name: 'source-future' }, futureVersion);
+		assert.equal((await fill).name, 'source-future');
+		await waitFor(() => !ConflictCachingTable.primaryStore.hasLock(id));
+		const filled = ConflictCachingTable.primaryStore.getEntry(id);
+		assert(
+			filled.version < futureVersion,
+			`a future source version (${futureVersion}) must not become the record version (${filled.version})`
+		);
+		// the point of the cap: an ordinary local write is not resequenced away behind the source's floor
+		await ConflictCachingTable.put(id, { id, name: 'later-write' });
+		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'later-write', {
+			message: 'a local write after a future-dated fill must not be silently discarded',
+		});
+		assert(ConflictCachingTable.primaryStore.getEntry(id).version > filled.version);
+	});
+
+	it('keeps a raced record when a first fill ties its version', async function () {
+		const id = 622;
+		// The raced record is attributed to a peer whose name sorts *before* this node's, so
+		// precedesExistingVersion() would break the tie in the fill's favor here and in the peer's favor
+		// on a node whose name sorts before it — the divergence the fill guard must not depend on.
+		const peerNodeId = ConflictCachingTable.auditStore.ensureLogExists('!tie-peer');
+		const localNodeName = Object.keys(exportIdMapping(ConflictCachingTable.auditStore)).find(
+			(name) => name !== '!tie-peer'
+		);
+		assert('!tie-peer' < localNodeName, 'the peer node name must sort before this node for this test to bite');
+		const sourceTimestamp = nextConflictTimestamp();
+		conflictSourceRequest = null;
+		const fill = ConflictCachingTable.get(id, { timestamp: sourceTimestamp });
+		await waitFor(() => conflictSourceRequest?.id === id);
+		await applyFromPeer(id, { id, name: 'raced-tie' }, sourceTimestamp, peerNodeId);
+		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'raced-tie');
+		const racedEntry = ConflictCachingTable.primaryStore.getEntry(id);
+		assert.equal(racedEntry.version, sourceTimestamp);
+		conflictSourceRequest.respond({ id, name: 'source-tie' }, sourceTimestamp);
+		assert.equal((await fill).name, 'source-tie');
+		await waitFor(() => !ConflictCachingTable.primaryStore.hasLock(id));
+		assert.equal(ConflictCachingTable.primaryStore.getSync(id).name, 'raced-tie');
+		assert.equal(ConflictCachingTable.primaryStore.getEntry(id).version, racedEntry.version);
+	});
+
+	it('converges on the same entry whether the raced write lands during or after the fill', async function () {
+		// The same two effects (a first fill at `sourceVersion`, a local write at `writeVersion`) applied in
+		// both orders must leave the same (version, value) — the property the single-ordering tests above
+		// each pin one instance of. Two replicas resolving the same missing key see exactly this pair of
+		// orderings when a write races the fetch on one of them.
+		let id = 630;
+		// a base in the past: the source-version cap is local time, so a future base would clamp the
+		// reported versions together and collapse the two cases this is comparing
+		const base = Date.now() - 60_000;
+		const commitWrite = async (key, record, timestamp) => {
+			const context = { timestamp };
+			await transaction(context, () => {
+				ConflictCachingTable.put(key, record, context);
+			});
+		};
+		for (const sourceWins of [true, false]) {
+			const results = [];
+			const sourceVersion = sourceWins ? base + 100 : base;
+			const writeVersion = sourceWins ? base : base + 100;
+			for (const writeDuringFetch of [true, false]) {
+				const key = id++;
+				const fillWith = { id: key, name: 'source' };
+				const writeWith = { id: key, name: 'write' };
+				conflictSourceRequest = null;
+				const fill = ConflictCachingTable.get(key, { timestamp: base });
+				await waitFor(() => conflictSourceRequest?.id === key);
+				if (writeDuringFetch) {
+					// the write is already committed when the fill's commit transaction reloads the entry
+					await commitWrite(key, writeWith, writeVersion);
+					conflictSourceRequest.respond(fillWith, sourceVersion);
+					await fill;
+					await waitFor(() => !ConflictCachingTable.primaryStore.hasLock(key));
+				} else {
+					// the fill commits first and the write is resequenced against it
+					conflictSourceRequest.respond(fillWith, sourceVersion);
+					await fill;
+					await waitFor(() => !ConflictCachingTable.primaryStore.hasLock(key));
+					await commitWrite(key, writeWith, writeVersion);
+				}
+				const entry = ConflictCachingTable.primaryStore.getEntry(key);
+				results.push({ name: entry.value.name, version: entry.version });
+			}
+			assert.deepEqual(
+				results[0],
+				results[1],
+				`fill@${sourceWins ? 'newer' : 'older'} must converge regardless of when the raced write lands`
+			);
+			assert.equal(results[0].name, sourceWins ? 'source' : 'write');
+		}
+	});
+
+	it('does not backdate a write the source performs while resolving', async function () {
+		const id = 640;
+		const sideId = 641;
+		const requestTimestamp = Date.now() - 3_600_000; // an hour-old request/transaction timestamp
+		const before = Date.now();
+		conflictSourceWriteId = sideId;
+		try {
+			conflictSourceRequest = null;
+			const fill = ConflictCachingTable.get(id, { timestamp: requestTimestamp });
+			await waitFor(() => conflictSourceRequest?.id === id);
+			assert.equal(conflictSourceRequest.timestamp, undefined);
+			conflictSourceRequest.respond({ id, name: 'source-with-write' });
+			await fill;
+			await waitFor(() => ConflictSideEffectTable.primaryStore.getSync(sideId)?.name === 'side-effect');
+			const sideEntry = ConflictSideEffectTable.primaryStore.getEntry(sideId);
+			assert(
+				sideEntry.version >= before,
+				`a source-side write must carry its own transaction time (${sideEntry.version}), not the inherited request timestamp (${requestTimestamp})`
+			);
+		} finally {
+			conflictSourceWriteId = null;
+		}
 	});
 
 	it('Source throw error', async function () {

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -507,10 +507,31 @@ describe('Caching', () => {
 		assert.equal(typeof sourceTimestamp, 'number');
 		await ConflictCachingTable.put(id, { id, name: 'authoritative' });
 		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'authoritative');
+		const authoritativeVersion = ConflictCachingTable.primaryStore.getEntry(id).version;
 		conflictSourceRequest.respond({ id, name: 'source' });
 		assert.equal((await fill).name, 'source');
-		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'authoritative');
+		await waitFor(() => !ConflictCachingTable.primaryStore.hasLock(id));
+		assert.equal(ConflictCachingTable.primaryStore.getSync(id).name, 'authoritative');
+		assert.equal(ConflictCachingTable.primaryStore.getEntry(id).version, authoritativeVersion);
 		assert(ConflictCachingTable.primaryStore.getEntry(id).version > sourceTimestamp);
+	});
+
+	it('advances a revalidation version when the request timestamp predates the cached record', async function () {
+		const id = 614;
+		await ConflictCachingTable.put(id, { id, name: 'seed-regression' });
+		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'seed-regression');
+		const existingVersion = ConflictCachingTable.primaryStore.getEntry(id).version;
+		await ConflictCachingTable.invalidate(id);
+		await waitFor(() => ConflictCachingTable.primaryStore.getEntry(id)?.metadataFlags);
+		conflictSourceRequest = null;
+		const fill = ConflictCachingTable.get(id, { timestamp: existingVersion - 1000 });
+		await waitFor(() => conflictSourceRequest?.id === id);
+		assert(conflictSourceRequest.timestamp > existingVersion);
+		conflictSourceRequest.respond({ id, name: 'refreshed' });
+		assert.equal((await fill).name, 'refreshed');
+		await waitFor(() => !ConflictCachingTable.primaryStore.hasLock(id));
+		assert.equal(ConflictCachingTable.primaryStore.getSync(id).name, 'refreshed');
+		assert(ConflictCachingTable.primaryStore.getEntry(id).version > existingVersion);
 	});
 
 	it('first source fill replaces an older raced record and its index entries', async function () {
@@ -556,10 +577,12 @@ describe('Caching', () => {
 		await ConflictCachingTable.put(id, { id, name: 'raced' });
 		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'raced');
 		assert(ConflictCachingTable.primaryStore.getEntry(id).version < sourceTimestamp);
+		const racedVersion = ConflictCachingTable.primaryStore.getEntry(id).version;
 		conflictSourceRequest.respond({ id, name: 'source' });
 		assert.equal((await fill).name, 'source');
-		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'raced');
+		await waitFor(() => !ConflictCachingTable.primaryStore.hasLock(id));
 		assert.equal(ConflictCachingTable.primaryStore.getSync(id).name, 'raced');
+		assert.equal(ConflictCachingTable.primaryStore.getEntry(id).version, racedVersion);
 	});
 
 	it('source deletion does not remove a record that raced the fill', async function () {
@@ -571,9 +594,11 @@ describe('Caching', () => {
 		await ConflictCachingTable.put(id, { id, name: 'older-delete' });
 		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'older-delete');
 		assert(ConflictCachingTable.primaryStore.getEntry(id).version < sourceTimestamp);
+		const racedVersion = ConflictCachingTable.primaryStore.getEntry(id).version;
 		conflictSourceRequest.respond(undefined);
 		assert.equal(await fill, undefined);
-		await waitFor(() => ConflictCachingTable.primaryStore.getSync(id)?.name === 'older-delete');
+		await waitFor(() => !ConflictCachingTable.primaryStore.hasLock(id));
+		assert.equal(ConflictCachingTable.primaryStore.getEntry(id).version, racedVersion);
 		const indexed = [];
 		for await (const record of ConflictCachingTable.search({
 			conditions: [{ attribute: 'name', value: 'older-delete' }],


### PR DESCRIPTION
> [!NOTE]
> The [rocksdb-js#766](https://github.com/HarperFast/rocksdb-js/pull/766) gate is now closed: `@harperfast/rocksdb-js` 2.8.0 is released and the floor + lockfile are raised to it, so the `VERSION_NOT_UNIQUE_FLAG` contract test runs instead of skipping.

## Problem

Two nodes can independently resolve the same missing `sourcedFrom` key. The old commit path compared against the entry captured before the source fetch, so a write that landed during the fetch was not resolved against the actual record being replaced. The first version of this PR fixed convergence by minting an incremented cache-record timestamp, but that conflated three different things:

- the source's authoritative `lastModified` version;
- the local token used to order competing first fills;
- the timestamp of the transaction in which `source.get()` runs.

In particular, installing a fetch-start token on `sourceContext.timestamp` backdated any write the source performed during resolution.

## Change

1. Reserve a monotonic ordering token before the fetch. An inherited request/transaction timestamp is used when present; otherwise the storage engine supplies one.
2. Do **not** install that token on `sourceContext.timestamp`. The source-resolution transaction, including source-side writes, retains its normal transaction timestamp — [asserted end-to-end now](https://github.com/HarperFast/harper/pull/2065/changes?w=1#diff-3e4675948d111966e41fc20a24a583b464f51390e2ca2fc4420e97959164200cR797), not just by checking that the field is unset.
3. After the source responds, a valid `sourceContext.lastModified` is the cache record's candidate version, [capped at `max(reserved token, Date.now())`](https://github.com/HarperFast/harper/pull/2065/changes?w=1#diff-4ff51263bd99981165fc179149c3195ea0c0ca3e2f360bafee2a6bb356964377R5864). A record's version doubles as this node's ordering token (`precedesExistingVersion()` compares a write's transaction timestamp against it), so an uncapped future-dated source established a version floor that silently discarded **every** later local write to that row until wall-clock caught up. Capping is [warned once per table](https://github.com/HarperFast/harper/pull/2065/changes?w=1#diff-4ff51263bd99981165fc179149c3195ea0c0ca3e2f360bafee2a6bb356964377R394) and traced per occurrence.
4. Reload the current entry inside the commit transaction. Revalidations keep exact-CAS behavior; a source miss never deletes a raced record; a first fill replaces a raced record only when [its candidate version is strictly greater](https://github.com/HarperFast/harper/pull/2065/changes?w=1#diff-4ff51263bd99981165fc179149c3195ea0c0ca3e2f360bafee2a6bb356964377R6012). That comparison is deliberately not `precedesExistingVersion()`: that resolves a tie with the **executing** node's name, and a fill from a shared source has no node identity of its own, so two replicas could keep different values at the same version. A discarded fill is now [traced](https://github.com/HarperFast/harper/pull/2065/changes?w=1#diff-4ff51263bd99981165fc179149c3195ea0c0ca3e2f360bafee2a6bb356964377R6019) instead of vanishing silently.
5. On RocksDB, if the source candidate cannot advance the current record version, store at the current version and set `VERSION_NOT_UNIQUE_FLAG` rather than fabricating an epsilon timestamp. #766 makes that safe by refusing to publish or confirm the reused version through the VerificationTable.

The producer flag is wired centrally in `recordUpdater`, so it also covers the ordinary resequenced partial-write case that motivated #766. LMDB continues to store the source candidate directly (below the local-time cap) because it retains separate source-version and local-time semantics.

The [`VERSION_NOT_UNIQUE_FLAG` regression](https://github.com/HarperFast/harper/pull/2065/changes?w=1#diff-e074583cf8528e1c18406545c4fb05e500524e1ab4f74b7a9b0b5413c43aa8daR137) now skips only while the installed rocksdb-js lacks the export, and asserts the two sides agree once it is present — a value drift fails instead of silently deleting the only test guarding the behavior.

## For the human reviewer

- **Open: an equal-version tie is still order-dependent when the fill commits first.** The guard above makes a fill lose a tie against a record that raced it. The mirror case is not covered: if this node's fill commits at version V and a peer write W@V arrives afterwards, the ordinary write path tie-breaks W against the fill's record, which carries *this* node's identity — so a replica that saw W first keeps W while a replica that filled first may keep its fill. Closing it needs a persisted, replica-independent identity (or ordering class) for source fills, which is a record-encoding and replication change beyond this PR. Practically the reachable tie is a second replica's fill of the same key from the same source, which is content-identical; a *divergent* tie needs a third-party write at exactly the source's reported `lastModified`. Flagged by both the pre-push Codex leg and Barber AI; I did not want to invent a new persisted identity under review feedback.
- **Open: the source's `UNCACHEABLE_TIMESTAMP` sentinel no longer survives a fill.** `resources/Table.ts:3369` sets `context.lastModified = Infinity` when a source resource's `get()` runs a dynamic `search()`. On `main` that `Infinity` became the resolved entry's version and suppressed the ETag/`Last-Modified` at the `isFinite` guards in `server/REST.ts:285-317`; here it fails the new `Number.isFinite` validation and is replaced by the finite fill timestamp, so the response carries a validator for content the source declared uncacheable (and a later `If-None-Match` can get a 304). It also flips `hasChanges` for that case, since `Infinity > existingVersion` no longer holds. Preserving the sentinel on the *returned* entry while keeping the *stored* version finite is a few lines, but it is a deliberate semantic call on top of the version model this PR introduces, so it is flagged rather than changed under review. Surfaced by the Harper domain leg of the pre-push review.
- **Open: the reserved ordering token skips the validation the source-reported version now gets.** `inheritedTimestamp` (`Table.get(id, { timestamp })`, or a peer transaction's timestamp) becomes `versionCeiling = Math.max(sourceTimestamp, Date.now())` unvalidated, so a caller-supplied future or non-millisecond timestamp reinstates exactly the frozen-row failure the cap exists to prevent, and a nanosecond-epoch value makes the trace log's `new Date(recordVersion).toISOString()` throw inside the commit callback. Same domain leg; worth deciding whether callers are trusted here.
- **Open: on LMDB a fill can now regress a record's version.** The `Math.max(sourceVersion, existingVersion)` clamp is `isRocksDB`-gated by design, so a revalidation whose candidate predates the cached record writes it at a lower version; a peer holding the pre-invalidation version then compares as strictly newer and anti-entropy can overwrite the fresh source data. That is the engine split `DESIGN.md` commits to, and the suite skips under LMDB (harper#414), so it is the untested half.
- **A same-version revalidation replacement writes no audit entry.** `hasChanges` is false when the source returns content but reports a `lastModified` at or below the existing version. That is the pre-existing cache-fill contract (fills are node-local; making every 200-response revalidation audit would add an audit entry per revalidation for any source that reports no `lastModified`), and on RocksDB the same-version write now carries `VERSION_NOT_UNIQUE_FLAG`, so the version is not vouchable. Worth a second opinion if you disagree that fills are node-local.
- **The version cap replaces a previously-stated tradeoff.** An earlier revision of this description listed "a badly future-dated source can establish a high version floor" as deliberate. It was demonstrably losing subsequent local writes, so it is now capped; the source value is still honored for anything at or below local time.
- **No LMDB coverage.** `caching.test.js` returns early under `HARPER_STORAGE_ENGINE=lmdb` (harper#414), so all the conflict tests are RocksDB-only. Re-enabling the suite there is its own task.

## Verification

- `npm run build`, `npm run format:check`, `npm run lint:required` — clean
- `unitTests/resources/caching.test.js` + `caching-rocks-database.test.js`: 43 passing, 1 pending (the #766-gated VT regression)
- `npm run test:unit:resources`: 1,753 passing, 22 pending, 8 failing locally — the same 8 fail with the msgpackr pin at both 2.0.5 and 2.0.6, so they are independent of this branch's dependency change; CI's `test:unit:all` is green on the same commits
- Fails-on-base check by mutation, rebuilding `dist/` each time: removing the version cap fails [`caps a source-reported version ahead of local time…`](https://github.com/HarperFast/harper/pull/2065/changes?w=1#diff-3e4675948d111966e41fc20a24a583b464f51390e2ca2fc4420e97959164200cR700); restoring `precedesExistingVersion()` in the fill guard fails [`keeps a raced record when a first fill ties its version`](https://github.com/HarperFast/harper/pull/2065/changes?w=1#diff-3e4675948d111966e41fc20a24a583b464f51390e2ca2fc4420e97959164200cR723); installing the token on `sourceContext.timestamp` fails [`does not backdate a write the source performs while resolving`](https://github.com/HarperFast/harper/pull/2065/changes?w=1#diff-3e4675948d111966e41fc20a24a583b464f51390e2ca2fc4420e97959164200cR797)
- New [order-independence test](https://github.com/HarperFast/harper/pull/2065/changes?w=1#diff-3e4675948d111966e41fc20a24a583b464f51390e2ca2fc4420e97959164200cR748) applies the same (fill version, write version) pair in both orderings across both version relations and asserts an identical final `(version, value)`
- End-to-end route: **not observable end-to-end** from a single node — the remaining property is multi-replica convergence, which needs a cluster harness; the unit tests drive the deterministic interleavings a single node can produce
- CI fix in this round: the smoke job's `build-tools/check-shrinkwrap-pins.mjs` failed with `the root msgpackr pin 2.0.5 does not match rocksdb-js 2.0.6` — raising rocksdb-js to 2.8.0 moved its `msgpackr` dependency and left the root pin behind, so npm installed a nested copy and broke the single-module-instance invariant. The [root pin is now 2.0.6](https://github.com/HarperFast/harper/pull/2065/changes?w=1#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R226) and the lockfile's nested `@harperfast/rocksdb-js/node_modules/msgpackr` entry is gone; `unitTests/build-tools/checkShrinkwrapPins.test.mjs` passes 15/15.
- The `Integration Tests 2/6 (Windows, Node.js v24)` failure is not from this branch: `describe-metadata-upgrade.test.ts` "install component and capture first describe_all" fails identically on `main` (runs 32905597531, 32902038519) with a 120s ECONNREFUSED on the `restart_service` readiness probe — harper#549.
- Independent pre-push review: rounds 1–2 Codex (graded) — 3 findings, 1 fixed, 2 open above. Round 3 (full, after the pin change): Codex + Gemini + Cursor Grok + Harper domain — adjudicated severity **minor**, no blockers; the two Codex majors were downgraded (both pre-existing orderings unchanged by this diff), four Gemini majors dropped in adjudication, and the three domain minors are listed above as open items.

Refs [HarperFast/harper-pro#645](https://github.com/HarperFast/harper-pro/pull/645)

<sub>Review-Coverage: authored=claude; ran=gemini,cursor-grok,codex; adjudicated=domain; declined=cursor-composer; rounds=3 @ d15f89389654</sub>

<sub>Human-Review-Need: 4 (decisions: fill-ordering-token, tie-goes-to-raced-record, rocks-clamp-and-flag, flag-scope-all-resequenced-writes, lmdb-keeps-source-version) @ d15f89389654</sub>
