### PR TITLE
Add review-coverage CI check (report mode)

### DIFF
--- a/.github/actions/review-coverage/action.yml
+++ b/.github/actions/review-coverage/action.yml
@@ -1,0 +1,26 @@
+# Cross-model review-coverage check — the CI surface of the dispatch human-review gate.
+# Parses the PR description with the gate's parser (reviewGate.mjs alongside; canonical
+# runtime copy in HarperFast/dispatch) and reports how many cross-model reviews it names.
+# This public copy lives in harper because GitHub does not allow public repos to use
+# actions hosted in private repos; other public HarperFast repos pin it by sha:
+#
+#   - uses: HarperFast/harper/.github/actions/review-coverage@<full sha> # main
+#
+name: review-coverage
+description: Report (or enforce) cross-model review coverage named in the PR description
+inputs:
+  mode:
+    description: report (always green, informational) or enforce (red when under-reported)
+    default: report
+  required:
+    description: how many distinct cross-model review families the description must name
+    default: '2'
+runs:
+  using: composite
+  steps:
+    - name: evaluate coverage
+      shell: bash
+      env:
+        REVIEW_COVERAGE_MODE: ${{ inputs.mode }}
+        REVIEW_COVERAGE_REQUIRED: ${{ inputs.required }}
+      run: node "${{ github.action_path }}/ci-review-coverage.mjs"

--- a/.github/actions/review-coverage/action.yml
+++ b/.github/actions/review-coverage/action.yml
@@ -16,11 +16,5 @@ inputs:
     description: how many distinct cross-model review families the description must name
     default: '2'
 runs:
-  using: composite
-  steps:
-    - name: evaluate coverage
-      shell: bash
-      env:
-        REVIEW_COVERAGE_MODE: ${{ inputs.mode }}
-        REVIEW_COVERAGE_REQUIRED: ${{ inputs.required }}
-      run: node "${{ github.action_path }}/ci-review-coverage.mjs"
+  using: node24
+  main: ci-review-coverage.mjs

--- a/.github/actions/review-coverage/ci-review-coverage.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.mjs
@@ -14,6 +14,14 @@ import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { COVERAGE_REQUIRED, isTrivialChange, reportedCrossModelReviews } from './reviewGate.mjs';
 
