### PR TITLE
Order list_agent_sessions by activity time instead of primary-key order

### DIFF
--- a/agent/mcpTools.ts
+++ b/agent/mcpTools.ts
@@ -57,7 +57,7 @@ const AGENT_MCP_TOOLS: Record<string, AgentMcpToolMeta> = {
 		readOnly: true,
 	},
 	list_agent_sessions: {
-		description: 'List built-in-agent sessions, most recent first.',
+		description: 'List built-in-agent sessions, most recently updated first.',
 		inputSchema: {
 			type: 'object',
 			properties: { limit: { type: 'integer', minimum: 1, description: 'Max sessions to return (default 100).' } },

--- a/agent/session.ts
+++ b/agent/session.ts
@@ -89,7 +89,7 @@ export async function listSessions(opts: { limit?: number } = {}): Promise<Agent
 		sort: { attribute: 'updatedAt', descending: true },
 		limit,
 	})) {
-		if (row) out.push(row as AgentSessionRow);
+		if (row != null) out.push(row as AgentSessionRow);
 	}
 	return out;
 }

--- a/agent/session.ts
+++ b/agent/session.ts
@@ -16,6 +16,20 @@ import type { AgentMessage, AgentRunStatus, AgentSessionRow, ApprovalRequest } f
 
 let cachedTable: any;
 
