### PR TITLE
Keep reads working when storage.debugLongTransactions is enabled

### DIFF
--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -418,7 +418,12 @@ export class DatabaseTransaction implements Transaction {
 
 	useReadTxn(disableSnapshot?: boolean) {
 		const readTxn = this.getReadTxn(disableSnapshot);
-		if (DEBUG_LONG_TXNS) this.stackTraces.push(new StartedTransaction());
+		// Only getReadTxn's fresh-handle branch seeds stackTraces, so it is still undefined when the
+		// handle was adopted by save() or was never opened at all (issue #2222). Trace only a real
+		// handle: without one the transaction is never added to trackedTxns, so the monitor has nothing
+		// to dump the traces for, and an ImmediateTransaction (whose getReadTxn never returns one)
+		// would accumulate them for its lifetime.
+		if (DEBUG_LONG_TXNS && readTxn) (this.stackTraces ??= []).push(new StartedTransaction());
 		this.readTxnsUsed++;
 		return readTxn;
 	}

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -418,12 +418,13 @@ export class DatabaseTransaction implements Transaction {
 
 	useReadTxn(disableSnapshot?: boolean) {
 		const readTxn = this.getReadTxn(disableSnapshot);
-		// Only getReadTxn's fresh-handle branch seeds stackTraces, so it is still undefined when the
-		// handle was adopted by save() or was never opened at all (issue #2222). Trace only a real
-		// handle: without one the transaction is never added to trackedTxns, so the monitor has nothing
-		// to dump the traces for, and an ImmediateTransaction (whose getReadTxn never returns one)
-		// would accumulate them for its lifetime.
-		if (DEBUG_LONG_TXNS && readTxn) (this.stackTraces ??= []).push(new StartedTransaction());
+		// stackTraces is seeded by the same getReadTxn branch that registers the transaction with
+		// trackedTxns, so its presence means the monitor can actually dump what is pushed here. A
+		// transaction that reached this point any other way — handle adopted by save(), past OPEN, or an
+		// ImmediateTransaction, whose getReadTxn never returns a handle — is untracked, and pushing to
+		// the array it never got threw (issue #2222). Capturing an Error per read that nothing can dump
+		// is not worth doing either, so those reads stay untraced.
+		if (DEBUG_LONG_TXNS && this.stackTraces) this.stackTraces.push(new StartedTransaction());
 		this.readTxnsUsed++;
 		return readTxn;
 	}

--- a/unitTests/resources/debugLongTransactionsReads.test.js
+++ b/unitTests/resources/debugLongTransactionsReads.test.js
@@ -31,6 +31,15 @@ describe('harper#2222 debugLongTransactions reads', function () {
 		const txn = new DatabaseTransaction();
 		txn.transaction = { openTimer: 0 }; // what save() assigns when a write opens the handle first
 		assert.strictEqual(txn.useReadTxn(), txn.transaction);
+		// Untracked, so a trace here could never be dumped.
+		assert.strictEqual(txn.stackTraces, undefined);
+	});
+
+	it('still traces a read on a transaction getReadTxn registered with the monitor', function () {
+		const txn = new DatabaseTransaction();
+		txn.transaction = { openTimer: 0 };
+		txn.stackTraces = []; // seeded by getReadTxn alongside trackedTxns.add
+		txn.useReadTxn();
 		assert.strictEqual(txn.stackTraces.length, 1);
 	});
 

--- a/unitTests/resources/debugLongTransactionsReads.test.js
+++ b/unitTests/resources/debugLongTransactionsReads.test.js
@@ -1,0 +1,50 @@
+/**
+ * harper#2222 — with `storage.debugLongTransactions: true`, useReadTxn() must not throw on a
+ * transaction whose read handle did not come from getReadTxn()'s fresh-handle branch. search() is
+ * its only caller, which is why the existing debugLongTransactions suites never covered it.
+ */
+const assert = require('node:assert');
+const env = require('#src/utility/environment/environmentManager');
+const { CONFIG_PARAMS } = require('#src/utility/hdbTerms');
+
+describe('harper#2222 debugLongTransactions reads', function () {
+	const modulePath = require.resolve('#src/resources/DatabaseTransaction');
+	let DatabaseTransaction, ImmediateTransaction, TRANSACTION_STATE, priorFlag, sharedModule;
+
+	before(function () {
+		priorFlag = env.get(CONFIG_PARAMS.STORAGE_DEBUGLONGTRANSACTIONS);
+		env.setProperty(CONFIG_PARAMS.STORAGE_DEBUGLONGTRANSACTIONS, true);
+		// The flag is captured in a load-time const, so this needs its own copy of the module. The
+		// shared one goes back afterwards: it owns the trackedTxns set and the long-transaction
+		// monitor that other suites drive.
+		sharedModule = require.cache[modulePath];
+		delete require.cache[modulePath];
+		({ DatabaseTransaction, ImmediateTransaction, TRANSACTION_STATE } = require(modulePath));
+	});
+
+	after(function () {
+		env.setProperty(CONFIG_PARAMS.STORAGE_DEBUGLONGTRANSACTIONS, priorFlag);
+		require.cache[modulePath] = sharedModule;
+	});
+
+	it('reads through a handle the transaction adopted outside getReadTxn()', function () {
+		const txn = new DatabaseTransaction();
+		txn.transaction = { openTimer: 0 }; // what save() assigns when a write opens the handle first
+		assert.strictEqual(txn.useReadTxn(), txn.transaction);
+		assert.strictEqual(txn.stackTraces.length, 1);
+	});
+
+	it('reads on an ImmediateTransaction (getReadTxn returns no handle)', function () {
+		const txn = new ImmediateTransaction({});
+		assert.strictEqual(txn.useReadTxn(), undefined);
+		// No handle means the monitor never tracks it, so traces would only accumulate unread.
+		assert.strictEqual(txn.stackTraces, undefined);
+	});
+
+	it('reads on a transaction that is no longer open', function () {
+		const txn = new DatabaseTransaction();
+		txn.open = TRANSACTION_STATE.CLOSED;
+		assert.strictEqual(txn.useReadTxn(), undefined);
+		assert.strictEqual(txn.stackTraces, undefined);
+	});
+});


### PR DESCRIPTION
Enabling `storage.debugLongTransactions` no longer breaks reads: with the flag on, any `search()` whose transaction did not open its own read handle threw `TypeError: Cannot read properties of undefined (reading 'push')` and returned a 500 (#2222). `useReadTxn()` recorded a stack trace unconditionally, but only `getReadTxn()`'s fresh-handle branch ever created the array it pushed onto — so a handle adopted by `save()`, a transaction past `OPEN`, or an `ImmediateTransaction` (whose `getReadTxn()` never returns a handle) crashed the read. The diagnostic broke exactly the reads an operator turns it on to diagnose.

Unresolved from review: the cross-model legs and I could not reproduce the reported 500 through an HTTP request — see Verification — so this is pinned at the unit level, not end-to-end. The adjudicator also surfaced a pre-existing, flag-independent gap in the same area (`save()`'s adopt branch seeds none of the per-handle bookkeeping `getReadTxn()` establishes, so `readTxnsUsed` goes `undefined++` → `NaN`); filed separately as #2224 rather than folded in here, because seeding it changes refcount and long-transaction-monitor semantics.

## For the human reviewer

1. **Fix at the read site, not the adopt site** (`fix-layer-read-site-vs-adopt-site`). The broken invariant is that `getReadTxn()`'s fresh branch establishes three things together — `readTxnsUsed = 1`, `trackedTxns.add(this)`, `stackTraces = [...]` — and `save()`'s adopt branch establishes none. Seeding all three in `save()` would fix this crash and the `NaN` refcount at once, but it also puts write-first transactions under the long-transaction monitor for the first time (they'd become abortable per #1407) and changes what `doneReadTxn()`'s refcount means. That is a semantic change I'm not willing to make as a drive-by on a crash fix, so this PR guards the read site and #2224 carries the root fix. Say the word if you'd rather have them together.
2. **Trace only reads the monitor can dump** (`traces-only-with-a-handle`). The guard is on `this.stackTraces`, not on the returned handle: the array is seeded by the same `getReadTxn()` branch that does `trackedTxns.add(this)`, so its presence marks a transaction whose traces the monitor can actually dump. Untracked reads (adopted handle, `ImmediateTransaction`, closed transaction) capture nothing rather than paying an `Error` per read that nothing reads. I originally guarded on the handle so adopted handles would keep collecting traces in case they later became tracked; [#2224](https://github.com/HarperFast/harper/issues/2224) would seed all three pieces of bookkeeping together, so tracing resumes on its own and the extra collection buys nothing. Changed in response to the `gemini-code-assist` review — thread resolved.
3. **Unit coverage only** (`unit-only-scope`, `require-cache-eviction-as-the-test-seam`). Four cases: three that crash on `origin/main` with the reported `TypeError`, plus a positive control proving a monitor-registered transaction is still traced. The test flips the load-time `DEBUG_LONG_TXNS` const by re-requiring the module with its own cache record and restoring the shared one, rather than exporting a new test seam next to `setTxnExpiration`. A seam is API once exported; the trade is one idle `unref()`ed monitor timer per run over an empty set. If you'd rather have the seam, it's a small change.

## Verification

- New unit test `unitTests/resources/debugLongTransactionsReads.test.js` pins the three crash shapes plus a positive control, and the three crash cases fail on `origin/main` sources (rebuilt `dist`, not incremental) with the exact reported error and frame: `TypeError: Cannot read properties of undefined (reading 'push')` at `DatabaseTransaction.useReadTxn (resources/DatabaseTransaction.ts:421:41)` — including `ImmediateTransaction.useReadTxn`, the frame in the issue report. 3 failing + 1 passing control before, 4 passing after.
- End-to-end route attempted and **not** achieved: I booted Harper with `storage.debugLongTransactions: true` and drove 12 request shapes against it (REST collection query, REST GET with `select`, relationship serialization in both directions, static `search()` with and without a context, write-then-search in one request transaction, cross-table write-then-search, SQL `SELECT ... WHERE`, `search_by_value`) — all returned 200. Every one of those opens its read handle through `getReadTxn()`'s fresh branch, which seeds `stackTraces`. Reaching `useReadTxn()` with an unseeded array needs the context's transaction reference to be released between `transactional()`'s `open === OPEN` check and `txnForContext()`, which I could not force deterministically from a fixture. The reporter's stack frame (`ImmediateTransaction.useReadTxn`) is reproduced directly in the unit test instead.
- `npm run test:unit:resources` — 1587 passing, 0 failing.
- `npm run test:integration` on the three suites that run with `debugLongTransactions: true` (`longtxn-secondary-index`, `eviction-secondary-index`, `txn-overtime-atomicity`) — 7 pass, 0 fail.
- `npm run test:unit:main` could not run on this machine: a stale mocha process (17 days old) holds `~/harper/database/system/LOCK`, so the suite dies at module load before any test. Unrelated to this change; CI runs the gate.
- `npm run typecheck`, `npm run lint:required`, `prettier --check` all clean.

Complexity: easy

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=4 @ 2bf62cd6513d</sub>

<sub>Human-Review-Need: 3 @ 2bf62cd6513d</sub>