+const NON_MEMBER_ASSOCIATIONS = new Set([
+	'COLLABORATOR',
+	'CONTRIBUTOR',
+	'FIRST_TIME_CONTRIBUTOR',
+	'FIRST_TIMER',
+	'NONE',
+]);
+
 /** The whole decision, pure. `pr` is the pull_request object from the Actions event
  *  payload. Returns { pass, exempt, summary, detail } — `pass` already accounts for mode. */
 export function evaluateCiCoverage(pr, { mode = 'report', required = COVERAGE_REQUIRED } = {}) {
@@ -30,7 +38,7 @@ export function evaluateCiCoverage(pr, { mode = 'report', required = COVERAGE_RE
 
 	// The Human-Review-Need footer is evidence a prepush review RAN; staleness means
 	// commits landed after the last reviewed head (HEG step 14's most-skipped step).
-	const footer = body.match(/Human-Review-Need:\s*(\d)(?:[^@\n]*)@\s*([0-9a-f]{6,40})/i);
+	const footer = body.match(/Human-Review-Need:\s*(\d+)(?:[^@\n]*)@\s*([0-9a-f]{6,40})/i);
 	const head = String(pr?.head?.sha ?? '');
 	const footerNote = !footer
 		? 'no Human-Review-Need footer'
@@ -40,15 +48,11 @@ export function evaluateCiCoverage(pr, { mode = 'report', required = COVERAGE_RE
 
 	// The triviality exemption requires the size fields to actually be present: a payload
 	// missing additions/deletions would otherwise read as 0+0 and silently exempt everything.
-	const sized =
-		Number.isFinite(Number(pr?.additions)) &&
-		Number.isFinite(Number(pr?.deletions)) &&
-		pr?.additions !== undefined &&
-		pr?.deletions !== undefined;
+	const sized = Number.isFinite(pr?.additions) && Number.isFinite(pr?.deletions);
 	const exempt =
-		/\[bot\]$/.test(login) || pr?.user?.type === 'Bot'
+		login.endsWith('[bot]') || pr?.user?.type === 'Bot'
 			? 'bot author'
-			: !(assoc === 'MEMBER' || assoc === 'OWNER')
+			: NON_MEMBER_ASSOCIATIONS.has(assoc)
 				? `author is not an org member (${assoc || 'unknown'}) — always human review`
 				: sized && isTrivialChange(pr?.additions, pr?.deletions)
 					? 'trivial change (≤2 lines)'
@@ -71,7 +75,9 @@ function main(mode) {
 	if (!eventPath) throw new Error('no event payload (--event or GITHUB_EVENT_PATH)');
 	const pr = JSON.parse(readFileSync(eventPath, 'utf8')).pull_request;
 	if (!pr) throw new Error('event payload has no pull_request');
-	const required = Number(arg('required', process.env.REVIEW_COVERAGE_REQUIRED ?? '')) || COVERAGE_REQUIRED;
+	const rawRequired = arg('required', process.env.REVIEW_COVERAGE_REQUIRED ?? '');
+	const required = rawRequired === '' ? COVERAGE_REQUIRED : Number(rawRequired);
+	if (!Number.isInteger(required) || required < 0) throw new Error(`invalid required '${rawRequired}'`);
 	const r = evaluateCiCoverage(pr, { mode, required });
 
 	const lines = [
@@ -103,7 +109,7 @@ function main(mode) {
 
 function invokedDirectly() {
 	try {
-		return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
+		return realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
 	} catch {
 		return false;
 	}

--- a/.github/actions/review-coverage/ci-review-coverage.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// CI surface for the human-review gate (policy: skills/pr-shepherd/SKILL.md; enforcement:
+// dispatch/lib/reviewGate.mjs via ReviewApi). This check makes coverage REPORTING visible
+// on the PR itself at open/edit time. It deliberately cannot replicate the gate: CI never
+// sees the fleet review's verdict, so demanding coverage here is STRICTER than policy
+// (the gate waives coverage for clean reviews). Hence two modes:
+//   report  (default) — always green; the check text and job summary carry the count
+//   enforce — red when a member-authored, non-trivial, non-draft PR reports <2
+// Run from the composite action in this directory, or locally:
+//   node scripts/ci-review-coverage.mjs --event <payload.json> [--mode enforce]
+
+import { readFileSync, appendFileSync } from 'node:fs';
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+	COVERAGE_REQUIRED, isTrivialChange, reportedCrossModelReviews,
+} from './reviewGate.mjs';
+
+/** The whole decision, pure. `pr` is the pull_request object from the Actions event
+ *  payload. Returns { pass, exempt, summary, detail } — `pass` already accounts for mode. */
+export function evaluateCiCoverage(pr, { mode = 'report', required = COVERAGE_REQUIRED } = {}) {
+	const login = String(pr?.user?.login ?? '');
+	const assoc = String(pr?.author_association ?? '');
+	const body = String(pr?.body ?? '');
+	const { count, families } = reportedCrossModelReviews(body);
+	const coverage = count >= required
+		? `${count} cross-model reviews reported (${families.join(', ')})`
+		: count === 1 ? `1 cross-model review reported (${families.join(', ')}) — policy asks for ${required}`
+		: `no cross-model reviews reported — policy asks for ${required}`;
+
+	// The Human-Review-Need footer is evidence a prepush review RAN; staleness means
+	// commits landed after the last reviewed head (HEG step 14's most-skipped step).
+	const footer = body.match(/Human-Review-Need:\s*(\d)(?:[^@\n]*)@\s*([0-9a-f]{6,40})/i);
+	const head = String(pr?.head?.sha ?? '');
+	const footerNote = !footer ? 'no Human-Review-Need footer'
+		: head.startsWith(footer[2].toLowerCase()) ? `Human-Review-Need: ${footer[1]} @ head`
+		: `Human-Review-Need footer is STALE (reviewed @ ${footer[2].slice(0, 7)}, head is ${head.slice(0, 7)})`;
+
+	// The triviality exemption requires the size fields to actually be present: a payload
+	// missing additions/deletions would otherwise read as 0+0 and silently exempt everything.
+	const sized = Number.isFinite(Number(pr?.additions)) && Number.isFinite(Number(pr?.deletions))
+		&& (pr?.additions !== undefined && pr?.deletions !== undefined);
+	const exempt = /\[bot\]$/.test(login) || pr?.user?.type === 'Bot' ? 'bot author'
+		: !(assoc === 'MEMBER' || assoc === 'OWNER') ? `author is not an org member (${assoc || 'unknown'}) — always human review`
+		: sized && isTrivialChange(pr?.additions, pr?.deletions) ? 'trivial change (≤2 lines)'
+		: pr?.draft ? 'draft — checked again at ready-for-review'
+		: '';
+	const compliant = count >= required;
+	const pass = mode !== 'enforce' || Boolean(exempt) || compliant;
+	const summary = exempt ? `exempt: ${exempt}` : coverage;
+	return { pass, exempt, compliant, count, families, summary, detail: `${coverage}; ${footerNote}` };
+}
+
+function arg(name, fallback = '') {
+	const i = process.argv.indexOf(`--${name}`);
+	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+function main(mode) {
+	const eventPath = arg('event', process.env.GITHUB_EVENT_PATH ?? '');
+	if (!eventPath) throw new Error('no event payload (--event or GITHUB_EVENT_PATH)');
+	const pr = JSON.parse(readFileSync(eventPath, 'utf8')).pull_request;
+	if (!pr) throw new Error('event payload has no pull_request');
+	const required = Number(arg('required', process.env.REVIEW_COVERAGE_REQUIRED ?? '')) || COVERAGE_REQUIRED;
+	const r = evaluateCiCoverage(pr, { mode, required });
+
+	const lines = [
+		`### Cross-model review coverage — ${r.pass ? (r.exempt ? '✅ exempt' : r.compliant ? '✅' : '⚠️ report-only') : '❌'}`,
+		'', r.detail, '',
+		r.exempt ? `_${r.exempt}_`
+			: r.compliant ? ''
+			: `Per team policy, a substantive PR is queued for human review only after ${required} cross-model reviews are run and reported in the description (\`## Review coverage\` naming each model — see harper-engineering-guidelines). The dispatch review gate enforces this when the fleet's review finds issues; this check just makes the reporting visible early.`,
+	].filter(Boolean);
+	if (process.env.GITHUB_STEP_SUMMARY) appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n') + '\n');
+	console.log(`review-coverage [${mode}]: ${r.exempt ? r.summary : r.detail}`);
+	// report mode stays green, but an under-reported PR still gets the count on the PR
+	// surface as a warning annotation rather than only in the job summary
+	if (r.pass && !r.exempt && !r.compliant)
+		console.error(`::warning::${r.detail} — the dispatch gate will block at review time if the fleet's review finds issues`);
+	if (!r.pass) {
+		console.error(`::error::${r.detail} — report the reviews in the PR description to pass; the dispatch gate will block at review time if the fleet's review also finds issues`);
+		process.exitCode = 1;
+	}
+}
+
+function invokedDirectly() {
+	try { return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url); } catch { return false; }
+}
+if (invokedDirectly()) {
+	const mode = (arg('mode', process.env.REVIEW_COVERAGE_MODE ?? 'report')).toLowerCase();
+	if (mode !== 'report' && mode !== 'enforce') {
+		// a typo'd mode must be loud — 'enfroce' silently meaning report is the bad direction
+		console.error(`::error::review-coverage: unknown mode '${mode}' (report|enforce)`);
+		process.exitCode = 1;
+	} else {
+		try { main(mode); } catch (error) {
+			// plumbing failures follow the mode: informational stays green, but an enforcing
+			// check that cannot read its payload must not silently wave PRs through
+			console.error(`review-coverage: ${error.message}${mode === 'enforce' ? '' : ' (passing — report mode fails only on policy)'}`);
+			if (mode === 'enforce') {
+				console.error(`::error::review-coverage could not evaluate this PR (${error.message}) — enforce mode fails closed`);
+				process.exitCode = 1;
+			}
+		}
+	}
+}

--- a/.github/actions/review-coverage/ci-review-coverage.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.mjs
@@ -9,60 +9,9 @@
 // Run from the JavaScript action in this directory, or locally:
 //   node .github/actions/review-coverage/ci-review-coverage.mjs --event <payload.json> [--mode enforce]
 
-import { appendFileSync, readFileSync, realpathSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { COVERAGE_REQUIRED, isTrivialChange, reportedCrossModelReviews } from './reviewGate.mjs';
-
-const NON_MEMBER_ASSOCIATIONS = new Set([
-	'COLLABORATOR',
-	'CONTRIBUTOR',
-	'FIRST_TIME_CONTRIBUTOR',
-	'FIRST_TIMER',
-	'MANNEQUIN',
-	'NONE',
-]);
-
-/** The whole decision, pure. `pr` is the pull_request object from the Actions event
- *  payload. Returns { pass, exempt, summary, detail } — `pass` already accounts for mode. */
-export function evaluateCiCoverage(pr, { mode = 'report', required = COVERAGE_REQUIRED } = {}) {
-	const login = String(pr?.user?.login ?? '');
-	const assoc = String(pr?.author_association ?? '');
-	const body = String(pr?.body ?? '');
-	const { count, families } = reportedCrossModelReviews(body);
-	const plural = count === 1 ? 'review' : 'reviews';
-	const reported = `${count} cross-model ${plural} reported${families.length ? ` (${families.join(', ')})` : ''}`;
-	const coverage = count >= required ? reported : `${reported} — policy asks for ${required}`;
-
-	// The Human-Review-Need footer is evidence a prepush review RAN; staleness means
-	// commits landed after the last reviewed head (HEG step 14's most-skipped step).
-	const footer = [...body.matchAll(/Human-Review-Need:\s*(\d+)(?:[^@\n]*@\s*([0-9a-f]{6,40}))?/gi)].at(-1);
-	const head = String(pr?.head?.sha ?? '').toLowerCase();
-	const footerNote = !footer
-		? 'no Human-Review-Need footer'
-		: !footer[2]
-			? `Human-Review-Need: ${footer[1]} @ unpinned sha`
-			: head.startsWith(footer[2].toLowerCase())
-				? `Human-Review-Need: ${footer[1]} @ head`
-				: `Human-Review-Need footer is STALE (reviewed @ ${footer[2].slice(0, 7)}, head is ${head.slice(0, 7)})`;
-
-	// The triviality exemption requires the size fields to actually be present: a payload
-	// missing additions/deletions would otherwise read as 0+0 and silently exempt everything.
-	const sized = Number.isFinite(pr?.additions) && Number.isFinite(pr?.deletions);
-	const exempt =
-		login.endsWith('[bot]') || pr?.user?.type === 'Bot'
-			? 'bot author'
-			: NON_MEMBER_ASSOCIATIONS.has(assoc)
-				? `author is not an org member (${assoc}) — always human review`
-				: sized && isTrivialChange(pr?.additions, pr?.deletions)
-					? 'trivial change (≤2 lines)'
-					: pr?.draft
-						? 'draft — checked again at ready-for-review'
-						: '';
-	const compliant = count >= required;
-	const pass = mode !== 'enforce' || Boolean(exempt) || compliant;
-	const summary = exempt ? `exempt: ${exempt}` : coverage;
-	return { pass, exempt, compliant, count, families, summary, detail: `${coverage}; ${footerNote}` };
-}
+import { appendFileSync, readFileSync } from 'node:fs';
+import { evaluateCiCoverage } from './evaluateCiCoverage.mjs';
+import { COVERAGE_REQUIRED } from './reviewGate.mjs';
 
 function arg(name, fallback = '') {
 	const i = process.argv.indexOf(`--${name}`);
@@ -98,8 +47,6 @@ function main(mode) {
 		}
 	}
 	console.log(`review-coverage [${mode}]: ${r.exempt ? r.summary : r.detail}`);
-	// report mode stays green, but an under-reported PR still gets the count on the PR
-	// surface as a warning annotation rather than only in the job summary
 	if (r.pass && !r.exempt && !r.compliant)
 		console.error(
 			`::warning::${r.detail} — the dispatch gate will block at review time if the fleet's review finds issues`
@@ -112,34 +59,21 @@ function main(mode) {
 	}
 }
 
-function invokedDirectly() {
+const mode = arg('mode', process.env.INPUT_MODE || process.env.REVIEW_COVERAGE_MODE || 'report').toLowerCase();
+if (mode !== 'report' && mode !== 'enforce') {
+	console.error(`::error::review-coverage: unknown mode '${mode}' (report|enforce)`);
+	process.exitCode = 1;
+} else {
 	try {
-		return realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
-	} catch {
-		return false;
-	}
-}
-if (invokedDirectly()) {
-	const mode = arg('mode', process.env.INPUT_MODE || process.env.REVIEW_COVERAGE_MODE || 'report').toLowerCase();
-	if (mode !== 'report' && mode !== 'enforce') {
-		// a typo'd mode must be loud — 'enfroce' silently meaning report is the bad direction
-		console.error(`::error::review-coverage: unknown mode '${mode}' (report|enforce)`);
-		process.exitCode = 1;
-	} else {
-		try {
-			main(mode);
-		} catch (error) {
-			// plumbing failures follow the mode: informational stays green, but an enforcing
-			// check that cannot read its payload must not silently wave PRs through
-			console.error(
-				`review-coverage: ${error.message}${mode === 'enforce' ? '' : ' (passing — report mode fails only on policy)'}`
-			);
-			if (mode === 'enforce') {
-				console.error(
-					`::error::review-coverage could not evaluate this PR (${error.message}) — enforce mode fails closed`
-				);
-				process.exitCode = 1;
-			}
+		main(mode);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(
+			`review-coverage: ${message}${mode === 'enforce' ? '' : ' (passing — report mode fails only on policy)'}`
+		);
+		if (mode === 'enforce') {
+			console.error(`::error::review-coverage could not evaluate this PR (${message}) — enforce mode fails closed`);
+			process.exitCode = 1;
 		}
 	}
 }

--- a/.github/actions/review-coverage/ci-review-coverage.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.mjs
@@ -7,7 +7,7 @@
 //   report  (default) — always green; the check text and job summary carry the count
 //   enforce — red when a member-authored, non-trivial, non-draft PR reports <2
 // Run from the composite action in this directory, or locally:
-//   node scripts/ci-review-coverage.mjs --event <payload.json> [--mode enforce]
+//   node .github/actions/review-coverage/ci-review-coverage.mjs --event <payload.json> [--mode enforce]
 
 import { readFileSync, appendFileSync } from 'node:fs';
 import { realpathSync } from 'node:fs';
@@ -39,7 +39,7 @@ export function evaluateCiCoverage(pr, { mode = 'report', required = COVERAGE_RE
 	// The Human-Review-Need footer is evidence a prepush review RAN; staleness means
 	// commits landed after the last reviewed head (HEG step 14's most-skipped step).
 	const footer = body.match(/Human-Review-Need:\s*(\d+)(?:[^@\n]*)@\s*([0-9a-f]{6,40})/i);
-	const head = String(pr?.head?.sha ?? '');
+	const head = String(pr?.head?.sha ?? '').toLowerCase();
 	const footerNote = !footer
 		? 'no Human-Review-Need footer'
 		: head.startsWith(footer[2].toLowerCase())
@@ -91,7 +91,13 @@ function main(mode) {
 				? ''
 				: `Per team policy, a substantive PR is queued for human review only after ${required} cross-model reviews are run and reported in the description (\`## Review coverage\` naming each model — see harper-engineering-guidelines). The dispatch review gate enforces this when the fleet's review finds issues; this check just makes the reporting visible early.`,
 	].filter(Boolean);
-	if (process.env.GITHUB_STEP_SUMMARY) appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n') + '\n');
+	if (process.env.GITHUB_STEP_SUMMARY) {
+		try {
+			appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n') + '\n');
+		} catch (error) {
+			console.error(`::warning::review-coverage could not write the step summary (${error.message})`);
+		}
+	}
 	console.log(`review-coverage [${mode}]: ${r.exempt ? r.summary : r.detail}`);
 	// report mode stays green, but an under-reported PR still gets the count on the PR
 	// surface as a warning annotation rather than only in the job summary

--- a/.github/actions/review-coverage/ci-review-coverage.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.mjs
@@ -6,11 +6,10 @@
 // (the gate waives coverage for clean reviews). Hence two modes:
 //   report  (default) — always green; the check text and job summary carry the count
 //   enforce — red when a member-authored, non-trivial, non-draft PR reports <2
-// Run from the composite action in this directory, or locally:
+// Run from the JavaScript action in this directory, or locally:
 //   node .github/actions/review-coverage/ci-review-coverage.mjs --event <payload.json> [--mode enforce]
 
-import { readFileSync, appendFileSync } from 'node:fs';
-import { realpathSync } from 'node:fs';
+import { appendFileSync, readFileSync, realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { COVERAGE_REQUIRED, isTrivialChange, reportedCrossModelReviews } from './reviewGate.mjs';
 
@@ -30,22 +29,21 @@ export function evaluateCiCoverage(pr, { mode = 'report', required = COVERAGE_RE
 	const assoc = String(pr?.author_association ?? '');
 	const body = String(pr?.body ?? '');
 	const { count, families } = reportedCrossModelReviews(body);
-	const coverage =
-		count >= required
-			? `${count} cross-model reviews reported (${families.join(', ')})`
-			: count === 1
-				? `1 cross-model review reported (${families.join(', ')}) — policy asks for ${required}`
-				: `no cross-model reviews reported — policy asks for ${required}`;
+	const plural = count === 1 ? 'review' : 'reviews';
+	const reported = `${count} cross-model ${plural} reported${families.length ? ` (${families.join(', ')})` : ''}`;
+	const coverage = count >= required ? reported : `${reported} — policy asks for ${required}`;
 
 	// The Human-Review-Need footer is evidence a prepush review RAN; staleness means
 	// commits landed after the last reviewed head (HEG step 14's most-skipped step).
-	const footer = body.match(/Human-Review-Need:\s*(\d+)(?:[^@\n]*)@\s*([0-9a-f]{6,40})/i);
+	const footer = [...body.matchAll(/Human-Review-Need:\s*(\d+)(?:[^@\n]*@\s*([0-9a-f]{6,40}))?/gi)].at(-1);
 	const head = String(pr?.head?.sha ?? '').toLowerCase();
 	const footerNote = !footer
 		? 'no Human-Review-Need footer'
-		: head.startsWith(footer[2].toLowerCase())
-			? `Human-Review-Need: ${footer[1]} @ head`
-			: `Human-Review-Need footer is STALE (reviewed @ ${footer[2].slice(0, 7)}, head is ${head.slice(0, 7)})`;
+		: !footer[2]
+			? `Human-Review-Need: ${footer[1]} @ unpinned sha`
+			: head.startsWith(footer[2].toLowerCase())
+				? `Human-Review-Need: ${footer[1]} @ head`
+				: `Human-Review-Need footer is STALE (reviewed @ ${footer[2].slice(0, 7)}, head is ${head.slice(0, 7)})`;
 
 	// The triviality exemption requires the size fields to actually be present: a payload
 	// missing additions/deletions would otherwise read as 0+0 and silently exempt everything.
@@ -76,7 +74,7 @@ function main(mode) {
 	if (!eventPath) throw new Error('no event payload (--event or GITHUB_EVENT_PATH)');
 	const pr = JSON.parse(readFileSync(eventPath, 'utf8')).pull_request;
 	if (!pr) throw new Error('event payload has no pull_request');
-	const rawRequired = arg('required', process.env.REVIEW_COVERAGE_REQUIRED ?? '');
+	const rawRequired = arg('required', process.env.INPUT_REQUIRED || process.env.REVIEW_COVERAGE_REQUIRED || '');
 	const required = rawRequired === '' ? COVERAGE_REQUIRED : Number(rawRequired);
 	if (!Number.isInteger(required) || required < 0) throw new Error(`invalid required '${rawRequired}'`);
 	const r = evaluateCiCoverage(pr, { mode, required });
@@ -122,7 +120,7 @@ function invokedDirectly() {
 	}
 }
 if (invokedDirectly()) {
-	const mode = arg('mode', process.env.REVIEW_COVERAGE_MODE ?? 'report').toLowerCase();
+	const mode = arg('mode', process.env.INPUT_MODE || process.env.REVIEW_COVERAGE_MODE || 'report').toLowerCase();
 	if (mode !== 'report' && mode !== 'enforce') {
 		// a typo'd mode must be loud — 'enfroce' silently meaning report is the bad direction
 		console.error(`::error::review-coverage: unknown mode '${mode}' (report|enforce)`);

--- a/.github/actions/review-coverage/ci-review-coverage.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.mjs
@@ -19,6 +19,7 @@ const NON_MEMBER_ASSOCIATIONS = new Set([
 	'CONTRIBUTOR',
 	'FIRST_TIME_CONTRIBUTOR',
 	'FIRST_TIMER',
+	'MANNEQUIN',
 	'NONE',
 ]);
 
@@ -53,7 +54,7 @@ export function evaluateCiCoverage(pr, { mode = 'report', required = COVERAGE_RE
 		login.endsWith('[bot]') || pr?.user?.type === 'Bot'
 			? 'bot author'
 			: NON_MEMBER_ASSOCIATIONS.has(assoc)
-				? `author is not an org member (${assoc || 'unknown'}) — always human review`
+				? `author is not an org member (${assoc}) — always human review`
 				: sized && isTrivialChange(pr?.additions, pr?.deletions)
 					? 'trivial change (≤2 lines)'
 					: pr?.draft

--- a/.github/actions/review-coverage/ci-review-coverage.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.mjs
@@ -12,9 +12,7 @@
 import { readFileSync, appendFileSync } from 'node:fs';
 import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import {
-	COVERAGE_REQUIRED, isTrivialChange, reportedCrossModelReviews,
-} from './reviewGate.mjs';
+import { COVERAGE_REQUIRED, isTrivialChange, reportedCrossModelReviews } from './reviewGate.mjs';
 
 /** The whole decision, pure. `pr` is the pull_request object from the Actions event
  *  payload. Returns { pass, exempt, summary, detail } — `pass` already accounts for mode. */
@@ -23,28 +21,40 @@ export function evaluateCiCoverage(pr, { mode = 'report', required = COVERAGE_RE
 	const assoc = String(pr?.author_association ?? '');
 	const body = String(pr?.body ?? '');
 	const { count, families } = reportedCrossModelReviews(body);
-	const coverage = count >= required
-		? `${count} cross-model reviews reported (${families.join(', ')})`
-		: count === 1 ? `1 cross-model review reported (${families.join(', ')}) — policy asks for ${required}`
-		: `no cross-model reviews reported — policy asks for ${required}`;
+	const coverage =
+		count >= required
+			? `${count} cross-model reviews reported (${families.join(', ')})`
+			: count === 1
+				? `1 cross-model review reported (${families.join(', ')}) — policy asks for ${required}`
+				: `no cross-model reviews reported — policy asks for ${required}`;
 
 	// The Human-Review-Need footer is evidence a prepush review RAN; staleness means
 	// commits landed after the last reviewed head (HEG step 14's most-skipped step).
 	const footer = body.match(/Human-Review-Need:\s*(\d)(?:[^@\n]*)@\s*([0-9a-f]{6,40})/i);
 	const head = String(pr?.head?.sha ?? '');
-	const footerNote = !footer ? 'no Human-Review-Need footer'
-		: head.startsWith(footer[2].toLowerCase()) ? `Human-Review-Need: ${footer[1]} @ head`
-		: `Human-Review-Need footer is STALE (reviewed @ ${footer[2].slice(0, 7)}, head is ${head.slice(0, 7)})`;
+	const footerNote = !footer
+		? 'no Human-Review-Need footer'
+		: head.startsWith(footer[2].toLowerCase())
+			? `Human-Review-Need: ${footer[1]} @ head`
+			: `Human-Review-Need footer is STALE (reviewed @ ${footer[2].slice(0, 7)}, head is ${head.slice(0, 7)})`;
 
 	// The triviality exemption requires the size fields to actually be present: a payload
 	// missing additions/deletions would otherwise read as 0+0 and silently exempt everything.
-	const sized = Number.isFinite(Number(pr?.additions)) && Number.isFinite(Number(pr?.deletions))
-		&& (pr?.additions !== undefined && pr?.deletions !== undefined);
-	const exempt = /\[bot\]$/.test(login) || pr?.user?.type === 'Bot' ? 'bot author'
-		: !(assoc === 'MEMBER' || assoc === 'OWNER') ? `author is not an org member (${assoc || 'unknown'}) — always human review`
-		: sized && isTrivialChange(pr?.additions, pr?.deletions) ? 'trivial change (≤2 lines)'
-		: pr?.draft ? 'draft — checked again at ready-for-review'
-		: '';
+	const sized =
+		Number.isFinite(Number(pr?.additions)) &&
+		Number.isFinite(Number(pr?.deletions)) &&
+		pr?.additions !== undefined &&
+		pr?.deletions !== undefined;
+	const exempt =
+		/\[bot\]$/.test(login) || pr?.user?.type === 'Bot'
+			? 'bot author'
+			: !(assoc === 'MEMBER' || assoc === 'OWNER')
+				? `author is not an org member (${assoc || 'unknown'}) — always human review`
+				: sized && isTrivialChange(pr?.additions, pr?.deletions)
+					? 'trivial change (≤2 lines)'
+					: pr?.draft
+						? 'draft — checked again at ready-for-review'
+						: '';
 	const compliant = count >= required;
 	const pass = mode !== 'enforce' || Boolean(exempt) || compliant;
 	const summary = exempt ? `exempt: ${exempt}` : coverage;
@@ -66,39 +76,57 @@ function main(mode) {
 
 	const lines = [
 		`### Cross-model review coverage — ${r.pass ? (r.exempt ? '✅ exempt' : r.compliant ? '✅' : '⚠️ report-only') : '❌'}`,
-		'', r.detail, '',
-		r.exempt ? `_${r.exempt}_`
-			: r.compliant ? ''
-			: `Per team policy, a substantive PR is queued for human review only after ${required} cross-model reviews are run and reported in the description (\`## Review coverage\` naming each model — see harper-engineering-guidelines). The dispatch review gate enforces this when the fleet's review finds issues; this check just makes the reporting visible early.`,
+		'',
+		r.detail,
+		'',
+		r.exempt
+			? `_${r.exempt}_`
+			: r.compliant
+				? ''
+				: `Per team policy, a substantive PR is queued for human review only after ${required} cross-model reviews are run and reported in the description (\`## Review coverage\` naming each model — see harper-engineering-guidelines). The dispatch review gate enforces this when the fleet's review finds issues; this check just makes the reporting visible early.`,
 	].filter(Boolean);
 	if (process.env.GITHUB_STEP_SUMMARY) appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n') + '\n');
 	console.log(`review-coverage [${mode}]: ${r.exempt ? r.summary : r.detail}`);
 	// report mode stays green, but an under-reported PR still gets the count on the PR
 	// surface as a warning annotation rather than only in the job summary
 	if (r.pass && !r.exempt && !r.compliant)
-		console.error(`::warning::${r.detail} — the dispatch gate will block at review time if the fleet's review finds issues`);
+		console.error(
+			`::warning::${r.detail} — the dispatch gate will block at review time if the fleet's review finds issues`
+		);
 	if (!r.pass) {
-		console.error(`::error::${r.detail} — report the reviews in the PR description to pass; the dispatch gate will block at review time if the fleet's review also finds issues`);
+		console.error(
+			`::error::${r.detail} — report the reviews in the PR description to pass; the dispatch gate will block at review time if the fleet's review also finds issues`
+		);
 		process.exitCode = 1;
 	}
 }
 
 function invokedDirectly() {
-	try { return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url); } catch { return false; }
+	try {
+		return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
+	} catch {
+		return false;
+	}
 }
 if (invokedDirectly()) {
-	const mode = (arg('mode', process.env.REVIEW_COVERAGE_MODE ?? 'report')).toLowerCase();
+	const mode = arg('mode', process.env.REVIEW_COVERAGE_MODE ?? 'report').toLowerCase();
 	if (mode !== 'report' && mode !== 'enforce') {
 		// a typo'd mode must be loud — 'enfroce' silently meaning report is the bad direction
 		console.error(`::error::review-coverage: unknown mode '${mode}' (report|enforce)`);
 		process.exitCode = 1;
 	} else {
-		try { main(mode); } catch (error) {
+		try {
+			main(mode);
+		} catch (error) {
 			// plumbing failures follow the mode: informational stays green, but an enforcing
 			// check that cannot read its payload must not silently wave PRs through
-			console.error(`review-coverage: ${error.message}${mode === 'enforce' ? '' : ' (passing — report mode fails only on policy)'}`);
+			console.error(
+				`review-coverage: ${error.message}${mode === 'enforce' ? '' : ' (passing — report mode fails only on policy)'}`
+			);
 			if (mode === 'enforce') {
-				console.error(`::error::review-coverage could not evaluate this PR (${error.message}) — enforce mode fails closed`);
+				console.error(
+					`::error::review-coverage could not evaluate this PR (${error.message}) — enforce mode fails closed`
+				);
 				process.exitCode = 1;
 			}
 		}

--- a/.github/actions/review-coverage/ci-review-coverage.test.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.test.mjs
@@ -76,6 +76,10 @@ test('the footer note distinguishes current, stale, and absent', () => {
 			.detail,
 		/Need: 4 @ head/
 	);
+	assert.match(
+		evaluateCiCoverage(pr({ body: `Human-Review-Need: 1 Human-Review-Need: 2 @ ${HEAD.slice(0, 12)}` })).detail,
+		/Need: 2 @ head/
+	);
 	assert.match(evaluateCiCoverage(pr()).detail, /no Human-Review-Need footer/);
 });
 

--- a/.github/actions/review-coverage/ci-review-coverage.test.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.test.mjs
@@ -46,17 +46,27 @@ test('enforce mode exempts exactly what the gate exempts, plus drafts', () => {
 	}
 });
 
-test('a payload missing size fields is NOT trivially exempt', () => {
-	const noSizes = pr();
-	delete noSizes.additions;
-	delete noSizes.deletions;
-	const r = evaluateCiCoverage(noSizes, { mode: 'enforce' });
-	assert.strictEqual(r.pass, false, 'missing additions/deletions must not read as a ≤2-line change');
+test('invalid or missing size fields are NOT trivially exempt', () => {
+	const cases = [pr(), pr({ additions: null, deletions: null }), pr({ additions: '', deletions: '' })];
+	delete cases[0].additions;
+	delete cases[0].deletions;
+	for (const candidate of cases) {
+		const r = evaluateCiCoverage(candidate, { mode: 'enforce' });
+		assert.strictEqual(r.pass, false, 'invalid additions/deletions must not read as a ≤2-line change');
+	}
+});
+
+test('a missing or unknown author association does not exempt the PR', () => {
+	const missing = pr();
+	delete missing.author_association;
+	assert.strictEqual(evaluateCiCoverage(missing, { mode: 'enforce' }).pass, false);
+	assert.strictEqual(evaluateCiCoverage(pr({ author_association: 'UNKNOWN' }), { mode: 'enforce' }).pass, false);
 });
 
 test('the footer note distinguishes current, stale, and absent', () => {
-	const at = (sha) => pr({ body: `x\n<sub>Human-Review-Need: 2 @ ${sha}</sub>` });
+	const at = (sha, score = 2) => pr({ body: `x\n<sub>Human-Review-Need: ${score} @ ${sha}</sub>` });
 	assert.match(evaluateCiCoverage(at(HEAD.slice(0, 12))).detail, /Human-Review-Need: 2 @ head/);
+	assert.match(evaluateCiCoverage(at(HEAD.slice(0, 12), 12)).detail, /Need: 12 @ head/);
 	assert.match(evaluateCiCoverage(at('999999999999')).detail, /STALE/);
 	assert.match(evaluateCiCoverage(pr()).detail, /no Human-Review-Need footer/);
 });
@@ -69,7 +79,7 @@ test('required is tunable', () => {
 // ---- exit codes, through the real CLI entry ----
 
 import { execFileSync } from 'node:child_process';
-import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { writeFileSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -98,4 +108,24 @@ test('exit codes: report never reds, enforce reds on policy AND on plumbing', ()
 	assert.strictEqual(run({ nope: true }, '--mode', 'report'), 0, 'plumbing failure stays green in report mode');
 	assert.strictEqual(run({ nope: true }, '--mode', 'enforce'), 1, 'enforce mode fails closed on plumbing');
 	assert.strictEqual(run(bare, '--mode', 'enfroce'), 1, "a typo'd mode is loud, not silently report");
+	assert.strictEqual(run(bare, '--mode', 'enforce', '--required', '0'), 0, 'zero is a valid threshold');
+	assert.strictEqual(run(bare, '--mode', 'report', '--required', 'tow'), 0, 'report mode stays green on bad input');
+	assert.strictEqual(run(bare, '--mode', 'enforce', '--required', 'tow'), 1, 'enforce mode fails closed on bad input');
+});
+
+test('the CLI runs through a symlinked entrypoint', () => {
+	const dir = mkdtempSync(path.join(tmpdir(), 'rc-link-'));
+	const link = path.join(dir, 'ci-review-coverage.mjs');
+	const file = path.join(dir, 'event.json');
+	symlinkSync(SCRIPT, link);
+	symlinkSync(fileURLToPath(new URL('./reviewGate.mjs', import.meta.url)), path.join(dir, 'reviewGate.mjs'));
+	writeFileSync(file, JSON.stringify({ pull_request: pr() }));
+	try {
+		const output = execFileSync(process.execPath, ['--preserve-symlinks-main', link, '--event', file], {
+			encoding: 'utf8',
+		});
+		assert.match(output, /review-coverage \[report\]/);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
 });

--- a/.github/actions/review-coverage/ci-review-coverage.test.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.test.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { evaluateCiCoverage } from './ci-review-coverage.mjs';
+
+const HEAD = 'abcdef1234567890abcdef1234567890abcdef12';
+const pr = (over = {}) => ({
+	user: { login: 'someone', type: 'User' },
+	author_association: 'MEMBER',
+	body: 'plain description',
+	additions: 40, deletions: 12, draft: false,
+	head: { sha: HEAD },
+	...over,
+});
+
+test('report mode is always green, but says what is missing', () => {
+	const r = evaluateCiCoverage(pr());
+	assert.equal(r.pass, true);
+	assert.equal(r.compliant, false);
+	assert.match(r.summary, /no cross-model reviews reported/);
+});
+
+test('enforce mode fails a member non-trivial PR reporting under the threshold', () => {
+	assert.equal(evaluateCiCoverage(pr(), { mode: 'enforce' }).pass, false);
+	const one = pr({ body: '## Review coverage\n- Codex: clean' });
+	assert.equal(evaluateCiCoverage(one, { mode: 'enforce' }).pass, false);
+	const two = pr({ body: '## Review coverage\n- Codex: clean\n- Gemini: 1 finding, fixed' });
+	const r = evaluateCiCoverage(two, { mode: 'enforce' });
+	assert.equal(r.pass, true);
+	assert.deepEqual(r.families, ['google', 'openai']);
+});
+
+test('enforce mode exempts exactly what the gate exempts, plus drafts', () => {
+	for (const [label, over] of [
+		['bot', { user: { login: 'renovate[bot]', type: 'Bot' } }],
+		['non-member', { author_association: 'CONTRIBUTOR' }],
+		['collaborator', { author_association: 'COLLABORATOR' }],
+		['trivial', { additions: 1, deletions: 1 }],
+		['draft', { draft: true }],
+	]) {
+		const r = evaluateCiCoverage(pr(over), { mode: 'enforce' });
+		assert.equal(r.pass, true, `${label} must not fail enforce mode`);
+		assert.ok(r.exempt, `${label} must be reported as exempt`);
+	}
+});
+
+test('a payload missing size fields is NOT trivially exempt', () => {
+	const noSizes = pr(); delete noSizes.additions; delete noSizes.deletions;
+	const r = evaluateCiCoverage(noSizes, { mode: 'enforce' });
+	assert.equal(r.pass, false, 'missing additions/deletions must not read as a ≤2-line change');
+});
+
+test('the footer note distinguishes current, stale, and absent', () => {
+	const at = (sha) => pr({ body: `x\n<sub>Human-Review-Need: 2 @ ${sha}</sub>` });
+	assert.match(evaluateCiCoverage(at(HEAD.slice(0, 12))).detail, /Human-Review-Need: 2 @ head/);
+	assert.match(evaluateCiCoverage(at('999999999999')).detail, /STALE/);
+	assert.match(evaluateCiCoverage(pr()).detail, /no Human-Review-Need footer/);
+});
+
+test('required is tunable', () => {
+	const one = pr({ body: '## Review coverage\n- Codex: clean' });
+	assert.equal(evaluateCiCoverage(one, { mode: 'enforce', required: 1 }).pass, true);
+});
+
+// ---- exit codes, through the real CLI entry ----
+
+import { execFileSync } from 'node:child_process';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const SCRIPT = fileURLToPath(new URL('./ci-review-coverage.mjs', import.meta.url));
+const run = (payload, ...args) => {
+	const dir = mkdtempSync(path.join(tmpdir(), 'rc-'));
+	const file = path.join(dir, 'event.json');
+	if (payload !== null) writeFileSync(file, JSON.stringify(payload));
+	try {
+		execFileSync(process.execPath, [SCRIPT, '--event', file, ...args], { stdio: 'pipe' });
+		return 0;
+	} catch (e) { return e.status ?? 1; }
+	finally { rmSync(dir, { recursive: true, force: true }); }
+};
+
+test('exit codes: report never reds, enforce reds on policy AND on plumbing', () => {
+	const compliant = { pull_request: pr({ body: '## Review coverage\n- Codex: ran\n- Gemini: ran' }) };
+	const bare = { pull_request: pr() };
+	assert.equal(run(compliant, '--mode', 'enforce'), 0);
+	assert.equal(run(bare, '--mode', 'report'), 0);
+	assert.equal(run(bare, '--mode', 'enforce'), 1);
+	assert.equal(run({ nope: true }, '--mode', 'report'), 0, 'plumbing failure stays green in report mode');
+	assert.equal(run({ nope: true }, '--mode', 'enforce'), 1, 'enforce mode fails closed on plumbing');
+	assert.equal(run(bare, '--mode', 'enfroce'), 1, 'a typo\'d mode is loud, not silently report');
+});

--- a/.github/actions/review-coverage/ci-review-coverage.test.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.test.mjs
@@ -37,6 +37,7 @@ test('enforce mode exempts exactly what the gate exempts, plus drafts', () => {
 		['bot', { user: { login: 'renovate[bot]', type: 'Bot' } }],
 		['non-member', { author_association: 'CONTRIBUTOR' }],
 		['collaborator', { author_association: 'COLLABORATOR' }],
+		['mannequin', { author_association: 'MANNEQUIN' }],
 		['trivial', { additions: 1, deletions: 1 }],
 		['draft', { draft: true }],
 	]) {
@@ -86,19 +87,17 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 const SCRIPT = fileURLToPath(new URL('./ci-review-coverage.mjs', import.meta.url));
-const run = (payload, ...args) => {
+const runResult = (payload, ...args) => {
 	const dir = mkdtempSync(path.join(tmpdir(), 'rc-'));
 	const file = path.join(dir, 'event.json');
 	if (payload !== null) writeFileSync(file, JSON.stringify(payload));
 	try {
-		execFileSync(process.execPath, [SCRIPT, '--event', file, ...args], { stdio: 'pipe' });
-		return 0;
-	} catch (e) {
-		return e.status ?? 1;
+		return spawnSync(process.execPath, [SCRIPT, '--event', file, ...args], { encoding: 'utf8' });
 	} finally {
 		rmSync(dir, { recursive: true, force: true });
 	}
 };
+const run = (payload, ...args) => runResult(payload, ...args).status ?? 1;
 
 test('exit codes: report never reds, enforce reds on policy AND on plumbing', () => {
 	const compliant = { pull_request: pr({ body: '## Review coverage\n- Codex: ran\n- Gemini: ran' }) };
@@ -110,8 +109,12 @@ test('exit codes: report never reds, enforce reds on policy AND on plumbing', ()
 	assert.strictEqual(run({ nope: true }, '--mode', 'enforce'), 1, 'enforce mode fails closed on plumbing');
 	assert.strictEqual(run(bare, '--mode', 'enfroce'), 1, "a typo'd mode is loud, not silently report");
 	assert.strictEqual(run(bare, '--mode', 'enforce', '--required', '0'), 0, 'zero is a valid threshold');
-	assert.strictEqual(run(bare, '--mode', 'report', '--required', 'tow'), 0, 'report mode stays green on bad input');
-	assert.strictEqual(run(bare, '--mode', 'enforce', '--required', 'tow'), 1, 'enforce mode fails closed on bad input');
+	const invalidReport = runResult(bare, '--mode', 'report', '--required', 'tow');
+	assert.strictEqual(invalidReport.status, 0, 'report mode stays green on bad input');
+	assert.match(invalidReport.stderr, /invalid required 'tow'/);
+	const invalidEnforce = runResult(bare, '--mode', 'enforce', '--required', 'tow');
+	assert.strictEqual(invalidEnforce.status, 1, 'enforce mode fails closed on bad input');
+	assert.match(invalidEnforce.stderr, /invalid required 'tow'/);
 });
 
 test('the CLI runs through a symlinked entrypoint', () => {

--- a/.github/actions/review-coverage/ci-review-coverage.test.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import test from 'node:test';
 
-import { evaluateCiCoverage } from './ci-review-coverage.mjs';
+import { evaluateCiCoverage } from './evaluateCiCoverage.mjs';
 
 const HEAD = 'abcdef1234567890abcdef1234567890abcdef12';
 const pr = (over = {}) => ({
@@ -136,6 +136,10 @@ test('the CLI runs through a symlinked entrypoint', () => {
 	const link = path.join(dir, 'ci-review-coverage.mjs');
 	const file = path.join(dir, 'event.json');
 	symlinkSync(SCRIPT, link);
+	symlinkSync(
+		fileURLToPath(new URL('./evaluateCiCoverage.mjs', import.meta.url)),
+		path.join(dir, 'evaluateCiCoverage.mjs')
+	);
 	symlinkSync(fileURLToPath(new URL('./reviewGate.mjs', import.meta.url)), path.join(dir, 'reviewGate.mjs'));
 	writeFileSync(file, JSON.stringify({ pull_request: pr() }));
 	try {

--- a/.github/actions/review-coverage/ci-review-coverage.test.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.test.mjs
@@ -19,7 +19,7 @@ test('report mode is always green, but says what is missing', () => {
 	const r = evaluateCiCoverage(pr());
 	assert.strictEqual(r.pass, true);
 	assert.strictEqual(r.compliant, false);
-	assert.match(r.summary, /no cross-model reviews reported/);
+	assert.match(r.summary, /0 cross-model reviews reported/);
 });
 
 test('enforce mode fails a member non-trivial PR reporting under the threshold', () => {
@@ -70,29 +70,43 @@ test('the footer note distinguishes current, stale, and absent', () => {
 	assert.match(evaluateCiCoverage(at(HEAD.slice(0, 12).toUpperCase())).detail, /Human-Review-Need: 2 @ head/);
 	assert.match(evaluateCiCoverage(at(HEAD.slice(0, 12), 12)).detail, /Need: 12 @ head/);
 	assert.match(evaluateCiCoverage(at('999999999999')).detail, /STALE/);
+	assert.match(evaluateCiCoverage(pr({ body: 'Human-Review-Need: 3' })).detail, /Need: 3 @ unpinned sha/);
+	assert.match(
+		evaluateCiCoverage(pr({ body: `Human-Review-Need: 2 @ 999999999999\nHuman-Review-Need: 4 @ ${HEAD.slice(0, 12)}` }))
+			.detail,
+		/Need: 4 @ head/
+	);
 	assert.match(evaluateCiCoverage(pr()).detail, /no Human-Review-Need footer/);
 });
 
 test('required is tunable', () => {
 	const one = pr({ body: '## Review coverage\n- Codex: clean' });
 	assert.strictEqual(evaluateCiCoverage(one, { mode: 'enforce', required: 1 }).pass, true);
+	const two = pr({ body: '## Review coverage\n- Codex: clean\n- Gemini: clean' });
+	const result = evaluateCiCoverage(two, { mode: 'enforce', required: 3 });
+	assert.strictEqual(result.pass, false);
+	assert.match(result.summary, /^2 cross-model reviews reported .*policy asks for 3$/);
 });
 
 // ---- exit codes, through the real CLI entry ----
 
 import { execFileSync, spawnSync } from 'node:child_process';
-import { writeFileSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 const SCRIPT = fileURLToPath(new URL('./ci-review-coverage.mjs', import.meta.url));
+const CLEAN_ENV = { ...process.env };
+delete CLEAN_ENV.GITHUB_ENV;
+delete CLEAN_ENV.GITHUB_OUTPUT;
+delete CLEAN_ENV.GITHUB_STEP_SUMMARY;
 const runResult = (payload, ...args) => {
 	const dir = mkdtempSync(path.join(tmpdir(), 'rc-'));
 	const file = path.join(dir, 'event.json');
 	if (payload !== null) writeFileSync(file, JSON.stringify(payload));
 	try {
-		return spawnSync(process.execPath, [SCRIPT, '--event', file, ...args], { encoding: 'utf8' });
+		return spawnSync(process.execPath, [SCRIPT, '--event', file, ...args], { encoding: 'utf8', env: CLEAN_ENV });
 	} finally {
 		rmSync(dir, { recursive: true, force: true });
 	}
@@ -127,8 +141,35 @@ test('the CLI runs through a symlinked entrypoint', () => {
 	try {
 		const output = execFileSync(process.execPath, ['--preserve-symlinks-main', link, '--event', file], {
 			encoding: 'utf8',
+			env: CLEAN_ENV,
 		});
 		assert.match(output, /review-coverage \[report\]/);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('the JavaScript action uses a pinned runtime and receives action inputs', () => {
+	const manifest = readFileSync(fileURLToPath(new URL('./action.yml', import.meta.url)), 'utf8');
+	assert.match(manifest, /runs:\n\s+using: node24\n\s+main: ci-review-coverage\.mjs/);
+	const dir = mkdtempSync(path.join(tmpdir(), 'rc-action-'));
+	const file = path.join(dir, 'event.json');
+	writeFileSync(
+		file,
+		JSON.stringify({ pull_request: pr({ body: '## Review coverage\n- Codex: clean\n- Gemini: clean' }) })
+	);
+	try {
+		const result = spawnSync(process.execPath, [SCRIPT], {
+			encoding: 'utf8',
+			env: {
+				...CLEAN_ENV,
+				GITHUB_EVENT_PATH: file,
+				INPUT_MODE: 'enforce',
+				INPUT_REQUIRED: '3',
+			},
+		});
+		assert.strictEqual(result.status, 1);
+		assert.match(result.stderr, /2 cross-model reviews reported .*policy asks for 3/);
 	} finally {
 		rmSync(dir, { recursive: true, force: true });
 	}
@@ -141,17 +182,17 @@ test('a step-summary write failure does not change the coverage verdict', () => 
 	try {
 		const report = spawnSync(process.execPath, [SCRIPT, '--event', file], {
 			encoding: 'utf8',
-			env: { ...process.env, GITHUB_STEP_SUMMARY: dir },
+			env: { ...CLEAN_ENV, GITHUB_STEP_SUMMARY: dir },
 		});
 		assert.strictEqual(report.status, 0);
 		assert.match(report.stderr, /could not write the step summary/);
-		assert.match(report.stderr, /::warning::no cross-model reviews reported/);
+		assert.match(report.stderr, /::warning::0 cross-model reviews reported/);
 
 		const compliant = { pull_request: pr({ body: '## Review coverage\n- Codex: ran\n- Gemini: ran' }) };
 		writeFileSync(file, JSON.stringify(compliant));
 		const enforce = spawnSync(process.execPath, [SCRIPT, '--event', file, '--mode', 'enforce'], {
 			encoding: 'utf8',
-			env: { ...process.env, GITHUB_STEP_SUMMARY: dir },
+			env: { ...CLEAN_ENV, GITHUB_STEP_SUMMARY: dir },
 		});
 		assert.strictEqual(enforce.status, 0);
 		assert.match(enforce.stderr, /could not write the step summary/);

--- a/.github/actions/review-coverage/ci-review-coverage.test.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.test.mjs
@@ -66,6 +66,7 @@ test('a missing or unknown author association does not exempt the PR', () => {
 test('the footer note distinguishes current, stale, and absent', () => {
 	const at = (sha, score = 2) => pr({ body: `x\n<sub>Human-Review-Need: ${score} @ ${sha}</sub>` });
 	assert.match(evaluateCiCoverage(at(HEAD.slice(0, 12))).detail, /Human-Review-Need: 2 @ head/);
+	assert.match(evaluateCiCoverage(at(HEAD.slice(0, 12).toUpperCase())).detail, /Human-Review-Need: 2 @ head/);
 	assert.match(evaluateCiCoverage(at(HEAD.slice(0, 12), 12)).detail, /Need: 12 @ head/);
 	assert.match(evaluateCiCoverage(at('999999999999')).detail, /STALE/);
 	assert.match(evaluateCiCoverage(pr()).detail, /no Human-Review-Need footer/);
@@ -78,7 +79,7 @@ test('required is tunable', () => {
 
 // ---- exit codes, through the real CLI entry ----
 
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { writeFileSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
@@ -125,6 +126,32 @@ test('the CLI runs through a symlinked entrypoint', () => {
 			encoding: 'utf8',
 		});
 		assert.match(output, /review-coverage \[report\]/);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('a step-summary write failure does not change the coverage verdict', () => {
+	const dir = mkdtempSync(path.join(tmpdir(), 'rc-summary-'));
+	const file = path.join(dir, 'event.json');
+	writeFileSync(file, JSON.stringify({ pull_request: pr() }));
+	try {
+		const report = spawnSync(process.execPath, [SCRIPT, '--event', file], {
+			encoding: 'utf8',
+			env: { ...process.env, GITHUB_STEP_SUMMARY: dir },
+		});
+		assert.strictEqual(report.status, 0);
+		assert.match(report.stderr, /could not write the step summary/);
+		assert.match(report.stderr, /::warning::no cross-model reviews reported/);
+
+		const compliant = { pull_request: pr({ body: '## Review coverage\n- Codex: ran\n- Gemini: ran' }) };
+		writeFileSync(file, JSON.stringify(compliant));
+		const enforce = spawnSync(process.execPath, [SCRIPT, '--event', file, '--mode', 'enforce'], {
+			encoding: 'utf8',
+			env: { ...process.env, GITHUB_STEP_SUMMARY: dir },
+		});
+		assert.strictEqual(enforce.status, 0);
+		assert.match(enforce.stderr, /could not write the step summary/);
 	} finally {
 		rmSync(dir, { recursive: true, force: true });
 	}

--- a/.github/actions/review-coverage/ci-review-coverage.test.mjs
+++ b/.github/actions/review-coverage/ci-review-coverage.test.mjs
@@ -1,4 +1,4 @@
-import assert from 'node:assert/strict';
+import assert from 'node:assert';
 import test from 'node:test';
 
 import { evaluateCiCoverage } from './ci-review-coverage.mjs';
@@ -8,26 +8,28 @@ const pr = (over = {}) => ({
 	user: { login: 'someone', type: 'User' },
 	author_association: 'MEMBER',
 	body: 'plain description',
-	additions: 40, deletions: 12, draft: false,
+	additions: 40,
+	deletions: 12,
+	draft: false,
 	head: { sha: HEAD },
 	...over,
 });
 
 test('report mode is always green, but says what is missing', () => {
 	const r = evaluateCiCoverage(pr());
-	assert.equal(r.pass, true);
-	assert.equal(r.compliant, false);
+	assert.strictEqual(r.pass, true);
+	assert.strictEqual(r.compliant, false);
 	assert.match(r.summary, /no cross-model reviews reported/);
 });
 
 test('enforce mode fails a member non-trivial PR reporting under the threshold', () => {
-	assert.equal(evaluateCiCoverage(pr(), { mode: 'enforce' }).pass, false);
+	assert.strictEqual(evaluateCiCoverage(pr(), { mode: 'enforce' }).pass, false);
 	const one = pr({ body: '## Review coverage\n- Codex: clean' });
-	assert.equal(evaluateCiCoverage(one, { mode: 'enforce' }).pass, false);
+	assert.strictEqual(evaluateCiCoverage(one, { mode: 'enforce' }).pass, false);
 	const two = pr({ body: '## Review coverage\n- Codex: clean\n- Gemini: 1 finding, fixed' });
 	const r = evaluateCiCoverage(two, { mode: 'enforce' });
-	assert.equal(r.pass, true);
-	assert.deepEqual(r.families, ['google', 'openai']);
+	assert.strictEqual(r.pass, true);
+	assert.deepStrictEqual(r.families, ['google', 'openai']);
 });
 
 test('enforce mode exempts exactly what the gate exempts, plus drafts', () => {
@@ -39,15 +41,17 @@ test('enforce mode exempts exactly what the gate exempts, plus drafts', () => {
 		['draft', { draft: true }],
 	]) {
 		const r = evaluateCiCoverage(pr(over), { mode: 'enforce' });
-		assert.equal(r.pass, true, `${label} must not fail enforce mode`);
+		assert.strictEqual(r.pass, true, `${label} must not fail enforce mode`);
 		assert.ok(r.exempt, `${label} must be reported as exempt`);
 	}
 });
 
 test('a payload missing size fields is NOT trivially exempt', () => {
-	const noSizes = pr(); delete noSizes.additions; delete noSizes.deletions;
+	const noSizes = pr();
+	delete noSizes.additions;
+	delete noSizes.deletions;
 	const r = evaluateCiCoverage(noSizes, { mode: 'enforce' });
-	assert.equal(r.pass, false, 'missing additions/deletions must not read as a ≤2-line change');
+	assert.strictEqual(r.pass, false, 'missing additions/deletions must not read as a ≤2-line change');
 });
 
 test('the footer note distinguishes current, stale, and absent', () => {
@@ -59,7 +63,7 @@ test('the footer note distinguishes current, stale, and absent', () => {
 
 test('required is tunable', () => {
 	const one = pr({ body: '## Review coverage\n- Codex: clean' });
-	assert.equal(evaluateCiCoverage(one, { mode: 'enforce', required: 1 }).pass, true);
+	assert.strictEqual(evaluateCiCoverage(one, { mode: 'enforce', required: 1 }).pass, true);
 });
 
 // ---- exit codes, through the real CLI entry ----
@@ -78,17 +82,20 @@ const run = (payload, ...args) => {
 	try {
 		execFileSync(process.execPath, [SCRIPT, '--event', file, ...args], { stdio: 'pipe' });
 		return 0;
-	} catch (e) { return e.status ?? 1; }
-	finally { rmSync(dir, { recursive: true, force: true }); }
+	} catch (e) {
+		return e.status ?? 1;
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
 };
 
 test('exit codes: report never reds, enforce reds on policy AND on plumbing', () => {
 	const compliant = { pull_request: pr({ body: '## Review coverage\n- Codex: ran\n- Gemini: ran' }) };
 	const bare = { pull_request: pr() };
-	assert.equal(run(compliant, '--mode', 'enforce'), 0);
-	assert.equal(run(bare, '--mode', 'report'), 0);
-	assert.equal(run(bare, '--mode', 'enforce'), 1);
-	assert.equal(run({ nope: true }, '--mode', 'report'), 0, 'plumbing failure stays green in report mode');
-	assert.equal(run({ nope: true }, '--mode', 'enforce'), 1, 'enforce mode fails closed on plumbing');
-	assert.equal(run(bare, '--mode', 'enfroce'), 1, 'a typo\'d mode is loud, not silently report');
+	assert.strictEqual(run(compliant, '--mode', 'enforce'), 0);
+	assert.strictEqual(run(bare, '--mode', 'report'), 0);
+	assert.strictEqual(run(bare, '--mode', 'enforce'), 1);
+	assert.strictEqual(run({ nope: true }, '--mode', 'report'), 0, 'plumbing failure stays green in report mode');
+	assert.strictEqual(run({ nope: true }, '--mode', 'enforce'), 1, 'enforce mode fails closed on plumbing');
+	assert.strictEqual(run(bare, '--mode', 'enfroce'), 1, "a typo'd mode is loud, not silently report");
 });

--- a/.github/actions/review-coverage/evaluateCiCoverage.mjs
+++ b/.github/actions/review-coverage/evaluateCiCoverage.mjs
@@ -1,0 +1,48 @@
+import { COVERAGE_REQUIRED, isTrivialChange, reportedCrossModelReviews } from './reviewGate.mjs';
+
+const NON_MEMBER_ASSOCIATIONS = new Set([
+	'COLLABORATOR',
+	'CONTRIBUTOR',
+	'FIRST_TIME_CONTRIBUTOR',
+	'FIRST_TIMER',
+	'MANNEQUIN',
+	'NONE',
+]);
+
+/** `pass` in the return value already accounts for report versus enforce mode. */
+export function evaluateCiCoverage(pr, { mode = 'report', required = COVERAGE_REQUIRED } = {}) {
+	const login = String(pr?.user?.login ?? '');
+	const assoc = String(pr?.author_association ?? '');
+	const body = String(pr?.body ?? '');
+	const { count, families } = reportedCrossModelReviews(body);
+	const plural = count === 1 ? 'review' : 'reviews';
+	const reported = `${count} cross-model ${plural} reported${families.length ? ` (${families.join(', ')})` : ''}`;
+	const coverage = count >= required ? reported : `${reported} — policy asks for ${required}`;
+
+	const footer = [...body.matchAll(/Human-Review-Need:\s*(\d+)(?:[^@\n]*@\s*([0-9a-f]{6,40}))?/gi)].at(-1);
+	const head = String(pr?.head?.sha ?? '').toLowerCase();
+	const footerNote = !footer
+		? 'no Human-Review-Need footer'
+		: !footer[2]
+			? `Human-Review-Need: ${footer[1]} @ unpinned sha`
+			: head.startsWith(footer[2].toLowerCase())
+				? `Human-Review-Need: ${footer[1]} @ head`
+				: `Human-Review-Need footer is STALE (reviewed @ ${footer[2].slice(0, 7)}, head is ${head.slice(0, 7)})`;
+
+	// Missing size fields would otherwise read as 0+0 and silently exempt every PR.
+	const sized = Number.isFinite(pr?.additions) && Number.isFinite(pr?.deletions);
+	const exempt =
+		login.endsWith('[bot]') || pr?.user?.type === 'Bot'
+			? 'bot author'
+			: NON_MEMBER_ASSOCIATIONS.has(assoc)
+				? `author is not an org member (${assoc}) — always human review`
+				: sized && isTrivialChange(pr?.additions, pr?.deletions)
+					? 'trivial change (≤2 lines)'
+					: pr?.draft
+						? 'draft — checked again at ready-for-review'
+						: '';
+	const compliant = count >= required;
+	const pass = mode !== 'enforce' || Boolean(exempt) || compliant;
+	const summary = exempt ? `exempt: ${exempt}` : coverage;
+	return { pass, exempt, compliant, count, families, summary, detail: `${coverage}; ${footerNote}` };
+}

--- a/.github/actions/review-coverage/evaluateCiCoverage.mjs
+++ b/.github/actions/review-coverage/evaluateCiCoverage.mjs
@@ -19,7 +19,9 @@ export function evaluateCiCoverage(pr, { mode = 'report', required = COVERAGE_RE
 	const reported = `${count} cross-model ${plural} reported${families.length ? ` (${families.join(', ')})` : ''}`;
 	const coverage = count >= required ? reported : `${reported} — policy asks for ${required}`;
 
-	const footer = [...body.matchAll(/Human-Review-Need:\s*(\d+)(?:[^@\n]*@\s*([0-9a-f]{6,40}))?/gi)].at(-1);
+	const footer = [
+		...body.matchAll(/Human-Review-Need:\s*(\d+)(?:(?:(?!Human-Review-Need:)[^@\n])*@\s*([0-9a-f]{6,40}))?/gi),
+	].at(-1);
 	const head = String(pr?.head?.sha ?? '').toLowerCase();
 	const footerNote = !footer
 		? 'no Human-Review-Need footer'

--- a/.github/actions/review-coverage/reviewGate.mjs
+++ b/.github/actions/review-coverage/reviewGate.mjs
@@ -79,8 +79,9 @@ export function reportedCrossModelReviews(body) {
 				continue;
 			}
 		}
-		if (inCoverage) harvest(line);
-		else if (/^\s*(?:[-*>]\s*)?independent-review\s*:/i.test(line)) harvest(line);
+		if (inCoverage) {
+			if (/^\s*(?:[-*]|\d+\.)\s/.test(line)) harvest(line);
+		} else if (/^\s*(?:[-*>]\s*)?independent-review\s*:/i.test(line)) harvest(line);
 		else if (/cross[- ]model/i.test(line)) harvest(line);
 	}
 	return { count: families.size, families: [...families].sort(), generator: own };

--- a/.github/actions/review-coverage/reviewGate.mjs
+++ b/.github/actions/review-coverage/reviewGate.mjs
@@ -25,7 +25,8 @@ const familiesIn = (text) => FAMILIES.filter(([re]) => re.test(text)).map(([, fa
 // Scoped to comma/semicolon segments, not whole lines: "- Codex: clean, Gemini: failed"
 // must count codex. "none" is deliberately absent ("- Gemini: none found." RAN), and
 // "error(s)" negates only when not itself negated ("no errors found" also RAN).
-const NEGATED = /\bfail(?:ed|ure)?\b|\bdid n[o']t run\b|\bskipped\b|\bunavailable\b|\bno usable output\b|\btimed? ?out\b|(?<!\bno )(?<!\bzero )(?<!\bwithout )\berrors?\b|\berrored\b|\bnot run\b|\bpending\b/i;
+const NEGATED =
+	/\bfail(?:ed|ure)?\b|\bdid n[o']t run\b|\bskipped\b|\bunavailable\b|\bno usable output\b|\btimed? ?out\b|(?<!\bno )(?<!\bzero )(?<!\bwithout )\berrors?\b|\berrored\b|\bnot run\b|\bpending\b/i;
 
 /** The model family that authored the change itself, when the body declares it (agent PRs
  *  end with a generated-by marker; HEG's Review coverage names the generating model). A
@@ -72,7 +73,11 @@ export function reportedCrossModelReviews(body) {
 		const heading = line.match(/^(#{1,4})\s+(.*)/);
 		if (heading) {
 			if (inCoverage && heading[1].length <= coverageLevel) inCoverage = false;
-			if (/review coverage/i.test(heading[2])) { inCoverage = true; coverageLevel = heading[1].length; continue; }
+			if (/review coverage/i.test(heading[2])) {
+				inCoverage = true;
+				coverageLevel = heading[1].length;
+				continue;
+			}
 		}
 		if (inCoverage) harvest(line);
 		else if (/^\s*(?:[-*>]\s*)?independent-review\s*:/i.test(line)) harvest(line);
@@ -103,7 +108,17 @@ export const COVERAGE_REQUIRED = 2;
 /** The whole decision, given everything already fetched. Returns { gate, why, coverage }.
  *  Order mirrors the policy: clean review → no gate; non-member author → no gate (always
  *  human review); trivial → no gate; otherwise gate iff reported coverage < 2. */
-export function evaluateReviewGate({ verdict, comments, author, user, isDraft, isMember, prBody, additions, deletions }) {
+export function evaluateReviewGate({
+	verdict,
+	comments,
+	author,
+	user,
+	isDraft,
+	isMember,
+	prBody,
+	additions,
+	deletions,
+}) {
 	const a = String(author ?? '');
 	if (isDraft || !a || a.toLowerCase() === String(user ?? '').toLowerCase())
 		return { gate: false, why: 'self-review / own PR', coverage: -1 };
@@ -128,8 +143,10 @@ export const hasGateMarker = (body, sha = '') =>
  *  worker uses it to park, and the gate uses it to recognise an UNEDITED parked draft as
  *  its own before daring to submit it (any mismatch = a human touched it = decline). */
 export function autoDraftSummary(reviewBody, agent, verdict) {
-	return (String(reviewBody ?? '').match(/TL;DR[:\s]*([\s\S]{0,700}?)(?=\n\n|\n#)/i) || [])[1]?.trim()
-		|| `Dispatch ${agent} review (verdict ${verdict || '?'}).`;
+	return (
+		(String(reviewBody ?? '').match(/TL;DR[:\s]*([\s\S]{0,700}?)(?=\n\n|\n#)/i) || [])[1]?.trim() ||
+		`Dispatch ${agent} review (verdict ${verdict || '?'}).`
+	);
 }
 export const autoDraftBody = (reviewBody, agent, verdict) => `🤖 ${autoDraftSummary(reviewBody, agent, verdict)}`;
 

--- a/.github/actions/review-coverage/reviewGate.mjs
+++ b/.github/actions/review-coverage/reviewGate.mjs
@@ -1,0 +1,150 @@
+// PUBLIC COPY for the review-coverage CI action. Canonical runtime copy lives in
+// HarperFast/dispatch dispatch/lib/reviewGate.mjs (the server gate imports it) — keep
+// these byte-identical below this header block.
+// Human-review gate decision logic. Policy of record: skills/pr-shepherd/SKILL.md,
+// "Human-review gate". Plain .mjs so shepherd/sync.mjs can import it under plain node.
+
+// Coverage counts FAMILIES, not model names: "codex + gpt-5" is one reviewer twice.
+const FAMILIES = [
+	[/\b(?:codex|gpt-?\d[\w.-]*|o[34](?:-mini)?|openai)\b/i, 'openai'],
+	[/\bgemini\b/i, 'google'],
+	[/\b(?:grok|xai)\b/i, 'xai'],
+	[/\b(?:claude|opus|sonnet|haiku|fable|anthropic)\b/i, 'anthropic'],
+	[/\b(?:composer|cursor)\b/i, 'cursor'],
+	[/\bqwen\b/i, 'qwen'],
+	[/\bdeepseek\b/i, 'deepseek'],
+	[/\bkimi\b/i, 'kimi'],
+	[/\bglm\b/i, 'glm'],
+	[/\bmistral\b/i, 'mistral'],
+	[/\bllama\b/i, 'meta'],
+];
+
+const familiesIn = (text) => FAMILIES.filter(([re]) => re.test(text)).map(([, fam]) => fam);
+
+// A segment that names a model but says the leg did NOT produce a review must not count.
+// Scoped to comma/semicolon segments, not whole lines: "- Codex: clean, Gemini: failed"
+// must count codex. "none" is deliberately absent ("- Gemini: none found." RAN), and
+// "error(s)" negates only when not itself negated ("no errors found" also RAN).
+const NEGATED = /\bfail(?:ed|ure)?\b|\bdid n[o']t run\b|\bskipped\b|\bunavailable\b|\bno usable output\b|\btimed? ?out\b|(?<!\bno )(?<!\bzero )(?<!\bwithout )\berrors?\b|\berrored\b|\bnot run\b|\bpending\b/i;
+
+/** The model family that authored the change itself, when the body declares it (agent PRs
+ *  end with a generated-by marker; HEG's Review coverage names the generating model). A
+ *  self-family review is not cross-model, so it never counts toward coverage. */
+export function generatorFamily(body) {
+	for (const line of String(body ?? '').split('\n')) {
+		if (!/generated (?:with|by)|generating model/i.test(line)) continue;
+		const fams = familiesIn(line);
+		if (fams.length === 1) return fams[0];
+	}
+	return '';
+}
+
+/** Count the DISTINCT outside-model review families the PR description reports as having
+ *  run. The failure direction is asymmetric: an undercount GATES a compliant PR (the gate
+ *  fires on count < 2), so negation filtering stays narrow and anything phrased per the
+ *  conventions below must parse. Free-prose interpretation is not attempted — the remedy
+ *  for unrecognized phrasing is the `## Review coverage` convention the gate's preamble
+ *  teaches, and a wrongly-gated PR self-heals through the recheck once adopted.
+ *
+ *  Scanned surfaces:
+ *   - the `## Review coverage` section (harper-engineering-guidelines step 14)
+ *   - `independent-review: <reviewer> — ...` lines (dev-agent step 5)
+ *   - lines mentioning "cross-model" alongside model names
+ *  Lines reporting a failed/skipped leg are ignored, as is the generating model's family. */
+export function reportedCrossModelReviews(body) {
+	const text = String(body ?? '');
+	const own = generatorFamily(text);
+	const families = new Set();
+	const harvest = (line) => {
+		// "No cross-model review was run (codex, gemini unavailable)" negates the whole
+		// line; per-segment negation handles mixed lines like "Codex: clean, Gemini: failed"
+		if (/\bno\b[^.]*\bcross[- ]model|\bwithout\b[^.]*\bcross[- ]model/i.test(line)) return;
+		for (const seg of String(line).split(/[,;·|]/)) {
+			if (NEGATED.test(seg)) continue;
+			for (const fam of familiesIn(seg)) if (fam !== own) families.add(fam);
+		}
+	};
+
+	const lines = text.split('\n');
+	let inCoverage = false;
+	let coverageLevel = 0;
+	for (const line of lines) {
+		const heading = line.match(/^(#{1,4})\s+(.*)/);
+		if (heading) {
+			if (inCoverage && heading[1].length <= coverageLevel) inCoverage = false;
+			if (/review coverage/i.test(heading[2])) { inCoverage = true; coverageLevel = heading[1].length; continue; }
+		}
+		if (inCoverage) harvest(line);
+		else if (/^\s*(?:[-*>]\s*)?independent-review\s*:/i.test(line)) harvest(line);
+		else if (/cross[- ]model/i.test(line)) harvest(line);
+	}
+	return { count: families.size, families: [...families].sort(), generator: own };
+}
+
+/** "Found findings" per the policy. LGTM (or an unparseable verdict — fail open) is clean;
+ *  CHANGES/BLOCK always count; COMMENT(S) counts only when the review anchored at least one
+ *  finding — a comments-verdict with nothing to anchor fails open to human review. */
+export function reviewHasFindings(verdict, comments) {
+	const v = String(verdict ?? '').toUpperCase();
+	if (!v || v === 'LGTM') return false;
+	if (v === 'CHANGES' || v === 'BLOCK') return true;
+	return Array.isArray(comments) && comments.length > 0;
+}
+
+/** The gate's triviality exemption: up to 2 changed lines, so a one-line EDIT (1 add +
+ *  1 del) is exempt along with pure one-liners. Wider than HEG's literal "more than one
+ *  line", deliberately — the failure direction is human review, not a block. */
+export function isTrivialChange(additions, deletions) {
+	return (Number(additions) || 0) + (Number(deletions) || 0) <= 2;
+}
+
+export const COVERAGE_REQUIRED = 2;
+
+/** The whole decision, given everything already fetched. Returns { gate, why, coverage }.
+ *  Order mirrors the policy: clean review → no gate; non-member author → no gate (always
+ *  human review); trivial → no gate; otherwise gate iff reported coverage < 2. */
+export function evaluateReviewGate({ verdict, comments, author, user, isDraft, isMember, prBody, additions, deletions }) {
+	const a = String(author ?? '');
+	if (isDraft || !a || a.toLowerCase() === String(user ?? '').toLowerCase())
+		return { gate: false, why: 'self-review / own PR', coverage: -1 };
+	if (/\[bot\]$|^app\//.test(a)) return { gate: false, why: 'bot author', coverage: -1 };
+	if (!reviewHasFindings(verdict, comments)) return { gate: false, why: 'clean review', coverage: -1 };
+	if (!isMember) return { gate: false, why: 'author is not an org member — always human review', coverage: -1 };
+	if (isTrivialChange(additions, deletions)) return { gate: false, why: 'trivial change', coverage: -1 };
+	const { count, families } = reportedCrossModelReviews(prBody);
+	if (count >= COVERAGE_REQUIRED)
+		return { gate: false, why: `coverage reported (${families.join(', ')})`, coverage: count };
+	return { gate: true, why: `findings + ${count}/${COVERAGE_REQUIRED} cross-model reviews reported`, coverage: count };
+}
+
+// The marker is the durable dedupe key: recognising our own gate reviews on GitHub is what
+// keeps submission idempotent when local state is lost mid-write.
+export const GATE_MARKER_PREFIX = '<!-- dispatch-review-gate';
+export const gateMarker = (sha) => `${GATE_MARKER_PREFIX} @ ${String(sha ?? '').slice(0, 12)} -->`;
+export const hasGateMarker = (body, sha = '') =>
+	String(body ?? '').includes(sha ? gateMarker(sha) : GATE_MARKER_PREFIX);
+
+/** The auto-draft pending review's body, as runReviewTask parks it. ONE definition: the
+ *  worker uses it to park, and the gate uses it to recognise an UNEDITED parked draft as
+ *  its own before daring to submit it (any mismatch = a human touched it = decline). */
+export function autoDraftSummary(reviewBody, agent, verdict) {
+	return (String(reviewBody ?? '').match(/TL;DR[:\s]*([\s\S]{0,700}?)(?=\n\n|\n#)/i) || [])[1]?.trim()
+		|| `Dispatch ${agent} review (verdict ${verdict || '?'}).`;
+}
+export const autoDraftBody = (reviewBody, agent, verdict) => `🤖 ${autoDraftSummary(reviewBody, agent, verdict)}`;
+
+/** The submitted REQUEST_CHANGES body: gating preamble, then the review itself. */
+export function gateReviewBody({ reviewBody, agent, headSha, coverage }) {
+	const preamble = [
+		'**Automated gate — not yet queued for human review.**',
+		'',
+		`This PR's AI review found issues, and the PR description reports ${coverage === 1 ? 'only one cross-model review' : 'no cross-model reviews'}.`,
+		`Per team policy, a substantive PR with AI-review findings is queued for human review only after at least ${COVERAGE_REQUIRED} cross-model reviews have been run, their findings addressed, and the coverage reported in the PR description (\`## Review coverage\` naming each model — see harper-engineering-guidelines).`,
+		'The findings below count as one of the two: address them, run a second outside-model review, update the description, and the gate lifts automatically on the next pass.',
+		'',
+		'---',
+		'',
+	].join('\n');
+	const signature = `\n\n— ${agent || 'fleet'} review, submitted by the dispatch review gate\n${gateMarker(headSha)}`;
+	return preamble + String(reviewBody ?? '').trim() + signature;
+}

--- a/.github/actions/review-coverage/reviewGate.mjs
+++ b/.github/actions/review-coverage/reviewGate.mjs
@@ -40,6 +40,54 @@ export function generatorFamily(body) {
 	return '';
 }
 
+/** Blank out fenced code blocks so an EXAMPLE of a footer cannot be read as a live one. A PR that
+ *  documents this field (or quotes a body) carries the field's own grammar inside a fence; counting
+ *  that would let a description claim coverage by illustrating it. Local rather than imported: this
+ *  file is a flattened vendored copy with no module deps of its own. */
+const withoutFences = (body) => String(body ?? '').replace(/^[ \t]*```[\s\S]*?^[ \t]*```[ \t]*$/gm, '');
+
+/** Leg name -> family for the STRUCTURED `Review-Coverage:` field.
+ *
+ *  Deliberately a table rather than `familiesIn`: the prose matcher returns EVERY family whose
+ *  pattern hits, and `cursor-grok` hits both `grok`->xai and `cursor`->cursor, so reusing it would
+ *  count one leg as two families and inflate the very number this gate acts on. A structured field
+ *  gets a structured mapping; an unknown leg name falls back to the FIRST prose match only.
+ *  Mirrors REVIEW_LEGS in HarperFast/skills-internal skills/cross-model-review/bin/prepush-policy.mjs. */
+const LEG_FAMILY = new Map([
+	['codex', 'openai'], ['gemini', 'google'], ['cursor-grok', 'xai'], ['cursor-composer', 'cursor'],
+	['claude', 'anthropic'], ['claude(fallback)', 'anthropic'], ['domain', 'anthropic'],
+]);
+const legFamily = (leg) => LEG_FAMILY.get(String(leg).trim().toLowerCase()) ?? familiesIn(leg)[0] ?? '';
+
+/** The machine-derived `Review-Coverage:` footer, when the description carries one.
+ *
+ *  Returns null when the field is absent, which is what lets the caller fall back to the prose
+ *  reader instead of reading "no field" as "no coverage" — the field is newer than most open PRs.
+ *
+ *  Only `ran=` counts. `blocked=` (asked for, could not deliver) and `declined=` (policy chose not
+ *  to run it) are coverage that did NOT happen. The producing side already excludes the authoring
+ *  family and the Harper adjudicator from `ran`; we re-exclude the authoring family anyway, because
+ *  this number acts on other people's PRs and should not inherit a guarantee it can check itself. */
+export function structuredCoverage(body) {
+	const match = /^[ \t]*(?:<sub>[ \t]*)?Review-Coverage:[ \t]*(.+?)[ \t]*(?:<\/sub>[ \t]*)?$/im.exec(withoutFences(body));
+	if (!match) return null;
+	const segments = new Map(match[1].split(';')
+		.map((seg) => seg.trim().split('='))
+		.filter((pair) => pair.length === 2)
+		.map(([key, value]) => [key.trim().toLowerCase(), value.trim()]));
+	const authored = familiesIn((segments.get('authored') || '').replace(/\s*@.*$/, ''))[0] || '';
+	const raw = segments.get('ran') || '';
+	const families = new Set();
+	if (raw && raw !== 'none') {
+		for (const leg of raw.split(',')) {
+			const fam = legFamily(leg.replace(/\(.*$/, ''));
+			if (fam && fam !== authored) families.add(fam);
+		}
+	}
+	const rounds = Number.parseInt((segments.get('rounds') || '').replace(/\s*@.*$/, ''), 10) || 0;
+	return { count: families.size, families: [...families].sort(), generator: authored, rounds, structured: true };
+}
+
 /** Count the DISTINCT outside-model review families the PR description reports as having
  *  run. The failure direction is asymmetric: an undercount GATES a compliant PR (the gate
  *  fires on count < 2), so negation filtering stays narrow and anything phrased per the
@@ -53,6 +101,11 @@ export function generatorFamily(body) {
  *   - lines mentioning "cross-model" alongside model names
  *  Lines reporting a failed/skipped leg are ignored, as is the generating model's family. */
 export function reportedCrossModelReviews(body) {
+	// The field is authoritative when present: it is derived from the run's receipt rather than
+	// written from memory, so it reports the legs that DIED as reliably as the ones that ran.
+	// Prose parsing stays for PRs opened before the field existed.
+	const structured = structuredCoverage(body);
+	if (structured) return structured;
 	const text = String(body ?? '');
 	const own = generatorFamily(text);
 	const families = new Set();

--- a/.github/actions/review-coverage/reviewGate.mjs
+++ b/.github/actions/review-coverage/reviewGate.mjs
@@ -54,8 +54,13 @@ const withoutFences = (body) => String(body ?? '').replace(/^[ \t]*```[\s\S]*?^[
  *  gets a structured mapping; an unknown leg name falls back to the FIRST prose match only.
  *  Mirrors REVIEW_LEGS in HarperFast/skills-internal skills/cross-model-review/bin/prepush-policy.mjs. */
 const LEG_FAMILY = new Map([
-	['codex', 'openai'], ['gemini', 'google'], ['cursor-grok', 'xai'], ['cursor-composer', 'cursor'],
-	['claude', 'anthropic'], ['claude(fallback)', 'anthropic'], ['domain', 'anthropic'],
+	['codex', 'openai'],
+	['gemini', 'google'],
+	['cursor-grok', 'xai'],
+	['cursor-composer', 'cursor'],
+	['claude', 'anthropic'],
+	['claude(fallback)', 'anthropic'],
+	['domain', 'anthropic'],
 ]);
 const legFamily = (leg) => LEG_FAMILY.get(String(leg).trim().toLowerCase()) ?? familiesIn(leg)[0] ?? '';
 
@@ -69,12 +74,17 @@ const legFamily = (leg) => LEG_FAMILY.get(String(leg).trim().toLowerCase()) ?? f
  *  family and the Harper adjudicator from `ran`; we re-exclude the authoring family anyway, because
  *  this number acts on other people's PRs and should not inherit a guarantee it can check itself. */
 export function structuredCoverage(body) {
-	const match = /^[ \t]*(?:<sub>[ \t]*)?Review-Coverage:[ \t]*(.+?)[ \t]*(?:<\/sub>[ \t]*)?$/im.exec(withoutFences(body));
+	const match = /^[ \t]*(?:<sub>[ \t]*)?Review-Coverage:[ \t]*(.+?)[ \t]*(?:<\/sub>[ \t]*)?$/im.exec(
+		withoutFences(body)
+	);
 	if (!match) return null;
-	const segments = new Map(match[1].split(';')
-		.map((seg) => seg.trim().split('='))
-		.filter((pair) => pair.length === 2)
-		.map(([key, value]) => [key.trim().toLowerCase(), value.trim()]));
+	const segments = new Map(
+		match[1]
+			.split(';')
+			.map((seg) => seg.trim().split('='))
+			.filter((pair) => pair.length === 2)
+			.map(([key, value]) => [key.trim().toLowerCase(), value.trim()])
+	);
 	const authored = familiesIn((segments.get('authored') || '').replace(/\s*@.*$/, ''))[0] || '';
 	const raw = segments.get('ran') || '';
 	const families = new Set();

--- a/.github/actions/review-coverage/reviewGate.test.mjs
+++ b/.github/actions/review-coverage/reviewGate.test.mjs
@@ -12,6 +12,8 @@ import {
 	isTrivialChange,
 	reportedCrossModelReviews,
 	reviewHasFindings,
+	COVERAGE_REQUIRED,
+	structuredCoverage,
 } from './reviewGate.mjs';
 
 // ---- coverage parsing ----
@@ -220,4 +222,60 @@ test('autoDraftBody mirrors the worker park body from TL;DR or the fallback', ()
 	assert.strictEqual(autoDraftSummary('## TL;DR: fixes the wedge\n\nrest', 'codex', 'CHANGES'), 'fixes the wedge');
 	assert.strictEqual(autoDraftBody('no tldr here', 'codex', 'CHANGES'), '🤖 Dispatch codex review (verdict CHANGES).');
 	assert.strictEqual(autoDraftBody('no tldr here', 'agy', ''), '🤖 Dispatch agy review (verdict ?).');
+});
+
+const FIELD = (segments) => `<sub>Review-Coverage: ${segments}</sub>`;
+
+test('the structured Review-Coverage field is preferred over prose, and counts only ran=', () => {
+	const body = ['## Summary', 'A fix.', '', 'Complexity: medium', '',
+		FIELD('authored=claude; ran=codex,gemini; adjudicated=domain; blocked=cursor-grok(auth); declined=cursor-composer; rounds=2 @ abcdef123456'),
+		'', '<sub>Human-Review-Need: 3 @ abcdef123456</sub>', '',
+		'🤖 Generated with [Claude Code](https://claude.com/claude-code)'].join('\n');
+	const r = reportedCrossModelReviews(body);
+	assert.strictEqual(r.count, 2);
+	assert.deepStrictEqual(r.families, ['google', 'openai']);
+	assert.strictEqual(r.rounds, 2);
+	assert.strictEqual(r.structured, true);
+	// This is the regression that made the field necessary to teach here at all: with only the
+	// prose reader, a description carrying the new footer and NO `## Review coverage` section
+	// counted 0 and warned as under-reported on every compliant PR.
+	assert.ok(r.count >= COVERAGE_REQUIRED);
+});
+
+test('a blocked or declined lens is never counted as coverage', () => {
+	assert.strictEqual(reportedCrossModelReviews(FIELD('authored=claude; ran=none; blocked=codex(auth),gemini(not-installed); rounds=1')).count, 0);
+	assert.strictEqual(reportedCrossModelReviews(FIELD('authored=claude; ran=none; declined=cursor-grok,cursor-composer; rounds=1')).count, 0);
+	// ran=none is an explicit report of zero outside coverage, not a missing field.
+	assert.strictEqual(structuredCoverage(FIELD('authored=claude; ran=none; rounds=1')).count, 0);
+	assert.strictEqual(structuredCoverage('## Summary\nno field here'), null);
+});
+
+test('one Cursor leg is one family, not two', () => {
+	// familiesIn('cursor-grok') matches BOTH /grok|xai/ -> xai and /composer|cursor/ -> cursor, so
+	// reusing the prose matcher would report 2 families for a single leg and inflate the count the
+	// gate acts on. The structured path maps leg names through a table for exactly this reason.
+	const r = structuredCoverage(FIELD('authored=claude; ran=cursor-grok; rounds=1'));
+	assert.deepStrictEqual(r.families, ['xai']);
+	assert.strictEqual(r.count, 1);
+	assert.deepStrictEqual(structuredCoverage(FIELD('authored=claude; ran=cursor-grok,cursor-composer; rounds=1')).families, ['cursor', 'xai']);
+});
+
+test('the authoring family never counts, and the adjudicator is excluded by the producer', () => {
+	// domain is the Harper adjudicator and is Claude by construction; it is reported under
+	// adjudicated=, never ran=, so a Claude-authored PR cannot reach 2 on its own legs.
+	const r = structuredCoverage(FIELD('authored=claude; ran=codex; adjudicated=domain; rounds=1'));
+	assert.deepStrictEqual(r.families, ['openai']);
+	// Defense in depth: an anthropic leg wrongly placed in ran= by a future producer is dropped.
+	assert.deepStrictEqual(structuredCoverage(FIELD('authored=claude; ran=codex,claude; rounds=1')).families, ['openai']);
+	// A codex-authored change gets its Claude leg back as genuine outside coverage.
+	assert.deepStrictEqual(structuredCoverage(FIELD('authored=codex; ran=claude,gemini; rounds=1')).families, ['anthropic', 'google']);
+});
+
+test('a fenced example of the field cannot satisfy the gate', () => {
+	const body = ['## Summary', 'Documents the field:', '```',
+		'Review-Coverage: authored=claude; ran=codex,gemini; rounds=9', '```', '',
+		'🤖 Generated with [Claude Code](https://claude.com/claude-code)'].join('\n');
+	assert.strictEqual(structuredCoverage(body), null);
+	// Falls through to the prose reader, which finds no coverage section either.
+	assert.strictEqual(reportedCrossModelReviews(body).count, 0);
 });

--- a/.github/actions/review-coverage/reviewGate.test.mjs
+++ b/.github/actions/review-coverage/reviewGate.test.mjs
@@ -1,0 +1,194 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+	autoDraftBody, autoDraftSummary, evaluateReviewGate, gateMarker, gateReviewBody,
+	generatorFamily, hasGateMarker, isTrivialChange, reportedCrossModelReviews, reviewHasFindings,
+} from './reviewGate.mjs';
+
+// ---- coverage parsing ----
+
+test('a Review coverage section counts distinct families', () => {
+	const body = [
+		'Fixes the thing.',
+		'## Review coverage',
+		'- Codex (gpt-5): 3 findings, all addressed',
+		'- Gemini: 1 finding, by-design',
+		'## Verification',
+		'- unit tests',
+	].join('\n');
+	const r = reportedCrossModelReviews(body);
+	assert.equal(r.count, 2);
+	assert.deepEqual(r.families, ['google', 'openai']);
+});
+
+test('same family twice is one reviewer', () => {
+	const body = '## Review coverage\n- codex round 1\n- gpt-5 round 2 (delta)';
+	assert.equal(reportedCrossModelReviews(body).count, 1);
+});
+
+test('a failed leg does not count', () => {
+	const body = '## Review coverage\n- Codex: 2 findings fixed\n- Gemini: FAILED — auth error';
+	const r = reportedCrossModelReviews(body);
+	assert.equal(r.count, 1);
+	assert.deepEqual(r.families, ['openai']);
+});
+
+test('a leg that ran with zero findings counts — "none found" is not a negation', () => {
+	const body = '## Review coverage\n- Codex: 2 findings, fixed\n- Gemini: none found.';
+	assert.equal(reportedCrossModelReviews(body).count, 2);
+});
+
+test('negation is segment-scoped: a mixed line counts the leg that ran', () => {
+	const body = '## Review coverage\n- Codex: clean, Gemini: failed';
+	const r = reportedCrossModelReviews(body);
+	assert.equal(r.count, 1);
+	assert.deepEqual(r.families, ['openai']);
+	assert.equal(reportedCrossModelReviews('## Review coverage\n- Gemini: error').count, 0);
+	assert.equal(reportedCrossModelReviews('## Review coverage\n- Gemini: no errors found.').count, 1,
+		'"no errors found" is a leg that RAN clean');
+});
+
+test('an h1 Review coverage heading parses too', () => {
+	assert.equal(reportedCrossModelReviews('# Review coverage\n- Codex ran\n- Gemini ran').count, 2);
+});
+
+test('the section ends at the next same-level heading', () => {
+	const body = '## Review coverage\n- Codex ran\n## Notes\nGemini is mentioned here but not as coverage';
+	assert.equal(reportedCrossModelReviews(body).count, 1);
+});
+
+test('independent-review lines count outside a coverage section', () => {
+	const body = 'independent-review: codex — 4 findings, 4 fixed, 0 open';
+	const r = reportedCrossModelReviews(body);
+	assert.equal(r.count, 1);
+	assert.deepEqual(r.families, ['openai']);
+});
+
+test('a failed independent-review line does not count', () => {
+	assert.equal(reportedCrossModelReviews('independent-review: FAILED — prepush-review.mjs unavailable').count, 0);
+});
+
+test('cross-model prose lines count, negated ones do not', () => {
+	assert.equal(reportedCrossModelReviews('Cross-model reviews: Codex and Gemini, both clean.').count, 2);
+	assert.equal(reportedCrossModelReviews('No cross-model review was run (codex, gemini unavailable).').count, 0);
+});
+
+test('model names in ordinary prose do not count', () => {
+	const body = 'This PR migrates our Gemini API client and adds Codex-style completions.';
+	assert.equal(reportedCrossModelReviews(body).count, 0);
+});
+
+test('the generating model family is excluded from coverage', () => {
+	const body = [
+		'## Review coverage',
+		'- Claude Opus (generating model): self-review',
+		'- Codex: 2 findings',
+		'',
+		'🤖 Generated with [Claude Code](https://claude.com/claude-code)',
+	].join('\n');
+	const r = reportedCrossModelReviews(body);
+	assert.equal(r.generator, 'anthropic');
+	assert.equal(r.count, 1);
+	assert.deepEqual(r.families, ['openai']);
+});
+
+test('generatorFamily stays empty when a line names several models', () => {
+	assert.equal(generatorFamily('Generated with Claude and reviewed by Codex'), '');
+	assert.equal(generatorFamily('🤖 Generated with [Claude Code](x)'), 'anthropic');
+	assert.equal(generatorFamily('no marker here'), '');
+});
+
+// ---- findings / triviality ----
+
+test('reviewHasFindings maps verdicts per policy', () => {
+	assert.equal(reviewHasFindings('LGTM', []), false);
+	assert.equal(reviewHasFindings('', [{}]), false); // unparseable verdict fails open
+	assert.equal(reviewHasFindings('CHANGES', []), true);
+	assert.equal(reviewHasFindings('BLOCK', []), true);
+	assert.equal(reviewHasFindings('COMMENTS', []), false); // comments verdict with nothing anchored
+	assert.equal(reviewHasFindings('COMMENTS', [{ path: 'a', body: 'b' }]), true);
+});
+
+test('isTrivialChange is the one-line threshold', () => {
+	assert.equal(isTrivialChange(1, 1), true);
+	assert.equal(isTrivialChange(2, 0), true);
+	assert.equal(isTrivialChange(2, 1), false);
+	assert.equal(isTrivialChange(0, 0), true);
+});
+
+// ---- the whole decision ----
+
+const base = {
+	verdict: 'CHANGES', comments: [{ path: 'x', body: 'y' }], author: 'someone',
+	user: 'kriszyp', isDraft: false, isMember: true, prBody: 'plain description',
+	additions: 40, deletions: 12,
+};
+
+test('findings + member + no reported coverage → gate', () => {
+	const d = evaluateReviewGate(base);
+	assert.equal(d.gate, true);
+	assert.equal(d.coverage, 0);
+});
+
+test('clean review never gates, regardless of coverage', () => {
+	assert.equal(evaluateReviewGate({ ...base, verdict: 'LGTM' }).gate, false);
+});
+
+test('non-member author never gates', () => {
+	assert.equal(evaluateReviewGate({ ...base, isMember: false }).gate, false);
+});
+
+test('bot author never gates', () => {
+	assert.equal(evaluateReviewGate({ ...base, author: 'renovate[bot]' }).gate, false);
+	assert.equal(evaluateReviewGate({ ...base, author: 'app/dependabot' }).gate, false);
+});
+
+test('own PR / self-review never gates', () => {
+	assert.equal(evaluateReviewGate({ ...base, author: 'KrisZyp' }).gate, false);
+	assert.equal(evaluateReviewGate({ ...base, isDraft: true }).gate, false);
+});
+
+test('trivial change never gates', () => {
+	assert.equal(evaluateReviewGate({ ...base, additions: 1, deletions: 1 }).gate, false);
+});
+
+test('two reported cross-model reviews lift the gate', () => {
+	const prBody = '## Review coverage\n- Codex: clean\n- Gemini: 1 finding, fixed';
+	const d = evaluateReviewGate({ ...base, prBody });
+	assert.equal(d.gate, false);
+	assert.equal(d.coverage, 2);
+});
+
+test('one reported review still gates', () => {
+	const prBody = '## Review coverage\n- Codex: clean';
+	const d = evaluateReviewGate({ ...base, prBody });
+	assert.equal(d.gate, true);
+	assert.equal(d.coverage, 1);
+});
+
+// ---- gate review body / marker ----
+
+test('gate body carries preamble, review, signature, and marker', () => {
+	const body = gateReviewBody({ reviewBody: 'verdict: CHANGES\nfindings...', agent: 'codex', headSha: 'abcdef1234567890', coverage: 1 });
+	assert.ok(body.startsWith('**Automated gate'));
+	assert.ok(body.includes('only one cross-model review'));
+	assert.ok(body.includes('verdict: CHANGES'));
+	assert.ok(body.includes('— codex review, submitted by the dispatch review gate'));
+	assert.ok(hasGateMarker(body));
+	assert.ok(body.includes(gateMarker('abcdef1234567890')));
+});
+
+test('marker detection ignores unrelated bodies and matches per-head when asked', () => {
+	assert.equal(hasGateMarker('a normal review body'), false);
+	const body = `x\n${gateMarker('abcdef1234567890')}`;
+	assert.equal(hasGateMarker(body), true);
+	assert.equal(hasGateMarker(body, 'abcdef1234567890'), true);
+	assert.equal(hasGateMarker(body, '9999999999999999'), false);
+});
+
+test('autoDraftBody mirrors the worker park body from TL;DR or the fallback', () => {
+	assert.equal(autoDraftSummary('## TL;DR: fixes the wedge\n\nrest', 'codex', 'CHANGES'), 'fixes the wedge');
+	assert.equal(autoDraftBody('no tldr here', 'codex', 'CHANGES'), '🤖 Dispatch codex review (verdict CHANGES).');
+	assert.equal(autoDraftBody('no tldr here', 'agy', ''), '🤖 Dispatch agy review (verdict ?).');
+});

--- a/.github/actions/review-coverage/reviewGate.test.mjs
+++ b/.github/actions/review-coverage/reviewGate.test.mjs
@@ -1,9 +1,17 @@
-import assert from 'node:assert/strict';
+import assert from 'node:assert';
 import test from 'node:test';
 
 import {
-	autoDraftBody, autoDraftSummary, evaluateReviewGate, gateMarker, gateReviewBody,
-	generatorFamily, hasGateMarker, isTrivialChange, reportedCrossModelReviews, reviewHasFindings,
+	autoDraftBody,
+	autoDraftSummary,
+	evaluateReviewGate,
+	gateMarker,
+	gateReviewBody,
+	generatorFamily,
+	hasGateMarker,
+	isTrivialChange,
+	reportedCrossModelReviews,
+	reviewHasFindings,
 } from './reviewGate.mjs';
 
 // ---- coverage parsing ----
@@ -18,65 +26,68 @@ test('a Review coverage section counts distinct families', () => {
 		'- unit tests',
 	].join('\n');
 	const r = reportedCrossModelReviews(body);
-	assert.equal(r.count, 2);
-	assert.deepEqual(r.families, ['google', 'openai']);
+	assert.strictEqual(r.count, 2);
+	assert.deepStrictEqual(r.families, ['google', 'openai']);
 });
 
 test('same family twice is one reviewer', () => {
 	const body = '## Review coverage\n- codex round 1\n- gpt-5 round 2 (delta)';
-	assert.equal(reportedCrossModelReviews(body).count, 1);
+	assert.strictEqual(reportedCrossModelReviews(body).count, 1);
 });
 
 test('a failed leg does not count', () => {
 	const body = '## Review coverage\n- Codex: 2 findings fixed\n- Gemini: FAILED — auth error';
 	const r = reportedCrossModelReviews(body);
-	assert.equal(r.count, 1);
-	assert.deepEqual(r.families, ['openai']);
+	assert.strictEqual(r.count, 1);
+	assert.deepStrictEqual(r.families, ['openai']);
 });
 
 test('a leg that ran with zero findings counts — "none found" is not a negation', () => {
 	const body = '## Review coverage\n- Codex: 2 findings, fixed\n- Gemini: none found.';
-	assert.equal(reportedCrossModelReviews(body).count, 2);
+	assert.strictEqual(reportedCrossModelReviews(body).count, 2);
 });
 
 test('negation is segment-scoped: a mixed line counts the leg that ran', () => {
 	const body = '## Review coverage\n- Codex: clean, Gemini: failed';
 	const r = reportedCrossModelReviews(body);
-	assert.equal(r.count, 1);
-	assert.deepEqual(r.families, ['openai']);
-	assert.equal(reportedCrossModelReviews('## Review coverage\n- Gemini: error').count, 0);
-	assert.equal(reportedCrossModelReviews('## Review coverage\n- Gemini: no errors found.').count, 1,
-		'"no errors found" is a leg that RAN clean');
+	assert.strictEqual(r.count, 1);
+	assert.deepStrictEqual(r.families, ['openai']);
+	assert.strictEqual(reportedCrossModelReviews('## Review coverage\n- Gemini: error').count, 0);
+	assert.strictEqual(
+		reportedCrossModelReviews('## Review coverage\n- Gemini: no errors found.').count,
+		1,
+		'"no errors found" is a leg that RAN clean'
+	);
 });
 
 test('an h1 Review coverage heading parses too', () => {
-	assert.equal(reportedCrossModelReviews('# Review coverage\n- Codex ran\n- Gemini ran').count, 2);
+	assert.strictEqual(reportedCrossModelReviews('# Review coverage\n- Codex ran\n- Gemini ran').count, 2);
 });
 
 test('the section ends at the next same-level heading', () => {
 	const body = '## Review coverage\n- Codex ran\n## Notes\nGemini is mentioned here but not as coverage';
-	assert.equal(reportedCrossModelReviews(body).count, 1);
+	assert.strictEqual(reportedCrossModelReviews(body).count, 1);
 });
 
 test('independent-review lines count outside a coverage section', () => {
 	const body = 'independent-review: codex — 4 findings, 4 fixed, 0 open';
 	const r = reportedCrossModelReviews(body);
-	assert.equal(r.count, 1);
-	assert.deepEqual(r.families, ['openai']);
+	assert.strictEqual(r.count, 1);
+	assert.deepStrictEqual(r.families, ['openai']);
 });
 
 test('a failed independent-review line does not count', () => {
-	assert.equal(reportedCrossModelReviews('independent-review: FAILED — prepush-review.mjs unavailable').count, 0);
+	assert.strictEqual(reportedCrossModelReviews('independent-review: FAILED — prepush-review.mjs unavailable').count, 0);
 });
 
 test('cross-model prose lines count, negated ones do not', () => {
-	assert.equal(reportedCrossModelReviews('Cross-model reviews: Codex and Gemini, both clean.').count, 2);
-	assert.equal(reportedCrossModelReviews('No cross-model review was run (codex, gemini unavailable).').count, 0);
+	assert.strictEqual(reportedCrossModelReviews('Cross-model reviews: Codex and Gemini, both clean.').count, 2);
+	assert.strictEqual(reportedCrossModelReviews('No cross-model review was run (codex, gemini unavailable).').count, 0);
 });
 
 test('model names in ordinary prose do not count', () => {
 	const body = 'This PR migrates our Gemini API client and adds Codex-style completions.';
-	assert.equal(reportedCrossModelReviews(body).count, 0);
+	assert.strictEqual(reportedCrossModelReviews(body).count, 0);
 });
 
 test('the generating model family is excluded from coverage', () => {
@@ -88,89 +99,100 @@ test('the generating model family is excluded from coverage', () => {
 		'🤖 Generated with [Claude Code](https://claude.com/claude-code)',
 	].join('\n');
 	const r = reportedCrossModelReviews(body);
-	assert.equal(r.generator, 'anthropic');
-	assert.equal(r.count, 1);
-	assert.deepEqual(r.families, ['openai']);
+	assert.strictEqual(r.generator, 'anthropic');
+	assert.strictEqual(r.count, 1);
+	assert.deepStrictEqual(r.families, ['openai']);
 });
 
 test('generatorFamily stays empty when a line names several models', () => {
-	assert.equal(generatorFamily('Generated with Claude and reviewed by Codex'), '');
-	assert.equal(generatorFamily('🤖 Generated with [Claude Code](x)'), 'anthropic');
-	assert.equal(generatorFamily('no marker here'), '');
+	assert.strictEqual(generatorFamily('Generated with Claude and reviewed by Codex'), '');
+	assert.strictEqual(generatorFamily('🤖 Generated with [Claude Code](x)'), 'anthropic');
+	assert.strictEqual(generatorFamily('no marker here'), '');
 });
 
 // ---- findings / triviality ----
 
 test('reviewHasFindings maps verdicts per policy', () => {
-	assert.equal(reviewHasFindings('LGTM', []), false);
-	assert.equal(reviewHasFindings('', [{}]), false); // unparseable verdict fails open
-	assert.equal(reviewHasFindings('CHANGES', []), true);
-	assert.equal(reviewHasFindings('BLOCK', []), true);
-	assert.equal(reviewHasFindings('COMMENTS', []), false); // comments verdict with nothing anchored
-	assert.equal(reviewHasFindings('COMMENTS', [{ path: 'a', body: 'b' }]), true);
+	assert.strictEqual(reviewHasFindings('LGTM', []), false);
+	assert.strictEqual(reviewHasFindings('', [{}]), false); // unparseable verdict fails open
+	assert.strictEqual(reviewHasFindings('CHANGES', []), true);
+	assert.strictEqual(reviewHasFindings('BLOCK', []), true);
+	assert.strictEqual(reviewHasFindings('COMMENTS', []), false); // comments verdict with nothing anchored
+	assert.strictEqual(reviewHasFindings('COMMENTS', [{ path: 'a', body: 'b' }]), true);
 });
 
 test('isTrivialChange is the one-line threshold', () => {
-	assert.equal(isTrivialChange(1, 1), true);
-	assert.equal(isTrivialChange(2, 0), true);
-	assert.equal(isTrivialChange(2, 1), false);
-	assert.equal(isTrivialChange(0, 0), true);
+	assert.strictEqual(isTrivialChange(1, 1), true);
+	assert.strictEqual(isTrivialChange(2, 0), true);
+	assert.strictEqual(isTrivialChange(2, 1), false);
+	assert.strictEqual(isTrivialChange(0, 0), true);
 });
 
 // ---- the whole decision ----
 
 const base = {
-	verdict: 'CHANGES', comments: [{ path: 'x', body: 'y' }], author: 'someone',
-	user: 'kriszyp', isDraft: false, isMember: true, prBody: 'plain description',
-	additions: 40, deletions: 12,
+	verdict: 'CHANGES',
+	comments: [{ path: 'x', body: 'y' }],
+	author: 'someone',
+	user: 'kriszyp',
+	isDraft: false,
+	isMember: true,
+	prBody: 'plain description',
+	additions: 40,
+	deletions: 12,
 };
 
 test('findings + member + no reported coverage → gate', () => {
 	const d = evaluateReviewGate(base);
-	assert.equal(d.gate, true);
-	assert.equal(d.coverage, 0);
+	assert.strictEqual(d.gate, true);
+	assert.strictEqual(d.coverage, 0);
 });
 
 test('clean review never gates, regardless of coverage', () => {
-	assert.equal(evaluateReviewGate({ ...base, verdict: 'LGTM' }).gate, false);
+	assert.strictEqual(evaluateReviewGate({ ...base, verdict: 'LGTM' }).gate, false);
 });
 
 test('non-member author never gates', () => {
-	assert.equal(evaluateReviewGate({ ...base, isMember: false }).gate, false);
+	assert.strictEqual(evaluateReviewGate({ ...base, isMember: false }).gate, false);
 });
 
 test('bot author never gates', () => {
-	assert.equal(evaluateReviewGate({ ...base, author: 'renovate[bot]' }).gate, false);
-	assert.equal(evaluateReviewGate({ ...base, author: 'app/dependabot' }).gate, false);
+	assert.strictEqual(evaluateReviewGate({ ...base, author: 'renovate[bot]' }).gate, false);
+	assert.strictEqual(evaluateReviewGate({ ...base, author: 'app/dependabot' }).gate, false);
 });
 
 test('own PR / self-review never gates', () => {
-	assert.equal(evaluateReviewGate({ ...base, author: 'KrisZyp' }).gate, false);
-	assert.equal(evaluateReviewGate({ ...base, isDraft: true }).gate, false);
+	assert.strictEqual(evaluateReviewGate({ ...base, author: 'KrisZyp' }).gate, false);
+	assert.strictEqual(evaluateReviewGate({ ...base, isDraft: true }).gate, false);
 });
 
 test('trivial change never gates', () => {
-	assert.equal(evaluateReviewGate({ ...base, additions: 1, deletions: 1 }).gate, false);
+	assert.strictEqual(evaluateReviewGate({ ...base, additions: 1, deletions: 1 }).gate, false);
 });
 
 test('two reported cross-model reviews lift the gate', () => {
 	const prBody = '## Review coverage\n- Codex: clean\n- Gemini: 1 finding, fixed';
 	const d = evaluateReviewGate({ ...base, prBody });
-	assert.equal(d.gate, false);
-	assert.equal(d.coverage, 2);
+	assert.strictEqual(d.gate, false);
+	assert.strictEqual(d.coverage, 2);
 });
 
 test('one reported review still gates', () => {
 	const prBody = '## Review coverage\n- Codex: clean';
 	const d = evaluateReviewGate({ ...base, prBody });
-	assert.equal(d.gate, true);
-	assert.equal(d.coverage, 1);
+	assert.strictEqual(d.gate, true);
+	assert.strictEqual(d.coverage, 1);
 });
 
 // ---- gate review body / marker ----
 
 test('gate body carries preamble, review, signature, and marker', () => {
-	const body = gateReviewBody({ reviewBody: 'verdict: CHANGES\nfindings...', agent: 'codex', headSha: 'abcdef1234567890', coverage: 1 });
+	const body = gateReviewBody({
+		reviewBody: 'verdict: CHANGES\nfindings...',
+		agent: 'codex',
+		headSha: 'abcdef1234567890',
+		coverage: 1,
+	});
 	assert.ok(body.startsWith('**Automated gate'));
 	assert.ok(body.includes('only one cross-model review'));
 	assert.ok(body.includes('verdict: CHANGES'));
@@ -180,15 +202,15 @@ test('gate body carries preamble, review, signature, and marker', () => {
 });
 
 test('marker detection ignores unrelated bodies and matches per-head when asked', () => {
-	assert.equal(hasGateMarker('a normal review body'), false);
+	assert.strictEqual(hasGateMarker('a normal review body'), false);
 	const body = `x\n${gateMarker('abcdef1234567890')}`;
-	assert.equal(hasGateMarker(body), true);
-	assert.equal(hasGateMarker(body, 'abcdef1234567890'), true);
-	assert.equal(hasGateMarker(body, '9999999999999999'), false);
+	assert.strictEqual(hasGateMarker(body), true);
+	assert.strictEqual(hasGateMarker(body, 'abcdef1234567890'), true);
+	assert.strictEqual(hasGateMarker(body, '9999999999999999'), false);
 });
 
 test('autoDraftBody mirrors the worker park body from TL;DR or the fallback', () => {
-	assert.equal(autoDraftSummary('## TL;DR: fixes the wedge\n\nrest', 'codex', 'CHANGES'), 'fixes the wedge');
-	assert.equal(autoDraftBody('no tldr here', 'codex', 'CHANGES'), '🤖 Dispatch codex review (verdict CHANGES).');
-	assert.equal(autoDraftBody('no tldr here', 'agy', ''), '🤖 Dispatch agy review (verdict ?).');
+	assert.strictEqual(autoDraftSummary('## TL;DR: fixes the wedge\n\nrest', 'codex', 'CHANGES'), 'fixes the wedge');
+	assert.strictEqual(autoDraftBody('no tldr here', 'codex', 'CHANGES'), '🤖 Dispatch codex review (verdict CHANGES).');
+	assert.strictEqual(autoDraftBody('no tldr here', 'agy', ''), '🤖 Dispatch agy review (verdict ?).');
 });

--- a/.github/actions/review-coverage/reviewGate.test.mjs
+++ b/.github/actions/review-coverage/reviewGate.test.mjs
@@ -69,6 +69,13 @@ test('the section ends at the next same-level heading', () => {
 	assert.strictEqual(reportedCrossModelReviews(body).count, 1);
 });
 
+test('ordinary prose after the final coverage section does not count', () => {
+	const body = '## Review coverage\n- Codex ran\n\nCross-model telemetry also touches the grok path.';
+	const result = reportedCrossModelReviews(body);
+	assert.strictEqual(result.count, 1);
+	assert.deepStrictEqual(result.families, ['openai']);
+});
+
 test('independent-review lines count outside a coverage section', () => {
 	const body = 'independent-review: codex — 4 findings, 4 fixed, 0 open';
 	const r = reportedCrossModelReviews(body);

--- a/.github/actions/review-coverage/reviewGate.test.mjs
+++ b/.github/actions/review-coverage/reviewGate.test.mjs
@@ -227,10 +227,20 @@ test('autoDraftBody mirrors the worker park body from TL;DR or the fallback', ()
 const FIELD = (segments) => `<sub>Review-Coverage: ${segments}</sub>`;
 
 test('the structured Review-Coverage field is preferred over prose, and counts only ran=', () => {
-	const body = ['## Summary', 'A fix.', '', 'Complexity: medium', '',
-		FIELD('authored=claude; ran=codex,gemini; adjudicated=domain; blocked=cursor-grok(auth); declined=cursor-composer; rounds=2 @ abcdef123456'),
-		'', '<sub>Human-Review-Need: 3 @ abcdef123456</sub>', '',
-		'🤖 Generated with [Claude Code](https://claude.com/claude-code)'].join('\n');
+	const body = [
+		'## Summary',
+		'A fix.',
+		'',
+		'Complexity: medium',
+		'',
+		FIELD(
+			'authored=claude; ran=codex,gemini; adjudicated=domain; blocked=cursor-grok(auth); declined=cursor-composer; rounds=2 @ abcdef123456'
+		),
+		'',
+		'<sub>Human-Review-Need: 3 @ abcdef123456</sub>',
+		'',
+		'🤖 Generated with [Claude Code](https://claude.com/claude-code)',
+	].join('\n');
 	const r = reportedCrossModelReviews(body);
 	assert.strictEqual(r.count, 2);
 	assert.deepStrictEqual(r.families, ['google', 'openai']);
@@ -243,8 +253,15 @@ test('the structured Review-Coverage field is preferred over prose, and counts o
 });
 
 test('a blocked or declined lens is never counted as coverage', () => {
-	assert.strictEqual(reportedCrossModelReviews(FIELD('authored=claude; ran=none; blocked=codex(auth),gemini(not-installed); rounds=1')).count, 0);
-	assert.strictEqual(reportedCrossModelReviews(FIELD('authored=claude; ran=none; declined=cursor-grok,cursor-composer; rounds=1')).count, 0);
+	assert.strictEqual(
+		reportedCrossModelReviews(FIELD('authored=claude; ran=none; blocked=codex(auth),gemini(not-installed); rounds=1'))
+			.count,
+		0
+	);
+	assert.strictEqual(
+		reportedCrossModelReviews(FIELD('authored=claude; ran=none; declined=cursor-grok,cursor-composer; rounds=1')).count,
+		0
+	);
 	// ran=none is an explicit report of zero outside coverage, not a missing field.
 	assert.strictEqual(structuredCoverage(FIELD('authored=claude; ran=none; rounds=1')).count, 0);
 	assert.strictEqual(structuredCoverage('## Summary\nno field here'), null);
@@ -257,7 +274,10 @@ test('one Cursor leg is one family, not two', () => {
 	const r = structuredCoverage(FIELD('authored=claude; ran=cursor-grok; rounds=1'));
 	assert.deepStrictEqual(r.families, ['xai']);
 	assert.strictEqual(r.count, 1);
-	assert.deepStrictEqual(structuredCoverage(FIELD('authored=claude; ran=cursor-grok,cursor-composer; rounds=1')).families, ['cursor', 'xai']);
+	assert.deepStrictEqual(
+		structuredCoverage(FIELD('authored=claude; ran=cursor-grok,cursor-composer; rounds=1')).families,
+		['cursor', 'xai']
+	);
 });
 
 test('the authoring family never counts, and the adjudicator is excluded by the producer', () => {
@@ -268,13 +288,22 @@ test('the authoring family never counts, and the adjudicator is excluded by the 
 	// Defense in depth: an anthropic leg wrongly placed in ran= by a future producer is dropped.
 	assert.deepStrictEqual(structuredCoverage(FIELD('authored=claude; ran=codex,claude; rounds=1')).families, ['openai']);
 	// A codex-authored change gets its Claude leg back as genuine outside coverage.
-	assert.deepStrictEqual(structuredCoverage(FIELD('authored=codex; ran=claude,gemini; rounds=1')).families, ['anthropic', 'google']);
+	assert.deepStrictEqual(structuredCoverage(FIELD('authored=codex; ran=claude,gemini; rounds=1')).families, [
+		'anthropic',
+		'google',
+	]);
 });
 
 test('a fenced example of the field cannot satisfy the gate', () => {
-	const body = ['## Summary', 'Documents the field:', '```',
-		'Review-Coverage: authored=claude; ran=codex,gemini; rounds=9', '```', '',
-		'🤖 Generated with [Claude Code](https://claude.com/claude-code)'].join('\n');
+	const body = [
+		'## Summary',
+		'Documents the field:',
+		'```',
+		'Review-Coverage: authored=claude; ran=codex,gemini; rounds=9',
+		'```',
+		'',
+		'🤖 Generated with [Claude Code](https://claude.com/claude-code)',
+	].join('\n');
 	assert.strictEqual(structuredCoverage(body), null);
 	// Falls through to the prose reader, which finds no coverage section either.
 	assert.strictEqual(reportedCrossModelReviews(body).count, 0);

--- a/.github/workflows/review-coverage.yml
+++ b/.github/workflows/review-coverage.yml
@@ -1,0 +1,22 @@
+# Cross-model review-coverage check (report mode: informational, never blocks).
+# Parses the PR description with the dispatch human-review gate's own parser and reports
+# how many cross-model reviews it names, plus the Human-Review-Need footer state — so
+# coverage is visible at PR open/edit time, before the fleet's review runs. `edited` is a
+# trigger because reporting coverage is a description edit, which moves no commit sha.
+# Action + policy live in HarperFast/dispatch (skills/pr-shepherd/SKILL.md,
+# dispatch/lib/reviewGate.mjs). Flipping to `mode: enforce` is a team policy decision.
+name: review-coverage
+on:
+  pull_request:
+    types: [opened, edited, synchronize, ready_for_review]
+permissions:
+  contents: read
+concurrency:
+  group: review-coverage-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      # @main deliberately: the point is to track the gate's parser, not a frozen copy
+      - uses: HarperFast/dispatch/actions/review-coverage@main

--- a/.github/workflows/review-coverage.yml
+++ b/.github/workflows/review-coverage.yml
@@ -20,7 +20,4 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # the action is hosted in THIS repo (public home; GitHub bars public repos from
-      # using private-repo actions, so it cannot live in dispatch) — other public
-      # HarperFast repos pin it by sha
       - uses: ./.github/actions/review-coverage

--- a/.github/workflows/review-coverage.yml
+++ b/.github/workflows/review-coverage.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # the action is hosted in THIS repo (public home; GitHub bars public repos from

--- a/.github/workflows/review-coverage.yml
+++ b/.github/workflows/review-coverage.yml
@@ -3,8 +3,8 @@
 # how many cross-model reviews it names, plus the Human-Review-Need footer state — so
 # coverage is visible at PR open/edit time, before the fleet's review runs. `edited` is a
 # trigger because reporting coverage is a description edit, which moves no commit sha.
-# Action + policy live in HarperFast/dispatch (skills/pr-shepherd/SKILL.md,
-# dispatch/lib/reviewGate.mjs). Flipping to `mode: enforce` is a team policy decision.
+# Policy: HarperFast/dispatch skills/pr-shepherd/SKILL.md. Flipping to `mode: enforce`
+# is a team policy decision.
 name: review-coverage
 on:
   pull_request:
@@ -18,6 +18,8 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      # org policy requires full-sha pinning; renovate bumps this, so it still tracks
-      # the gate's parser (dispatch@main) at dep-bot cadence
-      - uses: HarperFast/dispatch/actions/review-coverage@a3210e62d4ffce378898605fd6afb3d4e1d0bee1 # main
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # the action is hosted in THIS repo (public home; GitHub bars public repos from
+      # using private-repo actions, so it cannot live in dispatch) — other public
+      # HarperFast repos pin it by sha
+      - uses: ./.github/actions/review-coverage

--- a/.github/workflows/review-coverage.yml
+++ b/.github/workflows/review-coverage.yml
@@ -18,5 +18,6 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      # @main deliberately: the point is to track the gate's parser, not a frozen copy
-      - uses: HarperFast/dispatch/actions/review-coverage@main
+      # org policy requires full-sha pinning; renovate bumps this, so it still tracks
+      # the gate's parser (dispatch@main) at dep-bot cadence
+      - uses: HarperFast/dispatch/actions/review-coverage@a3210e62d4ffce378898605fd6afb3d4e1d0bee1 # main

--- a/.github/workflows/review-coverage.yml
+++ b/.github/workflows/review-coverage.yml
@@ -23,5 +23,3 @@ jobs:
       # using private-repo actions, so it cannot live in dispatch) — other public
       # HarperFast repos pin it by sha
       - uses: ./.github/actions/review-coverage
-      - name: test review-coverage action
-        run: node --test .github/actions/review-coverage/*.test.mjs

--- a/.github/workflows/review-coverage.yml
+++ b/.github/workflows/review-coverage.yml
@@ -8,7 +8,7 @@
 name: review-coverage
 on:
   pull_request:
-    types: [opened, edited, synchronize, ready_for_review]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
 permissions:
   contents: read
 concurrency:
@@ -23,3 +23,5 @@ jobs:
       # using private-repo actions, so it cannot live in dispatch) — other public
       # HarperFast repos pin it by sha
       - uses: ./.github/actions/review-coverage
+      - name: test review-coverage action
+        run: node --test .github/actions/review-coverage/*.test.mjs

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -51,6 +51,7 @@ jobs:
         run: npm run test:bench # pure-logic tests for benchmarks/ converters; doesn't need a running Harper instance
 
       - name: Review-coverage action tests
+        if: matrix.node-version == 24
         run: node --test .github/actions/review-coverage/*.test.mjs
 
       - name: Setup Harper

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Benchmark unit tests
         run: npm run test:bench # pure-logic tests for benchmarks/ converters; doesn't need a running Harper instance
 
+      - name: Review-coverage action tests
+        run: node --test .github/actions/review-coverage/*.test.mjs
+
       - name: Setup Harper
         env:
           DEFAULTS_MODE: 'dev'


### PR DESCRIPTION
## What / why

Adds the **review-coverage** CI check in **report mode** — informational only, never blocks. On every PR open / description edit / push / ready-for-review, it parses the PR description and surfaces:

- how many **cross-model reviews** the description names (`## Review coverage` section, `independent-review:` lines, or explicit cross-model prose), and
- whether the `Human-Review-Need:` footer is present and **current vs the head sha** (a stale footer means commits landed after the last pre-push review).

Under-reported substantive PRs (org-member author, >2 changed lines, non-draft) get a `::warning::` annotation with the count; bots, outside contributors, trivial changes, and drafts are exempt. Always green in this mode.

**Why the action is hosted here:** GitHub bars public repos from using actions in private repos (no setting overrides it), so the JavaScript action (`using: node24`) + parser get their public home in this repo at `.github/actions/review-coverage/`. `reviewGate.mjs` is a header-marked copy of the canonical runtime version in HarperFast/dispatch (the server-side gate imports that one); other public HarperFast repos pin this action by sha (harper-pro#706).

**Context:** the dispatch review fleet now gates substantive member PRs whose AI review finds issues and whose description reports fewer than two cross-model reviews (auto request-changes until coverage is reported). This check makes that expectation visible the moment a PR opens. Flipping to `mode: enforce` (red when under-reported) is deliberately NOT part of this PR — CI can't see the review verdict, so enforcing here is stricter than the gate; that's a team policy call.

## Verification

- This PR dogfoods the check: it reports the two documented review families and verifies the `Human-Review-Need:` footer against the current head.
- 38 unit tests ride along in the action dir (parser + decision matrix + CLI exit codes); run with `node --test .github/actions/review-coverage/*.test.mjs`.
- The action + script were reviewed in dispatch#59 (codex + gemini + cursor-grok + harper-domain adjudication, 2 rounds).

## Review coverage

- Codex: reviewed the action + evaluation script in dispatch#59 (graded leg)
- Gemini: reviewed the action + evaluation script in dispatch#59

— Claude Fable 5 (dispatched by Kris)
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Human-Review-Need: 4 (decisions: attestation-vs-evidence, vendored-byte-copy, harper-as-org-action-host, report-vs-enforce-default, association-as-membership-proxy, staleness-reported-never-enforced, non-member-exemption-renders-as-pass, tests-in-product-unit-test-job) @ a4f543bdf07c</sub>

