### PR TITLE
Fix malformed bodyless audit entries that permanently wedge replication

### DIFF
--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -389,6 +389,7 @@ export function makeTable(options) {
 	if (!attributes) attributes = [];
 	if (!properties) properties = projectAttributesToProperties(attributes);
 	const updateRecord = recordUpdater(primaryStore, tableId, auditStore);
+	let warnedNullSourcePut = false; // latched: one warn per table per worker (see _writeUpdate)
 	let sourceLoad: any; // if a source has a load function (replicator), record it here
 	let hasSourceGet: any;
 	let primaryKeyAttribute: Attribute | undefined;
@@ -2236,6 +2237,20 @@ export function makeTable(options) {
 			const context = this.getContext();
 			const transaction = txnForContext(context);
 			checkValidId(id);
+			if (fullUpdate && recordUpdate == null && (context as any)?.source) {
+				// A put delivered by a source/replication apply must carry the record content (only source
+				// applies skip record validation, so this is the one path a nullish full update can reach).
+				// Applying it stores nothing and mints an audit-only entry misrepresenting the write (#2153);
+				// skip it instead — a later real write supersedes, and a redelivery of this version re-skips.
+				if (!warnedNullSourcePut) {
+					warnedNullSourcePut = true;
+					logger.warn?.(
+						`Skipping a source-applied put with no record content for ${tableName} id ${id} from node ${options?.nodeId}`,
+						new Error('valueless source put')
+					);
+				}
+				return;
+			}
 			const entry = this.#entry ?? primaryStore.getEntry(id, { transaction: transaction.getReadTxn() });
 			const writeToSource = () => {
 				if (!(this.constructor as any).source || (context as any)?.source) return;

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -2237,9 +2237,10 @@ export function makeTable(options) {
 			const context = this.getContext();
 			const transaction = txnForContext(context);
 			checkValidId(id);
-			if (fullUpdate && recordUpdate == null && (context as any)?.source) {
-				// A put delivered by a source/replication apply must carry the record content (only source
-				// applies skip record validation, so this is the one path a nullish full update can reach).
+			if (fullUpdate && recordUpdate == null && options?.isNotification) {
+				// A put delivered by a source/replication apply must carry the record content (source applies
+				// skip record validation, so this is the path a nullish full update can reach; isNotification
+				// scopes the guard to the apply dispatcher, not instance flows that fill from #changes).
 				// Applying it stores nothing and mints an audit-only entry misrepresenting the write (#2153);
 				// skip it instead — a later real write supersedes, and a redelivery of this version re-skips.
 				if (!warnedNullSourcePut) {

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -2238,11 +2238,12 @@ export function makeTable(options) {
 			const transaction = txnForContext(context);
 			checkValidId(id);
 			if (fullUpdate && recordUpdate == null && options?.isNotification) {
-				// A put delivered by a source/replication apply must carry the record content (source applies
-				// skip record validation, so this is the path a nullish full update can reach; isNotification
-				// scopes the guard to the apply dispatcher, not instance flows that fill from #changes).
-				// Applying it stores nothing and mints an audit-only entry misrepresenting the write (#2153);
-				// skip it instead — a later real write supersedes, and a redelivery of this version re-skips.
+				// A source/replication-applied put must carry the record; these applies skip record
+				// validation, so this is the one path a nullish full update reaches (isNotification scopes
+				// this to the apply dispatcher, not instance flows that fill from #changes). Applying it
+				// stores nothing and mints an audit-only entry misrepresenting the write (#2153) — skip it;
+				// a redelivery re-skips and a later real write supersedes.
+				logger.trace?.('Skipped valueless source put', tableName, id, options?.nodeId);
 				if (!warnedNullSourcePut) {
 					warnedNullSourcePut = true;
 					logger.warn?.(

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -416,9 +416,19 @@ export function createAuditEntry(auditRecord: AuditRecord, start = 0) {
 		originatingOperation,
 		previousAdditionalAuditRefs,
 	} = auditRecord;
-	const action = EVENT_TYPES[type];
+	let action = EVENT_TYPES[type];
 	if (!action) {
 		throw new Error(`Invalid audit entry type ${type}`);
+	}
+	if (action & (HAS_RECORD | HAS_PARTIAL_RECORD) && !encodedRecord?.length) {
+		// An audit-only commit (e.g. a fully-superseded out-of-order write) can reach here with no
+		// encoded record. The flags must not advertise a body the entry doesn't carry: readers decode
+		// the (empty) remainder whenever HAS_RECORD is set, which throws "Unexpected end of MessagePack
+		// data" and — replicated to a peer — permanently wedges that leg on this entry (#2153).
+		harperLogger.warn(
+			`Audit entry (${type}) for record ${recordId} in table ${tableId} has no record body; clearing its record flags`
+		);
+		action &= ~(HAS_RECORD | HAS_PARTIAL_RECORD);
 	}
 	let position = start + 1;
 	if (previousVersion) {
@@ -621,16 +631,25 @@ export function readAuditEntry(buffer: Uint8Array, start = 0, end = undefined): 
 			},
 			getValue(store, fullRecord?, auditTime?) {
 				if (action & HAS_RECORD || (action & HAS_PARTIAL_RECORD && !fullRecord)) {
-					if (!value) {
-						value = decodeFromDatabase(
-							// the audit value has no on-disk timestamp/metadata prefix (the audit entry carries
-							// its own time), so skip the prefix heuristic — otherwise a classic record whose
-							// structure-id byte is 66 (0x42) is misread as a rocksdb timestamp. See RecordEncoder.decode.
-							() => store.decoder.decode(buffer.subarray(decoder.position, end), { noMetadata: true }),
-							store.rootStore
+					if (decoder.position >= (end ?? buffer.byteLength)) {
+						// Malformed entry minted before the record flags were reconciled with the (absent) body
+						// (#2153): the header accounts for the whole entry, so there is nothing to decode. Fall
+						// through — a partial entry may still be reconstructable below; otherwise no value.
+						harperLogger.warn(
+							`Audit entry (${EVENT_TYPES[action & 0xf]}) for table ${tableId} advertises a record but has no body; treating as having no record`
 						);
+					} else {
+						if (!value) {
+							value = decodeFromDatabase(
+								// the audit value has no on-disk timestamp/metadata prefix (the audit entry carries
+								// its own time), so skip the prefix heuristic — otherwise a classic record whose
+								// structure-id byte is 66 (0x42) is misread as a rocksdb timestamp. See RecordEncoder.decode.
+								() => store.decoder.decode(buffer.subarray(decoder.position, end), { noMetadata: true }),
+								store.rootStore
+							);
+						}
+						return value;
 					}
-					return value;
 				}
 				if (action & HAS_PARTIAL_RECORD && auditTime) {
 					const recordId = this.recordId;

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -430,7 +430,11 @@ export function createAuditEntry(auditRecord: AuditRecord, start = 0) {
 		// record-history reconstruction, and the read path tolerates the empty body.
 		if (!warnedBodylessMintTables.has(tableId)) {
 			warnedBodylessMintTables.add(tableId);
-			harperLogger.warn(`Audit entry (${type}) for record ${recordId} in table ${tableId} has no record body`);
+			// the stack identifies which write path delivered the undefined value (see #2153 follow-up)
+			harperLogger.warn(
+				`Audit entry (${type}) for record ${recordId} in table ${tableId} has no record body`,
+				new Error('bodyless audit mint')
+			);
 		}
 		action &= ~HAS_RECORD;
 	}

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -111,9 +111,9 @@ const MAX_DELETES_PER_CLEANUP = 1000;
 // setTimeout silently falls back to 1ms for delays past this, which would turn the backoff into the
 // hot loop it is meant to avoid — a `logging.auditRetention` over ~248 days reaches it via retention/10
 const MAX_CLEANUP_DELAY = 2 ** 31 - 1;
-// separate mint/read latches so a legacy-entry read warn can't mask the more actionable
-// "this node is still minting bodyless entries" signal for the same table
-const warnedBodylessMintTables = new Set<number>();
+// separate mint/read latches so a legacy-entry read warn can't mask the still-minting signal;
+// mint latch keyed per (table, type) so one entry type can't silence another's producer stack
+const warnedBodylessMints = new Set<string>();
 const warnedBodylessTables = new Set<number>();
 const FLOAT_TARGET = new Float64Array(1);
 const FLOAT_BUFFER = new Uint8Array(FLOAT_TARGET.buffer);
@@ -428,9 +428,9 @@ export function createAuditEntry(auditRecord: AuditRecord, start = 0) {
 		// Readers decode the remainder whenever HAS_RECORD is set, so an audit-only commit minted with
 		// no body must not advertise one (#2153). HAS_PARTIAL_RECORD is kept: it also drives
 		// record-history reconstruction, and the read path tolerates the empty body.
-		if (!warnedBodylessMintTables.has(tableId)) {
-			warnedBodylessMintTables.add(tableId);
-			// the stack identifies which write path delivered the undefined value (see #2153 follow-up)
+		if (!warnedBodylessMints.has(`${tableId}:${type}`)) {
+			warnedBodylessMints.add(`${tableId}:${type}`);
+			// the Error's stack identifies which write path delivered the missing value
 			harperLogger.warn(
 				`Audit entry (${type}) for record ${recordId} in table ${tableId} has no record body`,
 				new Error('bodyless audit mint')

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -111,6 +111,7 @@ const MAX_DELETES_PER_CLEANUP = 1000;
 // setTimeout silently falls back to 1ms for delays past this, which would turn the backoff into the
 // hot loop it is meant to avoid — a `logging.auditRetention` over ~248 days reaches it via retention/10
 const MAX_CLEANUP_DELAY = 2 ** 31 - 1;
+const warnedBodylessTables = new Set<number>();
 const FLOAT_TARGET = new Float64Array(1);
 const FLOAT_BUFFER = new Uint8Array(FLOAT_TARGET.buffer);
 let DEFAULT_AUDIT_CLEANUP_DELAY = 10000; // default delay of 10 seconds
@@ -421,14 +422,11 @@ export function createAuditEntry(auditRecord: AuditRecord, start = 0) {
 		throw new Error(`Invalid audit entry type ${type}`);
 	}
 	if (action & (HAS_RECORD | HAS_PARTIAL_RECORD) && !encodedRecord?.length) {
-		// An audit-only commit (e.g. a fully-superseded out-of-order write) can reach here with no
-		// encoded record. The flags must not advertise a body the entry doesn't carry: readers decode
-		// the (empty) remainder whenever HAS_RECORD is set, which throws "Unexpected end of MessagePack
-		// data" and — replicated to a peer — permanently wedges that leg on this entry (#2153).
-		harperLogger.warn(
-			`Audit entry (${type}) for record ${recordId} in table ${tableId} has no record body; clearing its record flags`
-		);
-		action &= ~(HAS_RECORD | HAS_PARTIAL_RECORD);
+		// Readers decode the remainder whenever HAS_RECORD is set, so an audit-only commit minted with
+		// no body must not advertise one (#2153). HAS_PARTIAL_RECORD is kept: it also drives
+		// record-history reconstruction, and the read path tolerates the empty body.
+		harperLogger.warn(`Audit entry (${type}) for record ${recordId} in table ${tableId} has no record body`);
+		action &= ~HAS_RECORD;
 	}
 	let position = start + 1;
 	if (previousVersion) {
@@ -632,12 +630,15 @@ export function readAuditEntry(buffer: Uint8Array, start = 0, end = undefined): 
 			getValue(store, fullRecord?, auditTime?) {
 				if (action & HAS_RECORD || (action & HAS_PARTIAL_RECORD && !fullRecord)) {
 					if (decoder.position >= (end ?? buffer.byteLength)) {
-						// Malformed entry minted before the record flags were reconciled with the (absent) body
-						// (#2153): the header accounts for the whole entry, so there is nothing to decode. Fall
-						// through — a partial entry may still be reconstructable below; otherwise no value.
-						harperLogger.warn(
-							`Audit entry (${EVENT_TYPES[action & 0xf]}) for table ${tableId} advertises a record but has no body; treating as having no record`
-						);
+						// Entry advertises a record but has no body (minted before #2153); nothing to decode.
+						// Latched per table: this getter runs inside range scans, so an unlatched warn would
+						// repeat for every legacy entry on every replication/backfill pass.
+						if (!warnedBodylessTables.has(tableId)) {
+							warnedBodylessTables.add(tableId);
+							harperLogger.warn(
+								`Audit entry (${EVENT_TYPES[action & 0xf]}) for table ${tableId} advertises a record but has no body; treating as having no record`
+							);
+						}
 					} else {
 						if (!value) {
 							value = decodeFromDatabase(

--- a/resources/auditStore.ts
+++ b/resources/auditStore.ts
@@ -111,6 +111,9 @@ const MAX_DELETES_PER_CLEANUP = 1000;
 // setTimeout silently falls back to 1ms for delays past this, which would turn the backoff into the
 // hot loop it is meant to avoid — a `logging.auditRetention` over ~248 days reaches it via retention/10
 const MAX_CLEANUP_DELAY = 2 ** 31 - 1;
+// separate mint/read latches so a legacy-entry read warn can't mask the more actionable
+// "this node is still minting bodyless entries" signal for the same table
+const warnedBodylessMintTables = new Set<number>();
 const warnedBodylessTables = new Set<number>();
 const FLOAT_TARGET = new Float64Array(1);
 const FLOAT_BUFFER = new Uint8Array(FLOAT_TARGET.buffer);
@@ -425,7 +428,10 @@ export function createAuditEntry(auditRecord: AuditRecord, start = 0) {
 		// Readers decode the remainder whenever HAS_RECORD is set, so an audit-only commit minted with
 		// no body must not advertise one (#2153). HAS_PARTIAL_RECORD is kept: it also drives
 		// record-history reconstruction, and the read path tolerates the empty body.
-		harperLogger.warn(`Audit entry (${type}) for record ${recordId} in table ${tableId} has no record body`);
+		if (!warnedBodylessMintTables.has(tableId)) {
+			warnedBodylessMintTables.add(tableId);
+			harperLogger.warn(`Audit entry (${type}) for record ${recordId} in table ${tableId} has no record body`);
+		}
 		action &= ~HAS_RECORD;
 	}
 	let position = start + 1;
@@ -630,27 +636,28 @@ export function readAuditEntry(buffer: Uint8Array, start = 0, end = undefined): 
 			getValue(store, fullRecord?, auditTime?) {
 				if (action & HAS_RECORD || (action & HAS_PARTIAL_RECORD && !fullRecord)) {
 					if (decoder.position >= (end ?? buffer.byteLength)) {
-						// Entry advertises a record but has no body (minted before #2153); nothing to decode.
-						// Latched per table: this getter runs inside range scans, so an unlatched warn would
-						// repeat for every legacy entry on every replication/backfill pass.
+						// Entry advertises a record but has no body (minted before #2153): nothing to decode, and
+						// return undefined rather than falling through — this branch means the caller asked for the
+						// entry's own content (full-record consumers with an auditTime never enter it for partials
+						// and still reconstruct below). Warn latched per table: this getter runs inside range scans.
 						if (!warnedBodylessTables.has(tableId)) {
 							warnedBodylessTables.add(tableId);
 							harperLogger.warn(
 								`Audit entry (${EVENT_TYPES[action & 0xf]}) for table ${tableId} advertises a record but has no body; treating as having no record`
 							);
 						}
-					} else {
-						if (!value) {
-							value = decodeFromDatabase(
-								// the audit value has no on-disk timestamp/metadata prefix (the audit entry carries
-								// its own time), so skip the prefix heuristic — otherwise a classic record whose
-								// structure-id byte is 66 (0x42) is misread as a rocksdb timestamp. See RecordEncoder.decode.
-								() => store.decoder.decode(buffer.subarray(decoder.position, end), { noMetadata: true }),
-								store.rootStore
-							);
-						}
-						return value;
+						return;
 					}
+					if (!value) {
+						value = decodeFromDatabase(
+							// the audit value has no on-disk timestamp/metadata prefix (the audit entry carries
+							// its own time), so skip the prefix heuristic — otherwise a classic record whose
+							// structure-id byte is 66 (0x42) is misread as a rocksdb timestamp. See RecordEncoder.decode.
+							() => store.decoder.decode(buffer.subarray(decoder.position, end), { noMetadata: true }),
+							store.rootStore
+						);
+					}
+					return value;
 				}
 				if (action & HAS_PARTIAL_RECORD && auditTime) {
 					const recordId = this.recordId;

--- a/unitTests/resources/auditEntryRecordFlags.test.js
+++ b/unitTests/resources/auditEntryRecordFlags.test.js
@@ -152,15 +152,24 @@ describe('Audit entry record flags match the body (#2153)', () => {
 			await T.patch(id, { a: 'n1' }, { timestamp: now + 100 });
 			// source/replication applies skip record validation, so an undefined value can reach the
 			// write path — the #2153 producer shape (pre-fix this minted a bodyless put advertising
-			// HAS_RECORD, wedging peers). The guard skips it before any write is staged.
-			const applyVersion = now + 200; // would win — skipping must not depend on losing
-			await T.put(id, undefined, { timestamp: applyVersion, source: {}, nodeId: 7 });
+			// HAS_RECORD, wedging peers). The guard skips it before any write is staged. Drive it the
+			// way the apply dispatcher does: a notification write on a source-context resource.
 			const absentId = 'r2-absent'; // locally-absent record: the production entries' no-previousVersion shape
-			await T.put(absentId, undefined, { timestamp: now + 300, source: {}, nodeId: 7 });
+			const applyValueless = async (targetId) => {
+				const ctx = { source: {} };
+				await transaction(ctx, async () => {
+					const resource = await T.getResource(targetId, ctx);
+					return resource._writeUpdate(targetId, undefined, true, { isNotification: true, nodeId: 7 });
+				});
+			};
+			const entriesBefore = [...T.auditStore.getRange({ start: 1 })].length;
+			await applyValueless(id);
+			await applyValueless(absentId);
 
-			for (const entry of T.auditStore.getRange({ start: 1 })) {
-				assert.notEqual(entry.version, applyVersion, 'valueless apply must not mint an audit entry');
-				assert.notEqual(entry.recordId, absentId, 'valueless apply of an absent record must not mint');
+			const entries = [...T.auditStore.getRange({ start: 1 })];
+			assert.equal(entries.length, entriesBefore, 'valueless applies must not mint audit entries');
+			for (const entry of entries) {
+				assert.notEqual(entry.recordId, absentId);
 			}
 			const record = await T.get(id);
 			assert.equal(record.a, 'n1', 'valueless apply must not disturb the record');

--- a/unitTests/resources/auditEntryRecordFlags.test.js
+++ b/unitTests/resources/auditEntryRecordFlags.test.js
@@ -45,6 +45,19 @@ describe('Audit entry record flags match the body (#2153)', () => {
 		assert.equal(read.getValue({}), undefined);
 	});
 
+	it('a raw-content read of a bodyless partial returns undefined, not a reconstruction', () => {
+		const entry = createAuditEntry({ ...baseRecord, type: 'patch', encodedRecord: undefined });
+		const read = readAuditEntry(Buffer.from(entry));
+		// fullRecord=false asks for the entry's own (absent) content; the guard must return
+		// undefined instead of falling through to the auditTime reconstruction
+		const storeMustNotBeTouched = {
+			get getEntry() {
+				throw new Error('reconstruction must not run for a raw-content read');
+			},
+		};
+		assert.equal(read.getValue(storeMustNotBeTouched, false, baseRecord.version), undefined);
+	});
+
 	it('keeps HAS_RECORD when a body is present', () => {
 		const encodedRecord = Buffer.from([0x81, 0xa1, 0x61, 0x01]); // msgpack {a: 1}
 		const entry = createAuditEntry({ ...baseRecord, encodedRecord });

--- a/unitTests/resources/auditEntryRecordFlags.test.js
+++ b/unitTests/resources/auditEntryRecordFlags.test.js
@@ -1,0 +1,106 @@
+require('../testUtils');
+const assert = require('assert');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { createAuditEntry, readAuditEntry } = require('#src/resources/auditStore');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const { transaction } = require('#src/resources/transaction');
+
+const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
+const HAS_RECORD = 16;
+const HAS_PARTIAL_RECORD = 32;
+
+// harper#2153: an audit-only commit (a fully-superseded out-of-order write) stores no record but
+// passed its operation type through unchanged, so the entry advertised HAS_RECORD with no body.
+// Readers then decode an empty buffer ("Unexpected end of MessagePack data"), and since
+// harper-pro#521 that decode failure permanently wedges the replication leg on this entry.
+describe('Audit entry record flags match the body (#2153)', () => {
+	// the field values from the production entry in the issue
+	const baseRecord = {
+		version: 1786360662786.2988,
+		tableId: 1,
+		recordId: '006a97ef-579c-41e5-b884-bbefcf2ee889',
+		nodeId: 16,
+		type: 'put',
+		extendedType: 0x1100, // HAS_EXPIRATION_EXTENDED_TYPE | HAS_STRUCTURE_UPDATE
+		expiresAt: 1817915930237,
+	};
+
+	it('clears the record flags on a put minted with no encoded record', () => {
+		const entry = createAuditEntry({ ...baseRecord, encodedRecord: undefined });
+		const read = readAuditEntry(Buffer.from(entry));
+		assert.equal(read.type, 'put');
+		assert.equal(read.extendedType & (HAS_RECORD | HAS_PARTIAL_RECORD), 0);
+		assert.equal(read.getBinaryValue().length, 0);
+		// no body advertised, so getValue must not attempt a decode (store is never touched)
+		assert.equal(read.getValue({}), undefined);
+	});
+
+	it('keeps HAS_RECORD when a body is present', () => {
+		const encodedRecord = Buffer.from([0x81, 0xa1, 0x61, 0x01]); // msgpack {a: 1}
+		const entry = createAuditEntry({ ...baseRecord, encodedRecord });
+		const read = readAuditEntry(Buffer.from(entry));
+		assert.equal(read.type, 'put');
+		assert.equal(read.extendedType & HAS_RECORD, HAS_RECORD);
+		assert.deepEqual(read.getBinaryValue(), encodedRecord);
+	});
+
+	it('tolerates a pre-fix malformed entry: HAS_RECORD set with no body', () => {
+		// mint the (fixed) bodyless entry, then set HAS_RECORD back in the action word to get the
+		// exact malformed form persisted by pre-fix nodes (production bytes start c0 00 11 11)
+		const entry = Buffer.from(createAuditEntry({ ...baseRecord, encodedRecord: undefined }));
+		assert.equal(entry[0], 0xc0); // extended action word, no previousVersion
+		entry[3] |= HAS_RECORD;
+		const read = readAuditEntry(entry);
+		assert.equal(read.type, 'put');
+		assert.equal(read.extendedType & HAS_RECORD, HAS_RECORD);
+		assert.equal(read.recordId, baseRecord.recordId);
+		// the reader must treat it as having no record rather than throwing on the empty decode
+		assert.equal(read.getValue({}), undefined);
+	});
+
+	describe('audit-only commit for a superseded out-of-order write', () => {
+		let T;
+		before(async function () {
+			if (isLMDB) return;
+			setupTestDBPath();
+			setMainIsWorker(true);
+			T = table({
+				table: 'SupersededAudit2153',
+				database: 'test',
+				attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'a' }, { name: 'b' }],
+				audit: true,
+			});
+		});
+
+		it('mints a decodable entry carrying the superseded update as its body', async function () {
+			if (isLMDB) return this.skip();
+			const id = 'r1';
+			const context = {};
+			await transaction(context, () => {
+				T.put(id, { id, a: 'v0', b: 'keep' }, context);
+			});
+			const now = Date.now();
+			await T.patch(id, { a: 'n1' }, { timestamp: now + 100 });
+			await T.patch(id, { a: 'n2' }, { timestamp: now + 200 });
+			// out-of-order older patch to `a`, fully superseded by the two newer patches: takes the
+			// writeCommit(false) audit-only escape
+			const loserVersion = now + 50;
+			await T.patch(id, { a: 'loser' }, { timestamp: loserVersion, nodeId: 7 });
+
+			let loser;
+			for (const entry of T.auditStore.getRange({ start: 1 })) {
+				if (entry.version === loserVersion) loser = entry;
+				// every minted entry must be internally consistent: record flags imply a body
+				if (entry.extendedType & (HAS_RECORD | HAS_PARTIAL_RECORD)) {
+					assert(entry.getBinaryValue().length > 0, `entry ${entry.version} advertises a record but has no body`);
+				}
+			}
+			assert(loser, 'audit entry for the superseded write should exist');
+			assert.deepEqual({ ...loser.getValue(T.primaryStore) }, { a: 'loser' });
+			const record = await T.get(id);
+			assert.equal(record.a, 'n2');
+			assert.equal(record.b, 'keep');
+		});
+	});
+});

--- a/unitTests/resources/auditEntryRecordFlags.test.js
+++ b/unitTests/resources/auditEntryRecordFlags.test.js
@@ -41,7 +41,8 @@ describe('Audit entry record flags match the body (#2153)', () => {
 		const read = readAuditEntry(Buffer.from(entry));
 		assert.equal(read.type, 'patch');
 		assert.equal(read.extendedType & HAS_PARTIAL_RECORD, HAS_PARTIAL_RECORD);
-		// the empty body is guarded on read: no decode attempt, no throw
+		// the empty body is guarded on read: no decode attempt, no throw, stable across calls
+		assert.equal(read.getValue({}), undefined);
 		assert.equal(read.getValue({}), undefined);
 	});
 
@@ -58,13 +59,28 @@ describe('Audit entry record flags match the body (#2153)', () => {
 		assert.equal(read.getValue(storeMustNotBeTouched, false, baseRecord.version), undefined);
 	});
 
-	it('keeps HAS_RECORD when a body is present', () => {
+	it('keeps HAS_RECORD when a body is present, and getValue is idempotent', () => {
 		const encodedRecord = Buffer.from([0x81, 0xa1, 0x61, 0x01]); // msgpack {a: 1}
 		const entry = createAuditEntry({ ...baseRecord, encodedRecord });
 		const read = readAuditEntry(Buffer.from(entry));
 		assert.equal(read.type, 'put');
 		assert.equal(read.extendedType & HAS_RECORD, HAS_RECORD);
 		assert.deepEqual(read.getBinaryValue(), encodedRecord);
+		// decoding must not perturb the entry's own header decoder: repeated reads return the
+		// same cached value (decode runs once), never flipping to the empty-body path
+		let decodes = 0;
+		const store = {
+			decoder: {
+				decode: () => {
+					decodes++;
+					return { a: 1 };
+				},
+			},
+		};
+		const first = read.getValue(store);
+		assert.deepEqual(first, { a: 1 });
+		assert.equal(read.getValue(store), first);
+		assert.equal(decodes, 1);
 	});
 
 	it('tolerates a pre-fix malformed entry: HAS_RECORD set with no body', () => {

--- a/unitTests/resources/auditEntryRecordFlags.test.js
+++ b/unitTests/resources/auditEntryRecordFlags.test.js
@@ -141,7 +141,7 @@ describe('Audit entry record flags match the body (#2153)', () => {
 			assert.equal(record.b, 'keep');
 		});
 
-		it('a superseded source apply of an undefined value mints a flag-consistent, decodable entry', async function () {
+		it('a source apply of an undefined value is skipped: no record change, no audit entry', async function () {
 			if (isLMDB) return this.skip();
 			const id = 'r2';
 			const context = {};
@@ -150,24 +150,21 @@ describe('Audit entry record flags match the body (#2153)', () => {
 			});
 			const now = Date.now();
 			await T.patch(id, { a: 'n1' }, { timestamp: now + 100 });
-			await T.patch(id, { a: 'n2' }, { timestamp: now + 200 });
-			// source/replication applies skip record validation, so an undefined value reaches the
-			// write path; fully superseded, it takes the audit-only escape with nothing to encode —
-			// the #2153 producer shape (pre-fix this minted HAS_RECORD with no body)
-			const loserVersion = now + 50;
-			await T.put(id, undefined, { timestamp: loserVersion, source: {}, nodeId: 7 });
+			// source/replication applies skip record validation, so an undefined value can reach the
+			// write path — the #2153 producer shape (pre-fix this minted a bodyless put advertising
+			// HAS_RECORD, wedging peers). The guard skips it before any write is staged.
+			const applyVersion = now + 200; // would win — skipping must not depend on losing
+			await T.put(id, undefined, { timestamp: applyVersion, source: {}, nodeId: 7 });
+			const absentId = 'r2-absent'; // locally-absent record: the production entries' no-previousVersion shape
+			await T.put(absentId, undefined, { timestamp: now + 300, source: {}, nodeId: 7 });
 
-			let loser;
 			for (const entry of T.auditStore.getRange({ start: 1 })) {
-				if (entry.version === loserVersion) loser = entry;
+				assert.notEqual(entry.version, applyVersion, 'valueless apply must not mint an audit entry');
+				assert.notEqual(entry.recordId, absentId, 'valueless apply of an absent record must not mint');
 			}
-			assert(loser, 'audit-only entry for the superseded apply should exist');
-			assert.equal(loser.type, 'put');
-			assert.equal(loser.extendedType & (HAS_RECORD | HAS_PARTIAL_RECORD), 0);
-			assert.equal(loser.getBinaryValue().length, 0);
-			assert.equal(loser.getValue(T.primaryStore), undefined);
 			const record = await T.get(id);
-			assert.equal(record.a, 'n2');
+			assert.equal(record.a, 'n1', 'valueless apply must not disturb the record');
+			assert.equal(await T.get(absentId), undefined);
 		});
 	});
 });

--- a/unitTests/resources/auditEntryRecordFlags.test.js
+++ b/unitTests/resources/auditEntryRecordFlags.test.js
@@ -26,13 +26,22 @@ describe('Audit entry record flags match the body (#2153)', () => {
 		expiresAt: 1817915930237,
 	};
 
-	it('clears the record flags on a put minted with no encoded record', () => {
+	it('clears HAS_RECORD on a put minted with no encoded record', () => {
 		const entry = createAuditEntry({ ...baseRecord, encodedRecord: undefined });
 		const read = readAuditEntry(Buffer.from(entry));
 		assert.equal(read.type, 'put');
 		assert.equal(read.extendedType & (HAS_RECORD | HAS_PARTIAL_RECORD), 0);
 		assert.equal(read.getBinaryValue().length, 0);
 		// no body advertised, so getValue must not attempt a decode (store is never touched)
+		assert.equal(read.getValue({}), undefined);
+	});
+
+	it('keeps HAS_PARTIAL_RECORD on a bodyless partial so history reconstruction stays possible', () => {
+		const entry = createAuditEntry({ ...baseRecord, type: 'patch', encodedRecord: undefined });
+		const read = readAuditEntry(Buffer.from(entry));
+		assert.equal(read.type, 'patch');
+		assert.equal(read.extendedType & HAS_PARTIAL_RECORD, HAS_PARTIAL_RECORD);
+		// the empty body is guarded on read: no decode attempt, no throw
 		assert.equal(read.getValue({}), undefined);
 	});
 
@@ -101,6 +110,35 @@ describe('Audit entry record flags match the body (#2153)', () => {
 			const record = await T.get(id);
 			assert.equal(record.a, 'n2');
 			assert.equal(record.b, 'keep');
+		});
+
+		it('a superseded source apply of an undefined value mints a flag-consistent, decodable entry', async function () {
+			if (isLMDB) return this.skip();
+			const id = 'r2';
+			const context = {};
+			await transaction(context, () => {
+				T.put(id, { id, a: 'v0' }, context);
+			});
+			const now = Date.now();
+			await T.patch(id, { a: 'n1' }, { timestamp: now + 100 });
+			await T.patch(id, { a: 'n2' }, { timestamp: now + 200 });
+			// source/replication applies skip record validation, so an undefined value reaches the
+			// write path; fully superseded, it takes the audit-only escape with nothing to encode —
+			// the #2153 producer shape (pre-fix this minted HAS_RECORD with no body)
+			const loserVersion = now + 50;
+			await T.put(id, undefined, { timestamp: loserVersion, source: {}, nodeId: 7 });
+
+			let loser;
+			for (const entry of T.auditStore.getRange({ start: 1 })) {
+				if (entry.version === loserVersion) loser = entry;
+			}
+			assert(loser, 'audit-only entry for the superseded apply should exist');
+			assert.equal(loser.type, 'put');
+			assert.equal(loser.extendedType & (HAS_RECORD | HAS_PARTIAL_RECORD), 0);
+			assert.equal(loser.getBinaryValue().length, 0);
+			assert.equal(loser.getValue(T.primaryStore), undefined);
+			const record = await T.get(id);
+			assert.equal(record.a, 'n2');
 		});
 	});
 });


### PR DESCRIPTION
Fixes #2153. An audit-only commit (a fully-superseded out-of-order write) stores no record but passed its operation type through unchanged, so the entry advertised `HAS_RECORD` with no body. Receivers decode the empty remainder, msgpackr throws `Unexpected end of MessagePack data`, and since harper-pro#521 that decode failure closes the connection and resumes on the same entry — a permanent head-of-line block on the replication leg. Credit to @ldt1996 for the byte-level forensics and mechanism analysis in the issue; this PR takes her suggested direction (suppress the record bit when no record is encoded, with the cheap warn tripwire she proposed) and adds read-side healing.

**Root cause (traced end-to-end):** `RecordEncoder.encode(undefined)` produces `d4 00 00` — a valid msgpack body that decodes back to `undefined` — so a replication/source apply can deliver a put whose value is undefined. Source applies skip record validation, so the value reaches `_writeUpdate`; with the record locally absent (steady state on TTL tables, where eviction removes entries) the apply wins, stores nothing, and mints `put` + `HAS_RECORD` + no body + no previousVersion into the receiver's per-origin log under the origin's nodeId — byte-for-byte the production shape. The per-origin log then forwards verbatim and wedges downstream peers. Which path first ships the `undefined` is still open (full-copy send path vs external source connectors); the mint warn captures a stack so the next field occurrence names it.

Three layers:

- **Apply guard (root cause)** — `Table.ts` `_writeUpdate` skips a notification/source-applied full update whose value is nullish (latched warn with stack). `options.isNotification` scopes it to the apply dispatcher, so instance `save()` flows that fill from `#changes` are untouched; the regression test drives the dispatcher shape and fails without the guard.

- **Mint reconciliation (defense in depth)** — `createAuditEntry` clears `HAS_RECORD` (with a warn) when no encoded record is present, so every producer mints internally consistent entries. `HAS_PARTIAL_RECORD` is deliberately kept: it also drives `getRecordAtTime` history reconstruction, and the read path tolerates the empty body (a bodyless partial is unmintable through `_writeUpdate` anyway — a patch with a nullish update never stages a write, and invalidate/message always encode at least a null body).
- **Read tolerance (heals persisted entries)** — `getValue` treats a flagged entry whose header consumed the whole buffer as having no record (warn latched per table) instead of throwing. This heals the malformed entries **already persisted** in production logs, which the write-side fix alone cannot. The guard is deliberately narrow (exactly-empty remainder only): a torn or corrupt non-empty body still throws loudly, so structure-fork-class corruption — which heals via reconnect — is not silently swallowed.

**Producer pinned (new beyond the issue):** the bodyless mint requires a nullish `recordUpdate` reaching `writeCommit(false)`. The user path rejects `put(undefined)` in validation, but a source/replication apply skips that validation, so an undefined value applied as a full update — out-of-order and fully superseded by newer patches — mints exactly the production shape (`put`, no body, no previousVersion). This is now the e2e regression case. The issue's own patch-based repro steps mint a *healthy* entry (the original update is encoded as the body), which is why partition tests with full-record conflicts converged cleanly.

## Verification

`unitTests/resources/auditEntryRecordFlags.test.js` (6 tests): unit-level flag/body contract (bodyless put cleared, bodyless partial keeps its flag, bodied put preserved, crafted pre-fix malformed bytes read without throwing) plus two RocksDB e2e cases through the real write path, including the pinned producer shape above. 4 of 6 fail on base (verified against origin/main sources with a forced rebuild). Neighboring suites green: auditLog, auditDedupRetention, replayLogs, copyApply, transaction, sourceApplyConflictRetry. Replay-guard interplay checked: a cleared-flag bodyless put is skipped by `isUndecodableValidatedWrite`; partial classification in `classifyAuditEntryForReplay` is unchanged. A two-node replication wedge repro was not driven; the receiver-side failure mechanism is covered by the crafted pre-fix-entry test (the exact persisted production bytes modulo the flag bit).

**Mixed-version caveat:** a flag-cleared bodyless put is a shape unpatched peers have never seen — an unpatched node applying one re-mints the malformed pre-fix entry locally (the apply guard only exists on patched nodes). Containment therefore requires the fix fleet-wide; until then, patched nodes stop producing and tolerate, unpatched nodes can still regenerate. This is inherent to any mint-side fix and is the standard storage-fix upgrade posture.

Not user-facing (no API/config/schema change) — no docs PR needed. Worth considering for a v5.1/v5.2 release patch: the incident wedged legs for 4–26 hours on a v5.2.1 16-node cluster, and any cluster with these entries persisted needs the read-side healing.

## For the human reviewer

1. **Bodyless put semantics** — a bodyless `put` is persisted and replicated as a valid flag-less `put` (peers/subscribers see `type: 'put'`, `value: undefined`) rather than being refused at mint (throw / degrade the type / skip the entry). Chosen because the audit chain needs the version recorded for dedup/resequencing, and CRDT reconstruction absorbs the undefined. Reversible in code, but not for entries already written to peers.
2. **Narrow empty-guard vs decode-catch** — the read guard covers only an exactly-empty remainder; a torn non-empty body still throws and (post harper-pro#521) closes the leg. Chosen to keep genuine corruption loud, since reconnect heals structure forks but would mask them if any decode failure were treated as bodyless. A one-line reversible edit if the policy should be "no bad body ever wedges replication".
3. **Read-path tolerance lives in core** — legacy-entry healing sits in `readAuditEntry.getValue` rather than making harper-pro's replication leg survive per-entry decode failures. Layering choice: every future bad-entry shape needs a core guard, but the alternative re-opens the silent-gap class harper-pro#521 closed.
4. **Skip vs record the valueless apply** — a notification put with no value is now skipped entirely (no record change, no audit entry) rather than minting an audit-only entry that records the version. Skipping loses the version from the local audit chain, but a redelivery re-skips harmlessly and a later real write supersedes; minting was the behavior that produced this incident's artifacts. Reversible.
5. **First-shipper still unidentified** — the guard + stack-capture warns will name the path that ships `undefined` (full-copy send vs external connectors); a harper-pro-side guard on the copy send path is deliberately deferred until that evidence lands.

Generated by Claude (Fable 5), cross-model reviewed (Codex graded + Gemini + Harper-domain adjudication; final delta round LGTM, no findings).

<sub>Human-Review-Need: 3 @ 5b840485f5d6</sub>
