### PR TITLE
Capture only whole blobs in a backup, substituting a marker for one still being written

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -483,24 +483,23 @@ engine-only backup):
 
 - **Managed backups** snapshot the blob roots to `<backupDir>/blobs/<backupId>/<rootIndex>/<relpath>`
   — a full, non-incremental copy per backup, mirroring the binding's `transaction_logs/<id>/` layout.
-  Files are hard-linked when possible (cheap, no extra space on the same filesystem) and copied when
-  the backup root is on a different filesystem; never symlinked. Hard-linking is safe against later
-  mutation because Harper blobs are content-addressed and write-once (each write allocates a new
-  monotonic file id → a new path; updates/deletes unlink the old path), so a snapshot's hard link
-  keeps the exact bytes even after the live blob is deleted, and no in-place overwrite can alter it.
-  The snapshot is built in a `.tmp-<id>` sibling and atomically renamed so a failed create leaves no
-  partial snapshot. `restore_backup` purges each blob root and rewrites it from the snapshot (so a
-  blob added after the backup is dropped and one deleted after it returns); `delete_backup` /
-  `purge_backups` remove the corresponding snapshot directories.
+  Each enumerated entry is classified before capture: complete blobs and existing abort markers are
+  hard-linked when possible (copied across filesystems), `.repair` temporaries are omitted, and an
+  incomplete blob is replaced by a retryable PENDING (`0xfe`) marker. If a classified blob vanishes
+  before capture, a terminal ERROR (`0xff`) marker preserves its file id. A file reclaimed before its
+  parent directory is read is outside the snapshot. This keeps a snapshot inode from changing as a
+  live write finishes, while complete blobs remain safe to hard-link because published blob paths are
+  write-once. The snapshot is built in a `.tmp-<id>` sibling and atomically renamed so a failed create
+  leaves no partial snapshot. `restore_backup` purges each blob root and rewrites it from the snapshot;
+  `delete_backup` / `purge_backups` remove the corresponding snapshot directories.
 - **`get_backup`** appends the blob files to the same tar under `blobs/<rootIndex>/<relpath>`. The
   binding's streaming backup finalizes its tar with exactly a 1024-byte (two-block) end-of-archive
   marker; `createBackupStream` streams the native _plain_ tar while withholding that trailer
   (verifying it is all-zero), appends the blob entries via `tar-stream` (whose `finalize` writes the
   one real trailer), and gzips the combined stream itself when requested — so the binding is always
-  asked for a plain tar and compression happens after the append. No scratch disk. Blob capture is
-  best-effort point-in-time (whatever files exist while it streams; a blob deleted mid-stream is
-  skipped) — Harper does not freeze blob writes for a backup, the same tradeoff the engine makes for
-  the transaction log.
+  asked for a plain tar and compression happens after the append. No scratch disk. The same blob
+  classification rule applies: complete blobs are streamed, incomplete or post-enumeration missing
+  blobs become PENDING/ERROR marker entries, and repair temporaries are omitted.
 
 **Completion manifest (`dataLayer/backupManifest.ts`).** `create_backup` is two-phase: the engine
 backup (`rootStore.backup()`) resolves — and is immediately visible to `list_backups`/`verify_backup`/

