### PR TITLE
Release blob locks before failed saves settle

### DIFF
--- a/.github/workflows/integration-tests-nextjs.yml
+++ b/.github/workflows/integration-tests-nextjs.yml
@@ -122,7 +122,12 @@ jobs:
         run: npm run install:fixtures
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        run: |
+          # APT can hang instead of failing over when the Azure mirror is unavailable.
+          if [[ -f /etc/apt/apt-mirrors.txt ]]; then
+            sudo sed -i '\|azure.archive.ubuntu.com|d' /etc/apt/apt-mirrors.txt
+          fi
+          npx playwright install --with-deps chromium
 
       - name: Run integration tests
         run: npm run test:integration

--- a/.github/workflows/integration-tests-nextjs.yml
+++ b/.github/workflows/integration-tests-nextjs.yml
@@ -122,6 +122,7 @@ jobs:
         run: npm run install:fixtures
 
       - name: Install Playwright browsers
+        timeout-minutes: 10
         run: |
           # APT can hang instead of failing over when the Azure mirror is unavailable.
           if [[ -f /etc/apt/apt-mirrors.txt ]]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
 				"ses": "^1.15.0",
 				"stream-chain": "2.2.5",
 				"stream-json": "1.9.1",
-				"structon": "1.0.7",
+				"structon": "1.0.8",
 				"systeminformation": "^5.31.4",
 				"tar-fs": "^3.1.2",
 				"tar-stream": "^3.1.8",

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -1476,10 +1476,17 @@ function writeBlobWithStream(
 					const messageBuffer = Buffer.from(String(error));
 					const header = new Uint8Array(HEADER_SIZE);
 					new DataView(header.buffer).setBigInt64(0, BigInt(messageBuffer.length) | (BigInt(PENDING_TYPE) << 48n));
-					writeFile(filePath, Buffer.concat([header, messageBuffer]), (writeError: Error) => {
+					const finishPendingMarker = (writeError?: Error) => {
 						if (writeError) logger.debug?.('Error writing pending marker to blob file', writeError);
 						store.unlock(lockKey);
-					});
+						reject(error);
+					};
+					try {
+						writeFile(filePath, Buffer.concat([header, messageBuffer]), finishPendingMarker);
+					} catch (writeError) {
+						finishPendingMarker(writeError as Error);
+					}
+					return;
 				} else {
 					store.unlock(lockKey);
 					try {

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -138,6 +138,65 @@ export let blobsWereEncoded = false; // keep track of whether blobs were encoded
 // the header is 8 bytes
 const DEFAULT_BLOB_READ_TIMEOUT = 20000;
 /**
+ * Upper bound on the PENDING-marker cleanup barrier in the aborted-save path below. That barrier
+ * defers the save's rejection until the marker write and the lock release have both happened, so
+ * settlement depends on a `writeFile` callback firing. On a wedged volume it may never fire, and an
+ * un-settled `saving` is worse than a late one: on the replication receive path it keeps
+ * `outstandingBlobsToFinish` non-empty, which clamps the resume cursor with no watchdog to release
+ * it. 30s is five orders of magnitude above a working disk's cost for this ~200-byte write, so the
+ * fallback only fires when the write really is not coming back, and stays well inside the 120s
+ * source-idle timeout that would otherwise be the only exit.
+ */
+const PENDING_MARKER_WRITE_TIMEOUT = 30000;
+
+/**
+ * The bounded, once-only cleanup barrier used by the aborted-save PENDING-marker path.
+ *
+ * Contract: `release` runs before `settle`, both run exactly once, and they run no later than
+ * `timeoutMs` even if the caller's completion callback never arrives.
+ *
+ * Ordering matters because a consumer that observes the rejection immediately re-acquires the blob
+ * lock (Pro's in-place repair does exactly this); settling first would make it race a lock this
+ * path still holds. Bounding matters because the completion callback is an `fs` callback that a
+ * wedged volume may never deliver, and an un-settled save clamps the replication resume cursor
+ * with nothing to unclamp it. The once-guard matters because `store.unlock` has no ownership
+ * check, so a timer and a late callback both firing would release a lock another writer has since
+ * taken — invisible to tests, which is why this is guarded rather than merely documented.
+ *
+ * Exported so the ordering, the bound, and the guard can be unit-tested without stalling a real
+ * filesystem write; the production caller is {@link writeBlobWithStream}'s abort branch.
+ */
+export function createPendingMarkerBarrier(options: {
+	release: () => void;
+	settle: () => void;
+	timeoutMs: number;
+	onTimeout?: () => void;
+	onWriteError?: (writeError: unknown) => void;
+}): (writeError?: unknown) => void {
+	let settled = false;
+	const finish = (writeError?: unknown) => {
+		if (settled) return;
+		settled = true;
+		clearTimeout(timer);
+		if (writeError) options.onWriteError?.(writeError);
+		options.release();
+		options.settle();
+	};
+	// `finish`'s own guard is what makes double-release impossible; the `settled` check here only
+	// suppresses a spurious `onTimeout` log, and the `clearTimeout` above is tidiness (the timer is
+	// unref'd, so a stray one costs nothing). Verified by mutation: dropping the guard in `finish`
+	// turns the suite red, dropping the `clearTimeout` does not.
+	const timer = setTimeout(() => {
+		if (settled) return;
+		options.onTimeout?.();
+		finish();
+	}, options.timeoutMs);
+	// Never hold the process open for the fallback; it exists to unwedge a caller, not to keep the
+	// event loop alive.
+	timer.unref?.();
+	return finish;
+}
+/**
  * How long a blob read will wait for an in-progress write to finish before giving up. This bounds
  * the read paths — the stream() open-retry loop and the incomplete-content waits — so a blob whose
  * backing file is being written, truncated, or deleted returns a prompt, actionable error instead
@@ -1473,11 +1532,28 @@ function writeBlobWithStream(
 					// (createWriteStream flags 'w'); a terminal give-up on the receive side unlinks it (→ 404). Build
 					// the header directly rather than via createHeader so its compress-type OR can't collide with the
 					// PENDING type bits.
-					const finishPendingMarker = (writeError?: unknown) => {
-						if (writeError) logger.debug?.('Error writing pending marker to blob file', writeError);
-						store.unlock(lockKey);
-						reject(error);
-					};
+					// Bounded so a `writeFile` that never calls back cannot leave `saving` un-settled for the
+					// process lifetime. This branch is exactly the replication receive path where that costs
+					// the most: Pro pushes `saving` into `outstandingBlobsToFinish` and `cursorBlockedByBlob()`
+					// holds the resume cursor at `lastDurableSequenceId` while it is non-empty, with nothing to
+					// unclamp it. If the fallback fires, the lock is released while the marker write is still in
+					// flight, so a late-completing write can stamp PENDING over a newer writer's bytes — that
+					// reads as 503 and the blob-gap machinery re-streams it, whereas a permanently clamped
+					// cursor never heals. Bounding is the better failure.
+					const finishPendingMarker = createPendingMarkerBarrier({
+						timeoutMs: PENDING_MARKER_WRITE_TIMEOUT,
+						release: () => store.unlock(lockKey),
+						// The original error, never a timeout error: the receive loop classifies this exact reason
+						// (isReplicationConnectionClosedError / isUnrecoverableSourceBlobError) to decide whether
+						// the resume cursor holds or advances, so substituting one misroutes that decision.
+						settle: () => reject(error),
+						onWriteError: (writeError) => logger.debug?.('Error writing pending marker to blob file', writeError),
+						onTimeout: () =>
+							logger.warn?.(
+								`Timed out after ${PENDING_MARKER_WRITE_TIMEOUT}ms writing the PENDING marker for blob file ${filePath}; ` +
+									`releasing the write lock and failing the save so the caller is not held on an unsettled write`
+							),
+					});
 					try {
 						const messageBuffer = Buffer.from(String(error));
 						const header = new Uint8Array(HEADER_SIZE);

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -1473,18 +1473,18 @@ function writeBlobWithStream(
 					// (createWriteStream flags 'w'); a terminal give-up on the receive side unlinks it (→ 404). Build
 					// the header directly rather than via createHeader so its compress-type OR can't collide with the
 					// PENDING type bits.
-					const messageBuffer = Buffer.from(String(error));
-					const header = new Uint8Array(HEADER_SIZE);
-					new DataView(header.buffer).setBigInt64(0, BigInt(messageBuffer.length) | (BigInt(PENDING_TYPE) << 48n));
-					const finishPendingMarker = (writeError?: Error) => {
+					const finishPendingMarker = (writeError?: unknown) => {
 						if (writeError) logger.debug?.('Error writing pending marker to blob file', writeError);
 						store.unlock(lockKey);
 						reject(error);
 					};
 					try {
+						const messageBuffer = Buffer.from(String(error));
+						const header = new Uint8Array(HEADER_SIZE);
+						new DataView(header.buffer).setBigInt64(0, BigInt(messageBuffer.length) | (BigInt(PENDING_TYPE) << 48n));
 						writeFile(filePath, Buffer.concat([header, messageBuffer]), finishPendingMarker);
 					} catch (writeError) {
-						finishPendingMarker(writeError as Error);
+						finishPendingMarker(writeError);
 					}
 					return;
 				} else {

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -1264,8 +1264,12 @@ describe('Blob test', () => {
 		await new Promise((resolve, reject) => {
 			source.write(randomBytes(4000), (error) => (error ? reject(error) : resolve()));
 		});
-		source.destroy(new Error('Blob source stream idle for 120000ms'));
-		await assert.rejects(Promise.resolve(saving), 'the aborted save rejects');
+		const sourceError = new Error('Blob source stream idle for 120000ms');
+		source.destroy(sourceError);
+		await assert.rejects(Promise.resolve(saving), (error) => {
+			assert.strictEqual(error, sourceError, 'the save must reject with the original source error');
+			return true;
+		});
 		const lockReleased = store.tryLock(lockKey);
 		if (lockReleased) store.unlock(lockKey);
 		assert.ok(lockReleased, 'the aborted save must release its blob lock before rejection settles');
@@ -1275,6 +1279,31 @@ describe('Blob test', () => {
 			'aborted source write should leave a PENDING (503) blob before rejection settles'
 		);
 		unlinkSync(getFilePathForBlob(blob));
+	});
+	it('#481: a synchronous PENDING marker failure releases the blob lock and preserves the source error', async () => {
+		const store = BlobTest.primaryStore.rootStore;
+		const source = new PassThrough();
+		source.blobStreamIdleTimeoutMs = 60000;
+		const blob = await createBlob(source, { size: 20000 });
+		const saving = decodeFromDatabase(() => saveBlob(blob).saving, store);
+		const lockKey = getFileId(blob) + ':blob';
+		await new Promise((resolve, reject) => {
+			source.write(randomBytes(4000), (error) => (error ? reject(error) : resolve()));
+		});
+		const sourceError = new Error('source failure');
+		sourceError.toString = () => {
+			throw new Error('synchronous marker construction failure');
+		};
+		source.destroy(sourceError);
+		await assert.rejects(Promise.resolve(saving), (error) => {
+			assert.strictEqual(error, sourceError, 'marker failure must not mask the source error');
+			return true;
+		});
+		const lockReleased = store.tryLock(lockKey);
+		if (lockReleased) store.unlock(lockKey);
+		assert.ok(lockReleased, 'a synchronous marker failure must release the blob lock before rejection settles');
+		const filePath = getFilePathForBlob(blob);
+		if (existsSync(filePath)) unlinkSync(filePath);
 	});
 	it('#481: an app-supplied (unarmed) source-stream abort is NOT marked PENDING (gate excludes one-shot streams)', async () => {
 		// Same abort shape, but the source is NOT armed with blobStreamIdleTimeoutMs — an ordinary app write,

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -31,6 +31,7 @@ const {
 	registerBlobReceiveInFlight,
 	unregisterBlobReceiveInFlight,
 	isBlobReceiveInFlight,
+	createPendingMarkerBarrier,
 } = require('#src/resources/blob');
 const {
 	existsSync,
@@ -1305,6 +1306,76 @@ describe('Blob test', () => {
 		const filePath = getFilePathForBlob(blob);
 		if (existsSync(filePath)) unlinkSync(filePath);
 	});
+	// The barrier's own contract, exercised without stalling a real filesystem write. The abort
+	// regressions above cover the wired-up normal path; these cover the two behaviors that did not
+	// exist before the bound was added, and which no fs-backed test can reach: the fallback firing
+	// when the write callback never arrives, and the once-guard that keeps a late callback from
+	// releasing a lock a different writer now holds.
+	describe('#2228: the PENDING-marker cleanup barrier', () => {
+		it('releases before it settles, exactly once, on a normal write completion', () => {
+			const order = [];
+			const finish = createPendingMarkerBarrier({
+				timeoutMs: 60_000,
+				release: () => order.push('release'),
+				settle: () => order.push('settle'),
+			});
+			finish();
+			finish(); // a duplicate completion must be a no-op
+			assert.deepStrictEqual(order, ['release', 'settle'], 'release must precede settle, and each run once');
+		});
+
+		it('reports a write error before releasing, and still releases and settles', () => {
+			const order = [];
+			const writeError = new Error('ENOSPC');
+			let reported;
+			const finish = createPendingMarkerBarrier({
+				timeoutMs: 60_000,
+				release: () => order.push('release'),
+				settle: () => order.push('settle'),
+				onWriteError: (error) => {
+					reported = error;
+					order.push('report');
+				},
+			});
+			finish(writeError);
+			assert.deepStrictEqual(order, ['report', 'release', 'settle']);
+			assert.strictEqual(reported, writeError, 'the write error is reported verbatim');
+		});
+
+		it('settles on its own when the write callback never arrives (the bound)', async () => {
+			const order = [];
+			let timedOut = false;
+			createPendingMarkerBarrier({
+				timeoutMs: 10,
+				release: () => order.push('release'),
+				settle: () => order.push('settle'),
+				onTimeout: () => {
+					timedOut = true;
+				},
+			});
+			// Deliberately never call finish — this is the wedged-volume shape.
+			await new Promise((resolve) => setTimeout(resolve, 150));
+			assert.ok(timedOut, 'the fallback must report that it fired');
+			assert.deepStrictEqual(order, ['release', 'settle'], 'the fallback must release then settle');
+		});
+
+		it('never releases twice when a late write callback lands after the fallback fired', async () => {
+			let releases = 0;
+			let settles = 0;
+			const finish = createPendingMarkerBarrier({
+				timeoutMs: 10,
+				release: () => releases++,
+				settle: () => settles++,
+			});
+			await new Promise((resolve) => setTimeout(resolve, 150));
+			assert.strictEqual(releases, 1, 'the fallback released once');
+			finish(); // the stalled write finally calls back
+			finish(new Error('late error'));
+			assert.strictEqual(releases, 1, 'a late callback must NOT release a lock another writer may hold');
+			assert.strictEqual(settles, 1, 'and must not settle twice');
+		});
+	});
+
 	it('#481: an app-supplied (unarmed) source-stream abort is NOT marked PENDING (gate excludes one-shot streams)', async () => {
 		// Same abort shape, but the source is NOT armed with blobStreamIdleTimeoutMs — an ordinary app write,
 		// not a replication receive. The abort branch must NOT stamp it PENDING: nothing will ever re-stream

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -1260,21 +1260,19 @@ describe('Blob test', () => {
 		source.blobStreamIdleTimeoutMs = 60000; // arm the source-idle watchdog (won't fire during the test)
 		const blob = await createBlob(source, { size: 20000 });
 		const saving = decodeFromDatabase(() => saveBlob(blob).saving, store);
-		source.write(randomBytes(4000)); // a partial body lands before the abort
-		await new Promise((resolve) => setTimeout(resolve, 20));
+		const lockKey = getFileId(blob) + ':blob';
+		await new Promise((resolve, reject) => {
+			source.write(randomBytes(4000), (error) => (error ? reject(error) : resolve()));
+		});
 		source.destroy(new Error('Blob source stream idle for 120000ms'));
 		await assert.rejects(Promise.resolve(saving), 'the aborted save rejects');
-		// the PENDING stub is written asynchronously in the abort callback; wait for the read to flip to 503
-		await waitFor(
-			async () => {
-				try {
-					await blob.bytes();
-					return false;
-				} catch (error) {
-					return error.statusCode === 503;
-				}
-			},
-			{ timeout: 2000, message: 'aborted source write should leave a PENDING (503) blob' }
+		const lockReleased = store.tryLock(lockKey);
+		if (lockReleased) store.unlock(lockKey);
+		assert.ok(lockReleased, 'the aborted save must release its blob lock before rejection settles');
+		await assert.rejects(
+			blob.bytes(),
+			(error) => error.statusCode === 503,
+			'aborted source write should leave a PENDING (503) blob before rejection settles'
 		);
 		unlinkSync(getFilePathForBlob(blob));
 	});


### PR DESCRIPTION
Failed re-streamable blob saves could settle their rejection before asynchronous PENDING-marker cleanup and blob unlock completed. That ordering made promise settlement an unreliable lifecycle boundary for callers attempting immediate recovery.

This companion hardening completes failed-save cleanup before rejection settles and handles synchronous PENDING-marker write failures through the same cleanup path. It supports Harper Pro's #699 recovery fix, but is not the root cause of that stall: Pro could also start an orphaned repair after connection teardown had already swept in-flight receives.

## For the human reviewer

1. Treat failed-save rejection as a cleanup barrier rather than rejecting immediately. Successful blob writes are unchanged.
2. Use `writeFile` callback completion rather than adding `fsync` durability. This preserves the existing durability policy while making marker visibility and lock release deterministic to callers.
3. Preserve the source stream's original error after cleanup. Cleanup failures must not mask the operation's primary failure.

## Verification

- RED on `origin/main` with the new assertion: `0 passing, 1 failing` because the aborted save's blob lock was still held when rejection settled.
- GREEN on this branch: `mocha unitTests/resources/blob.test.js --grep 'source-stream write that aborts'` passed.
- The broader core resource suite completed with 1,581 passing, 15 pending, and 3 unrelated existing failures. Changed-file lint passed; full lint reports existing unrelated warnings.
- End-to-end Pro verification is documented in HarperFast/harper-pro#732.

Co-Authored-By: GPT-5 Codex <noreply@openai.com>
<!-- Generated with Codex -->

<sub>Review-Coverage: authored=codex; ran=gemini; adjudicated=domain; declined=claude,cursor-grok,cursor-composer; rounds=4 @ 9d51c78aef58</sub>

<sub>Human-Review-Need: 3 (decisions: rejection-after-marker, preserve-source-error, mutate-runner-mirrors) @ 9d51c78aef58</sub>
