### PR TITLE
Correct blind-write transaction bookkeeping and bring those transactions under the long-transaction monitor

### DIFF
--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -400,14 +400,12 @@ export class DatabaseTransaction implements Transaction {
 		// snapshot that blocks compaction. Only applied when creating the transaction fresh; an
 		// already-open transaction keeps whatever snapshot mode it was created with.
 		// `coordinatedRetry` signals IsBusy write conflicts as RETRY_NOW rather than ERR_BUSY.
-		this.transaction = new RocksTransaction(this.db.store, { coordinatedRetry: true, disableSnapshot });
+		this.attachOwnedTransaction(new RocksTransaction(this.db.store, { coordinatedRetry: true, disableSnapshot }));
 
 		if (this.timestamp) {
 			this.transaction.setTimestamp(this.timestamp);
 		}
 
-		this.readTxnsUsed = 1;
-		this.baseReadRefConsumed = false; // fresh handle, fresh base reference for commit() to consume
 		if (DEBUG_LONG_TXNS) {
 			this.stackTraces = [new StartedTransaction()];
 		}
@@ -415,6 +413,22 @@ export class DatabaseTransaction implements Transaction {
 		trackedTxns.add(this);
 		if (trackedTxns.size > readTxnQueueDepthHighWater) readTxnQueueDepthHighWater = trackedTxns.size;
 		return this.transaction;
+	}
+
+	// Monitor state is not ownership state: it stays with `trackedTxns.add` in getReadTxn().
+	private attachOwnedTransaction(transaction: RocksTransactionWithRetry): void {
+		this.transaction = transaction;
+		this.readTxnsUsed = 1;
+		this.baseReadRefConsumed = false;
+	}
+
+	private detachOwnedTransaction(): RocksTransactionWithRetry | null {
+		const transaction = this.transaction;
+		trackedTxns.delete(this);
+		this.transaction = null;
+		this.readTxnsUsed = 0;
+		this.readTxnRefCount = 0;
+		return transaction;
 	}
 
 	useReadTxn(disableSnapshot?: boolean) {
@@ -432,9 +446,16 @@ export class DatabaseTransaction implements Transaction {
 			// transaction (see the outstanding-iterators branch in commit()), so aborting it here
 			// discards nothing — the replay re-staged the writes AND their audit/txn-log entries
 			// into its own transaction; this handle's never-committed log batch dies with it.
-			trackedTxns.delete(this);
-			this.transaction?.abort();
-			this.transaction = null;
+			const transaction = this.detachOwnedTransaction();
+			try {
+				transaction?.abort();
+			} catch (error) {
+				// Contained, not ignored: abort() calls this before it marks the wrapper CLOSED, clears
+				// writes and releases the context. Warn rather than debug — reached from abort()'s drain
+				// loop the handle can still hold write intents, and stalled writers with a clean log is
+				// the worst outcome here.
+				harperLogger.warn?.('Failed to release a transaction’s native handle', error);
+			}
 			this.completeDeferredContextRelease();
 		}
 	}
@@ -446,14 +467,12 @@ export class DatabaseTransaction implements Transaction {
 	 * abort (an in-flight replay commit owns them), only the snapshot's lifetime is enforced.
 	 */
 	releaseReadTxn(): void {
-		trackedTxns.delete(this);
-		this.readTxnsUsed = 0; // doneReadTxn() no-ops for the remaining iterators (guarded on this.transaction)
+		const transaction = this.detachOwnedTransaction();
 		try {
-			this.transaction?.abort();
+			transaction?.abort();
 		} catch (error) {
 			harperLogger.debug?.('releasing timed-out read transaction', error);
 		}
-		this.transaction = null;
 		this.completeDeferredContextRelease();
 	}
 
@@ -470,7 +489,12 @@ export class DatabaseTransaction implements Transaction {
 	}
 
 	disregardReadTxn(): void {
-		if (--this.readTxnRefCount === 0 && this.readTxnsUsed === 1) {
+		// Never release a handle carrying staged writes: commit() skips re-staging a write it has marked
+		// saved, so aborting the handle here drops it. The count is clamped because every getReadTxn()
+		// increments it but only this releases, so an unpaired call would drive it negative and cancel
+		// out a later handle's references.
+		if (this.readTxnRefCount > 0 && --this.readTxnRefCount === 0 && this.readTxnsUsed === 1) {
+			if (this.writes.some((write) => write)) return;
 			this.doneReadTxn();
 		}
 	}
@@ -658,7 +682,7 @@ export class DatabaseTransaction implements Transaction {
 				harperLogger.warn?.('Created new transaction in save, but the store does match existing store', transaction.id);
 			}
 			if (this.open === TRANSACTION_STATE.OPEN) {
-				this.transaction = transaction;
+				this.attachOwnedTransaction(transaction);
 			} else {
 				// if it is closed, we have to immediately commit, using our immediate transaction
 				immediateCommit = true;
@@ -810,8 +834,7 @@ export class DatabaseTransaction implements Transaction {
 					}
 				} else {
 					// no more reads need to be performed, just commit/abort based if there are any writes
-					trackedTxns.delete(this);
-					this.transaction = null; // clear transaction so any further operations operate immediately
+					this.detachOwnedTransaction(); // any further operations operate immediately
 					if (transaction) {
 						this.writes = this.writes.filter((write) => write); // filter out removed entries
 						if (this.writes.length > 0) {
@@ -1074,22 +1097,19 @@ export class DatabaseTransaction implements Transaction {
 	 * first, then abort each link's native transaction and release its DatabaseTransaction-level
 	 * resources. Two passes (mirroring abortDueToTimeout) so a throw while aborting one link can't leave
 	 * later links (this.next) holding native handles / read snapshots until GC. `headTransaction` is the
-	 * head link's native transaction, which commit() detached to a local before this point
-	 * (this.transaction is already null), so it is aborted directly; every other link still owns its
-	 * native transaction on `txn.transaction`.
+	 * head link's native transaction, which commit() detached to a local before this point, so it is
+	 * aborted directly; every other link still owns its native transaction on `txn.transaction`. The
+	 * head can still hold a retained read handle here (commit()'s outstanding-iterators branch), which
+	 * its iterators release.
 	 */
 	abortChainAfterRetries(headTransaction: RocksTransaction): void {
 		for (let txn: DatabaseTransaction = this; txn; txn = txn.next) {
 			txn.open = TRANSACTION_STATE.CLOSED;
 		}
 		for (let txn: DatabaseTransaction = this; txn; txn = txn.next) {
-			const nativeTxn = txn === this ? headTransaction : txn.transaction;
-			// Clear the native handle and read-snapshot bookkeeping so the abort() below only performs
-			// non-native cleanup (blobs, writes) and can't double-abort (RocksTransaction.abort() throws
-			// on an already-aborted handle) or spin abort()'s doneReadTxn loop on a nulled handle.
-			txn.transaction = null;
-			txn.readTxnsUsed = 0;
-			trackedTxns.delete(txn);
+			// Detach first so the abort() below performs only non-native cleanup and can't double-abort.
+			const detached = txn.detachOwnedTransaction();
+			const nativeTxn = txn === this ? headTransaction : detached;
 			try {
 				nativeTxn?.abort();
 			} catch (abortError) {
@@ -1142,8 +1162,27 @@ export class DatabaseTransaction implements Transaction {
 		}
 	}
 	directCommitSync(): void {
-		trackedTxns.delete(this);
-		this.transaction?.commitSync();
+		const transaction = this.transaction;
+		try {
+			transaction?.commitSync();
+		} catch (error) {
+			// Still uncommitted and still holding its write intents, and no caller aborts after this
+			// throws. abort() rather than the native abort alone: it reclaims blobs a replayed write
+			// staged.
+			this.detachOwnedTransaction();
+			try {
+				transaction?.abort();
+			} catch (abortError) {
+				harperLogger.debug?.('aborting a transaction whose synchronous commit failed', abortError);
+			}
+			try {
+				this.abort();
+			} catch (abortError) {
+				harperLogger.debug?.('cleaning up after a failed synchronous commit', abortError);
+			}
+			throw error;
+		}
+		this.detachOwnedTransaction();
 	}
 	getContext() {
 		return this.#context;

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -436,10 +436,19 @@ export class DatabaseTransaction implements Transaction {
 	 * one. Membership is keyed on the root but claimed per link, so removing it on any link's detach
 	 * would unsupervise a logical transaction still holding writes elsewhere in the chain.
 	 */
-	/** Drop the whole chain's supervision, however its links got there. */
+	/**
+	 * Give up on the whole chain: release any handle its links still hold, then drop the supervision
+	 * that was the only remaining way to find them. Clearing the bookkeeping alone would strand a live
+	 * handle in neither registry — the chained-commit throw this exists for is exactly the case where a
+	 * link never reached its own detach. Snapshots only, matching the CLOSED branch that calls this:
+	 * staged writes may be riding an in-flight replay commit and are not the monitor's to drop.
+	 */
 	dropWriteSupervision(): void {
 		const root = this.root ?? this;
-		for (let link: DatabaseTransaction = root; link; link = link.next) link.writeSupervised = false;
+		for (let link: DatabaseTransaction = root; link; link = link.next) {
+			if (link.transaction) link.releaseReadTxn(); // detaches, which clears this link's own claim
+			link.writeSupervised = false;
+		}
 		supervisedWriteRoots.delete(root);
 	}
 

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -1069,10 +1069,7 @@ export class DatabaseTransaction implements Transaction {
 	}
 	abort(): void {
 		while (this.readTxnsUsed > 0) this.doneReadTxn(); // release the read snapshot when we abort, we assume we don't need it
-		// A write-only transaction never took a read reference (getReadTxn was never called), so the loop
-		// above releases nothing even though save() created a native handle; release it here instead of
-		// leaking the handle and its snapshot until GC. abortChainAfterRetries() detaches the handle
-		// before calling abort(), so this is a no-op there rather than a double-abort.
+		// Defensively release any native handle whose reference bookkeeping was already consumed.
 		if (this.transaction) this.releaseReadTxn();
 		this.open = TRANSACTION_STATE.CLOSED;
 		this.drainCompletions();
@@ -1097,21 +1094,29 @@ export class DatabaseTransaction implements Transaction {
 	 * later links (this.next) holding native handles / read snapshots until GC. `headTransaction` is the
 	 * head link's native transaction, which commit() detached to a local before this point, so it is
 	 * aborted directly; every other link still owns its native transaction on `txn.transaction`. The
-	 * head can still hold a retained read handle here (commit()'s outstanding-iterators branch), which
-	 * its iterators release.
+	 * head can also own a retained read handle from commit()'s outstanding-iterators branch, separate
+	 * from the replay transaction; retry exhaustion aborts both.
 	 */
 	abortChainAfterRetries(headTransaction: RocksTransaction): void {
 		for (let txn: DatabaseTransaction = this; txn; txn = txn.next) {
 			txn.open = TRANSACTION_STATE.CLOSED;
 		}
 		for (let txn: DatabaseTransaction = this; txn; txn = txn.next) {
-			// Detach first so the abort() below performs only non-native cleanup and can't double-abort.
 			const detached = txn.detachOwnedTransaction();
-			const nativeTxn = txn === this ? headTransaction : detached;
+			const committingTransaction = txn === this ? headTransaction : detached;
 			try {
-				nativeTxn?.abort();
+				committingTransaction?.abort();
 			} catch (abortError) {
 				harperLogger.debug?.('aborting conflicted transaction in chain after exhausting retries', abortError);
+			}
+			// With outstanding iterators, the head owns a retained read handle while the retry commits
+			// through a separate replay handle. Both must be aborted after retry exhaustion.
+			if (txn === this && detached && detached !== committingTransaction) {
+				try {
+					detached.abort();
+				} catch (abortError) {
+					harperLogger.debug?.('aborting retained read transaction after exhausting retries', abortError);
+				}
 			}
 			try {
 				// abort() synchronously walks savedBlobs and can call write.store.getEntry(), which can throw

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -1073,19 +1073,21 @@ export class DatabaseTransaction implements Transaction {
 		if (this.transaction) this.releaseReadTxn();
 		this.open = TRANSACTION_STATE.CLOSED;
 		this.drainCompletions();
-		for (const write of this.writes) {
-			if (write?.savedBlobs)
-				cleanupUnusedBlobs(write.savedBlobs, collectRetainedFileIds(write.store.getEntry(write.key)?.value));
+		try {
+			for (const write of this.writes) {
+				if (write?.savedBlobs)
+					cleanupUnusedBlobs(write.savedBlobs, collectRetainedFileIds(write.store.getEntry(write.key)?.value));
+			}
+		} finally {
+			this.clearWrites();
+			// A timeout-poisoned abort (abortDueToTimeout()) is the one abort that is NOT "reuse-free":
+			// Resource.ts's dispatcher deliberately keeps joining a `timedOut` transaction (instead of
+			// starting a fresh one) so the rest of the logical operation fails atomically via the
+			// poison check in addWrite()/commit(), rather than silently landing a later write on a
+			// brand-new transaction after an earlier one was rolled back (#1411). Releasing here would
+			// make that check see `undefined?.timedOut` and take the "start fresh" branch instead.
+			this.releaseContext(!this.timedOut);
 		}
-		// reset the transaction
-		this.clearWrites();
-		// A timeout-poisoned abort (abortDueToTimeout()) is the one abort that is NOT "reuse-free":
-		// Resource.ts's dispatcher deliberately keeps joining a `timedOut` transaction (instead of
-		// starting a fresh one) so the rest of the logical operation fails atomically via the
-		// poison check in addWrite()/commit(), rather than silently landing a later write on a
-		// brand-new transaction after an earlier one was rolled back (#1411). Releasing here would
-		// make that check see `undefined?.timedOut` and take the "start fresh" branch instead.
-		this.releaseContext(!this.timedOut);
 	}
 	/**
 	 * Give up on a chain of linked transactions after exhausting conflict retries: poison every link

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -519,7 +519,7 @@ export class DatabaseTransaction implements Transaction {
 		// increments it but only this releases, so an unpaired call would drive it negative and cancel
 		// out a later handle's references.
 		if (this.readTxnRefCount > 0 && --this.readTxnRefCount === 0 && this.readTxnsUsed === 1) {
-			for (const write of this.writes) if (write) return;
+			if (this.writes.length > 0) return;
 			this.doneReadTxn();
 		}
 	}

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -437,9 +437,11 @@ export class DatabaseTransaction implements Transaction {
 		this.readTxnRefCount = 0;
 		if (supervisedWriteRoots.size) {
 			const root = this.root ?? this;
-			let link: DatabaseTransaction = root;
-			while (link && !link.transaction) link = link.next;
-			if (!link) supervisedWriteRoots.delete(root);
+			if (supervisedWriteRoots.has(root)) {
+				let link: DatabaseTransaction = root;
+				while (link && !link.transaction) link = link.next;
+				if (!link) supervisedWriteRoots.delete(root);
+			}
 		}
 		return transaction;
 	}
@@ -1113,6 +1115,15 @@ export class DatabaseTransaction implements Transaction {
 			// brand-new transaction after an earlier one was rolled back (#1411). Releasing here would
 			// make that check see `undefined?.timedOut` and take the "start fresh" branch instead.
 			this.releaseContext(!this.timedOut);
+			const next = this.next;
+			this.next = null;
+			if (next) {
+				try {
+					next.abort();
+				} catch (error) {
+					harperLogger.debug?.('cleaning up a chained transaction during abort', error);
+				}
+			}
 		}
 	}
 	/**

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -519,7 +519,7 @@ export class DatabaseTransaction implements Transaction {
 		// increments it but only this releases, so an unpaired call would drive it negative and cancel
 		// out a later handle's references.
 		if (this.readTxnRefCount > 0 && --this.readTxnRefCount === 0 && this.readTxnsUsed === 1) {
-			if (this.writes.some((write) => write)) return;
+			for (const write of this.writes) if (write) return;
 			this.doneReadTxn();
 		}
 	}

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -399,14 +399,12 @@ export class DatabaseTransaction implements Transaction {
 		// snapshot that blocks compaction. Only applied when creating the transaction fresh; an
 		// already-open transaction keeps whatever snapshot mode it was created with.
 		// `coordinatedRetry` signals IsBusy write conflicts as RETRY_NOW rather than ERR_BUSY.
-		this.transaction = new RocksTransaction(this.db.store, { coordinatedRetry: true, disableSnapshot });
+		this.attachOwnedTransaction(new RocksTransaction(this.db.store, { coordinatedRetry: true, disableSnapshot }));
 
 		if (this.timestamp) {
 			this.transaction.setTimestamp(this.timestamp);
 		}
 
-		this.readTxnsUsed = 1;
-		this.baseReadRefConsumed = false; // fresh handle, fresh base reference for commit() to consume
 		if (DEBUG_LONG_TXNS) {
 			this.stackTraces = [new StartedTransaction()];
 		}
@@ -414,6 +412,22 @@ export class DatabaseTransaction implements Transaction {
 		trackedTxns.add(this);
 		if (trackedTxns.size > readTxnQueueDepthHighWater) readTxnQueueDepthHighWater = trackedTxns.size;
 		return this.transaction;
+	}
+
+	// Monitor state is not ownership state: it stays with `trackedTxns.add` in getReadTxn().
+	private attachOwnedTransaction(transaction: RocksTransactionWithRetry): void {
+		this.transaction = transaction;
+		this.readTxnsUsed = 1;
+		this.baseReadRefConsumed = false;
+	}
+
+	private detachOwnedTransaction(): RocksTransactionWithRetry | null {
+		const transaction = this.transaction;
+		trackedTxns.delete(this);
+		this.transaction = null;
+		this.readTxnsUsed = 0;
+		this.readTxnRefCount = 0;
+		return transaction;
 	}
 
 	useReadTxn(disableSnapshot?: boolean) {
@@ -431,9 +445,14 @@ export class DatabaseTransaction implements Transaction {
 			// transaction (see the outstanding-iterators branch in commit()), so aborting it here
 			// discards nothing — the replay re-staged the writes AND their audit/txn-log entries
 			// into its own transaction; this handle's never-committed log batch dies with it.
-			trackedTxns.delete(this);
-			this.transaction?.abort();
-			this.transaction = null;
+			const transaction = this.detachOwnedTransaction();
+			try {
+				transaction?.abort();
+			} catch (error) {
+				// abort() calls this before it marks the wrapper CLOSED, clears writes and releases the
+				// context; a throw here would strand all three and mask the caller's original error.
+				harperLogger.debug?.('releasing a drained read transaction', error);
+			}
 			this.completeDeferredContextRelease();
 		}
 	}
@@ -445,14 +464,12 @@ export class DatabaseTransaction implements Transaction {
 	 * abort (an in-flight replay commit owns them), only the snapshot's lifetime is enforced.
 	 */
 	releaseReadTxn(): void {
-		trackedTxns.delete(this);
-		this.readTxnsUsed = 0; // doneReadTxn() no-ops for the remaining iterators (guarded on this.transaction)
+		const transaction = this.detachOwnedTransaction();
 		try {
-			this.transaction?.abort();
+			transaction?.abort();
 		} catch (error) {
 			harperLogger.debug?.('releasing timed-out read transaction', error);
 		}
-		this.transaction = null;
 		this.completeDeferredContextRelease();
 	}
 
@@ -469,7 +486,12 @@ export class DatabaseTransaction implements Transaction {
 	}
 
 	disregardReadTxn(): void {
-		if (--this.readTxnRefCount === 0 && this.readTxnsUsed === 1) {
+		// Never release a handle carrying staged writes: commit() skips re-staging a write it has marked
+		// saved, so aborting the handle here drops it. The count is clamped because every getReadTxn()
+		// increments it but only this releases, so an unpaired call would drive it negative and cancel
+		// out a later handle's references.
+		if (this.readTxnRefCount > 0 && --this.readTxnRefCount === 0 && this.readTxnsUsed === 1) {
+			if (this.writes.some((write) => write)) return;
 			this.doneReadTxn();
 		}
 	}
@@ -612,7 +634,7 @@ export class DatabaseTransaction implements Transaction {
 				harperLogger.warn?.('Created new transaction in save, but the store does match existing store', transaction.id);
 			}
 			if (this.open === TRANSACTION_STATE.OPEN) {
-				this.transaction = transaction;
+				this.attachOwnedTransaction(transaction);
 			} else {
 				// if it is closed, we have to immediately commit, using our immediate transaction
 				immediateCommit = true;
@@ -763,8 +785,7 @@ export class DatabaseTransaction implements Transaction {
 					}
 				} else {
 					// no more reads need to be performed, just commit/abort based if there are any writes
-					trackedTxns.delete(this);
-					this.transaction = null; // clear transaction so any further operations operate immediately
+					this.detachOwnedTransaction(); // any further operations operate immediately
 					if (transaction) {
 						this.writes = this.writes.filter((write) => write); // filter out removed entries
 						if (this.writes.length > 0) {
@@ -1025,22 +1046,19 @@ export class DatabaseTransaction implements Transaction {
 	 * first, then abort each link's native transaction and release its DatabaseTransaction-level
 	 * resources. Two passes (mirroring abortDueToTimeout) so a throw while aborting one link can't leave
 	 * later links (this.next) holding native handles / read snapshots until GC. `headTransaction` is the
-	 * head link's native transaction, which commit() detached to a local before this point
-	 * (this.transaction is already null), so it is aborted directly; every other link still owns its
-	 * native transaction on `txn.transaction`.
+	 * head link's native transaction, which commit() detached to a local before this point, so it is
+	 * aborted directly; every other link still owns its native transaction on `txn.transaction`. The
+	 * head can still hold a retained read handle here (commit()'s outstanding-iterators branch), which
+	 * its iterators release.
 	 */
 	abortChainAfterRetries(headTransaction: RocksTransaction): void {
 		for (let txn: DatabaseTransaction = this; txn; txn = txn.next) {
 			txn.open = TRANSACTION_STATE.CLOSED;
 		}
 		for (let txn: DatabaseTransaction = this; txn; txn = txn.next) {
-			const nativeTxn = txn === this ? headTransaction : txn.transaction;
-			// Clear the native handle and read-snapshot bookkeeping so the abort() below only performs
-			// non-native cleanup (blobs, writes) and can't double-abort (RocksTransaction.abort() throws
-			// on an already-aborted handle) or spin abort()'s doneReadTxn loop on a nulled handle.
-			txn.transaction = null;
-			txn.readTxnsUsed = 0;
-			trackedTxns.delete(txn);
+			// Detach first so the abort() below performs only non-native cleanup and can't double-abort.
+			const detached = txn.detachOwnedTransaction();
+			const nativeTxn = txn === this ? headTransaction : detached;
 			try {
 				nativeTxn?.abort();
 			} catch (abortError) {
@@ -1093,8 +1111,27 @@ export class DatabaseTransaction implements Transaction {
 		}
 	}
 	directCommitSync(): void {
-		trackedTxns.delete(this);
-		this.transaction?.commitSync();
+		const transaction = this.transaction;
+		try {
+			transaction?.commitSync();
+		} catch (error) {
+			// Still uncommitted and still holding its write intents, and no caller aborts after this
+			// throws. abort() rather than the native abort alone: it reclaims blobs a replayed write
+			// staged.
+			this.detachOwnedTransaction();
+			try {
+				transaction?.abort();
+			} catch (abortError) {
+				harperLogger.debug?.('aborting a transaction whose synchronous commit failed', abortError);
+			}
+			try {
+				this.abort();
+			} catch (abortError) {
+				harperLogger.debug?.('cleaning up after a failed synchronous commit', abortError);
+			}
+			throw error;
+		}
+		this.detachOwnedTransaction();
 	}
 	getContext() {
 		return this.#context;

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -16,6 +16,11 @@ import type { Entry } from './RecordEncoder.ts';
 import { toBufferKey } from 'ordered-binary';
 
 const trackedTxns = new Set<DatabaseTransaction>();
+// Logical transactions the monitor supervises for their WRITES, kept apart from trackedTxns because the
+// two have different units and different consumers: trackedTxns is per-link, bounds a read snapshot, and
+// is what the read-queue-depth metric counts, while this holds one entry per logical transaction — the
+// chain root — so a chain child can never become its own timeout root (issue #2231).
+const supervisedWriteRoots = new Set<DatabaseTransaction>();
 const MAX_OUTSTANDING_TXN_DURATION = convertToMS(envMngr.get(CONFIG_PARAMS.STORAGE_MAXTRANSACTIONQUEUETIME)) || 45000; // Allow write transactions to be queued for up to 45 seconds before we start rejecting them
 const DEBUG_LONG_TXNS = envMngr.get(CONFIG_PARAMS.STORAGE_DEBUGLONGTRANSACTIONS);
 export const TRANSACTION_STATE = {
@@ -341,6 +346,10 @@ export class DatabaseTransaction implements Transaction {
 	timestamp = 0;
 	retries = 0;
 	declare next: DatabaseTransaction;
+	// The head of this multi-store chain, set when the link is created; absent on the head itself.
+	declare root?: DatabaseTransaction;
+	// Whether this link is why its chain root is write-supervised (see endWriteSupervision).
+	declare writeSupervised?: boolean;
 	declare stale: boolean;
 	// Whether this read handle's base reference (readTxnsUsed starts at 1 in getReadTxn) has been
 	// consumed by a commit round; iterator references are consumed only by doneReadTxn().
@@ -422,9 +431,36 @@ export class DatabaseTransaction implements Transaction {
 		this.baseReadRefConsumed = false;
 	}
 
+	/**
+	 * Drop this link's supervision claim, and the root's with it once no link in the chain still holds
+	 * one. Membership is keyed on the root but claimed per link, so removing it on any link's detach
+	 * would unsupervise a logical transaction still holding writes elsewhere in the chain.
+	 */
+	/**
+	 * End supervision for the whole chain. abort() cleans only its own link, so a claim held by a chain
+	 * link would otherwise keep the root enrolled for the life of the process — the monitor revisiting a
+	 * CLOSED transaction every tick, and the registry pinning the chain beyond GC's reach.
+	 */
+	private endChainWriteSupervision(): void {
+		const root = this.root ?? this;
+		for (let link: DatabaseTransaction = root; link; link = link.next) link.writeSupervised = false;
+		supervisedWriteRoots.delete(root);
+	}
+
+	private endWriteSupervision(): void {
+		if (!this.writeSupervised) return;
+		this.writeSupervised = false;
+		const root = this.root ?? this;
+		for (let link: DatabaseTransaction = root; link; link = link.next) {
+			if (link.writeSupervised) return;
+		}
+		supervisedWriteRoots.delete(root);
+	}
+
 	private detachOwnedTransaction(): RocksTransactionWithRetry | null {
 		const transaction = this.transaction;
 		trackedTxns.delete(this);
+		this.endWriteSupervision();
 		this.transaction = null;
 		this.readTxnsUsed = 0;
 		this.readTxnRefCount = 0;
@@ -683,6 +719,21 @@ export class DatabaseTransaction implements Transaction {
 			}
 			if (this.open === TRANSACTION_STATE.OPEN) {
 				this.attachOwnedTransaction(transaction);
+				// A write that never read is otherwise invisible to the long-transaction monitor: its
+				// handle was adopted here rather than in getReadTxn(), which is the only other place that
+				// registers. Supervise the chain root, so the monitor reaps the logical transaction as one
+				// unit. Replay is excluded deliberately — it is synchronous, already bounded by its own
+				// stall and wall-clock guards, and commits at timestamp boundaries that a monitor-driven
+				// commit could split.
+				if (!this.isReplay) {
+					this.writeSupervised = true;
+					const root = this.root ?? this;
+					// The monitor decays the root's idle limit, but only getReadTxn() and addWrite() arm it,
+					// and neither has necessarily run on a root whose chain link took the write — an unarmed
+					// limit decays to NaN, which is never <= 0, so the transaction would never be reaped.
+					if (root.timeout === undefined) root.timeout = Math.max(txnExpiration, root.timeoutBudget ?? 0);
+					supervisedWriteRoots.add(root);
+				}
 			} else {
 				// if it is closed, we have to immediately commit, using our immediate transaction
 				immediateCommit = true;
@@ -1084,6 +1135,7 @@ export class DatabaseTransaction implements Transaction {
 		}
 		// reset the transaction
 		this.clearWrites();
+		this.endChainWriteSupervision();
 		// A timeout-poisoned abort (abortDueToTimeout()) is the one abort that is NOT "reuse-free":
 		// Resource.ts's dispatcher deliberately keeps joining a `timedOut` transaction (instead of
 		// starting a fresh one) so the rest of the logical operation fails atomically via the
@@ -1255,7 +1307,14 @@ function chainStillActive(txn: DatabaseTransaction): boolean {
 
 function startMonitoringTxns() {
 	timer = setInterval(function () {
-		for (const txn of trackedTxns) {
+		// Both registries, in sequence rather than as a union: a root can be in each (it read, and a
+		// later link blind-wrote), and the membership check is cheaper than allocating per tick.
+		for (const txn of trackedTxns) monitorTransaction(txn);
+		for (const txn of supervisedWriteRoots) if (!trackedTxns.has(txn)) monitorTransaction(txn);
+	}, txnExpiration).unref();
+
+	function monitorTransaction(txn: DatabaseTransaction) {
+		{
 			// Decay write recency once per tick for every tracked link, independent of the `timeout`
 			// branches below — a tracked link that keeps its own idle limit alive by reading must not
 			// thereby keep chainStillActive believing it was written recently too.
@@ -1322,7 +1381,7 @@ function startMonitoringTxns() {
 				txn.timeout -= txnExpiration;
 			}
 		}
-	}, txnExpiration).unref();
+	}
 }
 
 startMonitoringTxns();
@@ -1334,6 +1393,11 @@ startMonitoringTxns();
  */
 export function resetReplayedWritesWarning() {
 	replayedWritesWarned = false;
+}
+
+/** Test seam: whether the monitor supervises this logical transaction for its writes. */
+export function isWriteSupervised(txn: DatabaseTransaction): boolean {
+	return supervisedWriteRoots.has(txn);
 }
 
 export function setTxnExpiration(ms) {

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -16,6 +16,11 @@ import type { Entry } from './RecordEncoder.ts';
 import { toBufferKey } from 'ordered-binary';
 
 const trackedTxns = new Set<DatabaseTransaction>();
+// Logical transactions the monitor supervises for their WRITES, kept apart from trackedTxns because the
+// two have different units and different consumers: trackedTxns is per-link, bounds a read snapshot, and
+// is what the read-queue-depth metric counts, while this holds one entry per logical transaction — the
+// chain root — so a chain child can never become its own timeout root (issue #2231).
+const supervisedWriteRoots = new Set<DatabaseTransaction>();
 const MAX_OUTSTANDING_TXN_DURATION = convertToMS(envMngr.get(CONFIG_PARAMS.STORAGE_MAXTRANSACTIONQUEUETIME)) || 45000; // Allow write transactions to be queued for up to 45 seconds before we start rejecting them
 const DEBUG_LONG_TXNS = envMngr.get(CONFIG_PARAMS.STORAGE_DEBUGLONGTRANSACTIONS);
 export const TRANSACTION_STATE = {
@@ -341,6 +346,8 @@ export class DatabaseTransaction implements Transaction {
 	timestamp = 0;
 	retries = 0;
 	declare next: DatabaseTransaction;
+	// The head of this multi-store chain, set when the link is created; absent on the head itself.
+	declare root?: DatabaseTransaction;
 	declare stale: boolean;
 	// Whether this read handle's base reference (readTxnsUsed starts at 1 in getReadTxn) has been
 	// consumed by a commit round; iterator references are consumed only by doneReadTxn().
@@ -425,6 +432,7 @@ export class DatabaseTransaction implements Transaction {
 	private detachOwnedTransaction(): RocksTransactionWithRetry | null {
 		const transaction = this.transaction;
 		trackedTxns.delete(this);
+		supervisedWriteRoots.delete(this.root ?? this);
 		this.transaction = null;
 		this.readTxnsUsed = 0;
 		this.readTxnRefCount = 0;
@@ -683,6 +691,13 @@ export class DatabaseTransaction implements Transaction {
 			}
 			if (this.open === TRANSACTION_STATE.OPEN) {
 				this.attachOwnedTransaction(transaction);
+				// A write that never read is otherwise invisible to the long-transaction monitor: its
+				// handle was adopted here rather than in getReadTxn(), which is the only other place that
+				// registers. Supervise the chain root, so the monitor reaps the logical transaction as one
+				// unit. Replay is excluded deliberately — it is synchronous, already bounded by its own
+				// stall and wall-clock guards, and commits at timestamp boundaries that a monitor-driven
+				// commit could split.
+				if (!this.isReplay) supervisedWriteRoots.add(this.root ?? this);
 			} else {
 				// if it is closed, we have to immediately commit, using our immediate transaction
 				immediateCommit = true;
@@ -1255,7 +1270,9 @@ function chainStillActive(txn: DatabaseTransaction): boolean {
 
 function startMonitoringTxns() {
 	timer = setInterval(function () {
-		for (const txn of trackedTxns) {
+		// A root can be in both registries (it read, and a later link blind-wrote), so the union is taken
+		// rather than iterating them in sequence. Allocated only when something is write-supervised.
+		for (const txn of supervisedWriteRoots.size ? new Set([...trackedTxns, ...supervisedWriteRoots]) : trackedTxns) {
 			// Decay write recency once per tick for every tracked link, independent of the `timeout`
 			// branches below — a tracked link that keeps its own idle limit alive by reading must not
 			// thereby keep chainStillActive believing it was written recently too.
@@ -1334,6 +1351,14 @@ startMonitoringTxns();
  */
 export function resetReplayedWritesWarning() {
 	replayedWritesWarned = false;
+}
+
+/**
+ * Test seam: the logical transactions the monitor supervises for their writes, alongside the read-tracked
+ * set that setTxnExpiration() returns.
+ */
+export function getSupervisedWriteRoots() {
+	return supervisedWriteRoots;
 }
 
 export function setTxnExpiration(ms) {

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -1110,6 +1110,11 @@ export class DatabaseTransaction implements Transaction {
 		while (this.readTxnsUsed > 0) this.doneReadTxn(); // release the read snapshot when we abort, we assume we don't need it
 		// Defensively release any native handle whose reference bookkeeping was already consumed.
 		if (this.transaction) this.releaseReadTxn();
+		// abortDueToTimeout() and abortChainAfterRetries() walk the chain themselves, but an ordinary
+		// application-error abort never did, so a link that took a blind write kept its native handle,
+		// its write intents and its supervision claim until GC. Re-entrant by design: every step here is
+		// idempotent, so the walking callers reaching this again is harmless.
+		for (let link: DatabaseTransaction = this.next; link; link = link.next) link.abort();
 		this.open = TRANSACTION_STATE.CLOSED;
 		this.drainCompletions();
 		try {
@@ -1152,6 +1157,9 @@ export class DatabaseTransaction implements Transaction {
 			txn.open = TRANSACTION_STATE.CLOSED;
 		}
 		for (let txn: DatabaseTransaction = this; txn; txn = txn.next) {
+			// Detach first so the abort() below performs only non-native cleanup, and so its doneReadTxn
+			// loop cannot spin on a nulled handle. Not to avoid a double abort: rocksdb-js tolerates
+			// abort-after-abort, and it is abort-after-COMMIT that throws.
 			const detached = txn.detachOwnedTransaction();
 			const committingTransaction = txn === this ? headTransaction : detached;
 			try {

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -432,10 +432,15 @@ export class DatabaseTransaction implements Transaction {
 	private detachOwnedTransaction(): RocksTransactionWithRetry | null {
 		const transaction = this.transaction;
 		trackedTxns.delete(this);
-		supervisedWriteRoots.delete(this.root ?? this);
 		this.transaction = null;
 		this.readTxnsUsed = 0;
 		this.readTxnRefCount = 0;
+		if (supervisedWriteRoots.size) {
+			const root = this.root ?? this;
+			let link: DatabaseTransaction = root;
+			while (link && !link.transaction) link = link.next;
+			if (!link) supervisedWriteRoots.delete(root);
+		}
 		return transaction;
 	}
 
@@ -697,7 +702,11 @@ export class DatabaseTransaction implements Transaction {
 				// unit. Replay is excluded deliberately — it is synchronous, already bounded by its own
 				// stall and wall-clock guards, and commits at timestamp boundaries that a monitor-driven
 				// commit could split.
-				if (!this.isReplay) supervisedWriteRoots.add(this.root ?? this);
+				if (!this.isReplay) {
+					const root = this.root ?? this;
+					root.timeout = Math.max(root.timeout || 0, this.timeout || txnExpiration, root.timeoutBudget || 0);
+					supervisedWriteRoots.add(root);
+				}
 			} else {
 				// if it is closed, we have to immediately commit, using our immediate transaction
 				immediateCommit = true;

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -16,6 +16,11 @@ import type { Entry } from './RecordEncoder.ts';
 import { toBufferKey } from 'ordered-binary';
 
 const trackedTxns = new Set<DatabaseTransaction>();
+// Logical transactions the monitor supervises for their WRITES, kept apart from trackedTxns because the
+// two have different units and different consumers: trackedTxns is per-link, bounds a read snapshot, and
+// is what the read-queue-depth metric counts, while this holds one entry per logical transaction — the
+// chain root — so a chain child can never become its own timeout root (issue #2231).
+const supervisedWriteRoots = new Set<DatabaseTransaction>();
 const MAX_OUTSTANDING_TXN_DURATION = convertToMS(envMngr.get(CONFIG_PARAMS.STORAGE_MAXTRANSACTIONQUEUETIME)) || 45000; // Allow write transactions to be queued for up to 45 seconds before we start rejecting them
 const DEBUG_LONG_TXNS = envMngr.get(CONFIG_PARAMS.STORAGE_DEBUGLONGTRANSACTIONS);
 export const TRANSACTION_STATE = {
@@ -341,6 +346,10 @@ export class DatabaseTransaction implements Transaction {
 	timestamp = 0;
 	retries = 0;
 	declare next: DatabaseTransaction;
+	// The head of this multi-store chain, set when the link is created; absent on the head itself.
+	declare root?: DatabaseTransaction;
+	// Whether this link is why its chain root is write-supervised (see endWriteSupervision).
+	declare writeSupervised?: boolean;
 	declare stale: boolean;
 	// Whether this read handle's base reference (readTxnsUsed starts at 1 in getReadTxn) has been
 	// consumed by a commit round; iterator references are consumed only by doneReadTxn().
@@ -422,9 +431,25 @@ export class DatabaseTransaction implements Transaction {
 		this.baseReadRefConsumed = false;
 	}
 
+	/**
+	 * Drop this link's supervision claim, and the root's with it once no link in the chain still holds
+	 * one. Membership is keyed on the root but claimed per link, so removing it on any link's detach
+	 * would unsupervise a logical transaction still holding writes elsewhere in the chain.
+	 */
+	private endWriteSupervision(): void {
+		if (!this.writeSupervised) return;
+		this.writeSupervised = false;
+		const root = this.root ?? this;
+		for (let link: DatabaseTransaction = root; link; link = link.next) {
+			if (link.writeSupervised) return;
+		}
+		supervisedWriteRoots.delete(root);
+	}
+
 	private detachOwnedTransaction(): RocksTransactionWithRetry | null {
 		const transaction = this.transaction;
 		trackedTxns.delete(this);
+		this.endWriteSupervision();
 		this.transaction = null;
 		this.readTxnsUsed = 0;
 		this.readTxnRefCount = 0;
@@ -683,6 +708,16 @@ export class DatabaseTransaction implements Transaction {
 			}
 			if (this.open === TRANSACTION_STATE.OPEN) {
 				this.attachOwnedTransaction(transaction);
+				// A write that never read is otherwise invisible to the long-transaction monitor: its
+				// handle was adopted here rather than in getReadTxn(), which is the only other place that
+				// registers. Supervise the chain root, so the monitor reaps the logical transaction as one
+				// unit. Replay is excluded deliberately — it is synchronous, already bounded by its own
+				// stall and wall-clock guards, and commits at timestamp boundaries that a monitor-driven
+				// commit could split.
+				if (!this.isReplay) {
+					this.writeSupervised = true;
+					supervisedWriteRoots.add(this.root ?? this);
+				}
 			} else {
 				// if it is closed, we have to immediately commit, using our immediate transaction
 				immediateCommit = true;
@@ -1255,7 +1290,14 @@ function chainStillActive(txn: DatabaseTransaction): boolean {
 
 function startMonitoringTxns() {
 	timer = setInterval(function () {
-		for (const txn of trackedTxns) {
+		// Both registries, in sequence rather than as a union: a root can be in each (it read, and a
+		// later link blind-wrote), and the membership check is cheaper than allocating per tick.
+		for (const txn of trackedTxns) monitorTransaction(txn);
+		for (const txn of supervisedWriteRoots) if (!trackedTxns.has(txn)) monitorTransaction(txn);
+	}, txnExpiration).unref();
+
+	function monitorTransaction(txn: DatabaseTransaction) {
+		{
 			// Decay write recency once per tick for every tracked link, independent of the `timeout`
 			// branches below — a tracked link that keeps its own idle limit alive by reading must not
 			// thereby keep chainStillActive believing it was written recently too.
@@ -1322,7 +1364,7 @@ function startMonitoringTxns() {
 				txn.timeout -= txnExpiration;
 			}
 		}
-	}, txnExpiration).unref();
+	}
 }
 
 startMonitoringTxns();
@@ -1334,6 +1376,11 @@ startMonitoringTxns();
  */
 export function resetReplayedWritesWarning() {
 	replayedWritesWarned = false;
+}
+
+/** Test seam: whether the monitor supervises this logical transaction for its writes. */
+export function isWriteSupervised(txn: DatabaseTransaction): boolean {
+	return supervisedWriteRoots.has(txn);
 }
 
 export function setTxnExpiration(ms) {

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -436,6 +436,13 @@ export class DatabaseTransaction implements Transaction {
 	 * one. Membership is keyed on the root but claimed per link, so removing it on any link's detach
 	 * would unsupervise a logical transaction still holding writes elsewhere in the chain.
 	 */
+	/** Drop the whole chain's supervision, however its links got there. */
+	dropWriteSupervision(): void {
+		const root = this.root ?? this;
+		for (let link: DatabaseTransaction = root; link; link = link.next) link.writeSupervised = false;
+		supervisedWriteRoots.delete(root);
+	}
+
 	private endWriteSupervision(): void {
 		if (!this.writeSupervised) return;
 		this.writeSupervised = false;
@@ -1110,11 +1117,6 @@ export class DatabaseTransaction implements Transaction {
 		while (this.readTxnsUsed > 0) this.doneReadTxn(); // release the read snapshot when we abort, we assume we don't need it
 		// Defensively release any native handle whose reference bookkeeping was already consumed.
 		if (this.transaction) this.releaseReadTxn();
-		// abortDueToTimeout() and abortChainAfterRetries() walk the chain themselves, but an ordinary
-		// application-error abort never did, so a link that took a blind write kept its native handle,
-		// its write intents and its supervision claim until GC. Re-entrant by design: every step here is
-		// idempotent, so the walking callers reaching this again is harmless.
-		for (let link: DatabaseTransaction = this.next; link; link = link.next) link.abort();
 		this.open = TRANSACTION_STATE.CLOSED;
 		this.drainCompletions();
 		try {
@@ -1331,6 +1333,14 @@ function startMonitoringTxns() {
 			if (txn.timeout <= 0) {
 				const url = (txn.getContext() as any)?.url;
 				if (txn.open === TRANSACTION_STATE.CLOSED) {
+					if (!txn.transaction) {
+						// Nothing left to supervise, and this is the registry's only unconditional exit:
+						// membership otherwise ends when a claiming link detaches, which a chained commit
+						// throwing synchronously inside when()'s success callback never reaches. Left
+						// enrolled, the transaction would draw the warning below every tick forever.
+						txn.dropWriteSupervision();
+						return;
+					}
 					// The commit was already acknowledged; any staged writes are riding an in-flight
 					// replay commit (see the outstanding-iterators branch in commit()) and are not the
 					// monitor's to abort — dropping them here would re-introduce the silent

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -5612,6 +5612,10 @@ export function makeTable(options) {
 				if (!nextTxn) {
 					// no next one, then add our database
 					transaction.next = isRocksDB ? new DatabaseTransaction() : new LMDBTransaction();
+					// The chain root, so a link that only ever receives a blind write is supervised by the
+					// long-transaction monitor as part of its logical transaction rather than as its own
+					// timeout root (issue #2231).
+					transaction.next.root = transaction.root ?? transaction;
 					// Inherit never-drop-on-conflict so a source-applied multi-store transaction doesn't
 					// drop the canonical write when a secondary store hits a transient conflict.
 					transaction.next.sourceApply = transaction.sourceApply;

--- a/unitTests/resources/adoptedHandleBookkeeping.test.js
+++ b/unitTests/resources/adoptedHandleBookkeeping.test.js
@@ -234,6 +234,23 @@ describe('harper#2224 adopted read-handle bookkeeping', function () {
 		assert.strictEqual(getSupervisedWriteRoots().has(head), false, 'supervision ends with chain ownership');
 	});
 
+	it('aborts every owned handle when a supervised multi-database transaction fails', async function () {
+		const { txn: head, context } = await blindWriteTransaction('root-abort');
+		const other = await Chained.getResource({ id: null }, context, {});
+		other._writeInvalidate('child-abort');
+		const child = head.next;
+		opened.push(child);
+		assert.ok(child?.transaction, 'expected both database links to own handles');
+
+		head.abort();
+
+		assert.strictEqual(head.transaction, null);
+		assert.strictEqual(child.transaction, null);
+		assert.deepStrictEqual(child.writes, []);
+		assert.strictEqual(head.next, null);
+		assert.strictEqual(getSupervisedWriteRoots().has(head), false);
+	});
+
 	it('leaves crash-recovery replay unsupervised, so a timestamp group cannot be split', async function () {
 		const context = {};
 		const txn = new DatabaseTransaction();

--- a/unitTests/resources/adoptedHandleBookkeeping.test.js
+++ b/unitTests/resources/adoptedHandleBookkeeping.test.js
@@ -205,18 +205,33 @@ describe('harper#2224 adopted read-handle bookkeeping', function () {
 		opened.push(head);
 		context.transaction = head;
 		head.setContext(context);
-		await Blind.get('chain-seed', context); // head claims the first database
+		head.db = Blind.primaryStore;
 
 		const other = await Chained.getResource({ id: null }, context, {});
-		other._writeInvalidate('chain-write'); // blind write, landing on the chained link
+		other._writeInvalidate('chain-write');
 		const child = head.next;
 		opened.push(child);
 		assert.ok(child?.transaction, 'expected the chained link to have adopted a handle');
+		assert.ok(Number.isFinite(head.timeout) && head.timeout > 0, 'the supervised root must have an armed timeout');
 
 		// The monitor iterates members independently and chainStillActive() only looks downstream, so a
 		// supervised child would be its own timeout root and could be reaped while the head is active.
 		assert.strictEqual(getSupervisedWriteRoots().has(head), true);
 		assert.strictEqual(getSupervisedWriteRoots().has(child), false);
+	});
+
+	it('keeps the root supervised while another chain link still owns a handle', async function () {
+		const { txn: head, context } = await blindWriteTransaction('root-write');
+		await Chained.get('chain-read', context);
+		const child = head.next;
+		opened.push(child);
+		assert.ok(child?.transaction, 'expected the chained read to own a handle');
+
+		child.releaseReadTxn();
+
+		assert.strictEqual(getSupervisedWriteRoots().has(head), true, 'the root write still owns a handle');
+		head.abort();
+		assert.strictEqual(getSupervisedWriteRoots().has(head), false, 'supervision ends with chain ownership');
 	});
 
 	it('leaves crash-recovery replay unsupervised, so a timestamp group cannot be split', async function () {

--- a/unitTests/resources/adoptedHandleBookkeeping.test.js
+++ b/unitTests/resources/adoptedHandleBookkeeping.test.js
@@ -14,6 +14,7 @@ const {
 	setTxnExpiration,
 	isWriteSupervised,
 	getTransactionQueueDepths,
+	RELEASED_TRANSACTION,
 } = require('#src/resources/DatabaseTransaction');
 
 // RocksDB's DatabaseTransaction owns the bookkeeping under test; LMDBTransaction keeps its own
@@ -109,7 +110,7 @@ describe('harper#2224 adopted read-handle bookkeeping', function () {
 		assert.strictEqual(txn.readTxnsUsed, 0);
 		assert.strictEqual(txn.open, TRANSACTION_STATE.CLOSED);
 		assert.deepStrictEqual(txn.writes, []);
-		assert.strictEqual(context.transaction, null);
+		assert.strictEqual(context.transaction, RELEASED_TRANSACTION);
 	});
 
 	it('counts a read through an adopted handle instead of poisoning the count with NaN', async function () {
@@ -450,7 +451,7 @@ describe('harper#2224 adopted read-handle bookkeeping', function () {
 		assert.throws(() => txn.directCommitSync(), /native commitSync failed/);
 		assert.strictEqual(txn.open, TRANSACTION_STATE.CLOSED);
 		assert.deepStrictEqual(txn.writes, []);
-		assert.strictEqual(context.transaction, null);
+		assert.strictEqual(context.transaction, RELEASED_TRANSACTION);
 	});
 
 	it('completes wrapper cleanup even when the native abort throws', function () {
@@ -464,6 +465,6 @@ describe('harper#2224 adopted read-handle bookkeeping', function () {
 		assert.strictEqual(txn.transaction, null);
 		assert.strictEqual(txn.readTxnsUsed, 0);
 		assert.strictEqual(txn.open, TRANSACTION_STATE.CLOSED);
-		assert.strictEqual(context.transaction, null);
+		assert.strictEqual(context.transaction, RELEASED_TRANSACTION);
 	});
 });

--- a/unitTests/resources/adoptedHandleBookkeeping.test.js
+++ b/unitTests/resources/adoptedHandleBookkeeping.test.js
@@ -331,6 +331,36 @@ describe('harper#2224 adopted read-handle bookkeeping', function () {
 		assert.strictEqual(isWriteSupervised(head), true, 'the head still holds writes of its own');
 	});
 
+	it('releases a chained link’s handle when an ordinary abort cleans the head', async function () {
+		const context = {};
+		const head = new DatabaseTransaction();
+		opened.push(head);
+		context.transaction = head;
+		head.setContext(context);
+		await Blind.get('abort-link-seed', context);
+
+		const other = await Chained.getResource({ id: null }, context, {});
+		other._writeInvalidate('abort-link');
+		const child = head.next;
+		opened.push(child);
+		const childHandle = child.transaction;
+		assert.ok(childHandle, 'expected the chained link to have adopted a handle');
+		let childAborts = 0;
+		const nativeAbort = childHandle.abort.bind(childHandle);
+		childHandle.abort = () => {
+			childAborts++;
+			return nativeAbort();
+		};
+
+		head.abort(); // an application error, not the monitor and not retry exhaustion
+
+		// Only abortDueToTimeout() and abortChainAfterRetries() ever walked the chain, so this link's
+		// handle and write intents used to survive the request that created them.
+		assert.strictEqual(childAborts, 1, 'the chained link’s native handle must be released too');
+		assert.strictEqual(child.transaction, null);
+		assert.strictEqual(child.open, TRANSACTION_STATE.CLOSED);
+	});
+
 	it('leaves crash-recovery replay unsupervised, so a timestamp group cannot be split', async function () {
 		const context = {};
 		const txn = new DatabaseTransaction();
@@ -349,10 +379,12 @@ describe('harper#2224 adopted read-handle bookkeeping', function () {
 		opened.push(txn);
 		const handle = stubHandle();
 		txn.attachOwnedTransaction(handle);
+		txn.readTxnRefCount = 3; // holders of the handle being released
 		txn.directCommitSync();
 		assert.strictEqual(handle.calls.commitSync, 1);
 		assert.strictEqual(txn.transaction, null);
 		assert.strictEqual(txn.readTxnsUsed, 0);
+		// Left set, a reused wrapper would carry these counts against a freshly adopted handle.
 		assert.strictEqual(txn.readTxnRefCount, 0);
 	});
 

--- a/unitTests/resources/adoptedHandleBookkeeping.test.js
+++ b/unitTests/resources/adoptedHandleBookkeeping.test.js
@@ -1,0 +1,232 @@
+/**
+ * harper#2224 — save()'s adopt branch, taken by every blind write, seeded none of the per-handle
+ * bookkeeping getReadTxn() establishes, so `undefined++` made readTxnsUsed NaN and abort() never
+ * released the native transaction or its write intents.
+ */
+const assert = require('node:assert');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const { DatabaseTransaction, TRANSACTION_STATE, setTxnExpiration } = require('#src/resources/DatabaseTransaction');
+
+// RocksDB's DatabaseTransaction owns the bookkeeping under test; LMDBTransaction keeps its own
+// counter independently and never adopts one of these handles.
+const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
+
+describe('harper#2224 adopted read-handle bookkeeping', function () {
+	let Blind;
+	// A handle left open pins a read snapshot for the rest of the process and blocks blob reclamation.
+	const opened = [];
+
+	after(function () {
+		setTxnExpiration(30000); // this suite reads trackedTxns through it; leave the default behind
+	});
+
+	afterEach(function () {
+		while (opened.length) {
+			const txn = opened.pop();
+			try {
+				if (txn.transaction) txn.abort();
+			} catch {
+				/* already finalized by the test */
+			}
+		}
+	});
+
+	before(function () {
+		if (isLMDB) this.skip();
+		setupTestDBPath();
+		setMainIsWorker(true);
+		Blind = table({
+			table: 'AdoptedHandle',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'v' }],
+		});
+	});
+
+	// Built the way replayLogs.ts does it: a resource with no id loads nothing, so the staged write is
+	// the first thing to touch the transaction. Invalidating by id would create the handle in
+	// getReadTxn() instead and test nothing here.
+	async function blindWriteTransaction(id) {
+		const context = {};
+		const txn = new DatabaseTransaction();
+		context.transaction = txn;
+		txn.setContext(context);
+		opened.push(txn);
+		const resource = await Blind.getResource({ id: null }, context, {});
+		assert.ok(!txn.transaction, 'nothing may have opened a handle yet, or this tests the wrong branch');
+		resource._writeInvalidate(id);
+		assert.ok(txn.transaction, 'expected the blind write to have adopted a native handle');
+		return { txn, context };
+	}
+
+	function stubHandle({ abortThrows = false, commitThrows = false } = {}) {
+		const calls = { abort: 0, commitSync: 0 };
+		return {
+			calls,
+			openTimer: 0,
+			abort() {
+				calls.abort++;
+				if (abortThrows) throw new Error('native abort failed');
+			},
+			commitSync() {
+				calls.commitSync++;
+				if (commitThrows) throw new Error('native commitSync failed');
+			},
+		};
+	}
+
+	it('seeds the base reference when a blind write adopts the handle', async function () {
+		const { txn } = await blindWriteTransaction('seed');
+		assert.strictEqual(txn.readTxnsUsed, 1);
+		assert.strictEqual(txn.baseReadRefConsumed, false);
+	});
+
+	it('releases the adopted handle on abort, and completes wrapper cleanup', async function () {
+		const { txn, context } = await blindWriteTransaction('abort');
+		const handle = txn.transaction;
+		let nativeAborts = 0;
+		const nativeAbort = handle.abort.bind(handle);
+		handle.abort = () => {
+			nativeAborts++;
+			return nativeAbort();
+		};
+		txn.abort();
+		assert.strictEqual(nativeAborts, 1, 'the native transaction itself must be aborted, not just dropped');
+		assert.strictEqual(txn.transaction, null, 'native handle must not outlive the abort');
+		assert.strictEqual(txn.readTxnsUsed, 0);
+		assert.strictEqual(txn.open, TRANSACTION_STATE.CLOSED);
+		assert.deepStrictEqual(txn.writes, []);
+		assert.strictEqual(context.transaction, null);
+	});
+
+	it('counts a read through an adopted handle instead of poisoning the count with NaN', async function () {
+		const { txn } = await blindWriteTransaction('read');
+		txn.useReadTxn();
+		assert.strictEqual(txn.readTxnsUsed, 2);
+		txn.doneReadTxn();
+		assert.strictEqual(txn.readTxnsUsed, 1, 'the base reference is commit()’s to consume, not the iterator’s');
+		assert.ok(txn.transaction, 'draining an iterator reference must not release the handle');
+	});
+
+	it('consumes the base reference exactly once across commit', async function () {
+		const { txn } = await blindWriteTransaction('commit');
+		await txn.commit({ doneWriting: true });
+		assert.strictEqual(txn.baseReadRefConsumed, true);
+		assert.strictEqual(txn.readTxnsUsed, 0);
+		assert.strictEqual(txn.transaction, null);
+		await txn.commit({ doneWriting: true }); // a second (wrapper) commit must not double-consume
+		assert.strictEqual(txn.readTxnsUsed, 0);
+	});
+
+	it('takes a read reference on every getReadTxn, which is what the two guards below count', async function () {
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		txn.db = Blind.primaryStore;
+		txn.getReadTxn();
+		assert.strictEqual(txn.readTxnRefCount, 1);
+		txn.getReadTxn();
+		assert.strictEqual(txn.readTxnRefCount, 2);
+	});
+
+	it('will not release a handle carrying staged writes when a source load disregards it', async function () {
+		await Blind.put({ id: 'disregard', v: 'stale' });
+		const context = {};
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		context.transaction = txn;
+		txn.setContext(context);
+		const resource = await Blind.getResource({ id: null }, context, {});
+		resource._writeUpdate('disregard', { v: 'fresh' }, true);
+
+		txn.readTxnRefCount = 1;
+		txn.disregardReadTxn();
+
+		assert.ok(txn.transaction, 'releasing the handle would abort the batch the write was staged into');
+		await txn.commit({ doneWriting: true });
+		assert.strictEqual((await Blind.get('disregard'))?.v, 'fresh');
+	});
+
+	it('clamps the read reference count instead of letting an unpaired release drive it negative', function () {
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		txn.readTxnRefCount = 0; // what detachOwnedTransaction() leaves behind
+		txn.disregardReadTxn(); // unpaired: the matching getReadTxn's handle was detached under it
+		assert.strictEqual(txn.readTxnRefCount, 0, 'a negative count would cancel a later handle’s references');
+	});
+
+	it('leaves an already-owned handle and its iterator references alone when a write stages into it', async function () {
+		const context = {};
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		context.transaction = txn;
+		txn.setContext(context);
+		await Blind.get('interleaved', context); // read first: getReadTxn() creates and owns the handle
+		const handle = txn.transaction;
+		txn.useReadTxn(); // an outstanding search iterator
+		assert.strictEqual(txn.readTxnsUsed, 2);
+
+		const resource = await Blind.getResource({ id: null }, context, {});
+		resource._writeInvalidate('interleaved');
+		assert.strictEqual(txn.transaction, handle, 'a write must not swap the handle it stages into');
+		assert.strictEqual(txn.readTxnsUsed, 2, 'the iterator reference must survive the write');
+	});
+
+	it('is never registered with the long-transaction monitor, even once it is read', async function () {
+		const trackedTxns = setTxnExpiration(30000);
+		const { txn } = await blindWriteTransaction('untracked');
+		assert.strictEqual(trackedTxns.has(txn), false);
+		// getReadTxn() returns the already-adopted handle before it reaches trackedTxns.add, so reading
+		// does not register it either. Deliberate here, and tracked as its own follow-up (#2231).
+		txn.getReadTxn();
+		assert.strictEqual(trackedTxns.has(txn), false);
+	});
+
+	it('detaches the handle when a synchronous commit succeeds', function () {
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		const handle = stubHandle();
+		txn.attachOwnedTransaction(handle);
+		txn.directCommitSync();
+		assert.strictEqual(handle.calls.commitSync, 1);
+		assert.strictEqual(txn.transaction, null);
+		assert.strictEqual(txn.readTxnsUsed, 0);
+	});
+
+	it('aborts and detaches when a synchronous commit fails, rethrowing the commit error', function () {
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		const handle = stubHandle({ commitThrows: true });
+		txn.attachOwnedTransaction(handle);
+		assert.throws(() => txn.directCommitSync(), /native commitSync failed/);
+		assert.strictEqual(handle.calls.abort, 1, 'an uncommitted handle still holds its write intents');
+		assert.strictEqual(txn.transaction, null);
+		assert.strictEqual(txn.readTxnsUsed, 0);
+	});
+
+	it('completes wrapper cleanup when a failed synchronous commit also fails to abort', function () {
+		const context = {};
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		context.transaction = txn;
+		txn.setContext(context);
+		txn.attachOwnedTransaction(stubHandle({ commitThrows: true, abortThrows: true }));
+		assert.throws(() => txn.directCommitSync(), /native commitSync failed/);
+		assert.strictEqual(txn.open, TRANSACTION_STATE.CLOSED);
+		assert.deepStrictEqual(txn.writes, []);
+		assert.strictEqual(context.transaction, null);
+	});
+
+	it('completes wrapper cleanup even when the native abort throws', function () {
+		const context = {};
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		context.transaction = txn;
+		txn.setContext(context);
+		txn.attachOwnedTransaction(stubHandle({ abortThrows: true }));
+		txn.abort();
+		assert.strictEqual(txn.transaction, null);
+		assert.strictEqual(txn.readTxnsUsed, 0);
+		assert.strictEqual(txn.open, TRANSACTION_STATE.CLOSED);
+		assert.strictEqual(context.transaction, null);
+	});
+});

--- a/unitTests/resources/adoptedHandleBookkeeping.test.js
+++ b/unitTests/resources/adoptedHandleBookkeeping.test.js
@@ -379,6 +379,8 @@ describe('harper#2224 adopted read-handle bookkeeping', function () {
 		head.open = TRANSACTION_STATE.CLOSED;
 		head.timeout = -1;
 		assert.strictEqual(isWriteSupervised(head), true);
+		const childHandle = child.transaction;
+		assert.ok(childHandle, 'the child still holds the handle its write was staged into');
 
 		setTxnExpiration(20);
 		try {
@@ -386,6 +388,9 @@ describe('harper#2224 adopted read-handle bookkeeping', function () {
 			while (isWriteSupervised(head) && Date.now() < deadline) await delay(20);
 			// Asserted before the cleanup below: aborting the child would evict the root by itself.
 			assert.strictEqual(isWriteSupervised(head), false, 'the monitor must be able to evict it unconditionally');
+			// And the handle goes with it: dropping only the bookkeeping would strand a live native
+			// transaction in neither registry, unreachable by anything that could ever release it.
+			assert.strictEqual(child.transaction, null, 'eviction must release the handle it was tracking');
 		} finally {
 			setTxnExpiration(30000);
 			try {

--- a/unitTests/resources/adoptedHandleBookkeeping.test.js
+++ b/unitTests/resources/adoptedHandleBookkeeping.test.js
@@ -361,6 +361,42 @@ describe('harper#2224 adopted read-handle bookkeeping', function () {
 		assert.strictEqual(child.open, TRANSACTION_STATE.CLOSED);
 	});
 
+	it('evicts a closed, handle-less root whose claim is held by a chain link', async function () {
+		const context = {};
+		const head = new DatabaseTransaction();
+		context.transaction = head;
+		head.setContext(context);
+		await Blind.get('evict-seed', context);
+		const other = await Chained.getResource({ id: null }, context, {});
+		other._writeInvalidate('evict-claim'); // the CHILD claims the root
+		const child = head.next;
+		assert.strictEqual(child.writeSupervised, true);
+
+		// What a chained commit throwing synchronously leaves: the head closed with its handle gone, but
+		// still enrolled, because the claiming link never detached. The head's own release path returns
+		// early — the claim is not its own — so without an unconditional exit it is enrolled forever.
+		head.releaseReadTxn();
+		head.open = TRANSACTION_STATE.CLOSED;
+		head.timeout = -1;
+		assert.strictEqual(isWriteSupervised(head), true);
+
+		setTxnExpiration(20);
+		try {
+			const deadline = Date.now() + 3000;
+			while (isWriteSupervised(head) && Date.now() < deadline) await delay(20);
+			// Asserted before the cleanup below: aborting the child would evict the root by itself.
+			assert.strictEqual(isWriteSupervised(head), false, 'the monitor must be able to evict it unconditionally');
+		} finally {
+			setTxnExpiration(30000);
+			try {
+				child.abort();
+			} catch {
+				/* already finalized */
+			}
+			head.clearWrites();
+		}
+	});
+
 	it('leaves crash-recovery replay unsupervised, so a timestamp group cannot be split', async function () {
 		const context = {};
 		const txn = new DatabaseTransaction();

--- a/unitTests/resources/adoptedHandleBookkeeping.test.js
+++ b/unitTests/resources/adoptedHandleBookkeeping.test.js
@@ -1,0 +1,236 @@
+/**
+ * harper#2224 — save()'s adopt branch, taken by every blind write, seeded none of the per-handle
+ * bookkeeping getReadTxn() establishes, so `undefined++` made readTxnsUsed NaN and abort() never
+ * released the native transaction or its write intents.
+ */
+const assert = require('node:assert');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+const { DatabaseTransaction, TRANSACTION_STATE, setTxnExpiration } = require('#src/resources/DatabaseTransaction');
+
+// RocksDB's DatabaseTransaction owns the bookkeeping under test; LMDBTransaction keeps its own
+// counter independently and never adopts one of these handles.
+const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
+
+describe('harper#2224 adopted read-handle bookkeeping', function () {
+	let Blind;
+	// A handle left open pins a read snapshot for the rest of the process and blocks blob reclamation.
+	const opened = [];
+
+	after(function () {
+		setTxnExpiration(30000); // this suite reads trackedTxns through it; leave the default behind
+	});
+
+	afterEach(function () {
+		while (opened.length) {
+			const txn = opened.pop();
+			try {
+				if (txn.transaction) txn.abort();
+			} catch {
+				/* already finalized by the test */
+			}
+		}
+	});
+
+	before(function () {
+		if (isLMDB) this.skip();
+		setupTestDBPath();
+		setMainIsWorker(true);
+		Blind = table({
+			table: 'AdoptedHandle',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'v' }],
+		});
+	});
+
+	// Built the way replayLogs.ts does it: a resource with no id loads nothing, so the staged write is
+	// the first thing to touch the transaction. Invalidating by id would create the handle in
+	// getReadTxn() instead and test nothing here.
+	async function blindWriteTransaction(id) {
+		const context = {};
+		const txn = new DatabaseTransaction();
+		context.transaction = txn;
+		txn.setContext(context);
+		opened.push(txn);
+		const resource = await Blind.getResource({ id: null }, context, {});
+		assert.ok(!txn.transaction, 'nothing may have opened a handle yet, or this tests the wrong branch');
+		resource._writeInvalidate(id);
+		assert.ok(txn.transaction, 'expected the blind write to have adopted a native handle');
+		return { txn, context };
+	}
+
+	function stubHandle({ abortThrows = false, commitThrows = false } = {}) {
+		const calls = { abort: 0, commitSync: 0 };
+		return {
+			calls,
+			openTimer: 0,
+			abort() {
+				calls.abort++;
+				if (abortThrows) throw new Error('native abort failed');
+			},
+			commitSync() {
+				calls.commitSync++;
+				if (commitThrows) throw new Error('native commitSync failed');
+			},
+		};
+	}
+
+	it('seeds the base reference when a blind write adopts the handle', async function () {
+		const { txn } = await blindWriteTransaction('seed');
+		assert.strictEqual(txn.readTxnsUsed, 1);
+		assert.strictEqual(txn.baseReadRefConsumed, false);
+	});
+
+	it('releases the adopted handle on abort, and completes wrapper cleanup', async function () {
+		const { txn, context } = await blindWriteTransaction('abort');
+		const handle = txn.transaction;
+		let nativeAborts = 0;
+		const nativeAbort = handle.abort.bind(handle);
+		handle.abort = () => {
+			nativeAborts++;
+			return nativeAbort();
+		};
+		txn.abort();
+		assert.strictEqual(nativeAborts, 1, 'the native transaction itself must be aborted, not just dropped');
+		assert.strictEqual(txn.transaction, null, 'native handle must not outlive the abort');
+		assert.strictEqual(txn.readTxnsUsed, 0);
+		assert.strictEqual(txn.open, TRANSACTION_STATE.CLOSED);
+		assert.deepStrictEqual(txn.writes, []);
+		assert.strictEqual(context.transaction, null);
+	});
+
+	it('counts a read through an adopted handle instead of poisoning the count with NaN', async function () {
+		const { txn } = await blindWriteTransaction('read');
+		txn.useReadTxn();
+		assert.strictEqual(txn.readTxnsUsed, 2);
+		txn.doneReadTxn();
+		assert.strictEqual(txn.readTxnsUsed, 1, 'the base reference is commit()’s to consume, not the iterator’s');
+		assert.ok(txn.transaction, 'draining an iterator reference must not release the handle');
+	});
+
+	it('consumes the base reference exactly once across commit', async function () {
+		const { txn } = await blindWriteTransaction('commit');
+		await txn.commit({ doneWriting: true });
+		assert.strictEqual(txn.baseReadRefConsumed, true);
+		assert.strictEqual(txn.readTxnsUsed, 0);
+		assert.strictEqual(txn.transaction, null);
+		await txn.commit({ doneWriting: true }); // a second (wrapper) commit must not double-consume
+		assert.strictEqual(txn.readTxnsUsed, 0);
+	});
+
+	it('takes a read reference on every getReadTxn, which is what the two guards below count', async function () {
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		txn.db = Blind.primaryStore;
+		txn.getReadTxn();
+		assert.strictEqual(txn.readTxnRefCount, 1);
+		txn.getReadTxn();
+		// Pins the increment the two guards below model with a hand-written count.
+		assert.strictEqual(txn.readTxnRefCount, 2);
+	});
+
+	it('will not release a handle carrying staged writes when a source load disregards it', async function () {
+		await Blind.put({ id: 'disregard', v: 'stale' });
+		const context = {};
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		context.transaction = txn;
+		txn.setContext(context);
+		const resource = await Blind.getResource({ id: null }, context, {});
+		resource._writeUpdate('disregard', { v: 'fresh' }, true);
+
+		// A caching read holding the only outstanding reference — the shape an unpaired disregard
+		// reaches after a detach zeroed the count.
+		txn.readTxnRefCount = 1;
+		txn.disregardReadTxn();
+
+		assert.ok(txn.transaction, 'releasing the handle would abort the batch the write was staged into');
+		await txn.commit({ doneWriting: true });
+		assert.strictEqual((await Blind.get('disregard'))?.v, 'fresh');
+	});
+
+	it('clamps the read reference count instead of letting an unpaired release drive it negative', function () {
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		txn.readTxnRefCount = 0; // what detachOwnedTransaction() leaves behind
+		txn.disregardReadTxn(); // unpaired: the matching getReadTxn's handle was detached under it
+		assert.strictEqual(txn.readTxnRefCount, 0, 'a negative count would cancel a later handle’s references');
+	});
+
+	it('leaves an already-owned handle and its iterator references alone when a write stages into it', async function () {
+		const context = {};
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		context.transaction = txn;
+		txn.setContext(context);
+		await Blind.get('interleaved', context); // read first: getReadTxn() creates and owns the handle
+		const handle = txn.transaction;
+		txn.useReadTxn(); // an outstanding search iterator
+		assert.strictEqual(txn.readTxnsUsed, 2);
+
+		const resource = await Blind.getResource({ id: null }, context, {});
+		resource._writeInvalidate('interleaved');
+		assert.strictEqual(txn.transaction, handle, 'a write must not swap the handle it stages into');
+		assert.strictEqual(txn.readTxnsUsed, 2, 'the iterator reference must survive the write');
+	});
+
+	it('is never registered with the long-transaction monitor, even once it is read', async function () {
+		const trackedTxns = setTxnExpiration(30000);
+		const { txn } = await blindWriteTransaction('untracked');
+		assert.strictEqual(trackedTxns.has(txn), false);
+		// getReadTxn() returns the already-adopted handle before it reaches trackedTxns.add, so reading
+		// does not register it either. Deliberate here, and tracked as its own follow-up (#2231).
+		txn.getReadTxn();
+		assert.strictEqual(trackedTxns.has(txn), false);
+	});
+
+	it('detaches the handle when a synchronous commit succeeds', function () {
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		const handle = stubHandle();
+		txn.attachOwnedTransaction(handle);
+		txn.directCommitSync();
+		assert.strictEqual(handle.calls.commitSync, 1);
+		assert.strictEqual(txn.transaction, null);
+		assert.strictEqual(txn.readTxnsUsed, 0);
+	});
+
+	it('aborts and detaches when a synchronous commit fails, rethrowing the commit error', function () {
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		const handle = stubHandle({ commitThrows: true });
+		txn.attachOwnedTransaction(handle);
+		assert.throws(() => txn.directCommitSync(), /native commitSync failed/);
+		assert.strictEqual(handle.calls.abort, 1, 'an uncommitted handle still holds its write intents');
+		assert.strictEqual(txn.transaction, null);
+		assert.strictEqual(txn.readTxnsUsed, 0);
+	});
+
+	it('completes wrapper cleanup when a failed synchronous commit also fails to abort', function () {
+		const context = {};
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		context.transaction = txn;
+		txn.setContext(context);
+		txn.attachOwnedTransaction(stubHandle({ commitThrows: true, abortThrows: true }));
+		assert.throws(() => txn.directCommitSync(), /native commitSync failed/);
+		// abort() is what reclaims blobs a replayed write staged.
+		assert.strictEqual(txn.open, TRANSACTION_STATE.CLOSED);
+		assert.deepStrictEqual(txn.writes, []);
+		assert.strictEqual(context.transaction, null);
+	});
+
+	it('completes wrapper cleanup even when the native abort throws', function () {
+		const context = {};
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		context.transaction = txn;
+		txn.setContext(context);
+		txn.attachOwnedTransaction(stubHandle({ abortThrows: true }));
+		txn.abort();
+		assert.strictEqual(txn.transaction, null);
+		assert.strictEqual(txn.readTxnsUsed, 0);
+		assert.strictEqual(txn.open, TRANSACTION_STATE.CLOSED);
+		assert.strictEqual(context.transaction, null);
+	});
+});

--- a/unitTests/resources/adoptedHandleBookkeeping.test.js
+++ b/unitTests/resources/adoptedHandleBookkeeping.test.js
@@ -4,17 +4,24 @@
  * released the native transaction or its write intents.
  */
 const assert = require('node:assert');
+const { setTimeout: delay } = require('node:timers/promises');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
-const { DatabaseTransaction, TRANSACTION_STATE, setTxnExpiration } = require('#src/resources/DatabaseTransaction');
+const {
+	DatabaseTransaction,
+	TRANSACTION_STATE,
+	setTxnExpiration,
+	isWriteSupervised,
+	getTransactionQueueDepths,
+} = require('#src/resources/DatabaseTransaction');
 
 // RocksDB's DatabaseTransaction owns the bookkeeping under test; LMDBTransaction keeps its own
 // counter independently and never adopts one of these handles.
 const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
 
 describe('harper#2224 adopted read-handle bookkeeping', function () {
-	let Blind;
+	let Blind, Chained;
 	// A handle left open pins a read snapshot for the rest of the process and blocks blob reclamation.
 	const opened = [];
 
@@ -39,6 +46,12 @@ describe('harper#2224 adopted read-handle bookkeeping', function () {
 		setMainIsWorker(true);
 		Blind = table({
 			table: 'AdoptedHandle',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'v' }],
+		});
+		// A second database, so a write to it lands on a chain link rather than the head.
+		Chained = table({
+			table: 'AdoptedHandleChained',
+			database: 'adoptedOther',
 			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'v' }],
 		});
 	});
@@ -171,14 +184,99 @@ describe('harper#2224 adopted read-handle bookkeeping', function () {
 		assert.strictEqual(txn.readTxnsUsed, 2, 'the iterator reference must survive the write');
 	});
 
-	it('is never registered with the long-transaction monitor, even once it is read', async function () {
+	it('is supervised by the long-transaction monitor without joining the read-tracked set', async function () {
 		const trackedTxns = setTxnExpiration(30000);
-		const { txn } = await blindWriteTransaction('untracked');
-		assert.strictEqual(trackedTxns.has(txn), false);
-		// getReadTxn() returns the already-adopted handle before it reaches trackedTxns.add, so reading
-		// does not register it either. Deliberate here, and tracked as its own follow-up (#2231).
+		const readDepthBefore = getTransactionQueueDepths().readDepth;
+		const { txn } = await blindWriteTransaction('supervised');
+
+		assert.strictEqual(isWriteSupervised(txn), true, 'a blind write must not be invisible');
+		// The read-tracked set and the depth metric it feeds keep their meaning: this transaction holds no
+		// read snapshot, and getReadTxn() returns the already-adopted handle before it would register.
 		txn.getReadTxn();
 		assert.strictEqual(trackedTxns.has(txn), false);
+		assert.strictEqual(getTransactionQueueDepths().readDepth, readDepthBefore);
+
+		await txn.commit({ doneWriting: true });
+		assert.strictEqual(isWriteSupervised(txn), false, 'supervision ends with ownership');
+	});
+
+	it('supervises the chain root, not the link that received the blind write', async function () {
+		const context = {};
+		const head = new DatabaseTransaction();
+		opened.push(head);
+		context.transaction = head;
+		head.setContext(context);
+		await Blind.get('chain-seed', context); // head claims the first database
+
+		const other = await Chained.getResource({ id: null }, context, {});
+		other._writeInvalidate('chain-write'); // blind write, landing on the chained link
+		const child = head.next;
+		opened.push(child);
+		assert.ok(child?.transaction, 'expected the chained link to have adopted a handle');
+
+		// The monitor iterates members independently and chainStillActive() only looks downstream, so a
+		// supervised child would be its own timeout root and could be reaped while the head is active.
+		assert.strictEqual(isWriteSupervised(head), true);
+		assert.strictEqual(isWriteSupervised(child), false);
+	});
+
+	it('keeps the root supervised when a read-only link in the same chain releases its handle', async function () {
+		const context = {};
+		const head = new DatabaseTransaction();
+		opened.push(head);
+		context.transaction = head;
+		head.setContext(context);
+		const resource = await Blind.getResource({ id: null }, context, {});
+		resource._writeInvalidate('chain-hold'); // head blind-writes: the root is supervised
+
+		const child = new DatabaseTransaction();
+		opened.push(child);
+		head.next = child;
+		child.root = head;
+		child.db = Chained.primaryStore;
+		child.getReadTxn(); // a read-only link, which never claimed supervision
+		child.doneReadTxn();
+
+		// Membership is keyed on the root, so removing it on any link's detach would leave the head
+		// holding write intents with nothing to reap it — the gap this supervision exists to close.
+		assert.strictEqual(isWriteSupervised(head), true);
+	});
+
+	it('reaps a blind-write transaction that runs past the open-transaction limit', async function () {
+		const context = {};
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		context.transaction = txn;
+		txn.setContext(context);
+		const resource = await Blind.getResource({ id: null }, context, {});
+
+		// Before the write: addWrite arms the idle limit from the expiration current at that moment.
+		setTxnExpiration(20);
+		try {
+			resource._writeInvalidate('over-time');
+			assert.strictEqual(isWriteSupervised(txn), true);
+			const deadline = Date.now() + 5000;
+			while (txn.open !== TRANSACTION_STATE.CLOSED && Date.now() < deadline) await delay(20);
+		} finally {
+			setTxnExpiration(30000);
+		}
+		// Not just visible: the monitor actually acts. Before this, nothing ever forced a release.
+		assert.strictEqual(txn.open, TRANSACTION_STATE.CLOSED, 'the monitor must reap what it supervises');
+		assert.strictEqual(txn.transaction, null);
+		assert.strictEqual(isWriteSupervised(txn), false);
+	});
+
+	it('leaves crash-recovery replay unsupervised, so a timestamp group cannot be split', async function () {
+		const context = {};
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		txn.isReplay = true; // set at construction in replayLogs, before any write
+		context.transaction = txn;
+		txn.setContext(context);
+		const resource = await Blind.getResource({ id: null }, context, {});
+		resource._writeInvalidate('replayed');
+		assert.ok(txn.transaction, 'the replayed write still adopts a handle');
+		assert.strictEqual(isWriteSupervised(txn), false);
 	});
 
 	it('detaches the handle when a synchronous commit succeeds', function () {

--- a/unitTests/resources/adoptedHandleBookkeeping.test.js
+++ b/unitTests/resources/adoptedHandleBookkeeping.test.js
@@ -4,17 +4,24 @@
  * released the native transaction or its write intents.
  */
 const assert = require('node:assert');
+const { setTimeout: delay } = require('node:timers/promises');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
-const { DatabaseTransaction, TRANSACTION_STATE, setTxnExpiration } = require('#src/resources/DatabaseTransaction');
+const {
+	DatabaseTransaction,
+	TRANSACTION_STATE,
+	setTxnExpiration,
+	isWriteSupervised,
+	getTransactionQueueDepths,
+} = require('#src/resources/DatabaseTransaction');
 
 // RocksDB's DatabaseTransaction owns the bookkeeping under test; LMDBTransaction keeps its own
 // counter independently and never adopts one of these handles.
 const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
 
 describe('harper#2224 adopted read-handle bookkeeping', function () {
-	let Blind;
+	let Blind, Chained;
 	// A handle left open pins a read snapshot for the rest of the process and blocks blob reclamation.
 	const opened = [];
 
@@ -39,6 +46,12 @@ describe('harper#2224 adopted read-handle bookkeeping', function () {
 		setMainIsWorker(true);
 		Blind = table({
 			table: 'AdoptedHandle',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'v' }],
+		});
+		// A second database, so a write to it lands on a chain link rather than the head.
+		Chained = table({
+			table: 'AdoptedHandleChained',
+			database: 'adoptedOther',
 			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'v' }],
 		});
 	});
@@ -171,14 +184,171 @@ describe('harper#2224 adopted read-handle bookkeeping', function () {
 		assert.strictEqual(txn.readTxnsUsed, 2, 'the iterator reference must survive the write');
 	});
 
-	it('is never registered with the long-transaction monitor, even once it is read', async function () {
+	it('is supervised by the long-transaction monitor without joining the read-tracked set', async function () {
 		const trackedTxns = setTxnExpiration(30000);
-		const { txn } = await blindWriteTransaction('untracked');
-		assert.strictEqual(trackedTxns.has(txn), false);
-		// getReadTxn() returns the already-adopted handle before it reaches trackedTxns.add, so reading
-		// does not register it either. Deliberate here, and tracked as its own follow-up (#2231).
+		const readDepthBefore = getTransactionQueueDepths().readDepth;
+		const { txn } = await blindWriteTransaction('supervised');
+
+		assert.strictEqual(isWriteSupervised(txn), true, 'a blind write must not be invisible');
+		// The read-tracked set and the depth metric it feeds keep their meaning: this transaction holds no
+		// read snapshot, and getReadTxn() returns the already-adopted handle before it would register.
 		txn.getReadTxn();
 		assert.strictEqual(trackedTxns.has(txn), false);
+		assert.strictEqual(getTransactionQueueDepths().readDepth, readDepthBefore);
+
+		await txn.commit({ doneWriting: true });
+		assert.strictEqual(isWriteSupervised(txn), false, 'supervision ends with ownership');
+	});
+
+	it('supervises the chain root, not the link that received the blind write', async function () {
+		const context = {};
+		const head = new DatabaseTransaction();
+		opened.push(head);
+		context.transaction = head;
+		head.setContext(context);
+		await Blind.get('chain-seed', context); // head claims the first database
+
+		const other = await Chained.getResource({ id: null }, context, {});
+		other._writeInvalidate('chain-write'); // blind write, landing on the chained link
+		const child = head.next;
+		opened.push(child);
+		assert.ok(child?.transaction, 'expected the chained link to have adopted a handle');
+
+		// The monitor iterates members independently and chainStillActive() only looks downstream, so a
+		// supervised child would be its own timeout root and could be reaped while the head is active.
+		assert.strictEqual(isWriteSupervised(head), true);
+		assert.strictEqual(isWriteSupervised(child), false);
+	});
+
+	it('keeps the root supervised when a read-only link in the same chain releases its handle', async function () {
+		const context = {};
+		const head = new DatabaseTransaction();
+		opened.push(head);
+		context.transaction = head;
+		head.setContext(context);
+		const resource = await Blind.getResource({ id: null }, context, {});
+		resource._writeInvalidate('chain-hold'); // head blind-writes: the root is supervised
+
+		const child = new DatabaseTransaction();
+		opened.push(child);
+		head.next = child;
+		child.root = head;
+		child.db = Chained.primaryStore;
+		child.getReadTxn(); // a read-only link, which never claimed supervision
+		child.doneReadTxn();
+
+		// Membership is keyed on the root, so removing it on any link's detach would leave the head
+		// holding write intents with nothing to reap it — the gap this supervision exists to close.
+		assert.strictEqual(isWriteSupervised(head), true);
+	});
+
+	it('reaps a blind-write transaction that runs past the open-transaction limit', async function () {
+		const context = {};
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		context.transaction = txn;
+		txn.setContext(context);
+		const resource = await Blind.getResource({ id: null }, context, {});
+
+		// Before the write: addWrite arms the idle limit from the expiration current at that moment.
+		setTxnExpiration(20);
+		try {
+			resource._writeInvalidate('over-time');
+			assert.strictEqual(isWriteSupervised(txn), true);
+			const deadline = Date.now() + 5000;
+			while (txn.open !== TRANSACTION_STATE.CLOSED && Date.now() < deadline) await delay(20);
+		} finally {
+			setTxnExpiration(30000);
+		}
+		// Not just visible: the monitor actually acts. Before this, nothing ever forced a release.
+		assert.strictEqual(txn.open, TRANSACTION_STATE.CLOSED, 'the monitor must reap what it supervises');
+		assert.strictEqual(txn.transaction, null);
+		assert.strictEqual(isWriteSupervised(txn), false);
+	});
+
+	it('reaps a chain whose write landed on a link, not on the root', async function () {
+		const context = {};
+		const head = new DatabaseTransaction();
+		opened.push(head);
+		context.transaction = head;
+		head.setContext(context);
+		// A read claims the head for the first database without arming its idle limit, and an unarmed
+		// limit decays to NaN, which is never <= 0 — the chained shape would go unreaped forever.
+		await Blind.get('chain-overtime-seed', context);
+		head.timeout = undefined; // the read's own arming is not what the chained write can rely on
+
+		setTxnExpiration(20);
+		try {
+			const other = await Chained.getResource({ id: null }, context, {});
+			other._writeInvalidate('chain-overtime');
+			const child = head.next;
+			opened.push(child);
+			assert.ok(child?.transaction, 'expected a chained link to have taken the write');
+			assert.strictEqual(isWriteSupervised(head), true);
+
+			const deadline = Date.now() + 5000;
+			while (head.open !== TRANSACTION_STATE.CLOSED && Date.now() < deadline) await delay(20);
+		} finally {
+			setTxnExpiration(30000);
+		}
+		assert.strictEqual(head.open, TRANSACTION_STATE.CLOSED, 'the logical transaction must be reaped');
+		assert.strictEqual(isWriteSupervised(head), false);
+	});
+
+	it('drops supervision for the whole chain when an aborting request cleans only the head', async function () {
+		const context = {};
+		const head = new DatabaseTransaction();
+		opened.push(head);
+		context.transaction = head;
+		head.setContext(context);
+		await Blind.get('abort-chain-seed', context);
+
+		const other = await Chained.getResource({ id: null }, context, {});
+		other._writeInvalidate('abort-chain');
+		const child = head.next;
+		opened.push(child);
+		assert.strictEqual(isWriteSupervised(head), true);
+		assert.strictEqual(child.writeSupervised, true, 'the claim is the child’s, not the head’s');
+
+		head.abort(); // abort() cleans its own link only
+
+		// Left enrolled, the monitor would revisit this CLOSED transaction every tick for the life of
+		// the process, warning each time, and the registry would pin the chain past GC.
+		assert.strictEqual(isWriteSupervised(head), false);
+		assert.strictEqual(child.writeSupervised, false);
+	});
+
+	it('keeps the root supervised while any link in the chain still claims it', async function () {
+		const context = {};
+		const head = new DatabaseTransaction();
+		opened.push(head);
+		context.transaction = head;
+		head.setContext(context);
+		const resource = await Blind.getResource({ id: null }, context, {});
+		resource._writeInvalidate('two-claims'); // the head claims
+
+		const other = await Chained.getResource({ id: null }, context, {});
+		other._writeInvalidate('two-claims-child'); // and so does the child
+		const child = head.next;
+		opened.push(child);
+		assert.strictEqual(head.writeSupervised, true);
+		assert.strictEqual(child.writeSupervised, true);
+
+		await child.commit({ doneWriting: true }); // one claim released
+		assert.strictEqual(isWriteSupervised(head), true, 'the head still holds writes of its own');
+	});
+
+	it('leaves crash-recovery replay unsupervised, so a timestamp group cannot be split', async function () {
+		const context = {};
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		txn.isReplay = true; // set at construction in replayLogs, before any write
+		context.transaction = txn;
+		txn.setContext(context);
+		const resource = await Blind.getResource({ id: null }, context, {});
+		resource._writeInvalidate('replayed');
+		assert.ok(txn.transaction, 'the replayed write still adopts a handle');
+		assert.strictEqual(isWriteSupervised(txn), false);
 	});
 
 	it('detaches the handle when a synchronous commit succeeds', function () {

--- a/unitTests/resources/adoptedHandleBookkeeping.test.js
+++ b/unitTests/resources/adoptedHandleBookkeeping.test.js
@@ -7,14 +7,20 @@ const assert = require('node:assert');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
-const { DatabaseTransaction, TRANSACTION_STATE, setTxnExpiration } = require('#src/resources/DatabaseTransaction');
+const {
+	DatabaseTransaction,
+	TRANSACTION_STATE,
+	setTxnExpiration,
+	getSupervisedWriteRoots,
+	getTransactionQueueDepths,
+} = require('#src/resources/DatabaseTransaction');
 
 // RocksDB's DatabaseTransaction owns the bookkeeping under test; LMDBTransaction keeps its own
 // counter independently and never adopts one of these handles.
 const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
 
 describe('harper#2224 adopted read-handle bookkeeping', function () {
-	let Blind;
+	let Blind, Chained;
 	// A handle left open pins a read snapshot for the rest of the process and blocks blob reclamation.
 	const opened = [];
 
@@ -39,6 +45,12 @@ describe('harper#2224 adopted read-handle bookkeeping', function () {
 		setMainIsWorker(true);
 		Blind = table({
 			table: 'AdoptedHandle',
+			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'v' }],
+		});
+		// A second database, so a write to it lands on a chain link rather than the head.
+		Chained = table({
+			table: 'AdoptedHandleChained',
+			database: 'adoptedOther',
 			attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'v' }],
 		});
 	});
@@ -171,14 +183,53 @@ describe('harper#2224 adopted read-handle bookkeeping', function () {
 		assert.strictEqual(txn.readTxnsUsed, 2, 'the iterator reference must survive the write');
 	});
 
-	it('is never registered with the long-transaction monitor, even once it is read', async function () {
+	it('is supervised by the long-transaction monitor without joining the read-tracked set', async function () {
 		const trackedTxns = setTxnExpiration(30000);
-		const { txn } = await blindWriteTransaction('untracked');
-		assert.strictEqual(trackedTxns.has(txn), false);
-		// getReadTxn() returns the already-adopted handle before it reaches trackedTxns.add, so reading
-		// does not register it either. Deliberate here, and tracked as its own follow-up (#2231).
+		const readDepthBefore = getTransactionQueueDepths().readDepth;
+		const { txn } = await blindWriteTransaction('supervised');
+
+		assert.strictEqual(getSupervisedWriteRoots().has(txn), true, 'a blind write must not be invisible');
+		// The read-tracked set and the depth metric it feeds keep their meaning: this transaction holds no
+		// read snapshot, and getReadTxn() returns the already-adopted handle before it would register.
 		txn.getReadTxn();
 		assert.strictEqual(trackedTxns.has(txn), false);
+		assert.strictEqual(getTransactionQueueDepths().readDepth, readDepthBefore);
+
+		await txn.commit({ doneWriting: true });
+		assert.strictEqual(getSupervisedWriteRoots().has(txn), false, 'supervision ends with ownership');
+	});
+
+	it('supervises the chain root, not the link that received the blind write', async function () {
+		const context = {};
+		const head = new DatabaseTransaction();
+		opened.push(head);
+		context.transaction = head;
+		head.setContext(context);
+		await Blind.get('chain-seed', context); // head claims the first database
+
+		const other = await Chained.getResource({ id: null }, context, {});
+		other._writeInvalidate('chain-write'); // blind write, landing on the chained link
+		const child = head.next;
+		opened.push(child);
+		assert.ok(child?.transaction, 'expected the chained link to have adopted a handle');
+
+		// The monitor iterates members independently and chainStillActive() only looks downstream, so a
+		// supervised child would be its own timeout root and could be reaped while the head is active.
+		assert.strictEqual(getSupervisedWriteRoots().has(head), true);
+		assert.strictEqual(getSupervisedWriteRoots().has(child), false);
+	});
+
+	it('leaves crash-recovery replay unsupervised, so a timestamp group cannot be split', async function () {
+		const context = {};
+		const txn = new DatabaseTransaction();
+		opened.push(txn);
+		txn.isReplay = true; // set at construction in replayLogs, before any write
+		context.transaction = txn;
+		txn.setContext(context);
+		const resource = await Blind.getResource({ id: null }, context, {});
+		resource._writeInvalidate('replayed');
+		assert.ok(txn.transaction, 'the replayed write still adopts a handle');
+		assert.strictEqual(getSupervisedWriteRoots().has(txn), false);
 	});
 
 	it('detaches the handle when a synchronous commit succeeds', function () {

--- a/unitTests/resources/sourceApplyConflictRetry.test.js
+++ b/unitTests/resources/sourceApplyConflictRetry.test.js
@@ -6,7 +6,12 @@ const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { transaction } = require('#src/resources/transaction');
 const { setTimeout: delay } = require('node:timers/promises');
 const { PrimaryRocksDatabase } = require('#src/resources/PrimaryRocksDatabase');
-const { DatabaseTransaction, TRANSACTION_STATE, setTxnExpiration } = require('#src/resources/DatabaseTransaction');
+const {
+	DatabaseTransaction,
+	TRANSACTION_STATE,
+	setTxnExpiration,
+	RELEASED_TRANSACTION,
+} = require('#src/resources/DatabaseTransaction');
 // A coordinatedRetry transaction (the source-apply path) signals an optimistic write conflict by
 // resolving commit() with this sentinel instead of rejecting with ERR_BUSY.
 const RETRY_NOW_VALUE = require('@harperfast/rocksdb-js').constants.RETRY_NOW_VALUE;
@@ -326,7 +331,7 @@ describe('abortChainAfterRetries chain cleanup', () => {
 		assert.ok(!trackedTxns.has(head), 'head must be untracked');
 		assert.ok(!trackedTxns.has(next), "later link must be untracked despite the earlier link's cleanup exception");
 		assert.deepStrictEqual(head.writes, [], 'failed blob cleanup must not retain the write graph');
-		assert.equal(context.transaction, null, 'failed blob cleanup must not retain the closed wrapper');
+		assert.equal(context.transaction, RELEASED_TRANSACTION, 'failed blob cleanup must not retain the closed wrapper');
 	});
 
 	it('aborts both head handles when an outstanding iterator forced writes onto a replay transaction', () => {

--- a/unitTests/resources/sourceApplyConflictRetry.test.js
+++ b/unitTests/resources/sourceApplyConflictRetry.test.js
@@ -324,4 +324,24 @@ describe('abortChainAfterRetries chain cleanup', () => {
 		assert.ok(!trackedTxns.has(head), 'head must be untracked');
 		assert.ok(!trackedTxns.has(next), "later link must be untracked despite the earlier link's cleanup exception");
 	});
+
+	it('aborts both head handles when an outstanding iterator forced writes onto a replay transaction', () => {
+		const head = new DatabaseTransaction();
+		const retainedRead = fakeNative();
+		const replayWrite = fakeNative();
+		head.transaction = retainedRead;
+		head.readTxnsUsed = 1;
+		head.readTxnRefCount = 1;
+
+		const trackedTxns = setTxnExpiration(30000);
+		trackedTxns.add(head);
+		head.abortChainAfterRetries(replayWrite);
+
+		assert.ok(replayWrite.aborted, 'the replay write transaction must be aborted');
+		assert.ok(retainedRead.aborted, 'the retained read transaction must be aborted');
+		assert.equal(head.transaction, null, 'the retained handle must be detached');
+		assert.equal(head.readTxnsUsed, 0);
+		assert.equal(head.readTxnRefCount, 0);
+		assert.ok(!trackedTxns.has(head), 'the retained read transaction must be untracked');
+	});
 });

--- a/unitTests/resources/sourceApplyConflictRetry.test.js
+++ b/unitTests/resources/sourceApplyConflictRetry.test.js
@@ -282,6 +282,8 @@ describe('abortChainAfterRetries chain cleanup', () => {
 	it("still detaches, untracks, and natively aborts later links when an earlier link's wrapper cleanup throws", () => {
 		const head = new DatabaseTransaction();
 		const next = new DatabaseTransaction();
+		const context = { transaction: head };
+		head.setContext(context);
 		head.next = next;
 
 		const headNative = fakeNative();
@@ -323,6 +325,8 @@ describe('abortChainAfterRetries chain cleanup', () => {
 		assert.equal(next.transaction, null, 'later link must have its native handle detached');
 		assert.ok(!trackedTxns.has(head), 'head must be untracked');
 		assert.ok(!trackedTxns.has(next), "later link must be untracked despite the earlier link's cleanup exception");
+		assert.deepStrictEqual(head.writes, [], 'failed blob cleanup must not retain the write graph');
+		assert.equal(context.transaction, null, 'failed blob cleanup must not retain the closed wrapper');
 	});
 
 	it('aborts both head handles when an outstanding iterator forced writes onto a replay transaction', () => {


### PR DESCRIPTION
`save()`'s adopt branch — the path every blind write takes, meaning any write with no preceding read: `invalidate`, `publish`, crash-recovery replay, reload markers — installed a native handle into `this.transaction` without the per-handle bookkeeping `getReadTxn()`'s fresh-handle branch establishes (`readTxnsUsed = 1`, the base reference `commit()` consumes exactly once, plus `baseReadRefConsumed`). `undefined++` is `NaN`, and every `NaN > 0` test is false, so the count was wrong for every consumer that reads it: `commit()`, `doneReadTxn()`, `disregardReadTxn()` and `releaseContext()`, not only `abort()`.

Separately, `trackedTxns.add` runs only in that same fresh-handle branch, and `getReadTxn()` returns an already-adopted handle before reaching it — so a transaction that never read was invisible to the long-transaction monitor for its whole life. #1407's abort-on-over-time did not apply to it: it held write intents with nothing to reap it, and peers' coordinated-retry commits parked on them.

Fixes #2224 and #2231.

> **On overlap with `main`:** the symptom this PR was originally titled for — `abort()` leaving the native handle alive — was fixed on `main` in 4fbe87d95 while this was in review, by making `abort()` release a still-live handle regardless of the count. That is the symptom-level repair; this is the state-level one, and the two are compatible (with the count correct, main's `if (this.transaction) this.releaseReadTxn()` is a no-op on the single-link path, and it still covers paths this does not). Measured against **current** `main`, 19 of this branch's 22 tests fail and 3 pass — one of the 3 being the abort case main now covers.

## For the human reviewer

1. **Monitor supervision is in, per Kris's ruling** — it was written up here as deferred to #2231, and that call was overridden. It is contained the way the planning gate demanded: a **separate** `supervisedWriteRoots` registry (so `trackedTxns`' per-link membership, the read-queue-depth metric, and the `setTxnExpiration()` test seam are all untouched, with no counter needed); one entry per **logical transaction**, keyed on the chain root via a back-pointer set at the single chain-creation site, because supervising a link would make it its own timeout root — force-committable or poisonable while its head is still active, which is the multi-store atomicity #1407 protects; and **crash-recovery replay excluded**, since it is synchronous, already stall- and wall-clock-bounded, and commits at timestamp boundaries a monitor-driven commit could split. **The behaviour change to weigh: a blind-write transaction that runs past `storage.maxTransactionOpenTime` is now reaped where it previously ran unbounded.** `sourceApply` keeps its existing force-commit exemption.
2. **`disregardReadTxn()` will not release a handle carrying staged writes, and its count is clamped.** `commit()` skips re-staging a write it has marked `saved`, so aborting that batch mid-request drops the write (measured: `{"v":"fresh"}` vs `null`). An earlier revision had `save()` take a `readTxnRefCount` reference instead; I removed it after measuring that the write path already takes one, so the release could never fire that way — it was guarding a path I could not demonstrate.
3. **`detachOwnedTransaction()` zeroes `readTxnRefCount`, which no prior release site did.** Not resetting (the old behaviour) means the count only grows, so the early-snapshot-release optimisation silently stops firing for the rest of that transaction's life — a held snapshot blocking compaction and blob reclamation. Resetting means an in-flight `disregardReadTxn()` can land on the next handle; the harmful half of that is blocked by (2), leaving an early release of a read-only handle with no outstanding iterator. **Not fixed, and worth your view:** the invariant-level answer is a generation stamp on the handle, compared on release, rather than a clamp. I judged that a separate change rather than growing this one further.
4. **Write supervision has an unconditional exit.** Membership otherwise ends only when a claiming link detaches, and a chained commit throwing synchronously inside `when()`'s success callback never reaches that — leaving a CLOSED, handle-less root enrolled, drawing a misleading "read iterators held a committed transaction's snapshot" warning every tick and pinning the chain past GC. The monitor now evicts such a member outright.

## Verification

- **`unitTests/resources/adoptedHandleBookkeeping.test.js`, 22 cases**, RocksDB-only (LMDB keeps its own counter in `LMDBTransaction` and never adopts one of these handles). **19 fail against current `origin/main`.** Every guard was falsified individually — remove the staged-write gate, the clamp, the `readTxnRefCount` reset, the root-timeout arming, the chain-wide supervision release, the chain abort walk, the split abort guards, or supervision itself, and a specific test goes red.
- **Four tests in here passed for the wrong reason at some point** and were rewritten only because falsification caught them: the blind-write fixture (invalidating *by id* loads the record first, exercising the wrong branch), the chained-reap case (`getResource({id: null})` does not claim the head, so no chain existed), the disregard case, and the supervision-eviction case (its own cleanup evicted the root before the assertion ran). Two of them also leaked live handles into the shared mocha process and turned 17 unrelated blob-reclamation tests red until bisected. The fixture now asserts no handle exists before the write, the chained cases assert a link was created, and every transaction the suite opens is torn down in `afterEach`.
- `npx mocha "unitTests/resources/**"` — **1610 passing, 0 failing** (RocksDB) and **1386 passing, 0 failing** under `HARPER_STORAGE_ENGINE=lmdb`. Baseline on the merge base is 1584.
- `npm run test:integration` over `integrationTests/database/**` and `integrationTests/resources/**` — **496 passing, 0 failing**, including the suites that run with a low `maxTransactionOpenTime`, where newly-supervised transactions would surface.
- `npm run typecheck`, `npm run lint:required`, `prettier --check` clean. `npm run test:unit:main` cannot run on this machine — a stale mocha process holds `~/harper/database/system/LOCK` — so CI is the gate for it.
- **Review:** eleven rounds. The Harper-domain leg was rate-limited for the first five and, once available, found four things three other lenses had missed — including that judgment call 2's earlier form was unnecessary. Chris's review corrected a native contract both comments stated backwards (measured: rocksdb-js tolerates abort-after-abort; abort-after-**commit** is what throws) and mutation-tested the `readTxnRefCount` reset as uncovered; both are fixed and pinned. Two model claims I refuted by code trace rather than acting on, both then dropped by the graded leg.
- `33a9aeb27` and `fe0088d4c` on this branch are Kris's, with GPT-5 Codex — a constant-time form of the staged-write guard, and regression coverage. My later work was rebased onto them rather than force-pushed over.

Complexity: complicated

<sub>Review-Coverage: authored=unknown; ran=none; rounds=1 @ 1b251a21b8f8</sub>

<sub>Human-Review-Need: 4 @ 1b251a21b8f8</sub>
