### PR TITLE
Deflake deferred cache and await LMDB reload markers

### DIFF
--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -575,6 +575,31 @@ export class DatabaseTransaction implements Transaction {
 		this.overloadChecked = true; // only check this once, don't interrupt ongoing transactions that have already made writes
 	}
 
+	/**
+	 * Stage an async operation that commit() must wait for. Staging can happen a turn or more before
+	 * commit() attaches its Promise.all, so the no-op rejection handler is attached here: without it a
+	 * rejection in that window is an unhandled rejection (fatal under --unhandled-rejections=strict).
+	 * The rejection still surfaces through commit()'s Promise.all.
+	 */
+	/**
+	 * The stored entry of the last write eligible for replication confirmation. Writes that opt out
+	 * (audit-only markers, which stage no record) are skipped rather than ending the search, so a
+	 * trailing marker cannot suppress confirmation for replicable writes staged earlier.
+	 */
+	lastConfirmableEntry(): Partial<Entry> | undefined {
+		for (let i = this.writes.length - 1; i >= 0; i--) {
+			const write = this.writes[i];
+			if (!write || write.skipReplicationConfirmation) continue;
+			const entry = write.store.getEntry(write.key);
+			if (entry) return entry;
+		}
+	}
+
+	stageCompletion(completion: Promise<void>) {
+		completion.then(undefined, () => {});
+		this.completions.push(completion);
+	}
+
 	addWrite(operation: TransactionWrite) {
 		if (this.timedOut) throw transactionOpenTooLongError();
 		// A write is activity: it re-arms the idle limit on this link even though the reads it
@@ -641,12 +666,12 @@ export class DatabaseTransaction implements Transaction {
 				return;
 			}
 			let result: Promise<void> = operation.before?.() as Promise<void>;
-			if (result?.then) this.completions.push(result);
+			if (result?.then) this.stageCompletion(result);
 			result = operation.beforeIntermediate?.() as Promise<void>;
-			if (result?.then) this.completions.push(result);
+			if (result?.then) this.stageCompletion(result);
 		}
 		const completion = operation.commit(txnTime, operation.entry, this.retries > 0, transaction) as Promise<void>;
-		if (typeof completion?.then === 'function') this.completions.push(completion);
+		if (typeof completion?.then === 'function') this.stageCompletion(completion);
 		// Sticky record that THIS write staged with its audit entry appended (log entries batch on the
 		// native transaction and are durably written by its commit attempt — even a failed one — so
 		// they survive the abort-after-failed-commit of the retry paths). isRetry stagings
