### PR TITLE
Prevent indexed cache TTL test flakes

### DIFF
--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -573,16 +573,9 @@ describe('Caching', () => {
 			await waitFor(() => IndexedCachingTable.primaryStore.getSync(23) === undefined, {
 				message: 'eviction should remove the primary record',
 			});
-			results = [];
-			for await (const record of IndexedCachingTable.search({
-				conditions: [{ attribute: 'name', value: 'name 23' }],
-			})) {
-				results.push(record);
-			}
-			assert.equal(results.length, 0);
+			assert.equal(IndexedCachingTable.indices.name.getValuesCount('name 23'), 0);
 		} finally {
 			sourceExpiresAt = undefined;
-			IndexedCachingTable.setTTLExpiration(0.005);
 		}
 	});
 

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -51,9 +51,11 @@ describe('Caching', () => {
 			get() {
 				let expiresAt = sourceExpiresAt ?? Date.now() + 2;
 				this.getContext().expiresAt = expiresAt;
+				// counted when the request starts, like the other sources here, so a concurrent
+				// duplicate is observable before the first response lands
+				sourceRequests++;
 				return new Promise((resolve, reject) => {
 					setTimeout(() => {
-						sourceRequests++;
 						if (return_error) {
 							let error = new Error('test source error');
 							error.statusCode = return_error;
@@ -512,9 +514,13 @@ describe('Caching', () => {
 		}
 	});
 	it('Can load cached indexed data', async function () {
+		const indexedEvents = [];
+		const indexedSubscription = await IndexedCachingTable.subscribe({});
+		indexedSubscription.on('data', (event) => {
+			indexedEvents.push(event);
+		});
 		try {
 			sourceRequests = 0;
-			events = [];
 			IndexedCachingTable.setTTLExpiration({ expiration: 50, eviction: 100 });
 			const firstExpiresAt = (sourceExpiresAt = Date.now() + 1);
 			let result = await IndexedCachingTable.get(23);
@@ -522,7 +528,6 @@ describe('Caching', () => {
 			await waitFor(() => !IndexedCachingTable.primaryStore.hasLock(23), {
 				message: 'initial source fill should finish committing',
 			});
-			events = [];
 			assert.equal(result.name, 'name ' + 23);
 			assert.equal(sourceRequests, 1);
 			await waitFor(
@@ -532,13 +537,20 @@ describe('Caching', () => {
 					message: 'initial source fill should expire',
 				}
 			);
-			sourceExpiresAt = Date.now() + 1000;
+			const revalidatedExpiresAt = (sourceExpiresAt = Date.now() + 1000);
 			let results = [];
 			for await (let record of IndexedCachingTable.search({ conditions: [{ attribute: 'name', value: 'name 23' }] })) {
 				results.push(record);
 			}
 			assert.equal(results.length, 1);
-			await waitFor(() => sourceRequests >= 2, { message: 'indexed query should revalidate the expired entry' });
+			// every revalidation this query could trigger is started before the refreshed entry is
+			// committed, so waiting on the commit makes the request count exact rather than a floor
+			await waitFor(
+				() =>
+					IndexedCachingTable.primaryStore.getEntry(23)?.expiresAt === revalidatedExpiresAt &&
+					!IndexedCachingTable.primaryStore.hasLock(23),
+				{ message: 'indexed query should revalidate the expired entry and commit the refreshed cache write' }
+			);
 			assert.equal(sourceRequests, 2);
 			result = await IndexedCachingTable.get(23);
 			assert.equal(result.id, 23);
@@ -557,15 +569,22 @@ describe('Caching', () => {
 				}
 			);
 			sourceExpiresAt = Date.now() + 1000;
+			// the preceding barriers have already let this table's earlier publishes land, so anything
+			// arriving from here on belongs to the revalidation below
+			indexedEvents.length = 0;
 			result = await IndexedCachingTable.get(23);
 			assert.equal(result.id, 23);
 			assert.equal(result.name, 'name ' + 23);
 			assert.equal(sourceRequests, 1);
-			assert.equal(events.length, 0);
 			assert(result.getExpiresAt());
 			await waitFor(() => !IndexedCachingTable.primaryStore.hasLock(23), {
 				message: 'source revalidation lock should be released',
 			});
+			assert.deepEqual(
+				indexedEvents.map((event) => event.type),
+				[],
+				'source revalidation should not publish an update event'
+			);
 			const entry = IndexedCachingTable.primaryStore.getEntry(23);
 			assert(entry, 'source revalidation should leave a cache entry to evict');
 			await IndexedCachingTable.evict(23, entry.value, entry.version);
@@ -576,6 +595,7 @@ describe('Caching', () => {
 			assert.equal(IndexedCachingTable.indices.name.getValuesCount('name 23'), 0);
 		} finally {
 			sourceExpiresAt = undefined;
+			indexedSubscription.return?.();
 		}
 	});
 

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -516,30 +516,46 @@ describe('Caching', () => {
 			sourceRequests = 0;
 			events = [];
 			IndexedCachingTable.setTTLExpiration({ expiration: 50, eviction: 100 });
-			sourceExpiresAt = Date.now() + 1;
+			const firstExpiresAt = (sourceExpiresAt = Date.now() + 1);
 			let result = await IndexedCachingTable.get(23);
 			assert.equal(result.id, 23);
-			await IndexedCachingTable.primaryStore.committed;
+			await waitFor(() => !IndexedCachingTable.primaryStore.hasLock(23), {
+				message: 'initial source fill should finish committing',
+			});
 			events = [];
 			assert.equal(result.name, 'name ' + 23);
 			assert.equal(sourceRequests, 1);
-			await waitFor(() => IndexedCachingTable.primaryStore.getEntry(23)?.expiresAt < Date.now());
+			await waitFor(
+				() =>
+					IndexedCachingTable.primaryStore.getEntry(23)?.expiresAt === firstExpiresAt && firstExpiresAt < Date.now(),
+				{
+					message: 'initial source fill should expire',
+				}
+			);
 			sourceExpiresAt = Date.now() + 1000;
 			let results = [];
 			for await (let record of IndexedCachingTable.search({ conditions: [{ attribute: 'name', value: 'name 23' }] })) {
 				results.push(record);
 			}
 			assert.equal(results.length, 1);
-			await waitFor(() => sourceRequests === 2);
+			await waitFor(() => sourceRequests >= 2, { message: 'indexed query should revalidate the expired entry' });
 			assert.equal(sourceRequests, 2);
 			result = await IndexedCachingTable.get(23);
 			assert.equal(result.id, 23);
 			await IndexedCachingTable.invalidate(23);
-			sourceExpiresAt = Date.now() + 1;
+			const secondExpiresAt = (sourceExpiresAt = Date.now() + 1);
 			await IndexedCachingTable.get(23);
-			await IndexedCachingTable.primaryStore.committed;
+			await waitFor(() => !IndexedCachingTable.primaryStore.hasLock(23), {
+				message: 'second source fill should finish committing',
+			});
 			sourceRequests = 0;
-			await waitFor(() => IndexedCachingTable.primaryStore.getEntry(23)?.expiresAt < Date.now());
+			await waitFor(
+				() =>
+					IndexedCachingTable.primaryStore.getEntry(23)?.expiresAt === secondExpiresAt && secondExpiresAt < Date.now(),
+				{
+					message: 'second source fill should expire',
+				}
+			);
 			sourceExpiresAt = Date.now() + 1000;
 			result = await IndexedCachingTable.get(23);
 			assert.equal(result.id, 23);
@@ -547,13 +563,26 @@ describe('Caching', () => {
 			assert.equal(sourceRequests, 1);
 			assert.equal(events.length, 0);
 			assert(result.getExpiresAt());
-			await waitFor(() => !IndexedCachingTable.primaryStore.hasLock(23));
+			await waitFor(() => !IndexedCachingTable.primaryStore.hasLock(23), {
+				message: 'source revalidation lock should be released',
+			});
 			const entry = IndexedCachingTable.primaryStore.getEntry(23);
+			assert(entry, 'source revalidation should leave a cache entry to evict');
 			await IndexedCachingTable.evict(23, entry.value, entry.version);
 			// evict should completely eliminate the record
-			await waitFor(() => IndexedCachingTable.primaryStore.getSync(23) === undefined);
+			await waitFor(() => IndexedCachingTable.primaryStore.getSync(23) === undefined, {
+				message: 'eviction should remove the primary record',
+			});
+			results = [];
+			for await (const record of IndexedCachingTable.search({
+				conditions: [{ attribute: 'name', value: 'name 23' }],
+			})) {
+				results.push(record);
+			}
+			assert.equal(results.length, 0);
 		} finally {
 			sourceExpiresAt = undefined;
+			IndexedCachingTable.setTTLExpiration(0.005);
 		}
 	});
 

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -51,8 +51,7 @@ describe('Caching', () => {
 			get() {
 				let expiresAt = sourceExpiresAt ?? Date.now() + 2;
 				this.getContext().expiresAt = expiresAt;
-				// counted when the request starts, like the other sources here, so a concurrent
-				// duplicate is observable before the first response lands
+				// counted at request start so a concurrent duplicate is observable before the first response
 				sourceRequests++;
 				return new Promise((resolve, reject) => {
 					setTimeout(() => {
@@ -519,6 +518,16 @@ describe('Caching', () => {
 		indexedSubscription.on('data', (event) => {
 			indexedEvents.push(event);
 		});
+		let fenceId = 24;
+		// publications are delivered in commit order, so a delivered fill of a scratch id proves
+		// everything committed before it has been delivered too
+		const fenceEvents = async () => {
+			const id = fenceId++;
+			await IndexedCachingTable.get(id);
+			await waitFor(() => indexedEvents.some((event) => event.id === id), {
+				message: 'the fencing source fill should reach the indexed subscription',
+			});
+		};
 		try {
 			sourceRequests = 0;
 			IndexedCachingTable.setTTLExpiration({ expiration: 50, eviction: 100 });
@@ -543,8 +552,8 @@ describe('Caching', () => {
 				results.push(record);
 			}
 			assert.equal(results.length, 1);
-			// every revalidation this query could trigger is started before the refreshed entry is
-			// committed, so waiting on the commit makes the request count exact rather than a floor
+			// every revalidation this query can trigger starts before the refreshed entry commits, so
+			// waiting on the commit makes the count below exact rather than a floor
 			await waitFor(
 				() =>
 					IndexedCachingTable.primaryStore.getEntry(23)?.expiresAt === revalidatedExpiresAt &&
@@ -560,7 +569,6 @@ describe('Caching', () => {
 			await waitFor(() => !IndexedCachingTable.primaryStore.hasLock(23), {
 				message: 'second source fill should finish committing',
 			});
-			sourceRequests = 0;
 			await waitFor(
 				() =>
 					IndexedCachingTable.primaryStore.getEntry(23)?.expiresAt === secondExpiresAt && secondExpiresAt < Date.now(),
@@ -568,10 +576,10 @@ describe('Caching', () => {
 					message: 'second source fill should expire',
 				}
 			);
-			sourceExpiresAt = Date.now() + 1000;
-			// the preceding barriers have already let this table's earlier publishes land, so anything
-			// arriving from here on belongs to the revalidation below
+			await fenceEvents();
 			indexedEvents.length = 0;
+			sourceExpiresAt = Date.now() + 1000;
+			sourceRequests = 0;
 			result = await IndexedCachingTable.get(23);
 			assert.equal(result.id, 23);
 			assert.equal(result.name, 'name ' + 23);
@@ -580,8 +588,9 @@ describe('Caching', () => {
 			await waitFor(() => !IndexedCachingTable.primaryStore.hasLock(23), {
 				message: 'source revalidation lock should be released',
 			});
+			await fenceEvents();
 			assert.deepEqual(
-				indexedEvents.map((event) => event.type),
+				indexedEvents.filter((event) => event.id === 23),
 				[],
 				'source revalidation should not publish an update event'
 			);
@@ -592,10 +601,12 @@ describe('Caching', () => {
 			await waitFor(() => IndexedCachingTable.primaryStore.getSync(23) === undefined, {
 				message: 'eviction should remove the primary record',
 			});
-			assert.equal(IndexedCachingTable.indices.name.getValuesCount('name 23'), 0);
+			await waitFor(() => IndexedCachingTable.indices.name.getValuesCount('name 23') === 0, {
+				message: 'eviction should remove the secondary index entry',
+			});
 		} finally {
 			sourceExpiresAt = undefined;
-			indexedSubscription.return?.();
+			indexedSubscription.close();
 		}
 	});
 

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -21,6 +21,7 @@ describe('Caching', () => {
 	let observedSwrIds = []; // ids the SwrQueryTable SWR hook saw via this.getId(), for the per-row-identity test
 	let events = [];
 	let timer = 0;
+	let sourceExpiresAt;
 	let return_value = true;
 	let return_error;
 	// skip LMDB test for now, https://github.com/HarperFast/harper/issues/414 for re-enabling
@@ -48,7 +49,7 @@ describe('Caching', () => {
 		});
 		Source = class extends Resource {
 			get() {
-				let expiresAt = Date.now() + 2;
+				let expiresAt = sourceExpiresAt ?? Date.now() + 2;
 				this.getContext().expiresAt = expiresAt;
 				return new Promise((resolve, reject) => {
 					setTimeout(() => {
@@ -511,38 +512,49 @@ describe('Caching', () => {
 		}
 	});
 	it('Can load cached indexed data', async function () {
-		sourceRequests = 0;
-		events = [];
-		IndexedCachingTable.setTTLExpiration(0.005);
-		let result = await IndexedCachingTable.get(23);
-		assert.equal(result.id, 23);
-		events = [];
-		assert.equal(result.name, 'name ' + 23);
-		assert.equal(sourceRequests, 1);
-		await new Promise((resolve) => setTimeout(resolve, 10));
-		let results = [];
-		for await (let record of IndexedCachingTable.search({ conditions: [{ attribute: 'name', value: 'name 23' }] })) {
-			results.push(record);
+		try {
+			sourceRequests = 0;
+			events = [];
+			IndexedCachingTable.setTTLExpiration({ expiration: 50, eviction: 100 });
+			sourceExpiresAt = Date.now() + 1;
+			let result = await IndexedCachingTable.get(23);
+			assert.equal(result.id, 23);
+			await IndexedCachingTable.primaryStore.committed;
+			events = [];
+			assert.equal(result.name, 'name ' + 23);
+			assert.equal(sourceRequests, 1);
+			await waitFor(() => IndexedCachingTable.primaryStore.getEntry(23)?.expiresAt < Date.now());
+			sourceExpiresAt = Date.now() + 1000;
+			let results = [];
+			for await (let record of IndexedCachingTable.search({ conditions: [{ attribute: 'name', value: 'name 23' }] })) {
+				results.push(record);
+			}
+			assert.equal(results.length, 1);
+			await waitFor(() => sourceRequests === 2);
+			assert.equal(sourceRequests, 2);
+			result = await IndexedCachingTable.get(23);
+			assert.equal(result.id, 23);
+			await IndexedCachingTable.invalidate(23);
+			sourceExpiresAt = Date.now() + 1;
+			await IndexedCachingTable.get(23);
+			await IndexedCachingTable.primaryStore.committed;
+			sourceRequests = 0;
+			await waitFor(() => IndexedCachingTable.primaryStore.getEntry(23)?.expiresAt < Date.now());
+			sourceExpiresAt = Date.now() + 1000;
+			result = await IndexedCachingTable.get(23);
+			assert.equal(result.id, 23);
+			assert.equal(result.name, 'name ' + 23);
+			assert.equal(sourceRequests, 1);
+			assert.equal(events.length, 0);
+			assert(result.getExpiresAt());
+			await waitFor(() => !IndexedCachingTable.primaryStore.hasLock(23));
+			const entry = IndexedCachingTable.primaryStore.getEntry(23);
+			await IndexedCachingTable.evict(23, entry.value, entry.version);
+			// evict should completely eliminate the record
+			await waitFor(() => IndexedCachingTable.primaryStore.getSync(23) === undefined);
+		} finally {
+			sourceExpiresAt = undefined;
 		}
-		assert.equal(results.length, 1);
-		assert.equal(sourceRequests, 2);
-		result = await IndexedCachingTable.get(23);
-		assert.equal(result.id, 23);
-		sourceRequests = 0;
-		// let it expire
-		await delay(10);
-		result = await IndexedCachingTable.get(23);
-		assert.equal(result.id, 23);
-		assert.equal(result.name, 'name ' + 23);
-		assert.equal(sourceRequests, 1);
-		assert.equal(events.length, 0);
-		result = await IndexedCachingTable.get(23);
-		await delay(10); // give the lock a chance to be released
-		assert(result.getExpiresAt());
-		result = IndexedCachingTable.primaryStore.getEntry(23);
-		await IndexedCachingTable.evict(23, result, result.version);
-		// evict should completely eliminate the record
-		await waitFor(() => IndexedCachingTable.primaryStore.getSync(23) === undefined);
 	});
 
 	it('Bigger stampede is handled', async function () {


### PR DESCRIPTION
The indexed cache test depended on a 5 ms expiry and 10 ms sleeps, so loaded runners could observe an additional revalidation before the exact source-request assertion. This change controls the source expiry explicitly, waits on cache state, publication delivery, and source-write locks, preserves exact request counts, and verifies secondary-index cleanup directly.

Review feedback on the first revision found two assertions that did not assert what they claimed, and both are now closed:

- The source-request check polled `sourceRequests >= 2` and then asserted equality on the next line, so it read the counter the instant it reached two. [`Source.get()` now counts a request when it starts](https://github.com/HarperFast/harper/pull/2184/changes?w=1#diff-3e4675948d111966e41fc20a24a583b464f51390e2ca2fc4420e97959164200cR55), matching the file's two other source fixtures, and [the query-path barrier waits for the revalidated entry to commit](https://github.com/HarperFast/harper/pull/2184/changes?w=1#diff-3e4675948d111966e41fc20a24a583b464f51390e2ca2fc4420e97959164200cR555) rather than for the counter. Every revalidation the query can trigger is started before that commit lands, so the exact `assert.equal(sourceRequests, 2)` now runs after all of them are counted.
- The event check watched a subscription on `CachingTable`, a table this test never touches, so it could not fail. A test-scoped subscription on `IndexedCachingTable` replaces it, and because subscription delivery is deferred through `setImmediate` in `resources/transactionBroadcast.ts`, both ends of the observation window are fenced by [a scratch-id source fill whose own publication is awaited](https://github.com/HarperFast/harper/pull/2184/changes?w=1#diff-3e4675948d111966e41fc20a24a583b464f51390e2ca2fc4420e97959164200cR524). Publications are delivered in commit order, so [the negative assertion](https://github.com/HarperFast/harper/pull/2184/changes?w=1#diff-3e4675948d111966e41fc20a24a583b464f51390e2ca2fc4420e97959164200cR595) cannot pass merely because a publication had not been delivered yet.

Eviction's [secondary-index check gets its own barrier](https://github.com/HarperFast/harper/pull/2184/changes?w=1#diff-3e4675948d111966e41fc20a24a583b464f51390e2ca2fc4420e97959164200cR605) instead of assuming it becomes visible with the primary removal, and the subscription is torn down with [`close()`](https://github.com/HarperFast/harper/pull/2184/changes?w=1#diff-3e4675948d111966e41fc20a24a583b464f51390e2ca2fc4420e97959164200cR609), which `Subscription` implements — `return()` lives on the iterator, not the subscription, so the earlier optional call was a no-op.

## For the human reviewer

Four decisions are deliberate rather than settled, and each is cheap to reverse:

- **Exact source-request counts.** `assert.equal(sourceRequests, 2)` / `=== 1` asserts "exactly one source request per expired row" as a product invariant, where sibling tests use `<=` bounds. If Harper legitimately tolerates a benign duplicate under scheduling pressure, this becomes the file's most fragile assertion.
- **Counting at request start.** Moving `sourceRequests++` out of the source's `setTimeout` changes the counter for every test sharing `Source` from "responses landed" to "requests started". That is what makes a concurrent duplicate observable, and it matches `CachingTable`'s and `SwrQueryTable`'s fixtures, but it is a shared-fixture change.
- **Proving a negative over an async channel.** "Revalidation publishes nothing" is asserted as an empty filtered array between two delivery fences. The fences make it sound, but an absence assertion is still the weakest available shape; a publish spy would be stronger and would mean rewriting this half of the test.
- **`IndexedCachingTable` is left at `{ expiration: 50, eviction: 100 }`** and the fence fills leave scratch records 24 and 25 behind. No test after this one touches that table (verified), and restoring the prior 5 ms TTL would rearm the cleanup churn this change removes — but a test inserted after this one would inherit both.

Gemini's round-2 findings were checked and not acted on: the missing `'error'` listener has no producer (`emit('error'` has zero matches under `resources/`), and its `setTTLExpiration` and scratch-record scenarios both name "Bigger stampede is handled", which uses `CachingTable`, not `IndexedCachingTable`. The three added comments were flagged as narration across both rounds; they are kept because each states an invariant the code cannot express (why the counter moved, why commit order makes the fence sound, why the commit barrier makes the count exact).

## Verification

- `npm run build` — passed.
- `npx mocha unitTests/resources/caching.test.js --grep "Can load cached indexed data"` repeated 50 times — 50/50 passed. Whole-file `npx mocha unitTests/resources/caching.test.js` repeated 20 times — 20/20 passed (20 passing each).
- `npm run test:unit:resources` — 1,553 passing / 15 pending; three unrelated pre-existing failures remain in `databases.test.js`, `randomAccessFieldsDirective.test.js`, and `replayStructures.test.js`. The changed caching test passed in this gate.
- Negative controls, each run 3 times and failing 3/3:
  - publishing an id-23 event (`invalidate(23)`) immediately before the closing fence → `source revalidation should not publish an update event`, proving the fence observes a publication committed just before it;
  - the reviewer's own injection, `setTimeout(() => { sourceRequests++; }, 5)` before the query-path barrier → `3 == 2`, which passed 3/3 against the previous revision;
  - restoring the old `evict(23, entry, entry.version)` argument → `eviction should remove the secondary index entry`.
- `npx prettier --check unitTests/resources/caching.test.js` and `npm run lint:required` — passed.
- GitHub Actions on `83b650d`: 41 checks pass, 1 fails — `Integration Tests 2/6 (Windows, Node.js v24)`. That shard fails in `integrationTests/apiTests/describe-metadata-upgrade.test.ts` (`Probe /SeoPageCache/ did not become ready within 120000ms ... after restart_service`), it failed twice on this head with two different transport errors, and it fails identically on `main` (run `32804430806`, same test, same probe timeout). Unrelated to this branch, which touches one unit-test file.
- End-to-end route: not observable end-to-end because this is test-only; the resource unit gate exercises the real table, source, storage, index, and subscription implementations.

## Review coverage

The first revision was authored by GPT-5 Codex; this revision by Claude Opus 5. Round 1 (`8b15c95`): Codex (graded), Gemini, Cursor Composer, and Harper-domain adjudication — one major finding (the event assertion had no delivery barrier) plus three minor, all fixed in `83b650d`. Round 2 (`83b650d`, `--full`): Codex graded leg returned LGTM with no findings; Gemini's findings are dispositioned above; the Cursor Composer and Harper-domain legs timed out, so outside findings were not machine-adjudicated this round.

<!-- Generated by Claude Opus 5 -->

<sub>Review-Coverage: authored=claude; ran=gemini,codex; blocked=cursor-composer(failed),domain(timeout); declined=cursor-grok; rounds=2 @ 83b650db0d04</sub>

<sub>Human-Review-Need: 4 @ 83b650db0d04</sub>
