### PR TITLE
fix: surface swallowed uWS startup-listen failures instead of hanging silently

### DIFF
--- a/integrationTests/database/bulk-conditional-mutation.test.ts
+++ b/integrationTests/database/bulk-conditional-mutation.test.ts
@@ -183,17 +183,29 @@ suite(
 		let client: Client;
 
 		before(async () => {
-			await setupHarperWithFixture(ctx, FIXTURE_PATH, {
-				config: {
-					threads: { count: 4 },
-					logging: { console: true, level: 'error' },
-				},
-				env: {},
-			});
-			client = createApiClient(ctx.harper);
-			// Wait until the Order table route is ready
-			await restartHttpWorkers(client, `/${TABLE}/`, 120_000);
-			log(`Harper started, seeding ${N} rows`);
+			try {
+				await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+					config: {
+						threads: { count: 4 },
+						logging: { console: true, level: 'error' },
+					},
+					env: {},
+				});
+				client = createApiClient(ctx.harper);
+				// Wait until the Order table route is ready
+				await restartHttpWorkers(client, `/${TABLE}/`, 120_000);
+				log(`Harper started, seeding ${N} rows`);
+			} catch (error) {
+				// A `before` failure cascades node:test into reporting every sibling test as a
+				// generic, contentless "test did not finish before its parent and was cancelled" —
+				// indistinguishable from 8 independent assertion failures unless a triager already
+				// knows to scroll to the bottom for the real cause. Surface it loudly, right here.
+				console.error(
+					`\n🛑 SUITE SETUP FAILED — "bulk conditional mutation [engine=${ENGINE}]": ${(error as Error)?.message ?? error}\n` +
+						`   All subtests reported below as cancelled/failed did not run; this single failure is the root cause of all of them, not independent bugs.\n`
+				);
+				throw error;
+			}
 		});
 
 		after(async () => {

--- a/integrationTests/database/bulk-conditional-mutation.test.ts
+++ b/integrationTests/database/bulk-conditional-mutation.test.ts
@@ -196,10 +196,8 @@ suite(
 				await restartHttpWorkers(client, `/${TABLE}/`, 120_000);
 				log(`Harper started, seeding ${N} rows`);
 			} catch (error) {
-				// A `before` failure cascades node:test into reporting every sibling test as a
-				// generic, contentless "test did not finish before its parent and was cancelled" —
-				// indistinguishable from 8 independent assertion failures unless a triager already
-				// knows to scroll to the bottom for the real cause. Surface it loudly, right here.
+				// node:test cascades a `before` failure into a generic, contentless "cancelled" for
+				// every sibling test; surface the real cause loudly here instead.
 				console.error(
 					`\n🛑 SUITE SETUP FAILED — "bulk conditional mutation [engine=${ENGINE}]": ${(error as Error)?.message ?? error}\n` +
 						`   All subtests reported below as cancelled/failed did not run; this single failure is the root cause of all of them, not independent bugs.\n`

--- a/integrationTests/resources/ttl-rate-limiter-concurrent.test.ts
+++ b/integrationTests/resources/ttl-rate-limiter-concurrent.test.ts
@@ -483,9 +483,14 @@ suite(
 				})
 			);
 
-			// Read final values.
+			// Read final values. Poll for a settled value rather than a single immediate read: with
+			// 10 windows × 50 hits firing at once (500 concurrent addTo calls across 4 workers), the
+			// cross-worker CRDT merge for the last few writes can still be landing when Promise.all
+			// above resolves — the exact race waitForStableGet was introduced for in leg (3) above,
+			// just at higher concurrency here. A bare get() right after the burst can read a
+			// mid-flight value and misreport it as a lost write.
 			for (const { id, acked, errs } of windowResults) {
-				const g = await get(id);
+				const g = await waitForStableGet(id);
 				if (g.status === 404) {
 					// Burst took >500ms and window expired — inconclusive for this probe.
 					windowLogs.push(`${id}: expired(404) acked=${acked} err=${errs} [skip]`);

--- a/integrationTests/resources/ttl-rate-limiter-concurrent.test.ts
+++ b/integrationTests/resources/ttl-rate-limiter-concurrent.test.ts
@@ -483,14 +483,13 @@ suite(
 				})
 			);
 
-			// Read final values. Poll for a settled value rather than a single immediate read: with
-			// 10 windows × 50 hits firing at once (500 concurrent addTo calls across 4 workers), the
-			// cross-worker CRDT merge for the last few writes can still be landing when Promise.all
-			// above resolves — the exact race waitForStableGet was introduced for in leg (3) above,
-			// just at higher concurrency here. A bare get() right after the burst can read a
-			// mid-flight value and misreport it as a lost write.
-			for (const { id, acked, errs } of windowResults) {
-				const g = await waitForStableGet(id);
+			// Poll each window for a settled value (see waitForStableGet/leg (3)) rather than a
+			// single immediate read. Concurrent, not sequential: serializing 10 polls could push
+			// later keys' reads past their own 500ms TTL and misreport a clean window as expired.
+			const settled = await Promise.all(windowResults.map(({ id }) => waitForStableGet(id)));
+			for (let i = 0; i < windowResults.length; i++) {
+				const { id, acked, errs } = windowResults[i];
+				const g = settled[i];
 				if (g.status === 404) {
 					// Burst took >500ms and window expired — inconclusive for this probe.
 					windowLogs.push(`${id}: expired(404) acked=${acked} err=${errs} [skip]`);
@@ -510,8 +509,8 @@ suite(
 				} else {
 					windowLogs.push(`${id}: status=${g.status} acked=${acked}`);
 				}
-				await del(id);
 			}
+			await Promise.all(windowResults.map(({ id }) => del(id)));
 
 			log(
 				`\n[QA-431] (5) MULTI-WORKER STRESS (${WINDOWS} windows × ${HITS_PER_WINDOW} hits, ${WORKERS} workers)\n` +

--- a/server/serverHelpers/uwsServer.ts
+++ b/server/serverHelpers/uwsServer.ts
@@ -226,11 +226,8 @@ export async function createUwsServer(options: UwsServerOptions): Promise<{ app:
 
 	await new Promise<void>((resolve, reject) => {
 		let settled = false;
-		// A healthy bind's listen()/listen_unix() callback fires near-instantly; this is a backstop
-		// against the native callback never firing at all (seen in CI as the worker's startup promise
-		// hanging indefinitely with no further output). Without this, a stuck native bind is
-		// indistinguishable from a slow-but-healthy one, and the only symptom is the *caller's*
-		// generic startup-idle-timeout firing many seconds later with no indication uWS was the cause.
+		// Backstop against the native listen callback never firing at all — without it, a stuck
+		// bind is indistinguishable from a slow one, and nothing here ever rejects.
 		const bindTimeout = setTimeout(() => {
 			if (settled) return;
 			settled = true;

--- a/server/serverHelpers/uwsServer.ts
+++ b/server/serverHelpers/uwsServer.ts
@@ -225,8 +225,26 @@ export async function createUwsServer(options: UwsServerOptions): Promise<{ app:
 	app.any('/*', withBody);
 
 	await new Promise<void>((resolve, reject) => {
-		const onListen = (listenSocket: unknown) =>
-			listenSocket ? resolve() : reject(new Error(`uWS failed to bind ${host ?? ''}:${port ?? socketPath}`));
+		let settled = false;
+		// A healthy bind's listen()/listen_unix() callback fires near-instantly; this is a backstop
+		// against the native callback never firing at all (seen in CI as the worker's startup promise
+		// hanging indefinitely with no further output). Without this, a stuck native bind is
+		// indistinguishable from a slow-but-healthy one, and the only symptom is the *caller's*
+		// generic startup-idle-timeout firing many seconds later with no indication uWS was the cause.
+		const bindTimeout = setTimeout(() => {
+			if (settled) return;
+			settled = true;
+			reject(
+				new Error(`uWS timed out waiting to bind ${host ?? ''}:${port ?? socketPath} (listen callback never fired)`)
+			);
+		}, 30_000);
+		const onListen = (listenSocket: unknown) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(bindTimeout);
+			if (listenSocket) resolve();
+			else reject(new Error(`uWS failed to bind ${host ?? ''}:${port ?? socketPath}`));
+		};
 		// uWS shares the port across workers (SO_REUSEPORT) by default, matching the Node reusePort path.
 		if (port != null) {
 			if (host) app.listen(host, port, onListen);

--- a/server/threads/socketRouter.ts
+++ b/server/threads/socketRouter.ts
@@ -81,12 +81,7 @@ export async function startHTTPThreads(threadCount = 2, dynamicThreads?: boolean
 	}
 }
 
-/**
- * Resolves once `worker` posts `child_started`, or rejects on a worker `error` or an `exit`
- * that arrives first (a pre-ready exit must reject this promise, not leave it pending forever).
- * A plain function of `worker` so it's testable against a stub EventEmitter without spawning a
- * real worker thread.
- */
+/** Resolves on `worker`'s `child_started` message; rejects on a worker `error` or a pre-ready `exit`. */
 export function createWorkerReadyPromise(worker, index) {
 	return new Promise((resolve, reject) => {
 		function cleanup() {
@@ -123,9 +118,7 @@ function startHTTPWorker(index, threadCount = 1) {
 			try {
 				await ready;
 			} catch {
-				// Already surfaced via workersReady (awaited by startHTTPThreads' Promise.all); this
-				// call's own return value is fire-and-forget from manageThreads.js, so rethrowing here
-				// would just be a second, unhandled report of the same failure.
+				// Already surfaced via workersReady; this call's own promise is fire-and-forget.
 				return;
 			}
 			workers.push(worker);

--- a/server/threads/socketRouter.ts
+++ b/server/threads/socketRouter.ts
@@ -89,15 +89,31 @@ function startHTTPWorker(index, threadCount = 1) {
 		async onStarted(worker) {
 			// note that this can be called multiple times, once when started, and again when threads are restarted
 			const ready = new Promise((resolve, reject) => {
+				function cleanup() {
+					worker.removeListener('message', onMessage);
+					worker.removeListener('error', reject);
+					worker.removeListener('exit', onExit);
+				}
 				function onMessage(message) {
 					if (message.type === 'child_started') {
-						worker.removeListener('message', onMessage);
+						cleanup();
 						resolve(worker);
 					}
+				}
+				// A worker that exits before ever posting child_started (e.g. threadServer.js's
+				// realExit(1) on a listener-startup failure) previously left this promise pending
+				// forever: manageThreads.js restarts the worker independently on 'exit', but that
+				// spawns a *new* ready promise for the new worker instance — this one, tied to the
+				// dead worker, would never resolve or reject, so Promise.all(workersReady) below
+				// would hang indefinitely even though the failure was already logged.
+				function onExit(code) {
+					cleanup();
+					reject(new Error(`Worker (index ${index}) exited with code ${code} before reporting ready`));
 				}
 
 				worker.on('message', onMessage);
 				worker.on('error', reject);
+				worker.on('exit', onExit);
 			});
 			workersReady.push(ready);
 			await ready;

--- a/server/threads/socketRouter.ts
+++ b/server/threads/socketRouter.ts
@@ -81,6 +81,36 @@ export async function startHTTPThreads(threadCount = 2, dynamicThreads?: boolean
 	}
 }
 
+/**
+ * Resolves once `worker` posts `child_started`, or rejects on a worker `error` or an `exit`
+ * that arrives first (a pre-ready exit must reject this promise, not leave it pending forever).
+ * A plain function of `worker` so it's testable against a stub EventEmitter without spawning a
+ * real worker thread.
+ */
+export function createWorkerReadyPromise(worker, index) {
+	return new Promise((resolve, reject) => {
+		function cleanup() {
+			worker.removeListener('message', onMessage);
+			worker.removeListener('error', reject);
+			worker.removeListener('exit', onExit);
+		}
+		function onMessage(message) {
+			if (message.type === 'child_started') {
+				cleanup();
+				resolve(worker);
+			}
+		}
+		function onExit(code) {
+			cleanup();
+			reject(new Error(`Worker (index ${index}) exited with code ${code} before reporting ready`));
+		}
+
+		worker.on('message', onMessage);
+		worker.on('error', reject);
+		worker.on('exit', onExit);
+	});
+}
+
 function startHTTPWorker(index, threadCount = 1) {
 	startWorker(join(__dirname, './threadServer.js'), {
 		name: hdbTerms.THREAD_TYPES.HTTP,
@@ -88,35 +118,16 @@ function startHTTPWorker(index, threadCount = 1) {
 		threadCount,
 		async onStarted(worker) {
 			// note that this can be called multiple times, once when started, and again when threads are restarted
-			const ready = new Promise((resolve, reject) => {
-				function cleanup() {
-					worker.removeListener('message', onMessage);
-					worker.removeListener('error', reject);
-					worker.removeListener('exit', onExit);
-				}
-				function onMessage(message) {
-					if (message.type === 'child_started') {
-						cleanup();
-						resolve(worker);
-					}
-				}
-				// A worker that exits before ever posting child_started (e.g. threadServer.js's
-				// realExit(1) on a listener-startup failure) previously left this promise pending
-				// forever: manageThreads.js restarts the worker independently on 'exit', but that
-				// spawns a *new* ready promise for the new worker instance — this one, tied to the
-				// dead worker, would never resolve or reject, so Promise.all(workersReady) below
-				// would hang indefinitely even though the failure was already logged.
-				function onExit(code) {
-					cleanup();
-					reject(new Error(`Worker (index ${index}) exited with code ${code} before reporting ready`));
-				}
-
-				worker.on('message', onMessage);
-				worker.on('error', reject);
-				worker.on('exit', onExit);
-			});
+			const ready = createWorkerReadyPromise(worker, index);
 			workersReady.push(ready);
-			await ready;
+			try {
+				await ready;
+			} catch {
+				// Already surfaced via workersReady (awaited by startHTTPThreads' Promise.all); this
+				// call's own return value is fire-and-forget from manageThreads.js, so rethrowing here
+				// would just be a second, unhandled report of the same failure.
+				return;
+			}
 			workers.push(worker);
 			worker.on('exit', removeWorker);
 			worker.on('shutdown', removeWorker);

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -237,10 +237,8 @@ function startServers() {
 					parentPort?.postMessage({ type: terms.ITC_EVENT_TYPES.CHILD_STARTED });
 				})
 				.catch((err) => {
-					// This promise gates whether the worker ever reports ready, so a rejection here
-					// must not fall into the process-wide 'unhandledRejection' handler above — that
-					// one is for steady-state runtime errors and silently absorbs it, leaving the
-					// worker parked forever with no further output.
+					// Must not fall into the process-wide 'unhandledRejection' handler above, which
+					// would silently absorb it and leave the worker parked forever.
 					console.error(
 						`Failed to start listening on ${threadId === 0 ? 'the main thread' : `worker ${threadId}`}`,
 						err

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -237,14 +237,10 @@ function startServers() {
 					parentPort?.postMessage({ type: terms.ITC_EVENT_TYPES.CHILD_STARTED });
 				})
 				.catch((err) => {
-					// A rejection here (e.g. a uWS app.listen()/listen_unix() callback that never
-					// resolved cleanly, or any other listener setup failure) must not be left to the
-					// process-wide 'unhandledRejection' handler above: that handler is tuned for
-					// steady-state runtime errors (log-and-continue), but this promise gates whether
-					// the worker EVER reports ready. Silently swallowing it left the worker parked
-					// forever with no further stdout/stderr — observed in CI as "Harper produced no
-					// startup output for 150000ms before reporting ready (likely hung)", a 150s idle
-					// timeout with zero diagnostic value instead of an immediate, clear cause.
+					// This promise gates whether the worker ever reports ready, so a rejection here
+					// must not fall into the process-wide 'unhandledRejection' handler above — that
+					// one is for steady-state runtime errors and silently absorbs it, leaving the
+					// worker parked forever with no further output.
 					console.error(
 						`Failed to start listening on ${threadId === 0 ? 'the main thread' : `worker ${threadId}`}`,
 						err

--- a/server/threads/threadServer.js
+++ b/server/threads/threadServer.js
@@ -225,16 +225,33 @@ function startServers() {
 			const listening = listenOnPorts();
 
 			// notify that we are now ready to start receiving requests
-			Promise.resolve(listening).then(() => {
-				if (getWorkerIndex() === 0) {
-					try {
-						startupLog(portServer);
-					} catch (err) {
-						console.error('Error displaying start-up log', err);
+			Promise.resolve(listening)
+				.then(() => {
+					if (getWorkerIndex() === 0) {
+						try {
+							startupLog(portServer);
+						} catch (err) {
+							console.error('Error displaying start-up log', err);
+						}
 					}
-				}
-				parentPort?.postMessage({ type: terms.ITC_EVENT_TYPES.CHILD_STARTED });
-			});
+					parentPort?.postMessage({ type: terms.ITC_EVENT_TYPES.CHILD_STARTED });
+				})
+				.catch((err) => {
+					// A rejection here (e.g. a uWS app.listen()/listen_unix() callback that never
+					// resolved cleanly, or any other listener setup failure) must not be left to the
+					// process-wide 'unhandledRejection' handler above: that handler is tuned for
+					// steady-state runtime errors (log-and-continue), but this promise gates whether
+					// the worker EVER reports ready. Silently swallowing it left the worker parked
+					// forever with no further stdout/stderr — observed in CI as "Harper produced no
+					// startup output for 150000ms before reporting ready (likely hung)", a 150s idle
+					// timeout with zero diagnostic value instead of an immediate, clear cause.
+					console.error(
+						`Failed to start listening on ${threadId === 0 ? 'the main thread' : `worker ${threadId}`}`,
+						err
+					);
+					harperLogger.fatal('Failed to bind server listeners during startup', err);
+					realExit(1);
+				});
 		});
 	componentsLoadedResolve(loaded);
 	// Clean up UDS files and force-close Bun server connections on unexpected exit.

--- a/unitTests/server/threads/socketRouterReadyPromise.test.js
+++ b/unitTests/server/threads/socketRouterReadyPromise.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const assert = require('node:assert');
+const { EventEmitter } = require('node:events');
+const { createWorkerReadyPromise } = require('#src/server/threads/socketRouter');
+
+/**
+ * A uWS listener-startup failure exits the worker via realExit(1) before it ever posts
+ * child_started (see threadServer.js). Without the 'exit' handling here, the parent's ready
+ * promise for that worker would stay pending forever, and Promise.all(workersReady) in
+ * startHTTPThreads() would hang even though the failure had already been logged.
+ */
+describe('socketRouter createWorkerReadyPromise', () => {
+	it('resolves when the worker posts child_started', async () => {
+		const worker = new EventEmitter();
+		const ready = createWorkerReadyPromise(worker, 0);
+		worker.emit('message', { type: 'child_started' });
+		assert.strictEqual(await ready, worker);
+	});
+
+	it('rejects if the worker exits before posting child_started', async () => {
+		const worker = new EventEmitter();
+		const ready = createWorkerReadyPromise(worker, 2);
+		worker.emit('exit', 1);
+		await assert.rejects(ready, /Worker \(index 2\) exited with code 1 before reporting ready/);
+	});
+
+	it('rejects on a worker error', async () => {
+		const worker = new EventEmitter();
+		const ready = createWorkerReadyPromise(worker, 0);
+		// createWorkerReadyPromise attaches `reject` directly as the 'error' listener; EventEmitter
+		// requires an 'error' listener to exist before emit('error', ...) or it throws synchronously.
+		ready.catch(() => {});
+		const error = new Error('boom');
+		worker.emit('error', error);
+		await assert.rejects(ready, error);
+	});
+
+	it('ignores an exit after child_started already resolved it', async () => {
+		const worker = new EventEmitter();
+		const ready = createWorkerReadyPromise(worker, 0);
+		worker.emit('message', { type: 'child_started' });
+		await ready;
+		assert.doesNotThrow(() => worker.emit('exit', 0));
+	});
+});

--- a/unitTests/server/threads/socketRouterReadyPromise.test.js
+++ b/unitTests/server/threads/socketRouterReadyPromise.test.js
@@ -4,12 +4,6 @@ const assert = require('node:assert');
 const { EventEmitter } = require('node:events');
 const { createWorkerReadyPromise } = require('#src/server/threads/socketRouter');
 
-/**
- * A uWS listener-startup failure exits the worker via realExit(1) before it ever posts
- * child_started (see threadServer.js). Without the 'exit' handling here, the parent's ready
- * promise for that worker would stay pending forever, and Promise.all(workersReady) in
- * startHTTPThreads() would hang even though the failure had already been logged.
- */
 describe('socketRouter createWorkerReadyPromise', () => {
 	it('resolves when the worker posts child_started', async () => {
 		const worker = new EventEmitter();


### PR DESCRIPTION
## What

The uWS HTTP variant of the Integration Tests workflow has been the single largest source of
red on `main`. Two distinct failure signatures recurred; this PR addresses both, differently,
per their actual cause:

**1. `bulk conditional mutation [engine=rocksdb]` — product defect, fixed.**
CI runs (31048551033, 31082467495) show the whole suite failing at once with
`Error [HarperStartupError]: Harper produced no startup output for 150000ms before reporting
ready (likely hung)`, while the 7 subtests + summary all report the generic node:test cascade
`'test did not finish before its parent and was cancelled'` — no indication of the real cause.

Root cause: a worker thread's startup-listen promise
(`server/threads/threadServer.js`'s `Promise.resolve(listening).then(...)`) had no `.catch()`.
Any rejection there — including a uWS `app.listen()`/`listen_unix()` native callback that
never fires — fell into the process-wide `unhandledRejection` handler, which is tuned for
steady-state runtime errors (log-and-continue) and silently absorbed it. The worker was left
parked forever: never posting `child_started`, never logging again — indistinguishable from a
slow-but-healthy boot until the harness's 150s idle-stdout watchdog gave up. This is a real
product gap, not CI-only: the same silent hang could happen in production.

Fixed with three changes:
- `server/serverHelpers/uwsServer.ts` — a 30s backstop around the native listen callback, so a
  bind that never calls back produces a clear rejection instead of an indefinite hang.
- `server/threads/threadServer.js` — catches that rejection explicitly, logs it, and
  `realExit(1)`s, matching the existing fatal-startup pattern in `operationsServer.ts`.
- `server/threads/socketRouter.ts` — the parent's per-worker `ready` promise (gating
  `startHTTPThreads()`) now also rejects if the worker exits before ever posting
  `child_started`. This was necessary in addition to the above: `realExit(1)` alone logs the
  failure but doesn't unblock the parent, since the existing `ready` promise only resolved on
  `child_started` or rejected on a worker `error` event — neither fires on a direct
  `process.exit()`. Without this, startup would still hang, just louder. Extracted into an
  exported `createWorkerReadyPromise(worker, index)` so the behavior has unit coverage
  (`unitTests/server/threads/socketRouterReadyPromise.test.js`) without spawning a real
  worker thread.
- `integrationTests/database/bulk-conditional-mutation.test.ts` — a loud, specific banner in
  the shared `before()`'s catch block, so any future setup failure of this kind is immediately
  attributable instead of reading as 8 independent bugs.

I could not reproduce the exact "native callback never fires" trigger locally (binds are
near-instant outside CI); confidence in the *mechanism* (the swallowed rejection) is high from
code reading and the two independent review rounds below, confidence in *why* uWS's callback
specifically stalls under CI load is unconfirmed.

**2. `QA-431 sub-second-TTL rate-limiter` leg (5) — test-determinism gap, fixed.**
CI run 31113724037 shows leg (5) (10 windows × 50 concurrent hits = 500 concurrent requests)
losing up to 24% of writes per window (`acked=50`, `stored` as low as 38), with zero
errors/rejections recorded. Not a product defect: legs (2)/(3) in the same file already
introduced `waitForStableGet()` specifically because "under CI load the CRDT-merge writes from
a concurrent burst can still be landing when a fixed wait ends, so a single read right after it
can observe a mid-flight value." Leg (5) — added in the same original commit (8dbe36e29) —
never got that treatment, and it's the one leg with 10x the concurrent load of (2)/(3)/(4),
making the race far more likely.

Fixed by reusing `waitForStableGet` for leg (5)'s reads, running all 10 polls concurrently
(not sequentially — a review round correctly flagged that serializing them could push later
keys' reads past their own 500ms TTL, turning a real "clean" window into a false "expired").
Verified 10/10 clean locally under `HARPER_UWS_HTTP=1` (could not reproduce the original race
locally — CI-load-only).

## For the human reviewer

Two real design tradeoffs surfaced by the independent review are left as open decisions rather
than resolved unilaterally in this PR:

- **decision — startup-restart-budget-bypass** — a pre-ready worker exit now fails startup
  immediately via the new `exit`-rejects-`ready` path, rather than letting
  `manageThreads.js`'s `MAX_UNEXPECTED_RESTARTS` retry and only failing once the budget is
  exhausted. The reviewer's stated concern was "a transient cold-start crash that used to
  self-heal now fails fast instead" — but by my own reading of `Promise.all(workersReady)`
  (it snapshots the array at call time; a restart's new `ready` promise for the replacement
  worker is never awaited by that snapshot), a pre-ready exit already hung forever before this
  PR regardless of whether the restart itself succeeded, so I don't think there was a working
  self-heal path to bypass. Flagging so a second pair of eyes can confirm or correct that
  reading before this is treated as settled.
- **decision — bind-failure-fatality-policy** — any non-`EADDRINUSE` listener bind failure is
  now fatal (`realExit(1)`), which is stricter than the deliberate `EADDRINUSE` carve-out at
  `threadServer.js` ("one unavailable port shouldn't stall the rest of boot"). Example: an
  optional secondary listener (e.g. MQTT on a not-yet-attached floating VIP) failing with
  `EADDRNOTAVAIL` would now take the whole node down instead of starting without it. Before
  this PR the same input silently hung forever, which was also wrong — the question is whether
  the target behavior for a non-critical listener should be "die loudly" or "log fatal and
  keep serving everything else," matching the `EADDRINUSE` policy. Left as-is (fail loudly) as
  the simplest correct behavior for the two signatures this PR actually targets; a persuasive
  case for the alternative would touch `threadServer.js`'s listener classification more
  broadly and felt out of scope here.

## Test plan

- `npm run build`, `npm run lint:required`, `npm run format:write` — clean.
- `unitTests/server/serverHelpers/uwsServer.test.js`,
  `unitTests/server/threads/threadServerListenOnPorts.test.js`,
  `unitTests/server/threads/socketRouterReadyPromise.test.js` (new) — 28/28 passing.
- `npm run test:unit:main` — 4344 passing, 1 pre-existing unrelated failure in
  `configValidator.test.js` (a domain-socket-path-length warning; untouched by this change).
- `integrationTests/database/bulk-conditional-mutation.test.ts` and
  `integrationTests/resources/ttl-rate-limiter-concurrent.test.ts` under `HARPER_UWS_HTTP=1` —
  both passing locally (8/8 and 5/5 respectively). Could not run the full `test:integration:all`
  matrix locally in this session.
- Independent review: three rounds via `prepush-review.mjs` (codex, gemini, harper-domain
  where selected). No majors survived adjudication in the two rounds domain adjudication ran;
  round 2 (`--full`, after fixing the domain-adjudicated major from round 1) reached
  `Human-Review-Need: 3`; round 3 (delta, domain leg auto-pruned as low-risk) surfaced one
  verifiably-false major (Gemini claimed the extracted helper's untyped params would fail
  `tsc` — the build is clean, and the same file already has untyped params on
  `startHTTPWorker(index, threadCount = 1)`) plus the two decision-ledger items above, already
  addressed by documenting them here rather than resolving unilaterally.

independent-review: codex+gemini+harper-domain — 3 rounds, adjudicated major fixed, minors fixed, 2 decisions carried to PR description

Refs #914

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Human-Review-Need: 4 @ 922328b3fe7a</sub>
