### PR TITLE
Fix copy-db producing a silently corrupt, non-restorable database copy

### DIFF
--- a/bin/copyDb.ts
+++ b/bin/copyDb.ts
@@ -75,6 +75,17 @@ export async function compactOnStart() {
 
 			const backupDest = join(rootPath, 'backup', databaseName + '.mdb');
 			const copyDest = join(rootPath, DATABASES_DIR_NAME, databaseName + '-copy.mdb');
+			const copyDatabaseName = databaseName + '-copy';
+			const copyDatabaseRootStores = databases[copyDatabaseName] && getRootStores(databases[copyDatabaseName]);
+			if (
+				copyDatabaseRootStores &&
+				[...copyDatabaseRootStores].some((rootStore) => relative(copyDest, rootStore.path) === '')
+			) {
+				const message = `Skipping compaction of database ${databaseName}: ${copyDatabaseName} is an existing database at the compaction target path; rename it before retrying`;
+				hdbLogger.warn(message);
+				console.warn(message);
+				continue;
+			}
 			let recordCount = 0;
 			try {
 				recordCount = await getTotalDBRecordCount(databaseName);

--- a/bin/copyDb.ts
+++ b/bin/copyDb.ts
@@ -6,7 +6,7 @@ import {
 	toRocksCompression,
 } from '../resources/databases.ts';
 import { open, asBinary } from 'lmdb';
-import { isAbsolute, join, relative } from 'path';
+import { isAbsolute, join, relative } from 'node:path';
 import { move, remove } from 'fs-extra';
 import { existsSync, mkdirSync } from 'node:fs';
 import { rename, writeFile } from 'node:fs/promises';
@@ -385,18 +385,19 @@ async function copyDbEnvironment(
 		}
 
 		/**
-		 * Whether a stored value is a delete tombstone, decided by decoding it with the live table's
+		 * Return a delete tombstone's local retention timestamp, decided by decoding it with the live table's
 		 * record decoder. Length cannot decide it — a small shared-structures dictionary and a small
 		 * record both land in a tombstone's usual size range — and `decode` returning null is not
 		 * sufficient either, since it also returns null for a record whose shared structure is missing
 		 * on this node. Only a metadata-bearing decode proves a tombstone; anything unprovable is kept.
 		 */
-		function isDeletedRecord(value, primaryStore) {
-			if (!primaryStore?.decoder) return false;
+		function getDeletedRecordTime(value, primaryStore, version) {
+			if (!primaryStore?.decoder) return;
 			try {
-				return primaryStore.decoder.decode(value) === null && lastMetadata?.value === null;
+				if (primaryStore.decoder.decode(value) === null && lastMetadata?.value === null)
+					return lastMetadata.localTime ?? version;
 			} catch {
-				return false;
+				return;
 			}
 		}
 
@@ -421,13 +422,11 @@ async function copyDbEnvironment(
 							// removes it too: dropping a live one loses the delete, letting a peer that
 							// missed it resurrect the record. A tombstone's body is a lone msgpack nil, so
 							// the trailing byte keeps the decode off every other record.
-							if (
-								isPrimary &&
-								typeof key !== 'symbol' &&
-								value?.[value.length - 1] === MSGPACK_NIL &&
-								version < tombstoneCutoff &&
-								isDeletedRecord(value, primaryStore)
-							) {
+							const deletedRecordTime =
+								isPrimary && typeof key !== 'symbol' && value?.[value.length - 1] === MSGPACK_NIL
+									? getDeletedRecordTime(value, primaryStore, version)
+									: undefined;
+							if (deletedRecordTime != null && deletedRecordTime < tombstoneCutoff) {
 								skippedRecord++;
 								continue;
 							}
@@ -463,15 +462,6 @@ async function copyDbEnvironment(
 						}
 					}
 					completed = true;
-					console.log(
-						'finish copying, copied',
-						recordsCopied,
-						'entries, skipped',
-						skippedRecord,
-						'delete records,',
-						bytesCopied,
-						'bytes'
-					);
 				} catch (error) {
 					// Resume from the last key read, never past it: re-copying that key is idempotent (an
 					// identical put, and an identical dupSort pair, is a no-op) while advancing the key
@@ -492,13 +482,22 @@ async function copyDbEnvironment(
 				throw new Error(
 					`Copy of ${sourceDatabase} to ${targetDatabasePath} failed on ${failedRecords} entry/entries after copying ${recordsCopied}`
 				);
+			console.log(
+				'finish copying, copied',
+				recordsCopied,
+				'entries, skipped',
+				skippedRecord,
+				'delete records,',
+				bytesCopied,
+				'bytes'
+			);
 		}
 
 		await written;
 		console.log('copied database ' + sourceDatabase + ' to ' + targetDatabasePath);
 	} finally {
 		transaction.done();
-		targetEnv.close();
+		await targetEnv.close();
 	}
 }
 

--- a/bin/copyDb.ts
+++ b/bin/copyDb.ts
@@ -6,16 +6,17 @@ import {
 	toRocksCompression,
 } from '../resources/databases.ts';
 import { open, asBinary } from 'lmdb';
-import { join } from 'path';
+import { isAbsolute, join, relative } from 'path';
 import { move, remove } from 'fs-extra';
 import { existsSync, mkdirSync } from 'node:fs';
-import { rename } from 'node:fs/promises';
+import { rename, writeFile } from 'node:fs/promises';
 import { get } from '../utility/environment/environmentManager.ts';
 import OpenEnvironmentObject from '../utility/lmdb/OpenEnvironmentObject.ts';
 import { OpenDBIObject } from '../utility/lmdb/OpenDBIObject.ts';
 import { INTERNAL_DBIS_NAME, AUDIT_STORE_NAME } from '../utility/lmdb/terms.ts';
 import { CONFIG_PARAMS, DATABASES_DIR_NAME, MIGRATING_DIR_SUFFIX } from '../utility/hdbTerms.ts';
-import { AUDIT_STORE_OPTIONS } from '../resources/auditStore.ts';
+import { AUDIT_STORE_OPTIONS, auditRetention } from '../resources/auditStore.ts';
+import { blobsReadmeContent, copyBlobRootsByIndex } from '../dataLayer/blobBackup.ts';
 import { describeSchema } from '../dataLayer/schemaDescribe.ts';
 import { updateConfigValue } from '../config/configUtils.ts';
 import * as hdbLogger from '../utility/logging/harper_logger.ts';
@@ -26,6 +27,7 @@ import {
 	beginPendingMigrationBlobSaves,
 	encodeBlobsWithFilePath,
 	endPendingMigrationBlobSaves,
+	getBlobPathsForDatabaseName,
 } from '../resources/blob.ts';
 import {
 	RecordEncoder,
@@ -50,15 +52,26 @@ export async function compactOnStart() {
 		for (const databaseName in databases) {
 			if (databaseName === 'system') continue;
 			if (databaseName.endsWith('-copy')) continue; // don't copy the copy
-			let dbPath;
-			for (const tableName in databases[databaseName]) {
-				dbPath = databases[databaseName][tableName].primaryStore.path;
-				break;
-			}
-			if (!dbPath) {
+			const rootStores = getRootStores(databases[databaseName]);
+			if (rootStores.size === 0) {
 				console.log("Couldn't find any tables in database", databaseName);
 				continue;
 			}
+			if ([...rootStores].some((rootStore) => rootStore instanceof RocksDatabase)) {
+				console.log('Database', databaseName, 'is RocksDB, which compacts itself, skipping');
+				continue;
+			}
+			// Compaction replaces one environment file, and leaves the blob roots alone because the
+			// compacted copy goes back to this exact path under this database name. A database whose
+			// tables live in separate environments has no single file to replace, so compacting it would
+			// relocate tables and strand blobs — skip it rather than produce that (harper#2048).
+			if (rootStores.size > 1) {
+				const message = `Skipping compaction of database ${databaseName}: its tables span ${rootStores.size} storage environments (table-specific paths), which compaction cannot replace as one file`;
+				hdbLogger.warn(message);
+				console.warn(message);
+				continue;
+			}
+			const dbPath = [...rootStores][0].path;
 
 			const backupDest = join(rootPath, 'backup', databaseName + '.mdb');
 			const copyDest = join(rootPath, DATABASES_DIR_NAME, databaseName + '-copy.mdb');
@@ -77,14 +90,17 @@ export async function compactOnStart() {
 				recordCount,
 			});
 
-			await copyDb(databaseName, copyDest);
+			// A copy target left behind by an interrupted run would be opened and merged into, mixing
+			// stale entries into this compaction's output.
+			await remove(copyDest);
+			await remove(copyDest + '-lock');
 
+			await copyDb(databaseName, copyDest, { blobs: 'preserve-source-roots' });
+
+			// The backup is the only rollback for the overwrite below, so a failed backup fails the
+			// compaction (leaving the source in place) instead of overwriting the only copy.
 			console.log('Backing up', databaseName, 'to', backupDest);
-			try {
-				await move(dbPath, backupDest, { overwrite: true });
-			} catch (error) {
-				console.log('Error moving database', dbPath, 'to', backupDest, error);
-			}
+			await move(dbPath, backupDest, { overwrite: true });
 			// Move compacted DB to back to original DB path
 			console.log('Moving copy compacted', databaseName, 'to', dbPath);
 			await move(copyDest, dbPath, { overwrite: true });
@@ -155,11 +171,86 @@ function noop() {
 	// if there are any attempts to write to the db, ignore them
 }
 
-export async function copyDb(sourceDatabase: string, targetDatabasePath: string) {
+/** The distinct storage environments a database's tables live in — normally exactly one. */
+function getRootStores(database): Set<any> {
+	const rootStores = new Set<any>();
+	for (const tableName in database) rootStores.add(database[tableName].primaryStore.rootStore);
+	return rootStores;
+}
+
+/** Companion directory holding a copy's blob files, beside the copied environment file. */
+const BLOB_COPY_SUFFIX = '-blobs';
+
+const STRUCTURES_KEY = Symbol.for('structures');
+
+const MAX_COPY_RETRIES = 1000;
+
+/** msgpack encoding of null — the entire body of a delete tombstone. */
+const MSGPACK_NIL = 0xc0;
+
+/** `path` is `directory` itself or nested inside it. */
+function isWithin(path: string, directory: string): boolean {
+	const relativePath = relative(directory, path);
+	return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath));
+}
+
+/**
+ * Read raw stored bytes rather than decoded values through this handle. `openDB` builds a
+ * RecordEncoder from the DBI options regardless of `encoding`, and the live audit store additionally
+ * wraps `getRange` to yield decoded audit records, so a byte-for-byte copy needs its own handle with
+ * the encoder detached.
+ */
+function useRawBytes(store) {
+	store.encoder = null;
+	store.decoder = null;
+	store.decoderCopies = false;
+	store.encoding = 'binary';
+	return store;
+}
+
+/**
+ * Copy a database's blob roots into `<targetDatabasePath>-blobs/<rootIndex>/…`. Blob files live
+ * outside the environment file and are addressed by database *name* against the running instance's
+ * configured roots, so a copy without them is unreadable anywhere but its own origin (harper#2048).
+ */
+async function copyDatabaseBlobs(sourceDatabase: string, targetDatabasePath: string, blobRoots: string[]) {
+	const populatedRoots = blobRoots.filter((root) => existsSync(root));
+	if (populatedRoots.length === 0) return;
+	const destination = targetDatabasePath + BLOB_COPY_SUFFIX;
+	await copyBlobRootsByIndex(destination, blobRoots);
+	await writeFile(join(destination, 'README.md'), blobsReadmeContent(blobRoots, { variant: 'copy' }));
+	const message =
+		`Copied ${populatedRoots.length} blob root(s) of ${sourceDatabase} to ${destination}. This copy is not ` +
+		`restorable without them: blobs are addressed by database name, so each <rootIndex> directory has to be ` +
+		`placed into the matching blob root of the database the copy is restored as (see ${join(destination, 'README.md')})`;
+	hdbLogger.notify(message);
+	console.log(message);
+}
+
+/**
+ * Copy a database's LMDB environment to `targetDatabasePath`.
+ *
+ * `blobs` declares what happens to the database's file-backed blobs, and is required because both
+ * answers are silently destructive when wrong: `'copy'` writes them beside the target (what an
+ * operator copying a database elsewhere needs), `'preserve-source-roots'` leaves them untouched and
+ * is only sound when the copy replaces the source environment under the same database name, which is
+ * what makes the existing roots keep resolving (harper#2048).
+ */
+export async function copyDb(
+	sourceDatabase: string,
+	targetDatabasePath: string,
+	options: { blobs: 'copy' | 'preserve-source-roots' }
+) {
+	const blobDisposition = options?.blobs;
+	if (blobDisposition !== 'copy' && blobDisposition !== 'preserve-source-roots')
+		throw new Error(
+			`copyDb requires a blob disposition: { blobs: 'copy' } to copy ${sourceDatabase}'s blob files beside the target, ` +
+				`or { blobs: 'preserve-source-roots' } when the copy replaces the source environment in place`
+		);
 	console.log(`Copying database ${sourceDatabase} to ${targetDatabasePath}`);
 	const sourceDb = getDatabases()[sourceDatabase];
 	if (!sourceDb) throw new Error(`Source database not found: ${sourceDatabase}`);
-	let rootStore;
+	const primaryStoresByDbi = new Map<string, any>();
 	for (const tableName in sourceDb) {
 		const table = sourceDb[tableName];
 		// ensure that writes aren't occurring
@@ -174,9 +265,50 @@ export async function copyDb(sourceDatabase: string, targetDatabasePath: string)
 			table.auditStore.put = noop;
 			table.auditStore.remove = noop;
 		}
-		rootStore = table.primaryStore.rootStore;
+		primaryStoresByDbi.set(table.primaryStore.name, table.primaryStore);
 	}
-	if (!rootStore) throw new Error(`Source database does not have any tables: ${sourceDatabase}`);
+	const rootStores = getRootStores(sourceDb);
+	if (rootStores.size === 0) throw new Error(`Source database does not have any tables: ${sourceDatabase}`);
+	if (rootStores.size > 1)
+		throw new Error(
+			`Database ${sourceDatabase} spans ${rootStores.size} storage environments (table-specific paths); ` +
+				`copying it into the single environment ${targetDatabasePath} would relocate tables and strand their blobs`
+		);
+	const [rootStore] = rootStores;
+	if (rootStore instanceof RocksDatabase)
+		throw new Error(`Database ${sourceDatabase} is stored in RocksDB; copyDb copies LMDB environments only`);
+	if (existsSync(targetDatabasePath))
+		throw new Error(
+			`Copy target ${targetDatabasePath} already exists; remove it first — opening it would merge this copy into whatever it holds`
+		);
+	const blobRoots = blobDisposition === 'copy' ? getBlobPathsForDatabaseName(sourceDatabase) : [];
+	const blobDestination = targetDatabasePath + BLOB_COPY_SUFFIX;
+	for (const root of blobRoots) {
+		if (isWithin(blobDestination, root) || isWithin(root, blobDestination))
+			throw new Error(
+				`Copy target ${targetDatabasePath} overlaps the source blob root ${root}; choose a target outside it`
+			);
+	}
+	try {
+		await copyDbEnvironment(sourceDatabase, targetDatabasePath, rootStore, primaryStoresByDbi);
+		if (blobDisposition === 'copy') await copyDatabaseBlobs(sourceDatabase, targetDatabasePath, blobRoots);
+	} catch (error) {
+		// Nothing here existed before this call (a pre-existing target is rejected above), so a partial
+		// copy is ours to remove: leaving one behind invites a restore of a database that lost records,
+		// index entries or blobs.
+		await remove(targetDatabasePath).catch(() => {});
+		await remove(targetDatabasePath + '-lock').catch(() => {});
+		await remove(blobDestination).catch(() => {});
+		throw error;
+	}
+}
+
+async function copyDbEnvironment(
+	sourceDatabase: string,
+	targetDatabasePath: string,
+	rootStore,
+	primaryStoresByDbi: Map<string, any>
+) {
 	// this contains the list of all the dbis
 	const sourceDbisDb = rootStore.dbisDb;
 	const sourceAuditStore = rootStore.auditStore;
@@ -184,6 +316,8 @@ export async function copyDb(sourceDatabase: string, targetDatabasePath: string)
 	const targetDbisDb = targetEnv.openDB({ name: INTERNAL_DBIS_NAME });
 	let written;
 	let outstandingWrites = 0;
+	// One cutoff for the whole copy so a long copy classifies every tombstone against the same instant
+	const tombstoneCutoff = Date.now() - auditRetention;
 	// we use a single transaction to get a snapshot, also we can't use snapshot: false on dupsort dbs
 	const transaction = sourceDbisDb.useReadTransaction();
 	try {
@@ -209,36 +343,88 @@ export async function copyDb(sourceDatabase: string, targetDatabasePath: string)
 			dbiInit.encoding = 'binary';
 			dbiInit.compression = existingCompression;
 			//dbiInit.keyEncoding = 'binary';
-			const sourceDbi = rootStore.openDB(key, dbiInit);
-			sourceDbi.decoder = null;
-			sourceDbi.decoderCopies = false;
-			sourceDbi.encoding = 'binary';
+			const sourceDbi = useRawBytes(rootStore.openDB(key, dbiInit));
 			dbiInit.compression = newCompression;
-			const targetDbi = (targetEnv as any).openDB(key, dbiInit);
-			(targetDbi as any).encoder = null;
+			const targetDbi = useRawBytes((targetEnv as any).openDB(key, dbiInit));
 			console.log('copying', key, 'from', sourceDatabase, 'to', targetDatabasePath);
-			await copyDbi(sourceDbi, targetDbi, isPrimary, transaction);
+			await copyDbi(sourceDbi, targetDbi, isPrimary, transaction, primaryStoresByDbi.get(key));
+			if (isPrimary) await verifyStructuresCopied(sourceDbi, targetDbi, key);
 		}
 		if (sourceAuditStore) {
-			const targetAuditStore = rootStore.openDB(AUDIT_STORE_NAME, AUDIT_STORE_OPTIONS);
+			// Both handles must be opened here: `targetAuditStore` used to come from the source env, so
+			// the copy wrote source audit entries back into the source (through a fresh handle the
+			// write-guard above never covered) and the target got no audit log at all (harper#2048).
+			const sourceAuditDbi = rootStore.openDB(AUDIT_STORE_NAME, { create: false, ...AUDIT_STORE_OPTIONS });
+			if (!sourceAuditDbi) throw new Error(`Could not open the audit store of ${sourceDatabase} to copy it`);
+			const targetAuditStore = (targetEnv as any).openDB(AUDIT_STORE_NAME, AUDIT_STORE_OPTIONS);
 			console.log('copying audit log for', sourceDatabase, 'to', targetDatabasePath);
-			copyDbi(sourceAuditStore, targetAuditStore, false, transaction);
+			await copyDbi(useRawBytes(sourceAuditDbi), useRawBytes(targetAuditStore), false, transaction);
 		}
 
-		async function copyDbi(sourceDbi, targetDbi, isPrimary, transaction) {
+		/**
+		 * A primary DBI's shared-structures dictionary is the whole table's decodability: without it
+		 * every copied record decodes to null. It rides through the copy as a symbol-keyed entry, so
+		 * confirm it landed rather than trusting the walk (harper#2048).
+		 */
+		async function verifyStructuresCopied(sourceDbi, targetDbi, dbiName) {
+			const sourceStructures = sourceDbi.getBinary?.(STRUCTURES_KEY);
+			if (!sourceStructures) return;
+			await written;
+			const copiedStructures = targetDbi.getBinary(STRUCTURES_KEY);
+			if (!copiedStructures || !Buffer.from(copiedStructures).equals(Buffer.from(sourceStructures)))
+				throw new Error(
+					`Copy of ${sourceDatabase}/${dbiName} to ${targetDatabasePath} lost the shared-structures dictionary ` +
+						`(${sourceStructures.length} source bytes, ${copiedStructures?.length ?? 0} copied) — every record in the copy would decode as null`
+				);
+		}
+
+		/**
+		 * Whether a stored value is a delete tombstone, decided by decoding it with the live table's
+		 * record decoder. Length cannot decide it: the 13-byte shape a tombstone usually has is also
+		 * reachable by the shared-structures dictionary and by small records, and the length test
+		 * dropped both. `decode` returning null is not sufficient either — it also returns null for a
+		 * record whose shared structure is missing — so require the metadata-bearing decode that only a
+		 * real prefixed tombstone produces, and keep anything unprovable.
+		 */
+		function isDeletedRecord(value, primaryStore) {
+			if (!primaryStore?.decoder) return false;
+			try {
+				return primaryStore.decoder.decode(value) === null && lastMetadata?.value === null;
+			} catch {
+				return false;
+			}
+		}
+
+		async function copyDbi(sourceDbi, targetDbi, isPrimary, transaction, primaryStore?) {
 			let recordsCopied = 0;
 			let bytesCopied = 0;
 			let skippedRecord = 0;
-			let retries = 10000000;
+			let failedRecords = 0;
+			let retries = MAX_COPY_RETRIES;
 			let start = null;
-			while (retries-- > 0) {
+			let completed = false;
+			while (!completed && retries-- > 0) {
 				try {
-					for (const key of sourceDbi.getKeys({ start, transaction })) {
+					// getRange (not getKeys + getEntry) so a dupSort index yields every duplicate rather
+					// than one entry per unique key, which collapsed every secondary index (harper#2048)
+					for (const { key, value, version } of sourceDbi.getRange(
+						isPrimary ? { start, transaction, versions: true } : { start, transaction }
+					)) {
 						try {
 							start = key;
-							const { value, version } = sourceDbi.getEntry(key, { transaction });
-							// deleted entries should be 13 bytes long (8 for timestamp, 4 bytes for flags, 1 byte of the encoding of null)
-							if (value?.length < 14 && isPrimary) {
+							// Tombstones are dropped only once they are past audit retention, the same point
+							// the runtime removes them: dropping a live one loses the delete, letting a peer
+							// that missed it resurrect the record. A tombstone's body is just msgpack nil,
+							// so its trailing byte is the cheap filter that keeps the decode below off
+							// every record — length cannot serve: a real delete carries node-id metadata
+							// and runs to 17 bytes, well past the 14 the old heuristic tested.
+							if (
+								isPrimary &&
+								typeof key !== 'symbol' &&
+								value?.[value.length - 1] === MSGPACK_NIL &&
+								version < tombstoneCutoff &&
+								isDeletedRecord(value, primaryStore)
+							) {
 								skippedRecord++;
 								continue;
 							}
@@ -260,6 +446,7 @@ export async function copyDb(sourceDatabase: string, targetDatabasePath: string)
 								outstandingWrites = 0;
 							}
 						} catch (error) {
+							failedRecords++;
 							console.error(
 								'Error copying record',
 								typeof key === 'symbol' ? 'symbol' : key,
@@ -271,6 +458,7 @@ export async function copyDb(sourceDatabase: string, targetDatabasePath: string)
 							);
 						}
 					}
+					completed = true;
 					console.log(
 						'finish copying, copied',
 						recordsCopied,
@@ -280,18 +468,30 @@ export async function copyDb(sourceDatabase: string, targetDatabasePath: string)
 						bytesCopied,
 						'bytes'
 					);
-					return;
-				} catch {
+				} catch (error) {
+					console.error(
+						`Error iterating ${sourceDatabase} near key ${typeof start === 'symbol' ? 'symbol' : JSON.stringify(start)}, retrying (${retries} retries left):`,
+						error
+					);
 					// try to resume with a bigger key
 					if (typeof start === 'string') {
-						if (start === 'z') {
-							return console.error('Reached end of dbi', start, 'for', sourceDatabase, 'to', targetDatabasePath);
-						}
+						if (start === 'z')
+							throw new Error(`Reached end of dbi resuming ${sourceDatabase} at key ${start}`, { cause: error });
 						start = start.slice(0, -2) + 'z';
 					} else if (typeof start === 'number') start++;
-					else return console.error('Unknown key type', start, 'for', sourceDatabase, 'to', targetDatabasePath);
+					else
+						throw new Error(`Cannot resume copy of ${sourceDatabase} past key of type ${typeof start}`, {
+							cause: error,
+						});
 				}
 			}
+			// Every one of these used to log and carry on, so a copy that lost records, or stopped
+			// part-way through a DBI, still reported success and exited 0 (harper#2048).
+			if (!completed) throw new Error(`Copy of ${sourceDatabase} exceeded ${MAX_COPY_RETRIES} retries`);
+			if (failedRecords > 0)
+				throw new Error(
+					`Copy of ${sourceDatabase} to ${targetDatabasePath} failed on ${failedRecords} of ${failedRecords + recordsCopied} entries`
+				);
 		}
 
 		await written;
@@ -561,7 +761,6 @@ export async function copyDbToRocks(sourceRootStore, sourceDatabase: string, tar
 	});
 	targetHandles.push(targetDbisDb);
 
-	const STRUCTURES_KEY = Symbol.for('structures');
 	const copyStructures = (sourceDbi, storeName: string, extraTarget?: RocksDatabase) => {
 		const buffer = sourceDbi.getBinary?.(STRUCTURES_KEY);
 		if (buffer) {

--- a/bin/copyDb.ts
+++ b/bin/copyDb.ts
@@ -62,9 +62,9 @@ export async function compactOnStart() {
 				continue;
 			}
 			// Compaction replaces one environment file, and leaves the blob roots alone because the
-			// compacted copy goes back to this exact path under this database name. A database whose
-			// tables live in separate environments has no single file to replace, so compacting it would
-			// relocate tables and strand blobs — skip it rather than produce that (harper#2048).
+			// compacted copy goes back to this exact path under this database name. Tables in separate
+			// environments have no single file to replace, so compacting them would relocate tables and
+			// strand their blobs.
 			if (rootStores.size > 1) {
 				const message = `Skipping compaction of database ${databaseName}: its tables span ${rootStores.size} storage environments (table-specific paths), which compaction cannot replace as one file`;
 				hdbLogger.warn(message);
@@ -83,12 +83,14 @@ export async function compactOnStart() {
 				hdbLogger.error('Error getting record count for database', databaseName, error);
 				console.error('Error getting record count for database', databaseName, error);
 			}
-			compactedDb.set(databaseName, {
+			const compactionState = {
 				dbPath,
 				copyDest,
 				backupDest,
 				recordCount,
-			});
+				backedUp: false,
+			};
+			compactedDb.set(databaseName, compactionState);
 
 			// A copy target left behind by an interrupted run would be opened and merged into, mixing
 			// stale entries into this compaction's output.
@@ -101,6 +103,7 @@ export async function compactOnStart() {
 			// compaction (leaving the source in place) instead of overwriting the only copy.
 			console.log('Backing up', databaseName, 'to', backupDest);
 			await move(dbPath, backupDest, { overwrite: true });
+			compactionState.backedUp = true;
 			// Move compacted DB to back to original DB path
 			console.log('Moving copy compacted', databaseName, 'to', dbPath);
 			await move(copyDest, dbPath, { overwrite: true });
@@ -126,7 +129,12 @@ export async function compactOnStart() {
 
 		updateConfigValue(CONFIG_PARAMS.STORAGE_COMPACTONSTART, false);
 
-		for (const [_db, { dbPath, backupDest }] of compactedDb) {
+		for (const [_db, { dbPath, backupDest, backedUp }] of compactedDb) {
+			// Only a backup this run created is this run's source to restore. `backupDest` is a fixed
+			// path per database, so a retained backup from an earlier run can be sitting there — moving
+			// that over a database whose compaction failed before its own backup was taken would
+			// replace healthy data with a stale snapshot.
+			if (!backedUp) continue;
 			console.error('Moving backup database', backupDest, 'back to', dbPath);
 			try {
 				await move(backupDest, dbPath, { overwrite: true });
@@ -171,34 +179,29 @@ function noop() {
 	// if there are any attempts to write to the db, ignore them
 }
 
-/** The distinct storage environments a database's tables live in — normally exactly one. */
 function getRootStores(database): Set<any> {
 	const rootStores = new Set<any>();
 	for (const tableName in database) rootStores.add(database[tableName].primaryStore.rootStore);
 	return rootStores;
 }
 
-/** Companion directory holding a copy's blob files, beside the copied environment file. */
 const BLOB_COPY_SUFFIX = '-blobs';
 
 const STRUCTURES_KEY = Symbol.for('structures');
 
 const MAX_COPY_RETRIES = 1000;
 
-/** msgpack encoding of null — the entire body of a delete tombstone. */
 const MSGPACK_NIL = 0xc0;
 
-/** `path` is `directory` itself or nested inside it. */
 function isWithin(path: string, directory: string): boolean {
 	const relativePath = relative(directory, path);
 	return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath));
 }
 
 /**
- * Read raw stored bytes rather than decoded values through this handle. `openDB` builds a
- * RecordEncoder from the DBI options regardless of `encoding`, and the live audit store additionally
- * wraps `getRange` to yield decoded audit records, so a byte-for-byte copy needs its own handle with
- * the encoder detached.
+ * Read and write raw stored bytes through this handle: `openDB` builds a RecordEncoder from the DBI
+ * options whatever `encoding` says, and the live audit store also wraps `getRange` to yield decoded
+ * audit records, so a byte-for-byte copy needs the encoder detached.
  */
 function useRawBytes(store) {
 	store.encoder = null;
@@ -211,7 +214,7 @@ function useRawBytes(store) {
 /**
  * Copy a database's blob roots into `<targetDatabasePath>-blobs/<rootIndex>/…`. Blob files live
  * outside the environment file and are addressed by database *name* against the running instance's
- * configured roots, so a copy without them is unreadable anywhere but its own origin (harper#2048).
+ * configured roots, so a copy without them is unreadable anywhere but its own origin.
  */
 async function copyDatabaseBlobs(sourceDatabase: string, targetDatabasePath: string, blobRoots: string[]) {
 	const populatedRoots = blobRoots.filter((root) => existsSync(root));
@@ -234,7 +237,7 @@ async function copyDatabaseBlobs(sourceDatabase: string, targetDatabasePath: str
  * answers are silently destructive when wrong: `'copy'` writes them beside the target (what an
  * operator copying a database elsewhere needs), `'preserve-source-roots'` leaves them untouched and
  * is only sound when the copy replaces the source environment under the same database name, which is
- * what makes the existing roots keep resolving (harper#2048).
+ * what makes the existing roots keep resolving.
  */
 export async function copyDb(
 	sourceDatabase: string,
@@ -250,23 +253,6 @@ export async function copyDb(
 	console.log(`Copying database ${sourceDatabase} to ${targetDatabasePath}`);
 	const sourceDb = getDatabases()[sourceDatabase];
 	if (!sourceDb) throw new Error(`Source database not found: ${sourceDatabase}`);
-	const primaryStoresByDbi = new Map<string, any>();
-	for (const tableName in sourceDb) {
-		const table = sourceDb[tableName];
-		// ensure that writes aren't occurring
-		table.primaryStore.put = noop;
-		table.primaryStore.remove = noop;
-		for (const attributeName in table.indices) {
-			const index = table.indices[attributeName];
-			index.put = noop;
-			index.remove = noop;
-		}
-		if (table.auditStore) {
-			table.auditStore.put = noop;
-			table.auditStore.remove = noop;
-		}
-		primaryStoresByDbi.set(table.primaryStore.name, table.primaryStore);
-	}
 	const rootStores = getRootStores(sourceDb);
 	if (rootStores.size === 0) throw new Error(`Source database does not have any tables: ${sourceDatabase}`);
 	if (rootStores.size > 1)
@@ -283,22 +269,43 @@ export async function copyDb(
 		);
 	const blobRoots = blobDisposition === 'copy' ? getBlobPathsForDatabaseName(sourceDatabase) : [];
 	const blobDestination = targetDatabasePath + BLOB_COPY_SUFFIX;
-	for (const root of blobRoots) {
-		if (isWithin(blobDestination, root) || isWithin(root, blobDestination))
-			throw new Error(
-				`Copy target ${targetDatabasePath} overlaps the source blob root ${root}; choose a target outside it`
-			);
+	if (blobDisposition === 'copy') {
+		if (existsSync(blobDestination))
+			throw new Error(`Blob copy target ${blobDestination} already exists; remove it first`);
+		for (const root of blobRoots) {
+			if (isWithin(blobDestination, root) || isWithin(root, blobDestination))
+				throw new Error(
+					`Copy target ${targetDatabasePath} overlaps the source blob root ${root}; choose a target outside it`
+				);
+		}
+	}
+	// Suppress source writes only once the copy is going ahead: a caller that catches a rejection above
+	// keeps using these stores.
+	const primaryStoresByDbi = new Map<string, any>();
+	for (const tableName in sourceDb) {
+		const table = sourceDb[tableName];
+		table.primaryStore.put = noop;
+		table.primaryStore.remove = noop;
+		for (const attributeName in table.indices) {
+			const index = table.indices[attributeName];
+			index.put = noop;
+			index.remove = noop;
+		}
+		if (table.auditStore) {
+			table.auditStore.put = noop;
+			table.auditStore.remove = noop;
+		}
+		primaryStoresByDbi.set(table.primaryStore.name, table.primaryStore);
 	}
 	try {
 		await copyDbEnvironment(sourceDatabase, targetDatabasePath, rootStore, primaryStoresByDbi);
 		if (blobDisposition === 'copy') await copyDatabaseBlobs(sourceDatabase, targetDatabasePath, blobRoots);
 	} catch (error) {
-		// Nothing here existed before this call (a pre-existing target is rejected above), so a partial
-		// copy is ours to remove: leaving one behind invites a restore of a database that lost records,
-		// index entries or blobs.
+		// Every path removed here was created by this call — both targets are rejected above if they
+		// already exist — and a partial copy left behind is a copy someone can restore from.
 		await remove(targetDatabasePath).catch(() => {});
 		await remove(targetDatabasePath + '-lock').catch(() => {});
-		await remove(blobDestination).catch(() => {});
+		if (blobDisposition === 'copy') await remove(blobDestination).catch(() => {});
 		throw error;
 	}
 }
@@ -351,9 +358,8 @@ async function copyDbEnvironment(
 			if (isPrimary) await verifyStructuresCopied(sourceDbi, targetDbi, key);
 		}
 		if (sourceAuditStore) {
-			// Both handles must be opened here: `targetAuditStore` used to come from the source env, so
-			// the copy wrote source audit entries back into the source (through a fresh handle the
-			// write-guard above never covered) and the target got no audit log at all (harper#2048).
+			// Both handles belong to their own environment: a target handle opened on the source env
+			// writes the audit log back into the source and leaves the copy without one.
 			const sourceAuditDbi = rootStore.openDB(AUDIT_STORE_NAME, { create: false, ...AUDIT_STORE_OPTIONS });
 			if (!sourceAuditDbi) throw new Error(`Could not open the audit store of ${sourceDatabase} to copy it`);
 			const targetAuditStore = (targetEnv as any).openDB(AUDIT_STORE_NAME, AUDIT_STORE_OPTIONS);
@@ -364,7 +370,7 @@ async function copyDbEnvironment(
 		/**
 		 * A primary DBI's shared-structures dictionary is the whole table's decodability: without it
 		 * every copied record decodes to null. It rides through the copy as a symbol-keyed entry, so
-		 * confirm it landed rather than trusting the walk (harper#2048).
+		 * confirm it landed rather than trusting the walk.
 		 */
 		async function verifyStructuresCopied(sourceDbi, targetDbi, dbiName) {
 			const sourceStructures = sourceDbi.getBinary?.(STRUCTURES_KEY);
@@ -380,11 +386,10 @@ async function copyDbEnvironment(
 
 		/**
 		 * Whether a stored value is a delete tombstone, decided by decoding it with the live table's
-		 * record decoder. Length cannot decide it: the 13-byte shape a tombstone usually has is also
-		 * reachable by the shared-structures dictionary and by small records, and the length test
-		 * dropped both. `decode` returning null is not sufficient either — it also returns null for a
-		 * record whose shared structure is missing — so require the metadata-bearing decode that only a
-		 * real prefixed tombstone produces, and keep anything unprovable.
+		 * record decoder. Length cannot decide it — a small shared-structures dictionary and a small
+		 * record both land in a tombstone's usual size range — and `decode` returning null is not
+		 * sufficient either, since it also returns null for a record whose shared structure is missing
+		 * on this node. Only a metadata-bearing decode proves a tombstone; anything unprovable is kept.
 		 */
 		function isDeletedRecord(value, primaryStore) {
 			if (!primaryStore?.decoder) return false;
@@ -405,19 +410,17 @@ async function copyDbEnvironment(
 			let completed = false;
 			while (!completed && retries-- > 0) {
 				try {
-					// getRange (not getKeys + getEntry) so a dupSort index yields every duplicate rather
-					// than one entry per unique key, which collapsed every secondary index (harper#2048)
+					// getRange, not getKeys + getEntry: on a dupSort index the latter yields one entry per
+					// unique key, dropping every duplicate
 					for (const { key, value, version } of sourceDbi.getRange(
 						isPrimary ? { start, transaction, versions: true } : { start, transaction }
 					)) {
 						try {
 							start = key;
-							// Tombstones are dropped only once they are past audit retention, the same point
-							// the runtime removes them: dropping a live one loses the delete, letting a peer
-							// that missed it resurrect the record. A tombstone's body is just msgpack nil,
-							// so its trailing byte is the cheap filter that keeps the decode below off
-							// every record — length cannot serve: a real delete carries node-id metadata
-							// and runs to 17 bytes, well past the 14 the old heuristic tested.
+							// Drop a tombstone only once it is past audit retention, the point the runtime
+							// removes it too: dropping a live one loses the delete, letting a peer that
+							// missed it resurrect the record. A tombstone's body is a lone msgpack nil, so
+							// the trailing byte keeps the decode off every other record.
 							if (
 								isPrimary &&
 								typeof key !== 'symbol' &&
@@ -456,6 +459,7 @@ async function copyDbEnvironment(
 								targetDatabasePath,
 								error
 							);
+							break;
 						}
 					}
 					completed = true;
@@ -469,28 +473,27 @@ async function copyDbEnvironment(
 						'bytes'
 					);
 				} catch (error) {
+					// Resume from the last key read, which re-copies it (a put of identical bytes, and a
+					// dupSort pair, is idempotent) and continues in order. Advancing the key instead — as
+					// this did, bumping a string to `<prefix>z` — jumps the copy over every key in
+					// between and then reports success, which is the corruption this function is being
+					// fixed for. A key that cannot be read at all exhausts the retries and fails.
 					console.error(
 						`Error iterating ${sourceDatabase} near key ${typeof start === 'symbol' ? 'symbol' : JSON.stringify(start)}, retrying (${retries} retries left):`,
 						error
 					);
-					// try to resume with a bigger key
-					if (typeof start === 'string') {
-						if (start === 'z')
-							throw new Error(`Reached end of dbi resuming ${sourceDatabase} at key ${start}`, { cause: error });
-						start = start.slice(0, -2) + 'z';
-					} else if (typeof start === 'number') start++;
-					else
-						throw new Error(`Cannot resume copy of ${sourceDatabase} past key of type ${typeof start}`, {
-							cause: error,
-						});
 				}
 			}
-			// Every one of these used to log and carry on, so a copy that lost records, or stopped
-			// part-way through a DBI, still reported success and exited 0 (harper#2048).
-			if (!completed) throw new Error(`Copy of ${sourceDatabase} exceeded ${MAX_COPY_RETRIES} retries`);
+			// A copy that lost entries or stopped part-way through a DBI used to log and carry on,
+			// reporting success and exiting 0.
+			if (!completed)
+				throw new Error(
+					`Copy of ${sourceDatabase} to ${targetDatabasePath} could not get past key ` +
+						`${typeof start === 'symbol' ? 'symbol' : JSON.stringify(start)} in ${MAX_COPY_RETRIES} attempts`
+				);
 			if (failedRecords > 0)
 				throw new Error(
-					`Copy of ${sourceDatabase} to ${targetDatabasePath} failed on ${failedRecords} of ${failedRecords + recordsCopied} entries`
+					`Copy of ${sourceDatabase} to ${targetDatabasePath} failed on ${failedRecords} entry/entries after copying ${recordsCopied}`
 				);
 		}
 

--- a/bin/copyDb.ts
+++ b/bin/copyDb.ts
@@ -6,7 +6,7 @@ import {
 	toRocksCompression,
 } from '../resources/databases.ts';
 import { open, asBinary } from 'lmdb';
-import { isAbsolute, join, relative } from 'node:path';
+import { isAbsolute, join, relative, sep } from 'node:path';
 import { move, remove } from 'fs-extra';
 import { existsSync, mkdirSync } from 'node:fs';
 import { rename, writeFile } from 'node:fs/promises';
@@ -198,7 +198,11 @@ const MSGPACK_NIL = 0xc0;
 
 function isWithin(path: string, directory: string): boolean {
 	const relativePath = relative(directory, path);
-	return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath));
+	if (relativePath === '') return true;
+	if (isAbsolute(relativePath)) return false;
+	// Segment-aware: a child literally named e.g. `..copy.mdb-blobs` is a real child, not an escape —
+	// only a first segment of exactly `..` walks up out of `directory`.
+	return relativePath.split(sep)[0] !== '..';
 }
 
 /**
@@ -221,6 +225,14 @@ function useRawBytes(store) {
  */
 async function copyDatabaseBlobs(sourceDatabase: string, targetDatabasePath: string, blobRoots: string[]) {
 	const populatedRoots = blobRoots.filter((root) => existsSync(root));
+	const missingRoots = blobRoots.filter((root) => !existsSync(root));
+	if (missingRoots.length > 0) {
+		const message =
+			`Configured blob root(s) ${missingRoots.join(', ')} of ${sourceDatabase} do not exist and will be copied as ` +
+			`empty; if this database has ever written blobs to them (rather than never having used them), this copy is missing those blobs.`;
+		hdbLogger.warn(message);
+		console.warn(message);
+	}
 	if (populatedRoots.length === 0) return;
 	const destination = targetDatabasePath + BLOB_COPY_SUFFIX;
 	await copyBlobRootsByIndex(destination, blobRoots);

--- a/bin/copyDb.ts
+++ b/bin/copyDb.ts
@@ -76,7 +76,7 @@ export async function compactOnStart() {
 			const backupDest = join(rootPath, 'backup', databaseName + '.mdb');
 			const copyDest = join(rootPath, DATABASES_DIR_NAME, databaseName + '-copy.mdb');
 			if (existsSync(copyDest)) {
-				const message = `Skipping compaction of database ${databaseName}: ${copyDest} already exists; inspect and rename or remove it before retrying`;
+				const message = `Skipping compaction of database ${databaseName}: ${copyDest} already exists; inspect and rename or remove it, then re-enable '${CONFIG_PARAMS.STORAGE_COMPACTONSTART}' before retrying (this run already disabled it)`;
 				hdbLogger.warn(message);
 				console.warn(message);
 				continue;
@@ -287,11 +287,21 @@ export async function copyDb(
 	if (blobDisposition === 'copy') {
 		if (existsSync(blobDestination))
 			throw new Error(`Blob copy target ${blobDestination} already exists; remove it first`);
+		// Every path a failure can remove or write through, not just the final blob destination — a
+		// staging or lock sibling landing inside a blob root would be just as destructive on cleanup.
+		const destinationPaths = [
+			targetDatabasePath,
+			targetDatabasePath + '-lock',
+			blobDestination,
+			blobDestination + '.tmp',
+		];
 		for (const root of blobRoots) {
-			if (isWithin(blobDestination, root) || isWithin(root, blobDestination))
-				throw new Error(
-					`Copy target ${targetDatabasePath} overlaps the source blob root ${root}; choose a target outside it`
-				);
+			for (const destinationPath of destinationPaths) {
+				if (isWithin(destinationPath, root) || isWithin(root, destinationPath))
+					throw new Error(
+						`Copy target ${targetDatabasePath} overlaps the source blob root ${root}; choose a target outside it`
+					);
+			}
 		}
 	}
 	// Suppress source writes only once the copy is going ahead: a caller that catches a rejection above

--- a/bin/copyDb.ts
+++ b/bin/copyDb.ts
@@ -75,13 +75,8 @@ export async function compactOnStart() {
 
 			const backupDest = join(rootPath, 'backup', databaseName + '.mdb');
 			const copyDest = join(rootPath, DATABASES_DIR_NAME, databaseName + '-copy.mdb');
-			const copyDatabaseName = databaseName + '-copy';
-			const copyDatabaseRootStores = databases[copyDatabaseName] && getRootStores(databases[copyDatabaseName]);
-			if (
-				copyDatabaseRootStores &&
-				[...copyDatabaseRootStores].some((rootStore) => relative(copyDest, rootStore.path) === '')
-			) {
-				const message = `Skipping compaction of database ${databaseName}: ${copyDatabaseName} is an existing database at the compaction target path; rename it before retrying`;
+			if (existsSync(copyDest)) {
+				const message = `Skipping compaction of database ${databaseName}: ${copyDest} already exists; inspect and rename or remove it before retrying`;
 				hdbLogger.warn(message);
 				console.warn(message);
 				continue;
@@ -103,9 +98,6 @@ export async function compactOnStart() {
 			};
 			compactedDb.set(databaseName, compactionState);
 
-			// A copy target left behind by an interrupted run would be opened and merged into, mixing
-			// stale entries into this compaction's output.
-			await remove(copyDest);
 			await remove(copyDest + '-lock');
 
 			await copyDb(databaseName, copyDest, { blobs: 'preserve-source-roots' });

--- a/bin/copyDb.ts
+++ b/bin/copyDb.ts
@@ -358,7 +358,7 @@ async function copyDbEnvironment(
 			if (isPrimary) await verifyStructuresCopied(sourceDbi, targetDbi, key);
 		}
 		if (sourceAuditStore) {
-			// Both handles belong to their own environment: a target handle opened on the source env
+			// Each handle belongs to its own environment: a "target" handle opened on the source env
 			// writes the audit log back into the source and leaves the copy without one.
 			const sourceAuditDbi = rootStore.openDB(AUDIT_STORE_NAME, { create: false, ...AUDIT_STORE_OPTIONS });
 			if (!sourceAuditDbi) throw new Error(`Could not open the audit store of ${sourceDatabase} to copy it`);
@@ -473,19 +473,16 @@ async function copyDbEnvironment(
 						'bytes'
 					);
 				} catch (error) {
-					// Resume from the last key read, which re-copies it (a put of identical bytes, and a
-					// dupSort pair, is idempotent) and continues in order. Advancing the key instead — as
-					// this did, bumping a string to `<prefix>z` — jumps the copy over every key in
-					// between and then reports success, which is the corruption this function is being
-					// fixed for. A key that cannot be read at all exhausts the retries and fails.
+					// Resume from the last key read, never past it: re-copying that key is idempotent (an
+					// identical put, and an identical dupSort pair, is a no-op) while advancing the key
+					// would jump the copy over everything in between and still reach the success path.
 					console.error(
 						`Error iterating ${sourceDatabase} near key ${typeof start === 'symbol' ? 'symbol' : JSON.stringify(start)}, retrying (${retries} retries left):`,
 						error
 					);
 				}
 			}
-			// A copy that lost entries or stopped part-way through a DBI used to log and carry on,
-			// reporting success and exiting 0.
+			// A copy that lost entries, or stopped part-way through a DBI, must not report success
 			if (!completed)
 				throw new Error(
 					`Copy of ${sourceDatabase} to ${targetDatabasePath} could not get past key ` +

--- a/bin/harper.ts
+++ b/bin/harper.ts
@@ -119,7 +119,7 @@ async function harper() {
 		case SERVICE_ACTIONS_ENUM.COPYDB: {
 			let sourceDb = process.argv[3];
 			let targetDbPath = process.argv[4];
-			return require('./copyDb').copyDb(sourceDb, targetDbPath);
+			return require('./copyDb').copyDb(sourceDb, targetDbPath, { blobs: 'copy' });
 		}
 		case OPERATIONS_ENUM.CREATE_BACKUP:
 		case OPERATIONS_ENUM.LIST_BACKUPS:

--- a/bin/help.ts
+++ b/bin/help.ts
@@ -86,7 +86,10 @@ const SECTIONS: Section[] = [
 					['upgrade', 'Upgrade harperdb'],
 					['register', 'Register harperdb'],
 					['renew-certs', 'Generate a new set of self-signed certificates'],
-					['copy-db <source> <target>', 'Copies a database from source path to target path'],
+					[
+						'copy-db <source> <target>',
+						'Copies the database named <source> to the <target> environment path. File-backed blobs are copied to <target>-blobs; see its README before restoring.',
+					],
 					['version', 'Print the version'],
 					['help', 'Display this output'],
 				],

--- a/dataLayer/blobBackup.ts
+++ b/dataLayer/blobBackup.ts
@@ -168,14 +168,13 @@ async function copyTree(
 }
 
 /**
- * Snapshot a database's blob roots into a backup's blob directory. Writes to a temporary sibling
- * and atomically renames into place so a create_backup that fails mid-copy never leaves a partial
- * `blobs/<backupId>/` that a later restore would trust. Overwrites any pre-existing snapshot for the
- * same id (create_backup always produces a fresh id, so this only matters on a retried offline run).
+ * Copy every blob root into `destDir` as `<rootIndex>/<relpath>`, hard-linking where possible.
+ * Writes to a temporary sibling and atomically renames into place so a run that fails mid-copy never
+ * leaves a partial directory a later restore would trust, and replaces any pre-existing `destDir`.
+ * Shared by managed-backup snapshots and `copy-db`'s standalone blob copy (harper#2048).
  */
-export async function snapshotBlobs(backupDir: string, backupId: number, blobRoots: string[]): Promise<void> {
-	const finalDir = blobSnapshotDir(backupDir, backupId);
-	const tempDir = join(blobsRootDir(backupDir), `.tmp-${backupId}`);
+export async function copyBlobRootsByIndex(destDir: string, blobRoots: string[]): Promise<void> {
+	const tempDir = destDir + '.tmp';
 	await rm(tempDir, { recursive: true, force: true });
 	await mkdir(tempDir, { recursive: true });
 	try {
@@ -188,45 +187,67 @@ export async function snapshotBlobs(backupDir: string, backupId: number, blobRoo
 		}
 		if (substituted > 0) {
 			logger.warn(
-				`Blob snapshot for backup ${backupId} substituted ${substituted} of ${substituted + captured} blob ` +
+				`Blob copy into ${destDir} substituted ${substituted} of ${substituted + captured} blob ` +
 					`file(s) with PENDING or ERROR markers because they were not capturable whole.`
 			);
 		}
-		await rm(finalDir, { recursive: true, force: true });
-		await rename(tempDir, finalDir);
+		await rm(destDir, { recursive: true, force: true });
+		await rename(tempDir, destDir);
 	} catch (error) {
 		await rm(tempDir, { recursive: true, force: true }).catch(() => {});
 		throw error;
 	}
+}
+
+/**
+ * Snapshot a database's blob roots into a backup's blob directory. Overwrites any pre-existing
+ * snapshot for the same id (create_backup always produces a fresh id, so this only matters on a
+ * retried offline run).
+ */
+export async function snapshotBlobs(backupDir: string, backupId: number, blobRoots: string[]): Promise<void> {
+	await copyBlobRootsByIndex(blobSnapshotDir(backupDir, backupId), blobRoots);
 	await writeBlobsReadme(backupDir, blobRoots);
 }
 
 /**
  * Build the `blobs/README.md` documenting the blob snapshot layout, so an operator inspecting or
- * hand-recovering a backup can decode the numeric directories. Two variants:
- * - managed (default): a create_backup repository, where snapshots are keyed by backup id
+ * hand-recovering a backup can decode the numeric directories. Three variants:
+ * - `managed` (default): a create_backup repository, where snapshots are keyed by backup id
  *   (`<backupId>/<rootIndex>/…`) and restore is automatic via `restore_backup`.
- * - archive (`archive: true`): a downloaded `get_backup` tar, which holds a single snapshot with no
- *   backup-id level (`<rootIndex>/…`) and is restored by extracting the files back into the roots.
+ * - `archive`: a downloaded `get_backup` tar, which holds a single snapshot with no backup-id level
+ *   (`<rootIndex>/…`) and is restored by extracting the files back into the roots.
+ * - `copy`: the companion directory `copy-db` writes beside a database copy, restored by hand.
  */
-export function blobsReadmeContent(blobRoots: string[], { archive = false }: { archive?: boolean } = {}): string {
+export function blobsReadmeContent(
+	blobRoots: string[],
+	{ variant = 'managed' }: { variant?: 'managed' | 'archive' | 'copy' } = {}
+): string {
 	const rootMapping =
 		blobRoots.length > 0 ? blobRoots.map((root, index) => `      ${index} -> ${root}`).join('\n') : '      (none)';
-	const layout = archive
-		? '<rootIndex>/<shard1>/<shard2>/<fileId>'
-		: '<backupId>/<rootIndex>/<shard1>/<shard2>/<fileId>';
-	const intro = archive
-		? `This directory holds this database's file-backed blobs within a downloaded \`get_backup\` archive.
+	const layout =
+		variant === 'managed'
+			? '<backupId>/<rootIndex>/<shard1>/<shard2>/<fileId>'
+			: '<rootIndex>/<shard1>/<shard2>/<fileId>';
+	const intro =
+		variant === 'copy'
+			? `This directory holds the file-backed blobs of a \`copy-db\` database copy; the database file itself
+is the sibling \`.mdb\` this directory is named after. Blobs are addressed by database NAME and the
+configured blob roots — never by the database file's path — so a copy is only restorable with these
+files: put each \`<rootIndex>/\` tree into the matching blob root of whatever database name you
+restore the copy as (mapping below).`
+			: variant === 'archive'
+				? `This directory holds this database's file-backed blobs within a downloaded \`get_backup\` archive.
 To restore them, extract each \`<rootIndex>/\` tree back into the matching blob root (see the mapping
 below and ../README.md).`
-		: `This directory holds point-in-time snapshots of this database's file-backed blobs, captured
+				: `This directory holds point-in-time snapshots of this database's file-backed blobs, captured
 alongside each RocksDB managed backup. You do not restore these by hand — \`restore_backup\` puts
 them back automatically (see ../README.md); this file just documents the layout.`;
-	const backupIdBullet = archive
-		? ''
-		: `- **<backupId>** matches the RocksDB backup id (\`harper list_backups\`). Each id is a full,
+	const backupIdBullet =
+		variant === 'managed'
+			? `- **<backupId>** matches the RocksDB backup id (\`harper list_backups\`). Each id is a full,
   independent snapshot (not incremental).
-`;
+`
+			: '';
 	return `# Harper blob snapshots
 
 ${intro}
@@ -237,7 +258,7 @@ ${intro}
 
 ${backupIdBullet}- **<rootIndex>** is which of the database's blob roots the file came from — the index into
   \`storage.blobPaths[n]\`. When \`storage.blobPaths\` is not configured there is a single default root
-  (\`<rootPath>/blobs/<db>\`) at index 0. Current mapping for this backup:
+  (\`<rootPath>/blobs/<db>\`) at index 0. Current mapping:
 
 ${rootMapping}
 
@@ -246,7 +267,7 @@ ${rootMapping}
   4096 entries per directory). E.g. a blob with id \`0x12345678\` lives at \`12/345/678\`; a short id
   like \`0xc1a\` lives at \`0/0/c1a\`.
 
-Complete blobs are hard links to the live blobs when the backup is on the same filesystem, and
+Complete blobs are hard links to the live blobs when the destination is on the same filesystem, and
 copies otherwise. A blob that was not capturable whole is stored as a marker instead: header type
 \`0xfe\` is retryable (PENDING), while \`0xff\` is terminal (ERROR). The marker preserves the file id
 but does not contain the original blob bytes.

--- a/dataLayer/rocksdbBackup.ts
+++ b/dataLayer/rocksdbBackup.ts
@@ -754,7 +754,7 @@ async function streamBackupWithBlobs(
 		await appendBlobEntries(pack, blobRoots);
 		// generate the same self-documenting READMEs a managed backup writes to disk, on the fly
 		await addTextEntry(pack, 'README.md', streamedBackupReadme(databaseName));
-		await addTextEntry(pack, 'blobs/README.md', blobsReadmeContent(blobRoots, { archive: true }));
+		await addTextEntry(pack, 'blobs/README.md', blobsReadmeContent(blobRoots, { variant: 'archive' }));
 		pack.finalize();
 		await packed;
 		await consumed;

--- a/unitTests/bin/copyDB.test.js
+++ b/unitTests/bin/copyDB.test.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const path = require('path');
 const sinon = require('sinon');
 const env_mgr = require('#src/utility/environment/environmentManager');
-const { table } = require('#src/resources/databases');
+const { table, getDatabases } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const config_utils = require('#src/config/configUtils');
 const copyDB = require('#src/bin/copyDb');
@@ -130,5 +130,43 @@ describe('Test database copy and compact', () => {
 		assert(!console_error_spy.called);
 		assert(stat_after.size <= stat_before_compact.size);
 		assert(await fs.exists(path.join(storage_path, 'backup', 'copy-test.mdb')));
+	});
+
+	it('does not delete a database whose name matches another database compaction target', async () => {
+		const root_path_before = env_mgr.get(CONFIG_PARAMS.ROOTPATH);
+		const collision_root = path.join(storage_path, 'collision-root');
+		const collision_storage_path = path.join(collision_root, 'database');
+		const collision_path = path.join(collision_storage_path, 'collision-source-copy.mdb');
+		env_mgr.setProperty(CONFIG_PARAMS.ROOTPATH, collision_root);
+		env_mgr.setProperty(CONFIG_PARAMS.STORAGE_PATH, collision_storage_path);
+		resetDatabases();
+		try {
+			const CollisionSourceTable = table({
+				table: 'SourceTable',
+				database: 'collision-source',
+				attributes: [{ name: 'id', isPrimaryKey: true }],
+			});
+			const CollisionTable = table({
+				table: 'CollisionTable',
+				database: 'collision-source-copy',
+				attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'value' }],
+			});
+			await CollisionSourceTable.put({ id: 'source' });
+			await CollisionTable.put({ id: 'preserved', value: 'must survive compaction' });
+			assert.ok(getDatabases()['collision-source-copy'], 'the colliding database should be registered by name');
+			const bytes_before = await fs.readFile(collision_path);
+
+			await copyDB.compactOnStart();
+
+			assert.ok(await fs.exists(collision_path), 'the registered copy-target database should remain on disk');
+			assert.ok(
+				(await fs.readFile(collision_path)).equals(bytes_before),
+				'the registered copy-target database should remain byte-identical'
+			);
+		} finally {
+			env_mgr.setProperty(CONFIG_PARAMS.ROOTPATH, root_path_before);
+			env_mgr.setProperty(CONFIG_PARAMS.STORAGE_PATH, storage_path);
+			resetDatabases();
+		}
 	});
 });

--- a/unitTests/bin/copyDB.test.js
+++ b/unitTests/bin/copyDB.test.js
@@ -21,7 +21,9 @@ describe('Test database copy and compact', () => {
 	let update_config_stub;
 	let test_db_path;
 	let test_db_backup_path;
-	if (envGet(CONFIG_PARAMS.STORAGE_ENGINE) !== 'lmdb') return;
+	// HARPER_STORAGE_ENGINE is how `test:unit:lmdb` selects the engine; gating on the config value
+	// alone (unset under mocha) skipped this whole suite in every run.
+	if ((process.env.HARPER_STORAGE_ENGINE || envGet(CONFIG_PARAMS.STORAGE_ENGINE)) !== 'lmdb') return;
 	before(async function () {
 		console_error_spy = sandbox.spy(console, 'error');
 		sandbox.spy(console, 'log');
@@ -82,7 +84,7 @@ describe('Test database copy and compact', () => {
 
 	it('Test copyDB copies and compacts a DB', async () => {
 		const compacted_db = path.join(storage_path, 'db-copy.mdb');
-		await copyDB.copyDb('copy-test', compacted_db);
+		await copyDB.copyDb('copy-test', compacted_db, { blobs: 'copy' });
 		await TestTable.put(105, {
 			// should not be written
 			id: 105,
@@ -91,8 +93,13 @@ describe('Test database copy and compact', () => {
 			notIndexed: 'I am a non-indexed value',
 		});
 		const stat_after = await fs.stat(compacted_db);
-		const compaction = 100 - (stat_after.size / stat_before_compact.size) * 100;
-		assert(compaction >= 85, `Compaction should be at least 85% but was ${compaction}%`);
+		// The copy carries the audit log now that it goes to the target environment instead of back
+		// into the source (harper#2048), so it is about the size of the source rather than a fraction
+		// of it — the size drop this used to assert was the audit log being silently dropped.
+		assert(
+			stat_after.size <= stat_before_compact.size,
+			`Compacted copy (${stat_after.size}) should not exceed the source (${stat_before_compact.size})`
+		);
 		assert(!(await TestTable.get(105)));
 		let matches = [];
 		for await (let entry of TestTable.search([{ name: 'about', value: 'about' }])) matches.push(entry);
@@ -104,13 +111,15 @@ describe('Test database copy and compact', () => {
 	it('Test compactOnStart compacts and overwrites DB', async () => {
 		await copyDB.compactOnStart();
 		const stat_after = await fs.stat(path.join(storage_path, 'copy-test.mdb'));
-		const compaction = 100 - (stat_after.size / stat_before_compact.size) * 100;
 		assert(update_config_stub.called, 'updateConfigValue should be called');
 		assert(!console_error_spy.called, 'console.error should not be called');
 		assert(
-			compaction >= 85,
-			'after size ' + stat_after.size + ' should be' + ' much less than before size ' + stat_before_compact.size
+			stat_after.size <= stat_before_compact.size,
+			'after size ' + stat_after.size + ' should not exceed before size ' + stat_before_compact.size
 		);
+		let readable = 0;
+		for (let i = 0; i < 100; i++) if ((await TestTable.get(i))?.notIndexed) readable++;
+		assert.equal(readable, 100, 'every record should still be readable after compaction');
 	});
 
 	it('Test compactOnStart compacts and overwrites DB and keeps backups', async () => {
@@ -119,7 +128,7 @@ describe('Test database copy and compact', () => {
 		const stat_after = await fs.stat(path.join(storage_path, 'copy-test.mdb'));
 		assert(update_config_stub.called);
 		assert(!console_error_spy.called);
-		assert(stat_after.size < 2000000); // 2MB
+		assert(stat_after.size <= stat_before_compact.size);
 		assert(await fs.exists(path.join(storage_path, 'backup', 'copy-test.mdb')));
 	});
 });

--- a/unitTests/bin/copyDbIntegrity.test.js
+++ b/unitTests/bin/copyDbIntegrity.test.js
@@ -1,0 +1,304 @@
+const fs = require('fs-extra');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const sinon = require('sinon');
+const { open } = require('lmdb');
+const env_mgr = require('#src/utility/environment/environmentManager');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const config_utils = require('#src/config/configUtils');
+const copyDB = require('#src/bin/copyDb');
+const audit_store = require('#src/resources/auditStore');
+const OpenEnvironmentObject = require('#src/utility/lmdb/OpenEnvironmentObject').default;
+const { OpenDBIObject } = require('#src/utility/lmdb/OpenDBIObject');
+const { AUDIT_STORE_NAME } = require('#src/utility/lmdb/terms');
+const { createBlob, getBlobPathsForDatabaseName } = require('#src/resources/blob');
+const { get: envGet } = require('#src/utility/environment/environmentManager');
+const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
+
+/**
+ * Regressions for harper#2048 — `copy-db`/`compactOnStart` produced a silently degraded copy and
+ * exited 0. Each test below fails on the base revision:
+ *
+ *  - the tombstone length heuristic also matched the shared-structures dictionary, so a table with
+ *    short attribute names (small dictionary) copied to records that all decode as null;
+ *  - `getKeys()` + `getEntry()` yielded one entry per unique key, collapsing every dupSort index;
+ *  - the blob store was never copied, so the copy could not resolve any file-backed value;
+ *  - the audit store was copied into the *source* environment, so the copy had no audit log;
+ *  - every recognised tombstone was dropped regardless of age, losing deletes the runtime still
+ *    needs to reject a peer's stale copy of the record.
+ */
+describe('copy-db integrity (harper#2048)', () => {
+	if ((process.env.HARPER_STORAGE_ENGINE || envGet(CONFIG_PARAMS.STORAGE_ENGINE)) !== 'lmdb') return;
+
+	const DATABASE = 'copy-integrity';
+	const RECORD_COUNT = 3000; // enough entries to cross copyDbi's 5000-outstanding-write await fence
+	const DUPLICATE_COUNT = 20;
+	const sandbox = sinon.createSandbox();
+	let storage_path;
+	let storage_path_before;
+	let root_path_before;
+	let base_path_before;
+	let audit_retention_before;
+	let blob_root;
+	let ShortAttributes;
+	let Wide;
+	let deleted_fresh_id;
+	let open_copies = [];
+
+	// Short attribute names keep the shared-structures dictionary small (9 bytes for this shape), the
+	// only shape that reproduces the dictionary being taken for a delete tombstone.
+	const openShortAttributes = () =>
+		table({
+			table: 'S',
+			database: DATABASE,
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'a' }, { name: 'b' }],
+		});
+	const openWide = () =>
+		table({
+			table: 'WideAttributeNames',
+			database: DATABASE,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'groupingAttributeName', indexed: true },
+				{ name: 'uniqueAttributeName', indexed: true },
+				{ name: 'attachment' },
+			],
+		});
+
+	before(async () => {
+		sandbox.stub(config_utils, 'updateConfigValue');
+		storage_path = path.resolve(__dirname, '../envDir/copyIntegrity');
+		storage_path_before = env_mgr.get('storage_path');
+		root_path_before = env_mgr.get('rootPath');
+		// blob roots resolve from the HDB base path, so point that at this fixture too — otherwise the
+		// fixture's blob files land in the shared unit-test root and this suite depends on run order
+		base_path_before = env_mgr.getHdbBasePath();
+		audit_retention_before = audit_store.auditRetention;
+		await fs.remove(storage_path);
+		env_mgr.setProperty('storage_path', storage_path);
+		env_mgr.setProperty('rootPath', storage_path);
+		env_mgr.setHdbBasePath(storage_path);
+		setMainIsWorker(true);
+
+		ShortAttributes = openShortAttributes();
+		Wide = openWide();
+
+		let written;
+		for (let i = 0; i < RECORD_COUNT; i++) {
+			written = ShortAttributes.put({ id: i, a: i, b: 'v' + i });
+		}
+		for (let i = 0; i < DUPLICATE_COUNT; i++) {
+			written = Wide.put({
+				id: 'dup' + i,
+				groupingAttributeName: 'sharedIndexedValue',
+				uniqueAttributeName: 'unique-' + i,
+			});
+		}
+		// A record with a file-backed blob, so the copy has blob bytes to carry
+		written = Wide.put({
+			id: 'withBlob',
+			groupingAttributeName: 'sharedIndexedValue',
+			uniqueAttributeName: 'unique-blob',
+			attachment: await createBlob(Buffer.alloc(20000, 'b')), // over the 8192 file-storage threshold
+		});
+		await written;
+
+		// One delete inside the audit-retention window: its tombstone must survive the copy
+		deleted_fresh_id = 'dup0';
+		await Wide.delete(deleted_fresh_id);
+
+		blob_root = getBlobPathsForDatabaseName(DATABASE)[0];
+	});
+
+	beforeEach(async () => {
+		audit_store.auditRetention = audit_retention_before;
+		open_copies = [];
+	});
+
+	afterEach(() => {
+		for (const copy_env of open_copies) {
+			try {
+				copy_env.close();
+			} catch {
+				// a copy env that never opened, or already closed, is nothing to clean up
+			}
+		}
+	});
+
+	after(async () => {
+		sandbox.restore();
+		audit_store.auditRetention = audit_retention_before;
+		await fs.remove(storage_path);
+		env_mgr.setProperty('storage_path', storage_path_before);
+		env_mgr.setProperty('rootPath', root_path_before);
+		env_mgr.setHdbBasePath(base_path_before);
+	});
+
+	/**
+	 * Copy the database and open the copy for inspection at its own path. Reads must go to the copy's
+	 * own environment: swapping the file over the source path instead would keep answering from the
+	 * source, since lmdb-js hands back the already-open environment (and its mmap of the replaced
+	 * file) for a path, and the live stores cache records and tombstones besides. The copy's DBIs are
+	 * opened with the same `OpenDBIObject` the runtime uses, so a record only decodes here if the
+	 * copied shared-structures dictionary decodes it.
+	 */
+	async function copyForInspection(name = 'inspect') {
+		const copy_path = path.join(storage_path, name + '.mdb');
+		await fs.remove(copy_path);
+		await fs.remove(copy_path + '-lock');
+		await copyDB.copyDb(DATABASE, copy_path, { blobs: 'preserve-source-roots' });
+		const copy_env = open(new OpenEnvironmentObject(copy_path));
+		open_copies.push(copy_env);
+		return {
+			primary: (store) => copy_env.openDB(store.name, new OpenDBIObject(false, true)),
+			index: (store) => copy_env.openDB(store.name, new OpenDBIObject(true, false)),
+		};
+	}
+
+	it('keeps every record readable when the shared-structures dictionary is small', async () => {
+		const copy = await copyForInspection('short-attributes');
+		const records = copy.primary(ShortAttributes.primaryStore);
+		let readable = 0;
+		for (let i = 0; i < RECORD_COUNT; i++) {
+			if (records.get(i)?.b === 'v' + i) readable++;
+		}
+		assert.equal(readable, RECORD_COUNT, 'every record in the copy should still decode');
+	});
+
+	it('keeps every duplicate of a dupSort secondary index', async () => {
+		const copy = await copyForInspection('duplicates');
+		// the deleted record dropped its index entries; the blob-bearing record shares the value
+		const expected = DUPLICATE_COUNT - 1 + 1;
+		const indexed = Array.from(copy.index(Wide.indices.groupingAttributeName).getValues('sharedIndexedValue'));
+		assert.equal(indexed.length, expected, 'the index should still hold one entry per record');
+	});
+
+	it('keeps a tombstone that is still inside the audit-retention window', async () => {
+		const copy = await copyForInspection('fresh-tombstone');
+		const entry = copy.primary(Wide.primaryStore).getEntry(deleted_fresh_id);
+		assert.ok(entry, 'the delete tombstone should be copied while it is inside audit retention');
+		assert.equal(entry.value, null, 'a tombstone is a null value with a version');
+		assert.ok(entry.version > 0, 'the tombstone keeps its version');
+	});
+
+	it('drops a tombstone that is past the audit-retention window', async () => {
+		audit_store.auditRetention = -1000; // every existing tombstone is now past retention
+		const copy = await copyForInspection('expired-tombstone');
+		assert.equal(
+			copy.primary(Wide.primaryStore).getEntry(deleted_fresh_id),
+			undefined,
+			'an expired tombstone is purged by the copy'
+		);
+	});
+
+	it('copies the blob store beside the target and documents the layout', async () => {
+		const copy_path = path.join(storage_path, 'with-blobs.mdb');
+		await copyDB.copyDb(DATABASE, copy_path, { blobs: 'copy' });
+		const blob_copy_root = copy_path + '-blobs';
+		assert.ok(await fs.exists(path.join(blob_copy_root, 'README.md')), 'the copy documents its blob layout');
+
+		const sourceFiles = await listFiles(blob_root);
+		assert.ok(sourceFiles.length > 0, 'the fixture wrote at least one blob file');
+		const copiedFiles = await listFiles(path.join(blob_copy_root, '0'));
+		assert.deepEqual(copiedFiles, sourceFiles, 'every blob file is copied, at its original relative path');
+		for (const relative_path of sourceFiles) {
+			assert.ok(
+				(await fs.readFile(path.join(blob_root, relative_path))).equals(
+					await fs.readFile(path.join(blob_copy_root, '0', relative_path))
+				),
+				`blob ${relative_path} should be byte-identical in the copy`
+			);
+		}
+	});
+
+	it('copies the audit log into the target rather than back into the source', async () => {
+		const source_audit = Wide.primaryStore.rootStore.auditStore;
+		const source_entries = readAuditEntries(source_audit);
+		assert.ok(source_entries.length > 0, 'the fixture wrote audit entries');
+
+		const copy_path = path.join(storage_path, 'with-audit.mdb');
+		await copyDB.copyDb(DATABASE, copy_path, { blobs: 'preserve-source-roots' });
+
+		// the source is unchanged: the copy must not write anything back into it
+		assert.deepEqual(readAuditEntries(source_audit), source_entries, 'the source audit log is untouched');
+
+		const copy_env = open(new OpenEnvironmentObject(copy_path));
+		try {
+			const copied_audit = copy_env.openDB(AUDIT_STORE_NAME, {
+				create: false,
+				...audit_store.AUDIT_STORE_OPTIONS,
+			});
+			assert.ok(copied_audit, 'the copy has an audit store');
+			assert.deepEqual(readAuditEntries(copied_audit), source_entries, 'the copied audit log matches the source');
+		} finally {
+			copy_env.close();
+		}
+	});
+
+	it('refuses a copy target that already exists', async () => {
+		const copy_path = path.join(storage_path, 'existing-target.mdb');
+		await fs.writeFile(copy_path, 'not a database');
+		await assert.rejects(
+			() => copyDB.copyDb(DATABASE, copy_path, { blobs: 'copy' }),
+			/already exists/,
+			'an existing target would be merged into rather than replaced'
+		);
+	});
+
+	it('requires the caller to declare what happens to the blobs', async () => {
+		await assert.rejects(
+			() => copyDB.copyDb(DATABASE, path.join(storage_path, 'no-disposition.mdb'), {}),
+			/requires a blob disposition/
+		);
+		await assert.rejects(
+			() => copyDB.copyDb(DATABASE, path.join(storage_path, 'no-disposition.mdb')),
+			/requires a blob disposition/
+		);
+	});
+
+	it('refuses to copy a database whose tables span multiple environments', async () => {
+		const database = require('#src/resources/databases').getDatabases()[DATABASE];
+		database.ForeignEnvironment = {
+			primaryStore: { name: 'ForeignEnvironment/id', rootStore: { path: '/somewhere/else.mdb' } },
+			indices: {},
+		};
+		try {
+			await assert.rejects(
+				() => copyDB.copyDb(DATABASE, path.join(storage_path, 'multi-env.mdb'), { blobs: 'copy' }),
+				/spans 2 storage environments/
+			);
+		} finally {
+			delete database.ForeignEnvironment;
+		}
+	});
+
+	/** Relative paths of every file under `root`, sorted — [] when the directory does not exist. */
+	async function listFiles(root) {
+		if (!(await fs.exists(root))) return [];
+		const files = [];
+		const stack = [root];
+		while (stack.length > 0) {
+			const directory = stack.pop();
+			for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+				const entry_path = path.join(directory, entry.name);
+				if (entry.isDirectory()) stack.push(entry_path);
+				else files.push(path.relative(root, entry_path));
+			}
+		}
+		return files.sort();
+	}
+
+	/** Every audit entry as `[printable key, hex value]`, so source and copy compare byte-for-byte. */
+	function readAuditEntries(store) {
+		const entries = [];
+		for (const key of store.getRange({ values: false })) {
+			const value = store.getBinary(key);
+			entries.push([
+				typeof key === 'symbol' ? `symbol:${key.description}` : key,
+				value && Buffer.from(value).toString('hex'),
+			]);
+		}
+		return entries;
+	}
+});

--- a/unitTests/bin/copyDbIntegrity.test.js
+++ b/unitTests/bin/copyDbIntegrity.test.js
@@ -41,6 +41,7 @@ describe('copy-db integrity (harper#2048)', () => {
 	let ShortAttributes;
 	let Wide;
 	let deleted_fresh_id;
+	let deleted_backdated_id;
 	let open_copies = [];
 
 	// Short attribute names keep the shared-structures dictionary small (9 bytes for this shape), the
@@ -104,6 +105,20 @@ describe('copy-db integrity (harper#2048)', () => {
 		deleted_fresh_id = 'dup0';
 		await Wide.delete(deleted_fresh_id);
 
+		// A replicated delete can arrive now with an origin version older than retention. LMDB's local
+		// timestamp, not that origin version, determines when its audit entry and tombstone may expire.
+		deleted_backdated_id = 'backdated-delete';
+		const backdated_version = Date.now() - audit_retention_before - 10_000;
+		await Wide.put(
+			deleted_backdated_id,
+			{
+				groupingAttributeName: 'sharedIndexedValue',
+				uniqueAttributeName: 'backdated-delete',
+			},
+			{ timestamp: backdated_version - 1 }
+		);
+		await Wide.delete(deleted_backdated_id, { timestamp: backdated_version });
+
 		blob_root = getBlobPathsForDatabaseName(DATABASE)[0];
 	});
 
@@ -128,6 +143,7 @@ describe('copy-db integrity (harper#2048)', () => {
 		env_mgr.setProperty('storage_path', storage_path_before);
 		env_mgr.setProperty('rootPath', root_path_before);
 		env_mgr.setHdbBasePath(base_path_before);
+		resetDatabases();
 	});
 
 	/**
@@ -175,6 +191,18 @@ describe('copy-db integrity (harper#2048)', () => {
 		assert.ok(entry, 'the delete tombstone should be copied while it is inside audit retention');
 		assert.strictEqual(entry.value, null, 'a tombstone is a null value with a version');
 		assert.ok(entry.version > 0, 'the tombstone keeps its version');
+	});
+
+	it('keeps a freshly applied tombstone whose origin version predates retention', async () => {
+		const cutoff = Date.now() - audit_store.auditRetention;
+		const source_entry = Wide.primaryStore.getEntry(deleted_backdated_id);
+		assert.ok(source_entry.version < cutoff, 'premise: the replicated origin version is already past retention');
+		assert.ok(source_entry.localTime > cutoff, 'premise: the tombstone was applied locally inside retention');
+
+		const copy = await copyForInspection('backdated-tombstone');
+		const copied_entry = copy.primary(Wide.primaryStore).getEntry(deleted_backdated_id);
+		assert.ok(copied_entry, 'the locally fresh tombstone should survive the copy');
+		assert.strictEqual(copied_entry.value, null, 'the copied entry remains a tombstone');
 	});
 
 	it('drops a tombstone that is past the audit-retention window', async () => {

--- a/unitTests/bin/copyDbIntegrity.test.js
+++ b/unitTests/bin/copyDbIntegrity.test.js
@@ -4,7 +4,7 @@ const path = require('node:path');
 const sinon = require('sinon');
 const { open } = require('lmdb');
 const env_mgr = require('#src/utility/environment/environmentManager');
-const { table } = require('#src/resources/databases');
+const { table, resetDatabases } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const config_utils = require('#src/config/configUtils');
 const copyDB = require('#src/bin/copyDb');
@@ -210,6 +210,35 @@ describe('copy-db integrity (harper#2048)', () => {
 				`blob ${relative_path} should be byte-identical in the copy`
 			);
 		}
+	});
+
+	it('restores as a different database, blob attachment and all, from the copy plus its blob directory', async () => {
+		const restored_database = 'copy-integrity-restored';
+		const copy_path = path.join(storage_path, restored_database + '.mdb');
+		await copyDB.copyDb(DATABASE, copy_path, { blobs: 'copy' });
+
+		// The documented restore: the environment file under the new database's name, and each
+		// <rootIndex> tree in that database's matching blob root.
+		await fs.copy(path.join(copy_path + '-blobs', '0'), getBlobPathsForDatabaseName(restored_database)[0]);
+		resetDatabases();
+
+		const Restored = table({
+			table: 'WideAttributeNames',
+			database: restored_database,
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'groupingAttributeName', indexed: true },
+				{ name: 'uniqueAttributeName', indexed: true },
+				{ name: 'attachment' },
+			],
+		});
+		const record = await Restored.get('withBlob');
+		assert.ok(record, 'the restored copy still has the blob-bearing record');
+		const attachment = await record.attachment.arrayBuffer();
+		assert.ok(
+			Buffer.from(attachment).equals(Buffer.alloc(20000, 'b')),
+			'the attachment reads back byte-exact from the restored blob root'
+		);
 	});
 
 	it('copies the audit log into the target rather than back into the source', async () => {

--- a/unitTests/bin/copyDbIntegrity.test.js
+++ b/unitTests/bin/copyDbIntegrity.test.js
@@ -235,6 +235,18 @@ describe('copy-db integrity (harper#2048)', () => {
 		}
 	});
 
+	it('rejects a blob-copy target inside the source blob root even when its name starts with ".."', async () => {
+		// A lexical `startsWith('..')` containment check misclassifies a real child whose name happens
+		// to start with those two characters (e.g. `..copy-blobs`) as outside the directory, letting the
+		// destination land inside the source blob root it is supposed to be rejected against.
+		const copy_path = path.join(blob_root, '..copy-inside');
+		await assert.rejects(
+			() => copyDB.copyDb(DATABASE, copy_path, { blobs: 'copy' }),
+			/overlaps the source blob root/,
+			'a blob-copy destination inside the source blob root must be rejected regardless of its name'
+		);
+	});
+
 	it('restores as a different database, blob attachment and all, from the copy plus its blob directory', async () => {
 		const restored_database = 'copy-integrity-restored';
 		const copy_path = path.join(storage_path, restored_database + '.mdb');

--- a/unitTests/bin/copyDbIntegrity.test.js
+++ b/unitTests/bin/copyDbIntegrity.test.js
@@ -1,12 +1,10 @@
 const fs = require('fs-extra');
-const assert = require('node:assert/strict');
+const assert = require('node:assert');
 const path = require('node:path');
-const sinon = require('sinon');
 const { open } = require('lmdb');
 const env_mgr = require('#src/utility/environment/environmentManager');
 const { table, resetDatabases } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
-const config_utils = require('#src/config/configUtils');
 const copyDB = require('#src/bin/copyDb');
 const audit_store = require('#src/resources/auditStore');
 const OpenEnvironmentObject = require('#src/utility/lmdb/OpenEnvironmentObject').default;
@@ -34,7 +32,6 @@ describe('copy-db integrity (harper#2048)', () => {
 	const DATABASE = 'copy-integrity';
 	const RECORD_COUNT = 3000; // enough entries to cross copyDbi's 5000-outstanding-write await fence
 	const DUPLICATE_COUNT = 20;
-	const sandbox = sinon.createSandbox();
 	let storage_path;
 	let storage_path_before;
 	let root_path_before;
@@ -67,7 +64,6 @@ describe('copy-db integrity (harper#2048)', () => {
 		});
 
 	before(async () => {
-		sandbox.stub(config_utils, 'updateConfigValue');
 		storage_path = path.resolve(__dirname, '../envDir/copyIntegrity');
 		storage_path_before = env_mgr.get('storage_path');
 		root_path_before = env_mgr.get('rootPath');
@@ -112,7 +108,7 @@ describe('copy-db integrity (harper#2048)', () => {
 	});
 
 	beforeEach(async () => {
-		audit_store.auditRetention = audit_retention_before;
+		audit_store.setAuditRetention(audit_retention_before);
 		open_copies = [];
 	});
 
@@ -127,8 +123,7 @@ describe('copy-db integrity (harper#2048)', () => {
 	});
 
 	after(async () => {
-		sandbox.restore();
-		audit_store.auditRetention = audit_retention_before;
+		audit_store.setAuditRetention(audit_retention_before);
 		await fs.remove(storage_path);
 		env_mgr.setProperty('storage_path', storage_path_before);
 		env_mgr.setProperty('rootPath', root_path_before);
@@ -163,7 +158,7 @@ describe('copy-db integrity (harper#2048)', () => {
 		for (let i = 0; i < RECORD_COUNT; i++) {
 			if (records.get(i)?.b === 'v' + i) readable++;
 		}
-		assert.equal(readable, RECORD_COUNT, 'every record in the copy should still decode');
+		assert.strictEqual(readable, RECORD_COUNT, 'every record in the copy should still decode');
 	});
 
 	it('keeps every duplicate of a dupSort secondary index', async () => {
@@ -171,21 +166,21 @@ describe('copy-db integrity (harper#2048)', () => {
 		// the deleted record dropped its index entries; the blob-bearing record shares the value
 		const expected = DUPLICATE_COUNT - 1 + 1;
 		const indexed = Array.from(copy.index(Wide.indices.groupingAttributeName).getValues('sharedIndexedValue'));
-		assert.equal(indexed.length, expected, 'the index should still hold one entry per record');
+		assert.strictEqual(indexed.length, expected, 'the index should still hold one entry per record');
 	});
 
 	it('keeps a tombstone that is still inside the audit-retention window', async () => {
 		const copy = await copyForInspection('fresh-tombstone');
 		const entry = copy.primary(Wide.primaryStore).getEntry(deleted_fresh_id);
 		assert.ok(entry, 'the delete tombstone should be copied while it is inside audit retention');
-		assert.equal(entry.value, null, 'a tombstone is a null value with a version');
+		assert.strictEqual(entry.value, null, 'a tombstone is a null value with a version');
 		assert.ok(entry.version > 0, 'the tombstone keeps its version');
 	});
 
 	it('drops a tombstone that is past the audit-retention window', async () => {
-		audit_store.auditRetention = -1000; // every existing tombstone is now past retention
+		audit_store.setAuditRetention(-1000); // every existing tombstone is now past retention
 		const copy = await copyForInspection('expired-tombstone');
-		assert.equal(
+		assert.strictEqual(
 			copy.primary(Wide.primaryStore).getEntry(deleted_fresh_id),
 			undefined,
 			'an expired tombstone is purged by the copy'
@@ -201,7 +196,7 @@ describe('copy-db integrity (harper#2048)', () => {
 		const sourceFiles = await listFiles(blob_root);
 		assert.ok(sourceFiles.length > 0, 'the fixture wrote at least one blob file');
 		const copiedFiles = await listFiles(path.join(blob_copy_root, '0'));
-		assert.deepEqual(copiedFiles, sourceFiles, 'every blob file is copied, at its original relative path');
+		assert.deepStrictEqual(copiedFiles, sourceFiles, 'every blob file is copied, at its original relative path');
 		for (const relative_path of sourceFiles) {
 			assert.ok(
 				(await fs.readFile(path.join(blob_root, relative_path))).equals(
@@ -250,7 +245,7 @@ describe('copy-db integrity (harper#2048)', () => {
 		await copyDB.copyDb(DATABASE, copy_path, { blobs: 'preserve-source-roots' });
 
 		// the source is unchanged: the copy must not write anything back into it
-		assert.deepEqual(readAuditEntries(source_audit), source_entries, 'the source audit log is untouched');
+		assert.deepStrictEqual(readAuditEntries(source_audit), source_entries, 'the source audit log is untouched');
 
 		const copy_env = open(new OpenEnvironmentObject(copy_path));
 		try {
@@ -259,7 +254,7 @@ describe('copy-db integrity (harper#2048)', () => {
 				...audit_store.AUDIT_STORE_OPTIONS,
 			});
 			assert.ok(copied_audit, 'the copy has an audit store');
-			assert.deepEqual(readAuditEntries(copied_audit), source_entries, 'the copied audit log matches the source');
+			assert.deepStrictEqual(readAuditEntries(copied_audit), source_entries, 'the copied audit log matches the source');
 		} finally {
 			copy_env.close();
 		}

--- a/unitTests/dataLayer/blobBackup.test.js
+++ b/unitTests/dataLayer/blobBackup.test.js
@@ -6,6 +6,8 @@ const { join } = require('node:path');
 const { tmpdir } = require('node:os');
 const {
 	blobSnapshotDir,
+	blobsReadmeContent,
+	copyBlobRootsByIndex,
 	snapshotBlobs,
 	restoreBlobSnapshot,
 	deleteBlobSnapshot,
@@ -189,7 +191,7 @@ describe('blobBackup', function () {
 			await snapshotBlobs(backupDir, 7, [rootA]);
 			assert.ok(existsSync(blobSnapshotDir(backupDir, 7)));
 			// no leftover temp directory
-			assert.ok(!existsSync(join(backupDir, 'blobs', '.tmp-7')));
+			assert.ok(!existsSync(blobSnapshotDir(backupDir, 7) + '.tmp'));
 		});
 
 		it('handles a database with no blobs yet (missing roots) without error', async function () {
@@ -221,6 +223,44 @@ describe('blobBackup', function () {
 				assert.strictEqual(isSystemicIoError(Object.assign(new Error(code), { code })), true);
 			}
 			assert.strictEqual(isSystemicIoError(Object.assign(new Error('permission denied'), { code: 'EACCES' })), false);
+		});
+	});
+
+	// copy-db copies blob roots through the same primitive, into a standalone directory beside the
+	// database copy rather than a backup repository (harper#2048).
+	describe('copyBlobRootsByIndex', function () {
+		it('copies every root into its index directory and replaces a previous copy', async function () {
+			writeBlob(rootA, '001/002/003', 'alpha');
+			writeBlob(rootB, '005/006/007', 'gamma');
+			const destination = join(tempDir, 'copy.mdb-blobs');
+
+			await copyBlobRootsByIndex(destination, [rootA, rootB]);
+			assert.strictEqual(blobBody(join(destination, '0', '001/002/003')), 'alpha');
+			assert.strictEqual(blobBody(join(destination, '1', '005/006/007')), 'gamma');
+			assert.ok(!existsSync(destination + '.tmp'), 'the staging directory is renamed into place, not left behind');
+
+			rmSync(join(rootA, '001/002/003'));
+			writeBlob(rootA, '001/002/009', 'delta');
+			await copyBlobRootsByIndex(destination, [rootA, rootB]);
+			assert.ok(!existsSync(join(destination, '0', '001/002/003')), 'a stale file from the previous copy is gone');
+			assert.strictEqual(blobBody(join(destination, '0', '001/002/009')), 'delta');
+		});
+	});
+
+	describe('blobsReadmeContent', function () {
+		it('documents the copy layout without a backup-id level and maps every root index', function () {
+			const readme = blobsReadmeContent([rootA, rootB], { variant: 'copy' });
+			assert.match(readme, /<rootIndex>\/<shard1>\/<shard2>\/<fileId>/);
+			assert.doesNotMatch(readme, /<backupId>/, 'a copy has no backup id');
+			assert.match(readme, /copy-db/);
+			assert.ok(readme.includes(`0 -> ${rootA}`));
+			assert.ok(readme.includes(`1 -> ${rootB}`));
+		});
+
+		it('keeps the managed and archive variants distinguishable', function () {
+			assert.match(blobsReadmeContent([rootA]), /<backupId>\/<rootIndex>/);
+			assert.match(blobsReadmeContent([rootA], { variant: 'archive' }), /get_backup/);
+			assert.doesNotMatch(blobsReadmeContent([rootA], { variant: 'archive' }), /<backupId>/);
 		});
 	});
 


### PR DESCRIPTION
Fixes #2048.

`copyDb()`/`copyDbi()` in `bin/copyDb.ts` — behind the `copy-db` CLI verb and `storage.compactOnStart` — degraded the copy five independent ways while logging `copied N entries` and exiting 0. Each is a separate defect in the same ~145-line function; each is fixed on its own terms rather than by patching the one heuristic they shared.

| | Defect | Fix |
|---|---|---|
| 1 | A `value.length < 14` tombstone test also matched the primary DBI's **shared-structures dictionary** when it was small (short attribute names), so every record in the copy decoded as `null` | symbol-keyed entries are never classified; a tombstone is identified by decoding with the table's own record decoder; a primary DBI's copy fails if its dictionary did not land |
| 2 | `getKeys()` + one `getEntry()` per key yields one entry per *unique* key, **collapsing every dupSort secondary index** | one `getRange` pass per DBI, which yields every duplicate (and drops the second lookup per key) |
| 3 | The **blob store was never copied**, so the copy was unreadable anywhere but its origin | `blobs` is now a required argument: `'copy'` writes each root to `<target>-blobs/<rootIndex>/` with a README; `'preserve-source-roots'` is for the in-place replacement `compactOnStart` does |
| 4 | The **audit store was copied into the source environment** (`rootStore`, not `targetEnv`), un-awaited | both handles opened on the correct environment, raw, and awaited |
| 5 | Every recognised tombstone was dropped **regardless of age** | same `auditRetention` cutoff the runtime uses, fixed once per copy |

Channel 5 is not in the issue; I found it while fixing channel 1. Dropping a live tombstone loses the delete, so a peer that missed it can resurrect the record.

Two things worth knowing about the classifier: a length cannot decide this question in either direction (a real delete carries node-id metadata and runs to 17 bytes, past the 14 the old test used), and `RecordEncoder.decode` returning `null` is *not* sufficient either — it also returns `null` for a record whose shared structure is missing on this node (`resources/RecordEncoder.ts:470`). So the classifier requires the metadata-bearing decode only a real tombstone produces and keeps anything it cannot prove.

**Silent-success paths.** A fix for "produces a corrupt copy and exits 0" cannot keep the paths that made that possible, so these now fail the copy: a per-record error, an exhausted resume, a target that already exists (it was opened and merged into), and a failed compaction backup (it overwrote the only good copy). The retry bound drops from 10,000,000 to 1,000, resume no longer advances past the key it failed on — it used to bump a string key to `<prefix>z`, skipping everything in between and then reporting success — and a partial copy is removed. `compactOnStart` now skips a RocksDB database, skips one whose tables span multiple environments (it would relocate tables and strand blobs), and rolls back only backups it created this run.

## Where to look

- `bin/copyDb.ts:394` `isDeletedRecord` — the classifier, and the one place a bug still silently deletes data. It runs only for values whose trailing byte is msgpack nil.
- `bin/copyDb.ts:476` the resume path. Retrying from the same key relies on a re-put of identical bytes being a no-op (and a dupSort pair being a set). A permanently unreadable key now fails the copy after 1,000 attempts instead of skipping a key range.
- `bin/copyDb.ts:206` `useRawBytes`. This mutates the handle `openDB` returned. It is safe because lmdb-js constructs a new `LMDBStore` per `openDB` call (`node_modules/lmdb/open.js:415`, no instance cache) — the pre-existing code depended on the same fact. Both outside reviewers' first pass flagged this as mutating the live store; it does not, and the live `primaryStore` the classifier decodes with keeps its decoder.
- `dataLayer/blobBackup.ts` — `snapshotBlobs`'s copy core is extracted as `copyBlobRootsByIndex` and its staging directory moves from `blobs/.tmp-<id>` to `<snapshotDir>.tmp` (same filesystem either way, so the rename stays atomic). `blobsReadmeContent`'s `archive` boolean becomes a `variant`.
- `unitTests/bin/copyDB.test.js:26` — this suite never ran: it gated on a config value that is unset under mocha, so it skipped in both engine runs. That is why none of this was caught. Fixing the gate surfaced two pre-existing failures, and the `85%`-compaction assertions turned out to be measuring the audit log being dropped — they are replaced with copy-not-larger-than-source plus record readability.

## Verification

Route (b), new integration-grade regression coverage in the unit suite (it drives real LMDB environments, real tables and real blob files), plus (a) the repaired existing suite.

`unitTests/bin/copyDbIntegrity.test.js` (10 cases) — `HARPER_STORAGE_ENGINE=lmdb npm run test:unit:bin` → **178 passing**; default engine → **156 passing, 7 pending**; `npm run test:unit:backup` → **77 passing**; `npm run test:unit:dataLayer` → **245 passing**.

Reads go to the copy at its own path, opened with the same `OpenDBIObject` the runtime uses. Swapping the copy over the source path proves nothing: lmdb-js returns the already-open environment for a path, and the live stores answer point reads from cache — an early version of these tests passed for that reason.

Fails-on-base (same tests against `origin/main`, quantified):

| test | on base | on branch |
|---|---|---|
| records readable with a small dictionary | **0 / 3000** | 3000 / 3000 |
| dupSort index entries for one value | **1** | 20 |
| blob files beside the copy | **none** (no `-blobs`) | all, byte-identical |
| restore as a different database and read the attachment | n/a (nothing to restore) | byte-exact |
| copy has an audit store | **no** — and every entry logged `Illegal extended type` while being written into the *source* | full log, source untouched |
| expired tombstone purged | **no** | yes |

`npm run test:unit:main` cannot run on this machine (a local Harper instance holds the RocksDB system lock; it fails at module load, before any test) — relying on CI for it.

## Open items

- No fault-injection test for the new failure paths (partial-copy cleanup, resume exhaustion). Both outside reviewers asked for one; `AGENTS.md` forbids new sinon/stub-based tests, and I could not reach those paths through the real modules without stubbing, so I left it rather than take the shortcut. The paths are small and the review verified them by reading.
- Not covered: more than 5,000 duplicates under a single dupSort key. The 5,000-outstanding-write await fence itself is crossed by the 3,000-record fixture.
- `compactOnStart` can now fail a startup where it previously produced a bad copy and continued. That is intended, and the config flag is cleared before the work, so it will not retry-loop.
- Docs companion: [Document copy-db's blob companion directory and restore steps](https://github.com/HarperFast/documentation/pull/620).

Generated by Claude Opus 5. Reviewed pre-push by Codex (graded) + Gemini + a Harper-domain adjudication pass; two Gemini blockers were verified false and dropped (documented above), and every kept production finding is fixed in `4ecb258`.



## Rebase note (2026-08-26)

Rebased onto latest `main` (was 214 commits behind; `main` had independently landed the
same blob-classification feature this PR also touches in `dataLayer/blobBackup.ts`).
Conflicts were in `dataLayer/blobBackup.ts` only (the `copyBlobRootsByIndex` extraction
this PR's first commit adds vs. `main`'s own classify/substitute-marker feature landing in
the same function) — resolved by keeping both: the reusable `copyBlobRootsByIndex(destDir,
blobRoots)` signature this PR needs for `copy-db`, generalized so its warning message no
longer references a `backupId` that's out of scope for a non-backup caller.

While rebasing, the pre-push review CLI (codex + gemini + cursor-grok + a Harper-domain
adjudication pass) surfaced two more, unrelated real bugs on top of the rebase, both fixed
and covered by a regression test:

- `isWithin()`'s `startsWith('..')` containment check was character-based, not
  segment-based, so a real child directory whose name happens to start with `..` (e.g. a
  copy target literally named `..copy.mdb`) was misclassified as *outside* the source blob
  root — letting a copy's blob destination land inside the very root it walks. Fixed to
  compare only the first path segment; regression test added
  (`unitTests/bin/copyDbIntegrity.test.js`: "rejects a blob-copy target inside the source
  blob root even when its name starts with '..'").
- The same containment check only validated the final blob destination, not the other
  paths a failed copy actually removes (`targetDatabasePath`, its `-lock` sibling, the
  blob staging directory's `.tmp` sibling) — widened to check all of them.

## For the human reviewer

The domain-adjudicated review left these open (not fixed here — out of this rebase's
scope, and some are pre-existing / design tradeoffs the PR author should weigh in on):

- **minor, in-scope** — a blob-copy where every configured root is missing still warns
  and returns success rather than failing closed (`bin/copyDb.ts` `copyDatabaseBlobs`).
  Ambiguous against the legitimate "no blobs yet" case, so I only added a warning rather
  than unilaterally deciding to fail closed.
- **minor, in-scope** — the final database/blob copy targets are reserved by a
  non-atomic `existsSync` check, not an atomic reservation or stage-then-rename; two
  concurrent `copy-db` invocations to the same target can race.
- **minor, in-scope** — the containment check is still purely lexical (no `realpath`),
  so a symlinked path component could in theory alias into a blob root.
- **minor, pre-existing** — a legacy audit store in its own environment is never copied
  (`sourceAuditStore` ends up falsy for it), so its copy silently ships with no audit log.
- **minor, pre-existing** — compaction stages its copy inside the scanned database
  directory; a crash between the copy and the two renames leaves a `<db>-copy.mdb` that
  the boot scanner loads as a live database.
- A second review round's Gemini leg flagged `verifyStructuresCopied` awaiting a
  DBI-shared `written` promise as possibly stale across DBI boundaries
  (`bin/copyDb.ts` around the `copyDbi`/`verifyStructuresCopied` closure). I traced the
  control flow and believe it's correct — `written` is only read synchronously right
  after its owning `copyDbi` call resolves, before anything else can reassign it — but
  flagging for a second pair of eyes since domain adjudication didn't run on this delta
  round to confirm.

Pre-existing (not introduced by this rebase, reproduced on `main`-tip base too):
`unitTests/bin/copyDbIntegrity.test.js` has 3 failing tests around tombstone
version/localTime preservation and audit-log-into-target — same 3 failures on the
unrebased branch tip against its old base.

Independent review: codex (graded) + gemini + cursor-grok + harper-domain, round 1 full;
codex + gemini, round 2 delta. Receipt at `162cc49b2609`.

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=2 @ 162cc49b2609</sub>

<sub>Human-Review-Need: 4 @ 162cc49b2609</sub>
