### PR TITLE
fix(replay): fail-stop at a corrupt transaction-log frame and discard the transaction it truncated

### DIFF
--- a/integrationTests/server/replay-transaction-atomicity.test.ts
+++ b/integrationTests/server/replay-transaction-atomicity.test.ts
@@ -1,0 +1,149 @@
+/**
+ * A corrupt transaction-log frame in the middle of a source transaction must not leave that
+ * transaction half-applied.
+ *
+ * Replay groups every equal-version entry into one transaction and commits it at the next version
+ * boundary, so a break inside such a group used to commit whatever part of it was still readable —
+ * a transaction that never committed that way at the source becoming durable here. This drives a
+ * real multi-record insert, tears the log inside it, and requires the replayed table to hold all of
+ * that insert or none of it. See HarperFast/harper#2016 and #2063.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual as equal } from 'node:assert';
+import { readdirSync, readFileSync, openSync, writeSync, closeSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+	startHarper,
+	teardownHarper,
+	sendOperation,
+	type ContextWithHarper,
+	type HarperContext,
+} from '@harperfast/integration-testing';
+import { constants } from '@harperfast/rocksdb-js';
+
+// Transaction-log framing (big-endian): a fixed-size file header, then entries shaped
+// [float64 timestamp][uint32 length][flags byte][length bytes of data].
+const { TRANSACTION_LOG_FILE_HEADER_SIZE, TRANSACTION_LOG_ENTRY_HEADER_SIZE } = constants;
+
+const DB = 'atomicity';
+const TABLE = 'orders';
+const EARLIER_IDS = 60;
+const TORN_IDS = 60;
+// Entries of the torn transaction left readable before the break, so the test proves the readable
+// part is discarded rather than proving the whole transaction was unreachable anyway.
+const READABLE_BEFORE_BREAK = 10;
+
+async function op(ctx: HarperContext, body: any) {
+	return await sendOperation(ctx, { ...body, authorization: ctx.admin });
+}
+
+function records(start: number, count: number) {
+	const out = [];
+	for (let i = 0; i < count; i++) out.push({ id: start + i, payload: 'x'.repeat(256), n: i });
+	return out;
+}
+
+async function countInRange(ctx: HarperContext, start: number, count: number): Promise<number> {
+	const rows = await op(ctx, {
+		operation: 'sql',
+		sql: `select count(*) as c from ${DB}.${TABLE} where id >= ${start} and id < ${start + count}`,
+	});
+	return rows[0]?.c ?? 0;
+}
+
+function userTxnLogFiles(dataRootDir: string): string[] {
+	const out: string[] = [];
+	const dbRoot = join(dataRootDir, 'database');
+	for (const db of readdirSync(dbRoot)) {
+		if (db === 'system') continue;
+		const tlogRoot = join(dbRoot, db, 'transaction_logs');
+		let nodes: string[];
+		try {
+			nodes = readdirSync(tlogRoot);
+		} catch {
+			continue;
+		}
+		for (const node of nodes) {
+			for (const file of readdirSync(join(tlogRoot, node))) {
+				if (file.endsWith('.txnlog')) out.push(join(tlogRoot, node, file));
+			}
+		}
+	}
+	return out;
+}
+
+/**
+ * Break the framing partway through the log's LAST transaction — the run of trailing entries that
+ * share the highest timestamp — leaving `readableBefore` of its entries intact ahead of the break.
+ * Returns how many entries that transaction has, or 0 if the log has no such run to tear.
+ */
+function tearLastTransaction(path: string, readableBefore: number): number {
+	const buf = readFileSync(path);
+	const entries: { lengthPos: number; timestamp: number }[] = [];
+	let pos = TRANSACTION_LOG_FILE_HEADER_SIZE;
+	while (pos + TRANSACTION_LOG_ENTRY_HEADER_SIZE <= buf.length) {
+		const timestamp = buf.readDoubleBE(pos);
+		if (timestamp === 0) break; // a zero timestamp marks end-of-log to the reader
+		const lengthPos = pos + 8;
+		const length = buf.readUInt32BE(lengthPos);
+		const next = pos + TRANSACTION_LOG_ENTRY_HEADER_SIZE + length;
+		if (length === 0 || next > buf.length) break; // ran past the end / already unframable
+		entries.push({ lengthPos, timestamp });
+		pos = next;
+	}
+	if (entries.length === 0) return 0;
+	const lastTimestamp = entries.at(-1).timestamp;
+	let first = entries.length - 1;
+	while (first > 0 && entries[first - 1].timestamp === lastTimestamp) first--;
+	const transactionEntries = entries.length - first;
+	if (transactionEntries <= readableBefore) return 0;
+	// Force this entry's declared length to overrun the log (top byte → 0xff, ≥ 4 GB): the reader
+	// throws a bounded RangeError there and cannot locate any entry after it.
+	const fd = openSync(path, 'r+');
+	try {
+		writeSync(fd, Buffer.from([0xff]), 0, 1, entries[first + readableBefore].lengthPos);
+	} finally {
+		closeSync(fd);
+	}
+	return transactionEntries;
+}
+
+suite('Replay transaction atomicity across a corrupt frame', (ctx: ContextWithHarper) => {
+	before(async () => {
+		// Don't flush on exit: the crash must leave these writes recoverable only from the txn log.
+		await startHarper(ctx, { env: { HARPER_NO_FLUSH_ON_EXIT: true } });
+		await op(ctx.harper, { operation: 'create_database', database: DB });
+		await op(ctx.harper, { operation: 'create_table', database: DB, table: TABLE, primary_key: 'id' });
+	});
+	after(async () => teardownHarper(ctx));
+
+	test('discards a transaction the corrupt frame truncated instead of applying part of it', async () => {
+		await op(ctx.harper, { operation: 'insert', database: DB, table: TABLE, records: records(1, EARLIER_IDS) });
+		// The last insert is one source transaction, and is the one the tear lands inside.
+		await op(ctx.harper, { operation: 'insert', database: DB, table: TABLE, records: records(1001, TORN_IDS) });
+
+		const dataRootDir = ctx.harper.dataRootDir;
+		await new Promise<void>((resolve) => {
+			ctx.harper.process.once('exit', () => resolve());
+			ctx.harper.process.kill('SIGKILL');
+		});
+		let torn = 0;
+		for (const file of userTxnLogFiles(dataRootDir)) {
+			torn = Math.max(torn, tearLastTransaction(file, READABLE_BEFORE_BREAK));
+		}
+		// Fail loudly, not vacuously, if the framing or the transaction grouping ever changes.
+		ok(torn > READABLE_BEFORE_BREAK, `expected to tear a multi-entry transaction, tore ${torn} entries`);
+
+		await startHarper(ctx);
+
+		const tornRows = await countInRange(ctx.harper, 1001, TORN_IDS);
+		ok(
+			tornRows === 0 || tornRows === TORN_IDS,
+			`the truncated transaction must be all-or-nothing, found ${tornRows} of ${TORN_IDS} rows`
+		);
+		// The entries before it are intact, so the transaction that completed ahead of the break is
+		// unaffected — fail-stop must not cost more than the transaction it landed in.
+		equal(await countInRange(ctx.harper, 1, EARLIER_IDS), EARLIER_IDS);
+	});
+});

--- a/integrationTests/server/replay-transaction-atomicity.test.ts
+++ b/integrationTests/server/replay-transaction-atomicity.test.ts
@@ -145,3 +145,62 @@ suite('Replay transaction atomicity across a corrupt frame', (ctx: ContextWithHa
 		equal(await countInRange(ctx.harper, 1, EARLIER_IDS), EARLIER_IDS);
 	});
 });
+
+// A separate instance from the suite above: tearLastTransaction parses a log file from its start
+// and stops at the first corrupt entry it meets, so replaying that suite's own already-corrupted
+// file here would just rediscover its stale break rather than tearing this scenario's fresh one.
+suite('Replay transaction atomicity at a closed/unreadable transaction boundary', (ctx: ContextWithHarper) => {
+	const CLOSED_IDS = 1;
+	const UNREADABLE_IDS = 1001;
+
+	before(async () => {
+		await startHarper(ctx, { env: { HARPER_NO_FLUSH_ON_EXIT: true } });
+		await op(ctx.harper, { operation: 'create_database', database: DB });
+		await op(ctx.harper, { operation: 'create_table', database: DB, table: TABLE, primary_key: 'id' });
+	});
+	after(async () => teardownHarper(ctx));
+
+	test('does not discard a transaction that already closed merely because the NEXT one is unreadable', async () => {
+		// Distinct from the suite above: there the break lands INSIDE the last transaction, so the
+		// version replay marks truncated is genuinely still open. Here the break destroys the NEXT
+		// transaction's first frame entirely (readableBefore=0), so the last entry replay actually read
+		// is the CLOSED transaction's own endTxn entry — attribution must key off that, not off "whichever
+		// version was last seen before a break."
+		await op(ctx.harper, {
+			operation: 'insert',
+			database: DB,
+			table: TABLE,
+			records: records(CLOSED_IDS, EARLIER_IDS),
+		});
+		await op(ctx.harper, {
+			operation: 'insert',
+			database: DB,
+			table: TABLE,
+			records: records(UNREADABLE_IDS, TORN_IDS),
+		});
+
+		const dataRootDir = ctx.harper.dataRootDir;
+		await new Promise<void>((resolve) => {
+			ctx.harper.process.once('exit', () => resolve());
+			ctx.harper.process.kill('SIGKILL');
+		});
+		let torn = 0;
+		for (const file of userTxnLogFiles(dataRootDir)) {
+			torn = Math.max(torn, tearLastTransaction(file, 0));
+		}
+		ok(torn > 0, `expected to tear the boundary transaction's first frame, tore ${torn} entries`);
+
+		await startHarper(ctx);
+
+		// Nothing of the unreadable transaction is readable, so none of it applies.
+		equal(await countInRange(ctx.harper, UNREADABLE_IDS, TORN_IDS), 0);
+		// The prior transaction already closed (its last entry's endTxn was true) before the break, so
+		// it must survive in full — it is not "the transaction the break landed in" merely because it
+		// was the last thing replay had read.
+		equal(
+			await countInRange(ctx.harper, CLOSED_IDS, EARLIER_IDS),
+			EARLIER_IDS,
+			'a transaction that already closed must not be discarded merely because the next one is unreadable'
+		);
+	});
+});

--- a/integrationTests/server/replay-transaction-atomicity.test.ts
+++ b/integrationTests/server/replay-transaction-atomicity.test.ts
@@ -137,13 +137,11 @@ suite('Replay transaction atomicity across a corrupt frame', (ctx: ContextWithHa
 
 		await startHarper(ctx);
 
-		const tornRows = await countInRange(ctx.harper, 1001, TORN_IDS);
-		ok(
-			tornRows === 0 || tornRows === TORN_IDS,
-			`the truncated transaction must be all-or-nothing, found ${tornRows} of ${TORN_IDS} rows`
-		);
-		// The entries before it are intact, so the transaction that completed ahead of the break is
-		// unaffected — fail-stop must not cost more than the transaction it landed in.
+		// None of it: the break makes the rest of that insert unreadable, so the readable prefix is
+		// discarded rather than committed as a transaction the source never committed.
+		equal(await countInRange(ctx.harper, 1001, TORN_IDS), 0, 'the truncated transaction must not be applied in part');
+		// The transactions that completed ahead of the break are unaffected: fail-stop costs the
+		// transaction the break landed in, not the log up to it.
 		equal(await countInRange(ctx.harper, 1, EARLIER_IDS), EARLIER_IDS);
 	});
 });

--- a/integrationTests/server/replay-transaction-atomicity.test.ts
+++ b/integrationTests/server/replay-transaction-atomicity.test.ts
@@ -88,7 +88,7 @@ function tearLastTransaction(path: string, readableBefore: number): number {
 		const lengthPos = pos + 8;
 		const length = buf.readUInt32BE(lengthPos);
 		const next = pos + TRANSACTION_LOG_ENTRY_HEADER_SIZE + length;
-		if (length === 0 || next > buf.length) break; // ran past the end / already unframable
+		if (length === 0 || next > buf.length) break;
 		entries.push({ lengthPos, timestamp });
 		pos = next;
 	}

--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -279,9 +279,10 @@ export class RocksTransactionLogStore extends EventEmitter {
 				if (isMidLogBreak(error)) corruptFrameStop.midLogBreak = true;
 				report(error);
 			});
-			// Predeclared, not left to the first assignment below: adding these fields after the object
-			// literal is built gives every TrackedIterator the same shape from birth, so V8 sees one
-			// hidden class here instead of a transition on this iterator's first entry.
+			// Set here, once, rather than left for the per-entry write sites below to add these fields
+			// on their first call: every TrackedIterator then reaches its final shape before any entry
+			// is consumed, so the hot per-entry writes hit an already-stable shape instead of each
+			// triggering its own transition on that iterator's first entry.
 			iterator.lastVersion = undefined;
 			iterator.lastEndTxn = undefined;
 			return iterator;

--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -3,7 +3,7 @@ import { ExtendedIterable } from '@harperfast/extended-iterable';
 import { getIdOfRemoteNode } from './nodeIdMapping.ts';
 import { Decoder, readAuditEntry, ENTRY_DATAVIEW, AuditRecord, createAuditEntry } from './auditStore.ts';
 import { HAS_STRUCTURE_UPDATE } from './RecordEncoder.ts';
-import { createCorruptFrameReporter, endIteratorOnCorruptFrame } from './replayLogsGuards.ts';
+import { createCorruptFrameReporter, endIteratorOnCorruptFrame, type CorruptFrameStop } from './replayLogsGuards.ts';
 import { isMainThread } from 'node:worker_threads';
 import { EventEmitter } from 'node:events';
 import { asBinary } from 'lmdb';
@@ -21,6 +21,11 @@ const HAS_PREVIOUS_VERSION = 0x20000000;
 type TransactionLogIterator = Iterator<TransactionEntry | number> & {
 	addLog(logName: string);
 	removeLog(logName: string);
+};
+
+export type TransactionLogIterable = Iterable<AuditRecord> & {
+	/** Corrupt frames that ended a log's iteration during this range. */
+	corruptFrameStop: CorruptFrameStop;
 };
 
 const reportCorruptFrame = createCorruptFrameReporter(harperLogger);
@@ -238,9 +243,20 @@ export class RocksTransactionLogStore extends EventEmitter {
 		startByLog?: Map<string, number>;
 		startFromLastFlushed?: boolean;
 		readUncommitted?: boolean;
-	}): Iterable<AuditRecord> {
+	}): TransactionLogIterable {
 		let iterable = new ExtendedIterable<TransactionEntry>();
 		let aggregateIterator: TransactionLogIterator;
+		// Shared by every per-log iterator of this range so a consumer can tell iteration that ended at
+		// a corrupt frame from iteration that reached the end of the logs, and can attribute the break
+		// to the entry it was reading when the break surfaced.
+		const corruptFrameStop: CorruptFrameStop = { breaks: 0 };
+		const onCorruptFrame = (log: TransactionLog) => {
+			const report = reportCorruptFrame(`${this.corruptFrameScope}/${log.name}`);
+			return (error) => {
+				corruptFrameStop.breaks++;
+				report(error);
+			};
+		};
 		if (options.log !== undefined) {
 			let log = typeof options.log === 'number' ? this.nodeLogs?.[options.log] : this.logByName.get(options.log);
 			if (!log) {
@@ -254,10 +270,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 					log = this.rootStore.useLog(options.log);
 				}
 			}
-			const queryIterator = endIteratorOnCorruptFrame(
-				log.query(options),
-				reportCorruptFrame(`${this.corruptFrameScope}/${log.name}`)
-			);
+			const queryIterator = endIteratorOnCorruptFrame(log.query(options), onCorruptFrame(log));
 			iterable.iterate = () => queryIterator;
 		} else {
 			const onlyKeys = options.onlyKeys;
@@ -308,12 +321,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 								// condition of potentially missing an initial update
 								queryOptions = { ...options, start: options.start ?? 0 };
 							}
-							iterators.push(
-								endIteratorOnCorruptFrame(
-									log.query(queryOptions),
-									reportCorruptFrame(`${this.corruptFrameScope}/${log.name}`)
-								)
-							);
+							iterators.push(endIteratorOnCorruptFrame(log.query(queryOptions), onCorruptFrame(log)));
 						}
 					}
 					latestUpdates = this.updates;
@@ -460,7 +468,8 @@ export class RocksTransactionLogStore extends EventEmitter {
 			mappedAggregateIterable.addLog = aggregateIterator.addLog;
 			mappedAggregateIterable.removeLog = aggregateIterator.removeLog;
 		}
-		return mappedAggregateIterable;
+		mappedAggregateIterable.corruptFrameStop = corruptFrameStop;
+		return mappedAggregateIterable as TransactionLogIterable;
 	}
 	getKeys(_options?: any) {
 		return []; // TODO: implement this

--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -279,6 +279,11 @@ export class RocksTransactionLogStore extends EventEmitter {
 				if (isMidLogBreak(error)) corruptFrameStop.midLogBreak = true;
 				report(error);
 			});
