### PR TITLE
Pin the load-bearing native and encoder dependencies

### DIFF
--- a/.github/workflows/update-rocksdb-js.yml
+++ b/.github/workflows/update-rocksdb-js.yml
@@ -34,7 +34,7 @@ jobs:
           package-manager-cache: false
 
       - name: Install latest rocksdb-js
-        run: npm install --save @harperfast/rocksdb-js@latest
+        run: npm install --save-exact @harperfast/rocksdb-js@latest
 
       - name: Stage changes
         id: stage-changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ Use this to land in the right folder before grepping. Every top-level folder is 
 
 - **`bin/`** — covered above (it's source).
 - **`benchmarks/`** — HNSW vector-search benchmark only (`hnsw-search.js`). Stand-alone; not part of CI.
-- **`build-tools/`** — shell scripts for the build pipeline (`build.sh`, `build-studio.sh`, `download-prebuilds.js`). No tests.
+- **`build-tools/`** — build-pipeline scripts. Tests: `unitTests/build-tools/`; run `npm run test:unit:main` after changes.
 - **`dev/`** — single dev utility (`sync-commits.js`) for cross-repo commit syncing. Not runtime.
 - **`integrationTests/`** — end-to-end tests against a built distribution. Run with `npm run test:integration` / `npm run test:integration:all`. Subdirs mirror source. See `integrationTests/README.md`.
 - **`unitTests/`** — Mocha unit tests; subdir per source layer. Run with `npm run test:unit:<layer>`.

--- a/build-tools/check-shrinkwrap-pins.mjs
+++ b/build-tools/check-shrinkwrap-pins.mjs
@@ -34,6 +34,7 @@ import { readFileSync } from 'node:fs';
 
 const CHECKED_DEPS = ['@harperfast/rocksdb-js', 'fastify', '@aws-sdk/client-s3'];
 const REGISTRY_QUERY_ATTEMPTS = 3;
+const retryWait = new Int32Array(new SharedArrayBuffer(4));
 
 const pkgRoot = process.argv[2];
 if (!pkgRoot) {
@@ -125,6 +126,13 @@ function verifyCanariesDiscriminate(pins) {
 				// the last array entry.
 				const out = execFileSync('npm', ['view', `${dep}@${range}`, 'version', '--json'], { encoding: 'utf8' });
 				const versions = JSON.parse(out);
+				if (Array.isArray(versions) && versions.length === 0) {
+					console.error(
+						`::error::${dep}@${range} matches no published version -- correct the declared range in package.json`
+					);
+					failed = true;
+					return;
+				}
 				rangeLatest[dep] = Array.isArray(versions)
 					? versions.reduce((max, v) => (compareVersions(v, max) > 0 ? v : max))
 					: versions;
@@ -134,6 +142,7 @@ function verifyCanariesDiscriminate(pins) {
 					`::warning::registry query attempt ${attempt}/${REGISTRY_QUERY_ATTEMPTS} failed for ${dep}@${range} (${e.message})`
 				);
 				if (attempt === REGISTRY_QUERY_ATTEMPTS) failedQueries.push(`${dep}@${range}`);
+				else Atomics.wait(retryWait, 0, 0, 1000 * attempt);
 			}
 		}
 	}
