### PR TITLE
Bound the exclusive 'update-attributes' lock wait and release it structurally

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -287,7 +287,7 @@ A handful of design points are non-obvious and easy to break:
 
 Two related traps: the create/schema-update path's exclusive `update-attributes` lock is a
 synchronous bounded wait (`acquireUpdateAttributesLock` in `Table.ts`: brief hot spin, then
-`Atomics.wait` backoff, `ServerError` after the 10s `LOCK_TIMEOUT` — harper#2251; it used to be
+`Atomics.wait` backoff, retryable `ServerError` after the 10s `UPDATE_ATTRIBUTES_LOCK_TIMEOUT` — harper#2251; it used to be
 an unbounded `while (!tryLock()) {}` spin that pinned a worker core forever if the holder never
 released). Release is structural — `table()` releases in a single `finally` and `dropTable` uses
 `withUpdateAttributesLock` — so a throw inside the locked window cannot leak the lock; keep it

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -292,9 +292,11 @@ an unbounded `while (!tryLock()) {}` spin that pinned a worker core forever if t
 released). Release is structural — `table()` releases in a single `finally` and `dropTable` uses
 `withUpdateAttributesLock` — so a throw inside the locked window cannot leak the lock (regression
 suite: `unitTests/resources/updateAttributesLock.test.js`). Because the acquire can now throw,
-`table()` takes the lock _before_ it mutates the live `Table` (attributes, class metadata, index
-handles): losing the race then leaves this worker's in-memory schema exactly as it found it, and
-moving any mutation above that acquire reintroduces schema drift the catalog never saw. A
+`table()` takes the RocksDB lock _before_ it mutates the live `Table` (attributes, class metadata,
+index handles): losing the race then leaves this worker's in-memory schema exactly as it found it,
+and moving any mutation above that acquire reintroduces schema drift the catalog never saw. LMDB
+keeps the lazy acquire — its `exclusiveLock()` is an environment-wide write transaction that cannot
+time out, so taking it eagerly would stall every write to the database on an unchanged reload. A
 successful acquire that waited past `UPDATE_ATTRIBUTES_LOCK_SLOW_WAIT` (1s) warns once, since
 contention is otherwise invisible until it becomes a timeout. The locked
 sections MUST stay synchronous: the wait blocks the event loop, so an awaited operation inside

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -291,7 +291,12 @@ synchronous bounded wait (`acquireUpdateAttributesLock` in `Table.ts`: brief hot
 an unbounded `while (!tryLock()) {}` spin that pinned a worker core forever if the holder never
 released). Release is structural — `table()` releases in a single `finally` and `dropTable` uses
 `withUpdateAttributesLock` — so a throw inside the locked window cannot leak the lock (regression
-suite: `unitTests/resources/updateAttributesLock.test.js`). The locked
+suite: `unitTests/resources/updateAttributesLock.test.js`). Because the acquire can now throw,
+`table()` takes the lock _before_ it mutates the live `Table` (attributes, class metadata, index
+handles): losing the race then leaves this worker's in-memory schema exactly as it found it, and
+moving any mutation above that acquire reintroduces schema drift the catalog never saw. A
+successful acquire that waited past `UPDATE_ATTRIBUTES_LOCK_SLOW_WAIT` (1s) warns once, since
+contention is otherwise invisible until it becomes a timeout. The locked
 sections MUST stay synchronous: the wait blocks the event loop, so an awaited operation inside
 one would stall a concurrent acquirer to its deadline. And dropping then recreating a
 same-named table within one process requires @harperfast/rocksdb-js >= the column-family

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -290,7 +290,8 @@ synchronous bounded wait (`acquireUpdateAttributesLock` in `Table.ts`: brief hot
 `Atomics.wait` backoff, retryable `ServerError` after the 10s `UPDATE_ATTRIBUTES_LOCK_TIMEOUT` — harper#2251; it used to be
 an unbounded `while (!tryLock()) {}` spin that pinned a worker core forever if the holder never
 released). Release is structural — `table()` releases in a single `finally` and `dropTable` uses
-`withUpdateAttributesLock` — so a throw inside the locked window cannot leak the lock. The locked
+`withUpdateAttributesLock` — so a throw inside the locked window cannot leak the lock (regression
+suite: `unitTests/resources/updateAttributesLock.test.js`). The locked
 sections MUST stay synchronous: the wait blocks the event loop, so an awaited operation inside
 one would stall a concurrent acquirer to its deadline. And dropping then recreating a
 same-named table within one process requires @harperfast/rocksdb-js >= the column-family

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -285,9 +285,15 @@ A handful of design points are non-obvious and easy to break:
   _bypassed_ by the seam and is therefore covered at the **integration** level (`sse-listchanged.test.ts` N3
   record / N4 collection), not in unit tests.
 
