### PR TITLE
fix(server): SSE serializer must distinguish absent data/id/retry from falsy

### DIFF
--- a/integrationTests/server/qa702-sse-event-data.test.ts
+++ b/integrationTests/server/qa702-sse-event-data.test.ts
@@ -393,8 +393,11 @@ suite(
 			ok(!r.aborted && r.ended && r.status >= 200 && r.status < 300, `expected a clean SSE response. raw:\n${r.raw}`);
 			const blocks = parseSseBlocks(r.raw);
 			ok(blocks.length >= 1, `expected at least one SSE block. raw:\n${r.raw}`);
-			strictEqual(blocks[0].data, '0', `expected the top-level data value, got: ${JSON.stringify(blocks[0])}`);
-			strictEqual('name' in blocks[0], false, `expected no literal sibling fields, got: ${JSON.stringify(blocks[0])}`);
+			deepStrictEqual(
+				blocks[0],
+				{ data: '0' },
+				`expected only the top-level data value, got: ${JSON.stringify(blocks[0])}`
+			);
 		});
 
 		test('a: plain object with an "id" key (no data/event) -- must be JSON-wrapped, not misread as an SSE id', async () => {

--- a/integrationTests/server/qa702-sse-event-data.test.ts
+++ b/integrationTests/server/qa702-sse-event-data.test.ts
@@ -172,8 +172,7 @@ function consumeSse(urlStr: string, authHeaders: Record<string, string>, timeout
 }
 
 // Groups raw SSE bytes into blank-line-delimited { event, data } records (mirrors the
-// unitTests/server/serverHelpers/progressEmitter.test.js parseSSEBlocks helper). Assumes no
-// record's `data` value contains an embedded newline (true for every case in this suite).
+// unitTests/server/serverHelpers/progressEmitter.test.js parseSSEBlocks helper).
 function parseSseBlocks(raw: string): Array<Record<string, string>> {
 	return raw
 		.split('\n\n')
@@ -186,7 +185,8 @@ function parseSseBlocks(raw: string): Array<Record<string, string>> {
 				const field = line.slice(0, colon);
 				let value = line.slice(colon + 1);
 				if (value.startsWith(' ')) value = value.slice(1);
-				out[field] = value;
+				if (field === 'data' && field in out) out.data += '\n' + value;
+				else out[field] = value;
 			}
 			return out;
 		})
@@ -280,6 +280,12 @@ suite(
 			{ name: 'empty string', path: 'EmptyStringPayload', hasData: true, expectedData: '' },
 			{ name: '0', path: 'ZeroPayload', hasData: true, expectedData: '0' },
 			{ name: 'false', path: 'FalsePayload', hasData: true, expectedData: 'false' },
+			{
+				name: 'multiline string',
+				path: 'MultilineStringPayload',
+				hasData: true,
+				expectedData: 'first line\nsecond line',
+			},
 			{
 				name: 'plain object (no "data" key)',
 				path: 'PlainObjectPayload',

--- a/integrationTests/server/qa702-sse-event-data.test.ts
+++ b/integrationTests/server/qa702-sse-event-data.test.ts
@@ -23,16 +23,14 @@
  *
  *     So instead, this suite covers the SIBLING encoder any Harper Resource client actually sees:
  *     contentTypes.ts's `text/event-stream` media-type `serialize()`, invoked via
- *     `resource.connect()`. It has a DIFFERENT, pre-existing falsy-data guard
- *     (`if (message.data) { ...emit data: line... }`) that silently OMITS the `data:` field
+ *     `resource.connect()`. It previously had a DIFFERENT, pre-existing falsy-data guard
+ *     (`if (message.data) { ...emit data: line... }`) that silently OMITTED the `data:` field
  *     entirely for any falsy value (undefined/null/''/0/false) rather than crashing OR emitting
- *     an explicit empty/`null` line the way the fixed writeSSE() does — a KNOWN DEFECT on this code
- *     path (harper#2026: `EventSource` never dispatches a frame with an empty data buffer, so a
- *     legitimate falsy payload like `data: false` is silently never seen by the client), not a
- *     #1863 regression check and not an intended contract. Pinned deliberately so the fix in
- *     harper#2026 shows up here as an expected assertion update, not a surprise regression. Flagged
- *     rather than fixed in THIS PR since changing the encoder is a production-code, cross-encoder
- *     decision (see above), not a test fix. See
+ *     an explicit empty/`null` line the way the fixed writeSSE() does — that was harper#2026
+ *     (`EventSource` never dispatches a frame with an empty data buffer, so a legitimate falsy
+ *     payload like `data: false` was silently never seen by the client). #2026 fixed the guard to
+ *     `message.data != null` (and `message.id != null`), so only undefined/null now omit their
+ *     field; this suite's assertions were updated alongside the fix. See
  *     integrationTests/qa-scratch/qa702-sse-event-data/resources.js for the full writeup.
  *
  * (b) F-133 re-characterization: does a resource.connect() async generator that throws mid-stream
@@ -277,18 +275,18 @@ suite(
 		//        itself (unreachable from here -- see file header for why, and for the actual #1863
 		//        anchor at unitTests/server/serverHelpers/progressEmitter.test.js) ────────────────────
 		//
-		// `hasData: false` cases exercise this encoder's OWN (pre-existing, different) falsy guard
-		// -- `if (message.data) {...}` -- which OMITS the `data:` field entirely for a falsy value,
-		// rather than crashing (the #1863 bug, on the other encoder) or emitting an explicit
-		// empty/`null` line (writeSSE()'s fixed behavior). That's the actual, current wire contract
-		// on THIS encoder; asserted here, not assumed.
+		// harper#2026 fix: the guard is now `message.data != null`, so only `undefined`/`null`
+		// omit the `data:` field entirely -- `''`/`0`/`false` are legitimate values and now emit
+		// their (string-coerced) `data:` line, matching the HTML EventSource spec (an empty data
+		// buffer is the only thing that gets silently discarded by a client, and now only
+		// undefined/null produce one).
 
 		const cases: Array<{ name: string; path: string; hasData: boolean; expectedData?: string }> = [
 			{ name: 'undefined', path: 'UndefinedPayload', hasData: false },
 			{ name: 'null', path: 'NullPayload', hasData: false },
-			{ name: 'empty string', path: 'EmptyStringPayload', hasData: false },
-			{ name: '0', path: 'ZeroPayload', hasData: false },
-			{ name: 'false', path: 'FalsePayload', hasData: false },
+			{ name: 'empty string', path: 'EmptyStringPayload', hasData: true, expectedData: '' },
+			{ name: '0', path: 'ZeroPayload', hasData: true, expectedData: '0' },
+			{ name: 'false', path: 'FalsePayload', hasData: true, expectedData: 'false' },
 			{
 				name: 'plain object (no "data" key)',
 				path: 'PlainObjectPayload',
@@ -345,7 +343,7 @@ suite(
 						strictEqual(
 							'data' in payloadBlock!,
 							false,
-							`expected NO data: field for falsy value ${c.name} -- pinning a KNOWN DEFECT (harper#2026: EventSource never dispatches an empty-data frame, so a client silently never sees a legitimate falsy payload), not an intended contract; got: ${JSON.stringify(payloadBlock)}`
+							`expected NO data: field for ${c.name} -- absence (undefined/null), not falsiness, is what omits the data: line; got: ${JSON.stringify(payloadBlock)}`
 						);
 					}
 
@@ -368,20 +366,15 @@ suite(
 			);
 		}
 
-		// harper#2026 has an `id: 0` half too (contentTypes.ts:152's `if (message.id)` drops the
-		// reconnect cursor `id: 0` by the identical mechanism), otherwise unpinned by the `hasData`
-		// matrix above -- pin it explicitly so #2026's eventual fix updates this assertion too.
-		test('a: event.id = 0 (with real data) -- id: 0 silently omitted, KNOWN DEFECT harper#2026', async () => {
+		// harper#2026 fix: `id: 0` is a legitimate reconnect cursor and must now be emitted
+		// (contentTypes.ts's guard is `message.id != null`, not truthiness).
+		test('a: event.id = 0 (with real data) -- id: 0 is emitted (harper#2026 fixed)', async () => {
 			const r = await consumeSse(`${restBase}/IdZeroPayload/`, authHeaders, 15_000);
 			ok(!r.aborted && r.ended && r.status >= 200 && r.status < 300, `expected a clean SSE response. raw:\n${r.raw}`);
 			const payloadBlock = parseSseBlocks(r.raw).find((b) => b.event === 'payload');
 			ok(payloadBlock, `expected a 'payload' event block. raw:\n${r.raw}`);
 			strictEqual(payloadBlock!.data, 'id-zero-probe', 'data field should be unaffected by the id value');
-			strictEqual(
-				'id' in payloadBlock!,
-				false,
-				`expected NO id: field for id=0 -- pinning KNOWN DEFECT harper#2026, not an intended contract; got: ${JSON.stringify(payloadBlock)}`
-			);
+			strictEqual(payloadBlock!.id, '0', `expected id: 0 to be emitted; got: ${JSON.stringify(payloadBlock)}`);
 		});
 
 		// ── (b) F-133 re-characterization: generator throws mid-stream ─────────────────────────

--- a/integrationTests/server/qa702-sse-event-data.test.ts
+++ b/integrationTests/server/qa702-sse-event-data.test.ts
@@ -23,15 +23,9 @@
  *
  *     So instead, this suite covers the SIBLING encoder any Harper Resource client actually sees:
  *     contentTypes.ts's `text/event-stream` media-type `serialize()`, invoked via
- *     `resource.connect()`. It previously had a DIFFERENT, pre-existing falsy-data guard
- *     (`if (message.data) { ...emit data: line... }`) that silently OMITTED the `data:` field
- *     entirely for any falsy value (undefined/null/''/0/false) rather than crashing OR emitting
- *     an explicit empty/`null` line the way the fixed writeSSE() does — that was harper#2026
- *     (`EventSource` never dispatches a frame with an empty data buffer, so a legitimate falsy
- *     payload like `data: false` was silently never seen by the client). #2026 fixed the guard to
- *     `message.data != null` (and `message.id != null`), so only undefined/null now omit their
- *     field; this suite's assertions were updated alongside the fix. See
- *     integrationTests/qa-scratch/qa702-sse-event-data/resources.js for the full writeup.
+ *     `resource.connect()`. Its falsy-data/id guards are asserted here against absence
+ *     (undefined/null), not truthiness — see integrationTests/qa-scratch/qa702-sse-event-data/
+ *     resources.js for the full writeup.
  *
  * (b) F-133 re-characterization: does a resource.connect() async generator that throws mid-stream
  *     still hang the response? Git archaeology first: commits 06f5fcff8/8930b1ef2 ("Fix SSE hang +
@@ -275,11 +269,10 @@ suite(
 		//        itself (unreachable from here -- see file header for why, and for the actual #1863
 		//        anchor at unitTests/server/serverHelpers/progressEmitter.test.js) ────────────────────
 		//
-		// harper#2026 fix: the guard is now `message.data != null`, so only `undefined`/`null`
-		// omit the `data:` field entirely -- `''`/`0`/`false` are legitimate values and now emit
-		// their (string-coerced) `data:` line, matching the HTML EventSource spec (an empty data
-		// buffer is the only thing that gets silently discarded by a client, and now only
-		// undefined/null produce one).
+		// Only undefined/null omit the `data:` field entirely; `''`/`0`/`false` now emit their
+		// (string-coerced) line. Note `''` still won't dispatch on a real EventSource client --
+		// the HTML spec discards an empty data buffer regardless of whether the field was present
+		// or omitted -- but the wire byte-for-byte representation is what's asserted here.
 
 		const cases: Array<{ name: string; path: string; hasData: boolean; expectedData?: string }> = [
 			{ name: 'undefined', path: 'UndefinedPayload', hasData: false },
@@ -366,15 +359,29 @@ suite(
 			);
 		}
 
-		// harper#2026 fix: `id: 0` is a legitimate reconnect cursor and must now be emitted
-		// (contentTypes.ts's guard is `message.id != null`, not truthiness).
-		test('a: event.id = 0 (with real data) -- id: 0 is emitted (harper#2026 fixed)', async () => {
+		// `id: 0` is a legitimate reconnect cursor and must be emitted, not treated as absent.
+		test('a: event.id = 0 (with real data) -- id: 0 is emitted', async () => {
 			const r = await consumeSse(`${restBase}/IdZeroPayload/`, authHeaders, 15_000);
 			ok(!r.aborted && r.ended && r.status >= 200 && r.status < 300, `expected a clean SSE response. raw:\n${r.raw}`);
 			const payloadBlock = parseSseBlocks(r.raw).find((b) => b.event === 'payload');
 			ok(payloadBlock, `expected a 'payload' event block. raw:\n${r.raw}`);
 			strictEqual(payloadBlock!.data, 'id-zero-probe', 'data field should be unaffected by the id value');
 			strictEqual(payloadBlock!.id, '0', `expected id: 0 to be emitted; got: ${JSON.stringify(payloadBlock)}`);
+		});
+
+		// The falsy-data cases above all set `event: 'payload'`, which alone satisfies the outer
+		// envelope-detection gate regardless of `data`. This covers a message with no `event` key
+		// at all, so a falsy `data` is the only thing deciding whether the gate is entered.
+		test('a: event-less message with data = 0 -- envelope gate must not treat this as absent', async () => {
+			const r = await consumeSse(`${restBase}/ZeroPayloadNoEvent/`, authHeaders, 15_000);
+			ok(!r.aborted && r.ended && r.status >= 200 && r.status < 300, `expected a clean SSE response. raw:\n${r.raw}`);
+			const blocks = parseSseBlocks(r.raw);
+			ok(blocks.length >= 1, `expected at least one SSE block. raw:\n${r.raw}`);
+			strictEqual(
+				blocks[0].data,
+				'0',
+				`expected a bare "data: 0" line, not the whole message JSON-wrapped; got: ${JSON.stringify(blocks[0])}`
+			);
 		});
 
 		// ── (b) F-133 re-characterization: generator throws mid-stream ─────────────────────────

--- a/integrationTests/server/qa702-sse-event-data.test.ts
+++ b/integrationTests/server/qa702-sse-event-data.test.ts
@@ -359,7 +359,6 @@ suite(
 			);
 		}
 
-		// `id: 0` is a legitimate reconnect cursor and must be emitted, not treated as absent.
 		test('a: event.id = 0 (with real data) -- id: 0 is emitted', async () => {
 			const r = await consumeSse(`${restBase}/IdZeroPayload/`, authHeaders, 15_000);
 			ok(!r.aborted && r.ended && r.status >= 200 && r.status < 300, `expected a clean SSE response. raw:\n${r.raw}`);
@@ -369,9 +368,14 @@ suite(
 			strictEqual(payloadBlock!.id, '0', `expected id: 0 to be emitted; got: ${JSON.stringify(payloadBlock)}`);
 		});
 
-		// The falsy-data cases above all set `event: 'payload'`, which alone satisfies the outer
-		// envelope-detection gate regardless of `data`. This covers a message with no `event` key
-		// at all, so a falsy `data` is the only thing deciding whether the gate is entered.
+		test('a: event.retry = 0 (with real data) -- retry: 0 is emitted', async () => {
+			const r = await consumeSse(`${restBase}/RetryZeroPayload/`, authHeaders, 15_000);
+			ok(!r.aborted && r.ended && r.status >= 200 && r.status < 300, `expected a clean SSE response. raw:\n${r.raw}`);
+			const payloadBlock = parseSseBlocks(r.raw).find((b) => b.event === 'payload');
+			ok(payloadBlock, `expected a 'payload' event block. raw:\n${r.raw}`);
+			strictEqual(payloadBlock!.retry, '0', `expected retry: 0 to be emitted; got: ${JSON.stringify(payloadBlock)}`);
+		});
+
 		test('a: event-less message with data = 0 -- envelope gate must not treat this as absent', async () => {
 			const r = await consumeSse(`${restBase}/ZeroPayloadNoEvent/`, authHeaders, 15_000);
 			ok(!r.aborted && r.ended && r.status >= 200 && r.status < 300, `expected a clean SSE response. raw:\n${r.raw}`);
@@ -384,11 +388,6 @@ suite(
 			);
 		});
 
-		// `id`/`retry` are deliberately NOT envelope-detection signals: widening the gate to them
-		// was tried in review and reverted, because a plain data object with a real `id` field
-		// (extremely common) would otherwise have that field peeled into an `id:` line while the
-		// rest of the object is silently dropped. A plain object containing an `id` key must still
-		// be JSON-wrapped wholesale, like any other plain object with no `data`/`event` key.
 		test('a: plain object with an "id" key (no data/event) -- must be JSON-wrapped, not misread as an SSE id', async () => {
 			const r = await consumeSse(`${restBase}/IdKeyPlainObjectPayload/`, authHeaders, 15_000);
 			ok(!r.aborted && r.ended && r.status >= 200 && r.status < 300, `expected a clean SSE response. raw:\n${r.raw}`);

--- a/integrationTests/server/qa702-sse-event-data.test.ts
+++ b/integrationTests/server/qa702-sse-event-data.test.ts
@@ -388,6 +388,15 @@ suite(
 			);
 		});
 
+		test('a: top-level data key with siblings -- data envelope takes precedence', async () => {
+			const r = await consumeSse(`${restBase}/DataKeyEnvelopePayload/`, authHeaders, 15_000);
+			ok(!r.aborted && r.ended && r.status >= 200 && r.status < 300, `expected a clean SSE response. raw:\n${r.raw}`);
+			const blocks = parseSseBlocks(r.raw);
+			ok(blocks.length >= 1, `expected at least one SSE block. raw:\n${r.raw}`);
+			strictEqual(blocks[0].data, '0', `expected the top-level data value, got: ${JSON.stringify(blocks[0])}`);
+			strictEqual('name' in blocks[0], false, `expected no literal sibling fields, got: ${JSON.stringify(blocks[0])}`);
+		});
+
 		test('a: plain object with an "id" key (no data/event) -- must be JSON-wrapped, not misread as an SSE id', async () => {
 			const r = await consumeSse(`${restBase}/IdKeyPlainObjectPayload/`, authHeaders, 15_000);
 			ok(!r.aborted && r.ended && r.status >= 200 && r.status < 300, `expected a clean SSE response. raw:\n${r.raw}`);

--- a/integrationTests/server/qa702-sse-event-data.test.ts
+++ b/integrationTests/server/qa702-sse-event-data.test.ts
@@ -190,7 +190,7 @@ function parseSseBlocks(raw: string): Array<Record<string, string>> {
 			}
 			return out;
 		})
-		.filter((rec) => 'event' in rec || 'data' in rec);
+		.filter((rec) => 'event' in rec || 'data' in rec || 'id' in rec || 'retry' in rec);
 }
 
 function readLogSafe(logPath: string): string {
@@ -381,6 +381,21 @@ suite(
 				blocks[0].data,
 				'0',
 				`expected a bare "data: 0" line, not the whole message JSON-wrapped; got: ${JSON.stringify(blocks[0])}`
+			);
+		});
+
+		// A standalone `id` (no data/event/retry) must also open the envelope gate, not fall to
+		// the else branch and get JSON-wrapped as a bogus data frame.
+		test('a: standalone id (no data/event) -- envelope gate must not treat this as absent', async () => {
+			const r = await consumeSse(`${restBase}/StandaloneIdPayload/`, authHeaders, 15_000);
+			ok(!r.aborted && r.ended && r.status >= 200 && r.status < 300, `expected a clean SSE response. raw:\n${r.raw}`);
+			const blocks = parseSseBlocks(r.raw);
+			ok(blocks.length >= 1, `expected at least one SSE block. raw:\n${r.raw}`);
+			strictEqual('data' in blocks[0], false, `expected no data: line; got: ${JSON.stringify(blocks[0])}`);
+			strictEqual(
+				blocks[0].id,
+				'42',
+				`expected a bare "id: 42" line, not the whole message JSON-wrapped; got: ${JSON.stringify(blocks[0])}`
 			);
 		});
 

--- a/integrationTests/server/qa702-sse-event-data.test.ts
+++ b/integrationTests/server/qa702-sse-event-data.test.ts
@@ -384,18 +384,20 @@ suite(
 			);
 		});
 
-		// A standalone `id` (no data/event/retry) must also open the envelope gate, not fall to
-		// the else branch and get JSON-wrapped as a bogus data frame.
-		test('a: standalone id (no data/event) -- envelope gate must not treat this as absent', async () => {
-			const r = await consumeSse(`${restBase}/StandaloneIdPayload/`, authHeaders, 15_000);
+		// `id`/`retry` are deliberately NOT envelope-detection signals: widening the gate to them
+		// was tried in review and reverted, because a plain data object with a real `id` field
+		// (extremely common) would otherwise have that field peeled into an `id:` line while the
+		// rest of the object is silently dropped. A plain object containing an `id` key must still
+		// be JSON-wrapped wholesale, like any other plain object with no `data`/`event` key.
+		test('a: plain object with an "id" key (no data/event) -- must be JSON-wrapped, not misread as an SSE id', async () => {
+			const r = await consumeSse(`${restBase}/IdKeyPlainObjectPayload/`, authHeaders, 15_000);
 			ok(!r.aborted && r.ended && r.status >= 200 && r.status < 300, `expected a clean SSE response. raw:\n${r.raw}`);
 			const blocks = parseSseBlocks(r.raw);
 			ok(blocks.length >= 1, `expected at least one SSE block. raw:\n${r.raw}`);
-			strictEqual('data' in blocks[0], false, `expected no data: line; got: ${JSON.stringify(blocks[0])}`);
 			strictEqual(
-				blocks[0].id,
-				'42',
-				`expected a bare "id: 42" line, not the whole message JSON-wrapped; got: ${JSON.stringify(blocks[0])}`
+				blocks[0].data,
+				JSON.stringify({ id: 42, name: 'Alice' }),
+				`expected the whole object JSON-wrapped, not "name" dropped; got: ${JSON.stringify(blocks[0])}`
 			);
 		});
 

--- a/integrationTests/server/qa702-sse-event-data/resources.js
+++ b/integrationTests/server/qa702-sse-event-data/resources.js
@@ -24,12 +24,11 @@
 //     Resource over `Accept: text/event-stream`: contentTypes.ts's `text/event-stream` media type
 //     `serialize()`, invoked via `resource.connect()`. It's the client-visible "neighbour" of the
 //     guarded path — same conceptual contract (turning a `{event, data}` message into SSE wire
-//     bytes) — and, as this suite documents, has a DIFFERENT (already-defensive, pre-existing)
-//     falsy-data guard: `if (message.data) { ...emit a data: line... }` silently OMITS the `data:`
-//     field entirely for any falsy `data` (undefined/null/''/0/false), rather than crashing OR
-//     emitting an explicit empty/`null` line the way the fixed writeSSE() does. That's a KNOWN
-//     DEFECT tracked as harper#2026 (which also covers the identical `id: 0` omission below), not
-//     a crash and not an intended contract — see the test file for the assertions this fixture backs.
+//     bytes) — and previously had a DIFFERENT (already-defensive, pre-existing) falsy-data guard:
+//     `if (message.data) { ...emit a data: line... }` silently omitted the `data:` field entirely
+//     for any falsy `data` (undefined/null/''/0/false). That was harper#2026 (which also covered
+//     the identical `id: 0` omission below); the guard is now `!= null` so only undefined/null
+//     omit their field — see the test file for the assertions this fixture backs.
 //
 // (b) Re-characterization of F-133 ("SSE hang on generator that throws mid-stream") on current
 //     main: ThrowGen below is the same shape QA-537 used to document the (at the time) still-open

--- a/integrationTests/server/qa702-sse-event-data/resources.js
+++ b/integrationTests/server/qa702-sse-event-data/resources.js
@@ -82,6 +82,14 @@ export class IdZeroPayload extends Resource {
 	}
 }
 
+// GET /RetryZeroPayload/ — a real `data` value paired with `retry: 0`.
+export class RetryZeroPayload extends Resource {
+	static loadAsInstance = false;
+	static async *connect() {
+		yield { event: 'payload', data: 'retry-zero-probe', retry: 0 };
+	}
+}
+
 // GET /ZeroPayloadNoEvent/ — falsy `data` with no `event` key at all. Exercises the outer
 // envelope-detection gate, distinct from the `hasData` matrix above which always sets
 // `event: 'payload'` and so never reaches this gate via `data` alone.
@@ -92,11 +100,9 @@ export class ZeroPayloadNoEvent extends Resource {
 	}
 }
 
-// GET /IdKeyPlainObjectPayload/ — a plain data object that happens to have a top-level `id`
-// key (e.g. a real database record), with no `data`/`event` key. `id`/`retry` are deliberately
-// NOT envelope-detection signals (contentTypes.ts) -- `id` is too common a literal-payload field
-// name for that -- so this must be JSON-wrapped wholesale like any other plain object, not have
-// its `id` peeled off into an `id:` line while the rest of the object is silently dropped.
+// GET /IdKeyPlainObjectPayload/ — a plain data object with a top-level `id` key (e.g. a real
+// database record) and no `data`/`event` key; must be JSON-wrapped wholesale, not misread as an
+// SSE id.
 export class IdKeyPlainObjectPayload extends Resource {
 	static loadAsInstance = false;
 	static async *connect() {

--- a/integrationTests/server/qa702-sse-event-data/resources.js
+++ b/integrationTests/server/qa702-sse-event-data/resources.js
@@ -24,11 +24,7 @@
 //     Resource over `Accept: text/event-stream`: contentTypes.ts's `text/event-stream` media type
 //     `serialize()`, invoked via `resource.connect()`. It's the client-visible "neighbour" of the
 //     guarded path — same conceptual contract (turning a `{event, data}` message into SSE wire
-//     bytes) — and previously had a DIFFERENT (already-defensive, pre-existing) falsy-data guard:
-//     `if (message.data) { ...emit a data: line... }` silently omitted the `data:` field entirely
-//     for any falsy `data` (undefined/null/''/0/false). That was harper#2026 (which also covered
-//     the identical `id: 0` omission below); the guard is now `!= null` so only undefined/null
-//     omit their field — see the test file for the assertions this fixture backs.
+//     bytes) — see the test file for the assertions this fixture backs.
 //
 // (b) Re-characterization of F-133 ("SSE hang on generator that throws mid-stream") on current
 //     main: ThrowGen below is the same shape QA-537 used to document the (at the time) still-open
@@ -78,13 +74,22 @@ export class ZeroPayload extends ssePayloadResource(0) {}
 // GET /FalsePayload/ — data: false.
 export class FalsePayload extends ssePayloadResource(false) {}
 
-// GET /IdZeroPayload/ — a real `data` value paired with `id: 0`. Same falsy-guard mechanism
-// (`if (message.id) {...}`, contentTypes.ts) drops the reconnect cursor `id: 0` exactly like it
-// drops falsy `data` above -- the other half of harper#2026, otherwise unpinned by this suite.
+// GET /IdZeroPayload/ — a real `data` value paired with `id: 0`, a legitimate reconnect cursor.
 export class IdZeroPayload extends Resource {
 	static loadAsInstance = false;
 	static async *connect() {
 		yield { event: 'payload', data: 'id-zero-probe', id: 0 };
+	}
+}
+
+// GET /ZeroPayloadNoEvent/ — falsy `data` with no `event` key at all. Exercises the outer
+// envelope-detection gate (contentTypes.ts's `if (message.data != null || message.event)`),
+// distinct from the `hasData` matrix above which always sets `event: 'payload'` and so never
+// reaches this gate.
+export class ZeroPayloadNoEvent extends Resource {
+	static loadAsInstance = false;
+	static async *connect() {
+		yield { data: 0 };
 	}
 }
 

--- a/integrationTests/server/qa702-sse-event-data/resources.js
+++ b/integrationTests/server/qa702-sse-event-data/resources.js
@@ -100,6 +100,15 @@ export class ZeroPayloadNoEvent extends Resource {
 	}
 }
 
+// GET /DataKeyEnvelopePayload/ — a top-level data key always selects the SSE-envelope contract,
+// so unrelated siblings are not serialized as literal payload fields.
+export class DataKeyEnvelopePayload extends Resource {
+	static loadAsInstance = false;
+	static async *connect() {
+		yield { data: 0, name: 'x' };
+	}
+}
+
 // GET /IdKeyPlainObjectPayload/ — a plain data object with a top-level `id` key (e.g. a real
 // database record) and no `data`/`event` key; must be JSON-wrapped wholesale, not misread as an
 // SSE id.

--- a/integrationTests/server/qa702-sse-event-data/resources.js
+++ b/integrationTests/server/qa702-sse-event-data/resources.js
@@ -74,6 +74,8 @@ export class ZeroPayload extends ssePayloadResource(0) {}
 // GET /FalsePayload/ — data: false.
 export class FalsePayload extends ssePayloadResource(false) {}
 
+export class MultilineStringPayload extends ssePayloadResource('first line\nsecond line') {}
+
 // GET /IdZeroPayload/ — a real `data` value paired with `id: 0`, a legitimate reconnect cursor.
 export class IdZeroPayload extends Resource {
 	static loadAsInstance = false;

--- a/integrationTests/server/qa702-sse-event-data/resources.js
+++ b/integrationTests/server/qa702-sse-event-data/resources.js
@@ -82,14 +82,22 @@ export class IdZeroPayload extends Resource {
 	}
 }
 
-// GET /ZeroPayloadNoEvent/ — falsy `data` with no `event` key at all. Exercises the outer
-// envelope-detection gate (contentTypes.ts's `if (message.data != null || message.event)`),
-// distinct from the `hasData` matrix above which always sets `event: 'payload'` and so never
-// reaches this gate.
+// GET /ZeroPayloadNoEvent/ — falsy `data` with no `event`/`id`/`retry` key at all. Exercises
+// the outer envelope-detection gate, distinct from the `hasData` matrix above which always sets
+// `event: 'payload'` and so never reaches this gate.
 export class ZeroPayloadNoEvent extends Resource {
 	static loadAsInstance = false;
 	static async *connect() {
 		yield { data: 0 };
+	}
+}
+
+// GET /StandaloneIdPayload/ — an `id` with no `data`/`event`/`retry` key at all: the envelope
+// gate's `id`-only path.
+export class StandaloneIdPayload extends Resource {
+	static loadAsInstance = false;
+	static async *connect() {
+		yield { id: 42 };
 	}
 }
 

--- a/integrationTests/server/qa702-sse-event-data/resources.js
+++ b/integrationTests/server/qa702-sse-event-data/resources.js
@@ -82,9 +82,9 @@ export class IdZeroPayload extends Resource {
 	}
 }
 
-// GET /ZeroPayloadNoEvent/ — falsy `data` with no `event`/`id`/`retry` key at all. Exercises
-// the outer envelope-detection gate, distinct from the `hasData` matrix above which always sets
-// `event: 'payload'` and so never reaches this gate.
+// GET /ZeroPayloadNoEvent/ — falsy `data` with no `event` key at all. Exercises the outer
+// envelope-detection gate, distinct from the `hasData` matrix above which always sets
+// `event: 'payload'` and so never reaches this gate via `data` alone.
 export class ZeroPayloadNoEvent extends Resource {
 	static loadAsInstance = false;
 	static async *connect() {
@@ -92,12 +92,15 @@ export class ZeroPayloadNoEvent extends Resource {
 	}
 }
 
-// GET /StandaloneIdPayload/ — an `id` with no `data`/`event`/`retry` key at all: the envelope
-// gate's `id`-only path.
-export class StandaloneIdPayload extends Resource {
+// GET /IdKeyPlainObjectPayload/ — a plain data object that happens to have a top-level `id`
+// key (e.g. a real database record), with no `data`/`event` key. `id`/`retry` are deliberately
+// NOT envelope-detection signals (contentTypes.ts) -- `id` is too common a literal-payload field
+// name for that -- so this must be JSON-wrapped wholesale like any other plain object, not have
+// its `id` peeled off into an `id:` line while the rest of the object is silently dropped.
+export class IdKeyPlainObjectPayload extends Resource {
 	static loadAsInstance = false;
 	static async *connect() {
-		yield { id: 42 };
+		yield { id: 42, name: 'Alice' };
 	}
 }
 

--- a/server/serverHelpers/contentTypes.ts
+++ b/server/serverHelpers/contentTypes.ts
@@ -141,7 +141,7 @@ mediaTypes.set('text/event-stream', {
 				id: message.timestamp,
 			};
 		}
-		if (message.data != null || message.event) {
+		if (message.data != null || message.event || message.id != null || message.retry != null) {
 			let serialized = '';
 			if (message.event) serialized += 'event: ' + message.event + '\n';
 			if (message.data != null) {
@@ -150,7 +150,7 @@ mediaTypes.set('text/event-stream', {
 				serialized += 'data: ' + data + '\n';
 			}
 			if (message.id != null) serialized += 'id: ' + message.id + '\n';
-			if (message.retry) serialized += 'retry: ' + message.retry + '\n';
+			if (message.retry != null) serialized += 'retry: ' + message.retry + '\n';
 			return serialized + '\n';
 		} else {
 			if (typeof message === 'object') return `data: ${JSONStringify(message)}\n\n`;

--- a/server/serverHelpers/contentTypes.ts
+++ b/server/serverHelpers/contentTypes.ts
@@ -141,7 +141,13 @@ mediaTypes.set('text/event-stream', {
 				id: message.timestamp,
 			};
 		}
-		if (message.data != null || message.event || message.id != null || message.retry != null) {
+		// Only `data`/`event` open the envelope path -- NOT `id`/`retry`. `id` in particular is an
+		// extremely common literal-payload field name (e.g. a database record), so treating a bare
+		// `id`/`retry` key as an SSE-envelope signal would misclassify plain data objects that
+		// happen to carry one, silently dropping every other field. A standalone id-only/retry-only
+		// SSE message is consequently unsupported (falls to the JSON-wrap branch below); a clean
+		// fix would need an explicit envelope marker, out of scope here.
+		if (message.data != null || message.event) {
 			let serialized = '';
 			if (message.event) serialized += 'event: ' + message.event + '\n';
 			if (message.data != null) {

--- a/server/serverHelpers/contentTypes.ts
+++ b/server/serverHelpers/contentTypes.ts
@@ -127,8 +127,7 @@ mediaTypes.set('application/ndjson', ndjsonHandler);
 
 function serializeSSEData(data: any) {
 	if (typeof data === 'object') return 'data: ' + JSONStringify(data) + '\n';
-	if (typeof data === 'string') return 'data: ' + data.replace(/\r\n|\r|\n/g, '\ndata: ') + '\n';
-	return 'data: ' + String(data) + '\n';
+	return 'data: ' + String(data).replace(/\r\n|\r|\n/g, '\ndata: ') + '\n';
 }
 
 mediaTypes.set('text/event-stream', {

--- a/server/serverHelpers/contentTypes.ts
+++ b/server/serverHelpers/contentTypes.ts
@@ -127,8 +127,8 @@ mediaTypes.set('application/ndjson', ndjsonHandler);
 
 function serializeSSEData(data: any) {
 	if (typeof data === 'object') return 'data: ' + JSONStringify(data) + '\n';
-	if (typeof data === 'string') data = data.replace(/\r\n|\r|\n/g, '\ndata: ');
-	return 'data: ' + data + '\n';
+	if (typeof data === 'string') return 'data: ' + data.replace(/\r\n|\r|\n/g, '\ndata: ') + '\n';
+	return 'data: ' + String(data) + '\n';
 }
 
 mediaTypes.set('text/event-stream', {

--- a/server/serverHelpers/contentTypes.ts
+++ b/server/serverHelpers/contentTypes.ts
@@ -126,7 +126,7 @@ mediaTypes.set('application/x-ndjson', ndjsonHandler);
 mediaTypes.set('application/ndjson', ndjsonHandler);
 
 function serializeSSEData(data: any) {
-	if (typeof data === 'object') data = JSONStringify(data);
+	if (typeof data === 'object') return 'data: ' + JSONStringify(data) + '\n';
 	return 'data: ' + String(data).replace(/\r\n|\r|\n/g, '\ndata: ') + '\n';
 }
 

--- a/server/serverHelpers/contentTypes.ts
+++ b/server/serverHelpers/contentTypes.ts
@@ -141,12 +141,9 @@ mediaTypes.set('text/event-stream', {
 				id: message.timestamp,
 			};
 		}
-		// Only `data`/`event` open the envelope path -- NOT `id`/`retry`. `id` in particular is an
-		// extremely common literal-payload field name (e.g. a database record), so treating a bare
-		// `id`/`retry` key as an SSE-envelope signal would misclassify plain data objects that
-		// happen to carry one, silently dropping every other field. A standalone id-only/retry-only
-		// SSE message is consequently unsupported (falls to the JSON-wrap branch below); a clean
-		// fix would need an explicit envelope marker, out of scope here.
+		// Only `data`/`event` open the envelope path. `id`/`retry` alone do not: `id` is too
+		// common a literal-payload field name (e.g. a database record) to safely treat as an
+		// SSE-envelope signal without misclassifying plain data objects that happen to carry one.
 		if (message.data != null || message.event) {
 			let serialized = '';
 			if (message.event) serialized += 'event: ' + message.event + '\n';

--- a/server/serverHelpers/contentTypes.ts
+++ b/server/serverHelpers/contentTypes.ts
@@ -141,7 +141,7 @@ mediaTypes.set('text/event-stream', {
 				id: message.timestamp,
 			};
 		}
-		if (message.data || message.event) {
+		if (message.data != null || message.event) {
 			let serialized = '';
 			if (message.event) serialized += 'event: ' + message.event + '\n';
 			if (message.data != null) {

--- a/server/serverHelpers/contentTypes.ts
+++ b/server/serverHelpers/contentTypes.ts
@@ -125,6 +125,11 @@ const ndjsonHandler = {
 mediaTypes.set('application/x-ndjson', ndjsonHandler);
 mediaTypes.set('application/ndjson', ndjsonHandler);
 
+function serializeSSEData(data: any) {
+	if (typeof data === 'object') data = JSONStringify(data);
+	return 'data: ' + String(data).replace(/\r\n|\r|\n/g, '\ndata: ') + '\n';
+}
+
 mediaTypes.set('text/event-stream', {
 	// Server-Sent Events (SSE)
 	serializeStream: function (iterable) {
@@ -148,16 +153,13 @@ mediaTypes.set('text/event-stream', {
 			let serialized = '';
 			if (message.event) serialized += 'event: ' + message.event + '\n';
 			if (message.data != null) {
-				let data = message.data;
-				if (typeof data === 'object') data = JSONStringify(data);
-				serialized += 'data: ' + data + '\n';
+				serialized += serializeSSEData(message.data);
 			}
 			if (message.id != null) serialized += 'id: ' + message.id + '\n';
 			if (message.retry != null) serialized += 'retry: ' + message.retry + '\n';
 			return serialized + '\n';
 		} else {
-			if (typeof message === 'object') return `data: ${JSONStringify(message)}\n\n`;
-			return `data: ${message}\n\n`;
+			return serializeSSEData(message) + '\n';
 		}
 	},
 	compressible: false,

--- a/server/serverHelpers/contentTypes.ts
+++ b/server/serverHelpers/contentTypes.ts
@@ -127,7 +127,8 @@ mediaTypes.set('application/ndjson', ndjsonHandler);
 
 function serializeSSEData(data: any) {
 	if (typeof data === 'object') return 'data: ' + JSONStringify(data) + '\n';
-	return 'data: ' + String(data).replace(/\r\n|\r|\n/g, '\ndata: ') + '\n';
+	if (typeof data === 'string') data = data.replace(/\r\n|\r|\n/g, '\ndata: ');
+	return 'data: ' + data + '\n';
 }
 
 mediaTypes.set('text/event-stream', {

--- a/server/serverHelpers/contentTypes.ts
+++ b/server/serverHelpers/contentTypes.ts
@@ -144,12 +144,12 @@ mediaTypes.set('text/event-stream', {
 		if (message.data || message.event) {
 			let serialized = '';
 			if (message.event) serialized += 'event: ' + message.event + '\n';
-			if (message.data) {
+			if (message.data != null) {
 				let data = message.data;
 				if (typeof data === 'object') data = JSONStringify(data);
 				serialized += 'data: ' + data + '\n';
 			}
-			if (message.id) serialized += 'id: ' + message.id + '\n';
+			if (message.id != null) serialized += 'id: ' + message.id + '\n';
 			if (message.retry) serialized += 'retry: ' + message.retry + '\n';
 			return serialized + '\n';
 		} else {

--- a/server/serverHelpers/contentTypes.ts
+++ b/server/serverHelpers/contentTypes.ts
@@ -141,9 +141,9 @@ mediaTypes.set('text/event-stream', {
 				id: message.timestamp,
 			};
 		}
-		// Only `data`/`event` open the envelope path. `id`/`retry` alone do not: `id` is too
-		// common a literal-payload field name (e.g. a database record) to safely treat as an
-		// SSE-envelope signal without misclassifying plain data objects that happen to carry one.
+		// A non-null top-level `data` or truthy `event` is an SSE envelope, even with sibling fields.
+		// `id`/`retry` alone do not open it: `id` is too common a literal-payload field name (e.g. a
+		// database record) to safely treat as an SSE-envelope signal.
 		if (message.data != null || message.event) {
 			let serialized = '';
 			if (message.event) serialized += 'event: ' + message.event + '\n';

--- a/unitTests/server/serverHelpers/contentTypes.test.js
+++ b/unitTests/server/serverHelpers/contentTypes.test.js
@@ -150,6 +150,13 @@ describe('contentTypes – text/event-stream (SSE)', function () {
 		assert.strictEqual(handler.serialize('first\nsecond'), 'data: first\ndata: second\n\n');
 	});
 
+	it('serializes multiline data after normalizing a native subscription message', function () {
+		assert.strictEqual(
+			handler.serialize({ value: 'first\nsecond', type: 'update', timestamp: 1 }),
+			'event: update\ndata: first\ndata: second\nid: 1\n\n'
+		);
+	});
+
 	// #1628: a finite async generator streamed to natural completion must close the SSE
 	// stream cleanly. transformIterable used to hand the terminal `{ value: undefined,
 	// done: true }` step to serialize(), which threw on `undefined.acknowledge` — hanging

--- a/unitTests/server/serverHelpers/contentTypes.test.js
+++ b/unitTests/server/serverHelpers/contentTypes.test.js
@@ -148,6 +148,7 @@ describe('contentTypes – text/event-stream (SSE)', function () {
 		const serialized = handler.serialize({ event: 'payload', data: 'first\nsecond\rthird\r\n' });
 		assert.strictEqual(serialized, 'event: payload\ndata: first\ndata: second\ndata: third\ndata: \n\n');
 		assert.strictEqual(handler.serialize('first\nsecond'), 'data: first\ndata: second\n\n');
+		assert.strictEqual(handler.serialize(Symbol('marker')), 'data: Symbol(marker)\n\n');
 	});
 
 	it('serializes multiline data after normalizing a native subscription message', function () {

--- a/unitTests/server/serverHelpers/contentTypes.test.js
+++ b/unitTests/server/serverHelpers/contentTypes.test.js
@@ -144,6 +144,12 @@ describe('contentTypes – application/x-ndjson', function () {
 describe('contentTypes – text/event-stream (SSE)', function () {
 	const handler = contentTypes.get('text/event-stream');
 
+	it('serializes each line of string data as a separate data field', function () {
+		const serialized = handler.serialize({ event: 'payload', data: 'first\nsecond\rthird\r\n' });
+		assert.strictEqual(serialized, 'event: payload\ndata: first\ndata: second\ndata: third\ndata: \n\n');
+		assert.strictEqual(handler.serialize('first\nsecond'), 'data: first\ndata: second\n\n');
+	});
+
 	// #1628: a finite async generator streamed to natural completion must close the SSE
 	// stream cleanly. transformIterable used to hand the terminal `{ value: undefined,
 	// done: true }` step to serialize(), which threw on `undefined.acknowledge` — hanging

--- a/unitTests/server/serverHelpers/contentTypes.test.js
+++ b/unitTests/server/serverHelpers/contentTypes.test.js
@@ -148,7 +148,7 @@ describe('contentTypes – text/event-stream (SSE)', function () {
 		const serialized = handler.serialize({ event: 'payload', data: 'first\nsecond\rthird\r\n' });
 		assert.strictEqual(serialized, 'event: payload\ndata: first\ndata: second\ndata: third\ndata: \n\n');
 		assert.strictEqual(handler.serialize('first\nsecond'), 'data: first\ndata: second\n\n');
-		assert.strictEqual(handler.serialize(Symbol('marker')), 'data: Symbol(marker)\n\n');
+		assert.strictEqual(handler.serialize(Symbol('first\nsecond')), 'data: Symbol(first\ndata: second)\n\n');
 	});
 
 	it('serializes multiline data after normalizing a native subscription message', function () {

--- a/unitTests/server/serverHelpers/contentTypes.test.js
+++ b/unitTests/server/serverHelpers/contentTypes.test.js
@@ -155,6 +155,10 @@ describe('contentTypes – text/event-stream (SSE)', function () {
 			handler.serialize({ value: 'first\nsecond', type: 'update', timestamp: 1 }),
 			'event: update\ndata: first\ndata: second\nid: 1\n\n'
 		);
+		assert.strictEqual(
+			handler.serialize({ value: 0, type: 'update', timestamp: 1 }),
+			'event: update\ndata: 0\nid: 1\n\n'
+		);
 	});
 
 	// #1628: a finite async generator streamed to natural completion must close the SSE


### PR DESCRIPTION
## Summary

`contentTypes.ts`'s `text/event-stream` `serialize()` used truthiness (`if (message.data)`, `if (message.id)`, `if (message.retry)`) to decide whether to emit `data:`/`id:`/`retry:` lines. That conflates "absent" with "falsy": legitimate values `0`, `false`, and `''` for `data`, `0` for `id` (a valid reconnect cursor), and `0` for `retry` were silently dropped from the wire frame. Per the `EventSource` spec, a frame with no `data:` line is discarded by the client without firing an event at all — a 200 response with nothing in the logs to flag it.

All three guards now check `!= null`, matching the idiom already used elsewhere in this file (`responseData?.contentType != null`).

**Caveat on `''`:** this fixes the wire representation (now emits `data: \n` instead of omitting the line) and is correct for the absence-vs-falsiness bug in general, but it does not change behavior for a real browser `EventSource` client on this specific value: per the HTML spec, an empty data buffer is discarded at dispatch time whether the `data:` line was present-but-empty or omitted entirely. `0` and `false` are the cases with an actual client-visible fix; `''` is fixed at the wire-byte level (useful for non-browser SSE consumers) but not for `EventSource` itself.

## What did *not* change, on purpose

The outer envelope-detection gate (`if (message.data != null || message.event)`) still only opens on `data`/`event`, not `id`/`retry`. This was tried during review (widening it to `message.id != null || message.retry != null`, to support a standalone id-only/retry-only message) and reverted: `id` is an extremely common literal-payload field name (e.g. any database record), so treating a bare `id` key as an SSE-envelope signal would misclassify a plain data object that happens to carry one — its `id` gets peeled into an `id:` line and every other field is silently dropped. That's a worse regression than the one this issue targets. A standalone id-only/retry-only SSE message therefore remains unsupported; a clean fix would need an explicit envelope marker (out of scope here). `integrationTests/server/qa702-sse-event-data/resources.js`'s `IdKeyPlainObjectPayload` fixture pins the correct (JSON-wrap-wholesale) behavior for this case.

## Change

- Follow-up review fix: [primitive coercion and CR/LF framing now share one path](https://github.com/HarperFast/harper/pull/2096/changes?w=1#diff-3ef5e58afb3497c3da77146d43e5ff63df88b7b9661cd862b98e390882c4f1fcR130), so newline-bearing `Symbol`/function strings cannot leak raw continuation lines; the [newline-bearing Symbol regression assertion](https://github.com/HarperFast/harper/pull/2096/changes?w=1#diff-1109cdb54e0c51de8a2b2d9b4701c8238ca0927bbc08b18b25cd3c86cb5edd50R151) pins that invariant.

- `server/serverHelpers/contentTypes.ts`: `data`/`id`/`retry` guards changed from truthiness to `!= null`.
- `integrationTests/server/qa702-sse-event-data.test.ts` + its `resources.js` fixture: this suite deliberately pinned the old (buggy) contract as a documented known-defect anchor (see #1972). Updated assertions/fixtures for the fixed contract, and added cases for the event-less-falsy-data and plain-object-with-an-id-key shapes that the review surfaced.

## Design assessment

Small, well-scoped fix confined to one function in shared serialization code. The `data`/`id` half was fully specified in #2026 with a pinned test anticipating it; the `retry` guard and the envelope-gate scoping question surfaced during cross-model review (see above) and were resolved before push.

## Verification

- Follow-up verification: `npm run build`; `npx mocha unitTests/server/serverHelpers/contentTypes.test.js` (21/21); `npm run format:write`; and `npm run lint:required` all passed. The new Symbol assertion was also confirmed to fail against the pre-fix serializer with the expected raw continuation line. `npm run test:unit:server` could not start the suite because its glob loads `unitTests/server/threads/fixtures/processGroupOwnerWorker.js` outside a worker (`parentPort` is null).

- Extended `qa702-sse-event-data.test.ts` integration suite (14/14 passing) — exercises the falsy-value matrix (`undefined`/`null`/`''`/`0`/`false`), `id: 0`, `retry: 0`, an event-less `data: 0` message, and a plain object with an `id` key.
- Ran `unitTests/server/serverHelpers/contentTypes.test.js` directly (19/19 passing) — unaffected non-falsy cases still serialize correctly.
- Full `test:unit:main`/`test:unit:resources`/`test:integration:all` gates not run locally (known local contention on this box — shared boot-props/RocksDB lock; CI is authoritative).
- 4 rounds of cross-model review (codex + gemini, + harper-domain adjudication on rounds 1–2): round 1 found the fix as filed was incomplete (outer envelope gate); round 2's suggested widening (to `id`/`retry`) was applied then round 3 caught that it introduced a data-loss regression for plain objects with an `id` key; round 4 confirmed the revert and closed out remaining nits. Converged with no new findings.

Fixes #2026

🤖 Generated by Claude (Sonnet 5)

<sub>Review-Coverage: authored=codex; ran=claude,gemini; declined=cursor-grok,cursor-composer,domain; rounds=6 @ 9d4dfcbbe4fb</sub>

<sub>Human-Review-Need: 4 @ 9d4dfcbbe4fb</sub>
