### PR TITLE
fix(blob): re-encode inline blobs from the copied buffer, not a stale read-buffer view

### DIFF
--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -55,7 +55,6 @@ type StorageInfo = {
 	recordId?: number;
 	contentBuffer?: any;
 	source?: Readable;
-	storageBuffer?: Buffer;
 	compress?: boolean;
 	flush?: boolean;
 	start?: number;
@@ -829,7 +828,7 @@ class FileBackedBlob extends (Blob as unknown as { new (): Blob }) implements Bl
 			storageInfoForBlob.set(slicedBlob, slicedStorageInfo);
 			if (this.size != undefined)
 				slicedBlob.size = (end == undefined ? this.size : Math.min(end, this.size)) - (start ?? 0);
-		} else if (sourceStorageInfo?.contentBuffer && !sourceStorageInfo.storageBuffer) {
+		} else if (sourceStorageInfo?.contentBuffer) {
 			const slicedStorageInfo = {
 				...sourceStorageInfo,
 				contentBuffer: sourceStorageInfo.contentBuffer.subarray(start, end),
@@ -1740,10 +1739,14 @@ addExtension({
 				throw new Error('No store specified, cannot load blob from storage');
 			}
 		} else {
+			// contentBuffer is a *copy* (copyingUnpacker uses copyBuffers), so it stays valid for the
+			// lifetime of the blob. Do not retain the raw ext-body `buffer` here: it is a view into the
+			// store's read buffer, which is recycled by later reads. Keeping it and re-emitting it on
+			// re-encode (e.g. a read-modify-write / REST PATCH) serialized whatever foreign bytes had
+			// since overwritten that buffer, corrupting the record (harper#2103).
 			storageInfoForBlob.set(blob, {
 				storageIndex: 0,
 				fileId: null,
-				storageBuffer: buffer as any,
 				contentBuffer: blobInfo[1] as any,
 			});
 			blob.size = blobInfo[1]?.length;
@@ -1764,9 +1767,6 @@ addExtension({
 		if (blob.type) options.type = blob.type;
 		if (blob.size !== undefined) options.size = blob.size;
 		if (storageInfo) {
-			if (storageInfo.storageBuffer) {
-				return storageInfo.storageBuffer;
-			}
 			if (
 				storageInfo.contentBuffer &&
 				(storageInfo.contentBuffer?.length < FILE_STORAGE_THRESHOLD || blob.saveInRecord)

--- a/unitTests/resources/recordCacheStableBuffer.test.js
+++ b/unitTests/resources/recordCacheStableBuffer.test.js
@@ -1,0 +1,109 @@
+const { setupTestDBPath } = require('../testUtils');
+const assert = require('node:assert');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+
+// Reproduction for the Blob-column decode corruption ("Data read, but end of buffer not reached", or
+// a record coming back with foreign bytes) reported against Harper 5.2.0.
+//
+// Mechanism: an inline Blob decoded from a cache/VT-enabled primary store keeps `storageBuffer` as a
+// VIEW into the read buffer (not a copy). A read-modify-write — the shape of a REST PATCH — fetches
+// the record, carries the unchanged Blob field, and re-puts it; the Blob re-encodes straight from
+// `storageBuffer`. If any read in between reuses that buffer, the re-put serializes stale/foreign
+// bytes. A pure-decode canary never sees this because the clobber is on the re-ENCODE.
+describe('record cache: blob decode across put / read / read-other / re-put / read', () => {
+	let T;
+	before(async function () {
+		this.timeout(20000);
+		setupTestDBPath();
+		setMainIsWorker(true);
+		T = table({
+			table: 'BlobSeqRepro',
+			database: 'packages',
+			attributes: [
+				{ name: 'path', isPrimaryKey: true },
+				{ name: 'name', type: 'String', indexed: true },
+				{ name: 'packageJson', type: 'Blob' },
+			],
+		});
+	});
+
+	async function readBlobText(id) {
+		const record = await T.get(id);
+		if (record == null) return null;
+		return record.packageJson == null ? null : record.packageJson.text();
+	}
+
+	// Control: re-putting a brand-new Blob value (not the fetched one) round-trips fine, even with an
+	// interleaved read of another key. This is the sequence our earlier tests exercised — it passes.
+	it('re-put with a NEW blob value round-trips (control)', async function () {
+		this.timeout(30000);
+		const A = '/node_modules/ctl-a/package.json';
+		const B = '/node_modules/ctl-b/package.json';
+		await T.put({ path: B, name: 'b', packageJson: JSON.stringify({ pkg: 'B', pad: 'B'.repeat(64) }) });
+
+		for (let i = 1; i <= 25; i++) {
+			const aV1 = JSON.stringify({ pkg: 'A', v: i, pad: 'a'.repeat(i) });
+			const aV2 = JSON.stringify({ pkg: 'A', v: i, pad: 'z'.repeat(i) });
+			await T.put({ path: A, name: 'a', packageJson: aV1 });
+			assert.strictEqual(await readBlobText(A), aV1, `read-after-put A @${i}`);
+			await readBlobText(B); // read another key
+			await T.put({ path: A, name: 'a', packageJson: aV2 }); // re-put a NEW value
+			assert.strictEqual(await readBlobText(A), aV2, `final read A @${i}`);
+		}
+	});
+
+	// Control: read-modify-write (carry the fetched Blob back into a re-put) with NO interleaved read.
+	// If this fails too, re-encoding a fetched inline blob is broken unconditionally; if it passes,
+	// the corruption specifically needs the buffer to be reused between fetch and re-put.
+	it('read-modify-write with NO interleaved read (isolates buffer reuse)', async function () {
+		this.timeout(30000);
+		const A = '/node_modules/rmw0-a/package.json';
+
+		let failures = 0;
+		let firstErr;
+		for (let i = 1; i <= 25; i++) {
+			const aVal = JSON.stringify({ pkg: 'A', v: i, pad: 'a'.repeat(i) });
+			try {
+				await T.put({ path: A, name: 'a', packageJson: aVal });
+				const recA = await T.get(A); // fetch (blob carries storageBuffer view)
+				await T.put({ path: A, name: 'a-v2', packageJson: recA.packageJson }); // re-put fetched blob
+				assert.strictEqual(await readBlobText(A), aVal, `@${i} got corrupted without interleave`);
+			} catch (e) {
+				failures++;
+				if (!firstErr) firstErr = `@${i}: ${e.message}`;
+			}
+		}
+		assert.strictEqual(failures, 0, `corruption without interleave on ${failures}/25 — first: ${firstErr}`);
+	});
+
+	// Regression guard (harper#2103): read-modify-write (PATCH shape) with an interleaved read that
+	// reuses the buffer. Before the fix this corrupted A on 25/25 cycles (the re-put re-emitted the
+	// blob's stale storageBuffer view); after the fix the re-put re-encodes from the copied
+	// contentBuffer and A round-trips.
+	it('read-modify-write WITH interleaved read does not corrupt the re-put', async function () {
+		this.timeout(30000);
+		const A = '/node_modules/rmw-a/package.json';
+		const B = '/node_modules/rmw-b/package.json';
+
+		let failures = 0;
+		let firstErr;
+		for (let i = 1; i <= 25; i++) {
+			const aVal = JSON.stringify({ pkg: 'A', v: i, pad: 'a'.repeat(i) });
+			const bVal = JSON.stringify({ pkg: 'B', v: i, pad: 'b'.repeat(200 + i) });
+			try {
+				await T.put({ path: B, name: 'b', packageJson: bVal });
+				await T.put({ path: A, name: 'a', packageJson: aVal }); // put A
+				const recA = await T.get(A); // read A — hold fetched record + its blob
+				await readBlobText(B); // read another key — reuses the buffer backing A's storageBuffer
+				await T.put({ path: A, name: 'a-v2', packageJson: recA.packageJson }); // re-put A carrying its blob
+				const got = await readBlobText(A); // read A
+				assert.strictEqual(got, aVal, `@${i} A blob corrupted after re-put: got ${String(got).slice(0, 80)}`);
+			} catch (e) {
+				failures++;
+				if (!firstErr) firstErr = `@${i}: ${e.message}`;
+			}
+		}
+		assert.strictEqual(failures, 0, `re-put corruption on ${failures}/25 cycles — first: ${firstErr}`);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the Harper 5.2.0 Blob-column decode corruption (`Error decoding record: Data read, but end of buffer not reached`) at its **root cause**, superseding [#2103 — fix(storage): stable read buffer for cached RocksDB reads (Blob-column decode corruption)](https://github.com/HarperFast/harper/pull/2103).

When a small blob is decoded inline, `blob.ts` kept two references to the payload:

- `contentBuffer` — a **copy** (`copyingUnpacker` uses `copyBuffers: true`), stable for the blob's lifetime
- `storageBuffer` — the raw msgpack ext-body, a **view into the store's read buffer**, not copied

`pack()` had a fast-path that re-emitted `storageBuffer` verbatim on re-encode. The read buffer is recycled by later reads, so a **read-modify-write** — the shape of a REST `PATCH` (fetch the record, carry the unchanged `Blob` field, put it back) — serialized whatever foreign bytes had since overwritten that buffer. The record on disk was corrupted, and the next read failed to decode.

## Fix

Drop `storageBuffer` entirely and let `pack()` fall through to the existing `contentBuffer` re-encode path. `contentBuffer` is already a stable copy, so this is correct with **no read-path allocation cost**.

## Why this supersedes #2103

@kriszyp was right. His instrumentation found no mid-decode clobber because the corruption is on the re-**encode** of a fetched/cached blob, not during decode — a decode-path canary can't observe it. #2103's `needsStableBuffer` masked the corruption by forcing every primary-store read to allocate a fresh buffer (so the view was never recycled), which fixed the symptom at a per-read cost. This change fixes the actual defect in Harper's blob layer instead.

## Reproduction (deterministic)

`unitTests/resources/recordCacheStableBuffer.test.js` builds a 3-case matrix on a cache/VT-enabled table with a `Blob` column:

| sequence | before fix |
|---|---|
| re-put a **new** blob value (interleaved read) | passes |
| RMW carrying the fetched blob, **no** interleaved read | passes |
| RMW carrying the fetched blob **+ interleaved read of another key** | **fails 25/25** |

The third case is the bug; the corrupted bytes even contained the record's own primary-key string, confirming the buffer had been overwritten before re-encode. All three pass after the fix; the full blob suite (63 tests) is green.

## Bonus

`slice()` on an inline blob previously threw (it was gated off by `storageBuffer`'s presence); it now works via the `contentBuffer` branch.

## Why it worked in 5.1.26 but broke in 5.2.0
The blob code didn't change. `storageBuffer: buffer` and the `pack` fast-path that re-emits it are byte-identical in `v5.1.26` and `v5.2.0` (both landed in "the big lift", Oct 2025). So the blob's habit of retaining a view into the read buffer and re-serializing it on re-encode is a long-standing latent bug. What changed is the read path underneath it, which went from handing back stable buffers to recycled ones.

Two things changed in 5.2.0's primary storage, both verified:

1. `PrimaryRocksDatabase` is brand-new in 5.2.0 (absent in 5.1.26). It added the `WeakLRUCache` record cache + the VerificationTable read path (`populateVersion` / `expectedVersion` / `FRESH_VERSION_FLAG`). 5.1.26's primary read path (`handleLocalTimeForGets`) had no cache — every get decoded fresh and returned; nothing was retained across reads.
2. rocksdb-js bumped `~2.4.1` → `^2.5.0` (now 2.7.1 installed).

The mechanism, from the rocksdb-js read path `index.cjs:590`: the primary `RecordEncoder` never sets `needsStableBuffer`, so the store is marked `decoderCopies = true`, and `get()` routes through `getBinaryFast` — a reusable buffer "only valid until the next get operation." Combined with the new cache retaining decoded records (blobs and all) across reads:

* `get(A)` decodes A; the cache keeps A's record, whose blob's `storageBuffer` is a view into the reusable buffer.
* a later read of another key recycles that buffer.
* a REST PATCH (read-modify-write) re-encodes A's carried-over blob → serializes the now-foreign bytes → the next read fails to decode.

In 5.1.26 there was nothing to retain a stale view: each `get` re-decoded from a buffer holding that record's own current bytes, so the re-encode always saw valid bytes. That's also why `cache: false` fixes it — it drops the retention/VT path, so every read re-decodes fresh and the window closes.

Confidence: high on the architecture (blob-identical, `PrimaryRocksDatabase`/cache/VT new, `decoderCopies`→`getBinaryFast` reusable buffer, `cache:false` fix all verified). The one inferred link is that rocksdb-js 2.4.x returned stable buffers where 2.5+ reuses them — I didn't run 2.4.x. But it doesn't change the fix or the conclusion: 5.2.0's new cache/VT read path activated a latent blob bug, and re-encoding from the copied `contentBuffer` is the correct place to close it regardless of how the buffer underneath behaves.