### PR TITLE
Make two-phase component deploys crash-safe and fail closed

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -133,6 +133,27 @@ A package-manager timeout must not release this lock while npm descendants are s
 
 Boot's `harper-application-lock.json` records an application configuration only after preparation fulfills. Recording at queue time would make a failed install look complete and suppress its retry on the next boot.
 
+## Two-phase component deploys roll forward from a durable activation claim
+
+With `system` database replication enabled, `deploy_component` first prepares the candidate under
+`.deploy-staging/<deployment UUID>/<project>` on every node. The deployment row carries the complete,
+immutable activation specification (package/install settings, routing, credential references, and
+`force`); activate-by-id never accepts replacements for those fields. After every stage response, the
+origin durably checkpoints the row as `staged`. Activation claims that row as `activating` while holding
+the same per-component filesystem lock, then swaps the candidate into the live path and commits root
+config plus `harper-application-lock.json` as one compensating transaction. Peers make the same local
+claim before their swap. This ordering is the recovery record: startup preserves `staged` candidates,
+deletes terminal/orphan candidates, and rolls an `activating` candidate forward before loading apps.
+
+Peer stage/activate/restart messages use the distinct authenticated `component_deploy_phase` operation.
+An older peer therefore rejects the unknown operation instead of ignoring a phase marker and deploying
+the staged build live. Public `_phase`/`_deploymentId` fields are rejected; the latter remains accepted
+only on the authenticated legacy one-shot replication path. Restart is gated until activation responses
+have settled. A partial activation is reported as split-node state and recovered by staging and activating
+a known-good build; there is deliberately no toggle-style automatic revert because retrying one after a
+lost response can reverse the recovery. `deployment_stagingRetention_maxCount` bounds resting staged
+trees per component and payload retention is pruned in the same row-aware lifecycle.
+
 ## Peer-side deploy_component payload read: retryable blob stalls and `Readable.from()` cancellation
 
 `readPayloadBlobWithRetry` (`components/deploymentRecorder.ts`) wraps the peer's read of a replicated `hdb_deployment` row's `payload_blob` so a transient 503 `BlobReadError` (`BLOB_UNAVAILABLE_STATUS`, `resources/blob.ts`) — content bytes not arriving within `blobReadTimeout`, e.g. a parked blob send on the origin — retries instead of failing the whole deploy. Two non-obvious constraints shaped the design:

--- a/bin/cliOperations.ts
+++ b/bin/cliOperations.ts
@@ -153,6 +153,22 @@ async function targetSupportsStreamingDeploy(options: any): Promise<boolean> {
 	}
 }
 
+async function targetSupportsStagedDeploy(options: any): Promise<boolean> {
+	try {
+		const probeOptions = {
+			...options,
+			headers: { ...options.headers, Accept: 'application/json' },
+			timeout: CLI_OPERATION_TIMEOUT_MS,
+		};
+		delete probeOptions.streamResponse;
+		const response = await httpRequest(probeOptions, { operation: 'registration_info' });
+		if (response.statusCode !== 200 || !response.body) return false;
+		return JSON.parse(response.body)?.capabilities?.componentDeployTwoPhase === 1;
+	} catch {
+		return false;
+	}
+}
+
 // Wraps the local packaging stream so an fs error while tar'ing up the payload (e.g. a file
 // vanishing after the pre-deploy scan, or a permissions failure reading the project tree)
 // surfaces as a descriptive packaging error instead of a raw fs error code. Without this, an
