### PR TITLE
Fail fast when the concurrent PATCH route is not ready

### DIFF
--- a/integrationTests/apiTests/utils/lifecycle.mjs
+++ b/integrationTests/apiTests/utils/lifecycle.mjs
@@ -5,10 +5,12 @@ import { awaitJobCompleted } from './operations.mjs';
 const DEFAULT_READINESS_TIMEOUT_MS = 60000;
 const READINESS_POLL_INTERVAL_MS = 250;
 
+const routeIsRegistered = (response) => response.status !== 404;
+
 /**
- * Poll `probePath` until it stops returning 404, i.e. until the route is registered and
- * being served. Any response in [200, 499] excluding 404 is treated as ready; 4xx
- * auth/validation responses are fine.
+ * Poll `probePath` until `isReady` accepts the response. By default that means the route
+ * stopped returning 404, i.e. it is registered and being served; any other status counts as
+ * ready, so 4xx auth/validation responses are fine.
  *
  * Use this directly (without `restartHttpWorkers`) when the component/route is already
  * installed and only async post-boot route registration needs to be awaited — no worker
@@ -17,23 +19,35 @@ const READINESS_POLL_INTERVAL_MS = 250;
  * @param {ReturnType<import('./client.mjs').createApiClient>} client
  * @param {string} probePath REST path that should be served by the component
  * @param {number} [timeoutMs] overall readiness budget (default 60s)
+ * @param {{ isReady?: (response: import('supertest').Response) => boolean }} [options]
  */