--- a/dataLayer/blobBackup.ts
+++ b/dataLayer/blobBackup.ts
@@ -96,6 +96,8 @@ async function captureBlobFile(srcPath: string, destPath: string): Promise<BlobC
 	try {
 		disposition = await classifyBlobFileForCapture(srcPath);
 	} catch (error) {
+		// This rethrow is unverified: only the membership of SYSTEMIC_IO_ERRORS is tested, because
+		// reaching it needs a real host-level fault no test here can produce.
 		if (isSystemicIoError(error)) throw error;
 		// Fall back to what this walk did before it classified anything. `link()` needs no read permission
 		// on the source, so a blob this failed to *read* may still be perfectly capturable; substituting

--- a/dataLayer/blobBackup.ts
+++ b/dataLayer/blobBackup.ts
@@ -5,6 +5,12 @@ import { copyFile, link, mkdir, readdir, rename, rm, unlink, writeFile } from 'n
 import { dirname, join, relative } from 'node:path';
 import { ClientError } from '../utility/errors/hdbError.ts';
 import logger from '../utility/logging/harper_logger.ts';
+import {
+	type BlobCaptureDisposition,
+	classifyBlobFileForCapture,
+	createCaptureMarker,
+	isSystemicIoError,
+} from '../resources/blob.ts';
 
 /**
  * Managed-backup snapshotting of a database's file-backed blobs.
@@ -21,17 +27,16 @@ import logger from '../utility/logging/harper_logger.ts';
  * possible (cheap, no extra space on the same filesystem) and copied otherwise (never symlinked, so
  * a snapshot is a standalone set of files that survives independent of the live blob).
  *
- * Consistency is best-effort and point-in-time-ish, matching how the engine treats the transaction
- * log: the walk captures whatever files exist at snapshot time. A blob deleted mid-walk is skipped;
- * a blob being written mid-walk is captured as-is (a hard link shares the inode, so it reflects the
- * writer's final bytes; a cross-filesystem copy captures the bytes present at copy time). Harper
- * does not freeze blob writes for the duration of a backup.
+ * Harper does not freeze blob writes for a backup, and a blob is written in place at its final path,
+ * so the walk can meet one that is still growing. Hard-linking that inode would put bytes in the
+ * snapshot that keep changing after it was taken. Every entry is therefore classified
+ * (`captureBlobFile`): a complete blob is linked, and one that is not is replaced by a PENDING marker
+ * rather than dropped, which keeps its file id reserved — `getNextFileId` recovers the id counter by
+ * scanning the directory, so an absent file would let a restored record's id be reissued.
  *
- * Hard-linking is safe against later mutation because Harper blobs are content-addressed and
- * write-once: each write allocates a fresh monotonic file id (a new path), and an update or delete
- * unlinks the old path rather than rewriting it in place — so a snapshot's hard link keeps the exact
- * bytes alive even after the live blob is deleted, and no in-place overwrite can retroactively alter
- * a snapshot.
+ * Past that gate, hard-linking is safe against later mutation: each write takes a fresh monotonic
+ * file id, and an update, delete, or in-place repair replaces or unlinks the path rather than
+ * rewriting the inode.
  */
 
 /** Directory holding all blob snapshots for a backup repository. */
@@ -49,14 +54,13 @@ export function blobSnapshotDir(backupDir: string, backupId: number): string {
  * the filesystem does not support additional hard links). Never creates a symlink. A source that
  * vanished mid-walk (a concurrent blob delete) is skipped rather than failing the whole snapshot.
  */
-async function linkOrCopy(src: string, dest: string): Promise<void> {
+async function linkOrCopy(src: string, dest: string): Promise<boolean> {
 	await mkdir(dirname(dest), { recursive: true });
 	try {
 		await link(src, dest);
 	} catch (error: any) {
 		if (error.code === 'ENOENT') {
-			// src disappeared (concurrent delete) — nothing to snapshot
-			if (!existsSync(src)) return;
+			if (!existsSync(src)) return false; // vanished since it was classified
 			throw error;
 		}
 		if (
@@ -66,24 +70,72 @@ async function linkOrCopy(src: string, dest: string): Promise<void> {
 			error.code === 'ENOTSUP' ||
 			error.code === 'EOPNOTSUPP'
 		) {
-			await copyFile(src, dest);
-			return;
+			try {
+				await copyFile(src, dest);
+			} catch (copyError: any) {
+				if (copyError.code === 'ENOENT') return false;
+				throw copyError;
+			}
+			return true;
 		}
 		if (error.code === 'EEXIST') {
 			await unlink(dest);
-			await linkOrCopy(src, dest);
-			return;
+			return linkOrCopy(src, dest);
 		}
 		throw error;
 	}
+	return true;
+}
+
+/**
+ * Put one blob file into the snapshot, returning true when a PENDING marker stood in for it.
+ */
+async function captureBlobFile(srcPath: string, destPath: string): Promise<boolean> {
+	let disposition: BlobCaptureDisposition;
+	try {
+		disposition = await classifyBlobFileForCapture(srcPath);
+	} catch (error) {
+		if (isSystemicIoError(error)) throw error;
+		// Fall back to what this walk did before it classified anything. `link()` needs no read permission
+		// on the source, so a blob this failed to *read* may still be perfectly capturable; substituting
+		// here would turn an unreadable-but-valid root into a backup of nothing but stubs.
+		logger.warn(`Could not verify blob ${srcPath} for snapshot; capturing it unverified`, error);
+		disposition = 'capture';
+	}
+	if (disposition === 'skip') return false;
+	// A capture can still lose the race with a delete between classify and link; those bytes are gone,
+	// so it falls through to a terminal marker rather than being dropped and freeing the id.
+	if (disposition === 'capture') {
+		if (await linkOrCopy(srcPath, destPath)) return false;
+		disposition = 'gone';
+	}
+	await mkdir(dirname(destPath), { recursive: true });
+	await writeFile(
+		destPath,
+		createCaptureMarker(
+			disposition,
+			disposition === 'gone'
+				? 'blob was deleted while this backup was being taken'
+				: 'blob was not yet complete when this backup was taken'
+		)
+	);
+	return true;
 }
 
 /**
  * Recursively copy every file under `srcRoot` into `destRoot` (hard-link-else-copy), preserving the
  * relative directory structure. Missing `srcRoot` is a no-op (a database with no blobs yet).
+ *
+ * `classify` belongs to the snapshot direction only; restore must replace exactly what the snapshot
+ * holds.
  */
-async function copyTree(srcRoot: string, destRoot: string): Promise<void> {
-	if (!existsSync(srcRoot)) return;
+async function copyTree(
+	srcRoot: string,
+	destRoot: string,
+	classify = false
+): Promise<{ substituted: number; captured: number }> {
+	const counts = { substituted: 0, captured: 0 };
+	if (!existsSync(srcRoot)) return counts;
 	const stack: string[] = [srcRoot];
 	while (stack.length > 0) {
 		const dir = stack.pop() as string;
@@ -99,11 +151,18 @@ async function copyTree(srcRoot: string, destRoot: string): Promise<void> {
 			if (entry.isDirectory()) {
 				stack.push(srcPath);
 			} else if (entry.isFile()) {
-				await linkOrCopy(srcPath, join(destRoot, relative(srcRoot, srcPath)));
+				const destPath = join(destRoot, relative(srcRoot, srcPath));
+				if (classify) {
+					if (await captureBlobFile(srcPath, destPath)) counts.substituted++;
+					else counts.captured++;
+				} else {
+					await linkOrCopy(srcPath, destPath);
+				}
 			}
 			// symlinks/other node types in a blob root are not expected and are intentionally skipped
 		}
 	}
+	return counts;
 }
 
 /**
@@ -118,8 +177,19 @@ export async function snapshotBlobs(backupDir: string, backupId: number, blobRoo
 	await rm(tempDir, { recursive: true, force: true });
 	await mkdir(tempDir, { recursive: true });
 	try {
+		let substituted = 0;
+		let captured = 0;
 		for (let index = 0; index < blobRoots.length; index++) {
-			await copyTree(blobRoots[index], join(tempDir, String(index)));
+			const counts = await copyTree(blobRoots[index], join(tempDir, String(index)), true);
+			substituted += counts.substituted;
+			captured += counts.captured;
+		}
+		if (substituted > 0) {
+			logger.warn(
+				`Blob snapshot for backup ${backupId} captured ${substituted} of ${substituted + captured} blob ` +
+					`file(s) as PENDING markers because they were not capturable whole. Records referencing them will ` +
+					`need blob repair after a restore.`
+			);
 		}
 		await rm(finalDir, { recursive: true, force: true });
 		await rename(tempDir, finalDir);

--- a/dataLayer/blobBackup.ts
+++ b/dataLayer/blobBackup.ts
@@ -29,10 +29,11 @@ import {
  *
  * Harper does not freeze blob writes for a backup, and a blob is written in place at its final path,
  * so the walk can meet one that is still growing. Hard-linking that inode would put bytes in the
- * snapshot that keep changing after it was taken. Every entry is therefore classified
- * (`captureBlobFile`): a complete blob is linked, and one that is not is replaced by a PENDING marker
- * rather than dropped, which keeps its file id reserved — `getNextFileId` recovers the id counter by
- * scanning the directory, so an absent file would let a restored record's id be reissued.
+ * snapshot that keep changing after it was taken. Every entry returned by the walk is therefore
+ * classified (`captureBlobFile`): a complete blob is linked, and one that becomes unavailable or is
+ * not yet complete is replaced by a marker rather than dropped. This closes the classify-to-capture
+ * race and keeps that file id reserved; a file reclaimed before its parent directory is read remains
+ * outside the snapshot.
  *
  * Past that gate, hard-linking is safe against later mutation: each write takes a fresh monotonic
  * file id, and an update, delete, or in-place repair replaces or unlinks the path rather than
@@ -51,8 +52,8 @@ export function blobSnapshotDir(backupDir: string, backupId: number): string {
 
 /**
  * Hard-link `src` to `dest`, falling back to a copy when the two are on different filesystems (or
- * the filesystem does not support additional hard links). Never creates a symlink. A source that
- * vanished mid-walk (a concurrent blob delete) is skipped rather than failing the whole snapshot.
+ * the filesystem does not support additional hard links). Never creates a symlink. Returns false
+ * when the source vanishes so the caller can substitute a marker for it.
  */
 async function linkOrCopy(src: string, dest: string): Promise<boolean> {
 	await mkdir(dirname(dest), { recursive: true });
@@ -88,9 +89,9 @@ async function linkOrCopy(src: string, dest: string): Promise<boolean> {
 }
 
 /**
- * Put one blob file into the snapshot, returning true when a PENDING marker stood in for it.
+ * Put one blob file into the snapshot, returning how the entry was captured.
  */
-async function captureBlobFile(srcPath: string, destPath: string): Promise<boolean> {
+async function captureBlobFile(srcPath: string, destPath: string): Promise<BlobCaptureDisposition> {
 	let disposition: BlobCaptureDisposition;
 	try {
 		disposition = await classifyBlobFileForCapture(srcPath);
@@ -102,11 +103,9 @@ async function captureBlobFile(srcPath: string, destPath: string): Promise<boole
 		logger.warn(`Could not verify blob ${srcPath} for snapshot; capturing it unverified`, error);
 		disposition = 'capture';
 	}
-	if (disposition === 'skip') return false;
-	// A capture can still lose the race with a delete between classify and link; those bytes are gone,
-	// so it falls through to a terminal marker rather than being dropped and freeing the id.
+	if (disposition === 'skip') return disposition;
 	if (disposition === 'capture') {
-		if (await linkOrCopy(srcPath, destPath)) return false;
+		if (await linkOrCopy(srcPath, destPath)) return disposition;
 		disposition = 'gone';
 	}
 	await mkdir(dirname(destPath), { recursive: true });
@@ -119,7 +118,7 @@ async function captureBlobFile(srcPath: string, destPath: string): Promise<boole
 				: 'blob was not yet complete when this backup was taken'
 		)
 	);
-	return true;
+	return disposition;
 }
 
 /**
@@ -153,8 +152,9 @@ async function copyTree(
 			} else if (entry.isFile()) {
 				const destPath = join(destRoot, relative(srcRoot, srcPath));
 				if (classify) {
-					if (await captureBlobFile(srcPath, destPath)) counts.substituted++;
-					else counts.captured++;
+					const disposition = await captureBlobFile(srcPath, destPath);
+					if (disposition === 'pending' || disposition === 'gone') counts.substituted++;
+					else if (disposition === 'capture') counts.captured++;
 				} else {
 					await linkOrCopy(srcPath, destPath);
 				}
@@ -186,9 +186,8 @@ export async function snapshotBlobs(backupDir: string, backupId: number, blobRoo
 		}
 		if (substituted > 0) {
 			logger.warn(
-				`Blob snapshot for backup ${backupId} captured ${substituted} of ${substituted + captured} blob ` +
-					`file(s) as PENDING markers because they were not capturable whole. Records referencing them will ` +
-					`need blob repair after a restore.`
+				`Blob snapshot for backup ${backupId} substituted ${substituted} of ${substituted + captured} blob ` +
+					`file(s) with PENDING or ERROR markers because they were not capturable whole.`
 			);
 		}
 		await rm(finalDir, { recursive: true, force: true });
@@ -245,8 +244,10 @@ ${rootMapping}
   4096 entries per directory). E.g. a blob with id \`0x12345678\` lives at \`12/345/678\`; a short id
   like \`0xc1a\` lives at \`0/0/c1a\`.
 
-Files are hard links to the live blobs when the backup is on the same filesystem, and copies
-otherwise.
+Complete blobs are hard links to the live blobs when the backup is on the same filesystem, and
+copies otherwise. A blob that was not capturable whole is stored as a marker instead: header type
+\`0xfe\` is retryable (PENDING), while \`0xff\` is terminal (ERROR). The marker preserves the file id
+but does not contain the original blob bytes.
 `;
 }
 

--- a/dataLayer/rocksdbBackup.ts
+++ b/dataLayer/rocksdbBackup.ts
@@ -10,7 +10,13 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { pack as tarPack, type Pack } from 'tar-stream';
 import { RocksDatabase, backups, registryStatus, type BackupInfo } from '@harperfast/rocksdb-js';
 import { getDatabases, resolveDatabasePath } from '../resources/databases.ts';
-import { getBlobPathsForDatabaseName } from '../resources/blob.ts';
+import {
+	type BlobCaptureDisposition,
+	classifyBlobFileForCapture,
+	createCaptureMarker,
+	getBlobPathsForDatabaseName,
+	isSystemicIoError,
+} from '../resources/blob.ts';
 import { getHdbBasePath } from '../utility/environment/environmentManager.ts';
 import { getConfigPath } from '../config/configUtils.ts';
 import { getBackupDirPath } from '../config/configHelpers.ts';
@@ -833,20 +839,58 @@ async function appendBlobEntries(pack: Pack, blobRoots: string[]): Promise<void>
 					// tar entry names are always POSIX-separated; relative() yields `\` on Windows, which
 					// would otherwise become literal filename characters when extracted on POSIX
 					const relativePath = relative(root, filePath).split(sep).join('/');
-					await appendBlobFile(pack, filePath, `blobs/${index}/${relativePath}`);
+					await appendBlobEntry(pack, filePath, `blobs/${index}/${relativePath}`);
 				}
 			}
 		}
 	}
 }
 
-/** Add a single file to the pack, streaming exactly the byte count captured at open time. */
-async function appendBlobFile(pack: Pack, filePath: string, name: string): Promise<void> {
+/**
+ * Add one blob to the pack, applying the same capture rule as the managed snapshot
+ * (`classifyBlobFileForCapture`): a blob still being written would otherwise be archived truncated,
+ * so it is packed as a PENDING marker, which also keeps its file id reserved on extraction.
+ */
+async function appendBlobEntry(pack: Pack, filePath: string, name: string): Promise<void> {
+	let disposition: BlobCaptureDisposition;
+	try {
+		disposition = await classifyBlobFileForCapture(filePath);
+	} catch (error) {
+		if (isSystemicIoError(error)) throw error;
+		// As on the snapshot path: a read failure is not evidence the bytes are bad, so fall back to the
+		// pre-classification behavior rather than downgrading a valid blob to a stub.
+		logger.warn(`Could not verify blob ${filePath} for the backup archive; packing it unverified`, error);
+		disposition = 'capture';
+	}
+	if (disposition === 'skip') return;
+	// A capture can lose the race with a delete between classify and open; those bytes are gone, so it
+	// falls through to a terminal marker rather than dropping the entry and freeing the id.
+	if (disposition === 'capture') {
+		if (await appendBlobFile(pack, filePath, name)) return;
+		disposition = 'gone';
+	}
+	const marker = createCaptureMarker(
+		disposition,
+		disposition === 'gone'
+			? 'blob was deleted while this archive was being built'
+			: 'blob was not yet complete when this archive was built'
+	);
+	await new Promise<void>((resolvePromise, reject) => {
+		const entry = pack.entry({ name, size: marker.length }, (error) => (error ? reject(error) : resolvePromise()));
+		entry.end(marker);
+	});
+}
+
+/**
+ * Add a single file to the pack, streaming exactly the byte count captured at open time. Returns false
+ * if it vanished first, so the caller can still reserve its id.
+ */
+async function appendBlobFile(pack: Pack, filePath: string, name: string): Promise<boolean> {
 	let handle;
 	try {
 		handle = await open(filePath, 'r');
 	} catch (error: any) {
-		if (error.code === 'ENOENT') return; // deleted mid-walk
+		if (error.code === 'ENOENT') return false;
 		throw error;
 	}
 	try {
@@ -866,6 +910,7 @@ async function appendBlobFile(pack: Pack, filePath: string, name: string): Promi
 	} finally {
 		await handle.close();
 	}
+	return true;
 }
 
 /** Add an in-memory string to the pack as a single tar entry (used for the generated READMEs). */

--- a/dataLayer/rocksdbBackup.ts
+++ b/dataLayer/rocksdbBackup.ts
@@ -683,8 +683,8 @@ function isRocksDbLockError(error: any): boolean {
  *
  * With blobs included (the default; `excludeBlobs` opts out), the database's file-backed blob roots
  * are appended to the same archive under `blobs/<rootIndex>/<relpath>` so a downloaded backup is a
- * complete Harper database. Blob capture is best-effort point-in-time (the archive contains whatever
- * files exist while it streams); a blob deleted mid-stream is skipped.
+ * complete Harper database. Each enumerated blob is classified before capture; one that is incomplete
+ * or vanishes before it can be opened is represented by a PENDING or ERROR marker at the same path.
  */
 export function createBackupStream(
 	rootStore: RocksDatabase,
@@ -814,8 +814,8 @@ function writeWithBackpressure(dest: PassThrough, chunk: Buffer): Promise<void> 
 
 /**
  * Append every blob file under the given blob roots to `pack` as `blobs/<rootIndex>/<relpath>`
- * entries. Size is captured at open time and exactly that many bytes are streamed; a file that
- * vanished before it could be opened (a concurrent blob delete) is skipped.
+ * entries. Complete files are streamed at the size captured on open; files that cannot be captured
+ * whole are represented by markers, and repair temporaries are omitted.
  */
 async function appendBlobEntries(pack: Pack, blobRoots: string[]): Promise<void> {
 	for (let index = 0; index < blobRoots.length; index++) {

--- a/dataLayer/rocksdbBackup.ts
+++ b/dataLayer/rocksdbBackup.ts
@@ -863,8 +863,6 @@ async function appendBlobEntry(pack: Pack, filePath: string, name: string): Prom
 		disposition = 'capture';
 	}
 	if (disposition === 'skip') return;
-	// A capture can lose the race with a delete between classify and open; those bytes are gone, so it
-	// falls through to a terminal marker rather than dropping the entry and freeing the id.
 	if (disposition === 'capture') {
 		if (await appendBlobFile(pack, filePath, name)) return;
 		disposition = 'gone';

--- a/dataLayer/rocksdbBackup.ts
+++ b/dataLayer/rocksdbBackup.ts
@@ -856,7 +856,7 @@ async function appendBlobEntry(pack: Pack, filePath: string, name: string): Prom
 	try {
 		disposition = await classifyBlobFileForCapture(filePath);
 	} catch (error) {
-		if (isSystemicIoError(error)) throw error;
+		if (isSystemicIoError(error)) throw error; // unverified, as on the snapshot path
 		// As on the snapshot path: a read failure is not evidence the bytes are bad, so fall back to the
 		// pre-classification behavior rather than downgrading a valid blob to a stub.
 		logger.warn(`Could not verify blob ${filePath} for the backup archive; packing it unverified`, error);

--- a/integrationTests/apiTests/describe-metadata-upgrade.test.ts
+++ b/integrationTests/apiTests/describe-metadata-upgrade.test.ts
@@ -7,7 +7,7 @@
  */
 import { suite, test, before, after } from 'node:test';
 import { ok, strictEqual } from 'node:assert';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -40,7 +40,8 @@ graphqlSchema:
   files: '*.graphql'
 `;
 
-const PINNED_DATA_DIR = mkdtempSync(join(tmpdir(), 'describe-metadata-upgrade-'));
+// Node 24's libuv asserts when a recursive watcher is rooted at Windows' 8.3 %TEMP% path.
+const PINNED_DATA_DIR = realpathSync.native(mkdtempSync(join(tmpdir(), 'describe-metadata-upgrade-')));
 
 async function describeAll(client: ReturnType<typeof createApiClient>) {
 	const res = await client.req().send({ operation: 'describe_all' });

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -2853,7 +2853,10 @@ function inflatesToExactly(filePath: string, size: number): Promise<boolean> {
 		// A zlib error is the answer (body truncated or corrupt); an I/O error is a failure to answer and
 		// must propagate, or a systemic fault would classify a corpus of complete blobs as incomplete.
 		const fail = (error: NodeJS.ErrnoException) => {
+			// Both: pipe() does not tear down the destination when the source errors, so the inflate's
+			// native zlib handle would sit allocated until GC — once per blob, on every backup walk.
 			source.destroy();
+			inflate.destroy();
 			if (error?.code?.startsWith('Z_')) resolve(false);
 			else reject(error);
 		};

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -1833,8 +1833,11 @@ export function isSystemicIoError(error: unknown): boolean {
 
 /**
  * How a consumer that captures a blob root (backup snapshot, backup archive) should treat one file.
- * `skip` is not a blob to capture at all; `capture` is safe to take as-is — its bytes will not change,
- * because no path rewrites a published blob file in place; `pending` and `gone` require markers.
+ * `skip` is not a blob to capture at all; `pending` and `gone` require markers; `capture` is taken as-is.
+ * `capture` means settled as far as the path can show, which is short of a guarantee: a known-size write
+ * that has landed every byte is indistinguishable here from a finished one, and if it then aborts, the
+ * PENDING stamp rewrites that inode in place, truncating any same-filesystem hard link taken from it.
+ * Telling the two apart needs the blob write lock, which is keyed by file id and unreachable from a walk.
  */
 export async function classifyBlobFileForCapture(filePath: string): Promise<BlobCaptureDisposition> {
 	if (filePath.endsWith(BLOB_REPAIR_SUFFIX)) return 'skip';

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -76,7 +76,7 @@ type StorageInfo = {
 };
 const FILE_STORAGE_THRESHOLD = 8192; // if the file is below this size, we will store it in memory, or within the record itself, otherwise we will store it in a file
 // We want to keep the file path private (but accessible to the extension)
-export const HEADER_SIZE = 8;
+const HEADER_SIZE = 8;
 const UNCOMPRESSED_TYPE = 0;
 const DEFLATE_TYPE = 1;
 const ERROR_TYPE = 0xff;
@@ -88,7 +88,7 @@ const ERROR_TYPE = 0xff;
 // `.repair` temp + rename. Distinct from ERROR_TYPE (a permanent corrupt/error stub, replicated as-is).
 // See harper-pro#481.
 const PENDING_TYPE = 0xfe;
-export const BLOB_REPAIR_SUFFIX = '.repair';
+const BLOB_REPAIR_SUFFIX = '.repair';
 const DEFAULT_HEADER = new Uint8Array([0, UNCOMPRESSED_TYPE, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
 const COMPRESS_HEADER = new Uint8Array([0, DEFLATE_TYPE, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
 const UNKNOWN_SIZE = 0xffffffffffff;
@@ -1834,9 +1834,7 @@ export function isSystemicIoError(error: unknown): boolean {
 /**
  * How a consumer that captures a blob root (backup snapshot, backup archive) should treat one file.
  * `skip` is not a blob to capture at all; `capture` is safe to take as-is — its bytes will not change,
- * because no path rewrites a published blob file in place; `substitute` must be replaced by a PENDING
- * marker, which keeps the file id reserved (`getNextFileId` recovers the counter by scanning the
- * directory) and keeps the record repairable rather than reading as absent.
+ * because no path rewrites a published blob file in place; `pending` and `gone` require markers.
  */
 export async function classifyBlobFileForCapture(filePath: string): Promise<BlobCaptureDisposition> {
 	if (filePath.endsWith(BLOB_REPAIR_SUFFIX)) return 'skip';
@@ -1846,9 +1844,9 @@ export async function classifyBlobFileForCapture(filePath: string): Promise<Blob
 	try {
 		handle = await openFile(filePath, 'r');
 	} catch (error) {
-		// Deleted between the directory read and here. The checkpointed record may still reference it, so
-		// the id must stay reserved — but these bytes are gone for good, so it is captured terminal
-		// rather than retryable: a PENDING marker would promise a retry that can never succeed.
+		// Reclamation can unlink a superseded blob after the engine checkpoint but before this walk. The
+		// checkpointed record may still reference it, so reserve the id. Treat local absence as terminal
+		// rather than making every read wait for repair; this gives up peer repair of that checkpointed version.
 		if ((error as { code?: string }).code === 'ENOENT') return 'gone';
 		throw error;
 	}
@@ -1879,7 +1877,7 @@ export async function classifyBlobFileForCapture(filePath: string): Promise<Blob
  * rewritten, so a consumer sharing blob inodes can keep them: dropping a PENDING marker downgrades a
  * retryable 503 to a 404 the replication layer reads as "cleanly gone" (harper-pro#481).
  */
-export function blobHeaderIsAbortMarker(header: Buffer): boolean {
+function blobHeaderIsAbortMarker(header: Buffer): boolean {
 	if (header.length < HEADER_SIZE) return false;
 	const type = header.readUInt16BE(0);
 	return type === PENDING_TYPE || type === ERROR_TYPE;

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -1824,7 +1824,7 @@ export function repairBlobFile(
 	}
 }
 
-/** Host-level failures, not file-level: they will hit every entry, so a consumer must fail the capture. */
+/** Fail-closed storage and descriptor errors that must abort the capture instead of producing an unverified backup. */
 const SYSTEMIC_IO_ERRORS = new Set(['EMFILE', 'ENFILE', 'ENOSPC', 'EIO', 'EROFS']);
 
 export function isSystemicIoError(error: unknown): boolean {
@@ -1860,11 +1860,10 @@ export async function classifyBlobFileForCapture(filePath: string): Promise<Blob
 	}
 	if (blobHeaderIsAbortMarker(header)) return 'capture';
 	if (blobHeaderIndicatesIncomplete(header, fileSize)) return 'pending';
-	// A deflate header records the *uncompressed* length and is final from the first byte, so a growing
-	// compressed body is invisible to the size check above and has to be read. There is no sound cheap
-	// proxy: an mtime window would exempt a stalled write, which the byte-copying capture paths would
-	// then truncate. Compression is opt-in per createBlob and unused inside Harper, so this reads
-	// nothing on an ordinary corpus.
+	// Once stamped, a deflate header records the *uncompressed* length, so a torn compressed body left
+	// by an unclean shutdown can pass the size check above. Verify the stream rather than assuming the
+	// repair sweep has already run. Compression is opt-in per createBlob and unused inside Harper, so
+	// this reads nothing on an ordinary corpus.
 	if (header[1] !== DEFLATE_TYPE) return 'capture';
 	const uncompressedSize = Number(
 		new DataView(header.buffer, header.byteOffset, HEADER_SIZE).getBigUint64(0) & 0xffffffffffffn
@@ -1885,9 +1884,9 @@ function blobHeaderIsAbortMarker(header: Buffer): boolean {
 
 /**
  * What a consumer capturing a blob root should do with one file. `pending` is a blob that was not
- * whole *yet* (retryable 503); `gone` is one whose bytes are unrecoverable (terminal 500). Both still
- * put a file at the id, because `getNextFileId` recovers the counter by scanning the directory and an
- * absent file lets a restored record's id be reissued.
+ * whole *yet* (retryable 503); `gone` is absent from this capture and represented as terminal 500.
+ * Both still put a file at the id, because `getNextFileId` recovers the counter by scanning the
+ * directory and an absent file lets a restored record's id be reissued.
  */
 export type BlobCaptureDisposition = 'skip' | 'capture' | 'pending' | 'gone';
 

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -12,7 +12,16 @@
  */
 
 import { addExtension, pack, Packr } from 'msgpackr';
-import { readFile, rename, statfs, readdir, rmdir, unlink as unlinkPromised } from 'node:fs/promises';
+import {
+	readFile,
+	rename,
+	statfs,
+	readdir,
+	rmdir,
+	open as openFile,
+	type FileHandle,
+	unlink as unlinkPromised,
+} from 'node:fs/promises';
 import {
 	close,
 	closeSync,
@@ -67,17 +76,19 @@ type StorageInfo = {
 };
 const FILE_STORAGE_THRESHOLD = 8192; // if the file is below this size, we will store it in memory, or within the record itself, otherwise we will store it in a file
 // We want to keep the file path private (but accessible to the extension)
-const HEADER_SIZE = 8;
+export const HEADER_SIZE = 8;
 const UNCOMPRESSED_TYPE = 0;
 const DEFLATE_TYPE = 1;
 const ERROR_TYPE = 0xff;
 // A write that aborted on a re-streamable external source (replication receive / origin fetch) stamps the
 // file with this type so a downstream read returns 503 (retry) rather than 500 (confidently incomplete).
-// The bytes are still expected — the receive side holds a blob gap and re-streams on reconnect, which
-// overwrites this stub; a terminal give-up unlinks the file (→ 404). Distinct from ERROR_TYPE (a permanent
-// corrupt/error stub, replicated as-is). See harper-pro#481.
+// The re-stream builds a fresh blob and takes a NEW file id (harper-pro's `createBlob` → `saveBlob`), so
+// this stub is orphaned rather than overwritten; a terminal give-up unlinks it (→ 404). No path rewrites
+// a published blob file in place: `repairBlobFile` is the only same-id writer and it publishes via a
+// `.repair` temp + rename. Distinct from ERROR_TYPE (a permanent corrupt/error stub, replicated as-is).
+// See harper-pro#481.
 const PENDING_TYPE = 0xfe;
-const BLOB_REPAIR_SUFFIX = '.repair';
+export const BLOB_REPAIR_SUFFIX = '.repair';
 const DEFAULT_HEADER = new Uint8Array([0, UNCOMPRESSED_TYPE, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
 const COMPRESS_HEADER = new Uint8Array([0, DEFLATE_TYPE, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
 const UNKNOWN_SIZE = 0xffffffffffff;
@@ -1528,8 +1539,8 @@ function writeBlobWithStream(
 					// half-replicated blob returns 503 (retry) instead of 500 (confidently incomplete → the peer
 					// advances its resume cursor past it = silent loss, harper-pro#481). Hold the write lock until the
 					// marker is durable so no concurrent read/send observes the bare partial file (lock-free + short =
-					// classified 500 = the very loss this prevents). The re-stream overwrites this stub
-					// (createWriteStream flags 'w'); a terminal give-up on the receive side unlinks it (→ 404). Build
+					// classified 500 = the very loss this prevents). The re-stream builds a fresh blob and so takes a
+					// new file id, leaving this stub for orphan GC; a terminal give-up unlinks it (→ 404). Build
 					// the header directly rather than via createHeader so its compress-type OR can't collide with the
 					// PENDING type bits.
 					// Bounded so a `writeFile` that never calls back cannot leave `saving` un-settled for the
@@ -1811,6 +1822,86 @@ export function repairBlobFile(
 		logger.warn?.('Unable to start in-place blob repair', error);
 		return undefined;
 	}
+}
+
+/** Host-level failures, not file-level: they will hit every entry, so a consumer must fail the capture. */
+const SYSTEMIC_IO_ERRORS = new Set(['EMFILE', 'ENFILE', 'ENOSPC', 'EIO', 'EROFS']);
+
+export function isSystemicIoError(error: unknown): boolean {
+	return SYSTEMIC_IO_ERRORS.has((error as { code?: string })?.code ?? '');
+}
+
+/**
+ * How a consumer that captures a blob root (backup snapshot, backup archive) should treat one file.
+ * `skip` is not a blob to capture at all; `capture` is safe to take as-is — its bytes will not change,
+ * because no path rewrites a published blob file in place; `substitute` must be replaced by a PENDING
+ * marker, which keeps the file id reserved (`getNextFileId` recovers the counter by scanning the
+ * directory) and keeps the record repairable rather than reading as absent.
+ */
+export async function classifyBlobFileForCapture(filePath: string): Promise<BlobCaptureDisposition> {
+	if (filePath.endsWith(BLOB_REPAIR_SUFFIX)) return 'skip';
+	let header: Buffer;
+	let fileSize: number;
+	let handle: FileHandle;
+	try {
+		handle = await openFile(filePath, 'r');
+	} catch (error) {
+		// Deleted between the directory read and here. The checkpointed record may still reference it, so
+		// the id must stay reserved — but these bytes are gone for good, so it is captured terminal
+		// rather than retryable: a PENDING marker would promise a retry that can never succeed.
+		if ((error as { code?: string }).code === 'ENOENT') return 'gone';
+		throw error;
+	}
+	try {
+		fileSize = (await handle.stat()).size;
+		header = Buffer.alloc(HEADER_SIZE);
+		const { bytesRead } = await handle.read(header, 0, HEADER_SIZE, 0);
+		header = header.subarray(0, bytesRead);
+	} finally {
+		await handle.close();
+	}
+	if (blobHeaderIsAbortMarker(header)) return 'capture';
+	if (blobHeaderIndicatesIncomplete(header, fileSize)) return 'pending';
+	// A deflate header records the *uncompressed* length and is final from the first byte, so a growing
+	// compressed body is invisible to the size check above and has to be read. There is no sound cheap
+	// proxy: an mtime window would exempt a stalled write, which the byte-copying capture paths would
+	// then truncate. Compression is opt-in per createBlob and unused inside Harper, so this reads
+	// nothing on an ordinary corpus.
+	if (header[1] !== DEFLATE_TYPE) return 'capture';
+	const uncompressedSize = Number(
+		new DataView(header.buffer, header.byteOffset, HEADER_SIZE).getBigUint64(0) & 0xffffffffffffn
+	);
+	return (await inflatesToExactly(filePath, uncompressedSize)) ? 'capture' : 'pending';
+}
+
+/**
+ * Whether the header is a deliberate abort marker rather than content. Written once and never
+ * rewritten, so a consumer sharing blob inodes can keep them: dropping a PENDING marker downgrades a
+ * retryable 503 to a 404 the replication layer reads as "cleanly gone" (harper-pro#481).
+ */
+export function blobHeaderIsAbortMarker(header: Buffer): boolean {
+	if (header.length < HEADER_SIZE) return false;
+	const type = header.readUInt16BE(0);
+	return type === PENDING_TYPE || type === ERROR_TYPE;
+}
+
+/**
+ * What a consumer capturing a blob root should do with one file. `pending` is a blob that was not
+ * whole *yet* (retryable 503); `gone` is one whose bytes are unrecoverable (terminal 500). Both still
+ * put a file at the id, because `getNextFileId` recovers the counter by scanning the directory and an
+ * absent file lets a restored record's id be reissued.
+ */
+export type BlobCaptureDisposition = 'skip' | 'capture' | 'pending' | 'gone';
+
+/** The stand-in bytes for a blob that could not be captured whole. */
+export function createCaptureMarker(disposition: 'pending' | 'gone', message: string): Buffer {
+	const messageBuffer = Buffer.from(message);
+	const header = Buffer.alloc(HEADER_SIZE);
+	new DataView(header.buffer, header.byteOffset, HEADER_SIZE).setBigInt64(
+		0,
+		BigInt(messageBuffer.length) | (BigInt(disposition === 'gone' ? ERROR_TYPE : PENDING_TYPE) << 48n)
+	);
+	return Buffer.concat([header, messageBuffer]);
 }
 
 export function blobHeaderIndicatesIncomplete(header: Buffer, fileSize: number): boolean {
@@ -2713,10 +2804,12 @@ export async function cleanupOrphans(database: any, databaseName?: string) {
 }
 
 async function isBlobFileComplete(storageInfo: StorageInfo): Promise<boolean> {
-	let filePath: string;
+	return isBlobFileCompleteAtPath(getFilePath(storageInfo));
+}
+
+async function isBlobFileCompleteAtPath(filePath: string): Promise<boolean> {
 	let fileSize: number;
 	try {
-		filePath = getFilePath(storageInfo);
 		fileSize = statSync(filePath).size;
 	} catch (e) {
 		if ((e as any).code === 'ENOENT') return false;
@@ -2738,30 +2831,40 @@ async function isBlobFileComplete(storageInfo: StorageInfo): Promise<boolean> {
 	// for a compressed blob it does not, so the body length can't be compared to it directly.
 	const size = Number(headerValue & 0xffffffffffffn);
 	if (header[1] === DEFLATE_TYPE) {
-		// A compressed blob's header size is the uncompressed length, so it can't be compared to the
-		// compressed on-disk body. Verify by streaming the body through inflate and counting the
-		// decompressed bytes: a fully-written deflate stream inflates to exactly `size` bytes; a
-		// truncated one errors (Z_BUF_ERROR) or yields fewer. Streaming (rather than inflateSync on
-		// the whole buffer) keeps memory bounded during the repair sweep, which may touch many large
-		// blobs.
-		return new Promise<boolean>((resolve) => {
-			let inflatedLength = 0;
-			const source = createReadStream(filePath, { start: HEADER_SIZE });
-			const inflate = createInflate();
-			const fail = () => {
-				source.destroy();
-				resolve(false);
-			};
-			source.on('error', fail);
-			inflate.on('error', fail);
-			inflate.on('data', (chunk: Buffer) => {
-				inflatedLength += chunk.length;
-			});
-			inflate.on('end', () => resolve(inflatedLength === size));
-			source.pipe(inflate);
-		});
+		// This function's contract is to resolve true/false; harper-pro's repair sweep awaits it without a
+		// catch (replication/blobRepair.ts), so an I/O fault must not become a rejection here. The capture
+		// classifier calls inflatesToExactly directly, where the distinction does matter.
+		return inflatesToExactly(filePath, size).catch(() => false);
 	}
 	return true;
+}
+
+/**
+ * Whether the deflate body after the header inflates to exactly `size` bytes. A compressed blob's
+ * header records the uncompressed length, so it cannot be compared to the on-disk body; a truncated
+ * stream errors (Z_BUF_ERROR) or yields fewer bytes. Streamed rather than inflateSync so memory stays
+ * bounded over a sweep that may touch many large blobs.
+ */
+function inflatesToExactly(filePath: string, size: number): Promise<boolean> {
+	return new Promise<boolean>((resolve, reject) => {
+		let inflatedLength = 0;
+		const source = createReadStream(filePath, { start: HEADER_SIZE });
+		const inflate = createInflate();
+		// A zlib error is the answer (body truncated or corrupt); an I/O error is a failure to answer and
+		// must propagate, or a systemic fault would classify a corpus of complete blobs as incomplete.
+		const fail = (error: NodeJS.ErrnoException) => {
+			source.destroy();
+			if (error?.code?.startsWith('Z_')) resolve(false);
+			else reject(error);
+		};
+		source.on('error', fail);
+		inflate.on('error', fail);
+		inflate.on('data', (chunk: Buffer) => {
+			inflatedLength += chunk.length;
+		});
+		inflate.on('end', () => resolve(inflatedLength === size));
+		source.pipe(inflate);
+	});
 }
 
 /**

--- a/resources/blob.ts
+++ b/resources/blob.ts
@@ -1860,10 +1860,12 @@ export async function classifyBlobFileForCapture(filePath: string): Promise<Blob
 	}
 	if (blobHeaderIsAbortMarker(header)) return 'capture';
 	if (blobHeaderIndicatesIncomplete(header, fileSize)) return 'pending';
-	// Once stamped, a deflate header records the *uncompressed* length, so a torn compressed body left
-	// by an unclean shutdown can pass the size check above. Verify the stream rather than assuming the
-	// repair sweep has already run. Compression is opt-in per createBlob and unused inside Harper, so
-	// this reads nothing on an ordinary corpus.
+	// A deflate header records the *uncompressed* length, so the check above compares lengths only for
+	// UNCOMPRESSED_TYPE and a short compressed body reaches here looking whole. Both producers of one
+	// need this: saveBlob stamps a known size before the first compressed byte, so a live write is
+	// invisible above and caught only here, and an unclean shutdown can leave a torn body the
+	// asynchronous repair sweep has not reached yet. Compression is opt-in per createBlob and unused
+	// inside Harper, so this reads nothing on an ordinary corpus.
 	if (header[1] !== DEFLATE_TYPE) return 'capture';
 	const uncompressedSize = Number(
 		new DataView(header.buffer, header.byteOffset, HEADER_SIZE).getBigUint64(0) & 0xffffffffffffn
@@ -2849,6 +2851,8 @@ function inflatesToExactly(filePath: string, size: number): Promise<boolean> {
 		const inflate = createInflate();
 		// A zlib error is the answer (body truncated or corrupt); an I/O error is a failure to answer and
 		// must propagate, or a systemic fault would classify a corpus of complete blobs as incomplete.
+		// The reject arm is unverified: it needs a read fault raised mid-inflate on a file that opened
+		// cleanly, which no test here can produce.
 		const fail = (error: NodeJS.ErrnoException) => {
 			// Both: pipe() does not tear down the destination when the source errors, so the inflate's
 			// native zlib handle would sit allocated until GC — once per blob, on every backup walk.

--- a/unitTests/dataLayer/blobBackup.test.js
+++ b/unitTests/dataLayer/blobBackup.test.js
@@ -12,12 +12,30 @@ const {
 	purgeBlobSnapshots,
 } = require('#src/dataLayer/blobBackup');
 
-// Lay out a blob root the way resources/blob.ts does: files nested a few directories deep by id.
+// Lay out a blob root the way resources/blob.ts does: files nested a few directories deep by id,
+// each an 8-byte header (type in the top 16 bits, body length in the low 48) followed by the body.
+function blobFile(contents) {
+	const body = Buffer.from(contents);
+	const header = Buffer.alloc(8);
+	header.writeUInt16BE(0, 0); // UNCOMPRESSED
+	header.writeUIntBE(body.length, 2, 6);
+	return Buffer.concat([header, body]);
+}
+
 function writeBlob(root, relPath, contents) {
+	return writeRawBlob(root, relPath, blobFile(contents));
+}
+
+// A file placed in a blob root verbatim — used for the shapes a snapshot must refuse.
+function writeRawBlob(root, relPath, bytes) {
 	const full = join(root, relPath);
 	mkdirSync(join(full, '..'), { recursive: true });
-	writeFileSync(full, contents);
+	writeFileSync(full, bytes);
 	return full;
+}
+
+function blobBody(path) {
+	return readFileSync(path).subarray(8).toString('utf8');
 }
 
 describe('blobBackup', function () {
@@ -46,9 +64,116 @@ describe('blobBackup', function () {
 			await snapshotBlobs(backupDir, 1, [rootA, rootB]);
 
 			const snap = blobSnapshotDir(backupDir, 1);
-			assert.strictEqual(readFileSync(join(snap, '0', '001/002/003'), 'utf8'), 'alpha');
-			assert.strictEqual(readFileSync(join(snap, '0', '001/002/004'), 'utf8'), 'beta');
-			assert.strictEqual(readFileSync(join(snap, '1', '005/006/007'), 'utf8'), 'gamma');
+			assert.strictEqual(blobBody(join(snap, '0', '001/002/003')), 'alpha');
+			assert.strictEqual(blobBody(join(snap, '0', '001/002/004')), 'beta');
+			assert.strictEqual(blobBody(join(snap, '1', '005/006/007')), 'gamma');
+		});
+
+		it('substitutes a PENDING marker for a blob still being written, keeping its file id reserved', async function () {
+			writeBlob(rootA, '001/002/003', 'complete');
+			// What a write in progress looks like on disk: the real header is only stamped when the
+			// stream ends, so until then the file carries the unknown-size placeholder and a short body.
+			const placeholder = Buffer.alloc(8);
+			placeholder.writeUInt16BE(0, 0);
+			placeholder.writeUIntBE(0xffffffffffff, 2, 6);
+			const inFlight = writeRawBlob(rootA, '001/002/004', Buffer.concat([placeholder, Buffer.from('partial')]));
+
+			await snapshotBlobs(backupDir, 1, [rootA]);
+
+			const snap = blobSnapshotDir(backupDir, 1);
+			const captured = join(snap, '0', '001/002/004');
+			assert.strictEqual(blobBody(join(snap, '0', '001/002/003')), 'complete');
+			assert.ok(existsSync(captured), 'the file id must stay reserved so it cannot be reissued after a restore');
+			assert.notStrictEqual(
+				statSync(captured).ino,
+				statSync(inFlight).ino,
+				'a blob still being written must not share its inode with the snapshot'
+			);
+			assert.strictEqual(readFileSync(captured).readUInt16BE(0), 0xfe, 'expected a PENDING marker (retryable)');
+			assert.ok(existsSync(inFlight), 'the live in-flight blob itself must be left alone');
+		});
+
+		it('preserves an existing PENDING marker rather than downgrading it to an absent blob', async function () {
+			const marker = Buffer.alloc(8);
+			marker.writeUInt16BE(0xfe, 0);
+			marker.writeUIntBE(4, 2, 6);
+			const src = writeRawBlob(rootA, '001/002/003', Buffer.concat([marker, Buffer.from('gone')]));
+
+			await snapshotBlobs(backupDir, 1, [rootA]);
+
+			const captured = join(blobSnapshotDir(backupDir, 1), '0', '001/002/003');
+			assert.ok(existsSync(captured));
+			assert.strictEqual(statSync(captured).ino, statSync(src).ino, 'a stable marker should be hard-linked as-is');
+		});
+
+		it('substitutes a marker for a truncated blob whose body is shorter than its header claims', async function () {
+			const header = Buffer.alloc(8);
+			header.writeUInt16BE(0, 0);
+			header.writeUIntBE(500, 2, 6); // claims 500 bytes, only 4 present
+			writeRawBlob(rootA, '001/002/003', Buffer.concat([header, Buffer.from('shrt')]));
+
+			await snapshotBlobs(backupDir, 1, [rootA]);
+
+			const captured = join(blobSnapshotDir(backupDir, 1), '0', '001/002/003');
+			assert.strictEqual(readFileSync(captured).readUInt16BE(0), 0xfe);
+		});
+
+		it('captures a complete compressed blob rather than substituting for it', async function () {
+			// A deflate body cannot be checked by length (its header records the *uncompressed* size), so
+			// this is the branch that reads the body to decide.
+			const { deflateSync } = require('node:zlib');
+			const payload = Buffer.from('compressible '.repeat(64));
+			const body = deflateSync(payload);
+			const header = Buffer.alloc(8);
+			header.writeUInt16BE(1, 0); // DEFLATE
+			header.writeUIntBE(payload.length, 2, 6);
+			const src = writeRawBlob(rootA, '001/002/003', Buffer.concat([header, body]));
+
+			await snapshotBlobs(backupDir, 1, [rootA]);
+
+			const captured = join(blobSnapshotDir(backupDir, 1), '0', '001/002/003');
+			assert.strictEqual(statSync(captured).ino, statSync(src).ino, 'a whole compressed blob should link');
+		});
+
+		it('substitutes for a compressed blob whose body is truncated', async function () {
+			const { deflateSync } = require('node:zlib');
+			const payload = Buffer.from('compressible '.repeat(64));
+			const body = deflateSync(payload);
+			const header = Buffer.alloc(8);
+			header.writeUInt16BE(1, 0);
+			header.writeUIntBE(payload.length, 2, 6);
+			writeRawBlob(rootA, '001/002/003', Buffer.concat([header, body.subarray(0, body.length - 8)]));
+
+			await snapshotBlobs(backupDir, 1, [rootA]);
+
+			const captured = join(blobSnapshotDir(backupDir, 1), '0', '001/002/003');
+			assert.strictEqual(readFileSync(captured).readUInt16BE(0), 0xfe);
+		});
+
+		it('restores a substituted marker so the record reads as retryable rather than absent', async function () {
+			const placeholder = Buffer.alloc(8);
+			placeholder.writeUInt16BE(0, 0);
+			placeholder.writeUIntBE(0xffffffffffff, 2, 6);
+			writeRawBlob(rootA, '001/002/003', Buffer.concat([placeholder, Buffer.from('partial')]));
+
+			await snapshotBlobs(backupDir, 1, [rootA]);
+			rmSync(rootA, { recursive: true, force: true });
+			await restoreBlobSnapshot(backupDir, 1, 'test', [rootA]);
+
+			const restored = join(rootA, '001/002/003');
+			assert.ok(existsSync(restored), 'the id must come back so it cannot be reissued');
+			assert.strictEqual(readFileSync(restored).readUInt16BE(0), 0xfe, 'restored as PENDING (retryable), not absent');
+		});
+
+		it('skips .repair temporaries rather than linking them into the snapshot', async function () {
+			writeBlob(rootA, '001/002/003', 'complete');
+			writeBlob(rootA, '001/002/003.repair', 'half-repaired');
+
+			await snapshotBlobs(backupDir, 1, [rootA]);
+
+			const snap = blobSnapshotDir(backupDir, 1);
+			assert.strictEqual(blobBody(join(snap, '0', '001/002/003')), 'complete');
+			assert.strictEqual(existsSync(join(snap, '0', '001/002/003.repair')), false);
 		});
 
 		it('hard-links files when possible (same inode, no extra space) on the same filesystem', async function () {
@@ -97,7 +222,7 @@ describe('blobBackup', function () {
 			await restoreBlobSnapshot(backupDir, 1, 'testdb', [rootA]);
 
 			assert.strictEqual(
-				readFileSync(join(rootA, '001/002/003'), 'utf8'),
+				blobBody(join(rootA, '001/002/003')),
 				'original',
 				'a blob deleted after the backup must be restored'
 			);
@@ -113,8 +238,8 @@ describe('blobBackup', function () {
 
 			await restoreBlobSnapshot(backupDir, 1, 'testdb', [rootA, rootB]);
 
-			assert.strictEqual(readFileSync(join(rootA, 'a/a/a'), 'utf8'), 'from-a');
-			assert.strictEqual(readFileSync(join(rootB, 'b/b/b'), 'utf8'), 'from-b');
+			assert.strictEqual(blobBody(join(rootA, 'a/a/a')), 'from-a');
+			assert.strictEqual(blobBody(join(rootB, 'b/b/b')), 'from-b');
 		});
 
 		it('rejects (without purging) a backup with more blob roots than the current config', async function () {
@@ -130,7 +255,7 @@ describe('blobBackup', function () {
 			);
 			// the single root must not have been purged before the rejection
 			assert.strictEqual(
-				readFileSync(join(rootA, 'existing/1/2'), 'utf8'),
+				blobBody(join(rootA, 'existing/1/2')),
 				'preexisting',
 				'a rejected restore must not purge the blob root'
 			);
@@ -140,7 +265,7 @@ describe('blobBackup', function () {
 			writeBlob(rootA, '001/002/003', 'live');
 			// no snapshotBlobs call for backup 2
 			await restoreBlobSnapshot(backupDir, 2, 'testdb', [rootA]);
-			assert.strictEqual(readFileSync(join(rootA, '001/002/003'), 'utf8'), 'live', 'existing blobs must be preserved');
+			assert.strictEqual(blobBody(join(rootA, '001/002/003')), 'live', 'existing blobs must be preserved');
 		});
 	});
 

--- a/unitTests/dataLayer/blobBackup.test.js
+++ b/unitTests/dataLayer/blobBackup.test.js
@@ -11,6 +11,7 @@ const {
 	deleteBlobSnapshot,
 	purgeBlobSnapshots,
 } = require('#src/dataLayer/blobBackup');
+const { classifyBlobFileForCapture, isSystemicIoError } = require('#src/resources/blob');
 
 // Lay out a blob root the way resources/blob.ts does: files nested a few directories deep by id,
 // each an 8-byte header (type in the top 16 bits, body length in the low 48) followed by the body.
@@ -205,6 +206,21 @@ describe('blobBackup', function () {
 			assert.match(readme, /storage\.blobPaths/);
 			assert.ok(readme.includes(`0 -> ${rootA}`), 'root index 0 must map to the first root');
 			assert.ok(readme.includes(`1 -> ${rootB}`), 'root index 1 must map to the second root');
+			assert.match(readme, /0xfe.*PENDING/);
+			assert.match(readme, /0xff.*ERROR/);
+		});
+	});
+
+	describe('blob capture classification', function () {
+		it('classifies a blob reclaimed before it can be opened as gone', async function () {
+			assert.strictEqual(await classifyBlobFileForCapture(join(rootA, '001/002/003')), 'gone');
+		});
+
+		it('recognizes only host-level I/O errors as systemic', function () {
+			for (const code of ['EMFILE', 'ENFILE', 'ENOSPC', 'EIO', 'EROFS']) {
+				assert.strictEqual(isSystemicIoError(Object.assign(new Error(code), { code })), true);
+			}
+			assert.strictEqual(isSystemicIoError(Object.assign(new Error('permission denied'), { code: 'EACCES' })), false);
 		});
 	});
 

--- a/unitTests/dataLayer/rocksdbBackup.test.js
+++ b/unitTests/dataLayer/rocksdbBackup.test.js
@@ -65,13 +65,24 @@ describe('rocksdbBackup', function () {
 		rmSync(backupDirForDatabase(DB_NAME), { recursive: true, force: true });
 	});
 
-	// Write a blob file into a database's (first) blob root at the given fileId-style relative path.
+	// Write a blob file into a database's (first) blob root at the given fileId-style relative path,
+	// shaped the way resources/blob.ts writes one: an 8-byte header (type in the top 16 bits, body
+	// length in the low 48) then the body. A snapshot only captures complete blobs, so a headerless
+	// fixture would be skipped.
 	function writeBlobFile(dbName, relPath, contents) {
 		const root = getBlobPathsForDatabaseName(dbName)[0];
 		const full = join(root, relPath);
 		mkdirSync(dirname(full), { recursive: true });
-		writeFileSync(full, contents);
+		const body = Buffer.from(contents);
+		const header = Buffer.alloc(8);
+		header.writeUInt16BE(0, 0); // UNCOMPRESSED
+		header.writeUIntBE(body.length, 2, 6);
+		writeFileSync(full, Buffer.concat([header, body]));
 		return full;
+	}
+
+	function readBlobBody(path) {
+		return readFileSync(path).subarray(8).toString('utf8');
 	}
 
 	function writeRecords(records) {
@@ -380,7 +391,7 @@ describe('rocksdbBackup', function () {
 			assert.strictEqual(created.blobs, true, 'blobs should be captured by default');
 			const backupDir = backupDirForDatabase(BLOB_DB);
 			const snapshotFile = join(blobSnapshotDir(backupDir, created.backup_id), '0', BLOB_REL);
-			assert.strictEqual(readFileSync(snapshotFile, 'utf8'), 'blob-payload', 'blob must be in the snapshot');
+			assert.strictEqual(readBlobBody(snapshotFile), 'blob-payload', 'blob must be in the snapshot');
 
 			// a backup writes restore instructions and a blob-layout doc into the repository
 			const backupReadme = readFileSync(join(backupDir, 'README.md'), 'utf8');
@@ -391,7 +402,7 @@ describe('rocksdbBackup', function () {
 			rmSync(join(getBlobPathsForDatabaseName(BLOB_DB)[0], BLOB_REL));
 			await restoreBackupOffline(BLOB_DB, created.backup_id);
 			assert.strictEqual(
-				readFileSync(join(getBlobPathsForDatabaseName(BLOB_DB)[0], BLOB_REL), 'utf8'),
+				readBlobBody(join(getBlobPathsForDatabaseName(BLOB_DB)[0], BLOB_REL)),
 				'blob-payload',
 				'a blob deleted after the backup must be restored'
 			);
@@ -515,6 +526,49 @@ describe('rocksdbBackup', function () {
 			return names;
 		}
 
+		it('packs a PENDING marker for an incomplete blob, keeping the tar valid', async function () {
+			this.timeout(30000);
+			const MARKER_DB = `${DB_NAME}-blob-marker`;
+			const markerDbDir = join(storageDir, MARKER_DB);
+			const database = RocksDatabase.open(markerDbDir);
+			try {
+				database.putSync('rec', { blob: 'x' });
+			} finally {
+				database.close();
+			}
+			const wholeRel = join('111', '222', '333');
+			const partialRel = join('111', '222', '334');
+			writeBlobFile(MARKER_DB, wholeRel, 'whole-blob');
+			// A write still in flight: the header claims more than the body holds.
+			const partialHeader = Buffer.alloc(8);
+			partialHeader.writeUInt16BE(0, 0);
+			partialHeader.writeUIntBE(9999, 2, 6);
+			const partialFull = join(getBlobPathsForDatabaseName(MARKER_DB)[0], partialRel);
+			mkdirSync(dirname(partialFull), { recursive: true });
+			writeFileSync(partialFull, Buffer.concat([partialHeader, Buffer.from('partial')]));
+
+			const store = RocksDatabase.open(markerDbDir);
+			try {
+				const entries = await extractTarNames(createBackupStream(store, MARKER_DB, false, false));
+				const toPosix = (rel) => rel.split(require('node:path').sep).join('/');
+				const partialEntry = `blobs/0/${toPosix(partialRel)}`;
+				assert.strictEqual(
+					entries
+						.get(`blobs/0/${toPosix(wholeRel)}`)
+						.subarray(8)
+						.toString('utf8'),
+					'whole-blob'
+				);
+				assert.ok(entries.has(partialEntry), 'the incomplete blob id must still be present in the archive');
+				const marker = entries.get(partialEntry);
+				assert.strictEqual(marker.readUInt16BE(0), 0xfe, 'expected a PENDING marker');
+				// a wrong pack.entry size corrupts the whole tar, so the declared size must match the body
+				assert.strictEqual(marker.length, 8 + marker.readUIntBE(2, 6));
+			} finally {
+				store.close();
+			}
+		});
+
 		it('includes blob files alongside the database files in a valid tar', async function () {
 			this.timeout(30000);
 			const STREAM_DB = `${DB_NAME}-blobs`;
@@ -539,7 +593,7 @@ describe('rocksdbBackup', function () {
 				);
 				const blobEntry = `blobs/0/${blobRel.split(require('node:path').sep).join('/')}`;
 				assert.ok(entries.has(blobEntry), `expected blob entry ${blobEntry}, got: ${[...entries.keys()].join(', ')}`);
-				assert.strictEqual(entries.get(blobEntry).toString('utf8'), 'streamed-blob');
+				assert.strictEqual(entries.get(blobEntry).subarray(8).toString('utf8'), 'streamed-blob');
 				// tar entry names are always POSIX-separated (no Windows backslashes leaking in)
 				for (const name of entries.keys()) {
 					assert.ok(!name.includes('\\'), `tar entry name must not contain a backslash: ${name}`);

--- a/unitTests/resources/blob.test.js
+++ b/unitTests/resources/blob.test.js
@@ -2102,3 +2102,115 @@ async function streamToBytes(stream) {
 	}
 	return Buffer.concat(chunks);
 }
+
+describe('backup of a blob root during a live write (harper#2262)', () => {
+	const { mkdtempSync, rmSync, writeFileSync, readFileSync: readFileNow, statSync: statNow } = require('node:fs');
+	const { tmpdir } = require('node:os');
+	const { join } = require('node:path');
+	const { snapshotBlobs, blobSnapshotDir } = require('#src/dataLayer/blobBackup');
+	const { getBlobPathsForDatabaseName, getFilePathForBlob: pathForBlob } = require('#src/resources/blob');
+
+	async function waitFor(probe, timeoutMs = 2000) {
+		const deadline = Date.now() + timeoutMs;
+		for (;;) {
+			const value = probe();
+			if (value !== undefined && value !== false) return value;
+			if (Date.now() >= deadline) return undefined;
+			await new Promise((resolve) => setImmediate(resolve));
+		}
+	}
+
+	let SnapshotTest;
+	let backupDir;
+	before(async () => {
+		setupTestDBPath();
+		setMainIsWorker(true);
+		SnapshotTest = table({
+			table: 'SnapshotTest',
+			database: 'test',
+			attributes: [
+				{ name: 'id', isPrimaryKey: true },
+				{ name: 'blob', type: 'Blob' },
+			],
+		});
+	});
+	beforeEach(() => {
+		backupDir = mkdtempSync(join(tmpdir(), 'harper.unit-test.live-snapshot-'));
+	});
+	afterEach(() => {
+		rmSync(backupDir, { recursive: true, force: true });
+	});
+
+	it('a restored substituted marker reads as retryable, not as absent or corrupt', async () => {
+		// The whole design rests on this: a blob captured as a marker must reach a reader as a 503 it
+		// will retry (and blob repair will heal), never a 404 that a replication peer reads as
+		// "cleanly gone" or a 500 it treats as confidently incomplete.
+		const { createCaptureMarker: mintMarker } = require('#src/resources/blob');
+		await SnapshotTest.put({ id: 'restored', blob: await createBlob(randomBytes(20000)) });
+		const record = await SnapshotTest.get('restored');
+		const filePath = pathForBlob(record.blob);
+
+		writeFileSync(filePath, mintMarker('pending', 'blob was not yet complete when this backup was taken'));
+
+		const reread = await SnapshotTest.get('restored');
+		let status;
+		try {
+			await reread.blob.bytes();
+			assert.fail('reading a PENDING marker should not resolve');
+		} catch (error) {
+			status = error.statusCode ?? error.status;
+		}
+		assert.strictEqual(status, 503, 'a restored marker must classify as retryable');
+	});
+
+	it('a blob that vanished mid-backup is captured terminal, not as a retry that can never succeed', async () => {
+		const { createCaptureMarker: mintMarker } = require('#src/resources/blob');
+		await SnapshotTest.put({ id: 'vanished', blob: await createBlob(randomBytes(20000)) });
+		const filePath = pathForBlob((await SnapshotTest.get('vanished')).blob);
+
+		writeFileSync(filePath, mintMarker('gone', 'blob was deleted while this backup was being taken'));
+
+		let status;
+		try {
+			await (await SnapshotTest.get('vanished')).blob.bytes();
+			assert.fail('reading a terminal marker should not resolve');
+		} catch (error) {
+			status = error.statusCode ?? error.status;
+		}
+		assert.strictEqual(status, 500, 'gone-for-good bytes must read terminal, not retryable');
+	});
+
+	it('never hard-links a blob that a real write is still streaming into', async () => {
+		await SnapshotTest.put({ id: 'settled', blob: await createBlob(randomBytes(4096)) });
+
+		const source = new PassThrough();
+		const growing = createBlob(source, { size: 60000 });
+		const put = SnapshotTest.put({ id: 'streaming', blob: growing });
+		source.write(randomBytes(30000));
+		const livePath = await waitFor(() => {
+			const path = pathForBlob(growing);
+			return path && existsSync(path) && statNow(path).size > 0 ? path : undefined;
+		});
+		assert.ok(livePath, 'the in-flight blob should be on disk with a body before the snapshot runs');
+		const roots = getBlobPathsForDatabaseName(SnapshotTest.primaryStore.rootStore.databaseName);
+		await snapshotBlobs(backupDir, 1, roots);
+
+		const rootIndex = roots.findIndex((root) => livePath.startsWith(root));
+		const relative = livePath.slice(roots[rootIndex].length + 1);
+		const captured = join(blobSnapshotDir(backupDir, 1), String(rootIndex), relative);
+		assert.ok(existsSync(captured), 'the in-flight blob id must still be reserved in the snapshot');
+		assert.notStrictEqual(
+			statNow(captured).ino,
+			statNow(livePath).ino,
+			'the snapshot shared an inode with a blob that was still being written'
+		);
+		const capturedBytes = readFileNow(captured);
+		assert.strictEqual(capturedBytes.readUInt16BE(0), 0xfe, 'expected a PENDING marker');
+
+		source.end(randomBytes(30000));
+		await put;
+
+		assert.strictEqual(readFileNow(livePath).length, 60000 + 8);
+		assert.deepStrictEqual(readFileNow(captured), capturedBytes, 'snapshot bytes changed after the write finished');
+	});
+});


### PR DESCRIPTION
Blob backup snapshots and streamed archives now use [one capture classifier](https://github.com/HarperFast/harper/pull/2265/changes?w=1#diff-5c96de79cba36ba9ddb5124ce7b7e96a398a3c50fc6b7bec11dc5d690f61767aR1842): complete blobs and stable abort markers are captured, repair temporaries are omitted, and incomplete or vanished entries already returned by the walk become PENDING or ERROR markers instead of torn files. Follow-up review fixes narrow the guarantee to the enumeration boundary, document marker entries in the generated README, keep skip entries out of the warning denominator, remove unused exports, and add direct coverage for ENOENT and the fail-closed error set. Earlier review rounds were comment-only: [the deflate check](https://github.com/HarperFast/harper/pull/2265/changes?w=1#diff-5c96de79cba36ba9ddb5124ce7b7e96a398a3c50fc6b7bec11dc5d690f61767aR1866) now names the live-write case it is the sole detector of, the two branches no test reaches say so where they are, and the classifier's contract no longer claims an invariant the write path violates (see the note opening the reviewer section). Fixes #2262. The Windows Node 24 integration fixture now [resolves its pinned `%TEMP%` root to the native long path](https://github.com/HarperFast/harper/pull/2265/changes?w=1#diff-2cd864eab8d523890e18b6a6dcbaf0d7e732677ad340e8feb025f8673f694538R44) before Harper starts, avoiding libuv’s recursive-watcher abort on 8.3 paths.

The remaining performance concern is explicit: `get_backup` currently opens and stats a complete blob once to classify it and again to stream it. Combining those handles is a reasonable future optimization, but it is not mixed into this correctness change.

## For the human reviewer

**Start here — a hard-link truncation race this PR documents but does not close.** Two independent review models found it separately this round, and I confirmed the mechanism by trace. A known-size write that has landed every byte but has not settled classifies as `capture`, because `blobHeaderIndicatesIncomplete` sees `fileSize === HEADER_SIZE + storedSize`; the snapshot then hard-links that live inode. If the write then aborts, the replication PENDING stamp at [`resources/blob.ts:1572`](https://github.com/HarperFast/harper/pull/2265/changes?w=1#diff-5c96de79cba36ba9ddb5124ce7b7e96a398a3c50fc6b7bec11dc5d690f61767aR1572) does `writeFile(filePath, …)` — an `O_TRUNC` open, which rewrites the **inode**, so the already-captured snapshot entry is truncated to an 8-byte stub after capture. Same-filesystem only; the copy path is immune.

I [narrowed the classifier's contract](https://github.com/HarperFast/harper/pull/2265/changes?w=1#diff-5c96de79cba36ba9ddb5124ce7b7e96a398a3c50fc6b7bec11dc5d690f61767aR1837) to stop claiming the invariant that is false, and left the behavior alone deliberately. Re-stat'ing after linking narrows the window but cannot close it — the abort can always land after the check — and the only complete fix is consulting the blob write lock, which is keyed by file id and is the store-access alternative decision 5 rejects. So this wants a decision, not a patch, and it may deserve its own issue. Damage is bounded: the snapshot gets a retryable PENDING stub rather than torn bytes, but the substitution counters still report it as captured.

1. **Point-in-time marker versus eventual hard-link bytes.** [Snapshot capture](https://github.com/HarperFast/harper/pull/2265/changes?w=1#diff-ef6081f3b8edd93e7e5b3c8bb011fc94a74142673b26b7b93d2f31718d71fc98R94) deliberately substitutes PENDING when classification observes an in-flight blob, even on the same-filesystem path where a hard link could later converge to the writer's final bytes. This favors immutable point-in-time semantics and consistent copy/link behavior over preserving a write that finishes after capture; changing the policy later will not repair snapshots already written.
2. **Vanished entries are terminal.** Reclamation can unlink a superseded blob after the engine checkpoint, so the restored checkpoint may still reference it. The classifier emits ERROR rather than PENDING to avoid making every local read wait for repair; the cost is that a peer holding the old bytes cannot heal that version because ERROR can replicate as-is while PENDING leaves a repairable gap. Changing this arm to PENDING is small, but it changes read and replication semantics. 

   *Merge-order note.* [harper#1835 — durable blob-unlink queue](https://github.com/HarperFast/harper/pull/1835) is open, and the fix currently suggested for its unresolved High moves the durable unlink row earlier, into `deleteBlob()` itself. If it lands in that shape, the reclamation window this arm reasons about stops being in-process: a queued unlink survives restart and can be replayed against a blob a later backup walk is still classifying, so a restart no longer rescues those bytes and terminal costs more than it does today. Neither PR needs a change for the other to be correct — whoever merges second should re-read this decision against the other PR's final shape.
3. **A backup with substituted markers still verifies as complete.** The [creation warning](https://github.com/HarperFast/harper/pull/2265/changes?w=1#diff-ef6081f3b8edd93e7e5b3c8bb011fc94a74142673b26b7b93d2f31718d71fc98R189) and generated README expose substitutions, but the manifest and `verify_backup` do not. Adding a degraded count would improve restore-time visibility, but it is a backup-format/API change and would not annotate existing snapshots.
4. **Storage and descriptor failures abort the backup.** `EIO`, `EMFILE`, `ENFILE`, `ENOSPC`, and `EROFS` fail closed rather than capturing a file unverified; non-systemic classifier failures preserve the previous capture behavior because a hard link can succeed without reading the source. Narrowing this set would favor availability over proving the backup was readable at capture time.
5. **Classification is local to both capture walks.** The root-cause alternative is coordinating the backup with blob-write/reclamation locks or enumerating exactly the file ids present in the checkpoint. That needs store access and a lossless path-to-id mapping the walks do not have, so [the archive path](https://github.com/HarperFast/harper/pull/2265/changes?w=1#diff-bbfcea2dd873a1ccd771306cbcf3cc20d95f4c7a01bb171b92f13683195fcb9eR854) shares the classifier instead.
6. **Size is sampled before the header, and I left it that way.** [Classification stats the file first and reads the header second](https://github.com/HarperFast/harper/pull/2265/changes?w=1#diff-5c96de79cba36ba9ddb5124ce7b7e96a398a3c50fc6b7bec11dc5d690f61767aR1857), so an unknown-size write that completes between the two samples is compared against a stale size and substituted. This round's review proposed re-stat'ing and trusting the file when the size is unchanged. Declining that is decision 1, not an oversight: the only entries affected are ones genuinely mid-write when classification began, and capturing a write that lands after the walk observes it is exactly what the point-in-time policy gives up. Reversing it is a policy change and should be decided as one.

7. **Three sites state in the source that a branch is untested.** The systemic-errno rethrow on [the snapshot path](https://github.com/HarperFast/harper/pull/2265/changes?w=1#diff-ef6081f3b8edd93e7e5b3c8bb011fc94a74142673b26b7b93d2f31718d71fc98R99) and [the archive path](https://github.com/HarperFast/harper/pull/2265/changes?w=1#diff-bbfcea2dd873a1ccd771306cbcf3cc20d95f4c7a01bb171b92f13683195fcb9eR859), and [`inflatesToExactly`'s reject arm](https://github.com/HarperFast/harper/pull/2265/changes?w=1#diff-5c96de79cba36ba9ddb5124ce7b7e96a398a3c50fc6b7bec11dc5d690f61767aR2857), each say so where they are, because reaching either needs a real host-level fault and AGENTS.md forbids adding a stubbing seam to fake one. A mutation run at this head confirms both branches genuinely survive the suite. The competing view is that coverage status is review metadata that does not belong in the source; I kept the notes because a fail-closed branch nothing reaches otherwise reads as verified. They are one-line deletions if you disagree.

## Verification

- `npm run build` — passed.
- `npm run test:unit:backup` — 84 passing.
- `npx mocha unitTests/resources/blob.test.js` — 106 passing, including the live-write snapshot lifecycle and marker read behavior.
- [`unitTests/dataLayer/blobBackup.test.js`](https://github.com/HarperFast/harper/pull/2265/changes?w=1#diff-b0412778c1b85da425ad68cce79648858c1a8d7bcc2bb972c74e35639d982591R214) now directly proves missing-path classification, the fail-closed error set, README marker documentation, and repair-temp accounting.
- `npm run test:unit:resources` — 1674 passing, 16 pending, 3 unrelated existing failures in random-access defaults and replay structures; all edited blob tests passed.
- `npm run test:unit:main` could not enter the suite because its initialization opened an unrelated configured `/home/kzyp/dev/tmp/hdb50node24final/database/system.mdb` and failed while decoding that state; retrying with a disposable `HDB_ROOT` produced the same pre-test failure.
- `npm run lint:required`, Prettier, and `git diff --check` — clean.
- Latest (comment-only) rounds re-verified: `npm run build`, `npm run test:unit:backup` (84 passing), `npx mocha unitTests/resources/blob.test.js` (106 passing), lint, Prettier, and `git diff --check` all clean. The suite results above are unchanged by them — no executable line moved.
- `npm run test:integration -- integrationTests/apiTests/describe-metadata-upgrade.test.ts` — 2 passing after canonicalizing the fixture root.
- `npm run test:integration:all` — 1795 passing; the only parent failure was the pre-existing local Node 26 JSON import-attribute error in the real-Ollama suite, which cancelled 6 children.

Complexity: complicated

<sub>Review-Coverage: authored=codex; ran=claude,gemini; declined=cursor-grok,cursor-composer,domain; rounds=4 @ f44e5db03403</sub>

<sub>Human-Review-Need: 4 @ f44e5db03403</sub>
