### PR TITLE
fix(replication): re-acquire the :blob lock before the failed-repair PENDING re-stamp

### DIFF
--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -1387,17 +1387,10 @@ function writeBlobWithStream(
 		if (!options?.lockHeld && !store.tryLock(lockKey)) {
 			throw new Error(`Unable to get lock for blob file ${fileId}`);
 		}
-		const writeStream = createWriteStream(filePath, { autoClose: false, flags: 'w' });
+		// Declared outside the setup try so finished() can close over them; assigned inside it.
+		let writeStream: any;
+		let compressedStream: any;
 		let wroteSize = false;
-		// deferSizeHeader: an in-place repair of an existing fileId keeps the pre-completion sentinel
-		// header until the body has fully landed, so concurrent readers of the (previously damaged)
-		// file keep getting retryable not-yet-complete semantics instead of a finalized header over a
-		// partial body; the final header is written on completion below, as for unknown-size saves.
-		if (blob.size !== undefined && !deferSizeHeader) {
-			// if we know the size, we can write the header immediately
-			writeStream.write(createHeader(blob.size)); // write the default header
-			wroteSize = true;
-		}
 		// Source-idle watchdog: destroys the source if no 'data' arrives for the threshold so pipeline
 		// rejects cleanly. Off unless the owning caller armed this source (or the env override is set);
 		// see getBlobStreamIdleTimeoutMs. On expiry while the stream is paused (pipeline backpressure),
@@ -1405,11 +1398,30 @@ function writeBlobWithStream(
 		// means a slow-but-live writeStream, not a wedge. A pause with zero downstream progress for the
 		// whole interval is a genuine stall (disk hang / stuck pipeline) the 'data' re-arm can never
 		// clear — the receive socket stays paused on backpressure that never lifts — so destroy it.
+		// (Declared here, not in the setup try below, because finished() closes over them.)
 		let idleTimer: NodeJS.Timeout | undefined;
 		let armIdleTimer: (() => void) | undefined;
 		let lastProgressBytes = 0;
 		const idleTimeoutMs = getBlobStreamIdleTimeoutMs(stream);
-		if (idleTimeoutMs > 0) {
+		// A synchronous throw in the setup below (createWriteStream, header write, deflate, pipeline
+		// wiring) is converted by the Promise executor into a rejection of storageInfo.saving — it never
+		// propagates to the caller, so no caller catch can release the :blob lock, and finished() (the
+		// only other release site) is never wired. That leaks the lock for the process lifetime and
+		// permanently wedges the fileId: reads wait on the lock and blobFileMissingOrIncomplete reads a
+		// held lock as a live writer, so the blob can never be repaired. Release-and-rethrow instead.
+		// (harper#2198 review)
+		try {
+			writeStream = createWriteStream(filePath, { autoClose: false, flags: 'w' });
+			// deferSizeHeader: an in-place repair of an existing fileId keeps the pre-completion sentinel
+			// header until the body has fully landed, so concurrent readers of the (previously damaged)
+			// file keep getting retryable not-yet-complete semantics instead of a finalized header over a
+			// partial body; the final header is written on completion below, as for unknown-size saves.
+			if (blob.size !== undefined && !deferSizeHeader) {
+				// if we know the size, we can write the header immediately
+				writeStream.write(createHeader(blob.size)); // write the default header
+				wroteSize = true;
+			}
+			if (idleTimeoutMs > 0) {
 			armIdleTimer = () => {
 				if (idleTimer) clearTimeout(idleTimer);
 				lastProgressBytes = writeStream.bytesWritten;
@@ -1428,14 +1440,17 @@ function writeBlobWithStream(
 			stream.on('resume', armIdleTimer);
 			armIdleTimer();
 		}
-		let compressedStream: any;
-		if (compress) {
-			if (!wroteSize) writeStream.write(COMPRESS_HEADER); // write the default header to the file
-			compressedStream = createDeflate();
-			pipeline(stream, compressedStream, writeStream, finished);
-		} else {
-			if (!wroteSize) writeStream.write(DEFAULT_HEADER); // write the default header to the file
-			pipeline(stream, writeStream, finished);
+			if (compress) {
+				if (!wroteSize) writeStream.write(COMPRESS_HEADER); // write the default header to the file
+				compressedStream = createDeflate();
+				pipeline(stream, compressedStream, writeStream, finished);
+			} else {
+				if (!wroteSize) writeStream.write(DEFAULT_HEADER); // write the default header to the file
+				pipeline(stream, writeStream, finished);
+			}
+		} catch (setupError) {
+			store.unlock(lockKey);
+			throw setupError;
 		}
 		function createHeader(size: number | bigint): Uint8Array {
 			let headerValue = BigInt(size);
@@ -1489,22 +1504,30 @@ function writeBlobWithStream(
 						store.unlock(lockKey);
 					});
 				} else {
-					store.unlock(lockKey);
+					// Hold the :blob lock THROUGH the error-stub write (matching the PENDING branch above):
+					// unlocking first left this writeFile racing any writer that acquired the freed lock —
+					// notably repairBlobFile's failure re-stamp — and two unordered writeFile calls to one
+					// path can land ERROR (500, reads advance past = #481's silent-loss shape) over a stamp
+					// that meant retry (503). (harper#2198 review)
+					let wroteErrorStub = false;
 					try {
 						if (statSync(filePath).size === 0) {
 							// if there was an error in the stream, nothing may have been written, so we can write the error message instead
 							const errorBuffer = Buffer.from(error.toString());
+							wroteErrorStub = true;
 							writeFile(
 								filePath,
 								Buffer.concat([createHeader(BigInt(errorBuffer.length) + 0xff000000000000n), errorBuffer]),
-								(error: Error) => {
-									if (error) logger.debug?.('Error write error message to blob file', error);
+								(writeError: Error) => {
+									store.unlock(lockKey);
+									if (writeError) logger.debug?.('Error write error message to blob file', writeError);
 								}
 							);
 						}
 					} catch (error) {
 						logger.debug?.('Error checking blob file after abort', error);
 					}
+					if (!wroteErrorStub) store.unlock(lockKey);
 				}
 				reject(error);
 			} else {
@@ -1595,8 +1618,11 @@ export function repairBlobFile(blob: Blob, source: Readable): Promise<void> | un
 		const storageInfo = storageInfoForBlob.get(blob);
 		if (!storageInfo?.fileId || !storageInfo.store) return undefined;
 		if (blobFileMissingOrIncomplete(blob) !== true) return undefined;
-		// Everything fallible resolves BEFORE the lock is taken, so no throw can leak it; from the
-		// tryLock on, the only call is writeBlobWithStream, whose catch below releases it.
+		// Everything fallible resolves BEFORE the lock is taken. writeBlobWithStream cannot throw
+		// synchronously — its setup runs inside a Promise executor, so a setup fault surfaces as a
+		// REJECTION of storageInfo.saving (with the lock released by its own unlock-on-throw guard,
+		// harper#2198 review) and lands in the settle handlers below; the catch below is
+		// defense-in-depth for a future non-executor throw, not a live release site.
 		storageInfo.filePath ??= getFilePath(storageInfo);
 		const filePath = storageInfo.filePath;
 		const expectedSize = (blob as { size?: number }).size;
@@ -1612,6 +1638,33 @@ export function repairBlobFile(blob: Blob, source: Readable): Promise<void> | un
 			// attempt, so the stamp must be skipped, never raced over their finalized header.
 			if (!storageInfo.store.tryLock(lockKey)) return;
 			try {
+				// Re-validate UNDER the lock (harper#2198 review): the acquire only proves no writer holds
+				// the file at this instant — between our settle and this acquire another thread can have
+				// completed a healthy write AND released. Stamp only when the on-disk state is provably
+				// still this attempt's damage: header incomplete (our aborted/partial write), or a
+				// finalized header whose size disagrees with the descriptor (our mismatched write — a
+				// concurrent CORRECT write shows the expected size and must be left alone). ENOENT and any
+				// unreadable state skip: stamping blind could resurrect a deleted file or clobber a state
+				// this attempt no longer owns.
+				let stillOurDamage = false;
+				try {
+					const fd = openSync(filePath, 'r');
+					try {
+						const size = fstatSync(fd).size;
+						const header = Buffer.allocUnsafe(HEADER_SIZE);
+						const read = size >= HEADER_SIZE ? readSync(fd, header, 0, HEADER_SIZE, 0) : 0;
+						if (read < HEADER_SIZE || blobHeaderIndicatesIncomplete(header, size)) stillOurDamage = true;
+						else if (expectedSize !== undefined && header.readUIntBE(2, 6) !== expectedSize) stillOurDamage = true;
+					} finally {
+						closeSync(fd);
+					}
+				} catch {
+					stillOurDamage = false;
+				}
+				if (!stillOurDamage) {
+					storageInfo.store.unlock(lockKey);
+					return;
+				}
 				const messageBuffer = Buffer.from(reason);
 				const header = new Uint8Array(HEADER_SIZE);
 				new DataView(header.buffer).setBigInt64(0, BigInt(messageBuffer.length) | (BigInt(PENDING_TYPE) << 48n));

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -1603,14 +1603,26 @@ export function repairBlobFile(blob: Blob, source: Readable): Promise<void> | un
 		const lockKey = storageInfo.fileId + ':blob';
 		if (!storageInfo.store.tryLock(lockKey)) return undefined;
 		const stampPendingBestEffort = (reason: string) => {
+			// The settle handlers below run AFTER writeBlobWithStream's completion path released the
+			// :blob lock, so a NEW writer for this fileId (a retried repair, or a fresh save — plausible
+			// here, since repair fires on identity-tie duplicate deliveries that can arrive on several
+			// links) may already own the file. Re-acquire before stamping and hold the lock through the
+			// async write (the same pattern as the idle-timeout retry stamp in writeBlobWithStream);
+			// failing to acquire means someone is actively writing — their outcome supersedes this failed
+			// attempt, so the stamp must be skipped, never raced over their finalized header.
+			if (!storageInfo.store.tryLock(lockKey)) return;
 			try {
 				const messageBuffer = Buffer.from(reason);
 				const header = new Uint8Array(HEADER_SIZE);
 				new DataView(header.buffer).setBigInt64(0, BigInt(messageBuffer.length) | (BigInt(PENDING_TYPE) << 48n));
 				writeFile(filePath, Buffer.concat([header, messageBuffer]), (writeError: Error) => {
+					storageInfo.store.unlock(lockKey);
 					if (writeError) logger.debug?.('Error re-stamping pending marker after failed blob repair', writeError);
 				});
-			} catch {}
+			} catch (stampError) {
+				storageInfo.store.unlock(lockKey);
+				logger.debug?.('Error re-stamping pending marker after failed blob repair', stampError);
+			}
 		};
 		try {
 			writeBlobWithStream(blob as any, source, storageInfo, { deferSizeHeader: true, lockHeld: true });

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -1750,6 +1750,35 @@ describe('blobFileMissingOrIncomplete (copy-apply duplicate-repair gate, harper-
 		const blob = await createBlob(Readable.from(randomBytes(64)));
 		assert.strictEqual(repairBlobFile(blob, Readable.from(randomBytes(16))), undefined);
 	});
+
+	it('a size-mismatched repair re-stamps PENDING, releases the :blob lock, and stays repairable (harper#2198)', async () => {
+		// Deterministically drives stampPendingBestEffort (harper#2198 review): a source shorter than
+		// the blob descriptor fails the settle-time size verification. Pins three things the suite
+		// previously could not distinguish from broken code: (1) the file ends PENDING (retryable, not
+		// finalized-wrong or ERROR), (2) the lock is released — observable because
+		// blobFileMissingOrIncomplete reads a HELD lock as a live writer and would return false — and
+		// (3) a subsequent repair of the same blob succeeds, proving the fileId was not wedged.
+		const { blob, filePath } = await savedBlob('repair-mismatch');
+		const original = readFileSync(filePath);
+		stampHeaderType(filePath, 0xfe); // PENDING stub — the damaged state that admits a repair
+		const shortSource = Readable.from(original.subarray(8, 108)); // 100 bytes << descriptor size
+		const saving = repairBlobFile(blob, shortSource);
+		assert.ok(saving, 'repair should start on a damaged blob');
+		await assert.rejects(saving, /size mismatch/);
+		// The re-stamp and unlock land in an async writeFile callback after the rejection; poll briefly.
+		let stamped = false;
+		for (let i = 0; i < 50 && !stamped; i++) {
+			await delay(10);
+			const header = readFileSync(filePath);
+			stamped = header.length >= 2 && header[1] === 0xfe && blobFileMissingOrIncomplete(blob) === true;
+		}
+		assert.ok(stamped, 'file must re-stamp PENDING with the :blob lock released (held lock reads as a live writer)');
+		const retry = repairBlobFile(blob, Readable.from(original.subarray(8)));
+		assert.ok(retry, 'a failed repair must leave the blob repairable — a leaked lock would decline here');
+		await retry;
+		assert.strictEqual(blobFileMissingOrIncomplete(blob), false);
+		assert.deepStrictEqual(readFileSync(filePath).subarray(8), original.subarray(8));
+	});
 });
 
 function delay(ms) {


### PR DESCRIPTION
Into #2177's branch — the fix for the blocker flagged [inline](https://github.com/HarperFast/harper/pull/2177#discussion_r3793850870), as a PR per review flow (patch previously posted in [this comment](https://github.com/HarperFast/harper/pull/2177#issuecomment-5318850780)).

## The race

`repairBlobFile`'s settle handlers run **after** `writeBlobWithStream`'s completion path has released the `:blob` lock. `stampPendingBestEffort` then wrote its PENDING re-stamp via a bare `writeFile` with no lock coordination — so a new writer for the same fileId (a retried repair, or a fresh save; plausible, since repair fires on identity-tie duplicate deliveries that can arrive on several links) could acquire the lock, complete a healthy write, and have the stale stamp land **on top of its finalized header**. That regresses a healthy blob to "incomplete" — the dangling state this API exists to fix, reintroduced by its own failure handler.

## The fix

Re-acquire the lock before stamping; hold it **through** the async write (the same pattern as the idle-timeout retry stamp in `writeBlobWithStream`); skip the stamp entirely if the lock is contended — the concurrent writer's outcome supersedes this failed attempt. `tryLock` precedes the `try` block so the catch can never release a lock this call never took.

A skipped stamp is safe on both invoking paths: the rejection path's file is already in a non-complete state from `writeBlobWithStream`'s own failure handling, and on the size-mismatch path the lock-holding writer is writing the same identity-tie content anyway; the next re-delivery re-probes either way.

## Verification, honestly scoped

Compiles clean under harper-pro's tsc (which builds `core/`); harper-pro's `copyGapCursorBanking` passes end-to-end against this change twice (`inPlaceRepairs=2, missingPayloadIds=[]`, together with the repair-window fix in HarperFast/harper-pro#720). The stamp paths are failure-path-only, so neither that e2e nor the three existing `repairBlobFile` unit tests reach them — same unit-coverage gap as the code this replaces, and the change is strictly narrowing (the stamp happens in fewer states than before, never more). A contention unit test needs a seam to grab the lock between `writeBlobWithStream`'s release and the settle handler; worth adding if one exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)