-export async function waitForRouteReady(client, probePath, timeoutMs = DEFAULT_READINESS_TIMEOUT_MS) {
+export async function waitForRouteReady(client, probePath, timeoutMs = DEFAULT_READINESS_TIMEOUT_MS, options) {
+	const isReady = options?.isReady ?? routeIsRegistered;
 	const deadline = Date.now() + timeoutMs;
 	let lastStatus;
 	let lastError;
 	while (Date.now() < deadline) {
+		let response;
 		try {
-			const response = await client.reqRest(probePath).timeout(2000);
+			response = await client.reqRest(probePath).timeout(2000);
 			lastStatus = response.status;
-			if (response.status !== 404) return;
+			lastError = undefined;
 		} catch (err) {
+			lastStatus = undefined;
 			lastError = err;
+		}
+		if (response) {
+			const readiness = isReady(response);
+			if (typeof readiness?.then === 'function') {
+				Promise.resolve(readiness).catch(() => {});
+				throw new TypeError('waitForRouteReady isReady must return a boolean synchronously');
+			}
+			if (readiness) return;
 		}
 		await setTimeout(READINESS_POLL_INTERVAL_MS);
 	}
 	throw new Error(
-		`Probe ${probePath} did not become ready within ${timeoutMs}ms ` +
+		`Probe ${client.restURL}${probePath} did not become ready within ${timeoutMs}ms ` +
 			`(last status=${lastStatus ?? 'none'}, last error=${lastError?.message ?? 'none'})`
 	);
 }
@@ -47,8 +61,8 @@ export async function waitForRouteReady(client, probePath, timeoutMs = DEFAULT_R
  *
  * `probePath` should be a REST route that returns a non-404 once the
  * just-installed component has registered its resources — typically the
- * route the test is about to exercise. Any response in [200, 499] excluding
- * 404 is treated as ready; 4xx auth/validation responses are fine.
+ * route the test is about to exercise. This wrapper uses the default readiness policy:
+ * every response except 404 counts as ready, including auth/validation errors and 5xx.
  *
  * @param {ReturnType<import('./client.mjs').createApiClient>} client
  * @param {string} probePath REST path that should be served by the component

--- a/integrationTests/database/concurrentPatchMerge.test.ts
+++ b/integrationTests/database/concurrentPatchMerge.test.ts
@@ -31,6 +31,8 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 // @ts-expect-error no type declarations
 import { createApiClient } from '../apiTests/utils/client.mjs';
+// @ts-expect-error no type declarations
+import { waitForRouteReady } from '../apiTests/utils/lifecycle.mjs';
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'concurrent-patch-merge');
 const ENGINE = process.env.HARPER_STORAGE_ENGINE === 'lmdb' ? 'lmdb' : 'rocksdb';
@@ -62,32 +64,9 @@ suite(`QA-328 concurrent PATCH field-level merge — ${ENGINE}`, (ctx: ContextWi
 		httpURL = ctx.harper.httpURL;
 		auth = client.headers.Authorization;
 
-		const readinessURL = `${httpURL}/CollabDoc/`;
-		const readinessDeadlineMs = 30_000;
-		const deadline = Date.now() + readinessDeadlineMs;
-		let ready = false;
-		let lastObserved = 'no response';
-		while (Date.now() < deadline) {
-			try {
-				const probe = await fetch(readinessURL, {
-					headers: { Authorization: auth },
-					signal: AbortSignal.timeout(3_000),
-				});
-				lastObserved = `HTTP ${probe.status}`;
-				await probe.body?.cancel();
-				if (probe.ok) {
-					ready = true;
-					break;
-				}
-			} catch (error) {
-				lastObserved = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
-			}
-			await sleep(250);
-		}
-		if (!ready)
-			throw new Error(
-				`Harper did not become ready at ${readinessURL} within ${readinessDeadlineMs}ms; last observed ${lastObserved}`
-			);
+		await waitForRouteReady(client, '/CollabDoc/', 30_000, {
+			isReady: (response: { status: number }) => response.status >= 200 && response.status < 300,
+		});
 	});
 
 	after(async () => {

--- a/integrationTests/database/concurrentPatchMerge.test.ts
+++ b/integrationTests/database/concurrentPatchMerge.test.ts
@@ -62,20 +62,32 @@ suite(`QA-328 concurrent PATCH field-level merge — ${ENGINE}`, (ctx: ContextWi
 		httpURL = ctx.harper.httpURL;
 		auth = client.headers.Authorization;
 
-		// Readiness poll — wait until CollabDoc endpoint responds (not 404)
-		const deadline = Date.now() + 30_000;
+		const readinessURL = `${httpURL}/CollabDoc/`;
+		const readinessDeadlineMs = 30_000;
+		const deadline = Date.now() + readinessDeadlineMs;
+		let ready = false;
+		let lastObserved = 'no response';
 		while (Date.now() < deadline) {
 			try {
-				const probe = await fetch(`${httpURL}/CollabDoc/`, {
+				const probe = await fetch(readinessURL, {
 					headers: { Authorization: auth },
 					signal: AbortSignal.timeout(3_000),
 				});
-				if (probe.status !== 404) break;
-			} catch {
-				/* not ready yet */
+				lastObserved = `HTTP ${probe.status}`;
+				await probe.body?.cancel();
+				if (probe.ok) {
+					ready = true;
+					break;
+				}
+			} catch (error) {
+				lastObserved = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
 			}
 			await sleep(250);
 		}
+		if (!ready)
+			throw new Error(
+				`Harper did not become ready at ${readinessURL} within ${readinessDeadlineMs}ms; last observed ${lastObserved}`
+			);
 	});
 
 	after(async () => {

--- a/unitTests/integrationLifecycle.test.mjs
+++ b/unitTests/integrationLifecycle.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert';
+import { waitForRouteReady } from '../integrationTests/apiTests/utils/lifecycle.mjs';
+
+function createProbeClient(outcomes) {
+	let attempts = 0;
+	return {
+		restURL: 'http://127.0.0.1:9926',
+		get attempts() {
+			return attempts;
+		},
+		reqRest() {
+			return {
+				timeout() {
+					const outcome = outcomes[attempts++];
+					return outcome instanceof Error ? Promise.reject(outcome) : Promise.resolve({ status: outcome });
+				},
+			};
+		},
+	};
+}
+
+describe('waitForRouteReady', () => {
+	it('preserves the default non-404 readiness policy', async () => {
+		const client = createProbeClient([404, 500]);
+
+		await waitForRouteReady(client, '/Widget/', 1_000);
+
+		assert.strictEqual(client.attempts, 2);
+	});
+
+	it('allows a caller to require a successful response', async () => {
+		const client = createProbeClient([500, 204]);
+
+		await waitForRouteReady(client, '/Widget/', 1_000, {
+			isReady: (response) => response.status >= 200 && response.status < 300,
+		});
+
+		assert.strictEqual(client.attempts, 2);
+	});
+
+	it('propagates predicate errors immediately', async () => {
+		const client = createProbeClient([200]);
+		const predicateError = new Error('invalid readiness response');
+
+		await assert.rejects(
+			waitForRouteReady(client, '/Widget/', 1_000, {
+				isReady: () => {
+					throw predicateError;
+				},
+			}),
+			(error) => error === predicateError
+		);
+		assert.strictEqual(client.attempts, 1);
+	});
+
+	it('rejects asynchronous predicates', async () => {
+		const client = createProbeClient([200]);
+
+		await assert.rejects(
+			waitForRouteReady(client, '/Widget/', 1_000, {
+				isReady: async () => {
+					throw new Error('async predicate failure');
+				},
+			}),
+			/waitForRouteReady isReady must return a boolean synchronously/
+		);
+		assert.strictEqual(client.attempts, 1);
+	});
+
+	it('reports the full URL and last HTTP status on timeout', async () => {
+		const client = createProbeClient([500, 500]);
+
+		await assert.rejects(
+			waitForRouteReady(client, '/Widget/', 300, { isReady: () => false }),
+			(error) =>
+				error.message.includes('http://127.0.0.1:9926/Widget/') &&
+				error.message.includes('last status=500') &&
+				error.message.includes('last error=none')
+		);
+		assert.ok(client.attempts >= 1);
+	});
+
+	it('reports the last transport failure on timeout', async () => {
+		const client = createProbeClient([new Error('connection refused'), new Error('connection refused')]);
+
+		await assert.rejects(
+			waitForRouteReady(client, '/Widget/', 300),
+			(error) => error.message.includes('last status=none') && error.message.includes('last error=connection refused')
+		);
+		assert.ok(client.attempts >= 1);
+	});
+});


### PR DESCRIPTION
## Summary

QA-328 now [uses the shared `waitForRouteReady` polling contract](https://github.com/HarperFast/harper/pull/2204/changes?w=1#diff-d61e41c4f3bfbc90cf64e2085c486db179bd6e3bf4b2db8b35c6dfafa179dbb4R24) while [requiring a real 2xx response from `CollabDoc`](https://github.com/HarperFast/harper/pull/2204/changes?w=1#diff-043c0b871ddc79915785cec04cf49c46eddf883b0aae4ffb66e517c6d20a75f8R67), so fixture startup failures stop in setup with the endpoint and latest observation instead of becoming misleading concurrency failures. The helper preserves the existing non-404 default for current callers and [focused unit coverage pins both policies and failure diagnostics](https://github.com/HarperFast/harper/pull/2204/changes?w=1#diff-61de4b21b73794b02e99adb8b90d7703fa2faf5759d4aa7bafbf96c6118d4bb5R22).

This test-only fail-fast change remains complementary to #2129's product-level worker lifecycle fix. One non-blocking review nit remains: the latest-status and latest-transport-error shapes are tested separately rather than through a mixed multi-interval transition, avoiding another fixed-sleep timing dependency.

## For the human reviewer

1. **Synchronous readiness predicates:** [`waitForRouteReady` rejects thenables and propagates predicate exceptions immediately](https://github.com/HarperFast/harper/pull/2204/changes?w=1#diff-d61e41c4f3bfbc90cf64e2085c486db179bd6e3bf4b2db8b35c6dfafa179dbb4R40) instead of awaiting or retrying them. This keeps timeout semantics deterministic and treats malformed predicates as caller bugs; changing direction is local to the helper.
2. **QA-328 requires 2xx:** The fixture probe uses 2xx rather than the helper's default non-404 policy because this suite needs a queryable table, not merely a registered route. Rejecting this choice restores weaker setup detection but does not affect production behavior.
3. **Existing callers retain non-404 readiness:** Tightening the shared default to 2xx would change every existing lifecycle caller, so this PR keeps compatibility and opts only QA-328 into stricter readiness. A future tightening needs a caller audit.
4. **Fourth-argument options object:** The predicate lives in a fourth argument after the existing positional timeout, avoiding churn at current three-argument call sites. An overload or broader options redesign is straightforward if this internal helper grows more policy controls.
5. **Narrow migration scope:** Only the reviewed QA-328 loop is consolidated here; similar pre-existing inline readiness loops remain outside this review fix. Expanding scope would require auditing their intentionally different readiness semantics.

## Verification

- `npm run build` — passed.
- `npx mocha unitTests/integrationLifecycle.test.mjs` — 6 passed.
- `npm run test:integration -- "integrationTests/database/concurrentPatchMerge.test.ts"` — RocksDB 7 passed; LMDB 7 passed with `HARPER_STORAGE_ENGINE=lmdb`.
- `npm run test:integration -- "integrationTests/database/eviction-secondary-index.test.ts"` — existing default-policy caller passed 3 tests.
- `npm run lint:required`, focused Prettier check, and `git diff --check` — passed.
- `npm run test:unit:main` did not reach tests because the environment opened a pre-existing shared system database and failed during metadata initialization. `npm run test:unit:resources` completed with 1,553 passing and 3 unrelated struct-serialization failures while the worktree retained its pre-existing `structon` lockfile mismatch; neither dependency file nor those tests are changed by this commit.

Complexity: medium

<sub>Review-Coverage: authored=codex; ran=claude,gemini; adjudicated=domain; declined=cursor-grok,cursor-composer; rounds=2 @ 5be36426069a</sub>

<sub>Human-Review-Need: 3 (decisions: sync-readiness-predicate, predicate-error-policy, preserve-non404-default, strict-collabdoc-readiness, fourth-positional-options) @ 5be36426069a</sub>