@@ -859,9 +884,9 @@ export class DatabaseTransaction implements Transaction {
 								// if we want to wait for replication confirmation, we need to track the transaction times
 								// and when replication notifications come in, we count the number of confirms until we reach the desired number
 								const databaseName = this.writes[0].store.rootStore.databaseName;
-								const lastWrite = this.writes[this.writes.length - 1];
-								const lastEntry =
-									lastWrite && !lastWrite.skipReplicationConfirmation && lastWrite.store.getEntry(lastWrite.key);
+								// the last write that can be confirmed: a trailing confirmation-exempt write (an
+								// audit-only marker) must not suppress confirmation for replicable writes staged before it
+								const lastEntry = this.lastConfirmableEntry();
 								if (confirmReplication && lastEntry) {
 									completions.push(
 										confirmReplication(databaseName, (lastEntry as any).version, this.replicatedConfirmation)

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -253,7 +253,7 @@ export type TransactionWrite = {
 	entry?: Partial<Entry>;
 	before?: () => void | Promise<void>;
 	beforeIntermediate?: () => void | Promise<void>;
-	commit?: (txnTime: number, existingEntry: Partial<Entry>, retry: boolean, transaction: any) => void;
+	commit?: (txnTime: number, existingEntry: Partial<Entry>, retry: boolean, transaction: any) => MaybePromise<void>;
 	validate?: (txnTime: number) => void;
 	fullUpdate?: boolean;
 	saved?: boolean;

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -258,6 +258,7 @@ export type TransactionWrite = {
 	fullUpdate?: boolean;
 	saved?: boolean;
 	deferSave?: boolean;
+	skipReplicationConfirmation?: boolean;
 	nodeName?: string;
 	nodeId?: number;
 	promise?: Promise<any>;
@@ -307,8 +308,8 @@ export function priorStagedWrite(operation: TransactionWrite): TransactionWrite 
  * `[-0]` and `[null]` vs `[NaN]` are DIFFERENT stored keys that value-ish encodings (JSON, string
  * coercion) collapse, cross-contaminating unrelated records. So every key is mapped through the
  * same encoder the stores use; latin1 keeps the bytes injective in a string. Symbol keys (internal
- * metadata writes) can't be key-encoded and keep native identity; so does null (topic-less
- * publishes), which never stages a record.
+ * metadata writes) can't be key-encoded and keep native identity. Null is reserved for topic-less
+ * publishes and audit-only markers.
  */
 export function writeKeyId(key: Id): unknown {
 	if (typeof key === 'symbol' || key == null) return key;
@@ -644,7 +645,8 @@ export class DatabaseTransaction implements Transaction {
 			result = operation.beforeIntermediate?.() as Promise<void>;
 			if (result?.then) this.completions.push(result);
 		}
-		operation.commit(txnTime, operation.entry, this.retries > 0, transaction);
+		const completion = operation.commit(txnTime, operation.entry, this.retries > 0, transaction) as Promise<void>;
+		if (typeof completion?.then === 'function') this.completions.push(completion);
 		// Sticky record that THIS write staged with its audit entry appended (log entries batch on the
 		// native transaction and are durably written by its commit attempt — even a failed one — so
 		// they survive the abort-after-failed-commit of the retry paths). isRetry stagings
@@ -858,13 +860,11 @@ export class DatabaseTransaction implements Transaction {
 								// and when replication notifications come in, we count the number of confirms until we reach the desired number
 								const databaseName = this.writes[0].store.rootStore.databaseName;
 								const lastWrite = this.writes[this.writes.length - 1];
-								if (confirmReplication && lastWrite) {
+								const lastEntry =
+									lastWrite && !lastWrite.skipReplicationConfirmation && lastWrite.store.getEntry(lastWrite.key);
+								if (confirmReplication && lastEntry) {
 									completions.push(
-										confirmReplication(
-											databaseName,
-											(lastWrite.store.getEntry(lastWrite.key) as any).version,
-											this.replicatedConfirmation
-										)
+										confirmReplication(databaseName, (lastEntry as any).version, this.replicatedConfirmation)
 									);
 								}
 							}

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -576,12 +576,6 @@ export class DatabaseTransaction implements Transaction {
 	}
 
 	/**
-	 * Stage an async operation that commit() must wait for. Staging can happen a turn or more before
-	 * commit() attaches its Promise.all, so the no-op rejection handler is attached here: without it a
-	 * rejection in that window is an unhandled rejection (fatal under --unhandled-rejections=strict).
-	 * The rejection still surfaces through commit()'s Promise.all.
-	 */
-	/**
 	 * The stored entry of the last write eligible for replication confirmation. Writes that opt out
 	 * (audit-only markers, which stage no record) are skipped rather than ending the search, so a
 	 * trailing marker cannot suppress confirmation for replicable writes staged earlier.
@@ -595,6 +589,12 @@ export class DatabaseTransaction implements Transaction {
 		}
 	}
 
+	/**
+	 * Stage an async operation that commit() must wait for. Staging can happen a turn or more before
+	 * commit() attaches its Promise.all, so the no-op rejection handler is attached here: without it a
+	 * rejection in that window is an unhandled rejection (fatal under --unhandled-rejections=strict).
+	 * The rejection still surfaces through commit()'s Promise.all.
+	 */
 	stageCompletion(completion: Promise<void>) {
 		completion.then(undefined, () => {});
 		this.completions.push(completion);
@@ -884,8 +884,6 @@ export class DatabaseTransaction implements Transaction {
 								// if we want to wait for replication confirmation, we need to track the transaction times
 								// and when replication notifications come in, we count the number of confirms until we reach the desired number
 								const databaseName = this.writes[0].store.rootStore.databaseName;
-								// the last write that can be confirmed: a trailing confirmation-exempt write (an
-								// audit-only marker) must not suppress confirmation for replicable writes staged before it
 								const lastEntry = this.lastConfirmableEntry();
 								if (confirmReplication && lastEntry) {
 									completions.push(

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -576,9 +576,12 @@ export class DatabaseTransaction implements Transaction {
 	}
 
 	/**
-	 * The stored entry of the last write eligible for replication confirmation. Writes that opt out
-	 * (audit-only markers, which stage no record) are skipped rather than ending the search, so a
-	 * trailing marker cannot suppress confirmation for replicable writes staged earlier.
+	 * The stored entry of the last write eligible for replication confirmation. Two kinds of write are
+	 * skipped (rather than ending the search) so a trailing one cannot suppress confirmation for
+	 * replicable writes staged earlier: writes that explicitly opt out (audit-only markers, which stage
+	 * no record), and writes with no stored entry at all — a delete, or a delete on an `audit: false`
+	 * table, leaves nothing to read back. So a `put(A); delete(B)` transaction confirms on A's entry,
+	 * whose version is this transaction's (every write in a transaction is stamped with one version).
 	 */
 	lastConfirmableEntry(): Partial<Entry> | undefined {
 		for (let i = this.writes.length - 1; i >= 0; i--) {
@@ -598,6 +601,22 @@ export class DatabaseTransaction implements Transaction {
 	stageCompletion(completion: Promise<void>) {
 		completion.then(undefined, () => {});
 		this.completions.push(completion);
+	}
+
+	/**
+	 * Discard staged completions that no commit() will ever aggregate (abort path). Their rejections
+	 * are already no-op-handled by stageCompletion(), so without this they fail silently; log instead.
+	 * Clearing them also keeps a reused transaction's next commit() from rejecting with the previous
+	 * batch's error.
+	 */
+	drainCompletions(): void {
+		if (this.completions.length === 0) return;
+		const completions = this.completions;
+		this.completions = [];
+		for (const completion of completions)
+			completion.then(undefined, (error) =>
+				harperLogger.warn?.('A staged transaction completion failed after the transaction was aborted', error)
+			);
 	}
 
 	addWrite(operation: TransactionWrite) {
@@ -1028,7 +1047,13 @@ export class DatabaseTransaction implements Transaction {
 	}
 	abort(): void {
 		while (this.readTxnsUsed > 0) this.doneReadTxn(); // release the read snapshot when we abort, we assume we don't need it
+		// A write-only transaction never took a read reference (getReadTxn was never called), so the loop
+		// above releases nothing even though save() created a native handle; release it here instead of
+		// leaking the handle and its snapshot until GC. abortDueToTimeout() detaches the handle before
+		// calling abort(), so this is a no-op there rather than a double-abort.
+		if (this.transaction) this.releaseReadTxn();
 		this.open = TRANSACTION_STATE.CLOSED;
+		this.drainCompletions();
 		for (const write of this.writes) {
 			if (write?.savedBlobs)
 				cleanupUnusedBlobs(write.savedBlobs, collectRetainedFileIds(write.store.getEntry(write.key)?.value));

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -1049,8 +1049,8 @@ export class DatabaseTransaction implements Transaction {
 		while (this.readTxnsUsed > 0) this.doneReadTxn(); // release the read snapshot when we abort, we assume we don't need it
 		// A write-only transaction never took a read reference (getReadTxn was never called), so the loop
 		// above releases nothing even though save() created a native handle; release it here instead of
-		// leaking the handle and its snapshot until GC. abortDueToTimeout() detaches the handle before
-		// calling abort(), so this is a no-op there rather than a double-abort.
+		// leaking the handle and its snapshot until GC. abortChainAfterRetries() detaches the handle
+		// before calling abort(), so this is a no-op there rather than a double-abort.
 		if (this.transaction) this.releaseReadTxn();
 		this.open = TRANSACTION_STATE.CLOSED;
 		this.drainCompletions();

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -579,9 +579,10 @@ export class DatabaseTransaction implements Transaction {
 	 * The stored entry of the last write eligible for replication confirmation. Two kinds of write are
 	 * skipped (rather than ending the search) so a trailing one cannot suppress confirmation for
 	 * replicable writes staged earlier: writes that explicitly opt out (audit-only markers, which stage
-	 * no record), and writes with no stored entry at all — a delete, or a delete on an `audit: false`
-	 * table, leaves nothing to read back. So a `put(A); delete(B)` transaction confirms on A's entry,
-	 * whose version is this transaction's (every write in a transaction is stamped with one version).
+	 * no record), and writes with no stored entry at all — a delete leaves a readable tombstone on any
+	 * audited or delete-tracking table, so only a delete on a table with neither is entry-less. Such a
+	 * `put(A); delete(B)` confirms on A's entry, whose version is this transaction's (every write in a
+	 * transaction is stamped with one version).
 	 */
 	lastConfirmableEntry(): Partial<Entry> | undefined {
 		for (let i = this.writes.length - 1; i >= 0; i--) {

--- a/resources/LMDBTransaction.ts
+++ b/resources/LMDBTransaction.ts
@@ -184,10 +184,12 @@ export class LMDBTransaction extends DatabaseTransaction {
 		this.open = options?.doneWriting ? TRANSACTION_STATE.LINGERING : TRANSACTION_STATE.OPEN;
 		let resolution;
 		const completions = [];
+		let commitCompletions: Promise<void>[];
 		let writeIndex = 0;
 		this.writes = this.writes.filter((write) => write); // filter out removed entries
 		const doWrite = (write) => {
-			write.commit(txnTime, write.entry, retries);
+			const completion = write.commit(txnTime, write.entry, retries);
+			if (typeof completion?.then === 'function') (commitCompletions ??= []).push(completion);
 		};
 		// this uses optimistic locking to submit a transaction, conditioning each write on the expected version
 		const nextCondition = () => {
@@ -235,6 +237,11 @@ export class LMDBTransaction extends DatabaseTransaction {
 					return true; // success. always success
 				});
 			}
+		}
+		if (commitCompletions) {
+			if (resolution) completions.push(...commitCompletions);
+			// A false resolution means an optimistic conflict and retries the writes.
+			else resolution = Promise.all(commitCompletions).then(() => true);
 		}
 
 		if (resolution) {

--- a/resources/LMDBTransaction.ts
+++ b/resources/LMDBTransaction.ts
@@ -228,7 +228,9 @@ export class LMDBTransaction extends DatabaseTransaction {
 				nextCondition();
 				if (commitCompletions) {
 					if (resolution) {
-						resolution = resolution.then((committed) => Promise.all(commitCompletions).then(() => committed));
+						resolution = Promise.resolve(resolution).then((committed) =>
+							Promise.all(commitCompletions).then(() => committed)
+						);
 					} else {
 						// Must resolve truthy or the conflict branch re-runs the writes.
 						resolution = Promise.all(commitCompletions).then(() => true);

--- a/resources/LMDBTransaction.ts
+++ b/resources/LMDBTransaction.ts
@@ -19,7 +19,6 @@ export const TRANSACTION_STATE = {
 	OPEN: 1, // the transaction is open and can be used for reads and writes
 	LINGERING: 2, // the transaction has completed a read, but can be used for immediate writes
 };
-let outstandingCommit;
 let confirmReplication;
 export function replicationConfirmation(callback) {
 	confirmReplication = callback;
@@ -254,14 +253,6 @@ export class LMDBTransaction extends DatabaseTransaction {
 		}
 
 		if (resolution) {
-			if (!outstandingCommit) {
-				outstandingCommit = resolution;
-				const clearOutstandingCommit = () => {
-					outstandingCommit = null;
-				};
-				outstandingCommit.then(clearOutstandingCommit, clearOutstandingCommit);
-			}
-
 			return resolution.then((resolution) => {
 				if (resolution) {
 					if (this.next) {
@@ -275,13 +266,11 @@ export class LMDBTransaction extends DatabaseTransaction {
 						// and when replication notifications come in, we count the number of confirms until we reach the desired number
 						const databaseName = this.writes[0].store.rootStore.databaseName;
 						const lastWrite = this.writes[this.writes.length - 1];
-						if (confirmReplication && lastWrite?.key != null)
+						const lastEntry =
+							lastWrite && !lastWrite.skipReplicationConfirmation && lastWrite.store.getEntry(lastWrite.key);
+						if (confirmReplication && lastEntry)
 							completions.push(
-								confirmReplication(
-									databaseName,
-									(lastWrite.store.getEntry(lastWrite.key) as any).localTime,
-									this.replicatedConfirmation
-								)
+								confirmReplication(databaseName, (lastEntry as any).localTime, this.replicatedConfirmation)
 							);
 					}
 					// commit succeeded; clean up files for any writes whose commit-handler took an early-return,

--- a/resources/LMDBTransaction.ts
+++ b/resources/LMDBTransaction.ts
@@ -224,11 +224,20 @@ export class LMDBTransaction extends DatabaseTransaction {
 			// will fail and retry due to contention. This is used to determine when to give up on optimistic writes and
 			// use a real (async) transaction to get exclusive access to the data
 			if (db?.retryRisk) db.retryRisk *= 0.99; // gradually decay the retry risk
-			if (this.writes.length + (db?.retryRisk || 0) < MAX_OPTIMISTIC_SIZE >> retries) nextCondition();
-			else {
+			if (this.writes.length + (db?.retryRisk || 0) < MAX_OPTIMISTIC_SIZE >> retries) {
+				nextCondition();
+				if (commitCompletions) {
+					if (resolution) {
+						resolution = resolution.then((committed) => Promise.all(commitCompletions).then(() => committed));
+					} else {
+						// Must resolve truthy or the conflict branch re-runs the writes.
+						resolution = Promise.all(commitCompletions).then(() => true);
+					}
+				}
+			} else {
 				// if it is too big to expect optimistic writes to work, or we have done too many retries we use
 				// a real LMDB transaction to get exclusive access to reading and writing
-				resolution = this.writes[0].store.transaction(() => {
+				const transactionResolution = this.writes[0].store.transaction(() => {
 					for (const write of this.writes) {
 						// we load latest data while in the transaction
 						write.entry = write.store.getEntry(write.key);
@@ -236,20 +245,19 @@ export class LMDBTransaction extends DatabaseTransaction {
 					}
 					return true; // success. always success
 				});
+				resolution = transactionResolution.then((committed) =>
+					commitCompletions ? Promise.all(commitCompletions).then(() => committed) : committed
+				);
 			}
-		}
-		if (commitCompletions) {
-			if (resolution) completions.push(...commitCompletions);
-			// A false resolution means an optimistic conflict and retries the writes.
-			else resolution = Promise.all(commitCompletions).then(() => true);
 		}
 
 		if (resolution) {
 			if (!outstandingCommit) {
 				outstandingCommit = resolution;
-				outstandingCommit.then(() => {
+				const clearOutstandingCommit = () => {
 					outstandingCommit = null;
-				});
+				};
+				outstandingCommit.then(clearOutstandingCommit, clearOutstandingCommit);
 			}
 
 			return resolution.then((resolution) => {
@@ -265,7 +273,7 @@ export class LMDBTransaction extends DatabaseTransaction {
 						// and when replication notifications come in, we count the number of confirms until we reach the desired number
 						const databaseName = this.writes[0].store.rootStore.databaseName;
 						const lastWrite = this.writes[this.writes.length - 1];
-						if (confirmReplication && lastWrite)
+						if (confirmReplication && lastWrite?.key != null)
 							completions.push(
 								confirmReplication(
 									databaseName,

--- a/resources/LMDBTransaction.ts
+++ b/resources/LMDBTransaction.ts
@@ -325,6 +325,7 @@ export class LMDBTransaction extends DatabaseTransaction {
 	abort(): void {
 		while (this.readTxnsUsed > 0) this.doneReadTxn(); // release the read snapshot when we abort, we assume we don't need it
 		this.open = TRANSACTION_STATE.CLOSED;
+		this.drainCompletions();
 		// any blobs that were pre-saved as part of these writes will never be referenced; schedule deletion
 		// (retaining any fileId the current on-disk record still references — an aborted write may carry an
 		// already-saved blob shared with the surviving record; see harper-pro#406).

--- a/resources/LMDBTransaction.ts
+++ b/resources/LMDBTransaction.ts
@@ -188,7 +188,13 @@ export class LMDBTransaction extends DatabaseTransaction {
 		this.writes = this.writes.filter((write) => write); // filter out removed entries
 		const doWrite = (write) => {
 			const completion = write.commit(txnTime, write.entry, retries);
-			if (typeof completion?.then === 'function') (commitCompletions ??= []).push(completion);
+			if (typeof completion?.then === 'function') {
+				// the aggregating Promise.all is attached a turn or more later (after the conditional batch
+				// or the exclusive transaction resolves), so handle rejection here to keep the gap from
+				// producing an unhandled rejection; it still surfaces through that Promise.all
+				completion.then(undefined, () => {});
+				(commitCompletions ??= []).push(completion);
+			}
 		};
 		// this uses optimistic locking to submit a transaction, conditioning each write on the expected version
 		const nextCondition = () => {
@@ -265,9 +271,7 @@ export class LMDBTransaction extends DatabaseTransaction {
 						// if we want to wait for replication confirmation, we need to track the transaction times
 						// and when replication notifications come in, we count the number of confirms until we reach the desired number
 						const databaseName = this.writes[0].store.rootStore.databaseName;
-						const lastWrite = this.writes[this.writes.length - 1];
-						const lastEntry =
-							lastWrite && !lastWrite.skipReplicationConfirmation && lastWrite.store.getEntry(lastWrite.key);
+						const lastEntry = this.lastConfirmableEntry();
 						if (confirmReplication && lastEntry)
 							completions.push(
 								confirmReplication(databaseName, (lastEntry as any).localTime, this.replicatedConfirmation)

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -4556,7 +4556,7 @@ export function makeTable(options) {
 					key: null,
 					store: primaryStore,
 					commit: (txnTime: number, _existingEntry: any, _retry: any, transaction: any) => {
-						updateRecord(
+						return updateRecord(
 							null, // recordId: null — a whole-table signal, not a per-row change
 							undefined, // no record to store: this writes the audit entry only
 							undefined,

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -4511,7 +4511,7 @@ export function makeTable(options) {
 					logger.trace?.(`Publishing message to id: ${id}, timestamp: ${new Date(txnTime).toISOString()}`);
 					// always audit this, but don't change existing version
 					// TODO: Use direct writes in the future (copying binary data is hard because it invalidates the cache)
-					updateRecord(
+					return updateRecord(
 						id,
 						existingEntry?.value ?? null,
 						existingEntry,
@@ -4555,6 +4555,7 @@ export function makeTable(options) {
 				tableTxn.addWrite({
 					key: null,
 					store: primaryStore,
+					skipReplicationConfirmation: true,
 					commit: (txnTime: number, _existingEntry: any, _retry: any, transaction: any) => {
 						return updateRecord(
 							null, // recordId: null — a whole-table signal, not a per-row change

--- a/unitTests/apiTests/cache-test.mjs
+++ b/unitTests/apiTests/cache-test.mjs
@@ -36,7 +36,7 @@ describe('test REST calls with cache table', () => {
 		assert.equal(response.status, 204);
 		response = await waitFor(
 			async () => {
-				const cacheResponse = await axios(`${baseUrl}/SimpleCache/3`, { validateStatus: () => true });
+				const cacheResponse = await axios(`${baseUrl}/SimpleCache/3`, { validateStatus: (status) => status < 500 });
 				return cacheResponse.status === 200 && cacheResponse.data?.name === 'name change' ? cacheResponse : false;
 			},
 			{ timeout: 5000, interval: 20, message: 'source update did not reach SimpleCache' }

--- a/unitTests/apiTests/cache-test.mjs
+++ b/unitTests/apiTests/cache-test.mjs
@@ -3,7 +3,6 @@
 import { assert } from 'chai';
 import axios from 'axios';
 import { setupTestApp, baseUrl } from './setupTestApp.mjs';
-import { setTimeout as delay } from 'node:timers/promises';
 import { waitFor } from '../waitFor.js';
 
 describe('test REST calls with cache table', () => {
@@ -35,8 +34,13 @@ describe('test REST calls with cache table', () => {
 		delete data.ageInMonths; // harper#1484: computed scalars now also surface on default reads
 		response = await axios.put(`${baseUrl}/FourProp/3`, data);
 		assert.equal(response.status, 204);
-		await delay(20);
-		response = await axios(`${baseUrl}/SimpleCache/3`);
+		response = await waitFor(
+			async () => {
+				const cacheResponse = await axios(`${baseUrl}/SimpleCache/3`);
+				return cacheResponse.data.name === 'name change' ? cacheResponse : false;
+			},
+			{ timeout: 2000, interval: 20, message: 'source update did not reach SimpleCache' }
+		);
 		assert.equal(response.status, 200);
 		assert.equal(response.data.id, 3);
 		assert.equal(response.data.name, 'name change');

--- a/unitTests/apiTests/cache-test.mjs
+++ b/unitTests/apiTests/cache-test.mjs
@@ -37,7 +37,7 @@ describe('test REST calls with cache table', () => {
 		response = await waitFor(
 			async () => {
 				const cacheResponse = await axios(`${baseUrl}/SimpleCache/3`, { validateStatus: () => true });
-				return cacheResponse.status === 200 && cacheResponse.data.name === 'name change' ? cacheResponse : false;
+				return cacheResponse.status === 200 && cacheResponse.data?.name === 'name change' ? cacheResponse : false;
 			},
 			{ timeout: 5000, interval: 20, message: 'source update did not reach SimpleCache' }
 		);

--- a/unitTests/apiTests/cache-test.mjs
+++ b/unitTests/apiTests/cache-test.mjs
@@ -36,10 +36,10 @@ describe('test REST calls with cache table', () => {
 		assert.equal(response.status, 204);
 		response = await waitFor(
 			async () => {
-				const cacheResponse = await axios(`${baseUrl}/SimpleCache/3`);
-				return cacheResponse.data.name === 'name change' ? cacheResponse : false;
+				const cacheResponse = await axios(`${baseUrl}/SimpleCache/3`, { validateStatus: () => true });
+				return cacheResponse.status === 200 && cacheResponse.data.name === 'name change' ? cacheResponse : false;
 			},
-			{ timeout: 2000, interval: 20, message: 'source update did not reach SimpleCache' }
+			{ timeout: 5000, interval: 20, message: 'source update did not reach SimpleCache' }
 		);
 		assert.equal(response.status, 200);
 		assert.equal(response.data.id, 3);

--- a/unitTests/resources/reloadMarker.test.js
+++ b/unitTests/resources/reloadMarker.test.js
@@ -3,7 +3,7 @@ const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { LOCAL_ONLY } = require('#src/resources/auditStore');
-const { setTimeout: delay } = require('node:timers/promises');
+const { waitFor } = require('../waitFor');
 require('#src/server/serverHelpers/serverUtilities');
 
 // A table-reload marker is a whole-table signal (harper-pro#489): one LOCAL_ONLY audit entry of type
@@ -16,15 +16,6 @@ describe('table-reload marker (harper-pro#489)', () => {
 		setupTestDBPath();
 		setMainIsWorker(true);
 	});
-
-	async function waitFor(predicate, message, timeout = 5000) {
-		const start = Date.now();
-		while (Date.now() - start < timeout) {
-			if (await predicate()) return;
-			await delay(20);
-		}
-		throw new Error('waitFor timed out: ' + message);
-	}
 
 	it('delivers a raw reload event to every subscriber on a system table', async function () {
 		// System-DB subscribers (knownNodes peer discovery, hdb_certificate CA install) consume the raw
@@ -46,8 +37,16 @@ describe('table-reload marker (harper-pro#489)', () => {
 
 		await ReloadTable.writeReloadMarker();
 
-		await waitFor(() => rootEvents.some((e) => e.type === 'reload'), 'root subscriber receives reload');
-		await waitFor(() => keyEvents.some((e) => e.type === 'reload'), 'keyed subscriber receives reload');
+		await waitFor(() => rootEvents.some((e) => e.type === 'reload'), {
+			timeout: 5000,
+			interval: 20,
+			message: 'root subscriber receives reload',
+		});
+		await waitFor(() => keyEvents.some((e) => e.type === 'reload'), {
+			timeout: 5000,
+			interval: 20,
+			message: 'keyed subscriber receives reload',
+		});
 
 		const reload = rootEvents.find((e) => e.type === 'reload');
 		assert.equal(reload.value, undefined, 'reload carries no record value');
@@ -72,10 +71,11 @@ describe('table-reload marker (harper-pro#489)', () => {
 
 		await ReloadTable.writeReloadMarker();
 
-		await waitFor(
-			() => events.some((e) => e.type === 'put' && e.id === 'r1'),
-			'subscriber receives the existing row as a put via the reload re-snapshot'
-		);
+		await waitFor(() => events.some((e) => e.type === 'put' && e.id === 'r1'), {
+			timeout: 5000,
+			interval: 20,
+			message: 'subscriber receives the existing row as a put via the reload re-snapshot',
+		});
 		assert.ok(
 			!events.some((e) => e.type === 'reload'),
 			'the bare reload marker is suppressed on a user table (re-snapshotted instead)'
@@ -93,14 +93,14 @@ describe('table-reload marker (harper-pro#489)', () => {
 
 		// The txn-log store's empty getRange positions at the tail (for live subscription), so scan from an
 		// explicit numeric start to read the existing entries.
-		let marker;
-		for (const entry of ReloadTable.auditStore.getRange({ start: 1 })) {
-			if (entry.type === 'reload') {
-				marker = entry;
-				break;
-			}
-		}
-		assert.ok(marker, 'a reload audit entry was written');
+		const marker = await waitFor(
+			() => {
+				for (const entry of ReloadTable.auditStore.getRange({ start: 1 })) {
+					if (entry.type === 'reload') return entry;
+				}
+			},
+			{ timeout: 5000, interval: 20, message: 'a reload audit entry was written' }
+		);
 		// LOCAL_ONLY makes the replication send path skip it by a bitmask test (no decode of an unknown
 		// type on a peer): the marker is a local signal only.
 		assert.ok(marker.extendedType & LOCAL_ONLY, 'reload marker is LOCAL_ONLY (never forwarded to peers)');

--- a/unitTests/resources/reloadMarker.test.js
+++ b/unitTests/resources/reloadMarker.test.js
@@ -151,6 +151,18 @@ describe('table-reload marker (harper-pro#489)', () => {
 			markerTransaction.replicatedConfirmation = 1;
 			await markerTransaction.commit({ doneWriting: true });
 			assert.equal(confirmationCalls, 1, 'a LOCAL_ONLY marker has nothing to confirm with peers');
+
+			// a trailing marker is exempt from confirmation, but it must not suppress confirmation for the
+			// replicable write staged before it in the same transaction
+			const mixedContext = { transaction: new DatabaseTransaction() };
+			await ReloadTable.put(2, { id: 2 }, mixedContext);
+			ReloadTable.writeReloadMarker(mixedContext);
+			const mixedTransaction = isLMDB ? mixedContext.transaction.next : mixedContext.transaction;
+			mixedTransaction.replicatedConfirmation = 1;
+			confirmedVersion = undefined;
+			await mixedTransaction.commit({ doneWriting: true });
+			assert.equal(confirmationCalls, 2, 'the replicable write staged before the marker is still confirmed');
+			assert.ok(confirmedVersion != null, 'confirmation uses the stored entry of the replicable write');
 		} finally {
 			setReplicationConfirmation(undefined);
 		}

--- a/unitTests/resources/reloadMarker.test.js
+++ b/unitTests/resources/reloadMarker.test.js
@@ -3,8 +3,11 @@ const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { LOCAL_ONLY } = require('#src/resources/auditStore');
+const { replicationConfirmation } = require('#src/resources/LMDBTransaction');
 const { waitFor } = require('../waitFor');
 require('#src/server/serverHelpers/serverUtilities');
+
+const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
 
 // A table-reload marker is a whole-table signal (harper-pro#489): one LOCAL_ONLY audit entry of type
 // 'reload' with no record, delivered to every subscriber on the table so they re-read it. It exists so
@@ -89,7 +92,14 @@ describe('table-reload marker (harper-pro#489)', () => {
 		});
 		// touch the audit stream first so the table has an audit store wired up
 		await ReloadTable.put({ id: 1, name: 'row' });
-		await ReloadTable.writeReloadMarker();
+		const originalRetryRisk = ReloadTable.primaryStore.retryRisk;
+		if (isLMDB) ReloadTable.primaryStore.retryRisk = 101;
+		try {
+			// Force the contention fallback; both LMDB commit paths must honor the completion contract.
+			await ReloadTable.writeReloadMarker();
+		} finally {
+			ReloadTable.primaryStore.retryRisk = originalRetryRisk;
+		}
 
 		// The txn-log store's empty getRange positions at the tail (for live subscription), so scan from an
 		// explicit numeric start to read the existing entries.
@@ -107,5 +117,23 @@ describe('table-reload marker (harper-pro#489)', () => {
 		assert.ok(marker.recordId == null, 'reload marker has a null recordId');
 		// the regular row keeps its own audit entry; the marker did not disturb it
 		assert.ok((await ReloadTable.getHistoryOfRecord(1)).length >= 1, 'the real row still has its audit entry');
+	});
+
+	it('does not request replication confirmation for a local-only marker', async function () {
+		if (!isLMDB) return this.skip();
+		const ReloadTable = table({
+			table: 'ReloadMarkerConfirmation',
+			attributes: [{ name: 'id', isPrimaryKey: true }],
+		});
+		let confirmationCalls = 0;
+		replicationConfirmation(() => {
+			confirmationCalls++;
+		});
+		try {
+			await ReloadTable.writeReloadMarker({ replicatedConfirmation: 1 });
+		} finally {
+			replicationConfirmation(undefined);
+		}
+		assert.equal(confirmationCalls, 0, 'a LOCAL_ONLY marker has nothing to confirm with peers');
 	});
 });

--- a/unitTests/resources/reloadMarker.test.js
+++ b/unitTests/resources/reloadMarker.test.js
@@ -93,14 +93,14 @@ describe('table-reload marker (harper-pro#489)', () => {
 
 		// The txn-log store's empty getRange positions at the tail (for live subscription), so scan from an
 		// explicit numeric start to read the existing entries.
-		const marker = await waitFor(
-			() => {
-				for (const entry of ReloadTable.auditStore.getRange({ start: 1 })) {
-					if (entry.type === 'reload') return entry;
-				}
-			},
-			{ timeout: 5000, interval: 20, message: 'a reload audit entry was written' }
-		);
+		let marker;
+		for (const entry of ReloadTable.auditStore.getRange({ start: 1 })) {
+			if (entry.type === 'reload' && entry.tableId === ReloadTable.tableId) {
+				marker = entry;
+				break;
+			}
+		}
+		assert.ok(marker, 'a reload audit entry was written');
 		// LOCAL_ONLY makes the replication send path skip it by a bitmask test (no decode of an unknown
 		// type on a peer): the marker is a local signal only.
 		assert.ok(marker.extendedType & LOCAL_ONLY, 'reload marker is LOCAL_ONLY (never forwarded to peers)');

--- a/unitTests/resources/reloadMarker.test.js
+++ b/unitTests/resources/reloadMarker.test.js
@@ -163,6 +163,28 @@ describe('table-reload marker (harper-pro#489)', () => {
 			await mixedTransaction.commit({ doneWriting: true });
 			assert.equal(confirmationCalls, 2, 'the replicable write staged before the marker is still confirmed');
 			assert.ok(confirmedVersion != null, 'confirmation uses the stored entry of the replicable write');
+
+			// the other write the confirmation walk skips: one with no stored entry at all. A delete on an
+			// audit: false table leaves nothing to read back, so a trailing delete must fall back to the put
+			// staged before it rather than confirming nothing.
+			const NoAuditTable = table({
+				table: 'ReloadMarkerNoAuditDelete',
+				attributes: [{ name: 'id', isPrimaryKey: true }],
+				audit: false,
+			});
+			await NoAuditTable.put(1, { id: 1 });
+			const deleteContext = { transaction: new DatabaseTransaction() };
+			await NoAuditTable.put(2, { id: 2 }, deleteContext);
+			await NoAuditTable.delete(1, deleteContext);
+			const deleteTransaction = isLMDB ? deleteContext.transaction.next : deleteContext.transaction;
+			deleteTransaction.replicatedConfirmation = 1;
+			confirmedVersion = undefined;
+			await deleteTransaction.commit({ doneWriting: true });
+			assert.equal(confirmationCalls, 3, 'the put staged before an entry-less delete is still confirmed');
+			// LMDB confirms on the audit store's local time, which an `audit: false` table's records do not
+			// carry at all (pre-existing: every confirmed write on such a table passes undefined). What this
+			// case pins is which write the walk selects, so only RocksDB can assert the value it carried.
+			if (!isLMDB) assert.ok(confirmedVersion != null, 'confirmation uses the stored entry of the put, not the delete');
 		} finally {
 			setReplicationConfirmation(undefined);
 		}

--- a/unitTests/resources/reloadMarker.test.js
+++ b/unitTests/resources/reloadMarker.test.js
@@ -3,12 +3,16 @@ const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { LOCAL_ONLY } = require('#src/resources/auditStore');
-const { DatabaseTransaction } = require('#src/resources/DatabaseTransaction');
-const { replicationConfirmation } = require('#src/resources/LMDBTransaction');
+const {
+	DatabaseTransaction,
+	replicationConfirmation: rocksReplicationConfirmation,
+} = require('#src/resources/DatabaseTransaction');
+const { replicationConfirmation: lmdbReplicationConfirmation } = require('#src/resources/LMDBTransaction');
 const { waitFor } = require('../waitFor');
 require('#src/server/serverHelpers/serverUtilities');
 
 const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
+const setReplicationConfirmation = isLMDB ? lmdbReplicationConfirmation : rocksReplicationConfirmation;
 
 // A table-reload marker is a whole-table signal (harper-pro#489): one LOCAL_ONLY audit entry of type
 // 'reload' with no record, delivered to every subscriber on the table so they re-read it. It exists so
@@ -87,58 +91,68 @@ describe('table-reload marker (harper-pro#489)', () => {
 	});
 
 	it('persists the marker as a local-only audit entry that never replicates', async function () {
-		const ReloadTable = table({
-			table: 'ReloadMarkerAudit',
-			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
-		});
-		// touch the audit stream first so the table has an audit store wired up
-		await ReloadTable.put({ id: 1, name: 'row' });
-		const originalRetryRisk = ReloadTable.primaryStore.retryRisk;
-		if (isLMDB) ReloadTable.primaryStore.retryRisk = 101;
-		try {
-			// Force the contention fallback; both LMDB commit paths must honor the completion contract.
-			await ReloadTable.writeReloadMarker();
-		} finally {
-			ReloadTable.primaryStore.retryRisk = originalRetryRisk;
-		}
-
-		// The txn-log store's empty getRange positions at the tail (for live subscription), so scan from an
-		// explicit numeric start to read the existing entries.
-		let marker;
-		for (const entry of ReloadTable.auditStore.getRange({ start: 1 })) {
-			if (entry.type === 'reload' && entry.tableId === ReloadTable.tableId) {
-				marker = entry;
-				break;
+		for (const forceContention of isLMDB ? [false, true] : [false]) {
+			const ReloadTable = table({
+				table: `ReloadMarkerAudit${forceContention ? 'Contention' : 'Optimistic'}`,
+				attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+			});
+			// touch the audit stream first so the table has an audit store wired up
+			await ReloadTable.put({ id: 1, name: 'row' });
+			const originalRetryRisk = ReloadTable.primaryStore.retryRisk;
+			if (isLMDB) ReloadTable.primaryStore.retryRisk = forceContention ? 101 : 0;
+			try {
+				await ReloadTable.writeReloadMarker();
+			} finally {
+				ReloadTable.primaryStore.retryRisk = originalRetryRisk;
 			}
+
+			// The txn-log store's empty getRange positions at the tail (for live subscription), so scan from an
+			// explicit numeric start to read the existing entries.
+			let marker;
+			for (const entry of ReloadTable.auditStore.getRange({ start: 1 })) {
+				if (entry.type === 'reload' && entry.tableId === ReloadTable.tableId) {
+					marker = entry;
+					break;
+				}
+			}
+			assert.ok(marker, 'a reload audit entry was written');
+			// LOCAL_ONLY makes the replication send path skip it by a bitmask test (no decode of an unknown
+			// type on a peer): the marker is a local signal only.
+			assert.ok(marker.extendedType & LOCAL_ONLY, 'reload marker is LOCAL_ONLY (never forwarded to peers)');
+			assert.ok(marker.recordId == null, 'reload marker has a null recordId');
+			// the regular row keeps its own audit entry; the marker did not disturb it
+			assert.ok((await ReloadTable.getHistoryOfRecord(1)).length >= 1, 'the real row still has its audit entry');
 		}
-		assert.ok(marker, 'a reload audit entry was written');
-		// LOCAL_ONLY makes the replication send path skip it by a bitmask test (no decode of an unknown
-		// type on a peer): the marker is a local signal only.
-		assert.ok(marker.extendedType & LOCAL_ONLY, 'reload marker is LOCAL_ONLY (never forwarded to peers)');
-		assert.ok(marker.recordId == null, 'reload marker has a null recordId');
-		// the regular row keeps its own audit entry; the marker did not disturb it
-		assert.ok((await ReloadTable.getHistoryOfRecord(1)).length >= 1, 'the real row still has its audit entry');
 	});
 
-	it('does not request replication confirmation for a local-only marker', async function () {
-		if (!isLMDB) return this.skip();
+	it('confirms a stored null-key publish but not a local-only marker', async function () {
 		const ReloadTable = table({
 			table: 'ReloadMarkerConfirmation',
 			attributes: [{ name: 'id', isPrimaryKey: true }],
 		});
-		const context = { transaction: new DatabaseTransaction() };
-		ReloadTable.writeReloadMarker(context);
-		const markerTransaction = context.transaction.next;
-		markerTransaction.replicatedConfirmation = 1;
 		let confirmationCalls = 0;
-		replicationConfirmation(() => {
+		let confirmedVersion;
+		setReplicationConfirmation((_databaseName, version) => {
 			confirmationCalls++;
+			confirmedVersion = version;
 		});
 		try {
+			const publishContext = { transaction: new DatabaseTransaction() };
+			ReloadTable.publish(null, { message: 'root topic' }, publishContext);
+			const publishTransaction = isLMDB ? publishContext.transaction.next : publishContext.transaction;
+			publishTransaction.replicatedConfirmation = 1;
+			await publishTransaction.commit({ doneWriting: true });
+			assert.equal(confirmationCalls, 1, 'a stored root-topic publish is confirmed');
+			assert.ok(confirmedVersion != null, 'the confirmation uses the stored entry version');
+
+			const context = { transaction: new DatabaseTransaction() };
+			ReloadTable.writeReloadMarker(context);
+			const markerTransaction = isLMDB ? context.transaction.next : context.transaction;
+			markerTransaction.replicatedConfirmation = 1;
 			await markerTransaction.commit({ doneWriting: true });
+			assert.equal(confirmationCalls, 1, 'a LOCAL_ONLY marker has nothing to confirm with peers');
 		} finally {
-			replicationConfirmation(undefined);
+			setReplicationConfirmation(undefined);
 		}
-		assert.equal(confirmationCalls, 0, 'a LOCAL_ONLY marker has nothing to confirm with peers');
 	});
 });

--- a/unitTests/resources/reloadMarker.test.js
+++ b/unitTests/resources/reloadMarker.test.js
@@ -3,6 +3,7 @@ const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { LOCAL_ONLY } = require('#src/resources/auditStore');
+const { DatabaseTransaction } = require('#src/resources/DatabaseTransaction');
 const { replicationConfirmation } = require('#src/resources/LMDBTransaction');
 const { waitFor } = require('../waitFor');
 require('#src/server/serverHelpers/serverUtilities');
@@ -125,12 +126,16 @@ describe('table-reload marker (harper-pro#489)', () => {
 			table: 'ReloadMarkerConfirmation',
 			attributes: [{ name: 'id', isPrimaryKey: true }],
 		});
+		const context = { transaction: new DatabaseTransaction() };
+		ReloadTable.writeReloadMarker(context);
+		const markerTransaction = context.transaction.next;
+		markerTransaction.replicatedConfirmation = 1;
 		let confirmationCalls = 0;
 		replicationConfirmation(() => {
 			confirmationCalls++;
 		});
 		try {
-			await ReloadTable.writeReloadMarker({ replicatedConfirmation: 1 });
+			await markerTransaction.commit({ doneWriting: true });
 		} finally {
 			replicationConfirmation(undefined);
 		}

--- a/unitTests/resources/reloadMarker.test.js
+++ b/unitTests/resources/reloadMarker.test.js
@@ -164,8 +164,8 @@ describe('table-reload marker (harper-pro#489)', () => {
 			assert.equal(confirmationCalls, 2, 'the replicable write staged before the marker is still confirmed');
 			assert.ok(confirmedVersion != null, 'confirmation uses the stored entry of the replicable write');
 
-			// the other write the confirmation walk skips: one with no stored entry at all — a delete on an
-			// audit: false table leaves nothing to read back
+			// the other write the confirmation walk skips: one with no stored entry at all — a delete
+			// leaves nothing to read back only when the table has neither audit nor delete tracking
 			const NoAuditTable = table({
 				table: 'ReloadMarkerNoAuditDelete',
 				attributes: [{ name: 'id', isPrimaryKey: true }],

--- a/unitTests/resources/reloadMarker.test.js
+++ b/unitTests/resources/reloadMarker.test.js
@@ -164,9 +164,8 @@ describe('table-reload marker (harper-pro#489)', () => {
 			assert.equal(confirmationCalls, 2, 'the replicable write staged before the marker is still confirmed');
 			assert.ok(confirmedVersion != null, 'confirmation uses the stored entry of the replicable write');
 
-			// the other write the confirmation walk skips: one with no stored entry at all. A delete on an
-			// audit: false table leaves nothing to read back, so a trailing delete must fall back to the put
-			// staged before it rather than confirming nothing.
+			// the other write the confirmation walk skips: one with no stored entry at all — a delete on an
+			// audit: false table leaves nothing to read back
 			const NoAuditTable = table({
 				table: 'ReloadMarkerNoAuditDelete',
 				attributes: [{ name: 'id', isPrimaryKey: true }],
@@ -182,8 +181,7 @@ describe('table-reload marker (harper-pro#489)', () => {
 			await deleteTransaction.commit({ doneWriting: true });
 			assert.equal(confirmationCalls, 3, 'the put staged before an entry-less delete is still confirmed');
 			// LMDB confirms on the audit store's local time, which an `audit: false` table's records do not
-			// carry at all (pre-existing: every confirmed write on such a table passes undefined). What this
-			// case pins is which write the walk selects, so only RocksDB can assert the value it carried.
+			// carry at all (pre-existing: every confirmed write on such a table passes undefined).
 			if (!isLMDB) assert.ok(confirmedVersion != null, 'confirmation uses the stored entry of the put, not the delete');
 		} finally {
 			setReplicationConfirmation(undefined);

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -6,6 +6,7 @@ const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { transaction } = require('#src/resources/transaction');
 const { DatabaseTransaction } = require('#src/resources/DatabaseTransaction');
+const { LMDBTransaction } = require('#src/resources/LMDBTransaction');
 const { IterableEventQueue } = require('#src/resources/IterableEventQueue');
 const { RocksDatabase } = require('@harperfast/rocksdb-js');
 const harperLogger = require('#src/utility/logging/harper_logger');
@@ -92,6 +93,29 @@ describe('Transactions', () => {
 		setImmediate(release);
 		await committed;
 		assert.equal(settled, true, 'commit resolved only after the callback completion settled');
+	});
+	it('waits for promise-returning commit callbacks on a keyed LMDB write', async function () {
+		if (!isLMDB) return this.skip();
+		const transaction = new LMDBTransaction();
+		transaction.db = TxnTest.primaryStore;
+		const order = [];
+		let release;
+		const completion = new Promise((resolve) => (release = resolve)).then(() => order.push('completion'));
+		transaction.addWrite({
+			key: 'lmdb-async-commit-callback',
+			store: TxnTest.primaryStore,
+			// keyed write: the conditional batch stages it, so this covers doWrite's non-null-key path
+			commit: () => {
+				TxnTest.primaryStore.put('lmdb-async-commit-callback', { name: 'staged' });
+				return completion;
+			},
+		});
+		// released well after the batch itself would resolve, so a commit that does not await the
+		// callback completion resolves first and fails the ordering assertion
+		const committed = transaction.commit({ doneWriting: true }).then(() => order.push('commit'));
+		setTimeout(release, 50);
+		await committed;
+		assert.deepEqual(order, ['completion', 'commit'], 'commit resolved only after the callback completion');
 	});
 	it('Can run txn with three tables and two databases', async function () {
 		const context = {};

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -95,8 +95,10 @@ describe('Transactions', () => {
 		assert.equal(settled, true, 'commit resolved only after the callback completion settled');
 	});
 	it('surfaces a commit-callback rejection without an unhandled rejection', async function () {
-		if (isLMDB) return this.skip();
-		const transaction = new DatabaseTransaction();
+		// runs on both engines: each has its own no-op rejection handler on the staged completion
+		// (DatabaseTransaction.stageCompletion and LMDBTransaction's doWrite), and each leaves a window
+		// where nothing else is attached to the rejection yet
+		const transaction = isLMDB ? new LMDBTransaction() : new DatabaseTransaction();
 		transaction.db = TxnTest.primaryStore;
 		const unhandled = [];
 		const onUnhandled = (reason) => unhandled.push(reason);
@@ -105,7 +107,12 @@ describe('Transactions', () => {
 			transaction.addWrite({
 				key: 'rejecting-commit-callback',
 				store: TxnTest.primaryStore,
-				commit: () => Promise.reject(new Error('audit write failed')),
+				commit: () => {
+					// keyed write: LMDB stages it in the conditional batch, so its aggregating Promise.all is
+					// attached only after that batch resolves — a turn or more after this rejection exists
+					if (isLMDB) TxnTest.primaryStore.put('rejecting-commit-callback', { name: 'staged' });
+					return Promise.reject(new Error('audit write failed'));
+				},
 			});
 			// the staging-to-commit gap: a rejection with no consumer is reported at the end of this turn
 			await new Promise((resolve) => setImmediate(() => setImmediate(resolve)));
@@ -115,7 +122,44 @@ describe('Transactions', () => {
 				/audit write failed/,
 				'the rejection still propagates out of commit'
 			);
+			// the commit-to-aggregation gap, which is the one LMDB's handler covers
+			await new Promise((resolve) => setImmediate(() => setImmediate(resolve)));
+			assert.deepEqual(unhandled, [], 'the completion stays handled across the commit aggregation gap');
 		} finally {
+			process.off('unhandledRejection', onUnhandled);
+		}
+	});
+	it('drains staged completions when a transaction is aborted', async function () {
+		if (isLMDB) return this.skip(); // LMDB creates its commit completions at commit time, not at write time
+		const transaction = new DatabaseTransaction();
+		transaction.db = TxnTest.primaryStore;
+		const unhandled = [];
+		const onUnhandled = (reason) => unhandled.push(reason);
+		process.on('unhandledRejection', onUnhandled);
+		const warnings = [];
+		const originalWarn = harperLogger.warn;
+		harperLogger.warn = (...args) => warnings.push(args);
+		try {
+			transaction.addWrite({
+				key: 'aborted-commit-callback',
+				store: TxnTest.primaryStore,
+				commit: () => Promise.reject(new Error('audit write failed after abort')),
+			});
+			assert.equal(transaction.completions.length, 1, 'the completion is staged before the abort');
+			transaction.abort();
+			assert.deepEqual(
+				transaction.completions,
+				[],
+				'an aborted batch cannot carry its completions into a later commit on a reused transaction'
+			);
+			await new Promise((resolve) => setImmediate(() => setImmediate(resolve)));
+			assert.deepEqual(unhandled, [], 'the abandoned rejection does not escape as an unhandled rejection');
+			assert.ok(
+				warnings.some((args) => /aborted/.test(args[0])),
+				'the abandoned rejection is logged rather than silently dropped'
+			);
+		} finally {
+			harperLogger.warn = originalWarn;
 			process.off('unhandledRejection', onUnhandled);
 		}
 	});
@@ -135,10 +179,13 @@ describe('Transactions', () => {
 				return completion;
 			},
 		});
-		// released well after the batch itself would resolve, so a commit that does not await the
-		// callback completion resolves first and fails the ordering assertion
+		// gated on the conditional batch itself rather than a timer: once the batch has flushed, a commit
+		// that does not await the callback completion has already resolved, so the empty-order assertion
+		// below fails deterministically instead of racing a fixed delay on a loaded machine
 		const committed = transaction.commit({ doneWriting: true }).then(() => order.push('commit'));
-		setTimeout(release, 50);
+		await TxnTest.primaryStore.flushed;
+		assert.deepEqual(order, [], 'commit has not resolved while the callback completion is pending');
+		release();
 		await committed;
 		assert.deepEqual(order, ['completion', 'commit'], 'commit resolved only after the callback completion');
 	});

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -78,20 +78,20 @@ describe('Transactions', () => {
 		if (isLMDB) return this.skip();
 		const transaction = new DatabaseTransaction();
 		transaction.db = TxnTest.primaryStore;
-		let completionObserved = false;
-		const completion = Promise.resolve();
-		const then = completion.then;
-		completion.then = function (...args) {
-			completionObserved = true;
-			return then.apply(this, args);
-		};
+		let settled = false;
+		let release;
+		const completion = new Promise((resolve) => (release = resolve)).then(() => {
+			settled = true;
+		});
 		transaction.addWrite({
 			key: 'async-commit-callback',
 			store: TxnTest.primaryStore,
 			commit: () => completion,
 		});
-		await transaction.commit({ doneWriting: true });
-		assert.equal(completionObserved, true, 'the callback completion was awaited');
+		const committed = transaction.commit({ doneWriting: true });
+		setImmediate(release);
+		await committed;
+		assert.equal(settled, true, 'commit resolved only after the callback completion settled');
 	});
 	it('Can run txn with three tables and two databases', async function () {
 		const context = {};

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -94,6 +94,31 @@ describe('Transactions', () => {
 		await committed;
 		assert.equal(settled, true, 'commit resolved only after the callback completion settled');
 	});
+	it('surfaces a commit-callback rejection without an unhandled rejection', async function () {
+		if (isLMDB) return this.skip();
+		const transaction = new DatabaseTransaction();
+		transaction.db = TxnTest.primaryStore;
+		const unhandled = [];
+		const onUnhandled = (reason) => unhandled.push(reason);
+		process.on('unhandledRejection', onUnhandled);
+		try {
+			transaction.addWrite({
+				key: 'rejecting-commit-callback',
+				store: TxnTest.primaryStore,
+				commit: () => Promise.reject(new Error('audit write failed')),
+			});
+			// the staging-to-commit gap: a rejection with no consumer is reported at the end of this turn
+			await new Promise((resolve) => setImmediate(() => setImmediate(resolve)));
+			assert.deepEqual(unhandled, [], 'the staged completion has a rejection handler before commit');
+			await assert.rejects(
+				() => transaction.commit({ doneWriting: true }),
+				/audit write failed/,
+				'the rejection still propagates out of commit'
+			);
+		} finally {
+			process.off('unhandledRejection', onUnhandled);
+		}
+	});
 	it('waits for promise-returning commit callbacks on a keyed LMDB write', async function () {
 		if (!isLMDB) return this.skip();
 		const transaction = new LMDBTransaction();

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -95,9 +95,8 @@ describe('Transactions', () => {
 		assert.equal(settled, true, 'commit resolved only after the callback completion settled');
 	});
 	it('surfaces a commit-callback rejection without an unhandled rejection', async function () {
-		// runs on both engines: each has its own no-op rejection handler on the staged completion
-		// (DatabaseTransaction.stageCompletion and LMDBTransaction's doWrite), and each leaves a window
-		// where nothing else is attached to the rejection yet
+		// each engine has its own no-op rejection handler on the staged completion
+		// (DatabaseTransaction.stageCompletion, LMDBTransaction's doWrite)
 		const transaction = isLMDB ? new LMDBTransaction() : new DatabaseTransaction();
 		transaction.db = TxnTest.primaryStore;
 		const unhandled = [];
@@ -146,7 +145,9 @@ describe('Transactions', () => {
 				commit: () => Promise.reject(new Error('audit write failed after abort')),
 			});
 			assert.equal(transaction.completions.length, 1, 'the completion is staged before the abort');
+			assert.ok(transaction.transaction, 'the write-only transaction holds a native handle with no read reference');
 			transaction.abort();
+			assert.equal(transaction.transaction, null, 'the abort releases the native handle rather than leaking it');
 			assert.deepEqual(
 				transaction.completions,
 				[],
@@ -179,9 +180,7 @@ describe('Transactions', () => {
 				return completion;
 			},
 		});
-		// gated on the conditional batch itself rather than a timer: once the batch has flushed, a commit
-		// that does not await the callback completion has already resolved, so the empty-order assertion
-		// below fails deterministically instead of racing a fixed delay on a loaded machine
+		// gated on the batch rather than a timer: a fixed delay a loaded runner outruns would pass silently
 		const committed = transaction.commit({ doneWriting: true }).then(() => order.push('commit'));
 		await TxnTest.primaryStore.flushed;
 		assert.deepEqual(order, [], 'commit has not resolved while the callback completion is pending');

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -74,6 +74,25 @@ describe('Transactions', () => {
 		assert.equal(answer.name, 'the answer');
 		assert.equal(answer.computed, 'the answer computed');
 	});
+	it('waits for promise-returning commit callbacks on RocksDB', async function () {
+		if (isLMDB) return this.skip();
+		const transaction = new DatabaseTransaction();
+		transaction.db = TxnTest.primaryStore;
+		let completionObserved = false;
+		const completion = Promise.resolve();
+		const then = completion.then;
+		completion.then = function (...args) {
+			completionObserved = true;
+			return then.apply(this, args);
+		};
+		transaction.addWrite({
+			key: 'async-commit-callback',
+			store: TxnTest.primaryStore,
+			commit: () => completion,
+		});
+		await transaction.commit({ doneWriting: true });
+		assert.equal(completionObserved, true, 'the callback completion was awaited');
+	});
 	it('Can run txn with three tables and two databases', async function () {
 		const context = {};
 		let start = Date.now();


### PR DESCRIPTION
The reload-marker assertion was not flaky. Under LMDB, `writeReloadMarker()` could resolve before its asynchronous audit-store write completed, so the immediate audit scan correctly exposed a transaction completion-ordering bug. The cache assertion was a separate eventual-propagation race.

This keeps the cache test's bounded poll, restores the reload marker's immediate-visibility contract, and applies the asynchronous commit-callback contract consistently across both storage engines.

Refs #2178

## What changed

- `cache-test.mjs` polls until the deferred source update is visible. It retries empty and non-success responses but still fails fast on server errors.
- Promise-returning transaction commit callbacks are awaited by LMDB's optimistic and exclusive paths and by RocksDB before the native transaction commits.
- Publish and reload-marker callbacks return their `updateRecord()` completion so transaction resolution includes audit persistence.
- Reload markers explicitly opt out of replication confirmation. Stored null-key root-topic publishes still receive confirmation, including when a prior null-key record exists.
- Replication confirmation checks the stored entry in both engines rather than dereferencing a missing entry.
- The disconnected LMDB `outstandingCommit` variable was removed; it had no effect on overload tracking or transaction behavior.
- Reload-marker tests cover LMDB's optimistic and contention paths, plus RocksDB parity. A separate RocksDB test verifies the promise-returning callback contract.

## Why this layer

The invariant belongs to the transaction wrapper: when a transaction callback starts asynchronous persistence, the returned commit promise must not resolve until that persistence settles. Polling in the test would hide the broken contract, and awaiting only in `writeReloadMarker()` would leave transaction chaining and error propagation inconsistent.

Null is not enough to identify a reload marker because Harper also stores root-topic publishes at the null key. The write therefore carries explicit metadata when it stages only a local audit marker.

The default path remains synchronous. Promise aggregation occurs only when a commit callback returns a promise.

## Verification

- Focused RocksDB reload-marker tests: 4 passing.
- Focused RocksDB promise-returning callback test: 1 passing.
- Focused LMDB reload-marker tests: 4 passing, covering optimistic and forced-contention paths.
- Negative controls at the merge base failed behaviorally: RocksDB incorrectly confirmed the local-only marker and did not observe callback completion; LMDB missed immediate marker persistence and root-topic confirmation.
- `HARPER_STORAGE_ENGINE=lmdb npm run test:unit:resources`: changed tests passed within 1,353 passing and 93 pending; only the two existing Node.js 26 `randomAccessFields` assertion failures remained.
- Default `npm run test:unit:resources`: changed tests passed within 1,555 passing and 15 pending; the three known Node.js 26 failures remained in `databases.test.js`, `randomAccessFieldsDirective.test.js`, and `replayStructures.test.js`.
- `npm run test:integration:all`: changed areas passed; the run ended in the unrelated Ollama backend group because Node rejected `json/systemSchema.json` without a JSON import attribute, cancelling the remaining Ollama cases.
- `npm run build`, `npm run lint:required`, `npm run format:write`, and `git diff --check`: passed.

The full local `test:unit:main` gate remains unavailable because this checkout's unit bootstrap opens an ambient install database before test setup; it fails during module load in that external database and does not reach the changed tests.

## Review coverage

The required full no-Claude review ran Gemini. Claude and its domain adjudication leg were pruned by policy, while both Cursor legs were pruned because this branch had reached its two-round cap. Gemini returned eight ungraded finding bullets; source tracing and the executed engine tests did not substantiate them, so no additional code changes were made. In particular, LMDB builds the conditional batch synchronously and preserves the eventual false conflict result, both transaction modules export the tested confirmation seam, and both engines accept the stored null-key publish exercised by the tests.

_— GPT-5 Codex_

<sub>Review-Coverage: authored=unknown; ran=none; rounds=1 @ d92bacc59e56</sub>

<sub>Human-Review-Need: 4 @ d92bacc59e56</sub>
