### PR TITLE
fix(run): stop double-wrapping startup URLs when node.hostname is a URL

### DIFF
--- a/bin/run.ts
+++ b/bin/run.ts
@@ -25,7 +25,7 @@ import * as keys from '../security/keys.ts';
 import { startHTTPThreads } from '../server/threads/socketRouter.ts';
 import * as hdbInfoController from '../dataLayer/hdbInfoController.ts';
 import { isReadOnlyMode } from '../resources/databases.ts';
-import { getThisNodeName } from '../server/nodeName.ts';
+import { getThisNodeName, getThisNodeHostname } from '../server/nodeName.ts';
 import * as hdbTerms from '../utility/hdbTerms.ts';
 import { getHdbPid, isProcessRunning } from '../utility/processManagement/processManagement.js';
 import { PACKAGE_ROOT } from '../utility/packageUtils.js';
@@ -321,14 +321,20 @@ function startupLog(portResolutions: any) {
 	}`;
 	logMsg += `, unix socket: ${configUtils.getConfigPath(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_DOMAINSOCKET)}\n`;
 	if (env.get(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_PORT)) {
-		logMsg += pad('') + 'http://' + getThisNodeName() + ':' + env.get(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_PORT) + '/\n';
+		logMsg +=
+			pad('') +
+			'http://' +
+			getThisNodeHostname() +
+			':' +
+			env.get(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_PORT) +
+			'/\n';
 	}
 	if (env.get(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_SECUREPORT)) {
 		logMsg +=
 			'\n' +
 			pad('') +
 			'https://' +
-			getThisNodeName() +
+			getThisNodeHostname() +
 			':' +
 			env.get(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_SECUREPORT) +
 			'/\n';
@@ -383,7 +389,7 @@ function startupLog(portResolutions: any) {
 			if (!restLog.includes(pair) && name === 'rest') {
 				restLog += pair;
 				if (value.protocol_name === 'HTTP' || value.protocol_name === 'HTTPS') {
-					restHostnames.push(`${value.protocol_name.toLowerCase()}://${getThisNodeName()}:${key}/`);
+					restHostnames.push(`${value.protocol_name.toLowerCase()}://${getThisNodeHostname()}:${key}/`);
 				}
 			}
 

--- a/bin/run.ts
+++ b/bin/run.ts
@@ -321,23 +321,10 @@ function startupLog(portResolutions: any) {
 	}`;
 	logMsg += `, unix socket: ${configUtils.getConfigPath(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_DOMAINSOCKET)}\n`;
 	if (env.get(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_PORT)) {
-		logMsg +=
-			pad('') +
-			'http://' +
-			getThisNodeHostname() +
-			':' +
-			env.get(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_PORT) +
-			'/\n';
+		logMsg += `${pad('')}http://${getThisNodeHostname()}:${env.get(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_PORT)}/\n`;
 	}
 	if (env.get(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_SECUREPORT)) {
-		logMsg +=
-			'\n' +
-			pad('') +
-			'https://' +
-			getThisNodeHostname() +
-			':' +
-			env.get(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_SECUREPORT) +
-			'/\n';
+		logMsg += `\n${pad('')}https://${getThisNodeHostname()}:${env.get(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_SECUREPORT)}/\n`;
 	}
 
 	// MQTT Log

--- a/server/nodeName.ts
+++ b/server/nodeName.ts
@@ -58,6 +58,24 @@ export function clearThisNodeName() {
 	nodeName = undefined;
 }
 
