### PR TITLE
Restore npm installs by aligning the Structon dependency pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -244,7 +244,7 @@
 		"ses": "^1.15.0",
 		"stream-chain": "2.2.5",
 		"stream-json": "1.9.1",
-		"structon": "1.0.7",
+		"structon": "1.0.8",
 		"systeminformation": "^5.31.4",
 		"tar-fs": "^3.1.2",
 		"tar-stream": "^3.1.8",


### PR DESCRIPTION
Align the exact Structon dependency pin with the existing `1.0.8` lockfile resolution, restoring `npm ci` on main without changing the lockfile.

The Sync Lock File workflow did not catch this manifest-to-lock mismatch; a separate `npm ci --dry-run` guard would prevent this regression class.

## For the human reviewer

No open judgment calls — this is a one-line manifest correction to the version already resolved in the lockfile.

## Verification

- `npm ci` — passed from this worktree; `package-lock.json` remained unchanged.
- `npm run build`, `npm run lint:required`, and `npm run format:check` — passed.
- End-to-end route: clean `npm ci` exercises the broken CI install path directly and passed.
- `npm run test:unit:main` could not initialize the pre-existing shared database at `/home/kzyp/dev/tmp/hdb50node24final`; the test process failed before executing tests, so the resources and integration suites were not run.

## Review coverage

Authored by GPT-5 Codex. Independent review skipped under dispatch policy for a genuine one-line change.

— GPT-5 Codex
<!-- generated-by: GPT-5 Codex -->

<sub>Human-Review-Need: 4 @ 7835b4d41a1d</sub>
