### PR TITLE
Reject a non-bare-host node identity and fix IPv6 replication URLs

### DIFF
--- a/security/keys.ts
+++ b/security/keys.ts
@@ -392,13 +392,15 @@ function loadAndWatch(path, loadCert, type) {
 }
 
 function getHost() {
-	let url = getThisNodeUrl();
-	if (url == null) {
+	// urlToNodeName returns undefined for a missing or malformed node/replication URL, so a bad
+	// replication.url falls back to the default host here rather than throwing during cert review.
+	const name = urlToNodeName(getThisNodeUrl());
+	if (name == null) {
 		const host = CERT_DOMAINS[0];
 		logger.info?.('node url is missing from harperdb-config.yaml, using default host' + host);
 		return host;
 	}
-	return urlToNodeName(url);
+	return name;
 }
 
 export function getCommonName() {

--- a/server/nodeName.ts
+++ b/server/nodeName.ts
@@ -1,8 +1,10 @@
 import { readFileSync } from 'node:fs';
 import { X509Certificate } from 'node:crypto';
+import { isIP } from 'node:net';
 import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 import * as env from '../utility/environment/environmentManager.ts';
 import { logger } from '../utility/logging/logger.ts';
+import { bareHostViolation } from '../utility/nodeIdentity.ts';
 import { server } from './Server.ts';
 
 Object.defineProperty(server, 'hostname', {
@@ -17,20 +19,26 @@ function getCommonNameFromCert() {
 	const certificatePath: string | undefined =
 		env.get(CONFIG_PARAMS.OPERATIONSAPI_TLS_CERTIFICATE) || env.get(CONFIG_PARAMS.TLS_CERTIFICATE);
 	if (certificatePath) {
-		// we can use this to get the hostname if it isn't provided by config
-		const certParsed = new X509Certificate(readFileSync(certificatePath));
-		const subject = certParsed.subject;
-		return (commonNameFromCert = subject?.match(/CN=(.*)/)?.[1] ?? null);
+		try {
+			// use this to get the hostname if it isn't provided by config
+			const subject = new X509Certificate(readFileSync(certificatePath)).subject;
+			return (commonNameFromCert = subject?.match(/CN=(.*)/)?.[1] ?? null);
+		} catch {
+			// a missing/unparseable cert file must not throw out of identity resolution — the caller
+			// falls back to another source. Do NOT cache the failure, so a later read (e.g. after the
+			// cert is created) can still pick up its common name.
+			return undefined;
+		}
 	}
 }
 
 let nodeName: string | undefined;
 export function getThisNodeName(): string {
 	if (nodeName) return nodeName; // if already determined, just return
-	nodeName = env.get(CONFIG_PARAMS.NODE_HOSTNAME); // standard config
-	if (nodeName) {
+	const configured = env.get(CONFIG_PARAMS.NODE_HOSTNAME);
+	if (configured) {
 		const replicationHostname = env.get('replication_hostname');
-		if (replicationHostname && replicationHostname !== nodeName) {
+		if (replicationHostname && replicationHostname !== configured) {
 			// If these are both set and differ, the node identity is ambiguous. node.hostname
 			// wins (it is what this node identifies as), but if it doesn't match the name this
 			// node is registered under in hdb_nodes, replication for that name silently turns
@@ -38,18 +46,21 @@ export function getThisNodeName(): string {
 			// node.hostname value — that's how a wrong identity (e.g. 'localhost') gets locked
 			// in. Steer the operator to reconcile against the registered node name instead.
 			logger.warn?.(
-				`The node.hostname (${nodeName}) and replication.hostname (${replicationHostname}) configuration values are both set and differ. This node will identify as "${nodeName}". Ensure that name matches this node's row in system.hdb_nodes; if it does not, set node.hostname (or remove it to fall back to replication.hostname) to match the registered node name, otherwise replication for this node will be disabled.`
+				`The node.hostname (${configured}) and replication.hostname (${replicationHostname}) configuration values are both set and differ. This node will identify as "${configured}". Ensure that name matches this node's row in system.hdb_nodes; if it does not, set node.hostname (or remove it to fall back to replication.hostname) to match the registered node name, otherwise replication for this node will be disabled.`
 			);
 		}
-		return nodeName;
 	}
-	// fallback to other means of getting the node name
+	// Use the first source that is a valid bare host (harper#2218). node.hostname and
+	// replication.hostname are rejected at the config boundary when invalid; the remaining derived
+	// sources are validated here and skipped — not fatal — if unusable, so a descriptive certificate
+	// common name or an empty value can never cache a corrupt identity or crash a request-time caller.
 	nodeName =
-		env.get('replication_hostname') ?? // for backwards compatibility
-		urlToNodeName(env.get('replication_url') as string) ??
-		getCommonNameFromCert() ??
-		getHostFromListeningPort('operationsapi_network_secureport') ??
-		getHostFromListeningPort('operationsapi_network_port') ??
+		asBareHost(configured, 'node.hostname') ??
+		asBareHost(env.get('replication_hostname'), 'replication.hostname') ?? // for backwards compatibility
+		asBareHost(replicationUrlHost(), 'the host in replication.url') ??
+		asBareHost(getCommonNameFromCert(), 'the certificate common name') ??
+		asBareHost(getHostFromListeningPort('operationsapi_network_secureport'), 'the operations API host') ??
+		asBareHost(getHostFromListeningPort('operationsapi_network_port'), 'the operations API host') ??
 		'127.0.0.1';
 	return nodeName;
 }
@@ -58,8 +69,9 @@ export function clearThisNodeName() {
 	nodeName = undefined;
 }
 
-// node.hostname may be configured as a full URL; reduce it to a bare host so composing a
-// display URL from it does not double-wrap the scheme and port.
+// Reduce a node name to a host safe to compose a display URL from: strip a scheme/port (defensive —
+// a configured node.hostname carrying those is now rejected at the config boundary) and bracket a
+// bare IPv6 literal, without which the composed startup URLs are unparseable.
 export function nodeNameToDisplayHost(name: string): string {
 	if (!name) return name;
 	const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(name);
@@ -77,10 +89,46 @@ export function getThisNodeHostname(): string {
 	return nodeNameToDisplayHost(getThisNodeName());
 }
 
+/**
+ * The host of replication.url, or undefined when it is unset or carries no usable host. Warns in the
+ * latter case for the same reason asBareHost does: a typo'd URL must not silently cost this node its
+ * identity. urlToNodeName itself stays quiet — it is also used for peer URLs, not just this node's.
+ */
+function replicationUrlHost(): string | undefined {
+	const url: string | undefined = env.get(CONFIG_PARAMS.REPLICATION_URL);
+	if (!url) return undefined;
+	const host = urlToNodeName(url);
+	if (host === undefined) {
+		logger.warn?.(
+			`Ignoring replication.url (${JSON.stringify(url)}) as this node's identity: it is not a URL with a host. Falling back to the next available source, which may leave this node identifying as 127.0.0.1 and unable to replicate.`
+		);
+	}
+	return host;
+}
+
+/**
+ * A candidate identity source, or undefined when it is unset or not a bare host. Skipping is
+ * deliberate (see getThisNodeName) but silence is a diagnosis trap: a typo'd source that quietly
+ * resolves identity to 127.0.0.1 looks like a working node until replication fails, so say so.
+ */
+function asBareHost(value: unknown, source: string): string | undefined {
+	if (value === undefined || value === null || value === '') return undefined;
+	const violation = bareHostViolation(value);
+	if (!violation) return value as string;
+	logger.warn?.(
+		`Ignoring ${source} (${JSON.stringify(value)}) as this node's identity: it ${violation}. Falling back to the next available source, which may leave this node identifying as 127.0.0.1 and unable to replicate. Set it to a bare hostname or IP literal.`
+	);
+	return undefined;
+}
+
 function getHostFromListeningPort(key: string) {
 	const port: string | undefined = env.get(key);
 	const lastColon = port?.lastIndexOf?.(':');
-	if (lastColon > 0) return port.slice(0, lastColon);
+	if (lastColon > 0) {
+		const host = port.slice(0, lastColon);
+		// A listen address stores IPv6 bracketed ("[::1]:9925"); the node identity is unbracketed.
+		return host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+	}
 }
 function getPortFromListeningPort(key: string) {
 	const port: string | undefined = env.get(key);
@@ -91,18 +139,33 @@ function getPortFromListeningPort(key: string) {
 
 export function hostnameToUrl(hostname) {
 	if (!hostname) return undefined;
+	// A bare IPv6 literal must be bracketed for the authority to parse: "ws://::1:9925" is rejected by
+	// the URL parser, "ws://[::1]:9925" is not. Hostnames and IPv4 pass through unchanged.
+	const host = isIP(hostname) === 6 ? `[${hostname}]` : hostname;
 	let port = getPortFromListeningPort('replication_port');
-	if (port) return `ws://${hostname}:${port}`;
+	if (port) return `ws://${host}:${port}`;
 	port = getPortFromListeningPort('replication_secureport');
-	if (port) return `wss://${hostname}:${port}`;
+	if (port) return `wss://${host}:${port}`;
 	port = getPortFromListeningPort('operationsapi_network_port');
-	if (port) return `ws://${hostname}:${port}`;
+	if (port) return `ws://${host}:${port}`;
 	port = getPortFromListeningPort('operationsapi_network_secureport');
-	if (port) return `wss://${hostname}:${port}`;
+	if (port) return `wss://${host}:${port}`;
 }
 
 export function urlToNodeName(nodeUrl?: string | URL): string | undefined {
-	if (nodeUrl) return new URL(nodeUrl).hostname; // this the part of the URL that is the node name, as we want it to match common name in the certificate
+	if (!nodeUrl) return undefined;
+	try {
+		// the part of the URL that is the node name, matched against the certificate common name. URL
+		// keeps an IPv6 host bracketed ("[::1]"); the identity is stored unbracketed so it stays one
+		// canonical string across sources and net.isIP types it as an IP certificate SAN.
+		const host = new URL(nodeUrl).hostname;
+		// A hostless scheme ("mailto:", "data:", "file:", "urn:") parses but has an empty hostname —
+		// that is no name at all, not an identity, so treat it like a malformed URL.
+		if (host === '') return undefined;
+		return host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+	} catch {
+		return undefined; // a malformed URL yields no name — callers skip this source rather than crash
+	}
 }
 
 export function getThisNodeUrl() {

--- a/unitTests/bin/startupBanner.test.js
+++ b/unitTests/bin/startupBanner.test.js
@@ -58,26 +58,22 @@ describe('startupLog banner URLs (#2218 double-wrapped startup URLs)', () => {
 		return lines.join('\n');
 	}
 
-	it('composes well-formed ops + REST URLs when node.hostname is a full URL', () => {
-		// A URL-valued node.hostname is exactly the #2218 trigger: getThisNodeName() returns the whole
-		// URL, so the pre-fix banner produced `http://http://localhost:9926:9925/`.
+	it('never double-wraps a scheme, and does not show a rejected URL-valued node.hostname', () => {
+		// A URL-valued node.hostname was the #2218 trigger: getThisNodeName() returned the whole URL, so
+		// the pre-fix banner produced `http://http://localhost:9926:9925/`. Such a value is now rejected
+		// at the config boundary and skipped during identity resolution (with a warning), so it cannot
+		// reach the banner at all — the banner shows the fallback identity instead of the URL's host.
 		const restPort = 9926;
 		const portResolutions = new Map([[restPort, [{ name: 'rest', protocol_name: 'HTTP' }]]]);
 
 		const banner = bannerFor('http://localhost:9926', portResolutions);
 
 		assert.ok(!banner.includes('http://http://'), `banner double-wrapped a scheme:\n${banner}`);
-		assert.ok(
-			banner.includes(`http://localhost:${opsPort()}/`),
-			`expected the Operations-API URL http://localhost:${opsPort()}/ in banner:\n${banner}`
-		);
-		assert.ok(
-			banner.includes(`http://localhost:${restPort}/`),
-			`expected the REST URL http://localhost:${restPort}/ in banner:\n${banner}`
-		);
+		assert.ok(!banner.includes('http://localhost:9926:'), `banner composed from the raw URL:\n${banner}`);
+		assertBannerUrlsParse(banner);
 	});
 
-	it('composes well-formed HTTPS ops + REST URLs when node.hostname is a full URL', () => {
+	it('composes well-formed HTTPS URLs without double-wrapping a URL-valued node.hostname', () => {
 		const securePort = 9935;
 		const restPort = 9927;
 		env.setProperty(CONFIG_PARAMS.OPERATIONSAPI_NETWORK_SECUREPORT, securePort);
@@ -86,14 +82,24 @@ describe('startupLog banner URLs (#2218 double-wrapped startup URLs)', () => {
 		const banner = bannerFor('https://localhost:9926', portResolutions);
 
 		assert.ok(!banner.includes('https://https://'), `banner double-wrapped a scheme:\n${banner}`);
+		assert.ok(banner.includes(`:${securePort}/`), `expected the secure ops port in banner:\n${banner}`);
+		assert.ok(banner.includes(`:${restPort}/`), `expected the REST port in banner:\n${banner}`);
+		assertBannerUrlsParse(banner);
+	});
+
+	it('brackets a bare IPv6 node.hostname so the composed URLs stay parseable', () => {
+		// The identity is stored unbracketed ("::1") so net.isIP types the certificate SAN as an IP;
+		// the banner must bracket it, or `http://::1:9925/` is not a parseable URL.
+		const restPort = 9926;
+		const portResolutions = new Map([[restPort, [{ name: 'rest', protocol_name: 'HTTP' }]]]);
+
+		const banner = bannerFor('::1', portResolutions);
+
 		assert.ok(
-			banner.includes(`https://localhost:${securePort}/`),
-			`expected the Operations-API URL https://localhost:${securePort}/ in banner:\n${banner}`
+			banner.includes(`http://[::1]:${opsPort()}/`),
+			`expected a bracketed IPv6 Operations-API URL in banner:\n${banner}`
 		);
-		assert.ok(
-			banner.includes(`https://localhost:${restPort}/`),
-			`expected the REST URL https://localhost:${restPort}/ in banner:\n${banner}`
-		);
+		assertBannerUrlsParse(banner);
 	});
 
 	it('leaves a plain bare-host node.hostname unchanged in composed URLs', () => {
@@ -114,3 +120,11 @@ describe('startupLog banner URLs (#2218 double-wrapped startup URLs)', () => {
 		);
 	});
 });
+
+// Every URL the banner prints must be parseable — the real invariant behind #2218 (a double-wrapped
+// or unbracketed authority is not).
+function assertBannerUrlsParse(banner) {
+	for (const url of banner.match(/https?:\/\/\S+/g) ?? []) {
+		assert.doesNotThrow(() => new URL(url), `banner contains an unparseable URL: ${url}`);
+	}
+}

--- a/unitTests/server/nodeName.test.js
+++ b/unitTests/server/nodeName.test.js
@@ -14,6 +14,7 @@ const {
 	getThisNodeHostname,
 	nodeNameToDisplayHost,
 	clearThisNodeName,
+	urlToNodeName,
 } = require('#src/server/nodeName');
 
 describe('getThisNodeName precedence (harper-pro#351)', () => {
@@ -124,11 +125,128 @@ describe('getThisNodeHostname reads and normalizes the configured node.hostname'
 	});
 
 	// Guards the wiring bin/run.ts depends on: the wrapper must normalize the resolved node name,
-	// not return it raw.
-	it('normalizes a URL-valued node.hostname to a bare host', () => {
-		env.setProperty('node_hostname', 'http://localhost:9926');
+	// not return it raw. A URL-valued node.hostname no longer reaches here — it is rejected at the
+	// config boundary and skipped during resolution — so the enduring normalization this proves is
+	// bracketing a bare IPv6 identity, which keeps the composed startup URLs parseable.
+	it('brackets a bare IPv6 node.hostname for display', () => {
+		env.setProperty('node_hostname', '::1');
 		clearThisNodeName();
-		assert.strictEqual(getThisNodeHostname(), 'localhost');
+		assert.strictEqual(getThisNodeHostname(), '[::1]');
+	});
+
+	it('returns a bare hostname unchanged', () => {
+		env.setProperty('node_hostname', 'node1.example.com');
+		clearThisNodeName();
+		assert.strictEqual(getThisNodeHostname(), 'node1.example.com');
+	});
+});
+
+describe('getThisNodeName resolves to a valid bare host (#2218)', () => {
+	// node.hostname / replication.hostname are rejected as invalid at the config boundary (see the
+	// configValidator suite). getThisNodeName itself never throws: it uses the first source that is a
+	// valid bare host and skips an empty or unusable derived source, so it can never cache a corrupt
+	// identity or crash a request-time caller. The '127.0.0.1' floor is always valid.
+	let originalGet;
+
+	beforeEach(() => {
+		originalGet = env.get;
+		clearThisNodeName();
+	});
+
+	afterEach(() => {
+		env.get = originalGet;
+		clearThisNodeName();
+	});
+
+	function resolve(values) {
+		env.get = (key) => values[key];
+		return getThisNodeName();
+	}
+
+	for (const value of ['node1.example.com', '::1', '2001:db8::1', '127.0.0.1']) {
+		it(`returns a valid bare identity ${JSON.stringify(value)}`, () => {
+			assert.strictEqual(resolve({ node_hostname: value }), value);
+		});
+	}
+
+	it('falls back through replication.hostname to the derived sources', () => {
+		assert.strictEqual(resolve({ node_hostname: undefined, replication_hostname: 'real-node' }), 'real-node');
+	});
+
+	it('never caches an empty identity — an empty replication.hostname is skipped, not used', () => {
+		// The bug this guards: `??` does not skip '', so an empty fallback used to be cached as the
+		// identity (then hostnameToUrl('') is undefined). It must fall through to the floor instead.
+		assert.strictEqual(resolve({ node_hostname: undefined, replication_hostname: '' }), '127.0.0.1');
+	});
+
+	it('skips an unusable derived source rather than crashing startup', () => {
+		// A derived source that is not a bare host (e.g. a certificate CN with spaces, modelled here by
+		// a listening host with a space) must be skipped, not throw; resolution falls to the floor.
+		assert.strictEqual(
+			resolve({ node_hostname: undefined, operationsapi_network_secureport: 'bad host:9925' }),
+			'127.0.0.1'
+		);
+	});
+
+	it('does not throw on a malformed replication.url — the source is skipped', () => {
+		// urlToNodeName(replication_url) parses a URL; a malformed value must yield no name and be
+		// skipped, not throw before asBareHost runs (which would crash a request-time first caller).
+		assert.strictEqual(resolve({ node_hostname: undefined, replication_url: 'not-a-url' }), '127.0.0.1');
+	});
+
+	for (const url of ['mailto:operator@example.com', 'data:text/plain,hi', 'file:///etc/passwd', 'urn:isbn:123']) {
+		it(`skips a hostless replication.url (${url.split(':')[0]}:) instead of yielding an empty identity`, () => {
+			// These schemes parse but have hostname === '', which would otherwise become the identity and
+			// land an empty DNS SAN in the certificate (security/keys.ts getHost). Assert the empty name
+			// directly at the source: resolving to the 127.0.0.1 floor alone would also hold if the
+			// identity were '', since an empty value falls through the chain too.
+			assert.strictEqual(urlToNodeName(url), undefined, 'a hostless URL must yield no name at all');
+			assert.strictEqual(resolve({ node_hostname: undefined, replication_url: url }), '127.0.0.1');
+		});
+	}
+
+	it('warns when it skips a malformed source, so a lost identity is not silent', () => {
+		// The diagnosis trap this guards: a typo'd source silently resolving to 127.0.0.1 looks like a
+		// working node until replication fails.
+		const originalWarn = logger.warn;
+		const warnings = [];
+		logger.warn = (msg) => warnings.push(msg);
+		try {
+			env.get = (key) => ({ replication_url: 'ws://bad host:9933' })[key];
+			assert.strictEqual(getThisNodeName(), '127.0.0.1');
+		} finally {
+			logger.warn = originalWarn;
+		}
+		assert.strictEqual(warnings.length, 1, 'expected one warning for the skipped source');
+		assert.ok(/replication\.url/.test(warnings[0]), 'warning should name the source it ignored');
+	});
+
+	it('does not warn when every source is valid', () => {
+		const originalWarn = logger.warn;
+		const warnings = [];
+		logger.warn = (msg) => warnings.push(msg);
+		try {
+			env.get = (key) => ({ node_hostname: 'node1.example.com' })[key];
+			assert.strictEqual(getThisNodeName(), 'node1.example.com');
+		} finally {
+			logger.warn = originalWarn;
+		}
+		assert.strictEqual(warnings.length, 0, 'a valid identity must resolve silently');
+	});
+
+	it('derives an unbracketed IPv6 identity from a replication.url IPv6 host (parity with the listen source)', () => {
+		// URL.hostname keeps IPv6 bracketed; the identity must be unbracketed so it matches the same
+		// node's identity from other sources and is typed as an IP certificate SAN.
+		assert.strictEqual(
+			resolve({ node_hostname: undefined, replication_url: 'ws://[2001:db8::1]:9933' }),
+			'2001:db8::1'
+		);
+	});
+
+	it('extracts an unbracketed IPv6 identity from a bracketed listening address', () => {
+		// The identity must be canonical/unbracketed ("::1") so net.isIP recognises it for the cert IP
+		// SAN and so it matches the same node's identity derived from other sources.
+		assert.strictEqual(resolve({ node_hostname: undefined, operationsapi_network_secureport: '[::1]:9925' }), '::1');
 	});
 });
 
@@ -161,5 +279,18 @@ describe('hostnameToUrl', () => {
 	it('still builds a ws:// url for a valid hostname when replication_port is configured', () => {
 		sandbox.stub(env, 'get').withArgs('replication_port').returns('0.0.0.0:9933');
 		assert.strictEqual(hostnameToUrl('host.example.com'), 'ws://host.example.com:9933');
+	});
+
+	it('brackets a bare IPv6 literal so the composed replication URL parses', () => {
+		sandbox.stub(env, 'get').withArgs('replication_port').returns('0.0.0.0:9933');
+		const url = hostnameToUrl('::1');
+		assert.strictEqual(url, 'ws://[::1]:9933');
+		// The real invariant: the constructed URL must be parseable (unbracketed "::1" is rejected).
+		assert.strictEqual(new URL(url).hostname, '[::1]');
+	});
+
+	it('does not bracket an IPv4 literal', () => {
+		sandbox.stub(env, 'get').withArgs('replication_port').returns('0.0.0.0:9933');
+		assert.strictEqual(hostnameToUrl('127.0.0.1'), 'ws://127.0.0.1:9933');
 	});
 });

--- a/unitTests/utility/nodeIdentity.test.js
+++ b/unitTests/utility/nodeIdentity.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const testUtils = require('../testUtils.js');
+testUtils.preTestPrep();
+
+const assert = require('assert');
+const { bareHostViolation } = require('#src/utility/nodeIdentity');
+
+describe('bareHostViolation (node identity must be a bare host)', () => {
+	const valid = [
+		'node1',
+		'node1.example.com',
+		'my-node',
+		'MyNode',
+		'localhost',
+		'127.0.0.1',
+		'10.0.0.5',
+		'::1',
+		'fe80::1',
+		'2001:db8::1',
+		'', // unset — the caller falls back to another source
+	];
+	for (const value of valid) {
+		it(`accepts ${JSON.stringify(value)}`, () => {
+			assert.strictEqual(bareHostViolation(value), undefined);
+		});
+	}
+
+	const invalid = [
+		['http://localhost:9926', /scheme/],
+		['ws://host', /scheme/],
+		['localhost:9925', /port/],
+		['localhost:80', /port/], // default port is not normalized away
+		['myhost:443', /port/], // :443 is the parse scheme's default port — still reported as a port
+		['[::1]:9925', /unbracketed/], // a bracketed form is rejected before the port check
+		['localhost/path', /path/],
+		['localhost?q=1', /query/],
+		['localhost#frag', /fragment/],
+		['user:pass@localhost', /credentials/],
+		['ws:host:9925', /not a valid hostname/], // scheme without "//" — unparseable authority
+		['localhost:99999', /not a valid hostname/], // out-of-range port — unparseable authority
+		['fe80::1%eth0', /not a valid hostname/], // a scoped IPv6 zone id has no valid URL authority
+		['node%20', /not a valid hostname/], // a host the ws:// consumer rejects must not pass here
+		['[::1]', /unbracketed/], // identity is stored unbracketed; bracketing belongs to URL construction
+		['[2001:db8::1]', /unbracketed/],
+		['[127.0.0.1]', /unbracketed/], // brackets around IPv4 are invalid too
+		[9925, /must be a string/],
+		[0, /must be a string/],
+		[true, /must be a string/],
+		[null, /must be a string/],
+		[{}, /must be a string/],
+	];
+	for (const [value, matcher] of invalid) {
+		it(`rejects ${JSON.stringify(value)}`, () => {
+			const reason = bareHostViolation(value);
+			assert.ok(reason, `expected a violation reason for ${JSON.stringify(value)}`);
+			assert.ok(matcher.test(reason), `reason "${reason}" should match ${matcher}`);
+		});
+	}
+
+	it('treats a bare IPv6 literal with a hex-group tail as a valid IPv6 address, not a port', () => {
+		// "::1:9925" is a syntactically valid IPv6 address; an operator wanting a port must bracket it.
+		assert.strictEqual(bareHostViolation('::1:9925'), undefined);
+	});
+});

--- a/unitTests/validation/configValidator.test.js
+++ b/unitTests/validation/configValidator.test.js
@@ -208,6 +208,54 @@ describe('Test configValidator module', () => {
 			config.replication.blobGapReconnectMs = 1000;
 			expect(configValidator(config).error).to.be.undefined;
 		});
+
+		it('rejects a URL / port / numeric node.hostname, and accepts a bare host (#2218)', () => {
+			const config = testUtils.deepClone(FAKE_CONFIG);
+			for (const [bad, reason] of [
+				['http://localhost:9926', 'must not include a URL scheme'],
+				['localhost:9926', 'must not include a port'],
+				[9926, 'must be a string'],
+			]) {
+				config.node = { hostname: bad };
+				expect(configValidator(config).error.message).to.include(`'node.hostname' ${reason}`);
+			}
+			config.node = { hostname: 'node1.example.com' };
+			expect(configValidator(config).error).to.be.undefined;
+			config.node = { hostname: '::1' }; // a bare IPv6 literal is a valid identity
+			expect(configValidator(config).error).to.be.undefined;
+		});
+
+		it('rejects an authority-form replication.url that parses to no host (#2218)', () => {
+			const config = testUtils.deepClone(FAKE_CONFIG);
+			// Written as a real URL ("//" authority) yet parses to no host — the unambiguous mistake.
+			config.replication = { url: 'file:///etc/passwd' };
+			expect(configValidator(config).error.message).to.include("'replication.url' must be a URL with a host");
+
+			config.replication = { url: 'wss://node1.example.com:9933' };
+			expect(configValidator(config).error).to.be.undefined;
+
+			// Deliberately tolerated at the boundary: these carry no host, but urlToNodeName skips them
+			// at runtime (so they can never reach a certificate SAN) and identity falls through to
+			// another source. A scheme-less "host:port" even parses as a *scheme*, so it cannot be told
+			// apart from "mailto:" here — rejecting that shape would turn a harmless config into a boot
+			// failure. node.url is also left alone: this repo never reads it.
+			for (const tolerated of ['mailto:operator@example.com', 'node1.example.com:9933', 'not a url']) {
+				config.replication = { url: tolerated };
+				expect(configValidator(config).error, `expected ${tolerated} to be accepted`).to.be.undefined;
+			}
+			config.replication = undefined;
+			config.node = { hostname: 'prod-node', url: 'mailto:admin@corp.com' };
+			expect(configValidator(config).error).to.be.undefined;
+		});
+
+		it('rejects a URL-valued replication.hostname (the previously accepted string|number path) (#2218)', () => {
+			const config = testUtils.deepClone(FAKE_CONFIG);
+			config.replication = { hostname: 'http://host:9926' };
+			expect(configValidator(config).error.message).to.include("'replication.hostname' must not include a URL scheme");
+
+			config.replication.hostname = 'node-two';
+			expect(configValidator(config).error).to.be.undefined;
+		});
 	});
 
 	describe('getDomainSocketPathLengthWarning', () => {

--- a/unitTests/validation/installValidator.test.js
+++ b/unitTests/validation/installValidator.test.js
@@ -42,4 +42,24 @@ describe('Test installValidator module', () => {
 		const result = installValidator(test_params);
 		expect(result.message).to.equal("'i/am/root' is already in use. Please enter a different path.");
 	});
+
+	// NODE_HOSTNAME is this node's identity, so install rejects a non-bare-host value here rather than
+	// letting it fail at first boot (#2218). This runs after installer.ts copies a v5 upgrade's
+	// REPLICATION_HOSTNAME into NODE_HOSTNAME, which is how a URL-ish legacy value reaches install.
+	it('rejects a NODE_HOSTNAME that is not a bare host', () => {
+		for (const [value, reason] of [
+			['http://localhost:9926', 'must not include a URL scheme'],
+			['localhost:9925', 'must not include a port'],
+			['[::1]', 'must be an unbracketed IPv6 literal'],
+		]) {
+			const result = installValidator({ NODE_HOSTNAME: value });
+			expect(result?.message, `expected ${value} to be rejected`).to.include(`'NODE_HOSTNAME' ${reason}`);
+		}
+	});
+
+	it('accepts a bare-host NODE_HOSTNAME, and leaves an unset one alone', () => {
+		for (const value of ['node1.example.com', '::1', '127.0.0.1', null, undefined]) {
+			expect(installValidator({ NODE_HOSTNAME: value }), `expected ${value} to be accepted`).to.be.undefined;
+		}
+	});
 });

--- a/utility/nodeIdentity.ts
+++ b/utility/nodeIdentity.ts
@@ -1,0 +1,45 @@
+import { isIP } from 'node:net';
+
+/**
+ * A node's identity — node.hostname, and the replication.hostname / certificate it falls back to —
+ * must be a bare hostname or IP literal, not a URL: it becomes the certificate common name and the
+ * host replication advertises and dials, so a scheme/port/path/non-string corrupts both (harper#2218,
+ * where "ws://http://host:9926:9925" resolves to host "http"). Returns a reason clause when `value`
+ * is not a bare host, else undefined. An empty string is "unset" (a caller's cue to fall back), not a
+ * violation.
+ */
+export function bareHostViolation(value: unknown): string | undefined {
+	if (typeof value !== 'string') return `must be a string, but is a ${value === null ? 'null' : typeof value}`;
+	if (value === '') return undefined;
+	// The identity is stored unbracketed (bracketing belongs to URL construction). Reject a bracketed
+	// form so it is never cached — otherwise net.isIP fails on it and the certificate SAN is mistyped
+	// as DNS rather than IP, and the same node's identity string would differ by source.
+	if (value.includes('[') || value.includes(']'))
+		return 'must be an unbracketed IPv6 literal (e.g. "::1", not "[::1]")';
+	// A zone id ("fe80::1%eth0") passes net.isIP but has no valid URL authority, so exclude it here.
+	if (isIP(value) && !value.includes('%')) return undefined; // a bare IPv4/IPv6 literal is a valid identity
+	if (value.includes('://')) return 'must not include a URL scheme';
+	let url;
+	try {
+		// Parse under a special scheme so the host grammar matches the ws:// replication URLs that
+		// consume this value — a host this accepts is one the consumer accepts (a non-special scheme is
+		// more lenient and would pass e.g. "node%20" or "0x7f.1"). A port or path makes url.hostname
+		// differ from the input and is caught by the round-trip check below.
+		url = new URL(`https://${value}`);
+	} catch {
+		return 'is not a valid hostname';
+	}
+	// Report the port before the round-trip check: the parser strips a default port for the scheme it
+	// was given (":443" under https), which would otherwise surface as a vaguer "is not a bare hostname".
+	if (url.port || (url.hostname && value.slice(url.hostname.length).startsWith(':'))) {
+		return 'must not include a port';
+	}
+	if (url.username || url.password) return 'must not include credentials';
+	if (url.search) return 'must not include a query string';
+	if (url.hash) return 'must not include a fragment';
+	if (url.pathname && url.pathname !== '/') return 'must not include a path';
+	// The host must survive parsing unchanged (compared case-insensitively, since URL lowercases it);
+	// anything that does not round-trip carried extra syntax and is not a bare host.
+	if (url.hostname.toLowerCase() !== value.toLowerCase()) return 'is not a bare hostname';
+	return undefined;
+}

--- a/validation/configValidator.ts
+++ b/validation/configValidator.ts
@@ -10,6 +10,7 @@ import * as hdbLogger from '../utility/logging/harper_logger.ts';
 import * as hdbUtils from '../utility/common_utils.ts';
 import * as hdbTerms from '../utility/hdbTerms.ts';
 import { getDomainSocketPathMaxBytes } from '../utility/domainSocket.ts';
+import { bareHostViolation } from '../utility/nodeIdentity.ts';
 import * as validator from './validationWrapper.ts';
 
 const DEFAULT_LOG_FOLDER = 'log';
@@ -52,6 +53,10 @@ const DIRECTORY_PATH_PATTERN = /^(?!\s*$)[^\x00-\x1f\x7f\x80-\x9f\u2028\u2029]+$
 const portConstraints = Joi.alternatives([number.min(0), string])
 	.optional()
 	.empty(null);
+// node.hostname / replication.hostname must be a bare host, not a URL (utility/nodeIdentity.ts).
+// `Joi.any` (not `string`) so validateBareHost reports a non-string with its own reason.
+const bareHostConstraints = Joi.any().custom(validateBareHost).optional().empty(null);
+const nodeUrlConstraints = string.custom(validateNodeUrl).optional().empty(null);
 // Controlled-flow ("directional") replication fields. A route's `replicates` is either a boolean
 // (full replication on/off) or an object describing per-direction flow; `sends`/`receives` and
 // `sendsTo`/`receivesFrom` are also accepted as top-level route keys (iterateRoutes normalizes both
@@ -247,8 +252,8 @@ export function configValidator(configJson, skipFsValidation = false) {
 			replicate: boolean.optional(),
 		}),
 		replication: Joi.object({
-			hostname: Joi.alternatives(string, number).optional().empty(null),
-			url: string.optional().empty(null),
+			hostname: bareHostConstraints,
+			url: nodeUrlConstraints,
 			port: portConstraints,
 			securePort: portConstraints,
 			routes: array.optional().empty(null),
@@ -262,6 +267,10 @@ export function configValidator(configJson, skipFsValidation = false) {
 			copyCursorFlushBytes: number.min(1).optional().empty(null),
 			copyCursorFlushIntervalMs: number.min(1).optional().empty(null),
 			replayTimeout: number.min(1).optional().empty(null),
+		}).optional(),
+		node: Joi.object({
+			hostname: bareHostConstraints,
+			url: string.optional().empty(null),
 		}).optional(),
 		componentsRoot: rootConstraints.optional(),
 		localStudio: Joi.object({
@@ -398,6 +407,36 @@ function doesPathExist(pathToCheck) {
 	}
 
 	return `Specified path ${pathToCheck} does not exist.`;
+}
+
+function validateBareHost(value, helpers) {
+	const violation = bareHostViolation(value);
+	if (violation) {
+		return helpers.message(
+			`{{#label}} ${violation}; it must be a bare hostname or IP literal (no scheme, port, or path) because it is this node's identity`
+		);
+	}
+	return value;
+}
+
+// A node URL supplies this node's identity via its host (server/nodeName.ts urlToNodeName), so it
+// must have an authority. A hostless scheme ("mailto:", "data:", "file:") parses but has no host.
+// A node URL supplies this node's identity via its host (server/nodeName.ts urlToNodeName). Only
+// reject the unambiguous mistake: a value written as a real URL (with a "//" authority) that still
+// parses to no host. Everything else is deliberately tolerated, because urlToNodeName skips a value
+// it cannot take a host from and identity falls through to another source — a scheme-less
+// "node1.example.com:9933" even parses as a *scheme*, so it is indistinguishable from "mailto:" here,
+// and rejecting that shape would turn a previously harmless config into a boot failure.
+function validateNodeUrl(value, helpers) {
+	if (!value.includes('//')) return value;
+	let host;
+	try {
+		host = new URL(value).hostname;
+	} catch {
+		return value; // unparseable — skipped at runtime, not worth failing the boot over
+	}
+	if (!host) return helpers.message('{{#label}} must be a URL with a host (e.g. "wss://node1.example.com:9933")');
+	return value;
 }
 
 function validatePath(value, helpers) {

--- a/validation/installValidator.ts
+++ b/validation/installValidator.ts
@@ -5,6 +5,7 @@ const { string, number } = Joi.types();
 import * as fs from 'fs-extra';
 import * as hdbTerms from '../utility/hdbTerms.ts';
 import * as path from 'path';
+import { bareHostViolation } from '../utility/nodeIdentity.ts';
 import * as validator from './validationWrapper.ts';
 
 export default installValidator;
@@ -22,9 +23,23 @@ function installValidator(param) {
 			null
 		),
 		[(hdbTerms.INSTALL_PROMPTS as any).TC_AGREEMENT]: string.valid('yes', 'YES', 'Yes'),
+		// Catch a bad node identity here rather than at first boot. This runs after the v5 migration
+		// copies REPLICATION_HOSTNAME into NODE_HOSTNAME, so an upgrade carrying a URL-ish value is
+		// reported during install with the same reason the config boundary would give (harper#2218).
+		[hdbTerms.INSTALL_PROMPTS.NODE_HOSTNAME]: Joi.custom(validateNodeHostname).allow('null', null),
 	});
 
 	return validator.validateBySchema(param, installSchema);
+}
+
+function validateNodeHostname(value, helpers) {
+	const violation = bareHostViolation(value);
+	if (violation) {
+		return helpers.message(
+			`{{#label}} ${violation}; it must be a bare hostname or IP literal (no scheme, port, or path) because it is this node's identity`
+		);
+	}
+	return value;
 }
 
 function validateRootAvailable(value, helpers) {


### PR DESCRIPTION
Enforce that this node's identity is a **bare hostname or IP literal** — not a URL, `host:port`, or non-string — at every configured source, and make IPv6 identities work end-to-end (canonical form, valid replication URLs, correct certificate SAN typing).

`node.hostname` (and the `replication.hostname` / certificate / listening address it falls back to) is this node's identity: it becomes the certificate common name (`security/keys.ts`) and the host replication advertises and dials (`hostnameToUrl`). A scheme, port, or non-string silently corrupts both — `hostnameToUrl` composes `ws://http://host:9926:9925`, whose parsed hostname is `http`, so the node advertises/dials a host literally named `http` with no error (#2218). Replaces the original warn-only PR after review by **@kriszyp** (replication/TLS domain expert) on this PR and #2219.

**What it does**
- **`utility/nodeIdentity.ts`** (new) — `bareHostViolation(value)`, the single predicate. Accepts a bare hostname or IPv4/IPv6 literal; rejects a scheme, port, path, credentials, non-string, bracketed IPv6 (`[::1]` — the identity is stored unbracketed), a scoped-zone IPv6 (`fe80::1%eth0`), and anything the `ws://` consumer would reject. It parses under a **special scheme** (`https://`) so its host grammar matches the actual replication-URL consumer (a non-special scheme is too lenient — it would pass `node%20`, `0x7f.1`, etc.).
- **`validation/configValidator.ts`** — rejects a URL/port/numeric `node.hostname` **and** `replication.hostname` at the config boundary (there was no `node` schema; `replication.hostname` previously accepted `string|number`). Config validation throws, so a bad identity **fails boot** with a clear message rather than starting known-broken. This is the loud enforcement.
- **`server/nodeName.ts` `getThisNodeName()`** — resolves to the first source that is a valid bare host and **skips** an empty, unusable, or malformed *derived* source (`replication.url` host, certificate CN, listening address). It never throws and never caches an empty identity; `127.0.0.1` is the always-valid floor. Identity is normalized to the **unbracketed** canonical form across sources (`getHostFromListeningPort` and `urlToNodeName` strip IPv6 brackets), so `net.isIP` types it as an **IP** certificate SAN and the same node's identity string is stable.
- **`validation/installValidator.ts`** — the same check runs at **install/upgrade** time on `NODE_HOSTNAME`. It sits right after the v5 migration copies `replication.hostname` into `node.hostname`, so an upgrade carrying a URL-ish value is reported during install instead of only failing at first boot.
- **Skipped sources now warn.** When the resolver ignores a malformed derived source it logs once, naming the source, value, and reason — a typo'd `replication.url` silently resolving identity to `127.0.0.1` was a diagnosis trap on a live cluster. A valid identity resolves silently.
- **`hostnameToUrl()`** — brackets a bare IPv6 literal for URL construction (`::1` → `ws://[::1]:port`); the unbracketed `ws://::1:port` is rejected by the URL parser.
- **`security/keys.ts`** — `getHost()` / `urlToNodeName` / `getCommonNameFromCert` are made fail-soft so a malformed `replication.url` or an unreadable cert file falls back instead of throwing during cert review.

Rejecting an invalid *configured* identity (rather than rewriting it) preserves the certificate common name — kriszyp's stated reason to prefer rejection.

**⚠️ Breaking:** an existing install whose `node.hostname`/`replication.hostname` is a URL, `host:port`, or non-string now **fails to boot** until corrected to a bare host — **needs a release note.** The v5 install migration (`installer.ts` copies `replication.hostname → node.hostname`) can carry such a value into `node.hostname` on upgrade, so per @ldt1996's review that case is now caught at **install time** with the same clear reason, rather than surfacing only at first boot. (My own local dev config had exactly this and was correctly rejected.)

## For the human reviewer

The change grew from a warning into a node-identity validation subsystem after kriszyp's review, and it touches TLS cert generation, so it went through several cross-model review rounds. The judgment calls:

1. **Loud at the config boundary, soft in the resolver.** An invalid `node.hostname`/`replication.hostname` fails boot (kriszyp's ask). `getThisNodeName` deliberately does **not** throw — an earlier revision that threw could crash a request-time caller on a descriptive cert CN, so the resolver skips-and-falls-through while the boundary rejects. Per @ldt1996's review the resolver now also *warns* whenever it skips a source, so the fall-through is visible without being fatal.
2. **IPv6 identity is stored unbracketed** (`::1`), bracketed only for URL construction, so `net.isIP` types the cert SAN as IP and sources agree. `::1:9925` is accepted as a distinct valid IPv6 (not `::1` + port) — inherent to IPv6 syntax, no clean way to disambiguate intent.
3. **Breaking-change scope** (⚠️ above) — deliberate per "prevent a known-broken startup"; the release-note call is yours.
4. **Deferred to follow-ups (surfaced by review, not done here):**
   - **Bare-IPv6-*literal* identity has a cert `secureContexts` lookup gap** — filed as #2261 (P2, under epic #1674): contexts are keyed by OpenSSL's *expanded* SAN text (`2001:DB8:0:0:0:0:0:1`) while `getThisNodeName` returns the *compact* form, so `secureContexts.get()` misses. Pre-existing cert infrastructure this change *exposes* by making IPv6 identities viable.
   - A malformed `replication.url` double-URL (`ws://http://host…` → host `http`) still slips (ambiguous; `replication.url` is a URL by design); the packaged JSON schema isn't yet synced with the runtime schema.

### Rebased onto merged #2219

This now sits on top of #2219, and the two compose well: identity stays the **unbracketed** canonical form (so `net.isIP` types the cert SAN as an IP), while #2219's `nodeNameToDisplayHost` brackets it for display — so the startup banner renders a parseable `http://[::1]:9926/`. That closes the IPv6-banner gap earlier review rounds flagged against this PR, and no longer needs a follow-up.

I did have to update two of #2219's tests, and one of its assertions no longer describes reachable behavior: they set `node.hostname` to a URL and expected the banner to show the *normalized* host (`localhost`). Such a value is now rejected at the config boundary and skipped during resolution, so it never reaches the banner — the banner shows the fallback identity instead, with a warning explaining why. #2219's real regression guard (no `http://http://` double-wrap) is kept and strengthened: the banner's URLs must now all actually parse, and a bare IPv6 `node.hostname` is asserted to render bracketed. Flagging it because those tests are two days old — @kriszyp / @ldt1996, tell me if you'd rather keep the old expectation and soften the resolver instead.

Addresses kriszyp's inline comments on `nodeName.ts:32` (validate every source; falsy non-strings; the fallback) and `:85` (`net.isIP` + bracket IPv6; reject parse failures; test the constructed URL).

## Verification

- **Route (c) — behavior via unit + boundary tests** (all run locally on Node 24):
  - `unitTests/utility/nodeIdentity.test.js` (34): the predicate accepts every valid host shape (hostname, IPv4, IPv6) and rejects scheme/port/path/creds/non-string/bracketed/scoped-IPv6/`node%20`/alt-IPv4-forms — **no false-positive on a valid identity** (a false-positive would break boot).
  - `unitTests/server/nodeName.test.js` (34, including #2219's display tests): `getThisNodeName` returns a valid bare identity, falls through, never caches empty, skips an unusable/malformed derived source without throwing, and yields the **unbracketed** IPv6 identity from both a bracketed listen address and a `replication.url` IPv6 host; `hostnameToUrl('::1')` composes the parseable `ws://[::1]:9933`.
  - `unitTests/validation/configValidator.test.js` (+2) and `installValidator.test.js` (+2): a URL/port/numeric `node.hostname` and `replication.hostname` are rejected with a clear message; bare host and `::1` accepted.
- `unitTests/bin/startupBanner.test.js` (4): no double-wrapped scheme, every banner URL parses, and a bare IPv6 `node.hostname` renders bracketed.
- `tsc` build, `oxlint`/`lint:required`, and `prettier` clean. The `bin`, `validation`, `utility`, and `security` suites were run after the rebase; `bin` is now 220 passing / 0 failing.
- **Full `test:unit:main` cannot run locally** — it dies at load on the RocksDB `LOCK` held by my running local Harper instance (known limitation; run targeted files). CI runs the full matrix. Two unrelated pre-existing failures noted: a path-length-dependent domain-socket test-isolation flake in the validation suite, and two `scopedImport`/compartment tests in the security suite — both fail identically on the base commit.

## Review coverage

Authored by Claude Opus 4.8/5. Reviewed across ten cross-model rounds as the design was reworked from @kriszyp's feedback and each round's findings were fixed. The graded opposite-family leg was **`codex` (`gpt-5.6-sol`)**, joined on the rounds their tooling was available by **`gemini` via agy (default model)**, **Cursor Grok (`cursor-grok-4.5-high`)** and **Composer (`composer-2.5`)**. Blockers fell 3 → 1 → 0 and stayed at 0; the final round's verdict names no blocker or major, and confirms the earlier over-reach fixes (the `ws+unix:` finding is dropped, and the `node.url` / scheme-less-URL / post-unbracket concerns are fixed or non-reproducible). Honest gaps: on the **last few rounds only `codex` ran** — Gemini hit its quota and both Cursor legs failed on a local SSH-agent signing error — and the **Harper domain-adjudication leg crashed on every round**, so outside findings were author-adjudicated rather than machine-filtered. Two human reviews on the current code: @ldt1996 approved and traced the predicate's edge cases (her three asks and nit are implemented here), and @kriszyp's empty-hostname finding is fixed. The last review ran on `b2c02c6850e2`; the pushed commit adds **only test changes** on top of it (production code is byte-identical — verified with `git diff`), which is why the footer's receipt SHA is newer than the reviewed one. Grade 4 is the deterministic floor for a high-risk `security/keys.ts` surface with unadjudicated findings, not a mandatory-finding grade.

<sub>Review-Coverage: authored=unknown; ran=none; rounds=1 @ 0692c49ecd8d</sub>

<sub>Human-Review-Need: 4 @ 0692c49ecd8d</sub>