+/**
+ * Returns this node's bare hostname (no scheme, no port) for composing display URLs.
+ * getThisNodeName() is normally a bare host ('localhost'), but if node.hostname is
+ * configured as a full URL ('http://localhost:9926'), composing a URL from it double-wraps
+ * the scheme and inherits the wrong port (http://http://localhost:9926:9925/). Reduce it
+ * back to the host so the composed URL is well-formed. (#2218)
+ */
+export function getThisNodeHostname(): string {
+	const name = getThisNodeName();
+	if (!name) return name;
+	try {
+		const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(name);
+		return new URL(hasScheme ? name : `http://${name}`).hostname || name;
+	} catch {
+		return name; // not URL-parseable; assume it is already a bare host
+	}
+}
+
 function getHostFromListeningPort(key: string) {
 	const port: string | undefined = env.get(key);
 	const lastColon = port?.lastIndexOf?.(':');

--- a/server/nodeName.ts
+++ b/server/nodeName.ts
@@ -58,9 +58,8 @@ export function clearThisNodeName() {
 	nodeName = undefined;
 }
 
-// Reduce node.hostname to a bare host for display-URL composition: it may be configured as a
-// full URL (which would otherwise double-wrap the scheme/port), and the bracketed retry lets a
-// bare IPv6 literal parse.
+// node.hostname may be configured as a full URL; reduce it to a bare host so composing a
+// display URL from it does not double-wrap the scheme and port.
 export function nodeNameToDisplayHost(name: string): string {
 	if (!name) return name;
 	const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(name);

--- a/server/nodeName.ts
+++ b/server/nodeName.ts
@@ -58,22 +58,27 @@ export function clearThisNodeName() {
 	nodeName = undefined;
 }
 
-/**
- * Returns this node's bare hostname (no scheme, no port) for composing display URLs.
- * getThisNodeName() is normally a bare host ('localhost'), but if node.hostname is
- * configured as a full URL ('http://localhost:9926'), composing a URL from it double-wraps
- * the scheme and inherits the wrong port (http://http://localhost:9926:9925/). Reduce it
- * back to the host so the composed URL is well-formed. (#2218)
- */
-export function getThisNodeHostname(): string {
-	const name = getThisNodeName();
+// node.hostname is normally a bare host, but may be configured as a full URL; composing a
+// display URL from that form would double-wrap its scheme and port. Reduce it to a bare host
+// (bracketed, for an IPv6 literal) first. (#2218)
+export function nodeNameToDisplayHost(name: string): string {
 	if (!name) return name;
-	try {
-		const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(name);
-		return new URL(hasScheme ? name : `http://${name}`).hostname || name;
-	} catch {
-		return name; // not URL-parseable; assume it is already a bare host
+	const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(name);
+	// A bare IPv6 literal ('::1') only parses once bracketed, so try that form too.
+	const candidateUrls = hasScheme ? [name] : [`http://${name}`, `http://[${name}]`];
+	for (const candidateUrl of candidateUrls) {
+		try {
+			const { hostname } = new URL(candidateUrl);
+			if (hostname) return hostname;
+		} catch {
+			// not this form; try the next candidate
+		}
 	}
+	return name;
+}
+
+export function getThisNodeHostname(): string {
+	return nodeNameToDisplayHost(getThisNodeName());
 }
 
 function getHostFromListeningPort(key: string) {

--- a/server/nodeName.ts
+++ b/server/nodeName.ts
@@ -58,21 +58,18 @@ export function clearThisNodeName() {
 	nodeName = undefined;
 }
 
-// node.hostname is normally a bare host, but may be configured as a full URL; composing a
-// display URL from that form would double-wrap its scheme and port. Reduce it to a bare host
-// (bracketed, for an IPv6 literal) first. (#2218)
+// Reduce node.hostname to a bare host for display-URL composition: it may be configured as a
+// full URL (which would otherwise double-wrap the scheme/port), and the bracketed retry lets a
+// bare IPv6 literal parse.
 export function nodeNameToDisplayHost(name: string): string {
 	if (!name) return name;
 	const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(name);
-	// A bare IPv6 literal ('::1') only parses once bracketed, so try that form too.
-	const candidateUrls = hasScheme ? [name] : [`http://${name}`, `http://[${name}]`];
-	for (const candidateUrl of candidateUrls) {
+	const candidates = hasScheme ? [name] : [`http://${name}`, `http://[${name}]`];
+	for (const candidate of candidates) {
 		try {
-			const { hostname } = new URL(candidateUrl);
+			const { hostname } = new URL(candidate);
 			if (hostname) return hostname;
-		} catch {
-			// not this form; try the next candidate
-		}
+		} catch {}
 	}
 	return name;
 }

--- a/unitTests/bin/startupBanner.test.js
+++ b/unitTests/bin/startupBanner.test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+// End-to-end guard for the #2218 fix (double-wrapped startup URLs). The pure helper
+// nodeNameToDisplayHost() is unit-tested in unitTests/server/nodeName.test.js, but nothing exercised
+// startupLog() itself, so a call site that switched back from getThisNodeHostname() to
+// getThisNodeName() would recreate the `http://http://host:port/` banner while that suite stayed
+// green. This drives the real, exported startupLog() with a real (URL-valued) node.hostname and
+// asserts the Operations-API HTTP/HTTPS and REST URL lines it prints are well-formed.
+
+const testUtils = require('../testUtils.js');
+testUtils.preTestPrep();
+
+const assert = require('assert');
+
+const env = require('#src/utility/environment/environmentManager');
+const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
+const { clearThisNodeName } = require('#src/server/nodeName');
+const { startupLog } = require('#src/bin/run');
+
+describe('startupLog banner URLs (#2218 double-wrapped startup URLs)', () => {
+	const originalConsoleLog = console.log;
+	// initTestEnvironment() sets operationsApi_network_port=9925 and http_port=9926; the secure
+	// operations port is unset by default, so tests that need it set (and restore) it explicitly. Read
+	// the live ops port at assert time rather than caching it, so the expected URL always tracks the
+	// same config value startupLog() reads (no load-time-vs-run-time skew if another suite mutates it).
+	const opsPort = () => env.get(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_PORT);
+
+	afterEach(() => {
+		console.log = originalConsoleLog;
+		// Undo the per-test node identity so the cached name and config override don't leak into
+		// other suites in the same mocha process.
+		env.setProperty(CONFIG_PARAMS.NODE_HOSTNAME, undefined);
+		env.setProperty(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_SECUREPORT, undefined);
+		clearThisNodeName();
+	});
+
+	// Runs startupLog() with node.hostname set to `hostname`, captures the emitted banner, and
+	// returns it as a single string.
+	function bannerFor(hostname, portResolutions = new Map()) {
+		env.setProperty(CONFIG_PARAMS.NODE_HOSTNAME, hostname);
+		clearThisNodeName(); // getThisNodeName() memoizes; drop any value cached by an earlier test
+
+		const lines = [];
+		console.log = (...args) => lines.push(args.join(' '));
+		try {
+			startupLog(portResolutions);
+		} finally {
+			console.log = originalConsoleLog;
+		}
+		return lines.join('\n');
+	}
+
+	it('composes well-formed ops + REST URLs when node.hostname is a full URL', () => {
+		// A URL-valued node.hostname is exactly the #2218 trigger: getThisNodeName() returns the whole
+		// URL, so the pre-fix banner produced `http://http://localhost:9926:9925/`.
+		const restPort = 9926;
+		const portResolutions = new Map([[restPort, [{ name: 'rest', protocol_name: 'HTTP' }]]]);
+
+		const banner = bannerFor('http://localhost:9926', portResolutions);
+
+		assert.ok(!banner.includes('http://http://'), `banner double-wrapped a scheme:\n${banner}`);
+		assert.ok(
+			banner.includes(`http://localhost:${opsPort()}/`),
+			`expected the Operations-API URL http://localhost:${opsPort()}/ in banner:\n${banner}`
+		);
+		assert.ok(
+			banner.includes(`http://localhost:${restPort}/`),
+			`expected the REST URL http://localhost:${restPort}/ in banner:\n${banner}`
+		);
+	});
+
+	it('composes well-formed HTTPS ops + REST URLs when node.hostname is a full URL', () => {
+		const securePort = 9935;
+		const restPort = 9927;
+		env.setProperty(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_SECUREPORT, securePort);
+		const portResolutions = new Map([[restPort, [{ name: 'rest', protocol_name: 'HTTPS' }]]]);
+
+		const banner = bannerFor('https://localhost:9926', portResolutions);
+
+		assert.ok(!banner.includes('https://https://'), `banner double-wrapped a scheme:\n${banner}`);
+		assert.ok(
+			banner.includes(`https://localhost:${securePort}/`),
+			`expected the Operations-API URL https://localhost:${securePort}/ in banner:\n${banner}`
+		);
+		assert.ok(
+			banner.includes(`https://localhost:${restPort}/`),
+			`expected the REST URL https://localhost:${restPort}/ in banner:\n${banner}`
+		);
+	});
+
+	it('leaves a plain bare-host node.hostname unchanged in composed URLs', () => {
+		// The complement of the URL case: normalization must not corrupt a hostname that was already
+		// bare (over-stripping would be just as wrong as double-wrapping).
+		const restPort = 9926;
+		const portResolutions = new Map([[restPort, [{ name: 'rest', protocol_name: 'HTTP' }]]]);
+
+		const banner = bannerFor('node-1.example.com', portResolutions);
+
+		assert.ok(
+			banner.includes(`http://node-1.example.com:${opsPort()}/`),
+			`expected the Operations-API URL http://node-1.example.com:${opsPort()}/ in banner:\n${banner}`
+		);
+		assert.ok(
+			banner.includes(`http://node-1.example.com:${restPort}/`),
+			`expected the REST URL http://node-1.example.com:${restPort}/ in banner:\n${banner}`
+		);
+	});
+});

--- a/unitTests/bin/startupBanner.test.js
+++ b/unitTests/bin/startupBanner.test.js
@@ -25,12 +25,20 @@ describe('startupLog banner URLs (#2218 double-wrapped startup URLs)', () => {
 	// same config value startupLog() reads (no load-time-vs-run-time skew if another suite mutates it).
 	const opsPort = () => env.get(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_PORT);
 
+	let originalNodeHostname;
+	let originalSecurePort;
+
+	beforeEach(() => {
+		originalNodeHostname = env.get(CONFIG_PARAMS.NODE_HOSTNAME);
+		originalSecurePort = env.get(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_SECUREPORT);
+	});
+
 	afterEach(() => {
 		console.log = originalConsoleLog;
-		// Undo the per-test node identity so the cached name and config override don't leak into
-		// other suites in the same mocha process.
-		env.setProperty(CONFIG_PARAMS.NODE_HOSTNAME, undefined);
-		env.setProperty(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_SECUREPORT, undefined);
+		// Restore (not blank) the config this suite mutated so it can't leak into other suites in
+		// the same mocha process.
+		env.setProperty(CONFIG_PARAMS.NODE_HOSTNAME, originalNodeHostname);
+		env.setProperty(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_SECUREPORT, originalSecurePort);
 		clearThisNodeName();
 	});
 

--- a/unitTests/server/nodeName.test.js
+++ b/unitTests/server/nodeName.test.js
@@ -8,7 +8,13 @@ const sinon = require('sinon');
 
 const env = require('#src/utility/environment/environmentManager');
 const { logger } = require('#src/utility/logging/logger');
-const { hostnameToUrl, getThisNodeName, nodeNameToDisplayHost, clearThisNodeName } = require('#src/server/nodeName');
+const {
+	hostnameToUrl,
+	getThisNodeName,
+	getThisNodeHostname,
+	nodeNameToDisplayHost,
+	clearThisNodeName,
+} = require('#src/server/nodeName');
 
 describe('getThisNodeName precedence (harper-pro#351)', () => {
 	let sandbox;
@@ -101,6 +107,28 @@ describe('nodeNameToDisplayHost (#2218 double-wrapped startup URLs)', () => {
 
 	it('returns an unparseable value unchanged rather than dropping it', () => {
 		assert.strictEqual(nodeNameToDisplayHost('node with space'), 'node with space');
+	});
+});
+
+describe('getThisNodeHostname reads and normalizes the configured node.hostname', () => {
+	let originalNodeHostname;
+
+	beforeEach(() => {
+		originalNodeHostname = env.get('node_hostname');
+		clearThisNodeName();
+	});
+
+	afterEach(() => {
+		env.setProperty('node_hostname', originalNodeHostname);
+		clearThisNodeName();
+	});
+
+	// Guards the wiring bin/run.ts depends on: the wrapper must normalize the resolved node name,
+	// not return it raw.
+	it('normalizes a URL-valued node.hostname to a bare host', () => {
+		env.setProperty('node_hostname', 'http://localhost:9926');
+		clearThisNodeName();
+		assert.strictEqual(getThisNodeHostname(), 'localhost');
 	});
 });
 

--- a/unitTests/server/nodeName.test.js
+++ b/unitTests/server/nodeName.test.js
@@ -8,7 +8,7 @@ const sinon = require('sinon');
 
 const env = require('#src/utility/environment/environmentManager');
 const { logger } = require('#src/utility/logging/logger');
-const { hostnameToUrl, getThisNodeName, clearThisNodeName } = require('#src/server/nodeName');
+const { hostnameToUrl, getThisNodeName, getThisNodeHostname, clearThisNodeName } = require('#src/server/nodeName');
 
 describe('getThisNodeName precedence (harper-pro#351)', () => {
 	let sandbox;
@@ -75,6 +75,45 @@ describe('getThisNodeName precedence (harper-pro#351)', () => {
 			logger.warn = originalWarn;
 		}
 		assert.ok(!warn.called, 'should not warn when replication.hostname is unset');
+	});
+});
+
+describe('getThisNodeHostname (#2218 double-wrapped startup URLs)', () => {
+	let sandbox;
+
+	beforeEach(() => {
+		sandbox = sinon.createSandbox();
+		clearThisNodeName();
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+		clearThisNodeName();
+	});
+
+	function stubNodeHostname(value) {
+		sandbox.stub(env, 'get').callsFake((key) => (key === 'node_hostname' ? value : undefined));
+	}
+
+	it('returns a bare host unchanged', () => {
+		stubNodeHostname('localhost');
+		assert.strictEqual(getThisNodeHostname(), 'localhost');
+	});
+
+	it('strips the scheme and port when node.hostname is a full URL', () => {
+		// Without this the startup banner composed http://http://localhost:9926:9925/
+		stubNodeHostname('http://localhost:9926');
+		assert.strictEqual(getThisNodeHostname(), 'localhost');
+	});
+
+	it('strips a bare host:port down to the host', () => {
+		stubNodeHostname('localhost:9926');
+		assert.strictEqual(getThisNodeHostname(), 'localhost');
+	});
+
+	it('preserves bracketed IPv6 hosts so composed URLs stay valid', () => {
+		stubNodeHostname('https://[::1]:9926');
+		assert.strictEqual(getThisNodeHostname(), '[::1]');
 	});
 });
 

--- a/unitTests/server/nodeName.test.js
+++ b/unitTests/server/nodeName.test.js
@@ -8,7 +8,7 @@ const sinon = require('sinon');
 
 const env = require('#src/utility/environment/environmentManager');
 const { logger } = require('#src/utility/logging/logger');
-const { hostnameToUrl, getThisNodeName, getThisNodeHostname, clearThisNodeName } = require('#src/server/nodeName');
+const { hostnameToUrl, getThisNodeName, nodeNameToDisplayHost, clearThisNodeName } = require('#src/server/nodeName');
 
 describe('getThisNodeName precedence (harper-pro#351)', () => {
 	let sandbox;
@@ -78,42 +78,25 @@ describe('getThisNodeName precedence (harper-pro#351)', () => {
 	});
 });
 
-describe('getThisNodeHostname (#2218 double-wrapped startup URLs)', () => {
-	let sandbox;
-
-	beforeEach(() => {
-		sandbox = sinon.createSandbox();
-		clearThisNodeName();
-	});
-
-	afterEach(() => {
-		sandbox.restore();
-		clearThisNodeName();
-	});
-
-	function stubNodeHostname(value) {
-		sandbox.stub(env, 'get').callsFake((key) => (key === 'node_hostname' ? value : undefined));
-	}
-
+describe('nodeNameToDisplayHost (#2218 double-wrapped startup URLs)', () => {
 	it('returns a bare host unchanged', () => {
-		stubNodeHostname('localhost');
-		assert.strictEqual(getThisNodeHostname(), 'localhost');
+		assert.strictEqual(nodeNameToDisplayHost('localhost'), 'localhost');
 	});
 
 	it('strips the scheme and port when node.hostname is a full URL', () => {
-		// Without this the startup banner composed http://http://localhost:9926:9925/
-		stubNodeHostname('http://localhost:9926');
-		assert.strictEqual(getThisNodeHostname(), 'localhost');
+		assert.strictEqual(nodeNameToDisplayHost('http://localhost:9926'), 'localhost');
 	});
 
 	it('strips a bare host:port down to the host', () => {
-		stubNodeHostname('localhost:9926');
-		assert.strictEqual(getThisNodeHostname(), 'localhost');
+		assert.strictEqual(nodeNameToDisplayHost('localhost:9926'), 'localhost');
 	});
 
-	it('preserves bracketed IPv6 hosts so composed URLs stay valid', () => {
-		stubNodeHostname('https://[::1]:9926');
-		assert.strictEqual(getThisNodeHostname(), '[::1]');
+	it('preserves an already-bracketed IPv6 host', () => {
+		assert.strictEqual(nodeNameToDisplayHost('https://[::1]:9926'), '[::1]');
+	});
+
+	it('brackets a bare IPv6 literal so composed URLs stay valid', () => {
+		assert.strictEqual(nodeNameToDisplayHost('::1'), '[::1]');
 	});
 });
 

--- a/unitTests/server/nodeName.test.js
+++ b/unitTests/server/nodeName.test.js
@@ -98,6 +98,10 @@ describe('nodeNameToDisplayHost (#2218 double-wrapped startup URLs)', () => {
 	it('brackets a bare IPv6 literal so composed URLs stay valid', () => {
 		assert.strictEqual(nodeNameToDisplayHost('::1'), '[::1]');
 	});
+
+	it('returns an unparseable value unchanged rather than dropping it', () => {
+		assert.strictEqual(nodeNameToDisplayHost('node with space'), 'node with space');
+	});
 });
 
 describe('hostnameToUrl', () => {


### PR DESCRIPTION
Fixes #2218. When `node.hostname` is configured as a full URL (e.g. `http://localhost:9926`), the Operations-API and REST lines of the startup banner composed URLs like `http://http://localhost:9926:9925/` — the scheme was wrapped twice and the wrong port appended, because the banner assumed `getThisNodeName()` returns a bare host. A new `nodeNameToDisplayHost()` reduces the node name to a bare host (stripping any scheme/port, and bracketing a bare IPv6 literal) before each banner URL is composed; the three banner URL sites now use it. Result: `http://localhost:9925/` (ops) and `http://localhost:9926/` (REST).

## For the human reviewer

1. **Scope — normalize at the banner, not in `getThisNodeName()`.** Chosen because `getThisNodeName()` is the node's identity (cert CN, replication), so rewriting it is risky, while the reported bug is display-only. The alternative — normalizing at the source — would also fix `hostnameToUrl()`, which shares the same bare-host assumption and would produce a corrupt replication URL (`ws://http://host:port`) for a URL-valued `node.hostname`. That corruption is pre-existing and left out of scope here; the root-cause follow-up (validate/warn the bare-host `node.hostname` invariant in `getThisNodeName()`, which also covers `hostnameToUrl()`/replication and the `security/keys.ts` cert identity) is being handled as a separate change already in progress. Reversible either way.
2. **`Hostname:` banner line left verbatim.** It still prints the raw configured `node.hostname` (the URL), deliberately — so an operator who configured a URL where a bare host is expected sees that, rather than having it silently masked. Only the composed URLs are normalized.

## Verification

Route: unit tests (plain `assert`, no stubbing) at two levels — the pure `nodeNameToDisplayHost` helper across bare host / full URL / `host:port` / bracketed and bare IPv6, and an end-to-end test that drives the real exported `startupLog()` with a URL-valued `node.hostname` and asserts the composed Operations-API HTTP/HTTPS and REST banner lines are well-formed (no `http://http://` double-wrap). Executed locally: `unitTests/server/nodeName.test.js` 15 passing and `unitTests/bin/startupBanner.test.js` 3 passing (18 together, no cross-suite leakage); `npm run lint:required` and `prettier --check` clean. The e2e test also fails as expected when the banner sites are reverted to `getThisNodeName()`, proving it catches the regression.

## Review coverage

Authored by Opus 4.8. Cross-model review ran 6 delta rounds (one after each round of fixes). Codex `gpt-5.6-sol` gave independent, graded outside-family coverage every round; Gemini via `agy` (default model) ran on some rounds and failed others (`agy` flakiness); the Harper domain adjudicator and Cursor legs were auto-pruned as narrow low-risk deltas, so Codex's findings were not domain-adjudicated. Every substantive finding was fixed and re-verified: new Sinon usage (→ pure function + plain `assert`), a bare-IPv6 URL gap, missing `getThisNodeHostname` wrapper coverage, missing end-to-end `startupLog` coverage, and a test-isolation cleanup gap. One nit is left open by choice — a two-line "why" comment on `nodeNameToDisplayHost`, kept as durable rationale the house style permits. Receipt @ `d7b5c46bb`.

<sub>Review-Coverage: authored=claude; ran=codex; declined=gemini,cursor-grok,cursor-composer,domain; rounds=1 @ d7b5c46bb96f</sub>

<sub>Human-Review-Need: 4 @ d7b5c46bb96f</sub>
