### PR TITLE
test(database): end-to-end regression coverage for copy-db's blob store (#2048)

### DIFF
--- a/integrationTests/database/copy-db-blob-store.test.ts
+++ b/integrationTests/database/copy-db-blob-store.test.ts
@@ -16,13 +16,23 @@
  * off the CI result, and surfaces the moment they start passing — at which point the marker comes
  * off and this becomes an ordinary regression anchor for the fix.
  *
+ * `{ todo }` alone isn't enough under THIS repo's runner, though: `harper-integration-test-run`
+ * (`@harperfast/integration-testing`, confirmed on published 0.7.0 and 0.7.1) sets
+ * `process.exitCode = 1` on node:test's raw `test:fail` event without checking `data.todo`, and
+ * node:test still emits that event for a failing todo test — only the summary counters and the
+ * stock CLI exit code special-case it. So a throwing `{ todo }` assertion fails this build exactly
+ * as hard as a real one. `assertContractOrDiagnose()` below is the workaround: it keeps `{ todo }`
+ * for readable output but catches the assertion itself so the test body never throws. Delete it
+ * once the runner checks `data.todo` (harper#2048 ch.3/4 fixes don't need it — only the runner bug
+ * does).
+ *
  * Scope note: #2048 also reaches `storage.compactOnStart`, but not with this consequence.
  * compactOnStart (bin/copyDb.ts:38) swaps the copy into the SAME rootPath and moves only
  * `database/{db}.mdb`, leaving `blobs/{db}/` adjacent and resolvable. Only an external target
  * loses the blobs. Asserted below so nobody "fixes" compactOnStart chasing this.
  */
 import { suite, test, before, after } from 'node:test';
