### PR TITLE
[DIAGNOSTIC - do not merge] Profile the Windows RocksDB seed slowdown (#2243)

### DIFF
--- a/integrationTests/database/txnlog-purge-stale-read-blast.test.ts
+++ b/integrationTests/database/txnlog-purge-stale-read-blast.test.ts
@@ -191,14 +191,36 @@ function fmtMiB(bytes: number): string {
 	return `${(bytes / 1024 / 1024).toFixed(3)}MiB`;
 }
 
-async function seedRange(ctx: ContextWithHarper, start: number, count: number, bucket: string): Promise<void> {
+// DIAGNOSTIC (harper#2243): time every insert batch and hand the durations back so the caller
+// can print a per-batch profile. The per-request budget is raised well past the production 60s
+// so a slow Windows run yields a full profile instead of aborting mid-seed.
+const PROFILE_BATCH_TIMEOUT_MS = 600_000;
+
+async function seedRange(ctx: ContextWithHarper, start: number, count: number, bucket: string): Promise<number[]> {
+	const batchMs: number[] = [];
 	for (let s = start; s < start + count; s += BATCH_SIZE) {
 		const records = [];
 		for (let i = s; i < Math.min(s + BATCH_SIZE, start + count); i++) {
 			records.push({ id: `k${i}`, seq: i, bucket, payload: payloadFor(i) });
 		}
-		const r = await rawOp(ctx, { operation: 'insert', schema: SCHEMA, table: TABLE, records });
+		const t0 = Date.now();
+		const r = await rawOp(
+			ctx,
+			{ operation: 'insert', schema: SCHEMA, table: TABLE, records },
+			PROFILE_BATCH_TIMEOUT_MS
+		);
+		batchMs.push(Date.now() - t0);
 		ok(r.status === 200, `insert batch@${s} should succeed, got ${r.status}: ${r.text.slice(0, 300)}`);
+	}
+	return batchMs;
+}
+
+async function rocksStats(ctx: ContextWithHarper): Promise<any> {
+	try {
+		const r = await fetch(`${ctx.harper.httpURL}/RocksStats/`, { headers: { Authorization: authHeader(ctx) } });
+		return await r.json();
+	} catch (error) {
+		return { available: false, error: String(error) };
 	}
 }
 
@@ -445,19 +467,37 @@ function defineSuite(engine: 'rocksdb' | 'lmdb') {
 			});
 
 			test('1. seed DEL (6000) + KEEP (6000) ranges, force flushes between waves', { timeout: 300_000 }, async () => {
-				// Flush every 2000 rows so data is genuinely on disk, not just resident in the memtable.
-				await seedRange(ctx, 0, 2000, 'DEL');
-				await flush(ctx, engine);
-				await seedRange(ctx, 2000, 2000, 'DEL');
-				await flush(ctx, engine);
-				await seedRange(ctx, 4000, 2000, 'DEL');
-				await flush(ctx, engine);
-				await seedRange(ctx, 6000, 2000, 'KEEP');
-				await flush(ctx, engine);
-				await seedRange(ctx, 8000, 2000, 'KEEP');
-				await flush(ctx, engine);
-				await seedRange(ctx, 10000, 2000, 'KEEP');
-				await flush(ctx, engine);
+				// DIAGNOSTIC (harper#2243): profile each wave -- per-batch insert durations, flush
+				// duration, and the RocksDB stat deltas that separate a write stall from slow
+				// flush/fsync. Printed as [WINPROFILE] lines so a CI log can be grepped for them.
+				const before = await rocksStats(ctx);
+				console.log(`[WINPROFILE] engine=${engine} platform=${process.platform} statsBefore=${JSON.stringify(before)}`);
+				const waves: Array<[number, number, string]> = [
+					[0, 2000, 'DEL'],
+					[2000, 2000, 'DEL'],
+					[4000, 2000, 'DEL'],
+					[6000, 2000, 'KEEP'],
+					[8000, 2000, 'KEEP'],
+					[10000, 2000, 'KEEP'],
+				];
+				for (const [start, count, bucket] of waves) {
+					const batchMs = await seedRange(ctx, start, count, bucket);
+					const flushT0 = Date.now();
+					await flush(ctx, engine);
+					const flushMs = Date.now() - flushT0;
+					const after = await rocksStats(ctx);
+					console.log(
+						`[WINPROFILE] engine=${engine} wave@${start} bucket=${bucket} ` +
+							`insertBatchesMs=[${batchMs.join(',')}] insertTotalMs=${batchMs.reduce((a, b) => a + b, 0)} ` +
+							`maxBatchMs=${Math.max(...batchMs)} flushMs=${flushMs} ` +
+							`stallMicros=${after?.stallMicros} memTableFlushPending=${after?.memTableFlushPending} ` +
+							`numImmutableMemTable=${after?.numImmutableMemTable} compactionPending=${after?.compactionPending} ` +
+							`pendingCompactionBytes=${after?.estimatePendingCompactionBytes} ` +
+							`logQueueDepth=${after?.commitPipelineLogQueueDepth} commitQueueDepth=${after?.commitPipelineCommitQueueDepth}`
+					);
+				}
+				const finalStats = await rocksStats(ctx);
+				console.log(`[WINPROFILE] engine=${engine} statsAfter=${JSON.stringify(finalStats)}`);
 
 				cutoffTimestamp = Date.now();
 				await sleep(250);

--- a/integrationTests/database/txnlog-purge-stale-read-blast/resources.js
+++ b/integrationTests/database/txnlog-purge-stale-read-blast/resources.js
@@ -70,3 +70,41 @@ export class FullScan extends Resource {
 		return { totalCount, records };
 	}
 }
+
+// DIAGNOSTIC ONLY (harper#2243) — not for merge. Exposes the RocksDB stat counters that
+// discriminate a write stall from slow flush/fsync on Windows. `enableStats: true` is already
+// set for every RocksDB database (resources/databases.ts), so the curated keys are populated.
+export class RocksStats extends Resource {
+	static loadAsInstance = false;
+	async get() {
+		const t = tables['Widget'];
+		const root = t?.primaryStore?.rootStore;
+		if (!root || typeof root.getStats !== 'function') return { available: false };
+		let stats;
+		try {
+			stats = root.getStats();
+		} catch (error) {
+			return { available: false, error: String(error) };
+		}
+		const pick = (k) => stats?.[k];
+		return {
+			available: true,
+			stallMicros: pick('rocksdb.stall.micros'),
+			writeStall: pick('rocksdb.db.write.stall'),
+			flushMicros: pick('rocksdb.db.flush.micros'),
+			writeMicros: pick('rocksdb.db.write.micros'),
+			compactionTimesMicros: pick('rocksdb.compaction.times.micros'),
+			numImmutableMemTable: pick('rocksdb.num-immutable-mem-table'),
+			memTableFlushPending: pick('rocksdb.mem-table-flush-pending'),
+			numRunningFlushes: pick('rocksdb.num-running-flushes'),
+			numRunningCompactions: pick('rocksdb.num-running-compactions'),
+			compactionPending: pick('rocksdb.compaction-pending'),
+			estimatePendingCompactionBytes: pick('rocksdb.estimate-pending-compaction-bytes'),
+			bytesWritten: pick('rocksdb.bytes.written'),
+			keysWritten: pick('rocksdb.number.keys.written'),
+			txnlogBytesWritten: pick('txnlog.bytesWritten'),
+			commitPipelineLogQueueDepth: pick('commitPipeline.logQueueDepth'),
+			commitPipelineCommitQueueDepth: pick('commitPipeline.commitQueueDepth'),
+		};
+	}
+}


### PR DESCRIPTION
**Do not merge. Do not review.** Instrumentation to answer one question on #2243.

## Question

#2243 measured the QA-782 seed (12,000 x 1.8KB records, 24 batches, 7 forced flushes) at **~2s on Linux and 83-238s on Windows**. Two candidate mechanisms were not distinguishable from CI logs, because the integration harness logs at `error` level:

1. slow Windows fsync making each forced memtable flush cost seconds, or
2. a RocksDB **write stall** — forced flushes pile up L0 files and the write path throttles.

## Method

`enableStats: true` is already set for every RocksDB database (`resources/databases.ts:662`), so rocksdb-js's curated counters are already populated. This branch adds a `RocksStats` fixture resource exposing them and times each insert batch and each flush.

The decisive counter is **`rocksdb.stall.micros`**:

- stall micros ≈ the missing 80-230s → **write stall** (fix likely belongs in rocksdb-js or write-buffer sizing)
- `db.flush.micros.sum` ≈ the missing time → **flush/fsync cost**
- neither → the time is somewhere else entirely (HTTP/ops path, txnlog, compaction)

The per-request budget is raised to 600s so a slow Windows run produces a complete profile instead of aborting mid-seed.

## Baseline (macOS, local)

```
rocksdb wave@0    insertBatchesMs=[46,39,25,31] flushMs=43  stallMicros=0
rocksdb statsAfter flushMicros.avg=5702us (14 flushes)  stallMicros=0
```

Grep the Windows shard-1 job log for `[WINPROFILE]`.

Closing this once the numbers are recorded on #2243.

_— Claude Opus 5_