### PR TITLE
fix(sql-engine): honor SELECT TOP n and floor fractional LIMIT/OFFSET

### DIFF
--- a/sqlEngine/parser/normalizer.ts
+++ b/sqlEngine/parser/normalizer.ts
@@ -156,8 +156,18 @@ function normalizeSelect(stmt: AlaSqlNode): SelectNode {
 
 	const where = stmt.where ? normalizeExpr(extractWhere(stmt.where as AlaSqlNode)) : undefined;
 	const orderBy = stmt.order ? (stmt.order as AlaSqlNode[]).map(normalizeSort) : undefined;
-	const limit = readNumValue(stmt.limit as AlaSqlNode | undefined);
-	const offset = readNumValue(stmt.offset as AlaSqlNode | undefined);
+	// `SELECT TOP n` is AlaSQL's SQL-Server spelling of `LIMIT n`. Without this the
+	// normalizer dropped `stmt.top` entirely, so `new`/`auto` mode returned *all*
+	// rows and — producing a valid plan — never fell back to legacy. The two clauses
+	// don't combine in standard SQL, so a query carrying both is ambiguous: defer it
+	// to legacy rather than silently pick one.
+	const rawLimit = readNumValue(stmt.limit as AlaSqlNode | undefined);
+	const top = readNumValue(stmt.top as AlaSqlNode | undefined);
+	if (rawLimit != null && top != null) {
+		throw new EngineUnsupportedError('TOP combined with LIMIT is not supported', stmt);
+	}
+	const limit = normalizeRowCount(rawLimit ?? top, 'LIMIT');
+	const offset = normalizeRowCount(readNumValue(stmt.offset as AlaSqlNode | undefined), 'OFFSET');
 	const distinct = !!stmt.distinct;
 
 	return {
@@ -270,6 +280,21 @@ function readNumValue(node: AlaSqlNode | undefined): number | undefined {
 	if (typeof v === 'number') return v;
 	if (typeof v === 'string') return Number(v);
 	return undefined;
+}
+
+/**
+ * Coerce a parsed LIMIT/OFFSET/TOP count to a non-negative integer. The legacy
+ * engine truncates a fractional count (`LIMIT 2.9` yields 2 rows), so we floor to
+ * match; anything non-finite or negative is deferred to the legacy engine rather
+ * than fed to PhysicalLimit, whose `>= cap` check would over-yield a fractional
+ * cap and never terminate on NaN.
+ */
+function normalizeRowCount(value: number | undefined, clause: string): number | undefined {
+	if (value == null) return undefined;
+	if (!Number.isFinite(value) || value < 0) {
+		throw new EngineUnsupportedError(`unsupported ${clause} value: ${value}`);
+	}
+	return Math.floor(value);
 }
 
 const ALASQL_BINARY_OPS: Record<string, BinaryOp> = {

--- a/sqlEngine/parser/normalizer.ts
+++ b/sqlEngine/parser/normalizer.ts
@@ -156,18 +156,20 @@ function normalizeSelect(stmt: AlaSqlNode): SelectNode {
 
 	const where = stmt.where ? normalizeExpr(extractWhere(stmt.where as AlaSqlNode)) : undefined;
 	const orderBy = stmt.order ? (stmt.order as AlaSqlNode[]).map(normalizeSort) : undefined;
-	// `SELECT TOP n` is AlaSQL's SQL-Server spelling of `LIMIT n`. Without this the
-	// normalizer dropped `stmt.top` entirely, so `new`/`auto` mode returned *all*
-	// rows and — producing a valid plan — never fell back to legacy. The two clauses
-	// don't combine in standard SQL, so a query carrying both is ambiguous: defer it
-	// to legacy rather than silently pick one.
-	const rawLimit = readNumValue(stmt.limit as AlaSqlNode | undefined);
-	const top = readNumValue(stmt.top as AlaSqlNode | undefined);
-	if (rawLimit != null && top != null) {
-		throw new EngineUnsupportedError('TOP combined with LIMIT is not supported', stmt);
+	// `SELECT TOP n` is AlaSQL's SQL-Server spelling of `LIMIT n`. The normalizer
+	// previously read neither `stmt.top` nor `stmt.percent`, so `new`/`auto` mode
+	// silently dropped TOP — returning *all* rows and, producing a valid plan, never
+	// falling back to legacy. Map TOP to the limit, but defer the spellings a plain
+	// LIMIT can't reproduce: `TOP n PERCENT` (a fraction of rows, not a count) and
+	// `TOP` combined with `LIMIT` (ambiguous — legacy lets TOP win).
+	const topNode = stmt.top as AlaSqlNode | undefined;
+	const limitNode = stmt.limit as AlaSqlNode | undefined;
+	if (topNode != null) {
+		if (stmt.percent) throw new EngineUnsupportedError('TOP … PERCENT is not supported', stmt);
+		if (limitNode != null) throw new EngineUnsupportedError('TOP combined with LIMIT is not supported', stmt);
 	}
-	const limit = normalizeRowCount(rawLimit ?? top, 'LIMIT');
-	const offset = normalizeRowCount(readNumValue(stmt.offset as AlaSqlNode | undefined), 'OFFSET');
+	const limit = readRowCount(limitNode ?? topNode, 'LIMIT', 1);
+	const offset = readRowCount(stmt.offset as AlaSqlNode | undefined, 'OFFSET', 0);
 	const distinct = !!stmt.distinct;
 
 	return {
@@ -274,27 +276,29 @@ function normalizeSort(node: AlaSqlNode): SortNode {
 	};
 }
 
-function readNumValue(node: AlaSqlNode | undefined): number | undefined {
-	if (node == null) return undefined;
-	const v = node.value;
-	if (typeof v === 'number') return v;
-	if (typeof v === 'string') return Number(v);
-	return undefined;
-}
+/** Largest row count the legacy engine handles before its 32-bit coercion diverges. */
+const MAX_ROW_COUNT = 0x7fffffff;
 
 /**
- * Coerce a parsed LIMIT/OFFSET/TOP count to a non-negative integer. The legacy
- * engine truncates a fractional count (`LIMIT 2.9` yields 2 rows), so we floor to
- * match; anything non-finite or negative is deferred to the legacy engine rather
- * than fed to PhysicalLimit, whose `>= cap` check would over-yield a fractional
- * cap and never terminate on NaN.
+ * Read a LIMIT/OFFSET/TOP clause as an integer in [min, 0x7fffffff], or undefined
+ * when the clause is absent. Values outside that window are deferred to the legacy
+ * engine instead of fed to the new one, because legacy's behavior there is a set of
+ * quirks the new engine doesn't reproduce: a limit of 0 means "no limit" (all
+ * rows), and any count >= 2^31 is coerced to 32 bits (`LIMIT 2^32` returns none).
+ * Deferring keeps `auto` mode identical to legacy. Fractional counts are floored to
+ * match legacy truncation (`LIMIT 2.9` -> 2 rows) — PhysicalLimit's `>= cap` check
+ * would otherwise over-yield a fractional cap. A present-but-unreadable clause
+ * (unreachable today — AlaSQL only accepts a numeric literal here) also defers
+ * rather than silently dropping the clause.
  */
-function normalizeRowCount(value: number | undefined, clause: string): number | undefined {
-	if (value == null) return undefined;
-	if (!Number.isFinite(value) || value < 0) {
-		throw new EngineUnsupportedError(`unsupported ${clause} value: ${value}`);
+function readRowCount(node: AlaSqlNode | undefined, clause: string, min: number): number | undefined {
+	if (node == null) return undefined;
+	const raw = node.value;
+	const value = Math.floor(typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw) : NaN);
+	if (!Number.isFinite(value) || value < min || value > MAX_ROW_COUNT) {
+		throw new EngineUnsupportedError(`unsupported ${clause} value`, node);
 	}
-	return Math.floor(value);
+	return value;
 }
 
 const ALASQL_BINARY_OPS: Record<string, BinaryOp> = {

--- a/unitTests/sqlEngine/pipeline.test.js
+++ b/unitTests/sqlEngine/pipeline.test.js
@@ -15,6 +15,7 @@ const alasql = require('alasql');
 
 const router = require('#src/sqlEngine/router');
 const binder = require('#src/sqlEngine/binder/bind');
+const { normalizeStatement } = require('#src/sqlEngine/parser/normalizer');
 const { EngineUnsupportedError } = require('#src/sqlEngine/errors');
 const { ClientError, IndexRebuildingError } = require('#src/utility/errors/hdbError');
 
@@ -400,13 +401,50 @@ describe('sqlEngine phase 1: SELECT pipeline', () => {
 		);
 	});
 
-	it('floors a fractional LIMIT to match legacy truncation', async () => {
-		// AlaSQL parses `LIMIT 2.9` as 2.9; legacy truncates to 2 rows. PhysicalLimit's
-		// `yielded >= cap` check would instead over-yield (3 rows) on a fractional cap,
-		// so the normalizer floors it.
-		const data = await runSql('SELECT name FROM dev.user WHERE age > 0 ORDER BY age LIMIT 2.9');
-		assert.strictEqual(data.length, 2);
+	it('floors a fractional LIMIT/OFFSET to match legacy truncation', async () => {
+		// AlaSQL parses `LIMIT 2.9`/`OFFSET 1.9` verbatim; legacy truncates them (2 rows,
+		// skip 1). PhysicalLimit's `yielded >= cap` check would instead over-yield (3 rows)
+		// on a fractional cap, so the normalizer floors both.
+		const data = await runSql('SELECT name FROM dev.user WHERE age > 0 ORDER BY age LIMIT 2.9 OFFSET 1.9');
+		assert.deepStrictEqual(
+			data.map((r) => r.name),
+			['alice', 'dave']
+		);
 		assert.strictEqual(mockTable._lastTarget.limit, 2);
+		assert.strictEqual(mockTable._lastTarget.offset, 1);
+	});
+
+	it('rejects TOP … PERCENT (fraction, not a count → legacy fallback)', async () => {
+		// AlaSQL sets top.value=50 and percent=true; mapping it to limit=50 would return
+		// all rows instead of 50% of them. Defer to legacy until percentage limiting exists.
+		await assert.rejects(
+			() => runSql('SELECT TOP 50 PERCENT name FROM dev.user WHERE age > 0 ORDER BY age'),
+			EngineUnsupportedError
+		);
+	});
+
+	it('rejects a LIMIT/TOP of 0 (legacy treats 0 as "no limit" → all rows)', async () => {
+		// Legacy AlaSQL returns ALL rows for `LIMIT 0`/`TOP 0`; the new engine would return
+		// none. Defer to legacy so `auto` mode stays identical.
+		await assert.rejects(() => runSql('SELECT name FROM dev.user WHERE age > 0 LIMIT 0'), EngineUnsupportedError);
+		await assert.rejects(() => runSql('SELECT TOP 0 name FROM dev.user WHERE age > 0'), EngineUnsupportedError);
+	});
+
+	it('rejects a row count past legacy 32-bit coercion (→ legacy fallback)', async () => {
+		// Legacy coerces counts >= 2^31 to 32 bits (`LIMIT 2^32` returns none, huge OFFSET
+		// wraps to 0); the new engine would apply them literally. Defer to legacy.
+		await assert.rejects(
+			() => runSql('SELECT name FROM dev.user WHERE age > 0 LIMIT 4294967296'),
+			EngineUnsupportedError
+		);
+	});
+
+	it('defers a present-but-unreadable LIMIT rather than silently dropping it', () => {
+		// Unreachable via SQL today (AlaSQL only accepts a numeric literal here), so this
+		// exercises the invariant at the AST level: a LIMIT clause that is present but not a
+		// static number must fall back, never return all rows unbounded.
+		const ast = { from: [{ databaseid: 'dev', tableid: 'user' }], columns: [{ columnid: '*' }], limit: { value: null } };
+		assert.throws(() => normalizeStatement(ast, 'select'), EngineUnsupportedError);
 	});
 
 	it('does NOT push LIMIT into the scan when a residual filter remains', async () => {

--- a/unitTests/sqlEngine/pipeline.test.js
+++ b/unitTests/sqlEngine/pipeline.test.js
@@ -443,7 +443,11 @@ describe('sqlEngine phase 1: SELECT pipeline', () => {
 		// Unreachable via SQL today (AlaSQL only accepts a numeric literal here), so this
 		// exercises the invariant at the AST level: a LIMIT clause that is present but not a
 		// static number must fall back, never return all rows unbounded.
-		const ast = { from: [{ databaseid: 'dev', tableid: 'user' }], columns: [{ columnid: '*' }], limit: { value: null } };
+		const ast = {
+			from: [{ databaseid: 'dev', tableid: 'user' }],
+			columns: [{ columnid: '*' }],
+			limit: { value: null },
+		};
 		assert.throws(() => normalizeStatement(ast, 'select'), EngineUnsupportedError);
 	});
 

--- a/unitTests/sqlEngine/pipeline.test.js
+++ b/unitTests/sqlEngine/pipeline.test.js
@@ -382,6 +382,33 @@ describe('sqlEngine phase 1: SELECT pipeline', () => {
 		assert.strictEqual(mockTable._lastTarget.offset, 1);
 	});
 
+	it('TOP n behaves like LIMIT n and pushes to Table.search', async () => {
+		// `SELECT TOP n` is AlaSQL's SQL-Server spelling of LIMIT; previously it was
+		// silently dropped, returning every row instead of n (and never falling back).
+		const data = await runSql('SELECT TOP 2 name FROM dev.user WHERE age > 0 ORDER BY age');
+		assert.deepStrictEqual(
+			data.map((r) => r.name),
+			['bob', 'alice']
+		);
+		assert.strictEqual(mockTable._lastTarget.limit, 2);
+	});
+
+	it('rejects TOP combined with LIMIT as ambiguous (→ legacy fallback)', async () => {
+		await assert.rejects(
+			() => runSql('SELECT TOP 2 name FROM dev.user WHERE age > 0 ORDER BY age LIMIT 3'),
+			EngineUnsupportedError
+		);
+	});
+
+	it('floors a fractional LIMIT to match legacy truncation', async () => {
+		// AlaSQL parses `LIMIT 2.9` as 2.9; legacy truncates to 2 rows. PhysicalLimit's
+		// `yielded >= cap` check would instead over-yield (3 rows) on a fractional cap,
+		// so the normalizer floors it.
+		const data = await runSql('SELECT name FROM dev.user WHERE age > 0 ORDER BY age LIMIT 2.9');
+		assert.strictEqual(data.length, 2);
+		assert.strictEqual(mockTable._lastTarget.limit, 2);
+	});
+
 	it('does NOT push LIMIT into the scan when a residual filter remains', async () => {
 		// `id > 0` is index-served, but `UPPER(city) = 'AUSTIN'` is a residual applied
 		// after the scan. Pushing the limit into Table.search would cap rows *before*


### PR DESCRIPTION
## Summary

The new SQL engine's normalizer read only `stmt.limit`/`stmt.offset`, so two LIMIT-family behaviors silently diverged from the legacy engine. This fixes both.

### 1. `SELECT TOP n` was silently ignored
`TOP` is AlaSQL's SQL-Server spelling of `LIMIT` and parses into `stmt.top`, which the normalizer never read. In `new`/`auto` mode the query produced a **valid** plan with no limit → it returned **every** row, and because the plan was valid it never triggered the `EngineUnsupportedError` fallback to legacy. So `SELECT TOP 5 ...` quietly returned the whole table.

Fix: `normalizeSelect` now maps `stmt.top` → `limit`. Verified against the bundled AlaSQL that legacy executes `TOP n` identically to `LIMIT n`, so the mapping preserves parity. `TOP` combined with `LIMIT` is non-standard and ambiguous (legacy lets TOP win), so that combination is rejected with `EngineUnsupportedError` and defers to legacy rather than silently picking one.

### 2. Fractional `LIMIT`/`OFFSET` over-yielded
AlaSQL parses `LIMIT 2.9` as `2.9`. Legacy truncates to **2** rows, but `PhysicalLimit`'s `yielded >= cap` check yields a **3rd** row before `3 >= 2.9` trips. New `normalizeRowCount` floors `LIMIT`/`OFFSET`/`TOP` to a non-negative integer (matching legacy truncation) and defers non-finite/negative counts to legacy.

## Why it matters
Both are silent correctness divergences under the default `sql.engine: auto` cutover — the query succeeds but returns the wrong rows, with no error and no fallback. That's the worst failure mode for the engine parity effort.

## Testing
- Added 3 unit tests to `unitTests/sqlEngine/pipeline.test.js`: `TOP n` pushes `limit` to `Table.search`, `TOP`+`LIMIT` rejects, fractional `LIMIT` floors.
- Full sqlEngine unit suite green: **99 passing** (built `dist/` first).
- Not yet run: the `sql-engine-differential` integration suite — worth adding a `TOP` case there before merge.

## Notes for reviewers
Surfaced while scoping a separate REST pagination / total-count exploration; this fix is standalone and doesn't depend on that work.

---

## Update after review (Codex + Gemini)

A cross-model review pass (Codex) plus the Gemini bot surfaced further legacy-parity gaps in the same normalize path — all now handled by deferring to legacy so `auto` mode stays byte-identical to it. Verified each against bundled AlaSQL:

| Input | Legacy behavior | Pre-fix new engine | Now |
|---|---|---|---|
| `TOP n PERCENT` | fraction of rows (`TOP 50 PERCENT` of 10 → 5) | mapped to `limit=n` → all/`n` rows | reject → legacy |
| `TOP 0` / `LIMIT 0` | `0` = "no limit" → all rows | `0` rows | reject → legacy |
| count `>= 2^31` | 32-bit coercion (`LIMIT 2^32` → none; huge `OFFSET` wraps to 0) | applied literally | reject → legacy |
| fractional `OFFSET` | truncates (`OFFSET 1.9` skips 1) | applied literally | floored |

`TOP 0` was newly exposed by the TOP fix (previously `TOP` was ignored → all rows, which happened to match legacy); `LIMIT 0` and the overflow cases were pre-existing new-engine divergences fixed here for free since `readNumValue`/`normalizeRowCount` were consolidated into one `readRowCount(node, clause, min)` that accepts `[min, 0x7fffffff]` and defers the rest.

**On the Gemini note (dynamic/`?` LIMIT expressions):** the cited forms (`LIMIT ?`, `LIMIT 1+1`, subqueries) actually **parse-error in AlaSQL** before reaching the normalizer, and legacy uses the same parser — so there was no live "silent all-rows" bug. But the underlying invariant is worth enforcing, so a present-but-unreadable clause now defers to legacy rather than dropping the limit, covered by an AST-level test. (Gemini's suggested `LIMIT ?` test would itself throw a parse `SyntaxError`, not `EngineUnsupportedError`.)

Not reachable via SQL: `TOP … OFFSET` and bare `OFFSET n` both parse-error, so the legacy "TOP ignores OFFSET" path can't be hit.

Tests: sqlEngine unit suite **103 passing** (added TOP PERCENT, `LIMIT`/`TOP 0`, overflow, fractional `OFFSET`, and the AST-level invariant guard).
