### PR TITLE
Report the Harper version in the startup options banner

### DIFF
--- a/bin/run.ts
+++ b/bin/run.ts
@@ -281,6 +281,8 @@ function startupLog(portResolutions: any) {
 		logMsg += `${pad('Mode:')}${chalk.yellow('READ-ONLY')}\n`;
 	}
 
+	logMsg += `${pad('Version:')}${packageJson.version}\n`;
+
 	logMsg += `${pad('Hostname:')}${getThisNodeName()}\n`;
 
 	logMsg += `${pad('Worker Threads:')}${env.get(CONFIG_PARAMS.THREADS_COUNT)}\n`;

--- a/integrationTests/README.md
+++ b/integrationTests/README.md
@@ -90,7 +90,7 @@ This is how CI captures logs for failed jobs — the log directory is uploaded a
 
 ### Requirements
 
-- Files must use the Node.js `node:test` API (`suite`, `test`, `before`, `after`, etc.) with assertions from `node:assert/strict`
+- Files must use the Node.js `node:test` API (`suite`, `test`, `before`, `after`, etc.) with assertions from `node:assert` (plain, not `/strict` — `no-restricted-imports` rejects it; call `assert.strictEqual`/`deepStrictEqual` for strict checks, see AGENTS.md)
 - Files must end in `.test.ts` or `.test.mjs` (both extensions are picked up by `test:integration:all`)
 - Files must be implemented as ESM (TypeScript or JavaScript)
 - Each file must begin with a JSDoc comment describing exactly what it tests — include relevant GitHub issue or PR links if they exist
@@ -109,7 +109,7 @@ The runner executes each file in its own process. For concurrent execution to be
  * Link to relevant GitHub issues or PRs if applicable.
  */
 import { suite, test, before, after } from 'node:test';
-import { strictEqual } from 'node:assert/strict';
+import { strictEqual } from 'node:assert';
 import { startHarper, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
 
 suite('short description', (ctx: ContextWithHarper) => {


### PR DESCRIPTION
Adds a `Version:` field to the startup options banner, so the block an operator reads — or pastes into a support thread — identifies the build it came from. Sourced from the same `packageJson.version` the `Harper <version> successfully started` marker already uses, so the two cannot disagree.

```
Version:            5.2.4
Hostname:           stage-1.studio.harperfabric.com
Worker Threads:     4
Root Path:          /home/harperdb/harper
```

Until now the version reached stdout only via that marker, which sits above the ASCII logo and a variable number of boot lines, so any excerpt starting at the banner carried no build identity. Under `IS_SCRIPTED_SERVICE` the marker isn't printed at all (`bin/run.ts:227`), which makes the banner the only version on stdout for those installs.

Also fixes an unrelated contradiction I tripped over here: `integrationTests/README.md` told you to import `node:assert/strict`, which `.oxlintrc.json` and `AGENTS.md:196` reject — so following the README produced a lint failure. Corrected in both the requirements list and the template. No existing integration test imported `/strict`, so nothing else moves.

## For the human reviewer

1. **No test, per @kriszyp's review** — logging is declarative, so there is no behavior to assert; a test could only guard against someone deleting a string. An earlier revision of this branch carried a full-boot integration test reading the banner off stdout; it is removed. The code is in branch history at `e86cf0e19` if anyone ever wants it. Verification below is a recorded live boot instead.

2. **Field position.** `Version:` goes after the conditional `Mode: READ-ONLY` line and before `Hostname:`, so the yellow read-only alert stays the first thing you see. The alternative is making `Version:` the literal first line — a one-line move, but this banner's field order is the de facto operator contract.

3. **Console-only, not `hdb.log`.** The banner is a bare `console.log`, so with `logging.stdStreams: false` the new field — like every other banner field — never lands in `hdb.log`; verified on a local boot. Someone holding only a customer's `hdb.log` from such an install still can't read the version. Emitting through `hdbLogger` would fix that, but makes the version a log-format commitment the moment anything parses it. I chose not to.

4. **The version now prints twice on stdout** — banner plus marker. Deliberate: the banner is the block people paste, the marker scrolls away. One-line revert either way.

## Verification

End-to-end route: **live smoke with recorded output.** No automated test, per decision 1.

Booted `dist/bin/harper.js run` from a worktree against a scratch root. Banner printed:

```
Version:            5.2.4
Hostname:           127.0.0.1
Worker Threads:     1
```

matching the `Harper 5.2.4 successfully started` line below it and `package.json`'s `version`. Also confirmed the banner is absent from that boot's `hdb.log` under `logging.stdStreams: false` (decision 3).

`prettier --check` and `oxlint --format stylish --quiet` clean.

### Known-unrelated intermittent failure: `Unit Test (Node.js v24)`

Checks are green as of `0771f3414`. Earlier runs of this PR were red on `HNSW greedy routing above layer 0 (ROUTING_EF)` (`unitTests/resources/vectorIndex.test.js:1009`), which is intermittent rather than fixed, and is not this change. Keeping the evidence here in case it reappears:

- **It fails on `main`** with the identical assertion — unit-test run 32515721637, Node v24, `greedy descent changed the result set for target 0`.
- Between two commits on this branch whose only diff was 4+/10- of *comment trimming* in a test file the unit suite never loads, the failure moved from Node 26 / target 0 to Node 24 / target 3.
- On two consecutive v24 runs, **both sides of the assertion changed**: run 2's expected value (`450,461,460,...`) is exactly run 1's actual. The test asserts `greedy === full`, so it compares two results that are each unstable across runs.
- `startupLog` is unreachable from the unit suite — one test file mentions `bin/run.ts` in a comment, none import it.

Possible origin, not traced: #2181 (merged 2026-08-20) auto-scales `efConstruction` and the search-ef ceiling with graph size, so the greedy/full equivalence that test asserts may no longer hold deterministically. Two other tests were also failing on `main` in the same window (`subscriptionReplay.test.js:432` on v26, `Txn Expiration > Slow txn will expire` on v22).

Separately, `npm run test:unit:main` cannot complete on macOS — it hangs in `unitTests/components/applicationSpawn.test.js` under the suite's `--timeout 0`, reproduced on `main` too. Overlaps #2085, which is already open.

Complexity: easy

<sub>Review-Coverage: authored=claude; ran=codex; adjudicated=domain; blocked=cursor-composer(not-installed),gemini(exit-1); declined=cursor-grok; rounds=11 @ 0771f34142a8</sub>

<sub>Human-Review-Need: 3 (decisions: version-source-core-vs-wrapper, banner-row-vs-existing-started-line, row-placement-and-label) @ 0771f34142a8</sub>
