### PR TITLE
Prevent job wedges on runtime database opens

### DIFF
--- a/dataLayer/harperBridge/ResourceBridge.ts
+++ b/dataLayer/harperBridge/ResourceBridge.ts
@@ -4,13 +4,10 @@ import { table, getDatabases, database, dropDatabase, type Table } from '../../r
 import insertUpdateValidate from './bridgeUtility/insertUpdateValidate.js';
 import SearchObject from '../SearchObject.ts';
 import {
-	OPERATIONS_ENUM,
 	VALUE_SEARCH_COMPARATORS,
 	VALUE_SEARCH_COMPARATORS_REVERSE_LOOKUP,
 	READ_AUDIT_LOG_SEARCH_TYPES_ENUM,
 } from '../../utility/hdbTerms.ts';
-import * as signalling from '../../utility/signalling.ts';
-import { SchemaEventMsg } from '../../server/threads/itc.js';
 import { asyncSetTimeout } from '../../utility/common_utils.ts';
 import { transaction } from '../../resources/transaction.ts';
 import type {
@@ -179,14 +176,10 @@ export class ResourceBridge extends BridgeMethods {
 			database: createSchemaObj.schema,
 			table: null,
 		});
-		return signalling.signalSchemaChange(
-			new SchemaEventMsg(process.pid, OPERATIONS_ENUM.CREATE_SCHEMA, createSchemaObj.schema)
-		);
 	}
 
 	async dropSchema(dropSchemaObj) {
 		await dropDatabase(dropSchemaObj.schema);
-		signalling.signalSchemaChange(new SchemaEventMsg(process.pid, OPERATIONS_ENUM.DROP_SCHEMA, dropSchemaObj.schema));
 	}
 
 	async updateRecords(updateObj) {

--- a/dataLayer/restoreMarker.ts
+++ b/dataLayer/restoreMarker.ts
@@ -51,6 +51,7 @@ import { tryFileLock, fileLockRelease } from '@harperfast/rocksdb-js';
 export const RESTORE_META_DIR = '`restore`';
 export const RESTORE_LOCK_SUFFIX = '.lock';
 export const RESTORING_MARKER_SUFFIX = '.restoring';
+const DATABASE_OPEN_LOCK_SUFFIX = '.open';
 
 /**
  * Directory holding the restore metadata for a database — the reserved `` `restore` `` sibling of
@@ -79,6 +80,26 @@ export function restoreLockPath(dbPath: string): string {
 
 export function restoringMarkerPath(dbPath: string): string {
 	return join(restoreMetaDir(dbPath), restoreMetaKey(dbPath) + RESTORING_MARKER_SUFFIX);
+}
+
+function databaseOpenLockPath(dbPath: string): string {
+	return join(restoreMetaDir(dbPath), restoreMetaKey(dbPath) + DATABASE_OPEN_LOCK_SUFFIX);
+}
+
+/**
+ * Serialize native RocksDB opens for one database across worker threads. rocksdb-js normally
+ * shares opened handles process-wide, but two cold worker-thread opens can still race before
+ * that registry entry exists and contend for RocksDB's process-local LOCK file.
+ */
+export function acquireDatabaseOpenLock(dbPath: string): number {
+	mkdirSync(restoreMetaDir(dbPath), { recursive: true });
+	let token = tryFileLock(databaseOpenLockPath(dbPath));
+	while (token === 0) token = tryFileLock(databaseOpenLockPath(dbPath));
+	return token;
+}
+
+export function releaseDatabaseOpenLock(token: number): void {
+	fileLockRelease(token);
 }
 
 export type RestoreState = 'in-progress' | 'incomplete' | 'clear';

--- a/dataLayer/restoreMarker.ts
+++ b/dataLayer/restoreMarker.ts
@@ -91,10 +91,18 @@ function databaseOpenLockPath(dbPath: string): string {
  * shares opened handles process-wide, but two cold worker-thread opens can still race before
  * that registry entry exists and contend for RocksDB's process-local LOCK file.
  */
-export function acquireDatabaseOpenLock(dbPath: string): number {
+export function acquireDatabaseOpenLock(dbPath: string, maxWaitMilliseconds = 30_000): number {
 	mkdirSync(restoreMetaDir(dbPath), { recursive: true });
 	let token = tryFileLock(databaseOpenLockPath(dbPath));
-	while (token === 0) token = tryFileLock(databaseOpenLockPath(dbPath));
+	const startedAt = Date.now();
+	const sleeper = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+	while (token === 0) {
+		if (Date.now() - startedAt >= maxWaitMilliseconds) {
+			throw new Error(`Timed out acquiring RocksDB open lock for ${dbPath}`);
+		}
+		Atomics.wait(sleeper, 0, 0, 10);
+		token = tryFileLock(databaseOpenLockPath(dbPath));
+	}
 	return token;
 }
 

--- a/dataLayer/restoreMarker.ts
+++ b/dataLayer/restoreMarker.ts
@@ -21,7 +21,7 @@ import { tryFileLock, fileLockRelease } from '@harperfast/rocksdb-js';
  * mutate the same directory concurrently.
  *
  * Restore metadata lives in an isolated `` `restore` `` directory *beside* the database directory
- * (never inside it, since a restore purges the destination). Each database's two files are keyed by
+ * (never inside it, since a restore purges the destination). Each database's metadata files are keyed by
  * a hash of the database directory name rather than being suffixed onto the name itself. That keeps
  * them out of the database-name namespace — a legal database literally named `orders.restoring`
  * would otherwise be mistaken for the restore marker of `orders`, and a 250-character name plus a
@@ -44,6 +44,8 @@ import { tryFileLock, fileLockRelease } from '@harperfast/rocksdb-js';
  *   successfully, while still holding the lock. Its *existence* means "a restore started and has
  *   not finished successfully". Its first line records the database directory name so the startup
  *   scan can map a marker back to the database it blocks without decoding the hashed key.
+ * - `<meta-dir>/<key>.open` — a short-lived mutex around root RocksDB opens and destroys. The main thread tracks
+ *   managed worker holders and releases their token if the worker exits before it can clean up.
  */
 
 // The backtick makes this an illegal database name (schemaRegex rejects `/` and backtick only), so
@@ -87,19 +89,19 @@ function databaseOpenLockPath(dbPath: string): string {
 }
 
 /**
- * Serialize native RocksDB opens for one database across worker threads. rocksdb-js normally
- * shares opened handles process-wide, but two cold worker-thread opens can still race before
- * that registry entry exists and contend for RocksDB's process-local LOCK file.
+ * Serialize root RocksDB opens and destroys for one database. rocksdb-js releases its registry
+ * entry before `DestroyDB`, so a concurrent reopen must wait until destruction is complete.
  */
 export function acquireDatabaseOpenLock(dbPath: string, maxWaitMilliseconds = 30_000): number {
 	mkdirSync(restoreMetaDir(dbPath), { recursive: true });
 	let token = tryFileLock(databaseOpenLockPath(dbPath));
 	const startedAt = Date.now();
-	const sleeper = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+	let sleeper: Int32Array;
 	while (token === 0) {
 		if (Date.now() - startedAt >= maxWaitMilliseconds) {
 			throw new Error(`Timed out acquiring RocksDB open lock for ${dbPath}`);
 		}
+		sleeper ??= new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
 		Atomics.wait(sleeper, 0, 0, 10);
 		token = tryFileLock(databaseOpenLockPath(dbPath));
 	}

--- a/dataLayer/schema.ts
+++ b/dataLayer/schema.ts
@@ -64,7 +64,11 @@ export async function createSchema(schemaCreateObject: any) {
 	// Await cross-worker propagation so the new schema is visible on every worker before
 	// returning success — otherwise describe_all on a lagging worker reports it missing (#1497).
 	await signalling.signalSchemaChange(
-		new SchemaEventMsg(process.pid, schemaCreateObject.operation ?? hdbTerms.OPERATIONS_ENUM.CREATE_SCHEMA, schemaCreateObject.schema)
+		new SchemaEventMsg(
+			process.pid,
+			schemaCreateObject.operation ?? hdbTerms.OPERATIONS_ENUM.CREATE_SCHEMA,
+			schemaCreateObject.schema
+		)
 	);
 
 	return schemaStructure;
@@ -189,7 +193,11 @@ export async function dropSchema(dropSchemaObject: any) {
 	// Await cross-worker propagation before returning success so no worker keeps serving the
 	// dropped schema (#1497).
 	await signalling.signalSchemaChange(
-		new SchemaEventMsg(process.pid, dropSchemaObject.operation ?? hdbTerms.OPERATIONS_ENUM.DROP_SCHEMA, dropSchemaObject.schema)
+		new SchemaEventMsg(
+			process.pid,
+			dropSchemaObject.operation ?? hdbTerms.OPERATIONS_ENUM.DROP_SCHEMA,
+			dropSchemaObject.schema
+		)
 	);
 
 	let response = await server.replication.replicateOperation(dropSchemaObject);

--- a/dataLayer/schema.ts
+++ b/dataLayer/schema.ts
@@ -64,7 +64,7 @@ export async function createSchema(schemaCreateObject: any) {
 	// Await cross-worker propagation so the new schema is visible on every worker before
 	// returning success — otherwise describe_all on a lagging worker reports it missing (#1497).
 	await signalling.signalSchemaChange(
-		new SchemaEventMsg(process.pid, schemaCreateObject.operation, schemaCreateObject.schema)
+		new SchemaEventMsg(process.pid, schemaCreateObject.operation ?? hdbTerms.OPERATIONS_ENUM.CREATE_SCHEMA, schemaCreateObject.schema)
 	);
 
 	return schemaStructure;
@@ -189,7 +189,7 @@ export async function dropSchema(dropSchemaObject: any) {
 	// Await cross-worker propagation before returning success so no worker keeps serving the
 	// dropped schema (#1497).
 	await signalling.signalSchemaChange(
-		new SchemaEventMsg(process.pid, dropSchemaObject.operation, dropSchemaObject.schema)
+		new SchemaEventMsg(process.pid, dropSchemaObject.operation ?? hdbTerms.OPERATIONS_ENUM.DROP_SCHEMA, dropSchemaObject.schema)
 	);
 
 	let response = await server.replication.replicateOperation(dropSchemaObject);

--- a/integrationTests/apiTests/terminology.test.mjs
+++ b/integrationTests/apiTests/terminology.test.mjs
@@ -15,7 +15,7 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { startHarper, teardownHarper } from '@harperfast/integration-testing';
 import { createApiClient } from './utils/client.mjs';
-import { awaitJobCompleted, waitFor } from './utils/operations.mjs';
+import { awaitJobCompleted } from './utils/operations.mjs';
 
 // Resolve the CSV fixture path relative to this file so Harper can read it.
 const SUPPLIERS_CSV = path.join(path.dirname(fileURLToPath(import.meta.url)), 'data/Suppliers.csv');
@@ -403,15 +403,11 @@ suite('Terminology aliases (database / primary_key)', (ctx) => {
 	});
 
 	test('drop_database with database param', async () => {
-		// The preceding drop_table signals syncSchemaMetadata across worker threads, which
-		// briefly reopens all schema RocksDB files including tuckerdoodle. If drop_database
-		// races that reopen it gets a "No locks available" LOCK error. Poll until the drop
-		// succeeds (workers release the lock quickly once their getDatabases pass finishes).
-		const r = await waitFor(() => client.req().send({ operation: 'drop_database', database: 'tuckerdoodle' }), {
-			until: (res) => res?.body?.message != null,
-			timeoutSeconds: 10,
-		});
-		assert.equal(r?.body?.message, "successfully deleted 'tuckerdoodle'", r?.text);
+		await client
+			.req()
+			.send({ operation: 'drop_database', database: 'tuckerdoodle' })
+			.expect((r) => assert.equal(r.body.message, "successfully deleted 'tuckerdoodle'", r.text))
+			.expect(200);
 	});
 
 	// ── async job operations ────────────────────────────────────────────────

--- a/integrationTests/apiTests/terminology.test.mjs
+++ b/integrationTests/apiTests/terminology.test.mjs
@@ -416,7 +416,7 @@ suite('Terminology aliases (database / primary_key)', (ctx) => {
 
 	// ── async job operations ────────────────────────────────────────────────
 
-	test('create job_guy database and working table for job tests', async () => {
+	test('runtime-created database immediately starts a job', async () => {
 		await client
 			.req()
 			.send({ operation: 'create_database', database: 'job_guy' })
@@ -427,9 +427,6 @@ suite('Terminology aliases (database / primary_key)', (ctx) => {
 			.send({ operation: 'create_table', database: 'job_guy', table: 'working', primary_key: 'id' })
 			.expect((r) => assert.equal(r.body.message, "table 'job_guy.working' successfully created.", r.text))
 			.expect(200);
-	});
-
-	test('delete_records_before with database param starts job', async () => {
 		const r = await client
 			.req()
 			.send({

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -24,7 +24,7 @@ import { _assignPackageExport } from '../globals.js';
 import { getIndexedValues } from '../utility/lmdb/commonUtility.ts';
 import * as signalling from '../utility/signalling.ts';
 import { SchemaEventMsg } from '../server/threads/itc.js';
-import { workerData } from 'worker_threads';
+import { isMainThread, workerData } from 'worker_threads';
 import harperLogger from '../utility/logging/harper_logger.ts';
 const { forComponent } = harperLogger;
 import * as manageThreads from '../server/threads/manageThreads.js';
@@ -52,6 +52,39 @@ import {
 	RESTORE_META_DIR,
 	type RestoreLock,
 } from '../dataLayer/restoreMarker.ts';
+
+declare const threads: { sendToThread(threadId: number, message: any): boolean };
+
+const DATABASE_OPEN_LOCK_ACQUIRED = 'database_open_lock_acquired';
+const DATABASE_OPEN_LOCK_RELEASED = 'database_open_lock_released';
+const workerDatabaseOpenLocks = new Map<number, number>();
+
+if (isMainThread) {
+	manageThreads.onMessageByType(DATABASE_OPEN_LOCK_ACQUIRED, (message, port) => {
+		workerDatabaseOpenLocks.set(message.token, port.threadId);
+	});
+	manageThreads.onMessageByType(DATABASE_OPEN_LOCK_RELEASED, (message) => {
+		workerDatabaseOpenLocks.delete(message.token);
+	});
+	manageThreads.onThreadExit((threadId) => {
+		for (const [token, ownerThreadId] of workerDatabaseOpenLocks) {
+			if (ownerThreadId !== threadId) continue;
+			releaseDatabaseOpenLock(token);
+			workerDatabaseOpenLocks.delete(token);
+		}
+	});
+}
+
+function acquireTrackedDatabaseOpenLock(path: string): number {
+	const token = acquireDatabaseOpenLock(path);
+	if (!isMainThread) threads.sendToThread(0, { type: DATABASE_OPEN_LOCK_ACQUIRED, token });
+	return token;
+}
+
+function releaseTrackedDatabaseOpenLock(token: number): void {
+	releaseDatabaseOpenLock(token);
+	if (!isMainThread) threads.sendToThread(0, { type: DATABASE_OPEN_LOCK_RELEASED, token });
+}
 
 /**
  * Check if Harper is running in read-only mode.
@@ -327,7 +360,7 @@ function openRocksDatabase(path: string, options: RocksDatabaseOptions & { dupSo
 		}
 		mkdirSync(path, { recursive: true });
 	}
-	const openLock = !options.name && !isReadOnlyMode() ? acquireDatabaseOpenLock(path) : 0;
+	const openLock = !isReadOnlyMode() ? acquireTrackedDatabaseOpenLock(path) : 0;
 	try {
 		let db: RocksRootDatabase;
 		if (options.dupSort) {
@@ -343,7 +376,7 @@ function openRocksDatabase(path: string, options: RocksDatabaseOptions & { dupSo
 		db.env = {};
 		return db;
 	} finally {
-		if (openLock) releaseDatabaseOpenLock(openLock);
+		if (openLock) releaseTrackedDatabaseOpenLock(openLock);
 	}
 }
 
@@ -1221,6 +1254,13 @@ function lockDatabaseForDrop(dbPath: string, databaseName: string, held: Restore
 	held.push(lock);
 }
 
+type DatabaseOpenLock = { dbPath: string; token: number };
+
+function lockDatabaseOpenForDrop(dbPath: string, held: DatabaseOpenLock[]): void {
+	if (held.some((lock) => lock.dbPath === dbPath)) return;
+	held.push({ dbPath, token: acquireTrackedDatabaseOpenLock(dbPath) });
+}
+
 /**
  * Delete the database
  * @param databaseName
@@ -1236,53 +1276,63 @@ export async function dropDatabase(databaseName) {
 	// (before writing its marker), so both operations serialize on this one primitive rather than on
 	// a check-then-act marker probe. Released in the finally below.
 	const restoreLocks: RestoreLock[] = [];
+	const openLocks: DatabaseOpenLock[] = [];
 	try {
-		for (const tableName in dbTables) {
-			const table = dbTables[tableName];
-			rootStore = table.primaryStore.rootStore;
-			if (rootStore instanceof RocksDatabase) lockDatabaseForDrop(rootStore.path, databaseName, restoreLocks);
-			lmdbDatabaseEnvs.delete(rootStore.path);
-			rocksdbDatabaseEnvs.delete(rootStore.path);
-		}
-
-		for (const tableName in dbTables) {
-			databaseEventsEmitter.emit('dropTable', tableName, databaseName);
-		}
-
-		if (databaseName === 'data') {
-			for (const tableName in tables) {
-				delete tables[tableName];
+		try {
+			for (const tableName in dbTables) {
+				const table = dbTables[tableName];
+				rootStore = table.primaryStore.rootStore;
+				if (rootStore instanceof RocksDatabase) {
+					lockDatabaseForDrop(rootStore.path, databaseName, restoreLocks);
+					lockDatabaseOpenForDrop(rootStore.path, openLocks);
+				}
+				lmdbDatabaseEnvs.delete(rootStore.path);
+				rocksdbDatabaseEnvs.delete(rootStore.path);
 			}
-			delete tables[DEFINED_TABLES];
-		}
-		delete databases[databaseName];
 
-		databaseEventsEmitter.emit('dropDatabase', databaseName);
+			for (const tableName in dbTables) {
+				databaseEventsEmitter.emit('dropTable', tableName, databaseName);
+			}
 
-		if (rootStore) {
-			if (rootStore.status === 'open') {
+			if (databaseName === 'data') {
+				for (const tableName in tables) {
+					delete tables[tableName];
+				}
+				delete tables[DEFINED_TABLES];
+			}
+			delete databases[databaseName];
+
+			databaseEventsEmitter.emit('dropDatabase', databaseName);
+
+			if (rootStore) {
+				if (rootStore.status === 'open') {
+					if (rootStore instanceof RocksDatabase) {
+						rootStore.close();
+						rootStore.destroy();
+					} else {
+						await rootStore.close();
+						await unlink(rootStore.path);
+					}
+				}
+			} else {
+				rootStore = database({ database: databaseName, table: null });
+				// a tableless database resolves its root store here rather than in the loop above, so take
+				// the drop lock now (still before any destructive step)
+				if (rootStore instanceof RocksDatabase) {
+					lockDatabaseForDrop(rootStore.path, databaseName, restoreLocks);
+					lockDatabaseOpenForDrop(rootStore.path, openLocks);
+				}
 				if (rootStore instanceof RocksDatabase) {
 					rootStore.close();
 					rootStore.destroy();
-				} else {
+				} else if (rootStore.status === 'open') {
 					await rootStore.close();
 					await unlink(rootStore.path);
 				}
 			}
-		} else {
-			rootStore = database({ database: databaseName, table: null });
-			// a tableless database resolves its root store here rather than in the loop above, so take
-			// the drop lock now (still before any destructive step)
-			if (rootStore instanceof RocksDatabase) lockDatabaseForDrop(rootStore.path, databaseName, restoreLocks);
-			if (rootStore instanceof RocksDatabase) {
-				rootStore.close();
-				rootStore.destroy();
-			} else if (rootStore.status === 'open') {
-				await rootStore.close();
-				await unlink(rootStore.path);
-			}
+		} finally {
+			for (const lock of openLocks) releaseTrackedDatabaseOpenLock(lock.token);
 		}
-
 		await deleteRootBlobPathsForDB(rootStore);
 	} finally {
 		for (const lock of restoreLocks) releaseRestoreLock(lock);

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -327,7 +327,7 @@ function openRocksDatabase(path: string, options: RocksDatabaseOptions & { dupSo
 		}
 		mkdirSync(path, { recursive: true });
 	}
-	const openLock = acquireDatabaseOpenLock(path);
+	const openLock = !options.name && !isReadOnlyMode() ? acquireDatabaseOpenLock(path) : 0;
 	try {
 		let db: RocksRootDatabase;
 		if (options.dupSort) {
@@ -343,7 +343,7 @@ function openRocksDatabase(path: string, options: RocksDatabaseOptions & { dupSo
 		db.env = {};
 		return db;
 	} finally {
-		releaseDatabaseOpenLock(openLock);
+		if (openLock) releaseDatabaseOpenLock(openLock);
 	}
 }
 

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -43,7 +43,9 @@ import { resolveRocksMemoryConfig } from '../utility/rocksMemoryConfig.ts';
 import { isProcessRunning } from '../utility/processManagement/processManagement.js';
 import {
 	acquireRestoreLock,
+	acquireDatabaseOpenLock,
 	checkRestoreState,
+	releaseDatabaseOpenLock,
 	releaseRestoreLock,
 	restoreMarkerPresent,
 	scanBlockedRestores,
@@ -325,19 +327,24 @@ function openRocksDatabase(path: string, options: RocksDatabaseOptions & { dupSo
 		}
 		mkdirSync(path, { recursive: true });
 	}
-	let db: RocksRootDatabase;
-	if (options.dupSort) {
-		db = new RocksIndexStore(path, options).open() as any;
-	} else {
-		db = new PrimaryRocksDatabase(path, options).open() as unknown as RocksRootDatabase;
-		// the RocksDB put and remove return promises, which masks thrown errors in non-awaiting calls to put/remove,
-		// making them unsafe to replace LMDB methods, which will synchronously throw errors if there is a problem
-		db.put = db.putSync as any;
-		db.remove = db.removeSync as any;
-		(db.encoder as any).name = options.name;
+	const openLock = acquireDatabaseOpenLock(path);
+	try {
+		let db: RocksRootDatabase;
+		if (options.dupSort) {
+			db = new RocksIndexStore(path, options).open() as any;
+		} else {
+			db = new PrimaryRocksDatabase(path, options).open() as unknown as RocksRootDatabase;
+			// the RocksDB put and remove return promises, which masks thrown errors in non-awaiting calls to put/remove,
+			// making them unsafe to replace LMDB methods, which will synchronously throw errors if there is a problem
+			db.put = db.putSync as any;
+			db.remove = db.removeSync as any;
+			(db.encoder as any).name = options.name;
+		}
+		db.env = {};
+		return db;
+	} finally {
+		releaseDatabaseOpenLock(openLock);
 	}
-	db.env = {};
-	return db;
 }
 
 const lmdbDatabaseEnvs = new Map<string, LMDBRootDatabase>();

--- a/unitTests/dataLayer/restoreMarker.test.js
+++ b/unitTests/dataLayer/restoreMarker.test.js
@@ -4,12 +4,15 @@ const assert = require('node:assert');
 const { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } = require('node:fs');
 const { basename, dirname, join } = require('node:path');
 const { tmpdir } = require('node:os');
+const { Worker } = require('node:worker_threads');
 const { tryFileLock, fileLockRelease } = require('@harperfast/rocksdb-js');
 const {
 	beginRestore,
 	completeRestore,
 	abandonRestore,
 	acquireRestoreLock,
+	acquireDatabaseOpenLock,
+	releaseDatabaseOpenLock,
 	releaseRestoreLock,
 	clearRestoreMarker,
 	checkRestoreState,
@@ -33,6 +36,35 @@ describe('restoreMarker', function () {
 	afterEach(function () {
 		rmSync(tempDir, { recursive: true, force: true });
 	});
+
+	function acquireOpenLockInWorker(maxWaitMilliseconds) {
+		const worker = new Worker(
+			`const { parentPort, workerData } = require('node:worker_threads');
+			const { acquireDatabaseOpenLock, releaseDatabaseOpenLock } = require(workerData.modulePath);
+			try {
+				const token = acquireDatabaseOpenLock(workerData.dbPath, workerData.maxWaitMilliseconds);
+				parentPort.postMessage({ acquired: true });
+				releaseDatabaseOpenLock(token);
+			} catch (error) {
+				parentPort.postMessage({ message: error.message });
+			}`,
+			{
+				eval: true,
+				workerData: {
+					dbPath,
+					maxWaitMilliseconds,
+					modulePath: require.resolve('#src/dataLayer/restoreMarker'),
+				},
+			}
+		);
+		return {
+			worker,
+			result: new Promise((resolve, reject) => {
+				worker.once('message', resolve);
+				worker.once('error', reject);
+			}),
+		};
+	}
 
 	describe('paths', function () {
 		it('keeps restore metadata in an isolated sibling directory, out of the database-name namespace', function () {
@@ -206,6 +238,26 @@ describe('restoreMarker', function () {
 				);
 			} finally {
 				completeRestore(lock);
+			}
+		});
+	});
+
+	describe('database open lock', function () {
+		it('excludes a concurrent worker-thread open until the first open completes', async function () {
+			const token = acquireDatabaseOpenLock(dbPath);
+			const blocked = acquireOpenLockInWorker(25);
+			try {
+				const result = await blocked.result;
+				assert.deepStrictEqual(result, { message: `Timed out acquiring RocksDB open lock for ${dbPath}` });
+			} finally {
+				releaseDatabaseOpenLock(token);
+				await blocked.worker.terminate();
+			}
+			const available = acquireOpenLockInWorker(25);
+			try {
+				assert.deepStrictEqual(await available.result, { acquired: true });
+			} finally {
+				await available.worker.terminate();
 			}
 		});
 	});

--- a/utility/lmdb/cleanLMDBMap.ts
+++ b/utility/lmdb/cleanLMDBMap.ts
@@ -17,6 +17,7 @@ async function cleanLMDBMap(msg: any) {
 			let cachedEnvironment = undefined;
 
 			switch (msg.operation) {
+				case 'drop_database':
 				case 'drop_schema':
 					for (let x = 0; x < keys.length; x++) {
 						let key = keys[x];


### PR DESCRIPTION
## Summary

- Serialize a database's root RocksDB opens with `DestroyDB` while its directory is being dropped.
- Remove the terminology test's `drop_database` polling workaround and assert the direct operation succeeds.
- Emit each schema-change signal once, retain the canonical operation default, and clear LMDB aliases on `drop_database`.

## Root cause

In [the failing uWS integration run](https://github.com/HarperFast/harper/actions/runs/31554910290), the first stuck job starts at the same second RocksDB records a same-process `LOCK` acquisition for `tuckerdoodle`. rocksdb-js 2.7.1 already serializes concurrent opens. Its registry, however, releases a database entry before it calls `DestroyDB`. The preceding `drop_database` races that destroy with schema propagation reopening the root in another thread; the job worker then hits the resulting native `LOCK` failure during module initialization, before `jobProcess` enters its error-handling IIFE.

The fix uses the existing per-database mutex for both root opens and destruction. A reopen now waits for `DestroyDB` to finish rather than reaching RocksDB while the directory is being removed.

## Verification

- `npm run build`
- `npm run lint:required`
- `npx mocha unitTests/dataLayer/restoreMarker.test.js`
- `npx mocha unitTests/server/threads/preloadSafeMode.test.js`
- `HARPER_UWS_HTTP=1 node --experimental-strip-types --test integrationTests/apiTests/terminology.test.mjs` (47 passing)

`npm run test:unit:main` exercised the new coverage but has two unrelated existing failures in this worktree: deployment-recorder timeout budget and the long-worktree domain-socket path expectation. The full integration fan-out exited nonzero without retaining the failing suite's log; the suspected final rate-limiter suite passes cleanly in isolation.

Independent storage review was run before the final PR. It confirmed the `DestroyDB` gap and identified broader follow-up work for pre-IIFE job failures; this stays a draft for human storage review.

— GPT-5 Codex

## Rebase + review follow-up (2026-09-13)

Rebased onto current `main` (407 commits ahead at the time). This PR's diff had never gone through
the pre-push review CLI before (`ran=none` in the prior footer) — 4 rounds ran during this rebase and
found real, fixed bugs plus a few the PR should carry forward as open decisions.

**Fixed in this pass:**
- `resources/databases.ts` (`openRocksDatabase`/`dropDatabase`): merge conflict against main's
  independently-added `stopAuditCleanup`/`removeStorageReclamation` calls (#2338) — kept both.
- The merge introduced a real 30s job wedge: `dropDatabase` now yields (`await stopAuditCleanup()`)
  while holding the open lock, letting a same-thread schema-change rescan re-enter
  `acquireDatabaseOpenLock` for the same path and spin the full timeout. Fixed with a same-thread
  reentrancy fast-fail in `dataLayer/restoreMarker.ts`.
- `resources/branchDatabase.ts`'s undeploy walk didn't know about this PR's `` `restore` `` lock
  metadata sibling and failed outright when a branch had ever taken the open lock. Fixed.
- Review round 1 (codex + gemini + cursor-grok, adjudicated): a blob-deletion race (open lock released
  before `deleteRootBlobPathsForDB`), a directory-resurrection race (`mkdirSync`/`existsSync` ran
  before the lock), a silent-scan-abort from the reentrancy fix above, and an unguarded
  `port.threadId` read. All fixed and re-reviewed clean.

**Not fixed — flagging for the merge decision instead of changing unilaterally on a rebase task:**
- **Worker lock-ownership tracking is best-effort IPC** (`resources/databases.ts:78-101`): the main
  thread learns which worker holds a lock via async `postMessage`; an abnormal worker exit (OOM,
  `kill -9`) before that message lands leaks the lock until process restart, or (per a Cursor Grok
  angle) a reused token could double-release a live opener's lock. Fixing this well means a different
  ownership-tracking primitive (e.g. main-thread-owned acquisition, or a `SharedArrayBuffer`-backed
  registry), which is a bigger, harder-to-reverse call than this task should make.
- **The open path blocks its own event loop.** `acquireDatabaseOpenLock`'s `Atomics.wait` retry parks
  the calling thread in 10ms slices for up to 30s on contention, and the timeout carries no HTTP
  `statusCode` (surfaces as 500, not 409). This is inherent to the lock design this PR introduces, not
  something the rebase changed. Reviewer note: Gemini repeatedly flagged this as `Atomics.wait` on
  Node's main thread throwing a `TypeError` and crashing the process — that's incorrect for Node
  (unlike browsers, Node permits `Atomics.wait` on the main thread; it blocks, it doesn't throw). I
  confirmed this empirically while debugging the job-wedge above: the exact same call executed on
  mocha's single (main) thread and blocked for the full duration without throwing. The real defect is
  the blocking itself, not a crash.
- **A scan can still resurrect a fully-dropped database as an empty zombie.** The fix in this pass
  closes the narrower "resurrect a directory a destroy is still working on" race, but a scan that
  enumerated a database's directory *before* a drop completes can still recreate it (empty) after the
  drop finishes and releases the lock, because `openRocksDatabase` has no way to know the caller is
  discovering rather than intending to create. Closing this needs an explicit create-intent flag
  threaded through `database()`/`openRocksDatabase`'s callers — an API shape change, not a rebase fix.
- Two Cursor Grok findings on pre-existing (not this-rebase) loop structure in `dropDatabase`: the
  per-table lock-acquire loop clears cache entries in the same pass it acquires locks, so a mid-loop
  timeout on table 2+ leaves table 1's cache entry cleared without actually dropping anything
  (`resources/databases.ts:2071`-ish); and the tableless-drop branch opens-then-releases the lock via
  `database(...)` before re-acquiring it for the drop, leaving a short unlocked window
  (`resources/databases.ts:2088`-ish). Both are structural to code this rebase didn't author; noted
  for whoever owns the next pass rather than fixed blind here.

Verified after every fix: `npm run build` / `typecheck` / `lint` / `format:check` clean; full
`test:unit:resources` (2495 passing, 0 failing), `test:unit:main` (5520 passing, 2 known-local-only
failures unrelated to this diff), `test:unit:dataLayer`, `test:unit:backup` all clean.

— Claude Sonnet 5

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=4; full=1 @ 25942aafa05e</sub>

<sub>Human-Review-Need: 4 @ 25942aafa05e</sub>