-import { ok, strictEqual } from 'node:assert';
+import { ok, strictEqual, AssertionError } from 'node:assert';
 import { resolve, join } from 'node:path';
 import { readdirSync, statSync, existsSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -62,6 +72,26 @@ function filesUnder(dir: string): string[] {
 	};
 	walk(dir, '');
 	return out.sort();
+}
+
+/**
+ * `{ todo }` is the correct node:test option for "assert what should be true, don't fail CI
+ * yet" — but @harperfast/integration-testing's `harper-integration-test-run` listens to the
+ * node:test runner's raw `test:fail` event and sets `process.exitCode = 1` on it unconditionally,
+ * without checking `data.todo` (confirmed against the published 0.7.0 and 0.7.1 builds). node:test
+ * itself still emits `test:fail` for a failing todo test — only the summary counters and CLI exit
+ * code special-case it — so under that runner a `{ todo }` assertion that throws fails the build
+ * exactly as hard as a real assertion, defeating the whole point of marking it todo. Until that's
+ * fixed upstream, keep `{ todo }` for readable local/TAP output, but never let the assertion itself
+ * throw out of the test body — catch it and report it as a diagnostic instead.
+ */
+function assertContractOrDiagnose(t: { diagnostic: (message: string) => void }, assertFn: () => void) {
+	try {
+		assertFn();
+	} catch (err) {
+		if (!(err instanceof AssertionError)) throw err;
+		t.diagnostic(`[KNOWN BUG, non-blocking] ${err.message}`);
+	}
 }
 
 suite(
@@ -163,34 +193,38 @@ suite(
 		test(
 			'the copy contains the blob store',
 			{ todo: 'fails until harper#2048 channel 3 is fixed; remove this marker when it starts passing' },
-			() => {
-				const inCopy = filesUnder(copyRoot);
-				const blobFiles = inCopy.filter((f) => /blobs?\//i.test(f));
-				ok(inCopy.length > 0, 'the copy should contain the database files');
-				ok(
-					blobFiles.length >= BLOB_DOCS,
-					`copy-db produced a non-restorable copy: ${sourceBlobCount} blob file(s) in the source, ` +
-						`${blobFiles.length} in the copy. Records in the copy carry fileId references that resolve ` +
-						`to nothing, while inline attributes survive byte-exact — so the loss is partial and silent. ` +
-						`Copy tree: ${JSON.stringify(inCopy.slice(0, 20))}`
-				);
+			(t) => {
+				assertContractOrDiagnose(t, () => {
+					const inCopy = filesUnder(copyRoot);
+					const blobFiles = inCopy.filter((f) => /blobs?\//i.test(f));
+					ok(inCopy.length > 0, 'the copy should contain the database files');
+					ok(
+						blobFiles.length >= BLOB_DOCS,
+						`copy-db produced a non-restorable copy: ${sourceBlobCount} blob file(s) in the source, ` +
+							`${blobFiles.length} in the copy. Records in the copy carry fileId references that resolve ` +
+							`to nothing, while inline attributes survive byte-exact — so the loss is partial and silent. ` +
+							`Copy tree: ${JSON.stringify(inCopy.slice(0, 20))}`
+					);
+				});
 			}
 		);
 
 		test(
 			'copy-db does not report success when records fail to copy',
 			{ todo: 'fails until harper#2048 channel 4 is fixed; remove this marker when it starts passing' },
-			() => {
-				// The audit-store copy opens its target on the SOURCE rootStore (bin/copyDb.ts:223,
-				// where every other dbi uses targetEnv at :217) and is not awaited (:225 vs :220), so
-				// per-record failures are logged and the exit code stays 0.
-				const failures = (copyOut.match(/Error copying record/g) ?? []).length;
-				strictEqual(
-					failures > 0 && copyExit === 0,
-					false,
-					`copy-db logged ${failures} per-record copy failure(s) and still exited ${copyExit}. ` +
-						`A backup verb that reports success while dropping records is what turns this into data loss.`
-				);
+			(t) => {
+				assertContractOrDiagnose(t, () => {
+					// The audit-store copy opens its target on the SOURCE rootStore (bin/copyDb.ts:223,
+					// where every other dbi uses targetEnv at :217) and is not awaited (:225 vs :220), so
+					// per-record failures are logged and the exit code stays 0.
+					const failures = (copyOut.match(/Error copying record/g) ?? []).length;
+					strictEqual(
+						failures > 0 && copyExit === 0,
+						false,
+						`copy-db logged ${failures} per-record copy failure(s) and still exited ${copyExit}. ` +
+							`A backup verb that reports success while dropping records is what turns this into data loss.`
+					);
+				});
 			}
 		);
 

--- a/integrationTests/database/copy-db-blob-store.test.ts
+++ b/integrationTests/database/copy-db-blob-store.test.ts
@@ -14,17 +14,8 @@
  * txnlog-purge-stale-read-blast arm 5 sat red on main for a day (159b4bbd9). So the contract
  * tests below assert what SHOULD be true and carry `todo`, which runs them, keeps their failure
  * off the CI result, and surfaces the moment they start passing — at which point the marker comes
- * off and this becomes an ordinary regression anchor for the fix.
- *
- * `{ todo }` alone isn't enough under THIS repo's runner, though: `harper-integration-test-run`
- * (`@harperfast/integration-testing`, confirmed on published 0.7.0 and 0.7.1) sets
- * `process.exitCode = 1` on node:test's raw `test:fail` event without checking `data.todo`, and
- * node:test still emits that event for a failing todo test — only the summary counters and the
- * stock CLI exit code special-case it. So a throwing `{ todo }` assertion fails this build exactly
- * as hard as a real one. `assertContractOrDiagnose()` below is the workaround: it keeps `{ todo }`
- * for readable output but catches the assertion itself so the test body never throws. Delete it
- * once the runner checks `data.todo` (harper#2048 ch.3/4 fixes don't need it — only the runner bug
- * does).
+ * off and this becomes an ordinary regression anchor for the fix. See `assertContractOrDiagnose()`
+ * below for why `{ todo }` alone doesn't actually achieve that in this repo.
  *
  * Scope note: #2048 also reaches `storage.compactOnStart`, but not with this consequence.
  * compactOnStart (bin/copyDb.ts:38) swaps the copy into the SAME rootPath and moves only
@@ -35,6 +26,7 @@ import { suite, test, before, after } from 'node:test';
 import { ok, strictEqual, AssertionError } from 'node:assert';
 import { resolve, join } from 'node:path';
 import { readdirSync, statSync, existsSync, mkdtempSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -75,15 +67,10 @@ function filesUnder(dir: string): string[] {
 }
 
 /**
- * `{ todo }` is the correct node:test option for "assert what should be true, don't fail CI
- * yet" — but @harperfast/integration-testing's `harper-integration-test-run` listens to the
- * node:test runner's raw `test:fail` event and sets `process.exitCode = 1` on it unconditionally,
- * without checking `data.todo` (confirmed against the published 0.7.0 and 0.7.1 builds). node:test
- * itself still emits `test:fail` for a failing todo test — only the summary counters and CLI exit
- * code special-case it — so under that runner a `{ todo }` assertion that throws fails the build
- * exactly as hard as a real assertion, defeating the whole point of marking it todo. Until that's
- * fixed upstream, keep `{ todo }` for readable local/TAP output, but never let the assertion itself
- * throw out of the test body — catch it and report it as a diagnostic instead.
+ * `harper-integration-test-run` (`@harperfast/integration-testing` 0.7.0/0.7.1) sets
+ * `process.exitCode = 1` on node:test's raw `test:fail` event without checking `data.todo`, so a
+ * throwing `{ todo }` assertion still fails this build. Catch it here instead — fix upstream, then
+ * delete this.
  */
 function assertContractOrDiagnose(t: { diagnostic: (message: string) => void }, assertFn: () => void) {
 	try {
@@ -150,6 +137,7 @@ suite(
 
 		after(async () => {
 			await teardownHarper(ctx);
+			if (copyRoot) await rm(copyRoot, { recursive: true, force: true });
 		});
 
 		test('PRECONDITION: the seeded blobs are file-backed on disk', () => {
@@ -177,7 +165,9 @@ suite(
 				copyExit = 0;
 				copyOut = `${r.stdout}\n${r.stderr}`;
 			} catch (e: any) {
-				copyExit = e.code ?? 1;
+				// e.code is a signal name (string) when the child was killed (e.g. maxBuffer overrun) —
+				// normalize so downstream `copyExit === 0` comparisons don't silently pass a string.
+				copyExit = typeof e.code === 'number' ? e.code : 1;
 				copyOut = `${e.stdout ?? ''}\n${e.stderr ?? ''}`;
 			}
 
@@ -194,10 +184,12 @@ suite(
 			'the copy contains the blob store',
 			{ todo: 'fails until harper#2048 channel 3 is fixed; remove this marker when it starts passing' },
 			(t) => {
+				const inCopy = filesUnder(copyRoot);
+				// Not part of the ch.3 contract — a harness failure (e.g. copy-db never ran) must throw
+				// for real, not get swallowed as "known bug #2048" by the diagnose wrapper below.
+				ok(inCopy.length > 0, 'the copy should contain the database files');
 				assertContractOrDiagnose(t, () => {
-					const inCopy = filesUnder(copyRoot);
 					const blobFiles = inCopy.filter((f) => /blobs?\//i.test(f));
-					ok(inCopy.length > 0, 'the copy should contain the database files');
 					ok(
 						blobFiles.length >= BLOB_DOCS,
 						`copy-db produced a non-restorable copy: ${sourceBlobCount} blob file(s) in the source, ` +

--- a/integrationTests/database/copy-db-blob-store.test.ts
+++ b/integrationTests/database/copy-db-blob-store.test.ts
@@ -15,9 +15,10 @@
  * compared against the sha256 its seed call returned.
  *
  * What it does not cover: restoring under a different database name (that is
- * `unitTests/bin/copyDbIntegrity.test.js:250`), a database with more than one blob root — nothing
- * exercises `rootIndex > 0` anywhere today — and channel 4's failure path, since no per-record copy
- * failure is induced here, so only the healthy exit-0 shape is asserted.
+ * `unitTests/bin/copyDbIntegrity.test.js:250`), restoring a database with more than one blob root
+ * (`unitTests/dataLayer/blobBackup.test.js:232` copies a second root, but nothing restores one), and
+ * channel 4's failure path, since no per-record copy failure is induced here — only the healthy
+ * exit-0 shape is asserted.
  *
  * `copy-db` is LMDB-only (`copyDb` rejects a RocksDB database outright), hence the engine pin.
  * The CLI reads `ROOTPATH`, not `HARPER_ROOT_PATH`.

--- a/integrationTests/database/copy-db-blob-store.test.ts
+++ b/integrationTests/database/copy-db-blob-store.test.ts
@@ -1,40 +1,51 @@
 /**
- * `copy-db` and the blob store — harper#2048 channel 3.
+ * `copy-db` and the blob store — end-to-end regression coverage for harper#2048 (channels 3 and 4),
+ * fixed by harper#2098.
  *
- * `copyDb()` (bin/copyDb.ts:158, behind the documented `copy-db <source> <target>` CLI verb at
- * bin/harper.ts:153) walks the source environment's dbis and byte-copies each one, deliberately
- * bypassing encode/decode. That faithfully copies every record's blob `fileId` reference, but the
- * blob BYTES live outside LMDB at `{rootPath}/blobs/{db}/`, and nothing in the function visits
- * that path — so the copy contains records referencing files that exist nowhere near it.
+ * A record's blob BYTES live outside the LMDB environment, under `{rootPath}/blobs/{db}/`, and are
+ * addressed by database NAME rather than by the environment file's path. `copyDb()` (bin/copyDb.ts,
+ * behind the documented `copy-db <source> <target>` CLI verb at bin/harper.ts) byte-copies the
+ * environment's dbis, so before harper#2098 the copy carried every record's `fileId` reference and
+ * none of the files those references resolve to — a partial, silent loss, because inline attributes
+ * survived byte-exact. It also kept exit 0 through per-record copy failures.
  *
- * WHY THE CONTRACT TESTS ARE `todo` RATHER THAN ASSERTIONS OF CURRENT BEHAVIOUR.
- * The tempting version of this test asserts what happens today — "the copy contains zero blob
- * files" — which passes now and goes RED the moment #2048 is fixed, reading as a regression when
- * it is the opposite. That failure mode is not hypothetical: it is exactly why
- * txnlog-purge-stale-read-blast arm 5 sat red on main for a day (159b4bbd9). So the contract
- * tests below assert what SHOULD be true and carry `todo`, which runs them, keeps their failure
- * off the CI result, and surfaces the moment they start passing — at which point the marker comes
- * off and this becomes an ordinary regression anchor for the fix. See `assertContractOrDiagnose()`
- * below for why `{ todo }` alone doesn't actually achieve that in this repo.
+ * harper#2098's unit coverage (unitTests/bin/copyDbIntegrity.test.js) drives `copyDb()` directly;
+ * this suite is the complementary end-to-end proof through the public CLI: it seeds file-backed
+ * blobs plus inline controls over HTTP, runs `copy-db` at an external target, then performs the
+ * restore the copy's own README documents — the environment file back to `database/{db}.mdb`, each
+ * `<rootIndex>/` tree of the `<target>-blobs` companion directory back into the matching blob root —
+ * and reads every seeded record back through HTTP.
  *
- * Scope note: #2048 also reaches `storage.compactOnStart`, but not with this consequence.
- * compactOnStart (bin/copyDb.ts:38) swaps the copy into the SAME rootPath and moves only
- * `database/{db}.mdb`, leaving `blobs/{db}/` adjacent and resolvable. Only an external target
- * loses the blobs. Asserted below so nobody "fixes" compactOnStart chasing this.
+ * The read-back is the assertion that carries the contract. Counting files under a `blobs`-shaped
+ * path only proves that something landed there; it cannot tell a restorable copy from one whose
+ * records are undecodable or point at the wrong bytes. So the source environment and blob root are
+ * REMOVED before the restore (asserted gone, so the read-back cannot be answered by surviving source
+ * files), and every blob is compared against the sha256 its seed call returned.
+ *
+ * Scope note: harper#2048 also reached `storage.compactOnStart`, but not with this consequence.
+ * compactOnStart swaps the copy into the SAME rootPath and moves only `database/{db}.mdb`, leaving
+ * `blobs/{db}/` adjacent and resolvable — which is why it copies with `blobs: 'preserve-source-roots'`.
+ * Asserted below so nobody "fixes" compactOnStart chasing this.
+ *
+ * Harness note: the CLI reads `ROOTPATH` (not `HARPER_ROOT_PATH`), and an empty CLI output means it
+ * never located the database — a harness problem, asserted separately so it is never scored as a
+ * finding about `copy-db`.
  */
 import { suite, test, before, after } from 'node:test';
-import { ok, strictEqual, AssertionError } from 'node:assert';
+import { ok, strictEqual } from 'node:assert';
 import { resolve, join } from 'node:path';
 import { readdirSync, statSync, existsSync, mkdtempSync } from 'node:fs';
-import { rm } from 'node:fs/promises';
+import { rm, cp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import {
 	setupHarperWithFixture,
+	startHarper,
 	killHarper,
 	teardownHarper,
 	type ContextWithHarper,
+	type StartHarperOptions,
 } from '@harperfast/integration-testing';
 // @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
 import { createApiClient } from '../apiTests/utils/client.mjs';
@@ -43,7 +54,12 @@ const run = promisify(execFile);
 const FIXTURE_PATH = resolve(import.meta.dirname, 'copy-db-blob-store');
 const BLOB_SIZE = 256 * 1024; // comfortably above the inline threshold, so these are real files
 const BLOB_DOCS = 6;
-const INLINE_DOCS = 4; // controls: small enough to live inside the record, must survive the copy
+const INLINE_DOCS = 4; // controls: no blob attribute at all, so they survive on the environment copy alone
+const DATABASE = 'data';
+const HARPER_OPTIONS: StartHarperOptions = {
+	config: { logging: { console: true, level: 'error' } },
+	env: { HARPER_STORAGE_ENGINE: 'lmdb' }, // copy-db is the LMDB path
+};
 
 /** Every non-empty file under a tree, relative to it. Disk truth, not API truth. */
 function filesUnder(dir: string): string[] {
@@ -66,168 +82,218 @@ function filesUnder(dir: string): string[] {
 	return out.sort();
 }
 
-/**
- * `harper-integration-test-run` (`@harperfast/integration-testing` 0.7.0/0.7.1) sets
- * `process.exitCode = 1` on node:test's raw `test:fail` event without checking `data.todo`, so a
- * throwing `{ todo }` assertion still fails this build. Catch it here instead — fix upstream, then
- * delete this.
- */
-function assertContractOrDiagnose(t: { diagnostic: (message: string) => void }, assertFn: () => void) {
-	try {
-		assertFn();
-	} catch (err) {
-		if (!(err instanceof AssertionError)) throw err;
-		t.diagnostic(`[KNOWN BUG, non-blocking] ${err.message}`);
-	}
-}
+suite('copy-db and the blob store (harper#2048)', { skip: process.platform === 'win32' }, (ctx: ContextWithHarper) => {
+	let client: ReturnType<typeof createApiClient>;
+	const dbPath = () => join(ctx.harper.dataRootDir, 'database', `${DATABASE}.mdb`);
+	const blobRoot = () => join(ctx.harper.dataRootDir, 'blobs', DATABASE);
 
-suite(
-	'copy-db and the blob store (harper#2048 ch.3)',
-	{ skip: process.platform === 'win32' },
-	(ctx: ContextWithHarper) => {
-		let client: ReturnType<typeof createApiClient>;
-		let httpURL: string;
-		const blobRoot = () => join(ctx.harper.dataRootDir, 'blobs', 'data');
+	// Populated by the copy step so the later tests assert against one real invocation rather
+	// than each shelling the CLI again.
+	let copyRoot = '';
+	let copyTarget = '';
+	let copyExit: number | null = null;
+	let copyOut = '';
+	let sourceBlobCount = 0;
+	// sha256 of each seeded blob, as reported by the seeding call — the byte-exact expectation
+	// the restored read-back is compared against.
+	const seededBlobSha = new Map<string, string>();
+	const seededInlineNote = new Map<string, string>();
 
-		// Populated by the copy step so the contract tests can assert against one real invocation
-		// rather than each shelling the CLI again.
-		let copyRoot = '';
-		let copyExit: number | null = null;
-		let copyOut = '';
-		let sourceBlobCount = 0;
-
-		before(async () => {
-			await setupHarperWithFixture(ctx, FIXTURE_PATH, {
-				config: { logging: { console: true, level: 'error' } },
-				env: { HARPER_STORAGE_ENGINE: 'lmdb' }, // copy-db is the LMDB path
-			});
-			client = createApiClient(ctx.harper);
-			httpURL = ctx.harper.httpURL;
-
-			// Poll the fixture route directly until it answers; never restartHttpWorkers() against a
-			// pre-installed fixture (fire-and-forget, races the worker respawn).
-			const deadline = Date.now() + 60_000;
-			let ready = false;
-			while (Date.now() < deadline) {
-				try {
-					const probe = await client.reqRest('/Verify/?key=none').timeout(2000);
-					if (probe.status === 200) {
-						ready = true;
-						break;
-					}
-				} catch {
-					/* not up yet */
-				}
-				await new Promise((r) => setTimeout(r, 250));
-			}
-			ok(ready, 'harper did not serve /Verify/ with 200 within 60s — boot failed');
-
-			const seed = async (payload: Record<string, unknown>) => {
-				const r = await fetch(`${httpURL}/Seed/`, {
-					method: 'POST',
-					headers: { 'Authorization': client.headers.Authorization, 'content-type': 'application/json' },
-					body: JSON.stringify(payload),
-				});
-				const text = await r.text();
-				ok(r.status < 300, `seed ${JSON.stringify(payload)} expected 2xx, got ${r.status}: ${text.slice(0, 300)}`);
-			};
-			for (let i = 0; i < BLOB_DOCS; i++) await seed({ kind: 'blob', key: `blob-${i}`, size: BLOB_SIZE });
-			for (let i = 0; i < INLINE_DOCS; i++) await seed({ kind: 'inline', key: `inline-${i}` });
-		});
-
-		after(async () => {
-			await teardownHarper(ctx);
-			if (copyRoot) await rm(copyRoot, { recursive: true, force: true });
-		});
-
-		test('PRECONDITION: the seeded blobs are file-backed on disk', () => {
-			sourceBlobCount = filesUnder(blobRoot()).length;
-			ok(
-				sourceBlobCount >= BLOB_DOCS,
-				`NON-VACUOUS PRECONDITION: expected >= ${BLOB_DOCS} blob files under ${blobRoot()}, found ${sourceBlobCount}. ` +
-					`Without file-backed blobs every assertion below is vacuous.`
-			);
-		});
-
-		test('copy-db runs against the instance and produces a target', async () => {
-			const target = join(mkdtempSync(join(tmpdir(), 'copydb-')), 'data-copy.mdb');
-			copyRoot = resolve(target, '..');
-
-			await killHarper(ctx); // the CLI opens the environment itself
-			const cli = resolve(import.meta.dirname, '../../dist/bin/harper.js');
-			ok(existsSync(cli), `expected a built CLI at ${cli} — run npm run build first`);
-
+	// Poll the fixture route directly until it answers; never restartHttpWorkers() against a
+	// pre-installed fixture (fire-and-forget, races the worker respawn).
+	async function waitForFixtureRoute(label: string) {
+		client = createApiClient(ctx.harper);
+		const deadline = Date.now() + 60_000;
+		while (Date.now() < deadline) {
 			try {
-				const r = await run(process.execPath, [cli, 'copy-db', 'data', target], {
-					env: { ...process.env, ROOTPATH: ctx.harper.dataRootDir },
-					maxBuffer: 32 * 1024 * 1024,
-				});
-				copyExit = 0;
-				copyOut = `${r.stdout}\n${r.stderr}`;
-			} catch (e: any) {
-				// e.code is a signal name (string) when the child was killed (e.g. maxBuffer overrun) —
-				// normalize so downstream `copyExit === 0` comparisons don't silently pass a string.
-				copyExit = typeof e.code === 'number' ? e.code : 1;
-				copyOut = `${e.stdout ?? ''}\n${e.stderr ?? ''}`;
+				const probe = await client.reqRest('/Verify/?key=none').timeout(2000);
+				if (probe.status === 200) return;
+			} catch {
+				/* not up yet */
 			}
-
-			// Distinguish "the CLI ran and did something" from "the CLI never found the database".
-			// The latter is a harness problem and must not be reported as a finding about copy-db.
-			ok(
-				copyOut.trim().length > 0,
-				`copy-db produced no output at all — it almost certainly never located the database (harness problem, not a defect). exit=${copyExit}`
-			);
-			ok(existsSync(target), `copy-db should have produced ${target}. Output:\n${copyOut.slice(-1500)}`);
-		});
-
-		test(
-			'the copy contains the blob store',
-			{ todo: 'fails until harper#2048 channel 3 is fixed; remove this marker when it starts passing' },
-			(t) => {
-				const inCopy = filesUnder(copyRoot);
-				// Not part of the ch.3 contract — a harness failure (e.g. copy-db never ran) must throw
-				// for real, not get swallowed as "known bug #2048" by the diagnose wrapper below.
-				ok(inCopy.length > 0, 'the copy should contain the database files');
-				assertContractOrDiagnose(t, () => {
-					const blobFiles = inCopy.filter((f) => /blobs?\//i.test(f));
-					ok(
-						blobFiles.length >= BLOB_DOCS,
-						`copy-db produced a non-restorable copy: ${sourceBlobCount} blob file(s) in the source, ` +
-							`${blobFiles.length} in the copy. Records in the copy carry fileId references that resolve ` +
-							`to nothing, while inline attributes survive byte-exact — so the loss is partial and silent. ` +
-							`Copy tree: ${JSON.stringify(inCopy.slice(0, 20))}`
-					);
-				});
-			}
-		);
-
-		test(
-			'copy-db does not report success when records fail to copy',
-			{ todo: 'fails until harper#2048 channel 4 is fixed; remove this marker when it starts passing' },
-			(t) => {
-				assertContractOrDiagnose(t, () => {
-					// The audit-store copy opens its target on the SOURCE rootStore (bin/copyDb.ts:223,
-					// where every other dbi uses targetEnv at :217) and is not awaited (:225 vs :220), so
-					// per-record failures are logged and the exit code stays 0.
-					const failures = (copyOut.match(/Error copying record/g) ?? []).length;
-					strictEqual(
-						failures > 0 && copyExit === 0,
-						false,
-						`copy-db logged ${failures} per-record copy failure(s) and still exited ${copyExit}. ` +
-							`A backup verb that reports success while dropping records is what turns this into data loss.`
-					);
-				});
-			}
-		);
-
-		test('SCOPE: compactOnStart is unaffected — it leaves blobs/ adjacent in the same rootPath', () => {
-			// Recorded as an assertion rather than a comment so the distinction survives: compactOnStart
-			// moves database/{db}.mdb into backup/ and the copy into its place, both inside rootPath.
-			const stillThere = filesUnder(blobRoot()).length;
-			ok(
-				stillThere >= BLOB_DOCS,
-				`blobs/ must remain in the source rootPath — that is why the compactOnStart channel survives — found ${stillThere}`
-			);
-		});
+			await new Promise((r) => setTimeout(r, 250));
+		}
+		ok(false, `harper did not serve /Verify/ with 200 within 60s ${label} — boot failed`);
 	}
-);
+
+	async function verify(key: string) {
+		const response = await client.reqRest(`/Verify/?key=${key}`).timeout(10_000);
+		strictEqual(response.status, 200, `GET /Verify/?key=${key} => ${response.status}: ${response.text?.slice(0, 300)}`);
+		return response.body;
+	}
+
+	before(async () => {
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, HARPER_OPTIONS);
+		await waitForFixtureRoute('on first boot');
+
+		const seed = async (payload: Record<string, unknown>) => {
+			const r = await fetch(`${ctx.harper.httpURL}/Seed/`, {
+				method: 'POST',
+				headers: { 'Authorization': client.headers.Authorization, 'content-type': 'application/json' },
+				body: JSON.stringify(payload),
+			});
+			const text = await r.text();
+			ok(r.status < 300, `seed ${JSON.stringify(payload)} expected 2xx, got ${r.status}: ${text.slice(0, 300)}`);
+			return JSON.parse(text);
+		};
+		for (let i = 0; i < BLOB_DOCS; i++) {
+			const key = `blob-${i}`;
+			const seeded = await seed({ kind: 'blob', key, size: BLOB_SIZE });
+			ok(seeded.sha, `seeding ${key} returned no sha to compare the restored blob against: ${JSON.stringify(seeded)}`);
+			strictEqual(seeded.size, BLOB_SIZE, `seeding ${key} stored ${seeded.size} bytes, not the requested ${BLOB_SIZE}`);
+			seededBlobSha.set(key, seeded.sha);
+		}
+		for (let i = 0; i < INLINE_DOCS; i++) {
+			const key = `inline-${i}`;
+			const note = `inline-control-${i}`;
+			await seed({ kind: 'inline', key, note });
+			seededInlineNote.set(key, note);
+		}
+	});
+
+	after(async () => {
+		try {
+			await teardownHarper(ctx);
+		} finally {
+			if (copyRoot) await rm(copyRoot, { recursive: true, force: true });
+		}
+	});
+
+	test('PRECONDITION: the seeded blobs are file-backed on disk and read back from the source', async () => {
+		sourceBlobCount = filesUnder(blobRoot()).length;
+		ok(
+			sourceBlobCount >= BLOB_DOCS,
+			`NON-VACUOUS PRECONDITION: expected >= ${BLOB_DOCS} blob files under ${blobRoot()}, found ${sourceBlobCount}. ` +
+				`Without file-backed blobs every assertion below is vacuous.`
+		);
+		// The same read-back the restored copy is held to, run against the source first: a failure
+		// here is a seeding/fixture problem, not a copy-db one.
+		for (const [key, sha] of seededBlobSha) {
+			const record = await verify(key);
+			strictEqual(record.sha, sha, `source ${key} does not read back as seeded: ${JSON.stringify(record)}`);
+		}
+		for (const [key, note] of seededInlineNote) {
+			const record = await verify(key);
+			strictEqual(record.note, note, `source ${key} does not read back as seeded: ${JSON.stringify(record)}`);
+		}
+	});
+
+	test('copy-db runs against the instance and reports success without per-record failures', async () => {
+		copyTarget = join(mkdtempSync(join(tmpdir(), 'copydb-')), 'data-copy.mdb');
+		copyRoot = resolve(copyTarget, '..');
+
+		await killHarper(ctx); // the CLI opens the environment itself
+		const cli = resolve(import.meta.dirname, '../../dist/bin/harper.js');
+		ok(existsSync(cli), `expected a built CLI at ${cli} — run npm run build first`);
+
+		try {
+			const r = await run(process.execPath, [cli, 'copy-db', DATABASE, copyTarget], {
+				env: { ...process.env, ROOTPATH: ctx.harper.dataRootDir },
+				maxBuffer: 32 * 1024 * 1024,
+			});
+			copyExit = 0;
+			copyOut = `${r.stdout}\n${r.stderr}`;
+		} catch (e: any) {
+			// e.code is a signal name (string) when the child was killed (e.g. maxBuffer overrun) —
+			// normalize so downstream `copyExit === 0` comparisons don't silently pass a string.
+			copyExit = typeof e.code === 'number' ? e.code : 1;
+			copyOut = `${e.stdout ?? ''}\n${e.stderr ?? ''}`;
+		}
+
+		// Distinguish "the CLI ran and did something" from "the CLI never found the database".
+		// The latter is a harness problem and must not be reported as a finding about copy-db.
+		ok(
+			copyOut.trim().length > 0,
+			`copy-db produced no output at all — it almost certainly never located the database (harness problem, not a defect). exit=${copyExit}`
+		);
+		ok(existsSync(copyTarget), `copy-db should have produced ${copyTarget}. Output:\n${copyOut.slice(-1500)}`);
+
+		// harper#2048 ch.4: per-record failures were logged while the exit code stayed 0, which is
+		// what turned a degraded copy into silent data loss.
+		const recordFailures = (copyOut.match(/Error copying record/g) ?? []).length;
+		strictEqual(
+			recordFailures,
+			0,
+			`copy-db logged ${recordFailures} per-record copy failure(s). Output:\n${copyOut.slice(-1500)}`
+		);
+		strictEqual(copyExit, 0, `copy-db exited ${copyExit}. Output:\n${copyOut.slice(-1500)}`);
+	});
+
+	test('the copy carries the blob store in its companion directory', () => {
+		const blobCompanion = `${copyTarget}-blobs`;
+		ok(
+			existsSync(blobCompanion),
+			`copy-db must write the source's blob roots to ${blobCompanion}; copy tree: ${JSON.stringify(filesUnder(copyRoot).slice(0, 20))}`
+		);
+		// `<rootIndex>/<shard1>/<shard2>/<fileId>`, plus the README documenting that layout.
+		const copiedBlobs = filesUnder(blobCompanion).filter((f) => f !== 'README.md');
+		ok(
+			copiedBlobs.length >= BLOB_DOCS,
+			`copy-db produced a non-restorable copy: ${sourceBlobCount} blob file(s) in the source, ` +
+				`${copiedBlobs.length} beside the copy. Companion tree: ${JSON.stringify(copiedBlobs.slice(0, 20))}`
+		);
+	});
+
+	test('SCOPE: compactOnStart is unaffected — copy-db leaves blobs/ in the source rootPath', () => {
+		// Recorded as an assertion rather than a comment so the distinction survives: compactOnStart
+		// moves database/{db}.mdb into backup/ and the copy into its place, both inside rootPath, so
+		// the source blob roots it copies with `preserve-source-roots` have to still be there.
+		const stillThere = filesUnder(blobRoot()).length;
+		ok(
+			stillThere >= BLOB_DOCS,
+			`blobs/ must remain in the source rootPath — that is why the compactOnStart channel survives — found ${stillThere}`
+		);
+	});
+
+	test('the copy restores byte-exact: blob payloads and inline attributes read back', async () => {
+		// Checked before anything is removed: without both halves of the copy this test would tear
+		// down the source and then fail on a missing file, which reads as a restore defect.
+		ok(
+			existsSync(copyTarget) && existsSync(`${copyTarget}-blobs`),
+			`the copy step must have produced both ${copyTarget} and its -blobs companion before the restore`
+		);
+
+		// The documented restore (see the companion directory's README.md): the environment file
+		// goes back to database/{db}.mdb, and each `<rootIndex>/` tree goes back into the matching
+		// blob root of the database name the copy is restored as. Index 0 is the single default
+		// root, `<rootPath>/blobs/<db>`.
+		await rm(dbPath(), { force: true });
+		await rm(`${dbPath()}-lock`, { force: true });
+		await rm(blobRoot(), { recursive: true, force: true });
+		ok(
+			!existsSync(dbPath()) && !existsSync(blobRoot()),
+			`NON-VACUOUS PRECONDITION: the source environment and blob root must be gone before the restore, ` +
+				`or the read-back below could be answered by surviving source files rather than by the copy`
+		);
+
+		await cp(copyTarget, dbPath());
+		await cp(join(`${copyTarget}-blobs`, '0'), blobRoot(), { recursive: true });
+
+		await startHarper(ctx, HARPER_OPTIONS);
+		await waitForFixtureRoute('after restoring the copy');
+
+		for (const [key, sha] of seededBlobSha) {
+			const record = await verify(key);
+			ok(record.present, `${key} is missing from the restored copy: ${JSON.stringify(record)}`);
+			ok(record.hasPayload, `${key} restored without its blob attribute: ${JSON.stringify(record)}`);
+			strictEqual(record.size, BLOB_SIZE, `${key} restored with ${record.size} bytes: ${JSON.stringify(record)}`);
+			strictEqual(
+				record.sha,
+				sha,
+				`${key}'s blob bytes did not survive the copy: seeded sha256 ${sha}, restored ${record.sha}. ` +
+					`A copy whose fileId references resolve to the wrong bytes fails here and nowhere else.`
+			);
+		}
+		for (const [key, note] of seededInlineNote) {
+			const record = await verify(key);
+			ok(record.present, `inline control ${key} is missing from the restored copy: ${JSON.stringify(record)}`);
+			strictEqual(
+				record.hasPayload,
+				false,
+				`inline control ${key} is not inline — it has a blob attribute, so it no longer controls for the ` +
+					`"inline attributes survive while blob bytes do not" half of harper#2048: ${JSON.stringify(record)}`
+			);
+			strictEqual(record.note, note, `inline control ${key} did not survive byte-exact: ${JSON.stringify(record)}`);
+		}
+	});
+});

--- a/integrationTests/database/copy-db-blob-store.test.ts
+++ b/integrationTests/database/copy-db-blob-store.test.ts
@@ -14,8 +14,9 @@
  * gone — first, so the read-back cannot be answered by surviving source files, and each blob is
  * compared against the sha256 its seed call returned.
  *
- * What it does not cover: restoring under a different database name or with more than one blob root
- * (`unitTests/bin/copyDbIntegrity.test.js:250`), and channel 4's failure path — no per-record copy
+ * What it does not cover: restoring under a different database name (that is
+ * `unitTests/bin/copyDbIntegrity.test.js:250`), a database with more than one blob root — nothing
+ * exercises `rootIndex > 0` anywhere today — and channel 4's failure path, since no per-record copy
  * failure is induced here, so only the healthy exit-0 shape is asserted.
  *
  * `copy-db` is LMDB-only (`copyDb` rejects a RocksDB database outright), hence the engine pin.
@@ -53,8 +54,8 @@ const HARPER_OPTIONS: StartHarperOptions = {
 const SEED_TIMEOUT_MS = 60_000;
 const COPY_TIMEOUT_MS = 120_000;
 const READY_TIMEOUT_MS = 60_000;
-// Above the framework's own CI startup ceiling, so a slow boot fails with its diagnosis rather than
-// with a bare test timeout.
+// The framework's own CI startup ceiling; the budgets below add to it so a slow boot fails with
+// startHarper's diagnosis rather than with a bare test timeout.
 const BOOT_TIMEOUT_MS = 300_000;
 
 /** Every non-empty file under a tree, relative to it. Disk truth, not API truth. */
@@ -86,8 +87,6 @@ suite('copy-db and the blob store (harper#2048)', { skip: process.platform === '
 	const dbPath = () => join(ctx.harper.dataRootDir, 'database', `${DATABASE}.mdb`);
 	const blobRoot = () => join(ctx.harper.dataRootDir, 'blobs', DATABASE);
 
-	// Populated by the copy step so the later tests assert against one real invocation rather than
-	// each shelling the CLI again.
 	let copyRoot = '';
 	let copyTarget = '';
 	let copyExit: number | null = null;
@@ -238,8 +237,7 @@ suite('copy-db and the blob store (harper#2048)', { skip: process.platform === '
 			existsSync(blobCompanion),
 			`copy-db must write the source's blob roots to ${blobCompanion}; copy tree: ${JSON.stringify(filesUnder(copyRoot).slice(0, 20))}`
 		);
-		// `<rootIndex>/<shard1>/<shard2>/<fileId>`, plus the README documenting that layout — which is
-		// the only instruction an operator gets for the restore this suite performs below.
+		// The only instruction an operator gets for the restore this suite performs below.
 		ok(existsSync(join(blobCompanion, 'README.md')), `${blobCompanion} must document its layout in README.md`);
 		const copiedBlobs = filesUnder(blobCompanion).filter((f) => f !== 'README.md');
 		ok(

--- a/integrationTests/database/copy-db-blob-store.test.ts
+++ b/integrationTests/database/copy-db-blob-store.test.ts
@@ -1,0 +1,207 @@
+/**
+ * `copy-db` and the blob store — harper#2048 channel 3.
+ *
+ * `copyDb()` (bin/copyDb.ts:158, behind the documented `copy-db <source> <target>` CLI verb at
+ * bin/harper.ts:153) walks the source environment's dbis and byte-copies each one, deliberately
+ * bypassing encode/decode. That faithfully copies every record's blob `fileId` reference, but the
+ * blob BYTES live outside LMDB at `{rootPath}/blobs/{db}/`, and nothing in the function visits
+ * that path — so the copy contains records referencing files that exist nowhere near it.
+ *
+ * WHY THE CONTRACT TESTS ARE `todo` RATHER THAN ASSERTIONS OF CURRENT BEHAVIOUR.
+ * The tempting version of this test asserts what happens today — "the copy contains zero blob
+ * files" — which passes now and goes RED the moment #2048 is fixed, reading as a regression when
+ * it is the opposite. That failure mode is not hypothetical: it is exactly why
+ * txnlog-purge-stale-read-blast arm 5 sat red on main for a day (159b4bbd9). So the contract
+ * tests below assert what SHOULD be true and carry `todo`, which runs them, keeps their failure
+ * off the CI result, and surfaces the moment they start passing — at which point the marker comes
+ * off and this becomes an ordinary regression anchor for the fix.
+ *
+ * Scope note: #2048 also reaches `storage.compactOnStart`, but not with this consequence.
+ * compactOnStart (bin/copyDb.ts:38) swaps the copy into the SAME rootPath and moves only
+ * `database/{db}.mdb`, leaving `blobs/{db}/` adjacent and resolvable. Only an external target
+ * loses the blobs. Asserted below so nobody "fixes" compactOnStart chasing this.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual } from 'node:assert';
+import { resolve, join } from 'node:path';
+import { readdirSync, statSync, existsSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import {
+	setupHarperWithFixture,
+	killHarper,
+	teardownHarper,
+	type ContextWithHarper,
+} from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations; runtime resolves fine
+import { createApiClient } from '../apiTests/utils/client.mjs';
+
+const run = promisify(execFile);
+const FIXTURE_PATH = resolve(import.meta.dirname, 'copy-db-blob-store');
+const BLOB_SIZE = 256 * 1024; // comfortably above the inline threshold, so these are real files
+const BLOB_DOCS = 6;
+const INLINE_DOCS = 4; // controls: small enough to live inside the record, must survive the copy
+
+/** Every non-empty file under a tree, relative to it. Disk truth, not API truth. */
+function filesUnder(dir: string): string[] {
+	const out: string[] = [];
+	const walk = (d: string, rel: string) => {
+		let entries;
+		try {
+			entries = readdirSync(d, { withFileTypes: true });
+		} catch {
+			return;
+		}
+		for (const e of entries) {
+			const p = join(d, e.name);
+			const r = rel ? `${rel}/${e.name}` : e.name;
+			if (e.isDirectory()) walk(p, r);
+			else if (statSync(p).size > 0) out.push(r);
+		}
+	};
+	walk(dir, '');
+	return out.sort();
+}
+
+suite(
+	'copy-db and the blob store (harper#2048 ch.3)',
+	{ skip: process.platform === 'win32' },
+	(ctx: ContextWithHarper) => {
+		let client: ReturnType<typeof createApiClient>;
+		let httpURL: string;
+		const blobRoot = () => join(ctx.harper.dataRootDir, 'blobs', 'data');
+
+		// Populated by the copy step so the contract tests can assert against one real invocation
+		// rather than each shelling the CLI again.
+		let copyRoot = '';
+		let copyExit: number | null = null;
+		let copyOut = '';
+		let sourceBlobCount = 0;
+
+		before(async () => {
+			await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+				config: { logging: { console: true, level: 'error' } },
+				env: { HARPER_STORAGE_ENGINE: 'lmdb' }, // copy-db is the LMDB path
+			});
+			client = createApiClient(ctx.harper);
+			httpURL = ctx.harper.httpURL;
+
+			// Poll the fixture route directly until it answers; never restartHttpWorkers() against a
+			// pre-installed fixture (fire-and-forget, races the worker respawn).
+			const deadline = Date.now() + 60_000;
+			let ready = false;
+			while (Date.now() < deadline) {
+				try {
+					const probe = await client.reqRest('/Verify/?key=none').timeout(2000);
+					if (probe.status === 200) {
+						ready = true;
+						break;
+					}
+				} catch {
+					/* not up yet */
+				}
+				await new Promise((r) => setTimeout(r, 250));
+			}
+			ok(ready, 'harper did not serve /Verify/ with 200 within 60s — boot failed');
+
+			const seed = async (payload: Record<string, unknown>) => {
+				const r = await fetch(`${httpURL}/Seed/`, {
+					method: 'POST',
+					headers: { 'Authorization': client.headers.Authorization, 'content-type': 'application/json' },
+					body: JSON.stringify(payload),
+				});
+				const text = await r.text();
+				ok(r.status < 300, `seed ${JSON.stringify(payload)} expected 2xx, got ${r.status}: ${text.slice(0, 300)}`);
+			};
+			for (let i = 0; i < BLOB_DOCS; i++) await seed({ kind: 'blob', key: `blob-${i}`, size: BLOB_SIZE });
+			for (let i = 0; i < INLINE_DOCS; i++) await seed({ kind: 'inline', key: `inline-${i}` });
+		});
+
+		after(async () => {
+			await teardownHarper(ctx);
+		});
+
+		test('PRECONDITION: the seeded blobs are file-backed on disk', () => {
+			sourceBlobCount = filesUnder(blobRoot()).length;
+			ok(
+				sourceBlobCount >= BLOB_DOCS,
+				`NON-VACUOUS PRECONDITION: expected >= ${BLOB_DOCS} blob files under ${blobRoot()}, found ${sourceBlobCount}. ` +
+					`Without file-backed blobs every assertion below is vacuous.`
+			);
+		});
+
+		test('copy-db runs against the instance and produces a target', async () => {
+			const target = join(mkdtempSync(join(tmpdir(), 'copydb-')), 'data-copy.mdb');
+			copyRoot = resolve(target, '..');
+
+			await killHarper(ctx); // the CLI opens the environment itself
+			const cli = resolve(import.meta.dirname, '../../dist/bin/harper.js');
+			ok(existsSync(cli), `expected a built CLI at ${cli} — run npm run build first`);
+
+			try {
+				const r = await run(process.execPath, [cli, 'copy-db', 'data', target], {
+					env: { ...process.env, ROOTPATH: ctx.harper.dataRootDir },
+					maxBuffer: 32 * 1024 * 1024,
+				});
+				copyExit = 0;
+				copyOut = `${r.stdout}\n${r.stderr}`;
+			} catch (e: any) {
+				copyExit = e.code ?? 1;
+				copyOut = `${e.stdout ?? ''}\n${e.stderr ?? ''}`;
+			}
+
+			// Distinguish "the CLI ran and did something" from "the CLI never found the database".
+			// The latter is a harness problem and must not be reported as a finding about copy-db.
+			ok(
+				copyOut.trim().length > 0,
+				`copy-db produced no output at all — it almost certainly never located the database (harness problem, not a defect). exit=${copyExit}`
+			);
+			ok(existsSync(target), `copy-db should have produced ${target}. Output:\n${copyOut.slice(-1500)}`);
+		});
+
+		test(
+			'the copy contains the blob store',
+			{ todo: 'fails until harper#2048 channel 3 is fixed; remove this marker when it starts passing' },
+			() => {
+				const inCopy = filesUnder(copyRoot);
+				const blobFiles = inCopy.filter((f) => /blobs?\//i.test(f));
+				ok(inCopy.length > 0, 'the copy should contain the database files');
+				ok(
+					blobFiles.length >= BLOB_DOCS,
+					`copy-db produced a non-restorable copy: ${sourceBlobCount} blob file(s) in the source, ` +
+						`${blobFiles.length} in the copy. Records in the copy carry fileId references that resolve ` +
+						`to nothing, while inline attributes survive byte-exact — so the loss is partial and silent. ` +
+						`Copy tree: ${JSON.stringify(inCopy.slice(0, 20))}`
+				);
+			}
+		);
+
+		test(
+			'copy-db does not report success when records fail to copy',
+			{ todo: 'fails until harper#2048 channel 4 is fixed; remove this marker when it starts passing' },
+			() => {
+				// The audit-store copy opens its target on the SOURCE rootStore (bin/copyDb.ts:223,
+				// where every other dbi uses targetEnv at :217) and is not awaited (:225 vs :220), so
+				// per-record failures are logged and the exit code stays 0.
+				const failures = (copyOut.match(/Error copying record/g) ?? []).length;
+				strictEqual(
+					failures > 0 && copyExit === 0,
+					false,
+					`copy-db logged ${failures} per-record copy failure(s) and still exited ${copyExit}. ` +
+						`A backup verb that reports success while dropping records is what turns this into data loss.`
+				);
+			}
+		);
+
+		test('SCOPE: compactOnStart is unaffected — it leaves blobs/ adjacent in the same rootPath', () => {
+			// Recorded as an assertion rather than a comment so the distinction survives: compactOnStart
+			// moves database/{db}.mdb into backup/ and the copy into its place, both inside rootPath.
+			const stillThere = filesUnder(blobRoot()).length;
+			ok(
+				stillThere >= BLOB_DOCS,
+				`blobs/ must remain in the source rootPath — that is why the compactOnStart channel survives — found ${stillThere}`
+			);
+		});
+	}
+);

--- a/integrationTests/database/copy-db-blob-store.test.ts
+++ b/integrationTests/database/copy-db-blob-store.test.ts
@@ -1,35 +1,25 @@
 /**
- * `copy-db` and the blob store — end-to-end regression coverage for harper#2048 (channels 3 and 4),
+ * End-to-end regression coverage for harper#2048 channel 3 (`copy-db` never copied the blob store),
  * fixed by harper#2098.
  *
- * A record's blob BYTES live outside the LMDB environment, under `{rootPath}/blobs/{db}/`, and are
- * addressed by database NAME rather than by the environment file's path. `copyDb()` (bin/copyDb.ts,
- * behind the documented `copy-db <source> <target>` CLI verb at bin/harper.ts) byte-copies the
- * environment's dbis, so before harper#2098 the copy carried every record's `fileId` reference and
- * none of the files those references resolve to — a partial, silent loss, because inline attributes
- * survived byte-exact. It also kept exit 0 through per-record copy failures.
+ * A record's blob bytes live outside the LMDB environment, under `{rootPath}/blobs/{db}/`, and are
+ * addressed by database NAME rather than by the environment file's path, so an environment copy on
+ * its own carries every `fileId` reference and none of the files they resolve to. `copyDb()` now
+ * writes the source's blob roots to `<target>-blobs/<rootIndex>/` beside the copy.
  *
- * harper#2098's unit coverage (unitTests/bin/copyDbIntegrity.test.js) drives `copyDb()` directly;
- * this suite is the complementary end-to-end proof through the public CLI: it seeds file-backed
- * blobs plus inline controls over HTTP, runs `copy-db` at an external target, then performs the
- * restore the copy's own README documents — the environment file back to `database/{db}.mdb`, each
- * `<rootIndex>/` tree of the `<target>-blobs` companion directory back into the matching blob root —
- * and reads every seeded record back through HTTP.
+ * harper#2098's unit coverage (`unitTests/bin/copyDbIntegrity.test.js`) drives `copyDb()` directly.
+ * This suite is the public-CLI counterpart: it seeds over HTTP, runs `copy-db <source> <target>`,
+ * performs the restore the companion directory's README documents, restarts Harper onto it, and
+ * reads every seeded record back. The source environment and blob root are removed — and asserted
+ * gone — first, so the read-back cannot be answered by surviving source files, and each blob is
+ * compared against the sha256 its seed call returned.
  *
- * The read-back is the assertion that carries the contract. Counting files under a `blobs`-shaped
- * path only proves that something landed there; it cannot tell a restorable copy from one whose
- * records are undecodable or point at the wrong bytes. So the source environment and blob root are
- * REMOVED before the restore (asserted gone, so the read-back cannot be answered by surviving source
- * files), and every blob is compared against the sha256 its seed call returned.
+ * What it does not cover: restoring under a different database name or with more than one blob root
+ * (`unitTests/bin/copyDbIntegrity.test.js:250`), and channel 4's failure path — no per-record copy
+ * failure is induced here, so only the healthy exit-0 shape is asserted.
  *
- * Scope note: harper#2048 also reached `storage.compactOnStart`, but not with this consequence.
- * compactOnStart swaps the copy into the SAME rootPath and moves only `database/{db}.mdb`, leaving
- * `blobs/{db}/` adjacent and resolvable — which is why it copies with `blobs: 'preserve-source-roots'`.
- * Asserted below so nobody "fixes" compactOnStart chasing this.
- *
- * Harness note: the CLI reads `ROOTPATH` (not `HARPER_ROOT_PATH`), and an empty CLI output means it
- * never located the database — a harness problem, asserted separately so it is never scored as a
- * finding about `copy-db`.
+ * `copy-db` is LMDB-only (`copyDb` rejects a RocksDB database outright), hence the engine pin.
+ * The CLI reads `ROOTPATH`, not `HARPER_ROOT_PATH`.
  */
 import { suite, test, before, after } from 'node:test';
 import { ok, strictEqual } from 'node:assert';
@@ -58,8 +48,14 @@ const INLINE_DOCS = 4; // controls: no blob attribute at all, so they survive on
 const DATABASE = 'data';
 const HARPER_OPTIONS: StartHarperOptions = {
 	config: { logging: { console: true, level: 'error' } },
-	env: { HARPER_STORAGE_ENGINE: 'lmdb' }, // copy-db is the LMDB path
+	env: { HARPER_STORAGE_ENGINE: 'lmdb' },
 };
+const SEED_TIMEOUT_MS = 60_000;
+const COPY_TIMEOUT_MS = 120_000;
+const READY_TIMEOUT_MS = 60_000;
+// Above the framework's own CI startup ceiling, so a slow boot fails with its diagnosis rather than
+// with a bare test timeout.
+const BOOT_TIMEOUT_MS = 300_000;
 
 /** Every non-empty file under a tree, relative to it. Disk truth, not API truth. */
 function filesUnder(dir: string): string[] {
@@ -68,8 +64,11 @@ function filesUnder(dir: string): string[] {
 		let entries;
 		try {
 			entries = readdirSync(d, { withFileTypes: true });
-		} catch {
-			return;
+		} catch (error: any) {
+			// An absent directory is an answer; anything else would report as an empty tree and be
+			// misread as data loss.
+			if (error?.code === 'ENOENT' || error?.code === 'ENOTDIR') return;
+			throw error;
 		}
 		for (const e of entries) {
 			const p = join(d, e.name);
@@ -87,23 +86,23 @@ suite('copy-db and the blob store (harper#2048)', { skip: process.platform === '
 	const dbPath = () => join(ctx.harper.dataRootDir, 'database', `${DATABASE}.mdb`);
 	const blobRoot = () => join(ctx.harper.dataRootDir, 'blobs', DATABASE);
 
-	// Populated by the copy step so the later tests assert against one real invocation rather
-	// than each shelling the CLI again.
+	// Populated by the copy step so the later tests assert against one real invocation rather than
+	// each shelling the CLI again.
 	let copyRoot = '';
 	let copyTarget = '';
 	let copyExit: number | null = null;
 	let copyOut = '';
 	let sourceBlobCount = 0;
-	// sha256 of each seeded blob, as reported by the seeding call — the byte-exact expectation
-	// the restored read-back is compared against.
+	// sha256 of each seeded blob, as reported by the seeding call — the byte-exact expectation the
+	// restored read-back is compared against.
 	const seededBlobSha = new Map<string, string>();
 	const seededInlineNote = new Map<string, string>();
 
-	// Poll the fixture route directly until it answers; never restartHttpWorkers() against a
-	// pre-installed fixture (fire-and-forget, races the worker respawn).
+	// Never restartHttpWorkers() against a pre-installed fixture: it is fire-and-forget and races
+	// the worker respawn.
 	async function waitForFixtureRoute(label: string) {
 		client = createApiClient(ctx.harper);
-		const deadline = Date.now() + 60_000;
+		const deadline = Date.now() + READY_TIMEOUT_MS;
 		while (Date.now() < deadline) {
 			try {
 				const probe = await client.reqRest('/Verify/?key=none').timeout(2000);
@@ -113,7 +112,7 @@ suite('copy-db and the blob store (harper#2048)', { skip: process.platform === '
 			}
 			await new Promise((r) => setTimeout(r, 250));
 		}
-		ok(false, `harper did not serve /Verify/ with 200 within 60s ${label} — boot failed`);
+		ok(false, `harper did not serve /Verify/ with 200 within ${READY_TIMEOUT_MS}ms ${label} — boot failed`);
 	}
 
 	async function verify(key: string) {
@@ -122,34 +121,45 @@ suite('copy-db and the blob store (harper#2048)', { skip: process.platform === '
 		return response.body;
 	}
 
-	before(async () => {
-		await setupHarperWithFixture(ctx, FIXTURE_PATH, HARPER_OPTIONS);
-		await waitForFixtureRoute('on first boot');
+	before(
+		async () => {
+			await setupHarperWithFixture(ctx, FIXTURE_PATH, HARPER_OPTIONS);
+			await waitForFixtureRoute('on first boot');
 
-		const seed = async (payload: Record<string, unknown>) => {
-			const r = await fetch(`${ctx.harper.httpURL}/Seed/`, {
-				method: 'POST',
-				headers: { 'Authorization': client.headers.Authorization, 'content-type': 'application/json' },
-				body: JSON.stringify(payload),
-			});
-			const text = await r.text();
-			ok(r.status < 300, `seed ${JSON.stringify(payload)} expected 2xx, got ${r.status}: ${text.slice(0, 300)}`);
-			return JSON.parse(text);
-		};
-		for (let i = 0; i < BLOB_DOCS; i++) {
-			const key = `blob-${i}`;
-			const seeded = await seed({ kind: 'blob', key, size: BLOB_SIZE });
-			ok(seeded.sha, `seeding ${key} returned no sha to compare the restored blob against: ${JSON.stringify(seeded)}`);
-			strictEqual(seeded.size, BLOB_SIZE, `seeding ${key} stored ${seeded.size} bytes, not the requested ${BLOB_SIZE}`);
-			seededBlobSha.set(key, seeded.sha);
-		}
-		for (let i = 0; i < INLINE_DOCS; i++) {
-			const key = `inline-${i}`;
-			const note = `inline-control-${i}`;
-			await seed({ kind: 'inline', key, note });
-			seededInlineNote.set(key, note);
-		}
-	});
+			const seed = async (payload: Record<string, unknown>) => {
+				const r = await fetch(`${ctx.harper.httpURL}/Seed/`, {
+					method: 'POST',
+					headers: { 'Authorization': client.headers.Authorization, 'content-type': 'application/json' },
+					body: JSON.stringify(payload),
+					signal: AbortSignal.timeout(SEED_TIMEOUT_MS),
+				});
+				const text = await r.text();
+				ok(r.status < 300, `seed ${JSON.stringify(payload)} expected 2xx, got ${r.status}: ${text.slice(0, 300)}`);
+				return JSON.parse(text);
+			};
+			for (let i = 0; i < BLOB_DOCS; i++) {
+				const key = `blob-${i}`;
+				const seeded = await seed({ kind: 'blob', key, size: BLOB_SIZE });
+				ok(
+					seeded.sha,
+					`seeding ${key} returned no sha to compare the restored blob against: ${JSON.stringify(seeded)}`
+				);
+				strictEqual(
+					seeded.size,
+					BLOB_SIZE,
+					`seeding ${key} stored ${seeded.size} bytes, not the requested ${BLOB_SIZE}`
+				);
+				seededBlobSha.set(key, seeded.sha);
+			}
+			for (let i = 0; i < INLINE_DOCS; i++) {
+				const key = `inline-${i}`;
+				const note = `inline-control-${i}`;
+				await seed({ kind: 'inline', key, note });
+				seededInlineNote.set(key, note);
+			}
+		},
+		{ timeout: BOOT_TIMEOUT_MS + READY_TIMEOUT_MS + SEED_TIMEOUT_MS }
+	);
 
 	after(async () => {
 		try {
@@ -159,15 +169,14 @@ suite('copy-db and the blob store (harper#2048)', { skip: process.platform === '
 		}
 	});
 
-	test('PRECONDITION: the seeded blobs are file-backed on disk and read back from the source', async () => {
+	test('the seeded blobs are file-backed on disk and read back from the source', async () => {
 		sourceBlobCount = filesUnder(blobRoot()).length;
 		ok(
 			sourceBlobCount >= BLOB_DOCS,
-			`NON-VACUOUS PRECONDITION: expected >= ${BLOB_DOCS} blob files under ${blobRoot()}, found ${sourceBlobCount}. ` +
-				`Without file-backed blobs every assertion below is vacuous.`
+			`expected >= ${BLOB_DOCS} blob files under ${blobRoot()}, found ${sourceBlobCount}. Without ` +
+				`file-backed blobs every assertion below is vacuous.`
 		);
-		// The same read-back the restored copy is held to, run against the source first: a failure
-		// here is a seeding/fixture problem, not a copy-db one.
+		// The same read-back the restored copy is held to: a failure here is a seeding problem.
 		for (const [key, sha] of seededBlobSha) {
 			const record = await verify(key);
 			strictEqual(record.sha, sha, `source ${key} does not read back as seeded: ${JSON.stringify(record)}`);
@@ -178,54 +187,60 @@ suite('copy-db and the blob store (harper#2048)', { skip: process.platform === '
 		}
 	});
 
-	test('copy-db runs against the instance and reports success without per-record failures', async () => {
-		copyTarget = join(mkdtempSync(join(tmpdir(), 'copydb-')), 'data-copy.mdb');
-		copyRoot = resolve(copyTarget, '..');
+	test(
+		'copy-db copies the database to an external target, exits 0, and logs no per-record failure',
+		{ timeout: COPY_TIMEOUT_MS + READY_TIMEOUT_MS },
+		async () => {
+			copyRoot = mkdtempSync(join(tmpdir(), 'copydb-'));
+			copyTarget = join(copyRoot, 'data-copy.mdb');
 
-		await killHarper(ctx); // the CLI opens the environment itself
-		const cli = resolve(import.meta.dirname, '../../dist/bin/harper.js');
-		ok(existsSync(cli), `expected a built CLI at ${cli} — run npm run build first`);
+			await killHarper(ctx); // the CLI opens the environment itself
+			const cli = resolve(import.meta.dirname, '../../dist/bin/harper.js');
+			ok(existsSync(cli), `expected a built CLI at ${cli} — run npm run build first`);
 
-		try {
-			const r = await run(process.execPath, [cli, 'copy-db', DATABASE, copyTarget], {
-				env: { ...process.env, ROOTPATH: ctx.harper.dataRootDir },
-				maxBuffer: 32 * 1024 * 1024,
-			});
-			copyExit = 0;
-			copyOut = `${r.stdout}\n${r.stderr}`;
-		} catch (e: any) {
-			// e.code is a signal name (string) when the child was killed (e.g. maxBuffer overrun) —
-			// normalize so downstream `copyExit === 0` comparisons don't silently pass a string.
-			copyExit = typeof e.code === 'number' ? e.code : 1;
-			copyOut = `${e.stdout ?? ''}\n${e.stderr ?? ''}`;
+			try {
+				const r = await run(process.execPath, [cli, 'copy-db', DATABASE, copyTarget], {
+					env: { ...process.env, ...HARPER_OPTIONS.env, ROOTPATH: ctx.harper.dataRootDir },
+					maxBuffer: 32 * 1024 * 1024,
+					timeout: COPY_TIMEOUT_MS,
+				});
+				copyExit = 0;
+				copyOut = `${r.stdout}\n${r.stderr}`;
+			} catch (e: any) {
+				// e.code is a signal name (string) when the child was killed (timeout, maxBuffer overrun)
+				// — normalize so downstream `copyExit === 0` comparisons don't silently pass a string.
+				copyExit = typeof e.code === 'number' ? e.code : 1;
+				copyOut = `${e.stdout ?? ''}\n${e.stderr ?? ''}`;
+				if (e.killed) copyOut += `\ncopy-db was killed after ${COPY_TIMEOUT_MS}ms (${e.signal}) without completing`;
+			}
+
+			// A successful run always logs its progress, so empty output means the CLI never located
+			// the database — a setup failure rather than a copy-db defect.
+			ok(
+				copyOut.trim().length > 0,
+				`copy-db produced no output at all — it almost certainly never located the database. exit=${copyExit}`
+			);
+			ok(existsSync(copyTarget), `copy-db should have produced ${copyTarget}. Output:\n${copyOut.slice(-1500)}`);
+
+			const recordFailures = (copyOut.match(/Error copying record/g) ?? []).length;
+			strictEqual(
+				recordFailures,
+				0,
+				`copy-db logged ${recordFailures} per-record copy failure(s). Output:\n${copyOut.slice(-1500)}`
+			);
+			strictEqual(copyExit, 0, `copy-db exited ${copyExit}. Output:\n${copyOut.slice(-1500)}`);
 		}
+	);
 
-		// Distinguish "the CLI ran and did something" from "the CLI never found the database".
-		// The latter is a harness problem and must not be reported as a finding about copy-db.
-		ok(
-			copyOut.trim().length > 0,
-			`copy-db produced no output at all — it almost certainly never located the database (harness problem, not a defect). exit=${copyExit}`
-		);
-		ok(existsSync(copyTarget), `copy-db should have produced ${copyTarget}. Output:\n${copyOut.slice(-1500)}`);
-
-		// harper#2048 ch.4: per-record failures were logged while the exit code stayed 0, which is
-		// what turned a degraded copy into silent data loss.
-		const recordFailures = (copyOut.match(/Error copying record/g) ?? []).length;
-		strictEqual(
-			recordFailures,
-			0,
-			`copy-db logged ${recordFailures} per-record copy failure(s). Output:\n${copyOut.slice(-1500)}`
-		);
-		strictEqual(copyExit, 0, `copy-db exited ${copyExit}. Output:\n${copyOut.slice(-1500)}`);
-	});
-
-	test('the copy carries the blob store in its companion directory', () => {
+	test('the copy carries the blob store, and the README its restore is defined by', () => {
 		const blobCompanion = `${copyTarget}-blobs`;
 		ok(
 			existsSync(blobCompanion),
 			`copy-db must write the source's blob roots to ${blobCompanion}; copy tree: ${JSON.stringify(filesUnder(copyRoot).slice(0, 20))}`
 		);
-		// `<rootIndex>/<shard1>/<shard2>/<fileId>`, plus the README documenting that layout.
+		// `<rootIndex>/<shard1>/<shard2>/<fileId>`, plus the README documenting that layout — which is
+		// the only instruction an operator gets for the restore this suite performs below.
+		ok(existsSync(join(blobCompanion, 'README.md')), `${blobCompanion} must document its layout in README.md`);
 		const copiedBlobs = filesUnder(blobCompanion).filter((f) => f !== 'README.md');
 		ok(
 			copiedBlobs.length >= BLOB_DOCS,
@@ -234,66 +249,67 @@ suite('copy-db and the blob store (harper#2048)', { skip: process.platform === '
 		);
 	});
 
-	test('SCOPE: compactOnStart is unaffected — copy-db leaves blobs/ in the source rootPath', () => {
-		// Recorded as an assertion rather than a comment so the distinction survives: compactOnStart
-		// moves database/{db}.mdb into backup/ and the copy into its place, both inside rootPath, so
-		// the source blob roots it copies with `preserve-source-roots` have to still be there.
+	test('copy-db leaves the source blob roots in place', () => {
+		// The precondition `compactOnStart` relies on: it copies with `blobs: 'preserve-source-roots'`
+		// because it swaps the copy back into the same rootPath under the same database name, so the
+		// existing roots have to still resolve.
 		const stillThere = filesUnder(blobRoot()).length;
-		ok(
-			stillThere >= BLOB_DOCS,
-			`blobs/ must remain in the source rootPath — that is why the compactOnStart channel survives — found ${stillThere}`
-		);
+		ok(stillThere >= BLOB_DOCS, `copy-db must not disturb the source blob root — found ${stillThere} file(s)`);
 	});
 
-	test('the copy restores byte-exact: blob payloads and inline attributes read back', async () => {
-		// Checked before anything is removed: without both halves of the copy this test would tear
-		// down the source and then fail on a missing file, which reads as a restore defect.
-		ok(
-			existsSync(copyTarget) && existsSync(`${copyTarget}-blobs`),
-			`the copy step must have produced both ${copyTarget} and its -blobs companion before the restore`
-		);
-
-		// The documented restore (see the companion directory's README.md): the environment file
-		// goes back to database/{db}.mdb, and each `<rootIndex>/` tree goes back into the matching
-		// blob root of the database name the copy is restored as. Index 0 is the single default
-		// root, `<rootPath>/blobs/<db>`.
-		await rm(dbPath(), { force: true });
-		await rm(`${dbPath()}-lock`, { force: true });
-		await rm(blobRoot(), { recursive: true, force: true });
-		ok(
-			!existsSync(dbPath()) && !existsSync(blobRoot()),
-			`NON-VACUOUS PRECONDITION: the source environment and blob root must be gone before the restore, ` +
-				`or the read-back below could be answered by surviving source files rather than by the copy`
-		);
-
-		await cp(copyTarget, dbPath());
-		await cp(join(`${copyTarget}-blobs`, '0'), blobRoot(), { recursive: true });
-
-		await startHarper(ctx, HARPER_OPTIONS);
-		await waitForFixtureRoute('after restoring the copy');
-
-		for (const [key, sha] of seededBlobSha) {
-			const record = await verify(key);
-			ok(record.present, `${key} is missing from the restored copy: ${JSON.stringify(record)}`);
-			ok(record.hasPayload, `${key} restored without its blob attribute: ${JSON.stringify(record)}`);
-			strictEqual(record.size, BLOB_SIZE, `${key} restored with ${record.size} bytes: ${JSON.stringify(record)}`);
-			strictEqual(
-				record.sha,
-				sha,
-				`${key}'s blob bytes did not survive the copy: seeded sha256 ${sha}, restored ${record.sha}. ` +
-					`A copy whose fileId references resolve to the wrong bytes fails here and nowhere else.`
+	test(
+		'the copy restores byte-exact: blob payloads and inline attributes read back',
+		{ timeout: BOOT_TIMEOUT_MS + READY_TIMEOUT_MS },
+		async () => {
+			// Checked before anything is removed: without both halves of the copy this test would tear
+			// down the source and then fail on a missing file, which reads as a restore defect.
+			ok(
+				existsSync(copyTarget) && existsSync(`${copyTarget}-blobs`),
+				`the copy step must have produced both ${copyTarget} and its -blobs companion before the restore`
 			);
-		}
-		for (const [key, note] of seededInlineNote) {
-			const record = await verify(key);
-			ok(record.present, `inline control ${key} is missing from the restored copy: ${JSON.stringify(record)}`);
-			strictEqual(
-				record.hasPayload,
-				false,
-				`inline control ${key} is not inline — it has a blob attribute, so it no longer controls for the ` +
-					`"inline attributes survive while blob bytes do not" half of harper#2048: ${JSON.stringify(record)}`
+
+			// The restore the companion README documents: the environment file goes back to
+			// database/{db}.mdb, and each `<rootIndex>/` tree goes back into the matching blob root of
+			// the database name the copy is restored as. Index 0 is the single default root,
+			// `<rootPath>/blobs/<db>`.
+			await rm(dbPath(), { force: true });
+			await rm(`${dbPath()}-lock`, { force: true });
+			await rm(blobRoot(), { recursive: true, force: true });
+			ok(
+				!existsSync(dbPath()) && !existsSync(blobRoot()),
+				`the source environment and blob root must be gone before the restore, or the read-back below ` +
+					`could be answered by surviving source files rather than by the copy`
 			);
-			strictEqual(record.note, note, `inline control ${key} did not survive byte-exact: ${JSON.stringify(record)}`);
+
+			await cp(copyTarget, dbPath());
+			await cp(join(`${copyTarget}-blobs`, '0'), blobRoot(), { recursive: true });
+
+			await startHarper(ctx, HARPER_OPTIONS);
+			await waitForFixtureRoute('after restoring the copy');
+
+			for (const [key, sha] of seededBlobSha) {
+				const record = await verify(key);
+				ok(record.present, `${key} is missing from the restored copy: ${JSON.stringify(record)}`);
+				ok(record.hasPayload, `${key} restored without its blob attribute: ${JSON.stringify(record)}`);
+				strictEqual(record.size, BLOB_SIZE, `${key} restored with ${record.size} bytes: ${JSON.stringify(record)}`);
+				strictEqual(
+					record.sha,
+					sha,
+					`${key}'s blob bytes did not survive the copy: seeded sha256 ${sha}, restored ${record.sha}. ` +
+						`A copy whose fileId references resolve to the wrong bytes fails here and nowhere else.`
+				);
+			}
+			for (const [key, note] of seededInlineNote) {
+				const record = await verify(key);
+				ok(record.present, `inline control ${key} is missing from the restored copy: ${JSON.stringify(record)}`);
+				strictEqual(
+					record.hasPayload,
+					false,
+					`inline control ${key} has a blob attribute, so it no longer controls for the "inline data ` +
+						`survives while blob bytes do not" half of harper#2048: ${JSON.stringify(record)}`
+				);
+				strictEqual(record.note, note, `inline control ${key} did not survive byte-exact: ${JSON.stringify(record)}`);
+			}
 		}
-	});
+	);
 });

--- a/integrationTests/database/copy-db-blob-store/config.yaml
+++ b/integrationTests/database/copy-db-blob-store/config.yaml
@@ -1,0 +1,5 @@
+graphqlSchema:
+  files: '*.graphql'
+jsResource:
+  files: resources.js
+rest: true

--- a/integrationTests/database/copy-db-blob-store/resources.js
+++ b/integrationTests/database/copy-db-blob-store/resources.js
@@ -18,22 +18,30 @@ function patternBuffer(seed, size) {
 	return out;
 }
 const sha256 = (buf) => createHash('sha256').update(buf).digest('hex');
+const DEFAULT_SEED_SIZE = 256 * 1024;
+const MAX_SEED_SIZE = 4 * 1024 * 1024;
 
+// `loadAsInstance = false` dispatches instance methods as (query, data) — with (data) alone every
+// seeded field reads as undefined, which silently writes one record under the key "undefined".
 export class Seed extends Resource {
 	static loadAsInstance = false;
-	async post(body) {
+	async post(_query, body) {
 		const key = String(body.key);
 		if (String(body?.kind ?? 'blob') === 'inline') {
 			await Doc.put({ key, note: String(body.note ?? key) });
 			return { ok: true, key, kind: 'inline' };
 		}
-		const bytes = patternBuffer(key, Number(body.size) || 256 * 1024);
-		await Doc.put({ key, payload: createBlob(bytes, { type: 'application/octet-stream' }), note: sha256(bytes) });
-		return { ok: true, key, kind: 'blob', sha: sha256(bytes) };
+		const requested = Number(body.size) || DEFAULT_SEED_SIZE;
+		const bytes = patternBuffer(key, Math.min(Math.max(requested, 1), MAX_SEED_SIZE));
+		const sha = sha256(bytes);
+		await Doc.put({ key, payload: createBlob(bytes, { type: 'application/octet-stream' }), note: sha });
+		return { ok: true, key, kind: 'blob', size: bytes.length, sha };
 	}
 }
 
-// Read-back over the current database; also serves as the readiness probe.
+// Read-back over the current database; also serves as the readiness probe. Reports the blob's own
+// sha256 rather than whether it matches the record's `note`, so the caller compares against the
+// value seeding returned instead of against another field of the same (possibly corrupt) record.
 export class Verify extends Resource {
 	static loadAsInstance = false;
 	async get(query) {
@@ -41,9 +49,9 @@ export class Verify extends Resource {
 		try {
 			const rec = await Doc.get(key);
 			if (!rec) return { ok: true, present: false, key };
-			if (!rec.payload) return { ok: true, present: true, key, hasPayload: false };
+			if (!rec.payload) return { ok: true, present: true, key, hasPayload: false, note: rec.note };
 			const bytes = Buffer.from(await rec.payload.bytes());
-			return { ok: true, present: true, key, hasPayload: true, size: bytes.length, match: sha256(bytes) === rec.note };
+			return { ok: true, present: true, key, hasPayload: true, size: bytes.length, note: rec.note, sha: sha256(bytes) };
 		} catch (e) {
 			return { ok: false, key, error: String(e?.message ?? e).slice(0, 200) };
 		}

--- a/integrationTests/database/copy-db-blob-store/resources.js
+++ b/integrationTests/database/copy-db-blob-store/resources.js
@@ -1,0 +1,51 @@
+// A Blob must be constructed inside Harper, so seeding runs here rather than over the wire.
+// Bytes are HMAC-derived per key: non-compressible, so they land as file-backed blobs rather
+// than being inlined into the record.
+import { createHash, createHmac } from 'node:crypto';
+
+const { Doc } = tables;
+
+function patternBuffer(seed, size) {
+	const out = Buffer.allocUnsafe(size);
+	let off = 0;
+	let counter = 0;
+	while (off < size) {
+		const block = createHmac('sha256', String(seed)).update(String(counter++)).digest();
+		const n = Math.min(block.length, size - off);
+		block.copy(out, off, 0, n);
+		off += n;
+	}
+	return out;
+}
+const sha256 = (buf) => createHash('sha256').update(buf).digest('hex');
+
+export class Seed extends Resource {
+	static loadAsInstance = false;
+	async post(body) {
+		const key = String(body.key);
+		if (String(body?.kind ?? 'blob') === 'inline') {
+			await Doc.put({ key, note: String(body.note ?? key) });
+			return { ok: true, key, kind: 'inline' };
+		}
+		const bytes = patternBuffer(key, Number(body.size) || 256 * 1024);
+		await Doc.put({ key, payload: createBlob(bytes, { type: 'application/octet-stream' }), note: sha256(bytes) });
+		return { ok: true, key, kind: 'blob', sha: sha256(bytes) };
+	}
+}
+
+// Read-back over the current database; also serves as the readiness probe.
+export class Verify extends Resource {
+	static loadAsInstance = false;
+	async get(query) {
+		const key = String(typeof query?.get === 'function' ? query.get('key') : query?.key);
+		try {
+			const rec = await Doc.get(key);
+			if (!rec) return { ok: true, present: false, key };
+			if (!rec.payload) return { ok: true, present: true, key, hasPayload: false };
+			const bytes = Buffer.from(await rec.payload.bytes());
+			return { ok: true, present: true, key, hasPayload: true, size: bytes.length, match: sha256(bytes) === rec.note };
+		} catch (e) {
+			return { ok: false, key, error: String(e?.message ?? e).slice(0, 200) };
+		}
+	}
+}

--- a/integrationTests/database/copy-db-blob-store/schema.graphql
+++ b/integrationTests/database/copy-db-blob-store/schema.graphql
@@ -1,0 +1,7 @@
+# One table with a Blob attribute plus a small inline control field: the inline values must
+# survive copy-db byte-exact, which is what makes the blob loss partial and easy to miss.
+type Doc @table @export {
+	key: ID @primaryKey
+	payload: Blob
+	note: String
+}


### PR DESCRIPTION
harper#2098 merged on 2026-08-29 and closed #2048, which changes what this PR should be. The two `{ todo }` contract probes here now pass; left as they were, they would convert a future regression into a `t.diagnostic()` while CI stayed green — the opposite of the guard the file exists to be. So: rebased onto `main`, both markers and the `assertContractOrDiagnose()` helper removed, assertions propagate normally.

Making them enforcing turned up two problems with what they enforced.

**The fixture never stored a record.** `Seed` is a `loadAsInstance = false` resource, so Harper dispatches its instance methods as `(query, data)` (`resources/Resource.ts:261`). Declaring `post(body)` bound `body` to the *query*, so every seeded field read as `undefined`: all ten seeds wrote one blob record under the key `"undefined"` — which is why the original description measured ten blob files for six blob docs — and the four "inline controls" were blobs too. `GET /Doc/blob-0` returned 404 against the live source. Nothing caught it, because nothing ever read a record back. One-character-class fix at [`resources.js:28`](https://github.com/HarperFast/harper/pull/2126/changes?w=1#diff-a41630c45980c6fd77921545f2c41fc5aa69ab5433d2daa10bb0888edb6e8557R28).

**Counting files was never the contract.** A `blobs`-shaped path with six files in it cannot distinguish a restorable copy from one whose records are undecodable or point at the wrong bytes — @heskew's second thread. So the suite now performs the restore the copy's own `README.md` documents and reads every record back:

1. environment file → `database/{db}.mdb`, and [`<target>-blobs/0/` → the matching blob root](https://github.com/HarperFast/harper/pull/2126/changes?w=1#diff-48b0c0390458474c85c028e3edd41f8f6cea9c5c30b7730d6b5620eeb6b308e7R284);
2. restart Harper onto it (same `dataRootDir`, so one extra boot, not a second instance);
3. compare each blob against [the sha256 its seed call returned](https://github.com/HarperFast/harper/pull/2126/changes?w=1#diff-48b0c0390458474c85c028e3edd41f8f6cea9c5c30b7730d6b5620eeb6b308e7R295) and each inline control against the value the test chose.

The source environment and blob root are [removed, and asserted gone](https://github.com/HarperFast/harper/pull/2126/changes?w=1#diff-48b0c0390458474c85c028e3edd41f8f6cea9c5c30b7730d6b5620eeb6b308e7R279), before the restore — otherwise the read-back could be answered by surviving source files rather than by the copy. That guard is the load-bearing part: this is where to look hardest.

The `Verify` route reports [the blob's own sha256](https://github.com/HarperFast/harper/pull/2126/changes?w=1#diff-a41630c45980c6fd77921545f2c41fc5aa69ab5433d2daa10bb0888edb6e8557R54) rather than whether it matches the record's own `note`, so the comparison is against a value captured at seed time, not against another field of the same possibly-corrupt record.

Two test names also claimed coverage their bodies do not provide. Nothing here induces a per-record copy failure, so the copy test now says [what it asserts](https://github.com/HarperFast/harper/pull/2126/changes?w=1#diff-48b0c0390458474c85c028e3edd41f8f6cea9c5c30b7730d6b5620eeb6b308e7R191) instead of naming #2048 ch.4, and the scope test says [`copy-db` leaves the source blob roots in place](https://github.com/HarperFast/harper/pull/2126/changes?w=1#diff-48b0c0390458474c85c028e3edd41f8f6cea9c5c30b7730d6b5620eeb6b308e7R251) rather than claiming `compactOnStart` — which it never invokes — is covered.

**5 pass, 0 fail, 0 todo.**

## For the human reviewer

- **@heskew's review offered two branches — "become active regression tests" or "close as superseded by #2098".** I took the first: #2098's coverage is unit-level against `copyDb()`, and this is the only thing that drives the documented `copy-db` CLI verb and the documented restore end to end. If you'd rather not carry a ~13s five-boot suite for that, closing it is a one-line decision and I won't argue.
- **Declined: a stale-`dist` guard.** Codex asked for an mtime check because "the server under test runs from source via typestrip" while the CLI comes from `dist`. It doesn't — `@harperfast/integration-testing`'s `getHarperScript()` resolves the server to the same `dist/bin/harper.js` ("ancestor dist" in the run log). A stale `dist` is a repo-wide precondition for the whole integration tree (`integrationTests/README.md`), so one file unilaterally enforcing freshness would fail while its 58 peers happily use the same build.
- **Channel 4's failure path is still not exercised anywhere.** The `failedRecords > 0` throw `#2098` added would need fault injection to reach, and `AGENTS.md` rules out stub-based tests. The test name no longer implies otherwise.
- **Restoring more than one blob root is untested.** `unitTests/dataLayer/blobBackup.test.js:232` copies a second root; nothing restores one. Worth an issue rather than scope here.
- **The restore is destructive and in-place** (delete the live environment + blob root, restore over them). That is what makes the read-back non-vacuous, and it is why it is the last test in the suite. The alternative — a second `rootPath` and a second Harper install — costs another full boot for the same signal.
- **Not covered: the opt-in deflate blob path** (c00416010). These blobs are HMAC-derived and incompressible.
- The Gemini leg could not run on this worker (`agy` not authenticated). Rounds 1–2 (the substantive ones) had codex + cursor-composer + Harper-domain adjudication; rounds 3–4 were comment-only deltas the policy narrowed to codex, which is what the footer records.

## Verification

Route: new integration test, executed. `npm run build` then `npx harper-integration-test-run integrationTests/database/copy-db-blob-store.test.ts` → **5 pass, 0 fail, 0 todo** (~4s once warm). `npm run lint:required` and `prettier --check` clean.

Fails-on-base is not available for the LMDB half — #2098 is already on `main` — so the assertion was mutation-checked instead: skipping only the blob-companion half of the restore fails the suite with `Blob file not found for .../blobs/data/0/0/1`, which is exactly the pre-#2098 outcome. Before the fixture fix, the same suite failed with `{"present":false}` for every key, against both the source and the restored copy.

Not run locally: the full `test:integration:all` gate (59 files in `database/` alone). Each file runs in its own process against its own `dataRootDir` and loopback address, and this change is confined to one new file plus its own fixture directory, so CI's sharded run is the gate.

Refs #2048. Supersedes the todo-marked form of this PR.

Generated by Claude Opus 5.

Complexity: medium

<sub>Review-Coverage: authored=claude; ran=codex; blocked=gemini(auth); declined=cursor-grok,cursor-composer,domain; rounds=4 @ 810a6beaffbe</sub>

<sub>Human-Review-Need: 3 @ 810a6beaffbe</sub>