@@ -142,7 +151,7 @@ function verifyCanariesDiscriminate(pins) {
 	if (stillDiscriminates) return;
 	if (failedQueries.length > 0) {
 		console.error(
-			`::error title=Retry dependency canary check::Could not verify that the shrinkwrap canaries still discriminate after ${REGISTRY_QUERY_ATTEMPTS} registry query attempts for ${failedQueries.join(', ')}. Retry this job; if the error persists, check npm registry availability.`
+			`::error title=Retry dependency canary check::Could not verify that the shrinkwrap canaries still discriminate after ${REGISTRY_QUERY_ATTEMPTS} registry query attempts for ${failedQueries.join(', ')}. Retry this job; if the error persists, check npm registry availability and confirm the listed package ranges match published versions.`
 		);
 		failed = true;
 		return;

--- a/build-tools/check-shrinkwrap-pins.mjs
+++ b/build-tools/check-shrinkwrap-pins.mjs
@@ -33,6 +33,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
 const CHECKED_DEPS = ['@harperfast/rocksdb-js', 'fastify', '@aws-sdk/client-s3'];
+const REGISTRY_QUERY_ATTEMPTS = 3;
 
 const pkgRoot = process.argv[2];
 if (!pkgRoot) {
@@ -113,44 +114,43 @@ function verifyCanariesDiscriminate(pins) {
 	// the declared range, not the registry's bare "latest" dist-tag (which could be a newer
 	// major the range excludes, and a broken install could never reach that either).
 	const rangeLatest = {};
-	let failedQueries = 0;
+	const failedQueries = [];
 	for (const [dep, { range }] of Object.entries(rangedPins)) {
-		try {
-			// `npm view <dep>@<range> version --json` returns every matching version, not
-			// just the max, and the order isn't a documented contract (it can track
-			// publish/insertion order rather than semver order, e.g. a backported patch
-			// published after a newer minor) -- compare them ourselves rather than trust
-			// the last array entry.
-			const out = execFileSync('npm', ['view', `${dep}@${range}`, 'version', '--json'], { encoding: 'utf8' });
-			const versions = JSON.parse(out);
-			rangeLatest[dep] = Array.isArray(versions)
-				? versions.reduce((max, v) => (compareVersions(v, max) > 0 ? v : max))
-				: versions;
-		} catch (e) {
-			failedQueries++;
-			console.log(
-				`::warning::could not check registry-latest-in-range for ${dep}@${range} (${e.message}) -- skipping discrimination check for it`
-			);
+		for (let attempt = 1; attempt <= REGISTRY_QUERY_ATTEMPTS; attempt++) {
+			try {
+				// `npm view <dep>@<range> version --json` returns every matching version, not
+				// just the max, and the order isn't a documented contract (it can track
+				// publish/insertion order rather than semver order, e.g. a backported patch
+				// published after a newer minor) -- compare them ourselves rather than trust
+				// the last array entry.
+				const out = execFileSync('npm', ['view', `${dep}@${range}`, 'version', '--json'], { encoding: 'utf8' });
+				const versions = JSON.parse(out);
+				rangeLatest[dep] = Array.isArray(versions)
+					? versions.reduce((max, v) => (compareVersions(v, max) > 0 ? v : max))
+					: versions;
+				break;
+			} catch (e) {
+				console.log(
+					`::warning::registry query attempt ${attempt}/${REGISTRY_QUERY_ATTEMPTS} failed for ${dep}@${range} (${e.message})`
+				);
+				if (attempt === REGISTRY_QUERY_ATTEMPTS) failedQueries.push(`${dep}@${range}`);
+			}
 		}
 	}
 	const checkable = Object.keys(rangeLatest);
-	if (checkable.length === 0) {
-		console.log('::warning::registry unreachable -- could not verify the canary set still discriminates');
-		return;
-	}
 	const stillDiscriminates = checkable.some((dep) => rangeLatest[dep] !== pins[dep].pinned);
-	if (!stillDiscriminates) {
-		if (failedQueries) {
-			console.log(
-				'::warning::could not verify every ranged canary still discriminates because one or more registry queries failed'
-			);
-			return;
-		}
+	if (stillDiscriminates) return;
+	if (failedQueries.length > 0) {
 		console.error(
-			`::error::every checked canary (${checkable.join(', ')}) is now pinned at the latest version its declared range allows -- this check would pass even on a reverted, unpinned install. Pick a new canary whose shrinkwrap pin lags what its range allows.`
+			`::error title=Retry dependency canary check::Could not verify that the shrinkwrap canaries still discriminate after ${REGISTRY_QUERY_ATTEMPTS} registry query attempts for ${failedQueries.join(', ')}. Retry this job; if the error persists, check npm registry availability.`
 		);
 		failed = true;
+		return;
 	}
+	console.error(
+		`::error::every checked canary (${checkable.join(', ')}) is now pinned at the latest version its declared range allows -- this check would pass even on a reverted, unpinned install. Pick a new canary whose shrinkwrap pin lags what its range allows.`
+	);
+	failed = true;
 }
 
 function isExactVersion(range) {

--- a/build-tools/check-shrinkwrap-pins.mjs
+++ b/build-tools/check-shrinkwrap-pins.mjs
@@ -30,9 +30,10 @@
 // Usage: node check-shrinkwrap-pins.mjs <package-root>
 
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 
 const CHECKED_DEPS = ['@harperfast/rocksdb-js', 'fastify', '@aws-sdk/client-s3'];
+const ROCKSDB_SINGLE_INSTANCE_DEPS = ['@harperfast/extended-iterable', 'msgpackr'];
 const REGISTRY_QUERY_ATTEMPTS = 3;
 const retryWait = new Int32Array(new SharedArrayBuffer(4));
 
@@ -93,6 +94,8 @@ for (const dep of CHECKED_DEPS) {
 	console.log(`${status}: ${dep}@${installed} matches the packed pin`);
 }
 
+verifyRocksDbDependencyAlignment();
+
 // A canary only proves the check works while its pin lags the registry -- if a lock bump
 // ever lands every ranged canary on registry-latest, the pin-match loop above would pass on a
 // reverted, broken Dockerfile just as easily as on this one. Fail loudly rather than let
@@ -103,6 +106,7 @@ process.exit(failed ? 1 : 0);
 
 function verifyCanariesDiscriminate(pins) {
 	const rangedPins = Object.fromEntries(Object.entries(pins).filter(([, { range }]) => !isExactVersion(range)));
+	if (Object.keys(pins).length === 0) return;
 	if (Object.keys(rangedPins).length === 0) {
 		console.error(
 			'::error::every checked canary has an exact declared version -- exact dependencies cannot distinguish a shrinkwrap install from a fresh resolution. Add a canary with a ranged manifest spec.'
@@ -160,6 +164,52 @@ function verifyCanariesDiscriminate(pins) {
 		`::error::every checked canary (${checkable.join(', ')}) is now pinned at the latest version its declared range allows -- this check would pass even on a reverted, unpinned install. Pick a new canary whose shrinkwrap pin lags what its range allows.`
 	);
 	failed = true;
+}
+
+function verifyRocksDbDependencyAlignment() {
+	let rocksdbManifest;
+	try {
+		rocksdbManifest = JSON.parse(readFileSync(`${pkgRoot}/node_modules/@harperfast/rocksdb-js/package.json`, 'utf8'));
+	} catch (e) {
+		console.error(`::error::could not inspect rocksdb-js dependency alignment: ${e.message}`);
+		failed = true;
+		return;
+	}
+
+	for (const dep of ROCKSDB_SINGLE_INSTANCE_DEPS) {
+		const rootSpec = manifest.dependencies?.[dep];
+		const rocksdbSpec = rocksdbManifest.dependencies?.[dep];
+		if (!isExactVersion(rootSpec) || rootSpec !== rocksdbSpec) {
+			console.error(
+				`::error::${dep} must be exact and match rocksdb-js (${rootSpec ?? 'missing'} !== ${rocksdbSpec ?? 'missing'}) -- update these pins together to preserve one module instance`
+			);
+			failed = true;
+			continue;
+		}
+
+		try {
+			const installed = JSON.parse(readFileSync(`${pkgRoot}/node_modules/${dep}/package.json`, 'utf8')).version;
+			if (installed !== rootSpec) {
+				console.error(`::error::${dep} resolved to ${installed}, expected the aligned exact pin ${rootSpec}`);
+				failed = true;
+			}
+		} catch (e) {
+			console.error(`::error::could not inspect the root ${dep} instance: ${e.message}`);
+			failed = true;
+		}
+
+		const nestedManifest = `${pkgRoot}/node_modules/@harperfast/rocksdb-js/node_modules/${dep}/package.json`;
+		if (existsSync(nestedManifest)) {
+			let nestedVersion = 'unknown';
+			try {
+				nestedVersion = JSON.parse(readFileSync(nestedManifest, 'utf8')).version;
+			} catch {}
+			console.error(
+				`::error::rocksdb-js loaded a nested ${dep}@${nestedVersion} -- root and rocksdb-js must share one module instance`
+			);
+			failed = true;
+		}
+	}
 }
 
 function isExactVersion(range) {

--- a/build-tools/check-shrinkwrap-pins.mjs
+++ b/build-tools/check-shrinkwrap-pins.mjs
@@ -179,9 +179,16 @@ function verifyRocksDbDependencyAlignment() {
 	for (const dep of ROCKSDB_SINGLE_INSTANCE_DEPS) {
 		const rootSpec = manifest.dependencies?.[dep];
 		const rocksdbSpec = rocksdbManifest.dependencies?.[dep];
-		if (!isExactVersion(rootSpec) || rootSpec !== rocksdbSpec) {
+		if (!isExactVersion(rootSpec)) {
 			console.error(
-				`::error::${dep} must be exact and match rocksdb-js (${rootSpec ?? 'missing'} !== ${rocksdbSpec ?? 'missing'}) -- update these pins together to preserve one module instance`
+				`::error::the root ${dep} spec must be exact, received ${rootSpec ?? 'missing'} -- update it with rocksdb-js to preserve one module instance`
+			);
+			failed = true;
+			continue;
+		}
+		if (rootSpec !== rocksdbSpec) {
+			console.error(
+				`::error::the root ${dep} pin ${rootSpec} does not match rocksdb-js ${rocksdbSpec ?? 'missing'} -- update these pins together to preserve one module instance`
 			);
 			failed = true;
 			continue;

--- a/build-tools/check-shrinkwrap-pins.mjs
+++ b/build-tools/check-shrinkwrap-pins.mjs
@@ -130,16 +130,23 @@ function verifyCanariesDiscriminate(pins) {
 				// the last array entry.
 				const out = execFileSync('npm', ['view', `${dep}@${range}`, 'version', '--json'], { encoding: 'utf8' });
 				const versions = JSON.parse(out);
+				if (Array.isArray(versions) && versions.length === 0) {
+					reportMissingRange(dep, range);
+					return;
+				}
+				if (
+					(Array.isArray(versions) && versions.some((version) => !isExactVersion(version))) ||
+					(!Array.isArray(versions) && !isExactVersion(versions))
+				) {
+					throw new Error('npm returned an invalid version payload');
+				}
 				rangeLatest[dep] = Array.isArray(versions)
 					? versions.reduce((max, v) => (compareVersions(v, max) > 0 ? v : max))
 					: versions;
 				break;
 			} catch (e) {
 				if (isNpmNotFoundError(e)) {
-					console.error(
-						`::error::${dep}@${range} matches no published version -- correct the declared range in package.json`
-					);
-					failed = true;
+					reportMissingRange(dep, range);
 					return;
 				}
 				console.log(
@@ -232,6 +239,13 @@ function isNpmNotFoundError(error) {
 	} catch {
 		return false;
 	}
+}
+
+function reportMissingRange(dep, range) {
+	console.error(
+		`::error::${dep}@${range} matches no published version in the configured registry -- correct the declared range in package.json or confirm the configured registry carries this package`
+	);
+	failed = true;
 }
 
 // Numeric major.minor.patch comparison, ignoring any prerelease/build suffix -- sufficient

--- a/build-tools/check-shrinkwrap-pins.mjs
+++ b/build-tools/check-shrinkwrap-pins.mjs
@@ -24,13 +24,15 @@
 // "latest" dist-tag: if the range excludes a newer major, a broken install could never
 // reach it either, so comparing to absolute latest would flag a canary as fine when it
 // has actually gone vacuous within the range that matters.
+// Exact manifest specs remain in the installed-version check, but cannot discriminate a
+// shrinkwrap install from a fresh resolution, so the discrimination check skips them.
 //
 // Usage: node check-shrinkwrap-pins.mjs <package-root>
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
-const CHECKED_DEPS = ['@harperfast/rocksdb-js', 'fastify'];
+const CHECKED_DEPS = ['@harperfast/rocksdb-js', 'fastify', '@aws-sdk/client-s3'];
 
 const pkgRoot = process.argv[2];
 if (!pkgRoot) {
@@ -85,11 +87,12 @@ for (const dep of CHECKED_DEPS) {
 		continue;
 	}
 
-	console.log(`shrinkwrap honored: ${dep}@${installed} matches the packed pin`);
+	const status = isExactVersion(range) ? 'shrinkwrap pin matches (exact manifest spec)' : 'shrinkwrap honored';
+	console.log(`${status}: ${dep}@${installed} matches the packed pin`);
 }
 
 // A canary only proves the check works while its pin lags the registry -- if a lock bump
-// ever lands both canaries on registry-latest, the pin-match loop above would pass on a
+// ever lands every ranged canary on registry-latest, the pin-match loop above would pass on a
 // reverted, broken Dockerfile just as easily as on this one. Fail loudly rather than let
 // that happen silently.
 verifyCanariesDiscriminate(pins);
@@ -97,11 +100,21 @@ verifyCanariesDiscriminate(pins);
 process.exit(failed ? 1 : 0);
 
 function verifyCanariesDiscriminate(pins) {
+	const rangedPins = Object.fromEntries(Object.entries(pins).filter(([, { range }]) => !isExactVersion(range)));
+	if (Object.keys(rangedPins).length === 0) {
+		console.error(
+			'::error::every checked canary has an exact declared version -- exact dependencies cannot distinguish a shrinkwrap install from a fresh resolution. Add a canary with a ranged manifest spec.'
+		);
+		failed = true;
+		return;
+	}
+
 	// What a broken/reverted install would actually resolve to: the max version satisfying
 	// the declared range, not the registry's bare "latest" dist-tag (which could be a newer
 	// major the range excludes, and a broken install could never reach that either).
 	const rangeLatest = {};
-	for (const [dep, { range }] of Object.entries(pins)) {
+	let failedQueries = 0;
+	for (const [dep, { range }] of Object.entries(rangedPins)) {
 		try {
 			// `npm view <dep>@<range> version --json` returns every matching version, not
 			// just the max, and the order isn't a documented contract (it can track
@@ -114,6 +127,7 @@ function verifyCanariesDiscriminate(pins) {
 				? versions.reduce((max, v) => (compareVersions(v, max) > 0 ? v : max))
 				: versions;
 		} catch (e) {
+			failedQueries++;
 			console.log(
 				`::warning::could not check registry-latest-in-range for ${dep}@${range} (${e.message}) -- skipping discrimination check for it`
 			);
@@ -126,11 +140,21 @@ function verifyCanariesDiscriminate(pins) {
 	}
 	const stillDiscriminates = checkable.some((dep) => rangeLatest[dep] !== pins[dep].pinned);
 	if (!stillDiscriminates) {
+		if (failedQueries) {
+			console.log(
+				'::warning::could not verify every ranged canary still discriminates because one or more registry queries failed'
+			);
+			return;
+		}
 		console.error(
 			`::error::every checked canary (${checkable.join(', ')}) is now pinned at the latest version its declared range allows -- this check would pass even on a reverted, unpinned install. Pick a new canary whose shrinkwrap pin lags what its range allows.`
 		);
 		failed = true;
 	}
+}
+
+function isExactVersion(range) {
+	return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(range);
 }
 
 // Numeric major.minor.patch comparison, ignoring any prerelease/build suffix -- sufficient

--- a/build-tools/check-shrinkwrap-pins.mjs
+++ b/build-tools/check-shrinkwrap-pins.mjs
@@ -130,18 +130,18 @@ function verifyCanariesDiscriminate(pins) {
 				// the last array entry.
 				const out = execFileSync('npm', ['view', `${dep}@${range}`, 'version', '--json'], { encoding: 'utf8' });
 				const versions = JSON.parse(out);
-				if (Array.isArray(versions) && versions.length === 0) {
+				rangeLatest[dep] = Array.isArray(versions)
+					? versions.reduce((max, v) => (compareVersions(v, max) > 0 ? v : max))
+					: versions;
+				break;
+			} catch (e) {
+				if (isNpmNotFoundError(e)) {
 					console.error(
 						`::error::${dep}@${range} matches no published version -- correct the declared range in package.json`
 					);
 					failed = true;
 					return;
 				}
-				rangeLatest[dep] = Array.isArray(versions)
-					? versions.reduce((max, v) => (compareVersions(v, max) > 0 ? v : max))
-					: versions;
-				break;
-			} catch (e) {
 				console.log(
 					`::warning::registry query attempt ${attempt}/${REGISTRY_QUERY_ATTEMPTS} failed for ${dep}@${range} (${e.message})`
 				);
@@ -224,6 +224,14 @@ function isExactVersion(range) {
 		typeof range === 'string' &&
 		/^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(range)
 	);
+}
+
+function isNpmNotFoundError(error) {
+	try {
+		return JSON.parse(error.stdout).error?.code === 'E404';
+	} catch {
+		return false;
+	}
 }
 
 // Numeric major.minor.patch comparison, ignoring any prerelease/build suffix -- sufficient

--- a/build-tools/check-shrinkwrap-pins.mjs
+++ b/build-tools/check-shrinkwrap-pins.mjs
@@ -155,7 +155,7 @@ function verifyCanariesDiscriminate(pins) {
 	if (stillDiscriminates) return;
 	if (failedQueries.length > 0) {
 		console.error(
-			`::error title=Retry dependency canary check::Could not verify that the shrinkwrap canaries still discriminate after ${REGISTRY_QUERY_ATTEMPTS} registry query attempts for ${failedQueries.join(', ')}. Retry this job; if the error persists, check npm registry availability and confirm the listed package ranges match published versions.`
+			`::error title=Retry dependency canary check::Could not verify that the shrinkwrap canaries still discriminate after ${REGISTRY_QUERY_ATTEMPTS} registry query attempts for ${failedQueries.join(', ')}. Retry this job; if the error persists, check npm/registry/runner configuration and confirm the listed package ranges match published versions.`
 		);
 		failed = true;
 		return;
@@ -220,7 +220,10 @@ function verifyRocksDbDependencyAlignment() {
 }
 
 function isExactVersion(range) {
-	return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(range);
+	return (
+		typeof range === 'string' &&
+		/^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(range)
+	);
 }
 
 // Numeric major.minor.patch comparison, ignoring any prerelease/build suffix -- sufficient

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
 				"@fastify/compress": "^8.3.1",
 				"@fastify/cors": "^11.2.0",
 				"@fastify/static": "^9.1.3",
-				"@harperfast/extended-iterable": "^1.0.1",
-				"@harperfast/rocksdb-js": "^2.7.1",
+				"@harperfast/extended-iterable": "1.0.3",
+				"@harperfast/rocksdb-js": "2.7.1",
 				"@harperfast/skills": "^1.10.8",
 				"@turf/area": "6.5.0",
 				"@turf/boolean-contains": "6.5.0",
@@ -61,7 +61,7 @@
 				"minimist": "1.2.8",
 				"moment": "2.30.1",
 				"mqtt-packet": "~9.0.1",
-				"msgpackr": "^2.0.5",
+				"msgpackr": "2.0.5",
 				"needle": "3.5.0",
 				"node-forge": "^1.3.1",
 				"node-stream-zip": "1.16.0",
@@ -82,7 +82,7 @@
 				"ses": "^1.15.0",
 				"stream-chain": "2.2.5",
 				"stream-json": "1.9.1",
-				"structon": "^1.0.7",
+				"structon": "1.0.7",
 				"systeminformation": "^5.31.4",
 				"tar-fs": "^3.1.2",
 				"tar-stream": "^3.1.8",
@@ -141,9 +141,9 @@
 				"node": "^22.18.0 || >=24.0.0"
 			},
 			"optionalDependencies": {
-				"bufferutil": "^4.0.9",
-				"segfault-handler": "^1.3.0",
-				"utf-8-validate": "^5.0.10"
+				"bufferutil": "4.1.0",
+				"segfault-handler": "1.3.0",
+				"utf-8-validate": "5.0.10"
 			},
 			"peerDependencies": {
 				"@aws-sdk/client-bedrock-runtime": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -178,8 +178,8 @@
 		"@fastify/compress": "^8.3.1",
 		"@fastify/cors": "^11.2.0",
 		"@fastify/static": "^9.1.3",
-		"@harperfast/extended-iterable": "^1.0.1",
-		"@harperfast/rocksdb-js": "^2.7.1",
+		"@harperfast/extended-iterable": "1.0.3",
+		"@harperfast/rocksdb-js": "2.7.1",
 		"@harperfast/skills": "^1.10.8",
 		"@turf/area": "6.5.0",
 		"@turf/boolean-contains": "6.5.0",
@@ -223,7 +223,7 @@
 		"minimist": "1.2.8",
 		"moment": "2.30.1",
 		"mqtt-packet": "~9.0.1",
-		"msgpackr": "^2.0.5",
+		"msgpackr": "2.0.5",
 		"needle": "3.5.0",
 		"node-forge": "^1.3.1",
 		"node-stream-zip": "1.16.0",
@@ -244,7 +244,7 @@
 		"ses": "^1.15.0",
 		"stream-chain": "2.2.5",
 		"stream-json": "1.9.1",
-		"structon": "^1.0.7",
+		"structon": "1.0.7",
 		"systeminformation": "^5.31.4",
 		"tar-fs": "^3.1.2",
 		"tar-stream": "^3.1.8",
@@ -261,9 +261,9 @@
 		}
 	},
 	"optionalDependencies": {
-		"bufferutil": "^4.0.9",
-		"segfault-handler": "^1.3.0",
-		"utf-8-validate": "^5.0.10"
+		"bufferutil": "4.1.0",
+		"segfault-handler": "1.3.0",
+		"utf-8-validate": "5.0.10"
 	},
 	"peerDependencies": {
 		"@aws-sdk/client-bedrock-runtime": "^3.0.0",

--- a/unitTests/build-tools/checkShrinkwrapPins.test.mjs
+++ b/unitTests/build-tools/checkShrinkwrapPins.test.mjs
@@ -47,6 +47,22 @@ describe('shrinkwrap pin canaries', function () {
 		}
 	});
 
+	it('fails when a root encoder spec is not exact', async function () {
+		const fixture = await createFixture({
+			'@harperfast/rocksdb-js': '2.7.1',
+			'fastify': '^5.8.2',
+			'@aws-sdk/client-s3': '^3.1012.0',
+			'msgpackr': '^2.0.5',
+		});
+		try {
+			const result = runCheck(fixture);
+			assert.strictEqual(result.status, 1);
+			assert.match(result.stderr, /root msgpackr spec must be exact, received \^2\.0\.5/);
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+
 	it('fails when rocksdb-js installs a nested encoder instance', async function () {
 		const fixture = await createFixture({
 			'@harperfast/rocksdb-js': '2.7.1',

--- a/unitTests/build-tools/checkShrinkwrapPins.test.mjs
+++ b/unitTests/build-tools/checkShrinkwrapPins.test.mjs
@@ -41,7 +41,7 @@ describe('shrinkwrap pin canaries', function () {
 			);
 			const result = runCheck(fixture);
 			assert.strictEqual(result.status, 1);
-			assert.match(result.stderr, /msgpackr must be exact and match rocksdb-js/);
+			assert.match(result.stderr, /root msgpackr pin 2\.0\.5 does not match rocksdb-js 2\.0\.6/);
 		} finally {
 			await fixture.cleanup();
 		}
@@ -270,9 +270,15 @@ async function createFixture(
 		const dependencyDir = join(packageRoot, 'node_modules', dependency);
 		await mkdir(dependencyDir, { recursive: true });
 		const dependencyManifest = {
-			version: installedVersions[dependency] ?? alignedDependencies[dependency] ?? '1.0.0',
+			version:
+				installedVersions[dependency] ??
+				(dependency in alignedDependencies ? packageDependencies[dependency] : '1.0.0'),
 		};
-		if (dependency === '@harperfast/rocksdb-js') dependencyManifest.dependencies = alignedDependencies;
+		if (dependency === '@harperfast/rocksdb-js') {
+			dependencyManifest.dependencies = Object.fromEntries(
+				Object.keys(alignedDependencies).map((dep) => [dep, packageDependencies[dep]])
+			);
+		}
 		await writeFile(join(dependencyDir, 'package.json'), JSON.stringify(dependencyManifest));
 	}
 	await writeFile(
@@ -294,7 +300,7 @@ fi
 case "$2" in
   fastify@*) printf '["1.0.0"]\\n' ;;
   @aws-sdk/client-s3@*) printf '["1.0.0", "1.0.1"]\\n' ;;
-  *) printf 'stub npm: unmodelled query %s\n' "$2" >&2; exit 1 ;;
+  *) printf 'stub npm: unmodelled query %s\\n' "$2" >&2; exit 1 ;;
 esac
 `
 	);

--- a/unitTests/build-tools/checkShrinkwrapPins.test.mjs
+++ b/unitTests/build-tools/checkShrinkwrapPins.test.mjs
@@ -242,7 +242,7 @@ describe('shrinkwrap pin canaries', function () {
 			false,
 			'',
 			3,
-			'@aws-sdk/client-s3@^3.1012.0'
+			{ missingRange: '@aws-sdk/client-s3@^3.1012.0' }
 		);
 		try {
 			const result = runCheck(fixture);
@@ -250,6 +250,54 @@ describe('shrinkwrap pin canaries', function () {
 			assert.match(result.stderr, /matches no published version/);
 			const queries = (await readFile(fixture.queryLog, 'utf8')).split('\n');
 			assert.strictEqual(queries.filter((query) => query === '@aws-sdk/client-s3@^3.1012.0').length, 1);
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+
+	it('fails without retries when a registry returns an empty version list', async function () {
+		const fixture = await createFixture(
+			{
+				'@harperfast/rocksdb-js': '2.7.1',
+				'fastify': '^5.8.2',
+				'@aws-sdk/client-s3': '^3.1012.0',
+			},
+			{},
+			false,
+			'',
+			3,
+			{ emptyRange: '@aws-sdk/client-s3@^3.1012.0' }
+		);
+		try {
+			const result = runCheck(fixture);
+			assert.strictEqual(result.status, 1);
+			assert.match(result.stderr, /matches no published version in the configured registry/);
+			const queries = (await readFile(fixture.queryLog, 'utf8')).split('\n');
+			assert.strictEqual(queries.filter((query) => query === '@aws-sdk/client-s3@^3.1012.0').length, 1);
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+
+	it('retries an invalid successful registry payload instead of treating it as proof', async function () {
+		const fixture = await createFixture(
+			{
+				'@harperfast/rocksdb-js': '2.7.1',
+				'fastify': '^5.8.2',
+				'@aws-sdk/client-s3': '^3.1012.0',
+			},
+			{},
+			true,
+			'',
+			3,
+			{ invalidRange: '@aws-sdk/client-s3@^3.1012.0' }
+		);
+		try {
+			const result = runCheck(fixture);
+			assert.strictEqual(result.status, 1);
+			assert.match(result.stderr, /::error title=Retry dependency canary check::/);
+			const queries = (await readFile(fixture.queryLog, 'utf8')).split('\n');
+			assert.strictEqual(queries.filter((query) => query === '@aws-sdk/client-s3@^3.1012.0').length, 3);
 		} finally {
 			await fixture.cleanup();
 		}
@@ -262,7 +310,7 @@ async function createFixture(
 	allRangeVersionsCurrent = false,
 	failedRange = '',
 	failedAttempts = 3,
-	missingRange = ''
+	registryResponses = {}
 ) {
 	const tempDir = await mkdtemp(join(tmpdir(), 'harper-shrinkwrap-canary-'));
 	const packageRoot = join(tempDir, 'package');
@@ -309,6 +357,14 @@ if [ "$MISSING_RANGE" = "$2" ]; then
   printf '{"error":{"code":"E404","summary":"No match found for version"}}\\n'
   exit 1
 fi
+if [ "$EMPTY_RANGE" = "$2" ]; then
+  printf '[]\\n'
+  exit
+fi
+if [ "$INVALID_RANGE" = "$2" ]; then
+  printf 'null\\n'
+  exit
+fi
 if [ "$ALL_RANGE_VERSIONS_CURRENT" = 1 ]; then
   printf '["1.0.0"]\\n'
   exit
@@ -328,7 +384,7 @@ esac
 		allRangeVersionsCurrent,
 		failedRange,
 		failedAttempts,
-		missingRange,
+		...registryResponses,
 		cleanup: () => rm(tempDir, { recursive: true, force: true }),
 	};
 }
@@ -343,7 +399,9 @@ function runCheck(fixture) {
 			ALL_RANGE_VERSIONS_CURRENT: fixture.allRangeVersionsCurrent ? '1' : '0',
 			FAILED_RANGE: fixture.failedRange,
 			FAILED_ATTEMPTS: String(fixture.failedAttempts),
-			MISSING_RANGE: fixture.missingRange,
+			MISSING_RANGE: fixture.missingRange ?? '',
+			EMPTY_RANGE: fixture.emptyRange ?? '',
+			INVALID_RANGE: fixture.invalidRange ?? '',
 		},
 	});
 }

--- a/unitTests/build-tools/checkShrinkwrapPins.test.mjs
+++ b/unitTests/build-tools/checkShrinkwrapPins.test.mjs
@@ -8,14 +8,69 @@ import { fileURLToPath } from 'node:url';
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const script = join(root, 'build-tools/check-shrinkwrap-pins.mjs');
 const dependencies = ['@harperfast/rocksdb-js', 'fastify', '@aws-sdk/client-s3'];
+const alignedDependencies = {
+	'@harperfast/extended-iterable': '1.0.3',
+	'msgpackr': '2.0.5',
+};
 
 describe('shrinkwrap pin canaries', function () {
-	it('keeps the checked canaries viable in the real manifest', async function () {
+	it('keeps the checked canaries present and ranged in the real manifest', async function () {
 		const manifest = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
 		const fixture = await createFixture(manifest.dependencies);
 		try {
 			const result = runCheck(fixture);
 			assert.strictEqual(result.status, 0, result.stderr);
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+
+	it('fails when a root encoder pin diverges from rocksdb-js', async function () {
+		const fixture = await createFixture({
+			'@harperfast/rocksdb-js': '2.7.1',
+			'fastify': '^5.8.2',
+			'@aws-sdk/client-s3': '^3.1012.0',
+		});
+		try {
+			await writeFile(
+				join(fixture.packageRoot, 'node_modules/@harperfast/rocksdb-js/package.json'),
+				JSON.stringify({
+					version: '1.0.0',
+					dependencies: { ...alignedDependencies, msgpackr: '2.0.6' },
+				})
+			);
+			const result = runCheck(fixture);
+			assert.strictEqual(result.status, 1);
+			assert.match(result.stderr, /msgpackr must be exact and match rocksdb-js/);
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+
+	it('fails when rocksdb-js installs a nested encoder instance', async function () {
+		const fixture = await createFixture({
+			'@harperfast/rocksdb-js': '2.7.1',
+			'fastify': '^5.8.2',
+			'@aws-sdk/client-s3': '^3.1012.0',
+		});
+		try {
+			const nestedDir = join(fixture.packageRoot, 'node_modules/@harperfast/rocksdb-js/node_modules/msgpackr');
+			await mkdir(nestedDir, { recursive: true });
+			await writeFile(join(nestedDir, 'package.json'), JSON.stringify({ version: '2.0.5' }));
+			const result = runCheck(fixture);
+			assert.strictEqual(result.status, 1);
+			assert.match(result.stderr, /rocksdb-js loaded a nested msgpackr@2\.0\.5/);
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+
+	it('does not misdiagnose an empty checked set as all-exact', async function () {
+		const fixture = await createFixture({});
+		try {
+			const result = runCheck(fixture);
+			assert.strictEqual(result.status, 1);
+			assert.doesNotMatch(result.stderr, /every checked canary has an exact declared version/);
 		} finally {
 			await fixture.cleanup();
 		}
@@ -200,7 +255,8 @@ async function createFixture(
 	await mkdir(packageRoot, { recursive: true });
 	await mkdir(binDir, { recursive: true });
 	await writeFile(queryLog, '');
-	await writeFile(join(packageRoot, 'package.json'), JSON.stringify({ dependencies: manifestDependencies }));
+	const packageDependencies = { ...alignedDependencies, ...manifestDependencies };
+	await writeFile(join(packageRoot, 'package.json'), JSON.stringify({ dependencies: packageDependencies }));
 	await writeFile(
 		join(packageRoot, 'npm-shrinkwrap.packed.json'),
 		JSON.stringify({
@@ -210,13 +266,14 @@ async function createFixture(
 			),
 		})
 	);
-	for (const dependency of dependencies) {
+	for (const dependency of [...dependencies, ...Object.keys(alignedDependencies)]) {
 		const dependencyDir = join(packageRoot, 'node_modules', dependency);
 		await mkdir(dependencyDir, { recursive: true });
-		await writeFile(
-			join(dependencyDir, 'package.json'),
-			JSON.stringify({ version: installedVersions[dependency] ?? '1.0.0' })
-		);
+		const dependencyManifest = {
+			version: installedVersions[dependency] ?? alignedDependencies[dependency] ?? '1.0.0',
+		};
+		if (dependency === '@harperfast/rocksdb-js') dependencyManifest.dependencies = alignedDependencies;
+		await writeFile(join(dependencyDir, 'package.json'), JSON.stringify(dependencyManifest));
 	}
 	await writeFile(
 		join(binDir, 'npm'),
@@ -237,7 +294,7 @@ fi
 case "$2" in
   fastify@*) printf '["1.0.0"]\\n' ;;
   @aws-sdk/client-s3@*) printf '["1.0.0", "1.0.1"]\\n' ;;
-  *) exit 1 ;;
+  *) printf 'stub npm: unmodelled query %s\n' "$2" >&2; exit 1 ;;
 esac
 `
 	);

--- a/unitTests/build-tools/checkShrinkwrapPins.test.mjs
+++ b/unitTests/build-tools/checkShrinkwrapPins.test.mjs
@@ -1,0 +1,175 @@
+import assert from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const script = join(root, 'build-tools/check-shrinkwrap-pins.mjs');
+const dependencies = ['@harperfast/rocksdb-js', 'fastify', '@aws-sdk/client-s3'];
+
+describe('shrinkwrap pin canaries', function () {
+	it('does not query exact versions while a ranged canary still discriminates', async function () {
+		const fixture = await createFixture({
+			'@harperfast/rocksdb-js': '2.7.1',
+			'fastify': '^5.8.2',
+			'@aws-sdk/client-s3': '^3.1012.0',
+		});
+		try {
+			const result = runCheck(fixture);
+			assert.strictEqual(result.status, 0, result.stderr);
+			const queries = await readFile(fixture.queryLog, 'utf8');
+			assert.doesNotMatch(queries, /@harperfast\/rocksdb-js/);
+			assert.match(queries, /@aws-sdk\/client-s3@\^3\.1012\.0/);
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+
+	it('still compares exact pins with the installed dependency', async function () {
+		const fixture = await createFixture(
+			{
+				'@harperfast/rocksdb-js': '2.7.1',
+				'fastify': '^5.8.2',
+				'@aws-sdk/client-s3': '^3.1012.0',
+			},
+			{ '@harperfast/rocksdb-js': '1.0.1' }
+		);
+		try {
+			const result = runCheck(fixture);
+			assert.strictEqual(result.status, 1);
+			assert.match(result.stderr, /@harperfast\/rocksdb-js resolved to 1\.0\.1 but the packed shrinkwrap pins 1\.0\.0/);
+			assert.doesNotMatch(await readFile(fixture.queryLog, 'utf8'), /@harperfast\/rocksdb-js/);
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+
+	it('fails when every canary has an exact manifest version', async function () {
+		const fixture = await createFixture(Object.fromEntries(dependencies.map((dependency) => [dependency, '1.0.0'])));
+		try {
+			const result = runCheck(fixture);
+			assert.strictEqual(result.status, 1);
+			assert.match(result.stderr, /every checked canary has an exact declared version/);
+			assert.strictEqual(await readFile(fixture.queryLog, 'utf8'), '');
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+
+	it('fails when every ranged canary is pinned at its max-in-range version', async function () {
+		const fixture = await createFixture(
+			{
+				'@harperfast/rocksdb-js': '2.7.1',
+				'fastify': '^5.8.2',
+				'@aws-sdk/client-s3': '^3.1012.0',
+			},
+			{},
+			true
+		);
+		try {
+			const result = runCheck(fixture);
+			assert.strictEqual(result.status, 1);
+			assert.match(
+				result.stderr,
+				/every checked canary \(fastify, @aws-sdk\/client-s3\) is now pinned at the latest version/
+			);
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+
+	it('warns when a registry failure leaves no discriminating ranged canary to verify', async function () {
+		const fixture = await createFixture(
+			{
+				'@harperfast/rocksdb-js': '2.7.1',
+				'fastify': '^5.8.2',
+				'@aws-sdk/client-s3': '^3.1012.0',
+			},
+			{},
+			true,
+			'@aws-sdk/client-s3@^3.1012.0'
+		);
+		try {
+			const result = runCheck(fixture);
+			assert.strictEqual(result.status, 0, result.stderr);
+			assert.match(result.stdout, /could not verify every ranged canary still discriminates/);
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+});
+
+async function createFixture(
+	manifestDependencies,
+	installedVersions = {},
+	allRangeVersionsCurrent = false,
+	failedRange = ''
+) {
+	const tempDir = await mkdtemp(join(tmpdir(), 'harper-shrinkwrap-canary-'));
+	const packageRoot = join(tempDir, 'package');
+	const binDir = join(tempDir, 'bin');
+	const queryLog = join(tempDir, 'queries.log');
+	await mkdir(packageRoot, { recursive: true });
+	await mkdir(binDir, { recursive: true });
+	await writeFile(queryLog, '');
+	await writeFile(join(packageRoot, 'package.json'), JSON.stringify({ dependencies: manifestDependencies }));
+	await writeFile(
+		join(packageRoot, 'npm-shrinkwrap.packed.json'),
+		JSON.stringify({
+			lockfileVersion: 3,
+			packages: Object.fromEntries(
+				dependencies.map((dependency) => [`node_modules/${dependency}`, { version: '1.0.0' }])
+			),
+		})
+	);
+	for (const dependency of dependencies) {
+		const dependencyDir = join(packageRoot, 'node_modules', dependency);
+		await mkdir(dependencyDir, { recursive: true });
+		await writeFile(
+			join(dependencyDir, 'package.json'),
+			JSON.stringify({ version: installedVersions[dependency] ?? '1.0.0' })
+		);
+	}
+	await writeFile(
+		join(binDir, 'npm'),
+		`#!/bin/sh
+printf '%s\\n' "$2" >> "$QUERY_LOG"
+if [ "$FAILED_RANGE" = "$2" ]; then
+  exit 1
+fi
+if [ "$ALL_RANGE_VERSIONS_CURRENT" = 1 ]; then
+  printf '["1.0.0"]\\n'
+  exit
+fi
+case "$2" in
+  fastify@\^5.8.2) printf '["1.0.0"]\\n' ;;
+  @aws-sdk/client-s3@\^3.1012.0) printf '["1.0.0", "1.0.1"]\\n' ;;
+  *) exit 1 ;;
+esac
+`
+	);
+	await chmod(join(binDir, 'npm'), 0o755);
+	return {
+		binDir,
+		packageRoot,
+		queryLog,
+		allRangeVersionsCurrent,
+		failedRange,
+		cleanup: () => rm(tempDir, { recursive: true, force: true }),
+	};
+}
+
+function runCheck(fixture) {
+	return spawnSync(process.execPath, [script, fixture.packageRoot], {
+		encoding: 'utf8',
+		env: {
+			...process.env,
+			PATH: `${fixture.binDir}:${process.env.PATH}`,
+			QUERY_LOG: fixture.queryLog,
+			ALL_RANGE_VERSIONS_CURRENT: fixture.allRangeVersionsCurrent ? '1' : '0',
+			FAILED_RANGE: fixture.failedRange,
+		},
+	});
+}

--- a/unitTests/build-tools/checkShrinkwrapPins.test.mjs
+++ b/unitTests/build-tools/checkShrinkwrapPins.test.mjs
@@ -80,7 +80,51 @@ describe('shrinkwrap pin canaries', function () {
 		}
 	});
 
-	it('warns when a registry failure leaves no discriminating ranged canary to verify', async function () {
+	it('retries a transient registry failure before evaluating the canary set', async function () {
+		const fixture = await createFixture(
+			{
+				'@harperfast/rocksdb-js': '2.7.1',
+				'fastify': '^5.8.2',
+				'@aws-sdk/client-s3': '^3.1012.0',
+			},
+			{},
+			false,
+			'@aws-sdk/client-s3@^3.1012.0',
+			1
+		);
+		try {
+			const result = runCheck(fixture);
+			assert.strictEqual(result.status, 0, result.stderr);
+			assert.match(result.stdout, /registry query attempt 1\/3 failed/);
+			const queries = (await readFile(fixture.queryLog, 'utf8')).split('\n');
+			assert.strictEqual(queries.filter((query) => query === '@aws-sdk/client-s3@^3.1012.0').length, 2);
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+
+	it('accepts a proven canary after another registry query exhausts its retries', async function () {
+		const fixture = await createFixture(
+			{
+				'@harperfast/rocksdb-js': '2.7.1',
+				'fastify': '^5.8.2',
+				'@aws-sdk/client-s3': '^3.1012.0',
+			},
+			{},
+			false,
+			'fastify@^5.8.2'
+		);
+		try {
+			const result = runCheck(fixture);
+			assert.strictEqual(result.status, 0, result.stderr);
+			const queries = (await readFile(fixture.queryLog, 'utf8')).split('\n');
+			assert.strictEqual(queries.filter((query) => query === 'fastify@^5.8.2').length, 3);
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+
+	it('fails with a retry-specific error when registry failures leave no proven canary', async function () {
 		const fixture = await createFixture(
 			{
 				'@harperfast/rocksdb-js': '2.7.1',
@@ -93,8 +137,12 @@ describe('shrinkwrap pin canaries', function () {
 		);
 		try {
 			const result = runCheck(fixture);
-			assert.strictEqual(result.status, 0, result.stderr);
-			assert.match(result.stdout, /could not verify every ranged canary still discriminates/);
+			assert.strictEqual(result.status, 1);
+			assert.match(result.stderr, /::error title=Retry dependency canary check::/);
+			assert.match(result.stderr, /after 3 registry query attempts/);
+			assert.match(result.stderr, /Retry this job/);
+			const queries = (await readFile(fixture.queryLog, 'utf8')).split('\n');
+			assert.strictEqual(queries.filter((query) => query === '@aws-sdk/client-s3@^3.1012.0').length, 3);
 		} finally {
 			await fixture.cleanup();
 		}
@@ -105,7 +153,8 @@ async function createFixture(
 	manifestDependencies,
 	installedVersions = {},
 	allRangeVersionsCurrent = false,
-	failedRange = ''
+	failedRange = '',
+	failedAttempts = 3
 ) {
 	const tempDir = await mkdtemp(join(tmpdir(), 'harper-shrinkwrap-canary-'));
 	const packageRoot = join(tempDir, 'package');
@@ -136,7 +185,8 @@ async function createFixture(
 		join(binDir, 'npm'),
 		`#!/bin/sh
 printf '%s\\n' "$2" >> "$QUERY_LOG"
-if [ "$FAILED_RANGE" = "$2" ]; then
+attempt=$(grep -Fxc "$2" "$QUERY_LOG")
+if [ "$FAILED_RANGE" = "$2" ] && [ "$attempt" -le "$FAILED_ATTEMPTS" ]; then
   exit 1
 fi
 if [ "$ALL_RANGE_VERSIONS_CURRENT" = 1 ]; then
@@ -157,6 +207,7 @@ esac
 		queryLog,
 		allRangeVersionsCurrent,
 		failedRange,
+		failedAttempts,
 		cleanup: () => rm(tempDir, { recursive: true, force: true }),
 	};
 }
@@ -170,6 +221,7 @@ function runCheck(fixture) {
 			QUERY_LOG: fixture.queryLog,
 			ALL_RANGE_VERSIONS_CURRENT: fixture.allRangeVersionsCurrent ? '1' : '0',
 			FAILED_RANGE: fixture.failedRange,
+			FAILED_ATTEMPTS: String(fixture.failedAttempts),
 		},
 	});
 }

--- a/unitTests/build-tools/checkShrinkwrapPins.test.mjs
+++ b/unitTests/build-tools/checkShrinkwrapPins.test.mjs
@@ -231,7 +231,7 @@ describe('shrinkwrap pin canaries', function () {
 		}
 	});
 
-	it('fails without retries when a registry query matches no published version', async function () {
+	it('fails without retries when npm reports no matching published version', async function () {
 		const fixture = await createFixture(
 			{
 				'@harperfast/rocksdb-js': '2.7.1',
@@ -262,7 +262,7 @@ async function createFixture(
 	allRangeVersionsCurrent = false,
 	failedRange = '',
 	failedAttempts = 3,
-	emptyRange = ''
+	missingRange = ''
 ) {
 	const tempDir = await mkdtemp(join(tmpdir(), 'harper-shrinkwrap-canary-'));
 	const packageRoot = join(tempDir, 'package');
@@ -305,9 +305,9 @@ attempt=$(grep -Fxc "$2" "$QUERY_LOG")
 if [ "$FAILED_RANGE" = "$2" ] && [ "$attempt" -le "$FAILED_ATTEMPTS" ]; then
   exit 1
 fi
-if [ "$EMPTY_RANGE" = "$2" ]; then
-  printf '[]\\n'
-  exit
+if [ "$MISSING_RANGE" = "$2" ]; then
+  printf '{"error":{"code":"E404","summary":"No match found for version"}}\\n'
+  exit 1
 fi
 if [ "$ALL_RANGE_VERSIONS_CURRENT" = 1 ]; then
   printf '["1.0.0"]\\n'
@@ -328,7 +328,7 @@ esac
 		allRangeVersionsCurrent,
 		failedRange,
 		failedAttempts,
-		emptyRange,
+		missingRange,
 		cleanup: () => rm(tempDir, { recursive: true, force: true }),
 	};
 }
@@ -343,7 +343,7 @@ function runCheck(fixture) {
 			ALL_RANGE_VERSIONS_CURRENT: fixture.allRangeVersionsCurrent ? '1' : '0',
 			FAILED_RANGE: fixture.failedRange,
 			FAILED_ATTEMPTS: String(fixture.failedAttempts),
-			EMPTY_RANGE: fixture.emptyRange,
+			MISSING_RANGE: fixture.missingRange,
 		},
 	});
 }

--- a/unitTests/build-tools/checkShrinkwrapPins.test.mjs
+++ b/unitTests/build-tools/checkShrinkwrapPins.test.mjs
@@ -10,6 +10,17 @@ const script = join(root, 'build-tools/check-shrinkwrap-pins.mjs');
 const dependencies = ['@harperfast/rocksdb-js', 'fastify', '@aws-sdk/client-s3'];
 
 describe('shrinkwrap pin canaries', function () {
+	it('keeps the checked canaries viable in the real manifest', async function () {
+		const manifest = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
+		const fixture = await createFixture(manifest.dependencies);
+		try {
+			const result = runCheck(fixture);
+			assert.strictEqual(result.status, 0, result.stderr);
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+
 	it('does not query exact versions while a ranged canary still discriminates', async function () {
 		const fixture = await createFixture({
 			'@harperfast/rocksdb-js': '2.7.1',
@@ -141,8 +152,33 @@ describe('shrinkwrap pin canaries', function () {
 			assert.match(result.stderr, /::error title=Retry dependency canary check::/);
 			assert.match(result.stderr, /after 3 registry query attempts/);
 			assert.match(result.stderr, /Retry this job/);
+			assert.match(result.stderr, /confirm the listed package ranges match published versions/);
 			const queries = (await readFile(fixture.queryLog, 'utf8')).split('\n');
 			assert.strictEqual(queries.filter((query) => query === '@aws-sdk/client-s3@^3.1012.0').length, 3);
+		} finally {
+			await fixture.cleanup();
+		}
+	});
+
+	it('fails without retries when a registry query matches no published version', async function () {
+		const fixture = await createFixture(
+			{
+				'@harperfast/rocksdb-js': '2.7.1',
+				'fastify': '^5.8.2',
+				'@aws-sdk/client-s3': '^3.1012.0',
+			},
+			{},
+			false,
+			'',
+			3,
+			'@aws-sdk/client-s3@^3.1012.0'
+		);
+		try {
+			const result = runCheck(fixture);
+			assert.strictEqual(result.status, 1);
+			assert.match(result.stderr, /matches no published version/);
+			const queries = (await readFile(fixture.queryLog, 'utf8')).split('\n');
+			assert.strictEqual(queries.filter((query) => query === '@aws-sdk/client-s3@^3.1012.0').length, 1);
 		} finally {
 			await fixture.cleanup();
 		}
@@ -154,7 +190,8 @@ async function createFixture(
 	installedVersions = {},
 	allRangeVersionsCurrent = false,
 	failedRange = '',
-	failedAttempts = 3
+	failedAttempts = 3,
+	emptyRange = ''
 ) {
 	const tempDir = await mkdtemp(join(tmpdir(), 'harper-shrinkwrap-canary-'));
 	const packageRoot = join(tempDir, 'package');
@@ -189,13 +226,17 @@ attempt=$(grep -Fxc "$2" "$QUERY_LOG")
 if [ "$FAILED_RANGE" = "$2" ] && [ "$attempt" -le "$FAILED_ATTEMPTS" ]; then
   exit 1
 fi
+if [ "$EMPTY_RANGE" = "$2" ]; then
+  printf '[]\\n'
+  exit
+fi
 if [ "$ALL_RANGE_VERSIONS_CURRENT" = 1 ]; then
   printf '["1.0.0"]\\n'
   exit
 fi
 case "$2" in
-  fastify@\^5.8.2) printf '["1.0.0"]\\n' ;;
-  @aws-sdk/client-s3@\^3.1012.0) printf '["1.0.0", "1.0.1"]\\n' ;;
+  fastify@*) printf '["1.0.0"]\\n' ;;
+  @aws-sdk/client-s3@*) printf '["1.0.0", "1.0.1"]\\n' ;;
   *) exit 1 ;;
 esac
 `
@@ -208,6 +249,7 @@ esac
 		allRangeVersionsCurrent,
 		failedRange,
 		failedAttempts,
+		emptyRange,
 		cleanup: () => rm(tempDir, { recursive: true, force: true }),
 	};
 }
@@ -222,6 +264,7 @@ function runCheck(fixture) {
 			ALL_RANGE_VERSIONS_CURRENT: fixture.allRangeVersionsCurrent ? '1' : '0',
 			FAILED_RANGE: fixture.failedRange,
 			FAILED_ATTEMPTS: String(fixture.failedAttempts),
+			EMPTY_RANGE: fixture.emptyRange,
 		},
 	});
 }


### PR DESCRIPTION
A caret range does not bind the version that reaches a running Harper node. harper-pro, a rebuilt container, and anyone installing published `harper` without this lockfile can resolve a newer native or encoder dependency without a Harper PR or human merge.

This PR converts the load-bearing ranges to the versions the lockfile already resolved. No installed dependency moves; only the allowed resolution narrows. The pins cover rocksdb-js, the encoder/iterator modules whose identity crosses its boundary, structon, and the optional native addons.

The module identity is now enforced rather than documented as an assumption. Docker smoke requires the root `msgpackr` and `@harperfast/extended-iterable` specs to be exact and byte-equal to rocksdb-js's requirements, verifies their installed root versions, and rejects a nested copy under rocksdb-js. A rocksdb-js automation or Renovate PR that moves only one side will therefore fail before it can merge.

The shrinkwrap canary remains meaningful after rocksdb-js becomes exact: exact specs still participate in installed-versus-packed comparison but not range discrimination, while ranged `fastify` and `@aws-sdk/client-s3` provide the discrimination proof. Registry queries retry three times with 1s/2s backoff. If the surviving canaries are current and a query remains unresolved, the check fails closed with a retry-specific error; Kris selected that behavior rather than treating “unknown” as “current.”

## For the human reviewer

1. **Exact pins in a published library.** These constraints propagate to consumers, which is the intended guarantee. The cost is that a consumer needs a Harper release to take a patch of these dependencies.
2. **Optional native scope.** `bufferutil`, `segfault-handler`, and `utf-8-validate` are exact because their prebuild/platform behavior is load-bearing, but exact optional pins also remove the in-range escape when a new Node ABI needs a newer prebuild. Their absence is largely silent today.
3. **Consumer layout.** Docker smoke proves the Harper image has one rocksdb-js-facing encoder/iterator instance. It cannot prove every downstream harper-pro or npm-consumer tree has the same layout; that remains the main boundary a human should consider.

The pre-existing lock entries for `@harperfast/extended-iterable` and `segfault-handler` still lack `resolved`/`integrity`. That pattern is lockfile-wide rather than introduced here, but an exact version without a tarball hash is a weaker supply-chain guarantee.

## Verification

- `npm run build`
- `npm run lint:required`
- `npx mocha unitTests/build-tools/checkShrinkwrapPins.test.mjs` — 13 passing
- `npm run test:unit:resources` — 1,556 passing, 15 pending
- Regression proof: the three retry/fail-closed cases fail against the pre-fix script and pass at this head.
- The focused suite spawns the real checker process and covers exact/ranged canaries, transient and exhausted queries, empty registry results, real-manifest viability, lockstep divergence, ranged encoder regressions, and nested module copies.
- GitHub: 42 checks passed and two intentionally skipped. This includes Docker smoke, Node 22/24/26 unit tests, adapters, and the complete Linux/Windows/Bun/uWS integration matrix. The first Node 22 attempt hit the unrelated immediate-expiration cache flake in `unitTests/apiTests/cache-test.mjs:69`; its isolated rerun passed.

The local umbrella unit/integration reruns were not clean under this machine's forced isolated Harper root: unrelated config/logger tests expected the user boot configuration, and one high-volume integration run returned nonzero without preserving the failing case in its truncated output. The prior PR head passed both umbrella suites, and the authoritative current-head GitHub matrices are green.

## Review coverage

Authored by GPT-5.6 Codex. Independent pre-push review covered the full PR with Claude and the Harper-domain adjudicator, plus delta rounds with Claude and Gemini. Earlier rounds also included Cursor Grok; Cursor Composer was pruned. The final delta review found the build tooling complete and carried only the dependency-policy decisions above.

<sub>Human-Review-Need: 4 @ 3e2adc81e285</sub>