@@ -283,7 +299,11 @@ export { cliOperations, buildRequest, redactCredentials, refreshExpiredOperation
 // version. Nothing to package when a `package` identifier is given (the server fetches it) or when
 // activating a previously-staged deployment (`deployment_id`, i.e. `harper activate`).
 const packageCwdForUpload = async (req) => {
-	if (req.package || req.deployment_id) {
+	if (req.deployment_id) {
+		req.project ||= path.basename(process.cwd());
+		return;
+	}
+	if (req.package) {
 		return;
 	}
 
@@ -467,8 +487,6 @@ async function cliOperations(req: any, skipResponseLog = false) {
 		console.error(verbError);
 		process.exit(1);
 	}
-	delete req._verb; // CLI-internal marker; never send it in the request body
-	await PREPARE_OPERATION[req.operation]?.(req);
 	try {
 		let options = target ?? {
 			protocol: 'http:',
@@ -506,6 +524,20 @@ async function cliOperations(req: any, skipResponseLog = false) {
 		if (target && !options.headers.Authorization && req.username && req.password) {
 			options.headers.Authorization = basicAuthHeader(req.username, req.password);
 		}
+		const requestsStagedDeploy =
+			req._verb !== undefined ||
+			req._cliVerb !== undefined ||
+			req.activate === false ||
+			req.deployment_id !== undefined ||
+			req.two_phase === true;
+		if (target && requestsStagedDeploy && !(await targetSupportsStagedDeploy(options))) {
+			throw new Error(
+				`Target Harper does not advertise staged-deploy support; refusing the request because an older server could deploy it live`
+			);
+		}
+		delete req._verb;
+		delete req._cliVerb;
+		await PREPARE_OPERATION[req.operation]?.(req);
 		// Streaming deploy (multipart upload + SSE progress) only works against >= 5.1 servers.
 		// When deploying to a remote target, probe its version first and downgrade to the
 		// legacy JSON deploy if it predates 5.1. Local (domain-socket) deploys always
@@ -540,7 +572,7 @@ async function cliOperations(req: any, skipResponseLog = false) {
 		// One renderer owns the (future) upload bar and the SSE event rendering for a
 		// multipart deploy. Created here so the upload-stream tap and the SSE consumer
 		// below share the same instance.
-		const renderer = req._multipart ? new DeployRenderer({ uploadTotal: req._uploadSizeEstimate ?? 0 }) : null;
+		const renderer = useSse ? new DeployRenderer({ uploadTotal: req._uploadSizeEstimate ?? 0 }) : null;
 		let body;
 		if (req._multipart) {
 			// Create the package stream here — after the renderer exists — so we can pass

--- a/components/Application.ts
+++ b/components/Application.ts
@@ -1,5 +1,12 @@
 import { type Logger } from '../utility/logging/logger.ts';
-import { getConfigObj, getConfigValue, getConfigPath } from '../config/configUtils.ts';
+import {
+	addConfig,
+	deleteConfigFromFile,
+	getConfigObj,
+	getConfigValue,
+	getConfigPath,
+	readConfigFile,
+} from '../config/configUtils.ts';
 import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 import logger, { errorForLog } from '../utility/logging/harper_logger.ts';
 import { broadcastDeployStart, broadcastDeployEnd } from './deployLifecycle.ts';
@@ -501,6 +508,11 @@ const MAX_INSTALL_COMMANDS = 2;
 //     (those are rooted at each live component dir), so building here triggers no
 //     restart-on-change storm and needs no deploy:start watcher suppression.
 export const DEPLOY_STAGING_DIR = '.deploy-staging';
+export const DEPLOY_ACTIVATION_DIR = '.deploy-activating';
+const STAGED_COMPLETE_MARKER = '.complete';
+const ACTIVATION_BACKUP_PREFIX = '.previous-';
+const ACTIVATION_NEW_PREFIX = '.new-';
+const DEPLOYMENT_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 // Hidden directory under the components root that RETAINS the immediately-previous live version of a
 // component (`.deploy-previous/<name>`) after an activate swap, so it can be swapped back by
@@ -1353,7 +1365,7 @@ export async function prepareApplication(application: Application) {
  * @param application The application to stage.
  * @returns The absolute path of the staging directory the incoming version was built into.
  */
-export async function stageApplication(application: Application): Promise<string> {
+async function _legacyStageApplication(application: Application): Promise<string> {
 	application.useStagingBuildDir();
 	// Start from a clean slate so a retried stage (same deployment id) can't inherit a half-built
 	// tree from a previous attempt.
@@ -1521,7 +1533,7 @@ export async function revertApplication(application: Application): Promise<void>
  * staging tree and tears down any transient credential state. The live component directory is never
  * touched. Safe to call whether or not staging ever ran.
  */
-export async function discardStagedApplication(application: Application): Promise<void> {
+async function _legacyDiscardStagedApplication(application: Application): Promise<void> {
 	try {
 		await application.cleanupGitCredentialSession();
 	} catch {
@@ -1536,6 +1548,387 @@ export async function discardStagedApplication(application: Application): Promis
 	await rm(application.stagingDirPath, { recursive: true, force: true }).catch((err) =>
 		logger.trace?.(`Failed to discard ${application.name} staging directory: ${err.message}`)
 	);
+}
+
+export function stagedApplicationPath(componentDirPath: string, deploymentId: string): string {
+	if (!DEPLOYMENT_ID_PATTERN.test(deploymentId)) throw new Error(`Invalid deployment id '${deploymentId}'`);
+	return join(dirname(componentDirPath), DEPLOY_STAGING_DIR, deploymentId, basename(componentDirPath));
+}
+
+async function ensureSecureDirectory(directory: string, create: boolean, description: string): Promise<boolean> {
+	let directoryStat;
+	try {
+		directoryStat = await lstat(directory);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+		if (!create) return false;
+		await mkdir(directory, { recursive: true, mode: 0o700 });
+		directoryStat = await lstat(directory);
+	}
+	if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) {
+		throw new Error(`${description} is not a directory: ${directory}`);
+	}
+	return true;
+}
+
+async function secureStagingDeploymentDirectory(
+	componentDirPath: string,
+	deploymentId: string,
+	create: boolean
+): Promise<string | undefined> {
+	const stagingDirPath = stagedApplicationPath(componentDirPath, deploymentId);
+	const deploymentDirPath = dirname(stagingDirPath);
+	const stagingRoot = dirname(deploymentDirPath);
+	if (!(await ensureSecureDirectory(stagingRoot, create, 'Component deploy staging path'))) return undefined;
+	if (!(await ensureSecureDirectory(deploymentDirPath, create, 'Component deploy staging path'))) return undefined;
+	return deploymentDirPath;
+}
+
+/** Build and install a candidate under .deploy-staging without mutating the live component tree. */
+export async function stageApplication(application: Application, deploymentId: string): Promise<string> {
+	const liveDirPath = application.dirPath;
+	const stagingDirPath = stagedApplicationPath(liveDirPath, deploymentId);
+	application.stagingId = deploymentId;
+	application.useStagingBuildDir();
+	try {
+		await withComponentPreparationLock(liveDirPath, async () => {
+			const deploymentDirPath = await secureStagingDeploymentDirectory(liveDirPath, deploymentId, true);
+			await rm(stagingDirPath, { recursive: true, force: true });
+			await rm(join(deploymentDirPath!, STAGED_COMPLETE_MARKER), { force: true });
+			try {
+				await application.writeTransientNpmrc();
+				try {
+					await application.startGitCredentialSession();
+					await extractApplication(application);
+				} finally {
+					await application.cleanupGitCredentialSession();
+				}
+				await installApplication(application);
+				await writeFile(join(deploymentDirPath!, STAGED_COMPLETE_MARKER), '', { flag: 'wx', mode: 0o600 });
+			} catch (error) {
+				await rm(stagingDirPath, { recursive: true, force: true }).catch(() => {});
+				await rm(join(deploymentDirPath!, STAGED_COMPLETE_MARKER), { force: true }).catch(() => {});
+				throw error;
+			} finally {
+				await application.cleanupTransientNpmrc();
+			}
+		});
+	} finally {
+		application.useLiveBuildDir();
+	}
+	await pruneStagedBuilds(application.name, deploymentId, getStagingRetentionMaxCount());
+	return stagingDirPath;
+}
+
+function activationStagingDirectory(componentDirPath: string): string {
+	return join(dirname(componentDirPath), DEPLOY_ACTIVATION_DIR, basename(componentDirPath));
+}
+
+async function activationArtifacts(componentDirPath: string, deploymentId: string): Promise<string[]> {
+	const directory = activationStagingDirectory(componentDirPath);
+	let entries;
+	try {
+		entries = await readdir(directory, { withFileTypes: true });
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+		throw error;
+	}
+	return entries
+		.filter(
+			(entry) =>
+				entry.name.startsWith(`${ACTIVATION_BACKUP_PREFIX}${deploymentId}`) ||
+				entry.name === `${ACTIVATION_NEW_PREFIX}${deploymentId}`
+		)
+		.map((entry) => join(directory, entry.name));
+}
+
+export async function hasCompleteStagedApplication(stagingDirPath: string): Promise<boolean> {
+	const deploymentDirPath = dirname(stagingDirPath);
+	const [stagingRootStat, deploymentStat, stagedStat, stagedTargetStat, markerStat] = await Promise.all([
+		lstat(dirname(deploymentDirPath)).catch(() => undefined),
+		lstat(deploymentDirPath).catch(() => undefined),
+		lstat(stagingDirPath).catch(() => undefined),
+		stat(stagingDirPath).catch(() => undefined),
+		lstat(join(deploymentDirPath, STAGED_COMPLETE_MARKER)).catch(() => undefined),
+	]);
+	return (
+		!!stagingRootStat?.isDirectory() &&
+		!stagingRootStat.isSymbolicLink() &&
+		!!deploymentStat?.isDirectory() &&
+		!deploymentStat.isSymbolicLink() &&
+		!!stagedStat &&
+		(stagedStat.isDirectory() || stagedStat.isSymbolicLink()) &&
+		!!stagedTargetStat?.isDirectory() &&
+		!!markerStat?.isFile() &&
+		!markerStat.isSymbolicLink()
+	);
+}
+
+/** Atomically replace the live component and compensate if persistent activation work fails. */
+export async function activateStagedApplication(
+	application: Application,
+	deploymentId: string,
+	hooks: {
+		beforeSwap?: () => Promise<void>;
+		beforeCommit?: () => Promise<void>;
+		onRollback?: () => Promise<void>;
+	} = {}
+): Promise<void> {
+	const stagingDirPath = stagedApplicationPath(application.dirPath, deploymentId);
+	await withComponentPreparationLock(application.dirPath, async () => {
+		await secureStagingDeploymentDirectory(application.dirPath, deploymentId, false);
+		if (!(await hasCompleteStagedApplication(stagingDirPath))) {
+			const stagedStat = await lstat(stagingDirPath).catch(() => undefined);
+			if (!stagedStat) {
+				throw new Error(`Cannot activate ${application.name}: deployment '${deploymentId}' has no staged build`);
+			}
+			throw new Error(`Cannot activate ${application.name}: staged build is incomplete`);
+		}
+
+		const activationDir = activationStagingDirectory(application.dirPath);
+		await ensureSecureDirectory(dirname(activationDir), true, 'Component activation staging path');
+		await ensureSecureDirectory(activationDir, true, 'Component activation staging path');
+		await broadcastDeployStart(application.name);
+		let backupPath: string | undefined;
+		let newMarkerPath: string | undefined;
+		let swapped = false;
+		try {
+			await hooks.beforeSwap?.();
+			const existingArtifacts = await activationArtifacts(application.dirPath, deploymentId);
+			backupPath = existingArtifacts.find((candidate) => basename(candidate).startsWith(ACTIVATION_BACKUP_PREFIX));
+			newMarkerPath = existingArtifacts.find((candidate) => basename(candidate).startsWith(ACTIVATION_NEW_PREFIX));
+			if (!backupPath && !newMarkerPath) {
+				try {
+					await lstat(application.dirPath);
+					application.isNewComponent = false;
+					backupPath = join(
+						activationDir,
+						`${ACTIVATION_BACKUP_PREFIX}${deploymentId}-${Date.now()}-${process.pid}-${randomUUID()}`
+					);
+					await rename(application.dirPath, backupPath);
+				} catch (error) {
+					if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+					application.isNewComponent = true;
+					newMarkerPath = join(activationDir, `${ACTIVATION_NEW_PREFIX}${deploymentId}`);
+					try {
+						await writeFile(newMarkerPath, '', { flag: 'wx', mode: 0o600 });
+					} catch (markerError) {
+						if ((markerError as NodeJS.ErrnoException).code !== 'EEXIST') throw markerError;
+						const markerStat = await lstat(newMarkerPath);
+						if (!markerStat.isFile() || markerStat.isSymbolicLink()) {
+							throw new Error(`Component activation marker is not a regular file: ${newMarkerPath}`);
+						}
+					}
+				}
+			}
+			await rename(stagingDirPath, application.dirPath);
+			swapped = true;
+			await hooks.beforeCommit?.();
+		} catch (error) {
+			const rollbackErrors: unknown[] = [];
+			if (swapped) {
+				try {
+					await rename(application.dirPath, stagingDirPath);
+				} catch (rollbackError) {
+					rollbackErrors.push(rollbackError);
+				}
+			}
+			if (backupPath) {
+				try {
+					await rename(backupPath, application.dirPath);
+				} catch (rollbackError) {
+					rollbackErrors.push(rollbackError);
+				}
+			}
+			if (newMarkerPath)
+				await rm(newMarkerPath, { force: true }).catch((rollbackError) => rollbackErrors.push(rollbackError));
+			try {
+				await hooks.onRollback?.();
+			} catch (rollbackError) {
+				rollbackErrors.push(rollbackError);
+			}
+			if (rollbackErrors.length) {
+				throw new AggregateError(
+					[error, ...rollbackErrors],
+					`Failed to activate and fully restore ${application.name}`
+				);
+			}
+			throw error;
+		} finally {
+			broadcastDeployEnd(application.name);
+		}
+		if (backupPath) await rm(backupPath, { recursive: true, force: true });
+		if (newMarkerPath) await rm(newMarkerPath, { force: true });
+		await rmdir(activationDir).catch((error) => {
+			if (!['ENOENT', 'ENOTEMPTY'].includes((error as NodeJS.ErrnoException).code ?? '')) throw error;
+		});
+	});
+	await rm(dirname(stagingDirPath), { recursive: true, force: true }).catch((error) =>
+		logger.warn(`Failed to remove committed deploy staging for ${application.name}:`, errorForLog(error))
+	);
+}
+
+export async function discardStagedApplication(componentDirPath: string, deploymentId: string): Promise<void> {
+	const stagingDirPath = stagedApplicationPath(componentDirPath, deploymentId);
+	await withComponentPreparationLock(componentDirPath, async () => {
+		if (!(await secureStagingDeploymentDirectory(componentDirPath, deploymentId, false))) return;
+		await rm(dirname(stagingDirPath), { recursive: true, force: true });
+	});
+}
+
+export async function discardProjectStagedApplications(componentDirPath: string): Promise<void> {
+	const stagingRoot = join(dirname(componentDirPath), DEPLOY_STAGING_DIR);
+	if (!(await ensureSecureDirectory(stagingRoot, false, 'Component deploy staging path'))) return;
+	for (const entry of await readdir(stagingRoot, { withFileTypes: true })) {
+		if (!entry.isDirectory() || !DEPLOYMENT_ID_PATTERN.test(entry.name)) continue;
+		const deploymentDirPath = join(stagingRoot, entry.name);
+		if (existsSync(join(deploymentDirPath, basename(componentDirPath)))) {
+			await rm(deploymentDirPath, { recursive: true, force: true });
+		}
+	}
+}
+
+export async function discardProjectActivationArtifacts(componentDirPath: string): Promise<void> {
+	const activationRoot = join(dirname(componentDirPath), DEPLOY_ACTIVATION_DIR);
+	if (!(await ensureSecureDirectory(activationRoot, false, 'Component activation staging path'))) return;
+	await rm(activationStagingDirectory(componentDirPath), { recursive: true, force: true });
+	await rmdir(activationRoot).catch((error) => {
+		if (!['ENOENT', 'ENOTEMPTY'].includes((error as NodeJS.ErrnoException).code ?? '')) throw error;
+	});
+}
+
+type DeploymentLookup = (deploymentId: string) => Promise<Record<string, any> | undefined>;
+
+function safeComponentName(name: unknown): name is string {
+	return typeof name === 'string' && /^[a-zA-Z0-9_-]+$/.test(name);
+}
+
+function activationArtifactDeploymentId(name: string): string | undefined {
+	const prefix = name.startsWith(ACTIVATION_BACKUP_PREFIX)
+		? ACTIVATION_BACKUP_PREFIX
+		: name.startsWith(ACTIVATION_NEW_PREFIX)
+			? ACTIVATION_NEW_PREFIX
+			: undefined;
+	if (!prefix) return undefined;
+	const deploymentId = name.slice(prefix.length, prefix.length + 36);
+	return DEPLOYMENT_ID_PATTERN.test(deploymentId) ? deploymentId : undefined;
+}
+
+async function removeActivationArtifacts(componentDirPath: string, deploymentId: string): Promise<void> {
+	for (const artifact of await activationArtifacts(componentDirPath, deploymentId)) {
+		await rm(artifact, { recursive: true, force: true });
+	}
+	await rmdir(activationStagingDirectory(componentDirPath)).catch(() => {});
+}
+
+export async function reconcileStagedApplicationArtifacts(
+	componentsRootDirPath: string,
+	getDeployment: DeploymentLookup,
+	persistActivation: (row: Record<string, any>) => Promise<void>
+): Promise<{ recovered: string[]; removed: string[]; errors: Map<string, Error> }> {
+	const recovered = new Set<string>();
+	const removed: string[] = [];
+	const errors = new Map<string, Error>();
+	const stagingRoot = join(componentsRootDirPath, DEPLOY_STAGING_DIR);
+	let deploymentEntries = [];
+	try {
+		if (await ensureSecureDirectory(stagingRoot, false, 'Component deploy staging path')) {
+			deploymentEntries = await readdir(stagingRoot, { withFileTypes: true });
+		}
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+	}
+
+	for (const entry of deploymentEntries) {
+		const deploymentPath = join(stagingRoot, entry.name);
+		if (!entry.isDirectory() || !DEPLOYMENT_ID_PATTERN.test(entry.name)) {
+			await rm(deploymentPath, { recursive: true, force: true });
+			removed.push(entry.name);
+			continue;
+		}
+		try {
+			let row = await getDeployment(entry.name);
+			if (!row || !safeComponentName(row.project)) {
+				await rm(deploymentPath, { recursive: true, force: true });
+				removed.push(entry.name);
+				continue;
+			}
+			const componentDirPath = join(componentsRootDirPath, row.project);
+			if (!['staged', 'activating'].includes(row.status)) {
+				let shouldRemove = false;
+				await withComponentPreparationLock(componentDirPath, async () => {
+					row = await getDeployment(entry.name);
+					shouldRemove = !row || !safeComponentName(row.project) || !['staged', 'activating'].includes(row.status);
+					if (shouldRemove) await rm(deploymentPath, { recursive: true, force: true });
+				});
+				if (shouldRemove) {
+					removed.push(entry.name);
+					continue;
+				}
+			}
+			const stagedPath = stagedApplicationPath(componentDirPath, entry.name);
+			if (row.status === 'staged') {
+				if (!(await hasCompleteStagedApplication(stagedPath))) {
+					throw new Error(`Staged deployment '${entry.name}' has no valid component tree for '${row.project}'`);
+				}
+				continue;
+			}
+			if (await hasCompleteStagedApplication(stagedPath)) {
+				await activateStagedApplication(new Application({ name: row.project }), entry.name, {
+					beforeCommit: () => persistActivation(row),
+				});
+			} else {
+				const liveStat = await lstat(componentDirPath).catch(() => undefined);
+				if (!liveStat?.isDirectory() || liveStat.isSymbolicLink()) {
+					throw new Error(`Interrupted activation '${entry.name}' has neither a staged nor live component tree`);
+				}
+				await persistActivation(row);
+			}
+			await removeActivationArtifacts(componentDirPath, entry.name);
+			recovered.add(entry.name);
+		} catch (error) {
+			errors.set(entry.name, error instanceof Error ? error : new Error(String(error)));
+		}
+	}
+
+	const activationRoot = join(componentsRootDirPath, DEPLOY_ACTIVATION_DIR);
+	if (await ensureSecureDirectory(activationRoot, false, 'Component activation staging path')) {
+		for (const projectEntry of await readdir(activationRoot, { withFileTypes: true })) {
+			const projectPath = join(activationRoot, projectEntry.name);
+			if (!projectEntry.isDirectory() || !safeComponentName(projectEntry.name)) {
+				await rm(projectPath, { recursive: true, force: true });
+				continue;
+			}
+			for (const artifact of await readdir(projectPath, { withFileTypes: true })) {
+				const deploymentId = activationArtifactDeploymentId(artifact.name);
+				const artifactPath = join(projectPath, artifact.name);
+				if (!deploymentId) {
+					await rm(artifactPath, { recursive: true, force: true });
+					continue;
+				}
+				const row = await getDeployment(deploymentId).catch(() => undefined);
+				const livePath = join(componentsRootDirPath, projectEntry.name);
+				const liveStat = await lstat(livePath).catch(() => undefined);
+				if (row?.status === 'activating' && row.project === projectEntry.name && liveStat?.isDirectory()) {
+					try {
+						await persistActivation(row);
+						await rm(artifactPath, { recursive: true, force: true });
+						recovered.add(deploymentId);
+					} catch (error) {
+						errors.set(deploymentId, error instanceof Error ? error : new Error(String(error)));
+					}
+				} else if (artifact.name.startsWith(ACTIVATION_BACKUP_PREFIX) && !liveStat) {
+					await rename(artifactPath, livePath);
+				} else {
+					await rm(artifactPath, { recursive: true, force: true });
+				}
+			}
+			await rmdir(projectPath).catch(() => {});
+		}
+		await rmdir(activationRoot).catch(() => {});
+	}
+	await rmdir(stagingRoot).catch(() => {});
+	return { recovered: [...recovered], removed, errors };
 }
 
 /**
@@ -1672,6 +2065,95 @@ async function persistApplicationLock(
 		});
 	applicationLockWriteQueues.set(harperApplicationLockPath, next);
 	await next;
+}
+
+function applicationConfigFromActivationSpec(spec: Record<string, any>): ApplicationConfig | undefined {
+	if (!spec.package) return undefined;
+	const applicationConfig: ApplicationConfig = { package: spec.package };
+	if (spec.install_command !== null || spec.install_timeout !== null || spec.install_allow_scripts !== null) {
+		applicationConfig.install = {};
+		if (spec.install_command !== null) applicationConfig.install.command = spec.install_command;
+		if (spec.install_timeout !== null) applicationConfig.install.timeout = spec.install_timeout;
+		if (spec.install_allow_scripts !== null) applicationConfig.install.allowInstallScripts = spec.install_allow_scripts;
+	}
+	if (spec.urlPath !== null) applicationConfig.urlPath = spec.urlPath;
+	if (spec.host !== null) applicationConfig.host = spec.host;
+	if (spec.credentials?.length) applicationConfig.credentials = spec.credentials;
+	return applicationConfig;
+}
+
+async function readApplicationLock(lockPath: string): Promise<{ applications: Record<string, ApplicationConfig> }> {
+	try {
+		const lock = JSON.parse(await readFile(lockPath, 'utf8'));
+		if (!lock.applications || typeof lock.applications !== 'object') lock.applications = {};
+		return lock;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { applications: {} };
+		throw error;
+	}
+}
+
+/** Persist a runtime activation into the boot-time application lock, or remove it during compensation. */
+export async function updateApplicationLockEntry(
+	name: string,
+	applicationConfig: ApplicationConfig | undefined
+): Promise<void> {
+	const lockPath = join(getConfigValue(CONFIG_PARAMS.ROOTPATH), 'harper-application-lock.json');
+	const previous = applicationLockWriteQueues.get(lockPath) ?? Promise.resolve();
+	const next = previous
+		.catch(() => {})
+		.then(async () => {
+			const lock = await readApplicationLock(lockPath);
+			if (applicationConfig === undefined) delete lock.applications[name];
+			else lock.applications[name] = applicationConfig;
+			const tempPath = `${lockPath}.${process.pid}.${randomUUID()}.tmp`;
+			await writeFile(tempPath, JSON.stringify(lock, null, 2), 'utf8');
+			await rename(tempPath, lockPath);
+		});
+	applicationLockWriteQueues.set(lockPath, next);
+	await next;
+}
+
+async function getApplicationLockEntry(name: string): Promise<ApplicationConfig | undefined> {
+	const lockPath = join(getConfigValue(CONFIG_PARAMS.ROOTPATH), 'harper-application-lock.json');
+	const previous = applicationLockWriteQueues.get(lockPath) ?? Promise.resolve();
+	let entry: ApplicationConfig | undefined;
+	const read = previous
+		.catch(() => {})
+		.then(async () => {
+			entry = (await readApplicationLock(lockPath)).applications[name];
+		});
+	applicationLockWriteQueues.set(lockPath, read);
+	await read;
+	return entry;
+}
+
+export async function createApplicationActivationTransaction(
+	project: string,
+	spec: Record<string, any>
+): Promise<{ commit(): Promise<void>; rollback(): Promise<void> }> {
+	const nextConfig = applicationConfigFromActivationSpec(spec);
+	if (!nextConfig) return { commit: async () => {}, rollback: async () => {} };
+	let previousConfig: ApplicationConfig | undefined;
+	let previousLockConfig: ApplicationConfig | undefined;
+	let commitStarted = false;
+	return {
+		async commit() {
+			if (commitStarted) return;
+			previousConfig = readConfigFile()?.[project];
+			previousLockConfig = await getApplicationLockEntry(project);
+			commitStarted = true;
+			await addConfig(project, nextConfig);
+			await updateApplicationLockEntry(project, nextConfig);
+		},
+		async rollback() {
+			if (!commitStarted) return;
+			if (previousConfig === undefined) deleteConfigFromFile([project]);
+			else await addConfig(project, previousConfig);
+			await updateApplicationLockEntry(project, previousLockConfig);
+			commitStarted = false;
+		},
+	};
 }
 
 /**

--- a/components/componentLoader.ts
+++ b/components/componentLoader.ts
@@ -49,13 +49,19 @@ import { lifecycle as componentLifecycle } from './status/index.ts';
 import { DEFAULT_CONFIG } from './DEFAULT_CONFIG.ts';
 import { materializeGlobalSecrets, processComponentEnv } from './componentSecrets.ts';
 import { PluginModule } from './PluginModule.ts';
-import { getEnvBuiltInComponents } from './Application.ts';
+import {
+	getEnvBuiltInComponents,
+	createApplicationActivationTransaction,
+	reconcileStagedApplicationArtifacts,
+} from './Application.ts';
+import { getDeploymentRow } from './deploymentRecorder.ts';
 import { pathToFileURL } from 'node:url';
 
 const CF_ROUTES_DIR = getConfigPath(CONFIG_PARAMS.COMPONENTSROOT);
 let loadedComponents = new Map<any, any>();
 let watchesSetup;
 let resources;
+let stagedArtifactsReconciled = false;
 
 /**
  * Load all the applications registered in Harper, those in the components directory as well as any directly
@@ -66,6 +72,38 @@ let resources;
 export async function loadComponentDirectories(loadedPluginModules?: Map<any, any>, loadedResources?: Resources) {
 	if (loadedResources) resources = loadedResources;
 	if (loadedPluginModules) loadedComponents = loadedPluginModules;
+	if (isMainThread && !stagedArtifactsReconciled) {
+		stagedArtifactsReconciled = true;
+		try {
+			const reconciliation = await reconcileStagedApplicationArtifacts(CF_ROUTES_DIR, getDeploymentRow, async (row) => {
+				const transaction = await createApplicationActivationTransaction(row.project, row.activation_spec);
+				try {
+					await transaction.commit();
+				} catch (error) {
+					try {
+						await transaction.rollback();
+					} catch (rollbackError) {
+						throw new AggregateError(
+							[error, rollbackError],
+							`Could not persist or roll back the recovered component activation for '${row.project}'`
+						);
+					}
+					throw error;
+				}
+			});
+			for (const deploymentId of reconciliation.recovered) {
+				harperLogger.warn(
+					`Rolled forward interrupted component activation '${deploymentId}' on this node; ` +
+						`the deployment remains activating until cluster state is reconciled`
+				);
+			}
+			for (const [deploymentId, error] of reconciliation.errors) {
+				harperLogger.error(`Could not reconcile staged component deployment '${deploymentId}':`, errorForLog(error));
+			}
+		} catch (error) {
+			harperLogger.error('Could not inspect staged component deployments during startup:', errorForLog(error as Error));
+		}
+	}
 	// Materialize hdb_secret global-tier rows into process.env and snapshot the scoped tier before
 	// any application loads (root components — including the Pro custody registration — have
 	// already loaded by this point). Re-runs on each reload cycle, which is how changed/late-custody

--- a/components/deploymentOperations.ts
+++ b/components/deploymentOperations.ts
@@ -101,8 +101,8 @@ export async function handleGetDeployment(req: GetRequest): Promise<any> {
 	// SSE content-negotiated branch — when serverHandlers.js detects
 	// `Accept: text/event-stream` it attaches a ProgressEmitter as req.progress and wraps
 	// our return as the operation's final SSE event. We replay event_log on connect, then
-	// tail the deployment's live emitter (if it's still running on this node) until it
-	// reaches a terminal status. The final return value becomes the SSE `done` event.
+	// tail the deployment's live emitter (if it's still running on this node) until its
+	// recorder finishes. The final return value becomes the SSE `done` event.
 	if (req.progress && typeof (req.progress as any).emit === 'function') {
 		const sse = req.progress;
 		const liveEmitter = getActiveEmitter(req.deployment_id);
@@ -150,7 +150,10 @@ export async function handleGetDeployment(req: GetRequest): Promise<any> {
 				if (typeof entry.t === 'number') lastReplayedTs = Math.max(lastReplayedTs, entry.t);
 			}
 
-			if (liveEmitter && !TERMINAL_STATUSES.has(row.status)) {
+			// A full two-phase deploy checkpoints `staged` before immediately entering activation.
+			// The live emitter, not that transient row status, is authoritative for whether this
+			// origin is still running the deployment.
+			if (liveEmitter) {
 				await new Promise<void>((resolve) => {
 					resolveLive = resolve;
 					// Flush anything that arrived during replay, filtering to events the replay missed.
@@ -170,7 +173,10 @@ export async function handleGetDeployment(req: GetRequest): Promise<any> {
 						if (!live || live !== liveEmitter) {
 							clearInterval(pollTimer);
 							const latest = await table.get(req.deployment_id);
-							if (latest && TERMINAL_STATUSES.has(latest.status) && !liveDone) {
+							// `staged` is a valid resting result and `activating` records
+							// uncertain cluster completion. If the original emitter is gone,
+							// there is no local work left to tail in either state.
+							if (latest && !liveDone) {
 								liveDone = true;
 								resolve();
 							}

--- a/components/deploymentRecorder.ts
+++ b/components/deploymentRecorder.ts
@@ -6,8 +6,8 @@
 // payload_blob (with sha256 + size), and writes the terminal status at the end.
 // Subscribes to a ProgressEmitter so phase transitions and install lines land in
 // event_log as they happen — making the deploy observable by Studio polling
-// get_deployment without an attached CLI. The persisted payload_blob will also serve
-// as the rollback source when that operation lands.
+// get_deployment without an attached CLI. The persisted payload_blob also serves as
+// the replication source for peer staging.
 
 import { randomUUID } from 'node:crypto';
 import { createHash } from 'node:crypto';
@@ -50,14 +50,14 @@ type DeploymentStatus =
 	| 'extracting'
 	| 'installing'
 	// Two-phase deploy: building the incoming version into staging cluster-wide (stage phase), and the
-	// terminal resting state of a stage_component that has not yet been activated.
+	// terminal resting state of a deploy_component stage that has not yet been activated.
 	| 'staging'
 	| 'staged'
 	| 'loading'
 	| 'replicating'
 	// Two-phase deploy: swapping the staged build into the live path cluster-wide (activate phase).
 	| 'activating'
-	// revert_component: swapping the live version back to its retained previous version.
+	// Retained for compatibility with deployment rows written by earlier preview builds.
 	| 'reverting'
 	| 'restarting'
 	| 'success'
@@ -71,10 +71,10 @@ interface CreateOptions {
 	restart_mode?: 'immediate' | 'rolling' | null;
 	rollback_of?: string | null;
 	// Deploy credentials in reference form (`{ registry, secret, scope? }` / `{ host, secret,
-	// username? }`) — never a literal token. Kept so a rollback can re-resolve the credential from
-	// hdb_secret without the operator re-supplying it. Null when the deploy used no credentials or a
-	// no-custody transient token.
+	// username? }`) — never a literal token. Peers and later activation resolve the reference from
+	// hdb_secret. Null when the deploy used no credentials or a no-custody transient token.
 	credentials?: CredentialReference[] | null;
+	activation_spec?: Record<string, unknown> | null;
 	emitter?: ProgressEmitter;
 }
 
@@ -113,6 +113,7 @@ export class DeploymentRecorder {
 			user: options.user ?? null,
 			rollback_of: options.rollback_of ?? null,
 			credentials: options.credentials ?? null,
+			activation_spec: options.activation_spec ?? null,
 			error: null,
 		};
 		const recorder = new DeploymentRecorder(deploymentId, record);
@@ -403,17 +404,24 @@ export class DeploymentRecorder {
 		this.sealed = true;
 	}
 
-	async finish(status: 'success' | 'failed' | 'rolled_back' | 'staged', error?: unknown): Promise<void> {
+	async checkpoint(status: DeploymentStatus, phase: string): Promise<void> {
 		if (this.finished) return;
-		// Send a terminal sentinel through the emitter (if any) BEFORE we unsubscribe and
-		// remove it from the registry, so any SSE tail subscribers can resolve their wait
-		// even on a code path that doesn't emit an explicit `error` event.
+		while (this.pendingPut) await this.pendingPut;
+		this.record.status = status;
+		this.record.phase = phase;
+		this.record.completed_at = null;
+		await this.put();
+	}
+
+	async finish(status: 'success' | 'failed' | 'rolled_back' | 'staged' | 'activating', error?: unknown): Promise<void> {
+		if (this.finished) return;
+		// Keep the emitter registered until the terminal row write lands. An SSE tailer may
+		// otherwise observe the sentinel, re-read the preceding staged checkpoint, and
+		// incorrectly finish with a stale result.
 		const emitter = activeEmitters.get(this.deploymentId);
-		emitter?.emit('_recorder_finished', { status });
 		this.finished = true;
 		this.unsubscribe?.();
 		this.unsubscribe = null;
-		activeEmitters.delete(this.deploymentId);
 		// Drain the ENTIRE coalesced-flush chain before mutating + persisting the terminal
 		// state. Just awaiting `this.pendingPut` once isn't enough: its `.finally` may
 		// re-schedule another put (when `dirty` was set during the in-flight put), and
@@ -428,7 +436,7 @@ export class DeploymentRecorder {
 			}
 		}
 		this.record.status = status;
-		this.record.completed_at = Date.now();
+		this.record.completed_at = status === 'activating' ? null : Date.now();
 		if (error) {
 			const e = error as { message?: string; code?: string | number; stack?: string };
 			this.record.error = {
@@ -437,7 +445,15 @@ export class DeploymentRecorder {
 				phase: this.record.phase,
 			};
 		}
-		await this.put();
+		try {
+			await this.put();
+		} finally {
+			// Emit after persistence but before removing the registry entry so subscribers
+			// always have a durable terminal row to re-read. The sentinel also releases
+			// tailers on failure paths that did not emit an explicit error event.
+			emitter?.emit('_recorder_finished', { status });
+			activeEmitters.delete(this.deploymentId);
+		}
 	}
 
 	get row(): Record<string, any> {
@@ -472,7 +488,7 @@ export async function getDeploymentRow(deploymentId: string): Promise<Record<str
 }
 
 /**
- * Best-effort terminal-status update for an existing deployment row by id, used when a later operation
+ * Best-effort status update for an existing deployment row by id, used when a later operation
  * finishes a deployment the current process didn't record with a live DeploymentRecorder — e.g.
  * `deploy_component({ deployment_id })` activating a build that an earlier stage-and-stop left in the
  * `staged` state. No-op when the row (or the table) is absent; observability only, so callers treat a
@@ -480,7 +496,8 @@ export async function getDeploymentRow(deploymentId: string): Promise<Record<str
  */
 export async function markDeploymentTerminal(
 	deploymentId: string,
-	status: 'success' | 'failed' | 'rolled_back' | 'staged'
+	status: 'success' | 'failed' | 'rolled_back' | 'staged' | 'activating',
+	error?: unknown
 ): Promise<void> {
 	const table = (databases as any).system?.[terms.SYSTEM_TABLE_NAMES.DEPLOYMENT_TABLE_NAME];
 	if (!table) return;
@@ -489,13 +506,112 @@ export async function markDeploymentTerminal(
 	// Patch (partial update) rather than mutating the row: table.get() returns a read-only record, so
 	// `row.status = …` throws "Cannot assign to read only property". A patch also touches only these two
 	// fields, so it can't truncate the rest of the row the way a spread-and-put might.
-	await table.patch(deploymentId, { status, completed_at: Date.now() });
+	const update: Record<string, unknown> = {
+		status,
+		completed_at: status === 'activating' ? null : Date.now(),
+	};
+	if (error !== undefined) {
+		update.error = {
+			message: error instanceof Error ? error.message : String(error),
+		};
+	}
+	await table.patch(deploymentId, update);
+}
+
+export async function recordDeploymentPeers(deploymentId: string, results: unknown): Promise<void> {
+	if (!Array.isArray(results) || results.length === 0) return;
+	const table = (databases as any).system?.[terms.SYSTEM_TABLE_NAMES.DEPLOYMENT_TABLE_NAME];
+	if (!table) return;
+	const row = await table.get(deploymentId);
+	if (!row) return;
+	const peers = Array.isArray(row.peer_results)
+		? row.peer_results.map((entry: unknown) => ({ ...(entry as object) }))
+		: [];
+	for (const result of results) {
+		const normalized = normalizePeerResult(result);
+		const index = normalized.node ? peers.findIndex((entry: any) => entry.node === normalized.node) : -1;
+		if (index >= 0) peers[index] = normalized;
+		else peers.push(normalized);
+	}
+	await table.patch(deploymentId, { peer_results: peers });
+}
+
+/** Claim a staged deployment for activation while the component preparation lock is held. */
+export async function claimStagedDeployment(
+	deploymentId: string,
+	project: string,
+	options: { allowActivating?: boolean; waitForStagedMs?: number } = {}
+): Promise<Record<string, any>> {
+	const table = (databases as any).system?.[terms.SYSTEM_TABLE_NAMES.DEPLOYMENT_TABLE_NAME];
+	if (!table) throw new ClientError('Deployment tracking is unavailable; cannot activate a staged deployment');
+	const deadline = Date.now() + coerceTimeoutMs(options.waitForStagedMs, 0);
+	let row = await table.get(deploymentId);
+	if (!row) throw new ClientError(`No deployment found with id '${deploymentId}'`);
+	if (row.project !== project) {
+		throw new ClientError(`Deployment '${deploymentId}' belongs to component '${row.project}', not '${project}'`);
+	}
+	while (['pending', 'staging'].includes(row.status) && Date.now() < deadline) {
+		await new Promise<void>((resolve) => setTimeout(resolve, Math.min(25, deadline - Date.now())));
+		row = await table.get(deploymentId);
+		if (!row) throw new ClientError(`No deployment found with id '${deploymentId}'`);
+		if (row.project !== project) {
+			throw new ClientError(`Deployment '${deploymentId}' belongs to component '${row.project}', not '${project}'`);
+		}
+	}
+	if (row.status === 'activating' && options.allowActivating) return row;
+	if (row.status !== 'staged') {
+		throw new ClientError(`Deployment '${deploymentId}' is '${row.status}', not staged and available for activation`);
+	}
+	await table.patch(deploymentId, { status: 'activating', phase: 'activate', completed_at: null, error: null });
+	return row;
 }
 
 // Deployment statuses that are settled — a non-terminal deployment's payload_blob may still be the
 // replication channel peers are installing from, so retention must never yank it mid-flight. Mirrors
 // deploymentOperations.ts's guard for the explicit delete_deployment_payload operation.
 const TERMINAL_STATUSES = new Set(['success', 'failed', 'rolled_back']);
+
+async function settleStagedRows(project: string, keepCount: number): Promise<string[]> {
+	const table = (databases as any).system?.[terms.SYSTEM_TABLE_NAMES.DEPLOYMENT_TABLE_NAME];
+	if (!table) return [];
+	const staged: Array<Record<string, any>> = [];
+	for await (const row of table.search([{ attribute: 'project', value: project }])) {
+		if (row?.status === 'staged') staged.push(row);
+	}
+	staged.sort(
+		(a, b) => (b.started_at ?? 0) - (a.started_at ?? 0) || String(a.deployment_id).localeCompare(b.deployment_id)
+	);
+	const expired = staged.slice(Math.max(0, keepCount));
+	for (const row of expired) {
+		await table.patch(row.deployment_id, {
+			status: 'failed',
+			completed_at: Date.now(),
+			error: { message: 'Staged build expired by deployment_stagingRetention_maxCount', phase: 'staged' },
+		});
+	}
+	return expired.map((row) => row.deployment_id);
+}
+
+export async function expireOldStagedDeployments(project: string, maxCount: number): Promise<string[]> {
+	const count = Number.isFinite(maxCount) ? Math.max(1, Math.floor(maxCount)) : 1;
+	return settleStagedRows(project, count);
+}
+
+export async function invalidateProjectStagedDeployments(project: string): Promise<string[]> {
+	const table = (databases as any).system?.[terms.SYSTEM_TABLE_NAMES.DEPLOYMENT_TABLE_NAME];
+	if (!table) return [];
+	const invalidated: string[] = [];
+	for await (const row of table.search([{ attribute: 'project', value: project }])) {
+		if (!['staged', 'activating'].includes(row?.status)) continue;
+		await table.patch(row.deployment_id, {
+			status: 'failed',
+			completed_at: Date.now(),
+			error: { message: 'Staged build invalidated because the component was dropped', phase: row.phase },
+		});
+		invalidated.push(row.deployment_id);
+	}
+	return invalidated;
+}
 
 /**
  * Count-based payload retention: keep at most `maxCount` stored payload tarballs for a project,
@@ -579,7 +695,12 @@ export function coerceTimeoutMs(value: unknown, fallback: number): number {
  */
 export async function awaitDeploymentRow(
 	deploymentId: string,
-	options: { timeoutMs?: number; pollIntervalMs?: number; initialPollIntervalMs?: number } = {}
+	options: {
+		timeoutMs?: number;
+		pollIntervalMs?: number;
+		initialPollIntervalMs?: number;
+		requirePayload?: boolean;
+	} = {}
 ): Promise<Record<string, any>> {
 	// Coerce defensively: the deploy operation's `deployment_timeout` reaches us via the
 	// operation body, and the Joi validator's coerced number is discarded by validateBySchema
@@ -594,6 +715,7 @@ export async function awaitDeploymentRow(
 	// human-noticeable latency, then back off exponentially up to maxIntervalMs for the
 	// rare case where the row is genuinely still replicating.
 	let intervalMs = options.initialPollIntervalMs ?? 5;
+	const requirePayload = options.requirePayload !== false;
 	const table = (databases as any).system?.[terms.SYSTEM_TABLE_NAMES.DEPLOYMENT_TABLE_NAME];
 	if (!table) {
 		throw new Error(
@@ -610,7 +732,7 @@ export async function awaitDeploymentRow(
 		try {
 			const row = await table.get(deploymentId);
 			if (row) {
-				if (row.payload_blob != null) return row;
+				if (!requirePayload || row.payload_blob != null) return row;
 				// Row replicated but its payload_blob write hasn't landed yet — replication is
 				// alive, just mid-flight. Remember this so the timeout message points at the
 				// payload write rather than a dead channel.

--- a/components/operations.js
+++ b/components/operations.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('node:path');
+const { isDeepStrictEqual } = require('node:util');
 const { isMainThread } = require('node:worker_threads');
 const fs = require('fs-extra');
 const fg = require('fast-glob');
@@ -30,12 +31,20 @@ const {
 	stageApplication,
 	activateApplication,
 	revertApplication,
+	stagedApplicationPath,
+	hasCompleteStagedApplication,
+	activateStagedApplication,
 	discardStagedApplication,
+	discardProjectStagedApplications,
+	discardProjectActivationArtifacts,
+	updateApplicationLockEntry,
+	createApplicationActivationTransaction,
 	ASIDE_STAGING_DIR,
 	DEPLOY_STAGING_DIR,
+	DEPLOY_ACTIVATION_DIR,
 	DEPLOY_PREVIOUS_DIR,
 } = require('./Application.ts');
-const { COMPONENT_PREPARATION_LOCK_DIR } = require('./componentPreparationLock.ts');
+const { COMPONENT_PREPARATION_LOCK_DIR, withComponentPreparationLock } = require('./componentPreparationLock.ts');
 const { server } = require('../server/Server.ts');
 const {
 	DeploymentRecorder,
@@ -43,12 +52,17 @@ const {
 	getDeploymentRow,
 	markDeploymentTerminal,
 	normalizePeerResult,
+	recordDeploymentPeers,
+	claimStagedDeployment,
+	expireOldStagedDeployments,
+	invalidateProjectStagedDeployments,
 	pruneProjectPayloads,
 	readPayloadBlobWithRetry,
 	coerceTimeoutMs,
 	DEFAULT_AWAIT_ROW_TIMEOUT_MS,
 } = require('./deploymentRecorder.ts');
 const { ProgressEmitter } = require('../server/serverHelpers/progressEmitter.ts');
+const { isOperationAuthorizationBypassed } = require('../server/serverHelpers/operationAuthorizationState.ts');
 
 /**
  * Read the settings.js file and return the
@@ -319,7 +333,11 @@ async function dropCustomFunctionProject(req) {
 
 	try {
 		const projectDir = path.join(cfDir, project);
+		await invalidateProjectStagedDeployments(project);
+		await discardProjectStagedApplications(projectDir);
+		await discardProjectActivationArtifacts(projectDir);
 		fs.rmSync(projectDir, { recursive: true });
+		await updateApplicationLockEntry(project, undefined);
 		let response = await server.replication.replicateOperation(req);
 		response.message = `Successfully deleted project: ${project}`;
 		return response;
@@ -398,18 +416,52 @@ async function deployComponent(req) {
 		req.project = getProjectNameFromPackage(req.package);
 	}
 
-	const validation = validator.deployComponentValidator(req);
+	const isReplicatedExecution = isTrustedReplicatedOperation(req);
+	let requestToValidate = req;
+	if (isReplicatedExecution) {
+		if (req._phase !== undefined) {
+			throw new ServerError(
+				`Unsupported legacy component deployment phase '${req._phase}'; upgrade the originating node before deploying`
+			);
+		}
+		const { _deploymentId, ...publicRequest } = req;
+		requestToValidate = publicRequest;
+	}
+	const validation = validator.deployComponentValidator(requestToValidate);
 	if (validation) {
 		throw handleHDBError(validation, validation.message, HTTP_STATUS_CODES.BAD_REQUEST);
 	}
-
-	const isReplicatedExecution = typeof req._deploymentId === 'string';
-
-	// Internal peer-phase execution. The two-phase cluster fan-out rides deploy_component itself, tagged
-	// with an internal `_phase` marker (`stage`/`activate`) rather than separate public operations — so
-	// the wire format is deploy_component + `_phase`, and only deploy_component is publicly exposed.
-	if (isReplicatedExecution && req._phase === 'stage') return deployPhaseStage(req);
-	if (isReplicatedExecution && req._phase === 'activate') return deployPhaseActivate(req);
+	const systemReplicated = isSystemDatabaseReplicated();
+	const requestedSeparatedPhase = req.activate === false || req.deployment_id !== undefined;
+	if (!isReplicatedExecution && req.two_phase === true && req.replicated === false) {
+		throw handleHDBError(
+			new Error(),
+			`two_phase:true requires operation replication to be enabled`,
+			HTTP_STATUS_CODES.BAD_REQUEST
+		);
+	}
+	if (!isReplicatedExecution && req.two_phase === true && !systemReplicated) {
+		throw handleHDBError(
+			new Error(),
+			`two_phase:true requires system database replication to be enabled`,
+			HTTP_STATUS_CODES.BAD_REQUEST
+		);
+	}
+	if (
+		!isReplicatedExecution &&
+		requestedSeparatedPhase &&
+		(req.two_phase === false || req.replicated === false || !systemReplicated)
+	) {
+		throw handleHDBError(
+			new Error(),
+			`activate:false and deployment_id require two-phase deploy with system database replication enabled`,
+			HTTP_STATUS_CODES.BAD_REQUEST
+		);
+	}
+	if (req.replicated !== false && !isReplicatedExecution && req.two_phase !== false && systemReplicated) {
+		if (req.deployment_id) return deployComponentActivateExisting(req);
+		return deployComponentTwoPhase(req);
+	}
 
 	// Ingest any provided credential token into the secrets store so the credential lives as
 	// replicated ciphertext (reference, not embed); already-reference entries pass through, and with
@@ -421,19 +473,7 @@ async function deployComponent(req) {
 	// token is not — it is used only for this node's install, then stripped before replication.
 	const credentialReferences = (req.credentials ?? []).filter((entry) => entry && entry.secret !== undefined);
 
-	// Two-phase is the default, but it leans on the system table's replication channel to carry the
-	// payload and correlate the stage/activate steps across the cluster. Fall back to the legacy
-	// one-shot deploy when: the caller opted out (`two_phase: false`); this is a legacy peer replaying a
-	// one-shot deploy (replicated, no `_phase`); or `system` isn't replicated on this node.
-	if (req.two_phase === false || isReplicatedExecution || !isSystemDatabaseReplicated()) {
-		return deployComponentOneShot(req, credentialReferences, isReplicatedExecution);
-	}
-
-	// `deployment_id` with no fresh payload → activate a previously-staged deployment (the second half of
-	// a stage-then-activate-later flow). Otherwise run the full stage+activate (which itself honors
-	// `activate: false` to stop after the cluster-wide staged barrier).
-	if (req.deployment_id) return deployComponentActivateExisting(req, credentialReferences);
-	return deployComponentTwoPhase(req, credentialReferences);
+	return deployComponentOneShot(req, credentialReferences, isReplicatedExecution);
 }
 
 /**
@@ -618,7 +658,7 @@ async function deployComponentOneShot(req, credentialReferences, isReplicatedExe
  * every node (phase 2, activate_component). The live component on every node is untouched until the
  * whole cluster has the bits in place, and the go-live window is just the swap + restart.
  */
-async function deployComponentTwoPhase(req, credentialReferences) {
+async function _legacyDeployComponentTwoPhase(req, credentialReferences) {
 	const { resolveCredentials } = require('./secretOperations.ts');
 	// Fail fast on a protected core name before we create any state or touch the cluster.
 	if (req.package) assertNotProtectedCoreComponent(req.project, req.force);
@@ -783,7 +823,7 @@ async function deployComponentTwoPhase(req, credentialReferences) {
  * path, writing config, or restarting. A failure here fails this peer's stage, which the origin's
  * barrier catches. No recorder (the origin owns the row) and no re-replication.
  */
-async function deployPhaseStage(req) {
+async function _legacyDeployPhaseStage(req) {
 	const { resolveCredentials } = require('./secretOperations.ts');
 	const emitter = null; // peers stream nothing back; the origin owns the emitter/recorder
 	const emit = () => {};
@@ -818,7 +858,7 @@ async function deployPhaseStage(req) {
  * id) into the live path, persist root config for a package deploy, and restart if the origin asked
  * for an immediate restart. No recorder, no re-replication.
  */
-async function deployPhaseActivate(req) {
+async function _legacyDeployPhaseActivate(req) {
 	if (req.package) assertNotProtectedCoreComponent(req.project, req.force);
 	const credentialReferences = (req.credentials ?? []).filter((entry) => entry && entry.secret !== undefined);
 	const application = new Application({
@@ -845,7 +885,7 @@ async function deployPhaseActivate(req) {
  * into the live path on the origin, replicates the activate phase to peers (each activates its own
  * staged copy of the same deployment id), restarts, and marks the deployment row success.
  */
-async function deployComponentActivateExisting(req, credentialReferences) {
+async function _legacyDeployComponentActivateExisting(req, credentialReferences) {
 	const stagingId = req.deployment_id;
 	// An activate-by-id call carries no `package` — `harper activate` sends only project + deployment_id,
 	// and the docs describe this path as fetching/installing nothing — so recover the staged deployment's
@@ -972,7 +1012,505 @@ async function deployComponentActivateExisting(req, credentialReferences) {
  * Reached two ways: directly by an operator, and by a peer replaying a replicated revert
  * (`_deploymentId` set). deploy_component's `revert_on_failure` path drives it internally.
  */
-async function revertComponent(req) {
+function activationSpecFromRequest(req, credentialReferences) {
+	return {
+		project: req.project,
+		package: req.package ?? null,
+		install_command: req.install_command ?? null,
+		install_timeout: req.install_timeout ?? null,
+		install_allow_scripts: req.install_allow_scripts ?? null,
+		urlPath: req.urlPath ?? null,
+		host: req.host ?? null,
+		credentials: credentialReferences.length ? credentialReferences : null,
+		force: req.force === true,
+	};
+}
+
+function applicationFromSpec(spec, payload, resolvedCredentials, installCapture, emit) {
+	return new Application({
+		name: spec.project,
+		payload,
+		packageIdentifier: spec.package ?? undefined,
+		install: {
+			command: spec.install_command ?? undefined,
+			timeout: spec.install_timeout ?? undefined,
+			allowInstallScripts: spec.install_allow_scripts ?? undefined,
+		},
+		credentials: resolvedCredentials,
+		onInstallLine: (manager, stream, line) => {
+			installCapture?.push(manager, stream, line);
+			emit?.('install', { manager, stream, line });
+		},
+	});
+}
+
+function failedPeerResults(results) {
+	return (results ?? []).filter((result) => result?.status === 'failed' || result?.error || result?.reason);
+}
+
+function describePeerFailures(failed) {
+	return failed
+		.map((peer) => `${peer.node ?? 'unknown'} (${peer.error?.message ?? peer.reason ?? 'unknown error'})`)
+		.join(', ');
+}
+
+function buildPhaseOperation(phase, deploymentId, project, activationSpec, extra = {}) {
+	return {
+		operation: hdbTerms.OPERATIONS_ENUM.COMPONENT_DEPLOY_PHASE,
+		phase,
+		deployment_id: deploymentId,
+		project,
+		activation_spec: activationSpec,
+		...extra,
+	};
+}
+
+async function resolveSpecCredentials(spec, waitMs = 0) {
+	const { resolveCredentials } = require('./secretOperations.ts');
+	return resolveCredentials(spec.credentials ?? [], spec.project, { waitMs });
+}
+
+function assertStoredActivationSpec(row, deploymentId, project, spec, allowedStatuses) {
+	if (
+		!row ||
+		row.project !== project ||
+		!allowedStatuses.includes(row.status) ||
+		!isDeepStrictEqual(row.activation_spec, spec)
+	) {
+		throw new ServerError(
+			`Deployment '${deploymentId}' does not have the expected immutable activation specification for '${project}'`
+		);
+	}
+}
+
+async function sourceStagedPayload(deploymentId, spec, timeoutMs) {
+	const deadline = Date.now() + timeoutMs;
+	const row = await awaitDeploymentRow(deploymentId, { timeoutMs, requirePayload: !spec.package });
+	assertStoredActivationSpec(row, deploymentId, spec.project, spec, ['pending', 'staging', 'staged', 'activating']);
+	if (spec.package) return undefined;
+	return readPayloadBlobWithRetry(() => row.payload_blob.stream(), {
+		timeoutMs: Math.max(0, deadline - Date.now()),
+	});
+}
+
+async function discardDeploymentEverywhere(project, deploymentId, activationSpec) {
+	const componentPath = path.join(configUtils.getConfigPath(hdbTerms.CONFIG_PARAMS.COMPONENTSROOT), project);
+	await discardStagedApplication(componentPath, deploymentId).catch(() => {});
+	await server.replication
+		.replicateOperation(buildPhaseOperation('discard', deploymentId, project, activationSpec))
+		.catch(() => {});
+}
+
+function getStagingRetentionMaxCount() {
+	const value = Number(env.get(hdbTerms.CONFIG_PARAMS.DEPLOYMENT_STAGINGRETENTION_MAXCOUNT));
+	return Number.isFinite(value) && value >= 1 ? Math.floor(value) : 5;
+}
+
+function getPayloadRetentionMaxCount() {
+	const value = Number(env.get(hdbTerms.CONFIG_PARAMS.DEPLOYMENT_PAYLOADRETENTION_MAXCOUNT));
+	return Number.isFinite(value) && value >= 0 ? Math.floor(value) : 1;
+}
+
+async function pruneStagedDeploymentArtifacts(project, activationSpec) {
+	const expired = await expireOldStagedDeployments(project, getStagingRetentionMaxCount());
+	for (const deploymentId of expired) await discardDeploymentEverywhere(project, deploymentId, activationSpec);
+}
+
+async function restartActivatedComponent(req, deploymentId, project, activationSpec, emit) {
+	if (req.restart === true) {
+		emit('phase', { phase: 'restart', status: 'start' });
+		const restartResponse = await server.replication.replicateOperation(
+			buildPhaseOperation('restart', deploymentId, project, activationSpec)
+		);
+		const failed = failedPeerResults(restartResponse?.replicated);
+		manageThreads.restartWorkers('http');
+		emit('phase', { phase: 'restart', status: 'done' });
+		return { restartMessage: `, restarting Harper`, replicated: restartResponse?.replicated, failedPeers: failed };
+	}
+	if (req.restart === 'rolling') {
+		const serverUtilities = require('../server/serverHelpers/serverUtilities.ts');
+		emit('phase', { phase: 'restart', status: 'start' });
+		const jobResponse = await serverUtilities.executeJob({
+			operation: 'restart_service',
+			service: 'http',
+			replicated: true,
+		});
+		emit('phase', { phase: 'restart', status: 'done' });
+		return { restartMessage: `, restarting Harper`, restartJobId: jobResponse.job_id, failedPeers: [] };
+	}
+	return { restartMessage: '', failedPeers: [] };
+}
+
+async function deployComponentTwoPhase(req) {
+	assertNotProtectedCoreComponent(req.project, req.force);
+	const { ingestCredentials, resolveCredentials } = require('./secretOperations.ts');
+	req.credentials = await ingestCredentials(req, req.credentials, req.project);
+	const credentialReferences = (req.credentials ?? []).filter((entry) => entry?.secret !== undefined);
+	const activationSpec = activationSpecFromRequest(req, credentialReferences);
+	const emitter = req.progress ?? new ProgressEmitter();
+	const emit = (event, data) => emitter.emit(event, data);
+	const installCapture = createInstallCapture();
+	const recorder = await DeploymentRecorder.create({
+		project: req.project,
+		package_identifier: req.package ?? null,
+		user: req.hdb_user?.username,
+		restart_mode: req.restart === 'rolling' ? 'rolling' : req.restart ? 'immediate' : null,
+		credentials: credentialReferences.length ? credentialReferences : null,
+		activation_spec: activationSpec,
+		emitter,
+	});
+	let application;
+	let activationCommitted = false;
+	let activationBarrierPassed = false;
+	try {
+		let payload = req.payload;
+		if (req.payload != null) {
+			await recorder.ingestPayload(req.payload);
+			payload = recorder.row.payload_blob.stream();
+		}
+		const resolvedCredentials = await resolveCredentials(req.credentials, req.project);
+		application = applicationFromSpec(activationSpec, payload, resolvedCredentials, installCapture, emit);
+		if (credentialReferences.length) req.credentials = credentialReferences;
+		else delete req.credentials;
+		delete req.progress;
+		delete req.payload;
+
+		emit('phase', { phase: 'stage', status: 'start' });
+		const stagedPath = await stageApplication(application, recorder.deploymentId);
+		await loadValidateComponent({ dirPath: stagedPath, emit });
+		recorder.seal();
+		const stageResponse = await server.replication.replicateOperation(
+			buildPhaseOperation('stage', recorder.deploymentId, req.project, activationSpec, {
+				deployment_timeout: req.deployment_timeout,
+			}),
+			{
+				onPeerResult: (result) => {
+					recorder.recordPeer(result);
+					emit('peer', result);
+				},
+			}
+		);
+		if (stageResponse?.replicated) recorder.recordPeers(stageResponse.replicated);
+		emit('phase', { phase: 'stage', status: 'done' });
+		const stageFailures = recorder.getFailedPeers();
+		if (stageFailures.length && !req.ignore_replication_errors) {
+			await discardDeploymentEverywhere(req.project, recorder.deploymentId, activationSpec);
+			throw new ServerError(
+				`Component '${req.project}' failed to stage on ${stageFailures.length} peer node(s): ` +
+					`${describePeerFailures(stageFailures)}. No node was activated and the live component is unchanged.`
+			);
+		}
+		await recorder.checkpoint('staged', 'staged');
+
+		if (req.activate === false) {
+			emit('phase', { phase: 'staged', status: 'done' });
+			await recorder.finish('staged');
+			await pruneStagedDeploymentArtifacts(req.project, activationSpec);
+			await pruneProjectPayloads(req.project, getPayloadRetentionMaxCount()).catch((error) =>
+				log.warn('Failed to prune staged deployment payloads', error)
+			);
+			return {
+				message: `Staged component: ${req.project}`,
+				project: req.project,
+				staged: true,
+				deployment_id: recorder.deploymentId,
+				replicated: stageResponse?.replicated,
+				...(stageFailures.length ? { failed_peers: stageFailures } : {}),
+			};
+		}
+
+		const configTransaction = await createApplicationActivationTransaction(req.project, activationSpec);
+		await activateStagedApplication(application, recorder.deploymentId, {
+			beforeSwap: async () => {
+				await claimStagedDeployment(recorder.deploymentId, req.project);
+				emit('phase', { phase: 'activate', status: 'start' });
+			},
+			beforeCommit: () => configTransaction.commit(),
+			onRollback: () => configTransaction.rollback(),
+		});
+		activationCommitted = true;
+		const activateResponse = await server.replication.replicateOperation(
+			buildPhaseOperation('activate', recorder.deploymentId, req.project, activationSpec),
+			{
+				onPeerResult: (result) => {
+					recorder.recordPeer(result);
+					emit('peer', result);
+				},
+			}
+		);
+		if (activateResponse?.replicated) recorder.recordPeers(activateResponse.replicated);
+		emit('phase', { phase: 'activate', status: 'done' });
+		const activateFailures = recorder.getFailedPeers();
+		if (activateFailures.length && !req.ignore_replication_errors) {
+			throw new ServerError(
+				`Component '${req.project}' activated on only part of the cluster. Split nodes: ` +
+					`${describePeerFailures(activateFailures)}. Roll forward by staging and activating a known-good deployment.`
+			);
+		}
+		activationBarrierPassed = activateFailures.length === 0;
+		if (!req.restart) markRestartRequiredForNewComponent(application);
+		const restart = await restartActivatedComponent(req, recorder.deploymentId, req.project, activationSpec, emit);
+		if (restart.failedPeers.length) recorder.recordPeers(restart.failedPeers);
+		if (restart.failedPeers.length && !req.ignore_replication_errors) {
+			throw new ServerError(
+				`Component '${req.project}' activated, but restart failed on: ${describePeerFailures(restart.failedPeers)}`
+			);
+		}
+		emit('phase', { phase: 'success', status: 'done' });
+		maybeReclaimPayload(recorder, emit);
+		await recorder.finish('success');
+		await pruneProjectPayloads(req.project, getPayloadRetentionMaxCount()).catch((error) =>
+			log.warn('Failed to prune deployment payloads', error)
+		);
+		return {
+			message: `Successfully deployed: ${req.project}${restart.restartMessage}`,
+			project: req.project,
+			deployment_id: recorder.deploymentId,
+			replicated: activateResponse?.replicated,
+			...(restart.restartJobId ? { restartJobId: restart.restartJobId } : {}),
+			...(recorder.getFailedPeers().length ? { failed_peers: recorder.getFailedPeers() } : {}),
+		};
+	} catch (error) {
+		if (application && !activationCommitted) {
+			await discardStagedApplication(application.dirPath, recorder.deploymentId).catch(() => {});
+		}
+		const capture = installCapture.snapshot();
+		const failedPeers = recorder.getFailedPeers();
+		const message = error?.message ?? String(error);
+		const structured = {
+			error: message,
+			phase: recorder.row.phase,
+			deployment_id: recorder.deploymentId,
+			...(capture.lines.length ? { install_output: capture } : {}),
+			...(failedPeers.length ? { failed_peers: failedPeers } : {}),
+		};
+		emit('error', {
+			message,
+			code: error?.statusCode ?? error?.code,
+			phase: recorder.row.phase,
+			deployment_id: recorder.deploymentId,
+			install_output: capture.lines.length ? capture : undefined,
+			failed_peers: failedPeers.length ? failedPeers : undefined,
+		});
+		await recorder
+			.finish(activationBarrierPassed ? 'success' : activationCommitted ? 'activating' : 'failed', error)
+			.catch((finishError) => log.warn('Failed to record two-phase deployment failure', finishError));
+		const outError = new ServerError(message, error?.statusCode);
+		outError.http_resp_msg = structured;
+		throw outError;
+	}
+}
+
+const ACTIVATION_FRESH_FIELDS = [
+	'payload',
+	'package',
+	'install_command',
+	'install_timeout',
+	'install_allow_scripts',
+	'urlPath',
+	'host',
+	'credentials',
+	'force',
+	'activate',
+	'two_phase',
+];
+
+function assertActivationRequestIsReferenceOnly(req) {
+	const supplied = ACTIVATION_FRESH_FIELDS.filter((field) => req[field] !== undefined);
+	if (supplied.length) {
+		throw handleHDBError(
+			new Error(),
+			`deployment_id activation uses the immutable staged configuration; remove: ${supplied.join(', ')}`,
+			HTTP_STATUS_CODES.BAD_REQUEST
+		);
+	}
+}
+
+async function deployComponentActivateExisting(req) {
+	assertActivationRequestIsReferenceOnly(req);
+	const row = await getDeploymentRow(req.deployment_id);
+	if (!row) throw handleHDBError(new Error(), `No deployment found with id '${req.deployment_id}'`, 404);
+	if (row.project !== req.project || row.status !== 'staged' || !row.activation_spec) {
+		throw handleHDBError(
+			new Error(),
+			`Deployment '${req.deployment_id}' is not a staged deployment for component '${req.project}'`,
+			HTTP_STATUS_CODES.CONFLICT
+		);
+	}
+	const spec = row.activation_spec;
+	assertNotProtectedCoreComponent(spec.project, spec.force);
+	const emitter = req.progress ?? new ProgressEmitter();
+	const emit = (event, data) => emitter.emit(event, data);
+	const componentPath = path.join(configUtils.getConfigPath(hdbTerms.CONFIG_PARAMS.COMPONENTSROOT), req.project);
+	let application;
+	const stagedPath = stagedApplicationPath(componentPath, req.deployment_id);
+	if (await hasCompleteStagedApplication(stagedPath)) {
+		application = applicationFromSpec(spec, undefined, undefined, null, emit);
+		await loadValidateComponent({ dirPath: stagedPath, emit });
+	} else {
+		const timeoutMs = coerceTimeoutMs(req.deployment_timeout, DEFAULT_AWAIT_ROW_TIMEOUT_MS);
+		const payload = await sourceStagedPayload(req.deployment_id, spec, timeoutMs);
+		const credentials = await resolveSpecCredentials(spec, timeoutMs);
+		application = applicationFromSpec(spec, payload, credentials, createInstallCapture(), emit);
+		const rebuiltPath = await stageApplication(application, req.deployment_id);
+		await loadValidateComponent({ dirPath: rebuiltPath, emit });
+	}
+	const configTransaction = await createApplicationActivationTransaction(req.project, spec);
+	emit('phase', { phase: 'activate', status: 'start' });
+	let claimed = false;
+	try {
+		await activateStagedApplication(application, req.deployment_id, {
+			beforeSwap: async () => {
+				await claimStagedDeployment(req.deployment_id, req.project);
+				claimed = true;
+			},
+			beforeCommit: () => configTransaction.commit(),
+			onRollback: () => configTransaction.rollback(),
+		});
+	} catch (error) {
+		if (claimed) await markDeploymentTerminal(req.deployment_id, 'staged').catch(() => {});
+		throw error;
+	}
+	let settledPeers = [];
+	let activationBarrierPassed = false;
+	try {
+		const peerResults = [];
+		const activateResponse = await server.replication.replicateOperation(
+			buildPhaseOperation('activate', req.deployment_id, req.project, spec),
+			{
+				onPeerResult: (result) => {
+					peerResults.push(result);
+					emit('peer', result);
+				},
+			}
+		);
+		settledPeers = Array.isArray(activateResponse?.replicated) ? activateResponse.replicated : peerResults;
+		await recordDeploymentPeers(req.deployment_id, settledPeers);
+		emit('phase', { phase: 'activate', status: 'done' });
+		const failed = failedPeerResults(settledPeers);
+		if (failed.length && !req.ignore_replication_errors) {
+			throw new ServerError(
+				`Component '${req.project}' activated on only part of the cluster. Split nodes: ` +
+					`${describePeerFailures(failed)}. Roll forward by staging and activating a known-good deployment.`
+			);
+		}
+		activationBarrierPassed = failed.length === 0;
+		if (!req.restart) markRestartRequiredForNewComponent(application);
+		const restart = await restartActivatedComponent(req, req.deployment_id, req.project, spec, emit);
+		if (restart.failedPeers.length) {
+			settledPeers = [...settledPeers, ...restart.failedPeers];
+			await recordDeploymentPeers(req.deployment_id, restart.failedPeers);
+		}
+		if (restart.failedPeers.length && !req.ignore_replication_errors) {
+			throw new ServerError(
+				`Component '${req.project}' activated, but restart failed on: ${describePeerFailures(restart.failedPeers)}`
+			);
+		}
+		await markDeploymentTerminal(req.deployment_id, 'success');
+		await maybeReclaimFinishedPayload(req.deployment_id, emit);
+		await pruneProjectPayloads(req.project, getPayloadRetentionMaxCount()).catch((error) =>
+			log.warn('Failed to prune activated deployment payloads', error)
+		);
+		return {
+			message: `Activated component: ${req.project}${restart.restartMessage}`,
+			project: req.project,
+			activated: true,
+			deployment_id: req.deployment_id,
+			replicated: activateResponse?.replicated,
+			...(restart.restartJobId ? { restartJobId: restart.restartJobId } : {}),
+			...(failedPeerResults(settledPeers).length ? { failed_peers: failedPeerResults(settledPeers) } : {}),
+		};
+	} catch (error) {
+		await markDeploymentTerminal(req.deployment_id, activationBarrierPassed ? 'success' : 'activating', error).catch(
+			() => {}
+		);
+		throw error;
+	}
+}
+
+async function componentDeployPhase(req) {
+	if (!isTrustedReplicatedOperation(req)) {
+		throw handleHDBError(new Error(), 'component_deploy_phase is restricted to authenticated cluster peers', 403);
+	}
+	const validation = validator.componentDeployPhaseValidator({
+		phase: req.phase,
+		deployment_id: req.deployment_id,
+		project: req.project,
+		activation_spec: req.activation_spec,
+		deployment_timeout: req.deployment_timeout,
+	});
+	if (validation) throw handleHDBError(validation, validation.message, HTTP_STATUS_CODES.BAD_REQUEST);
+	const spec = req.activation_spec;
+	if (!spec || spec.project !== req.project) {
+		throw handleHDBError(new Error(), 'Invalid immutable activation specification', HTTP_STATUS_CODES.BAD_REQUEST);
+	}
+	const componentPath = path.join(configUtils.getConfigPath(hdbTerms.CONFIG_PARAMS.COMPONENTSROOT), req.project);
+	if (req.phase === 'discard') {
+		await discardStagedApplication(componentPath, req.deployment_id);
+		return { message: `Discarded staged component: ${req.project}` };
+	}
+	if (req.phase === 'restart') {
+		const row = await getDeploymentRow(req.deployment_id);
+		assertStoredActivationSpec(row, req.deployment_id, req.project, spec, [
+			'pending',
+			'staging',
+			'staged',
+			'activating',
+		]);
+		manageThreads.restartWorkers('http');
+		return { message: `Restarting component runtime for: ${req.project}` };
+	}
+	if (req.phase === 'stage') {
+		assertNotProtectedCoreComponent(req.project, spec.force);
+		const timeoutMs = coerceTimeoutMs(req.deployment_timeout, DEFAULT_AWAIT_ROW_TIMEOUT_MS);
+		const payload = await sourceStagedPayload(req.deployment_id, spec, timeoutMs);
+		const credentials = await resolveSpecCredentials(spec, timeoutMs);
+		const application = applicationFromSpec(spec, payload, credentials, createInstallCapture());
+		const stagedPath = await stageApplication(application, req.deployment_id);
+		await loadValidateComponent({ dirPath: stagedPath, emit: () => {} });
+		return { message: `Staged component: ${req.project}`, project: req.project, staged: true };
+	}
+	const row = await getDeploymentRow(req.deployment_id);
+	assertStoredActivationSpec(row, req.deployment_id, req.project, spec, ['pending', 'staging', 'staged', 'activating']);
+	let application;
+	const stagedPath = stagedApplicationPath(componentPath, req.deployment_id);
+	if (await hasCompleteStagedApplication(stagedPath)) {
+		application = applicationFromSpec(spec, undefined, undefined, null);
+		await loadValidateComponent({ dirPath: stagedPath, emit: () => {} });
+	} else {
+		const timeoutMs = coerceTimeoutMs(req.deployment_timeout, DEFAULT_AWAIT_ROW_TIMEOUT_MS);
+		const payload = await sourceStagedPayload(req.deployment_id, spec, timeoutMs);
+		const credentials = await resolveSpecCredentials(spec, timeoutMs);
+		application = applicationFromSpec(spec, payload, credentials, createInstallCapture());
+		const rebuiltPath = await stageApplication(application, req.deployment_id);
+		await loadValidateComponent({ dirPath: rebuiltPath, emit: () => {} });
+	}
+	const configTransaction = await createApplicationActivationTransaction(req.project, spec);
+	await activateStagedApplication(application, req.deployment_id, {
+		beforeSwap: async () => {
+			await claimStagedDeployment(req.deployment_id, req.project, {
+				allowActivating: true,
+				waitForStagedMs: coerceTimeoutMs(req.deployment_timeout, DEFAULT_AWAIT_ROW_TIMEOUT_MS),
+			});
+		},
+		beforeCommit: () => configTransaction.commit(),
+		onRollback: () => configTransaction.rollback(),
+	});
+	markRestartRequiredForNewComponent(application);
+	return { message: `Activated component: ${req.project}`, project: req.project, activated: true };
+}
+
+function isTrustedReplicatedOperation(req) {
+	const user = req.hdb_user;
+	return (
+		isOperationAuthorizationBypassed() &&
+		req.replicated === false &&
+		!!user &&
+		!!(user.name || user.replicates || user.subscribers)
+	);
+}
+
+async function _revertComponent(req) {
 	if (req.project) req.project = path.parse(req.project).name;
 	const validation = validator.revertComponentValidator(req);
 	if (validation) throw handleHDBError(validation, validation.message, HTTP_STATUS_CODES.BAD_REQUEST);
@@ -1357,6 +1895,29 @@ function maybeReclaimPayload(recorder, emit) {
 	}
 }
 
+async function maybeReclaimFinishedPayload(deploymentId, emit) {
+	try {
+		const row = await getDeploymentRow(deploymentId);
+		const payloadSize = row?.payload_size;
+		const retentionMaxSize = getPayloadRetentionMaxSize();
+		if (
+			typeof payloadSize !== 'number' ||
+			payloadSize <= retentionMaxSize ||
+			failedPeerResults(row.peer_results).length > 0 ||
+			row.payload_blob == null
+		) {
+			return;
+		}
+		const { handleDeleteDeploymentPayload } = require('./deploymentOperations.ts');
+		const result = await handleDeleteDeploymentPayload({ deployment_id: deploymentId });
+		if (result.freed_bytes > 0) {
+			emit('payload_dropped', { payload_size: result.freed_bytes, max_size: retentionMaxSize });
+		}
+	} catch (error) {
+		log.warn(`Failed to reclaim payload for activated deployment '${deploymentId}'`, error);
+	}
+}
+
 /**
  * Count-based payload retention (deployment_payloadRetention_maxCount): after a successful deploy, keep
  * only the newest N stored payloads for this project and drop the rest. Where the size-based reclaim
@@ -1513,6 +2074,7 @@ async function getComponents() {
 					itemName === 'node_modules' ||
 					itemName === ASIDE_STAGING_DIR ||
 					itemName === DEPLOY_STAGING_DIR ||
+					itemName === DEPLOY_ACTIVATION_DIR ||
 					itemName === DEPLOY_PREVIOUS_DIR ||
 					itemName === COMPONENT_PREPARATION_LOCK_DIR
 				)
@@ -1830,28 +2392,34 @@ async function dropComponent(req) {
 
 	const { project, file } = req;
 	const projectPath = req.file ? path.join(project, file) : project;
-	const pathToComponent = path.join(configUtils.getConfigPath(hdbTerms.CONFIG_PARAMS.COMPONENTSROOT), projectPath);
+	const componentsRoot = configUtils.getConfigPath(hdbTerms.CONFIG_PARAMS.COMPONENTSROOT);
+	const componentPath = path.join(componentsRoot, project);
+	const pathToComponent = path.join(componentsRoot, projectPath);
 
-	const componentSymlink = path.join(env.get(hdbTerms.CONFIG_PARAMS.ROOTPATH), 'node_modules', project);
-	if (await fs.pathExists(componentSymlink)) {
-		await fs.unlink(componentSymlink);
-	}
-
-	if (await fs.pathExists(pathToComponent)) {
-		await fs.remove(pathToComponent);
-	}
-
-	// Remove the component from the package.json file
-	const packageJsonPath = path.join(env.get(hdbTerms.CONFIG_PARAMS.ROOTPATH), 'package.json');
-	if (await fs.pathExists(packageJsonPath)) {
-		const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
-		if (packageJson?.dependencies?.[project]) {
-			delete packageJson.dependencies[project];
+	await withComponentPreparationLock(componentPath, async () => {
+		const componentSymlink = path.join(env.get(hdbTerms.CONFIG_PARAMS.ROOTPATH), 'node_modules', project);
+		if (await fs.pathExists(componentSymlink)) {
+			await fs.unlink(componentSymlink);
 		}
-		await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf8');
-	}
 
-	configUtils.deleteConfigFromFile([project]);
+		if (!file) {
+			await invalidateProjectStagedDeployments(project);
+			await discardProjectStagedApplications(componentPath);
+			await discardProjectActivationArtifacts(componentPath);
+		}
+		if (await fs.pathExists(pathToComponent)) await fs.remove(pathToComponent);
+		if (!file) await updateApplicationLockEntry(project, undefined);
+
+		const packageJsonPath = path.join(env.get(hdbTerms.CONFIG_PARAMS.ROOTPATH), 'package.json');
+		if (await fs.pathExists(packageJsonPath)) {
+			const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
+			if (packageJson?.dependencies?.[project]) delete packageJson.dependencies[project];
+			await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf8');
+		}
+
+		configUtils.deleteConfigFromFile([project]);
+	});
+
 	let response = await server.replication.replicateOperation(req);
 	if (req.restart === true) {
 		manageThreads.restartWorkers('http');
@@ -1869,8 +2437,7 @@ exports.addComponent = addComponent;
 exports.dropCustomFunctionProject = dropCustomFunctionProject;
 exports.packageComponent = packageComponent;
 exports.deployComponent = deployComponent;
-exports.revertComponent = revertComponent;
-exports.selectRevertTargets = selectRevertTargets; // exported for unit testing the revert_on_failure node-targeting
+exports.componentDeployPhase = componentDeployPhase;
 exports.getComponents = getComponents;
 exports.getComponentFile = getComponentFile;
 exports.setComponentFile = setComponentFile;

--- a/components/operationsValidation.js
+++ b/components/operationsValidation.js
@@ -13,6 +13,7 @@ const { ENV_ENCRYPTED_PREFIX } = require('../utility/envFile.ts');
 
 // File name can only be alphanumeric, dash and underscores
 const PROJECT_FILE_NAME_REGEX = /^[a-zA-Z0-9-_]+$/;
+const DEPLOYMENT_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 // dotenv's accepted key character set. Restricting keys to this prevents a crafted key (e.g. one
 // containing `=` or a newline) from injecting extra assignments into a .env file.
@@ -25,7 +26,7 @@ module.exports = {
 	dropCustomFunctionProjectValidator,
 	packageComponentValidator,
 	deployComponentValidator,
-	revertComponentValidator,
+	componentDeployPhaseValidator,
 	setComponentFileValidator,
 	getComponentFileValidator,
 	dropComponentFileValidator,
@@ -456,10 +457,14 @@ const URL_PATH_SCHEMA = Joi.string()
 	.min(1)
 	.custom((value, helpers) => {
 		if (value.includes('..')) return helpers.error('any.invalid');
+		if (value.split('/').includes('.')) return helpers.error('string.dotSegment');
 		return value;
 	})
 	.optional()
-	.messages({ 'any.invalid': 'urlPath must not contain ".."' });
+	.messages({
+		'any.invalid': 'urlPath must not contain ".."',
+		'string.dotSegment': 'urlPath must not contain "." path segments',
+	});
 
 // `registryAuth` was the credentials field's name on the 5.2 dev line. Rejected rather than ignored:
 // validation allows unknown keys, so a caller still sending it would otherwise get a deploy that
@@ -494,16 +499,20 @@ function deployComponentValidator(req) {
 		// Activate a previously-staged deployment (from an `activate: false` stage) cluster-wide. Same safe
 		// charset as `project` because it becomes a staging-dir path segment (`.deploy-staging/<id>/<name>`)
 		// — a `../` value would otherwise resolve the staging source outside `.deploy-staging`.
-		deployment_id: Joi.string().pattern(PROJECT_FILE_NAME_REGEX).optional().messages({
-			'string.pattern.base': `'deployment_id' must only contain letters, numbers, dashes, and underscores`,
+		deployment_id: Joi.string().pattern(DEPLOYMENT_ID_REGEX).optional().messages({
+			'string.pattern.base': `'deployment_id' must be a UUID`,
 		}),
 		// If the activate phase fails on some nodes (leaving the cluster split across versions), swap the
 		// nodes that did activate back to the retained previous version before reporting the failure. Off
 		// by default.
-		revert_on_failure: Joi.boolean().optional(),
+		revert_on_failure: Joi.any().forbidden().messages({
+			'any.unknown': `'revert_on_failure' is not supported; recover partial activation by rolling forward`,
+		}),
 		// Opt out of the two-phase (stage-then-activate) deploy and use the legacy one-shot path instead.
 		// Defaults to two-phase.
 		two_phase: Joi.boolean().optional(),
+		_deploymentId: Joi.any().forbidden(),
+		_phase: Joi.any().forbidden(),
 		urlPath: URL_PATH_SCHEMA,
 		// Deploy credentials. Each entry is npm registry auth (`registry`) or git host auth (`host`,
 		// #1792), and supplies its secret either as a literal `token` (used only for this node's
@@ -515,6 +524,24 @@ function deployComponentValidator(req) {
 	return validator.validateBySchema(req, deployProjSchema);
 }
 
+/** Validate the path- and state-selecting fields on the authenticated peer-only deploy operation. */
+function componentDeployPhaseValidator(req) {
+	const phaseSchema = Joi.object({
+		phase: Joi.string().valid('stage', 'activate', 'discard', 'restart').required(),
+		deployment_id: Joi.string().pattern(DEPLOYMENT_ID_REGEX).required().messages({
+			'string.pattern.base': `'deployment_id' must be a UUID`,
+		}),
+		project: Joi.string()
+			.pattern(PROJECT_FILE_NAME_REGEX)
+			.required()
+			.messages({ 'string.pattern.base': HDB_ERROR_MSGS.BAD_PROJECT_NAME }),
+		activation_spec: Joi.object().required(),
+		deployment_timeout: Joi.number().min(0).optional(),
+	}).unknown(false);
+
+	return validator.validateBySchema(req, phaseSchema);
+}
+
 /**
  * Validate revert_component requests — swap a component's live version back to its retained previous
  * version. No build inputs (nothing is fetched or installed); just the project, an optional restart,
@@ -522,7 +549,7 @@ function deployComponentValidator(req) {
  * @param req
  * @returns {*}
  */
-function revertComponentValidator(req) {
+function _revertComponentValidator(req) {
 	const revertSchema = Joi.object({
 		project: Joi.string()
 			.pattern(PROJECT_FILE_NAME_REGEX)

--- a/config/configUtils.ts
+++ b/config/configUtils.ts
@@ -1202,7 +1202,7 @@ export async function addConfig(topLevelElement, values) {
 	atomicWriteFile(getConfigFilePath(), String(configDoc));
 }
 
-export function deleteConfigFromFile(param: string) {
+export function deleteConfigFromFile(param: Array<string | number>) {
 	const configFilePath = getConfigFilePath(hdbUtils.getPropsFilePath());
 	const configDoc = parseYamlDoc(configFilePath);
 	configDoc.deleteIn(param);

--- a/integrationTests/deploy/deploy-tracking-events.test.ts
+++ b/integrationTests/deploy/deploy-tracking-events.test.ts
@@ -206,7 +206,7 @@ suite('Deployment tracking — events + SSE', (ctx: ContextWithHarper) => {
 
 			// Poll list_deployments until we see the in-flight row. The recorder row is created
 			// after the multipart body is fully received (which is fast for a tiny fixture).
-			const TERMINAL = new Set(['success', 'failed', 'rolled_back']);
+			const TERMINAL = new Set(['success', 'failed', 'rolled_back', 'staged']);
 			let inFlightId: string | null = null;
 			for (let i = 0; i < 15 && !inFlightId; i++) {
 				await sleep(300);

--- a/integrationTests/deploy/deploy-tracking-peer-branch.test.ts
+++ b/integrationTests/deploy/deploy-tracking-peer-branch.test.ts
@@ -1,21 +1,18 @@
 /**
- * Deployment tracking — peer-side branch.
+ * Deployment tracking — peer-operation authorization boundary.
  *
- * In a real multi-node deploy, the origin strips `req.payload` before `replicateOperation`
- * and the peer reads the tarball from the replicated `hdb_deployment.payload_blob` row
- * attribute instead. This test exercises that **peer-side branch** in isolation on a
- * single node by:
+ * In a real multi-node deploy, the origin sends a private `component_deploy_phase`
+ * operation and the peer reads the tarball from the replicated
+ * `hdb_deployment.payload_blob` row. The authorization-bypass context that admits that
+ * operation exists only around trusted replication dispatch, so an HTTP caller must not
+ * be able to impersonate a peer with the legacy `_deploymentId` marker. This test:
  *
  *   1. Doing a normal deploy to populate an `hdb_deployment` row with a `payload_blob`.
- *   2. Submitting a second `deploy_component` operation with `_deploymentId` set to that
- *      row's id and **no** `payload` field — the same shape origin produces for peers.
- *   3. Asserting the deploy completes successfully — meaning the peer-side branch in
- *      `deployComponent` found the row, streamed `payload_blob`, and ran prepare/install/load
- *      from the blob bytes.
+ *   2. Submitting a second public `deploy_component` operation with `_deploymentId` set.
+ *   3. Asserting validation rejects the caller-controlled internal marker.
  *
- * The true 3-node test (verifies BLOB_CHUNK replication actually delivers the row to
- * peers, and that `peer_results` is populated) lives in harper-pro, where the actual
- * `replicateOperation` is implemented. This OSS test only verifies the handler wiring.
+ * The true 3-node test (including the trusted peer operation, BLOB_CHUNK delivery, and
+ * `peer_results`) lives in harper-pro, where `replicateOperation` is implemented.
  */
 import { suite, test, before, after } from 'node:test';
 import { ok, strictEqual } from 'node:assert';
@@ -86,7 +83,7 @@ async function callOperation(
 	return { status: res.status, body: parsed, rawText: text };
 }
 
-suite('Deployment tracking — peer-side branch', (ctx: ContextWithHarper) => {
+suite('Deployment tracking — peer-operation authorization boundary', (ctx: ContextWithHarper) => {
 	let fixtureDir: string;
 	let seedDeploymentId: string;
 
@@ -134,46 +131,14 @@ suite('Deployment tracking — peer-side branch', (ctx: ContextWithHarper) => {
 		ok(got.body.payload_hash, 'seed row should have a sha256 payload_hash');
 	});
 
-	// On Bun the deploy hangs after extraction when reading a Web ReadableStream from a
-	// file-backed blob inside the same Harper process — same code passes on Node v22/v24
-	// across Linux and Windows. Skipping for now; the harper-pro 3-node cluster test
-	// (HarperFast/harper-pro#221) covers the same code path end-to-end with real replication.
-	const skipOnBun = process.env.HARPER_RUNTIME === 'bun';
-	test(
-		'peer-side branch: deploy_component with _deploymentId + no payload uses the row blob',
-		{ skip: skipOnBun },
-		async () => {
-			// Simulate the operation shape origin produces for peers via `replicateOperation`:
-			// `_deploymentId` set, no `payload`, no multipart. The handler should detect this is a
-			// replicated execution and source the tarball from the row's payload_blob.
-			const peerProject = 'peer-branch-replay-application';
-			const response = await callOperation(ctx, {
-				operation: 'deploy_component',
-				project: peerProject,
-				restart: false,
-				_deploymentId: seedDeploymentId,
-			});
-			strictEqual(response.status, 200, `peer-side deploy should succeed; got ${response.status}: ${response.rawText}`);
-
-			// Confirm the component was actually written on disk (peer code path ran extraction
-			// from the row's payload_blob and not from a missing req.payload).
-			const fetched = await fetch(`${ctx.harper.operationsAPIURL}/${peerProject}/`, {
-				headers: {
-					Authorization:
-						'Basic ' + Buffer.from(`${ctx.harper.admin.username}:${ctx.harper.admin.password}`).toString('base64'),
-				},
-			});
-			// The component exposes nothing routable, but a 404 from the component (vs. a 503/connection
-			// failure) confirms it loaded — Harper only routes to deployed component names.
-			ok(
-				fetched.status === 404 || fetched.status === 200,
-				`expected component to be reachable (any 200/404 from the loaded component), got ${fetched.status}`
-			);
-		}
-	);
-
-	// Note: the bogus-_deploymentId-id timeout case isn't covered here because the
-	// awaitDeploymentRow 120s default would balloon test time. The timeout path (and the
-	// per-deploy deployment_timeout override) is exercised by the unit tests for
-	// awaitDeploymentRow directly.
+	test('public deploy_component rejects the legacy _deploymentId peer marker', async () => {
+		const response = await callOperation(ctx, {
+			operation: 'deploy_component',
+			project: 'peer-branch-replay-application',
+			restart: false,
+			_deploymentId: seedDeploymentId,
+		});
+		strictEqual(response.status, 400, `internal marker should be rejected; got: ${response.rawText}`);
+		strictEqual(response.body.error, "'_deploymentId' is not allowed");
+	});
 });

--- a/json/systemSchema.json
+++ b/json/systemSchema.json
@@ -425,6 +425,9 @@
 				"attribute": "rollback_of"
 			},
 			{
+				"attribute": "activation_spec"
+			},
+			{
 				"attribute": "error"
 			},
 			{

--- a/resources/registrationDeprecated.ts
+++ b/resources/registrationDeprecated.ts
@@ -4,5 +4,6 @@ export function getRegistrationInfo() {
 	return {
 		version: packageJson.version,
 		deprecated: true,
+		capabilities: { componentDeployTwoPhase: 1 },
 	};
 }

--- a/server/serverHelpers/operationAuthorizationState.ts
+++ b/server/serverHelpers/operationAuthorizationState.ts
@@ -1,0 +1,11 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const operationAuthorizationState = new AsyncLocalStorage<boolean>();
+
+export function runWithOperationAuthorizationBypass<T>(bypassAuth: boolean, callback: () => T): T {
+	return operationAuthorizationState.run(bypassAuth === true, callback);
+}
+
+export function isOperationAuthorizationBypassed(): boolean {
+	return operationAuthorizationState.getStore() === true;
+}

--- a/server/serverHelpers/serverHandlers.js
+++ b/server/serverHelpers/serverHandlers.js
@@ -33,7 +33,6 @@ const { ProgressEmitter, createSSEResponseStream } = require('./progressEmitter.
 // the client disconnects (the emitter's abort signal), so subscribers see new lines live.
 const SSE_PROGRESS_OPERATIONS = new Set([
 	terms.OPERATIONS_ENUM.DEPLOY_COMPONENT,
-	terms.OPERATIONS_ENUM.REVERT_COMPONENT,
 	terms.OPERATIONS_ENUM.GET_DEPLOYMENT,
 	terms.OPERATIONS_ENUM.READ_LOG,
 ]);

--- a/server/serverHelpers/serverUtilities.ts
+++ b/server/serverHelpers/serverUtilities.ts
@@ -47,6 +47,7 @@ import {
 	getRemoteOperationFunction,
 	setLocalOperationDispatch,
 } from './registeredOperations.ts';
+import { runWithOperationAuthorizationBypass } from './operationAuthorizationState.ts';
 
 const pSearchSearch = util.promisify(search.search);
 let pEvaluateSql: (sql: string) => Promise<any>;
@@ -309,9 +310,12 @@ _assignPackageExport('operation', operation);
  */
 export function operation(operation: OperationRequestBody, context: Context, authorize: boolean) {
 	operation.hdb_user = context?.user;
-	operation.bypass_auth = !authorize;
-	const operation_function = chooseOperation(operation);
-	return processLocalTransaction({ body: operation }, operation_function);
+	const bypassAuth = !authorize;
+	operation.bypass_auth = bypassAuth;
+	return runWithOperationAuthorizationBypass(bypassAuth, () => {
+		const operation_function = chooseOperation(operation);
+		return processLocalTransaction({ body: operation }, operation_function);
+	});
 }
 
 interface Transaction {
@@ -547,8 +551,8 @@ function initializeOperationFunctionMap(): Map<OperationFunctionName, OperationF
 		new OperationFunctionObject(customFunctionOperations.deployComponent)
 	);
 	opFuncMap.set(
-		terms.OPERATIONS_ENUM.REVERT_COMPONENT,
-		new OperationFunctionObject(customFunctionOperations.revertComponent)
+		terms.OPERATIONS_ENUM.COMPONENT_DEPLOY_PHASE,
+		new OperationFunctionObject(customFunctionOperations.componentDeployPhase)
 	);
 	opFuncMap.set(
 		terms.OPERATIONS_ENUM.LIST_DEPLOYMENTS,

--- a/unitTests/bin/cliOperations.test.js
+++ b/unitTests/bin/cliOperations.test.js
@@ -13,6 +13,7 @@ const tokenAuthModule = require('#src/security/tokenAuthentication');
 const packageComponentModule = require('#src/components/packageComponent');
 const processManagementModule = require('#src/utility/processManagement/processManagement');
 const configUtilsModule = require('#src/config/configUtils');
+const { DeployRenderer } = require('#src/bin/deployRenderer');
 
 // Thrown by the mocked process.exit below so a call to it unwinds the async
 // cliOperations() call (rather than actually terminating the test runner) and
@@ -240,6 +241,141 @@ describe('cliOperations', () => {
 			const deploy = calls[1];
 			assert.strictEqual(deploy.options.headers.Accept, 'text/event-stream');
 			assert.strictEqual(result.success, true);
+		});
+
+		it('fails closed on every staged-deploy control against a target without two-phase capability', async () => {
+			const originalExit = process.exit;
+			const originalConsoleError = console.error;
+			const errors = [];
+			const calls = [];
+			process.exit = (code) => {
+				throw new ProcessExitSignal(code);
+			};
+			console.error = (...args) => errors.push(args.join(' '));
+			commonUtilsModule.httpRequest = async (options, req) => {
+				calls.push({ options, req });
+				return { statusCode: 200, body: JSON.stringify({ version: '5.1.7' }) };
+			};
+			try {
+				for (const request of [
+					{ package: '@scope/widget', activate: false, _cliVerb: 'stage' },
+					{ package: '@scope/widget', activate: false },
+					{ deployment_id: '41faded8-6cf5-4a2a-95f8-863e7ea498fa' },
+					{ package: '@scope/widget', two_phase: true },
+				]) {
+					await assert.rejects(
+						cliOperationsModule.cliOperations(
+							{
+								operation: 'deploy_component',
+								project: 'widget',
+								target: 'example.com',
+								...request,
+							},
+							true
+						),
+						ProcessExitSignal
+					);
+				}
+			} finally {
+				process.exit = originalExit;
+				console.error = originalConsoleError;
+			}
+
+			assert.deepStrictEqual(
+				calls.map(({ req }) => req.operation),
+				Array(4).fill('registration_info'),
+				'only one capability probe per request reached the target'
+			);
+			assert.match(errors.join('\n'), /does not advertise staged-deploy support/);
+		});
+
+		it('renders stage phase events and strips its CLI-only verb marker', async () => {
+			const calls = [];
+			const rendered = [];
+			const originalRenderEvent = DeployRenderer.prototype.renderEvent;
+			DeployRenderer.prototype.renderEvent = function (message) {
+				rendered.push(message.event);
+			};
+			commonUtilsModule.httpRequest = async (options, req) => {
+				calls.push({ options, req });
+				if (req.operation === 'registration_info') {
+					return {
+						statusCode: 200,
+						body: JSON.stringify({
+							version: '5.2.0',
+							capabilities: { componentDeployTwoPhase: 1 },
+						}),
+					};
+				}
+				return Object.assign(
+					Readable.from([
+						'event: phase\ndata: {"phase":"stage","status":"start"}\n\n',
+						'event: done\ndata: {"result":{"staged":true}}\n\n',
+					]),
+					{ statusCode: 200, headers: { 'content-type': 'text/event-stream' } }
+				);
+			};
+			let result;
+			try {
+				result = await cliOperationsModule.cliOperations(
+					{
+						operation: 'deploy_component',
+						project: 'widget',
+						package: '@scope/widget',
+						activate: false,
+						_cliVerb: 'stage',
+						target: 'example.com',
+					},
+					true
+				);
+			} finally {
+				DeployRenderer.prototype.renderEvent = originalRenderEvent;
+			}
+
+			const deploy = calls.at(-1);
+			assert.strictEqual(deploy.req._cliVerb, undefined);
+			assert.strictEqual(deploy.req.activate, false);
+			assert.deepStrictEqual(rendered, ['phase', 'done']);
+			assert.strictEqual(result.staged, true);
+		});
+
+		it('defaults the activate project from the current directory', async () => {
+			const calls = [];
+			const projectDir = path.join(testDir, 'activate-project');
+			fs.ensureDirSync(projectDir);
+			const priorCwd = process.cwd();
+			commonUtilsModule.httpRequest = async (options, req) => {
+				calls.push({ options, req });
+				if (req.operation === 'registration_info') {
+					return {
+						statusCode: 200,
+						body: JSON.stringify({
+							version: '5.2.0',
+							capabilities: { componentDeployTwoPhase: 1 },
+						}),
+					};
+				}
+				return Object.assign(Readable.from(['event: done\ndata: {"result":{"activated":true}}\n\n']), {
+					statusCode: 200,
+					headers: { 'content-type': 'text/event-stream' },
+				});
+			};
+			try {
+				process.chdir(projectDir);
+				await cliOperationsModule.cliOperations(
+					{
+						operation: 'deploy_component',
+						deployment_id: '41faded8-6cf5-4a2a-95f8-863e7ea498fa',
+						_cliVerb: 'activate',
+						target: 'example.com',
+					},
+					true
+				);
+			} finally {
+				process.chdir(priorCwd);
+			}
+
+			assert.strictEqual(calls.at(-1).req.project, 'activate-project');
 		});
 	});
 

--- a/unitTests/components/deployPhaseOperations.test.js
+++ b/unitTests/components/deployPhaseOperations.test.js
@@ -1,13 +1,6 @@
 'use strict';
 
-// Operation-level tests for the two-phase deploy handlers: stage_component, activate_component, and
-// deploy_component (both the two-phase default and the two_phase:false one-shot fallback). These run
-// the real handlers against a real temp filesystem with a real tarball payload — no stubbing — in the
-// deployStaging.test.js style (AGENTS.md: new tests use plain `assert` against real modules, no
-// sinon/rewire). Payload deploys are used throughout so nothing reaches the component loader (a
-// `package` deploy's protected-name guard would), and no test requests a restart.
-
-const assert = require('node:assert');
+const assert = require('node:assert/strict');
 const fs = require('node:fs/promises');
 const { existsSync } = require('node:fs');
 const os = require('node:os');
@@ -19,398 +12,686 @@ const testUtils = require('../testUtils.js');
 testUtils.preTestPrep();
 
 const operations = require('#src/components/operations');
-const { DEPLOY_STAGING_DIR, Application, stageApplication } = require('#src/components/Application');
+const { DEPLOY_STAGING_DIR, DEPLOY_ACTIVATION_DIR, discardStagedApplication } = require('#src/components/Application');
 const { restartNeeded, resetRestartNeeded } = require('#src/components/requestRestart');
 const { server } = require('#src/server/Server');
 const { databases } = require('#src/resources/databases');
-const { SYSTEM_TABLE_NAMES } = require('#src/utility/hdbTerms');
-const { getConfigPath, getConfiguration, getConfigFilePath } = require('#src/config/configUtils');
-const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
+const { SYSTEM_TABLE_NAMES, CONFIG_PARAMS } = require('#src/utility/hdbTerms');
+const { getConfigPath, readConfigFile } = require('#src/config/configUtils');
+const environment = require('#src/utility/environment/environmentManager');
+const { runWithOperationAuthorizationBypass } = require('#src/server/serverHelpers/operationAuthorizationState');
+const manageThreads = require('#src/server/threads/manageThreads');
 
-const DEPLOYMENT_TABLE = SYSTEM_TABLE_NAMES.DEPLOYMENT_TABLE_NAME;
 const COMPONENTS_ROOT = getConfigPath(CONFIG_PARAMS.COMPONENTSROOT);
+const DEPLOYMENT_TABLE = SYSTEM_TABLE_NAMES.DEPLOYMENT_TABLE_NAME;
 
-// Pack a directory's CONTENTS into a gzipped tar Buffer, the shape a deploy payload takes.
-function packDirectory(dir) {
+function packDirectory(directory) {
 	return new Promise((resolve, reject) => {
 		const chunks = [];
 		tarfs
-			.pack(dir)
+			.pack(directory)
 			.pipe(zlib.createGzip())
-			.on('data', (c) => chunks.push(c))
+			.on('data', (chunk) => chunks.push(chunk))
 			.on('end', () => resolve(Buffer.concat(chunks)))
 			.on('error', reject);
 	});
 }
 
-// A component source that already contains node_modules, so installApplication short-circuits and no
-// npm/network is needed.
-async function makeComponentPayload(marker) {
-	const src = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-op-src-'));
-	await fs.writeFile(path.join(src, 'package.json'), JSON.stringify({ name: 'op-fixture', version: '1.0.0' }));
-	await fs.writeFile(path.join(src, 'index.js'), `module.exports = ${JSON.stringify(marker)};\n`);
-	await fs.mkdir(path.join(src, 'node_modules'), { recursive: true });
-	await fs.writeFile(path.join(src, 'node_modules', '.marker'), marker);
-	const payload = await packDirectory(src);
-	await fs.rm(src, { recursive: true, force: true });
+async function makePayload(marker, version = marker, withNodeModules = true) {
+	const source = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-phase-op-'));
+	await fs.writeFile(path.join(source, 'package.json'), JSON.stringify({ name: 'phase-op', version }));
+	await fs.writeFile(path.join(source, 'index.js'), `module.exports = ${JSON.stringify(marker)};\n`);
+	if (withNodeModules) await fs.mkdir(path.join(source, 'node_modules'), { recursive: true });
+	const payload = await packDirectory(source);
+	await fs.rm(source, { recursive: true, force: true });
 	return payload;
 }
 
-const readIndex = (dir) => fs.readFile(path.join(dir, 'index.js'), 'utf8');
-
-// componentLoader reaches the private `@harperfast/skills` dependency, which is absent from some local
-// checkouts. Only the `package`-deploy path touches it (via the protected-core-name guard), so probe
-// once and let that one test skip rather than fail on a missing dependency.
-function componentLoaderAvailable() {
-	try {
-		require('#src/components/componentLoader');
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-describe('deploy operations: stage_component / activate_component / deploy_component', function () {
+describe('deploy_component two-phase orchestration', function () {
 	this.timeout(30_000);
+	const rows = new Map();
+	let priorTable;
+	let priorReplicate;
+	let priorSafeMode;
+	let sequence = 0;
+	const names = [];
 
 	before(async () => {
-		await fs.mkdir(COMPONENTS_ROOT, { recursive: true });
+		priorSafeMode = process.env.HARPER_SAFE_MODE;
+		process.env.HARPER_SAFE_MODE = 'true';
+		// The first component operation completes lazy server initialization, which replaces
+		// databases.system. Run it before installing the table seam used by these tests.
+		const warmupProject = name();
+		const warmup = await operations.deployComponent({
+			project: warmupProject,
+			payload: await makePayload('warmup'),
+			activate: false,
+		});
+		await fs.rm(path.join(COMPONENTS_ROOT, DEPLOY_STAGING_DIR, warmup.deployment_id), {
+			recursive: true,
+			force: true,
+		});
+		if (!databases.system) databases.system = {};
+		priorTable = databases.system[DEPLOYMENT_TABLE];
 	});
 
-	let counter = 0;
-	const names = [];
-	function freshName() {
-		const name = `op_test_${process.pid}_${counter++}`;
-		names.push(name);
-		return name;
-	}
+	beforeEach(() => {
+		resetRestartNeeded();
+		rows.clear();
+		databases.system[DEPLOYMENT_TABLE] = {
+			async get(id) {
+				return rows.get(id);
+			},
+			async put(row) {
+				rows.set(row.deployment_id, { ...row });
+			},
+			async patch(id, partial) {
+				const row = rows.get(id);
+				if (row) rows.set(id, { ...row, ...partial });
+			},
+			async *search(conditions = []) {
+				for (const row of rows.values()) {
+					if (conditions.every((condition) => row[condition.attribute] === condition.value)) yield row;
+				}
+			},
+		};
+		priorReplicate = server.replication.replicateOperation;
+		server.replication.replicateOperation = async () => ({ replicated: [] });
+	});
 
-	// Sweep any live dirs, staging, previous, and aside created by the suite.
-	after(async () => {
-		for (const name of names) await fs.rm(path.join(COMPONENTS_ROOT, name), { recursive: true, force: true });
-		await fs.rm(path.join(COMPONENTS_ROOT, DEPLOY_STAGING_DIR), { recursive: true, force: true });
-		await fs.rm(path.join(COMPONENTS_ROOT, '.deploy-previous'), { recursive: true, force: true });
-		await fs.rm(path.join(COMPONENTS_ROOT, '.deploy-aside'), { recursive: true, force: true });
-		// Deploying a genuinely-new component flips the process-wide restart-needed buffer on
-		// (harper#674, via deployComponent's requestRestart() scoping). That buffer is shared across
-		// the whole mocha process, so restore it or a later test asserting a pristine buffer
-		// (e.g. requestRestart.test.js) fails on ordering alone.
+	afterEach(() => {
+		server.replication.replicateOperation = priorReplicate;
 		resetRestartNeeded();
 	});
 
-	// Each test below deploys fresh components, and deploying a never-live component flips the
-	// process-wide restart-needed buffer (harper#674). Start every test from a known-clean buffer so the
-	// restartNeeded() assertions below reflect only that test's own deploy, not a prior test's leak.
-	beforeEach(() => resetRestartNeeded());
+	after(async () => {
+		if (priorSafeMode === undefined) delete process.env.HARPER_SAFE_MODE;
+		else process.env.HARPER_SAFE_MODE = priorSafeMode;
+		if (priorTable === undefined) delete databases.system[DEPLOYMENT_TABLE];
+		else databases.system[DEPLOYMENT_TABLE] = priorTable;
+		for (const name of names) await fs.rm(path.join(COMPONENTS_ROOT, name), { recursive: true, force: true });
+		await fs.rm(path.join(COMPONENTS_ROOT, DEPLOY_STAGING_DIR), { recursive: true, force: true });
+		await fs.rm(path.join(COMPONENTS_ROOT, DEPLOY_ACTIVATION_DIR), { recursive: true, force: true });
+		await fs.rm(path.join(COMPONENTS_ROOT, '.deploy-aside'), { recursive: true, force: true });
+	});
 
-	it('deploy_component({activate:false}) stages into the hidden dir without going live, and returns a deployment_id', async () => {
-		const name = freshName();
-		const res = await operations.deployComponent({
-			project: name,
-			payload: await makeComponentPayload('op-staged'),
+	function name() {
+		const value = `phase_op_${process.pid}_${sequence++}`;
+		names.push(value);
+		return value;
+	}
+
+	it('stages without touching live and records an immutable activation specification', async () => {
+		const project = name();
+		const result = await operations.deployComponent({
+			project,
+			payload: await makePayload('1.0.0'),
 			activate: false,
 		});
 
-		assert.strictEqual(res.staged, true);
-		assert.strictEqual(res.project, name);
-		assert.strictEqual(typeof res.deployment_id, 'string');
-
-		const stagedDir = path.join(COMPONENTS_ROOT, DEPLOY_STAGING_DIR, res.deployment_id, name);
-		assert.ok(existsSync(path.join(stagedDir, 'index.js')), 'component was built into the staging dir');
-		assert.strictEqual(existsSync(path.join(COMPONENTS_ROOT, name)), false, 'staging did not touch the live path');
+		assert.equal(result.staged, true);
+		assert.match(result.deployment_id, /^[0-9a-f-]{36}$/i);
+		assert.equal(existsSync(path.join(COMPONENTS_ROOT, project)), false);
+		assert.equal(existsSync(path.join(COMPONENTS_ROOT, DEPLOY_STAGING_DIR, result.deployment_id, project)), true);
+		const row = rows.get(result.deployment_id);
+		assert.ok(row, `deployment row missing; present ids: ${Array.from(rows.keys()).join(', ')}`);
+		assert.equal(row.status, 'staged');
+		assert.deepEqual(row.activation_spec, {
+			project,
+			package: null,
+			install_command: null,
+			install_timeout: null,
+			install_allow_scripts: null,
+			urlPath: null,
+			host: null,
+			credentials: null,
+			force: false,
+		});
 	});
 
-	it('deploy_component({deployment_id}) takes a prior stage live', async () => {
-		const name = freshName();
+	it('uses a no-custody literal registry token for the origin install without recording it', async () => {
+		const project = name();
+		const token = 'transient-origin-token';
+		const installCommand =
+			`node -e "const fs=require('fs');` +
+			`const value=fs.readFileSync(process.env.npm_config_userconfig||process.env.NPM_CONFIG_USERCONFIG,'utf8');` +
+			`if(!value.includes('//registry.example.com/:_authToken='))process.exit(7);` +
+			`fs.writeFileSync('credential-seen','yes')"`;
+		const result = await operations.deployComponent({
+			project,
+			payload: await makePayload('credential-origin', '6.0.0', false),
+			install_command: installCommand,
+			credentials: [{ registry: 'https://registry.example.com', token }],
+			activate: false,
+		});
+
+		const stagedPath = path.join(COMPONENTS_ROOT, DEPLOY_STAGING_DIR, result.deployment_id, project);
+		assert.equal(await fs.readFile(path.join(stagedPath, 'credential-seen'), 'utf8'), 'yes');
+		assert.equal(rows.get(result.deployment_id).activation_spec.credentials, null);
+		assert.doesNotMatch(JSON.stringify(rows.get(result.deployment_id)), new RegExp(token));
+	});
+
+	it('activates only a staged row owned by the requested project', async () => {
+		const project = name();
 		const staged = await operations.deployComponent({
-			project: name,
-			payload: await makeComponentPayload('op-activated'),
+			project,
+			payload: await makePayload('2.0.0'),
 			activate: false,
 		});
-		const res = await operations.deployComponent({ project: name, deployment_id: staged.deployment_id });
 
-		assert.strictEqual(res.activated, true);
-		assert.strictEqual(res.project, name);
-		assert.strictEqual(res.deployment_id, staged.deployment_id);
-		const liveDir = path.join(COMPONENTS_ROOT, name);
-		assert.ok(existsSync(liveDir), 'live component dir now exists');
-		assert.match(await readIndex(liveDir), /op-activated/);
-		// A restart was not requested, so the message must not claim one.
-		assert.doesNotMatch(res.message, /restart/i);
-		// ...but this component was never live before, so activating it without a restart must mark one
-		// as required (harper#674) — the activate-existing leg of the two-phase restart-required fix. The
-		// message assertion above can't see this: the string never mentions "restart" on the no-restart
-		// path whether or not the marking runs, so assert the flag directly.
-		assert.strictEqual(
-			restartNeeded(),
-			true,
-			'activating a never-live component without restart marks a restart required'
+		await assert.rejects(
+			operations.deployComponent({ project: `${project}_other`, deployment_id: staged.deployment_id }),
+			/not a staged deployment/
+		);
+		const activated = await operations.deployComponent({ project, deployment_id: staged.deployment_id });
+
+		assert.equal(activated.activated, true);
+		assert.equal(rows.get(staged.deployment_id).status, 'success');
+		assert.match(await fs.readFile(path.join(COMPONENTS_ROOT, project, 'index.js'), 'utf8'), /2.0.0/);
+	});
+
+	it('does not let a duplicate activation undo the winning activation state', async () => {
+		const project = name();
+		const staged = await operations.deployComponent({
+			project,
+			payload: await makePayload('duplicate-winner', '6.0.0'),
+			activate: false,
+		});
+
+		const outcomes = await Promise.allSettled([
+			operations.deployComponent({ project, deployment_id: staged.deployment_id }),
+			operations.deployComponent({ project, deployment_id: staged.deployment_id }),
+		]);
+
+		assert.equal(outcomes.filter((outcome) => outcome.status === 'fulfilled').length, 1);
+		assert.equal(outcomes.filter((outcome) => outcome.status === 'rejected').length, 1);
+		assert.equal(rows.get(staged.deployment_id).status, 'success');
+		assert.match(await fs.readFile(path.join(COMPONENTS_ROOT, project, 'index.js'), 'utf8'), /duplicate-winner/);
+	});
+
+	it('rejects fresh build or routing input on activate-by-id', async () => {
+		const project = name();
+		const staged = await operations.deployComponent({
+			project,
+			payload: await makePayload('3.0.0'),
+			activate: false,
+		});
+
+		await assert.rejects(
+			operations.deployComponent({
+				project,
+				deployment_id: staged.deployment_id,
+				install_command: 'npm install --evil',
+			}),
+			/immutable staged configuration.*install_command/
 		);
 	});
 
-	// The activate-existing path fans the activate out to peers just like the two-phase activate phase,
-	// and replicateOperation never rejects on a per-peer failure — failures surface only as 'failed'
-	// entries. Without the shared activate gate this path returned 2xx {activated:true} while part of the
-	// cluster stayed on the old version, making revert_on_failure/ignore_replication_errors no-ops here.
-	describe('deploy_component({deployment_id}) peer-failure gate', () => {
-		let priorReplicate;
-		// Swap in a replicator that reports one failed peer (the repo's property-swap pattern; no
-		// sinon/rewire per AGENTS.md). Restored after each test.
-		function stubFailedPeer() {
-			priorReplicate = server.replication.replicateOperation;
-			server.replication.replicateOperation = async () => ({
-				replicated: [{ node: 'peer-a', status: 'failed', reason: 'no staged build found' }],
+	it('stages and activates a full deploy before reporting success', async () => {
+		const project = name();
+		const result = await operations.deployComponent({
+			project,
+			payload: await makePayload('full-deploy', '6.0.0'),
+		});
+
+		assert.match(result.message, /Successfully deployed/);
+		assert.equal(rows.get(result.deployment_id).status, 'success');
+		assert.match(await fs.readFile(path.join(COMPONENTS_ROOT, project, 'index.js'), 'utf8'), /full-deploy/);
+		assert.equal(existsSync(path.join(COMPONENTS_ROOT, DEPLOY_STAGING_DIR, result.deployment_id)), false);
+		assert.equal(restartNeeded(), true, 'a new component activated without restart requires one');
+	});
+
+	it('reclaims an oversized payload only after a full two-phase activation succeeds', async () => {
+		const project = name();
+		const priorMaxSize = environment.get(CONFIG_PARAMS.DEPLOYMENT_PAYLOADRETENTION_MAXSIZE);
+		environment.setProperty(CONFIG_PARAMS.DEPLOYMENT_PAYLOADRETENTION_MAXSIZE, 1);
+		try {
+			const result = await operations.deployComponent({
+				project,
+				payload: await makePayload('reclaimed-full-deploy', '6.0.0'),
 			});
+
+			const row = rows.get(result.deployment_id);
+			assert.equal(row.status, 'success');
+			assert.equal(row.payload_blob, null);
+			assert.ok(row.event_log.some((event) => event.event === 'payload_dropped'));
+		} finally {
+			environment.setProperty(CONFIG_PARAMS.DEPLOYMENT_PAYLOADRETENTION_MAXSIZE, priorMaxSize);
 		}
-		afterEach(() => {
-			if (priorReplicate) server.replication.replicateOperation = priorReplicate;
-			priorReplicate = undefined;
-		});
+	});
 
-		async function stageOnly(name, marker) {
-			const staged = await operations.deployComponent({
-				project: name,
-				payload: await makeComponentPayload(marker),
-				activate: false,
-			});
-			return staged.deployment_id;
+	it('reclaims an oversized retained payload after activate-by-id succeeds', async () => {
+		const project = name();
+		const staged = await operations.deployComponent({
+			project,
+			payload: await makePayload('reclaimed-staged-deploy', '6.0.0'),
+			activate: false,
+		});
+		assert.ok(rows.get(staged.deployment_id).payload_blob, 'staged deployment keeps its recovery payload');
+
+		const priorMaxSize = environment.get(CONFIG_PARAMS.DEPLOYMENT_PAYLOADRETENTION_MAXSIZE);
+		environment.setProperty(CONFIG_PARAMS.DEPLOYMENT_PAYLOADRETENTION_MAXSIZE, 1);
+		try {
+			await operations.deployComponent({ project, deployment_id: staged.deployment_id });
+
+			const row = rows.get(staged.deployment_id);
+			assert.equal(row.status, 'success');
+			assert.equal(row.payload_blob, null);
+			assert.ok(row.event_log.some((event) => event.event === 'payload_dropped'));
+		} finally {
+			environment.setProperty(CONFIG_PARAMS.DEPLOYMENT_PAYLOADRETENTION_MAXSIZE, priorMaxSize);
 		}
-
-		// End-to-end cover for the package-identifier recovery: stage a `package` deploy with
-		// `activate: false`, then activate it by id with no `package` on the request (what `harper activate`
-		// sends) and assert root config is persisted AND the recovered identifier reaches peers. A `file:`
-		// tarball package needs no network and no payload blob — extraction reads the tarball directly — so
-		// a mock deployment table is enough to drive the whole path.
-		it('recovers a staged package deploy: persists root config and fans the package out to peers', async function () {
-			// Unlike the payload deploys used elsewhere in this file, a `package` deploy runs the
-			// protected-core-name guard, which requires componentLoader and so pulls in the private
-			// `@harperfast/skills` dependency. That isn't installed in every local checkout, so skip there
-			// instead of failing on the environment; CI installs it and runs this for real.
-			if (!componentLoaderAvailable()) return this.skip();
-			const name = freshName();
-			const tgzDir = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-op-pkg-'));
-			const tgzPath = path.join(tgzDir, 'component.tgz');
-			await fs.writeFile(tgzPath, await makeComponentPayload('pkg-staged'));
-			const packageId = `file:${tgzPath}`;
-
-			const rows = new Map();
-			const priorTable = databases.system?.[DEPLOYMENT_TABLE];
-			if (!databases.system) databases.system = {};
-			databases.system[DEPLOYMENT_TABLE] = {
-				async get(id) {
-					return rows.get(id);
-				},
-				async put(row) {
-					rows.set(row.deployment_id, { ...row });
-				},
-				async patch(id, partial) {
-					const existing = rows.get(id);
-					if (existing) rows.set(id, { ...existing, ...partial });
-				},
-				async *search(conditions = []) {
-					for (const row of rows.values()) if (conditions.every((c) => row[c.attribute] === c.value)) yield row;
-				},
-			};
-			const configBackup = await fs.readFile(getConfigFilePath(), 'utf8');
-
-			try {
-				const staged = await operations.deployComponent({ project: name, package: packageId, activate: false });
-				assert.strictEqual(staged.staged, true, 'the package deploy staged without going live');
-				assert.strictEqual(
-					rows.get(staged.deployment_id)?.package_identifier,
-					packageId,
-					'the stage recorded the package identifier on the row — the source the activate recovers from'
-				);
-
-				let fannedOut;
-				priorReplicate = server.replication.replicateOperation;
-				server.replication.replicateOperation = async (op) => {
-					fannedOut = op;
-					return {};
-				};
-
-				// No `package` here — exactly what `harper activate project=… deployment_id=…` sends.
-				await operations.deployComponent({ project: name, deployment_id: staged.deployment_id });
-
-				assert.strictEqual(
-					fannedOut?.package,
-					packageId,
-					'the recovered identifier rides the activate sub-op, so peers persist root config too'
-				);
-				assert.strictEqual(
-					getConfiguration()[name]?.package,
-					packageId,
-					'the origin persisted the package reference to root config'
-				);
-			} finally {
-				await fs.writeFile(getConfigFilePath(), configBackup);
-				if (priorTable === undefined) delete databases.system[DEPLOYMENT_TABLE];
-				else databases.system[DEPLOYMENT_TABLE] = priorTable;
-				await fs.rm(tgzDir, { recursive: true, force: true });
-			}
-		});
-
-		it('rejects (does not report success) when a peer fails to activate', async () => {
-			const name = freshName();
-			const deploymentId = await stageOnly(name, 'gate-fail');
-			stubFailedPeer();
-			await assert.rejects(
-				() => operations.deployComponent({ project: name, deployment_id: deploymentId }),
-				/failed to activate on 1 .*peer node\(s\).*peer-a/s,
-				'a partially-failed activate must surface as an error, not a 2xx success'
-			);
-		});
-
-		it('honors ignore_replication_errors on this path, resolving despite the failed peer', async () => {
-			const name = freshName();
-			const deploymentId = await stageOnly(name, 'gate-ignore');
-			stubFailedPeer();
-			const res = await operations.deployComponent({
-				project: name,
-				deployment_id: deploymentId,
-				ignore_replication_errors: true,
-			});
-			assert.strictEqual(res.activated, true, 'the opt-out still returns success');
-			assert.match(await readIndex(path.join(COMPONENTS_ROOT, name)), /gate-ignore/, 'the origin still went live');
-		});
 	});
 
-	it('deploy_component (two-phase default) stages then activates end-to-end', async () => {
-		const name = freshName();
-		const res = await operations.deployComponent({ project: name, payload: await makeComponentPayload('op-deployed') });
-
-		assert.match(res.message, /Successfully deployed/);
-		assert.strictEqual(typeof res.deployment_id, 'string');
-		const liveDir = path.join(COMPONENTS_ROOT, name);
-		assert.match(await readIndex(liveDir), /op-deployed/, 'component is live after a two-phase deploy');
-		// New component deployed without a restart → restart required (harper#674), the origin two-phase leg.
-		assert.strictEqual(restartNeeded(), true, 'a fresh two-phase deploy without restart marks a restart required');
-		// The staged copy was consumed by the swap; its per-deploy staging parent is cleaned up.
-		assert.strictEqual(
-			existsSync(path.join(COMPONENTS_ROOT, DEPLOY_STAGING_DIR, res.deployment_id)),
-			false,
-			'per-deploy staging parent removed after activation'
-		);
-	});
-
-	it('redeploying an already-live component without restart does NOT mark a restart required', async () => {
-		// The negative direction of harper#674/#1806: an existing, already-active component's own watcher
-		// requests any restart a redeploy needs, so deploy_component must stay quiet. Two-phase can't lean
-		// on extractApplication's in-place check (it builds into a fresh staging dir), so this guards that
-		// activateApplication correctly reports isNewComponent:false when a live version already exists.
-		const name = freshName();
-		await operations.deployComponent({ project: name, payload: await makeComponentPayload('redeploy-v1') });
-		resetRestartNeeded(); // clear the flag the first (new-component) deploy legitimately set
-		await operations.deployComponent({ project: name, payload: await makeComponentPayload('redeploy-v2') });
-		assert.strictEqual(
-			restartNeeded(),
-			false,
-			'a redeploy of an already-live component must not self-request a restart'
-		);
-	});
-
-	it('peer _phase:activate takes a locally-staged build live and marks a restart for a new component', async () => {
-		// The peer leg of the fix: a peer applies the fanned-out deploy_component tagged _phase:'activate'
-		// (deployPhaseActivate), swapping its OWN locally-staged build live. It must mark restart-required
-		// per node for a genuinely-new component (harper#674) — otherwise a cluster-wide restart:false
-		// deploy reports restartRequired on the origin only. Stage the build directly (standing in for the
-		// peer's earlier stage phase), then drive the activate phase through the public op with the
-		// internal markers, exactly as the replicated fan-out does.
-		const name = freshName();
-		const deploymentId = `peer-activate-${name}`;
-		const staged = new Application({
-			name,
-			payload: await makeComponentPayload('peer-activated'),
-			stagingId: deploymentId,
-		});
-		await stageApplication(staged);
-
-		const res = await operations.deployComponent({
-			project: name,
-			_phase: 'activate',
-			_deploymentId: deploymentId,
-			restart: false,
-		});
-
-		assert.strictEqual(res.activated, true, 'peer activate reports the component activated');
-		const liveDir = path.join(COMPONENTS_ROOT, name);
-		assert.match(await readIndex(liveDir), /peer-activated/, 'the locally-staged build is now live');
-		assert.strictEqual(
-			restartNeeded(),
-			true,
-			'peer activate of a never-live component without restart marks a restart required'
-		);
-	});
-
-	it('deploy_component with two_phase:false runs the legacy one-shot path', async () => {
-		const name = freshName();
-		const res = await operations.deployComponent({
-			project: name,
-			payload: await makeComponentPayload('op-oneshot'),
+	it('preserves the legacy one-shot path when explicitly requested', async () => {
+		const project = name();
+		const result = await operations.deployComponent({
+			project,
+			payload: await makePayload('one-shot', '6.0.0'),
 			two_phase: false,
 		});
 
-		assert.match(res.message, /Successfully deployed/);
-		const liveDir = path.join(COMPONENTS_ROOT, name);
-		assert.match(await readIndex(liveDir), /op-oneshot/, 'component is live after a one-shot deploy');
+		assert.match(result.message, /Successfully deployed/);
+		assert.match(await fs.readFile(path.join(COMPONENTS_ROOT, project, 'index.js'), 'utf8'), /one-shot/);
 	});
 
-	it('revert_component swaps the live version back to the previous deployment', async () => {
-		const name = freshName();
-		const liveDir = path.join(COMPONENTS_ROOT, name);
-		await operations.deployComponent({ project: name, payload: await makeComponentPayload('rev-v1') });
-		await operations.deployComponent({ project: name, payload: await makeComponentPayload('rev-v2') });
-		assert.match(await readIndex(liveDir), /rev-v2/, 'v2 is live before revert');
+	it('accepts the legacy deployment row marker only from a trusted replicated operation', async () => {
+		const project = name();
+		const payload = await makePayload('trusted-one-shot', '6.0.0');
+		const result = await runWithOperationAuthorizationBypass(true, () =>
+			operations.deployComponent({
+				project,
+				payload,
+				two_phase: false,
+				_deploymentId: '41faded8-6cf5-4a2a-95f8-863e7ea498fa',
+				replicated: false,
+				hdb_user: { name: 'cluster-peer' },
+			})
+		);
 
-		const res = await operations.revertComponent({ project: name });
-
-		assert.strictEqual(res.reverted, true);
-		assert.strictEqual(res.project, name);
-		assert.match(await readIndex(liveDir), /rev-v1/, 'revert restored v1 to live');
+		assert.match(result.message, /Successfully deployed/);
+		assert.match(await fs.readFile(path.join(COMPONENTS_ROOT, project, 'index.js'), 'utf8'), /trusted-one-shot/);
 	});
 
-	it('revert_component rejects a component with no retained previous version', async () => {
-		const name = freshName();
-		await operations.deployComponent({ project: name, payload: await makeComponentPayload('rev-once') });
-		await assert.rejects(() => operations.revertComponent({ project: name }), /no previous version is retained/i);
+	it('fails closed on the preview phase marker even from a trusted peer', async () => {
+		await assert.rejects(
+			runWithOperationAuthorizationBypass(true, () =>
+				operations.deployComponent({
+					project: name(),
+					_phase: 'stage',
+					replicated: false,
+					hdb_user: { name: 'cluster-peer' },
+				})
+			),
+			/Unsupported legacy component deployment phase/
+		);
 	});
 
-	it('revert_component requires a project', async () => {
-		await assert.rejects(() => operations.revertComponent({}), /project/i);
+	it('fails closed on an activate peer failure before scheduling a restart', async () => {
+		const project = name();
+		const staged = await operations.deployComponent({
+			project,
+			payload: await makePayload('4.0.0'),
+			activate: false,
+		});
+		const phases = [];
+		server.replication.replicateOperation = async (operation) => {
+			phases.push(operation.phase);
+			if (operation.phase === 'activate') {
+				return { replicated: [{ node: 'peer-a', status: 'failed', reason: 'config write failed' }] };
+			}
+			return { replicated: [] };
+		};
+
+		await assert.rejects(
+			operations.deployComponent({ project, deployment_id: staged.deployment_id, restart: true }),
+			/Split nodes: peer-a.*[Rr]oll forward/s
+		);
+		assert.deepEqual(phases, ['activate'], 'restart phase was never sent after the activation gate failed');
+		assert.equal(rows.get(staged.deployment_id).status, 'activating');
+		assert.equal(rows.get(staged.deployment_id).completed_at, null);
+		assert.ok(rows.get(staged.deployment_id).payload_blob, 'payload remains available to repair a split cluster');
+		assert.equal(rows.get(staged.deployment_id).peer_results[0].node, 'peer-a');
 	});
 
-	// The revert_on_failure fan-out itself needs a live multi-node cluster (harper-pro's replicator) to
-	// run end-to-end, but its node-targeting is a pure function — and the exact spot that had two
-	// review-caught bugs (skip failed peers, skip self). Exercise it directly.
-	describe('selectRevertTargets (revert_on_failure node targeting)', () => {
-		const nodes = [{ name: 'origin' }, { name: 'peerA' }, { name: 'peerB' }, { name: 'peerC' }];
+	it('records success when restart fails after the activation barrier', async () => {
+		const project = name();
+		const phases = [];
+		server.replication.replicateOperation = async (operation) => {
+			phases.push(operation.phase);
+			return operation.phase === 'restart'
+				? { replicated: [{ node: 'peer-a', status: 'failed', reason: 'restart unavailable' }] }
+				: { replicated: [] };
+		};
+		const priorRestartWorkers = manageThreads.restartWorkers;
+		manageThreads.restartWorkers = () => {};
+		let deploymentId;
+		try {
+			await assert.rejects(
+				operations
+					.deployComponent({
+						project,
+						payload: await makePayload('activated-before-restart-failure', '6.0.0'),
+						restart: true,
+					})
+					.catch((error) => {
+						deploymentId = error.http_resp_msg?.deployment_id;
+						throw error;
+					}),
+				/restart failed/
+			);
+		} finally {
+			manageThreads.restartWorkers = priorRestartWorkers;
+		}
 
-		it('returns activated peers, excluding this node and failed peers', () => {
-			const failed = [{ node: 'peerB', status: 'failed' }];
-			const targets = operations.selectRevertTargets(nodes, failed, 'origin').map((n) => n.name);
-			assert.deepStrictEqual(targets.sort(), ['peerA', 'peerC'], 'peerB (failed) and origin (self) excluded');
+		assert.deepEqual(phases, ['stage', 'activate', 'restart']);
+		assert.equal(rows.get(deploymentId).status, 'success');
+		assert.match(await fs.readFile(path.join(COMPONENTS_ROOT, project, 'index.js'), 'utf8'), /activated-before/);
+	});
+
+	it('records peer failures but honors ignore_replication_errors', async () => {
+		const project = name();
+		const staged = await operations.deployComponent({
+			project,
+			payload: await makePayload('ignored-peer', '6.0.0'),
+			activate: false,
+		});
+		server.replication.replicateOperation = async () => ({
+			replicated: [{ node: 'peer-a', status: 'failed', reason: 'offline' }],
 		});
 
-		it('excludes THIS node even when it is present in server.nodes (bidirectional double-revert guard)', () => {
-			const targets = operations.selectRevertTargets(nodes, [], 'origin').map((n) => n.name);
-			assert.ok(!targets.includes('origin'), 'self must never receive a self-directed revert');
-			assert.deepStrictEqual(targets.sort(), ['peerA', 'peerB', 'peerC']);
+		const result = await operations.deployComponent({
+			project,
+			deployment_id: staged.deployment_id,
+			ignore_replication_errors: true,
 		});
 
-		it('excludes every failed peer (they never activated and are on the correct version)', () => {
-			const failed = [
-				{ node: 'peerA', status: 'failed' },
-				{ node: 'peerC', status: 'failed' },
-			];
-			const targets = operations.selectRevertTargets(nodes, failed, 'origin').map((n) => n.name);
-			assert.deepStrictEqual(targets, ['peerB'], 'only the one activated peer is a revert target');
-		});
+		assert.equal(result.activated, true);
+		assert.equal(rows.get(staged.deployment_id).status, 'success');
+		assert.equal(rows.get(staged.deployment_id).peer_results[0].status, 'failed');
+	});
 
-		it('is safe with empty/undefined nodes and failed lists, and ignores failed entries with no node name', () => {
-			assert.deepStrictEqual(operations.selectRevertTargets(undefined, undefined, 'origin'), []);
-			assert.deepStrictEqual(operations.selectRevertTargets([], [{ node: null }], 'origin'), []);
-			const targets = operations.selectRevertTargets(nodes, [{ node: null }], 'origin').map((n) => n.name);
-			assert.deepStrictEqual(targets.sort(), ['peerA', 'peerB', 'peerC'], 'a null-node failed entry drops nobody');
+	it('records and surfaces ignored restart failures after the activation gate', async () => {
+		const project = name();
+		const staged = await operations.deployComponent({
+			project,
+			payload: await makePayload('restart-failure', '6.0.0'),
+			activate: false,
 		});
+		const phases = [];
+		server.replication.replicateOperation = async (operation) => {
+			phases.push(operation.phase);
+			return operation.phase === 'restart'
+				? { replicated: [{ node: 'peer-a', status: 'failed', reason: 'restart unavailable' }] }
+				: { replicated: [] };
+		};
+		const priorRestartWorkers = manageThreads.restartWorkers;
+		let localRestarts = 0;
+		manageThreads.restartWorkers = () => localRestarts++;
+		let result;
+		try {
+			result = await operations.deployComponent({
+				project,
+				deployment_id: staged.deployment_id,
+				restart: true,
+				ignore_replication_errors: true,
+			});
+		} finally {
+			manageThreads.restartWorkers = priorRestartWorkers;
+		}
+
+		assert.deepEqual(phases, ['activate', 'restart']);
+		assert.equal(localRestarts, 1);
+		assert.equal(result.activated, true);
+		assert.equal(result.failed_peers[0].node, 'peer-a');
+		assert.equal(rows.get(staged.deployment_id).peer_results[0].status, 'failed');
+	});
+
+	it('uses the row-backed immutable specification for trusted peer phases', async () => {
+		const project = name();
+		const staged = await operations.deployComponent({
+			project,
+			payload: await makePayload('peer-phase', '6.0.0'),
+			activate: false,
+		});
+		const row = rows.get(staged.deployment_id);
+		const componentPath = path.join(COMPONENTS_ROOT, project);
+		await discardStagedApplication(componentPath, staged.deployment_id);
+		const executePeerPhase = (phase, activationSpec) =>
+			runWithOperationAuthorizationBypass(true, () =>
+				operations.componentDeployPhase({
+					operation: 'component_deploy_phase',
+					phase,
+					project,
+					deployment_id: staged.deployment_id,
+					activation_spec: activationSpec,
+					replicated: false,
+					hdb_user: { name: 'cluster-peer' },
+				})
+			);
+
+		await assert.rejects(
+			executePeerPhase('stage', { ...row.activation_spec, host: 'tampered.example' }),
+			/immutable activation specification/
+		);
+		await executePeerPhase('stage', row.activation_spec);
+		assert.equal(existsSync(path.join(COMPONENTS_ROOT, DEPLOY_STAGING_DIR, staged.deployment_id, project)), true);
+		await executePeerPhase('activate', row.activation_spec);
+		assert.match(await fs.readFile(path.join(componentPath, 'index.js'), 'utf8'), /peer-phase/);
+		assert.equal(rows.get(staged.deployment_id).status, 'activating');
+		assert.equal(restartNeeded(), true);
+	});
+
+	it('rebuilds a missing peer stage from the durable deployment payload before activation', async () => {
+		const project = name();
+		const staged = await operations.deployComponent({
+			project,
+			payload: await makePayload('rebuilt-peer', '6.0.0'),
+			activate: false,
+		});
+		const row = rows.get(staged.deployment_id);
+		const componentPath = path.join(COMPONENTS_ROOT, project);
+		await discardStagedApplication(componentPath, staged.deployment_id);
+
+		await runWithOperationAuthorizationBypass(true, () =>
+			operations.componentDeployPhase({
+				operation: 'component_deploy_phase',
+				phase: 'activate',
+				project,
+				deployment_id: staged.deployment_id,
+				activation_spec: row.activation_spec,
+				replicated: false,
+				hdb_user: { name: 'cluster-peer' },
+			})
+		);
+
+		assert.match(await fs.readFile(path.join(componentPath, 'index.js'), 'utf8'), /rebuilt-peer/);
+		assert.equal(rows.get(staged.deployment_id).status, 'activating');
+	});
+
+	it('waits for the staged row checkpoint when peer activation arrives first', async () => {
+		const project = name();
+		const staged = await operations.deployComponent({
+			project,
+			payload: await makePayload('lagged-row', '6.0.0'),
+			activate: false,
+		});
+		const row = rows.get(staged.deployment_id);
+		rows.set(staged.deployment_id, { ...row, status: 'staging' });
+		setImmediate(() => rows.set(staged.deployment_id, { ...rows.get(staged.deployment_id), status: 'staged' }));
+
+		await runWithOperationAuthorizationBypass(true, () =>
+			operations.componentDeployPhase({
+				operation: 'component_deploy_phase',
+				phase: 'activate',
+				project,
+				deployment_id: staged.deployment_id,
+				activation_spec: row.activation_spec,
+				deployment_timeout: 200,
+				replicated: false,
+				hdb_user: { name: 'cluster-peer' },
+			})
+		);
+
+		assert.match(await fs.readFile(path.join(COMPONENTS_ROOT, project, 'index.js'), 'utf8'), /lagged-row/);
+		assert.equal(rows.get(staged.deployment_id).status, 'activating');
+	});
+
+	it('recovers a staged package specification for config and peer activation', async () => {
+		const project = name();
+		const tarDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-phase-package-'));
+		const tarPath = path.join(tarDirectory, 'component.tgz');
+		await fs.writeFile(tarPath, await makePayload('package-stage', '6.0.0'));
+		const packageIdentifier = `file:${tarPath}`;
+		const configRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-phase-config-'));
+		const configPath = path.join(configRoot, 'harper-config.yaml');
+		await fs.writeFile(configPath, `rootPath: ${JSON.stringify(configRoot)}\n`);
+		const priorRootEnv = process.env.ROOTPATH;
+		const priorRootConfig = getConfigPath(CONFIG_PARAMS.ROOTPATH);
+		process.env.ROOTPATH = configRoot;
+		environment.setProperty(CONFIG_PARAMS.ROOTPATH, configRoot);
+		try {
+			const staged = await operations.deployComponent({
+				project,
+				package: packageIdentifier,
+				activate: false,
+			});
+			let activationOperation;
+			server.replication.replicateOperation = async (operation) => {
+				activationOperation = operation;
+				return { replicated: [] };
+			};
+
+			await operations.deployComponent({ project, deployment_id: staged.deployment_id });
+
+			assert.equal(readConfigFile()[project].package, packageIdentifier);
+			assert.equal(activationOperation.operation, 'component_deploy_phase');
+			assert.equal(activationOperation.activation_spec.package, packageIdentifier);
+		} finally {
+			if (priorRootEnv === undefined) delete process.env.ROOTPATH;
+			else process.env.ROOTPATH = priorRootEnv;
+			environment.setProperty(CONFIG_PARAMS.ROOTPATH, priorRootConfig);
+			await fs.rm(configRoot, { recursive: true, force: true });
+			await fs.rm(tarDirectory, { recursive: true, force: true });
+		}
+	});
+
+	it('drop_component invalidates staged rows and removes recovery artifacts', async () => {
+		const project = name();
+		const configRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-phase-drop-'));
+		const componentsRoot = path.join(configRoot, 'components');
+		const configPath = path.join(configRoot, 'harper-config.yaml');
+		const priorRootEnv = process.env.ROOTPATH;
+		const priorRootConfig = getConfigPath(CONFIG_PARAMS.ROOTPATH);
+		const priorComponentsRoot = getConfigPath(CONFIG_PARAMS.COMPONENTSROOT);
+		process.env.ROOTPATH = configRoot;
+		environment.setProperty(CONFIG_PARAMS.ROOTPATH, configRoot);
+		environment.setProperty(CONFIG_PARAMS.COMPONENTSROOT, componentsRoot);
+		await fs.writeFile(configPath, `rootPath: ${JSON.stringify(configRoot)}\n`);
+		try {
+			const staged = await operations.deployComponent({
+				project,
+				payload: await makePayload('drop-stage', '6.0.0'),
+				activate: false,
+			});
+			const activationPath = path.join(componentsRoot, DEPLOY_ACTIVATION_DIR, project, 'interrupted');
+			await fs.mkdir(activationPath, { recursive: true });
+			await fs.writeFile(
+				path.join(configRoot, 'harper-application-lock.json'),
+				JSON.stringify({ applications: { [project]: { package: 'stale-package' } } })
+			);
+
+			await operations.dropComponent({ project });
+
+			assert.equal(rows.get(staged.deployment_id).status, 'failed');
+			const deploymentStagePath = path.join(componentsRoot, DEPLOY_STAGING_DIR, staged.deployment_id);
+			assert.equal(
+				existsSync(deploymentStagePath),
+				false,
+				`staged deployment directory still contains: ${await fs.readdir(deploymentStagePath).catch(() => [])}`
+			);
+			assert.equal(existsSync(path.join(componentsRoot, DEPLOY_ACTIVATION_DIR, project)), false);
+			const applicationLock = JSON.parse(await fs.readFile(path.join(configRoot, 'harper-application-lock.json')));
+			assert.equal(applicationLock.applications[project], undefined);
+		} finally {
+			if (priorRootEnv === undefined) delete process.env.ROOTPATH;
+			else process.env.ROOTPATH = priorRootEnv;
+			environment.setProperty(CONFIG_PARAMS.ROOTPATH, priorRootConfig);
+			environment.setProperty(CONFIG_PARAMS.COMPONENTSROOT, priorComponentsRoot);
+			await fs.rm(configRoot, { recursive: true, force: true });
+		}
+	});
+
+	it('rejects separated-phase controls on the one-shot fallback', async () => {
+		await assert.rejects(
+			operations.deployComponent({
+				project: name(),
+				payload: await makePayload('5.0.0'),
+				activate: false,
+				two_phase: false,
+			}),
+			/require two-phase deploy/
+		);
+	});
+
+	it('rejects an explicit two-phase request when the system database is not replicated', async () => {
+		const priorReplications = environment.get(CONFIG_PARAMS.REPLICATION_DATABASES);
+		environment.setProperty(CONFIG_PARAMS.REPLICATION_DATABASES, ['data']);
+		try {
+			await assert.rejects(
+				operations.deployComponent({
+					project: name(),
+					payload: await makePayload('requires-system-replication'),
+					two_phase: true,
+				}),
+				/requires system database replication/
+			);
+		} finally {
+			environment.setProperty(CONFIG_PARAMS.REPLICATION_DATABASES, priorReplications);
+		}
+	});
+
+	it('does not trust caller-supplied internal phase markers', async () => {
+		await assert.rejects(
+			operations.deployComponent({
+				project: name(),
+				payload: await makePayload('untrusted-replication'),
+				replicated: false,
+				two_phase: true,
+			}),
+			/requires operation replication/
+		);
+		await assert.rejects(
+			operations.deployComponent({
+				project: name(),
+				_deploymentId: '../../escape',
+				_phase: 'stage',
+			}),
+			/is not allowed/
+		);
+		await assert.rejects(
+			operations.componentDeployPhase({
+				operation: 'component_deploy_phase',
+				phase: 'discard',
+				project: name(),
+				deployment_id: '41faded8-6cf5-4a2a-95f8-863e7ea498fa',
+				activation_spec: { project: 'anything' },
+			}),
+			/restricted to authenticated cluster peers/
+		);
+		await assert.rejects(
+			runWithOperationAuthorizationBypass(true, () =>
+				operations.componentDeployPhase({
+					operation: 'component_deploy_phase',
+					phase: 'discard',
+					project: '../escape',
+					deployment_id: '41faded8-6cf5-4a2a-95f8-863e7ea498fa',
+					activation_spec: { project: '../escape' },
+					replicated: false,
+					hdb_user: { name: 'cluster-peer' },
+				})
+			),
+			/project name/i
+		);
 	});
 });

--- a/unitTests/components/deployPhaseValidators.test.js
+++ b/unitTests/components/deployPhaseValidators.test.js
@@ -1,68 +1,58 @@
 'use strict';
 
-// Validators for the two-phase deploy operations. Uses node:assert (not chai) and loads only
-// operationsValidation (Joi + config helpers), so it runs without the private agent dependency that
-// componentLoader pulls in.
-
-const assert = require('node:assert');
+const assert = require('node:assert/strict');
 const validator = require('#js/components/operationsValidation');
 
-// validateBySchema returns a truthy validation error when invalid, undefined when valid.
-const ok = (result) => assert.strictEqual(result, undefined, `expected valid, got: ${result && result.message}`);
-const rejected = (result) => assert.ok(result, 'expected a validation error');
+const valid = (result) => assert.equal(result, undefined, `expected valid, got: ${result?.message}`);
+const invalid = (result) => assert.ok(result, 'expected a validation error');
 
-describe('revertComponentValidator', () => {
-	it('accepts a project-only revert', () => {
-		ok(validator.revertComponentValidator({ project: 'my_app' }));
-	});
-
-	it('accepts a deployment_id, restart, and ignore_replication_errors', () => {
-		ok(
-			validator.revertComponentValidator({
+describe('deployComponentValidator two-phase controls', () => {
+	it('accepts stage-and-stop and UUID activation', () => {
+		valid(validator.deployComponentValidator({ project: 'my_app', activate: false }));
+		valid(
+			validator.deployComponentValidator({
 				project: 'my_app',
-				deployment_id: 'abc-123',
-				restart: 'rolling',
-				ignore_replication_errors: true,
+				deployment_id: '41faded8-6cf5-4a2a-95f8-863e7ea498fa',
 			})
 		);
 	});
 
-	it('requires a project', () => {
-		rejected(validator.revertComponentValidator({ deployment_id: 'abc-123' }));
-	});
-
-	it('rejects an invalid restart value', () => {
-		rejected(validator.revertComponentValidator({ project: 'my_app', restart: 'sideways' }));
-	});
-});
-
-describe('deployComponentValidator two-phase props (activate / deployment_id / flags)', () => {
-	it('accepts activate: false (stage-and-stop)', () => {
-		ok(validator.deployComponentValidator({ project: 'my_app', activate: false }));
-	});
-
-	it('accepts a deployment_id (activate an existing stage)', () => {
-		ok(
-			validator.deployComponentValidator({ project: 'my_app', deployment_id: '41faded8-6cf5-4a2a-95f8-863e7ea498fa' })
-		);
-	});
-
-	it('rejects a path-traversal deployment_id (it becomes a staging-dir path segment)', () => {
-		for (const bad of ['../evil', 'a/b', 'dep/../..', '.', '..']) {
-			rejected(validator.deployComponentValidator({ project: 'my_app', deployment_id: bad }));
+	it('requires deployment_id to be a UUID and rejects path traversal', () => {
+		for (const deploymentId of ['abc-123', '../evil', 'dep/../..', '.', '..']) {
+			invalid(validator.deployComponentValidator({ project: 'my_app', deployment_id: deploymentId }));
 		}
 	});
 
-	it('accepts revert_on_failure: true', () => {
-		ok(validator.deployComponentValidator({ project: 'my_app', package: 'npm:x', revert_on_failure: true }));
+	it('rejects caller-controlled internal phase markers', () => {
+		invalid(validator.deployComponentValidator({ project: 'my_app', _deploymentId: 'x' }));
+		invalid(validator.deployComponentValidator({ project: 'my_app', _phase: 'stage' }));
 	});
 
-	it('accepts two_phase: false (legacy opt-out) and true', () => {
-		ok(validator.deployComponentValidator({ project: 'my_app', package: 'npm:x', two_phase: false }));
-		ok(validator.deployComponentValidator({ project: 'my_app', package: 'npm:x', two_phase: true }));
+	it('rejects retry-unsafe automatic rollback', () => {
+		invalid(validator.deployComponentValidator({ project: 'my_app', revert_on_failure: true }));
 	});
 
-	it('rejects a non-boolean two_phase', () => {
-		rejected(validator.deployComponentValidator({ project: 'my_app', package: 'npm:x', two_phase: 'yes' }));
+	it('preserves routing validation', () => {
+		invalid(validator.deployComponentValidator({ project: 'my_app', package: 'npm:x', urlPath: '/a/./b' }));
+		invalid(validator.deployComponentValidator({ project: 'my_app', package: 'npm:x', urlPath: '/a/../b' }));
+	});
+});
+
+describe('componentDeployPhaseValidator', () => {
+	const validPhase = {
+		phase: 'stage',
+		deployment_id: '41faded8-6cf5-4a2a-95f8-863e7ea498fa',
+		project: 'my_app',
+		activation_spec: { project: 'my_app' },
+	};
+
+	it('accepts a bounded internal phase request', () => {
+		valid(validator.componentDeployPhaseValidator(validPhase));
+	});
+
+	it('rejects invalid phases, project traversal, and non-UUID ids', () => {
+		invalid(validator.componentDeployPhaseValidator({ ...validPhase, phase: 'deploy' }));
+		invalid(validator.componentDeployPhaseValidator({ ...validPhase, project: '../escape' }));
+		invalid(validator.componentDeployPhaseValidator({ ...validPhase, deployment_id: '../../escape' }));
 	});
 });

--- a/unitTests/components/deployStaging.test.js
+++ b/unitTests/components/deployStaging.test.js
@@ -1,16 +1,11 @@
 'use strict';
 
-// Unit tests for the two-phase deploy primitives in components/Application.ts:
-// stageApplication (build the incoming version into a hidden staging dir, never touching the live
-// path), activateApplication (atomically swap the staged copy into the live path), and
-// discardStagedApplication (drop an aborted stage). These exercise the real filesystem — no
-// componentLoader, no network — so they run without the private agent dependency.
-
-const assert = require('node:assert');
+const assert = require('node:assert/strict');
 const fs = require('node:fs/promises');
 const { existsSync } = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { randomUUID } = require('node:crypto');
 const zlib = require('node:zlib');
 const tarfs = require('tar-fs');
 
@@ -20,311 +15,375 @@ testUtils.preTestPrep();
 const {
 	Application,
 	stageApplication,
-	activateApplication,
-	revertApplication,
+	activateStagedApplication,
 	discardStagedApplication,
+	discardProjectActivationArtifacts,
+	reconcileStagedApplicationArtifacts,
+	createApplicationActivationTransaction,
+	stagedApplicationPath,
 	DEPLOY_STAGING_DIR,
-	DEPLOY_PREVIOUS_DIR,
+	DEPLOY_ACTIVATION_DIR,
 	ASIDE_STAGING_DIR,
 } = require('#src/components/Application');
-const { getConfigPath } = require('#src/config/configUtils');
+const { getConfigPath, readConfigFile } = require('#src/config/configUtils');
 const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
+const environment = require('#src/utility/environment/environmentManager');
 
 const COMPONENTS_ROOT = getConfigPath(CONFIG_PARAMS.COMPONENTSROOT);
 
-// Pack a directory's CONTENTS into a gzipped tar Buffer, the shape a deploy payload takes.
 function packDirectory(dir) {
 	return new Promise((resolve, reject) => {
 		const chunks = [];
 		tarfs
 			.pack(dir)
 			.pipe(zlib.createGzip())
-			.on('data', (c) => chunks.push(c))
+			.on('data', (chunk) => chunks.push(chunk))
 			.on('end', () => resolve(Buffer.concat(chunks)))
 			.on('error', reject);
 	});
 }
 
-// A minimal component source that already contains node_modules, so installApplication short-circuits
-// ("already has node_modules; skipping install") and the test needs no npm/network.
-async function makeComponentPayload(marker) {
-	const src = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-stage-src-'));
-	await fs.writeFile(path.join(src, 'package.json'), JSON.stringify({ name: 'stage-fixture', version: '1.0.0' }));
-	await fs.writeFile(path.join(src, 'index.js'), `module.exports = ${JSON.stringify(marker)};\n`);
-	await fs.mkdir(path.join(src, 'node_modules'), { recursive: true });
-	await fs.writeFile(path.join(src, 'node_modules', '.marker'), marker);
-	const payload = await packDirectory(src);
-	await fs.rm(src, { recursive: true, force: true });
+async function makeComponentPayload(marker, version = '1.0.0') {
+	const source = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-stage-src-'));
+	await fs.writeFile(path.join(source, 'package.json'), JSON.stringify({ name: 'stage-fixture', version }));
+	await fs.writeFile(path.join(source, 'index.js'), `module.exports = ${JSON.stringify(marker)};\n`);
+	await fs.mkdir(path.join(source, 'node_modules'), { recursive: true });
+	const payload = await packDirectory(source);
+	await fs.rm(source, { recursive: true, force: true });
 	return payload;
 }
 
-async function readMarker(dir) {
-	return fs.readFile(path.join(dir, 'index.js'), 'utf8');
+async function readMarker(directory) {
+	return fs.readFile(path.join(directory, 'index.js'), 'utf8');
 }
 
-describe('two-phase deploy primitives (stage / activate / discard)', function () {
+describe('two-phase component directory transaction', function () {
 	this.timeout(30_000);
+	let sequence = 0;
 
-	before(async () => {
-		await fs.mkdir(COMPONENTS_ROOT, { recursive: true });
-	});
+	before(async () => fs.mkdir(COMPONENTS_ROOT, { recursive: true }));
 
-	// Each case uses a unique component name so the tests are order-independent and don't collide.
-	let counter = 0;
-	function freshApp(payload) {
-		const name = `stage_test_${process.pid}_${counter++}`;
-		return new Application({ name, payload });
+	function fixtureName() {
+		return `stage_test_${process.pid}_${sequence++}`;
 	}
 
-	it('stageApplication builds into the hidden staging dir and does NOT touch the live path', async () => {
-		const app = freshApp(await makeComponentPayload('v1'));
-
-		assert.ok(app.stagingDirPath.includes(DEPLOY_STAGING_DIR), 'staging path is under the staging dir');
-		assert.strictEqual(app.buildDirPath, app.dirPath, 'build target defaults to the live dir before staging');
-
-		const stagedPath = await stageApplication(app);
-
-		assert.strictEqual(stagedPath, app.stagingDirPath);
-		assert.ok(existsSync(path.join(app.stagingDirPath, 'index.js')), 'component extracted into staging');
-		assert.ok(existsSync(path.join(app.stagingDirPath, 'node_modules')), 'node_modules present in staging');
-		assert.strictEqual(existsSync(app.dirPath), false, 'live component dir was NOT created by staging');
-
-		await fs.rm(path.dirname(app.stagingDirPath), { recursive: true, force: true });
-	});
-
-	it('activateApplication swaps the staged copy into the live path atomically', async () => {
-		const app = freshApp(await makeComponentPayload('v1'));
-		await stageApplication(app);
-		await activateApplication(app);
-
-		assert.ok(existsSync(app.dirPath), 'live component dir now exists');
-		assert.match(await readMarker(app.dirPath), /v1/, 'live dir holds the staged content');
-		assert.strictEqual(existsSync(app.stagingDirPath), false, 'the staged copy was consumed by the swap');
-		assert.strictEqual(app.buildDirPath, app.dirPath, 'build target reset to live after activation');
-		// No live version existed before the swap, so this is a first deploy. deploy_component reads this
-		// to mark restartRequired for a never-loaded component (harper#674); staging is always fresh, so
-		// activate — not extract — is what establishes it on the two-phase path.
-		assert.strictEqual(app.isNewComponent, true, 'a first-ever activate marks the component new');
-
-		await fs.rm(app.dirPath, { recursive: true, force: true });
-	});
-
-	it('stage → activate replaces an existing live version and moves the old one aside', async () => {
-		const name = `stage_test_${process.pid}_${counter++}`;
-		const dirPath = path.join(COMPONENTS_ROOT, name);
-		// Seed an existing live version.
-		await fs.mkdir(dirPath, { recursive: true });
-		await fs.writeFile(path.join(dirPath, 'index.js'), 'module.exports = "OLD";\n');
-		await fs.writeFile(path.join(dirPath, 'leftover.txt'), 'from the old version');
-
-		const app = new Application({ name, payload: await makeComponentPayload('v2') });
-		await stageApplication(app);
-		await activateApplication(app);
-
-		assert.match(await readMarker(dirPath), /v2/, 'live dir now holds the new version');
-		assert.strictEqual(existsSync(path.join(dirPath, 'leftover.txt')), false, 'old-version files are gone from live');
-		// A live version existed before the swap, so this is a redeploy, not a first deploy — deploy_component
-		// must NOT self-request a restart here (harper#1806); the existing component's own watcher does.
-		assert.strictEqual(app.isNewComponent, false, 'activating over an existing live version marks it not-new');
-
-		await fs.rm(dirPath, { recursive: true, force: true });
-		await fs.rm(path.join(COMPONENTS_ROOT, ASIDE_STAGING_DIR), { recursive: true, force: true });
-	});
-
-	it('discardStagedApplication removes the staging tree and leaves the live path untouched', async () => {
-		const name = `stage_test_${process.pid}_${counter++}`;
-		const dirPath = path.join(COMPONENTS_ROOT, name);
-		await fs.mkdir(dirPath, { recursive: true });
-		await fs.writeFile(path.join(dirPath, 'index.js'), 'module.exports = "LIVE";\n');
-
-		const app = new Application({ name, payload: await makeComponentPayload('v3') });
-		await stageApplication(app);
-		assert.ok(existsSync(app.stagingDirPath), 'staged before discard');
-
-		await discardStagedApplication(app);
-
-		assert.strictEqual(existsSync(app.stagingDirPath), false, 'staging tree removed');
-		assert.match(await readMarker(dirPath), /LIVE/, 'live version untouched by discard');
-
-		await fs.rm(dirPath, { recursive: true, force: true });
-	});
-
-	it('a failed stage leaves the live path untouched and cleans up its partial staging tree', async () => {
-		const name = `stage_test_${process.pid}_${counter++}`;
-		const dirPath = path.join(COMPONENTS_ROOT, name);
-		await fs.mkdir(dirPath, { recursive: true });
-		await fs.writeFile(path.join(dirPath, 'index.js'), 'module.exports = "LIVE";\n');
-
-		// No payload and no package identifier → extractApplication throws before anything is built.
-		const app = new Application({ name });
-		await assert.rejects(() => stageApplication(app), /payload or package/i);
-
-		assert.strictEqual(existsSync(app.stagingDirPath), false, 'partial staging tree removed on failure');
-		assert.match(await readMarker(dirPath), /LIVE/, 'live version untouched by a failed stage');
-		assert.strictEqual(app.buildDirPath, app.dirPath, 'build target reset to live after a failed stage');
-
-		await fs.rm(dirPath, { recursive: true, force: true });
-	});
-
-	it('two independent components stage into non-colliding staging dirs', async () => {
-		const a = freshApp(await makeComponentPayload('A'));
-		const b = freshApp(await makeComponentPayload('B'));
-		await Promise.all([stageApplication(a), stageApplication(b)]);
-
-		assert.notStrictEqual(a.stagingDirPath, b.stagingDirPath);
-		assert.match(await readMarker(a.stagingDirPath), /A/);
-		assert.match(await readMarker(b.stagingDirPath), /B/);
-
-		await Promise.all([discardStagedApplication(a), discardStagedApplication(b)]);
-	});
-
-	it('stages a `file:` tarball package identifier (the package path, no payload)', async () => {
-		// Regression for the staging parent dir: extractApplication's `file:`-tarball branch (and the
-		// npm-pack branch) resolve paths relative to dirname(stagingDirPath), which must exist before
-		// extraction. A payload-only test never exercises that branch.
-		const name = `stage_test_${process.pid}_${counter++}`;
-		const tgzDir = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-stage-tgz-'));
-		const tgzPath = path.join(tgzDir, 'component.tgz');
-		await fs.writeFile(tgzPath, await makeComponentPayload('from-tarball'));
-
-		const app = new Application({ name, packageIdentifier: `file:${tgzPath}` });
-		await stageApplication(app);
-		assert.match(await readMarker(app.stagingDirPath), /from-tarball/, 'tarball extracted into staging');
-		assert.strictEqual(existsSync(app.dirPath), false, 'live dir untouched by staging a tarball');
-
-		await discardStagedApplication(app);
-		await fs.rm(tgzDir, { recursive: true, force: true });
-	});
-
-	it('activate cleanup does NOT sweep a sibling staged build of the same component', async () => {
-		// Two deploys of the same component staged concurrently share the .deploy-staging/<name> parent.
-		// Activating one must not recursively delete that parent and destroy the other's staged build.
-		const name = `stage_test_${process.pid}_${counter++}`;
-		const first = new Application({ name, payload: await makeComponentPayload('first') });
-		const second = new Application({ name, payload: await makeComponentPayload('second') });
-		await stageApplication(first);
-		await stageApplication(second);
-		assert.notStrictEqual(first.stagingDirPath, second.stagingDirPath);
-
-		await activateApplication(first);
-
-		assert.match(await readMarker(first.dirPath), /first/, 'first went live');
-		assert.ok(existsSync(second.stagingDirPath), 'the sibling staged build survived the activate cleanup');
-
-		await fs.rm(first.dirPath, { recursive: true, force: true });
-		await discardStagedApplication(second);
-		await fs.rm(path.join(COMPONENTS_ROOT, DEPLOY_STAGING_DIR), { recursive: true, force: true });
-		await fs.rm(path.join(COMPONENTS_ROOT, ASIDE_STAGING_DIR), { recursive: true, force: true });
-	});
-
-	it('activate moves a DANGLING symlink at the live path aside instead of failing EEXIST', async () => {
-		// A prior `file:`-directory deploy leaves the live path as a symlink; if its target is later
-		// removed the link dangles. moveDirAside must detect it via lstat (access(F_OK) follows the link
-		// and reports ENOENT) so the swap replaces it cleanly.
-		const name = `stage_test_${process.pid}_${counter++}`;
-		const dirPath = path.join(COMPONENTS_ROOT, name);
-		await fs.symlink(path.join(os.tmpdir(), `does-not-exist-${process.pid}-${counter}`), dirPath);
-		assert.strictEqual(existsSync(dirPath), false, 'precondition: the symlink is dangling');
-
-		const app = new Application({ name, payload: await makeComponentPayload('replaced') });
-		await stageApplication(app);
-		await activateApplication(app);
-
-		const stat = await fs.lstat(dirPath);
-		assert.strictEqual(stat.isSymbolicLink(), false, 'live path is now a real directory, not the dead link');
-		assert.match(await readMarker(dirPath), /replaced/);
-
-		await fs.rm(dirPath, { recursive: true, force: true });
-		await fs.rm(path.join(COMPONENTS_ROOT, ASIDE_STAGING_DIR), { recursive: true, force: true });
-	});
-
-	// Deploy a version (stage + activate) through the primitives, returning the app.
-	async function deployVersion(name, marker) {
-		const app = new Application({ name, payload: await makeComponentPayload(marker) });
-		await stageApplication(app);
-		await activateApplication(app);
-		return app;
-	}
-
-	it('activate retains the outgoing version as .deploy-previous/<name>', async () => {
-		const name = `stage_test_${process.pid}_${counter++}`;
-		await deployVersion(name, 'v1');
-		await deployVersion(name, 'v2');
-
-		const liveDir = path.join(COMPONENTS_ROOT, name);
-		const previousDir = path.join(COMPONENTS_ROOT, DEPLOY_PREVIOUS_DIR, name);
-		assert.match(await readMarker(liveDir), /v2/, 'live is the newest version');
-		assert.match(await readMarker(previousDir), /v1/, 'the outgoing version is retained as previous');
-
-		await fs.rm(liveDir, { recursive: true, force: true });
-		await fs.rm(path.join(COMPONENTS_ROOT, DEPLOY_PREVIOUS_DIR), { recursive: true, force: true });
-		await fs.rm(path.join(COMPONENTS_ROOT, ASIDE_STAGING_DIR), { recursive: true, force: true });
-	});
-
-	it('revertApplication swaps live <-> previous, and a second revert rolls forward again', async () => {
-		const name = `stage_test_${process.pid}_${counter++}`;
-		await deployVersion(name, 'v1');
-		const app = await deployVersion(name, 'v2');
-		const liveDir = path.join(COMPONENTS_ROOT, name);
-		const previousDir = path.join(COMPONENTS_ROOT, DEPLOY_PREVIOUS_DIR, name);
-
-		await revertApplication(app);
-		assert.match(await readMarker(liveDir), /v1/, 'reverted live back to v1');
-		assert.match(await readMarker(previousDir), /v2/, 'the reverted-away v2 is now the previous');
-
-		await revertApplication(app);
-		assert.match(await readMarker(liveDir), /v2/, 'reverting the revert rolls forward to v2');
-		assert.match(await readMarker(previousDir), /v1/, 'v1 is the previous again');
-
-		await fs.rm(liveDir, { recursive: true, force: true });
-		await fs.rm(path.join(COMPONENTS_ROOT, DEPLOY_PREVIOUS_DIR), { recursive: true, force: true });
-		await fs.rm(path.join(COMPONENTS_ROOT, ASIDE_STAGING_DIR), { recursive: true, force: true });
-	});
-
-	it('revertApplication throws when there is no retained previous (deployed only once)', async () => {
-		const name = `stage_test_${process.pid}_${counter++}`;
-		const app = await deployVersion(name, 'only'); // first-ever deploy: nothing retained as previous
-
-		await assert.rejects(() => revertApplication(app), /no previous version is retained/i);
-
+	async function cleanup(name) {
 		await fs.rm(path.join(COMPONENTS_ROOT, name), { recursive: true, force: true });
+		await fs.rm(path.join(COMPONENTS_ROOT, DEPLOY_STAGING_DIR), { recursive: true, force: true });
+		await fs.rm(path.join(COMPONENTS_ROOT, DEPLOY_ACTIVATION_DIR), { recursive: true, force: true });
 		await fs.rm(path.join(COMPONENTS_ROOT, ASIDE_STAGING_DIR), { recursive: true, force: true });
+	}
+
+	it('builds a staged tree without touching the live component', async () => {
+		const name = fixtureName();
+		const deploymentId = randomUUID();
+		const application = new Application({ name, payload: await makeComponentPayload('candidate') });
+
+		const stagedPath = await stageApplication(application, deploymentId);
+
+		assert.equal(stagedPath, stagedApplicationPath(application.dirPath, deploymentId));
+		assert.match(await readMarker(stagedPath), /candidate/);
+		assert.equal(existsSync(application.dirPath), false);
+		await cleanup(name);
 	});
 
-	it('evicts the oldest not-yet-activated staged builds beyond the retention count (default 5)', async () => {
-		// Simulate repeated `activate: false` stage-and-stops of the same component (distinct stagingIds,
-		// never activated). Each stage should prune older ones down to the retention count.
-		const name = `stage_test_${process.pid}_${counter++}`;
+	it('atomically activates a staged tree and consumes only that deployment', async () => {
+		const name = fixtureName();
+		const deploymentId = randomUUID();
+		const siblingId = randomUUID();
+		const application = new Application({ name, payload: await makeComponentPayload('candidate') });
+		await stageApplication(application, deploymentId);
+		application.payload = await makeComponentPayload('sibling');
+		await stageApplication(application, siblingId);
+
+		await activateStagedApplication(application, deploymentId);
+
+		assert.match(await readMarker(application.dirPath), /candidate/);
+		assert.equal(existsSync(stagedApplicationPath(application.dirPath, deploymentId)), false);
+		assert.equal(existsSync(stagedApplicationPath(application.dirPath, siblingId)), true);
+		await cleanup(name);
+	});
+
+	it('rejects a candidate whose staging build did not complete', async () => {
+		const name = fixtureName();
+		const deploymentId = randomUUID();
+		const application = new Application({ name, payload: await makeComponentPayload('incomplete') });
+		const stagedPath = await stageApplication(application, deploymentId);
+		await fs.rm(path.join(path.dirname(stagedPath), '.complete'));
+
+		await assert.rejects(activateStagedApplication(application, deploymentId), /staged build is incomplete/);
+
+		assert.equal(existsSync(application.dirPath), false);
+		assert.match(await readMarker(stagedPath), /incomplete/);
+		await cleanup(name);
+	});
+
+	it('resumes a new-component activation after its durable marker was already created', async () => {
+		const name = fixtureName();
+		const deploymentId = randomUUID();
+		const application = new Application({ name, payload: await makeComponentPayload('resumed') });
+		await stageApplication(application, deploymentId);
+		const activationPath = path.join(COMPONENTS_ROOT, DEPLOY_ACTIVATION_DIR, name);
+		await fs.mkdir(activationPath, { recursive: true });
+		await fs.writeFile(path.join(activationPath, `.new-${deploymentId}`), '', { mode: 0o600 });
+
+		await activateStagedApplication(application, deploymentId);
+
+		assert.match(await readMarker(application.dirPath), /resumed/);
+		assert.equal(existsSync(activationPath), false);
+		await cleanup(name);
+	});
+
+	it('does not report activation failure when only committed-stage cleanup is denied', async function () {
+		if (process.platform === 'win32' || process.getuid?.() === 0) this.skip();
+		const name = fixtureName();
+		const deploymentId = randomUUID();
+		const application = new Application({ name, payload: await makeComponentPayload('cleanup-deferred') });
+		await stageApplication(application, deploymentId);
 		const stagingRoot = path.join(COMPONENTS_ROOT, DEPLOY_STAGING_DIR);
-		const stagingIds = [];
-		for (let i = 0; i < 7; i++) {
-			const app = new Application({ name, payload: await makeComponentPayload(`v${i}`) });
-			stagingIds.push(app.stagingId);
-			await stageApplication(app);
+		await fs.chmod(stagingRoot, 0o500);
+		try {
+			await activateStagedApplication(application, deploymentId);
+		} finally {
+			await fs.chmod(stagingRoot, 0o700);
 		}
 
-		const remaining = stagingIds.filter((id) => existsSync(path.join(stagingRoot, id, name)));
-		// Contract: at most `maxCount` staged builds are retained per component, and the just-staged one is
-		// always kept. (Which older builds are evicted is ordered by mtime — reliable in real use where
-		// stages are time-separated, but this tight loop can create ties, so it isn't asserted here.)
-		assert.strictEqual(remaining.length, 5, `expected 5 staged builds retained, got ${remaining.length}`);
-		assert.ok(existsSync(path.join(stagingRoot, stagingIds[6], name)), 'the most recent stage is always retained');
-
-		await fs.rm(stagingRoot, { recursive: true, force: true });
+		assert.match(await readMarker(application.dirPath), /cleanup-deferred/);
+		assert.equal(existsSync(path.join(stagingRoot, deploymentId)), true, 'cleanup remains retryable garbage');
+		await cleanup(name);
 	});
 
-	it('only one previous is retained across three deploys (older previous evicted)', async () => {
-		const name = `stage_test_${process.pid}_${counter++}`;
-		await deployVersion(name, 'v1');
-		await deployVersion(name, 'v2');
-		await deployVersion(name, 'v3');
+	it('restores live and preserves the staged tree when persistent activation work fails', async () => {
+		const name = fixtureName();
+		const livePath = path.join(COMPONENTS_ROOT, name);
+		const deploymentId = randomUUID();
+		await fs.mkdir(livePath, { recursive: true });
+		await fs.writeFile(path.join(livePath, 'index.js'), 'module.exports = "live";\n');
+		const application = new Application({ name, payload: await makeComponentPayload('candidate', '2.0.0') });
+		await stageApplication(application, deploymentId);
 
-		const previousDir = path.join(COMPONENTS_ROOT, DEPLOY_PREVIOUS_DIR, name);
-		assert.match(await readMarker(path.join(COMPONENTS_ROOT, name)), /v3/, 'live is v3');
-		assert.match(await readMarker(previousDir), /v2/, 'previous is v2; v1 was evicted');
+		await assert.rejects(
+			activateStagedApplication(application, deploymentId, {
+				beforeCommit: async () => {
+					throw new Error('config write failed');
+				},
+			}),
+			/config write failed/
+		);
 
-		await fs.rm(path.join(COMPONENTS_ROOT, name), { recursive: true, force: true });
-		await fs.rm(path.join(COMPONENTS_ROOT, DEPLOY_PREVIOUS_DIR), { recursive: true, force: true });
-		await fs.rm(path.join(COMPONENTS_ROOT, ASIDE_STAGING_DIR), { recursive: true, force: true });
+		assert.match(await readMarker(livePath), /live/);
+		assert.match(await readMarker(stagedApplicationPath(livePath, deploymentId)), /candidate/);
+		await cleanup(name);
+	});
+
+	it('serializes duplicate activation without ever losing the live directory', async () => {
+		const name = fixtureName();
+		const deploymentId = randomUUID();
+		const application = new Application({ name, payload: await makeComponentPayload('candidate') });
+		await stageApplication(application, deploymentId);
+
+		const outcomes = await Promise.allSettled([
+			activateStagedApplication(application, deploymentId),
+			activateStagedApplication(application, deploymentId),
+		]);
+
+		assert.equal(outcomes.filter((outcome) => outcome.status === 'fulfilled').length, 1);
+		assert.equal(outcomes.filter((outcome) => outcome.status === 'rejected').length, 1);
+		assert.match(await readMarker(application.dirPath), /candidate/);
+		await cleanup(name);
+	});
+
+	it('snapshots config at commit time so a queued rollback preserves the preceding winner', async () => {
+		const name = fixtureName();
+		const configRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-activation-config-'));
+		const priorRootEnv = process.env.ROOTPATH;
+		const priorRootConfig = getConfigPath(CONFIG_PARAMS.ROOTPATH);
+		process.env.ROOTPATH = configRoot;
+		environment.setProperty(CONFIG_PARAMS.ROOTPATH, configRoot);
+		await fs.writeFile(path.join(configRoot, 'harper-config.yaml'), `rootPath: ${JSON.stringify(configRoot)}\n`);
+		const spec = (version, urlPath) => ({
+			project: name,
+			package: `example@${version}`,
+			install_command: null,
+			install_timeout: null,
+			install_allow_scripts: null,
+			urlPath,
+			host: null,
+			credentials: null,
+		});
+		const first = await createApplicationActivationTransaction(name, spec('1.0.0', '/first'));
+		const second = await createApplicationActivationTransaction(name, spec('2.0.0', '/second'));
+		try {
+			await first.commit();
+			await second.commit();
+			await second.rollback();
+
+			assert.deepEqual(readConfigFile()[name], { package: 'example@1.0.0', urlPath: '/first' });
+			const lock = JSON.parse(
+				await fs.readFile(path.join(configRoot, 'harper-application-lock.json'), { encoding: 'utf8' })
+			);
+			assert.deepEqual(lock.applications[name], { package: 'example@1.0.0', urlPath: '/first' });
+		} finally {
+			await second.rollback();
+			await first.rollback();
+			if (priorRootEnv === undefined) delete process.env.ROOTPATH;
+			else process.env.ROOTPATH = priorRootEnv;
+			environment.setProperty(CONFIG_PARAMS.ROOTPATH, priorRootConfig);
+			await fs.rm(configRoot, { recursive: true, force: true });
+		}
+	});
+
+	it('discard removes only the selected staged tree and leaves live unchanged', async () => {
+		const name = fixtureName();
+		const livePath = path.join(COMPONENTS_ROOT, name);
+		const deploymentId = randomUUID();
+		await fs.mkdir(livePath, { recursive: true });
+		await fs.writeFile(path.join(livePath, 'index.js'), 'module.exports = "live";\n');
+		const application = new Application({ name, payload: await makeComponentPayload('candidate') });
+		await stageApplication(application, deploymentId);
+
+		await discardStagedApplication(livePath, deploymentId);
+
+		assert.equal(existsSync(stagedApplicationPath(livePath, deploymentId)), false);
+		assert.match(await readMarker(livePath), /live/);
+		await cleanup(name);
+	});
+
+	it('drop cleanup removes only the selected component activation artifacts', async () => {
+		const name = fixtureName();
+		const sibling = fixtureName();
+		const activationRoot = path.join(COMPONENTS_ROOT, DEPLOY_ACTIVATION_DIR);
+		await fs.mkdir(path.join(activationRoot, name, 'old'), { recursive: true });
+		await fs.mkdir(path.join(activationRoot, sibling, 'keep'), { recursive: true });
+
+		await discardProjectActivationArtifacts(path.join(COMPONENTS_ROOT, name));
+
+		assert.equal(existsSync(path.join(activationRoot, name)), false);
+		assert.equal(existsSync(path.join(activationRoot, sibling, 'keep')), true);
+		await cleanup(name);
+	});
+
+	it('startup reconciliation removes terminal stages and preserves valid staged rows', async () => {
+		const name = fixtureName();
+		const keptId = randomUUID();
+		const removedId = randomUUID();
+		const application = new Application({ name, payload: await makeComponentPayload('kept') });
+		await stageApplication(application, keptId);
+		application.payload = await makeComponentPayload('removed');
+		await stageApplication(application, removedId);
+		const rows = new Map([
+			[keptId, { deployment_id: keptId, project: name, status: 'staged' }],
+			[removedId, { deployment_id: removedId, project: name, status: 'failed' }],
+		]);
+
+		const result = await reconcileStagedApplicationArtifacts(
+			COMPONENTS_ROOT,
+			async (id) => rows.get(id),
+			async () => {}
+		);
+
+		assert.equal(existsSync(stagedApplicationPath(application.dirPath, keptId)), true);
+		assert.equal(existsSync(stagedApplicationPath(application.dirPath, removedId)), false);
+		assert.deepEqual(result.removed, [removedId]);
+		await cleanup(name);
+	});
+
+	it('startup reconciliation rolls an activating staged tree forward', async () => {
+		const name = fixtureName();
+		const deploymentId = randomUUID();
+		const livePath = path.join(COMPONENTS_ROOT, name);
+		await fs.mkdir(livePath, { recursive: true });
+		await fs.writeFile(path.join(livePath, 'index.js'), 'module.exports = "old";\n');
+		const application = new Application({ name, payload: await makeComponentPayload('candidate') });
+		await stageApplication(application, deploymentId);
+		const activationPath = path.join(COMPONENTS_ROOT, DEPLOY_ACTIVATION_DIR, name);
+		await fs.mkdir(activationPath, { recursive: true });
+		await fs.rename(livePath, path.join(activationPath, `.previous-${deploymentId}-crash`));
+		const row = {
+			deployment_id: deploymentId,
+			project: name,
+			status: 'activating',
+			activation_spec: { project: name },
+		};
+		const persisted = [];
+
+		const result = await reconcileStagedApplicationArtifacts(
+			COMPONENTS_ROOT,
+			async (id) => (id === deploymentId ? row : undefined),
+			async (value) => persisted.push(value.deployment_id)
+		);
+
+		assert.match(await readMarker(livePath), /candidate/);
+		assert.deepEqual(persisted, [deploymentId]);
+		assert.deepEqual(result.recovered, [deploymentId]);
+		assert.equal(existsSync(activationPath), false);
+		await cleanup(name);
+	});
+
+	it('startup reconciliation finishes an activation whose candidate is already live', async () => {
+		const name = fixtureName();
+		const deploymentId = randomUUID();
+		const livePath = path.join(COMPONENTS_ROOT, name);
+		const activationPath = path.join(COMPONENTS_ROOT, DEPLOY_ACTIVATION_DIR, name);
+		await fs.mkdir(livePath, { recursive: true });
+		await fs.writeFile(path.join(livePath, 'index.js'), 'module.exports = "candidate";\n');
+		await fs.mkdir(path.join(activationPath, `.previous-${deploymentId}-crash`), { recursive: true });
+		const row = {
+			deployment_id: deploymentId,
+			project: name,
+			status: 'activating',
+			activation_spec: { project: name },
+		};
+		let persisted = 0;
+
+		const result = await reconcileStagedApplicationArtifacts(
+			COMPONENTS_ROOT,
+			async (id) => (id === deploymentId ? row : undefined),
+			async () => persisted++
+		);
+
+		assert.equal(persisted, 1);
+		assert.deepEqual(result.recovered, [deploymentId]);
+		assert.match(await readMarker(livePath), /candidate/);
+		assert.equal(existsSync(activationPath), false);
+		await cleanup(name);
+	});
+
+	it('rejects a non-UUID before it can become a filesystem path segment', () => {
+		assert.throws(() => stagedApplicationPath(path.join(COMPONENTS_ROOT, fixtureName()), '../../escape'), /Invalid/);
+	});
+
+	it('rejects a symlinked staging root without touching its target', async () => {
+		const name = fixtureName();
+		const deploymentId = randomUUID();
+		const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-stage-outside-'));
+		await fs.writeFile(path.join(outside, 'sentinel'), 'keep');
+		await fs.rm(path.join(COMPONENTS_ROOT, DEPLOY_STAGING_DIR), { recursive: true, force: true });
+		await fs.symlink(outside, path.join(COMPONENTS_ROOT, DEPLOY_STAGING_DIR), 'dir');
+		const application = new Application({ name, payload: await makeComponentPayload('candidate') });
+
+		await assert.rejects(stageApplication(application, deploymentId), /staging path is not a directory/);
+		assert.equal(await fs.readFile(path.join(outside, 'sentinel'), 'utf8'), 'keep');
+
+		await cleanup(name);
+		await fs.rm(outside, { recursive: true, force: true });
+	});
+
+	it('activates a completed local-directory package symlink with secure staging containers', async () => {
+		const name = fixtureName();
+		const deploymentId = randomUUID();
+		const packageDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'harper-stage-package-'));
+		await fs.writeFile(path.join(packageDirectory, 'marker.txt'), 'directory-package');
+		const application = new Application({ name, packageIdentifier: packageDirectory });
+
+		const stagedPath = await stageApplication(application, deploymentId);
+		assert.equal((await fs.lstat(stagedPath)).isSymbolicLink(), true);
+		await activateStagedApplication(application, deploymentId);
+
+		assert.equal((await fs.lstat(application.dirPath)).isSymbolicLink(), true);
+		assert.equal(await fs.readFile(path.join(application.dirPath, 'marker.txt'), 'utf8'), 'directory-package');
+
+		await cleanup(name);
+		await fs.rm(packageDirectory, { recursive: true, force: true });
 	});
 });

--- a/unitTests/components/deploymentOperations.test.js
+++ b/unitTests/components/deploymentOperations.test.js
@@ -14,7 +14,13 @@ const { Readable } = require('node:stream');
 const testUtils = require('../testUtils.js');
 testUtils.preTestPrep();
 
-const { handleGetDeploymentPayload, handleDeleteDeploymentPayload } = require('#src/components/deploymentOperations');
+const {
+	handleGetDeployment,
+	handleGetDeploymentPayload,
+	handleDeleteDeploymentPayload,
+} = require('#src/components/deploymentOperations');
+const { DeploymentRecorder } = require('#src/components/deploymentRecorder');
+const { ProgressEmitter } = require('#src/server/serverHelpers/progressEmitter');
 const { databases } = require('#src/resources/databases');
 const terms = require('#src/utility/hdbTerms');
 
@@ -63,6 +69,33 @@ async function collect(stream) {
 	for await (const chunk of stream) chunks.push(chunk);
 	return Buffer.concat(chunks);
 }
+
+describe('handleGetDeployment SSE tail', () => {
+	let installed;
+	beforeEach(() => {
+		installed = installMockDeploymentTable();
+	});
+	afterEach(() => installed.restore());
+
+	it('keeps tailing a transient staged checkpoint while the origin recorder is active', async () => {
+		const lifecycle = new ProgressEmitter();
+		const recorder = await DeploymentRecorder.create({ project: 'app', emitter: lifecycle });
+		await recorder.checkpoint('staged', 'staged');
+		let settled = false;
+		const resultPromise = handleGetDeployment({
+			deployment_id: recorder.deploymentId,
+			progress: new ProgressEmitter(),
+		}).then((result) => {
+			settled = true;
+			return result;
+		});
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.strictEqual(settled, false, 'staged is only terminal after its live recorder is gone');
+
+		await recorder.finish('success');
+		assert.strictEqual((await resultPromise).status, 'success');
+	});
+});
 
 describe('handleGetDeploymentPayload', () => {
 	let installed;
@@ -138,13 +171,15 @@ describe('handleDeleteDeploymentPayload', () => {
 		});
 	});
 
-	it('409s on a non-terminal deployment (blob may still be replicating to peers)', async () => {
-		installed.mock.rows.set('d1', { deployment_id: 'd1', status: 'pending', payload_blob: mockBlob(Buffer.from('x')) });
-		await assert.rejects(handleDeleteDeploymentPayload({ deployment_id: 'd1' }), (err) => {
-			assert.match(err.message, /not in a terminal state/);
-			assert.strictEqual(err.statusCode, 409);
-			return true;
-		});
+	it('409s on pending and staged deployments whose blobs may still be needed by peers', async () => {
+		for (const status of ['pending', 'staged']) {
+			installed.mock.rows.set('d1', { deployment_id: 'd1', status, payload_blob: mockBlob(Buffer.from('x')) });
+			await assert.rejects(handleDeleteDeploymentPayload({ deployment_id: 'd1' }), (err) => {
+				assert.match(err.message, /not in a terminal state/);
+				assert.strictEqual(err.statusCode, 409);
+				return true;
+			});
+		}
 		assert.strictEqual(installed.mock.puts.length, 0, 'must not write the row');
 	});
 

--- a/unitTests/components/deploymentRecorder.test.js
+++ b/unitTests/components/deploymentRecorder.test.js
@@ -19,6 +19,10 @@ const {
 	awaitDeploymentRow,
 	readPayloadBlobWithRetry,
 	markDeploymentTerminal,
+	recordDeploymentPeers,
+	claimStagedDeployment,
+	expireOldStagedDeployments,
+	invalidateProjectStagedDeployments,
 	pruneProjectPayloads,
 	getDeploymentRow,
 } = require('#src/components/deploymentRecorder');
@@ -386,6 +390,12 @@ describe('awaitDeploymentRow', () => {
 		assert.ok(result.payload_blob);
 	});
 
+	it('can wait for package deployment metadata without requiring a payload blob', async () => {
+		const row = { deployment_id: 'package-row', package_identifier: 'npm:example', payload_blob: null };
+		installed.mock.rows.set(row.deployment_id, row);
+		assert.strictEqual(await awaitDeploymentRow(row.deployment_id, { timeoutMs: 0, requirePayload: false }), row);
+	});
+
 	it('rejects with a "did not replicate" timeout when the row never arrives within timeoutMs', async () => {
 		await assert.rejects(
 			() => awaitDeploymentRow('never-arrives', { timeoutMs: 100, pollIntervalMs: 25 }),
@@ -681,6 +691,21 @@ describe('markDeploymentTerminal', () => {
 		assert.strictEqual(typeof row.completed_at, 'number', 'completed_at was stamped');
 	});
 
+	it('preserves an uncertain partial activation as non-terminal with its error', async () => {
+		installed.mock.rows.set('dep-activating', {
+			deployment_id: 'dep-activating',
+			status: 'staged',
+			completed_at: 100,
+		});
+
+		await markDeploymentTerminal('dep-activating', 'activating', new Error('peer did not acknowledge'));
+
+		const row = installed.mock.rows.get('dep-activating');
+		assert.strictEqual(row.status, 'activating');
+		assert.strictEqual(row.completed_at, null);
+		assert.strictEqual(row.error.message, 'peer did not acknowledge');
+	});
+
 	it('is a no-op when the row is absent (best-effort, never throws)', async () => {
 		await markDeploymentTerminal('missing', 'success');
 		assert.strictEqual(installed.mock.rows.has('missing'), false, 'no row is fabricated for an unknown id');
@@ -736,6 +761,115 @@ describe('getDeploymentRow', () => {
 			if (databases.system && prior !== undefined) databases.system[DEPLOYMENT_TABLE] = prior;
 			installed = installMockDeploymentTable();
 		}
+	});
+});
+
+describe('staged deployment state', () => {
+	let installed;
+	beforeEach(() => {
+		installed = installMockDeploymentTable({ freezeGet: true });
+	});
+	afterEach(() => installed.restore());
+
+	it('claims only the matching staged row and durably marks it activating', async () => {
+		installed.mock.rows.set('staged-1', {
+			deployment_id: 'staged-1',
+			project: 'app',
+			status: 'staged',
+			completed_at: 100,
+		});
+
+		await assert.rejects(claimStagedDeployment('staged-1', 'other'), /belongs to component 'app'/);
+		await claimStagedDeployment('staged-1', 'app');
+
+		const row = installed.mock.rows.get('staged-1');
+		assert.strictEqual(row.status, 'activating');
+		assert.strictEqual(row.phase, 'activate');
+		assert.strictEqual(row.completed_at, null);
+	});
+
+	it('accepts an already-activating row only for replicated activation ordering', async () => {
+		installed.mock.rows.set('activating-1', {
+			deployment_id: 'activating-1',
+			project: 'app',
+			status: 'activating',
+		});
+
+		await assert.rejects(claimStagedDeployment('activating-1', 'app'), /not staged/);
+		const row = await claimStagedDeployment('activating-1', 'app', { allowActivating: true });
+
+		assert.strictEqual(row.status, 'activating');
+	});
+
+	it('waits for a replicated deployment row to reach staged before claiming it', async () => {
+		installed.mock.rows.set('lagging-1', {
+			deployment_id: 'lagging-1',
+			project: 'app',
+			status: 'staging',
+		});
+		setImmediate(() => {
+			installed.mock.rows.set('lagging-1', {
+				...installed.mock.rows.get('lagging-1'),
+				status: 'staged',
+			});
+		});
+
+		await claimStagedDeployment('lagging-1', 'app', { waitForStagedMs: 200 });
+
+		assert.strictEqual(installed.mock.rows.get('lagging-1').status, 'activating');
+	});
+
+	it('expires only staged rows beyond the per-project count', async () => {
+		for (const [id, startedAt, status = 'staged'] of [
+			['old', 100],
+			['middle', 200],
+			['new', 300],
+			['active', 50, 'activating'],
+		]) {
+			installed.mock.rows.set(id, {
+				deployment_id: id,
+				project: 'app',
+				status,
+				started_at: startedAt,
+			});
+		}
+
+		assert.deepStrictEqual(await expireOldStagedDeployments('app', 2), ['old']);
+		assert.strictEqual(installed.mock.rows.get('old').status, 'failed');
+		assert.strictEqual(installed.mock.rows.get('middle').status, 'staged');
+		assert.strictEqual(installed.mock.rows.get('new').status, 'staged');
+		assert.strictEqual(installed.mock.rows.get('active').status, 'activating');
+	});
+
+	it('invalidates staged and activating rows when their component is dropped', async () => {
+		for (const status of ['staged', 'activating', 'success']) {
+			installed.mock.rows.set(status, { deployment_id: status, project: 'app', status });
+		}
+
+		const invalidated = await invalidateProjectStagedDeployments('app');
+
+		assert.deepStrictEqual(invalidated.sort(), ['activating', 'staged']);
+		assert.strictEqual(installed.mock.rows.get('staged').status, 'failed');
+		assert.strictEqual(installed.mock.rows.get('activating').status, 'failed');
+		assert.strictEqual(installed.mock.rows.get('success').status, 'success');
+	});
+
+	it('persists normalized peer outcomes on an existing staged row', async () => {
+		installed.mock.rows.set('dep', {
+			deployment_id: 'dep',
+			status: 'activating',
+			peer_results: [{ node: 'peer-a', status: 'success' }],
+		});
+
+		await recordDeploymentPeers('dep', [
+			{ node: 'peer-a', status: 'failed', reason: 'offline' },
+			{ node: 'peer-b', status: 'success' },
+		]);
+
+		const peers = installed.mock.rows.get('dep').peer_results;
+		assert.strictEqual(peers.length, 2);
+		assert.strictEqual(peers.find((peer) => peer.node === 'peer-a').error.message, 'offline');
+		assert.strictEqual(peers.find((peer) => peer.node === 'peer-b').status, 'success');
 	});
 });
 
@@ -804,15 +938,17 @@ describe('pruneProjectPayloads (deployment_payloadRetention_maxCount)', () => {
 		);
 	});
 
-	it('never drops a non-terminal deployment (its blob may still be the replication channel)', async () => {
+	it('never drops staged or activating deployments whose blobs may still be the replication channel', async () => {
 		seed('newest', { startedAt: 300 });
 		seed('in-flight', { startedAt: 200, status: 'activating' });
+		seed('staged', { startedAt: 150, status: 'staged' });
 		seed('old', { startedAt: 100 });
 
 		await pruneProjectPayloads('app', 1);
 
 		assert.strictEqual(hasPayload('newest'), true, 'newest retained');
 		assert.strictEqual(hasPayload('in-flight'), true, 'the in-flight deployment keeps its payload');
+		assert.strictEqual(hasPayload('staged'), true, 'the staged deployment keeps its payload for later activation');
 		assert.strictEqual(hasPayload('old'), false, 'the settled older one is still dropped');
 	});
 

--- a/unitTests/server/fastifyRoutes/operations.test.js
+++ b/unitTests/server/fastifyRoutes/operations.test.js
@@ -150,6 +150,7 @@ describe('Test custom functions operations', () => {
 			await fs.ensureFile(path.join(CF_DIR_ROOT, 'my-cool-component', '.hidden'));
 			await fs.ensureFile(path.join(CF_DIR_ROOT, 'my-cool-component', 'utils', 'utils.js'));
 			await fs.outputFile(path.join(CF_DIR_ROOT, 'my-other-component', 'config.yaml'), test_yaml_string);
+			await fs.ensureFile(path.join(CF_DIR_ROOT, '.deploy-activating', 'my-cool-component', '.new-deployment'));
 			sandbox.stub(configUtils, 'getConfiguration').returns({
 				'my-other-component': {
 					package: '@my-org/my-other-component',
@@ -181,6 +182,7 @@ describe('Test custom functions operations', () => {
 			expect(otherComponent.urlPath).to.equal('/other');
 			expect(otherComponent.host).to.equal('other.example.com');
 			expect(otherComponent.loadComponent).to.equal('if-installed');
+			expect(result.entries.find((e) => e.name === '.deploy-activating')).to.be.undefined;
 		});
 
 		it('Test getComponents includes status information when component status exists', async () => {
@@ -522,9 +524,11 @@ describe('Test custom functions operations', () => {
 
 			// Mock the two-phase build/swap primitives to prevent actual install + filesystem work.
 			const stageApplicationStub = sandbox.stub().resolves('/tmp/staging');
-			const activateApplicationStub = sandbox.stub().resolves();
+			const activateApplicationStub = sandbox
+				.stub()
+				.callsFake(async (_application, _deploymentId, hooks) => hooks?.beforeCommit?.());
 			operations.__set__('stageApplication', stageApplicationStub);
-			operations.__set__('activateApplication', activateApplicationStub);
+			operations.__set__('activateStagedApplication', activateApplicationStub);
 
 			// This should work - user components can be overwritten without force
 			await operations.deployComponent({
@@ -551,9 +555,11 @@ describe('Test custom functions operations', () => {
 
 			// Mock the two-phase build/swap primitives to prevent actual install + filesystem work.
 			const stageApplicationStub = sandbox.stub().resolves('/tmp/staging');
-			const activateApplicationStub = sandbox.stub().resolves();
+			const activateApplicationStub = sandbox
+				.stub()
+				.callsFake(async (_application, _deploymentId, hooks) => hooks?.beforeCommit?.());
 			operations.__set__('stageApplication', stageApplicationStub);
-			operations.__set__('activateApplication', activateApplicationStub);
+			operations.__set__('activateStagedApplication', activateApplicationStub);
 
 			// This should work fine - no component exists yet
 			await operations.deployComponent({
@@ -600,9 +606,11 @@ describe('Test custom functions operations', () => {
 
 			// Mock the two-phase build/swap primitives to prevent actual install + filesystem work.
 			const stageApplicationStub = sandbox.stub().resolves('/tmp/staging');
-			const activateApplicationStub = sandbox.stub().resolves();
+			const activateApplicationStub = sandbox
+				.stub()
+				.callsFake(async (_application, _deploymentId, hooks) => hooks?.beforeCommit?.());
 			operations.__set__('stageApplication', stageApplicationStub);
-			operations.__set__('activateApplication', activateApplicationStub);
+			operations.__set__('activateStagedApplication', activateApplicationStub);
 
 			// This should NOT throw an error because force is true
 			await operations.deployComponent({

--- a/unitTests/server/serverHelpers/serverUtilities.test.js
+++ b/unitTests/server/serverHelpers/serverUtilities.test.js
@@ -570,9 +570,11 @@ describe('Test serverUtilities.js module ', () => {
 	describe('registerOperation permission seam', function () {
 		const { server } = require('#src/server/Server');
 		const op_auth = require('#src/utility/operation_authorization');
+		const { isOperationAuthorizationBypassed } = require('#src/server/serverHelpers/operationAuthorizationState');
 		const { validateOperations } = require('#src/utility/operationPermissions');
 		const SU_OP = 'test_registered_su_op';
 		const OPEN_OP = 'test_registered_open_op';
+		const AUTH_STATE_OP = 'test_internal_authorization_state';
 
 		// A non-super_user request JSON for a given op, optionally carrying an `operations` grant.
 		const nonSuRequest = (op, operations) => ({
@@ -596,7 +598,15 @@ describe('Test serverUtilities.js module ', () => {
 			// Keep the process-global registries clean — these test-only ops shouldn't leak into other
 			// suites. registerOperation touches three globals (the op-function map plus verifyPerms'
 			// requiredPermissions and the grantable-ops set), so undo all three, not just the map.
-			for (const op of [SU_OP, OPEN_OP, 'test_name_pinning_op', 'shared_op_a', 'shared_op_b', 'dyn_grantable_op']) {
+			for (const op of [
+				SU_OP,
+				OPEN_OP,
+				AUTH_STATE_OP,
+				'test_name_pinning_op',
+				'shared_op_a',
+				'shared_op_b',
+				'dyn_grantable_op',
+			]) {
 				serverUtilities.OPERATION_FUNCTION_MAP.delete(op);
 				op_auth.unregisterOperationPermission(op);
 			}
@@ -659,6 +669,19 @@ describe('Test serverUtilities.js module ', () => {
 
 		it('allows a non-super_user whose role grants the op via the operations allowlist (SU-bypass)', function () {
 			assert.equal(op_auth.verifyPerms(nonSuRequest(SU_OP, [SU_OP]), SU_OP), null);
+		});
+
+		it('exposes trusted authorization bypass through server.operation without leaking it afterward', async function () {
+			server.registerOperation({
+				name: AUTH_STATE_OP,
+				execute: async () => ({ bypassed: isOperationAuthorizationBypassed() }),
+				requiresSuperUser: true,
+			});
+
+			const result = await server.operation({ operation: AUTH_STATE_OP }, { user: { name: 'cluster-peer' } }, false);
+
+			assert.deepEqual(result, { bypassed: true });
+			assert.equal(isOperationAuthorizationBypassed(), false);
 		});
 	});
 

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -318,17 +318,10 @@ export const OPERATIONS_ENUM = {
 	PACKAGE_CUSTOM_FUNCTION_PROJECT: 'package_custom_function_project',
 	DEPLOY_CUSTOM_FUNCTION_PROJECT: 'deploy_custom_function_project',
 	PACKAGE_COMPONENT: 'package_component',
-	// deploy_component runs a two-phase deploy internally (stage the incoming version into a hidden
-	// dir cluster-wide, gate on every node, then atomically swap it live). The two phases are fanned
-	// out to peers as deploy_component tagged with an internal `_phase` marker rather than separate
-	// public operations. Public knobs: `activate: false` (stage-and-stop, returns a staged
-	// deployment_id) and `deployment_id` (activate a previously-staged deployment). See
-	// components/Application.ts (stageApplication/activateApplication).
+	// deploy_component runs a two-phase deploy internally. Peer phases use a distinct operation so
+	// older nodes fail closed instead of interpreting an unknown phase field as a one-shot deploy.
 	DEPLOY_COMPONENT: 'deploy_component',
-	// Swap a component's live version back to its retained previous version, cluster-wide. Backs
-	// customer-driven rollback (deploy → test → revert) and swap-back on a partially-failed activate.
-	// See components/Application.ts (revertApplication).
-	REVERT_COMPONENT: 'revert_component',
+	COMPONENT_DEPLOY_PHASE: 'component_deploy_phase',
 	READ_TRANSACTION_LOG: 'read_transaction_log',
 	DELETE_TRANSACTION_LOGS_BEFORE: 'delete_transaction_logs_before',
 	INSTALL_NODE_MODULES: 'install_node_modules',

--- a/utility/operation_authorization.ts
+++ b/utility/operation_authorization.ts
@@ -286,7 +286,7 @@ requiredPermissions.set(functionsOperations.addComponent.name, new (permission a
 requiredPermissions.set(functionsOperations.dropCustomFunctionProject.name, new (permission as any)(true, []));
 requiredPermissions.set(functionsOperations.packageComponent.name, new (permission as any)(true, []));
 requiredPermissions.set(functionsOperations.deployComponent.name, new (permission as any)(true, []));
-requiredPermissions.set(functionsOperations.revertComponent.name, new (permission as any)(true, []));
+requiredPermissions.set(functionsOperations.componentDeployPhase.name, new (permission as any)(true, []));
 requiredPermissions.set(
 	deploymentOperations.handleListDeployments.name,
 	new (permission as any)(true, [], terms.OPERATIONS_ENUM.LIST_DEPLOYMENTS)


### PR DESCRIPTION
## Relationship to #1849

This is a follow-up to #1849 and targets that PR's head branch. It does not replace #1849: the original PR remains the canonical review and discussion thread, including all existing feedback.

The branch is one focused commit directly atop #1849. It ports the relevant interruption-recovery guarantees onto #1849's implementation without merging unrelated `main` or #2066 history.

## What changed

- Makes component deployment a durable stage/activate transaction with completion markers, immutable activation specifications, and atomic live/config/lock-file activation.
- Authenticates internal phase operations as replicated peer work and prevents caller-supplied phase markers or `replicated: false` requests from entering peer fanout.
- Recovers interrupted activation on startup, rebuilds missing peer stages from retained payloads, and preserves uncertain partial activation as `activating` for explicit roll-forward.
- Retains payloads and staging artifacts while peers can still need them, with bounded cleanup for terminal, expired, or dropped deployments.
- Preserves successful-deploy payload reclamation, local-directory package symlinks, and hides internal activation artifacts from `get_components`.
- Adds `stage` and `activate` CLI flows with capability probing and fail-closed behavior for unsupported staged-deploy controls.
- Covers crash windows, replication ordering, token custody, cleanup failures, config serialization, restart failures, CLI compatibility, and the trusted peer-dispatch seam.

## Deliberate behavior

- Mixed-version staged deployment fails closed instead of silently changing to one-shot semantics.
- After any node crosses the activation barrier, failures are not automatically rolled back; the deployment remains visibly `activating` and is recovered or rolled forward.
- The revert behavior described in docs PR #599 should be revised to match this roll-forward policy.

## Verification

- `npm run build`
- `npm run lint:required`
- `npm run format:write`
- 259 focused deploy, recorder, staging, validation, CLI, legacy-route, and server-dispatch tests
- `git diff --check` and HEG added-code hazard checks

`test:unit:main` was attempted locally but the checkout's existing `/Users/nathan/harper/database/system.mdb` state failed during suite initialization, before tests ran. CI is the authoritative broad-suite result.

## Cross-model review

Authored by Codex. Two earlier Claude Opus high-effort passes reviewed the implementation, and their concrete findings were addressed: completion markers, peer row ordering, payload retention, post-activation failure semantics, configuration snapshot timing, stale lock cleanup, token custody, startup reconciliation, recorder sealing, CLI project defaults, and structural prevention of one-shot peer fanout.

Three requested final/targeted Opus retries against the materially complete patch ended with the Claude CLI's `Execution error` and produced no usable report. No same-family Codex review was substituted; final-artifact cross-model coverage is therefore explicitly degraded pending CI/human review.