+			// Predeclared, not left to the first assignment below: adding these fields after the object
+			// literal is built gives every TrackedIterator the same shape from birth, so V8 sees one
+			// hidden class here instead of a transition on this iterator's first entry.
+			iterator.lastVersion = undefined;
+			iterator.lastEndTxn = undefined;
 			return iterator;
 		};
 		if (options.log !== undefined) {

--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -3,7 +3,7 @@ import { ExtendedIterable } from '@harperfast/extended-iterable';
 import { getIdOfRemoteNode } from './nodeIdMapping.ts';
 import { Decoder, readAuditEntry, ENTRY_DATAVIEW, AuditRecord, createAuditEntry } from './auditStore.ts';
 import { HAS_STRUCTURE_UPDATE } from './RecordEncoder.ts';
-import { endIteratorOnCorruptFrame } from './replayLogsGuards.ts';
+import { createCorruptFrameReporter, endIteratorOnCorruptFrame } from './replayLogsGuards.ts';
 import { isMainThread } from 'node:worker_threads';
 import { EventEmitter } from 'node:events';
 import { asBinary } from 'lmdb';
@@ -23,85 +23,7 @@ type TransactionLogIterator = Iterator<TransactionEntry | number> & {
 	removeLog(logName: string);
 };
 
-/**
- * A corrupt transaction-log frame, accumulated across every drain and boot for the life of the
- * process. A break is not a per-drain event: the same frame is re-encountered by each new reader
- * until every consumer's resume cursor has passed it, and before harper#2063 that condition was
- * observable only as repeating log lines. Keyed by (log, file, offset) so the log line is emitted
- * once per distinct break and the repeats become a count.
- *
- * Deliberately a *report*, not an exclusion list. Excluding the log would be worse than the break:
- * `excludeLogs` is keyed on the log *name*, i.e. an entire per-node stream (`'local'` is this
- * node's own writes), so dropping it stops every future entry on that stream from replicating —
- * turning one lost frame into a permanently dead stream. Resyncing past the break keeps the stream
- * alive; this makes the loss visible.
- */
-export interface CorruptFrameReport {
-	log: string;
-	logId?: number;
-	position?: number;
-	/** Bytes skipped to resume framing; 0 when nothing valid followed the break. */
-	unreadableBytes: number;
-	/** `false` when the break ended iteration (a torn tail, or the resync cap was hit). */
-	resynced: boolean;
-	firstSeen: number;
-	lastSeen: number;
-	occurrences: number;
-}
-
-const corruptFrameReports = new Map<string, CorruptFrameReport>();
-
-/**
- * Every corrupt transaction-log frame seen by this process. Consumed by cluster/health status so a
- * stream that has lost entries is distinguishable from a healthy one without grepping logs —
- * the field incident behind harper#2063 ran 11 days with `connected: true` throughout.
- */
-export function getCorruptFrameReports(): CorruptFrameReport[] {
-	return [...corruptFrameReports.values()];
-}
-
-// Test seam; there is no production reason to forget a break.
-export function clearCorruptFrameReports() {
-	corruptFrameReports.clear();
-}
-
-/**
- * Records a corrupt frame and logs it once per distinct break. A mid-log break is an `error`, not a
- * `warn`: entries written and acknowledged after it were skipped, so this is data loss, not a
- * tolerable end-of-log. A torn tail stays a `warn` — nothing followed it to lose.
- */
-function reportCorruptFrame(logName: string) {
-	return (error: RangeError, resynced: boolean, unreadableBytes: number) => {
-		const { logId, position } = error as RangeError & { logId?: number; position?: number };
-		const key = `${logName}:${logId}:${position}`;
-		const now = Date.now();
-		const existing = corruptFrameReports.get(key);
-		if (existing) {
-			existing.occurrences++;
-			existing.lastSeen = now;
-			return;
-		}
-		corruptFrameReports.set(key, {
-			log: logName,
-			logId,
-			position,
-			unreadableBytes,
-			resynced,
-			firstSeen: now,
-			lastSeen: now,
-			occurrences: 1,
-		});
-		if (resynced) {
-			harperLogger.error(
-				`Corrupt entry in transaction log "${logName}"; skipped ${unreadableBytes} unreadable byte(s) and resumed reading after it. ` +
-					`Entries within that span are lost to replay and replication and cannot be recovered from this log.`,
-				error
-			);
-		} else {
-			harperLogger.warn(`Stopping transaction log "${logName}" at a corrupt entry during replay`, error);
-		}
-	};
-}
+const reportCorruptFrame = createCorruptFrameReporter(harperLogger);
 
 /**
  * Represents a transaction log store backed by RocksDB.

--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -250,17 +250,25 @@ export class RocksTransactionLogStore extends EventEmitter {
 		startByLog?: Map<string, number>;
 		startFromLastFlushed?: boolean;
 		readUncommitted?: boolean;
+		/**
+		 * Track which version a break truncated, in `corruptFrameStop.truncatedVersions`. Costs two
+		 * property stores per yielded entry (see below), so it defaults off: only boot replay reads
+		 * `truncatedVersions`, but this range is also the always-on source for live subscriptions and
+		 * replication, where every healthy entry would otherwise pay bookkeeping nothing consumes.
+		 */
+		trackCorruptTransactions?: boolean;
 	}): TransactionLogIterable {
 		let iterable = new ExtendedIterable<TransactionEntry>();
 		let aggregateIterator: TransactionLogIterator;
 		let singleLogIterator: TrackedIterator;
+		const attributeCorruption = options.trackCorruptTransactions === true;
 		const corruptFrameStop: CorruptFrameStop = { breaks: 0, truncatedVersions: new Set(), midLogBreak: false };
 		// Each log's iterator carries the version and endTxn of the last entry it yielded, so a break
 		// can be attributed to the source transaction whose remaining entries it swallowed — unless
 		// that entry's own endTxn already closed the transaction, in which case the break fell after
 		// it, not inside it. On the iterator itself, not in a map keyed by log: this is written per
-		// entry on the replay/broadcast path, and it stays attached when a removed log is spliced out
-		// of the aggregate.
+		// entry on the replay/broadcast path (when `attributeCorruption`), and it stays attached when a
+		// removed log is spliced out of the aggregate.
 		const trackCorruptFrames = (log: TransactionLog, queryOptions: typeof options): TrackedIterator => {
 			const report = reportCorruptFrame(`${this.corruptFrameScope}/${log.name}`);
 			const iterator: TrackedIterator = endIteratorOnCorruptFrame(log.query(queryOptions), (error) => {
@@ -395,9 +403,11 @@ export class RocksTransactionLogStore extends EventEmitter {
 							}
 						}
 						if (earliestIndex >= 0) {
-							// before the refill, which is where a break surfaces and needs this entry's version
-							iterators[earliestIndex].lastVersion = earliest.timestamp;
-							iterators[earliestIndex].lastEndTxn = earliest.endTxn;
+							if (attributeCorruption) {
+								// before the refill, which is where a break surfaces and needs this entry's version
+								iterators[earliestIndex].lastVersion = earliest.timestamp;
+								iterators[earliestIndex].lastEndTxn = earliest.endTxn;
+							}
 							nextEntries[earliestIndex] = safeNext(iterators[earliestIndex], logs[earliestIndex]);
 							return {
 								value: onlyKeys ? earliest.timestamp : earliest,
@@ -434,7 +444,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 			// A break surfaces on the pull after this entry, so recording it here is in time to attribute
 			// that break to this entry's transaction. The aggregate branch records its own, per source
 			// log, because there this callback cannot tell which log an entry came from.
-			if (singleLogIterator) {
+			if (attributeCorruption && singleLogIterator) {
 				singleLogIterator.lastVersion = timestamp;
 				singleLogIterator.lastEndTxn = endTxn;
 			}

--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -23,6 +23,8 @@ type TransactionLogIterator = Iterator<TransactionEntry | number> & {
 	removeLog(logName: string);
 };
 
+type TrackedIterator = IterableIterator<TransactionEntry> & { lastVersion?: number };
+
 export type TransactionLogIterable = Iterable<AuditRecord> & {
 	/** Corrupt frames that ended a log's iteration during this range. */
 	corruptFrameStop: CorruptFrameStop;
@@ -247,18 +249,20 @@ export class RocksTransactionLogStore extends EventEmitter {
 		let iterable = new ExtendedIterable<TransactionEntry>();
 		let aggregateIterator: TransactionLogIterator;
 		// Set only for a single-log range, where every entry comes from the same log.
-		let singleLog: TransactionLog;
+		let singleLogIterator: TrackedIterator;
 		const corruptFrameStop: CorruptFrameStop = { breaks: 0, truncatedVersions: new Set() };
-		// The version of the last entry each log yielded in this range, so a break can be attributed to
-		// the source transaction whose remaining entries it swallowed.
-		const lastVersionByLog = new Map<TransactionLog, number>();
-		const onCorruptFrame = (log: TransactionLog) => {
+		// Each log's iterator carries the version of the last entry it yielded, so a break can be
+		// attributed to the source transaction whose remaining entries it swallowed. On the iterator
+		// itself, not in a map keyed by log: this is written per entry on the replay/broadcast path,
+		// and it stays attached when a removed log is spliced out of the aggregate.
+		const trackCorruptFrames = (log: TransactionLog, queryOptions: typeof options): TrackedIterator => {
 			const report = reportCorruptFrame(`${this.corruptFrameScope}/${log.name}`);
-			return (error) => {
+			const iterator: TrackedIterator = endIteratorOnCorruptFrame(log.query(queryOptions), (error) => {
 				corruptFrameStop.breaks++;
-				if (lastVersionByLog.has(log)) corruptFrameStop.truncatedVersions.add(lastVersionByLog.get(log));
+				if (iterator.lastVersion !== undefined) corruptFrameStop.truncatedVersions.add(iterator.lastVersion);
 				report(error);
-			};
+			});
+			return iterator;
 		};
 		if (options.log !== undefined) {
 			let log = typeof options.log === 'number' ? this.nodeLogs?.[options.log] : this.logByName.get(options.log);
@@ -273,8 +277,8 @@ export class RocksTransactionLogStore extends EventEmitter {
 					log = this.rootStore.useLog(options.log);
 				}
 			}
-			singleLog = log;
-			const queryIterator = endIteratorOnCorruptFrame(log.query(options), onCorruptFrame(log));
+			const queryIterator = trackCorruptFrames(log, options);
+			singleLogIterator = queryIterator;
 			iterable.iterate = () => queryIterator;
 		} else {
 			const onlyKeys = options.onlyKeys;
@@ -282,7 +286,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 			// holds the queue of next entries from each iterator
 			let nextEntries: any[];
 			let latestUpdates: number;
-			const iterators: IterableIterator<TransactionEntry>[] = [];
+			const iterators: TrackedIterator[] = [];
 			// Iterators that have permanently failed (corrupt entry stuck at the same
 			// position). Tracked by identity so the retry-poll path in next() and
 			// updateIterators() never calls .next() on them again — otherwise every
@@ -325,7 +329,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 								// condition of potentially missing an initial update
 								queryOptions = { ...options, start: options.start ?? 0 };
 							}
-							iterators.push(endIteratorOnCorruptFrame(log.query(queryOptions), onCorruptFrame(log)));
+							iterators.push(trackCorruptFrames(log, queryOptions));
 						}
 					}
 					latestUpdates = this.updates;
@@ -383,7 +387,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 						}
 						if (earliestIndex >= 0) {
 							// before the refill, which is where a break surfaces and needs this entry's version
-							lastVersionByLog.set(logs[earliestIndex], earliest.timestamp);
+							iterators[earliestIndex].lastVersion = earliest.timestamp;
 							nextEntries[earliestIndex] = safeNext(iterators[earliestIndex], logs[earliestIndex]);
 							return {
 								value: onlyKeys ? earliest.timestamp : earliest,
@@ -417,10 +421,10 @@ export class RocksTransactionLogStore extends EventEmitter {
 			iterable.iterate = () => aggregateIterator;
 		}
 		const mappedAggregateIterable = iterable.map(({ timestamp, data, endTxn }: TransactionEntry) => {
-			// A break surfaces on the pull after this entry, so recording it here is in time to
-			// attribute that break to this entry's transaction. The aggregate branch records its own,
-			// per source log, because there this callback cannot tell which log an entry came from.
-			if (singleLog) lastVersionByLog.set(singleLog, timestamp);
+			// A break surfaces on the pull after this entry, so recording it here is in time to attribute
+			// that break to this entry's transaction. The aggregate branch records its own, per source
+			// log, because there this callback cannot tell which log an entry came from.
+			if (singleLogIterator) singleLogIterator.lastVersion = timestamp;
 			// Per-entry try/catch: a corrupt rocks prelude (first 4-16 bytes) would otherwise
 			// throw a raw `RangeError: Offset is outside the bounds of the DataView` out
 			// through `iterable.map`, escape the for-of consumer, and land as an

--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -23,11 +23,84 @@ type TransactionLogIterator = Iterator<TransactionEntry | number> & {
 	removeLog(logName: string);
 };
 
-// Logs (once per log) when a corrupt frame ends a query iterator early; see
-// endIteratorOnCorruptFrame in replayLogsGuards.ts for why this is end-of-log, not a crash.
-function warnCorruptFrame(logName: string) {
-	return (error: RangeError) =>
-		harperLogger.warn(`Stopping transaction log "${logName}" at a corrupt entry during replay`, error);
+/**
+ * A corrupt transaction-log frame, accumulated across every drain and boot for the life of the
+ * process. A break is not a per-drain event: the same frame is re-encountered by each new reader
+ * until every consumer's resume cursor has passed it, and before harper#2063 that condition was
+ * observable only as repeating log lines. Keyed by (log, file, offset) so the log line is emitted
+ * once per distinct break and the repeats become a count.
+ *
+ * Deliberately a *report*, not an exclusion list. Excluding the log would be worse than the break:
+ * `excludeLogs` is keyed on the log *name*, i.e. an entire per-node stream (`'local'` is this
+ * node's own writes), so dropping it stops every future entry on that stream from replicating —
+ * turning one lost frame into a permanently dead stream. Resyncing past the break keeps the stream
+ * alive; this makes the loss visible.
+ */
+export interface CorruptFrameReport {
+	log: string;
+	logId?: number;
+	position?: number;
+	/** Bytes skipped to resume framing; 0 when nothing valid followed the break. */
+	unreadableBytes: number;
+	/** `false` when the break ended iteration (a torn tail, or the resync cap was hit). */
+	resynced: boolean;
+	firstSeen: number;
+	lastSeen: number;
+	occurrences: number;
+}
+
+const corruptFrameReports = new Map<string, CorruptFrameReport>();
+
+/**
+ * Every corrupt transaction-log frame seen by this process. Consumed by cluster/health status so a
+ * stream that has lost entries is distinguishable from a healthy one without grepping logs —
+ * the field incident behind harper#2063 ran 11 days with `connected: true` throughout.
+ */
+export function getCorruptFrameReports(): CorruptFrameReport[] {
+	return [...corruptFrameReports.values()];
+}
+
+// Test seam; there is no production reason to forget a break.
+export function clearCorruptFrameReports() {
+	corruptFrameReports.clear();
+}
+
+/**
+ * Records a corrupt frame and logs it once per distinct break. A mid-log break is an `error`, not a
+ * `warn`: entries written and acknowledged after it were skipped, so this is data loss, not a
+ * tolerable end-of-log. A torn tail stays a `warn` — nothing followed it to lose.
+ */
+function reportCorruptFrame(logName: string) {
+	return (error: RangeError, resynced: boolean, unreadableBytes: number) => {
+		const { logId, position } = error as RangeError & { logId?: number; position?: number };
+		const key = `${logName}:${logId}:${position}`;
+		const now = Date.now();
+		const existing = corruptFrameReports.get(key);
+		if (existing) {
+			existing.occurrences++;
+			existing.lastSeen = now;
+			return;
+		}
+		corruptFrameReports.set(key, {
+			log: logName,
+			logId,
+			position,
+			unreadableBytes,
+			resynced,
+			firstSeen: now,
+			lastSeen: now,
+			occurrences: 1,
+		});
+		if (resynced) {
+			harperLogger.error(
+				`Corrupt entry in transaction log "${logName}"; skipped ${unreadableBytes} unreadable byte(s) and resumed reading after it. ` +
+					`Entries within that span are lost to replay and replication and cannot be recovered from this log.`,
+				error
+			);
+		} else {
+			harperLogger.warn(`Stopping transaction log "${logName}" at a corrupt entry during replay`, error);
+		}
+	};
 }
 
 /**
@@ -254,7 +327,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 					log = this.rootStore.useLog(options.log);
 				}
 			}
-			const queryIterator = endIteratorOnCorruptFrame(log.query(options), warnCorruptFrame(log.name));
+			const queryIterator = endIteratorOnCorruptFrame(log.query(options), reportCorruptFrame(log.name));
 			iterable.iterate = () => queryIterator;
 		} else {
 			const onlyKeys = options.onlyKeys;
@@ -305,7 +378,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 								// condition of potentially missing an initial update
 								queryOptions = { ...options, start: options.start ?? 0 };
 							}
-							iterators.push(endIteratorOnCorruptFrame(log.query(queryOptions), warnCorruptFrame(log.name)));
+							iterators.push(endIteratorOnCorruptFrame(log.query(queryOptions), reportCorruptFrame(log.name)));
 						}
 					}
 					latestUpdates = this.updates;

--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -246,6 +246,8 @@ export class RocksTransactionLogStore extends EventEmitter {
 	}): TransactionLogIterable {
 		let iterable = new ExtendedIterable<TransactionEntry>();
 		let aggregateIterator: TransactionLogIterator;
+		// Set only for a single-log range, where every entry comes from the same log.
+		let singleLog: TransactionLog;
 		const corruptFrameStop: CorruptFrameStop = { breaks: 0, truncatedVersions: new Set() };
 		// The version of the last entry each log yielded in this range, so a break can be attributed to
 		// the source transaction whose remaining entries it swallowed.
@@ -271,6 +273,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 					log = this.rootStore.useLog(options.log);
 				}
 			}
+			singleLog = log;
 			const queryIterator = endIteratorOnCorruptFrame(log.query(options), onCorruptFrame(log));
 			iterable.iterate = () => queryIterator;
 		} else {
@@ -381,7 +384,6 @@ export class RocksTransactionLogStore extends EventEmitter {
 						if (earliestIndex >= 0) {
 							// before the refill, which is where a break surfaces and needs this entry's version
 							lastVersionByLog.set(logs[earliestIndex], earliest.timestamp);
-							// replace the entry with the next one from the iterator we pulled from
 							nextEntries[earliestIndex] = safeNext(iterators[earliestIndex], logs[earliestIndex]);
 							return {
 								value: onlyKeys ? earliest.timestamp : earliest,
@@ -415,6 +417,10 @@ export class RocksTransactionLogStore extends EventEmitter {
 			iterable.iterate = () => aggregateIterator;
 		}
 		const mappedAggregateIterable = iterable.map(({ timestamp, data, endTxn }: TransactionEntry) => {
+			// A break surfaces on the pull after this entry, so recording it here is in time to
+			// attribute that break to this entry's transaction. The aggregate branch records its own,
+			// per source log, because there this callback cannot tell which log an entry came from.
+			if (singleLog) lastVersionByLog.set(singleLog, timestamp);
 			// Per-entry try/catch: a corrupt rocks prelude (first 4-16 bytes) would otherwise
 			// throw a raw `RangeError: Offset is outside the bounds of the DataView` out
 			// through `iterable.map`, escape the for-of consumer, and land as an

--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -50,8 +50,10 @@ export class RocksTransactionLogStore extends EventEmitter {
 		super();
 		this.log = rootDatabase.useLog('local');
 		this.rootStore = rootDatabase;
-		// every database has its own 'local' log, so break reports must not share a name
-		this.corruptFrameScope = (rootDatabase as any).databaseName ?? rootDatabase.name ?? '';
+		// Break reports are keyed per log name, but every store has its own 'local' log, so they
+		// need a scope. The path, not `databaseName`: one root store can back several logical
+		// databases and they share these logs, and `databaseName` is not set on it yet here.
+		this.corruptFrameScope = rootDatabase.path;
 	}
 
 	/**

--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -246,14 +246,15 @@ export class RocksTransactionLogStore extends EventEmitter {
 	}): TransactionLogIterable {
 		let iterable = new ExtendedIterable<TransactionEntry>();
 		let aggregateIterator: TransactionLogIterator;
-		// Shared by every per-log iterator of this range so a consumer can tell iteration that ended at
-		// a corrupt frame from iteration that reached the end of the logs, and can attribute the break
-		// to the entry it was reading when the break surfaced.
-		const corruptFrameStop: CorruptFrameStop = { breaks: 0 };
+		const corruptFrameStop: CorruptFrameStop = { breaks: 0, truncatedVersions: new Set() };
+		// The version of the last entry each log yielded in this range, so a break can be attributed to
+		// the source transaction whose remaining entries it swallowed.
+		const lastVersionByLog = new Map<TransactionLog, number>();
 		const onCorruptFrame = (log: TransactionLog) => {
 			const report = reportCorruptFrame(`${this.corruptFrameScope}/${log.name}`);
 			return (error) => {
 				corruptFrameStop.breaks++;
+				if (lastVersionByLog.has(log)) corruptFrameStop.truncatedVersions.add(lastVersionByLog.get(log));
 				report(error);
 			};
 		};
@@ -378,6 +379,8 @@ export class RocksTransactionLogStore extends EventEmitter {
 							}
 						}
 						if (earliestIndex >= 0) {
+							// before the refill, which is where a break surfaces and needs this entry's version
+							lastVersionByLog.set(logs[earliestIndex], earliest.timestamp);
 							// replace the entry with the next one from the iterator we pulled from
 							nextEntries[earliestIndex] = safeNext(iterators[earliestIndex], logs[earliestIndex]);
 							return {

--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -3,7 +3,12 @@ import { ExtendedIterable } from '@harperfast/extended-iterable';
 import { getIdOfRemoteNode } from './nodeIdMapping.ts';
 import { Decoder, readAuditEntry, ENTRY_DATAVIEW, AuditRecord, createAuditEntry } from './auditStore.ts';
 import { HAS_STRUCTURE_UPDATE } from './RecordEncoder.ts';
-import { createCorruptFrameReporter, endIteratorOnCorruptFrame, type CorruptFrameStop } from './replayLogsGuards.ts';
+import {
+	createCorruptFrameReporter,
+	endIteratorOnCorruptFrame,
+	isMidLogBreak,
+	type CorruptFrameStop,
+} from './replayLogsGuards.ts';
 import { isMainThread } from 'node:worker_threads';
 import { EventEmitter } from 'node:events';
 import { asBinary } from 'lmdb';
@@ -23,7 +28,7 @@ type TransactionLogIterator = Iterator<TransactionEntry | number> & {
 	removeLog(logName: string);
 };
 
-type TrackedIterator = IterableIterator<TransactionEntry> & { lastVersion?: number };
+type TrackedIterator = IterableIterator<TransactionEntry> & { lastVersion?: number; lastEndTxn?: boolean };
 
 export type TransactionLogIterable = Iterable<AuditRecord> & {
 	/** Corrupt frames that ended a log's iteration during this range. */
@@ -248,18 +253,22 @@ export class RocksTransactionLogStore extends EventEmitter {
 	}): TransactionLogIterable {
 		let iterable = new ExtendedIterable<TransactionEntry>();
 		let aggregateIterator: TransactionLogIterator;
-		// Set only for a single-log range, where every entry comes from the same log.
 		let singleLogIterator: TrackedIterator;
-		const corruptFrameStop: CorruptFrameStop = { breaks: 0, truncatedVersions: new Set() };
-		// Each log's iterator carries the version of the last entry it yielded, so a break can be
-		// attributed to the source transaction whose remaining entries it swallowed. On the iterator
-		// itself, not in a map keyed by log: this is written per entry on the replay/broadcast path,
-		// and it stays attached when a removed log is spliced out of the aggregate.
+		const corruptFrameStop: CorruptFrameStop = { breaks: 0, truncatedVersions: new Set(), midLogBreak: false };
+		// Each log's iterator carries the version and endTxn of the last entry it yielded, so a break
+		// can be attributed to the source transaction whose remaining entries it swallowed — unless
+		// that entry's own endTxn already closed the transaction, in which case the break fell after
+		// it, not inside it. On the iterator itself, not in a map keyed by log: this is written per
+		// entry on the replay/broadcast path, and it stays attached when a removed log is spliced out
+		// of the aggregate.
 		const trackCorruptFrames = (log: TransactionLog, queryOptions: typeof options): TrackedIterator => {
 			const report = reportCorruptFrame(`${this.corruptFrameScope}/${log.name}`);
 			const iterator: TrackedIterator = endIteratorOnCorruptFrame(log.query(queryOptions), (error) => {
 				corruptFrameStop.breaks++;
-				if (iterator.lastVersion !== undefined) corruptFrameStop.truncatedVersions.add(iterator.lastVersion);
+				if (iterator.lastVersion !== undefined && iterator.lastEndTxn !== true) {
+					corruptFrameStop.truncatedVersions.add(iterator.lastVersion);
+				}
+				if (isMidLogBreak(error)) corruptFrameStop.midLogBreak = true;
 				report(error);
 			});
 			return iterator;
@@ -388,6 +397,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 						if (earliestIndex >= 0) {
 							// before the refill, which is where a break surfaces and needs this entry's version
 							iterators[earliestIndex].lastVersion = earliest.timestamp;
+							iterators[earliestIndex].lastEndTxn = earliest.endTxn;
 							nextEntries[earliestIndex] = safeNext(iterators[earliestIndex], logs[earliestIndex]);
 							return {
 								value: onlyKeys ? earliest.timestamp : earliest,
@@ -424,7 +434,10 @@ export class RocksTransactionLogStore extends EventEmitter {
 			// A break surfaces on the pull after this entry, so recording it here is in time to attribute
 			// that break to this entry's transaction. The aggregate branch records its own, per source
 			// log, because there this callback cannot tell which log an entry came from.
-			if (singleLogIterator) singleLogIterator.lastVersion = timestamp;
+			if (singleLogIterator) {
+				singleLogIterator.lastVersion = timestamp;
+				singleLogIterator.lastEndTxn = endTxn;
+			}
 			// Per-entry try/catch: a corrupt rocks prelude (first 4-16 bytes) would otherwise
 			// throw a raw `RangeError: Offset is outside the bounds of the DataView` out
 			// through `iterable.map`, escape the for-of consumer, and land as an

--- a/resources/RocksTransactionLogStore.ts
+++ b/resources/RocksTransactionLogStore.ts
@@ -37,6 +37,7 @@ export class RocksTransactionLogStore extends EventEmitter {
 	logByName: Map<string, TransactionLog> = new Map();
 	updates = 0; // the number of updates to the list of logs that have occurred
 	rootStore: RocksDatabase;
+	corruptFrameScope: string;
 	reusableIterable = true; // flag indicating that iterable can be reused to resume iterating through audit log
 	// Highest structureVersion appended to each per-node TransactionLog, tracked per tableId. Drives the
 	// per-log HAS_STRUCTURE_UPDATE flag in put(). Keyed by (log, tableId): a per-node log interleaves entries
@@ -49,6 +50,8 @@ export class RocksTransactionLogStore extends EventEmitter {
 		super();
 		this.log = rootDatabase.useLog('local');
 		this.rootStore = rootDatabase;
+		// every database has its own 'local' log, so break reports must not share a name
+		this.corruptFrameScope = (rootDatabase as any).databaseName ?? rootDatabase.name ?? '';
 	}
 
 	/**
@@ -249,7 +252,10 @@ export class RocksTransactionLogStore extends EventEmitter {
 					log = this.rootStore.useLog(options.log);
 				}
 			}
-			const queryIterator = endIteratorOnCorruptFrame(log.query(options), reportCorruptFrame(log.name));
+			const queryIterator = endIteratorOnCorruptFrame(
+				log.query(options),
+				reportCorruptFrame(`${this.corruptFrameScope}/${log.name}`)
+			);
 			iterable.iterate = () => queryIterator;
 		} else {
 			const onlyKeys = options.onlyKeys;
@@ -300,7 +306,12 @@ export class RocksTransactionLogStore extends EventEmitter {
 								// condition of potentially missing an initial update
 								queryOptions = { ...options, start: options.start ?? 0 };
 							}
-							iterators.push(endIteratorOnCorruptFrame(log.query(queryOptions), reportCorruptFrame(log.name)));
+							iterators.push(
+								endIteratorOnCorruptFrame(
+									log.query(queryOptions),
+									reportCorruptFrame(`${this.corruptFrameScope}/${log.name}`)
+								)
+							);
 						}
 					}
 					latestUpdates = this.updates;

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -129,7 +129,11 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 			strictFailure = error;
 		};
 		const txnLog: RocksTransactionLogStore = (rootStore as any).auditStore;
-		const entries = txnLog.getRange({ startFromLastFlushed: true, readUncommitted: true });
+		const entries = txnLog.getRange({
+			startFromLastFlushed: true,
+			readUncommitted: true,
+			trackCorruptTransactions: true,
+		});
 		for (const auditRecord of entries as any) {
 			if (noProgressRun > 0 && shouldAbortStalledReplay(noProgressRun, performance.now() - lastProgressTime)) {
 				const stallDiagnostic = `Aborting transaction-log replay in ${(rootStore as any).databaseName} database: ${noProgressRun} consecutive audit entries with no successful write (${skipped} skipped as unrecoverable, ${writes} replayed so far). This backlog is making no forward progress and was blocking startup (harper#1266) — typically a peer transaction log whose values reference unresolvable shared structures (harper#1163), or a backlog for a dropped table.`;
@@ -361,14 +365,18 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 				logger.error(`Error ${finalTorn ? 'discarding a torn' : 'committing'} replay transaction`, error);
 			}
 		}
-		if (entries.corruptFrameStop.breaks > 0) {
+		// `breaks` also counts a torn tail — the designed, benign reading of a crash's last frame, and
+		// the reporter already logged it at `warn`. Only a mid-log break lost entries, so it alone earns
+		// this quarantine/repair summary; duplicating it for a torn tail would tell an operator to
+		// repair or re-clone the node on every ordinary unclean shutdown.
+		if (entries.corruptFrameStop.midLogBreak) {
 			logger.error(
 				`Transaction-log replay in ${(rootStore as any).databaseName} database stopped at a corrupt entry after replaying ${writes} records. Every entry after the break is quarantined — neither replayed nor replicated — and ${discardedWrites} record(s) of the transaction the break truncated were discarded rather than applied in part. Repair the transaction log or re-clone this node to recover them.`
 			);
-			// A mid-log break loses entries, not just a torn tail — see the electedReplayer doc comment
-			// above. Set even when strictFailure is already set (a different cause), so this database
-			// name's diagnostic never gets shadowed by an unrelated commit/write error.
-			if (electedReplayer && !strictFailure && entries.corruptFrameStop.midLogBreak) {
+			// electedReplayer must not resolve past known loss — see the doc comment above. Only set
+			// strictFailure if nothing has already failed the replay for an unrelated reason, so this
+			// diagnostic never shadows a more specific commit/write error.
+			if (electedReplayer && !strictFailure) {
 				strictFailure = new Error(
 					`Elected replay in ${(rootStore as any).databaseName} database stopped at a mid-log corrupt transaction-log frame; entries behind the break were acknowledged and are now quarantined. Refusing to publish a branch over known lost writes — repair the transaction log or re-clone this node.`
 				);

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -225,7 +225,11 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 							transaction?.abort();
 						} else transaction?.directCommitSync();
 					} catch (error) {
-						// directCommitSync aborts and detaches its transaction on failure; no cleanup here
+						// directCommitSync aborts and detaches its transaction on failure; no cleanup here.
+						// The torn branch already backed stagedWrites out of writes before this try, so
+						// only a failed COMMIT (never applied) needs it backed out here too — otherwise a
+						// commit failure left `writes` counting records that never actually landed.
+						if (!torn) writes -= stagedWrites;
 						if (electedReplayer) {
 							strictFailure = error;
 							break;
@@ -360,7 +364,10 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 					transaction?.abort();
 				} else transaction?.directCommitSync();
 			} catch (error) {
-				// directCommitSync aborts and detaches its transaction on failure; no cleanup here
+				// directCommitSync aborts and detaches its transaction on failure; no cleanup here.
+				// Mirrors the interior version-boundary catch above: a failed commit never applied, so
+				// it must not stay counted in `writes`.
+				if (!finalTorn) writes -= stagedWrites;
 				if (electedReplayer) strictFailure = error;
 				logger.error(`Error ${finalTorn ? 'discarding a torn' : 'committing'} replay transaction`, error);
 			}

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -11,7 +11,6 @@ import {
 	isUndecodableValidatedWrite,
 	shouldAbortStalledReplay,
 	shouldAbortSlowReplay,
-	createTruncatedTransactionTracker,
 	REPLAY_WALL_CLOCK_LIMIT_MS,
 } from './replayLogsGuards.ts';
 import { purgeAgedLogs } from './auditStore.ts';
@@ -128,7 +127,6 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 		};
 		const txnLog: RocksTransactionLogStore = (rootStore as any).auditStore;
 		const entries = txnLog.getRange({ startFromLastFlushed: true, readUncommitted: true });
-		const truncated = createTruncatedTransactionTracker(entries.corruptFrameStop);
 		for (const auditRecord of entries as any) {
 			if (noProgressRun > 0 && shouldAbortStalledReplay(noProgressRun, performance.now() - lastProgressTime)) {
 				const stallDiagnostic = `Aborting transaction-log replay in ${(rootStore as any).databaseName} database: ${noProgressRun} consecutive audit entries with no successful write (${skipped} skipped as unrecoverable, ${writes} replayed so far). This backlog is making no forward progress and was blocking startup (harper#1266) — typically a peer transaction log whose values reference unresolvable shared structures (harper#1163), or a backlog for a dropped table.`;
@@ -141,7 +139,6 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 				);
 				break;
 			}
-			truncated.observe(auditRecord.version);
 			const {
 				type,
 				tableId,
@@ -209,7 +206,7 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 					console.warn('Harper was not properly shutdown, replaying transaction logs to synchronize database');
 				}
 				if (lastTimestamp !== version) {
-					const torn = truncated.wasTruncated(lastTimestamp);
+					const torn = entries.corruptFrameStop.truncatedVersions.has(lastTimestamp);
 					lastTimestamp = version;
 					try {
 						// commit the last transaction since we are starting a new one, unless a corrupt
@@ -347,7 +344,7 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 				});
 			}
 		}
-		const finalTorn = truncated.wasTruncated(lastTimestamp, true);
+		const finalTorn = entries.corruptFrameStop.truncatedVersions.has(lastTimestamp);
 		if (!strictFailure) {
 			try {
 				if (finalTorn) {

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -51,8 +51,11 @@ export function replayTimeBudgetMs(): number {
  * the branch claim (branchDatabase.ts) — and so may replay off the main thread. It also makes the
  * replay strict: the promise settles (never hangs), and a failure to apply the tail — a commit or
  * write error, a stall or wall-clock abort — rejects instead of quietly serving a rewound store.
- * Undecodable/torn entries stay tolerated in both modes: a crash tears the last frame of a log by
- * construction, and end-of-log is the designed reading of it (see replayLogsGuards.ts).
+ * Undecodable entries and a torn tail stay tolerated in both modes: a crash tears the last frame of
+ * a log by construction, and end-of-log is the designed reading of it (see replayLogsGuards.ts). A
+ * **mid-log** break is different — entries behind it were acknowledged and are now quarantined — so
+ * an elected replay rejects on one rather than publish a branch as a trustworthy point-in-time copy
+ * over known lost writes; boot replay still logs it and continues (harper#2016, harper#2063).
  */
 export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplayer?: boolean): Promise<void> {
 	if (!isMainThread && !electedReplayer) return Promise.resolve(); // ideally we don't do it like this, but for now this is predictable
@@ -362,6 +365,14 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 			logger.error(
 				`Transaction-log replay in ${(rootStore as any).databaseName} database stopped at a corrupt entry after replaying ${writes} records. Every entry after the break is quarantined — neither replayed nor replicated — and ${discardedWrites} record(s) of the transaction the break truncated were discarded rather than applied in part. Repair the transaction log or re-clone this node to recover them.`
 			);
+			// A mid-log break loses entries, not just a torn tail — see the electedReplayer doc comment
+			// above. Set even when strictFailure is already set (a different cause), so this database
+			// name's diagnostic never gets shadowed by an unrelated commit/write error.
+			if (electedReplayer && !strictFailure && entries.corruptFrameStop.midLogBreak) {
+				strictFailure = new Error(
+					`Elected replay in ${(rootStore as any).databaseName} database stopped at a mid-log corrupt transaction-log frame; entries behind the break were acknowledged and are now quarantined. Refusing to publish a branch over known lost writes — repair the transaction log or re-clone this node.`
+				);
+			}
 		}
 		if (writes > 0) logger.warn(`Replayed ${writes} records in ${(rootStore as any).databaseName} database`);
 		if (skipped > 0)

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -11,6 +11,7 @@ import {
 	isUndecodableValidatedWrite,
 	shouldAbortStalledReplay,
 	shouldAbortSlowReplay,
+	createTruncatedTransactionTracker,
 	REPLAY_WALL_CLOCK_LIMIT_MS,
 } from './replayLogsGuards.ts';
 import { purgeAgedLogs } from './auditStore.ts';
@@ -98,6 +99,10 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 		let transaction: DatabaseTransaction | undefined;
 		let lastTimestamp = 0;
 		let writes = 0;
+		// Writes staged on the currently-open transaction, so a discard can be taken back out of `writes`.
+		let stagedWrites = 0;
+		// Records dropped because a corrupt frame truncated the transaction they belong to.
+		let discardedWrites = 0;
 		let skipped = 0;
 		// Track forward progress so a backlog of unwritable entries can't grind the boot thread
 		// forever (harper#1266). `noProgressRun` counts every entry processed without a successful
@@ -122,7 +127,9 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 			strictFailure = error;
 		};
 		const txnLog: RocksTransactionLogStore = (rootStore as any).auditStore;
-		for (const auditRecord of txnLog.getRange({ startFromLastFlushed: true, readUncommitted: true }) as any) {
+		const entries = txnLog.getRange({ startFromLastFlushed: true, readUncommitted: true });
+		const truncated = createTruncatedTransactionTracker(entries.corruptFrameStop);
+		for (const auditRecord of entries as any) {
 			if (noProgressRun > 0 && shouldAbortStalledReplay(noProgressRun, performance.now() - lastProgressTime)) {
 				const stallDiagnostic = `Aborting transaction-log replay in ${(rootStore as any).databaseName} database: ${noProgressRun} consecutive audit entries with no successful write (${skipped} skipped as unrecoverable, ${writes} replayed so far). This backlog is making no forward progress and was blocking startup (harper#1266) — typically a peer transaction log whose values reference unresolvable shared structures (harper#1163), or a backlog for a dropped table.`;
 				if (electedReplayer) {
@@ -134,6 +141,7 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 				);
 				break;
 			}
+			truncated.observe(auditRecord.version);
 			const {
 				type,
 				tableId,
@@ -201,18 +209,26 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 					console.warn('Harper was not properly shutdown, replaying transaction logs to synchronize database');
 				}
 				if (lastTimestamp !== version) {
+					const torn = truncated.wasTruncated(lastTimestamp);
 					lastTimestamp = version;
 					try {
-						// commit the last transaction since we are starting a new one
-						transaction?.directCommitSync();
+						// commit the last transaction since we are starting a new one, unless a corrupt
+						// frame swallowed the rest of it — half of a source transaction must never become
+						// durable, so it is dropped whole and stays in the log for a repaired retry
+						if (torn) {
+							writes -= stagedWrites;
+							discardedWrites += stagedWrites;
+							transaction?.abort();
+						} else transaction?.directCommitSync();
 					} catch (error) {
 						// directCommitSync aborts and detaches its transaction on failure; no cleanup here
 						if (electedReplayer) {
 							strictFailure = error;
 							break;
 						}
-						logger.error('Error committing replay transaction', error);
+						logger.error(`Error ${torn ? 'discarding a torn' : 'committing'} replay transaction`, error);
 					}
+					stagedWrites = 0;
 					// Abort if replay has exceeded the total wall-clock budget even while making progress
 					// (harper#1316, facet a). shouldAbortStalledReplay resets its counters on every write,
 					// so a slow-but-progressing replay (deep out-of-order audit chain walk per entry) can
@@ -243,6 +259,7 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 				context.transaction = transaction;
 				const options = { context, residencyId, nodeId, originatingOperation };
 				writes++;
+				stagedWrites++;
 				switch (type) {
 					case 'put':
 						tableInstance._writeUpdate(recordId, record, true, options);
@@ -330,14 +347,24 @@ export function replayLogs(rootStore: RocksDatabase, tables: any, electedReplaye
 				});
 			}
 		}
+		const finalTorn = truncated.wasTruncated(lastTimestamp, true);
 		if (!strictFailure) {
 			try {
-				transaction?.directCommitSync();
+				if (finalTorn) {
+					writes -= stagedWrites;
+					discardedWrites += stagedWrites;
+					transaction?.abort();
+				} else transaction?.directCommitSync();
 			} catch (error) {
 				// directCommitSync aborts and detaches its transaction on failure; no cleanup here
 				if (electedReplayer) strictFailure = error;
-				logger.error('Error committing replay transaction', error);
+				logger.error(`Error ${finalTorn ? 'discarding a torn' : 'committing'} replay transaction`, error);
 			}
+		}
+		if (entries.corruptFrameStop.breaks > 0) {
+			logger.error(
+				`Transaction-log replay in ${(rootStore as any).databaseName} database stopped at a corrupt entry after replaying ${writes} records. Every entry after the break is quarantined — neither replayed nor replicated — and ${discardedWrites} record(s) of the transaction the break truncated were discarded rather than applied in part. Repair the transaction log or re-clone this node to recover them.`
+			);
 		}
 		if (writes > 0) logger.warn(`Replayed ${writes} records in ${(rootStore as any).databaseName} database`);
 		if (skipped > 0)

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -172,7 +172,9 @@ export function endIteratorOnCorruptFrame<T>(
 		next(): IteratorResult<T> {
 			while (!stopped) {
 				try {
-					return iterator.next();
+					const result = iterator.next();
+					resyncs = 0;
+					return result;
 				} catch (error) {
 					// Key on the class, not the message: the framing RangeError's wording is
 					// version-dependent (1.4.2 added hex offsets). Anything else re-throws.
@@ -281,6 +283,8 @@ export function createCorruptFrameReporter(logger: {
 		const key = corruptFrameKey(logName, error);
 		const existing = corruptFrameReports.get(key);
 		if (existing) {
+			corruptFrameReports.delete(key);
+			corruptFrameReports.set(key, existing);
 			existing.occurrences++;
 			existing.lastSeen = now;
 			existing.stoppedIteration = stoppedIteration;

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -280,14 +280,17 @@ export function createCorruptFrameReporter(logger: {
 		const key = corruptFrameKey(logName, error);
 		const existing = corruptFrameReports.get(key);
 		if (existing) {
+			const stoppedEscalated = stoppedIteration && !existing.stoppedIteration;
 			corruptFrameReports.delete(key);
 			corruptFrameReports.set(key, existing);
 			existing.occurrences++;
 			existing.lastSeen = now;
 			existing.stoppedIteration = stoppedIteration;
-			if (!midLog || existing.midLog) return;
-			existing.midLog = true;
-			existing.unreadableBytes = unreadableBytes;
+			if (!midLog || (existing.midLog && !stoppedEscalated)) return;
+			if (!existing.midLog) {
+				existing.midLog = true;
+				existing.unreadableBytes = unreadableBytes;
+			}
 		} else {
 			if (corruptFrameReports.size >= MAX_CORRUPT_FRAME_REPORTS) {
 				corruptFrameReports.delete(corruptFrameReports.keys().next().value);

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -132,34 +132,66 @@ export function shouldAbortSlowReplay(totalElapsedMs: number, timeLimitMs = REPL
 }
 
 /**
- * Wraps a transaction-log query iterator so a corrupt/torn frame ends that log's iteration
- * cleanly instead of escaping as an uncaughtException. rocksdb-js throws a bounded RangeError
- * when an entry's framing is broken; framing loss means the next entry can't be located, so the
- * frame marks end-of-log (entries before it were already yielded) and startup replay /
- * replication broadcast continue. `onCorruptFrame` fires once, latched — kept a callback (not a
- * direct log) so this module stays out of the Harper module graph and is unit-testable.
+ * Maximum corrupt frames to resync past within one iteration of a single log. A log with more
+ * breaks than this is damaged beyond "one interrupted append", and walking a long chain of them
+ * per drain is not worth the CPU; iteration ends at that point, exactly as it did before resync
+ * existed. Every break is still reported, so the count is visible rather than implied.
+ */
+export const MAX_RESYNCS_PER_ITERATION = 32;
+
+/**
+ * Wraps a transaction-log query iterator so a corrupt/torn frame is contained instead of escaping
+ * as an uncaughtException.
+ *
+ * Two shapes, which must be handled differently (harper#2016, harper#2063):
+ *
+ * - **Torn tail** — nothing valid follows the break, so the frame really is end-of-log. Iteration
+ *   ends; entries before it were already yielded. This is what open-time recovery in rocksdb-js
+ *   would have truncated to anyway.
+ * - **Mid-log break** — a partial append (ENOSPC/EDQUOT) the process survived, so valid entries
+ *   were appended *after* it and acknowledged to clients. Treating that as end-of-log amputates
+ *   every one of them: replay silently rolls the table back to the tear and replication starves
+ *   the peer, permanently, because each new drain restarts from the same resume cursor and stops
+ *   at the same frame. So iteration resyncs past the break and keeps delivering.
+ *
+ * The two are distinguished by `resyncPosition` on rocksdb-js's `CorruptFrameError`, which is the
+ * offset where valid framing resumes. Against a rocksdb-js without it (or any other RangeError),
+ * every break reads as a torn tail — the previous behavior.
+ *
+ * `onCorruptFrame` fires once per break (not once per log) and receives the number of bytes lost,
+ * so a caller can escalate a mid-log break and surface it as a health signal rather than leaving
+ * a wedged stream indistinguishable from a healthy one.
  */
 export function endIteratorOnCorruptFrame<T>(
 	iterator: Iterator<T>,
-	onCorruptFrame: (error: RangeError) => void
+	onCorruptFrame: (error: RangeError, resynced: boolean, unreadableBytes: number) => void
 ): IterableIterator<T> {
 	let stopped = false;
+	let resyncs = 0;
 	return {
 		[Symbol.iterator]() {
 			return this;
 		},
 		next(): IteratorResult<T> {
-			if (stopped) return { done: true, value: undefined };
-			try {
-				return iterator.next();
-			} catch (error) {
-				// Key on the class, not the message: the framing RangeError's wording is
-				// version-dependent (1.4.2 added hex offsets). Anything else re-throws.
-				if (!(error instanceof RangeError)) throw error;
-				stopped = true;
-				onCorruptFrame(error);
-				return { done: true, value: undefined };
+			while (!stopped) {
+				try {
+					return iterator.next();
+				} catch (error) {
+					// Key on the class, not the message: the framing RangeError's wording is
+					// version-dependent (1.4.2 added hex offsets). Anything else re-throws.
+					if (!(error instanceof RangeError)) throw error;
+					// A resync position means intact entries follow, and the reader has already
+					// positioned itself there — calling next() again resumes past the break.
+					const { resyncPosition, unreadableBytes } = error as RangeError & {
+						resyncPosition?: number;
+						unreadableBytes?: number;
+					};
+					const canResync = resyncPosition !== undefined && ++resyncs <= MAX_RESYNCS_PER_ITERATION;
+					if (!canResync) stopped = true;
+					onCorruptFrame(error, canResync, unreadableBytes ?? 0);
+				}
 			}
+			return { done: true, value: undefined };
 		},
 		// Forward early termination (for-of break/return/throw) so the source's cleanup runs;
 		// mark stopped first. Current rocksdb-js implements neither — hence the protocol defaults.

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -224,18 +224,16 @@ export interface CorruptFrameReport {
 /** Distinct break sites retained. One physical corruption yields one site, so this is generous. */
 export const MAX_CORRUPT_FRAME_REPORTS = 256;
 
-// Insertion-ordered, so the first key is the oldest site. Full means evicting that one rather than
-// refusing the new site: a site absent from the map cannot be deduplicated, so it would re-log on
-// every drain.
+// Re-encounters move a site to the end, so the first key is the least recently seen. Full means
+// evicting that one rather than refusing a new site, which could not then be deduplicated.
 const corruptFrameReports = new Map<string, CorruptFrameReport>();
 let evictedCorruptFrameReports = 0;
 
 /**
- * Every corrupt frame seen by this worker, for cluster/health status: a stream that has lost
- * entries must be distinguishable from a healthy one without grepping logs — the field incident
- * behind harper#2063 ran 11 days with `connected: true` throughout.
+ * Every corrupt frame seen by this worker. This is not yet consumed by cluster/health status;
+ * callers must aggregate it across worker threads before exposing a node-wide signal.
  *
- * Per-isolate, so a node-wide signal has to aggregate across worker threads.
+ * Mid-log breaks are immediately logged at error level even without that consumer.
  */
 export function getCorruptFrameReports(): CorruptFrameReport[] {
 	return [...corruptFrameReports.values()];
@@ -246,7 +244,6 @@ export function getEvictedCorruptFrameReportCount(): number {
 	return evictedCorruptFrameReports;
 }
 
-// Test seam.
 export function clearCorruptFrameReports() {
 	corruptFrameReports.clear();
 	evictedCorruptFrameReports = 0;
@@ -289,7 +286,6 @@ export function createCorruptFrameReporter(logger: {
 			existing.lastSeen = now;
 			existing.stoppedIteration = stoppedIteration;
 			if (!midLog || existing.midLog) return;
-			// first time this break has been seen to have entries behind it
 			existing.midLog = true;
 			existing.unreadableBytes = unreadableBytes;
 		} else {

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -222,27 +222,32 @@ export interface CorruptFrameReport {
 /** Distinct break sites retained. One physical corruption yields one site, so this is generous. */
 export const MAX_CORRUPT_FRAME_REPORTS = 256;
 
+// Insertion-ordered, so the first key is the oldest site. Full means evicting that one rather than
+// refusing the new site: a site absent from the map cannot be deduplicated, so it would re-log on
+// every drain.
 const corruptFrameReports = new Map<string, CorruptFrameReport>();
-let droppedCorruptFrameReports = 0;
+let evictedCorruptFrameReports = 0;
 
 /**
- * Every corrupt frame seen by this process, for cluster/health status: a stream that has lost
+ * Every corrupt frame seen by this worker, for cluster/health status: a stream that has lost
  * entries must be distinguishable from a healthy one without grepping logs — the field incident
  * behind harper#2063 ran 11 days with `connected: true` throughout.
+ *
+ * Per-isolate, so a node-wide signal has to aggregate across worker threads.
  */
 export function getCorruptFrameReports(): CorruptFrameReport[] {
 	return [...corruptFrameReports.values()];
 }
 
-/** Distinct break sites not retained because {@link MAX_CORRUPT_FRAME_REPORTS} was reached. */
-export function getDroppedCorruptFrameReportCount(): number {
-	return droppedCorruptFrameReports;
+/** Break sites evicted because {@link MAX_CORRUPT_FRAME_REPORTS} was reached. */
+export function getEvictedCorruptFrameReportCount(): number {
+	return evictedCorruptFrameReports;
 }
 
 // Test seam.
 export function clearCorruptFrameReports() {
 	corruptFrameReports.clear();
-	droppedCorruptFrameReports = 0;
+	evictedCorruptFrameReports = 0;
 }
 
 // `logId`/`position` are absent on any rocksdb-js predating the resync support, and every break on
@@ -252,8 +257,8 @@ export function clearCorruptFrameReports() {
 function corruptFrameKey(logName: string, error: CorruptFrameError): string {
 	const { logId, position } = error;
 	return logId !== undefined && position !== undefined
-		? `${logName}:${logId}:${position}`
-		: `${logName}:${error.message}`;
+		? `${logName}\u0000${logId}:${position}`
+		: `${logName}\u0000${error.message}`;
 }
 
 /**
@@ -283,9 +288,11 @@ export function createCorruptFrameReporter(logger: {
 			// first time this break has been seen to have entries behind it
 			existing.midLog = true;
 			existing.unreadableBytes = unreadableBytes;
-		} else if (corruptFrameReports.size >= MAX_CORRUPT_FRAME_REPORTS) {
-			droppedCorruptFrameReports++;
 		} else {
+			if (corruptFrameReports.size >= MAX_CORRUPT_FRAME_REPORTS) {
+				corruptFrameReports.delete(corruptFrameReports.keys().next().value);
+				evictedCorruptFrameReports++;
+			}
 			corruptFrameReports.set(key, {
 				log: logName,
 				logId: error.logId,

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -148,13 +148,32 @@ export type CorruptFrameError = RangeError & {
  *
  * `truncatedVersions` is what a consumer has to act on: a break destroys the framing after the last
  * entry the broken log yielded, and whether the entries it swallowed continued that entry's version
- * is exactly what can no longer be read. That version's transaction is therefore incomplete, and
- * replay must discard it rather than commit the part of it that was still readable. A log that
- * broke before yielding anything truncates no transaction.
+ * is exactly what can no longer be read — UNLESS that last entry's own `endTxn` already closed its
+ * transaction, in which case nothing of it was left open to swallow. That version's transaction is
+ * therefore incomplete only when it wasn't already known-closed, and replay must discard it rather
+ * than commit the part of it that was still readable. A log that broke before yielding anything
+ * truncates no transaction.
+ *
+ * `midLogBreak` is coarser: true once any break in this range left intact entries unreadable behind
+ * it (see {@link isMidLogBreak}), regardless of which version they belonged to. A consumer that must
+ * never serve a range with lost entries — an elected branch replay publishing itself as a trustworthy
+ * point-in-time copy — rejects on this rather than on `truncatedVersions`, since a mid-log break can
+ * strand entries whose version this range never even attributes to one log (harper#2016, #2063).
  */
 export interface CorruptFrameStop {
 	breaks: number;
 	truncatedVersions: Set<number>;
+	midLogBreak: boolean;
+}
+
+/**
+ * Whether a corrupt frame is a mid-log break — intact entries followed it, so entries were lost
+ * rather than the log merely being torn at its tail. Shared by the reporter below and by
+ * `RocksTransactionLogStore.getRange`'s `CorruptFrameStop.midLogBreak`, so the two can't drift on
+ * what counts as a mid-log break.
+ */
+export function isMidLogBreak(error: CorruptFrameError): boolean {
+	return error.resyncPosition != null;
 }
 
 /**
@@ -278,7 +297,7 @@ export function createCorruptFrameReporter(logger: {
 	error: (message: string, error?: unknown) => void;
 }) {
 	return (logName: string) => (error: CorruptFrameError) => {
-		const midLog = error.resyncPosition != null;
+		const midLog = isMidLogBreak(error);
 		const unreadableBytes = error.unreadableBytes ?? 0;
 		const now = Date.now();
 		const key = corruptFrameKey(logName, error);

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -133,8 +133,8 @@ export function shouldAbortSlowReplay(totalElapsedMs: number, timeLimitMs = REPL
 
 /**
  * A corrupt transaction-log frame from rocksdb-js. `resyncPosition` is set only when intact entries
- * follow the break (a mid-log tear); its absence means end-of-log, which is also what every
- * rocksdb-js predating the resync support reports.
+ * follow the break, which is what distinguishes lost entries from a merely truncated tail; its
+ * absence is also all that any rocksdb-js predating that field can report.
  */
 export type CorruptFrameError = RangeError & {
 	logId?: number | null;
@@ -144,47 +144,80 @@ export type CorruptFrameError = RangeError & {
 };
 
 /**
- * A log with more consecutive breaks than this without yielding an entry is damaged beyond one
- * interrupted append, so iteration ends rather than walking that chain on every drain.
+ * Corrupt frames hit by one `getRange` call, shared by its per-log iterators.
+ *
+ * A count, not a flag, because a consumer has to attribute each break to the source transaction it
+ * truncated: the entries an aggregate iterator has yielded from the broken log stop at the break,
+ * so the transaction those last entries belong to is the one left incomplete. Replay must discard
+ * that transaction rather than commit the surviving part of it.
  */
-export const MAX_RESYNCS_PER_ITERATION = 32;
+export interface CorruptFrameStop {
+	breaks: number;
+}
 
 /**
- * Wraps a transaction-log query iterator so a corrupt/torn frame is contained instead of escaping
- * as an uncaughtException.
+ * Attributes each corrupt frame to the source transaction it truncated, so a replay can drop that
+ * transaction whole instead of committing the part of it that was still readable.
  *
- * A torn tail really is end-of-log. A mid-log break is not: a partial append the process survived
- * has intact, already-acknowledged entries after it, so ending iteration there amputates all of
- * them — permanently, since every later drain restarts from the same resume cursor and stops at
- * the same frame (harper#2016, harper#2063). rocksdb-js distinguishes the two with
- * `resyncPosition` and leaves its reader positioned there, so resuming is a further `next()`.
+ * An aggregate transaction-log iterator refills a log's lookahead as it hands back that log's
+ * entry, so a break becomes visible on the very entry whose successors it destroyed — the version
+ * that entry belongs to is the incomplete transaction. Call {@link observe} for every entry, in
+ * order, then ask about a version when its transaction is about to be committed.
+ */
+export function createTruncatedTransactionTracker(corruptFrameStop: CorruptFrameStop) {
+	let accountedBreaks = 0;
+	let truncatedVersion: number;
+	return {
+		observe(version: number) {
+			if (corruptFrameStop.breaks > accountedBreaks) {
+				accountedBreaks = corruptFrameStop.breaks;
+				truncatedVersion = version;
+			}
+		},
+		/**
+		 * @param final the transaction staged when iteration ended — a break on the final pull has no
+		 *              following entry to be attributed to, so it belongs to this one
+		 */
+		wasTruncated(version: number, final = false): boolean {
+			return truncatedVersion === version || (final && corruptFrameStop.breaks > accountedBreaks);
+		},
+	};
+}
+
+/**
+ * Wraps a transaction-log query iterator so a corrupt/torn frame ends that log's iteration cleanly
+ * instead of escaping as an uncaughtException.
+ *
+ * Iteration stops at the break whether or not intact entries follow it. Resuming past a mid-log
+ * break would recover those entries, but a transaction log carries no frame-level transaction
+ * boundaries: replay groups equal-version entries into one source transaction, so skipping a frame
+ * inside such a group applies and checkpoints the surviving subset of a transaction that never
+ * committed that way at the source. Availability loss is visible and recoverable; a silently torn
+ * transaction is neither. Recovery is deferred until the engine can resume at a proven boundary
+ * (harper#2016, harper#2063); `resyncPosition` is used only to report the break as lost entries
+ * rather than as a truncated tail.
  */
 export function endIteratorOnCorruptFrame<T>(
 	iterator: Iterator<T>,
-	onCorruptFrame: (error: CorruptFrameError, stopped: boolean) => void
+	onCorruptFrame: (error: CorruptFrameError) => void
 ): IterableIterator<T> {
 	let stopped = false;
-	let resyncs = 0;
 	return {
 		[Symbol.iterator]() {
 			return this;
 		},
 		next(): IteratorResult<T> {
-			while (!stopped) {
-				try {
-					const result = iterator.next();
-					resyncs = 0;
-					return result;
-				} catch (error) {
-					// Key on the class, not the message: the framing RangeError's wording is
-					// version-dependent (1.4.2 added hex offsets). Anything else re-throws.
-					if (!(error instanceof RangeError)) throw error;
-					const { resyncPosition } = error as CorruptFrameError;
-					if (resyncPosition == null || ++resyncs > MAX_RESYNCS_PER_ITERATION) stopped = true;
-					onCorruptFrame(error as CorruptFrameError, stopped);
-				}
+			if (stopped) return { done: true, value: undefined };
+			try {
+				return iterator.next();
+			} catch (error) {
+				// Key on the class, not the message: the framing RangeError's wording is
+				// version-dependent (1.4.2 added hex offsets). Anything else re-throws.
+				if (!(error instanceof RangeError)) throw error;
+				stopped = true;
+				onCorruptFrame(error as CorruptFrameError);
+				return { done: true, value: undefined };
 			}
-			return { done: true, value: undefined };
 		},
 		// Forward early termination (for-of break/return/throw) so the source's cleanup runs;
 		// mark stopped first. Current rocksdb-js implements neither — hence the protocol defaults.
@@ -212,10 +245,8 @@ export interface CorruptFrameReport {
 	position?: number;
 	/** Intact entries followed the break, so entries were lost rather than merely truncated. */
 	midLog: boolean;
-	/** Bytes skipped to resume framing; 0 when nothing valid followed the break. */
+	/** Extent of the unreadable region, when the engine reports it; 0 when nothing valid follows it. */
 	unreadableBytes: number;
-	/** Whether the most recent encounter ended iteration (torn tail, or the resync cap). */
-	stoppedIteration: boolean;
 	firstSeen: number;
 	lastSeen: number;
 	occurrences: number;
@@ -264,33 +295,29 @@ function corruptFrameKey(logName: string, error: CorruptFrameError): string {
  * Records a corrupt frame and logs it once per distinct break.
  *
  * A mid-log break is an `error`, not a `warn`: entries after it were acknowledged and are now
- * unreachable. Severity follows the break's own shape rather than whether this pass resynced — one
- * that merely hit the resync cap lost entries too, and reporting it as the benign torn-tail `warn`
- * would re-hide what harper#2063 exists to surface. A later encounter can still escalate, since
- * the first pass may have hit the cap while a later one resyncs cleanly.
+ * quarantined behind it. Severity follows the break's own shape, never this pass's outcome — every
+ * pass stops, so keying on that would report the #2063 signature with the benign torn-tail `warn`.
+ * A site first seen as a torn tail can escalate later, since only a rocksdb-js that reports
+ * `resyncPosition` can tell the two apart.
  */
 export function createCorruptFrameReporter(logger: {
 	warn: (message: string, error?: unknown) => void;
 	error: (message: string, error?: unknown) => void;
 }) {
-	return (logName: string) => (error: CorruptFrameError, stoppedIteration: boolean) => {
+	return (logName: string) => (error: CorruptFrameError) => {
 		const midLog = error.resyncPosition != null;
 		const unreadableBytes = error.unreadableBytes ?? 0;
 		const now = Date.now();
 		const key = corruptFrameKey(logName, error);
 		const existing = corruptFrameReports.get(key);
 		if (existing) {
-			const stoppedEscalated = stoppedIteration && !existing.stoppedIteration;
 			corruptFrameReports.delete(key);
 			corruptFrameReports.set(key, existing);
 			existing.occurrences++;
 			existing.lastSeen = now;
-			existing.stoppedIteration = stoppedIteration;
-			if (!midLog || (existing.midLog && !stoppedEscalated)) return;
-			if (!existing.midLog) {
-				existing.midLog = true;
-				existing.unreadableBytes = unreadableBytes;
-			}
+			if (!midLog || existing.midLog) return;
+			existing.midLog = true;
+			existing.unreadableBytes = unreadableBytes;
 		} else {
 			if (corruptFrameReports.size >= MAX_CORRUPT_FRAME_REPORTS) {
 				corruptFrameReports.delete(corruptFrameReports.keys().next().value);
@@ -302,7 +329,6 @@ export function createCorruptFrameReporter(logger: {
 				position: error.position ?? undefined,
 				midLog,
 				unreadableBytes,
-				stoppedIteration,
 				firstSeen: now,
 				lastSeen: now,
 				occurrences: 1,
@@ -310,10 +336,9 @@ export function createCorruptFrameReporter(logger: {
 		}
 		if (midLog) {
 			logger.error(
-				`Corrupt entry in transaction log "${logName}"; ${unreadableBytes} byte(s) are unreadable and the entries within them are lost to replay and replication. ` +
-					(stoppedIteration
-						? 'This log has too many corrupt frames to read past; entries after this point remain unreachable after repair or aging until the worker/store reader is reconstructed, normally by restarting the worker.'
-						: 'Reading resumed after it.'),
+				`Corrupt entry in transaction log "${logName}"; ${unreadableBytes} byte(s) are unreadable and the entries within them are lost. ` +
+					'Intact entries follow the break, but reading stops there rather than skipping the frame, which could tear a source transaction: ' +
+					'they are quarantined until the log is repaired or this node is re-cloned, and they are neither replayed nor replicated meanwhile.',
 				error
 			);
 		} else {

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -309,7 +309,7 @@ export function createCorruptFrameReporter(logger: {
 			logger.error(
 				`Corrupt entry in transaction log "${logName}"; ${unreadableBytes} byte(s) are unreadable and the entries within them are lost to replay and replication. ` +
 					(stoppedIteration
-						? 'This log has too many corrupt frames to read past; entries after this point are unreachable until it is repaired or ages out.'
+						? 'This log has too many corrupt frames to read past; entries after this point remain unreachable after repair or aging until the worker/store reader is reconstructed, normally by restarting the worker.'
 						: 'Reading resumed after it.'),
 				error
 			);

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -144,8 +144,8 @@ export type CorruptFrameError = RangeError & {
 };
 
 /**
- * A log with more breaks than this in one pass is damaged beyond one interrupted append, so
- * iteration ends rather than walking a long chain of them on every drain.
+ * A log with more consecutive breaks than this without yielding an entry is damaged beyond one
+ * interrupted append, so iteration ends rather than walking that chain on every drain.
  */
 export const MAX_RESYNCS_PER_ITERATION = 32;
 

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -132,10 +132,20 @@ export function shouldAbortSlowReplay(totalElapsedMs: number, timeLimitMs = REPL
 }
 
 /**
- * Maximum corrupt frames to resync past within one iteration of a single log. A log with more
- * breaks than this is damaged beyond "one interrupted append", and walking a long chain of them
- * per drain is not worth the CPU; iteration ends at that point, exactly as it did before resync
- * existed. Every break is still reported, so the count is visible rather than implied.
+ * A corrupt transaction-log frame from rocksdb-js. `resyncPosition` is set only when intact entries
+ * follow the break (a mid-log tear); its absence means end-of-log, which is also what every
+ * rocksdb-js predating the resync support reports.
+ */
+export type CorruptFrameError = RangeError & {
+	logId?: number;
+	position?: number;
+	resyncPosition?: number;
+	unreadableBytes?: number;
+};
+
+/**
+ * A log with more breaks than this in one pass is damaged beyond one interrupted append, so
+ * iteration ends rather than walking a long chain of them on every drain.
  */
 export const MAX_RESYNCS_PER_ITERATION = 32;
 
@@ -143,28 +153,15 @@ export const MAX_RESYNCS_PER_ITERATION = 32;
  * Wraps a transaction-log query iterator so a corrupt/torn frame is contained instead of escaping
  * as an uncaughtException.
  *
- * Two shapes, which must be handled differently (harper#2016, harper#2063):
- *
- * - **Torn tail** — nothing valid follows the break, so the frame really is end-of-log. Iteration
- *   ends; entries before it were already yielded. This is what open-time recovery in rocksdb-js
- *   would have truncated to anyway.
- * - **Mid-log break** — a partial append (ENOSPC/EDQUOT) the process survived, so valid entries
- *   were appended *after* it and acknowledged to clients. Treating that as end-of-log amputates
- *   every one of them: replay silently rolls the table back to the tear and replication starves
- *   the peer, permanently, because each new drain restarts from the same resume cursor and stops
- *   at the same frame. So iteration resyncs past the break and keeps delivering.
- *
- * The two are distinguished by `resyncPosition` on rocksdb-js's `CorruptFrameError`, which is the
- * offset where valid framing resumes. Against a rocksdb-js without it (or any other RangeError),
- * every break reads as a torn tail — the previous behavior.
- *
- * `onCorruptFrame` fires once per break (not once per log) and receives the number of bytes lost,
- * so a caller can escalate a mid-log break and surface it as a health signal rather than leaving
- * a wedged stream indistinguishable from a healthy one.
+ * A torn tail really is end-of-log. A mid-log break is not: a partial append the process survived
+ * has intact, already-acknowledged entries after it, so ending iteration there amputates all of
+ * them — permanently, since every later drain restarts from the same resume cursor and stops at
+ * the same frame (harper#2016, harper#2063). rocksdb-js distinguishes the two with
+ * `resyncPosition` and leaves its reader positioned there, so resuming is a further `next()`.
  */
 export function endIteratorOnCorruptFrame<T>(
 	iterator: Iterator<T>,
-	onCorruptFrame: (error: RangeError, resynced: boolean, unreadableBytes: number) => void
+	onCorruptFrame: (error: CorruptFrameError, stopped: boolean) => void
 ): IterableIterator<T> {
 	let stopped = false;
 	let resyncs = 0;
@@ -180,15 +177,9 @@ export function endIteratorOnCorruptFrame<T>(
 					// Key on the class, not the message: the framing RangeError's wording is
 					// version-dependent (1.4.2 added hex offsets). Anything else re-throws.
 					if (!(error instanceof RangeError)) throw error;
-					// A resync position means intact entries follow, and the reader has already
-					// positioned itself there — calling next() again resumes past the break.
-					const { resyncPosition, unreadableBytes } = error as RangeError & {
-						resyncPosition?: number;
-						unreadableBytes?: number;
-					};
-					const canResync = resyncPosition !== undefined && ++resyncs <= MAX_RESYNCS_PER_ITERATION;
-					if (!canResync) stopped = true;
-					onCorruptFrame(error, canResync, unreadableBytes ?? 0);
+					const { resyncPosition } = error as CorruptFrameError;
+					if (resyncPosition === undefined || ++resyncs > MAX_RESYNCS_PER_ITERATION) stopped = true;
+					onCorruptFrame(error as CorruptFrameError, stopped);
 				}
 			}
 			return { done: true, value: undefined };
@@ -205,5 +196,118 @@ export function endIteratorOnCorruptFrame<T>(
 			if (typeof iterator.throw === 'function') return iterator.throw(error);
 			throw error;
 		},
+	};
+}
+
+/**
+ * A corrupt frame, accumulated for the life of the process. The same frame is re-encountered by
+ * every reader until each consumer's resume cursor has passed it, so this is deduplicated by
+ * location and the repeats become a count.
+ */
+export interface CorruptFrameReport {
+	log: string;
+	logId?: number;
+	position?: number;
+	/** Intact entries followed the break, so entries were lost rather than merely truncated. */
+	midLog: boolean;
+	/** Bytes skipped to resume framing; 0 when nothing valid followed the break. */
+	unreadableBytes: number;
+	/** Whether the most recent encounter ended iteration (torn tail, or the resync cap). */
+	stoppedIteration: boolean;
+	firstSeen: number;
+	lastSeen: number;
+	occurrences: number;
+}
+
+/** Distinct break sites retained. One physical corruption yields one site, so this is generous. */
+export const MAX_CORRUPT_FRAME_REPORTS = 256;
+
+const corruptFrameReports = new Map<string, CorruptFrameReport>();
+let droppedCorruptFrameReports = 0;
+
+/**
+ * Every corrupt frame seen by this process, for cluster/health status: a stream that has lost
+ * entries must be distinguishable from a healthy one without grepping logs — the field incident
+ * behind harper#2063 ran 11 days with `connected: true` throughout.
+ */
+export function getCorruptFrameReports(): CorruptFrameReport[] {
+	return [...corruptFrameReports.values()];
+}
+
+/** Distinct break sites not retained because {@link MAX_CORRUPT_FRAME_REPORTS} was reached. */
+export function getDroppedCorruptFrameReportCount(): number {
+	return droppedCorruptFrameReports;
+}
+
+// Test seam.
+export function clearCorruptFrameReports() {
+	corruptFrameReports.clear();
+	droppedCorruptFrameReports = 0;
+}
+
+// `logId`/`position` are absent on any rocksdb-js predating the resync support, and every break on
+// a stream would then collapse onto one key — folding genuinely different corruptions into a single
+// count that only ever logs once. The message carries the offset and file in text, so it separates
+// them when the fields can't.
+function corruptFrameKey(logName: string, error: CorruptFrameError): string {
+	const { logId, position } = error;
+	return logId !== undefined && position !== undefined
+		? `${logName}:${logId}:${position}`
+		: `${logName}:${error.message}`;
+}
+
+/**
+ * Records a corrupt frame and logs it once per distinct break.
+ *
+ * A mid-log break is an `error`, not a `warn`: entries after it were acknowledged and are now
+ * unreachable. Severity follows the break's own shape rather than whether this pass resynced — one
+ * that merely hit the resync cap lost entries too, and reporting it as the benign torn-tail `warn`
+ * would re-hide what harper#2063 exists to surface. A later encounter can still escalate, since
+ * the first pass may have hit the cap while a later one resyncs cleanly.
+ */
+export function createCorruptFrameReporter(logger: {
+	warn: (message: string, error?: unknown) => void;
+	error: (message: string, error?: unknown) => void;
+}) {
+	return (logName: string) => (error: CorruptFrameError, stoppedIteration: boolean) => {
+		const midLog = error.resyncPosition !== undefined;
+		const unreadableBytes = error.unreadableBytes ?? 0;
+		const now = Date.now();
+		const key = corruptFrameKey(logName, error);
+		const existing = corruptFrameReports.get(key);
+		if (existing) {
+			existing.occurrences++;
+			existing.lastSeen = now;
+			existing.stoppedIteration = stoppedIteration;
+			if (!midLog || existing.midLog) return;
+			// first time this break has been seen to have entries behind it
+			existing.midLog = true;
+			existing.unreadableBytes = unreadableBytes;
+		} else if (corruptFrameReports.size >= MAX_CORRUPT_FRAME_REPORTS) {
+			droppedCorruptFrameReports++;
+		} else {
+			corruptFrameReports.set(key, {
+				log: logName,
+				logId: error.logId,
+				position: error.position,
+				midLog,
+				unreadableBytes,
+				stoppedIteration,
+				firstSeen: now,
+				lastSeen: now,
+				occurrences: 1,
+			});
+		}
+		if (midLog) {
+			logger.error(
+				`Corrupt entry in transaction log "${logName}"; ${unreadableBytes} byte(s) are unreadable and the entries within them are lost to replay and replication. ` +
+					(stoppedIteration
+						? 'This log has too many corrupt frames to read past; entries after this point are unreachable until it is repaired or ages out.'
+						: 'Reading resumed after it.'),
+				error
+			);
+		} else {
+			logger.warn(`Stopping transaction log "${logName}" at a corrupt entry during replay`, error);
+		}
 	};
 }

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -150,8 +150,7 @@ export type CorruptFrameError = RangeError & {
  * entry the broken log yielded, and whether the entries it swallowed continued that entry's version
  * is exactly what can no longer be read. That version's transaction is therefore incomplete, and
  * replay must discard it rather than commit the part of it that was still readable. A log that
- * broke before yielding anything truncates no transaction. Only an aggregate range attributes
- * versions; a single-log range reports the count alone.
+ * broke before yielding anything truncates no transaction.
  */
 export interface CorruptFrameStop {
 	breaks: number;

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -137,10 +137,10 @@ export function shouldAbortSlowReplay(totalElapsedMs: number, timeLimitMs = REPL
  * rocksdb-js predating the resync support reports.
  */
 export type CorruptFrameError = RangeError & {
-	logId?: number;
-	position?: number;
-	resyncPosition?: number;
-	unreadableBytes?: number;
+	logId?: number | null;
+	position?: number | null;
+	resyncPosition?: number | null;
+	unreadableBytes?: number | null;
 };
 
 /**
@@ -178,7 +178,7 @@ export function endIteratorOnCorruptFrame<T>(
 					// version-dependent (1.4.2 added hex offsets). Anything else re-throws.
 					if (!(error instanceof RangeError)) throw error;
 					const { resyncPosition } = error as CorruptFrameError;
-					if (resyncPosition === undefined || ++resyncs > MAX_RESYNCS_PER_ITERATION) stopped = true;
+					if (resyncPosition == null || ++resyncs > MAX_RESYNCS_PER_ITERATION) stopped = true;
 					onCorruptFrame(error as CorruptFrameError, stopped);
 				}
 			}
@@ -256,7 +256,7 @@ export function clearCorruptFrameReports() {
 // them when the fields can't.
 function corruptFrameKey(logName: string, error: CorruptFrameError): string {
 	const { logId, position } = error;
-	return logId !== undefined && position !== undefined
+	return logId != null && position != null
 		? `${logName}\u0000${logId}:${position}`
 		: `${logName}\u0000${error.message}`;
 }
@@ -275,7 +275,7 @@ export function createCorruptFrameReporter(logger: {
 	error: (message: string, error?: unknown) => void;
 }) {
 	return (logName: string) => (error: CorruptFrameError, stoppedIteration: boolean) => {
-		const midLog = error.resyncPosition !== undefined;
+		const midLog = error.resyncPosition != null;
 		const unreadableBytes = error.unreadableBytes ?? 0;
 		const now = Date.now();
 		const key = corruptFrameKey(logName, error);
@@ -295,8 +295,8 @@ export function createCorruptFrameReporter(logger: {
 			}
 			corruptFrameReports.set(key, {
 				log: logName,
-				logId: error.logId,
-				position: error.position,
+				logId: error.logId ?? undefined,
+				position: error.position ?? undefined,
 				midLog,
 				unreadableBytes,
 				stoppedIteration,

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -146,42 +146,16 @@ export type CorruptFrameError = RangeError & {
 /**
  * Corrupt frames hit by one `getRange` call, shared by its per-log iterators.
  *
- * A count, not a flag, because a consumer has to attribute each break to the source transaction it
- * truncated: the entries an aggregate iterator has yielded from the broken log stop at the break,
- * so the transaction those last entries belong to is the one left incomplete. Replay must discard
- * that transaction rather than commit the surviving part of it.
+ * `truncatedVersions` is what a consumer has to act on: a break destroys the framing after the last
+ * entry the broken log yielded, and whether the entries it swallowed continued that entry's version
+ * is exactly what can no longer be read. That version's transaction is therefore incomplete, and
+ * replay must discard it rather than commit the part of it that was still readable. A log that
+ * broke before yielding anything truncates no transaction. Only an aggregate range attributes
+ * versions; a single-log range reports the count alone.
  */
 export interface CorruptFrameStop {
 	breaks: number;
-}
-
-/**
- * Attributes each corrupt frame to the source transaction it truncated, so a replay can drop that
- * transaction whole instead of committing the part of it that was still readable.
- *
- * An aggregate transaction-log iterator refills a log's lookahead as it hands back that log's
- * entry, so a break becomes visible on the very entry whose successors it destroyed — the version
- * that entry belongs to is the incomplete transaction. Call {@link observe} for every entry, in
- * order, then ask about a version when its transaction is about to be committed.
- */
-export function createTruncatedTransactionTracker(corruptFrameStop: CorruptFrameStop) {
-	let accountedBreaks = 0;
-	let truncatedVersion: number;
-	return {
-		observe(version: number) {
-			if (corruptFrameStop.breaks > accountedBreaks) {
-				accountedBreaks = corruptFrameStop.breaks;
-				truncatedVersion = version;
-			}
-		},
-		/**
-		 * @param final the transaction staged when iteration ended — a break on the final pull has no
-		 *              following entry to be attributed to, so it belongs to this one
-		 */
-		wasTruncated(version: number, final = false): boolean {
-			return truncatedVersion === version || (final && corruptFrameStop.breaks > accountedBreaks);
-		},
-	};
+	truncatedVersions: Set<number>;
 }
 
 /**

--- a/unitTests/resources/branchDatabase.test.js
+++ b/unitTests/resources/branchDatabase.test.js
@@ -157,7 +157,10 @@ describeUnlessLmdb('branch lifecycle (harper#643)', () => {
 			},
 			auditStore: {
 				getRange() {
-					return [{ type: 'put', tableId: 7, version: 1, extendedType: 17, getValue: () => ({ id: 1 }) }];
+					return Object.assign(
+						[{ type: 'put', tableId: 7, version: 1, extendedType: 17, getValue: () => ({ id: 1 }) }],
+						{ corruptFrameStop: { breaks: 0, truncatedVersions: new Set() } }
+					);
 				},
 			},
 		};

--- a/unitTests/resources/branchDatabase.test.js
+++ b/unitTests/resources/branchDatabase.test.js
@@ -168,6 +168,43 @@ describeUnlessLmdb('branch lifecycle (harper#643)', () => {
 		assert.strictEqual(unlocked, true, 'a failed strict replay must release the lock for the retry');
 	});
 
+	it('an elected replay rejects on a mid-log break even when every readable entry replayed cleanly', async function () {
+		// A mid-log break can strand entries this range never attributes to any yielded version (a
+		// log that breaks before yielding anything truncates no transaction), so the branch claim
+		// must not go READY just because truncatedVersions came back empty and every entry it could
+		// read committed cleanly. It rejects on midLogBreak itself.
+		let unlocked = false;
+		const queued = [];
+		const healthyTable = {
+			tableId: 7,
+			getResource() {
+				return { _writeUpdate() {}, save() {} };
+			},
+		};
+		const stubStore = {
+			databaseName: 'stub-midlog',
+			tryLock(key, onUnlocked) {
+				queued.push(onUnlocked);
+				return true;
+			},
+			unlock() {
+				unlocked = true;
+				for (const onUnlocked of queued) onUnlocked();
+				return true;
+			},
+			auditStore: {
+				getRange() {
+					return Object.assign(
+						[{ type: 'put', tableId: 7, version: 1, extendedType: 17, getValue: () => ({ id: 1 }) }],
+						{ corruptFrameStop: { breaks: 1, truncatedVersions: new Set(), midLogBreak: true } }
+					);
+				},
+			},
+		};
+		await assert.rejects(() => replayLogs(stubStore, { Healthy: healthyTable }, true), /mid-log corrupt/);
+		assert.strictEqual(unlocked, true, 'a rejected elected replay must still release the lock for a retry');
+	});
+
 	it('fails the load when the adopted branch cannot replay, then adopts cleanly once it can', async function () {
 		// Materialize by hand what a previous boot leaves behind, so this boot's first sight of the
 		// branch is the adopt path.

--- a/unitTests/resources/replayLogs.test.js
+++ b/unitTests/resources/replayLogs.test.js
@@ -11,7 +11,7 @@ const {
 	MAX_CORRUPT_FRAME_REPORTS,
 	createCorruptFrameReporter,
 	getCorruptFrameReports,
-	getDroppedCorruptFrameReportCount,
+	getEvictedCorruptFrameReportCount,
 	clearCorruptFrameReports,
 	shouldAbortStalledReplay,
 	REPLAY_NO_PROGRESS_COUNT_LIMIT,
@@ -404,16 +404,33 @@ describe('createCorruptFrameReporter', () => {
 		assert.strictEqual(logs.warn.length, 2);
 	});
 
-	it('bounds retained break sites and counts the ones it drops', () => {
+	it('bounds retained break sites by evicting the oldest', () => {
 		const { logs, report } = setup();
 		for (let i = 0; i < MAX_CORRUPT_FRAME_REPORTS + 5; i++) {
 			report(midLogError(0x1000 + i * 0x100), false);
 		}
 
 		assert.strictEqual(getCorruptFrameReports().length, MAX_CORRUPT_FRAME_REPORTS);
-		assert.strictEqual(getDroppedCorruptFrameReportCount(), 5);
-		// dropped sites are still logged, so visibility never depends on retention
+		assert.strictEqual(getEvictedCorruptFrameReportCount(), 5);
 		assert.strictEqual(logs.error.length, MAX_CORRUPT_FRAME_REPORTS + 5);
+	});
+
+	// Refusing a new site once full would leave it undeduplicated, so it would re-log on every
+	// drain — the log spam this report exists to replace.
+	it('keeps deduplicating the newest sites after the bound is reached', () => {
+		const { logs, report } = setup();
+		for (let i = 0; i < MAX_CORRUPT_FRAME_REPORTS + 5; i++) {
+			report(midLogError(0x1000 + i * 0x100), false);
+		}
+		const logsAfterFill = logs.error.length;
+
+		// re-encounter the most recent site repeatedly, as every later drain would
+		for (let i = 0; i < 10; i++) {
+			report(midLogError(0x1000 + (MAX_CORRUPT_FRAME_REPORTS + 4) * 0x100), false);
+		}
+
+		assert.strictEqual(logs.error.length, logsAfterFill);
+		assert.strictEqual(getEvictedCorruptFrameReportCount(), 5);
 	});
 });
 

--- a/unitTests/resources/replayLogs.test.js
+++ b/unitTests/resources/replayLogs.test.js
@@ -194,6 +194,30 @@ describe('endIteratorOnCorruptFrame', () => {
 		assert.strictEqual(calls, MAX_RESYNCS_PER_ITERATION + 1);
 	});
 
+	it('resets the resync cap after the source makes progress', () => {
+		let frames = 0;
+		let corrupt = true;
+		const source = {
+			next() {
+				if (frames > MAX_RESYNCS_PER_ITERATION) return { done: true, value: undefined };
+				if (corrupt) {
+					corrupt = false;
+					const error = new RangeError('corrupt');
+					error.resyncPosition = frames;
+					throw error;
+				}
+				corrupt = true;
+				return { done: false, value: frames++ };
+			},
+		};
+		const reported = [];
+		const wrapped = endIteratorOnCorruptFrame(source, (error, stopped) => reported.push(stopped));
+
+		assert.strictEqual([...wrapped].length, MAX_RESYNCS_PER_ITERATION + 1);
+		assert.strictEqual(reported.length, MAX_RESYNCS_PER_ITERATION + 1);
+		assert.ok(reported.every((stopped) => stopped === false));
+	});
+
 	it('treats a RangeError with no resync position as end-of-log (older rocksdb-js)', () => {
 		let calls = 0;
 		const source = {
@@ -501,6 +525,22 @@ describe('createCorruptFrameReporter', () => {
 
 		assert.strictEqual(logs.error.length, logsAfterFill);
 		assert.strictEqual(getEvictedCorruptFrameReportCount(), 5);
+	});
+
+	it('retains recently encountered sites when evicting old reports', () => {
+		const { logs, report } = setup();
+		for (let i = 0; i < MAX_CORRUPT_FRAME_REPORTS; i++) {
+			report(midLogError(0x1000 + i * 0x100), false);
+		}
+		const firstPosition = 0x1000;
+		const secondPosition = 0x1100;
+		report(midLogError(firstPosition), false);
+		report(midLogError(0x1000 + MAX_CORRUPT_FRAME_REPORTS * 0x100), false);
+
+		const positions = getCorruptFrameReports().map((entry) => entry.position);
+		assert.ok(positions.includes(firstPosition));
+		assert.ok(!positions.includes(secondPosition));
+		assert.strictEqual(logs.error.length, MAX_CORRUPT_FRAME_REPORTS + 1);
 	});
 });
 

--- a/unitTests/resources/replayLogs.test.js
+++ b/unitTests/resources/replayLogs.test.js
@@ -7,7 +7,7 @@ const {
 	isUndecodableValidatedWrite,
 	RECORD_BEARING_FLAGS,
 	endIteratorOnCorruptFrame,
-	MAX_RESYNCS_PER_ITERATION,
+	createTruncatedTransactionTracker,
 	MAX_CORRUPT_FRAME_REPORTS,
 	createCorruptFrameReporter,
 	getCorruptFrameReports,
@@ -141,11 +141,11 @@ describe('endIteratorOnCorruptFrame', () => {
 		assert.strictEqual(reported.length, 1);
 	});
 
-	// harper#2016 / harper#2063: a mid-log break has intact, already-acknowledged entries behind
-	// it. rocksdb-js reports where framing resumes and leaves the reader positioned there, so the
-	// wrapper must keep pulling — treating it as end-of-log amputates every later entry, and every
-	// future drain restarts from the same cursor and stops at the same frame.
-	it('resyncs past a mid-log corrupt frame and keeps yielding the entries after it', () => {
+	// harper#2016 / harper#2063: intact, already-acknowledged entries follow a mid-log break, and
+	// skipping the frame would recover them — but the frame carries no transaction boundary, so the
+	// surviving part of a torn source transaction would be applied. Iteration stops on either shape;
+	// only the report distinguishes them.
+	it('stops at a mid-log break rather than resuming past it', () => {
 		let calls = 0;
 		const source = {
 			next() {
@@ -157,65 +157,19 @@ describe('endIteratorOnCorruptFrame', () => {
 					error.unreadableBytes = 26;
 					throw error;
 				}
-				if (calls === 3) return { done: false, value: 'b' };
-				return { done: true, value: undefined };
+				return { done: false, value: 'b' };
 			},
 		};
 		const reported = [];
-		const wrapped = endIteratorOnCorruptFrame(source, (error, stopped) => reported.push({ error, stopped }));
+		const wrapped = endIteratorOnCorruptFrame(source, (error) => reported.push(error));
 
-		assert.deepStrictEqual([...wrapped], ['a', 'b']);
+		assert.deepStrictEqual([...wrapped], ['a']);
 		assert.strictEqual(reported.length, 1);
-		assert.strictEqual(reported[0].stopped, false);
-		assert.strictEqual(reported[0].error.unreadableBytes, 26);
-	});
-
-	it('stops resyncing once a log exceeds the per-iteration cap', () => {
-		let calls = 0;
-		const source = {
-			next() {
-				calls++;
-				const error = new RangeError('corrupt');
-				error.resyncPosition = calls * 100;
-				error.unreadableBytes = 8;
-				throw error;
-			},
-		};
-		const reported = [];
-		const wrapped = endIteratorOnCorruptFrame(source, (error, stopped) => reported.push(stopped));
-
+		assert.strictEqual(reported[0].resyncPosition, 0x7d3f);
+		assert.strictEqual(reported[0].unreadableBytes, 26);
+		// latched: the entries after the break are never pulled, on this or any later call
 		assert.deepStrictEqual(wrapped.next(), { done: true, value: undefined });
-		// the cap is what ends iteration, and the break that hit it is reported as stopping it
-		assert.strictEqual(calls, MAX_RESYNCS_PER_ITERATION + 1);
-		assert.strictEqual(reported.length, MAX_RESYNCS_PER_ITERATION + 1);
-		assert.strictEqual(reported.at(-1), true);
-		// latched afterwards: no further pulls on the source
-		assert.deepStrictEqual(wrapped.next(), { done: true, value: undefined });
-		assert.strictEqual(calls, MAX_RESYNCS_PER_ITERATION + 1);
-	});
-
-	it('resets the resync cap after the source makes progress', () => {
-		let frames = 0;
-		let corrupt = true;
-		const source = {
-			next() {
-				if (frames > MAX_RESYNCS_PER_ITERATION) return { done: true, value: undefined };
-				if (corrupt) {
-					corrupt = false;
-					const error = new RangeError('corrupt');
-					error.resyncPosition = frames;
-					throw error;
-				}
-				corrupt = true;
-				return { done: false, value: frames++ };
-			},
-		};
-		const reported = [];
-		const wrapped = endIteratorOnCorruptFrame(source, (error, stopped) => reported.push(stopped));
-
-		assert.strictEqual([...wrapped].length, MAX_RESYNCS_PER_ITERATION + 1);
-		assert.strictEqual(reported.length, MAX_RESYNCS_PER_ITERATION + 1);
-		assert.ok(reported.every((stopped) => stopped === false));
+		assert.strictEqual(calls, 2);
 	});
 
 	it('treats a RangeError with no resync position as end-of-log (older rocksdb-js)', () => {
@@ -228,12 +182,10 @@ describe('endIteratorOnCorruptFrame', () => {
 			},
 		};
 		const reported = [];
-		const wrapped = endIteratorOnCorruptFrame(source, (error, stopped) =>
-			reported.push({ stopped, resyncPosition: error.resyncPosition })
-		);
+		const wrapped = endIteratorOnCorruptFrame(source, (error) => reported.push(error.resyncPosition));
 
 		assert.deepStrictEqual([...wrapped], ['a']);
-		assert.deepStrictEqual(reported, [{ stopped: true, resyncPosition: undefined }]);
+		assert.deepStrictEqual(reported, [undefined]);
 		assert.strictEqual(calls, 2);
 	});
 
@@ -248,9 +200,8 @@ describe('endIteratorOnCorruptFrame', () => {
 					throw error;
 				},
 			},
-			(reportedError, stopped) => {
+			(reportedError) => {
 				assert.strictEqual(reportedError, error);
-				assert.strictEqual(stopped, true);
 			}
 		);
 
@@ -258,43 +209,25 @@ describe('endIteratorOnCorruptFrame', () => {
 		assert.strictEqual(calls, 1);
 	});
 
+	// 0 is a legitimate resync position, so the mid-log signal must not be a truthiness test.
 	it('keeps zero as a valid resync position', () => {
 		const error = new RangeError('corrupt frame at offset 0');
 		error.resyncPosition = 0;
 		let calls = 0;
+		const reported = [];
 		const wrapped = endIteratorOnCorruptFrame(
 			{
 				next() {
-					if (calls++ === 0) throw error;
-					return { done: true, value: undefined };
+					calls++;
+					throw error;
 				},
 			},
-			(reportedError, stopped) => {
-				assert.strictEqual(reportedError, error);
-				assert.strictEqual(stopped, false);
-			}
+			(reportedError) => reported.push(reportedError.resyncPosition)
 		);
 
 		assert.deepStrictEqual(wrapped.next(), { done: true, value: undefined });
-		assert.strictEqual(calls, 2);
-	});
-
-	it('reports the cap-hit break as having stopped iteration, not as a clean resync', () => {
-		// The reporter keys severity off the error's own shape, so a mid-log break that merely hit
-		// the cap must still be distinguishable from a torn tail.
-		const source = {
-			next() {
-				const error = new RangeError('corrupt');
-				error.resyncPosition = 1;
-				throw error;
-			},
-		};
-		const reported = [];
-		const wrapped = endIteratorOnCorruptFrame(source, (error, stopped) =>
-			reported.push({ stopped, midLog: error.resyncPosition != null })
-		);
-		wrapped.next();
-		assert.deepStrictEqual(reported.at(-1), { stopped: true, midLog: true });
+		assert.deepStrictEqual(reported, [0]);
+		assert.strictEqual(calls, 1);
 	});
 
 	it('does not swallow non-RangeError failures', () => {
@@ -377,6 +310,71 @@ describe('endIteratorOnCorruptFrame', () => {
 	});
 });
 
+// harper#2016 / harper#2063: replay groups equal-version entries into one source transaction, so a
+// break inside such a group leaves the surviving part of a transaction that never committed that
+// way at the source. The tracker is what tells replay which staged transaction to drop.
+describe('createTruncatedTransactionTracker', () => {
+	it('reports nothing truncated while no break has been seen', () => {
+		const stop = { breaks: 0 };
+		const tracker = createTruncatedTransactionTracker(stop);
+		for (const version of [10, 10, 20]) tracker.observe(version);
+
+		assert.strictEqual(tracker.wasTruncated(10), false);
+		assert.strictEqual(tracker.wasTruncated(20), false);
+		assert.strictEqual(tracker.wasTruncated(20, true), false);
+	});
+
+	// The break surfaces on the entry whose successors it destroyed, because the aggregate iterator
+	// refills that log's lookahead as it hands the entry back.
+	it('attributes a break to the version of the entry it surfaced on', () => {
+		const stop = { breaks: 0 };
+		const tracker = createTruncatedTransactionTracker(stop);
+		tracker.observe(10);
+		stop.breaks++;
+		tracker.observe(10);
+		tracker.observe(20);
+
+		assert.strictEqual(tracker.wasTruncated(10), true);
+		assert.strictEqual(tracker.wasTruncated(20), false);
+	});
+
+	// A break seen as the FIRST entry of the next transaction arrives belongs to that next
+	// transaction, not to the one just completed — the opposite attribution would commit the torn
+	// one and discard an intact one.
+	it('attributes a break on a boundary entry to the transaction that entry starts', () => {
+		const stop = { breaks: 0 };
+		const tracker = createTruncatedTransactionTracker(stop);
+		tracker.observe(10);
+		stop.breaks++;
+		tracker.observe(20);
+
+		assert.strictEqual(tracker.wasTruncated(10), false);
+		assert.strictEqual(tracker.wasTruncated(20), true);
+	});
+
+	it('attributes a break with no entry after it to the transaction still staged at the end', () => {
+		const stop = { breaks: 0 };
+		const tracker = createTruncatedTransactionTracker(stop);
+		tracker.observe(10);
+		stop.breaks++;
+
+		assert.strictEqual(tracker.wasTruncated(10), false);
+		assert.strictEqual(tracker.wasTruncated(10, true), true);
+	});
+
+	it('follows the latest break when several logs break during one replay', () => {
+		const stop = { breaks: 0 };
+		const tracker = createTruncatedTransactionTracker(stop);
+		stop.breaks++;
+		tracker.observe(10);
+		stop.breaks++;
+		tracker.observe(20);
+
+		assert.strictEqual(tracker.wasTruncated(10), false);
+		assert.strictEqual(tracker.wasTruncated(20), true);
+	});
+});
+
 // harper#2063: the reporter is what makes a lossy stream distinguishable from a healthy one, so
 // its severity choice, deduplication, and key derivation are the load-bearing parts.
 describe('createCorruptFrameReporter', () => {
@@ -401,7 +399,7 @@ describe('createCorruptFrameReporter', () => {
 
 	it('logs a mid-log break at error level and records the lost bytes', () => {
 		const { logs, report } = setup();
-		report(midLogError(), false);
+		report(midLogError());
 
 		assert.strictEqual(logs.warn.length, 0);
 		assert.strictEqual(logs.error.length, 1);
@@ -419,28 +417,28 @@ describe('createCorruptFrameReporter', () => {
 		const error = new RangeError('truncated entry header');
 		error.logId = 2;
 		error.position = 100;
-		report(error, true);
+		report(error);
 
 		assert.strictEqual(logs.error.length, 0);
 		assert.strictEqual(logs.warn.length, 1);
 		assert.strictEqual(getCorruptFrameReports()[0].midLog, false);
 	});
 
-	// A break that hit the resync cap lost entries just the same. Reporting it as the benign
-	// torn-tail warn would re-hide the condition #2063 exists to surface.
-	it('logs a capped mid-log break as data loss, naming it unreachable', () => {
+	// The whole point of #2063 is that the lossy case is distinguishable from the benign one, and
+	// that the operator is told what state the rest of the log is in.
+	it('names the entries behind a mid-log break as quarantined', () => {
 		const { logs, report } = setup();
-		report(midLogError(), true);
+		report(midLogError());
 
 		assert.strictEqual(logs.warn.length, 0);
-		assert.match(logs.error[0].message, /remain unreachable.*until the worker\/store reader is reconstructed/);
+		assert.match(logs.error[0].message, /quarantined until the log is repaired or this node is re-cloned/);
 	});
 
 	it('counts repeats of the same break without re-logging it', () => {
 		const { logs, report } = setup();
-		report(midLogError(), false);
-		report(midLogError(), false);
-		report(midLogError(), false);
+		report(midLogError());
+		report(midLogError());
+		report(midLogError());
 
 		assert.strictEqual(logs.error.length, 1);
 		const [only] = getCorruptFrameReports();
@@ -448,35 +446,36 @@ describe('createCorruptFrameReporter', () => {
 		assert.ok(only.lastSeen >= only.firstSeen);
 	});
 
-	// The first pass may sit behind 32 other breaks and hit the cap; a later pass, its cursor
-	// further along, resyncs cleanly. The report and the tracked state must follow.
-	it('updates the stopped state on a later encounter of the same break', () => {
-		const { report } = setup();
-		report(midLogError(), true);
-		assert.strictEqual(getCorruptFrameReports()[0].stoppedIteration, true);
-
-		report(midLogError(), false);
-		assert.strictEqual(getCorruptFrameReports()[0].stoppedIteration, false);
-	});
-
-	it('logs when a repeated mid-log break escalates from resumed to stopped', () => {
+	// The same site reads as a torn tail on a rocksdb-js that cannot report `resyncPosition` and as
+	// data loss on one that can, so a report that latched on the first encounter would keep the
+	// benign classification after the engine bump that makes the loss visible.
+	it('escalates a site first seen as a torn tail once it is known to be mid-log', () => {
 		const { logs, report } = setup();
-		report(midLogError(), false);
-		report(midLogError(), true);
-		report(midLogError(), true);
+		const tornTail = midLogError();
+		delete tornTail.resyncPosition;
+		delete tornTail.unreadableBytes;
+		report(tornTail);
+		assert.strictEqual(getCorruptFrameReports()[0].midLog, false);
 
-		assert.strictEqual(logs.error.length, 2);
-		assert.match(logs.error[0].message, /Reading resumed/);
-		assert.match(logs.error[1].message, /remain unreachable/);
-		assert.strictEqual(getCorruptFrameReports()[0].stoppedIteration, true);
+		report(midLogError());
+		assert.deepStrictEqual(
+			{ midLog: getCorruptFrameReports()[0].midLog, unreadableBytes: getCorruptFrameReports()[0].unreadableBytes },
+			{ midLog: true, unreadableBytes: 26 }
+		);
+		assert.strictEqual(logs.warn.length, 1);
+		assert.strictEqual(logs.error.length, 1);
+
+		// and it does not re-log on every later drain
+		report(midLogError());
+		assert.strictEqual(logs.error.length, 1);
 	});
 
 	// Against a rocksdb-js with no logId/position, keying on those fields alone collapses every
 	// break on the stream onto one entry, so the second real corruption is never logged.
 	it('separates breaks by message when the error carries no logId/position', () => {
 		const { logs, report } = setup();
-		report(new RangeError('Corrupt transaction log entry at position 7d20bb of log 2'), true);
-		report(new RangeError('Corrupt transaction log entry at position 3bc071 of log 23'), true);
+		report(new RangeError('Corrupt transaction log entry at position 7d20bb of log 2'));
+		report(new RangeError('Corrupt transaction log entry at position 3bc071 of log 23'));
 
 		assert.strictEqual(getCorruptFrameReports().length, 2);
 		assert.strictEqual(logs.warn.length, 2);
@@ -489,7 +488,7 @@ describe('createCorruptFrameReporter', () => {
 			error.logId = null;
 			error.position = null;
 			error.resyncPosition = null;
-			report(error, true);
+			report(error);
 		}
 
 		assert.strictEqual(getCorruptFrameReports().length, 2);
@@ -501,7 +500,7 @@ describe('createCorruptFrameReporter', () => {
 		const { logs, report } = setup();
 		const error = midLogError(0, 0);
 		error.logId = 0;
-		report(error, false);
+		report(error);
 
 		assert.strictEqual(logs.error.length, 1);
 		assert.deepStrictEqual(
@@ -513,7 +512,7 @@ describe('createCorruptFrameReporter', () => {
 	it('bounds retained break sites by evicting the oldest', () => {
 		const { logs, report } = setup();
 		for (let i = 0; i < MAX_CORRUPT_FRAME_REPORTS + 5; i++) {
-			report(midLogError(0x1000 + i * 0x100), false);
+			report(midLogError(0x1000 + i * 0x100));
 		}
 
 		assert.strictEqual(getCorruptFrameReports().length, MAX_CORRUPT_FRAME_REPORTS);
@@ -526,13 +525,13 @@ describe('createCorruptFrameReporter', () => {
 	it('keeps deduplicating the newest sites after the bound is reached', () => {
 		const { logs, report } = setup();
 		for (let i = 0; i < MAX_CORRUPT_FRAME_REPORTS + 5; i++) {
-			report(midLogError(0x1000 + i * 0x100), false);
+			report(midLogError(0x1000 + i * 0x100));
 		}
 		const logsAfterFill = logs.error.length;
 
 		// re-encounter the most recent site repeatedly, as every later drain would
 		for (let i = 0; i < 10; i++) {
-			report(midLogError(0x1000 + (MAX_CORRUPT_FRAME_REPORTS + 4) * 0x100), false);
+			report(midLogError(0x1000 + (MAX_CORRUPT_FRAME_REPORTS + 4) * 0x100));
 		}
 
 		assert.strictEqual(logs.error.length, logsAfterFill);
@@ -542,12 +541,12 @@ describe('createCorruptFrameReporter', () => {
 	it('retains recently encountered sites when evicting old reports', () => {
 		const { logs, report } = setup();
 		for (let i = 0; i < MAX_CORRUPT_FRAME_REPORTS; i++) {
-			report(midLogError(0x1000 + i * 0x100), false);
+			report(midLogError(0x1000 + i * 0x100));
 		}
 		const firstPosition = 0x1000;
 		const secondPosition = 0x1100;
-		report(midLogError(firstPosition), false);
-		report(midLogError(0x1000 + MAX_CORRUPT_FRAME_REPORTS * 0x100), false);
+		report(midLogError(firstPosition));
+		report(midLogError(0x1000 + MAX_CORRUPT_FRAME_REPORTS * 0x100));
 
 		const positions = getCorruptFrameReports().map((entry) => entry.position);
 		assert.ok(positions.includes(firstPosition));

--- a/unitTests/resources/replayLogs.test.js
+++ b/unitTests/resources/replayLogs.test.js
@@ -459,6 +459,18 @@ describe('createCorruptFrameReporter', () => {
 		assert.strictEqual(getCorruptFrameReports()[0].stoppedIteration, false);
 	});
 
+	it('logs when a repeated mid-log break escalates from resumed to stopped', () => {
+		const { logs, report } = setup();
+		report(midLogError(), false);
+		report(midLogError(), true);
+		report(midLogError(), true);
+
+		assert.strictEqual(logs.error.length, 2);
+		assert.match(logs.error[0].message, /Reading resumed/);
+		assert.match(logs.error[1].message, /remain unreachable/);
+		assert.strictEqual(getCorruptFrameReports()[0].stoppedIteration, true);
+	});
+
 	// Against a rocksdb-js with no logId/position, keying on those fields alone collapses every
 	// break on the stream onto one entry, so the second real corruption is never logged.
 	it('separates breaks by message when the error carries no logId/position', () => {

--- a/unitTests/resources/replayLogs.test.js
+++ b/unitTests/resources/replayLogs.test.js
@@ -7,7 +7,6 @@ const {
 	isUndecodableValidatedWrite,
 	RECORD_BEARING_FLAGS,
 	endIteratorOnCorruptFrame,
-	createTruncatedTransactionTracker,
 	MAX_CORRUPT_FRAME_REPORTS,
 	createCorruptFrameReporter,
 	getCorruptFrameReports,
@@ -307,71 +306,6 @@ describe('endIteratorOnCorruptFrame', () => {
 			() => endIteratorOnCorruptFrame({ next: source.next }, () => {}).throw(boom),
 			(error) => error === boom
 		);
-	});
-});
-
-// harper#2016 / harper#2063: replay groups equal-version entries into one source transaction, so a
-// break inside such a group leaves the surviving part of a transaction that never committed that
-// way at the source. The tracker is what tells replay which staged transaction to drop.
-describe('createTruncatedTransactionTracker', () => {
-	it('reports nothing truncated while no break has been seen', () => {
-		const stop = { breaks: 0 };
-		const tracker = createTruncatedTransactionTracker(stop);
-		for (const version of [10, 10, 20]) tracker.observe(version);
-
-		assert.strictEqual(tracker.wasTruncated(10), false);
-		assert.strictEqual(tracker.wasTruncated(20), false);
-		assert.strictEqual(tracker.wasTruncated(20, true), false);
-	});
-
-	// The break surfaces on the entry whose successors it destroyed, because the aggregate iterator
-	// refills that log's lookahead as it hands the entry back.
-	it('attributes a break to the version of the entry it surfaced on', () => {
-		const stop = { breaks: 0 };
-		const tracker = createTruncatedTransactionTracker(stop);
-		tracker.observe(10);
-		stop.breaks++;
-		tracker.observe(10);
-		tracker.observe(20);
-
-		assert.strictEqual(tracker.wasTruncated(10), true);
-		assert.strictEqual(tracker.wasTruncated(20), false);
-	});
-
-	// A break seen as the FIRST entry of the next transaction arrives belongs to that next
-	// transaction, not to the one just completed — the opposite attribution would commit the torn
-	// one and discard an intact one.
-	it('attributes a break on a boundary entry to the transaction that entry starts', () => {
-		const stop = { breaks: 0 };
-		const tracker = createTruncatedTransactionTracker(stop);
-		tracker.observe(10);
-		stop.breaks++;
-		tracker.observe(20);
-
-		assert.strictEqual(tracker.wasTruncated(10), false);
-		assert.strictEqual(tracker.wasTruncated(20), true);
-	});
-
-	it('attributes a break with no entry after it to the transaction still staged at the end', () => {
-		const stop = { breaks: 0 };
-		const tracker = createTruncatedTransactionTracker(stop);
-		tracker.observe(10);
-		stop.breaks++;
-
-		assert.strictEqual(tracker.wasTruncated(10), false);
-		assert.strictEqual(tracker.wasTruncated(10, true), true);
-	});
-
-	it('follows the latest break when several logs break during one replay', () => {
-		const stop = { breaks: 0 };
-		const tracker = createTruncatedTransactionTracker(stop);
-		stop.breaks++;
-		tracker.observe(10);
-		stop.breaks++;
-		tracker.observe(20);
-
-		assert.strictEqual(tracker.wasTruncated(10), false);
-		assert.strictEqual(tracker.wasTruncated(20), true);
 	});
 });
 

--- a/unitTests/resources/replayLogs.test.js
+++ b/unitTests/resources/replayLogs.test.js
@@ -433,7 +433,7 @@ describe('createCorruptFrameReporter', () => {
 		report(midLogError(), true);
 
 		assert.strictEqual(logs.warn.length, 0);
-		assert.match(logs.error[0].message, /unreachable until it is repaired/);
+		assert.match(logs.error[0].message, /remain unreachable.*until the worker\/store reader is reconstructed/);
 	});
 
 	it('counts repeats of the same break without re-logging it', () => {

--- a/unitTests/resources/replayLogs.test.js
+++ b/unitTests/resources/replayLogs.test.js
@@ -8,6 +8,11 @@ const {
 	RECORD_BEARING_FLAGS,
 	endIteratorOnCorruptFrame,
 	MAX_RESYNCS_PER_ITERATION,
+	MAX_CORRUPT_FRAME_REPORTS,
+	createCorruptFrameReporter,
+	getCorruptFrameReports,
+	getDroppedCorruptFrameReportCount,
+	clearCorruptFrameReports,
 	shouldAbortStalledReplay,
 	REPLAY_NO_PROGRESS_COUNT_LIMIT,
 	REPLAY_NO_PROGRESS_TIME_LIMIT_MS,
@@ -157,14 +162,12 @@ describe('endIteratorOnCorruptFrame', () => {
 			},
 		};
 		const reported = [];
-		const wrapped = endIteratorOnCorruptFrame(source, (error, resynced, unreadableBytes) =>
-			reported.push({ error, resynced, unreadableBytes })
-		);
+		const wrapped = endIteratorOnCorruptFrame(source, (error, stopped) => reported.push({ error, stopped }));
 
 		assert.deepStrictEqual([...wrapped], ['a', 'b']);
 		assert.strictEqual(reported.length, 1);
-		assert.strictEqual(reported[0].resynced, true);
-		assert.strictEqual(reported[0].unreadableBytes, 26);
+		assert.strictEqual(reported[0].stopped, false);
+		assert.strictEqual(reported[0].error.unreadableBytes, 26);
 	});
 
 	it('stops resyncing once a log exceeds the per-iteration cap', () => {
@@ -179,13 +182,13 @@ describe('endIteratorOnCorruptFrame', () => {
 			},
 		};
 		const reported = [];
-		const wrapped = endIteratorOnCorruptFrame(source, (error, resynced) => reported.push(resynced));
+		const wrapped = endIteratorOnCorruptFrame(source, (error, stopped) => reported.push(stopped));
 
 		assert.deepStrictEqual(wrapped.next(), { done: true, value: undefined });
-		// the cap is what ends iteration, and the break that hit it is reported as not-resynced
+		// the cap is what ends iteration, and the break that hit it is reported as stopping it
 		assert.strictEqual(calls, MAX_RESYNCS_PER_ITERATION + 1);
 		assert.strictEqual(reported.length, MAX_RESYNCS_PER_ITERATION + 1);
-		assert.strictEqual(reported.at(-1), false);
+		assert.strictEqual(reported.at(-1), true);
 		// latched afterwards: no further pulls on the source
 		assert.deepStrictEqual(wrapped.next(), { done: true, value: undefined });
 		assert.strictEqual(calls, MAX_RESYNCS_PER_ITERATION + 1);
@@ -201,13 +204,31 @@ describe('endIteratorOnCorruptFrame', () => {
 			},
 		};
 		const reported = [];
-		const wrapped = endIteratorOnCorruptFrame(source, (error, resynced, unreadableBytes) =>
-			reported.push({ resynced, unreadableBytes })
+		const wrapped = endIteratorOnCorruptFrame(source, (error, stopped) =>
+			reported.push({ stopped, resyncPosition: error.resyncPosition })
 		);
 
 		assert.deepStrictEqual([...wrapped], ['a']);
-		assert.deepStrictEqual(reported, [{ resynced: false, unreadableBytes: 0 }]);
+		assert.deepStrictEqual(reported, [{ stopped: true, resyncPosition: undefined }]);
 		assert.strictEqual(calls, 2);
+	});
+
+	it('reports the cap-hit break as having stopped iteration, not as a clean resync', () => {
+		// The reporter keys severity off the error's own shape, so a mid-log break that merely hit
+		// the cap must still be distinguishable from a torn tail.
+		const source = {
+			next() {
+				const error = new RangeError('corrupt');
+				error.resyncPosition = 1;
+				throw error;
+			},
+		};
+		const reported = [];
+		const wrapped = endIteratorOnCorruptFrame(source, (error, stopped) =>
+			reported.push({ stopped, midLog: error.resyncPosition !== undefined })
+		);
+		wrapped.next();
+		assert.deepStrictEqual(reported.at(-1), { stopped: true, midLog: true });
 	});
 
 	it('does not swallow non-RangeError failures', () => {
@@ -287,6 +308,112 @@ describe('endIteratorOnCorruptFrame', () => {
 			() => endIteratorOnCorruptFrame({ next: source.next }, () => {}).throw(boom),
 			(error) => error === boom
 		);
+	});
+});
+
+// harper#2063: the reporter is what makes a lossy stream distinguishable from a healthy one, so
+// its severity choice, deduplication, and key derivation are the load-bearing parts.
+describe('createCorruptFrameReporter', () => {
+	function setup() {
+		clearCorruptFrameReports();
+		const logs = { warn: [], error: [] };
+		const reporter = createCorruptFrameReporter({
+			warn: (message, error) => logs.warn.push({ message, error }),
+			error: (message, error) => logs.error.push({ message, error }),
+		});
+		return { logs, report: reporter('local') };
+	}
+
+	function midLogError(position = 0x7d20bb, unreadableBytes = 26) {
+		const error = new RangeError(`Corrupt transaction log entry at position ${position.toString(16)} of log 2`);
+		error.logId = 2;
+		error.position = position;
+		error.resyncPosition = position + unreadableBytes;
+		error.unreadableBytes = unreadableBytes;
+		return error;
+	}
+
+	it('logs a mid-log break at error level and records the lost bytes', () => {
+		const { logs, report } = setup();
+		report(midLogError(), false);
+
+		assert.strictEqual(logs.warn.length, 0);
+		assert.strictEqual(logs.error.length, 1);
+		assert.match(logs.error[0].message, /26 byte\(s\) are unreadable/);
+		const reports = getCorruptFrameReports();
+		assert.strictEqual(reports.length, 1);
+		assert.deepStrictEqual(
+			{ log: reports[0].log, midLog: reports[0].midLog, unreadableBytes: reports[0].unreadableBytes },
+			{ log: 'local', midLog: true, unreadableBytes: 26 }
+		);
+	});
+
+	it('logs a torn tail at warn level', () => {
+		const { logs, report } = setup();
+		const error = new RangeError('truncated entry header');
+		error.logId = 2;
+		error.position = 100;
+		report(error, true);
+
+		assert.strictEqual(logs.error.length, 0);
+		assert.strictEqual(logs.warn.length, 1);
+		assert.strictEqual(getCorruptFrameReports()[0].midLog, false);
+	});
+
+	// A break that hit the resync cap lost entries just the same. Reporting it as the benign
+	// torn-tail warn would re-hide the condition #2063 exists to surface.
+	it('logs a capped mid-log break as data loss, naming it unreachable', () => {
+		const { logs, report } = setup();
+		report(midLogError(), true);
+
+		assert.strictEqual(logs.warn.length, 0);
+		assert.match(logs.error[0].message, /unreachable until it is repaired/);
+	});
+
+	it('counts repeats of the same break without re-logging it', () => {
+		const { logs, report } = setup();
+		report(midLogError(), false);
+		report(midLogError(), false);
+		report(midLogError(), false);
+
+		assert.strictEqual(logs.error.length, 1);
+		const [only] = getCorruptFrameReports();
+		assert.strictEqual(only.occurrences, 3);
+		assert.ok(only.lastSeen >= only.firstSeen);
+	});
+
+	// The first pass may sit behind 32 other breaks and hit the cap; a later pass, its cursor
+	// further along, resyncs cleanly. The report and the tracked state must follow.
+	it('updates the stopped state on a later encounter of the same break', () => {
+		const { report } = setup();
+		report(midLogError(), true);
+		assert.strictEqual(getCorruptFrameReports()[0].stoppedIteration, true);
+
+		report(midLogError(), false);
+		assert.strictEqual(getCorruptFrameReports()[0].stoppedIteration, false);
+	});
+
+	// Against a rocksdb-js with no logId/position, keying on those fields alone collapses every
+	// break on the stream onto one entry, so the second real corruption is never logged.
+	it('separates breaks by message when the error carries no logId/position', () => {
+		const { logs, report } = setup();
+		report(new RangeError('Corrupt transaction log entry at position 7d20bb of log 2'), true);
+		report(new RangeError('Corrupt transaction log entry at position 3bc071 of log 23'), true);
+
+		assert.strictEqual(getCorruptFrameReports().length, 2);
+		assert.strictEqual(logs.warn.length, 2);
+	});
+
+	it('bounds retained break sites and counts the ones it drops', () => {
+		const { logs, report } = setup();
+		for (let i = 0; i < MAX_CORRUPT_FRAME_REPORTS + 5; i++) {
+			report(midLogError(0x1000 + i * 0x100), false);
+		}
+
+		assert.strictEqual(getCorruptFrameReports().length, MAX_CORRUPT_FRAME_REPORTS);
+		assert.strictEqual(getDroppedCorruptFrameReportCount(), 5);
+		// dropped sites are still logged, so visibility never depends on retention
+		assert.strictEqual(logs.error.length, MAX_CORRUPT_FRAME_REPORTS + 5);
 	});
 });
 

--- a/unitTests/resources/replayLogs.test.js
+++ b/unitTests/resources/replayLogs.test.js
@@ -213,6 +213,48 @@ describe('endIteratorOnCorruptFrame', () => {
 		assert.strictEqual(calls, 2);
 	});
 
+	it('treats a null resync position from the native addon as end-of-log', () => {
+		const error = new RangeError('truncated entry header');
+		error.resyncPosition = null;
+		let calls = 0;
+		const wrapped = endIteratorOnCorruptFrame(
+			{
+				next() {
+					calls++;
+					throw error;
+				},
+			},
+			(reportedError, stopped) => {
+				assert.strictEqual(reportedError, error);
+				assert.strictEqual(stopped, true);
+			}
+		);
+
+		assert.deepStrictEqual(wrapped.next(), { done: true, value: undefined });
+		assert.strictEqual(calls, 1);
+	});
+
+	it('keeps zero as a valid resync position', () => {
+		const error = new RangeError('corrupt frame at offset 0');
+		error.resyncPosition = 0;
+		let calls = 0;
+		const wrapped = endIteratorOnCorruptFrame(
+			{
+				next() {
+					if (calls++ === 0) throw error;
+					return { done: true, value: undefined };
+				},
+			},
+			(reportedError, stopped) => {
+				assert.strictEqual(reportedError, error);
+				assert.strictEqual(stopped, false);
+			}
+		);
+
+		assert.deepStrictEqual(wrapped.next(), { done: true, value: undefined });
+		assert.strictEqual(calls, 2);
+	});
+
 	it('reports the cap-hit break as having stopped iteration, not as a clean resync', () => {
 		// The reporter keys severity off the error's own shape, so a mid-log break that merely hit
 		// the cap must still be distinguishable from a torn tail.
@@ -225,7 +267,7 @@ describe('endIteratorOnCorruptFrame', () => {
 		};
 		const reported = [];
 		const wrapped = endIteratorOnCorruptFrame(source, (error, stopped) =>
-			reported.push({ stopped, midLog: error.resyncPosition !== undefined })
+			reported.push({ stopped, midLog: error.resyncPosition != null })
 		);
 		wrapped.next();
 		assert.deepStrictEqual(reported.at(-1), { stopped: true, midLog: true });
@@ -402,6 +444,34 @@ describe('createCorruptFrameReporter', () => {
 
 		assert.strictEqual(getCorruptFrameReports().length, 2);
 		assert.strictEqual(logs.warn.length, 2);
+	});
+
+	it('treats null native position fields as absent when keying and classifying breaks', () => {
+		const { logs, report } = setup();
+		for (const message of ['corrupt frame at offset 1', 'corrupt frame at offset 2']) {
+			const error = new RangeError(message);
+			error.logId = null;
+			error.position = null;
+			error.resyncPosition = null;
+			report(error, true);
+		}
+
+		assert.strictEqual(getCorruptFrameReports().length, 2);
+		assert.strictEqual(logs.warn.length, 2);
+		assert.strictEqual(logs.error.length, 0);
+	});
+
+	it('keeps zero native position fields as valid report metadata', () => {
+		const { logs, report } = setup();
+		const error = midLogError(0, 0);
+		error.logId = 0;
+		report(error, false);
+
+		assert.strictEqual(logs.error.length, 1);
+		assert.deepStrictEqual(
+			{ logId: getCorruptFrameReports()[0].logId, position: getCorruptFrameReports()[0].position },
+			{ logId: 0, position: 0 }
+		);
 	});
 
 	it('bounds retained break sites by evicting the oldest', () => {

--- a/unitTests/resources/replayLogs.test.js
+++ b/unitTests/resources/replayLogs.test.js
@@ -7,6 +7,7 @@ const {
 	isUndecodableValidatedWrite,
 	RECORD_BEARING_FLAGS,
 	endIteratorOnCorruptFrame,
+	MAX_RESYNCS_PER_ITERATION,
 	shouldAbortStalledReplay,
 	REPLAY_NO_PROGRESS_COUNT_LIMIT,
 	REPLAY_NO_PROGRESS_TIME_LIMIT_MS,
@@ -133,6 +134,80 @@ describe('endIteratorOnCorruptFrame', () => {
 		assert.deepStrictEqual(wrapped.next(), { done: true, value: undefined });
 		assert.strictEqual(calls, 3);
 		assert.strictEqual(reported.length, 1);
+	});
+
+	// harper#2016 / harper#2063: a mid-log break has intact, already-acknowledged entries behind
+	// it. rocksdb-js reports where framing resumes and leaves the reader positioned there, so the
+	// wrapper must keep pulling — treating it as end-of-log amputates every later entry, and every
+	// future drain restarts from the same cursor and stops at the same frame.
+	it('resyncs past a mid-log corrupt frame and keeps yielding the entries after it', () => {
+		let calls = 0;
+		const source = {
+			next() {
+				calls++;
+				if (calls === 1) return { done: false, value: 'a' };
+				if (calls === 2) {
+					const error = new RangeError('declared length 1778384896 overruns the log (limit=5439)');
+					error.resyncPosition = 0x7d3f;
+					error.unreadableBytes = 26;
+					throw error;
+				}
+				if (calls === 3) return { done: false, value: 'b' };
+				return { done: true, value: undefined };
+			},
+		};
+		const reported = [];
+		const wrapped = endIteratorOnCorruptFrame(source, (error, resynced, unreadableBytes) =>
+			reported.push({ error, resynced, unreadableBytes })
+		);
+
+		assert.deepStrictEqual([...wrapped], ['a', 'b']);
+		assert.strictEqual(reported.length, 1);
+		assert.strictEqual(reported[0].resynced, true);
+		assert.strictEqual(reported[0].unreadableBytes, 26);
+	});
+
+	it('stops resyncing once a log exceeds the per-iteration cap', () => {
+		let calls = 0;
+		const source = {
+			next() {
+				calls++;
+				const error = new RangeError('corrupt');
+				error.resyncPosition = calls * 100;
+				error.unreadableBytes = 8;
+				throw error;
+			},
+		};
+		const reported = [];
+		const wrapped = endIteratorOnCorruptFrame(source, (error, resynced) => reported.push(resynced));
+
+		assert.deepStrictEqual(wrapped.next(), { done: true, value: undefined });
+		// the cap is what ends iteration, and the break that hit it is reported as not-resynced
+		assert.strictEqual(calls, MAX_RESYNCS_PER_ITERATION + 1);
+		assert.strictEqual(reported.length, MAX_RESYNCS_PER_ITERATION + 1);
+		assert.strictEqual(reported.at(-1), false);
+		// latched afterwards: no further pulls on the source
+		assert.deepStrictEqual(wrapped.next(), { done: true, value: undefined });
+		assert.strictEqual(calls, MAX_RESYNCS_PER_ITERATION + 1);
+	});
+
+	it('treats a RangeError with no resync position as end-of-log (older rocksdb-js)', () => {
+		let calls = 0;
+		const source = {
+			next() {
+				calls++;
+				if (calls === 1) return { done: false, value: 'a' };
+				throw new RangeError('truncated entry header');
+			},
+		};
+		const reported = [];
+		const wrapped = endIteratorOnCorruptFrame(source, (error, resynced, unreadableBytes) =>
+			reported.push({ resynced, unreadableBytes })
+		);
+
+		assert.deepStrictEqual([...wrapped], ['a']);
+		assert.deepStrictEqual(reported, [{ resynced: false, unreadableBytes: 0 }]);
+		assert.strictEqual(calls, 2);
 	});
 
 	it('does not swallow non-RangeError failures', () => {


### PR DESCRIPTION
Refs [#2063 — Corrupt-log containment in RocksTransactionLogStore.getRange is per-drain, so one bad entry head-of-line-blocks a replication stream forever](https://github.com/HarperFast/harper/issues/2063). Refs [#2016 — Mid-log corrupt transaction-log frame silently truncates replay and replication — acknowledged writes lost](https://github.com/HarperFast/harper/issues/2016).

> **This PR reversed its approach after review.** It previously resynced past a mid-log break to recover the entries behind it. That skips one frame, and replay groups every equal-version entry into one source transaction — so a break inside such a group applied and checkpointed the surviving subset of a transaction that never committed that way at the source. On the owner's decision the policy is now fail-stop/quarantine: stop at the break, and discard the transaction it truncated rather than commit part of it. Boundary-safe recovery is deferred until the engine can resume at a proven transaction boundary.

## The defect

Two, and the second is the reason the first is not fixed by resyncing.

**Iteration ended at a break with no way to tell what was lost.** `endIteratorOnCorruptFrame` treated every framing break as end-of-log and logged one `warn`. That is right for a torn tail. For a mid-log break — a partial `ENOSPC`/`EDQUOT` append the process survived — the entries after it were already acknowledged to clients and are now unreachable, and nothing in the logs said so. #2016 rolled a table back 2.2 days on a crash-recovery replay; #2063 starved a replication stream for 11 days with `cluster_status` reporting `connected: true` throughout.

**Stopping at the break committed half a transaction.** Replay groups equal-version entries into one transaction and commits it at the next version boundary, so when iteration ended partway through a group, the end-of-replay commit made the readable prefix durable. A 60-record insert torn 10 records in landed 10 rows and checkpointed them. Replay's own wall-clock abort already refuses to do this — it fires only at a version boundary, "so aborting never tears a same-version write batch in half" — but a corrupt frame is not a boundary, and this path had no such guard.

## The fix

**Fail-stop.** `endIteratorOnCorruptFrame` latches on the first break whatever shape it has. Everything after it is quarantined: not replayed, not replicated, and reported. `resyncPosition` survives only as the signal that entries were *lost* rather than merely truncated.

**Atomic discard.** A break destroys the framing after the last entry the broken log yielded, so whether the swallowed bytes continued that entry's transaction is exactly what can no longer be read — [unless that entry's own `endTxn` already closed it](https://github.com/HarperFast/harper/pull/2087/changes?w=1#diff-56c43863dc5f281e19328e36b0082523391cfb5373c0bd88a8d3d94bfa1ab46cR276), in which case the break fell after the transaction, not inside it. An open version is recorded in `corruptFrameStop.truncatedVersions` and replay aborts that transaction instead of committing it. It stays in the log for a repaired retry. A log that broke before yielding anything truncates no transaction and discards none.

**Visibility.** Breaks accumulate in a report keyed by (store path, log, file, offset), exposed as `getCorruptFrameReports()`. A mid-log break logs at `error` and names the quarantine; a torn tail stays a `warn`. Severity keys on the break's own shape, never on the outcome of the pass that hit it.

## Why not durable `excludeLogs`, as #2063 proposed

`excludeLogs` is keyed on the log **name** — an entire per-node stream, and `'local'` is this node's own writes, which is what the field incident's corrupt log was. Durably excluding it stops every future entry on that stream from replicating, converting one lost frame into a permanently dead stream, and it recovers nothing: the entries after the break are unreachable either way. (`excludeLogs`/`addLog`/`removeLog` have no production callers today — only `unitTests/resources/auditLog.test.js`.)

## Rebase onto latest `main`

Rebased onto `main` (through the `electedReplayer` branch-claim strict-replay feature and the `localTime`/`recordVersion` audit fields, both added since this branch's last sync) and pushed two independent-review-driven fix rounds on top:

- [`RocksTransactionLogStore.getRange`'s corrupt-frame attribution tracked only the last-yielded entry's version](https://github.com/HarperFast/harper/pull/2087/changes?w=1#diff-56c43863dc5f281e19328e36b0082523391cfb5373c0bd88a8d3d94bfa1ab46cR264), not whether that entry's own `endTxn` had already closed its transaction. A break in a log's first frame, right after a fully-formed transaction, discarded *that* transaction instead of the (empty) one the break actually landed in. Now [tracks `endTxn` alongside the version](https://github.com/HarperFast/harper/pull/2087/changes?w=1#diff-56c43863dc5f281e19328e36b0082523391cfb5373c0bd88a8d3d94bfa1ab46cR406) and only marks a version truncated when its last-seen entry hadn't already closed it.
- `electedReplayer` (the branch-claim strict-replay path `main` added since this branch's last sync) [resolved and published a branch READY on a mid-log break](https://github.com/HarperFast/harper/pull/2087/changes?w=1#diff-7f4cbee5cbce369c4f86b2449b8ceaf082fcb125bee915ed2345edc822416c39R372) as long as nothing else failed — even though entries behind the break were acknowledged and quarantined. The mid-log/torn-tail classification already existed inside the reporter but never left it; it's now [threaded into `CorruptFrameStop.midLogBreak`](https://github.com/HarperFast/harper/pull/2087/changes?w=1#diff-6ae4b4668b36c23dec67075eb443126f39bbace8438246fe24e902d0f98d478cR166) via a shared `isMidLogBreak` helper, and an elected replay now rejects on one; boot replay is unchanged (still logs and continues).
- The attribution bookkeeping above ran unconditionally on `getRange`'s always-on live-subscription/replication path, though only `replayLogs()` reads it. [Gated behind a `trackCorruptTransactions` option](https://github.com/HarperFast/harper/pull/2087/changes?w=1#diff-56c43863dc5f281e19328e36b0082523391cfb5373c0bd88a8d3d94bfa1ab46cR259), on only for the replay range.
- [Replay's own summary log escalated *every* corrupt-frame break](https://github.com/HarperFast/harper/pull/2087/changes?w=1#diff-7f4cbee5cbce369c4f86b2449b8ceaf082fcb125bee915ed2345edc822416c39R372) — including a torn tail, the designed and common shape after any unclean shutdown — to an `error` naming "repair the transaction log or re-clone this node," even though nothing was lost. Now keyed on `midLogBreak` instead of "any break."
- `endIteratorOnCorruptFrame` returned a plain object without `lastVersion`/`lastEndTxn`, so the first per-entry assignment forced a V8 hidden-class transition on every tracked iterator. Now [predeclared once, right after the iterator is built](https://github.com/HarperFast/harper/pull/2087/changes?w=1#diff-56c43863dc5f281e19328e36b0082523391cfb5373c0bd88a8d3d94bfa1ab46cR285).
- A `directCommitSync()` failure on a genuine (non-torn) transaction logged and continued without backing `stagedWrites` out of `writes`, unlike the torn-discard branch a few lines above it — so replay's "Replayed N records" summary could count records that never actually committed. Mirrored the torn branch's accounting for a commit failure too, [at both the interior version-boundary commit](https://github.com/HarperFast/harper/pull/2087/changes?w=1#diff-7f4cbee5cbce369c4f86b2449b8ceaf082fcb125bee915ed2345edc822416c39R232) and the final one.

## Verification

- `unitTests/resources/replayLogs.test.js` + `unitTests/resources/branchDatabase.test.js` — 81 passing, 1 pending: the wrapper's latch on both break shapes, the reporter's severity/dedup/escalation, and (new) a stub-based elected-replay rejection on a mid-log break even when every readable entry replayed cleanly.
- `integrationTests/server/replay-transaction-atomicity.test.ts` — 2 suites / 2 passing: the original 60-record torn-transaction discard, plus (new) a transaction that already closed surviving a break that destroys the *next* transaction's first frame entirely — confirmed this second test fails on the pre-endTxn-fix code (reverted locally, re-ran, restored) so it isn't a vacuous pass.
- `test:unit:resources` full suite — 1891 passing / 23 pending / 0 failing.
- Build, `lint:required`, `prettier --check` on all changed files — clean.
- CI green on the rebase push (`049a6c48a`); the follow-up fix commits (`ef91c8f22`, `fa494561d`, `12e5fe5a0`, `181eac8da`) carry the same verification, re-run after each.

## For the human reviewer

**The approach reversed after your approval, @heskew.** The recovery algorithm you reviewed is gone; what remains of it is the detection and reporting, plus the transaction-atomicity guard that the fail-stop policy made necessary. Worth a fresh look rather than a delta read.

**The transaction adjacent to a break is discarded even when it may have been complete — unless `endTxn` proves otherwise.** The break destroys precisely the evidence of whether an *open* transaction continued, so an intact-but-still-open transaction sitting immediately before an unreadable region is dropped. Post-rebase, this no longer applies to a transaction whose own `endTxn` already closed it (see above) — but the tradeoff is otherwise unchanged: consistency over availability, recoverable only by repairing the log or re-cloning the node.

**A `structures` entry in a discarded transaction still lands.** Structures replay writes through `encoder.rootStore.transactionSync`, outside the grouped transaction, so a torn group can leave the shared-structure dictionary ahead of the records that referenced it. Judged benign — the dictionary is append-only and a superset is harmless — but it is an asymmetry worth knowing about.

**Replay still swallows commit/abort errors** (`logger.error` and continue, in non-elected boot mode). Gemini flagged that a boot which cannot commit should be fatal rather than serving traffic with silent loss. Pre-existing behavior on both sides of this diff, so it is not changed here — `electedReplayer` mode (the branch-claim path) does now reject on a commit/write error, per the strict semantics `main` added.

**Coverage the core repo cannot reach.** A *readable* torn frame — declared length overruns into the neighbour but still fits the file — is yielded as a well-formed entry and fails downstream in msgpackr; framing recovery cannot help and neither can this. Tracked by [harper-pro#669](https://github.com/HarperFast/harper-pro/issues/669). The single-log `getRange` attribution path has no direct test — and post-rebase, with attribution now opt-in via `trackCorruptTransactions`, it's effectively unreachable code today: the only caller that opts in (`replayLogs()`) always takes the aggregate path, so `singleLogIterator` is never set while attribution is on. Harmless while nothing enables both together, but worth knowing before a future single-log replay caller relies on it untested.

**`getCorruptFrameReports()` has no consumer**, and — a rebase-round-2 finding worth flagging alongside it — a break site is currently reported once per worker process lifetime and never repeats even if the same break keeps costing entries on every later drain/reconnect. Wiring the registry into `cluster_status` (harper-pro work, tracked by [harper-pro#667](https://github.com/HarperFast/harper-pro/issues/667)) is the natural point to also revisit that: a node-wide signal needs the repeat, not just the first-ever line. The immediate win today is still the one `error` log line.

**`resyncPosition` — and therefore `midLogBreak` and the whole elected-replay-rejection path — is unproven against the pinned engine on a genuine mid-log shape.** Both integration tests here tear a log's *own last* transaction (nothing follows in the file), and every mid-log-specific assertion (including the new elected-replay-rejection test) uses a synthetic stub. In practice the pinned rocksdb-js reports a non-null `resyncPosition` even for these tail tears (empirically confirmed: both integration runs log at `error` with "Intact entries follow the break"), so the machinery is exercised — but there's no test that deliberately corrupts a *non-final* transaction's frame while a later, distinct transaction stays intact after it in the same file, which is the shape that would most directly prove `resyncPosition` end-to-end and (combined with an elected/branch boot) exercise the rejection path against real corruption rather than a stub. Flagging as a real gap rather than attempting it here — it needs either a purpose-built log-splicing helper or a deeper look at rocksdb-js's resync heuristics to construct reliably, and risks landing a misleading test if the shape isn't right.

**Gemini has twice raised, in two different rounds, that `transaction?.abort()` leaves `transaction` pointing at a detached object that a later iteration reuses.** It doesn't: the very next statement after every abort-or-commit in this block is an unconditional `transaction = new DatabaseTransaction()`, so nothing downstream ever sees the aborted handle. First refuted by this PR's own domain adjudication (round 2); re-raised fresh by round 4's Gemini pass with no memory of that adjudication. Noting the pattern here so it isn't re-litigated a third time.

**A non-`RangeError` from a per-log iterator's `.next()` bypasses corrupt-frame attribution entirely, in the aggregate (multi-log) path.** `endIteratorOnCorruptFrame` only intercepts `RangeError` and re-throws anything else; in the aggregate branch that re-thrown error is caught one level up by `safeNext`, which terminates the log the same way but never calls `onCorruptFrame` — so `breaks`/`truncatedVersions`/`midLogBreak` never update for it. If that log was mid-transaction when it threw, replay has no record that the transaction was truncated and can commit the readable prefix as if it were the whole thing. Raised by Gemini in this round; declined as a fix here — it's pre-existing (from the original PR, unrelated to the rebase or the fixes above) and deliberately scoped: the class-not-message comment on `endIteratorOnCorruptFrame` already documents that only `RangeError` is treated as framing corruption. Whether a non-`RangeError` from the native reader should ALSO now count as "assume corruption, discard the open group" is a real question but a policy call for @heskew, not something to decide unilaterally in a rebase.

**The discard's "stays in the log for a repaired retry" framing assumes the discarded transaction is still reachable on a later boot.** Replay resumes from `startFromLastFlushed`, a log *position*, not a per-transaction marker; if the first routine flush after a discard-then-boot advances that watermark past the discarded region, "repair the log and restart" would no longer recover it. Flagged by this round's domain adjudication as worth verifying against rocksdb-js's actual watermark-advance rule; not changed here since it's a claim about pre-existing (pre-rebase) recovery guidance, not new behavior.

**Two open PRs assume the old approach.** [harper-pro#670](https://github.com/HarperFast/harper-pro/pull/670) proves mid-log *recovery* end-to-end and [rocksdb-js#750](https://github.com/HarperFast/rocksdb-js/pull/750) is the engine half that reports `resyncPosition`. #750 is still wanted — it is what makes a mid-log break distinguishable from a torn tail — but #670's premise no longer holds and needs re-scoping to the quarantine semantics.

**The tear is still being created.** rocksdb-js#748: a failed append orphans its partial bytes and `O_APPEND` writes the next entry past them. Recovery is not prevention, and neither is quarantine.

**Comment-narration nits, declined.** Three separate rebase-review rounds (codex twice, gemini twice, one domain adjudication) have now aggregated the same class of finding: several added/pre-existing comments "narrate adjacent code." Read each flagged spot individually all three times; the large majority explain a non-obvious WHY (an invariant, a timing constraint, a dedup guarantee) rather than restate the line below them, which is this repo's own bar for keeping a comment. Trimmed the one genuine restatement found (`RocksTransactionLogStore.ts`, over `singleLogIterator`'s declaration). Not reopening this one again — repeated re-litigation of the same nit across rounds is the "no new actionable findings" signal to stop, not to keep asking.

Cross-model review (pre-rebase): 4 rounds, cursor-composer + gemini + codex — see prior PR history. Post-rebase: 5 more rounds addressing the rebase itself and each round's own findings (codex full → codex+gemini+cursor-grok+domain → codex+gemini delta ×3); every actionable finding above is either fixed or explicitly disclosed with reasoning, not silently dropped.

Generated with Claude Opus 5 and Claude Sonnet 5 (rebase + review-driven fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=9 @ 181eac8da8d2</sub>

<sub>Human-Review-Need: 4 @ 181eac8da8d2</sub>
