### PR TITLE
Canary reliable AI review evidence in Harper

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,7 +33,7 @@ jobs:
     # Note: the `claude-review` label name is matched there too —
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@224c2adcfdb408d68c7ca48eb618623c990a96ad # main 2026-07-28 (#80 week-of-07-20 calibration: producing-side guard verification; on 82c9484)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@4b59dc0ddb15aff517884127b58204f79193b4f2 # main 2026-08-20 (#86 reliable review evidence, context, and run binding)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -60,7 +60,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 224c2adcfdb408d68c7ca48eb618623c990a96ad
+      ai-review-prompts-ref: 4b59dc0ddb15aff517884127b58204f79193b4f2
       # CANARY (2026-07-11): run this repo's Claude reviews on Sonnet 5
       # while the fleet default stays claude-sonnet-4-6. Every ai-review-log
       # entry records `Model:`, so calibration can compare sonnet-5 vs

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -52,7 +52,7 @@ jobs:
     # Note: the `gemini-review` label name is matched there too —
     # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@224c2adcfdb408d68c7ca48eb618623c990a96ad # main 2026-07-28 (#80 week-of-07-20 calibration: producing-side guard verification; on 82c9484)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@4b59dc0ddb15aff517884127b58204f79193b4f2 # main 2026-08-20 (#86 reliable review evidence, context, and run binding)
     # Caller-side permissions at the calling-job level (NOT workflow-
     # level — that placement caps the reusable's per-job grants below
     # what they need and breaks the workflow at startup; see
@@ -70,7 +70,7 @@ jobs:
       # duplication is unavoidable: reusable workflows can't introspect
       # their own ref (`github.workflow_ref` resolves to the CALLER's
       # ref in workflow_call context), and `uses: …@<ref>` is literal.
-      ai-review-prompts-ref: 224c2adcfdb408d68c7ca48eb618623c990a96ad
+      ai-review-prompts-ref: 4b59dc0ddb15aff517884127b58204f79193b4f2
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/validate-caller-workflows.yml
+++ b/.github/workflows/validate-caller-workflows.yml
@@ -27,9 +27,9 @@ on:
 
 jobs:
   validate:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@224c2adcfdb408d68c7ca48eb618623c990a96ad # main 2026-07-28 (#80 week-of-07-20 calibration: producing-side guard verification; on 82c9484)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@4b59dc0ddb15aff517884127b58204f79193b4f2 # main 2026-08-20 (#86 reliable review evidence, context, and run binding)
     with:
       # Same SHA as the `uses:` ref above — the reusable uses this
       # to check out the validator script at the matching version.
       # Same SHA-twice pattern as the other caller workflows.
-      ai-review-prompts-ref: 224c2adcfdb408d68c7ca48eb618623c990a96ad
+      ai-review-prompts-ref: 4b59dc0ddb15aff517884127b58204f79193b4f2


### PR DESCRIPTION
Canary the reliable review-evidence plumbing from HarperFast/ai-review-prompts#86 in Harper by pinning the Claude and Gemini review callers to its verified merge commit. Gemini completed the live canary, while Claude correctly declined this self-modifying caller-workflow change.

## For the human reviewer

No open judgment calls — this is a paired, immutable pin bump to the already-reviewed #86 merge commit; mention, issue-to-PR, permissions, triggers, and secrets are unchanged. The validator caller now moves to the same pin (e0b9b96, from kriszyp's review): the #86 delta changes the workflow contract the validator checks callers against, so the pins move together — the same bump is applied on harper-pro#748 and oauth#210.

## Verification

- Preflight: `git diff --check` passed.
- Preflight: `yq eval '.'` parsed both changed workflow files successfully.
- Provenance: GitHub reports `4b59dc0ddb15aff517884127b58204f79193b4f2` as the signed, verified merge commit for HarperFast/ai-review-prompts#86.
- End-to-end route (c), Gemini live smoke: [run 32437905419](https://github.com/HarperFast/harper/actions/runs/32437905419) loaded `_gemini-review.yml@4b59dc0…`, captured the prior-thread context snapshot, and posted the exact provider marker plus run/attempt/head marker. It returned no blockers and correctly used `review:no-log` for this mechanical diff, so no ai-review-log issue was created.
- Claude guard-path smoke: [run 32438007568](https://github.com/HarperFast/harper/actions/runs/32438007568) loaded `_claude-review.yml@4b59dc0…` and captured the prior-thread context snapshot. Claude then declined the caller-workflow change as expected; #86 correctly classified the attempt as `invalid-review-status` and did not log or post it as a verdict.

## Review coverage

Authored by Codex. Cross-model review: Claude Fable 5 ✓ (independent graded review; no findings). Gemini, Cursor, and Harper-domain adjudication were pruned by the minimal low-risk policy. Receipt @ b7cedc20acaf4e254ba89c521d7a4ffc38547a2f.

<sub>Human-Review-Need: 2 @ b7cedc20acaf</sub>

