### PR TITLE
fix(txn): keep context.transaction usable after its transaction completes

### DIFF
--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -1196,14 +1196,12 @@ export class ImmediateTransaction extends DatabaseTransaction {
  * What `context.transaction` holds once its transaction has completed and released the back-reference
  * (see releaseContext()). `commit()`/`abort()` are no-ops and reads through it see the latest
  * committed state, so the documented `getContext().transaction.commit()` pattern stays callable after
- * completion; `txnTime: 0` is the one thing it cannot report faithfully, since nothing is staged and no
- * timestamp was taken.
+ * completion, reporting the same `txnTime: 0` that re-committing the completed transaction itself did
+ * (its own timestamp is reset by the commit that completed it).
  *
- * Deliberately NOT a DatabaseTransaction subclass, and deliberately not extensible. It is one
- * process-wide instance shared by every released context — so it must own no mutable state at all, and
- * anything not on this exact surface must fail loudly rather than inherit behavior that would write
- * through to every other context. That is also why the surface is this small: these are the only
- * members any core reader of `context.transaction` touches (`txnForContext` maps it to absent first).
+ * Not a DatabaseTransaction subclass and not extensible: one process-wide instance shared by every
+ * released context owns no mutable state, and anything off this surface fails loudly rather than
+ * inheriting behavior that would write through to every other context.
  */
 const RELEASED_TRANSACTION_SURFACE = {
 	open: TRANSACTION_STATE.CLOSED,
@@ -1235,6 +1233,15 @@ const RELEASED_TRANSACTION_SURFACE = {
 };
 Object.freeze(RELEASED_TRANSACTION_SURFACE);
 export const RELEASED_TRANSACTION = RELEASED_TRANSACTION_SURFACE as unknown as DatabaseTransaction;
+
+/**
+ * The placeholder means "this context has no transaction". Every reader that would otherwise act on the
+ * value — claim it for a store, adopt it as a context, treat it as data — must ask first, or it operates
+ * on the one instance every released context shares.
+ */
+export function isReleasedTransaction(value: unknown): boolean {
+	return value === RELEASED_TRANSACTION;
+}
 
 let timer;
 

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -1193,24 +1193,13 @@ export class ImmediateTransaction extends DatabaseTransaction {
 }
 
 /**
- * What `context.transaction` holds once the transaction that was attached to it has completed — its
- * owning scope's final commit (`doneWriting`) or an abort — and released the back-reference (see
- * releaseContext()). One frozen, process-wide instance, so a long-lived context (an MQTT
- * subscription context, an ambient operation context) retains nothing measurable, which is the
- * whole point of releasing.
- *
- * A `null` slot broke the documented pattern of committing the current transaction mid-handler and
- * then continuing to use the context (`await getContext().transaction.commit()`, v5-migration docs;
- * "transactions can now be reused after calling transaction.commit()", 4.5.0 release notes): the
- * next `context.transaction.<anything>` threw `Cannot read properties of null`. Before the release
- * existed the slot held the completed, CLOSED transaction and those calls were harmless no-ops —
- * this restores exactly that observable behavior without retaining the transaction.
- *
- * Behaves like any CLOSED transaction: commit/abort are no-ops (nothing is staged here — this
- * instance is shared, so txnForContext() refuses to claim it and addWrite() throws rather than
- * quietly staging onto process-wide state), and reads through it see the latest committed state
- * with no snapshot pinned. Frozen so that a path which does try to claim it fails loudly instead of
- * corrupting every other context's view.
+ * What `context.transaction` holds once its transaction has completed and released the back-reference
+ * (see releaseContext()). One frozen, process-wide instance: the slot stays usable — the documented
+ * `getContext().transaction.commit()` pattern must not throw after completion — without any context
+ * retaining a finished transaction. `txnTime: 0` is the one fidelity loss versus re-committing the
+ * real completed transaction, which reported its own last timestamp; nothing is staged here either way.
+ * Frozen because it is shared: a path that tries to claim or mutate it must fail loudly rather than
+ * corrupt every other context's view.
  */
 class ReleasedTransaction extends DatabaseTransaction {
 	constructor() {

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -517,9 +517,9 @@ export class DatabaseTransaction implements Transaction {
 	 * alive (a fresh write on the same context must not join a DIFFERENT, already-replayed
 	 * transaction) until doneReadTxn() drains the last one, so the release is deferred to there.
 	 *
-	 * Leaves RELEASED_TRANSACTION in the slot rather than `null` (which broke the documented
-	 * post-commit `getContext().transaction.commit()` pattern) or `delete` (which would repeatedly
-	 * force a long-lived, hot context into V8's dictionary-mode property storage).
+	 * Leaves RELEASED_TRANSACTION in the slot: the slot must stay callable (see that constant), and it
+	 * must stay a plain assignment — `delete` repeatedly forces a long-lived, hot context into V8's
+	 * dictionary-mode property storage.
 	 */
 	private releaseContext(final: boolean): void {
 		if (!final) return;
@@ -1194,42 +1194,47 @@ export class ImmediateTransaction extends DatabaseTransaction {
 
 /**
  * What `context.transaction` holds once its transaction has completed and released the back-reference
- * (see releaseContext()). One frozen, process-wide instance: the slot stays usable — the documented
- * `getContext().transaction.commit()` pattern must not throw after completion — without any context
- * retaining a finished transaction. `txnTime: 0` is the one fidelity loss versus re-committing the
- * real completed transaction, which reported its own last timestamp; nothing is staged here either way.
- * Frozen because it is shared: a path that tries to claim or mutate it must fail loudly rather than
- * corrupt every other context's view.
+ * (see releaseContext()). `commit()`/`abort()` are no-ops and reads through it see the latest
+ * committed state, so the documented `getContext().transaction.commit()` pattern stays callable after
+ * completion; `txnTime: 0` is the one thing it cannot report faithfully, since nothing is staged and no
+ * timestamp was taken.
+ *
+ * Deliberately NOT a DatabaseTransaction subclass, and deliberately not extensible. It is one
+ * process-wide instance shared by every released context — so it must own no mutable state at all, and
+ * anything not on this exact surface must fail loudly rather than inherit behavior that would write
+ * through to every other context. That is also why the surface is this small: these are the only
+ * members any core reader of `context.transaction` touches (`txnForContext` maps it to absent first).
  */
-class ReleasedTransaction extends DatabaseTransaction {
-	constructor() {
-		super();
-		this.open = TRANSACTION_STATE.CLOSED;
-	}
+const RELEASED_TRANSACTION_SURFACE = {
+	open: TRANSACTION_STATE.CLOSED,
+	transaction: undefined,
+	writes: Object.freeze([]),
 	commit(): CommitResolution {
 		return { txnTime: 0 };
-	}
-	abort(): void {}
-	getReadTxn(): any {
+	},
+	abort(): void {},
+	getReadTxn(): undefined {
 		return; // no transaction means read latest
-	}
-	useReadTxn(): any {
+	},
+	useReadTxn(): undefined {
 		return;
-	}
-	doneReadTxn(): void {}
-	disregardReadTxn(): void {}
+	},
+	doneReadTxn(): void {},
+	disregardReadTxn(): void {},
 	hasPendingWrites(): boolean {
 		return false;
-	}
+	},
 	addWrite(): never {
 		throw new Error(
 			'Cannot write to a transaction that has already completed; start a new one with transaction() or pass a fresh context'
 		);
-	}
-}
-const releasedTransaction = new ReleasedTransaction();
-Object.freeze(releasedTransaction);
-export const RELEASED_TRANSACTION: DatabaseTransaction = releasedTransaction;
+	},
+	setContext(): never {
+		throw new Error('Cannot attach a context to the shared released transaction');
+	},
+};
+Object.freeze(RELEASED_TRANSACTION_SURFACE);
+export const RELEASED_TRANSACTION = RELEASED_TRANSACTION_SURFACE as unknown as DatabaseTransaction;
 
 let timer;
 

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -466,7 +466,7 @@ export class DatabaseTransaction implements Transaction {
 	private completeDeferredContextRelease(): void {
 		if (!this.pendingContextRelease) return;
 		this.pendingContextRelease = false;
-		if (this.#context?.transaction === this) this.#context.transaction = null;
+		if (this.#context?.transaction === this) this.#context.transaction = RELEASED_TRANSACTION;
 	}
 
 	disregardReadTxn(): void {
@@ -517,11 +517,9 @@ export class DatabaseTransaction implements Transaction {
 	 * alive (a fresh write on the same context must not join a DIFFERENT, already-replayed
 	 * transaction) until doneReadTxn() drains the last one, so the release is deferred to there.
 	 *
-	 * Sets `.transaction` to `null` rather than deleting the property: `Context.transaction` is
-	 * typed `DatabaseTransaction | null | undefined` precisely to document this released state, and
-	 * `delete` would repeatedly force a long-lived, hot context (e.g. an MQTT subscription context
-	 * releasing/reattaching a transaction per message) into V8's slower dictionary-mode property
-	 * storage.
+	 * Leaves RELEASED_TRANSACTION in the slot rather than `null` (which broke the documented
+	 * post-commit `getContext().transaction.commit()` pattern) or `delete` (which would repeatedly
+	 * force a long-lived, hot context into V8's dictionary-mode property storage).
 	 */
 	private releaseContext(final: boolean): void {
 		if (!final) return;
@@ -529,7 +527,7 @@ export class DatabaseTransaction implements Transaction {
 			this.pendingContextRelease = true;
 			return;
 		}
-		if (this.#context?.transaction === this) this.#context.transaction = null;
+		if (this.#context?.transaction === this) this.#context.transaction = RELEASED_TRANSACTION;
 	}
 
 	checkOverloaded() {
@@ -1193,6 +1191,56 @@ export class ImmediateTransaction extends DatabaseTransaction {
 		return; // no transaction means read latest
 	}
 }
+
+/**
+ * What `context.transaction` holds once the transaction that was attached to it has completed — its
+ * owning scope's final commit (`doneWriting`) or an abort — and released the back-reference (see
+ * releaseContext()). One frozen, process-wide instance, so a long-lived context (an MQTT
+ * subscription context, an ambient operation context) retains nothing measurable, which is the
+ * whole point of releasing.
+ *
+ * A `null` slot broke the documented pattern of committing the current transaction mid-handler and
+ * then continuing to use the context (`await getContext().transaction.commit()`, v5-migration docs;
+ * "transactions can now be reused after calling transaction.commit()", 4.5.0 release notes): the
+ * next `context.transaction.<anything>` threw `Cannot read properties of null`. Before the release
+ * existed the slot held the completed, CLOSED transaction and those calls were harmless no-ops —
+ * this restores exactly that observable behavior without retaining the transaction.
+ *
+ * Behaves like any CLOSED transaction: commit/abort are no-ops (nothing is staged here — this
+ * instance is shared, so txnForContext() refuses to claim it and addWrite() throws rather than
+ * quietly staging onto process-wide state), and reads through it see the latest committed state
+ * with no snapshot pinned. Frozen so that a path which does try to claim it fails loudly instead of
+ * corrupting every other context's view.
+ */
+class ReleasedTransaction extends DatabaseTransaction {
+	constructor() {
+		super();
+		this.open = TRANSACTION_STATE.CLOSED;
+	}
+	commit(): CommitResolution {
+		return { txnTime: 0 };
+	}
+	abort(): void {}
+	getReadTxn(): any {
+		return; // no transaction means read latest
+	}
+	useReadTxn(): any {
+		return;
+	}
+	doneReadTxn(): void {}
+	disregardReadTxn(): void {}
+	hasPendingWrites(): boolean {
+		return false;
+	}
+	addWrite(): never {
+		throw new Error(
+			'Cannot write to a transaction that has already completed; start a new one with transaction() or pass a fresh context'
+		);
+	}
+}
+const releasedTransaction = new ReleasedTransaction();
+Object.freeze(releasedTransaction);
+export const RELEASED_TRANSACTION: DatabaseTransaction = releasedTransaction;
 
 let timer;
 

--- a/resources/Resource.ts
+++ b/resources/Resource.ts
@@ -229,7 +229,7 @@ export class Resource<Record extends object = any> implements ResourceInterface<
 				record = idPrefix;
 			}
 		}
-		if (isReleasedTransaction(context)) context = undefined; // never adopt the shared placeholder as a context
+		if (isReleasedTransaction(context)) context = undefined;
 		if (context) {
 			if ((context as any).getContext) context = (context as any).getContext();
 		} else {
@@ -595,7 +595,7 @@ function transactional(
 	function applyContext(idOrQuery: string | Id | Query, dataOrContext?: any, context?: Context) {
 		let id, query, isCollection;
 		let data;
-		// The released placeholder must not be adopted as this call's context — or, worse, as its data.
+		// An absent argument, not a context — and not this call's data either.
 		if (isReleasedTransaction(dataOrContext)) dataOrContext = undefined;
 		if (isReleasedTransaction(context)) context = undefined;
 		// First we do our argument normalization. There are two main types of methods, with or without content

--- a/resources/Resource.ts
+++ b/resources/Resource.ts
@@ -229,6 +229,7 @@ export class Resource<Record extends object = any> implements ResourceInterface<
 				record = idPrefix;
 			}
 		}
+		if (isReleasedTransaction(context)) context = undefined; // never adopt the shared placeholder as a context
 		if (context) {
 			if ((context as any).getContext) context = (context as any).getContext();
 		} else {
@@ -594,9 +595,7 @@ function transactional(
 	function applyContext(idOrQuery: string | Id | Query, dataOrContext?: any, context?: Context) {
 		let id, query, isCollection;
 		let data;
-		// `Table.delete(id, context.transaction)` is a supported form, and on a released context that
-		// argument is the placeholder — which must read as "no transaction" here rather than be adopted
-		// as the context (it is frozen, so transaction() assigning onto it would throw) or as data.
+		// The released placeholder must not be adopted as this call's context — or, worse, as its data.
 		if (isReleasedTransaction(dataOrContext)) dataOrContext = undefined;
 		if (isReleasedTransaction(context)) context = undefined;
 		// First we do our argument normalization. There are two main types of methods, with or without content

--- a/resources/Resource.ts
+++ b/resources/Resource.ts
@@ -10,7 +10,12 @@ import {
 	RequestTargetOrId,
 } from './ResourceInterface.ts';
 import { randomUUID } from 'crypto';
-import { DatabaseTransaction, TRANSACTION_STATE, type Transaction } from './DatabaseTransaction.ts';
+import {
+	DatabaseTransaction,
+	isReleasedTransaction,
+	TRANSACTION_STATE,
+	type Transaction,
+} from './DatabaseTransaction.ts';
 import { IterableEventQueue } from './IterableEventQueue.ts';
 import { _assignPackageExport } from '../globals.js';
 import { ClientError, AccessViolation } from '../utility/errors/hdbError.ts';
@@ -589,6 +594,11 @@ function transactional(
 	function applyContext(idOrQuery: string | Id | Query, dataOrContext?: any, context?: Context) {
 		let id, query, isCollection;
 		let data;
+		// `Table.delete(id, context.transaction)` is a supported form, and on a released context that
+		// argument is the placeholder — which must read as "no transaction" here rather than be adopted
+		// as the context (it is frozen, so transaction() assigning onto it would throw) or as data.
+		if (isReleasedTransaction(dataOrContext)) dataOrContext = undefined;
+		if (isReleasedTransaction(context)) context = undefined;
 		// First we do our argument normalization. There are two main types of methods, with or without content
 		if (hasContent) {
 			// for put, post, patch, publish, query

--- a/resources/ResourceInterface.ts
+++ b/resources/ResourceInterface.ts
@@ -68,12 +68,13 @@ export interface Context {
 	/** Describes the current cookie-based session if it is present and grants the capacity to delete it. authentication.enableSessions must be turned on in the harperdb-config.yaml  */
 	session?: Session;
 	/**
-	 * The database transaction object. `undefined` means none was ever attached. Once an attached
-	 * transaction completes it releases its back-reference (DatabaseTransaction.ts's
-	 * releaseContext()) and the slot holds RELEASED_TRANSACTION, a shared completed transaction:
-	 * always safe to call `commit()`/`abort()` on (both no-ops) and to read through (latest committed
-	 * state, no snapshot), so code that commits mid-handler can keep using its context. `null` was
-	 * the previous released marker and is still accepted defensively.
+	 * The database transaction object. `undefined` means none was ever attached. On the RocksDB path, a
+	 * completed transaction releases its back-reference (DatabaseTransaction.ts's releaseContext()) and
+	 * the slot holds RELEASED_TRANSACTION, a shared completed transaction: always safe to call
+	 * `commit()`/`abort()` on (both no-ops) and to read through (latest committed state, no snapshot),
+	 * so code that commits mid-handler can keep using its context. LMDBTransaction does not release,
+	 * so there the completed transaction itself stays in the slot — also safe to call, but retained.
+	 * `null` was the previous released marker and is still accepted defensively.
 	 */
 	transaction?: DatabaseTransaction | null;
 	/**	 If the operation that will be performed with this context should check user authorization	 */

--- a/resources/ResourceInterface.ts
+++ b/resources/ResourceInterface.ts
@@ -68,11 +68,12 @@ export interface Context {
 	/** Describes the current cookie-based session if it is present and grants the capacity to delete it. authentication.enableSessions must be turned on in the harperdb-config.yaml  */
 	session?: Session;
 	/**
-	 * The database transaction object. `undefined` means none was ever attached; `null` means one
-	 * was attached and has since completed and released its back-reference (DatabaseTransaction.ts's
-	 * releaseContext()) — kept `null` rather than deleting the property so a long-lived, hot context
-	 * (e.g. an MQTT subscription context releasing/reattaching a transaction per message) doesn't
-	 * repeatedly force V8 to deoptimize it into dictionary-mode property storage.
+	 * The database transaction object. `undefined` means none was ever attached. Once an attached
+	 * transaction completes it releases its back-reference (DatabaseTransaction.ts's
+	 * releaseContext()) and the slot holds RELEASED_TRANSACTION, a shared completed transaction:
+	 * always safe to call `commit()`/`abort()` on (both no-ops) and to read through (latest committed
+	 * state, no snapshot), so code that commits mid-handler can keep using its context. `null` was
+	 * the previous released marker and is still accepted defensively.
 	 */
 	transaction?: DatabaseTransaction | null;
 	/**	 If the operation that will be performed with this context should check user authorization	 */

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5598,11 +5598,9 @@ export function makeTable(options) {
 	}
 	function txnForContext(context: Context) {
 		let transaction = context?.transaction;
-		// RELEASED_TRANSACTION is the shared, process-wide placeholder a completed transaction leaves in
-		// the slot (DatabaseTransaction.ts's releaseContext) — it is a marker that this context has no
-		// transaction, not one to claim: the "uninitialized DatabaseTransaction, we can claim it" branch
-		// below would assign this table's store to an instance every other context is also pointing at.
-		// Treated as absent, exactly as the empty slot it replaced was.
+		// The shared placeholder a completed transaction leaves in the slot marks "no transaction", so it
+		// is treated as absent rather than claimed by the branch below (which, on a frozen instance,
+		// would throw).
 		if (transaction === RELEASED_TRANSACTION) transaction = undefined;
 		if (transaction) {
 			if (!transaction.db && isRocksDB) {

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -36,7 +36,7 @@ import {
 	DatabaseTransaction,
 	ImmediateTransaction,
 	priorStagedWrite,
-	RELEASED_TRANSACTION,
+	isReleasedTransaction,
 	TRANSACTION_STATE,
 } from './DatabaseTransaction.ts';
 import * as envMngr from '../utility/environment/environmentManager.ts';
@@ -5598,8 +5598,7 @@ export function makeTable(options) {
 	}
 	function txnForContext(context: Context) {
 		let transaction = context?.transaction;
-		// The placeholder means "no transaction": it is shared process-wide and must never be claimed.
-		if (transaction === RELEASED_TRANSACTION) transaction = undefined;
+		if (isReleasedTransaction(transaction)) transaction = undefined;
 		if (transaction) {
 			if (!transaction.db && isRocksDB) {
 				// this is an uninitialized DatabaseTransaction, we can claim it

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5598,9 +5598,7 @@ export function makeTable(options) {
 	}
 	function txnForContext(context: Context) {
 		let transaction = context?.transaction;
-		// The shared placeholder a completed transaction leaves in the slot marks "no transaction", so it
-		// is treated as absent rather than claimed by the branch below (which, on a frozen instance,
-		// would throw).
+		// The placeholder means "no transaction": it is shared process-wide and must never be claimed.
 		if (transaction === RELEASED_TRANSACTION) transaction = undefined;
 		if (transaction) {
 			if (!transaction.db && isRocksDB) {

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -36,6 +36,7 @@ import {
 	DatabaseTransaction,
 	ImmediateTransaction,
 	priorStagedWrite,
+	RELEASED_TRANSACTION,
 	TRANSACTION_STATE,
 } from './DatabaseTransaction.ts';
 import * as envMngr from '../utility/environment/environmentManager.ts';
@@ -5597,6 +5598,12 @@ export function makeTable(options) {
 	}
 	function txnForContext(context: Context) {
 		let transaction = context?.transaction;
+		// RELEASED_TRANSACTION is the shared, process-wide placeholder a completed transaction leaves in
+		// the slot (DatabaseTransaction.ts's releaseContext) — it is a marker that this context has no
+		// transaction, not one to claim: the "uninitialized DatabaseTransaction, we can claim it" branch
+		// below would assign this table's store to an instance every other context is also pointing at.
+		// Treated as absent, exactly as the empty slot it replaced was.
+		if (transaction === RELEASED_TRANSACTION) transaction = undefined;
 		if (transaction) {
 			if (!transaction.db && isRocksDB) {
 				// this is an uninitialized DatabaseTransaction, we can claim it

--- a/resources/transaction.ts
+++ b/resources/transaction.ts
@@ -1,11 +1,6 @@
 import type { Context } from './ResourceInterface.ts';
 import { _assignPackageExport } from '../globals.js';
-import {
-	DatabaseTransaction,
-	RELEASED_TRANSACTION,
-	type Transaction,
-	TRANSACTION_STATE,
-} from './DatabaseTransaction.ts';
+import { DatabaseTransaction, type Transaction, TRANSACTION_STATE } from './DatabaseTransaction.ts';
 import { AsyncLocalStorage } from 'async_hooks';
 
 export const contextStorage = new AsyncLocalStorage<Context>();
@@ -80,18 +75,21 @@ export function transaction<T>(
 
 _assignPackageExport('transaction', transaction);
 
-// These assert that the caller still owns a live transaction, so a released slot must keep throwing
-// as an absent one always did — unlike `context.transaction.commit()`, whose documented contract is to
-// stay callable after completion.
-transaction.commit = function (contextSource) {
+// These assert that the caller still owns a live transaction, unlike `context.transaction.commit()`,
+// whose documented contract is to stay callable after completion. The check is on state, not on the
+// released placeholder's identity: a completed transaction can still be in the slot (the deferred
+// release, while an iterator drains) or never leave it (LMDB never releases), and all three mean the
+// same thing to a caller. A timeout-poisoned transaction is passed through so its own commit() reports
+// the poison rather than this weaker error.
+function requireLiveTransaction(contextSource, action: string): Transaction {
 	const transaction = (contextSource.getContext?.() || contextSource)?.transaction;
-	if (!transaction || transaction === RELEASED_TRANSACTION)
-		throw new Error('No active transaction is available to commit');
-	return transaction.commit();
+	if (!transaction || (transaction.open !== TRANSACTION_STATE.OPEN && !(transaction as any).timedOut))
+		throw new Error(`No active transaction is available to ${action}`);
+	return transaction;
+}
+transaction.commit = function (contextSource) {
+	return requireLiveTransaction(contextSource, 'commit').commit({});
 };
 transaction.abort = function (contextSource) {
-	const transaction = (contextSource.getContext?.() || contextSource)?.transaction;
-	if (!transaction || transaction === RELEASED_TRANSACTION)
-		throw new Error('No active transaction is available to abort');
-	return transaction.abort();
+	return requireLiveTransaction(contextSource, 'abort').abort();
 };

--- a/resources/transaction.ts
+++ b/resources/transaction.ts
@@ -30,14 +30,13 @@ export function transaction<T>(
 		asyncStorageContext = contextStorage.getStore();
 		context = asyncStorageContext ?? {};
 	} else {
+		// The released placeholder is an absent argument, not a context: normalized before the fallback
+		// chain below so it resolves to the ambient store exactly as the `null` it replaced did, rather
+		// than to a bare `{}` that would drop the caller's user, session and timestamp.
+		const contextArg = isReleasedTransaction(ctx) ? undefined : ctx;
 		// request argument included, but null or undefined, so maybe create a new one
-		context = ctx ?? (asyncStorageContext = contextStorage.getStore()) ?? {};
+		context = contextArg ?? (asyncStorageContext = contextStorage.getStore()) ?? {};
 	}
-	// Every path that adopts a caller-supplied transaction or context ends here, so this is the one place
-	// that has to refuse the released placeholder: it carries no context state, and assigning a new
-	// transaction onto the frozen shared instance below would throw. Treated as no context at all, which
-	// is what the `null` it replaced became.
-	if (isReleasedTransaction(context)) context = {};
 
 	if (typeof callback !== 'function') {
 		throw new TypeError('Callback function must be provided to transaction');

--- a/resources/transaction.ts
+++ b/resources/transaction.ts
@@ -1,6 +1,11 @@
 import type { Context } from './ResourceInterface.ts';
 import { _assignPackageExport } from '../globals.js';
-import { DatabaseTransaction, type Transaction, TRANSACTION_STATE } from './DatabaseTransaction.ts';
+import {
+	DatabaseTransaction,
+	isReleasedTransaction,
+	type Transaction,
+	TRANSACTION_STATE,
+} from './DatabaseTransaction.ts';
 import { AsyncLocalStorage } from 'async_hooks';
 
 export const contextStorage = new AsyncLocalStorage<Context>();
@@ -28,6 +33,11 @@ export function transaction<T>(
 		// request argument included, but null or undefined, so maybe create a new one
 		context = ctx ?? (asyncStorageContext = contextStorage.getStore()) ?? {};
 	}
+	// Every path that adopts a caller-supplied transaction or context ends here, so this is the one place
+	// that has to refuse the released placeholder: it carries no context state, and assigning a new
+	// transaction onto the frozen shared instance below would throw. Treated as no context at all, which
+	// is what the `null` it replaced became.
+	if (isReleasedTransaction(context)) context = {};
 
 	if (typeof callback !== 'function') {
 		throw new TypeError('Callback function must be provided to transaction');
@@ -75,11 +85,9 @@ export function transaction<T>(
 
 _assignPackageExport('transaction', transaction);
 
-// Only a context that never had a transaction has none to act on. NOT a state check, and NOT a check
-// for the released placeholder: both would throw for a transaction that has completed but is still
-// reachable, and these helpers have to behave there exactly as a completed transaction in the slot
-// always did — a no-op — or a checkpointing loop that commits every Nth row starts failing on its
-// second checkpoint.
+// Only a context that never had a transaction has none to act on: a completed transaction still in the
+// slot must no-op here, as it always did, or a checkpointing loop that commits every Nth row fails on
+// its second checkpoint.
 transaction.commit = function (contextSource) {
 	const transaction = (contextSource.getContext?.() || contextSource)?.transaction;
 	if (!transaction) throw new Error('No active transaction is available to commit');

--- a/resources/transaction.ts
+++ b/resources/transaction.ts
@@ -75,21 +75,18 @@ export function transaction<T>(
 
 _assignPackageExport('transaction', transaction);
 
-// These assert that the caller still owns a live transaction, unlike `context.transaction.commit()`,
-// whose documented contract is to stay callable after completion. The check is on state, not on the
-// released placeholder's identity: a completed transaction can still be in the slot (the deferred
-// release, while an iterator drains) or never leave it (LMDB never releases), and all three mean the
-// same thing to a caller. A timeout-poisoned transaction is passed through so its own commit() reports
-// the poison rather than this weaker error.
-function requireLiveTransaction(contextSource, action: string): Transaction {
-	const transaction = (contextSource.getContext?.() || contextSource)?.transaction;
-	if (!transaction || (transaction.open !== TRANSACTION_STATE.OPEN && !(transaction as any).timedOut))
-		throw new Error(`No active transaction is available to ${action}`);
-	return transaction;
-}
+// Only a context that never had a transaction has none to act on. NOT a state check, and NOT a check
+// for the released placeholder: both would throw for a transaction that has completed but is still
+// reachable, and these helpers have to behave there exactly as a completed transaction in the slot
+// always did — a no-op — or a checkpointing loop that commits every Nth row starts failing on its
+// second checkpoint.
 transaction.commit = function (contextSource) {
-	return requireLiveTransaction(contextSource, 'commit').commit({});
+	const transaction = (contextSource.getContext?.() || contextSource)?.transaction;
+	if (!transaction) throw new Error('No active transaction is available to commit');
+	return transaction.commit();
 };
 transaction.abort = function (contextSource) {
-	return requireLiveTransaction(contextSource, 'abort').abort();
+	const transaction = (contextSource.getContext?.() || contextSource)?.transaction;
+	if (!transaction) throw new Error('No active transaction is available to abort');
+	return transaction.abort();
 };

--- a/resources/transaction.ts
+++ b/resources/transaction.ts
@@ -1,6 +1,11 @@
 import type { Context } from './ResourceInterface.ts';
 import { _assignPackageExport } from '../globals.js';
-import { DatabaseTransaction, type Transaction, TRANSACTION_STATE } from './DatabaseTransaction.ts';
+import {
+	DatabaseTransaction,
+	RELEASED_TRANSACTION,
+	type Transaction,
+	TRANSACTION_STATE,
+} from './DatabaseTransaction.ts';
 import { AsyncLocalStorage } from 'async_hooks';
 
 export const contextStorage = new AsyncLocalStorage<Context>();
@@ -75,13 +80,18 @@ export function transaction<T>(
 
 _assignPackageExport('transaction', transaction);
 
+// These assert that the caller still owns a live transaction, so a released slot must keep throwing
+// as an absent one always did — unlike `context.transaction.commit()`, whose documented contract is to
+// stay callable after completion.
 transaction.commit = function (contextSource) {
 	const transaction = (contextSource.getContext?.() || contextSource)?.transaction;
-	if (!transaction) throw new Error('No active transaction is available to commit');
+	if (!transaction || transaction === RELEASED_TRANSACTION)
+		throw new Error('No active transaction is available to commit');
 	return transaction.commit();
 };
 transaction.abort = function (contextSource) {
 	const transaction = (contextSource.getContext?.() || contextSource)?.transaction;
-	if (!transaction) throw new Error('No active transaction is available to abort');
+	if (!transaction || transaction === RELEASED_TRANSACTION)
+		throw new Error('No active transaction is available to abort');
 	return transaction.abort();
 };

--- a/unitTests/resources/lingeringWriteCommit.test.js
+++ b/unitTests/resources/lingeringWriteCommit.test.js
@@ -4,7 +4,7 @@ const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { transaction } = require('#src/resources/transaction');
-const { TRANSACTION_STATE } = require('#src/resources/DatabaseTransaction');
+const { TRANSACTION_STATE, RELEASED_TRANSACTION } = require('#src/resources/DatabaseTransaction');
 const { setTimeout: delay } = require('node:timers/promises');
 
 // A commit issued while a search iterator still holds the read transaction cannot commit the
@@ -61,7 +61,7 @@ describe('commit with open read iterators commits writes immediately on a replay
 		const { context, iterator } = await commitWithOpenIterator('linger-write');
 		// Captured before the iterator drains: once it does, DatabaseTransaction now releases the
 		// context's own back-reference too (releaseContext(), deferred here until the last iterator
-		// finishes — see doneReadTxn()), so context.transaction itself goes null. Assertions below
+		// finishes — see doneReadTxn()), so the slot stops pointing at this instance. Assertions below
 		// that need the specific (now-closed) transaction instance use this captured reference.
 		const closedTxn = context.transaction;
 		assert.equal(
@@ -78,7 +78,11 @@ describe('commit with open read iterators commits writes immediately on a replay
 		while (!(await iterator.next()).done);
 		await delay(50); // give a released-handle failure a beat to surface as an unhandledRejection
 		assert.equal(closedTxn.transaction, null, 'the drained iterator must release the native handle');
-		assert.equal(context.transaction, null, 'the drained iterator must also release the context’s back-reference');
+		assert.equal(
+			context.transaction,
+			RELEASED_TRANSACTION,
+			'the drained iterator must also release the context’s back-reference'
+		);
 		assert.ok(await LingerTable.get('linger-write'), 'releasing the read handle must not disturb the committed write');
 		// audit/txn-log entries batch on the native transaction they were staged into and are only
 		// written by its commit; the replay must re-stage them into ITS transaction — the original
@@ -143,14 +147,14 @@ describe('commit with open read iterators commits writes immediately on a replay
 		assert.equal(await LingerTable.get('linger-fail'), undefined, 'the failed write is not committed');
 		// A terminal commit failure is just as final as a success: releaseContext() defers the
 		// context release the same way (pendingContextRelease) until the still-open iterator drains,
-		// so capture the wrapper before draining it — draining deletes context.transaction itself.
+		// so capture the wrapper before draining it — draining replaces context.transaction itself.
 		const closedTxn = context.transaction;
 		// the original read handle must survive the replay failure: the iterator finishes normally
 		while (!(await iterator.next()).done);
 		assert.equal(closedTxn.transaction, null, 'the drained iterator must still release the native handle');
 		assert.equal(
 			context.transaction,
-			null,
+			RELEASED_TRANSACTION,
 			'the drained iterator must also release the context’s back-reference, even after a terminal commit failure'
 		);
 		await delay(100);

--- a/unitTests/resources/operationContextTransactionLeak.test.js
+++ b/unitTests/resources/operationContextTransactionLeak.test.js
@@ -4,7 +4,7 @@ const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const serverUtilities = require('#src/server/serverHelpers/serverUtilities');
 const { contextStorage } = require('#src/resources/transaction');
-const { TRANSACTION_STATE, DatabaseTransaction } = require('#src/resources/DatabaseTransaction');
+const { TRANSACTION_STATE, DatabaseTransaction, RELEASED_TRANSACTION } = require('#src/resources/DatabaseTransaction');
 
 // Regression coverage for a transaction-context leak exposed by issue #1591/#1592 (ambient user
 // context for operation handlers) and confirmed against a real 2-node cluster-formation scenario
@@ -200,17 +200,17 @@ describe('Ambient operation context must not couple independent writes (transact
 		const [afterFirst, afterSecond, afterThird] = transactionsSeenAfterEachWrite;
 		assert.strictEqual(
 			afterFirst,
-			null,
+			RELEASED_TRANSACTION,
 			"the first write's transaction must be released from the ambient context once its commit completes"
 		);
 		assert.strictEqual(
 			afterSecond,
-			null,
+			RELEASED_TRANSACTION,
 			"the second write's transaction must likewise be released, not left attached for a later write to observe"
 		);
 		assert.strictEqual(
 			afterThird,
-			null,
+			RELEASED_TRANSACTION,
 			"the third write's transaction must likewise be released, for the same reason"
 		);
 

--- a/unitTests/resources/operationContextTransactionLeak.test.js
+++ b/unitTests/resources/operationContextTransactionLeak.test.js
@@ -237,4 +237,32 @@ describe('Ambient operation context must not couple independent writes (transact
 			'the third write must not join the second write’s transaction instance, for the same reason'
 		);
 	});
+
+	// The delivery path the 5.2.3 regression actually broke: an operations-API handler running under
+	// processLocalTransaction's ambient context (fabric connect, create/delete cluster in
+	// central-manager) reads through that context, then commits it itself — the documented
+	// mid-handler pattern. The unit-level shape in transaction.test.js uses a bare `{}` context; this
+	// one goes through the real operation-handler ambient context, which is what made the failure
+	// user-visible.
+	it('lets an operation handler commit its ambient context after a static read completed that context’s transaction', async () => {
+		let committed = false;
+		const result = await serverUtilities.processLocalTransaction(
+			{ body: { operation: 'test_registered_op', hdb_user: { username: 'internal_bookkeeping' } } },
+			async () => {
+				const context = contextStorage.getStore();
+				await LeakTable.get('handler-commit-target');
+				// getUserPermissions()'s shape: bound the transaction the reads above ran in, then carry on.
+				await context.transaction.commit();
+				committed = true;
+				await LeakTable.put('handler-commit-target', { name: 'written after the handler commit' });
+				await context.transaction.commit();
+				return { message: 'ok' };
+			}
+		);
+		assert.equal(result?.message, 'ok', 'the handler must not fail on its own mid-handler commit');
+		assert.ok(committed);
+		const record = await LeakTable.get('handler-commit-target');
+		assert.ok(record, 'the write made after the handler’s own commit must persist');
+		assert.equal(record.name, 'written after the handler commit');
+	});
 });

--- a/unitTests/resources/operationContextTransactionLeak.test.js
+++ b/unitTests/resources/operationContextTransactionLeak.test.js
@@ -238,12 +238,9 @@ describe('Ambient operation context must not couple independent writes (transact
 		);
 	});
 
-	// The delivery path the 5.2.3 regression actually broke: an operations-API handler running under
-	// processLocalTransaction's ambient context (fabric connect, create/delete cluster in
-	// central-manager) reads through that context, then commits it itself — the documented
-	// mid-handler pattern. The unit-level shape in transaction.test.js uses a bare `{}` context; this
-	// one goes through the real operation-handler ambient context, which is what made the failure
-	// user-visible.
+	// The delivery path: an operations-API handler under processLocalTransaction's ambient context reads
+	// through that context and then commits it itself. transaction.test.js covers the same shape on a
+	// bare `{}` context; only this one exercises the real ambient operation context.
 	it('lets an operation handler commit its ambient context after a static read completed that context’s transaction', async () => {
 		let committed = false;
 		const result = await serverUtilities.processLocalTransaction(

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -5,7 +5,7 @@ const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { transaction } = require('#src/resources/transaction');
-const { DatabaseTransaction } = require('#src/resources/DatabaseTransaction');
+const { DatabaseTransaction, RELEASED_TRANSACTION } = require('#src/resources/DatabaseTransaction');
 const { LMDBTransaction } = require('#src/resources/LMDBTransaction');
 const { IterableEventQueue } = require('#src/resources/IterableEventQueue');
 const { RocksDatabase } = require('@harperfast/rocksdb-js');
@@ -226,11 +226,11 @@ describe('Transactions', () => {
 			}
 			assert.equal(entries[0].name, 'thirteen');
 			await TxnTest3.put(14, { name: 'fourteen' }, context);
-			// context.transaction may already be released here: the preceding get()/search() calls each ran
-			// (and durably committed) their own short-lived transaction once the explicit commit above closed
-			// the original one, and DatabaseTransaction now releases the context's back-reference as soon as
-			// one of those completes — so there may be nothing left to explicitly commit.
-			await context.transaction?.commit();
+			// The preceding get()/search() calls each ran (and durably committed) their own short-lived
+			// transaction once the explicit commit above closed the original one, so there may be nothing
+			// left to commit — but the documented pattern is to keep committing the context's transaction,
+			// and that must stay callable rather than throwing on a released slot.
+			await context.transaction.commit();
 			assert.equal((await TxnTest.get(7, context)).name, 'SEVEN');
 			assert.equal((await TxnTest2.get(13, context)).name, 'thirteen');
 			assert.equal((await TxnTest3.get(14, context)).name, 'fourteen');
@@ -827,10 +827,10 @@ describe('Transactions', () => {
 				}
 				await context.transaction.commit();
 				await TxnTest.put({ id: 8, name: 'eight changed' }); // no context
-				// context.transaction may already be released here — the ambient put above ran (and durably
-				// committed) its own short-lived transaction once the explicit commit above closed the
-				// original one; see the identical comment in 'Can run txn with commit in the middle'.
-				await context.transaction?.commit();
+				// As in 'Can run txn with commit in the middle': the ambient put above ran (and durably
+				// committed) its own short-lived transaction once the explicit commit closed the original
+				// one, and committing the context's transaction again must still be safe.
+				await context.transaction.commit();
 				assert.equal((await TxnTest.get(8, context)).name, 'eight changed');
 			});
 		});
@@ -847,10 +847,11 @@ describe('Transactions', () => {
 			await transaction(context, async () => {
 				await TxnTest.put(90, { name: 'release-on-commit' }, context);
 			});
-			// releaseContext() nulls the slot rather than deleting it — Context.transaction is typed
-			// `DatabaseTransaction | null | undefined` to document a released-but-previously-attached
-			// state, so a long-lived, hot context isn't repeatedly forced into V8 dictionary mode.
-			assert.strictEqual(context.transaction, null);
+			// releaseContext() leaves the shared RELEASED_TRANSACTION in the slot rather than nulling or
+			// deleting it: the completed instance is no longer retained (the point of the release), while
+			// code that legitimately reaches for context.transaction after committing still finds a safe,
+			// completed transaction instead of a null.
+			assert.strictEqual(context.transaction, RELEASED_TRANSACTION);
 			assert.equal((await TxnTest.get(90)).name, 'release-on-commit');
 		});
 		it('releases the context’s back-reference once the transaction aborts', async function () {
@@ -862,7 +863,7 @@ describe('Transactions', () => {
 				}),
 				/forced abort for test/
 			);
-			assert.strictEqual(context.transaction, null);
+			assert.strictEqual(context.transaction, RELEASED_TRANSACTION);
 			assert.equal(await TxnTest.get(91), undefined);
 		});
 		it('does not clobber a context that has been re-pointed at a different transaction', async function () {
@@ -889,7 +890,7 @@ describe('Transactions', () => {
 			await transaction(context, async () => {
 				await TxnTest.put(92, { name: 'first txn on shared context' }, context);
 			});
-			assert.strictEqual(context.transaction, null);
+			assert.strictEqual(context.transaction, RELEASED_TRANSACTION);
 			await transaction(context, async () => {
 				await TxnTest.put(93, { name: 'second txn on shared context' }, context);
 			});
@@ -899,15 +900,16 @@ describe('Transactions', () => {
 		// The release must not strand a later write on an uncommitted transaction. It doesn't, and the
 		// reason is worth pinning: resources/transaction.ts:35 only REUSES a context's transaction when
 		// it is still OPEN, so a retained CLOSED one was never reused for a subsequent write anyway —
-		// line 39 minted a fresh DatabaseTransaction either way. Nulling it therefore changes only what
-		// stays reachable, not how the next write is serviced: it still goes through the transaction()
-		// wrapper, which commits in onComplete (or aborts in onError) by construction.
+		// line 39 minted a fresh DatabaseTransaction either way. Replacing it with the completed
+		// RELEASED_TRANSACTION therefore changes only what stays reachable, not how the next write is
+		// serviced: it still goes through the transaction() wrapper, which commits in onComplete (or
+		// aborts in onError) by construction.
 		it('keeps post-completion writes on a reused context durable, with nothing left staged', async function () {
 			const context = {};
 			await transaction(context, async () => {
 				await TxnTest.put(94, { name: 'inside txn' }, context);
 			});
-			assert.strictEqual(context.transaction, null);
+			assert.strictEqual(context.transaction, RELEASED_TRANSACTION);
 			// Writes made with the SAME context after its transaction completed must still commit.
 			await TxnTest.put(95, { name: 'after commit' }, context);
 			await TxnTest.get(95, context); // a read in between, which also re-enters the dispatcher
@@ -920,6 +922,41 @@ describe('Transactions', () => {
 				0,
 				'no write may be left staged on an uncommitted transaction attached to the reused context'
 			);
+		});
+		// The shape that broke central-manager on 5.2.3 (fabric connect / create + delete cluster all
+		// returned `Cannot read properties of null (reading 'commit')`): a handler that has no
+		// transaction() wrapper of its own, makes a static Resource API call with its context — which
+		// Resource.ts services by minting a transaction ON that context and driving it to a final commit
+		// — and then follows the documented pattern of committing the context's transaction itself. The
+		// release must not turn that documented call into a TypeError.
+		it('lets a handler commit its context after a nested Resource API call completed that context’s transaction', async function () {
+			const context = {};
+			await TxnTest.get(97, context);
+			assert.strictEqual(
+				context.transaction,
+				RELEASED_TRANSACTION,
+				'premise: the nested get’s own final commit released the slot'
+			);
+			await context.transaction.commit(); // documented pattern; must not throw
+			await TxnTest.put(97, { name: 'after released commit' }, context);
+			await context.transaction.commit();
+			assert.equal((await TxnTest.get(97)).name, 'after released commit');
+		});
+		// A shared, process-wide released transaction must never be claimed as a place to stage writes.
+		it('never lets the released placeholder be claimed or written to', async function () {
+			const context = {};
+			await transaction(context, async () => {
+				await TxnTest.put(98, { name: 'claim check' }, context);
+			});
+			assert.strictEqual(context.transaction, RELEASED_TRANSACTION);
+			await TxnTest.put(99, { name: 'not staged on the placeholder' }, context);
+			// The write is serviced by a transaction of its own, which releases the slot back to the
+			// placeholder when it completes — so the slot's identity says nothing here. What must hold is
+			// that the shared instance was never claimed or staged into on the way through.
+			assert.equal(RELEASED_TRANSACTION.writes.length, 0, 'nothing may ever be staged on the placeholder');
+			assert.equal(RELEASED_TRANSACTION.db, undefined, 'no store may ever claim the placeholder');
+			assert.throws(() => RELEASED_TRANSACTION.addWrite({}), /already completed/);
+			assert.equal((await TxnTest.get(99)).name, 'not staged on the placeholder');
 		});
 		// #1411: a timeout-poisoned abort must NOT release the context's back-reference. Resource.ts's
 		// dispatcher deliberately keeps joining a `timedOut` transaction (context?.transaction?.timedOut)

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -990,10 +990,27 @@ describe('Transactions', () => {
 			assert.strictEqual(context.transaction, RELEASED_TRANSACTION);
 			await TxnTest.delete(120, context.transaction);
 			assert.equal(await TxnTest.get(120), undefined, 'the delete must run on a fresh transaction');
-			const created = await TxnTest.create({ name: 'created-with-released-slot' }, context.transaction);
-			assert.ok(created?.id ?? created, 'create must not fail on a released slot');
+			const createdId = await TxnTest.create({ name: 'created-with-released-slot' }, context.transaction);
+			assert.equal((await TxnTest.get(createdId))?.name, 'created-with-released-slot', 'the create must persist');
 			await transaction(context.transaction, async () => TxnTest.put(121, { name: 'direct' }));
 			assert.equal((await TxnTest.get(121)).name, 'direct');
+		});
+		// A released slot must also be a clean start for a MULTI-STORE transaction: the chain the previous
+		// transaction built (`next`) went with its commit, so the next one has to build its own.
+		it('starts a fresh multi-store chain after the slot is released', async function () {
+			const context = {};
+			await transaction(context, async () => {
+				await TxnTest.put(140, { name: 'store-a' }, context);
+				await TxnTest2.put(140, { name: 'store-b' }, context);
+			});
+			assert.strictEqual(context.transaction, RELEASED_TRANSACTION);
+			await transaction(context, async () => {
+				await TxnTest.put(141, { name: 'store-a-again' }, context);
+				await TxnTest2.put(141, { name: 'store-b-again' }, context);
+				assert.equal(context.transaction.next?.next, undefined, 'the chain must not carry links over');
+			});
+			assert.equal((await TxnTest.get(141)).name, 'store-a-again');
+			assert.equal((await TxnTest2.get(141)).name, 'store-b-again');
 		});
 		// "Absent" has to mean the same thing at every route: an absent argument falls through to the
 		// ambient context. Resolving the placeholder to a bare `{}` instead would silently drop the

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -226,8 +226,6 @@ describe('Transactions', () => {
 			}
 			assert.equal(entries[0].name, 'thirteen');
 			await TxnTest3.put(14, { name: 'fourteen' }, context);
-			// There may be nothing left to commit here — the documented pattern is to keep committing the
-			// context's transaction regardless, so it must stay callable.
 			await context.transaction.commit();
 			assert.equal((await TxnTest.get(7, context)).name, 'SEVEN');
 			assert.equal((await TxnTest2.get(13, context)).name, 'thirteen');
@@ -825,8 +823,6 @@ describe('Transactions', () => {
 				}
 				await context.transaction.commit();
 				await TxnTest.put({ id: 8, name: 'eight changed' }); // no context
-				// As in 'Can run txn with commit in the middle': committing the context's transaction again
-				// must stay safe.
 				await context.transaction.commit();
 				assert.equal((await TxnTest.get(8, context)).name, 'eight changed');
 			});
@@ -844,8 +840,6 @@ describe('Transactions', () => {
 			await transaction(context, async () => {
 				await TxnTest.put(90, { name: 'release-on-commit' }, context);
 			});
-			// The completed instance is no longer retained, and the slot still holds a safe, callable
-			// completed transaction.
 			assert.strictEqual(context.transaction, RELEASED_TRANSACTION);
 			assert.equal((await TxnTest.get(90)).name, 'release-on-commit');
 		});
@@ -926,7 +920,7 @@ describe('Transactions', () => {
 				RELEASED_TRANSACTION,
 				'premise: the nested get’s own final commit released the slot'
 			);
-			await context.transaction.commit(); // documented pattern; must not throw
+			await context.transaction.commit();
 			await TxnTest.put(97, { name: 'after released commit' }, context);
 			await context.transaction.commit();
 			assert.equal((await TxnTest.get(97)).name, 'after released commit');
@@ -939,19 +933,18 @@ describe('Transactions', () => {
 			});
 			assert.strictEqual(context.transaction, RELEASED_TRANSACTION);
 			await TxnTest.put(99, { name: 'not staged on the placeholder' }, context);
-			// The write is serviced by a transaction of its own, which releases the slot back to the
-			// placeholder when it completes — so the slot's identity says nothing here. What must hold is
-			// that the shared instance was never claimed or staged into on the way through.
+			// The write runs on a transaction of its own, which releases the slot back to the placeholder,
+			// so the slot's identity says nothing here — only that the shared instance was never claimed.
 			assert.equal(RELEASED_TRANSACTION.writes.length, 0, 'nothing may ever be staged on the placeholder');
 			assert.equal(RELEASED_TRANSACTION.db, undefined, 'no store may ever claim the placeholder');
 			assert.equal((await TxnTest.get(99)).name, 'not staged on the placeholder');
 		});
-		// The placeholder is one instance shared by every released context, so each way of reaching its
-		// state must fail rather than write through to all of them.
+		// One instance is shared by every released context, so each route into its state must fail rather
+		// than write through to all of them.
 		it('refuses every route into the shared placeholder’s state', function () {
 			assert.throws(() => RELEASED_TRANSACTION.addWrite({}), /already completed/);
 			assert.throws(() => RELEASED_TRANSACTION.setContext({}), /shared released transaction/);
-			assert.throws(() => RELEASED_TRANSACTION.writes.push({}), TypeError, 'the write set must be frozen too');
+			assert.throws(() => RELEASED_TRANSACTION.writes.push({}), TypeError);
 			assert.throws(() => {
 				'use strict';
 				RELEASED_TRANSACTION.open = TRANSACTION_STATE.OPEN;
@@ -961,25 +954,48 @@ describe('Transactions', () => {
 		// transaction.commit(context) / transaction.abort(context) assert the caller still owns a live
 		// transaction. That has to hold for every way a transaction stops being live, not just an absent
 		// slot — a completed one can also still be sitting in it.
-		it('keeps transaction.commit()/abort() throwing once there is no live transaction', async function () {
+		it('keeps transaction.commit()/abort() throwing for a context that never had a transaction', function () {
 			assert.throws(() => transaction.commit({}), /No active transaction is available to commit/);
 			assert.throws(() => transaction.abort({}), /No active transaction is available to abort/);
+		});
+		// The two documented forms must agree: whatever `context.transaction.commit()` does on a completed
+		// transaction, `transaction.commit(context)` does too.
+		it('makes transaction.commit(context) a no-op on a released slot, like the direct form', async function () {
 			const context = {};
 			await transaction(context, async () => {
 				await TxnTest.put(100, { name: 'live' }, context);
-				await transaction.commit(context); // still OPEN: allowed
 			});
-			assert.throws(() => transaction.commit(context), /No active transaction is available to commit/);
-			assert.throws(() => transaction.abort(context), /No active transaction is available to abort/);
-			// Identity is not the test — a completed transaction still parked in the slot (the deferred
-			// release, or LMDB, which never releases at all) must throw too.
-			const completed = new DatabaseTransaction();
-			completed.open = TRANSACTION_STATE.CLOSED;
-			assert.throws(
-				() => transaction.commit({ transaction: completed }),
-				/No active transaction is available to commit/,
-				'a completed transaction still in the slot is not a live one'
-			);
+			assert.strictEqual(context.transaction, RELEASED_TRANSACTION);
+			assert.deepEqual(await transaction.commit(context), { txnTime: 0 });
+			assert.equal(transaction.abort(context), undefined);
+			assert.equal((await TxnTest.get(100)).name, 'live');
+		});
+		// A checkpointing loop commits every Nth row inside one scope. Each explicit commit closes the
+		// transaction without ending the scope that owns it, so the helper has to stay callable — and the
+		// rows written between checkpoints have to survive.
+		it('stays callable for repeated checkpoint commits inside one scope', async function () {
+			const context = {};
+			await transaction(context, async () => {
+				for (let i = 0; i < 4; i++) {
+					await TxnTest.put(110 + i, { name: `checkpoint-${i}` }, context);
+					await transaction.commit(context);
+				}
+			});
+			for (let i = 0; i < 4; i++) {
+				assert.equal((await TxnTest.get(110 + i))?.name, `checkpoint-${i}`, `row ${i} must persist`);
+			}
+		});
+		// `Table.delete(id, context.transaction)` is a supported bare-transaction form; on a released
+		// context that argument is the placeholder, which must read as "no transaction" rather than be
+		// adopted as the (frozen) context.
+		it('accepts a released slot passed as the bare-transaction argument', async function () {
+			const context = {};
+			await transaction(context, async () => {
+				await TxnTest.put(120, { name: 'bare-arg' }, context);
+			});
+			assert.strictEqual(context.transaction, RELEASED_TRANSACTION);
+			await TxnTest.delete(120, context.transaction);
+			assert.equal(await TxnTest.get(120), undefined, 'the delete must run on a fresh transaction');
 		});
 		// #1411: a timeout-poisoned abort must NOT release the context's back-reference. Resource.ts's
 		// dispatcher deliberately keeps joining a `timedOut` transaction (context?.transaction?.timedOut)

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -951,15 +951,10 @@ describe('Transactions', () => {
 			}, TypeError);
 			assert.equal(RELEASED_TRANSACTION.open, TRANSACTION_STATE.CLOSED);
 		});
-		// transaction.commit(context) / transaction.abort(context) assert the caller still owns a live
-		// transaction. That has to hold for every way a transaction stops being live, not just an absent
-		// slot — a completed one can also still be sitting in it.
 		it('keeps transaction.commit()/abort() throwing for a context that never had a transaction', function () {
 			assert.throws(() => transaction.commit({}), /No active transaction is available to commit/);
 			assert.throws(() => transaction.abort({}), /No active transaction is available to abort/);
 		});
-		// The two documented forms must agree: whatever `context.transaction.commit()` does on a completed
-		// transaction, `transaction.commit(context)` does too.
 		it('makes transaction.commit(context) a no-op on a released slot, like the direct form', async function () {
 			const context = {};
 			await transaction(context, async () => {
@@ -970,9 +965,6 @@ describe('Transactions', () => {
 			assert.equal(transaction.abort(context), undefined);
 			assert.equal((await TxnTest.get(100)).name, 'live');
 		});
-		// A checkpointing loop commits every Nth row inside one scope. Each explicit commit closes the
-		// transaction without ending the scope that owns it, so the helper has to stay callable — and the
-		// rows written between checkpoints have to survive.
 		it('stays callable for repeated checkpoint commits inside one scope', async function () {
 			const context = {};
 			await transaction(context, async () => {
@@ -985,17 +977,23 @@ describe('Transactions', () => {
 				assert.equal((await TxnTest.get(110 + i))?.name, `checkpoint-${i}`, `row ${i} must persist`);
 			}
 		});
-		// `Table.delete(id, context.transaction)` is a supported bare-transaction form; on a released
-		// context that argument is the placeholder, which must read as "no transaction" rather than be
-		// adopted as the (frozen) context.
-		it('accepts a released slot passed as the bare-transaction argument', async function () {
+		// Passing a transaction where a context is expected is a supported form; on a released context that
+		// argument is the placeholder, and every route that adopts it must read it as "no transaction"
+		// rather than assign onto the frozen shared instance.
+		it('accepts a released slot wherever a transaction or context is accepted', async function () {
 			const context = {};
 			await transaction(context, async () => {
 				await TxnTest.put(120, { name: 'bare-arg' }, context);
 			});
 			assert.strictEqual(context.transaction, RELEASED_TRANSACTION);
-			await TxnTest.delete(120, context.transaction);
+			await TxnTest.delete(120, context.transaction); // transactional() argument normalization
 			assert.equal(await TxnTest.get(120), undefined, 'the delete must run on a fresh transaction');
+			// Resource.create shifts its own arguments and never reaches that normalizer.
+			const created = await TxnTest.create({ name: 'created-with-released-slot' }, context.transaction);
+			assert.ok(created?.id ?? created, 'create must not fail on a released slot');
+			// transaction() called with the placeholder directly as its context.
+			await transaction(context.transaction, async () => TxnTest.put(121, { name: 'direct' }));
+			assert.equal((await TxnTest.get(121)).name, 'direct');
 		});
 		// #1411: a timeout-poisoned abort must NOT release the context's back-reference. Resource.ts's
 		// dispatcher deliberately keeps joining a `timedOut` transaction (context?.transaction?.timedOut)

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -5,7 +5,7 @@ const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { transaction } = require('#src/resources/transaction');
-const { DatabaseTransaction, RELEASED_TRANSACTION } = require('#src/resources/DatabaseTransaction');
+const { DatabaseTransaction, RELEASED_TRANSACTION, TRANSACTION_STATE } = require('#src/resources/DatabaseTransaction');
 const { LMDBTransaction } = require('#src/resources/LMDBTransaction');
 const { IterableEventQueue } = require('#src/resources/IterableEventQueue');
 const { RocksDatabase } = require('@harperfast/rocksdb-js');
@@ -226,10 +226,8 @@ describe('Transactions', () => {
 			}
 			assert.equal(entries[0].name, 'thirteen');
 			await TxnTest3.put(14, { name: 'fourteen' }, context);
-			// The preceding get()/search() calls each ran (and durably committed) their own short-lived
-			// transaction once the explicit commit above closed the original one, so there may be nothing
-			// left to commit — but the documented pattern is to keep committing the context's transaction,
-			// and that must stay callable rather than throwing on a released slot.
+			// There may be nothing left to commit here — the documented pattern is to keep committing the
+			// context's transaction regardless, so it must stay callable.
 			await context.transaction.commit();
 			assert.equal((await TxnTest.get(7, context)).name, 'SEVEN');
 			assert.equal((await TxnTest2.get(13, context)).name, 'thirteen');
@@ -827,9 +825,8 @@ describe('Transactions', () => {
 				}
 				await context.transaction.commit();
 				await TxnTest.put({ id: 8, name: 'eight changed' }); // no context
-				// As in 'Can run txn with commit in the middle': the ambient put above ran (and durably
-				// committed) its own short-lived transaction once the explicit commit closed the original
-				// one, and committing the context's transaction again must still be safe.
+				// As in 'Can run txn with commit in the middle': committing the context's transaction again
+				// must stay safe.
 				await context.transaction.commit();
 				assert.equal((await TxnTest.get(8, context)).name, 'eight changed');
 			});
@@ -847,10 +844,8 @@ describe('Transactions', () => {
 			await transaction(context, async () => {
 				await TxnTest.put(90, { name: 'release-on-commit' }, context);
 			});
-			// releaseContext() leaves the shared RELEASED_TRANSACTION in the slot rather than nulling or
-			// deleting it: the completed instance is no longer retained (the point of the release), while
-			// code that legitimately reaches for context.transaction after committing still finds a safe,
-			// completed transaction instead of a null.
+			// The completed instance is no longer retained, and the slot still holds a safe, callable
+			// completed transaction.
 			assert.strictEqual(context.transaction, RELEASED_TRANSACTION);
 			assert.equal((await TxnTest.get(90)).name, 'release-on-commit');
 		});
@@ -897,13 +892,10 @@ describe('Transactions', () => {
 			assert.equal((await TxnTest.get(92)).name, 'first txn on shared context');
 			assert.equal((await TxnTest.get(93)).name, 'second txn on shared context');
 		});
-		// The release must not strand a later write on an uncommitted transaction. It doesn't, and the
-		// reason is worth pinning: resources/transaction.ts:35 only REUSES a context's transaction when
-		// it is still OPEN, so a retained CLOSED one was never reused for a subsequent write anyway —
-		// line 39 minted a fresh DatabaseTransaction either way. Replacing it with the completed
-		// RELEASED_TRANSACTION therefore changes only what stays reachable, not how the next write is
-		// serviced: it still goes through the transaction() wrapper, which commits in onComplete (or
-		// aborts in onError) by construction.
+		// The release must not strand a later write on an uncommitted transaction. It cannot:
+		// resources/transaction.ts only reuses a context's transaction while it is OPEN, so a later write
+		// always goes through the transaction() wrapper, which commits in onComplete (or aborts in
+		// onError) by construction.
 		it('keeps post-completion writes on a reused context durable, with nothing left staged', async function () {
 			const context = {};
 			await transaction(context, async () => {
@@ -923,12 +915,9 @@ describe('Transactions', () => {
 				'no write may be left staged on an uncommitted transaction attached to the reused context'
 			);
 		});
-		// The shape that broke central-manager on 5.2.3 (fabric connect / create + delete cluster all
-		// returned `Cannot read properties of null (reading 'commit')`): a handler that has no
-		// transaction() wrapper of its own, makes a static Resource API call with its context — which
-		// Resource.ts services by minting a transaction ON that context and driving it to a final commit
-		// — and then follows the documented pattern of committing the context's transaction itself. The
-		// release must not turn that documented call into a TypeError.
+		// A handler with no transaction() wrapper of its own makes a static Resource API call with its
+		// context; Resource.ts services that by minting a transaction ON the context and driving it to a
+		// final commit. The handler may then still commit its own context, per the documented pattern.
 		it('lets a handler commit its context after a nested Resource API call completed that context’s transaction', async function () {
 			const context = {};
 			await TxnTest.get(97, context);
@@ -955,8 +944,42 @@ describe('Transactions', () => {
 			// that the shared instance was never claimed or staged into on the way through.
 			assert.equal(RELEASED_TRANSACTION.writes.length, 0, 'nothing may ever be staged on the placeholder');
 			assert.equal(RELEASED_TRANSACTION.db, undefined, 'no store may ever claim the placeholder');
-			assert.throws(() => RELEASED_TRANSACTION.addWrite({}), /already completed/);
 			assert.equal((await TxnTest.get(99)).name, 'not staged on the placeholder');
+		});
+		// The placeholder is one instance shared by every released context, so each way of reaching its
+		// state must fail rather than write through to all of them.
+		it('refuses every route into the shared placeholder’s state', function () {
+			assert.throws(() => RELEASED_TRANSACTION.addWrite({}), /already completed/);
+			assert.throws(() => RELEASED_TRANSACTION.setContext({}), /shared released transaction/);
+			assert.throws(() => RELEASED_TRANSACTION.writes.push({}), TypeError, 'the write set must be frozen too');
+			assert.throws(() => {
+				'use strict';
+				RELEASED_TRANSACTION.open = TRANSACTION_STATE.OPEN;
+			}, TypeError);
+			assert.equal(RELEASED_TRANSACTION.open, TRANSACTION_STATE.CLOSED);
+		});
+		// transaction.commit(context) / transaction.abort(context) assert the caller still owns a live
+		// transaction. That has to hold for every way a transaction stops being live, not just an absent
+		// slot — a completed one can also still be sitting in it.
+		it('keeps transaction.commit()/abort() throwing once there is no live transaction', async function () {
+			assert.throws(() => transaction.commit({}), /No active transaction is available to commit/);
+			assert.throws(() => transaction.abort({}), /No active transaction is available to abort/);
+			const context = {};
+			await transaction(context, async () => {
+				await TxnTest.put(100, { name: 'live' }, context);
+				await transaction.commit(context); // still OPEN: allowed
+			});
+			assert.throws(() => transaction.commit(context), /No active transaction is available to commit/);
+			assert.throws(() => transaction.abort(context), /No active transaction is available to abort/);
+			// Identity is not the test — a completed transaction still parked in the slot (the deferred
+			// release, or LMDB, which never releases at all) must throw too.
+			const completed = new DatabaseTransaction();
+			completed.open = TRANSACTION_STATE.CLOSED;
+			assert.throws(
+				() => transaction.commit({ transaction: completed }),
+				/No active transaction is available to commit/,
+				'a completed transaction still in the slot is not a live one'
+			);
 		});
 		// #1411: a timeout-poisoned abort must NOT release the context's back-reference. Resource.ts's
 		// dispatcher deliberately keeps joining a `timedOut` transaction (context?.transaction?.timedOut)

--- a/unitTests/resources/transaction.test.js
+++ b/unitTests/resources/transaction.test.js
@@ -4,7 +4,8 @@ const { setTimeout: delay } = require('node:timers/promises');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
-const { transaction } = require('#src/resources/transaction');
+const { transaction, contextStorage } = require('#src/resources/transaction');
+const serverUtilities = require('#src/server/serverHelpers/serverUtilities');
 const { DatabaseTransaction, RELEASED_TRANSACTION, TRANSACTION_STATE } = require('#src/resources/DatabaseTransaction');
 const { LMDBTransaction } = require('#src/resources/LMDBTransaction');
 const { IterableEventQueue } = require('#src/resources/IterableEventQueue');
@@ -977,23 +978,44 @@ describe('Transactions', () => {
 				assert.equal((await TxnTest.get(110 + i))?.name, `checkpoint-${i}`, `row ${i} must persist`);
 			}
 		});
-		// Passing a transaction where a context is expected is a supported form; on a released context that
-		// argument is the placeholder, and every route that adopts it must read it as "no transaction"
-		// rather than assign onto the frozen shared instance.
+		// Passing a transaction where a context is expected is a supported form, and on a released context
+		// that argument is the placeholder. Every route that adopts one has to read it as an absent
+		// argument — Resource.create shifts its own arguments and never reaches transactional()'s
+		// normalizer, and transaction() can be handed it directly.
 		it('accepts a released slot wherever a transaction or context is accepted', async function () {
 			const context = {};
 			await transaction(context, async () => {
 				await TxnTest.put(120, { name: 'bare-arg' }, context);
 			});
 			assert.strictEqual(context.transaction, RELEASED_TRANSACTION);
-			await TxnTest.delete(120, context.transaction); // transactional() argument normalization
+			await TxnTest.delete(120, context.transaction);
 			assert.equal(await TxnTest.get(120), undefined, 'the delete must run on a fresh transaction');
-			// Resource.create shifts its own arguments and never reaches that normalizer.
 			const created = await TxnTest.create({ name: 'created-with-released-slot' }, context.transaction);
 			assert.ok(created?.id ?? created, 'create must not fail on a released slot');
-			// transaction() called with the placeholder directly as its context.
 			await transaction(context.transaction, async () => TxnTest.put(121, { name: 'direct' }));
 			assert.equal((await TxnTest.get(121)).name, 'direct');
+		});
+		// "Absent" has to mean the same thing at every route: an absent argument falls through to the
+		// ambient context. Resolving the placeholder to a bare `{}` instead would silently drop the
+		// caller's user, session and timestamp for everything inside.
+		it('keeps the ambient context when a released slot is passed as the context', async function () {
+			const seen = {};
+			await serverUtilities.processLocalTransaction(
+				{ body: { operation: 'test_registered_op', hdb_user: { username: 'ambient_identity' } } },
+				async () => {
+					const context = contextStorage.getStore();
+					await TxnTest.get(130); // completes and releases this context's transaction
+					assert.strictEqual(context.transaction, RELEASED_TRANSACTION);
+					await transaction(context.transaction, async () => {
+						seen.user = contextStorage.getStore()?.user?.username;
+						await TxnTest.put(130, { name: 'ambient' });
+					});
+					await TxnTest.create({ name: 'created-ambient' }, context.transaction);
+					return { message: 'ok' };
+				}
+			);
+			assert.equal(seen.user, 'ambient_identity', 'the ambient user must survive the released-slot route');
+			assert.equal((await TxnTest.get(130)).name, 'ambient');
 		});
 		// #1411: a timeout-poisoned abort must NOT release the context's back-reference. Resource.ts's
 		// dispatcher deliberately keeps joining a `timedOut` transaction (context?.transaction?.timedOut)


### PR DESCRIPTION
Closes #2229.

`releaseContext()` (added in #2030, to stop a long-lived context pinning a completed transaction) set `context.transaction = null`. That introduced a third state for a published slot, and application code cannot interpret it — the next touch throws `Cannot read properties of null (reading 'commit')`.

Committing the current transaction mid-handler and then continuing to use the context is documented in two places: `release-notes/v5-lincoln/v5-migration.md` (`await getContext().transaction.commit()`) and the 4.5.0 notes ("transactions can now be reused after calling `transaction.commit()`"). On 5.2.1+ that pattern 500s. It is what took out central-manager's fabric connect and cluster create/delete on 5.2.3 for any non-super-user, since `getUserPermissions()` commits the caller's transaction mid-request.

A completed transaction now leaves `RELEASED_TRANSACTION` in the slot: one frozen, process-wide completed transaction. `commit()`/`abort()` are no-ops and reads through it see the latest committed state — what the slot did before #2030 — while retention stays O(1) per process rather than O(live contexts), so #2030's measurement is kept. Because the instance is shared, every route that adopts a caller-supplied transaction or context refuses it (`txnForContext`, `transactional()`'s argument normalizer, `Resource.create`'s own argument shift, `transaction()` itself), and `addWrite()`/`setContext()` throw.

Two more callers were broken by the same `null` and are fixed with it: `transaction.commit(context)` (a checkpointing loop that commits every Nth row fails on its **second** checkpoint on 5.2.3 — the intervening write is serviced by its own scope, whose final commit releases the slot), and passing a transaction where a context is expected (`Table.delete(id, context.transaction)`).

## For the human reviewer

1. **The slot is now permanently truthy after first attach, rather than `null`.** The alternative was keeping `null` and changing the docs plus every caller to `context.transaction?.commit()`. That loses: the pattern is published, so the break reaches every app that followed our own docs, and it shipped in a patch. The cost of this direction is that any downstream `if (context.transaction)` flips meaning — I audited every core reader (`transaction.ts`, `Resource.ts`, `Table.ts`'s two `stale` writebacks and `txnForContext`, `HierarchicalNavigableSmallWorld.ts`) and none is truthiness-sensitive, and harper-pro reads `context.transaction` nowhere outside `core/`. Downstream apps and plugins are the residual exposure: `if (context.transaction) context.transaction.addWrite(op)` now enters the branch and throws instead of silently skipping. **Hardest thing to rule on, and the one I most want a second opinion on.**
2. **One shared instance rather than a per-context lightweight closed one.** Sharing is what keeps the memory win. It also means the instance must own no mutable state — hence the small frozen surface rather than a `DatabaseTransaction` subclass, whose inherited `writes` array stayed mutable through `context.transaction.writes.push(...)` and whose `setContext()` could rebind the shared private context. Anything off that surface now fails loudly rather than inheriting behavior that writes through to every other context.
3. **`isReleasedTransaction()` is checked at four call sites rather than being a state on the transaction.** A future adoption site that forgets gets a `TypeError` from the frozen instance — loud, but still a crash. The alternative (brand it, or funnel every adopter through one place) is cheap now and invasive later; I went with the predicate because `Resource.create` keeps its own reference to the argument and reads `context.transaction.startedFrom` back inside the callback, so a funnel-only guard leaves that reference pointing at the frozen object.
4. **"Absent" is standardized as "use the ambient context", not "a fresh empty context".** Every route resolves the placeholder to `undefined` and falls through to `contextStorage.getStore()`. Review flagged that this changes `Resource.create`'s shifted two-argument form, whose isolation on `origin/main` would be lost — so I measured what that form actually did with a real completed transaction in the slot, which is what 5.2.0 had. It resolved to **the caller's own context**, because `DatabaseTransaction` has a `getContext()` and `create` calls it. The private `{}` only ever appeared on 5.2.1–5.2.3, from `context = record || {}` with `null`; it is an artifact of the bug, not behavior to preserve. A shared placeholder cannot carry a back-reference to the context that released it — that is the point of releasing — so the ambient context is the nearest faithful restoration, and it is also what `Table.create(record)` with no second argument already does.
5. **`context.transaction.commit()` stays callable and `transaction.commit(context)` stays a no-op on a completed transaction.** Review pushed twice for the helper to throw instead (a silent no-op can mask a context-lifecycle bug). It threw on 5.2.3 only as a side effect of the `null`, and on 5.2.0 it was a no-op — so keeping the throw would have preserved half the regression, which is how the checkpoint-loop break above was found. Both documented forms now agree.
6. **LMDB is not at parity and the interface comment says so.** `LMDBTransaction` overrides `commit()`/`abort()` and never calls `releaseContext()`, so there the completed transaction stays in the slot — callable, but retained. That gap predates this change; documented rather than closed, since LMDB is deprecated and its LINGERING semantics are load-bearing.
7. **Not in scope, worth knowing:** writes made with a context whose transaction has completed are each committed immediately and individually — no atomicity, no rollback. Identical on 5.2.0, so not part of this regression, but it is why a failed `deleteCluster` can leave a cluster TERMINATED with its instances RUNNING, and it is the real content of central-manager#705. A follow-up makes those writes atomic while the owning scope's commit is still pending.

One claim I made early and had to retract: `txnTime: 0` from the placeholder's `commit()` is **not** a fidelity loss. Measured on both paths — re-committing the real completed transaction also returns `{ txnTime: 0 }`, because the commit that completed it reset its timestamp.

## Verification

Regression range established by running one case on three checkouts — `v5.2.0`, `v5.2.3` (`origin/main`) and this branch: `context.transaction` after a nested Resource-API call, then `commit()`. 5.2.0 leaves the completed CLOSED transaction and the call is a no-op; 5.2.3 throws the production `TypeError`; this branch matches 5.2.0. `getReadTxn()`'s `open !== OPEN` early return and `save()`'s post-commit immediate-commit path, which the original triage blamed, are byte-identical between 5.2.0 and 5.2.3.

Fails-on-base: the tests here fail on unfixed `origin/main` for the right reasons — the two restored `commit in the middle` calls and the ambient handler case with `Cannot read properties of null (reading 'commit')`, the checkpoint loop and the bare-transaction/`create` routes with `No active transaction is available to commit`.

Added: the ambient delivery path (`processLocalTransaction`, the function `serverHandlers.js` calls for every operation, so this is the real operations entry point — only the HTTP transport is absent), the bare-context regression shape, all four adoption routes plus ambient-identity preservation through them, a fresh multi-store chain after release, every route into the shared placeholder's state, and the `transaction.commit()`/`abort()` behavior on absent versus released slots.

Gates, locally: `test:unit:resources` 1593 passing, 0 failing on RocksDB and 1392 passing, 0 failing with `HARPER_STORAGE_ENGINE=lmdb`. `npm run lint:required` and prettier clean. `test:unit:main` and `test:integration:all` could not run in this checkout — long-running Harper processes from other worktrees hold `~/harper/database/system/LOCK`, so both abort on `Resource temporarily unavailable` before any test executes.

Those two ran in CI and passed, which closes the one real gap in the local verification: **42 checks pass, 2 skipped** — all six integration shards on Node 24, Windows, Bun and uWS, plus unit tests on Node 22/24/26. One Next.js adapter leg was cancelled on a 30-minute `Install Playwright browsers` download timeout, before reaching any test; it passed on re-run.

Not verified: MQTT long-lived-context reattach (the scenario motivating #2030 — untested before this change too), and an operations-HTTP or central-manager flow end to end.

Complexity: complicated

<sub>Review-Coverage: authored=unknown; ran=none; rounds=1 @ d746a30801ea</sub>

<sub>Human-Review-Need: 4 @ d746a30801ea</sub>
