### PR TITLE
chore(deps): raise msgpackr floor to ^2.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
 				"minimist": "1.2.8",
 				"moment": "2.30.1",
 				"mqtt-packet": "~9.0.1",
-				"msgpackr": "^2.0.4",
+				"msgpackr": "^2.0.5",
 				"needle": "3.5.0",
 				"node-forge": "^1.3.1",
 				"node-stream-zip": "1.16.0",

--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
 		"minimist": "1.2.8",
 		"moment": "2.30.1",
 		"mqtt-packet": "~9.0.1",
-		"msgpackr": "^2.0.4",
+		"msgpackr": "^2.0.5",
 		"needle": "3.5.0",
 		"node-forge": "^1.3.1",
 		"node-stream-zip": "1.16.0",


### PR DESCRIPTION
## What

Raises the declared `msgpackr` floor in `package.json` from `^2.0.4` to `^2.0.5` (and mirrors it in `package-lock.json`'s root dependency block).

## Why

The published `harper@5.2.0` shipped an `npm-shrinkwrap.json` that pinned `msgpackr` to **2.0.4**. `main`'s `package-lock.json` already resolves **2.0.5** — it was bumped after the `v5.2.0` tag by `a264242b4` (*chore(deps): Update rocksdb-js to 2.7.0*) as an `npm install` side effect, since `^2.0.4` permits 2.0.5. So the next release cut from `main` already ships 2.0.5.

This change simply makes that intent explicit and guards against a future lock regeneration ever resolving back below 2.0.5.

## Scope

- No functional change — the resolved `node_modules/msgpackr` lock entry is unchanged (already 2.0.5).
- `npm-shrinkwrap.json` is gitignored and generated at release time from the committed `package-lock.json`, which carries the 2.0.5 resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)