### PR TITLE
Bound the boot transaction-log replay batch so an oversized transaction can't OOM the node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ benchmarks/compression/results/
 
 # northwind export_local test artifact
 test_export.json.json
+test_export_*.json
 
 # dev-mode boots (harper dev <fixture>) symlink node_modules/harper into the
 # fixture component dir; keep those out of commits

--- a/integrationTests/server/replay-large-transaction.test.ts
+++ b/integrationTests/server/replay-large-transaction.test.ts
@@ -6,10 +6,16 @@
  * exhausted heap mid-replay, and because the next boot restarts the same replay, the node never
  * came back up. Replay now also commits once the staged batch crosses its size bounds, mid-version.
  *
- * This exercises that mid-version flush on a real crash/replay cycle and asserts the property the
- * flush must not break: a torn-and-recommitted transaction still replays completely. It does not
- * reproduce the OOM itself (that needs a heap-constrained run over GB-scale logs); the bound is
- * covered by unit tests over shouldFlushReplayBatch.
+ * These exercise that mid-version commit on real crash/replay cycles and assert the properties it
+ * must not break: a torn-and-recommitted transaction still replays completely, and a key written
+ * twice in one transaction still ends at its LAST value even when the two writes land in different
+ * batches (the committed earlier write ties the later one on version/nodeId, which without
+ * `Context.partiallyCommitted` reads as a re-delivered duplicate and is dropped).
+ *
+ * They do not reproduce the OOM itself (that needs a heap-constrained run over GB-scale logs), and
+ * they do not crash BETWEEN two replay batches — the bound is covered by unit tests over
+ * shouldFlushReplayBatch, and the re-application of a torn version rests on replay restarting from
+ * the log's last-flushed position.
  */
 import { suite, test, before, after } from 'node:test';
 import { ok, strictEqual as equal } from 'node:assert';