-Two related traps: the create path's exclusive `update-attributes` lock is a synchronous spin
-lock (`while (!tryLock()) {}`), so any throw inside the create window must release it or every
-subsequent create on that database pins a worker at 100% CPU. And dropping then recreating a
+Two related traps: the create/schema-update path's exclusive `update-attributes` lock is a
+synchronous bounded wait (`acquireUpdateAttributesLock` in `Table.ts`: brief hot spin, then
+`Atomics.wait` backoff, `ServerError` after the 10s `LOCK_TIMEOUT` — harper#2251; it used to be
+an unbounded `while (!tryLock()) {}` spin that pinned a worker core forever if the holder never
+released). Release is structural — `table()` releases in a single `finally` and `dropTable` uses
+`withUpdateAttributesLock` — so a throw inside the locked window cannot leak the lock; keep it
+that way (regression suite: `unitTests/resources/updateAttributesLock.test.js`). The locked
+sections MUST stay synchronous: the wait blocks the event loop, so an awaited operation inside
+one would stall a concurrent acquirer to its deadline. And dropping then recreating a
 same-named table within one process requires @harperfast/rocksdb-js >= the column-family
 eviction fix (1.4.3 / rocksdb-js#<main PR>): older bindings keep the dropped column family's
 by-name registry entry alive whenever other worker threads hold handles, so the recreate

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -290,8 +290,7 @@ synchronous bounded wait (`acquireUpdateAttributesLock` in `Table.ts`: brief hot
 `Atomics.wait` backoff, retryable `ServerError` after the 10s `UPDATE_ATTRIBUTES_LOCK_TIMEOUT` — harper#2251; it used to be
 an unbounded `while (!tryLock()) {}` spin that pinned a worker core forever if the holder never
 released). Release is structural — `table()` releases in a single `finally` and `dropTable` uses
-`withUpdateAttributesLock` — so a throw inside the locked window cannot leak the lock; keep it
-that way (regression suite: `unitTests/resources/updateAttributesLock.test.js`). The locked
+`withUpdateAttributesLock` — so a throw inside the locked window cannot leak the lock. The locked
 sections MUST stay synchronous: the wait blocks the event loop, so an awaited operation inside
 one would stall a concurrent acquirer to its deadline. And dropping then recreating a
 same-named table within one process requires @harperfast/rocksdb-js >= the column-family

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -49,6 +49,7 @@ import {
 	ServerError,
 	AccessViolation,
 	ValidationError,
+	UpdateAttributesLockTimeoutError,
 	type ValidationIssue,
 } from '../utility/errors/hdbError.ts';
 import * as signalling from '../utility/signalling.ts';
@@ -134,21 +135,13 @@ const CACHEABLE_STATUS_CODES = new Set([200, 203, 204, 206, 300, 301, 308, 404, 
 envMngr.initSync();
 const LMDB_PREFETCH_WRITES = envMngr.get(CONFIG_PARAMS.STORAGE_PREFETCHWRITES);
 const LOCK_TIMEOUT = 10000;
+// This bounds schema-lock acquisition; LOCK_TIMEOUT bounds in-flight record writes during a drop.
 export const UPDATE_ATTRIBUTES_LOCK_TIMEOUT = 10000;
 const UPDATE_ATTRIBUTES_LOCK = 'update-attributes';
 // raw ASCII bytes are ordered-binary's encoding of the string, so this addresses the same native
 // lock as string-keyed tryLock/unlock calls
 const updateAttributesLockKey = Buffer.from(UPDATE_ATTRIBUTES_LOCK);
 const lockWait = new Int32Array(new SharedArrayBuffer(4));
-
-class UpdateAttributesLockTimeoutError extends ServerError {
-	code = 'UPDATE_ATTRIBUTES_LOCK_TIMEOUT';
-	retryable = true;
-	constructor(message: string) {
-		super(message, 503);
-		this.name = 'UpdateAttributesLockTimeoutError';
-	}
-}
 
 /** The wait blocks the event loop, so the locked section must stay synchronous. */
 export function acquireUpdateAttributesLock(

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -138,6 +138,9 @@ const LOCK_TIMEOUT = 10000;
 // This bounds schema-lock acquisition; LOCK_TIMEOUT bounds in-flight record writes during a drop.
 export const UPDATE_ATTRIBUTES_LOCK_TIMEOUT = 10000;
 const UPDATE_ATTRIBUTES_LOCK = 'update-attributes';
+// A successful acquire that blocked this long still starved this worker's event loop for that
+// whole span; without a trace, contention is only ever visible once it becomes a timeout (harper#2251).
+export const UPDATE_ATTRIBUTES_LOCK_SLOW_WAIT = 1000;
 // raw ASCII bytes are ordered-binary's encoding of the string, so this addresses the same native
 // lock as string-keyed tryLock/unlock calls
 const updateAttributesLockKey = Buffer.from(UPDATE_ATTRIBUTES_LOCK);
@@ -164,6 +167,11 @@ export function acquireUpdateAttributesLock(
 			if (waitTime < 16) waitTime *= 2;
 		}
 	}
+	const waited = performance.now() - startTime;
+	if (waited >= UPDATE_ATTRIBUTES_LOCK_SLOW_WAIT)
+		logger.warn?.(
+			`Acquired the exclusive '${UPDATE_ATTRIBUTES_LOCK}' lock on ${scopeDescription} after waiting ${Math.round(waited)}ms; this worker's event loop was blocked for that wait, and a holder that runs past ${UPDATE_ATTRIBUTES_LOCK_TIMEOUT}ms fails the update outright`
+		);
 }
 
 export function releaseUpdateAttributesLock(rootStore: RocksDatabase) {

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -138,8 +138,7 @@ const LOCK_TIMEOUT = 10000;
 // This bounds schema-lock acquisition; LOCK_TIMEOUT bounds in-flight record writes during a drop.
 export const UPDATE_ATTRIBUTES_LOCK_TIMEOUT = 10000;
 const UPDATE_ATTRIBUTES_LOCK = 'update-attributes';
-// A successful acquire that blocked this long still starved this worker's event loop for that
-// whole span; without a trace, contention is only ever visible once it becomes a timeout (harper#2251).
+// Contention is otherwise only visible once it becomes a timeout (harper#2251).
 export const UPDATE_ATTRIBUTES_LOCK_SLOW_WAIT = 1000;
 // raw ASCII bytes are ordered-binary's encoding of the string, so this addresses the same native
 // lock as string-keyed tryLock/unlock calls
@@ -168,10 +167,14 @@ export function acquireUpdateAttributesLock(
 		}
 	}
 	const waited = performance.now() - startTime;
+	// The caller cannot register its release until we return, so a throw here would leak the lock
+	// with no `finally` able to reach it.
 	if (waited >= UPDATE_ATTRIBUTES_LOCK_SLOW_WAIT)
-		logger.warn?.(
-			`Acquired the exclusive '${UPDATE_ATTRIBUTES_LOCK}' lock on ${scopeDescription} after waiting ${Math.round(waited)}ms; this worker's event loop was blocked for that wait, and a holder that runs past ${UPDATE_ATTRIBUTES_LOCK_TIMEOUT}ms fails the update outright`
-		);
+		try {
+			logger.warn?.(
+				`Acquired the exclusive '${UPDATE_ATTRIBUTES_LOCK}' lock on ${scopeDescription} after waiting ${Math.round(waited)}ms; this worker's event loop was blocked for that wait, and a holder that runs past ${UPDATE_ATTRIBUTES_LOCK_TIMEOUT}ms fails the update outright`
+			);
+		} catch {}
 }
 
 export function releaseUpdateAttributesLock(rootStore: RocksDatabase) {

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -134,19 +134,17 @@ envMngr.initSync();
 const LMDB_PREFETCH_WRITES = envMngr.get(CONFIG_PARAMS.STORAGE_PREFETCHWRITES);
 export const LOCK_TIMEOUT = 10000;
 const UPDATE_ATTRIBUTES_LOCK = 'update-attributes';
-// Pre-encoded lock key, hoisted so the retry loop below does not re-marshal the string on every
-// tryLock attempt. ordered-binary encodes a plain-ASCII string as its raw bytes, so this Buffer
-// addresses the same native lock as the string form.
+// raw ASCII bytes are ordered-binary's encoding of the string, so this addresses the same native
+// lock as string-keyed tryLock/unlock calls
 const updateAttributesLockKey = Buffer.from(UPDATE_ATTRIBUTES_LOCK);
 const lockWait = new Int32Array(new SharedArrayBuffer(4));
 
 /**
- * Acquires the exclusive cross-thread 'update-attributes' lock that serializes schema/attribute
- * updates (and table create/drop) per database. Synchronous by design: the callers cannot yield to
- * the event loop, and a release by another thread is visible to the retry without yielding (the
- * lock lives in native shared state). Spins hot only briefly, then blocks this thread in bounded
- * waits, and throws after `timeout` instead of spinning forever — a holder that never releases
- * (e.g. a crashed schema operation) previously pinned this worker's core permanently (harper#2251).
+ * Acquires the exclusive cross-thread 'update-attributes' lock serializing schema/attribute updates
+ * (and table create/drop) per database. The wait is synchronous and blocks the event loop, so the
+ * locked section must stay synchronous too — a release by another thread is observable without
+ * yielding, but any release requiring this thread's own event loop can never arrive. Throws after
+ * `timeout` rather than spinning forever on a holder that never releases (harper#2251).
  */
 export function acquireUpdateAttributesLock(
 	rootStore: RocksDatabase,

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -132,7 +132,57 @@ const MAX_INFLIGHT_EVICTION_BATCHES = 4;
 const CACHEABLE_STATUS_CODES = new Set([200, 203, 204, 206, 300, 301, 308, 404, 405, 410, 414, 501]);
 envMngr.initSync();
 const LMDB_PREFETCH_WRITES = envMngr.get(CONFIG_PARAMS.STORAGE_PREFETCHWRITES);
-const LOCK_TIMEOUT = 10000;
+export const LOCK_TIMEOUT = 10000;
+const UPDATE_ATTRIBUTES_LOCK = 'update-attributes';
+// Pre-encoded lock key, hoisted so the retry loop below does not re-marshal the string on every
+// tryLock attempt. ordered-binary encodes a plain-ASCII string as its raw bytes, so this Buffer
+// addresses the same native lock as the string form.
+const updateAttributesLockKey = Buffer.from(UPDATE_ATTRIBUTES_LOCK);
+const lockWait = new Int32Array(new SharedArrayBuffer(4));
+
+/**
+ * Acquires the exclusive cross-thread 'update-attributes' lock that serializes schema/attribute
+ * updates (and table create/drop) per database. Synchronous by design: the callers cannot yield to
+ * the event loop, and a release by another thread is visible to the retry without yielding (the
+ * lock lives in native shared state). Spins hot only briefly, then blocks this thread in bounded
+ * waits, and throws after `timeout` instead of spinning forever — a holder that never releases
+ * (e.g. a crashed schema operation) previously pinned this worker's core permanently (harper#2251).
+ */
+export function acquireUpdateAttributesLock(
+	rootStore: RocksDatabase,
+	scopeDescription: string,
+	timeout = LOCK_TIMEOUT
+) {
+	if (rootStore.tryLock(updateAttributesLockKey)) return;
+	const startTime = Date.now();
+	let waitTime = 1;
+	while (!rootStore.tryLock(updateAttributesLockKey)) {
+		const elapsed = Date.now() - startTime;
+		if (elapsed >= timeout) {
+			throw new ServerError(
+				`Timed out after ${elapsed}ms waiting for the exclusive '${UPDATE_ATTRIBUTES_LOCK}' lock on ${scopeDescription}; the lock holder never released it, so this schema/attribute update cannot proceed`
+			);
+		}
+		if (elapsed >= 2) {
+			Atomics.wait(lockWait, 0, 0, Math.min(waitTime, timeout - elapsed));
+			if (waitTime < 16) waitTime *= 2;
+		}
+	}
+}
+
+export function releaseUpdateAttributesLock(rootStore: RocksDatabase) {
+	rootStore.unlock(updateAttributesLockKey);
+}
+
+/** Runs `callback` under the exclusive 'update-attributes' lock, releasing it on every exit path. */
+export function withUpdateAttributesLock<T>(rootStore: RocksDatabase, scopeDescription: string, callback: () => T): T {
+	acquireUpdateAttributesLock(rootStore, scopeDescription);
+	try {
+		return callback();
+	} finally {
+		releaseUpdateAttributesLock(rootStore);
+	}
+}
 // Tolerate a redundant column family drop. Drops are broadcast to every worker
 // thread and each holds its own handle to the same underlying family, so a
 // concurrent worker may already have dropped it; the storage engine reports
@@ -1502,14 +1552,12 @@ export function makeTable(options) {
 					// Serialize the drops + catalog removal against a concurrent
 					// same-name create (and completeInterruptedDrop) under the database's
 					// 'update-attributes' exclusive lock - the same lock the create path
-					// holds. It is a synchronous spin lock that blocks the event loop, so
+					// holds. It is a synchronous lock wait that blocks the event loop, so
 					// the locked section MUST stay synchronous: drop with dropSync (as
 					// completeInterruptedDrop does), never an awaited drop(), or a
-					// concurrent create's spin would deadlock waiting on a drop that the
-					// blocked event loop can never resolve.
-					while (!rootStore.tryLock('update-attributes')) {}
-					let removed = false;
-					try {
+					// concurrent create's wait would be stuck on a drop that the blocked
+					// event loop can never resolve, burning its full deadline before failing.
+					const removed = withUpdateAttributesLock(rootStore, `table '${databaseName}.${tableName}'`, () => {
 						for (const attribute of attributes) {
 							const index = indices[attribute.name];
 							if (index)
@@ -1524,10 +1572,8 @@ export function makeTable(options) {
 						} catch (error) {
 							ignoreAlreadyDropped(error);
 						}
-						removed = removeTombstonedCatalog();
-					} finally {
-						rootStore.unlock('update-attributes');
-					}
+						return removeTombstonedCatalog();
+					});
 					if (removed) await dbisDb.committed;
 				} else {
 					// LMDB: no shared column-family double-drop, and its engine lock is

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -14,6 +14,7 @@ import {
 import { type Database } from 'lmdb';
 import { Script } from 'node:vm';
 import { randomUUID } from 'node:crypto';
+import { performance } from 'node:perf_hooks';
 import { getIndexedValues } from '../utility/lmdb/commonUtility.ts';
 import { getThisNodeId, exportIdMapping } from './nodeIdMapping.ts';
 import lodash from 'lodash';
@@ -140,27 +141,29 @@ const UPDATE_ATTRIBUTES_LOCK = 'update-attributes';
 const updateAttributesLockKey = Buffer.from(UPDATE_ATTRIBUTES_LOCK);
 const lockWait = new Int32Array(new SharedArrayBuffer(4));
 
-/**
- * Acquires the exclusive cross-thread 'update-attributes' lock serializing schema/attribute updates
- * (and table create/drop) per database. The wait is synchronous and blocks the event loop, so the
- * locked section must stay synchronous too — a release by another thread is observable without
- * yielding, but any release requiring this thread's own event loop can never arrive. Throws after
- * `timeout` rather than spinning forever on a holder that never releases (harper#2251).
- */
+class UpdateAttributesLockTimeoutError extends ServerError {
+	code = 'UPDATE_ATTRIBUTES_LOCK_TIMEOUT';
+	retryable = true;
+	constructor(message: string) {
+		super(message, 503);
+		this.name = 'UpdateAttributesLockTimeoutError';
+	}
+}
+
+/** The wait blocks the event loop, so the locked section must stay synchronous. */
 export function acquireUpdateAttributesLock(
 	rootStore: RocksDatabase,
 	scopeDescription: string,
 	timeout = UPDATE_ATTRIBUTES_LOCK_TIMEOUT
 ) {
 	if (rootStore.tryLock(updateAttributesLockKey)) return;
-	const startTime = Date.now();
+	const startTime = performance.now();
 	let waitTime = 1;
 	while (!rootStore.tryLock(updateAttributesLockKey)) {
-		const elapsed = Date.now() - startTime;
+		const elapsed = performance.now() - startTime;
 		if (elapsed >= timeout) {
-			throw new ServerError(
-				`Timed out after ${elapsed}ms waiting for the exclusive '${UPDATE_ATTRIBUTES_LOCK}' lock on ${scopeDescription}; the lock holder never released it, so this schema/attribute update cannot proceed`,
-				503
+			throw new UpdateAttributesLockTimeoutError(
+				`Timed out after ${Math.round(elapsed)}ms waiting for the exclusive '${UPDATE_ATTRIBUTES_LOCK}' lock on ${scopeDescription}; the lock holder did not release it before the deadline, so this schema/attribute update cannot proceed`
 			);
 		}
 		if (elapsed >= 2) {
@@ -174,15 +177,26 @@ export function releaseUpdateAttributesLock(rootStore: RocksDatabase) {
 	rootStore.unlock(updateAttributesLockKey);
 }
 
-/** Runs `callback` under the exclusive 'update-attributes' lock, releasing it on every exit path. */
-export function withUpdateAttributesLock<T>(rootStore: RocksDatabase, scopeDescription: string, callback: () => T): T {
+export function withUpdateAttributesLock<Callback extends () => unknown>(
+	rootStore: RocksDatabase,
+	scopeDescription: string,
+	callback: Callback & (ReturnType<Callback> extends PromiseLike<unknown> ? never : unknown)
+): ReturnType<Callback> {
 	acquireUpdateAttributesLock(rootStore, scopeDescription);
 	try {
 		const result = callback();
 		if (typeof (result as any)?.then === 'function') {
-			throw new TypeError(`withUpdateAttributesLock callback must be synchronous (${scopeDescription})`);
+			Promise.resolve(result).catch((error) =>
+				logger.error?.(
+					`Async update-attributes callback rejected after its lock was released (${scopeDescription})`,
+					error
+				)
+			);
+			throw new TypeError(
+				`withUpdateAttributesLock callback must be synchronous (${scopeDescription}); asynchronous work may continue after the lock is released`
+			);
 		}
-		return result;
+		return result as ReturnType<Callback>;
 	} finally {
 		releaseUpdateAttributesLock(rootStore);
 	}

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -132,7 +132,8 @@ const MAX_INFLIGHT_EVICTION_BATCHES = 4;
 const CACHEABLE_STATUS_CODES = new Set([200, 203, 204, 206, 300, 301, 308, 404, 405, 410, 414, 501]);
 envMngr.initSync();
 const LMDB_PREFETCH_WRITES = envMngr.get(CONFIG_PARAMS.STORAGE_PREFETCHWRITES);
-export const LOCK_TIMEOUT = 10000;
+const LOCK_TIMEOUT = 10000;
+export const UPDATE_ATTRIBUTES_LOCK_TIMEOUT = 10000;
 const UPDATE_ATTRIBUTES_LOCK = 'update-attributes';
 // raw ASCII bytes are ordered-binary's encoding of the string, so this addresses the same native
 // lock as string-keyed tryLock/unlock calls
@@ -149,7 +150,7 @@ const lockWait = new Int32Array(new SharedArrayBuffer(4));
 export function acquireUpdateAttributesLock(
 	rootStore: RocksDatabase,
 	scopeDescription: string,
-	timeout = LOCK_TIMEOUT
+	timeout = UPDATE_ATTRIBUTES_LOCK_TIMEOUT
 ) {
 	if (rootStore.tryLock(updateAttributesLockKey)) return;
 	const startTime = Date.now();
@@ -158,7 +159,8 @@ export function acquireUpdateAttributesLock(
 		const elapsed = Date.now() - startTime;
 		if (elapsed >= timeout) {
 			throw new ServerError(
-				`Timed out after ${elapsed}ms waiting for the exclusive '${UPDATE_ATTRIBUTES_LOCK}' lock on ${scopeDescription}; the lock holder never released it, so this schema/attribute update cannot proceed`
+				`Timed out after ${elapsed}ms waiting for the exclusive '${UPDATE_ATTRIBUTES_LOCK}' lock on ${scopeDescription}; the lock holder never released it, so this schema/attribute update cannot proceed`,
+				503
 			);
 		}
 		if (elapsed >= 2) {
@@ -176,7 +178,11 @@ export function releaseUpdateAttributesLock(rootStore: RocksDatabase) {
 export function withUpdateAttributesLock<T>(rootStore: RocksDatabase, scopeDescription: string, callback: () => T): T {
 	acquireUpdateAttributesLock(rootStore, scopeDescription);
 	try {
-		return callback();
+		const result = callback();
+		if (typeof (result as any)?.then === 'function') {
+			throw new TypeError(`withUpdateAttributesLock callback must be synchronous (${scopeDescription})`);
+		}
+		return result;
 	} finally {
 		releaseUpdateAttributesLock(rootStore);
 	}

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -9,7 +9,7 @@ import {
 	getBaseSchemaPath,
 	getTransactionAuditStoreBasePath,
 } from '../dataLayer/harperBridge/lmdbBridge/lmdbUtility/initializePaths.js';
-import { makeTable, ignoreAlreadyDropped } from './Table.ts';
+import { makeTable, ignoreAlreadyDropped, acquireUpdateAttributesLock, releaseUpdateAttributesLock } from './Table.ts';
 import OpenEnvironmentObject from '../utility/lmdb/OpenEnvironmentObject.ts';
 import {
 	CONFIG_PARAMS,
@@ -1555,113 +1555,122 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 		if (attribute.expiresAt) attribute.indexed = true;
 	}
 	let hasChanges;
-	let releaseExclusiveLock: () => void;
-	if (Table) {
-		primaryKey = Table.primaryKey;
-		if (Table.primaryStore.rootStore.status === 'closed') {
-			throw new Error(`Can not use a closed data store from ${tableName} class`);
-		}
-		// Reject moving the primary key to a different attribute on a table that already has records.
-		// The storage key (Table.primaryKey) is never re-pointed here, so honoring the change would
-		// leave describe reporting the new attribute while every record — old and newly inserted — stays
-		// keyed by the original one; search_by_id/update/delete by the declared key then all miss. Only
-		// schema-authored callers (@table / defineTable / create_table) reassert the declaration, so
-		// gate on schemaDefinedExplicit to leave cluster schema-replication / data-loader callers alone.
-		// See HarperFast/studio#1199.
-		const declaredPrimaryKey = attributes.find((attribute) => attribute.isPrimaryKey)?.name;
-		if (schemaDefinedExplicit && declaredPrimaryKey && declaredPrimaryKey !== Table.primaryKey) {
-			let hasRecords = false;
-			for (const _entry of Table.primaryStore.getRange({ start: true })) {
-				hasRecords = true;
-				break;
+	let releaseExclusiveLock: (() => void) | undefined;
+	const attributesToIndex = [];
+	const indicesToRemove = [];
+	// Every path that may take the exclusive lock (via exclusiveLock()) runs inside this try; the
+	// single release lives in its finally so no early return or throw can leak the lock — a leaked
+	// lock wedges every later create_table / attribute update on this database (harper#2251).
+	try {
+		if (Table) {
+			primaryKey = Table.primaryKey;
+			if (Table.primaryStore.rootStore.status === 'closed') {
+				throw new Error(`Can not use a closed data store from ${tableName} class`);
 			}
-			if (hasRecords) {
-				throw new ClientError(
-					`Cannot change the primary key of table '${databaseName}.${tableName}' from '${Table.primaryKey}' to ` +
-						`'${declaredPrimaryKey}' because it already contains records. Recreate the table with the new primary ` +
-						`key, or migrate the existing records.`,
-					400
+			// Reject moving the primary key to a different attribute on a table that already has records.
+			// The storage key (Table.primaryKey) is never re-pointed here, so honoring the change would
+			// leave describe reporting the new attribute while every record — old and newly inserted — stays
+			// keyed by the original one; search_by_id/update/delete by the declared key then all miss. Only
+			// schema-authored callers (@table / defineTable / create_table) reassert the declaration, so
+			// gate on schemaDefinedExplicit to leave cluster schema-replication / data-loader callers alone.
+			// See HarperFast/studio#1199.
+			const declaredPrimaryKey = attributes.find((attribute) => attribute.isPrimaryKey)?.name;
+			if (schemaDefinedExplicit && declaredPrimaryKey && declaredPrimaryKey !== Table.primaryKey) {
+				let hasRecords = false;
+				for (const _entry of Table.primaryStore.getRange({ start: true })) {
+					hasRecords = true;
+					break;
+				}
+				if (hasRecords) {
+					throw new ClientError(
+						`Cannot change the primary key of table '${databaseName}.${tableName}' from '${Table.primaryKey}' to ` +
+							`'${declaredPrimaryKey}' because it already contains records. Recreate the table with the new primary ` +
+							`key, or migrate the existing records.`,
+						400
+					);
+				}
+			}
+			// it table already exists, get the split segments setting
+			if (splitSegments == undefined) splitSegments = Table.splitSegments;
+			Table.attributes.splice(0, Table.attributes.length, ...attributes);
+			// Re-assert from the live declaration so a stale value on disk (replicated event,
+			// v4-era backfill) is corrected on every reload. Gated on `schemaDefinedExplicit` so
+			// callers that omit the flag (cluster schema-replication, data loader) don't flip a
+			// dynamic table to true via the default at the top of table().
+			if (schemaDefinedExplicit) Table.schemaDefined = schemaDefined;
+			// Refresh class-level schema metadata to track docstring/directive changes across reloads.
+			Table.description = description;
+			Table.properties = properties;
+			Table.hidden = hidden;
+			// undefined means a non-schema caller (add_attribute, cluster schema events) — don't clobber
+			if (cacheControl !== undefined) Table.cacheControl = cacheControl;
+		} else {
+			const auditStore = rootStore.auditStore;
+			primaryKeyAttribute = attributes.find((attribute) => attribute.isPrimaryKey) || {};
+			primaryKey = primaryKeyAttribute.name;
+			primaryKeyAttribute.isPrimaryKey = true;
+			primaryKeyAttribute.is_hash_attribute = true; // backward-compat: harperdb@4.x reads this field to open the DBI with correct flags
+			primaryKeyAttribute.schemaDefined = schemaDefined;
+			// can't change compression after the fact (except threshold), so save only when we create the table
+			primaryKeyAttribute.compression = getDefaultCompression();
+			if (trackDeletes) primaryKeyAttribute.trackDeletes = true;
+			audit = primaryKeyAttribute.audit = typeof audit === 'boolean' ? audit : envGet(CONFIG_PARAMS.LOGGING_AUDITLOG);
+			if (expiration) primaryKeyAttribute.expiration = expiration;
+			if (eviction) primaryKeyAttribute.eviction = eviction;
+			// persist cacheControl so all threads (and future boots) see it; undefined callers inherit
+			// a descriptor value carried by cluster schema events; null (schema has no directive)
+			// clears a stale value the carried descriptor may hold
+			if (cacheControl === undefined) cacheControl = primaryKeyAttribute.cacheControl;
+			else if (cacheControl === null) delete primaryKeyAttribute.cacheControl;
+			else primaryKeyAttribute.cacheControl = cacheControl;
+			splitSegments ??= false;
+			primaryKeyAttribute.splitSegments = splitSegments; // always default to not splitting segments going forward
+			if (typeof sealed === 'boolean') primaryKeyAttribute.sealed = sealed;
+			if (typeof replicate === 'boolean') primaryKeyAttribute.replicate = replicate;
+			// An explicit directive PINS this table's encoding: we persist the boolean, so later changes
+			// to the global storage.randomAccessFields default never affect this table. Tables WITHOUT the
+			// directive are intentionally not persisted here — they follow the current global default on
+			// each open (a runtime lever to flip encoding fleet-wide). Switching either way is safe: the
+			// struct READ hook always stays on and struct (0x20-0x3f) vs classic-record (0x40-0x7f) bytes
+			// are disjoint, so already-written records still decode; only the encoding of NEW writes changes.
+			if (typeof randomAccessFields === 'boolean') primaryKeyAttribute.randomAccessFields = randomAccessFields;
+			if (origin) {
+				if (!primaryKeyAttribute.origins) primaryKeyAttribute.origins = [origin];
+				else if (!primaryKeyAttribute.origins.includes(origin)) primaryKeyAttribute.origins.push(origin);
+			}
+			logger.trace(`${tableName} table loading, opening primary store`);
+			const dbiInit = createOpenDBIObject(false, true);
+			dbiInit.compression = primaryKeyAttribute.compression;
+			// per-table override of the storage.randomAccessFields default (see OpenDBIObject)
+			if (typeof primaryKeyAttribute.randomAccessFields === 'boolean')
+				dbiInit.randomAccessStructure = primaryKeyAttribute.randomAccessFields;
+			const dbiName = tableName + '/';
+
+			if (rootStore instanceof RocksDatabase) {
+				attributesDbi = (rootStore as any).dbisDb = openRocksDatabase(rootStore.path, {
+					...internalDbiInit,
+					disableWAL: false,
+					name: INTERNAL_DBIS_NAME,
+				} as any);
+			} else {
+				attributesDbi = (rootStore as any).dbisDb = (rootStore as any).openDB(
+					INTERNAL_DBIS_NAME,
+					internalDbiInit as any
 				);
 			}
-		}
-		// it table already exists, get the split segments setting
-		if (splitSegments == undefined) splitSegments = Table.splitSegments;
-		Table.attributes.splice(0, Table.attributes.length, ...attributes);
-		// Re-assert from the live declaration so a stale value on disk (replicated event,
-		// v4-era backfill) is corrected on every reload. Gated on `schemaDefinedExplicit` so
-		// callers that omit the flag (cluster schema-replication, data loader) don't flip a
-		// dynamic table to true via the default at the top of table().
-		if (schemaDefinedExplicit) Table.schemaDefined = schemaDefined;
-		// Refresh class-level schema metadata to track docstring/directive changes across reloads.
-		Table.description = description;
-		Table.properties = properties;
-		Table.hidden = hidden;
-		// undefined means a non-schema caller (add_attribute, cluster schema events) — don't clobber
-		if (cacheControl !== undefined) Table.cacheControl = cacheControl;
-	} else {
-		const auditStore = rootStore.auditStore;
-		primaryKeyAttribute = attributes.find((attribute) => attribute.isPrimaryKey) || {};
-		primaryKey = primaryKeyAttribute.name;
-		primaryKeyAttribute.isPrimaryKey = true;
-		primaryKeyAttribute.is_hash_attribute = true; // backward-compat: harperdb@4.x reads this field to open the DBI with correct flags
-		primaryKeyAttribute.schemaDefined = schemaDefined;
-		// can't change compression after the fact (except threshold), so save only when we create the table
-		primaryKeyAttribute.compression = getDefaultCompression();
-		if (trackDeletes) primaryKeyAttribute.trackDeletes = true;
-		audit = primaryKeyAttribute.audit = typeof audit === 'boolean' ? audit : envGet(CONFIG_PARAMS.LOGGING_AUDITLOG);
-		if (expiration) primaryKeyAttribute.expiration = expiration;
-		if (eviction) primaryKeyAttribute.eviction = eviction;
-		// persist cacheControl so all threads (and future boots) see it; undefined callers inherit
-		// a descriptor value carried by cluster schema events; null (schema has no directive)
-		// clears a stale value the carried descriptor may hold
-		if (cacheControl === undefined) cacheControl = primaryKeyAttribute.cacheControl;
-		else if (cacheControl === null) delete primaryKeyAttribute.cacheControl;
-		else primaryKeyAttribute.cacheControl = cacheControl;
-		splitSegments ??= false;
-		primaryKeyAttribute.splitSegments = splitSegments; // always default to not splitting segments going forward
-		if (typeof sealed === 'boolean') primaryKeyAttribute.sealed = sealed;
-		if (typeof replicate === 'boolean') primaryKeyAttribute.replicate = replicate;
-		// An explicit directive PINS this table's encoding: we persist the boolean, so later changes
-		// to the global storage.randomAccessFields default never affect this table. Tables WITHOUT the
-		// directive are intentionally not persisted here — they follow the current global default on
-		// each open (a runtime lever to flip encoding fleet-wide). Switching either way is safe: the
-		// struct READ hook always stays on and struct (0x20-0x3f) vs classic-record (0x40-0x7f) bytes
-		// are disjoint, so already-written records still decode; only the encoding of NEW writes changes.
-		if (typeof randomAccessFields === 'boolean') primaryKeyAttribute.randomAccessFields = randomAccessFields;
-		if (origin) {
-			if (!primaryKeyAttribute.origins) primaryKeyAttribute.origins = [origin];
-			else if (!primaryKeyAttribute.origins.includes(origin)) primaryKeyAttribute.origins.push(origin);
-		}
-		logger.trace(`${tableName} table loading, opening primary store`);
-		const dbiInit = createOpenDBIObject(false, true);
-		dbiInit.compression = primaryKeyAttribute.compression;
-		// per-table override of the storage.randomAccessFields default (see OpenDBIObject)
-		if (typeof primaryKeyAttribute.randomAccessFields === 'boolean')
-			dbiInit.randomAccessStructure = primaryKeyAttribute.randomAccessFields;
-		const dbiName = tableName + '/';
+			markInternalDbiNonVersioned(attributesDbi);
 
-		if (rootStore instanceof RocksDatabase) {
-			attributesDbi = (rootStore as any).dbisDb = openRocksDatabase(rootStore.path, {
-				...internalDbiInit,
-				disableWAL: false,
-				name: INTERNAL_DBIS_NAME,
-			} as any);
-		} else {
-			attributesDbi = (rootStore as any).dbisDb = (rootStore as any).openDB(INTERNAL_DBIS_NAME, internalDbiInit as any);
-		}
-		markInternalDbiNonVersioned(attributesDbi);
+			exclusiveLock(); // get an exclusive lock on the database so we can verify that we are the only thread creating the table (and assigning the table id)
+			const existingTableMeta = (attributesDbi as any).getSync(dbiName);
+			if (existingTableMeta && !existingTableMeta.dropping) {
+				// table was created while we were setting up; release before the recursive reload — the
+				// lock is not reentrant, so the table() call below must be able to acquire it afresh
+				releaseLock();
+				resetDatabases();
+				return table(tableDefinition);
+			}
 
-		exclusiveLock(); // get an exclusive lock on the database so we can verify that we are the only thread creating the table (and assigning the table id)
-		const existingTableMeta = (attributesDbi as any).getSync(dbiName);
-		if (existingTableMeta && !existingTableMeta.dropping) {
-			// table was created while we were setting up
-			if (releaseExclusiveLock) releaseExclusiveLock();
-			resetDatabases();
-			return table(tableDefinition);
-		}
-
-		let primaryStore;
-		try {
+			let primaryStore;
 			if (existingTableMeta?.dropping) {
 				// A previous drop of this table was interrupted after its tombstone
 				// was written. Complete it now (under the exclusive lock) so the
@@ -1728,56 +1737,43 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 			hasChanges = true;
 
 			attributesDbi.put(dbiName, primaryKeyAttribute);
-		} catch (error) {
-			// A failure while opening/creating the column family or writing the
-			// table id / catalog entry (e.g. into an env poisoned by a prior
-			// dangling column family) must NOT leak the exclusive
-			// 'update-attributes' spin lock. If it leaks, every subsequent
-			// create_table / attribute update on this database spins forever
-			// (a hard wedge that pins a worker at 100% CPU). Release before rethrow.
-			if (releaseExclusiveLock) releaseExclusiveLock();
-			throw error;
 		}
-	}
-	const indices = Table.indices;
-	if (!attributesDbi) {
-		if (rootStore instanceof RocksDatabase) {
-			(rootStore as any).dbisDb = openRocksDatabase(rootStore.path, {
-				...internalDbiInit,
-				disableWAL: false,
-				name: INTERNAL_DBIS_NAME,
-			} as any);
-		} else {
-			(rootStore as any).dbisDb = (rootStore as any).openDB(INTERNAL_DBIS_NAME, internalDbiInit as any);
+		const indices = Table.indices;
+		if (!attributesDbi) {
+			if (rootStore instanceof RocksDatabase) {
+				(rootStore as any).dbisDb = openRocksDatabase(rootStore.path, {
+					...internalDbiInit,
+					disableWAL: false,
+					name: INTERNAL_DBIS_NAME,
+				} as any);
+			} else {
+				(rootStore as any).dbisDb = (rootStore as any).openDB(INTERNAL_DBIS_NAME, internalDbiInit as any);
+			}
+			attributesDbi = markInternalDbiNonVersioned((rootStore as any).dbisDb);
 		}
-		attributesDbi = markInternalDbiNonVersioned((rootStore as any).dbisDb);
-	}
-	Table.dbisDB = attributesDbi;
-	const indicesToRemove = [];
-	for (const { key, value } of attributesDbi.getRange({ start: true })) {
-		if (value == null) continue;
-		let [attributeTableName, attribute_name] = key.toString().split('/');
-		if (attribute_name === '') attribute_name = value.name; // primary key
-		if (attribute_name) {
-			if (attributeTableName !== tableName) continue;
-		} else {
-			// table attribute for a table with no primary key, we don't want to remove this, so continue on
-			continue;
-		}
-		const attribute = attributes.find((attribute) => attribute.name === attribute_name);
-		const removeIndex = !attribute?.indexed && value.indexed && !value.isPrimaryKey;
-		if (!attribute || removeIndex) {
-			exclusiveLock();
-			hasChanges = true;
-			if (!attribute) attributesDbi.remove(key);
-			if (removeIndex) {
-				const indexDbi = Table.indices[attributeTableName];
-				if (indexDbi) indicesToRemove.push(indexDbi);
+		Table.dbisDB = attributesDbi;
+		for (const { key, value } of attributesDbi.getRange({ start: true })) {
+			if (value == null) continue;
+			let [attributeTableName, attribute_name] = key.toString().split('/');
+			if (attribute_name === '') attribute_name = value.name; // primary key
+			if (attribute_name) {
+				if (attributeTableName !== tableName) continue;
+			} else {
+				// table attribute for a table with no primary key, we don't want to remove this, so continue on
+				continue;
+			}
+			const attribute = attributes.find((attribute) => attribute.name === attribute_name);
+			const removeIndex = !attribute?.indexed && value.indexed && !value.isPrimaryKey;
+			if (!attribute || removeIndex) {
+				exclusiveLock();
+				hasChanges = true;
+				if (!attribute) attributesDbi.remove(key);
+				if (removeIndex) {
+					const indexDbi = Table.indices[attributeTableName];
+					if (indexDbi) indicesToRemove.push(indexDbi);
+				}
 			}
 		}
-	}
-	const attributesToIndex = [];
-	try {
 		// TODO: If we have attributes and the schemaDefined flag is not set, turn it on
 		// iterate through the attributes to ensure that we have all the dbis created and indexed
 		for (const attribute of attributes || []) {
@@ -1986,7 +1982,7 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 			}
 		}
 	} finally {
-		if (releaseExclusiveLock) releaseExclusiveLock();
+		releaseLock();
 	}
 	if (hasChanges) {
 		Table.schemaVersion++;
@@ -2017,10 +2013,9 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 	function exclusiveLock() {
 		if (releaseExclusiveLock) return;
 		if (rootStore instanceof RocksDatabase) {
-			while (!rootStore.tryLock('update-attributes')) {} // use a spin lock, we really need an synchronous exclusive lock here
-			releaseExclusiveLock = () => {
-				rootStore.unlock('update-attributes');
-			};
+			// bounded synchronous wait; throws ServerError if the holder never releases (harper#2251)
+			acquireUpdateAttributesLock(rootStore, `table '${databaseName}.${tableName}'`);
+			releaseExclusiveLock = () => releaseUpdateAttributesLock(rootStore);
 		} else {
 			// we only need an exclusive transaction lock in lmdb
 			rootStore.transactionSync(() => {
@@ -2031,6 +2026,13 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 				};
 			});
 		}
+	}
+	// Idempotent so the early-release before the recursive reload above and the structural release
+	// in the finally can both run without double-unlocking (which could release another thread's lock)
+	function releaseLock() {
+		const release = releaseExclusiveLock;
+		releaseExclusiveLock = undefined;
+		if (release) release();
 	}
 }
 /**

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1558,9 +1558,8 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 	let releaseExclusiveLock: (() => void) | undefined;
 	const attributesToIndex = [];
 	const indicesToRemove = [];
-	// Every path that may take the exclusive lock (via exclusiveLock()) runs inside this try; the
-	// single release lives in its finally so no early return or throw can leak the lock — a leaked
-	// lock wedges every later create_table / attribute update on this database (harper#2251).
+	// the exclusive lock may only be released via releaseLock() — a leaked lock wedges every later
+	// schema update on this database (harper#2251)
 	try {
 		if (Table) {
 			primaryKey = Table.primaryKey;
@@ -1663,8 +1662,8 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 			exclusiveLock(); // get an exclusive lock on the database so we can verify that we are the only thread creating the table (and assigning the table id)
 			const existingTableMeta = (attributesDbi as any).getSync(dbiName);
 			if (existingTableMeta && !existingTableMeta.dropping) {
-				// table was created while we were setting up; release before the recursive reload — the
-				// lock is not reentrant, so the table() call below must be able to acquire it afresh
+				// table was created while we were setting up; the lock is not reentrant, so release
+				// before the recursive reload
 				releaseLock();
 				resetDatabases();
 				return table(tableDefinition);
@@ -2013,7 +2012,6 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 	function exclusiveLock() {
 		if (releaseExclusiveLock) return;
 		if (rootStore instanceof RocksDatabase) {
-			// bounded synchronous wait; throws ServerError if the holder never releases (harper#2251)
 			acquireUpdateAttributesLock(rootStore, `table '${databaseName}.${tableName}'`);
 			releaseExclusiveLock = () => releaseUpdateAttributesLock(rootStore);
 		} else {
@@ -2027,8 +2025,8 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 			});
 		}
 	}
-	// Idempotent so the early-release before the recursive reload above and the structural release
-	// in the finally can both run without double-unlocking (which could release another thread's lock)
+	// idempotent: the early release before the recursive reload and the finally both run, and a
+	// second unlock could release another thread's lock
 	function releaseLock() {
 		const release = releaseExclusiveLock;
 		releaseExclusiveLock = undefined;

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1558,8 +1558,6 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 	let releaseExclusiveLock: (() => void) | undefined;
 	const attributesToIndex = [];
 	const indicesToRemove = [];
-	// the exclusive lock may only be released via releaseLock() — a leaked lock wedges every later
-	// schema update on this database (harper#2251)
 	try {
 		if (Table) {
 			primaryKey = Table.primaryKey;

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1587,6 +1587,12 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 					);
 				}
 			}
+			// Acquire before the first mutation of the live Table, not lazily at the first catalog write:
+			// the acquire is bounded and throws, and everything below this line (attributes, class
+			// metadata, index handles) is in-memory state with no catalog row behind it yet. Taking the
+			// lock first makes a lost race a clean no-op instead of leaving this worker describing
+			// attributes it never persisted. Costs an uncontended tryLock on unchanged reloads.
+			exclusiveLock();
 			// it table already exists, get the split segments setting
 			if (splitSegments == undefined) splitSegments = Table.splitSegments;
 			Table.attributes.splice(0, Table.attributes.length, ...attributes);

--- a/resources/databases.ts
+++ b/resources/databases.ts
@@ -1587,12 +1587,11 @@ export function table<TableResourceType>(tableDefinition: TableDefinition): Tabl
 					);
 				}
 			}
-			// Acquire before the first mutation of the live Table, not lazily at the first catalog write:
-			// the acquire is bounded and throws, and everything below this line (attributes, class
-			// metadata, index handles) is in-memory state with no catalog row behind it yet. Taking the
-			// lock first makes a lost race a clean no-op instead of leaving this worker describing
-			// attributes it never persisted. Costs an uncontended tryLock on unchanged reloads.
-			exclusiveLock();
+			// Acquire before the first mutation of the live Table below, so a lost race leaves no
+			// attributes this worker describes but never persisted. Only the RocksDB acquire is bounded
+			// and can throw, and only it is cheap when uncontended: LMDB's exclusiveLock() opens an
+			// environment-wide write transaction that cannot time out, so it stays lazy.
+			if (rootStore instanceof RocksDatabase) exclusiveLock();
 			// it table already exists, get the split segments setting
 			if (splitSegments == undefined) splitSegments = Table.splitSegments;
 			Table.attributes.splice(0, Table.attributes.length, ...attributes);

--- a/unitTests/resources/updateAttributesLock-thread.js
+++ b/unitTests/resources/updateAttributesLock-thread.js
@@ -10,8 +10,19 @@ setMainIsWorker(true);
 const rootStore = database({ database: 'test', table: null });
 let heldLock = false;
 
-function reportDeadline(action, callback) {
-	const acquired = rootStore.tryLock('update-attributes');
+const DEADLINE_DEFINITION = {
+	table: 'DeadlineWedged',
+	database: 'test',
+	attributes: [{ name: 'id', type: 'Int', isPrimaryKey: true }],
+};
+const DEADLINE_REDECLARATION = {
+	...DEADLINE_DEFINITION,
+	attributes: [...DEADLINE_DEFINITION.attributes, { name: 'added', type: 'String', indexed: true }],
+};
+let deadlineTable;
+
+function reportDeadline(action, callback, { selfLock = true, extra } = {}) {
+	const acquired = selfLock ? rootStore.tryLock('update-attributes') : false;
 	const startTime = Date.now();
 	let error;
 	try {
@@ -27,7 +38,14 @@ function reportDeadline(action, callback) {
 	} finally {
 		if (acquired) rootStore.unlock('update-attributes');
 	}
-	parentPort.postMessage({ type: 'deadline-result', action, acquired, elapsed: Date.now() - startTime, error });
+	parentPort.postMessage({
+		type: 'deadline-result',
+		action,
+		acquired,
+		elapsed: Date.now() - startTime,
+		error,
+		...extra?.(),
+	});
 }
 
 function liveSchema(Table) {
@@ -35,6 +53,10 @@ function liveSchema(Table) {
 		attributes: Table.attributes.map((attribute) => attribute.name),
 		indices: Object.keys(Table.indices),
 		schemaVersion: Table.schemaVersion,
+		description: Table.description ?? null,
+		hidden: Table.hidden ?? null,
+		cacheControl: Table.cacheControl ?? null,
+		schemaDefined: Table.schemaDefined ?? null,
 	};
 }
 
@@ -53,25 +75,23 @@ parentPort
 			reportDeadline(message.type, () =>
 				acquireUpdateAttributesLock(rootStore, "table 'test.Wedged'", message.timeout)
 			);
-		} else if (message.type === 'table-deadline') {
-			const definition = {
-				table: 'DeadlineWedged',
-				database: 'test',
-				attributes: [{ name: 'id', type: 'Int', isPrimaryKey: true }],
-			};
-			const Table = table(definition);
-			const redeclaration = {
-				...definition,
-				attributes: [...definition.attributes, { name: 'added', type: 'String', indexed: true }],
-			};
-			const before = liveSchema(Table);
-			reportDeadline(message.type, () => table(redeclaration));
-			parentPort.postMessage({ type: 'live-schema', before, after: liveSchema(Table) });
+		} else if (message.type === 'prepare-deadline-table') {
+			deadlineTable = table(DEADLINE_DEFINITION);
+			parentPort.postMessage({ type: 'deadline-table-prepared', before: liveSchema(deadlineTable) });
+		} else if (message.type === 'declare-under-wedge') {
+			// snapshot around this call alone: unrelated schema activity between messages would
+			// otherwise show up as drift
+			const before = liveSchema(deadlineTable);
+			reportDeadline(message.type, () => table(DEADLINE_REDECLARATION), {
+				selfLock: false,
+				extra: () => ({ before, after: liveSchema(deadlineTable) }),
+			});
+		} else if (message.type === 'redeclare') {
 			try {
 				parentPort.postMessage({
 					type: 'table-updated',
-					updated: Boolean(table(redeclaration)),
-					applied: liveSchema(Table),
+					updated: Boolean(table(DEADLINE_REDECLARATION)),
+					applied: liveSchema(deadlineTable),
 				});
 			} catch (error) {
 				parentPort.postMessage({ type: 'table-updated', updated: false, error: error.message });

--- a/unitTests/resources/updateAttributesLock-thread.js
+++ b/unitTests/resources/updateAttributesLock-thread.js
@@ -9,6 +9,7 @@ const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 setupTestDBPath();
 setMainIsWorker(true);
 const rootStore = database({ database: 'test', table: null });
+let heldLock = false;
 
 function reportDeadline(action, callback) {
 	const acquired = rootStore.tryLock('update-attributes');
@@ -21,6 +22,8 @@ function reportDeadline(action, callback) {
 			isServerError: caughtError instanceof ServerError,
 			message: caughtError.message,
 			statusCode: caughtError.statusCode,
+			code: caughtError.code,
+			retryable: caughtError.retryable,
 		};
 	} finally {
 		if (acquired) rootStore.unlock('update-attributes');
@@ -31,10 +34,13 @@ function reportDeadline(action, callback) {
 parentPort
 	?.on('message', (message) => {
 		if (message.type === 'hold-lock') {
-			const acquired = rootStore.tryLock('update-attributes');
-			parentPort.postMessage({ type: 'held', acquired });
+			heldLock = rootStore.tryLock('update-attributes');
+			parentPort.postMessage({ type: 'held', acquired: heldLock });
+		} else if (message.type === 'release-lock') {
 			setTimeout(() => {
-				rootStore.unlock('update-attributes');
+				if (heldLock) rootStore.unlock('update-attributes');
+				heldLock = false;
+				parentPort.postMessage({ type: 'released' });
 			}, message.holdTime);
 		} else if (message.type === 'helper-deadline') {
 			reportDeadline(message.type, () =>
@@ -47,7 +53,11 @@ parentPort
 				attributes: [{ name: 'id', type: 'Int', isPrimaryKey: true }],
 			};
 			reportDeadline(message.type, () => table(definition));
-			parentPort.postMessage({ type: 'table-created', created: Boolean(table(definition)) });
+			try {
+				parentPort.postMessage({ type: 'table-created', created: Boolean(table(definition)) });
+			} catch (error) {
+				parentPort.postMessage({ type: 'table-created', created: false, error: error.message });
+			}
 		} else if (message.type === 'shutdown') {
 			process.exit(0);
 		}

--- a/unitTests/resources/updateAttributesLock-thread.js
+++ b/unitTests/resources/updateAttributesLock-thread.js
@@ -1,4 +1,3 @@
-require('../testUtils');
 const { parentPort } = require('worker_threads');
 const { setupTestDBPath } = require('../testUtils');
 const { database, table } = require('#src/resources/databases');
@@ -58,8 +57,6 @@ parentPort
 			} catch (error) {
 				parentPort.postMessage({ type: 'table-created', created: false, error: error.message });
 			}
-		} else if (message.type === 'shutdown') {
-			process.exit(0);
 		}
 	})
 	.ref();

--- a/unitTests/resources/updateAttributesLock-thread.js
+++ b/unitTests/resources/updateAttributesLock-thread.js
@@ -1,0 +1,22 @@
+require('../testUtils');
+const { parentPort } = require('worker_threads');
+const { setupTestDBPath } = require('../testUtils');
+const { database } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+
+setupTestDBPath();
+setMainIsWorker(true);
+const rootStore = database({ database: 'test', table: null });
+parentPort
+	?.on('message', (message) => {
+		if (message.type === 'hold-lock') {
+			const acquired = rootStore.tryLock('update-attributes');
+			parentPort.postMessage({ type: 'held', acquired });
+			setTimeout(() => {
+				rootStore.unlock('update-attributes');
+			}, message.holdTime);
+		} else if (message.type === 'shutdown') {
+			process.exit(0);
+		}
+	})
+	.ref();

--- a/unitTests/resources/updateAttributesLock-thread.js
+++ b/unitTests/resources/updateAttributesLock-thread.js
@@ -1,12 +1,33 @@
 require('../testUtils');
 const { parentPort } = require('worker_threads');
 const { setupTestDBPath } = require('../testUtils');
-const { database } = require('#src/resources/databases');
+const { database, table } = require('#src/resources/databases');
+const { acquireUpdateAttributesLock } = require('#src/resources/Table');
+const { ServerError } = require('#src/utility/errors/hdbError');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 
 setupTestDBPath();
 setMainIsWorker(true);
 const rootStore = database({ database: 'test', table: null });
+
+function reportDeadline(action, callback) {
+	const acquired = rootStore.tryLock('update-attributes');
+	const startTime = Date.now();
+	let error;
+	try {
+		callback();
+	} catch (caughtError) {
+		error = {
+			isServerError: caughtError instanceof ServerError,
+			message: caughtError.message,
+			statusCode: caughtError.statusCode,
+		};
+	} finally {
+		if (acquired) rootStore.unlock('update-attributes');
+	}
+	parentPort.postMessage({ type: 'deadline-result', action, acquired, elapsed: Date.now() - startTime, error });
+}
+
 parentPort
 	?.on('message', (message) => {
 		if (message.type === 'hold-lock') {
@@ -15,6 +36,18 @@ parentPort
 			setTimeout(() => {
 				rootStore.unlock('update-attributes');
 			}, message.holdTime);
+		} else if (message.type === 'helper-deadline') {
+			reportDeadline(message.type, () =>
+				acquireUpdateAttributesLock(rootStore, "table 'test.Wedged'", message.timeout)
+			);
+		} else if (message.type === 'table-deadline') {
+			const definition = {
+				table: 'DeadlineWedged',
+				database: 'test',
+				attributes: [{ name: 'id', type: 'Int', isPrimaryKey: true }],
+			};
+			reportDeadline(message.type, () => table(definition));
+			parentPort.postMessage({ type: 'table-created', created: Boolean(table(definition)) });
 		} else if (message.type === 'shutdown') {
 			process.exit(0);
 		}

--- a/unitTests/resources/updateAttributesLock-thread.js
+++ b/unitTests/resources/updateAttributesLock-thread.js
@@ -30,6 +30,14 @@ function reportDeadline(action, callback) {
 	parentPort.postMessage({ type: 'deadline-result', action, acquired, elapsed: Date.now() - startTime, error });
 }
 
+function liveSchema(Table) {
+	return {
+		attributes: Table.attributes.map((attribute) => attribute.name),
+		indices: Object.keys(Table.indices),
+		schemaVersion: Table.schemaVersion,
+	};
+}
+
 parentPort
 	?.on('message', (message) => {
 		if (message.type === 'hold-lock') {
@@ -51,11 +59,22 @@ parentPort
 				database: 'test',
 				attributes: [{ name: 'id', type: 'Int', isPrimaryKey: true }],
 			};
-			reportDeadline(message.type, () => table(definition));
+			const Table = table(definition);
+			const redeclaration = {
+				...definition,
+				attributes: [...definition.attributes, { name: 'added', type: 'String', indexed: true }],
+			};
+			const before = liveSchema(Table);
+			reportDeadline(message.type, () => table(redeclaration));
+			parentPort.postMessage({ type: 'live-schema', before, after: liveSchema(Table) });
 			try {
-				parentPort.postMessage({ type: 'table-created', created: Boolean(table(definition)) });
+				parentPort.postMessage({
+					type: 'table-updated',
+					updated: Boolean(table(redeclaration)),
+					applied: liveSchema(Table),
+				});
 			} catch (error) {
-				parentPort.postMessage({ type: 'table-created', created: false, error: error.message });
+				parentPort.postMessage({ type: 'table-updated', updated: false, error: error.message });
 			}
 		}
 	})

--- a/unitTests/resources/updateAttributesLock.test.js
+++ b/unitTests/resources/updateAttributesLock.test.js
@@ -17,11 +17,36 @@ const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const TEST_DB = 'test';
 const LOCK_KEY = 'update-attributes';
 
+function openWorker() {
+	return new Worker(__dirname + '/updateAttributesLock-thread.js', { workerData: { addPorts: [] } });
+}
+
+function request(workerThread, message, expectedType, hardTimeout) {
+	return new Promise((resolve, reject) => {
+		let timer;
+		const settle = (finish) => {
+			clearTimeout(timer);
+			workerThread.off('message', onMessage);
+			workerThread.off('error', onError);
+			finish();
+		};
+		const onMessage = (result) => {
+			if (result.type === expectedType) settle(() => resolve(result));
+		};
+		const onError = (error) => settle(() => reject(error));
+		timer = setTimeout(
+			() => settle(() => reject(new Error(`worker never answered '${message.type}' within ${hardTimeout}ms`))),
+			hardTimeout
+		);
+		workerThread.on('message', onMessage);
+		workerThread.on('error', onError);
+		workerThread.postMessage(message);
+	});
+}
+
 function runWorkerAction(message, expectedMessageTypes, hardTimeout) {
 	return new Promise((resolve, reject) => {
-		const workerThread = new Worker(__dirname + '/updateAttributesLock-thread.js', {
-			workerData: { addPorts: [] },
-		});
+		const workerThread = openWorker();
 		const received = [];
 		let finished = false;
 		let timer;
@@ -156,19 +181,33 @@ describe('update-attributes exclusive lock', () => {
 		rootStore.unlock(LOCK_KEY);
 	});
 
-	it('a real table() operation fails with ServerError after the full deadline, leaving the live schema untouched', async function () {
+	it('a real table() operation fails with ServerError after another thread wedges the lock for the full deadline', async function () {
 		this.timeout(40000);
-		const messages = await runWorkerAction(
-			{ type: 'table-deadline' },
-			['deadline-result', 'live-schema', 'table-updated'],
-			30000
-		);
-		const {
-			'deadline-result': deadlineResult,
-			'live-schema': liveSchema,
-			'table-updated': updateResult,
-		} = Object.fromEntries(messages.map((message) => [message.type, message]));
-		assert.ok(deadlineResult.acquired, 'test worker should be able to wedge the lock');
+		const workerThread = openWorker();
+		let wedged = false;
+		let deadlineResult, updateResult;
+		try {
+			await request(workerThread, { type: 'prepare-deadline-table' }, 'deadline-table-prepared', 20000);
+			wedged = rootStore.tryLock(LOCK_KEY);
+			assert.ok(wedged, 'this thread should be able to wedge the lock the worker will wait on');
+			deadlineResult = await request(workerThread, { type: 'declare-under-wedge' }, 'deadline-result', 30000);
+			rootStore.unlock(LOCK_KEY);
+			wedged = false;
+			updateResult = await request(workerThread, { type: 'redeclare' }, 'table-updated', 20000);
+			assert.ok(
+				!deadlineResult.before.attributes.includes('added'),
+				'test should start from the pre-declaration schema'
+			);
+			assert.deepStrictEqual(
+				deadlineResult.after,
+				deadlineResult.before,
+				'a lock-acquire timeout must not leave that worker describing attributes it never persisted'
+			);
+		} finally {
+			if (wedged) rootStore.unlock(LOCK_KEY);
+			await workerThread.terminate();
+		}
+		assert.ok(deadlineResult.error, 'the wedged declaration should have thrown');
 		assert.ok(deadlineResult.error.isServerError, 'production table() path should throw ServerError');
 		assert.strictEqual(deadlineResult.error.statusCode, 503);
 		assert.strictEqual(deadlineResult.error.code, 'UPDATE_ATTRIBUTES_LOCK_TIMEOUT');
@@ -186,13 +225,6 @@ describe('update-attributes exclusive lock', () => {
 			deadlineResult.elapsed < UPDATE_ATTRIBUTES_LOCK_TIMEOUT + 5000,
 			`should throw shortly after the deadline, took ${deadlineResult.elapsed}ms`
 		);
-		// the acquire happens before any mutation of the live Table, so losing the race is a no-op
-		assert.deepStrictEqual(
-			liveSchema.after,
-			liveSchema.before,
-			'a lock-acquire timeout must not leave this worker describing attributes it never persisted'
-		);
-		assert.ok(!liveSchema.before.attributes.includes('added'), 'test should start from the pre-declaration schema');
 		assert.ok(updateResult.updated, `redeclaration should succeed once the lock is free: ${updateResult.error ?? ''}`);
 		assert.ok(updateResult.applied.attributes.includes('added'), 'the retried declaration should apply the attribute');
 		assert.ok(updateResult.applied.indices.includes('added'), 'the retried declaration should open the index');

--- a/unitTests/resources/updateAttributesLock.test.js
+++ b/unitTests/resources/updateAttributesLock.test.js
@@ -16,9 +16,7 @@ const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const TEST_DB = 'test';
 const LOCK_KEY = 'update-attributes';
 
-// Regression tests for harper#2251: the exclusive 'update-attributes' lock must be acquired with a
-// bounded wait (throwing instead of spinning a core forever when the holder never releases) and must
-// be released structurally on every exit path of the schema-update code it guards.
+// harper#2251: bounded acquire (throw instead of spinning a core forever) + structural release
 describe('update-attributes exclusive lock', () => {
 	let rootStore;
 	before(function () {
@@ -96,6 +94,35 @@ describe('update-attributes exclusive lock', () => {
 		rootStore.unlock(LOCK_KEY);
 		// a subsequent schema update must succeed rather than wedge — restore the original definition
 		table({ table: 'LockLeak', database: TEST_DB, attributes });
+	});
+
+	it('a real table() operation fails with ServerError after the full deadline when the lock is wedged', function () {
+		this.timeout(40000);
+		const definition = {
+			table: 'DeadlineWedged',
+			database: TEST_DB,
+			attributes: [{ name: 'id', type: 'Int', isPrimaryKey: true }],
+		};
+		assert.ok(rootStore.tryLock(LOCK_KEY), 'test should be able to wedge the lock');
+		const startTime = Date.now();
+		try {
+			assert.throws(
+				() => table(definition),
+				(error) => {
+					assert.ok(error instanceof ServerError, `expected ServerError, got ${error.constructor.name}`);
+					assert.ok(error.message.includes(LOCK_KEY), 'message should name the lock');
+					assert.ok(error.message.includes(`table '${TEST_DB}.DeadlineWedged'`), 'message should name the table');
+					return true;
+				}
+			);
+			const elapsed = Date.now() - startTime;
+			assert.ok(elapsed >= 9500, `should have waited the full LOCK_TIMEOUT, threw after ${elapsed}ms`);
+			assert.ok(elapsed < 30000, `should throw shortly after the deadline, took ${elapsed}ms`);
+		} finally {
+			rootStore.unlock(LOCK_KEY);
+		}
+		// once the lock is free, the same operation must succeed
+		assert.ok(table(definition), 'create should succeed after the lock is released');
 	});
 
 	it('waits for a briefly-held lock and acquires once the holding thread releases', async function () {

--- a/unitTests/resources/updateAttributesLock.test.js
+++ b/unitTests/resources/updateAttributesLock.test.js
@@ -9,12 +9,43 @@ const {
 	withUpdateAttributesLock,
 } = require('#src/resources/Table');
 const { PrimaryRocksDatabase } = require('#src/resources/PrimaryRocksDatabase');
-const { ServerError } = require('#src/utility/errors/hdbError');
 const { RocksDatabase } = require('@harperfast/rocksdb-js');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 
 const TEST_DB = 'test';
 const LOCK_KEY = 'update-attributes';
+
+function runWorkerAction(message, expectedMessageTypes, hardTimeout) {
+	return new Promise((resolve, reject) => {
+		const workerThread = new Worker(__dirname + '/updateAttributesLock-thread.js', {
+			workerData: { addPorts: [] },
+		});
+		const received = [];
+		let finished = false;
+		let timer;
+		const finish = (callback) => {
+			if (finished) return;
+			finished = true;
+			clearTimeout(timer);
+			workerThread.removeAllListeners();
+			workerThread.terminate().then(callback, reject);
+		};
+		timer = setTimeout(
+			() => finish(() => reject(new Error(`worker action '${message.type}' exceeded its ${hardTimeout}ms watchdog`))),
+			hardTimeout
+		);
+		workerThread.on('message', (result) => {
+			if (!expectedMessageTypes.includes(result.type)) return;
+			received.push(result);
+			if (received.length === expectedMessageTypes.length) finish(() => resolve(received));
+		});
+		workerThread.once('error', (error) => finish(() => reject(error)));
+		workerThread.once('exit', (code) =>
+			finish(() => reject(new Error(`worker action '${message.type}' exited before completing (code ${code})`)))
+		);
+		workerThread.postMessage(message);
+	});
+}
 
 // harper#2251: bounded acquire (throw instead of spinning a core forever) + structural release
 describe('update-attributes exclusive lock', () => {
@@ -34,26 +65,16 @@ describe('update-attributes exclusive lock', () => {
 		rootStore.unlock(LOCK_KEY);
 	});
 
-	it('throws ServerError after the deadline when the lock is never released', () => {
-		assert.ok(rootStore.tryLock(LOCK_KEY), 'test should be able to take the lock to wedge it');
-		const startTime = Date.now();
-		try {
-			assert.throws(
-				() => acquireUpdateAttributesLock(rootStore, `table '${TEST_DB}.Wedged'`, 250),
-				(error) => {
-					assert.ok(error instanceof ServerError, `expected ServerError, got ${error.constructor.name}`);
-					assert.ok(error.message.includes(LOCK_KEY), 'message should name the lock');
-					assert.ok(error.message.includes(`table '${TEST_DB}.Wedged'`), 'message should name the table in scope');
-					assert.ok(/\d+ms/.test(error.message), 'message should report the elapsed deadline');
-					return true;
-				}
-			);
-			const elapsed = Date.now() - startTime;
-			assert.ok(elapsed >= 240, `should have waited out the deadline, threw after ${elapsed}ms`);
-			assert.ok(elapsed < 5000, `should throw shortly after the deadline, took ${elapsed}ms`);
-		} finally {
-			rootStore.unlock(LOCK_KEY);
-		}
+	it('throws ServerError after the deadline when the lock is never released', async () => {
+		const [result] = await runWorkerAction({ type: 'helper-deadline', timeout: 250 }, ['deadline-result'], 5000);
+		assert.ok(result.acquired, 'test worker should be able to take the lock to wedge it');
+		assert.ok(result.error.isServerError, 'deadline should throw ServerError');
+		assert.strictEqual(result.error.statusCode, 503);
+		assert.ok(result.error.message.includes(LOCK_KEY), 'message should name the lock');
+		assert.ok(result.error.message.includes(`table '${TEST_DB}.Wedged'`), 'message should name the table in scope');
+		assert.ok(/\d+ms/.test(result.error.message), 'message should report the elapsed deadline');
+		assert.ok(result.elapsed >= 240, `should have waited out the deadline, threw after ${result.elapsed}ms`);
+		assert.ok(result.elapsed < 5000, `should throw shortly after the deadline, took ${result.elapsed}ms`);
 	});
 
 	it('releases the lock when the guarded callback throws', () => {
@@ -65,6 +86,15 @@ describe('update-attributes exclusive lock', () => {
 			/boom/
 		);
 		assert.ok(rootStore.tryLock(LOCK_KEY), 'lock should have been released despite the throw');
+		rootStore.unlock(LOCK_KEY);
+	});
+
+	it('rejects asynchronous guarded callbacks and releases the lock', () => {
+		assert.throws(
+			() => withUpdateAttributesLock(rootStore, `table '${TEST_DB}.Async'`, () => Promise.resolve(42)),
+			/withUpdateAttributesLock callback must be synchronous/
+		);
+		assert.ok(rootStore.tryLock(LOCK_KEY), 'lock should be released after rejecting an asynchronous callback');
 		rootStore.unlock(LOCK_KEY);
 	});
 
@@ -96,33 +126,57 @@ describe('update-attributes exclusive lock', () => {
 		table({ table: 'LockLeak', database: TEST_DB, attributes });
 	});
 
-	it('a real table() operation fails with ServerError after the full deadline when the lock is wedged', function () {
-		this.timeout(40000);
+	it('releases the lock before recursively reloading a concurrently-created table', function () {
+		this.timeout(30000);
 		const definition = {
-			table: 'DeadlineWedged',
+			table: 'ConcurrentCreate',
 			database: TEST_DB,
 			attributes: [{ name: 'id', type: 'Int', isPrimaryKey: true }],
 		};
-		assert.ok(rootStore.tryLock(LOCK_KEY), 'test should be able to wedge the lock');
-		const startTime = Date.now();
+		const originalGetSync = PrimaryRocksDatabase.prototype.getSync;
+		let intercepted = false;
+		PrimaryRocksDatabase.prototype.getSync = function (key) {
+			if (!intercepted && key?.toString() === 'ConcurrentCreate/') {
+				intercepted = true;
+				PrimaryRocksDatabase.prototype.getSync = originalGetSync;
+				return { name: 'id' };
+			}
+			return originalGetSync.apply(this, arguments);
+		};
 		try {
-			assert.throws(
-				() => table(definition),
-				(error) => {
-					assert.ok(error instanceof ServerError, `expected ServerError, got ${error.constructor.name}`);
-					assert.ok(error.message.includes(LOCK_KEY), 'message should name the lock');
-					assert.ok(error.message.includes(`table '${TEST_DB}.DeadlineWedged'`), 'message should name the table');
-					return true;
-				}
-			);
-			const elapsed = Date.now() - startTime;
-			assert.ok(elapsed >= 9500, `should have waited the full LOCK_TIMEOUT, threw after ${elapsed}ms`);
-			assert.ok(elapsed < 30000, `should throw shortly after the deadline, took ${elapsed}ms`);
+			assert.ok(table(definition), 'recursive reload should complete after releasing the non-reentrant lock');
 		} finally {
-			rootStore.unlock(LOCK_KEY);
+			PrimaryRocksDatabase.prototype.getSync = originalGetSync;
 		}
-		// once the lock is free, the same operation must succeed
-		assert.ok(table(definition), 'create should succeed after the lock is released');
+		assert.ok(intercepted, 'test should drive the concurrently-created branch');
+		assert.ok(rootStore.tryLock(LOCK_KEY), 'lock should be free after the recursive reload');
+		rootStore.unlock(LOCK_KEY);
+	});
+
+	it('a real table() operation fails with ServerError after the full deadline when the lock is wedged', async function () {
+		this.timeout(30000);
+		const [deadlineResult, createResult] = await runWorkerAction(
+			{ type: 'table-deadline' },
+			['deadline-result', 'table-created'],
+			20000
+		);
+		assert.ok(deadlineResult.acquired, 'test worker should be able to wedge the lock');
+		assert.ok(deadlineResult.error.isServerError, 'production table() path should throw ServerError');
+		assert.strictEqual(deadlineResult.error.statusCode, 503);
+		assert.ok(deadlineResult.error.message.includes(LOCK_KEY), 'message should name the lock');
+		assert.ok(
+			deadlineResult.error.message.includes(`table '${TEST_DB}.DeadlineWedged'`),
+			'message should name the table'
+		);
+		assert.ok(
+			deadlineResult.elapsed >= 9500,
+			`should have waited the full update-attributes deadline, threw after ${deadlineResult.elapsed}ms`
+		);
+		assert.ok(
+			deadlineResult.elapsed < 20000,
+			`should throw shortly after the deadline, took ${deadlineResult.elapsed}ms`
+		);
+		assert.ok(createResult.created, 'create should succeed after the lock is released');
 	});
 
 	it('waits for a briefly-held lock and acquires once the holding thread releases', async function () {
@@ -134,7 +188,7 @@ describe('update-attributes exclusive lock', () => {
 			const held = await new Promise((resolve, reject) => {
 				workerThread.once('message', resolve);
 				workerThread.once('error', reject);
-				workerThread.postMessage({ type: 'hold-lock', holdTime: 300 });
+				workerThread.postMessage({ type: 'hold-lock', holdTime: 1000 });
 			});
 			assert.ok(held.acquired, 'worker thread should have taken the lock');
 			const startTime = Date.now();

--- a/unitTests/resources/updateAttributesLock.test.js
+++ b/unitTests/resources/updateAttributesLock.test.js
@@ -7,7 +7,9 @@ const {
 	releaseUpdateAttributesLock,
 	withUpdateAttributesLock,
 	UPDATE_ATTRIBUTES_LOCK_TIMEOUT,
+	UPDATE_ATTRIBUTES_LOCK_SLOW_WAIT,
 } = require('#src/resources/Table');
+const { logger } = require('#src/utility/logging/logger');
 const { PrimaryRocksDatabase } = require('#src/resources/PrimaryRocksDatabase');
 const { RocksDatabase } = require('@harperfast/rocksdb-js');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
@@ -154,13 +156,18 @@ describe('update-attributes exclusive lock', () => {
 		rootStore.unlock(LOCK_KEY);
 	});
 
-	it('a real table() operation fails with ServerError after the full deadline when the lock is wedged', async function () {
-		this.timeout(30000);
-		const [deadlineResult, createResult] = await runWorkerAction(
+	it('a real table() operation fails with ServerError after the full deadline, leaving the live schema untouched', async function () {
+		this.timeout(40000);
+		const messages = await runWorkerAction(
 			{ type: 'table-deadline' },
-			['deadline-result', 'table-created'],
-			20000
+			['deadline-result', 'live-schema', 'table-updated'],
+			30000
 		);
+		const {
+			'deadline-result': deadlineResult,
+			'live-schema': liveSchema,
+			'table-updated': updateResult,
+		} = Object.fromEntries(messages.map((message) => [message.type, message]));
 		assert.ok(deadlineResult.acquired, 'test worker should be able to wedge the lock');
 		assert.ok(deadlineResult.error.isServerError, 'production table() path should throw ServerError');
 		assert.strictEqual(deadlineResult.error.statusCode, 503);
@@ -179,7 +186,46 @@ describe('update-attributes exclusive lock', () => {
 			deadlineResult.elapsed < UPDATE_ATTRIBUTES_LOCK_TIMEOUT + 5000,
 			`should throw shortly after the deadline, took ${deadlineResult.elapsed}ms`
 		);
-		assert.ok(createResult.created, `create should succeed after the lock is released: ${createResult.error ?? ''}`);
+		// the acquire happens before any mutation of the live Table, so losing the race is a no-op
+		assert.deepStrictEqual(
+			liveSchema.after,
+			liveSchema.before,
+			'a lock-acquire timeout must not leave this worker describing attributes it never persisted'
+		);
+		assert.ok(!liveSchema.before.attributes.includes('added'), 'test should start from the pre-declaration schema');
+		assert.ok(updateResult.updated, `redeclaration should succeed once the lock is free: ${updateResult.error ?? ''}`);
+		assert.ok(updateResult.applied.attributes.includes('added'), 'the retried declaration should apply the attribute');
+		assert.ok(updateResult.applied.indices.includes('added'), 'the retried declaration should open the index');
+	});
+
+	it('warns exactly once when a successful acquisition waited past the slow-wait threshold', async function () {
+		this.timeout(30000);
+		const warnings = [];
+		const originalWarn = Object.getOwnPropertyDescriptor(logger, 'warn');
+		logger.warn = (message) => warnings.push(message);
+		const workerThread = new Worker(__dirname + '/updateAttributesLock-thread.js', {
+			workerData: { addPorts: [] },
+		});
+		try {
+			withUpdateAttributesLock(rootStore, `table '${TEST_DB}.FastWait'`, () => 0);
+			assert.strictEqual(warnings.length, 0, 'an uncontended acquisition must stay silent');
+			const held = await new Promise((resolve, reject) => {
+				workerThread.once('message', resolve);
+				workerThread.once('error', reject);
+				workerThread.postMessage({ type: 'hold-lock' });
+			});
+			assert.ok(held.acquired, 'worker thread should have taken the lock');
+			workerThread.postMessage({ type: 'release-lock', holdTime: UPDATE_ATTRIBUTES_LOCK_SLOW_WAIT + 300 });
+			acquireUpdateAttributesLock(rootStore, `table '${TEST_DB}.SlowWait'`);
+			releaseUpdateAttributesLock(rootStore);
+		} finally {
+			if (originalWarn) Object.defineProperty(logger, 'warn', originalWarn);
+			else delete logger.warn;
+			await workerThread.terminate();
+		}
+		assert.strictEqual(warnings.length, 1, `expected one slow-wait warning, got ${warnings.length}`);
+		assert.ok(warnings[0].includes(`table '${TEST_DB}.SlowWait'`), 'the warning should name the table in scope');
+		assert.ok(/waiting \d+ms/.test(warnings[0]), 'the warning should report how long the acquisition waited');
 	});
 
 	it('waits for a briefly-held lock and acquires once the holding thread releases', async function () {

--- a/unitTests/resources/updateAttributesLock.test.js
+++ b/unitTests/resources/updateAttributesLock.test.js
@@ -7,6 +7,7 @@ const {
 	acquireUpdateAttributesLock,
 	releaseUpdateAttributesLock,
 	withUpdateAttributesLock,
+	UPDATE_ATTRIBUTES_LOCK_TIMEOUT,
 } = require('#src/resources/Table');
 const { PrimaryRocksDatabase } = require('#src/resources/PrimaryRocksDatabase');
 const { RocksDatabase } = require('@harperfast/rocksdb-js');
@@ -70,6 +71,8 @@ describe('update-attributes exclusive lock', () => {
 		assert.ok(result.acquired, 'test worker should be able to take the lock to wedge it');
 		assert.ok(result.error.isServerError, 'deadline should throw ServerError');
 		assert.strictEqual(result.error.statusCode, 503);
+		assert.strictEqual(result.error.code, 'UPDATE_ATTRIBUTES_LOCK_TIMEOUT');
+		assert.strictEqual(result.error.retryable, true);
 		assert.ok(result.error.message.includes(LOCK_KEY), 'message should name the lock');
 		assert.ok(result.error.message.includes(`table '${TEST_DB}.Wedged'`), 'message should name the table in scope');
 		assert.ok(/\d+ms/.test(result.error.message), 'message should report the elapsed deadline');
@@ -163,20 +166,22 @@ describe('update-attributes exclusive lock', () => {
 		assert.ok(deadlineResult.acquired, 'test worker should be able to wedge the lock');
 		assert.ok(deadlineResult.error.isServerError, 'production table() path should throw ServerError');
 		assert.strictEqual(deadlineResult.error.statusCode, 503);
+		assert.strictEqual(deadlineResult.error.code, 'UPDATE_ATTRIBUTES_LOCK_TIMEOUT');
+		assert.strictEqual(deadlineResult.error.retryable, true);
 		assert.ok(deadlineResult.error.message.includes(LOCK_KEY), 'message should name the lock');
 		assert.ok(
 			deadlineResult.error.message.includes(`table '${TEST_DB}.DeadlineWedged'`),
 			'message should name the table'
 		);
 		assert.ok(
-			deadlineResult.elapsed >= 9500,
+			deadlineResult.elapsed >= UPDATE_ATTRIBUTES_LOCK_TIMEOUT - 500,
 			`should have waited the full update-attributes deadline, threw after ${deadlineResult.elapsed}ms`
 		);
 		assert.ok(
-			deadlineResult.elapsed < 20000,
+			deadlineResult.elapsed < UPDATE_ATTRIBUTES_LOCK_TIMEOUT + 5000,
 			`should throw shortly after the deadline, took ${deadlineResult.elapsed}ms`
 		);
-		assert.ok(createResult.created, 'create should succeed after the lock is released');
+		assert.ok(createResult.created, `create should succeed after the lock is released: ${createResult.error ?? ''}`);
 	});
 
 	it('waits for a briefly-held lock and acquires once the holding thread releases', async function () {
@@ -188,16 +193,17 @@ describe('update-attributes exclusive lock', () => {
 			const held = await new Promise((resolve, reject) => {
 				workerThread.once('message', resolve);
 				workerThread.once('error', reject);
-				workerThread.postMessage({ type: 'hold-lock', holdTime: 1000 });
+				workerThread.postMessage({ type: 'hold-lock' });
 			});
 			assert.ok(held.acquired, 'worker thread should have taken the lock');
+			const bufferKeyAcquired = rootStore.tryLock(Buffer.from(LOCK_KEY));
+			if (bufferKeyAcquired) rootStore.unlock(Buffer.from(LOCK_KEY));
+			assert.strictEqual(bufferKeyAcquired, false, 'Buffer and string keys must address the same held lock');
+			workerThread.postMessage({ type: 'release-lock', holdTime: 300 });
 			const startTime = Date.now();
-			// blocks synchronously; the worker's timer releases the lock from its own event loop,
-			// which the bounded wait observes through the native shared lock state
 			acquireUpdateAttributesLock(rootStore, `table '${TEST_DB}.Contended'`);
 			const elapsed = Date.now() - startTime;
 			releaseUpdateAttributesLock(rootStore);
-			assert.ok(elapsed >= 200, `should have waited for the holder, waited ${elapsed}ms`);
 			assert.ok(elapsed < 5000, `should acquire promptly after release, took ${elapsed}ms`);
 		} finally {
 			await workerThread.terminate();

--- a/unitTests/resources/updateAttributesLock.test.js
+++ b/unitTests/resources/updateAttributesLock.test.js
@@ -1,0 +1,125 @@
+require('../testUtils');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+const { setupTestDBPath } = require('../testUtils');
+const { database, table } = require('#src/resources/databases');
+const {
+	acquireUpdateAttributesLock,
+	releaseUpdateAttributesLock,
+	withUpdateAttributesLock,
+} = require('#src/resources/Table');
+const { PrimaryRocksDatabase } = require('#src/resources/PrimaryRocksDatabase');
+const { ServerError } = require('#src/utility/errors/hdbError');
+const { RocksDatabase } = require('@harperfast/rocksdb-js');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+
+const TEST_DB = 'test';
+const LOCK_KEY = 'update-attributes';
+
+// Regression tests for harper#2251: the exclusive 'update-attributes' lock must be acquired with a
+// bounded wait (throwing instead of spinning a core forever when the holder never releases) and must
+// be released structurally on every exit path of the schema-update code it guards.
+describe('update-attributes exclusive lock', () => {
+	let rootStore;
+	before(function () {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		rootStore = database({ database: TEST_DB, table: null });
+		// the lock helpers are RocksDB-only; the LMDB path uses a transaction lock instead
+		if (!(rootStore instanceof RocksDatabase)) this.skip();
+	});
+
+	it('acquires immediately when uncontended and releases on completion', () => {
+		const result = withUpdateAttributesLock(rootStore, `table '${TEST_DB}.Uncontended'`, () => 42);
+		assert.equal(result, 42);
+		assert.ok(rootStore.tryLock(LOCK_KEY), 'lock should be free after the callback completed');
+		rootStore.unlock(LOCK_KEY);
+	});
+
+	it('throws ServerError after the deadline when the lock is never released', () => {
+		assert.ok(rootStore.tryLock(LOCK_KEY), 'test should be able to take the lock to wedge it');
+		const startTime = Date.now();
+		try {
+			assert.throws(
+				() => acquireUpdateAttributesLock(rootStore, `table '${TEST_DB}.Wedged'`, 250),
+				(error) => {
+					assert.ok(error instanceof ServerError, `expected ServerError, got ${error.constructor.name}`);
+					assert.ok(error.message.includes(LOCK_KEY), 'message should name the lock');
+					assert.ok(error.message.includes(`table '${TEST_DB}.Wedged'`), 'message should name the table in scope');
+					assert.ok(/\d+ms/.test(error.message), 'message should report the elapsed deadline');
+					return true;
+				}
+			);
+			const elapsed = Date.now() - startTime;
+			assert.ok(elapsed >= 240, `should have waited out the deadline, threw after ${elapsed}ms`);
+			assert.ok(elapsed < 5000, `should throw shortly after the deadline, took ${elapsed}ms`);
+		} finally {
+			rootStore.unlock(LOCK_KEY);
+		}
+	});
+
+	it('releases the lock when the guarded callback throws', () => {
+		assert.throws(
+			() =>
+				withUpdateAttributesLock(rootStore, `table '${TEST_DB}.Throwing'`, () => {
+					throw new Error('boom');
+				}),
+			/boom/
+		);
+		assert.ok(rootStore.tryLock(LOCK_KEY), 'lock should have been released despite the throw');
+		rootStore.unlock(LOCK_KEY);
+	});
+
+	it('table() releases the lock when a schema update throws mid-flight', function () {
+		this.timeout(30000);
+		const attributes = [
+			{ name: 'id', type: 'Int', isPrimaryKey: true },
+			{ name: 'extra', type: 'String', indexed: true },
+		];
+		table({ table: 'LockLeak', database: TEST_DB, attributes });
+		// Reload the schema without 'extra' while the catalog remove throws: table() takes the
+		// exclusive lock just before removing the dropped attribute, so the throw escapes from
+		// inside the locked region and must not leak the lock.
+		const originalRemoveSync = PrimaryRocksDatabase.prototype.removeSync;
+		PrimaryRocksDatabase.prototype.removeSync = function () {
+			throw new Error('simulated catalog failure');
+		};
+		try {
+			assert.throws(
+				() => table({ table: 'LockLeak', database: TEST_DB, attributes: [attributes[0]] }),
+				/simulated catalog failure/
+			);
+		} finally {
+			PrimaryRocksDatabase.prototype.removeSync = originalRemoveSync;
+		}
+		assert.ok(rootStore.tryLock(LOCK_KEY), 'exclusive lock must not leak when table() throws');
+		rootStore.unlock(LOCK_KEY);
+		// a subsequent schema update must succeed rather than wedge — restore the original definition
+		table({ table: 'LockLeak', database: TEST_DB, attributes });
+	});
+
+	it('waits for a briefly-held lock and acquires once the holding thread releases', async function () {
+		this.timeout(30000);
+		const workerThread = new Worker(__dirname + '/updateAttributesLock-thread.js', {
+			workerData: { addPorts: [] },
+		});
+		try {
+			const held = await new Promise((resolve, reject) => {
+				workerThread.once('message', resolve);
+				workerThread.once('error', reject);
+				workerThread.postMessage({ type: 'hold-lock', holdTime: 300 });
+			});
+			assert.ok(held.acquired, 'worker thread should have taken the lock');
+			const startTime = Date.now();
+			// blocks synchronously; the worker's timer releases the lock from its own event loop,
+			// which the bounded wait observes through the native shared lock state
+			acquireUpdateAttributesLock(rootStore, `table '${TEST_DB}.Contended'`);
+			const elapsed = Date.now() - startTime;
+			releaseUpdateAttributesLock(rootStore);
+			assert.ok(elapsed >= 200, `should have waited for the holder, waited ${elapsed}ms`);
+			assert.ok(elapsed < 5000, `should acquire promptly after release, took ${elapsed}ms`);
+		} finally {
+			await workerThread.terminate();
+		}
+	});
+});

--- a/unitTests/resources/updateAttributesLock.test.js
+++ b/unitTests/resources/updateAttributesLock.test.js
@@ -202,6 +202,7 @@ describe('update-attributes exclusive lock', () => {
 			acquireUpdateAttributesLock(rootStore, `table '${TEST_DB}.Contended'`);
 			const elapsed = Date.now() - startTime;
 			releaseUpdateAttributesLock(rootStore);
+			assert.ok(elapsed >= 200, `should wait for the holding thread, acquired after ${elapsed}ms`);
 			assert.ok(elapsed < 5000, `should acquire promptly after release, took ${elapsed}ms`);
 		} finally {
 			await workerThread.terminate();

--- a/unitTests/resources/updateAttributesLock.test.js
+++ b/unitTests/resources/updateAttributesLock.test.js
@@ -1,4 +1,3 @@
-require('../testUtils');
 const assert = require('assert');
 const { Worker } = require('worker_threads');
 const { setupTestDBPath } = require('../testUtils');
@@ -48,7 +47,6 @@ function runWorkerAction(message, expectedMessageTypes, hardTimeout) {
 	});
 }
 
-// harper#2251: bounded acquire (throw instead of spinning a core forever) + structural release
 describe('update-attributes exclusive lock', () => {
 	let rootStore;
 	before(function () {
@@ -108,11 +106,11 @@ describe('update-attributes exclusive lock', () => {
 			{ name: 'extra', type: 'String', indexed: true },
 		];
 		table({ table: 'LockLeak', database: TEST_DB, attributes });
-		// Reload the schema without 'extra' while the catalog remove throws: table() takes the
-		// exclusive lock just before removing the dropped attribute, so the throw escapes from
-		// inside the locked region and must not leak the lock.
 		const originalRemoveSync = PrimaryRocksDatabase.prototype.removeSync;
+		let heldAtThrow;
 		PrimaryRocksDatabase.prototype.removeSync = function () {
+			heldAtThrow = !rootStore.tryLock(LOCK_KEY);
+			if (!heldAtThrow) rootStore.unlock(LOCK_KEY);
 			throw new Error('simulated catalog failure');
 		};
 		try {
@@ -123,9 +121,9 @@ describe('update-attributes exclusive lock', () => {
 		} finally {
 			PrimaryRocksDatabase.prototype.removeSync = originalRemoveSync;
 		}
+		assert.strictEqual(heldAtThrow, true, 'the throw must escape from inside the locked region');
 		assert.ok(rootStore.tryLock(LOCK_KEY), 'exclusive lock must not leak when table() throws');
 		rootStore.unlock(LOCK_KEY);
-		// a subsequent schema update must succeed rather than wedge — restore the original definition
 		table({ table: 'LockLeak', database: TEST_DB, attributes });
 	});
 

--- a/unitTests/resources/updateAttributesLock.test.js
+++ b/unitTests/resources/updateAttributesLock.test.js
@@ -29,7 +29,7 @@ describe('update-attributes exclusive lock', () => {
 
 	it('acquires immediately when uncontended and releases on completion', () => {
 		const result = withUpdateAttributesLock(rootStore, `table '${TEST_DB}.Uncontended'`, () => 42);
-		assert.equal(result, 42);
+		assert.strictEqual(result, 42);
 		assert.ok(rootStore.tryLock(LOCK_KEY), 'lock should be free after the callback completed');
 		rootStore.unlock(LOCK_KEY);
 	});

--- a/unitTests/types/updateAttributesLock.type-test.ts
+++ b/unitTests/types/updateAttributesLock.type-test.ts
@@ -1,0 +1,8 @@
+import { withUpdateAttributesLock } from '../../dist/resources/Table.js';
+
+declare const rootStore: Parameters<typeof withUpdateAttributesLock>[0];
+
+withUpdateAttributesLock(rootStore, "table 'test.Sync'", () => 42);
+
+// @ts-expect-error the lock callback must finish before the synchronous lock is released
+withUpdateAttributesLock(rootStore, "table 'test.Async'", async () => 42);

--- a/utility/errors/hdbError.ts
+++ b/utility/errors/hdbError.ts
@@ -85,6 +85,17 @@ export class IndexRebuildingError extends ServerError {
 	}
 }
 
+export class UpdateAttributesLockTimeoutError extends ServerError {
+	code: string;
+	retryable: boolean;
+	constructor(message: string) {
+		super(message, 503);
+		this.name = 'UpdateAttributesLockTimeoutError';
+		this.code = 'UPDATE_ATTRIBUTES_LOCK_TIMEOUT';
+		this.retryable = true;
+	}
+}
+
 /** One structured validation failure. `path` is dot-scoped (`body.price`, `query.sort`, `params.id`). */
 export interface ValidationIssue {
 	/** Where the failure occurred, e.g. `body.price`, `query.expand`, `params.id`. */


### PR DESCRIPTION
Fixes #2251.

The exclusive `update-attributes` lock could spin forever at 100% CPU when a holder failed to release it, and `table()` relied on scattered manual unlocks that made every throw or early return another leak risk.

- [The shared lock helper](https://github.com/HarperFast/harper/pull/2252/changes?w=1#diff-4ff51263bd99981165fc179149c3195ea0c0ca3e2f360bafee2a6bb356964377R139) now fast-paths an uncontended acquire, briefly spins, sleeps with bounded backoff, and throws a machine-readable retryable 503 after the dedicated 10-second deadline. The interval clock is monotonic, and the lock key is encoded once.
- `table()` funnels every acquired lock through one idempotent `finally`; `dropTable()` uses the same structural wrapper. The recursive concurrently-created-table branch releases before re-entry because the lock is not reentrant.
- The wrapper rejects Promise-returning callbacks at the TypeScript boundary and diagnoses/contains JavaScript misuse so an orphaned rejection is not left unhandled.
- Because the acquire can now throw, [`table()` takes the RocksDB lock before the first mutation of the live `Table`](https://github.com/HarperFast/harper/pull/2252/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R1594) rather than lazily at the first catalog write. A lost race is then a clean no-op instead of a worker left describing attributes that were never persisted, with an indexed attribute whose dbi never reached `Table.indices`. LMDB keeps the lazy acquire: its `exclusiveLock()` opens an environment-wide write transaction that cannot time out, so taking it eagerly would stall every write to the database on an unchanged reload.
- [A successful acquire that waited past `UPDATE_ATTRIBUTES_LOCK_SLOW_WAIT` (1s) warns once](https://github.com/HarperFast/harper/pull/2252/changes?w=1#diff-4ff51263bd99981165fc179149c3195ea0c0ca3e2f360bafee2a6bb356964377R172) with the table and elapsed time — contention was otherwise invisible until it became a timeout. The warn is wrapped because the caller registers its release only after the acquire returns, so a throwing logger would leak the lock with no `finally` able to reach it.
- [Ten lock regression tests](https://github.com/HarperFast/harper/pull/2252/changes?w=1#diff-34535e18757ee87b9a9f84716e21a3e0a5db180d623a4803412a9eb0b90671dcR52) cover the helper and real `table()` deadline paths under hard parent-side watchdogs, exception release (including proof that the injected failure occurs while locked), recursive reload release, machine-readable retry fields, and cross-thread key identity/hand-off. [A compile-time contract test](https://github.com/HarperFast/harper/pull/2252/changes?w=1#diff-a3ab3525f966686436756a59324acded641ba7d641561689729609dc44b63c58R1) rejects async callbacks.

## For the human reviewer

The three owner decisions this PR was waiting on are now made and implemented — targeted no-drift recovery by acquiring before mutating, a one-shot `warn` at 1s, and a fixed 10s deadline. What remains:

- **The eager acquire serializes unchanged RocksDB reloads, by design.** [Every existing-table declaration now takes the lock](https://github.com/HarperFast/harper/pull/2252/changes?w=1#diff-2a3520ef673512c350042faa431f24956f148f2e19889470bd00a79b5da339c5R1594) and holds it through the whole reconciliation pass (the `attributesDbi` range scan, a `getSync` per attribute, `openIndex` per indexed attribute), not just around the first catalog write. A hot component reload re-runs the schema declaration on every worker simultaneously, so *N* threads × *M* unchanged tables in one database now fully serialize, each waiter blocking its own event loop while it waits; review put 24 × 60 in range of the 10s deadline. This is the accepted cost of making the no-drift invariant structural rather than reconstructed, and it is the one place where a preflight "does this declaration differ from `Table.attributes`?" check would buy the old lock-free path back. I did not add that check: the loop stamps `key`/`dbi`/`indexNulls` onto the declared attribute objects, so skipping the splice when they compare equal diverges live and declared identity, and the stamping makes an unchanged declaration compare *unequal* on most indexed tables anyway.
- **A lock-acquire timeout in the replication apply path is swallowed.** The `define_schema` event calls `table({..., origin: 'cluster'})` inside the apply loop, whose `catch` logs `error in subscription handler` and pulls the next event. Under the old unbounded spin this call could not fail — it hung, visibly. It can now throw, and a node that loses the race never adds the attribute or builds the index while its peers do: replicated records still carry the field, so `search_by_value` on that attribute returns empty on that node only, with nothing surfaced to any client. `retryable: true` does not help — a repo-wide grep finds no reader of `.retryable`. Fixing this means either failing the event instead of advancing past it, or making the cluster-origin acquire unbounded; both are replication-semantics calls beyond this PR, so I left it. Worth its own issue.
- **The invariant covers the acquire, not every later failure.** A catalog write that throws *after* the lock is held still leaves the live `Table` ahead of disk, exactly as before this PR. Only the new, load-triggered timeout path is closed.
- **The full-duration regression costs a real 10s in `test:unit:resources`**, per the decision to keep the deadline on the production contract. `table()` exposes no timeout injection point, so a cheaper version would need one.
- The hot-spin/backoff profile remains the original PR's chosen design. A native-notified or asynchronous lock would be a larger cross-cutting change.

## Verification

- `npm run build` — passed.
- `npm run lint:required` — passed. The stricter repository-wide `npm run lint` still reports 12 unrelated pre-existing warnings outside this diff.
- `npx mocha unitTests/resources/updateAttributesLock.test.js` — 10 passing.
- `npm run test:types` — passed, including the async-callback negative contract.
- `npm run test:unit:resources` — 1680 passing, 16 pending, 3 failing; the three failures are the same local baseline failures previously reproduced on `origin/main` (`randomAccessFields` ×2 and `replayStructures`).
- Fails-on-base check: with only the eager-acquire line reverted, [the new cross-thread regression](https://github.com/HarperFast/harper/pull/2252/changes?w=1#diff-34535e18757ee87b9a9f84716e21a3e0a5db180d623a4803412a9eb0b90671dcR184) fails with `+ 'added'` in the live attribute list and an empty `indices` — the reported drift, reproduced exactly.
- `npm run test:unit:main` could not run on this machine: a stale global `hdb_boot_properties.file` points at a removed install, and the same failure reproduces on an unmodified tree. CI covers it.
- End-to-end route: not safely observable through the operations API without deliberately wedging a live worker. [The regression now wedges the lock from a second thread](https://github.com/HarperFast/harper/pull/2252/changes?w=1#diff-0ddf4b0322d95adff8ab690f54dd095fdbaf534a597a71e25d703e31f474594eR81) — the production failure mode — and snapshots attributes, index handles, `schemaVersion` and class metadata around the timed-out call alone.
- PR CI on `ca336ba33c04` — fully green: 42 checks pass across Linux/Windows/Bun/uWS integration, Next.js adapter, unit (Node 22/24/26), build, lint, format, review and security. Three failures on the first pass were flakes and cleared on rerun: `Integration Tests 2/6` failed its instance readiness probe (`ECONNREFUSED` at suite setup — the same signature `main` was failing with at the time), and the unit job failed `caching.test.js:155` on one attempt and `vectorIndex.test.js:1009` on the next before passing clean, which is timing/approximate-search nondeterminism rather than a deterministic regression.
- Independent review, this round: full pass (Codex + Gemini + Cursor Composer + Harper-domain) raised four items — the LMDB half of the eager acquire, the slow-wait logger leak window, single-thread-only regression coverage, and a narrating comment. All four are fixed here. The delta pass (Codex + Gemini) confirmed those fixes and returned only the two owner-level items carried above.

Complexity: moderate — concurrency-sensitive schema/DDL locking, with no storage-format or record hot-path change.

— Claude Opus, continuing work by Claude Fable and GPT-5 Codex

🤖 Generated with Claude Code

<sub>Review-Coverage: authored=claude; ran=gemini,codex; declined=cursor-grok,cursor-composer,domain; rounds=4 @ ca336ba33c04</sub>

<sub>Human-Review-Need: 4 @ ca336ba33c04</sub>
