### PR TITLE
Fix deployment ingest transaction-context test

### DIFF
--- a/unitTests/components/deploymentRecorder.test.js
+++ b/unitTests/components/deploymentRecorder.test.js
@@ -519,6 +519,7 @@ describe('DeploymentRecorder.ingestPayload transaction context', () => {
 		assert.strictEqual(ambientContext.transaction, ambientTransaction);
 		assert.strictEqual(ambientTransaction.timeoutBudget, undefined);
 		assert.strictEqual(writeContexts.length, 2);
+		assert.strictEqual(writeContexts[0].transactionTimeoutBudget, 0);
 		assert.ok(writeContexts.every((context) => context.transaction));
 		assert.notStrictEqual(writeContexts[0].transaction, writeContexts[1].transaction);
 		assert.ok(writeContexts.every((context) => context.transaction !== ambientTransaction));

--- a/unitTests/components/deploymentRecorder.test.js
+++ b/unitTests/components/deploymentRecorder.test.js
@@ -504,6 +504,7 @@ describe('DeploymentRecorder.ingestPayload transaction context', () => {
 			installed.restore();
 		}
 
+		assert.ok(ingestContext);
 		assert.strictEqual(ingestContext.user, user);
 		assert.strictEqual(ingestContext.originatingOperation, 'deploy_component');
 		assert.strictEqual(ingestContext.session, session);

--- a/unitTests/components/deploymentRecorder.test.js
+++ b/unitTests/components/deploymentRecorder.test.js
@@ -483,7 +483,11 @@ describe('DeploymentRecorder.ingestPayload transaction context', () => {
 		const writeContexts = [];
 		const installed = installMockDeploymentTable();
 		installed.mock.put = async (row) => {
-			const writeContext = { ...contextStorage.getStore() };
+			const context = contextStorage.getStore();
+			const writeContext = {
+				...context,
+				transactionTimeoutBudget: context?.transaction?.timeoutBudget,
+			};
 			writeContexts.push(writeContext);
 			if (row.payload_blob) {
 				ingestContext = writeContext;
@@ -506,13 +510,14 @@ describe('DeploymentRecorder.ingestPayload transaction context', () => {
 		assert.strictEqual(ingestContext.signal, signal);
 		assert.ok(ingestContext.transaction);
 		assert.notStrictEqual(ingestContext.transaction, ambientTransaction);
-		assert.strictEqual(ingestContext.transaction.timeoutBudget, configuredBudget);
+		assert.strictEqual(ingestContext.transactionTimeoutBudget, ingestTransactionTimeoutMs(configuredBudget));
 		assert.strictEqual(ingestContext.isExplicit, undefined);
 		assert.strictEqual(ingestContext.authorize, undefined);
 		assert.strictEqual(ingestContext.timestamp, undefined);
 		assert.strictEqual(ingestContext.sourceApply, undefined);
 		assert.strictEqual(ingestContext.replicatedConfirmation, undefined);
 		assert.strictEqual(ambientContext.transaction, ambientTransaction);
+		assert.strictEqual(ambientTransaction.timeoutBudget, undefined);
 		assert.strictEqual(writeContexts.length, 2);
 		assert.ok(writeContexts.every((context) => context.transaction));
 		assert.ok(writeContexts.every((context) => context.transaction !== ambientTransaction));

--- a/unitTests/components/deploymentRecorder.test.js
+++ b/unitTests/components/deploymentRecorder.test.js
@@ -483,9 +483,10 @@ describe('DeploymentRecorder.ingestPayload transaction context', () => {
 		const writeContexts = [];
 		const installed = installMockDeploymentTable();
 		installed.mock.put = async (row) => {
-			writeContexts.push(contextStorage.getStore());
+			const writeContext = { ...contextStorage.getStore() };
+			writeContexts.push(writeContext);
 			if (row.payload_blob) {
-				ingestContext = contextStorage.getStore();
+				ingestContext = writeContext;
 			}
 			installed.mock.rows.set(row.deployment_id, row);
 		};
@@ -503,6 +504,7 @@ describe('DeploymentRecorder.ingestPayload transaction context', () => {
 		assert.strictEqual(ingestContext.originatingOperation, 'deploy_component');
 		assert.strictEqual(ingestContext.session, session);
 		assert.strictEqual(ingestContext.signal, signal);
+		assert.ok(ingestContext.transaction);
 		assert.notStrictEqual(ingestContext.transaction, ambientTransaction);
 		assert.strictEqual(ingestContext.transaction.timeoutBudget, configuredBudget);
 		assert.strictEqual(ingestContext.isExplicit, undefined);
@@ -512,6 +514,7 @@ describe('DeploymentRecorder.ingestPayload transaction context', () => {
 		assert.strictEqual(ingestContext.replicatedConfirmation, undefined);
 		assert.strictEqual(ambientContext.transaction, ambientTransaction);
 		assert.strictEqual(writeContexts.length, 2);
+		assert.ok(writeContexts.every((context) => context.transaction));
 		assert.ok(writeContexts.every((context) => context.transaction !== ambientTransaction));
 	});
 

--- a/unitTests/components/deploymentRecorder.test.js
+++ b/unitTests/components/deploymentRecorder.test.js
@@ -520,6 +520,7 @@ describe('DeploymentRecorder.ingestPayload transaction context', () => {
 		assert.strictEqual(ambientTransaction.timeoutBudget, undefined);
 		assert.strictEqual(writeContexts.length, 2);
 		assert.ok(writeContexts.every((context) => context.transaction));
+		assert.notStrictEqual(writeContexts[0].transaction, writeContexts[1].transaction);
 		assert.ok(writeContexts.every((context) => context.transaction !== ambientTransaction));
 	});
 


### PR DESCRIPTION
Snapshot the deployment-recorder ALS context at the mocked payload write boundary so the test validates the isolated transaction before final commit cleanup clears its context reference. The test now also guards the payload-only timeout budget, audit-field propagation, and isolation from the caller and creation transactions.

## For the human reviewer

1. This is intentionally a test-only repair: `DatabaseTransaction.releaseContext()` clearing `context.transaction` after commit is documented memory hygiene, while the write-time transaction contract traces correctly through `withIsolatedTransaction()`. The reversible alternative is a product change that would retain a completed transaction solely for a test, which would reintroduce retention on a shared write path.
2. Streaming ingest-budget coverage is not included because this lightweight table mock bypasses blob persistence; the focused repair fixes the deterministic Buffer-path assertion failure, while resource transaction tests cover the storage-side budget mechanics.

## Verification

`npm run build`; `npx mocha unitTests/components/deploymentRecorder.test.js` (51 passing); `npm run lint:required`. The canonical `npm run test:unit:all` was also run locally under Node 26; CI will run its Node 22/24/26 matrix.

## Review coverage

Authored by GPT-5 Codex. Cross-model review: Claude ✓; Gemini ✗ (no output); final full round also included Cursor Composer ✓ and Harper-domain adjudication ✓. Receipt @ 8d70dd251.

Co-Authored-By: GPT-5 Codex <noreply@openai.com>
Generated by Codex

<sub>Human-Review-Need: 3 @ 8d70dd2511d4</sub>
