### PR TITLE
Allow a component-registered operation to be granted in a role's operations allowlist

### DIFF
--- a/integrationTests/components/fixtures/registered-operation/resources.js
+++ b/integrationTests/components/fixtures/registered-operation/resources.js
@@ -37,3 +37,18 @@ server.registerOperation({
 		throw error;
 	},
 });
+
+// requiresSuperUser makes this one both enforced and grantable, which is what puts its name in
+// front of the main thread's validateOperations.
+server.registerOperation({
+	name: 'component_registered_grantable',
+	requiresSuperUser: true,
+	execute: async function componentRegisteredGrantable(op) {
+		return {
+			granted: true,
+			executedOnMainThread: isMainThread,
+			executedOnThreadId: threadId,
+			username: op.hdb_user?.username ?? null,
+		};
+	},
+});

--- a/integrationTests/components/fixtures/registered-operation/resources.js
+++ b/integrationTests/components/fixtures/registered-operation/resources.js
@@ -38,8 +38,6 @@ server.registerOperation({
 	},
 });
 
-// requiresSuperUser makes this one both enforced and grantable, which is what puts its name in
-// front of the main thread's validateOperations.
 server.registerOperation({
 	name: 'component_registered_grantable',
 	requiresSuperUser: true,

--- a/integrationTests/components/registered-operation.test.ts
+++ b/integrationTests/components/registered-operation.test.ts
@@ -26,6 +26,17 @@ const GRANTED_USER = 'component_op_granted_user';
 const UNGRANTED_ROLE = 'component_op_ungranted_role';
 const UNGRANTED_USER = 'component_op_ungranted_user';
 const USER_PASS = 'Abc1234!';
+// A trust policy the OIDC operation will accept on every axis except the one under test, so a
+// rejection can only be about the operation name. Shapes taken from the GitHub Actions profile's
+// own requirements: a canonical audience (explicit port, trailing slash) and specific claims.
+const TRUST_POLICY = {
+	issuer: 'https://token.actions.githubusercontent.com',
+	audience: 'https://my-instance.harperdb.io:9925/',
+	claims: {
+		repository_id: '67890',
+		workflow_ref: 'HarperFast/my-app/.github/workflows/deploy.yml@refs/heads/main',
+	},
+};
 
 suite('Component: registered-operation (#1736)', (ctx: ContextWithHarper) => {
 	async function op(body: any): Promise<{ status: number; body: any }> {
@@ -193,6 +204,34 @@ suite('Component: registered-operation (#1736)', (ctx: ContextWithHarper) => {
 
 			const { status, body } = await asUser(UNGRANTED_USER, { operation: GRANTABLE_OP });
 			strictEqual(status, 403, JSON.stringify(body));
+		});
+
+		test('add_oidc_trust accepts the op in a trust policy scope', async () => {
+			// The third main-thread consumer of validateOperations, and the one whose own source
+			// documented this gap as a known limitation until this change.
+			const { status, body } = await op({
+				operation: 'add_oidc_trust',
+				id: 'component-op-policy',
+				...TRUST_POLICY,
+				user: GRANTED_USER,
+				operations: [GRANTABLE_OP],
+			});
+			strictEqual(status, 200, JSON.stringify(body));
+		});
+
+		test('add_oidc_trust still rejects an op name no component registered', async () => {
+			const { status, body } = await op({
+				operation: 'add_oidc_trust',
+				id: 'component-op-bogus-policy',
+				...TRUST_POLICY,
+				user: GRANTED_USER,
+				operations: ['component_registered_never_declared'],
+			});
+			strictEqual(status, 400, JSON.stringify(body));
+			ok(
+				JSON.stringify(body).includes('not a Harper operation'),
+				`expected the trust-policy rejection, got: ${JSON.stringify(body)}`
+			);
 		});
 
 		test('impersonation accepts an inline role naming the op', async () => {

--- a/integrationTests/components/registered-operation.test.ts
+++ b/integrationTests/components/registered-operation.test.ts
@@ -207,7 +207,6 @@ suite('Component: registered-operation (#1736)', (ctx: ContextWithHarper) => {
 		});
 
 		test('add_oidc_trust accepts the op in a trust policy scope', async () => {
-			// The third main-thread consumer of validateOperations.
 			const { status, body } = await op({
 				operation: 'add_oidc_trust',
 				id: 'component-op-policy',

--- a/integrationTests/components/registered-operation.test.ts
+++ b/integrationTests/components/registered-operation.test.ts
@@ -6,6 +6,11 @@
  * OPERATION_FUNCTION_MAP instances; the ops-API dispatcher runs on the main thread with its
  * own instance. The cross-thread bridge (server/serverHelpers/registeredOperations.ts)
  * forwards an unrecognized operation to one registering worker and relays the result.
+ *
+ * The same split governs the role `operations` allowlist: registerOperationPermission marks a
+ * declared op grantable on the worker, but validateOperations is consulted on the main thread.
+ * Only an integration test crosses that boundary — unit tests register and validate on one
+ * thread, so the topology, and therefore the gap, is invisible to them.
  */
 import { suite, test, before, after } from 'node:test';
 import { strictEqual, ok } from 'node:assert';
@@ -15,6 +20,14 @@ import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'fixtures/registered-operation');
 
+// The one op the fixture declares a permission for, and so the only grantable one.
+const GRANTABLE_OP = 'component_registered_grantable';
+const GRANTED_ROLE = 'component_op_granted_role';
+const GRANTED_USER = 'component_op_granted_user';
+const UNGRANTED_ROLE = 'component_op_ungranted_role';
+const UNGRANTED_USER = 'component_op_ungranted_user';
+const USER_PASS = 'Abc1234!';
+
 suite('Component: registered-operation (#1736)', (ctx: ContextWithHarper) => {
 	async function op(body: any): Promise<{ status: number; body: any }> {
 		const { username, password } = ctx.harper.admin;
@@ -23,6 +36,18 @@ suite('Component: registered-operation (#1736)', (ctx: ContextWithHarper) => {
 			headers: {
 				'Content-Type': 'application/json',
 				'Authorization': `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`,
+			},
+			body: JSON.stringify(body),
+		});
+		return { status: response.status, body: await response.json() };
+	}
+
+	async function asUser(username: string, body: any): Promise<{ status: number; body: any }> {
+		const response = await fetch(ctx.harper.operationsAPIURL, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Basic ${Buffer.from(`${username}:${USER_PASS}`).toString('base64')}`,
 			},
 			body: JSON.stringify(body),
 		});
@@ -87,5 +112,101 @@ suite('Component: registered-operation (#1736)', (ctx: ContextWithHarper) => {
 		const { status, body } = await op({ operation: 'definitely_not_registered_anywhere' });
 		strictEqual(status, 400, JSON.stringify(body));
 		ok(JSON.stringify(body).includes('not found'), `expected operation-not-found error, got: ${JSON.stringify(body)}`);
+	});
+
+	suite('grantable in a role `operations` allowlist across the worker/main boundary', () => {
+		before(async () => {
+			// The announcement is fire-and-forget ITC. A successful forward proves the handler ran, and
+			// it carries the grantable flag in the same message — so this gates on the exact state
+			// these tests depend on, rather than on elapsed time.
+			const deadline = Date.now() + 15_000;
+			for (;;) {
+				const { status } = await op({ operation: GRANTABLE_OP });
+				if (status === 200) break;
+				if (Date.now() > deadline) throw new Error(`main thread never registered '${GRANTABLE_OP}'`);
+				await new Promise((resolve) => setTimeout(resolve, 100));
+			}
+		});
+
+		test('add_role accepts the worker-registered op name in `operations`', async () => {
+			const { status, body } = await op({
+				operation: 'add_role',
+				role: GRANTED_ROLE,
+				permission: { operations: [GRANTABLE_OP] },
+			});
+			strictEqual(status, 200, JSON.stringify(body));
+		});
+
+		test('add_role still rejects an op name no component registered', async () => {
+			// Negative control: proves the assertion above is not passing because validateOperations
+			// was skipped for this payload shape.
+			const { status, body } = await op({
+				operation: 'add_role',
+				role: 'component_op_bogus_role',
+				permission: { operations: ['component_registered_never_declared'] },
+			});
+			strictEqual(status, 400, JSON.stringify(body));
+			ok(
+				JSON.stringify(body).includes('component_registered_never_declared'),
+				`expected the offending op name in the error, got: ${JSON.stringify(body)}`
+			);
+		});
+
+		test('alter_role accepts it too', async () => {
+			const { status, body } = await op({
+				operation: 'alter_role',
+				id: GRANTED_ROLE,
+				permission: { operations: [GRANTABLE_OP, 'user_info'] },
+			});
+			strictEqual(status, 200, JSON.stringify(body));
+		});
+
+		test('a non-super_user granted the op can actually call it', async () => {
+			const added = await op({
+				operation: 'add_user',
+				role: GRANTED_ROLE,
+				username: GRANTED_USER,
+				password: USER_PASS,
+				active: true,
+			});
+			strictEqual(added.status, 200, JSON.stringify(added.body));
+
+			const { status, body } = await asUser(GRANTED_USER, { operation: GRANTABLE_OP });
+			strictEqual(status, 200, JSON.stringify(body));
+			strictEqual(body.granted, true);
+			strictEqual(body.username, GRANTED_USER);
+			// Still executed on the worker — main only had to accept the name, not enforce it.
+			strictEqual(body.executedOnMainThread, false);
+		});
+
+		test('a non-super_user without the grant is still denied (enforcement unchanged)', async () => {
+			const role = await op({
+				operation: 'add_role',
+				role: UNGRANTED_ROLE,
+				permission: { operations: ['user_info'] },
+			});
+			strictEqual(role.status, 200, JSON.stringify(role.body));
+			const added = await op({
+				operation: 'add_user',
+				role: UNGRANTED_ROLE,
+				username: UNGRANTED_USER,
+				password: USER_PASS,
+				active: true,
+			});
+			strictEqual(added.status, 200, JSON.stringify(added.body));
+
+			const { status, body } = await asUser(UNGRANTED_USER, { operation: GRANTABLE_OP });
+			strictEqual(status, 403, JSON.stringify(body));
+		});
+
+		test('impersonation accepts an inline role naming the op', async () => {
+			// applyImpersonation runs validateOperations on the main thread too.
+			const { status, body } = await op({
+				operation: GRANTABLE_OP,
+				impersonate: { role: { permission: { operations: [GRANTABLE_OP] } } },
+			});
+			strictEqual(status, 200, JSON.stringify(body));
+			strictEqual(body.granted, true);
+		});
 	});
 });

--- a/integrationTests/components/registered-operation.test.ts
+++ b/integrationTests/components/registered-operation.test.ts
@@ -137,7 +137,6 @@ suite('Component: registered-operation (#1736)', (ctx: ContextWithHarper) => {
 		});
 
 		test('add_role still rejects an op name no component registered', async () => {
-			// Guards the test above: a validateOperations that stopped running would look like a pass.
 			const { status, body } = await op({
 				operation: 'add_role',
 				role: 'component_op_bogus_role',

--- a/integrationTests/components/registered-operation.test.ts
+++ b/integrationTests/components/registered-operation.test.ts
@@ -207,8 +207,7 @@ suite('Component: registered-operation (#1736)', (ctx: ContextWithHarper) => {
 		});
 
 		test('add_oidc_trust accepts the op in a trust policy scope', async () => {
-			// The third main-thread consumer of validateOperations, and the one whose own source
-			// documented this gap as a known limitation until this change.
+			// The third main-thread consumer of validateOperations.
 			const { status, body } = await op({
 				operation: 'add_oidc_trust',
 				id: 'component-op-policy',

--- a/integrationTests/components/registered-operation.test.ts
+++ b/integrationTests/components/registered-operation.test.ts
@@ -20,7 +20,6 @@ import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '
 
 const FIXTURE_PATH = resolve(import.meta.dirname, 'fixtures/registered-operation');
 
-// The one op the fixture declares a permission for, and so the only grantable one.
 const GRANTABLE_OP = 'component_registered_grantable';
 const GRANTED_ROLE = 'component_op_granted_role';
 const GRANTED_USER = 'component_op_granted_user';
@@ -175,7 +174,6 @@ suite('Component: registered-operation (#1736)', (ctx: ContextWithHarper) => {
 			strictEqual(status, 200, JSON.stringify(body));
 			strictEqual(body.granted, true);
 			strictEqual(body.username, GRANTED_USER);
-			// Still executed on the worker — main only had to accept the name, not enforce it.
 			strictEqual(body.executedOnMainThread, false);
 		});
 

--- a/integrationTests/components/registered-operation.test.ts
+++ b/integrationTests/components/registered-operation.test.ts
@@ -138,8 +138,8 @@ suite('Component: registered-operation (#1736)', (ctx: ContextWithHarper) => {
 		});
 
 		test('add_role still rejects an op name no component registered', async () => {
-			// Negative control: proves the assertion above is not passing because validateOperations
-			// was skipped for this payload shape.
+			// Guards the test above: without this, a validateOperations that stopped running at all
+			// would look like a pass.
 			const { status, body } = await op({
 				operation: 'add_role',
 				role: 'component_op_bogus_role',
@@ -200,7 +200,6 @@ suite('Component: registered-operation (#1736)', (ctx: ContextWithHarper) => {
 		});
 
 		test('impersonation accepts an inline role naming the op', async () => {
-			// applyImpersonation runs validateOperations on the main thread too.
 			const { status, body } = await op({
 				operation: GRANTABLE_OP,
 				impersonate: { role: { permission: { operations: [GRANTABLE_OP] } } },

--- a/integrationTests/components/registered-operation.test.ts
+++ b/integrationTests/components/registered-operation.test.ts
@@ -137,8 +137,7 @@ suite('Component: registered-operation (#1736)', (ctx: ContextWithHarper) => {
 		});
 
 		test('add_role still rejects an op name no component registered', async () => {
-			// Guards the test above: without this, a validateOperations that stopped running at all
-			// would look like a pass.
+			// Guards the test above: a validateOperations that stopped running would look like a pass.
 			const { status, body } = await op({
 				operation: 'add_role',
 				role: 'component_op_bogus_role',

--- a/security/authn/oidc/trustPolicyOperations.ts
+++ b/security/authn/oidc/trustPolicyOperations.ts
@@ -53,15 +53,6 @@ function validate(validation: any): void {
  * caught here, where the reader is the administrator who wrote it. Delegates to the same helper
  * add_role/alter_role use, so group names resolve identically rather than through a second
  * definition that could drift.
- *
- * Known limitation, inherited rather than introduced: that helper's registry of runtime-registered
- * operations is process-local, and the OPERATION_REGISTERED bridge propagates only name→thread
- * routing, never grantability (server/serverHelpers/registeredOperations.ts). A component's
- * `server.registerOperation` runs in a worker while this operation runs on the main thread, so an
- * operation registered that way is NOT recognized here and a policy naming one is rejected. It
- * fails closed — a rejected policy, never a widened one — and `add_role`, `alter_role`, and
- * impersonation validation all share the gap, which is why the fix belongs to that bridge rather
- * than to a local workaround here.
  */
 function assertOperationsAreKnown(operations: string[]): void {
 	const invalidOperation = validateOperations(operations);

--- a/server/DESIGN.md
+++ b/server/DESIGN.md
@@ -148,6 +148,16 @@ must run on a worker, `registeredOperations.ts` carries that state in the same-p
 separately from the structured-cloned body. Never attach trusted dispatch state to an operation
 payload.
 
+`server.registerOperation()` runs per-worker, so anything the **main** thread must later know about a
+registered op has to ride the OPERATION_REGISTERED announcement — a module-local registry populated
+during registration exists only in the worker that registered. The bridge carries two such facts
+today: name→thread routing (for execution forwarding) and `grantable` (so `validateOperations` on
+main will accept the name in a role's `operations` allowlist, for add_role/alter_role, impersonation,
+and OIDC trust policies). Adding a third main-thread consumer of a worker-registered fact means
+extending that message, not reading a registry that main never populated. Grantability is safe to
+mirror because it only widens what an allowlist may _name_; enforcement stays on the worker's
+`chooseOperation`.
+
 ## Resource ↔ HTTP boundary
 
 `REST.ts → http(request, nextHandler)` is the chief integration point: it takes a `Request`, asks the `Resources` registry for a match, builds a `RequestTarget`, and dispatches into the Resource class's static method. Cache headers are translated to `request.expiresAt` / `onlyIfCached` / `noCache` flags within the same function.

--- a/server/serverHelpers/registeredOperations.ts
+++ b/server/serverHelpers/registeredOperations.ts
@@ -26,7 +26,7 @@ import * as env from '../../utility/environment/environmentManager.ts';
 import harperLogger from '../../utility/logging/harper_logger.ts';
 import { ServerError } from '../../utility/errors/hdbError.ts';
 import { sendItcEvent } from '../threads/itc.js';
-import { hasThreadExited, onMessageByType, onThreadExit } from '../threads/manageThreads.js';
+import { onMessageByType, onThreadExit } from '../threads/manageThreads.js';
 import {
 	registerWorkerGrantableOperation,
 	unregisterWorkerGrantableOperation,
@@ -66,6 +66,14 @@ const registeredByWorker = new Map<string, Set<number>>();
 // Per originator, not per name: a rolling deploy whose new generation drops `requiresSuperUser`
 // must keep routing the name while retracting grantability, which a name-level flag cannot express.
 const grantableByWorker = new Map<string, Set<number>>();
+// Threads already reported dead, so an announcement that lost the race with its own thread's exit
+// cannot install an entry no later exit event will clean up — including a thread whose FIRST
+// announcement is the one in flight, which is why this cannot be narrowed to threads already
+// holding a registration. One integer per dead thread, never pruned, matching the growth profile
+// manageThreads accepts for notifiedDeadThreadIds; it cannot reject a replacement because worker
+// ids are monotonically increasing and not reused within a process. Deliberately a local set:
+// reading manageThreads' equivalent regressed Windows worker-restart timing (see PR #2260).
+const exitedThreadIds = new Set<number>();
 const pendingExecutions = new Map<
 	number,
 	{ targetThreadId: number; resolve: (result: any) => void; reject: (error: Error) => void }
@@ -95,11 +103,7 @@ export function operationRegisteredHandler(event: {
 	if (!isMainThread) return;
 	const { name, grantable, originator } = event?.message ?? {};
 	if (typeof name !== 'string' || typeof originator !== 'number') return;
-	// An announcement can lose the race with its own thread's exit, and exit notification fires once
-	// per thread, so without this the entry would never be cleaned up. Reads manageThreads' tombstone
-	// rather than keeping a second one: job threads are one-shot workers, so a duplicate here would
-	// grow per completed job, not per worker restart.
-	if (hasThreadExited(originator)) {
+	if (exitedThreadIds.has(originator)) {
 		operationLog.debug(`Ignoring operation '${name}' announced by exited worker thread ${originator}`);
 		return;
 	}
@@ -117,6 +121,7 @@ export function operationRegisteredHandler(event: {
  * waiting out the timeout, and forget its registrations (a replacement re-registers on load).
  */
 function handleThreadExit(deadThreadId: number) {
+	exitedThreadIds.add(deadThreadId);
 	for (const [name, workerIds] of registeredByWorker) {
 		if (!workerIds.delete(deadThreadId)) continue;
 		// A surviving worker that never declared a permission must not keep the name admissible.
@@ -129,6 +134,10 @@ function handleThreadExit(deadThreadId: number) {
 			pending.reject(new ServerError('The worker thread executing this operation exited', 503));
 		}
 	}
+}
+
+export function notifyThreadExitedForTest(deadThreadId: number) {
+	handleThreadExit(deadThreadId);
 }
 
 function setWorkerGrantable(name: string, threadId: number, grantable: boolean) {

--- a/server/serverHelpers/registeredOperations.ts
+++ b/server/serverHelpers/registeredOperations.ts
@@ -64,6 +64,17 @@ export function setLocalOperationDispatch(dispatch: typeof localDispatch) {
 
 /** name -> threadIds of workers that registered it (main thread only) */
 const registeredByWorker = new Map<string, Set<number>>();
+// name -> threadIds that declared it grantable. Tracked per originator rather than per name so the
+// mirrored mark lives exactly as long as a live worker declares it: a rolling deploy whose new
+// generation drops `requiresSuperUser` keeps the routing entry (it still executes) while retracting
+// grantability, which a name-level flag cannot express.
+const grantableByWorker = new Map<string, Set<number>>();
+// Threads already reported dead. Exit notification is deduplicated for the life of the process
+// (manageThreads.notifyThreadExit), so an announcement that lost a race with its own thread's exit
+// would otherwise install an entry no later exit event can ever clean up. Never pruned, and never
+// wrongly rejects a replacement: worker ids are monotonically increasing and not reused in a
+// process, so this grows by one per worker restart (the same reasoning as notifiedDeadThreadIds).
+const exitedThreadIds = new Set<number>();
 const pendingExecutions = new Map<
 	number,
 	{ targetThreadId: number; resolve: (result: any) => void; reject: (error: Error) => void }
@@ -96,22 +107,70 @@ export function operationRegisteredHandler(event: {
 	// Arm thread-exit cleanup when the registry gains its first entry, not on the first forward:
 	// a worker that exits before any call would otherwise leave its entries here forever.
 	attachMainListeners();
+	if (exitedThreadIds.has(originator)) {
+		operationLog.debug(`Ignoring operation '${name}' announced by exited worker thread ${originator}`);
+		return;
+	}
 	let workerIds = registeredByWorker.get(name);
 	if (!workerIds) registeredByWorker.set(name, (workerIds = new Set()));
 	workerIds.add(originator);
 	// Mirroring only widens what an allowlist may name; enforcement stays on the worker's own
-	// chooseOperation.
-	if (grantable) registerWorkerGrantableOperation(name);
+	// chooseOperation. A re-announcement that no longer declares a permission retracts this
+	// thread's claim rather than leaving a stale one behind.
+	setWorkerGrantable(name, originator, grantable === true);
 	operationLog.debug(`Registered operation '${name}' announced by worker thread ${originator}`);
 }
 
 /**
- * Forget an operation whose last registering worker is gone. Both prune paths (thread exit, and a
- * failed send discovering a dead port) must route through here so routing and grantability can
- * never disagree about whether the op is still offered.
+ * A worker that dies mid-execution can never respond, so fail its in-flight forwards rather than
+ * waiting out the timeout, and forget its registrations (a replacement re-registers on load).
+ */
+function handleThreadExit(deadThreadId: number) {
+	exitedThreadIds.add(deadThreadId);
+	for (const [name, workerIds] of registeredByWorker) {
+		workerIds.delete(deadThreadId);
+		// Retract this thread's grantability claim even when others still route the name — a
+		// remaining worker that never declared a permission must not keep it admissible.
+		if (workerIds.size === 0) dropRegistration(name);
+		else setWorkerGrantable(name, deadThreadId, false);
+	}
+	for (const [requestId, pending] of pendingExecutions) {
+		if (pending.targetThreadId === deadThreadId) {
+			pendingExecutions.delete(requestId);
+			pending.reject(new ServerError('The worker thread executing this operation exited', 503));
+		}
+	}
+}
+
+/** Test seam for the cleanup above, which `attachMainListeners` wires to the real thread-exit event. */
+export function notifyThreadExitedForTest(deadThreadId: number) {
+	handleThreadExit(deadThreadId);
+}
+
+/** Record or retract one thread's grantability claim, then re-derive the mirrored mark from live claims. */
+function setWorkerGrantable(name: string, threadId: number, grantable: boolean) {
+	let grantableIds = grantableByWorker.get(name);
+	if (grantable) {
+		if (!grantableIds) grantableByWorker.set(name, (grantableIds = new Set()));
+		grantableIds.add(threadId);
+	} else {
+		grantableIds?.delete(threadId);
+	}
+	if (grantableIds?.size) registerWorkerGrantableOperation(name);
+	else {
+		grantableByWorker.delete(name);
+		unregisterWorkerGrantableOperation(name);
+	}
+}
+
+/**
+ * Forget an operation no live worker offers any more. Both prune paths — thread exit, and a failed
+ * send discovering a dead port — route through here so a name can never keep a route without an
+ * owner. Grantability is dropped per owner instead, in `setWorkerGrantable`.
  */
 function dropRegistration(name: string) {
 	registeredByWorker.delete(name);
+	grantableByWorker.delete(name);
 	unregisterWorkerGrantableOperation(name);
 }
 
@@ -145,21 +204,7 @@ function attachMainListeners() {
 		if (error) pending.reject(new ServerError(error.message, error.statusCode || 500));
 		else pending.resolve(result);
 	});
-	// A worker that dies mid-execution can never respond; fail its in-flight forwards rather
-	// than waiting out the timeout, and forget its registrations (a replacement worker
-	// re-registers on component load).
-	onThreadExit((deadThreadId: number) => {
-		for (const [name, workerIds] of registeredByWorker) {
-			workerIds.delete(deadThreadId);
-			if (workerIds.size === 0) dropRegistration(name);
-		}
-		for (const [requestId, pending] of pendingExecutions) {
-			if (pending.targetThreadId === deadThreadId) {
-				pendingExecutions.delete(requestId);
-				pending.reject(new ServerError('The worker thread executing this operation exited', 503));
-			}
-		}
-	});
+	onThreadExit(handleThreadExit);
 }
 
 async function executeRemoteOperation(name: string, body: any, bypassAuth: boolean): Promise<any> {

--- a/server/serverHelpers/registeredOperations.ts
+++ b/server/serverHelpers/registeredOperations.ts
@@ -11,9 +11,8 @@
  * so a request is sent to exactly ONE registering worker (never broadcast-first-wins).
  *
  *  - Worker: `registerOperation()` announces the name (OPERATION_REGISTERED) to all threads;
- *    only the main thread records it, as name -> Set<threadId>. An op that declared a permission
- *    also announces `grantable`: validateOperations runs on main (add_role/alter_role,
- *    impersonation, OIDC trust policies) but the mark was made in the worker's own module scope.
+ *    only the main thread records it, as name -> Set<threadId>, plus `grantable` (see the
+ *    per-worker registration note in server/DESIGN.md).
  *  - Main: on an OPERATION_FUNCTION_MAP miss, `getRemoteOperationFunction()` supplies a forwarding
  *    function that sends the request body (OPERATION_EXECUTE_REQUEST) to one live registering
  *    worker and awaits the correlated OPERATION_EXECUTE_RESPONSE.
@@ -29,7 +28,11 @@ import harperLogger from '../../utility/logging/harper_logger.ts';
 import { ServerError } from '../../utility/errors/hdbError.ts';
 import { sendItcEvent } from '../threads/itc.js';
 import { onMessageByType, onThreadExit } from '../threads/manageThreads.js';
-import { registerGrantableOperation, unregisterGrantableOperation } from '../../utility/operationPermissions.ts';
+import {
+	registerGrantableOperation,
+	unregisterGrantableOperation,
+	validateOperations,
+} from '../../utility/operationPermissions.ts';
 import { runWithOperationAuthorizationBypass } from './operationAuthorizationState.ts';
 
 const operationLog = harperLogger.loggerWithTag('operation');
@@ -62,7 +65,8 @@ export function setLocalOperationDispatch(dispatch: typeof localDispatch) {
 
 /** name -> threadIds of workers that registered it (main thread only) */
 const registeredByWorker = new Map<string, Set<number>>();
-// Marks made on a worker's behalf, so thread-exit cleanup never revokes one this thread owns.
+// Only names this thread newly marked grantable for a worker, so cleanup below cannot revoke a mark
+// that was already admissible for another reason (an enum op, a group, a main-thread registration).
 const grantableFromWorkers = new Set<string>();
 const pendingExecutions = new Map<
 	number,
@@ -99,13 +103,23 @@ export function operationRegisteredHandler(event: {
 	let workerIds = registeredByWorker.get(name);
 	if (!workerIds) registeredByWorker.set(name, (workerIds = new Set()));
 	workerIds.add(originator);
-	// Mirroring the worker's grantable mark only widens what an allowlist may name; it grants
-	// nothing. Enforcement stays on the worker's own chooseOperation (see getRemoteOperationFunction).
-	if (grantable) {
+	// Mirroring only widens what an allowlist may name; enforcement stays on the worker's own
+	// chooseOperation. Claim the name for cleanup only when this mirror is what made it admissible.
+	if (grantable && validateOperations([name]) !== null) {
 		grantableFromWorkers.add(name);
 		registerGrantableOperation(name);
 	}
 	operationLog.debug(`Registered operation '${name}' announced by worker thread ${originator}`);
+}
+
+/**
+ * Forget an operation whose last registering worker is gone. Both prune paths (thread exit, and a
+ * failed send discovering a dead port) must route through here so routing and grantability can
+ * never disagree about whether the op is still offered.
+ */
+function dropRegistration(name: string) {
+	registeredByWorker.delete(name);
+	if (grantableFromWorkers.delete(name)) unregisterGrantableOperation(name);
 }
 
 let rotation = 0;
@@ -144,10 +158,7 @@ function attachMainListeners() {
 	onThreadExit((deadThreadId: number) => {
 		for (const [name, workerIds] of registeredByWorker) {
 			workerIds.delete(deadThreadId);
-			if (workerIds.size === 0) {
-				registeredByWorker.delete(name);
-				if (grantableFromWorkers.delete(name)) unregisterGrantableOperation(name);
-			}
+			if (workerIds.size === 0) dropRegistration(name);
 		}
 		for (const [requestId, pending] of pendingExecutions) {
 			if (pending.targetThreadId === deadThreadId) {
@@ -209,7 +220,7 @@ async function executeRemoteOperation(name: string, body: any, bypassAuth: boole
 			});
 		});
 	}
-	if (registeredByWorker.get(name)?.size === 0) registeredByWorker.delete(name);
+	if (registeredByWorker.get(name)?.size === 0) dropRegistration(name);
 	throw new ServerError(
 		`Operation '${name}' is registered by a component but no worker thread is available to run it`,
 		503

--- a/server/serverHelpers/registeredOperations.ts
+++ b/server/serverHelpers/registeredOperations.ts
@@ -11,7 +11,9 @@
  * so a request is sent to exactly ONE registering worker (never broadcast-first-wins).
  *
  *  - Worker: `registerOperation()` announces the name (OPERATION_REGISTERED) to all threads;
- *    only the main thread records it, as name -> Set<threadId>.
+ *    only the main thread records it, as name -> Set<threadId>. An op that declared a permission
+ *    also announces `grantable`: validateOperations runs on main (add_role/alter_role,
+ *    impersonation, OIDC trust policies) but the mark was made in the worker's own module scope.
  *  - Main: on an OPERATION_FUNCTION_MAP miss, `getRemoteOperationFunction()` supplies a forwarding
  *    function that sends the request body (OPERATION_EXECUTE_REQUEST) to one live registering
  *    worker and awaits the correlated OPERATION_EXECUTE_RESPONSE.
@@ -27,6 +29,7 @@ import harperLogger from '../../utility/logging/harper_logger.ts';
 import { ServerError } from '../../utility/errors/hdbError.ts';
 import { sendItcEvent } from '../threads/itc.js';
 import { onMessageByType, onThreadExit } from '../threads/manageThreads.js';
+import { registerGrantableOperation, unregisterGrantableOperation } from '../../utility/operationPermissions.ts';
 import { runWithOperationAuthorizationBypass } from './operationAuthorizationState.ts';
 
 const operationLog = harperLogger.loggerWithTag('operation');
@@ -59,6 +62,8 @@ export function setLocalOperationDispatch(dispatch: typeof localDispatch) {
 
 /** name -> threadIds of workers that registered it (main thread only) */
 const registeredByWorker = new Map<string, Set<number>>();
+// Marks made on a worker's behalf, so thread-exit cleanup never revokes one this thread owns.
+const grantableFromWorkers = new Set<string>();
 const pendingExecutions = new Map<
 	number,
 	{ targetThreadId: number; resolve: (result: any) => void; reject: (error: Error) => void }
@@ -71,24 +76,35 @@ let mainListenersAttached = false;
  * a lost announcement just means the op stays unreachable (the pre-#1736 status quo), and the
  * broadcast has its own ack timeout.
  */
-export function announceRegisteredOperation(name: string) {
+export function announceRegisteredOperation(name: string, grantable = false) {
 	if (isMainThread) return;
 	sendItcEvent({
 		type: terms.ITC_EVENT_TYPES.OPERATION_REGISTERED,
-		message: { name },
+		message: { name, grantable },
 	}).catch((error) => operationLog.error(`Failed to announce registered operation '${name}'`, error));
 }
 
 /**
  * ITC handler (all threads receive the broadcast; only main records it).
  */
-export function operationRegisteredHandler(event: { message: { name: string; originator: number } }) {
+export function operationRegisteredHandler(event: {
+	message: { name: string; grantable?: boolean; originator: number };
+}) {
 	if (!isMainThread) return;
-	const { name, originator } = event.message;
+	const { name, grantable, originator } = event.message;
 	if (typeof name !== 'string' || typeof originator !== 'number') return;
+	// Arm thread-exit cleanup when the registry gains its first entry, not on the first forward:
+	// a worker that exits before any call would otherwise leave its entries here forever.
+	attachMainListeners();
 	let workerIds = registeredByWorker.get(name);
 	if (!workerIds) registeredByWorker.set(name, (workerIds = new Set()));
 	workerIds.add(originator);
+	// Mirroring the worker's grantable mark only widens what an allowlist may name; it grants
+	// nothing. Enforcement stays on the worker's own chooseOperation (see getRemoteOperationFunction).
+	if (grantable) {
+		grantableFromWorkers.add(name);
+		registerGrantableOperation(name);
+	}
 	operationLog.debug(`Registered operation '${name}' announced by worker thread ${originator}`);
 }
 
@@ -128,7 +144,10 @@ function attachMainListeners() {
 	onThreadExit((deadThreadId: number) => {
 		for (const [name, workerIds] of registeredByWorker) {
 			workerIds.delete(deadThreadId);
-			if (workerIds.size === 0) registeredByWorker.delete(name);
+			if (workerIds.size === 0) {
+				registeredByWorker.delete(name);
+				if (grantableFromWorkers.delete(name)) unregisterGrantableOperation(name);
+			}
 		}
 		for (const [requestId, pending] of pendingExecutions) {
 			if (pending.targetThreadId === deadThreadId) {

--- a/server/serverHelpers/registeredOperations.ts
+++ b/server/serverHelpers/registeredOperations.ts
@@ -29,9 +29,8 @@ import { ServerError } from '../../utility/errors/hdbError.ts';
 import { sendItcEvent } from '../threads/itc.js';
 import { onMessageByType, onThreadExit } from '../threads/manageThreads.js';
 import {
-	registerGrantableOperation,
-	unregisterGrantableOperation,
-	validateOperations,
+	registerWorkerGrantableOperation,
+	unregisterWorkerGrantableOperation,
 } from '../../utility/operationPermissions.ts';
 import { runWithOperationAuthorizationBypass } from './operationAuthorizationState.ts';
 
@@ -65,9 +64,6 @@ export function setLocalOperationDispatch(dispatch: typeof localDispatch) {
 
 /** name -> threadIds of workers that registered it (main thread only) */
 const registeredByWorker = new Map<string, Set<number>>();
-// Only names this thread newly marked grantable for a worker, so cleanup below cannot revoke a mark
-// that was already admissible for another reason (an enum op, a group, a main-thread registration).
-const grantableFromWorkers = new Set<string>();
 const pendingExecutions = new Map<
 	number,
 	{ targetThreadId: number; resolve: (result: any) => void; reject: (error: Error) => void }
@@ -104,11 +100,8 @@ export function operationRegisteredHandler(event: {
 	if (!workerIds) registeredByWorker.set(name, (workerIds = new Set()));
 	workerIds.add(originator);
 	// Mirroring only widens what an allowlist may name; enforcement stays on the worker's own
-	// chooseOperation. Claim the name for cleanup only when this mirror is what made it admissible.
-	if (grantable && validateOperations([name]) !== null) {
-		grantableFromWorkers.add(name);
-		registerGrantableOperation(name);
-	}
+	// chooseOperation.
+	if (grantable) registerWorkerGrantableOperation(name);
 	operationLog.debug(`Registered operation '${name}' announced by worker thread ${originator}`);
 }
 
@@ -119,7 +112,7 @@ export function operationRegisteredHandler(event: {
  */
 function dropRegistration(name: string) {
 	registeredByWorker.delete(name);
-	if (grantableFromWorkers.delete(name)) unregisterGrantableOperation(name);
+	unregisterWorkerGrantableOperation(name);
 }
 
 let rotation = 0;

--- a/server/serverHelpers/registeredOperations.ts
+++ b/server/serverHelpers/registeredOperations.ts
@@ -26,7 +26,7 @@ import * as env from '../../utility/environment/environmentManager.ts';
 import harperLogger from '../../utility/logging/harper_logger.ts';
 import { ServerError } from '../../utility/errors/hdbError.ts';
 import { sendItcEvent } from '../threads/itc.js';
-import { onMessageByType, onThreadExit } from '../threads/manageThreads.js';
+import { hasThreadExited, onMessageByType, onThreadExit } from '../threads/manageThreads.js';
 import {
 	registerWorkerGrantableOperation,
 	unregisterWorkerGrantableOperation,
@@ -66,12 +66,6 @@ const registeredByWorker = new Map<string, Set<number>>();
 // Per originator, not per name: a rolling deploy whose new generation drops `requiresSuperUser`
 // must keep routing the name while retracting grantability, which a name-level flag cannot express.
 const grantableByWorker = new Map<string, Set<number>>();
-// Threads already reported dead. Exit notification is deduplicated for the life of the process
-// (manageThreads.notifyThreadExit), so an announcement that lost a race with its own thread's exit
-// would otherwise install an entry no later exit event can ever clean up. Never pruned, and never
-// wrongly rejects a replacement: worker ids are monotonically increasing and not reused in a
-// process, so this grows by one per worker restart (the same reasoning as notifiedDeadThreadIds).
-const exitedThreadIds = new Set<number>();
 const pendingExecutions = new Map<
 	number,
 	{ targetThreadId: number; resolve: (result: any) => void; reject: (error: Error) => void }
@@ -101,7 +95,11 @@ export function operationRegisteredHandler(event: {
 	if (!isMainThread) return;
 	const { name, grantable, originator } = event?.message ?? {};
 	if (typeof name !== 'string' || typeof originator !== 'number') return;
-	if (exitedThreadIds.has(originator)) {
+	// An announcement can lose the race with its own thread's exit, and exit notification fires once
+	// per thread, so without this the entry would never be cleaned up. Reads manageThreads' tombstone
+	// rather than keeping a second one: job threads are one-shot workers, so a duplicate here would
+	// grow per completed job, not per worker restart.
+	if (hasThreadExited(originator)) {
 		operationLog.debug(`Ignoring operation '${name}' announced by exited worker thread ${originator}`);
 		return;
 	}
@@ -119,7 +117,6 @@ export function operationRegisteredHandler(event: {
  * waiting out the timeout, and forget its registrations (a replacement re-registers on load).
  */
 function handleThreadExit(deadThreadId: number) {
-	exitedThreadIds.add(deadThreadId);
 	for (const [name, workerIds] of registeredByWorker) {
 		if (!workerIds.delete(deadThreadId)) continue;
 		// A surviving worker that never declared a permission must not keep the name admissible.
@@ -132,10 +129,6 @@ function handleThreadExit(deadThreadId: number) {
 			pending.reject(new ServerError('The worker thread executing this operation exited', 503));
 		}
 	}
-}
-
-export function notifyThreadExitedForTest(deadThreadId: number) {
-	handleThreadExit(deadThreadId);
 }
 
 function setWorkerGrantable(name: string, threadId: number, grantable: boolean) {

--- a/server/serverHelpers/registeredOperations.ts
+++ b/server/serverHelpers/registeredOperations.ts
@@ -134,7 +134,6 @@ function handleThreadExit(deadThreadId: number) {
 	}
 }
 
-/** `attachMainListeners` wires the same function to the real thread-exit event. */
 export function notifyThreadExitedForTest(deadThreadId: number) {
 	handleThreadExit(deadThreadId);
 }

--- a/server/serverHelpers/registeredOperations.ts
+++ b/server/serverHelpers/registeredOperations.ts
@@ -121,7 +121,7 @@ export function operationRegisteredHandler(event: {
 function handleThreadExit(deadThreadId: number) {
 	exitedThreadIds.add(deadThreadId);
 	for (const [name, workerIds] of registeredByWorker) {
-		workerIds.delete(deadThreadId);
+		if (!workerIds.delete(deadThreadId)) continue;
 		// A surviving worker that never declared a permission must not keep the name admissible.
 		if (workerIds.size === 0) dropRegistration(name);
 		else setWorkerGrantable(name, deadThreadId, false);
@@ -144,11 +144,8 @@ function setWorkerGrantable(name: string, threadId: number, grantable: boolean) 
 	if (grantable) {
 		if (!grantableIds) grantableByWorker.set(name, (grantableIds = new Set()));
 		grantableIds.add(threadId);
-	} else {
-		grantableIds?.delete(threadId);
-	}
-	if (grantableIds?.size) registerWorkerGrantableOperation(name);
-	else {
+		registerWorkerGrantableOperation(name);
+	} else if (grantableIds?.delete(threadId) && grantableIds.size === 0) {
 		grantableByWorker.delete(name);
 		unregisterWorkerGrantableOperation(name);
 	}

--- a/server/serverHelpers/registeredOperations.ts
+++ b/server/serverHelpers/registeredOperations.ts
@@ -11,8 +11,7 @@
  * so a request is sent to exactly ONE registering worker (never broadcast-first-wins).
  *
  *  - Worker: `registerOperation()` announces the name (OPERATION_REGISTERED) to all threads;
- *    only the main thread records it, as name -> Set<threadId>, plus `grantable` (see the
- *    per-worker registration note in server/DESIGN.md).
+ *    only the main thread records it, as name -> Set<threadId>, plus `grantable`.
  *  - Main: on an OPERATION_FUNCTION_MAP miss, `getRemoteOperationFunction()` supplies a forwarding
  *    function that sends the request body (OPERATION_EXECUTE_REQUEST) to one live registering
  *    worker and awaits the correlated OPERATION_EXECUTE_RESPONSE.
@@ -64,10 +63,8 @@ export function setLocalOperationDispatch(dispatch: typeof localDispatch) {
 
 /** name -> threadIds of workers that registered it (main thread only) */
 const registeredByWorker = new Map<string, Set<number>>();
-// name -> threadIds that declared it grantable. Tracked per originator rather than per name so the
-// mirrored mark lives exactly as long as a live worker declares it: a rolling deploy whose new
-// generation drops `requiresSuperUser` keeps the routing entry (it still executes) while retracting
-// grantability, which a name-level flag cannot express.
+// Per originator, not per name: a rolling deploy whose new generation drops `requiresSuperUser`
+// must keep routing the name while retracting grantability, which a name-level flag cannot express.
 const grantableByWorker = new Map<string, Set<number>>();
 // Threads already reported dead. Exit notification is deduplicated for the life of the process
 // (manageThreads.notifyThreadExit), so an announcement that lost a race with its own thread's exit
@@ -99,14 +96,11 @@ export function announceRegisteredOperation(name: string, grantable = false) {
  * ITC handler (all threads receive the broadcast; only main records it).
  */
 export function operationRegisteredHandler(event: {
-	message: { name: string; grantable?: boolean; originator: number };
+	message?: { name?: string; grantable?: boolean; originator?: number };
 }) {
 	if (!isMainThread) return;
-	const { name, grantable, originator } = event.message;
+	const { name, grantable, originator } = event?.message ?? {};
 	if (typeof name !== 'string' || typeof originator !== 'number') return;
-	// Arm thread-exit cleanup when the registry gains its first entry, not on the first forward:
-	// a worker that exits before any call would otherwise leave its entries here forever.
-	attachMainListeners();
 	if (exitedThreadIds.has(originator)) {
 		operationLog.debug(`Ignoring operation '${name}' announced by exited worker thread ${originator}`);
 		return;
@@ -114,9 +108,8 @@ export function operationRegisteredHandler(event: {
 	let workerIds = registeredByWorker.get(name);
 	if (!workerIds) registeredByWorker.set(name, (workerIds = new Set()));
 	workerIds.add(originator);
-	// Mirroring only widens what an allowlist may name; enforcement stays on the worker's own
-	// chooseOperation. A re-announcement that no longer declares a permission retracts this
-	// thread's claim rather than leaving a stale one behind.
+	// Mirroring only widens what an allowlist may name; enforcement stays on the worker's
+	// chooseOperation. A re-announcement that drops the permission retracts this thread's claim.
 	setWorkerGrantable(name, originator, grantable === true);
 	operationLog.debug(`Registered operation '${name}' announced by worker thread ${originator}`);
 }
@@ -129,8 +122,7 @@ function handleThreadExit(deadThreadId: number) {
 	exitedThreadIds.add(deadThreadId);
 	for (const [name, workerIds] of registeredByWorker) {
 		workerIds.delete(deadThreadId);
-		// Retract this thread's grantability claim even when others still route the name — a
-		// remaining worker that never declared a permission must not keep it admissible.
+		// A surviving worker that never declared a permission must not keep the name admissible.
 		if (workerIds.size === 0) dropRegistration(name);
 		else setWorkerGrantable(name, deadThreadId, false);
 	}
@@ -207,6 +199,12 @@ function attachMainListeners() {
 	onThreadExit(handleThreadExit);
 }
 
+// Armed at load rather than on first use: serverUtilities imports this module during its own load,
+// before any worker exists. Thread-exit notification fires once per thread and is dropped outright
+// if no listener is attached yet, so a worker dying before its first announcement is processed
+// would otherwise leave a registration nothing could ever clean up.
+if (isMainThread) attachMainListeners();
+
 async function executeRemoteOperation(name: string, body: any, bypassAuth: boolean): Promise<any> {
 	attachMainListeners();
 	const workerIds = registeredByWorker.get(name);
@@ -236,7 +234,10 @@ async function executeRemoteOperation(name: string, body: any, bypassAuth: boole
 			);
 		}
 		if (!sent) {
+			// The port is gone, so this thread's claims go with it — grantability included, which
+			// handleThreadExit would otherwise not retract while other workers still route the name.
 			workerIds.delete(targetThreadId);
+			setWorkerGrantable(name, targetThreadId, false);
 			continue;
 		}
 		return new Promise((promiseResolve, promiseReject) => {

--- a/server/serverHelpers/registeredOperations.ts
+++ b/server/serverHelpers/registeredOperations.ts
@@ -134,7 +134,7 @@ function handleThreadExit(deadThreadId: number) {
 	}
 }
 
-/** Test seam for the cleanup above, which `attachMainListeners` wires to the real thread-exit event. */
+/** `attachMainListeners` wires the same function to the real thread-exit event. */
 export function notifyThreadExitedForTest(deadThreadId: number) {
 	handleThreadExit(deadThreadId);
 }

--- a/server/serverHelpers/registeredOperations.ts
+++ b/server/serverHelpers/registeredOperations.ts
@@ -26,7 +26,7 @@ import * as env from '../../utility/environment/environmentManager.ts';
 import harperLogger from '../../utility/logging/harper_logger.ts';
 import { ServerError } from '../../utility/errors/hdbError.ts';
 import { sendItcEvent } from '../threads/itc.js';
-import { onMessageByType, onThreadExit } from '../threads/manageThreads.js';
+import { hasThreadExited, onMessageByType, onThreadExit } from '../threads/manageThreads.js';
 import {
 	registerWorkerGrantableOperation,
 	unregisterWorkerGrantableOperation,
@@ -66,14 +66,6 @@ const registeredByWorker = new Map<string, Set<number>>();
 // Per originator, not per name: a rolling deploy whose new generation drops `requiresSuperUser`
 // must keep routing the name while retracting grantability, which a name-level flag cannot express.
 const grantableByWorker = new Map<string, Set<number>>();
-// Threads already reported dead, so an announcement that lost the race with its own thread's exit
-// cannot install an entry no later exit event will clean up — including a thread whose FIRST
-// announcement is the one in flight, which is why this cannot be narrowed to threads already
-// holding a registration. One integer per dead thread, never pruned, matching the growth profile
-// manageThreads accepts for notifiedDeadThreadIds; it cannot reject a replacement because worker
-// ids are monotonically increasing and not reused within a process. Deliberately a local set:
-// reading manageThreads' equivalent regressed Windows worker-restart timing (see PR #2260).
-const exitedThreadIds = new Set<number>();
 const pendingExecutions = new Map<
 	number,
 	{ targetThreadId: number; resolve: (result: any) => void; reject: (error: Error) => void }
@@ -103,7 +95,11 @@ export function operationRegisteredHandler(event: {
 	if (!isMainThread) return;
 	const { name, grantable, originator } = event?.message ?? {};
 	if (typeof name !== 'string' || typeof originator !== 'number') return;
-	if (exitedThreadIds.has(originator)) {
+	// An announcement can lose the race with its own thread's exit, and exit notification fires once
+	// per thread, so without this the entry would never be cleaned up. Reads manageThreads' tombstone
+	// rather than keeping a second one: job threads are one-shot workers, so a duplicate here would
+	// grow per completed job, not per worker restart.
+	if (hasThreadExited(originator)) {
 		operationLog.debug(`Ignoring operation '${name}' announced by exited worker thread ${originator}`);
 		return;
 	}
@@ -121,7 +117,6 @@ export function operationRegisteredHandler(event: {
  * waiting out the timeout, and forget its registrations (a replacement re-registers on load).
  */
 function handleThreadExit(deadThreadId: number) {
-	exitedThreadIds.add(deadThreadId);
 	for (const [name, workerIds] of registeredByWorker) {
 		if (!workerIds.delete(deadThreadId)) continue;
 		// A surviving worker that never declared a permission must not keep the name admissible.
@@ -134,10 +129,6 @@ function handleThreadExit(deadThreadId: number) {
 			pending.reject(new ServerError('The worker thread executing this operation exited', 503));
 		}
 	}
-}
-
-export function notifyThreadExitedForTest(deadThreadId: number) {
-	handleThreadExit(deadThreadId);
 }
 
 function setWorkerGrantable(name: string, threadId: number, grantable: boolean) {

--- a/server/serverHelpers/registeredOperations.ts
+++ b/server/serverHelpers/registeredOperations.ts
@@ -139,7 +139,6 @@ export function notifyThreadExitedForTest(deadThreadId: number) {
 	handleThreadExit(deadThreadId);
 }
 
-/** Record or retract one thread's grantability claim, then re-derive the mirrored mark from live claims. */
 function setWorkerGrantable(name: string, threadId: number, grantable: boolean) {
 	let grantableIds = grantableByWorker.get(name);
 	if (grantable) {

--- a/server/serverHelpers/serverUtilities.ts
+++ b/server/serverHelpers/serverUtilities.ts
@@ -200,10 +200,11 @@ server.registerOperation = (operationDefinition: OperationDefinition) => {
 	const { name, execute, requiresSuperUser } = operationDefinition;
 	let handler = execute;
 	if (requiresSuperUser === undefined) {
-		// A re-registration that drops the flag must also drop the entry the earlier one installed,
-		// or the declaration and enforcement disagree: main retracts the grantable mark while this
-		// worker keeps honouring an already-persisted role grant. Only names this API registered are
-		// cleared, so a component cannot strip a built-in's permission by re-declaring its name.
+		// A re-registration that drops the flag must also drop the entry the earlier one installed, or
+		// declaration and enforcement disagree: main retracts the grantable mark while this worker keeps
+		// honouring an already-persisted role grant. Scoped to names declared through this API, so one it
+		// never declared is untouched — a component that declared a built-in's name already overwrote
+		// that entry by declaring it, and this only follows.
 		if (declaredPermissionNames.delete(name)) opAuth.unregisterOperationPermission(name);
 	} else {
 		// verifyPerms keys requiredPermissions by the handler's function `.name`, but registered ops

--- a/server/serverHelpers/serverUtilities.ts
+++ b/server/serverHelpers/serverUtilities.ts
@@ -186,6 +186,10 @@ export type OperationDefinition = {
 	requiresSuperUser?: boolean;
 };
 
+// Operation names this API installed a permission entry for, so a later registration that drops
+// `requiresSuperUser` can retract exactly that entry and nothing else.
+const declaredPermissionNames = new Set<string>();
+
 /**
  * Register an operation function with the server.
  * @param operationDefinition
@@ -195,7 +199,13 @@ server.registerOperation = (operationDefinition: OperationDefinition) => {
 	if (isDeployValidating()) return;
 	const { name, execute, requiresSuperUser } = operationDefinition;
 	let handler = execute;
-	if (requiresSuperUser !== undefined) {
+	if (requiresSuperUser === undefined) {
+		// A re-registration that drops the flag must also drop the entry the earlier one installed,
+		// or the declaration and enforcement disagree: main retracts the grantable mark while this
+		// worker keeps honouring an already-persisted role grant. Only names this API registered are
+		// cleared, so a component cannot strip a built-in's permission by re-declaring its name.
+		if (declaredPermissionNames.delete(name)) opAuth.unregisterOperationPermission(name);
+	} else {
 		// verifyPerms keys requiredPermissions by the handler's function `.name`, but registered ops
 		// are typically anonymous arrows (all named "execute") which collide and can't be keyed. Wrap
 		// in a FRESH function named after the op so the lookup resolves the right entry. Wrap rather
@@ -205,6 +215,7 @@ server.registerOperation = (operationDefinition: OperationDefinition) => {
 		handler = (...args: any[]) => (execute as any)(...args);
 		Object.defineProperty(handler, 'name', { value: name, configurable: true });
 		opAuth.registerOperationPermission(name, { requiresSu: requiresSuperUser });
+		declaredPermissionNames.add(name);
 	}
 	OPERATION_FUNCTION_MAP.set(name as any, new OperationFunctionObject(handler));
 	// Components load per-worker, so a registration made there is invisible to the main-thread

--- a/server/serverHelpers/serverUtilities.ts
+++ b/server/serverHelpers/serverUtilities.ts
@@ -209,8 +209,8 @@ server.registerOperation = (operationDefinition: OperationDefinition) => {
 	OPERATION_FUNCTION_MAP.set(name as any, new OperationFunctionObject(handler));
 	// Components load per-worker, so a registration made there is invisible to the main-thread
 	// ops-API dispatcher (each thread has its own OPERATION_FUNCTION_MAP instance). Announce it
-	// so the main thread can forward calls to this worker (#1736), and can mirror the role-allowlist
-	// mark that registerOperationPermission above made only in this thread's scope.
+	// so the main thread can forward calls here (#1736), and can mirror the role-allowlist mark that
+	// registerOperationPermission above made only in this thread's scope.
 	if (!isMainThread) announceRegisteredOperation(name, requiresSuperUser !== undefined);
 };
 

--- a/server/serverHelpers/serverUtilities.ts
+++ b/server/serverHelpers/serverUtilities.ts
@@ -209,8 +209,8 @@ server.registerOperation = (operationDefinition: OperationDefinition) => {
 	OPERATION_FUNCTION_MAP.set(name as any, new OperationFunctionObject(handler));
 	// Components load per-worker, so a registration made there is invisible to the main-thread
 	// ops-API dispatcher (each thread has its own OPERATION_FUNCTION_MAP instance). Announce it
-	// so the main thread can forward calls to this worker (#1736), and so it can mirror the
-	// role-allowlist mark that registerOperationPermission above made only in this thread's scope.
+	// so the main thread can forward calls to this worker (#1736), and can mirror the role-allowlist
+	// mark that registerOperationPermission above made only in this thread's scope.
 	if (!isMainThread) announceRegisteredOperation(name, requiresSuperUser !== undefined);
 };
 

--- a/server/serverHelpers/serverUtilities.ts
+++ b/server/serverHelpers/serverUtilities.ts
@@ -209,8 +209,9 @@ server.registerOperation = (operationDefinition: OperationDefinition) => {
 	OPERATION_FUNCTION_MAP.set(name as any, new OperationFunctionObject(handler));
 	// Components load per-worker, so a registration made there is invisible to the main-thread
 	// ops-API dispatcher (each thread has its own OPERATION_FUNCTION_MAP instance). Announce it
-	// so the main thread can forward calls to this worker (#1736).
-	if (!isMainThread) announceRegisteredOperation(name);
+	// so the main thread can forward calls to this worker (#1736), and so it can mirror the
+	// role-allowlist mark that registerOperationPermission above made only in this thread's scope.
+	if (!isMainThread) announceRegisteredOperation(name, requiresSuperUser !== undefined);
 };
 
 // Register the durable MCP quota policy as a function (see components/mcp/quota.ts). Worker-local,

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -152,6 +152,8 @@ module.exports = {
 	restoreShutdownDeadline,
 	registerWorkerDataProvider,
 	onThreadExit,
+	hasThreadExited,
+	notifyThreadExit,
 	registerProcessGroup,
 	unregisterProcessGroup,
 	isThreadRunning,
@@ -1117,6 +1119,15 @@ if (isMainThread) {
 	process.on('exit', () => {
 		for (const ownerThreadId of [...processGroupsByThread.keys()]) terminateProcessGroupsForThread(ownerThreadId);
 	});
+}
+
+/**
+ * Whether a thread has already been reported dead. Sync, unlike `isThreadRunning`, because it only
+ * reads the tombstone `notifyThreadExit` records below — callers on the exit path need an answer
+ * without awaiting process-group confirmation.
+ */
+function hasThreadExited(threadId) {
+	return notifiedDeadThreadIds.has(threadId);
 }
 
 function notifyThreadExit(deadThreadId) {

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -152,6 +152,10 @@ module.exports = {
 	restoreShutdownDeadline,
 	registerWorkerDataProvider,
 	onThreadExit,
+	hasThreadExited,
+	// Exported so tests can drive the real exit path rather than a module-local stand-in; the
+	// dedupe above makes a spurious call a no-op.
+	notifyThreadExit,
 	registerProcessGroup,
 	unregisterProcessGroup,
 	isThreadRunning,
@@ -1117,6 +1121,15 @@ if (isMainThread) {
 	process.on('exit', () => {
 		for (const ownerThreadId of [...processGroupsByThread.keys()]) terminateProcessGroupsForThread(ownerThreadId);
 	});
+}
+
+/**
+ * Whether a thread has already been reported dead. Sync, unlike `isThreadRunning`, because it only
+ * reads the tombstone `notifyThreadExit` records below — callers on the exit path need an answer
+ * without awaiting process-group confirmation.
+ */
+function hasThreadExited(threadId) {
+	return notifiedDeadThreadIds.has(threadId);
 }
 
 function notifyThreadExit(deadThreadId) {

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -153,8 +153,6 @@ module.exports = {
 	registerWorkerDataProvider,
 	onThreadExit,
 	hasThreadExited,
-	// Exported so tests can drive the real exit path rather than a module-local stand-in; the
-	// dedupe above makes a spurious call a no-op.
 	notifyThreadExit,
 	registerProcessGroup,
 	unregisterProcessGroup,

--- a/server/threads/manageThreads.js
+++ b/server/threads/manageThreads.js
@@ -152,8 +152,6 @@ module.exports = {
 	restoreShutdownDeadline,
 	registerWorkerDataProvider,
 	onThreadExit,
-	hasThreadExited,
-	notifyThreadExit,
 	registerProcessGroup,
 	unregisterProcessGroup,
 	isThreadRunning,
@@ -1119,15 +1117,6 @@ if (isMainThread) {
 	process.on('exit', () => {
 		for (const ownerThreadId of [...processGroupsByThread.keys()]) terminateProcessGroupsForThread(ownerThreadId);
 	});
-}
-
-/**
- * Whether a thread has already been reported dead. Sync, unlike `isThreadRunning`, because it only
- * reads the tombstone `notifyThreadExit` records below — callers on the exit path need an answer
- * without awaiting process-group confirmation.
- */
-function hasThreadExited(threadId) {
-	return notifiedDeadThreadIds.has(threadId);
 }
 
 function notifyThreadExit(deadThreadId) {

--- a/unitTests/security/authn/oidc/trustPolicyOperations.test.js
+++ b/unitTests/security/authn/oidc/trustPolicyOperations.test.js
@@ -264,15 +264,10 @@ describe('oidc trustPolicyOperations', () => {
 			assert.strictEqual(installed.mock.rows.size, 0, 'expected nothing stored');
 		});
 
-		// Delegating to validateOperations rather than checking OPERATIONS_ENUM locally means an
-		// operation registered in THIS process is accepted. That is the seam, not a promise about
-		// component-registered operations: the registry is process-local, `add_oidc_trust` runs on the
-		// main thread, and `server.registerOperation` runs in a worker whose OPERATION_REGISTERED
-		// announcement carries only name→thread routing, never grantability. So a component's
-		// operation is NOT recognized here in production, and this same-thread test cannot show that
-		// — it is asserting the delegation, not the topology. A policy naming such an operation is
-		// rejected, which fails closed; add_role, alter_role, and impersonation validation share the
-		// gap, so the fix belongs to that bridge rather than to a workaround here.
+		// Asserts the delegation to validateOperations, not the worker→main topology: registering here
+		// puts the mark in this thread's own registry, so a same-thread test cannot distinguish the two.
+		// The cross-thread path a real component takes is covered in
+		// integrationTests/components/registered-operation.test.ts.
 		it('accepts an operation registered in this process', async () => {
 			const dynamicOp = 'test_dynamic_scope_op';
 			opAuth.registerOperationPermission(dynamicOp, { requiresSu: true });

--- a/unitTests/server/serverHelpers/serverUtilities.test.js
+++ b/unitTests/server/serverHelpers/serverUtilities.test.js
@@ -224,14 +224,22 @@ describe('Test serverUtilities.js module ', () => {
 	// Only the receiving half is reachable here — announceRegisteredOperation returns early on the
 	// main thread, so integrationTests/components/registered-operation.test.ts owns the real hop.
 	describe('cross-thread grantable operation mirroring', function () {
-		const { validateOperations, unregisterGrantableOperation } = require('#src/utility/operationPermissions');
+		const {
+			validateOperations,
+			registerGrantableOperation,
+			unregisterGrantableOperation,
+			unregisterWorkerGrantableOperation,
+		} = require('#src/utility/operationPermissions');
 		const GRANTABLE = 'test_cross_thread_grantable_op';
 		const PLAIN = 'test_cross_thread_plain_op';
+		const SHARED = 'test_cross_thread_shared_op';
 
 		after(function () {
-			// Don't leak either name into the process-global grantable set for later suites.
-			unregisterGrantableOperation(GRANTABLE);
-			unregisterGrantableOperation(PLAIN);
+			// Don't leak these names into the process-global registries for later suites.
+			for (const op of [GRANTABLE, PLAIN, SHARED]) {
+				unregisterWorkerGrantableOperation(op);
+				unregisterGrantableOperation(op);
+			}
 		});
 
 		it('makes a worker-announced declared op grantable on the main thread', function () {
@@ -254,6 +262,22 @@ describe('Test serverUtilities.js module ', () => {
 			assert.notEqual(validateOperations([PLAIN]), null);
 			// A forward is still set up for it, so the routing half is unaffected.
 			assert.equal(typeof registeredOperations.getRemoteOperationFunction(PLAIN), 'function');
+		});
+
+		it('keeps a main-thread registration of the same name independent of the worker mirror', function () {
+			// A hot deploy can load a startOnMainThread component that registers an op a retiring
+			// worker also offers (manageThreads restartWorkers loads root components before draining
+			// the old workers), so the two marks have to survive each other.
+			registeredOperations.operationRegisteredHandler({
+				message: { name: SHARED, grantable: true, originator: 41 },
+			});
+			registerGrantableOperation(SHARED);
+
+			unregisterWorkerGrantableOperation(SHARED);
+			assert.equal(validateOperations([SHARED]), null, 'main-thread registration should survive worker revocation');
+
+			unregisterGrantableOperation(SHARED);
+			assert.notEqual(validateOperations([SHARED]), null, 'both marks gone should make it ungrantable again');
 		});
 	});
 

--- a/unitTests/server/serverHelpers/serverUtilities.test.js
+++ b/unitTests/server/serverHelpers/serverUtilities.test.js
@@ -221,6 +221,42 @@ describe('Test serverUtilities.js module ', () => {
 		});
 	});
 
+	// Only the receiving half is reachable here — announceRegisteredOperation returns early on the
+	// main thread, so integrationTests/components/registered-operation.test.ts owns the real hop.
+	describe('cross-thread grantable operation mirroring', function () {
+		const { validateOperations, unregisterGrantableOperation } = require('#src/utility/operationPermissions');
+		const GRANTABLE = 'test_cross_thread_grantable_op';
+		const PLAIN = 'test_cross_thread_plain_op';
+
+		after(function () {
+			// Don't leak either name into the process-global grantable set for later suites.
+			unregisterGrantableOperation(GRANTABLE);
+			unregisterGrantableOperation(PLAIN);
+		});
+
+		it('makes a worker-announced declared op grantable on the main thread', function () {
+			assert.notEqual(validateOperations([GRANTABLE]), null, 'name should be unknown before the announcement');
+
+			registeredOperations.operationRegisteredHandler({
+				message: { name: GRANTABLE, grantable: true, originator: 31 },
+			});
+
+			assert.equal(validateOperations([GRANTABLE]), null, 'name should be grantable after the announcement');
+		});
+
+		it('leaves an op that declared no permission ungrantable', function () {
+			// requiresSuperUser omitted means no verifyPerms entry and nothing to grant — the routing
+			// entry must not smuggle the name into the allowlist.
+			registeredOperations.operationRegisteredHandler({
+				message: { name: PLAIN, grantable: false, originator: 31 },
+			});
+
+			assert.notEqual(validateOperations([PLAIN]), null);
+			// A forward is still set up for it, so the routing half is unaffected.
+			assert.equal(typeof registeredOperations.getRemoteOperationFunction(PLAIN), 'function');
+		});
+	});
+
 	describe('operation authorization state', function () {
 		it('is scoped across awaits and restores nested authorization', async function () {
 			assert.strictEqual(operationAuthorizationState.isOperationAuthorizationBypassed(), false);

--- a/unitTests/server/serverHelpers/serverUtilities.test.js
+++ b/unitTests/server/serverHelpers/serverUtilities.test.js
@@ -233,10 +233,13 @@ describe('Test serverUtilities.js module ', () => {
 		const GRANTABLE = 'test_cross_thread_grantable_op';
 		const PLAIN = 'test_cross_thread_plain_op';
 		const SHARED = 'test_cross_thread_shared_op';
+		const ROLLED = 'test_cross_thread_rolled_op';
+		const RETRACTED = 'test_cross_thread_retracted_op';
+		const ZOMBIE = 'test_cross_thread_zombie_op';
 
 		after(function () {
 			// Don't leak these names into the process-global registries for later suites.
-			for (const op of [GRANTABLE, PLAIN, SHARED]) {
+			for (const op of [GRANTABLE, PLAIN, SHARED, ROLLED, RETRACTED, ZOMBIE]) {
 				unregisterWorkerGrantableOperation(op);
 				unregisterGrantableOperation(op);
 			}
@@ -253,21 +256,18 @@ describe('Test serverUtilities.js module ', () => {
 		});
 
 		it('leaves an op that declared no permission ungrantable', function () {
-			// requiresSuperUser omitted means no verifyPerms entry and nothing to grant — the routing
-			// entry must not smuggle the name into the allowlist.
 			registeredOperations.operationRegisteredHandler({
 				message: { name: PLAIN, grantable: false, originator: 31 },
 			});
 
 			assert.notEqual(validateOperations([PLAIN]), null);
-			// A forward is still set up for it, so the routing half is unaffected.
+			// The routing half is unaffected — only admissibility is withheld.
 			assert.equal(typeof registeredOperations.getRemoteOperationFunction(PLAIN), 'function');
 		});
 
 		it('keeps a main-thread registration of the same name independent of the worker mirror', function () {
-			// A hot deploy can load a startOnMainThread component that registers an op a retiring
-			// worker also offers (manageThreads restartWorkers loads root components before draining
-			// the old workers), so the two marks have to survive each other.
+			// restartWorkers loads root components before draining old workers, so a startOnMainThread
+			// component can register an op a retiring worker also offers.
 			registeredOperations.operationRegisteredHandler({
 				message: { name: SHARED, grantable: true, originator: 41 },
 			});
@@ -278,6 +278,54 @@ describe('Test serverUtilities.js module ', () => {
 
 			unregisterGrantableOperation(SHARED);
 			assert.notEqual(validateOperations([SHARED]), null, 'both marks gone should make it ungrantable again');
+		});
+
+		it('retracts grantability when a re-announcement drops the declared permission', function () {
+			registeredOperations.operationRegisteredHandler({
+				message: { name: RETRACTED, grantable: true, originator: 51 },
+			});
+			assert.equal(validateOperations([RETRACTED]), null);
+
+			registeredOperations.operationRegisteredHandler({
+				message: { name: RETRACTED, grantable: false, originator: 51 },
+			});
+			assert.notEqual(validateOperations([RETRACTED]), null, 'the same thread withdrawing must retract its claim');
+		});
+
+		it('stops being grantable once the last declaring worker is gone, even while another still routes it', function () {
+			// The rolling-deploy case: the new generation keeps the operation but drops
+			// requiresSuperUser, so the name must stay routable and stop being grantable.
+			registeredOperations.operationRegisteredHandler({
+				message: { name: ROLLED, grantable: true, originator: 61 },
+			});
+			registeredOperations.operationRegisteredHandler({
+				message: { name: ROLLED, grantable: false, originator: 62 },
+			});
+			assert.equal(validateOperations([ROLLED]), null, 'still declared by thread 61');
+
+			registeredOperations.notifyThreadExitedForTest(61);
+
+			assert.notEqual(validateOperations([ROLLED]), null, 'no live worker declares it grantable any more');
+			assert.equal(
+				typeof registeredOperations.getRemoteOperationFunction(ROLLED),
+				'function',
+				'thread 62 still routes it'
+			);
+		});
+
+		it('ignores an announcement that lost a race with its own thread exit', function () {
+			registeredOperations.notifyThreadExitedForTest(71);
+
+			registeredOperations.operationRegisteredHandler({
+				message: { name: ZOMBIE, grantable: true, originator: 71 },
+			});
+
+			assert.notEqual(validateOperations([ZOMBIE]), null, 'a dead thread must not install a grant');
+			assert.equal(
+				registeredOperations.getRemoteOperationFunction(ZOMBIE),
+				undefined,
+				'nor a route nothing will ever clean up'
+			);
 		});
 	});
 

--- a/unitTests/server/serverHelpers/serverUtilities.test.js
+++ b/unitTests/server/serverHelpers/serverUtilities.test.js
@@ -298,7 +298,6 @@ describe('Test serverUtilities.js module ', () => {
 		});
 
 		it('stops being grantable once the last declaring worker is gone, even while another still routes it', function () {
-			// Rolling deploy: the new generation keeps the operation but drops requiresSuperUser.
 			registeredOperations.operationRegisteredHandler({
 				message: { name: ROLLED, grantable: true, originator: DECLARING_THREAD },
 			});
@@ -938,7 +937,15 @@ describe('Test serverUtilities.js module ', () => {
 			// Keep the process-global registries clean — these test-only ops shouldn't leak into other
 			// suites. registerOperation touches three globals (the op-function map plus verifyPerms'
 			// requiredPermissions and the grantable-ops set), so undo all three, not just the map.
-			for (const op of [SU_OP, OPEN_OP, 'test_name_pinning_op', 'shared_op_a', 'shared_op_b', 'dyn_grantable_op']) {
+			for (const op of [
+				SU_OP,
+				OPEN_OP,
+				'test_name_pinning_op',
+				'shared_op_a',
+				'shared_op_b',
+				'dyn_grantable_op',
+				'test_redeclared_op',
+			]) {
 				serverUtilities.OPERATION_FUNCTION_MAP.delete(op);
 				op_auth.unregisterOperationPermission(op);
 			}
@@ -971,6 +978,50 @@ describe('Test serverUtilities.js module ', () => {
 			assert.notEqual(validateOperations(['dyn_grantable_op']), null); // unknown name before registration
 			server.registerOperation({ name: 'dyn_grantable_op', execute: async () => ({}), requiresSuperUser: true });
 			assert.equal(validateOperations(['dyn_grantable_op']), null); // grantable after registration
+		});
+
+		it('retracts the permission entry when a re-registration drops requiresSuperUser', function () {
+			// Declaration and enforcement must not disagree: main retracts the grantable mark on the
+			// re-announcement, so a role grant persisted while the op was declared must stop being
+			// honoured here too. Named after the op so verifyPerms resolves the stale entry if it
+			// survives — an anonymous handler would mask the bug rather than test it.
+			const op = 'test_redeclared_op';
+			// eslint-disable-next-line func-names
+			const named = {
+				[op]: async function () {
+					return {};
+				},
+			}[op];
+			server.registerOperation({ name: op, execute: named, requiresSuperUser: true });
+			assert.equal(validateOperations([op]), null, 'grantable while declared');
+			assert.equal(op_auth.verifyPerms(nonSuRequest(op, [op]), op), null, 'granted role may call it');
+
+			server.registerOperation({ name: op, execute: named });
+
+			assert.notEqual(validateOperations([op]), null, 'no longer grantable once undeclared');
+			let threw;
+			try {
+				op_auth.verifyPerms(nonSuRequest(op, [op]), op);
+			} catch (err) {
+				threw = err;
+			}
+			assert.ok(threw, 'a persisted grant must not survive the declaration being dropped');
+			assert.equal(threw.statusCode, 400);
+		});
+
+		it('does not strip a permission entry this API never registered', function () {
+			// Ownership protection, exercised against an independent registrant rather than a real
+			// built-in so the assertion does not depend on mutating shared dispatch state.
+			const op = 'test_independent_registrant_op';
+			op_auth.registerOperationPermission(op, { requiresSu: true });
+			try {
+				server.registerOperation({ name: op, execute: async () => ({}) });
+				assert.equal(validateOperations([op]), null, 'an entry this API did not create must survive');
+				assert.ok(op_auth.verifyPerms(nonSuRequest(op), op), 'and must still gate a non-super_user');
+			} finally {
+				op_auth.unregisterOperationPermission(op);
+				serverUtilities.OPERATION_FUNCTION_MAP.delete(op);
+			}
 		});
 
 		it('does not touch handler name or register perms when requiresSuperUser is omitted (opt-in)', function () {

--- a/unitTests/server/serverHelpers/serverUtilities.test.js
+++ b/unitTests/server/serverHelpers/serverUtilities.test.js
@@ -9,7 +9,6 @@ const sandbox = sinon.createSandbox();
 const { TEST_JSON_SUPER_USER, TEST_JSON_NON_SU } = require('../../test_data');
 const serverUtilities = require('#src/server/serverHelpers/serverUtilities');
 const registeredOperations = require('#src/server/serverHelpers/registeredOperations');
-const manageThreads = require('#src/server/threads/manageThreads');
 const operationAuthorizationState = require('#src/server/serverHelpers/operationAuthorizationState');
 const { runWithDeployValidationGuard } = require('#src/server/serverHelpers/deployValidationState');
 const quota = require('#src/components/mcp/quota');
@@ -307,7 +306,7 @@ describe('Test serverUtilities.js module ', () => {
 			});
 			assert.equal(validateOperations([ROLLED]), null, 'still declared by the first thread');
 
-			manageThreads.notifyThreadExit(DECLARING_THREAD);
+			registeredOperations.notifyThreadExitedForTest(DECLARING_THREAD);
 
 			assert.notEqual(validateOperations([ROLLED]), null, 'no live worker declares it grantable any more');
 			assert.equal(
@@ -344,7 +343,7 @@ describe('Test serverUtilities.js module ', () => {
 		});
 
 		it('ignores an announcement that lost a race with its own thread exit', function () {
-			manageThreads.notifyThreadExit(DEAD_THREAD);
+			registeredOperations.notifyThreadExitedForTest(DEAD_THREAD);
 
 			registeredOperations.operationRegisteredHandler({
 				message: { name: ZOMBIE, grantable: true, originator: DEAD_THREAD },

--- a/unitTests/server/serverHelpers/serverUtilities.test.js
+++ b/unitTests/server/serverHelpers/serverUtilities.test.js
@@ -236,10 +236,16 @@ describe('Test serverUtilities.js module ', () => {
 		const ROLLED = 'test_cross_thread_rolled_op';
 		const RETRACTED = 'test_cross_thread_retracted_op';
 		const ZOMBIE = 'test_cross_thread_zombie_op';
+		const FAILED_SEND = 'test_cross_thread_failed_send_op';
+		// Tombstones in exitedThreadIds are permanent and module-global, so synthetic ids must be
+		// ones the runtime will never assign to a real worker in this process.
+		const DECLARING_THREAD = 9_000_061;
+		const ROUTING_THREAD = 9_000_062;
+		const DEAD_THREAD = 9_000_071;
+		const SENDER_THREAD = 9_000_081;
 
 		after(function () {
-			// Don't leak these names into the process-global registries for later suites.
-			for (const op of [GRANTABLE, PLAIN, SHARED, ROLLED, RETRACTED, ZOMBIE]) {
+			for (const op of [GRANTABLE, PLAIN, SHARED, ROLLED, RETRACTED, ZOMBIE, FAILED_SEND]) {
 				unregisterWorkerGrantableOperation(op);
 				unregisterGrantableOperation(op);
 			}
@@ -261,7 +267,6 @@ describe('Test serverUtilities.js module ', () => {
 			});
 
 			assert.notEqual(validateOperations([PLAIN]), null);
-			// The routing half is unaffected — only admissibility is withheld.
 			assert.equal(typeof registeredOperations.getRemoteOperationFunction(PLAIN), 'function');
 		});
 
@@ -295,28 +300,54 @@ describe('Test serverUtilities.js module ', () => {
 		it('stops being grantable once the last declaring worker is gone, even while another still routes it', function () {
 			// Rolling deploy: the new generation keeps the operation but drops requiresSuperUser.
 			registeredOperations.operationRegisteredHandler({
-				message: { name: ROLLED, grantable: true, originator: 61 },
+				message: { name: ROLLED, grantable: true, originator: DECLARING_THREAD },
 			});
 			registeredOperations.operationRegisteredHandler({
-				message: { name: ROLLED, grantable: false, originator: 62 },
+				message: { name: ROLLED, grantable: false, originator: ROUTING_THREAD },
 			});
-			assert.equal(validateOperations([ROLLED]), null, 'still declared by thread 61');
+			assert.equal(validateOperations([ROLLED]), null, 'still declared by the first thread');
 
-			registeredOperations.notifyThreadExitedForTest(61);
+			registeredOperations.notifyThreadExitedForTest(DECLARING_THREAD);
 
 			assert.notEqual(validateOperations([ROLLED]), null, 'no live worker declares it grantable any more');
 			assert.equal(
 				typeof registeredOperations.getRemoteOperationFunction(ROLLED),
 				'function',
-				'thread 62 still routes it'
+				'the surviving worker still routes it'
 			);
 		});
 
+		it('retracts grantability when a failed send prunes the declaring worker', async function () {
+			const originalThreads = global.threads;
+			global.threads = {
+				sendToThread() {
+					return false;
+				},
+			};
+			try {
+				registeredOperations.operationRegisteredHandler({
+					message: { name: FAILED_SEND, grantable: true, originator: SENDER_THREAD },
+				});
+				assert.equal(validateOperations([FAILED_SEND]), null);
+
+				const forward = registeredOperations.getRemoteOperationFunction(FAILED_SEND, true);
+				await assert.rejects(forward({ operation: FAILED_SEND }), /no worker thread is available/);
+
+				assert.notEqual(
+					validateOperations([FAILED_SEND]),
+					null,
+					'a dead port must retract the claim, not just the route'
+				);
+			} finally {
+				global.threads = originalThreads;
+			}
+		});
+
 		it('ignores an announcement that lost a race with its own thread exit', function () {
-			registeredOperations.notifyThreadExitedForTest(71);
+			registeredOperations.notifyThreadExitedForTest(DEAD_THREAD);
 
 			registeredOperations.operationRegisteredHandler({
-				message: { name: ZOMBIE, grantable: true, originator: 71 },
+				message: { name: ZOMBIE, grantable: true, originator: DEAD_THREAD },
 			});
 
 			assert.notEqual(validateOperations([ZOMBIE]), null, 'a dead thread must not install a grant');

--- a/unitTests/server/serverHelpers/serverUtilities.test.js
+++ b/unitTests/server/serverHelpers/serverUtilities.test.js
@@ -246,7 +246,7 @@ describe('Test serverUtilities.js module ', () => {
 		});
 
 		it('makes a worker-announced declared op grantable on the main thread', function () {
-			assert.notEqual(validateOperations([GRANTABLE]), null, 'name should be unknown before the announcement');
+			assert.notEqual(validateOperations([GRANTABLE]), null);
 
 			registeredOperations.operationRegisteredHandler({
 				message: { name: GRANTABLE, grantable: true, originator: 31 },
@@ -267,7 +267,7 @@ describe('Test serverUtilities.js module ', () => {
 
 		it('keeps a main-thread registration of the same name independent of the worker mirror', function () {
 			// restartWorkers loads root components before draining old workers, so a startOnMainThread
-			// component can register an op a retiring worker also offers.
+			// component can claim a name a retiring worker still offers.
 			registeredOperations.operationRegisteredHandler({
 				message: { name: SHARED, grantable: true, originator: 41 },
 			});
@@ -293,8 +293,7 @@ describe('Test serverUtilities.js module ', () => {
 		});
 
 		it('stops being grantable once the last declaring worker is gone, even while another still routes it', function () {
-			// The rolling-deploy case: the new generation keeps the operation but drops
-			// requiresSuperUser, so the name must stay routable and stop being grantable.
+			// Rolling deploy: the new generation keeps the operation but drops requiresSuperUser.
 			registeredOperations.operationRegisteredHandler({
 				message: { name: ROLLED, grantable: true, originator: 61 },
 			});

--- a/unitTests/server/serverHelpers/serverUtilities.test.js
+++ b/unitTests/server/serverHelpers/serverUtilities.test.js
@@ -238,8 +238,8 @@ describe('Test serverUtilities.js module ', () => {
 		const RETRACTED = 'test_cross_thread_retracted_op';
 		const ZOMBIE = 'test_cross_thread_zombie_op';
 		const FAILED_SEND = 'test_cross_thread_failed_send_op';
-		// Tombstones in exitedThreadIds are permanent and module-global, so synthetic ids must be
-		// ones the runtime will never assign to a real worker in this process.
+		// Thread-exit tombstones are permanent and process-global, so synthetic ids must be ones the
+		// runtime will never assign to a real worker.
 		const DECLARING_THREAD = 9_000_061;
 		const ROUTING_THREAD = 9_000_062;
 		const DEAD_THREAD = 9_000_071;

--- a/unitTests/server/serverHelpers/serverUtilities.test.js
+++ b/unitTests/server/serverHelpers/serverUtilities.test.js
@@ -9,6 +9,7 @@ const sandbox = sinon.createSandbox();
 const { TEST_JSON_SUPER_USER, TEST_JSON_NON_SU } = require('../../test_data');
 const serverUtilities = require('#src/server/serverHelpers/serverUtilities');
 const registeredOperations = require('#src/server/serverHelpers/registeredOperations');
+const manageThreads = require('#src/server/threads/manageThreads');
 const operationAuthorizationState = require('#src/server/serverHelpers/operationAuthorizationState');
 const { runWithDeployValidationGuard } = require('#src/server/serverHelpers/deployValidationState');
 const quota = require('#src/components/mcp/quota');
@@ -306,7 +307,7 @@ describe('Test serverUtilities.js module ', () => {
 			});
 			assert.equal(validateOperations([ROLLED]), null, 'still declared by the first thread');
 
-			registeredOperations.notifyThreadExitedForTest(DECLARING_THREAD);
+			manageThreads.notifyThreadExit(DECLARING_THREAD);
 
 			assert.notEqual(validateOperations([ROLLED]), null, 'no live worker declares it grantable any more');
 			assert.equal(
@@ -343,7 +344,7 @@ describe('Test serverUtilities.js module ', () => {
 		});
 
 		it('ignores an announcement that lost a race with its own thread exit', function () {
-			registeredOperations.notifyThreadExitedForTest(DEAD_THREAD);
+			manageThreads.notifyThreadExit(DEAD_THREAD);
 
 			registeredOperations.operationRegisteredHandler({
 				message: { name: ZOMBIE, grantable: true, originator: DEAD_THREAD },

--- a/utility/operationPermissions.ts
+++ b/utility/operationPermissions.ts
@@ -97,6 +97,11 @@ const validGroups: Set<string> = new Set(Object.keys(OPERATION_PERMISSION_GROUPS
 // permission) whose names may fall outside OPERATIONS_ENUM. Tracked so they're grantable in a
 // role's `operations` allowlist (add_role/alter_role/impersonation validate against this set too).
 const dynamicallyRegisteredOps: Set<string> = new Set();
+// The same, for ops registered on a WORKER and mirrored here by the OPERATION_REGISTERED bridge.
+// Deliberately a separate set: the two threads can register the same name independently (a hot
+// deploy can add a `startOnMainThread` component while the worker offering that name is retiring),
+// so worker-lifecycle cleanup must not be able to revoke a mark this thread made itself.
+const workerRegisteredOps: Set<string> = new Set();
 
 /**
  * Mark a dynamically-registered operation name as a valid target for role `operations` grants.
@@ -116,12 +121,28 @@ export function unregisterGrantableOperation(name: string): void {
 }
 
 /**
+ * Mirror a worker's grantable operation so role validation, which runs on the main thread, accepts
+ * the name. See server/serverHelpers/registeredOperations.ts — the worker still owns enforcement.
+ */
+export function registerWorkerGrantableOperation(name: string): void {
+	workerRegisteredOps.add(name);
+}
+
+/** Drop a mirrored name once no worker offers the operation any more. */
+export function unregisterWorkerGrantableOperation(name: string): void {
+	workerRegisteredOps.delete(name);
+}
+
+/**
  * Validates that every entry in an operations array is a known operation name or group name.
  * Returns the first invalid entry, or null if all entries are valid.
  */
 export function validateOperations(operations: readonly unknown[]): string | null {
 	for (const op of operations) {
-		if (typeof op !== 'string' || (!validOps.has(op) && !validGroups.has(op) && !dynamicallyRegisteredOps.has(op))) {
+		if (
+			typeof op !== 'string' ||
+			(!validOps.has(op) && !validGroups.has(op) && !dynamicallyRegisteredOps.has(op) && !workerRegisteredOps.has(op))
+		) {
 			return String(op);
 		}
 	}

--- a/utility/operationPermissions.ts
+++ b/utility/operationPermissions.ts
@@ -120,15 +120,11 @@ export function unregisterGrantableOperation(name: string): void {
 	dynamicallyRegisteredOps.delete(name);
 }
 
-/**
- * Mirror a worker's grantable operation so role validation, which runs on the main thread, accepts
- * the name. See server/serverHelpers/registeredOperations.ts — the worker still owns enforcement.
- */
+/** Ownership of the mirror lives in registeredOperations.ts; enforcement stays on the worker. */
 export function registerWorkerGrantableOperation(name: string): void {
 	workerRegisteredOps.add(name);
 }
 
-/** Drop a mirrored name once no worker offers the operation any more. */
 export function unregisterWorkerGrantableOperation(name: string): void {
 	workerRegisteredOps.delete(name);
 }

--- a/utility/operationPermissions.ts
+++ b/utility/operationPermissions.ts
@@ -120,7 +120,6 @@ export function unregisterGrantableOperation(name: string): void {
 	dynamicallyRegisteredOps.delete(name);
 }
 
-/** Ownership of the mirror lives in registeredOperations.ts; enforcement stays on the worker. */
 export function registerWorkerGrantableOperation(name: string): void {
 	workerRegisteredOps.add(name);
 }


### PR DESCRIPTION
An operation a component registers with `requiresSuperUser` is meant to be grantable in a role's `operations` allowlist, but naming it in `add_role`, `alter_role`, or an impersonation payload was rejected as "not a valid operation name or group" — the grantable mark was made in the worker that registered the operation, while the validation that reads it runs on the main thread. The registration announcement now carries that fact across the thread boundary, so a scoped role can actually be granted a component operation.

Enforcement is unchanged: the main thread only decides whether a name is *admissible* in an allowlist, and the operation still runs through the registering worker's own `chooseOperation`.

One finding is disclosed rather than fixed, and is inherited from the `registerOperation` bridge (#1736) rather than introduced here — the announcement is fire-and-forget, so an `add_role` naming a component operation can still lose a race against component load at startup. It fails closed (a rejected role), and the existing execution path has the same window.

## For the human reviewer

**The step-6 framing gate did not clear.** The planning review returned `Framing-Verdict: better-alternative-exists`, and it was right — I adopted its recommendation rather than defending mine, which is why the history carries superseded approaches (squash on merge). The entries below lead with the parts I got wrong, because those are the ones worth your scepticism:

1. **The approach changed after review, and the earlier one was genuinely broken.** I first mirrored grantability as a set of *names*. That cannot enforce the invariant the design claimed ("admissible iff a live worker declares it grantable"): on a rolling deploy whose new generation keeps an operation but drops `requiresSuperUser`, the routing set stays non-empty via the new workers, so the mark is never revoked — `add_role` accepts a grant whose execution then fails closed with operation-not-found. Grantability is now tracked per declaring thread (`name -> Set<threadId>`) and the mirrored mark is re-derived from live claims. **What to check:** that `setWorkerGrantable` re-derives on every path, including retraction, and that `handleThreadExit` retracts one thread's claim while preserving routing for survivors.
2. **My "main-mediated registration" rejection was overstated, and I did not adopt the correction.** I disqualified it as requiring `server.registerOperation()` to become async. The reviewer pointed out that the loader could instead collect synchronous registrations and await one batched acknowledgement before declaring the worker ready — no API change, and it would also close the fire-and-forget startup window disclosed above. I did not do it: it introduces a worker-readiness protocol in the component loader, which is a materially larger change than the one this bug needs. **This is the entry most worth overruling.** If you want the startup window closed rather than documented, that is the design to ask for, and this PR is the wrong shape for it.
3. **A mixed worker generation can make a granted call succeed intermittently, and I declined to fix it.** If the old generation declares an operation grantable and the replacement omits `requiresSuperUser`, a role grant is accepted while both generations are live, and calls then alternate between succeeding on the declaring worker and returning a permission error on the other. Routing ignores `grantableByWorker` deliberately: selecting a worker by authorization metadata would require the main thread to know *why* a caller is authorized (super_user vs. an `operations` grant), which is the authorization determination this module documents that main must not make — #1736 split it as main routes, worker enforces. It fails closed (a permission error, never a wrongful success) and it is transient: once the old generation is gone this change retracts grantability and the grant is correctly rejected at write time. **If you would rather routing became authorization-aware, that is a design call, and this is where to make it.**
4. **`grantable` is derived as `requiresSuperUser !== undefined`** rather than being a new field on `OperationDefinition`. It reuses the existing tri-state that already decides whether `registerOperationPermission` is called at all, so the two cannot drift; the cost is that the wire flag's meaning is implicit in that expression. Note this deliberately treats `requiresSuperUser: false` as grantable, which matches the tri-state's documented meaning ("grantable AND open to any authenticated user") and keeps worker-registered operations behaving like main-thread ones.
5. **Arming the thread-exit cleanup at module load widens this PR past the stated bug.** `attachMainListeners()` previously ran only on the first *forwarded call*. Thread-exit notification fires once per thread and is dropped when no listener is attached, so a worker that registered and died before that first call leaked its entries permanently. That is a pre-existing bug in the routing map — I fixed it here because the new mark would otherwise inherit it, but it is separable if you would rather see it on its own.

Also flagged by the planning review and **not** addressed: it recommended lifecycle tests driven through a real hot restart/deploy, and integration coverage of a mixed old/new generation. The new unit tests drive the exit seam directly instead, so they prove the state machine but not that a real `restart_service` produces those transitions.

Adjacent bug found while checking symmetry, filed rather than fixed here: #2203 (P2, under [Epic] Component authoring & packaging DX) — a component's own `roles.yaml` still cannot grant an operation its own `resources.js` registers, because `DEFAULT_CONFIG` orders the `roles` plugin before `jsResource` and `componentLoader.ts:542` iterates config keys in order. Same-thread ordering, different mechanism, survives this fix.

**This invalidates documentation of the limitation in two places that are still in flight, neither on a `main` branch, so there is no companion docs PR to open yet:** the `Known limitation` comment on `assertOperationsAreKnown` in `security/authn/oidc/trustPolicyOperations.ts` on #2173's branch, and the "that registry is process-local, so a policy naming one is rejected" paragraph in `reference/operations-api/operations.md` on an unpushed `HarperFast/documentation` branch. Whichever of the two PRs lands second should drop both. Nothing currently on documentation `main` is made false by this change.

**Windows CI is red for reasons outside this PR (#2273, #2313), and the repo owner has accepted that for this merge.** `Integration Tests 2/6` fails `Component: risk-query` and `describe_all metadata upgrade`, both npm work → `restart_service` → route readiness, which is #2273 (`deploy_component (restart: true)` hangs after npm pack) — open and reproducing on `main`. `Integration Tests 6/6` fails `set_configuration`, which is #2313 (Windows config-write rename retry blocking the thread), with fixes in flight in #2339 and #2191. Neither is reachable from this diff.

For the record, since an earlier version of this description said otherwise: I bisected the 2/6 failure to a commit here and reverted it on that basis. **That was wrong.** The same test fails at 350s with the commit reverted and ranges 259–465s across builds with identical code, so ~200s of variance was being read as a 110s signal. The revert has been undone in `9ac125c45` and the variance data is on #2273 so the next person doesn't repeat it.

## Verification

**Route (a), extended existing integration test** — `integrationTests/components/registered-operation.test.ts` gains six cases in a nested suite covering `add_role`, `alter_role`, impersonation, an end-to-end grant (a non-super_user with the grant executes the operation on a worker), and two negative controls: an unregistered name is still rejected, and a non-super_user *without* the grant still gets 403. No new CI entry.

```
HARPER_INTEGRATION_TEST_LOOPBACK_POOL_START=1 HARPER_INTEGRATION_TEST_LOOPBACK_POOL_COUNT=1 \
  npm run test:integration -- --isolation=none integrationTests/components/registered-operation.test.ts
→ 11/11 pass (5 pre-existing + 6 new)
```

**Unit** — seven new cases in `unitTests/server/serverHelpers/serverUtilities.test.js`, covering the rolling-deploy retraction, withdrawal by re-announcement, the exited-thread announcement guard, main/worker mark independence, and the failed-send retraction through its real trigger (`sendToThread` reporting a dead port). `npx mocha "unitTests/server/serverHelpers/*.test.js"` → 295 passing, 1 failing. That failure is pre-existing (`uwsServer.test.js`, "rejects a body over maxBodyBytes with 413"); confirmed by stashing this branch's changes and re-running. Run as the whole suite rather than the changed file alone, because these tests mutate the process-global grantable registries. Also `npx mocha unitTests/utility/operationPermissions.test.js unitTests/security/impersonation.test.js unitTests/validation/role_validation.test.js` → 133 passing, 0 failing.

**fails-on-base** — through a detached worktree at the merge-base with `origin/main`, with only the test changes applied: the new unit cases fail there and reach their intended assertions rather than a setup or compile error; the 4 positive integration cases fail there while both negative controls pass. Everything passes on the branch.

**Rebased onto current `origin/main`** (374408e3f) before review — the branch had fallen 67 commits behind. No conflicts, and `origin/main` had touched none of these 7 files.

**Not run locally:** `test:unit:main` and `test:unit:resources` abort at load on this machine — another process holds `~/harper/database/data/LOCK`, and `HDB_ROOT`/`ROOTPATH` overrides do not reroute the path that opens it. Worth knowing separately: **mocha exits 0 when it dies this way**, so an exit code is not evidence those suites ran. `test:integration:all` (160 files) was not run locally either: without the loopback address pool configured it can only run sequentially against `127.0.0.1`. Both are left to this PR's Actions run.

The coverage field below pins the final round, which was a comment-only delta. The substantive round on this code (`b1b267ecd`) was classified high-risk / security-auth and ran three outside lenses — codex, gemini and cursor-grok — at high effort; it is the round that found the re-registration authorization divergence fixed in `5daaa6d96`. Harper domain adjudication failed or was pruned on every round, so no round was filtered by the leg that drops false positives, and I triaged findings myself.

`npm run lint:required` clean; `npm run format:write` produced no changes; `npm run build` clean; TypeStrip/tabs/`node:`-prefix/assert-style greps clean over `origin/main...HEAD`.

Complexity: complicated

<sub>Review-Coverage: authored=claude; ran=codex; blocked=gemini(quota); declined=cursor-grok,cursor-composer,domain; rounds=11 @ 9ac125c459f2</sub>

<sub>Human-Review-Need: 4 @ 9ac125c459f2</sub>
