### PR TITLE
Bound the analytics node-storage walk so it cannot OOM the main thread on every boot

### DIFF
--- a/resources/analytics/write.ts
+++ b/resources/analytics/write.ts
@@ -3,7 +3,7 @@ import { onMessageByType } from '../../server/threads/manageThreads.js';
 import { getDatabases, table, isReadOnlyMode } from '../databases.ts';
 import type { Databases, Table, Tables } from '../databases.ts';
 import harperLogger from '../../utility/logging/harper_logger.ts';
-import { stat, readdir } from 'node:fs/promises';
+import { stat, opendir } from 'node:fs/promises';
 const { getLogFilePath, forComponent } = harperLogger;
 import { dirname, join } from 'path';
 import { open } from 'fs/promises';
@@ -780,32 +780,81 @@ function getDatabasesIncludingSystem(): Databases {
 	return all;
 }
 
-export async function getDirectorySizeAsync(dirPath: string): Promise<number> {
-	try {
-		const entries = await readdir(dirPath, { withFileTypes: true });
-		const sizes = await Promise.all(
-			entries.map((entry) => {
-				const fullPath = join(dirPath, entry.name);
-				if (entry.isDirectory()) return getDirectorySizeAsync(fullPath);
-				if (entry.isFile()) return stat(fullPath).then((s) => s.size);
-				return 0;
-			})
-		);
-		let total = 0;
-		for (const size of sizes) total += size;
-		return total;
-	} catch {
-		// directory may not exist or be inaccessible
-		return 0;
+/**
+ * Total size of everything under `dirPath`, measured with the smallest footprint we can manage rather
+ * than the fewest wall-clock seconds: this runs about every ten minutes (`analytics.aggregatePeriod`
+ * 60s x `analytics.storageInterval` 10), so it can afford to be slow, and it shares the libuv thread
+ * pool with everything else on this thread.
+ *
+ * Peak live set is O(directories): each directory streams through `opendir` instead of materializing a
+ * dirent array, files are stat'd one at a time, and only the directory stack and a running total are
+ * retained. The previous implementation fanned out over every entry in the tree with an unbounded
+ * `Promise.all`, holding a path string, a dirent and a pending stat per file simultaneously — which
+ * grew the main thread's heap until V8 aborted on a root with a large blob store (harper#2240).
+ *
+ * A per-file stat failure must not zero the tree: the previous `Promise.all` rejected on one bad stat
+ * and the outer catch returned 0 for everything under `dirPath`, so a file removed mid-walk erased the
+ * whole measurement.
+ *
+ * `statFile` is a test seam; production always uses `stat`.
+ */
+export async function getDirectorySizeAsync(
+	dirPath: string,
+	options?: { statFile?: (path: string) => Promise<{ size: number }> }
+): Promise<number> {
+	const statFile = options?.statFile ?? stat;
+	const directories: string[] = [dirPath];
+	let total = 0;
+	let statFailures = 0;
+	while (directories.length > 0) {
+		const directory = directories.pop() as string;
+		let handle;
+		try {
+			handle = await opendir(directory);
+		} catch {
+			continue; // may not exist or be inaccessible — contributes 0, as before
+		}
+		try {
+			for await (const entry of handle) {
+				const fullPath = join(directory, entry.name);
+				if (entry.isDirectory()) {
+					directories.push(fullPath);
+					continue;
+				}
+				if (!entry.isFile()) continue;
+				try {
+					total += (await statFile(fullPath)).size;
+				} catch {
+					statFailures++;
+				}
+			}
+		} catch {
+			// Iteration failed partway (permissions, removal mid-walk). `for await` does not run the
+			// iterator's return() when next() rejects, so close explicitly rather than relying on Dir
+			// internals; a double close throws ERR_DIR_CLOSED, hence the swallow.
+			await handle.close().catch(() => {});
+		}
 	}
+	if (statFailures > 0) {
+		log.debug?.(`Storage metric: ${statFailures} file(s) could not be stat'd; reported size is an under-count`);
+	}
+	return total;
 }
 
 const DEFAULT_STORAGE_INTERVAL = 10;
 let nodeStorageInterval = DEFAULT_STORAGE_INTERVAL;
 let nodeStorageCycleCount = 0;
+let nodeStorageWalkInFlight = false;
 
 async function storeNodeStorageMetric(analyticsTable: Table) {
 	if (nodeStorageInterval <= 0 || ++nodeStorageCycleCount % nodeStorageInterval !== 1) return;
+	// A walk of a large root can outlast the cadence; overlapping walks would multiply the peak. Logged
+	// so a gap in the series reads as "measurement is not keeping up" rather than "storage stopped".
+	if (nodeStorageWalkInFlight) {
+		log.debug?.('Skipping node storage metric: the previous walk is still running');
+		return;
+	}
+	nodeStorageWalkInFlight = true;
 	try {
 		const size = await getDirectorySizeAsync(getHdbBasePath());
 		storeMetric(analyticsTable, {
@@ -814,6 +863,8 @@ async function storeNodeStorageMetric(analyticsTable: Table) {
 		});
 	} catch (error) {
 		log.warn?.('Error getting node storage metric', error);
+	} finally {
+		nodeStorageWalkInFlight = false;
 	}
 }
 

--- a/unitTests/resources/analytics/write.test.js
+++ b/unitTests/resources/analytics/write.test.js
@@ -113,6 +113,59 @@ describe('getDirectorySizeAsync', () => {
 		const size = await getDirectorySizeAsync(join(tmpDir, 'nope'));
 		expect(size).to.equal(0);
 	});
+
+	// harper#2240: the walk used to fan out over every entry in the tree with an unbounded
+	// Promise.all, so it held a path string, a dirent and a pending stat for EVERY file at once. On a
+	// node whose root carries a large blob store that grew the main thread's heap ~72 MB/s until V8
+	// aborted — on every boot, since the metric runs on the first analytics cycle. It measures about
+	// every ten minutes, so the footprint matters and the wall clock does not.
+	it('stats one file at a time', async () => {
+		const FILES = 300;
+		await Promise.all(
+			Array.from({ length: FILES }, (unused, i) => writeFile(join(tmpDir, `f${i}.txt`), 'x'.repeat(10)))
+		);
+		let outstanding = 0;
+		let peak = 0;
+		const statFile = async (_path) => {
+			outstanding++;
+			if (outstanding > peak) peak = outstanding;
+			await new Promise((resolve) => setImmediate(resolve));
+			outstanding--;
+			return { size: 10 };
+		};
+		const size = await getDirectorySizeAsync(tmpDir, { statFile });
+		expect(size).to.equal(FILES * 10);
+		expect(peak).to.equal(1);
+	});
+
+	it('sums a directory far wider than any plausible batch', async () => {
+		const FILES = 2000;
+		await Promise.all(Array.from({ length: FILES }, (unused, i) => writeFile(join(tmpDir, `w${i}.bin`), 'ab')));
+		expect(await getDirectorySizeAsync(tmpDir)).to.equal(FILES * 2);
+	});
+
+	it('descends through many nested levels', async () => {
+		let dir = tmpDir;
+		for (let i = 0; i < 60; i++) {
+			dir = join(dir, `d${i}`);
+			await mkdir(dir);
+		}
+		await writeFile(join(dir, 'deep.txt'), 'abcd');
+		expect(await getDirectorySizeAsync(tmpDir)).to.equal(4);
+	});
+
+	it('skips a file whose stat fails instead of zeroing the whole tree', async () => {
+		// The old Promise.all rejected on one bad stat and the outer catch returned 0 for everything
+		// under dirPath — a file removed mid-walk erased the entire measurement.
+		await writeFile(join(tmpDir, 'good1.txt'), 'aaaa');
+		await writeFile(join(tmpDir, 'gone.txt'), 'bbbbbb');
+		await writeFile(join(tmpDir, 'good2.txt'), 'cc');
+		const statFile = async (path) => {
+			if (path.endsWith('gone.txt')) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+			return { size: path.endsWith('good1.txt') ? 4 : 2 };
+		};
+		expect(await getDirectorySizeAsync(tmpDir, { statFile })).to.equal(6);
+	});
 });
 
 describe('calculateCPUUtilization', () => {


### PR DESCRIPTION
Fixes #2240.

`storeNodeStorageMetric` computed the `NODE_STORAGE` metric by walking the **entire Harper root** with a
recursive, unbounded `Promise.all` fan-out. The peak live set was **O(files in the tree)** — a path
string, a dirent and a pending `stat` for every file at once — so on a node whose root carries a large
blob store the **main thread's** heap grew ~72 MB/s until V8 aborted. Because the metric runs on the
**first** analytics cycle after start, that happened on every boot: the node could not stay up
(124 restarts observed live on 5.2.3).

The walk now streams each directory through `opendir` (one handle at a time, no dirent array per
directory) and stats **one file at a time**, accumulating a running total — so the peak is
O(directories).

## Measurements

Same totals in every case; peak `heapUsed` sampled at 20 ms during the walk.

| tree | before | after (sequential) |
|---|---|---|
| 50,000 files / 50 dirs (flat) | 108 MB, 0.5 s | **10 MB**, 1.4–4.0 s |
| 65,536 files / 16,384 leaf dirs (blob-store shape) | 163 MB, 1.2 s | **27 MB**, 5.3–10.3 s |

The flat case extrapolates to ~2.9 GB at the ~1.6M files of the affected node — the magnitude that was
actually observed. The sharded case extrapolates to roughly 2–4 minutes of wall clock at that file
count, against a cadence of about ten minutes (see below), so a walk normally finishes between samples;
if it does not, the new overlap guard skips the next one and logs why.

**Why sequential rather than a bounded pool.** An earlier revision used a 64-wide stat pool. It is
*not* meaningfully better on memory — measured 11 MB vs 10 MB flat, 26 MB vs 27 MB sharded, because the
peak is dominated by the directory stack, not by pending stats — and it costs something real: 64
concurrent `stat` calls monopolize the libuv thread pool (4 threads by default, and `UV_THREADPOOL_SIZE`
is not set anywhere in the install) that blob reads and every other fs operation on this thread share.
For a measurement that runs every ten minutes and has no deadline, minimizing interference is worth
more than wall clock. Sequential also deletes the pool bookkeeping entirely.

**Residual bound.** Peak is now O(directories): 27 MB at 16k directories, so ~1.6 MB per thousand. A
deeply sharded blob store with a few hundred thousand directories would still cost a few hundred MB at
peak. That is three orders of magnitude better than before and does not OOM, but it is the reason the
follow-up below is worth taking seriously.

## Cadence, for context

`analytics.aggregatePeriod` defaults to **60 s** and `analytics.storageInterval` to **10 cycles**, so
this metric measures roughly **every ten minutes** — plus once about a minute into every boot, which is
what made the old fan-out fatal rather than merely wasteful.

## For the human reviewer

1. **Two behavior changes, both deliberate.** A file whose `stat` fails is now skipped instead of
   zeroing the tree — previously one bad stat rejected the `Promise.all` and the outer catch returned
   `0` for everything under the root, so a file removed mid-walk erased the whole measurement. And a
   walk that outlasts the cadence now skips the next sample rather than running two walks at once.
   Both are logged at debug so an under-count or a gap in the series is diagnosable rather than
   mysterious.
2. **Two review suggestions about the stat pool are now moot** — there is no pool. One proposed
   hoisting it above the directory loop so it spans directories; measured, that made no difference on
   the sharded tree (2,789 ms vs 2,777 ms, no peak advantage) and was worse on the flat one (692 ms vs
   451 ms, 18.5 MB vs 10.8 MB). Removing concurrency altogether supersedes both.
3. **The metric semantic is unchanged** — recursive byte total of the root — which is why this is a
   bounded traversal rather than something cheaper. Worth a follow-up decision: a size metric probably
   should not walk 1.6M files at all (RocksDB already tracks its own sizes, and the blob store
   dominates the count). I did not change the semantic here because that is a product call, not a bug
   fix.
4. The walk is O(directories) in memory and unbounded in time. If the time matters more than I think
   on some deployment, the lever is `analytics.storageInterval` (or `0` to disable), not concurrency.

## Verification

- Unit: the four existing `getDirectorySizeAsync` cases are unchanged and still pass, plus new cases
  pinning that stats are issued one at a time (peak outstanding == 1), a 2,000-file directory, nested
  descent, and the stat-failure path. 40 passing in that file.
- The out-of-tree A/B harness that produced the table above compares the old and new walk against the
  same generated trees; it is not committed (it needs generated fixtures of ~65k files).
- **Not** verified: the end-to-end `NODE_STORAGE` metric path and the overlap guard under a real
  analytics cadence. Both are timer-driven; I tested the helper, not the scheduler.

## Operator note

An affected node can be recovered today without this change: `analytics.storageInterval: 0`
(env `ANALYTICS_STORAGEINTERVAL=0`) disables the metric, and the `nodeStorageInterval <= 0` early
return already exists. That is strictly better than raising `--max-old-space-size`, which only moves
the wall. Note that raising the **main thread's** ceiling needs container `NODE_OPTIONS` —
`threads.maxHeapMemory` governs workers only.