+/** `listSessions` sorts on `updatedAt`, which Table.search serves only from an index. */
+export const AGENT_SESSION_ATTRIBUTES = [
+	{ name: 'session_id', isPrimaryKey: true },
+	{ name: 'user', type: 'string', indexed: true },
+	{ name: 'status', type: 'string', indexed: true },
+	{ name: 'messages' },
+	{ name: 'pendingApprovals' },
+	{ name: 'model', type: 'string' },
+	{ name: 'provider', type: 'string' },
+	{ name: 'createdAt', type: 'number', indexed: true },
+	{ name: 'updatedAt', type: 'number', indexed: true },
+	{ name: 'lastError', type: 'string' },
+];
+
 export function getAgentSessionTable(): any {
 	if (cachedTable) return cachedTable;
 	cachedTable = table({
@@ -23,18 +37,7 @@ export function getAgentSessionTable(): any {
 		database: SYSTEM_SCHEMA_NAME,
 		audit: true,
 		trackDeletes: false,
-		attributes: [
-			{ name: 'session_id', isPrimaryKey: true },
-			{ name: 'user', type: 'string', indexed: true },
-			{ name: 'status', type: 'string', indexed: true },
-			{ name: 'messages' },
-			{ name: 'pendingApprovals' },
-			{ name: 'model', type: 'string' },
-			{ name: 'provider', type: 'string' },
-			{ name: 'createdAt', type: 'number', indexed: true },
-			{ name: 'updatedAt', type: 'number', indexed: true },
-			{ name: 'lastError', type: 'string' },
-		],
+		attributes: AGENT_SESSION_ATTRIBUTES,
 	});
 	return cachedTable;
 }

--- a/agent/session.ts
+++ b/agent/session.ts
@@ -77,11 +77,12 @@ export async function getSession(sessionId: string): Promise<AgentSessionRow | u
 export async function listSessions(opts: { limit?: number } = {}): Promise<AgentSessionRow[]> {
 	const limit = opts.limit ?? 100;
 	const out: AgentSessionRow[] = [];
-	// Ordered through the indexed `updatedAt`, not a reverse scan of the primary store: the primary
-	// key is a random UUID, so key order carries no time information and `limit` would truncate an
-	// arbitrary subset rather than dropping the least recent sessions.
+	// Sort with no conditions on purpose: Table.search pushes an order-aligned pseudo-condition when
+	// the sort attribute is indexed, and throws 404 when it is not. Adding a `updatedAt > 0` sentinel
+	// to force the index would make conditions non-empty, so losing `indexed` on the attribute would
+	// silently degrade to decoding every session (full transcripts) and sorting in memory instead of
+	// failing. The sentinel would also drop rows whose updatedAt is absent or 0.
 	for await (const row of getAgentSessionTable().search({
-		conditions: [{ attribute: 'updatedAt', comparator: 'greater_than', value: 0 }],
 		sort: { attribute: 'updatedAt', descending: true },
 		limit,
 	})) {

--- a/agent/session.ts
+++ b/agent/session.ts
@@ -77,8 +77,15 @@ export async function getSession(sessionId: string): Promise<AgentSessionRow | u
 export async function listSessions(opts: { limit?: number } = {}): Promise<AgentSessionRow[]> {
 	const limit = opts.limit ?? 100;
 	const out: AgentSessionRow[] = [];
-	for (const entry of getAgentSessionTable().primaryStore.getRange({ reverse: true, limit })) {
-		if (entry.value) out.push(entry.value as AgentSessionRow);
+	// Ordered through the indexed `updatedAt`, not a reverse scan of the primary store: the primary
+	// key is a random UUID, so key order carries no time information and `limit` would truncate an
+	// arbitrary subset rather than dropping the least recent sessions.
+	for await (const row of getAgentSessionTable().search({
+		conditions: [{ attribute: 'updatedAt', comparator: 'greater_than', value: 0 }],
+		sort: { attribute: 'updatedAt', descending: true },
+		limit,
+	})) {
+		if (row) out.push(row as AgentSessionRow);
 	}
 	return out;
 }

--- a/unitTests/agent/session.test.js
+++ b/unitTests/agent/session.test.js
@@ -72,7 +72,7 @@ describe('agent/session table definition', () => {
 	it('declares updatedAt as indexed, which listSessions sorts on', () => {
 		const updatedAt = AGENT_SESSION_ATTRIBUTES.find((attribute) => attribute.name === 'updatedAt');
 		assert.ok(updatedAt, 'updatedAt attribute is declared');
-		assert.equal(updatedAt.indexed, true);
+		assert.strictEqual(updatedAt.indexed, true);
 	});
 });
 
@@ -186,7 +186,7 @@ describe('agent/session', () => {
 	it('lists sessions most-recently-updated first, not in primary-key order', async () => {
 		const oldestFirst = await seedSessionsOldestFirst(4);
 		const sessions = await listSessions({ limit: 10 });
-		assert.deepEqual(
+		assert.deepStrictEqual(
 			sessions.map((s) => s.session_id),
 			[...oldestFirst].reverse()
 		);
@@ -195,7 +195,7 @@ describe('agent/session', () => {
 	it('limit keeps the most recent sessions rather than an arbitrary subset', async () => {
 		const oldestFirst = await seedSessionsOldestFirst(5);
 		const sessions = await listSessions({ limit: 2 });
-		assert.deepEqual(
+		assert.deepStrictEqual(
 			sessions.map((s) => s.session_id),
 			[oldestFirst[4], oldestFirst[3]]
 		);
@@ -205,7 +205,7 @@ describe('agent/session', () => {
 		const oldestFirst = await seedSessionsOldestFirst(3);
 		await appendMessage(oldestFirst[1], { role: 'user', content: 'revived', createdAt: Date.now() });
 		const sessions = await listSessions({ limit: 10 });
-		assert.equal(sessions[0].session_id, oldestFirst[1]);
+		assert.strictEqual(sessions[0].session_id, oldestFirst[1]);
 	});
 
 	it('serializes concurrent mutations on the same session (no lost updates)', async () => {

--- a/unitTests/agent/session.test.js
+++ b/unitTests/agent/session.test.js
@@ -5,6 +5,7 @@ const {
 	createSession,
 	getSession,
 	listSessions,
+	AGENT_SESSION_ATTRIBUTES,
 	appendMessage,
 	setStatus,
 	addPendingApproval,
@@ -39,7 +40,7 @@ function makeMockTable() {
 				}
 			}
 			if (sort) {
-				rows.sort((a, b) => (a[sort.attribute] - b[sort.attribute]) * (sort.descending ? -1 : 1));
+				rows.sort((a, b) => ((a[sort.attribute] ?? 0) - (b[sort.attribute] ?? 0)) * (sort.descending ? -1 : 1));
 			}
 			return (async function* () {
 				for (const row of rows.slice(0, limit)) yield read(row);
@@ -62,6 +63,18 @@ function makeMockTable() {
 		},
 	};
 }
+
+describe('agent/session table definition', () => {
+	// listSessions sorts on `updatedAt` with no conditions, which Table.search only serves from an
+	// index — without one it throws 404. The mock in the suite below sorts in memory whatever it is
+	// asked to, so it cannot notice the attribute losing `indexed`; this asserts the declaration
+	// the query depends on.
+	it('declares updatedAt as indexed, which listSessions sorts on', () => {
+		const updatedAt = AGENT_SESSION_ATTRIBUTES.find((attribute) => attribute.name === 'updatedAt');
+		assert.ok(updatedAt, 'updatedAt attribute is declared');
+		assert.equal(updatedAt.indexed, true);
+	});
+});
 
 describe('agent/session', () => {
 	let mock;

--- a/unitTests/agent/session.test.js
+++ b/unitTests/agent/session.test.js
@@ -31,8 +31,6 @@ function makeMockTable() {
 		async put(record) {
 			store.set(record.session_id, structuredClone(record));
 		},
-		// Index-ordered scan, the shape Table.search provides when the sort attribute is indexed
-		// and aligned with the leading condition. Models ordering + limit; not the query planner.
 		search({ conditions = [], sort, limit = Infinity } = {}) {
 			let rows = Array.from(store.values());
 			for (const condition of conditions) {
@@ -54,9 +52,8 @@ function makeMockTable() {
 			async get(key) {
 				return read(store.get(key));
 			},
-			// Key-ordered, like the real primary store. Insertion order would make a reverse scan
-			// look time-ordered, which is exactly how the ordering defect in listSessions survived
-			// its own test (harper#2268) — the primary key is a random UUID.
+			// Key-ordered, like the real primary store; insertion order would make a reverse scan
+			// look time-ordered.
 			getRange({ limit = Infinity, reverse } = {}) {
 				const entries = Array.from(store.entries()).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
 				if (reverse) entries.reverse();
@@ -159,10 +156,8 @@ describe('agent/session', () => {
 		await assert.rejects(resolveApproval(session.session_id, approval.id, true), /already resolved/);
 	});
 
-	// Ids descend while activity time ascends, so key order and time order are exact opposites:
-	// a key-ordered scan and a time-ordered one cannot agree by luck. Ids that ascend alongside
-	// time would let a reverse primary-key scan pass these assertions, which is how the real
-	// random-UUID ordering defect survived a green test.
+	// Ids descend while activity time ascends, so a key-ordered scan and a time-ordered one cannot
+	// agree by luck.
 	async function seedSessionsOldestFirst(count) {
 		const created = [];
 		for (let i = 0; i < count; i++) {
@@ -193,8 +188,6 @@ describe('agent/session', () => {
 		);
 	});
 
-	// Revives a middle session: reviving the one whose id sorts highest would also come back first
-	// under a reverse primary-key scan, so it would not distinguish the two orderings.
 	it('reflects later activity in the order, so a revived old session sorts first', async () => {
 		const oldestFirst = await seedSessionsOldestFirst(3);
 		await appendMessage(oldestFirst[1], { role: 'user', content: 'revived', createdAt: Date.now() });

--- a/unitTests/agent/session.test.js
+++ b/unitTests/agent/session.test.js
@@ -31,6 +31,22 @@ function makeMockTable() {
 		async put(record) {
 			store.set(record.session_id, structuredClone(record));
 		},
+		// Index-ordered scan, the shape Table.search provides when the sort attribute is indexed
+		// and aligned with the leading condition. Models ordering + limit; not the query planner.
+		search({ conditions = [], sort, limit = Infinity } = {}) {
+			let rows = Array.from(store.values());
+			for (const condition of conditions) {
+				if (condition.comparator === 'greater_than') {
+					rows = rows.filter((row) => row[condition.attribute] > condition.value);
+				}
+			}
+			if (sort) {
+				rows.sort((a, b) => (a[sort.attribute] - b[sort.attribute]) * (sort.descending ? -1 : 1));
+			}
+			return (async function* () {
+				for (const row of rows.slice(0, limit)) yield read(row);
+			})();
+		},
 		primaryStore: {
 			async put(key, value) {
 				store.set(key, structuredClone(value));
@@ -38,8 +54,11 @@ function makeMockTable() {
 			async get(key) {
 				return read(store.get(key));
 			},
+			// Key-ordered, like the real primary store. Insertion order would make a reverse scan
+			// look time-ordered, which is exactly how the ordering defect in listSessions survived
+			// its own test (harper#2268) — the primary key is a random UUID.
 			getRange({ limit = Infinity, reverse } = {}) {
-				const entries = Array.from(store.entries());
+				const entries = Array.from(store.entries()).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
 				if (reverse) entries.reverse();
 				return entries.slice(0, limit).map(([key, value]) => ({ key, value: read(value) }));
 			},
@@ -140,14 +159,47 @@ describe('agent/session', () => {
 		await assert.rejects(resolveApproval(session.session_id, approval.id, true), /already resolved/);
 	});
 
-	it('lists sessions in reverse insertion order', async () => {
-		const a = await createSession({ user: 'admin' });
-		const b = await createSession({ user: 'admin' });
+	// Ids descend while activity time ascends, so key order and time order are exact opposites:
+	// a key-ordered scan and a time-ordered one cannot agree by luck. Ids that ascend alongside
+	// time would let a reverse primary-key scan pass these assertions, which is how the real
+	// random-UUID ordering defect survived a green test.
+	async function seedSessionsOldestFirst(count) {
+		const created = [];
+		for (let i = 0; i < count; i++) {
+			const session = await createSession({ user: 'admin', sessionId: `id-${count - 1 - i}` });
+			// Explicit activity times: consecutive createSession calls land in the same millisecond,
+			// and tied timestamps would leave these assertions resting on clock granularity.
+			mock.store.get(session.session_id).updatedAt = 1000 + i;
+			created.push(session.session_id);
+		}
+		return created;
+	}
+
+	it('lists sessions most-recently-updated first, not in primary-key order', async () => {
+		const oldestFirst = await seedSessionsOldestFirst(4);
 		const sessions = await listSessions({ limit: 10 });
-		const ids = sessions.map((s) => s.session_id);
-		assert.ok(ids.includes(a.session_id));
-		assert.ok(ids.includes(b.session_id));
-		assert.equal(sessions[0].session_id, b.session_id);
+		assert.deepEqual(
+			sessions.map((s) => s.session_id),
+			[...oldestFirst].reverse()
+		);
+	});
+
+	it('limit keeps the most recent sessions rather than an arbitrary subset', async () => {
+		const oldestFirst = await seedSessionsOldestFirst(5);
+		const sessions = await listSessions({ limit: 2 });
+		assert.deepEqual(
+			sessions.map((s) => s.session_id),
+			[oldestFirst[4], oldestFirst[3]]
+		);
+	});
+
+	// Revives a middle session: reviving the one whose id sorts highest would also come back first
+	// under a reverse primary-key scan, so it would not distinguish the two orderings.
+	it('reflects later activity in the order, so a revived old session sorts first', async () => {
+		const oldestFirst = await seedSessionsOldestFirst(3);
+		await appendMessage(oldestFirst[1], { role: 'user', content: 'revived', createdAt: Date.now() });
+		const sessions = await listSessions({ limit: 10 });
+		assert.equal(sessions[0].session_id, oldestFirst[1]);
 	});
 
 	it('serializes concurrent mutations on the same session (no lost updates)', async () => {


### PR DESCRIPTION
`list_agent_sessions` is documented as returning sessions "most recent first". It scanned the primary store with `reverse: true`, and the primary key is a `randomUUID`, so the order was uncorrelated with time and `limit` truncated an arbitrary subset rather than dropping the least recent. It now scans the already-indexed `updatedAt` attribute descending, bounded by `limit`.

Observed on 5.2.4 before the fix: of ten sessions the newest came back ninth and the oldest seventh, in strictly descending id order.

## For the human reviewer

1. **`updatedAt` or `createdAt` as what "most recent" means.** I chose `updatedAt` — last activity — so a long-running session that just did something sorts first, which is what an operator scanning for recent agent activity wants and how any conversation list behaves. `createdAt` would give stable creation order and stable pagination instead. Both attributes were already indexed, so there is no cost difference; this is purely list semantics, and the tool description now states which one it means. The third test pins the choice, so changing your mind means changing that test too.
2. **The index alignment is verified by reading, not by executing.** Nothing in CI drives the real `hdb_agent_session` table. The unit mock proves `listSessions` *asks for* descending `updatedAt`, and a second test asserts the table declaration marks that attribute indexed — so removing `indexed: true` now fails the suite rather than passing while production 404s. What still isn't executed anywhere is the real planner: that `Table.search` index-aligns this exact shape I confirmed by reading `resources/Table.ts:3429-3441`. The mock also mutates `mock.store` in place to set timestamps, bypassing index maintenance. One case against the real table (under `unitTests/resources/`, which does exercise real tables) is additive later — until then that half rests on code reading, and you should decide whether that is good enough to merge on.
3. **`limit` still has no cursor or total count.** A caller cannot tell "100 sessions" from "the newest 100 of 5000". This PR makes the truncation predictable instead of arbitrary, which is the bug, but does not make it visible. Adding paging later is a breaking change to the tool contract, so it is cheaper to decide now if it is wanted.
4. **Ordering keys on wall-clock `Date.now()`** written by whichever node handled the mutation. If this system table replicates, a node whose clock runs fast puts its sessions permanently at the top of every operator's list. Ordering-only, no integrity impact, and strictly better than the arbitrary order it replaces — flagged because the tool description now makes a promise a skewed cluster cannot keep. I did not confirm whether `hdb_agent_session` participates in replication.

Round-1 review caught a real defect in the first version of this fix, now resolved: I had added a `updatedAt > 0` sentinel condition to force the index, which made `conditions` non-empty and so disabled the `resources/Table.ts:3435` guard. Losing `indexed` on the attribute would then have silently degraded the call to decoding every session record — full transcripts and pending approvals — and sorting in memory, with no error and the suite still green. Sort-only gets the same index behavior and keeps the failure loud.

## Verification

- **Unit:** `npx mocha --conditions=typestrip unitTests/agent/session.test.js` → 11 passing.
- **Fails-on-base:** restored `agent/session.ts` from `origin/main`, deleted `dist/agent/session.js` and the tsbuildinfo, rebuilt, re-ran → the three new tests fail, the eight pre-existing ones pass as a control. Restored and rebuilt → 11 passing.
- **No end-to-end route was executed** (decision 2 above). This is the honest gap: the fix is proven at the unit boundary and by reading the query planner, not by driving the real table. The pre-fix behavior *was* observed live — the ten-session ordering above came off a running 5.2.4 instance with the agent enabled.

The existing test could not have caught this: the mock's `getRange` reversed a `Map`'s insertion order, which coincidentally matches most-recent-first, so the buggy code passed. The mock now orders by key like the real store, and the seeded ids descend while activity time ascends so key order and time order cannot agree by luck.

Fixes #2268

One nit is knowingly carried: the exported constant's doc comment restates the dependency already stated at the query site. Trimming it would leave the review receipt no longer matching HEAD, which is a worse trade than the duplicated sentence.

Complexity: medium

<sub>Review-Coverage: authored=claude; ran=codex,gemini; declined=cursor-grok,cursor-composer,domain; rounds=4 @ d7b67bf8d2d6</sub>

<sub>Human-Review-Need: 3 @ d7b67bf8d2d6</sub>
