### PR TITLE
Fix multi-worker lost counter increments and stale reads when a resequenced write reuses a version

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -68,13 +68,16 @@ a version tie with the _executing_ node's name, and a fill from a shared source 
 identity of its own, so two replicas resolving the same tie could keep different values at the same
 version — the one state anti-entropy cannot repair. On a tie the raced record wins on every replica. A
 RocksDB replacement whose candidate cannot advance the current version stores at the current version
-and carries `VERSION_NOT_UNIQUE_FLAG`; rocksdb-js 2.8.0 ([#766](https://github.com/HarperFast/rocksdb-js/pull/766))
+and carries `VERSION_REUSED` (`resources/RecordEncoder.ts`, aliasing rocksdb-js's own
+`VERSION_NOT_UNIQUE_FLAG`); rocksdb-js 2.8.0 ([#766](https://github.com/HarperFast/rocksdb-js/pull/766))
 then refuses to publish or confirm that version through the VerificationTable. This avoids inventing
 an epsilon timestamp solely to force replacement while keeping stale record-cache values from being
 vouched as fresh.
 
-The flag is also applied to ordinary resequenced RocksDB writes. Those records remain ineligible for
-VerificationTable fast-path confirmation until a later write advances their version.
+The flag is applied generically to every RocksDB record write whose version does not advance past
+the record it replaces (`recordUpdater` in `RecordEncoder.ts`), not just this source-fill path — an
+ordinary resequenced (out-of-order CRDT-merged) write gets it too. Those records remain ineligible
+for VerificationTable fast-path confirmation until a later write advances their version.
 
 ## Blob orphan cleanup: pre-saved files outlive cancelled commits
 

--- a/integrationTests/resources/ttl-rate-limiter-convergence.test.ts
+++ b/integrationTests/resources/ttl-rate-limiter-convergence.test.ts
@@ -1,15 +1,8 @@
 /**
- * QA-431 companion — convergence classification for the multi-worker counter stress.
- *
- * Amplifies ttl-rate-limiter-concurrent.test.ts subtest (5) (same fixture: 500ms-TTL counter,
- * 4 workers) and adds the two ingredients that made the lost-count defect reproducible: GET
- * pressure DURING each burst (cold reads re-seed the VerificationTable, which is what let a
- * stale cached value be vouched for after a resequenced merge reused a version), and, for any
- * window that reads back short, polling within the TTL window to classify the anomaly:
- *   CONVERGED_LATE — reached acked on a later read: the first read raced still-landing merges.
- *   STUCK_SHORT    — never reached acked before expiry: a durably lost increment (DEFECT).
- * Under 4-CPU-constrained runners the unfixed defect produced 3-15 STUCK_SHORT windows per 900;
- * see the fix PR for the full mechanism (VERSION_REUSED / unvouchable sentinel / uncachedRead).
+ * QA-431 companion — same fixture as ttl-rate-limiter-concurrent.test.ts, with the two
+ * ingredients that make version-reuse cache staleness reproducible: GET pressure DURING each
+ * burst (cold reads re-seed the VerificationTable), and per-window convergence classification —
+ * CONVERGED_LATE (a read raced still-landing merges) vs STUCK_SHORT (a durably lost increment).
  */
 
 import { suite, test, before, after } from 'node:test';
@@ -134,6 +127,11 @@ suite(
 				);
 
 				for (const { id, acked } of perWindow) {
+					// a window whose burst was wholly rejected measures nothing
+					if (acked === 0) {
+						inconclusive++;
+						continue;
+					}
 					const first = await getHits(id);
 					if (first.status !== 200) {
 						inconclusive++;

--- a/integrationTests/resources/ttl-rate-limiter-convergence.test.ts
+++ b/integrationTests/resources/ttl-rate-limiter-convergence.test.ts
@@ -37,18 +37,23 @@ suite(
 			httpURL = ctx.harper.httpURL;
 			auth = client.headers.Authorization;
 			const deadline = Date.now() + 30_000;
+			let ready = false;
 			while (Date.now() < deadline) {
 				try {
 					const r = await fetch(`${httpURL}/RateCounter/`, {
 						headers: { Authorization: auth },
 						signal: AbortSignal.timeout(3_000),
 					});
-					if (r.status !== 503) break;
+					if (r.status !== 503) {
+						ready = true;
+						break;
+					}
 				} catch {
 					/* not ready */
 				}
 				await sleep(200);
 			}
+			if (!ready) throw new Error('RateCounter never left 503 within the 30s readiness deadline');
 		});
 
 		after(async () => {

--- a/integrationTests/resources/ttl-rate-limiter-convergence.test.ts
+++ b/integrationTests/resources/ttl-rate-limiter-convergence.test.ts
@@ -122,11 +122,15 @@ suite(
 						const results = await Promise.all(Array.from({ length: HITS }, () => increment(id)));
 						bursting = false;
 						await reader;
-						return { id, acked: results.filter((s) => s === 200).length };
+						return {
+							id,
+							acked: results.filter((s) => s === 200).length,
+							errs: results.filter((s) => s === 'error').length,
+						};
 					})
 				);
 
-				for (const { id, acked } of perWindow) {
+				for (const { id, acked, errs } of perWindow) {
 					// a window whose burst was wholly rejected measures nothing
 					if (acked === 0) {
 						inconclusive++;
@@ -137,13 +141,15 @@ suite(
 						inconclusive++;
 						continue;
 					}
-					if (first.hits === acked) {
+					// a timed-out request may still have been applied, so anything up to acked+errs is
+					// exact-or-explained; only beyond that is a double-apply
+					if (first.hits! >= acked && first.hits! <= acked + errs) {
 						clean++;
 						continue;
 					}
-					if (first.hits! > acked) {
+					if (first.hits! > acked + errs) {
 						over++;
-						anomalyLogs.push(`${id}: OVER first=${first.hits} acked=${acked}`);
+						anomalyLogs.push(`${id}: OVER first=${first.hits} acked=${acked} errs=${errs}`);
 						continue;
 					}
 					const seen: (number | string)[] = [first.hits!];
@@ -164,9 +170,9 @@ suite(
 						}
 						seen.push(g.hits!);
 						finalHits = g.hits;
-						if (g.hits === acked) break;
+						if (g.hits! >= acked) break;
 					}
-					if (finalHits === acked) {
+					if (finalHits! >= acked && finalHits! <= acked + errs) {
 						convergedLate++;
 						anomalyLogs.push(`${id}: CONVERGED_LATE acked=${acked} seen=[${seen.join(',')}]`);
 					} else if (expired) {

--- a/integrationTests/resources/ttl-rate-limiter-convergence.test.ts
+++ b/integrationTests/resources/ttl-rate-limiter-convergence.test.ts
@@ -175,6 +175,11 @@ suite(
 					if (finalHits! >= acked && finalHits! <= acked + errs) {
 						convergedLate++;
 						anomalyLogs.push(`${id}: CONVERGED_LATE acked=${acked} seen=[${seen.join(',')}]`);
+					} else if (finalHits! > acked + errs) {
+						over++;
+						anomalyLogs.push(
+							`${id}: OVER-LATE final=${finalHits} acked=${acked} errs=${errs} seen=[${seen.join(',')}]`
+						);
 					} else if (expired) {
 						inconclusive++;
 						anomalyLogs.push(`${id}: EXPIRED-WHILE-SHORT acked=${acked} seen=[${seen.join(',')}]`);

--- a/integrationTests/resources/ttl-rate-limiter-convergence.test.ts
+++ b/integrationTests/resources/ttl-rate-limiter-convergence.test.ts
@@ -1,0 +1,200 @@
+/**
+ * QA-431 companion — convergence classification for the multi-worker counter stress.
+ *
+ * Amplifies ttl-rate-limiter-concurrent.test.ts subtest (5) (same fixture: 500ms-TTL counter,
+ * 4 workers) and adds the two ingredients that made the lost-count defect reproducible: GET
+ * pressure DURING each burst (cold reads re-seed the VerificationTable, which is what let a
+ * stale cached value be vouched for after a resequenced merge reused a version), and, for any
+ * window that reads back short, polling within the TTL window to classify the anomaly:
+ *   CONVERGED_LATE — reached acked on a later read: the first read raced still-landing merges.
+ *   STUCK_SHORT    — never reached acked before expiry: a durably lost increment (DEFECT).
+ * Under 4-CPU-constrained runners the unfixed defect produced 3-15 STUCK_SHORT windows per 900;
+ * see the fix PR for the full mechanism (VERSION_REUSED / unvouchable sentinel / uncachedRead).
+ */
+
+import { suite, test, before, after } from 'node:test';
+import { ok } from 'node:assert';
+import { resolve } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+// @ts-expect-error utils/client.mjs has no type declarations
+import { createApiClient } from '../apiTests/utils/client.mjs';
+
+const FIXTURE_PATH = resolve(import.meta.dirname, 'ttl-rate-limiter-concurrent');
+const WORKERS = 4;
+const ROUNDS = 10;
+const WINDOWS = 10;
+const HITS = 50;
+
+const skipSuite = process.platform === 'win32' || process.env.HARPER_RUNTIME === 'bun';
+
+suite(
+	`QA-431 convergence [${ROUNDS} rounds × ${WINDOWS} windows × ${HITS} hits, ${WORKERS} workers]`,
+	{ skip: skipSuite },
+	(ctx: ContextWithHarper) => {
+		let httpURL: string;
+		let auth: string;
+
+		before(async () => {
+			await setupHarperWithFixture(ctx, FIXTURE_PATH, {
+				config: { threads: { count: WORKERS } },
+				env: {},
+			});
+			const client = createApiClient(ctx.harper);
+			httpURL = ctx.harper.httpURL;
+			auth = client.headers.Authorization;
+			const deadline = Date.now() + 30_000;
+			while (Date.now() < deadline) {
+				try {
+					const r = await fetch(`${httpURL}/RateCounter/`, {
+						headers: { Authorization: auth },
+						signal: AbortSignal.timeout(3_000),
+					});
+					if (r.status !== 503) break;
+				} catch {
+					/* not ready */
+				}
+				await sleep(200);
+			}
+		});
+
+		after(async () => {
+			await teardownHarper(ctx);
+		});
+
+		function hdrs() {
+			return { 'Content-Type': 'application/json', 'Authorization': auth };
+		}
+
+		async function increment(id: string): Promise<number | 'error'> {
+			try {
+				const r = await fetch(`${httpURL}/RateIncrement/`, {
+					method: 'POST',
+					headers: hdrs(),
+					body: JSON.stringify({ id }),
+					signal: AbortSignal.timeout(6_000),
+				});
+				return r.status;
+			} catch {
+				return 'error';
+			}
+		}
+
+		async function put(id: string, hits: number): Promise<number | 'error'> {
+			try {
+				const r = await fetch(`${httpURL}/RateCounter/${id}`, {
+					method: 'PUT',
+					headers: hdrs(),
+					body: JSON.stringify({ id, hits }),
+					signal: AbortSignal.timeout(5_000),
+				});
+				return r.status;
+			} catch {
+				return 'error';
+			}
+		}
+
+		async function getHits(id: string): Promise<{ status: number | 'error'; hits: number | null }> {
+			try {
+				const r = await fetch(`${httpURL}/RateCounter/${id}`, {
+					headers: { Authorization: auth },
+					signal: AbortSignal.timeout(5_000),
+				});
+				if (r.status !== 200) return { status: r.status, hits: null };
+				const body = await r.json();
+				return { status: 200, hits: Number(body?.hits ?? -1) };
+			} catch {
+				return { status: 'error', hits: null };
+			}
+		}
+
+		test('concurrent bursts with in-burst GET pressure converge to exact counts', async () => {
+			let clean = 0;
+			let convergedLate = 0;
+			let stuckShort = 0;
+			let over = 0;
+			let inconclusive = 0;
+			const anomalyLogs: string[] = [];
+
+			for (let round = 0; round < ROUNDS; round++) {
+				const ids = Array.from({ length: WINDOWS }, (_, w) => `r${round}w${w}`);
+				await Promise.all(ids.map((id) => put(id, 0)));
+
+				const perWindow = await Promise.all(
+					ids.map(async (id) => {
+						let bursting = true;
+						const reader = (async () => {
+							while (bursting) await getHits(id);
+						})();
+						const results = await Promise.all(Array.from({ length: HITS }, () => increment(id)));
+						bursting = false;
+						await reader;
+						return { id, acked: results.filter((s) => s === 200).length };
+					})
+				);
+
+				for (const { id, acked } of perWindow) {
+					const first = await getHits(id);
+					if (first.status !== 200) {
+						inconclusive++;
+						continue;
+					}
+					if (first.hits === acked) {
+						clean++;
+						continue;
+					}
+					if (first.hits! > acked) {
+						over++;
+						anomalyLogs.push(`${id}: OVER first=${first.hits} acked=${acked}`);
+						continue;
+					}
+					const seen: (number | string)[] = [first.hits!];
+					let finalHits: number | null = first.hits;
+					let expired = false;
+					const deadline = Date.now() + 400;
+					while (Date.now() < deadline) {
+						await sleep(20);
+						const g = await getHits(id);
+						if (g.status === 404) {
+							expired = true;
+							seen.push('404');
+							break;
+						}
+						if (g.status !== 200) {
+							seen.push(String(g.status));
+							continue;
+						}
+						seen.push(g.hits!);
+						finalHits = g.hits;
+						if (g.hits === acked) break;
+					}
+					if (finalHits === acked) {
+						convergedLate++;
+						anomalyLogs.push(`${id}: CONVERGED_LATE acked=${acked} seen=[${seen.join(',')}]`);
+					} else if (expired) {
+						inconclusive++;
+						anomalyLogs.push(`${id}: EXPIRED-WHILE-SHORT acked=${acked} seen=[${seen.join(',')}]`);
+					} else {
+						stuckShort++;
+						anomalyLogs.push(`${id}: STUCK_SHORT final=${finalHits} acked=${acked} seen=[${seen.join(',')}]`);
+					}
+				}
+				// let the round's records expire so rounds stay independent
+				await sleep(700);
+			}
+
+			console.log(
+				`\n[QA-431-CONVERGENCE] ${ROUNDS}×${WINDOWS}×${HITS} (${WORKERS} workers)\n` +
+					`  clean=${clean} converged-late=${convergedLate} stuck-short=${stuckShort} over=${over} inconclusive=${inconclusive}\n` +
+					(anomalyLogs.length ? `  ${anomalyLogs.join('\n  ')}` : '  (no anomalies)')
+			);
+
+			ok(stuckShort === 0, `QA-431-CONVERGENCE: ${stuckShort} window(s) with durably lost increments`);
+			ok(over === 0, `QA-431-CONVERGENCE: ${over} window(s) over-counted (double-apply)`);
+			ok(
+				clean + convergedLate + stuckShort + over >= (ROUNDS * WINDOWS) / 2,
+				`QA-431-CONVERGENCE: only ${clean + convergedLate + stuckShort + over}/${ROUNDS * WINDOWS} windows measurable`
+			);
+		});
+	}
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2661,15 +2661,6 @@
 				"node": "^22.18.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@harperfast/rocksdb-js/node_modules/msgpackr": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.6.tgz",
-			"integrity": "sha512-plGul/tqjt9vqWFR9zyqyLZls6gb5KTLvnsRO2B9+TZ8tNiXiVI/CR8LiDWlAX4IUeVkQ9gsmzKA6voC2QOciw==",
-			"license": "MIT",
-			"optionalDependencies": {
-				"msgpackr-extract": "^3.0.4"
-			}
-		},
 		"node_modules/@harperfast/skills": {
 			"version": "1.12.2",
 			"resolved": "https://registry.npmjs.org/@harperfast/skills/-/skills-1.12.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2661,6 +2661,15 @@
 				"node": "^22.18.0 || >=24.0.0"
 			}
 		},
+		"node_modules/@harperfast/rocksdb-js/node_modules/msgpackr": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.6.tgz",
+			"integrity": "sha512-plGul/tqjt9vqWFR9zyqyLZls6gb5KTLvnsRO2B9+TZ8tNiXiVI/CR8LiDWlAX4IUeVkQ9gsmzKA6voC2QOciw==",
+			"license": "MIT",
+			"optionalDependencies": {
+				"msgpackr-extract": "^3.0.4"
+			}
+		},
 		"node_modules/@harperfast/skills": {
 			"version": "1.12.2",
 			"resolved": "https://registry.npmjs.org/@harperfast/skills/-/skills-1.12.2.tgz",

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -372,12 +372,12 @@ export type TransactionWrite = {
 	// this settles (fire-and-forget from the if-branch), so Table.save()'s lock-writable path awaits
 	// it to ensure the write is durable before resolving to the caller.
 	innerCommit?: MaybePromise<CommitResolution>;
-	// this round stored its record under a version it reused rather than advanced (a resequenced
-	// out-of-order fold); the commit success path parks the unvouchable sentinel for the key. Reset
-	// per commit-handler round, like stagedEntry.
+	// this round stored under a reused version (a resequenced fold), so the commit success path
+	// parks the unvouchable sentinel for the key. Reset per commit-handler round, like stagedEntry.
 	storedReusedVersion?: boolean;
-	// a bulk base-copy snapshot row: keeps its pre-read base instead of the commit-time reload
-	isCopyApply?: boolean;
+	// the commit derives stored state (folds, index diffs, residency) from its base entry, so
+	// save() must reload that base through the committing transaction's snapshot
+	reloadCommitBase?: boolean;
 };
 
 export function getAppliedWriteVersion(recordVersion: number | undefined, txnLogKey: number): number {
@@ -819,16 +819,34 @@ export class DatabaseTransaction implements Transaction {
 	 * under a reused version (see VERSION_REUSED). The writer parks it because no reader can be
 	 * relied on to: with every worker's cache warm, no read ever decodes the flagged record, and
 	 * the native soft-miss re-confirm keeps vouching the reused version off the stored record.
+	 * Runs after durability, so nothing here may disturb the commit's cleanup.
 	 */
 	private parkReusedVersionSentinels(): void {
-		for (const write of this.writes) {
-			if (write?.storedReusedVersion && !write.skipped && typeof write.store.parkUnvouchable === 'function') {
-				if (!write.store.parkUnvouchable(write.key)) {
-					// A concurrent write's intent holds the slot; if that write aborts, the key stays
-					// vouch-suspect until a decoding read re-parks — logged so the hole is detectable.
-					harperLogger.debug?.('unvouchable sentinel not parked, slot held by a concurrent write', write.key);
+		try {
+			for (const write of this.writes) {
+				if (write?.storedReusedVersion && !write.skipped && typeof write.store.parkUnvouchable === 'function') {
+					const { store, key } = write;
+					if (!store.parkUnvouchable(key)) {
+						// A concurrent write's intent holds the slot; if that write commits, its own cycle
+						// resolves the key, but if it aborts nothing re-parks — warm peers would keep being
+						// vouched the pre-merge value. Retry once the intent has had time to clear, and
+						// escalate to warn: a still-refused park is a silent stale-read hole in production.
+						setTimeout(() => {
+							try {
+								if (!store.parkUnvouchable(key)) {
+									harperLogger.warn?.(
+										`unvouchable sentinel could not be parked for ${store.path ?? ''} key ${String(key)}; warm readers may serve a stale value until the next write to it`
+									);
+								}
+							} catch {
+								/* store closing; nothing to protect */
+							}
+						}, 10).unref?.();
+					}
 				}
 			}
+		} catch (parkError) {
+			harperLogger.debug?.('parking unvouchable sentinels failed', parkError);
 		}
 	}
 
@@ -1063,18 +1081,14 @@ export class DatabaseTransaction implements Transaction {
 		// flags so an ordinary write never reads the property (harper#2412).
 		const writeVersion =
 			this.sourceApply || this.isReplay ? getAppliedWriteVersion(operation.recordVersion, txnTime) : txnTime;
-		// A record write's base must be what this transaction's snapshot holds, not a value the
-		// resource phase read through the cross-worker cache vouch, which can be stale when a
-		// resequenced write reused a version: an incremental update folds CRDT ops and unmentioned
-		// fields from the base, and even a full put diffs indices, blob retention, and residency
-		// against it. Reload with uncachedRead so the vouch is never consulted; a write landing
-		// between this snapshot and commit still surfaces as a conflict and retries. Bulk
-		// copy-apply rows and crash-recovery replays keep their pre-read base (one read per row,
-		// as before): their convergence contract is the post-copy/replay pass, not this reload.
+		// The commit base must come from this transaction's snapshot, never the cross-worker cache
+		// vouch (stale when a resequenced write reused a version); a write landing between this
+		// snapshot and commit still surfaces as a conflict and retries. Replays keep their
+		// pre-read base — their convergence contract is the replay pass itself.
 		if (
 			reloadEntry ||
 			operation.entry === undefined ||
-			(operation.fullUpdate !== undefined && !operation.saved && !operation.isCopyApply && !this.isReplay)
+			(operation.reloadCommitBase && !operation.saved && !this.isReplay)
 		) {
 			operation.entry = operation.store.getEntry(operation.key, { transaction, uncachedRead: true });
 		}

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -1048,8 +1048,8 @@ export class DatabaseTransaction implements Transaction {
 		// their pre-read base — their convergence contract is the replay pass itself.
 		const reloadsCommitBase = operation.reloadCommitBase && !operation.saved && !this.isReplay;
 		if (reloadEntry || operation.entry === undefined || reloadsCommitBase) {
-			// the other two triggers are pre-existing reads of kinds that keep their own conflict
-			// semantics, so only a base that feeds stored state gives up the cache vouch
+			// a cold read for a kind that keeps its own conflict semantics is the one case that can
+			// still take the vouch fast path; a state-deriving base or a conflict reload cannot
 			const uncachedRead = !!operation.reloadCommitBase || reloadEntry;
 			operation.entry = operation.store.getEntry(operation.key, { transaction, uncachedRead });
 		}

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -1049,8 +1049,9 @@ export class DatabaseTransaction implements Transaction {
 		const reloadsCommitBase = operation.reloadCommitBase && !operation.saved && !this.isReplay;
 		if (reloadEntry || operation.entry === undefined || reloadsCommitBase) {
 			// a cold read for a kind that keeps its own conflict semantics is the one case that can
-			// still take the vouch fast path; a state-deriving base or a conflict reload cannot
-			const uncachedRead = !!operation.reloadCommitBase || reloadEntry;
+			// still take the vouch fast path; a state-deriving base or a conflict reload cannot —
+			// except during replay, whose cold reads keep the vouch fast path like any other read
+			const uncachedRead = (!!operation.reloadCommitBase && !this.isReplay) || reloadEntry;
 			operation.entry = operation.store.getEntry(operation.key, { transaction, uncachedRead });
 		}
 		if (!operation.saved) {

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -372,9 +372,6 @@ export type TransactionWrite = {
 	// this settles (fire-and-forget from the if-branch), so Table.save()'s lock-writable path awaits
 	// it to ensure the write is durable before resolving to the caller.
 	innerCommit?: MaybePromise<CommitResolution>;
-	// this round stored under a reused version (a resequenced fold), so the commit success path
-	// parks the unvouchable sentinel for the key. Reset per commit-handler round, like stagedEntry.
-	storedReusedVersion?: boolean;
 	// the commit derives stored state (folds, index diffs, residency) from its base entry, so
 	// save() must reload that base through the committing transaction's snapshot
 	reloadCommitBase?: boolean;
@@ -812,29 +809,6 @@ export class DatabaseTransaction implements Transaction {
 		for (const write of this.writes) if (write?.stagedIn === this) write.stagedIn = undefined;
 		this.writes = [];
 		this.writesByKey = undefined;
-	}
-
-	/**
-	 * After a successful commit, park the unvouchable sentinel for every key this batch stored
-	 * under a reused version (see VERSION_REUSED). The writer parks it because no reader can be
-	 * relied on to: with every worker's cache warm, no read ever decodes the flagged record, and
-	 * the native soft-miss re-confirm keeps vouching the reused version off the stored record.
-	 * Runs after durability, so nothing here may disturb the commit's cleanup.
-	 */
-	private parkReusedVersionSentinels(): void {
-		try {
-			for (const write of this.writes) {
-				if (
-					write?.storedReusedVersion &&
-					!write.skipped &&
-					typeof write.store.parkUnvouchableWithRetry === 'function'
-				) {
-					write.store.parkUnvouchableWithRetry(write.key);
-				}
-			}
-		} catch (parkError) {
-			harperLogger.debug?.('parking unvouchable sentinels failed', parkError);
-		}
 	}
 
 	/**
@@ -1362,7 +1336,6 @@ export class DatabaseTransaction implements Transaction {
 									cleanupUnusedBlobs(write.savedBlobs, collectRetainedFileIds(write.store.getEntry(write.key)?.value));
 							}
 							if (this.recordLocks) this.noteCommittedLockVersions();
-							this.parkReusedVersionSentinels();
 							// now reset transactions tracking; this transaction be reused and committed again
 							this.retries = 0; // reset per-native-transaction retry counter so a reused DatabaseTransaction's next batch starts fresh
 							this.clearWrites();
@@ -1501,7 +1474,6 @@ export class DatabaseTransaction implements Transaction {
 						cleanupUnusedBlobs(write.savedBlobs, collectRetainedFileIds(write.store.getEntry(write.key)?.value));
 				}
 				if (this.recordLocks) this.noteCommittedLockVersions();
-				this.parkReusedVersionSentinels();
 				this.clearWrites();
 				this.releaseRecordLocks();
 				if (options.doneWriting) this.endScopeOwnership();

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -376,6 +376,8 @@ export type TransactionWrite = {
 	// out-of-order fold); the commit success path parks the unvouchable sentinel for the key. Reset
 	// per commit-handler round, like stagedEntry.
 	storedReusedVersion?: boolean;
+	// a bulk base-copy snapshot row: keeps its pre-read base instead of the commit-time reload
+	isCopyApply?: boolean;
 };
 
 export function getAppliedWriteVersion(recordVersion: number | undefined, txnLogKey: number): number {
@@ -814,18 +816,18 @@ export class DatabaseTransaction implements Transaction {
 
 	/**
 	 * After a successful commit, park the unvouchable sentinel for every key this batch stored
-	 * under a reused version (see VERSION_REUSED): from this moment the key's version identifies
-	 * two stored values, and a worker still holding the pre-merge one must not be told it is
-	 * fresh. The writer parks it — a reader-side park leaves a window in which the native layer
-	 * re-confirms the reused version off the stored record and republishes it, and with every
-	 * worker holding a warm cache no reader ever decodes the record to discover the flag. A slot
-	 * that cannot take the sentinel (a newer write's intent holds it) is left alone: that write's
-	 * own cycle supersedes the sentinel either way.
+	 * under a reused version (see VERSION_REUSED). The writer parks it because no reader can be
+	 * relied on to: with every worker's cache warm, no read ever decodes the flagged record, and
+	 * the native soft-miss re-confirm keeps vouching the reused version off the stored record.
 	 */
 	private parkReusedVersionSentinels(): void {
 		for (const write of this.writes) {
 			if (write?.storedReusedVersion && !write.skipped && typeof write.store.parkUnvouchable === 'function') {
-				write.store.parkUnvouchable(write.key);
+				if (!write.store.parkUnvouchable(write.key)) {
+					// A concurrent write's intent holds the slot; if that write aborts, the key stays
+					// vouch-suspect until a decoding read re-parks — logged so the hole is detectable.
+					harperLogger.debug?.('unvouchable sentinel not parked, slot held by a concurrent write', write.key);
+				}
 			}
 		}
 	}
@@ -1061,13 +1063,19 @@ export class DatabaseTransaction implements Transaction {
 		// flags so an ordinary write never reads the property (harper#2412).
 		const writeVersion =
 			this.sourceApply || this.isReplay ? getAppliedWriteVersion(operation.recordVersion, txnTime) : txnTime;
-		// An incremental (non-full) update stores a record derived from its base — CRDT folds and
-		// unmentioned fields both come from it — so the base must be what this transaction's
-		// snapshot holds, not a value the resource phase read through the cross-worker cache
-		// vouch (which can be stale when a resequenced write reused a version). Reload it here,
-		// and on every retry round, with uncachedRead so the vouch is never consulted; a write
-		// that lands between this snapshot and commit still surfaces as a conflict and retries.
-		if (reloadEntry || operation.entry === undefined || (operation.fullUpdate === false && !operation.saved)) {
+		// A record write's base must be what this transaction's snapshot holds, not a value the
+		// resource phase read through the cross-worker cache vouch, which can be stale when a
+		// resequenced write reused a version: an incremental update folds CRDT ops and unmentioned
+		// fields from the base, and even a full put diffs indices, blob retention, and residency
+		// against it. Reload with uncachedRead so the vouch is never consulted; a write landing
+		// between this snapshot and commit still surfaces as a conflict and retries. Bulk
+		// copy-apply rows and crash-recovery replays keep their pre-read base (one read per row,
+		// as before): their convergence contract is the post-copy/replay pass, not this reload.
+		if (
+			reloadEntry ||
+			operation.entry === undefined ||
+			(operation.fullUpdate !== undefined && !operation.saved && !operation.isCopyApply && !this.isReplay)
+		) {
 			operation.entry = operation.store.getEntry(operation.key, { transaction, uncachedRead: true });
 		}
 		if (!operation.saved) {

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -1046,8 +1046,9 @@ export class DatabaseTransaction implements Transaction {
 		// cross-worker cache vouch (stale when a resequenced write reused a version). That closes the
 		// lost-update window only when this transaction holds a snapshot to validate the later Put
 		// against; a snapshot-free transaction (this.snapshotFree, after a mid-scope-commit rotation)
-		// still narrows it to the read-to-put span, but does not close it — see PR discussion. Replays
-		// keep their pre-read base — their convergence contract is the replay pass itself.
+		// has no snapshot for rocksdb-js to validate the Put against, so it only narrows the window to
+		// the read-to-put span rather than closing it (open follow-up, tracked in the PR description).
+		// Replays keep their pre-read base — their convergence contract is the replay pass itself.
 		const reloadsCommitBase = operation.reloadCommitBase && !operation.saved && !this.isReplay;
 		if (reloadEntry || operation.entry === undefined || reloadsCommitBase) {
 			const uncachedRead = (!!operation.reloadCommitBase && !this.isReplay) || reloadEntry;

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -1043,14 +1043,13 @@ export class DatabaseTransaction implements Transaction {
 		const writeVersion =
 			this.sourceApply || this.isReplay ? getAppliedWriteVersion(operation.recordVersion, txnTime) : txnTime;
 		// A base that feeds stored state must come from this transaction's snapshot, never the
-		// cross-worker cache vouch (stale when a resequenced write reused a version); a write landing
-		// between this snapshot and commit still surfaces as a conflict and retries. Replays keep
-		// their pre-read base — their convergence contract is the replay pass itself.
+		// cross-worker cache vouch (stale when a resequenced write reused a version). That closes the
+		// lost-update window only when this transaction holds a snapshot to validate the later Put
+		// against; a snapshot-free transaction (this.snapshotFree, after a mid-scope-commit rotation)
+		// still narrows it to the read-to-put span, but does not close it — see PR discussion. Replays
+		// keep their pre-read base — their convergence contract is the replay pass itself.
 		const reloadsCommitBase = operation.reloadCommitBase && !operation.saved && !this.isReplay;
 		if (reloadEntry || operation.entry === undefined || reloadsCommitBase) {
-			// a cold read for a kind that keeps its own conflict semantics is the one case that can
-			// still take the vouch fast path; a state-deriving base or a conflict reload cannot —
-			// except during replay, whose cold reads keep the vouch fast path like any other read
 			const uncachedRead = (!!operation.reloadCommitBase && !this.isReplay) || reloadEntry;
 			operation.entry = operation.store.getEntry(operation.key, { transaction, uncachedRead });
 		}

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -372,6 +372,10 @@ export type TransactionWrite = {
 	// this settles (fire-and-forget from the if-branch), so Table.save()'s lock-writable path awaits
 	// it to ensure the write is durable before resolving to the caller.
 	innerCommit?: MaybePromise<CommitResolution>;
+	// this round stored its record under a version it reused rather than advanced (a resequenced
+	// out-of-order fold); the commit success path parks the unvouchable sentinel for the key. Reset
+	// per commit-handler round, like stagedEntry.
+	storedReusedVersion?: boolean;
 };
 
 export function getAppliedWriteVersion(recordVersion: number | undefined, txnLogKey: number): number {
@@ -809,6 +813,24 @@ export class DatabaseTransaction implements Transaction {
 	}
 
 	/**
+	 * After a successful commit, park the unvouchable sentinel for every key this batch stored
+	 * under a reused version (see VERSION_REUSED): from this moment the key's version identifies
+	 * two stored values, and a worker still holding the pre-merge one must not be told it is
+	 * fresh. The writer parks it — a reader-side park leaves a window in which the native layer
+	 * re-confirms the reused version off the stored record and republishes it, and with every
+	 * worker holding a warm cache no reader ever decodes the record to discover the flag. A slot
+	 * that cannot take the sentinel (a newer write's intent holds it) is left alone: that write's
+	 * own cycle supersedes the sentinel either way.
+	 */
+	private parkReusedVersionSentinels(): void {
+		for (const write of this.writes) {
+			if (write?.storedReusedVersion && !write.skipped && typeof write.store.parkUnvouchable === 'function') {
+				write.store.parkUnvouchable(write.key);
+			}
+		}
+	}
+
+	/**
 	 * Drop this transaction's back-reference from its context once completed (commit or abort),
 	 * so a long-lived context (e.g. an MQTT subscription context held open for the life of a
 	 * suspended delivery loop) doesn't keep pinning a finished transaction in memory. Guarded by
@@ -1039,8 +1061,14 @@ export class DatabaseTransaction implements Transaction {
 		// flags so an ordinary write never reads the property (harper#2412).
 		const writeVersion =
 			this.sourceApply || this.isReplay ? getAppliedWriteVersion(operation.recordVersion, txnTime) : txnTime;
-		if (reloadEntry || operation.entry === undefined) {
-			operation.entry = operation.store.getEntry(operation.key, { transaction });
+		// An incremental (non-full) update stores a record derived from its base — CRDT folds and
+		// unmentioned fields both come from it — so the base must be what this transaction's
+		// snapshot holds, not a value the resource phase read through the cross-worker cache
+		// vouch (which can be stale when a resequenced write reused a version). Reload it here,
+		// and on every retry round, with uncachedRead so the vouch is never consulted; a write
+		// that lands between this snapshot and commit still surfaces as a conflict and retries.
+		if (reloadEntry || operation.entry === undefined || (operation.fullUpdate === false && !operation.saved)) {
+			operation.entry = operation.store.getEntry(operation.key, { transaction, uncachedRead: true });
 		}
 		if (!operation.saved) {
 			operation.saved = true;
@@ -1325,6 +1353,7 @@ export class DatabaseTransaction implements Transaction {
 									cleanupUnusedBlobs(write.savedBlobs, collectRetainedFileIds(write.store.getEntry(write.key)?.value));
 							}
 							if (this.recordLocks) this.noteCommittedLockVersions();
+							this.parkReusedVersionSentinels();
 							// now reset transactions tracking; this transaction be reused and committed again
 							this.retries = 0; // reset per-native-transaction retry counter so a reused DatabaseTransaction's next batch starts fresh
 							this.clearWrites();
@@ -1463,6 +1492,7 @@ export class DatabaseTransaction implements Transaction {
 						cleanupUnusedBlobs(write.savedBlobs, collectRetainedFileIds(write.store.getEntry(write.key)?.value));
 				}
 				if (this.recordLocks) this.noteCommittedLockVersions();
+				this.parkReusedVersionSentinels();
 				this.clearWrites();
 				this.releaseRecordLocks();
 				if (options.doneWriting) this.endScopeOwnership();

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -824,25 +824,12 @@ export class DatabaseTransaction implements Transaction {
 	private parkReusedVersionSentinels(): void {
 		try {
 			for (const write of this.writes) {
-				if (write?.storedReusedVersion && !write.skipped && typeof write.store.parkUnvouchable === 'function') {
-					const { store, key } = write;
-					if (!store.parkUnvouchable(key)) {
-						// A concurrent write's intent holds the slot; if that write commits, its own cycle
-						// resolves the key, but if it aborts nothing re-parks — warm peers would keep being
-						// vouched the pre-merge value. Retry once the intent has had time to clear, and
-						// escalate to warn: a still-refused park is a silent stale-read hole in production.
-						setTimeout(() => {
-							try {
-								if (!store.parkUnvouchable(key)) {
-									harperLogger.warn?.(
-										`unvouchable sentinel could not be parked for ${store.path ?? ''} key ${String(key)}; warm readers may serve a stale value until the next write to it`
-									);
-								}
-							} catch {
-								/* store closing; nothing to protect */
-							}
-						}, 10).unref?.();
-					}
+				if (
+					write?.storedReusedVersion &&
+					!write.skipped &&
+					typeof write.store.parkUnvouchableWithRetry === 'function'
+				) {
+					write.store.parkUnvouchableWithRetry(write.key);
 				}
 			}
 		} catch (parkError) {

--- a/resources/DatabaseTransaction.ts
+++ b/resources/DatabaseTransaction.ts
@@ -1042,16 +1042,16 @@ export class DatabaseTransaction implements Transaction {
 		// flags so an ordinary write never reads the property (harper#2412).
 		const writeVersion =
 			this.sourceApply || this.isReplay ? getAppliedWriteVersion(operation.recordVersion, txnTime) : txnTime;
-		// The commit base must come from this transaction's snapshot, never the cross-worker cache
-		// vouch (stale when a resequenced write reused a version); a write landing between this
-		// snapshot and commit still surfaces as a conflict and retries. Replays keep their
-		// pre-read base — their convergence contract is the replay pass itself.
-		if (
-			reloadEntry ||
-			operation.entry === undefined ||
-			(operation.reloadCommitBase && !operation.saved && !this.isReplay)
-		) {
-			operation.entry = operation.store.getEntry(operation.key, { transaction, uncachedRead: true });
+		// A base that feeds stored state must come from this transaction's snapshot, never the
+		// cross-worker cache vouch (stale when a resequenced write reused a version); a write landing
+		// between this snapshot and commit still surfaces as a conflict and retries. Replays keep
+		// their pre-read base — their convergence contract is the replay pass itself.
+		const reloadsCommitBase = operation.reloadCommitBase && !operation.saved && !this.isReplay;
+		if (reloadEntry || operation.entry === undefined || reloadsCommitBase) {
+			// the other two triggers are pre-existing reads of kinds that keep their own conflict
+			// semantics, so only a base that feeds stored state gives up the cache vouch
+			const uncachedRead = !!operation.reloadCommitBase || reloadEntry;
+			operation.entry = operation.store.getEntry(operation.key, { transaction, uncachedRead });
 		}
 		if (!operation.saved) {
 			operation.saved = true;

--- a/resources/PrimaryRocksDatabase.ts
+++ b/resources/PrimaryRocksDatabase.ts
@@ -121,12 +121,9 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 	 */
 	getEntry(id: any, options?: any): any {
 		this.readCount++;
-		// A commit-path base read must reflect the caller's transaction snapshot. The cache-vouch
-		// fast path answers a different question — "is this worker's cached value the latest
-		// committed?" — and answers even that wrongly for a version a resequenced write reused
-		// (one version, two stored values), so a fold on a vouched base can silently drop the
-		// concurrent update it folded over. Read the store directly and leave the cache and the
-		// VerificationTable untouched (their latest-committed semantics don't fit a snapshot read).
+		// Commit-path base reads must reflect the caller's transaction snapshot; the cache vouch
+		// answers "latest committed" — the wrong question there, and wrong outright for a version a
+		// resequenced write reused — so read the store directly, touching neither cache nor VT.
 		if (options?.uncachedRead) {
 			const raw = options.async ? super.get(id, options) : super.getSync(id, options);
 			return when(raw, (result) => this.#processEntry(result, id));
@@ -144,13 +141,10 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 				? (entryMap.get(cachedValue) as Entry | undefined)
 				: undefined;
 		const expectedVersion = cached?.version;
-		// The parked sentinel is the cross-worker "this key's version must not be vouched for" signal,
-		// and it has to be consulted BEFORE the native get on BOTH the cold and the warm path. Cold,
-		// because the native get would otherwise seed the slot with the version it reads. Warm, because
-		// on a VT miss the native layer re-confirms freshness against the version stored in the record
-		// itself ("soft miss") and republishes it — for a record whose stored version was reused, that
-		// re-vouches a version two different values share, and overwrites the sentinel, so a worker
-		// still holding the pre-merge value would keep being told it is fresh indefinitely.
+		// The sentinel must be consulted before the native get on cold AND warm paths: a cold get
+		// would seed the slot with the version it reads, and a warm get's soft-miss re-confirms
+		// freshness off the stored record's version and republishes it — for a reused version that
+		// overwrites the sentinel and vouches a version two different values share.
 		const unvouchable = cache !== undefined && this.verifyVersion(id, VERSION_UNVOUCHABLE);
 
 		// Build get options, always merging with caller options to preserve
@@ -180,11 +174,8 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 				return undefined;
 			}
 			if (entry.version != null && cache) {
-				// Checked before the cacheability gate below: a flagged record with a null or primitive
-				// value is just as unvouchable. Normally the slot already holds the sentinel from the
-				// write; re-park it for a record flagged before this shipped, or one whose slot a read
-				// republished. A store that cannot take it (closing, dropped) must not turn a completed
-				// read into a failed one — not caching is the safe outcome either way.
+				// Checked ahead of the cacheability gate: a flagged record with a null or primitive
+				// value is just as unvouchable. The re-park covers a slot a read republished.
 				if (entry.metadataFlags & VERSION_REUSED || entry.version === VERSION_UNVOUCHABLE) {
 					if (!unvouchable) {
 						try {
@@ -195,10 +186,8 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 					}
 					if (cachedValue !== undefined) cache.delete(id);
 				} else if (unvouchable) {
-					// Clean record under a parked sentinel (a post-commit park raced a newer in-order
-					// write): stay uncached — restoring the real version from JS would be an unguarded
-					// force-set that can overwrite a concurrent write's slot state. The next write to the
-					// key clears the sentinel through its own write cycle and vouching resumes.
+					// Clean record under a parked sentinel: stay uncached — a JS-side restore would be an
+					// unguarded force-set racing concurrent writes; the key's next write clears the sentinel.
 					if (cachedValue !== undefined) cache.delete(id);
 				} else if (entry.value != null && typeof entry.value === 'object') {
 					// Only object values can be weakly cached and mapped back to their Entry;
@@ -214,15 +203,16 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 	/**
 	 * Park the unvouchable sentinel for a key whose stored version no longer identifies a single
 	 * value (see VERSION_REUSED). Called by the transaction's commit success path — the writer is
-	 * the only party that knows before any reader decodes the record. A slot that cannot take it
-	 * (a newer write's intent holds it) is left alone: that write's cycle supersedes it anyway.
+	 * the only party that knows before any reader decodes the record. Returns whether the sentinel
+	 * is in place; a slot held by a newer write's intent refuses it.
 	 */
-	parkUnvouchable(id: any): void {
+	parkUnvouchable(id: any): boolean {
 		try {
 			this.populateVersion(id, VERSION_UNVOUCHABLE);
 		} catch {
-			/* a reader that decodes the flagged record re-parks; never fail a completed commit */
+			/* never fail a completed commit; the verify below reports the miss */
 		}
+		return this.verifyVersion(id, VERSION_UNVOUCHABLE);
 	}
 
 	getSync(id: any, options?: any): any {

--- a/resources/PrimaryRocksDatabase.ts
+++ b/resources/PrimaryRocksDatabase.ts
@@ -3,14 +3,7 @@ import { RocksDatabase, type RocksDatabaseOptions, constants, type Store, Transa
 const FRESH_VERSION_FLAG = constants.FRESH_VERSION_FLAG;
 import { WeakLRUCache } from 'weak-lru-cache';
 import { when } from '../utility/when.ts';
-import { assignStoredFields, entryMap, METADATA, VERSION_REUSED, type Entry } from './RecordEncoder.ts';
-
-// Parked in a VerificationTable slot to mark a key unvouchable, since the VT has no invalidate call.
-// It doubles as the cross-worker signal that a key's version identifies more than one stored value:
-// once any worker has parked it, no other worker's read asks the native get to publish that version.
-// A timestamp ~285,000 years out — improbable rather than impossible, as write timestamps are
-// caller-supplied, so a record read back at exactly this version is never cached either.
-const VERSION_UNVOUCHABLE = Number.MAX_SAFE_INTEGER;
+import { assignStoredFields, entryMap, METADATA, VERSION_REUSED, VERSION_UNVOUCHABLE, type Entry } from './RecordEncoder.ts';
 
 /**
  * RocksDatabase subclass that owns all primary-store behaviour for Harper tables:
@@ -128,6 +121,16 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 	 */
 	getEntry(id: any, options?: any): any {
 		this.readCount++;
+		// A commit-path base read must reflect the caller's transaction snapshot. The cache-vouch
+		// fast path answers a different question — "is this worker's cached value the latest
+		// committed?" — and answers even that wrongly for a version a resequenced write reused
+		// (one version, two stored values), so a fold on a vouched base can silently drop the
+		// concurrent update it folded over. Read the store directly and leave the cache and the
+		// VerificationTable untouched (their latest-committed semantics don't fit a snapshot read).
+		if (options?.uncachedRead) {
+			const raw = options.async ? super.get(id, options) : super.getSync(id, options);
+			return when(raw, (result) => this.#processEntry(result, id));
+		}
 		const cache = this.#cache;
 		// The cache stores the record *value* (weakly, via setValue) rather than
 		// the Entry: a WeakRef-wrapped value lets the LRFU expirer release it once
@@ -141,24 +144,28 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 				? (entryMap.get(cachedValue) as Entry | undefined)
 				: undefined;
 		const expectedVersion = cached?.version;
-		// The native get publishes the version it read into the slot, so a key whose version must not be
-		// vouched for has to be recognised BEFORE the read; withdrawing afterwards leaves it published
-		// in between. The parked sentinel is what makes that recognisable across workers. Asked only on
-		// the path that is about to request publication, and which is paying for a store read anyway; a
-		// read that has a cached version skips the check and can publish once per worker per flag,
-		// since the read that finds the flag drops its cached value and so takes this path next time.
-		const unvouchable = cache !== undefined && expectedVersion == null && this.verifyVersion(id, VERSION_UNVOUCHABLE);
+		// The parked sentinel is the cross-worker "this key's version must not be vouched for" signal,
+		// and it has to be consulted BEFORE the native get on BOTH the cold and the warm path. Cold,
+		// because the native get would otherwise seed the slot with the version it reads. Warm, because
+		// on a VT miss the native layer re-confirms freshness against the version stored in the record
+		// itself ("soft miss") and republishes it — for a record whose stored version was reused, that
+		// re-vouches a version two different values share, and overwrites the sentinel, so a worker
+		// still holding the pre-merge value would keep being told it is fresh indefinitely.
+		const unvouchable = cache !== undefined && this.verifyVersion(id, VERSION_UNVOUCHABLE);
 
 		// Build get options, always merging with caller options to preserve
 		// transaction snapshot. Pass expectedVersion when cached:
 		//   VT hit  → native returns FRESH_VERSION_FLAG, no DB read
 		//   VT miss → native reads DB and auto-populates VT slot
 		// For cold reads (no cached version), use populateVersion flag so the
-		// native layer seeds the VT slot in the same call — unless the slot says unvouchable.
+		// native layer seeds the VT slot in the same call.
+		// An unvouchable key takes a plain decoding read: no version trust, no VT seeding.
 		let getOptions: any;
-		if (expectedVersion != null) {
+		if (unvouchable) {
+			getOptions = options;
+		} else if (expectedVersion != null) {
 			getOptions = options ? { ...options, expectedVersion } : { expectedVersion };
-		} else if (cache && !unvouchable) {
+		} else if (cache) {
 			getOptions = options ? { ...options, populateVersion: true } : { populateVersion: true };
 		} else {
 			getOptions = options;
@@ -187,6 +194,12 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 						}
 					}
 					if (cachedValue !== undefined) cache.delete(id);
+				} else if (unvouchable) {
+					// Clean record under a parked sentinel (a post-commit park raced a newer in-order
+					// write): stay uncached — restoring the real version from JS would be an unguarded
+					// force-set that can overwrite a concurrent write's slot state. The next write to the
+					// key clears the sentinel through its own write cycle and vouching resumes.
+					if (cachedValue !== undefined) cache.delete(id);
 				} else if (entry.value != null && typeof entry.value === 'object') {
 					// Only object values can be weakly cached and mapped back to their Entry;
 					// primitive/empty values fall through uncached (no fast path, still correct).
@@ -196,6 +209,20 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 			}
 			return entry;
 		});
+	}
+
+	/**
+	 * Park the unvouchable sentinel for a key whose stored version no longer identifies a single
+	 * value (see VERSION_REUSED). Called by the transaction's commit success path — the writer is
+	 * the only party that knows before any reader decodes the record. A slot that cannot take it
+	 * (a newer write's intent holds it) is left alone: that write's cycle supersedes it anyway.
+	 */
+	parkUnvouchable(id: any): void {
+		try {
+			this.populateVersion(id, VERSION_UNVOUCHABLE);
+		} catch {
+			/* a reader that decodes the flagged record re-parks; never fail a completed commit */
+		}
 	}
 
 	getSync(id: any, options?: any): any {

--- a/resources/PrimaryRocksDatabase.ts
+++ b/resources/PrimaryRocksDatabase.ts
@@ -125,8 +125,8 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 		// answers "latest committed" — the wrong question there, and wrong outright for a version a
 		// resequenced write reused — so read the store directly, touching neither cache nor VT.
 		if (options?.uncachedRead) {
-			const raw = options.async ? super.get(id, options) : super.getSync(id, options);
-			return when(raw, (result) => this.#processEntry(result, id));
+			if (options.async) return when(super.get(id, options), (result) => this.#processEntry(result, id));
+			return this.#processEntry(super.getSync(id, options), id);
 		}
 		const cache = this.#cache;
 		// The cache stores the record *value* (weakly, via setValue) rather than

--- a/resources/PrimaryRocksDatabase.ts
+++ b/resources/PrimaryRocksDatabase.ts
@@ -3,8 +3,7 @@ import { RocksDatabase, type RocksDatabaseOptions, constants, type Store, Transa
 const FRESH_VERSION_FLAG = constants.FRESH_VERSION_FLAG;
 import { WeakLRUCache } from 'weak-lru-cache';
 import { when } from '../utility/when.ts';
-import { assignStoredFields, entryMap, METADATA, VERSION_REUSED, VERSION_UNVOUCHABLE, type Entry } from './RecordEncoder.ts';
-import * as harperLogger from '../utility/logging/harper_logger.ts';
+import { assignStoredFields, entryMap, METADATA, VERSION_REUSED, type Entry } from './RecordEncoder.ts';
 
 /**
  * RocksDatabase subclass that owns all primary-store behaviour for Harper tables:
@@ -142,11 +141,6 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 				? (entryMap.get(cachedValue) as Entry | undefined)
 				: undefined;
 		const expectedVersion = cached?.version;
-		// The sentinel must be consulted before the native get on cold AND warm paths: a cold get
-		// would seed the slot with the version it reads, and a warm get's soft-miss re-confirms
-		// freshness off the stored record's version and republishes it — for a reused version that
-		// overwrites the sentinel and vouches a version two different values share.
-		const unvouchable = cache !== undefined && this.verifyVersion(id, VERSION_UNVOUCHABLE);
 
 		// Build get options, always merging with caller options to preserve
 		// transaction snapshot. Pass expectedVersion when cached:
@@ -154,11 +148,10 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 		//   VT miss → native reads DB and auto-populates VT slot
 		// For cold reads (no cached version), use populateVersion flag so the
 		// native layer seeds the VT slot in the same call.
-		// An unvouchable key takes a plain decoding read: no version trust, no VT seeding.
+		// A record stored under a reused version carries VERSION_REUSED, and the native layer answers
+		// neither FRESH nor a slot publication for it, so both branches are safe for such a key.
 		let getOptions: any;
-		if (unvouchable) {
-			getOptions = options;
-		} else if (expectedVersion != null) {
+		if (expectedVersion != null) {
 			getOptions = options ? { ...options, expectedVersion } : { expectedVersion };
 		} else if (cache) {
 			getOptions = options ? { ...options, populateVersion: true } : { populateVersion: true };
@@ -175,19 +168,8 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 				return undefined;
 			}
 			if (entry.version != null && cache) {
-				// ahead of the cacheability gate: a flagged null/primitive value is just as unvouchable
-				if (entry.metadataFlags & VERSION_REUSED || entry.version === VERSION_UNVOUCHABLE) {
-					if (!unvouchable) {
-						try {
-							this.populateVersion(id, VERSION_UNVOUCHABLE);
-						} catch {
-							/* leave the slot alone; this record is not cached regardless */
-						}
-					}
-					if (cachedValue !== undefined) cache.delete(id);
-				} else if (unvouchable) {
-					// clean record under a parked sentinel: stay uncached (a JS-side slot restore would be
-					// an unguarded force-set racing concurrent writes); the key's next write clears it
+				// its version no longer identifies its value, so drop any copy already held
+				if (entry.metadataFlags & VERSION_REUSED) {
 					if (cachedValue !== undefined) cache.delete(id);
 				} else if (entry.value != null && typeof entry.value === 'object') {
 					// Only object values can be weakly cached and mapped back to their Entry;
@@ -198,52 +180,6 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 			}
 			return entry;
 		});
-	}
-
-	/**
-	 * Park the unvouchable sentinel for a key whose stored version no longer identifies a single
-	 * value (see VERSION_REUSED). Called by the transaction's commit success path — the writer is
-	 * the only party that knows before any reader decodes the record. Returns whether the sentinel
-	 * is in place; a slot held by a newer write's intent refuses it.
-	 */
-	parkUnvouchable(id: any): boolean {
-		try {
-			this.populateVersion(id, VERSION_UNVOUCHABLE);
-			return this.verifyVersion(id, VERSION_UNVOUCHABLE);
-		} catch {
-			// never fail (or leak) a completed commit over the advisory park
-			return false;
-		}
-	}
-
-	/**
-	 * parkUnvouchable with a bounded backoff for slots held by a concurrent write's intent. On
-	 * final refusal, reads the stored head: a competitor that committed an advancing version
-	 * resolved the key legitimately (debug), while a still-flagged head means warm peers may be
-	 * vouched a stale value until the key's next write (warn — the hole is otherwise invisible).
-	 */
-	parkUnvouchableWithRetry(id: any, delays: number[] = [10, 50, 250]): void {
-		if (this.parkUnvouchable(id)) return;
-		const retry = (attempt: number) => {
-			try {
-				if (this.parkUnvouchable(id)) return;
-				if (attempt < delays.length) {
-					setTimeout(() => retry(attempt + 1), delays[attempt]).unref?.();
-					return;
-				}
-				const head = this.getEntry(id, { uncachedRead: true });
-				if (head && (head.metadataFlags & VERSION_REUSED || head.version === VERSION_UNVOUCHABLE)) {
-					harperLogger.warn?.(
-						`unvouchable sentinel could not be parked for ${(this as any).path ?? ''} key ${String(id)}; warm readers may serve a stale value until the next write to it`
-					);
-				} else {
-					harperLogger.debug?.('unvouchable park superseded by an advancing write', id);
-				}
-			} catch {
-				/* store closing; nothing left to protect */
-			}
-		};
-		setTimeout(() => retry(1), delays[0]).unref?.();
 	}
 
 	getSync(id: any, options?: any): any {

--- a/resources/PrimaryRocksDatabase.ts
+++ b/resources/PrimaryRocksDatabase.ts
@@ -3,7 +3,14 @@ import { RocksDatabase, type RocksDatabaseOptions, constants, type Store, Transa
 const FRESH_VERSION_FLAG = constants.FRESH_VERSION_FLAG;
 import { WeakLRUCache } from 'weak-lru-cache';
 import { when } from '../utility/when.ts';
-import { assignStoredFields, entryMap, METADATA, type Entry } from './RecordEncoder.ts';
+import { assignStoredFields, entryMap, METADATA, VERSION_REUSED, type Entry } from './RecordEncoder.ts';
+
+// Parked in a VerificationTable slot to mark a key unvouchable, since the VT has no invalidate call.
+// It doubles as the cross-worker signal that a key's version identifies more than one stored value:
+// once any worker has parked it, no other worker's read asks the native get to publish that version.
+// A timestamp ~285,000 years out — improbable rather than impossible, as write timestamps are
+// caller-supplied, so a record read back at exactly this version is never cached either.
+const VERSION_UNVOUCHABLE = Number.MAX_SAFE_INTEGER;
 
 /**
  * RocksDatabase subclass that owns all primary-store behaviour for Harper tables:
@@ -134,17 +141,24 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 				? (entryMap.get(cachedValue) as Entry | undefined)
 				: undefined;
 		const expectedVersion = cached?.version;
+		// The native get publishes the version it read into the slot, so a key whose version must not be
+		// vouched for has to be recognised BEFORE the read; withdrawing afterwards leaves it published
+		// in between. The parked sentinel is what makes that recognisable across workers. Asked only on
+		// the path that is about to request publication, and which is paying for a store read anyway; a
+		// read that has a cached version skips the check and can publish once per worker per flag,
+		// since the read that finds the flag drops its cached value and so takes this path next time.
+		const unvouchable = cache !== undefined && expectedVersion == null && this.verifyVersion(id, VERSION_UNVOUCHABLE);
 
 		// Build get options, always merging with caller options to preserve
 		// transaction snapshot. Pass expectedVersion when cached:
 		//   VT hit  → native returns FRESH_VERSION_FLAG, no DB read
 		//   VT miss → native reads DB and auto-populates VT slot
 		// For cold reads (no cached version), use populateVersion flag so the
-		// native layer seeds the VT slot in the same call.
+		// native layer seeds the VT slot in the same call — unless the slot says unvouchable.
 		let getOptions: any;
 		if (expectedVersion != null) {
 			getOptions = options ? { ...options, expectedVersion } : { expectedVersion };
-		} else if (cache) {
+		} else if (cache && !unvouchable) {
 			getOptions = options ? { ...options, populateVersion: true } : { populateVersion: true };
 		} else {
 			getOptions = options;
@@ -158,11 +172,27 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 				if (cache && cachedValue !== undefined) cache.delete(id);
 				return undefined;
 			}
-			// Only object values can be weakly cached and mapped back to their Entry;
-			// primitive/empty values fall through uncached (no fast path, still correct).
-			if (entry.version != null && cache && entry.value != null && typeof entry.value === 'object') {
-				entryMap.set(entry.value, entry);
-				cache.setValue(id, entry.value, (entry.size ?? 0) >> 10);
+			if (entry.version != null && cache) {
+				// Checked before the cacheability gate below: a flagged record with a null or primitive
+				// value is just as unvouchable. Normally the slot already holds the sentinel from the
+				// write; re-park it for a record flagged before this shipped, or one whose slot a read
+				// republished. A store that cannot take it (closing, dropped) must not turn a completed
+				// read into a failed one — not caching is the safe outcome either way.
+				if (entry.metadataFlags & VERSION_REUSED || entry.version === VERSION_UNVOUCHABLE) {
+					if (!unvouchable) {
+						try {
+							this.populateVersion(id, VERSION_UNVOUCHABLE);
+						} catch {
+							/* leave the slot alone; this record is not cached regardless */
+						}
+					}
+					if (cachedValue !== undefined) cache.delete(id);
+				} else if (entry.value != null && typeof entry.value === 'object') {
+					// Only object values can be weakly cached and mapped back to their Entry;
+					// primitive/empty values fall through uncached (no fast path, still correct).
+					entryMap.set(entry.value, entry);
+					cache.setValue(id, entry.value, (entry.size ?? 0) >> 10);
+				}
 			}
 			return entry;
 		});

--- a/resources/PrimaryRocksDatabase.ts
+++ b/resources/PrimaryRocksDatabase.ts
@@ -174,8 +174,7 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 				return undefined;
 			}
 			if (entry.version != null && cache) {
-				// Checked ahead of the cacheability gate: a flagged record with a null or primitive
-				// value is just as unvouchable. The re-park covers a slot a read republished.
+				// ahead of the cacheability gate: a flagged null/primitive value is just as unvouchable
 				if (entry.metadataFlags & VERSION_REUSED || entry.version === VERSION_UNVOUCHABLE) {
 					if (!unvouchable) {
 						try {
@@ -186,8 +185,8 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 					}
 					if (cachedValue !== undefined) cache.delete(id);
 				} else if (unvouchable) {
-					// Clean record under a parked sentinel: stay uncached — a JS-side restore would be an
-					// unguarded force-set racing concurrent writes; the key's next write clears the sentinel.
+					// clean record under a parked sentinel: stay uncached (a JS-side slot restore would be
+					// an unguarded force-set racing concurrent writes); the key's next write clears it
 					if (cachedValue !== undefined) cache.delete(id);
 				} else if (entry.value != null && typeof entry.value === 'object') {
 					// Only object values can be weakly cached and mapped back to their Entry;
@@ -209,10 +208,11 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 	parkUnvouchable(id: any): boolean {
 		try {
 			this.populateVersion(id, VERSION_UNVOUCHABLE);
+			return this.verifyVersion(id, VERSION_UNVOUCHABLE);
 		} catch {
-			/* never fail a completed commit; the verify below reports the miss */
+			// never fail (or leak) a completed commit over the advisory park
+			return false;
 		}
-		return this.verifyVersion(id, VERSION_UNVOUCHABLE);
 	}
 
 	getSync(id: any, options?: any): any {

--- a/resources/PrimaryRocksDatabase.ts
+++ b/resources/PrimaryRocksDatabase.ts
@@ -148,8 +148,6 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 		//   VT miss → native reads DB and auto-populates VT slot
 		// For cold reads (no cached version), use populateVersion flag so the
 		// native layer seeds the VT slot in the same call.
-		// A record stored under a reused version carries VERSION_REUSED, and the native layer answers
-		// neither FRESH nor a slot publication for it, so both branches are safe for such a key.
 		let getOptions: any;
 		if (expectedVersion != null) {
 			getOptions = options ? { ...options, expectedVersion } : { expectedVersion };

--- a/resources/PrimaryRocksDatabase.ts
+++ b/resources/PrimaryRocksDatabase.ts
@@ -4,6 +4,7 @@ const FRESH_VERSION_FLAG = constants.FRESH_VERSION_FLAG;
 import { WeakLRUCache } from 'weak-lru-cache';
 import { when } from '../utility/when.ts';
 import { assignStoredFields, entryMap, METADATA, VERSION_REUSED, VERSION_UNVOUCHABLE, type Entry } from './RecordEncoder.ts';
+import * as harperLogger from '../utility/logging/harper_logger.ts';
 
 /**
  * RocksDatabase subclass that owns all primary-store behaviour for Harper tables:
@@ -213,6 +214,36 @@ export class PrimaryRocksDatabase extends RocksDatabase {
 			// never fail (or leak) a completed commit over the advisory park
 			return false;
 		}
+	}
+
+	/**
+	 * parkUnvouchable with a bounded backoff for slots held by a concurrent write's intent. On
+	 * final refusal, reads the stored head: a competitor that committed an advancing version
+	 * resolved the key legitimately (debug), while a still-flagged head means warm peers may be
+	 * vouched a stale value until the key's next write (warn — the hole is otherwise invisible).
+	 */
+	parkUnvouchableWithRetry(id: any, delays: number[] = [10, 50, 250]): void {
+		if (this.parkUnvouchable(id)) return;
+		const retry = (attempt: number) => {
+			try {
+				if (this.parkUnvouchable(id)) return;
+				if (attempt < delays.length) {
+					setTimeout(() => retry(attempt + 1), delays[attempt]).unref?.();
+					return;
+				}
+				const head = this.getEntry(id, { uncachedRead: true });
+				if (head && (head.metadataFlags & VERSION_REUSED || head.version === VERSION_UNVOUCHABLE)) {
+					harperLogger.warn?.(
+						`unvouchable sentinel could not be parked for ${(this as any).path ?? ''} key ${String(id)}; warm readers may serve a stale value until the next write to it`
+					);
+				} else {
+					harperLogger.debug?.('unvouchable park superseded by an advancing write', id);
+				}
+			} catch {
+				/* store closing; nothing left to protect */
+			}
+		};
+		setTimeout(() => retry(1), delays[0]).unref?.();
 	}
 
 	getSync(id: any, options?: any): any {

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -132,7 +132,12 @@ export const VERSION_REUSED = constants.VERSION_NOT_UNIQUE_FLAG;
 // The bit is persisted in every resequenced record, so a rocksdb-js that moved it down onto one of
 // the flags above (or up into the tag byte) would silently change what records already on disk
 // mean: it must stay a single bit strictly between them.
-if ((VERSION_REUSED & (VERSION_REUSED - 1)) !== 0 || VERSION_REUSED < 0x10000 || VERSION_REUSED > 0x800000)
+if (
+	typeof VERSION_REUSED !== 'number' ||
+	(VERSION_REUSED & (VERSION_REUSED - 1)) !== 0 ||
+	VERSION_REUSED < 0x10000 ||
+	VERSION_REUSED > 0x800000
+)
 	throw new Error(
 		`rocksdb-js VERSION_NOT_UNIQUE_FLAG (${VERSION_REUSED}) is not a single bit in the range Harper record metadata reserves for it`
 	);

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -30,7 +30,7 @@ import {
 } from './blob.ts';
 import { getThisNodeId } from './nodeIdMapping.ts';
 import { recordAction } from './analytics/write.ts';
-import { RocksDatabase } from '@harperfast/rocksdb-js';
+import { constants, RocksDatabase } from '@harperfast/rocksdb-js';
 import { when } from '../utility/when.ts';
 import { CONFIG_PARAMS } from '../utility/hdbTerms.ts';
 import * as envMngr from '../utility/environment/environmentManager.js';
@@ -125,18 +125,13 @@ export const PENDING_LOCAL_TIME = 1;
 export const HAS_STRUCTURE_UPDATE = 0x100;
 export const HAS_ADDITIONAL_AUDIT_REFS = 0x80;
 // A resequenced write keeps the (newer) version it merged onto, so one version identifies two
-// different stored values; read caching's freshness oracle is version equality, so such a record
-// must never be cached or vouched for. Deliberately above every audit extendedType bit, which the
-// record metadata word borrows from for HAS_BLOBS/LOCAL_ONLY.
-export const VERSION_REUSED = 0x10000;
-// Parked in a VerificationTable slot to mark a key unvouchable (the VT has no invalidate call): the
-// cross-worker signal that a key's version identifies more than one stored value. A timestamp
-// ~285,000 years out — improbable rather than impossible, since write timestamps are
-// caller-supplied, so a record read back at exactly this version is never cached either.
-export const VERSION_UNVOUCHABLE = Number.MAX_SAFE_INTEGER;
-// The single definition of "this write stores under a reused version" — the durable VERSION_REUSED
-// bit (recordUpdater) and the post-commit sentinel park (Table's writeCommit) must never diverge.
-export function versionIsReused(newVersion: number, existingEntry: { version?: number } | undefined): boolean {
+// different stored values; every freshness oracle keyed on version equality is then wrong. This is
+// rocksdb-js's VERSION_NOT_UNIQUE_FLAG, and the record metadata word written at value offset 8 is
+// the same header word the VerificationTable reads (its ACTION_32_BIT tag byte is the tag the
+// native predicate requires), so setting it here is what stops the native layer vouching for or
+// publishing this version. Above every audit extendedType bit the metadata word borrows from.
+export const VERSION_REUSED = constants.VERSION_NOT_UNIQUE_FLAG;
+function versionIsReused(newVersion: number, existingEntry: { version?: number } | undefined): boolean {
 	return existingEntry?.version != null && newVersion <= existingEntry.version;
 }
 

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -139,7 +139,7 @@ if (
 	VERSION_REUSED > 0x800000
 )
 	throw new Error(
-		`rocksdb-js VERSION_NOT_UNIQUE_FLAG (${VERSION_REUSED}) is not a single bit in the range Harper record metadata reserves for it`
+		`rocksdb-js VERSION_NOT_UNIQUE_FLAG (${VERSION_REUSED}) is not a single bit in the range Harper record metadata reserves for it — requires @harperfast/rocksdb-js >= 2.8.0`
 	);
 function versionIsReused(newVersion: number, existingEntry: { version?: number } | undefined): boolean {
 	return existingEntry?.version != null && newVersion <= existingEntry.version;

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -132,6 +132,12 @@ export const HAS_ADDITIONAL_AUDIT_REFS = 0x80;
 // above every bit the audit extendedType uses (auditStore.ts), which the record metadata word borrows
 // from for HAS_BLOBS/LOCAL_ONLY.
 export const VERSION_REUSED = 0x10000;
+// Parked in a VerificationTable slot to mark a key unvouchable, since the VT has no invalidate call.
+// It doubles as the cross-worker signal that a key's version identifies more than one stored value:
+// once any worker has parked it, no other worker's read trusts or republishes that version. A
+// timestamp ~285,000 years out — improbable rather than impossible, as write timestamps are
+// caller-supplied, so a record read back at exactly this version is never cached either.
+export const VERSION_UNVOUCHABLE = Number.MAX_SAFE_INTEGER;
 
 const TRACKED_WRITE_TYPES = new Set(['put', 'patch', 'delete', 'message', 'publish']);
 // For now we use this as the private property mechanism for mapping records to entries.

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -125,12 +125,17 @@ export const PENDING_LOCAL_TIME = 1;
 export const HAS_STRUCTURE_UPDATE = 0x100;
 export const HAS_ADDITIONAL_AUDIT_REFS = 0x80;
 // A resequenced write keeps the (newer) version it merged onto, so one version identifies two
-// different stored values; every freshness oracle keyed on version equality is then wrong. This is
-// rocksdb-js's VERSION_NOT_UNIQUE_FLAG, and the record metadata word written at value offset 8 is
-// the same header word the VerificationTable reads (its ACTION_32_BIT tag byte is the tag the
-// native predicate requires), so setting it here is what stops the native layer vouching for or
-// publishing this version. Above every audit extendedType bit the metadata word borrows from.
+// different stored values and version equality proves nothing. The metadata word this is set in is
+// the same header word the VerificationTable reads at value offset 8 — ACTION_32_BIT is the tag
+// byte its predicate requires — so the bit is what stops the native layer vouching for the version.
 export const VERSION_REUSED = constants.VERSION_NOT_UNIQUE_FLAG;
+// The bit is persisted in every resequenced record, so a rocksdb-js that moved it down onto one of
+// the flags above (or up into the tag byte) would silently change what records already on disk
+// mean: it must stay a single bit strictly between them.
+if ((VERSION_REUSED & (VERSION_REUSED - 1)) !== 0 || VERSION_REUSED < 0x10000 || VERSION_REUSED > 0x800000)
+	throw new Error(
+		`rocksdb-js VERSION_NOT_UNIQUE_FLAG (${VERSION_REUSED}) is not a single bit in the range Harper record metadata reserves for it`
+	);
 function versionIsReused(newVersion: number, existingEntry: { version?: number } | undefined): boolean {
 	return existingEntry?.version != null && newVersion <= existingEntry.version;
 }
@@ -896,9 +901,8 @@ export function recordUpdater(store, tableId, auditStore) {
 		if (expiresAt >= 0) assignMetadata |= HAS_EXPIRATION;
 		metadataInNextEncoding = assignMetadata;
 		expiresAtNextEncoding = expiresAt;
-		// A RocksDB write whose version does not advance past the record it replaces stores a second
-		// value under that version, so the version stops identifying one stored value (VERSION_REUSED).
-		// Derived here rather than at the call sites because every record write goes through this one.
+		// A write whose version does not advance past the record it replaces stores a second value
+		// under that version; every record write reaches this one place, so it is derived here.
 		if (isRocksDB && record !== undefined && versionIsReused(newVersion, existingEntry))
 			metadataInNextEncoding |= VERSION_REUSED;
 		const putOptions: {

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -124,7 +124,14 @@ export const HAS_NODE_ID = 64;
 export const PENDING_LOCAL_TIME = 1;
 export const HAS_STRUCTURE_UPDATE = 0x100;
 export const HAS_ADDITIONAL_AUDIT_REFS = 0x80;
-export const VERSION_NOT_UNIQUE_FLAG = 0x10000;
+// Set on a record whose stored version was reused rather than advanced: a resequenced write keeps
+// the (newer) version it merged onto, so one version identifies two different stored values. Read
+// caching's freshness oracle is version equality, so it must neither cache such a record nor let the
+// VerificationTable vouch for that version — otherwise a worker still holding the pre-merge value
+// serves it as fresh, and an addTo folding onto it drops the increment it merged over. Deliberately
+// above every bit the audit extendedType uses (auditStore.ts), which the record metadata word borrows
+// from for HAS_BLOBS/LOCAL_ONLY.
+export const VERSION_REUSED = 0x10000;
 
 const TRACKED_WRITE_TYPES = new Set(['put', 'patch', 'delete', 'message', 'publish']);
 // For now we use this as the private property mechanism for mapping records to entries.
@@ -885,11 +892,14 @@ export function recordUpdater(store, tableId, auditStore) {
 				: NO_TIMESTAMP;
 		const expiresAt = options?.expiresAt;
 		if (expiresAt >= 0) assignMetadata |= HAS_EXPIRATION;
-		if (isRocksDB && record !== undefined && existingEntry?.version != null && newVersion <= existingEntry.version) {
-			assignMetadata = Math.max(assignMetadata, 0) | VERSION_NOT_UNIQUE_FLAG;
-		}
 		metadataInNextEncoding = assignMetadata;
 		expiresAtNextEncoding = expiresAt;
+		// A RocksDB write whose version does not advance past the record it replaces stores a second
+		// value under that version, so the version stops identifying one stored value (VERSION_REUSED).
+		// Derived here rather than at the call sites because every record write goes through this one.
+		const versionReused =
+			isRocksDB && record !== undefined && existingEntry?.version != null && newVersion <= existingEntry.version;
+		if (versionReused) metadataInNextEncoding |= VERSION_REUSED;
 		const putOptions: {
 			version: number;
 			instructedWrite?: boolean;

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -906,10 +906,10 @@ export function recordUpdater(store, tableId, auditStore) {
 		if (expiresAt >= 0) assignMetadata |= HAS_EXPIRATION;
 		metadataInNextEncoding = assignMetadata;
 		expiresAtNextEncoding = expiresAt;
-		// A write whose version does not advance past the record it replaces stores a second value
-		// under that version; every record write reaches this one place, so it is derived here.
+		// Math.max normalizes the -1 "no metadata word" sentinel to 0 first: OR-ing the flag into
+		// -1 directly would stay -1 and silently drop the metadata word (and the flag with it).
 		if (isRocksDB && record !== undefined && versionIsReused(newVersion, existingEntry))
-			metadataInNextEncoding |= VERSION_REUSED;
+			metadataInNextEncoding = Math.max(metadataInNextEncoding, 0) | VERSION_REUSED;
 		const putOptions: {
 			version: number;
 			instructedWrite?: boolean;

--- a/resources/RecordEncoder.ts
+++ b/resources/RecordEncoder.ts
@@ -124,20 +124,21 @@ export const HAS_NODE_ID = 64;
 export const PENDING_LOCAL_TIME = 1;
 export const HAS_STRUCTURE_UPDATE = 0x100;
 export const HAS_ADDITIONAL_AUDIT_REFS = 0x80;
-// Set on a record whose stored version was reused rather than advanced: a resequenced write keeps
-// the (newer) version it merged onto, so one version identifies two different stored values. Read
-// caching's freshness oracle is version equality, so it must neither cache such a record nor let the
-// VerificationTable vouch for that version — otherwise a worker still holding the pre-merge value
-// serves it as fresh, and an addTo folding onto it drops the increment it merged over. Deliberately
-// above every bit the audit extendedType uses (auditStore.ts), which the record metadata word borrows
-// from for HAS_BLOBS/LOCAL_ONLY.
+// A resequenced write keeps the (newer) version it merged onto, so one version identifies two
+// different stored values; read caching's freshness oracle is version equality, so such a record
+// must never be cached or vouched for. Deliberately above every audit extendedType bit, which the
+// record metadata word borrows from for HAS_BLOBS/LOCAL_ONLY.
 export const VERSION_REUSED = 0x10000;
-// Parked in a VerificationTable slot to mark a key unvouchable, since the VT has no invalidate call.
-// It doubles as the cross-worker signal that a key's version identifies more than one stored value:
-// once any worker has parked it, no other worker's read trusts or republishes that version. A
-// timestamp ~285,000 years out — improbable rather than impossible, as write timestamps are
+// Parked in a VerificationTable slot to mark a key unvouchable (the VT has no invalidate call): the
+// cross-worker signal that a key's version identifies more than one stored value. A timestamp
+// ~285,000 years out — improbable rather than impossible, since write timestamps are
 // caller-supplied, so a record read back at exactly this version is never cached either.
 export const VERSION_UNVOUCHABLE = Number.MAX_SAFE_INTEGER;
+// The single definition of "this write stores under a reused version" — the durable VERSION_REUSED
+// bit (recordUpdater) and the post-commit sentinel park (Table's writeCommit) must never diverge.
+export function versionIsReused(newVersion: number, existingEntry: { version?: number } | undefined): boolean {
+	return existingEntry?.version != null && newVersion <= existingEntry.version;
+}
 
 const TRACKED_WRITE_TYPES = new Set(['put', 'patch', 'delete', 'message', 'publish']);
 // For now we use this as the private property mechanism for mapping records to entries.
@@ -903,9 +904,8 @@ export function recordUpdater(store, tableId, auditStore) {
 		// A RocksDB write whose version does not advance past the record it replaces stores a second
 		// value under that version, so the version stops identifying one stored value (VERSION_REUSED).
 		// Derived here rather than at the call sites because every record write goes through this one.
-		const versionReused =
-			isRocksDB && record !== undefined && existingEntry?.version != null && newVersion <= existingEntry.version;
-		if (versionReused) metadataInNextEncoding |= VERSION_REUSED;
+		if (isRocksDB && record !== undefined && versionIsReused(newVersion, existingEntry))
+			metadataInNextEncoding |= VERSION_REUSED;
 		const putOptions: {
 			version: number;
 			instructedWrite?: boolean;

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -92,7 +92,6 @@ import {
 	type StructureCounts,
 	entryMap,
 	storedFieldsOnly,
-	versionIsReused,
 } from './RecordEncoder.ts';
 import { recordAction, recordActionBinary } from './analytics/write.ts';
 import { rebuildUpdateBefore } from './crdt.ts';
@@ -2268,13 +2267,10 @@ export function makeTable(options) {
 					const txnLogKey =
 						isRocksDB && options?.version != null ? (transaction?.getTimestamp?.() ?? txnTime) : txnTime;
 					write.skipped = false; // reset on each retry; cleanup happens after commit if still true
-					write.storedReusedVersion = false; // likewise
 					if (precedesExistingVersion(txnTime, existingEntry, options?.nodeId) <= 0) {
 						write.skipped = true;
 						return;
 					}
-					// a nodeId-won timestamp tie stores at the existing version — a reuse
-					if (isRocksDB && versionIsReused(txnTime, existingEntry)) write.storedReusedVersion = true;
 					partialRecord ??= null;
 					for (const name in indices) {
 						if (!partialRecord) partialRecord = {};
@@ -2333,10 +2329,7 @@ export function makeTable(options) {
 				commit: (txnTime, existingEntry, _retry, transaction: any) => {
 					const txnLogKey =
 						isRocksDB && options?.version != null ? (transaction?.getTimestamp?.() ?? txnTime) : txnTime;
-					write.storedReusedVersion = false; // reset per round
 					if (precedesExistingVersion(txnTime, existingEntry, options?.nodeId) <= 0) return;
-					// a nodeId-won timestamp tie stores at the existing version — a reuse
-					if (isRocksDB && versionIsReused(txnTime, existingEntry)) write.storedReusedVersion = true;
 					const residency = TableResource.getResidencyRecord(options.residencyId);
 					let metadata = 0;
 					let newRecord = null;
@@ -2415,9 +2408,6 @@ export function makeTable(options) {
 				false,
 				null // the audit record value should be empty since there are no changes to the actual data
 			);
-			// stored at the unchanged version — always a reuse, and outside the tracked-write flow
-			// whose commit path would otherwise park it
-			if (isRocksDB) (primaryStore as any).parkUnvouchableWithRetry(existingEntry.key);
 			return true;
 		}
 		/**
@@ -3031,7 +3021,6 @@ export function makeTable(options) {
 					write.skipped = false; // reset on each retry; cleanup happens after commit if still true
 					write.stagedEntry = undefined; // likewise: only set once this round actually stores a record
 					write.superseded = false; // likewise: a later write to this key re-marks it this round
-					write.storedReusedVersion = false; // likewise: only the round that commits decides it
 					// The record a preceding write in this transaction left for this key is what this write
 					// applies to (see priorStagedWrite): a staged write is not visible to a read, so without
 					// this the index diff re-removes the values that write already removed and never removes
@@ -3620,8 +3609,6 @@ export function makeTable(options) {
 						}
 					}
 					function writeCommit(storeRecord: boolean) {
-						// marked, not parked: the VT slot holds this write's own intent until commit
-						if (storeRecord && isRocksDB && versionIsReused(txnTime, existingEntry)) write.storedReusedVersion = true;
 						// we need to write the commit. if storeRecord then we need to store the record, otherwise we just need to store the audit record
 						updateRecord(
 							id,
@@ -3772,7 +3759,6 @@ export function makeTable(options) {
 				commit: (txnTime, existingEntry, retry, transaction: any) => {
 					write.stagedEntry = undefined; // reset per round; set below once the removal is applied
 					write.superseded = false; // reset per round, as in the update path
-					write.storedReusedVersion = false; // likewise
 					// what a preceding write in this transaction left for this key is what gets removed
 					// from the indices here, not the pre-transaction record (harper#1968)
 					const priorStagedOp = priorStagedWrite(write);
@@ -3795,8 +3781,6 @@ export function makeTable(options) {
 					}
 					updateIndices(id, existingRecord, null, transaction && { transaction });
 					if (audit || trackDeletes) {
-						// a tie-timestamp tombstone stores under the reused version too (see writeCommit)
-						if (isRocksDB && versionIsReused(txnTime, existingEntry)) write.storedReusedVersion = true;
 						updateRecord(
 							id,
 							null,

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -2267,7 +2267,7 @@ export function makeTable(options) {
 					const txnLogKey =
 						isRocksDB && options?.version != null ? (transaction?.getTimestamp?.() ?? txnTime) : txnTime;
 					write.skipped = false; // reset on each retry; cleanup happens after commit if still true
-					if (precedesExistingVersion(txnTime, existingEntry, options?.nodeId) <= 0) {
+					if (precedesExistingVersion(txnTime, existingEntry, options?.nodeId) < 0) {
 						write.skipped = true;
 						return;
 					}
@@ -2329,7 +2329,7 @@ export function makeTable(options) {
 				commit: (txnTime, existingEntry, _retry, transaction: any) => {
 					const txnLogKey =
 						isRocksDB && options?.version != null ? (transaction?.getTimestamp?.() ?? txnTime) : txnTime;
-					if (precedesExistingVersion(txnTime, existingEntry, options?.nodeId) <= 0) return;
+					if (precedesExistingVersion(txnTime, existingEntry, options?.nodeId) < 0) return;
 					const residency = TableResource.getResidencyRecord(options.residencyId);
 					let metadata = 0;
 					let newRecord = null;

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -2268,10 +2268,13 @@ export function makeTable(options) {
 					const txnLogKey =
 						isRocksDB && options?.version != null ? (transaction?.getTimestamp?.() ?? txnTime) : txnTime;
 					write.skipped = false; // reset on each retry; cleanup happens after commit if still true
-					if (precedesExistingVersion(txnTime, existingEntry, options?.nodeId) < 0) {
+					write.storedReusedVersion = false; // likewise
+					if (precedesExistingVersion(txnTime, existingEntry, options?.nodeId) <= 0) {
 						write.skipped = true;
 						return;
 					}
+					// a nodeId-won timestamp tie stores at the existing version — a reuse
+					if (isRocksDB && versionIsReused(txnTime, existingEntry)) write.storedReusedVersion = true;
 					partialRecord ??= null;
 					for (const name in indices) {
 						if (!partialRecord) partialRecord = {};
@@ -2330,7 +2333,10 @@ export function makeTable(options) {
 				commit: (txnTime, existingEntry, _retry, transaction: any) => {
 					const txnLogKey =
 						isRocksDB && options?.version != null ? (transaction?.getTimestamp?.() ?? txnTime) : txnTime;
-					if (precedesExistingVersion(txnTime, existingEntry, options?.nodeId) < 0) return;
+					write.storedReusedVersion = false; // reset per round
+					if (precedesExistingVersion(txnTime, existingEntry, options?.nodeId) <= 0) return;
+					// a nodeId-won timestamp tie stores at the existing version — a reuse
+					if (isRocksDB && versionIsReused(txnTime, existingEntry)) write.storedReusedVersion = true;
 					const residency = TableResource.getResidencyRecord(options.residencyId);
 					let metadata = 0;
 					let newRecord = null;
@@ -2409,6 +2415,9 @@ export function makeTable(options) {
 				false,
 				null // the audit record value should be empty since there are no changes to the actual data
 			);
+			// stored at the unchanged version — always a reuse, and outside the tracked-write flow
+			// whose commit path would otherwise park it
+			if (isRocksDB) (primaryStore as any).parkUnvouchableWithRetry(existingEntry.key);
 			return true;
 		}
 		/**

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -3017,6 +3017,7 @@ export function makeTable(options) {
 					write.skipped = false; // reset on each retry; cleanup happens after commit if still true
 					write.stagedEntry = undefined; // likewise: only set once this round actually stores a record
 					write.superseded = false; // likewise: a later write to this key re-marks it this round
+					write.storedReusedVersion = false; // likewise: only the round that commits decides it
 					// The record a preceding write in this transaction left for this key is what this write
 					// applies to (see priorStagedWrite): a staged write is not visible to a read, so without
 					// this the index diff re-removes the values that write already removed and never removes
@@ -3605,6 +3606,13 @@ export function makeTable(options) {
 						}
 					}
 					function writeCommit(storeRecord: boolean) {
+						// A stored record whose version does not advance past the one it replaces (a resequenced
+						// out-of-order fold) leaves two different values identified by one version. Mark the
+						// write so the transaction's success path parks the unvouchable sentinel for the key —
+						// the writer is the only party that knows before any reader does, and parking cannot
+						// happen earlier because the VT slot holds this write's own intent until commit.
+						if (storeRecord && isRocksDB && existingEntry?.version != null && txnTime <= existingEntry.version)
+							write.storedReusedVersion = true;
 						// we need to write the commit. if storeRecord then we need to store the record, otherwise we just need to store the audit record
 						updateRecord(
 							id,

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -2263,6 +2263,7 @@ export function makeTable(options) {
 				entry: this.#entry,
 				recordVersion: options?.version,
 				lockHandle: this.#lockHandle && this.#lockHandle.keyId === writeKeyId(id) ? this.#lockHandle : undefined,
+				reloadCommitBase: true,
 				commit: (txnTime, existingEntry, _retry, transaction: any) => {
 					const txnLogKey =
 						isRocksDB && options?.version != null ? (transaction?.getTimestamp?.() ?? txnTime) : txnTime;
@@ -2321,6 +2322,7 @@ export function makeTable(options) {
 				entry: this.#entry,
 				recordVersion: options?.version,
 				lockHandle: this.#lockHandle && this.#lockHandle.keyId === writeKeyId(id) ? this.#lockHandle : undefined,
+				reloadCommitBase: true,
 				before:
 					(this.constructor as any).source?.relocate && !(context as any)?.source
 						? (this.constructor as any).source.relocate.bind((this.constructor as any).source, id, undefined, context)
@@ -2914,7 +2916,8 @@ export function makeTable(options) {
 				entry,
 				nodeName: (context as any)?.nodeName,
 				fullUpdate,
-				isCopyApply: options?.isCopyApply === true,
+				// copy-apply rows keep their pre-read base: one read per row, healed by the post-copy replay
+				reloadCommitBase: options?.isCopyApply !== true,
 				deferSave: true,
 				// the origin's record version on an applied write; absent for a locally-originated one
 				recordVersion: options?.version,
@@ -3608,8 +3611,7 @@ export function makeTable(options) {
 						}
 					}
 					function writeCommit(storeRecord: boolean) {
-						// Marked (not parked) here: the VT slot holds this write's own intent until commit, so
-						// the transaction's success path does the actual sentinel park.
+						// marked, not parked: the VT slot holds this write's own intent until commit
 						if (storeRecord && isRocksDB && versionIsReused(txnTime, existingEntry)) write.storedReusedVersion = true;
 						// we need to write the commit. if storeRecord then we need to store the record, otherwise we just need to store the audit record
 						updateRecord(
@@ -3750,6 +3752,7 @@ export function makeTable(options) {
 				store: primaryStore,
 				entry,
 				chainsStagedState: true,
+				reloadCommitBase: true,
 				nodeName: (context as any)?.nodeName,
 				recordVersion: options?.version,
 				lockHandle: this.#lockHandle && this.#lockHandle.keyId === writeKeyId(id) ? this.#lockHandle : undefined,
@@ -3760,6 +3763,7 @@ export function makeTable(options) {
 				commit: (txnTime, existingEntry, retry, transaction: any) => {
 					write.stagedEntry = undefined; // reset per round; set below once the removal is applied
 					write.superseded = false; // reset per round, as in the update path
+					write.storedReusedVersion = false; // likewise
 					// what a preceding write in this transaction left for this key is what gets removed
 					// from the indices here, not the pre-transaction record (harper#1968)
 					const priorStagedOp = priorStagedWrite(write);
@@ -3782,6 +3786,8 @@ export function makeTable(options) {
 					}
 					updateIndices(id, existingRecord, null, transaction && { transaction });
 					if (audit || trackDeletes) {
+						// a tie-timestamp tombstone stores under the reused version too (see writeCommit)
+						if (isRocksDB && versionIsReused(txnTime, existingEntry)) write.storedReusedVersion = true;
 						updateRecord(
 							id,
 							null,

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -92,6 +92,7 @@ import {
 	type StructureCounts,
 	entryMap,
 	storedFieldsOnly,
+	versionIsReused,
 } from './RecordEncoder.ts';
 import { recordAction, recordActionBinary } from './analytics/write.ts';
 import { rebuildUpdateBefore } from './crdt.ts';
@@ -2913,6 +2914,7 @@ export function makeTable(options) {
 				entry,
 				nodeName: (context as any)?.nodeName,
 				fullUpdate,
+				isCopyApply: options?.isCopyApply === true,
 				deferSave: true,
 				// the origin's record version on an applied write; absent for a locally-originated one
 				recordVersion: options?.version,
@@ -3496,8 +3498,8 @@ export function makeTable(options) {
 					if (recordToStore && recordToStore.getRecord)
 						throw new Error('Can not assign a record to a record, check for circular references');
 					if (residencyId == undefined) {
-						if (entry?.residencyId)
-							(context as any).previousResidency = TableResource.getResidencyRecord(entry.residencyId);
+						if (existingEntry?.residencyId)
+							(context as any).previousResidency = TableResource.getResidencyRecord(existingEntry.residencyId);
 						const residency = residencyFromFunction(TableResource.getResidency(recordToStore, context));
 						if (residency) {
 							if (!residency.includes(server.hostname)) {
@@ -3606,13 +3608,9 @@ export function makeTable(options) {
 						}
 					}
 					function writeCommit(storeRecord: boolean) {
-						// A stored record whose version does not advance past the one it replaces (a resequenced
-						// out-of-order fold) leaves two different values identified by one version. Mark the
-						// write so the transaction's success path parks the unvouchable sentinel for the key —
-						// the writer is the only party that knows before any reader does, and parking cannot
-						// happen earlier because the VT slot holds this write's own intent until commit.
-						if (storeRecord && isRocksDB && existingEntry?.version != null && txnTime <= existingEntry.version)
-							write.storedReusedVersion = true;
+						// Marked (not parked) here: the VT slot holds this write's own intent until commit, so
+						// the transaction's success path does the actual sentinel park.
+						if (storeRecord && isRocksDB && versionIsReused(txnTime, existingEntry)) write.storedReusedVersion = true;
 						// we need to write the commit. if storeRecord then we need to store the record, otherwise we just need to store the audit record
 						updateRecord(
 							id,

--- a/resources/Table.ts
+++ b/resources/Table.ts
@@ -2977,10 +2977,13 @@ export function makeTable(options) {
 											: txnTime;
 							}
 							if (createdTimeProperty) {
-								if (entry?.value) {
+								// the reloaded commit base, not the pre-read one: a full PUT racing a create
+								// would otherwise stamp a fresh created time over the real one
+								const base = write.entry;
+								if (base?.value) {
 									if (fullUpdate || recordUpdate[createdTimeProperty.name]) {
 										// make sure to retain original created time
-										recordUpdate[createdTimeProperty.name] = entry?.value[createdTimeProperty.name];
+										recordUpdate[createdTimeProperty.name] = base.value[createdTimeProperty.name];
 									}
 								} else {
 									// new entry, set created time

--- a/unitTests/resources/cache-probe.bench.js
+++ b/unitTests/resources/cache-probe.bench.js
@@ -33,7 +33,9 @@ async function main() {
 	console.log(`warm getEntry (with probe): ${warmNs.toFixed(0)} ns/op (${(1e9 / warmNs / 1e6).toFixed(2)} M ops/s)`);
 	console.log(`verifyVersion probe alone:  ${probeNs.toFixed(0)} ns/op`);
 	console.log(`probe share of warm read:   ${((probeNs / warmNs) * 100).toFixed(1)}%`);
-	console.log(`estimated pre-change warm:  ${(warmNs - probeNs).toFixed(0)} ns/op → overhead ${((probeNs / (warmNs - probeNs)) * 100).toFixed(1)}%`);
+	console.log(
+		`estimated pre-change warm:  ${(warmNs - probeNs).toFixed(0)} ns/op → overhead ${((probeNs / (warmNs - probeNs)) * 100).toFixed(1)}%`
+	);
 	process.exit(0);
 }
 main().catch((e) => {

--- a/unitTests/resources/cache-probe.bench.js
+++ b/unitTests/resources/cache-probe.bench.js
@@ -3,6 +3,13 @@ const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 
+describe('warm cached read', function () {
+	it('measures warm getEntry throughput', async function () {
+		this.timeout(120_000);
+		await main();
+	});
+});
+
 async function main() {
 	setupTestDBPath();
 	setMainIsWorker(true);
@@ -24,9 +31,4 @@ async function main() {
 	const warmNs = Number(t1 - t0) / N;
 
 	console.log(`warm getEntry: ${warmNs.toFixed(0)} ns/op (${(1e9 / warmNs / 1e6).toFixed(2)} M ops/s)`);
-	process.exit(0);
 }
-main().catch((e) => {
-	console.error(e);
-	process.exit(1);
-});

--- a/unitTests/resources/cache-probe.bench.js
+++ b/unitTests/resources/cache-probe.bench.js
@@ -14,28 +14,16 @@ async function main() {
 	const store = TestTable.primaryStore;
 	await TestTable.put(1, { name: 'warm', payload: 'x'.repeat(200) });
 	await TestTable.get(1); // warm cache + VT
-	const entry = store.getEntry(1);
-	const version = entry.version;
+	store.getEntry(1);
 
 	const N = 2_000_000;
-	// warm getEntry (includes the new sentinel probe)
-	let t0 = process.hrtime.bigint();
+	for (let i = 0; i < 100_000; i++) store.getEntry(1);
+	const t0 = process.hrtime.bigint();
 	for (let i = 0; i < N; i++) store.getEntry(1);
-	let t1 = process.hrtime.bigint();
+	const t1 = process.hrtime.bigint();
 	const warmNs = Number(t1 - t0) / N;
 
-	// bare verifyVersion — the added per-read probe in isolation
-	t0 = process.hrtime.bigint();
-	for (let i = 0; i < N; i++) store.verifyVersion(1, version);
-	t1 = process.hrtime.bigint();
-	const probeNs = Number(t1 - t0) / N;
-
-	console.log(`warm getEntry (with probe): ${warmNs.toFixed(0)} ns/op (${(1e9 / warmNs / 1e6).toFixed(2)} M ops/s)`);
-	console.log(`verifyVersion probe alone:  ${probeNs.toFixed(0)} ns/op`);
-	console.log(`probe share of warm read:   ${((probeNs / warmNs) * 100).toFixed(1)}%`);
-	console.log(
-		`estimated pre-change warm:  ${(warmNs - probeNs).toFixed(0)} ns/op → overhead ${((probeNs / (warmNs - probeNs)) * 100).toFixed(1)}%`
-	);
+	console.log(`warm getEntry: ${warmNs.toFixed(0)} ns/op (${(1e9 / warmNs / 1e6).toFixed(2)} M ops/s)`);
 	process.exit(0);
 }
 main().catch((e) => {

--- a/unitTests/resources/cache-probe.bench.js
+++ b/unitTests/resources/cache-probe.bench.js
@@ -1,0 +1,42 @@
+require('../testUtils');
+const { setupTestDBPath } = require('../testUtils');
+const { table } = require('#src/resources/databases');
+const { setMainIsWorker } = require('#js/server/threads/manageThreads');
+
+async function main() {
+	setupTestDBPath();
+	setMainIsWorker(true);
+	const TestTable = table({
+		table: 'CacheProbeBench',
+		database: 'test',
+		attributes: [{ name: 'id', isPrimaryKey: true }, { name: 'name' }],
+	});
+	const store = TestTable.primaryStore;
+	await TestTable.put(1, { name: 'warm', payload: 'x'.repeat(200) });
+	await TestTable.get(1); // warm cache + VT
+	const entry = store.getEntry(1);
+	const version = entry.version;
+
+	const N = 2_000_000;
+	// warm getEntry (includes the new sentinel probe)
+	let t0 = process.hrtime.bigint();
+	for (let i = 0; i < N; i++) store.getEntry(1);
+	let t1 = process.hrtime.bigint();
+	const warmNs = Number(t1 - t0) / N;
+
+	// bare verifyVersion — the added per-read probe in isolation
+	t0 = process.hrtime.bigint();
+	for (let i = 0; i < N; i++) store.verifyVersion(1, version);
+	t1 = process.hrtime.bigint();
+	const probeNs = Number(t1 - t0) / N;
+
+	console.log(`warm getEntry (with probe): ${warmNs.toFixed(0)} ns/op (${(1e9 / warmNs / 1e6).toFixed(2)} M ops/s)`);
+	console.log(`verifyVersion probe alone:  ${probeNs.toFixed(0)} ns/op`);
+	console.log(`probe share of warm read:   ${((probeNs / warmNs) * 100).toFixed(1)}%`);
+	console.log(`estimated pre-change warm:  ${(warmNs - probeNs).toFixed(0)} ns/op → overhead ${((probeNs / (warmNs - probeNs)) * 100).toFixed(1)}%`);
+	process.exit(0);
+}
+main().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});

--- a/unitTests/resources/caching-rocks-database.test.js
+++ b/unitTests/resources/caching-rocks-database.test.js
@@ -6,6 +6,7 @@ const { VERSION_REUSED } = require('#src/resources/RecordEncoder');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { RocksDatabase } = require('@harperfast/rocksdb-js');
 const { PrimaryRocksDatabase } = require('#src/resources/PrimaryRocksDatabase');
+const { VERSION_UNVOUCHABLE } = require('#src/resources/RecordEncoder');
 
 const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
 
@@ -134,35 +135,27 @@ describe('PrimaryRocksDatabase', function () {
 		const now = Date.now();
 		await TestTable.put(9, { name: 'base', count: 0 });
 		await TestTable.patch(9, { name: 'newer', count: { __op__: 'add', value: 1 } }, { timestamp: now + 100 });
-		await TestTable.get(9); // cache the record and seed the VT slot with its version
+		await TestTable.get(9);
 		const inOrder = TestTable.primaryStore.getEntry(9);
 		assert(TestTable.primaryStore.verifyVersion(9, inOrder.version), 'VT should vouch for an in-order version');
 
-		// An out-of-order write merges onto the newer record and is stored under its version, so two
-		// different stored values share that version.
+		// out-of-order: merges onto the newer record and stores under its (reused) version
 		await TestTable.patch(9, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 50 });
-		// The WRITE parks the sentinel, before any read decodes the record: a reader-side park leaves
-		// a window in which a worker holding the pre-merge value keeps being confirmed fresh off the
-		// stored record's (reused) version, and with every worker warm no reader ever decodes at all.
+		// Asserted before any read: with every worker warm, no reader ever decodes the flagged
+		// record, so only the writer can park in time.
 		assert(
-			TestTable.primaryStore.verifyVersion(9, Number.MAX_SAFE_INTEGER),
+			TestTable.primaryStore.verifyVersion(9, VERSION_UNVOUCHABLE),
 			'the resequenced write itself must park the unvouchable sentinel'
 		);
 		const resequenced = TestTable.primaryStore.getEntry(9);
 		assert.equal(resequenced.version, inOrder.version, 'resequenced write keeps the existing version');
 		assert.equal(resequenced.value.count, 2, 'both increments are applied');
-
-		// The version must never be vouched for once two stored values share it: another worker still
-		// holding the pre-merge value would verify it as fresh and serve it, and an addTo folding onto
-		// that stale value silently drops the increment it merged over. Asserting the sentinel rather
-		// than merely "does not verify": any write clears the slot, so the weaker form would pass
-		// without this change, and the sentinel is also what tells the next reader not to republish.
 		assert(
 			!TestTable.primaryStore.verifyVersion(9, resequenced.version),
 			'VT must not vouch for a version shared by two stored values'
 		);
 		assert(
-			TestTable.primaryStore.verifyVersion(9, Number.MAX_SAFE_INTEGER),
+			TestTable.primaryStore.verifyVersion(9, VERSION_UNVOUCHABLE),
 			'reading a resequenced record must leave the slot parked as unvouchable'
 		);
 	});
@@ -173,11 +166,12 @@ describe('PrimaryRocksDatabase', function () {
 		await TestTable.get(12); // warm the cache and seed the VT slot
 		const cached = store.getEntry(12);
 		assert(store.verifyVersion(12, cached.version), 'VT vouches for the in-order version');
-
-		// A commit-path base read must come from the store (through the caller's transaction
-		// snapshot), never from the vouch fast path — the vouch answers "latest committed", which
-		// is the wrong question for a snapshot read and wrong outright for a reused version.
+		// The vouch fast path returns the cached object itself, so identity is what distinguishes
+		// the two paths — an equal-values assertion would stay green if uncachedRead regressed
+		// into the vouch path and went back to serving stale commit bases.
+		assert.equal(store.getEntry(12).value, cached.value, 'the vouch path serves the cached object');
 		const direct = store.getEntry(12, { uncachedRead: true });
+		assert.notEqual(direct.value, cached.value, 'uncachedRead must decode from the store, not serve the cache');
 		assert.equal(direct.value.name, 'stored');
 		assert.equal(direct.value.count, 5);
 		assert.equal(direct.version, cached.version, 'the decoded entry carries the stored version');
@@ -192,10 +186,8 @@ describe('PrimaryRocksDatabase', function () {
 		const reused = store.getEntry(11);
 		assert(!store.verifyVersion(11, reused.version), 'the reused version is not vouched for');
 
-		// The next in-order write advances the version, so the record identifies its own value again
-		// and both the cache and the VT are usable for it. The read that discovers the flag is gone
-		// still asks for no seeding (it was issued while the key was remembered as reused), so it is
-		// the read after it that re-seeds — the same one-read lag as any cold key.
+		// the next in-order write gives the record a version of its own; vouching resumes with the
+		// same one-read lag as any cold key
 		await TestTable.patch(11, { name: 'later' }, { timestamp: now + 200 });
 		const advanced = store.getEntry(11);
 		assert(advanced.version > reused.version, 'the in-order write advances the version');

--- a/unitTests/resources/caching-rocks-database.test.js
+++ b/unitTests/resources/caching-rocks-database.test.js
@@ -6,7 +6,7 @@ const { VERSION_REUSED } = require('#src/resources/RecordEncoder');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { RocksDatabase } = require('@harperfast/rocksdb-js');
 const { PrimaryRocksDatabase } = require('#src/resources/PrimaryRocksDatabase');
-const { VERSION_UNVOUCHABLE } = require('#src/resources/RecordEncoder');
+const { VERSION_REUSED } = require('#src/resources/RecordEncoder');
 
 const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
 
@@ -132,32 +132,24 @@ describe('PrimaryRocksDatabase', function () {
 	});
 
 	it('VT does not vouch for a version a resequenced write reused', async function () {
+		const store = TestTable.primaryStore;
 		const now = Date.now();
 		await TestTable.put(9, { name: 'base', count: 0 });
 		await TestTable.patch(9, { name: 'newer', count: { __op__: 'add', value: 1 } }, { timestamp: now + 100 });
 		await TestTable.get(9);
-		const inOrder = TestTable.primaryStore.getEntry(9);
-		assert(TestTable.primaryStore.verifyVersion(9, inOrder.version), 'VT should vouch for an in-order version');
+		const inOrder = store.getEntry(9);
+		assert(store.verifyVersion(9, inOrder.version), 'VT should vouch for an in-order version');
 
 		// out-of-order: merges onto the newer record and stores under its (reused) version
 		await TestTable.patch(9, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 50 });
-		// Asserted before any read: with every worker warm, no reader ever decodes the flagged
-		// record, so only the writer can park in time.
-		assert(
-			TestTable.primaryStore.verifyVersion(9, VERSION_UNVOUCHABLE),
-			'the resequenced write itself must park the unvouchable sentinel'
-		);
-		const resequenced = TestTable.primaryStore.getEntry(9);
+		const resequenced = store.getEntry(9);
 		assert.equal(resequenced.version, inOrder.version, 'resequenced write keeps the existing version');
 		assert.equal(resequenced.value.count, 2, 'both increments are applied');
-		assert(
-			!TestTable.primaryStore.verifyVersion(9, resequenced.version),
-			'VT must not vouch for a version shared by two stored values'
-		);
-		assert(
-			TestTable.primaryStore.verifyVersion(9, VERSION_UNVOUCHABLE),
-			'reading a resequenced record must leave the slot parked as unvouchable'
-		);
+		assert(resequenced.metadataFlags & VERSION_REUSED, 'the stored record is marked non-unique for the native layer');
+		assert(!store.verifyVersion(9, resequenced.version), 'VT must not vouch for a version shared by two stored values');
+		// a read of a flagged record must publish nothing and cache nothing, however many times it runs
+		assert.notEqual(store.getEntry(9).value, resequenced.value, 'a flagged record is never served from cache');
+		assert(!store.verifyVersion(9, resequenced.version), 'reading a flagged record must not publish its version');
 	});
 
 	it('an uncachedRead bypasses the cache vouch and returns the stored record', async function () {
@@ -184,6 +176,7 @@ describe('PrimaryRocksDatabase', function () {
 		await TestTable.patch(11, { name: 'newer', count: { __op__: 'add', value: 1 } }, { timestamp: now + 100 });
 		await TestTable.patch(11, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 50 });
 		const reused = store.getEntry(11);
+		assert(reused.metadataFlags & VERSION_REUSED, 'the reused version is marked');
 		assert(!store.verifyVersion(11, reused.version), 'the reused version is not vouched for');
 
 		// the next in-order write gives the record a version of its own; vouching resumes with the

--- a/unitTests/resources/caching-rocks-database.test.js
+++ b/unitTests/resources/caching-rocks-database.test.js
@@ -6,7 +6,6 @@ const { VERSION_REUSED } = require('#src/resources/RecordEncoder');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { RocksDatabase } = require('@harperfast/rocksdb-js');
 const { PrimaryRocksDatabase } = require('#src/resources/PrimaryRocksDatabase');
-const { VERSION_REUSED } = require('#src/resources/RecordEncoder');
 
 const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
 
@@ -120,11 +119,11 @@ describe('PrimaryRocksDatabase', function () {
 	it('marks a record whose version was reused by a resequenced write, preserving its expiresAt', async function () {
 		const now = Date.now();
 		const expiresAt = now + 60_000;
-		await TestTable.put(10, { name: 'base', count: 0 });
-		await TestTable.patch(10, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 100 });
-		const inOrder = TestTable.primaryStore.getEntry(10);
-		await TestTable.patch(10, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 50, expiresAt });
-		const resequenced = TestTable.primaryStore.getEntry(10);
+		await TestTable.put(13, { name: 'base', count: 0 });
+		await TestTable.patch(13, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 100 });
+		const inOrder = TestTable.primaryStore.getEntry(13);
+		await TestTable.patch(13, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 50, expiresAt });
+		const resequenced = TestTable.primaryStore.getEntry(13);
 		assert.equal(resequenced.version, inOrder.version);
 		assert.equal(resequenced.value.count, 2);
 		assert.equal(resequenced.expiresAt, expiresAt);

--- a/unitTests/resources/caching-rocks-database.test.js
+++ b/unitTests/resources/caching-rocks-database.test.js
@@ -148,6 +148,8 @@ describe('PrimaryRocksDatabase', function () {
 		assert(!store.verifyVersion(9, resequenced.version), 'VT must not vouch for a version shared by two stored values');
 		assert.notEqual(store.getEntry(9).value, resequenced.value, 'a flagged record is never served from cache');
 		assert(!store.verifyVersion(9, resequenced.version), 'reading a flagged record must not publish its version');
+		const client = await TestTable.get(9);
+		assert.equal(client.count, 2, 'a client-level read sees the merged value, not a stale cache vouch');
 	});
 
 	it('an uncachedRead bypasses the cache vouch and returns the stored record', async function () {

--- a/unitTests/resources/caching-rocks-database.test.js
+++ b/unitTests/resources/caching-rocks-database.test.js
@@ -2,9 +2,9 @@ require('../testUtils');
 const assert = require('assert');
 const { setupTestDBPath } = require('../testUtils');
 const { table } = require('#src/resources/databases');
-const { VERSION_NOT_UNIQUE_FLAG } = require('#src/resources/RecordEncoder');
+const { VERSION_REUSED } = require('#src/resources/RecordEncoder');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
-const { RocksDatabase, constants } = require('@harperfast/rocksdb-js');
+const { RocksDatabase } = require('@harperfast/rocksdb-js');
 const { PrimaryRocksDatabase } = require('#src/resources/PrimaryRocksDatabase');
 
 const isLMDB = process.env.HARPER_STORAGE_ENGINE === 'lmdb';
@@ -116,33 +116,68 @@ describe('PrimaryRocksDatabase', function () {
 		assert.equal(result.name, 'eight updated');
 	});
 
-	it('marks a record whose version was reused by a resequenced write', async function () {
+	it('marks a record whose version was reused by a resequenced write, preserving its expiresAt', async function () {
 		const now = Date.now();
 		const expiresAt = now + 60_000;
-		await TestTable.put(9, { name: 'base', count: 0 });
-		await TestTable.patch(9, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 100 });
-		const inOrder = TestTable.primaryStore.getEntry(9);
-		await TestTable.patch(9, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 50, expiresAt });
-		const resequenced = TestTable.primaryStore.getEntry(9);
+		await TestTable.put(10, { name: 'base', count: 0 });
+		await TestTable.patch(10, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 100 });
+		const inOrder = TestTable.primaryStore.getEntry(10);
+		await TestTable.patch(10, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 50, expiresAt });
+		const resequenced = TestTable.primaryStore.getEntry(10);
 		assert.equal(resequenced.version, inOrder.version);
 		assert.equal(resequenced.value.count, 2);
 		assert.equal(resequenced.expiresAt, expiresAt);
-		assert(resequenced.metadataFlags & VERSION_NOT_UNIQUE_FLAG);
+		assert(resequenced.metadataFlags & VERSION_REUSED);
 	});
 
-	it('does not vouch for stale cached data after a version-reusing write', async function () {
-		// A drift between Harper's flag and the native constant would silently disarm the assertions below.
-		assert.equal(constants.VERSION_NOT_UNIQUE_FLAG, VERSION_NOT_UNIQUE_FLAG);
+	it('VT does not vouch for a version a resequenced write reused', async function () {
+		const now = Date.now();
+		await TestTable.put(9, { name: 'base', count: 0 });
+		await TestTable.patch(9, { name: 'newer', count: { __op__: 'add', value: 1 } }, { timestamp: now + 100 });
+		await TestTable.get(9); // cache the record and seed the VT slot with its version
+		const inOrder = TestTable.primaryStore.getEntry(9);
+		assert(TestTable.primaryStore.verifyVersion(9, inOrder.version), 'VT should vouch for an in-order version');
+
+		// An out-of-order write merges onto the newer record and is stored under its version, so two
+		// different stored values share that version.
+		await TestTable.patch(9, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 50 });
+		const resequenced = TestTable.primaryStore.getEntry(9);
+		assert.equal(resequenced.version, inOrder.version, 'resequenced write keeps the existing version');
+		assert.equal(resequenced.value.count, 2, 'both increments are applied');
+
+		// The version must never be vouched for once two stored values share it: another worker still
+		// holding the pre-merge value would verify it as fresh and serve it, and an addTo folding onto
+		// that stale value silently drops the increment it merged over. Asserting the sentinel rather
+		// than merely "does not verify": any write clears the slot, so the weaker form would pass
+		// without this change, and the sentinel is also what tells the next reader not to republish.
+		assert(
+			!TestTable.primaryStore.verifyVersion(9, resequenced.version),
+			'VT must not vouch for a version shared by two stored values'
+		);
+		assert(
+			TestTable.primaryStore.verifyVersion(9, Number.MAX_SAFE_INTEGER),
+			'reading a resequenced record must leave the slot parked as unvouchable'
+		);
+	});
+
+	it('an in-order write after a resequenced one restores vouching', async function () {
+		const store = TestTable.primaryStore;
 		const now = Date.now();
 		await TestTable.put(11, { name: 'base', count: 0 });
-		await TestTable.patch(11, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 100 });
-		await TestTable.get(11);
-		await TestTable.get(11);
-		const inOrder = TestTable.primaryStore.getEntry(11);
-		assert(TestTable.primaryStore.verifyVersion(11, inOrder.version));
-
+		await TestTable.patch(11, { name: 'newer', count: { __op__: 'add', value: 1 } }, { timestamp: now + 100 });
 		await TestTable.patch(11, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 50 });
-		assert.equal((await TestTable.get(11)).count, 2);
-		assert(!TestTable.primaryStore.verifyVersion(11, inOrder.version));
+		const reused = store.getEntry(11);
+		assert(!store.verifyVersion(11, reused.version), 'the reused version is not vouched for');
+
+		// The next in-order write advances the version, so the record identifies its own value again
+		// and both the cache and the VT are usable for it. The read that discovers the flag is gone
+		// still asks for no seeding (it was issued while the key was remembered as reused), so it is
+		// the read after it that re-seeds — the same one-read lag as any cold key.
+		await TestTable.patch(11, { name: 'later' }, { timestamp: now + 200 });
+		const advanced = store.getEntry(11);
+		assert(advanced.version > reused.version, 'the in-order write advances the version');
+		assert.equal(advanced.value.count, 2, 'the merged count survives the in-order write');
+		store.getEntry(11);
+		assert(store.verifyVersion(11, advanced.version), 'vouching resumes for a version of its own');
 	});
 });

--- a/unitTests/resources/caching-rocks-database.test.js
+++ b/unitTests/resources/caching-rocks-database.test.js
@@ -141,6 +141,13 @@ describe('PrimaryRocksDatabase', function () {
 		// An out-of-order write merges onto the newer record and is stored under its version, so two
 		// different stored values share that version.
 		await TestTable.patch(9, { count: { __op__: 'add', value: 1 } }, { timestamp: now + 50 });
+		// The WRITE parks the sentinel, before any read decodes the record: a reader-side park leaves
+		// a window in which a worker holding the pre-merge value keeps being confirmed fresh off the
+		// stored record's (reused) version, and with every worker warm no reader ever decodes at all.
+		assert(
+			TestTable.primaryStore.verifyVersion(9, Number.MAX_SAFE_INTEGER),
+			'the resequenced write itself must park the unvouchable sentinel'
+		);
 		const resequenced = TestTable.primaryStore.getEntry(9);
 		assert.equal(resequenced.version, inOrder.version, 'resequenced write keeps the existing version');
 		assert.equal(resequenced.value.count, 2, 'both increments are applied');
@@ -158,6 +165,22 @@ describe('PrimaryRocksDatabase', function () {
 			TestTable.primaryStore.verifyVersion(9, Number.MAX_SAFE_INTEGER),
 			'reading a resequenced record must leave the slot parked as unvouchable'
 		);
+	});
+
+	it('an uncachedRead bypasses the cache vouch and returns the stored record', async function () {
+		const store = TestTable.primaryStore;
+		await TestTable.put(12, { name: 'stored', count: 5 });
+		await TestTable.get(12); // warm the cache and seed the VT slot
+		const cached = store.getEntry(12);
+		assert(store.verifyVersion(12, cached.version), 'VT vouches for the in-order version');
+
+		// A commit-path base read must come from the store (through the caller's transaction
+		// snapshot), never from the vouch fast path — the vouch answers "latest committed", which
+		// is the wrong question for a snapshot read and wrong outright for a reused version.
+		const direct = store.getEntry(12, { uncachedRead: true });
+		assert.equal(direct.value.name, 'stored');
+		assert.equal(direct.value.count, 5);
+		assert.equal(direct.version, cached.version, 'the decoded entry carries the stored version');
 	});
 
 	it('an in-order write after a resequenced one restores vouching', async function () {

--- a/unitTests/resources/caching-rocks-database.test.js
+++ b/unitTests/resources/caching-rocks-database.test.js
@@ -147,7 +147,6 @@ describe('PrimaryRocksDatabase', function () {
 		assert.equal(resequenced.value.count, 2, 'both increments are applied');
 		assert(resequenced.metadataFlags & VERSION_REUSED, 'the stored record is marked non-unique for the native layer');
 		assert(!store.verifyVersion(9, resequenced.version), 'VT must not vouch for a version shared by two stored values');
-		// a read of a flagged record must publish nothing and cache nothing, however many times it runs
 		assert.notEqual(store.getEntry(9).value, resequenced.value, 'a flagged record is never served from cache');
 		assert(!store.verifyVersion(9, resequenced.version), 'reading a flagged record must not publish its version');
 	});
@@ -158,9 +157,7 @@ describe('PrimaryRocksDatabase', function () {
 		await TestTable.get(12); // warm the cache and seed the VT slot
 		const cached = store.getEntry(12);
 		assert(store.verifyVersion(12, cached.version), 'VT vouches for the in-order version');
-		// The vouch fast path returns the cached object itself, so identity is what distinguishes
-		// the two paths — an equal-values assertion would stay green if uncachedRead regressed
-		// into the vouch path and went back to serving stale commit bases.
+		// the vouch fast path returns the cached object itself, so identity is what distinguishes them
 		assert.equal(store.getEntry(12).value, cached.value, 'the vouch path serves the cached object');
 		const direct = store.getEntry(12, { uncachedRead: true });
 		assert.notEqual(direct.value, cached.value, 'uncachedRead must decode from the store, not serve the cache');

--- a/unitTests/resources/caching.test.js
+++ b/unitTests/resources/caching.test.js
@@ -6,7 +6,7 @@ const { table } = require('#src/resources/databases');
 const { Resource } = require('#src/resources/Resource');
 const { setMainIsWorker } = require('#js/server/threads/manageThreads');
 const { RequestTarget } = require('#src/resources/RequestTarget');
-const { VERSION_NOT_UNIQUE_FLAG } = require('#src/resources/RecordEncoder');
+const { VERSION_REUSED } = require('#src/resources/RecordEncoder');
 const { INVALIDATED } = require('#src/resources/Table');
 const { exportIdMapping } = require('#src/resources/nodeIdMapping');
 const { transaction } = require('#src/resources/transaction');
@@ -599,7 +599,7 @@ describe('Caching', () => {
 		assert.equal(ConflictCachingTable.primaryStore.getSync(id).name, 'refreshed');
 		const refreshedEntry = ConflictCachingTable.primaryStore.getEntry(id);
 		assert.equal(refreshedEntry.version, invalidatedVersion);
-		assert(refreshedEntry.metadataFlags & VERSION_NOT_UNIQUE_FLAG);
+		assert(refreshedEntry.metadataFlags & VERSION_REUSED);
 	});
 
 	it('uses a source-reported version before the transaction timestamp', async function () {
@@ -668,7 +668,7 @@ describe('Caching', () => {
 		await waitFor(() => !ConflictCachingTable.primaryStore.hasLock(id));
 		const refreshedEntry = ConflictCachingTable.primaryStore.getEntry(id);
 		assert.equal(refreshedEntry.version, invalidatedVersion);
-		assert(refreshedEntry.metadataFlags & VERSION_NOT_UNIQUE_FLAG);
+		assert(refreshedEntry.metadataFlags & VERSION_REUSED);
 	});
 
 	it('falls back from an invalid source-reported version', async function () {


### PR DESCRIPTION
Fixes the intermittent `QA-431(5): N window(s) with lost counts under multi-worker stress` failure in `integrationTests/resources/ttl-rate-limiter-concurrent.test.ts` — investigated and reproduced as a genuine product defect, not a test timing assumption.

## Root cause

A resequenced (out-of-order CRDT) write stores its merged record under the version it merged onto rather than advancing it — the version is the max applied update timestamp and must stay that way for cross-node convergence — so **one version can identify two different stored values**. Every freshness decision keyed on version equality is then wrong:

1. **Lost writes (the QA-431 failure).** The commit path read its fold base through the record cache's version vouch (first attempt via the resource-phase read, coordinated-retry reloads via `getEntry(key, {transaction})`). The vouch answers "is this the latest committed version?" — the wrong question for a snapshot read, and wrong outright for a reused version — so an `addTo`/patch folded onto the stale pre-merge value and durably overwrote the concurrent increment it had merged over. A patch stores a full record derived from its base, so a stale base also silently resurrects old values of fields the patch didn't mention; a put's stale base corrupts index diffing, blob retention, and residency the same way.
2. **Indefinitely stale reads.** On a VerificationTable miss, the native layer re-confirms freshness against the version stored in the record itself and republishes it. For a reused version this re-vouches the stale holder's cache forever once every worker is warm — observed live as GETs pinned at 41–49/50 until TTL expiry while the store held exactly 50.

## Fix

Harper already writes `[8-byte BE version][4-byte BE metadata word]` at the front of every primary record, and that metadata word **is** the header word rocksdb-js's VerificationTable reads at value offset 8 — its `ACTION_32_BIT` tag byte (14) is exactly the `VERSION_HEADER_TAG` the native predicate requires. So the whole cross-worker half of the fix is one durable bit:

- [`VERSION_REUSED`](https://github.com/HarperFast/harper/pull/2259/changes?w=1#diff-d175bc619774c0fb18833823092f139f0ba6a0eb4503f49159fd5c2e0e324f38R129) is rocksdb-js's `constants.VERSION_NOT_UNIQUE_FLAG`, [set in `recordUpdater`](https://github.com/HarperFast/harper/pull/2259/changes?w=1#diff-d175bc619774c0fb18833823092f139f0ba6a0eb4503f49159fd5c2e0e324f38R910) whenever a RocksDB record write does not advance past the version it replaces. Every record write funnels through that one place. rocksdb-js 2.8.0 then never answers `FRESH` for such a value and never publishes it to a slot, on every read path — sync, async, and both transactional ones ([HarperFast/rocksdb-js#766](https://github.com/HarperFast/rocksdb-js/pull/766)).
- The [JS record cache refuses to hold a flagged record](https://github.com/HarperFast/harper/pull/2259/changes?w=1#diff-857a3b7947228534c5055a20509e57ee05474fb84e726499a502a2cfc9631f83R170) and drops any copy it already had.
- New [`uncachedRead` option](https://github.com/HarperFast/harper/pull/2259/changes?w=1#diff-857a3b7947228534c5055a20509e57ee05474fb84e726499a502a2cfc9631f83R127) on `PrimaryRocksDatabase.getEntry`: a plain transaction-snapshot read — no vouch trust, no VT seeding, no cache publish. Every record-write kind that derives stored state from its base (update, put, delete, invalidate, relocate — marked with an explicit `reloadCommitBase` flag) [reloads that base at commit through it](https://github.com/HarperFast/harper/pull/2259/changes?w=1#diff-2ae62080514cb4ef64bf50088e7ea0587701f558af71f76b119f07e00f3d56beR925); bulk copy-apply rows and crash-recovery replays keep their pre-read base (one read per row, as before — their convergence contract is the post-copy/replay pass), and a cold read for a kind that keeps its own conflict semantics (publish/message/sourcedFrom resolve, and a replay's cold read) still takes the vouch fast path. Both [`previousResidency`](https://github.com/HarperFast/harper/pull/2259/changes?w=1#diff-4ff51263bd99981165fc179149c3195ea0c0ca3e2f360bafee2a6bb356964377R3035) and [created-time retention](https://github.com/HarperFast/harper/pull/2259/changes?w=1#diff-4ff51263bd99981165fc179149c3195ea0c0ca3e2f360bafee2a6bb356964377R2557) are derived from the reloaded base. Without the delete-path reload, a delete diffing indices from a stale base left phantom index entries for the deleted record.

Because the bit lands in a persisted record, a [module-load guard](https://github.com/HarperFast/harper/pull/2259/changes?w=1#diff-d175bc619774c0fb18833823092f139f0ba6a0eb4503f49159fd5c2e0e324f38R133) fails fast if a future rocksdb-js moves `VERSION_NOT_UNIQUE_FLAG` onto one of Harper's own metadata flags, into the tag byte, or removes it — a silently-unset flag is a silent return of the data-loss bug; the message names the minimum rocksdb-js version it requires (`>= 2.8.0`).

This replaces the earlier JS-only compensation (a `VERSION_UNVOUCHABLE` sentinel parked in the VT slot by the writer, plus a `verifyVersion` probe on every warm read). That machinery — the writer-side park with its backoff/verify/resolve ladder, the reader-side sentinel checks, and the residual re-vouch race it could not close — is entirely gone.

### Consolidated with #2065

`main` independently landed an overlapping fix for the *same* bug (PR #2065, merged 2026-08-29, same day this PR was opened): it set the identical `VERSION_NOT_UNIQUE_FLAG` bit, with the identical guard predicate, in the same `recordUpdater()` function, for its own `getFromSource` source-fill write path. This branch's generic in-`recordUpdater` fix already covers that call site (every write, including source-fill, funnels through the one patched function), so the rebase consolidated onto this PR's implementation as canonical — broader (every write, not just source-fill), sourced from rocksdb-js's own `constants` export instead of a hardcoded local value, guarded against the constant drifting out of Harper's reserved bit range, and kept out of `assignMetadata`/the audit `extendedType` bits that `assignMetadata` also feeds. #2065's redundant inline block and its two duplicate-intent tests were folded into this PR's `VERSION_REUSED` mechanism rather than dropped; #2065's disjoint `Table.ts` source-version capping/tie-breaking changes are unrelated to the flag and carried through untouched.

## Verification

- **Red on unpatched main:** amplified QA-431(5)-shaped repro (same fixture, in-burst GET pressure, `taskset` to 4 CPUs) lost increments in 3–15 windows per 900, with a per-vouch audit proving the losses durable. **The bit is load-bearing on 2.8.0**: with `metadataInNextEncoding |= VERSION_REUSED` disabled and everything else in place, `unitTests/resources/caching-rocks-database.test.js` fails at `VT must not vouch for a version shared by two stored values` — the native layer vouches the reused version. Both new unit assertions ([flag set](https://github.com/HarperFast/harper/pull/2259/changes?w=1#diff-e074583cf8528e1c18406545c4fb05e500524e1ab4f74b7a9b0b5413c43aa8daR130), refusal to vouch) fail without it, and a [client-level read](https://github.com/HarperFast/harper/pull/2259/changes?w=1#diff-e074583cf8528e1c18406545c4fb05e500524e1ab4f74b7a9b0b5413c43aa8daR151) proves a caller sees the merged value rather than a stale vouch.
- **Green with the fix:** [`ttl-rate-limiter-convergence.test.ts`](https://github.com/HarperFast/harper/pull/2259/changes?w=1#diff-0c05a8d549c72b32907b8fa6ae7e877d727edb2f23a55e1b9973993736d9790fR1) — 100/100 windows exact, zero converged-late, zero stuck-short, zero over-count, run four separate times across this rebase (twice pre- and twice post- the round-12/13 fixes below); the unmodified `ttl-rate-limiter-concurrent.test.ts` 5/5 including QA-431(5).
- Local gates at the earlier rebase point (`main`@`5cd0e2c12`): `npm run build` clean; `npm run test:unit:resources` — 2020 passing / 0 failing / 29 pending (2 timeout-based failures in an unrelated `branchDatabase.test.js` suite were box-load contention from other agents' concurrent runs on this shared machine, not this change — confirmed by an isolated re-run: 70/70 passing); `unitTests/resources/caching-rocks-database.test.js` + `caching.test.js` 47/47 passing. The branch has since been rebased onto `main`@`106372f96` (current `origin/main`), where full CI is green on the head — see the first reviewer note below.

## For the human reviewer

- **The one open major, and it is yours to call:** a `reloadCommitBase` write still pays a second point read + decode of its base at commit time, on both storage engines — LMDB pays it despite having no VerificationTable defect to dodge. Now that the native layer refuses to vouch for a reused version, independent review (codex, twice across rounds) argues the reload is redundant belt-and-braces — the cheaper shape proposed is to make the *existing* resource-phase pre-read snapshot-direct and reuse it, one read instead of two. I kept the reload because the pre-read's base can also arrive from `this.#entry`, which may have been populated by an application `get()` well outside the committing transaction, and narrowing that correctly touches three write paths; reversing it later is one predicate change plus a re-run of the convergence suite to prove the flag alone holds.
- **CI is green on this head (`e497027d2`, based on `main`@`106372f96`):** every check passes, including the four this PR was flagged on — `Unit Test (Node.js v22)` and all three `Next.js adapter integration` jobs (Node 20/22/24). Two separate causes were behind the earlier red. The first was `npm install` steps stalling across unrelated jobs and repos within one run (npm-registry conditions, not this diff — `Next.js adapter integration` never reaches Harper's code on that step); it cleared without a code change. The second, on `62c490ff7`, was real and this PR's: round 3 tightened the `_writeInvalidate`/`_writeRelocate` version guard from `< 0` to `<= 0` to gate a `storedReusedVersion` marking, round 6 replaced that marking with `VERSION_NOT_UNIQUE_FLAG` and deleted the tracking but left the tightened comparison behind with nothing reading it. `precedesExistingVersion` already breaks a version tie on node name, so only a same-node tie reaches `0` — and skipping it discarded the audit-clock write that #2497's dual-clock work (which arrived on this rebase) records for an applied invalidate/relocate whose log key advanced while its record version did not, failing the two log-key-pointer assertions in `unitTests/resources/dualClockAuditRecord.test.js`. [`e497027d2`](https://github.com/HarperFast/harper/pull/2259/commits/e497027d28680c5780d2e0f8e1648fe4685c9c1a) restores `< 0`.
- **One small unexplained timing delta:** `Unit Test` on this head runs ~1–2 min slower than the same jobs on its own base `main`@`106372f96` the same day (v22 10m02s vs 9m, v24 9m52s vs 8m, v26 9m12s vs 8m). `main`'s own runs vary between 8 and 10 min, so this sits inside the noise band, but it points the same direction as the commit-base reload's added write-path cost noted in the first bullet above, and the `Run tests` step cap is 15 min.
- **New, from this rebase's independent review — a real gap, not fixed here:** the reload's safety only holds when the committing transaction holds a snapshot for RocksDB's optimistic conflict validation to check the later `Put` against (verified against rocksdb-js's binding: `SetSnapshot()` is gated on `!disableSnapshot` on every Get/Put/Delete path). Harper sets `this.snapshotFree = true` after a mid-scope-commit rotation (a scope that commits more than once), and a snapshot-free transaction gets no such validation — the reload narrows the lost-update window to the read-to-put span instead of closing it (see the comment at `DatabaseTransaction.ts` around the reload). Closing it needs either a rocksdb-js API to force a snapshot on one read of an otherwise snapshot-free transaction, or having Harper skip the snapshot-free rotation for a scope that will do a `reloadCommitBase` write — both bigger than this PR. The primary defense (the persisted `VERSION_REUSED` flag + native VT refusal) does not depend on this reload and is unaffected.
- **Design choice:** compensating for "one version, two values" with a durable non-uniqueness bit rather than advancing the version on resequenced folds — advancing would fabricate a timestamp no real update carries and break cross-node CRDT convergence.
- **Durable uncacheability:** a flagged key stays uncached/unvouched until its next in-order write rewrites it — a caching cliff for resequencing-heavy tables (e.g. replicated counters with clock skew) that no metric currently surfaces. The predicate flags ties (`newVersion <= existing`) too, so same-timestamp deletes and relocates that deliberately hold their version are flagged as well.
- **Load-time throw:** the flag-range guard crashes startup rather than degrading if rocksdb-js ever ships without the constant. That is deliberate — the failure it prevents is silent data loss — but it is a hard dependency on 2.8.0+.
- **Test-oracle tolerances (declined, repeatedly flagged in review):** the convergence oracle counts `acked === 0` windows as inconclusive with a 50% floor, admits convergence within a 400 ms poll, and treats `hits <= acked + errs` as exact-or-explained. Each absorbs a real failure it could otherwise catch. It is deliberately tolerant so the test is not flaky on loaded CI runners; a deterministic cross-worker regression test (including a tombstone that reuses a version, which nothing covers today) would be strictly better and is not in this PR.
- **`validate()` runs once:** created-time retention now reads the reloaded base, but `validate()` is not re-run on a conflict retry, so a retry that reloads a *newly created* base still keeps the first round's decision. Pre-existing structure, not introduced by this PR; re-running `validate()` on retry would also re-run schema validation and audit dedup, which is its own change.
- **Write kinds outside the reload set:** publish/message writers and sourcedFrom cache-fill resolves keep their own conflict semantics and are not marked `reloadCommitBase` — worth a follow-up look rather than widening this PR.
- **Rebased onto current `main`, consolidating with #2065** (see above) — main's overlapping flag logic and two duplicate-intent tests were folded into this PR's mechanism rather than kept side-by-side; main's disjoint source-version capping/tie-breaking changes in the same files carried through untouched. Independent review caught and this rebase fixed two real regressions the consolidation introduced: (1) the merge reordered `metadataInNextEncoding = assignMetadata` ahead of the `VERSION_REUSED` OR instead of after it, so the documented `assignMetadata = -1` default silently dropped the metadata word — and the flag with it — for any resequenced write reaching `recordUpdater` through that default (latent in-repo, but live via the function's direct callers); restored the dropped `Math.max(assignMetadata, 0)` normalization main's replaced line had. (2) A comment overclaimed the snapshot-free conflict guarantee described above — corrected instead of left wrong. Also strengthened two tests independent review flagged as gaps: the integration test's 30s readiness wait now throws instead of silently falling through on timeout, and the reused-version unit test now asserts a client-level read (not just internal `verifyVersion`/`metadataFlags` state).

Refs #1881 (same version-reuse family, index-scan surface).

Signed: Claude Sonnet 5 (dispatch agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Review-Coverage: authored=claude; ran=gemini,codex; adjudicated=domain; declined=cursor-grok,cursor-composer; rounds=15 @ e497027d2868</sub>

<sub>Human-Review-Need: 3 (decisions: reload-every-write-vs-targeted, js-cache-exclusion-on-top-of-native-refusal, runtime-guard-on-pinned-constant, alias-name-across-boundary, ship-throwaway-bench, oracle-tolerance, snapshot-free-gap-deferred) @ e497027d2868</sub>
