### PR TITLE
Register replication_receiveQueueHighWaterMark so the receive-queue budget can be configured

### DIFF
--- a/unitTests/config/replicationReceiveQueueParam.test.js
+++ b/unitTests/config/replicationReceiveQueueParam.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+// `env.get` resolves a name only if it is present in CONFIG_PARAM_MAP, which is populated from
+// CONFIG_PARAMS by lowercased name. An unregistered param therefore reads as `undefined` forever: the
+// configured value is silently ignored, its compiled-in default always applies, and set_configuration
+// rejects it as unrecognized. That is how `replication_leadingDuplicateSkip` shipped inert
+// (harper-pro#395), and several sibling replication params are inert today (harper-pro#734).
+//
+// harper-pro's receive-queue budget (harper-pro#735) reads this param, and its own suite asserts the
+// registration — but only against whatever core its submodule pins. This guards the entry here.
+
+const assert = require('node:assert/strict');
+const { CONFIG_PARAMS, CONFIG_PARAM_MAP } = require('#src/utility/hdbTerms');
+
+describe('replication_receiveQueueHighWaterMark registration', () => {
+	it('is registered in CONFIG_PARAMS so env.get can resolve it', () => {
+		assert.strictEqual(CONFIG_PARAMS.REPLICATION_RECEIVEQUEUEHIGHWATERMARK, 'replication_receiveQueueHighWaterMark');
+	});
+
+	it('is reachable through CONFIG_PARAM_MAP, so set_configuration accepts it', () => {
+		assert.strictEqual(
+			CONFIG_PARAM_MAP['replication_receivequeuehighwatermark'],
+			'replication_receiveQueueHighWaterMark'
+		);
+	});
+});

--- a/utility/hdbTerms.ts
+++ b/utility/hdbTerms.ts
@@ -658,6 +658,10 @@ export const CONFIG_PARAMS = {
 	REPLICATION_BLOBCONCURRENCY: 'replication_blobConcurrency',
 	REPLICATION_MAXPAYLOAD: 'replication_maxPayload',
 	REPLICATION_RECORDCONCURRENCY: 'replication_recordConcurrency',
+	// Byte ceiling on inbound replication frames accepted but not yet processed. Without it the
+	// receive path's frame queue is unbounded and a receiver slower than its peer grows it at the full
+	// inbound line rate until the worker is OOM-killed (harper#2226, harper-pro#659).
+	REPLICATION_RECEIVEQUEUEHIGHWATERMARK: 'replication_receiveQueueHighWaterMark',
 	REPLICATION_PINGINTERVAL: 'replication_pingInterval',
 	REPLICATION_PINGTIMEOUT: 'replication_pingTimeout',
 	REPLICATION_COPYTIMEOUT: 'replication_copyTimeout',


### PR DESCRIPTION
Registers `replication_receiveQueueHighWaterMark` in `CONFIG_PARAMS`.

`env.get` resolves only names present in `CONFIG_PARAM_MAP` — `getConfigValue` returns `undefined`
for anything absent — so a config param that isn't registered is silently ignored and its
compiled-in default always applies. That is how `replication_leadingDuplicateSkip` shipped inert
(harper-pro#395, which is why `unitTests/replication/leadingDuplicateSkipConfig.test.mjs` exists),
and it is the current state of four sibling replication knobs (harper-pro#734).

Companion to HarperFast/harper-pro#735, which bounds the replication receive path's inbound
frame queue and reads this param. Without this commit that PR's budget cannot be configured at all:
the default would be permanently in force, an operator watching a worker OOM could neither lower it
nor set `0` to disable, and there would be no error — only the default's behavior. A unit test on
the harper-pro side asserts this registration resolves, so the pair cannot drift back apart.

## For the human reviewer

One line in an enum, but it gates a fix's entire configurability, so the ordering matters: this
needs to land (and be present in whatever core the harper-pro PR pins) before the harper-pro side is
useful. The reviewers of the harper-pro PR flagged exactly this as the release-ordering risk.

Worth knowing separately: `replication_receiveEventHighWaterMark`, `replication_receiveYieldInterval`,
`replication_copyCheckpointRecords` and `replication_copyCheckpointMaxIntervalMs` are all unregistered
today, so they are inert. Filed as harper-pro#734 rather than fixed here — registering them would
make previously-ignored values in existing config files start taking effect, which deserves its own
review rather than riding along with this.

## Verification

`npm run build` clean; the harper-pro unit test asserting
`CONFIG_PARAMS.REPLICATION_RECEIVEQUEUEHIGHWATERMARK === 'replication_receiveQueueHighWaterMark'`
passes against this commit, and the harper-pro integration test confirms a configured budget reaches
the gate (the warn payload carries the configured value, not the default).