@@ -26,6 +32,8 @@ import {
 
 const DB = 'bigtxn';
 const TABLE = 'bigrows';
+const REPEAT_TABLE = 'repeatrows';
+const REPEAT_ID = 1_000_000;
 // Comfortably over REPLAY_MAX_STAGED_WRITES (10,000) so one insert operation — one transaction, one
 // version — forces at least one mid-version flush. The log assertion below fails loudly if that
 // bound is ever raised past this, rather than silently no longer exercising the flush.
@@ -52,13 +60,28 @@ function readHarperLogs(dirs: (string | undefined)[]): string {
 	return combined;
 }
 
+async function crashAndReplay(ctx: ContextWithHarper) {
+	await new Promise<void>((resolve) => {
+		ctx.harper.process.once('exit', () => resolve());
+		ctx.harper.process.kill('SIGKILL');
+	});
+	await startHarper(ctx, { startupTimeoutMs: MAX_REPLAY_STARTUP_MS });
+}
+
+async function readRepeated(ctx: HarperContext) {
+	const rows = await op(ctx, { operation: 'sql', sql: `select n from ${DB}.${REPEAT_TABLE} where id = ${REPEAT_ID}` });
+	return rows[0] ?? {};
+}
+
 suite('Transaction log replay of an oversized transaction', (ctx: ContextWithHarper) => {
 	before(async () => {
 		await startHarper(ctx, {
 			env: { HARPER_NO_FLUSH_ON_EXIT: true }, // don't flush on exit; we are simulating a crash
 		});
 		await op(ctx.harper, { operation: 'create_database', database: DB });
-		await op(ctx.harper, { operation: 'create_table', database: DB, table: TABLE, primary_key: 'id' });
+		for (const table of [TABLE, REPEAT_TABLE]) {
+			await op(ctx.harper, { operation: 'create_table', database: DB, table, primary_key: 'id' });
+		}
 	});
 	after(async () => teardownHarper(ctx));
 
@@ -68,11 +91,7 @@ suite('Transaction log replay of an oversized transaction', (ctx: ContextWithHar
 		for (let id = 0; id < RECORD_COUNT; id++) records.push({ id, payload: `p${id}`, n: id });
 		await op(ctx.harper, { operation: 'insert', database: DB, table: TABLE, records });
 
-		await new Promise<void>((resolve) => {
-			ctx.harper.process.once('exit', () => resolve());
-			ctx.harper.process.kill('SIGKILL');
-		});
-		await startHarper(ctx, { startupTimeoutMs: MAX_REPLAY_STARTUP_MS });
+		await crashAndReplay(ctx);
 
 		const count = await op(ctx.harper, { operation: 'sql', sql: `select count(*) as c from ${DB}.${TABLE}` });
 		equal(count[0]?.c ?? count[0]?.['COUNT(*)'], RECORD_COUNT);
@@ -91,5 +110,31 @@ suite('Transaction log replay of an oversized transaction', (ctx: ContextWithHar
 			log.includes('intra-transaction batch'),
 			'expected replay to report a mid-version flush; the transaction may no longer exceed the staged-batch bound'
 		);
+	});
+
+	test('a key written twice in one oversized transaction replays to its last value', async () => {
+		// Both writes to REPEAT_ID belong to one operation — one transaction, one version — with the
+		// batch bound falling between them.
+		const records: any[] = [{ id: REPEAT_ID, payload: 'first', n: 1 }];
+		for (let id = 1; id <= RECORD_COUNT; id++) records.push({ id, payload: `p${id}`, n: id });
+		records.push({ id: REPEAT_ID, payload: 'last', n: 2 });
+		await op(ctx.harper, { operation: 'upsert', database: DB, table: REPEAT_TABLE, records });
+		equal((await readRepeated(ctx.harper)).n, 2, 'the second write should win before the crash');
+
+		await crashAndReplay(ctx);
+
+		equal((await readRepeated(ctx.harper)).n, 2, 'the second write to the repeated key was lost in replay');
+	});
+
+	test('a key patched after an earlier write in the same oversized transaction replays to its last value', async () => {
+		const records: any[] = [{ id: REPEAT_ID, n: 3 }];
+		for (let id = 1; id <= RECORD_COUNT; id++) records.push({ id, n: id + 1 });
+		records.push({ id: REPEAT_ID, n: 4 });
+		await op(ctx.harper, { operation: 'update', database: DB, table: REPEAT_TABLE, records });
+		equal((await readRepeated(ctx.harper)).n, 4, 'the second patch should win before the crash');
+
+		await crashAndReplay(ctx);
+
+		equal((await readRepeated(ctx.harper)).n, 4, 'the second patch of the repeated key was lost in replay');
 	});
 });

--- a/integrationTests/server/replay-large-transaction.test.ts
+++ b/integrationTests/server/replay-large-transaction.test.ts
@@ -6,16 +6,12 @@
  * exhausted heap mid-replay, and because the next boot restarts the same replay, the node never
  * came back up. Replay now also commits once the staged batch crosses its size bounds, mid-version.
  *
- * These exercise that mid-version commit on real crash/replay cycles and assert the properties it
- * must not break: a torn-and-recommitted transaction still replays completely, and a key written
- * twice in one transaction still ends at its LAST value even when the two writes land in different
- * batches (the committed earlier write ties the later one on version/nodeId, which without
- * `Context.partiallyCommitted` reads as a re-delivered duplicate and is dropped).
+ * A key written twice in one transaction must still end at its LAST value when the two writes land
+ * in different batches: the committed earlier write ties the later one on version/nodeId, which
+ * without `DatabaseTransaction.partiallyCommitted` reads as a re-delivered duplicate and is dropped.
  *
- * They do not reproduce the OOM itself (that needs a heap-constrained run over GB-scale logs), and
- * they do not crash BETWEEN two replay batches — the bound is covered by unit tests over
- * shouldFlushReplayBatch, and the re-application of a torn version rests on replay restarting from
- * the log's last-flushed position.
+ * Not covered here: the OOM itself (needs a heap-constrained run over GB-scale logs), a crash
+ * BETWEEN two replay batches, and commit failure.
  */
 import { suite, test, before, after } from 'node:test';
 import { ok, strictEqual as equal } from 'node:assert';

--- a/integrationTests/server/replay-large-transaction.test.ts
+++ b/integrationTests/server/replay-large-transaction.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Boot replay of a transaction too large to stage as one in-memory batch (harper#2161).
+ *
+ * Replay used to commit its transaction only at a version boundary, so every write of one source
+ * transaction accumulated in a single batch with no bound at all — a big enough transaction
+ * exhausted heap mid-replay, and because the next boot restarts the same replay, the node never
+ * came back up. Replay now also commits once the staged batch crosses its size bounds, mid-version.
+ *
+ * This exercises that mid-version flush on a real crash/replay cycle and asserts the property the
+ * flush must not break: a torn-and-recommitted transaction still replays completely. It does not
+ * reproduce the OOM itself (that needs a heap-constrained run over GB-scale logs); the bound is
+ * covered by unit tests over shouldFlushReplayBatch.
+ */
+import { suite, test, before, after } from 'node:test';
+import { ok, strictEqual as equal } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+	startHarper,
+	teardownHarper,
+	sendOperation,
+	type ContextWithHarper,
+	type HarperContext,
+} from '@harperfast/integration-testing';
+
+const DB = 'bigtxn';
+const TABLE = 'bigrows';
+// Comfortably over REPLAY_MAX_STAGED_WRITES (10,000) so one insert operation — one transaction, one
+// version — forces at least one mid-version flush. The log assertion below fails loudly if that
+// bound is ever raised past this, rather than silently no longer exercising the flush.
+const RECORD_COUNT = 25_000;
+const MAX_REPLAY_STARTUP_MS = 120_000;
+
+async function op(ctx: HarperContext, body: any) {
+	return await sendOperation(ctx, { ...body, authorization: ctx.admin });
+}
+
+// Every hdb.log this instance may have written to. A restart gets a fresh per-start log directory
+// from the harness, but Harper keeps logging to the root recorded in the config it persisted on
+// first start — so the restart's replay output lands in the FIRST directory, not the current one.
+function readHarperLogs(dirs: (string | undefined)[]): string {
+	let combined = '';
+	for (const dir of dirs) {
+		if (!dir) continue;
+		try {
+			combined += readFileSync(join(dir, 'hdb.log'), 'utf8');
+		} catch {
+			// a directory that was never written to
+		}
+	}
+	return combined;
+}
+
+suite('Transaction log replay of an oversized transaction', (ctx: ContextWithHarper) => {
+	before(async () => {
+		await startHarper(ctx, {
+			env: { HARPER_NO_FLUSH_ON_EXIT: true }, // don't flush on exit; we are simulating a crash
+		});
+		await op(ctx.harper, { operation: 'create_database', database: DB });
+		await op(ctx.harper, { operation: 'create_table', database: DB, table: TABLE, primary_key: 'id' });
+	});
+	after(async () => teardownHarper(ctx));
+
+	test('replays every record of a transaction larger than one staged batch', async () => {
+		const firstLogDir = ctx.harper.logDir;
+		const records = [];
+		for (let id = 0; id < RECORD_COUNT; id++) records.push({ id, payload: `p${id}`, n: id });
+		await op(ctx.harper, { operation: 'insert', database: DB, table: TABLE, records });
+
+		await new Promise<void>((resolve) => {
+			ctx.harper.process.once('exit', () => resolve());
+			ctx.harper.process.kill('SIGKILL');
+		});
+		await startHarper(ctx, { startupTimeoutMs: MAX_REPLAY_STARTUP_MS });
+
+		const count = await op(ctx.harper, { operation: 'sql', sql: `select count(*) as c from ${DB}.${TABLE}` });
+		equal(count[0]?.c ?? count[0]?.['COUNT(*)'], RECORD_COUNT);
+		// Spot-check the ends and the middle: a flush that dropped or misordered the tail of a torn
+		// batch would still leave the count right if it also replayed something else.
+		for (const id of [0, RECORD_COUNT >> 1, RECORD_COUNT - 1]) {
+			const found = await op(ctx.harper, {
+				operation: 'sql',
+				sql: `select id, n from ${DB}.${TABLE} where id = ${id}`,
+			});
+			equal(found[0]?.n, id, `record ${id} did not replay`);
+		}
+
+		const log = readHarperLogs([firstLogDir, ctx.harper.logDir, join(ctx.harper.dataRootDir, 'log')]);
+		ok(
+			log.includes('intra-transaction batch'),
+			'expected replay to report a mid-version flush; the transaction may no longer exceed the staged-batch bound'
+		);
+	});
+});

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -365,9 +365,11 @@ export class DatabaseTransaction implements Transaction {
 	// position interior to it. A stored record that ties this transaction's (version, nodeId) is then
 	// that earlier write, and program order says this one supersedes it; without this the write path
 	// reads the tie as a re-delivered duplicate and drops it, since the staged-write chain that
-	// normally carries program order went with the committed batch. Replay only ever reads entries at
-	// or after the log's last-flushed position, so the entry being replayed is itself never durable —
-	// the tie can only come from a different, earlier entry of the same transaction.
+	// normally carries program order went with the committed batch. Entries at or after the log's
+	// last-flushed position were not flushed, and RocksDB's own WAL is off, so a replayed entry's
+	// write is not durable and the tie can only come from an earlier entry of the same transaction —
+	// except in the window where a flush completed but its position has not been recorded yet, where
+	// this also skips the re-delivery guards that make a commutative op idempotent.
 	declare partiallyCommitted?: boolean;
 	// Set when this transaction replays the local audit log during crash recovery (replayLogs.ts).
 	// Replayed records were valid when first written, so schema validation is skipped — a schema

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -360,6 +360,15 @@ export class DatabaseTransaction implements Transaction {
 	// or external caching source); its commits retry transient conflicts without the request-path
 	// retry cap. Propagated to chained (multi-store) transactions in txnForContext.
 	declare sourceApply?: boolean;
+	// Set on a replay transaction whose source transaction may already be durable in part — because
+	// boot replay committed an earlier batch of it (harper#2161), or because replay resumed at a
+	// position interior to it. A stored record that ties this transaction's (version, nodeId) is then
+	// that earlier write, and program order says this one supersedes it; without this the write path
+	// reads the tie as a re-delivered duplicate and drops it, since the staged-write chain that
+	// normally carries program order went with the committed batch. Replay only ever reads entries at
+	// or after the log's last-flushed position, so the entry being replayed is itself never durable —
+	// the tie can only come from a different, earlier entry of the same transaction.
+	declare partiallyCommitted?: boolean;
 	// Set when this transaction replays the local audit log during crash recovery (replayLogs.ts).
 	// Replayed records were valid when first written, so schema validation is skipped — a schema
 	// that has since added required fields must not block replaying older records (harper#1316).

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1955,7 +1955,7 @@ export function makeTable(options) {
 						: undefined,
 				commit: (txnTime, existingEntry, _retry, transaction: any) => {
 					const precedesExisting = precedesExistingVersion(txnTime, existingEntry, options?.nodeId);
-					// see the invalidate path above
+					// see the invalidate path above (same tie handling)
 					if (precedesExisting < 0 || (precedesExisting === 0 && !(context?.transaction as any)?.partiallyCommitted))
 						return;
 					const residency = TableResource.getResidencyRecord(options.residencyId);
@@ -2421,9 +2421,8 @@ export function makeTable(options) {
 					let precedesExisting = precedesExistingVersion(txnTime, existingEntry, options?.nodeId);
 					// A partially committed replay transaction carries the same program-order signal for its
 					// earlier writes, which are committed rather than staged and so have no chain left (see
-					// DatabaseTransaction.partiallyCommitted). Only a tie can change here — forcing an already
-					// winning write to 1 is a no-op — so testing it first keeps both reads off the path an
-					// ordinary write takes.
+					// DatabaseTransaction.partiallyCommitted). Only a tie can change here, so testing it first
+					// keeps both reads off the path an ordinary write takes.
 					if (precedesExisting === 0 && (priorStaged || (context?.transaction as any)?.partiallyCommitted))
 						precedesExisting = 1;
 					let auditRecordToStore: any; // what to store in the audit record. For a full update, this can be left undefined in which case it is the same as full record update and optimized to use a binary copy

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -2421,8 +2421,10 @@ export function makeTable(options) {
 					let precedesExisting = precedesExistingVersion(txnTime, existingEntry, options?.nodeId);
 					// A partially committed replay transaction carries the same program-order signal for its
 					// earlier writes, which are committed rather than staged and so have no chain left (see
-					// DatabaseTransaction.partiallyCommitted).
-					if ((priorStaged || (context?.transaction as any)?.partiallyCommitted) && precedesExisting >= 0)
+					// DatabaseTransaction.partiallyCommitted). Only a tie can change here — forcing an already
+					// winning write to 1 is a no-op — so testing it first keeps both reads off the path an
+					// ordinary write takes.
+					if (precedesExisting === 0 && (priorStaged || (context?.transaction as any)?.partiallyCommitted))
 						precedesExisting = 1;
 					let auditRecordToStore: any; // what to store in the audit record. For a full update, this can be left undefined in which case it is the same as full record update and optimized to use a binary copy
 					const type = fullUpdate ? 'put' : 'patch';
@@ -5626,8 +5628,10 @@ export function makeTable(options) {
 					transaction.next.sourceApply = transaction.sourceApply;
 					transaction.next.timeoutBudget = transaction.timeoutBudget;
 					// Inherit the replay marker so a multi-table replay transaction skips validation on
-					// every store, not just the first (harper#1316).
+					// every store, not just the first (harper#1316), and with it the program-order signal
+					// for a replay transaction being applied in pieces (harper#2161).
 					transaction.next.isReplay = transaction.isReplay;
+					transaction.next.partiallyCommitted = transaction.partiallyCommitted;
 					// Inherit which resource/method started this logical operation, so a chained (second
 					// table) transaction's long-transaction-abort log (DatabaseTransaction.ts) can still
 					// identify the request that caused it instead of leaving that field blank. The

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1901,7 +1901,10 @@ export function makeTable(options) {
 				entry: this.#entry,
 				commit: (txnTime, existingEntry, _retry, transaction: any) => {
 					write.skipped = false; // reset on each retry; cleanup happens after commit if still true
-					if (precedesExistingVersion(txnTime, existingEntry, options?.nodeId) <= 0) {
+					const precedesExisting = precedesExistingVersion(txnTime, existingEntry, options?.nodeId);
+					// A tie is this transaction's own earlier, already-committed write when it is being applied
+					// in pieces (see DatabaseTransaction.partiallyCommitted) — program order, not a duplicate.
+					if (precedesExisting < 0 || (precedesExisting === 0 && !(context?.transaction as any)?.partiallyCommitted)) {
 						write.skipped = true;
 						return;
 					}
@@ -1951,7 +1954,10 @@ export function makeTable(options) {
 						? (this.constructor as any).source.relocate.bind((this.constructor as any).source, id, undefined, context)
 						: undefined,
 				commit: (txnTime, existingEntry, _retry, transaction: any) => {
-					if (precedesExistingVersion(txnTime, existingEntry, options?.nodeId) <= 0) return;
+					const precedesExisting = precedesExistingVersion(txnTime, existingEntry, options?.nodeId);
+					// see the invalidate path above
+					if (precedesExisting < 0 || (precedesExisting === 0 && !(context?.transaction as any)?.partiallyCommitted))
+						return;
 					const residency = TableResource.getResidencyRecord(options.residencyId);
 					let metadata = 0;
 					let newRecord = null;
@@ -2413,7 +2419,11 @@ export function makeTable(options) {
 					// round, and must still go through the out-of-order merge below or its changes would be
 					// silently overwritten.
 					let precedesExisting = precedesExistingVersion(txnTime, existingEntry, options?.nodeId);
-					if (priorStaged && precedesExisting >= 0) precedesExisting = 1;
+					// A partially committed replay transaction carries the same program-order signal for its
+					// earlier writes, which are committed rather than staged and so have no chain left (see
+					// DatabaseTransaction.partiallyCommitted).
+					if ((priorStaged || (context?.transaction as any)?.partiallyCommitted) && precedesExisting >= 0)
+						precedesExisting = 1;
 					let auditRecordToStore: any; // what to store in the audit record. For a full update, this can be left undefined in which case it is the same as full record update and optimized to use a binary copy
 					const type = fullUpdate ? 'put' : 'patch';
 					let residencyId: number | undefined;

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -1904,7 +1904,7 @@ export function makeTable(options) {
 					const precedesExisting = precedesExistingVersion(txnTime, existingEntry, options?.nodeId);
 					// A tie is this transaction's own earlier, already-committed write when it is being applied
 					// in pieces (see DatabaseTransaction.partiallyCommitted) — program order, not a duplicate.
-					if (precedesExisting < 0 || (precedesExisting === 0 && !(context?.transaction as any)?.partiallyCommitted)) {
+					if (precedesExisting < 0 || (precedesExisting === 0 && !context?.transaction?.partiallyCommitted)) {
 						write.skipped = true;
 						return;
 					}
@@ -1956,8 +1956,7 @@ export function makeTable(options) {
 				commit: (txnTime, existingEntry, _retry, transaction: any) => {
 					const precedesExisting = precedesExistingVersion(txnTime, existingEntry, options?.nodeId);
 					// see the invalidate path above (same tie handling)
-					if (precedesExisting < 0 || (precedesExisting === 0 && !(context?.transaction as any)?.partiallyCommitted))
-						return;
+					if (precedesExisting < 0 || (precedesExisting === 0 && !context?.transaction?.partiallyCommitted)) return;
 					const residency = TableResource.getResidencyRecord(options.residencyId);
 					let metadata = 0;
 					let newRecord = null;
@@ -2423,8 +2422,7 @@ export function makeTable(options) {
 					// earlier writes, which are committed rather than staged and so have no chain left (see
 					// DatabaseTransaction.partiallyCommitted). Only a tie can change here, so testing it first
 					// keeps both reads off the path an ordinary write takes.
-					if (precedesExisting === 0 && (priorStaged || (context?.transaction as any)?.partiallyCommitted))
-						precedesExisting = 1;
+					if (precedesExisting === 0 && (priorStaged || context?.transaction?.partiallyCommitted)) precedesExisting = 1;
 					let auditRecordToStore: any; // what to store in the audit record. For a full update, this can be left undefined in which case it is the same as full record update and optimized to use a binary copy
 					const type = fullUpdate ? 'put' : 'patch';
 					let residencyId: number | undefined;

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -11,7 +11,9 @@ import {
 	isUndecodableValidatedWrite,
 	shouldAbortStalledReplay,
 	shouldAbortSlowReplay,
+	shouldFlushReplayBatch,
 	REPLAY_WALL_CLOCK_LIMIT_MS,
+	REPLAY_WRITE_OVERHEAD_BYTES,
 } from './replayLogsGuards.ts';
 import { purgeAgedLogs } from './auditStore.ts';
 import { get as envGet } from '../utility/environment/environmentManager.ts';
@@ -79,6 +81,13 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 		let lastTimestamp = 0;
 		let writes = 0;
 		let skipped = 0;
+		// Staged since the last commit, so the batch can be flushed before it exhausts heap
+		// (harper#2161). The byte figure is an estimate: each write is charged its audit entry size
+		// plus a fixed overhead for what the entry size can't see (the write operation, the key, the
+		// prior record entry it retains, index staging).
+		let stagedBytes = 0;
+		let stagedWrites = 0;
+		let midVersionFlushes = 0;
 		// Track forward progress so a backlog of unwritable entries can't grind the boot thread
 		// forever (harper#1266). `noProgressRun` counts every entry processed without a successful
 		// write since the last one — undecodable/corrupt skips AND entries for a dropped table — and
@@ -165,8 +174,18 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 					warnedReplayHappening = true;
 					console.warn('Harper was not properly shutdown, replaying transaction logs to synchronize database');
 				}
-				if (lastTimestamp !== version) {
+				// A new version always starts a new transaction; within a version, one is also started
+				// once the staged batch outgrows memory, which is the only bound on a version carrying
+				// a very large number of writes (harper#2161). Mid-version tearing is safe here and only
+				// here: replay restarts from the log's last-flushed position and re-applies in timestamp
+				// order, so a version torn by a crash between flushes is re-applied in full on the next
+				// boot.
+				const newVersion = lastTimestamp !== version;
+				if (newVersion || shouldFlushReplayBatch(stagedBytes, stagedWrites)) {
+					if (!newVersion) midVersionFlushes++;
 					lastTimestamp = version;
+					stagedBytes = 0;
+					stagedWrites = 0;
 					try {
 						// commit the last transaction since we are starting a new one
 						transaction?.directCommitSync();
@@ -176,13 +195,16 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 					// Abort if replay has exceeded the total wall-clock budget even while making progress
 					// (harper#1316, facet a). shouldAbortStalledReplay resets its counters on every write,
 					// so a slow-but-progressing replay (deep out-of-order audit chain walk per entry) can
-					// peg the boot thread indefinitely without tripping it. Checked only here, at a version
-					// boundary: the prior version's transaction was just committed in full and the new one
-					// is not yet staged, so aborting never tears a same-version (same source-transaction)
-					// write batch in half. Re-clone to recover the unreplayed remainder.
+					// peg the boot thread indefinitely without tripping it. Checked only at a commit point:
+					// what was staged has just been committed in full and nothing is staged yet, so the
+					// abort only ever cuts BETWEEN writes. A mid-version cut leaves a partially applied
+					// source transaction, which is why this used to be pinned to version boundaries — but a
+					// single version can be arbitrarily large, so pinning it there let one oversized version
+					// peg the boot thread with no bound at all. An aborted replay already requires a
+					// re-clone, so bounding it wins over the torn-transaction window it may leave.
 					if (shouldAbortSlowReplay(performance.now() - replayStartTime, replayTimeoutMs)) {
 						logger.fatal(
-							`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: replay has exceeded the wall-clock time limit (${writes} written, ${skipped} skipped). The transaction log contains a pathologically deep out-of-order write history that is too expensive to reconcile during boot (harper#1316). Re-clone this node from a healthy leader to recover the unreplayed data.`
+							`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: replay has exceeded the wall-clock time limit (${writes} written, ${skipped} skipped). The transaction log contains a pathologically deep out-of-order write history that is too expensive to reconcile during boot (harper#1316). Re-clone this node from a healthy leader to recover the unreplayed data; if the abort fell inside an oversized transaction, part of that transaction is applied and the rest is not.`
 						);
 						transaction = undefined as any; // already committed above; nothing staged for the new version
 						break;
@@ -200,6 +222,10 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 				context.transaction = transaction;
 				const options = { context, residencyId, nodeId, originatingOperation };
 				writes++;
+				// Charged before the write, not after it: a write that throws part-way has still staged
+				// whatever it got through, and that must count against the flush bound.
+				stagedBytes += (auditRecord.size ?? 0) + REPLAY_WRITE_OVERHEAD_BYTES;
+				stagedWrites++;
 				switch (type) {
 					case 'put':
 						tableInstance._writeUpdate(recordId, record, true, options);
@@ -289,6 +315,12 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 			logger.error('Error committing replay transaction', error);
 		}
 		if (writes > 0) logger.warn(`Replayed ${writes} records in ${(rootStore as any).databaseName} database`);
+		// Warn, like the replay summaries above it: the default log level is `warn`, and a node that
+		// is being diagnosed for a boot-time OOM loop is exactly where this line must not be invisible.
+		if (midVersionFlushes > 0)
+			logger.warn(
+				`Replay committed ${midVersionFlushes} intra-transaction batch(es) in ${(rootStore as any).databaseName} database: the log contains transactions too large to stage in memory as a single batch (harper#2161)`
+			);
 		if (skipped > 0)
 			logger.warn(
 				`Skipped ${skipped} unrecoverable audit entries in ${(rootStore as any).databaseName} database during replay`

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -28,10 +28,20 @@ let warnedReplayHappening = false;
 // version, while a missing one would let a later same-key write be dropped as a duplicate.
 const TORN_VERSION_KEY = Symbol.for('replay-torn-version');
 
-// Throws rather than defaulting: without this state replay cannot tell its own earlier write from a
-// re-delivered duplicate, and a store that cannot serve one key is not one to replay a log into.
-function readTornVersion(rootStore: RocksDatabase): number | undefined {
-	return (rootStore as any).getSync(TORN_VERSION_KEY) || undefined;
+// `unknown` rather than "nothing was torn": a read that failed cannot distinguish the two, and only
+// one of them is safe to assume. Replay then treats every version it applies as possibly torn, which
+// costs the identity-tie dedup for this boot; assuming the other way would drop a later same-key
+// write of a transaction that really was torn.
+function readTornVersion(rootStore: RocksDatabase): { version?: number; unknown?: boolean } {
+	try {
+		return { version: (rootStore as any).getSync(TORN_VERSION_KEY) || undefined };
+	} catch (error) {
+		logger.fatal(
+			'Could not read the replay torn-transaction marker; replaying as though every transaction were committed in pieces',
+			error
+		);
+		return { unknown: true };
+	}
 }
 
 function recordTornVersion(rootStore: RocksDatabase, version: number): boolean {
@@ -104,24 +114,18 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 		let lastTimestamp = 0;
 		let writes = 0;
 		let skipped = 0;
-		// Staged since the last commit, so the batch can be committed before it exhausts heap
-		// (harper#2161). The byte figure is an estimate: the audit entry's own size, the prior record
-		// each staged write retains, and a fixed per-write overhead for the rest (write operation,
-		// key, index staging).
+		// Staged since the last commit (harper#2161); the byte figure is an estimate.
 		let stagedBytes = 0;
 		let stagedWrites = 0;
 		let midVersionFlushes = 0;
 		let versionCommittedInPieces = false;
-		// The version a previous replay left committed in pieces, if any (see recordTornVersion): a durable
-		// fact rather than an assumption, so a replay that tore nothing keeps the identity-tie dedup for
-		// every version it applies.
-		const resumedTornVersion = readTornVersion(rootStore);
-		// Set by every path that leaves entries unread: the marker must outlive an aborted replay, since the
-		// rest of that source transaction is still to come.
+		// A durable fact rather than an assumption, so a replay that tore nothing keeps the identity-tie
+		// dedup for every version it applies.
+		const { version: resumedTornVersion, unknown: tornStateUnknown } = readTornVersion(rootStore);
+		// The marker must outlive an aborted replay: the rest of that source transaction is still to come.
 		let abortedReplay = false;
-		// True when what is about to be committed, or has just been committed, is only part of its source
-		// transaction — the state in which losing a batch, or dropping a later same-key write, tears it.
-		const committingVersionIsTorn = () => versionCommittedInPieces || lastTimestamp === resumedTornVersion;
+		const committingVersionIsTorn = () =>
+			versionCommittedInPieces || tornStateUnknown || lastTimestamp === resumedTornVersion;
 		// Track forward progress so a backlog of unwritable entries can't grind the boot thread
 		// forever (harper#1266). `noProgressRun` counts every entry processed without a successful
 		// write since the last one — undecodable/corrupt skips AND entries for a dropped table — and
@@ -222,7 +226,7 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 					// durable yet at this point, so failing to record it is still recoverable — but tearing
 					// the transaction without it is not: the next boot would resume inside the transaction
 					// with no way to tell its own earlier write from a duplicate.
-					if (!newVersion && !versionCommittedInPieces && version !== resumedTornVersion) {
+					if (!newVersion && !versionCommittedInPieces && !tornStateUnknown && version !== resumedTornVersion) {
 						if (!recordTornVersion(rootStore, version)) {
 							logger.fatal(
 								`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: an oversized transaction has to be committed in batches, and the marker recording that could not be written (${writes} written, ${skipped} skipped). Re-clone this node from a healthy leader to recover the unreplayed data.`
@@ -237,13 +241,9 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 						// commit what is staged; a new transaction is started below
 						transaction?.directCommitSync();
 					} catch (error) {
-						// The condition is "the transaction being committed was already committed in part",
-						// not "this is a mid-version commit": the batch that fails can equally be the last
-						// batch of a version torn earlier — by this run or by the run before it — reached at
-						// the version boundary. Continuing then boots the node with a hole punched through one
-						// source transaction: this batch is lost, the iterator never revisits it (replay
-						// restarts from the log's last-flushed position, which a failed commit does not
-						// rewind), and later versions land on top of the gap.
+						// Losing a batch of an already-torn transaction punches a hole through it: the iterator
+						// never revisits the batch (replay restarts from the log's last-flushed position, which
+						// a failed commit does not rewind) and later versions would land on top of the gap.
 						if (!newVersion || wasTorn) {
 							logger.fatal(
 								`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: a batch of an oversized transaction failed to commit (${writes} written, ${skipped} skipped). Continuing would apply later writes over writes that were never committed. Re-clone this node from a healthy leader to recover the unreplayed data.`,
@@ -288,7 +288,8 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 					// of it, or the run before it did — the log's last-flushed position is a commit boundary,
 					// so with batching it can fall inside a source transaction, and replay then resumes there.
 					// See DatabaseTransaction.partiallyCommitted.
-					transaction.partiallyCommitted = versionCommittedInPieces || version === resumedTornVersion;
+					transaction.partiallyCommitted =
+						versionCommittedInPieces || tornStateUnknown || version === resumedTornVersion;
 					// retries=1 routes operation.commit() through its retry path (no duplicate audit staging)
 					transaction.retries = 1;
 					// Explicit replay marker: skips schema validation (harper#1316) and makes save() stamp

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -21,6 +21,29 @@ import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 
 let warnedReplayHappening = false;
 
+// Records the source-transaction version that replay is committing in pieces, so the next boot knows
+// which version it may have resumed into (harper#2161). Written before the batch it describes and
+// cleared once that version has been applied in full, so the durable state errs toward "torn": a
+// spurious marker only widens the tie handling in DatabaseTransaction.partiallyCommitted for one
+// version, while a missing one would let a later same-key write be dropped as a duplicate.
+const TORN_VERSION_KEY = Symbol.for('replay-torn-version');
+
+function readTornVersion(rootStore: RocksDatabase): number | undefined {
+	try {
+		return (rootStore as any).getSync(TORN_VERSION_KEY) || undefined;
+	} catch (error) {
+		logger.warn('Could not read the replay torn-transaction marker', error);
+	}
+}
+
+function recordTornVersion(rootStore: RocksDatabase, version: number): void {
+	try {
+		(rootStore as any).putSync(TORN_VERSION_KEY, version);
+	} catch (error) {
+		logger.warn('Could not record the replay torn-transaction marker', error);
+	}
+}
+
 // True when `updated` would DROP shared structures relative to `existing` — for either the classic
 // array form or the {named, typed} Map form, and for a form change between the two. Shared
 // structures only ever grow (ids are stable and append-only), so a shorter replayed buffer is a
@@ -88,10 +111,15 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 		let stagedBytes = 0;
 		let stagedWrites = 0;
 		let midVersionFlushes = 0;
-		// The version being replayed has already had part of itself committed — by this run, or (for the
-		// version replay resumed into) by a previous interrupted one.
+		// The version being replayed has already had part of itself committed by THIS run.
 		let versionCommittedInPieces = false;
-		let resumedIntoVersion = true;
+		// The version a previous replay left committed in pieces, if any (see recordTornVersion): a durable
+		// fact rather than an assumption, so a replay that never tore anything keeps the identity-tie dedup
+		// for every version it applies.
+		const resumedTornVersion = readTornVersion(rootStore);
+		// True when what is about to be committed, or has just been committed, is only part of its source
+		// transaction — the state in which losing a batch, or dropping a later same-key write, tears it.
+		const committingVersionIsTorn = () => versionCommittedInPieces || lastTimestamp === resumedTornVersion;
 		// Track forward progress so a backlog of unwritable entries can't grind the boot thread
 		// forever (harper#1266). `noProgressRun` counts every entry processed without a successful
 		// write since the last one — undecodable/corrupt skips AND entries for a dropped table — and
@@ -186,17 +214,24 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 				// entry, so the batch overshoots the bound by at most the one write that crosses it.
 				const entryCost = (auditRecord.size ?? 0) + REPLAY_WRITE_OVERHEAD_BYTES;
 				if (newVersion || shouldFlushReplayBatch(stagedBytes + entryCost, stagedWrites + 1)) {
+					// Marked before the batch it describes is committed, so a crash between the two records a
+					// tear that did not happen rather than missing one that did.
+					if (!newVersion && !versionCommittedInPieces && version !== resumedTornVersion) {
+						recordTornVersion(rootStore, version);
+					}
+					const wasTorn = committingVersionIsTorn();
 					try {
-						// commit the last transaction since we are starting a new one
+						// commit what is staged; a new transaction is started below
 						transaction?.directCommitSync();
 					} catch (error) {
 						// The condition is "the transaction being committed was already committed in part",
-						// not "this is a mid-version commit": the batch that fails can equally be the LAST
-						// batch of a torn version, reached at the version boundary. Continuing then boots the
-						// node with a hole punched through one source transaction — this batch is lost, the
-						// iterator never revisits it (replay restarts from the log's last-flushed position,
-						// which a failed commit does not rewind), and later versions land on top of the gap.
-						if (!newVersion || versionCommittedInPieces) {
+						// not "this is a mid-version commit": the batch that fails can equally be the last
+						// batch of a version torn earlier — by this run or by the run before it — reached at
+						// the version boundary. Continuing then boots the node with a hole punched through one
+						// source transaction: this batch is lost, the iterator never revisits it (replay
+						// restarts from the log's last-flushed position, which a failed commit does not
+						// rewind), and later versions land on top of the gap.
+						if (!newVersion || wasTorn) {
 							logger.fatal(
 								`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: a batch of an oversized transaction failed to commit (${writes} written, ${skipped} skipped). Continuing would apply later writes over writes that were never committed. Re-clone this node from a healthy leader to recover the unreplayed data.`,
 								error
@@ -207,10 +242,9 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 						logger.error('Error committing replay transaction', error);
 					}
 					if (newVersion) {
+						// The version that just committed is whole again, so clear its marker.
+						if (wasTorn) recordTornVersion(rootStore, 0);
 						versionCommittedInPieces = false;
-						// lastTimestamp is still the previous version here, so a non-zero one means the version
-						// starting now is not the one replay resumed into.
-						if (lastTimestamp !== 0) resumedIntoVersion = false;
 					} else {
 						midVersionFlushes++;
 						versionCommittedInPieces = true;
@@ -235,12 +269,11 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 					transaction = new DatabaseTransaction();
 					transaction.db = primaryStore;
 					transaction.timestamp = version;
-					// This version can already be durable in part two ways: this run committed an earlier
-					// batch of it, or a previous interrupted run did and replay resumed at a position inside
-					// it — the log's last-flushed position is a commit boundary, and with batching a commit
-					// boundary can fall inside a source transaction. Only the version replay resumed into can
-					// be in the second state. See DatabaseTransaction.partiallyCommitted.
-					transaction.partiallyCommitted = versionCommittedInPieces || resumedIntoVersion;
+					// This version can already be durable in part two ways: this run committed an earlier batch
+					// of it, or the run before it did — the log's last-flushed position is a commit boundary,
+					// so with batching it can fall inside a source transaction, and replay then resumes there.
+					// See DatabaseTransaction.partiallyCommitted.
+					transaction.partiallyCommitted = versionCommittedInPieces || version === resumedTornVersion;
 					// retries=1 routes operation.commit() through its retry path (no duplicate audit staging)
 					transaction.retries = 1;
 					// Explicit replay marker: skips schema validation (harper#1316) and makes save() stamp
@@ -346,13 +379,16 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 				});
 			}
 		}
+		const lastVersionWasTorn = committingVersionIsTorn();
 		try {
 			transaction?.directCommitSync();
+			// Whatever was torn is whole again once its last batch commits.
+			if (lastVersionWasTorn) recordTornVersion(rootStore, 0);
 		} catch (error) {
 			// The last batch of a torn transaction failing here leaves that transaction durable in part,
 			// which the operator has to know about; a whole-transaction commit failing is the pre-existing
 			// all-or-nothing loss.
-			if (versionCommittedInPieces) {
+			if (lastVersionWasTorn) {
 				logger.fatal(
 					`Transaction-log replay in ${(rootStore as any).databaseName} database left an oversized transaction partially applied: its final batch failed to commit (${writes} written, ${skipped} skipped). Re-clone this node from a healthy leader to recover the unreplayed data.`,
 					error

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -28,19 +28,19 @@ let warnedReplayHappening = false;
 // version, while a missing one would let a later same-key write be dropped as a duplicate.
 const TORN_VERSION_KEY = Symbol.for('replay-torn-version');
 
+// Throws rather than defaulting: without this state replay cannot tell its own earlier write from a
+// re-delivered duplicate, and a store that cannot serve one key is not one to replay a log into.
 function readTornVersion(rootStore: RocksDatabase): number | undefined {
-	try {
-		return (rootStore as any).getSync(TORN_VERSION_KEY) || undefined;
-	} catch (error) {
-		logger.warn('Could not read the replay torn-transaction marker', error);
-	}
+	return (rootStore as any).getSync(TORN_VERSION_KEY) || undefined;
 }
 
-function recordTornVersion(rootStore: RocksDatabase, version: number): void {
+function recordTornVersion(rootStore: RocksDatabase, version: number): boolean {
 	try {
 		(rootStore as any).putSync(TORN_VERSION_KEY, version);
+		return true;
 	} catch (error) {
 		logger.warn('Could not record the replay torn-transaction marker', error);
+		return false;
 	}
 }
 
@@ -111,12 +111,14 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 		let stagedBytes = 0;
 		let stagedWrites = 0;
 		let midVersionFlushes = 0;
-		// The version being replayed has already had part of itself committed by THIS run.
 		let versionCommittedInPieces = false;
 		// The version a previous replay left committed in pieces, if any (see recordTornVersion): a durable
-		// fact rather than an assumption, so a replay that never tore anything keeps the identity-tie dedup
-		// for every version it applies.
+		// fact rather than an assumption, so a replay that tore nothing keeps the identity-tie dedup for
+		// every version it applies.
 		const resumedTornVersion = readTornVersion(rootStore);
+		// Set by every path that leaves entries unread: the marker must outlive an aborted replay, since the
+		// rest of that source transaction is still to come.
+		let abortedReplay = false;
 		// True when what is about to be committed, or has just been committed, is only part of its source
 		// transaction — the state in which losing a batch, or dropping a later same-key write, tears it.
 		const committingVersionIsTorn = () => versionCommittedInPieces || lastTimestamp === resumedTornVersion;
@@ -138,6 +140,7 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 				logger.fatal(
 					`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: ${noProgressRun} consecutive audit entries with no successful write (${skipped} skipped as unrecoverable, ${writes} replayed so far). This backlog is making no forward progress and was blocking startup (harper#1266) — typically a peer transaction log whose values reference unresolvable shared structures (harper#1163), or a backlog for a dropped table. Continuing boot without replaying the remainder; shed or relocate the oversized/undecodable peer transaction log(s), or re-clone this node, to recover the unreplayed data.`
 				);
+				abortedReplay = true;
 				break;
 			}
 			const {
@@ -215,9 +218,19 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 				const entryCost = (auditRecord.size ?? 0) + REPLAY_WRITE_OVERHEAD_BYTES;
 				if (newVersion || shouldFlushReplayBatch(stagedBytes + entryCost, stagedWrites + 1)) {
 					// Marked before the batch it describes is committed, so a crash between the two records a
-					// tear that did not happen rather than missing one that did.
+					// tear that did not happen rather than missing one that did. Nothing of this version is
+					// durable yet at this point, so failing to record it is still recoverable — but tearing
+					// the transaction without it is not: the next boot would resume inside the transaction
+					// with no way to tell its own earlier write from a duplicate.
 					if (!newVersion && !versionCommittedInPieces && version !== resumedTornVersion) {
-						recordTornVersion(rootStore, version);
+						if (!recordTornVersion(rootStore, version)) {
+							logger.fatal(
+								`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: an oversized transaction has to be committed in batches, and the marker recording that could not be written (${writes} written, ${skipped} skipped). Re-clone this node from a healthy leader to recover the unreplayed data.`
+							);
+							transaction = undefined as any;
+							abortedReplay = true;
+							break;
+						}
 					}
 					const wasTorn = committingVersionIsTorn();
 					try {
@@ -237,6 +250,7 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 								error
 							);
 							transaction = undefined as any;
+							abortedReplay = true;
 							break;
 						}
 						logger.error('Error committing replay transaction', error);
@@ -264,6 +278,7 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 							`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: replay has exceeded the wall-clock time limit (${writes} written, ${skipped} skipped). The transaction log contains a pathologically deep out-of-order write history that is too expensive to reconcile during boot (harper#1316). Re-clone this node from a healthy leader to recover the unreplayed data.`
 						);
 						transaction = undefined as any; // already committed above; nothing staged for the new version
+						abortedReplay = true;
 						break;
 					}
 					transaction = new DatabaseTransaction();
@@ -382,8 +397,10 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 		const lastVersionWasTorn = committingVersionIsTorn();
 		try {
 			transaction?.directCommitSync();
-			// Whatever was torn is whole again once its last batch commits.
-			if (lastVersionWasTorn) recordTornVersion(rootStore, 0);
+			// Only an iteration that ran to the end of the log leaves the torn transaction whole; every
+			// abort path above stops with entries of it unread, and this commit would otherwise no-op over
+			// a discarded transaction and clear the marker they exist to preserve.
+			if (lastVersionWasTorn && !abortedReplay) recordTornVersion(rootStore, 0);
 		} catch (error) {
 			// The last batch of a torn transaction failing here leaves that transaction durable in part,
 			// which the operator has to know about; a whole-transaction commit failing is the pre-existing

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -226,7 +226,10 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 					// durable yet at this point, so failing to record it is still recoverable — but tearing
 					// the transaction without it is not: the next boot would resume inside the transaction
 					// with no way to tell its own earlier write from a duplicate.
-					if (!newVersion && !versionCommittedInPieces && !tornStateUnknown && version !== resumedTornVersion) {
+					// Attempted even when the marker could not be READ: a failed read says nothing about
+					// whether it can be written, and skipping the write would leave the next boot with no
+					// record of this tear at all.
+					if (!newVersion && !versionCommittedInPieces && (tornStateUnknown || version !== resumedTornVersion)) {
 						if (!recordTornVersion(rootStore, version)) {
 							logger.fatal(
 								`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: an oversized transaction has to be committed in batches, and the marker recording that could not be written (${writes} written, ${skipped} skipped). Re-clone this node from a healthy leader to recover the unreplayed data.`

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -81,13 +81,17 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 		let lastTimestamp = 0;
 		let writes = 0;
 		let skipped = 0;
-		// Staged since the last commit, so the batch can be flushed before it exhausts heap
-		// (harper#2161). The byte figure is an estimate: each write is charged its audit entry size
-		// plus a fixed overhead for what the entry size can't see (the write operation, the key, the
-		// prior record entry it retains, index staging).
+		// Staged since the last commit, so the batch can be committed before it exhausts heap
+		// (harper#2161). The byte figure is an estimate: the audit entry's own size, the prior record
+		// each staged write retains, and a fixed per-write overhead for the rest (write operation,
+		// key, index staging).
 		let stagedBytes = 0;
 		let stagedWrites = 0;
 		let midVersionFlushes = 0;
+		// The version being replayed has already had part of itself committed — by this run, or (for the
+		// version replay resumed into) by a previous interrupted one.
+		let versionCommittedInPieces = false;
+		let resumedIntoVersion = true;
 		// Track forward progress so a backlog of unwritable entries can't grind the boot thread
 		// forever (harper#1266). `noProgressRun` counts every entry processed without a successful
 		// write since the last one — undecodable/corrupt skips AND entries for a dropped table — and
@@ -174,37 +178,56 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 					warnedReplayHappening = true;
 					console.warn('Harper was not properly shutdown, replaying transaction logs to synchronize database');
 				}
-				// A new version always starts a new transaction; within a version, one is also started
-				// once the staged batch outgrows memory, which is the only bound on a version carrying
-				// a very large number of writes (harper#2161). Mid-version tearing is safe here and only
-				// here: replay restarts from the log's last-flushed position and re-applies in timestamp
-				// order, so a version torn by a crash between flushes is re-applied in full on the next
-				// boot.
 				const newVersion = lastTimestamp !== version;
-				if (newVersion || shouldFlushReplayBatch(stagedBytes, stagedWrites)) {
-					if (!newVersion) midVersionFlushes++;
-					lastTimestamp = version;
-					stagedBytes = 0;
-					stagedWrites = 0;
+				// A version's writes all stage into one transaction, so a version carrying a very large
+				// number of them has no memory bound at all (harper#2161). Committing mid-version is safe
+				// for replay, and only for replay: what a crash leaves torn is re-applied on the next boot,
+				// from the log's last-flushed position and in timestamp order. The decision includes this
+				// entry, so the batch overshoots the bound by at most the one write that crosses it.
+				const entryCost = (auditRecord.size ?? 0) + REPLAY_WRITE_OVERHEAD_BYTES;
+				if (newVersion || shouldFlushReplayBatch(stagedBytes + entryCost, stagedWrites + 1)) {
 					try {
 						// commit the last transaction since we are starting a new one
 						transaction?.directCommitSync();
 					} catch (error) {
+						// The condition is "the transaction being committed was already committed in part",
+						// not "this is a mid-version commit": the batch that fails can equally be the LAST
+						// batch of a torn version, reached at the version boundary. Continuing then boots the
+						// node with a hole punched through one source transaction — this batch is lost, the
+						// iterator never revisits it (replay restarts from the log's last-flushed position,
+						// which a failed commit does not rewind), and later versions land on top of the gap.
+						if (!newVersion || versionCommittedInPieces) {
+							logger.fatal(
+								`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: a batch of an oversized transaction failed to commit (${writes} written, ${skipped} skipped). Continuing would apply later writes over writes that were never committed. Re-clone this node from a healthy leader to recover the unreplayed data.`,
+								error
+							);
+							transaction = undefined as any;
+							break;
+						}
 						logger.error('Error committing replay transaction', error);
 					}
+					if (newVersion) {
+						versionCommittedInPieces = false;
+						// lastTimestamp is still the previous version here, so a non-zero one means the version
+						// starting now is not the one replay resumed into.
+						if (lastTimestamp !== 0) resumedIntoVersion = false;
+					} else {
+						midVersionFlushes++;
+						versionCommittedInPieces = true;
+					}
+					lastTimestamp = version;
+					stagedBytes = 0;
+					stagedWrites = 0;
 					// Abort if replay has exceeded the total wall-clock budget even while making progress
 					// (harper#1316, facet a). shouldAbortStalledReplay resets its counters on every write,
 					// so a slow-but-progressing replay (deep out-of-order audit chain walk per entry) can
-					// peg the boot thread indefinitely without tripping it. Checked only at a commit point:
-					// what was staged has just been committed in full and nothing is staged yet, so the
-					// abort only ever cuts BETWEEN writes. A mid-version cut leaves a partially applied
-					// source transaction, which is why this used to be pinned to version boundaries — but a
-					// single version can be arbitrarily large, so pinning it there let one oversized version
-					// peg the boot thread with no bound at all. An aborted replay already requires a
-					// re-clone, so bounding it wins over the torn-transaction window it may leave.
-					if (shouldAbortSlowReplay(performance.now() - replayStartTime, replayTimeoutMs)) {
+					// peg the boot thread indefinitely without tripping it. Checked only at a version
+					// boundary: the prior version's transaction was just committed in full and the new one
+					// is not yet staged, so aborting never tears a same-version (same source-transaction)
+					// write batch in half. Re-clone to recover the unreplayed remainder.
+					if (newVersion && shouldAbortSlowReplay(performance.now() - replayStartTime, replayTimeoutMs)) {
 						logger.fatal(
-							`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: replay has exceeded the wall-clock time limit (${writes} written, ${skipped} skipped). The transaction log contains a pathologically deep out-of-order write history that is too expensive to reconcile during boot (harper#1316). Re-clone this node from a healthy leader to recover the unreplayed data; if the abort fell inside an oversized transaction, part of that transaction is applied and the rest is not.`
+							`Aborting transaction-log replay in ${(rootStore as any).databaseName} database: replay has exceeded the wall-clock time limit (${writes} written, ${skipped} skipped). The transaction log contains a pathologically deep out-of-order write history that is too expensive to reconcile during boot (harper#1316). Re-clone this node from a healthy leader to recover the unreplayed data.`
 						);
 						transaction = undefined as any; // already committed above; nothing staged for the new version
 						break;
@@ -212,6 +235,12 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 					transaction = new DatabaseTransaction();
 					transaction.db = primaryStore;
 					transaction.timestamp = version;
+					// This version can already be durable in part two ways: this run committed an earlier
+					// batch of it, or a previous interrupted run did and replay resumed at a position inside
+					// it — the log's last-flushed position is a commit boundary, and with batching a commit
+					// boundary can fall inside a source transaction. Only the version replay resumed into can
+					// be in the second state. See DatabaseTransaction.partiallyCommitted.
+					transaction.partiallyCommitted = versionCommittedInPieces || resumedIntoVersion;
 					// retries=1 routes operation.commit() through its retry path (no duplicate audit staging)
 					transaction.retries = 1;
 					// Explicit replay marker: skips schema validation (harper#1316) and makes save() stamp
@@ -224,8 +253,9 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 				writes++;
 				// Charged before the write, not after it: a write that throws part-way has still staged
 				// whatever it got through, and that must count against the flush bound.
-				stagedBytes += (auditRecord.size ?? 0) + REPLAY_WRITE_OVERHEAD_BYTES;
+				stagedBytes += entryCost;
 				stagedWrites++;
+				const writesBefore = transaction.writes.length;
 				switch (type) {
 					case 'put':
 						tableInstance._writeUpdate(recordId, record, true, options);
@@ -294,6 +324,13 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 						// saveStructures, which would set structureUpdate and re-log the structure during replay.
 					}
 				}
+				// The prior record each staged write read and holds for the life of the transaction
+				// (DatabaseTransaction.save()) is invisible to the audit entry's own size, and for a
+				// patch or delete of a wide record it is the dominant allocation — an update-shaped
+				// oversized transaction would otherwise reach the write bound holding gigabytes.
+				for (let i = writesBefore; i < transaction.writes.length; i++) {
+					stagedBytes += transaction.writes[i]?.entry?.size ?? 0;
+				}
 				// Forward progress: a write was staged successfully, so reset the no-progress
 				// trackers. Doing this AFTER the switch (not before) means a slow or throwing
 				// write is neither counted as progress nor charged to the stall bound (harper#1266).
@@ -312,11 +349,19 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 		try {
 			transaction?.directCommitSync();
 		} catch (error) {
-			logger.error('Error committing replay transaction', error);
+			// The last batch of a torn transaction failing here leaves that transaction durable in part,
+			// which the operator has to know about; a whole-transaction commit failing is the pre-existing
+			// all-or-nothing loss.
+			if (versionCommittedInPieces) {
+				logger.fatal(
+					`Transaction-log replay in ${(rootStore as any).databaseName} database left an oversized transaction partially applied: its final batch failed to commit (${writes} written, ${skipped} skipped). Re-clone this node from a healthy leader to recover the unreplayed data.`,
+					error
+				);
+			} else {
+				logger.error('Error committing replay transaction', error);
+			}
 		}
 		if (writes > 0) logger.warn(`Replayed ${writes} records in ${(rootStore as any).databaseName} database`);
-		// Warn, like the replay summaries above it: the default log level is `warn`, and a node that
-		// is being diagnosed for a boot-time OOM loop is exactly where this line must not be invisible.
 		if (midVersionFlushes > 0)
 			logger.warn(
 				`Replay committed ${midVersionFlushes} intra-transaction batch(es) in ${(rootStore as any).databaseName} database: the log contains transactions too large to stage in memory as a single batch (harper#2161)`

--- a/resources/replayLogs.ts
+++ b/resources/replayLogs.ts
@@ -259,8 +259,11 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 						logger.error('Error committing replay transaction', error);
 					}
 					if (newVersion) {
-						// The version that just committed is whole again, so clear its marker.
-						if (wasTorn) recordTornVersion(rootStore, 0);
+						// Only a version that actually committed is whole again. Without the transaction check,
+						// the no-op commit at the FIRST entry of a run — nothing is staged yet — would clear the
+						// marker before this boot has replayed anything, and with an unreadable marker (every
+						// version reads as torn) that discards the record of a real tear from the run before.
+						if (wasTorn && transaction) recordTornVersion(rootStore, 0);
 						versionCommittedInPieces = false;
 					} else {
 						midVersionFlushes++;
@@ -404,7 +407,7 @@ export function replayLogs(rootStore: RocksDatabase, tables: any): Promise<void>
 			// Only an iteration that ran to the end of the log leaves the torn transaction whole; every
 			// abort path above stops with entries of it unread, and this commit would otherwise no-op over
 			// a discarded transaction and clear the marker they exist to preserve.
-			if (lastVersionWasTorn && !abortedReplay) recordTornVersion(rootStore, 0);
+			if (lastVersionWasTorn && !abortedReplay && transaction) recordTornVersion(rootStore, 0);
 		} catch (error) {
 			// The last batch of a torn transaction failing here leaves that transaction durable in part,
 			// which the operator has to know about; a whole-transaction commit failing is the pre-existing

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -131,30 +131,22 @@ export function shouldAbortSlowReplay(totalElapsedMs: number, timeLimitMs = REPL
 	return totalElapsedMs >= timeLimitMs;
 }
 
-// Replay commits its DatabaseTransaction at a version boundary, so every write belonging to one
-// source transaction stages into a single in-memory batch (JS write operations plus the native
-// write batch). A version carrying a very large number of writes — a bulk load, or a peer
-// transaction replicated as one version — therefore has no bound at all, and exhausts heap before
-// any of the guards above can fire: they are progress- and time-based, and a replay that is happily
-// writing its way to an OOM trips neither. The process then dies mid-replay and the next boot
-// restarts the same replay, so the node never boots (harper#2161).
-//
-// Flushing mid-version is safe for REPLAY specifically (it is not for a live write, which has no
-// second chance): a torn version is re-applied in full on the next boot, because replay always
-// restarts from the log's last-flushed position and re-applies entries in timestamp order, which
-// is idempotent.
+// The guards above are progress- and time-based, so neither fires on a replay that is writing its
+// way to an OOM: every write of one source transaction stages into a single in-memory batch, and a
+// version carrying a very large number of writes has no bound at all. The process dies mid-replay
+// and the next boot restarts the same replay, so the node never boots (harper#2161). These bounds
+// are what lets replay commit that batch in pieces.
 
-// Estimated staged bytes before replay flushes mid-version. Deliberately far below any realistic
-// heap: the estimate below undercounts (it charges the audit entry, not the prior record entry each
-// write also retains), and a sync commit of a batch this size costs milliseconds, so there is no
-// reason to run closer to the edge.
+// Estimated staged bytes before replay commits mid-version. Deliberately far below any realistic
+// heap: the estimate is approximate, and a sync commit of a batch this size costs milliseconds.
 export const REPLAY_MAX_STAGED_BYTES = 32 * 1024 * 1024;
 
-// Staged write count bound, for the case the byte bound can't see: millions of tiny records whose
-// per-write JS overhead (write operation, key, retained entry, index staging) dwarfs their value.
+// Also bound the write count, for the shape the byte bound reads as small: many tiny records whose
+// per-write JS overhead dwarfs their value.
 export const REPLAY_MAX_STAGED_WRITES = 10_000;
 
-// Charged per staged write on top of the audit entry's own size, for that per-write overhead.
+// Charged per staged write for what neither the audit entry nor the retained prior record covers:
+// the write operation, the encoded key, index staging.
 export const REPLAY_WRITE_OVERHEAD_BYTES = 256;
 
 /**

--- a/resources/replayLogsGuards.ts
+++ b/resources/replayLogsGuards.ts
@@ -131,6 +131,48 @@ export function shouldAbortSlowReplay(totalElapsedMs: number, timeLimitMs = REPL
 	return totalElapsedMs >= timeLimitMs;
 }
 
+// Replay commits its DatabaseTransaction at a version boundary, so every write belonging to one
+// source transaction stages into a single in-memory batch (JS write operations plus the native
+// write batch). A version carrying a very large number of writes — a bulk load, or a peer
+// transaction replicated as one version — therefore has no bound at all, and exhausts heap before
+// any of the guards above can fire: they are progress- and time-based, and a replay that is happily
+// writing its way to an OOM trips neither. The process then dies mid-replay and the next boot
+// restarts the same replay, so the node never boots (harper#2161).
+//
+// Flushing mid-version is safe for REPLAY specifically (it is not for a live write, which has no
+// second chance): a torn version is re-applied in full on the next boot, because replay always
+// restarts from the log's last-flushed position and re-applies entries in timestamp order, which
+// is idempotent.
+
+// Estimated staged bytes before replay flushes mid-version. Deliberately far below any realistic
+// heap: the estimate below undercounts (it charges the audit entry, not the prior record entry each
+// write also retains), and a sync commit of a batch this size costs milliseconds, so there is no
+// reason to run closer to the edge.
+export const REPLAY_MAX_STAGED_BYTES = 32 * 1024 * 1024;
+
+// Staged write count bound, for the case the byte bound can't see: millions of tiny records whose
+// per-write JS overhead (write operation, key, retained entry, index staging) dwarfs their value.
+export const REPLAY_MAX_STAGED_WRITES = 10_000;
+
+// Charged per staged write on top of the audit entry's own size, for that per-write overhead.
+export const REPLAY_WRITE_OVERHEAD_BYTES = 256;
+
+/**
+ * Whether replay should commit and restart its transaction mid-version because the staged batch has
+ * grown past what may be held in memory (harper#2161).
+ *
+ * @param stagedBytes  estimated bytes staged since the last commit
+ * @param stagedWrites writes staged since the last commit
+ */
+export function shouldFlushReplayBatch(
+	stagedBytes: number,
+	stagedWrites: number,
+	byteLimit = REPLAY_MAX_STAGED_BYTES,
+	writeLimit = REPLAY_MAX_STAGED_WRITES
+): boolean {
+	return stagedBytes >= byteLimit || stagedWrites >= writeLimit;
+}
+
 /**
  * Wraps a transaction-log query iterator so a corrupt/torn frame ends that log's iteration
  * cleanly instead of escaping as an uncaughtException. rocksdb-js throws a bounded RangeError

--- a/unitTests/resources/replayLogs.test.js
+++ b/unitTests/resources/replayLogs.test.js
@@ -13,6 +13,10 @@ const {
 	REPLAY_NO_PROGRESS_TIME_SKIP_FLOOR,
 	shouldAbortSlowReplay,
 	REPLAY_WALL_CLOCK_LIMIT_MS,
+	shouldFlushReplayBatch,
+	REPLAY_MAX_STAGED_BYTES,
+	REPLAY_MAX_STAGED_WRITES,
+	REPLAY_WRITE_OVERHEAD_BYTES,
 } = require('#src/resources/replayLogsGuards');
 
 // Regression tests for the unclean-shutdown replay guards. Without these, an audit log
@@ -302,5 +306,34 @@ describe('shouldAbortSlowReplay', () => {
 		// shouldAbortSlowReplay fires purely on total elapsed time — writes or not.
 		assert.strictEqual(shouldAbortSlowReplay(5000, 1000), true);
 		assert.strictEqual(shouldAbortSlowReplay(500, 1000), false);
+	});
+});
+
+describe('shouldFlushReplayBatch', () => {
+	it('exposes bounds well below any realistic heap', () => {
+		assert.strictEqual(REPLAY_MAX_STAGED_BYTES, 32 * 1024 * 1024);
+		assert.strictEqual(REPLAY_MAX_STAGED_WRITES, 10_000);
+		assert.strictEqual(REPLAY_WRITE_OVERHEAD_BYTES, 256);
+	});
+
+	it('does not flush a batch below both bounds', () => {
+		assert.strictEqual(shouldFlushReplayBatch(0, 0), false);
+		assert.strictEqual(shouldFlushReplayBatch(REPLAY_MAX_STAGED_BYTES - 1, REPLAY_MAX_STAGED_WRITES - 1), false);
+	});
+
+	it('flushes on the byte bound alone (few, very large records)', () => {
+		assert.strictEqual(shouldFlushReplayBatch(REPLAY_MAX_STAGED_BYTES, 1), true);
+		assert.strictEqual(shouldFlushReplayBatch(REPLAY_MAX_STAGED_BYTES + 1, 1), true);
+	});
+
+	it('flushes on the write bound alone (many tiny records whose overhead the bytes miss)', () => {
+		assert.strictEqual(shouldFlushReplayBatch(0, REPLAY_MAX_STAGED_WRITES), true);
+		assert.strictEqual(shouldFlushReplayBatch(0, REPLAY_MAX_STAGED_WRITES + 1), true);
+	});
+
+	it('honors caller-supplied bounds (used to keep unit tests fast/deterministic)', () => {
+		assert.strictEqual(shouldFlushReplayBatch(999, 9, 1000, 10), false);
+		assert.strictEqual(shouldFlushReplayBatch(1000, 9, 1000, 10), true);
+		assert.strictEqual(shouldFlushReplayBatch(999, 10, 1000, 10), true);
 	});
 });


### PR DESCRIPTION
Fixes #2161.

Boot transaction-log replay committed and recreated its `DatabaseTransaction` only when the entry's
version changed, so every write belonging to one source transaction staged into a single in-memory
batch — the JS write operations (each retaining the prior record it read) plus the native write
batch — with no bound at all. A version carrying a very large number of writes (a bulk load, or a
peer transaction replicated as one version) therefore exhausted heap mid-replay. Because the process
died during replay, the next boot restarted the same replay and died again: a boot loop with no
forward progress and no self-recovery.

The existing replay guards cannot catch this. `shouldAbortStalledReplay` resets on every successful
write and `shouldAbortSlowReplay` is wall-clock, so a replay writing its way to an OOM trips neither.

## What changed

**The bound.** `shouldFlushReplayBatch` bounds the staged batch by estimated bytes (32 MB) or staged
writes (10,000); replay commits and starts a new transaction when either is crossed, not only at a
version boundary. The decision includes the entry about to be staged, so the batch overshoots by at
most the write that crosses it. Bytes are charged as the audit entry's own size, plus the prior
record each staged write retains (the dominant allocation for a patch/delete-shaped transaction, and
invisible to the audit entry's size), plus a fixed per-write overhead.

Committing in pieces is safe for **replay** specifically: what a crash leaves torn is re-applied on
the next boot, from the log's last-flushed position and in timestamp order.

**Same-key program order (`DatabaseTransaction.partiallyCommitted`).** Starting a new transaction
drops the per-key staged-write chain, which is what tells the write path that a later write to a key
already written in this transaction is program order rather than a re-delivered duplicate. After a
commit the earlier write is durable and ties the later one on (version, nodeId), so the later write
falls into the out-of-order/dedup block — where the keyed audit lookup can set `write.skipped = true`
and silently drop it. The flag says the source transaction is already durable in part, and the three
tie-sensitive paths (update/patch, invalidate, relocate) then read the tie as program order. Delete
already applied on a tie.

The basis: entries at or after the log's last-flushed position were not flushed, and RocksDB's own
WAL is off, so a replayed entry's write is not durable — the tie can only be an *earlier* entry of
the same transaction.

**Knowing which transaction is torn.** A version can also be durable in part because a *previous*
interrupted replay committed a batch of it: `databaseFlushed()` in rocksdb-js records the flushed
position from the last **commit** covered by a memtable flush, so once replay batches, that position
can fall inside a source transaction and replay resumes there. Replay therefore records the version
it is tearing in the root store — before the batch it describes, cleared once that version is applied
in full — so a boot that tore nothing keeps the identity-tie dedup for every version it applies. The
marker fails closed: if it cannot be written, replay aborts rather than tearing a transaction it
cannot mark; if it cannot be read, replay treats every version as possibly torn for that boot.

**Failure paths.** A commit that fails for a transaction already committed in part now aborts replay,
rather than applying later writes over writes that were never committed — and the marker survives
every abort path, since the rest of that transaction is still to come. The wall-clock abort (#1316)
goes back to version boundaries only, so a timeout can still only cut between source transactions.

## For the human reviewer

- **The dedup bypass is the judgment call.** `partiallyCommitted` skips the keyed audit dedup for
  equal-version, same-node ties on the versions it covers. The WAL-off argument above says such a tie
  can only be this transaction's own earlier write. The **residual**: in the window where a memtable
  flush completed but its position has not been recorded yet, replay can re-apply an entry that *is*
  durable — idempotent for put/delete/invalidate/relocate, but a commutative patch would fold twice.
  Reviewers raised this three rounds running; I scoped it as tightly as I could find a way to (torn
  versions only, known from the durable marker) rather than eliminating it.
- **The marker is new durable state.** One root-store symbol key, written only when an oversized
  transaction is being torn. A stale marker (crash after the final commit, before the clear) is
  conservative — it only widens tie handling for one exact version that will never recur.
- **Mid-version tearing itself.** The alternative is keeping replayed transactions atomic and
  bounding memory another way, or refusing to replay an oversized version. A node that booted torn
  cannot be un-torn — but with the current code that node does not boot at all.
- **The deeper fix the issue also suggests** — a durable replay *cursor*, so a killed replay resumes
  instead of restarting — would make the marker and the tie widening unnecessary. Worth a follow-up
  issue if you agree; I kept this change to the memory bound and what it forces.
- **The bounds are constants, not config**, and the byte figure is an estimate over encoded sizes
  while the heap holds decoded objects. The write bound is the backstop.

## Verification

- Unit: `test:unit:main`, `test:unit:resources` — new `shouldFlushReplayBatch` cases pass. Four
  pre-existing failures on this machine are unchanged by this branch and reproduce with base sources
  built (`replayStructures.test.js` composite-key, two `databases.test.js` `randomAccessFields`
  cases, `deploymentRecorder.test.js` transaction context).
- Integration (end-to-end route): new `integrationTests/server/replay-large-transaction.test.ts` —
  three crash/replay cycles over 25,000-write single transactions: every record replays, a key
  written twice in one transaction replays to its last value, and the same for a patch. The first
  **fails on base** (base sources rebuilt and rerun: no mid-version commit is reported).
- `crash-replay`, `replay-stress`, `blob`, `transactions`, `ttl` suites pass. The full
  `test:integration:all` run on this machine has many unrelated failures (suite-level 60s timeouts
  under local CPU contention); every failing suite that touches this change passes in isolation. CI
  is the gate.
- I confirmed the mechanism and the fix by instrumenting `resources/Table.ts`: pre-fix, the repeated
  key enters the tie path (`precedes=0 priorStaged=false`) and survives only because the best-effort
  keyed dedup missed; post-fix it never enters that path. The marker's write/clear round-trip was
  verified the same way.
- **Not covered by tests**: the OOM itself (needs a heap-constrained run over GB-scale logs), a crash
  *between* two replay batches, marker I/O failure, and the invalidate/relocate tie paths. The marker
  lifecycle is the crash-safety mechanism here and it has no automated coverage — the honest gap in
  this PR.

## Review coverage

Pre-push cross-model review (`prepush-review.mjs`), five rounds: **Codex** (graded), **Gemini**,
**Cursor Composer** (rounds 1–2, then Cursor round cap), **Harper domain adjudication**. Every round
found something real, and each one is fixed above: round 1's same-key blocker (which the domain leg
dropped as pre-existing — I traced the code, instrumented the build, and it was not); round 2's
version-scoped flag, `!newVersion` commit guard and public-`Context` placement; round 3's "assume
every replay is torn" default, which is what produced the durable marker; round 4's marker
fail-closed and abort-path clearing. The resume-inside-a-transaction question was settled by reading
the rocksdb-js implementation rather than assuming it.

Two findings are carried into this PR rather than fixed: the transaction-wide tie widening (the first
bullet above — the reviewers and I disagree on how reachable the residual is, so it is stated for you
to rule on) and the missing marker-lifecycle tests. The final commit is a one-line fix for a round-5
finding (persist the marker even when it could not be read) made after that review ran; no leg has
seen that commit.

<sub>Human-Review-Need: 4 @ 6e70fe49d57a</sub>
