### PR TITLE
feat(components): stream package_component instead of base64 JSON

### DIFF
--- a/components/operations.js
+++ b/components/operations.js
@@ -373,14 +373,17 @@ async function packageComponent(req) {
 		try {
 			pathToProject = await fs.realpath(path.join(env.get(hdbTerms.CONFIG_PARAMS.ROOTPATH), 'node_modules', project));
 		} catch (err) {
+			// Only a genuinely absent project earns the friendly message. Everything else —
+			// ENOTDIR from a broken installation, EACCES from a permissions problem — is rethrown
+			// with its code, path, and cause intact, rather than being flattened into a
+			// misleading "missing project". Rethrowing is also what guarantees pathToProject is
+			// set past this point, which the stream shape depends on: its response headers are
+			// committed before the packer walks, so a failure discovered later would reach the
+			// caller as a 200 with a truncated body instead of an error it can act on.
 			if (err.code === hdbTerms.NODE_ERROR_CODES.ENOENT) throw new Error(`Unable to locate project '${project}'`);
+			throw err;
 		}
 	}
-	// The inner catch above swallows any non-ENOENT realpath failure, leaving pathToProject
-	// undefined. That has to be a thrown error rather than a walk of `undefined`: on the stream
-	// path the response headers are already committed by the time the packer runs, so the caller
-	// would receive a 200 with a truncated body instead of a failure it can act on.
-	if (!pathToProject) throw new Error(`Unable to locate project '${project}'`);
 
 	if (req.estimate) {
 		const { totalSize, danglingSymlinks } = await scanPackageDirectory(pathToProject, req);

--- a/components/operations.js
+++ b/components/operations.js
@@ -22,7 +22,11 @@ const {
 const { handleHDBError, ServerError, hdbErrors } = require('../utility/errors/hdbError.ts');
 const { HDB_ERROR_MSGS, HTTP_STATUS_CODES } = hdbErrors;
 const manageThreads = require('../server/threads/manageThreads.js');
-const { packageDirectory } = require('../components/packageComponent.ts');
+const {
+	packageDirectory,
+	scanPackageDirectory,
+	streamPackagedDirectory,
+} = require('../components/packageComponent.ts');
 const { Resources } = require('../resources/Resources.ts');
 const { Application, prepareApplication, ASIDE_STAGING_DIR } = require('./Application.ts');
 const { COMPONENT_PREPARATION_LOCK_DIR } = require('./componentPreparationLock.ts');
@@ -321,10 +325,31 @@ async function dropCustomFunctionProject(req) {
 }
 
 /**
- * Will package a component into a temp tar file then output that file as a base64 string.
- * Req can accept a skip_node_modules boolean which will skip the node mods when creating temp tar file.
+ * Package a component's directory into a tar+gzip archive.
+ *
+ * Three response shapes, selected by the request:
+ *
+ * - `stream: true` — the archive as raw bytes, with download headers attached. serverHandlers.js
+ *   pipes any returned Readable that carries a `headers` Map. **Prefer this for anything that
+ *   isn't known to be small**; see the note below.
+ * - `estimate: true` — no archive at all, just `{ total_size, dangling_symlinks }` from a single
+ *   directory walk, so a caller can decide whether packaging is worth it before paying for it.
+ * - neither (default) — the historical `{ project, payload }` shape, base64 inside JSON.
+ *
+ * The default is retained for compatibility but does not scale, and callers should migrate off
+ * it. Buffering the archive and base64-ing it costs ~4.7x the archive size resident in this
+ * (shared, multi-tenant) process — 2x to concat the gzip chunks, +1.33x for the base64 string,
+ * +1.33x again when Fastify serializes the envelope — and it hard-fails above ~384 MiB of
+ * compressed output, because base64 of that exceeds V8's 512 MiB string cap
+ * (`buffer.constants.MAX_STRING_LENGTH`) and `.toString('base64')` throws ERR_STRING_TOO_LONG.
+ * The streamed shape is constant-memory on both ends and has no size ceiling.
+ *
+ * `skip_node_modules` / `skip_symlinks` apply to all three shapes. `estimate` is checked before
+ * `stream`, so it wins if a caller sets both.
+ *
  * @param req
- * @returns {Promise<{payload: *, project}>}
+ * @returns {Promise<{payload: string, project: string}|{project: string, total_size: number,
+ *   dangling_symlinks: string[]}|Readable>}
  */
 async function packageComponent(req) {
 	if (req.project) {
@@ -350,6 +375,29 @@ async function packageComponent(req) {
 		} catch (err) {
 			if (err.code === hdbTerms.NODE_ERROR_CODES.ENOENT) throw new Error(`Unable to locate project '${project}'`);
 		}
+	}
+	// The inner catch above swallows any non-ENOENT realpath failure, leaving pathToProject
+	// undefined. That has to be a thrown error rather than a walk of `undefined`: on the stream
+	// path the response headers are already committed by the time the packer runs, so the caller
+	// would receive a 200 with a truncated body instead of a failure it can act on.
+	if (!pathToProject) throw new Error(`Unable to locate project '${project}'`);
+
+	if (req.estimate) {
+		const { totalSize, danglingSymlinks } = await scanPackageDirectory(pathToProject, req);
+		return { project, total_size: totalSize, dangling_symlinks: danglingSymlinks };
+	}
+
+	if (req.stream) {
+		const stream = streamPackagedDirectory(pathToProject, req);
+		const headers = new Map();
+		headers.set('content-type', 'application/gzip');
+		// `project` is narrowed to a bare filename by path.parse().name above and validated
+		// against PROJECT_FILE_NAME_REGEX, so it cannot inject header content.
+		headers.set('content-disposition', `attachment; filename="${project}.tar.gz"`);
+		stream.headers = headers;
+		// tar-fs output is already gzipped; tell serverHandlers not to compress it a second time.
+		stream.preCompressed = true;
+		return stream;
 	}
 
 	const payload = (await packageDirectory(pathToProject, req)).toString('base64');

--- a/components/operationsValidation.js
+++ b/components/operationsValidation.js
@@ -371,6 +371,12 @@ function packageComponentValidator(req) {
 			.messages({ 'string.pattern.base': HDB_ERROR_MSGS.BAD_PROJECT_NAME }),
 		skip_node_modules: Joi.boolean(),
 		skip_symlinks: Joi.boolean(),
+		// Response shape selectors — see packageComponent() in operations.js. Deliberately not
+		// declared as Joi exclusive peers: `oxor` conflicts on *presence*, so it would reject a
+		// caller that always sends both fields and sets one to false. `estimate` wins when both
+		// are true, which the handler enforces by checking it first.
+		stream: Joi.boolean(),
+		estimate: Joi.boolean(),
 	});
 
 	return validator.validateBySchema(req, packageProjSchema);

--- a/unitTests/components/packageComponentOperation.test.js
+++ b/unitTests/components/packageComponentOperation.test.js
@@ -1,0 +1,172 @@
+'use strict';
+
+// Covers the three response shapes of the `package_component` operation handler against a real
+// temporary components root: the streamed archive (`stream: true`), the size probe
+// (`estimate: true`), and the historical base64 envelope (neither). The transport half — Fastify
+// piping a returned Readable that carries a `headers` Map — is already covered by
+// unitTests/server/serverHelpers/serverHandlers.test.js, so this file stops at the handler's
+// return value.
+
+const assert = require('node:assert');
+const fs = require('fs-extra');
+const path = require('node:path');
+const os = require('node:os');
+const { Readable } = require('node:stream');
+const { pipeline } = require('node:stream/promises');
+
+const testUtils = require('../testUtils.js');
+testUtils.preTestPrep();
+
+const env = require('#src/utility/environment/environmentManager');
+const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
+const operations = require('#js/components/operations');
+const gunzip = require('gunzip-maybe');
+const tar = require('tar-fs');
+
+const PROJECT = 'pkg-op-app';
+const FILES = {
+	'package.json': '{"name":"pkg-op-app","version":"1.0.0"}\n',
+	'index.js': 'module.exports = () => 42;\n',
+	'docs/README.md': '# pkg-op-app\n',
+	'node_modules/dep/index.js': 'module.exports = "dep";\n',
+};
+
+async function extractToTree(stream) {
+	const outDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pkg-op-out-'));
+	await pipeline(stream, gunzip(), tar.extract(outDir));
+	const out = {};
+	const walk = async (rel) => {
+		for (const entry of await fs.readdir(path.join(outDir, rel), { withFileTypes: true })) {
+			const childRel = rel ? path.join(rel, entry.name) : entry.name;
+			if (entry.isDirectory()) await walk(childRel);
+			else out[childRel] = await fs.readFile(path.join(outDir, childRel), 'utf8');
+		}
+	};
+	await walk('');
+	await fs.remove(outDir);
+	return out;
+}
+
+describe('package_component (handler)', () => {
+	let ROOT;
+
+	before(() => {
+		env.initTestEnvironment();
+		ROOT = path.join(os.tmpdir(), `harper-pkg-op-${process.pid}`);
+		env.setProperty(CONFIG_PARAMS.COMPONENTSROOT, ROOT);
+		for (const [rel, content] of Object.entries(FILES)) {
+			fs.outputFileSync(path.join(ROOT, PROJECT, rel), content);
+		}
+	});
+
+	after(() => {
+		fs.removeSync(ROOT);
+	});
+
+	describe('default (base64) shape', () => {
+		it('still returns { project, payload } when neither selector is set', async () => {
+			const result = await operations.packageComponent({ project: PROJECT, skip_node_modules: true });
+			assert.equal(result.project, PROJECT);
+			assert.equal(typeof result.payload, 'string');
+			assert.ok(result.payload.length > 0, 'payload must not be empty');
+			// A gzip member starts with 1f 8b, which base64-encodes to a leading "H4sI".
+			assert.ok(result.payload.startsWith('H4sI'), `expected a gzip payload, got ${result.payload.slice(0, 8)}`);
+		});
+	});
+
+	describe('stream: true', () => {
+		it('returns a Readable carrying download headers, marked preCompressed', async () => {
+			const stream = await operations.packageComponent({ project: PROJECT, stream: true, skip_node_modules: true });
+			assert.ok(stream instanceof Readable, 'must return a Readable, not an envelope');
+			assert.equal(stream.headers.get('content-type'), 'application/gzip');
+			assert.equal(stream.headers.get('content-disposition'), `attachment; filename="${PROJECT}.tar.gz"`);
+			// Without this serverHandlers would gzip the already-gzipped tar a second time.
+			assert.strictEqual(stream.preCompressed, true);
+			stream.destroy();
+		});
+
+		it('streams bytes that extract back to the source tree', async () => {
+			const stream = await operations.packageComponent({ project: PROJECT, stream: true, skip_node_modules: true });
+			const extracted = await extractToTree(stream);
+			assert.deepEqual(extracted, {
+				'package.json': FILES['package.json'],
+				'index.js': FILES['index.js'],
+				[path.join('docs', 'README.md')]: FILES['docs/README.md'],
+			});
+		});
+
+		it('honors skip_node_modules: false by including the node_modules tree', async () => {
+			const stream = await operations.packageComponent({ project: PROJECT, stream: true, skip_node_modules: false });
+			const extracted = await extractToTree(stream);
+			assert.equal(extracted[path.join('node_modules', 'dep', 'index.js')], FILES['node_modules/dep/index.js']);
+		});
+
+		it('never materializes the archive as a string — no payload field to blow the V8 cap', async () => {
+			const stream = await operations.packageComponent({ project: PROJECT, stream: true });
+			assert.strictEqual(stream.payload, undefined);
+			stream.destroy();
+		});
+	});
+
+	describe('estimate: true', () => {
+		it('returns the packable size and no payload', async () => {
+			const result = await operations.packageComponent({ project: PROJECT, estimate: true, skip_node_modules: true });
+			const expected = Object.entries(FILES)
+				.filter(([rel]) => !rel.startsWith('node_modules/'))
+				.reduce((sum, [, content]) => sum + Buffer.byteLength(content), 0);
+			assert.equal(result.project, PROJECT);
+			assert.equal(result.total_size, expected);
+			assert.deepEqual(result.dangling_symlinks, []);
+			assert.strictEqual(result.payload, undefined, 'estimate must not package anything');
+		});
+
+		it('counts the node_modules tree when skip_node_modules is not set', async () => {
+			const withMods = await operations.packageComponent({ project: PROJECT, estimate: true });
+			const withoutMods = await operations.packageComponent({
+				project: PROJECT,
+				estimate: true,
+				skip_node_modules: true,
+			});
+			assert.equal(withMods.total_size - withoutMods.total_size, Buffer.byteLength(FILES['node_modules/dep/index.js']));
+		});
+
+		it('wins over stream when a caller sets both', async () => {
+			const result = await operations.packageComponent({ project: PROJECT, estimate: true, stream: true });
+			assert.ok(!(result instanceof Readable));
+			assert.equal(typeof result.total_size, 'number');
+		});
+	});
+
+	describe('validation and resolution', () => {
+		it('rejects a non-boolean selector', async () => {
+			await assert.rejects(() => operations.packageComponent({ project: PROJECT, stream: 'yes-please' }), /stream/);
+		});
+
+		it('reports a project that exists in neither location rather than streaming an empty archive', async () => {
+			await assert.rejects(
+				() => operations.packageComponent({ project: 'no-such-project', stream: true }),
+				/Unable to locate project/
+			);
+		});
+
+		// The node_modules fallback's catch only rethrows ENOENT, so any other realpath failure
+		// (here ENOTDIR, from a rootPath whose node_modules is a file) leaves pathToProject
+		// undefined and used to reach the packer. On the stream path that surfaces as a 200 with
+		// a truncated body, because the response headers are committed before the walk runs.
+		it('throws instead of packaging undefined when the fallback fails for a non-ENOENT reason', async () => {
+			const rootPath = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-op-root-'));
+			fs.writeFileSync(path.join(rootPath, 'node_modules'), 'not a directory');
+			const priorRootPath = env.get(CONFIG_PARAMS.ROOTPATH);
+			env.setProperty(CONFIG_PARAMS.ROOTPATH, rootPath);
+			try {
+				await assert.rejects(
+					() => operations.packageComponent({ project: 'no-such-project', stream: true }),
+					/Unable to locate project/
+				);
+			} finally {
+				env.setProperty(CONFIG_PARAMS.ROOTPATH, priorRootPath);
+				fs.removeSync(rootPath);
+			}
+		});
+	});
+});

--- a/unitTests/components/packageComponentOperation.test.js
+++ b/unitTests/components/packageComponentOperation.test.js
@@ -149,11 +149,13 @@ describe('package_component (handler)', () => {
 			);
 		});
 
-		// The node_modules fallback's catch only rethrows ENOENT, so any other realpath failure
-		// (here ENOTDIR, from a rootPath whose node_modules is a file) leaves pathToProject
-		// undefined and used to reach the packer. On the stream path that surfaces as a 200 with
-		// a truncated body, because the response headers are committed before the walk runs.
-		it('throws instead of packaging undefined when the fallback fails for a non-ENOENT reason', async () => {
+		// A broken installation is not a missing project. The node_modules fallback rethrows
+		// anything that isn't ENOENT (here ENOTDIR, from a rootPath whose node_modules is a
+		// file) so the operator sees the real cause; flattening it into "Unable to locate
+		// project" would send them looking for the wrong problem. Rethrowing is also what
+		// leaves pathToProject guaranteed past that block, which the stream shape needs —
+		// its headers are committed before the packer walks.
+		it('rethrows a non-ENOENT fallback failure with its original code', async () => {
 			const rootPath = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-op-root-'));
 			fs.writeFileSync(path.join(rootPath, 'node_modules'), 'not a directory');
 			const priorRootPath = env.get(CONFIG_PARAMS.ROOTPATH);
@@ -161,7 +163,14 @@ describe('package_component (handler)', () => {
 			try {
 				await assert.rejects(
 					() => operations.packageComponent({ project: 'no-such-project', stream: true }),
-					/Unable to locate project/
+					(err) => {
+						assert.strictEqual(err.code, 'ENOTDIR', 'the original error code must survive');
+						assert.ok(
+							!/Unable to locate project/.test(err.message),
+							`a broken installation must not read as a missing project: ${err.message}`
+						);
+						return true;
+					}
 				);
 			} finally {
 				env.setProperty(CONFIG_PARAMS.ROOTPATH, priorRootPath);


### PR DESCRIPTION
Closes #2150.

`package_component` returned the whole component tarball as base64 inside the JSON envelope. This adds a streamed shape, which is what the operation should have been doing all along — the machinery was already in the repo, the handler just wasn't using it.

## The problem

`components/operations.js:354`:

```js
const payload = (await packageDirectory(pathToProject, req)).toString('base64');
return { project, payload };
```

For an archive of N bytes that peaks at roughly **4.7N resident** in the shared (on Fabric, multi-tenant) Harper process: 2N to accumulate and `Buffer.concat` the gzip chunks, +1.33N for the base64 string, +1.33N again when Fastify serializes the envelope.

And it has a hard ceiling, not just pressure — `.toString('base64')` throws `ERR_STRING_TOO_LONG` once the result exceeds V8's string cap:

```
$ node -e "const b=require('buffer'); console.log(b.constants.MAX_STRING_LENGTH)"
536870888        # 512 MiB → ~384 MiB of gzipped tar is the ceiling
```

The browser pays the same tax again, which is the downstream symptom in HarperFast/studio#1591: bytes transfer fine, then Chrome kills the renderer while decoding.

## The change

**`stream: true`** returns the packer's `Readable` with download headers attached. Nothing new had to be built:

- `streamPackagedDirectory()` (`components/packageComponent.ts:115`) already returns a tar-fs → gzip `Readable`, and its docstring says it exists to avoid "the Node.js 2GB Buffer cap that the buffered variant runs into for large components". The handler simply called the buffered variant instead.
- `serverHandlers.js:172` already pipes any returned `Readable` carrying a `headers` Map, and honours `preCompressed` so an already-gzipped body isn't compressed twice.
- `handleGetDeploymentPayload()` and `get_backup` are the existing precedents on that path.

Memory is constant on both ends, nothing is staged to disk, and there is no size ceiling.

**`estimate: true`** returns `{ project, total_size, dangling_symlinks }` from a single `scanPackageDirectory()` walk without packaging anything, so a caller can decide whether the download is worth starting. Studio wants this for the include-node_modules case, where its own `get_components` tree gives it no size to work from.

**The base64 shape stays the default**, so every existing caller is untouched. The remote operation's only real consumer is Studio — the CLI's `package` alias packages locally for deploy (`bin/cliOperations.ts:14`) and never reads a remote `payload`.

## Notes for review

- `estimate` is checked before `stream` and wins if both are set. They are deliberately **not** declared as Joi exclusive peers: `oxor` conflicts on *presence*, so it would reject a caller that always sends both fields with one set to `false`.
- `content-disposition` interpolates `project`, which is already narrowed by `path.parse().name` and validated against `PROJECT_FILE_NAME_REGEX` before it gets there, so it can't inject header content.
- The project-resolution guard is a drive-by fix with a real reason to be in this PR: the node_modules fallback's `catch` only rethrows ENOENT, so any other realpath failure left `pathToProject` undefined and walked it anyway. That was survivable when the response was buffered; on the stream path headers are committed before the walk runs, so it would surface as a 200 with a truncated body. Its test drives a real ENOTDIR (a rootPath whose `node_modules` is a file) and fails without the guard.
- A mid-walk failure after headers are committed still truncates the response — inherent to streaming, and the same behaviour `get_backup`/`get_deployment_payload` already have.
- **Fabric Connect can't carry this.** Central Manager's proxy is message-passing, not an HTTP reverse proxy, and caps bodies at 2 MB ("Fabric Connect body size must be less than 2MB. Utilize Direct Connect for larger payloads."). A streamed download needs a direct Bearer connection; that's a Studio-side concern, noted on studio#1591.

## Testing

New `unitTests/components/packageComponentOperation.test.js` — 11 tests against a real temporary components root, covering all three response shapes, `skip_node_modules` on the stream path, a full stream → gunzip → tar-extract round trip back to the source tree, the estimate totals with and without node_modules, and both resolution failures. The transport half is already covered by `unitTests/server/serverHelpers/serverHandlers.test.js`, so this stops at the handler's return value.

Ran green locally alongside every other suite that imports the changed modules — `packageComponent`, `envOperations`, `deploymentOperations`, `serverHandlers`, `fastifyRoutes/operations` — 94 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
