### PR TITLE
test(database): keep the QA-782 lmdb control arm off Windows

### DIFF
--- a/integrationTests/database/txnlog-purge-stale-read-blast.test.ts
+++ b/integrationTests/database/txnlog-purge-stale-read-blast.test.ts
@@ -73,6 +73,18 @@ const FIXTURE_PATH = resolve(import.meta.dirname, 'txnlog-purge-stale-read-blast
 const SCHEMA = 'data';
 const TABLE = 'Widget';
 const skipSuite = process.env.HARPER_RUNTIME === 'bun';
+// The lmdb arm is the CONTROL (the phantom under test is RocksDB-specific), and on Windows its
+// seed is not viable at this magnitude: LMDB insert cost there grows superlinearly with database
+// size -- measured 2.7s per 500-record batch at the start and 37.7s by the fifth wave, ~311s for
+// the seed against the rocksdb arm's 28.3s on the same runner, while Linux does both in ~2s
+// (harper#2243). That crosses the seed's per-request budget on a slow runner and reds
+// `Integration Tests 1/6 (Windows)` intermittently on `main`.
+//
+// Skipped rather than shrunk: the control's value is running the SAME workload as the subject, and
+// per-engine record counts would weaken exactly that. The control still runs on every other
+// platform, and LMDB is deprecated, so Windows-specific LMDB coverage buys little. Do NOT "fix"
+// this by raising the timeout -- that keeps ~5 minutes of Windows CI time and adds no signal.
+const skipLmdbArm = process.platform === 'win32';
 
 // DEL range gets bulk-deleted (the subject of this whole suite). KEEP range stays untouched
 // (scoping sanity: proves the delete/read paths aren't just globally broken). Padded payload
@@ -410,7 +422,7 @@ async function assertAbsentEverywhere(
 function defineSuite(engine: 'rocksdb' | 'lmdb') {
 	suite(
 		`QA-782 stale-read blast radius: ordinary table reads after bulk delete [${engine}]`,
-		{ skip: skipSuite },
+		{ skip: skipSuite || (engine === 'lmdb' && skipLmdbArm) },
 		(ctx: ContextWithHarper) => {
 			const findings: string[] = [];
 			const armConfig = {


### PR DESCRIPTION
Fixes #2243.

`Integration Tests 1/6 (Windows, Node.js v24)` has been intermittently red on `main`. The cause is the **lmdb control arm** of `txnlog-purge-stale-read-blast.test.ts`, not the rocksdb subject arm and not anything in the product.

## What was measured

A diagnostic branch exposed rocksdb-js's stat counters (`enableStats: true` is already set for every RocksDB database in `resources/databases.ts`) and timed each insert batch and flush on a Windows runner:

| arm | inserts | flush (wall) | total |
|---|---|---|---|
| rocksdb | 2.8s | 24.2s | **28.3s — passed** |
| lmdb | **311s** | 0.03s | **311s — blew the 300s subtest timeout** |

Linux completes both arms in ~2s. LMDB's per-batch cost on Windows grows superlinearly with database size — 2.7s per 500-record (~900KB) batch at the start, **37.7s by the fifth wave**. On a slow runner that crosses the seed's per-request budget; on a fast one it does not. That is the flake.

Both candidate mechanisms were ruled out, not assumed:

- **Not a RocksDB write stall** — `rocksdb.stall.micros = 0` at every checkpoint, with `mem-table-flush-pending`, `num-immutable-mem-table`, `compaction-pending` and `estimate-pending-compaction-bytes` all zero.
- **Not slow RocksDB fsync** — RocksDB's own flush histogram totals 1.47s across 14 flushes (avg 105ms).

## For the human reviewer

1. **Skipped, not shrunk.** The lmdb arm is the control; its value is running the *same* workload as the subject, so introducing per-engine record counts would weaken the very comparison it exists to make. Both arms still run on every other platform, and LMDB is deprecated, so Windows-specific LMDB coverage buys little.
2. **Deliberately not a timeout bump.** Raising the budget would green the board while keeping ~5 minutes of Windows CI time and adding no signal. The code comment says so, so the next person to see this test slow down does not reach for the timeout.
3. One loose end left in #2243, not addressed here: 24.2s of wall-clock flush against 1.47s of actual RocksDB flush means ~23s sits in the HTTP/ops round trip. Unexplained and probably unrelated, but recorded.

## Verification

- With the arm skipped, the rocksdb arm still passes **7/7 in 17.8s** and the lmdb arm reports `SKIP` (validated locally through a temporary force flag, removed before commit).
- Prettier clean.

_— Claude Opus 5_